### PR TITLE
[CL-801] Move popover in kitchen sink story to avoid scrolling

### DIFF
--- a/libs/components/src/stories/kitchen-sink/components/kitchen-sink-main.component.ts
+++ b/libs/components/src/stories/kitchen-sink/components/kitchen-sink-main.component.ts
@@ -105,7 +105,21 @@ class KitchenSinkDialog {
 
     <div class="tw-my-6">
       <h1 bitTypography="h1">Bitwarden Kitchen Sink<bit-avatar text="Bit Warden"></bit-avatar></h1>
-      <a bitLink linkType="primary" href="#">Learn more</a>
+      <a bitLink linkType="primary" href="#">This is a link</a>
+      <p bitTypography="body1" class="tw-inline">
+        &nbsp;and this is a link button popover trigger:&nbsp;
+      </p>
+      <button
+        bitLink
+        linkType="primary"
+        [bitPopoverTriggerFor]="myPopover"
+        #triggerRef="popoverTrigger"
+        type="button"
+        slot="end"
+        aria-label="Popover trigger link"
+      >
+        <i class="bwi bwi-question-circle"></i>
+      </button>
     </div>
 
     <bit-callout type="info" title="About the Kitchen Sink">
@@ -149,6 +163,14 @@ class KitchenSinkDialog {
         </bit-section>
       </bit-tab>
     </bit-tab-group>
+
+    <bit-popover [title]="'Educational Popover'" #myPopover>
+      <div>You can learn more things at:</div>
+      <ul class="tw-mt-2 tw-mb-0 tw-ps-4">
+        <li>Help center</li>
+        <li>Support</li>
+      </ul>
+    </bit-popover>
   `,
 })
 export class KitchenSinkMainComponent {

--- a/libs/components/src/stories/kitchen-sink/kitchen-sink.stories.ts
+++ b/libs/components/src/stories/kitchen-sink/kitchen-sink.stories.ts
@@ -6,7 +6,6 @@ import {
   userEvent,
   getAllByRole,
   getByRole,
-  getByLabelText,
   fireEvent,
   getByText,
   getAllByLabelText,
@@ -155,16 +154,11 @@ export const PopoverOpen: Story = {
   render: Default.render,
   play: async (context) => {
     const canvas = context.canvasElement;
-    const passwordLabelIcon = getByLabelText(canvas, "A random password (required)", {
-      selector: "button",
+    const popoverLink = getByRole(canvas, "button", {
+      name: "Popover trigger link",
     });
 
-    await userEvent.click(passwordLabelIcon);
-  },
-  parameters: {
-    chromatic: {
-      disableSnapshot: true,
-    },
+    await userEvent.click(popoverLink);
   },
 };
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[CL-801](https://bitwarden.atlassian.net/browse/CL-801)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
The kitchen sink popover test has had some flakiness recently, and we think it might be due to the scrolling that happens during the snapshot. This PR adds a popover higher up in the page so that scrolling isn't needed


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
