### PR TITLE
[PM-24141] Fix reading null error

### DIFF
--- a/apps/desktop/src/platform/config/slim-config.service.ts
+++ b/apps/desktop/src/platform/config/slim-config.service.ts
@@ -43,8 +43,8 @@ export class SlimConfigService implements ConfigService {
       this.environmentService.environment$,
       this.globalStateProvider.get(GLOBAL_SERVER_CONFIGURATIONS).state$,
     ]).pipe(
-      map(([environment, serverConfig]) =>
-        getFeatureFlagValue(serverConfig[environment.getApiUrl()], key),
+      map(([environment, serverConfigMap]) =>
+        getFeatureFlagValue(serverConfigMap?.[environment.getApiUrl()], key),
       ),
     );
   }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-24141

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Fix a `TypeError: Cannot read properties of null (reading 'https://api.bitwarden.com')` error. This service exists to temporarily give feature flag values from desktop auto type. I helped with the creation of it but I missed that it should be null safe to server config just like the default version of this service does. 

https://github.com/bitwarden/clients/blob/1f73ff17ed6e94f3d1468d2f54e7177543f4382a/libs/common/src/platform/services/config/default-config.service.ts#L205

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
