### PR TITLE
[PM-23979] Remove the inaccurate percent discount badge

### DIFF
--- a/apps/web/src/app/billing/organizations/change-plan-dialog.component.html
+++ b/apps/web/src/app/billing/organizations/change-plan-dialog.component.html
@@ -11,24 +11,6 @@
         }}</span>
         <!-- Discount Badge -->
         <div class="tw-flex tw-items-center tw-gap-2">
-          <span
-            class="tw-mr-1"
-            [hidden]="isSubscriptionCanceled"
-            *ngIf="
-              this.discountPercentageFromSub > 0
-                ? discountPercentageFromSub
-                : this.discountPercentage && selectedInterval === planIntervals.Annually
-            "
-            bitBadge
-            variant="success"
-            >{{
-              "upgradeDiscount"
-                | i18n
-                  : (selectedInterval === planIntervals.Annually && discountPercentageFromSub == 0
-                      ? this.discountPercentage
-                      : this.discountPercentageFromSub)
-            }}</span
-          >
           <!-- Plan Interval Toggle -->
           <div class="tw-inline-block" *ngIf="!isSubscriptionCanceled">
             <bit-toggle-group
@@ -929,7 +911,7 @@
         </div>
         <!-- discountPercentage to PM Only -->
         <div
-          *ngIf="totalOpened && discountPercentage && !organization.useSecretsManager"
+          *ngIf="totalOpened && !organization.useSecretsManager"
           class="tw-flex tw-flex-wrap tw-gap-4"
         >
           <bit-hint class="tw-w-1/2">

--- a/apps/web/src/app/billing/organizations/change-plan-dialog.component.ts
+++ b/apps/web/src/app/billing/organizations/change-plan-dialog.component.ts
@@ -149,7 +149,6 @@ export class ChangePlanDialogComponent implements OnInit, OnDestroy {
   @Output() onCanceled = new EventEmitter<void>();
   @Output() onTrialBillingSuccess = new EventEmitter();
 
-  protected discountPercentage: number = 20;
   protected discountPercentageFromSub: number;
   protected loading = true;
   protected planCards: PlanCard[];

--- a/apps/web/src/app/billing/shared/plan-card/plan-card.component.html
+++ b/apps/web/src/app/billing/shared/plan-card/plan-card.component.html
@@ -31,10 +31,6 @@
         class="tw-text-[1.25rem] tw-mt-[6px] tw-font-bold tw-mb-0 tw-leading-[2rem] tw-flex tw-items-center"
       >
         <span class="tw-capitalize tw-whitespace-nowrap">{{ plan().title }}</span>
-        <!-- Discount Badge -->
-        <span class="tw-mr-1 tw-ml-2" *ngIf="isRecommended" bitBadge variant="success">
-          {{ "upgradeDiscount" | i18n: plan().discount }}</span
-        >
       </h3>
       <span>
         <b class="tw-text-lg tw-font-semibold">{{ plan().costPerMember | currency: "$" }} </b>

--- a/apps/web/src/app/billing/shared/plan-card/plan-card.component.ts
+++ b/apps/web/src/app/billing/shared/plan-card/plan-card.component.ts
@@ -5,7 +5,6 @@ import { ProductTierType } from "@bitwarden/common/billing/enums";
 export interface PlanCard {
   title: string;
   costPerMember: number;
-  discount?: number;
   isDisabled: boolean;
   isAnnual: boolean;
   isSelected: boolean;


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-23979
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Rather than calculating the percentage discount and displaying a inaccurate number, the change is to remove the badge entirely.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
<img width="1728" height="1117" alt="Screenshot 2025-07-24 at 21 13 30" src="https://github.com/user-attachments/assets/01fc7a8d-1ccb-4976-a86d-57b37ab51d03" />
<img width="1728" height="1117" alt="Screenshot 2025-07-24 at 21 13 43" src="https://github.com/user-attachments/assets/81f20f0a-e59a-4b3f-94fe-afe1bbc05fb0" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
