### PR TITLE
Migrate UIF to use takeuntilDestroyed

### DIFF
--- a/libs/components/src/async-actions/bit-action.directive.ts
+++ b/libs/components/src/async-actions/bit-action.directive.ts
@@ -1,7 +1,8 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
-import { Directive, HostListener, model, OnDestroy, Optional } from "@angular/core";
-import { BehaviorSubject, finalize, Subject, takeUntil, tap } from "rxjs";
+import { Directive, HostListener, model, Optional, inject, DestroyRef } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
+import { BehaviorSubject, finalize, tap } from "rxjs";
 
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { ValidationService } from "@bitwarden/common/platform/abstractions/validation.service";
@@ -16,8 +17,7 @@ import { FunctionReturningAwaitable, functionToObservable } from "../utils/funct
 @Directive({
   selector: "[bitAction]",
 })
-export class BitActionDirective implements OnDestroy {
-  private destroy$ = new Subject<void>();
+export class BitActionDirective {
   private _loading$ = new BehaviorSubject<boolean>(false);
 
   /**
@@ -39,6 +39,8 @@ export class BitActionDirective implements OnDestroy {
   disabled = false;
 
   readonly handler = model<FunctionReturningAwaitable>(undefined, { alias: "bitAction" });
+
+  private readonly destroyRef = inject(DestroyRef);
 
   constructor(
     private buttonComponent: ButtonLikeAbstraction,
@@ -62,13 +64,8 @@ export class BitActionDirective implements OnDestroy {
           },
         }),
         finalize(() => (this.loading = false)),
-        takeUntil(this.destroy$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe();
-  }
-
-  ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 }

--- a/libs/components/src/async-actions/form-button.directive.ts
+++ b/libs/components/src/async-actions/form-button.directive.ts
@@ -1,7 +1,7 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
-import { Directive, OnDestroy, Optional, input } from "@angular/core";
-import { Subject, takeUntil } from "rxjs";
+import { Directive, Optional, input } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 
 import { ButtonLikeAbstraction } from "../shared/button-like.abstraction";
 
@@ -26,9 +26,7 @@ import { BitSubmitDirective } from "./bit-submit.directive";
 @Directive({
   selector: "button[bitFormButton]",
 })
-export class BitFormButtonDirective implements OnDestroy {
-  private destroy$ = new Subject<void>();
-
+export class BitFormButtonDirective {
   readonly type = input<string>();
   readonly disabled = input<boolean>();
 
@@ -38,7 +36,7 @@ export class BitFormButtonDirective implements OnDestroy {
     @Optional() actionDirective?: BitActionDirective,
   ) {
     if (submitDirective && buttonComponent) {
-      submitDirective.loading$.pipe(takeUntil(this.destroy$)).subscribe((loading) => {
+      submitDirective.loading$.pipe(takeUntilDestroyed()).subscribe((loading) => {
         if (this.type() === "submit") {
           buttonComponent.loading.set(loading);
         } else {
@@ -46,7 +44,7 @@ export class BitFormButtonDirective implements OnDestroy {
         }
       });
 
-      submitDirective.disabled$.pipe(takeUntil(this.destroy$)).subscribe((disabled) => {
+      submitDirective.disabled$.pipe(takeUntilDestroyed()).subscribe((disabled) => {
         const disabledValue = this.disabled();
         if (disabledValue !== false) {
           buttonComponent.disabled.set(disabledValue || disabled);
@@ -55,18 +53,13 @@ export class BitFormButtonDirective implements OnDestroy {
     }
 
     if (submitDirective && actionDirective) {
-      actionDirective.loading$.pipe(takeUntil(this.destroy$)).subscribe((disabled) => {
+      actionDirective.loading$.pipe(takeUntilDestroyed()).subscribe((disabled) => {
         submitDirective.disabled = disabled;
       });
 
-      submitDirective.disabled$.pipe(takeUntil(this.destroy$)).subscribe((disabled) => {
+      submitDirective.disabled$.pipe(takeUntilDestroyed()).subscribe((disabled) => {
         actionDirective.disabled = disabled;
       });
     }
-  }
-
-  ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 }

--- a/libs/components/src/tabs/tab-nav-bar/tab-link.component.ts
+++ b/libs/components/src/tabs/tab-nav-bar/tab-link.component.ts
@@ -6,12 +6,13 @@ import {
   Component,
   HostListener,
   Input,
-  OnDestroy,
   ViewChild,
   input,
+  inject,
+  DestroyRef,
 } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { IsActiveMatchOptions, RouterLinkActive, RouterModule } from "@angular/router";
-import { Subject, takeUntil } from "rxjs";
 
 import { TabListItemDirective } from "../shared/tab-list-item.directive";
 
@@ -22,9 +23,8 @@ import { TabNavBarComponent } from "./tab-nav-bar.component";
   templateUrl: "tab-link.component.html",
   imports: [TabListItemDirective, RouterModule],
 })
-export class TabLinkComponent implements FocusableOption, AfterViewInit, OnDestroy {
-  private destroy$ = new Subject<void>();
-
+export class TabLinkComponent implements FocusableOption, AfterViewInit {
+  private readonly destroyRef = inject(DestroyRef);
   @ViewChild(TabListItemDirective) tabItem: TabListItemDirective;
   @ViewChild("rla") routerLinkActive: RouterLinkActive;
 
@@ -61,12 +61,7 @@ export class TabLinkComponent implements FocusableOption, AfterViewInit, OnDestr
     // The active state of tab links are tracked via the routerLinkActive directive
     // We need to watch for changes to tell the parent nav group when the tab is active
     this.routerLinkActive.isActiveChange
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((_) => this._tabNavBar.updateActiveLink());
-  }
-
-  ngOnDestroy() {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Migrates existing `takeUntil` patterns to the newer `takeUntilDestroyed` pattern. Uses `destroyRef` for anything outside the constructor.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
