### PR TITLE
[PM-24219] CipherListView from SDK cannot be bulk moved.

### DIFF
--- a/apps/web/src/app/vault/components/vault-items/vault-items.component.ts
+++ b/apps/web/src/app/vault/components/vault-items/vault-items.component.ts
@@ -566,7 +566,7 @@ export class VaultItemsComponent<C extends CipherViewLike> {
   }
 
   private hasPersonalItems(): boolean {
-    return this.selection.selected.some(({ cipher }) => cipher?.organizationId === null);
+    return this.selection.selected.some(({ cipher }) => !cipher?.organizationId);
   }
 
   private allCiphersHaveEditAccess(): boolean {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-24219](https://bitwarden.atlassian.net/browse/PM-24219)

## 📔 Objective

- Use bang operator to check for the presence of an 1organizationId1, strict equality with `null` doesn't work with the SDK as `undefined` is populated rather than `null`

## 📸 Screenshots

<video src="https://github.com/user-attachments/assets/a1ed4de4-e389-4734-933b-00974450db48" />

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-24219]: https://bitwarden.atlassian.net/browse/PM-24219?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ