### PR TITLE
Clarify organization collection permissions

### DIFF
--- a/apps/web/src/app/admin-console/organizations/shared/components/access-selector/access-selector.models.ts
+++ b/apps/web/src/app/admin-console/organizations/shared/components/access-selector/access-selector.models.ts
@@ -87,10 +87,10 @@ export type Permission = {
 
 export const getPermissionList = (): Permission[] => {
   const permissions = [
-    { perm: CollectionPermission.View, labelId: "viewItems" },
     { perm: CollectionPermission.ViewExceptPass, labelId: "viewItemsHidePass" },
-    { perm: CollectionPermission.Edit, labelId: "editItems" },
+    { perm: CollectionPermission.View, labelId: "viewItems" },
     { perm: CollectionPermission.EditExceptPass, labelId: "editItemsHidePass" },
+    { perm: CollectionPermission.Edit, labelId: "editItems" },
     { perm: CollectionPermission.Manage, labelId: "manageCollection" },
   ];
 

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -2246,13 +2246,13 @@
     "message": "View items"
   },
   "viewItemsHidePass": {
-    "message": "View items, hidden passwords"
+    "message": "View items; passwords hidden"
   },
   "editItems": {
     "message": "Edit items"
   },
   "editItemsHidePass": {
-    "message": "Edit items, hidden passwords"
+    "message": "Edit items; passwords hidden"
   },
   "disable": {
     "message": "Turn off"


### PR DESCRIPTION
## 🎟️ Tracking

https://github.com/bitwarden/clients/issues/15786

## 📔 Objective

The permission options for organization collections are currently ambiguous and out of order.

They are ambiguous because "View items, hidden passwords" could mean either "View items AND hidden passwords" or (as is apparently intended) "View items, BUT passwords are hidden".  This PR clarifies the message to say "View items; passwords hidden" to avoid ambiguity.  Similar change for "Edit items, hidden passwords".

They are out of order because they go (numbered from most to least restrictive):

2 - View items
1 - View items; hidden passwords
4 - Edit items
3 - Edit items; hidden passwords
5 - Manage collection

This PR re-orders the options to be in order of most to least restrictive.

## 📸 Screenshots

<img width="737" height="418" alt="2025-07-28 12_53_49-Members _ Vaultwarden Web — LibreWolf" src="https://github.com/user-attachments/assets/83c58f7c-c9d9-476f-8cef-b2568d54f693" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
