### PR TITLE
:sparkles: Add msi build to pipeline and artifacts

### DIFF
--- a/.github/workflows/release-desktop-beta.yml
+++ b/.github/workflows/release-desktop-beta.yml
@@ -324,6 +324,13 @@ jobs:
           path: apps/desktop/dist/nsis-web/Bitwarden-Installer-${{ env._PACKAGE_VERSION }}.exe
           if-no-files-found: error
 
+      - name: Upload msi artifact
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: Bitwarden-${{ env._PACKAGE_VERSION }}.msi
+          path: apps/desktop/dist/Bitwarden-${{ env._PACKAGE_VERSION }}.msi
+          if-no-files-found: error
+
       - name: Upload appx ia32 artifact
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -108,6 +108,7 @@ jobs:
             apps/desktop/artifacts/Bitwarden-${{ env.PKG_VERSION }}-x86_64.AppImage,
             apps/desktop/artifacts/Bitwarden-Portable-${{ env.PKG_VERSION }}.exe,
             apps/desktop/artifacts/Bitwarden-Installer-${{ env.PKG_VERSION }}.exe,
+            apps/desktop/artifacts/Bitwarden-${{ env.PKG_VERSION }}.msi,
             apps/desktop/artifacts/Bitwarden-${{ env.PKG_VERSION }}-ia32-store.appx,
             apps/desktop/artifacts/Bitwarden-${{ env.PKG_VERSION }}-ia32.appx,
             apps/desktop/artifacts/bitwarden-${{ env.PKG_VERSION }}-ia32.nsis.7z,

--- a/apps/desktop/electron-builder.json
+++ b/apps/desktop/electron-builder.json
@@ -88,7 +88,7 @@
   },
   "win": {
     "electronUpdaterCompatibility": ">=0.0.1",
-    "target": ["portable", "nsis-web", "appx"],
+    "target": ["portable", "nsis-web", "appx", "msi"],
     "signtoolOptions": {
       "sign": "./sign.js"
     },
@@ -160,6 +160,10 @@
   },
   "portable": {
     "artifactName": "${productName}-Portable-${version}.${ext}"
+  },
+  "msi": {
+    "artifactName": "${productName}-${version}.${ext}",
+    "runAfterFinish": false
   },
   "appx": {
     "artifactName": "${productName}-${version}-${arch}.${ext}",


### PR DESCRIPTION
## 🎟️ Tracking
[https://community.bitwarden.com/t/make-msi-installer-available/34692](https://community.bitwarden.com/t/make-msi-installer-available/34692)

## 📔 Objective

This merge request adds the MSI build option to the pipeline. 
This is a frequently requested feature from the forum and enables automated installations (e.g., using software distribution).

The merge request adds all necessary steps to the workflows and the corresponding adjustments to electron-builder.json.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
