### PR TITLE
[PM-23788] changed the getType to address new cipherLike

### DIFF
--- a/apps/browser/src/vault/popup/components/vault-v2/item-more-options/item-more-options.component.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/item-more-options/item-more-options.component.ts
@@ -78,7 +78,7 @@ export class ItemMoreOptionsComponent {
     switchMap(([c, restrictedTypes]) => {
       // This will check for restrictions from org policies before allowing cloning.
       const isItemRestricted = restrictedTypes.some(
-        (restrictType) => restrictType.cipherType === c.type,
+        (restrictType) => restrictType.cipherType === CipherViewLikeUtils.getType(c),
       );
       if (!isItemRestricted) {
         return this.cipherAuthorizationService.canCloneCipher$(c);

--- a/apps/web/src/app/vault/components/vault-items/vault-items.component.ts
+++ b/apps/web/src/app/vault/components/vault-items/vault-items.component.ts
@@ -285,7 +285,7 @@ export class VaultItemsComponent<C extends CipherViewLike> {
   protected canClone(vaultItem: VaultItem<C>) {
     // This will check for restrictions from org policies before allowing cloning.
     const isItemRestricted = this.restrictedPolicies().some(
-      (rt) => rt.cipherType === vaultItem.cipher.type,
+      (rt) => rt.cipherType === CipherViewLikeUtils.getType(vaultItem.cipher),
     );
     if (isItemRestricted) {
       return false;


### PR DESCRIPTION
## 🎟️ Tracking

[PM-23788](https://bitwarden.atlassian.net/browse/PM-23788)
[PM-23793](https://bitwarden.atlassian.net/browse/PM-23793)

## 📔 Objective

Items were coming back as dynamic types. Apply the `getType` method from utils to account for the different item types. 

## 📸 Screenshots



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
