### PR TITLE
[PM-24261] Switch withLatestFrom to combineLatest

### DIFF
--- a/apps/web/src/app/admin-console/organizations/members/members.component.ts
+++ b/apps/web/src/app/admin-console/organizations/members/members.component.ts
@@ -13,7 +13,6 @@ import {
   Observable,
   shareReplay,
   switchMap,
-  withLatestFrom,
   tap,
 } from "rxjs";
 
@@ -310,10 +309,13 @@ export class MembersComponent extends BaseMembersComponent<OrganizationUserView>
       ),
     );
 
-    const decryptedCollections$ = this.accountService.activeAccount$.pipe(
-      getUserId,
-      switchMap((userId) => this.keyService.orgKeys$(userId)),
-      withLatestFrom(response),
+    const decryptedCollections$ = combineLatest([
+      this.accountService.activeAccount$.pipe(
+        getUserId,
+        switchMap((userId) => this.keyService.orgKeys$(userId)),
+      ),
+      response,
+    ]).pipe(
       switchMap(([orgKeys, collections]) =>
         this.collectionService.decryptMany$(collections, orgKeys),
       ),


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-24261
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
This Pr fixes a race condition introduced in the CollectionService vNext refactor. Use of `withLatestFrom` operator caused an issue where this observable never emits. Switching to `combineLatest` resolves the issue.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

https://github.com/user-attachments/assets/340a1f13-7132-49e5-9e3b-0231840531a8


<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
