### PR TITLE
[PM-24232] - [Defect][Web] Admin Console - SSH key and Folder should not show as options from New button

### DIFF
--- a/apps/web/src/app/vault/individual-vault/vault-header/vault-header.component.html
+++ b/apps/web/src/app/vault/individual-vault/vault-header/vault-header.component.html
@@ -78,6 +78,7 @@
     <vault-new-cipher-menu
       [canCreateCipher]="true"
       [canCreateFolder]="true"
+      [canCreateSshKey]="true"
       [canCreateCollection]="canCreateCollections"
       (cipherAdded)="addCipher($event)"
       (folderAdded)="addFolder()"

--- a/libs/vault/src/cipher-form/cipher-form-container.ts
+++ b/libs/vault/src/cipher-form/cipher-form-container.ts
@@ -1,5 +1,7 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
+import { Observable } from "rxjs";
+
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { CipherFormConfig } from "@bitwarden/vault";
 
@@ -74,4 +76,6 @@ export abstract class CipherFormContainer {
   abstract disableFormFields(): void;
 
   abstract enableFormFields(): void;
+
+  formStatusChange$: Observable<void>;
 }

--- a/libs/vault/src/cipher-form/cipher-form-container.ts
+++ b/libs/vault/src/cipher-form/cipher-form-container.ts
@@ -77,5 +77,9 @@ export abstract class CipherFormContainer {
 
   abstract enableFormFields(): void;
 
-  formStatusChange$: Observable<void>;
+  /**
+   * An observable that emits when the form status changes to enabled.
+   * This can be used to disable child forms when the parent form is enabled.
+   */
+  formEnabled$: Observable<void>;
 }

--- a/libs/vault/src/cipher-form/components/cipher-form.component.ts
+++ b/libs/vault/src/cipher-form/components/cipher-form.component.ts
@@ -113,6 +113,12 @@ export class CipherFormComponent implements AfterViewInit, OnInit, OnChanges, Ci
   @Output() formReady = this.formReadySubject.asObservable();
 
   /**
+   * Emitted when the form status changes to enabled or disabled.
+   */
+  private formStatusChangeSubject = new Subject<void>();
+  formStatusChange$ = this.formStatusChangeSubject.asObservable();
+
+  /**
    * The original cipher being edited or cloned. Null for add mode.
    */
   originalCipherView: CipherView | null;
@@ -156,11 +162,7 @@ export class CipherFormComponent implements AfterViewInit, OnInit, OnChanges, Ci
 
   enableFormFields(): void {
     this.cipherForm.enable({ emitEvent: false });
-    //  disable the SSH key section as they should never be editable
-    const sshKeyGroup = this.cipherForm.get("sshKeyDetails");
-    if (sshKeyGroup) {
-      sshKeyGroup.disable({ emitEvent: false });
-    }
+    this.formStatusChangeSubject.next();
   }
 
   /**

--- a/libs/vault/src/cipher-form/components/cipher-form.component.ts
+++ b/libs/vault/src/cipher-form/components/cipher-form.component.ts
@@ -156,6 +156,11 @@ export class CipherFormComponent implements AfterViewInit, OnInit, OnChanges, Ci
 
   enableFormFields(): void {
     this.cipherForm.enable({ emitEvent: false });
+    //  disable the SSH key section as they should never be editable
+    const sshKeyGroup = this.cipherForm.get("sshKeyDetails");
+    if (sshKeyGroup) {
+      sshKeyGroup.disable({ emitEvent: false });
+    }
   }
 
   /**

--- a/libs/vault/src/cipher-form/components/cipher-form.component.ts
+++ b/libs/vault/src/cipher-form/components/cipher-form.component.ts
@@ -113,10 +113,10 @@ export class CipherFormComponent implements AfterViewInit, OnInit, OnChanges, Ci
   @Output() formReady = this.formReadySubject.asObservable();
 
   /**
-   * Emitted when the form status changes to enabled or disabled.
+   * Emitted when the form is enabled
    */
-  private formStatusChangeSubject = new Subject<void>();
-  formStatusChange$ = this.formStatusChangeSubject.asObservable();
+  private formEnabledSubject = new Subject<void>();
+  formEnabled$ = this.formEnabledSubject.asObservable();
 
   /**
    * The original cipher being edited or cloned. Null for add mode.
@@ -162,7 +162,7 @@ export class CipherFormComponent implements AfterViewInit, OnInit, OnChanges, Ci
 
   enableFormFields(): void {
     this.cipherForm.enable({ emitEvent: false });
-    this.formStatusChangeSubject.next();
+    this.formEnabledSubject.next();
   }
 
   /**

--- a/libs/vault/src/cipher-form/components/item-details/item-details-section.component.ts
+++ b/libs/vault/src/cipher-form/components/item-details/item-details-section.component.ts
@@ -20,7 +20,6 @@ import { ConfigService } from "@bitwarden/common/platform/abstractions/config/co
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { CollectionId, OrganizationId, UserId } from "@bitwarden/common/types/guid";
-import { CipherType } from "@bitwarden/common/vault/enums";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import {
   CardComponent,
@@ -249,7 +248,7 @@ export class ItemDetailsSectionComponent implements OnInit {
       if (this.itemDetailsForm.controls.organizationId.value === null) {
         this.cipherFormContainer.disableFormFields();
         this.itemDetailsForm.controls.organizationId.enable();
-      } else if (this.originalCipherView?.type !== CipherType.SshKey) {
+      } else {
         this.cipherFormContainer.enableFormFields();
       }
     }

--- a/libs/vault/src/cipher-form/components/item-details/item-details-section.component.ts
+++ b/libs/vault/src/cipher-form/components/item-details/item-details-section.component.ts
@@ -20,6 +20,7 @@ import { ConfigService } from "@bitwarden/common/platform/abstractions/config/co
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { CollectionId, OrganizationId, UserId } from "@bitwarden/common/types/guid";
+import { CipherType } from "@bitwarden/common/vault/enums";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import {
   CardComponent,
@@ -248,7 +249,7 @@ export class ItemDetailsSectionComponent implements OnInit {
       if (this.itemDetailsForm.controls.organizationId.value === null) {
         this.cipherFormContainer.disableFormFields();
         this.itemDetailsForm.controls.organizationId.enable();
-      } else {
+      } else if (this.originalCipherView?.type !== CipherType.SshKey) {
         this.cipherFormContainer.enableFormFields();
       }
     }

--- a/libs/vault/src/cipher-form/components/sshkey-section/sshkey-section.component.ts
+++ b/libs/vault/src/cipher-form/components/sshkey-section/sshkey-section.component.ts
@@ -1,10 +1,10 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
 import { CommonModule } from "@angular/common";
-import { Component, Input, OnInit } from "@angular/core";
+import { Component, DestroyRef, inject, Input, OnInit } from "@angular/core";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { FormBuilder, ReactiveFormsModule } from "@angular/forms";
-import { firstValueFrom, Subject, takeUntil } from "rxjs";
+import { firstValueFrom } from "rxjs";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { ClientType } from "@bitwarden/common/enums";
@@ -60,7 +60,7 @@ export class SshKeySectionComponent implements OnInit {
   });
 
   showImport = false;
-  private destroy$ = new Subject<void>();
+  private destroyRef = inject(DestroyRef);
 
   constructor(
     private cipherFormContainer: CipherFormContainer,
@@ -98,8 +98,8 @@ export class SshKeySectionComponent implements OnInit {
 
     // Disable the form if the cipher form container is enabled
     // to prevent user interaction
-    this.cipherFormContainer.formStatusChange$
-      .pipe(takeUntil(this.destroy$))
+    this.cipherFormContainer.formEnabled$
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(() => this.sshKeyForm.disable());
   }
 

--- a/libs/vault/src/cipher-form/components/sshkey-section/sshkey-section.component.ts
+++ b/libs/vault/src/cipher-form/components/sshkey-section/sshkey-section.component.ts
@@ -4,7 +4,7 @@ import { CommonModule } from "@angular/common";
 import { Component, Input, OnInit } from "@angular/core";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { FormBuilder, ReactiveFormsModule } from "@angular/forms";
-import { firstValueFrom } from "rxjs";
+import { firstValueFrom, Subject, takeUntil } from "rxjs";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { ClientType } from "@bitwarden/common/enums";
@@ -60,6 +60,7 @@ export class SshKeySectionComponent implements OnInit {
   });
 
   showImport = false;
+  private destroy$ = new Subject<void>();
 
   constructor(
     private cipherFormContainer: CipherFormContainer,
@@ -94,6 +95,12 @@ export class SshKeySectionComponent implements OnInit {
     if (this.platformUtilsService.getClientType() !== ClientType.Web) {
       this.showImport = true;
     }
+
+    // Disable the form if the cipher form container is enabled
+    // to prevent user interaction
+    this.cipherFormContainer.formStatusChange$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => this.sshKeyForm.disable());
   }
 
   /** Set form initial form values from the current cipher */

--- a/libs/vault/src/components/new-cipher-menu/new-cipher-menu.component.html
+++ b/libs/vault/src/components/new-cipher-menu/new-cipher-menu.component.html
@@ -1,4 +1,4 @@
-<ng-container *ngIf="canCreateCipher || canCreateCollection || canCreateFolder">
+<ng-container *ngIf="canCreateCipher() || canCreateCollection() || canCreateFolder()">
   <div>
     <button
       bitButton
@@ -18,13 +18,13 @@
           {{ item.labelKey | i18n }}
         </button>
       }
-      <bit-menu-divider *ngIf="canCreateCipher"></bit-menu-divider>
-      <button *ngIf="canCreateFolder" type="button" bitMenuItem (click)="folderAdded.emit()">
+      <bit-menu-divider *ngIf="canCreateCipher()"></bit-menu-divider>
+      <button *ngIf="canCreateFolder()" type="button" bitMenuItem (click)="folderAdded.emit()">
         <i class="bwi bwi-fw bwi-folder" aria-hidden="true"></i>
         {{ "folder" | i18n }}
       </button>
       <button
-        *ngIf="canCreateCollection"
+        *ngIf="canCreateCollection()"
         type="button"
         bitMenuItem
         (click)="collectionAdded.emit()"

--- a/libs/vault/src/components/new-cipher-menu/new-cipher-menu.component.ts
+++ b/libs/vault/src/components/new-cipher-menu/new-cipher-menu.component.ts
@@ -18,6 +18,7 @@ export class NewCipherMenuComponent {
   canCreateCipher = input(false);
   canCreateFolder = input(false);
   canCreateCollection = input(false);
+  canCreateSshKey = input(false);
   folderAdded = output();
   collectionAdded = output();
   cipherAdded = output<CipherType>();
@@ -30,6 +31,9 @@ export class NewCipherMenuComponent {
   cipherMenuItems$ = this.restrictedItemTypesService.restricted$.pipe(
     map((restrictedTypes) => {
       return CIPHER_MENU_ITEMS.filter((item) => {
+        if (!this.canCreateSshKey() && item.type === CipherType.SshKey) {
+          return false;
+        }
         return !restrictedTypes.some((restrictedType) => restrictedType.cipherType === item.type);
       });
     }),


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-24232

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR does the following:

- "Folder" will no longer be shown as an option in the AC "New" menu, a regression from [creating the new item menu component](https://github.com/bitwarden/clients/pull/15467)
- the sshkey form will no longer be incorrectly enabled, a regression from [ Update cipher form component to restrict editing old My Vault items](https://github.com/bitwarden/clients/pull/15687)

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/15d86077-f19f-4439-b5a5-91a02bc4e5dc



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
