### PR TITLE
[CL-753] Fix popover spacing in client code

### DIFF
--- a/apps/web/src/app/auth/settings/security/device-management-old.component.html
+++ b/apps/web/src/app/auth/settings/security/device-management-old.component.html
@@ -11,7 +11,7 @@
         <i class="bwi bwi-question-circle" aria-hidden="true"></i>
       </button>
       <bit-popover [title]="'whatIsADevice' | i18n" #infoPopover>
-        <p>{{ "aDeviceIs" | i18n }}</p>
+        <p class="tw-mb-0">{{ "aDeviceIs" | i18n }}</p>
       </bit-popover>
       <i
         *ngIf="asyncActionLoading"

--- a/apps/web/src/app/billing/payment/components/enter-payment-method.component.ts
+++ b/apps/web/src/app/billing/payment/components/enter-payment-method.component.ts
@@ -108,7 +108,7 @@ type PaymentMethodFormGroup = FormGroup<{
                   <i class="bwi bwi-question-circle tw-text-lg" aria-hidden="true"></i>
                 </button>
                 <bit-popover [title]="'cardSecurityCode' | i18n" #cardSecurityCodePopover>
-                  <p>{{ "cardSecurityCodeDescription" | i18n }}</p>
+                  <p class="tw-mb-0">{{ "cardSecurityCodeDescription" | i18n }}</p>
                 </bit-popover>
               </app-payment-label>
               <div id="stripe-card-cvc" class="tw-stripe-form-control"></div>

--- a/libs/angular/src/auth/device-management/device-management.component.html
+++ b/libs/angular/src/auth/device-management/device-management.component.html
@@ -12,7 +12,7 @@
     </button>
 
     <bit-popover [title]="'whatIsADevice' | i18n" #infoPopover>
-      <p>{{ "aDeviceIs" | i18n }}</p>
+      <p class="tw-mb-0">{{ "aDeviceIs" | i18n }}</p>
     </bit-popover>
   </div>
 

--- a/libs/vault/src/cipher-form/components/login-details-section/login-details-section.component.html
+++ b/libs/vault/src/cipher-form/components/login-details-section/login-details-section.component.html
@@ -103,7 +103,9 @@
           <i class="bwi bwi-sm bwi-question-circle" aria-hidden="true"></i>
         </button>
         <bit-popover #totpPopover [title]="'totpHelperTitle' | i18n">
-          <p>{{ (canCaptureTotp ? "totpHelperWithCapture" : "totpHelper") | i18n }}</p>
+          <p class="tw-mb-0">
+            {{ (canCaptureTotp ? "totpHelperWithCapture" : "totpHelper") | i18n }}
+          </p>
         </bit-popover>
       </bit-label>
       <input bitInput formControlName="totp" type="password" class="tw-font-mono" />


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[CL-753](https://bitwarden.atlassian.net/browse/CL-753)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR fixes a spacing issue in the client implementations of the popover.

Please be sure to do this for future implementations!

Also, auth team, the popover on the devices page is overlapping the trigger button, so there is something weird going on with the trigger button.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

Sorry billing, I couldn't figure out where to find your popover 🤦‍♀️ 

| Before | After |
|------- | ----- |
| <img width="788" height="785" alt="Screenshot 2025-07-30 at 9 58 38 AM" src="https://github.com/user-attachments/assets/9dc56477-e014-4a76-949f-d711de1879d2" /> | <img width="788" height="785" alt="Screenshot 2025-07-30 at 9 50 00 AM" src="https://github.com/user-attachments/assets/d8c5a5b7-07af-4a46-b48a-3736e7e5b52e" /> |
| <img width="788" height="785" alt="Screenshot 2025-07-30 at 9 58 52 AM" src="https://github.com/user-attachments/assets/c82838d4-eba6-40d0-bdc2-fec36d6ed93f" /> | <img width="788" height="785" alt="Screenshot 2025-07-30 at 9 54 21 AM" src="https://github.com/user-attachments/assets/c93069f3-90f4-4a2b-9de3-7d877ddf926d" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[CL-753]: https://bitwarden.atlassian.net/browse/CL-753?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ