### PR TITLE
[PM-24309] Fix `TaxService.previewTaxAmountForOrganizationTrial` return type

### DIFF
--- a/apps/web/src/app/billing/accounts/trial-initiation/trial-billing-step.component.ts
+++ b/apps/web/src/app/billing/accounts/trial-initiation/trial-billing-step.component.ts
@@ -304,6 +304,7 @@ export class TrialBillingStepComponent implements OnInit, OnDestroy {
     this.fetchingTaxAmount = true;
 
     if (!this.taxInfoComponent.validate()) {
+      this.fetchingTaxAmount = false;
       return 0;
     }
 
@@ -326,7 +327,7 @@ export class TrialBillingStepComponent implements OnInit, OnDestroy {
 
     const response = await this.taxService.previewTaxAmountForOrganizationTrial(request);
     this.fetchingTaxAmount = false;
-    return response.taxAmount;
+    return response;
   };
 
   get price() {

--- a/libs/common/src/billing/abstractions/tax.service.abstraction.ts
+++ b/libs/common/src/billing/abstractions/tax.service.abstraction.ts
@@ -3,7 +3,6 @@ import { PreviewIndividualInvoiceRequest } from "../models/request/preview-indiv
 import { PreviewOrganizationInvoiceRequest } from "../models/request/preview-organization-invoice.request";
 import { PreviewTaxAmountForOrganizationTrialRequest } from "../models/request/tax";
 import { PreviewInvoiceResponse } from "../models/response/preview-invoice.response";
-import { PreviewTaxAmountResponse } from "../models/response/tax";
 
 export abstract class TaxServiceAbstraction {
   abstract getCountries(): CountryListItem[];
@@ -20,5 +19,5 @@ export abstract class TaxServiceAbstraction {
 
   abstract previewTaxAmountForOrganizationTrial: (
     request: PreviewTaxAmountForOrganizationTrialRequest,
-  ) => Promise<PreviewTaxAmountResponse>;
+  ) => Promise<number>;
 }

--- a/libs/common/src/billing/services/tax.service.ts
+++ b/libs/common/src/billing/services/tax.service.ts
@@ -1,5 +1,4 @@
 import { PreviewTaxAmountForOrganizationTrialRequest } from "@bitwarden/common/billing/models/request/tax";
-import { PreviewTaxAmountResponse } from "@bitwarden/common/billing/models/response/tax";
 
 import { ApiService } from "../../abstractions/api.service";
 import { TaxServiceAbstraction } from "../abstractions/tax.service.abstraction";
@@ -306,13 +305,14 @@ export class TaxService implements TaxServiceAbstraction {
 
   async previewTaxAmountForOrganizationTrial(
     request: PreviewTaxAmountForOrganizationTrialRequest,
-  ): Promise<PreviewTaxAmountResponse> {
-    return await this.apiService.send(
+  ): Promise<number> {
+    const response = await this.apiService.send(
       "POST",
       "/tax/preview-amount/organization-trial",
       request,
       true,
       true,
     );
+    return response as number;
   }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-24309

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Genuinely not sure how this was working before unless something changed that I can't identify, but the return type in `clients` on the API invocation that was providing the tax amount for organization trial estimation did not match what `server` was giving back. This PR resolves that.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->


https://github.com/user-attachments/assets/55d7d470-cce2-45b8-a133-58ffda0b6887



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
