### PR TITLE
[PM-23990] Desktop - Saving a cipher after adding an attachment

### DIFF
--- a/apps/desktop/src/vault/app/vault/vault-v2.component.ts
+++ b/apps/desktop/src/vault/app/vault/vault-v2.component.ts
@@ -466,14 +466,23 @@ export class VaultV2Component<C extends CipherViewLike>
         return;
       }
 
-      const updatedCipher = await this.cipherService.get(
-        this.cipherId as CipherId,
-        this.activeUserId as UserId,
+      // The encrypted state of ciphers is updated when an attachment is added,
+      // but the cache is also cleared. Depending on timing, `cipherService.get` can return the
+      // old cipher. Retrieve the updated cipher from `cipherViews$`,
+      // which refreshes after the cached is cleared.
+      const updatedCipherView = await firstValueFrom(
+        this.cipherService.cipherViews$(this.activeUserId!).pipe(
+          filter((c) => !!c),
+          map((ciphers) => ciphers.find((c) => c.id === this.cipherId)),
+        ),
       );
-      const updatedCipherView = await this.cipherService.decrypt(
-        updatedCipher,
-        this.activeUserId as UserId,
-      );
+
+      // `find` can return undefined but that shouldn't happen as
+      // this would mean that the cipher was deleted.
+      // To make TypeScript happy, exit early if it isn't found.
+      if (!updatedCipherView) {
+        return;
+      }
 
       this.cipherFormComponent.patchCipher((currentCipher) => {
         currentCipher.attachments = updatedCipherView.attachments;
@@ -499,7 +508,6 @@ export class VaultV2Component<C extends CipherViewLike>
 
     if (cipher.decryptionFailure) {
       invokeMenu(menu);
-      return;
     }
 
     if (!cipher.isDeleted) {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-23990](https://bitwarden.atlassian.net/browse/PM-23990)

## 📔 Objective

This one is an odd one, I was only able to consistently recreate it for organization ciphers not individually owned ciphers. 

#### Issue

When saving a cipher after adding an attachment the user can get a "cipher is out of date" error message back from the server.

#### Cause

The cipher revision date is updated when an attachment is added but using `cipherService.get` was getting called _before_ the encrypted state was re-populated with the updated cipher. This can be problematic based on [some other race conditions](https://github.com/bitwarden/clients/blob/021d275c437f4f4ee689dfcd5695c69a62bca08c/libs/common/src/vault/services/cipher.service.ts#L1148-L1149) that we have solved for in the past, there are extra `ticks` being waiting for.

#### Solution

The cipher cache is cleared when the encrypted state is updated. `cipherViews$` can be used to wait for the cache to be cleared and decrypted with the new ciphers rather than getting an individual cipher.

## 📸 Screenshots

|Before|After|
|-|-|
|<video src="https://github.com/user-attachments/assets/e5d5e720-1b5e-4fbe-a498-e15368109cbb" /> |<video src="https://github.com/user-attachments/assets/87082cfa-4369-4e47-bdb9-994826674c5e" /> |

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-23990]: https://bitwarden.atlassian.net/browse/PM-23990?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ