### PR TITLE
[PM-19475] Login component button icons are not marked as aria-hidden="true"

### DIFF
--- a/libs/auth/src/angular/login/login.component.html
+++ b/libs/auth/src/angular/login/login.component.html
@@ -53,14 +53,14 @@
           buttonType="secondary"
           (click)="handleLoginWithPasskeyClick()"
         >
-          <i class="bwi bwi-passkey tw-mr-1"></i>
+          <i class="bwi bwi-passkey tw-mr-1" aria-hidden="true"></i>
           {{ "logInWithPasskey" | i18n }}
         </button>
       </ng-container>
 
       <!-- Button to Login with SSO -->
       <button type="button" bitButton block buttonType="secondary" (click)="handleSsoClick()">
-        <i class="bwi bwi-provider tw-mr-1"></i>
+        <i class="bwi bwi-provider tw-mr-1" aria-hidden="true"></i>
         {{ "useSingleSignOn" | i18n }}
       </button>
     </div>
@@ -96,7 +96,7 @@
           buttonType="secondary"
           (click)="startAuthRequestLogin()"
         >
-          <i class="bwi bwi-mobile"></i>
+          <i class="bwi bwi-mobile" aria-hidden="true"></i>
           {{ "loginWithDevice" | i18n }}
         </button>
       </ng-container>


### PR DESCRIPTION
## 🎟️ Tracking

[PM-19475](https://bitwarden.atlassian.net/browse/PM-19475)

## 📔 Objective

Login component button icons were not previously marked `aria-hidden="true"`. This would cause undesirable screen reader output of `[?]`, and in certain cases could prevent a user from properly navigating off the element.

Adding the aria attributes to Passkey, SSO, and Device login buttons should improve the user experience for users with screen readers.

## 📸 Screenshots

### Before
<img width="613" height="120" alt="Screenshot 2025-07-31 at 2 33 42 PM" src="https://github.com/user-attachments/assets/ea8dcec6-c743-4153-aea1-6df34c6f09ec" />

### After
https://github.com/user-attachments/assets/af2478a1-733a-45f9-bae5-b621a7585123

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-19475]: https://bitwarden.atlassian.net/browse/PM-19475?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ