### PR TITLE
[PM-23911] Autofill Nudge destination

### DIFF
--- a/apps/browser/src/autofill/popup/settings/autofill.component.html
+++ b/apps/browser/src/autofill/popup/settings/autofill.component.html
@@ -12,7 +12,7 @@
         [subtitle]="'autofillSpotlightDesc' | i18n"
         [buttonText]="spotlightButtonText"
         (onDismiss)="dismissSpotlight()"
-        (onButtonClick)="openURI($event, disablePasswordManagerURI)"
+        (onButtonClick)="disableBrowserAutofillSettingsFromNudge($event)"
         [buttonIcon]="spotlightButtonIcon"
       ></bit-spotlight>
     </div>

--- a/apps/browser/src/autofill/popup/settings/autofill.component.ts
+++ b/apps/browser/src/autofill/popup/settings/autofill.component.ts
@@ -585,4 +585,16 @@ export class AutofillComponent implements OnInit {
     }
     return hints;
   }
+
+  /** Navigates the user from the Autofill Nudge to the proper destination based on their browser. */
+  async disableBrowserAutofillSettingsFromNudge(event: Event) {
+    // When we can programmatically disable the autofill setting, do that first
+    // otherwise open the appropriate URI for the browser
+    if (this.canOverrideBrowserAutofillSetting) {
+      this.defaultBrowserAutofillDisabled = true;
+      await this.updateDefaultBrowserAutofillDisabled();
+    } else {
+      await this.openURI(event, this.disablePasswordManagerURI);
+    }
+  }
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-23911](https://bitwarden.atlassian.net/browse/PM-23911)

## 📔 Objective

Navigate the user from the autofill nudge to the proper destination based on their browser. I.E. In chrome the setting can be programmatically changed while in other browsers it should be manually updated by the user.

## 📸 Screenshots

|Chrome|FireFox|Safari|
|-|-|-|
|<video src="https://github.com/user-attachments/assets/efa420e3-6374-480a-882b-49c792b330cb" />|<video src="https://github.com/user-attachments/assets/3cac9c1f-ef37-426a-9317-51d6ba64beb9" />|<video src="https://github.com/user-attachments/assets/848c9ab9-c1f3-43fb-8e81-e46de9af1bed" />|

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes








[PM-23911]: https://bitwarden.atlassian.net/browse/PM-23911?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ