### PR TITLE
[PM-22284] - [Defect] Inconsistent UI issues with Send page empty state

### DIFF
--- a/apps/browser/src/tools/popup/send-v2/send-v2.component.html
+++ b/apps/browser/src/tools/popup/send-v2/send-v2.component.html
@@ -22,7 +22,9 @@
   >
     <bit-no-items [icon]="noItemIcon" class="tw-text-main">
       <ng-container slot="title">{{ "sendsTitleNoItems" | i18n }}</ng-container>
-      <ng-container slot="description">{{ "sendsBodyNoItems" | i18n }}</ng-container>
+      <ng-container slot="description">
+        <p bitTypography="body2" class="tw-mx-6 tw-mt-2">{{ "sendsBodyNoItems" | i18n }}</p>
+      </ng-container>
       <tools-new-send-dropdown
         [hideIcon]="true"
         *ngIf="!sendsDisabled"

--- a/apps/browser/src/tools/popup/send-v2/send-v2.component.ts
+++ b/apps/browser/src/tools/popup/send-v2/send-v2.component.ts
@@ -9,7 +9,13 @@ import { PolicyType } from "@bitwarden/common/admin-console/enums";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { getUserId } from "@bitwarden/common/auth/services/account.service";
 import { SendType } from "@bitwarden/common/tools/send/enums/send-type";
-import { ButtonModule, CalloutModule, Icons, NoItemsModule } from "@bitwarden/components";
+import {
+  ButtonModule,
+  CalloutModule,
+  Icons,
+  NoItemsModule,
+  TypographyModule,
+} from "@bitwarden/components";
 import {
   NewSendDropdownComponent,
   NoSendsIcon,
@@ -48,6 +54,7 @@ export enum SendState {
     SendListItemsContainerComponent,
     SendListFiltersComponent,
     SendSearchComponent,
+    TypographyModule,
   ],
 })
 export class SendV2Component implements OnDestroy {

--- a/libs/tools/send/send-ui/src/icons/no-send.icon.ts
+++ b/libs/tools/send/send-ui/src/icons/no-send.icon.ts
@@ -1,7 +1,7 @@
 import { svgIcon } from "@bitwarden/components";
 
 export const NoSendsIcon = svgIcon`
-  <svg xmlns="http://www.w3.org/2000/svg" width="120" height="125" fill="none">
+  <svg xmlns="http://www.w3.org/2000/svg" width="100" height="105" fill="none" viewBox="0 0 120 125">
     <path class="tw-stroke-art-primary" stroke-width="3" d="M13.425 11.994H5.99a4.311 4.311 0 0 0-4.311 4.312v62.09a4.311 4.311 0 0 0 4.311 4.311h40.09"/>
     <path class="tw-stroke-art-primary tw-fill-background" stroke-width="3" d="M66.27 75.142h-49.9a3.234 3.234 0 0 1-3.233-3.234V9.818a3.234 3.234 0 0 1 3.234-3.233h35.764a3.233 3.233 0 0 1 2.293.953l14.134 14.216c.602.605.94 1.425.94 2.28v47.874a3.233 3.233 0 0 1-3.233 3.234Z"/>
     <path class="tw-stroke-art-accent" stroke-width="2" d="M47.021 35.586c0-3.818-2.728-6.915-6.095-6.915-3.367 0-6.096 3.097-6.096 6.915"/>

--- a/libs/tools/send/send-ui/src/new-send-dropdown/new-send-dropdown.component.html
+++ b/libs/tools/send/send-ui/src/new-send-dropdown/new-send-dropdown.component.html
@@ -1,10 +1,4 @@
-<button
-  bitButton
-  size="small"
-  [bitMenuTriggerFor]="itemOptions"
-  [buttonType]="buttonType"
-  type="button"
->
+<button bitButton [bitMenuTriggerFor]="itemOptions" [buttonType]="buttonType" type="button">
   <i *ngIf="!hideIcon" class="bwi bwi-plus" aria-hidden="true"></i>
   {{ (hideIcon ? "createSend" : "new") | i18n }}
 </button>


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-22284


## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR updates the New Send UI to match the comps more closely, specifically the icon and font size.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

|Prev|Updated|
---|---
|<img width="384" height="623" alt="Screenshot 2025-08-01 at 12 26 39 PM" src="https://github.com/user-attachments/assets/e3d4ec93-9cb0-483c-8b0e-76970a9d265f" />|<img width="390" height="630" alt="Screenshot 2025-08-01 at 12 18 46 PM" src="https://github.com/user-attachments/assets/807f4ca0-bdc9-4273-8354-63d71c791372" />|


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
