### PR TITLE
[CL-691] Update style of the menu component

### DIFF
--- a/libs/components/src/menu/menu-divider.component.html
+++ b/libs/components/src/menu/menu-divider.component.html
@@ -1,5 +1,5 @@
 <div
-  class="tw-my-2 tw-border-0 tw-border-t tw-border-solid tw-border-t-secondary-500"
+  class="tw-my-2 tw-border-0 tw-border-t tw-border-solid tw-border-t-secondary-100"
   role="separator"
   aria-hidden="true"
 ></div>

--- a/libs/components/src/menu/menu.component.html
+++ b/libs/components/src/menu/menu.component.html
@@ -1,7 +1,7 @@
 <ng-template>
   <div
     (click)="closed.emit()"
-    class="tw-flex tw-shrink-0 tw-flex-col tw-rounded-lg tw-border tw-border-solid tw-border-secondary-500 tw-bg-background tw-bg-clip-padding tw-py-1 tw-overflow-y-auto"
+    class="tw-flex tw-shrink-0 tw-flex-col tw-rounded-lg tw-border tw-border-solid tw-border-secondary-100 tw-bg-background tw-shadow-md tw-bg-clip-padding tw-py-1 tw-overflow-y-auto"
     [attr.role]="ariaRole()"
     [attr.aria-label]="ariaLabel()"
     cdkTrapFocus


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[CL-691](https://bitwarden.atlassian.net/browse/CL-691)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR updates the border and shadow of the menu component.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
| Header | Header |
|--------|--------|
| Cell | Cell | 
| <img width="830" height="703" alt="Screenshot 2025-08-04 at 1 53 50 PM" src="https://github.com/user-attachments/assets/121522e9-7328-4f1a-8b2e-c898cd5e9544" /> | <img width="830" height="703" alt="Screenshot 2025-08-04 at 1 47 46 PM" src="https://github.com/user-attachments/assets/7611f31c-535c-47b6-82bb-f41c63483c7c" /> |
| <img width="830" height="703" alt="Screenshot 2025-08-04 at 1 54 00 PM" src="https://github.com/user-attachments/assets/050e673c-e17f-4df1-9438-246b79f9e3f0" /> | <img width="830" height="703" alt="Screenshot 2025-08-04 at 1 43 32 PM" src="https://github.com/user-attachments/assets/5114d6d5-7ded-4dfb-b19e-903a7d1293d7" /> |


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
