### PR TITLE
[PM-24453] Treat Folders like Collections in Cipher Row view

### DIFF
--- a/apps/web/src/app/vault/components/vault-items/vault-folder-row.component.html
+++ b/apps/web/src/app/vault/components/vault-items/vault-folder-row.component.html
@@ -1,0 +1,73 @@
+<td bitCell [ngClass]="RowHeightClass" class="tw-min-w-fit">
+  @if (this.canEditFolder || this.canDeleteFolder) {
+    <input
+      type="checkbox"
+      bitCheckbox
+      appStopProp
+      [disabled]="disabled"
+      [checked]="checked"
+      (change)="$event ? this.checkedToggled.next() : null"
+      [attr.aria-label]="'folderItemSelect' | i18n"
+    />
+  }
+</td>
+<td bitCell [ngClass]="RowHeightClass" class="tw-min-w-fit">
+  <div aria-hidden="true">
+    <i class="bwi bwi-fw bwi-lg bwi-folder"></i>
+  </div>
+</td>
+<td bitCell [ngClass]="RowHeightClass">
+  <button
+    bitLink
+    [disabled]="disabled"
+    type="button"
+    class="tw-flex tw-w-full tw-text-start tw-leading-snug"
+    linkType="secondary"
+    title="{{ 'viewFolderWithName' | i18n: folderDisplayName }}"
+    [routerLink]="[]"
+    [queryParams]="{ folderId: folder.id }"
+    queryParamsHandling="merge"
+    appStopProp
+  >
+    <span class="tw-truncate tw-mr-1" [title]="folderPath">{{ folderDisplayName }}</span>
+  </button>
+</td>
+<td bitCell [ngClass]="RowHeightClass" *ngIf="showOwner" class="tw-hidden lg:tw-table-cell">
+  <!-- Folders don't have owners, leave empty -->
+</td>
+<td bitCell [ngClass]="RowHeightClass" *ngIf="showCollections">
+  <!-- Folders don't belong to collections, leave empty -->
+</td>
+<td bitCell [ngClass]="RowHeightClass" *ngIf="showGroups">
+  <!-- Folders don't have groups, leave empty -->
+</td>
+<td bitCell [ngClass]="RowHeightClass" *ngIf="showPermissionsColumn">
+  <!-- Folders don't have permissions in the same way, leave empty -->
+</td>
+<td bitCell [ngClass]="RowHeightClass" class="tw-text-right">
+  @if (canEditFolder || canDeleteFolder) {
+    <button
+      [disabled]="disabled"
+      [bitMenuTriggerFor]="folderOptions"
+      size="small"
+      bitIconButton="bwi-ellipsis-v"
+      type="button"
+      appA11yTitle="{{ 'options' | i18n }}"
+      appStopProp
+    ></button>
+  }
+  <bit-menu #folderOptions>
+    <ng-container *ngIf="canEditFolder">
+      <button type="button" bitMenuItem (click)="editFolder()">
+        <i class="bwi bwi-fw bwi-pencil-square" aria-hidden="true"></i>
+        {{ "editFolder" | i18n }}
+      </button>
+    </ng-container>
+    <button *ngIf="canDeleteFolder" type="button" bitMenuItem (click)="deleteFolder()">
+      <span class="tw-text-danger">
+        <i class="bwi bwi-fw bwi-trash" aria-hidden="true"></i>
+        {{ "delete" | i18n }}
+      </span>
+    </button>
+  </bit-menu>
+</td>

--- a/apps/web/src/app/vault/components/vault-items/vault-folder-row.component.ts
+++ b/apps/web/src/app/vault/components/vault-items/vault-folder-row.component.ts
@@ -1,0 +1,59 @@
+// FIXME: Update this file to be type safe and remove this and next line
+// @ts-strict-ignore
+import { Component, EventEmitter, Input, Output } from "@angular/core";
+
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { FolderView } from "@bitwarden/common/vault/models/view/folder.view";
+import { CipherViewLike } from "@bitwarden/common/vault/utils/cipher-view-like-utils";
+
+import { VaultItemEvent } from "./vault-item-event";
+import { RowHeightClass } from "./vault-items.component";
+
+@Component({
+  selector: "tr[appVaultFolderRow]",
+  templateUrl: "vault-folder-row.component.html",
+  standalone: false,
+})
+export class VaultFolderRowComponent<C extends CipherViewLike> {
+  protected RowHeightClass = RowHeightClass;
+
+  @Input() disabled: boolean;
+  @Input() folder: FolderView;
+  @Input() showOwner: boolean;
+  @Input() showCollections: boolean;
+  @Input() showGroups: boolean;
+  @Input() canEditFolder: boolean;
+  @Input() canDeleteFolder: boolean;
+  @Input() showPermissionsColumn: boolean;
+
+  @Output() onEvent = new EventEmitter<VaultItemEvent<C>>();
+
+  @Input() checked: boolean;
+  @Output() checkedToggled = new EventEmitter<void>();
+
+  constructor(private i18nService: I18nService) {}
+
+  get folderDisplayName() {
+    // For nested folders, show only the last part of the path
+    const parts = this.folder.name.split("/");
+    return parts[parts.length - 1];
+  }
+
+  get folderPath() {
+    const parts = this.folder.name.split("/");
+    if (parts.length <= 1) {
+      return "";
+    }
+
+    // Return parent path for tooltip
+    return parts.slice(0, -1).join(" > ");
+  }
+
+  protected editFolder() {
+    this.onEvent.next({ type: "editFolder", item: this.folder });
+  }
+
+  protected deleteFolder() {
+    this.onEvent.next({ type: "delete", items: [{ folder: this.folder }] });
+  }
+}

--- a/apps/web/src/app/vault/components/vault-items/vault-item-event.ts
+++ b/apps/web/src/app/vault/components/vault-items/vault-item-event.ts
@@ -1,4 +1,5 @@
 import { CollectionView } from "@bitwarden/admin-console/common";
+import { FolderView } from "@bitwarden/common/vault/models/view/folder.view";
 import { CipherViewLike } from "@bitwarden/common/vault/utils/cipher-view-like-utils";
 
 import { VaultItem } from "./vault-item";
@@ -14,4 +15,5 @@ export type VaultItemEvent<C extends CipherViewLike> =
   | { type: "delete"; items: VaultItem<C>[] }
   | { type: "copyField"; item: C; field: "username" | "password" | "totp" }
   | { type: "moveToFolder"; items: C[] }
-  | { type: "assignToCollections"; items: C[] };
+  | { type: "assignToCollections"; items: C[] }
+  | { type: "editFolder"; item: FolderView };

--- a/apps/web/src/app/vault/components/vault-items/vault-item.ts
+++ b/apps/web/src/app/vault/components/vault-items/vault-item.ts
@@ -1,7 +1,9 @@
 import { CollectionView } from "@bitwarden/admin-console/common";
+import { FolderView } from "@bitwarden/common/vault/models/view/folder.view";
 import { CipherViewLike } from "@bitwarden/common/vault/utils/cipher-view-like-utils";
 
 export interface VaultItem<C extends CipherViewLike> {
   collection?: CollectionView;
   cipher?: C;
+  folder?: FolderView;
 }

--- a/apps/web/src/app/vault/components/vault-items/vault-items.component.html
+++ b/apps/web/src/app/vault/components/vault-items/vault-items.component.html
@@ -110,6 +110,23 @@
     <ng-template body let-rows$>
       <ng-container *cdkVirtualFor="let item of rows$; templateCacheSize: 0">
         <tr
+          *ngIf="item.folder"
+          bitRow
+          appVaultFolderRow
+          alignContent="middle"
+          [disabled]="disabled"
+          [folder]="item.folder"
+          [showOwner]="showOwner"
+          [showCollections]="showCollections"
+          [showGroups]="showGroups"
+          [showPermissionsColumn]="showPermissionsColumn"
+          [canDeleteFolder]="canDeleteFolder(item.folder)"
+          [canEditFolder]="canEditFolder(item.folder)"
+          [checked]="selection.isSelected(item)"
+          (checkedToggled)="selection.toggle(item)"
+          (onEvent)="event($event)"
+        ></tr>
+        <tr
           *ngIf="item.collection"
           bitRow
           appVaultCollectionRow

--- a/apps/web/src/app/vault/components/vault-items/vault-items.module.ts
+++ b/apps/web/src/app/vault/components/vault-items/vault-items.module.ts
@@ -13,6 +13,7 @@ import { PipesModule } from "../../individual-vault/pipes/pipes.module";
 
 import { VaultCipherRowComponent } from "./vault-cipher-row.component";
 import { VaultCollectionRowComponent } from "./vault-collection-row.component";
+import { VaultFolderRowComponent } from "./vault-folder-row.component";
 import { VaultItemsComponent } from "./vault-items.component";
 
 @NgModule({
@@ -28,7 +29,12 @@ import { VaultItemsComponent } from "./vault-items.component";
     PipesModule,
     ScrollLayoutDirective,
   ],
-  declarations: [VaultItemsComponent, VaultCipherRowComponent, VaultCollectionRowComponent],
+  declarations: [
+    VaultItemsComponent,
+    VaultCipherRowComponent,
+    VaultCollectionRowComponent,
+    VaultFolderRowComponent,
+  ],
   exports: [VaultItemsComponent],
 })
 export class VaultItemsModule {}

--- a/apps/web/src/app/vault/individual-vault/vault.component.html
+++ b/apps/web/src/app/vault/individual-vault/vault.component.html
@@ -39,6 +39,7 @@
     <app-vault-items
       [ciphers]="ciphers"
       [collections]="collections"
+      [folders]="folders"
       [allCollections]="allCollections"
       [allOrganizations]="allOrganizations"
       [disabled]="refreshing"


### PR DESCRIPTION
🎟️ Tracking
https://bitwarden.atlassian.net/browse/PFI-964

📔 Objective
Allow users to view nested folders in the cipher view, similar to how nested Collections are displayed

📸 Screenshots
<img width="1241" height="628" alt="nestedfolderview" src="https://github.com/user-attachments/assets/bae836e0-4256-4467-a6e8-15e7a7eaf1bf" />
<img width="1246" height="652" alt="editfolder" src="https://github.com/user-attachments/assets/57d7781b-3210-4aae-bc83-618fb286f192" />