### PR TITLE
PM-23386 Display autofill options after sync

### DIFF
--- a/libs/common/src/vault/abstractions/cipher.service.ts
+++ b/libs/common/src/vault/abstractions/cipher.service.ts
@@ -42,7 +42,7 @@ export abstract class CipherService implements UserKeyRotationDataProvider<Ciphe
    * An empty array indicates that all ciphers were successfully decrypted.
    */
   abstract failedToDecryptCiphers$(userId: UserId): Observable<CipherView[] | null>;
-  abstract clearCache(userId: UserId): Promise<void>;
+  abstract clearCache(userId: UserId, skipUIUpdate?: boolean): Promise<void>;
   abstract encrypt(
     model: CipherView,
     userId: UserId,


### PR DESCRIPTION
## 🎟️ Tracking
[PM-23386](https://bitwarden.atlassian.net/browse/PM-23368)

## 📔 Objective

Currently when the user manually syncs their vault the autofill overlay items are cleared out and none are displayed.  This change displays the autofill items after the vault is synced manually.

## 📸 Screenshots
Before:
https://github.com/user-attachments/assets/fd659f6f-b87c-463e-9bc0-dd64aa64e018

After:
https://github.com/user-attachments/assets/7c604095-5df5-4733-ae12-3877747188f0

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


