### PR TITLE
[CL-682] Convert color password enum to const

### DIFF
--- a/libs/components/src/color-password/color-password.component.ts
+++ b/libs/components/src/color-password/color-password.component.ts
@@ -2,7 +2,7 @@ import { Component, computed, HostBinding, input } from "@angular/core";
 
 import { Utils } from "@bitwarden/common/platform/misc/utils";
 
-type CharacterType = "Letter" | "Emoji" | "Special" | "Number";
+type CharacterType = "letter" | "emoji" | "special" | "number";
 
 /**
  * The color password is used primarily in the Generator pages and in the Login type form. It includes
@@ -30,10 +30,10 @@ export class ColorPasswordComponent {
   });
 
   characterStyles: Record<CharacterType, string[]> = {
-    Emoji: [],
-    Letter: ["tw-text-main"],
-    Special: ["tw-text-danger"],
-    Number: ["tw-text-primary-600"],
+    emoji: [],
+    letter: ["tw-text-main"],
+    special: ["tw-text-danger"],
+    number: ["tw-text-primary-600"],
   };
 
   @HostBinding("class")
@@ -62,18 +62,18 @@ export class ColorPasswordComponent {
 
   private getCharacterType(character: string): CharacterType {
     if (character.match(Utils.regexpEmojiPresentation)) {
-      return "Emoji";
+      return "emoji";
     }
 
     if (character.match(/\d/)) {
-      return "Number";
+      return "number";
     }
 
     const specials = ["&", "<", ">", " "];
     if (specials.includes(character) || character.match(/[^\w ]/)) {
-      return "Special";
+      return "special";
     }
 
-    return "Letter";
+    return "letter";
   }
 }

--- a/libs/components/src/color-password/color-password.component.ts
+++ b/libs/components/src/color-password/color-password.component.ts
@@ -2,14 +2,8 @@ import { Component, computed, HostBinding, input } from "@angular/core";
 
 import { Utils } from "@bitwarden/common/platform/misc/utils";
 
-const CharacterTypes = {
-  Letter: "Letter",
-  Emoji: "Emoji",
-  Special: "Special",
-  Number: "Number",
-} as const;
+type CharacterType = "Letter" | "Emoji" | "Special" | "Number";
 
-type CharacterType = keyof typeof CharacterTypes;
 /**
  * The color password is used primarily in the Generator pages and in the Login type form. It includes
  * the logic for displaying letters as `text-main`, numbers as `primary`, and special symbols as
@@ -36,10 +30,10 @@ export class ColorPasswordComponent {
   });
 
   characterStyles: Record<CharacterType, string[]> = {
-    [CharacterTypes.Emoji]: [],
-    [CharacterTypes.Letter]: ["tw-text-main"],
-    [CharacterTypes.Special]: ["tw-text-danger"],
-    [CharacterTypes.Number]: ["tw-text-primary-600"],
+    Emoji: [],
+    Letter: ["tw-text-main"],
+    Special: ["tw-text-danger"],
+    Number: ["tw-text-primary-600"],
   };
 
   @HostBinding("class")
@@ -68,18 +62,18 @@ export class ColorPasswordComponent {
 
   private getCharacterType(character: string): CharacterType {
     if (character.match(Utils.regexpEmojiPresentation)) {
-      return CharacterTypes.Emoji;
+      return "Emoji";
     }
 
     if (character.match(/\d/)) {
-      return CharacterTypes.Number;
+      return "Number";
     }
 
     const specials = ["&", "<", ">", " "];
     if (specials.includes(character) || character.match(/[^\w ]/)) {
-      return CharacterTypes.Special;
+      return "Special";
     }
 
-    return CharacterTypes.Letter;
+    return "Letter";
   }
 }

--- a/libs/components/src/color-password/color-password.component.ts
+++ b/libs/components/src/color-password/color-password.component.ts
@@ -2,14 +2,14 @@ import { Component, computed, HostBinding, input } from "@angular/core";
 
 import { Utils } from "@bitwarden/common/platform/misc/utils";
 
-// FIXME: update to use a const object instead of a typescript enum
-// eslint-disable-next-line @bitwarden/platform/no-enums
-enum CharacterType {
-  Letter,
-  Emoji,
-  Special,
-  Number,
-}
+const CharacterTypes = {
+  Letter: "Letter",
+  Emoji: "Emoji",
+  Special: "Special",
+  Number: "Number",
+} as const;
+
+type CharacterType = keyof typeof CharacterTypes;
 /**
  * The color password is used primarily in the Generator pages and in the Login type form. It includes
  * the logic for displaying letters as `text-main`, numbers as `primary`, and special symbols as
@@ -36,10 +36,10 @@ export class ColorPasswordComponent {
   });
 
   characterStyles: Record<CharacterType, string[]> = {
-    [CharacterType.Emoji]: [],
-    [CharacterType.Letter]: ["tw-text-main"],
-    [CharacterType.Special]: ["tw-text-danger"],
-    [CharacterType.Number]: ["tw-text-primary-600"],
+    [CharacterTypes.Emoji]: [],
+    [CharacterTypes.Letter]: ["tw-text-main"],
+    [CharacterTypes.Special]: ["tw-text-danger"],
+    [CharacterTypes.Number]: ["tw-text-primary-600"],
   };
 
   @HostBinding("class")
@@ -68,18 +68,18 @@ export class ColorPasswordComponent {
 
   private getCharacterType(character: string): CharacterType {
     if (character.match(Utils.regexpEmojiPresentation)) {
-      return CharacterType.Emoji;
+      return CharacterTypes.Emoji;
     }
 
     if (character.match(/\d/)) {
-      return CharacterType.Number;
+      return CharacterTypes.Number;
     }
 
     const specials = ["&", "<", ">", " "];
     if (specials.includes(character) || character.match(/[^\w ]/)) {
-      return CharacterType.Special;
+      return CharacterTypes.Special;
     }
 
-    return CharacterType.Letter;
+    return CharacterTypes.Letter;
   }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[CL-682](https://bitwarden.atlassian.net/browse/CL-682)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR converts the one enum in the CL to a const, to follow our coding guidelines and remove an eslint ignore.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[CL-682]: https://bitwarden.atlassian.net/browse/CL-682?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ