### PR TITLE
[PM-24119] Bump extension response timeout

### DIFF
--- a/apps/web/src/app/vault/services/web-browser-interaction.service.ts
+++ b/apps/web/src/app/vault/services/web-browser-interaction.service.ts
@@ -25,7 +25,7 @@ import { VaultMessages } from "@bitwarden/common/vault/enums/vault-messages.enum
  * used to allow for the extension to open and then emit to the message.
  * NOTE: This value isn't computed by any means, it is just a reasonable timeout for the extension to respond.
  */
-const OPEN_RESPONSE_TIMEOUT_MS = 2000;
+const OPEN_RESPONSE_TIMEOUT_MS = 3000;
 
 /**
  * Timeout for checking if the extension is installed.


### PR DESCRIPTION
## 🎟️ Tracking

[PM-24119](https://bitwarden.atlassian.net/browse/PM-24119)

## 📔 Objective

Bump timeout of open response to account for odd timing with extensions. This should minimize the scenario where the extension opens but the webpage still times out from not receiving the open message.

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-24119]: https://bitwarden.atlassian.net/browse/PM-24119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ