### PR TITLE
Remove `getIsAuthenticated` in KM files

### DIFF
--- a/libs/common/src/key-management/vault-timeout/services/vault-timeout.service.ts
+++ b/libs/common/src/key-management/vault-timeout/services/vault-timeout.service.ts
@@ -14,6 +14,7 @@ import { BiometricsService } from "@bitwarden/key-management";
 
 import { AccountService } from "../../../auth/abstractions/account.service";
 import { AuthService } from "../../../auth/abstractions/auth.service";
+import { TokenService } from "../../../auth/abstractions/token.service";
 import { AuthenticationStatus } from "../../../auth/enums/authentication-status";
 import { LogService } from "../../../platform/abstractions/log.service";
 import { MessagingService } from "../../../platform/abstractions/messaging.service";
@@ -42,7 +43,8 @@ export class VaultTimeoutService implements VaultTimeoutServiceAbstraction {
     protected platformUtilsService: PlatformUtilsService,
     private messagingService: MessagingService,
     private searchService: SearchService,
-    private stateService: StateService,
+    private readonly stateService: StateService,
+    private readonly tokenService: TokenService,
     private authService: AuthService,
     private vaultTimeoutSettingsService: VaultTimeoutSettingsService,
     private stateEventRunnerService: StateEventRunnerService,
@@ -108,7 +110,10 @@ export class VaultTimeoutService implements VaultTimeoutServiceAbstraction {
   async lock(userId?: UserId): Promise<void> {
     await this.biometricService.setShouldAutopromptNow(false);
 
-    const authed = await this.stateService.getIsAuthenticated({ userId: userId });
+    const lockingUserId =
+      userId ?? (await firstValueFrom(this.accountService.activeAccount$.pipe(map((a) => a?.id))));
+
+    const authed = await firstValueFrom(this.tokenService.hasAccessToken$(lockingUserId));
     if (!authed) {
       return;
     }
@@ -120,12 +125,6 @@ export class VaultTimeoutService implements VaultTimeoutServiceAbstraction {
     if (!supportsLock) {
       await this.logOut(userId);
     }
-
-    const currentUserId = await firstValueFrom(
-      this.accountService.activeAccount$.pipe(map((a) => a?.id)),
-    );
-
-    const lockingUserId = userId ?? currentUserId;
 
     // HACK: Start listening for the transition of the locking user from something to the locked state.
     // This is very much a hack to ensure that the authentication status to retrievable right after


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Remove `StateService.getIsAuthenticated()` uses from all files owned by KM

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
