### PR TITLE
Remove `getIsAuthenticated` in autofill files

### DIFF
--- a/apps/browser/src/autofill/browser/main-context-menu-handler.spec.ts
+++ b/apps/browser/src/autofill/browser/main-context-menu-handler.spec.ts
@@ -2,6 +2,7 @@ import { mock, MockProxy } from "jest-mock-extended";
 import { BehaviorSubject, of } from "rxjs";
 
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { TokenService } from "@bitwarden/common/auth/abstractions/token.service";
 import {
   AUTOFILL_CARD_ID,
   AUTOFILL_ID,
@@ -17,7 +18,6 @@ import { AutofillSettingsServiceAbstraction } from "@bitwarden/common/autofill/s
 import { BillingAccountProfileStateService } from "@bitwarden/common/billing/abstractions/account/billing-account-profile-state.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
-import { StateService } from "@bitwarden/common/platform/abstractions/state.service";
 import { UserId } from "@bitwarden/common/types/guid";
 import { CipherType } from "@bitwarden/common/vault/enums";
 import { Cipher } from "@bitwarden/common/vault/models/domain/cipher";
@@ -67,7 +67,7 @@ const createCipher = (data?: {
 };
 
 describe("context-menu", () => {
-  let stateService: MockProxy<StateService>;
+  let tokenService: MockProxy<TokenService>;
   let autofillSettingsService: MockProxy<AutofillSettingsServiceAbstraction>;
   let i18nService: MockProxy<I18nService>;
   let logService: MockProxy<LogService>;
@@ -85,7 +85,7 @@ describe("context-menu", () => {
   let sut: MainContextMenuHandler;
 
   beforeEach(() => {
-    stateService = mock();
+    tokenService = mock();
     autofillSettingsService = mock();
     i18nService = mock();
     logService = mock();
@@ -109,7 +109,7 @@ describe("context-menu", () => {
 
     i18nService.t.mockImplementation((key) => key);
     sut = new MainContextMenuHandler(
-      stateService,
+      tokenService,
       autofillSettingsService,
       i18nService,
       logService,
@@ -276,7 +276,7 @@ describe("context-menu", () => {
     it("removes menu items that require code injection", async () => {
       billingAccountProfileStateService.hasPremiumFromAnySource$.mockReturnValue(of(true));
       autofillSettingsService.enableContextMenu$ = of(true);
-      stateService.getIsAuthenticated.mockResolvedValue(true);
+      tokenService.hasAccessToken$.mockReturnValue(of(true));
 
       const optionId = "1";
       await sut.loadOptions("TEST_TITLE", optionId, createCipher());
@@ -317,7 +317,7 @@ describe("context-menu", () => {
     });
 
     it("Loads context menu items that ask the user to unlock their vault if they are authed", async () => {
-      stateService.getIsAuthenticated.mockResolvedValue(true);
+      tokenService.hasAccessToken$.mockReturnValue(of(true));
 
       await sut.noAccess();
 
@@ -325,7 +325,7 @@ describe("context-menu", () => {
     });
 
     it("Loads context menu items that ask the user to login to their vault if they are not authed", async () => {
-      stateService.getIsAuthenticated.mockResolvedValue(false);
+      tokenService.hasAccessToken$.mockReturnValue(of(false));
 
       await sut.noAccess();
 

--- a/apps/browser/src/autofill/browser/main-context-menu-handler.ts
+++ b/apps/browser/src/autofill/browser/main-context-menu-handler.ts
@@ -1,8 +1,9 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
-import { firstValueFrom } from "rxjs";
+import { firstValueFrom, map } from "rxjs";
 
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { TokenService } from "@bitwarden/common/auth/abstractions/token.service";
 import {
   AUTOFILL_CARD_ID,
   AUTOFILL_ID,
@@ -23,7 +24,6 @@ import { AutofillSettingsServiceAbstraction } from "@bitwarden/common/autofill/s
 import { BillingAccountProfileStateService } from "@bitwarden/common/billing/abstractions/account/billing-account-profile-state.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
-import { StateService } from "@bitwarden/common/platform/abstractions/state.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { CipherType } from "@bitwarden/common/vault/enums/cipher-type";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
@@ -152,7 +152,7 @@ export class MainContextMenuHandler {
   ];
 
   constructor(
-    private stateService: StateService,
+    private tokenService: TokenService,
     private autofillSettingsService: AutofillSettingsServiceAbstraction,
     private i18nService: I18nService,
     private logService: LogService,
@@ -343,7 +343,11 @@ export class MainContextMenuHandler {
 
   async noAccess() {
     if (await this.init()) {
-      const authed = await this.stateService.getIsAuthenticated();
+      const userId = await firstValueFrom(
+        this.accountService.activeAccount$.pipe(map((a) => a?.id)),
+      );
+      const authed =
+        userId != null && (await firstValueFrom(this.tokenService.hasAccessToken$(userId)));
       this.loadOptions(
         this.i18nService.t(authed ? "unlockVaultMenu" : "loginToVaultMenu"),
         NOOP_COMMAND_SUFFIX,


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Remove `StateService.getIsAuthenticated()` uses from all files owned by autofill

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
