### PR TITLE
[PM-19054] hide experimental `bw send --email` flag

### DIFF
--- a/apps/cli/src/tools/send/send.program.ts
+++ b/apps/cli/src/tools/send/send.program.ts
@@ -55,10 +55,13 @@ export class SendProgram extends BaseProgram {
           "optional password to access this Send. Can also be specified in JSON.",
         ).conflicts("email"),
       )
-      .option(
-        "--email <email>",
-        "optional emails to access this Send. Can also be specified in JSON.",
-        parseEmail,
+      .addOption(
+        new Option(
+          "--email <email>",
+          "optional emails to access this Send. Can also be specified in JSON.",
+        )
+          .argParser(parseEmail)
+          .hideHelp(),
       )
       .option("-a, --maxAccessCount <amount>", "The amount of max possible accesses.")
       .option("--hidden", "Hide <data> in web by default. Valid only if --file is not set.")


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-19054

## 📔 Objective

Hide the `bw send --email` flag until end-to-end connectivity is available.

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
