### PR TITLE
feature: de-duplication tool with test coverage  

### DIFF
--- a/apps/web/src/app/layouts/user-layout.component.html
+++ b/apps/web/src/app/layouts/user-layout.component.html
@@ -8,6 +8,7 @@
       <bit-nav-item [text]="'generator' | i18n" route="tools/generator"></bit-nav-item>
       <bit-nav-item [text]="'importData' | i18n" route="tools/import"></bit-nav-item>
       <bit-nav-item [text]="'exportVault' | i18n" route="tools/export"></bit-nav-item>
+      <bit-nav-item [text]="'De-duplication tool'" route="tools/de-duplicate"></bit-nav-item>
     </bit-nav-group>
     <bit-nav-item icon="bwi-sliders" [text]="'reports' | i18n" route="reports"></bit-nav-item>
     <bit-nav-group icon="bwi-cog" [text]="'settings' | i18n" route="settings">

--- a/apps/web/src/app/oss-routing.module.ts
+++ b/apps/web/src/app/oss-routing.module.ts
@@ -674,6 +674,14 @@ const routes: Routes = [
             } satisfies RouteDataProperties,
           },
           {
+            path: "de-duplicate",
+            loadComponent: () =>
+              import("./tools/de-duplicate/de-duplicate.component").then(
+                (m) => m.DeDuplicateComponent,
+              ),
+            data: { titleId: "duplicateItemsFound" } satisfies RouteDataProperties,
+          },
+          {
             path: "generator",
             component: CredentialGeneratorComponent,
             data: { titleId: "generator" } satisfies RouteDataProperties,

--- a/apps/web/src/app/tools/de-duplicate/de-duplicate.component.html
+++ b/apps/web/src/app/tools/de-duplicate/de-duplicate.component.html
@@ -1,0 +1,28 @@
+<app-header></app-header>
+
+<bit-container>
+  <div class="tw-flex tw-flex-col tw-gap-4">
+    <h1 bitTypography="h1" class="tw-m-0">De-duplicate vault</h1>
+    <bit-callout type="info" title="De-duplicating vault">
+      Vault items associated that contain matching usernames and passwords, have similar names, and
+      belong to the same organization and folder will be displayed for review and optional deletion.
+      Duplicated items already in the trash will be permanently deleted. Duplicate items not yet in
+      the trash will be moved to the trash.
+    </bit-callout>
+
+    <div class="tw-flex tw-gap-2">
+      <button
+        bitButton
+        buttonType="primary"
+        type="button"
+        [disabled]="loading"
+        (click)="findDuplicates()"
+      >
+        Find Duplicates
+      </button>
+      <div *ngIf="loading" class="tw-self-center tw-text-muted">{{ "loading" | i18n }}</div>
+    </div>
+
+    <div *ngIf="message" class="tw-text-sm tw-text-muted">{{ message }}</div>
+  </div>
+</bit-container>

--- a/apps/web/src/app/tools/de-duplicate/de-duplicate.component.ts
+++ b/apps/web/src/app/tools/de-duplicate/de-duplicate.component.ts
@@ -1,0 +1,49 @@
+import { CommonModule } from "@angular/common";
+import { Component, Inject } from "@angular/core";
+import { firstValueFrom } from "rxjs";
+
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { getUserId } from "@bitwarden/common/auth/services/account.service";
+import { ButtonModule, CalloutModule } from "@bitwarden/components";
+
+import { HeaderModule } from "../../layouts/header/header.module";
+import { SharedModule } from "../../shared";
+import { DeDuplicateService } from "../../vault/services/de-duplicate.service";
+
+
+@Component({
+  selector: "app-de-duplicate",
+  standalone: true,
+  imports: [CommonModule, SharedModule, HeaderModule, ButtonModule, CalloutModule],
+  templateUrl: "./de-duplicate.component.html",
+})
+export class DeDuplicateComponent {
+  loading = false;
+  message: string;
+
+  constructor(
+    @Inject(DeDuplicateService) private deDuplicateService: DeDuplicateService,
+    private accountService: AccountService,
+  ) {}
+
+  async findDuplicates() {
+    this.loading = true;
+    this.message = null;
+
+    try {
+      const userId = await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId));
+      const setCount = await this.deDuplicateService.findAndHandleDuplicates(userId);
+      if (setCount === 0) {
+        this.message = "No duplicate login items were found.";
+      } else if (setCount === 1) {
+        this.message = "1 duplicate set found (reviewed).";
+      } else {
+        this.message = `${setCount} duplicate sets found (reviewed).`;
+      }
+    } catch (e) {
+      this.message = `An error occurred: ${e.message}`;
+    } finally {
+      this.loading = false;
+    }
+  }
+}

--- a/apps/web/src/app/tools/de-duplicate/duplicate-review-dialog.component.ts
+++ b/apps/web/src/app/tools/de-duplicate/duplicate-review-dialog.component.ts
@@ -1,0 +1,148 @@
+import { CommonModule } from "@angular/common";
+import { Component, Inject } from "@angular/core";
+import { FormsModule } from "@angular/forms";
+
+import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+import { ButtonModule, DialogModule, DialogRef, DIALOG_DATA } from "@bitwarden/components";
+
+export interface DuplicateReviewDialogData {
+  duplicateSets: { key: string; ciphers: CipherView[] }[];
+}
+
+export interface DuplicateReviewDialogResult {
+  confirmed: boolean;
+  deleteCipherIds: string[];
+}
+
+@Component({
+  selector: "app-duplicate-review-dialog",
+  standalone: true,
+  imports: [CommonModule, DialogModule, ButtonModule, FormsModule],
+  template: `
+    <bit-dialog>
+      <span bitDialogTitle class="tw-font-semibold">Duplicate items found</span>
+      <div bitDialogContent>
+        <div class="tw-space-y-4 tw-w-[min(90vw,960px)]">
+          <p class="tw-text-muted tw-m-0">Review and delete duplicate entries.</p>
+          <div *ngIf="duplicateSets?.length" class="tw-text-sm tw-font-medium">
+            {{ totalDuplicateItemCount }} duplicated item{{
+              totalDuplicateItemCount === 1 ? "" : "s"
+            }}
+            found for {{ duplicateSets.length }} credential{{
+              duplicateSets.length === 1 ? "" : "s"
+            }}
+          </div>
+
+          <ng-container *ngIf="duplicateSets?.length; else noneFound">
+            <div
+              class="tw-max-h-96 tw-overflow-auto tw-border tw-rounded tw-divide-y tw-bg-background"
+            >
+              <div
+                *ngFor="let set of duplicateSets; let i = index"
+                class="tw-p-3 tw-space-y-2 tw-bg-background-alt"
+              >
+                <div class="tw-text-sm tw-font-medium">
+                  {{ i + 1 }}. {{ set.ciphers[0]?.login?.username || "—" }}
+                </div>
+                <div class="tw-text-xs tw-text-muted">{{ set.ciphers.length }} item(s)</div>
+                <table class="tw-w-full tw-text-sm tw-border-collapse">
+                  <thead>
+                    <tr class="tw-text-left tw-text-xs tw-text-muted">
+                      <th class="tw-w-6"></th>
+                      <th>Name</th>
+                      <th>Username</th>
+                      <th>Folder</th>
+                      <th>Organization</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr
+                      *ngFor="let cipher of set.ciphers; let idx = index"
+                      class="tw-align-top hover:tw-bg-background-alt/40"
+                    >
+                      <td>
+                        <input
+                          type="checkbox"
+                          [disabled]="idx === 0"
+                          [(ngModel)]="selection[cipher.id]"
+                          [ngModelOptions]="{ standalone: true }"
+                        />
+                      </td>
+                      <td class="tw-pr-2">
+                        <span [ngClass]="{ 'tw-font-semibold': idx === 0 }">{{ cipher.name }}</span>
+                        <span *ngIf="cipher.isDeleted" class="tw-italic tw-text-xs tw-text-muted">
+                          (In Trash)</span
+                        >
+                      </td>
+                      <td class="tw-pr-2">{{ cipher.login?.username }}</td>
+                      <td class="tw-pr-2">{{ cipher.folderId || "—" }}</td>
+                      <td class="tw-pr-2">{{ cipher.organizationId || "—" }}</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </ng-container>
+          <ng-template #noneFound>
+            <div class="tw-text-sm tw-text-muted">No duplicates found.</div>
+          </ng-template>
+        </div>
+      </div>
+      <ng-container bitDialogFooter>
+        <button bitButton buttonType="secondary" type="button" (click)="cancel()">Keep All</button>
+        <button
+          bitButton
+          buttonType="danger"
+          type="button"
+          (click)="confirm()"
+          [disabled]="!hasAnySelected()"
+        >
+          Delete Selected
+        </button>
+      </ng-container>
+    </bit-dialog>
+  `,
+})
+export class DuplicateReviewDialogComponent {
+  duplicateSets: { key: string; ciphers: CipherView[] }[] = [];
+  selection: Record<string, boolean> = {};
+
+  get totalDuplicateItemCount(): number {
+    return this.duplicateSets.reduce((sum, set) => sum + Math.max(0, set.ciphers.length - 1), 0);
+  }
+
+  constructor(
+    private dialogRef: DialogRef<DuplicateReviewDialogResult>,
+    @Inject(DIALOG_DATA) public data: DuplicateReviewDialogData,
+  ) {
+    this.duplicateSets = data.duplicateSets ?? [];
+    for (const set of this.duplicateSets) {
+      set.ciphers.forEach((c, idx) => {
+        if (idx === 0) {
+          this.selection[c.id] = false;
+        } else {
+          this.selection[c.id] = true;
+        }
+      });
+    }
+  }
+
+  hasAnySelected() {
+    return Object.values(this.selection).some((v) => v);
+  }
+
+  confirm() {
+    const deleteCipherIds = Object.entries(this.selection)
+      .filter(([, selected]) => selected)
+      .map(([id]) => id);
+    this.dialogRef.close({ confirmed: true, deleteCipherIds });
+  }
+
+  cancel() {
+    this.dialogRef.close({ confirmed: false, deleteCipherIds: [] });
+  }
+
+  static open(dialogService: any, data: DuplicateReviewDialogData) {
+    return (dialogService as any).open(DuplicateReviewDialogComponent, { data });
+  }
+}

--- a/apps/web/src/app/tools/de-duplicate/duplicate-success-dialog.component.html
+++ b/apps/web/src/app/tools/de-duplicate/duplicate-success-dialog.component.html
@@ -1,0 +1,16 @@
+<bit-dialog>
+  <span bitDialogTitle> De-duplication complete </span>
+  <div bitDialogContent>
+    <p>
+      <strong>{{ data.trashed }}</strong> item{{ data.trashed === 1 ? "" : "s" }} moved to Trash.
+      <br />
+      <strong>{{ data.permanentlyDeleted }}</strong> item{{
+        data.permanentlyDeleted === 1 ? "" : "s"
+      }}
+      permanently deleted.
+    </p>
+  </div>
+  <ng-container bitDialogFooter>
+    <button bitButton bitDialogClose buttonType="primary" type="button">OK</button>
+  </ng-container>
+</bit-dialog>

--- a/apps/web/src/app/tools/de-duplicate/duplicate-success-dialog.component.ts
+++ b/apps/web/src/app/tools/de-duplicate/duplicate-success-dialog.component.ts
@@ -1,0 +1,20 @@
+import { CommonModule } from "@angular/common";
+import { Component, Inject } from "@angular/core";
+
+import { ButtonModule, DialogModule, DialogRef, DIALOG_DATA } from "@bitwarden/components";
+
+export interface DuplicateSuccessDialogData {
+  trashed: number;
+  permanentlyDeleted: number;
+}
+
+@Component({
+  templateUrl: "./duplicate-success-dialog.component.html",
+  imports: [CommonModule, DialogModule, ButtonModule],
+})
+export class DuplicateSuccessDialogComponent {
+  constructor(
+    public dialogRef: DialogRef,
+    @Inject(DIALOG_DATA) public data: DuplicateSuccessDialogData,
+  ) {}
+}

--- a/apps/web/src/app/vault/services/de-duplicate.service.spec.ts
+++ b/apps/web/src/app/vault/services/de-duplicate.service.spec.ts
@@ -1,0 +1,357 @@
+import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+
+import { DeDuplicateService } from "./de-duplicate.service";
+
+const cipherServiceStub = {
+  getAllDecrypted: jest.fn(),
+  delete: jest.fn(),
+};
+
+const dialogServiceStub = {
+  open: jest.fn(),
+};
+
+function buildCipher({
+  id,
+  name,
+  username,
+  password,
+  folderId = null,
+  organizationId = null,
+}: {
+  id: string;
+  name: string;
+  username: string;
+  password: string;
+  folderId?: string | null;
+  organizationId?: string | null;
+}): CipherView {
+  const cv = new CipherView();
+  (cv as any).id = id;
+  (cv as any).name = name;
+  (cv as any).folderId = folderId;
+  (cv as any).organizationId = organizationId;
+  (cv as any).login = { username, password };
+  return cv;
+}
+
+describe("DeDuplicateService - duplicate detection", () => {
+  let service: DeDuplicateService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    const cipherAuthorizationServiceStub = {};
+    service = new DeDuplicateService(
+      cipherServiceStub as any,
+      dialogServiceStub as any,
+      cipherAuthorizationServiceStub as any,
+    );
+  });
+
+  function findSets(ciphers: CipherView[]) {
+    return (service as any).findDuplicateSets(ciphers) as { key: string; ciphers: CipherView[] }[];
+  }
+
+  it("does NOT group ciphers with same username/password but different names", () => {
+    const c1 = buildCipher({
+      id: "1",
+      name: "SiteA",
+      username: "user@example.com",
+      password: "pass",
+    });
+    const c2 = buildCipher({
+      id: "2",
+      name: "SiteB",
+      username: "user@example.com",
+      password: "pass",
+    });
+    const sets = findSets([c1, c2]);
+    expect(sets.length).toBe(0);
+  });
+
+  it("does NOT group ciphers with same username/password but different folders", () => {
+    const c1 = buildCipher({
+      id: "1",
+      name: "Site",
+      username: "user@example.com",
+      password: "pass",
+      folderId: "folder1",
+    });
+    const c2 = buildCipher({
+      id: "2",
+      name: "Site",
+      username: "user@example.com",
+      password: "pass",
+      folderId: "folder2",
+    });
+    const sets = findSets([c1, c2]);
+    expect(sets.length).toBe(0);
+  });
+
+  it("does NOT group ciphers with same username/password but different organizations", () => {
+    const c1 = buildCipher({
+      id: "1",
+      name: "Site",
+      username: "user@example.com",
+      password: "pass",
+      organizationId: "org1",
+    });
+    const c2 = buildCipher({
+      id: "2",
+      name: "Site",
+      username: "user@example.com",
+      password: "pass",
+      organizationId: "org2",
+    });
+    const sets = findSets([c1, c2]);
+    expect(sets.length).toBe(0);
+  });
+
+  it("clusterKey returns username if present, otherwise name, otherwise empty string", () => {
+    const c1 = buildCipher({ id: "1", name: "Demo", username: "u", password: "p" });
+    const c2 = buildCipher({ id: "2", name: "Demo", username: "", password: "p" });
+    const c3 = buildCipher({ id: "3", name: "", username: "", password: "p" });
+    expect((service as any).clusterKey([c1])).toBe("u");
+    expect((service as any).clusterKey([c2])).toBe("Demo");
+    expect((service as any).clusterKey([c3])).toBe("");
+  });
+
+  it("canonicalName strips (username) suffix correctly", () => {
+    const c1 = buildCipher({ id: "1", name: "Demo (u)", username: "u", password: "p" });
+    const c2 = buildCipher({ id: "2", name: "Demo", username: "u", password: "p" });
+    expect((service as any).canonicalName(c1)).toBe("Demo");
+    expect((service as any).canonicalName(c2)).toBe("Demo");
+  });
+
+  it("buildCredentialBuckets buckets ciphers by username, password, org, folder", () => {
+    const c1 = buildCipher({
+      id: "1",
+      name: "A",
+      username: "u",
+      password: "p",
+      folderId: "f1",
+      organizationId: "o1",
+    });
+    const c2 = buildCipher({
+      id: "2",
+      name: "B",
+      username: "u",
+      password: "p",
+      folderId: "f1",
+      organizationId: "o1",
+    });
+    const map = (service as any).buildCredentialBuckets([c1, c2]);
+    expect(map.size).toBe(1);
+    expect(map.values().next().value.length).toBe(2);
+  });
+
+  it("buildCredentialBuckets skips ciphers with missing username or password", () => {
+    const c1 = buildCipher({ id: "1", name: "A", username: "", password: "p" });
+    const c2 = buildCipher({ id: "2", name: "B", username: "u", password: "" });
+    const map = (service as any).buildCredentialBuckets([c1, c2]);
+    expect(map.size).toBe(0);
+  });
+
+  it("buildNameBuckets buckets ciphers by canonical name, username, org, folder, skipping consumed", () => {
+    const c1 = buildCipher({
+      id: "1",
+      name: "Demo (u)",
+      username: "u",
+      password: "p",
+      folderId: "f1",
+      organizationId: "o1",
+    });
+    const c2 = buildCipher({
+      id: "2",
+      name: "Demo",
+      username: "u",
+      password: "p",
+      folderId: "f1",
+      organizationId: "o1",
+    });
+    const consumed = new Set(["1"]);
+    const map = (service as any).buildNameBuckets([c1, c2], consumed);
+    expect(map.size).toBe(1);
+    expect(map.values().next().value[0].id).toBe("2");
+  });
+
+  it("groupByName groups ciphers into clusters and singles", () => {
+    const c1 = buildCipher({ id: "1", name: "Demo", username: "u", password: "p" });
+    const c2 = buildCipher({ id: "2", name: "Demo (u)", username: "u", password: "p" });
+    const c3 = buildCipher({ id: "3", name: "Other", username: "u", password: "p" });
+    const result = (service as any).groupByName([c1, c2, c3]);
+    expect(result.clusters.length).toBe(1);
+    expect(result.singles.length).toBe(1);
+    expect(result.clusters[0].map((c: CipherView) => c.id)).toEqual(["1", "2"]);
+    expect(result.singles[0].id).toBe("3");
+  });
+
+  it("isDuplicateByName detects duplicates by name and (username) suffix", () => {
+    const c1 = buildCipher({ id: "1", name: "Demo", username: "u", password: "p" });
+    const c2 = buildCipher({ id: "2", name: "Demo (u)", username: "u", password: "p" });
+    expect((service as any).isDuplicateByName(c1, c2)).toBe(true);
+    expect((service as any).isDuplicateByName(c2, c1)).toBe(true);
+    const c3 = buildCipher({ id: "3", name: "Other", username: "u", password: "p" });
+    expect((service as any).isDuplicateByName(c1, c3)).toBe(false);
+  });
+
+  it("groups credential-identical name variants (Name vs Name (username))", () => {
+    const c1 = buildCipher({
+      id: "1",
+      name: "Example",
+      username: "user@example.com",
+      password: "pass",
+    });
+    const c2 = buildCipher({
+      id: "2",
+      name: "Example (user@example.com)",
+      username: "user@example.com",
+      password: "pass",
+    });
+
+    const sets = findSets([c1, c2]);
+    expect(sets.length).toBe(1);
+    expect(sets[0].ciphers.map((c) => c.id).sort()).toEqual(["1", "2"]);
+  });
+
+  it("does NOT group different domains with same creds when names are unrelated", () => {
+    const c1 = buildCipher({
+      id: "1",
+      name: "accounts.hackthebox.com",
+      username: "user@example.com",
+      password: "same",
+    });
+    const c2 = buildCipher({
+      id: "2",
+      name: "forum.hackthebox.com",
+      username: "user@example.com",
+      password: "same",
+    });
+
+    const sets = findSets([c1, c2]);
+    expect(sets.length).toBe(0);
+  });
+
+  it("groups name variants in secondary pass even if passwords differ (credential grouping skipped)", () => {
+    const c1 = buildCipher({
+      id: "1",
+      name: "Demo",
+      username: "user@example.com",
+      password: "p1",
+    });
+    const c2 = buildCipher({
+      id: "2",
+      name: "Demo (user@example.com)",
+      username: "user@example.com",
+      password: "different",
+    });
+
+    const sets = findSets([c1, c2]);
+    expect(sets.length).toBe(1);
+    expect(sets[0].ciphers.map((c) => c.id).sort()).toEqual(["1", "2"]);
+  });
+
+  it("keeps credential-identical but different folders separate", () => {
+    const c1 = buildCipher({
+      id: "1",
+      name: "accounts.example.com",
+      username: "u",
+      password: "p",
+      folderId: "f1",
+    });
+    const c2 = buildCipher({
+      id: "2",
+      name: "forum.example.com",
+      username: "u",
+      password: "p",
+      folderId: "f2",
+    });
+
+    const sets = findSets([c1, c2]);
+    expect(sets.length).toBe(0);
+  });
+
+  it("does not merge across organizations when org differs", () => {
+    const c1 = buildCipher({
+      id: "1",
+      name: "Example",
+      username: "u",
+      password: "p",
+      organizationId: "org1",
+    });
+    const c2 = buildCipher({
+      id: "2",
+      name: "Example (u)",
+      username: "u",
+      password: "p",
+      organizationId: "org2",
+    });
+
+    const sets = findSets([c1, c2]);
+    expect(sets.length).toBe(0);
+  });
+
+  it("clusters three variants correctly (base + two username suffixed)", () => {
+    const c1 = buildCipher({ id: "1", name: "Demo", username: "u", password: "p" });
+    const c2 = buildCipher({ id: "2", name: "Demo (u)", username: "u", password: "p" });
+    const c3 = buildCipher({ id: "3", name: "Demo (u)", username: "u", password: "p" });
+
+    const sets = findSets([c1, c2, c3]);
+    expect(sets.length).toBe(1);
+    expect(sets[0].ciphers.map((c) => c.id).sort()).toEqual(["1", "2", "3"]);
+  });
+
+  it("skips singleton groups even after splitting clusters", () => {
+    // Two credential-equal entries but only one matches name variant rule with the seed
+    const c1 = buildCipher({ id: "1", name: "Alpha", username: "u", password: "p" });
+    const c2 = buildCipher({ id: "2", name: "Beta", username: "u", password: "p" });
+    const sets = findSets([c1, c2]);
+    expect(sets.length).toBe(0);
+  });
+
+  it("secondary pass does not re-add ciphers already consumed in credential pass", () => {
+    const c1 = buildCipher({ id: "1", name: "Demo", username: "u", password: "p" });
+    const c2 = buildCipher({ id: "2", name: "Demo (u)", username: "u", password: "p" });
+    const c3 = buildCipher({ id: "3", name: "Demo (u)", username: "u", password: "DIFF" });
+
+    const sets = findSets([c1, c2, c3]);
+    const serialized = sets.map((s) =>
+      s.ciphers
+        .map((c) => c.id)
+        .sort()
+        .join("|"),
+    );
+    const unique = new Set(serialized);
+    expect(unique.size).toBe(serialized.length);
+  });
+
+  it("does not group different usernames with same base name after deletions", () => {
+    const c1 = buildCipher({ id: "1", name: "Service", username: "alice", password: "p1" });
+    const c2 = buildCipher({ id: "2", name: "Service (alice)", username: "alice", password: "p2" });
+    const c3 = buildCipher({ id: "3", name: "Service", username: "bob", password: "p3" });
+    const c4 = buildCipher({ id: "4", name: "Service (bob)", username: "bob", password: "p4" });
+    const sets = findSets([c1, c2, c3, c4]);
+    // Expect two separate groups (alice-related, bob-related) not merged together
+    expect(sets.length).toBe(2);
+    const groupedIds = sets.map((s) => s.ciphers.map((c) => c.id).sort());
+    expect(groupedIds).toEqual(
+      expect.arrayContaining([
+        expect.arrayContaining(["1", "2"]),
+        expect.arrayContaining(["3", "4"]),
+      ]),
+    );
+    // Ensure no cross-username cluster
+    groupedIds.forEach((ids) => {
+      const usernames = ids.map(
+        (id) =>
+          ({
+            "1": "alice",
+            "2": "alice",
+            "3": "bob",
+            "4": "bob",
+          })[id]!,
+      );
+      expect(new Set(usernames).size).toBe(1);
+    });
+  });
+});

--- a/apps/web/src/app/vault/services/de-duplicate.service.ts
+++ b/apps/web/src/app/vault/services/de-duplicate.service.ts
@@ -1,0 +1,277 @@
+import { Injectable } from "@angular/core";
+import { firstValueFrom } from "rxjs";
+
+import { UserId } from "@bitwarden/common/types/guid";
+import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
+import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+import { CipherAuthorizationService } from "@bitwarden/common/vault/services/cipher-authorization.service";
+import { DialogService } from "@bitwarden/components";
+
+import {
+  DuplicateReviewDialogComponent,
+  DuplicateReviewDialogResult,
+} from "../../tools/de-duplicate/duplicate-review-dialog.component";
+import {
+  DuplicateSuccessDialogComponent,
+  DuplicateSuccessDialogData,
+} from "../../tools/de-duplicate/duplicate-success-dialog.component";
+
+interface DuplicateSet {
+  key: string; // identifies a group of duplicates (cluster)
+  ciphers: CipherView[];
+}
+
+@Injectable({
+  providedIn: "root",
+})
+export class DeDuplicateService {
+  constructor(
+    private cipherService: CipherService,
+    private dialogService: DialogService,
+    private cipherAuthorizationService: CipherAuthorizationService,
+  ) {}
+
+  /**
+   * Main entry point to find and handle duplicate ciphers for a given user.
+   * @param userId The ID of the current user.
+   * @returns A promise that resolves to the number of duplicate sets found.
+   */
+  async findAndHandleDuplicates(userId: UserId): Promise<number> {
+    const allCiphers = await this.cipherService.getAllDecrypted(userId);
+    const duplicateSets = this.findDuplicateSets(allCiphers);
+
+    if (duplicateSets.length > 0) {
+      await this.handleDuplicates(duplicateSets, userId);
+    }
+
+    return duplicateSets.length;
+  }
+
+  /**
+   * Finds groups of ciphers (clusters) that are considered duplicates.
+   * @param ciphers A list of all the user's ciphers.
+   * @returns An array of DuplicateSet objects, each representing a group of duplicates.
+   */
+  private findDuplicateSets(ciphers: CipherView[]): DuplicateSet[] {
+    const duplicateSets: DuplicateSet[] = [];
+    const consumed = new Set<string>(); // used to prevent redundant comparisons
+
+    // 1. First pass: group by exact credential matches (username, password, org, folder).
+    const credentialBuckets = this.buildCredentialBuckets(ciphers);
+    for (const bucket of credentialBuckets.values()) {
+      if (bucket.length < 2) {continue;}
+      const { clusters } = this.groupByName(bucket);
+      for (const cluster of clusters) {
+        duplicateSets.push({ key: this.clusterKey(cluster), ciphers: cluster });
+        cluster.forEach((c) => consumed.add(c.id));
+      }
+    }
+
+    // 2. Second pass: Cluster remaining ciphers by a canonical name variant.
+    // This catches duplicates with the same name/username but different passwords, in case import sources had unsynchronized passwords
+    const nameBuckets = this.buildNameBuckets(ciphers, consumed);
+    for (const bucket of nameBuckets.values()) {
+      if (bucket.length < 2) {continue;}
+      const { clusters } = this.groupByName(bucket);
+      for (const cluster of clusters) {
+        if (cluster.every((c) => consumed.has(c.id))) {continue;}
+        duplicateSets.push({ key: this.clusterKey(cluster), ciphers: cluster });
+        cluster.forEach((c) => consumed.add(c.id));
+      }
+    }
+
+    return duplicateSets;
+  }
+
+  /**
+   * Generates a display key for a cluster of duplicate ciphers.
+   * The key is either the username or the name of the first cipher in the cluster.
+   * @param cluster The group of ciphers.
+   * @returns A string key for the cluster.
+   */
+  private clusterKey(cluster: CipherView[]): string {
+    const first = cluster[0];
+    return first.login?.username || first.name || "";
+  }
+
+  /**
+   * Groups ciphers into "buckets" based on an exact match of their username, password, item name,
+   * organization, and folder.
+   * @param ciphers All the user's ciphers.
+   * @returns A Map where keys are concatenated credential strings and values are lists of matching ciphers.
+   */
+  private buildCredentialBuckets(ciphers: CipherView[]) {
+    const map = new Map<string, CipherView[]>();
+    for (const cipher of ciphers) {
+      const username = cipher.login?.username;
+      const password = cipher.login?.password;
+      if (!username || !password) {continue;}
+      const key = `${username}|${password}|${cipher.organizationId || "noOrg"}|${cipher.folderId || "noFolder"}`;
+      if (!map.has(key)) {map.set(key, []);}
+      map.get(key)!.push(cipher);
+    }
+    return map;
+  }
+
+  /**
+   * Normalizes a cipher's name by removing a trailing `(username)` suffix.
+   * e.g., "My Site (harr1424)" becomes "My Site".
+   * @param cipher The cipher to process.
+   * @returns The canonical name string.
+   */
+  private canonicalName(cipher: CipherView): string {
+    const username = cipher.login?.username || "";
+    const name = cipher.name || "";
+    const suffix = ` (${username})`;
+    return username && name.endsWith(suffix) ? name.slice(0, -suffix.length) : name;
+  }
+
+  /**
+   * Groups ciphers into "buckets" based on their canonical name, username, organization, and folder.
+   * It ignores ciphers that were already processed in the first pass (present in the 'consumed' set)
+   * @param ciphers All the user's ciphers.
+   * @param consumed A set of cipher IDs that have already been clustered.
+   * @returns A Map where keys are concatenated name strings and values are lists of matching ciphers.
+   */
+  private buildNameBuckets(ciphers: CipherView[], consumed: Set<string>) {
+    const map = new Map<string, CipherView[]>();
+    for (const cipher of ciphers) {
+      if (consumed.has(cipher.id)) {continue;}
+      if (!cipher.login) {continue;}
+      const base = this.canonicalName(cipher);
+      const key = `${base}|${cipher.login.username || "noUser"}|${cipher.organizationId || "noOrg"}|${cipher.folderId || "noFolder"}`;
+      if (!map.has(key)) {map.set(key, []);}
+      map.get(key)!.push(cipher);
+    }
+    return map;
+  }
+
+  /**
+   * A greedy algorithm to group a list of ciphers into clusters based on a name variant match.
+   * This is used in both passes of the de-duplication logic.
+   * @param list The list of ciphers to be clustered.
+   * @returns An object containing `clusters` (groups of 2 or more ciphers) and `singles` (ciphers that didn't match anything).
+   */
+  private groupByName(list: CipherView[]): { clusters: CipherView[][]; singles: CipherView[] } {
+    const unassigned = [...list];
+    const clusters: CipherView[][] = [];
+    const singles: CipherView[] = [];
+    while (unassigned.length) {
+      const seed = unassigned.shift()!;
+      const cluster = [seed];
+      for (let i = unassigned.length - 1; i >= 0; i--) {
+        const candidate = unassigned[i];
+        if (this.isDuplicateByName(seed, candidate)) {
+          cluster.push(candidate);
+          unassigned.splice(i, 1);
+        }
+      }
+      if (cluster.length > 1) {clusters.push(cluster);}
+      else {singles.push(seed);}
+    }
+    return { clusters, singles };
+  }
+
+  /**
+   * Determines if two ciphers are duplicates based on a flexible name comparison.
+   * It checks for an exact name match or a name with a `(username)` suffix.
+   * @param cipher1 The first cipher.
+   * @param cipher2 The second cipher.
+   * @returns `true` if the ciphers are duplicates by name, `false` otherwise.
+   */
+  private isDuplicateByName(cipher1: CipherView, cipher2: CipherView): boolean {
+    const username = cipher1.login?.username || "";
+    return (
+      cipher1.name === cipher2.name || // e.g.,
+      cipher1.name === `${cipher2.name} (${username})` ||
+      cipher2.name === `${cipher1.name} (${username})` //
+    );
+  }
+
+  /**
+   * Handles the user interaction and server-side deletion of identified duplicates.
+   * This method prompts the user, checks permissions, and performs batch deletions.
+   * @param duplicateSets The groups of duplicate ciphers found earlier.
+   * @param userId The ID of the current user.
+   */
+  private async handleDuplicates(duplicateSets: DuplicateSet[], userId: UserId) {
+    // 1. Open the dialog to let the user review and select duplicates to delete.
+    const dialogRef = DuplicateReviewDialogComponent.open(this.dialogService, {
+      duplicateSets,
+    });
+    const result: DuplicateReviewDialogResult | undefined = await firstValueFrom(dialogRef.closed);
+    if (!result?.confirmed || result.deleteCipherIds.length === 0) {
+      return;
+    }
+
+    // 2. Create a quick lookup map for the ciphers to be deleted.
+    const cipherIndex = new Map<string, CipherView>();
+    for (const set of duplicateSets) {
+      for (const c of set.ciphers) {
+        cipherIndex.set(c.id, c);
+      }
+    }
+
+    // 3. Filter the user's selected deletions based on their permissions.
+    // TODO: Determine why a user may not have permission to delete a cipher and explore ways of notifying them of this situation
+    const permissionChecks = result.deleteCipherIds.map(async (id) => {
+      const cipher = cipherIndex.get(id);
+      if (!cipher) {return null;}
+      const canDelete = await firstValueFrom(
+        this.cipherAuthorizationService.canDeleteCipher$(cipher),
+      );
+      return canDelete ? cipher : null;
+    });
+    const permitted = (await Promise.all(permissionChecks)).filter(
+      (c): c is CipherView => c != null,
+    );
+    if (permitted.length === 0) {
+      return;
+    }
+
+    // 4. Separate permitted deletions into soft-delete (to trash) and permanent-delete.
+    const toSoftDelete: string[] = [];
+    const toPermanentlyDelete: string[] = [];
+    for (const cipher of permitted) {
+      if (cipher.isDeleted) {
+        toPermanentlyDelete.push(cipher.id);
+      } else {
+        toSoftDelete.push(cipher.id);
+      }
+    }
+
+    // 5. Perform the server-backed deletions in batches to avoid payload limits of > 500 ciphers
+    const BATCH_SIZE = 500;
+    const processBatches = async (
+      ids: string[],
+      action: (batch: string[]) => Promise<any>,
+    ): Promise<void> => {
+      for (let i = 0; i < ids.length; i += BATCH_SIZE) {
+        const slice = ids.slice(i, i + BATCH_SIZE);
+        if (slice.length) {
+          await action(slice);
+        }
+      }
+    };
+
+    if (toSoftDelete.length > 0) {
+      await processBatches(toSoftDelete, (batch) =>
+        this.cipherService.softDeleteManyWithServer(batch, userId),
+      );
+    }
+    if (toPermanentlyDelete.length > 0) {
+      await processBatches(toPermanentlyDelete, (batch) =>
+        this.cipherService.deleteManyWithServer(batch, userId),
+      );
+    }
+
+    // 6. Show a summary dialog if any deletions occurred.
+    const summary: DuplicateSuccessDialogData = {
+      trashed: toSoftDelete.length,
+      permanentlyDeleted: toPermanentlyDelete.length,
+    };
+    if (summary.trashed > 0 || summary.permanentlyDeleted > 0) {
+      this.dialogService.open(DuplicateSuccessDialogComponent, { data: summary });
+    }
+  }
+}


### PR DESCRIPTION
## 🎟️ Tracking

https://github.com/orgs/bitwarden/discussions/15942

https://community.bitwarden.com/t/duplicate-removal-tool-report-including-merge/648

## 📔 Objective

This PR includes a service to find duplicated ciphers in a single user's vault and Ui components to display these duplicates for review and allow the user to delete them.  Duplicates are identified by identical item names (or matching canonical names) sharing the same username, folder, and organization. Such duplicates are common when importing credentials from multiple sources into a Bitwarden vault, and as the community issue above demonstrates, this is a feature that the user community has been asking for. 

## 📸 Screenshots

<img width="1209" height="1270" alt="de-duplicate-component" src="https://github.com/user-attachments/assets/cdb7103e-7b25-43c8-aefa-067f9b871a88" />

<img width="556" height="653" alt="duplicate-review-dialog" src="https://github.com/user-attachments/assets/920697ee-85ea-4c3b-b5a3-8c8a49fb4b6b" />

<img width="556" height="238" alt="duplicate-success-dialog" src="https://github.com/user-attachments/assets/bfd838f7-58aa-4fc5-ac1d-aa5351371e89" />

<img width="556" height="649" alt="second-run-duplicate-review-dialog" src="https://github.com/user-attachments/assets/016b9745-6325-4ef6-834b-7927d7e55777" />

<img width="556" height="248" alt="second-run-duplicate-success-dialog" src="https://github.com/user-attachments/assets/f5909996-0fd3-442f-840a-28f5dfdd4ff2" />

## 🌱 Next steps: 
- I will reach out to Crowdin project owners to determine the best way to integrate i18n and l10n in my contribution. I am a first-time contributor, and my current understanding after reading [documentation](https://bitwarden.com/translate) is that the project owner will need to add keys for the translated strings to the web project. Please reach out to correct me if I am wrong regarding the workflow here. 

## ⏰ Reminders before review

- Contributor guidelines followed  YES
- All formatters and local linters executed and passed  YES
- Written new unit and / or integration tests where applicable  YES, see below: 
   `clients/apps/web/src/app/vault/services/de-duplicate.service.spec.ts`
- Protected functional changes with optionality (feature flags)  NO
- Used internationalization (i18n) for all UI strings  NO, I need to research this further
- CI builds passed  N/A
- Communicated to DevOps any deployment requirements  NO
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team  NO

## 🦮 Reviewer guidelines

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱  (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
