### PR TITLE
fix(current-account-component): [Auth/PM-16263] In dark mode, browser profile icon outline is white.

### DIFF
--- a/apps/browser/src/auth/popup/account-switching/current-account.component.html
+++ b/apps/browser/src/auth/popup/account-switching/current-account.component.html
@@ -2,7 +2,7 @@
   <button
     *ngIf="currentAccount$ | async as currentAccount; else defaultButton"
     type="button"
-    class="tw-rounded-full hover:tw-outline hover:tw-outline-1 hover:tw-outline-offset-1"
+    class="tw-rounded-full hover:tw-outline hover:tw-outline-1 hover:tw-outline-offset-1 hover:tw-outline-primary-600"
     (click)="currentAccountClicked()"
   >
     <span class="tw-sr-only"> {{ "bitwardenAccount" | i18n }} {{ currentAccount.email }}</span>


### PR DESCRIPTION
## 🎟️ Tracking

[PM-16263](https://bitwarden.atlassian.net/browse/PM-16263)

## 📔 Objective

Updates the outline color of user account avatar to prefer the _primary_ theme color. This creates consistency with other element outlines for both light and dark themes.

## 📸 Screenshots

### Light 💡

Should remain unchanged.

#### Before

<img width="378" height="65" alt="PM-16263__before_light" src="https://github.com/user-attachments/assets/6320fdd9-c794-4335-aa41-72bf59319308" />

#### After

<img width="376" height="65" alt="PM-16263__after_light" src="https://github.com/user-attachments/assets/e34c7382-c0ef-4adb-b070-8151a497caf7" />

### Dark 🕶️ 

#### Before

<img width="378" height="62" alt="PM-16263__before_dark" src="https://github.com/user-attachments/assets/9b285fa4-4829-4f36-a078-cc9774809072" />

#### After

<img width="376" height="59" alt="PM-16263__after_dark" src="https://github.com/user-attachments/assets/0a9f4b8f-0f0f-477f-8ace-c0d4a22b8c93" />


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-16263]: https://bitwarden.atlassian.net/browse/PM-16263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ