### PR TITLE
Implements proof of concept for symbols for message handler keys.

### DIFF
--- a/apps/browser/src/autofill/background/notification.background.spec.ts
+++ b/apps/browser/src/autofill/background/notification.background.spec.ts
@@ -27,6 +27,7 @@ import { TaskService, SecurityTask } from "@bitwarden/common/vault/tasks";
 
 import { BrowserApi } from "../../platform/browser/browser-api";
 import { NotificationQueueMessageType } from "../enums/notification-queue-message-type.enum";
+import { SAVE_CIPHER_ATTEMPT_COMPLETED } from "../notification/abstractions/notification-bar";
 import { FormData } from "../services/abstractions/autofill.service";
 import AutofillService from "../services/autofill.service";
 import { createAutofillPageDetailsMock, createChromeTabMock } from "../spec/autofill-mocks";
@@ -834,7 +835,7 @@ describe("NotificationBackground", () => {
           expect(updateWithServerSpy).toHaveBeenCalled();
           expect(tabSendMessageDataSpy).toHaveBeenCalledWith(
             sender.tab,
-            "saveCipherAttemptCompleted",
+            SAVE_CIPHER_ATTEMPT_COMPLETED,
             {
               itemName: "testItemName",
               cipherId: cipherView.id,
@@ -883,7 +884,7 @@ describe("NotificationBackground", () => {
           expect(updateWithServerSpy).not.toHaveBeenCalled();
           expect(tabSendMessageDataSpy).not.toHaveBeenCalledWith(
             sender.tab,
-            "saveCipherAttemptCompleted",
+            SAVE_CIPHER_ATTEMPT_COMPLETED,
             {
               itemName: "testItemName",
               cipherId: cipherView.id,
@@ -962,7 +963,7 @@ describe("NotificationBackground", () => {
           expect(updateWithServerSpy).toHaveBeenCalled();
           expect(tabSendMessageDataSpy).toHaveBeenCalledWith(
             sender.tab,
-            "saveCipherAttemptCompleted",
+            SAVE_CIPHER_ATTEMPT_COMPLETED,
             {
               cipherId: "testId",
               itemName: "Test Item",
@@ -1144,7 +1145,7 @@ describe("NotificationBackground", () => {
           expect(createWithServerSpy).toHaveBeenCalled();
           expect(tabSendMessageDataSpy).toHaveBeenCalledWith(
             sender.tab,
-            "saveCipherAttemptCompleted",
+            SAVE_CIPHER_ATTEMPT_COMPLETED,
             {
               cipherId: cipherView.id,
               itemName: cipherView.name,
@@ -1198,7 +1199,7 @@ describe("NotificationBackground", () => {
           });
           expect(tabSendMessageDataSpy).toHaveBeenCalledWith(
             sender.tab,
-            "saveCipherAttemptCompleted",
+            SAVE_CIPHER_ATTEMPT_COMPLETED,
             {
               error: errorMessage,
             },
@@ -1233,7 +1234,7 @@ describe("NotificationBackground", () => {
           expect(updateWithServerSpy).toThrow(errorMessage);
           expect(tabSendMessageDataSpy).toHaveBeenCalledWith(
             sender.tab,
-            "saveCipherAttemptCompleted",
+            SAVE_CIPHER_ATTEMPT_COMPLETED,
             {
               error: errorMessage,
             },

--- a/apps/browser/src/autofill/background/notification.background.ts
+++ b/apps/browser/src/autofill/background/notification.background.ts
@@ -61,6 +61,7 @@ import {
 } from "../content/components/cipher/types";
 import { CollectionView } from "../content/components/common-types";
 import { NotificationQueueMessageType } from "../enums/notification-queue-message-type.enum";
+import { SAVE_CIPHER_ATTEMPT_COMPLETED } from "../notification/abstractions/notification-bar";
 import { AutofillService } from "../services/abstractions/autofill.service";
 import { TemporaryNotificationChangeLoginService } from "../services/notification-change-login-password.service";
 
@@ -779,7 +780,7 @@ export default class NotificationBackground {
     if (message.success) {
       await this.saveOrUpdateCredentials(message.tab, false, undefined, true);
     } else {
-      await BrowserApi.tabSendMessageData(message.tab, "saveCipherAttemptCompleted", {
+      await BrowserApi.tabSendMessageData(message.tab, SAVE_CIPHER_ATTEMPT_COMPLETED, {
         error: "Password reprompt failed",
       });
       return;
@@ -864,13 +865,13 @@ export default class NotificationBackground {
       const { cipher } = encrypted;
       try {
         await this.cipherService.createWithServer(encrypted);
-        await BrowserApi.tabSendMessageData(tab, "saveCipherAttemptCompleted", {
+        await BrowserApi.tabSendMessageData(tab, SAVE_CIPHER_ATTEMPT_COMPLETED, {
           itemName: newCipher?.name && String(newCipher?.name),
           cipherId: cipher?.id && String(cipher?.id),
         });
         await BrowserApi.tabSendMessage(tab, { command: "addedCipher" });
       } catch (error) {
-        await BrowserApi.tabSendMessageData(tab, "saveCipherAttemptCompleted", {
+        await BrowserApi.tabSendMessageData(tab, SAVE_CIPHER_ATTEMPT_COMPLETED, {
           error: error?.message && String(error.message),
         });
       }
@@ -936,7 +937,7 @@ export default class NotificationBackground {
 
       await this.cipherService.updateWithServer(cipher);
 
-      await BrowserApi.tabSendMessageData(tab, "saveCipherAttemptCompleted", {
+      await BrowserApi.tabSendMessageData(tab, SAVE_CIPHER_ATTEMPT_COMPLETED, {
         itemName: cipherView?.name && String(cipherView?.name),
         cipherId: cipherView?.id && String(cipherView.id),
         task: taskData,
@@ -954,7 +955,7 @@ export default class NotificationBackground {
         );
       }
     } catch (error) {
-      await BrowserApi.tabSendMessageData(tab, "saveCipherAttemptCompleted", {
+      await BrowserApi.tabSendMessageData(tab, SAVE_CIPHER_ATTEMPT_COMPLETED, {
         error: error?.message && String(error.message),
       });
     }

--- a/apps/browser/src/autofill/notification/abstractions/notification-bar.ts
+++ b/apps/browser/src/autofill/notification/abstractions/notification-bar.ts
@@ -36,7 +36,7 @@ type NotificationBarIframeInitData = {
 };
 
 type NotificationBarWindowMessage = {
-  command: string;
+  command: symbol;
   data?: {
     cipherId?: string;
     task?: NotificationTaskInfo;
@@ -46,10 +46,13 @@ type NotificationBarWindowMessage = {
   initData?: NotificationBarIframeInitData;
 };
 
+export const INIT_NOTIFICATION_BAR = Symbol("initNotificationBar");
+export const SAVE_CIPHER_ATTEMPT_COMPLETED = Symbol("saveCipherAttemptCompleted");
+
 type NotificationBarWindowMessageHandlers = {
-  [key: string]: CallableFunction;
-  initNotificationBar: ({ message }: { message: NotificationBarWindowMessage }) => void;
-  saveCipherAttemptCompleted: ({ message }: { message: NotificationBarWindowMessage }) => void;
+  [key: symbol]: CallableFunction;
+  [INIT_NOTIFICATION_BAR]: ({ message }: { message: NotificationBarWindowMessage }) => void;
+  [SAVE_CIPHER_ATTEMPT_COMPLETED]: ({ message }: { message: NotificationBarWindowMessage }) => void;
 };
 
 type AtRiskPasswordNotificationParams = {

--- a/apps/browser/src/autofill/notification/bar.ts
+++ b/apps/browser/src/autofill/notification/bar.ts
@@ -21,6 +21,8 @@ import {
   NotificationBarIframeInitData,
   NotificationType,
   NotificationTypes,
+  INIT_NOTIFICATION_BAR,
+  SAVE_CIPHER_ATTEMPT_COMPLETED,
 } from "./abstractions/notification-bar";
 
 const logService = new ConsoleLogService(false);
@@ -29,8 +31,8 @@ let windowMessageOrigin: string;
 let useComponentBar = false;
 
 const notificationBarWindowMessageHandlers: NotificationBarWindowMessageHandlers = {
-  initNotificationBar: ({ message }) => initNotificationBar(message),
-  saveCipherAttemptCompleted: ({ message }) =>
+  [INIT_NOTIFICATION_BAR]: ({ message }) => initNotificationBar(message),
+  [SAVE_CIPHER_ATTEMPT_COMPLETED]: ({ message }) =>
     useComponentBar
       ? handleSaveCipherConfirmation(message)
       : handleSaveCipherAttemptCompletedMessage(message),
@@ -51,7 +53,7 @@ function applyNotificationBarStyle() {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     require("./bar.scss");
   }
-  postMessageToParent({ command: "initNotificationBar" });
+  postMessageToParent({ command: INIT_NOTIFICATION_BAR });
 }
 
 function getI18n() {

--- a/apps/browser/src/autofill/overlay/notifications/content/overlay-notifications-content.service.spec.ts
+++ b/apps/browser/src/autofill/overlay/notifications/content/overlay-notifications-content.service.spec.ts
@@ -1,6 +1,10 @@
 import { mock, MockProxy } from "jest-mock-extended";
 
 import AutofillInit from "../../../content/autofill-init";
+import {
+  INIT_NOTIFICATION_BAR,
+  SAVE_CIPHER_ATTEMPT_COMPLETED,
+} from "../../../notification/abstractions/notification-bar";
 import { DomQueryService } from "../../../services/abstractions/dom-query.service";
 import DomElementVisibilityService from "../../../services/dom-element-visibility.service";
 import { flushPromises, sendMockExtensionMessage } from "../../../spec/testing-utils";
@@ -171,7 +175,7 @@ describe("OverlayNotificationsContentService", () => {
       );
       globalThis.dispatchEvent(
         new MessageEvent("message", {
-          data: { command: "initNotificationBar" },
+          data: { command: INIT_NOTIFICATION_BAR },
           source: overlayNotificationsContentService["notificationBarIframeElement"]?.contentWindow,
         }),
       );
@@ -180,7 +184,7 @@ describe("OverlayNotificationsContentService", () => {
       expect(postMessageSpy).toHaveBeenCalledTimes(1);
       expect(postMessageSpy).toHaveBeenCalledWith(
         {
-          command: "initNotificationBar",
+          command: INIT_NOTIFICATION_BAR,
           initData: expect.any(Object),
         },
         "*",
@@ -277,7 +281,7 @@ describe("OverlayNotificationsContentService", () => {
       expect(
         overlayNotificationsContentService["notificationBarIframeElement"].contentWindow
           .postMessage,
-      ).toHaveBeenCalledWith({ command: "saveCipherAttemptCompleted", error: undefined }, "*");
+      ).toHaveBeenCalledWith({ command: SAVE_CIPHER_ATTEMPT_COMPLETED, error: undefined }, "*");
     });
   });
 

--- a/apps/browser/src/autofill/overlay/notifications/content/overlay-notifications-content.service.ts
+++ b/apps/browser/src/autofill/overlay/notifications/content/overlay-notifications-content.service.ts
@@ -3,9 +3,11 @@
 import { EVENTS } from "@bitwarden/common/autofill/constants";
 
 import {
+  INIT_NOTIFICATION_BAR,
   NotificationBarIframeInitData,
   NotificationType,
   NotificationTypes,
+  SAVE_CIPHER_ATTEMPT_COMPLETED,
 } from "../../../notification/abstractions/notification-bar";
 import { sendExtensionMessage, setElementStyles } from "../../../utils";
 import {
@@ -155,7 +157,7 @@ export class OverlayNotificationsContentService
     const { error, ...otherData } = message?.data || {};
 
     this.sendMessageToNotificationBarIframe({
-      command: "saveCipherAttemptCompleted",
+      command: SAVE_CIPHER_ATTEMPT_COMPLETED,
       data: Object.keys(otherData).length ? otherData : undefined,
       error,
     });
@@ -253,12 +255,12 @@ export class OverlayNotificationsContentService
       const { source, data } = event;
       if (
         source !== this.notificationBarIframeElement.contentWindow ||
-        data?.command !== "initNotificationBar"
+        data?.command !== INIT_NOTIFICATION_BAR
       ) {
         return;
       }
 
-      this.sendMessageToNotificationBarIframe({ command: "initNotificationBar", initData });
+      this.sendMessageToNotificationBarIframe({ command: INIT_NOTIFICATION_BAR, initData });
       globalThis.removeEventListener("message", handleInitNotificationBarMessage);
     };
 

--- a/apps/browser/src/platform/browser/browser-api.ts
+++ b/apps/browser/src/platform/browser/browser-api.ts
@@ -267,7 +267,7 @@ export class BrowserApi {
 
   static tabSendMessageData(
     tab: chrome.tabs.Tab,
-    command: string,
+    command: string | symbol,
     data: any = null,
   ): Promise<void> {
     const obj: any = {


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This implements a basic proof of concept for using the `Symbol` type for browser extension message handler keys.

The current implementation (string keys) has some weaknesses fixed by using Symbols:

- Strings are not traceable through the code base. 

By abstracting the keys into symbol, a Visual Studio Code user can "Find all references" and see every part of the extension which sends a message with that command. Currently, a user must grep the codebase for `"<messageHandlerName>"` as a string to locate these calls. 

- String values are not unique

By ensuring we always reference a symbol, we avoid possible collisions with other strings with the same value (translation strings come to mind). This also limits the possibility that a command becomes out of sync through a spelling error or otherwise. While its possible to define a enum-like const that would have similar qualities while retaining string commands, it would unnecessary lengthen the handlers and require unique namespaces (e.g. `NOTIFICATION_CONTENT_MESSAGE_HANDLERS.SAVE_CIPHER_ATTEMPT_COMPLETED`) whereas symbols are much shorter, their ultimate syntax can be up for debate but screaming snake case is utilized in this example.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

Improved developer ergonomics example: 

1. Come across a relevant example of the command symbol. 
2. Find all references to the command symbol.
3. Go to definition of the command symbol.
4. Find all implementations of the handler type (takes user directly to the class with listeners that respond to the command)

https://github.com/user-attachments/assets/2e0b9f41-107d-492a-8ff0-f5de8fe46b9e


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
