### PR TITLE
Add feature flag to short-circuit the passkey provider

### DIFF
--- a/apps/desktop/src/autofill/services/desktop-autofill.service.ts
+++ b/apps/desktop/src/autofill/services/desktop-autofill.service.ts
@@ -191,6 +191,14 @@ export class DesktopAutofillService implements OnDestroy {
 
   listenIpc() {
     ipc.autofill.listenPasskeyRegistration(async (clientId, sequenceNumber, request, callback) => {
+      if (!(await this.configService.getFeatureFlag(FeatureFlag.MacOsNativeCredentialSync))) {
+        this.logService.debug(
+          "listenPasskeyRegistration: MacOsNativeCredentialSync feature flag is disabled",
+        );
+        callback(new Error("MacOsNativeCredentialSync feature flag is disabled"), null);
+        return;
+      }
+
       this.registrationRequest = request;
 
       this.logService.warning("listenPasskeyRegistration", clientId, sequenceNumber, request);
@@ -217,6 +225,14 @@ export class DesktopAutofillService implements OnDestroy {
 
     ipc.autofill.listenPasskeyAssertionWithoutUserInterface(
       async (clientId, sequenceNumber, request, callback) => {
+        if (!(await this.configService.getFeatureFlag(FeatureFlag.MacOsNativeCredentialSync))) {
+          this.logService.debug(
+            "listenPasskeyAssertionWithoutUserInterface: MacOsNativeCredentialSync feature flag is disabled",
+          );
+          callback(new Error("MacOsNativeCredentialSync feature flag is disabled"), null);
+          return;
+        }
+
         this.logService.warning(
           "listenPasskeyAssertion without user interface",
           clientId,
@@ -276,6 +292,14 @@ export class DesktopAutofillService implements OnDestroy {
     );
 
     ipc.autofill.listenPasskeyAssertion(async (clientId, sequenceNumber, request, callback) => {
+      if (!(await this.configService.getFeatureFlag(FeatureFlag.MacOsNativeCredentialSync))) {
+        this.logService.debug(
+          "listenPasskeyAssertion: MacOsNativeCredentialSync feature flag is disabled",
+        );
+        callback(new Error("MacOsNativeCredentialSync feature flag is disabled"), null);
+        return;
+      }
+
       this.logService.warning("listenPasskeyAssertion", clientId, sequenceNumber, request);
 
       const controller = new AbortController();
@@ -295,6 +319,13 @@ export class DesktopAutofillService implements OnDestroy {
 
     // Listen for native status messages
     ipc.autofill.listenNativeStatus(async (clientId, sequenceNumber, status) => {
+      if (!(await this.configService.getFeatureFlag(FeatureFlag.MacOsNativeCredentialSync))) {
+        this.logService.debug(
+          "listenNativeStatus: MacOsNativeCredentialSync feature flag is disabled",
+        );
+        return;
+      }
+
       this.logService.info("Received native status", status.key, status.value);
       if (status.key === "request-sync") {
         // perform ad-hoc sync


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-22581

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

This PR adds a feature flag that short-circuits macos passkey operations.
Bitwarden will still show up as a passkey provider in the macos settings, regardless to the flag value.

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
