### PR TITLE
[PM-24689] Handle possible null active account

### DIFF
--- a/libs/common/src/vault/services/restricted-item-types.service.spec.ts
+++ b/libs/common/src/vault/services/restricted-item-types.service.spec.ts
@@ -67,6 +67,13 @@ describe("RestrictedItemTypesService", () => {
     expect(result).toEqual([]);
   });
 
+  it("emits empty array if no account is active", async () => {
+    accountService.activeAccount$ = of(null);
+
+    const result = await firstValueFrom(service.restricted$);
+    expect(result).toEqual([]);
+  });
+
   it("emits empty array if no organizations exist", async () => {
     organizationService.organizations$.mockReturnValue(of([]));
     policyService.policiesByType$.mockReturnValue(of([]));


### PR DESCRIPTION
## 🎟️ Tracking

[PM-24689](https://bitwarden.atlassian.net/browse/PM-24689)

## 📔 Objective

The `restricted$` observable internally subscribes to `activeAccount$` (instead of accepting a userId) and needs to consider if the active user is null (e.g. during logout).

## 📸 Screenshots


https://github.com/user-attachments/assets/69851939-1e0c-4df8-bed5-2543575708a6



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-24689]: https://bitwarden.atlassian.net/browse/PM-24689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ