### PR TITLE
[PM-24082] - Unauthorized Password Visibility in Bitwarden Desktop App

### DIFF
--- a/libs/vault/src/cipher-view/login-credentials/login-credentials-view.component.html
+++ b/libs/vault/src/cipher-view/login-credentials/login-credentials-view.component.html
@@ -36,6 +36,7 @@
         [ngClass]="{ 'tw-hidden': passwordRevealed }"
         readonly
         bitInput
+        #passwordInput
         type="password"
         [value]="cipher.login.password"
         aria-readonly="true"

--- a/libs/vault/src/cipher-view/login-credentials/login-credentials-view.component.ts
+++ b/libs/vault/src/cipher-view/login-credentials/login-credentials-view.component.ts
@@ -3,12 +3,14 @@
 import { CommonModule, DatePipe } from "@angular/common";
 import {
   Component,
+  ElementRef,
   EventEmitter,
   inject,
   Input,
   OnChanges,
   Output,
   SimpleChanges,
+  ViewChild,
 } from "@angular/core";
 import { Observable, switchMap } from "rxjs";
 
@@ -61,6 +63,8 @@ export class LoginCredentialsViewComponent implements OnChanges {
   @Input() activeUserId: UserId;
   @Input() hadPendingChangePasswordTask: boolean;
   @Output() handleChangePassword = new EventEmitter<void>();
+  @ViewChild("passwordInput")
+  private passwordInput!: ElementRef<HTMLInputElement>;
 
   isPremium$: Observable<boolean> = this.accountService.activeAccount$.pipe(
     switchMap((account) =>
@@ -92,6 +96,10 @@ export class LoginCredentialsViewComponent implements OnChanges {
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes["cipher"]) {
+      if (this.passwordInput?.nativeElement) {
+        // Reset password input type in case it's been toggled
+        this.passwordInput.nativeElement.type = "password";
+      }
       this.passwordRevealed = false;
       this.showPasswordCount = false;
     }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-24082

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR fixes an issue where, in the desktop app in the cipher view, if the password visibility was toggled on and the user selected a cipher from a different org, the password visibility state would remain visible. This was due to the password input field type not being reset.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
### Before

https://github.com/user-attachments/assets/2f3c06be-73ac-4ae6-b9b7-50c833f4a062


### After 

https://github.com/user-attachments/assets/226a46f0-b8f1-4a8c-b4fd-fbb28320139f





## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
