### PR TITLE
[PM-22987] Hide download for corrupt attachments

### DIFF
--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -702,6 +702,12 @@
   "attachmentSaved": {
     "message": "Attachment saved"
   },
+  "addAttachment": {
+    "message": "Add attachment"
+  },
+  "maxFileSizeSansPunctuation": {
+    "message": "Maximum file size is 500 MB"
+  },
   "file": {
     "message": "File"
   },

--- a/libs/vault/src/cipher-form/components/attachments/delete-attachment/delete-attachment.component.ts
+++ b/libs/vault/src/cipher-form/components/attachments/delete-attachment/delete-attachment.component.ts
@@ -29,7 +29,7 @@ export class DeleteAttachmentComponent {
   /** The attachment that is can be deleted */
   @Input({ required: true }) attachment!: AttachmentView;
 
-  /** Whether the attachemnt is being accessed from the admin console */
+  /** Whether the attachment is being accessed from the admin console */
   @Input() admin: boolean = false;
 
   /** Emits when the attachment is successfully deleted */

--- a/libs/vault/src/components/download-attachment/download-attachment.component.html
+++ b/libs/vault/src/components/download-attachment/download-attachment.component.html
@@ -1,4 +1,5 @@
 <button
+  *ngIf="!isDecryptionFailure"
   [bitAction]="download"
   bitIconButton="bwi-download"
   buttonType="main"

--- a/libs/vault/src/components/download-attachment/download-attachment.component.spec.ts
+++ b/libs/vault/src/components/download-attachment/download-attachment.component.spec.ts
@@ -5,6 +5,7 @@ import { BehaviorSubject } from "rxjs";
 
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import { EncryptService } from "@bitwarden/common/key-management/crypto/abstractions/encrypt.service";
+import { DECRYPT_ERROR } from "@bitwarden/common/key-management/crypto/models/enc-string";
 import { ErrorResponse } from "@bitwarden/common/models/response/error.response";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { FileDownloadService } from "@bitwarden/common/platform/abstractions/file-download/file-download.service";
@@ -119,6 +120,13 @@ describe("DownloadAttachmentComponent", () => {
       // Request is not defined in the Jest runtime
       // eslint-disable-next-line no-global-assign
       Request = MockRequest as any;
+    });
+
+    it("hides download button when the attachment has decryption failure", () => {
+      component.attachment.fileName = DECRYPT_ERROR;
+      fixture.detectChanges();
+
+      expect(fixture.debugElement.query(By.css("button"))).toBeNull();
     });
 
     it("uses the attachment url when available when getAttachmentData returns a 404", async () => {

--- a/libs/vault/src/components/download-attachment/download-attachment.component.ts
+++ b/libs/vault/src/components/download-attachment/download-attachment.component.ts
@@ -6,6 +6,7 @@ import { firstValueFrom } from "rxjs";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
+import { DECRYPT_ERROR } from "@bitwarden/common/key-management/crypto/models/enc-string";
 import { ErrorResponse } from "@bitwarden/common/models/response/error.response";
 import { FileDownloadService } from "@bitwarden/common/platform/abstractions/file-download/file-download.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
@@ -45,6 +46,10 @@ export class DownloadAttachmentComponent {
     private stateProvider: StateProvider,
     private cipherService: CipherService,
   ) {}
+
+  protected get isDecryptionFailure(): boolean {
+    return this.attachment.fileName === DECRYPT_ERROR;
+  }
 
   /** Download the attachment */
   download = async () => {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-22987](https://bitwarden.atlassian.net/browse/PM-22987)

## 📔 Objective

When an attachment cannot be decrypted hide the ability to download it. 
- Also noticed that the desktop was missing some translations for the add attachment dialog. Tacked those on here too.

The scenario for a user to end up in this spot has sense been fixed, I made some notes in the `QA testing notes` of the ticket if you'd like to test locally. 

## 📸 Screenshots

|Desktop|Web|Extension|
|-|-|-|
|<video src="https://github.com/user-attachments/assets/63e54f83-7351-4743-89fa-852af2409626"/>|<video src="https://github.com/user-attachments/assets/4dd745a6-a593-4685-8478-ea47c633aae5"/>|<video src="https://github.com/user-attachments/assets/81651d64-4d9e-4afe-acd7-d18d9dcee0ce" />|


## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes



[PM-22987]: https://bitwarden.atlassian.net/browse/PM-22987?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ