### PR TITLE
[PM-24710] Add a debounceTime to autofill currentPageDetails 

### DIFF
--- a/apps/browser/src/vault/popup/services/vault-popup-autofill.service.ts
+++ b/apps/browser/src/vault/popup/services/vault-popup-autofill.service.ts
@@ -4,6 +4,7 @@ import { Injectable } from "@angular/core";
 import { ActivatedRoute } from "@angular/router";
 import {
   combineLatest,
+  debounceTime,
   firstValueFrom,
   map,
   Observable,
@@ -164,6 +165,7 @@ export class VaultPopupAutofillService {
         }),
       );
     }),
+    debounceTime(50),
     shareReplay({ refCount: false, bufferSize: 1 }),
   );
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-24710](https://bitwarden.atlassian.net/browse/PM-24710)

## 📔 Objective

The `this.autofillService.collectPageDetailsFromTab$(tab)` method never completes and is constantly collecting page details from the current tab and appending them to a list of `pageDetails`. All the relevant fields are normally collected in a few ms and made available before its ever needed to be called by user interaction. 

However, when initiating an autofill from a overlay/content script that has master password reprompt, the page details are `firstValuedFrom` when the [view component first loads](https://github.com/bitwarden/clients/blob/41ad0a7ef9b8f53149ce0161bb7a7afeb72d0785/apps/browser/src/vault/popup/components/vault-v2/view-v2/view-v2.component.ts#L154) which doesn't give enough time for the page details to always be collected.

https://github.com/bitwarden/clients/pull/15431 recently modified the order at which we call the load action, and it changed the timing and revealed this problem. Adding the `debounceTime(50)` ensure's we always wait at least 50ms from the last collected page detail before we attempt processing the entire list.

## 📸 Screenshots

https://github.com/user-attachments/assets/4a663d9f-c991-4cfc-88e2-e15841cb4727


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
