### PR TITLE
[PM-24777] Remove Object.assign call in fromCollectionView

### DIFF
--- a/libs/admin-console/src/common/collections/models/collection.ts
+++ b/libs/admin-console/src/common/collections/models/collection.ts
@@ -55,14 +55,19 @@ export class Collection extends Domain {
     encryptService: EncryptService,
     orgKey: OrgKey,
   ): Promise<Collection> {
-    return Object.assign(
-      new Collection({
-        name: await encryptService.encryptString(view.name, orgKey),
-        id: view.id,
-        organizationId: view.organizationId,
-      }),
-      view,
-    );
+    const collection = new Collection({
+      name: await encryptService.encryptString(view.name, orgKey),
+      id: view.id,
+      organizationId: view.organizationId,
+    });
+
+    collection.externalId = view.externalId;
+    collection.readOnly = view.readOnly;
+    collection.hidePasswords = view.hidePasswords;
+    collection.manage = view.manage;
+    collection.type = view.type;
+
+    return collection;
   }
 
   decrypt(orgKey: OrgKey, encryptService: EncryptService): Promise<CollectionView> {

--- a/libs/admin-console/src/common/collections/models/collection.view.ts
+++ b/libs/admin-console/src/common/collections/models/collection.view.ts
@@ -102,12 +102,15 @@ export class CollectionView implements View, ITreeNodeObject {
     encryptService: EncryptService,
     key: OrgKey,
   ): Promise<CollectionView> {
-    const view: CollectionView = Object.assign(
-      new CollectionView({ ...collection, name: "" }),
-      collection,
-    );
+    const view = new CollectionView({ ...collection, name: "" });
+
     view.name = await encryptService.decryptString(collection.name, key);
     view.assigned = true;
+    view.externalId = collection.externalId;
+    view.readOnly = collection.readOnly;
+    view.hidePasswords = collection.hidePasswords;
+    view.manage = collection.manage;
+    view.type = collection.type;
     return view;
   }
 


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-24777
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
This pr fixes an issue introduced in the Ts-strict work for collection domain models. In this case, the `Object.assign` call here is incorrectly overriding the name we gave in the constructor.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
