### PR TITLE
[PM-22309] Resolve TypeScript 5.8 blockers for tool owned files

### DIFF
--- a/libs/common/src/tools/state/buffered-state.ts
+++ b/libs/common/src/tools/state/buffered-state.ts
@@ -73,7 +73,7 @@ export class BufferedState<Input, Output, Dependency> implements SingleUserState
   private async overwriteOutput(dependency: Dependency) {
     // take the latest value from the buffer
     let buffered: Input;
-    await this.bufferedState.update((state: Input | null): Input | null => {
+    await this.bufferedState.update((state): Input | null => {
       buffered = state ?? null;
       return null;
     });

--- a/libs/common/src/tools/state/buffered-state.ts
+++ b/libs/common/src/tools/state/buffered-state.ts
@@ -45,12 +45,14 @@ export class BufferedState<Input, Output, Dependency> implements SingleUserState
       map((dependency) => [key.shouldOverwrite(dependency), dependency] as const),
     );
     const overwrite$ = combineLatest([hasValue$, overwriteDependency$]).pipe(
-      concatMap(async ([hasValue, [shouldOverwrite, dependency]]) => {
-        if (hasValue && shouldOverwrite) {
-          await this.overwriteOutput(dependency);
-        }
-        return [false, null] as const;
-      }),
+      concatMap(
+        async ([hasValue, [shouldOverwrite, dependency]]): Promise<readonly [false, null]> => {
+          if (hasValue && shouldOverwrite) {
+            await this.overwriteOutput(dependency);
+          }
+          return [false, null] as const;
+        },
+      ),
     );
 
     // drive overwrites only when there's a subscription;
@@ -71,7 +73,7 @@ export class BufferedState<Input, Output, Dependency> implements SingleUserState
   private async overwriteOutput(dependency: Dependency) {
     // take the latest value from the buffer
     let buffered: Input;
-    await this.bufferedState.update((state) => {
+    await this.bufferedState.update((state: Input | null): Input | null => {
       buffered = state ?? null;
       return null;
     });

--- a/libs/tools/generator/extensions/legacy/src/legacy-password-generation.service.ts
+++ b/libs/tools/generator/extensions/legacy/src/legacy-password-generation.service.ts
@@ -345,7 +345,8 @@ export class LegacyPasswordGenerationService implements PasswordGenerationServic
       timeout({
         // timeout after 1 second
         each: 1000,
-        with() {
+        // TODO(PM-22309): Typescript 5.8 update, confirm type
+        with(): any[] {
           return [];
         },
       }),
@@ -370,7 +371,8 @@ export class LegacyPasswordGenerationService implements PasswordGenerationServic
       timeout({
         // timeout after 1 second
         each: 1000,
-        with() {
+        // TODO(PM-22309): Typescript 5.8 update, confirm type
+        with(): any[] {
           return [];
         },
       }),


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-22309

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Adds explicit return types that TypeScript complains about being inferred in 5.8.

```
libs/common/src/tools/state/buffered-state.ts:48:17 - error TS7011: Function expression, which lacks return-type annotation, implicitly has an 'readonly [false, any]' return type.
48       concatMap(async ([hasValue, [shouldOverwrite, dependency]]) => {

libs/common/src/tools/state/buffered-state.ts:74:37 - error TS7011: Function expression, which lacks return-type annotation, implicitly has an 'any' return type.
74     await this.bufferedState.update((state) => {

libs/tools/generator/extensions/legacy/src/legacy-password-generation.service.ts:348:9 - error TS7010: 'with', which lacks return-type annotation, implicitly has an 'any[]' return type.
348         with() {

libs/tools/generator/extensions/legacy/src/legacy-password-generation.service.ts:373:9 - error TS7010: 'with', which lacks return-type annotation, implicitly has an 'any[]' return type.
373         with() {
```

I added `todos` to two places where the suggested type is `any[]` since we'd probably want to refine the type in the future.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
