### PR TITLE
[PM-22371] remove end user activation flag

### DIFF
--- a/apps/web/src/app/vault/components/setup-extension/setup-extension.component.spec.ts
+++ b/apps/web/src/app/vault/components/setup-extension/setup-extension.component.spec.ts
@@ -5,8 +5,6 @@ import { BehaviorSubject } from "rxjs";
 
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { DeviceType } from "@bitwarden/common/enums";
-import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
-import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
@@ -22,7 +20,6 @@ describe("SetupExtensionComponent", () => {
   let fixture: ComponentFixture<SetupExtensionComponent>;
   let component: SetupExtensionComponent;
 
-  const getFeatureFlag = jest.fn().mockResolvedValue(false);
   const navigate = jest.fn().mockResolvedValue(true);
   const openExtension = jest.fn().mockResolvedValue(true);
   const update = jest.fn().mockResolvedValue(true);
@@ -34,14 +31,12 @@ describe("SetupExtensionComponent", () => {
     openExtension.mockClear();
     update.mockClear();
     setAnonLayoutWrapperData.mockClear();
-    getFeatureFlag.mockClear().mockResolvedValue(true);
     window.matchMedia = jest.fn().mockReturnValue(false);
 
     await TestBed.configureTestingModule({
       imports: [SetupExtensionComponent, RouterModule.forRoot([])],
       providers: [
         { provide: I18nService, useValue: { t: (key: string) => key } },
-        { provide: ConfigService, useValue: { getFeatureFlag } },
         { provide: WebBrowserInteractionService, useValue: { extensionInstalled$, openExtension } },
         { provide: PlatformUtilsService, useValue: { getDevice: () => DeviceType.UnknownBrowser } },
         { provide: AnonLayoutWrapperDataService, useValue: { setAnonLayoutWrapperData } },
@@ -74,19 +69,8 @@ describe("SetupExtensionComponent", () => {
   });
 
   describe("initialization", () => {
-    it("redirects to the vault if the feature flag is disabled", async () => {
-      Utils.isMobileBrowser = false;
-      getFeatureFlag.mockResolvedValue(false);
-      navigate.mockClear();
-
-      await component.ngOnInit();
-
-      expect(navigate).toHaveBeenCalledWith(["/vault"]);
-    });
-
     it("redirects to the vault if the user is on a mobile browser", async () => {
       Utils.isMobileBrowser = true;
-      getFeatureFlag.mockResolvedValue(true);
       navigate.mockClear();
 
       await component.ngOnInit();
@@ -96,12 +80,10 @@ describe("SetupExtensionComponent", () => {
 
     it("does not redirect the user", async () => {
       Utils.isMobileBrowser = false;
-      getFeatureFlag.mockResolvedValue(true);
       navigate.mockClear();
 
       await component.ngOnInit();
 
-      expect(getFeatureFlag).toHaveBeenCalledWith(FeatureFlag.PM19315EndUserActivationMvp);
       expect(navigate).not.toHaveBeenCalled();
     });
   });

--- a/apps/web/src/app/vault/components/setup-extension/setup-extension.component.ts
+++ b/apps/web/src/app/vault/components/setup-extension/setup-extension.component.ts
@@ -7,8 +7,6 @@ import { firstValueFrom, pairwise, startWith } from "rxjs";
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { getUserId } from "@bitwarden/common/auth/services/account.service";
-import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
-import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { StateProvider } from "@bitwarden/common/platform/state";
@@ -59,7 +57,6 @@ type SetupExtensionState = UnionOfValues<typeof SetupExtensionState>;
 })
 export class SetupExtensionComponent implements OnInit, OnDestroy {
   private webBrowserExtensionInteractionService = inject(WebBrowserInteractionService);
-  private configService = inject(ConfigService);
   private router = inject(Router);
   private destroyRef = inject(DestroyRef);
   private platformUtilsService = inject(PlatformUtilsService);
@@ -134,12 +131,9 @@ export class SetupExtensionComponent implements OnInit, OnDestroy {
 
   /** Conditionally redirects the user to the vault upon landing on the page. */
   async conditionallyRedirectUser() {
-    const isFeatureEnabled = await this.configService.getFeatureFlag(
-      FeatureFlag.PM19315EndUserActivationMvp,
-    );
     const isMobile = Utils.isMobileBrowser;
 
-    if (!isFeatureEnabled || isMobile) {
+    if (isMobile) {
       await this.dismissExtensionPage();
       await this.router.navigate(["/vault"]);
     }

--- a/apps/web/src/app/vault/guards/setup-extension-redirect.guard.spec.ts
+++ b/apps/web/src/app/vault/guards/setup-extension-redirect.guard.spec.ts
@@ -4,8 +4,6 @@ import { BehaviorSubject } from "rxjs";
 
 import { VaultProfileService } from "@bitwarden/angular/vault/services/vault-profile.service";
 import { Account, AccountService } from "@bitwarden/common/auth/abstractions/account.service";
-import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
-import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { StateProvider } from "@bitwarden/common/platform/state";
 
@@ -27,26 +25,17 @@ describe("setupExtensionRedirectGuard", () => {
   const extensionInstalled$ = new BehaviorSubject<boolean>(false);
   const state$ = new BehaviorSubject<boolean>(false);
   const createUrlTree = jest.fn();
-  const getFeatureFlag = jest.fn().mockImplementation((key) => {
-    if (key === FeatureFlag.PM19315EndUserActivationMvp) {
-      return Promise.resolve(true);
-    }
-
-    return Promise.resolve(false);
-  });
   const getProfileCreationDate = jest.fn().mockResolvedValue(seventeenDaysAgo);
 
   beforeEach(() => {
     Utils.isMobileBrowser = false;
 
-    getFeatureFlag.mockClear();
     getProfileCreationDate.mockClear();
     createUrlTree.mockClear();
 
     TestBed.configureTestingModule({
       providers: [
         { provide: Router, useValue: { createUrlTree } },
-        { provide: ConfigService, useValue: { getFeatureFlag } },
         { provide: AccountService, useValue: { activeAccount$ } },
         { provide: StateProvider, useValue: { getUser: () => ({ state$ }) } },
         { provide: WebBrowserInteractionService, useValue: { extensionInstalled$ } },
@@ -77,12 +66,6 @@ describe("setupExtensionRedirectGuard", () => {
 
   it("returns `true` when the profile check fails", async () => {
     getProfileCreationDate.mockRejectedValueOnce(new Error("Profile check failed"));
-
-    expect(await setupExtensionGuard()).toBe(true);
-  });
-
-  it("returns `true` when the feature flag is disabled", async () => {
-    getFeatureFlag.mockResolvedValueOnce(false);
 
     expect(await setupExtensionGuard()).toBe(true);
   });

--- a/apps/web/src/app/vault/guards/setup-extension-redirect.guard.ts
+++ b/apps/web/src/app/vault/guards/setup-extension-redirect.guard.ts
@@ -4,8 +4,6 @@ import { firstValueFrom, map } from "rxjs";
 
 import { VaultProfileService } from "@bitwarden/angular/vault/services/vault-profile.service";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
-import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
-import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
 import {
   SETUP_EXTENSION_DISMISSED_DISK,
@@ -26,7 +24,6 @@ export const SETUP_EXTENSION_DISMISSED = new UserKeyDefinition<boolean>(
 
 export const setupExtensionRedirectGuard: CanActivateFn = async () => {
   const router = inject(Router);
-  const configService = inject(ConfigService);
   const accountService = inject(AccountService);
   const vaultProfileService = inject(VaultProfileService);
   const stateProvider = inject(StateProvider);
@@ -34,13 +31,9 @@ export const setupExtensionRedirectGuard: CanActivateFn = async () => {
 
   const isMobile = Utils.isMobileBrowser;
 
-  const endUserFeatureEnabled = await configService.getFeatureFlag(
-    FeatureFlag.PM19315EndUserActivationMvp,
-  );
-
   // The extension page isn't applicable for mobile users, do not redirect them.
   // Include before any other checks to avoid unnecessary processing.
-  if (!endUserFeatureEnabled || isMobile) {
+  if (isMobile) {
     return true;
   }
 

--- a/libs/auth/src/angular/registration/registration-finish/registration-finish.component.ts
+++ b/libs/auth/src/angular/registration/registration-finish/registration-finish.component.ts
@@ -10,9 +10,7 @@ import { MasterPasswordPolicyOptions } from "@bitwarden/common/admin-console/mod
 import { AccountApiService } from "@bitwarden/common/auth/abstractions/account-api.service";
 import { RegisterVerificationEmailClickedRequest } from "@bitwarden/common/auth/models/request/registration/register-verification-email-clicked.request";
 import { HttpStatusCode } from "@bitwarden/common/enums";
-import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { ErrorResponse } from "@bitwarden/common/models/response/error.response";
-import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { ValidationService } from "@bitwarden/common/platform/abstractions/validation.service";
@@ -79,7 +77,6 @@ export class RegistrationFinishComponent implements OnInit, OnDestroy {
     private logService: LogService,
     private anonLayoutWrapperDataService: AnonLayoutWrapperDataService,
     private loginSuccessHandlerService: LoginSuccessHandlerService,
-    private configService: ConfigService,
   ) {}
 
   async ngOnInit() {
@@ -187,19 +184,6 @@ export class RegistrationFinishComponent implements OnInit, OnDestroy {
       if (authenticationResult?.requiresTwoFactor) {
         await this.router.navigate(["/2fa"]);
         return;
-      }
-
-      const endUserActivationFlagEnabled = await this.configService.getFeatureFlag(
-        FeatureFlag.PM19315EndUserActivationMvp,
-      );
-
-      if (!endUserActivationFlagEnabled) {
-        // Only show the toast when the end user activation feature flag is _not_ enabled
-        this.toastService.showToast({
-          variant: "success",
-          title: null,
-          message: this.i18nService.t("youHaveBeenLoggedIn"),
-        });
       }
 
       await this.loginSuccessHandlerService.run(authenticationResult.userId);

--- a/libs/common/src/enums/feature-flag.enum.ts
+++ b/libs/common/src/enums/feature-flag.enum.ts
@@ -52,7 +52,6 @@ export enum FeatureFlag {
   PM22136_SdkCipherEncryption = "pm-22136-sdk-cipher-encryption",
   CipherKeyEncryption = "cipher-key-encryption",
   RemoveCardItemTypePolicy = "pm-16442-remove-card-item-type-policy",
-  PM19315EndUserActivationMvp = "pm-19315-end-user-activation-mvp",
 
   /* Platform */
   IpcChannelFramework = "ipc-channel-framework",
@@ -94,7 +93,6 @@ export const DefaultFeatureFlagValue = {
   [FeatureFlag.PM19941MigrateCipherDomainToSdk]: FALSE,
   [FeatureFlag.RemoveCardItemTypePolicy]: FALSE,
   [FeatureFlag.PM22134SdkCipherListView]: FALSE,
-  [FeatureFlag.PM19315EndUserActivationMvp]: FALSE,
   [FeatureFlag.PM22136_SdkCipherEncryption]: FALSE,
 
   /* Auth */


### PR DESCRIPTION
## 🎟️ Tracking

[PM-22371](https://bitwarden.atlassian.net/browse/PM-22371)

## 📔 Objective

removing the `PM19315EndUserActivationMvp` flag and it's usages. 

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-22371]: https://bitwarden.atlassian.net/browse/PM-22371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ