### PR TITLE
Add OrganizationWarningsModule to imports for AccessIntelligenceModule

### DIFF
--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/access-intelligence.module.ts
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/access-intelligence.module.ts
@@ -14,12 +14,13 @@ import { EncryptService } from "@bitwarden/common/key-management/crypto/abstract
 import { PasswordStrengthServiceAbstraction } from "@bitwarden/common/tools/password-strength/password-strength.service.abstraction";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { KeyService } from "@bitwarden/key-management";
+import { OrganizationWarningsModule } from "@bitwarden/web-vault/app/billing/organizations/warnings/organization-warnings.module";
 
 import { AccessIntelligenceRoutingModule } from "./access-intelligence-routing.module";
 import { RiskInsightsComponent } from "./risk-insights.component";
 
 @NgModule({
-  imports: [RiskInsightsComponent, AccessIntelligenceRoutingModule],
+  imports: [RiskInsightsComponent, AccessIntelligenceRoutingModule, OrganizationWarningsModule],
   providers: [
     {
       provide: MemberCipherDetailsApiService,


### PR DESCRIPTION
## 🎟️ Tracking

[PM-24963](https://bitwarden.atlassian.net/browse/PM-24963)

## 📔 Objective

Fixes a bug where the Access Intelligence page doesn't load, due to a missing OrganizationWarningsModule. Fixed by adding the `OrganizationWarningsModule` to the `@NgModule` imports in the access-intelligence module.

## Screenshots

https://github.com/user-attachments/assets/9ab526ce-d833-4f85-8a61-dc45b1ecfd11



[PM-24963]: https://bitwarden.atlassian.net/browse/PM-24963?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ