### PR TITLE
[CL-833] Fix FrontendLayoutComponent logo, update index & 404

### DIFF
--- a/apps/web/src/404.html
+++ b/apps/web/src/404.html
@@ -16,16 +16,18 @@
   </head>
 
   <body class="tw-min-h-screen !tw-min-w-0 tw-text-center tw-bg-background-alt tw-flex tw-flex-col">
-    <img class="new-logo-themed tw-m-8" alt="Bitwarden" />
+    <img class="new-logo-themed tw-my-4 tw-mx-6" alt="Bitwarden" />
 
-    <main class="tw-max-w-3xl tw-mx-auto tw-px-2 tw-my-4">
+    <main class="tw-max-w-3xl tw-mx-auto tw-px-2 tw-my-8">
       <h1 class="tw-mb-0 tw-h1">Sorry, this page isn't available.</h1>
 
       <p class="tw-py-9 tw-mb-0">
         The link you followed may be broken, or the page may have been removed. Try going back to
         the previous page or see our
-        <a href="https://bitwarden.com/help/" target="_blank" rel="noreferrer">Help Center</a> for
-        more information.
+        <a href="https://bitwarden.com/help/" target="_blank" rel="noreferrer" class="tw-link"
+          >Help Center</a
+        >
+        for more information.
       </p>
 
       <a href="/" class="tw-btn-secondary tw-inline-block">Go to your web vault</a>

--- a/apps/web/src/index.html
+++ b/apps/web/src/index.html
@@ -16,7 +16,7 @@
   <body class="layout_frontend">
     <app-root>
       <!-- Note: any changes to this html need to be made in the app.component.html as well -->
-      <div class="tw-p-8 tw-flex">
+      <div class="tw-px-6 tw-py-4 tw-flex">
         <img class="new-logo-themed" alt="Bitwarden" />
         <div class="spinner-container tw-justify-center">
           <i

--- a/apps/web/src/scss/tailwind.css
+++ b/apps/web/src/scss/tailwind.css
@@ -11,19 +11,9 @@
  * - Shared styles like Logo.
  */
 @layer components {
-  .tw-h1 {
-    @apply tw-text-3xl tw-font-semibold;
-  }
-
-  .tw-btn {
-    @apply tw-font-semibold tw-py-1.5 tw-px-3 tw-rounded tw-transition tw-border tw-border-solid tw-text-center tw-no-underline hover:tw-no-underline focus:tw-outline-none;
-  }
-
-  .tw-btn-secondary {
-    @apply tw-btn;
-
-    @apply tw-bg-transparent tw-border-text-muted hover:tw-bg-text-muted hover:tw-border-text-muted hover:!tw-text-contrast disabled:tw-bg-transparent disabled:tw-border-text-muted/60 disabled:!tw-text-muted/60 disabled:tw-cursor-not-allowed;
-    @apply tw-text-muted !important;
+  body {
+    @apply tw-bg-background;
+    @apply tw-text-main;
   }
 
   /**
@@ -49,11 +39,6 @@
     }
   }
 
-  body {
-    @apply tw-bg-background;
-    @apply tw-text-main;
-  }
-
   /**
    * Loading page
    */
@@ -71,6 +56,16 @@
   }
 
   /**
+   * Logo on old `FrontendLayoutComponent`. Remove when the component is gone.
+   */
+  img.logo {
+    display: block;
+    height: 43px;
+    margin: 0 auto;
+    width: 284px;
+  }
+
+  /**
    * Logo, used both in loading and on "frontend" pages.
    */
   img.new-logo-themed {
@@ -83,5 +78,30 @@
   }
   .theme_dark img.new-logo-themed {
     content: url("../images/logo-white.svg");
+  }
+}
+
+/**
+ * 404 page styling.
+ */
+@layer components {
+  .tw-h1 {
+    @apply tw-text-3xl tw-font-semibold;
+  }
+
+  .tw-btn {
+    @apply tw-font-semibold tw-py-1.5 tw-px-3 tw-rounded-full tw-transition tw-border-2 tw-border-solid tw-text-center tw-no-underline focus:tw-outline-none;
+  }
+
+  .tw-btn-secondary {
+    @apply tw-btn;
+
+    @apply tw-bg-transparent tw-text-primary-600 tw-border-primary-600 hover:tw-bg-hover-default;
+  }
+
+  .tw-link {
+    @apply tw-font-semibold hover:tw-underline hover:tw-decoration-1;
+
+    @apply tw-text-primary-600 hover:tw-text-primary-700 focus-visible:before:tw-ring-primary-600;
   }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/CL-833

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

- Re-added `.logo` class that is used by the old `FrontendLayoutComponent`. This component is deprecated and should be actively migrated away from.
- Updated 404.html styling to match the new baseline.
- Updated index.html to adjust the logo position so that it matches the `AnnonLayoutComponent`.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

<img width="999" height="557" alt="image" src="https://github.com/user-attachments/assets/3ad81b58-4e8d-444f-8680-5ab75b43444c" />


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
