### PR TITLE
Linux ARM64 builds and build artefacts

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -334,6 +334,9 @@ jobs:
           sudo apt-get update
           sudo apt-get -y install pkg-config libxss-dev rpm musl-dev musl-tools flatpak flatpak-builder
 
+      - name: Set up Snap
+        run: sudo snap install snapcraft --classic
+
       - name: Print environment
         run: |
           node --version

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -390,6 +390,41 @@ jobs:
       - name: Build application
         run: npm run dist:lin:arm64
 
+      - name: Upload .deb artifact
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: Bitwarden-${{ env._PACKAGE_VERSION }}-arm64.deb
+          path: apps/desktop/dist/Bitwarden-${{ env._PACKAGE_VERSION }}-arm64.deb
+          if-no-files-found: error
+
+      - name: Upload .rpm artifact
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: Bitwarden-${{ env._PACKAGE_VERSION }}-arm64.rpm
+          path: apps/desktop/dist/Bitwarden-${{ env._PACKAGE_VERSION }}-arm64.rpm
+          if-no-files-found: error
+
+      - name: Upload .freebsd artifact
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: Bitwarden-${{ env._PACKAGE_VERSION }}-arm64.freebsd
+          path: apps/desktop/dist/Bitwarden-${{ env._PACKAGE_VERSION }}-arm64.freebsd
+          if-no-files-found: error
+
+      - name: Upload .snap artifact
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: bitwarden_${{ env._PACKAGE_VERSION }}_arm64.snap
+          path: apps/desktop/dist/bitwarden_${{ env._PACKAGE_VERSION }}_arm64.snap
+          if-no-files-found: error
+
+      - name: Upload .AppImage artifact
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: Bitwarden-${{ env._PACKAGE_VERSION }}-arm64.AppImage
+          path: apps/desktop/dist/Bitwarden-${{ env._PACKAGE_VERSION }}-arm64.AppImage
+          if-no-files-found: error
+
       - name: Upload tar.gz artifact
         uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
         with:

--- a/.github/workflows/release-desktop-beta.yml
+++ b/.github/workflows/release-desktop-beta.yml
@@ -204,6 +204,95 @@ jobs:
           if-no-files-found: error
 
 
+  linux-arm64:
+    name: Linux ARM64 Build
+    runs-on: ubuntu-22.04-arm
+    needs: setup
+    permissions:
+      contents: read
+    env:
+      _PACKAGE_VERSION: ${{ needs.setup.outputs.release_version }}
+      _NODE_VERSION: ${{ needs.setup.outputs.node_version }}
+      NODE_OPTIONS: --max_old_space_size=4096
+    defaults:
+      run:
+        working-directory: apps/desktop
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ needs.setup.outputs.branch_name }}
+
+      - name: Set up Node
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        with:
+          cache: 'npm'
+          cache-dependency-path: '**/package-lock.json'
+          node-version: ${{ env._NODE_VERSION }}
+
+      - name: Set up environment
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install pkg-config libxss-dev rpm musl-dev musl-tools
+
+      - name: Set up Snap
+        run: sudo snap install snapcraft --classic
+
+      - name: Print environment
+        run: |
+          node --version
+          npm --version
+
+      - name: Install Node dependencies
+        run: npm ci
+        working-directory: ./
+
+      - name: Build application
+        run: npm run dist:lin:arm64
+
+      - name: Upload .deb artifact
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: Bitwarden-${{ env._PACKAGE_VERSION }}-arm64.deb
+          path: apps/desktop/dist/Bitwarden-${{ env._PACKAGE_VERSION }}-arm64.deb
+          if-no-files-found: error
+
+      - name: Upload .rpm artifact
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: Bitwarden-${{ env._PACKAGE_VERSION }}-arm64.rpm
+          path: apps/desktop/dist/Bitwarden-${{ env._PACKAGE_VERSION }}-arm64.rpm
+          if-no-files-found: error
+
+      - name: Upload .freebsd artifact
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: Bitwarden-${{ env._PACKAGE_VERSION }}-arm64.freebsd
+          path: apps/desktop/dist/Bitwarden-${{ env._PACKAGE_VERSION }}-arm64.freebsd
+          if-no-files-found: error
+
+      - name: Upload .AppImage artifact
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: Bitwarden-${{ env._PACKAGE_VERSION }}-arm64.AppImage
+          path: apps/desktop/dist/Bitwarden-${{ env._PACKAGE_VERSION }}-arm64.AppImage
+          if-no-files-found: error
+
+      - name: Upload .snap artifact
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: bitwarden_${{ env._PACKAGE_VERSION }}_arm64.snap
+          path: apps/desktop/dist/bitwarden_${{ env._PACKAGE_VERSION }}_arm64.snap
+          if-no-files-found: error
+
+      - name: Upload tar.gz artifact
+        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
+        with:
+          name: bitwarden_${{ env._PACKAGE_VERSION }}_arm64.tar.gz
+          path: apps/desktop/dist/bitwarden_desktop_arm64.tar.gz
+          if-no-files-found: error
+
+
   windows:
     name: Windows Build
     runs-on: windows-2022
@@ -996,6 +1085,7 @@ jobs:
     needs:
       - setup
       - linux
+      - linux-arm64
       - windows
       - macos-build
       - macos-package-github
@@ -1081,6 +1171,7 @@ jobs:
     needs:
       - setup
       - linux
+      - linux-arm64
       - windows
       - macos-build
       - macos-package-github

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -102,10 +102,15 @@ jobs:
           RELEASE_CHANNEL: ${{ steps.release_channel.outputs.channel }}
         with:
           artifacts: "apps/desktop/artifacts/Bitwarden-${{ env.PKG_VERSION }}-amd64.deb,
+            apps/desktop/artifacts/Bitwarden-${{ env.PKG_VERSION }}-arm64.deb,
             apps/desktop/artifacts/Bitwarden-${{ env.PKG_VERSION }}-x86_64.rpm,
+            apps/desktop/artifacts/Bitwarden-${{ env.PKG_VERSION }}-arm64.rpm,
             apps/desktop/artifacts/Bitwarden-${{ env.PKG_VERSION }}-x64.freebsd,
+            apps/desktop/artifacts/Bitwarden-${{ env.PKG_VERSION }}-arm64.freebsd,
             apps/desktop/artifacts/bitwarden_${{ env.PKG_VERSION }}_amd64.snap,
+            apps/desktop/artifacts/bitwarden_${{ env.PKG_VERSION }}_arm64.snap,
             apps/desktop/artifacts/Bitwarden-${{ env.PKG_VERSION }}-x86_64.AppImage,
+            apps/desktop/artifacts/Bitwarden-${{ env.PKG_VERSION }}-arm64.AppImage,
             apps/desktop/artifacts/Bitwarden-Portable-${{ env.PKG_VERSION }}.exe,
             apps/desktop/artifacts/Bitwarden-Installer-${{ env.PKG_VERSION }}.exe,
             apps/desktop/artifacts/Bitwarden-${{ env.PKG_VERSION }}-ia32-store.appx,

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -38,7 +38,7 @@
     "pack:dir": "npm run clean:dist && electron-builder --dir -p never",
     "pack:lin:flatpak": "npm run clean:dist && electron-builder --dir -p never && flatpak-builder  --repo=build/.repo build/.flatpak  ./resources/com.bitwarden.desktop.devel.yaml --install-deps-from=flathub --force-clean &&  flatpak build-bundle ./build/.repo/ ./dist/com.bitwarden.desktop.flatpak com.bitwarden.desktop",
     "pack:lin": "npm run clean:dist && electron-builder --linux --x64 -p never && export SNAP_FILE=$(realpath ./dist/bitwarden_*.snap) && unsquashfs -d ./dist/tmp-snap/ $SNAP_FILE && mkdir -p ./dist/tmp-snap/meta/polkit/ && cp ./resources/com.bitwarden.desktop.policy  ./dist/tmp-snap/meta/polkit/polkit.com.bitwarden.desktop.policy && rm $SNAP_FILE && snap pack --compression=lzo ./dist/tmp-snap/ && mv ./*.snap ./dist/ && rm -rf ./dist/tmp-snap/",
-    "pack:lin:arm64": "npm run clean:dist && electron-builder --dir -p never && tar -czvf ./dist/bitwarden_desktop_arm64.tar.gz -C ./dist/linux-arm64-unpacked/ .",
+    "pack:lin:arm64": "npm run clean:dist && electron-builder --linux --arm64 -p never && tar -czvf ./dist/bitwarden_desktop_arm64.tar.gz -C ./dist/linux-arm64-unpacked/ .",
     "pack:mac": "npm run clean:dist && electron-builder --mac --universal -p never",
     "pack:mac:with-extension": "npm run clean:dist && npm run build:macos-extension:mac && electron-builder --mac --universal -p never",
     "pack:mac:arm64": "npm run clean:dist && electron-builder --mac --arm64 -p never",


### PR DESCRIPTION
## 🎟️ Tracking

#16083

[https://github.com/flathub/com.bitwarden.desktop/issues/63](https://github.com/flathub/com.bitwarden.desktop/issues/63)

GH-15910

## 📔 Objective

Add Linux ARM64 build and release support for the Desktop app:
- Build ARM64 artifacts alongside x64 in CI (deb, rpm, freebsd, snap, AppImage,, tar.gz)
- Make ARM64 artifacts available in beta and stable releases
- Unblock Flatpak path  by publishing ARM64 .deb (external Flatpak repo handles manifest)
  - Flatpak packaging remains x64-only in CI; updating the Flathub manifest to include aarch64 will be a follow-up done in the external repo, ref. [https://github.com/flathub/com.bitwarden.desktop/issues/63](https://github.com/flathub/com.bitwarden.desktop/issues/63).

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

> [!WARNING]  
> I was unable to run CI end-to-end from my fork or on my local computer. I managed to build the AppImage and rpm file locally. I'm not sure how to test if the build process is successful before submitting this pull request. I apologize if this pull request is premature.

## 🦮 Reviewer guidelines

- Check that `apps/desktop/package.json` `pack:lin:arm64` generates packaged artifacts (deb/rpm/AppImage/snap)
  - deb: Bitwarden-${version}-arm64.deb
  - rpm: Bitwarden-${version}-arm64.rpm
  - snap: bitwarden_${version}_arm64.snap
  - FreeBSD: Bitwarden-{version}-arm64.freebsd
  - AppImage: Bitwarden-${version}-arm64.AppImage
  - tar.gz: bitwarden_desktop_arm64.tar.gz

- Flatpak: this PR only unblocks ARM64 by publishing the official ARM64 .deb. The Flatpak build in CI remains x64-only (`linux` job runs `npm run pack:lin:flatpak`; `linux-arm64` does not).
  - The Flathub manifest update to include aarch64 will be handled separately in the external repository, ref. ref. [https://github.com/flathub/com.bitwarden.desktop/issues/63](https://github.com/flathub/com.bitwarden.desktop/issues/63).
  - Not sure if this is ought to be done a different way.

---

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
