### PR TITLE
[PM-24351] Fix: Hide VAT/Tax ID field for Families plans in marketing initiated billing flow

### DIFF
--- a/apps/web/src/app/billing/accounts/trial-initiation/trial-billing-step.component.html
+++ b/apps/web/src/app/billing/accounts/trial-initiation/trial-billing-step.component.html
@@ -51,6 +51,7 @@
       <h2 class="tw-mb-3 tw-text-base tw-font-semibold">{{ "paymentType" | i18n }}</h2>
       <app-payment [showAccountCredit]="false"></app-payment>
       <app-manage-tax-information
+        [showTaxIdField]="showTaxIdField"
         (taxInformationChanged)="onTaxInformationChanged()"
       ></app-manage-tax-information>
 

--- a/apps/web/src/app/billing/accounts/trial-initiation/trial-billing-step.component.ts
+++ b/apps/web/src/app/billing/accounts/trial-initiation/trial-billing-step.component.ts
@@ -259,6 +259,15 @@ export class TrialBillingStepComponent implements OnInit, OnDestroy {
     return planType ? this.applicablePlans.find((plan) => plan.type === planType) : null;
   }
 
+  protected get showTaxIdField(): boolean {
+    switch (this.organizationInfo.type) {
+      case ProductTierType.Families:
+        return false;
+      default:
+        return true;
+    }
+  }
+
   private getBillingInformationFromTaxInfoComponent(): BillingInformation {
     return {
       postalCode: this.taxInfoComponent.getTaxInformation()?.postalCode,


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-24351
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
The marketing initiated Families plan billing flow was displaying the VAT/Tax ID field, which should only be shown for Business plan subscriptions (Teams and Enterprise). This created confusion for users signing up for personal/family plans.

**Root Cause**
The TrialBillingStepComponent was using ManageTaxInformationComponent without specifying the showTaxIdField property, causing it to default to true and display the VAT field for all organization types, including Families plans.

**Solution**

- Added showTaxIdField getter to TrialBillingStepComponent that returns false for ProductTierType.Families plans

- Updated the component template to pass the showTaxIdField property to ManageTaxInformationComponent

**Changes Made**

1. apps/web/src/app/billing/accounts/trial-initiation/trial-billing-step.component.ts

-     Added showTaxIdField getter that excludes Families plans from showing VAT field

2. apps/web/src/app/billing/accounts/trial-initiation/trial-billing-step.component.html

-     Added [showTaxIdField]="showTaxIdField" binding to app-manage-tax-information component

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/f5a82908-aa93-4bc5-a688-1f257f64a7c0


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
