### PR TITLE
[CL-825] absolutely position checkbox to fix ios rendering bug

### DIFF
--- a/libs/components/src/checkbox/checkbox.component.ts
+++ b/libs/components/src/checkbox/checkbox.component.ts
@@ -21,6 +21,7 @@ export class CheckboxComponent implements BitFormControlAbstraction {
     "tw-align-sub",
     "tw-flex-none", // Flexbox fix for bit-form-control
     "!tw-p-1",
+    // Give checkbox explicit height and width to fix iOS rendering bug
     "tw-h-[calc(1.12rem_+_theme(spacing.2))]",
     "tw-w-[calc(1.12rem_+_theme(spacing.2))]",
     "after:tw-inset-1",

--- a/libs/components/src/checkbox/checkbox.component.ts
+++ b/libs/components/src/checkbox/checkbox.component.ts
@@ -21,6 +21,8 @@ export class CheckboxComponent implements BitFormControlAbstraction {
     "tw-align-sub",
     "tw-flex-none", // Flexbox fix for bit-form-control
     "!tw-p-1",
+    "tw-h-[calc(1.12rem_+_theme(spacing.2))]",
+    "tw-w-[calc(1.12rem_+_theme(spacing.2))]",
     "after:tw-inset-1",
     // negative margin to negate the positioning added by the padding
     "!-tw-mt-1",

--- a/libs/components/src/form-control/form-control.component.html
+++ b/libs/components/src/form-control/form-control.component.html
@@ -1,5 +1,5 @@
 <label
-  class="tw-transition tw-items-start [&:has(input[type='checkbox'])]:tw-relative [&:has(input[type='checkbox'])]:tw-ps-[calc(1.12rem_+_.5rem)] [&_input[type='checkbox']]:tw-absolute [&_input[type='checkbox']]:tw-inset-0 [&:has(input[type='radio'])]:tw-gap-1.5 tw-select-none tw-mb-0 tw-inline-flex tw-rounded has-[:focus-visible]:tw-ring has-[:focus-visible]:tw-ring-primary-600"
+  class="tw-transition tw-items-start [&:has(input[type='checkbox'])]:tw-gap-1 [&:has(input[type='radio'])]:tw-gap-1.5 tw-select-none tw-mb-0 tw-inline-flex tw-rounded has-[:focus-visible]:tw-ring has-[:focus-visible]:tw-ring-primary-600"
   [ngClass]="[formControl().disabled ? 'tw-cursor-auto' : 'tw-cursor-pointer']"
 >
   <ng-content></ng-content>

--- a/libs/components/src/form-control/form-control.component.html
+++ b/libs/components/src/form-control/form-control.component.html
@@ -1,5 +1,5 @@
 <label
-  class="tw-transition tw-items-start [&:has(input[type='checkbox'])]:tw-gap-[.25rem] [&:has(input[type='radio'])]:tw-gap-1.5 tw-select-none tw-mb-0 tw-inline-flex tw-rounded has-[:focus-visible]:tw-ring has-[:focus-visible]:tw-ring-primary-600"
+  class="tw-transition tw-items-start [&:has(input[type='checkbox'])]:tw-relative [&:has(input[type='checkbox'])]:tw-ps-[calc(1.12rem_+_.5rem)] [&_input[type='checkbox']]:tw-absolute [&_input[type='checkbox']]:tw-inset-0 [&:has(input[type='radio'])]:tw-gap-1.5 tw-select-none tw-mb-0 tw-inline-flex tw-rounded has-[:focus-visible]:tw-ring has-[:focus-visible]:tw-ring-primary-600"
   [ngClass]="[formControl().disabled ? 'tw-cursor-auto' : 'tw-cursor-pointer']"
 >
   <ng-content></ng-content>


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/CL-825

## 📔 Objective

Fix iOS browsers rendering checkboxes. Negative margin + gap wasn't being rendered properly

## 📸 Screenshots
<img width="387" height="809" alt="image" src="https://github.com/user-attachments/assets/ed8b9ccd-e61a-434b-8383-6df00ec61065" />


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
