### PR TITLE
Frees calls to shadow DOM-triggered (scoped) collection method

### DIFF
--- a/apps/browser/src/autofill/services/collect-autofill-content.service.ts
+++ b/apps/browser/src/autofill/services/collect-autofill-content.service.ts
@@ -982,9 +982,7 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
   private processMutations = () => {
     const queueLength = this.mutationsQueue.length;
 
-    if (!this.domQueryService.pageContainsShadowDomElements()) {
-      this.checkPageContainsShadowDom();
-    }
+    requestIdleCallbackPolyfill(this.maybeFlagShadowDOMPageUpdate, { timeout: 500 });
 
     for (let queueIndex = 0; queueIndex < queueLength; queueIndex++) {
       const mutations = this.mutationsQueue[queueIndex];
@@ -1006,12 +1004,12 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
    * Handles checking if the current page contains a ShadowDOM element and
    * flags that a re-collection of page details is required if it does.
    */
-  private checkPageContainsShadowDom() {
+  private maybeFlagShadowDOMPageUpdate = () => {
     this.domQueryService.checkPageContainsShadowDom();
     if (this.domQueryService.pageContainsShadowDomElements()) {
       this.flagPageDetailsUpdateIsRequired();
     }
-  }
+  };
 
   /**
    * Triggers several flags that indicate that a collection of page details should


### PR DESCRIPTION
## 🎟️ Tracking

[PM-24479](https://bitwarden.atlassian.net/browse/PM-24479)

Related to reverted https://github.com/bitwarden/clients/pull/12695 

## 📔 Objective

[This change](https://github.com/bitwarden/clients/pull/12695/files#diff-8ff1ef69519807ae86fc872374b223656c9459d1b8b0304e8a2b602182b68f98R987) reset the scope of `[CollectAutofillContentService].checkPageContainsShadowDom`, which means subsequent calls in that method to `DomQueryService`'s members referenced a class that was then `undefined`.

After that change was reverted, intervening changes may have changed the execution order of the `DomQueryService`'s own checks for shadow DOM elements, because the check as to whether any elements were present was always returning true, therefore updated page details were never (or rarely) collected (due to a possible race condition in element loading).

```js
    // nearly always returns false due to early checking outside of this class
    if (!this.domQueryService.pageContainsShadowDomElements()) { 
      requestIdleCallbackPolyfill(this.checkPageContainsShadowDom, { timeout: 500 }); // unbound from class
    }
```

This change better signals the intent of the function which may update page details, ensures its scope is deterministic via arrow syntax, and otherwise relies on the `DomQueryService` directly for canonical data on shadow DOM. We may still want to limit calls to this method if computation proves too expensive or if ongoing mutations trigger too many queries, perhaps by caching references to current shadow DOM elements to see if a new query is necessary.

Notably, this causes successful autofill on hbomax.com and may extend that functionality to other forms using shadow DOM. 

❓ @jprusik do we want to see if the method [here](https://github.com/bitwarden/clients/pull/12695/files#diff-8ff1ef69519807ae86fc872374b223656c9459d1b8b0304e8a2b602182b68f98R951) to limit mutations being processed should also be re-implemented?

## 📸 Screenshots

<img width="1243" height="693" alt="Screenshot 2025-08-21 at 4 36 20 PM" src="https://github.com/user-attachments/assets/cfc558c3-05a6-4487-b08f-7176e3142fe5" />

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
