### PR TITLE
Lossless SSH key import with optional passphrase storage and on-demand decryption for SSH agent

### DIFF
--- a/libs/common/src/vault/models/api/ssh-key.api.ts
+++ b/libs/common/src/vault/models/api/ssh-key.api.ts
@@ -7,11 +7,6 @@ export class SshKeyApi extends BaseResponse {
   publicKey: string;
   keyFingerprint: string;
 
-  // New fields for lossless encrypted key preservation and UX
-  originalPrivateKey?: string;
-  isEncrypted?: boolean;
-  sshKeyPassphrase?: string;
-
   constructor(data: any = null) {
     super(data);
     if (data == null) {
@@ -20,10 +15,5 @@ export class SshKeyApi extends BaseResponse {
     this.privateKey = this.getResponseProperty("PrivateKey");
     this.publicKey = this.getResponseProperty("PublicKey");
     this.keyFingerprint = this.getResponseProperty("KeyFingerprint");
-
-    // Map new optional properties if present
-    this.originalPrivateKey = this.getResponseProperty("OriginalPrivateKey");
-    this.isEncrypted = this.getResponseProperty("IsEncrypted");
-    this.sshKeyPassphrase = this.getResponseProperty("SshKeyPassphrase");
   }
 }

--- a/libs/common/src/vault/models/api/ssh-key.api.ts
+++ b/libs/common/src/vault/models/api/ssh-key.api.ts
@@ -7,6 +7,11 @@ export class SshKeyApi extends BaseResponse {
   publicKey: string;
   keyFingerprint: string;
 
+  // New fields for lossless encrypted key preservation and UX
+  originalPrivateKey?: string;
+  isEncrypted?: boolean;
+  sshKeyPassphrase?: string;
+
   constructor(data: any = null) {
     super(data);
     if (data == null) {
@@ -15,5 +20,10 @@ export class SshKeyApi extends BaseResponse {
     this.privateKey = this.getResponseProperty("PrivateKey");
     this.publicKey = this.getResponseProperty("PublicKey");
     this.keyFingerprint = this.getResponseProperty("KeyFingerprint");
+
+    // Map new optional properties if present
+    this.originalPrivateKey = this.getResponseProperty("OriginalPrivateKey");
+    this.isEncrypted = this.getResponseProperty("IsEncrypted");
+    this.sshKeyPassphrase = this.getResponseProperty("SshKeyPassphrase");
   }
 }

--- a/libs/common/src/vault/models/data/ssh-key.data.ts
+++ b/libs/common/src/vault/models/data/ssh-key.data.ts
@@ -7,6 +7,11 @@ export class SshKeyData {
   publicKey: string;
   keyFingerprint: string;
 
+  // New fields to preserve original encrypted key and optional passphrase
+  originalPrivateKey?: string;
+  isEncrypted?: boolean;
+  sshKeyPassphrase?: string;
+
   constructor(data?: SshKeyApi) {
     if (data == null) {
       return;
@@ -15,5 +20,10 @@ export class SshKeyData {
     this.privateKey = data.privateKey;
     this.publicKey = data.publicKey;
     this.keyFingerprint = data.keyFingerprint;
+
+    // Map new optional properties if present
+    this.originalPrivateKey = data.originalPrivateKey;
+    this.isEncrypted = data.isEncrypted;
+    this.sshKeyPassphrase = data.sshKeyPassphrase;
   }
 }

--- a/libs/common/src/vault/models/data/ssh-key.data.ts
+++ b/libs/common/src/vault/models/data/ssh-key.data.ts
@@ -7,11 +7,6 @@ export class SshKeyData {
   publicKey: string;
   keyFingerprint: string;
 
-  // New fields to preserve original encrypted key and optional passphrase
-  originalPrivateKey?: string;
-  isEncrypted?: boolean;
-  sshKeyPassphrase?: string;
-
   constructor(data?: SshKeyApi) {
     if (data == null) {
       return;
@@ -20,10 +15,5 @@ export class SshKeyData {
     this.privateKey = data.privateKey;
     this.publicKey = data.publicKey;
     this.keyFingerprint = data.keyFingerprint;
-
-    // Map new optional properties if present
-    this.originalPrivateKey = data.originalPrivateKey;
-    this.isEncrypted = data.isEncrypted;
-    this.sshKeyPassphrase = data.sshKeyPassphrase;
   }
 }

--- a/libs/common/src/vault/models/domain/ssh-key.ts
+++ b/libs/common/src/vault/models/domain/ssh-key.ts
@@ -15,11 +15,6 @@ export class SshKey extends Domain {
   publicKey: EncString;
   keyFingerprint: EncString;
 
-  // New fields for preserving encrypted PEM and passphrase
-  originalPrivateKey?: EncString;
-  isEncrypted?: boolean;
-  sshKeyPassphrase?: EncString;
-
   constructor(obj?: SshKeyData) {
     super();
     if (obj == null) {
@@ -33,8 +28,6 @@ export class SshKey extends Domain {
         privateKey: null,
         publicKey: null,
         keyFingerprint: null,
-        originalPrivateKey: null,
-        sshKeyPassphrase: null,
       },
       [],
     );
@@ -48,7 +41,7 @@ export class SshKey extends Domain {
     return this.decryptObj<SshKey, SshKeyView>(
       this,
       new SshKeyView(),
-      ["privateKey", "publicKey", "keyFingerprint", "originalPrivateKey", "sshKeyPassphrase"],
+      ["privateKey", "publicKey", "keyFingerprint"],
       orgId,
       encKey,
       "DomainType: SshKey; " + context,
@@ -61,8 +54,6 @@ export class SshKey extends Domain {
       privateKey: null,
       publicKey: null,
       keyFingerprint: null,
-      originalPrivateKey: null,
-      sshKeyPassphrase: null,
     });
     return c;
   }
@@ -92,9 +83,6 @@ export class SshKey extends Domain {
       privateKey: this.privateKey.toSdk(),
       publicKey: this.publicKey.toSdk(),
       fingerprint: this.keyFingerprint.toSdk(),
-      originalPrivateKey: this.originalPrivateKey?.toSdk(),
-      isEncrypted: this.isEncrypted,
-      sshKeyPassphrase: this.sshKeyPassphrase?.toSdk(),
     };
   }
 
@@ -111,9 +99,6 @@ export class SshKey extends Domain {
     sshKey.privateKey = EncString.fromJSON(obj.privateKey);
     sshKey.publicKey = EncString.fromJSON(obj.publicKey);
     sshKey.keyFingerprint = EncString.fromJSON(obj.fingerprint);
-    sshKey.originalPrivateKey = EncString.fromJSON((obj as any).originalPrivateKey);
-    sshKey.isEncrypted = (obj as any).isEncrypted;
-    sshKey.sshKeyPassphrase = EncString.fromJSON((obj as any).sshKeyPassphrase);
 
     return sshKey;
   }

--- a/libs/common/src/vault/models/domain/ssh-key.ts
+++ b/libs/common/src/vault/models/domain/ssh-key.ts
@@ -15,6 +15,11 @@ export class SshKey extends Domain {
   publicKey: EncString;
   keyFingerprint: EncString;
 
+  // New fields for preserving encrypted PEM and passphrase
+  originalPrivateKey?: EncString;
+  isEncrypted?: boolean;
+  sshKeyPassphrase?: EncString;
+
   constructor(obj?: SshKeyData) {
     super();
     if (obj == null) {
@@ -28,6 +33,8 @@ export class SshKey extends Domain {
         privateKey: null,
         publicKey: null,
         keyFingerprint: null,
+        originalPrivateKey: null,
+        sshKeyPassphrase: null,
       },
       [],
     );
@@ -41,7 +48,7 @@ export class SshKey extends Domain {
     return this.decryptObj<SshKey, SshKeyView>(
       this,
       new SshKeyView(),
-      ["privateKey", "publicKey", "keyFingerprint"],
+      ["privateKey", "publicKey", "keyFingerprint", "originalPrivateKey", "sshKeyPassphrase"],
       orgId,
       encKey,
       "DomainType: SshKey; " + context,
@@ -54,6 +61,8 @@ export class SshKey extends Domain {
       privateKey: null,
       publicKey: null,
       keyFingerprint: null,
+      originalPrivateKey: null,
+      sshKeyPassphrase: null,
     });
     return c;
   }
@@ -83,6 +92,9 @@ export class SshKey extends Domain {
       privateKey: this.privateKey.toSdk(),
       publicKey: this.publicKey.toSdk(),
       fingerprint: this.keyFingerprint.toSdk(),
+      originalPrivateKey: this.originalPrivateKey?.toSdk(),
+      isEncrypted: this.isEncrypted,
+      sshKeyPassphrase: this.sshKeyPassphrase?.toSdk(),
     };
   }
 
@@ -99,6 +111,9 @@ export class SshKey extends Domain {
     sshKey.privateKey = EncString.fromJSON(obj.privateKey);
     sshKey.publicKey = EncString.fromJSON(obj.publicKey);
     sshKey.keyFingerprint = EncString.fromJSON(obj.fingerprint);
+    sshKey.originalPrivateKey = EncString.fromJSON((obj as any).originalPrivateKey);
+    sshKey.isEncrypted = (obj as any).isEncrypted;
+    sshKey.sshKeyPassphrase = EncString.fromJSON((obj as any).sshKeyPassphrase);
 
     return sshKey;
   }

--- a/libs/common/src/vault/models/request/cipher.request.ts
+++ b/libs/common/src/vault/models/request/cipher.request.ts
@@ -110,6 +110,16 @@ export class CipherRequest {
           cipher.sshKey.keyFingerprint != null
             ? cipher.sshKey.keyFingerprint.encryptedString
             : null;
+
+        // New optional fields for preserving original encrypted PEM and passphrase
+        this.sshKey.originalPrivateKey =
+          cipher.sshKey.originalPrivateKey != null
+            ? cipher.sshKey.originalPrivateKey.encryptedString
+            : null;
+        this.sshKey.sshKeyPassphrase =
+          cipher.sshKey.sshKeyPassphrase != null
+            ? cipher.sshKey.sshKeyPassphrase.encryptedString
+            : null;
         break;
       case CipherType.Card:
         this.card = new CardApi();

--- a/libs/common/src/vault/models/request/cipher.request.ts
+++ b/libs/common/src/vault/models/request/cipher.request.ts
@@ -110,16 +110,6 @@ export class CipherRequest {
           cipher.sshKey.keyFingerprint != null
             ? cipher.sshKey.keyFingerprint.encryptedString
             : null;
-
-        // New optional fields for preserving original encrypted PEM and passphrase
-        this.sshKey.originalPrivateKey =
-          cipher.sshKey.originalPrivateKey != null
-            ? cipher.sshKey.originalPrivateKey.encryptedString
-            : null;
-        this.sshKey.sshKeyPassphrase =
-          cipher.sshKey.sshKeyPassphrase != null
-            ? cipher.sshKey.sshKeyPassphrase.encryptedString
-            : null;
         break;
       case CipherType.Card:
         this.card = new CardApi();

--- a/libs/common/src/vault/models/view/ssh-key.view.ts
+++ b/libs/common/src/vault/models/view/ssh-key.view.ts
@@ -13,6 +13,11 @@ export class SshKeyView extends ItemView {
   publicKey: string = null;
   keyFingerprint: string = null;
 
+  // New metadata to preserve original encrypted PEM and passphrase handling
+  originalPrivateKey?: string = null;
+  isEncrypted?: boolean = null;
+  sshKeyPassphrase?: string = null;
+
   constructor(n?: SshKey) {
     super();
     if (!n) {
@@ -57,7 +62,12 @@ export class SshKeyView extends ItemView {
 
     const sshKeyView = new SshKeyView();
 
-    sshKeyView.privateKey = obj.privateKey ?? null;
+    // Prefer showing the original PEM if present (keeps encrypted header intact)
+    sshKeyView.originalPrivateKey = (obj as any).originalPrivateKey ?? null;
+    sshKeyView.isEncrypted = (obj as any).isEncrypted ?? null;
+    sshKeyView.sshKeyPassphrase = (obj as any).sshKeyPassphrase ?? null;
+
+    sshKeyView.privateKey = (sshKeyView.originalPrivateKey ?? obj.privateKey) ?? null;
     sshKeyView.publicKey = obj.publicKey ?? null;
     sshKeyView.keyFingerprint = obj.fingerprint ?? null;
 
@@ -72,6 +82,10 @@ export class SshKeyView extends ItemView {
       privateKey: this.privateKey,
       publicKey: this.publicKey,
       fingerprint: this.keyFingerprint,
-    };
+      // Preserve metadata if present
+      ...(this.originalPrivateKey != null ? { originalPrivateKey: this.originalPrivateKey } : {}),
+      ...(this.isEncrypted != null ? { isEncrypted: this.isEncrypted } : {}),
+      ...(this.sshKeyPassphrase != null ? { sshKeyPassphrase: this.sshKeyPassphrase } : {}),
+    } as unknown as SdkSshKeyView;
   }
 }

--- a/libs/common/src/vault/models/view/ssh-key.view.ts
+++ b/libs/common/src/vault/models/view/ssh-key.view.ts
@@ -13,11 +13,6 @@ export class SshKeyView extends ItemView {
   publicKey: string = null;
   keyFingerprint: string = null;
 
-  // New metadata to preserve original encrypted PEM and passphrase handling
-  originalPrivateKey?: string = null;
-  isEncrypted?: boolean = null;
-  sshKeyPassphrase?: string = null;
-
   constructor(n?: SshKey) {
     super();
     if (!n) {
@@ -62,12 +57,7 @@ export class SshKeyView extends ItemView {
 
     const sshKeyView = new SshKeyView();
 
-    // Prefer showing the original PEM if present (keeps encrypted header intact)
-    sshKeyView.originalPrivateKey = (obj as any).originalPrivateKey ?? null;
-    sshKeyView.isEncrypted = (obj as any).isEncrypted ?? null;
-    sshKeyView.sshKeyPassphrase = (obj as any).sshKeyPassphrase ?? null;
-
-    sshKeyView.privateKey = (sshKeyView.originalPrivateKey ?? obj.privateKey) ?? null;
+    sshKeyView.privateKey = obj.privateKey ?? null;
     sshKeyView.publicKey = obj.publicKey ?? null;
     sshKeyView.keyFingerprint = obj.fingerprint ?? null;
 
@@ -82,10 +72,6 @@ export class SshKeyView extends ItemView {
       privateKey: this.privateKey,
       publicKey: this.publicKey,
       fingerprint: this.keyFingerprint,
-      // Preserve metadata if present
-      ...(this.originalPrivateKey != null ? { originalPrivateKey: this.originalPrivateKey } : {}),
-      ...(this.isEncrypted != null ? { isEncrypted: this.isEncrypted } : {}),
-      ...(this.sshKeyPassphrase != null ? { sshKeyPassphrase: this.sshKeyPassphrase } : {}),
-    } as unknown as SdkSshKeyView;
+    };
   }
 }

--- a/libs/importer/src/components/dialog/sshkey-password-prompt.component.html
+++ b/libs/importer/src/components/dialog/sshkey-password-prompt.component.html
@@ -17,13 +17,6 @@
         />
         <button type="button" bitSuffix bitIconButton bitPasswordInputToggle></button>
       </bit-form-field>
-
-      <bit-form-field class="tw-mt-4">
-        <bit-form-control>
-          <input type="checkbox" bitCheckbox formControlName="rememberPassphrase" />
-          <bit-label>{{ "rememberPassphrase" | i18n: "Store passphrase in this item (encrypted)" }}</bit-label>
-        </bit-form-control>
-      </bit-form-field>
     </div>
 
     <ng-container bitDialogFooter>

--- a/libs/importer/src/components/dialog/sshkey-password-prompt.component.html
+++ b/libs/importer/src/components/dialog/sshkey-password-prompt.component.html
@@ -17,6 +17,13 @@
         />
         <button type="button" bitSuffix bitIconButton bitPasswordInputToggle></button>
       </bit-form-field>
+
+      <bit-form-field class="tw-mt-4">
+        <bit-form-control>
+          <input type="checkbox" bitCheckbox formControlName="rememberPassphrase" />
+          <bit-label>{{ "rememberPassphrase" | i18n: "Store passphrase in this item (encrypted)" }}</bit-label>
+        </bit-form-control>
+      </bit-form-field>
     </div>
 
     <ng-container bitDialogFooter>

--- a/libs/importer/src/components/dialog/sshkey-password-prompt.component.ts
+++ b/libs/importer/src/components/dialog/sshkey-password-prompt.component.ts
@@ -28,6 +28,7 @@ import {
 export class SshKeyPasswordPromptComponent {
   protected formGroup = this.formBuilder.group({
     sshKeyPassword: ["", Validators.required],
+    rememberPassphrase: [false],
   });
 
   constructor(
@@ -40,6 +41,9 @@ export class SshKeyPasswordPromptComponent {
     if (!this.formGroup.valid) {
       return;
     }
-    this.dialogRef.close(this.formGroup.value.sshKeyPassword);
+    this.dialogRef.close({
+      password: this.formGroup.value.sshKeyPassword,
+      rememberPassphrase: this.formGroup.value.rememberPassphrase ?? false,
+    });
   };
 }

--- a/libs/importer/src/components/dialog/sshkey-password-prompt.component.ts
+++ b/libs/importer/src/components/dialog/sshkey-password-prompt.component.ts
@@ -28,7 +28,6 @@ import {
 export class SshKeyPasswordPromptComponent {
   protected formGroup = this.formBuilder.group({
     sshKeyPassword: ["", Validators.required],
-    rememberPassphrase: [false],
   });
 
   constructor(
@@ -41,9 +40,6 @@ export class SshKeyPasswordPromptComponent {
     if (!this.formGroup.valid) {
       return;
     }
-    this.dialogRef.close({
-      password: this.formGroup.value.sshKeyPassword,
-      rememberPassphrase: this.formGroup.value.rememberPassphrase ?? false,
-    });
+    this.dialogRef.close(this.formGroup.value.sshKeyPassword);
   };
 }

--- a/libs/vault/src/services/default-ssh-import-prompt.service.ts
+++ b/libs/vault/src/services/default-ssh-import-prompt.service.ts
@@ -48,16 +48,13 @@ export class DefaultSshImportPromptService implements SshImportPromptService {
 
     if (isPasswordProtectedSshKey) {
       for (;;) {
-        const result = await this.getSshKeyPassword();
-        if (!result || result.password == null || result.password === "") {
+        const password = await this.getSshKeyPassword();
+        if (password === "" || password == null) {
           return null;
         }
 
         try {
-          parsedKey = import_ssh_key(key, result.password);
-          // Carry user's remember preference and provided passphrase forward
-          (parsedKey as any).__rememberPassphrase = result.rememberPassphrase === true;
-          (parsedKey as any).__providedPassphrase = result.password;
+          parsedKey = import_ssh_key(key, password);
           break;
         } catch (e) {
           const error = e as SshKeyImportError;
@@ -79,19 +76,11 @@ export class DefaultSshImportPromptService implements SshImportPromptService {
       message: this.i18nService.t("sshKeyImported"),
     });
 
-    // If user opted to remember passphrase, persist it with the item; otherwise do not store it.
-    const remember = (parsedKey as any).__rememberPassphrase === true;
-    const provided = (parsedKey as any).__providedPassphrase as string | undefined;
-
     return new SshKeyData(
       new SshKeyApi({
         privateKey: parsedKey!.privateKey,
         publicKey: parsedKey!.publicKey,
         keyFingerprint: parsedKey!.fingerprint,
-        // Preserve metadata from SDK for fidelity and UX
-        originalPrivateKey: (parsedKey as any).originalPrivateKey,
-        isEncrypted: (parsedKey as any).isEncrypted,
-        sshKeyPassphrase: remember ? provided : undefined,
       }),
     );
   }
@@ -110,8 +99,8 @@ export class DefaultSshImportPromptService implements SshImportPromptService {
     }
   }
 
-  private async getSshKeyPassword(): Promise<{ password: string; rememberPassphrase: boolean } | undefined> {
-    const dialog = this.dialogService.open<{ password: string; rememberPassphrase: boolean }>(SshKeyPasswordPromptComponent, {
+  private async getSshKeyPassword(): Promise<string | undefined> {
+    const dialog = this.dialogService.open<string>(SshKeyPasswordPromptComponent, {
       ariaModal: true,
     });
 


### PR DESCRIPTION
Summary
Enables lossless import of SSH private keys by preserving the original PEM (including encryption headers) and adds a “Remember passphrase” option. Desktop agent now decrypts on-demand for use, avoiding plaintext persistence.
Linked PRs needed to work for this changes:
- clients: https://github.com/bitwarden/clients/pull/16120
- server:
-  sdk-internal: 

Linked Issue
- OpenSSH keys with passphrase not saving correctly (https://github.com/bitwarden/clients/issues/13878)
- SSH agent can't import RSA keys (PKCS#1 / PEM) (https://github.com/bitwarden/clients/issues/15088)
- unable to save SSH key with or without a passphrase from puttygen (https://github.com/bitwarden/clients/issues/13343)

UX/Behavior Changes
- Import from clipboard: If encrypted, prompt for passphrase and optional “Remember passphrase” checkbox.
- Item view: Displays/copies the original PEM (encrypted) when present, ensuring fidelity.
- Desktop SSH agent: If a passphrase is stored, decrypts original PEM in memory on-demand and serves unencrypted OpenSSH PEM to the agent. No plaintext persisted.

Changes
- Importer UI
  - libs/importer/src/components/dialog/sshkey-password-prompt.component.html/.ts
    - Added rememberPassphrase checkbox with clear label “Store passphrase in this item (encrypted)”.
    - Dialog returns { password, rememberPassphrase }.
- Import flow
  - libs/vault/src/services/default-ssh-import-prompt.service.ts
    - Prompt loop supports WrongPassword retry.
    - After successful import, constructs SshKeyData/SshKeyApi with:
      - originalPrivateKey, isEncrypted (from SDK), and sshKeyPassphrase only if rememberPassphrase is selected.
- Desktop SSH agent
  - apps/desktop/src/autofill/services/ssh-agent.service.ts
    - On list/refresh:
      - If sshKeyPassphrase present, calls decrypt_ssh_key_for_agent(originalPrivateKey, passphrase) before sending to the agent.
      - Otherwise, uses stored privateKey as-is.
    - Decryptions are transient and in-memory only.
- Client models
  - libs/common/src/vault/models/api/ssh-key.api.ts
  - libs/common/src/vault/models/data/ssh-key.data.ts
  - libs/common/src/vault/models/domain/ssh-key.ts
  - libs/common/src/vault/models/view/ssh-key.view.ts
    - Added fields: originalPrivateKey, sshKeyPassphrase (and isEncrypted metadata for display logic).
    - View prefers originalPrivateKey for display/copy if present.
- Client request mapping
  - libs/common/src/vault/models/request/cipher.request.ts
    - Sends originalPrivateKey and sshKeyPassphrase (if provided).
    - Does not send isEncrypted to avoid type mismatch; server can derive when needed.

Backwards Compatibility
- New fields are optional and encrypted.
- Existing items remain compatible; no migrations required on the client.

i18n
- Added/used label for remember passphrase. Ensure translations:
  - rememberPassphrase: “Store passphrase in this item (encrypted)”
- Existing strings for password prompt are reused.

Security Considerations
- Passphrase storage is opt-in and encrypted-at-rest.
- No plaintext key is persisted; decryption only occurs in memory for agent use.

Testing
- Manual:
  1) Import an encrypted OpenSSH ed25519 key with passphrase; select “Remember passphrase”.
  2) Copy the private key from the item — matches original PEM including encryption header.
  3) Use the desktop agent to sign (e.g., git clone) — succeeds without storing plaintext.
  4) Repeat import without “Remember passphrase” — agent listing still works; when using, either prompt can be added later or use stored unencrypted key if provided.
- Unit (recommended):
  - DefaultSshImportPromptService mapping logic.
  - SshKeyView preference for originalPrivateKey.
  - Desktop agent flow mocks calling decrypt_ssh_key_for_agent.