### PR TITLE
Fix copy labels and toasts for ssh key items in web and browser

### DIFF
--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -867,6 +867,15 @@
   "copyLicenseNumber": {
     "message": "Copy license number"
   },
+  "copyPrivateKey": {
+    "message": "Copy private key"
+  },
+  "copyPublicKey": {
+    "message": "Copy public key"
+  },
+  "copyFingerprint": {
+    "message": "Copy fingerprint"
+  },
   "copyName": {
     "message": "Copy name"
   },

--- a/libs/vault/src/cipher-view/sshkey-sections/sshkey-view.component.html
+++ b/libs/vault/src/cipher-view/sshkey-sections/sshkey-view.component.html
@@ -25,9 +25,10 @@
         bitIconButton="bwi-clone"
         bitSuffix
         type="button"
+        [label]="'copyPrivateKey' | i18n"
         [appCopyClick]="sshKey.privateKey"
         showToast
-        [label]="'copyValue' | i18n"
+        [valueLabel]="'sshPrivateKey' | i18n"
       ></button>
     </bit-form-field>
     <bit-form-field>
@@ -43,9 +44,10 @@
         bitIconButton="bwi-clone"
         bitSuffix
         type="button"
+        [label]="'copyPublicKey' | i18n"
         [appCopyClick]="sshKey.publicKey"
         showToast
-        [label]="'copyValue' | i18n"
+        [valueLabel]="'sshPublicKey' | i18n"
       ></button>
     </bit-form-field>
     <bit-form-field>
@@ -61,9 +63,10 @@
         bitIconButton="bwi-clone"
         bitSuffix
         type="button"
+        [label]="'copyFingerprint' | i18n"
         [appCopyClick]="sshKey.keyFingerprint"
         showToast
-        [label]="'copyValue' | i18n"
+        [valueLabel]="'sshFingerprint' | i18n"
       ></button>
     </bit-form-field>
   </read-only-cipher-card>


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-16938

## 📔 Objective

Fixes the copy toast messages for ssh key items in the web and browser. Currently the toast message for all three items is `Copy Successful`.

Also fixes the hover labels to show `Copy <item>`, instead of just `<item>`.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
