### PR TITLE
[PM-25001] Do not fetch refresh token on sync during login

### DIFF
--- a/apps/cli/src/auth/commands/login.command.ts
+++ b/apps/cli/src/auth/commands/login.command.ts
@@ -333,7 +333,7 @@ export class LoginCommand {
       }
 
       // Run full sync before handling success response or password reset flows (to get Master Password Policies)
-      await this.syncService.fullSync(true);
+      await this.syncService.fullSync(true, { skipTokenRefresh: true });
 
       // Handle updating passwords if NOT using an API Key for authentication
       if (clientId == null && clientSecret == null) {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-25001](https://bitwarden.atlassian.net/browse/PM-25001)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Refresh token is not being fetched properly intermittently, this should rectify the issue by not fetching the refresh token on the `fullSync` call right after login.

We think the root cause of the refresh token fetch error is a rate limit that is being intermittently triggered on a full sync similar to [this PR](https://github.com/bitwarden/clients/pull/14423).

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-25001]: https://bitwarden.atlassian.net/browse/PM-25001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ