### PR TITLE
[PM-23998] Make manage the initial permission when clicking the add access badge

### DIFF
--- a/apps/web/src/app/admin-console/organizations/collections/vault.component.ts
+++ b/apps/web/src/app/admin-console/organizations/collections/vault.component.ts
@@ -118,6 +118,7 @@ import { VaultFilter } from "../../../vault/individual-vault/vault-filter/shared
 import { AdminConsoleCipherFormConfigService } from "../../../vault/org-vault/services/admin-console-cipher-form-config.service";
 import { GroupApiService, GroupView } from "../core";
 import { openEntityEventsDialog } from "../manage/entity-events.component";
+import { CollectionPermission } from "../shared/components/access-selector";
 import {
   CollectionDialogAction,
   CollectionDialogTabType,
@@ -854,6 +855,7 @@ export class VaultComponent implements OnInit, OnDestroy {
             event.item as CollectionAdminView,
             CollectionDialogTabType.Access,
             event.readonly,
+            event.initialPermission,
           );
           break;
         case "bulkEditCollectionAccess":
@@ -1325,6 +1327,7 @@ export class VaultComponent implements OnInit, OnDestroy {
     c: CollectionAdminView,
     tab: CollectionDialogTabType,
     readonly: boolean,
+    initialPermission?: CollectionPermission,
   ): Promise<void> {
     const dialog = openCollectionDialog(this.dialogService, {
       data: {
@@ -1335,6 +1338,7 @@ export class VaultComponent implements OnInit, OnDestroy {
         isAddAccessCollection: c.unmanaged,
         limitNestedCollections: !this.organization.canEditAnyCollection,
         isAdminConsoleActive: true,
+        initialPermission,
       },
     });
 

--- a/apps/web/src/app/admin-console/organizations/shared/components/access-selector/access-selector.component.ts
+++ b/apps/web/src/app/admin-console/organizations/shared/components/access-selector/access-selector.component.ts
@@ -126,7 +126,6 @@ export class AccessSelectorComponent implements ControlValueAccessor, OnInit, On
 
   protected itemType = AccessItemType;
   protected permissionList: Permission[];
-  protected initialPermission = CollectionPermission.View;
 
   /**
    * When disabled, the access selector will make the assumption that a readonly state is desired.
@@ -207,6 +206,12 @@ export class AccessSelectorComponent implements ControlValueAccessor, OnInit, On
    * Hide the multi-select so that new items cannot be added
    */
   @Input() hideMultiSelect = false;
+
+  /**
+   * The initial permission that will be selected in the dialog, defaults to View.
+   */
+  @Input()
+  protected initialPermission: CollectionPermission = CollectionPermission.View;
 
   constructor(
     private readonly formBuilder: FormBuilder,

--- a/apps/web/src/app/admin-console/organizations/shared/components/collection-dialog/collection-dialog.component.html
+++ b/apps/web/src/app/admin-console/organizations/shared/components/collection-dialog/collection-dialog.component.html
@@ -103,6 +103,7 @@
             [selectorLabelText]="'selectGroupsAndMembers' | i18n"
             [selectorHelpText]="'userPermissionOverrideHelperDesc' | i18n"
             [emptySelectionText]="'noMembersOrGroupsAdded' | i18n"
+            [initialPermission]="initialPermission"
           ></bit-access-selector>
           <bit-access-selector
             *ngIf="!organization.useGroups"

--- a/apps/web/src/app/admin-console/organizations/shared/components/collection-dialog/collection-dialog.component.ts
+++ b/apps/web/src/app/admin-console/organizations/shared/components/collection-dialog/collection-dialog.component.ts
@@ -93,6 +93,7 @@ export interface CollectionDialogParams {
   initialTab?: CollectionDialogTabType;
   parentCollectionId?: string;
   showOrgSelector?: boolean;
+  initialPermission?: CollectionPermission;
   /**
    * Flag to limit the nested collections to only those the user has explicit CanManage access too.
    */
@@ -143,6 +144,7 @@ export class CollectionDialogComponent implements OnInit, OnDestroy {
   protected showDeleteButton = false;
   protected showAddAccessWarning = false;
   protected buttonDisplayName: ButtonType = ButtonType.Save;
+  protected initialPermission: CollectionPermission;
   private orgExceedingCollectionLimit!: Organization;
 
   constructor(
@@ -162,6 +164,7 @@ export class CollectionDialogComponent implements OnInit, OnDestroy {
     private configService: ConfigService,
   ) {
     this.tabIndex = params.initialTab ?? CollectionDialogTabType.Info;
+    this.initialPermission = params.initialPermission ?? CollectionPermission.View;
   }
 
   async ngOnInit() {

--- a/apps/web/src/app/vault/components/vault-items/vault-collection-row.component.html
+++ b/apps/web/src/app/vault/components/vault-items/vault-collection-row.component.html
@@ -17,23 +17,32 @@
   </div>
 </td>
 <td bitCell [ngClass]="RowHeightClass">
-  <button
-    bitLink
-    [disabled]="disabled"
-    type="button"
-    class="tw-flex tw-w-full tw-text-start tw-leading-snug"
-    linkType="secondary"
-    title="{{ 'viewCollectionWithName' | i18n: collection.name }}"
-    [routerLink]="[]"
-    [queryParams]="{ collectionId: collection.id }"
-    queryParamsHandling="merge"
-    appStopProp
-  >
-    <span class="tw-truncate tw-mr-1">{{ collection.name }}</span>
-    <div>
-      <span *ngIf="showAddAccess" bitBadge variant="warning">{{ "addAccess" | i18n }}</span>
-    </div>
-  </button>
+  <div class="tw-flex">
+    <button
+      bitLink
+      [disabled]="disabled"
+      type="button"
+      class="tw-flex tw-text-start tw-leading-snug"
+      linkType="secondary"
+      title="{{ 'viewCollectionWithName' | i18n: collection.name }}"
+      [routerLink]="[]"
+      [queryParams]="{ collectionId: collection.id }"
+      queryParamsHandling="merge"
+      appStopProp
+    >
+      <span class="tw-truncate tw-mr-1">{{ collection.name }}</span>
+    </button>
+    @if (showAddAccess) {
+      <button
+        bitBadge
+        type="button"
+        (click)="addAccess(CollectionPermission.Manage)"
+        variant="warning"
+      >
+        {{ "addAccess" | i18n }}
+      </button>
+    }
+  </div>
 </td>
 <td bitCell [ngClass]="RowHeightClass" *ngIf="showOwner" class="tw-hidden lg:tw-table-cell">
   <app-org-badge

--- a/apps/web/src/app/vault/components/vault-items/vault-collection-row.component.ts
+++ b/apps/web/src/app/vault/components/vault-items/vault-collection-row.component.ts
@@ -10,6 +10,7 @@ import { CipherViewLike } from "@bitwarden/common/vault/utils/cipher-view-like-u
 import { GroupView } from "../../../admin-console/organizations/core";
 
 import {
+  CollectionPermission,
   convertToPermission,
   getPermissionList,
 } from "./../../../admin-console/organizations/shared/components/access-selector/access-selector.models";
@@ -24,6 +25,7 @@ import { RowHeightClass } from "./vault-items.component";
 export class VaultCollectionRowComponent<C extends CipherViewLike> {
   protected RowHeightClass = RowHeightClass;
   protected Unassigned = "unassigned";
+  protected CollectionPermission = CollectionPermission;
 
   @Input() disabled: boolean;
   @Input() collection: CollectionView;
@@ -100,6 +102,15 @@ export class VaultCollectionRowComponent<C extends CipherViewLike> {
 
   protected access(readonly: boolean) {
     this.onEvent.next({ type: "viewCollectionAccess", item: this.collection, readonly: readonly });
+  }
+
+  protected addAccess(initialPermission: CollectionPermission) {
+    this.onEvent.next({
+      type: "viewCollectionAccess",
+      item: this.collection,
+      readonly: false,
+      initialPermission,
+    });
   }
 
   protected deleteCollection() {

--- a/apps/web/src/app/vault/components/vault-items/vault-item-event.ts
+++ b/apps/web/src/app/vault/components/vault-items/vault-item-event.ts
@@ -1,12 +1,18 @@
 import { CollectionView } from "@bitwarden/admin-console/common";
 import { CipherViewLike } from "@bitwarden/common/vault/utils/cipher-view-like-utils";
+import { CollectionPermission } from "@bitwarden/web-vault/app/admin-console/organizations/shared/components/access-selector";
 
 import { VaultItem } from "./vault-item";
 
 export type VaultItemEvent<C extends CipherViewLike> =
   | { type: "viewAttachments"; item: C }
   | { type: "bulkEditCollectionAccess"; items: CollectionView[] }
-  | { type: "viewCollectionAccess"; item: CollectionView; readonly: boolean }
+  | {
+      type: "viewCollectionAccess";
+      item: CollectionView;
+      readonly: boolean;
+      initialPermission?: CollectionPermission;
+    }
   | { type: "viewEvents"; item: C }
   | { type: "editCollection"; item: CollectionView; readonly: boolean }
   | { type: "clone"; item: C }


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-23998
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
This PR makes the default permission in the collection dialog "Manage" when being accessed from the collections page by clicking the add access button. The ability to click the add access button to open the collection dialog is also new functionality.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
