### PR TITLE
[PM-25225] Added margin between item name and attachment icon

### DIFF
--- a/apps/browser/src/vault/popup/components/vault-v2/vault-list-items-container/vault-list-items-container.component.html
+++ b/apps/browser/src/vault/popup/components/vault-v2/vault-list-items-container/vault-list-items-container.component.html
@@ -116,7 +116,7 @@
             ></i>
             <i
               *ngIf="CipherViewLikeUtils.hasAttachments(cipher)"
-              class="bwi bwi-paperclip bwi-sm"
+              class="bwi bwi-paperclip bwi-sm margin-left-1ch"
               [appA11yTitle]="'attachments' | i18n"
             ></i>
             <span slot="secondary">{{ CipherViewLikeUtils.subtitle(cipher) }}</span>

--- a/libs/angular/src/scss/bwicons/styles/style.scss
+++ b/libs/angular/src/scss/bwicons/styles/style.scss
@@ -99,6 +99,10 @@ $icomoon-font-path: "~@bitwarden/angular/src/scss/bwicons/fonts/" !default;
   transform: rotate(270deg);
 }
 
+.margin-left-1ch {
+  margin-left: 1ch;
+}
+
 // For new icons - add their glyph name and value to the map below
 $icons: (
   "angle-down": "\e900",


### PR DESCRIPTION
## 🎟️ Tracking

Issue [#15568](https://github.com/bitwarden/clients/issues/15568)

## 📔 Objective

Added missing margin between item name and attachment icon

## 📸 Screenshots

Before:
<img width="173" height="75" alt="image" src="https://github.com/user-attachments/assets/24a70125-d122-474a-a35a-fed443000fd1" />
After:
<img width="186" height="81" alt="image" src="https://github.com/user-attachments/assets/73d063c4-22cb-4a2e-96c0-80387356a2ca" />


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
