### PR TITLE
Fix a cache race condition in local backed session storage

### DIFF
--- a/apps/browser/src/platform/services/local-backed-session-storage.service.ts
+++ b/apps/browser/src/platform/services/local-backed-session-storage.service.ts
@@ -77,20 +77,20 @@ export class LocalBackedSessionStorageService
       // Cache is still empty and we just got a value from local/session storage, cache it.
       this.cache[key] = value;
       return value as T;
-    } else if (this.cache[key] === undefined && this.cache[key] === undefined) {
+    } else if (this.cache[key] === undefined && value === undefined) {
       // Cache is still empty and we got nothing from local/session storage, no need to modify cache.
       return value as T;
-    } else if (this.cache[key] !== undefined && value === undefined) {
-      // Cache was filled after the local/session storage read completed. We got null
-      // from the storage read, but we have a value from the cache, use that.
-      this.logService.warning(
-        `Conflict while reading from local session storage. Key: ${key}. Using cached value.`,
-      );
-      return this.cache[key] as T;
     } else if (this.cache[key] !== undefined && value !== undefined) {
       // Conflict, somebody wrote to the cache while we were reading from storage
       // but we also got a value from storage. We assume the cache is more up to date
       // and use that value.
+      this.logService.warning(
+        `Conflict while reading from local session storage. Key: ${key}. Using cached value.`,
+      );
+      return this.cache[key] as T;
+    } else if (this.cache[key] !== undefined && value === undefined) {
+      // Cache was filled after the local/session storage read completed. We got null
+      // from the storage read, but we have a value from the cache, use that.
       this.logService.warning(
         `Conflict while reading from local session storage. Key: ${key}. Using cached value.`,
       );

--- a/apps/browser/src/platform/services/local-backed-session-storage.service.ts
+++ b/apps/browser/src/platform/services/local-backed-session-storage.service.ts
@@ -85,14 +85,14 @@ export class LocalBackedSessionStorageService
       // but we also got a value from storage. We assume the cache is more up to date
       // and use that value.
       this.logService.warning(
-        `Conflict while reading from local session storage. Key: ${key}. Using cached value.`,
+        `Conflict while reading from local session storage, both cache and storage have values. Key: ${key}. Using cached value.`,
       );
       return this.cache[key] as T;
     } else if (this.cache[key] !== undefined && value === undefined) {
       // Cache was filled after the local/session storage read completed. We got null
       // from the storage read, but we have a value from the cache, use that.
       this.logService.warning(
-        `Conflict while reading from local session storage. Key: ${key}. Using cached value.`,
+        `Conflict while reading from local session storage, cache has value but storage does not. Key: ${key}. Using cached value.`,
       );
       return this.cache[key] as T;
     }

--- a/apps/browser/src/platform/services/local-backed-session-storage.service.ts
+++ b/apps/browser/src/platform/services/local-backed-session-storage.service.ts
@@ -73,8 +73,29 @@ export class LocalBackedSessionStorageService
 
     const value = await this.getLocalSessionValue(await this.sessionKey.get(), key);
 
-    this.cache[key] = value;
-    return value as T;
+    if (this.cache[key] === undefined && value !== undefined) {
+      // Cache is still empty and we just got a value from local/session storage, cache it.
+      this.cache[key] = value;
+      return value as T;
+    } else if (this.cache[key] === undefined && this.cache[key] === undefined) {
+      // Cache is still empty and we got nothing from local/session storage, no need to modify cache.
+      return value as T;
+    } else if (this.cache[key] !== undefined && value === undefined) {
+      // Cache was filled after the local/session storage read completed. We got null
+      // from the storage read, but we have a value from the cache, use that.
+      this.logService.warning(
+        `Conflict while reading from local session storage. Key: ${key}. Using cached value.`,
+      );
+      return this.cache[key] as T;
+    } else if (this.cache[key] !== undefined && value !== undefined) {
+      // Conflict, somebody wrote to the cache while we were reading from storage
+      // but we also got a value from storage. We assume the cache is more up to date
+      // and use that value.
+      this.logService.warning(
+        `Conflict while reading from local session storage. Key: ${key}. Using cached value.`,
+      );
+      return this.cache[key] as T;
+    }
   }
 
   async has(key: string): Promise<boolean> {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

Fixing an issue where the cache gets corrupted (incorrectly set to `null`) due to a race condition.

I think there are two solutions to this problem:
1. Always write to local storage _FIRST_. That way if anyone reads local storage they will always get the correct value and can update the cache with it without consequences.
2. When reading the data, double-check the `cache` to see if it has changed while we were checking local storage. If it has then trust the cache because that is always updated first (and that update is atomic).

I think 1. has the issue that if we update `localStorage` first then `get` might get called before we have a chance to update the `cache` causing it to return incorrect data. This PR therefore implements 2.

### Race condition described

1. `LocalBackedSessionStorageService.get` gets called, checks `this.cache` and finds `undefined`. This is interpreted as meaning that we have no cached value and we need check storage.
4. Execution continues and we call into `getLocalSessionValue`
5. Inside `getLocalSessionValue` we call `this.localStorage.get` which eventually calls `chromeStorageApi.get`

6. Now two things happen:
  - `chromeStorageApi.get` reads `null` from the storage
  - The current thread of functions calls is pre-empted by a separate call to `LocalBackedSessionStorageService.save`

7. `LocalBackedSessionStorageService.save` updates the cache with a new non-null value
8. Execution continues and `await this.updateLocalSessionValue` is called.

9. This call is pre-empted and execution goes back to `LocalBackedSessionStorageService.get`
10. `chromeStorageApi.get` completes and returns the `null` that it read from storage at the time it was called, which in turn causes `getLocalSessionValue` to return `null`
11. The cache is updated with the value we got from `getLocalSessionValue`, i.e. `null`.
12.  `LocalBackedSessionStorageService.get` completes and returns `null`

13. Execution goes back to `LocalBackedSessionStorageService.save` which saves the non-null value to local storage and then the function completes.

Result:
- The cache contains a `null` value
- Local storage contains a `non-null` value
- Any future call to `LocalBackedSessionStorageService.get` will see `null` in the cache and simply return that, ignoring the correct `non-null` value in local storage

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
