### PR TITLE
[PM-25222] Fix svg alignment issues caused by new preflight defaults

### DIFF
--- a/libs/components/src/tw-theme-preflight.css
+++ b/libs/components/src/tw-theme-preflight.css
@@ -65,4 +65,9 @@
   select {
     appearance: none;
   }
+
+  /* overriding preflight since the apps were built assuming svgs are inline */
+  svg {
+    display: inline;
+  }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[PM-25222](https://bitwarden.atlassian.net/browse/PM-25222)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
The new Tailwind preflight styles make svgs block elements. Previously they were inline, so the apps have styled them as if they are inline. Changing to block therefore messed up some alignment styling. This PR overrides the styles to set them as inline again as a quick fix.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
| Before | After |
|--------|--------|
| <img width="557" height="388" alt="1b2400ae-ba98-499d-be2c-ba29fc8bc8bd" src="https://github.com/user-attachments/assets/83a6f9ce-aa57-49fd-87a0-29141218865e" /> | <img width="565" height="385" alt="Screenshot 2025-08-27 at 9 30 43 AM" src="https://github.com/user-attachments/assets/c377cffe-de9b-4cb2-90a5-0be21ee9078f" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-25222]: https://bitwarden.atlassian.net/browse/PM-25222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ