### PR TITLE
Move max-old-space-size to .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 save-exact=true
+node-options=--max-old-space-size=8192

--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
     "test:locales": "tsc --project ./scripts/tsconfig.json && node ./scripts/dist/test-locales.js",
     "lint:dep-ownership": "tsc --project ./scripts/tsconfig.json && node ./scripts/dist/dep-ownership.js",
     "docs:json": "compodoc -p ./tsconfig.json -e json -d . --disableRoutesGraph",
-    "storybook": "cross-env NODE_OPTIONS=\"--max-old-space-size=8192\" ng run components:storybook",
-    "build-storybook": "cross-env NODE_OPTIONS=\"--max-old-space-size=8192\" ng run components:build-storybook",
-    "build-storybook:ci": "cross-env NODE_OPTIONS=\"--max-old-space-size=8192\" ng run components:build-storybook --webpack-stats-json",
+    "storybook": "ng run components:storybook",
+    "build-storybook": "ng run components:build-storybook",
+    "build-storybook:ci": "ng run components:build-storybook --webpack-stats-json",
     "test-stories": "test-storybook --url http://localhost:6006",
     "test-stories:watch": "test-stories --watch"
   },


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
N/A

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Fix intermittent failures in our tests on `main` due to heap overflows. e.g.

```
PASS libs/common tests libs/common/src/vault/models/view/folder.view.spec.ts
PASS libs/tools/generator/extensions/navigation/src/key-definition.spec.ts

<--- Last few GCs --->

[3133:0x3509b000]   349851 ms: Scavenge 4034.7 (4123.7) -> 4030.6 (4142.2) MB, pooled: 0 MB, 14.88 / 0.11 ms  (average mu = 0.394, current mu = 0.423) allocation failure; 
[3133:0x3509b000]   353690 ms: Mark-Compact 4036.9 (4143.9) -> 4022.9 (4145.3) MB, pooled: 0 MB, 3794.01 / 4.11 ms  (average mu = 0.282, current mu = 0.170) allocation failure; GC in old space requested


<--- JS stacktrace --->

FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
----- Native stack trace -----

FAIL libs/common tests libs/common/src/platform/services/key-state/provider-keys.state.spec.ts
  ● Test suite failed to run

    A jest worker process (pid=3133) was terminated by another process: signal=SIGTERM, exitCode=null. Operating system logs may contain more information on why this occurred.

      at ChildProcessWorker._onExit (../../node_modules/jest-worker/build/workers/ChildProcessWorker.js:370:23)

PASS apps/browser/src/background/main.background.spec.ts (13.199 s)
PASS libs/common tests libs/common/src/admin-console/enums/policy-type.enum.spec.ts
```

This is because our app generally runs with `NODE_OPTIONS=\"--max-old-space-size=8192\"` to increase the available memory, but the tests weren't running with this environment variable set. (Obviously the real solution is to restructure our app, we're working on that.)

I've moved this setting into the `.npmrc` file using [node-options config](https://docs.npmjs.com/cli/v10/using-npm/config#node-options), so that it applies to all `npm` lifecycle scripts from this directory.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
