### PR TITLE
[PM-24797] Hidden custom fields for new ciphers

### DIFF
--- a/libs/vault/src/cipher-form/components/custom-fields/custom-fields.component.html
+++ b/libs/vault/src/cipher-form/components/custom-fields/custom-fields.component.html
@@ -22,6 +22,7 @@
         }"
         [attr.data-testid]="field.value.name + '-entry'"
         cdkDrag
+        [cdkDragDisabled]="!canEdit(field.value.type)"
         #customFieldRow
       >
         <!-- Text Field -->

--- a/libs/vault/src/cipher-form/components/custom-fields/custom-fields.component.ts
+++ b/libs/vault/src/cipher-form/components/custom-fields/custom-fields.component.ts
@@ -150,7 +150,9 @@ export class CustomFieldsComponent implements OnInit, AfterViewInit {
   canEdit(type: FieldType): boolean {
     return (
       !this.isPartialEdit &&
-      (type !== FieldType.Hidden || this.cipherFormContainer.originalCipherView?.viewPassword)
+      (type !== FieldType.Hidden ||
+        this.cipherFormContainer.originalCipherView === null ||
+        this.cipherFormContainer.originalCipherView.viewPassword)
     );
   }
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-24797](https://bitwarden.atlassian.net/browse/PM-24797)

## 📔 Objective

When adding a new cipher the user should be able to edit & reorder a hidden field

### Root Cause

The `canEdit` method was not handing the add state of the form where `originalCipherView` will be null.

### Extra Fix

The hidden field was still draggable even when the user could not edit it - I disabled the drag-ability when the user cannot edit. 

## 📸 Screenshots

<video src="https://github.com/user-attachments/assets/c585f5ae-b36b-46ed-a4b7-1f61dab46d21" />

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-24797]: https://bitwarden.atlassian.net/browse/PM-24797?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ