### PR TITLE
[PM-25287] Add AddMasterPasswordUnlockData state migration

### DIFF
--- a/libs/state/src/state-migrations/migrate.ts
+++ b/libs/state/src/state-migrations/migrate.ts
@@ -69,12 +69,13 @@ import { MoveBiometricAutoPromptToAccount } from "./migrations/7-move-biometric-
 import { RemoveAcBannersDismissed } from "./migrations/70-remove-ac-banner-dismissed";
 import { RemoveNewCustomizationOptionsCalloutDismissed } from "./migrations/71-remove-new-customization-options-callout-dismissed";
 import { RemoveAccountDeprovisioningBannerDismissed } from "./migrations/72-remove-account-deprovisioning-banner-dismissed";
+import { AddMasterPasswordUnlockData } from "./migrations/73-add-master-password-unlock-data";
 import { MoveStateVersionMigrator } from "./migrations/8-move-state-version";
 import { MoveBrowserSettingsToGlobal } from "./migrations/9-move-browser-settings-to-global";
 import { MinVersionMigrator } from "./migrations/min-version";
 
 export const MIN_VERSION = 3;
-export const CURRENT_VERSION = 72;
+export const CURRENT_VERSION = 73;
 export type MinVersion = typeof MIN_VERSION;
 
 export function createMigrationBuilder() {
@@ -148,7 +149,8 @@ export function createMigrationBuilder() {
     .with(MigrateIncorrectFolderKey, 68, 69)
     .with(RemoveAcBannersDismissed, 69, 70)
     .with(RemoveNewCustomizationOptionsCalloutDismissed, 70, 71)
-    .with(RemoveAccountDeprovisioningBannerDismissed, 71, CURRENT_VERSION);
+    .with(RemoveAccountDeprovisioningBannerDismissed, 71, 72)
+    .with(AddMasterPasswordUnlockData, 72, CURRENT_VERSION);
 }
 
 export async function currentVersion(

--- a/libs/state/src/state-migrations/migrations/73-add-master-password-unlock-data.spec.ts
+++ b/libs/state/src/state-migrations/migrations/73-add-master-password-unlock-data.spec.ts
@@ -1,0 +1,155 @@
+import { runMigrator } from "../migration-helper.spec";
+
+import { AddMasterPasswordUnlockData } from "./73-add-master-password-unlock-data";
+
+describe("AddMasterPasswordUnlockData", () => {
+  const sut = new AddMasterPasswordUnlockData(72, 73);
+
+  describe("migrate", () => {
+    it("updates users that don't have master password unlock data", async () => {
+      const output = await runMigrator(sut, {
+        global_account_accounts: {
+          user1: {
+            email: "user1@email.Com",
+            name: "User 1",
+          },
+          user2: {
+            email: "user2@email.com",
+            name: "User 2",
+          },
+        },
+        user_user1_masterPassword_masterKeyEncryptedUserKey: "user1MasterKeyEncryptedUser",
+        user_user1_kdfConfig_kdfConfig: { kdfType: 0, iterations: 600000 },
+        user_user2_masterPassword_masterKeyEncryptedUserKey: "user2MasterKeyEncryptedUser",
+        user_user2_kdfConfig_kdfConfig: { kdfType: 0, iterations: 600001 },
+      });
+
+      expect(output).toEqual({
+        global_account_accounts: {
+          user1: {
+            email: "user1@email.Com",
+            name: "User 1",
+          },
+          user2: {
+            email: "user2@email.com",
+            name: "User 2",
+          },
+        },
+        user_user1_masterPassword_masterKeyEncryptedUserKey: "user1MasterKeyEncryptedUser",
+        user_user1_kdfConfig_kdfConfig: { kdfType: 0, iterations: 600000 },
+        user_user1_masterPasswordUnlock_masterPasswordUnlockKey: {
+          salt: "user1@email.com",
+          kdf: { kdfType: 0, iterations: 600000 },
+          masterKeyWrappedUserKey: "user1MasterKeyEncryptedUser",
+        },
+        user_user2_masterPassword_masterKeyEncryptedUserKey: "user2MasterKeyEncryptedUser",
+        user_user2_kdfConfig_kdfConfig: { kdfType: 0, iterations: 600001 },
+        user_user2_masterPasswordUnlock_masterPasswordUnlockKey: {
+          salt: "user2@email.com",
+          kdf: { kdfType: 0, iterations: 600001 },
+          masterKeyWrappedUserKey: "user2MasterKeyEncryptedUser",
+        },
+      });
+    });
+
+    it("does not update users that already have master password unlock data", async () => {
+      const output = await runMigrator(sut, {
+        global_account_accounts: {
+          user1: {
+            email: "user1@email.Com",
+            name: "User 1",
+          },
+        },
+        user_user1_masterPassword_masterKeyEncryptedUserKey: "user1MasterKeyEncryptedUser",
+        user_user1_kdfConfig_kdfConfig: { kdfType: 0, iterations: 600000 },
+        user_user1_masterPasswordUnlock_masterPasswordUnlockKey: { someData: "data" },
+      });
+
+      expect(output).toEqual({
+        global_account_accounts: {
+          user1: {
+            email: "user1@email.Com",
+            name: "User 1",
+          },
+        },
+        user_user1_masterPassword_masterKeyEncryptedUserKey: "user1MasterKeyEncryptedUser",
+        user_user1_kdfConfig_kdfConfig: { kdfType: 0, iterations: 600000 },
+        user_user1_masterPasswordUnlock_masterPasswordUnlockKey: { someData: "data" },
+      });
+    });
+
+    it("does not update users that have missing data required to construct master password unlock data", async () => {
+      const output = await runMigrator(sut, {
+        global_account_accounts: {
+          user1: {
+            name: "User 1",
+          },
+        },
+        user_user1_kdfConfig_kdfConfig: { kdfType: 0, iterations: 600000 },
+      });
+
+      expect(output).toEqual({
+        global_account_accounts: {
+          user1: {
+            name: "User 1",
+          },
+        },
+        user_user1_kdfConfig_kdfConfig: { kdfType: 0, iterations: 600000 },
+      });
+    });
+  });
+
+  describe("rollback", () => {
+    it("rolls back data", async () => {
+      const output = await runMigrator(
+        sut,
+        {
+          global_account_accounts: {
+            user1: {
+              email: "user1@email.Com",
+              name: "User 1",
+            },
+            user2: {
+              email: "user2@email.com",
+              name: "User 2",
+            },
+            user3: {
+              email: "user3@email.com",
+              name: "User 3",
+            },
+          },
+          user_user1_masterPassword_masterKeyEncryptedUserKey: "user1MasterKeyEncryptedUser",
+          user_user1_kdfConfig_kdfConfig: { kdfType: 0, iterations: 600000 },
+          user_user2_masterPassword_masterKeyEncryptedUserKey: "user2MasterKeyEncryptedUser",
+          user_user2_kdfConfig_kdfConfig: { kdfType: 0, iterations: 600001 },
+          user_user1_masterPasswordUnlock_masterPasswordUnlockKey: "fakeData",
+          user_user2_masterPasswordUnlock_masterPasswordUnlockKey: "fakeData",
+          user_user3_masterPasswordUnlock_masterPasswordUnlockKey: null,
+        },
+        "rollback",
+      );
+
+      expect(output).toEqual({
+        global_account_accounts: {
+          user1: {
+            email: "user1@email.Com",
+            name: "User 1",
+          },
+          user2: {
+            email: "user2@email.com",
+            name: "User 2",
+          },
+          user3: {
+            email: "user3@email.com",
+            name: "User 3",
+          },
+        },
+        user_user1_masterPassword_masterKeyEncryptedUserKey: "user1MasterKeyEncryptedUser",
+        user_user1_kdfConfig_kdfConfig: { kdfType: 0, iterations: 600000 },
+        user_user2_masterPassword_masterKeyEncryptedUserKey: "user2MasterKeyEncryptedUser",
+        user_user2_kdfConfig_kdfConfig: { kdfType: 0, iterations: 600001 },
+        user_user3_masterPasswordUnlock_masterPasswordUnlockKey: null,
+      });
+    });
+  });
+});

--- a/libs/state/src/state-migrations/migrations/73-add-master-password-unlock-data.ts
+++ b/libs/state/src/state-migrations/migrations/73-add-master-password-unlock-data.ts
@@ -1,0 +1,83 @@
+import { KeyDefinitionLike, MigrationHelper } from "../migration-helper";
+import { Migrator } from "../migrator";
+
+export const ACCOUNT_ACCOUNTS: KeyDefinitionLike = {
+  stateDefinition: {
+    name: "account",
+  },
+  key: "accounts",
+};
+
+export const MASTER_PASSWORD_UNLOCK_KEY: KeyDefinitionLike = {
+  key: "masterPasswordUnlockKey",
+  stateDefinition: { name: "masterPasswordUnlock" },
+};
+
+export const MASTER_KEY_ENCRYPTED_USER_KEY: KeyDefinitionLike = {
+  key: "masterKeyEncryptedUserKey",
+  stateDefinition: { name: "masterPassword" },
+};
+
+export const KDF_CONFIG_DISK: KeyDefinitionLike = {
+  key: "kdfConfig",
+  stateDefinition: { name: "kdfConfig" },
+};
+
+type KdfConfig = {
+  iterations: number;
+  kdfType: 0 | 1;
+  memory?: number;
+  parallelism?: number;
+};
+
+export type AccountType = {
+  profile?: {
+    email?: string;
+  };
+};
+
+type AccountsMap = Record<string, Account>;
+type Account = {
+  email: string;
+  name: string;
+};
+
+export class AddMasterPasswordUnlockData extends Migrator<72, 73> {
+  async migrate(helper: MigrationHelper): Promise<void> {
+    async function migrateAccount(userId: string, accounts: AccountsMap) {
+      const email = accounts[userId]?.email;
+      const kdfConfig: KdfConfig = await helper.getFromUser(userId, KDF_CONFIG_DISK);
+      const masterKeyEncryptedUserKey = await helper.getFromUser(
+        userId,
+        MASTER_KEY_ENCRYPTED_USER_KEY,
+      );
+      if (
+        (await helper.getFromUser(userId, MASTER_PASSWORD_UNLOCK_KEY)) == null &&
+        email != null &&
+        kdfConfig != null &&
+        masterKeyEncryptedUserKey != null
+      ) {
+        await helper.setToUser(userId, MASTER_PASSWORD_UNLOCK_KEY, {
+          salt: email.trim().toLowerCase(),
+          kdf: kdfConfig,
+          masterKeyWrappedUserKey: masterKeyEncryptedUserKey,
+        });
+      }
+    }
+
+    const accountDictionary = await helper.getFromGlobal<AccountsMap>(ACCOUNT_ACCOUNTS);
+    const accounts = await helper.getAccounts();
+    await Promise.all(accounts.map(({ userId }) => migrateAccount(userId, accountDictionary)));
+  }
+
+  async rollback(helper: MigrationHelper): Promise<void> {
+    async function rollbackAccount(userId: string) {
+      if ((await helper.getFromUser(userId, MASTER_PASSWORD_UNLOCK_KEY)) != null) {
+        await helper.removeFromUser(userId, MASTER_PASSWORD_UNLOCK_KEY);
+      }
+    }
+
+    const accounts = await helper.getAccounts();
+    await Promise.all(accounts.map(({ userId }) => rollbackAccount(userId)));
+  }
+}


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-25287

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->


Add a state migration that constructs MasterPasswordUnlockData from existing state and sets the MasterPasswordUnlockData if the state is empty. This is to cover an edge case when upgrading clients where MasterPasswordUnlockData could potentially be unset. See the ticket for more details.


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
