### PR TITLE
[PM23246] Add unlock with master password unlock data for lock component

### DIFF
--- a/libs/angular/src/services/jslib-services.module.ts
+++ b/libs/angular/src/services/jslib-services.module.ts
@@ -161,10 +161,12 @@ import { DeviceTrustServiceAbstraction } from "@bitwarden/common/key-management/
 import { DeviceTrustService } from "@bitwarden/common/key-management/device-trust/services/device-trust.service.implementation";
 import { KeyConnectorService as KeyConnectorServiceAbstraction } from "@bitwarden/common/key-management/key-connector/abstractions/key-connector.service";
 import { KeyConnectorService } from "@bitwarden/common/key-management/key-connector/services/key-connector.service";
+import { MasterPasswordUnlockService } from "@bitwarden/common/key-management/master-password/abstractions/master-password-unlock.service";
 import {
   InternalMasterPasswordServiceAbstraction,
   MasterPasswordServiceAbstraction,
 } from "@bitwarden/common/key-management/master-password/abstractions/master-password.service.abstraction";
+import { DefaultMasterPasswordUnlockService } from "@bitwarden/common/key-management/master-password/services/default-master-password-unlock.service";
 import { MasterPasswordService } from "@bitwarden/common/key-management/master-password/services/master-password.service";
 import { PinServiceAbstraction } from "@bitwarden/common/key-management/pin/pin.service.abstraction";
 import { PinService } from "@bitwarden/common/key-management/pin/pin.service.implementation";
@@ -999,6 +1001,11 @@ const safeProviders: SafeProvider[] = [
   safeProvider({
     provide: MasterPasswordServiceAbstraction,
     useExisting: InternalMasterPasswordServiceAbstraction,
+  }),
+  safeProvider({
+    provide: MasterPasswordUnlockService,
+    useClass: DefaultMasterPasswordUnlockService,
+    deps: [InternalMasterPasswordServiceAbstraction, KeyService],
   }),
   safeProvider({
     provide: KeyConnectorServiceAbstraction,

--- a/libs/common/src/key-management/master-password/abstractions/master-password-unlock.service.ts
+++ b/libs/common/src/key-management/master-password/abstractions/master-password-unlock.service.ts
@@ -1,0 +1,15 @@
+import { Account } from "../../../auth/abstractions/account.service";
+import { UserKey } from "../../../types/key";
+
+export abstract class MasterPasswordUnlockService {
+  /**
+   * Unlocks the user's account using the master password.
+   * @param masterPassword The master password provided by the user.
+   * @param activeAccount The active account for which the key is being unlocked.
+   * @returns the user's decrypted userKey.
+   */
+  abstract unlockWithMasterPassword(
+    masterPassword: string,
+    activeAccount: Account,
+  ): Promise<UserKey>;
+}

--- a/libs/common/src/key-management/master-password/abstractions/master-password.service.abstraction.ts
+++ b/libs/common/src/key-management/master-password/abstractions/master-password.service.abstraction.ts
@@ -166,4 +166,12 @@ export abstract class InternalMasterPasswordServiceAbstraction extends MasterPas
     masterPasswordUnlockData: MasterPasswordUnlockData,
     userId: UserId,
   ): Promise<void>;
+
+  /**
+   * An observable that emits the master password unlock data for the target user.
+   * @param userId The user ID.
+   * @throws If the user ID is null or undefined.
+   * @returns An observable that emits the master password unlock data or null if not found.
+   */
+  abstract masterPasswordUnlockData$(userId: UserId): Observable<MasterPasswordUnlockData | null>;
 }

--- a/libs/common/src/key-management/master-password/services/default-master-password-unlock.service.spec.ts
+++ b/libs/common/src/key-management/master-password/services/default-master-password-unlock.service.spec.ts
@@ -1,0 +1,193 @@
+import { mock, MockProxy } from "jest-mock-extended";
+import { of } from "rxjs";
+
+// eslint-disable-next-line no-restricted-imports
+import { Argon2KdfConfig, KeyService } from "@bitwarden/key-management";
+import { UserId } from "@bitwarden/user-core";
+
+import { Account } from "../../../auth/abstractions/account.service";
+import { HashPurpose } from "../../../platform/enums";
+import { SymmetricCryptoKey } from "../../../platform/models/domain/symmetric-crypto-key";
+import { MasterKey, UserKey } from "../../../types/key";
+import { EncString } from "../../crypto/models/enc-string";
+import { InternalMasterPasswordServiceAbstraction } from "../abstractions/master-password.service.abstraction";
+import {
+  MasterKeyWrappedUserKey,
+  MasterPasswordSalt,
+  MasterPasswordUnlockData,
+} from "../types/master-password.types";
+
+import { DefaultMasterPasswordUnlockService } from "./default-master-password-unlock.service";
+
+describe("DefaultMasterPasswordUnlockService", () => {
+  let sut: DefaultMasterPasswordUnlockService;
+
+  let masterPasswordService: MockProxy<InternalMasterPasswordServiceAbstraction>;
+  let keyService: MockProxy<KeyService>;
+
+  const mockMasterPassword = "testExample";
+  const activeAccount: Account = {
+    id: "user-id" as UserId,
+    email: "user@example.com",
+    emailVerified: true,
+    name: "User",
+  };
+  const mockUserKey = new SymmetricCryptoKey(new Uint8Array(64)) as UserKey;
+  const mockMasterPasswordUnlockData: MasterPasswordUnlockData = new MasterPasswordUnlockData(
+    "user@example.com" as MasterPasswordSalt,
+    new Argon2KdfConfig(100000, 64, 1),
+    new EncString("encryptedMasterKeyWrappedUserKey") as MasterKeyWrappedUserKey,
+  );
+
+  //Legacy data for tests
+  const mockMasterKey = new SymmetricCryptoKey(new Uint8Array(32)) as MasterKey;
+  const mockKeyHash = "localKeyHash";
+
+  beforeEach(() => {
+    masterPasswordService = mock<InternalMasterPasswordServiceAbstraction>();
+    keyService = mock<KeyService>();
+
+    sut = new DefaultMasterPasswordUnlockService(masterPasswordService, keyService);
+
+    masterPasswordService.masterPasswordUnlockData$.mockReturnValue(
+      of(mockMasterPasswordUnlockData),
+    );
+    masterPasswordService.unwrapUserKeyFromMasterPasswordUnlockData.mockResolvedValue(mockUserKey);
+
+    // Legacy state mocking
+    keyService.makeMasterKey.mockResolvedValue(mockMasterKey);
+    keyService.hashMasterKey.mockResolvedValue(mockKeyHash);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe("unlockWithMasterPassword", () => {
+    test.each([null as unknown as string, undefined as unknown as string, ""])(
+      "throws when the provided master password is %s",
+      async (masterPassword) => {
+        await expect(sut.unlockWithMasterPassword(masterPassword, activeAccount)).rejects.toThrow(
+          "Master password is required",
+        );
+        expect(masterPasswordService.masterPasswordUnlockData$).not.toHaveBeenCalled();
+        expect(
+          masterPasswordService.unwrapUserKeyFromMasterPasswordUnlockData,
+        ).not.toHaveBeenCalled();
+      },
+    );
+
+    test.each([null as unknown as Account, undefined as unknown as Account])(
+      "throws when the provided master password is %s",
+      async (account) => {
+        await expect(sut.unlockWithMasterPassword(mockMasterPassword, account)).rejects.toThrow(
+          "Active account is required",
+        );
+      },
+    );
+
+    it("throws an error when the user doesn't have masterPasswordUnlockData", async () => {
+      masterPasswordService.masterPasswordUnlockData$.mockReturnValue(of(null));
+
+      await expect(sut.unlockWithMasterPassword(mockMasterPassword, activeAccount)).rejects.toThrow(
+        "Master password unlock data was not found for the user " + activeAccount.id,
+      );
+      expect(masterPasswordService.masterPasswordUnlockData$).toHaveBeenCalledWith(
+        activeAccount.id,
+      );
+      expect(
+        masterPasswordService.unwrapUserKeyFromMasterPasswordUnlockData,
+      ).not.toHaveBeenCalled();
+    });
+
+    test.each([null as unknown as UserKey, undefined as unknown as UserKey])(
+      "throws when the unwrap userKey is %s",
+      async (userKey) => {
+        masterPasswordService.masterPasswordUnlockData$.mockReturnValue(
+          of(mockMasterPasswordUnlockData),
+        );
+        masterPasswordService.unwrapUserKeyFromMasterPasswordUnlockData.mockResolvedValue(userKey);
+
+        await expect(
+          sut.unlockWithMasterPassword(mockMasterPassword, activeAccount),
+        ).rejects.toThrow("User key couldn't be decrypted");
+        expect(masterPasswordService.masterPasswordUnlockData$).toHaveBeenCalledWith(
+          activeAccount.id,
+        );
+        expect(
+          masterPasswordService.unwrapUserKeyFromMasterPasswordUnlockData,
+        ).toHaveBeenCalledWith(mockMasterPassword, mockMasterPasswordUnlockData);
+      },
+    );
+
+    it("returns userKey successfully", async () => {
+      const result = await sut.unlockWithMasterPassword(mockMasterPassword, activeAccount);
+
+      expect(result).toEqual(mockUserKey);
+      expect(masterPasswordService.masterPasswordUnlockData$).toHaveBeenCalledWith(
+        activeAccount.id,
+      );
+      expect(masterPasswordService.unwrapUserKeyFromMasterPasswordUnlockData).toHaveBeenCalledWith(
+        mockMasterPassword,
+        mockMasterPasswordUnlockData,
+      );
+    });
+
+    it("sets legacy state on success", async () => {
+      const result = await sut.unlockWithMasterPassword(mockMasterPassword, activeAccount);
+
+      expect(result).toEqual(mockUserKey);
+      expect(masterPasswordService.masterPasswordUnlockData$).toHaveBeenCalledWith(
+        activeAccount.id,
+      );
+      expect(masterPasswordService.unwrapUserKeyFromMasterPasswordUnlockData).toHaveBeenCalledWith(
+        mockMasterPassword,
+        mockMasterPasswordUnlockData,
+      );
+
+      expect(keyService.makeMasterKey).toHaveBeenCalledWith(
+        mockMasterPassword,
+        activeAccount.email,
+        mockMasterPasswordUnlockData.kdf,
+      );
+      expect(keyService.hashMasterKey).toHaveBeenCalledWith(
+        mockMasterPassword,
+        mockMasterKey,
+        HashPurpose.LocalAuthorization,
+      );
+      expect(masterPasswordService.setMasterKeyHash).toHaveBeenCalledWith(
+        mockKeyHash,
+        activeAccount.id,
+      );
+      expect(masterPasswordService.setMasterKey).toHaveBeenCalledWith(
+        mockMasterKey,
+        activeAccount.id,
+      );
+    });
+
+    it("throws an error if masterKey construction fails", async () => {
+      keyService.makeMasterKey.mockResolvedValue(null as unknown as MasterKey);
+
+      await expect(sut.unlockWithMasterPassword(mockMasterPassword, activeAccount)).rejects.toThrow(
+        "Master key could not be created to set legacy master password state.",
+      );
+
+      expect(masterPasswordService.masterPasswordUnlockData$).toHaveBeenCalledWith(
+        activeAccount.id,
+      );
+      expect(masterPasswordService.unwrapUserKeyFromMasterPasswordUnlockData).toHaveBeenCalledWith(
+        mockMasterPassword,
+        mockMasterPasswordUnlockData,
+      );
+
+      expect(keyService.makeMasterKey).toHaveBeenCalledWith(
+        mockMasterPassword,
+        activeAccount.email,
+        mockMasterPasswordUnlockData.kdf,
+      );
+      expect(keyService.hashMasterKey).not.toHaveBeenCalled();
+      expect(masterPasswordService.setMasterKeyHash).not.toHaveBeenCalled();
+      expect(masterPasswordService.setMasterKey).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/libs/common/src/key-management/master-password/services/default-master-password-unlock.service.ts
+++ b/libs/common/src/key-management/master-password/services/default-master-password-unlock.service.ts
@@ -1,0 +1,78 @@
+import { firstValueFrom } from "rxjs";
+
+import { Account } from "@bitwarden/common/auth/abstractions/account.service";
+import { InternalMasterPasswordServiceAbstraction } from "@bitwarden/common/key-management/master-password/abstractions/master-password.service.abstraction";
+import { HashPurpose } from "@bitwarden/common/platform/enums";
+import { UserKey } from "@bitwarden/common/types/key";
+// eslint-disable-next-line no-restricted-imports
+import { KdfConfig, KeyService } from "@bitwarden/key-management";
+
+import { MasterPasswordUnlockService } from "../abstractions/master-password-unlock.service";
+
+export class DefaultMasterPasswordUnlockService implements MasterPasswordUnlockService {
+  constructor(
+    private readonly masterPasswordService: InternalMasterPasswordServiceAbstraction,
+    private readonly keyService: KeyService,
+  ) {}
+
+  async unlockWithMasterPassword(masterPassword: string, activeAccount: Account): Promise<UserKey> {
+    this.validateInput(masterPassword, activeAccount);
+
+    const masterPasswordUnlockData = await firstValueFrom(
+      this.masterPasswordService.masterPasswordUnlockData$(activeAccount.id),
+    );
+
+    if (masterPasswordUnlockData == null) {
+      throw new Error("Master password unlock data was not found for the user " + activeAccount.id);
+    }
+
+    const userKey = await this.masterPasswordService.unwrapUserKeyFromMasterPasswordUnlockData(
+      masterPassword,
+      masterPasswordUnlockData,
+    );
+
+    if (userKey == null) {
+      throw new Error("User key couldn't be decrypted");
+    }
+
+    await this.setLegacyState(masterPassword, activeAccount, masterPasswordUnlockData.kdf);
+
+    return userKey;
+  }
+
+  private validateInput(masterPassword: string, activeAccount: Account): void {
+    if (!masterPassword) {
+      throw new Error("Master password is required");
+    }
+    if (!activeAccount) {
+      throw new Error("Active account is required");
+    }
+  }
+
+  // Previously unlocking had the side effect of setting the masterKey and masterPasswordHash in state.
+  // This is to preserve that behavior, once masterKey and masterPasswordHash state is removed this should be removed as well.
+  private async setLegacyState(
+    masterPassword: string,
+    activeAccount: Account,
+    kdfConfig: KdfConfig,
+  ): Promise<void> {
+    const masterKey = await this.keyService.makeMasterKey(
+      masterPassword,
+      activeAccount.email,
+      kdfConfig,
+    );
+
+    if (!masterKey) {
+      throw new Error("Master key could not be created to set legacy master password state.");
+    }
+
+    const localKeyHash = await this.keyService.hashMasterKey(
+      masterPassword,
+      masterKey,
+      HashPurpose.LocalAuthorization,
+    );
+
+    await this.masterPasswordService.setMasterKeyHash(localKeyHash, activeAccount.id);
+    await this.masterPasswordService.setMasterKey(masterKey, activeAccount.id);
+  }
+}

--- a/libs/common/src/key-management/master-password/services/fake-master-password.service.ts
+++ b/libs/common/src/key-management/master-password/services/fake-master-password.service.ts
@@ -115,4 +115,8 @@ export class FakeMasterPasswordService implements InternalMasterPasswordServiceA
   ): Promise<void> {
     return this.mock.setMasterPasswordUnlockData(masterPasswordUnlockData, userId);
   }
+
+  masterPasswordUnlockData$(userId: UserId): Observable<MasterPasswordUnlockData | null> {
+    return this.mock.masterPasswordUnlockData$(userId);
+  }
 }

--- a/libs/common/src/key-management/master-password/services/master-password.service.spec.ts
+++ b/libs/common/src/key-management/master-password/services/master-password.service.spec.ts
@@ -1,6 +1,5 @@
 import { mock, MockProxy } from "jest-mock-extended";
-import * as rxjs from "rxjs";
-import { firstValueFrom, of } from "rxjs";
+import { firstValueFrom } from "rxjs";
 import { Jsonify } from "type-fest";
 
 import { SdkLoadService } from "@bitwarden/common/platform/abstractions/sdk/sdk-load.service";
@@ -10,6 +9,7 @@ import { Argon2KdfConfig, KdfConfig, KdfType, PBKDF2KdfConfig } from "@bitwarden
 
 import {
   FakeAccountService,
+  FakeStateProvider,
   makeEncString,
   makeSymmetricCryptoKey,
   mockAccountServiceWith,
@@ -18,7 +18,6 @@ import { ForceSetPasswordReason } from "../../../auth/models/domain/force-set-pa
 import { LogService } from "../../../platform/abstractions/log.service";
 import { StateService } from "../../../platform/abstractions/state.service";
 import { SymmetricCryptoKey } from "../../../platform/models/domain/symmetric-crypto-key";
-import { StateProvider } from "../../../platform/state";
 import { UserId } from "../../../types/guid";
 import { MasterKey, UserKey } from "../../../types/key";
 import { KeyGenerationService } from "../../crypto";
@@ -31,25 +30,30 @@ import {
   MasterPasswordUnlockData,
 } from "../types/master-password.types";
 
-import { MASTER_PASSWORD_UNLOCK_KEY, MasterPasswordService } from "./master-password.service";
+import {
+  FORCE_SET_PASSWORD_REASON,
+  MASTER_KEY_ENCRYPTED_USER_KEY,
+  MASTER_PASSWORD_UNLOCK_KEY,
+  MasterPasswordService,
+} from "./master-password.service";
 
 describe("MasterPasswordService", () => {
   let sut: MasterPasswordService;
 
-  let stateProvider: MockProxy<StateProvider>;
   let stateService: MockProxy<StateService>;
   let keyGenerationService: MockProxy<KeyGenerationService>;
   let encryptService: MockProxy<EncryptService>;
   let logService: MockProxy<LogService>;
   let cryptoFunctionService: MockProxy<CryptoFunctionService>;
   let accountService: FakeAccountService;
+  let stateProvider: FakeStateProvider;
 
   const userId = "00000000-0000-0000-0000-000000000000" as UserId;
-  const mockUserState = {
-    state$: of(null),
-    update: jest.fn().mockResolvedValue(null),
-  };
 
+  const kdfPBKDF2: KdfConfig = new PBKDF2KdfConfig(600_000);
+  const kdfArgon2: KdfConfig = new Argon2KdfConfig(4, 64, 3);
+  const salt = "test@bitwarden.com" as MasterPasswordSalt;
+  const userKey = makeSymmetricCryptoKey(64, 2) as UserKey;
   const testUserKey: SymmetricCryptoKey = makeSymmetricCryptoKey(64, 1);
   const testMasterKey: MasterKey = makeSymmetricCryptoKey(32, 2);
   const testStretchedMasterKey: SymmetricCryptoKey = makeSymmetricCryptoKey(64, 3);
@@ -59,17 +63,13 @@ describe("MasterPasswordService", () => {
     "2.gbauOANURUHqvhLTDnva1A==|nSW+fPumiuTaDB/s12+JO88uemV6rhwRSR+YR1ZzGr5j6Ei3/h+XEli2Unpz652NlZ9NTuRpHxeOqkYYJtp7J+lPMoclgteXuAzUu9kqlRc=|DeUFkhIwgkGdZA08bDnDqMMNmZk21D+H5g8IostPKAY=";
 
   beforeEach(() => {
-    stateProvider = mock<StateProvider>();
     stateService = mock<StateService>();
     keyGenerationService = mock<KeyGenerationService>();
     encryptService = mock<EncryptService>();
     logService = mock<LogService>();
     cryptoFunctionService = mock<CryptoFunctionService>();
     accountService = mockAccountServiceWith(userId);
-
-    stateProvider.getUser.mockReturnValue(mockUserState as any);
-
-    mockUserState.update.mockReset();
+    stateProvider = new FakeStateProvider(accountService);
 
     sut = new MasterPasswordService(
       stateProvider,
@@ -87,6 +87,10 @@ describe("MasterPasswordService", () => {
       value: Promise.resolve(),
       configurable: true,
     });
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
   });
 
   describe("saltForUser$", () => {
@@ -112,12 +116,10 @@ describe("MasterPasswordService", () => {
 
       await sut.setForceSetPasswordReason(reason, userId);
 
-      expect(stateProvider.getUser).toHaveBeenCalled();
-      expect(mockUserState.update).toHaveBeenCalled();
-
-      // Call the update function to verify it returns the correct reason
-      const updateFn = mockUserState.update.mock.calls[0][0];
-      expect(updateFn(null)).toBe(reason);
+      const state = await firstValueFrom(
+        stateProvider.getUser(userId, FORCE_SET_PASSWORD_REASON).state$,
+      );
+      expect(state).toEqual(reason);
     });
 
     it("throws an error if reason is null", async () => {
@@ -133,31 +135,29 @@ describe("MasterPasswordService", () => {
     });
 
     it("does not overwrite AdminForcePasswordReset with other reasons except None", async () => {
-      jest
-        .spyOn(sut, "forceSetPasswordReason$")
-        .mockReturnValue(of(ForceSetPasswordReason.AdminForcePasswordReset));
-
-      jest
-        .spyOn(rxjs, "firstValueFrom")
-        .mockResolvedValue(ForceSetPasswordReason.AdminForcePasswordReset);
+      stateProvider.singleUser
+        .getFake(userId, FORCE_SET_PASSWORD_REASON)
+        .nextState(ForceSetPasswordReason.AdminForcePasswordReset);
 
       await sut.setForceSetPasswordReason(ForceSetPasswordReason.WeakMasterPassword, userId);
 
-      expect(mockUserState.update).not.toHaveBeenCalled();
+      const state = await firstValueFrom(
+        stateProvider.getUser(userId, FORCE_SET_PASSWORD_REASON).state$,
+      );
+      expect(state).toEqual(ForceSetPasswordReason.AdminForcePasswordReset);
     });
 
     it("allows overwriting AdminForcePasswordReset with None", async () => {
-      jest
-        .spyOn(sut, "forceSetPasswordReason$")
-        .mockReturnValue(of(ForceSetPasswordReason.AdminForcePasswordReset));
-
-      jest
-        .spyOn(rxjs, "firstValueFrom")
-        .mockResolvedValue(ForceSetPasswordReason.AdminForcePasswordReset);
+      stateProvider.singleUser
+        .getFake(userId, FORCE_SET_PASSWORD_REASON)
+        .nextState(ForceSetPasswordReason.AdminForcePasswordReset);
 
       await sut.setForceSetPasswordReason(ForceSetPasswordReason.None, userId);
 
-      expect(mockUserState.update).toHaveBeenCalled();
+      const state = await firstValueFrom(
+        stateProvider.getUser(userId, FORCE_SET_PASSWORD_REASON).state$,
+      );
+      expect(state).toEqual(ForceSetPasswordReason.None);
     });
   });
   describe("decryptUserKeyWithMasterKey", () => {
@@ -228,10 +228,10 @@ describe("MasterPasswordService", () => {
 
       await sut.setMasterKeyEncryptedUserKey(encryptedKey, userId);
 
-      expect(stateProvider.getUser).toHaveBeenCalled();
-      expect(mockUserState.update).toHaveBeenCalled();
-      const updateFn = mockUserState.update.mock.calls[0][0];
-      expect(updateFn(null)).toEqual(encryptedKey.toJSON());
+      const state = await firstValueFrom(
+        stateProvider.getUser(userId, MASTER_KEY_ENCRYPTED_USER_KEY).state$,
+      );
+      expect(state).toEqual(encryptedKey.toJSON());
     });
   });
 
@@ -329,11 +329,6 @@ describe("MasterPasswordService", () => {
   });
 
   describe("setMasterPasswordUnlockData", () => {
-    const kdfPBKDF2: KdfConfig = new PBKDF2KdfConfig(600_000);
-    const kdfArgon2: KdfConfig = new Argon2KdfConfig(4, 64, 3);
-    const salt = "test@bitwarden.com" as MasterPasswordSalt;
-    const userKey = makeSymmetricCryptoKey(64, 2) as UserKey;
-
     it.each([kdfPBKDF2, kdfArgon2])(
       "sets the master password unlock data kdf %o in the state",
       async (kdfConfig) => {
@@ -346,11 +341,10 @@ describe("MasterPasswordService", () => {
 
         await sut.setMasterPasswordUnlockData(masterPasswordUnlockData, userId);
 
-        expect(stateProvider.getUser).toHaveBeenCalledWith(userId, MASTER_PASSWORD_UNLOCK_KEY);
-        expect(mockUserState.update).toHaveBeenCalled();
-
-        const updateFn = mockUserState.update.mock.calls[0][0];
-        expect(updateFn(null)).toEqual(masterPasswordUnlockData.toJSON());
+        const state = await firstValueFrom(
+          stateProvider.getUser(userId, MASTER_PASSWORD_UNLOCK_KEY).state$,
+        );
+        expect(state).toEqual(masterPasswordUnlockData.toJSON());
       },
     );
 
@@ -372,6 +366,40 @@ describe("MasterPasswordService", () => {
         sut.setMasterPasswordUnlockData(masterPasswordUnlockData, null as unknown as UserId),
       ).rejects.toThrow("userId is null or undefined.");
     });
+  });
+
+  describe("masterPasswordUnlockData$", () => {
+    test.each([null as unknown as UserId, undefined as unknown as UserId])(
+      "throws when the provided userId is %s",
+      async (userId) => {
+        expect(() => sut.masterPasswordUnlockData$(userId)).toThrow("userId is null or undefined.");
+      },
+    );
+
+    it("returns null when no data is set", async () => {
+      stateProvider.singleUser.getFake(userId, MASTER_PASSWORD_UNLOCK_KEY).nextState(null);
+
+      const result = await firstValueFrom(sut.masterPasswordUnlockData$(userId));
+
+      expect(result).toBeNull();
+    });
+
+    it.each([kdfPBKDF2, kdfArgon2])(
+      "returns the master password unlock data for kdf %o from state",
+      async (kdfConfig) => {
+        const masterPasswordUnlockData = await sut.makeMasterPasswordUnlockData(
+          "test-password",
+          kdfConfig,
+          salt,
+          userKey,
+        );
+        await sut.setMasterPasswordUnlockData(masterPasswordUnlockData, userId);
+
+        const result = await firstValueFrom(sut.masterPasswordUnlockData$(userId));
+
+        expect(result).toEqual(masterPasswordUnlockData.toJSON());
+      },
+    );
   });
 
   describe("MASTER_PASSWORD_UNLOCK_KEY", () => {

--- a/libs/common/src/key-management/master-password/services/master-password.service.ts
+++ b/libs/common/src/key-management/master-password/services/master-password.service.ts
@@ -50,7 +50,7 @@ const MASTER_KEY_HASH = new UserKeyDefinition<string>(MASTER_PASSWORD_DISK, "mas
 });
 
 /** Disk to persist through lock */
-const MASTER_KEY_ENCRYPTED_USER_KEY = new UserKeyDefinition<EncryptedString>(
+export const MASTER_KEY_ENCRYPTED_USER_KEY = new UserKeyDefinition<EncryptedString>(
   MASTER_PASSWORD_DISK,
   "masterKeyEncryptedUserKey",
   {
@@ -60,7 +60,7 @@ const MASTER_KEY_ENCRYPTED_USER_KEY = new UserKeyDefinition<EncryptedString>(
 );
 
 /** Disk to persist through lock and account switches */
-const FORCE_SET_PASSWORD_REASON = new UserKeyDefinition<ForceSetPasswordReason>(
+export const FORCE_SET_PASSWORD_REASON = new UserKeyDefinition<ForceSetPasswordReason>(
   MASTER_PASSWORD_DISK,
   "forceSetPasswordReason",
   {
@@ -339,5 +339,11 @@ export class MasterPasswordService implements InternalMasterPasswordServiceAbstr
     await this.stateProvider
       .getUser(userId, MASTER_PASSWORD_UNLOCK_KEY)
       .update(() => masterPasswordUnlockData.toJSON());
+  }
+
+  masterPasswordUnlockData$(userId: UserId): Observable<MasterPasswordUnlockData | null> {
+    assertNonNullish(userId, "userId");
+
+    return this.stateProvider.getUser(userId, MASTER_PASSWORD_UNLOCK_KEY).state$;
   }
 }

--- a/libs/key-management-ui/src/lock/components/lock.component.html
+++ b/libs/key-management-ui/src/lock/components/lock.component.html
@@ -119,73 +119,87 @@
   </ng-container>
 
   <!-- MP Unlock -->
-  <ng-container
-    *ngIf="
-      unlockOptions.masterPassword.enabled && activeUnlockOption === UnlockOption.MasterPassword
-    "
-  >
-    <form [bitSubmit]="submit" [formGroup]="formGroup">
-      <bit-form-field>
-        <bit-label>{{ "masterPass" | i18n }}</bit-label>
-        <input
-          type="password"
-          formControlName="masterPassword"
-          bitInput
-          appAutofocus
-          name="masterPassword"
-          class="tw-font-mono"
-          required
-          appInputVerbatim
-        />
-        <button
-          type="button"
-          bitIconButton
-          bitSuffix
-          bitPasswordInputToggle
-          [(toggled)]="showPassword"
-        ></button>
-
-        <!-- [attr.aria-pressed]="showPassword" -->
-      </bit-form-field>
-
-      <div class="tw-flex tw-flex-col tw-space-y-3">
-        <button type="submit" bitButton bitFormButton buttonType="primary" block>
-          {{ "unlock" | i18n }}
-        </button>
-
-        <p class="tw-text-center">{{ "or" | i18n }}</p>
-
-        <ng-container *ngIf="showBiometrics">
+  @if (
+    (forceUpdateKDFSettings$ | async) &&
+    unlockOptions.masterPassword.enabled &&
+    activeUnlockOption === UnlockOption.MasterPassword
+  ) {
+    <bit-master-password-lock
+      [(activeUnlockOption)]="activeUnlockOption"
+      [unlockOptions]="this.unlockOptions"
+      [biometricUnlockBtnText]="biometricUnlockBtnText"
+      (successfulUnlock)="setUserKeyAndContinue($event, true)"
+      (logOut)="logOut()"
+    ></bit-master-password-lock>
+  } @else {
+    <ng-container
+      *ngIf="
+        unlockOptions.masterPassword.enabled && activeUnlockOption === UnlockOption.MasterPassword
+      "
+    >
+      <form [bitSubmit]="submit" [formGroup]="formGroup">
+        <bit-form-field>
+          <bit-label>{{ "masterPass" | i18n }}</bit-label>
+          <input
+            type="password"
+            formControlName="masterPassword"
+            bitInput
+            appAutofocus
+            name="masterPassword"
+            class="tw-font-mono"
+            required
+            appInputVerbatim
+          />
           <button
             type="button"
-            bitButton
-            bitFormButton
-            buttonType="secondary"
-            [disabled]="!biometricsAvailable"
-            block
-            (click)="activeUnlockOption = UnlockOption.Biometrics"
-          >
-            <span> {{ biometricUnlockBtnText | i18n }}</span>
-          </button>
-        </ng-container>
+            bitIconButton
+            bitSuffix
+            bitPasswordInputToggle
+            [(toggled)]="showPassword"
+          ></button>
 
-        <ng-container *ngIf="unlockOptions.pin.enabled">
-          <button
-            type="button"
-            bitButton
-            bitFormButton
-            buttonType="secondary"
-            block
-            (click)="activeUnlockOption = UnlockOption.Pin"
-          >
-            {{ "unlockWithPin" | i18n }}
-          </button>
-        </ng-container>
+          <!-- [attr.aria-pressed]="showPassword" -->
+        </bit-form-field>
 
-        <button type="button" bitButton bitFormButton block (click)="logOut()">
-          {{ "logOut" | i18n }}
-        </button>
-      </div>
-    </form>
-  </ng-container>
+        <div class="tw-flex tw-flex-col tw-space-y-3">
+          <button type="submit" bitButton bitFormButton buttonType="primary" block>
+            {{ "unlock" | i18n }}
+          </button>
+
+          <p class="tw-text-center">{{ "or" | i18n }}</p>
+
+          <ng-container *ngIf="showBiometrics">
+            <button
+              type="button"
+              bitButton
+              bitFormButton
+              buttonType="secondary"
+              [disabled]="!biometricsAvailable"
+              block
+              (click)="activeUnlockOption = UnlockOption.Biometrics"
+            >
+              <span> {{ biometricUnlockBtnText | i18n }}</span>
+            </button>
+          </ng-container>
+
+          <ng-container *ngIf="unlockOptions.pin.enabled">
+            <button
+              type="button"
+              bitButton
+              bitFormButton
+              buttonType="secondary"
+              block
+              (click)="activeUnlockOption = UnlockOption.Pin"
+            >
+              {{ "unlockWithPin" | i18n }}
+            </button>
+          </ng-container>
+
+          <button type="button" bitButton bitFormButton block (click)="logOut()">
+            {{ "logOut" | i18n }}
+          </button>
+        </div>
+      </form>
+    </ng-container>
+  }
 </ng-container>

--- a/libs/key-management-ui/src/lock/components/lock.component.spec.ts
+++ b/libs/key-management-ui/src/lock/components/lock.component.spec.ts
@@ -25,6 +25,7 @@ import { DeviceTrustServiceAbstraction } from "@bitwarden/common/key-management/
 import { InternalMasterPasswordServiceAbstraction } from "@bitwarden/common/key-management/master-password/abstractions/master-password.service.abstraction";
 import { PinServiceAbstraction } from "@bitwarden/common/key-management/pin/pin.service.abstraction";
 import { BroadcasterService } from "@bitwarden/common/platform/abstractions/broadcaster.service";
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
@@ -91,6 +92,7 @@ describe("LockComponent", () => {
   const mockLockComponentService = mock<LockComponentService>();
   const mockAnonLayoutWrapperDataService = mock<AnonLayoutWrapperDataService>();
   const mockBroadcasterService = mock<BroadcasterService>();
+  const mockConfigService = mock<ConfigService>();
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -148,6 +150,7 @@ describe("LockComponent", () => {
         { provide: LockComponentService, useValue: mockLockComponentService },
         { provide: AnonLayoutWrapperDataService, useValue: mockAnonLayoutWrapperDataService },
         { provide: BroadcasterService, useValue: mockBroadcasterService },
+        { provide: ConfigService, useValue: mockConfigService },
       ],
     })
       .overrideProvider(DialogService, { useValue: mockDialogService })

--- a/libs/key-management-ui/src/lock/components/master-password-lock/master-password-lock.component.html
+++ b/libs/key-management-ui/src/lock/components/master-password-lock/master-password-lock.component.html
@@ -1,0 +1,55 @@
+<form [formGroup]="formGroup" [bitSubmit]="submit">
+  <bit-form-field>
+    <bit-label>{{ "masterPass" | i18n }}</bit-label>
+    <input
+      type="password"
+      formControlName="masterPassword"
+      bitInput
+      appAutofocus
+      name="masterPassword"
+      class="tw-font-mono"
+      required
+      appInputVerbatim
+    />
+    <button type="button" bitIconButton bitSuffix bitPasswordInputToggle></button>
+  </bit-form-field>
+
+  <div class="tw-flex tw-flex-col tw-space-y-3">
+    <button type="submit" bitButton bitFormButton buttonType="primary" block>
+      {{ "unlock" | i18n }}
+    </button>
+
+    <p class="tw-text-center">{{ "or" | i18n }}</p>
+
+    @if (showBiometricsSwap()) {
+      <button
+        type="button"
+        bitButton
+        bitFormButton
+        buttonType="secondary"
+        [disabled]="!biometricsAvailable()"
+        block
+        (click)="activeUnlockOption.set(UnlockOption.Biometrics)"
+      >
+        <span> {{ biometricUnlockBtnText() | i18n }}</span>
+      </button>
+    }
+
+    @if (showPinSwap()) {
+      <button
+        type="button"
+        bitButton
+        bitFormButton
+        buttonType="secondary"
+        block
+        (click)="activeUnlockOption.set(UnlockOption.Pin)"
+      >
+        {{ "unlockWithPin" | i18n }}
+      </button>
+    }
+
+    <button type="button" bitButton bitFormButton block (click)="logOut.emit()">
+      {{ "logOut" | i18n }}
+    </button>
+  </div>
+</form>

--- a/libs/key-management-ui/src/lock/components/master-password-lock/master-password-lock.component.spec.ts
+++ b/libs/key-management-ui/src/lock/components/master-password-lock/master-password-lock.component.spec.ts
@@ -1,0 +1,385 @@
+import { DebugElement } from "@angular/core";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { FormBuilder, ReactiveFormsModule } from "@angular/forms";
+import { By } from "@angular/platform-browser";
+import { mock } from "jest-mock-extended";
+import { of } from "rxjs";
+
+import { JslibModule } from "@bitwarden/angular/jslib.module";
+import { Account, AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { MasterPasswordUnlockService } from "@bitwarden/common/key-management/master-password/abstractions/master-password-unlock.service";
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
+import { UserKey } from "@bitwarden/common/types/key";
+import {
+  AsyncActionsModule,
+  ButtonModule,
+  FormFieldModule,
+  IconButtonModule,
+  ToastService,
+} from "@bitwarden/components";
+import { BiometricsStatus } from "@bitwarden/key-management";
+import { UserId } from "@bitwarden/user-core";
+
+import { UnlockOption, UnlockOptions } from "../../services/lock-component.service";
+
+import { MasterPasswordLockComponent } from "./master-password-lock.component";
+
+describe("MasterPasswordLockComponent", () => {
+  let component: MasterPasswordLockComponent;
+  let fixture: ComponentFixture<MasterPasswordLockComponent>;
+
+  const accountService = mock<AccountService>();
+  const masterPasswordUnlockService = mock<MasterPasswordUnlockService>();
+  const i18nService = mock<I18nService>();
+  const toastService = mock<ToastService>();
+  const logService = mock<LogService>();
+
+  const mockMasterPassword = "testExample";
+  const activeAccount: Account = {
+    id: "user-id" as UserId,
+    email: "user@example.com",
+    emailVerified: true,
+    name: "User",
+  };
+  const mockUserKey = new SymmetricCryptoKey(new Uint8Array(64)) as UserKey;
+
+  const setupComponent = (
+    unlockOptions: Partial<UnlockOptions> = {},
+    biometricUnlockBtnText: string = "default",
+    account: Account | null = activeAccount,
+  ) => {
+    const defaultOptions: UnlockOptions = {
+      masterPassword: { enabled: true },
+      pin: { enabled: false },
+      biometrics: {
+        enabled: false,
+        biometricsStatus: BiometricsStatus.NotEnabledLocally,
+      },
+    };
+
+    accountService.activeAccount$ = of(account);
+    fixture.componentRef.setInput("unlockOptions", { ...defaultOptions, ...unlockOptions });
+    fixture.componentRef.setInput("biometricUnlockBtnText", biometricUnlockBtnText);
+    fixture.detectChanges();
+
+    return {
+      form: fixture.debugElement.query(By.css("form")),
+      component,
+      ...getFormElements(fixture.debugElement.query(By.css("form"))),
+    };
+  };
+
+  const getFormElements = (form: DebugElement) => ({
+    masterPasswordInput: form.query(By.css('input[formControlName="masterPassword"]')),
+    toggleButton: form.query(By.css("button[bitPasswordInputToggle]")),
+    submitButton: form.query(By.css('button[type="submit"]')),
+    logoutButton: form.query(By.css('button[type="button"]:not([bitPasswordInputToggle])')),
+    secondaryButton: form.query(By.css('button[buttonType="secondary"]')),
+  });
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    i18nService.t.mockImplementation((key: string) => key);
+
+    await TestBed.configureTestingModule({
+      imports: [
+        MasterPasswordLockComponent,
+        JslibModule,
+        ReactiveFormsModule,
+        ButtonModule,
+        FormFieldModule,
+        AsyncActionsModule,
+        IconButtonModule,
+      ],
+      providers: [
+        FormBuilder,
+        { provide: AccountService, useValue: accountService },
+        { provide: MasterPasswordUnlockService, useValue: masterPasswordUnlockService },
+        { provide: I18nService, useValue: i18nService },
+        { provide: ToastService, useValue: toastService },
+        { provide: LogService, useValue: logService },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(MasterPasswordLockComponent);
+    component = fixture.componentInstance;
+  });
+
+  describe("form rendering", () => {
+    let elements: ReturnType<typeof setupComponent>;
+
+    beforeEach(() => {
+      elements = setupComponent();
+    });
+
+    it("creates form with proper structure", () => {
+      expect(component.formGroup).toBeDefined();
+      expect(component.formGroup.controls.masterPassword).toBeDefined();
+    });
+
+    const formElementTests = [
+      {
+        name: "master password input",
+        selector: "masterPasswordInput",
+        expectations: (el: HTMLInputElement) => {
+          expect(el).toMatchObject({
+            type: "password",
+            name: "masterPassword",
+            required: true,
+          });
+          expect(el.attributes).toHaveProperty("bitInput");
+        },
+      },
+      {
+        name: "password toggle button",
+        selector: "toggleButton",
+        expectations: (el: HTMLButtonElement) => {
+          expect(el.type).toBe("button");
+          expect(el.attributes).toHaveProperty("bitIconButton");
+        },
+      },
+      {
+        name: "unlock submit button",
+        selector: "submitButton",
+        expectations: (el: HTMLButtonElement) => {
+          expect(el).toMatchObject({
+            type: "submit",
+            textContent: expect.stringContaining("unlock"),
+          });
+          expect(el.attributes).toHaveProperty("bitButton");
+        },
+      },
+      {
+        name: "logout button",
+        selector: "logoutButton",
+        expectations: (el: HTMLButtonElement) => {
+          expect(el).toMatchObject({
+            type: "button",
+            textContent: expect.stringContaining("logOut"),
+          });
+          expect(el.attributes).toHaveProperty("bitButton");
+        },
+      },
+    ];
+
+    test.each(formElementTests)("renders $name correctly", ({ selector, expectations }) => {
+      const element = elements[selector as keyof typeof elements] as DebugElement;
+      expect(element).toBeTruthy();
+      expectations(element.nativeElement);
+    });
+
+    const hiddenButtonTests = [
+      {
+        case: "biometrics swap button when biometrics disabled",
+        setup: () => setupComponent({}, "swapBiometrics"),
+        expectHidden: true,
+      },
+      {
+        case: "PIN swap button when PIN disabled",
+        setup: () => setupComponent(),
+        expectHidden: true,
+      },
+    ];
+
+    test.each(hiddenButtonTests)("doesn't render $case", ({ setup, expectHidden }) => {
+      const { secondaryButton } = setup();
+      expect(!!secondaryButton).toBe(!expectHidden);
+    });
+  });
+
+  describe("password input", () => {
+    let setup: ReturnType<typeof setupComponent>;
+    beforeEach(() => {
+      setup = setupComponent();
+    });
+
+    it("should bind form input to masterPassword form control", async () => {
+      const input = setup.masterPasswordInput;
+      expect(input).toBeTruthy();
+      expect(input.nativeElement).toBeInstanceOf(HTMLInputElement);
+      expect(component.formGroup).toBeTruthy();
+      const masterPasswordControl = component.formGroup!.get("masterPassword");
+      expect(masterPasswordControl).toBeTruthy();
+
+      masterPasswordControl!.setValue("test-password");
+      fixture.detectChanges();
+
+      const inputElement = input.nativeElement as HTMLInputElement;
+      expect(inputElement.value).toEqual("test-password");
+    });
+
+    it("should validate required master password field", async () => {
+      const formGroup = component.formGroup;
+
+      // Initially form should be invalid (empty required field)
+      expect(formGroup?.invalid).toEqual(true);
+      expect(formGroup?.get("masterPassword")?.hasError("required")).toBe(true);
+
+      // Set a value
+      formGroup?.get("masterPassword")?.setValue("test-password");
+
+      expect(formGroup?.invalid).toEqual(false);
+      expect(formGroup?.get("masterPassword")?.hasError("required")).toBe(false);
+    });
+
+    it("should toggle password visibility when toggle button is clicked", async () => {
+      const toggleButton = setup.toggleButton;
+      expect(toggleButton).toBeTruthy();
+      expect(toggleButton.nativeElement).toBeInstanceOf(HTMLButtonElement);
+      const toggleButtonElement = toggleButton.nativeElement as HTMLButtonElement;
+      const input = setup.masterPasswordInput;
+      expect(input).toBeTruthy();
+      expect(input.nativeElement).toBeInstanceOf(HTMLInputElement);
+      const inputElement = input.nativeElement as HTMLInputElement;
+
+      // Initially password should be hidden
+      expect(inputElement.type).toEqual("password");
+
+      // Click toggle button
+      toggleButtonElement.click();
+      fixture.detectChanges();
+
+      expect(inputElement.type).toEqual("text");
+
+      // Click toggle button again
+      toggleButtonElement.click();
+      fixture.detectChanges();
+
+      expect(inputElement.type).toEqual("password");
+    });
+  });
+
+  describe("logout", () => {
+    it("emits logOut event when logout button is clicked", () => {
+      const setup = setupComponent();
+      let logoutEmitted = false;
+      component.logOut.subscribe(() => {
+        logoutEmitted = true;
+      });
+
+      expect(setup.logoutButton).toBeTruthy();
+      expect(setup.logoutButton.nativeElement).toBeInstanceOf(HTMLButtonElement);
+      const logoutButtonElement = setup.logoutButton.nativeElement as HTMLButtonElement;
+
+      // Click logout button
+      logoutButtonElement.click();
+
+      expect(logoutEmitted).toBe(true);
+    });
+  });
+
+  describe("swap buttons", () => {
+    const swapButtonScenarios = [
+      {
+        name: "PIN swap button when PIN is enabled",
+        unlockOptions: {
+          pin: { enabled: true },
+          biometrics: {
+            enabled: false,
+            biometricsStatus: BiometricsStatus.PlatformUnsupported,
+          },
+        },
+        expectedText: "unlockWithPin",
+        expectedUnlockOption: UnlockOption.Pin,
+      },
+      {
+        name: "biometrics swap button when biometrics is enabled",
+        unlockOptions: {
+          pin: { enabled: false },
+          biometrics: { enabled: true, biometricsStatus: BiometricsStatus.Available },
+        },
+        expectedText: "swapBiometrics",
+        expectedUnlockOption: UnlockOption.Biometrics,
+      },
+    ];
+
+    test.each(swapButtonScenarios)(
+      "renders and handles $name",
+      ({ unlockOptions, expectedText, expectedUnlockOption }) => {
+        const setup = setupComponent(unlockOptions, expectedText);
+        const secondaryButton = setup.secondaryButton;
+
+        expect(secondaryButton).toBeTruthy();
+        expect(secondaryButton.nativeElement.textContent?.trim()).toEqual(expectedText);
+
+        // Test click behavior
+        secondaryButton.nativeElement.click();
+        expect(component.activeUnlockOption()).toBe(expectedUnlockOption);
+      },
+    );
+  });
+
+  describe("submit", () => {
+    test.each([null, undefined as unknown as string, ""])(
+      "won't unlock and show password invalid toast when master password is %s",
+      async (value) => {
+        component.formGroup.controls.masterPassword.setValue(value);
+
+        await component.submit();
+
+        expect(toastService.showToast).toHaveBeenCalledWith({
+          variant: "error",
+          title: i18nService.t("errorOccurred"),
+          message: i18nService.t("masterPasswordRequired"),
+        });
+        expect(masterPasswordUnlockService.unlockWithMasterPassword).not.toHaveBeenCalled();
+      },
+    );
+
+    test.each([null as unknown as Account, undefined as unknown as Account])(
+      "throws error when active account is %s",
+      async (value) => {
+        accountService.activeAccount$ = of(value);
+        component.formGroup.controls.masterPassword.setValue(mockMasterPassword);
+
+        await expect(component.submit()).rejects.toThrow("No active account found");
+
+        expect(masterPasswordUnlockService.unlockWithMasterPassword).not.toHaveBeenCalled();
+      },
+    );
+
+    it("shows an error toast and logs the error when unlock with master password fails", async () => {
+      const customError = new Error("Specialized error message");
+      masterPasswordUnlockService.unlockWithMasterPassword.mockRejectedValue(customError);
+      accountService.activeAccount$ = of(activeAccount);
+      component.formGroup.controls.masterPassword.setValue(mockMasterPassword);
+
+      await component.submit();
+
+      expect(masterPasswordUnlockService.unlockWithMasterPassword).toHaveBeenCalledWith(
+        mockMasterPassword,
+        activeAccount,
+      );
+      expect(toastService.showToast).toHaveBeenCalledWith({
+        variant: "error",
+        title: i18nService.t("errorOccurred"),
+        message: i18nService.t("invalidMasterPassword"),
+      });
+      expect(logService.error).toHaveBeenCalledWith(
+        "[MasterPasswordLockComponent] Failed to unlock via master password",
+        customError,
+      );
+    });
+
+    it("emits userKey when unlock is successful", async () => {
+      masterPasswordUnlockService.unlockWithMasterPassword.mockResolvedValue(mockUserKey);
+      accountService.activeAccount$ = of(activeAccount);
+      component.formGroup.controls.masterPassword.setValue(mockMasterPassword);
+      let emittedUserKey: UserKey | undefined;
+      component.successfulUnlock.subscribe((userKey: UserKey) => {
+        emittedUserKey = userKey;
+      });
+
+      await component.submit();
+
+      expect(emittedUserKey).toEqual(mockUserKey);
+      expect(masterPasswordUnlockService.unlockWithMasterPassword).toHaveBeenCalledWith(
+        mockMasterPassword,
+        activeAccount,
+      );
+    });
+  });
+});

--- a/libs/key-management-ui/src/lock/components/master-password-lock/master-password-lock.component.ts
+++ b/libs/key-management-ui/src/lock/components/master-password-lock/master-password-lock.component.ts
@@ -1,0 +1,112 @@
+import { Component, computed, inject, input, model, output } from "@angular/core";
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from "@angular/forms";
+import { firstValueFrom } from "rxjs";
+
+import { JslibModule } from "@bitwarden/angular/jslib.module";
+import { Account, AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { MasterPasswordUnlockService } from "@bitwarden/common/key-management/master-password/abstractions/master-password-unlock.service";
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { UserKey } from "@bitwarden/common/types/key";
+import {
+  AsyncActionsModule,
+  ButtonModule,
+  FormFieldModule,
+  IconButtonModule,
+  ToastService,
+} from "@bitwarden/components";
+import { BiometricsStatus } from "@bitwarden/key-management";
+import { LogService } from "@bitwarden/logging";
+
+import {
+  UnlockOption,
+  UnlockOptions,
+  UnlockOptionValue,
+} from "../../services/lock-component.service";
+
+@Component({
+  selector: "bit-master-password-lock",
+  templateUrl: "master-password-lock.component.html",
+  imports: [
+    JslibModule,
+    ReactiveFormsModule,
+    ButtonModule,
+    FormFieldModule,
+    AsyncActionsModule,
+    IconButtonModule,
+  ],
+})
+export class MasterPasswordLockComponent {
+  private readonly accountService = inject(AccountService);
+  private readonly masterPasswordUnlockService = inject(MasterPasswordUnlockService);
+  private readonly i18nService = inject(I18nService);
+  private readonly toastService = inject(ToastService);
+  private readonly logService = inject(LogService);
+  UnlockOption = UnlockOption;
+
+  activeUnlockOption = model.required<UnlockOptionValue>();
+
+  unlockOptions = input.required<UnlockOptions>();
+  biometricUnlockBtnText = input.required<string>();
+  showPinSwap = computed(() => this.unlockOptions().pin.enabled);
+  biometricsAvailable = computed(() => this.unlockOptions().biometrics.enabled ?? false);
+  showBiometricsSwap = computed(() => {
+    const status = this.unlockOptions().biometrics.biometricsStatus;
+    return (
+      status !== BiometricsStatus.PlatformUnsupported &&
+      status !== BiometricsStatus.NotEnabledLocally
+    );
+  });
+
+  successfulUnlock = output<UserKey>();
+  logOut = output<void>();
+
+  formGroup = new FormGroup({
+    masterPassword: new FormControl("", {
+      validators: [Validators.required],
+      updateOn: "submit",
+    }),
+  });
+
+  submit = async () => {
+    this.formGroup.markAllAsTouched();
+    const masterPassword = this.formGroup.controls.masterPassword.value;
+    if (this.formGroup.invalid || !masterPassword) {
+      this.toastService.showToast({
+        variant: "error",
+        title: this.i18nService.t("errorOccurred"),
+        message: this.i18nService.t("masterPasswordRequired"),
+      });
+      return;
+    }
+
+    const activeAccount = await firstValueFrom(this.accountService.activeAccount$);
+    if (activeAccount == null) {
+      throw new Error("No active account found");
+    }
+
+    await this.unlockViaMasterPassword(masterPassword, activeAccount);
+  };
+
+  private async unlockViaMasterPassword(
+    masterPassword: string,
+    activeAccount: Account,
+  ): Promise<void> {
+    try {
+      const userKey = await this.masterPasswordUnlockService.unlockWithMasterPassword(
+        masterPassword,
+        activeAccount,
+      );
+      this.successfulUnlock.emit(userKey);
+    } catch (error) {
+      this.logService.error(
+        "[MasterPasswordLockComponent] Failed to unlock via master password",
+        error,
+      );
+      this.toastService.showToast({
+        variant: "error",
+        title: this.i18nService.t("errorOccurred"),
+        message: this.i18nService.t("invalidMasterPassword"),
+      });
+    }
+  }
+}


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-23246

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Add unlocking with master password unlock data for angular lock component behind a feature flag.



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
