### PR TITLE
[PM-20034]  - [Vault] Display View Login button and specific banner when an At-risk password task is missing a valid website

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -556,6 +556,9 @@
   "view": {
     "message": "View"
   },
+  "viewLogin": {
+    "message": "View login"
+  },
   "noItemsInList": {
     "message": "There are no items to list."
   },
@@ -5445,6 +5448,12 @@
   },
   "changeAtRiskPassword": {
     "message": "Change at-risk password"
+  },
+  "changeAtRiskPasswordAndAddWebsite": {
+    "message": "This login is at-risk and missing a website. Add a website and change the password for stronger security"
+  },
+  "missingWebsite": {
+    "message": "Missing website"
   },
   "settingsVaultOptions": {
     "message": "Vault options"

--- a/apps/browser/src/vault/popup/components/at-risk-passwords/at-risk-passwords.component.html
+++ b/apps/browser/src/vault/popup/components/at-risk-passwords/at-risk-passwords.component.html
@@ -3,7 +3,7 @@
     slot="header"
     [pageTitle]="'atRiskPasswords' | i18n"
     showBackButton
-    [backAction]="navigateToVault.bind(this)"
+    [backAction]="navigateToVault"
   >
     <ng-container slot="end">
       <app-pop-out></app-pop-out>
@@ -65,10 +65,11 @@
             type="button"
             bitBadge
             variant="primary"
+            *ngIf="hasLoginUri(cipher)"
             appStopProp
             (click)="launchChangePassword(cipher)"
             [title]="'changeButtonTitle' | i18n: cipher.name"
-            [attr.aria-label]="'changeButtonTitle' | i18n: cipher.name"
+            [appA11yTitle]="'changeButtonTitle' | i18n: cipher.name"
             [disabled]="launchingCipher() == cipher"
           >
             <ng-container *ngIf="launchingCipher() != cipher">
@@ -79,6 +80,19 @@
               class="bwi bwi-spinner bwi-spin"
               aria-hidden="true"
             ></i>
+          </button>
+          <button
+            type="button"
+            bitBadge
+            variant="primary"
+            *ngIf="!hasLoginUri(cipher)"
+            [appA11yTitle]="'viewItemTitle' | i18n: cipher.name"
+            [title]="'viewItemTitle' | i18n: cipher.name"
+            (click)="viewCipher(cipher)"
+          >
+            <ng-container>
+              {{ "viewLogin" | i18n }}
+            </ng-container>
           </button>
         </bit-item-action>
       </bit-item>

--- a/apps/browser/src/vault/popup/components/at-risk-passwords/at-risk-passwords.component.ts
+++ b/apps/browser/src/vault/popup/components/at-risk-passwords/at-risk-passwords.component.ts
@@ -253,6 +253,10 @@ export class AtRiskPasswordsComponent implements OnInit {
     await this.atRiskPasswordPageService.dismissCallout(userId);
   }
 
+  protected hasLoginUri(cipher: CipherView) {
+    return cipher.login?.uris.length > 0;
+  }
+
   launchChangePassword = async (cipher: CipherView) => {
     try {
       this.launchingCipher.set(cipher);
@@ -273,7 +277,7 @@ export class AtRiskPasswordsComponent implements OnInit {
    * which can conflict with the `PopupRouterCacheService`. This replaces the
    * built-in back button behavior so the user always navigates to the vault.
    */
-  protected async navigateToVault() {
+  protected navigateToVault = async () => {
     await this.router.navigate(["/tabs/vault"]);
-  }
+  };
 }

--- a/libs/vault/src/cipher-view/cipher-view.component.html
+++ b/libs/vault/src/cipher-view/cipher-view.component.html
@@ -4,10 +4,14 @@
   </bit-callout>
 
   <bit-callout
-    *ngIf="cipher?.login.uris.length > 0 && hadPendingChangePasswordTask"
+    *ngIf="!hasLoginUri && hadPendingChangePasswordTask"
     type="warning"
-    [title]="''"
+    [title]="'missingWebsite' | i18n"
   >
+    {{ "changeAtRiskPasswordAndAddWebsite" | i18n }}
+  </bit-callout>
+
+  <bit-callout *ngIf="hasLoginUri && hadPendingChangePasswordTask" type="warning" [title]="''">
     <i class="bwi bwi-exclamation-triangle tw-text-warning" aria-hidden="true"></i>
     <a bitLink href="#" appStopClick (click)="launchChangePassword()">
       {{ "changeAtRiskPassword" | i18n }}
@@ -39,7 +43,7 @@
     *ngIf="hasLogin"
     [cipher]="cipher"
     [activeUserId]="activeUserId$ | async"
-    [hadPendingChangePasswordTask]="hadPendingChangePasswordTask"
+    [hadPendingChangePasswordTask]="hadPendingChangePasswordTask && cipher?.login.uris.length > 0"
     (handleChangePassword)="launchChangePassword()"
   ></app-login-credentials-view>
 

--- a/libs/vault/src/cipher-view/cipher-view.component.ts
+++ b/libs/vault/src/cipher-view/cipher-view.component.ts
@@ -139,6 +139,10 @@ export class CipherViewComponent implements OnChanges, OnDestroy {
     return !!this.cipher?.sshKey?.privateKey;
   }
 
+  get hasLoginUri() {
+    return (this.cipher?.login?.uris.length ?? 0) > 0;
+  }
+
   async loadCipherData() {
     if (!this.cipher) {
       return;


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-20034

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR includes logic to show a different banner for at-risk password logins that don't have a website uri and a different button in the at-risk password list that links to the login view.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/131e6e1c-f726-469d-b53e-d0806df095e6



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
