### PR TITLE
[PM-25320] feat(windows): show hover text explaining why windows hello is disabled on first launch

### DIFF
--- a/libs/key-management-ui/src/lock/components/lock.component.html
+++ b/libs/key-management-ui/src/lock/components/lock.component.html
@@ -93,7 +93,7 @@
             [disabled]="!biometricsAvailable"
             block
             [title]="biometricsAvailable ? undefined : biometricUnavailabilityReason"
-            [style]="biometricsAvailable ? undefined : 'pointer-events: auto'"
+            [ngClass]="{ 'tw-pointer-events-auto': !biometricsAvailable }"
             (click)="activeUnlockOption = UnlockOption.Biometrics"
           >
             <span> {{ biometricUnlockBtnText | i18n }}</span>


### PR DESCRIPTION
<img width="925" height="190" alt="image" src="https://github.com/user-attachments/assets/bbf01a1b-05a7-4e78-a2ef-7bfa2c5e629b" />

## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
