### PR TITLE
Fix SDK typings

### DIFF
--- a/libs/common/src/platform/services/sdk/default-sdk.service.spec.ts
+++ b/libs/common/src/platform/services/sdk/default-sdk.service.spec.ts
@@ -232,6 +232,7 @@ function createMockClient(): MockProxy<BitwardenClient> {
   client.platform.mockReturnValue({
     state: jest.fn().mockReturnValue(mock()),
     free: mock(),
+    load_flags: jest.fn(),
   });
   return client;
 }

--- a/libs/vault/src/services/copy-cipher-field.service.ts
+++ b/libs/vault/src/services/copy-cipher-field.service.ts
@@ -145,9 +145,9 @@ export class CopyCipherFieldService {
     if (action.event !== undefined) {
       await this.eventCollectionService.collect(
         action.event,
-        uuidAsString(cipher.id),
+        cipher.id ? uuidAsString(cipher.id) : undefined,
         false,
-        uuidAsString(cipher.organizationId),
+        cipher.organizationId ? uuidAsString(cipher.organizationId) : undefined,
       );
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

https://github.com/bitwarden/clients/pull/14962 introduced some typing changes, on `main` these are failing because of:
- `string | undefined` being passed to `uuidAsString`
- Missing `load_flags` within a test file for the SDK client

## 📸 Screenshots

N/A

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
