### PR TITLE
Allow Inactive user authenticated API calls

### DIFF
--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -735,6 +735,7 @@ export default class MainBackground {
       this.logService,
       (logoutReason: LogoutReason, userId?: UserId) => this.logout(logoutReason, userId),
       this.vaultTimeoutSettingsService,
+      this.accountService,
       { createRequest: (url, request) => new Request(url, request) },
     );
 
@@ -841,7 +842,7 @@ export default class MainBackground {
       this.tokenService,
     );
 
-    this.configApiService = new ConfigApiService(this.apiService, this.tokenService);
+    this.configApiService = new ConfigApiService(this.apiService);
 
     this.configService = new DefaultConfigService(
       this.configApiService,

--- a/apps/cli/src/platform/services/node-api.service.ts
+++ b/apps/cli/src/platform/services/node-api.service.ts
@@ -4,6 +4,7 @@ import * as FormData from "form-data";
 import { HttpsProxyAgent } from "https-proxy-agent";
 import * as fe from "node-fetch";
 
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { TokenService } from "@bitwarden/common/auth/abstractions/token.service";
 import { VaultTimeoutSettingsService } from "@bitwarden/common/key-management/vault-timeout";
 import { AppIdService } from "@bitwarden/common/platform/abstractions/app-id.service";
@@ -28,6 +29,7 @@ export class NodeApiService extends ApiService {
     logService: LogService,
     logoutCallback: () => Promise<void>,
     vaultTimeoutSettingsService: VaultTimeoutSettingsService,
+    accountService: AccountService,
     customUserAgent: string = null,
   ) {
     super(
@@ -39,6 +41,7 @@ export class NodeApiService extends ApiService {
       logService,
       logoutCallback,
       vaultTimeoutSettingsService,
+      accountService,
       { createRequest: (url, request) => new Request(url, request) },
       customUserAgent,
     );

--- a/apps/cli/src/service-container/service-container.ts
+++ b/apps/cli/src/service-container/service-container.ts
@@ -504,12 +504,13 @@ export class ServiceContainer {
       this.logService,
       logoutCallback,
       this.vaultTimeoutSettingsService,
+      this.accountService,
       customUserAgent,
     );
 
     this.containerService = new ContainerService(this.keyService, this.encryptService);
 
-    this.configApiService = new ConfigApiService(this.apiService, this.tokenService);
+    this.configApiService = new ConfigApiService(this.apiService);
 
     this.authService = new AuthService(
       this.accountService,

--- a/libs/angular/src/services/jslib-services.module.ts
+++ b/libs/angular/src/services/jslib-services.module.ts
@@ -752,6 +752,7 @@ const safeProviders: SafeProvider[] = [
       LogService,
       LOGOUT_CALLBACK,
       VaultTimeoutSettingsService,
+      AccountService,
       HTTP_OPERATIONS,
     ],
   }),
@@ -1158,7 +1159,7 @@ const safeProviders: SafeProvider[] = [
   safeProvider({
     provide: ConfigApiServiceAbstraction,
     useClass: ConfigApiService,
-    deps: [ApiServiceAbstraction, TokenServiceAbstraction],
+    deps: [ApiServiceAbstraction],
   }),
   safeProvider({
     provide: AnonymousHubServiceAbstraction,

--- a/libs/common/src/abstractions/api.service.ts
+++ b/libs/common/src/abstractions/api.service.ts
@@ -127,11 +127,34 @@ import { OptionalCipherResponse } from "../vault/models/response/optional-cipher
  * of this decision please read https://contributing.bitwarden.com/architecture/adr/refactor-api-service.
  */
 export abstract class ApiService {
+  /** @deprecated Use the overload accepting the user you want the request authenticated for. */
   abstract send(
     method: "GET" | "POST" | "PUT" | "DELETE" | "PATCH",
     path: string,
     body: any,
-    authed: boolean,
+    authed: true,
+    hasResponse: boolean,
+    apiUrl?: string | null,
+    alterHeaders?: (header: Headers) => void,
+  ): Promise<any>;
+
+  /** Sends an unauthenticated API request. */
+  abstract send(
+    method: "GET" | "POST" | "PUT" | "DELETE" | "PATCH",
+    path: string,
+    body: any,
+    authed: false,
+    hasResponse: boolean,
+    apiUrl?: string | null,
+    alterHeaders?: (header: Headers) => void,
+  ): Promise<any>;
+
+  /** Sends an API request authenticated with the given users ID. */
+  abstract send(
+    method: "GET" | "POST" | "PUT" | "DELETE" | "PATCH",
+    path: string,
+    body: any,
+    userId: UserId,
     hasResponse: boolean,
     apiUrl?: string | null,
     alterHeaders?: (headers: Headers) => void,
@@ -499,7 +522,7 @@ export abstract class ApiService {
   abstract postBitPayInvoice(request: BitPayInvoiceRequest): Promise<string>;
   abstract postSetupPayment(): Promise<string>;
 
-  abstract getActiveBearerToken(): Promise<string>;
+  abstract getActiveBearerToken(userId: UserId): Promise<string>;
   abstract fetch(request: Request): Promise<Response>;
   abstract nativeFetch(request: Request): Promise<Response>;
 

--- a/libs/common/src/auth/abstractions/token.service.ts
+++ b/libs/common/src/auth/abstractions/token.service.ts
@@ -72,14 +72,14 @@ export abstract class TokenService {
    * @param userId - The optional user id to get the access token for; if not provided, the active user is used.
    * @returns A promise that resolves with the access token or null.
    */
-  abstract getAccessToken(userId?: UserId): Promise<string | null>;
+  abstract getAccessToken(userId: UserId): Promise<string | null>;
 
   /**
    * Gets the refresh token.
    * @param userId - The optional user id to get the refresh token for; if not provided, the active user is used.
    * @returns A promise that resolves with the refresh token or null.
    */
-  abstract getRefreshToken(userId?: UserId): Promise<string | null>;
+  abstract getRefreshToken(userId: UserId): Promise<string | null>;
 
   /**
    * Sets the API Key Client ID for the active user id in memory or disk based on the given vaultTimeoutAction and vaultTimeout.
@@ -96,10 +96,10 @@ export abstract class TokenService {
   ): Promise<string>;
 
   /**
-   * Gets the API Key Client ID for the active user.
+   * Gets the API Key Client ID for the given user.
    * @returns A promise that resolves with the API Key Client ID or undefined
    */
-  abstract getClientId(userId?: UserId): Promise<string | undefined>;
+  abstract getClientId(userId: UserId): Promise<string | undefined>;
 
   /**
    * Sets the API Key Client Secret for the active user id in memory or disk based on the given vaultTimeoutAction and vaultTimeout.
@@ -116,10 +116,10 @@ export abstract class TokenService {
   ): Promise<string>;
 
   /**
-   * Gets the API Key Client Secret for the active user.
+   * Gets the API Key Client Secret for the given user.
    * @returns A promise that resolves with the API Key Client Secret or undefined
    */
-  abstract getClientSecret(userId?: UserId): Promise<string | undefined>;
+  abstract getClientSecret(userId: UserId): Promise<string | undefined>;
 
   /**
    * Sets the two factor token for the given email in global state.
@@ -157,7 +157,7 @@ export abstract class TokenService {
    * Gets the expiration date for the access token. Returns if token can't be decoded or has no expiration
    * @returns A promise that resolves with the expiration date for the access token.
    */
-  abstract getTokenExpirationDate(): Promise<Date | null>;
+  abstract getTokenExpirationDate(userId: UserId): Promise<Date | null>;
 
   /**
    * Calculates the adjusted time in seconds until the access token expires, considering an optional offset.
@@ -168,14 +168,14 @@ export abstract class TokenService {
    * based on the actual expiration.
    * @returns {Promise<number>} Promise resolving to the adjusted seconds remaining.
    */
-  abstract tokenSecondsRemaining(offsetSeconds?: number): Promise<number>;
+  abstract tokenSecondsRemaining(userId: UserId, offsetSeconds?: number): Promise<number>;
 
   /**
    * Checks if the access token needs to be refreshed.
    * @param {number} [minutes=5] - Optional number of minutes before the access token expires to consider refreshing it.
    * @returns A promise that resolves with a boolean indicating if the access token needs to be refreshed.
    */
-  abstract tokenNeedsRefresh(minutes?: number): Promise<boolean>;
+  abstract tokenNeedsRefresh(userId: UserId, minutes?: number): Promise<boolean>;
 
   /**
    * Gets the user id for the active user from the access token.

--- a/libs/common/src/auth/services/token.service.spec.ts
+++ b/libs/common/src/auth/services/token.service.spec.ts
@@ -409,28 +409,8 @@ describe("TokenService", () => {
     });
 
     describe("getAccessToken", () => {
-      it("returns null when no user id is provided and there is no active user in global state", async () => {
-        // Act
-        const result = await tokenService.getAccessToken();
-        // Assert
-        expect(result).toBeNull();
-      });
-
-      it("returns null when no access token is found in memory, disk, or secure storage", async () => {
-        // Arrange
-        globalStateProvider.getFake(ACCOUNT_ACTIVE_ACCOUNT_ID).nextState(userIdFromAccessToken);
-
-        // Act
-        const result = await tokenService.getAccessToken();
-        // Assert
-        expect(result).toBeNull();
-      });
-
       describe("Memory storage tests", () => {
-        test.each([
-          ["gets the access token from memory when a user id is provided ", userIdFromAccessToken],
-          ["gets the access token from memory when no user id is provided", undefined],
-        ])("%s", async (_, userId) => {
+        it("gets the access token from memory when a user id is provided ", async () => {
           // Arrange
           singleUserStateProvider
             .getFake(userIdFromAccessToken, ACCESS_TOKEN_MEMORY)
@@ -442,12 +422,10 @@ describe("TokenService", () => {
             .nextState(undefined);
 
           // Need to have global active id set to the user id
-          if (!userId) {
-            globalStateProvider.getFake(ACCOUNT_ACTIVE_ACCOUNT_ID).nextState(userIdFromAccessToken);
-          }
+          globalStateProvider.getFake(ACCOUNT_ACTIVE_ACCOUNT_ID).nextState(userIdFromAccessToken);
 
           // Act
-          const result = await tokenService.getAccessToken(userId);
+          const result = await tokenService.getAccessToken(userIdFromAccessToken);
 
           // Assert
           expect(result).toEqual(accessTokenJwt);
@@ -455,10 +433,7 @@ describe("TokenService", () => {
       });
 
       describe("Disk storage tests (secure storage not supported on platform)", () => {
-        test.each([
-          ["gets the access token from disk when the user id is specified", userIdFromAccessToken],
-          ["gets the access token from disk when no user id is specified", undefined],
-        ])("%s", async (_, userId) => {
+        it("gets the access token from disk when the user id is specified", async () => {
           // Arrange
           singleUserStateProvider
             .getFake(userIdFromAccessToken, ACCESS_TOKEN_MEMORY)
@@ -469,12 +444,10 @@ describe("TokenService", () => {
             .nextState(accessTokenJwt);
 
           // Need to have global active id set to the user id
-          if (!userId) {
-            globalStateProvider.getFake(ACCOUNT_ACTIVE_ACCOUNT_ID).nextState(userIdFromAccessToken);
-          }
+          globalStateProvider.getFake(ACCOUNT_ACTIVE_ACCOUNT_ID).nextState(userIdFromAccessToken);
 
           // Act
-          const result = await tokenService.getAccessToken(userId);
+          const result = await tokenService.getAccessToken(userIdFromAccessToken);
           // Assert
           expect(result).toEqual(accessTokenJwt);
         });
@@ -486,16 +459,7 @@ describe("TokenService", () => {
           tokenService = createTokenService(supportsSecureStorage);
         });
 
-        test.each([
-          [
-            "gets the encrypted access token from disk, decrypts it, and returns it when a user id is provided",
-            userIdFromAccessToken,
-          ],
-          [
-            "gets the encrypted access token from disk, decrypts it, and returns it when no user id is provided",
-            undefined,
-          ],
-        ])("%s", async (_, userId) => {
+        it("gets the encrypted access token from disk, decrypts it, and returns it when a user id is provided", async () => {
           // Arrange
           singleUserStateProvider
             .getFake(userIdFromAccessToken, ACCESS_TOKEN_MEMORY)
@@ -509,27 +473,17 @@ describe("TokenService", () => {
           encryptService.decryptString.mockResolvedValue("decryptedAccessToken");
 
           // Need to have global active id set to the user id
-          if (!userId) {
-            globalStateProvider.getFake(ACCOUNT_ACTIVE_ACCOUNT_ID).nextState(userIdFromAccessToken);
-          }
+
+          globalStateProvider.getFake(ACCOUNT_ACTIVE_ACCOUNT_ID).nextState(userIdFromAccessToken);
 
           // Act
-          const result = await tokenService.getAccessToken(userId);
+          const result = await tokenService.getAccessToken(userIdFromAccessToken);
 
           // Assert
           expect(result).toEqual("decryptedAccessToken");
         });
 
-        test.each([
-          [
-            "falls back and gets the unencrypted access token from disk when there isn't an access token key in secure storage and a user id is provided",
-            userIdFromAccessToken,
-          ],
-          [
-            "falls back and gets the unencrypted access token from disk when there isn't an access token key in secure storage and no user id is provided",
-            undefined,
-          ],
-        ])("%s", async (_, userId) => {
+        it("falls back and gets the unencrypted access token from disk when there isn't an access token key in secure storage and a user id is provided", async () => {
           // Arrange
           singleUserStateProvider
             .getFake(userIdFromAccessToken, ACCESS_TOKEN_MEMORY)
@@ -540,14 +494,12 @@ describe("TokenService", () => {
             .nextState(accessTokenJwt);
 
           // Need to have global active id set to the user id
-          if (!userId) {
-            globalStateProvider.getFake(ACCOUNT_ACTIVE_ACCOUNT_ID).nextState(userIdFromAccessToken);
-          }
+          globalStateProvider.getFake(ACCOUNT_ACTIVE_ACCOUNT_ID).nextState(userIdFromAccessToken);
 
           // No access token key set
 
           // Act
-          const result = await tokenService.getAccessToken(userId);
+          const result = await tokenService.getAccessToken(userIdFromAccessToken);
 
           // Assert
           expect(result).toEqual(accessTokenJwt);
@@ -738,7 +690,7 @@ describe("TokenService", () => {
 
           // Act
           // note: don't await here because we want to test the error
-          const result = tokenService.getTokenExpirationDate();
+          const result = tokenService.getTokenExpirationDate(userIdFromAccessToken);
           // Assert
           await expect(result).rejects.toThrow("Failed to decode access token: Mock error");
         });
@@ -748,7 +700,7 @@ describe("TokenService", () => {
           tokenService.decodeAccessToken = jest.fn().mockResolvedValue(null);
 
           // Act
-          const result = await tokenService.getTokenExpirationDate();
+          const result = await tokenService.getTokenExpirationDate(userIdFromAccessToken);
 
           // Assert
           expect(result).toBeNull();
@@ -763,7 +715,7 @@ describe("TokenService", () => {
             .mockResolvedValue(accessTokenDecodedWithoutExp);
 
           // Act
-          const result = await tokenService.getTokenExpirationDate();
+          const result = await tokenService.getTokenExpirationDate(userIdFromAccessToken);
 
           // Assert
           expect(result).toBeNull();
@@ -777,7 +729,7 @@ describe("TokenService", () => {
             .mockResolvedValue(accessTokenDecodedWithNonNumericExp);
 
           // Act
-          const result = await tokenService.getTokenExpirationDate();
+          const result = await tokenService.getTokenExpirationDate(userIdFromAccessToken);
 
           // Assert
           expect(result).toBeNull();
@@ -788,7 +740,7 @@ describe("TokenService", () => {
           tokenService.decodeAccessToken = jest.fn().mockResolvedValue(accessTokenDecoded);
 
           // Act
-          const result = await tokenService.getTokenExpirationDate();
+          const result = await tokenService.getTokenExpirationDate(userIdFromAccessToken);
 
           // Assert
           expect(result).toEqual(new Date(accessTokenDecoded.exp * 1000));
@@ -801,7 +753,7 @@ describe("TokenService", () => {
           tokenService.getTokenExpirationDate = jest.fn().mockResolvedValue(null);
 
           // Act
-          const result = await tokenService.tokenSecondsRemaining();
+          const result = await tokenService.tokenSecondsRemaining(userIdFromAccessToken);
 
           // Assert
           expect(result).toEqual(0);
@@ -823,7 +775,7 @@ describe("TokenService", () => {
           tokenService.getTokenExpirationDate = jest.fn().mockResolvedValue(expirationDate);
 
           // Act
-          const result = await tokenService.tokenSecondsRemaining();
+          const result = await tokenService.tokenSecondsRemaining(userIdFromAccessToken);
 
           // Assert
           expect(result).toEqual(expectedSecondsRemaining);
@@ -849,7 +801,10 @@ describe("TokenService", () => {
           tokenService.getTokenExpirationDate = jest.fn().mockResolvedValue(expirationDate);
 
           // Act
-          const result = await tokenService.tokenSecondsRemaining(offsetSeconds);
+          const result = await tokenService.tokenSecondsRemaining(
+            userIdFromAccessToken,
+            offsetSeconds,
+          );
 
           // Assert
           expect(result).toEqual(expectedSecondsRemaining);
@@ -866,7 +821,7 @@ describe("TokenService", () => {
           tokenService.tokenSecondsRemaining = jest.fn().mockResolvedValue(tokenSecondsRemaining);
 
           // Act
-          const result = await tokenService.tokenNeedsRefresh();
+          const result = await tokenService.tokenNeedsRefresh(userIdFromAccessToken);
 
           // Assert
           expect(result).toEqual(true);
@@ -878,7 +833,7 @@ describe("TokenService", () => {
           tokenService.tokenSecondsRemaining = jest.fn().mockResolvedValue(tokenSecondsRemaining);
 
           // Act
-          const result = await tokenService.tokenNeedsRefresh();
+          const result = await tokenService.tokenNeedsRefresh(userIdFromAccessToken);
 
           // Assert
           expect(result).toEqual(false);
@@ -890,7 +845,7 @@ describe("TokenService", () => {
           tokenService.tokenSecondsRemaining = jest.fn().mockResolvedValue(tokenSecondsRemaining);
 
           // Act
-          const result = await tokenService.tokenNeedsRefresh(2);
+          const result = await tokenService.tokenNeedsRefresh(userIdFromAccessToken, 2);
 
           // Assert
           expect(result).toEqual(true);
@@ -902,7 +857,7 @@ describe("TokenService", () => {
           tokenService.tokenSecondsRemaining = jest.fn().mockResolvedValue(tokenSecondsRemaining);
 
           // Act
-          const result = await tokenService.tokenNeedsRefresh(5);
+          const result = await tokenService.tokenNeedsRefresh(userIdFromAccessToken, 5);
 
           // Assert
           expect(result).toEqual(false);
@@ -1565,26 +1520,6 @@ describe("TokenService", () => {
       });
 
       describe("Memory storage tests", () => {
-        it("gets the refresh token from memory when no user id is specified (uses global active user)", async () => {
-          // Arrange
-          singleUserStateProvider
-            .getFake(userIdFromAccessToken, REFRESH_TOKEN_MEMORY)
-            .nextState(refreshToken);
-
-          singleUserStateProvider
-            .getFake(userIdFromAccessToken, REFRESH_TOKEN_DISK)
-            .nextState(undefined);
-
-          // Need to have global active id set to the user id
-          globalStateProvider.getFake(ACCOUNT_ACTIVE_ACCOUNT_ID).nextState(userIdFromAccessToken);
-
-          // Act
-          const result = await tokenService.getRefreshToken();
-
-          // Assert
-          expect(result).toEqual(refreshToken);
-        });
-
         it("gets the refresh token from memory when a user id is specified", async () => {
           // Arrange
           singleUserStateProvider
@@ -1603,25 +1538,6 @@ describe("TokenService", () => {
       });
 
       describe("Disk storage tests (secure storage not supported on platform)", () => {
-        it("gets the refresh token from disk when no user id is specified", async () => {
-          // Arrange
-          singleUserStateProvider
-            .getFake(userIdFromAccessToken, REFRESH_TOKEN_MEMORY)
-            .nextState(undefined);
-
-          singleUserStateProvider
-            .getFake(userIdFromAccessToken, REFRESH_TOKEN_DISK)
-            .nextState(refreshToken);
-
-          // Need to have global active id set to the user id
-          globalStateProvider.getFake(ACCOUNT_ACTIVE_ACCOUNT_ID).nextState(userIdFromAccessToken);
-
-          // Act
-          const result = await tokenService.getRefreshToken();
-          // Assert
-          expect(result).toEqual(refreshToken);
-        });
-
         it("gets the refresh token from disk when a user id is specified", async () => {
           // Arrange
           singleUserStateProvider
@@ -1643,27 +1559,6 @@ describe("TokenService", () => {
         beforeEach(() => {
           const supportsSecureStorage = true;
           tokenService = createTokenService(supportsSecureStorage);
-        });
-
-        it("gets the refresh token from secure storage when no user id is specified", async () => {
-          // Arrange
-          singleUserStateProvider
-            .getFake(userIdFromAccessToken, REFRESH_TOKEN_MEMORY)
-            .nextState(undefined);
-
-          singleUserStateProvider
-            .getFake(userIdFromAccessToken, REFRESH_TOKEN_DISK)
-            .nextState(undefined);
-
-          secureStorageService.get.mockResolvedValue(refreshToken);
-
-          // Need to have global active id set to the user id
-          globalStateProvider.getFake(ACCOUNT_ACTIVE_ACCOUNT_ID).nextState(userIdFromAccessToken);
-
-          // Act
-          const result = await tokenService.getRefreshToken();
-          // Assert
-          expect(result).toEqual(refreshToken);
         });
 
         it("gets the refresh token from secure storage when a user id is specified", async () => {
@@ -1697,29 +1592,6 @@ describe("TokenService", () => {
 
           // Act
           const result = await tokenService.getRefreshToken(userIdFromAccessToken);
-
-          // Assert
-          expect(result).toEqual(refreshToken);
-
-          // assert that secure storage was not called
-          expect(secureStorageService.get).not.toHaveBeenCalled();
-        });
-
-        it("falls back and gets the refresh token from disk when no user id is specified even if the platform supports secure storage", async () => {
-          // Arrange
-          singleUserStateProvider
-            .getFake(userIdFromAccessToken, REFRESH_TOKEN_MEMORY)
-            .nextState(undefined);
-
-          singleUserStateProvider
-            .getFake(userIdFromAccessToken, REFRESH_TOKEN_DISK)
-            .nextState(refreshToken);
-
-          // Need to have global active id set to the user id
-          globalStateProvider.getFake(ACCOUNT_ACTIVE_ACCOUNT_ID).nextState(userIdFromAccessToken);
-
-          // Act
-          const result = await tokenService.getRefreshToken();
 
           // Assert
           expect(result).toEqual(refreshToken);
@@ -1944,45 +1816,7 @@ describe("TokenService", () => {
     });
 
     describe("getClientId", () => {
-      it("returns undefined when no user id is provided and there is no active user in global state", async () => {
-        // Act
-        const result = await tokenService.getClientId();
-        // Assert
-        expect(result).toBeUndefined();
-      });
-
-      it("returns null when no client id is found in memory or disk", async () => {
-        // Arrange
-        globalStateProvider.getFake(ACCOUNT_ACTIVE_ACCOUNT_ID).nextState(userIdFromAccessToken);
-
-        // Act
-        const result = await tokenService.getClientId();
-        // Assert
-        expect(result).toBeNull();
-      });
-
       describe("Memory storage tests", () => {
-        it("gets the client id from memory when no user id is specified (uses global active user)", async () => {
-          // Arrange
-          singleUserStateProvider
-            .getFake(userIdFromAccessToken, API_KEY_CLIENT_ID_MEMORY)
-            .nextState(clientId);
-
-          // set disk to undefined
-          singleUserStateProvider
-            .getFake(userIdFromAccessToken, API_KEY_CLIENT_ID_DISK)
-            .nextState(undefined);
-
-          // Need to have global active id set to the user id
-          globalStateProvider.getFake(ACCOUNT_ACTIVE_ACCOUNT_ID).nextState(userIdFromAccessToken);
-
-          // Act
-          const result = await tokenService.getClientId();
-
-          // Assert
-          expect(result).toEqual(clientId);
-        });
-
         it("gets the client id from memory when given a user id", async () => {
           // Arrange
           singleUserStateProvider
@@ -2002,25 +1836,6 @@ describe("TokenService", () => {
       });
 
       describe("Disk storage tests", () => {
-        it("gets the client id from disk when no user id is specified", async () => {
-          // Arrange
-          singleUserStateProvider
-            .getFake(userIdFromAccessToken, API_KEY_CLIENT_ID_MEMORY)
-            .nextState(undefined);
-
-          singleUserStateProvider
-            .getFake(userIdFromAccessToken, API_KEY_CLIENT_ID_DISK)
-            .nextState(clientId);
-
-          // Need to have global active id set to the user id
-          globalStateProvider.getFake(ACCOUNT_ACTIVE_ACCOUNT_ID).nextState(userIdFromAccessToken);
-
-          // Act
-          const result = await tokenService.getClientId();
-          // Assert
-          expect(result).toEqual(clientId);
-        });
-
         it("gets the client id from disk when a user id is specified", async () => {
           // Arrange
           singleUserStateProvider
@@ -2215,45 +2030,17 @@ describe("TokenService", () => {
     });
 
     describe("getClientSecret", () => {
-      it("returns undefined when no user id is provided and there is no active user in global state", async () => {
-        // Act
-        const result = await tokenService.getClientSecret();
-        // Assert
-        expect(result).toBeUndefined();
-      });
-
       it("returns null when no client secret is found in memory or disk", async () => {
         // Arrange
         globalStateProvider.getFake(ACCOUNT_ACTIVE_ACCOUNT_ID).nextState(userIdFromAccessToken);
 
         // Act
-        const result = await tokenService.getClientSecret();
+        const result = await tokenService.getClientSecret(userIdFromAccessToken);
         // Assert
         expect(result).toBeNull();
       });
 
       describe("Memory storage tests", () => {
-        it("gets the client secret from memory when no user id is specified (uses global active user)", async () => {
-          // Arrange
-          singleUserStateProvider
-            .getFake(userIdFromAccessToken, API_KEY_CLIENT_SECRET_MEMORY)
-            .nextState(clientSecret);
-
-          // set disk to undefined
-          singleUserStateProvider
-            .getFake(userIdFromAccessToken, API_KEY_CLIENT_SECRET_DISK)
-            .nextState(undefined);
-
-          // Need to have global active id set to the user id
-          globalStateProvider.getFake(ACCOUNT_ACTIVE_ACCOUNT_ID).nextState(userIdFromAccessToken);
-
-          // Act
-          const result = await tokenService.getClientSecret();
-
-          // Assert
-          expect(result).toEqual(clientSecret);
-        });
-
         it("gets the client secret from memory when a user id is specified", async () => {
           // Arrange
           singleUserStateProvider
@@ -2273,25 +2060,6 @@ describe("TokenService", () => {
       });
 
       describe("Disk storage tests", () => {
-        it("gets the client secret from disk when no user id specified", async () => {
-          // Arrange
-          singleUserStateProvider
-            .getFake(userIdFromAccessToken, API_KEY_CLIENT_SECRET_MEMORY)
-            .nextState(undefined);
-
-          singleUserStateProvider
-            .getFake(userIdFromAccessToken, API_KEY_CLIENT_SECRET_DISK)
-            .nextState(clientSecret);
-
-          // Need to have global active id set to the user id
-          globalStateProvider.getFake(ACCOUNT_ACTIVE_ACCOUNT_ID).nextState(userIdFromAccessToken);
-
-          // Act
-          const result = await tokenService.getClientSecret();
-          // Assert
-          expect(result).toEqual(clientSecret);
-        });
-
         it("gets the client secret from disk when a user id is specified", async () => {
           // Arrange
           singleUserStateProvider

--- a/libs/common/src/key-management/vault-timeout/services/vault-timeout-settings.service.ts
+++ b/libs/common/src/key-management/vault-timeout/services/vault-timeout-settings.service.ts
@@ -70,17 +70,17 @@ export class VaultTimeoutSettingsService implements VaultTimeoutSettingsServiceA
 
     // We swap these tokens from being on disk for lock actions, and in memory for logout actions
     // Get them here to set them to their new location after changing the timeout action and clearing if needed
-    const accessToken = await this.tokenService.getAccessToken();
-    const refreshToken = await this.tokenService.getRefreshToken();
-    const clientId = await this.tokenService.getClientId();
-    const clientSecret = await this.tokenService.getClientSecret();
+    const accessToken = await this.tokenService.getAccessToken(userId);
+    const refreshToken = await this.tokenService.getRefreshToken(userId);
+    const clientId = await this.tokenService.getClientId(userId);
+    const clientSecret = await this.tokenService.getClientSecret(userId);
 
     await this.setVaultTimeout(userId, timeout);
 
     if (timeout != VaultTimeoutStringType.Never && action === VaultTimeoutAction.LogOut) {
       // if we have a vault timeout and the action is log out, reset tokens
       // as the tokens were stored on disk and now should be stored in memory
-      await this.tokenService.clearTokens();
+      await this.tokenService.clearTokens(userId);
     }
 
     await this.setVaultTimeoutAction(userId, action);

--- a/libs/common/src/platform/server-notifications/internal/signalr-connection.service.ts
+++ b/libs/common/src/platform/server-notifications/internal/signalr-connection.service.ts
@@ -78,7 +78,7 @@ export class SignalRConnectionService {
     return new Observable<SignalRNotification>((subsciber) => {
       const connection = this.hubConnectionBuilderFactory()
         .withUrl(notificationsUrl + "/hub", {
-          accessTokenFactory: () => this.apiService.getActiveBearerToken(),
+          accessTokenFactory: () => this.apiService.getActiveBearerToken(userId),
           skipNegotiation: true,
           transport: HttpTransportType.WebSockets,
         })

--- a/libs/common/src/platform/server-notifications/internal/web-push-notifications-api.service.ts
+++ b/libs/common/src/platform/server-notifications/internal/web-push-notifications-api.service.ts
@@ -1,3 +1,5 @@
+import { UserId } from "@bitwarden/user-core";
+
 import { ApiService } from "../../../abstractions/api.service";
 import { AppIdService } from "../../abstractions/app-id.service";
 
@@ -12,13 +14,13 @@ export class WebPushNotificationsApiService {
   /**
    * Posts a device-user association to the server and ensures it's installed for push server notifications
    */
-  async putSubscription(pushSubscription: PushSubscriptionJSON): Promise<void> {
+  async putSubscription(pushSubscription: PushSubscriptionJSON, userId: UserId): Promise<void> {
     const request = WebPushRequest.from(pushSubscription);
     await this.apiService.send(
       "POST",
       `/devices/identifier/${await this.appIdService.getAppId()}/web-push-auth`,
       request,
-      true,
+      userId,
       false,
     );
   }

--- a/libs/common/src/platform/server-notifications/internal/worker-webpush-connection.service.ts
+++ b/libs/common/src/platform/server-notifications/internal/worker-webpush-connection.service.ts
@@ -143,7 +143,7 @@ class MyWebPushConnector implements WebPushConnector {
         await subscriptionUsersState.update(() => subscriptionUsers);
 
         // Inform the server about the new subscription-user association
-        await this.webPushApiService.putSubscription(subscription.toJSON());
+        await this.webPushApiService.putSubscription(subscription.toJSON(), this.userId);
       }),
       switchMap(() => this.pushEvent$),
       map((e) => {

--- a/libs/common/src/platform/services/config/config-api.service.ts
+++ b/libs/common/src/platform/services/config/config-api.service.ts
@@ -1,22 +1,21 @@
 import { ApiService } from "../../../abstractions/api.service";
-import { TokenService } from "../../../auth/abstractions/token.service";
 import { UserId } from "../../../types/guid";
 import { ConfigApiServiceAbstraction } from "../../abstractions/config/config-api.service.abstraction";
 import { ServerConfigResponse } from "../../models/response/server-config.response";
 
 export class ConfigApiService implements ConfigApiServiceAbstraction {
-  constructor(
-    private apiService: ApiService,
-    private tokenService: TokenService,
-  ) {}
+  constructor(private apiService: ApiService) {}
 
   async get(userId: UserId | null): Promise<ServerConfigResponse> {
     // Authentication adds extra context to config responses, if the user has an access token, we want to use it
     // We don't particularly care about ensuring the token is valid and not expired, just that it exists
-    const authed: boolean =
-      userId == null ? false : (await this.tokenService.getAccessToken(userId)) != null;
+    let r: any;
+    if (userId == null) {
+      r = await this.apiService.send("GET", "/config", null, false, true);
+    } else {
+      r = await this.apiService.send("GET", "/config", null, userId, true);
+    }
 
-    const r = await this.apiService.send("GET", "/config", null, authed, true);
     return new ServerConfigResponse(r);
   }
 }

--- a/libs/common/src/services/api.service.spec.ts
+++ b/libs/common/src/services/api.service.spec.ts
@@ -1,13 +1,19 @@
 import { mock, MockProxy } from "jest-mock-extended";
-import { of } from "rxjs";
+import { ObservedValueOf, of } from "rxjs";
 
 // This import has been flagged as unallowed for this class. It may be involved in a circular dependency loop.
 // eslint-disable-next-line no-restricted-imports
 import { LogoutReason } from "@bitwarden/auth/common";
+import { UserId } from "@bitwarden/user-core";
 
+import { AccountService } from "../auth/abstractions/account.service";
 import { TokenService } from "../auth/abstractions/token.service";
 import { DeviceType } from "../enums";
-import { VaultTimeoutSettingsService } from "../key-management/vault-timeout";
+import {
+  VaultTimeoutAction,
+  VaultTimeoutSettingsService,
+  VaultTimeoutStringType,
+} from "../key-management/vault-timeout";
 import { ErrorResponse } from "../models/response/error.response";
 import { AppIdService } from "../platform/abstractions/app-id.service";
 import { Environment, EnvironmentService } from "../platform/abstractions/environment.service";
@@ -25,9 +31,13 @@ describe("ApiService", () => {
   let logService: MockProxy<LogService>;
   let logoutCallback: jest.Mock<Promise<void>, [reason: LogoutReason]>;
   let vaultTimeoutSettingsService: MockProxy<VaultTimeoutSettingsService>;
+  let accountService: MockProxy<AccountService>;
   let httpOperations: MockProxy<HttpOperations>;
 
   let sut: ApiService;
+
+  const testActiveUser = "activeUser" as UserId;
+  const testInactiveUser = "inactiveUser" as UserId;
 
   beforeEach(() => {
     tokenService = mock();
@@ -40,6 +50,15 @@ describe("ApiService", () => {
     logService = mock();
     logoutCallback = jest.fn();
     vaultTimeoutSettingsService = mock();
+    accountService = mock();
+
+    accountService.activeAccount$ = of({
+      id: testActiveUser,
+      email: "user1@example.com",
+      emailVerified: true,
+      name: "Test Name",
+    } satisfies ObservedValueOf<AccountService["activeAccount$"]>);
+
     httpOperations = mock();
 
     sut = new ApiService(
@@ -51,6 +70,7 @@ describe("ApiService", () => {
       logService,
       logoutCallback,
       vaultTimeoutSettingsService,
+      accountService,
       httpOperations,
       "custom-user-agent",
     );
@@ -61,6 +81,12 @@ describe("ApiService", () => {
       environmentService.environment$ = of({
         getApiUrl: () => "https://example.com",
       } satisfies Partial<Environment> as Environment);
+
+      environmentService.getEnvironment$.mockReturnValue(
+        of({
+          getApiUrl: () => "https://authed.example.com",
+        } satisfies Partial<Environment> as Environment),
+      );
 
       httpOperations.createRequest.mockImplementation((url, request) => {
         return {
@@ -96,6 +122,7 @@ describe("ApiService", () => {
 
       expect(nativeFetch).toHaveBeenCalledTimes(1);
       const request = nativeFetch.mock.calls[0][0];
+      expect(request.url).toBe("https://authed.example.com/something");
       // This should get set for users of send
       expect(request.cache).toBe("no-store");
       // TODO: Could expect on the credentials parameter
@@ -108,6 +135,185 @@ describe("ApiService", () => {
       expect(request.headers.get("Authorization")).toBe("Bearer access_token");
       // The response body
       expect(response).toEqual({ hello: "world" });
+    });
+
+    it("authenticates with non-active user when user is passed in", async () => {
+      environmentService.environment$ = of({
+        getApiUrl: () => "https://example.com",
+      } satisfies Partial<Environment> as Environment);
+
+      environmentService.getEnvironment$.calledWith(testInactiveUser).mockReturnValueOnce(
+        of({
+          getApiUrl: () => "https://inactive.example.com",
+        } satisfies Partial<Environment> as Environment),
+      );
+
+      httpOperations.createRequest.mockImplementation((url, request) => {
+        return {
+          url: url,
+          cache: request.cache,
+          credentials: request.credentials,
+          method: request.method,
+          mode: request.mode,
+          signal: request.signal,
+          headers: new Headers(request.headers),
+        } satisfies Partial<Request> as unknown as Request;
+      });
+
+      tokenService.getAccessToken
+        .calledWith(testInactiveUser)
+        .mockResolvedValue("inactive_access_token");
+
+      tokenService.tokenNeedsRefresh.calledWith(testInactiveUser).mockResolvedValue(false);
+
+      const nativeFetch = jest.fn<Promise<Response>, [request: Request]>();
+
+      nativeFetch.mockImplementation((request) => {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ hello: "world" }),
+          headers: new Headers({
+            "content-type": "application/json",
+          }),
+        } satisfies Partial<Response> as Response);
+      });
+
+      sut.nativeFetch = nativeFetch;
+
+      const response = await sut.send(
+        "GET",
+        "/something",
+        null,
+        testInactiveUser,
+        true,
+        null,
+        null,
+      );
+
+      expect(nativeFetch).toHaveBeenCalledTimes(1);
+      const request = nativeFetch.mock.calls[0][0];
+      expect(request.url).toBe("https://inactive.example.com/something");
+      // This should get set for users of send
+      expect(request.cache).toBe("no-store");
+      // TODO: Could expect on the credentials parameter
+      expect(request.headers.get("Device-Type")).toBe("2"); // Chrome Extension
+      // Custom user agent should get set
+      expect(request.headers.get("User-Agent")).toBe("custom-user-agent");
+      // This should be set when the caller has indicated there is a response
+      expect(request.headers.get("Accept")).toBe("application/json");
+      // If they have indicated that it's authed, then the authorization header should get set.
+      expect(request.headers.get("Authorization")).toBe("Bearer inactive_access_token");
+      // The response body
+      expect(response).toEqual({ hello: "world" });
+    });
+
+    const cases: {
+      name: string;
+      authedOrUserId: boolean | UserId;
+      expectedEffectiveUser: UserId;
+    }[] = [
+      {
+        name: "refreshes active user when true passed in for auth",
+        authedOrUserId: true,
+        expectedEffectiveUser: testActiveUser,
+      },
+      {
+        name: "refreshes acess token when the user passed in happens to be the active one",
+        authedOrUserId: testActiveUser,
+        expectedEffectiveUser: testActiveUser,
+      },
+      {
+        name: "refreshes access token when the user passed in happens to be inactive",
+        authedOrUserId: testInactiveUser,
+        expectedEffectiveUser: testInactiveUser,
+      },
+    ];
+
+    it.each(cases)("$name does", async ({ authedOrUserId, expectedEffectiveUser }) => {
+      environmentService.getEnvironment$.calledWith(expectedEffectiveUser).mockReturnValue(
+        of({
+          getApiUrl: () => `https://${expectedEffectiveUser}.example.com`,
+          getIdentityUrl: () => `https://${expectedEffectiveUser}.identity.example.com`,
+        } satisfies Partial<Environment> as Environment),
+      );
+
+      tokenService.getAccessToken
+        .calledWith(expectedEffectiveUser)
+        .mockResolvedValue(`${expectedEffectiveUser}_access_token`);
+
+      tokenService.tokenNeedsRefresh.calledWith(expectedEffectiveUser).mockResolvedValue(true);
+
+      tokenService.getRefreshToken
+        .calledWith(expectedEffectiveUser)
+        .mockResolvedValue(`${expectedEffectiveUser}_refresh_token`);
+
+      tokenService.decodeAccessToken
+        .calledWith(expectedEffectiveUser)
+        .mockResolvedValue({ client_id: "web" });
+
+      tokenService.decodeAccessToken
+        .calledWith(`${expectedEffectiveUser}_new_access_token`)
+        .mockResolvedValue({ sub: expectedEffectiveUser });
+
+      vaultTimeoutSettingsService.getVaultTimeoutActionByUserId$
+        .calledWith(expectedEffectiveUser)
+        .mockReturnValue(of(VaultTimeoutAction.Lock));
+
+      vaultTimeoutSettingsService.getVaultTimeoutByUserId$
+        .calledWith(expectedEffectiveUser)
+        .mockReturnValue(of(VaultTimeoutStringType.Never));
+
+      tokenService.setTokens
+        .calledWith(
+          `${expectedEffectiveUser}_new_access_token`,
+          VaultTimeoutAction.Lock,
+          VaultTimeoutStringType.Never,
+          `${expectedEffectiveUser}_new_refresh_token`,
+        )
+        .mockResolvedValue({ accessToken: `${expectedEffectiveUser}_refreshed_access_token` });
+
+      httpOperations.createRequest.mockImplementation((url, request) => {
+        return {
+          url: url,
+          cache: request.cache,
+          credentials: request.credentials,
+          method: request.method,
+          mode: request.mode,
+          signal: request.signal,
+          headers: new Headers(request.headers),
+        } satisfies Partial<Request> as unknown as Request;
+      });
+
+      const nativeFetch = jest.fn<Promise<Response>, [request: Request]>();
+
+      nativeFetch.mockImplementation((request) => {
+        if (request.url.includes("identity")) {
+          return Promise.resolve({
+            ok: true,
+            status: 200,
+            json: () =>
+              Promise.resolve({
+                access_token: `${expectedEffectiveUser}_new_access_token`,
+                refresh_token: `${expectedEffectiveUser}_new_refresh_token`,
+              }),
+          } satisfies Partial<Response> as Response);
+        }
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ hello: "world" }),
+          headers: new Headers({
+            "content-type": "application/json",
+          }),
+        } satisfies Partial<Response> as Response);
+      });
+
+      sut.nativeFetch = nativeFetch;
+
+      await sut.send("GET", "/something", null, authedOrUserId, true, null, null);
+
+      expect(nativeFetch).toHaveBeenCalledTimes(2);
     });
   });
 
@@ -169,9 +375,11 @@ describe("ApiService", () => {
   it.each(errorData)(
     "throws error-like response when not ok response with $name",
     async ({ input, error }) => {
-      environmentService.environment$ = of({
-        getApiUrl: () => "https://example.com",
-      } satisfies Partial<Environment> as Environment);
+      environmentService.getEnvironment$.calledWith(testActiveUser).mockReturnValue(
+        of({
+          getApiUrl: () => "https://example.com",
+        } satisfies Partial<Environment> as Environment),
+      );
 
       httpOperations.createRequest.mockImplementation((url, request) => {
         return {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-25362

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Makes it possible to pass in a users ID to the `ApiService.send` and have the API request be made on behalf of that given user instead of the active user. 

This also requires the `userId` on `getActiveBearerToken` and I updated all the call sites to either supply the user id with the user id they have in context or falling back to getting the active user. 

The design for this is to begin encouraging consumers to pass in the `userId` of the user they want authenticated instead of passing `true` that they do want it authenticated. Passing in `true` is still supported, but marked as deprecated. It is intended to behave equally, if not more resilient to the current behavior of passing in `true`. When true is passed in we get the active user right up front and use that ID for the rest of the code. Before there were multiple times that the active user was retrieved which technically could have caused some problems if a request was fired off and account switching took place right after.

Passing in `null` to try and indicate they do NOT want an authenticated request is NOT supported. Even though internally to the method we treat a `null` user Id as the indicator to not add the `Authentication` header I don't think it would be good to expose that publicly because they could think they have a user ID when they actually don't. Instead it's expected that you explicitly say `false`. 



## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
