### PR TITLE
[PM-24151] Unable to log in to browser extension in Safari

### DIFF
--- a/libs/auth/src/angular/login/login.component.ts
+++ b/libs/auth/src/angular/login/login.component.ts
@@ -266,7 +266,7 @@ export class LoginComponent implements OnInit, OnDestroy {
     if (error instanceof ErrorResponse) {
       switch (error.statusCode) {
         case HttpStatusCode.BadRequest: {
-          if (error.message.toLowerCase().includes("username or password is incorrect")) {
+          if (error.message?.toLowerCase().includes("username or password is incorrect")) {
             this.formGroup.controls.masterPassword.setErrors({
               error: {
                 message: this.i18nService.t("invalidMasterPassword"),


### PR DESCRIPTION
## 🎟️ Tracking

[PM-24151](https://bitwarden.atlassian.net/browse/PM-24151)

## 📔 Objective

In GH Issue #15779, users have reported inability to log in under certain circumstances. The purpose of this update is to improve the feedback around this issue to prevent parsing errors from surfacing to the user.

This should enable users to self-serve where applicable and increase grace on the whole in instances where 400-class HTTP status responses with a content-type other than `text/plain` do not come with expected `Message` or `ValidationErrors` properties.

Additional investigation is ongoing; this update serves to prevent exceptional cases from covering up details when they exist.

## 📸 Screenshots

Error before, as reported:
<img width="1055" height="666" alt="PM-24151__error-before" src="https://github.com/user-attachments/assets/ea51f72d-f519-4d4e-8722-292511e888f4" />

Error after, where error response did not satisfy any of the expected and displayable properties:
<img width="926" height="777" alt="PM-24151__error-after" src="https://github.com/user-attachments/assets/f4c65e49-4a0e-44bc-858e-947e6517e184" />


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
