### PR TITLE
[BEEEP/PM-26332] Hide unsupported biometric options on flatpak

### DIFF
--- a/apps/desktop/src/key-management/biometrics/main-biometrics.service.ts
+++ b/apps/desktop/src/key-management/biometrics/main-biometrics.service.ts
@@ -8,6 +8,7 @@ import { UserKey } from "@bitwarden/common/types/key";
 import { BiometricsStatus, BiometricStateService } from "@bitwarden/key-management";
 
 import { WindowMain } from "../../main/window.main";
+import { isFlatpak } from "../../utils";
 
 import { DesktopBiometricsService } from "./desktop.biometrics.service";
 import { OsBiometricService } from "./os-biometrics.service";
@@ -142,6 +143,6 @@ export class MainBiometricsService extends DesktopBiometricsService {
   }
 
   async canEnableBiometricUnlock(): Promise<boolean> {
-    return true;
+    return !isFlatpak();
   }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-26332

## 📔 Objective

Bitwarden desktop, packaged as flatpak, does not support biometric unlock currently. Activating the option does not work. This is confusing to users, and while we don’t support it, the option should just be hidden entirely.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
