### PR TITLE
[PM-24796] Keep CipherView prototype when caching cipher form value

### DIFF
--- a/libs/vault/src/cipher-form/services/default-cipher-form-cache.service.spec.ts
+++ b/libs/vault/src/cipher-form/services/default-cipher-form-cache.service.spec.ts
@@ -2,6 +2,7 @@ import { signal } from "@angular/core";
 import { TestBed } from "@angular/core/testing";
 
 import { ViewCacheService } from "@bitwarden/angular/platform/view-cache";
+import { Cipher } from "@bitwarden/common/vault/models/domain/cipher";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 
 import { CipherFormCacheService } from "./default-cipher-form-cache.service";
@@ -36,9 +37,10 @@ describe("CipherFormCacheService", () => {
     it("updates the signal value", async () => {
       service = testBed.inject(CipherFormCacheService);
 
-      service.cacheCipherView({ id: "cipher-5" } as CipherView);
+      service.cacheCipherView(new CipherView({ id: "cipher-5" } as Cipher));
 
-      expect(cacheSignal.set).toHaveBeenCalledWith({ id: "cipher-5" });
+      expect(cacheSignal.set).toHaveBeenCalledWith(expect.any(CipherView)); // Ensure we keep the CipherView prototype
+      expect(cacheSignal.set).toHaveBeenCalledWith(expect.objectContaining({ id: "cipher-5" }));
     });
 
     describe("initializedWithValue", () => {

--- a/libs/vault/src/cipher-form/services/default-cipher-form-cache.service.ts
+++ b/libs/vault/src/cipher-form/services/default-cipher-form-cache.service.ts
@@ -1,4 +1,5 @@
 import { inject, Injectable } from "@angular/core";
+import { Jsonify } from "type-fest";
 
 import { ViewCacheService } from "@bitwarden/angular/platform/view-cache";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
@@ -32,10 +33,10 @@ export class CipherFormCacheService {
    * Update the cache with the new CipherView.
    */
   cacheCipherView(cipherView: CipherView): void {
-    // Create a new shallow reference to force the signal to update
+    // Create a new reference to force the signal to update
     // By default, signals use `Object.is` to determine equality
     // Docs: https://angular.dev/guide/signals#signal-equality-functions
-    this.cipherCache.set({ ...cipherView } as CipherView);
+    this.cipherCache.set(CipherView.fromJSON(cipherView as Jsonify<CipherView>));
   }
 
   /**


### PR DESCRIPTION
## 🎟️ Tracking

[PM-24796](https://bitwarden.atlassian.net/browse/PM-24796)

## 📔 Objective

The `{ ...cipherView } as CipherView` was stripping the `CipherView` prototype which would lead to failures when calling the `toSdkCipherView` method during save.

Another alternative would be to pass a custom equality operator to the `WritableSignal` during its construction, however that would involve modifying the `ViewCacheService` interface to support passing in `CreateSignalOptions` with a `equal: () => false` value. This would then allow us to simply set the same `cipherView` multiple times to the signal and it would still propagate.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-24796]: https://bitwarden.atlassian.net/browse/PM-24796?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ