### PR TITLE
[PM-24647] Add directive import for dark themed videos

### DIFF
--- a/apps/web/src/app/vault/components/setup-extension/add-extension-videos.component.spec.ts
+++ b/apps/web/src/app/vault/components/setup-extension/add-extension-videos.component.spec.ts
@@ -2,8 +2,11 @@ import { ComponentFixture, fakeAsync, TestBed, tick } from "@angular/core/testin
 import { By } from "@angular/platform-browser";
 import { provideNoopAnimations } from "@angular/platform-browser/animations";
 import { RouterModule } from "@angular/router";
+import { BehaviorSubject } from "rxjs";
 
+import { SYSTEM_THEME_OBSERVABLE } from "@bitwarden/angular/services/injection-tokens";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { ThemeStateService } from "@bitwarden/common/platform/theming/theme-state.service";
 
 import { AddExtensionVideosComponent } from "./add-extension-videos.component";
 
@@ -36,6 +39,8 @@ describe("AddExtensionVideosComponent", () => {
       providers: [
         provideNoopAnimations(),
         { provide: I18nService, useValue: { t: (key: string) => key } },
+        { provide: SYSTEM_THEME_OBSERVABLE, useValue: new BehaviorSubject("system") },
+        { provide: ThemeStateService, useValue: { selectedTheme$: new BehaviorSubject("system") } },
       ],
     }).compileComponents();
 

--- a/apps/web/src/app/vault/components/setup-extension/add-extension-videos.component.ts
+++ b/apps/web/src/app/vault/components/setup-extension/add-extension-videos.component.ts
@@ -4,11 +4,12 @@ import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { debounceTime, fromEvent } from "rxjs";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
+import { DarkImageSourceDirective } from "@bitwarden/vault";
 
 @Component({
   selector: "vault-add-extension-videos",
   templateUrl: "./add-extension-videos.component.html",
-  imports: [CommonModule, JslibModule],
+  imports: [CommonModule, JslibModule, DarkImageSourceDirective],
 })
 export class AddExtensionVideosComponent {
   @ViewChildren("video", { read: ElementRef }) protected videoElements!: QueryList<

--- a/apps/web/src/app/vault/components/setup-extension/setup-extension.component.spec.ts
+++ b/apps/web/src/app/vault/components/setup-extension/setup-extension.component.spec.ts
@@ -3,6 +3,7 @@ import { By } from "@angular/platform-browser";
 import { Router, RouterModule } from "@angular/router";
 import { BehaviorSubject } from "rxjs";
 
+import { SYSTEM_THEME_OBSERVABLE } from "@bitwarden/angular/services/injection-tokens";
 import { BrowserExtensionIcon } from "@bitwarden/assets/svg";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { DeviceType } from "@bitwarden/common/enums";
@@ -10,6 +11,7 @@ import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.servic
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { StateProvider } from "@bitwarden/common/platform/state";
+import { ThemeStateService } from "@bitwarden/common/platform/theming/theme-state.service";
 import { AnonLayoutWrapperDataService } from "@bitwarden/components";
 
 import { WebBrowserInteractionService } from "../../services/web-browser-interaction.service";
@@ -39,6 +41,8 @@ describe("SetupExtensionComponent", () => {
         { provide: I18nService, useValue: { t: (key: string) => key } },
         { provide: WebBrowserInteractionService, useValue: { extensionInstalled$, openExtension } },
         { provide: PlatformUtilsService, useValue: { getDevice: () => DeviceType.UnknownBrowser } },
+        { provide: SYSTEM_THEME_OBSERVABLE, useValue: new BehaviorSubject("system") },
+        { provide: ThemeStateService, useValue: { selectedTheme$: new BehaviorSubject("system") } },
         { provide: AnonLayoutWrapperDataService, useValue: { setAnonLayoutWrapperData } },
         {
           provide: AccountService,


### PR DESCRIPTION
## 🎟️ Tracking

[PM-24647](https://bitwarden.atlassian.net/browse/PM-24647)

## 📔 Objective

The import for the directive was missing and thus didn't swap in the dark themed `src` for the setup extension videos. Added the import for the fix.

## 📸 Screenshots

<video src="https://github.com/user-attachments/assets/0eddc80f-b493-4fc8-8ab7-2f6a267fe5c9" />

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
