### PR TITLE
[CL-641][Defect][Web] More spacing defects including self-host environment

### DIFF
--- a/apps/web/src/app/billing/organizations/organization-subscription-selfhost.component.html
+++ b/apps/web/src/app/billing/organizations/organization-subscription-selfhost.component.html
@@ -44,7 +44,7 @@
         }}
         <div
           *ngIf="subscription.hasSeparateGracePeriod && !subscription.isInTrial"
-          class="tw-text-muted"
+          class="tw-text-muted tw-break-words tw-whitespace-normal tw-max-w-fit tw-inline-block"
         >
           {{
             "selfHostGracePeriodHelp"

--- a/apps/web/src/app/billing/organizations/organization-subscription-selfhost.component.html
+++ b/apps/web/src/app/billing/organizations/organization-subscription-selfhost.component.html
@@ -12,7 +12,7 @@
   ></app-org-subscription-hidden>
 
   <ng-container *ngIf="subscription && firstLoaded">
-    <dl>
+    <dl class="tw-mb-2">
       <dt>{{ "billingPlan" | i18n }}</dt>
       <dd>{{ subscription.planName }}</dd>
       <ng-container *ngIf="billingSyncSetUp">

--- a/apps/web/src/app/billing/organizations/organization-subscription-selfhost.component.html
+++ b/apps/web/src/app/billing/organizations/organization-subscription-selfhost.component.html
@@ -61,6 +61,7 @@
       href="{{ this.cloudWebVaultUrl }}"
       target="_blank"
       rel="noreferrer"
+      class="tw-mb-4"
     >
       {{ "launchCloudSubscription" | i18n }}
     </a>
@@ -93,7 +94,7 @@
           </bit-hint>
         </bit-radio-button>
         <ng-container *ngIf="updateMethod === licenseOptions.SYNC">
-          <div class="tw-mt-6">
+          <div class="tw-mt-6 tw-flex tw-gap-2">
             <button
               bitButton
               buttonType="secondary"

--- a/apps/web/src/app/billing/shared/self-hosting-license-uploader/self-hosting-license-uploader.component.html
+++ b/apps/web/src/app/billing/shared/self-hosting-license-uploader/self-hosting-license-uploader.component.html
@@ -4,7 +4,7 @@
 <form [formGroup]="form" [bitSubmit]="submit">
   <bit-form-field>
     <bit-label>{{ description | i18n }}</bit-label>
-    <div class="tw-mt-4">
+    <div class="tw-my-1">
       <button bitButton type="button" buttonType="secondary" (click)="fileSelector.click()">
         {{ "chooseFile" | i18n }}
       </button>

--- a/apps/web/src/app/billing/shared/self-hosting-license-uploader/self-hosting-license-uploader.component.html
+++ b/apps/web/src/app/billing/shared/self-hosting-license-uploader/self-hosting-license-uploader.component.html
@@ -1,4 +1,6 @@
-<p bitTypography="body1">{{ "uploadLicenseFileOrg" | i18n }}</p>
+<p bitTypography="body1" class="tw-break-words tw-whitespace-normal tw-mb-4">
+  {{ "uploadLicenseFileOrg" | i18n }}
+</p>
 <form [formGroup]="form" [bitSubmit]="submit">
   <bit-form-field>
     <bit-label>{{ description | i18n }}</bit-label>

--- a/apps/web/src/app/billing/shared/self-hosting-license-uploader/self-hosting-license-uploader.component.html
+++ b/apps/web/src/app/billing/shared/self-hosting-license-uploader/self-hosting-license-uploader.component.html
@@ -1,10 +1,10 @@
-<p bitTypography="body1" class="tw-break-words tw-whitespace-normal tw-mb-4">
+<p bitTypography="body1" class="tw-break-words tw-whitespace-normal tw-mb-8">
   {{ "uploadLicenseFileOrg" | i18n }}
 </p>
 <form [formGroup]="form" [bitSubmit]="submit">
   <bit-form-field>
     <bit-label>{{ description | i18n }}</bit-label>
-    <div>
+    <div class="tw-mt-4">
       <button bitButton type="button" buttonType="secondary" (click)="fileSelector.click()">
         {{ "chooseFile" | i18n }}
       </button>

--- a/apps/web/src/app/billing/shared/update-license.component.html
+++ b/apps/web/src/app/billing/shared/update-license.component.html
@@ -1,11 +1,11 @@
 <form [formGroup]="updateLicenseForm" [bitSubmit]="submit">
   <bit-form-field>
     <bit-label *ngIf="showAutomaticSyncAndManualUpload">{{ "licenseFile" | i18n }}</bit-label>
-    <div class="tw-pb-1 tw-pt-2">
+    <div class="tw-pb-1 tw-pt-2 tw-flex tw-items-center tw-gap-3">
       <button bitButton type="button" buttonType="secondary" (click)="fileSelector.click()">
         {{ "chooseFile" | i18n }}
       </button>
-      {{ this.licenseFile ? this.licenseFile.name : ("noFileChosen" | i18n) }}
+      <span>{{ this.licenseFile ? this.licenseFile.name : ("noFileChosen" | i18n) }}</span>
     </div>
     <input
       bitInput
@@ -24,17 +24,19 @@
               : "bitwarden_organization_license.json")
     }}</bit-hint>
   </bit-form-field>
-  <button type="submit" buttonType="primary" bitButton bitFormButton>
-    {{ "submit" | i18n }}
-  </button>
-  <button
-    bitButton
-    *ngIf="showCancel"
-    bitFormButton
-    buttonType="secondary"
-    type="button"
-    [bitAction]="cancel"
-  >
-    {{ "cancel" | i18n }}
-  </button>
+  <div class="tw-flex tw-gap-2 tw-mt-4">
+    <button type="submit" buttonType="primary" bitButton bitFormButton>
+      {{ "submit" | i18n }}
+    </button>
+    <button
+      bitButton
+      *ngIf="showCancel"
+      bitFormButton
+      buttonType="secondary"
+      type="button"
+      [bitAction]="cancel"
+    >
+      {{ "cancel" | i18n }}
+    </button>
+  </div>
 </form>


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/CL-641

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
**🐛 Issue**
Resolves spacing issues in the self-hosted admin console billing section where UI elements were too close together, affecting readability and user experience.
**Reference: CL-641**

**🔧 Changes**
**1. Licensing and Billing Management Buttons**
- File: `organization-subscription-selfhost.component.html`
- Fix: Added proper horizontal spacing between "Manage billing token" and "Sync license" buttons
- Implementation: Applied tw-flex tw-gap-2 classes to create consistent button spacing

**2. License Upload File Selection**

- File: `update-license.component.html`
- Fix: Improved spacing between "Choose File" button and filename display
- Implementation:
  - Added `tw-flex tw-items-center tw-gap-3 `for proper horizontal alignment
  - Wrapped filename text in semantic <span> element

**3. General Page Layout Improvements**

- File: `organization-subscription-selfhost.component.html`
- Fix: Enhanced spacing around "Launch Cloud Subscription" button
- **Implementation:** Added` tw-mb-4` bottom margin
- File: `update-license.component.html`
- Fix: Improved Submit/Cancel button layout
- Implementation: Wrapped buttons in flex container with `tw-flex tw-gap-2 tw-mt-4`

**🔍 Files Changed**
- `apps/web/src/app/billing/organizations/organization-subscription-selfhost.component.html`
- `apps/web/src/app/billing/shared/update-license.component.html`

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
<img width="1728" height="1117" alt="Screenshot 2025-09-04 at 15 45 57" src="https://github.com/user-attachments/assets/b9ea9e8a-bd29-4697-893f-313fa525c80d" />
<img width="1728" height="1117" alt="Screenshot 2025-09-04 at 15 56 57" src="https://github.com/user-attachments/assets/f7f722a9-a411-4f18-80a2-e199c84026ff" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
