### PR TITLE
Revert [PM-25424] Fix unnecessary quick reconnect

### DIFF
--- a/libs/common/src/platform/server-notifications/internal/default-server-notifications.service.ts
+++ b/libs/common/src/platform/server-notifications/internal/default-server-notifications.service.ts
@@ -172,7 +172,6 @@ export class DefaultServerNotificationsService implements ServerNotificationsSer
 
   private hasAccessToken$(userId: UserId) {
     return this.configService.getFeatureFlag$(FeatureFlag.PushNotificationsWhenLocked).pipe(
-      distinctUntilChanged(),
       switchMap((featureFlagEnabled) => {
         if (featureFlagEnabled) {
           return this.authService.authStatusFor$(userId).pipe(
@@ -306,23 +305,11 @@ export class DefaultServerNotificationsService implements ServerNotificationsSer
   startListening() {
     return this.notifications$
       .pipe(
-        mergeMap(async ([notification, userId]) => {
-          try {
-            await this.processNotification(notification, userId);
-          } catch (err: unknown) {
-            this.logService.error(
-              `Problem processing notification of type ${notification.type}`,
-              err,
-            );
-          }
-        }),
+        mergeMap(async ([notification, userId]) => this.processNotification(notification, userId)),
       )
       .subscribe({
-        error: (err: unknown) =>
-          this.logService.error(
-            "Fatal error in server notifications$ observable, notifications won't be recieved anymore.",
-            err,
-          ),
+        error: (e: unknown) =>
+          this.logService.warning("Error in server notifications$ observable", e),
       });
   }
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-25424

## 📔 Objective

Reverts https://github.com/bitwarden/clients/commit/9946f612963a2ab5be97749f9a76a2d8ca3ac8e5 as we discovered that notifications were not being processed with this change.

In order to unblock other work, and given that this change is to remove extra connections we were trying to make (low impact), we'll revert from `main` and follow up after more investigation.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
