### PR TITLE
[PM-25460] Skip SDK Decryption for Emergency Access Attachments

### DIFF
--- a/libs/common/src/vault/abstractions/cipher.service.ts
+++ b/libs/common/src/vault/abstractions/cipher.service.ts
@@ -257,6 +257,10 @@ export abstract class CipherService implements UserKeyRotationDataProvider<Ciphe
    * @param attachment The attachment view object
    * @param response The response object containing the encrypted content
    * @param userId The user ID whose key will be used for decryption
+   * @param useLegacyDecryption When true, forces the use of the legacy decryption method
+   * even when the SDK feature is enabled. This is helpful for domains of
+   * the application that have yet to be moved into the SDK, i.e. emergency access.
+   * TODO: PM-25469 - this should be obsolete once emergency access is moved to the SDK.
    *
    * @returns A promise that resolves to the decrypted content
    */
@@ -265,6 +269,7 @@ export abstract class CipherService implements UserKeyRotationDataProvider<Ciphe
     attachment: AttachmentView,
     response: Response,
     userId: UserId,
+    useLegacyDecryption?: boolean,
   ): Promise<Uint8Array | null>;
 
   /**

--- a/libs/common/src/vault/services/cipher.service.ts
+++ b/libs/common/src/vault/services/cipher.service.ts
@@ -1544,11 +1544,13 @@ export class CipherService implements CipherServiceAbstraction {
     return encryptedCiphers;
   }
 
+  /** @inheritdoc */
   async getDecryptedAttachmentBuffer(
     cipherId: CipherId,
     attachment: AttachmentView,
     response: Response,
     userId: UserId,
+    useLegacyDecryption?: boolean,
   ): Promise<Uint8Array> {
     const useSdkDecryption = await this.configService.getFeatureFlag(
       FeatureFlag.PM19941MigrateCipherDomainToSdk,
@@ -1558,7 +1560,7 @@ export class CipherService implements CipherServiceAbstraction {
       this.ciphers$(userId).pipe(map((ciphersData) => new Cipher(ciphersData[cipherId]))),
     );
 
-    if (useSdkDecryption) {
+    if (useSdkDecryption && !useLegacyDecryption) {
       const encryptedContent = await response.arrayBuffer();
       return this.cipherEncryptionService.decryptAttachmentContent(
         cipherDomain,

--- a/libs/vault/src/components/download-attachment/download-attachment.component.ts
+++ b/libs/vault/src/components/download-attachment/download-attachment.component.ts
@@ -92,6 +92,9 @@ export class DownloadAttachmentComponent {
         this.attachment,
         response,
         userId,
+        // When the emergency access ID is present, the cipher is being viewed via emergency access.
+        // Force legacy decryption in these cases.
+        this.emergencyAccessId ? true : false,
       );
 
       this.fileDownloadService.download({


### PR DESCRIPTION
## 🎟️ Tracking

[PM-25460](https://bitwarden.atlassian.net/browse/PM-25460)

## 📔 Objective

Adds option to avoid using the SDK to decrypt attachments for emergency access
- The SDK does not have emergency access functionality built in at this point and thus decryption of the attachment fails.

## 📸 Screenshots

<video src="https://github.com/user-attachments/assets/6cb4ae4f-b239-40a5-aafc-284611ca294a" />

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
