### PR TITLE
[PM-25472] Register `UnsupportedSystemNotificationService` in Unsupported Browsers Angular Context

### DIFF
--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -303,7 +303,10 @@ import { BackgroundMemoryStorageService } from "../platform/storage/background-m
 import { BrowserStorageServiceProvider } from "../platform/storage/browser-storage-service.provider";
 import { OffscreenStorageService } from "../platform/storage/offscreen-storage.service";
 import { SyncServiceListener } from "../platform/sync/sync-service.listener";
-import { BrowserSystemNotificationService } from "../platform/system-notifications/browser-system-notification.service";
+import {
+  BrowserSystemNotificationService,
+  isNotificationsSupported,
+} from "../platform/system-notifications/browser-system-notification.service";
 import { fromChromeRuntimeMessaging } from "../platform/utils/from-chrome-runtime-messaging";
 import { AtRiskCipherBadgeUpdaterService } from "../vault/services/at-risk-cipher-badge-updater.service";
 
@@ -1124,7 +1127,7 @@ export default class MainBackground {
 
     this.actionsService = new BrowserActionsService(this.logService, this.platformUtilsService);
 
-    if ("notifications" in chrome) {
+    if (isNotificationsSupported()) {
       this.systemNotificationService = new BrowserSystemNotificationService(
         this.platformUtilsService,
       );

--- a/apps/browser/src/platform/system-notifications/browser-system-notification.service.ts
+++ b/apps/browser/src/platform/system-notifications/browser-system-notification.service.ts
@@ -12,6 +12,16 @@ import {
 
 import { fromChromeEvent } from "../browser/from-chrome-event";
 
+/**
+ * A check to see if the current browser has the needed API to support the `BrowserSystemNotificationService`.
+ *
+ * This check should only be called during dependency creation, if consumers need to know if
+ * system notifications can be used they should use {@link SystemNotificationsService.isSupported}.
+ */
+export function isNotificationsSupported() {
+  return "notifications" in chrome && chrome.notifications != null;
+}
+
 export class BrowserSystemNotificationService implements SystemNotificationsService {
   notificationClicked$: Observable<SystemNotificationEvent>;
 

--- a/apps/browser/src/popup/services/services.module.ts
+++ b/apps/browser/src/popup/services/services.module.ts
@@ -107,6 +107,7 @@ import { PrimarySecondaryStorageService } from "@bitwarden/common/platform/stora
 import { WindowStorageService } from "@bitwarden/common/platform/storage/window-storage.service";
 import { SyncService } from "@bitwarden/common/platform/sync";
 import { SystemNotificationsService } from "@bitwarden/common/platform/system-notifications/system-notifications.service";
+import { UnsupportedSystemNotificationsService } from "@bitwarden/common/platform/system-notifications/unsupported-system-notifications.service";
 import { SendApiService } from "@bitwarden/common/tools/send/services/send-api.service.abstraction";
 import { InternalSendService } from "@bitwarden/common/tools/send/services/send.service.abstraction";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
@@ -178,7 +179,10 @@ import { ForegroundTaskSchedulerService } from "../../platform/services/task-sch
 import { BrowserStorageServiceProvider } from "../../platform/storage/browser-storage-service.provider";
 import { ForegroundMemoryStorageService } from "../../platform/storage/foreground-memory-storage.service";
 import { ForegroundSyncService } from "../../platform/sync/foreground-sync.service";
-import { BrowserSystemNotificationService } from "../../platform/system-notifications/browser-system-notification.service";
+import {
+  BrowserSystemNotificationService,
+  isNotificationsSupported,
+} from "../../platform/system-notifications/browser-system-notification.service";
 import { fromChromeRuntimeMessaging } from "../../platform/utils/from-chrome-runtime-messaging";
 import { FilePopoutUtilsService } from "../../tools/popup/services/file-popout-utils.service";
 import { Fido2UserVerificationService } from "../../vault/services/fido2-user-verification.service";
@@ -563,7 +567,13 @@ const safeProviders: SafeProvider[] = [
   }),
   safeProvider({
     provide: SystemNotificationsService,
-    useClass: BrowserSystemNotificationService,
+    useFactory: (platformUtilsService: PlatformUtilsService) => {
+      if (isNotificationsSupported()) {
+        return new BrowserSystemNotificationService(platformUtilsService);
+      }
+
+      return new UnsupportedSystemNotificationsService();
+    },
     deps: [PlatformUtilsService],
   }),
   safeProvider({
@@ -594,11 +604,6 @@ const safeProviders: SafeProvider[] = [
     provide: SsoUrlService,
     useClass: SsoUrlService,
     deps: [],
-  }),
-  safeProvider({
-    provide: SystemNotificationsService,
-    useClass: BrowserSystemNotificationService,
-    deps: [PlatformUtilsService],
   }),
   safeProvider({
     provide: LoginComponentService,

--- a/libs/common/src/platform/system-notifications/system-notifications.service.ts
+++ b/libs/common/src/platform/system-notifications/system-notifications.service.ts
@@ -35,6 +35,12 @@ export type SystemNotificationEvent = {
  * A service responsible for displaying operating system level server notifications.
  */
 export abstract class SystemNotificationsService {
+  /**
+   * Used to know if a given platform supports system notifications. This check should
+   * be used to guard any usage of the other members in this service.
+   */
+  abstract isSupported(): boolean;
+
   abstract notificationClicked$: Observable<SystemNotificationEvent>;
 
   /**
@@ -50,9 +56,4 @@ export abstract class SystemNotificationsService {
    * @param clearInfo Any info needed required to clear a notification.
    */
   abstract clear(clearInfo: SystemNotificationClearInfo): Promise<void>;
-
-  /**
-   * Used to know if a given platform supports server notifications.
-   */
-  abstract isSupported(): boolean;
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-25472

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Switch the browser angular services module to have the same check that we are using in `main.background.ts`. Without this, a subscription on `systemNotificationsService.notificationClicked$` caused a fatal error because it was trying to use `chrome.notifications.onButtonClicked` which wasn't there. The unsupported system notifications service has a real observable on it for `notificationClicked$` just that observable only emits an error and then completes. It only causes a local error for that use and lets the application still continue to bootstrap. 

Nothing in `main` actually listens or creates notifications, this bug was discovered on a branch that is introducing a usage though. To emulate the error I tried subscribing to `systemNotificationsService.notificationClicked$` in browser app components constructor. 

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
