### PR TITLE
fixing -> Item checkboxes do not reflect selected items after searching or filtering or clicking on different folders.

### DIFF
--- a/apps/web/src/app/vault/components/vault-items/vault-items.component.ts
+++ b/apps/web/src/app/vault/components/vault-items/vault-items.component.ts
@@ -88,7 +88,17 @@ export class VaultItemsComponent<C extends CipherViewLike> {
 
   protected editableItems: VaultItem<C>[] = [];
   protected dataSource = new TableDataSource<VaultItem<C>>();
-  protected selection = new SelectionModel<VaultItem<C>>(true, [], true);
+  protected selection = new SelectionModel<VaultItem<C>>(
+    true, // allow multiple selection
+    [], // initial selection
+    true, // emit changes
+    // Custom compare function
+    (a, b) => {
+      const aId = a?.cipher?.id ?? a?.collection?.id;
+      const bId = b?.cipher?.id ?? b?.collection?.id;
+      return aId === bId;
+    },
+  );
   protected canDeleteSelected$: Observable<boolean>;
   protected canRestoreSelected$: Observable<boolean>;
   protected disableMenu$: Observable<boolean>;
@@ -165,7 +175,6 @@ export class VaultItemsComponent<C extends CipherViewLike> {
       }),
     );
   }
-
   clearSelection() {
     this.selection.clear();
   }


### PR DESCRIPTION
## 🎟️ Tracking

fixing #15330   and duplicates of 15330 - #15921  #15677 

## 📔 Objective
    Currently, the checkboxes inside the Vault view do not persist when users interact with the UI.
    Specifically:
    When applying filters ,  navigating to a different folder , switching between views.
    The selected checkboxes automatically become unmarked, causing confusion .
    Fix
    This PR ensures that checkbox states are preserved across:
    Filtering ,Folder navigation.
    With this change, user selections remain intact until explicitly changed by the user.

## 📸 Screenshots


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
