### PR TITLE
[PM-25551] Fix member list sorting by name instead of email

### DIFF
--- a/apps/web/src/app/admin-console/organizations/members/members.component.html
+++ b/apps/web/src/app/admin-console/organizations/members/members.component.html
@@ -98,7 +98,7 @@
                   "all" | i18n
                 }}</label>
               </th>
-              <th bitCell bitSortable="email" default>{{ "name" | i18n }}</th>
+              <th bitCell bitSortable="name" default>{{ "name" | i18n }}</th>
               <th bitCell>{{ (organization.useGroups ? "groups" : "collections") | i18n }}</th>
               <th bitCell bitSortable="type">{{ "role" | i18n }}</th>
               <th bitCell>{{ "policies" | i18n }}</th>


### PR DESCRIPTION
## 🎟️ Tracking

fixing #14897 

## 📔 Objective

Fix sorting on the Members page in the org – previously, sorting was based on email addresses, but now it will be based on member names.

## 📸 Screenshots
before fixing -
<img width="1344" height="403" alt="before" src="https://github.com/user-attachments/assets/fda20046-820a-42e4-a930-18e8bfb3908e" />

after fixing -
<img width="1356" height="404" alt="after" src="https://github.com/user-attachments/assets/d9873c80-5ee4-4575-b087-d509327d0999" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
