### PR TITLE
[PM-24982] Create Cart Summary Component in Bitwarden Pricing

### DIFF
--- a/libs/pricing/src/components/cart-summary/cart-summary.component.html
+++ b/libs/pricing/src/components/cart-summary/cart-summary.component.html
@@ -49,9 +49,9 @@
           <div class="tw-flex tw-justify-between">
             <div class="tw-flex-1">
               <div bitTypography="body2" class="tw-text-muted">
-                {{ additionalStorage?.quantity }} {{ additionalStorage?.name | i18n }} x
-                {{ additionalStorage?.cost | currency: "USD" : "symbol" }} /
-                {{ additionalStorage?.cadence | i18n }}
+                {{ additionalStorage.quantity }} {{ additionalStorage.name | i18n }} x
+                {{ additionalStorage.cost | currency: "USD" : "symbol" }} /
+                {{ additionalStorage.cadence | i18n }}
               </div>
             </div>
             <div bitTypography="body2" class="tw-text-muted">
@@ -71,9 +71,9 @@
           <!-- Secrets Manager Members -->
           <div class="tw-flex tw-justify-between">
             <div bitTypography="body2" class="tw-text-muted">
-              {{ secretsManager?.seats.quantity }} {{ secretsManager?.seats.name | i18n }} x
-              {{ secretsManager?.seats.cost | currency: "USD" : "symbol" }}
-              / {{ secretsManager?.seats.cadence | i18n }}
+              {{ secretsManager.seats.quantity }} {{ secretsManager.seats.name | i18n }} x
+              {{ secretsManager.seats.cost | currency: "USD" : "symbol" }}
+              / {{ secretsManager.seats.cadence | i18n }}
             </div>
             <div bitTypography="body2" class="tw-text-muted">
               {{ secretsManagerSeatsTotal() | currency: "USD" : "symbol" }}
@@ -84,11 +84,11 @@
           @if (additionalServiceAccounts) {
             <div class="tw-flex tw-justify-between">
               <div bitTypography="body2" class="tw-text-muted">
-                {{ additionalServiceAccounts?.quantity }}
-                {{ additionalServiceAccounts?.name | i18n }} x
-                {{ additionalServiceAccounts?.cost | currency: "USD" : "symbol" }}
+                {{ additionalServiceAccounts.quantity }}
+                {{ additionalServiceAccounts.name | i18n }} x
+                {{ additionalServiceAccounts.cost | currency: "USD" : "symbol" }}
                 /
-                {{ additionalServiceAccounts?.cadence | i18n }}
+                {{ additionalServiceAccounts.cadence | i18n }}
               </div>
               <div bitTypography="body2" class="tw-text-muted">
                 {{ additionalServiceAccountsTotal() | currency: "USD" : "symbol" }}

--- a/libs/pricing/src/components/cart-summary/cart-summary.component.html
+++ b/libs/pricing/src/components/cart-summary/cart-summary.component.html
@@ -11,15 +11,14 @@
     </h2>
     <button
       type="button"
+      class="!tw-p-0 tw-mb-1"
       (click)="toggleExpanded()"
-      class="tw-cursor-pointer tw-pb-2"
-      [ariaLabel]="isExpanded() ? 'collapseCartDetails' : 'expandCartDetails'"
+      [bitIconButton]="isExpanded() ? 'bwi-angle-up' : 'bwi-angle-down'"
+      [label]="isExpanded() ? 'Collapse purchase details' : 'Expand purchase details'"
       [attr.aria-expanded]="isExpanded()"
       [attr.aria-controls]="'cart-summary-details'"
       bitTypography="body1"
-    >
-      <i aria-hidden="true" class="bwi {{ isExpanded() ? 'bwi-angle-up' : 'bwi-angle-down' }}"></i>
-    </button>
+    ></button>
   </div>
 
   @if (isExpanded()) {
@@ -31,10 +30,10 @@
         </div>
 
         <!-- Password Manager Members -->
-        <div class="tw-flex tw-justify-between tw-mb-2">
+        <div class="tw-flex tw-justify-between">
           <div class="tw-flex-1">
             <div bitTypography="body2" class="tw-text-muted">
-              {{ passwordManager.quantity }} {{ "Members" | i18n }} x
+              {{ passwordManager.quantity }} {{ passwordManager.name | i18n }} x
               {{ passwordManager.cost | currency: "USD" : "symbol" }}
               /
               {{ passwordManager.cadence | i18n }}
@@ -47,10 +46,10 @@
 
         <!-- Additional Storage -->
         @if (additionalStorage) {
-          <div class="tw-flex tw-justify-between tw-pb-2">
+          <div class="tw-flex tw-justify-between">
             <div class="tw-flex-1">
               <div bitTypography="body2" class="tw-text-muted">
-                {{ additionalStorage?.quantity }} {{ "Additional GB" | i18n }} x
+                {{ additionalStorage?.quantity }} {{ additionalStorage?.name | i18n }} x
                 {{ additionalStorage?.cost | currency: "USD" : "symbol" }} /
                 {{ additionalStorage?.cadence | i18n }}
               </div>
@@ -70,9 +69,9 @@
           </div>
 
           <!-- Secrets Manager Members -->
-          <div class="tw-flex tw-justify-between tw-pb-2">
+          <div class="tw-flex tw-justify-between">
             <div bitTypography="body2" class="tw-text-muted">
-              {{ secretsManager?.seats.quantity }} {{ "Members" | i18n }} x
+              {{ secretsManager?.seats.quantity }} {{ secretsManager?.seats.name | i18n }} x
               {{ secretsManager?.seats.cost | currency: "USD" : "symbol" }}
               / {{ secretsManager?.seats.cadence | i18n }}
             </div>
@@ -83,16 +82,16 @@
 
           <!-- Additional Service Accounts -->
           @if (additionalServiceAccounts) {
-            <div class="tw-flex tw-justify-between tw-pb-2">
+            <div class="tw-flex tw-justify-between">
               <div bitTypography="body2" class="tw-text-muted">
                 {{ additionalServiceAccounts?.quantity }}
-                {{ "Additional machine accounts" | i18n }} x
+                {{ additionalServiceAccounts?.name | i18n }} x
                 {{ additionalServiceAccounts?.cost | currency: "USD" : "symbol" }}
                 /
                 {{ additionalServiceAccounts?.cadence | i18n }}
               </div>
               <div bitTypography="body2" class="tw-text-muted">
-                ${{ additionalServiceAccountsTotal() | currency: "USD" : "symbol" }}
+                {{ additionalServiceAccountsTotal() | currency: "USD" : "symbol" }}
               </div>
             </div>
           }

--- a/libs/pricing/src/components/cart-summary/cart-summary.component.html
+++ b/libs/pricing/src/components/cart-summary/cart-summary.component.html
@@ -5,7 +5,7 @@
 
 <div class="tw-size-full">
   <div class="tw-flex tw-items-center tw-gap-1 tw-pb-4">
-    <h2 bitTypography="h4">
+    <h2 bitTypography="h4" id="purchase-summary-heading">
       {{ "Total" | i18n }}: {{ total() | currency: "USD" : "symbol" }} USD
       <span bitTypography="body2">/ {{ passwordManager.cadence | i18n }}</span>
     </h2>
@@ -16,13 +16,13 @@
       [bitIconButton]="isExpanded() ? 'bwi-angle-up' : 'bwi-angle-down'"
       [label]="isExpanded() ? 'Collapse purchase details' : 'Expand purchase details'"
       [attr.aria-expanded]="isExpanded()"
-      [attr.aria-controls]="'cart-summary-details'"
+      [attr.aria-controls]="'purchase-summary-details'"
       bitTypography="body1"
     ></button>
   </div>
 
   @if (isExpanded()) {
-    <div id="cart-summary-details" class="tw-pb-2">
+    <div id="purchase-summary-details" class="tw-pb-2">
       <!-- Password Manager Section -->
       <div class="tw-border-b tw-border-secondary-100 tw-pb-2">
         <div class="tw-flex tw-justify-between tw-mb-1">

--- a/libs/pricing/src/components/cart-summary/cart-summary.component.html
+++ b/libs/pricing/src/components/cart-summary/cart-summary.component.html
@@ -1,129 +1,119 @@
+@let passwordManager = this.passwordManager();
+@let additionalStorage = this.additionalStorage();
+@let secretsManager = this.secretsManager();
+@let additionalServiceAccounts = this.secretsManager()?.additionalServiceAccounts;
+
 <div class="tw-size-full">
-  <div class="tw-py-4 tw-px-2">
-    <div class="tw-flex tw-items-center tw-gap-1">
-      <h2 bitTypography="h4">
-        Total: {{ total() | currency: "USD" : "symbol" }} USD
-        <span bitTypography="body2">/ {{ passwordManager()?.cadence }}</span>
-      </h2>
-      <button
-        type="button"
-        (click)="toggleExpanded()"
-        class="tw-cursor-pointer tw-mb-2"
-        [ariaLabel]="isExpanded() ? 'collapseCartDetails' : 'expandCartDetails'"
-        [attr.aria-expanded]="isExpanded()"
-        [attr.aria-controls]="'cart-summary-details'"
-        bitTypography="body1"
-      >
-        <i
-          aria-hidden="true"
-          class="bwi {{ isExpanded() ? 'bwi-angle-up' : 'bwi-angle-down' }}"
-        ></i>
-      </button>
-    </div>
+  <div class="tw-flex tw-items-center tw-gap-1 tw-pb-4">
+    <h2 bitTypography="h4">
+      {{ "Total" | i18n }}: {{ total() | currency: "USD" : "symbol" }} USD
+      <span bitTypography="body2">/ {{ passwordManager.cadence | i18n }}</span>
+    </h2>
+    <button
+      type="button"
+      (click)="toggleExpanded()"
+      class="tw-cursor-pointer tw-pb-2"
+      [ariaLabel]="isExpanded() ? 'collapseCartDetails' : 'expandCartDetails'"
+      [attr.aria-expanded]="isExpanded()"
+      [attr.aria-controls]="'cart-summary-details'"
+      bitTypography="body1"
+    >
+      <i aria-hidden="true" class="bwi {{ isExpanded() ? 'bwi-angle-up' : 'bwi-angle-down' }}"></i>
+    </button>
+  </div>
 
-    @if (isExpanded()) {
-      <div id="cart-summary-details" class="tw-mb-4">
-        <!-- Password Manager Section -->
-        <div class="tw-border-b tw-border-secondary-100 tw-mb-2">
-          <div class="tw-flex tw-justify-between tw-mb-1">
-            <div bitTypography="h6" class="tw-text-muted">Password Manager</div>
+  @if (isExpanded()) {
+    <div id="cart-summary-details" class="tw-pb-2">
+      <!-- Password Manager Section -->
+      <div class="tw-border-b tw-border-secondary-100 tw-pb-2">
+        <div class="tw-flex tw-justify-between tw-mb-1">
+          <h3 bitTypography="h5" class="tw-text-muted">{{ "Password Manager" | i18n }}</h3>
+        </div>
+
+        <!-- Password Manager Members -->
+        <div class="tw-flex tw-justify-between tw-mb-2">
+          <div class="tw-flex-1">
+            <div bitTypography="body2" class="tw-text-muted">
+              {{ passwordManager.quantity }} {{ "Members" | i18n }} x
+              {{ passwordManager.cost | currency: "USD" : "symbol" }}
+              /
+              {{ passwordManager.cadence | i18n }}
+            </div>
           </div>
+          <div bitTypography="body2" class="tw-text-muted">
+            {{ passwordManagerTotal() | currency: "USD" : "symbol" }}
+          </div>
+        </div>
 
-          <!-- Password Manager Members -->
-          <div class="tw-flex tw-justify-between tw-mb-2">
+        <!-- Additional Storage -->
+        @if (additionalStorage) {
+          <div class="tw-flex tw-justify-between tw-pb-2">
             <div class="tw-flex-1">
               <div bitTypography="body2" class="tw-text-muted">
-                {{ passwordManager()?.quantity }} Members x
-                {{ passwordManager()?.cost | currency: "USD" : "symbol" }}
-                /
-                {{ passwordManager()?.cadence }}
+                {{ additionalStorage?.quantity }} {{ "Additional GB" | i18n }} x
+                {{ additionalStorage?.cost | currency: "USD" : "symbol" }} /
+                {{ additionalStorage?.cadence | i18n }}
               </div>
             </div>
             <div bitTypography="body2" class="tw-text-muted">
-              ${{ passwordManagerTotal().toFixed(2) }}
+              {{ additionalStorageTotal() | currency: "USD" : "symbol" }}
+            </div>
+          </div>
+        }
+      </div>
+
+      <!-- Secrets Manager Section -->
+      @if (secretsManager) {
+        <div class="tw-border-b tw-border-secondary-100 tw-py-2">
+          <div class="tw-flex tw-justify-between">
+            <h3 bitTypography="h5" class="tw-text-muted">{{ "Secrets Manager" | i18n }}</h3>
+          </div>
+
+          <!-- Secrets Manager Members -->
+          <div class="tw-flex tw-justify-between tw-pb-2">
+            <div bitTypography="body2" class="tw-text-muted">
+              {{ secretsManager?.seats.quantity }} {{ "Members" | i18n }} x
+              {{ secretsManager?.seats.cost | currency: "USD" : "symbol" }}
+              / {{ secretsManager?.seats.cadence | i18n }}
+            </div>
+            <div bitTypography="body2" class="tw-text-muted">
+              {{ secretsManagerSeatsTotal() | currency: "USD" : "symbol" }}
             </div>
           </div>
 
-          <!-- Additional Storage -->
-          @if (additionalStorage()) {
-            <div class="tw-flex tw-justify-between tw-mb-2">
-              <div class="tw-flex-1">
-                <div bitTypography="body2" class="tw-text-muted">
-                  {{ additionalStorage()?.quantity }} Additional GB x
-                  {{ additionalStorage()?.cost | currency: "USD" : "symbol" }} /
-                  {{ additionalStorage()?.cadence }}
-                </div>
+          <!-- Additional Service Accounts -->
+          @if (additionalServiceAccounts) {
+            <div class="tw-flex tw-justify-between tw-pb-2">
+              <div bitTypography="body2" class="tw-text-muted">
+                {{ additionalServiceAccounts?.quantity }}
+                {{ "Additional machine accounts" | i18n }} x
+                {{ additionalServiceAccounts?.cost | currency: "USD" : "symbol" }}
+                /
+                {{ additionalServiceAccounts?.cadence | i18n }}
               </div>
               <div bitTypography="body2" class="tw-text-muted">
-                {{ additionalStorageTotal() | currency: "USD" : "symbol" }}
+                ${{ additionalServiceAccountsTotal() | currency: "USD" : "symbol" }}
               </div>
             </div>
           }
         </div>
+      }
 
-        <!-- Secrets Manager Section -->
-        @if (secretsManager()) {
-          <div class="tw-border-b tw-border-secondary-100">
-            <div class="tw-flex tw-justify-between">
-              <div bitTypography="h6" class="tw-text-muted">Secrets Manager</div>
-            </div>
-
-            <!-- Secrets Manager Members -->
-            <div class="tw-flex tw-justify-between tw-mb-2">
-              <div class="tw-flex-1">
-                <div bitTypography="body2" class="tw-text-muted">
-                  {{ secretsManager()?.seats.quantity }} Members x
-                  {{ secretsManager()?.seats.cost | currency: "USD" : "symbol" }}
-                  / {{ secretsManager()?.seats.cadence }}
-                </div>
-              </div>
-              <div bitTypography="body2" class="tw-text-muted">
-                {{ secretsManagerSeatsTotal() | currency: "USD" : "symbol" }}
-              </div>
-            </div>
-
-            <!-- Additional Service Accounts -->
-            @if (secretsManager()?.additionalServiceAccounts) {
-              <div class="tw-flex tw-justify-between tw-mb-2">
-                <div class="tw-flex-1">
-                  <div bitTypography="body2" class="tw-text-muted">
-                    {{ secretsManager()?.additionalServiceAccounts.quantity }} Additional machine
-                    accounts x
-                    {{
-                      secretsManager()?.additionalServiceAccounts.cost | currency: "USD" : "symbol"
-                    }}
-                    /
-                    {{ secretsManager()?.additionalServiceAccounts.cadence }}
-                  </div>
-                </div>
-                <div bitTypography="body2" class="tw-text-muted">
-                  ${{ secretsManagerServiceAccountsTotal().toFixed(2) }}
-                </div>
-              </div>
-            }
-          </div>
-        }
-
-        <!-- Estimated Tax -->
-        <div class="tw-flex tw-justify-between tw-border-b tw-border-secondary-100 tw-mb-2">
-          <div class="tw-flex-1">
-            <div bitTypography="h6" class="tw-text-muted">Estimated Tax</div>
-          </div>
-          <div bitTypography="body2" class="tw-text-muted">
-            {{ estimatedTax() | currency: "USD" : "symbol" }}
-          </div>
-        </div>
-
-        <!-- Total -->
-        <div class="tw-flex tw-justify-between tw-items-center">
-          <div class="tw-flex-1">
-            <div bitTypography="h6" class="tw-text-muted">Total</div>
-          </div>
-          <div bitTypography="body2" class="tw-text-muted">
-            {{ total() | currency: "USD" : "symbol" }} / {{ passwordManager()?.cadence }}
-          </div>
+      <!-- Estimated Tax -->
+      <div class="tw-flex tw-justify-between tw-border-b tw-border-secondary-100 tw-pt-2 tw-pb-0.5">
+        <h3 bitTypography="h5" class="tw-text-muted">{{ "Estimated tax" | i18n }}</h3>
+        <div bitTypography="body2" class="tw-text-muted">
+          {{ estimatedTax() | currency: "USD" : "symbol" }}
         </div>
       </div>
-    }
-  </div>
+
+      <!-- Total -->
+      <div class="tw-flex tw-justify-between tw-items-center tw-pt-2">
+        <h3 bitTypography="h5" class="tw-text-muted">{{ "Total" | i18n }}</h3>
+        <div bitTypography="body2" class="tw-text-muted">
+          {{ total() | currency: "USD" : "symbol" }} / {{ passwordManager.cadence | i18n }}
+        </div>
+      </div>
+    </div>
+  }
 </div>

--- a/libs/pricing/src/components/cart-summary/cart-summary.component.html
+++ b/libs/pricing/src/components/cart-summary/cart-summary.component.html
@@ -4,20 +4,21 @@
 @let additionalServiceAccounts = this.secretsManager()?.additionalServiceAccounts;
 
 <div class="tw-size-full">
-  <div class="tw-flex tw-items-center tw-gap-1 tw-pb-4">
-    <h2 bitTypography="h4" id="purchase-summary-heading">
-      {{ "Total" | i18n }}: {{ total() | currency: "USD" : "symbol" }} USD
-      <span bitTypography="body2">/ {{ passwordManager.cadence | i18n }}</span>
-    </h2>
+  <div class="tw-flex tw-items-center tw-pb-4">
+    <div class="tw-flex tw-items-center">
+      <h2 bitTypography="h4" id="purchase-summary-heading" class="!tw-m-0">
+        {{ "Total" | i18n }}: {{ total() | currency: "USD" : "symbol" }} USD
+      </h2>
+      <span bitTypography="h3">&nbsp;</span>
+      <span bitTypography="body1" class="tw-text-main">/ {{ passwordManager.cadence | i18n }}</span>
+    </div>
     <button
       type="button"
-      class="!tw-p-0 tw-mb-1"
       (click)="toggleExpanded()"
       [bitIconButton]="isExpanded() ? 'bwi-angle-up' : 'bwi-angle-down'"
       [label]="isExpanded() ? 'Collapse purchase details' : 'Expand purchase details'"
       [attr.aria-expanded]="isExpanded()"
       [attr.aria-controls]="'purchase-summary-details'"
-      bitTypography="body1"
     ></button>
   </div>
 
@@ -32,14 +33,14 @@
         <!-- Password Manager Members -->
         <div class="tw-flex tw-justify-between">
           <div class="tw-flex-1">
-            <div bitTypography="body2" class="tw-text-muted">
+            <div bitTypography="body1" class="tw-text-muted">
               {{ passwordManager.quantity }} {{ passwordManager.name | i18n }} x
               {{ passwordManager.cost | currency: "USD" : "symbol" }}
               /
               {{ passwordManager.cadence | i18n }}
             </div>
           </div>
-          <div bitTypography="body2" class="tw-text-muted">
+          <div bitTypography="body1" class="tw-text-muted">
             {{ passwordManagerTotal() | currency: "USD" : "symbol" }}
           </div>
         </div>
@@ -48,13 +49,13 @@
         @if (additionalStorage) {
           <div class="tw-flex tw-justify-between">
             <div class="tw-flex-1">
-              <div bitTypography="body2" class="tw-text-muted">
+              <div bitTypography="body1" class="tw-text-muted">
                 {{ additionalStorage.quantity }} {{ additionalStorage.name | i18n }} x
                 {{ additionalStorage.cost | currency: "USD" : "symbol" }} /
                 {{ additionalStorage.cadence | i18n }}
               </div>
             </div>
-            <div bitTypography="body2" class="tw-text-muted">
+            <div bitTypography="body1" class="tw-text-muted">
               {{ additionalStorageTotal() | currency: "USD" : "symbol" }}
             </div>
           </div>
@@ -70,12 +71,12 @@
 
           <!-- Secrets Manager Members -->
           <div class="tw-flex tw-justify-between">
-            <div bitTypography="body2" class="tw-text-muted">
+            <div bitTypography="body1" class="tw-text-muted">
               {{ secretsManager.seats.quantity }} {{ secretsManager.seats.name | i18n }} x
               {{ secretsManager.seats.cost | currency: "USD" : "symbol" }}
               / {{ secretsManager.seats.cadence | i18n }}
             </div>
-            <div bitTypography="body2" class="tw-text-muted">
+            <div bitTypography="body1" class="tw-text-muted">
               {{ secretsManagerSeatsTotal() | currency: "USD" : "symbol" }}
             </div>
           </div>
@@ -83,14 +84,14 @@
           <!-- Additional Service Accounts -->
           @if (additionalServiceAccounts) {
             <div class="tw-flex tw-justify-between">
-              <div bitTypography="body2" class="tw-text-muted">
+              <div bitTypography="body1" class="tw-text-muted">
                 {{ additionalServiceAccounts.quantity }}
                 {{ additionalServiceAccounts.name | i18n }} x
                 {{ additionalServiceAccounts.cost | currency: "USD" : "symbol" }}
                 /
                 {{ additionalServiceAccounts.cadence | i18n }}
               </div>
-              <div bitTypography="body2" class="tw-text-muted">
+              <div bitTypography="body1" class="tw-text-muted">
                 {{ additionalServiceAccountsTotal() | currency: "USD" : "symbol" }}
               </div>
             </div>
@@ -101,7 +102,7 @@
       <!-- Estimated Tax -->
       <div class="tw-flex tw-justify-between tw-border-b tw-border-secondary-100 tw-pt-2 tw-pb-0.5">
         <h3 bitTypography="h5" class="tw-text-muted">{{ "Estimated tax" | i18n }}</h3>
-        <div bitTypography="body2" class="tw-text-muted">
+        <div bitTypography="body1" class="tw-text-muted">
           {{ estimatedTax() | currency: "USD" : "symbol" }}
         </div>
       </div>
@@ -109,7 +110,7 @@
       <!-- Total -->
       <div class="tw-flex tw-justify-between tw-items-center tw-pt-2">
         <h3 bitTypography="h5" class="tw-text-muted">{{ "Total" | i18n }}</h3>
-        <div bitTypography="body2" class="tw-text-muted">
+        <div bitTypography="body1" class="tw-text-muted">
           {{ total() | currency: "USD" : "symbol" }} / {{ passwordManager.cadence | i18n }}
         </div>
       </div>

--- a/libs/pricing/src/components/cart-summary/cart-summary.component.html
+++ b/libs/pricing/src/components/cart-summary/cart-summary.component.html
@@ -14,6 +14,7 @@
     </div>
     <button
       type="button"
+      size="small"
       (click)="toggleExpanded()"
       [bitIconButton]="isExpanded() ? 'bwi-angle-up' : 'bwi-angle-down'"
       [label]="isExpanded() ? 'Collapse purchase details' : 'Expand purchase details'"

--- a/libs/pricing/src/components/cart-summary/cart-summary.component.html
+++ b/libs/pricing/src/components/cart-summary/cart-summary.component.html
@@ -1,0 +1,129 @@
+<div class="tw-size-full">
+  <div class="tw-py-4 tw-px-2">
+    <div class="tw-flex tw-items-center tw-gap-1">
+      <h2 bitTypography="h4">
+        Total: {{ total() | currency: "USD" : "symbol" }} USD
+        <span bitTypography="body2">/ {{ passwordManager()?.cadence }}</span>
+      </h2>
+      <button
+        type="button"
+        (click)="toggleExpanded()"
+        class="tw-cursor-pointer tw-mb-2"
+        [ariaLabel]="isExpanded() ? 'collapseCartDetails' : 'expandCartDetails'"
+        [attr.aria-expanded]="isExpanded()"
+        [attr.aria-controls]="'cart-summary-details'"
+        bitTypography="body1"
+      >
+        <i
+          aria-hidden="true"
+          class="bwi {{ isExpanded() ? 'bwi-angle-up' : 'bwi-angle-down' }}"
+        ></i>
+      </button>
+    </div>
+
+    @if (isExpanded()) {
+      <div id="cart-summary-details" class="tw-mb-4">
+        <!-- Password Manager Section -->
+        <div class="tw-border-b tw-border-secondary-100 tw-mb-2">
+          <div class="tw-flex tw-justify-between tw-mb-1">
+            <div bitTypography="h6" class="tw-text-muted">Password Manager</div>
+          </div>
+
+          <!-- Password Manager Members -->
+          <div class="tw-flex tw-justify-between tw-mb-2">
+            <div class="tw-flex-1">
+              <div bitTypography="body2" class="tw-text-muted">
+                {{ passwordManager()?.quantity }} Members x
+                {{ passwordManager()?.cost | currency: "USD" : "symbol" }}
+                /
+                {{ passwordManager()?.cadence }}
+              </div>
+            </div>
+            <div bitTypography="body2" class="tw-text-muted">
+              ${{ passwordManagerTotal().toFixed(2) }}
+            </div>
+          </div>
+
+          <!-- Additional Storage -->
+          @if (additionalStorage()) {
+            <div class="tw-flex tw-justify-between tw-mb-2">
+              <div class="tw-flex-1">
+                <div bitTypography="body2" class="tw-text-muted">
+                  {{ additionalStorage()?.quantity }} Additional GB x
+                  {{ additionalStorage()?.cost | currency: "USD" : "symbol" }} /
+                  {{ additionalStorage()?.cadence }}
+                </div>
+              </div>
+              <div bitTypography="body2" class="tw-text-muted">
+                {{ additionalStorageTotal() | currency: "USD" : "symbol" }}
+              </div>
+            </div>
+          }
+        </div>
+
+        <!-- Secrets Manager Section -->
+        @if (secretsManager()) {
+          <div class="tw-border-b tw-border-secondary-100">
+            <div class="tw-flex tw-justify-between">
+              <div bitTypography="h6" class="tw-text-muted">Secrets Manager</div>
+            </div>
+
+            <!-- Secrets Manager Members -->
+            <div class="tw-flex tw-justify-between tw-mb-2">
+              <div class="tw-flex-1">
+                <div bitTypography="body2" class="tw-text-muted">
+                  {{ secretsManager()?.seats.quantity }} Members x
+                  {{ secretsManager()?.seats.cost | currency: "USD" : "symbol" }}
+                  / {{ secretsManager()?.seats.cadence }}
+                </div>
+              </div>
+              <div bitTypography="body2" class="tw-text-muted">
+                {{ secretsManagerSeatsTotal() | currency: "USD" : "symbol" }}
+              </div>
+            </div>
+
+            <!-- Additional Service Accounts -->
+            @if (secretsManager()?.additionalServiceAccounts) {
+              <div class="tw-flex tw-justify-between tw-mb-2">
+                <div class="tw-flex-1">
+                  <div bitTypography="body2" class="tw-text-muted">
+                    {{ secretsManager()?.additionalServiceAccounts.quantity }} Additional machine
+                    accounts x
+                    {{
+                      secretsManager()?.additionalServiceAccounts.cost | currency: "USD" : "symbol"
+                    }}
+                    /
+                    {{ secretsManager()?.additionalServiceAccounts.cadence }}
+                  </div>
+                </div>
+                <div bitTypography="body2" class="tw-text-muted">
+                  ${{ secretsManagerServiceAccountsTotal().toFixed(2) }}
+                </div>
+              </div>
+            }
+          </div>
+        }
+
+        <!-- Estimated Tax -->
+        <div class="tw-flex tw-justify-between tw-border-b tw-border-secondary-100 tw-mb-2">
+          <div class="tw-flex-1">
+            <div bitTypography="h6" class="tw-text-muted">Estimated Tax</div>
+          </div>
+          <div bitTypography="body2" class="tw-text-muted">
+            {{ estimatedTax() | currency: "USD" : "symbol" }}
+          </div>
+        </div>
+
+        <!-- Total -->
+        <div class="tw-flex tw-justify-between tw-items-center">
+          <div class="tw-flex-1">
+            <div bitTypography="h6" class="tw-text-muted">Total</div>
+          </div>
+          <div bitTypography="body2" class="tw-text-muted">
+            {{ total() | currency: "USD" : "symbol" }} / {{ passwordManager()?.cadence }}
+          </div>
+        </div>
+      </div>
+    }
+  </div>
+</div>

--- a/libs/pricing/src/components/cart-summary/cart-summary.component.mdx
+++ b/libs/pricing/src/components/cart-summary/cart-summary.component.mdx
@@ -10,6 +10,27 @@ behavior across Bitwarden applications.
 
 <Canvas of={CartSummaryStories.Default} />
 
+## Table of Contents
+
+- [Usage](#usage)
+- [API](#api)
+  - [Inputs](#inputs)
+  - [Events](#events)
+- [Data Structure](#data-structure)
+- [Flexibility](#flexibility)
+- [Design](#design)
+- [Examples](#examples)
+  - [Yearly Cadence](#yearly-cadence)
+  - [With Additional Storage](#with-additional-storage)
+  - [With Secrets Manager](#with-secrets-manager)
+  - [With Secrets Manager and Additional Service Accounts](#with-secrets-manager-and-additional-service-accounts)
+  - [All Products](#all-products)
+  - [Premium Plan](#premium-plan)
+  - [Family Plan](#family-plan)
+- [Features](#features)
+- [Do's and Don'ts](#dos-and-donts)
+- [Accessibility](#accessibility)
+
 ## Usage
 
 The cart summary component is designed to be used in checkout and subscription interfaces to display
@@ -67,7 +88,7 @@ The cart summary component provides flexibility through its structured input pro
 <billing-cart-summary
   [passwordManager]="{
     quantity: 5,
-    name: 'Password Manager',
+    name: 'Members',
     cost: 50.00,
     cadence: 'month'
   }"
@@ -79,13 +100,13 @@ The cart summary component provides flexibility through its structured input pro
 <billing-cart-summary
   [passwordManager]="{
     quantity: 5,
-    name: 'Password Manager',
+    name: 'Members',
     cost: 50.00,
     cadence: 'month'
   }"
   [additionalStorage]="{
     quantity: 2,
-    name: 'Additional Storage (1GB)',
+    name: 'Additional storage GB',
     cost: 10.00,
     cadence: 'month'
   }"
@@ -100,12 +121,12 @@ The component follows the Bitwarden design system with:
 
 - **Collapsible Interface**: Toggles between compact and detailed views
 - **Clean Styling**: Uses Tailwind utility classes for consistent appearance
-- **Modern Angular**: Uses `@if` control flow with signal inputs
+- **Modern Angular**: Uses `@if` control flow and `@let` with signal inputs
 - **Signal inputs**: Type-safe inputs using Angular's signal-based input API
-- **Typography**: Consistent text styling with appropriate font weights
+- **Typography**: Consistent text styling using the typography module
 - **Layout**: Flexbox layout with clear section boundaries
 - **Interactivity**: Collapsible summary with intuitive toggle behavior
-- **Accessibility**: Semantic structure with proper button and icon usage
+- **Accessibility**: Semantic structure with proper button and icon usage using IconButtonModule
 
 ## Examples
 
@@ -119,7 +140,7 @@ Show cart with yearly subscription:
 <billing-cart-summary
   [passwordManager]="{
     quantity: 5,
-    name: 'Password Manager Annual',
+    name: 'Members',
     cost: 500.00,
     cadence: 'year'
   }"
@@ -138,13 +159,13 @@ Show cart with password manager and additional storage:
 <billing-cart-summary
   [passwordManager]="{
     quantity: 5,
-    name: 'Password Manager',
+    name: 'Members',
     cost: 50.00,
     cadence: 'month'
   }"
   [additionalStorage]="{
     quantity: 2,
-    name: 'Additional Storage (1GB)',
+    name: 'Additional storage GB',
     cost: 10.00,
     cadence: 'month'
   }"
@@ -163,14 +184,14 @@ Show cart with password manager and secrets manager seats only:
 <billing-cart-summary
   [passwordManager]="{
     quantity: 5,
-    name: 'Password Manager',
+    name: 'Members',
     cost: 50.00,
     cadence: 'month'
   }"
   [secretsManager]="{
     seats: {
       quantity: 3,
-      name: 'Secrets Manager Seats',
+      name: 'Members',
       cost: 30.00,
       cadence: 'month'
     }
@@ -190,20 +211,20 @@ Show cart with password manager, secrets manager seats, and additional service a
 <billing-cart-summary
   [passwordManager]="{
     quantity: 5,
-    name: 'Password Manager',
+    name: 'Members',
     cost: 50.00,
     cadence: 'month'
   }"
   [secretsManager]="{
     seats: {
       quantity: 3,
-      name: 'Secrets Manager Seats',
+      name: 'Members',
       cost: 30.00,
       cadence: 'month'
     },
     additionalServiceAccounts: {
       quantity: 2,
-      name: 'Additional Service Accounts',
+      name: 'Additional machine accounts',
       cost: 6.00,
       cadence: 'month'
     }
@@ -213,9 +234,9 @@ Show cart with password manager, secrets manager seats, and additional service a
 </billing-cart-summary>
 ```
 
-### Complete Cart
+### All Products
 
-Show a complete cart with all available products:
+Show a cart with all available products:
 
 <Canvas of={CartSummaryStories.AllProducts} />
 
@@ -223,26 +244,26 @@ Show a complete cart with all available products:
 <billing-cart-summary
   [passwordManager]="{
     quantity: 5,
-    name: 'Password Manager',
+    name: 'Members',
     cost: 50.00,
     cadence: 'month'
   }"
   [additionalStorage]="{
     quantity: 2,
-    name: 'Additional Storage (1GB)',
+    name: 'Additional storage GB',
     cost: 10.00,
     cadence: 'month'
   }"
   [secretsManager]="{
     seats: {
       quantity: 3,
-      name: 'Secrets Manager Seats',
+      name: 'Members',
       cost: 30.00,
       cadence: 'month'
     },
     additionalServiceAccounts: {
       quantity: 2,
-      name: 'Additional Service Accounts',
+      name: 'Additional machine accounts',
       cost: 6.00,
       cadence: 'month'
     }
@@ -252,14 +273,49 @@ Show a complete cart with all available products:
 </billing-cart-summary>
 ```
 
+### Premium Plan
+Show cart with premium plan:
+<Canvas of={CartSummaryStories.PremiumPlan} />
+```html
+<billing-cart-summary
+  [passwordManager]="{
+    quantity: 1,
+    name: 'Premium membership',
+    cost: 10.00,
+    cadence: 'month'
+  }"
+  [estimatedTax]="2.71"
+>
+</billing-cart-summary>
+```
+
+### Families Plan
+
+Show cart with families plan:
+
+<Canvas of={CartSummaryStories.FamiliesPlan} />
+```html
+<billing-cart-summary
+  [passwordManager]="{
+    quantity: 1,
+    name: 'Families membership',
+    cost: 40.00,
+    cadence: 'month'
+  }"
+  [estimatedTax]="4.67"
+>
+</billing-cart-summary>
+```
+
 ## Features
 
 - **Collapsible Interface**: Users can toggle between a summary view showing only the total and a
   detailed view showing all line items
 - **Line Item Grouping**: Organizes items by product category (Password Manager, Secrets Manager)
-- **Dynamic Calculations**: Automatically calculates and displays subtotals and totals
+- **Dynamic Calculations**: Automatically calculates and displays subtotals and totals using Angular signals and computed values
 - **Flexible Structure**: Accommodates different combinations of products and add-ons
 - **Consistent Formatting**: Maintains uniform display of prices, quantities, and cadence
+- **Modern Angular Patterns**: Uses `@let` to efficiently store and reuse signal values in the template
 
 ## Do's and Don'ts
 

--- a/libs/pricing/src/components/cart-summary/cart-summary.component.mdx
+++ b/libs/pricing/src/components/cart-summary/cart-summary.component.mdx
@@ -1,0 +1,291 @@
+import { Meta, Story, Canvas } from "@storybook/addon-docs";
+import * as CartSummaryStories from "./cart-summary.component.stories";
+
+<Meta of={CartSummaryStories} />
+
+# Cart Summary
+
+A reusable UI component for displaying order summary information with consistent styling and
+behavior across Bitwarden applications.
+
+<Canvas of={CartSummaryStories.Default} />
+
+## Usage
+
+The cart summary component is designed to be used in checkout and subscription interfaces to display
+order details, prices, and totals.
+
+```ts
+import { CartSummaryComponent, LineItem } from "@bitwarden/pricing";
+```
+
+```html
+<billing-cart-summary
+  [passwordManager]="passwordManagerItem"
+  [additionalStorage]="additionalStorageItem"
+  [secretsManager]="secretsManagerItems"
+  [estimatedTax]="taxAmount"
+>
+</billing-cart-summary>
+```
+
+## API
+
+### Inputs
+
+| Input               | Type                                                                     | Description                                                     |
+| ------------------- | ------------------------------------------------------------------------ | --------------------------------------------------------------- |
+| `passwordManager`   | `LineItem`                                                               | **Required.** The Password Manager product line item            |
+| `additionalStorage` | `LineItem \| undefined`                                                  | **Optional.** Additional storage line item, if applicable       |
+| `secretsManager`    | `{ seats: LineItem; additionalServiceAccounts?: LineItem } \| undefined` | **Optional.** Secrets Manager related line items, if applicable |
+| `estimatedTax`      | `number`                                                                 | **Required.** Estimated tax amount                              |
+
+### Events
+
+The cart summary component does not emit any events, but it does have internal behavior for
+collapsing and expanding the view.
+
+## Data Structure
+
+The component uses the following LineItem data structure:
+
+```typescript
+export type LineItem = {
+  quantity: number; // Number of items
+  name: string; // Display name of the item
+  cost: number; // Cost of each item
+  cadence: "month" | "year"; // Billing period
+};
+```
+
+## Flexibility
+
+The cart summary component provides flexibility through its structured input properties:
+
+```html
+<!-- Basic usage with only Password Manager -->
+<billing-cart-summary
+  [passwordManager]="{
+    quantity: 5,
+    name: 'Password Manager',
+    cost: 50.00,
+    cadence: 'month'
+  }"
+  [estimatedTax]="9.60"
+>
+</billing-cart-summary>
+
+<!-- With Additional Storage -->
+<billing-cart-summary
+  [passwordManager]="{
+    quantity: 5,
+    name: 'Password Manager',
+    cost: 50.00,
+    cadence: 'month'
+  }"
+  [additionalStorage]="{
+    quantity: 2,
+    name: 'Additional Storage (1GB)',
+    cost: 10.00,
+    cadence: 'month'
+  }"
+  [estimatedTax]="12.00"
+>
+</billing-cart-summary>
+```
+
+## Design
+
+The component follows the Bitwarden design system with:
+
+- **Collapsible Interface**: Toggles between compact and detailed views
+- **Clean Styling**: Uses Tailwind utility classes for consistent appearance
+- **Modern Angular**: Uses `@if` control flow with signal inputs
+- **Signal inputs**: Type-safe inputs using Angular's signal-based input API
+- **Typography**: Consistent text styling with appropriate font weights
+- **Layout**: Flexbox layout with clear section boundaries
+- **Interactivity**: Collapsible summary with intuitive toggle behavior
+- **Accessibility**: Semantic structure with proper button and icon usage
+
+## Examples
+
+### Yearly Cadence
+
+Show cart with yearly subscription:
+
+<Canvas of={CartSummaryStories.PasswordManagerYearlyCadence} />
+
+```html
+<billing-cart-summary
+  [passwordManager]="{
+    quantity: 5,
+    name: 'Password Manager Annual',
+    cost: 500.00,
+    cadence: 'year'
+  }"
+  [estimatedTax]="120.00"
+>
+</billing-cart-summary>
+```
+
+### With Additional Storage
+
+Show cart with password manager and additional storage:
+
+<Canvas of={CartSummaryStories.WithAdditionalStorage} />
+
+```html
+<billing-cart-summary
+  [passwordManager]="{
+    quantity: 5,
+    name: 'Password Manager',
+    cost: 50.00,
+    cadence: 'month'
+  }"
+  [additionalStorage]="{
+    quantity: 2,
+    name: 'Additional Storage (1GB)',
+    cost: 10.00,
+    cadence: 'month'
+  }"
+  [estimatedTax]="12.00"
+>
+</billing-cart-summary>
+```
+
+### With Secrets Manager
+
+Show cart with password manager and secrets manager seats only:
+
+<Canvas of={CartSummaryStories.SecretsManagerSeatsOnly} />
+
+```html
+<billing-cart-summary
+  [passwordManager]="{
+    quantity: 5,
+    name: 'Password Manager',
+    cost: 50.00,
+    cadence: 'month'
+  }"
+  [secretsManager]="{
+    seats: {
+      quantity: 3,
+      name: 'Secrets Manager Seats',
+      cost: 30.00,
+      cadence: 'month'
+    }
+  }"
+  [estimatedTax]="16.00"
+>
+</billing-cart-summary>
+```
+
+### With Secrets Manager and Additional Service Accounts
+
+Show cart with password manager, secrets manager seats, and additional service accounts:
+
+<Canvas of={CartSummaryStories.SecretsManagerSeatsAndServiceAccounts} />
+
+```html
+<billing-cart-summary
+  [passwordManager]="{
+    quantity: 5,
+    name: 'Password Manager',
+    cost: 50.00,
+    cadence: 'month'
+  }"
+  [secretsManager]="{
+    seats: {
+      quantity: 3,
+      name: 'Secrets Manager Seats',
+      cost: 30.00,
+      cadence: 'month'
+    },
+    additionalServiceAccounts: {
+      quantity: 2,
+      name: 'Additional Service Accounts',
+      cost: 6.00,
+      cadence: 'month'
+    }
+  }"
+  [estimatedTax]="16.00"
+>
+</billing-cart-summary>
+```
+
+### Complete Cart
+
+Show a complete cart with all available products:
+
+<Canvas of={CartSummaryStories.AllProducts} />
+
+```html
+<billing-cart-summary
+  [passwordManager]="{
+    quantity: 5,
+    name: 'Password Manager',
+    cost: 50.00,
+    cadence: 'month'
+  }"
+  [additionalStorage]="{
+    quantity: 2,
+    name: 'Additional Storage (1GB)',
+    cost: 10.00,
+    cadence: 'month'
+  }"
+  [secretsManager]="{
+    seats: {
+      quantity: 3,
+      name: 'Secrets Manager Seats',
+      cost: 30.00,
+      cadence: 'month'
+    },
+    additionalServiceAccounts: {
+      quantity: 2,
+      name: 'Additional Service Accounts',
+      cost: 6.00,
+      cadence: 'month'
+    }
+  }"
+  [estimatedTax]="19.20"
+>
+</billing-cart-summary>
+```
+
+## Features
+
+- **Collapsible Interface**: Users can toggle between a summary view showing only the total and a
+  detailed view showing all line items
+- **Line Item Grouping**: Organizes items by product category (Password Manager, Secrets Manager)
+- **Dynamic Calculations**: Automatically calculates and displays subtotals and totals
+- **Flexible Structure**: Accommodates different combinations of products and add-ons
+- **Consistent Formatting**: Maintains uniform display of prices, quantities, and cadence
+
+## Do's and Don'ts
+
+### ✅ Do
+
+- Use consistent naming and formatting for line items
+- Include clear quantity and unit pricing information
+- Ensure tax estimates are accurate and clearly labeled
+- Maintain consistent cadence formats across related items
+- Use the same cadence for all items within a single cart
+
+### ❌ Don't
+
+- Mix monthly and yearly cadences within the same cart
+- Omit required inputs (passwordManager, estimatedTax)
+- Modify the component's internal calculations
+- Use inconsistent formatting for monetary values
+- Override the default styles and layout
+
+## Accessibility
+
+The component includes:
+
+- Semantic HTML structure with proper headings
+- Button element for the collapsible toggle
+- Keyboard navigation support
+- Clear visual indication of expanded state
+- Descriptive labels and text
+- Sufficient color contrast for text elements

--- a/libs/pricing/src/components/cart-summary/cart-summary.component.mdx
+++ b/libs/pricing/src/components/cart-summary/cart-summary.component.mdx
@@ -274,7 +274,9 @@ Show a cart with all available products:
 ```
 
 ### Premium Plan
+
 Show cart with premium plan:
+
 <Canvas of={CartSummaryStories.PremiumPlan} />
 ```html
 <billing-cart-summary
@@ -312,10 +314,12 @@ Show cart with families plan:
 - **Collapsible Interface**: Users can toggle between a summary view showing only the total and a
   detailed view showing all line items
 - **Line Item Grouping**: Organizes items by product category (Password Manager, Secrets Manager)
-- **Dynamic Calculations**: Automatically calculates and displays subtotals and totals using Angular signals and computed values
+- **Dynamic Calculations**: Automatically calculates and displays subtotals and totals using Angular
+  signals and computed values
 - **Flexible Structure**: Accommodates different combinations of products and add-ons
 - **Consistent Formatting**: Maintains uniform display of prices, quantities, and cadence
-- **Modern Angular Patterns**: Uses `@let` to efficiently store and reuse signal values in the template
+- **Modern Angular Patterns**: Uses `@let` to efficiently store and reuse signal values in the
+  template
 
 ## Do's and Don'ts
 

--- a/libs/pricing/src/components/cart-summary/cart-summary.component.spec.ts
+++ b/libs/pricing/src/components/cart-summary/cart-summary.component.spec.ts
@@ -1,0 +1,209 @@
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { By } from "@angular/platform-browser";
+
+import { CartSummaryComponent, LineItem } from "./cart-summary.component";
+
+describe("CartSummaryComponent", () => {
+  let component: CartSummaryComponent;
+  let fixture: ComponentFixture<CartSummaryComponent>;
+
+  const mockPasswordManager: LineItem = {
+    quantity: 5,
+    name: "Password Manager",
+    cost: 50,
+    cadence: "month",
+  };
+
+  const mockAdditionalStorage: LineItem = {
+    quantity: 2,
+    name: "Additional Storage",
+    cost: 10,
+    cadence: "month",
+  };
+
+  const mockSecretsManager = {
+    seats: {
+      quantity: 3,
+      name: "Secrets Manager Seats",
+      cost: 30,
+      cadence: "month" as "month" | "year",
+    },
+    additionalServiceAccounts: {
+      quantity: 2,
+      name: "Additional Service Accounts",
+      cost: 6,
+      cadence: "month" as "month" | "year",
+    },
+  };
+
+  const mockEstimatedTax = 9.6;
+
+  function setupComponent(
+    options: {
+      passwordManager?: LineItem;
+      additionalStorage?: LineItem | null;
+      secretsManager?: { seats: LineItem; additionalServiceAccounts?: LineItem } | null;
+      estimatedTax?: number;
+    } = {},
+  ) {
+    const pm = options.passwordManager ?? mockPasswordManager;
+    const storage =
+      options.additionalStorage !== null
+        ? (options.additionalStorage ?? mockAdditionalStorage)
+        : undefined;
+    const sm =
+      options.secretsManager !== null ? (options.secretsManager ?? mockSecretsManager) : undefined;
+    const tax = options.estimatedTax ?? mockEstimatedTax;
+
+    // Set input values
+    fixture.componentRef.setInput("passwordManager", pm);
+    if (storage !== undefined) {
+      fixture.componentRef.setInput("additionalStorage", storage);
+    }
+    if (sm !== undefined) {
+      fixture.componentRef.setInput("secretsManager", sm);
+    }
+    fixture.componentRef.setInput("estimatedTax", tax);
+
+    fixture.detectChanges();
+  }
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CartSummaryComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CartSummaryComponent);
+    component = fixture.componentInstance;
+
+    // Default setup with all inputs
+    setupComponent();
+  });
+
+  it("should create", () => {
+    // Assert
+    expect(component).toBeTruthy();
+  });
+
+  describe("UI Toggle Functionality", () => {
+    it("should toggle expanded state when the button is clicked", () => {
+      // Arrange
+      expect(component.isExpanded()).toBe(true);
+      const toggleButton = fixture.debugElement.query(By.css("button[type='button']"));
+      expect(toggleButton).toBeTruthy();
+
+      // Act - First click (collapse)
+      toggleButton.triggerEventHandler("click", null);
+      fixture.detectChanges();
+
+      // Assert - Component is collapsed
+      expect(component.isExpanded()).toBe(false);
+      const icon = fixture.debugElement.query(By.css("i.bwi"));
+      expect(icon.nativeElement.classList.contains("bwi-angle-down")).toBe(true);
+
+      // Act - Second click (expand)
+      toggleButton.triggerEventHandler("click", null);
+      fixture.detectChanges();
+
+      // Assert - Component is expanded again
+      expect(component.isExpanded()).toBe(true);
+      expect(icon.nativeElement.classList.contains("bwi-angle-up")).toBe(true);
+    });
+
+    it("should hide details when collapsed", () => {
+      // Arrange
+      component.isExpanded.set(false);
+      fixture.detectChanges();
+
+      // Act / Assert
+      const detailsSection = fixture.debugElement.query(By.css(".tw-mb-4.tw-pb-4.tw-text-muted"));
+      expect(detailsSection).toBeFalsy();
+    });
+
+    it("should show details when expanded", () => {
+      // Arrange
+      component.isExpanded.set(true);
+      fixture.detectChanges();
+
+      // Act / Assert
+      const detailsSection = fixture.debugElement.query(By.css(".tw-mb-4.tw-pb-4.tw-text-muted"));
+      expect(detailsSection).toBeTruthy();
+    });
+  });
+
+  describe("Content Rendering", () => {
+    it("should display correct password manager information", () => {
+      // Arrange
+      const pmSection = fixture.debugElement.query(By.css(".tw-mb-3.tw-border-b"));
+      const pmHeading = pmSection.query(By.css(".tw-font-semibold"));
+      const pmLineItem = pmSection.query(By.css(".tw-flex-1 .tw-text-sm"));
+      const pmTotal = pmSection.query(By.css(".tw-text-sm:not(.tw-flex-1 *)"));
+
+      // Act/ Assert
+      expect(pmSection).toBeTruthy();
+      expect(pmHeading.nativeElement.textContent.trim()).toBe("Password Manager");
+      expect(pmLineItem.nativeElement.textContent).toContain("5 Members");
+      expect(pmLineItem.nativeElement.textContent).toContain("$50.00");
+      expect(pmLineItem.nativeElement.textContent).toContain("month");
+      expect(pmTotal.nativeElement.textContent).toContain("$250.00"); // 5 * $50
+    });
+
+    it("should display correct additional storage information", () => {
+      // Arrange
+      const storageItem = fixture.debugElement.query(
+        By.css(".tw-mb-3.tw-border-b .tw-flex-justify-between:nth-of-type(3)"),
+      );
+      const storageText = fixture.debugElement.query(By.css(".tw-mb-3.tw-border-b")).nativeElement
+        .textContent;
+      // Act/Assert
+
+      expect(storageItem).toBeTruthy();
+      expect(storageText).toContain("2 Additional GB");
+      expect(storageText).toContain("$10.00");
+      expect(storageText).toContain("$20.00");
+    });
+
+    it("should display correct secrets manager information", () => {
+      // Arrange
+      const smSection = fixture.debugElement.queryAll(By.css(".tw-mb-3.tw-border-b"))[1];
+      const smHeading = smSection.query(By.css(".tw-font-semibold"));
+      const sectionText = smSection.nativeElement.textContent;
+
+      // Act/ Assert
+      expect(smSection).toBeTruthy();
+      expect(smHeading.nativeElement.textContent.trim()).toBe("Secrets Manager");
+
+      // Check seats line item
+      expect(sectionText).toContain("3 Members");
+      expect(sectionText).toContain("$30.00");
+      expect(sectionText).toContain("$90.00"); // 3 * $30
+
+      // Check additional service accounts
+      expect(sectionText).toContain("2 Additional machine accounts");
+      expect(sectionText).toContain("$6.00");
+      expect(sectionText).toContain("$12.00"); // 2 * $6
+    });
+
+    it("should display correct tax and total", () => {
+      // Arrange
+      const taxSection = fixture.debugElement.query(
+        By.css(".tw-flex.tw-justify-between.tw-mb-3.tw-border-b:last-of-type"),
+      );
+      const expectedTotal = "$381.60"; // 250 + 20 + 90 + 12 + 9.6
+      const topTotal = fixture.debugElement.query(By.css("h2"));
+      const bottomTotal = fixture.debugElement.query(
+        By.css(
+          ".tw-flex.tw-justify-between.tw-items-center:last-child .tw-font-semibold:last-child",
+        ),
+      );
+
+      // Act / Assert
+      expect(taxSection.nativeElement.textContent).toContain("Estimated Tax");
+      expect(taxSection.nativeElement.textContent).toContain("$9.60");
+
+      expect(topTotal.nativeElement.textContent).toContain(expectedTotal);
+
+      expect(bottomTotal.nativeElement.textContent).toContain(expectedTotal);
+    });
+  });
+});

--- a/libs/pricing/src/components/cart-summary/cart-summary.component.stories.ts
+++ b/libs/pricing/src/components/cart-summary/cart-summary.component.stories.ts
@@ -8,6 +8,7 @@ import { CartSummaryComponent } from "./cart-summary.component";
 export default {
   title: "Billing/Cart Summary",
   component: CartSummaryComponent,
+  description: "A summary of the items in the cart, including pricing details.",
   decorators: [
     moduleMetadata({
       imports: [TypographyModule, IconButtonModule],
@@ -28,6 +29,12 @@ export default {
       cadence: "month",
     },
     estimatedTax: 9.6,
+  },
+  parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/nuFrzHsgEoEk2Sm8fWOGuS/Premium-Upgrade-flows--pricing-increase-?node-id=877-23653&t=OpDXkupIsvfbh4jT-4",
+    },
   },
 } as Meta<CartSummaryComponent>;
 

--- a/libs/pricing/src/components/cart-summary/cart-summary.component.stories.ts
+++ b/libs/pricing/src/components/cart-summary/cart-summary.component.stories.ts
@@ -1,7 +1,7 @@
 import { Meta, moduleMetadata, StoryObj } from "@storybook/angular";
 
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
-import { TypographyModule } from "@bitwarden/components";
+import { IconButtonModule, TypographyModule } from "@bitwarden/components";
 
 import { CartSummaryComponent } from "./cart-summary.component";
 
@@ -10,7 +10,7 @@ export default {
   component: CartSummaryComponent,
   decorators: [
     moduleMetadata({
-      imports: [TypographyModule],
+      imports: [TypographyModule, IconButtonModule],
       // Return the same value for all keys for simplicity
       providers: [
         {
@@ -23,7 +23,7 @@ export default {
   args: {
     passwordManager: {
       quantity: 5,
-      name: "Password Manager",
+      name: "Members",
       cost: 50.0,
       cadence: "month",
     },
@@ -36,15 +36,10 @@ export const Default: Story = {};
 
 export const WithAdditionalStorage: Story = {
   args: {
-    passwordManager: {
-      quantity: 5,
-      name: "Password Manager",
-      cost: 50.0,
-      cadence: "month",
-    },
+    ...Default.args,
     additionalStorage: {
       quantity: 2,
-      name: "Additional Storage (1GB)",
+      name: "Additional storage GB",
       cost: 10.0,
       cadence: "month",
     },
@@ -56,7 +51,7 @@ export const PasswordManagerYearlyCadence: Story = {
   args: {
     passwordManager: {
       quantity: 5,
-      name: "Password Manager Annual",
+      name: "Members",
       cost: 500.0,
       cadence: "year",
     },
@@ -66,16 +61,11 @@ export const PasswordManagerYearlyCadence: Story = {
 
 export const SecretsManagerSeatsOnly: Story = {
   args: {
-    passwordManager: {
-      quantity: 5,
-      name: "Password Manager",
-      cost: 50.0,
-      cadence: "month",
-    },
+    ...Default.args,
     secretsManager: {
       seats: {
         quantity: 3,
-        name: "Secrets Manager Seats",
+        name: "Members",
         cost: 30.0,
         cadence: "month",
       },
@@ -86,22 +76,17 @@ export const SecretsManagerSeatsOnly: Story = {
 
 export const SecretsManagerSeatsAndServiceAccounts: Story = {
   args: {
-    passwordManager: {
-      quantity: 5,
-      name: "Password Manager",
-      cost: 50.0,
-      cadence: "month",
-    },
+    ...Default.args,
     secretsManager: {
       seats: {
         quantity: 3,
-        name: "Secrets Manager Seats",
+        name: "Members",
         cost: 30.0,
         cadence: "month",
       },
       additionalServiceAccounts: {
         quantity: 2,
-        name: "Additional Service Accounts",
+        name: "Additional machine accounts",
         cost: 6.0,
         cadence: "month",
       },
@@ -112,32 +97,51 @@ export const SecretsManagerSeatsAndServiceAccounts: Story = {
 
 export const AllProducts: Story = {
   args: {
-    passwordManager: {
-      quantity: 5,
-      name: "Password Manager",
-      cost: 50.0,
-      cadence: "month",
-    },
+    ...Default.args,
     additionalStorage: {
       quantity: 2,
-      name: "Additional Storage (1GB)",
+      name: "Additional storage GB",
       cost: 10.0,
       cadence: "month",
     },
     secretsManager: {
       seats: {
         quantity: 3,
-        name: "Secrets Manager Seats",
+        name: "Members",
         cost: 30.0,
         cadence: "month",
       },
       additionalServiceAccounts: {
         quantity: 2,
-        name: "Additional Service Accounts",
+        name: "Additional machine accounts",
         cost: 6.0,
         cadence: "month",
       },
     },
     estimatedTax: 19.2,
+  },
+};
+
+export const FamiliesPlan: Story = {
+  args: {
+    passwordManager: {
+      quantity: 1,
+      name: "Families membership",
+      cost: 40.0,
+      cadence: "year",
+    },
+    estimatedTax: 4.67,
+  },
+};
+
+export const PremiumPlan: Story = {
+  args: {
+    passwordManager: {
+      quantity: 1,
+      name: "Premium membership",
+      cost: 10.0,
+      cadence: "year",
+    },
+    estimatedTax: 2.71,
   },
 };

--- a/libs/pricing/src/components/cart-summary/cart-summary.component.stories.ts
+++ b/libs/pricing/src/components/cart-summary/cart-summary.component.stories.ts
@@ -1,0 +1,128 @@
+import { Meta, StoryObj } from "@storybook/angular";
+
+import { CartSummaryComponent } from "./cart-summary.component";
+
+export default {
+  title: "Billing/Cart Summary",
+  component: CartSummaryComponent,
+  args: {
+    passwordManager: {
+      quantity: 5,
+      name: "Password Manager",
+      cost: 50.0,
+      cadence: "month",
+    },
+    estimatedTax: 9.6,
+  },
+} as Meta<CartSummaryComponent>;
+
+type Story = StoryObj<CartSummaryComponent>;
+export const Default: Story = {};
+
+export const WithAdditionalStorage: Story = {
+  args: {
+    passwordManager: {
+      quantity: 5,
+      name: "Password Manager",
+      cost: 50.0,
+      cadence: "month",
+    },
+    additionalStorage: {
+      quantity: 2,
+      name: "Additional Storage (1GB)",
+      cost: 10.0,
+      cadence: "month",
+    },
+    estimatedTax: 12.0,
+  },
+};
+
+export const PasswordManagerYearlyCadence: Story = {
+  args: {
+    passwordManager: {
+      quantity: 5,
+      name: "Password Manager Annual",
+      cost: 500.0,
+      cadence: "year",
+    },
+    estimatedTax: 120.0,
+  },
+};
+
+export const SecretsManagerSeatsOnly: Story = {
+  args: {
+    passwordManager: {
+      quantity: 5,
+      name: "Password Manager",
+      cost: 50.0,
+      cadence: "month",
+    },
+    secretsManager: {
+      seats: {
+        quantity: 3,
+        name: "Secrets Manager Seats",
+        cost: 30.0,
+        cadence: "month",
+      },
+    },
+    estimatedTax: 16.0,
+  },
+};
+
+export const SecretsManagerSeatsAndServiceAccounts: Story = {
+  args: {
+    passwordManager: {
+      quantity: 5,
+      name: "Password Manager",
+      cost: 50.0,
+      cadence: "month",
+    },
+    secretsManager: {
+      seats: {
+        quantity: 3,
+        name: "Secrets Manager Seats",
+        cost: 30.0,
+        cadence: "month",
+      },
+      additionalServiceAccounts: {
+        quantity: 2,
+        name: "Additional Service Accounts",
+        cost: 6.0,
+        cadence: "month",
+      },
+    },
+    estimatedTax: 16.0,
+  },
+};
+
+export const AllProducts: Story = {
+  args: {
+    passwordManager: {
+      quantity: 5,
+      name: "Password Manager",
+      cost: 50.0,
+      cadence: "month",
+    },
+    additionalStorage: {
+      quantity: 2,
+      name: "Additional Storage (1GB)",
+      cost: 10.0,
+      cadence: "month",
+    },
+    secretsManager: {
+      seats: {
+        quantity: 3,
+        name: "Secrets Manager Seats",
+        cost: 30.0,
+        cadence: "month",
+      },
+      additionalServiceAccounts: {
+        quantity: 2,
+        name: "Additional Service Accounts",
+        cost: 6.0,
+        cadence: "month",
+      },
+    },
+    estimatedTax: 19.2,
+  },
+};

--- a/libs/pricing/src/components/cart-summary/cart-summary.component.stories.ts
+++ b/libs/pricing/src/components/cart-summary/cart-summary.component.stories.ts
@@ -1,10 +1,25 @@
-import { Meta, StoryObj } from "@storybook/angular";
+import { Meta, moduleMetadata, StoryObj } from "@storybook/angular";
+
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { TypographyModule } from "@bitwarden/components";
 
 import { CartSummaryComponent } from "./cart-summary.component";
 
 export default {
   title: "Billing/Cart Summary",
   component: CartSummaryComponent,
+  decorators: [
+    moduleMetadata({
+      imports: [TypographyModule],
+      // Return the same value for all keys for simplicity
+      providers: [
+        {
+          provide: I18nService,
+          useValue: { t: (key: string) => key },
+        },
+      ],
+    }),
+  ],
   args: {
     passwordManager: {
       quantity: 5,

--- a/libs/pricing/src/components/cart-summary/cart-summary.component.ts
+++ b/libs/pricing/src/components/cart-summary/cart-summary.component.ts
@@ -1,7 +1,7 @@
 import { CurrencyPipe } from "@angular/common";
 import { Component, computed, input, signal } from "@angular/core";
 
-import { TypographyModule } from "@bitwarden/components";
+import { TypographyModule, IconButtonModule } from "@bitwarden/components";
 import { I18nPipe } from "@bitwarden/ui-common";
 
 export type LineItem = {
@@ -19,7 +19,7 @@ export type LineItem = {
 @Component({
   selector: "billing-cart-summary",
   templateUrl: "./cart-summary.component.html",
-  imports: [TypographyModule, CurrencyPipe, I18nPipe],
+  imports: [TypographyModule, IconButtonModule, CurrencyPipe, I18nPipe],
 })
 export class CartSummaryComponent {
   // Required inputs

--- a/libs/pricing/src/components/cart-summary/cart-summary.component.ts
+++ b/libs/pricing/src/components/cart-summary/cart-summary.component.ts
@@ -1,0 +1,94 @@
+import { CurrencyPipe } from "@angular/common";
+import { Component, computed, input, signal } from "@angular/core";
+
+import { TypographyModule } from "@bitwarden/components";
+
+export type LineItem = {
+  quantity: number;
+  name: string;
+  cost: number;
+  cadence: "month" | "year";
+};
+
+/**
+ * A reusable UI-only component that displays a cart summary with line items.
+ * This component has no external dependencies and performs minimal logic -
+ * it only displays data and allows expanding/collapsing of line items.
+ */
+@Component({
+  selector: "billing-cart-summary",
+  templateUrl: "./cart-summary.component.html",
+  imports: [TypographyModule, CurrencyPipe],
+})
+export class CartSummaryComponent {
+  // Required inputs
+  passwordManager = input.required<LineItem>();
+  additionalStorage = input<LineItem | undefined>(undefined);
+  secretsManager = input<{ seats: LineItem; additionalServiceAccounts?: LineItem } | undefined>(
+    undefined,
+  );
+  estimatedTax = input.required<number>();
+
+  // UI state
+  isExpanded = signal(true);
+
+  /**
+   * Calculates total for password manager line item
+   */
+  readonly passwordManagerTotal = computed<number>(() => {
+    const pm = this.passwordManager();
+    return pm ? pm.quantity * pm.cost : 0;
+  });
+
+  /**
+   * Calculates total for additional storage line item if present
+   */
+  readonly additionalStorageTotal = computed<number>(() => {
+    const storage = this.additionalStorage();
+    return storage ? storage.quantity * storage.cost : 0;
+  });
+
+  /**
+   * Calculates total for secrets manager seats if present
+   */
+  readonly secretsManagerSeatsTotal = computed<number>(() => {
+    const sm = this.secretsManager();
+    return sm?.seats ? sm.seats.quantity * sm.seats.cost : 0;
+  });
+
+  /**
+   * Calculates total for secrets manager service accounts if present
+   */
+  readonly secretsManagerServiceAccountsTotal = computed<number>(() => {
+    const sm = this.secretsManager();
+    return sm?.additionalServiceAccounts
+      ? sm.additionalServiceAccounts.quantity * sm.additionalServiceAccounts.cost
+      : 0;
+  });
+
+  /**
+   * Calculates the total of all line items
+   */
+  readonly total = computed<number>(() => this.getTotalCost());
+
+  /**
+   * Toggles the expanded/collapsed state of the cart items
+   */
+  toggleExpanded(): void {
+    this.isExpanded.update((value: boolean) => !value);
+  }
+
+  /**
+   * Gets the total cost of all line items in the cart
+   * @returns The total cost as a number
+   */
+  private getTotalCost(): number {
+    return (
+      this.passwordManagerTotal() +
+      this.additionalStorageTotal() +
+      this.secretsManagerSeatsTotal() +
+      this.secretsManagerServiceAccountsTotal() +
+      this.estimatedTax()
+    );
+  }
+}

--- a/libs/pricing/src/components/cart-summary/cart-summary.component.ts
+++ b/libs/pricing/src/components/cart-summary/cart-summary.component.ts
@@ -2,6 +2,7 @@ import { CurrencyPipe } from "@angular/common";
 import { Component, computed, input, signal } from "@angular/core";
 
 import { TypographyModule } from "@bitwarden/components";
+import { I18nPipe } from "@bitwarden/ui-common";
 
 export type LineItem = {
   quantity: number;
@@ -18,15 +19,13 @@ export type LineItem = {
 @Component({
   selector: "billing-cart-summary",
   templateUrl: "./cart-summary.component.html",
-  imports: [TypographyModule, CurrencyPipe],
+  imports: [TypographyModule, CurrencyPipe, I18nPipe],
 })
 export class CartSummaryComponent {
   // Required inputs
   passwordManager = input.required<LineItem>();
-  additionalStorage = input<LineItem | undefined>(undefined);
-  secretsManager = input<{ seats: LineItem; additionalServiceAccounts?: LineItem } | undefined>(
-    undefined,
-  );
+  additionalStorage = input<LineItem>();
+  secretsManager = input<{ seats: LineItem; additionalServiceAccounts?: LineItem }>();
   estimatedTax = input.required<number>();
 
   // UI state
@@ -36,8 +35,7 @@ export class CartSummaryComponent {
    * Calculates total for password manager line item
    */
   readonly passwordManagerTotal = computed<number>(() => {
-    const pm = this.passwordManager();
-    return pm ? pm.quantity * pm.cost : 0;
+    return this.passwordManager().quantity * this.passwordManager().cost;
   });
 
   /**
@@ -59,7 +57,7 @@ export class CartSummaryComponent {
   /**
    * Calculates total for secrets manager service accounts if present
    */
-  readonly secretsManagerServiceAccountsTotal = computed<number>(() => {
+  readonly additionalServiceAccountsTotal = computed<number>(() => {
     const sm = this.secretsManager();
     return sm?.additionalServiceAccounts
       ? sm.additionalServiceAccounts.quantity * sm.additionalServiceAccounts.cost
@@ -87,7 +85,7 @@ export class CartSummaryComponent {
       this.passwordManagerTotal() +
       this.additionalStorageTotal() +
       this.secretsManagerSeatsTotal() +
-      this.secretsManagerServiceAccountsTotal() +
+      this.additionalServiceAccountsTotal() +
       this.estimatedTax()
     );
   }

--- a/libs/pricing/src/index.ts
+++ b/libs/pricing/src/index.ts
@@ -1,2 +1,3 @@
 // Components
 export * from "./components/pricing-card/pricing-card.component";
+export * from "./components/cart-summary/cart-summary.component";


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-24982
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR Adds a new cart summary component to the pricing library.

This component provides a reusable way to display order summary information, including line items for password manager, additional storage, and secrets manager, along with estimated tax and total cost. It includes a collapsible interface to toggle between a summary view and a detailed view of the cart items. Also includes storybook stories and documentation for the new component.

- 📓  Has a description of the change
- ✏️ Has tests
- 📝 Has documentation
- 📚  Has a story in storybook

🖌️ Design Note: I don't currently have access to Figma or the component just yet, so some things may be off a bit.
## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/59d7a418-002f-4395-a09d-02119452886f



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
