### PR TITLE
[PM-20034] Add missing translations for missing website banner

### DIFF
--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -3839,6 +3839,12 @@
   "changeAtRiskPassword": {
     "message": "Change at-risk password"
   },
+  "changeAtRiskPasswordAndAddWebsite": {
+    "message": "This login is at-risk and missing a website. Add a website and change the password for stronger security."
+  },
+  "missingWebsite": {
+    "message": "Missing website"
+  },
   "cannotRemoveViewOnlyCollections": {
     "message": "You cannot remove collections with View only permissions: $COLLECTIONS$",
     "placeholders": {

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -10900,6 +10900,12 @@
   "changeAtRiskPassword": {
     "message": "Change at-risk password"
   },
+  "changeAtRiskPasswordAndAddWebsite": {
+    "message": "This login is at-risk and missing a website. Add a website and change the password for stronger security."
+  },
+  "missingWebsite": {
+    "message": "Missing website"
+  },
   "removeUnlockWithPinPolicyTitle": {
     "message": "Remove Unlock with PIN"
   },
@@ -11240,4 +11246,3 @@
     "message": "Confirm Key Connector domain"
   }
 }
-


### PR DESCRIPTION
## 🎟️ Tracking

[PM-20034](https://bitwarden.atlassian.net/browse/PM-20034)

## 📔 Objective

Translations were missed for banner on Web & Desktop in https://github.com/bitwarden/clients/pull/16206, adding them here.

## 📸 Screenshots

|Browser|Web|Desktop|
|-|-|-|
|<img width="383" height="603" alt="Screenshot 2025-09-08 at 2 27 49 PM" src="https://github.com/user-attachments/assets/d803c978-e59c-4332-9fcf-c563d3a701f3" />|<img width="748" height="731" alt="Screenshot 2025-09-08 at 2 27 41 PM" src="https://github.com/user-attachments/assets/20ac89d1-5573-43a8-8d3a-ceb42065ce03" />|<img width="1559" height="1078" alt="Screenshot 2025-09-08 at 2 28 03 PM" src="https://github.com/user-attachments/assets/65abffab-7202-49ec-b43e-e053e53f1e06" />|

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-20034]: https://bitwarden.atlassian.net/browse/PM-20034?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ