### PR TITLE
[PM-23593] Show correct icon when email verification not required

### DIFF
--- a/libs/auth/src/angular/registration/registration-start/registration-start.component.ts
+++ b/libs/auth/src/angular/registration/registration-start/registration-start.component.ts
@@ -161,6 +161,7 @@ export class RegistrationStartComponent implements OnInit, OnDestroy {
       await this.router.navigate(["/finish-signup"], {
         queryParams: { token: result, email: this.email.value },
       });
+      return;
     }
 
     // Result is null, so email verification is required


### PR DESCRIPTION
## 🎟️ Tracking

[PM-23593](https://bitwarden.atlassian.net/browse/PM-23593)

## 📔 Objective

During account creation, when the environment does not require email verification, shows the correct icon (Lock Icon) on the `/finish-signup` page.

The early `return` prevents code from continuing after the navigation and setting `this.state = RegistrationStartState.CHECK_EMAIL`

## 📸 Screenshots

https://github.com/user-attachments/assets/2fb2fa22-3afd-4f67-b5e3-6e89bf0eba38

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-23593]: https://bitwarden.atlassian.net/browse/PM-23593?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ