### PR TITLE
[PM-25600] Fix issue with import format selector

### DIFF
--- a/libs/importer/src/components/import.component.ts
+++ b/libs/importer/src/components/import.component.ts
@@ -259,7 +259,7 @@ export class ImportComponent implements OnInit, OnDestroy, AfterViewInit {
 
           // when an importer is defined, the loader needs to be set to a value from
           // its list.
-          const loader = importer.loaders.includes(Loader.chromium)
+          const loader = importer.loaders?.includes(Loader.chromium)
             ? Loader.chromium
             : importer.loaders?.[0];
           this.formGroup.controls.chromiumLoader.setValue(loader ?? Loader.file);


### PR DESCRIPTION
## 🎟️ Tracking
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-25600

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Addresses an issue when selecting an import format (non-chromium) when the use-chromium-importer feature flag is enabled

```
Unhandled error in angular TypeError: Cannot read properties of undefined (reading 'includes')
    at Object.next (import.component.ts:263:43)
    at ConsumerObserver.next (Subscriber.ts:161:25)
    at Subscriber._next (Subscriber.ts:119:22)
    at Subscriber.next (Subscriber.ts:75:12)
    at map.ts:58:20
    at OperatorSubscriber._this._next (OperatorSubscriber.ts:70:13)
    at Subscriber.next (Subscriber.ts:75:12)
    at combineLatest.ts:272:34
    at OperatorSubscriber._this._next (OperatorSubscriber.ts:70:13)
    at Subscriber.next (Subscriber.ts:75:12)
```

was logged on the console, as the existing import formats have not been defined in the `importers.ts`-file which describes their capabilities. A fallback is added in the `import.component` to always show the `Loaders.File`-option (upload file or paste into field), but it errors out beforehand. It’s [checking if the loaders include chromium](https://github.com/bitwarden/clients/blob/main/libs/importer/src/components/import.component.ts#L262) loaders, but fails as loaders is undefined.

Will be 🍒 ⛏️  to `rc`

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
