### PR TITLE
[CL-95] loading spinner

### DIFF
--- a/libs/components/src/async-actions/in-forms.stories.ts
+++ b/libs/components/src/async-actions/in-forms.stories.ts
@@ -148,6 +148,7 @@ export default {
               required: "required",
               inputRequired: "Input is required.",
               inputEmail: "Input is not an email-address.",
+              loading: "Loading",
             });
           },
         },

--- a/libs/components/src/async-actions/standalone.stories.ts
+++ b/libs/components/src/async-actions/standalone.stories.ts
@@ -3,11 +3,13 @@ import { action } from "@storybook/addon-actions";
 import { Meta, StoryObj, moduleMetadata } from "@storybook/angular";
 import { delay, of } from "rxjs";
 
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { ValidationService } from "@bitwarden/common/platform/abstractions/validation.service";
 
 import { ButtonModule } from "../button";
 import { IconButtonModule } from "../icon-button";
+import { I18nMockService } from "../utils";
 
 import { AsyncActionsModule } from "./async-actions.module";
 import { BitActionDirective } from "./bit-action.directive";
@@ -102,6 +104,14 @@ export default {
           useValue: {
             error: action("LogService.error"),
           } as Partial<LogService>,
+        },
+        {
+          provide: I18nService,
+          useFactory: () => {
+            return new I18nMockService({
+              loading: "Loading",
+            });
+          },
         },
       ],
     }),

--- a/libs/components/src/banner/banner.stories.ts
+++ b/libs/components/src/banner/banner.stories.ts
@@ -22,6 +22,7 @@ export default {
           useFactory: () => {
             return new I18nMockService({
               close: "Close",
+              loading: "Loading",
             });
           },
         },

--- a/libs/components/src/breadcrumbs/breadcrumbs.stories.ts
+++ b/libs/components/src/breadcrumbs/breadcrumbs.stories.ts
@@ -35,6 +35,7 @@ export default {
           useFactory: () => {
             return new I18nMockService({
               moreBreadcrumbs: "More breadcrumbs",
+              loading: "Loading",
             });
           },
         },

--- a/libs/components/src/button/button.component.html
+++ b/libs/components/src/button/button.component.html
@@ -6,6 +6,6 @@
     class="tw-absolute tw-inset-0 tw-flex tw-items-center tw-justify-center"
     [ngClass]="{ 'tw-invisible': !showLoadingStyle() }"
   >
-    <i class="bwi bwi-spinner bwi-lg bwi-spin" aria-hidden="true"></i>
+    <bit-spinner size="fill" noColor></bit-spinner>
   </span>
 </span>

--- a/libs/components/src/button/button.component.ts
+++ b/libs/components/src/button/button.component.ts
@@ -14,6 +14,7 @@ import { debounce, interval } from "rxjs";
 
 import { AriaDisableDirective } from "../a11y";
 import { ButtonLikeAbstraction, ButtonType, ButtonSize } from "../shared/button-like.abstraction";
+import { SpinnerComponent } from "../spinner";
 import { ariaDisableElement } from "../utils";
 
 const focusRing = [
@@ -60,7 +61,7 @@ const buttonStyles: Record<ButtonType, string[]> = {
   selector: "button[bitButton], a[bitButton]",
   templateUrl: "button.component.html",
   providers: [{ provide: ButtonLikeAbstraction, useExisting: ButtonComponent }],
-  imports: [NgClass],
+  imports: [NgClass, SpinnerComponent],
   hostDirectives: [AriaDisableDirective],
 })
 export class ButtonComponent implements ButtonLikeAbstraction {

--- a/libs/components/src/button/button.stories.ts
+++ b/libs/components/src/button/button.stories.ts
@@ -1,12 +1,28 @@
-import { Meta, StoryObj } from "@storybook/angular";
+import { Meta, moduleMetadata, StoryObj } from "@storybook/angular";
+
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 
 import { formatArgsForCodeSnippet } from "../../../../.storybook/format-args-for-code-snippet";
+import { I18nMockService } from "../utils/i18n-mock.service";
 
 import { ButtonComponent } from "./button.component";
 
 export default {
   title: "Component Library/Button",
   component: ButtonComponent,
+  decorators: [
+    moduleMetadata({
+      providers: [
+        {
+          provide: I18nService,
+          useFactory: () =>
+            new I18nMockService({
+              loading: "Loading",
+            }),
+        },
+      ],
+    }),
+  ],
   args: {
     disabled: false,
     loading: false,

--- a/libs/components/src/dialog/dialog/dialog.component.html
+++ b/libs/components/src/dialog/dialog/dialog.component.html
@@ -52,7 +52,7 @@
   >
     @if (loading()) {
       <div class="tw-absolute tw-flex tw-size-full tw-items-center tw-justify-center">
-        <i class="bwi bwi-spinner bwi-spin bwi-lg" [attr.aria-label]="'loading' | i18n"></i>
+        <bit-spinner></bit-spinner>
       </div>
     }
     <div

--- a/libs/components/src/dialog/dialog/dialog.component.ts
+++ b/libs/components/src/dialog/dialog/dialog.component.ts
@@ -14,6 +14,7 @@ import {
 import { I18nPipe } from "@bitwarden/ui-common";
 
 import { BitIconButtonComponent } from "../../icon-button/icon-button.component";
+import { SpinnerComponent } from "../../spinner";
 import { TypographyDirective } from "../../typography/typography.directive";
 import { hasScrolledFrom } from "../../utils/has-scrolled-from";
 import { fadeIn } from "../animations";
@@ -37,6 +38,7 @@ import { DialogTitleContainerDirective } from "../directives/dialog-title-contai
     I18nPipe,
     CdkTrapFocus,
     CdkScrollable,
+    SpinnerComponent,
   ],
 })
 export class DialogComponent implements AfterViewInit {

--- a/libs/components/src/dialog/simple-dialog/simple-dialog.stories.ts
+++ b/libs/components/src/dialog/simple-dialog/simple-dialog.stories.ts
@@ -1,7 +1,10 @@
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
 import { Meta, moduleMetadata, StoryObj } from "@storybook/angular";
 
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+
 import { ButtonModule } from "../../button";
+import { I18nMockService } from "../../utils";
 import { DialogModule } from "../dialog.module";
 
 import { SimpleDialogComponent } from "./simple-dialog.component";
@@ -12,6 +15,16 @@ export default {
   decorators: [
     moduleMetadata({
       imports: [ButtonModule, NoopAnimationsModule, DialogModule],
+      providers: [
+        {
+          provide: I18nService,
+          useFactory: () => {
+            return new I18nMockService({
+              loading: "Loading",
+            });
+          },
+        },
+      ],
     }),
   ],
   parameters: {

--- a/libs/components/src/form-field/password-input-toggle.stories.ts
+++ b/libs/components/src/form-field/password-input-toggle.stories.ts
@@ -19,7 +19,10 @@ export default {
       providers: [
         {
           provide: I18nService,
-          useValue: new I18nMockService({ toggleVisibility: "Toggle visibility" }),
+          useValue: new I18nMockService({
+            toggleVisibility: "Toggle visibility",
+            loading: "Loading",
+          }),
         },
       ],
     }),

--- a/libs/components/src/icon-button/icon-button.component.html
+++ b/libs/components/src/icon-button/icon-button.component.html
@@ -6,10 +6,6 @@
     class="tw-absolute tw-inset-0 tw-flex tw-items-center tw-justify-center"
     [ngClass]="{ 'tw-invisible': !showLoadingStyle() }"
   >
-    <i
-      class="bwi bwi-spinner bwi-spin"
-      aria-hidden="true"
-      [ngClass]="{ 'bwi-lg': size() === 'default' }"
-    ></i>
+    <bit-spinner size="fill" noColor></bit-spinner>
   </span>
 </span>

--- a/libs/components/src/icon-button/icon-button.component.ts
+++ b/libs/components/src/icon-button/icon-button.component.ts
@@ -16,6 +16,7 @@ import { AriaDisableDirective } from "../a11y";
 import { setA11yTitleAndAriaLabel } from "../a11y/set-a11y-title-and-aria-label";
 import { ButtonLikeAbstraction } from "../shared/button-like.abstraction";
 import { FocusableElement } from "../shared/focusable-element";
+import { SpinnerComponent } from "../spinner";
 import { ariaDisableElement } from "../utils";
 
 export type IconButtonType = "primary" | "danger" | "contrast" | "main" | "muted" | "nav-contrast";
@@ -87,7 +88,7 @@ const sizes: Record<IconButtonSize, string[]> = {
     { provide: ButtonLikeAbstraction, useExisting: BitIconButtonComponent },
     { provide: FocusableElement, useExisting: BitIconButtonComponent },
   ],
-  imports: [NgClass],
+  imports: [NgClass, SpinnerComponent],
   host: {
     /**
      * When the `bitIconButton` input is dynamic from a consumer, Angular doesn't put the

--- a/libs/components/src/icon-button/icon-button.stories.ts
+++ b/libs/components/src/icon-button/icon-button.stories.ts
@@ -1,12 +1,29 @@
-import { Meta, StoryObj } from "@storybook/angular";
+import { Meta, moduleMetadata, StoryObj } from "@storybook/angular";
+
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 
 import { formatArgsForCodeSnippet } from "../../../../.storybook/format-args-for-code-snippet";
+import { I18nMockService } from "../utils";
 
 import { BitIconButtonComponent } from "./icon-button.component";
 
 export default {
   title: "Component Library/Icon Button",
   component: BitIconButtonComponent,
+  decorators: [
+    moduleMetadata({
+      providers: [
+        {
+          provide: I18nService,
+          useFactory: () => {
+            return new I18nMockService({
+              loading: "Loading",
+            });
+          },
+        },
+      ],
+    }),
+  ],
   args: {
     bitIconButton: "bwi-plus",
     label: "Your button label here",

--- a/libs/components/src/menu/menu.stories.ts
+++ b/libs/components/src/menu/menu.stories.ts
@@ -1,7 +1,10 @@
 import { OverlayModule } from "@angular/cdk/overlay";
 import { Meta, StoryObj, moduleMetadata } from "@storybook/angular";
 
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+
 import { ButtonModule } from "../button/button.module";
+import { I18nMockService } from "../utils";
 
 import { MenuTriggerForDirective } from "./menu-trigger-for.directive";
 import { MenuModule } from "./menu.module";
@@ -12,6 +15,12 @@ export default {
   decorators: [
     moduleMetadata({
       imports: [MenuModule, OverlayModule, ButtonModule],
+      providers: [
+        {
+          provide: I18nService,
+          useValue: new I18nMockService({ loading: "Loading" }),
+        },
+      ],
     }),
   ],
   parameters: {

--- a/libs/components/src/multi-select/multi-select.component.html
+++ b/libs/components/src/multi-select/multi-select.component.html
@@ -20,7 +20,7 @@
   appendTo="body"
 >
   <ng-template ng-loadingspinner-tmp>
-    <i class="bwi bwi-spinner bwi-spin tw-me-1" [title]="loadingText" aria-hidden="true"></i>
+    <bit-spinner></bit-spinner>
   </ng-template>
   <ng-template ng-label-tmp let-item="item" let-clear="clear">
     <button

--- a/libs/components/src/multi-select/multi-select.component.ts
+++ b/libs/components/src/multi-select/multi-select.component.ts
@@ -27,6 +27,7 @@ import { I18nPipe } from "@bitwarden/ui-common";
 
 import { BadgeModule } from "../badge";
 import { BitFormFieldControl } from "../form-field/form-field-control";
+import { SpinnerComponent } from "../spinner";
 
 import { SelectItemView } from "./models/select-item-view";
 
@@ -37,7 +38,14 @@ let nextId = 0;
   selector: "bit-multi-select",
   templateUrl: "./multi-select.component.html",
   providers: [{ provide: BitFormFieldControl, useExisting: MultiSelectComponent }],
-  imports: [NgSelectModule, ReactiveFormsModule, FormsModule, BadgeModule, I18nPipe],
+  imports: [
+    NgSelectModule,
+    ReactiveFormsModule,
+    FormsModule,
+    BadgeModule,
+    I18nPipe,
+    SpinnerComponent,
+  ],
   host: {
     "[id]": "this.id()",
   },

--- a/libs/components/src/no-items/no-items.stories.ts
+++ b/libs/components/src/no-items/no-items.stories.ts
@@ -1,6 +1,9 @@
 import { Meta, StoryObj, moduleMetadata } from "@storybook/angular";
 
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+
 import { ButtonModule } from "../button";
+import { I18nMockService } from "../utils";
 
 import { NoItemsComponent } from "./no-items.component";
 import { NoItemsModule } from "./no-items.module";
@@ -11,6 +14,12 @@ export default {
   decorators: [
     moduleMetadata({
       imports: [ButtonModule, NoItemsModule],
+      providers: [
+        {
+          provide: I18nService,
+          useValue: new I18nMockService({ loading: "Loading" }),
+        },
+      ],
     }),
   ],
   parameters: {

--- a/libs/components/src/section/section.stories.ts
+++ b/libs/components/src/section/section.stories.ts
@@ -1,9 +1,12 @@
 import { Meta, StoryObj, componentWrapperDecorator, moduleMetadata } from "@storybook/angular";
 
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+
 import { CardComponent } from "../card";
 import { IconButtonModule } from "../icon-button";
 import { ItemModule } from "../item";
 import { TypographyModule } from "../typography";
+import { I18nMockService } from "../utils";
 
 import { SectionComponent, SectionHeaderComponent } from "./";
 
@@ -18,6 +21,12 @@ export default {
         CardComponent,
         IconButtonModule,
         ItemModule,
+      ],
+      providers: [
+        {
+          provide: I18nService,
+          useValue: new I18nMockService({ loading: "Loading" }),
+        },
       ],
     }),
     componentWrapperDecorator((story) => `<div class="tw-text-main">${story}</div>`),

--- a/libs/components/src/spinner/index.ts
+++ b/libs/components/src/spinner/index.ts
@@ -1,0 +1,1 @@
+export * from "./spinner.component";

--- a/libs/components/src/spinner/spinner.component.html
+++ b/libs/components/src/spinner/spinner.component.html
@@ -1,9 +1,8 @@
-<!-- TODO: CL-30 Remove tw-align-inherit once bootstrap is removed. -->
 <svg
   xmlns="http://www.w3.org/2000/svg"
   viewBox="0 0 56 56"
   fill="none"
-  class="tw-h-full tw-w-full tw-animate-spin tw-align-[inherit]"
+  class="tw-size-full tw-animate-spin"
   aria-hidden="true"
 >
   <circle

--- a/libs/components/src/spinner/spinner.component.html
+++ b/libs/components/src/spinner/spinner.component.html
@@ -1,0 +1,20 @@
+<!-- TODO: CL-30 Remove tw-align-inherit once bootstrap is removed. -->
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 56 56"
+  fill="none"
+  class="tw-h-full tw-w-full tw-animate-spin tw-align-[inherit]"
+  aria-hidden="true"
+>
+  <circle
+    cx="28"
+    cy="28"
+    r="23"
+    stroke="currentColor"
+    pathLength="4"
+    stroke-width="5"
+    stroke-dasharray="1 3"
+  ></circle>
+  <circle cx="28" cy="28" r="23" stroke="currentColor" stroke-width="5" opacity="0.4"></circle>
+</svg>
+<span class="tw-sr-only" *ngIf="sr">{{ title }}</span>

--- a/libs/components/src/spinner/spinner.component.ts
+++ b/libs/components/src/spinner/spinner.component.ts
@@ -1,0 +1,51 @@
+import { CommonModule } from "@angular/common";
+import { Component, HostBinding, Input, booleanAttribute } from "@angular/core";
+
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+
+@Component({
+  selector: "bit-spinner",
+  templateUrl: "spinner.component.html",
+  standalone: true,
+  imports: [CommonModule],
+})
+export class SpinnerComponent {
+  /**
+   * The size of the spinner. Defaults to `large`.
+   */
+  @Input() size: "fill" | "small" | "large" = "large";
+
+  /**
+   * Disable the default color of the spinner, inherits the text color.
+   */
+  @Input({ transform: booleanAttribute }) noColor = false;
+
+  /**
+   * Accessibility title. Defaults to `Loading`.
+   */
+  @Input() title = this.i18nService.t("loading");
+
+  /**
+   * Display text for screen readers.
+   */
+  @Input({ transform: booleanAttribute }) sr = true;
+
+  @HostBinding("class") get classList() {
+    return ["tw-inline-block", "tw-overflow-hidden"]
+      .concat(this.sizeClass)
+      .concat([this.noColor ? null : "tw-text-primary-600"]);
+  }
+
+  constructor(private i18nService: I18nService) {}
+
+  get sizeClass() {
+    switch (this.size) {
+      case "small":
+        return ["tw-h-4"];
+      case "large":
+        return ["tw-h-16"];
+      default:
+        return ["tw-h-full", "tw-w-full"];
+    }
+  }
+}

--- a/libs/components/src/spinner/spinner.component.ts
+++ b/libs/components/src/spinner/spinner.component.ts
@@ -31,7 +31,7 @@ export class SpinnerComponent {
   @Input({ transform: booleanAttribute }) sr = true;
 
   @HostBinding("class") get classList() {
-    return ["tw-inline-block", "tw-overflow-hidden"]
+    return ["tw-inline-block", "tw-overflow-hidden", "tw-flex", "tw-items-center"]
       .concat(this.sizeClass)
       .concat([this.noColor ? null : "tw-text-primary-600"]);
   }

--- a/libs/components/src/spinner/spinner.stories.ts
+++ b/libs/components/src/spinner/spinner.stories.ts
@@ -1,0 +1,53 @@
+import { CommonModule } from "@angular/common";
+import { Meta, moduleMetadata, StoryObj } from "@storybook/angular";
+
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+
+import { I18nMockService } from "../utils";
+
+import { SpinnerComponent } from "./spinner.component";
+
+export default {
+  title: "Component Library/Spinner",
+  component: SpinnerComponent,
+  decorators: [
+    moduleMetadata({
+      imports: [CommonModule],
+      providers: [
+        {
+          provide: I18nService,
+          useFactory: () => {
+            return new I18nMockService({
+              loading: "Loading",
+            });
+          },
+        },
+      ],
+      declarations: [],
+    }),
+  ],
+  parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/file/Zt3YSeb6E6lebAffrNLa0h/Tailwind-Component-Library?node-id=1881%3A16956",
+    },
+  },
+} as Meta;
+
+type Story = StoryObj<SpinnerComponent>;
+
+export const Default: Story = {
+  args: {},
+};
+
+export const Fill: Story = {
+  args: {
+    size: "fill",
+  },
+};
+
+export const Small: Story = {
+  args: {
+    size: "small",
+  },
+};

--- a/libs/components/src/stories/kitchen-sink/components/kitchen-sink-form.component.ts
+++ b/libs/components/src/stories/kitchen-sink/components/kitchen-sink-form.component.ts
@@ -23,6 +23,7 @@ import { KitchenSinkSharedModule } from "../kitchen-sink-shared.module";
           inputMaxValue: (max) => `Input value must not exceed ${max}.`,
           inputMinValue: (min) => `Input value must be at least ${min}.`,
           inputRequired: "Input is required.",
+          loading: "Loading",
           multiSelectClearAll: "Clear all",
           multiSelectLoading: "Retrieving options...",
           multiSelectNotFound: "No items found",

--- a/libs/components/src/stories/kitchen-sink/kitchen-sink.stories.ts
+++ b/libs/components/src/stories/kitchen-sink/kitchen-sink.stories.ts
@@ -64,6 +64,7 @@ export default {
               toggleSideNavigation: "Toggle side navigation",
               yes: "Yes",
               no: "No",
+              loading: "Loading",
             });
           },
         },

--- a/libs/components/src/tabs/tabs.stories.ts
+++ b/libs/components/src/tabs/tabs.stories.ts
@@ -3,8 +3,11 @@ import { Component, importProvidersFrom } from "@angular/core";
 import { RouterModule } from "@angular/router";
 import { applicationConfig, Meta, moduleMetadata, StoryObj } from "@storybook/angular";
 
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+
 import { ButtonModule } from "../button";
 import { FormFieldModule } from "../form-field";
+import { I18nMockService } from "../utils";
 
 import { TabGroupComponent } from "./tab-group/tab-group.component";
 import { TabsModule } from "./tabs.module";
@@ -55,6 +58,12 @@ export default {
         ItemThreeDummyComponent,
         ItemWithChildCounterDummyComponent,
         DisabledDummyComponent,
+      ],
+      providers: [
+        {
+          provide: I18nService,
+          useValue: new I18nMockService({ loading: "Loading" }),
+        },
       ],
     }),
     applicationConfig({


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/CL-95

## 📔 Objective

- Add a new loading spinner component
- Apply loading spinner to CL components where previous icon font spinner was used

## 📸 Screenshots
### Spinner
<img width="765" height="155" alt="image" src="https://github.com/user-attachments/assets/7514d268-f352-41dd-97ef-9c59122af1a8" />

### Loading button
<img width="171" height="129" alt="image" src="https://github.com/user-attachments/assets/dab0b0b9-92df-47c6-95c6-e098559624bf" />

### Loading Dialog
<img width="756" height="416" alt="image" src="https://github.com/user-attachments/assets/024bcd33-a9c0-40b7-a699-e5de9907ef66" />

### Loading Icon button
<img width="141" height="120" alt="image" src="https://github.com/user-attachments/assets/6e3aa5e8-7483-4ff4-a2b3-6c4cda4f6a31" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
