### PR TITLE
[PM-24935] - [Desktop] Fix loading state in cipher form save button

### DIFF
--- a/apps/desktop/src/vault/app/vault/item-footer.component.html
+++ b/apps/desktop/src/vault/app/vault/item-footer.component.html
@@ -4,16 +4,12 @@
       #submitBtn
       form="cipherForm"
       type="submit"
-      *ngIf="action !== 'view'"
+      [hidden]="action === 'view'"
+      bitButton
       class="primary"
       appA11yTitle="{{ 'save' | i18n }}"
     >
-      <span [hidden]="isSubmitting">{{ "save" | i18n }}</span>
-      <i
-        class="bwi bwi-spinner bwi-spin bwi-lg bwi-fw"
-        [hidden]="!isSubmitting"
-        aria-hidden="true"
-      ></i>
+      {{ "save" | i18n }}
     </button>
     <button
       type="button"

--- a/apps/desktop/src/vault/app/vault/item-footer.component.ts
+++ b/apps/desktop/src/vault/app/vault/item-footer.component.ts
@@ -24,7 +24,6 @@ export class ItemFooterComponent implements OnInit {
   @Input({ required: true }) cipher: CipherView = new CipherView();
   @Input() collectionId: string | null = null;
   @Input({ required: true }) action: string = "view";
-  @Input() isSubmitting: boolean = false;
   @Input() masterPasswordAlreadyPrompted: boolean = false;
   @Output() onEdit = new EventEmitter<CipherView>();
   @Output() onClone = new EventEmitter<CipherView>();

--- a/apps/desktop/src/vault/app/vault/vault-v2.component.html
+++ b/apps/desktop/src/vault/app/vault/vault-v2.component.html
@@ -32,7 +32,6 @@
             formId="cipherForm"
             [config]="config"
             (cipherSaved)="savedCipher($event)"
-            [beforeSubmit]="onSubmit"
             [submitBtn]="footer?.submitBtn"
             (formStatusChange$)="formStatusChanged($event)"
           >

--- a/apps/desktop/src/vault/app/vault/vault-v2.component.html
+++ b/apps/desktop/src/vault/app/vault/vault-v2.component.html
@@ -19,7 +19,6 @@
       (onClone)="cloneCipher($event)"
       (onDelete)="deleteCipher()"
       (onCancel)="cancelCipher($event)"
-      [isSubmitting]="isSubmitting"
       [masterPasswordAlreadyPrompted]="cipherRepromptId === cipherId"
     ></app-vault-item-footer>
     <div class="content">

--- a/apps/desktop/src/vault/app/vault/vault-v2.component.ts
+++ b/apps/desktop/src/vault/app/vault/vault-v2.component.ts
@@ -161,7 +161,6 @@ export class VaultV2Component<C extends CipherViewLike>
   cipher: CipherView | null = new CipherView();
   collections: CollectionView[] | null = null;
   config: CipherFormConfig | null = null;
-  isSubmitting = false;
 
   /** Tracks the disabled status of the edit cipher form */
   protected formDisabled: boolean = false;
@@ -741,7 +740,6 @@ export class VaultV2Component<C extends CipherViewLike>
     await this.vaultItemsComponent?.load(this.activeFilter.buildFilter()).catch(() => {});
     await this.go().catch(() => {});
     await this.vaultItemsComponent?.refresh().catch(() => {});
-    this.isSubmitting = false;
   }
 
   async deleteCipher() {
@@ -916,11 +914,6 @@ export class VaultV2Component<C extends CipherViewLike>
       this.changeDetectorRef.detectChanges();
     });
   }
-
-  protected onSubmit = async () => {
-    this.isSubmitting = true;
-    return Promise.resolve(true);
-  };
 
   private prefillCipherFromFilter() {
     if (this.activeFilter.selectedCollectionId != null && this.vaultFilterComponent != null) {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-24935

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR fixes an issue where the desktop cipher form button wasn't properly handling error state on save. The solution was to simply allow the cipher form to handle loading state as it is already set up to do so. This allowed us to remove some redundant loading state code in the desktop vault.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/2f9bd18a-cfb0-4876-bf61-2a9f18d6a8e0


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
