### PR TITLE
[PM-25634] Bugfix - Cannot update new credentials with MP reprompt on Firefox

### DIFF
--- a/apps/browser/src/vault/popup/components/vault-v2/view-v2/view-v2.component.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/view-v2/view-v2.component.ts
@@ -329,8 +329,9 @@ export class ViewV2Component {
       case UPDATE_PASSWORD: {
         const repromptSuccess = await this.passwordRepromptService.showPasswordPrompt();
 
+        const tab = await BrowserApi.getTab(senderTabId);
         await sendExtensionMessage("bgHandleReprompt", {
-          tab: await chrome.tabs.get(senderTabId),
+          tab,
           success: repromptSuccess,
         });
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-25634](https://bitwarden.atlassian.net/browse/PM-25634)

## 📔 Objective

- Login on Extension on Firefox
- Have a login for a website that has MP reprompt enabled
- Navigate to website
- Autofill login
- Change filled PW before submitting
- Submit form
- Click Update from Notification Bar
- Enter MP on new popup

Expected: Popup is dismissed, creds updated, notification bar switches to let me know creds have been updated

Actual: Popup hangs, creds not updated, notification bar not updated

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-25634]: https://bitwarden.atlassian.net/browse/PM-25634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ