### PR TITLE
[PM-25225] - [browser] - fix vault list items attachment icon placement

### DIFF
--- a/apps/browser/src/vault/popup/components/vault-v2/vault-list-items-container/vault-list-items-container.component.html
+++ b/apps/browser/src/vault/popup/components/vault-v2/vault-list-items-container/vault-list-items-container.component.html
@@ -106,19 +106,21 @@
               <app-vault-icon [cipher]="cipher"></app-vault-icon>
             </div>
             <span data-testid="item-name">{{ cipher.name }}</span>
-            <i
-              *ngIf="cipher.organizationId"
-              slot="default-trailing"
-              appOrgIcon
-              [tierType]="cipher.organization!.productTierType"
-              [size]="'small'"
-              [appA11yTitle]="orgIconTooltip(cipher)"
-            ></i>
-            <i
-              *ngIf="CipherViewLikeUtils.hasAttachments(cipher)"
-              class="bwi bwi-paperclip bwi-sm"
-              [appA11yTitle]="'attachments' | i18n"
-            ></i>
+            <div slot="default-trailing" class="tw-flex tw-gap-1.5">
+              <i
+                *ngIf="cipher.organizationId"
+                slot="default-trailing"
+                appOrgIcon
+                [tierType]="cipher.organization!.productTierType"
+                [size]="'small'"
+                [appA11yTitle]="orgIconTooltip(cipher)"
+              ></i>
+              <i
+                *ngIf="CipherViewLikeUtils.hasAttachments(cipher)"
+                class="bwi bwi-paperclip bwi-sm"
+                [appA11yTitle]="'attachments' | i18n"
+              ></i>
+            </div>
             <span slot="secondary">{{ CipherViewLikeUtils.subtitle(cipher) }}</span>
           </button>
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-25225

Fixed [15568](https://github.com/bitwarden/clients/issues/15568)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR fixes an issue with attachment icon placement in the vault list in the browser extension. It ensures proper margin both on it's own and when alongside the org icon.

## 📸 Screenshots
<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
|Before|After|
---|---
|<img width="382" height="602" alt="Screenshot 2025-09-11 at 11 16 26 AM" src="https://github.com/user-attachments/assets/a14a0911-eab0-473d-80ef-f20e13e5aed1" />|<img width="395" height="601" alt="Screenshot 2025-09-11 at 10 53 43 AM" src="https://github.com/user-attachments/assets/3a537ae5-a90a-4a03-9a36-900777edc77d" />|


## ⏰ Reminders before review


- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
