### PR TITLE
[PM-925][Desktop] - Wrong default ownership when adding new item on account with multiple vaults

### DIFF
--- a/apps/desktop/src/vault/app/vault/vault-v2.component.ts
+++ b/apps/desktop/src/vault/app/vault/vault-v2.component.ts
@@ -926,17 +926,22 @@ export class VaultV2Component<C extends CipherViewLike>
       }
     } else if (this.activeFilter.selectedOrganizationId) {
       this.addOrganizationId = this.activeFilter.selectedOrganizationId;
+    } else {
+      // clear out organizationId when the user switches to a personal vault filter
+      this.addOrganizationId = null;
     }
     if (this.activeFilter.selectedFolderId && this.activeFilter.selectedFolder) {
       this.folderId = this.activeFilter.selectedFolderId;
     }
 
-    if (this.addOrganizationId && this.config) {
-      this.config.initialValues = {
-        ...this.config.initialValues,
-        organizationId: this.addOrganizationId as OrganizationId,
-      };
+    if (this.config == null) {
+      return;
     }
+
+    this.config.initialValues = {
+      ...this.config.initialValues,
+      organizationId: this.addOrganizationId as OrganizationId,
+    };
   }
 
   private async canNavigateAway(action: string, cipher?: CipherView) {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-925

Fixes #4217

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR fixes an issue in desktop where if a user adds a cipher from an org filter then switches to their personal vault filter and adds a cipher the form defaults the owner to the org. This was due to the `config.initialValues.organizationId` not being reset in `prefillCipherFromFilter`.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/62967b27-bad8-45ce-9f99-fd7a74f0017b


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
