### PR TITLE
[PM-25694] [Defect] Secrets manager + AC integrations page not listing any integrations

### DIFF
--- a/bitwarden_license/bit-web/src/app/secrets-manager/integrations/integrations.module.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/integrations/integrations.module.ts
@@ -1,6 +1,5 @@
 import { NgModule } from "@angular/core";
 
-
 import { HecOrganizationIntegrationService } from "@bitwarden/bit-common/dirt/organization-integrations/services/hec-organization-integration-service";
 import { OrganizationIntegrationApiService } from "@bitwarden/bit-common/dirt/organization-integrations/services/organization-integration-api.service";
 import { OrganizationIntegrationConfigurationApiService } from "@bitwarden/bit-common/dirt/organization-integrations/services/organization-integration-configuration-api.service";

--- a/bitwarden_license/bit-web/src/app/secrets-manager/integrations/integrations.module.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/integrations/integrations.module.ts
@@ -1,5 +1,12 @@
 import { NgModule } from "@angular/core";
 
+
+import { HecOrganizationIntegrationService } from "@bitwarden/bit-common/dirt/organization-integrations/services/hec-organization-integration-service";
+import { OrganizationIntegrationApiService } from "@bitwarden/bit-common/dirt/organization-integrations/services/organization-integration-api.service";
+import { OrganizationIntegrationConfigurationApiService } from "@bitwarden/bit-common/dirt/organization-integrations/services/organization-integration-configuration-api.service";
+import { ApiService } from "@bitwarden/common/abstractions/api.service";
+import { safeProvider } from "@bitwarden/ui-common";
+
 import { IntegrationCardComponent } from "../../dirt/organization-integrations/integration-card/integration-card.component";
 import { IntegrationGridComponent } from "../../dirt/organization-integrations/integration-grid/integration-grid.component";
 import { SecretsManagerSharedModule } from "../shared/sm-shared.module";
@@ -13,6 +20,23 @@ import { IntegrationsComponent } from "./integrations.component";
     IntegrationsRoutingModule,
     IntegrationCardComponent,
     IntegrationGridComponent,
+  ],
+  providers: [
+    safeProvider({
+      provide: HecOrganizationIntegrationService,
+      useClass: HecOrganizationIntegrationService,
+      deps: [OrganizationIntegrationApiService, OrganizationIntegrationConfigurationApiService],
+    }),
+    safeProvider({
+      provide: OrganizationIntegrationApiService,
+      useClass: OrganizationIntegrationApiService,
+      deps: [ApiService],
+    }),
+    safeProvider({
+      provide: OrganizationIntegrationConfigurationApiService,
+      useClass: OrganizationIntegrationConfigurationApiService,
+      deps: [ApiService],
+    }),
   ],
   declarations: [IntegrationsComponent],
 })


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-25694

## 📔 Objective

A change made to the integrations module in the admin module cause the integrations module to break in the Secrets manager module. This PR should fix it.

## 📸 Screenshots

<img width="3600" height="2212" alt="image" src="https://github.com/user-attachments/assets/1c1979cc-338e-4dfc-be87-ea3f512ce90f" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
