### PR TITLE
[PM-24633] - group same parent name collections by org

### DIFF
--- a/libs/admin-console/src/common/collections/services/default-collection.service.spec.ts
+++ b/libs/admin-console/src/common/collections/services/default-collection.service.spec.ts
@@ -369,6 +369,27 @@ describe("DefaultCollectionService", () => {
     });
   });
 
+  describe("groupByOrganization", () => {
+    it("groups collections by organization", () => {
+      const org1 = { organizationId: "org1" } as CollectionView;
+      org1.name = "Collection 1";
+
+      const org2 = { organizationId: "org1" } as CollectionView;
+      org2.name = "Collection 2";
+      const org3 = { organizationId: "org2" } as CollectionView;
+      org3.name = "Collection 3";
+      const collections = [org1, org2, org3];
+
+      const result = collectionService.groupByOrganization(collections);
+
+      expect(result.size).toBe(2);
+      expect(result.get(org1.organizationId)?.length).toBe(2);
+      expect(result.get(org1.organizationId)).toContainPartialObjects([org1, org2]);
+      expect(result.get(org3.organizationId)?.length).toBe(1);
+      expect(result.get(org3.organizationId)).toContainPartialObjects([org3]);
+    });
+  });
+
   const setEncryptedState = (collectionData: CollectionData[] | null) =>
     stateProvider.setUserState(
       ENCRYPTED_COLLECTION_DATA_KEY,

--- a/libs/admin-console/src/common/collections/services/default-collection.service.ts
+++ b/libs/admin-console/src/common/collections/services/default-collection.service.ts
@@ -214,13 +214,8 @@ export class DefaultCollectionService implements CollectionService {
   }
 
   // Transforms the input CollectionViews into TreeNodes
-  // ensures collections with same parent name from different orgs aren't grouped together
   getAllNested(collections: CollectionView[]): TreeNode<CollectionView>[] {
-    const groupedByOrg = new Map<string, CollectionView[]>();
-    collections.map((c) => {
-      const key = c.organizationId;
-      (groupedByOrg.get(key) ?? groupedByOrg.set(key, []).get(key)!).push(c);
-    });
+    const groupedByOrg = this.groupByOrganization(collections);
 
     const all: TreeNode<CollectionView>[] = [];
     for (const group of groupedByOrg.values()) {
@@ -233,6 +228,15 @@ export class DefaultCollectionService implements CollectionService {
       all.push(...nodes);
     }
     return all;
+  }
+
+  groupByOrganization(collections: CollectionView[]): Map<string, CollectionView[]> {
+    const groupedByOrg = new Map<string, CollectionView[]>();
+    collections.map((c) => {
+      const key = c.organizationId;
+      (groupedByOrg.get(key) ?? groupedByOrg.set(key, []).get(key)!).push(c);
+    });
+    return groupedByOrg;
   }
 
   /**


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-24633

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR fixes an issue where nested collections from different orgs with the same parent name were being grouped under the same collection in the desktop filter. The solution was to first group the collections by org before nesting them.

Fixes https://github.com/bitwarden/clients/issues/15970

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
|Before|After|
---|---
|<img width="627" height="921" alt="Screenshot 2025-09-12 at 4 37 58 PM" src="https://github.com/user-attachments/assets/8d3007ec-c182-4cfa-93f3-19e79decd070" />|<img width="833" height="967" alt="Screenshot 2025-09-12 at 4 37 27 PM" src="https://github.com/user-attachments/assets/43ddce96-7168-48a8-8b53-7fd5346b3df0" />|


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
