### PR TITLE
PM-23906 Wrap sdk callsite with try/catch to handle errors appropriately

### DIFF
--- a/libs/importer/src/importers/bitwarden/bitwarden-password-protected-importer.spec.ts
+++ b/libs/importer/src/importers/bitwarden/bitwarden-password-protected-importer.spec.ts
@@ -136,5 +136,17 @@ describe("BitwardenPasswordProtectedImporter", () => {
       jDoc.data = null;
       expect((await importer.parse(JSON.stringify(jDoc))).success).toEqual(false);
     });
+
+    it("returns invalidFilePassword errorMessage if decryptString throws", async () => {
+      encryptService.decryptString.mockImplementation(() => {
+        throw new Error("SDK error");
+      });
+      i18nService.t.mockReturnValue("invalidFilePassword");
+
+      const result = await importer.parse(JSON.stringify(jDoc));
+
+      expect(result.success).toBe(false);
+      expect(result.errorMessage).toBe("invalidFilePassword");
+    });
   });
 });

--- a/libs/importer/src/importers/bitwarden/bitwarden-password-protected-importer.ts
+++ b/libs/importer/src/importers/bitwarden/bitwarden-password-protected-importer.ts
@@ -97,7 +97,6 @@ export class BitwardenPasswordProtectedImporter extends BitwardenJsonImporter im
       );
       return encKeyValidationDecrypt != null;
     } catch {
-      // sdk call throws if password is incorrect
       return false;
     }
   }

--- a/libs/importer/src/importers/bitwarden/bitwarden-password-protected-importer.ts
+++ b/libs/importer/src/importers/bitwarden/bitwarden-password-protected-importer.ts
@@ -91,11 +91,8 @@ export class BitwardenPasswordProtectedImporter extends BitwardenJsonImporter im
     const encKeyValidation = new EncString(jdoc.encKeyValidation_DO_NOT_EDIT);
 
     try {
-      const encKeyValidationDecrypt = await this.encryptService.decryptString(
-        encKeyValidation,
-        this.key,
-      );
-      return encKeyValidationDecrypt != null;
+      await this.encryptService.decryptString(encKeyValidation, this.key);
+      return true;
     } catch {
       return false;
     }

--- a/libs/importer/src/importers/bitwarden/bitwarden-password-protected-importer.ts
+++ b/libs/importer/src/importers/bitwarden/bitwarden-password-protected-importer.ts
@@ -90,14 +90,15 @@ export class BitwardenPasswordProtectedImporter extends BitwardenJsonImporter im
 
     const encKeyValidation = new EncString(jdoc.encKeyValidation_DO_NOT_EDIT);
 
-    const encKeyValidationDecrypt = await this.encryptService.decryptString(
-      encKeyValidation,
-      this.key,
-    );
-    if (encKeyValidationDecrypt === null) {
+    try {
+      const encKeyValidationDecrypt = await this.encryptService.decryptString(
+        encKeyValidation,
+        this.key,
+      );
+      return encKeyValidationDecrypt != null;
+    } catch {
       return false;
     }
-    return true;
   }
 
   private cannotParseFile(jdoc: BitwardenPasswordProtectedFileFormat): boolean {

--- a/libs/importer/src/importers/bitwarden/bitwarden-password-protected-importer.ts
+++ b/libs/importer/src/importers/bitwarden/bitwarden-password-protected-importer.ts
@@ -97,6 +97,7 @@ export class BitwardenPasswordProtectedImporter extends BitwardenJsonImporter im
       );
       return encKeyValidationDecrypt != null;
     } catch {
+      // sdk call throws if password is incorrect
       return false;
     }
   }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-23906

## 📔 Objective

### Description

When the user tries to import a password protected file entering the wrong password, then the error message The cipher's MAC doesn't match the expected value is displayed

### Replication steps

Log in to Bitwarden

Navigate to Tools > Export vault

Select Json Encrypted (Password protected)

Enter a password and save the export file 

Navigate to Tools > Import Data 

Import the file previously generated and enter the wrong password 

### Actual result:
The error message The cipher's MAC doesn't match the expected value is displayed

### Resolution: 

`encryptService.decryptString()` calls a method in the internal SDK which when provided an invalid key returns `CryptoError::InvalidMac`. The originating callsite has been wrapped in a try/catch in order to intercept the error and return false so that logic in `parse()` may return a more appropriate error message to the UI.

## 📸 Screenshots

<img width="535" height="296" alt="image" src="https://github.com/user-attachments/assets/4290433b-4af9-49de-b3ae-bc87a8f01fec" />


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
