### PR TITLE
Bug-9159 fix

### DIFF
--- a/libs/importer/src/importers/base-importer.spec.ts
+++ b/libs/importer/src/importers/base-importer.spec.ts
@@ -23,6 +23,10 @@ class FakeBaseImporter extends BaseImporter {
   processFolder(result: ImportResult, folderName: string, addRelationship: boolean = true): void {
     return super.processFolder(result, folderName, addRelationship);
   }
+
+  cleanupCipher(cipher: CipherView): void {
+    return super.cleanupCipher(cipher);
+  }
 }
 
 describe("processFolder method", () => {
@@ -283,6 +287,60 @@ describe("BaseImporter class", () => {
         </passwordsafe>`;
       const result = importer.parseXml(xml);
       expect(result).toBe(null);
+    });
+  });
+
+  describe("cleanupCipher method", () => {
+    beforeEach(() => {
+      cipher = importer.initLoginCipher();
+    });
+
+    it("should preserve leading and trailing spaces in notes", () => {
+      cipher.notes = "  This note has leading and trailing spaces  ";
+      importer.cleanupCipher(cipher);
+      expect(cipher.notes).toBe("  This note has leading and trailing spaces  ");
+    });
+
+    it("should preserve spaces in the middle of notes", () => {
+      cipher.notes = "This note has   multiple   spaces";
+      importer.cleanupCipher(cipher);
+      expect(cipher.notes).toBe("This note has   multiple   spaces");
+    });
+
+    it("should set notes to null if they contain only whitespace", () => {
+      cipher.notes = "   \t\n  ";
+      importer.cleanupCipher(cipher);
+      expect(cipher.notes).toBe(null);
+    });
+
+    it("should set notes to null if they are empty", () => {
+      cipher.notes = "";
+      importer.cleanupCipher(cipher);
+      expect(cipher.notes).toBe(null);
+    });
+
+    it("should set notes to null if they are null", () => {
+      cipher.notes = null;
+      importer.cleanupCipher(cipher);
+      expect(cipher.notes).toBe(null);
+    });
+
+    it("should preserve normal notes without spaces", () => {
+      cipher.notes = "This is a normal note";
+      importer.cleanupCipher(cipher);
+      expect(cipher.notes).toBe("This is a normal note");
+    });
+
+    it("should set name to '--' if it contains only whitespace", () => {
+      cipher.name = "   \t\n  ";
+      importer.cleanupCipher(cipher);
+      expect(cipher.name).toBe("--");
+    });
+
+    it("should preserve normal names", () => {
+      cipher.name = "Test Item";
+      importer.cleanupCipher(cipher);
+      expect(cipher.name).toBe("Test Item");
     });
   });
 });

--- a/libs/importer/src/importers/base-importer.ts
+++ b/libs/importer/src/importers/base-importer.ts
@@ -321,9 +321,8 @@ export abstract class BaseImporter {
     }
     if (this.isNullOrWhitespace(cipher.notes)) {
       cipher.notes = null;
-    } else {
-      cipher.notes = cipher.notes.trim();
     }
+    // Note: Removed cipher.notes.trim() to preserve leading/trailing spaces in notes
   }
 
   protected processKvp(


### PR DESCRIPTION
- Added cleanupCipher method to preserve leading/trailing spaces in notes and set them to null if they contain only whitespace or are empty.
- Updated the BaseImporter class to remove trimming of notes to maintain original formatting.
- Added unit tests for cleanupCipher to verify behavior for various note and name scenarios.

## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
