### PR TITLE
[PM-25488] Badge stays after lock when using pin

### DIFF
--- a/apps/browser/src/auth/services/auth-status-badge-updater.service.ts
+++ b/apps/browser/src/auth/services/auth-status-badge-updater.service.ts
@@ -17,7 +17,7 @@ export class AuthStatusBadgeUpdaterService {
     private accountService: AccountService,
     private authService: AuthService,
   ) {
-    this.badgeService.setDynamicState(StateName, (_tab) =>
+    this.badgeService.setState(StateName, (_tab) =>
       this.accountService.activeAccount$.pipe(
         switchMap((account) =>
           account

--- a/apps/browser/src/auth/services/auth-status-badge-updater.service.ts
+++ b/apps/browser/src/auth/services/auth-status-badge-updater.service.ts
@@ -17,8 +17,8 @@ export class AuthStatusBadgeUpdaterService {
     private accountService: AccountService,
     private authService: AuthService,
   ) {
-    this.accountService.activeAccount$
-      .pipe(
+    this.badgeService.setDynamicState(StateName, (_tab) =>
+      this.accountService.activeAccount$.pipe(
         switchMap((account) =>
           account
             ? this.authService.authStatusFor$(account.id)
@@ -27,30 +27,36 @@ export class AuthStatusBadgeUpdaterService {
         mergeMap(async (authStatus) => {
           switch (authStatus) {
             case AuthenticationStatus.LoggedOut: {
-              await this.badgeService.setState(StateName, BadgeStatePriority.High, {
-                icon: BadgeIcon.LoggedOut,
-                backgroundColor: Unset,
-                text: Unset,
-              });
-              break;
+              return {
+                priority: BadgeStatePriority.High,
+                state: {
+                  icon: BadgeIcon.LoggedOut,
+                  backgroundColor: Unset,
+                  text: Unset,
+                },
+              };
             }
             case AuthenticationStatus.Locked: {
-              await this.badgeService.setState(StateName, BadgeStatePriority.High, {
-                icon: BadgeIcon.Locked,
-                backgroundColor: Unset,
-                text: Unset,
-              });
-              break;
+              return {
+                priority: BadgeStatePriority.High,
+                state: {
+                  icon: BadgeIcon.Locked,
+                  backgroundColor: Unset,
+                  text: Unset,
+                },
+              };
             }
             case AuthenticationStatus.Unlocked: {
-              await this.badgeService.setState(StateName, BadgeStatePriority.Low, {
-                icon: BadgeIcon.Unlocked,
-              });
-              break;
+              return {
+                priority: BadgeStatePriority.Low,
+                state: {
+                  icon: BadgeIcon.Unlocked,
+                },
+              };
             }
           }
         }),
-      )
-      .subscribe();
+      ),
+    );
   }
 }

--- a/apps/browser/src/autofill/services/autofill-badge-updater.service.ts
+++ b/apps/browser/src/autofill/services/autofill-badge-updater.service.ts
@@ -26,6 +26,8 @@ export class AutofillBadgeUpdaterService {
       switchMap((account) => (account?.id ? this.cipherService.ciphers$(account?.id) : of([]))),
     );
 
+    this.badgeService.setDynamicState("autofill-badge-updater", (activeTabsUpdated$) => {});
+
     // Recalculate badges for all active tabs when ciphers or active account changes
     combineLatest({
       account: this.accountService.activeAccount$,

--- a/apps/browser/src/autofill/services/autofill-badge-updater.service.ts
+++ b/apps/browser/src/autofill/services/autofill-badge-updater.service.ts
@@ -1,5 +1,6 @@
 import {
   combineLatest,
+  concatMap,
   delay,
   distinctUntilChanged,
   merge,
@@ -17,7 +18,7 @@ import { UserId } from "@bitwarden/common/types/guid";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 
 import { Tab } from "../../platform/badge/badge-browser-api";
-import { BadgeService, StateSetting } from "../../platform/badge/badge.service";
+import { BadgeService, BadgeStateSetting } from "../../platform/badge/badge.service";
 import { BadgeStatePriority } from "../../platform/badge/priority";
 
 const StateName = "autofill-badge-updater";
@@ -36,63 +37,49 @@ export class AutofillBadgeUpdaterService {
       switchMap((account) => (account?.id ? this.cipherService.ciphers$(account?.id) : of([]))),
     );
 
-    this.badgeService.setDynamicState(StateName, (activeTabsUpdated$, activeTabs$) => {
-      const stateChangedObservable$: Observable<StateSetting[]> = combineLatest({
+    this.badgeService.setDynamicState(StateName, (tab) => {
+      const stateChangedObservable$: Observable<BadgeStateSetting | undefined> = combineLatest({
         account: this.accountService.activeAccount$,
         enableBadgeCounter:
           this.badgeSettingsService.enableBadgeCounter$.pipe(distinctUntilChanged()),
         ciphers: ciphers$.pipe(delay(100)), // Delay to allow cipherService.getAllDecryptedForUrl to pick up changes
       }).pipe(
-        withLatestFrom(activeTabs$),
-        mergeMap(async ([{ account, enableBadgeCounter }, tabs]) => {
-          if (!account) {
-            return [];
+        mergeMap(async ({ account, enableBadgeCounter }) => {
+          if (!account || !enableBadgeCounter) {
+            return undefined;
           }
 
-          return await Promise.all(
-            tabs.map(async (tab) => {
-              if (enableBadgeCounter) {
-                return {
-                  state: {
-                    text: await this.calculateCountText(tab, account.id),
-                  },
-                  priority: BadgeStatePriority.Default,
-                  tabId: tab.tabId,
-                };
-              } else {
-                // Explicitly emit empty state for tab to clear any existing badge
-                return {
-                  state: {},
-                  priority: BadgeStatePriority.Default,
-                  tabId: tab.tabId,
-                };
-              }
-            }),
-          );
+          return {
+            state: {
+              text: await this.calculateCountText(tab, account.id),
+            },
+            priority: BadgeStatePriority.Default,
+            tabId: tab.tabId,
+          };
         }),
       );
 
-      const tabUpdatedObservable$: Observable<StateSetting[]> = activeTabsUpdated$.pipe(
+      const tabUpdatedObservable$: Observable<BadgeStateSetting> = of(tab).pipe(
         withLatestFrom(
           this.accountService.activeAccount$,
           this.badgeSettingsService.enableBadgeCounter$,
         ),
-        mergeMap(async ([tabs, account, enableBadgeCounter]) => {
+        concatMap(async ([tab, account, enableBadgeCounter]) => {
           if (!account || !enableBadgeCounter) {
-            return [];
+            return {
+              state: {},
+              priority: BadgeStatePriority.Default,
+              tabId: tab.tabId,
+            };
           }
 
-          return await Promise.all(
-            tabs.map(async (tab) => {
-              return {
-                state: {
-                  text: await this.calculateCountText(tab, account.id),
-                },
-                priority: BadgeStatePriority.Default,
-                tabId: tab.tabId,
-              };
-            }),
-          );
+          return {
+            state: {
+              text: await this.calculateCountText(tab, account!.id),
+            },
+            priority: BadgeStatePriority.Default,
+            tabId: tab.tabId,
+          };
         }),
       );
 

--- a/apps/browser/src/autofill/services/autofill-badge-updater.service.ts
+++ b/apps/browser/src/autofill/services/autofill-badge-updater.service.ts
@@ -37,7 +37,7 @@ export class AutofillBadgeUpdaterService {
       switchMap((account) => (account?.id ? this.cipherService.ciphers$(account?.id) : of([]))),
     );
 
-    this.badgeService.setDynamicState(StateName, (tab) => {
+    this.badgeService.setState(StateName, (tab) => {
       const stateChangedObservable$: Observable<BadgeStateSetting | undefined> = combineLatest({
         account: this.accountService.activeAccount$,
         enableBadgeCounter:

--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -1901,7 +1901,6 @@ export default class MainBackground {
       this.badgeService,
       this.accountService,
       this.cipherService,
-      this.logService,
       this.taskService,
     );
 

--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -1411,7 +1411,6 @@ export default class MainBackground {
     );
 
     this.badgeService = new BadgeService(
-      this.stateProvider,
       new DefaultBadgeBrowserApi(this.platformUtilsService),
       this.logService,
     );

--- a/apps/browser/src/platform/badge/badge.service.spec.ts
+++ b/apps/browser/src/platform/badge/badge.service.spec.ts
@@ -69,6 +69,13 @@ describe("BadgeService", () => {
           expect(badgeApi.specificStates[tabId]).toEqual(DefaultBadgeState);
         });
 
+        it("sets default values even if state function never emits", async () => {
+          badgeService.setState("state-name", (_tab) => EMPTY);
+
+          await new Promise((resolve) => setTimeout(resolve, 0));
+          expect(badgeApi.specificStates[tabId]).toEqual(DefaultBadgeState);
+        });
+
         it("merges states when multiple same-priority states have been set", async () => {
           await badgeService.setState(
             "state-1",

--- a/apps/browser/src/platform/badge/badge.service.spec.ts
+++ b/apps/browser/src/platform/badge/badge.service.spec.ts
@@ -1,11 +1,11 @@
 import { mock, MockProxy } from "jest-mock-extended";
-import { Subscription } from "rxjs";
+import { EMPTY, of, Subscription } from "rxjs";
 
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { FakeAccountService, FakeStateProvider } from "@bitwarden/common/spec";
 
 import { RawBadgeState } from "./badge-browser-api";
-import { BadgeService } from "./badge.service";
+import { BadgeService, DynamicStateFunction } from "./badge.service";
 import { DefaultBadgeState } from "./consts";
 import { BadgeIcon } from "./icon";
 import { BadgeStatePriority } from "./priority";
@@ -32,616 +32,778 @@ describe("BadgeService", () => {
     badgeServiceSubscription?.unsubscribe();
   });
 
-  describe("calling without tabId", () => {
-    const tabId = 1;
-
-    describe("given a single tab is open", () => {
-      beforeEach(() => {
-        badgeApi.tabs = [tabId];
-        badgeApi.setActiveTabs([tabId]);
-        badgeServiceSubscription = badgeService.startListening();
-      });
-
-      it("sets provided state when no other state has been set", async () => {
-        const state: BadgeState = {
-          text: "text",
-          backgroundColor: "color",
-          icon: BadgeIcon.Locked,
-        };
-
-        await badgeService.setState("state-name", BadgeStatePriority.Default, state);
-
-        await new Promise((resolve) => setTimeout(resolve, 0));
-        expect(badgeApi.specificStates[tabId]).toEqual(state);
-      });
-
-      it("sets default values when none are provided", async () => {
-        // This is a bit of a weird thing to do, but I don't think it's something we need to prohibit
-        const state: BadgeState = {};
-
-        await badgeService.setState("state-name", BadgeStatePriority.Default, state);
-
-        await new Promise((resolve) => setTimeout(resolve, 0));
-        expect(badgeApi.specificStates[tabId]).toEqual(DefaultBadgeState);
-      });
-
-      it("merges states when multiple same-priority states have been set", async () => {
-        await badgeService.setState("state-1", BadgeStatePriority.Default, { text: "text" });
-        await badgeService.setState("state-2", BadgeStatePriority.Default, {
-          backgroundColor: "#fff",
-        });
-        await badgeService.setState("state-3", BadgeStatePriority.Default, {
-          icon: BadgeIcon.Locked,
-        });
-
-        await new Promise((resolve) => setTimeout(resolve, 0));
-        const expectedState: RawBadgeState = {
-          text: "text",
-          backgroundColor: "#fff",
-          icon: BadgeIcon.Locked,
-        };
-        expect(badgeApi.specificStates[tabId]).toEqual(expectedState);
-      });
-
-      it("overrides previous lower-priority state when higher-priority state is set", async () => {
-        await badgeService.setState("state-1", BadgeStatePriority.Low, {
-          text: "text",
-          backgroundColor: "#fff",
-          icon: BadgeIcon.Locked,
-        });
-        await badgeService.setState("state-2", BadgeStatePriority.Default, {
-          text: "override",
-        });
-        await badgeService.setState("state-3", BadgeStatePriority.High, {
-          backgroundColor: "#aaa",
-        });
-
-        await new Promise((resolve) => setTimeout(resolve, 0));
-        const expectedState: RawBadgeState = {
-          text: "override",
-          backgroundColor: "#aaa",
-          icon: BadgeIcon.Locked,
-        };
-        expect(badgeApi.specificStates[tabId]).toEqual(expectedState);
-      });
-
-      it("removes override when a previously high-priority state is cleared", async () => {
-        await badgeService.setState("state-1", BadgeStatePriority.Low, {
-          text: "text",
-          backgroundColor: "#fff",
-          icon: BadgeIcon.Locked,
-        });
-        await badgeService.setState("state-2", BadgeStatePriority.Default, {
-          text: "override",
-        });
-        await badgeService.clearState("state-2");
-
-        await new Promise((resolve) => setTimeout(resolve, 0));
-        const expectedState: RawBadgeState = {
-          text: "text",
-          backgroundColor: "#fff",
-          icon: BadgeIcon.Locked,
-        };
-        expect(badgeApi.specificStates[tabId]).toEqual(expectedState);
-      });
-
-      it("sets default values when all states have been cleared", async () => {
-        await badgeService.setState("state-1", BadgeStatePriority.Low, {
-          text: "text",
-          backgroundColor: "#fff",
-          icon: BadgeIcon.Locked,
-        });
-        await badgeService.setState("state-2", BadgeStatePriority.Default, {
-          text: "override",
-        });
-        await badgeService.setState("state-3", BadgeStatePriority.High, {
-          backgroundColor: "#aaa",
-        });
-        await badgeService.clearState("state-1");
-        await badgeService.clearState("state-2");
-        await badgeService.clearState("state-3");
-
-        await new Promise((resolve) => setTimeout(resolve, 0));
-        expect(badgeApi.specificStates[tabId]).toEqual(DefaultBadgeState);
-      });
-
-      it("sets default value high-priority state contains Unset", async () => {
-        await badgeService.setState("state-1", BadgeStatePriority.Low, {
-          text: "text",
-          backgroundColor: "#fff",
-          icon: BadgeIcon.Locked,
-        });
-        await badgeService.setState("state-3", BadgeStatePriority.High, {
-          icon: Unset,
-        });
-
-        await new Promise((resolve) => setTimeout(resolve, 0));
-        const expectedState: RawBadgeState = {
-          text: "text",
-          backgroundColor: "#fff",
-          icon: DefaultBadgeState.icon,
-        };
-        expect(badgeApi.specificStates[tabId]).toEqual(expectedState);
-      });
-
-      it("ignores medium-priority Unset when high-priority contains a value", async () => {
-        await badgeService.setState("state-1", BadgeStatePriority.Low, {
-          text: "text",
-          backgroundColor: "#fff",
-          icon: BadgeIcon.Locked,
-        });
-        await badgeService.setState("state-3", BadgeStatePriority.Default, {
-          icon: Unset,
-        });
-        await badgeService.setState("state-3", BadgeStatePriority.High, {
-          icon: BadgeIcon.Unlocked,
-        });
-
-        await new Promise((resolve) => setTimeout(resolve, 0));
-        const expectedState: RawBadgeState = {
-          text: "text",
-          backgroundColor: "#fff",
-          icon: BadgeIcon.Unlocked,
-        };
-        expect(badgeApi.specificStates[tabId]).toEqual(expectedState);
-      });
-    });
-
-    describe("given multiple tabs are open, only one active", () => {
-      const tabId = 1;
-      const tabIds = [1, 2, 3];
-
-      beforeEach(() => {
-        badgeApi.tabs = tabIds;
-        badgeApi.setActiveTabs([tabId]);
-        badgeServiceSubscription = badgeService.startListening();
-      });
-
-      it("sets general state for active tab when no other state has been set", async () => {
-        const state: BadgeState = {
-          text: "text",
-          backgroundColor: "color",
-          icon: BadgeIcon.Locked,
-        };
-
-        await badgeService.setState("state-name", BadgeStatePriority.Default, state);
-
-        await new Promise((resolve) => setTimeout(resolve, 0));
-        expect(badgeApi.specificStates).toEqual({
-          1: state,
-          2: undefined,
-          3: undefined,
-        });
-      });
-
-      it("only updates the active tab when setting state", async () => {
-        const state: BadgeState = {
-          text: "text",
-          backgroundColor: "color",
-          icon: BadgeIcon.Locked,
-        };
-        badgeApi.setState.mockReset();
-
-        await badgeService.setState("state-1", BadgeStatePriority.Default, state, tabId);
-        await badgeService.setState("state-2", BadgeStatePriority.Default, state, 2);
-        await badgeService.setState("state-2", BadgeStatePriority.Default, state, 2);
-
-        await new Promise((resolve) => setTimeout(resolve, 0));
-        expect(badgeApi.setState).toHaveBeenCalledTimes(1);
-      });
-    });
-
-    describe("given multiple tabs are open and multiple are active", () => {
-      const activeTabIds = [1, 2];
-      const tabIds = [1, 2, 3];
-
-      beforeEach(() => {
-        badgeApi.tabs = tabIds;
-        badgeApi.setActiveTabs(activeTabIds);
-        badgeServiceSubscription = badgeService.startListening();
-      });
-
-      it("sets general state for active tabs when no other state has been set", async () => {
-        const state: BadgeState = {
-          text: "text",
-          backgroundColor: "color",
-          icon: BadgeIcon.Locked,
-        };
-
-        await badgeService.setState("state-name", BadgeStatePriority.Default, state);
-
-        await new Promise((resolve) => setTimeout(resolve, 0));
-        expect(badgeApi.specificStates).toEqual({
-          1: state,
-          2: state,
-          3: undefined,
-        });
-      });
-
-      it("only updates the active tabs when setting general state", async () => {
-        const state: BadgeState = {
-          text: "text",
-          backgroundColor: "color",
-          icon: BadgeIcon.Locked,
-        };
-        badgeApi.setState.mockReset();
-
-        await badgeService.setState("state-1", BadgeStatePriority.Default, state, 1);
-        await badgeService.setState("state-2", BadgeStatePriority.Default, state, 2);
-        await badgeService.setState("state-3", BadgeStatePriority.Default, state, 3);
-
-        await new Promise((resolve) => setTimeout(resolve, 0));
-        expect(badgeApi.setState).toHaveBeenCalledTimes(2);
-      });
-    });
-  });
-
-  describe("calling with tabId", () => {
-    describe("given a single tab is open", () => {
+  describe("static state", () => {
+    describe("calling without tabId", () => {
       const tabId = 1;
 
-      beforeEach(() => {
-        badgeApi.tabs = [tabId];
-        badgeApi.setActiveTabs([tabId]);
-        badgeServiceSubscription = badgeService.startListening();
-      });
-
-      it("sets provided state when no other state has been set", async () => {
-        const state: BadgeState = {
-          text: "text",
-          backgroundColor: "color",
-          icon: BadgeIcon.Locked,
-        };
-
-        await badgeService.setState("state-name", BadgeStatePriority.Default, state, tabId);
-
-        await new Promise((resolve) => setTimeout(resolve, 0));
-        expect(badgeApi.specificStates[tabId]).toEqual(state);
-      });
-
-      it("sets default values when none are provided", async () => {
-        // This is a bit of a weird thing to do, but I don't think it's something we need to prohibit
-        const state: BadgeState = {};
-
-        await badgeService.setState("state-name", BadgeStatePriority.Default, state, tabId);
-
-        await new Promise((resolve) => setTimeout(resolve, 0));
-        expect(badgeApi.specificStates[tabId]).toEqual(DefaultBadgeState);
-      });
-
-      it("merges tabId specific state with general states", async () => {
-        await badgeService.setState("general-state", BadgeStatePriority.Default, { text: "text" });
-        await badgeService.setState(
-          "specific-state",
-          BadgeStatePriority.Default,
-          {
-            backgroundColor: "#fff",
-          },
-          tabId,
-        );
-        await badgeService.setState("general-state-2", BadgeStatePriority.Default, {
-          icon: BadgeIcon.Locked,
+      describe("given a single tab is open", () => {
+        beforeEach(() => {
+          badgeApi.tabs = [tabId];
+          badgeApi.setActiveTabs([tabId]);
+          badgeServiceSubscription = badgeService.startListening();
         });
 
-        await new Promise((resolve) => setTimeout(resolve, 0));
-        expect(badgeApi.specificStates[tabId]).toEqual({
-          text: "text",
-          backgroundColor: "#fff",
-          icon: BadgeIcon.Locked,
-        });
-      });
-
-      it("merges states when multiple same-priority states with the same tabId have been set", async () => {
-        await badgeService.setState("state-1", BadgeStatePriority.Default, { text: "text" }, tabId);
-        await badgeService.setState(
-          "state-2",
-          BadgeStatePriority.Default,
-          {
-            backgroundColor: "#fff",
-          },
-          tabId,
-        );
-        await badgeService.setState(
-          "state-3",
-          BadgeStatePriority.Default,
-          {
+        it("sets provided state when no other state has been set", async () => {
+          const state: BadgeState = {
+            text: "text",
+            backgroundColor: "color",
             icon: BadgeIcon.Locked,
-          },
-          tabId,
-        );
+          };
 
-        await new Promise((resolve) => setTimeout(resolve, 0));
-        const expectedState: RawBadgeState = {
-          text: "text",
-          backgroundColor: "#fff",
-          icon: BadgeIcon.Locked,
-        };
-        expect(badgeApi.specificStates[tabId]).toEqual(expectedState);
-      });
+          await badgeService.setDynamicState(
+            "state-name",
+            GeneralStateFunction(BadgeStatePriority.Default, state),
+          );
 
-      it("overrides previous lower-priority state when higher-priority state with the same tabId is set", async () => {
-        await badgeService.setState(
-          "state-1",
-          BadgeStatePriority.Low,
-          {
+          await new Promise((resolve) => setTimeout(resolve, 0));
+          expect(badgeApi.specificStates[tabId]).toEqual(state);
+        });
+
+        it("sets default values when none are provided", async () => {
+          // This is a bit of a weird thing to do, but I don't think it's something we need to prohibit
+          const state: BadgeState = {};
+
+          await badgeService.setDynamicState(
+            "state-name",
+            GeneralStateFunction(BadgeStatePriority.Default, state),
+          );
+
+          await new Promise((resolve) => setTimeout(resolve, 0));
+          expect(badgeApi.specificStates[tabId]).toEqual(DefaultBadgeState);
+        });
+
+        it("merges states when multiple same-priority states have been set", async () => {
+          await badgeService.setDynamicState(
+            "state-1",
+            GeneralStateFunction(BadgeStatePriority.Default, { text: "text" }),
+          );
+          await badgeService.setDynamicState(
+            "state-2",
+            GeneralStateFunction(BadgeStatePriority.Default, {
+              backgroundColor: "#fff",
+            }),
+          );
+          await badgeService.setDynamicState(
+            "state-3",
+            GeneralStateFunction(BadgeStatePriority.Default, {
+              icon: BadgeIcon.Locked,
+            }),
+          );
+
+          await new Promise((resolve) => setTimeout(resolve, 0));
+          const expectedState: RawBadgeState = {
             text: "text",
             backgroundColor: "#fff",
             icon: BadgeIcon.Locked,
-          },
-          tabId,
-        );
-        await badgeService.setState(
-          "state-2",
-          BadgeStatePriority.Default,
-          {
+          };
+          expect(badgeApi.specificStates[tabId]).toEqual(expectedState);
+        });
+
+        it("overrides previous lower-priority state when higher-priority state is set", async () => {
+          await badgeService.setDynamicState(
+            "state-1",
+            GeneralStateFunction(BadgeStatePriority.Low, {
+              text: "text",
+              backgroundColor: "#fff",
+              icon: BadgeIcon.Locked,
+            }),
+          );
+          await badgeService.setDynamicState(
+            "state-2",
+            GeneralStateFunction(BadgeStatePriority.Default, {
+              text: "override",
+            }),
+          );
+          await badgeService.setDynamicState(
+            "state-3",
+            GeneralStateFunction(BadgeStatePriority.High, {
+              backgroundColor: "#aaa",
+            }),
+          );
+
+          await new Promise((resolve) => setTimeout(resolve, 0));
+          const expectedState: RawBadgeState = {
             text: "override",
-          },
-          tabId,
-        );
-        await badgeService.setState(
-          "state-3",
-          BadgeStatePriority.High,
-          {
             backgroundColor: "#aaa",
-          },
-          tabId,
-        );
+            icon: BadgeIcon.Locked,
+          };
+          expect(badgeApi.specificStates[tabId]).toEqual(expectedState);
+        });
 
-        await new Promise((resolve) => setTimeout(resolve, 0));
-        const expectedState: RawBadgeState = {
-          text: "override",
-          backgroundColor: "#aaa",
-          icon: BadgeIcon.Locked,
-        };
-        expect(badgeApi.specificStates[tabId]).toEqual(expectedState);
-      });
+        it("removes override when a previously high-priority state is cleared", async () => {
+          await badgeService.setDynamicState(
+            "state-1",
+            GeneralStateFunction(BadgeStatePriority.Low, {
+              text: "text",
+              backgroundColor: "#fff",
+              icon: BadgeIcon.Locked,
+            }),
+          );
+          await badgeService.setDynamicState(
+            "state-2",
+            GeneralStateFunction(BadgeStatePriority.Default, {
+              text: "override",
+            }),
+          );
+          await badgeService.clearDynamicState("state-2");
 
-      it("overrides lower-priority tab-specific state when higher-priority general state is set", async () => {
-        await badgeService.setState(
-          "state-1",
-          BadgeStatePriority.Low,
-          {
+          await new Promise((resolve) => setTimeout(resolve, 0));
+          const expectedState: RawBadgeState = {
             text: "text",
             backgroundColor: "#fff",
             icon: BadgeIcon.Locked,
-          },
-          tabId,
-        );
-        await badgeService.setState("state-2", BadgeStatePriority.Default, {
-          text: "override",
-        });
-        await badgeService.setState("state-3", BadgeStatePriority.High, {
-          backgroundColor: "#aaa",
+          };
+          expect(badgeApi.specificStates[tabId]).toEqual(expectedState);
         });
 
-        await new Promise((resolve) => setTimeout(resolve, 0));
-        expect(badgeApi.specificStates[tabId]).toEqual({
-          text: "override",
-          backgroundColor: "#aaa",
-          icon: BadgeIcon.Locked,
-        });
-      });
+        it("sets default values when all states have been cleared", async () => {
+          await badgeService.setDynamicState(
+            "state-1",
+            GeneralStateFunction(BadgeStatePriority.Low, {
+              text: "text",
+              backgroundColor: "#fff",
+              icon: BadgeIcon.Locked,
+            }),
+          );
+          await badgeService.setDynamicState(
+            "state-2",
+            GeneralStateFunction(BadgeStatePriority.Default, {
+              text: "override",
+            }),
+          );
+          await badgeService.setDynamicState(
+            "state-3",
+            GeneralStateFunction(BadgeStatePriority.High, {
+              backgroundColor: "#aaa",
+            }),
+          );
+          await badgeService.clearDynamicState("state-1");
+          await badgeService.clearDynamicState("state-2");
+          await badgeService.clearDynamicState("state-3");
 
-      it("removes override when a previously high-priority state with the same tabId is cleared", async () => {
-        await badgeService.setState(
-          "state-1",
-          BadgeStatePriority.Low,
-          {
+          await new Promise((resolve) => setTimeout(resolve, 0));
+          expect(badgeApi.specificStates[tabId]).toEqual(DefaultBadgeState);
+        });
+
+        it("sets default value high-priority state contains Unset", async () => {
+          await badgeService.setDynamicState(
+            "state-1",
+            GeneralStateFunction(BadgeStatePriority.Low, {
+              text: "text",
+              backgroundColor: "#fff",
+              icon: BadgeIcon.Locked,
+            }),
+          );
+          await badgeService.setDynamicState(
+            "state-3",
+            GeneralStateFunction(BadgeStatePriority.High, {
+              icon: Unset,
+            }),
+          );
+
+          await new Promise((resolve) => setTimeout(resolve, 0));
+          const expectedState: RawBadgeState = {
             text: "text",
             backgroundColor: "#fff",
-            icon: BadgeIcon.Locked,
-          },
-          tabId,
-        );
-        await badgeService.setState(
-          "state-2",
-          BadgeStatePriority.Default,
-          {
-            text: "override",
-          },
-          tabId,
-        );
-        await badgeService.clearState("state-2");
-
-        await new Promise((resolve) => setTimeout(resolve, 0));
-        expect(badgeApi.specificStates[tabId]).toEqual({
-          text: "text",
-          backgroundColor: "#fff",
-          icon: BadgeIcon.Locked,
+            icon: DefaultBadgeState.icon,
+          };
+          expect(badgeApi.specificStates[tabId]).toEqual(expectedState);
         });
-      });
 
-      it("sets default state when all states with the same tabId have been cleared", async () => {
-        await badgeService.setState(
-          "state-1",
-          BadgeStatePriority.Low,
-          {
+        it("ignores medium-priority Unset when high-priority contains a value", async () => {
+          await badgeService.setDynamicState(
+            "state-1",
+            GeneralStateFunction(BadgeStatePriority.Low, {
+              text: "text",
+              backgroundColor: "#fff",
+              icon: BadgeIcon.Locked,
+            }),
+          );
+          await badgeService.setDynamicState(
+            "state-3",
+            GeneralStateFunction(BadgeStatePriority.Default, {
+              icon: Unset,
+            }),
+          );
+          await badgeService.setDynamicState(
+            "state-3",
+            GeneralStateFunction(BadgeStatePriority.High, {
+              icon: BadgeIcon.Unlocked,
+            }),
+          );
+
+          await new Promise((resolve) => setTimeout(resolve, 0));
+          const expectedState: RawBadgeState = {
             text: "text",
             backgroundColor: "#fff",
-            icon: BadgeIcon.Locked,
-          },
-          tabId,
-        );
-        await badgeService.setState(
-          "state-2",
-          BadgeStatePriority.Default,
-          {
-            text: "override",
-          },
-          tabId,
-        );
-        await badgeService.setState(
-          "state-3",
-          BadgeStatePriority.High,
-          {
-            backgroundColor: "#aaa",
-          },
-          tabId,
-        );
-        await badgeService.clearState("state-1");
-        await badgeService.clearState("state-2");
-        await badgeService.clearState("state-3");
-
-        await new Promise((resolve) => setTimeout(resolve, 0));
-        expect(badgeApi.specificStates[tabId]).toEqual(DefaultBadgeState);
-      });
-
-      it("sets default value when high-priority state contains Unset", async () => {
-        await badgeService.setState(
-          "state-1",
-          BadgeStatePriority.Low,
-          {
-            text: "text",
-            backgroundColor: "#fff",
-            icon: BadgeIcon.Locked,
-          },
-          tabId,
-        );
-        await badgeService.setState(
-          "state-3",
-          BadgeStatePriority.High,
-          {
-            icon: Unset,
-          },
-          tabId,
-        );
-
-        await new Promise((resolve) => setTimeout(resolve, 0));
-        expect(badgeApi.specificStates[tabId]).toEqual({
-          text: "text",
-          backgroundColor: "#fff",
-          icon: DefaultBadgeState.icon,
-        });
-      });
-
-      it("ignores medium-priority Unset when high-priority contains a value", async () => {
-        await badgeService.setState(
-          "state-1",
-          BadgeStatePriority.Low,
-          {
-            text: "text",
-            backgroundColor: "#fff",
-            icon: BadgeIcon.Locked,
-          },
-          tabId,
-        );
-        await badgeService.setState(
-          "state-3",
-          BadgeStatePriority.Default,
-          {
-            icon: Unset,
-          },
-          tabId,
-        );
-        await badgeService.setState(
-          "state-3",
-          BadgeStatePriority.High,
-          {
             icon: BadgeIcon.Unlocked,
-          },
-          tabId,
-        );
+          };
+          expect(badgeApi.specificStates[tabId]).toEqual(expectedState);
+        });
+      });
 
-        await new Promise((resolve) => setTimeout(resolve, 0));
-        expect(badgeApi.specificStates[tabId]).toEqual({
-          text: "text",
-          backgroundColor: "#fff",
-          icon: BadgeIcon.Unlocked,
+      describe("given multiple tabs are open, only one active", () => {
+        const tabId = 1;
+        const tabIds = [1, 2, 3];
+
+        beforeEach(() => {
+          badgeApi.tabs = tabIds;
+          badgeApi.setActiveTabs([tabId]);
+          badgeServiceSubscription = badgeService.startListening();
+        });
+
+        it("sets general state for active tab when no other state has been set", async () => {
+          const state: BadgeState = {
+            text: "text",
+            backgroundColor: "color",
+            icon: BadgeIcon.Locked,
+          };
+
+          await badgeService.setDynamicState(
+            "state-name",
+            GeneralStateFunction(BadgeStatePriority.Default, state),
+          );
+
+          await new Promise((resolve) => setTimeout(resolve, 0));
+          expect(badgeApi.specificStates).toEqual({
+            1: state,
+            2: undefined,
+            3: undefined,
+          });
+        });
+
+        it.skip("only updates the active tab when setting state", async () => {
+          const state: BadgeState = {
+            text: "text",
+            backgroundColor: "color",
+            icon: BadgeIcon.Locked,
+          };
+          badgeApi.setState.mockReset();
+
+          await badgeService.setState("state-1", BadgeStatePriority.Default, state, tabId);
+          await badgeService.setState("state-2", BadgeStatePriority.Default, state, 2);
+          await badgeService.setState("state-2", BadgeStatePriority.Default, state, 2);
+
+          await new Promise((resolve) => setTimeout(resolve, 0));
+          expect(badgeApi.setState).toHaveBeenCalledTimes(1);
+        });
+      });
+
+      describe("given multiple tabs are open and multiple are active", () => {
+        const activeTabIds = [1, 2];
+        const tabIds = [1, 2, 3];
+
+        beforeEach(() => {
+          badgeApi.tabs = tabIds;
+          badgeApi.setActiveTabs(activeTabIds);
+          badgeServiceSubscription = badgeService.startListening();
+        });
+
+        it("sets general state for active tabs when no other state has been set", async () => {
+          const state: BadgeState = {
+            text: "text",
+            backgroundColor: "color",
+            icon: BadgeIcon.Locked,
+          };
+
+          await badgeService.setDynamicState(
+            "state-name",
+            GeneralStateFunction(BadgeStatePriority.Default, state),
+          );
+
+          await new Promise((resolve) => setTimeout(resolve, 0));
+          expect(badgeApi.specificStates).toEqual({
+            1: state,
+            2: state,
+            3: undefined,
+          });
+        });
+
+        it.skip("only updates the active tabs when setting general state", async () => {
+          const state: BadgeState = {
+            text: "text",
+            backgroundColor: "color",
+            icon: BadgeIcon.Locked,
+          };
+          badgeApi.setState.mockReset();
+
+          await badgeService.setState("state-1", BadgeStatePriority.Default, state, 1);
+          await badgeService.setState("state-2", BadgeStatePriority.Default, state, 2);
+          await badgeService.setState("state-3", BadgeStatePriority.Default, state, 3);
+
+          await new Promise((resolve) => setTimeout(resolve, 0));
+          expect(badgeApi.setState).toHaveBeenCalledTimes(2);
         });
       });
     });
 
-    describe("given multiple tabs are open, only one active", () => {
-      const tabId = 1;
-      const tabIds = [1, 2, 3];
+    describe("setting tab-specific states", () => {
+      describe("given a single tab is open", () => {
+        const tabId = 1;
 
-      beforeEach(() => {
-        badgeApi.tabs = tabIds;
-        badgeApi.setActiveTabs([tabId]);
-        badgeServiceSubscription = badgeService.startListening();
-      });
+        beforeEach(() => {
+          badgeApi.tabs = [tabId];
+          badgeApi.setActiveTabs([tabId]);
+          badgeServiceSubscription = badgeService.startListening();
+        });
 
-      it("sets tab-specific state for provided tab", async () => {
-        const generalState: BadgeState = {
-          text: "general-text",
-          backgroundColor: "general-color",
-          icon: BadgeIcon.Unlocked,
-        };
-        const specificState: BadgeState = {
-          text: "tab-text",
-          icon: BadgeIcon.Locked,
-        };
+        it("sets provided state when no other state has been set", async () => {
+          const state: BadgeState = {
+            text: "text",
+            backgroundColor: "color",
+            icon: BadgeIcon.Locked,
+          };
 
-        await badgeService.setState("general-state", BadgeStatePriority.Default, generalState);
-        await badgeService.setState(
-          "tab-state",
-          BadgeStatePriority.Default,
-          specificState,
-          tabIds[0],
-        );
+          await badgeService.setDynamicState(
+            "state-name",
+            TabSpecificStateFunction(BadgeStatePriority.Default, state, tabId),
+          );
 
-        await new Promise((resolve) => setTimeout(resolve, 0));
-        expect(badgeApi.specificStates).toEqual({
-          [tabIds[0]]: { ...specificState, backgroundColor: "general-color" },
-          [tabIds[1]]: undefined,
-          [tabIds[2]]: undefined,
+          await new Promise((resolve) => setTimeout(resolve, 0));
+          expect(badgeApi.specificStates[tabId]).toEqual(state);
+        });
+
+        it("sets default values when none are provided", async () => {
+          // This is a bit of a weird thing to do, but I don't think it's something we need to prohibit
+          const state: BadgeState = {};
+
+          await badgeService.setDynamicState(
+            "state-name",
+            TabSpecificStateFunction(BadgeStatePriority.Default, state, tabId),
+          );
+
+          await new Promise((resolve) => setTimeout(resolve, 0));
+          expect(badgeApi.specificStates[tabId]).toEqual(DefaultBadgeState);
+        });
+
+        it("merges tabId specific state with general states", async () => {
+          await badgeService.setDynamicState(
+            "general-state",
+            TabSpecificStateFunction(
+              BadgeStatePriority.Default,
+              {
+                text: "text",
+              },
+              tabId,
+            ),
+          );
+          await badgeService.setDynamicState(
+            "specific-state",
+            TabSpecificStateFunction(
+              BadgeStatePriority.Default,
+              {
+                backgroundColor: "#fff",
+              },
+              tabId,
+            ),
+          );
+          await badgeService.setDynamicState(
+            "general-state-2",
+            GeneralStateFunction(BadgeStatePriority.Default, {
+              icon: BadgeIcon.Locked,
+            }),
+          );
+
+          await new Promise((resolve) => setTimeout(resolve, 0));
+          expect(badgeApi.specificStates[tabId]).toEqual({
+            text: "text",
+            backgroundColor: "#fff",
+            icon: BadgeIcon.Locked,
+          });
+        });
+
+        it("merges states when multiple same-priority states with the same tabId have been set", async () => {
+          await badgeService.setDynamicState(
+            "state-1",
+            TabSpecificStateFunction(BadgeStatePriority.Default, { text: "text" }, tabId),
+          );
+          await badgeService.setDynamicState(
+            "state-2",
+            TabSpecificStateFunction(
+              BadgeStatePriority.Default,
+              {
+                backgroundColor: "#fff",
+              },
+              tabId,
+            ),
+          );
+          await badgeService.setDynamicState(
+            "state-3",
+            TabSpecificStateFunction(
+              BadgeStatePriority.Default,
+              {
+                icon: BadgeIcon.Locked,
+              },
+              tabId,
+            ),
+          );
+
+          await new Promise((resolve) => setTimeout(resolve, 0));
+          const expectedState: RawBadgeState = {
+            text: "text",
+            backgroundColor: "#fff",
+            icon: BadgeIcon.Locked,
+          };
+          expect(badgeApi.specificStates[tabId]).toEqual(expectedState);
+        });
+
+        it("overrides previous lower-priority state when higher-priority state with the same tabId is set", async () => {
+          await badgeService.setDynamicState(
+            "state-1",
+            TabSpecificStateFunction(
+              BadgeStatePriority.Low,
+              {
+                text: "text",
+                backgroundColor: "#fff",
+                icon: BadgeIcon.Locked,
+              },
+              tabId,
+            ),
+          );
+          await badgeService.setDynamicState(
+            "state-2",
+            TabSpecificStateFunction(
+              BadgeStatePriority.Default,
+              {
+                text: "override",
+              },
+              tabId,
+            ),
+          );
+          await badgeService.setDynamicState(
+            "state-3",
+            TabSpecificStateFunction(
+              BadgeStatePriority.High,
+              {
+                backgroundColor: "#aaa",
+              },
+              tabId,
+            ),
+          );
+
+          await new Promise((resolve) => setTimeout(resolve, 0));
+          const expectedState: RawBadgeState = {
+            text: "override",
+            backgroundColor: "#aaa",
+            icon: BadgeIcon.Locked,
+          };
+          expect(badgeApi.specificStates[tabId]).toEqual(expectedState);
+        });
+
+        it("overrides lower-priority tab-specific state when higher-priority general state is set", async () => {
+          await badgeService.setDynamicState(
+            "state-1",
+            TabSpecificStateFunction(
+              BadgeStatePriority.Low,
+              {
+                text: "text",
+                backgroundColor: "#fff",
+                icon: BadgeIcon.Locked,
+              },
+              tabId,
+            ),
+          );
+          await badgeService.setDynamicState(
+            "state-2",
+            GeneralStateFunction(BadgeStatePriority.Default, {
+              text: "override",
+            }),
+          );
+          await badgeService.setDynamicState(
+            "state-3",
+            GeneralStateFunction(BadgeStatePriority.High, {
+              backgroundColor: "#aaa",
+            }),
+          );
+
+          await new Promise((resolve) => setTimeout(resolve, 0));
+          expect(badgeApi.specificStates[tabId]).toEqual({
+            text: "override",
+            backgroundColor: "#aaa",
+            icon: BadgeIcon.Locked,
+          });
+        });
+
+        it("removes override when a previously high-priority state with the same tabId is cleared", async () => {
+          await badgeService.setDynamicState(
+            "state-1",
+            TabSpecificStateFunction(
+              BadgeStatePriority.Low,
+              {
+                text: "text",
+                backgroundColor: "#fff",
+                icon: BadgeIcon.Locked,
+              },
+              tabId,
+            ),
+          );
+          await badgeService.setDynamicState(
+            "state-2",
+            TabSpecificStateFunction(
+              BadgeStatePriority.Default,
+              {
+                text: "override",
+              },
+              tabId,
+            ),
+          );
+          await badgeService.clearDynamicState("state-2");
+
+          await new Promise((resolve) => setTimeout(resolve, 0));
+          expect(badgeApi.specificStates[tabId]).toEqual({
+            text: "text",
+            backgroundColor: "#fff",
+            icon: BadgeIcon.Locked,
+          });
+        });
+
+        it("sets default state when all states with the same tabId have been cleared", async () => {
+          await badgeService.setDynamicState(
+            "state-1",
+            TabSpecificStateFunction(
+              BadgeStatePriority.Low,
+              {
+                text: "text",
+                backgroundColor: "#fff",
+                icon: BadgeIcon.Locked,
+              },
+              tabId,
+            ),
+          );
+          await badgeService.setDynamicState(
+            "state-2",
+            TabSpecificStateFunction(
+              BadgeStatePriority.Default,
+              {
+                text: "override",
+              },
+              tabId,
+            ),
+          );
+          await badgeService.setDynamicState(
+            "state-3",
+            TabSpecificStateFunction(
+              BadgeStatePriority.High,
+              {
+                backgroundColor: "#aaa",
+              },
+              tabId,
+            ),
+          );
+          await badgeService.clearDynamicState("state-1");
+          await badgeService.clearDynamicState("state-2");
+          await badgeService.clearDynamicState("state-3");
+
+          await new Promise((resolve) => setTimeout(resolve, 0));
+          expect(badgeApi.specificStates[tabId]).toEqual(DefaultBadgeState);
+        });
+
+        it("sets default value when high-priority state contains Unset", async () => {
+          await badgeService.setDynamicState(
+            "state-1",
+            TabSpecificStateFunction(
+              BadgeStatePriority.Low,
+              {
+                text: "text",
+                backgroundColor: "#fff",
+                icon: BadgeIcon.Locked,
+              },
+              tabId,
+            ),
+          );
+          await badgeService.setDynamicState(
+            "state-3",
+            TabSpecificStateFunction(
+              BadgeStatePriority.High,
+              {
+                icon: Unset,
+              },
+              tabId,
+            ),
+          );
+
+          await new Promise((resolve) => setTimeout(resolve, 0));
+          expect(badgeApi.specificStates[tabId]).toEqual({
+            text: "text",
+            backgroundColor: "#fff",
+            icon: DefaultBadgeState.icon,
+          });
+        });
+
+        it("ignores medium-priority Unset when high-priority contains a value", async () => {
+          await badgeService.setDynamicState(
+            "state-1",
+            TabSpecificStateFunction(
+              BadgeStatePriority.Low,
+              {
+                text: "text",
+                backgroundColor: "#fff",
+                icon: BadgeIcon.Locked,
+              },
+              tabId,
+            ),
+          );
+          await badgeService.setDynamicState(
+            "state-3",
+            TabSpecificStateFunction(
+              BadgeStatePriority.Default,
+              {
+                icon: Unset,
+              },
+              tabId,
+            ),
+          );
+          await badgeService.setDynamicState(
+            "state-3",
+            TabSpecificStateFunction(
+              BadgeStatePriority.High,
+              {
+                icon: BadgeIcon.Unlocked,
+              },
+              tabId,
+            ),
+          );
+
+          await new Promise((resolve) => setTimeout(resolve, 0));
+          expect(badgeApi.specificStates[tabId]).toEqual({
+            text: "text",
+            backgroundColor: "#fff",
+            icon: BadgeIcon.Unlocked,
+          });
         });
       });
-    });
 
-    describe("given multiple tabs are open and multiple are active", () => {
-      const activeTabIds = [1, 2];
-      const tabIds = [1, 2, 3];
+      describe("given multiple tabs are open, only one active", () => {
+        const tabId = 1;
+        const tabIds = [1, 2, 3];
 
-      beforeEach(() => {
-        badgeApi.tabs = tabIds;
-        badgeApi.setActiveTabs(activeTabIds);
-        badgeServiceSubscription = badgeService.startListening();
-      });
+        beforeEach(() => {
+          badgeApi.tabs = tabIds;
+          badgeApi.setActiveTabs([tabId]);
+          badgeServiceSubscription = badgeService.startListening();
+        });
 
-      it("sets general state for all active tabs when no other state has been set", async () => {
-        const generalState: BadgeState = {
-          text: "general-text",
-          backgroundColor: "general-color",
-          icon: BadgeIcon.Unlocked,
-        };
+        it("sets tab-specific state for provided tab", async () => {
+          const generalState: BadgeState = {
+            text: "general-text",
+            backgroundColor: "general-color",
+            icon: BadgeIcon.Unlocked,
+          };
+          const specificState: BadgeState = {
+            text: "tab-text",
+            icon: BadgeIcon.Locked,
+          };
 
-        await badgeService.setState("general-state", BadgeStatePriority.Default, generalState);
+          await badgeService.setDynamicState(
+            "general-state",
+            GeneralStateFunction(BadgeStatePriority.Default, generalState),
+          );
+          await badgeService.setDynamicState(
+            "tab-state",
+            TabSpecificStateFunction(BadgeStatePriority.Default, specificState, tabIds[0]),
+          );
 
-        await new Promise((resolve) => setTimeout(resolve, 0));
-        expect(badgeApi.specificStates).toEqual({
-          [tabIds[0]]: generalState,
-          [tabIds[1]]: generalState,
-          [tabIds[2]]: undefined,
+          await new Promise((resolve) => setTimeout(resolve, 0));
+          expect(badgeApi.specificStates).toEqual({
+            [tabIds[0]]: { ...specificState, backgroundColor: "general-color" },
+            [tabIds[1]]: undefined,
+            [tabIds[2]]: undefined,
+          });
         });
       });
 
-      it("sets tab-specific state for provided tab", async () => {
-        const generalState: BadgeState = {
-          text: "general-text",
-          backgroundColor: "general-color",
-          icon: BadgeIcon.Unlocked,
-        };
-        const specificState: BadgeState = {
-          text: "tab-text",
-          icon: BadgeIcon.Locked,
-        };
+      describe("given multiple tabs are open and multiple are active", () => {
+        const activeTabIds = [1, 2];
+        const tabIds = [1, 2, 3];
 
-        await badgeService.setState("general-state", BadgeStatePriority.Default, generalState);
-        await badgeService.setState(
-          "tab-state",
-          BadgeStatePriority.Default,
-          specificState,
-          tabIds[0],
-        );
+        beforeEach(() => {
+          badgeApi.tabs = tabIds;
+          badgeApi.setActiveTabs(activeTabIds);
+          badgeServiceSubscription = badgeService.startListening();
+        });
 
-        await new Promise((resolve) => setTimeout(resolve, 0));
-        expect(badgeApi.specificStates).toEqual({
-          [tabIds[0]]: { ...specificState, backgroundColor: "general-color" },
-          [tabIds[1]]: generalState,
-          [tabIds[2]]: undefined,
+        it("sets general state for all active tabs when no other state has been set", async () => {
+          const generalState: BadgeState = {
+            text: "general-text",
+            backgroundColor: "general-color",
+            icon: BadgeIcon.Unlocked,
+          };
+
+          await badgeService.setDynamicState(
+            "general-state",
+            GeneralStateFunction(BadgeStatePriority.Default, generalState),
+          );
+
+          await new Promise((resolve) => setTimeout(resolve, 0));
+          expect(badgeApi.specificStates).toEqual({
+            [tabIds[0]]: generalState,
+            [tabIds[1]]: generalState,
+            [tabIds[2]]: undefined,
+          });
+        });
+
+        it("sets tab-specific state for provided tab", async () => {
+          const generalState: BadgeState = {
+            text: "general-text",
+            backgroundColor: "general-color",
+            icon: BadgeIcon.Unlocked,
+          };
+          const specificState: BadgeState = {
+            text: "tab-text",
+            icon: BadgeIcon.Locked,
+          };
+
+          await badgeService.setDynamicState(
+            "general-state",
+            GeneralStateFunction(BadgeStatePriority.Default, generalState),
+          );
+          await badgeService.setDynamicState(
+            "tab-state",
+            TabSpecificStateFunction(BadgeStatePriority.Default, specificState, tabIds[0]),
+          );
+
+          await new Promise((resolve) => setTimeout(resolve, 0));
+          expect(badgeApi.specificStates).toEqual({
+            [tabIds[0]]: { ...specificState, backgroundColor: "general-color" },
+            [tabIds[1]]: generalState,
+            [tabIds[2]]: undefined,
+          });
         });
       });
     });
   });
 });
+
+/**
+ * Creates a dynamic state function that only provides a state for a specific tab.
+ */
+function TabSpecificStateFunction(
+  priority: BadgeStatePriority,
+  state: BadgeState,
+  tabId: number,
+): DynamicStateFunction {
+  return (tab) => {
+    if (tab.tabId === tabId) {
+      return of({
+        priority,
+        state,
+      });
+    }
+
+    return EMPTY;
+  };
+}
+
+/**
+ * Creates a dynamic state function that provides the same state for all tabs.
+ */
+function GeneralStateFunction(
+  priority: BadgeStatePriority,
+  state: BadgeState,
+): DynamicStateFunction {
+  return (_tab) =>
+    of({
+      priority,
+      state,
+    });
+}

--- a/apps/browser/src/platform/badge/badge.service.ts
+++ b/apps/browser/src/platform/badge/badge.service.ts
@@ -103,37 +103,6 @@ export class BadgeService {
           );
         },
       });
-    //   activeTabs: this.badgeApi.activeTabs$,
-    //   dynamicStateFunctions: this.stateFunctions,
-    // })
-    //   .pipe(
-    //     switchMap(({ activeTabs, dynamicStateFunctions }) => {
-    //       const functions = [...Object.values(dynamicStateFunctions), defaultTabStateFunction];
-
-    //       const tabObservables = activeTabs.map((tab) =>
-    //         combineLatest(functions.map((f) => f(tab).pipe(startWith(undefined)))).pipe(
-    //           map((states) => ({
-    //             states: states.filter((s): s is BadgeStateSetting => s !== undefined),
-    //             tab,
-    //           })),
-    //           debounceTime(BADGE_UPDATE_DEBOUNCE_MS),
-    //         ),
-    //       );
-
-    //       return merge(...tabObservables);
-    //     }),
-    //     concatMap(async (tabUpdate) => {
-    //       await this.updateBadge(tabUpdate.states, tabUpdate.tab.tabId);
-    //     }),
-    //   )
-    //   .subscribe({
-    //     error: (error: unknown) => {
-    //       this.logService.error(
-    //         "BadgeService: Fatal error updating badge state. Badge will no longer be updated.",
-    //         error,
-    //       );
-    //     },
-    //   });
   }
 
   /**

--- a/apps/browser/src/platform/badge/badge.service.ts
+++ b/apps/browser/src/platform/badge/badge.service.ts
@@ -39,10 +39,6 @@ export type BadgeStateFunction = (tab: Tab) => Observable<BadgeStateSetting | un
 export class BadgeService {
   private stateFunctions = new BehaviorSubject<Record<string, BadgeStateFunction>>({});
 
-  getActiveTabs(): Promise<Tab[]> {
-    return this.badgeApi.getActiveTabs();
-  }
-
   constructor(
     private badgeApi: BadgeBrowserApi,
     private logService: LogService,

--- a/apps/browser/src/platform/badge/badge.service.ts
+++ b/apps/browser/src/platform/badge/badge.service.ts
@@ -172,11 +172,8 @@ export class BadgeService {
    * @param tabId Tab id for which the the latest state change applied to. Set this to activeTab.tabId to force an update.
    * @param activeTabs The currently active tabs. If not provided, it will be fetched from the badge API.
    */
-  private async updateBadge(
-    serviceState: Record<string, BadgeStateSetting> | BadgeStateSetting[] | null | undefined,
-    tabId: number,
-  ) {
-    const newBadgeState = this.calculateState(new Set(Object.values(serviceState ?? {})));
+  private async updateBadge(serviceState: BadgeStateSetting[], tabId: number) {
+    const newBadgeState = this.calculateState(new Set(serviceState));
     try {
       await this.badgeApi.setState(newBadgeState, tabId);
     } catch (error) {

--- a/apps/browser/src/platform/badge/badge.service.ts
+++ b/apps/browser/src/platform/badge/badge.service.ts
@@ -2,6 +2,7 @@ import {
   BehaviorSubject,
   combineLatest,
   concatMap,
+  debounceTime,
   map,
   merge,
   Observable,
@@ -17,6 +18,8 @@ import { BadgeBrowserApi, RawBadgeState, Tab } from "./badge-browser-api";
 import { DefaultBadgeState } from "./consts";
 import { BadgeStatePriority } from "./priority";
 import { BadgeState, Unset } from "./state";
+
+const BADGE_UPDATE_DEBOUNCE_MS = 100;
 
 export interface BadgeStateSetting {
   priority: BadgeStatePriority;
@@ -69,6 +72,7 @@ export class BadgeService {
                 states: states.filter((s): s is BadgeStateSetting => s !== undefined),
                 tab,
               })),
+              debounceTime(BADGE_UPDATE_DEBOUNCE_MS),
             ),
           );
 

--- a/apps/browser/src/platform/badge/badge.service.ts
+++ b/apps/browser/src/platform/badge/badge.service.ts
@@ -141,8 +141,8 @@ export class BadgeService {
     this.stateFunctions.next(newDynamicStateFunctions);
   }
 
-  private calculateState(states: Set<BadgeStateSetting>): RawBadgeState {
-    const sortedStates = [...states].sort((a, b) => a.priority - b.priority);
+  private calculateState(states: BadgeStateSetting[]): RawBadgeState {
+    const sortedStates = states.sort((a, b) => a.priority - b.priority);
 
     const mergedState = sortedStates
       .map((s) => s.state)
@@ -173,7 +173,7 @@ export class BadgeService {
    * @param activeTabs The currently active tabs. If not provided, it will be fetched from the badge API.
    */
   private async updateBadge(serviceState: BadgeStateSetting[], tabId: number) {
-    const newBadgeState = this.calculateState(new Set(serviceState));
+    const newBadgeState = this.calculateState(serviceState);
     try {
       await this.badgeApi.setState(newBadgeState, tabId);
     } catch (error) {

--- a/apps/browser/src/platform/badge/scope.ts
+++ b/apps/browser/src/platform/badge/scope.ts
@@ -1,0 +1,23 @@
+export const BadgeStateScope = {
+  /**
+   * The state is global and applies to all users.
+   */
+  Global: { type: "global" } satisfies BadgeStateScope,
+  /**
+   * The state is for a specific user and only applies to that user when they are unlocked.
+   */
+  UserUnlocked: (userId: string) =>
+    ({
+      type: "user_unlocked",
+      userId,
+    }) satisfies BadgeStateScope,
+} as const;
+
+export type BadgeStateScope =
+  | {
+      type: "global";
+    }
+  | {
+      type: "user_unlocked";
+      userId: string;
+    };

--- a/apps/browser/src/platform/badge/state.ts
+++ b/apps/browser/src/platform/badge/state.ts
@@ -1,6 +1,8 @@
 import { BadgeIcon } from "./icon";
 
-export const Unset = Symbol("Unset badge state");
+const UnsetValue = Symbol("Unset badge state");
+
+export const Unset = UnsetValue as typeof UnsetValue;
 export type Unset = typeof Unset;
 
 export type BadgeState = {

--- a/apps/browser/src/platform/badge/test/mock-badge-browser-api.ts
+++ b/apps/browser/src/platform/badge/test/mock-badge-browser-api.ts
@@ -5,6 +5,7 @@ import { BadgeBrowserApi, RawBadgeState, Tab } from "../badge-browser-api";
 export class MockBadgeBrowserApi implements BadgeBrowserApi {
   private _activeTabsUpdated$ = new BehaviorSubject<Tab[]>([]);
   activeTabsUpdated$ = this._activeTabsUpdated$.asObservable();
+  activeTabs$ = this._activeTabsUpdated$.asObservable();
 
   specificStates: Record<number, RawBadgeState> = {};
   generalState?: RawBadgeState;

--- a/apps/browser/src/platform/badge/test/mock-badge-browser-api.ts
+++ b/apps/browser/src/platform/badge/test/mock-badge-browser-api.ts
@@ -1,11 +1,26 @@
-import { BehaviorSubject } from "rxjs";
+import { BehaviorSubject, concat, defer, of, Subject, switchMap } from "rxjs";
 
-import { BadgeBrowserApi, RawBadgeState, Tab } from "../badge-browser-api";
+import { BadgeBrowserApi, RawBadgeState, Tab, TabEvent } from "../badge-browser-api";
 
 export class MockBadgeBrowserApi implements BadgeBrowserApi {
+  private _activeTabs = new BehaviorSubject<Tab[]>([]);
   private _activeTabsUpdated$ = new BehaviorSubject<Tab[]>([]);
+  private _tabEvents$ = new Subject<TabEvent>();
   activeTabsUpdated$ = this._activeTabsUpdated$.asObservable();
   activeTabs$ = this._activeTabsUpdated$.asObservable();
+
+  tabEvents$ = concat(
+    defer(() => [this.activeTabs]).pipe(
+      switchMap((activeTabs) => {
+        const tabEvents: TabEvent[] = activeTabs.map((tabId) => ({
+          type: "activated",
+          tab: { tabId, url: `https://example.com/${tabId}` },
+        }));
+        return of(...tabEvents);
+      }),
+    ),
+    this._tabEvents$.asObservable(),
+  );
 
   specificStates: Record<number, RawBadgeState> = {};
   generalState?: RawBadgeState;
@@ -29,6 +44,21 @@ export class MockBadgeBrowserApi implements BadgeBrowserApi {
     this._activeTabsUpdated$.next(
       tabs.map((tabId) => ({ tabId, url: `https://example.com/${tabId}` })),
     );
+
+    tabs.forEach((tabId) => {
+      this._tabEvents$.next({
+        type: "activated",
+        tab: { tabId, url: `https://example.com/${tabId}` },
+      });
+    });
+  }
+
+  updateTab(tabId: number) {
+    this._tabEvents$.next({ type: "updated", tab: { tabId, url: `https://example.com/${tabId}` } });
+  }
+
+  deactivateTab(tabId: number) {
+    this._tabEvents$.next({ type: "deactivated", tabId });
   }
 
   setState = jest.fn().mockImplementation((state: RawBadgeState, tabId?: number): Promise<void> => {

--- a/apps/browser/src/vault/services/at-risk-cipher-badge-updater.service.spec.ts
+++ b/apps/browser/src/vault/services/at-risk-cipher-badge-updater.service.spec.ts
@@ -1,12 +1,11 @@
-import { BehaviorSubject } from "rxjs";
+import { BehaviorSubject, firstValueFrom } from "rxjs";
 
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
-import { SecurityTask, TaskService } from "@bitwarden/common/vault/tasks";
-import { LogService } from "@bitwarden/logging";
-import { UserId } from "@bitwarden/user-core";
+import { SecurityTask, SecurityTaskType, TaskService } from "@bitwarden/common/vault/tasks";
 
-import { BadgeService } from "../../platform/badge/badge.service";
+import { Tab } from "../../platform/badge/badge-browser-api";
+import { BadgeService, DynamicStateFunction } from "../../platform/badge/badge.service";
 import { BadgeIcon } from "../../platform/badge/icon";
 import { BadgeStatePriority } from "../../platform/badge/priority";
 import { Unset } from "../../platform/badge/state";
@@ -17,35 +16,33 @@ import { AtRiskCipherBadgeUpdaterService } from "./at-risk-cipher-badge-updater.
 describe("AtRiskCipherBadgeUpdaterService", () => {
   let service: AtRiskCipherBadgeUpdaterService;
 
-  let setState: jest.Mock;
-  let clearState: jest.Mock;
-  let warning: jest.Mock;
+  let setDynamicState: jest.Mock;
   let getAllDecryptedForUrl: jest.Mock;
   let getTab: jest.Mock;
   let addListener: jest.Mock;
 
-  const activeAccount$ = new BehaviorSubject({ id: "test-account-id" });
-  const cipherViews$ = new BehaviorSubject([]);
-  const pendingTasks$ = new BehaviorSubject<SecurityTask[]>([]);
-  const userId = "test-user-id" as UserId;
+  let activeAccount$: BehaviorSubject<{ id: string }>;
+  let cipherViews$: BehaviorSubject<Array<{ id: string; isDeleted?: boolean }>>;
+  let pendingTasks$: BehaviorSubject<SecurityTask[]>;
 
   beforeEach(async () => {
-    setState = jest.fn().mockResolvedValue(undefined);
-    clearState = jest.fn().mockResolvedValue(undefined);
-    warning = jest.fn();
+    setDynamicState = jest.fn().mockResolvedValue(undefined);
     getAllDecryptedForUrl = jest.fn().mockResolvedValue([]);
     getTab = jest.fn();
     addListener = jest.fn();
+
+    activeAccount$ = new BehaviorSubject({ id: "test-account-id" });
+    cipherViews$ = new BehaviorSubject<Array<{ id: string; isDeleted?: boolean }>>([]);
+    pendingTasks$ = new BehaviorSubject<SecurityTask[]>([]);
 
     jest.spyOn(BrowserApi, "addListener").mockImplementation(addListener);
     jest.spyOn(BrowserApi, "getTab").mockImplementation(getTab);
 
     service = new AtRiskCipherBadgeUpdaterService(
-      { setState, clearState } as unknown as BadgeService,
+      { setDynamicState } as unknown as BadgeService,
       { activeAccount$ } as unknown as AccountService,
-      { cipherViews$, getAllDecryptedForUrl } as unknown as CipherService,
-      { warning } as unknown as LogService,
-      { pendingTasks$ } as unknown as TaskService,
+      { cipherViews$: () => cipherViews$, getAllDecryptedForUrl } as unknown as CipherService,
+      { pendingTasks$: () => pendingTasks$ } as unknown as TaskService,
     );
 
     await service.init();
@@ -55,30 +52,41 @@ describe("AtRiskCipherBadgeUpdaterService", () => {
     jest.restoreAllMocks();
   });
 
+  it("registers dynamic state function on init", () => {
+    expect(setDynamicState).toHaveBeenCalledWith("at-risk-cipher-badge", expect.any(Function));
+  });
+
   it("clears the tab state when there are no ciphers and no pending tasks", async () => {
-    const tab = { id: 1 } as chrome.tabs.Tab;
+    const tab: Tab = { tabId: 1, url: "https://bitwarden.com" };
+    const stateFunction = setDynamicState.mock.calls[0][1];
 
-    await service["setTabState"](tab, userId, []);
+    const state = await firstValueFrom(stateFunction(tab));
 
-    expect(clearState).toHaveBeenCalledWith("at-risk-cipher-badge-1");
+    expect(state).toBeUndefined();
   });
 
   it("sets state when there are pending tasks for the tab", async () => {
-    const tab = { id: 3, url: "https://bitwarden.com" } as chrome.tabs.Tab;
-    const pendingTasks: SecurityTask[] = [{ id: "task1", cipherId: "cipher1" } as SecurityTask];
+    const tab: Tab = { tabId: 3, url: "https://bitwarden.com" };
+    const stateFunction: DynamicStateFunction = setDynamicState.mock.calls[0][1];
+    const pendingTasks: SecurityTask[] = [
+      {
+        id: "task1",
+        cipherId: "cipher1",
+        type: SecurityTaskType.UpdateAtRiskCredential,
+      } as SecurityTask,
+    ];
+    pendingTasks$.next(pendingTasks);
     getAllDecryptedForUrl.mockResolvedValueOnce([{ id: "cipher1" }]);
 
-    await service["setTabState"](tab, userId, pendingTasks);
+    const state = await firstValueFrom(stateFunction(tab));
 
-    expect(setState).toHaveBeenCalledWith(
-      "at-risk-cipher-badge-3",
-      BadgeStatePriority.High,
-      {
+    expect(state).toEqual({
+      priority: BadgeStatePriority.High,
+      state: {
         icon: BadgeIcon.Berry,
         text: Unset,
         backgroundColor: Unset,
       },
-      3,
-    );
+    });
   });
 });

--- a/apps/browser/src/vault/services/at-risk-cipher-badge-updater.service.spec.ts
+++ b/apps/browser/src/vault/services/at-risk-cipher-badge-updater.service.spec.ts
@@ -5,7 +5,7 @@ import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.servi
 import { SecurityTask, SecurityTaskType, TaskService } from "@bitwarden/common/vault/tasks";
 
 import { Tab } from "../../platform/badge/badge-browser-api";
-import { BadgeService, DynamicStateFunction } from "../../platform/badge/badge.service";
+import { BadgeService, BadgeStateFunction } from "../../platform/badge/badge.service";
 import { BadgeIcon } from "../../platform/badge/icon";
 import { BadgeStatePriority } from "../../platform/badge/priority";
 import { Unset } from "../../platform/badge/state";
@@ -67,7 +67,7 @@ describe("AtRiskCipherBadgeUpdaterService", () => {
 
   it("sets state when there are pending tasks for the tab", async () => {
     const tab: Tab = { tabId: 3, url: "https://bitwarden.com" };
-    const stateFunction: DynamicStateFunction = setDynamicState.mock.calls[0][1];
+    const stateFunction: BadgeStateFunction = setDynamicState.mock.calls[0][1];
     const pendingTasks: SecurityTask[] = [
       {
         id: "task1",

--- a/apps/browser/src/vault/services/at-risk-cipher-badge-updater.service.spec.ts
+++ b/apps/browser/src/vault/services/at-risk-cipher-badge-updater.service.spec.ts
@@ -16,7 +16,7 @@ import { AtRiskCipherBadgeUpdaterService } from "./at-risk-cipher-badge-updater.
 describe("AtRiskCipherBadgeUpdaterService", () => {
   let service: AtRiskCipherBadgeUpdaterService;
 
-  let setDynamicState: jest.Mock;
+  let setState: jest.Mock;
   let getAllDecryptedForUrl: jest.Mock;
   let getTab: jest.Mock;
   let addListener: jest.Mock;
@@ -26,7 +26,7 @@ describe("AtRiskCipherBadgeUpdaterService", () => {
   let pendingTasks$: BehaviorSubject<SecurityTask[]>;
 
   beforeEach(async () => {
-    setDynamicState = jest.fn().mockResolvedValue(undefined);
+    setState = jest.fn().mockResolvedValue(undefined);
     getAllDecryptedForUrl = jest.fn().mockResolvedValue([]);
     getTab = jest.fn();
     addListener = jest.fn();
@@ -39,7 +39,7 @@ describe("AtRiskCipherBadgeUpdaterService", () => {
     jest.spyOn(BrowserApi, "getTab").mockImplementation(getTab);
 
     service = new AtRiskCipherBadgeUpdaterService(
-      { setDynamicState } as unknown as BadgeService,
+      { setState } as unknown as BadgeService,
       { activeAccount$ } as unknown as AccountService,
       { cipherViews$: () => cipherViews$, getAllDecryptedForUrl } as unknown as CipherService,
       { pendingTasks$: () => pendingTasks$ } as unknown as TaskService,
@@ -53,12 +53,12 @@ describe("AtRiskCipherBadgeUpdaterService", () => {
   });
 
   it("registers dynamic state function on init", () => {
-    expect(setDynamicState).toHaveBeenCalledWith("at-risk-cipher-badge", expect.any(Function));
+    expect(setState).toHaveBeenCalledWith("at-risk-cipher-badge", expect.any(Function));
   });
 
   it("clears the tab state when there are no ciphers and no pending tasks", async () => {
     const tab: Tab = { tabId: 1, url: "https://bitwarden.com" };
-    const stateFunction = setDynamicState.mock.calls[0][1];
+    const stateFunction = setState.mock.calls[0][1];
 
     const state = await firstValueFrom(stateFunction(tab));
 
@@ -67,7 +67,7 @@ describe("AtRiskCipherBadgeUpdaterService", () => {
 
   it("sets state when there are pending tasks for the tab", async () => {
     const tab: Tab = { tabId: 3, url: "https://bitwarden.com" };
-    const stateFunction: BadgeStateFunction = setDynamicState.mock.calls[0][1];
+    const stateFunction: BadgeStateFunction = setState.mock.calls[0][1];
     const pendingTasks: SecurityTask[] = [
       {
         id: "task1",

--- a/apps/browser/src/vault/services/at-risk-cipher-badge-updater.service.ts
+++ b/apps/browser/src/vault/services/at-risk-cipher-badge-updater.service.ts
@@ -1,26 +1,18 @@
-import { combineLatest, map, mergeMap, of, Subject, switchMap } from "rxjs";
+import { combineLatest, concatMap, map, of, switchMap } from "rxjs";
 
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
-import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
-import { UserId } from "@bitwarden/common/types/guid";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
-import { SecurityTask, SecurityTaskType, TaskService } from "@bitwarden/common/vault/tasks";
+import { SecurityTaskType, TaskService } from "@bitwarden/common/vault/tasks";
 import { filterOutNullish } from "@bitwarden/common/vault/utils/observable-utilities";
 
 import { BadgeService } from "../../platform/badge/badge.service";
 import { BadgeIcon } from "../../platform/badge/icon";
 import { BadgeStatePriority } from "../../platform/badge/priority";
 import { Unset } from "../../platform/badge/state";
-import { BrowserApi } from "../../platform/browser/browser-api";
 
-const StateName = (tabId: number) => `at-risk-cipher-badge-${tabId}`;
+const StateName = "at-risk-cipher-badge";
 
 export class AtRiskCipherBadgeUpdaterService {
-  private tabReplaced$ = new Subject<{ addedTab: chrome.tabs.Tab; removedTabId: number }>();
-  private tabUpdated$ = new Subject<chrome.tabs.Tab>();
-  private tabRemoved$ = new Subject<number>();
-  private tabActivated$ = new Subject<chrome.tabs.Tab>();
-
   private activeUserData$ = this.accountService.activeAccount$.pipe(
     filterOutNullish(),
     switchMap((user) =>
@@ -40,124 +32,36 @@ export class AtRiskCipherBadgeUpdaterService {
     private badgeService: BadgeService,
     private accountService: AccountService,
     private cipherService: CipherService,
-    private logService: LogService,
     private taskService: TaskService,
-  ) {
-    combineLatest({
-      replaced: this.tabReplaced$,
-      activeUserData: this.activeUserData$,
-    })
-      .pipe(
-        mergeMap(async ({ replaced, activeUserData: [userId, pendingTasks] }) => {
-          await this.clearTabState(replaced.removedTabId);
-          await this.setTabState(replaced.addedTab, userId, pendingTasks);
-        }),
-      )
-      .subscribe(() => {});
-
-    combineLatest({
-      tab: this.tabActivated$,
-      activeUserData: this.activeUserData$,
-    })
-      .pipe(
-        mergeMap(async ({ tab, activeUserData: [userId, pendingTasks] }) => {
-          await this.setTabState(tab, userId, pendingTasks);
-        }),
-      )
-      .subscribe();
-
-    combineLatest({
-      tab: this.tabUpdated$,
-      activeUserData: this.activeUserData$,
-    })
-      .pipe(
-        mergeMap(async ({ tab, activeUserData: [userId, pendingTasks] }) => {
-          await this.setTabState(tab, userId, pendingTasks);
-        }),
-      )
-      .subscribe();
-
-    this.tabRemoved$
-      .pipe(
-        mergeMap(async (tabId) => {
-          await this.clearTabState(tabId);
-        }),
-      )
-      .subscribe();
-  }
+  ) {}
 
   init() {
-    BrowserApi.addListener(chrome.tabs.onReplaced, async (addedTabId, removedTabId) => {
-      const newTab = await BrowserApi.getTab(addedTabId);
-      if (!newTab) {
-        this.logService.warning(
-          `Tab replaced event received but new tab not found (id: ${addedTabId})`,
-        );
-        return;
-      }
+    this.badgeService.setDynamicState(StateName, (tab) => {
+      return this.activeUserData$.pipe(
+        concatMap(async ([userId, pendingTasks]) => {
+          const ciphers = tab.url
+            ? await this.cipherService.getAllDecryptedForUrl(tab.url, userId, [], undefined, true)
+            : [];
 
-      this.tabReplaced$.next({
-        removedTabId,
-        addedTab: newTab,
-      });
+          const hasPendingTasksForTab = pendingTasks.some((task) =>
+            ciphers.some((cipher) => cipher.id === task.cipherId && !cipher.isDeleted),
+          );
+
+          if (!hasPendingTasksForTab) {
+            return undefined;
+          }
+
+          return {
+            priority: BadgeStatePriority.High,
+            state: {
+              icon: BadgeIcon.Berry,
+              // Unset text and background color to use default badge appearance
+              text: Unset,
+              backgroundColor: Unset,
+            },
+          };
+        }),
+      );
     });
-
-    BrowserApi.addListener(chrome.tabs.onUpdated, (_, changeInfo, tab) => {
-      if (changeInfo.url) {
-        this.tabUpdated$.next(tab);
-      }
-    });
-
-    BrowserApi.addListener(chrome.tabs.onActivated, async (activeInfo) => {
-      const tab = await BrowserApi.getTab(activeInfo.tabId);
-      if (!tab) {
-        this.logService.warning(
-          `Tab activated event received but tab not found (id: ${activeInfo.tabId})`,
-        );
-        return;
-      }
-
-      this.tabActivated$.next(tab);
-    });
-
-    BrowserApi.addListener(chrome.tabs.onRemoved, (tabId, _) => this.tabRemoved$.next(tabId));
-  }
-
-  /** Sets the pending task state for the tab */
-  private async setTabState(tab: chrome.tabs.Tab, userId: UserId, pendingTasks: SecurityTask[]) {
-    if (!tab.id) {
-      this.logService.warning("Tab event received but tab id is undefined");
-      return;
-    }
-
-    const ciphers = tab.url
-      ? await this.cipherService.getAllDecryptedForUrl(tab.url, userId, [], undefined, true)
-      : [];
-
-    const hasPendingTasksForTab = pendingTasks.some((task) =>
-      ciphers.some((cipher) => cipher.id === task.cipherId && !cipher.isDeleted),
-    );
-
-    if (!hasPendingTasksForTab) {
-      await this.clearTabState(tab.id);
-      return;
-    }
-
-    await this.badgeService.setState(
-      StateName(tab.id),
-      BadgeStatePriority.High,
-      {
-        icon: BadgeIcon.Berry,
-        // Unset text and background color to use default badge appearance
-        text: Unset,
-        backgroundColor: Unset,
-      },
-      tab.id,
-    );
-  }
-
-  /** Clears the pending task state from a tab */
-  private async clearTabState(tabId: number) {
-    await this.badgeService.clearState(StateName(tabId));
   }
 }

--- a/apps/browser/src/vault/services/at-risk-cipher-badge-updater.service.ts
+++ b/apps/browser/src/vault/services/at-risk-cipher-badge-updater.service.ts
@@ -36,7 +36,7 @@ export class AtRiskCipherBadgeUpdaterService {
   ) {}
 
   init() {
-    this.badgeService.setDynamicState(StateName, (tab) => {
+    this.badgeService.setState(StateName, (tab) => {
       return this.activeUserData$.pipe(
         concatMap(async ([userId, pendingTasks]) => {
           const ciphers = tab.url

--- a/libs/state/src/core/state-definitions.ts
+++ b/libs/state/src/core/state-definitions.ts
@@ -109,9 +109,6 @@ export const NEW_WEB_LAYOUT_BANNER_DISK = new StateDefinition("newWebLayoutBanne
 export const APPLICATION_ID_DISK = new StateDefinition("applicationId", "disk", {
   web: "disk-local",
 });
-export const BADGE_MEMORY = new StateDefinition("badge", "memory", {
-  browser: "memory-large-object",
-});
 export const BIOMETRIC_SETTINGS_DISK = new StateDefinition("biometricSettings", "disk");
 export const CLEAR_EVENT_DISK = new StateDefinition("clearEvent", "disk");
 export const CONFIG_DISK = new StateDefinition("config", "disk", {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

Rewrites the badge service to not rely on state, that way these values won't be able to stay in memory.
This new design also greatly simplifies the usage by unifying general and tab-specific states into a single callback function.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
