### PR TITLE
Display autofill overlay on potterybarn.com password field

### DIFF
--- a/apps/browser/src/autofill/services/inline-menu-field-qualification.service.ts
+++ b/apps/browser/src/autofill/services/inline-menu-field-qualification.service.ts
@@ -434,11 +434,9 @@ export class InlineMenuFieldQualificationService
       return false;
     }
 
-    // If the form has any visible username fields, we should treat the field as part of a login form
-    const visibleUsernameFields = usernameFieldsInPageDetails.filter(
-      (f) => f.form === field.form && f.viewable,
-    );
-    if (visibleUsernameFields.length > 0) {
+    // If the form has any username fields, we should treat the field as part of a login form
+    const usernameFields = usernameFieldsInPageDetails.filter((f) => f.form === field.form);
+    if (usernameFields.length > 0) {
       return true;
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-25072](https://bitwarden.atlassian.net/browse/PM-25072)

## 📔 Objective

potterybarn.com, williams-sonoma.com, and other sister sites in the network did not display the password autofill menu.  What was happening was on the password form there was a username field that was hidden by CSS.   Since the username field wasn't visible we were failing the autofill.  Now we allow the hidden username field if the password field is part of the same form.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
