### PR TITLE
[PM-19989] Fix table header sort indicator and enable drawer open on row click

### DIFF
--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/app-table-row-scrollable.component.html
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/app-table-row-scrollable.component.html
@@ -4,7 +4,9 @@
       <th></th>
       <th bitCell></th>
       <th bitSortable="applicationName" bitCell>{{ "application" | i18n }}</th>
-      <th bitSortable="atRiskPasswordCount" bitCell>{{ "atRiskPasswords" | i18n }}</th>
+      <th bitSortable="atRiskPasswordCount" bitCell default="desc">
+        {{ "atRiskPasswords" | i18n }}
+      </th>
       <th bitSortable="passwordCount" bitCell>{{ "totalPasswords" | i18n }}</th>
       <th bitSortable="atRiskMemberCount" bitCell>{{ "atRiskMembers" | i18n }}</th>
       <th bitSortable="memberCount" bitCell>{{ "totalMembers" | i18n }}</th>
@@ -14,6 +16,7 @@
         bitCell
         *ngIf="showRowCheckBox"
         [ngClass]="{ 'tw-bg-primary-100': isDrawerIsOpenForThisRecord(row.applicationName) }"
+        appStopProp
       >
         <input
           bitCheckbox
@@ -31,21 +34,42 @@
       >
         <i class="bwi bwi-star-f" *ngIf="row.isMarkedAsCritical"></i>
       </td>
-      <td bitCell>
-        <app-vault-icon *ngIf="row.ciphers.length > 0" [cipher]="row.ciphers[0]"></app-vault-icon>
-      </td>
       <td
+        bitCell
         class="tw-cursor-pointer"
         [ngClass]="{ 'tw-bg-primary-100': isDrawerIsOpenForThisRecord(row.applicationName) }"
         (click)="showAppAtRiskMembers(row.applicationName)"
-        (keypress)="showAppAtRiskMembers(row.applicationName)"
+        (keydown.enter)="showAppAtRiskMembers(row.applicationName)"
+        (keydown.space)="showAppAtRiskMembers(row.applicationName)"
+        role="button"
+        tabindex="0"
+        [attr.aria-label]="'viewItem' | i18n"
+      >
+        <app-vault-icon *ngIf="row.ciphers.length > 0" [cipher]="row.ciphers[0]"></app-vault-icon>
+      </td>
+      <td
         bitCell
+        class="tw-cursor-pointer"
+        [ngClass]="{ 'tw-bg-primary-100': isDrawerIsOpenForThisRecord(row.applicationName) }"
+        (click)="showAppAtRiskMembers(row.applicationName)"
+        (keydown.enter)="showAppAtRiskMembers(row.applicationName)"
+        (keydown.space)="showAppAtRiskMembers(row.applicationName)"
+        role="button"
+        tabindex="0"
+        [attr.aria-label]="'viewItem' | i18n"
       >
         <span>{{ row.applicationName }}</span>
       </td>
       <td
         bitCell
+        class="tw-cursor-pointer"
         [ngClass]="{ 'tw-bg-primary-100': isDrawerIsOpenForThisRecord(row.applicationName) }"
+        (click)="showAppAtRiskMembers(row.applicationName)"
+        (keydown.enter)="showAppAtRiskMembers(row.applicationName)"
+        (keydown.space)="showAppAtRiskMembers(row.applicationName)"
+        role="button"
+        tabindex="0"
+        [attr.aria-label]="'viewItem' | i18n"
       >
         <span>
           {{ row.atRiskPasswordCount }}
@@ -53,7 +77,14 @@
       </td>
       <td
         bitCell
+        class="tw-cursor-pointer"
         [ngClass]="{ 'tw-bg-primary-100': isDrawerIsOpenForThisRecord(row.applicationName) }"
+        (click)="showAppAtRiskMembers(row.applicationName)"
+        (keydown.enter)="showAppAtRiskMembers(row.applicationName)"
+        (keydown.space)="showAppAtRiskMembers(row.applicationName)"
+        role="button"
+        tabindex="0"
+        [attr.aria-label]="'viewItem' | i18n"
       >
         <span>
           {{ row.passwordCount }}
@@ -61,7 +92,14 @@
       </td>
       <td
         bitCell
+        class="tw-cursor-pointer"
         [ngClass]="{ 'tw-bg-primary-100': isDrawerIsOpenForThisRecord(row.applicationName) }"
+        (click)="showAppAtRiskMembers(row.applicationName)"
+        (keydown.enter)="showAppAtRiskMembers(row.applicationName)"
+        (keydown.space)="showAppAtRiskMembers(row.applicationName)"
+        role="button"
+        tabindex="0"
+        [attr.aria-label]="'viewItem' | i18n"
       >
         <span>
           {{ row.atRiskMemberCount }}
@@ -70,7 +108,14 @@
       <td
         bitCell
         data-testid="total-membership"
+        class="tw-cursor-pointer"
         [ngClass]="{ 'tw-bg-primary-100': isDrawerIsOpenForThisRecord(row.applicationName) }"
+        (click)="showAppAtRiskMembers(row.applicationName)"
+        (keydown.enter)="showAppAtRiskMembers(row.applicationName)"
+        (keydown.space)="showAppAtRiskMembers(row.applicationName)"
+        role="button"
+        tabindex="0"
+        [attr.aria-label]="'viewItem' | i18n"
       >
         {{ row.memberCount }}
       </td>
@@ -78,6 +123,7 @@
         bitCell
         *ngIf="showRowMenuForCriticalApps"
         [ngClass]="{ 'tw-bg-primary-100': isDrawerIsOpenForThisRecord(row.applicationName) }"
+        appStopProp
       >
         <button
           [bitMenuTriggerFor]="rowMenu"


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-19989

## 📔 Objective

1. The table is sorted by at-risk passwords, but the sort indicator was not reflected in the table header. 
2. Previously, only selecting the application name would open the drawer component. This behavior has been updated to ensure the drawer opens as expected when the row is clicked.

## 📸 Screenshots

<img width="1123" height="112" alt="image" src="https://github.com/user-attachments/assets/314b4391-773c-43cc-a606-2f177afe2b8c" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
