### PR TITLE
[PM-25629] Hide Chromium importer for Brave/Windows only

### DIFF
--- a/apps/desktop/desktop_native/bitwarden_chromium_importer/src/windows.rs
+++ b/apps/desktop/desktop_native/bitwarden_chromium_importer/src/windows.rs
@@ -16,8 +16,7 @@ mod util;
 // Public API
 //
 
-// if Brave is re-enabled, be sure to adjust array size (5 => 6)
-pub const SUPPORTED_BROWSERS: [BrowserConfig; 5] = [
+pub const SUPPORTED_BROWSERS: [BrowserConfig; 6] = [
     BrowserConfig {
         name: "Chrome",
         data_dir: "AppData/Local/Google/Chrome/User Data",
@@ -30,11 +29,10 @@ pub const SUPPORTED_BROWSERS: [BrowserConfig; 5] = [
         name: "Microsoft Edge",
         data_dir: "AppData/Local/Microsoft/Edge/User Data",
     },
-    /* Remove Brave for Windows Desktop clients */
-    // BrowserConfig {
-    //     name: "Brave",
-    //     data_dir: "AppData/Local/BraveSoftware/Brave-Browser/User Data",
-    // },
+    BrowserConfig {
+        name: "Brave",
+        data_dir: "AppData/Local/BraveSoftware/Brave-Browser/User Data",
+    },
     BrowserConfig {
         name: "Opera",
         data_dir: "AppData/Roaming/Opera Software/Opera Stable",

--- a/apps/desktop/desktop_native/bitwarden_chromium_importer/src/windows.rs
+++ b/apps/desktop/desktop_native/bitwarden_chromium_importer/src/windows.rs
@@ -16,7 +16,8 @@ mod util;
 // Public API
 //
 
-pub const SUPPORTED_BROWSERS: [BrowserConfig; 6] = [
+// if Brave is re-enabled, be sure to adjust array size (5 => 6)
+pub const SUPPORTED_BROWSERS: [BrowserConfig; 5] = [
     BrowserConfig {
         name: "Chrome",
         data_dir: "AppData/Local/Google/Chrome/User Data",
@@ -29,10 +30,12 @@ pub const SUPPORTED_BROWSERS: [BrowserConfig; 6] = [
         name: "Microsoft Edge",
         data_dir: "AppData/Local/Microsoft/Edge/User Data",
     },
-    BrowserConfig {
-        name: "Brave",
-        data_dir: "AppData/Local/BraveSoftware/Brave-Browser/User Data",
-    },
+    /* Remove Brave for Windows Desktop clients */
+    
+    // BrowserConfig {
+    //     name: "Brave",
+    //     data_dir: "AppData/Local/BraveSoftware/Brave-Browser/User Data",
+    // },
     BrowserConfig {
         name: "Opera",
         data_dir: "AppData/Roaming/Opera Software/Opera Stable",

--- a/apps/desktop/desktop_native/bitwarden_chromium_importer/src/windows.rs
+++ b/apps/desktop/desktop_native/bitwarden_chromium_importer/src/windows.rs
@@ -31,7 +31,6 @@ pub const SUPPORTED_BROWSERS: [BrowserConfig; 5] = [
         data_dir: "AppData/Local/Microsoft/Edge/User Data",
     },
     /* Remove Brave for Windows Desktop clients */
-    
     // BrowserConfig {
     //     name: "Brave",
     //     data_dir: "AppData/Local/BraveSoftware/Brave-Browser/User Data",

--- a/libs/importer/src/services/import.service.ts
+++ b/libs/importer/src/services/import.service.ts
@@ -146,21 +146,21 @@ export class ImportService implements ImportServiceAbstraction {
       map(([type, enabled]) => {
         let loaders = availableLoaders(type, client);
 
-        if (enabled) {
-          /* Hide Chromium importer for Brave on Windows desktop only */
+        let isUnsupported = false;
+
+        if (enabled && type === "bravecsv") {
           try {
-            const device = this.system.environment.getDevice?.();
+            const device = this.system.environment.getDevice();
             const isWindowsDesktop = device === DeviceType.WindowsDesktop;
-            if (type === "bravecsv" && isWindowsDesktop) {
-              loaders = loaders?.filter((loader) => loader !== Loader.chromium);
+            if (isWindowsDesktop) {
+              isUnsupported = true;
             }
           } catch {
-            // In the case we can't detect the environment, it's safer to remove the chromium loader
-            loaders = loaders?.filter((loader) => loader !== Loader.chromium);
+            isUnsupported = true;
           }
         }
-
-        if (!enabled) {
+        // If the feature flag is disabled, or if the browser is unsupported, remove the chromium loader
+        if (!enabled || isUnsupported) {
           loaders = loaders?.filter((loader) => loader !== Loader.chromium);
         }
 

--- a/libs/importer/src/services/import.service.ts
+++ b/libs/importer/src/services/import.service.ts
@@ -146,15 +146,18 @@ export class ImportService implements ImportServiceAbstraction {
       map(([type, enabled]) => {
         let loaders = availableLoaders(type, client);
 
-        /* Hide Chromium importer for Brave on Windows desktop only */
-        try {
-          const device = this.system.environment.getDevice?.();
-          const isWindowsDesktop = device === DeviceType.WindowsDesktop;
-          if (type === "bravecsv" && isWindowsDesktop) {
+        if (enabled) {
+          /* Hide Chromium importer for Brave on Windows desktop only */
+          try {
+            const device = this.system.environment.getDevice?.();
+            const isWindowsDesktop = device === DeviceType.WindowsDesktop;
+            if (type === "bravecsv" && isWindowsDesktop) {
+              loaders = loaders?.filter((loader) => loader !== Loader.chromium);
+            }
+          } catch {
+            // In the case we can't detect the environment, it's safer to remove the chromium loader
             loaders = loaders?.filter((loader) => loader !== Loader.chromium);
           }
-        } catch {
-          // TODO handle situation where environment could not provide device type
         }
 
         if (!enabled) {


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-25629

## 📔 Objective

Hide / disable the "direct from browser" Chromium importer for Brave on Windows desktop clients only. 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
