### PR TITLE
[PM-25682] Migrate CipherView and subviews to be TS strict compliant

### DIFF
--- a/apps/browser/src/autofill/background/notification.background.spec.ts
+++ b/apps/browser/src/autofill/background/notification.background.spec.ts
@@ -133,19 +133,11 @@ describe("NotificationBackground", () => {
 
       expect(cipherView.name).toEqual("example.com");
       expect(cipherView.login).toEqual({
-        autofillOnPageLoad: null,
-        fido2Credentials: null,
+        fido2Credentials: [],
         password: message.password,
-        passwordRevisionDate: null,
-        totp: null,
         uris: [
           {
-            _canLaunch: null,
-            _domain: null,
-            _host: null,
-            _hostname: null,
             _uri: message.uri,
-            match: null,
           },
         ],
         username: message.username,

--- a/apps/browser/src/autofill/background/notification.background.ts
+++ b/apps/browser/src/autofill/background/notification.background.ts
@@ -1221,7 +1221,6 @@ export default class NotificationBackground {
     cipherView.folderId = folderId;
     cipherView.type = CipherType.Login;
     cipherView.login = loginView;
-    cipherView.organizationId = null;
 
     return cipherView;
   }

--- a/apps/browser/src/autofill/browser/cipher-context-menu-handler.ts
+++ b/apps/browser/src/autofill/browser/cipher-context-menu-handler.ts
@@ -114,6 +114,6 @@ export class CipherContextMenuHandler {
       title += ` ${cipher.card.subTitle}`;
     }
 
-    await this.mainContextMenuHandler.loadOptions(title, cipher.id, cipher);
+    await this.mainContextMenuHandler.loadOptions(title, cipher.id!, cipher);
   }
 }

--- a/apps/browser/src/autofill/browser/cipher-context-menu-handler.ts
+++ b/apps/browser/src/autofill/browser/cipher-context-menu-handler.ts
@@ -114,6 +114,6 @@ export class CipherContextMenuHandler {
       title += ` ${cipher.card.subTitle}`;
     }
 
-    await this.mainContextMenuHandler.loadOptions(title, cipher.id!, cipher);
+    await this.mainContextMenuHandler.loadOptions(title, cipher.id, cipher);
   }
 }

--- a/apps/desktop/src/vault/app/vault/vault-v2.component.ts
+++ b/apps/desktop/src/vault/app/vault/vault-v2.component.ts
@@ -45,6 +45,7 @@ import {
   CipherViewLike,
   CipherViewLikeUtils,
 } from "@bitwarden/common/vault/utils/cipher-view-like-utils";
+import { filterOutNullish } from "@bitwarden/common/vault/utils/observable-utilities";
 import {
   BadgeModule,
   ButtonModule,
@@ -167,6 +168,7 @@ export class VaultV2Component<C extends CipherViewLike>
 
   private organizations$: Observable<Organization[]> = this.accountService.activeAccount$.pipe(
     map((a) => a?.id),
+    filterOutNullish(),
     switchMap((id) => this.organizationService.organizations$(id)),
   );
 
@@ -323,7 +325,7 @@ export class VaultV2Component<C extends CipherViewLike>
       )) === true
     ) {
       const authRequests = await firstValueFrom(
-        this.authRequestService.getLatestPendingAuthRequest$(),
+        this.authRequestService.getLatestPendingAuthRequest$()!,
       );
       if (authRequests != null) {
         this.messagingService.send("openLoginApproval", {
@@ -432,7 +434,7 @@ export class VaultV2Component<C extends CipherViewLike>
     if (await this.shouldReprompt(cipher, "view")) {
       return;
     }
-    this.cipherId = cipher.id;
+    this.cipherId = cipher.id!;
     this.cipher = cipher;
     this.collections =
       this.vaultFilterComponent?.collections?.fullList.filter((c) =>
@@ -637,7 +639,7 @@ export class VaultV2Component<C extends CipherViewLike>
     if (await this.shouldReprompt(cipher, "edit")) {
       return;
     }
-    this.cipherId = cipher.id;
+    this.cipherId = cipher.id!;
     this.cipher = cipher;
     await this.buildFormConfig("edit");
     if (!cipher.edit && this.config) {
@@ -651,7 +653,7 @@ export class VaultV2Component<C extends CipherViewLike>
     if (await this.shouldReprompt(cipher, "clone")) {
       return;
     }
-    this.cipherId = cipher.id;
+    this.cipherId = cipher.id!;
     this.cipher = cipher;
     await this.buildFormConfig("clone");
     this.action = "clone";
@@ -732,7 +734,7 @@ export class VaultV2Component<C extends CipherViewLike>
         .pipe(getByIds(cipher.collectionIds)),
     );
 
-    this.cipherId = cipher.id;
+    this.cipherId = cipher.id!;
     this.cipher = cipher;
     if (this.activeUserId) {
       await this.cipherService.clearCache(this.activeUserId).catch(() => {});
@@ -758,7 +760,7 @@ export class VaultV2Component<C extends CipherViewLike>
   }
 
   async cancelCipher(cipher: CipherView) {
-    this.cipherId = cipher.id;
+    this.cipherId = cipher.id!;
     this.cipher = cipher;
     this.action = this.cipherId != null ? "view" : null;
     await this.go().catch(() => {});
@@ -963,7 +965,7 @@ export class VaultV2Component<C extends CipherViewLike>
     }
     const repromptResult = await this.passwordRepromptService.showPasswordPrompt();
     if (repromptResult) {
-      this.cipherRepromptId = cipher.id;
+      this.cipherRepromptId = cipher.id!;
     }
     return repromptResult;
   }

--- a/apps/desktop/src/vault/app/vault/vault-v2.component.ts
+++ b/apps/desktop/src/vault/app/vault/vault-v2.component.ts
@@ -434,7 +434,7 @@ export class VaultV2Component<C extends CipherViewLike>
     if (await this.shouldReprompt(cipher, "view")) {
       return;
     }
-    this.cipherId = cipher.id!;
+    this.cipherId = cipher.id;
     this.cipher = cipher;
     this.collections =
       this.vaultFilterComponent?.collections?.fullList.filter((c) =>
@@ -639,7 +639,7 @@ export class VaultV2Component<C extends CipherViewLike>
     if (await this.shouldReprompt(cipher, "edit")) {
       return;
     }
-    this.cipherId = cipher.id!;
+    this.cipherId = cipher.id;
     this.cipher = cipher;
     await this.buildFormConfig("edit");
     if (!cipher.edit && this.config) {
@@ -653,7 +653,7 @@ export class VaultV2Component<C extends CipherViewLike>
     if (await this.shouldReprompt(cipher, "clone")) {
       return;
     }
-    this.cipherId = cipher.id!;
+    this.cipherId = cipher.id;
     this.cipher = cipher;
     await this.buildFormConfig("clone");
     this.action = "clone";
@@ -734,7 +734,7 @@ export class VaultV2Component<C extends CipherViewLike>
         .pipe(getByIds(cipher.collectionIds)),
     );
 
-    this.cipherId = cipher.id!;
+    this.cipherId = cipher.id;
     this.cipher = cipher;
     if (this.activeUserId) {
       await this.cipherService.clearCache(this.activeUserId).catch(() => {});
@@ -760,7 +760,7 @@ export class VaultV2Component<C extends CipherViewLike>
   }
 
   async cancelCipher(cipher: CipherView) {
-    this.cipherId = cipher.id!;
+    this.cipherId = cipher.id;
     this.cipher = cipher;
     this.action = this.cipherId != null ? "view" : null;
     await this.go().catch(() => {});
@@ -965,7 +965,7 @@ export class VaultV2Component<C extends CipherViewLike>
     }
     const repromptResult = await this.passwordRepromptService.showPasswordPrompt();
     if (repromptResult) {
-      this.cipherRepromptId = cipher.id!;
+      this.cipherRepromptId = cipher.id;
     }
     return repromptResult;
   }

--- a/apps/web/src/app/admin-console/organizations/collections/vault.component.ts
+++ b/apps/web/src/app/admin-console/organizations/collections/vault.component.ts
@@ -1130,14 +1130,14 @@ export class vNextVaultComponent implements OnInit, OnDestroy {
     // If user has edit all Access no need to check for unassigned ciphers
     if (organization.canEditAllCiphers) {
       ciphers.map((cipher) => {
-        editAccessCiphers.push(cipher.id);
+        editAccessCiphers.push(cipher.id!);
       });
     } else {
       ciphers.map((cipher) => {
         if (cipher.collectionIds.length === 0) {
-          unassignedCiphers.push(cipher.id);
+          unassignedCiphers.push(cipher.id!);
         } else if (cipher.edit) {
-          editAccessCiphers.push(cipher.id);
+          editAccessCiphers.push(cipher.id!);
         }
       });
     }
@@ -1192,7 +1192,7 @@ export class vNextVaultComponent implements OnInit, OnDestroy {
 
     try {
       const activeUserId = await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId));
-      await this.deleteCipherWithServer(c.id, activeUserId, permanent, c.isUnassigned);
+      await this.deleteCipherWithServer(c.id!, activeUserId, permanent, c.isUnassigned);
       this.toastService.showToast({
         variant: "success",
 
@@ -1265,9 +1265,9 @@ export class vNextVaultComponent implements OnInit, OnDestroy {
 
     ciphers.map((c) => {
       if (c.isUnassigned) {
-        unassignedCiphers.push(c.id);
+        unassignedCiphers.push(c.id!);
       } else {
-        assignedCiphers.push(c.id);
+        assignedCiphers.push(c.id!);
       }
     });
 
@@ -1321,7 +1321,7 @@ export class vNextVaultComponent implements OnInit, OnDestroy {
       aType = "Password";
       value = cipher.login.password;
       typeI18nKey = "password";
-    } else if (field === "totp") {
+    } else if (field === "totp" && cipher.login.totp != null) {
       aType = "TOTP";
       const totpResponse = await firstValueFrom(this.totpService.getCode$(cipher.login.totp));
       value = totpResponse.code;
@@ -1342,7 +1342,7 @@ export class vNextVaultComponent implements OnInit, OnDestroy {
       return;
     }
 
-    if (!cipher.viewPassword) {
+    if (!cipher.viewPassword || value == null) {
       return;
     }
 
@@ -1494,7 +1494,7 @@ export class vNextVaultComponent implements OnInit, OnDestroy {
       data: {
         name: cipher.name,
         organizationId: organization.id,
-        entityId: cipher.id,
+        entityId: cipher.id!,
         showUser: true,
         entity: "cipher",
       },

--- a/apps/web/src/app/admin-console/organizations/collections/vault.component.ts
+++ b/apps/web/src/app/admin-console/organizations/collections/vault.component.ts
@@ -1088,7 +1088,7 @@ export class vNextVaultComponent implements OnInit, OnDestroy {
 
     // Allow restore of an Unassigned Item
     try {
-      if (c.id == null) {
+      if (c.id == null || c.id === "") {
         throw new Error("Cipher must have an Id to be restored");
       }
       const activeUserId = await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId));

--- a/apps/web/src/app/admin-console/organizations/collections/vault.component.ts
+++ b/apps/web/src/app/admin-console/organizations/collections/vault.component.ts
@@ -1130,14 +1130,14 @@ export class vNextVaultComponent implements OnInit, OnDestroy {
     // If user has edit all Access no need to check for unassigned ciphers
     if (organization.canEditAllCiphers) {
       ciphers.map((cipher) => {
-        editAccessCiphers.push(cipher.id!);
+        editAccessCiphers.push(cipher.id);
       });
     } else {
       ciphers.map((cipher) => {
         if (cipher.collectionIds.length === 0) {
-          unassignedCiphers.push(cipher.id!);
+          unassignedCiphers.push(cipher.id);
         } else if (cipher.edit) {
-          editAccessCiphers.push(cipher.id!);
+          editAccessCiphers.push(cipher.id);
         }
       });
     }
@@ -1192,7 +1192,7 @@ export class vNextVaultComponent implements OnInit, OnDestroy {
 
     try {
       const activeUserId = await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId));
-      await this.deleteCipherWithServer(c.id!, activeUserId, permanent, c.isUnassigned);
+      await this.deleteCipherWithServer(c.id, activeUserId, permanent, c.isUnassigned);
       this.toastService.showToast({
         variant: "success",
 
@@ -1265,9 +1265,9 @@ export class vNextVaultComponent implements OnInit, OnDestroy {
 
     ciphers.map((c) => {
       if (c.isUnassigned) {
-        unassignedCiphers.push(c.id!);
+        unassignedCiphers.push(c.id);
       } else {
-        assignedCiphers.push(c.id!);
+        assignedCiphers.push(c.id);
       }
     });
 
@@ -1494,7 +1494,7 @@ export class vNextVaultComponent implements OnInit, OnDestroy {
       data: {
         name: cipher.name,
         organizationId: organization.id,
-        entityId: cipher.id!,
+        entityId: cipher.id,
         showUser: true,
         entity: "cipher",
       },

--- a/apps/web/src/app/dirt/reports/pages/exposed-passwords-report.component.ts
+++ b/apps/web/src/app/dirt/reports/pages/exposed-passwords-report.component.ts
@@ -89,6 +89,9 @@ export class ExposedPasswordsReportComponent extends CipherReportComponent imple
 
   private async isPasswordExposed(cv: CipherView): Promise<ReportResult | null> {
     const { login } = cv;
+    if (login.password == null) {
+      return null;
+    }
     return await this.auditService.passwordLeaked(login.password).then((exposedCount) => {
       if (exposedCount > 0) {
         return { ...cv, exposedXTimes: exposedCount } as ReportResult;

--- a/bitwarden_license/bit-common/src/dirt/reports/risk-insights/helpers/risk-insights-data-mappers.ts
+++ b/bitwarden_license/bit-common/src/dirt/reports/risk-insights/helpers/risk-insights-data-mappers.ts
@@ -36,7 +36,7 @@ export function getTrimmedCipherUris(cipher: CipherView): string[] {
 
   const uniqueDomains = new Set<string>();
 
-  uris.forEach((u: { uri: string }) => {
+  uris.forEach((u: { uri: string | undefined }) => {
     const domain = Utils.getDomain(u.uri) ?? u.uri;
     uniqueDomains.add(domain);
   });
@@ -88,7 +88,7 @@ export function getFlattenedCipherDetails(
   uri: string,
 ): CipherHealthReportUriDetail {
   return {
-    cipherId: detail.id,
+    cipherId: detail.id!,
     reusedPasswordCount: detail.reusedPasswordCount,
     weakPasswordDetail: detail.weakPasswordDetail,
     exposedPasswordDetail: detail.exposedPasswordDetail,

--- a/bitwarden_license/bit-common/src/dirt/reports/risk-insights/helpers/risk-insights-data-mappers.ts
+++ b/bitwarden_license/bit-common/src/dirt/reports/risk-insights/helpers/risk-insights-data-mappers.ts
@@ -88,7 +88,7 @@ export function getFlattenedCipherDetails(
   uri: string,
 ): CipherHealthReportUriDetail {
   return {
-    cipherId: detail.id!,
+    cipherId: detail.id,
     reusedPasswordCount: detail.reusedPasswordCount,
     weakPasswordDetail: detail.weakPasswordDetail,
     exposedPasswordDetail: detail.exposedPasswordDetail,

--- a/libs/angular/src/pipes/search-ciphers.pipe.ts
+++ b/libs/angular/src/pipes/search-ciphers.pipe.ts
@@ -26,7 +26,7 @@ export class SearchCiphersPipe implements PipeTransform {
       if (c.name != null && c.name.toLowerCase().indexOf(searchText) > -1) {
         return true;
       }
-      if (searchText.length >= 8 && c.id?.startsWith(searchText)) {
+      if (searchText.length >= 8 && c.id.startsWith(searchText)) {
         return true;
       }
       if (c.subTitle != null && c.subTitle.toLowerCase().indexOf(searchText) > -1) {

--- a/libs/angular/src/pipes/search-ciphers.pipe.ts
+++ b/libs/angular/src/pipes/search-ciphers.pipe.ts
@@ -26,7 +26,7 @@ export class SearchCiphersPipe implements PipeTransform {
       if (c.name != null && c.name.toLowerCase().indexOf(searchText) > -1) {
         return true;
       }
-      if (searchText.length >= 8 && c.id.startsWith(searchText)) {
+      if (searchText.length >= 8 && c.id?.startsWith(searchText)) {
         return true;
       }
       if (c.subTitle != null && c.subTitle.toLowerCase().indexOf(searchText) > -1) {

--- a/libs/common/src/platform/misc/safe-urls.ts
+++ b/libs/common/src/platform/misc/safe-urls.ts
@@ -17,13 +17,13 @@ const CanLaunchWhitelist = [
 ];
 
 export class SafeUrls {
-  static canLaunch(uri: string): boolean {
+  static canLaunch(uri: string | null | undefined): boolean {
     if (Utils.isNullOrWhitespace(uri)) {
       return false;
     }
 
     for (let i = 0; i < CanLaunchWhitelist.length; i++) {
-      if (uri.indexOf(CanLaunchWhitelist[i]) === 0) {
+      if (uri!.indexOf(CanLaunchWhitelist[i]) === 0) {
         return true;
       }
     }

--- a/libs/common/src/platform/misc/utils.ts
+++ b/libs/common/src/platform/misc/utils.ts
@@ -314,7 +314,7 @@ export class Utils {
     }
   }
 
-  static getDomain(uriString: string): string {
+  static getDomain(uriString: string | null | undefined): string {
     if (Utils.isNullOrWhitespace(uriString)) {
       return null;
     }

--- a/libs/common/src/platform/misc/utils.ts
+++ b/libs/common/src/platform/misc/utils.ts
@@ -392,11 +392,11 @@ export class Utils {
     };
   }
 
-  static isNullOrWhitespace(str: string): boolean {
+  static isNullOrWhitespace(str: string | undefined | null): boolean {
     return str == null || typeof str !== "string" || str.trim() === "";
   }
 
-  static isNullOrEmpty(str: string | null): boolean {
+  static isNullOrEmpty(str: string | null | undefined): boolean {
     return str == null || typeof str !== "string" || str == "";
   }
 
@@ -418,7 +418,7 @@ export class Utils {
     return (Object.keys(obj).filter((k) => Number.isNaN(+k)) as K[]).map((k) => obj[k]);
   }
 
-  static getUrl(uriString: string): URL {
+  static getUrl(uriString: string | undefined | null): URL {
     if (this.isNullOrWhitespace(uriString)) {
       return null;
     }

--- a/libs/common/src/platform/services/fido2/fido2-autofill-utils.ts
+++ b/libs/common/src/platform/services/fido2/fido2-autofill-utils.ts
@@ -24,11 +24,11 @@ export async function getCredentialsForAutofill(
       const credId = Utils.fromBufferToUrlB64(parseCredentialId(credential.credentialId));
 
       return {
-        cipherId: cipher.id,
+        cipherId: cipher.id!,
         credentialId: credId,
         rpId: credential.rpId,
         userHandle: credential.userHandle,
         userName: credential.userName,
-      };
+      } as Fido2CredentialAutofillView;
     });
 }

--- a/libs/common/src/platform/services/fido2/fido2-autofill-utils.ts
+++ b/libs/common/src/platform/services/fido2/fido2-autofill-utils.ts
@@ -24,7 +24,7 @@ export async function getCredentialsForAutofill(
       const credId = Utils.fromBufferToUrlB64(parseCredentialId(credential.credentialId));
 
       return {
-        cipherId: cipher.id!,
+        cipherId: cipher.id,
         credentialId: credId,
         rpId: credential.rpId,
         userHandle: credential.userHandle,

--- a/libs/common/src/vault/models/domain/attachment.ts
+++ b/libs/common/src/vault/models/domain/attachment.ts
@@ -47,6 +47,7 @@ export class Attachment extends Domain {
   ): Promise<AttachmentView> {
     const view = await this.decryptObj<Attachment, AttachmentView>(
       this,
+      // @ts-expect-error ViewEncryptableKeys type should be fixed to allow for optional values, but is out of scope for now.
       new AttachmentView(this),
       ["fileName"],
       orgId,

--- a/libs/common/src/vault/models/domain/card.spec.ts
+++ b/libs/common/src/vault/models/domain/card.spec.ts
@@ -63,7 +63,6 @@ describe("Card", () => {
     expect(view).toEqual({
       _brand: "brand",
       _number: "number",
-      _subTitle: null,
       cardholderName: "cardHolder",
       code: "code",
       expMonth: "expMonth",

--- a/libs/common/src/vault/models/domain/cipher.ts
+++ b/libs/common/src/vault/models/domain/cipher.ts
@@ -159,6 +159,8 @@ export class Cipher extends Domain implements Decryptable<CipherView> {
 
     await this.decryptObj<Cipher, CipherView>(
       this,
+      // @ts-expect-error Ciphers have optional Ids which are getting swallowed by the ViewEncryptableKeys type
+      // The ViewEncryptableKeys type should be fixed to allow for optional Ids, but is out of scope for now.
       model,
       ["name", "notes"],
       this.organizationId,

--- a/libs/common/src/vault/models/domain/fido2-credential.ts
+++ b/libs/common/src/vault/models/domain/fido2-credential.ts
@@ -56,6 +56,7 @@ export class Fido2Credential extends Domain {
   async decrypt(orgId: string, encKey?: SymmetricCryptoKey): Promise<Fido2CredentialView> {
     const view = await this.decryptObj<Fido2Credential, Fido2CredentialView>(
       this,
+      // @ts-expect-error ViewEncryptableKeys type should be fixed to allow for optional values, but is out of scope for now.
       new Fido2CredentialView(),
       [
         "credentialId",

--- a/libs/common/src/vault/models/domain/field.ts
+++ b/libs/common/src/vault/models/domain/field.ts
@@ -39,6 +39,7 @@ export class Field extends Domain {
   decrypt(orgId: string, encKey?: SymmetricCryptoKey): Promise<FieldView> {
     return this.decryptObj<Field, FieldView>(
       this,
+      // @ts-expect-error ViewEncryptableKeys type should be fixed to allow for optional values, but is out of scope for now.
       new FieldView(this),
       ["name", "value"],
       orgId,

--- a/libs/common/src/vault/models/domain/identity.spec.ts
+++ b/libs/common/src/vault/models/domain/identity.spec.ts
@@ -112,7 +112,6 @@ describe("Identity", () => {
     expect(view).toEqual({
       _firstName: "mockFirstName",
       _lastName: "mockLastName",
-      _subTitle: null,
       address1: "mockAddress1",
       address2: "mockAddress2",
       address3: "mockAddress3",

--- a/libs/common/src/vault/models/domain/login-uri.spec.ts
+++ b/libs/common/src/vault/models/domain/login-uri.spec.ts
@@ -56,10 +56,6 @@ describe("LoginUri", () => {
     const view = await loginUri.decrypt(null);
 
     expect(view).toEqual({
-      _canLaunch: null,
-      _domain: null,
-      _host: null,
-      _hostname: null,
       _uri: "uri",
       match: 3,
     });

--- a/libs/common/src/vault/models/domain/login.spec.ts
+++ b/libs/common/src/vault/models/domain/login.spec.ts
@@ -2,7 +2,7 @@ import { MockProxy, mock } from "jest-mock-extended";
 
 import { mockEnc, mockFromJson } from "../../../../spec";
 import { EncryptedString, EncString } from "../../../key-management/crypto/models/enc-string";
-import { UriMatchStrategy, UriMatchStrategySetting } from "../../../models/domain/domain-service";
+import { UriMatchStrategy } from "../../../models/domain/domain-service";
 import { LoginData } from "../../models/data/login.data";
 import { Login } from "../../models/domain/login";
 import { LoginUri } from "../../models/domain/login-uri";
@@ -82,12 +82,7 @@ describe("Login DTO", () => {
       totp: "encrypted totp",
       uris: [
         {
-          match: null as UriMatchStrategySetting,
           _uri: "decrypted uri",
-          _domain: null as string,
-          _hostname: null as string,
-          _host: null as string,
-          _canLaunch: null as boolean,
         },
       ],
       autofillOnPageLoad: true,

--- a/libs/common/src/vault/models/view/attachment.view.ts
+++ b/libs/common/src/vault/models/view/attachment.view.ts
@@ -1,5 +1,3 @@
-// FIXME: Update this file to be type safe and remove this and next line
-// @ts-strict-ignore
 import { Jsonify } from "type-fest";
 
 import { AttachmentView as SdkAttachmentView } from "@bitwarden/sdk-internal";
@@ -10,12 +8,12 @@ import { SymmetricCryptoKey } from "../../../platform/models/domain/symmetric-cr
 import { Attachment } from "../domain/attachment";
 
 export class AttachmentView implements View {
-  id: string = null;
-  url: string = null;
-  size: string = null;
-  sizeName: string = null;
-  fileName: string = null;
-  key: SymmetricCryptoKey = null;
+  id?: string;
+  url?: string;
+  size?: string;
+  sizeName?: string;
+  fileName?: string;
+  key?: SymmetricCryptoKey;
   /**
    * The SDK returns an encrypted key for the attachment.
    */
@@ -35,7 +33,7 @@ export class AttachmentView implements View {
   get fileSize(): number {
     try {
       if (this.size != null) {
-        return parseInt(this.size, null);
+        return parseInt(this.size);
       }
     } catch {
       // Invalid file size.
@@ -71,7 +69,7 @@ export class AttachmentView implements View {
       fileName: this.fileName,
       key: this.encryptedKey?.toSdk(),
       // TODO: PM-23005 - Temporary field, should be removed when encrypted migration is complete
-      decryptedKey: this.key ? this.key.toBase64() : null,
+      decryptedKey: this.key ? this.key.toBase64() : undefined,
     };
   }
 
@@ -84,13 +82,13 @@ export class AttachmentView implements View {
     }
 
     const view = new AttachmentView();
-    view.id = obj.id ?? null;
-    view.url = obj.url ?? null;
-    view.size = obj.size ?? null;
-    view.sizeName = obj.sizeName ?? null;
-    view.fileName = obj.fileName ?? null;
+    view.id = obj.id;
+    view.url = obj.url;
+    view.size = obj.size;
+    view.sizeName = obj.sizeName;
+    view.fileName = obj.fileName;
     // TODO: PM-23005 - Temporary field, should be removed when encrypted migration is complete
-    view.key = obj.decryptedKey ? SymmetricCryptoKey.fromString(obj.decryptedKey) : null;
+    view.key = obj.decryptedKey ? SymmetricCryptoKey.fromString(obj.decryptedKey) : undefined;
     view.encryptedKey = obj.key ? new EncString(obj.key) : undefined;
 
     return view;

--- a/libs/common/src/vault/models/view/card.view.ts
+++ b/libs/common/src/vault/models/view/card.view.ts
@@ -1,5 +1,3 @@
-// FIXME: Update this file to be type safe and remove this and next line
-// @ts-strict-ignore
 import { Jsonify } from "type-fest";
 
 import { CardView as SdkCardView } from "@bitwarden/sdk-internal";
@@ -12,45 +10,45 @@ import { ItemView } from "./item.view";
 
 export class CardView extends ItemView implements SdkCardView {
   @linkedFieldOption(LinkedId.CardholderName, { sortPosition: 0 })
-  cardholderName: string = null;
+  cardholderName: string | undefined;
   @linkedFieldOption(LinkedId.ExpMonth, { sortPosition: 3, i18nKey: "expirationMonth" })
-  expMonth: string = null;
+  expMonth: string | undefined;
   @linkedFieldOption(LinkedId.ExpYear, { sortPosition: 4, i18nKey: "expirationYear" })
-  expYear: string = null;
+  expYear: string | undefined;
   @linkedFieldOption(LinkedId.Code, { sortPosition: 5, i18nKey: "securityCode" })
-  code: string = null;
+  code: string | undefined;
 
-  private _brand: string = null;
-  private _number: string = null;
-  private _subTitle: string = null;
+  private _brand?: string;
+  private _number?: string;
+  private _subTitle?: string;
 
-  get maskedCode(): string {
-    return this.code != null ? "•".repeat(this.code.length) : null;
+  get maskedCode(): string | undefined {
+    return this.code != null ? "•".repeat(this.code.length) : undefined;
   }
 
-  get maskedNumber(): string {
-    return this.number != null ? "•".repeat(this.number.length) : null;
+  get maskedNumber(): string | undefined {
+    return this.number != null ? "•".repeat(this.number.length) : undefined;
   }
 
   @linkedFieldOption(LinkedId.Brand, { sortPosition: 2 })
-  get brand(): string {
+  get brand(): string | undefined {
     return this._brand;
   }
-  set brand(value: string) {
+  set brand(value: string | undefined) {
     this._brand = value;
-    this._subTitle = null;
+    this._subTitle = undefined;
   }
 
   @linkedFieldOption(LinkedId.Number, { sortPosition: 1 })
-  get number(): string {
+  get number(): string | undefined {
     return this._number;
   }
-  set number(value: string) {
+  set number(value: string | undefined) {
     this._number = value;
-    this._subTitle = null;
+    this._subTitle = undefined;
   }
 
-  get subTitle(): string {
+  get subTitle(): string | undefined {
     if (this._subTitle == null) {
       this._subTitle = this.brand;
       if (this.number != null && this.number.length >= 4) {
@@ -69,11 +67,11 @@ export class CardView extends ItemView implements SdkCardView {
     return this._subTitle;
   }
 
-  get expiration(): string {
-    const normalizedYear = normalizeExpiryYearFormat(this.expYear);
+  get expiration(): string | undefined {
+    const normalizedYear = this.expYear ? normalizeExpiryYearFormat(this.expYear) : undefined;
 
     if (!this.expMonth && !normalizedYear) {
-      return null;
+      return undefined;
     }
 
     let exp = this.expMonth != null ? ("0" + this.expMonth).slice(-2) : "__";
@@ -82,14 +80,14 @@ export class CardView extends ItemView implements SdkCardView {
     return exp;
   }
 
-  static fromJSON(obj: Partial<Jsonify<CardView>>): CardView {
+  static fromJSON(obj: Partial<Jsonify<CardView>> | undefined): CardView {
     return Object.assign(new CardView(), obj);
   }
 
   // ref https://stackoverflow.com/a/5911300
-  static getCardBrandByPatterns(cardNum: string): string {
+  static getCardBrandByPatterns(cardNum: string | undefined | null): string | undefined {
     if (cardNum == null || typeof cardNum !== "string" || cardNum.trim() === "") {
-      return null;
+      return undefined;
     }
 
     // Visa
@@ -146,25 +144,21 @@ export class CardView extends ItemView implements SdkCardView {
       return "Visa";
     }
 
-    return null;
+    return undefined;
   }
 
   /**
    * Converts an SDK CardView to a CardView.
    */
-  static fromSdkCardView(obj: SdkCardView): CardView | undefined {
-    if (obj == null) {
-      return undefined;
-    }
-
+  static fromSdkCardView(obj: SdkCardView): CardView {
     const cardView = new CardView();
 
-    cardView.cardholderName = obj.cardholderName ?? null;
-    cardView.brand = obj.brand ?? null;
-    cardView.number = obj.number ?? null;
-    cardView.expMonth = obj.expMonth ?? null;
-    cardView.expYear = obj.expYear ?? null;
-    cardView.code = obj.code ?? null;
+    cardView.cardholderName = obj.cardholderName;
+    cardView.brand = obj.brand;
+    cardView.number = obj.number;
+    cardView.expMonth = obj.expMonth;
+    cardView.expYear = obj.expYear;
+    cardView.code = obj.code;
 
     return cardView;
   }

--- a/libs/common/src/vault/models/view/cipher.view.spec.ts
+++ b/libs/common/src/vault/models/view/cipher.view.spec.ts
@@ -179,7 +179,7 @@ describe("CipherView", () => {
         folderId: "folderId",
         collectionIds: ["collectionId"],
         name: "name",
-        notes: null,
+        notes: undefined,
         type: CipherType.Login,
         favorite: true,
         edit: true,
@@ -223,7 +223,7 @@ describe("CipherView", () => {
         passwordHistory: [],
         creationDate: new Date("2022-01-01T12:00:00.000Z"),
         revisionDate: new Date("2022-01-02T12:00:00.000Z"),
-        deletedDate: null,
+        deletedDate: undefined,
       });
     });
   });

--- a/libs/common/src/vault/models/view/cipher.view.ts
+++ b/libs/common/src/vault/models/view/cipher.view.ts
@@ -112,7 +112,7 @@ export class CipherView implements View, InitializerMetadata {
   }
 
   get hasAttachments(): boolean {
-    return this.attachments && this.attachments.length > 0;
+    return !!this.attachments && this.attachments.length > 0;
   }
 
   get hasOldAttachments(): boolean {

--- a/libs/common/src/vault/models/view/cipher.view.ts
+++ b/libs/common/src/vault/models/view/cipher.view.ts
@@ -25,7 +25,7 @@ import { SshKeyView } from "./ssh-key.view";
 export class CipherView implements View, InitializerMetadata {
   readonly initializerKey = InitializerKey.CipherView;
 
-  id?: string;
+  id: string = "";
   organizationId?: string;
   folderId?: string;
   name: string = "";
@@ -189,7 +189,7 @@ export class CipherView implements View, InitializerMetadata {
 
     const view = new CipherView();
     view.type = obj.type ?? CipherType.Login;
-    view.id = obj.id;
+    view.id = obj.id ?? "";
     view.name = obj.name ?? "";
     if (obj.creationDate) {
       view.creationDate = new Date(obj.creationDate);

--- a/libs/common/src/vault/models/view/cipher.view.ts
+++ b/libs/common/src/vault/models/view/cipher.view.ts
@@ -1,7 +1,6 @@
-// FIXME: Update this file to be type safe and remove this and next line
-// @ts-strict-ignore
 import { EncString } from "@bitwarden/common/key-management/crypto/models/enc-string";
 import { asUuid, uuidAsString } from "@bitwarden/common/platform/abstractions/sdk/sdk.service";
+import { ItemView } from "@bitwarden/common/vault/models/view/item.view";
 import { CipherView as SdkCipherView } from "@bitwarden/sdk-internal";
 
 import { View } from "../../../models/view/view";
@@ -26,18 +25,18 @@ import { SshKeyView } from "./ssh-key.view";
 export class CipherView implements View, InitializerMetadata {
   readonly initializerKey = InitializerKey.CipherView;
 
-  id: string = null;
-  organizationId: string | undefined = null;
-  folderId: string = null;
-  name: string = null;
-  notes: string = null;
-  type: CipherType = null;
+  id?: string;
+  organizationId?: string;
+  folderId?: string;
+  name: string = "";
+  notes?: string;
+  type: CipherType = CipherType.Login;
   favorite = false;
   organizationUseTotp = false;
-  permissions: CipherPermissionsApi = new CipherPermissionsApi();
+  permissions?: CipherPermissionsApi = new CipherPermissionsApi();
   edit = false;
   viewPassword = true;
-  localData: LocalData;
+  localData?: LocalData;
   login = new LoginView();
   identity = new IdentityView();
   card = new CardView();
@@ -46,10 +45,10 @@ export class CipherView implements View, InitializerMetadata {
   attachments: AttachmentView[] = [];
   fields: FieldView[] = [];
   passwordHistory: PasswordHistoryView[] = [];
-  collectionIds: string[] = null;
-  revisionDate: Date = null;
-  creationDate: Date = null;
-  deletedDate: Date = null;
+  collectionIds: string[] = [];
+  revisionDate: Date;
+  creationDate: Date;
+  deletedDate?: Date;
   reprompt: CipherRepromptType = CipherRepromptType.None;
   // We need a copy of the encrypted key so we can pass it to
   // the SdkCipherView during encryption
@@ -62,6 +61,7 @@ export class CipherView implements View, InitializerMetadata {
 
   constructor(c?: Cipher) {
     if (!c) {
+      this.creationDate = this.revisionDate = new Date();
       return;
     }
 
@@ -84,7 +84,7 @@ export class CipherView implements View, InitializerMetadata {
     this.key = c.key;
   }
 
-  private get item() {
+  private get item(): ItemView | undefined {
     switch (this.type) {
       case CipherType.Login:
         return this.login;
@@ -100,10 +100,10 @@ export class CipherView implements View, InitializerMetadata {
         break;
     }
 
-    return null;
+    return undefined;
   }
 
-  get subTitle(): string {
+  get subTitle(): string | undefined {
     return this.item?.subTitle;
   }
 
@@ -130,11 +130,11 @@ export class CipherView implements View, InitializerMetadata {
     return this.fields && this.fields.length > 0;
   }
 
-  get passwordRevisionDisplayDate(): Date {
+  get passwordRevisionDisplayDate(): Date | undefined {
     if (this.type !== CipherType.Login || this.login == null) {
-      return null;
+      return undefined;
     } else if (this.login.password == null || this.login.password === "") {
-      return null;
+      return undefined;
     }
     return this.login.passwordRevisionDate;
   }
@@ -164,23 +164,17 @@ export class CipherView implements View, InitializerMetadata {
    * Determines if the cipher can be launched in a new browser tab.
    */
   get canLaunch(): boolean {
-    return this.type === CipherType.Login && this.login.canLaunch;
+    return this.type === CipherType.Login && this.login!.canLaunch;
   }
 
   linkedFieldValue(id: LinkedIdType) {
     const linkedFieldOption = this.linkedFieldOptions?.get(id);
-    if (linkedFieldOption == null) {
-      return null;
+    const item = this.item;
+    if (linkedFieldOption == null || item == null) {
+      return undefined;
     }
 
-    // FIXME: Remove when updating file. Eslint update
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const item = this.item;
-    return this.item[linkedFieldOption.propertyKey as keyof typeof item];
-  }
-
-  linkedFieldI18nKey(id: LinkedIdType): string {
-    return this.linkedFieldOptions.get(id)?.i18nKey;
+    return item[linkedFieldOption.propertyKey as keyof typeof item];
   }
 
   // This is used as a marker to indicate that the cipher view object still has its prototype
@@ -188,22 +182,30 @@ export class CipherView implements View, InitializerMetadata {
     return this;
   }
 
-  static fromJSON(obj: Partial<DeepJsonify<CipherView>>): CipherView {
+  static fromJSON(obj: Partial<DeepJsonify<CipherView>>): CipherView | null {
     if (obj == null) {
       return null;
     }
 
     const view = new CipherView();
-    const creationDate = obj.creationDate == null ? null : new Date(obj.creationDate);
-    const revisionDate = obj.revisionDate == null ? null : new Date(obj.revisionDate);
-    const deletedDate = obj.deletedDate == null ? null : new Date(obj.deletedDate);
-    const attachments = obj.attachments?.map((a: any) => AttachmentView.fromJSON(a));
-    const fields = obj.fields?.map((f: any) => FieldView.fromJSON(f));
-    const passwordHistory = obj.passwordHistory?.map((ph: any) => PasswordHistoryView.fromJSON(ph));
-    const permissions = CipherPermissionsApi.fromJSON(obj.permissions);
-    let key: EncString | undefined;
+    view.type = obj.type ?? CipherType.Login;
+    view.id = obj.id;
+    view.name = obj.name ?? "";
+    if (obj.creationDate) {
+      view.creationDate = new Date(obj.creationDate);
+    }
+    if (obj.revisionDate) {
+      view.revisionDate = new Date(obj.revisionDate);
+    }
+    view.deletedDate = obj.deletedDate == null ? undefined : new Date(obj.deletedDate);
+    view.attachments = obj.attachments?.map((a: any) => AttachmentView.fromJSON(a)) ?? [];
+    view.fields = obj.fields?.map((f: any) => FieldView.fromJSON(f)) ?? [];
+    view.passwordHistory =
+      obj.passwordHistory?.map((ph: any) => PasswordHistoryView.fromJSON(ph)) ?? [];
+    view.permissions = obj.permissions ? CipherPermissionsApi.fromJSON(obj.permissions) : undefined;
 
     if (obj.key != null) {
+      let key: EncString | undefined;
       if (typeof obj.key === "string") {
         // If the key is a string, we need to parse it as EncString
         key = EncString.fromJSON(obj.key);
@@ -211,18 +213,8 @@ export class CipherView implements View, InitializerMetadata {
         // If the key is already an EncString instance, we can use it directly
         key = obj.key;
       }
+      view.key = key;
     }
-
-    Object.assign(view, obj, {
-      creationDate: creationDate,
-      revisionDate: revisionDate,
-      deletedDate: deletedDate,
-      attachments: attachments,
-      fields: fields,
-      passwordHistory: passwordHistory,
-      permissions: permissions,
-      key: key,
-    });
 
     switch (obj.type) {
       case CipherType.Card:
@@ -256,45 +248,53 @@ export class CipherView implements View, InitializerMetadata {
     }
 
     const cipherView = new CipherView();
-    cipherView.id = uuidAsString(obj.id) ?? null;
-    cipherView.organizationId = uuidAsString(obj.organizationId) ?? null;
-    cipherView.folderId = uuidAsString(obj.folderId) ?? null;
+    cipherView.id = uuidAsString(obj.id);
+    cipherView.organizationId = uuidAsString(obj.organizationId);
+    cipherView.folderId = uuidAsString(obj.folderId);
     cipherView.name = obj.name;
-    cipherView.notes = obj.notes ?? null;
+    cipherView.notes = obj.notes;
     cipherView.type = obj.type;
     cipherView.favorite = obj.favorite;
     cipherView.organizationUseTotp = obj.organizationUseTotp;
-    cipherView.permissions = CipherPermissionsApi.fromSdkCipherPermissions(obj.permissions);
+    cipherView.permissions = obj.permissions
+      ? CipherPermissionsApi.fromSdkCipherPermissions(obj.permissions)
+      : undefined;
     cipherView.edit = obj.edit;
     cipherView.viewPassword = obj.viewPassword;
     cipherView.localData = fromSdkLocalData(obj.localData);
     cipherView.attachments =
-      obj.attachments?.map((a) => AttachmentView.fromSdkAttachmentView(a)) ?? [];
-    cipherView.fields = obj.fields?.map((f) => FieldView.fromSdkFieldView(f)) ?? [];
+      obj.attachments?.map((a) => AttachmentView.fromSdkAttachmentView(a)!) ?? [];
+    cipherView.fields = obj.fields?.map((f) => FieldView.fromSdkFieldView(f)!) ?? [];
     cipherView.passwordHistory =
-      obj.passwordHistory?.map((ph) => PasswordHistoryView.fromSdkPasswordHistoryView(ph)) ?? [];
+      obj.passwordHistory?.map((ph) => PasswordHistoryView.fromSdkPasswordHistoryView(ph)!) ?? [];
     cipherView.collectionIds = obj.collectionIds?.map((i) => uuidAsString(i)) ?? [];
-    cipherView.revisionDate = obj.revisionDate == null ? null : new Date(obj.revisionDate);
-    cipherView.creationDate = obj.creationDate == null ? null : new Date(obj.creationDate);
-    cipherView.deletedDate = obj.deletedDate == null ? null : new Date(obj.deletedDate);
+    cipherView.revisionDate = new Date(obj.revisionDate);
+    cipherView.creationDate = new Date(obj.creationDate);
+    cipherView.deletedDate = obj.deletedDate == null ? undefined : new Date(obj.deletedDate);
     cipherView.reprompt = obj.reprompt ?? CipherRepromptType.None;
-    cipherView.key = EncString.fromJSON(obj.key);
+    cipherView.key = obj.key ? EncString.fromJSON(obj.key) : undefined;
 
     switch (obj.type) {
       case CipherType.Card:
-        cipherView.card = CardView.fromSdkCardView(obj.card);
+        cipherView.card = obj.card ? CardView.fromSdkCardView(obj.card) : new CardView();
         break;
       case CipherType.Identity:
-        cipherView.identity = IdentityView.fromSdkIdentityView(obj.identity);
+        cipherView.identity = obj.identity
+          ? IdentityView.fromSdkIdentityView(obj.identity)
+          : new IdentityView();
         break;
       case CipherType.Login:
-        cipherView.login = LoginView.fromSdkLoginView(obj.login);
+        cipherView.login = obj.login ? LoginView.fromSdkLoginView(obj.login) : new LoginView();
         break;
       case CipherType.SecureNote:
-        cipherView.secureNote = SecureNoteView.fromSdkSecureNoteView(obj.secureNote);
+        cipherView.secureNote = obj.secureNote
+          ? SecureNoteView.fromSdkSecureNoteView(obj.secureNote)
+          : new SecureNoteView();
         break;
       case CipherType.SshKey:
-        cipherView.sshKey = SshKeyView.fromSdkSshKeyView(obj.sshKey);
+        cipherView.sshKey = obj.sshKey
+          ? SshKeyView.fromSdkSshKeyView(obj.sshKey)
+          : new SshKeyView();
         break;
       default:
         break;
@@ -344,19 +344,19 @@ export class CipherView implements View, InitializerMetadata {
 
     switch (this.type) {
       case CipherType.Card:
-        sdkCipherView.card = this.card.toSdkCardView();
+        sdkCipherView.card = this.card?.toSdkCardView();
         break;
       case CipherType.Identity:
-        sdkCipherView.identity = this.identity.toSdkIdentityView();
+        sdkCipherView.identity = this.identity?.toSdkIdentityView();
         break;
       case CipherType.Login:
-        sdkCipherView.login = this.login.toSdkLoginView();
+        sdkCipherView.login = this.login?.toSdkLoginView();
         break;
       case CipherType.SecureNote:
-        sdkCipherView.secureNote = this.secureNote.toSdkSecureNoteView();
+        sdkCipherView.secureNote = this.secureNote?.toSdkSecureNoteView();
         break;
       case CipherType.SshKey:
-        sdkCipherView.sshKey = this.sshKey.toSdkSshKeyView();
+        sdkCipherView.sshKey = this.sshKey?.toSdkSshKeyView();
         break;
       default:
         break;

--- a/libs/common/src/vault/models/view/fido2-credential.view.ts
+++ b/libs/common/src/vault/models/view/fido2-credential.view.ts
@@ -1,5 +1,3 @@
-// FIXME: Update this file to be type safe and remove this and next line
-// @ts-strict-ignore
 import { Jsonify } from "type-fest";
 
 import {
@@ -10,21 +8,21 @@ import {
 import { ItemView } from "./item.view";
 
 export class Fido2CredentialView extends ItemView {
-  credentialId: string;
-  keyType: "public-key";
-  keyAlgorithm: "ECDSA";
-  keyCurve: "P-256";
-  keyValue: string;
-  rpId: string;
-  userHandle: string;
-  userName: string;
-  counter: number;
-  rpName: string;
-  userDisplayName: string;
-  discoverable: boolean;
-  creationDate: Date = null;
+  credentialId!: string;
+  keyType!: "public-key";
+  keyAlgorithm!: "ECDSA";
+  keyCurve!: "P-256";
+  keyValue!: string;
+  rpId!: string;
+  userHandle?: string;
+  userName?: string;
+  counter!: number;
+  rpName?: string;
+  userDisplayName?: string;
+  discoverable: boolean = false;
+  creationDate!: Date;
 
-  get subTitle(): string {
+  get subTitle(): string | undefined {
     return this.userDisplayName;
   }
 
@@ -54,8 +52,8 @@ export class Fido2CredentialView extends ItemView {
     view.counter = parseInt(obj.counter);
     view.rpName = obj.rpName;
     view.userDisplayName = obj.userDisplayName;
-    view.discoverable = obj.discoverable?.toLowerCase() === "true" ? true : false;
-    view.creationDate = obj.creationDate ? new Date(obj.creationDate) : null;
+    view.discoverable = obj.discoverable?.toLowerCase() === "true";
+    view.creationDate = new Date(obj.creationDate);
 
     return view;
   }

--- a/libs/common/src/vault/models/view/field.view.ts
+++ b/libs/common/src/vault/models/view/field.view.ts
@@ -1,5 +1,3 @@
-// FIXME: Update this file to be type safe and remove this and next line
-// @ts-strict-ignore
 import { Jsonify } from "type-fest";
 
 import { FieldView as SdkFieldView, FieldType as SdkFieldType } from "@bitwarden/sdk-internal";
@@ -9,13 +7,13 @@ import { FieldType, LinkedIdType } from "../../enums";
 import { Field } from "../domain/field";
 
 export class FieldView implements View {
-  name: string = null;
-  value: string = null;
-  type: FieldType = null;
+  name?: string;
+  value?: string;
+  type: FieldType = FieldType.Text;
   newField = false; // Marks if the field is new and hasn't been saved
   showValue = false;
   showCount = false;
-  linkedId: LinkedIdType = null;
+  linkedId?: LinkedIdType;
 
   constructor(f?: Field) {
     if (!f) {
@@ -26,8 +24,8 @@ export class FieldView implements View {
     this.linkedId = f.linkedId;
   }
 
-  get maskedValue(): string {
-    return this.value != null ? "••••••••" : null;
+  get maskedValue(): string | undefined {
+    return this.value != null ? "••••••••" : undefined;
   }
 
   static fromJSON(obj: Partial<Jsonify<FieldView>>): FieldView {

--- a/libs/common/src/vault/models/view/identity.view.ts
+++ b/libs/common/src/vault/models/view/identity.view.ts
@@ -1,5 +1,3 @@
-// FIXME: Update this file to be type safe and remove this and next line
-// @ts-strict-ignore
 import { Jsonify } from "type-fest";
 
 import { IdentityView as SdkIdentityView } from "@bitwarden/sdk-internal";
@@ -12,65 +10,65 @@ import { ItemView } from "./item.view";
 
 export class IdentityView extends ItemView implements SdkIdentityView {
   @linkedFieldOption(LinkedId.Title, { sortPosition: 0 })
-  title: string = null;
+  title: string | undefined;
   @linkedFieldOption(LinkedId.MiddleName, { sortPosition: 2 })
-  middleName: string = null;
+  middleName: string | undefined;
   @linkedFieldOption(LinkedId.Address1, { sortPosition: 12 })
-  address1: string = null;
+  address1: string | undefined;
   @linkedFieldOption(LinkedId.Address2, { sortPosition: 13 })
-  address2: string = null;
+  address2: string | undefined;
   @linkedFieldOption(LinkedId.Address3, { sortPosition: 14 })
-  address3: string = null;
+  address3: string | undefined;
   @linkedFieldOption(LinkedId.City, { sortPosition: 15, i18nKey: "cityTown" })
-  city: string = null;
+  city: string | undefined;
   @linkedFieldOption(LinkedId.State, { sortPosition: 16, i18nKey: "stateProvince" })
-  state: string = null;
+  state: string | undefined;
   @linkedFieldOption(LinkedId.PostalCode, { sortPosition: 17, i18nKey: "zipPostalCode" })
-  postalCode: string = null;
+  postalCode: string | undefined;
   @linkedFieldOption(LinkedId.Country, { sortPosition: 18 })
-  country: string = null;
+  country: string | undefined;
   @linkedFieldOption(LinkedId.Company, { sortPosition: 6 })
-  company: string = null;
+  company: string | undefined;
   @linkedFieldOption(LinkedId.Email, { sortPosition: 10 })
-  email: string = null;
+  email: string | undefined;
   @linkedFieldOption(LinkedId.Phone, { sortPosition: 11 })
-  phone: string = null;
+  phone: string | undefined;
   @linkedFieldOption(LinkedId.Ssn, { sortPosition: 7 })
-  ssn: string = null;
+  ssn: string | undefined;
   @linkedFieldOption(LinkedId.Username, { sortPosition: 5 })
-  username: string = null;
+  username: string | undefined;
   @linkedFieldOption(LinkedId.PassportNumber, { sortPosition: 8 })
-  passportNumber: string = null;
+  passportNumber: string | undefined;
   @linkedFieldOption(LinkedId.LicenseNumber, { sortPosition: 9 })
-  licenseNumber: string = null;
+  licenseNumber: string | undefined;
 
-  private _firstName: string = null;
-  private _lastName: string = null;
-  private _subTitle: string = null;
+  private _firstName: string | undefined;
+  private _lastName: string | undefined;
+  private _subTitle: string | undefined;
 
   constructor() {
     super();
   }
 
   @linkedFieldOption(LinkedId.FirstName, { sortPosition: 1 })
-  get firstName(): string {
+  get firstName(): string | undefined {
     return this._firstName;
   }
-  set firstName(value: string) {
+  set firstName(value: string | undefined) {
     this._firstName = value;
-    this._subTitle = null;
+    this._subTitle = undefined;
   }
 
   @linkedFieldOption(LinkedId.LastName, { sortPosition: 4 })
-  get lastName(): string {
+  get lastName(): string | undefined {
     return this._lastName;
   }
-  set lastName(value: string) {
+  set lastName(value: string | undefined) {
     this._lastName = value;
-    this._subTitle = null;
+    this._subTitle = undefined;
   }
 
-  get subTitle(): string {
+  get subTitle(): string | undefined {
     if (this._subTitle == null && (this.firstName != null || this.lastName != null)) {
       this._subTitle = "";
       if (this.firstName != null) {
@@ -88,7 +86,7 @@ export class IdentityView extends ItemView implements SdkIdentityView {
   }
 
   @linkedFieldOption(LinkedId.FullName, { sortPosition: 3 })
-  get fullName(): string {
+  get fullName(): string | undefined {
     if (
       this.title != null ||
       this.firstName != null ||
@@ -111,11 +109,11 @@ export class IdentityView extends ItemView implements SdkIdentityView {
       return name.trim();
     }
 
-    return null;
+    return undefined;
   }
 
-  get fullAddress(): string {
-    let address = this.address1;
+  get fullAddress(): string | undefined {
+    let address = this.address1 ?? "";
     if (!Utils.isNullOrWhitespace(this.address2)) {
       if (!Utils.isNullOrWhitespace(address)) {
         address += ", ";
@@ -131,9 +129,9 @@ export class IdentityView extends ItemView implements SdkIdentityView {
     return address;
   }
 
-  get fullAddressPart2(): string {
+  get fullAddressPart2(): string | undefined {
     if (this.city == null && this.state == null && this.postalCode == null) {
-      return null;
+      return undefined;
     }
     const city = this.city || "-";
     const state = this.state;
@@ -146,7 +144,7 @@ export class IdentityView extends ItemView implements SdkIdentityView {
     return addressPart2;
   }
 
-  get fullAddressForCopy(): string {
+  get fullAddressForCopy(): string | undefined {
     let address = this.fullAddress;
     if (this.city != null || this.state != null || this.postalCode != null) {
       address += "\n" + this.fullAddressPart2;
@@ -157,38 +155,34 @@ export class IdentityView extends ItemView implements SdkIdentityView {
     return address;
   }
 
-  static fromJSON(obj: Partial<Jsonify<IdentityView>>): IdentityView {
+  static fromJSON(obj: Partial<Jsonify<IdentityView>> | undefined): IdentityView {
     return Object.assign(new IdentityView(), obj);
   }
 
   /**
    * Converts the SDK IdentityView to an IdentityView.
    */
-  static fromSdkIdentityView(obj: SdkIdentityView): IdentityView | undefined {
-    if (obj == null) {
-      return undefined;
-    }
-
+  static fromSdkIdentityView(obj: SdkIdentityView): IdentityView {
     const identityView = new IdentityView();
 
-    identityView.title = obj.title ?? null;
-    identityView.firstName = obj.firstName ?? null;
-    identityView.middleName = obj.middleName ?? null;
-    identityView.lastName = obj.lastName ?? null;
-    identityView.address1 = obj.address1 ?? null;
-    identityView.address2 = obj.address2 ?? null;
-    identityView.address3 = obj.address3 ?? null;
-    identityView.city = obj.city ?? null;
-    identityView.state = obj.state ?? null;
-    identityView.postalCode = obj.postalCode ?? null;
-    identityView.country = obj.country ?? null;
-    identityView.company = obj.company ?? null;
-    identityView.email = obj.email ?? null;
-    identityView.phone = obj.phone ?? null;
-    identityView.ssn = obj.ssn ?? null;
-    identityView.username = obj.username ?? null;
-    identityView.passportNumber = obj.passportNumber ?? null;
-    identityView.licenseNumber = obj.licenseNumber ?? null;
+    identityView.title = obj.title;
+    identityView.firstName = obj.firstName;
+    identityView.middleName = obj.middleName;
+    identityView.lastName = obj.lastName;
+    identityView.address1 = obj.address1;
+    identityView.address2 = obj.address2;
+    identityView.address3 = obj.address3;
+    identityView.city = obj.city;
+    identityView.state = obj.state;
+    identityView.postalCode = obj.postalCode;
+    identityView.country = obj.country;
+    identityView.company = obj.company;
+    identityView.email = obj.email;
+    identityView.phone = obj.phone;
+    identityView.ssn = obj.ssn;
+    identityView.username = obj.username;
+    identityView.passportNumber = obj.passportNumber;
+    identityView.licenseNumber = obj.licenseNumber;
 
     return identityView;
   }

--- a/libs/common/src/vault/models/view/item.view.ts
+++ b/libs/common/src/vault/models/view/item.view.ts
@@ -1,9 +1,7 @@
-// FIXME: Update this file to be type safe and remove this and next line
-// @ts-strict-ignore
 import { View } from "../../../models/view/view";
 import { LinkedMetadata } from "../../linked-field-option.decorator";
 
 export abstract class ItemView implements View {
-  linkedFieldOptions: Map<number, LinkedMetadata>;
-  abstract get subTitle(): string;
+  linkedFieldOptions?: Map<number, LinkedMetadata>;
+  abstract get subTitle(): string | undefined;
 }

--- a/libs/common/src/vault/models/view/login-uri.view.ts
+++ b/libs/common/src/vault/models/view/login-uri.view.ts
@@ -1,5 +1,3 @@
-// FIXME: Update this file to be type safe and remove this and next line
-// @ts-strict-ignore
 import { Jsonify } from "type-fest";
 
 import { LoginUriView as SdkLoginUriView } from "@bitwarden/sdk-internal";
@@ -11,13 +9,13 @@ import { Utils } from "../../../platform/misc/utils";
 import { LoginUri } from "../domain/login-uri";
 
 export class LoginUriView implements View {
-  match: UriMatchStrategySetting = null;
+  match?: UriMatchStrategySetting;
 
-  private _uri: string = null;
-  private _domain: string = null;
-  private _hostname: string = null;
-  private _host: string = null;
-  private _canLaunch: boolean = null;
+  private _uri?: string;
+  private _domain?: string;
+  private _hostname?: string;
+  private _host?: string;
+  private _canLaunch?: boolean;
 
   constructor(u?: LoginUri) {
     if (!u) {
@@ -27,59 +25,59 @@ export class LoginUriView implements View {
     this.match = u.match;
   }
 
-  get uri(): string {
+  get uri(): string | undefined {
     return this._uri;
   }
-  set uri(value: string) {
+  set uri(value: string | undefined) {
     this._uri = value;
-    this._domain = null;
-    this._canLaunch = null;
+    this._domain = undefined;
+    this._canLaunch = undefined;
   }
 
-  get domain(): string {
+  get domain(): string | undefined {
     if (this._domain == null && this.uri != null) {
       this._domain = Utils.getDomain(this.uri);
       if (this._domain === "") {
-        this._domain = null;
+        this._domain = undefined;
       }
     }
 
     return this._domain;
   }
 
-  get hostname(): string {
+  get hostname(): string | undefined {
     if (this.match === UriMatchStrategy.RegularExpression) {
-      return null;
+      return undefined;
     }
     if (this._hostname == null && this.uri != null) {
       this._hostname = Utils.getHostname(this.uri);
       if (this._hostname === "") {
-        this._hostname = null;
+        this._hostname = undefined;
       }
     }
 
     return this._hostname;
   }
 
-  get host(): string {
+  get host(): string | undefined {
     if (this.match === UriMatchStrategy.RegularExpression) {
-      return null;
+      return undefined;
     }
     if (this._host == null && this.uri != null) {
       this._host = Utils.getHost(this.uri);
       if (this._host === "") {
-        this._host = null;
+        this._host = undefined;
       }
     }
 
     return this._host;
   }
 
-  get hostnameOrUri(): string {
+  get hostnameOrUri(): string | undefined {
     return this.hostname != null ? this.hostname : this.uri;
   }
 
-  get hostOrUri(): string {
+  get hostOrUri(): string | undefined {
     return this.host != null ? this.host : this.uri;
   }
 
@@ -104,7 +102,10 @@ export class LoginUriView implements View {
     return this._canLaunch;
   }
 
-  get launchUri(): string {
+  get launchUri(): string | undefined {
+    if (this.uri == null) {
+      return undefined;
+    }
     return this.uri.indexOf("://") < 0 && !Utils.isNullOrWhitespace(Utils.getDomain(this.uri))
       ? "http://" + this.uri
       : this.uri;
@@ -141,7 +142,7 @@ export class LoginUriView implements View {
   matchesUri(
     targetUri: string,
     equivalentDomains: Set<string>,
-    defaultUriMatch: UriMatchStrategySetting = null,
+    defaultUriMatch?: UriMatchStrategySetting,
     /** When present, will override the match strategy for the cipher if it is `Never` with `Domain` */
     overrideNeverMatchStrategy?: true,
   ): boolean {
@@ -198,7 +199,7 @@ export class LoginUriView implements View {
 
     if (Utils.DomainMatchBlacklist.has(this.domain)) {
       const domainUrlHost = Utils.getHost(targetUri);
-      return !Utils.DomainMatchBlacklist.get(this.domain).has(domainUrlHost);
+      return !Utils.DomainMatchBlacklist.get(this.domain)!.has(domainUrlHost);
     }
 
     return true;

--- a/libs/common/src/vault/models/view/login.view.spec.ts
+++ b/libs/common/src/vault/models/view/login.view.spec.ts
@@ -29,11 +29,6 @@ describe("LoginView", () => {
   });
 
   describe("fromSdkLoginView", () => {
-    it("should return undefined when the input is null", () => {
-      const result = LoginView.fromSdkLoginView(null as unknown as SdkLoginView);
-      expect(result).toBeUndefined();
-    });
-
     it("should return a LoginView from an SdkLoginView", () => {
       jest.spyOn(LoginUriView, "fromSdkLoginUriView").mockImplementation(mockFromSdk);
 

--- a/libs/common/src/vault/models/view/secure-note.view.ts
+++ b/libs/common/src/vault/models/view/secure-note.view.ts
@@ -1,5 +1,3 @@
-// FIXME: Update this file to be type safe and remove this and next line
-// @ts-strict-ignore
 import { Jsonify } from "type-fest";
 
 import { SecureNoteView as SdkSecureNoteView } from "@bitwarden/sdk-internal";
@@ -10,7 +8,7 @@ import { SecureNote } from "../domain/secure-note";
 import { ItemView } from "./item.view";
 
 export class SecureNoteView extends ItemView implements SdkSecureNoteView {
-  type: SecureNoteType = null;
+  type: SecureNoteType = SecureNoteType.Generic;
 
   constructor(n?: SecureNote) {
     super();
@@ -21,24 +19,20 @@ export class SecureNoteView extends ItemView implements SdkSecureNoteView {
     this.type = n.type;
   }
 
-  get subTitle(): string {
-    return null;
+  get subTitle(): string | undefined {
+    return undefined;
   }
 
-  static fromJSON(obj: Partial<Jsonify<SecureNoteView>>): SecureNoteView {
+  static fromJSON(obj: Partial<Jsonify<SecureNoteView>> | undefined): SecureNoteView {
     return Object.assign(new SecureNoteView(), obj);
   }
 
   /**
    * Converts the SDK SecureNoteView to a SecureNoteView.
    */
-  static fromSdkSecureNoteView(obj: SdkSecureNoteView): SecureNoteView | undefined {
-    if (!obj) {
-      return undefined;
-    }
-
+  static fromSdkSecureNoteView(obj: SdkSecureNoteView): SecureNoteView {
     const secureNoteView = new SecureNoteView();
-    secureNoteView.type = obj.type ?? null;
+    secureNoteView.type = obj.type;
 
     return secureNoteView;
   }

--- a/libs/common/src/vault/models/view/ssh-key.view.ts
+++ b/libs/common/src/vault/models/view/ssh-key.view.ts
@@ -43,18 +43,14 @@ export class SshKeyView extends ItemView {
     return this.keyFingerprint;
   }
 
-  static fromJSON(obj: Partial<Jsonify<SshKeyView>>): SshKeyView {
+  static fromJSON(obj: Partial<Jsonify<SshKeyView>> | undefined): SshKeyView {
     return Object.assign(new SshKeyView(), obj);
   }
 
   /**
    * Converts the SDK SshKeyView to a SshKeyView.
    */
-  static fromSdkSshKeyView(obj: SdkSshKeyView): SshKeyView | undefined {
-    if (!obj) {
-      return undefined;
-    }
-
+  static fromSdkSshKeyView(obj: SdkSshKeyView): SshKeyView {
     const sshKeyView = new SshKeyView();
 
     sshKeyView.privateKey = obj.privateKey ?? null;

--- a/libs/common/src/vault/utils/cipher-view-like-utils.spec.ts
+++ b/libs/common/src/vault/utils/cipher-view-like-utils.spec.ts
@@ -272,6 +272,10 @@ describe("CipherViewLikeUtils", () => {
         (cipherView.attachments as any) = null;
 
         expect(CipherViewLikeUtils.hasAttachments(cipherView)).toBe(false);
+
+        cipherView.attachments = [];
+
+        expect(CipherViewLikeUtils.hasAttachments(cipherView)).toBe(false);
       });
     });
 

--- a/libs/importer/src/importers/base-importer.ts
+++ b/libs/importer/src/importers/base-importer.ts
@@ -236,7 +236,7 @@ export abstract class BaseImporter {
     return hostname.startsWith("www.") ? hostname.replace("www.", "") : hostname;
   }
 
-  protected isNullOrWhitespace(str: string): boolean {
+  protected isNullOrWhitespace(str: string | undefined | null): boolean {
     return Utils.isNullOrWhitespace(str);
   }
 

--- a/libs/importer/src/importers/base-importer.ts
+++ b/libs/importer/src/importers/base-importer.ts
@@ -193,7 +193,6 @@ export abstract class BaseImporter {
       if (this.isNullOrWhitespace(loginUri.uri)) {
         return null;
       }
-      loginUri.match = null;
       return [loginUri];
     }
 
@@ -205,7 +204,6 @@ export abstract class BaseImporter {
         if (this.isNullOrWhitespace(loginUri.uri)) {
           return;
         }
-        loginUri.match = null;
         returnArr.push(loginUri);
       });
       return returnArr.length === 0 ? null : returnArr;

--- a/libs/importer/src/importers/chrome-csv-importer.spec.ts
+++ b/libs/importer/src/importers/chrome-csv-importer.spec.ts
@@ -11,9 +11,6 @@ const CipherData = [
     title: "should parse app name",
     csv: androidData,
     expected: Object.assign(new CipherView(), {
-      id: null,
-      organizationId: null,
-      folderId: null,
       name: "com.xyz.example.app.android",
       login: Object.assign(new LoginView(), {
         username: "username@example.com",
@@ -24,7 +21,6 @@ const CipherData = [
           }),
         ],
       }),
-      notes: null,
       type: 1,
     }),
   },
@@ -32,9 +28,6 @@ const CipherData = [
     title: "should parse password",
     csv: simplePasswordData,
     expected: Object.assign(new CipherView(), {
-      id: null,
-      organizationId: null,
-      folderId: null,
       name: "www.example.com",
       login: Object.assign(new LoginView(), {
         username: "username@example.com",
@@ -45,7 +38,6 @@ const CipherData = [
           }),
         ],
       }),
-      notes: null,
       type: 1,
     }),
   },
@@ -54,6 +46,7 @@ const CipherData = [
 describe("Chrome CSV Importer", () => {
   CipherData.forEach((data) => {
     it(data.title, async () => {
+      jest.useFakeTimers().setSystemTime(data.expected.creationDate);
       const importer = new ChromeCsvImporter();
       const result = await importer.parse(data.csv);
       expect(result != null).toBe(true);

--- a/libs/importer/src/importers/dashlane/dashlane-csv-importer.spec.ts
+++ b/libs/importer/src/importers/dashlane/dashlane-csv-importer.spec.ts
@@ -59,12 +59,12 @@ describe("Dashlane CSV Importer", () => {
     const cipher = result.ciphers.shift();
     expect(cipher.type).toBe(CipherType.Card);
     expect(cipher.name).toBe("John's savings account");
-    expect(cipher.card.brand).toBeNull();
+    expect(cipher.card.brand).toBeUndefined();
     expect(cipher.card.cardholderName).toBe("John Doe");
     expect(cipher.card.number).toBe("accountNumber");
-    expect(cipher.card.code).toBeNull();
-    expect(cipher.card.expMonth).toBeNull();
-    expect(cipher.card.expYear).toBeNull();
+    expect(cipher.card.code).toBeUndefined();
+    expect(cipher.card.expMonth).toBeUndefined();
+    expect(cipher.card.expYear).toBeUndefined();
 
     expect(cipher.fields.length).toBe(4);
 
@@ -112,7 +112,7 @@ describe("Dashlane CSV Importer", () => {
     expect(cipher.name).toBe("John Doe card");
     expect(cipher.identity.fullName).toBe("John Doe");
     expect(cipher.identity.firstName).toBe("John");
-    expect(cipher.identity.middleName).toBeNull();
+    expect(cipher.identity.middleName).toBeUndefined();
     expect(cipher.identity.lastName).toBe("Doe");
     expect(cipher.identity.licenseNumber).toBe("123123123");
 
@@ -133,7 +133,7 @@ describe("Dashlane CSV Importer", () => {
     expect(cipher2.name).toBe("John Doe passport");
     expect(cipher2.identity.fullName).toBe("John Doe");
     expect(cipher2.identity.firstName).toBe("John");
-    expect(cipher2.identity.middleName).toBeNull();
+    expect(cipher2.identity.middleName).toBeUndefined();
     expect(cipher2.identity.lastName).toBe("Doe");
     expect(cipher2.identity.passportNumber).toBe("123123123");
 
@@ -154,7 +154,7 @@ describe("Dashlane CSV Importer", () => {
     expect(cipher3.name).toBe("John Doe license");
     expect(cipher3.identity.fullName).toBe("John Doe");
     expect(cipher3.identity.firstName).toBe("John");
-    expect(cipher3.identity.middleName).toBeNull();
+    expect(cipher3.identity.middleName).toBeUndefined();
     expect(cipher3.identity.lastName).toBe("Doe");
     expect(cipher3.identity.licenseNumber).toBe("1234556");
     expect(cipher3.identity.state).toBe("DC");
@@ -173,7 +173,7 @@ describe("Dashlane CSV Importer", () => {
     expect(cipher4.name).toBe("John Doe social_security");
     expect(cipher4.identity.fullName).toBe("John Doe");
     expect(cipher4.identity.firstName).toBe("John");
-    expect(cipher4.identity.middleName).toBeNull();
+    expect(cipher4.identity.middleName).toBeUndefined();
     expect(cipher4.identity.lastName).toBe("Doe");
     expect(cipher4.identity.ssn).toBe("123123123");
 

--- a/libs/importer/src/importers/firefox-csv-importer.spec.ts
+++ b/libs/importer/src/importers/firefox-csv-importer.spec.ts
@@ -11,9 +11,6 @@ const CipherData = [
     title: "should parse password",
     csv: simplePasswordData,
     expected: Object.assign(new CipherView(), {
-      id: null,
-      organizationId: null,
-      folderId: null,
       name: "example.com",
       login: Object.assign(new LoginView(), {
         username: "foo",
@@ -24,7 +21,6 @@ const CipherData = [
           }),
         ],
       }),
-      notes: null,
       type: 1,
     }),
   },
@@ -32,9 +28,6 @@ const CipherData = [
     title: 'should skip "chrome://FirefoxAccounts"',
     csv: firefoxAccountsData,
     expected: Object.assign(new CipherView(), {
-      id: null,
-      organizationId: null,
-      folderId: null,
       name: "example.com",
       login: Object.assign(new LoginView(), {
         username: "foo",
@@ -45,7 +38,6 @@ const CipherData = [
           }),
         ],
       }),
-      notes: null,
       type: 1,
     }),
   },
@@ -54,6 +46,7 @@ const CipherData = [
 describe("Firefox CSV Importer", () => {
   CipherData.forEach((data) => {
     it(data.title, async () => {
+      jest.useFakeTimers().setSystemTime(data.expected.creationDate);
       const importer = new FirefoxCsvImporter();
       const result = await importer.parse(data.csv);
       expect(result != null).toBe(true);

--- a/libs/importer/src/importers/keeper/keeper-csv-importer.spec.ts
+++ b/libs/importer/src/importers/keeper/keeper-csv-importer.spec.ts
@@ -51,10 +51,10 @@ describe("Keeper CSV Importer", () => {
     expect(result != null).toBe(true);
 
     const cipher = result.ciphers.shift();
-    expect(cipher.login.totp).toBeNull();
+    expect(cipher.login.totp).toBeUndefined();
 
     const cipher2 = result.ciphers.shift();
-    expect(cipher2.login.totp).toBeNull();
+    expect(cipher2.login.totp).toBeUndefined();
 
     const cipher3 = result.ciphers.shift();
     expect(cipher3.login.totp).toEqual(

--- a/libs/importer/src/importers/keeper/keeper-json-importer.spec.ts
+++ b/libs/importer/src/importers/keeper/keeper-json-importer.spec.ts
@@ -51,7 +51,7 @@ describe("Keeper Json Importer", () => {
     expect(result != null).toBe(true);
 
     const cipher = result.ciphers.shift();
-    expect(cipher.login.totp).toBeNull();
+    expect(cipher.login.totp).toBeUndefined();
 
     // 2nd Cipher
     const cipher2 = result.ciphers.shift();

--- a/libs/importer/src/importers/lastpass/lastpass-csv-importer.spec.ts
+++ b/libs/importer/src/importers/lastpass/lastpass-csv-importer.spec.ts
@@ -37,9 +37,6 @@ Expiration Date:June,2020
 Notes:some text
 ",Credit-card,,0`,
     expected: Object.assign(new CipherView(), {
-      id: null,
-      organizationId: null,
-      folderId: null,
       name: "Credit-card",
       notes: "some text\n",
       type: 3,
@@ -71,11 +68,7 @@ Start Date:,
 Expiration Date:,
 Notes:",empty,,0`,
     expected: Object.assign(new CipherView(), {
-      id: null,
-      organizationId: null,
-      folderId: null,
       name: "empty",
-      notes: null,
       type: 3,
       card: {
         expMonth: undefined,
@@ -101,11 +94,7 @@ Start Date:,
 Expiration Date:January,
 Notes:",noyear,,0`,
     expected: Object.assign(new CipherView(), {
-      id: null,
-      organizationId: null,
-      folderId: null,
       name: "noyear",
-      notes: null,
       type: 3,
       card: {
         cardholderName: "John Doe",
@@ -139,11 +128,7 @@ Start Date:,
 Expiration Date:,2020
 Notes:",nomonth,,0`,
     expected: Object.assign(new CipherView(), {
-      id: null,
-      organizationId: null,
-      folderId: null,
       name: "nomonth",
-      notes: null,
       type: 3,
       card: {
         cardholderName: "John Doe",
@@ -171,6 +156,7 @@ Notes:",nomonth,,0`,
 describe("Lastpass CSV Importer", () => {
   CipherData.forEach((data) => {
     it(data.title, async () => {
+      jest.useFakeTimers().setSystemTime(data.expected.creationDate);
       const importer = new LastPassCsvImporter();
       const result = await importer.parse(data.csv);
       expect(result != null).toBe(true);

--- a/libs/importer/src/importers/myki-csv-importer.spec.ts
+++ b/libs/importer/src/importers/myki-csv-importer.spec.ts
@@ -468,8 +468,8 @@ describe("Myki CSV Importer", () => {
     const cipher = result.ciphers.shift();
 
     expect(cipher.name).toEqual("2FA nickname");
-    expect(cipher.login.username).toBeNull();
-    expect(cipher.login.password).toBeNull();
+    expect(cipher.login.username).toBeUndefined();
+    expect(cipher.login.password).toBeUndefined();
     expect(cipher.login.totp).toBe("someTOTPSeed");
     expect(cipher.notes).toEqual("Additional information field content.");
 

--- a/libs/importer/src/importers/nordpass-csv-importer.spec.ts
+++ b/libs/importer/src/importers/nordpass-csv-importer.spec.ts
@@ -17,8 +17,8 @@ const namesTestData = [
     fullName: "MyFirstName",
     expected: Object.assign(new IdentityView(), {
       firstName: "MyFirstName",
-      middleName: null,
-      lastName: null,
+      middleName: undefined,
+      lastName: undefined,
     }),
   },
   {
@@ -26,7 +26,7 @@ const namesTestData = [
     fullName: "MyFirstName MyLastName",
     expected: Object.assign(new IdentityView(), {
       firstName: "MyFirstName",
-      middleName: null,
+      middleName: undefined,
       lastName: "MyLastName",
     }),
   },

--- a/libs/importer/src/importers/onepassword/onepassword-1pux-importer.spec.ts
+++ b/libs/importer/src/importers/onepassword/onepassword-1pux-importer.spec.ts
@@ -393,7 +393,7 @@ describe("1Password 1Pux Importer", () => {
 
     const identity = cipher.identity;
     expect(identity.firstName).toEqual("Michael");
-    expect(identity.middleName).toBeNull();
+    expect(identity.middleName).toBeUndefined();
     expect(identity.lastName).toEqual("Scarn");
     expect(identity.address1).toEqual("2120 Mifflin Rd.");
     expect(identity.state).toEqual("Pennsylvania");
@@ -423,7 +423,7 @@ describe("1Password 1Pux Importer", () => {
 
     const identity = cipher.identity;
     expect(identity.firstName).toEqual("Cash");
-    expect(identity.middleName).toBeNull();
+    expect(identity.middleName).toBeUndefined();
     expect(identity.lastName).toEqual("Bandit");
     expect(identity.state).toEqual("Washington");
     expect(identity.country).toEqual("United States of America");
@@ -447,7 +447,7 @@ describe("1Password 1Pux Importer", () => {
 
     const identity = cipher.identity;
     expect(identity.firstName).toEqual("George");
-    expect(identity.middleName).toBeNull();
+    expect(identity.middleName).toBeUndefined();
     expect(identity.lastName).toEqual("Engels");
     expect(identity.company).toEqual("National Public Library");
     expect(identity.phone).toEqual("9995555555");
@@ -472,7 +472,7 @@ describe("1Password 1Pux Importer", () => {
 
     const identity = cipher.identity;
     expect(identity.firstName).toEqual("David");
-    expect(identity.middleName).toBeNull();
+    expect(identity.middleName).toBeUndefined();
     expect(identity.lastName).toEqual("Global");
     expect(identity.passportNumber).toEqual("76436847");
 
@@ -499,7 +499,7 @@ describe("1Password 1Pux Importer", () => {
 
     const identity = cipher.identity;
     expect(identity.firstName).toEqual("Chef");
-    expect(identity.middleName).toBeNull();
+    expect(identity.middleName).toBeUndefined();
     expect(identity.lastName).toEqual("Coldroom");
     expect(identity.company).toEqual("Super Cool Store Co.");
 
@@ -523,7 +523,7 @@ describe("1Password 1Pux Importer", () => {
 
     const identity = cipher.identity;
     expect(identity.firstName).toEqual("Jack");
-    expect(identity.middleName).toBeNull();
+    expect(identity.middleName).toBeUndefined();
     expect(identity.lastName).toEqual("Judd");
     expect(identity.ssn).toEqual("131-216-1900");
   });
@@ -682,12 +682,12 @@ describe("1Password 1Pux Importer", () => {
     expect(folders[3].name).toBe("Education");
     expect(folders[4].name).toBe("Starter Kit");
 
-    // Check that ciphers have a folder assigned to them
-    expect(result.ciphers.filter((c) => c.folderId === folders[0].id).length).toBeGreaterThan(0);
-    expect(result.ciphers.filter((c) => c.folderId === folders[1].id).length).toBeGreaterThan(0);
-    expect(result.ciphers.filter((c) => c.folderId === folders[2].id).length).toBeGreaterThan(0);
-    expect(result.ciphers.filter((c) => c.folderId === folders[3].id).length).toBeGreaterThan(0);
-    expect(result.ciphers.filter((c) => c.folderId === folders[4].id).length).toBeGreaterThan(0);
+    // Check that folder/cipher relationships
+    expect(result.folderRelationships.filter(([_, f]) => f == 0).length).toBeGreaterThan(0);
+    expect(result.folderRelationships.filter(([_, f]) => f == 1).length).toBeGreaterThan(0);
+    expect(result.folderRelationships.filter(([_, f]) => f == 2).length).toBeGreaterThan(0);
+    expect(result.folderRelationships.filter(([_, f]) => f == 3).length).toBeGreaterThan(0);
+    expect(result.folderRelationships.filter(([_, f]) => f == 4).length).toBeGreaterThan(0);
   });
 
   it("should create collections if part of an organization", async () => {

--- a/libs/importer/src/importers/safari-csv-importer.spec.ts
+++ b/libs/importer/src/importers/safari-csv-importer.spec.ts
@@ -11,9 +11,6 @@ const CipherData = [
     title: "should parse URLs in new CSV format",
     csv: simplePasswordData,
     expected: Object.assign(new CipherView(), {
-      id: null,
-      organizationId: null,
-      folderId: null,
       name: "example.com (example_user)",
       login: Object.assign(new LoginView(), {
         username: "example_user",
@@ -33,9 +30,6 @@ const CipherData = [
     title: "should parse URLs in old CSV format",
     csv: oldSimplePasswordData,
     expected: Object.assign(new CipherView(), {
-      id: null,
-      organizationId: null,
-      folderId: null,
       name: "example.com (example_user)",
       login: Object.assign(new LoginView(), {
         username: "example_user",
@@ -45,6 +39,7 @@ const CipherData = [
             uri: "https://example.com",
           }),
         ],
+        totp: null,
       }),
       type: 1,
     }),
@@ -54,6 +49,7 @@ const CipherData = [
 describe("Safari CSV Importer", () => {
   CipherData.forEach((data) => {
     it(data.title, async () => {
+      jest.useFakeTimers().setSystemTime(data.expected.creationDate);
       const importer = new SafariCsvImporter();
       const result = await importer.parse(data.csv);
       expect(result != null).toBe(true);

--- a/libs/importer/src/importers/zohovault-csv-importer.spec.ts
+++ b/libs/importer/src/importers/zohovault-csv-importer.spec.ts
@@ -11,9 +11,6 @@ const CipherData = [
     title: "should parse Zoho Vault CSV format",
     csv: samplezohovaultcsvdata,
     expected: Object.assign(new CipherView(), {
-      id: null,
-      organizationId: null,
-      folderId: null,
       name: "XYZ Test",
       login: Object.assign(new LoginView(), {
         username: "email@domain.de",
@@ -41,6 +38,7 @@ describe("Zoho Vault CSV Importer", () => {
 
   CipherData.forEach((data) => {
     it(data.title, async () => {
+      jest.useFakeTimers().setSystemTime(data.expected.creationDate);
       const importer = new ZohoVaultCsvImporter();
       const result = await importer.parse(data.csv);
       expect(result != null).toBe(true);

--- a/libs/vault/src/cipher-form/components/attachments/delete-attachment/delete-attachment.component.ts
+++ b/libs/vault/src/cipher-form/components/attachments/delete-attachment/delete-attachment.component.ts
@@ -66,7 +66,7 @@ export class DeleteAttachmentComponent {
 
       await this.cipherService.deleteAttachmentWithServer(
         this.cipherId,
-        this.attachment.id,
+        this.attachment.id!,
         activeUserId,
         this.admin,
       );

--- a/libs/vault/src/cipher-form/components/card-details-section/card-details-section.component.spec.ts
+++ b/libs/vault/src/cipher-form/components/card-details-section/card-details-section.component.spec.ts
@@ -20,7 +20,7 @@ describe("CardDetailsSectionComponent", () => {
   let registerChildFormSpy: jest.SpyInstance;
   let patchCipherSpy: jest.SpyInstance;
 
-  const getInitialCipherView = jest.fn(() => null);
+  const getInitialCipherView = jest.fn(() => null as any);
 
   beforeEach(async () => {
     cipherFormProvider = mock<CipherFormContainer>({ getInitialCipherView });
@@ -67,6 +67,7 @@ describe("CardDetailsSectionComponent", () => {
     cardView.brand = "Visa";
     cardView.expMonth = "";
     cardView.code = "";
+    cardView.expYear = "";
 
     expect(patchCipherSpy).toHaveBeenCalled();
     const patchFn = patchCipherSpy.mock.lastCall[0];
@@ -85,6 +86,7 @@ describe("CardDetailsSectionComponent", () => {
     cardView.number = "";
     cardView.expMonth = "";
     cardView.code = "";
+    cardView.brand = "";
     cardView.expYear = "2022";
 
     expect(patchCipherSpy).toHaveBeenCalled();
@@ -122,8 +124,6 @@ describe("CardDetailsSectionComponent", () => {
       number,
       code,
       brand: cardView.brand,
-      expMonth: null,
-      expYear: null,
     });
   });
 

--- a/libs/vault/src/cipher-form/components/card-details-section/card-details-section.component.ts
+++ b/libs/vault/src/cipher-form/components/card-details-section/card-details-section.component.ts
@@ -62,7 +62,7 @@ export class CardDetailsSectionComponent implements OnInit {
 
   /** Available Card Brands */
   readonly cardBrands = [
-    { name: "-- " + this.i18nService.t("select") + " --", value: "" },
+    { name: "-- " + this.i18nService.t("select") + " --", value: null },
     { name: "Visa", value: "Visa" },
     { name: "Mastercard", value: "Mastercard" },
     { name: "American Express", value: "Amex" },

--- a/libs/vault/src/cipher-form/components/card-details-section/card-details-section.component.ts
+++ b/libs/vault/src/cipher-form/components/card-details-section/card-details-section.component.ts
@@ -52,17 +52,17 @@ export class CardDetailsSectionComponent implements OnInit {
    * leaving as just null gets inferred as `unknown`
    */
   cardDetailsForm = this.formBuilder.group({
-    cardholderName: null as string | null,
-    number: null as string | null,
-    brand: null as string | null,
-    expMonth: null as string | null,
-    expYear: null as string | number | null,
-    code: null as string | null,
+    cardholderName: "",
+    number: "",
+    brand: "",
+    expMonth: "",
+    expYear: "" as string | number,
+    code: "",
   });
 
   /** Available Card Brands */
   readonly cardBrands = [
-    { name: "-- " + this.i18nService.t("select") + " --", value: null },
+    { name: "-- " + this.i18nService.t("select") + " --", value: "" },
     { name: "Visa", value: "Visa" },
     { name: "Mastercard", value: "Mastercard" },
     { name: "American Express", value: "Amex" },
@@ -110,16 +110,14 @@ export class CardDetailsSectionComponent implements OnInit {
       .pipe(takeUntilDestroyed())
       .subscribe(({ cardholderName, number, brand, expMonth, expYear, code }) => {
         this.cipherFormContainer.patchCipher((cipher) => {
-          const expirationYear = normalizeExpiryYearFormat(expYear);
+          const expirationYear = normalizeExpiryYearFormat(expYear) ?? "";
 
-          Object.assign(cipher.card, {
-            cardholderName,
-            number,
-            brand,
-            expMonth,
-            expYear: expirationYear,
-            code,
-          });
+          cipher.card.cardholderName = cardholderName;
+          cipher.card.number = number;
+          cipher.card.brand = brand;
+          cipher.card.expMonth = expMonth;
+          cipher.card.expYear = expirationYear;
+          cipher.card.code = code;
 
           return cipher;
         });
@@ -167,6 +165,7 @@ export class CardDetailsSectionComponent implements OnInit {
       expMonth: this.initialValues?.expMonth || "",
       expYear: this.initialValues?.expYear || "",
       code: this.initialValues?.code || "",
+      brand: CardView.getCardBrandByPatterns(this.initialValues?.number) || "",
     });
   }
 
@@ -194,19 +193,5 @@ export class CardDetailsSectionComponent implements OnInit {
         originalCipher.organizationId,
       );
     }
-  }
-
-  /** Set form initial form values from the current cipher */
-  private setInitialValues(cipherView: CipherView) {
-    const { cardholderName, number, brand, expMonth, expYear, code } = cipherView.card;
-
-    this.cardDetailsForm.setValue({
-      cardholderName: cardholderName,
-      number: number,
-      brand: brand,
-      expMonth: expMonth,
-      expYear: expYear,
-      code: code,
-    });
   }
 }

--- a/libs/vault/src/cipher-form/components/custom-fields/custom-fields.component.ts
+++ b/libs/vault/src/cipher-form/components/custom-fields/custom-fields.component.ts
@@ -386,7 +386,7 @@ export class CustomFieldsComponent implements OnInit, AfterViewInit {
       fieldView.type = field.type;
       fieldView.name = field.name;
       fieldView.value = value;
-      fieldView.linkedId = field.linkedId;
+      fieldView.linkedId = field.linkedId ?? undefined;
       return fieldView;
     });
 

--- a/libs/vault/src/cipher-form/components/identity/identity.component.ts
+++ b/libs/vault/src/cipher-form/components/identity/identity.component.ts
@@ -172,7 +172,7 @@ export class IdentitySectionComponent implements OnInit {
   populateFormData(cipherView: CipherView) {
     const { identity } = cipherView;
 
-    this.identityForm.setValue({
+    this.identityForm.patchValue({
       title: identity.title,
       firstName: identity.firstName,
       middleName: identity.middleName,

--- a/libs/vault/src/cipher-form/components/item-details/item-details-section.component.ts
+++ b/libs/vault/src/cipher-form/components/item-details/item-details-section.component.ts
@@ -307,7 +307,7 @@ export class ItemDetailsSectionComponent implements OnInit {
   private async initFromExistingCipher(prefillCipher: CipherView) {
     const { name, folderId, collectionIds } = prefillCipher;
 
-    this.itemDetailsForm.setValue({
+    this.itemDetailsForm.patchValue({
       name: name ? name : (this.initialValues?.name ?? ""),
       organizationId: prefillCipher.organizationId, // We do not allow changing ownership of an existing cipher.
       folderId: folderId ? folderId : (this.initialValues?.folderId ?? null),

--- a/libs/vault/src/cipher-form/services/default-cipher-form.service.ts
+++ b/libs/vault/src/cipher-form/services/default-cipher-form.service.ts
@@ -36,7 +36,7 @@ export class DefaultCipherFormService implements CipherFormService {
     let savedCipher: Cipher;
 
     // Creating a new cipher
-    if (cipher.id == null) {
+    if (cipher.id == null || cipher.id === "") {
       const encrypted = await this.cipherService.encrypt(cipher, activeUserId);
       savedCipher = await this.cipherService.createWithServer(encrypted, config.admin);
       return await this.cipherService.decrypt(savedCipher, activeUserId);

--- a/libs/vault/src/cipher-view/custom-fields/custom-fields-v2.component.ts
+++ b/libs/vault/src/cipher-view/custom-fields/custom-fields-v2.component.ts
@@ -44,7 +44,7 @@ import { VaultAutosizeReadOnlyTextArea } from "../../directives/readonly-textare
 export class CustomFieldV2Component implements OnInit, OnChanges {
   @Input({ required: true }) cipher!: CipherView;
   fieldType = FieldType;
-  fieldOptions: Map<number, LinkedMetadata> | null = null;
+  fieldOptions: Map<number, LinkedMetadata> | undefined;
 
   /** Indexes of hidden fields that are revealed */
   revealedHiddenFields: number[] = [];
@@ -124,7 +124,7 @@ export class CustomFieldV2Component implements OnInit, OnChanges {
       case CipherType.Identity:
         return IdentityView.prototype.linkedFieldOptions;
       default:
-        return null;
+        return undefined;
     }
   }
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-25682](https://bitwarden.atlassian.net/browse/PM-25682)

## 📔 Objective

Remove the `@ts-strict-ignore` comments from the CipherView/subviews and update those views to be strict compliant; along with any down stream side effects.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
