### PR TITLE
[PM-21812][PM-21813] Migrate autofill and notification settings

### DIFF
--- a/apps/browser/src/autofill/popup/settings/autofill.component.html
+++ b/apps/browser/src/autofill/popup/settings/autofill.component.html
@@ -279,7 +279,7 @@
     <bit-section disableMargin>
       <bit-item>
         <a bit-item-content routerLink="/blocked-domains">{{ "blockedDomains" | i18n }}</a>
-        <i slot="end" class="bwi bwi-angle-right bwi-lg row-sub-icon" aria-hidden="true"></i>
+        <i slot="end" class="bwi bwi-angle-right bwi-lg" aria-hidden="true"></i>
       </bit-item>
     </bit-section>
   </div>

--- a/apps/browser/src/autofill/popup/settings/notifications.component.html
+++ b/apps/browser/src/autofill/popup/settings/notifications.component.html
@@ -50,7 +50,7 @@
     <bit-section disableMargin>
       <bit-item>
         <a bit-item-content routerLink="/excluded-domains">{{ "excludedDomains" | i18n }}</a>
-        <i slot="end" class="bwi bwi-angle-right row-sub-icon" aria-hidden="true"></i>
+        <i slot="end" class="bwi bwi-angle-right" aria-hidden="true"></i>
       </bit-item>
     </bit-section>
   </div>

--- a/apps/browser/src/popup/scss/box.scss
+++ b/apps/browser/src/popup/scss/box.scss
@@ -526,13 +526,6 @@
     width: calc(100% - 25px);
   }
 
-  .row-sub-icon,
-  .row-sub-label + i.bwi {
-    @include themify($themes) {
-      color: themed("disabledIconColor");
-    }
-  }
-
   .icon {
     display: flex;
     justify-content: center;

--- a/apps/desktop/src/scss/box.scss
+++ b/apps/desktop/src/scss/box.scss
@@ -429,21 +429,6 @@
     width: calc(100% - 25px);
   }
 
-  .row-sub-icon {
-    @include themify($themes) {
-      color: themed("disabledIconColor");
-    }
-  }
-
-  .row-sub-label {
-    margin: 0 15px;
-    white-space: nowrap;
-
-    @include themify($themes) {
-      color: themed("mutedColor");
-    }
-  }
-
   .progress {
     display: flex;
     height: 5px;


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-21812
https://bitwarden.atlassian.net/browse/PM-21813

## 📔 Objective

- To continue to migrate all existing components to Tailwind, it's important for us to remove any unnecessary and/or unused stylings.
- I verified that removal of the non-Tailwind classes did not impact the UI by double-checking against similarly style bit-icon elements (see screenshot below). 
- I successfully ran all unit tests locally and performed a variety of spot checking throughout the browser settings prior to raising the PR. 
 
## 📸 Screenshots

| Autofill Before (Dark) | Autofill After (Dark) |
|----|----|
| <img width="478" height="488" alt="Autofill - Before Dark" src="https://github.com/user-attachments/assets/de41eb47-d136-487c-a55c-279d8e7bbc47" /> | <img width="466" height="422" alt="Screenshot 2025-09-19 at 2 26 17 PM" src="https://github.com/user-attachments/assets/dcbe3e03-0846-4033-b203-125cbaa940ac" />  |
| Notifications Before (Light) | Notifications After (Light) | 
| <img width="477" height="326" alt="Notificaitons - Before Light" src="https://github.com/user-attachments/assets/d8e5aab6-ecb1-468a-95c3-0dfd240b4838" /> | <img width="479" height="425" alt="Screenshot 2025-09-19 at 2 25 45 PM" src="https://github.com/user-attachments/assets/6583c2bb-5058-41cf-bebe-1e1d189e192c" /> |

<img width="550" height="342" alt="bit-item-right-arrow-icon-styling" src="https://github.com/user-attachments/assets/7f6b1f49-5706-41af-adc8-13fa72ac93b1" />



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
