### PR TITLE
[PM-25838] Adding new properties to the summary and renaming the type

### DIFF
--- a/bitwarden_license/bit-common/src/dirt/reports/risk-insights/models/report-models.ts
+++ b/bitwarden_license/bit-common/src/dirt/reports/risk-insights/models/report-models.ts
@@ -90,7 +90,7 @@ export type CipherApplicationView = {
  * total at risk members, application, and at risk application
  * counts. Aggregated from all calculated applications
  */
-export type ApplicationHealthReportSummary = {
+export type OrganizationReportSummary = {
   totalMemberCount: number;
   totalAtRiskMemberCount: number;
   totalApplicationCount: number;
@@ -138,7 +138,7 @@ export type PasswordHealthReportApplicationId = Opaque<string, "PasswordHealthRe
 // -------------------- Risk Insights Report Models --------------------
 export interface RiskInsightsReportData {
   data: ApplicationHealthReportDetailEnriched[];
-  summary: ApplicationHealthReportSummary;
+  summary: OrganizationReportSummary;
 }
 export interface RiskInsightsReport {
   organizationId: OrganizationId;
@@ -157,6 +157,6 @@ export type ReportResult = CipherView & {
 
 export type ReportDetailsAndSummary = {
   data: ApplicationHealthReportDetailEnriched[];
-  summary: ApplicationHealthReportSummary;
+  summary: OrganizationReportSummary;
   dateCreated: Date;
 };

--- a/bitwarden_license/bit-common/src/dirt/reports/risk-insights/models/report-models.ts
+++ b/bitwarden_license/bit-common/src/dirt/reports/risk-insights/models/report-models.ts
@@ -92,9 +92,14 @@ export type CipherApplicationView = {
  */
 export type OrganizationReportSummary = {
   totalMemberCount: number;
+  totalCriticalMemberCount: number;
   totalAtRiskMemberCount: number;
+  totalCriticalAtRiskMemberCount: number;
   totalApplicationCount: number;
+  totalCriticalApplicationCount: number;
   totalAtRiskApplicationCount: number;
+  totalCriticalAtRiskApplicationCount: number;
+  newApplications: string[];
 };
 
 export type CriticalSummaryDetails = {

--- a/bitwarden_license/bit-common/src/dirt/reports/risk-insights/services/risk-insights-report.service.ts
+++ b/bitwarden_license/bit-common/src/dirt/reports/risk-insights/services/risk-insights-report.service.ts
@@ -68,6 +68,11 @@ export class RiskInsightsReportService {
     totalAtRiskMemberCount: 0,
     totalApplicationCount: 0,
     totalAtRiskApplicationCount: 0,
+    totalCriticalMemberCount: 0,
+    totalCriticalAtRiskMemberCount: 0,
+    totalCriticalApplicationCount: 0,
+    totalCriticalAtRiskApplicationCount: 0,
+    newApplications: [],
   });
   riskInsightsSummary$ = this.riskInsightsSummarySubject.asObservable();
 
@@ -197,11 +202,17 @@ export class RiskInsightsReportService {
     const atRiskMembers = reports.flatMap((x) => x.atRiskMemberDetails);
     const uniqueAtRiskMembers = getUniqueMembers(atRiskMembers);
 
+    // TODO: totalCriticalMemberCount, totalCriticalAtRiskMemberCount, totalCriticalApplicationCount, totalCriticalAtRiskApplicationCount, and newApplications will be handled with future logic implementation
     return {
       totalMemberCount: uniqueMembers.length,
+      totalCriticalMemberCount: 0,
       totalAtRiskMemberCount: uniqueAtRiskMembers.length,
+      totalCriticalAtRiskMemberCount: 0,
       totalApplicationCount: reports.length,
+      totalCriticalApplicationCount: 0,
       totalAtRiskApplicationCount: reports.filter((app) => app.atRiskPasswordCount > 0).length,
+      totalCriticalAtRiskApplicationCount: 0,
+      newApplications: [],
     };
   }
 
@@ -235,6 +246,11 @@ export class RiskInsightsReportService {
                 totalAtRiskMemberCount: 0,
                 totalApplicationCount: 0,
                 totalAtRiskApplicationCount: 0,
+                totalCriticalMemberCount: 0,
+                totalCriticalAtRiskMemberCount: 0,
+                totalCriticalApplicationCount: 0,
+                totalCriticalAtRiskApplicationCount: 0,
+                newApplications: [],
               },
             });
           }

--- a/bitwarden_license/bit-common/src/dirt/reports/risk-insights/services/risk-insights-report.service.ts
+++ b/bitwarden_license/bit-common/src/dirt/reports/risk-insights/services/risk-insights-report.service.ts
@@ -40,7 +40,7 @@ import {
 } from "../models/password-health";
 import {
   ApplicationHealthReportDetail,
-  ApplicationHealthReportSummary,
+  OrganizationReportSummary,
   AtRiskMemberDetail,
   AtRiskApplicationDetail,
   RiskInsightsReportData,
@@ -63,7 +63,7 @@ export class RiskInsightsReportService {
   private riskInsightsReportSubject = new BehaviorSubject<ApplicationHealthReportDetail[]>([]);
   riskInsightsReport$ = this.riskInsightsReportSubject.asObservable();
 
-  private riskInsightsSummarySubject = new BehaviorSubject<ApplicationHealthReportSummary>({
+  private riskInsightsSummarySubject = new BehaviorSubject<OrganizationReportSummary>({
     totalMemberCount: 0,
     totalAtRiskMemberCount: 0,
     totalApplicationCount: 0,
@@ -190,9 +190,7 @@ export class RiskInsightsReportService {
    * @param reports The previously calculated application health report data
    * @returns A summary object containing report totals
    */
-  generateApplicationsSummary(
-    reports: ApplicationHealthReportDetail[],
-  ): ApplicationHealthReportSummary {
+  generateApplicationsSummary(reports: ApplicationHealthReportDetail[]): OrganizationReportSummary {
     const totalMembers = reports.flatMap((x) => x.memberDetails);
     const uniqueMembers = getUniqueMembers(totalMembers);
 

--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/all-applications.component.ts
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/all-applications.component.ts
@@ -16,7 +16,7 @@ import {
 } from "@bitwarden/bit-common/dirt/reports/risk-insights/models/password-health";
 import {
   ApplicationHealthReportDetail,
-  ApplicationHealthReportSummary,
+  OrganizationReportSummary,
 } from "@bitwarden/bit-common/dirt/reports/risk-insights/models/report-models";
 import { RiskInsightsEncryptionService } from "@bitwarden/bit-common/dirt/reports/risk-insights/services/risk-insights-encryption.service";
 import {
@@ -69,11 +69,16 @@ export class AllApplicationsComponent implements OnInit {
   protected organization = new Organization();
   noItemsIcon = Security;
   protected markingAsCritical = false;
-  protected applicationSummary: ApplicationHealthReportSummary = {
+  protected applicationSummary: OrganizationReportSummary = {
     totalMemberCount: 0,
     totalAtRiskMemberCount: 0,
     totalApplicationCount: 0,
     totalAtRiskApplicationCount: 0,
+    totalCriticalMemberCount: 0,
+    totalCriticalAtRiskMemberCount: 0,
+    totalCriticalApplicationCount: 0,
+    totalCriticalAtRiskApplicationCount: 0,
+    newApplications: [],
   };
 
   destroyRef = inject(DestroyRef);

--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/critical-applications.component.ts
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/critical-applications.component.ts
@@ -16,7 +16,7 @@ import {
   LEGACY_ApplicationHealthReportDetailWithCriticalFlag,
   LEGACY_ApplicationHealthReportDetailWithCriticalFlagAndCipher,
 } from "@bitwarden/bit-common/dirt/reports/risk-insights/models/password-health";
-import { ApplicationHealthReportSummary } from "@bitwarden/bit-common/dirt/reports/risk-insights/models/report-models";
+import { OrganizationReportSummary } from "@bitwarden/bit-common/dirt/reports/risk-insights/models/report-models";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { getUserId } from "@bitwarden/common/auth/services/account.service";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
@@ -57,7 +57,7 @@ export class CriticalApplicationsComponent implements OnInit {
   private destroyRef = inject(DestroyRef);
   protected loading = false;
   protected organizationId: OrganizationId;
-  protected applicationSummary = {} as ApplicationHealthReportSummary;
+  protected applicationSummary = {} as OrganizationReportSummary;
   noItemsIcon = Security;
   enableRequestPasswordChange = false;
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-25838

## 📔 Objective

Adding properties to the risk insights report summary and renaming the type to match the new naming convention. New properties added are to assist in report metrics and reduce recalculation on load. 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
