### PR TITLE
[PM-25922] Hotfix: Revert canManageDeviceApprovals

### DIFF
--- a/libs/common/src/admin-console/models/domain/organization.spec.ts
+++ b/libs/common/src/admin-console/models/domain/organization.spec.ts
@@ -111,7 +111,7 @@ describe("Organization", () => {
       expect(organization.canManageDeviceApprovals).toBe(false);
     });
 
-    it("should return false when ssoEnabled is false", () => {
+    it.skip("should return false when ssoEnabled is false", () => {
       data.type = OrganizationUserType.Admin;
       data.useSso = true;
       data.ssoEnabled = false;
@@ -122,7 +122,7 @@ describe("Organization", () => {
       expect(organization.canManageDeviceApprovals).toBe(false);
     });
 
-    it("should return false when ssoMemberDecryptionType is not TrustedDeviceEncryption", () => {
+    it.skip("should return false when ssoMemberDecryptionType is not TrustedDeviceEncryption", () => {
       data.type = OrganizationUserType.Admin;
       data.useSso = true;
       data.ssoEnabled = true;

--- a/libs/common/src/admin-console/models/domain/organization.ts
+++ b/libs/common/src/admin-console/models/domain/organization.ts
@@ -309,12 +309,7 @@ export class Organization {
   }
 
   get canManageDeviceApprovals() {
-    return (
-      (this.isAdmin || this.permissions.manageResetPassword) &&
-      this.useSso &&
-      this.ssoEnabled &&
-      this.ssoMemberDecryptionType === MemberDecryptionType.TrustedDeviceEncryption
-    );
+    return (this.isAdmin || this.permissions.manageResetPassword) && this.useSso;
   }
 
   get isExemptFromPolicies() {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-25922

## 📔 Objective

There’s an issue where not every endpoint is providing the data needed for the client to perform the new checks. This PR reverts just the new check feature on the client.

1. Revert the new check.  
2. Skip tests for this particular functionality, but keep the rest of the tests.  


## 📸 Screenshots
We have good test coverage for this. I’m confident it’s ready for QA.

## ⏰ Reminders before review


- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
