### PR TITLE
[PM-21815] - Implement component form the component library & Tailwind CSS

### DIFF
--- a/apps/browser/src/key-management/key-connector/remove-password.component.html
+++ b/apps/browser/src/key-management/key-connector/remove-password.component.html
@@ -1,53 +1,51 @@
-<header>
-  <div class="left"></div>
-  <div class="center">
-    <span class="title">{{ "removeMasterPassword" | i18n }}</span>
-  </div>
-  <div class="right"></div>
-</header>
+<popup-page>
+  <popup-header slot="header" pageTitle="{{ 'removeMasterPassword' | i18n }}">
+    <ng-container slot="end">
+      <app-pop-out></app-pop-out>
+    </ng-container>
+  </popup-header>
 
-<main tabindex="-1">
-  <div class="box">
-    <div class="box-content" *ngIf="loading">
-      <div class="box-content-row">
-        <i class="bwi bwi-spinner bwi-spin" title="{{ 'loading' | i18n }}" aria-hidden="true"></i>
-      </div>
+  @if (loading) {
+    <div class="tw-text-center">
+      <i
+        class="bwi bwi-spinner bwi-spin bwi-2x tw-text-muted"
+        title="{{ 'loading' | i18n }}"
+        aria-hidden="true"
+      ></i>
+      <span class="tw-sr-only">{{ "loading" | i18n }}</span>
     </div>
-    <div class="box-content" *ngIf="!loading">
-      <div class="box-content-row" appBoxRow>
-        <p>{{ "removeMasterPasswordForOrganizationUserKeyConnector" | i18n }}</p>
-        <p class="tw-mb-0">{{ "organizationName" | i18n }}:</p>
-        <p class="tw-text-muted tw-mb-6">{{ organization.name }}</p>
-        <p class="tw-mb-0">{{ "keyConnectorDomain" | i18n }}:</p>
-        <p class="tw-text-muted tw-mb-6">{{ organization.keyConnectorUrl }}</p>
-      </div>
-      <div class="box-content-row">
-        <button type="button" class="btn block primary" (click)="convert()" [disabled]="action">
-          <i
-            class="bwi bwi-spinner bwi-spin"
-            title="{{ 'loading' | i18n }}"
-            aria-hidden="true"
-            *ngIf="continuing"
-          ></i>
-          {{ "removeMasterPassword" | i18n }}
-        </button>
-      </div>
-      <div class="box-content-row">
-        <button
-          type="button"
-          class="btn btn-outline-secondary block"
-          (click)="leave()"
-          [disabled]="action"
-        >
-          <i
-            class="bwi bwi-spinner bwi-spin"
-            title="{{ 'loading' | i18n }}"
-            aria-hidden="true"
-            *ngIf="leaving"
-          ></i>
-          {{ "leaveOrganization" | i18n }}
-        </button>
-      </div>
-    </div>
-  </div>
-</main>
+  } @else {
+    <p>{{ "removeMasterPasswordForOrganizationUserKeyConnector" | i18n }}</p>
+    <p class="tw-mb-0">{{ "organizationName" | i18n }}:</p>
+    <p class="tw-text-muted tw-mb-6">{{ organization.name }}</p>
+    <p class="tw-mb-0">{{ "keyConnectorDomain" | i18n }}:</p>
+    <p class="tw-text-muted tw-mb-6">{{ organization.keyConnectorUrl }}</p>
+    <button
+      type="button"
+      bitButton
+      buttonType="primary"
+      block
+      (click)="convert()"
+      [disabled]="action"
+      class="tw-mb-2"
+    >
+      <i
+        class="bwi bwi-spinner bwi-spin"
+        title="{{ 'loading' | i18n }}"
+        aria-hidden="true"
+        *ngIf="continuing"
+      ></i>
+      {{ "removeMasterPassword" | i18n }}
+    </button>
+
+    <button type="button" bitButton block (click)="leave()" [disabled]="action">
+      <i
+        class="bwi bwi-spinner bwi-spin"
+        title="{{ 'loading' | i18n }}"
+        aria-hidden="true"
+        *ngIf="leaving"
+      ></i>
+      {{ "leaveOrganization" | i18n }}
+    </button>
+  }
+</popup-page>


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-21815?focusedCommentId=110347

## 📔 Objective

The goal is to bring the component up-to-date with the proper components form the component library and to utilize only the most current Tailwind CSS classes for styling. I ensured that existing functionality remained in tact after the change by removing the master password from a dev-test account and only leveraged SSO. All local unit tests are passing as expected.

## 📸 Screenshots

### Before

<img width="562" height="639" alt="RemoveMasterPassword_Before" src="https://github.com/user-attachments/assets/d9ce535e-f4ce-45e2-9f27-4979df6ea5f5" />

### After
| Light Theme | Dark Theme |
|-----|-----|
|  <img width="455" height="661" alt="After - Light Theme" src="https://github.com/user-attachments/assets/504f70c0-2d39-4382-a23d-2d48bc407df9" /> |  <img width="452" height="631" alt="After - Dark Theme" src="https://github.com/user-attachments/assets/cce7e3a0-6fca-4e83-a770-5ea1ef9d57f0" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
