### PR TITLE
[PM-25991] Change validation from pattern to minLength

### DIFF
--- a/bitwarden_license/bit-web/src/app/dirt/organization-integrations/integration-dialog/connect-dialog/connect-dialog-hec.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/dirt/organization-integrations/integration-dialog/connect-dialog/connect-dialog-hec.component.spec.ts
@@ -121,9 +121,9 @@ describe("ConnectDialogHecComponent", () => {
     expect(component.formGroup.valid).toBeTruthy();
   });
 
-  it("should invalidate url if not matching pattern", () => {
+  it("should test url is at least 7 characters long", () => {
     component.formGroup.setValue({
-      url: "ftp://test.com",
+      url: "test",
       bearerToken: "token",
       index: "1",
       service: "Test Service",

--- a/bitwarden_license/bit-web/src/app/dirt/organization-integrations/integration-dialog/connect-dialog/connect-dialog-hec.component.ts
+++ b/bitwarden_license/bit-web/src/app/dirt/organization-integrations/integration-dialog/connect-dialog/connect-dialog-hec.component.ts
@@ -37,7 +37,7 @@ export class ConnectHecDialogComponent implements OnInit {
   hecConfig: HecConfiguration | null = null;
   hecTemplate: HecTemplate | null = null;
   formGroup = this.formBuilder.group({
-    url: ["", [Validators.required, Validators.pattern("https?://.+")]],
+    url: ["", [Validators.required, Validators.minLength(7)]],
     bearerToken: ["", Validators.required],
     index: ["", Validators.required],
     service: ["", Validators.required],


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-25991

## 📔 Objective

The pattern validator could not use a customized message.
Also, the pattern validator was never used within Bitwarden.
Given that, the validation was changed to use a minLength

## 📸 Screenshots

<img width="1152" height="688" alt="image" src="https://github.com/user-attachments/assets/1af71c8b-350a-4a83-9469-73a8bf5f79c7" />


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
