### PR TITLE
Autofill form that has the focus

### DIFF
--- a/apps/browser/src/autofill/background/abstractions/overlay.background.ts
+++ b/apps/browser/src/autofill/background/abstractions/overlay.background.ts
@@ -48,6 +48,7 @@ export type FocusedFieldData = {
   frameId?: number;
   accountCreationFieldType?: string;
   showPasskeys?: boolean;
+  focusedFieldForm?: string;
 };
 
 export type InlineMenuElementPosition = {

--- a/apps/browser/src/autofill/background/overlay.background.ts
+++ b/apps/browser/src/autofill/background/overlay.background.ts
@@ -1175,6 +1175,7 @@ export class OverlayBackground implements OverlayBackgroundInterface {
       pageDetails,
       fillNewPassword: true,
       allowTotpAutofill: true,
+      focusedFieldForm: this.focusedFieldData?.focusedFieldForm,
     });
 
     if (totpCode) {
@@ -1859,6 +1860,7 @@ export class OverlayBackground implements OverlayBackgroundInterface {
       pageDetails,
       fillNewPassword: true,
       allowTotpAutofill: false,
+      focusedFieldForm: this.focusedFieldData?.focusedFieldForm,
     });
 
     globalThis.setTimeout(async () => {

--- a/apps/browser/src/autofill/services/abstractions/autofill.service.ts
+++ b/apps/browser/src/autofill/services/abstractions/autofill.service.ts
@@ -30,6 +30,7 @@ export interface AutoFillOptions {
   allowUntrustedIframe?: boolean;
   allowTotpAutofill?: boolean;
   autoSubmitLogin?: boolean;
+  focusedFieldForm?: string;
 }
 
 export interface FormData {

--- a/apps/browser/src/autofill/services/autofill-overlay-content.service.ts
+++ b/apps/browser/src/autofill/services/autofill-overlay-content.service.ts
@@ -974,6 +974,7 @@ export class AutofillOverlayContentService implements AutofillOverlayContentServ
       inlineMenuFillType: autofillFieldData?.inlineMenuFillType,
       showPasskeys: !!autofillFieldData?.showPasskeys,
       accountCreationFieldType: autofillFieldData?.accountCreationFieldType,
+      focusedFieldForm: autofillFieldData?.form,
     };
 
     const allFields = this.formFieldElements;

--- a/apps/browser/src/autofill/services/autofill.service.ts
+++ b/apps/browser/src/autofill/services/autofill.service.ts
@@ -434,7 +434,15 @@ export default class AutofillService implements AutofillServiceInterface {
           return;
         }
 
-        const fillScript = await this.generateFillScript(pd.details, {
+        // If we have a focused form, filter the page details to only include fields from that form
+        const details = options.focusedFieldForm
+          ? {
+              ...pd.details,
+              fields: pd.details.fields.filter((f) => f.form === options.focusedFieldForm),
+            }
+          : pd.details;
+
+        const fillScript = await this.generateFillScript(details, {
           skipUsernameOnlyFill: options.skipUsernameOnlyFill || false,
           onlyEmptyFields: options.onlyEmptyFields || false,
           fillNewPassword: options.fillNewPassword || false,


### PR DESCRIPTION
## 🎟️ Tracking

[PM-25073](https://bitwarden.atlassian.net/browse/PM-25073)

## 📔 Objective

On the sign-in form for bedbathandbeyond.com (hover over `Account` and click `Sign In`) the page has two forms.  One is to Create and Account and the other is to Sign In.  Autofill would always fill incorrectly.  Now we check to see if the currently focused form has autofill fields and we only autofill those.  If it doesn't we fall back to regular autofill behavior.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-25073]: https://bitwarden.atlassian.net/browse/PM-25073?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ