### PR TITLE
[PM-24534] Archive via CLI

### DIFF
--- a/apps/browser/src/popup/services/services.module.ts
+++ b/apps/browser/src/popup/services/services.module.ts
@@ -708,14 +708,7 @@ const safeProviders: SafeProvider[] = [
   safeProvider({
     provide: CipherArchiveService,
     useClass: DefaultCipherArchiveService,
-    deps: [
-      CipherService,
-      ApiService,
-      DialogService,
-      PasswordRepromptService,
-      BillingAccountProfileStateService,
-      ConfigService,
-    ],
+    deps: [CipherService, ApiService, BillingAccountProfileStateService, ConfigService],
   }),
 ];
 

--- a/apps/cli/src/commands/list.command.ts
+++ b/apps/cli/src/commands/list.command.ts
@@ -21,6 +21,7 @@ import { FolderService } from "@bitwarden/common/vault/abstractions/folder/folde
 import { SearchService } from "@bitwarden/common/vault/abstractions/search.service";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { KeyService } from "@bitwarden/key-management";
+import { CipherArchiveService } from "@bitwarden/vault";
 
 import { CollectionResponse } from "../admin-console/models/response/collection.response";
 import { OrganizationUserResponse } from "../admin-console/models/response/organization-user.response";
@@ -45,6 +46,7 @@ export class ListCommand {
     private accountService: AccountService,
     private keyService: KeyService,
     private cliRestrictedItemTypesService: CliRestrictedItemTypesService,
+    private cipherArchiveService: CipherArchiveService,
   ) {}
 
   async run(object: string, cmdOptions: Record<string, any>): Promise<Response> {
@@ -71,8 +73,13 @@ export class ListCommand {
     let ciphers: CipherView[];
 
     const activeUserId = await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId));
+    const userCanArchive = await firstValueFrom(
+      this.cipherArchiveService.userCanArchive$(activeUserId),
+    );
 
     options.trash = options.trash || false;
+    options.archived = userCanArchive && options.archived;
+
     if (options.url != null && options.url.trim() !== "") {
       ciphers = await this.cipherService.getAllDecryptedForUrl(options.url, activeUserId);
     } else {
@@ -85,9 +92,12 @@ export class ListCommand {
       options.organizationId != null
     ) {
       ciphers = ciphers.filter((c) => {
-        if (options.trash !== c.isDeleted) {
+        const matchesStateOptions = this.matchesStateOptions(c, options);
+
+        if (!matchesStateOptions) {
           return false;
         }
+
         if (options.folderId != null) {
           if (options.folderId === "notnull" && c.folderId != null) {
             return true;
@@ -131,11 +141,16 @@ export class ListCommand {
         return false;
       });
     } else if (options.search == null || options.search.trim() === "") {
-      ciphers = ciphers.filter((c) => options.trash === c.isDeleted);
+      ciphers = ciphers.filter((c) => this.matchesStateOptions(c, options));
     }
 
     if (options.search != null && options.search.trim() !== "") {
-      ciphers = this.searchService.searchCiphersBasic(ciphers, options.search, options.trash);
+      ciphers = this.searchService.searchCiphersBasic(
+        ciphers,
+        options.search,
+        options.trash,
+        options.archived,
+      );
     }
 
     ciphers = await this.cliRestrictedItemTypesService.filterRestrictedCiphers(ciphers);
@@ -287,6 +302,17 @@ export class ListCommand {
     const res = new ListResponse(organizations.map((o) => new OrganizationResponse(o)));
     return Response.success(res);
   }
+
+  /**
+   * Checks if the cipher passes either the trash or the archive options.
+   * @returns true if the cipher passes *any* of the filters
+   */
+  private matchesStateOptions(c: CipherView, options: Options): boolean {
+    const passesTrashFilter = options.trash && c.isDeleted;
+    const passesArchivedFilter = options.archived && c.isArchived;
+
+    return passesTrashFilter || passesArchivedFilter;
+  }
 }
 
 class Options {
@@ -296,6 +322,7 @@ class Options {
   search: string;
   url: string;
   trash: boolean;
+  archived: boolean;
 
   constructor(passedOptions: Record<string, any>) {
     this.organizationId = passedOptions?.organizationid || passedOptions?.organizationId;
@@ -304,5 +331,6 @@ class Options {
     this.search = passedOptions?.search;
     this.url = passedOptions?.url;
     this.trash = CliUtils.convertBooleanOption(passedOptions?.trash);
+    this.archived = CliUtils.convertBooleanOption(passedOptions?.archived);
   }
 }

--- a/apps/cli/src/oss-serve-configurator.ts
+++ b/apps/cli/src/oss-serve-configurator.ts
@@ -107,6 +107,7 @@ export class OssServeConfigurator {
       this.serviceContainer.accountService,
       this.serviceContainer.cliRestrictedItemTypesService,
       this.serviceContainer.policyService,
+      this.serviceContainer.billingAccountProfileStateService,
     );
     this.generateCommand = new GenerateCommand(
       this.serviceContainer.passwordGenerationService,

--- a/apps/cli/src/oss-serve-configurator.ts
+++ b/apps/cli/src/oss-serve-configurator.ts
@@ -150,6 +150,7 @@ export class OssServeConfigurator {
       this.serviceContainer.cipherService,
       this.serviceContainer.accountService,
       this.serviceContainer.cipherAuthorizationService,
+      this.serviceContainer.cipherArchiveService,
     );
     this.shareCommand = new ShareCommand(
       this.serviceContainer.cipherService,

--- a/apps/cli/src/oss-serve-configurator.ts
+++ b/apps/cli/src/oss-serve-configurator.ts
@@ -83,6 +83,7 @@ export class OssServeConfigurator {
       this.serviceContainer.accountService,
       this.serviceContainer.keyService,
       this.serviceContainer.cliRestrictedItemTypesService,
+      this.serviceContainer.cipherArchiveService,
     );
     this.createCommand = new CreateCommand(
       this.serviceContainer.cipherService,

--- a/apps/cli/src/service-container/service-container.ts
+++ b/apps/cli/src/service-container/service-container.ts
@@ -176,6 +176,8 @@ import {
   DefaultStateService,
 } from "@bitwarden/state-internal";
 import { SerializedMemoryStorageService } from "@bitwarden/storage-core";
+import { CipherArchiveService } from "@bitwarden/vault/abstractions/cipher-archive.service";
+import { DefaultCipherArchiveService } from "@bitwarden/vault/services/default-cipher-archive.service";
 import {
   IndividualVaultExportService,
   IndividualVaultExportServiceAbstraction,
@@ -298,6 +300,7 @@ export class ServiceContainer {
   cipherEncryptionService: CipherEncryptionService;
   restrictedItemTypesService: RestrictedItemTypesService;
   cliRestrictedItemTypesService: CliRestrictedItemTypesService;
+  cipherArchiveService: CipherArchiveService;
 
   constructor() {
     let p = null;
@@ -724,6 +727,13 @@ export class ServiceContainer {
       this.logService,
       this.cipherEncryptionService,
       this.messagingService,
+    );
+
+    this.cipherArchiveService = new DefaultCipherArchiveService(
+      this.cipherService,
+      this.apiService,
+      this.billingAccountProfileStateService,
+      this.configService,
     );
 
     this.folderService = new FolderService(

--- a/apps/cli/src/vault.program.ts
+++ b/apps/cli/src/vault.program.ts
@@ -375,7 +375,7 @@ export class VaultProgram extends BaseProgram {
     return new Command("restore")
       .argument("<object>", "Valid objects are: " + restoreObjects.join(", "))
       .argument("<id>", "Object's globally unique `id`.")
-      .description("Restores an object from the trash.")
+      .description("Restores an object from the trash or archive.")
       .on("--help", () => {
         writeLn("\n  Examples:");
         writeLn("");
@@ -392,6 +392,7 @@ export class VaultProgram extends BaseProgram {
           this.serviceContainer.cipherService,
           this.serviceContainer.accountService,
           this.serviceContainer.cipherAuthorizationService,
+          this.serviceContainer.cipherArchiveService,
         );
         const response = await command.run(object, id);
         this.processResponse(response);

--- a/apps/cli/src/vault.program.ts
+++ b/apps/cli/src/vault.program.ts
@@ -75,6 +75,7 @@ export class VaultProgram extends BaseProgram {
         "Filter items or collections by organization id.",
       )
       .option("--trash", "Filter items that are deleted and in the trash.")
+      .option("--archived", "Filter items that are archived.")
       .on("--help", () => {
         writeLn("\n  Notes:");
         writeLn("");
@@ -118,6 +119,7 @@ export class VaultProgram extends BaseProgram {
           this.serviceContainer.accountService,
           this.serviceContainer.keyService,
           this.serviceContainer.cliRestrictedItemTypesService,
+          this.serviceContainer.cipherArchiveService,
         );
         const response = await command.run(object, cmd);
 

--- a/apps/cli/src/vault.program.ts
+++ b/apps/cli/src/vault.program.ts
@@ -290,6 +290,7 @@ export class VaultProgram extends BaseProgram {
           this.serviceContainer.accountService,
           this.serviceContainer.cliRestrictedItemTypesService,
           this.serviceContainer.policyService,
+          this.serviceContainer.billingAccountProfileStateService,
         );
         const response = await command.run(object, id, encodedJson, cmd);
         this.processResponse(response);

--- a/apps/cli/src/vault/archive.command.ts
+++ b/apps/cli/src/vault/archive.command.ts
@@ -93,6 +93,12 @@ export class ArchiveCommand {
       case CipherViewLikeUtils.isArchived(cipher): {
         return { canArchive: false, errorMessage: "Item is already archived." };
       }
+      case CipherViewLikeUtils.isDeleted(cipher): {
+        return {
+          canArchive: false,
+          errorMessage: "Item is in the trash, the item must be restored before archiving.",
+        };
+      }
       case cipher.organizationId != null: {
         return { canArchive: false, errorMessage: "Cannot archive items in an organization." };
       }

--- a/apps/cli/src/vault/archive.command.ts
+++ b/apps/cli/src/vault/archive.command.ts
@@ -1,0 +1,103 @@
+import { firstValueFrom } from "rxjs";
+
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { getUserId } from "@bitwarden/common/auth/services/account.service";
+import { BillingAccountProfileStateService } from "@bitwarden/common/billing/abstractions";
+import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
+import { CipherId } from "@bitwarden/common/types/guid";
+import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
+import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+import { CipherViewLikeUtils } from "@bitwarden/common/vault/utils/cipher-view-like-utils";
+import { UserId } from "@bitwarden/user-core";
+import { CipherArchiveService } from "@bitwarden/vault";
+
+import { Response } from "../models/response";
+
+export class ArchiveCommand {
+  constructor(
+    private cipherService: CipherService,
+    private accountService: AccountService,
+    private configService: ConfigService,
+    private cipherArchiveService: CipherArchiveService,
+    private billingAccountProfileStateService: BillingAccountProfileStateService,
+  ) {}
+
+  async run(object: string, id: string): Promise<Response> {
+    const featureFlagEnabled = await this.configService.getFeatureFlag(
+      FeatureFlag.PM19148_InnovationArchive,
+    );
+
+    if (!featureFlagEnabled) {
+      return Response.notFound();
+    }
+
+    if (id != null) {
+      id = id.toLowerCase();
+    }
+
+    const normalizedObject = object.toLowerCase();
+
+    if (normalizedObject === "item") {
+      return this.archiveCipher(id);
+    }
+
+    return Response.badRequest("Unknown object.");
+  }
+
+  private async archiveCipher(cipherId: string) {
+    const activeUserId = await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId));
+    const cipher = await this.cipherService.get(cipherId, activeUserId);
+
+    if (cipher == null) {
+      return Response.notFound();
+    }
+
+    const cipherView = await this.cipherService.decrypt(cipher, activeUserId);
+
+    const { canArchive, errorMessage } = await this.userCanArchiveCipher(cipherView, activeUserId);
+
+    if (!canArchive) {
+      return Response.error(errorMessage);
+    }
+
+    try {
+      await this.cipherArchiveService.archiveWithServer(cipherView.id as CipherId, activeUserId);
+      return Response.success();
+    } catch (e) {
+      return Response.error(e);
+    }
+  }
+
+  /**
+   * Determines if the user can archive the given cipher.
+   * When the user cannot archive the cipher, an appropriate error message is provided.
+   */
+  private async userCanArchiveCipher(
+    cipher: CipherView,
+    userId: UserId,
+  ): Promise<
+    { canArchive: true; errorMessage?: never } | { canArchive: false; errorMessage: string }
+  > {
+    const hasPremiumFromAnySource = await firstValueFrom(
+      this.billingAccountProfileStateService.hasPremiumFromAnySource$(userId),
+    );
+
+    switch (true) {
+      case !hasPremiumFromAnySource: {
+        return {
+          canArchive: false,
+          errorMessage: "Premium status is required to use this feature.",
+        };
+      }
+      case CipherViewLikeUtils.isArchived(cipher): {
+        return { canArchive: false, errorMessage: "Item is already archived." };
+      }
+      case cipher.organizationId != null: {
+        return { canArchive: false, errorMessage: "Cannot archive items in an organization." };
+      }
+      default:
+        return { canArchive: true };
+    }
+  }
+}

--- a/libs/angular/src/services/jslib-services.module.ts
+++ b/libs/angular/src/services/jslib-services.module.ts
@@ -291,7 +291,6 @@ import { DefaultTaskService, TaskService } from "@bitwarden/common/vault/tasks";
 import {
   AnonLayoutWrapperDataService,
   DefaultAnonLayoutWrapperDataService,
-  DialogService,
   ToastService,
 } from "@bitwarden/components";
 import {
@@ -1616,8 +1615,6 @@ const safeProviders: SafeProvider[] = [
     deps: [
       CipherServiceAbstraction,
       ApiServiceAbstraction,
-      DialogService,
-      PasswordRepromptService,
       BillingAccountProfileStateService,
       ConfigService,
     ],

--- a/libs/common/src/vault/abstractions/search.service.ts
+++ b/libs/common/src/vault/abstractions/search.service.ts
@@ -30,6 +30,7 @@ export abstract class SearchService {
     ciphers: C[],
     query: string,
     deleted?: boolean,
+    archived?: boolean,
   ): C[];
   abstract searchSends(sends: SendView[], query: string): SendView[];
 }

--- a/libs/common/src/vault/services/search.service.ts
+++ b/libs/common/src/vault/services/search.service.ts
@@ -296,10 +296,18 @@ export class SearchService implements SearchServiceAbstraction {
     return results;
   }
 
-  searchCiphersBasic<C extends CipherViewLike>(ciphers: C[], query: string, deleted = false) {
+  searchCiphersBasic<C extends CipherViewLike>(
+    ciphers: C[],
+    query: string,
+    deleted = false,
+    archived = false,
+  ) {
     query = SearchService.normalizeSearchQuery(query.trim().toLowerCase());
     return ciphers.filter((c) => {
       if (deleted !== CipherViewLikeUtils.isDeleted(c)) {
+        return false;
+      }
+      if (archived !== CipherViewLikeUtils.isArchived(c)) {
         return false;
       }
       if (c.name != null && c.name.toLowerCase().indexOf(query) > -1) {

--- a/libs/vault/src/abstractions/cipher-archive.service.ts
+++ b/libs/vault/src/abstractions/cipher-archive.service.ts
@@ -1,7 +1,6 @@
 import { Observable } from "rxjs";
 
 import { CipherId, UserId } from "@bitwarden/common/types/guid";
-import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { CipherViewLike } from "@bitwarden/common/vault/utils/cipher-view-like-utils";
 
 export abstract class CipherArchiveService {
@@ -10,5 +9,4 @@ export abstract class CipherArchiveService {
   abstract showArchiveVault$(userId: UserId): Observable<boolean>;
   abstract archiveWithServer(ids: CipherId | CipherId[], userId: UserId): Promise<void>;
   abstract unarchiveWithServer(ids: CipherId | CipherId[], userId: UserId): Promise<void>;
-  abstract canInteract(cipher: CipherView): Promise<boolean>;
 }

--- a/libs/vault/src/services/default-cipher-archive.service.spec.ts
+++ b/libs/vault/src/services/default-cipher-archive.service.spec.ts
@@ -11,21 +11,14 @@ import {
   CipherBulkArchiveRequest,
   CipherBulkUnarchiveRequest,
 } from "@bitwarden/common/vault/models/request/cipher-bulk-archive.request";
-import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
-import { DialogService } from "@bitwarden/components";
 import { CipherListView } from "@bitwarden/sdk-internal";
 
-import { DecryptionFailureDialogComponent } from "../components/decryption-failure-dialog/decryption-failure-dialog.component";
-
 import { DefaultCipherArchiveService } from "./default-cipher-archive.service";
-import { PasswordRepromptService } from "./password-reprompt.service";
 
 describe("DefaultCipherArchiveService", () => {
   let service: DefaultCipherArchiveService;
   let mockCipherService: jest.Mocked<CipherService>;
   let mockApiService: jest.Mocked<ApiService>;
-  let mockDialogService: jest.Mocked<DialogService>;
-  let mockPasswordRepromptService: jest.Mocked<PasswordRepromptService>;
   let mockBillingAccountProfileStateService: jest.Mocked<BillingAccountProfileStateService>;
   let mockConfigService: jest.Mocked<ConfigService>;
 
@@ -35,16 +28,12 @@ describe("DefaultCipherArchiveService", () => {
   beforeEach(() => {
     mockCipherService = mock<CipherService>();
     mockApiService = mock<ApiService>();
-    mockDialogService = mock<DialogService>();
-    mockPasswordRepromptService = mock<PasswordRepromptService>();
     mockBillingAccountProfileStateService = mock<BillingAccountProfileStateService>();
     mockConfigService = mock<ConfigService>();
 
     service = new DefaultCipherArchiveService(
       mockCipherService,
       mockApiService,
-      mockDialogService,
-      mockPasswordRepromptService,
       mockBillingAccountProfileStateService,
       mockConfigService,
     );
@@ -242,48 +231,6 @@ describe("DefaultCipherArchiveService", () => {
         true,
         true,
       );
-    });
-  });
-
-  describe("canInteract", () => {
-    let mockCipherView: CipherView;
-
-    beforeEach(() => {
-      mockCipherView = {
-        id: cipherId,
-        decryptionFailure: false,
-      } as unknown as CipherView;
-    });
-
-    it("should return false and open dialog when cipher has decryption failure", async () => {
-      mockCipherView.decryptionFailure = true;
-      const openSpy = jest.spyOn(DecryptionFailureDialogComponent, "open").mockImplementation();
-
-      const result = await service.canInteract(mockCipherView);
-
-      expect(result).toBe(false);
-      expect(openSpy).toHaveBeenCalledWith(mockDialogService, {
-        cipherIds: [cipherId],
-      });
-    });
-
-    it("should return password reprompt result when no decryption failure", async () => {
-      mockPasswordRepromptService.passwordRepromptCheck.mockResolvedValue(true);
-
-      const result = await service.canInteract(mockCipherView);
-
-      expect(result).toBe(true);
-      expect(mockPasswordRepromptService.passwordRepromptCheck).toHaveBeenCalledWith(
-        mockCipherView,
-      );
-    });
-
-    it("should return false when password reprompt fails", async () => {
-      mockPasswordRepromptService.passwordRepromptCheck.mockResolvedValue(false);
-
-      const result = await service.canInteract(mockCipherView);
-
-      expect(result).toBe(false);
     });
   });
 });

--- a/libs/vault/src/services/default-cipher-archive.service.ts
+++ b/libs/vault/src/services/default-cipher-archive.service.ts
@@ -12,27 +12,21 @@ import {
   CipherBulkUnarchiveRequest,
 } from "@bitwarden/common/vault/models/request/cipher-bulk-archive.request";
 import { CipherResponse } from "@bitwarden/common/vault/models/response/cipher.response";
-import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import {
   CipherViewLike,
   CipherViewLikeUtils,
 } from "@bitwarden/common/vault/utils/cipher-view-like-utils";
-import { DialogService } from "@bitwarden/components";
 
 import { CipherArchiveService } from "../abstractions/cipher-archive.service";
-import { DecryptionFailureDialogComponent } from "../components/decryption-failure-dialog/decryption-failure-dialog.component";
-
-import { PasswordRepromptService } from "./password-reprompt.service";
 
 export class DefaultCipherArchiveService implements CipherArchiveService {
   constructor(
     private cipherService: CipherService,
     private apiService: ApiService,
-    private dialogService: DialogService,
-    private passwordRepromptService: PasswordRepromptService,
     private billingAccountProfileStateService: BillingAccountProfileStateService,
     private configService: ConfigService,
   ) {}
+
   /**
    * Observable that contains the list of ciphers that have been archived.
    */
@@ -124,22 +118,5 @@ export class DefaultCipherArchiveService implements CipherArchiveService {
     }
 
     await this.cipherService.replace(currentCiphers, userId);
-  }
-
-  /**
-   * Check if the user is able to interact with the cipher
-   * (password re-prompt / decryption failure checks).
-   * @param cipher
-   * @private
-   */
-  async canInteract(cipher: CipherView) {
-    if (cipher.decryptionFailure) {
-      DecryptionFailureDialogComponent.open(this.dialogService, {
-        cipherIds: [cipher.id as CipherId],
-      });
-      return false;
-    }
-
-    return await this.passwordRepromptService.passwordRepromptCheck(cipher);
   }
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -61,6 +61,7 @@
       "@bitwarden/ui-common/setup-jest": ["./libs/ui/common/src/setup-jest"],
       "@bitwarden/user-core": ["libs/user-core/src/index.ts"],
       "@bitwarden/vault": ["./libs/vault/src"],
+      "@bitwarden/vault/*": ["./libs/vault/src/*"],
       "@bitwarden/vault-export-core": ["./libs/tools/export/vault-export/vault-export-core/src"],
       "@bitwarden/vault-export-ui": ["./libs/tools/export/vault-export/vault-export-ui/src"],
       "@bitwarden/web-vault/*": ["./apps/web/src/*"]


### PR DESCRIPTION
## 🎟️ Tracking

[PM-24534](https://bitwarden.atlassian.net/browse/PM-24534)
PR Stacked on top of https://github.com/bitwarden/clients/pull/16226

## 📔 Objective

Add archive feature to the CLI
- Refactored `canInteract` out of the `DefaultCipherArchiveService`. This included Angular/UI aspects that should not be included in the CLI. Moved to `ArchiveComponent` which is the only location it is used.
- Add ability to archive a cipher given:
  - The feature flag is enabled
  - The user is a premium user
  - The item is not already deleted or archived
  - The item does not belong to an organization
- Add ability to restore an archived cipher
- Add ability to edit an archived cipher
  - When a user loses their premium status and attempts to edit the archived cipher - we will automatically unarchive it. 
  - The message to the user is still TBD.

## 📸 Screenshots

Happy path demo:
<video src="https://github.com/user-attachments/assets/0860c496-0fae-4353-83e1-0181d10bf31b" />

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
