### PR TITLE
[PM-25947] Disable website actions

### DIFF
--- a/libs/vault/src/cipher-form/components/autofill-options/autofill-options.component.html
+++ b/libs/vault/src/cipher-form/components/autofill-options/autofill-options.component.html
@@ -10,12 +10,12 @@
       <vault-autofill-uri-option
         *ngFor="let uri of uriControls; let i = index"
         cdkDrag
-        [cdkDragDisabled]="uriControls.length <= 1"
+        [cdkDragDisabled]="uriControls.length <= 1 || autofillOptionsForm.disabled"
         [formControlName]="i"
         (remove)="removeUri(i)"
         (onKeydown)="onUriItemKeydown($event, i)"
-        [canReorder]="uriControls.length > 1"
-        [canRemove]="uriControls.length > 1"
+        [canReorder]="uriControls.length > 1 && autofillOptionsForm.enabled"
+        [canRemove]="uriControls.length > 1 && autofillOptionsForm.enabled"
         [defaultMatchDetection]="defaultMatchDetection$ | async"
         [index]="i"
       ></vault-autofill-uri-option>

--- a/libs/vault/src/cipher-form/components/autofill-options/uri-option.component.html
+++ b/libs/vault/src/cipher-form/components/autofill-options/uri-option.component.html
@@ -23,7 +23,7 @@
           data-testid="remove-uri-button"
         ></button>
       </bit-form-field>
-      <div class="tw-flex tw-items-center tw-ml-1.5">
+      <div class="tw-flex tw-items-center tw-ml-1.5" *ngIf="canReorder">
         <button
           type="button"
           bitIconButton="bwi-drag-and-drop"
@@ -32,7 +32,6 @@
           [label]="'reorderToggleButton' | i18n: uriLabel"
           (keydown)="handleKeydown($event)"
           data-testid="reorder-toggle-button"
-          *ngIf="canReorder"
         ></button>
       </div>
     </div>


### PR DESCRIPTION
## 🎟️ Tracking

[PM-25947](https://bitwarden.atlassian.net/browse/PM-25947)

## 📔 Objective

When the cipher form is disabled, do not allow login websites to be reordered or removed

## 📸 Screenshots

Web, Desktop, Browser
<video src="https://github.com/user-attachments/assets/de608618-5252-4b1e-96ba-459969278c4e"/>


## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
