### PR TITLE
[PM-18470] Pre-populate Key Connector URL

### DIFF
--- a/bitwarden_license/bit-web/src/app/auth/sso/sso.component.ts
+++ b/bitwarden_license/bit-web/src/app/auth/sso/sso.component.ts
@@ -268,7 +268,7 @@ export class SsoComponent implements OnInit, OnDestroy {
             // Pre-populate a default key connector URL (user can still change it)
             const env = await firstValueFrom(this.environmentService.environment$);
             const webVaultUrl = env.getWebVaultUrl();
-            const defaultKeyConnectorUrl = webVaultUrl + "/key-connector";
+            const defaultKeyConnectorUrl = webVaultUrl + "/key-connector/";
 
             this.ssoConfigForm.controls.keyConnectorUrl.setValue(defaultKeyConnectorUrl);
           } else {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-18470](https://bitwarden.atlassian.net/browse/PM-18470)

## 📔 Objective

When Key Connector is a valid selection, setup a listener to changes to the Member Decryption Options form radio selection:
- If radio selection is Key Connector
  - Set a default URL
- If radio selection is NOT Key Connector
  - Clear the URL

## 📸 Screenshots

### The Default URL

Notice that when the user overwrites the default URL with a custom URL, but then clicks MP or TDE, and then comes back to KC, the default URL is what shows, not the custom URL they previously entered. 

Note that in order to test this visually I manually updated Client code to show the KC radio option and URL form field. QA will test with a genuine KC setup.

https://github.com/user-attachments/assets/61275fad-73c4-4f7e-873a-0eaabbca2f8f

### Clearing the URL

Note that in order to test this visually I manually updated Client code to show the KC radio option and URL form field such that the KC URL field is always visible regardless of Member Decryption type. QA will test with a genuine KC setup.

https://github.com/user-attachments/assets/b247109a-6c62-4b87-bfa7-f86fcd31631d

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-18470]: https://bitwarden.atlassian.net/browse/PM-18470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ