### PR TITLE
[PM-23251] Remove low-kdf banner

### DIFF
--- a/apps/web/src/app/vault/individual-vault/vault-banners/vault-banners.component.html
+++ b/apps/web/src/app/vault/individual-vault/vault-banners/vault-banners.component.html
@@ -26,18 +26,6 @@
 </bit-banner>
 
 <bit-banner
-  id="kdf-settings-banner"
-  bannerType="warning"
-  *ngIf="visibleBanners.includes(VisibleVaultBanner.KDFSettings)"
-  (onClose)="dismissBanner(VisibleVaultBanner.KDFSettings)"
->
-  {{ "lowKDFIterationsBanner" | i18n }}
-  <a bitLink linkType="secondary" routerLink="/settings/security/security-keys">
-    {{ "changeKDFSettings" | i18n }}
-  </a>
-</bit-banner>
-
-<bit-banner
   id="pending-auth-request-banner"
   bannerType="info"
   icon="bwi-info-circle"

--- a/apps/web/src/app/vault/individual-vault/vault-banners/vault-banners.component.spec.ts
+++ b/apps/web/src/app/vault/individual-vault/vault-banners/vault-banners.component.spec.ts
@@ -35,7 +35,6 @@ describe("VaultBannersComponent", () => {
     shouldShowPremiumBanner$: jest.fn((userId: UserId) => premiumBanner$),
     shouldShowUpdateBrowserBanner: jest.fn(),
     shouldShowVerifyEmailBanner: jest.fn(),
-    shouldShowLowKDFBanner: jest.fn(),
     shouldShowPendingAuthRequestBanner: jest.fn((userId: UserId) =>
       Promise.resolve(pendingAuthRequest$.value),
     ),
@@ -48,7 +47,6 @@ describe("VaultBannersComponent", () => {
     messageSubject = new Subject<{ command: string }>();
     bannerService.shouldShowUpdateBrowserBanner.mockResolvedValue(false);
     bannerService.shouldShowVerifyEmailBanner.mockResolvedValue(false);
-    bannerService.shouldShowLowKDFBanner.mockResolvedValue(false);
     pendingAuthRequest$.next(false);
     premiumBanner$.next(false);
 
@@ -136,11 +134,6 @@ describe("VaultBannersComponent", () => {
         name: "VerifyEmail",
         method: bannerService.shouldShowVerifyEmailBanner,
         banner: VisibleVaultBanner.VerifyEmail,
-      },
-      {
-        name: "LowKDF",
-        method: bannerService.shouldShowLowKDFBanner,
-        banner: VisibleVaultBanner.KDFSettings,
       },
     ].forEach(({ name, method, banner }) => {
       describe(name, () => {

--- a/apps/web/src/app/vault/individual-vault/vault-banners/vault-banners.component.ts
+++ b/apps/web/src/app/vault/individual-vault/vault-banners/vault-banners.component.ts
@@ -100,14 +100,12 @@ export class VaultBannersComponent implements OnInit {
     const showBrowserOutdated =
       await this.vaultBannerService.shouldShowUpdateBrowserBanner(activeUserId);
     const showVerifyEmail = await this.vaultBannerService.shouldShowVerifyEmailBanner(activeUserId);
-    const showLowKdf = await this.vaultBannerService.shouldShowLowKDFBanner(activeUserId);
     const showPendingAuthRequest =
       await this.vaultBannerService.shouldShowPendingAuthRequestBanner(activeUserId);
 
     this.visibleBanners = [
       showBrowserOutdated ? VisibleVaultBanner.OutdatedBrowser : null,
       showVerifyEmail ? VisibleVaultBanner.VerifyEmail : null,
-      showLowKdf ? VisibleVaultBanner.KDFSettings : null,
       showPendingAuthRequest ? VisibleVaultBanner.PendingAuthRequest : null,
     ].filter((banner) => banner !== null);
   }

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -8364,12 +8364,6 @@
   "groupSlashUser": {
     "message": "Group/User"
   },
-  "lowKdfIterations": {
-    "message": "Low KDF Iterations"
-  },
-  "updateLowKdfIterationsDesc": {
-    "message": "Update your encryption settings to meet new security recommendations and improve account protection."
-  },
   "kdfSettingsChangeLogoutWarning": {
     "message": "Proceeding will log you out of all active sessions. You will need to log back in and complete two-step login, if any. We recommend exporting your vault before changing your encryption settings to prevent data loss."
   },
@@ -9983,12 +9977,6 @@
         "example": "2"
       }
     }
-  },
-  "lowKDFIterationsBanner": {
-    "message": "Low KDF iterations. Increase your iterations to improve the security of your account."
-  },
-  "changeKDFSettings": {
-    "message": "Change KDF settings"
   },
   "secureYourInfrastructure": {
     "message": "Secure your infrastructure"


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-23251

## 📔 Objective

The low kdf banner is no longer required since we don’t nudge users to upgrade their KDF, we force them. It can be removed.

Also removed few unused messages from localization file `messages.json`.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
