### PR TITLE
[PM-23995] Updated change kdf component for Forced update KDF settings

### DIFF
--- a/apps/web/src/app/key-management/change-kdf/change-kdf-confirmation.component.html
+++ b/apps/web/src/app/key-management/change-kdf/change-kdf-confirmation.component.html
@@ -1,11 +1,13 @@
 <form [formGroup]="form" [bitSubmit]="submit" autocomplete="off">
   <bit-dialog>
     <span bitDialogTitle>
-      {{ "changeKdf" | i18n }}
+      {{ "updateYourEncryptionSettings" | i18n }}
     </span>
 
     <span bitDialogContent>
-      <bit-callout type="warning">{{ "kdfSettingsChangeLogoutWarning" | i18n }}</bit-callout>
+      @if (!forceUpdateKDFSettingsFeatureFlag$) {
+        <bit-callout type="warning">{{ "kdfSettingsChangeLogoutWarning" | i18n }}</bit-callout>
+      }
       <bit-form-field>
         <bit-label>{{ "masterPass" | i18n }}</bit-label>
         <input bitInput type="password" formControlName="masterPassword" appAutofocus />
@@ -18,12 +20,12 @@
         ></button>
         <bit-hint>
           {{ "confirmIdentity" | i18n }}
-        </bit-hint></bit-form-field
-      >
+        </bit-hint>
+      </bit-form-field>
     </span>
     <ng-container bitDialogFooter>
       <button bitButton buttonType="primary" type="submit" bitFormButton>
-        <span>{{ "changeKdf" | i18n }}</span>
+        <span>{{ "updateSettings" | i18n }}</span>
       </button>
       <button bitButton buttonType="secondary" type="button" bitFormButton bitDialogClose>
         {{ "cancel" | i18n }}

--- a/apps/web/src/app/key-management/change-kdf/change-kdf.component.html
+++ b/apps/web/src/app/key-management/change-kdf/change-kdf.component.html
@@ -1,31 +1,32 @@
-<h2 bitTypography="h2">{{ "encKeySettings" | i18n }}</h2>
-<bit-callout type="warning">{{ "kdfSettingsChangeLogoutWarning" | i18n }}</bit-callout>
-<p bitTypography="body1">
-  {{ "higherKDFIterations" | i18n }}
+<h2 bitTypography="h2" class="tw-mt-6">
+  {{ "encKeySettings" | i18n }}
+</h2>
+@if (!forceUpdateKDFSettingsFeatureFlag$) {
+  <bit-callout type="warning">{{ "kdfSettingsChangeLogoutWarning" | i18n }}</bit-callout>
+}
+<p bitTypography="body1" class="tw-mt-4">
+  {{ "encryptionKeySettingsHowShouldWeEncryptYourData" | i18n }}
 </p>
 <p bitTypography="body1">
-  {{
-    "kdfToHighWarningIncreaseInIncrements"
-      | i18n: (isPBKDF2(kdfConfig) ? ("incrementsOf100,000" | i18n) : ("smallIncrements" | i18n))
-  }}
+  {{ "encryptionKeySettingsIncreaseImproveSecurity" | i18n }}
 </p>
 <form [formGroup]="formGroup" autocomplete="off">
-  <div class="tw-grid tw-grid-cols-12 tw-gap-4">
+  <div class="tw-grid tw-grid-cols-12 tw-gap-x-4">
     <div class="tw-col-span-6">
       <bit-form-field>
-        <bit-label
-          >{{ "kdfAlgorithm" | i18n }}
-          <a
-            class="tw-ml-auto"
+        <bit-label>
+          {{ "algorithm" | i18n }}
+          <button
+            type="button"
+            class="tw-border-none tw-bg-transparent tw-text-primary-600 tw-p-0"
+            [bitPopoverTriggerFor]="algorithmPopover"
+            #triggerRef="popoverTrigger"
+            aria-label="Open about encryption algorithms popover"
+            title="Open about encryption algorithms popover"
             bitLink
-            href="https://bitwarden.com/help/kdf-algorithms"
-            target="_blank"
-            rel="noreferrer"
-            appA11yTitle="{{ 'learnMoreAboutEncryptionAlgorithms' | i18n }}"
-            slot="end"
           >
             <i class="bwi bwi-question-circle" aria-hidden="true"></i>
-          </a>
+          </button>
         </bit-label>
         <bit-select formControlName="kdf">
           <bit-option
@@ -35,33 +36,12 @@
           ></bit-option>
         </bit-select>
       </bit-form-field>
-      <bit-form-field formGroupName="kdfConfig" *ngIf="isArgon2(kdfConfig)">
-        <bit-label>{{ "kdfMemory" | i18n }}</bit-label>
-        <input
-          bitInput
-          formControlName="memory"
-          type="number"
-          [min]="ARGON2_MEMORY.min"
-          [max]="ARGON2_MEMORY.max"
-        />
-      </bit-form-field>
     </div>
     <div class="tw-col-span-6">
-      <div class="tw-mb-0">
-        <bit-form-field formGroupName="kdfConfig" *ngIf="isPBKDF2(kdfConfig)">
+      @if (isPBKDF2(kdfConfig)) {
+        <bit-form-field formGroupName="kdfConfig">
           <bit-label>
             {{ "kdfIterations" | i18n }}
-            <a
-              bitLink
-              class="tw-ml-auto"
-              href="https://bitwarden.com/help/what-encryption-is-used/#changing-kdf-iterations"
-              target="_blank"
-              rel="noreferrer"
-              appA11yTitle="{{ 'learnMoreAboutKDFIterations' | i18n }}"
-              slot="end"
-            >
-              <i class="bwi bwi-question-circle" aria-hidden="true"></i>
-            </a>
           </bit-label>
           <input
             bitInput
@@ -72,34 +52,49 @@
           />
           <bit-hint>{{ "kdfIterationRecommends" | i18n }}</bit-hint>
         </bit-form-field>
-        <ng-container *ngIf="isArgon2(kdfConfig)">
-          <bit-form-field formGroupName="kdfConfig">
-            <bit-label>
-              {{ "kdfIterations" | i18n }}
-            </bit-label>
-            <input
-              bitInput
-              type="number"
-              formControlName="iterations"
-              [min]="ARGON2_ITERATIONS.min"
-              [max]="ARGON2_ITERATIONS.max"
-            />
-          </bit-form-field>
-          <bit-form-field formGroupName="kdfConfig">
-            <bit-label>
-              {{ "kdfParallelism" | i18n }}
-            </bit-label>
-            <input
-              bitInput
-              type="number"
-              formControlName="parallelism"
-              [min]="ARGON2_PARALLELISM.min"
-              [max]="ARGON2_PARALLELISM.max"
-            />
-          </bit-form-field>
-        </ng-container>
-      </div>
+      } @else if (isArgon2(kdfConfig)) {
+        <bit-form-field formGroupName="kdfConfig">
+          <bit-label>{{ "kdfMemory" | i18n }}</bit-label>
+          <input
+            bitInput
+            formControlName="memory"
+            type="number"
+            [min]="ARGON2_MEMORY.min"
+            [max]="ARGON2_MEMORY.max"
+          />
+        </bit-form-field>
+      }
     </div>
+    @if (isArgon2(kdfConfig)) {
+      <div class="tw-col-span-6">
+        <bit-form-field formGroupName="kdfConfig">
+          <bit-label>
+            {{ "kdfIterations" | i18n }}
+          </bit-label>
+          <input
+            bitInput
+            type="number"
+            formControlName="iterations"
+            [min]="ARGON2_ITERATIONS.min"
+            [max]="ARGON2_ITERATIONS.max"
+          />
+        </bit-form-field>
+      </div>
+      <div class="tw-col-span-6">
+        <bit-form-field formGroupName="kdfConfig">
+          <bit-label>
+            {{ "kdfParallelism" | i18n }}
+          </bit-label>
+          <input
+            bitInput
+            type="number"
+            formControlName="parallelism"
+            [min]="ARGON2_PARALLELISM.min"
+            [max]="ARGON2_PARALLELISM.max"
+          />
+        </bit-form-field>
+      </div>
+    }
   </div>
   <button
     (click)="openConfirmationModal()"
@@ -107,7 +102,28 @@
     buttonType="primary"
     bitButton
     bitFormButton
+    class="tw-mt-2"
   >
-    {{ "changeKdf" | i18n }}
+    {{ "updateEncryptionSettings" | i18n }}
   </button>
 </form>
+
+<bit-popover [title]="'encryptionKeySettingsAlgorithmPopoverTitle' | i18n" #algorithmPopover>
+  <ul class="tw-mt-2 tw-mb-0 tw-ps-4">
+    <li class="tw-mb-2">{{ "encryptionKeySettingsAlgorithmPopoverPBKDF2" | i18n }}</li>
+    <li>{{ "encryptionKeySettingsAlgorithmPopoverArgon2Id" | i18n }}</li>
+  </ul>
+  <div class="tw-mt-4 tw-mb-1">
+    <a
+      href="https://bitwarden.com/help/kdf-algorithms/"
+      bitLink
+      target="_blank"
+      rel="noreferrer"
+      appA11yTitle="{{ 'learnMoreAboutEncryptionAlgorithms' | i18n }}"
+    >
+      {{ "learnMore" | i18n }}
+      <i class="bwi bwi-popout tw-ml-1" aria-hidden="true"></i>
+    </a>
+  </div>
+  <button type="button" bitButton class="tw-mt-4" (click)="triggerRef.closePopover()">Close</button>
+</bit-popover>

--- a/apps/web/src/app/key-management/change-kdf/change-kdf.module.ts
+++ b/apps/web/src/app/key-management/change-kdf/change-kdf.module.ts
@@ -1,13 +1,15 @@
 import { CommonModule } from "@angular/common";
 import { NgModule } from "@angular/core";
 
+import { PopoverModule } from "@bitwarden/components";
+
 import { SharedModule } from "../../shared";
 
 import { ChangeKdfConfirmationComponent } from "./change-kdf-confirmation.component";
 import { ChangeKdfComponent } from "./change-kdf.component";
 
 @NgModule({
-  imports: [CommonModule, SharedModule],
+  imports: [CommonModule, SharedModule, PopoverModule],
   declarations: [ChangeKdfComponent, ChangeKdfConfirmationComponent],
   exports: [ChangeKdfComponent, ChangeKdfConfirmationComponent],
 })

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -11,7 +11,7 @@
   "criticalApplications": {
     "message": "Critical applications"
   },
-  "noCriticalAppsAtRisk":{
+  "noCriticalAppsAtRisk": {
     "message": "No critical applications at risk"
   },
   "accessIntelligence": {
@@ -134,7 +134,7 @@
   "atRiskMembers": {
     "message": "At-risk members"
   },
-  "membersAtRiskActivityDescription":{
+  "membersAtRiskActivityDescription": {
     "message": "Members with edit access to at-risk items for critical applications"
   },
   "membersAtRisk": {
@@ -1558,7 +1558,6 @@
       }
     }
   },
-
   "dontAskAgainOnThisDeviceFor30Days": {
     "message": "Don't ask again on this device for 30 days"
   },
@@ -1929,9 +1928,6 @@
   "encKeySettings": {
     "message": "Encryption key settings"
   },
-  "kdfAlgorithm": {
-    "message": "KDF algorithm"
-  },
   "kdfIterations": {
     "message": "KDF iterations"
   },
@@ -1966,9 +1962,6 @@
   "argon2Desc": {
     "message": "Higher KDF iterations, memory, and parallelism can help protect your master password from being brute forced by an attacker."
   },
-  "changeKdf": {
-    "message": "Change KDF"
-  },
   "encKeySettingsChanged": {
     "message": "Encryption key settings saved"
   },
@@ -1985,22 +1978,22 @@
     "message": "Proceeding will also log you out of your current session, requiring you to log back in. You will also be prompted for two-step login again, if set up. Active sessions on other devices may continue to remain active for up to one hour."
   },
   "newDeviceLoginProtection": {
-    "message":"New device login"
+    "message": "New device login"
   },
   "turnOffNewDeviceLoginProtection": {
-    "message":"Turn off new device login protection"
+    "message": "Turn off new device login protection"
   },
   "turnOnNewDeviceLoginProtection": {
-    "message":"Turn on new device login protection"
+    "message": "Turn on new device login protection"
   },
   "turnOffNewDeviceLoginProtectionModalDesc": {
-    "message":"Proceed below to turn off the verification emails bitwarden sends when you login from a new device."
+    "message": "Proceed below to turn off the verification emails bitwarden sends when you login from a new device."
   },
   "turnOnNewDeviceLoginProtectionModalDesc": {
-    "message":"Proceed below to have bitwarden send you verification emails when you login from a new device."
+    "message": "Proceed below to have bitwarden send you verification emails when you login from a new device."
   },
   "turnOffNewDeviceLoginProtectionWarning": {
-    "message":"With new device login protection turned off, anyone with your master password can access your account from any device. To protect your account without verification emails, set up two-step login."
+    "message": "With new device login protection turned off, anyone with your master password can access your account from any device. To protect your account without verification emails, set up two-step login."
   },
   "accountNewDeviceLoginProtectionSaved": {
     "message": "New device login protection changes saved"
@@ -2136,7 +2129,7 @@
   "selectImportCollection": {
     "message": "Select a collection"
   },
-    "importTargetHintCollection": {
+  "importTargetHintCollection": {
     "message": "Select this option if you want the imported file contents moved to a collection"
   },
   "importTargetHintFolder": {
@@ -5526,26 +5519,26 @@
     "message": "All items will be owned and saved to the organization, enabling organization-wide controls, visibility, and reporting. When turned on, a default collection be available for each member to store items. Learn more about managing the ",
     "description": "This will be used as part of a larger sentence, broken up to include links. The full sentence will read 'All items will be owned and saved to the organization, enabling organization-wide controls, visibility, and reporting. When turned on, a default collection be available for each member to store items. Learn more about managing the credential lifecycle.'"
   },
-  "organizationDataOwnershipContentAnchor":{
+  "organizationDataOwnershipContentAnchor": {
     "message": "credential lifecycle",
     "description": "This will be used as a hyperlink"
   },
-  "organizationDataOwnershipWarningTitle":{
+  "organizationDataOwnershipWarningTitle": {
     "message": "Are you sure you want to proceed?"
   },
-  "organizationDataOwnershipWarning1":{
+  "organizationDataOwnershipWarning1": {
     "message": "will remain accessible to members"
   },
-  "organizationDataOwnershipWarning2":{
+  "organizationDataOwnershipWarning2": {
     "message": "will not be automatically selected when creating new items"
   },
-  "organizationDataOwnershipWarning3":{
+  "organizationDataOwnershipWarning3": {
     "message": "cannot be managed from the Admin Console until the user is offboarded"
   },
-  "organizationDataOwnershipWarningContentTop":{
+  "organizationDataOwnershipWarningContentTop": {
     "message": "By turning this policy off, the default collection: "
   },
-  "organizationDataOwnershipWarningContentBottom":{
+  "organizationDataOwnershipWarningContentBottom": {
     "message": "Learn more about the ",
     "description": "This will be used as part of a larger sentence, broken up to include links. The full sentence will read 'Learn more about the credential lifecycle.'"
   },
@@ -8420,7 +8413,7 @@
     }
   },
   "accessedSecret": {
-  "message": "Accessed secret $SECRET_ID$.",
+    "message": "Accessed secret $SECRET_ID$.",
     "placeholders": {
       "secret_id": {
         "content": "$1",
@@ -8428,7 +8421,7 @@
       }
     }
   },
-   "editedSecretWithId": {
+  "editedSecretWithId": {
     "message": "Edited a secret with identifier: $SECRET_ID$",
     "placeholders": {
       "secret_id": {
@@ -8437,7 +8430,7 @@
       }
     }
   },
-   "deletedSecretWithId": {
+  "deletedSecretWithId": {
     "message": "Deleted a secret with identifier: $SECRET_ID$",
     "placeholders": {
       "secret_id": {
@@ -8455,7 +8448,7 @@
       }
     }
   },
-   "restoredSecretWithId": {
+  "restoredSecretWithId": {
     "message": "Restored a secret with identifier: $SECRET_ID$",
     "placeholders": {
       "secret_id": {
@@ -8464,7 +8457,7 @@
       }
     }
   },
-   "createdSecretWithId": {
+  "createdSecretWithId": {
     "message": "Created a new secret with identifier: $SECRET_ID$",
     "placeholders": {
       "secret_id": {
@@ -8474,7 +8467,7 @@
     }
   },
   "accessedProjectWithId": {
-  "message": "Accessed a project with Id: $PROJECT_ID$.",
+    "message": "Accessed a project with Id: $PROJECT_ID$.",
     "placeholders": {
       "project_id": {
         "content": "$1",
@@ -8483,7 +8476,7 @@
     }
   },
   "nameUnavailableProjectDeleted": {
-  "message": "Deleted project Id: $PROJECT_ID$",
+    "message": "Deleted project Id: $PROJECT_ID$",
     "placeholders": {
       "project_id": {
         "content": "$1",
@@ -8492,7 +8485,7 @@
     }
   },
   "nameUnavailableSecretDeleted": {
-  "message": "Deleted secret Id: $SECRET_ID$",
+    "message": "Deleted secret Id: $SECRET_ID$",
     "placeholders": {
       "secret_id": {
         "content": "$1",
@@ -8500,7 +8493,7 @@
       }
     }
   },
-   "editedProjectWithId": {
+  "editedProjectWithId": {
     "message": "Edited a project with identifier: $PROJECT_ID$",
     "placeholders": {
       "project_id": {
@@ -8509,7 +8502,7 @@
       }
     }
   },
-   "deletedProjectWithId": {
+  "deletedProjectWithId": {
     "message": "Deleted a project with identifier: $PROJECT_ID$",
     "placeholders": {
       "project_id": {
@@ -8518,7 +8511,7 @@
       }
     }
   },
-   "createdProjectWithId": {
+  "createdProjectWithId": {
     "message": "Created a new project with identifier: $PROJECT_ID$",
     "placeholders": {
       "project_id": {
@@ -9236,15 +9229,15 @@
     "message": "Common formats",
     "description": "Label indicating the most common import formats"
   },
-     "uriMatchDefaultStrategyHint": {
+  "uriMatchDefaultStrategyHint": {
     "message": "URI match detection is how Bitwarden identifies autofill suggestions.",
     "description": "Explains to the user that URI match detection determines how Bitwarden suggests autofill options, and clarifies that this default strategy applies when no specific match detection is set for a login item."
   },
-   "regExAdvancedOptionWarning": {
+  "regExAdvancedOptionWarning": {
     "message": "\"Regular expression\" is an advanced option with increased risk of exposing credentials.",
     "description": "Content for dialog which warns a user when selecting 'regular expression' matching strategy as a cipher match strategy"
   },
-   "startsWithAdvancedOptionWarning": {
+  "startsWithAdvancedOptionWarning": {
     "message": "\"Starts with\" is an advanced option with increased risk of exposing credentials.",
     "description": "Content for dialog which warns a user when selecting 'starts with' matching strategy as a cipher match strategy"
   },
@@ -9252,11 +9245,11 @@
     "message": "More about match detection",
     "description": "Link to match detection docs on warning dialog for advance match strategy"
   },
-   "uriAdvancedOption":{
+  "uriAdvancedOption": {
     "message": "Advanced options",
     "description": "Advanced option placeholder for uri option component"
   },
-   "warningCapitalized": {
+  "warningCapitalized": {
     "message": "Warning",
     "description": "Warning (should maintain locale-relevant capitalization)"
   },
@@ -10087,26 +10080,8 @@
   "memberAccessReportAuthenticationEnabledFalse": {
     "message": "Off"
   },
-  "higherKDFIterations": {
-    "message": "Higher KDF iterations can help protect your master password from being brute forced by an attacker."
-  },
-  "incrementsOf100,000": {
-    "message": "increments of 100,000"
-  },
-  "smallIncrements": {
-    "message": "small increments"
-  },
   "kdfIterationRecommends": {
     "message": "We recommend 600,000 or more"
-  },
-  "kdfToHighWarningIncreaseInIncrements": {
-    "message": "For older devices, setting your KDF too high may lead to performance issues. Increase the value in $VALUE$ and test your devices.",
-    "placeholders": {
-      "value": {
-        "content": "$1",
-        "example": "increments of 100,000"
-      }
-    }
   },
   "providerReinstate": {
     "message": " Contact Customer Support to reinstate your subscription."
@@ -10783,7 +10758,7 @@
   "orgTrustWarning1": {
     "message": "This organization has an Enterprise policy that will enroll you in account recovery. Enrollment will allow organization administrators to change your password. Only proceed if you recognize this organization and the fingerprint phrase displayed below matches the organization's fingerprint."
   },
-  "trustUser":{
+  "trustUser": {
     "message": "Trust user"
   },
   "sshKeyWrongPassword": {
@@ -10819,7 +10794,7 @@
   "openingExtension": {
     "message": "Opening the Bitwarden browser extension"
   },
-  "somethingWentWrong":{
+  "somethingWentWrong": {
     "message": "Something went wrong..."
   },
   "openingExtensionError": {
@@ -10906,7 +10881,7 @@
       }
     }
   },
-  "accountDeprovisioningNotification" : {
+  "accountDeprovisioningNotification": {
     "message": "Administrators now have the ability to delete member accounts that belong to a claimed domain."
   },
   "deleteManagedUserWarningDesc": {
@@ -10997,14 +10972,14 @@
   "upgradeForFullEventsMessage": {
     "message": "Event logs are not stored for your organization. Upgrade to a Teams or Enterprise plan to get full access to organization event logs."
   },
-  "upgradeEventLogTitleMessage" : {
-    "message" : "Upgrade to see event logs from your organization."
+  "upgradeEventLogTitleMessage": {
+    "message": "Upgrade to see event logs from your organization."
   },
-  "upgradeEventLogMessage":{
-    "message" : "These events are examples only and do not reflect real events within your Bitwarden organization."
+  "upgradeEventLogMessage": {
+    "message": "These events are examples only and do not reflect real events within your Bitwarden organization."
   },
-  "viewEvents":{
-    "message" : "View Events"
+  "viewEvents": {
+    "message": "View Events"
   },
   "cannotCreateCollection": {
     "message": "Free organizations may have up to 2 collections. Upgrade to a paid plan to add more collections."
@@ -11265,14 +11240,14 @@
       }
     }
   },
-   "unlimitedSecretsAndProjects": {
+  "unlimitedSecretsAndProjects": {
     "message": "Unlimited secrets and projects"
   },
-   "providersubscriptionCanceled": {
+  "providersubscriptionCanceled": {
     "message": "Subscription canceled"
   },
   "providersubCanceledmessage": {
-    "message" : "To resubscribe, contact Bitwarden Customer Support."
+    "message": "To resubscribe, contact Bitwarden Customer Support."
   },
   "showMore": {
     "message": "Show more"
@@ -11341,5 +11316,32 @@
   },
   "verifyNow": {
     "message": "Verify now."
+  },
+  "updateEncryptionSettings": {
+    "message": "Update encryption settings"
+  },
+  "updateYourEncryptionSettings": {
+    "message": "Update your encryption settings"
+  },
+  "updateSettings": {
+    "message": "Update settings"
+  },
+  "algorithm": {
+    "message": "Algorithm"
+  },
+  "encryptionKeySettingsHowShouldWeEncryptYourData": {
+    "message": "Choose how Bitwarden should encrypt your vault data. All options are secure, but stronger methods offer better protection-especially against brute-force attacks. Bitwarden recommend the default setting for most users."
+  },
+  "encryptionKeySettingsIncreaseImproveSecurity": {
+    "message": "Increasing the values above the default will improve security, but your vault may take longer to unlock as a result."
+  },
+  "encryptionKeySettingsAlgorithmPopoverTitle": {
+    "message": "About encryption algorithms"
+  },
+  "encryptionKeySettingsAlgorithmPopoverPBKDF2": {
+    "message": "PBKDF2-SHA256 is a well-tested encryption method that balances security and performance. Good for all users."
+  },
+  "encryptionKeySettingsAlgorithmPopoverArgon2Id": {
+    "message": "Argon2id offers stronger protection against modern attacks. Best for advanced users with powerful devices."
   }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-23995

## 📔 Objective

Updated change kdf component for Forced update KDF settings work.
See Jira for figma designs.

### Visual changes:
- New, more user friendly wording
- More spacing
- A help tooltip over "Algorithm" field now opens a popover with user friendly message with link to Bitwarden help docs.
- When `pm-18021-force-update-kdf-settings` feature flag is enabled:
  - The 'logout' warning banner is no longer visible in the component and confirmation dialog.
  - Once updated, does not show a message about being logged out in the success toast.
- (bug, fixed) KDF iterations, memory, parallelism did not load on init (fields were not required and did not had min/max checks)

### Functional changes:
- When `pm-18021-force-update-kdf-settings` feature flag is enabled, does not log out the user.

## 📸 Screenshots

https://github.com/user-attachments/assets/e89e2a92-04ef-41cc-92e8-6f32537734fa


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
