### PR TITLE
[PM-24377] Use `PureCrypto` for `decryptUserKeyWithMasterKey` on the master password service

### DIFF
--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -687,9 +687,7 @@ export default class MainBackground {
 
     this.masterPasswordService = new MasterPasswordService(
       this.stateProvider,
-      this.stateService,
       this.keyGenerationService,
-      this.encryptService,
       this.logService,
       this.cryptoFunctionService,
       this.accountService,

--- a/apps/cli/src/service-container/service-container.ts
+++ b/apps/cli/src/service-container/service-container.ts
@@ -436,9 +436,7 @@ export class ServiceContainer {
     this.kdfConfigService = new DefaultKdfConfigService(this.stateProvider);
     this.masterPasswordService = new MasterPasswordService(
       this.stateProvider,
-      this.stateService,
       this.keyGenerationService,
-      this.encryptService,
       this.logService,
       this.cryptoFunctionService,
       this.accountService,

--- a/libs/angular/src/services/jslib-services.module.ts
+++ b/libs/angular/src/services/jslib-services.module.ts
@@ -1034,9 +1034,7 @@ const safeProviders: SafeProvider[] = [
     useClass: MasterPasswordService,
     deps: [
       StateProvider,
-      StateServiceAbstraction,
       KeyGenerationService,
-      EncryptService,
       LogService,
       CryptoFunctionServiceAbstraction,
       AccountServiceAbstraction,

--- a/libs/common/src/key-management/master-password/services/master-password.service.ts
+++ b/libs/common/src/key-management/master-password/services/master-password.service.ts
@@ -12,8 +12,6 @@ import { PureCrypto } from "@bitwarden/sdk-internal";
 
 import { ForceSetPasswordReason } from "../../../auth/models/domain/force-set-password-reason";
 import { LogService } from "../../../platform/abstractions/log.service";
-import { StateService } from "../../../platform/abstractions/state.service";
-import { EncryptionType } from "../../../platform/enums";
 import { SymmetricCryptoKey } from "../../../platform/models/domain/symmetric-crypto-key";
 import {
   MASTER_PASSWORD_DISK,
@@ -26,7 +24,6 @@ import { UserId } from "../../../types/guid";
 import { MasterKey, UserKey } from "../../../types/key";
 import { KeyGenerationService } from "../../crypto";
 import { CryptoFunctionService } from "../../crypto/abstractions/crypto-function.service";
-import { EncryptService } from "../../crypto/abstractions/encrypt.service";
 import { EncryptedString, EncString } from "../../crypto/models/enc-string";
 import { InternalMasterPasswordServiceAbstraction } from "../abstractions/master-password.service.abstraction";
 import {
@@ -82,9 +79,7 @@ export const MASTER_PASSWORD_UNLOCK_KEY = new UserKeyDefinition<MasterPasswordUn
 export class MasterPasswordService implements InternalMasterPasswordServiceAbstraction {
   constructor(
     private stateProvider: StateProvider,
-    private stateService: StateService,
     private keyGenerationService: KeyGenerationService,
-    private encryptService: EncryptService,
     private logService: LogService,
     private cryptoFunctionService: CryptoFunctionService,
     private accountService: AccountService,
@@ -219,33 +214,15 @@ export class MasterPasswordService implements InternalMasterPasswordServiceAbstr
       throw new Error("No master key found.");
     }
 
-    let decUserKey: SymmetricCryptoKey;
-
-    if (userKey.encryptionType === EncryptionType.AesCbc256_B64) {
-      try {
-        decUserKey = await this.encryptService.unwrapSymmetricKey(userKey, masterKey);
-      } catch {
-        this.logService.warning("Failed to decrypt user key with master key.");
-        return null;
-      }
-    } else if (userKey.encryptionType === EncryptionType.AesCbc256_HmacSha256_B64) {
-      try {
-        const newKey = await this.keyGenerationService.stretchKey(masterKey);
-        decUserKey = await this.encryptService.unwrapSymmetricKey(userKey, newKey);
-      } catch {
-        this.logService.warning("Failed to decrypt user key with stretched master key.");
-        return null;
-      }
-    } else {
-      throw new Error("Unsupported encryption type.");
-    }
-
-    if (decUserKey == null) {
-      this.logService.warning("Failed to decrypt user key with master key, user key is null.");
+    await SdkLoadService.Ready;
+    try {
+      return new SymmetricCryptoKey(
+        PureCrypto.decrypt_user_key_with_master_key(userKey.toSdk(), masterKey.toEncoded()),
+      ) as UserKey;
+    } catch {
+      this.logService.warning("Failed to decrypt user key with master key.");
       return null;
     }
-
-    return decUserKey as UserKey;
   }
 
   async makeMasterPasswordAuthenticationData(


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-24377

## 📔 Objective

Uses new SDK method `PureCrypto.decrypt_user_key_with_master_key` being introduced in https://github.com/bitwarden/sdk-internal/pull/465, to decrypt UserKey with MasterKey.

This is to isolate type 0 decryption to just go through an isolated SDK code path.
Note currently key connector and master password login go through this code path and should be the focus.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
