### PR TITLE
Refactor app-table-row-scrollable component to use openApplication fo…

### DIFF
--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/app-table-row-scrollable.component.html
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/app-table-row-scrollable.component.html
@@ -15,7 +15,7 @@
       <td
         bitCell
         *ngIf="showRowCheckBox"
-        [ngClass]="{ 'tw-bg-primary-100': isDrawerIsOpenForThisRecord(row.applicationName) }"
+        [ngClass]="{ 'tw-bg-primary-100': row.applicationName === openApplication }"
         appStopProp
       >
         <input
@@ -30,14 +30,14 @@
       <td
         bitCell
         *ngIf="!showRowCheckBox"
-        [ngClass]="{ 'tw-bg-primary-100': isDrawerIsOpenForThisRecord(row.applicationName) }"
+        [ngClass]="{ 'tw-bg-primary-100': row.applicationName === openApplication }"
       >
         <i class="bwi bwi-star-f" *ngIf="row.isMarkedAsCritical"></i>
       </td>
       <td
         bitCell
         class="tw-cursor-pointer"
-        [ngClass]="{ 'tw-bg-primary-100': isDrawerIsOpenForThisRecord(row.applicationName) }"
+        [ngClass]="{ 'tw-bg-primary-100': row.applicationName === openApplication }"
         (click)="showAppAtRiskMembers(row.applicationName)"
         (keydown.enter)="showAppAtRiskMembers(row.applicationName)"
         (keydown.space)="showAppAtRiskMembers(row.applicationName)"
@@ -50,7 +50,7 @@
       <td
         bitCell
         class="tw-cursor-pointer"
-        [ngClass]="{ 'tw-bg-primary-100': isDrawerIsOpenForThisRecord(row.applicationName) }"
+        [ngClass]="{ 'tw-bg-primary-100': row.applicationName === openApplication }"
         (click)="showAppAtRiskMembers(row.applicationName)"
         (keydown.enter)="showAppAtRiskMembers(row.applicationName)"
         (keydown.space)="showAppAtRiskMembers(row.applicationName)"
@@ -63,7 +63,7 @@
       <td
         bitCell
         class="tw-cursor-pointer"
-        [ngClass]="{ 'tw-bg-primary-100': isDrawerIsOpenForThisRecord(row.applicationName) }"
+        [ngClass]="{ 'tw-bg-primary-100': row.applicationName === openApplication }"
         (click)="showAppAtRiskMembers(row.applicationName)"
         (keydown.enter)="showAppAtRiskMembers(row.applicationName)"
         (keydown.space)="showAppAtRiskMembers(row.applicationName)"
@@ -78,7 +78,7 @@
       <td
         bitCell
         class="tw-cursor-pointer"
-        [ngClass]="{ 'tw-bg-primary-100': isDrawerIsOpenForThisRecord(row.applicationName) }"
+        [ngClass]="{ 'tw-bg-primary-100': row.applicationName === openApplication }"
         (click)="showAppAtRiskMembers(row.applicationName)"
         (keydown.enter)="showAppAtRiskMembers(row.applicationName)"
         (keydown.space)="showAppAtRiskMembers(row.applicationName)"
@@ -93,7 +93,7 @@
       <td
         bitCell
         class="tw-cursor-pointer"
-        [ngClass]="{ 'tw-bg-primary-100': isDrawerIsOpenForThisRecord(row.applicationName) }"
+        [ngClass]="{ 'tw-bg-primary-100': row.applicationName === openApplication }"
         (click)="showAppAtRiskMembers(row.applicationName)"
         (keydown.enter)="showAppAtRiskMembers(row.applicationName)"
         (keydown.space)="showAppAtRiskMembers(row.applicationName)"
@@ -109,7 +109,7 @@
         bitCell
         data-testid="total-membership"
         class="tw-cursor-pointer"
-        [ngClass]="{ 'tw-bg-primary-100': isDrawerIsOpenForThisRecord(row.applicationName) }"
+        [ngClass]="{ 'tw-bg-primary-100': row.applicationName === openApplication }"
         (click)="showAppAtRiskMembers(row.applicationName)"
         (keydown.enter)="showAppAtRiskMembers(row.applicationName)"
         (keydown.space)="showAppAtRiskMembers(row.applicationName)"
@@ -122,7 +122,7 @@
       <td
         bitCell
         *ngIf="showRowMenuForCriticalApps"
-        [ngClass]="{ 'tw-bg-primary-100': isDrawerIsOpenForThisRecord(row.applicationName) }"
+        [ngClass]="{ 'tw-bg-primary-100': row.applicationName === openApplication }"
         appStopProp
       >
         <button

--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/app-table-row-scrollable.component.ts
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/app-table-row-scrollable.component.ts
@@ -18,7 +18,7 @@ export class AppTableRowScrollableComponent {
   @Input() showRowMenuForCriticalApps: boolean = false;
   @Input() showRowCheckBox: boolean = false;
   @Input() selectedUrls: Set<string> = new Set<string>();
-  @Input() isDrawerIsOpenForThisRecord!: (applicationName: string) => boolean;
+  @Input() openApplication: string = "";
   @Input() showAppAtRiskMembers!: (applicationName: string) => void;
   @Input() unmarkAsCritical!: (applicationName: string) => void;
   @Input() checkboxChange!: (applicationName: string, $event: Event) => void;


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-25616

## 📔 Objective

Update the app-table-row-scrollable [component](https://github.com/bitwarden/clients/pull/16005/files#diff-7c4da6c4826b058bc7d4a1d513a67d43c765276d44d8b1676e3ce16aaed0a72f) to use openApplication input variable instead of the function input variable isDrawerIsOpenForThisRecord.


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
