### PR TITLE
Implement resizable side nav

### DIFF
--- a/libs/components/src/navigation/side-nav.component.html
+++ b/libs/components/src/navigation/side-nav.component.html
@@ -5,43 +5,60 @@
   };
   as data
 ) {
-  <nav
-    id="bit-side-nav"
-    class="tw-fixed md:tw-sticky tw-inset-y-0 tw-left-0 tw-z-30 tw-flex tw-h-screen tw-flex-col tw-overscroll-none tw-overflow-auto tw-bg-background-alt3 tw-outline-none"
-    [ngClass]="{ 'tw-w-60': data.open }"
-    [ngStyle]="
-      variant() === 'secondary' && {
-        '--color-text-alt2': 'var(--color-text-main)',
-        '--color-background-alt3': 'var(--color-secondary-100)',
-        '--color-background-alt4': 'var(--color-secondary-300)',
-        '--color-hover-contrast': 'var(--color-hover-default)',
-      }
-    "
-    [cdkTrapFocus]="data.isOverlay"
-    [attr.role]="data.isOverlay ? 'dialog' : null"
-    [attr.aria-modal]="data.isOverlay ? 'true' : null"
-    (keydown)="handleKeyDown($event)"
-  >
-    <ng-content></ng-content>
-    <div class="tw-sticky tw-bottom-0 tw-left-0 tw-z-20 tw-mt-auto tw-w-full tw-bg-background-alt3">
-      <bit-nav-divider></bit-nav-divider>
-      @if (data.open) {
-        <ng-content select="[slot=footer]"></ng-content>
-      }
-      <div class="tw-mx-0.5 tw-my-4 tw-w-[3.75rem]">
-        <button
-          #toggleButton
-          type="button"
-          class="tw-mx-auto tw-block tw-max-w-fit"
-          [bitIconButton]="data.open ? 'bwi-angle-left' : 'bwi-angle-right'"
-          buttonType="nav-contrast"
-          size="small"
-          (click)="sideNavService.toggle()"
-          [label]="'toggleSideNavigation' | i18n"
-          [attr.aria-expanded]="data.open"
-          aria-controls="bit-side-nav"
-        ></button>
+  <div class="tw-relative">
+    <nav
+      id="bit-side-nav"
+      class="tw-sticky tw-inset-y-0 tw-left-0 tw-z-30 tw-flex tw-h-screen tw-flex-col tw-overscroll-none tw-overflow-auto tw-bg-background-alt3 tw-outline-none"
+      [ngClass]="{ 'tw-w-60': data.open }"
+      [style.width.px]="currentWidth()"
+      [ngStyle]="
+        variant() === 'secondary' && {
+          '--color-text-alt2': 'var(--color-text-main)',
+          '--color-background-alt3': 'var(--color-secondary-100)',
+          '--color-background-alt4': 'var(--color-secondary-300)',
+          '--color-hover-contrast': 'var(--color-hover-default)',
+        }
+      "
+      [cdkTrapFocus]="data.isOverlay"
+      [attr.role]="data.isOverlay ? 'dialog' : null"
+      [attr.aria-modal]="data.isOverlay ? 'true' : null"
+      (keydown)="handleKeyDown($event)"
+    >
+      <ng-content></ng-content>
+      <div
+        class="tw-sticky tw-bottom-0 tw-left-0 tw-z-20 tw-mt-auto tw-w-full tw-bg-background-alt3"
+      >
+        <bit-nav-divider></bit-nav-divider>
+        @if (data.open) {
+          <ng-content select="[slot=footer]"></ng-content>
+        }
+        <div class="tw-mx-0.5 tw-my-4 tw-w-[3.75rem]">
+          <button
+            #toggleButton
+            type="button"
+            class="tw-mx-auto tw-block tw-max-w-fit"
+            [bitIconButton]="data.open ? 'bwi-angle-left' : 'bwi-angle-right'"
+            buttonType="nav-contrast"
+            size="small"
+            (click)="sideNavService.toggle()"
+            [label]="'toggleSideNavigation' | i18n"
+            [attr.aria-expanded]="data.open"
+            aria-controls="bit-side-nav"
+          ></button>
+        </div>
+      </div>
+    </nav>
+    <div
+      cdkDrag
+      (cdkDragMoved)="onDragMoved($event)"
+      class="tw-group tw-absolute tw-top-0 -tw-right-2 tw-z-30 tw-h-full tw-w-3 tw-text-contrast tw-cursor-col-resize tw-opacity-0 hover:tw-opacity-100 tw-transition-opacity [&.cdk-drag-dragging]:tw-opacity-100 [&.cdk-drag-dragging_>_div]:tw-scale-x-100"
+      [ngClass]="{ 'tw-hidden': !data.open }"
+    >
+      <div
+        class="tw-flex tw-items-center tw-justify-center tw-size-full tw-bg-background-alt4 tw-transition-transform tw-scale-x-0 group-hover:tw-scale-x-100 tw-transition-transform tw-origin-center"
+      >
+        <span class="tw-text-sm tw-text-alt2 tw-pointer-events-none tw-select-none">⠿</span>
       </div>
     </div>
-  </nav>
+  </div>
 }

--- a/libs/components/src/navigation/side-nav.component.ts
+++ b/libs/components/src/navigation/side-nav.component.ts
@@ -1,6 +1,9 @@
 import { CdkTrapFocus } from "@angular/cdk/a11y";
+import { DragDropModule, CdkDragMove } from "@angular/cdk/drag-drop";
 import { CommonModule } from "@angular/common";
-import { Component, ElementRef, input, viewChild } from "@angular/core";
+import { Component, ElementRef, input, OnDestroy, signal, viewChild } from "@angular/core";
+import { Subject } from "rxjs";
+import { takeUntil } from "rxjs/operators";
 
 import { I18nPipe } from "@bitwarden/ui-common";
 
@@ -11,17 +14,47 @@ import { SideNavService } from "./side-nav.service";
 
 export type SideNavVariant = "primary" | "secondary";
 
+const DEFAULT_OPEN_WIDTH = 275;
+const DEFAULT_CLOSED_WIDTH = 64;
+const MIN_OPEN_WIDTH = 240;
+const MAX_OPEN_WIDTH = 384;
+
 @Component({
   selector: "bit-side-nav",
   templateUrl: "side-nav.component.html",
-  imports: [CommonModule, CdkTrapFocus, NavDividerComponent, BitIconButtonComponent, I18nPipe],
+  imports: [
+    CommonModule,
+    CdkTrapFocus,
+    NavDividerComponent,
+    BitIconButtonComponent,
+    I18nPipe,
+    DragDropModule,
+  ],
 })
-export class SideNavComponent {
+export class SideNavComponent implements OnDestroy {
   readonly variant = input<SideNavVariant>("primary");
 
   private readonly toggleButton = viewChild("toggleButton", { read: ElementRef });
 
-  constructor(protected sideNavService: SideNavService) {}
+  protected lastOpenWidth = DEFAULT_OPEN_WIDTH;
+  protected currentWidth = signal(DEFAULT_OPEN_WIDTH);
+  private readonly destroy$ = new Subject<void>();
+
+  constructor(protected sideNavService: SideNavService) {
+    sideNavService.open$.pipe(takeUntil(this.destroy$)).subscribe((isOpen) => {
+      if (isOpen) {
+        this.currentWidth.set(this.lastOpenWidth);
+      } else {
+        this.lastOpenWidth = this.currentWidth();
+        this.currentWidth.set(DEFAULT_CLOSED_WIDTH);
+      }
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
 
   protected handleKeyDown = (event: KeyboardEvent) => {
     if (event.key === "Escape") {
@@ -32,4 +65,12 @@ export class SideNavComponent {
 
     return true;
   };
+
+  protected onDragMoved(event: CdkDragMove) {
+    this.currentWidth.set(
+      Math.min(Math.max(event.pointerPosition.x, MIN_OPEN_WIDTH), MAX_OPEN_WIDTH),
+    );
+    const element = event.source.element.nativeElement;
+    element.style.transform = "none";
+  }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/CL-132

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Update nav sidebar to be resizable.

When the sidebar is collapsed, the previous width is preserved for when it expands again.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/93b225b8-a2ba-46f5-a3f3-bfab6561428d

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
