### PR TITLE
build: add nx configuration in libs/dirt/card

### DIFF
--- a/libs/dirt/card/package.json
+++ b/libs/dirt/card/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "clean": "rimraf dist",
     "build": "npm run clean && tsc",
-    "build:watch": "npm run clean && tsc -watch"
+    "build:watch": "npm run clean && tsc -watch",
+    "test": "jest --passWithNoTests"
   }
 }

--- a/libs/dirt/card/project.json
+++ b/libs/dirt/card/project.json
@@ -1,0 +1,41 @@
+{
+  "name": "@bitwarden/dirt-card",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/dirt/card/src",
+  "projectType": "library",
+  "tags": ["scope:dirt-card", "type:lib"],
+  "targets": {
+    "build": {
+      "executor": "nx:run-script",
+      "dependsOn": [],
+      "options": {
+        "script": "build"
+      }
+    },
+    "build:watch": {
+      "executor": "nx:run-script",
+      "options": {
+        "script": "build:watch"
+      }
+    },
+    "clean": {
+      "executor": "nx:run-script",
+      "options": {
+        "script": "clean"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": ["libs/dirt/card/**/*.ts"]
+      }
+    },
+    "test": {
+      "executor": "nx:run-script",
+      "options": {
+        "script": "test"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## 🎟️ Tracking

- https://bitwarden.atlassian.net/browse/PM-20254
- https://github.com/bitwarden/clients/pull/16538
- https://github.com/bitwarden/clients/pull/16539
- https://github.com/bitwarden/clients/pull/16540
- https://github.com/bitwarden/clients/pull/16542
- https://github.com/bitwarden/clients/pull/16544
- https://github.com/bitwarden/clients/pull/16545
- https://github.com/bitwarden/clients/pull/16546
- https://github.com/bitwarden/clients/pull/16547
- https://github.com/bitwarden/clients/pull/16548
- https://github.com/bitwarden/clients/pull/16549
- https://github.com/bitwarden/clients/pull/16550
- https://github.com/bitwarden/clients/pull/16551
- https://github.com/bitwarden/clients/pull/16562
- https://github.com/bitwarden/clients/pull/16563
- https://github.com/bitwarden/clients/pull/16564

## 📔 Objective

Adds Nx configuration to `@bitwarden/dirt` library, which has a nested structure at `libs/dirt/card/` rather than the standard `libs/dirt/` location. The `project.json` uses a facade pattern that delegates to existing npm scripts to avoid breaking circular dependencies. Added "test": "jest --passWithNoTests" script to package.json since library has jest.config.js but no test files. This enables `nx build`, `nx lint`, and `nx test` commands while maintaining backward compatibility.

NOTE: The Experimental NX CI job is expected to be failing at this stage. This is one of the steps being taken to get it green.

## Screenshots

These screenshots show the build, lint, and test output for all 15 libraries in this set of PRs together.

<img width="1356" height="1098" alt="Screenshot 2025-09-23 at 12 39 29 PM" src="https://github.com/user-attachments/assets/ec883efb-cc27-48af-9d15-9817067f77b0" />

<img width="954" height="1004" alt="Screenshot 2025-09-23 at 12 39 33 PM" src="https://github.com/user-attachments/assets/2bb1e6f8-7f40-48c0-ab52-08b42a9c59a7" />

<img width="1070" height="1034" alt="Screenshot 2025-09-23 at 12 39 40 PM" src="https://github.com/user-attachments/assets/231e5bae-7340-43c1-bb34-2c3f9def7302" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

- 👍 or similar for great changes
- 📝 or ℹ️ for notes or general info
- ❓ for questions
- 🤔 or 💭 for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 for suggestions / improvements
- ❌ or ⚠️ for more significant problems or concerns needing attention
- 🌱 or ♻️ for future improvements or indications of technical debt
- ⛏ for minor or nitpick changes