### PR TITLE
build: add nx configuration to tools nested libraries

### DIFF
--- a/libs/tools/export/vault-export/vault-export-core/package.json
+++ b/libs/tools/export/vault-export/vault-export-core/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "clean": "rimraf dist",
     "build": "npm run clean && tsc",
-    "build:watch": "npm run clean && tsc -watch"
+    "build:watch": "npm run clean && tsc -watch",
+    "test": "jest"
   }
 }

--- a/libs/tools/export/vault-export/vault-export-core/project.json
+++ b/libs/tools/export/vault-export/vault-export-core/project.json
@@ -1,0 +1,41 @@
+{
+  "name": "@bitwarden/vault-export-core",
+  "$schema": "../../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/tools/export/vault-export/vault-export-core/src",
+  "projectType": "library",
+  "tags": ["scope:vault-export-core", "type:lib"],
+  "targets": {
+    "build": {
+      "executor": "nx:run-script",
+      "dependsOn": [],
+      "options": {
+        "script": "build"
+      }
+    },
+    "build:watch": {
+      "executor": "nx:run-script",
+      "options": {
+        "script": "build:watch"
+      }
+    },
+    "clean": {
+      "executor": "nx:run-script",
+      "options": {
+        "script": "clean"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": ["libs/tools/export/vault-export/vault-export-core/**/*.ts"]
+      }
+    },
+    "test": {
+      "executor": "nx:run-script",
+      "options": {
+        "script": "test"
+      }
+    }
+  }
+}

--- a/libs/tools/export/vault-export/vault-export-ui/package.json
+++ b/libs/tools/export/vault-export/vault-export-ui/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "clean": "rimraf dist",
     "build": "npm run clean && tsc",
-    "build:watch": "npm run clean && tsc -watch"
+    "build:watch": "npm run clean && tsc -watch",
+    "test": "jest --passWithNoTests"
   }
 }

--- a/libs/tools/export/vault-export/vault-export-ui/project.json
+++ b/libs/tools/export/vault-export/vault-export-ui/project.json
@@ -1,0 +1,41 @@
+{
+  "name": "@bitwarden/vault-export-ui",
+  "$schema": "../../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/tools/export/vault-export/vault-export-ui/src",
+  "projectType": "library",
+  "tags": ["scope:vault-export-ui", "type:lib"],
+  "targets": {
+    "build": {
+      "executor": "nx:run-script",
+      "dependsOn": [],
+      "options": {
+        "script": "build"
+      }
+    },
+    "build:watch": {
+      "executor": "nx:run-script",
+      "options": {
+        "script": "build:watch"
+      }
+    },
+    "clean": {
+      "executor": "nx:run-script",
+      "options": {
+        "script": "clean"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": ["libs/tools/export/vault-export/vault-export-ui/**/*.ts"]
+      }
+    },
+    "test": {
+      "executor": "nx:run-script",
+      "options": {
+        "script": "test"
+      }
+    }
+  }
+}

--- a/libs/tools/generator/components/package.json
+++ b/libs/tools/generator/components/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "clean": "rimraf dist",
     "build": "npm run clean && tsc",
-    "build:watch": "npm run clean && tsc -watch"
+    "build:watch": "npm run clean && tsc -watch",
+    "test": "jest --passWithNoTests"
   }
 }

--- a/libs/tools/generator/components/project.json
+++ b/libs/tools/generator/components/project.json
@@ -1,0 +1,41 @@
+{
+  "name": "@bitwarden/generator-components",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/tools/generator/components/src",
+  "projectType": "library",
+  "tags": ["scope:generator-components", "type:lib"],
+  "targets": {
+    "build": {
+      "executor": "nx:run-script",
+      "dependsOn": [],
+      "options": {
+        "script": "build"
+      }
+    },
+    "build:watch": {
+      "executor": "nx:run-script",
+      "options": {
+        "script": "build:watch"
+      }
+    },
+    "clean": {
+      "executor": "nx:run-script",
+      "options": {
+        "script": "clean"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": ["libs/tools/generator/components/**/*.ts"]
+      }
+    },
+    "test": {
+      "executor": "nx:run-script",
+      "options": {
+        "script": "test"
+      }
+    }
+  }
+}

--- a/libs/tools/generator/core/package.json
+++ b/libs/tools/generator/core/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "clean": "rimraf dist",
     "build": "npm run clean && tsc",
-    "build:watch": "npm run clean && tsc -watch"
+    "build:watch": "npm run clean && tsc -watch",
+    "test": "jest"
   }
 }

--- a/libs/tools/generator/core/project.json
+++ b/libs/tools/generator/core/project.json
@@ -1,0 +1,41 @@
+{
+  "name": "@bitwarden/generator-core",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/tools/generator/core/src",
+  "projectType": "library",
+  "tags": ["scope:generator-core", "type:lib"],
+  "targets": {
+    "build": {
+      "executor": "nx:run-script",
+      "dependsOn": [],
+      "options": {
+        "script": "build"
+      }
+    },
+    "build:watch": {
+      "executor": "nx:run-script",
+      "options": {
+        "script": "build:watch"
+      }
+    },
+    "clean": {
+      "executor": "nx:run-script",
+      "options": {
+        "script": "clean"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": ["libs/tools/generator/core/**/*.ts"]
+      }
+    },
+    "test": {
+      "executor": "nx:run-script",
+      "options": {
+        "script": "test"
+      }
+    }
+  }
+}

--- a/libs/tools/generator/extensions/history/package.json
+++ b/libs/tools/generator/extensions/history/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "clean": "rimraf dist",
     "build": "npm run clean && tsc",
-    "build:watch": "npm run clean && tsc -watch"
+    "build:watch": "npm run clean && tsc -watch",
+    "test": "jest"
   }
 }

--- a/libs/tools/generator/extensions/history/project.json
+++ b/libs/tools/generator/extensions/history/project.json
@@ -1,0 +1,41 @@
+{
+  "name": "@bitwarden/generator-history",
+  "$schema": "../../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/tools/generator/extensions/history/src",
+  "projectType": "library",
+  "tags": ["scope:generator-history", "type:lib"],
+  "targets": {
+    "build": {
+      "executor": "nx:run-script",
+      "dependsOn": [],
+      "options": {
+        "script": "build"
+      }
+    },
+    "build:watch": {
+      "executor": "nx:run-script",
+      "options": {
+        "script": "build:watch"
+      }
+    },
+    "clean": {
+      "executor": "nx:run-script",
+      "options": {
+        "script": "clean"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": ["libs/tools/generator/extensions/history/**/*.ts"]
+      }
+    },
+    "test": {
+      "executor": "nx:run-script",
+      "options": {
+        "script": "test"
+      }
+    }
+  }
+}

--- a/libs/tools/generator/extensions/legacy/package.json
+++ b/libs/tools/generator/extensions/legacy/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "clean": "rimraf dist",
     "build": "npm run clean && tsc",
-    "build:watch": "npm run clean && tsc -watch"
+    "build:watch": "npm run clean && tsc -watch",
+    "test": "jest"
   }
 }

--- a/libs/tools/generator/extensions/legacy/project.json
+++ b/libs/tools/generator/extensions/legacy/project.json
@@ -1,0 +1,41 @@
+{
+  "name": "@bitwarden/generator-legacy",
+  "$schema": "../../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/tools/generator/extensions/legacy/src",
+  "projectType": "library",
+  "tags": ["scope:generator-legacy", "type:lib"],
+  "targets": {
+    "build": {
+      "executor": "nx:run-script",
+      "dependsOn": [],
+      "options": {
+        "script": "build"
+      }
+    },
+    "build:watch": {
+      "executor": "nx:run-script",
+      "options": {
+        "script": "build:watch"
+      }
+    },
+    "clean": {
+      "executor": "nx:run-script",
+      "options": {
+        "script": "clean"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": ["libs/tools/generator/extensions/legacy/**/*.ts"]
+      }
+    },
+    "test": {
+      "executor": "nx:run-script",
+      "options": {
+        "script": "test"
+      }
+    }
+  }
+}

--- a/libs/tools/generator/extensions/navigation/package.json
+++ b/libs/tools/generator/extensions/navigation/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "clean": "rimraf dist",
     "build": "npm run clean && tsc",
-    "build:watch": "npm run clean && tsc -watch"
+    "build:watch": "npm run clean && tsc -watch",
+    "test": "jest"
   }
 }

--- a/libs/tools/generator/extensions/navigation/project.json
+++ b/libs/tools/generator/extensions/navigation/project.json
@@ -1,0 +1,41 @@
+{
+  "name": "@bitwarden/generator-navigation",
+  "$schema": "../../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/tools/generator/extensions/navigation/src",
+  "projectType": "library",
+  "tags": ["scope:generator-navigation", "type:lib"],
+  "targets": {
+    "build": {
+      "executor": "nx:run-script",
+      "dependsOn": [],
+      "options": {
+        "script": "build"
+      }
+    },
+    "build:watch": {
+      "executor": "nx:run-script",
+      "options": {
+        "script": "build:watch"
+      }
+    },
+    "clean": {
+      "executor": "nx:run-script",
+      "options": {
+        "script": "clean"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": ["libs/tools/generator/extensions/navigation/**/*.ts"]
+      }
+    },
+    "test": {
+      "executor": "nx:run-script",
+      "options": {
+        "script": "test"
+      }
+    }
+  }
+}

--- a/libs/tools/send/send-ui/package.json
+++ b/libs/tools/send/send-ui/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "clean": "rimraf dist",
     "build": "npm run clean && tsc",
-    "build:watch": "npm run clean && tsc -watch"
+    "build:watch": "npm run clean && tsc -watch",
+    "test": "jest"
   }
 }

--- a/libs/tools/send/send-ui/project.json
+++ b/libs/tools/send/send-ui/project.json
@@ -1,0 +1,41 @@
+{
+  "name": "@bitwarden/send-ui",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/tools/send/send-ui/src",
+  "projectType": "library",
+  "tags": ["scope:send-ui", "type:lib"],
+  "targets": {
+    "build": {
+      "executor": "nx:run-script",
+      "dependsOn": [],
+      "options": {
+        "script": "build"
+      }
+    },
+    "build:watch": {
+      "executor": "nx:run-script",
+      "options": {
+        "script": "build:watch"
+      }
+    },
+    "clean": {
+      "executor": "nx:run-script",
+      "options": {
+        "script": "clean"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": ["libs/tools/send/send-ui/**/*.ts"]
+      }
+    },
+    "test": {
+      "executor": "nx:run-script",
+      "options": {
+        "script": "test"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## 🎟️ Tracking

- https://bitwarden.atlassian.net/browse/PM-20254
- https://github.com/bitwarden/clients/pull/16538
- https://github.com/bitwarden/clients/pull/16539
- https://github.com/bitwarden/clients/pull/16540
- https://github.com/bitwarden/clients/pull/16542
- https://github.com/bitwarden/clients/pull/16544
- https://github.com/bitwarden/clients/pull/16545
- https://github.com/bitwarden/clients/pull/16546
- https://github.com/bitwarden/clients/pull/16547
- https://github.com/bitwarden/clients/pull/16548
- https://github.com/bitwarden/clients/pull/16549
- https://github.com/bitwarden/clients/pull/16550
- https://github.com/bitwarden/clients/pull/16551
- https://github.com/bitwarden/clients/pull/16562
- https://github.com/bitwarden/clients/pull/16563
- https://github.com/bitwarden/clients/pull/16564

## 📔 Objective

Adds Nx configuration to all 8 libraries within the tools directory: `@bitwarden/send-ui`, `@bitwarden/generator-core`, `@bitwarden/generator-components`, `@bitwarden/vault-export-core`, `@bitwarden/vault-export-ui`, `@bitwarden/generator-history`, `@bitwarden/generator-legacy`, and `@bitwarden/generator-navigation`. Each `project.json` uses a facade pattern that delegates to existing npm scripts to avoid breaking circular dependencies. Added missing "test": "jest" scripts to 6 libraries and used "jest --passWithNoTests" for 2 libraries without test files. This enables `nx build`, `nx lint`, and `nx test` commands for all 8 libraries while maintaining backward compatibility.

NOTE: The Experimental NX CI job is expected to be failing at this stage. This is one of the steps being taken to get it green.

## Screenshots

These screenshots show the build, lint, and test output for all 15 libraries in this set of PRs together.

<img width="1356" height="1098" alt="Screenshot 2025-09-23 at 12 39 29 PM" src="https://github.com/user-attachments/assets/ec883efb-cc27-48af-9d15-9817067f77b0" />

<img width="954" height="1004" alt="Screenshot 2025-09-23 at 12 39 33 PM" src="https://github.com/user-attachments/assets/2bb1e6f8-7f40-48c0-ab52-08b42a9c59a7" />

<img width="1070" height="1034" alt="Screenshot 2025-09-23 at 12 39 40 PM" src="https://github.com/user-attachments/assets/231e5bae-7340-43c1-bb34-2c3f9def7302" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

- 👍 or similar for great changes
- 📝 or ℹ️ for notes or general info
- ❓ for questions
- 🤔 or 💭 for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 for suggestions / improvements
- ❌ or ⚠️ for more significant problems or concerns needing attention
- 🌱 or ♻️ for future improvements or indications of technical debt
- ⛏ for minor or nitpick changes