### PR TITLE
[PM-26073] Activity tab -  remove learn more link

### DIFF
--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/all-activity.component.html
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/all-activity.component.html
@@ -12,11 +12,6 @@
           {{ "noAppsInOrgTitle" | i18n: organization?.name }}
         </h2>
       </ng-container>
-      <ng-container slot="description">
-        <div class="tw-flex tw-flex-col tw-mb-2">
-          <a class="tw-text-primary-600" routerLink="/login">{{ "learnMore" | i18n }}</a>
-        </div>
-      </ng-container>
     </bit-no-items>
   </div>
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-26073

## 📔 Objective

remove a redundant link from the activity tab

## 📸 Screenshots

<img width="986" height="678" alt="image" src="https://github.com/user-attachments/assets/7bf0626b-207c-4a64-8683-1a50b9e22324" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
