### PR TITLE
[PM-26120] Only run BIT trigger workflow when Build Browser workflow completes successfully

### DIFF
--- a/.github/workflows/test-browser-interactions.yml
+++ b/.github/workflows/test-browser-interactions.yml
@@ -11,6 +11,7 @@ jobs:
   check-files:
     name: Check files
     runs-on: ubuntu-22.04
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     permissions:
       actions: write
       contents: read


### PR DESCRIPTION
## 🎟️ Tracking

[PM-26120](https://bitwarden.atlassian.net/browse/PM-26120)

## 📔 Objective

We presently trigger “Autofill BIT checks” every time the “Build Browser” workflow completes. Since the chrome build artifact is a requirement for BIT, we should only run the triggering workflow when the “Build Browser” workflow actually succeeds

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-26120]: https://bitwarden.atlassian.net/browse/PM-26120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ