### PR TITLE
[PM-26105] - [Defect][Browser] Firefox and Safari toolbar is in the middle of extension

### DIFF
--- a/apps/browser/src/popup/scss/base.scss
+++ b/apps/browser/src/popup/scss/base.scss
@@ -151,6 +151,7 @@ textarea {
 
 app-root > div {
   height: 100%;
+  width: 100%;
 }
 
 main::-webkit-scrollbar,
@@ -373,7 +374,8 @@ header:not(bit-callout header, bit-dialog header, popup-page header) {
 
 app-root {
   width: 100%;
-  height: 100%;
+  height: 100vh;
+  display: flex;
 
   @include themify($themes) {
     background-color: themed("backgroundColor");


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-26105

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR fixes an issue in Safari/FF where the main app-root element isn't occupying the full height of the window. This was caused from a [previous PR](https://github.com/bitwarden/clients/pull/16292) to fix the toast element not showing over dialogs which removed the `position: absolute` style from `app-root`. 

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

Test with At Risk Carousel dialog and a test toast notification 
https://github.com/user-attachments/assets/2d87523d-6b63-42d2-81c3-c9c614a63c06


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
