### PR TITLE
[PM-26196] Correct error with desktop window being off screen when displays are changed/unplugged

### DIFF
--- a/apps/desktop/src/main/window.main.ts
+++ b/apps/desktop/src/main/window.main.ts
@@ -500,9 +500,9 @@ export class WindowMain {
         displayBounds.x !== state.displayBounds.x ||
         displayBounds.y !== state.displayBounds.y
       ) {
-        state.x = undefined;
-        state.y = undefined;
         displayBounds = screen.getPrimaryDisplay().bounds;
+        state.x = displayBounds.x + displayBounds.width / 2 - state.width / 2;
+        state.y = displayBounds.y + displayBounds.height / 2 - state.height / 2;
       }
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

https://github.com/bitwarden/clients/issues/2617

## 📔 Objective

Makes a small change to center the window of the desktop app when bounds change. ([#2617](https://github.com/bitwarden/clients/issues/2617))

This is my first commit, and I don't believe this would count as a major UX change so I have not made a forum post.

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
