### PR TITLE
[PM-25172] Fix default autofill on page load cipher level setting

### DIFF
--- a/libs/common/src/vault/models/domain/login.ts
+++ b/libs/common/src/vault/models/domain/login.ts
@@ -183,7 +183,7 @@ export class Login extends Domain {
       ? new Date(obj.passwordRevisionDate)
       : undefined;
     login.totp = EncString.fromJSON(obj.totp);
-    login.autofillOnPageLoad = obj.autofillOnPageLoad ?? false;
+    login.autofillOnPageLoad = obj.autofillOnPageLoad;
     login.fido2Credentials = obj.fido2Credentials?.map((f) =>
       Fido2Credential.fromSdkFido2Credential(f),
     );


### PR DESCRIPTION
## 🎟️ Tracking

[PM-25172](https://bitwarden.atlassian.net/browse/PM-25172)

## 📔 Objective

Do not null coalesce a login's autofillOnPageLoad setting to false when mapping from the `SdkLoginView`. Undefined is a valid option that defaults to the extension autofill on page load setting

## 📸 Screenshots


https://github.com/user-attachments/assets/4c5273c3-a81c-4dfb-ac4c-1d448e6ec601



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-25172]: https://bitwarden.atlassian.net/browse/PM-25172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ