### PR TITLE
[PM-24633] - Nested collections displaying incorrectly across vaults due to similar parent collection names.

### DIFF
--- a/apps/web/src/app/admin-console/organizations/collections/utils/collection-utils.ts
+++ b/apps/web/src/app/admin-console/organizations/collections/utils/collection-utils.ts
@@ -5,6 +5,7 @@ import {
   CollectionView,
   NestingDelimiter,
 } from "@bitwarden/admin-console/common";
+import { OrganizationId } from "@bitwarden/common/types/guid";
 import { TreeNode } from "@bitwarden/common/vault/models/domain/tree-node";
 import { ServiceUtils } from "@bitwarden/common/vault/service-utils";
 
@@ -26,15 +27,23 @@ export function getNestedCollectionTree(
     .sort((a, b) => a.name.localeCompare(b.name))
     .map(cloneCollection);
 
-  const nodes: TreeNode<CollectionView | CollectionAdminView>[] = [];
-  clonedCollections.forEach((collection) => {
-    const parts =
-      collection.name != null
-        ? collection.name.replace(/^\/+|\/+$/g, "").split(NestingDelimiter)
-        : [];
-    ServiceUtils.nestedTraverse(nodes, 0, parts, collection, null, NestingDelimiter);
+  const all: TreeNode<CollectionView | CollectionAdminView>[] = [];
+  const groupedByOrg = new Map<OrganizationId, CollectionView[]>();
+  clonedCollections.map((c) => {
+    const key = c.organizationId;
+    (groupedByOrg.get(key) ?? groupedByOrg.set(key, []).get(key)!).push(c);
   });
-  return nodes;
+
+  for (const group of groupedByOrg.values()) {
+    const nodes: TreeNode<CollectionView>[] = [];
+    for (const c of group) {
+      const collectionCopy = Object.assign(new CollectionView({ ...c, name: c.name }), c);
+      const parts = c.name ? c.name.replace(/^\/+|\/+$/g, "").split(NestingDelimiter) : [];
+      ServiceUtils.nestedTraverse(nodes, 0, parts, collectionCopy, undefined, NestingDelimiter);
+    }
+    all.push(...nodes);
+  }
+  return all;
 }
 
 export function cloneCollection(collection: CollectionView): CollectionView;


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-24633
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR fixes another bug related to the original one regarding how child nodes are collected for our collection filters, which they were not previously grouping under the correct collection if there were collections with duplicate names across orgs.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/7eef1b32-ac72-44d5-9910-34a7fb1175b5



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
