### PR TITLE
Platform/PM-26186 - Utils.fromBufferToB64 - add type safety and ArrayBufferView support + tests

### DIFF
--- a/libs/common/src/platform/misc/utils.spec.ts
+++ b/libs/common/src/platform/misc/utils.spec.ts
@@ -302,15 +302,87 @@ describe("Utils Service", () => {
       expect(b64String).toBe(b64HelloWorldString);
     });
 
-    runInBothEnvironments("should return an empty string for an empty ArrayBuffer", () => {
+    runInBothEnvironments("should return null for an empty ArrayBuffer", () => {
       const buffer = new Uint8Array([]).buffer;
       const b64String = Utils.fromBufferToB64(buffer);
-      expect(b64String).toBe("");
+      expect(b64String).toBeNull();
     });
 
     runInBothEnvironments("should return null for null input", () => {
       const b64String = Utils.fromBufferToB64(null);
       expect(b64String).toBeNull();
+    });
+
+    runInBothEnvironments("returns null for undefined input", () => {
+      const b64 = Utils.fromBufferToB64(undefined as unknown as ArrayBuffer);
+      expect(b64).toBeNull();
+    });
+
+    runInBothEnvironments("returns null for empty input", () => {
+      const b64 = Utils.fromBufferToB64(new ArrayBuffer(0));
+      expect(b64).toBeNull();
+    });
+
+    runInBothEnvironments("accepts Uint8Array directly", () => {
+      const u8 = new Uint8Array(asciiHelloWorldArray);
+      const b64 = Utils.fromBufferToB64(u8);
+      expect(b64).toBe(b64HelloWorldString);
+    });
+
+    runInBothEnvironments("respects byteOffset/byteLength (view window)", () => {
+      // [xx, 'hello world', yy] — view should only encode the middle slice
+      const prefix = [1, 2, 3];
+      const suffix = [4, 5];
+      const all = new Uint8Array([...prefix, ...asciiHelloWorldArray, ...suffix]);
+      const view = new Uint8Array(all.buffer, prefix.length, asciiHelloWorldArray.length);
+      const b64 = Utils.fromBufferToB64(view);
+      expect(b64).toBe(b64HelloWorldString);
+    });
+
+    runInBothEnvironments("handles DataView (ArrayBufferView other than Uint8Array)", () => {
+      const u8 = new Uint8Array(asciiHelloWorldArray);
+      const dv = new DataView(u8.buffer, 0, u8.byteLength);
+      const b64 = Utils.fromBufferToB64(dv);
+      expect(b64).toBe(b64HelloWorldString);
+    });
+
+    runInBothEnvironments("handles DataView with offset/length window", () => {
+      // Buffer: [xx, 'hello world', yy]
+      const prefix = [9, 9, 9];
+      const suffix = [8, 8];
+      const all = new Uint8Array([...prefix, ...asciiHelloWorldArray, ...suffix]);
+
+      // DataView over just the "hello world" window
+      const dv = new DataView(all.buffer, prefix.length, asciiHelloWorldArray.length);
+
+      const b64 = Utils.fromBufferToB64(dv);
+      expect(b64).toBe(b64HelloWorldString);
+    });
+
+    runInBothEnvironments("encodes empty view (offset-length window of zero) as null", () => {
+      const backing = new Uint8Array([1, 2, 3, 4]);
+      const emptyView = new Uint8Array(backing.buffer, 2, 0);
+      const b64 = Utils.fromBufferToB64(emptyView);
+      expect(b64).toBeNull();
+    });
+
+    runInBothEnvironments("does not mutate the input", () => {
+      const original = new Uint8Array(asciiHelloWorldArray);
+      const copyBefore = new Uint8Array(original); // snapshot
+      Utils.fromBufferToB64(original);
+      expect(original).toEqual(copyBefore); // unchanged
+    });
+
+    it("produces the same Base64 in Node vs non-Node mode", () => {
+      const bytes = new Uint8Array(asciiHelloWorldArray);
+
+      Utils.isNode = true;
+      const nodeB64 = Utils.fromBufferToB64(bytes);
+
+      Utils.isNode = false;
+      const browserB64 = Utils.fromBufferToB64(bytes);
+
+      expect(browserB64).toBe(nodeB64);
     });
   });
 

--- a/libs/common/src/platform/misc/utils.spec.ts
+++ b/libs/common/src/platform/misc/utils.spec.ts
@@ -302,10 +302,10 @@ describe("Utils Service", () => {
       expect(b64String).toBe(b64HelloWorldString);
     });
 
-    runInBothEnvironments("should return null for an empty ArrayBuffer", () => {
+    runInBothEnvironments("should return empty string for an empty ArrayBuffer", () => {
       const buffer = new Uint8Array([]).buffer;
       const b64String = Utils.fromBufferToB64(buffer);
-      expect(b64String).toBeNull();
+      expect(b64String).toBe("");
     });
 
     runInBothEnvironments("should return null for null input", () => {
@@ -318,9 +318,9 @@ describe("Utils Service", () => {
       expect(b64).toBeNull();
     });
 
-    runInBothEnvironments("returns null for empty input", () => {
+    runInBothEnvironments("returns empty string for empty input", () => {
       const b64 = Utils.fromBufferToB64(new ArrayBuffer(0));
-      expect(b64).toBeNull();
+      expect(b64).toBe("");
     });
 
     runInBothEnvironments("accepts Uint8Array directly", () => {
@@ -359,12 +359,15 @@ describe("Utils Service", () => {
       expect(b64).toBe(b64HelloWorldString);
     });
 
-    runInBothEnvironments("encodes empty view (offset-length window of zero) as null", () => {
-      const backing = new Uint8Array([1, 2, 3, 4]);
-      const emptyView = new Uint8Array(backing.buffer, 2, 0);
-      const b64 = Utils.fromBufferToB64(emptyView);
-      expect(b64).toBeNull();
-    });
+    runInBothEnvironments(
+      "encodes empty view (offset-length window of zero) as empty string",
+      () => {
+        const backing = new Uint8Array([1, 2, 3, 4]);
+        const emptyView = new Uint8Array(backing.buffer, 2, 0);
+        const b64 = Utils.fromBufferToB64(emptyView);
+        expect(b64).toBe("");
+      },
+    );
 
     runInBothEnvironments("does not mutate the input", () => {
       const original = new Uint8Array(asciiHelloWorldArray);

--- a/libs/common/src/platform/misc/utils.ts
+++ b/libs/common/src/platform/misc/utils.ts
@@ -128,19 +128,76 @@ export class Utils {
     return arr;
   }
 
-  static fromBufferToB64(buffer: ArrayBuffer): string {
+  /**
+   * Convert binary data into a Base64 string.
+   *
+   * Overloads are provided for two categories of input:
+   *
+   * 1. ArrayBuffer
+   *    - A raw, fixed-length chunk of memory (no element semantics).
+   *    - Example: `const buf = new ArrayBuffer(16);`
+   *
+   * 2. ArrayBufferView
+   *    - A *view* onto an existing buffer that gives the bytes meaning.
+   *    - Examples: Uint8Array, Int32Array, DataView, etc.
+   *    - Views can expose only a *window* of the underlying buffer via
+   *      `byteOffset` and `byteLength`.
+   *      Example:
+   *      ```ts
+   *      const buf = new ArrayBuffer(8);
+   *      const full = new Uint8Array(buf);       // sees all 8 bytes
+   *      const half = new Uint8Array(buf, 4, 4); // sees only last 4 bytes
+   *      ```
+   *
+   * Returns:
+   * - Base64 string for non-empty inputs,
+   * - null if `buffer` is `null` or `undefined` or for empty inputs (length 0)
+   */
+  static fromBufferToB64(buffer: ArrayBuffer | ArrayBufferView | null | undefined): string | null {
+    // Handle null / undefined input
     if (buffer == null) {
       return null;
     }
+
+    const bytes: Uint8Array = Utils.normalizeToUint8Array(buffer);
+
+    // Handle empty input
+    if (bytes.length === 0) {
+      return null;
+    }
+
     if (Utils.isNode) {
-      return Buffer.from(buffer).toString("base64");
+      return Buffer.from(bytes).toString("base64");
     } else {
       let binary = "";
-      const bytes = new Uint8Array(buffer);
       for (let i = 0; i < bytes.byteLength; i++) {
         binary += String.fromCharCode(bytes[i]);
       }
       return Utils.global.btoa(binary);
+    }
+  }
+
+  /**
+   * Normalizes input into a Uint8Array so we always have a uniform,
+   * byte-level view of the data. This avoids dealing with differences
+   * between ArrayBuffer (raw memory with no indexing) and other typed
+   * views (which may have element sizes, offsets, and lengths).
+   * @param buffer ArrayBuffer or ArrayBufferView (e.g. Uint8Array, DataView, etc.)
+   */
+  private static normalizeToUint8Array(buffer: ArrayBuffer | ArrayBufferView): Uint8Array {
+    /**
+     * 1) Uint8Array: already bytes → use directly.
+     * 2) ArrayBuffer: wrap whole buffer.
+     * 3) Other ArrayBufferView (e.g., DataView, Int32Array):
+     *    wrap the view’s window (byteOffset..byteOffset+byteLength).
+     */
+    if (buffer instanceof Uint8Array) {
+      return buffer;
+    } else if (buffer instanceof ArrayBuffer) {
+      return new Uint8Array(buffer);
+    } else {
+      const view = buffer as ArrayBufferView;
+      return new Uint8Array(view.buffer, view.byteOffset, view.byteLength);
     }
   }
 

--- a/libs/common/src/platform/misc/utils.ts
+++ b/libs/common/src/platform/misc/utils.ts
@@ -151,8 +151,12 @@ export class Utils {
    *
    * Returns:
    * - Base64 string for non-empty inputs,
-   * - null if `buffer` is `null` or `undefined` or for empty inputs (length 0)
+   * - null if `buffer` is `null` or `undefined`
+   * - empty string if `buffer` is empty (0 bytes)
    */
+  static fromBufferToB64(buffer: null | undefined): null;
+  static fromBufferToB64(buffer: ArrayBuffer): string;
+  static fromBufferToB64(buffer: ArrayBufferView): string;
   static fromBufferToB64(buffer: ArrayBuffer | ArrayBufferView | null | undefined): string | null {
     // Handle null / undefined input
     if (buffer == null) {
@@ -163,7 +167,7 @@ export class Utils {
 
     // Handle empty input
     if (bytes.length === 0) {
-      return null;
+      return "";
     }
 
     if (Utils.isNode) {


### PR DESCRIPTION
## 🎟️ Tracking
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-26186

I first discovered the issue here: https://github.com/bitwarden/clients/pull/16007/files#diff-8204084e4ff23efa6f4e62286432fea59ae914706140ba21a0b1c06cab29bd5dR162

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
`Utils.fromBufferToB64` only accepts ArrayBuffer inputs. This means callers cannot call `Utils.fromBufferToB64(<Uint8Array>)` without getting a `Type '"Uint8Array"' is not assignable to type '"ArrayBuffer"'.ts(2345)` error. We should update `fromBufferToB64` to broaden its signature to support an `ArrayBufferView` (e.g., `Uint8Array`) as we historically call it with `Uint8Array` anyway.



## 📸 Screenshots
<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
n/a

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
