### PR TITLE
[PM-18717] Fix multiple organization situation for Free Families Policy sponsorship

### DIFF
--- a/apps/web/src/app/billing/services/free-families-policy.service.ts
+++ b/apps/web/src/app/billing/services/free-families-policy.service.ts
@@ -19,12 +19,6 @@ interface EnterpriseOrgStatus {
 
 @Injectable({ providedIn: "root" })
 export class FreeFamiliesPolicyService {
-  protected enterpriseOrgStatus: EnterpriseOrgStatus = {
-    isFreeFamilyPolicyEnabled: false,
-    belongToOneEnterpriseOrgs: false,
-    belongToMultipleEnterpriseOrgs: false,
-  };
-
   constructor(
     private policyService: PolicyService,
     private organizationService: OrganizationService,
@@ -104,9 +98,11 @@ export class FreeFamiliesPolicyService {
     if (!orgStatus) {
       return false;
     }
-    const { belongToOneEnterpriseOrgs, isFreeFamilyPolicyEnabled } = orgStatus;
+    const { isFreeFamilyPolicyEnabled } = orgStatus;
     const hasSponsorshipOrgs = organizations.some((org) => org.canManageSponsorships);
-    return hasSponsorshipOrgs && !(belongToOneEnterpriseOrgs && isFreeFamilyPolicyEnabled);
+
+    // Hide if ANY organization has the policy enabled
+    return hasSponsorshipOrgs && !isFreeFamilyPolicyEnabled;
   }
 
   checkEnterpriseOrganizationsAndFetchPolicy(): Observable<EnterpriseOrgStatus> {
@@ -122,16 +118,12 @@ export class FreeFamiliesPolicyService {
     const { belongToOneEnterpriseOrgs, belongToMultipleEnterpriseOrgs } =
       this.evaluateEnterpriseOrganizations(organizations);
 
-    if (!belongToOneEnterpriseOrgs) {
-      return of({
-        isFreeFamilyPolicyEnabled: false,
-        belongToOneEnterpriseOrgs,
-        belongToMultipleEnterpriseOrgs,
-      });
-    }
+    // Get all enterprise organization IDs
+    const enterpriseOrgIds = organizations
+      .filter((org) => org.canManageSponsorships)
+      .map((org) => org.id);
 
-    const organizationId = this.getOrganizationIdForOneEnterprise(organizations);
-    if (!organizationId) {
+    if (enterpriseOrgIds.length === 0) {
       return of({
         isFreeFamilyPolicyEnabled: false,
         belongToOneEnterpriseOrgs,
@@ -146,7 +138,7 @@ export class FreeFamiliesPolicyService {
       ),
       map((policies) => ({
         isFreeFamilyPolicyEnabled: policies.some(
-          (policy) => policy.organizationId === organizationId && policy.enabled,
+          (policy) => enterpriseOrgIds.includes(policy.organizationId) && policy.enabled,
         ),
         belongToOneEnterpriseOrgs,
         belongToMultipleEnterpriseOrgs,
@@ -165,10 +157,5 @@ export class FreeFamiliesPolicyService {
       belongToOneEnterpriseOrgs: count === 1,
       belongToMultipleEnterpriseOrgs: count > 1,
     };
-  }
-
-  private getOrganizationIdForOneEnterprise(organizations: any[]): string | null {
-    const enterpriseOrganizations = organizations.filter((org) => org.canManageSponsorships);
-    return enterpriseOrganizations.length === 1 ? enterpriseOrganizations[0].id : null;
   }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-18717

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Resolves a defect where the "Remove Free Bitwarden Families sponsorship" is always off if the user belongs to more than one organization.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->


https://github.com/user-attachments/assets/b6208c7f-4e08-4260-8822-85263afbd71e



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
