### PR TITLE
Turn inline menu experience off if the host page is aggressively taking over the top-layer

### DIFF
--- a/apps/browser/src/autofill/overlay/inline-menu/content/autofill-inline-menu-content.service.ts
+++ b/apps/browser/src/autofill/overlay/inline-menu/content/autofill-inline-menu-content.service.ts
@@ -22,6 +22,8 @@ import {
 import { AutofillInlineMenuButtonIframe } from "../iframe-content/autofill-inline-menu-button-iframe";
 import { AutofillInlineMenuListIframe } from "../iframe-content/autofill-inline-menu-list-iframe";
 
+const TopLayerRefreshBackoffThresholds = { countLimit: 5, timeSpanLimit: 3000 };
+
 export class AutofillInlineMenuContentService implements AutofillInlineMenuContentServiceInterface {
   private readonly sendExtensionMessage = sendExtensionMessage;
   private readonly generateRandomCustomElementName = generateRandomCustomElementName;
@@ -35,6 +37,11 @@ export class AutofillInlineMenuContentService implements AutofillInlineMenuConte
   private bodyMutationObserver: MutationObserver;
   private inlineMenuElementsMutationObserver: MutationObserver;
   private containerElementMutationObserver: MutationObserver;
+  private topLayerRefreshCountWithinTimeThreshold: number = 0;
+  private lastTrackedTopLayerRefreshTimestamp = Date.now();
+  // Distinct from preventing inline menu script injection, this is for cases where the page
+  // is subsequently determined to be risky.
+  private inlineMenuEnabled = true;
   private mutationObserverIterations = 0;
   private mutationObserverIterationsResetTimeout: number | NodeJS.Timeout;
   private handlePersistentLastChildOverrideTimeout: number | NodeJS.Timeout;
@@ -430,7 +437,7 @@ export class AutofillInlineMenuContentService implements AutofillInlineMenuConte
   private checkPageRisks = async () => {
     const pageIsOpaque = await this.getPageIsOpaque();
 
-    const risksFound = !pageIsOpaque;
+    const risksFound = !pageIsOpaque || !this.inlineMenuEnabled;
 
     if (risksFound) {
       this.closeInlineMenu();
@@ -481,7 +488,32 @@ export class AutofillInlineMenuContentService implements AutofillInlineMenuConte
     return otherTopLayeritems;
   };
 
+  checkAndUpdateTopLayerRefreshCount = () => {
+    const { countLimit, timeSpanLimit } = TopLayerRefreshBackoffThresholds;
+    const now = Date.now();
+    const timeSinceLastTrackedRefresh = now - this.lastTrackedTopLayerRefreshTimestamp;
+    const currentlyWithinTimeThreshold = timeSinceLastTrackedRefresh <= timeSpanLimit;
+    const withinCountThreshold = this.topLayerRefreshCountWithinTimeThreshold <= countLimit;
+
+    if (currentlyWithinTimeThreshold) {
+      if (withinCountThreshold) {
+        this.topLayerRefreshCountWithinTimeThreshold++;
+      } else {
+        // Set inline menu to be off; page is aggressively trying to take top position of top layer
+        this.inlineMenuEnabled = false;
+        void this.checkPageRisks();
+      }
+    } else {
+      this.lastTrackedTopLayerRefreshTimestamp = now;
+      this.topLayerRefreshCountWithinTimeThreshold = 0;
+    }
+  };
+
   refreshTopLayerPosition = () => {
+    if (!this.inlineMenuEnabled) {
+      return;
+    }
+
     const otherTopLayerItems = this.getUnownedTopLayerItems();
 
     // No need to refresh if there are no other top-layer items
@@ -495,6 +527,7 @@ export class AutofillInlineMenuContentService implements AutofillInlineMenuConte
     const listInDocument =
       this.listElement &&
       (globalThis.document.getElementsByTagName(this.listElement.tagName)[0] as HTMLElement);
+
     if (buttonInDocument) {
       buttonInDocument.hidePopover();
       buttonInDocument.showPopover();
@@ -503,6 +536,10 @@ export class AutofillInlineMenuContentService implements AutofillInlineMenuConte
     if (listInDocument) {
       listInDocument.hidePopover();
       listInDocument.showPopover();
+    }
+
+    if (buttonInDocument || listInDocument) {
+      this.checkAndUpdateTopLayerRefreshCount();
     }
   };
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-25269](https://bitwarden.atlassian.net/browse/PM-25269)

## 📔 Objective

If a script is consistently competing for top-layer top visibility, we need to (temporarily) disable the inline menu, as a security concern.

## 📸 Screenshots

https://github.com/user-attachments/assets/ce830471-5a87-43c6-ba5e-d66623980924

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
