### PR TITLE
[PM-25613] Add report trigger logic

### DIFF
--- a/bitwarden_license/bit-common/src/dirt/reports/risk-insights/index.ts
+++ b/bitwarden_license/bit-common/src/dirt/reports/risk-insights/index.ts
@@ -1,1 +1,2 @@
 export * from "./services";
+export * from "./models";

--- a/bitwarden_license/bit-common/src/dirt/reports/risk-insights/models/api-models.types.ts
+++ b/bitwarden_license/bit-common/src/dirt/reports/risk-insights/models/api-models.types.ts
@@ -1,7 +1,12 @@
-import { EncryptedString } from "@bitwarden/common/key-management/crypto/models/enc-string";
+import { EncString } from "@bitwarden/common/key-management/crypto/models/enc-string";
+import { BaseResponse } from "@bitwarden/common/models/response/base.response";
 import { OrganizationId } from "@bitwarden/common/types/guid";
 
-import { PasswordHealthReportApplicationId, RiskInsightsReport } from "./report-models";
+import {
+  OrganizationReportSummary,
+  PasswordHealthReportApplicationId,
+  RiskInsightsReport,
+} from "./report-models";
 
 // -------------------- Password Health Report Models --------------------
 /**
@@ -35,15 +40,78 @@ export interface SaveRiskInsightsReportRequest {
   data: RiskInsightsReport;
 }
 
-export interface SaveRiskInsightsReportResponse {
+export class SaveRiskInsightsReportResponse extends BaseResponse {
   id: string;
+
+  constructor(response: any) {
+    super(response);
+    this.id = this.getResponseProperty("organizationId");
+  }
+}
+export function isSaveRiskInsightsReportResponse(obj: any): obj is SaveRiskInsightsReportResponse {
+  return obj && typeof obj.id === "string" && obj.id !== "";
 }
 
-export interface GetRiskInsightsReportResponse {
+export class GetRiskInsightsReportResponse extends BaseResponse {
   id: string;
   organizationId: OrganizationId;
   // TODO Update to use creationDate from server
   date: string;
-  reportData: EncryptedString;
-  contentEncryptionKey: EncryptedString;
+  reportData: EncString;
+  contentEncryptionKey: EncString;
+
+  constructor(response: any) {
+    super(response);
+
+    this.id = this.getResponseProperty("organizationId");
+    this.organizationId = this.getResponseProperty("organizationId");
+    this.date = this.getResponseProperty("date");
+    this.reportData = new EncString(this.getResponseProperty("reportData"));
+    this.contentEncryptionKey = new EncString(this.getResponseProperty("contentEncryptionKey"));
+  }
+}
+
+export class GetRiskInsightsSummaryResponse extends BaseResponse {
+  id: string;
+  organizationId: OrganizationId;
+  encryptedData: EncString; // Decrypted as OrganizationReportSummary
+  contentEncryptionKey: EncString;
+
+  constructor(response: any) {
+    super(response);
+    // TODO Handle taking array of summary data and converting to array
+    this.id = this.getResponseProperty("id");
+    this.organizationId = this.getResponseProperty("organizationId");
+    this.encryptedData = this.getResponseProperty("encryptedData");
+    this.contentEncryptionKey = this.getResponseProperty("contentEncryptionKey");
+  }
+
+  // TODO
+  getSummary(): OrganizationReportSummary {
+    return {
+      totalMemberCount: 0,
+      totalCriticalMemberCount: 0,
+      totalAtRiskMemberCount: 0,
+      totalCriticalAtRiskMemberCount: 0,
+      totalApplicationCount: 0,
+      totalCriticalApplicationCount: 0,
+      totalAtRiskApplicationCount: 0,
+      totalCriticalAtRiskApplicationCount: 0,
+      newApplications: [],
+    };
+  }
+}
+export class GetRiskInsightsApplicationDataResponse extends BaseResponse {
+  reportId: string;
+  organizationId: OrganizationId;
+  encryptedData: EncString;
+  contentEncryptionKey: EncString;
+
+  constructor(response: any) {
+    super(response);
+    this.reportId = this.getResponseProperty("reportId");
+    this.organizationId = this.getResponseProperty("organizationId");
+    this.encryptedData = this.getResponseProperty("encryptedData");
+    this.contentEncryptionKey = this.getResponseProperty("contentEncryptionKey");
+  }
 }

--- a/bitwarden_license/bit-common/src/dirt/reports/risk-insights/models/index.ts
+++ b/bitwarden_license/bit-common/src/dirt/reports/risk-insights/models/index.ts
@@ -1,0 +1,3 @@
+export * from "./api-models.types";
+export * from "./password-health";
+export * from "./report-models";

--- a/bitwarden_license/bit-common/src/dirt/reports/risk-insights/models/password-health.ts
+++ b/bitwarden_license/bit-common/src/dirt/reports/risk-insights/models/password-health.ts
@@ -1,9 +1,9 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
+import { EncString } from "@bitwarden/common/key-management/crypto/models/enc-string";
 import { OrganizationId } from "@bitwarden/common/types/guid";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { BadgeVariant } from "@bitwarden/components";
-import { EncString } from "@bitwarden/sdk-internal";
 
 import { ApplicationHealthReportDetail } from "./report-models";
 
@@ -40,7 +40,7 @@ export type ExposedPasswordDetail = {
 export interface EncryptedDataWithKey {
   organizationId: OrganizationId;
   encryptedData: EncString;
-  encryptionKey: EncString;
+  contentEncryptionKey: EncString;
 }
 
 export type LEGACY_MemberDetailsFlat = {
@@ -76,10 +76,3 @@ export type LEGACY_CipherHealthReportUriDetail = {
   trimmedUri: string;
   cipher: CipherView;
 };
-
-export interface EncryptedDataModel {
-  organizationId: OrganizationId;
-  encryptedData: string;
-  encryptionKey: string;
-  date: Date;
-}

--- a/bitwarden_license/bit-common/src/dirt/reports/risk-insights/models/report-models.ts
+++ b/bitwarden_license/bit-common/src/dirt/reports/risk-insights/models/report-models.ts
@@ -158,7 +158,7 @@ export interface RiskInsightsReport {
   organizationId: OrganizationId;
   date: string;
   reportData: string;
-  reportKey: string;
+  contentEncryptionKey: string;
 }
 
 export type ReportScore = { label: string; badgeVariant: BadgeVariant; sortOrder: number };

--- a/bitwarden_license/bit-common/src/dirt/reports/risk-insights/services/risk-insights-api.service.spec.ts
+++ b/bitwarden_license/bit-common/src/dirt/reports/risk-insights/services/risk-insights-api.service.spec.ts
@@ -1,11 +1,19 @@
 import { mock } from "jest-mock-extended";
+import { firstValueFrom } from "rxjs";
 
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
+import { EncString } from "@bitwarden/common/key-management/crypto/models/enc-string";
 import { makeEncString } from "@bitwarden/common/spec";
 import { OrganizationId, OrganizationReportId } from "@bitwarden/common/types/guid";
 
-import { SaveRiskInsightsReportRequest } from "../models/api-models.types";
-import { EncryptedDataModel } from "../models/password-health";
+import {
+  GetRiskInsightsApplicationDataResponse,
+  GetRiskInsightsReportResponse,
+  GetRiskInsightsSummaryResponse,
+  SaveRiskInsightsReportRequest,
+  SaveRiskInsightsReportResponse,
+} from "../models/api-models.types";
+import { EncryptedDataWithKey } from "../models/password-health";
 
 import { RiskInsightsApiService } from "./risk-insights-api.service";
 
@@ -13,14 +21,11 @@ describe("RiskInsightsApiService", () => {
   let service: RiskInsightsApiService;
   const mockApiService = mock<ApiService>();
 
+  const mockId = "id";
   const orgId = "org1" as OrganizationId;
-
-  const getRiskInsightsReportResponse = {
-    organizationId: orgId,
-    date: new Date().toISOString(),
-    reportData: "test",
-    reportKey: "test-key",
-  };
+  const mockReportId = "report-1";
+  const mockKey = "encryption-key-1";
+  const mockData = "encrypted-data";
 
   const reportData = makeEncString("test").encryptedString?.toString() ?? "";
   const reportKey = makeEncString("test-key").encryptedString?.toString() ?? "";
@@ -30,11 +35,8 @@ describe("RiskInsightsApiService", () => {
       organizationId: orgId,
       date: new Date().toISOString(),
       reportData: reportData,
-      reportKey: reportKey,
+      contentEncryptionKey: reportKey,
     },
-  };
-  const saveRiskInsightsReportResponse = {
-    ...saveRiskInsightsReportRequest.data,
   };
 
   beforeEach(() => {
@@ -45,11 +47,19 @@ describe("RiskInsightsApiService", () => {
     expect(service).toBeTruthy();
   });
 
-  it("Get Report: should call apiService.send with correct parameters and return the response for getRiskInsightsReport ", (done) => {
+  it("getRiskInsightsReport$ should call apiService.send with correct parameters and return the response", () => {
+    const getRiskInsightsReportResponse = {
+      id: mockId,
+      organizationId: orgId,
+      date: new Date().toISOString(),
+      reportData: mockData,
+      contentEncryptionKey: mockKey,
+    };
+
     mockApiService.send.mockReturnValue(Promise.resolve(getRiskInsightsReportResponse));
 
     service.getRiskInsightsReport$(orgId).subscribe((result) => {
-      expect(result).toEqual(getRiskInsightsReportResponse);
+      expect(result).toEqual(new GetRiskInsightsReportResponse(getRiskInsightsReportResponse));
       expect(mockApiService.send).toHaveBeenCalledWith(
         "GET",
         `/reports/organizations/${orgId.toString()}/latest`,
@@ -57,187 +67,173 @@ describe("RiskInsightsApiService", () => {
         true,
         true,
       );
-      done();
     });
   });
 
-  it("Get Report: should return null if apiService.send rejects with 404 error for getRiskInsightsReport", (done) => {
+  it("getRiskInsightsReport$ should return null if apiService.send rejects with 404 error", async () => {
     const error = { statusCode: 404 };
     mockApiService.send.mockReturnValue(Promise.reject(error));
 
-    service.getRiskInsightsReport$(orgId).subscribe((result) => {
-      expect(result).toBeNull();
-      done();
-    });
+    const result = await firstValueFrom(service.getRiskInsightsReport$(orgId));
+
+    expect(result).toBeNull();
   });
 
-  it("Get Report: should throw error if apiService.send rejects with non-404 error for getRiskInsightsReport", (done) => {
+  it("getRiskInsightsReport$ should propagate errors if apiService.send rejects 500 server error", async () => {
     const error = { statusCode: 500, message: "Server error" };
     mockApiService.send.mockReturnValue(Promise.reject(error));
 
-    service.getRiskInsightsReport$(orgId).subscribe({
-      next: () => {
-        // Should not reach here
-        fail("Expected error to be thrown");
-      },
-      error: () => {
-        expect(mockApiService.send).toHaveBeenCalledWith(
-          "GET",
-          `/reports/organizations/${orgId.toString()}/latest`,
-          null,
-          true,
-          true,
-        );
-        done();
-      },
-      complete: () => {
-        done();
-      },
-    });
+    await expect(firstValueFrom(service.getRiskInsightsReport$(orgId))).rejects.toEqual(error);
+
+    expect(mockApiService.send).toHaveBeenCalledWith(
+      "GET",
+      `/reports/organizations/${orgId.toString()}/latest`,
+      null,
+      true,
+      true,
+    );
   });
 
-  it("Save Report: should call apiService.send with correct parameters for saveRiskInsightsReport", (done) => {
-    mockApiService.send.mockReturnValue(Promise.resolve(saveRiskInsightsReportResponse));
+  it("saveRiskInsightsReport$ should call apiService.send with correct parameters", async () => {
+    mockApiService.send.mockReturnValue(Promise.resolve(saveRiskInsightsReportRequest));
 
-    service.saveRiskInsightsReport$(saveRiskInsightsReportRequest, orgId).subscribe((result) => {
-      expect(result).toEqual(saveRiskInsightsReportResponse);
-      expect(mockApiService.send).toHaveBeenCalledWith(
-        "POST",
-        `/reports/organizations/${orgId.toString()}`,
-        saveRiskInsightsReportRequest.data,
-        true,
-        true,
-      );
-      done();
-    });
+    const result = await firstValueFrom(
+      service.saveRiskInsightsReport$(saveRiskInsightsReportRequest, orgId),
+    );
+
+    expect(result).toEqual(new SaveRiskInsightsReportResponse(saveRiskInsightsReportRequest));
+    expect(mockApiService.send).toHaveBeenCalledWith(
+      "POST",
+      `/reports/organizations/${orgId.toString()}`,
+      saveRiskInsightsReportRequest.data,
+      true,
+      true,
+    );
   });
 
-  it("Save Report: should propagate errors from apiService.send for saveRiskInsightsReport - 1", (done) => {
+  it("saveRiskInsightsReport$ should propagate errors from apiService.send for saveRiskInsightsReport - 1", async () => {
     const error = { statusCode: 500, message: "Internal Server Error" };
     mockApiService.send.mockReturnValue(Promise.reject(error));
 
-    service.saveRiskInsightsReport$(saveRiskInsightsReportRequest, orgId).subscribe({
-      next: () => {
-        fail("Expected error to be thrown");
-      },
-      error: () => {
-        expect(mockApiService.send).toHaveBeenCalledWith(
-          "POST",
-          `/reports/organizations/${orgId.toString()}`,
-          saveRiskInsightsReportRequest.data,
-          true,
-          true,
-        );
-        done();
-      },
-      complete: () => {
-        done();
-      },
-    });
+    await expect(
+      firstValueFrom(service.saveRiskInsightsReport$(saveRiskInsightsReportRequest, orgId)),
+    ).rejects.toEqual(error);
+
+    expect(mockApiService.send).toHaveBeenCalledWith(
+      "POST",
+      `/reports/organizations/${orgId.toString()}`,
+      saveRiskInsightsReportRequest.data,
+      true,
+      true,
+    );
   });
 
-  it("Save Report: should propagate network errors from apiService.send for saveRiskInsightsReport - 2", (done) => {
+  it("saveRiskInsightsReport$ should propagate network errors from apiService.send - 2", async () => {
     const error = new Error("Network error");
     mockApiService.send.mockReturnValue(Promise.reject(error));
 
-    service.saveRiskInsightsReport$(saveRiskInsightsReportRequest, orgId).subscribe({
-      next: () => {
-        fail("Expected error to be thrown");
-      },
-      error: () => {
-        expect(mockApiService.send).toHaveBeenCalledWith(
-          "POST",
-          `/reports/organizations/${orgId.toString()}`,
-          saveRiskInsightsReportRequest.data,
-          true,
-          true,
-        );
-        done();
-      },
-      complete: () => {
-        done();
-      },
-    });
+    await expect(
+      firstValueFrom(service.saveRiskInsightsReport$(saveRiskInsightsReportRequest, orgId)),
+    ).rejects.toEqual(error);
+
+    expect(mockApiService.send).toHaveBeenCalledWith(
+      "POST",
+      `/reports/organizations/${orgId.toString()}`,
+      saveRiskInsightsReportRequest.data,
+      true,
+      true,
+    );
   });
 
-  it("Get Summary: should call apiService.send with correct parameters and return an Observable", (done) => {
+  it("getRiskInsightsSummary$ should call apiService.send with correct parameters and return an Observable", async () => {
     const minDate = new Date("2024-01-01");
     const maxDate = new Date("2024-01-31");
-    const mockResponse: EncryptedDataModel[] = [{ encryptedData: "abc" } as EncryptedDataModel];
+    const mockResponse = [
+      {
+        reportId: mockReportId,
+        organizationId: orgId,
+        encryptedData: mockData,
+        contentEncryptionKey: mockKey,
+      },
+    ];
 
     mockApiService.send.mockResolvedValueOnce(mockResponse);
 
-    service.getRiskInsightsSummary$(orgId, minDate, maxDate).subscribe((result) => {
-      expect(mockApiService.send).toHaveBeenCalledWith(
-        "GET",
-        `/reports/organizations/${orgId.toString()}/data/summary?startDate=${minDate.toISOString().split("T")[0]}&endDate=${maxDate.toISOString().split("T")[0]}`,
-        null,
-        true,
-        true,
-      );
-      expect(result).toEqual(mockResponse);
-      done();
-    });
+    const result = await firstValueFrom(service.getRiskInsightsSummary$(orgId, minDate, maxDate));
+
+    expect(mockApiService.send).toHaveBeenCalledWith(
+      "GET",
+      `/reports/organizations/${orgId.toString()}/data/summary?startDate=${minDate.toISOString().split("T")[0]}&endDate=${maxDate.toISOString().split("T")[0]}`,
+      null,
+      true,
+      true,
+    );
+    expect(result).toEqual(new GetRiskInsightsSummaryResponse(mockResponse));
   });
 
-  it("Update Summary: should call apiService.send with correct parameters and return an Observable", (done) => {
-    const data: EncryptedDataModel = { encryptedData: "xyz" } as EncryptedDataModel;
+  it("updateRiskInsightsSummary$ should call apiService.send with correct parameters and return an Observable", async () => {
+    const data: EncryptedDataWithKey = {
+      organizationId: orgId,
+      encryptedData: new EncString(mockData),
+      contentEncryptionKey: new EncString(mockKey),
+    };
+
     const reportId = "report123" as OrganizationReportId;
 
     mockApiService.send.mockResolvedValueOnce(undefined);
 
-    service.updateRiskInsightsSummary$(data, orgId, reportId).subscribe((result) => {
-      expect(mockApiService.send).toHaveBeenCalledWith(
-        "PATCH",
-        `/reports/organizations/${orgId.toString()}/data/summary/${reportId.toString()}`,
-        data,
-        true,
-        true,
-      );
-      expect(result).toBeUndefined();
-      done();
-    });
+    const result = await firstValueFrom(service.updateRiskInsightsSummary$(data, orgId, reportId));
+
+    expect(mockApiService.send).toHaveBeenCalledWith(
+      "PATCH",
+      `/reports/organizations/${orgId.toString()}/data/summary/${reportId.toString()}`,
+      data,
+      true,
+      true,
+    );
+    expect(result).toBeUndefined();
   });
 
-  it("Get Applications: should call apiService.send with correct parameters and return an Observable", (done) => {
+  it("getRiskInsightsApplicationData$ should call apiService.send with correct parameters and return an Observable", async () => {
     const reportId = "report123" as OrganizationReportId;
-    const mockResponse: EncryptedDataModel | null = {
-      encryptedData: "abc",
-    } as EncryptedDataModel;
+    const mockResponse: EncryptedDataWithKey | null = {
+      organizationId: orgId,
+      encryptedData: new EncString(mockData),
+      contentEncryptionKey: new EncString(mockKey),
+    };
 
     mockApiService.send.mockResolvedValueOnce(mockResponse);
 
-    service.getRiskInsightsApplicationData$(orgId, reportId).subscribe((result) => {
-      expect(mockApiService.send).toHaveBeenCalledWith(
-        "GET",
-        `/reports/organizations/${orgId.toString()}/data/application/${reportId.toString()}`,
-        null,
-        true,
-        true,
-      );
-      expect(result).toEqual(mockResponse);
-      done();
-    });
+    const result = await firstValueFrom(service.getRiskInsightsApplicationData$(orgId, reportId));
+    expect(mockApiService.send).toHaveBeenCalledWith(
+      "GET",
+      `/reports/organizations/${orgId.toString()}/data/application/${reportId.toString()}`,
+      null,
+      true,
+      true,
+    );
+    expect(result).toEqual(new GetRiskInsightsApplicationDataResponse(mockResponse));
   });
 
-  it("Update Applications: should call apiService.send with correct parameters and return an Observable", (done) => {
-    const applicationData: EncryptedDataModel = { encryptedData: "xyz" } as EncryptedDataModel;
+  it("updateRiskInsightsApplicationData$ should call apiService.send with correct parameters and return an Observable", async () => {
+    const applicationData: EncryptedDataWithKey = {
+      organizationId: orgId,
+      encryptedData: new EncString(mockData),
+      contentEncryptionKey: new EncString(mockKey),
+    };
     const reportId = "report123" as OrganizationReportId;
 
     mockApiService.send.mockResolvedValueOnce(undefined);
-
-    service
-      .updateRiskInsightsApplicationData$(applicationData, orgId, reportId)
-      .subscribe((result) => {
-        expect(mockApiService.send).toHaveBeenCalledWith(
-          "PATCH",
-          `/reports/organizations/${orgId.toString()}/data/application/${reportId.toString()}`,
-          applicationData,
-          true,
-          true,
-        );
-        expect(result).toBeUndefined();
-        done();
-      });
+    const result = await firstValueFrom(
+      service.updateRiskInsightsApplicationData$(applicationData, orgId, reportId),
+    );
+    expect(mockApiService.send).toHaveBeenCalledWith(
+      "PATCH",
+      `/reports/organizations/${orgId.toString()}/data/application/${reportId.toString()}`,
+      applicationData,
+      true,
+      true,
+    );
+    expect(result).toBeUndefined();
   });
 });

--- a/bitwarden_license/bit-common/src/dirt/reports/risk-insights/services/risk-insights-data.service.ts
+++ b/bitwarden_license/bit-common/src/dirt/reports/risk-insights/services/risk-insights-data.service.ts
@@ -1,5 +1,14 @@
 import { BehaviorSubject, firstValueFrom, Observable, of } from "rxjs";
-import { finalize, switchMap, withLatestFrom } from "rxjs/operators";
+import {
+  distinctUntilChanged,
+  exhaustMap,
+  filter,
+  finalize,
+  map,
+  switchMap,
+  tap,
+  withLatestFrom,
+} from "rxjs/operators";
 
 import {
   getOrganizationById,
@@ -16,6 +25,7 @@ import {
   DrawerType,
   ApplicationHealthReportDetail,
   ApplicationHealthReportDetailEnriched,
+  ReportDetailsAndSummary,
 } from "../models/report-models";
 
 import { CriticalAppsService } from "./critical-apps.service";
@@ -53,12 +63,22 @@ export class RiskInsightsDataService {
   private errorSubject = new BehaviorSubject<string | null>(null);
   error$ = this.errorSubject.asObservable();
 
+  // ---------------------- Drawer Variables ----------------------
   openDrawer = false;
   drawerInvokerId: string = "";
   activeDrawerType: DrawerType = DrawerType.None;
   atRiskMemberDetails: AtRiskMemberDetail[] = [];
   appAtRiskMembers: AppAtRiskMembersDialogParams | null = null;
   atRiskAppDetails: AtRiskApplicationDetail[] | null = null;
+
+  // ------------------------- Report Variables ----------------
+  // The last run report details
+  private reportResultsSubject = new BehaviorSubject<ReportDetailsAndSummary | null>(null);
+  reportResults$ = this.reportResultsSubject.asObservable();
+  // Is a report being generated
+  private isRunningReportSubject = new BehaviorSubject<boolean>(false);
+  isRunningReport$ = this.isRunningReportSubject.asObservable();
+  // The error from report generation if there was an error
 
   constructor(
     private accountService: AccountService,
@@ -75,7 +95,7 @@ export class RiskInsightsDataService {
       this.userIdSubject.next(userId);
     }
 
-    // [FIXME] getOrganizationById is now deprecated - update when we can
+    // [FIXME] getOrganizationById is now deprecated - replace with appropriate method
     // Fetch organization details
     const org = await firstValueFrom(
       this.organizationService.organizations$(userId).pipe(getOrganizationById(organizationId)),
@@ -90,20 +110,18 @@ export class RiskInsightsDataService {
     // Load critical applications for organization
     await this.criticalAppsService.loadOrganizationContext(organizationId, userId);
 
-    // TODO: PM-25613
-    // // Load existing report
+    // Load existing report
+    this.fetchLastReport(organizationId, userId);
 
-    // this.fetchLastReport(organizationId, userId);
-
-    // // Setup new report generation
-    // this._runApplicationsReport().subscribe({
-    //   next: (result) => {
-    //     this.isRunningReportSubject.next(false);
-    //   },
-    //   error: () => {
-    //     this.errorSubject.next("Failed to save report");
-    //   },
-    // });
+    // Setup new report generation
+    this._runApplicationsReport().subscribe({
+      next: (result) => {
+        this.isRunningReportSubject.next(false);
+      },
+      error: () => {
+        this.errorSubject.next("Failed to save report");
+      },
+    });
   }
 
   /**
@@ -230,4 +248,87 @@ export class RiskInsightsDataService {
     this.atRiskAppDetails = null;
     this.drawerInvokerId = "";
   };
+
+  // ------------------- Trigger Report Generation -------------------
+  /** Trigger generating a report based on the current applications */
+  triggerReport(): void {
+    this.isRunningReportSubject.next(true);
+  }
+
+  /**
+   * Fetches the applications report and updates the applicationsSubject.
+   * @param organizationId The ID of the organization.
+   */
+  fetchLastReport(organizationId: OrganizationId, userId: UserId): void {
+    this.isLoadingSubject.next(true);
+
+    this.reportService
+      .getRiskInsightsReport$(organizationId, userId)
+      .pipe(
+        switchMap((report) => {
+          return this.enrichReportData$(report.data).pipe(
+            map((enrichedReport) => ({
+              data: enrichedReport,
+              summary: report.summary,
+            })),
+          );
+        }),
+        finalize(() => {
+          this.isLoadingSubject.next(false);
+        }),
+      )
+      .subscribe({
+        next: ({ data, summary }) => {
+          this.reportResultsSubject.next({
+            data,
+            summary,
+            dateCreated: new Date(),
+          });
+          this.errorSubject.next(null);
+          this.isLoadingSubject.next(false);
+        },
+        error: () => {
+          this.errorSubject.next("Failed to fetch report");
+          this.reportResultsSubject.next(null);
+          this.isLoadingSubject.next(false);
+        },
+      });
+  }
+
+  private _runApplicationsReport() {
+    return this.isRunningReport$.pipe(
+      distinctUntilChanged(),
+      filter((isRunning) => isRunning),
+      withLatestFrom(this.organizationDetails$, this.userId$),
+      exhaustMap(([_, { organizationId }, userId]) => {
+        if (!organizationId || !userId) {
+          return;
+        }
+
+        // Generate the report
+        return this.reportService.generateApplicationsReport$(organizationId).pipe(
+          map((data) => ({
+            data,
+            summary: this.reportService.generateApplicationsSummary(data),
+          })),
+          switchMap(({ data, summary }) =>
+            this.enrichReportData$(data).pipe(
+              map((enrichedData) => ({ data: enrichedData, summary })),
+            ),
+          ),
+          tap(({ data, summary }) => {
+            this.reportResultsSubject.next({ data, summary, dateCreated: new Date() });
+            this.errorSubject.next(null);
+          }),
+          switchMap(({ data, summary }) => {
+            // Just returns ID
+            return this.reportService.saveRiskInsightsReport$(data, summary, {
+              organizationId,
+              userId,
+            });
+          }),
+        );
+      }),
+    );
+  }
 }

--- a/bitwarden_license/bit-common/src/dirt/reports/risk-insights/services/risk-insights-encryption.service.ts
+++ b/bitwarden_license/bit-common/src/dirt/reports/risk-insights/services/risk-insights-encryption.service.ts
@@ -51,13 +51,13 @@ export class RiskInsightsEncryptionService {
       throw new Error("Encryption failed, encrypted strings are null");
     }
 
-    const encryptedData = dataEncrypted.encryptedString;
-    const encryptionKey = wrappedEncryptionKey.encryptedString;
+    const encryptedData = dataEncrypted;
+    const contentEncryptionKeyString = wrappedEncryptionKey;
 
-    const encryptedDataPacket = {
-      organizationId: organizationId,
-      encryptedData: encryptedData,
-      encryptionKey: encryptionKey,
+    const encryptedDataPacket: EncryptedDataWithKey = {
+      organizationId,
+      encryptedData,
+      contentEncryptionKey: contentEncryptionKeyString,
     };
 
     return encryptedDataPacket;

--- a/bitwarden_license/bit-common/src/dirt/reports/risk-insights/services/risk-insights-report.service.spec.ts
+++ b/bitwarden_license/bit-common/src/dirt/reports/risk-insights/services/risk-insights-report.service.spec.ts
@@ -3,14 +3,20 @@ import { firstValueFrom, of } from "rxjs";
 import { ZXCVBNResult } from "zxcvbn";
 
 import { AuditService } from "@bitwarden/common/abstractions/audit.service";
-import { EncryptedString } from "@bitwarden/common/key-management/crypto/models/enc-string";
+import { EncString } from "@bitwarden/common/key-management/crypto/models/enc-string";
+import { ErrorResponse } from "@bitwarden/common/models/response/error.response";
 import { PasswordStrengthServiceAbstraction } from "@bitwarden/common/tools/password-strength";
 import { OrganizationId, UserId } from "@bitwarden/common/types/guid";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { CipherType } from "@bitwarden/common/vault/enums";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 
-import { GetRiskInsightsReportResponse } from "../models/api-models.types";
+import {
+  GetRiskInsightsReportResponse,
+  SaveRiskInsightsReportResponse,
+} from "../models/api-models.types";
+import { EncryptedDataWithKey } from "../models/password-health";
+import { ApplicationHealthReportDetail, OrganizationReportSummary } from "../models/report-models";
 import { MemberCipherDetailsResponse } from "../response/member-cipher-details.response";
 
 import { mockCiphers } from "./ciphers.mock";
@@ -34,10 +40,20 @@ describe("RiskInsightsReportService", () => {
     decryptRiskInsightsReport: jest.fn().mockResolvedValue("decryptedReportData"),
   });
 
-  // Mock data
-  const mockOrgId = "orgId" as OrganizationId;
+  // Non changing mock data
+  const mockOrganizationId = "orgId" as OrganizationId;
+  const mockUserId = "userId" as UserId;
+  const ENCRYPTED_TEXT = "This data has been encrypted";
+  const ENCRYPTED_KEY = "Re-encrypted Cipher Key";
+  const mockEncryptedText = new EncString(ENCRYPTED_TEXT);
+  const mockEncryptedKey = new EncString(ENCRYPTED_KEY);
+
+  // Changing mock data
   let mockCipherViews: CipherView[];
   let mockMemberDetails: MemberCipherDetailsResponse[];
+  let mockReport: ApplicationHealthReportDetail[];
+  let mockSummary: OrganizationReportSummary;
+  let mockEncryptedReport: EncryptedDataWithKey;
 
   beforeEach(() => {
     pwdStrengthService.getPasswordStrength.mockImplementation((password: string) => {
@@ -106,6 +122,37 @@ describe("RiskInsightsReportService", () => {
         email: "user3@other.com",
       }),
     ];
+
+    mockReport = [
+      {
+        applicationName: "app1",
+        passwordCount: 0,
+        atRiskPasswordCount: 0,
+        atRiskCipherIds: [],
+        memberCount: 0,
+        atRiskMemberCount: 0,
+        memberDetails: [],
+        atRiskMemberDetails: [],
+        cipherIds: [],
+      },
+    ];
+    mockSummary = {
+      totalMemberCount: 0,
+      totalCriticalMemberCount: 0,
+      totalAtRiskMemberCount: 0,
+      totalCriticalAtRiskMemberCount: 0,
+      totalApplicationCount: 0,
+      totalCriticalApplicationCount: 0,
+      totalAtRiskApplicationCount: 0,
+      totalCriticalAtRiskApplicationCount: 0,
+      newApplications: [],
+    };
+
+    mockEncryptedReport = {
+      organizationId: mockOrganizationId,
+      encryptedData: mockEncryptedText,
+      contentEncryptionKey: mockEncryptedKey,
+    };
   });
 
   it("should group and aggregate application health reports correctly", (done) => {
@@ -128,7 +175,7 @@ describe("RiskInsightsReportService", () => {
   });
 
   it("should generate the raw data report correctly", async () => {
-    const result = await firstValueFrom(service.LEGACY_generateRawDataReport$(mockOrgId));
+    const result = await firstValueFrom(service.LEGACY_generateRawDataReport$(mockOrganizationId));
 
     expect(result).toHaveLength(6);
 
@@ -154,7 +201,7 @@ describe("RiskInsightsReportService", () => {
   });
 
   it("should generate the raw data + uri report correctly", async () => {
-    const result = await firstValueFrom(service.generateRawDataUriReport$(mockOrgId));
+    const result = await firstValueFrom(service.generateRawDataUriReport$(mockOrganizationId));
 
     expect(result).toHaveLength(11);
 
@@ -177,7 +224,9 @@ describe("RiskInsightsReportService", () => {
   });
 
   it("should generate applications health report data correctly", async () => {
-    const result = await firstValueFrom(service.LEGACY_generateApplicationsReport$(mockOrgId));
+    const result = await firstValueFrom(
+      service.LEGACY_generateApplicationsReport$(mockOrganizationId),
+    );
 
     expect(result).toHaveLength(8);
 
@@ -219,7 +268,7 @@ describe("RiskInsightsReportService", () => {
 
   it("should generate applications summary data correctly", async () => {
     const reportResult = await firstValueFrom(
-      service.LEGACY_generateApplicationsReport$(mockOrgId),
+      service.LEGACY_generateApplicationsReport$(mockOrganizationId),
     );
     const reportSummary = service.generateApplicationsSummary(reportResult);
 
@@ -230,55 +279,57 @@ describe("RiskInsightsReportService", () => {
   });
 
   describe("saveRiskInsightsReport", () => {
-    it("should not update subjects if save response does not have id", async () => {
-      const organizationId = "orgId" as OrganizationId;
-      const userId = "userId" as UserId;
-      const report = [{ applicationName: "app1" }] as any;
-
-      const encryptedReport = {
-        organizationId: organizationId as OrganizationId,
-        encryptedData: "encryptedData" as EncryptedString,
-        encryptionKey: "encryptionKey" as EncryptedString,
-      };
-
+    it("should not update subjects if save response does not have id", (done) => {
       mockRiskInsightsEncryptionService.encryptRiskInsightsReport.mockResolvedValue(
-        encryptedReport,
+        mockEncryptedReport,
       );
 
-      const saveResponse = { id: "" }; // Simulating no ID in response
+      const saveResponse = new SaveRiskInsightsReportResponse({ id: "" }); // Simulating no ID in response
       mockRiskInsightsApiService.saveRiskInsightsReport$.mockReturnValue(of(saveResponse));
 
-      const reportSubjectSpy = jest.spyOn((service as any).riskInsightsReportSubject, "next");
-      const summarySubjectSpy = jest.spyOn((service as any).riskInsightsSummarySubject, "next");
-
-      await service.saveRiskInsightsReport(organizationId, userId, report);
-
-      expect(reportSubjectSpy).not.toHaveBeenCalled();
-      expect(summarySubjectSpy).not.toHaveBeenCalled();
+      service
+        .saveRiskInsightsReport$(mockReport, mockSummary, {
+          organizationId: mockOrganizationId,
+          userId: mockUserId,
+        })
+        .subscribe({
+          next: (response) => {
+            done.fail("Expected error due to invalid response");
+          },
+          error: (error: unknown) => {
+            if (error instanceof ErrorResponse && error.statusCode) {
+              expect(error.message).toBe("Invalid response from API");
+            }
+            done();
+          },
+        });
     });
+
+    it("should encrypt and save report, then update subjects", async () => {});
   });
 
-  describe("getRiskInsightsReport", () => {
+  describe("getRiskInsightsReport$", () => {
     beforeEach(() => {
       // Reset the mocks before each test
       jest.clearAllMocks();
     });
 
-    it("should call riskInsightsApiService.getRiskInsightsReport with the correct organizationId", () => {
+    it("should call riskInsightsApiService.getRiskInsightsReport$ with the correct organizationId", async () => {
       // we need to ensure that the api is invoked with the specified organizationId
       // here it doesn't matter what the Api returns
       const apiResponse = {
         id: "reportId",
         date: new Date().toISOString(),
-        organizationId: "orgId",
-        reportData: "encryptedReportData",
-        contentEncryptionKey: "encryptionKey",
+        organizationId: mockOrganizationId,
+        reportData: mockEncryptedReport.encryptedData,
+        contentEncryptionKey: mockEncryptedReport.contentEncryptionKey,
       } as GetRiskInsightsReportResponse;
 
       const organizationId = "orgId" as OrganizationId;
       const userId = "userId" as UserId;
       mockRiskInsightsApiService.getRiskInsightsReport$.mockReturnValue(of(apiResponse));
-      service.getRiskInsightsReport(organizationId, userId);
+      await firstValueFrom(service.getRiskInsightsReport$(organizationId, userId));
+
       expect(mockRiskInsightsApiService.getRiskInsightsReport$).toHaveBeenCalledWith(
         organizationId,
       );
@@ -301,8 +352,8 @@ describe("RiskInsightsReportService", () => {
         id: "reportId",
         date: new Date().toISOString(),
         organizationId: organizationId as OrganizationId,
-        reportData: "encryptedReportData",
-        contentEncryptionKey: "encryptionKey",
+        reportData: mockEncryptedReport.encryptedData,
+        contentEncryptionKey: mockEncryptedReport.contentEncryptionKey,
       } as GetRiskInsightsReportResponse;
 
       const decryptedReport = {
@@ -313,12 +364,7 @@ describe("RiskInsightsReportService", () => {
         decryptedReport,
       );
 
-      const reportSubjectSpy = jest.spyOn((service as any).riskInsightsReportSubject, "next");
-
-      service.getRiskInsightsReport(organizationId, userId);
-
-      // Wait for all microtasks to complete
-      await Promise.resolve();
+      const result = await firstValueFrom(service.getRiskInsightsReport$(organizationId, userId));
 
       expect(mockRiskInsightsEncryptionService.decryptRiskInsightsReport).toHaveBeenCalledWith(
         organizationId,
@@ -327,7 +373,7 @@ describe("RiskInsightsReportService", () => {
         expect.anything(),
         expect.any(Function),
       );
-      expect(reportSubjectSpy).toHaveBeenCalledWith(decryptedReport.data);
+      expect(result).toEqual(decryptedReport);
     });
   });
 });

--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/risk-insights.component.ts
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/risk-insights.component.ts
@@ -137,6 +137,9 @@ export class RiskInsightsComponent implements OnInit {
         },
       });
   }
+  runReport = () => {
+    this.dataService.triggerReport();
+  };
 
   /**
    * Refreshes the data by re-fetching the applications report.


### PR DESCRIPTION
… classes that properly handle encstring with placeholders for upcoming usage

## 🎟️ Tracking

[PM-25613](https://bitwarden.atlassian.net/browse/PM-25613)

## 📔 Objective

This pull request adds report trigger logic needed for report persistence.

Changes:

- Add report trigger logic to component
- Update report api to properly handle EncStrings

Follow up changes:

- Use trigger report logic to manually instead of auto generating the report

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
