### PR TITLE
[PM-26235] Filter duplicate policies in rxjs

### DIFF
--- a/apps/web/src/app/admin-console/organizations/policies/policies.component.html
+++ b/apps/web/src/app/admin-console/organizations/policies/policies.component.html
@@ -1,7 +1,6 @@
 <app-header></app-header>
 
 <bit-container>
-  @let organization = organization$ | async;
   @if (loading) {
     <i
       class="bwi bwi-spinner bwi-spin tw-text-muted"
@@ -13,18 +12,16 @@
   @if (!loading) {
     <bit-table>
       <ng-template body>
-        @for (p of policies; track p.name) {
-          @if (p.display$(organization, configService) | async) {
-            <tr bitRow>
-              <td bitCell ngPreserveWhitespaces>
-                <button type="button" bitLink (click)="edit(p)">{{ p.name | i18n }}</button>
-                @if (policiesEnabledMap.get(p.type)) {
-                  <span bitBadge variant="success">{{ "on" | i18n }}</span>
-                }
-                <small class="tw-text-muted tw-block">{{ p.description | i18n }}</small>
-              </td>
-            </tr>
-          }
+        @for (p of policies$ | async; track p.type) {
+          <tr bitRow>
+            <td bitCell ngPreserveWhitespaces>
+              <button type="button" bitLink (click)="edit(p)">{{ p.name | i18n }}</button>
+              @if (policiesEnabledMap.get(p.type)) {
+                <span bitBadge variant="success">{{ "on" | i18n }}</span>
+              }
+              <small class="tw-text-muted tw-block">{{ p.description | i18n }}</small>
+            </td>
+          </tr>
         }
       </ng-template>
     </bit-table>


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-26235

## 📔 Objective

Unable to open Developer Tools when navigating to Admin Console Policies page, since it immediately freezes crashes.
The console log is filled with angular warn log messages, about duplicate for loop track.
This is because there are two policies present, with the same name, which only later is filtered, but already a duplicate in the angular loop.
Fixed by moving the `display$` policy filtering from angular looping into rxjs observable.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
