### PR TITLE
[PM-24124] Pin State Service

### DIFF
--- a/libs/common/src/key-management/pin/pin-state.service.abstraction.ts
+++ b/libs/common/src/key-management/pin/pin-state.service.abstraction.ts
@@ -16,7 +16,7 @@ export abstract class PinStateServiceAbstraction {
    * @param userId The user's id
    * @throws If the user id is not provided
    */
-  abstract getUserKeyWrappedPin$(userId: UserId): Observable<EncString | null>;
+  abstract userKeyWrappedPin$(userId: UserId): Observable<EncString | null>;
 
   /**
    * Gets the user's {@link PinLockType}

--- a/libs/common/src/key-management/pin/pin-state.service.abstraction.ts
+++ b/libs/common/src/key-management/pin/pin-state.service.abstraction.ts
@@ -69,7 +69,7 @@ export abstract class PinStateServiceAbstraction {
   abstract clearPinState(userId: UserId): Promise<void>;
 
   /**
-   * Clears only the user's ephemeral PIN
+   * Clears only the user's ephemeral PIN. Persistent PIN state and UserKey wrapped PIN remains unchanged.
    * @param userId The user's id
    * @throws If the user id is not provided
    */

--- a/libs/common/src/key-management/pin/pin-state.service.abstraction.ts
+++ b/libs/common/src/key-management/pin/pin-state.service.abstraction.ts
@@ -1,0 +1,77 @@
+import { Observable } from "rxjs";
+
+import { PasswordProtectedKeyEnvelope } from "@bitwarden/sdk-internal";
+
+import { UserId } from "../../types/guid";
+import { EncryptedString, EncString } from "../crypto/models/enc-string";
+
+import { PinLockType } from "./pin-lock-type";
+
+/**
+ * The PinStateService manages the storage and retrieval of PIN-related state for user accounts.
+ */
+export abstract class PinStateServiceAbstraction {
+  /**
+   * Gets the user's UserKey encrypted PIN
+   * @param userId The user's id
+   * @throws If the user id is not provided
+   */
+  abstract getUserKeyWrappedPin$(userId: UserId): Observable<EncString | null>;
+
+  /**
+   * Gets the user's {@link PinLockType}
+   * @param userId The user's id
+   * @throws If the user id is not provided
+   */
+  abstract getPinLockType(userId: UserId): Promise<PinLockType>;
+
+  /**
+   * Gets the user's PIN-protected UserKey envelope, either persistent or ephemeral based on the provided PinLockType
+   * @param userId The user's id
+   * @param pinLockType User's {@link PinLockType}.
+   * @throws if the user id is not provided
+   * @throws if the pin lock type is not persistent or ephemeral
+   */
+  abstract getPinProtectedUserKeyEnvelope(
+    userId: UserId,
+    pinLockType: PinLockType,
+  ): Promise<PasswordProtectedKeyEnvelope | null>;
+
+  /**
+   * Gets the user's legacy PIN-protected UserKey
+   * @deprecated Use {@link getPinProtectedUserKeyEnvelope} instead. Only for migration support.
+   * @param userId The user's id
+   * @throws If the user id is not provided
+   */
+  abstract getLegacyPinKeyEncryptedUserKeyPersistent(userId: UserId): Promise<EncString | null>;
+
+  /**
+   * Sets the PIN state for the user
+   * @param userId The user's id
+   * @param pinProtectedUserKeyEnvelope The user's PIN-protected UserKey envelope
+   * @param userKeyEncryptedPin The user's UserKey-encrypted PIN
+   * @param pinLockType The user's PinLockType
+   * @throws If the user id, pinProtectedUserKeyEnvelope, or pinLockType is not provided
+   * @throws If the pin lock type is not persistent or ephemeral
+   */
+  abstract setPinState(
+    userId: UserId,
+    pinProtectedUserKeyEnvelope: PasswordProtectedKeyEnvelope,
+    userKeyEncryptedPin: EncryptedString,
+    pinLockType: PinLockType,
+  ): Promise<void>;
+
+  /**
+   * Clears all PIN state for the user, both persistent and ephemeral
+   * @param userId The user's id
+   * @throws If the user id is not provided
+   */
+  abstract clearPinState(userId: UserId): Promise<void>;
+
+  /**
+   * Clears only the user's ephemeral PIN
+   * @param userId The user's id
+   * @throws If the user id is not provided
+   */
+  abstract clearEphemeralPinState(userId: UserId): Promise<void>;
+}

--- a/libs/common/src/key-management/pin/pin-state.service.implementation.ts
+++ b/libs/common/src/key-management/pin/pin-state.service.implementation.ts
@@ -19,7 +19,7 @@ import {
 export class PinStateService implements PinStateServiceAbstraction {
   constructor(private stateProvider: StateProvider) {}
 
-  getUserKeyWrappedPin$(userId: UserId): Observable<EncString | null> {
+  userKeyWrappedPin$(userId: UserId): Observable<EncString | null> {
     assertNonNullish(userId, "userId");
 
     return this.stateProvider

--- a/libs/common/src/key-management/pin/pin-state.service.implementation.ts
+++ b/libs/common/src/key-management/pin/pin-state.service.implementation.ts
@@ -1,0 +1,119 @@
+import { firstValueFrom, map, Observable } from "rxjs";
+
+import { PasswordProtectedKeyEnvelope } from "@bitwarden/sdk-internal";
+import { StateProvider } from "@bitwarden/state";
+import { UserId } from "@bitwarden/user-core";
+
+import { assertNonNullish } from "../../auth/utils";
+import { EncryptedString, EncString } from "../crypto/models/enc-string";
+
+import { PinLockType } from "./pin-lock-type";
+import { PinStateServiceAbstraction } from "./pin-state.service.abstraction";
+import {
+  PIN_PROTECTED_USER_KEY_ENVELOPE_PERSISTENT,
+  PIN_PROTECTED_USER_KEY_ENVELOPE_EPHEMERAL,
+  USER_KEY_ENCRYPTED_PIN,
+  PIN_KEY_ENCRYPTED_USER_KEY_PERSISTENT,
+} from "./pin.state";
+
+export class PinStateService implements PinStateServiceAbstraction {
+  constructor(private stateProvider: StateProvider) {}
+
+  getUserKeyWrappedPin$(userId: UserId): Observable<EncString | null> {
+    assertNonNullish(userId, "userId");
+
+    return this.stateProvider
+      .getUserState$(USER_KEY_ENCRYPTED_PIN, userId)
+      .pipe(map((value) => (value ? new EncString(value) : null)));
+  }
+
+  async getPinLockType(userId: UserId): Promise<PinLockType> {
+    assertNonNullish(userId, "userId");
+
+    const isPersistentPinSet =
+      (await this.getPinProtectedUserKeyEnvelope(userId, "PERSISTENT")) != null ||
+      // Deprecated
+      (await this.getLegacyPinKeyEncryptedUserKeyPersistent(userId)) != null;
+    const isPinSet =
+      (await firstValueFrom(this.stateProvider.getUserState$(USER_KEY_ENCRYPTED_PIN, userId))) !=
+      null;
+
+    if (isPersistentPinSet) {
+      return "PERSISTENT";
+    } else if (isPinSet) {
+      return "EPHEMERAL";
+    } else {
+      return "DISABLED";
+    }
+  }
+
+  async getPinProtectedUserKeyEnvelope(
+    userId: UserId,
+    pinLockType: PinLockType,
+  ): Promise<PasswordProtectedKeyEnvelope | null> {
+    assertNonNullish(userId, "userId");
+
+    if (pinLockType === "EPHEMERAL") {
+      return await firstValueFrom(
+        this.stateProvider.getUserState$(PIN_PROTECTED_USER_KEY_ENVELOPE_EPHEMERAL, userId),
+      );
+    } else if (pinLockType === "PERSISTENT") {
+      return await firstValueFrom(
+        this.stateProvider.getUserState$(PIN_PROTECTED_USER_KEY_ENVELOPE_PERSISTENT, userId),
+      );
+    } else {
+      throw new Error(`Unsupported PinLockType: ${pinLockType}`);
+    }
+  }
+
+  async getLegacyPinKeyEncryptedUserKeyPersistent(userId: UserId): Promise<EncString | null> {
+    assertNonNullish(userId, "userId");
+
+    return await firstValueFrom(
+      this.stateProvider
+        .getUserState$(PIN_KEY_ENCRYPTED_USER_KEY_PERSISTENT, userId)
+        .pipe(map((value) => (value ? new EncString(value) : null))),
+    );
+  }
+
+  async setPinState(
+    userId: UserId,
+    pinProtectedUserKeyEnvelope: PasswordProtectedKeyEnvelope,
+    userKeyEncryptedPin: EncryptedString,
+    pinLockType: PinLockType,
+  ): Promise<void> {
+    assertNonNullish(userId, "userId");
+    assertNonNullish(pinProtectedUserKeyEnvelope, "pinProtectedUserKeyEnvelope");
+    assertNonNullish(pinLockType, "pinLockType");
+
+    let keyDefinition;
+    if (pinLockType === "EPHEMERAL") {
+      keyDefinition = PIN_PROTECTED_USER_KEY_ENVELOPE_EPHEMERAL;
+    } else if (pinLockType === "PERSISTENT") {
+      keyDefinition = PIN_PROTECTED_USER_KEY_ENVELOPE_PERSISTENT;
+    } else {
+      throw new Error(`Cannot set up PIN with pin lock type ${pinLockType}`);
+    }
+
+    await this.stateProvider.setUserState(keyDefinition, pinProtectedUserKeyEnvelope, userId);
+
+    await this.stateProvider.setUserState(USER_KEY_ENCRYPTED_PIN, userKeyEncryptedPin, userId);
+  }
+
+  async clearPinState(userId: UserId): Promise<void> {
+    assertNonNullish(userId, "userId");
+
+    await this.stateProvider.setUserState(USER_KEY_ENCRYPTED_PIN, null, userId);
+    await this.stateProvider.setUserState(PIN_PROTECTED_USER_KEY_ENVELOPE_EPHEMERAL, null, userId);
+    await this.stateProvider.setUserState(PIN_PROTECTED_USER_KEY_ENVELOPE_PERSISTENT, null, userId);
+
+    // Note: This can be deleted after sufficiently many PINs are migrated and the state is removed.
+    await this.stateProvider.setUserState(PIN_KEY_ENCRYPTED_USER_KEY_PERSISTENT, null, userId);
+  }
+
+  async clearEphemeralPinState(userId: UserId): Promise<void> {
+    assertNonNullish(userId, "userId");
+
+    await this.stateProvider.setUserState(PIN_PROTECTED_USER_KEY_ENVELOPE_EPHEMERAL, null, userId);
+  }
+}

--- a/libs/common/src/key-management/pin/pin-state.service.implementation.ts
+++ b/libs/common/src/key-management/pin/pin-state.service.implementation.ts
@@ -86,16 +86,21 @@ export class PinStateService implements PinStateServiceAbstraction {
     assertNonNullish(pinProtectedUserKeyEnvelope, "pinProtectedUserKeyEnvelope");
     assertNonNullish(pinLockType, "pinLockType");
 
-    let keyDefinition;
     if (pinLockType === "EPHEMERAL") {
-      keyDefinition = PIN_PROTECTED_USER_KEY_ENVELOPE_EPHEMERAL;
+      await this.stateProvider.setUserState(
+        PIN_PROTECTED_USER_KEY_ENVELOPE_EPHEMERAL,
+        pinProtectedUserKeyEnvelope,
+        userId,
+      );
     } else if (pinLockType === "PERSISTENT") {
-      keyDefinition = PIN_PROTECTED_USER_KEY_ENVELOPE_PERSISTENT;
+      await this.stateProvider.setUserState(
+        PIN_PROTECTED_USER_KEY_ENVELOPE_PERSISTENT,
+        pinProtectedUserKeyEnvelope,
+        userId,
+      );
     } else {
       throw new Error(`Cannot set up PIN with pin lock type ${pinLockType}`);
     }
-
-    await this.stateProvider.setUserState(keyDefinition, pinProtectedUserKeyEnvelope, userId);
 
     await this.stateProvider.setUserState(USER_KEY_ENCRYPTED_PIN, userKeyEncryptedPin, userId);
   }

--- a/libs/common/src/key-management/pin/pin-state.service.spec.ts
+++ b/libs/common/src/key-management/pin/pin-state.service.spec.ts
@@ -1,0 +1,441 @@
+import { firstValueFrom } from "rxjs";
+
+import { PasswordProtectedKeyEnvelope } from "@bitwarden/sdk-internal";
+
+import { FakeAccountService, FakeStateProvider, mockAccountServiceWith } from "../../../spec";
+import { Utils } from "../../platform/misc/utils";
+import { UserId } from "../../types/guid";
+import { EncryptedString } from "../crypto/models/enc-string";
+
+import { PinLockType } from "./pin-lock-type";
+import { PinStateService } from "./pin-state.service.implementation";
+import {
+  USER_KEY_ENCRYPTED_PIN,
+  PIN_PROTECTED_USER_KEY_ENVELOPE_EPHEMERAL,
+  PIN_PROTECTED_USER_KEY_ENVELOPE_PERSISTENT,
+  PIN_KEY_ENCRYPTED_USER_KEY_PERSISTENT,
+} from "./pin.state";
+
+describe("PinStateService", () => {
+  let sut: PinStateService;
+
+  let accountService: FakeAccountService;
+  let stateProvider: FakeStateProvider;
+
+  const mockUserId = Utils.newGuid() as UserId;
+  const mockUserEmail = "user@example.com";
+  const mockUserKeyEncryptedPin = "userKeyEncryptedPin" as EncryptedString;
+  const mockEphemeralEnvelope = "mock-ephemeral-envelope" as PasswordProtectedKeyEnvelope;
+  const mockPersistentEnvelope = "mock-persistent-envelope" as PasswordProtectedKeyEnvelope;
+
+  beforeEach(() => {
+    accountService = mockAccountServiceWith(mockUserId, { email: mockUserEmail });
+    stateProvider = new FakeStateProvider(accountService);
+
+    sut = new PinStateService(stateProvider);
+  });
+
+  it("should instantiate the PinStateService", () => {
+    expect(sut).not.toBeFalsy();
+  });
+
+  describe("getUserKeyWrappedPin$", () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    test.each([null, undefined])("throws if userId is %p", async (userId) => {
+      // Arrange
+      await sut.setPinState(
+        mockUserId,
+        mockPersistentEnvelope,
+        mockUserKeyEncryptedPin,
+        "PERSISTENT",
+      );
+
+      // Act & Assert
+      expect(() => sut.getUserKeyWrappedPin$(userId as any)).toThrow(
+        "userId is null or undefined.",
+      );
+    });
+
+    test.each([null, undefined])("emits null if userKeyEncryptedPin is nullish", async (value) => {
+      // Arrange
+      await stateProvider.setUserState(USER_KEY_ENCRYPTED_PIN, value, mockUserId);
+
+      // Act
+      const result = await firstValueFrom(sut.getUserKeyWrappedPin$(mockUserId));
+
+      // Assert
+      expect(result).toBe(null);
+    });
+
+    it("emits the userKeyEncryptedPin when available", async () => {
+      // Arrange
+      await sut.setPinState(
+        mockUserId,
+        mockPersistentEnvelope,
+        mockUserKeyEncryptedPin,
+        "PERSISTENT",
+      );
+
+      // Act
+      const result = await firstValueFrom(sut.getUserKeyWrappedPin$(mockUserId));
+
+      // Assert
+      expect(result?.encryptedString).toEqual(mockUserKeyEncryptedPin);
+    });
+  });
+
+  describe("getPinLockType()", () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it("should throw an error if userId is null", async () => {
+      // Act & Assert
+      await expect(sut.getPinLockType(null as any)).rejects.toThrow("userId");
+    });
+
+    it("should return 'PERSISTENT' if a pin protected user key (persistent) is found", async () => {
+      // Arrange
+      await sut.setPinState(
+        mockUserId,
+        mockPersistentEnvelope,
+        mockUserKeyEncryptedPin,
+        "PERSISTENT",
+      );
+
+      // Act
+      const result = await sut.getPinLockType(mockUserId);
+
+      // Assert
+      expect(result).toBe("PERSISTENT");
+    });
+
+    it("should return 'PERSISTENT' if a legacy pin key encrypted user key (persistent) is found", async () => {
+      // Arrange
+      await stateProvider.setUserState(
+        PIN_KEY_ENCRYPTED_USER_KEY_PERSISTENT,
+        mockUserKeyEncryptedPin,
+        mockUserId,
+      );
+
+      // Act
+      const result = await sut.getPinLockType(mockUserId);
+
+      // Assert
+      expect(result).toBe("PERSISTENT");
+    });
+
+    it("should return 'PERSISTENT' even if user key encrypted pin is also set", async () => {
+      // Arrange - set both persistent envelope and user key encrypted pin
+      await sut.setPinState(
+        mockUserId,
+        mockPersistentEnvelope,
+        mockUserKeyEncryptedPin,
+        "PERSISTENT",
+      );
+
+      // Act
+      const result = await sut.getPinLockType(mockUserId);
+
+      // Assert
+      expect(result).toBe("PERSISTENT");
+    });
+
+    it("should return 'EPHEMERAL' if only user key encrypted pin is found", async () => {
+      // Arrange
+      await stateProvider.setUserState(USER_KEY_ENCRYPTED_PIN, mockUserKeyEncryptedPin, mockUserId);
+
+      // Act
+      const result = await sut.getPinLockType(mockUserId);
+
+      // Assert
+      expect(result).toBe("EPHEMERAL");
+    });
+
+    it("should return 'DISABLED' if no PIN-related state is found", async () => {
+      // Arrange - don't set any PIN-related state
+
+      // Act
+      const result = await sut.getPinLockType(mockUserId);
+
+      // Assert
+      expect(result).toBe("DISABLED");
+    });
+
+    it("should return 'DISABLED' if all PIN-related state is null", async () => {
+      // Arrange - explicitly set all state to null
+      await stateProvider.setUserState(
+        PIN_PROTECTED_USER_KEY_ENVELOPE_PERSISTENT,
+        null,
+        mockUserId,
+      );
+      await stateProvider.setUserState(PIN_KEY_ENCRYPTED_USER_KEY_PERSISTENT, null, mockUserId);
+      await stateProvider.setUserState(USER_KEY_ENCRYPTED_PIN, null, mockUserId);
+
+      // Act
+      const result = await sut.getPinLockType(mockUserId);
+
+      // Assert
+      expect(result).toBe("DISABLED");
+    });
+  });
+
+  describe("getPinProtectedUserKeyEnvelope()", () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    test.each([
+      [null, "PERSISTENT" as PinLockType],
+      [undefined, "PERSISTENT" as PinLockType],
+      [null, "EPHEMERAL" as PinLockType],
+      [undefined, "EPHEMERAL" as PinLockType],
+      [null, "DISABLED" as PinLockType],
+      [undefined, "DISABLED" as PinLockType],
+    ])("throws if userId is %p with pinLockType %s", async (userId, pinLockType: PinLockType) => {
+      // Using unnecesary switch so we can have exhaustive check on PinLockType
+      switch (pinLockType) {
+        case "PERSISTENT":
+          return await expect(
+            sut.getPinProtectedUserKeyEnvelope(userId as any, pinLockType),
+          ).rejects.toThrow("userId is null or undefined.");
+        case "EPHEMERAL":
+          return await expect(
+            sut.getPinProtectedUserKeyEnvelope(userId as any, pinLockType),
+          ).rejects.toThrow("userId is null or undefined.");
+        case "DISABLED":
+          return await expect(
+            sut.getPinProtectedUserKeyEnvelope(userId as any, pinLockType),
+          ).rejects.toThrow("userId is null or undefined.");
+        default: {
+          // This is the exhaustive check, will cause a compile error if a PinLockType is not handled above
+          const _exhaustiveCheck: never = pinLockType;
+          return _exhaustiveCheck;
+        }
+      }
+    });
+
+    it("should throw error for unsupported pinLockType", async () => {
+      // Act & Assert
+      await expect(
+        sut.getPinProtectedUserKeyEnvelope(mockUserId, "DISABLED" as any),
+      ).rejects.toThrow("Unsupported PinLockType: DISABLED");
+    });
+
+    test.each([["PERSISTENT" as PinLockType], ["EPHEMERAL" as PinLockType]])(
+      "should return %s envelope when pinLockType is %s",
+      async (pinLockType: PinLockType) => {
+        // Arrange
+        const mockEnvelope =
+          pinLockType === "PERSISTENT" ? mockPersistentEnvelope : mockEphemeralEnvelope;
+
+        await sut.setPinState(mockUserId, mockEnvelope, mockUserKeyEncryptedPin, pinLockType);
+
+        // Act
+        const result = await sut.getPinProtectedUserKeyEnvelope(mockUserId, pinLockType);
+
+        // Assert
+        expect(result).toBe(mockEnvelope);
+      },
+    );
+
+    test.each([["PERSISTENT" as PinLockType], ["EPHEMERAL" as PinLockType]])(
+      "should return null when %s envelope is not set",
+      async (pinLockType: PinLockType) => {
+        // Arrange - don't set any state
+
+        // Act
+        const result = await sut.getPinProtectedUserKeyEnvelope(mockUserId, pinLockType);
+
+        // Assert
+        expect(result).toBeNull();
+      },
+    );
+
+    test.each([
+      ["PERSISTENT" as PinLockType, PIN_PROTECTED_USER_KEY_ENVELOPE_PERSISTENT],
+      ["EPHEMERAL" as PinLockType, PIN_PROTECTED_USER_KEY_ENVELOPE_EPHEMERAL],
+    ])(
+      "should return null when %s envelope is explicitly set to null",
+      async (pinLockType, keyDefinition) => {
+        // Arrange
+        await stateProvider.setUserState(keyDefinition, null, mockUserId);
+
+        // Act
+        const result = await sut.getPinProtectedUserKeyEnvelope(mockUserId, pinLockType);
+
+        // Assert
+        expect(result).toBeNull();
+      },
+    );
+
+    it("should not cross-contaminate PERSISTENT and EPHEMERAL envelopes", async () => {
+      // Arrange - set both envelopes to different values
+      await sut.setPinState(
+        mockUserId,
+        mockPersistentEnvelope,
+        mockUserKeyEncryptedPin,
+        "PERSISTENT",
+      );
+      await sut.setPinState(
+        mockUserId,
+        mockEphemeralEnvelope,
+        mockUserKeyEncryptedPin,
+        "EPHEMERAL",
+      );
+
+      // Act
+      const persistentResult = await sut.getPinProtectedUserKeyEnvelope(mockUserId, "PERSISTENT");
+      const ephemeralResult = await sut.getPinProtectedUserKeyEnvelope(mockUserId, "EPHEMERAL");
+
+      // Assert
+      expect(persistentResult).toBe(mockPersistentEnvelope);
+      expect(ephemeralResult).toBe(mockEphemeralEnvelope);
+      expect(persistentResult).not.toBe(ephemeralResult);
+    });
+  });
+
+  describe("getLegacyPinKeyEncryptedUserKeyPersistent()", () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    test.each([null, undefined])("throws if userId is %p", async (userId) => {
+      // Act & Assert
+      await expect(() =>
+        sut.getLegacyPinKeyEncryptedUserKeyPersistent(userId as any),
+      ).rejects.toThrow("userId is null or undefined.");
+    });
+
+    it("should return EncString when legacy key is set", async () => {
+      // Arrange
+      await stateProvider.setUserState(
+        PIN_KEY_ENCRYPTED_USER_KEY_PERSISTENT,
+        mockUserKeyEncryptedPin,
+        mockUserId,
+      );
+
+      // Act
+      const result = await sut.getLegacyPinKeyEncryptedUserKeyPersistent(mockUserId);
+
+      // Assert
+      expect(result?.encryptedString).toEqual(mockUserKeyEncryptedPin);
+    });
+
+    test.each([null, undefined])("should return null when legacy key is %p", async (value) => {
+      // Arrange
+      await stateProvider.setUserState(PIN_KEY_ENCRYPTED_USER_KEY_PERSISTENT, value, mockUserId);
+
+      // Act
+      const result = await sut.getLegacyPinKeyEncryptedUserKeyPersistent(mockUserId);
+
+      // Assert
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("setPinState()", () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    test.each([[null], [undefined]])("throws if userId is %p", async (userId) => {
+      // Act & Assert
+      await expect(
+        sut.setPinState(
+          userId as any,
+          mockPersistentEnvelope,
+          mockUserKeyEncryptedPin,
+          "PERSISTENT",
+        ),
+      ).rejects.toThrow(`userId is null or undefined.`);
+    });
+
+    test.each([[null], [undefined]])(
+      "throws if pinProtectedUserKeyEnvelope is %p",
+      async (envelope) => {
+        // Act & Assert
+        await expect(
+          sut.setPinState(mockUserId, envelope as any, mockUserKeyEncryptedPin, "PERSISTENT"),
+        ).rejects.toThrow(`pinProtectedUserKeyEnvelope is null or undefined.`);
+      },
+    );
+
+    test.each([[null], [undefined]])("throws if pinLockType is %p", async (pinLockType) => {
+      // Act & Assert
+      await expect(
+        sut.setPinState(
+          mockUserId,
+          mockPersistentEnvelope,
+          mockUserKeyEncryptedPin,
+          pinLockType as any,
+        ),
+      ).rejects.toThrow(`pinLockType is null or undefined.`);
+    });
+
+    it("should throw error for unsupported pinLockType", async () => {
+      // Act & Assert
+      await expect(
+        sut.setPinState(
+          mockUserId,
+          mockPersistentEnvelope,
+          mockUserKeyEncryptedPin,
+          "DISABLED" as PinLockType,
+        ),
+      ).rejects.toThrow("Cannot set up PIN with pin lock type DISABLED");
+    });
+
+    test.each([["PERSISTENT" as PinLockType], ["EPHEMERAL" as PinLockType]])(
+      "should set %s PIN state correctly",
+      async (pinLockType: PinLockType) => {
+        // Arrange
+        const mockEnvelope =
+          pinLockType === "PERSISTENT" ? mockPersistentEnvelope : mockEphemeralEnvelope;
+
+        // Act
+        await sut.setPinState(mockUserId, mockEnvelope, mockUserKeyEncryptedPin, pinLockType);
+
+        // Assert - verify the correct envelope was set
+        const envelopeResult = await sut.getPinProtectedUserKeyEnvelope(mockUserId, pinLockType);
+        expect(envelopeResult).toBe(mockEnvelope);
+
+        // Assert - verify the user key encrypted PIN was set
+        const pinResult = await firstValueFrom(sut.getUserKeyWrappedPin$(mockUserId));
+        expect(pinResult?.encryptedString).toEqual(mockUserKeyEncryptedPin);
+      },
+    );
+  });
+
+  describe("clearPinState", () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    test.each([null, undefined])("throws if userId is %p", async (userId) => {
+      // Act & Assert
+      await expect(sut.clearPinState(userId as any)).rejects.toThrow(
+        `userId is null or undefined.`,
+      );
+    });
+
+    it("clears UserKey encrypted PIN", async () => {
+      // Arrange
+      await sut.setPinState(
+        mockUserId,
+        mockPersistentEnvelope,
+        mockUserKeyEncryptedPin,
+        "PERSISTENT",
+      );
+
+      // Act
+      await sut.clearPinState(mockUserId);
+
+      // Assert
+      const result = await firstValueFrom(sut.getUserKeyWrappedPin$(mockUserId));
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/libs/common/src/key-management/pin/pin-state.service.spec.ts
+++ b/libs/common/src/key-management/pin/pin-state.service.spec.ts
@@ -39,7 +39,7 @@ describe("PinStateService", () => {
     expect(sut).not.toBeFalsy();
   });
 
-  describe("getUserKeyWrappedPin$", () => {
+  describe("userKeyWrappedPin$", () => {
     beforeEach(() => {
       jest.clearAllMocks();
     });
@@ -54,9 +54,7 @@ describe("PinStateService", () => {
       );
 
       // Act & Assert
-      expect(() => sut.getUserKeyWrappedPin$(userId as any)).toThrow(
-        "userId is null or undefined.",
-      );
+      expect(() => sut.userKeyWrappedPin$(userId as any)).toThrow("userId is null or undefined.");
     });
 
     test.each([null, undefined])("emits null if userKeyEncryptedPin is nullish", async (value) => {
@@ -64,7 +62,7 @@ describe("PinStateService", () => {
       await stateProvider.setUserState(USER_KEY_ENCRYPTED_PIN, value, mockUserId);
 
       // Act
-      const result = await firstValueFrom(sut.getUserKeyWrappedPin$(mockUserId));
+      const result = await firstValueFrom(sut.userKeyWrappedPin$(mockUserId));
 
       // Assert
       expect(result).toBe(null);
@@ -80,7 +78,7 @@ describe("PinStateService", () => {
       );
 
       // Act
-      const result = await firstValueFrom(sut.getUserKeyWrappedPin$(mockUserId));
+      const result = await firstValueFrom(sut.userKeyWrappedPin$(mockUserId));
 
       // Assert
       expect(result?.encryptedString).toEqual(mockUserKeyEncryptedPin);
@@ -403,7 +401,7 @@ describe("PinStateService", () => {
         expect(envelopeResult).toBe(mockEnvelope);
 
         // Assert - verify the user key encrypted PIN was set
-        const pinResult = await firstValueFrom(sut.getUserKeyWrappedPin$(mockUserId));
+        const pinResult = await firstValueFrom(sut.userKeyWrappedPin$(mockUserId));
         expect(pinResult?.encryptedString).toEqual(mockUserKeyEncryptedPin);
       },
     );
@@ -434,7 +432,7 @@ describe("PinStateService", () => {
       await sut.clearPinState(mockUserId);
 
       // Assert
-      const result = await firstValueFrom(sut.getUserKeyWrappedPin$(mockUserId));
+      const result = await firstValueFrom(sut.userKeyWrappedPin$(mockUserId));
       expect(result).toBeNull();
     });
 
@@ -509,7 +507,7 @@ describe("PinStateService", () => {
       );
 
       // Verify all state is set before clearing
-      expect(await firstValueFrom(sut.getUserKeyWrappedPin$(mockUserId))).not.toBeNull();
+      expect(await firstValueFrom(sut.userKeyWrappedPin$(mockUserId))).not.toBeNull();
       expect(await sut.getPinProtectedUserKeyEnvelope(mockUserId, "EPHEMERAL")).not.toBeNull();
       expect(await sut.getPinProtectedUserKeyEnvelope(mockUserId, "PERSISTENT")).not.toBeNull();
       expect(await sut.getLegacyPinKeyEncryptedUserKeyPersistent(mockUserId)).not.toBeNull();
@@ -518,7 +516,7 @@ describe("PinStateService", () => {
       await sut.clearPinState(mockUserId);
 
       // Assert - all PIN state should be cleared
-      expect(await firstValueFrom(sut.getUserKeyWrappedPin$(mockUserId))).toBeNull();
+      expect(await firstValueFrom(sut.userKeyWrappedPin$(mockUserId))).toBeNull();
       expect(await sut.getPinProtectedUserKeyEnvelope(mockUserId, "EPHEMERAL")).toBeNull();
       expect(await sut.getPinProtectedUserKeyEnvelope(mockUserId, "PERSISTENT")).toBeNull();
       expect(await sut.getLegacyPinKeyEncryptedUserKeyPersistent(mockUserId)).toBeNull();
@@ -550,7 +548,7 @@ describe("PinStateService", () => {
       await expect(sut.clearPinState(mockUserId)).resolves.not.toThrow();
 
       // Verify state remains cleared
-      expect(await firstValueFrom(sut.getUserKeyWrappedPin$(mockUserId))).toBeNull();
+      expect(await firstValueFrom(sut.userKeyWrappedPin$(mockUserId))).toBeNull();
       expect(await sut.getPinProtectedUserKeyEnvelope(mockUserId, "EPHEMERAL")).toBeNull();
       expect(await sut.getPinProtectedUserKeyEnvelope(mockUserId, "PERSISTENT")).toBeNull();
       expect(await sut.getLegacyPinKeyEncryptedUserKeyPersistent(mockUserId)).toBeNull();
@@ -600,7 +598,7 @@ describe("PinStateService", () => {
       await sut.clearEphemeralPinState(mockUserId);
 
       // Assert - user key encrypted PIN should still be present
-      const pinResult = await firstValueFrom(sut.getUserKeyWrappedPin$(mockUserId));
+      const pinResult = await firstValueFrom(sut.userKeyWrappedPin$(mockUserId));
       expect(pinResult?.encryptedString).toEqual(mockUserKeyEncryptedPin);
     });
 

--- a/libs/common/src/key-management/pin/pin-state.service.spec.ts
+++ b/libs/common/src/key-management/pin/pin-state.service.spec.ts
@@ -83,6 +83,16 @@ describe("PinStateService", () => {
       // Assert
       expect(result?.encryptedString).toEqual(mockUserKeyEncryptedPin);
     });
+
+    it("emits null when userKeyEncryptedPin isn't available", async () => {
+      // Arrange - don't set any state
+
+      // Act
+      const result = await firstValueFrom(sut.userKeyWrappedPin$(mockUserId));
+
+      // Assert
+      expect(result).toBeNull();
+    });
   });
 
   describe("getPinLockType()", () => {
@@ -117,22 +127,6 @@ describe("PinStateService", () => {
         PIN_KEY_ENCRYPTED_USER_KEY_PERSISTENT,
         mockUserKeyEncryptedPin,
         mockUserId,
-      );
-
-      // Act
-      const result = await sut.getPinLockType(mockUserId);
-
-      // Assert
-      expect(result).toBe("PERSISTENT");
-    });
-
-    it("should return 'PERSISTENT' even if user key encrypted pin is also set", async () => {
-      // Arrange - set both persistent envelope and user key encrypted pin
-      await sut.setPinState(
-        mockUserId,
-        mockPersistentEnvelope,
-        mockUserKeyEncryptedPin,
-        "PERSISTENT",
       );
 
       // Act


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-24124

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
The idea here is to disconnect the `VaultTimeoutSettingService` dependency on the `PinService` due to circular dependency issues:

Pin Service -> SDK Service -> Config Service -> Config API Service -> API Service -> Vault Timeout Settings Service -> Pin Service

This creates a `PinStateService` that is responsible for setting and getting Pin state. The `PinService` is still KM's official API surface and it is highly recommended to use that instead of reaching out to the `PinStateService`. 

`VaultTimeoutSettingService` would then replace the `PinService.isPinSet()` call with:
```
await pinStateService.getPinLockType(userId) !== "DISABLED";
```
Obviously not an ideal API, but necessary until Auth can disconnect VaultTimeoutSettings as a dependency to lower level services.

The new chain would be:

Pin Service -> SDK Service -> Config Service -> Config API Service -> API Service -> Vault Timeout Settings Service -> **Pin State Service**

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
