### PR TITLE
[PM-26318] Limit data.json to current user read/write

### DIFF
--- a/apps/desktop/src/platform/services/electron-storage.service.ts
+++ b/apps/desktop/src/platform/services/electron-storage.service.ts
@@ -12,6 +12,8 @@ import {
 } from "@bitwarden/common/platform/abstractions/storage.service";
 import { NodeUtils } from "@bitwarden/node/node-utils";
 
+import { isWindowsPortable } from "../../utils";
+
 interface BaseOptions<T extends string> {
   action: T;
   key: string;
@@ -32,10 +34,11 @@ export class ElectronStorageService implements AbstractStorageService {
     if (!fs.existsSync(dir)) {
       NodeUtils.mkdirpSync(dir, "700");
     }
+    const fileMode = isWindowsPortable() ? 0o666 : 0o600;
     const storeConfig: ElectronStore.Options<Record<string, unknown>> = {
       defaults: defaults,
       name: "data",
-      configFileMode: 0o600,
+      configFileMode: fileMode,
     };
     this.store = new ElectronStore(storeConfig);
     this.updates$ = this.updatesSubject.asObservable();

--- a/apps/desktop/src/platform/services/electron-storage.service.ts
+++ b/apps/desktop/src/platform/services/electron-storage.service.ts
@@ -3,6 +3,7 @@
 import * as fs from "fs";
 
 import { ipcMain } from "electron";
+import ElectronStore from "electron-store";
 import { Subject } from "rxjs";
 
 import {
@@ -10,23 +11,6 @@ import {
   StorageUpdate,
 } from "@bitwarden/common/platform/abstractions/storage.service";
 import { NodeUtils } from "@bitwarden/node/node-utils";
-
-// See: https://github.com/sindresorhus/electron-store/blob/main/index.d.ts
-interface ElectronStoreOptions {
-  defaults: unknown;
-  name: string;
-}
-
-type ElectronStoreConstructor = new (options: ElectronStoreOptions) => ElectronStore;
-
-// eslint-disable-next-line
-const Store: ElectronStoreConstructor = require("electron-store");
-
-interface ElectronStore {
-  get: (key: string) => unknown;
-  set: (key: string, obj: unknown) => void;
-  delete: (key: string) => void;
-}
 
 interface BaseOptions<T extends string> {
   action: T;
@@ -48,11 +32,12 @@ export class ElectronStorageService implements AbstractStorageService {
     if (!fs.existsSync(dir)) {
       NodeUtils.mkdirpSync(dir, "700");
     }
-    const storeConfig: ElectronStoreOptions = {
+    const storeConfig: ElectronStore.Options<Record<string, unknown>> = {
       defaults: defaults,
       name: "data",
+      configFileMode: 0o600,
     };
-    this.store = new Store(storeConfig);
+    this.store = new ElectronStore(storeConfig);
     this.updates$ = this.updatesSubject.asObservable();
 
     ipcMain.handle("storageService", (event, options: Options) => {


### PR DESCRIPTION
## Tracking 

https://bitwarden.atlassian.net/browse/PM-26318

## 📔 Objective

Limits desktop's data store (`data.json`) to 0600 permissions, or read/write for current user and inaccessible otherwise.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
