### PR TITLE
[PM-26185] new app metric card

### DIFF
--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -231,6 +231,24 @@
   "totalApplications": {
     "message": "Total applications"
   },
+  "applicationsNeedingReview": {
+    "message": "Applications needing review"
+  },
+  "newApplicationsWithCount": {
+    "message": "$COUNT$ new applications",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "13"
+      }
+    }
+  },
+  "newApplicationsDescription": {
+    "message": "Review new applications to mark as critical and keep your organization secure"
+  },
+  "reviewNow": {
+    "message": "Review now"
+  },
   "unmarkAsCritical": {
     "message": "Unmark as critical"
   },

--- a/bitwarden_license/bit-common/src/dirt/reports/risk-insights/services/all-activities.service.ts
+++ b/bitwarden_license/bit-common/src/dirt/reports/risk-insights/services/all-activities.service.ts
@@ -39,6 +39,7 @@ export class AllActivitiesService {
       totalAtRiskMemberCount: summary.totalAtRiskMemberCount,
       totalApplicationCount: summary.totalApplicationCount,
       totalAtRiskApplicationCount: summary.totalAtRiskApplicationCount,
+      newApplications: summary.newApplications,
     });
   }
 }

--- a/bitwarden_license/bit-common/src/dirt/reports/risk-insights/services/risk-insights-report.service.ts
+++ b/bitwarden_license/bit-common/src/dirt/reports/risk-insights/services/risk-insights-report.service.ts
@@ -233,6 +233,23 @@ export class RiskInsightsReportService {
     const uniqueAtRiskMembers = getUniqueMembers(atRiskMembers);
 
     // TODO: totalCriticalMemberCount, totalCriticalAtRiskMemberCount, totalCriticalApplicationCount, totalCriticalAtRiskApplicationCount, and newApplications will be handled with future logic implementation
+    // TODO: Replace with actual new applications detection logic (PM-26185)
+    const dummyNewApplications = [
+      "github.com",
+      "google.com",
+      "stackoverflow.com",
+      "gitlab.com",
+      "bitbucket.org",
+      "npmjs.com",
+      "docker.com",
+      "aws.amazon.com",
+      "azure.microsoft.com",
+      "jenkins.io",
+      "terraform.io",
+      "kubernetes.io",
+      "atlassian.net",
+    ];
+
     return {
       totalMemberCount: uniqueMembers.length,
       totalCriticalMemberCount: 0,
@@ -242,7 +259,7 @@ export class RiskInsightsReportService {
       totalCriticalApplicationCount: 0,
       totalAtRiskApplicationCount: reports.filter((app) => app.atRiskPasswordCount > 0).length,
       totalCriticalAtRiskApplicationCount: 0,
-      newApplications: [],
+      newApplications: dummyNewApplications,
     };
   }
 

--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/activity-card.component.html
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/activity-card.component.html
@@ -16,6 +16,7 @@
         bitButton
         size="small"
         [buttonType]="buttonType"
+        [attr.aria-label]="buttonText"
         (click)="onButtonClick()"
       >
         {{ buttonText }}

--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/activity-card.component.html
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/activity-card.component.html
@@ -1,12 +1,22 @@
 <div class="tw-flex-col">
   <span bitTypography="h6" class="tw-flex tw-text-main">{{ title }}</span>
   <div class="tw-flex tw-items-baseline tw-gap-2">
+    @if (showIcon) {
+      <i class="bwi {{ iconClass }} tw-text-muted" aria-hidden="true"></i>
+    }
     <span bitTypography="h3">{{ cardMetrics }}</span>
   </div>
   <div class="tw-flex tw-items-baseline tw-mt-4 tw-gap-2">
     <span bitTypography="body2">{{ metricDescription }}</span>
   </div>
-  @if (showNavigationLink) {
+  @if (showButton) {
+    <div class="tw-flex tw-items-baseline tw-mt-4 tw-gap-2">
+      <button type="button" bitButton [buttonType]="buttonType" (click)="onButtonClick()">
+        {{ buttonText }}
+      </button>
+    </div>
+  }
+  @if (showNavigationLink && !showButton) {
     <div class="tw-flex tw-items-baseline tw-mt-4 tw-gap-2">
       <p bitTypography="body1">
         <a bitLink (click)="navigateToLink(navigationLink)" rel="noreferrer">

--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/activity-card.component.html
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/activity-card.component.html
@@ -11,7 +11,13 @@
   </div>
   @if (showButton) {
     <div class="tw-flex tw-items-baseline tw-mt-4 tw-gap-2">
-      <button type="button" bitButton [buttonType]="buttonType" (click)="onButtonClick()">
+      <button
+        type="button"
+        bitButton
+        size="small"
+        [buttonType]="buttonType"
+        (click)="onButtonClick()"
+      >
         {{ buttonText }}
       </button>
     </div>

--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/activity-card.component.ts
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/activity-card.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from "@angular/common";
-import { Component, Input } from "@angular/core";
+import { Component, EventEmitter, Input, Output } from "@angular/core";
 import { Router } from "@angular/router";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
@@ -43,9 +43,43 @@ export class ActivityCardComponent {
    */
   @Input() showNavigationLink: boolean = false;
 
+  /**
+   * Show icon next to metrics
+   */
+  @Input() showIcon: boolean = false;
+
+  /**
+   * Icon class (e.g., "bwi-exclamation-triangle")
+   */
+  @Input() iconClass: string = "";
+
+  /**
+   * Show button instead of link
+   */
+  @Input() showButton: boolean = false;
+
+  /**
+   * Button text
+   */
+  @Input() buttonText: string = "";
+
+  /**
+   * Button type (e.g., "primary", "secondary")
+   */
+  @Input() buttonType: "primary" | "secondary" | "danger" = "primary";
+
+  /**
+   * Event emitted when button is clicked
+   */
+  @Output() buttonClick = new EventEmitter<void>();
+
   constructor(private router: Router) {}
 
   navigateToLink = async (navigationLink: string) => {
     await this.router.navigateByUrl(navigationLink);
+  };
+
+  onButtonClick = () => {
+    this.buttonClick.emit();
   };
 }

--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/activity-card.component.ts
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/activity-card.component.ts
@@ -3,7 +3,7 @@ import { Component, EventEmitter, Input, Output } from "@angular/core";
 import { Router } from "@angular/router";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
-import { ButtonModule, LinkModule, TypographyModule } from "@bitwarden/components";
+import { ButtonModule, ButtonType, LinkModule, TypographyModule } from "@bitwarden/components";
 
 @Component({
   selector: "dirt-activity-card",
@@ -66,7 +66,7 @@ export class ActivityCardComponent {
   /**
    * Button type (e.g., "primary", "secondary")
    */
-  @Input() buttonType: "primary" | "secondary" | "danger" = "primary";
+  @Input() buttonType: ButtonType = "primary";
 
   /**
    * Event emitted when button is clicked

--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/all-activity.component.html
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/all-activity.component.html
@@ -50,6 +50,20 @@
         [showNavigationLink]="totalCriticalAppsAtRiskCount > 0"
       >
       </dirt-activity-card>
+
+      <dirt-activity-card
+        class="tw-col-span-2"
+        [title]="'applicationsNeedingReview' | i18n"
+        [cardMetrics]="'newApplicationsWithCount' | i18n: newApplicationsCount"
+        [metricDescription]="'newApplicationsDescription' | i18n"
+        [showIcon]="true"
+        [iconClass]="'bwi-exclamation-triangle'"
+        [showButton]="true"
+        [buttonText]="'reviewNow' | i18n"
+        [buttonType]="'primary'"
+        (buttonClick)="onReviewNewApplications()"
+      >
+      </dirt-activity-card>
     </div>
   </div>
 }

--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/all-activity.component.ts
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/all-activity.component.ts
@@ -11,7 +11,9 @@ import { OrganizationService } from "@bitwarden/common/admin-console/abstraction
 import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { getUserId } from "@bitwarden/common/auth/services/account.service";
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { getById } from "@bitwarden/common/platform/misc";
+import { ToastService } from "@bitwarden/components";
 import { SharedModule } from "@bitwarden/web-vault/app/shared";
 
 import { ActivityCardComponent } from "./activity-card.component";
@@ -30,6 +32,7 @@ export class AllActivityComponent implements OnInit {
   totalCriticalAppsAtRiskMemberCount = 0;
   totalCriticalAppsCount = 0;
   totalCriticalAppsAtRiskCount = 0;
+  newApplicationsCount = 0;
 
   destroyRef = inject(DestroyRef);
 
@@ -50,6 +53,7 @@ export class AllActivityComponent implements OnInit {
           this.totalCriticalAppsAtRiskMemberCount = summary.totalCriticalAtRiskMemberCount;
           this.totalCriticalAppsCount = summary.totalCriticalApplicationCount;
           this.totalCriticalAppsAtRiskCount = summary.totalCriticalAtRiskApplicationCount;
+          this.newApplicationsCount = summary.newApplications.length;
         });
     }
   }
@@ -60,6 +64,8 @@ export class AllActivityComponent implements OnInit {
     protected organizationService: OrganizationService,
     protected dataService: RiskInsightsDataService,
     protected allActivitiesService: AllActivitiesService,
+    private toastService: ToastService,
+    private i18nService: I18nService,
   ) {}
 
   get RiskInsightsTabType() {
@@ -70,4 +76,13 @@ export class AllActivityComponent implements OnInit {
     const organizationId = this.activatedRoute.snapshot.paramMap.get("organizationId");
     return `/organizations/${organizationId}/access-intelligence/risk-insights?tabIndex=${tabIndex}`;
   }
+
+  onReviewNewApplications = () => {
+    // TODO: Implement dialog for reviewing new applications (follow-up task)
+    this.toastService.showToast({
+      variant: "info",
+      title: this.i18nService.t("applicationsNeedingReview"),
+      message: this.i18nService.t("newApplicationsWithCount", this.newApplicationsCount.toString()),
+    });
+  };
 }

--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/all-activity.component.ts
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/all-activity.component.ts
@@ -77,8 +77,12 @@ export class AllActivityComponent implements OnInit {
     return `/organizations/${organizationId}/access-intelligence/risk-insights?tabIndex=${tabIndex}`;
   }
 
+  /**
+   * Handles the review new applications button click.
+   * Shows a toast notification as a placeholder until the dialog is implemented.
+   * TODO: Implement dialog for reviewing new applications (follow-up task)
+   */
   onReviewNewApplications = () => {
-    // TODO: Implement dialog for reviewing new applications (follow-up task)
     this.toastService.showToast({
       variant: "info",
       title: this.i18nService.t("applicationsNeedingReview"),


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-26185

## 📔 Objective

From Jira:
The OrganizationReportSummary has a new property for newApplications which will contain a list of urls for applications that are in the current report that did not appear on the previous report. This task for just adding the card and the review now button. There will be a follow-up task for opening the dialog for when review now is selected. 

-------

Implements new applications metric card in Activity tab with warning icon and "Review now" button. Uses dummy data for testing; actual new application detection and review dialog to be implemented in follow-up tasks.

### Files Changed

#### `clients/apps/web/src/locales/en/messages.json`
- Added 4 new i18n keys: `applicationsNeedingReview`, `newApplicationsWithCount`, `newApplicationsDescription`, and `reviewNow`

#### `clients/bitwarden_license/bit-common/src/dirt/reports/risk-insights/services/risk-insights-report.service.ts`
- Added dummy data (13 application URLs) to `generateApplicationsSummary()` for testing the `newApplications` property
- Included TODO comment for future backend implementation

#### `clients/bitwarden_license/bit-common/src/dirt/reports/risk-insights/services/all-activities.service.ts`
- Updated `setAllAppsReportSummary()` to pass through `newApplications` array from summary data

#### `clients/bitwarden_license/bit-web/src/app/dirt/access-intelligence/activity-card.component.ts`
- Added optional icon support: `showIcon` and `iconClass` inputs
- Added optional button support: `showButton`, `buttonText`, `buttonType` inputs and `buttonClick` output
- Imported `ButtonType` from `@bitwarden/components` for type safety
- Maintains backward compatibility with existing link-based usage

#### `clients/bitwarden_license/bit-web/src/app/dirt/access-intelligence/activity-card.component.html`
- Added conditional icon rendering next to card metrics
- Added conditional button rendering with `size="small"` and `[attr.aria-label]` for accessibility
- Made button and link mutually exclusive (button takes precedence)

#### `clients/bitwarden_license/bit-web/src/app/dirt/access-intelligence/all-activity.component.ts`
- Added `newApplicationsCount` property to track new applications
- Updated `reportSummary$` subscription to capture `newApplications.length`
- Added `onReviewNewApplications()` method with toast notification placeholder (dialog implementation in follow-up task)
- Injected `ToastService` and `I18nService` dependencies
- Added JSDoc documentation for new method

#### `clients/bitwarden_license/bit-web/src/app/dirt/access-intelligence/all-activity.component.html`
- Added third metric card for "Applications needing review"
- Configured with warning icon, count display, description, and "Review now" button
- Wired up to `onReviewNewApplications()` handler via `buttonClick` event

## 📸 Screenshots

<img width="1259" height="611" alt="image" src="https://github.com/user-attachments/assets/8da9b352-d70b-4452-839c-6f4c48874d70" />


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
