### PR TITLE
Anders/unlock prf 3

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -28,6 +28,9 @@
   "logInWithPasskey": {
     "message": "Log in with passkey"
   },
+  "unlockWithPasskey": {
+    "message": "Unlock with passkey"
+  },
   "useSingleSignOn": {
     "message": "Use single sign-on"
   },
@@ -3149,6 +3152,12 @@
   },
   "error": {
     "message": "Error"
+  },
+  "prfUnlockFailed": {
+    "message": "Failed to unlock with passkey. Please try again or use another unlock method."
+  },
+  "noPrfCredentialsAvailable": {
+    "message": "No PRF-enabled passkeys are available for unlock. Please log in with a passkey first."
   },
   "decryptionError": {
     "message": "Decryption error"

--- a/apps/browser/src/key-management/lock/services/extension-lock-component.service.spec.ts
+++ b/apps/browser/src/key-management/lock/services/extension-lock-component.service.spec.ts
@@ -13,6 +13,7 @@ import {
   BiometricsService,
   BiometricsStatus,
   BiometricStateService,
+  WebAuthnPrfUnlockServiceAbstraction,
 } from "@bitwarden/key-management";
 import { UnlockOptions } from "@bitwarden/key-management-ui";
 
@@ -34,6 +35,7 @@ describe("ExtensionLockComponentService", () => {
   let vaultTimeoutSettingsService: MockProxy<VaultTimeoutSettingsService>;
   let routerService: MockProxy<BrowserRouterService>;
   let biometricStateService: MockProxy<BiometricStateService>;
+  let webAuthnPrfUnlockService: MockProxy<WebAuthnPrfUnlockServiceAbstraction>;
 
   beforeEach(() => {
     userDecryptionOptionsService = mock<UserDecryptionOptionsServiceAbstraction>();
@@ -43,6 +45,7 @@ describe("ExtensionLockComponentService", () => {
     vaultTimeoutSettingsService = mock<VaultTimeoutSettingsService>();
     routerService = mock<BrowserRouterService>();
     biometricStateService = mock<BiometricStateService>();
+    webAuthnPrfUnlockService = mock<WebAuthnPrfUnlockServiceAbstraction>();
 
     TestBed.configureTestingModule({
       providers: [
@@ -74,6 +77,10 @@ describe("ExtensionLockComponentService", () => {
         {
           provide: BiometricStateService,
           useValue: biometricStateService,
+        },
+        {
+          provide: WebAuthnPrfUnlockServiceAbstraction,
+          useValue: webAuthnPrfUnlockService,
         },
       ],
     });
@@ -212,6 +219,9 @@ describe("ExtensionLockComponentService", () => {
             enabled: true,
             biometricsStatus: BiometricsStatus.Available,
           },
+          prf: {
+            enabled: false,
+          },
         },
       ],
       [
@@ -233,6 +243,9 @@ describe("ExtensionLockComponentService", () => {
           biometrics: {
             enabled: true,
             biometricsStatus: BiometricsStatus.Available,
+          },
+          prf: {
+            enabled: false,
           },
         },
       ],
@@ -256,6 +269,9 @@ describe("ExtensionLockComponentService", () => {
             enabled: true,
             biometricsStatus: BiometricsStatus.Available,
           },
+          prf: {
+            enabled: false,
+          },
         },
       ],
       [
@@ -277,6 +293,9 @@ describe("ExtensionLockComponentService", () => {
           biometrics: {
             enabled: true,
             biometricsStatus: BiometricsStatus.Available,
+          },
+          prf: {
+            enabled: false,
           },
         },
       ],
@@ -300,6 +319,9 @@ describe("ExtensionLockComponentService", () => {
             enabled: false,
             biometricsStatus: BiometricsStatus.UnlockNeeded,
           },
+          prf: {
+            enabled: false,
+          },
         },
       ],
       [
@@ -322,6 +344,9 @@ describe("ExtensionLockComponentService", () => {
             enabled: false,
             biometricsStatus: BiometricsStatus.NotEnabledInConnectedDesktopApp,
           },
+          prf: {
+            enabled: false,
+          },
         },
       ],
       [
@@ -343,6 +368,9 @@ describe("ExtensionLockComponentService", () => {
           biometrics: {
             enabled: false,
             biometricsStatus: BiometricsStatus.HardwareUnavailable,
+          },
+          prf: {
+            enabled: false,
           },
         },
       ],
@@ -373,6 +401,10 @@ describe("ExtensionLockComponentService", () => {
 
       //  PIN
       pinService.isPinDecryptionAvailable.mockResolvedValue(mockInputs.pinDecryptionAvailable);
+
+      // PRF
+      webAuthnPrfUnlockService.isPrfUnlockAvailable.mockResolvedValue(false);
+      webAuthnPrfUnlockService.getPrfUnlockCredentials.mockResolvedValue([]);
 
       const unlockOptions = await firstValueFrom(service.getAvailableUnlockOptions$(userId));
 

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -11256,5 +11256,14 @@
   },
   "verifyNow": {
     "message": "Verify now."
+  },
+  "unlockWithPasskey": {
+    "message": "Unlock with passkey"
+  },
+  "prfUnlockFailed": {
+    "message": "Failed to unlock with passkey. Please try again or use another unlock method."
+  },
+  "noPrfCredentialsAvailable": {
+    "message": "No PRF-enabled passkeys are available for unlock."
   }
 }

--- a/libs/angular/src/services/jslib-services.module.ts
+++ b/libs/angular/src/services/jslib-services.module.ts
@@ -315,6 +315,8 @@ import {
   KeyService,
   UserAsymmetricKeysRegenerationApiService,
   UserAsymmetricKeysRegenerationService,
+  WebAuthnPrfUnlockService,
+  WebAuthnPrfUnlockServiceAbstraction,
 } from "@bitwarden/key-management";
 import {
   ActiveUserStateProvider,
@@ -803,7 +805,7 @@ const safeProviders: SafeProvider[] = [
       FolderApiServiceAbstraction,
       InternalOrganizationServiceAbstraction,
       SendApiServiceAbstraction,
-      UserDecryptionOptionsServiceAbstraction,
+      InternalUserDecryptionOptionsServiceAbstraction,
       AvatarServiceAbstraction,
       LOGOUT_CALLBACK,
       BillingAccountProfileStateService,
@@ -926,11 +928,6 @@ const safeProviders: SafeProvider[] = [
   safeProvider({
     provide: WebPushConnectionService,
     useClass: UnsupportedWebPushConnectionService,
-    deps: [],
-  }),
-  safeProvider({
-    provide: ActionsService,
-    useClass: UnsupportedActionsService,
     deps: [],
   }),
   safeProvider({
@@ -1257,6 +1254,19 @@ const safeProviders: SafeProvider[] = [
     provide: WebAuthnLoginApiServiceAbstraction,
     useClass: WebAuthnLoginApiService,
     deps: [ApiServiceAbstraction, EnvironmentService],
+  }),
+  safeProvider({
+    provide: WebAuthnPrfUnlockServiceAbstraction,
+    useClass: WebAuthnPrfUnlockService,
+    deps: [
+      WebAuthnLoginPrfKeyServiceAbstraction,
+      KeyService,
+      UserDecryptionOptionsServiceAbstraction,
+      EncryptService,
+      EnvironmentService,
+      WINDOW,
+      LogService,
+    ],
   }),
   safeProvider({
     provide: WebAuthnLoginServiceAbstraction,

--- a/libs/auth/src/common/login-strategies/webauthn-login.strategy.spec.ts
+++ b/libs/auth/src/common/login-strategies/webauthn-login.strategy.spec.ts
@@ -168,19 +168,25 @@ describe("WebAuthnLoginStrategy", () => {
   const userDecryptionOptsServerResponseWithWebAuthnPrfOption: IUserDecryptionOptionsServerResponse =
     {
       HasMasterPassword: true,
-      WebAuthnPrfOption: {
-        EncryptedPrivateKey: mockEncPrfPrivateKey,
-        EncryptedUserKey: mockEncUserKey,
-      },
+      WebAuthnPrfOptions: [
+        {
+          EncryptedPrivateKey: mockEncPrfPrivateKey,
+          EncryptedUserKey: mockEncUserKey,
+          CredentialId: "mockCredentialId",
+          Transports: ["usb", "nfc"],
+        },
+      ],
     };
 
   const mockIdTokenResponseWithModifiedWebAuthnPrfOption = (key: string, value: any) => {
     const userDecryptionOpts: IUserDecryptionOptionsServerResponse = {
       ...userDecryptionOptsServerResponseWithWebAuthnPrfOption,
-      WebAuthnPrfOption: {
-        ...userDecryptionOptsServerResponseWithWebAuthnPrfOption.WebAuthnPrfOption,
-        [key]: value,
-      },
+      WebAuthnPrfOptions: [
+        {
+          ...userDecryptionOptsServerResponseWithWebAuthnPrfOption.WebAuthnPrfOptions[0],
+          [key]: value,
+        },
+      ],
     };
     return identityTokenResponseFactory(null, userDecryptionOpts);
   };
@@ -249,12 +255,12 @@ describe("WebAuthnLoginStrategy", () => {
 
     expect(encryptService.unwrapDecapsulationKey).toHaveBeenCalledTimes(1);
     expect(encryptService.unwrapDecapsulationKey).toHaveBeenCalledWith(
-      idTokenResponse.userDecryptionOptions.webAuthnPrfOption.encryptedPrivateKey,
+      idTokenResponse.userDecryptionOptions.webAuthnPrfOptions[0].encryptedPrivateKey,
       webAuthnCredentials.prfKey,
     );
     expect(encryptService.decapsulateKeyUnsigned).toHaveBeenCalledTimes(1);
     expect(encryptService.decapsulateKeyUnsigned).toHaveBeenCalledWith(
-      idTokenResponse.userDecryptionOptions.webAuthnPrfOption.encryptedUserKey,
+      idTokenResponse.userDecryptionOptions.webAuthnPrfOptions[0].encryptedUserKey,
       mockPrfPrivateKey,
     );
     expect(keyService.setUserKey).toHaveBeenCalledWith(mockUserKey, userId);

--- a/libs/auth/src/common/login-strategies/webauthn-login.strategy.ts
+++ b/libs/auth/src/common/login-strategies/webauthn-login.strategy.ts
@@ -72,10 +72,22 @@ export class WebAuthnLoginStrategy extends LoginStrategy {
 
     const userDecryptionOptions = idTokenResponse?.userDecryptionOptions;
 
-    if (userDecryptionOptions?.webAuthnPrfOption) {
-      const webAuthnPrfOption = idTokenResponse.userDecryptionOptions?.webAuthnPrfOption;
-
+    if (
+      userDecryptionOptions?.webAuthnPrfOptions &&
+      userDecryptionOptions.webAuthnPrfOptions.length > 0
+    ) {
       const credentials = this.cache.value.credentials;
+      const credentialId = credentials.deviceResponse.id;
+
+      // Find the matching WebAuthn PRF option for this credential
+      const webAuthnPrfOption = userDecryptionOptions.webAuthnPrfOptions.find(
+        (option) => option.credentialId === credentialId,
+      );
+
+      if (!webAuthnPrfOption) {
+        throw new Error("No matching WebAuthn PRF option found for this credential");
+      }
+
       // confirm we still have the prf key
       if (!credentials.prfKey) {
         return;

--- a/libs/common/src/auth/models/response/user-decryption-options/user-decryption-options.response.spec.ts
+++ b/libs/common/src/auth/models/response/user-decryption-options/user-decryption-options.response.spec.ts
@@ -30,7 +30,7 @@ describe("UserDecryptionOptionsResponse", () => {
     expect(response.masterPasswordUnlock!.masterKeyWrappedUserKey).toEqual(encryptedUserKey);
     expect(response.trustedDeviceOption).toBeUndefined();
     expect(response.keyConnectorOption).toBeUndefined();
-    expect(response.webAuthnPrfOption).toBeUndefined();
+    expect(response.webAuthnPrfOptions).toBeUndefined();
   });
 
   it("should create response when master password unlock is not present", () => {
@@ -42,6 +42,6 @@ describe("UserDecryptionOptionsResponse", () => {
     expect(response.masterPasswordUnlock).toBeUndefined();
     expect(response.trustedDeviceOption).toBeUndefined();
     expect(response.keyConnectorOption).toBeUndefined();
-    expect(response.webAuthnPrfOption).toBeUndefined();
+    expect(response.webAuthnPrfOptions).toBeUndefined();
   });
 });

--- a/libs/common/src/auth/models/response/user-decryption-options/user-decryption-options.response.ts
+++ b/libs/common/src/auth/models/response/user-decryption-options/user-decryption-options.response.ts
@@ -19,7 +19,7 @@ export interface IUserDecryptionOptionsServerResponse {
   MasterPasswordUnlock?: unknown;
   TrustedDeviceOption?: ITrustedDeviceUserDecryptionOptionServerResponse;
   KeyConnectorOption?: IKeyConnectorUserDecryptionOptionServerResponse;
-  WebAuthnPrfOption?: IWebAuthnPrfDecryptionOptionServerResponse;
+  WebAuthnPrfOptions?: IWebAuthnPrfDecryptionOptionServerResponse[];
 }
 
 export class UserDecryptionOptionsResponse extends BaseResponse {
@@ -27,7 +27,7 @@ export class UserDecryptionOptionsResponse extends BaseResponse {
   masterPasswordUnlock?: MasterPasswordUnlockResponse;
   trustedDeviceOption?: TrustedDeviceUserDecryptionOptionResponse;
   keyConnectorOption?: KeyConnectorUserDecryptionOptionResponse;
-  webAuthnPrfOption?: WebAuthnPrfDecryptionOptionResponse;
+  webAuthnPrfOptions?: WebAuthnPrfDecryptionOptionResponse[];
 
   constructor(response: IUserDecryptionOptionsServerResponse) {
     super(response);
@@ -49,9 +49,10 @@ export class UserDecryptionOptionsResponse extends BaseResponse {
         this.getResponseProperty("KeyConnectorOption"),
       );
     }
-    if (response.WebAuthnPrfOption) {
-      this.webAuthnPrfOption = new WebAuthnPrfDecryptionOptionResponse(
-        this.getResponseProperty("WebAuthnPrfOption"),
+    if (response.WebAuthnPrfOptions && Array.isArray(response.WebAuthnPrfOptions)) {
+      this.webAuthnPrfOptions = this.getResponseProperty("WebAuthnPrfOptions")?.map(
+        (option: IWebAuthnPrfDecryptionOptionServerResponse) =>
+          new WebAuthnPrfDecryptionOptionResponse(option),
       );
     }
   }

--- a/libs/common/src/auth/models/response/user-decryption-options/webauthn-prf-decryption-option.response.ts
+++ b/libs/common/src/auth/models/response/user-decryption-options/webauthn-prf-decryption-option.response.ts
@@ -6,19 +6,30 @@ import { BaseResponse } from "../../../../models/response/base.response";
 export interface IWebAuthnPrfDecryptionOptionServerResponse {
   EncryptedPrivateKey: string;
   EncryptedUserKey: string;
+  CredentialId: string;
+  Transports: string[];
 }
 
 export class WebAuthnPrfDecryptionOptionResponse extends BaseResponse {
   encryptedPrivateKey: EncString;
   encryptedUserKey: EncString;
+  credentialId: string;
+  transports: string[];
 
-  constructor(response: IWebAuthnPrfDecryptionOptionServerResponse) {
+  constructor(response: IWebAuthnPrfDecryptionOptionServerResponse | any) {
     super(response);
-    if (response.EncryptedPrivateKey) {
-      this.encryptedPrivateKey = new EncString(this.getResponseProperty("EncryptedPrivateKey"));
+
+    const encPrivateKey = this.getResponseProperty("EncryptedPrivateKey");
+    if (encPrivateKey) {
+      this.encryptedPrivateKey = new EncString(encPrivateKey);
     }
-    if (response.EncryptedUserKey) {
-      this.encryptedUserKey = new EncString(this.getResponseProperty("EncryptedUserKey"));
+
+    const encUserKey = this.getResponseProperty("EncryptedUserKey");
+    if (encUserKey) {
+      this.encryptedUserKey = new EncString(encUserKey);
     }
+
+    this.credentialId = this.getResponseProperty("CredentialId");
+    this.transports = this.getResponseProperty("Transports") || [];
   }
 }

--- a/libs/common/src/key-management/models/response/user-decryption.response.ts
+++ b/libs/common/src/key-management/models/response/user-decryption.response.ts
@@ -1,8 +1,10 @@
+import { WebAuthnPrfDecryptionOptionResponse } from "../../../auth/models/response/user-decryption-options/webauthn-prf-decryption-option.response";
 import { BaseResponse } from "../../../models/response/base.response";
 import { MasterPasswordUnlockResponse } from "../../master-password/models/response/master-password-unlock.response";
 
 export class UserDecryptionResponse extends BaseResponse {
   masterPasswordUnlock?: MasterPasswordUnlockResponse;
+  webAuthnPrfOptions?: WebAuthnPrfDecryptionOptionResponse[];
 
   constructor(response: unknown) {
     super(response);
@@ -10,6 +12,13 @@ export class UserDecryptionResponse extends BaseResponse {
     const masterPasswordUnlock = this.getResponseProperty("MasterPasswordUnlock");
     if (masterPasswordUnlock != null && typeof masterPasswordUnlock === "object") {
       this.masterPasswordUnlock = new MasterPasswordUnlockResponse(masterPasswordUnlock);
+    }
+
+    const webAuthnPrfOptions = this.getResponseProperty("WebAuthnPrfOptions");
+    if (webAuthnPrfOptions != null && Array.isArray(webAuthnPrfOptions)) {
+      this.webAuthnPrfOptions = webAuthnPrfOptions.map(
+        (option) => new WebAuthnPrfDecryptionOptionResponse(option),
+      );
     }
   }
 }

--- a/libs/common/src/platform/sync/default-sync.service.spec.ts
+++ b/libs/common/src/platform/sync/default-sync.service.spec.ts
@@ -9,7 +9,7 @@ import { CollectionService } from "@bitwarden/admin-console/common";
 import {
   LogoutReason,
   UserDecryptionOptions,
-  UserDecryptionOptionsServiceAbstraction,
+  InternalUserDecryptionOptionsServiceAbstraction,
 } from "@bitwarden/auth/common";
 // This import has been flagged as unallowed for this class. It may be involved in a circular dependency loop.
 // eslint-disable-next-line no-restricted-imports
@@ -66,7 +66,7 @@ describe("DefaultSyncService", () => {
   let folderApiService: MockProxy<FolderApiServiceAbstraction>;
   let organizationService: MockProxy<InternalOrganizationServiceAbstraction>;
   let sendApiService: MockProxy<SendApiService>;
-  let userDecryptionOptionsService: MockProxy<UserDecryptionOptionsServiceAbstraction>;
+  let userDecryptionOptionsService: MockProxy<InternalUserDecryptionOptionsServiceAbstraction>;
   let avatarService: MockProxy<AvatarService>;
   let logoutCallback: jest.Mock<Promise<void>, [logoutReason: LogoutReason, userId?: UserId]>;
   let billingAccountProfileStateService: MockProxy<BillingAccountProfileStateService>;

--- a/libs/key-management-ui/src/lock/components/lock.component.html
+++ b/libs/key-management-ui/src/lock/components/lock.component.html
@@ -47,6 +47,20 @@
         </button>
       </ng-container>
 
+      <ng-container *ngIf="unlockOptions.prf.enabled">
+        <button
+          type="button"
+          bitButton
+          buttonType="secondary"
+          block
+          (click)="unlockViaPrf()"
+          [disabled]="unlockingViaPrf"
+          [loading]="unlockingViaPrf"
+        >
+          {{ "unlockWithPasskey" | i18n }}
+        </button>
+      </ng-container>
+
       <button type="button" bitButton block (click)="logOut()">
         {{ "logOut" | i18n }}
       </button>
@@ -108,6 +122,21 @@
             (click)="activeUnlockOption = UnlockOption.MasterPassword"
           >
             {{ "unlockWithMasterPassword" | i18n }}
+          </button>
+        </ng-container>
+
+        <ng-container *ngIf="unlockOptions.prf.enabled">
+          <button
+            type="button"
+            bitButton
+            bitFormButton
+            buttonType="secondary"
+            block
+            (click)="unlockViaPrf()"
+            [disabled]="unlockingViaPrf"
+            [loading]="unlockingViaPrf"
+          >
+            {{ "unlockWithPasskey" | i18n }}
           </button>
         </ng-container>
 
@@ -179,6 +208,21 @@
             (click)="activeUnlockOption = UnlockOption.Pin"
           >
             {{ "unlockWithPin" | i18n }}
+          </button>
+        </ng-container>
+
+        <ng-container *ngIf="unlockOptions.prf.enabled">
+          <button
+            type="button"
+            bitButton
+            bitFormButton
+            buttonType="secondary"
+            block
+            (click)="unlockViaPrf()"
+            [disabled]="unlockingViaPrf"
+            [loading]="unlockingViaPrf"
+          >
+            {{ "unlockWithPasskey" | i18n }}
           </button>
         </ng-container>
 

--- a/libs/key-management-ui/src/lock/components/lock.component.spec.ts
+++ b/libs/key-management-ui/src/lock/components/lock.component.spec.ts
@@ -51,6 +51,7 @@ import {
   KeyService,
   PBKDF2KdfConfig,
   UserAsymmetricKeysRegenerationService,
+  WebAuthnPrfUnlockServiceAbstraction,
 } from "@bitwarden/key-management";
 
 import {
@@ -91,6 +92,7 @@ describe("LockComponent", () => {
   const mockLockComponentService = mock<LockComponentService>();
   const mockAnonLayoutWrapperDataService = mock<AnonLayoutWrapperDataService>();
   const mockBroadcasterService = mock<BroadcasterService>();
+  const mockWebAuthnPrfUnlockService = mock<WebAuthnPrfUnlockServiceAbstraction>();
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -148,6 +150,7 @@ describe("LockComponent", () => {
         { provide: LockComponentService, useValue: mockLockComponentService },
         { provide: AnonLayoutWrapperDataService, useValue: mockAnonLayoutWrapperDataService },
         { provide: BroadcasterService, useValue: mockBroadcasterService },
+        { provide: WebAuthnPrfUnlockServiceAbstraction, useValue: mockWebAuthnPrfUnlockService },
       ],
     })
       .overrideProvider(DialogService, { useValue: mockDialogService })
@@ -168,6 +171,7 @@ describe("LockComponent", () => {
           enabled: false,
           biometricsStatus: BiometricsStatus.NotEnabledLocally,
         },
+        prf: { enabled: false },
       };
 
       component.activeUnlockOption = UnlockOption.MasterPassword;

--- a/libs/key-management-ui/src/lock/services/lock-component.service.ts
+++ b/libs/key-management-ui/src/lock/services/lock-component.service.ts
@@ -10,6 +10,7 @@ export const UnlockOption = Object.freeze({
   MasterPassword: "masterPassword",
   Pin: "pin",
   Biometrics: "biometrics",
+  Prf: "prf",
 }) satisfies { [Prop in keyof UnlockOptions as Capitalize<Prop>]: Prop };
 
 export type UnlockOptions = {
@@ -22,6 +23,9 @@ export type UnlockOptions = {
   biometrics: {
     enabled: boolean;
     biometricsStatus: BiometricsStatus;
+  };
+  prf: {
+    enabled: boolean;
   };
 };
 

--- a/libs/key-management/src/abstractions/webauthn/webauthn-prf-unlock.service.abstraction.ts
+++ b/libs/key-management/src/abstractions/webauthn/webauthn-prf-unlock.service.abstraction.ts
@@ -1,0 +1,44 @@
+import { PrfKey } from "@bitwarden/common/types/key";
+
+/**
+ * Service for unlocking vault using WebAuthn PRF (pseudo-random function) extension.
+ * Provides offline vault unlock capabilities by deriving unlock keys from PRF outputs.
+ */
+export abstract class WebAuthnPrfUnlockServiceAbstraction {
+  /**
+   * Check if PRF unlock is available for the current user
+   * @param userId The user ID to check PRF unlock availability for
+   * @returns Promise<boolean> true if PRF unlock is available
+   */
+  abstract isPrfUnlockAvailable(userId: string): Promise<boolean>;
+
+  /**
+   * Get PRF credentials for unlock (stored credential IDs that support PRF)
+   * @param userId The user ID to get credentials for
+   * @returns Promise<{credentialId: string; transports: string[]}[]> Array of credentials with transports that support PRF unlock
+   */
+  abstract getPrfUnlockCredentials(
+    userId: string,
+  ): Promise<{ credentialId: string; transports: string[] }[]>;
+
+  /**
+   * Attempt to unlock the vault using WebAuthn PRF
+   * @param userId The user ID to unlock vault for
+   * @returns Promise<boolean> true if unlock was successful
+   */
+  abstract unlockVaultWithPrf(userId: string): Promise<boolean>;
+
+  /**
+   * Get the salt used for PRF unlock operations
+   * Uses the same salt as login to ensure PRF keys match
+   * @returns Promise<ArrayBuffer> The salt for PRF unlock operations
+   */
+  abstract getUnlockWithPrfSalt(): Promise<ArrayBuffer>;
+
+  /**
+   * Create symmetric unlock key from PRF output
+   * @param prf The PRF output from authenticator
+   * @returns Promise<PrfKey> The derived unlock key
+   */
+  abstract createUnlockKeyFromPrf(prf: ArrayBuffer): Promise<PrfKey>;
+}

--- a/libs/key-management/src/index.ts
+++ b/libs/key-management/src/index.ts
@@ -22,3 +22,7 @@ export { DefaultKdfConfigService } from "./kdf-config.service";
 export { KdfType } from "./enums/kdf-type.enum";
 
 export * from "./user-asymmetric-key-regeneration";
+
+// WebAuthn PRF Unlock
+export { WebAuthnPrfUnlockServiceAbstraction } from "./abstractions/webauthn/webauthn-prf-unlock.service.abstraction";
+export { WebAuthnPrfUnlockService } from "./services/webauthn/webauthn-prf-unlock.service";

--- a/libs/key-management/src/services/webauthn/webauthn-prf-unlock.service.ts
+++ b/libs/key-management/src/services/webauthn/webauthn-prf-unlock.service.ts
@@ -1,0 +1,223 @@
+import { firstValueFrom } from "rxjs";
+
+// eslint-disable-next-line no-restricted-imports
+import {
+  UserDecryptionOptions,
+  UserDecryptionOptionsServiceAbstraction,
+} from "@bitwarden/auth/common";
+import { WebAuthnLoginPrfKeyServiceAbstraction } from "@bitwarden/common/auth/abstractions/webauthn/webauthn-login-prf-key.service.abstraction";
+import { EncryptService } from "@bitwarden/common/key-management/crypto/abstractions/encrypt.service";
+import { EncString } from "@bitwarden/common/key-management/crypto/models/enc-string";
+import { EnvironmentService } from "@bitwarden/common/platform/abstractions/environment.service";
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+import { Fido2Utils } from "@bitwarden/common/platform/services/fido2/fido2-utils";
+import { UserId } from "@bitwarden/common/types/guid";
+import { PrfKey, UserKey } from "@bitwarden/common/types/key";
+import { KeyService } from "@bitwarden/key-management";
+
+import { WebAuthnPrfUnlockServiceAbstraction } from "../../abstractions/webauthn/webauthn-prf-unlock.service.abstraction";
+
+export class WebAuthnPrfUnlockService implements WebAuthnPrfUnlockServiceAbstraction {
+  private navigatorCredentials: CredentialsContainer;
+
+  constructor(
+    private webAuthnLoginPrfKeyService: WebAuthnLoginPrfKeyServiceAbstraction,
+    private keyService: KeyService,
+    private userDecryptionOptionsService: UserDecryptionOptionsServiceAbstraction,
+    private encryptService: EncryptService,
+    private environmentService: EnvironmentService,
+    private window: Window,
+    private logService?: LogService,
+  ) {
+    this.navigatorCredentials = this.window.navigator.credentials;
+  }
+
+  async isPrfUnlockAvailable(userId: string): Promise<boolean> {
+    try {
+      const credentials = await this.getPrfUnlockCredentials(userId);
+      return credentials.length > 0;
+    } catch (error) {
+      this.logService?.error("Error checking PRF unlock availability:", error);
+      return false;
+    }
+  }
+
+  async getPrfUnlockCredentials(
+    userId: string,
+  ): Promise<{ credentialId: string; transports: string[] }[]> {
+    try {
+      const userDecryptionOptions = await this.getUserDecryptionOptions(userId);
+      if (!userDecryptionOptions?.webAuthnPrfOptions) {
+        return [];
+      }
+      return userDecryptionOptions.webAuthnPrfOptions.map((option) => ({
+        credentialId: option.credentialId,
+        transports: option.transports,
+      }));
+    } catch (error) {
+      this.logService?.error("Error getting PRF unlock credentials:", error);
+      return [];
+    }
+  }
+
+  async unlockVaultWithPrf(userId: string): Promise<boolean> {
+    try {
+      const credentials = await this.getPrfUnlockCredentials(userId);
+      if (credentials.length === 0) {
+        throw new Error("No PRF credentials available for unlock");
+      }
+
+      // Get the appropriate rpId from the user's environment
+      const rawRpId = await this.getRpIdForUser(userId);
+      // Extract hostname using URL parsing to handle IPv6 and ports correctly
+      const url = new URL(`https://${rawRpId}`);
+      const rpId = url.hostname;
+      const prfSalt = await this.getUnlockWithPrfSalt();
+
+      // Create credential request options
+      const options: CredentialRequestOptions = {
+        publicKey: {
+          challenge: crypto.getRandomValues(new Uint8Array(32)),
+          allowCredentials: credentials.map(({ credentialId, transports }) => {
+            // The credential ID is already base64url encoded from login storage
+            // We need to decode it to ArrayBuffer for WebAuthn
+            const decodedId = Fido2Utils.stringToBuffer(credentialId);
+            return {
+              type: "public-key",
+              id: decodedId,
+              transports: (transports || []) as AuthenticatorTransport[],
+            };
+          }),
+          rpId: rpId,
+          userVerification: "preferred", // Allow platform authenticators to work properly
+          extensions: {
+            prf: { eval: { first: prfSalt } },
+          },
+        },
+      };
+
+      // Get credential with PRF - wrap in timeout to avoid hanging
+      // Use shorter timeout for testing in browser extension context
+      const response = await this.navigatorCredentials.get(options);
+
+      if (!response) {
+        throw new Error("WebAuthn get() returned null/undefined");
+      }
+
+      if (!(response instanceof PublicKeyCredential)) {
+        throw new Error("Failed to get PRF credential for unlock");
+      }
+
+      // Extract PRF result
+      // TODO: Remove `any` when typescript typings add support for PRF
+      const extensionResults = response.getClientExtensionResults() as any;
+      const prfResult = extensionResults.prf?.results?.first;
+      if (!prfResult) {
+        throw new Error("No PRF result received from authenticator");
+      }
+
+      // Create unlock key from PRF
+      const unlockKey = await this.createUnlockKeyFromPrf(prfResult);
+      const userIdTyped = userId as UserId;
+
+      // PRF unlock must follow the same key derivation process as PRF login:
+      // PRF key → decrypt private key → use private key to decrypt user key → set user key
+
+      // First, we need to get the WebAuthn PRF option data from UserDecryptionOptions
+      // This contains the encrypted private key and encrypted user key
+      const userDecryptionOptions = await this.getUserDecryptionOptions(userId);
+
+      if (
+        !userDecryptionOptions?.webAuthnPrfOptions ||
+        userDecryptionOptions.webAuthnPrfOptions.length === 0
+      ) {
+        throw new Error("No WebAuthn PRF option found for user - cannot perform PRF unlock");
+      }
+
+      // Get the credential ID from the response to find the matching option
+      const responseCredentialId = Fido2Utils.bufferToString(response.rawId);
+      const webAuthnPrfOption = userDecryptionOptions.webAuthnPrfOptions.find(
+        (option) => option.credentialId === responseCredentialId,
+      );
+
+      if (!webAuthnPrfOption) {
+        throw new Error("No matching WebAuthn PRF option found for this credential");
+      }
+
+      // Step 1: Decrypt PRF encrypted private key using the PRF key
+      const privateKey = await this.encryptService.unwrapDecapsulationKey(
+        new EncString(webAuthnPrfOption.encryptedPrivateKey),
+        unlockKey,
+      );
+
+      // Step 2: Use private key to decrypt user key
+      const actualUserKey = await this.encryptService.decapsulateKeyUnsigned(
+        new EncString(webAuthnPrfOption.encryptedUserKey),
+        privateKey,
+      );
+
+      if (!actualUserKey) {
+        throw new Error("Failed to decrypt user key from private key");
+      }
+
+      // Step 3: Set the actual user key
+      await this.keyService.setUserKey(actualUserKey as UserKey, userIdTyped);
+
+      return true;
+    } catch (error) {
+      this.logService?.error("PRF unlock failed:", error);
+      return false;
+    }
+  }
+
+  async getUnlockWithPrfSalt(): Promise<ArrayBuffer> {
+    try {
+      // Use the same salt as login to ensure PRF keys match
+      return await this.webAuthnLoginPrfKeyService.getLoginWithPrfSalt();
+    } catch (error) {
+      this.logService?.error("Error getting unlock PRF salt:", error);
+      throw error;
+    }
+  }
+
+  async createUnlockKeyFromPrf(prf: ArrayBuffer): Promise<PrfKey> {
+    try {
+      return await this.webAuthnLoginPrfKeyService.createSymmetricKeyFromPrf(prf);
+    } catch (error) {
+      this.logService?.error("Failed to create unlock key from PRF:", error);
+      throw error;
+    }
+  }
+
+  /**
+   * Helper method to get user decryption options for a user
+   */
+  private async getUserDecryptionOptions(userId: string): Promise<UserDecryptionOptions | null> {
+    try {
+      return (await firstValueFrom(
+        this.userDecryptionOptionsService.userDecryptionOptionsById$(userId as UserId),
+      )) as UserDecryptionOptions;
+    } catch (error) {
+      this.logService?.error("Error getting user decryption options:", error);
+      return null;
+    }
+  }
+
+  /**
+   * Helper method to get the appropriate rpId for WebAuthn PRF operations
+   * Returns the hostname from the user's environment configuration
+   */
+  private async getRpIdForUser(userId: string): Promise<string> {
+    try {
+      const environment = await firstValueFrom(
+        this.environmentService.getEnvironment$(userId as UserId),
+      );
+      const hostname = environment.getHostname();
+
+      return hostname;
+    } catch (error) {
+      this.logService?.error("Error getting rpId", error);
+      return "";
+    }
+  }
+}

--- a/libs/key-management/src/services/webauthn/webauthn-prf-unlock.service.ts
+++ b/libs/key-management/src/services/webauthn/webauthn-prf-unlock.service.ts
@@ -91,7 +91,7 @@ export class WebAuthnPrfUnlockService implements WebAuthnPrfUnlockServiceAbstrac
           rpId: rpId,
           userVerification: "preferred", // Allow platform authenticators to work properly
           extensions: {
-            prf: { eval: { first: prfSalt } },
+            prf: { eval: { first: prfSalt } } as any,
           },
         },
       };


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-2035

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

This PR introduces PRF powered unlock in our web + browser clients. It sits on top of the `browser-prf` branch since until that branch is merged.

Here's a summary of the changes:

* PRF Decryption Options for *all* the users passkeys are included in the server sync response and stored. This allows both offline unlock, but also allows for unlock via any passkey, regardless of method of login.
* New KM owned `webauthn-prf-unlock.service.ts`. Internally it forwards a few calls to the existing `WebAuthnLoginPrfKeyServiceAbstraction`.

All PRF enabled passkes are included in 

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
