### PR TITLE
[PM-26329] Bugfixes to all-activities cards

### DIFF
--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -59,8 +59,8 @@
   "createNewLoginItem": {
     "message": "Create new login item"
   },
-  "onceYouMarkCriticalApplicationsActivityDescription": {
-    "message": "Once you mark applications critical, they will display here."
+  "onceYouMarkApplicationsCriticalTheyWillDisplayHere": {
+    "message": "Once you mark applications critical, they will display here"
   },
   "viewAtRiskMembers": {
     "message": "View at-risk members"
@@ -165,8 +165,8 @@
   "membersAtRiskActivityDescription":{
     "message": "Members with edit access to at-risk items for critical applications"
   },
-  "membersAtRisk": {
-    "message": "$COUNT$ members at risk",
+  "membersAtRiskCount": {
+    "message": "$COUNT$ members at-risk",
     "placeholders": {
       "count": {
         "content": "$1",

--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/all-activity.component.html
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/all-activity.component.html
@@ -22,7 +22,7 @@
       <dirt-activity-card
         class="tw-col-span-2 tw-cursor-pointer"
         [title]="'atRiskMembers' | i18n"
-        [cardMetrics]="'membersAtRisk' | i18n: totalCriticalAppsAtRiskMemberCount"
+        [cardMetrics]="'membersAtRiskCount' | i18n: totalCriticalAppsAtRiskMemberCount"
         [metricDescription]="'membersAtRiskActivityDescription' | i18n"
         navigationText="{{ 'viewAtRiskMembers' | i18n }}"
         navigationLink="{{ getLinkForRiskInsightsTab(RiskInsightsTabType.AllApps) }}"
@@ -37,11 +37,11 @@
         [cardMetrics]="
           totalCriticalAppsCount === 0
             ? ('countOfCriticalApplications' | i18n: totalCriticalAppsCount)
-            : ('countOfApplicationsAtRisk' | i18n: totalCriticalAppsCount)
+            : ('countOfApplicationsAtRisk' | i18n: totalCriticalAppsAtRiskCount)
         "
         [metricDescription]="
           totalCriticalAppsCount === 0
-            ? ('onceYouMarkCriticalApplicationsActivityDescription' | i18n)
+            ? ('onceYouMarkApplicationsCriticalTheyWillDisplayHere' | i18n)
             : ('criticalApplicationsAreAtRisk'
               | i18n: totalCriticalAppsAtRiskCount : totalCriticalAppsCount)
         "


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-26329

## 📔 Objective

The text of the cards must be consistent to Bitwarden nomenclature, example: at-risk should be a hyphenated word
The count of at-risk applications within the critical apps tab was incorrect - this was fixed.

## 📸 Screenshots

### Cards with data
<img width="2390" height="1024" alt="image" src="https://github.com/user-attachments/assets/d5ddc1a6-8f74-4ea2-9546-df28676ad49e" />

### Cards w/out data
<img width="2424" height="958" alt="image" src="https://github.com/user-attachments/assets/78f9987c-a658-4921-81a1-9785042b43c0" />


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
