### PR TITLE
[PM-22454] Autofill correct login form from extension

### DIFF
--- a/apps/browser/src/autofill/services/autofill.service.ts
+++ b/apps/browser/src/autofill/services/autofill.service.ts
@@ -2299,9 +2299,7 @@ export default class AutofillService implements AutofillServiceInterface {
           if (includesUsernameFieldName) {
             return f;
           }
-        }
-
-        if (includesUsernameFieldName && !isInSameForm) {
+        } else {
           usernameField = f;
         }
       }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-22454](https://bitwarden.atlassian.net/browse/PM-22454)

## 📔 Objective

The booksamillion.com sign in page has an account creation form and a login form that are side by side.  The overlay was filling in correctly but the extension and context menu were not.  Now filling from the extension and context menu fill in the correct fields.

## 📸 Screenshots

https://github.com/user-attachments/assets/06aa390c-0115-4cdf-a273-48331527c8a9

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-22454]: https://bitwarden.atlassian.net/browse/PM-22454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ