### PR TITLE
[PM-25166]Hide and Show Old Premium Banner Depending On the Feature Flag

### DIFF
--- a/apps/web/src/app/vault/individual-vault/vault-banners/vault-banners.component.spec.ts
+++ b/apps/web/src/app/vault/individual-vault/vault-banners/vault-banners.component.spec.ts
@@ -8,6 +8,7 @@ import { I18nPipe } from "@bitwarden/angular/platform/pipes/i18n.pipe";
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { TokenService } from "@bitwarden/common/auth/abstractions/token.service";
+import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
@@ -29,6 +30,7 @@ describe("VaultBannersComponent", () => {
   let messageSubject: Subject<{ command: string }>;
   const premiumBanner$ = new BehaviorSubject<boolean>(false);
   const pendingAuthRequest$ = new BehaviorSubject<boolean>(false);
+  const premiumUpgradeNewDesignFlag$ = new BehaviorSubject<boolean>(false);
   const mockUserId = Utils.newGuid() as UserId;
 
   const bannerService = mock<VaultBannersService>({
@@ -88,7 +90,14 @@ describe("VaultBannersComponent", () => {
         },
         {
           provide: ConfigService,
-          useValue: mock<ConfigService>(),
+          useValue: mock<ConfigService>({
+            getFeatureFlag$: jest.fn((flag: FeatureFlag) => {
+              if (flag === FeatureFlag.PremiumUpgradeNewDesign) {
+                return premiumUpgradeNewDesignFlag$;
+              }
+              return new BehaviorSubject(false);
+            }),
+          }),
         },
       ],
     })
@@ -104,8 +113,14 @@ describe("VaultBannersComponent", () => {
   });
 
   describe("premiumBannerVisible$", () => {
-    it("shows premium banner", async () => {
+    beforeEach(() => {
+      // Reset feature flag to default (false) before each test
+      premiumUpgradeNewDesignFlag$.next(false);
+    });
+
+    it("shows premium banner when shouldShowPremiumBanner is true and feature flag is off", async () => {
       premiumBanner$.next(true);
+      premiumUpgradeNewDesignFlag$.next(false);
 
       fixture.detectChanges();
 
@@ -113,8 +128,29 @@ describe("VaultBannersComponent", () => {
       expect(banner.componentInstance.bannerType()).toBe("premium");
     });
 
-    it("dismisses premium banner", async () => {
+    it("hides premium banner when feature flag is enabled", async () => {
+      premiumBanner$.next(true);
+      premiumUpgradeNewDesignFlag$.next(true);
+
+      fixture.detectChanges();
+
+      const banner = fixture.debugElement.query(By.directive(BannerComponent));
+      expect(banner).toBeNull();
+    });
+
+    it("dismisses premium banner when shouldShowPremiumBanner is false", async () => {
       premiumBanner$.next(false);
+      premiumUpgradeNewDesignFlag$.next(false);
+
+      fixture.detectChanges();
+
+      const banner = fixture.debugElement.query(By.directive(BannerComponent));
+      expect(banner).toBeNull();
+    });
+
+    it("hides premium banner when both shouldShowPremiumBanner is false and feature flag is enabled", async () => {
+      premiumBanner$.next(false);
+      premiumUpgradeNewDesignFlag$.next(true);
 
       fixture.detectChanges();
 

--- a/apps/web/src/app/vault/individual-vault/vault-banners/vault-banners.component.ts
+++ b/apps/web/src/app/vault/individual-vault/vault-banners/vault-banners.component.ts
@@ -1,10 +1,12 @@
 import { Component, Input, OnInit } from "@angular/core";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { Router } from "@angular/router";
-import { filter, firstValueFrom, map, Observable, switchMap } from "rxjs";
+import { combineLatest, filter, firstValueFrom, map, Observable, switchMap } from "rxjs";
 
 import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { MessageListener } from "@bitwarden/common/platform/messaging";
 import { UserId } from "@bitwarden/common/types/guid";
 import { BannerModule } from "@bitwarden/components";
@@ -39,10 +41,21 @@ export class VaultBannersComponent implements OnInit {
     private router: Router,
     private accountService: AccountService,
     private messageListener: MessageListener,
+    private configService: ConfigService,
   ) {
     this.premiumBannerVisible$ = this.activeUserId$.pipe(
       filter((userId): userId is UserId => userId != null),
-      switchMap((userId) => this.vaultBannerService.shouldShowPremiumBanner$(userId)),
+      switchMap((userId) =>
+        combineLatest([
+          this.vaultBannerService.shouldShowPremiumBanner$(userId),
+          this.configService.getFeatureFlag$(FeatureFlag.PremiumUpgradeNewDesign),
+        ]).pipe(
+          map(
+            ([shouldShowBanner, premiumUpgradeNewDesignEnabled]) =>
+              shouldShowBanner && !premiumUpgradeNewDesignEnabled,
+          ),
+        ),
+      ),
     );
 
     // Listen for auth request messages and show banner immediately

--- a/libs/common/src/enums/feature-flag.enum.ts
+++ b/libs/common/src/enums/feature-flag.enum.ts
@@ -25,6 +25,7 @@ export enum FeatureFlag {
   PM17772_AdminInitiatedSponsorships = "pm-17772-admin-initiated-sponsorships",
   PM21821_ProviderPortalTakeover = "pm-21821-provider-portal-takeover",
   PM22415_TaxIDWarnings = "pm-22415-tax-id-warnings",
+  PremiumUpgradeNewDesign = "pm-24996-implement-upgrade-from-free-dialog",
 
   /* Key Management */
   PrivateKeyRegeneration = "pm-12241-private-key-regeneration",
@@ -101,6 +102,7 @@ export const DefaultFeatureFlagValue = {
   [FeatureFlag.PM17772_AdminInitiatedSponsorships]: FALSE,
   [FeatureFlag.PM21821_ProviderPortalTakeover]: FALSE,
   [FeatureFlag.PM22415_TaxIDWarnings]: FALSE,
+  [FeatureFlag.PremiumUpgradeNewDesign]: FALSE,
 
   /* Key Management */
   [FeatureFlag.PrivateKeyRegeneration]: FALSE,


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-25166

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR deprecates the green "go-premium" banner that appears on the web app vault page for non-premium users. With the introduction of the new navigation premium callout, this banner is no longer needed and should be hidden.

**Changes Made**
**Added feature flag:** PremiumUpgradeNewDesign to control the visibility of the premium banner
**Updated vault banners component:** Modified the premium banner visibility logic to check both the existing shouldShowPremiumBanner condition AND the new feature flag
**Enhanced test coverage:** Added comprehensive test cases to verify the banner behavior with the feature flag enabled/disabled
**Feature flag defaults to false:** Ensures the banner remains visible until the feature is fully rolled out

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
<img width="1728" height="1117" alt="Screenshot 2025-10-01 at 5 45 26 PM" src="https://github.com/user-attachments/assets/b4aa931e-dffd-4715-a846-89ca6c18d19d" />
<img width="1728" height="1117" alt="Screenshot 2025-10-01 at 5 45 20 PM" src="https://github.com/user-attachments/assets/586e64d8-7fe5-4602-b925-1d397b83b5de" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
