### PR TITLE
BRE-1178 - Add Desktop Beta app for the Microsoft Store

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -771,12 +771,13 @@ jobs:
 
       - name: Configure for beta build
         run: |
-          jq '.productName = "Bitwarden Beta" | \
-          .appx.identityName = "8bitSolutionsLLC.BitwardenBeta" | \
-          .appx.artifactName = "Bitwarden-Beta-${version}-${arch}.${ext}" | \
-          .portable.artifactName = "Bitwarden-Beta-Portable-${version}.${ext}" | \
-          .nsisWeb.artifactName = "Bitwarden-Beta-Installer-${version}.${ext}"' \
-          electron-builder.json
+          $config = Get-Content electron-builder.json | ConvertFrom-Json
+          $config.productName = "Bitwarden Beta"
+          $config.appx.identityName = "8bitSolutionsLLC.BitwardenBeta"
+          $config.appx.artifactName = "Bitwarden-Beta-`${version}-`${arch}.`${ext}"
+          $config.portable.artifactName = "Bitwarden-Beta-Portable-`${version}.`${ext}"
+          $config.nsisWeb.artifactName = "Bitwarden-Beta-Installer-`${version}.`${ext}"
+          $config | ConvertTo-Json -Depth 32 | Set-Content electron-builder.json
 
       - name: Build
         run: npm run build
@@ -932,11 +933,6 @@ jobs:
           name: ${{ needs.setup.outputs.release_channel }}-beta.yml
           path: apps/desktop/dist/nsis-web/${{ needs.setup.outputs.release_channel }}.yml
           if-no-files-found: error
-
-      - name: Restore electron-builder config
-        run: |
-          jq '.productName = "Bitwarden" | .appx.identityName = "8bitSolutionsLLC.bitwardendesktop" | .appx.artifactName = "${productName}-${version}-${arch}.${ext}" | .portable.artifactName = "${productName}-Portable-${version}.${ext}" | .nsisWeb.artifactName = "${productName}-Installer-${version}.${ext}"' electron-builder.json > electron-builder-temp.json
-          Move-Item electron-builder-temp.json electron-builder.json
 
 
   macos-build:

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -696,9 +696,6 @@ jobs:
       - name: Install AST
         run: dotnet tool install --global AzureSignTool --version 4.0.1
 
-      - name: Set up environment
-        run: choco install checksum --no-progress
-
       - name: Print environment
         run: |
           node --version
@@ -785,11 +782,6 @@ jobs:
           SIGNING_CLIENT_SECRET: ${{ steps.retrieve-secrets.outputs.code-signing-client-secret }}
           SIGNING_CERT_NAME: ${{ steps.retrieve-secrets.outputs.code-signing-cert-name }}
         run: npm run pack:win:beta
-
-      - name: Test
-        if: always()
-        shell: bash
-        run: ls -alhR ./dist/
 
       - name: Rename appx files for store
         if: ${{ needs.setup.outputs.has_secrets == 'true' }}

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -781,13 +781,6 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Test
-        shell: bash
-        run: |
-          pwd
-          ls -alh
-          ls -alh ./dist
-
       - name: Pack
         if: ${{ needs.setup.outputs.has_secrets == 'false' }}
         run: npm run pack:win
@@ -802,6 +795,14 @@ jobs:
           SIGNING_CLIENT_SECRET: ${{ steps.retrieve-secrets.outputs.code-signing-client-secret }}
           SIGNING_CERT_NAME: ${{ steps.retrieve-secrets.outputs.code-signing-cert-name }}
         run: npm run pack:win
+
+      - name: Test
+        if: always()
+        shell: bash
+        run: |
+          pwd
+          ls -alh
+          ls -alh ./dist
 
       - name: Rename appx files for store
         if: ${{ needs.setup.outputs.has_secrets == 'true' }}

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -801,18 +801,6 @@ jobs:
           Copy-Item "./dist/Bitwarden-Beta-${{ env._PACKAGE_VERSION }}-arm64.appx" `
             -Destination "./dist/Bitwarden-Beta-${{ env._PACKAGE_VERSION }}-arm64-store.appx"
 
-      - name: Package for Chocolatey
-        if: ${{ needs.setup.outputs.has_secrets == 'true' }}
-        run: |
-          Copy-Item -Path ./stores/chocolatey -Destination ./dist/chocolatey -Recurse
-          Copy-Item -Path ./dist/nsis-web/Bitwarden-Beta-Installer-${{ env._PACKAGE_VERSION }}.exe `
-          -Destination ./dist/chocolatey
-
-          $checksum = checksum -t sha256 ./dist/chocolatey/Bitwarden-Beta-Installer-${{ env._PACKAGE_VERSION }}.exe
-          $chocoInstall = "./dist/chocolatey/tools/chocolateyinstall.ps1"
-          (Get-Content $chocoInstall).replace('__version__', "$env:_PACKAGE_VERSION").replace('__checksum__', $checksum) | Set-Content $chocoInstall
-          choco pack ./dist/chocolatey/bitwarden.nuspec --version "$env:_PACKAGE_VERSION" --out ./dist/chocolatey
-
       - name: Fix NSIS artifact names for auto-updater
         if: ${{ needs.setup.outputs.has_secrets == 'true' }}
         run: |
@@ -908,14 +896,6 @@ jobs:
         with:
           name: bitwarden-beta-${{ env._PACKAGE_VERSION }}-arm64.nsis.7z
           path: apps/desktop/dist/nsis-web/bitwarden-beta-${{ env._PACKAGE_VERSION }}-arm64.nsis.7z
-          if-no-files-found: error
-
-      - name: Upload nupkg artifact
-        if: ${{ needs.setup.outputs.has_secrets == 'true' }}
-        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
-        with:
-          name: bitwarden.${{ env._PACKAGE_VERSION }}.nupkg
-          path: apps/desktop/dist/chocolatey/bitwarden.${{ env._PACKAGE_VERSION }}.nupkg
           if-no-files-found: error
 
       - name: Upload auto-update artifact

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -684,7 +684,7 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          ref: ${{  github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up Node
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
@@ -768,20 +768,12 @@ jobs:
         working-directory: apps/desktop/desktop_native
         run: node build.js cross-platform
 
-      - name: Configure for beta build
-        run: |
-          $config = Get-Content electron-builder.json | ConvertFrom-Json
-          $config.productName = "Bitwarden-Beta"
-          $config.extraMetadata.name = "bitwarden-beta"
-          $config.appx.identityName = "8bitSolutionsLLC.BitwardenBeta"
-          $config | ConvertTo-Json -Depth 32 | Set-Content electron-builder.json
-
       - name: Build
         run: npm run build
 
       - name: Pack
         if: ${{ needs.setup.outputs.has_secrets == 'false' }}
-        run: npm run pack:win
+        run: npm run pack:win:beta
 
       - name: Pack & Sign
         if: ${{ needs.setup.outputs.has_secrets == 'true' }}
@@ -792,7 +784,7 @@ jobs:
           SIGNING_TENANT_ID: ${{ steps.retrieve-secrets.outputs.code-signing-tenant-id }}
           SIGNING_CLIENT_SECRET: ${{ steps.retrieve-secrets.outputs.code-signing-client-secret }}
           SIGNING_CERT_NAME: ${{ steps.retrieve-secrets.outputs.code-signing-cert-name }}
-        run: npm run pack:win
+        run: npm run pack:win:beta
 
       - name: Test
         if: always()

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -771,11 +771,8 @@ jobs:
       - name: Configure for beta build
         run: |
           $config = Get-Content electron-builder.json | ConvertFrom-Json
-          $config.productName = "Bitwarden Beta"
+          $config.productName = "Bitwarden-Beta"
           $config.appx.identityName = "8bitSolutionsLLC.BitwardenBeta"
-          $config.appx.artifactName = "Bitwarden-Beta-`${version}-`${arch}.`${ext}"
-          $config.portable.artifactName = "Bitwarden-Beta-Portable-`${version}.`${ext}"
-          $config.nsisWeb.artifactName = "Bitwarden-Beta-Installer-`${version}.`${ext}"
           $config | ConvertTo-Json -Depth 32 | Set-Content electron-builder.json
 
       - name: Build

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -668,8 +668,7 @@ jobs:
   windows-beta:
     name: Windows Beta Build
     runs-on: windows-2022
-    needs:
-      - setup
+    needs: setup
     permissions:
         contents: read
         id-token: write
@@ -782,10 +781,13 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Test
+        shell: bash
+        run: ls -alh dist
+
       - name: Pack
         if: ${{ needs.setup.outputs.has_secrets == 'false' }}
-        run: |
-          npm run pack:win
+        run: npm run pack:win
 
       - name: Pack & Sign
         if: ${{ needs.setup.outputs.has_secrets == 'true' }}
@@ -796,8 +798,7 @@ jobs:
           SIGNING_TENANT_ID: ${{ steps.retrieve-secrets.outputs.code-signing-tenant-id }}
           SIGNING_CLIENT_SECRET: ${{ steps.retrieve-secrets.outputs.code-signing-client-secret }}
           SIGNING_CERT_NAME: ${{ steps.retrieve-secrets.outputs.code-signing-cert-name }}
-        run: |
-          npm run pack:win
+        run: npm run pack:win
 
       - name: Rename appx files for store
         if: ${{ needs.setup.outputs.has_secrets == 'true' }}

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -772,6 +772,7 @@ jobs:
         run: |
           $config = Get-Content electron-builder.json | ConvertFrom-Json
           $config.productName = "Bitwarden-Beta"
+          $config.extraMetadata.name = "bitwarden-beta"
           $config.appx.identityName = "8bitSolutionsLLC.BitwardenBeta"
           $config | ConvertTo-Json -Depth 32 | Set-Content electron-builder.json
 

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -799,10 +799,7 @@ jobs:
       - name: Test
         if: always()
         shell: bash
-        run: |
-          pwd
-          ls -alh
-          ls -alh ./dist
+        run: ls -alh ./dist/win-unpacked
 
       - name: Rename appx files for store
         if: ${{ needs.setup.outputs.has_secrets == 'true' }}

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -771,8 +771,12 @@ jobs:
 
       - name: Configure for beta build
         run: |
-          jq '.productName = "Bitwarden Beta" | .appx.identityName = "8bitSolutionsLLC.BitwardenBeta" | .appx.artifactName = "Bitwarden-Beta-${version}-${arch}.${ext}" | .portable.artifactName = "Bitwarden-Beta-Portable-${version}.${ext}" | .nsisWeb.artifactName = "Bitwarden-Beta-Installer-${version}.${ext}"' electron-builder.json > electron-builder-temp.json
-          Move-Item electron-builder-temp.json electron-builder.json
+          jq '.productName = "Bitwarden Beta" | \
+          .appx.identityName = "8bitSolutionsLLC.BitwardenBeta" | \
+          .appx.artifactName = "Bitwarden-Beta-${version}-${arch}.${ext}" | \
+          .portable.artifactName = "Bitwarden-Beta-Portable-${version}.${ext}" | \
+          .nsisWeb.artifactName = "Bitwarden-Beta-Installer-${version}.${ext}"' \
+          electron-builder.json
 
       - name: Build
         run: npm run build

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -796,7 +796,7 @@ jobs:
       - name: Test
         if: always()
         shell: bash
-        run: ls -alh ./dist/win-unpacked
+        run: ls -alhR ./dist/
 
       - name: Rename appx files for store
         if: ${{ needs.setup.outputs.has_secrets == 'true' }}

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -665,6 +665,275 @@ jobs:
           path: apps/desktop/dist/nsis-web/${{ needs.setup.outputs.release_channel }}.yml
           if-no-files-found: error
 
+  windows-beta:
+    name: Windows Beta Build
+    runs-on: windows-2022
+    needs:
+      - setup
+    permissions:
+        contents: read
+        id-token: write
+    defaults:
+      run:
+        shell: pwsh
+        working-directory: apps/desktop
+    env:
+      _PACKAGE_VERSION: ${{ needs.setup.outputs.package_version }}
+      _NODE_VERSION: ${{ needs.setup.outputs.node_version }}
+      NODE_OPTIONS: --max_old_space_size=4096
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{  github.event.pull_request.head.sha }}
+
+      - name: Set up Node
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        with:
+          cache: 'npm'
+          cache-dependency-path: '**/package-lock.json'
+          node-version: ${{ env._NODE_VERSION }}
+
+      - name: Install AST
+        run: dotnet tool install --global AzureSignTool --version 4.0.1
+
+      - name: Set up environment
+        run: choco install checksum --no-progress
+
+      - name: Print environment
+        run: |
+          node --version
+          npm --version
+          choco --version
+          rustup show
+
+      - name: Log in to Azure
+        if: ${{ needs.setup.outputs.has_secrets == 'true' }}
+        uses: bitwarden/gh-actions/azure-login@main
+        with:
+          subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          tenant_id: ${{ secrets.AZURE_TENANT_ID }}
+          client_id: ${{ secrets.AZURE_CLIENT_ID }}
+
+      - name: Retrieve secrets
+        id: retrieve-secrets
+        if: ${{ needs.setup.outputs.has_secrets == 'true' }}
+        uses: bitwarden/gh-actions/get-keyvault-secrets@main
+        with:
+          keyvault: "bitwarden-ci"
+          secrets: "code-signing-vault-url,
+            code-signing-client-id,
+            code-signing-tenant-id,
+            code-signing-client-secret,
+            code-signing-cert-name"
+
+      - name: Log out from Azure
+        if: ${{ needs.setup.outputs.has_secrets == 'true' }}
+        uses: bitwarden/gh-actions/azure-logout@main
+
+      - name: Install Node dependencies
+        run: npm ci
+        working-directory: ./
+
+      - name: Download SDK Artifacts
+        if: ${{ inputs.sdk_branch != '' && needs.setup.outputs.has_secrets == 'true' }}
+        uses: bitwarden/gh-actions/download-artifacts@main
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          workflow: build-wasm-internal.yml
+          workflow_conclusion: success
+          branch: ${{ inputs.sdk_branch }}
+          artifacts: sdk-internal
+          repo: bitwarden/sdk-internal
+          path: ../sdk-internal
+          if_no_artifact_found: fail
+
+      - name: Override SDK
+        if: ${{ inputs.sdk_branch != '' && needs.setup.outputs.has_secrets == 'true' }}
+        working-directory: ./
+        run: |
+          ls -l ../
+          npm link ../sdk-internal
+
+      - name: Cache Native Module
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        id: cache
+        with:
+          path: |
+            apps/desktop/desktop_native/napi/*.node
+            apps/desktop/desktop_native/dist/*
+          key: rust-${{ runner.os }}-${{ hashFiles('apps/desktop/desktop_native/**/*') }}
+
+      - name: Build Native Module
+        if: steps.cache.outputs.cache-hit != 'true'
+        working-directory: apps/desktop/desktop_native
+        run: node build.js cross-platform
+
+      - name: Configure for beta build
+        run: |
+          jq '.productName = "Bitwarden Beta" | .appx.identityName = "8bitSolutionsLLC.BitwardenBeta" | .appx.artifactName = "Bitwarden-Beta-${version}-${arch}.${ext}" | .portable.artifactName = "Bitwarden-Beta-Portable-${version}.${ext}" | .nsisWeb.artifactName = "Bitwarden-Beta-Installer-${version}.${ext}"' electron-builder.json > electron-builder-temp.json
+          Move-Item electron-builder-temp.json electron-builder.json
+
+      - name: Build
+        run: npm run build
+
+      - name: Pack
+        if: ${{ needs.setup.outputs.has_secrets == 'false' }}
+        run: |
+          npm run pack:win
+
+      - name: Pack & Sign
+        if: ${{ needs.setup.outputs.has_secrets == 'true' }}
+        env:
+          ELECTRON_BUILDER_SIGN: 1
+          SIGNING_VAULT_URL: ${{ steps.retrieve-secrets.outputs.code-signing-vault-url }}
+          SIGNING_CLIENT_ID: ${{ steps.retrieve-secrets.outputs.code-signing-client-id }}
+          SIGNING_TENANT_ID: ${{ steps.retrieve-secrets.outputs.code-signing-tenant-id }}
+          SIGNING_CLIENT_SECRET: ${{ steps.retrieve-secrets.outputs.code-signing-client-secret }}
+          SIGNING_CERT_NAME: ${{ steps.retrieve-secrets.outputs.code-signing-cert-name }}
+        run: |
+          npm run pack:win
+
+      - name: Rename appx files for store
+        if: ${{ needs.setup.outputs.has_secrets == 'true' }}
+        run: |
+          Copy-Item "./dist/Bitwarden-Beta-${{ env._PACKAGE_VERSION }}-ia32.appx" `
+            -Destination "./dist/Bitwarden-Beta-${{ env._PACKAGE_VERSION }}-ia32-store.appx"
+          Copy-Item "./dist/Bitwarden-Beta-${{ env._PACKAGE_VERSION }}-x64.appx" `
+            -Destination "./dist/Bitwarden-Beta-${{ env._PACKAGE_VERSION }}-x64-store.appx"
+          Copy-Item "./dist/Bitwarden-Beta-${{ env._PACKAGE_VERSION }}-arm64.appx" `
+            -Destination "./dist/Bitwarden-Beta-${{ env._PACKAGE_VERSION }}-arm64-store.appx"
+
+      - name: Package for Chocolatey
+        if: ${{ needs.setup.outputs.has_secrets == 'true' }}
+        run: |
+          Copy-Item -Path ./stores/chocolatey -Destination ./dist/chocolatey -Recurse
+          Copy-Item -Path ./dist/nsis-web/Bitwarden-Beta-Installer-${{ env._PACKAGE_VERSION }}.exe `
+          -Destination ./dist/chocolatey
+
+          $checksum = checksum -t sha256 ./dist/chocolatey/Bitwarden-Beta-Installer-${{ env._PACKAGE_VERSION }}.exe
+          $chocoInstall = "./dist/chocolatey/tools/chocolateyinstall.ps1"
+          (Get-Content $chocoInstall).replace('__version__', "$env:_PACKAGE_VERSION").replace('__checksum__', $checksum) | Set-Content $chocoInstall
+          choco pack ./dist/chocolatey/bitwarden.nuspec --version "$env:_PACKAGE_VERSION" --out ./dist/chocolatey
+
+      - name: Fix NSIS artifact names for auto-updater
+        if: ${{ needs.setup.outputs.has_secrets == 'true' }}
+        run: |
+          Rename-Item -Path .\dist\nsis-web\Bitwarden-Beta-${{ env._PACKAGE_VERSION }}-ia32.nsis.7z `
+            -NewName bitwarden-beta-${{ env._PACKAGE_VERSION }}-ia32.nsis.7z
+          Rename-Item -Path .\dist\nsis-web\Bitwarden-Beta-${{ env._PACKAGE_VERSION }}-x64.nsis.7z `
+            -NewName bitwarden-beta-${{ env._PACKAGE_VERSION }}-x64.nsis.7z
+          Rename-Item -Path .\dist\nsis-web\Bitwarden-Beta-${{ env._PACKAGE_VERSION }}-arm64.nsis.7z `
+            -NewName bitwarden-beta-${{ env._PACKAGE_VERSION }}-arm64.nsis.7z
+
+      - name: Upload portable exe artifact
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: Bitwarden-Beta-Portable-${{ env._PACKAGE_VERSION }}.exe
+          path: apps/desktop/dist/Bitwarden-Beta-Portable-${{ env._PACKAGE_VERSION }}.exe
+          if-no-files-found: error
+
+      - name: Upload installer exe artifact
+        if: ${{ needs.setup.outputs.has_secrets == 'true' }}
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: Bitwarden-Beta-Installer-${{ env._PACKAGE_VERSION }}.exe
+          path: apps/desktop/dist/nsis-web/Bitwarden-Beta-Installer-${{ env._PACKAGE_VERSION }}.exe
+          if-no-files-found: error
+
+      - name: Upload appx ia32 artifact
+        if: ${{ needs.setup.outputs.has_secrets == 'true' }}
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: Bitwarden-Beta-${{ env._PACKAGE_VERSION }}-ia32.appx
+          path: apps/desktop/dist/Bitwarden-Beta-${{ env._PACKAGE_VERSION }}-ia32.appx
+          if-no-files-found: error
+
+      - name: Upload store appx ia32 artifact
+        if: ${{ needs.setup.outputs.has_secrets == 'true' }}
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: Bitwarden-Beta-${{ env._PACKAGE_VERSION }}-ia32-store.appx
+          path: apps/desktop/dist/Bitwarden-Beta-${{ env._PACKAGE_VERSION }}-ia32-store.appx
+          if-no-files-found: error
+
+      - name: Upload NSIS ia32 artifact
+        if: ${{ needs.setup.outputs.has_secrets == 'true' }}
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: bitwarden-beta-${{ env._PACKAGE_VERSION }}-ia32.nsis.7z
+          path: apps/desktop/dist/nsis-web/bitwarden-beta-${{ env._PACKAGE_VERSION }}-ia32.nsis.7z
+          if-no-files-found: error
+
+      - name: Upload appx x64 artifact
+        if: ${{ needs.setup.outputs.has_secrets == 'true' }}
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: Bitwarden-Beta-${{ env._PACKAGE_VERSION }}-x64.appx
+          path: apps/desktop/dist/Bitwarden-Beta-${{ env._PACKAGE_VERSION }}-x64.appx
+          if-no-files-found: error
+
+      - name: Upload store appx x64 artifact
+        if: ${{ needs.setup.outputs.has_secrets == 'true' }}
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: Bitwarden-Beta-${{ env._PACKAGE_VERSION }}-x64-store.appx
+          path: apps/desktop/dist/Bitwarden-Beta-${{ env._PACKAGE_VERSION }}-x64-store.appx
+          if-no-files-found: error
+
+      - name: Upload NSIS x64 artifact
+        if: ${{ needs.setup.outputs.has_secrets == 'true' }}
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: bitwarden-beta-${{ env._PACKAGE_VERSION }}-x64.nsis.7z
+          path: apps/desktop/dist/nsis-web/bitwarden-beta-${{ env._PACKAGE_VERSION }}-x64.nsis.7z
+          if-no-files-found: error
+
+      - name: Upload appx ARM64 artifact
+        if: ${{ needs.setup.outputs.has_secrets == 'true' }}
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: Bitwarden-Beta-${{ env._PACKAGE_VERSION }}-arm64.appx
+          path: apps/desktop/dist/Bitwarden-Beta-${{ env._PACKAGE_VERSION }}-arm64.appx
+          if-no-files-found: error
+
+      - name: Upload store appx ARM64 artifact
+        if: ${{ needs.setup.outputs.has_secrets == 'true' }}
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: Bitwarden-Beta-${{ env._PACKAGE_VERSION }}-arm64-store.appx
+          path: apps/desktop/dist/Bitwarden-Beta-${{ env._PACKAGE_VERSION }}-arm64-store.appx
+          if-no-files-found: error
+
+      - name: Upload NSIS ARM64 artifact
+        if: ${{ needs.setup.outputs.has_secrets == 'true' }}
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: bitwarden-beta-${{ env._PACKAGE_VERSION }}-arm64.nsis.7z
+          path: apps/desktop/dist/nsis-web/bitwarden-beta-${{ env._PACKAGE_VERSION }}-arm64.nsis.7z
+          if-no-files-found: error
+
+      - name: Upload nupkg artifact
+        if: ${{ needs.setup.outputs.has_secrets == 'true' }}
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: bitwarden.${{ env._PACKAGE_VERSION }}.nupkg
+          path: apps/desktop/dist/chocolatey/bitwarden.${{ env._PACKAGE_VERSION }}.nupkg
+          if-no-files-found: error
+
+      - name: Upload auto-update artifact
+        if: ${{ needs.setup.outputs.has_secrets == 'true' }}
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: ${{ needs.setup.outputs.release_channel }}-beta.yml
+          path: apps/desktop/dist/nsis-web/${{ needs.setup.outputs.release_channel }}.yml
+          if-no-files-found: error
+
+      - name: Restore electron-builder config
+        run: |
+          jq '.productName = "Bitwarden" | .appx.identityName = "8bitSolutionsLLC.bitwardendesktop" | .appx.artifactName = "${productName}-${version}-${arch}.${ext}" | .portable.artifactName = "${productName}-Portable-${version}.${ext}" | .nsisWeb.artifactName = "${productName}-Installer-${version}.${ext}"' electron-builder.json > electron-builder-temp.json
+          Move-Item electron-builder-temp.json electron-builder.json
+
 
   macos-build:
     name: MacOS Build

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -783,7 +783,10 @@ jobs:
 
       - name: Test
         shell: bash
-        run: ls -alh dist
+        run: |
+          pwd
+          ls -alh
+          ls -alh ./dist
 
       - name: Pack
         if: ${{ needs.setup.outputs.has_secrets == 'false' }}

--- a/apps/desktop/electron-builder.beta.json
+++ b/apps/desktop/electron-builder.beta.json
@@ -1,0 +1,132 @@
+{
+  "extraMetadata": {
+    "name": "bitwarden-beta"
+  },
+  "productName": "Bitwarden Beta",
+  "appId": "com.bitwarden.desktop.beta",
+  "buildDependenciesFromSource": true,
+  "copyright": "Copyright © 2015-2025 Bitwarden Inc.",
+  "directories": {
+    "buildResources": "resources",
+    "output": "dist",
+    "app": "build"
+  },
+  "afterSign": "scripts/after-sign.js",
+  "afterPack": "scripts/after-pack.js",
+  "asarUnpack": ["**/*.node"],
+  "files": [
+    "**/*",
+    "!**/node_modules/@bitwarden/desktop-napi/**/*",
+    "**/node_modules/@bitwarden/desktop-napi/index.js",
+    "**/node_modules/@bitwarden/desktop-napi/desktop_napi.${platform}-${arch}*.node"
+  ],
+  "electronVersion": "36.8.1",
+  "generateUpdatesFilesForAllChannels": true,
+  "publish": {
+    "provider": "generic",
+    "url": "https://artifacts.bitwarden.com/desktop"
+  },
+  "win": {
+    "electronUpdaterCompatibility": ">=0.0.1",
+    "target": ["portable", "nsis-web", "appx"],
+    "signtoolOptions": {
+      "sign": "./sign.js"
+    },
+    "extraFiles": [
+      {
+        "from": "desktop_native/dist/desktop_proxy.${platform}-${arch}.exe",
+        "to": "desktop_proxy.exe"
+      }
+    ]
+  },
+  "nsisWeb": {
+    "oneClick": false,
+    "perMachine": false,
+    "allowToChangeInstallationDirectory": false,
+    "artifactName": "${productName}-Installer-${version}.${ext}",
+    "uninstallDisplayName": "${productName}",
+    "deleteAppDataOnUninstall": true,
+    "include": "installer.nsh"
+  },
+  "portable": {
+    "artifactName": "${productName}-Portable-${version}.${ext}"
+  },
+  "appx": {
+    "artifactName": "${productName}-${version}-${arch}.${ext}",
+    "backgroundColor": "#175DDC",
+    "applicationId": "BitwardenBeta",
+    "identityName": "8bitSolutionsLLC.BitwardenBeta",
+    "publisher": "CN=14D52771-DE3C-4886-B8BF-825BA7690418",
+    "publisherDisplayName": "Bitwarden Inc",
+    "languages": [
+      "en-US",
+      "af",
+      "ar",
+      "az-latn",
+      "be",
+      "bg",
+      "bn",
+      "bs",
+      "ca",
+      "cs",
+      "cy",
+      "da",
+      "de",
+      "el",
+      "en-gb",
+      "en-in",
+      "es",
+      "et",
+      "eu",
+      "fa",
+      "fi",
+      "fil",
+      "fr",
+      "gl",
+      "he",
+      "hi",
+      "hr",
+      "hu",
+      "id",
+      "it",
+      "ja",
+      "ka",
+      "km",
+      "kn",
+      "ko",
+      "lt",
+      "lv",
+      "ml",
+      "mr",
+      "nb",
+      "ne",
+      "nl",
+      "nn",
+      "or",
+      "pl",
+      "pt-br",
+      "pt-pt",
+      "ro",
+      "ru",
+      "si",
+      "sk",
+      "sl",
+      "sr-cyrl",
+      "sv",
+      "ta",
+      "te",
+      "th",
+      "tr",
+      "uk",
+      "vi",
+      "zh-cn",
+      "zh-tw"
+    ]
+  },
+  "protocols": [
+    {
+      "name": "Bitwarden",
+      "schemes": ["bitwarden"]
+    }
+  ]
+}

--- a/apps/desktop/electron-builder.beta.json
+++ b/apps/desktop/electron-builder.beta.json
@@ -43,16 +43,16 @@
     "oneClick": false,
     "perMachine": false,
     "allowToChangeInstallationDirectory": false,
-    "artifactName": "${productName}-Installer-${version}.${ext}",
+    "artifactName": "Bitwarden-Beta-Installer-${version}.${ext}",
     "uninstallDisplayName": "${productName}",
     "deleteAppDataOnUninstall": true,
     "include": "installer.nsh"
   },
   "portable": {
-    "artifactName": "${productName}-Portable-${version}.${ext}"
+    "artifactName": "Bitwarden-Beta-Portable-${version}.${ext}"
   },
   "appx": {
-    "artifactName": "${productName}-${version}-${arch}.${ext}",
+    "artifactName": "Bitwarden-Beta-${version}-${arch}.${ext}",
     "backgroundColor": "#175DDC",
     "applicationId": "BitwardenBeta",
     "identityName": "8bitSolutionsLLC.BitwardenBeta",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -48,6 +48,7 @@
     "pack:mac:masdev": "npm run clean:dist && electron-builder --mac mas-dev --universal -p never",
     "pack:mac:masdev:with-extension": "npm run clean:dist && npm run build:macos-extension:masdev && electron-builder --mac mas-dev --universal -p never",
     "pack:win": "npm run clean:dist && electron-builder --win --x64 --arm64 --ia32 -p never -c.win.signtoolOptions.certificateSubjectName=\"8bit Solutions LLC\"",
+    "pack:win:beta": "npm run clean:dist && electron-builder --config electron-builder.beta.json --win --x64 --arm64 --ia32 -p never -c.win.signtoolOptions.certificateSubjectName=\"8bit Solutions LLC\"",
     "pack:win:ci": "npm run clean:dist && electron-builder --win --x64 --arm64 --ia32 -p never",
     "dist:dir": "npm run build && npm run pack:dir",
     "dist:lin": "npm run build && npm run pack:lin",

--- a/apps/desktop/scripts/after-pack.js
+++ b/apps/desktop/scripts/after-pack.js
@@ -151,7 +151,7 @@ async function addElectronFuses(context) {
   const IS_LINUX = platform === "linux";
   const executableName = IS_LINUX
     ? context.packager.appInfo.productFilename.toLowerCase().replace("-dev", "").replace(" ", "-")
-    : context.packager.appInfo.productFilename.replace(" ", "-"); // .toLowerCase() to accomodate Linux file named `name` but productFileName is `Name` -- Replaces '-dev' because on Linux the executable name is `name` even for the DEV builds
+    : context.packager.appInfo.productFilename; // .toLowerCase() to accomodate Linux file named `name` but productFileName is `Name` -- Replaces '-dev' because on Linux the executable name is `name` even for the DEV builds
 
   const electronBinaryPath = path.join(context.appOutDir, `${executableName}${ext}`);
 

--- a/apps/desktop/scripts/after-pack.js
+++ b/apps/desktop/scripts/after-pack.js
@@ -151,7 +151,7 @@ async function addElectronFuses(context) {
   const IS_LINUX = platform === "linux";
   const executableName = IS_LINUX
     ? context.packager.appInfo.productFilename.toLowerCase().replace("-dev", "").replace(" ", "-")
-    : context.packager.appInfo.productFilename; // .toLowerCase() to accomodate Linux file named `name` but productFileName is `Name` -- Replaces '-dev' because on Linux the executable name is `name` even for the DEV builds
+    : context.packager.appInfo.productFilename.replace(" ", "-"); // .toLowerCase() to accomodate Linux file named `name` but productFileName is `Name` -- Replaces '-dev' because on Linux the executable name is `name` even for the DEV builds
 
   const electronBinaryPath = path.join(context.appOutDir, `${executableName}${ext}`);
 

--- a/apps/desktop/sign.js
+++ b/apps/desktop/sign.js
@@ -13,7 +13,7 @@ exports.default = async function (configuration) {
         `-fd ${configuration.hash} ` +
         `-du ${configuration.site} ` +
         `-tr http://timestamp.digicert.com ` +
-        `${configuration.path}`,
+        `"${configuration.path}"`,
       {
         stdio: "inherit",
       },

--- a/apps/desktop/src/utils.ts
+++ b/apps/desktop/src/utils.ts
@@ -53,7 +53,8 @@ export function isWindowsStore() {
   if (
     windows &&
     !windowsStore &&
-    process.resourcesPath?.indexOf("8bitSolutionsLLC.bitwardendesktop_") > -1
+    (process.resourcesPath?.indexOf("8bitSolutionsLLC.bitwardendesktop_") > -1 ||
+     process.resourcesPath?.indexOf("8bitSolutionsLLC.BitwardenBeta_") > -1)
   ) {
     windowsStore = true;
   }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
- [BRE-1178](https://bitwarden.atlassian.net/browse/BRE-1178?atlOrigin=eyJpIjoiNGI1YzNjNmI2Y2E5NDU3NTkxNzhmNTZjZjZmZDYyMzUiLCJwIjoiaiJ9)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR adds the ability to generate artifacts for a beta version of our Desktop app for the Microsoft Store.

### Changes:
- Add `windows-beta` job in the Build Desktop workflow.
- Add `electron-builder.beta.json` configuration for building the beta app.
- Add the `pack:win:beta` NPM script that uses the beta config for Electron Builder.
- Update the `sign.js` script to quote the `configuration.path` variable.
- Update the `utils.ts` file to make sure `windowsStore` is still set to true for the beta app.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[BRE-1178]: https://bitwarden.atlassian.net/browse/BRE-1178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ