### PR TITLE
[PM-26440] Fix logic for list filtering for trash and archived items

### DIFF
--- a/apps/cli/src/commands/list.command.ts
+++ b/apps/cli/src/commands/list.command.ts
@@ -304,14 +304,14 @@ export class ListCommand {
   }
 
   /**
-   * Checks if the cipher passes either the trash or the archive options.
-   * @returns true if the cipher passes *any* of the filters
+   * Checks if the cipher passes the state filter options.
+   * @returns true if the cipher matches the requested state
    */
   private matchesStateOptions(c: CipherView, options: Options): boolean {
-    const passesTrashFilter = options.trash && c.isDeleted;
-    const passesArchivedFilter = options.archived && c.isArchived;
+    const passesTrashFilter = options.trash === c.isDeleted;
+    const passesArchivedFilter = options.archived === c.isArchived;
 
-    return passesTrashFilter || passesArchivedFilter;
+    return passesTrashFilter && passesArchivedFilter;
   }
 }
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-26440](https://bitwarden.atlassian.net/browse/PM-26440)

## 📔 Objective

In https://github.com/bitwarden/clients/pull/16502 I introduced a refactor for handling the trash and archive filters on the `list` command. This logic was incorrect by only working when one of the `--trash` or `--archived` filters were defined. It also needs to consider when none of the are passed.
- This updates the logic to match the filter state directly to the state on the cipher, `options.trash === c.isDeleted`,  `options.archived === c.isArchived` and ensure that _both_ pass. 

## 📸 Screenshots

<video src="https://github.com/user-attachments/assets/3ab8094b-361b-4e7a-8ae8-8edaef90440a"/>

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-26440]: https://bitwarden.atlassian.net/browse/PM-26440?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ