### PR TITLE
Re-enable CI to run rust unit tests in desktop_native on Windows platform

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -125,7 +125,7 @@ jobs:
 
       - name: Test Windows
         if: ${{ matrix.os=='windows-2022'}}
-        working-directory: ./apps/desktop/desktop_native/core
+        working-directory: ./apps/desktop/desktop_native
         run: cargo test -- --test-threads=1
 
   rust-coverage:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -126,7 +126,7 @@ jobs:
       - name: Test Windows
         if: ${{ matrix.os=='windows-2022'}}
         working-directory: ./apps/desktop/desktop_native
-        run: cargo test --workspace --exclude=napi -- --test-threads=1
+        run: cargo test --workspace --exclude=desktop_napi -- --test-threads=1
 
   rust-coverage:
     name: Rust Coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -126,7 +126,7 @@ jobs:
       - name: Test Windows
         if: ${{ matrix.os=='windows-2022'}}
         working-directory: ./apps/desktop/desktop_native
-        run: cargo test -- --test-threads=1
+        run: cargo test --workspace --exclude=napi -- --test-threads=1
 
   rust-coverage:
     name: Rust Coverage


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

This was disabled in https://github.com/bitwarden/clients/pull/11003.
I'm opening a PR to re-enable so we have coverage in CI for windows unit tests.

Unit tests are being added to other crates outside of `core` (example: https://github.com/bitwarden/clients/pull/16710)

First tried enabling for all, but still was seeing the errors that resulted in 11003. So excluding only desktop_napi now.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
