### PR TITLE
[PM-662] - add AppPageFocusDirective

### DIFF
--- a/apps/browser/src/platform/popup/layout/popup-header.component.html
+++ b/apps/browser/src/platform/popup/layout/popup-header.component.html
@@ -1,4 +1,4 @@
-<!-- 
+<!--
   end padding is less than start padding to prioritize visual alignment when icon buttons are used at the end of the end slot.
   other elements used at the end of the end slot may need to add their own margin/padding to achieve visual alignment.
 -->
@@ -16,6 +16,7 @@
   <div class="tw-max-w-screen-sm tw-mx-auto tw-flex tw-justify-between tw-w-full">
     <div class="tw-inline-flex tw-items-center tw-gap-2 tw-h-9">
       <button
+        appPageFocus
         bitIconButton="bwi-angle-left"
         type="button"
         *ngIf="showBackButton"

--- a/apps/browser/src/platform/popup/layout/popup-header.component.ts
+++ b/apps/browser/src/platform/popup/layout/popup-header.component.ts
@@ -12,6 +12,7 @@ import {
   TypographyModule,
 } from "@bitwarden/components";
 
+import { AppPageFocusDirective } from "../../../vault/popup/components/a11y/page-focus.directive";
 import { PopupRouterCacheService } from "../view-cache/popup-router-cache.service";
 
 import { PopupPageComponent } from "./popup-page.component";
@@ -19,7 +20,14 @@ import { PopupPageComponent } from "./popup-page.component";
 @Component({
   selector: "popup-header",
   templateUrl: "popup-header.component.html",
-  imports: [TypographyModule, CommonModule, IconButtonModule, JslibModule, AsyncActionsModule],
+  imports: [
+    TypographyModule,
+    CommonModule,
+    IconButtonModule,
+    JslibModule,
+    AsyncActionsModule,
+    AppPageFocusDirective,
+  ],
 })
 export class PopupHeaderComponent {
   private popupRouterCacheService = inject(PopupRouterCacheService);

--- a/apps/browser/src/vault/popup/components/a11y/page-focus.directive.ts
+++ b/apps/browser/src/vault/popup/components/a11y/page-focus.directive.ts
@@ -1,0 +1,32 @@
+import { AfterViewInit, Directive, ElementRef, NgZone } from "@angular/core";
+
+@Directive({
+  selector: "[appPageFocus]",
+  standalone: true,
+})
+export class AppPageFocusDirective implements AfterViewInit {
+  constructor(
+    private el: ElementRef<HTMLElement>,
+    private zone: NgZone,
+  ) {}
+
+  ngAfterViewInit(): void {
+    const el = this.el.nativeElement;
+
+    const naturallyFocusable =
+      el instanceof HTMLButtonElement ||
+      el instanceof HTMLAnchorElement ||
+      el instanceof HTMLInputElement ||
+      el instanceof HTMLTextAreaElement ||
+      el instanceof HTMLSelectElement ||
+      el.hasAttribute("tabindex");
+
+    if (!naturallyFocusable) {
+      el.setAttribute("tabindex", "-1");
+    }
+
+    this.zone.runOutsideAngular(() => {
+      requestAnimationFrame(() => el.focus({ preventScroll: false }));
+    });
+  }
+}


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-662

Fixes https://github.com/bitwarden/clients/issues/3676

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR adds an `AppPageFocus` directive for ensuring focus on the desired element. This PR only adds it to the popup-header component as that what was pointed out in the bug ticket but it can be applied to any focusable html element.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/3b702143-28d5-4ddc-bba8-3c6725c5826c



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
