### PR TITLE
[PM-26495] Activity tab empty state changed

### DIFF
--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -93,7 +93,7 @@
   "sendReminders": {
     "message": "Send reminders"
   },
-  "criticalApplicationsActivityDescription": {
+  "onceYouMarkApplicationsCriticalTheyWillDisplayHere": {
     "message": "Once you mark applications critical, they will display here."
   },
   "viewAtRiskMembers": {

--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/all-activity.component.html
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/all-activity.component.html
@@ -4,19 +4,7 @@
   </div>
 }
 
-@if (!(isLoading$ | async) && (noData$ | async)) {
-  <div class="tw-mt-4">
-    <bit-no-items class="tw-text-main">
-      <ng-container slot="title">
-        <h2 class="tw-font-semibold tw-mt-4">
-          {{ "noAppsInOrgTitle" | i18n: organization?.name }}
-        </h2>
-      </ng-container>
-    </bit-no-items>
-  </div>
-}
-
-@if (!(isLoading$ | async) && !(noData$ | async)) {
+@if (!(isLoading$ | async)) {
   <ul
     class="tw-inline-grid tw-grid-cols-3 tw-gap-6 tw-m-0 tw-p-0 tw-w-full tw-auto-cols-auto tw-list-none"
   >

--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/all-activity.component.ts
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/all-activity.component.ts
@@ -1,7 +1,7 @@
 import { Component, DestroyRef, inject, OnInit } from "@angular/core";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { ActivatedRoute } from "@angular/router";
-import { BehaviorSubject, firstValueFrom } from "rxjs";
+import { firstValueFrom } from "rxjs";
 
 import {
   AllActivitiesService,
@@ -31,7 +31,6 @@ import { RiskInsightsTabType } from "./risk-insights.component";
 })
 export class AllActivityComponent implements OnInit {
   protected isLoading$ = this.dataService.isLoading$;
-  protected noData$ = new BehaviorSubject(true);
   organization: Organization | null = null;
   totalCriticalAppsAtRiskMemberCount = 0;
   totalCriticalAppsCount = 0;
@@ -53,7 +52,6 @@ export class AllActivityComponent implements OnInit {
       this.allActivitiesService.reportSummary$
         .pipe(takeUntilDestroyed(this.destroyRef))
         .subscribe((summary) => {
-          this.noData$.next(summary.totalApplicationCount === 0);
           this.totalCriticalAppsAtRiskMemberCount = summary.totalCriticalAtRiskMemberCount;
           this.totalCriticalAppsCount = summary.totalCriticalApplicationCount;
           this.totalCriticalAppsAtRiskCount = summary.totalCriticalAtRiskApplicationCount;


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-26495

## 📔 Objective

Change the empty state of the All activities tab

## 📸 Screenshots

### When no applications exists or no critical apps exist
<img width="1179" height="614" alt="image" src="https://github.com/user-attachments/assets/c07f0ee6-ee39-48e6-824d-c37a6ab13f7f" />

### When applications exists but no critical apps setup
<img width="1179" height="614" alt="image" src="https://github.com/user-attachments/assets/64b25c49-9cd1-4643-b2ee-d873ab5cc2cc" />


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
