### PR TITLE
Re-enable lock on sleep on snap

### DIFF
--- a/apps/desktop/src/main/power-monitor.main.ts
+++ b/apps/desktop/src/main/power-monitor.main.ts
@@ -4,8 +4,6 @@ import { LogService } from "@bitwarden/common/platform/abstractions/log.service"
 import { MessageSender } from "@bitwarden/common/platform/messaging";
 import { powermonitors } from "@bitwarden/desktop-napi";
 
-import { isSnapStore } from "../utils";
-
 // tslint:disable-next-line
 const IdleLockSeconds = 5 * 60; // 5 minutes
 const IdleCheckInterval = 30 * 1000; // 30 seconds
@@ -19,13 +17,9 @@ export class PowerMonitorMain {
   ) {}
 
   init() {
-    // ref: https://github.com/electron/electron/issues/13767
-    if (!isSnapStore()) {
-      // System sleep
-      powerMonitor.on("suspend", () => {
-        this.messagingService.send("systemSuspended");
-      });
-    }
+    powerMonitor.on("suspend", () => {
+      this.messagingService.send("systemSuspended");
+    });
 
     if (process.platform !== "linux") {
       // System locked


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

In 2018 electron had a bug that caused it to crash when listening for system sleep on snap. This has long been fixed and the filter is no longer needed.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
