### PR TITLE
[BEEEP] Add println clippy lints for `desktop_native`.

### DIFF
--- a/apps/desktop/desktop_native/Cargo.toml
+++ b/apps/desktop/desktop_native/Cargo.toml
@@ -76,6 +76,10 @@ zbus_polkit = "=5.0.0"
 zeroizing-alloc = "=0.1.0"
 
 [workspace.lints.clippy]
+# Dis-allow println and eprintln, which are typically used in debugging.
+# Use `tracing` and `tracing-subscriber` crates for observability needs.
+print_stderr = "deny"
+print_stdout = "deny"
+string_slice = "warn"
 unused_async = "deny"
 unwrap_used = "deny"
-string_slice = "warn"


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-26091

## 📔 Objective

As follow-up to https://github.com/bitwarden/clients/pull/16321 , disable `println` and `eprintln`. This check is run in CI. Local debugging using printlns is unaffected.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
