### PR TITLE
[BEEEP] Add a cargo deny configuration for `desktop_native`

### DIFF
--- a/apps/desktop/desktop_native/deny.toml
+++ b/apps/desktop/desktop_native/deny.toml
@@ -1,0 +1,40 @@
+# https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
+[advisories]
+ignore = [
+  # Vulnerability in `rsa` crate: https://rustsec.org/advisories/RUSTSEC-2023-0071.html
+  { id = "RUSTSEC-2023-0071", reason = "There is no fix available yet." },
+  { id = "RUSTSEC-2024-0436", reason = "paste crate is unmaintained."}
+]
+
+# https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html
+[licenses]
+# See https://spdx.org/licenses/ for list of possible licenses
+allow = [
+  "0BSD",
+  "Apache-2.0",
+  "BSD-2-Clause",
+  "BSD-3-Clause",
+  "BSL-1.0",
+  "ISC",
+  "MIT",
+  "MPL-2.0",
+  "Unicode-3.0",
+  "Zlib",
+]
+
+
+[licenses.private]
+# If true, ignores workspace crates that aren't published, or are only
+# published to private registries.
+# To see how to mark a crate as unpublished (to the official registry),
+# visit https://doc.rust-lang.org/cargo/reference/manifest.html#the-publish-field.
+ignore = true
+
+# This section is considered when running `cargo deny check bans`.
+# More documentation about the 'bans' section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html
+[bans]
+deny = [
+# TODO: enable after https://github.com/bitwarden/clients/pull/16761 is merged
+#    { name = "log", wrappers = [], reason = "Use `tracing` and `tracing-subscriber` for observability needs." },
+]


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-26562

## 📔 Objective

Cargo deny is a good project hygiene tool to make sure the code we are shipping adheres:
- to our licensing requirements
- to our tolerance for known security vulnerabilities
- to our own internal policies

This was partially motivated by a prior BEEEP effort to improve observability (github.com/bitwarden/clients/pull/16321) , and as part of that, we can use deny's banlist to enforce a policy to standardize the project to use `tracing` instead of `log`.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
