### PR TITLE
PM-22143 Import related enum refactoring

### DIFF
--- a/libs/importer/src/importers/fsecure/fsecure-fsk-importer.ts
+++ b/libs/importer/src/importers/fsecure/fsecure-fsk-importer.ts
@@ -1,5 +1,3 @@
-// FIXME: Update this file to be type safe and remove this and next line
-// @ts-strict-ignore
 import { CipherType } from "@bitwarden/common/vault/enums";
 import { CardView } from "@bitwarden/common/vault/models/view/card.view";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
@@ -8,7 +6,7 @@ import { ImportResult } from "../../models/import-result";
 import { BaseImporter } from "../base-importer";
 import { Importer } from "../importer";
 
-import { FskEntry, FskEntryTypesEnum, FskFile } from "./fsecure-fsk-types";
+import { FskEntry, FskEntryType, FskFile } from "./fsecure-fsk-types";
 
 export class FSecureFskImporter extends BaseImporter implements Importer {
   parse(data: string): Promise<ImportResult> {
@@ -19,37 +17,32 @@ export class FSecureFskImporter extends BaseImporter implements Importer {
       return Promise.resolve(result);
     }
 
-    for (const key in results.data) {
-      // eslint-disable-next-line
-      if (!results.data.hasOwnProperty(key)) {
-        continue;
-      }
-
-      const value = results.data[key];
+    for (const [, value] of Object.entries(results.data)) {
       const cipher = this.parseEntry(value);
-      result.ciphers.push(cipher);
+      if (cipher != null) {
+        result.ciphers.push(cipher);
+      }
     }
 
     result.success = true;
     return Promise.resolve(result);
   }
 
-  private parseEntry(entry: FskEntry): CipherView {
+  private parseEntry(entry: FskEntry): CipherView | undefined {
     const cipher = this.initLoginCipher();
     cipher.name = this.getValueOrDefault(entry.service);
     cipher.notes = this.getValueOrDefault(entry.notes);
     cipher.favorite = entry.favorite > 0;
 
     switch (entry.type) {
-      case FskEntryTypesEnum.Login:
+      case FskEntryType.Login:
         this.handleLoginEntry(entry, cipher);
         break;
-      case FskEntryTypesEnum.CreditCard:
+      case FskEntryType.CreditCard:
         this.handleCreditCardEntry(entry, cipher);
         break;
       default:
-        return;
-        break;
+        return undefined;
     }
 
     this.convertToNoteIfNeeded(cipher);

--- a/libs/importer/src/importers/fsecure/fsecure-fsk-types.ts
+++ b/libs/importer/src/importers/fsecure/fsecure-fsk-types.ts
@@ -6,12 +6,18 @@ export interface Data {
   [key: string]: FskEntry;
 }
 
-// FIXME: update to use a const object instead of a typescript enum
-// eslint-disable-next-line @bitwarden/platform/no-enums
-export enum FskEntryTypesEnum {
-  Login = 1,
-  CreditCard = 2,
-}
+/**
+ * Represents the different types of FSK entries.
+ */
+export const FskEntryType = Object.freeze({
+  Login: 1,
+  CreditCard: 2,
+});
+
+/**
+ * Type representing valid FSK entry type values.
+ */
+export type FskEntryType = (typeof FskEntryType)[keyof typeof FskEntryType];
 
 export interface FskEntry {
   color: string;
@@ -26,7 +32,7 @@ export interface FskEntry {
   rev: string | number;
   service: string;
   style: string;
-  type: FskEntryTypesEnum;
+  type: FskEntryType;
   url: string;
   username: string;
   createdDate: number; // UNIX timestamp

--- a/libs/importer/src/importers/lastpass/access/enums/idp-provider.ts
+++ b/libs/importer/src/importers/lastpass/access/enums/idp-provider.ts
@@ -1,10 +1,16 @@
-// FIXME: update to use a const object instead of a typescript enum
-// eslint-disable-next-line @bitwarden/platform/no-enums
-export enum IdpProvider {
-  Azure = 0,
-  OktaAuthServer = 1,
-  OktaNoAuthServer = 2,
-  Google = 3,
-  PingOne = 4,
-  OneLogin = 5,
-}
+/**
+ * Represents the different identity providers supported for authentication.
+ */
+export const IdpProvider = Object.freeze({
+  Azure: 0,
+  OktaAuthServer: 1,
+  OktaNoAuthServer: 2,
+  Google: 3,
+  PingOne: 4,
+  OneLogin: 5,
+} as const);
+
+/**
+ * Type representing valid identity provider values.
+ */
+export type IdpProvider = (typeof IdpProvider)[keyof typeof IdpProvider];

--- a/libs/importer/src/importers/lastpass/access/enums/lastpass-login-type.ts
+++ b/libs/importer/src/importers/lastpass/access/enums/lastpass-login-type.ts
@@ -1,7 +1,13 @@
-// FIXME: update to use a const object instead of a typescript enum
-// eslint-disable-next-line @bitwarden/platform/no-enums
-export enum LastpassLoginType {
-  MasterPassword = 0,
+/**
+ * Represents LastPass login types.
+ */
+export const LastpassLoginType = Object.freeze({
+  MasterPassword: 0,
   // Not sure what Types 1 and 2 are?
-  Federated = 3,
-}
+  Federated: 3,
+} as const);
+
+/**
+ * Type representing valid LastPass login type values.
+ */
+export type LastpassLoginType = (typeof LastpassLoginType)[keyof typeof LastpassLoginType];

--- a/libs/importer/src/importers/lastpass/access/enums/otp-method.ts
+++ b/libs/importer/src/importers/lastpass/access/enums/otp-method.ts
@@ -1,7 +1,13 @@
-// FIXME: update to use a const object instead of a typescript enum
-// eslint-disable-next-line @bitwarden/platform/no-enums
-export enum OtpMethod {
-  GoogleAuth,
-  MicrosoftAuth,
-  Yubikey,
-}
+/**
+ * Represents OTP authentication methods.
+ */
+export const OtpMethod = Object.freeze({
+  GoogleAuth: 0,
+  MicrosoftAuth: 1,
+  Yubikey: 2,
+} as const);
+
+/**
+ * Type representing valid OTP method values.
+ */
+export type OtpMethod = (typeof OtpMethod)[keyof typeof OtpMethod];

--- a/libs/importer/src/importers/lastpass/access/enums/platform.ts
+++ b/libs/importer/src/importers/lastpass/access/enums/platform.ts
@@ -1,6 +1,12 @@
-// FIXME: update to use a const object instead of a typescript enum
-// eslint-disable-next-line @bitwarden/platform/no-enums
-export enum Platform {
-  Desktop,
-  Mobile,
-}
+/**
+ * Platform types representing different device categories.
+ */
+export const Platform = Object.freeze({
+  Desktop: 0,
+  Mobile: 1,
+} as const);
+
+/**
+ * Type representing valid platform values.
+ */
+export type Platform = (typeof Platform)[keyof typeof Platform];

--- a/libs/importer/src/importers/onepassword/onepassword-1pux-importer.ts
+++ b/libs/importer/src/importers/onepassword/onepassword-1pux-importer.ts
@@ -14,12 +14,12 @@ import { BaseImporter } from "../base-importer";
 import { Importer } from "../importer";
 
 import {
-  CategoryEnum,
+  Category,
   Details,
   ExportData,
   FieldsEntity,
   Item,
-  LoginFieldTypeEnum,
+  LoginFieldType,
   Overview,
   PasswordHistoryEntity,
   SectionsEntity,
@@ -45,38 +45,38 @@ export class OnePassword1PuxImporter extends BaseImporter implements Importer {
 
         const cipher = this.initLoginCipher();
 
-        const category = item.categoryUuid as CategoryEnum;
+        const category = item.categoryUuid as Category;
         switch (category) {
-          case CategoryEnum.Login:
-          case CategoryEnum.Database:
-          case CategoryEnum.Password:
-          case CategoryEnum.WirelessRouter:
-          case CategoryEnum.Server:
-          case CategoryEnum.API_Credential:
+          case Category.Login:
+          case Category.Database:
+          case Category.Password:
+          case Category.WirelessRouter:
+          case Category.Server:
+          case Category.API_Credential:
             cipher.type = CipherType.Login;
             cipher.login = new LoginView();
             break;
-          case CategoryEnum.CreditCard:
-          case CategoryEnum.BankAccount:
+          case Category.CreditCard:
+          case Category.BankAccount:
             cipher.type = CipherType.Card;
             cipher.card = new CardView();
             break;
-          case CategoryEnum.SecureNote:
-          case CategoryEnum.SoftwareLicense:
-          case CategoryEnum.EmailAccount:
-          case CategoryEnum.MedicalRecord:
+          case Category.SecureNote:
+          case Category.SoftwareLicense:
+          case Category.EmailAccount:
+          case Category.MedicalRecord:
             // case CategoryEnum.Document:
             cipher.type = CipherType.SecureNote;
             cipher.secureNote = new SecureNoteView();
             cipher.secureNote.type = SecureNoteType.Generic;
             break;
-          case CategoryEnum.Identity:
-          case CategoryEnum.DriversLicense:
-          case CategoryEnum.OutdoorLicense:
-          case CategoryEnum.Membership:
-          case CategoryEnum.Passport:
-          case CategoryEnum.RewardsProgram:
-          case CategoryEnum.SocialSecurityNumber:
+          case Category.Identity:
+          case Category.DriversLicense:
+          case Category.OutdoorLicense:
+          case Category.Membership:
+          case Category.Passport:
+          case Category.RewardsProgram:
+          case Category.SocialSecurityNumber:
             cipher.type = CipherType.Identity;
             cipher.identity = new IdentityView();
             break;
@@ -166,10 +166,10 @@ export class OnePassword1PuxImporter extends BaseImporter implements Importer {
       let fieldValue = loginField.value;
       let fieldType: FieldType = FieldType.Text;
       switch (loginField.fieldType) {
-        case LoginFieldTypeEnum.Password:
+        case LoginFieldType.Password:
           fieldType = FieldType.Hidden;
           break;
-        case LoginFieldTypeEnum.CheckBox:
+        case LoginFieldType.CheckBox:
           fieldValue = loginField.value !== "" ? "true" : "false";
           fieldType = FieldType.Boolean;
           break;
@@ -180,8 +180,8 @@ export class OnePassword1PuxImporter extends BaseImporter implements Importer {
     });
   }
 
-  private processDetails(category: CategoryEnum, details: Details, cipher: CipherView) {
-    if (category !== CategoryEnum.Password) {
+  private processDetails(category: Category, details: Details, cipher: CipherView) {
+    if (category !== Category.Password) {
       return;
     }
 
@@ -191,7 +191,7 @@ export class OnePassword1PuxImporter extends BaseImporter implements Importer {
     cipher.login.password = details.password;
   }
 
-  private processSections(category: CategoryEnum, sections: SectionsEntity[], cipher: CipherView) {
+  private processSections(category: Category, sections: SectionsEntity[], cipher: CipherView) {
     if (sections == null || sections.length === 0) {
       return;
     }
@@ -206,7 +206,7 @@ export class OnePassword1PuxImporter extends BaseImporter implements Importer {
   }
 
   private parseSectionFields(
-    category: CategoryEnum,
+    category: Category,
     fields: FieldsEntity[],
     cipher: CipherView,
     sectionTitle: string,
@@ -232,20 +232,20 @@ export class OnePassword1PuxImporter extends BaseImporter implements Importer {
         }
 
         switch (category) {
-          case CategoryEnum.Login:
-          case CategoryEnum.Database:
-          case CategoryEnum.EmailAccount:
-          case CategoryEnum.WirelessRouter:
+          case Category.Login:
+          case Category.Database:
+          case Category.EmailAccount:
+          case Category.WirelessRouter:
             break;
 
-          case CategoryEnum.Server:
+          case Category.Server:
             if (this.isNullOrWhitespace(cipher.login.uri) && field.id === "url") {
               cipher.login.uris = this.makeUriArray(fieldValue);
               return;
             }
             break;
 
-          case CategoryEnum.API_Credential:
+          case Category.API_Credential:
             if (this.fillApiCredentials(field, fieldValue, cipher)) {
               return;
             }
@@ -258,7 +258,7 @@ export class OnePassword1PuxImporter extends BaseImporter implements Importer {
           return;
         }
 
-        if (category === CategoryEnum.BankAccount) {
+        if (category === Category.BankAccount) {
           if (this.fillBankAccount(field, fieldValue, cipher)) {
             return;
           }
@@ -281,34 +281,34 @@ export class OnePassword1PuxImporter extends BaseImporter implements Importer {
         }
 
         switch (category) {
-          case CategoryEnum.Identity:
+          case Category.Identity:
             break;
-          case CategoryEnum.DriversLicense:
+          case Category.DriversLicense:
             if (this.fillDriversLicense(field, fieldValue, cipher)) {
               return;
             }
             break;
-          case CategoryEnum.OutdoorLicense:
+          case Category.OutdoorLicense:
             if (this.fillOutdoorLicense(field, fieldValue, cipher)) {
               return;
             }
             break;
-          case CategoryEnum.Membership:
+          case Category.Membership:
             if (this.fillMembership(field, fieldValue, cipher)) {
               return;
             }
             break;
-          case CategoryEnum.Passport:
+          case Category.Passport:
             if (this.fillPassport(field, fieldValue, cipher)) {
               return;
             }
             break;
-          case CategoryEnum.RewardsProgram:
+          case Category.RewardsProgram:
             if (this.fillRewardsProgram(field, fieldValue, cipher)) {
               return;
             }
             break;
-          case CategoryEnum.SocialSecurityNumber:
+          case Category.SocialSecurityNumber:
             if (this.fillSSN(field, fieldValue, cipher)) {
               return;
             }

--- a/libs/importer/src/importers/onepassword/types/onepassword-1pux-importer-types.ts
+++ b/libs/importer/src/importers/onepassword/types/onepassword-1pux-importer-types.ts
@@ -25,30 +25,67 @@ export interface VaultAttributes {
   type: string;
 }
 
-// FIXME: update to use a const object instead of a typescript enum
-// eslint-disable-next-line @bitwarden/platform/no-enums
-export enum CategoryEnum {
-  Login = "001",
-  CreditCard = "002",
-  SecureNote = "003",
-  Identity = "004",
-  Password = "005",
-  Document = "006",
-  SoftwareLicense = "100",
-  BankAccount = "101",
-  Database = "102",
-  DriversLicense = "103",
-  OutdoorLicense = "104",
-  Membership = "105",
-  Passport = "106",
-  RewardsProgram = "107",
-  SocialSecurityNumber = "108",
-  WirelessRouter = "109",
-  Server = "110",
-  EmailAccount = "111",
-  API_Credential = "112",
-  MedicalRecord = "113",
-}
+/**
+ * Represents the different types of items that can be stored in 1Password.
+ */
+export const Category = Object.freeze({
+  Login: "001",
+  CreditCard: "002",
+  SecureNote: "003",
+  Identity: "004",
+  Password: "005",
+  Document: "006",
+  SoftwareLicense: "100",
+  BankAccount: "101",
+  Database: "102",
+  DriversLicense: "103",
+  OutdoorLicense: "104",
+  Membership: "105",
+  Passport: "106",
+  RewardsProgram: "107",
+  SocialSecurityNumber: "108",
+  WirelessRouter: "109",
+  Server: "110",
+  EmailAccount: "111",
+  API_Credential: "112",
+  MedicalRecord: "113",
+} as const);
+
+/**
+ * Represents valid 1Password category values.
+ */
+export type Category = (typeof Category)[keyof typeof Category];
+
+// const namesByCategory = new Map<Category, keyof typeof Category>(
+//   Object.entries(Category).map(([key, value]) => [value, key as keyof typeof Category]),
+// );
+
+// /**
+//  * Checks if a value is a valid 1Password Category.
+//  * @param value - The value to check.
+//  * @returns True if the value is a valid 1Password Category, false otherwise.
+//  */
+// export function isCategory(value: unknown): value is Category {
+//   return namesByCategory.has(value as Category);
+// }
+
+// /**
+//  * Converts a value to a 1Password Category if it is valid.
+//  * @param value - The value to convert.
+//  * @returns The value as a Category if valid, otherwise undefined.
+//  */
+// export function asCategory(value: unknown): Category | undefined {
+//   return isCategory(value) ? (value as Category) : undefined;
+// }
+
+// /**
+//  * Gets the name of a 1Password Category value.
+//  * @param value - The Category value to get the name for.
+//  * @returns The name of the Category value, or undefined if not found.
+//  */
+// export function nameOfCategory(value: Category): keyof typeof Category | undefined {
+//   return namesByCategory.get(value);
+// }
 
 export interface Item {
   uuid: string;
@@ -69,23 +106,30 @@ export interface Details {
   password?: string | null;
 }
 
-// FIXME: update to use a const object instead of a typescript enum
-// eslint-disable-next-line @bitwarden/platform/no-enums
-export enum LoginFieldTypeEnum {
-  TextOrHtml = "T",
-  EmailAddress = "E",
-  URL = "U",
-  Number = "N",
-  Password = "P",
-  TextArea = "A",
-  PhoneNumber = "TEL",
-  CheckBox = "C",
-}
+/**
+ * Represents 1Password login field types that can be stored in login items.
+ */
+export const LoginFieldType = Object.freeze({
+  TextOrHtml: "T",
+  EmailAddress: "E",
+  URL: "U",
+  Number: "N",
+  Password: "P",
+  TextArea: "A",
+  PhoneNumber: "TEL",
+  CheckBox: "C",
+} as const);
+
+/**
+ * Type representing valid 1Password login field type values.
+ */
+export type LoginFieldType = (typeof LoginFieldType)[keyof typeof LoginFieldType];
+
 export interface LoginFieldsEntity {
   value: string;
   id: string;
   name: string;
-  fieldType: LoginFieldTypeEnum | string;
+  fieldType: LoginFieldType | string;
   designation?: string | null;
 }
 export interface SectionsEntity {

--- a/libs/importer/src/importers/protonpass/types/protonpass-json-type.ts
+++ b/libs/importer/src/importers/protonpass/types/protonpass-json-type.ts
@@ -27,12 +27,19 @@ export type ProtonPassItem = {
   pinned: boolean;
 };
 
-// FIXME: update to use a const object instead of a typescript enum
-// eslint-disable-next-line @bitwarden/platform/no-enums
-export enum ProtonPassItemState {
-  ACTIVE = 1,
-  TRASHED = 2,
-}
+/**
+ * Proton Pass item states as a const object.
+ * Represents the different states an item can be in (active or trashed).
+ */
+export const ProtonPassItemState = Object.freeze({
+  ACTIVE: 1,
+  TRASHED: 2,
+} as const);
+
+/**
+ * Type representing valid Proton Pass item state values.
+ */
+export type ProtonPassItemState = (typeof ProtonPassItemState)[keyof typeof ProtonPassItemState];
 
 export type ProtonPassItemData = {
   metadata: ProtonPassItemMetadata;


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-22143?atlOrigin=eyJpIjoiMTI1ZDU5MjQ4YjVhNDVjMDgxNzM1MDQyMTY1ODYzZDgiLCJwIjoiaiJ9

## 📔 Objective

A decision was made to move away from using enums in TS and instead to use const objects.

Refactor all tools enums into const objects.

For easier review it might be good to split Send and Import into separate PRs

When changing SendType, please be careful that it will likely break some navigation on the send-v2.component and maybe even desktop related as it doesn’t share the UI components yet

Remove all associated eslint disable statements 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
