### PR TITLE
[PM-13422] Fix flaky test around sync time

### DIFF
--- a/libs/common/src/platform/sync/default-sync.service.spec.ts
+++ b/libs/common/src/platform/sync/default-sync.service.spec.ts
@@ -329,10 +329,8 @@ describe("DefaultSyncService", () => {
         // Mock the value of this observable because it's used in `syncProfile`. Without it, the test breaks.
         keyConnectorService.convertAccountRequired$ = of(false);
 
-        // Baseline date/time to compare sync time to, in order to avoid needing to use some kind of fake date provider.
-        const beforeSync = Date.now();
+        jest.useFakeTimers({ now: Date.now() });
 
-        // send it!
         await sut.fullSync(true, defaultSyncOptions);
 
         expectUpdateCallCount(mockUserState, 1);
@@ -340,9 +338,10 @@ describe("DefaultSyncService", () => {
         const updateCall = mockUserState.update.mock.calls[0];
         // Get the first argument to update(...) -- this will be the date callback that returns the date of the last successful sync
         const dateCallback = updateCall[0];
-        const actualTime = dateCallback() as Date;
+        const actualDate = dateCallback() as Date;
 
-        expect(Math.abs(actualTime.getTime() - beforeSync)).toBeLessThan(1);
+        expect(actualDate.getTime()).toEqual(jest.now());
+        jest.useRealTimers();
       });
 
       it("updates last sync time when no sync is necessary", async () => {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-13422](https://bitwarden.atlassian.net/browse/PM-13422)

## 📔 Objective

Updates the unit test `DefaultSyncService` > `fullSync` > `mutate 'last update time'` > `uses the current time when a sync is forced` to use [Jest's Fake Timers](https://jestjs.io/docs/jest-object#fake-timers) to make time predictable during a unit test.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-13422]: https://bitwarden.atlassian.net/browse/PM-13422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ