### PR TITLE
[PM-26649] Prevent log-out when changing KDF settings (except old clients)

### DIFF
--- a/libs/common/src/enums/feature-flag.enum.ts
+++ b/libs/common/src/enums/feature-flag.enum.ts
@@ -30,6 +30,7 @@ export enum FeatureFlag {
   PrivateKeyRegeneration = "pm-12241-private-key-regeneration",
   EnrollAeadOnKeyRotation = "enroll-aead-on-key-rotation",
   ForceUpdateKDFSettings = "pm-18021-force-update-kdf-settings",
+  NoLogoutOnKdfChange = "pm-23995-no-logout-on-kdf-change",
 
   /* Tools */
   DesktopSendUIRefresh = "desktop-send-ui-refresh",
@@ -106,6 +107,7 @@ export const DefaultFeatureFlagValue = {
   [FeatureFlag.PrivateKeyRegeneration]: FALSE,
   [FeatureFlag.EnrollAeadOnKeyRotation]: FALSE,
   [FeatureFlag.ForceUpdateKDFSettings]: FALSE,
+  [FeatureFlag.NoLogoutOnKdfChange]: FALSE,
 
   /* Platform */
   [FeatureFlag.IpcChannelFramework]: FALSE,

--- a/libs/common/src/models/response/notification.response.ts
+++ b/libs/common/src/models/response/notification.response.ts
@@ -41,8 +41,10 @@ export class NotificationResponse extends BaseResponse {
       case NotificationType.SyncOrganizations:
       case NotificationType.SyncOrgKeys:
       case NotificationType.SyncSettings:
-      case NotificationType.LogOut:
         this.payload = new UserNotification(payload);
+        break;
+      case NotificationType.LogOut:
+        this.payload = new LogOutNotification(payload);
         break;
       case NotificationType.SyncSendCreate:
       case NotificationType.SyncSendUpdate:
@@ -182,5 +184,16 @@ export class ProviderBankAccountVerifiedPushNotification extends BaseResponse {
     super(response);
     this.providerId = this.getResponseProperty("ProviderId");
     this.adminId = this.getResponseProperty("AdminId");
+  }
+}
+
+export class LogOutNotification extends BaseResponse {
+  userId: string;
+  reason?: string;
+
+  constructor(response: any) {
+    super(response);
+    this.userId = this.getResponseProperty("UserId");
+    this.reason = this.getResponseProperty("Reason");
   }
 }

--- a/libs/common/src/platform/server-notifications/internal/default-server-notifications.service.ts
+++ b/libs/common/src/platform/server-notifications/internal/default-server-notifications.service.ts
@@ -24,6 +24,7 @@ import { AuthService } from "../../../auth/abstractions/auth.service";
 import { AuthenticationStatus } from "../../../auth/enums/authentication-status";
 import { NotificationType } from "../../../enums";
 import {
+  LogOutNotification,
   NotificationResponse,
   SyncCipherNotification,
   SyncFolderNotification,
@@ -263,10 +264,22 @@ export class DefaultServerNotificationsService implements ServerNotificationsSer
         this.activitySubject.next("inactive"); // Force a disconnect
         this.activitySubject.next("active"); // Allow a reconnect
         break;
-      case NotificationType.LogOut:
+      case NotificationType.LogOut: {
         this.logService.info("[Notifications Service] Received logout notification");
-        await this.logoutCallback("logoutNotification", userId);
+
+        const logOutNotification = notification.payload as LogOutNotification;
+        const noLogoutOnKdfChange = await firstValueFrom(
+          this.configService.getFeatureFlag$(FeatureFlag.NoLogoutOnKdfChange),
+        );
+        if (noLogoutOnKdfChange && logOutNotification.reason === "kdfChange") {
+          this.logService.info(
+            "[Notifications Service] Skipping logout due to no logout KDF change",
+          );
+        } else {
+          await this.logoutCallback("logoutNotification", userId);
+        }
         break;
+      }
       case NotificationType.SyncSendCreate:
       case NotificationType.SyncSendUpdate:
         await this.syncService.syncUpsertSend(


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-26649

## 📔 Objective

Prevent the logout in clients, when received the logout push notification, conditioned that:
1. `pm-23995-no-logout-on-kdf-change` feature flag is enabled and
2. the “reason” field in the logout push notification is “kdfChange”

, otherwise proceed to logout.

This is to make sure all client versions regardless of the feature flag will get the logout push notification, so older clients would not into bad state (since they can’t handle new KDF change without logout), but newer clients would not log out.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
