### PR TITLE
[PM-26628] FIX: [Defect] Upgrade modal shown after restarting subscription

### DIFF
--- a/apps/web/src/app/billing/organizations/warnings/services/organization-warnings.service.ts
+++ b/apps/web/src/app/billing/organizations/warnings/services/organization-warnings.service.ts
@@ -204,14 +204,16 @@ export class OrganizationWarningsService {
           }
           case "resubscribe": {
             const subscription = await this.organizationApiService.getSubscription(organization.id);
-            const dialogReference = openChangePlanDialog(this.dialogService, {
-              data: {
-                organizationId: organization.id,
-                subscription: subscription,
-                productTierType: organization.productTierType,
-              },
-            });
-            await lastValueFrom(dialogReference.closed);
+            if (!organization.enabled) {
+              const dialogReference = openChangePlanDialog(this.dialogService, {
+                data: {
+                  organizationId: organization.id,
+                  subscription: subscription,
+                  productTierType: organization.productTierType,
+                },
+              });
+              await lastValueFrom(dialogReference.closed);
+            }
             break;
           }
           case "contact_owner": {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-26628

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
An “Upgrade Plan” modal pop-up appears after restarting a canceled subscription. This is also popping up for Enterprise Plans that have no further upgrade path. This has been replicated in main and on the rc branch.


GIVEN: You are restarting a canceled subscription

WHEN: You submit the payment on the “Restart subscription modal”

THEN: (Expected) You should be directed to your Subscription page

Actual: You are redirected to your Subscription page with an “Upgrade Plan” modal pop-up. This is also popping up for Enterprise Plans that have no further upgrade path.



## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/dd606139-bd40-40c1-a3ac-dc30416374e7


https://github.com/user-attachments/assets/65ef7c76-b249-404e-827f-0d39616b9595


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
