### PR TITLE
[PM-25858]Organization warnings endpoint should not be called from self-hosted instances

### DIFF
--- a/apps/web/src/app/billing/organizations/warnings/services/organization-warnings.service.ts
+++ b/apps/web/src/app/billing/organizations/warnings/services/organization-warnings.service.ts
@@ -17,6 +17,7 @@ import { take } from "rxjs/operators";
 import { OrganizationApiServiceAbstraction } from "@bitwarden/common/admin-console/abstractions/organization/organization-api.service.abstraction";
 import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { OrganizationId } from "@bitwarden/common/types/guid";
 import { DialogService } from "@bitwarden/components";
 import { OrganizationBillingClient } from "@bitwarden/web-vault/app/billing/clients";
@@ -55,6 +56,7 @@ export class OrganizationWarningsService {
     private i18nService: I18nService,
     private organizationApiService: OrganizationApiServiceAbstraction,
     private organizationBillingClient: OrganizationBillingClient,
+    private platformUtilsService: PlatformUtilsService,
     private router: Router,
   ) {}
 
@@ -254,7 +256,7 @@ export class OrganizationWarningsService {
     organization: Organization,
     bypassCache: boolean = false,
   ): Observable<OrganizationWarningsResponse> => {
-    if (organization.selfHost) {
+    if (this.platformUtilsService.isSelfHost()) {
       return from(Promise.resolve(new OrganizationWarningsResponse({})));
     }
 

--- a/apps/web/src/app/billing/organizations/warnings/services/organization-warnings.service.ts
+++ b/apps/web/src/app/billing/organizations/warnings/services/organization-warnings.service.ts
@@ -254,6 +254,10 @@ export class OrganizationWarningsService {
     organization: Organization,
     bypassCache: boolean = false,
   ): Observable<OrganizationWarningsResponse> => {
+    if (organization.selfHost) {
+      return from(Promise.resolve(new OrganizationWarningsResponse({})));
+    }
+
     const organizationId = organization.id as OrganizationId;
     const existing = this.cache$.get(organizationId);
     if (existing && !bypassCache) {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-25858

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
The OrganizationWarningsService is requesting warnings for self-hosted organizations. We just need to put a check in place to prevent the service from been called

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
