### PR TITLE
Revert electron 38

### DIFF
--- a/apps/desktop/electron-builder.json
+++ b/apps/desktop/electron-builder.json
@@ -20,7 +20,7 @@
     "**/node_modules/@bitwarden/desktop-napi/index.js",
     "**/node_modules/@bitwarden/desktop-napi/desktop_napi.${platform}-${arch}*.node"
   ],
-  "electronVersion": "38.2.0",
+  "electronVersion": "36.9.3",
   "generateUpdatesFilesForAllChannels": true,
   "publish": {
     "provider": "generic",

--- a/package-lock.json
+++ b/package-lock.json
@@ -133,7 +133,7 @@
         "copy-webpack-plugin": "13.0.0",
         "cross-env": "10.0.0",
         "css-loader": "7.1.2",
-        "electron": "38.2.0",
+        "electron": "36.9.3",
         "electron-builder": "26.0.12",
         "electron-log": "5.4.0",
         "electron-reload": "2.0.0-alpha.1",
@@ -20845,9 +20845,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "38.2.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-38.2.0.tgz",
-      "integrity": "sha512-Cw5Mb+N5NxsG0Hc1qr8I65Kt5APRrbgTtEEn3zTod30UNJRnAE1xbGk/1NOaDn3ODzI/MYn6BzT9T9zreP7xWA==",
+      "version": "36.9.3",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-36.9.3.tgz",
+      "integrity": "sha512-eR5yswsA55zVTPDEIA/PSdVNBLOp0q0Wsavgx0S3BmJYOqKoH1gqzS+hggf0/aY5OvUjVNSHiJJA1VsB5aJUug==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "copy-webpack-plugin": "13.0.0",
     "cross-env": "10.0.0",
     "css-loader": "7.1.2",
-    "electron": "38.2.0",
+    "electron": "36.9.3",
     "electron-builder": "26.0.12",
     "electron-log": "5.4.0",
     "electron-reload": "2.0.0-alpha.1",


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-25748

https://bitwarden.atlassian.net/browse/PM-26700
https://bitwarden.atlassian.net/browse/PM-26677

## 📔 Objective

We have a couple of issues with this version in `rc` and so we're reverting back to major version 36.9.3. Note that this is still an upgrade over the previous 36.8.1, as we need the macos performance fixes and the title bar color fixes

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
