### PR TITLE
Prefer autofilling login forms over registration forms

### DIFF
--- a/apps/browser/src/autofill/services/autofill-constants.ts
+++ b/apps/browser/src/autofill/services/autofill-constants.ts
@@ -59,6 +59,14 @@ export class AutoFillConstants {
     "neue e-mail",
   ];
 
+  static readonly RegistrationKeywords: string[] = [
+    "register",
+    "signup",
+    "sign-up",
+    "join",
+    "create",
+  ];
+
   static readonly NewsletterFormNames: string[] = ["newsletter"];
 
   static readonly FieldIgnoreList: string[] = ["captcha", "findanything", "forgot"];

--- a/apps/browser/src/autofill/services/autofill.service.ts
+++ b/apps/browser/src/autofill/services/autofill.service.ts
@@ -856,13 +856,28 @@ export default class AutofillService implements AutofillServiceInterface {
       options.fillNewPassword,
     );
 
+    const loginPasswordFields: AutofillField[] = [];
+    const registrationPasswordFields: AutofillField[] = [];
+
+    passwordFields.forEach((passField) => {
+      if (this.isRegistrationPasswordField(pageDetails, passField)) {
+        registrationPasswordFields.push(passField);
+      } else {
+        loginPasswordFields.push(passField);
+      }
+    });
+
+    // Prefer login fields over registration fields
+    const prioritizedPasswordFields =
+      loginPasswordFields.length > 0 ? loginPasswordFields : registrationPasswordFields;
+
     for (const formKey in pageDetails.forms) {
       // eslint-disable-next-line
       if (!pageDetails.forms.hasOwnProperty(formKey)) {
         continue;
       }
 
-      passwordFields.forEach((passField) => {
+      prioritizedPasswordFields.forEach((passField) => {
         pf = passField;
         passwords.push(pf);
 
@@ -887,8 +902,7 @@ export default class AutofillService implements AutofillServiceInterface {
     if (passwordFields.length && !passwords.length) {
       // The page does not have any forms with password fields. Use the first password field on the page and the
       // input field just before it as the username.
-
-      pf = passwordFields[0];
+      pf = prioritizedPasswordFields[0];
       passwords.push(pf);
 
       if (login.username && pf.elementNumber > 0) {
@@ -2249,6 +2263,38 @@ export default class AutofillService implements AutofillServiceInterface {
     });
 
     return arr;
+  }
+
+  /**
+   * Determines if a password field is part of a registration/signup form.
+   * @param {AutofillPageDetails} pageDetails
+   * @param {AutofillField} passwordField
+   * @returns {boolean}
+   * @private
+   */
+  private isRegistrationPasswordField(
+    pageDetails: AutofillPageDetails,
+    passwordField: AutofillField,
+  ): boolean {
+    if (!passwordField.form || !pageDetails.forms) {
+      return false;
+    }
+
+    const form = pageDetails.forms[passwordField.form];
+    if (!form) {
+      return false;
+    }
+
+    const formIdentifierValues = [
+      form.htmlID?.toLowerCase?.(),
+      form.htmlName?.toLowerCase?.(),
+      passwordField?.htmlID?.toLowerCase?.(),
+      passwordField?.htmlName?.toLowerCase?.(),
+    ].filter(Boolean);
+
+    return formIdentifierValues.some((value) =>
+      AutoFillConstants.RegistrationKeywords.some((keyword) => value.includes(keyword)),
+    );
   }
 
   /**


### PR DESCRIPTION
## 🎟️ Tracking

[PM-25074](https://bitwarden.atlassian.net/browse/PM-25074)

## 📔 Objective

When the user clicks `Account` on bedbathandbeyond.com autofill was not displaying at all before.  Now two enhancements have been made:
1. The autofill overlay displays and functions correctly targeting the correct form.
2. The context menu and the extension fill the login form correctly.

A list of registration keywords were added to `AutoFillConstants` and a check is made to see if the page has both a sign in and account creation form and if it does to autofill the sign in form.
*NOTE* if you are testing this also check booksamillion.com.  That sign-in form is similar but different and you will want to verify that type of form works as well.

## 📸 Screenshots


https://github.com/user-attachments/assets/d2d849bf-d591-44ac-85c9-19ef1e282ae5


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-25074]: https://bitwarden.atlassian.net/browse/PM-25074?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ