### PR TITLE
[PM-26749] Add missing properties to CipherView.fromJSON

### DIFF
--- a/libs/common/src/vault/models/view/cipher.view.ts
+++ b/libs/common/src/vault/models/view/cipher.view.ts
@@ -196,7 +196,19 @@ export class CipherView implements View, InitializerMetadata {
     const view = new CipherView();
     view.type = obj.type ?? CipherType.Login;
     view.id = obj.id ?? "";
+    view.organizationId = obj.organizationId ?? undefined;
+    view.folderId = obj.folderId ?? undefined;
+    view.collectionIds = obj.collectionIds ?? [];
     view.name = obj.name ?? "";
+    view.notes = obj.notes;
+    view.edit = obj.edit ?? false;
+    view.viewPassword = obj.viewPassword ?? true;
+    view.favorite = obj.favorite ?? false;
+    view.organizationUseTotp = obj.organizationUseTotp ?? false;
+    view.localData = obj.localData ? obj.localData : undefined;
+    view.permissions = obj.permissions ? CipherPermissionsApi.fromJSON(obj.permissions) : undefined;
+    view.reprompt = obj.reprompt ?? CipherRepromptType.None;
+    view.decryptionFailure = obj.decryptionFailure ?? false;
     if (obj.creationDate) {
       view.creationDate = new Date(obj.creationDate);
     }
@@ -209,7 +221,6 @@ export class CipherView implements View, InitializerMetadata {
     view.fields = obj.fields?.map((f: any) => FieldView.fromJSON(f)) ?? [];
     view.passwordHistory =
       obj.passwordHistory?.map((ph: any) => PasswordHistoryView.fromJSON(ph)) ?? [];
-    view.permissions = obj.permissions ? CipherPermissionsApi.fromJSON(obj.permissions) : undefined;
 
     if (obj.key != null) {
       let key: EncString | undefined;


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-26749

## 📔 Objective

#16463 updated the `CipherView.fromJSON()` method and removed an `Object.assign()` call without adding some underlying `CipherView` the properties back. This caused downstream effects when restoring ciphers from state/JSON.


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
