### PR TITLE
[CL-876] Responsive preferences page

### DIFF
--- a/apps/web/src/app/settings/preferences.component.html
+++ b/apps/web/src/app/settings/preferences.component.html
@@ -2,7 +2,7 @@
 
 <bit-container>
   <p bitTypography="body1">{{ "preferencesDesc" | i18n }}</p>
-  <form [formGroup]="form" [bitSubmit]="submit" class="tw-w-full tw-max-w-xl">
+  <form [formGroup]="form" [bitSubmit]="submit" class="tw-w-full tw-max-w-md">
     <bit-callout type="info" *ngIf="vaultTimeoutPolicyCallout | async as policy">
       <span *ngIf="policy.timeout && policy.action">
         {{


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/CL-876

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Update the layout of the preferences page to be more responsive. Currently the preference fields always display at 50% width causing them to get smaller than should be.

Now the space reduces first, then the fields as the viewport gets smaller.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/c1853d8e-cea4-4ead-8642-ff9e50a6520c

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
