### PR TITLE
build(desktop): integrate nx

### DIFF
--- a/apps/desktop/project.json
+++ b/apps/desktop/project.json
@@ -1,0 +1,115 @@
+{
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "name": "desktop",
+  "projectType": "application",
+  "sourceRoot": "apps/desktop/src",
+  "tags": ["scope:desktop", "type:app"],
+  "targets": {
+    "build-native": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "cd desktop_native && node build.js",
+        "cwd": "apps/desktop"
+      }
+    },
+    "build-main": {
+      "executor": "nx:run-commands",
+      "outputs": ["{workspaceRoot}/dist/apps/desktop"],
+      "options": {
+        "command": "cross-env NODE_ENV=production webpack --config webpack.config.js --config-name main",
+        "cwd": "apps/desktop"
+      },
+      "configurations": {
+        "development": {
+          "command": "cross-env NODE_ENV=development webpack --config webpack.config.js --config-name main"
+        },
+        "production": {
+          "command": "cross-env NODE_ENV=production webpack --config webpack.config.js --config-name main"
+        }
+      }
+    },
+    "build-preload": {
+      "executor": "nx:run-commands",
+      "outputs": ["{workspaceRoot}/dist/apps/desktop"],
+      "options": {
+        "command": "cross-env NODE_ENV=production webpack --config webpack.config.js --config-name preload",
+        "cwd": "apps/desktop"
+      },
+      "configurations": {
+        "development": {
+          "command": "cross-env NODE_ENV=development webpack --config webpack.config.js --config-name preload"
+        },
+        "production": {
+          "command": "cross-env NODE_ENV=production webpack --config webpack.config.js --config-name preload"
+        }
+      }
+    },
+    "build-renderer": {
+      "executor": "nx:run-commands",
+      "outputs": ["{workspaceRoot}/dist/apps/desktop"],
+      "options": {
+        "command": "cross-env NODE_ENV=production webpack --config webpack.config.js --config-name renderer",
+        "cwd": "apps/desktop"
+      },
+      "configurations": {
+        "development": {
+          "command": "cross-env NODE_ENV=development webpack --config webpack.config.js --config-name renderer"
+        },
+        "production": {
+          "command": "cross-env NODE_ENV=production webpack --config webpack.config.js --config-name renderer"
+        }
+      }
+    },
+    "build": {
+      "executor": "nx:run-commands",
+      "dependsOn": ["build-native"],
+      "outputs": ["{workspaceRoot}/dist/apps/desktop"],
+      "options": {
+        "parallel": true,
+        "commands": [
+          "nx run desktop:build-main",
+          "nx run desktop:build-preload",
+          "nx run desktop:build-renderer"
+        ]
+      },
+      "configurations": {
+        "development": {
+          "commands": [
+            "nx run desktop:build-main --configuration=development",
+            "nx run desktop:build-preload --configuration=development",
+            "nx run desktop:build-renderer --configuration=development"
+          ]
+        },
+        "production": {
+          "commands": [
+            "nx run desktop:build-main --configuration=production",
+            "nx run desktop:build-preload --configuration=production",
+            "nx run desktop:build-renderer --configuration=production"
+          ]
+        }
+      }
+    },
+    "serve": {
+      "executor": "nx:run-commands",
+      "dependsOn": ["build-native"],
+      "options": {
+        "command": "node scripts/nx-serve.js",
+        "cwd": "apps/desktop"
+      }
+    },
+    "test": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/apps/desktop"],
+      "options": {
+        "jestConfig": "apps/desktop/jest.config.js"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": ["apps/desktop/**/*.ts", "apps/desktop/**/*.html"]
+      }
+    }
+  }
+}

--- a/apps/desktop/scripts/nx-serve.js
+++ b/apps/desktop/scripts/nx-serve.js
@@ -1,0 +1,42 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+const path = require("path");
+
+const concurrently = require("concurrently");
+const rimraf = require("rimraf");
+const args = process.argv.splice(2);
+const outputPath = path.resolve(__dirname, "../../../dist/apps/desktop");
+
+rimraf.sync(outputPath);
+require("fs").mkdirSync(outputPath, { recursive: true });
+
+concurrently(
+  [
+    {
+      name: "Main",
+      command: `cross-env NODE_ENV=development OUTPUT_PATH=${outputPath} webpack --config webpack.config.js --config-name main --watch`,
+      prefixColor: "yellow",
+    },
+    {
+      name: "Prel",
+      command: `cross-env NODE_ENV=development OUTPUT_PATH=${outputPath} webpack --config webpack.config.js --config-name preload --watch`,
+      prefixColor: "magenta",
+    },
+    {
+      name: "Rend",
+      command: `cross-env NODE_ENV=development OUTPUT_PATH=${outputPath} webpack --config webpack.config.js --config-name renderer --watch`,
+      prefixColor: "cyan",
+    },
+    {
+      name: "Elec",
+      command: `npx wait-on ${outputPath}/main.js ${outputPath}/index.html && npx electron --no-sandbox --inspect=5858 ${args.join(
+        " ",
+      )} ${outputPath} --watch`,
+      prefixColor: "green",
+    },
+  ],
+  {
+    prefix: "name",
+    outputStream: process.stdout,
+    killOthers: ["success", "failure"],
+  },
+);

--- a/apps/desktop/webpack.config.js
+++ b/apps/desktop/webpack.config.js
@@ -1,18 +1,43 @@
+const path = require("path");
 const { buildConfig } = require("./webpack.base");
 
-module.exports = buildConfig({
-  configName: "OSS",
-  renderer: {
-    entry: "./src/app/main.ts",
-    entryModule: "src/app/app.module#AppModule",
-    tsConfig: "./tsconfig.renderer.json",
-  },
-  main: {
-    entry: "./src/entry.ts",
-    tsConfig: "./tsconfig.json",
-  },
-  preload: {
-    entry: "./src/preload.ts",
-    tsConfig: "./tsconfig.json",
-  },
-});
+module.exports = (webpackConfig, context) => {
+  const isNxBuild = context && context.options;
+
+  if (isNxBuild) {
+    return buildConfig({
+      configName: "OSS",
+      renderer: {
+        entry: path.resolve(__dirname, "src/app/main.ts"),
+        entryModule: "src/app/app.module#AppModule",
+        tsConfig: path.resolve(context.context.root, "apps/desktop/tsconfig.renderer.json"),
+      },
+      main: {
+        entry: path.resolve(__dirname, "src/entry.ts"),
+        tsConfig: path.resolve(context.context.root, "apps/desktop/tsconfig.json"),
+      },
+      preload: {
+        entry: path.resolve(__dirname, "src/preload.ts"),
+        tsConfig: path.resolve(context.context.root, "apps/desktop/tsconfig.json"),
+      },
+      outputPath: path.resolve(context.context.root, context.options.outputPath),
+    });
+  } else {
+    return buildConfig({
+      configName: "OSS",
+      renderer: {
+        entry: path.resolve(__dirname, "src/app/main.ts"),
+        entryModule: "src/app/app.module#AppModule",
+        tsConfig: path.resolve(__dirname, "tsconfig.renderer.json"),
+      },
+      main: {
+        entry: path.resolve(__dirname, "src/entry.ts"),
+        tsConfig: path.resolve(__dirname, "tsconfig.json"),
+      },
+      preload: {
+        entry: path.resolve(__dirname, "src/preload.ts"),
+        tsConfig: path.resolve(__dirname, "tsconfig.json"),
+      },
+    });
+  }
+};


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-24802
- https://github.com/bitwarden/clients/pull/16648
- https://github.com/bitwarden/clients/pull/16706
- https://github.com/bitwarden/clients/pull/16712

## 📔 Objective

Enable Nx builds in the desktop app. For example:

```bash
# basic commands
npx nx serve desktop
npx nx build-native desktop
npx nx build desktop (bundles the next three)
npx nx build-renderer desktop 
npx nx build-main desktop 
npx nx build-preload desktop 
npx nx test desktop
npx nx lint desktop
```

Most complexity here is that we need to support the pre-nx build pipelines for a while, so we have to juggle both configurations. The recent refactor of our webpack config to a webpack config factory was pretty helpful here. I added some optional parameters that come from Nx in Nx builds. Most lines are just changes from relative paths to absolute paths to account for the fact that npm and nx have different working directories.

Once we update CI to use Nx builds exclusively, and the Nx builds have had time to get battle tested, we'll remove the old npm builds and this configuration will get much simpler.

Otherwise, this is a fairly straightforward port of the build commands from desktops's package.json into a functioning project.json. It uses the standard executors and follows Nx conventions for this kind of build without much else that is special.

## 📸 Screenshots

*running `npx nx serve desktop`*
<img width="3456" height="2234" alt="a running serve" src="https://github.com/user-attachments/assets/dbd40f8e-056a-48b0-a7e7-f9bf26107997" />

*running `npx nx build desktop`*
<img width="3456" height="2234" alt="a build" src="https://github.com/user-attachments/assets/d5a9e2be-aaf2-4a88-9bd8-5635fb4c2b6a" />

*running `npx nx build-native desktop`*
<img width="3456" height="2234" alt="building the native module" src="https://github.com/user-attachments/assets/877657ae-1f96-49b0-993c-2076df3acb47" />

*running `npx nx test desktop` and `npx nx lint desktop`*
<img width="3456" height="2234" alt="linting_and_testing" src="https://github.com/user-attachments/assets/ab1bad2b-3e9c-4d85-8737-b8bbd7a0f456" />


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
