### PR TITLE
fix: add Datadog org integration service to SM integrations module

### DIFF
--- a/bitwarden_license/bit-web/src/app/secrets-manager/integrations/integrations.module.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/integrations/integrations.module.ts
@@ -1,5 +1,6 @@
 import { NgModule } from "@angular/core";
 
+import { DatadogOrganizationIntegrationService } from "@bitwarden/bit-common/dirt/organization-integrations/services/datadog-organization-integration-service";
 import { HecOrganizationIntegrationService } from "@bitwarden/bit-common/dirt/organization-integrations/services/hec-organization-integration-service";
 import { OrganizationIntegrationApiService } from "@bitwarden/bit-common/dirt/organization-integrations/services/organization-integration-api.service";
 import { OrganizationIntegrationConfigurationApiService } from "@bitwarden/bit-common/dirt/organization-integrations/services/organization-integration-configuration-api.service";
@@ -21,6 +22,11 @@ import { IntegrationsComponent } from "./integrations.component";
     IntegrationGridComponent,
   ],
   providers: [
+    safeProvider({
+      provide: DatadogOrganizationIntegrationService,
+      useClass: DatadogOrganizationIntegrationService,
+      deps: [OrganizationIntegrationApiService, OrganizationIntegrationConfigurationApiService],
+    }),
     safeProvider({
       provide: HecOrganizationIntegrationService,
       useClass: HecOrganizationIntegrationService,


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/SM-1621

## 📔 Objective

Fix missing Secrets Manager integration cards. 

## 📸 Screenshots

Before:

<img width="3328" height="1946" alt="image" src="https://github.com/user-attachments/assets/253a322b-d512-4bca-8248-f8273c3e0b1f" />

After:

<img width="3326" height="2046" alt="image" src="https://github.com/user-attachments/assets/baaa3edb-072d-47bb-ba08-90b07c211ec3" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
