### PR TITLE
[PM-26954] Disable 'sync vault now' button while busy

### DIFF
--- a/apps/browser/src/vault/popup/settings/vault-settings.component.html
+++ b/apps/browser/src/vault/popup/settings/vault-settings.component.html
@@ -66,10 +66,16 @@
       </a>
     </bit-item>
     <bit-item>
-      <button type="button" bit-item-content (click)="sync()">
+      <button type="button" bit-item-content [disabled]="syncLoading" (click)="sync()">
         {{ "syncNow" | i18n }}
         <span slot="secondary">{{ lastSync }}</span>
-        <i slot="end" class="bwi bwi-refresh" aria-hidden="true"></i>
+        <span slot="end">
+          @if (syncLoading) {
+            <bit-spinner size="small"></bit-spinner>
+          } @else {
+            <i class="bwi bwi-refresh" aria-hidden="true"></i>
+          }
+        </span>
       </button>
     </bit-item>
   </bit-item-group>

--- a/apps/browser/src/vault/popup/settings/vault-settings.component.ts
+++ b/apps/browser/src/vault/popup/settings/vault-settings.component.ts
@@ -14,7 +14,13 @@ import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.servic
 import { CipherArchiveService } from "@bitwarden/common/vault/abstractions/cipher-archive.service";
 import { PremiumUpgradePromptService } from "@bitwarden/common/vault/abstractions/premium-upgrade-prompt.service";
 import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.service.abstraction";
-import { BerryComponent, ItemModule, ToastOptions, ToastService } from "@bitwarden/components";
+import {
+  BerryComponent,
+  SpinnerComponent,
+  ItemModule,
+  ToastOptions,
+  ToastService,
+} from "@bitwarden/components";
 
 import { PopOutComponent } from "../../../platform/popup/components/pop-out.component";
 import { PopupHeaderComponent } from "../../../platform/popup/layout/popup-header.component";
@@ -34,6 +40,7 @@ import { PopupPageComponent } from "../../../platform/popup/layout/popup-page.co
     ItemModule,
     BerryComponent,
     PremiumBadgeComponent,
+    SpinnerComponent,
   ],
   providers: [
     { provide: PremiumUpgradePromptService, useClass: BrowserPremiumUpgradePromptService },
@@ -43,6 +50,7 @@ export class VaultSettingsComponent implements OnInit, OnDestroy {
   private readonly premiumBadgeComponent = viewChild(PremiumBadgeComponent);
 
   lastSync = "--";
+  syncLoading = false;
   private userId$ = this.accountService.activeAccount$.pipe(getUserId);
 
   protected readonly userCanArchive = toSignal(
@@ -89,19 +97,25 @@ export class VaultSettingsComponent implements OnInit, OnDestroy {
   }
 
   async sync() {
+    this.syncLoading = true;
     let toastConfig: ToastOptions;
-    const success = await this.syncService.fullSync(true);
-    if (success) {
-      await this.setLastSync();
-      toastConfig = {
-        variant: "success",
-        title: "",
-        message: this.i18nService.t("syncingComplete"),
-      };
-    } else {
-      toastConfig = { variant: "error", title: "", message: this.i18nService.t("syncingFailed") };
+
+    try {
+      const success = await this.syncService.fullSync(true);
+      if (success) {
+        await this.setLastSync();
+        toastConfig = {
+          variant: "success",
+          title: "",
+          message: this.i18nService.t("syncingComplete"),
+        };
+      } else {
+        toastConfig = { variant: "error", title: "", message: this.i18nService.t("syncingFailed") };
+      }
+      this.toastService.showToast(toastConfig);
+    } finally {
+      this.syncLoading = false;
     }
-    this.toastService.showToast(toastConfig);
   }
 
   private async setLastSync() {


### PR DESCRIPTION
## 🎟️ Tracking

https://community.bitwarden.com/t/sync-vault-now-should-indicate-visually-that-syncing-has-started/86106

## 📔 Objective

Clicking the "Sync vault now" button in the browser extension produces no visual feedback whatsoever until sync completes, which can take several seconds. This is a bad UX pattern as it undermines and confuses the user.

This MR dims the button and disables it once it has been clicked, and reverts this once sync completes (one way or the other).

## 📸 Screenshots

### Before clicking

<img width="200" alt="Screenshot 2025-10-14 at 17-32-35 Bitwarden" src="https://github.com/user-attachments/assets/4eaaa2aa-40fe-4c91-b07c-3cef5f0a76bd" />

### After clicking, before sync completes

<img width="200" alt="Screenshot 2025-10-14 at 17-32-40 Bitwarden" src="https://github.com/user-attachments/assets/2dcefc5f-2a3f-45ab-ba3f-143673566b66" />

### After sync completes

<img width="200" alt="Screenshot 2025-10-14 at 17-32-47 Bitwarden" src="https://github.com/user-attachments/assets/9643a2b0-99e3-42d9-88a4-e9faaeef0a5b" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
