### PR TITLE
[PM-26959] deprecated server fetch for phishing urls

### DIFF
--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -1423,7 +1423,6 @@ export default class MainBackground {
 
     PhishingDetectionService.initialize(
       this.accountService,
-      this.auditService,
       this.billingAccountProfileStateService,
       this.configService,
       this.eventCollectionService,

--- a/apps/browser/src/dirt/phishing-detection/services/cdn-phishing.service.spec.ts
+++ b/apps/browser/src/dirt/phishing-detection/services/cdn-phishing.service.spec.ts
@@ -1,0 +1,226 @@
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+
+import { CDNPhishingService } from "./cdn-phishing.service";
+
+// Mock fetch globally
+global.fetch = jest.fn();
+
+describe("CDNPhishingService", () => {
+  let service: CDNPhishingService;
+  let logService: LogService;
+  let parserService: any;
+  let checksumService: any;
+
+  beforeEach(() => {
+    logService = {
+      info: jest.fn(),
+      debug: jest.fn(),
+      warning: jest.fn(),
+      error: jest.fn(),
+    } as any;
+
+    parserService = {
+      parseDomains: jest.fn(),
+    } as any;
+
+    checksumService = {
+      calculateChecksum: jest.fn(),
+      validateChecksum: jest.fn(),
+    } as any;
+
+    service = new CDNPhishingService(logService, parserService, checksumService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("getPhishingDomainsAsync", () => {
+    it("should fetch and parse domains successfully", async () => {
+      const mockContent = "phishing1.com\nphishing2.com\n# comment\nphishing3.com";
+      const mockDomains = ["phishing1.com", "phishing2.com", "phishing3.com"];
+      const mockResponse = {
+        ok: true,
+        text: jest.fn().mockResolvedValue(mockContent),
+      };
+
+      (global.fetch as jest.Mock).mockResolvedValue(mockResponse);
+      parserService.parseDomains.mockReturnValue(mockDomains);
+
+      const result = await service.getPhishingDomainsAsync();
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        "https://raw.githubusercontent.com/Phishing-Database/Phishing.Database/master/phishing-domains-ACTIVE.txt",
+        expect.objectContaining({
+          method: "GET",
+          headers: expect.objectContaining({
+            Accept: "text/plain",
+          }),
+        }),
+      );
+      expect(parserService.parseDomains).toHaveBeenCalledWith(mockContent);
+      expect(result).toEqual(mockDomains);
+      expect(logService.info).toHaveBeenCalledWith(
+        "[CDNPhishingService] Fetching phishing domains from GitHub CDN",
+      );
+      expect(logService.info).toHaveBeenCalledWith(
+        "[CDNPhishingService] Successfully parsed 3 domains from GitHub CDN",
+      );
+    });
+
+    it("should handle HTTP error responses", async () => {
+      const mockResponse = {
+        ok: false,
+        status: 404,
+        statusText: "Not Found",
+      };
+
+      (global.fetch as jest.Mock).mockResolvedValue(mockResponse);
+
+      await expect(service.getPhishingDomainsAsync()).rejects.toThrow("HTTP 404: Not Found");
+      expect(logService.error).toHaveBeenCalledWith(
+        "[CDNPhishingService] Failed to fetch phishing domains from GitHub CDN:",
+        expect.any(Error),
+      );
+    });
+
+    it("should handle network errors", async () => {
+      const networkError = new Error("Network error");
+      (global.fetch as jest.Mock).mockRejectedValue(networkError);
+
+      await expect(service.getPhishingDomainsAsync()).rejects.toThrow("Network error");
+      expect(logService.error).toHaveBeenCalledWith(
+        "[CDNPhishingService] Failed to fetch phishing domains from GitHub CDN:",
+        networkError,
+      );
+    });
+
+    it("should handle timeout errors", async () => {
+      const timeoutError = new Error("Request timeout after 15000ms");
+      (global.fetch as jest.Mock).mockRejectedValue(timeoutError);
+
+      await expect(service.getPhishingDomainsAsync()).rejects.toThrow(
+        "Request timeout after 15000ms",
+      );
+    });
+  });
+
+  describe("getRemoteChecksumAsync", () => {
+    it("should fetch and parse remote SHA-256 checksum successfully", async () => {
+      const mockChecksumLine =
+        "00feeac3b6deed8baf165f00cce816971e8da9e2cb8a59d3cec5823f1f4787d2 *phishing-domains-ACTIVE.txt";
+      const mockResponse = {
+        ok: true,
+        text: jest.fn().mockResolvedValue(mockChecksumLine),
+      };
+
+      (global.fetch as jest.Mock).mockResolvedValue(mockResponse);
+      checksumService.validateChecksum.mockReturnValue(true);
+
+      const result = await service.getRemoteChecksumAsync();
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        "https://raw.githubusercontent.com/Phishing-Database/checksums/refs/heads/master/phishing-domains-ACTIVE.txt.sha256",
+        expect.objectContaining({
+          method: "GET",
+          headers: expect.objectContaining({
+            Accept: "text/plain",
+          }),
+        }),
+      );
+      expect(result).toBe("00feeac3b6deed8baf165f00cce816971e8da9e2cb8a59d3cec5823f1f4787d2");
+      expect(logService.info).toHaveBeenCalledWith(
+        "[CDNPhishingService] Fetching remote checksum (SHA-256) from GitHub checksums repo",
+      );
+      expect(logService.info).toHaveBeenCalledWith(
+        "[CDNPhishingService] Successfully retrieved remote checksum: 00feeac3b6deed8baf165f00cce816971e8da9e2cb8a59d3cec5823f1f4787d2",
+      );
+    });
+
+    it("should handle HTTP error responses", async () => {
+      const mockResponse = {
+        ok: false,
+        status: 500,
+        statusText: "Internal Server Error",
+      };
+
+      (global.fetch as jest.Mock).mockResolvedValue(mockResponse);
+
+      await expect(service.getRemoteChecksumAsync()).rejects.toThrow(
+        "HTTP 500: Internal Server Error",
+      );
+      expect(logService.error).toHaveBeenCalledWith(
+        "[CDNPhishingService] Failed to fetch remote checksum from GitHub:",
+        expect.any(Error),
+      );
+    });
+
+    it("should handle invalid checksum formats", async () => {
+      const invalidContent = "not-a-checksum-value";
+      const mockResponse = { ok: true, text: jest.fn().mockResolvedValue(invalidContent) };
+      (global.fetch as jest.Mock).mockResolvedValue(mockResponse);
+      checksumService.validateChecksum.mockReturnValue(false);
+
+      await expect(service.getRemoteChecksumAsync()).rejects.toThrow(
+        "Invalid checksum format received from remote checksums repo",
+      );
+    });
+
+    it("should handle network errors", async () => {
+      const networkError = new Error("Network error");
+      (global.fetch as jest.Mock).mockRejectedValue(networkError);
+
+      await expect(service.getRemoteChecksumAsync()).rejects.toThrow("Network error");
+      expect(logService.error).toHaveBeenCalledWith(
+        "[CDNPhishingService] Failed to fetch remote checksum from GitHub:",
+        networkError,
+      );
+    });
+  });
+
+  describe("_fetchWithTimeout", () => {
+    it("should handle successful requests within timeout", async () => {
+      const mockResponse = { ok: true, text: jest.fn() };
+      (global.fetch as jest.Mock).mockResolvedValue(mockResponse);
+
+      const result = await service["_fetchWithTimeout"]("https://example.com");
+
+      expect(result).toBe(mockResponse);
+      expect(global.fetch).toHaveBeenCalledWith(
+        "https://example.com",
+        expect.objectContaining({
+          signal: expect.any(AbortSignal),
+        }),
+      );
+    });
+
+    it("should handle timeout errors", async () => {
+      // Mock fetch to never resolve
+      (global.fetch as jest.Mock).mockImplementation(
+        () =>
+          new Promise((resolve, reject) => {
+            // Simulate timeout by rejecting with AbortError
+            setTimeout(() => {
+              const error = new Error("Request timeout after 60000ms");
+              error.name = "AbortError";
+              reject(error);
+            }, 100);
+          }),
+      );
+
+      await expect(service["_fetchWithTimeout"]("https://example.com")).rejects.toThrow(
+        "Request timeout after 15000ms",
+      );
+    });
+
+    it("should handle abort errors", async () => {
+      const abortError = new Error("Request aborted");
+      abortError.name = "AbortError";
+      (global.fetch as jest.Mock).mockRejectedValue(abortError);
+
+      await expect(service["_fetchWithTimeout"]("https://example.com")).rejects.toThrow(
+        "Request timeout after 15000ms",
+      );
+    });
+  });
+});

--- a/apps/browser/src/dirt/phishing-detection/services/cdn-phishing.service.ts
+++ b/apps/browser/src/dirt/phishing-detection/services/cdn-phishing.service.ts
@@ -1,0 +1,109 @@
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+
+import { PhishingChecksumService } from "./phishing-checksum.service";
+import { PhishingDataParserService } from "./phishing-data-parser.service";
+
+export interface ICloudPhishingDomainQuery {
+  getPhishingDomainsAsync(): Promise<string[]>;
+  getRemoteChecksumAsync(): Promise<string>;
+}
+
+export class CDNPhishingService implements ICloudPhishingDomainQuery {
+  private static readonly _DOMAINS_URL =
+    "https://raw.githubusercontent.com/Phishing-Database/Phishing.Database/master/phishing-domains-ACTIVE.txt";
+  private static readonly _CHECKSUM_SHA256_URL =
+    "https://raw.githubusercontent.com/Phishing-Database/checksums/refs/heads/master/phishing-domains-ACTIVE.txt.sha256";
+  private static readonly _TIMEOUT = 15000;
+
+  constructor(
+    private readonly logService: LogService,
+    private readonly parserService: PhishingDataParserService,
+    private readonly checksumService: PhishingChecksumService,
+  ) {}
+
+  async getPhishingDomainsAsync(): Promise<string[]> {
+    try {
+      this.logService.info("[CDNPhishingService] Fetching phishing domains from GitHub CDN");
+
+      const response = await this._fetchWithTimeout(CDNPhishingService._DOMAINS_URL);
+
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      }
+
+      const content = await response.text();
+      const domains = this.parserService.parseDomains(content);
+
+      this.logService.info(
+        `[CDNPhishingService] Successfully parsed ${domains.length} domains from GitHub CDN`,
+      );
+      return domains;
+    } catch (error) {
+      this.logService.error(
+        "[CDNPhishingService] Failed to fetch phishing domains from GitHub CDN:",
+        error,
+      );
+      throw error;
+    }
+  }
+
+  async getRemoteChecksumAsync(): Promise<string> {
+    try {
+      this.logService.info(
+        "[CDNPhishingService] Fetching remote checksum (SHA-256) from GitHub checksums repo",
+      );
+
+      // Fetch the remote SHA-256 checksum
+      const response = await this._fetchWithTimeout(CDNPhishingService._CHECKSUM_SHA256_URL);
+
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      }
+
+      const content = await response.text();
+      // Expected format: "<hex> *phishing-domains-ACTIVE.txt"; take the first token as checksum
+      const parsed = content.trim().split(/\s+/)[0]?.trim() ?? "";
+
+      if (!this.checksumService.validateChecksum(parsed)) {
+        throw new Error("Invalid checksum format received from remote checksums repo");
+      }
+
+      this.logService.info(
+        `[CDNPhishingService] Successfully retrieved remote checksum: ${parsed}`,
+      );
+      return parsed;
+    } catch (error) {
+      this.logService.error(
+        "[CDNPhishingService] Failed to fetch remote checksum from GitHub:",
+        error,
+      );
+      throw error;
+    }
+  }
+
+  // Only downloading domains if checksum changes
+
+  private async _fetchWithTimeout(url: string): Promise<Response> {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), CDNPhishingService._TIMEOUT);
+
+    try {
+      const response = await fetch(url, {
+        method: "GET",
+        headers: {
+          Accept: "text/plain",
+        },
+        signal: controller.signal,
+      });
+
+      clearTimeout(timeoutId);
+      return response;
+    } catch (error) {
+      clearTimeout(timeoutId);
+      if (error.name === "AbortError") {
+        throw new Error(`Request timeout after ${CDNPhishingService._TIMEOUT}ms`);
+      }
+      throw error;
+    }
+  }
+}

--- a/apps/browser/src/dirt/phishing-detection/services/phishing-checksum.service.spec.ts
+++ b/apps/browser/src/dirt/phishing-detection/services/phishing-checksum.service.spec.ts
@@ -1,0 +1,189 @@
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+import { AbstractStorageService } from "@bitwarden/common/platform/abstractions/storage.service";
+
+import { PhishingChecksumService } from "./phishing-checksum.service";
+
+describe("PhishingChecksumService", () => {
+  let service: PhishingChecksumService;
+  let logService: LogService;
+  let storageService: AbstractStorageService;
+
+  beforeEach(() => {
+    logService = {
+      debug: jest.fn(),
+      warning: jest.fn(),
+      error: jest.fn(),
+    } as any;
+
+    storageService = {
+      get: jest.fn().mockResolvedValue(null),
+      save: jest.fn().mockResolvedValue(undefined),
+    } as any;
+
+    service = new PhishingChecksumService(logService, storageService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("validateChecksum", () => {
+    it("should validate correct SHA256 checksum format", () => {
+      const validChecksum = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+      expect(service.validateChecksum(validChecksum)).toBe(true);
+    });
+
+    it("should validate uppercase SHA256 checksum format", () => {
+      const validChecksum = "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF";
+
+      expect(service.validateChecksum(validChecksum)).toBe(true);
+    });
+
+    it("should reject invalid checksum formats", () => {
+      const invalidChecksums = [
+        "", // empty
+        "   ", // whitespace only
+        "short", // too short
+        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdefextra", // too long
+        "g1b2c3d4e5f6789012345678901234567890abcdef1234567890abcdef1234567890", // invalid characters
+      ];
+
+      invalidChecksums.forEach((checksum) => {
+        expect(service.validateChecksum(checksum)).toBe(false);
+      });
+    });
+
+    it("should handle null and undefined", () => {
+      expect(service.validateChecksum(null as any)).toBe(false);
+      expect(service.validateChecksum(undefined as any)).toBe(false);
+    });
+
+    it("should trim whitespace before validation", () => {
+      const validChecksum = "  0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef  ";
+
+      expect(service.validateChecksum(validChecksum)).toBe(true);
+    });
+  });
+
+  describe("getCurrentChecksum", () => {
+    it("should retrieve checksum from storage", async () => {
+      const storedChecksum = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+      (storageService.get as jest.Mock).mockResolvedValue(storedChecksum);
+
+      const result = await service.getCurrentChecksum();
+
+      expect(storageService.get).toHaveBeenCalledWith("phishing_domains_checksum");
+      expect(result).toBe(storedChecksum);
+    });
+
+    it("should return empty string when no checksum is stored", async () => {
+      (storageService.get as jest.Mock).mockResolvedValue(null);
+
+      const result = await service.getCurrentChecksum();
+
+      expect(result).toBe("");
+    });
+
+    it("should handle storage errors gracefully", async () => {
+      const storageError = new Error("Storage error");
+      (storageService.get as jest.Mock).mockRejectedValue(storageError);
+
+      const result = await service.getCurrentChecksum();
+
+      expect(result).toBe("");
+      expect(logService.error).toHaveBeenCalledWith(
+        "[PhishingChecksumService] Failed to get current checksum:",
+        storageError,
+      );
+    });
+  });
+
+  describe("saveChecksum", () => {
+    it("should save valid checksum to storage", async () => {
+      const validChecksum = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+      (storageService.save as jest.Mock).mockResolvedValue(undefined);
+
+      await service.saveChecksum(validChecksum);
+
+      expect(storageService.save).toHaveBeenCalledWith("phishing_domains_checksum", validChecksum);
+      expect(logService.debug).toHaveBeenCalledWith(
+        "[PhishingChecksumService] Saved checksum: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      );
+    });
+
+    it("should not save invalid checksum", async () => {
+      const invalidChecksum = "invalid";
+      (storageService.save as jest.Mock).mockResolvedValue(undefined);
+
+      await service.saveChecksum(invalidChecksum);
+
+      expect(storageService.save).not.toHaveBeenCalled();
+      expect(logService.warning).toHaveBeenCalledWith(
+        "[PhishingChecksumService] Invalid checksum format: invalid",
+      );
+    });
+
+    it("should handle storage errors", async () => {
+      const validChecksum = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+      const storageError = new Error("Storage error");
+      (storageService.save as jest.Mock).mockRejectedValue(storageError);
+
+      await expect(service.saveChecksum(validChecksum)).rejects.toThrow("Storage error");
+      expect(logService.error).toHaveBeenCalledWith(
+        "[PhishingChecksumService] Failed to save checksum:",
+        storageError,
+      );
+    });
+  });
+
+  describe("compareChecksums", () => {
+    it("should return true for identical checksums", () => {
+      const checksum = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+      expect(service.compareChecksums(checksum, checksum)).toBe(true);
+    });
+
+    it("should return false for different checksums", () => {
+      const checksum1 = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+      const checksum2 = "b2c3d4e5f6789012345678901234567890abcdef1234567890abcdef1234567890a1";
+
+      expect(service.compareChecksums(checksum1, checksum2)).toBe(false);
+    });
+
+    it("should handle case insensitive comparison", () => {
+      const checksum1 = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+      const checksum2 = "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF";
+
+      expect(service.compareChecksums(checksum1, checksum2)).toBe(true);
+    });
+
+    it("should handle whitespace trimming", () => {
+      const checksum1 = "  0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef  ";
+      const checksum2 = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+      expect(service.compareChecksums(checksum1, checksum2)).toBe(true);
+    });
+
+    it("should handle null and undefined values", () => {
+      const checksum = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+      expect(service.compareChecksums(null as any, checksum)).toBe(false);
+      expect(service.compareChecksums(checksum, null as any)).toBe(false);
+      expect(service.compareChecksums(null as any, null as any)).toBe(true);
+      expect(service.compareChecksums(undefined as any, checksum)).toBe(false);
+      expect(service.compareChecksums(checksum, undefined as any)).toBe(false);
+    });
+
+    it("should log comparison results", () => {
+      const checksum1 = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+      const checksum2 = "b2c3d4e5f6789012345678901234567890abcdef1234567890abcdef1234567890a1";
+
+      service.compareChecksums(checksum1, checksum2);
+
+      expect(logService.debug).toHaveBeenCalledWith(
+        "[PhishingChecksumService] Checksum comparison: different",
+      );
+    });
+  });
+});

--- a/apps/browser/src/dirt/phishing-detection/services/phishing-checksum.service.ts
+++ b/apps/browser/src/dirt/phishing-detection/services/phishing-checksum.service.ts
@@ -1,0 +1,72 @@
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+import { AbstractStorageService } from "@bitwarden/common/platform/abstractions/storage.service";
+
+export class PhishingChecksumService {
+  private static readonly _CHECKSUM_STORAGE_KEY = "phishing_domains_checksum";
+
+  constructor(
+    private readonly logService: LogService,
+    private readonly storageService: AbstractStorageService,
+  ) {}
+
+  /**
+   * Validates checksum format (SHA256 hex string)
+   */
+  validateChecksum(checksum: string): boolean {
+    if (!checksum || checksum.trim() === "") {
+      return false;
+    }
+
+    // SHA256 produces 64-character hex string
+    const sha256Regex = /^[a-fA-F0-9]{64}$/i;
+    return sha256Regex.test(checksum.trim());
+  }
+
+  /**
+   * Gets the current checksum from storage
+   */
+  async getCurrentChecksum(): Promise<string> {
+    try {
+      const checksum = await this.storageService.get<string>(
+        PhishingChecksumService._CHECKSUM_STORAGE_KEY,
+      );
+      return checksum || "";
+    } catch (error) {
+      this.logService.error("[PhishingChecksumService] Failed to get current checksum:", error);
+      return "";
+    }
+  }
+
+  /**
+   * Saves checksum to storage
+   */
+  async saveChecksum(checksum: string): Promise<void> {
+    if (!this.validateChecksum(checksum)) {
+      this.logService.warning(`[PhishingChecksumService] Invalid checksum format: ${checksum}`);
+      return;
+    }
+
+    try {
+      await this.storageService.save(PhishingChecksumService._CHECKSUM_STORAGE_KEY, checksum);
+      this.logService.debug(`[PhishingChecksumService] Saved checksum: ${checksum}`);
+    } catch (error) {
+      this.logService.error("[PhishingChecksumService] Failed to save checksum:", error);
+      throw error;
+    }
+  }
+
+  /**
+   * Compares two checksums
+   */
+  compareChecksums(current: string, remote: string): boolean {
+    const normalizedCurrent = current?.trim().toLowerCase() || "";
+    const normalizedRemote = remote?.trim().toLowerCase() || "";
+
+    const isEqual = normalizedCurrent === normalizedRemote;
+    this.logService.debug(
+      `[PhishingChecksumService] Checksum comparison: ${isEqual ? "equal" : "different"}`,
+    );
+
+    return isEqual;
+  }
+}

--- a/apps/browser/src/dirt/phishing-detection/services/phishing-data-parser.service.spec.ts
+++ b/apps/browser/src/dirt/phishing-detection/services/phishing-data-parser.service.spec.ts
@@ -1,0 +1,268 @@
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+
+import { PhishingDataParserService } from "./phishing-data-parser.service";
+
+describe("PhishingDataParserService", () => {
+  let service: PhishingDataParserService;
+  let logService: LogService;
+
+  beforeEach(() => {
+    logService = {
+      debug: jest.fn(),
+      warning: jest.fn(),
+      error: jest.fn(),
+    } as any;
+
+    service = new PhishingDataParserService(logService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("parseDomains", () => {
+    it("should parse domains from text content correctly", () => {
+      const content = "phishing1.com\nphishing2.com\nphishing3.com";
+      const expectedDomains = ["phishing1.com", "phishing2.com", "phishing3.com"];
+
+      const result = service.parseDomains(content);
+
+      expect(result).toEqual(expectedDomains);
+      expect(logService.debug).toHaveBeenCalledWith(
+        "[PhishingDataParserService] Parsed 3 domains from content",
+      );
+    });
+
+    it("should handle mixed line endings (\\r\\n and \\n)", () => {
+      const content = "phishing1.com\r\nphishing2.com\nphishing3.com\r\nphishing4.com";
+      const expectedDomains = ["phishing1.com", "phishing2.com", "phishing3.com", "phishing4.com"];
+
+      const result = service.parseDomains(content);
+
+      expect(result).toEqual(expectedDomains);
+    });
+
+    it("should filter out comments (lines starting with #)", () => {
+      const content =
+        "phishing1.com\n# This is a comment\nphishing2.com\n# Another comment\nphishing3.com";
+      const expectedDomains = ["phishing1.com", "phishing2.com", "phishing3.com"];
+
+      const result = service.parseDomains(content);
+
+      expect(result).toEqual(expectedDomains);
+    });
+
+    it("should filter out empty lines", () => {
+      const content = "phishing1.com\n\nphishing2.com\n   \nphishing3.com";
+      const expectedDomains = ["phishing1.com", "phishing2.com", "phishing3.com"];
+
+      const result = service.parseDomains(content);
+
+      expect(result).toEqual(expectedDomains);
+    });
+
+    it("should trim whitespace from lines", () => {
+      const content = "  phishing1.com  \n  phishing2.com  \n  phishing3.com  ";
+      const expectedDomains = ["phishing1.com", "phishing2.com", "phishing3.com"];
+
+      const result = service.parseDomains(content);
+
+      expect(result).toEqual(expectedDomains);
+    });
+
+    it("should handle empty content", () => {
+      const result = service.parseDomains("");
+
+      expect(result).toEqual([]);
+      expect(logService.debug).toHaveBeenCalledWith(
+        "[PhishingDataParserService] Empty content provided",
+      );
+    });
+
+    it("should handle whitespace-only content", () => {
+      const result = service.parseDomains("   \n  \n  ");
+
+      expect(result).toEqual([]);
+      expect(logService.debug).toHaveBeenCalledWith(
+        "[PhishingDataParserService] Empty content provided",
+      );
+    });
+
+    it("should handle content with only comments", () => {
+      const content = "# Comment 1\n# Comment 2\n# Comment 3";
+      const result = service.parseDomains(content);
+
+      expect(result).toEqual([]);
+    });
+
+    it("should handle content with only empty lines", () => {
+      const content = "\n\n\n";
+      const result = service.parseDomains(content);
+
+      expect(result).toEqual([]);
+    });
+
+    it("should handle parsing errors gracefully", () => {
+      // Mock an error by making the content non-string and causing an error
+      const invalidContent = {
+        trim: jest.fn().mockReturnValue("test"),
+        split: jest.fn().mockImplementation(() => {
+          throw new Error("Test error");
+        }),
+      } as any;
+
+      const result = service.parseDomains(invalidContent);
+
+      expect(result).toEqual([]);
+      expect(logService.error).toHaveBeenCalledWith(
+        "[PhishingDataParserService] Failed to parse domains:",
+        expect.any(Error),
+      );
+    });
+
+    it("should handle large content efficiently", () => {
+      const domains = Array.from({ length: 1000 }, (_, i) => `phishing${i}.com`);
+      const content = domains.join("\n");
+
+      const result = service.parseDomains(content);
+
+      expect(result).toEqual(domains);
+      expect(result.length).toBe(1000);
+    });
+  });
+
+  describe("validateDomain", () => {
+    it("should validate correct domain formats", () => {
+      const validDomains = [
+        "example.com",
+        "sub.example.com",
+        "a.b.c.d.e",
+        "example.co.uk",
+        "test-domain.com",
+        "123.com",
+        "a1b2c3.com",
+        "very-long-domain-name-that-is-still-valid.com",
+      ];
+
+      validDomains.forEach((domain) => {
+        expect(service.validateDomain(domain)).toBe(true);
+      });
+    });
+
+    it("should reject invalid domain formats", () => {
+      const invalidDomains = [
+        "", // empty
+        "   ", // whitespace only
+        "example", // no TLD
+        ".com", // starts with dot
+        "example.", // ends with dot
+        "example..com", // double dots
+        "example-.com", // hyphen at end of label
+        "-example.com", // hyphen at start of label
+        "example@.com", // invalid character
+        "example .com", // space in domain
+        "example.com/", // path
+        "example.com:8080", // port
+        "http://example.com", // protocol
+        "example.com#fragment", // fragment
+        "example.com?query=1", // query
+      ];
+
+      invalidDomains.forEach((domain) => {
+        expect(service.validateDomain(domain)).toBe(false);
+      });
+    });
+
+    it("should handle null and undefined", () => {
+      expect(service.validateDomain(null as any)).toBe(false);
+      expect(service.validateDomain(undefined as any)).toBe(false);
+    });
+
+    it("should handle edge cases", () => {
+      expect(service.validateDomain("a.b")).toBe(true); // minimal valid domain
+      expect(service.validateDomain("a")).toBe(false); // single character
+      expect(service.validateDomain("a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p.q.r.s.t.u.v.w.x.y.z")).toBe(
+        true,
+      ); // very long but valid
+    });
+  });
+
+  describe("validateAndFilterDomains", () => {
+    it("should filter out invalid domains", () => {
+      const domains = [
+        "valid1.com",
+        "invalid-domain",
+        "valid2.com",
+        "",
+        "valid3.com",
+        "another-invalid",
+      ];
+      const expectedValidDomains = ["valid1.com", "valid2.com", "valid3.com"];
+
+      const result = service.validateAndFilterDomains(domains);
+
+      expect(result).toEqual(expectedValidDomains);
+    });
+
+    it("should return all domains when all are valid", () => {
+      const domains = ["valid1.com", "valid2.com", "valid3.com"];
+      const expectedValidDomains = ["valid1.com", "valid2.com", "valid3.com"];
+
+      const result = service.validateAndFilterDomains(domains);
+
+      expect(result).toEqual(expectedValidDomains);
+    });
+
+    it("should return empty array when all domains are invalid", () => {
+      const domains = ["invalid1", "invalid2", "invalid3"];
+
+      const result = service.validateAndFilterDomains(domains);
+
+      expect(result).toEqual([]);
+    });
+
+    it("should return empty array for empty input", () => {
+      const result = service.validateAndFilterDomains([]);
+
+      expect(result).toEqual([]);
+    });
+
+    it("should log warning when domains are filtered out", () => {
+      const domains = ["valid.com", "invalid", "another-valid.com"];
+
+      service.validateAndFilterDomains(domains);
+
+      expect(logService.warning).toHaveBeenCalledWith(
+        "[PhishingDataParserService] Filtered out 1 invalid domains",
+      );
+    });
+
+    it("should not log warning when no domains are filtered", () => {
+      const domains = ["valid1.com", "valid2.com"];
+
+      service.validateAndFilterDomains(domains);
+
+      expect(logService.warning).not.toHaveBeenCalled();
+    });
+
+    it("should handle mixed valid and invalid domains", () => {
+      const domains = [
+        "valid1.com",
+        "invalid-domain",
+        "valid2.co.uk",
+        "another-invalid",
+        "valid3.org",
+        "",
+        "valid4.net",
+      ];
+      const expectedValidDomains = ["valid1.com", "valid2.co.uk", "valid3.org", "valid4.net"];
+
+      const result = service.validateAndFilterDomains(domains);
+
+      expect(result).toEqual(expectedValidDomains);
+      expect(logService.warning).toHaveBeenCalledWith(
+        "[PhishingDataParserService] Filtered out 3 invalid domains",
+      );
+    });
+  });
+});

--- a/apps/browser/src/dirt/phishing-detection/services/phishing-data-parser.service.ts
+++ b/apps/browser/src/dirt/phishing-detection/services/phishing-data-parser.service.ts
@@ -1,0 +1,57 @@
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+
+export class PhishingDataParserService {
+  constructor(private readonly logService: LogService) {}
+
+  parseDomains(content: string): string[] {
+    if (!content || content.trim() === "") {
+      this.logService.debug("[PhishingDataParserService] Empty content provided");
+      return [];
+    }
+
+    try {
+      const domains = content
+        .split(/\r?\n/) // Split by \r\n or \n
+        .map((line) => line.trim()) // Trim whitespace
+        .filter((line) => line && !line.startsWith("#")); // Filter empty lines and comments
+
+      this.logService.debug(
+        `[PhishingDataParserService] Parsed ${domains.length} domains from content`,
+      );
+      return domains;
+    } catch (error) {
+      this.logService.error("[PhishingDataParserService] Failed to parse domains:", error);
+      return [];
+    }
+  }
+
+  /**
+   * Validates domain format (basic validation)
+   */
+  validateDomain(domain: string): boolean {
+    if (!domain || domain.trim() === "") {
+      return false;
+    }
+
+    // Domain validation - must contain at least one dot and valid characters
+    const domainRegex =
+      /^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+$/;
+    return domainRegex.test(domain);
+  }
+
+  /**
+   * Validates and filters domains array
+   */
+  validateAndFilterDomains(domains: string[]): string[] {
+    const validDomains = domains.filter((domain) => this.validateDomain(domain));
+
+    if (validDomains.length !== domains.length) {
+      const invalidCount = domains.length - validDomains.length;
+      this.logService.warning(
+        `[PhishingDataParserService] Filtered out ${invalidCount} invalid domains`,
+      );
+    }
+
+    return validDomains;
+  }
+}

--- a/apps/browser/src/dirt/phishing-detection/services/phishing-detection.service.spec.ts
+++ b/apps/browser/src/dirt/phishing-detection/services/phishing-detection.service.spec.ts
@@ -1,6 +1,5 @@
 import { of } from "rxjs";
 
-import { AuditService } from "@bitwarden/common/abstractions/audit.service";
 import { EventCollectionService } from "@bitwarden/common/abstractions/event/event-collection.service";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { BillingAccountProfileStateService } from "@bitwarden/common/billing/abstractions";
@@ -13,7 +12,6 @@ import { PhishingDetectionService } from "./phishing-detection.service";
 
 describe("PhishingDetectionService", () => {
   let accountService: AccountService;
-  let auditService: AuditService;
   let billingAccountProfileStateService: BillingAccountProfileStateService;
   let configService: ConfigService;
   let eventCollectionService: EventCollectionService;
@@ -22,8 +20,7 @@ describe("PhishingDetectionService", () => {
   let taskSchedulerService: TaskSchedulerService;
 
   beforeEach(() => {
-    accountService = { getAccount$: jest.fn(() => of(null)) } as any;
-    auditService = { getKnownPhishingDomains: jest.fn() } as any;
+    accountService = { activeAccount$: of(null) } as any;
     billingAccountProfileStateService = {} as any;
     configService = { getFeatureFlag$: jest.fn(() => of(false)) } as any;
     eventCollectionService = {} as any;
@@ -36,7 +33,6 @@ describe("PhishingDetectionService", () => {
     expect(() => {
       PhishingDetectionService.initialize(
         accountService,
-        auditService,
         billingAccountProfileStateService,
         configService,
         eventCollectionService,
@@ -66,7 +62,6 @@ describe("PhishingDetectionService", () => {
     // Run the initialization
     PhishingDetectionService.initialize(
       accountService,
-      auditService,
       billingAccountProfileStateService,
       configService,
       eventCollectionService,
@@ -105,7 +100,6 @@ describe("PhishingDetectionService", () => {
     // Run the initialization
     PhishingDetectionService.initialize(
       accountService,
-      auditService,
       billingAccountProfileStateService,
       configService,
       eventCollectionService,

--- a/libs/common/src/abstractions/audit.service.ts
+++ b/libs/common/src/abstractions/audit.service.ts
@@ -14,10 +14,4 @@ export abstract class AuditService {
    * @returns A promise that resolves to an array of BreachAccountResponse objects.
    */
   abstract breachedAccounts: (username: string) => Promise<BreachAccountResponse[]>;
-  /**
-   * Checks if a domain is known for phishing.
-   * @param domain The domain to check.
-   * @returns A promise that resolves to a boolean indicating if the domain is known for phishing.
-   */
-  abstract getKnownPhishingDomains: () => Promise<string[]>;
 }

--- a/libs/common/src/services/audit.service.ts
+++ b/libs/common/src/services/audit.service.ts
@@ -80,9 +80,4 @@ export class AuditService implements AuditServiceAbstraction {
       throw new Error();
     }
   }
-
-  async getKnownPhishingDomains(): Promise<string[]> {
-    const response = await this.apiService.send("GET", "/phishing-domains", null, true, true);
-    return response as string[];
-  }
 }


### PR DESCRIPTION
## 🎟️ Tracking

n/a

## 📔 Objective

Replaced server-side phishing domain fetching with direct CDN access using checksum-based updates.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
