### PR TITLE
[PM-26990] Extend import success dialog to show archived items count

### DIFF
--- a/libs/importer/src/components/dialog/import-success-dialog.component.ts
+++ b/libs/importer/src/components/dialog/import-success-dialog.component.ts
@@ -44,6 +44,7 @@ export class ImportSuccessDialogComponent implements OnInit {
     let identities = 0;
     let secureNotes = 0;
     let sshKeys = 0;
+    let archived = 0;
     this.data.ciphers.map((c) => {
       switch (c.type) {
         case CipherType.Login:
@@ -64,6 +65,10 @@ export class ImportSuccessDialogComponent implements OnInit {
         default:
           break;
       }
+
+      if (c.isArchived) {
+        archived++;
+      }
     });
 
     const list: ResultList[] = [];
@@ -81,6 +86,9 @@ export class ImportSuccessDialogComponent implements OnInit {
     }
     if (sshKeys > 0) {
       list.push({ icon: "key", type: "typeSshKey", count: sshKeys });
+    }
+    if (archived > 0) {
+      list.push({ icon: "archive", type: "archiveNoun", count: archived });
     }
     if (this.data.folders.length > 0) {
       list.push({ icon: "folder", type: "folders", count: this.data.folders.length });


### PR DESCRIPTION
## 🎟️ Tracking
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-26990

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Extend the import success dialog to show archived items count, when archived items were imported.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
| Before | After |
|--------|--------|
|<img width="486" height="305" alt="image" src="https://github.com/user-attachments/assets/119d6668-a5de-4024-ae5a-193ed94e306e" /> | <img width="486" height="305" alt="image" src="https://github.com/user-attachments/assets/c1650690-fe87-4a3a-9c06-0b6001edb39f" /> |


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
