### PR TITLE
[PM-26949] Auto-accept archive edits for piped commands

### DIFF
--- a/apps/cli/src/commands/edit.command.ts
+++ b/apps/cli/src/commands/edit.command.ts
@@ -261,8 +261,13 @@ export class EditCommand {
 
   /** Prompt the user to accept movement of their cipher back to the their vault. */
   private async promptForArchiveEdit(): Promise<boolean> {
-    // When running in serve or no interaction mode, automatically accept the prompt
-    if (process.env.BW_SERVE === "true" || process.env.BW_NOINTERACTION === "true") {
+    // When user has disabled interactivity or does not have the ability to prompt,
+    // automatically move the item back to the vault and inform them.
+    if (
+      process.env.BW_SERVE === "true" ||
+      process.env.BW_NOINTERACTION === "true" ||
+      !process.stdin.isTTY
+    ) {
       CliUtils.writeLn(
         "Archive is only available with a Premium subscription, which has ended. Your edit was saved and the item was moved back to your vault.",
       );


### PR DESCRIPTION
## 🎟️ Tracking

[PM-26949](https://bitwarden.atlassian.net/browse/PM-26949)

## 📔 Objective

When a user is piping together commands it removes the ability to prompt the user because the input is being piped elsewhere. Luckily, node provides a `isTTY` which will be false when the stream is being piped to places other than stdin.

## 📸 Screenshots

<video src="https://github.com/user-attachments/assets/a7323a3d-93f5-4e1c-be38-04520172d5a0" />

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-26949]: https://bitwarden.atlassian.net/browse/PM-26949?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ