### PR TITLE
[PM-26994] MP prompt first then Archive

### DIFF
--- a/apps/web/src/app/vault/individual-vault/vault.component.ts
+++ b/apps/web/src/app/vault/individual-vault/vault.component.ts
@@ -686,6 +686,12 @@ export class VaultComponent<C extends CipherViewLike> implements OnInit, OnDestr
   }
 
   async archive(cipher: C) {
+    const repromptPassed = await this.passwordRepromptService.passwordRepromptCheck(cipher);
+
+    if (!repromptPassed) {
+      return;
+    }
+
     const confirmed = await this.dialogService.openSimpleDialog({
       title: { key: "archiveItem" },
       content: { key: "archiveItemConfirmDesc" },
@@ -696,10 +702,6 @@ export class VaultComponent<C extends CipherViewLike> implements OnInit, OnDestr
       return;
     }
 
-    const repromptPassed = await this.passwordRepromptService.passwordRepromptCheck(cipher);
-    if (!repromptPassed) {
-      return;
-    }
     const activeUserId = await firstValueFrom(this.userId$);
     try {
       await this.cipherArchiveService.archiveWithServer(cipher.id as CipherId, activeUserId);
@@ -718,6 +720,10 @@ export class VaultComponent<C extends CipherViewLike> implements OnInit, OnDestr
   }
 
   async bulkArchive(ciphers: C[]) {
+    if (!(await this.repromptCipher(ciphers))) {
+      return;
+    }
+
     const confirmed = await this.dialogService.openSimpleDialog({
       title: { key: "archiveBulkItems" },
       content: { key: "archiveBulkItemsConfirmDesc" },
@@ -725,10 +731,6 @@ export class VaultComponent<C extends CipherViewLike> implements OnInit, OnDestr
     });
 
     if (!confirmed) {
-      return;
-    }
-
-    if (!(await this.repromptCipher(ciphers))) {
       return;
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-26994](https://bitwarden.atlassian.net/browse/PM-26994)

## 📔 Objective

To match other master password prompt flows - prompt for the MP first, then show the archive confirmation dialog.

## 📸 Screenshots

<video src="https://github.com/user-attachments/assets/45817efb-b176-4645-b46e-a6760a7f1b01" />

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-26994]: https://bitwarden.atlassian.net/browse/PM-26994?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ