### PR TITLE
Display autofill overlay for zoom.us signin password

### DIFF
--- a/apps/browser/src/autofill/services/autofill-overlay-content.service.ts
+++ b/apps/browser/src/autofill/services/autofill-overlay-content.service.ts
@@ -1085,7 +1085,15 @@ export class AutofillOverlayContentService implements AutofillOverlayContentServ
         pageDetails,
       )
     ) {
-      this.setQualifiedAccountCreationFillType(autofillFieldData);
+      const hasUsernameField = [...this.formFieldElements.values()].some((field) =>
+        this.inlineMenuFieldQualificationService.isUsernameField(field),
+      );
+
+      if (hasUsernameField) {
+        void this.setQualifiedLoginFillType(autofillFieldData);
+      } else {
+        this.setQualifiedAccountCreationFillType(autofillFieldData);
+      }
       return false;
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-26348](https://bitwarden.atlassian.net/browse/PM-26348)

## 📔 Objective

Signing into zoom.us was incorrectly showing a generated password when the user had autofilled their username in the previous form step.  This is a split login form that uses a hidden input for the username on the password page of the form.  I added a check so that we don't qualify the password field as an account creation field if the username field exists in the form.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

Besides testing on zoom.us also test on the following sites:
* bedbathandbeyond.com - This will verify that other username fields on a page will not cause issues.  This fix uses qualified username fields in the same form.
* webtests.dev - Make sure you don't have any login credentials saved and see that the simple form or multi step login form try to generate a password.  If you save the new credentials then those flows will allow you to use them to autofill the fields.

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-26348]: https://bitwarden.atlassian.net/browse/PM-26348?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ