### PR TITLE
[PM-24650] Resolve sign in button disappearing from ADP login form

### DIFF
--- a/apps/browser/src/autofill/services/insert-autofill-content.service.ts
+++ b/apps/browser/src/autofill/services/insert-autofill-content.service.ts
@@ -190,7 +190,7 @@ class InsertAutofillContentService implements InsertAutofillContentServiceInterf
     const elementCanBeReadonly =
       elementIsInputElement(element) || elementIsTextAreaElement(element);
     const elementCanBeFilled = elementCanBeReadonly || elementIsSelectElement(element);
-    const elementValue = (element as HTMLInputElement).value || element.innerText || "";
+    const elementValue = (element as HTMLInputElement)?.value || element?.innerText || "";
 
     const elementAlreadyHasTheValue = !!(elementValue?.length && elementValue === value);
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-24650](https://bitwarden.atlassian.net/browse/PM-24650)

## 📔 Objective

This PR addresses two issues that together fix autofill breakage on employee `https://login.adp.com` login portals.

The changes in this PR include:
- ensuring we're executing fill actions serially
- ensuring we don't re-enter values in fields that already have the value entered

## 📸 Screenshots and further details

The original issue looks like this:

https://github.com/user-attachments/assets/88ef662c-c7a6-4586-9ded-9fd83a63e09f

This occurs due to two behaviours. First, if the fields are filled too quickly, the web app (as designed) gets caught in an unintended state, where the username input change triggers the removal of the password field and revert of the submit button to the next step button. But because we fill the password input before it's removed, the app's inferences that determine which step it's on results in conflicting information that leaves the app in a bad state (that a human user would not be able to normally achieve).

One reason our fill script runs afoul of this scenario is because we execute the individual actions for filling a field (click, focus, fill) synchronously. This allows their execution to happen out of intended order and all at once, undermining the intention to simulate user entry. This is resolved by awaiting each action before executing the next (0390ce82441d2f5fd2ab89136560dcfbe5bfc70c).

While serial execution currently appears sufficient to resolve this case, our timings could potentially be slowed in the future, as we delay each fill action by 20ms (see `runFillScriptAction` in `InsertAutofillContentService`). We likely could go as high as 200ms before it will be noticeable, and should consider it for future changes, since it will bring us closer to simulating human entry speeds and avoiding breakages from app race cases like this (however, no adjustments to these timings have been made in this PR).

With the invalid app state concern resolved, we get behaviour closer to what users who are doing manual entry experience; the button remains, but reverts from "sign in" to "next". This happens because the page/app behaviour resets the login flow to the first step when the username field is changed in any way.  This is what the page behaviour looks like when the user (with no password manager installed) does the same re-entry of the username like the extension is doing:

https://github.com/user-attachments/assets/6caadd9c-7027-415e-bf74-805801239680

With the autofill script, we always enter field values regardless of any present values, and so trigger the app reset behaviour every time because we re-enter the username field value.

This is resolved by doing an (intentionally late) check on the field receiving the value. If the field has a value and that value matches what is about to be filled, the script will now skip filling that field (c8cf2889dd8c0d95ae701380c9827a8944514485). 

The new autofill experience after these changes looks like this:

https://github.com/user-attachments/assets/f199a718-fe1d-4943-82b8-3b3491d3967b

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-24650]: https://bitwarden.atlassian.net/browse/PM-24650?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ