### PR TITLE
PM-23144 Preserve export type across export source selections

### DIFF
--- a/libs/tools/export/vault-export/vault-export-core/src/services/vault-export.service.abstraction.ts
+++ b/libs/tools/export/vault-export/vault-export-core/src/services/vault-export.service.abstraction.ts
@@ -1,9 +1,29 @@
+import { Observable } from "rxjs";
+
 import { UserId, OrganizationId } from "@bitwarden/common/types/guid";
 
 import { ExportedVault } from "../types";
 
 export const EXPORT_FORMATS = ["csv", "json", "encrypted_json", "zip"] as const;
 export type ExportFormat = (typeof EXPORT_FORMATS)[number];
+
+/**
+ * Options that determine which export formats are available
+ */
+export type FormatOptions = {
+  /** Whether the export is for the user's personal vault */
+  isMyVault: boolean;
+};
+
+/**
+ * Metadata describing an available export format
+ */
+export type ExportFormatMetadata = {
+  /** Display name for the format (e.g., ".json", ".csv") */
+  name: string;
+  /** The export format identifier */
+  format: ExportFormat;
+};
 
 export abstract class VaultExportServiceAbstraction {
   abstract getExport: (
@@ -18,4 +38,11 @@ export abstract class VaultExportServiceAbstraction {
     password: string,
     onlyManagedCollections?: boolean,
   ) => Promise<ExportedVault>;
+
+  /**
+   * Get available export formats based on vault context
+   * @param options Options determining which formats are available
+   * @returns Observable stream of available export formats
+   */
+  abstract formats$(options: FormatOptions): Observable<ExportFormatMetadata[]>;
 }

--- a/libs/tools/export/vault-export/vault-export-ui/src/components/export.component.html
+++ b/libs/tools/export/vault-export/vault-export-ui/src/components/export.component.html
@@ -35,7 +35,7 @@
   <bit-form-field>
     <bit-label>{{ "fileFormat" | i18n }}</bit-label>
     <bit-select formControlName="format">
-      <bit-option *ngFor="let f of formatOptions" [value]="f.value" [label]="f.name" />
+      <bit-option *ngFor="let f of formatOptions$ | async" [value]="f.format" [label]="f.name" />
     </bit-select>
   </bit-form-field>
 

--- a/libs/tools/export/vault-export/vault-export-ui/src/components/export.component.ts
+++ b/libs/tools/export/vault-export/vault-export-ui/src/components/export.component.ts
@@ -67,7 +67,11 @@ import {
 } from "@bitwarden/components";
 import { GeneratorServicesModule } from "@bitwarden/generator-components";
 import { CredentialGeneratorService, GenerateRequest, Type } from "@bitwarden/generator-core";
-import { ExportedVault, VaultExportServiceAbstraction } from "@bitwarden/vault-export-core";
+import {
+  ExportedVault,
+  ExportFormatMetadata,
+  VaultExportServiceAbstraction,
+} from "@bitwarden/vault-export-core";
 
 import { EncryptedExportType } from "../enums/encrypted-export-type.enum";
 
@@ -217,11 +221,11 @@ export class ExportComponent implements OnInit, OnDestroy, AfterViewInit {
     fileEncryptionType: [EncryptedExportType.AccountEncrypted],
   });
 
-  formatOptions = [
-    { name: ".json", value: "json" },
-    { name: ".csv", value: "csv" },
-    { name: ".json (Encrypted)", value: "encrypted_json" },
-  ];
+  /**
+   * Observable stream of available export format options
+   * Dynamically updates based on vault selection (My Vault vs Organization)
+   */
+  formatOptions$: Observable<ExportFormatMetadata[]>;
 
   private destroy$ = new Subject<void>();
   private onlyManagedCollections = true;
@@ -324,17 +328,28 @@ export class ExportComponent implements OnInit, OnDestroy, AfterViewInit {
   }
 
   private observeFormSelections(): void {
-    this.exportForm.controls.vaultSelector.valueChanges
-      .pipe(takeUntil(this.destroy$))
-      .subscribe((value) => {
-        this.organizationId = value !== "myVault" ? value : undefined;
+    // Set up dynamic format options based on vault selection
+    this.formatOptions$ = this.exportForm.controls.vaultSelector.valueChanges.pipe(
+      startWith(this.exportForm.controls.vaultSelector.value),
+      map((vaultSelection) => {
+        const isMyVault = vaultSelection === "myVault";
+        // Update organizationId based on vault selection
+        this.organizationId = isMyVault ? undefined : vaultSelection;
+        return { isMyVault };
+      }),
+      switchMap((options) => this.exportService.formats$(options)),
+      tap((formats) => {
+        // Preserve the current format selection if it's still available in the new format list
+        const currentFormat = this.exportForm.get("format").value;
+        const isFormatAvailable = formats.some((f) => f.format === currentFormat);
 
-        this.formatOptions = this.formatOptions.filter((option) => option.value !== "zip");
-        this.exportForm.get("format").setValue("json");
-        if (value === "myVault") {
-          this.formatOptions.push({ name: ".zip (with attachments)", value: "zip" });
+        // Only reset to json if the current format is no longer available
+        if (!isFormatAvailable) {
+          this.exportForm.get("format").setValue("json");
         }
-      });
+      }),
+      shareReplay({ bufferSize: 1, refCount: true }),
+    );
   }
 
   /**


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-23144?atlOrigin=eyJpIjoiZGZkODJmYzAwNjhjNDgzY2FmZTZiYTBkYWVhMDk5MDYiLCJwIjoiaiJ9

resolves #15426
resolves #15383

## 📔 Objective

- expand upon code changes proposed in #15426 
- preserve export type across different selections in the vault selector dropdown 
- implementation adheres to https://github.com/bitwarden/clients/pull/15426#discussion_r2305231446 
- ensure exported files match export type descriptions (encrypted JSON really is encrypted JSON) ✅
 
## 📸 Screenshots

![export-persistence](https://github.com/user-attachments/assets/1460e4b2-0148-49d5-8b1a-3c1cf50fde90)


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
