### PR TITLE
[PM-26476] Fill Assist Proof-of-concept

### DIFF
--- a/apps/browser/src/autofill/browser/context-menu-clicked-handler.ts
+++ b/apps/browser/src/autofill/browser/context-menu-clicked-handler.ts
@@ -13,6 +13,7 @@ import {
   AUTOFILL_ID,
   AUTOFILL_IDENTITY_ID,
   COPY_IDENTIFIER_ID,
+  COPY_ELEMENT_PATH_ID,
   COPY_PASSWORD_ID,
   COPY_USERNAME_ID,
   COPY_VERIFICATION_CODE_ID,
@@ -73,6 +74,9 @@ export class ContextMenuClickedHandler {
         break;
       case COPY_IDENTIFIER_ID:
         this.copyToClipboard({ text: await this.getIdentifier(tab, info), tab: tab });
+        break;
+      case COPY_ELEMENT_PATH_ID:
+        this.copyToClipboard({ text: await this.getElementPath(tab, info), tab: tab });
         break;
       default:
         await this.cipherAction(info, tab);
@@ -235,6 +239,24 @@ export class ContextMenuClickedHandler {
         : menuItemId === CREATE_LOGIN_ID
           ? CipherType.Login
           : null;
+  }
+
+  private async getElementPath(tab: chrome.tabs.Tab, info: chrome.contextMenus.OnClickData) {
+    return new Promise<string>((resolve, reject) => {
+      BrowserApi.sendTabsMessage(
+        tab.id,
+        { command: "getClickedElementPath" },
+        { frameId: info.frameId },
+        (identifier: string) => {
+          if (chrome.runtime.lastError) {
+            reject(chrome.runtime.lastError);
+            return;
+          }
+
+          resolve(identifier);
+        },
+      );
+    });
   }
 
   private async getIdentifier(tab: chrome.tabs.Tab, info: chrome.contextMenus.OnClickData) {

--- a/apps/browser/src/autofill/browser/main-context-menu-handler.spec.ts
+++ b/apps/browser/src/autofill/browser/main-context-menu-handler.spec.ts
@@ -148,7 +148,7 @@ describe("context-menu", () => {
 
       const createdMenu = await sut.init();
       expect(createdMenu).toBeTruthy();
-      expect(createSpy).toHaveBeenCalledTimes(10);
+      expect(createSpy).toHaveBeenCalledTimes(11);
     });
 
     it("has menu enabled and has premium", async () => {
@@ -156,7 +156,7 @@ describe("context-menu", () => {
 
       const createdMenu = await sut.init();
       expect(createdMenu).toBeTruthy();
-      expect(createSpy).toHaveBeenCalledTimes(11);
+      expect(createSpy).toHaveBeenCalledTimes(12);
     });
 
     it("has menu enabled and has premium, but card type is restricted", async () => {
@@ -166,7 +166,7 @@ describe("context-menu", () => {
 
       const createdMenu = await sut.init();
       expect(createdMenu).toBeTruthy();
-      expect(createSpy).toHaveBeenCalledTimes(10);
+      expect(createSpy).toHaveBeenCalledTimes(11);
     });
     it("has menu enabled, does not have premium, and card type is restricted", async () => {
       billingAccountProfileStateService.hasPremiumFromAnySource$.mockReturnValue(of(false));
@@ -174,7 +174,7 @@ describe("context-menu", () => {
 
       const createdMenu = await sut.init();
       expect(createdMenu).toBeTruthy();
-      expect(createSpy).toHaveBeenCalledTimes(9);
+      expect(createSpy).toHaveBeenCalledTimes(10);
     });
   });
 
@@ -283,7 +283,7 @@ describe("context-menu", () => {
 
       await sut.removeBlockedUriMenuItems();
 
-      expect(MainContextMenuHandler["remove"]).toHaveBeenCalledTimes(5);
+      expect(MainContextMenuHandler["remove"]).toHaveBeenCalledTimes(6);
       expect(MainContextMenuHandler["remove"]).toHaveBeenCalledWith(AUTOFILL_ID);
       expect(MainContextMenuHandler["remove"]).toHaveBeenCalledWith(AUTOFILL_IDENTITY_ID);
       expect(MainContextMenuHandler["remove"]).toHaveBeenCalledWith(AUTOFILL_CARD_ID);

--- a/apps/browser/src/autofill/browser/main-context-menu-handler.ts
+++ b/apps/browser/src/autofill/browser/main-context-menu-handler.ts
@@ -9,6 +9,7 @@ import {
   AUTOFILL_ID,
   AUTOFILL_IDENTITY_ID,
   COPY_IDENTIFIER_ID,
+  COPY_ELEMENT_PATH_ID,
   COPY_PASSWORD_ID,
   COPY_USERNAME_ID,
   COPY_VERIFICATION_CODE_ID,
@@ -93,6 +94,12 @@ export class MainContextMenuHandler {
       id: COPY_IDENTIFIER_ID,
       parentId: ROOT_ID,
       title: this.i18nService.t("copyElementIdentifier"),
+      requiresUnblockedUri: true,
+    },
+    {
+      id: COPY_ELEMENT_PATH_ID,
+      parentId: ROOT_ID,
+      title: "Copy element path",
       requiresUnblockedUri: true,
     },
   ];

--- a/apps/browser/src/autofill/content/context-menu-handler.ts
+++ b/apps/browser/src/autofill/content/context-menu-handler.ts
@@ -1,12 +1,11 @@
-// FIXME: Update this file to be type safe and remove this and next line
-// @ts-strict-ignore
 const inputTags = ["input", "textarea", "select"];
 const labelTags = ["label", "span"];
 const attributes = ["id", "name", "label-aria", "placeholder"];
 const invalidElement = chrome.i18n.getMessage("copyCustomFieldNameInvalidElement");
 const noUniqueIdentifier = chrome.i18n.getMessage("copyCustomFieldNameNotUnique");
 
-let clickedEl: HTMLElement = null;
+let clickedEl: HTMLElement | null = null;
+let clickedElComposedPath: EventTarget[] | null = null;
 
 // Find the best attribute to be used as the Name for an element in a custom field.
 function getClickedElementIdentifier() {
@@ -26,7 +25,7 @@ function getClickedElementIdentifier() {
       inputId = clickedEl.closest("label")?.getAttribute("for");
     }
 
-    inputEl = document.getElementById(inputId);
+    inputEl = inputId ? document.getElementById(inputId) : null;
   } else {
     inputEl = clickedEl;
   }
@@ -38,11 +37,56 @@ function getClickedElementIdentifier() {
   for (const attr of attributes) {
     const attributeValue = inputEl.getAttribute(attr);
     const selector = "[" + attr + '="' + attributeValue + '"]';
-    if (!isNullOrEmpty(attributeValue) && document.querySelectorAll(selector)?.length === 1) {
+    if (
+      attributeValue &&
+      !isNullOrEmpty(attributeValue) &&
+      document.querySelectorAll(selector)?.length === 1
+    ) {
       return attributeValue;
     }
   }
   return noUniqueIdentifier;
+}
+
+function getClickedElementPath() {
+  if (!clickedElComposedPath?.length) {
+    return invalidElement;
+  }
+
+  const querySelector = clickedElComposedPath.reduce((builtQuery, target, index) => {
+    // Skip the Window and Document objects at the end of the path
+    if (!(target instanceof Element)) {
+      return builtQuery;
+    }
+
+    const targetName = target.nodeName.toLowerCase();
+    let selector = targetName;
+
+    // Add id if present
+    if (target instanceof HTMLElement && target.id) {
+      selector += `#${target.id}`;
+    }
+
+    // Check if next item is a shadow root
+    const nextTarget = clickedElComposedPath?.[index + 1];
+    const isShadowRoot = nextTarget instanceof ShadowRoot;
+
+    // Add separator based on whether we're crossing a shadow boundary
+    if (builtQuery) {
+      if (isShadowRoot) {
+        builtQuery = selector + " >>> " + builtQuery;
+      } else {
+        builtQuery = selector + " > " + builtQuery;
+      }
+    } else {
+      builtQuery = selector;
+    }
+
+    return builtQuery;
+  }, "");
+
+  // @TODO If `clickedElComposedPath` ends with a closed shadowRoot, send a message to background to recursively pierce the closed root and find the first visible input or else the first nested closed shadowRoot. Continue until an input is found or neither an input nor closed shadow root is found at the deepest-traversed node tree level. Append the additional query rules for traversed closed shadow roots to the query string returned here.
+  return querySelector;
 }
 
 function isNullOrEmpty(s: string) {
@@ -53,6 +97,7 @@ function isNullOrEmpty(s: string) {
 // Remember it for use later.
 document.addEventListener("contextmenu", (event) => {
   clickedEl = event.target as HTMLElement;
+  clickedElComposedPath = event.composedPath();
 });
 
 // Runs when the 'Copy Custom Field Name' context menu item is actually clicked.
@@ -62,12 +107,24 @@ chrome.runtime.onMessage.addListener((event, _sender, sendResponse) => {
     if (sendResponse) {
       sendResponse(identifier);
     }
-    // FIXME: Verify that this floating promise is intentional. If it is, add an explanatory comment and ensure there is proper error handling.
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    chrome.runtime.sendMessage({
+
+    void chrome.runtime.sendMessage({
       command: "getClickedElementResponse",
       sender: "contextMenuHandler",
-      identifier: identifier,
+      identifier,
+    });
+  }
+
+  if (event.command === "getClickedElementPath") {
+    const path = getClickedElementPath();
+    if (sendResponse) {
+      sendResponse(path);
+    }
+
+    void chrome.runtime.sendMessage({
+      command: "getClickedElementPathResponse",
+      sender: "contextMenuHandler",
+      path,
     });
   }
 });

--- a/apps/browser/src/autofill/enums/autofill-field.enums.ts
+++ b/apps/browser/src/autofill/enums/autofill-field.enums.ts
@@ -1,3 +1,4 @@
+/** @deprecated use `AutofillFieldQualifier` in `libs/common/src/autofill/constants` instead */
 export const AutofillFieldQualifier = {
   password: "password",
   newPassword: "newPassword",
@@ -26,5 +27,6 @@ export const AutofillFieldQualifier = {
   identityUsername: "identityUsername",
 } as const;
 
+/** @deprecated use `AutofillFieldQualifierType` in `libs/common/src/autofill/types` instead */
 export type AutofillFieldQualifierType =
   (typeof AutofillFieldQualifier)[keyof typeof AutofillFieldQualifier];

--- a/apps/browser/src/autofill/models/autofill-script.ts
+++ b/apps/browser/src/autofill/models/autofill-script.ts
@@ -1,9 +1,20 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
+import { AutofillFieldQualifierType } from "@bitwarden/common/autofill/types";
 // String values affect code flow in autofill.ts and must not be changed
-export type FillScriptActions = "click_on_opid" | "focus_by_opid" | "fill_by_opid";
+export type FillScriptActions =
+  | "click_on_opid"
+  | "focus_by_opid"
+  | "fill_by_opid"
+  | "fill_by_targeted_field_type"
+  | "click_on_targeted_field_type"
+  | "focus_by_targeted_field_type";
 
-export type FillScript = [action: FillScriptActions, opid: string, value?: string];
+export type FillScript = [
+  action: FillScriptActions,
+  actionTarget: AutofillFieldQualifierType | string,
+  value?: string,
+];
 
 export type AutofillScriptProperties = {
   delay_between_operations?: number;
@@ -13,6 +24,15 @@ export type AutofillInsertActions = {
   fill_by_opid: ({ opid, value }: { opid: string; value: string }) => void;
   click_on_opid: ({ opid }: { opid: string }) => void;
   focus_by_opid: ({ opid }: { opid: string }) => void;
+  fill_by_targeted_field_type: ({
+    fieldType,
+    value,
+  }: {
+    fieldType: AutofillFieldQualifierType;
+    value: string;
+  }) => void;
+  click_on_targeted_field_type: ({ fieldType }: { fieldType: AutofillFieldQualifierType }) => void;
+  focus_by_targeted_field_type: ({ fieldType }: { fieldType: AutofillFieldQualifierType }) => void;
 };
 
 export default class AutofillScript {

--- a/apps/browser/src/autofill/overlay/notifications/content/overlay-notifications-content.service.spec.ts
+++ b/apps/browser/src/autofill/overlay/notifications/content/overlay-notifications-content.service.spec.ts
@@ -19,7 +19,7 @@ describe("OverlayNotificationsContentService", () => {
 
   beforeEach(() => {
     jest.useFakeTimers();
-    jest.spyOn(utils, "sendExtensionMessage").mockImplementation(jest.fn());
+    jest.spyOn(utils, "sendExtensionMessage").mockImplementation(async () => null);
     domQueryService = mock<DomQueryService>();
     domElementVisibilityService = new DomElementVisibilityService();
     overlayNotificationsContentService = new OverlayNotificationsContentService();

--- a/apps/browser/src/autofill/popup/settings/autofill-targeting-rules.component.html
+++ b/apps/browser/src/autofill/popup/settings/autofill-targeting-rules.component.html
@@ -1,0 +1,205 @@
+<popup-page>
+  <popup-header slot="header" pageTitle="Autofill Targeting Rules" showBackButton>
+    <ng-container slot="end">
+      <app-pop-out></app-pop-out>
+    </ng-container>
+  </popup-header>
+
+  <div class="tw-bg-background-alt">
+    <bit-section>
+      <p class="tw-m-0">
+        Override which inputs should be autofilled on a page using query selectors.
+      </p>
+      <a
+        bitLink
+        linkType="primary"
+        rel="noreferrer"
+        target="_blank"
+        href="https://bitwarden.com/help/blocking-uris/"
+        >Learn more about Autofill Targeting Rules</a
+      >
+    </bit-section>
+    <bit-section *ngIf="!isLoading">
+      <bit-section-header>
+        <h2 bitTypography="h6">{{ "domainsTitle" | i18n }}</h2>
+        <span bitTypography="body2" slot="end">{{
+          viewTargetingRulesDomains.length + domainForms.value.length
+        }}</span>
+      </bit-section-header>
+      <bit-item
+        *ngFor="let domain of viewTargetingRulesDomains; let i = index; trackBy: trackByFunction"
+      >
+        <bit-item-content *ngIf="i < fieldsEditThreshold">
+          <div id="uriTargetingRules{{ i }}">{{ domain }}</div>
+          <div
+            *ngIf="targetingRulesDomainsViewState[domain].username"
+            title="{{ targetingRulesDomainsViewState[domain].username }}"
+            style="padding-left: 12px"
+          >
+            <div style="font-size: 0.8rem; font-weight: bold">Username:</div>
+            <div
+              style="
+                font-size: 0.7rem;
+                font-weight: lighter;
+                font-family: monospace;
+                text-overflow: ellipsis;
+                overflow-y: clip;
+              "
+            >
+              {{ targetingRulesDomainsViewState[domain].username }}
+            </div>
+          </div>
+          <div
+            *ngIf="targetingRulesDomainsViewState[domain].password"
+            title="{{ targetingRulesDomainsViewState[domain].password }}"
+            style="padding-left: 12px"
+          >
+            <div style="font-size: 0.8rem; font-weight: bold">Password:</div>
+            <div
+              style="
+                font-size: 0.7rem;
+                font-weight: lighter;
+                font-family: monospace;
+                text-overflow: ellipsis;
+                overflow-y: clip;
+              "
+            >
+              {{ targetingRulesDomainsViewState[domain].password }}
+            </div>
+          </div>
+          <div
+            *ngIf="targetingRulesDomainsViewState[domain].totp"
+            title="{{ targetingRulesDomainsViewState[domain].totp }}"
+            style="padding-left: 12px"
+          >
+            <div style="font-size: 0.8rem; font-weight: bold">TOTP:</div>
+            <div
+              style="
+                font-size: 0.7rem;
+                font-weight: lighter;
+                font-family: monospace;
+                text-overflow: ellipsis;
+                overflow-y: clip;
+              "
+            >
+              {{ targetingRulesDomainsViewState[domain].totp }}
+            </div>
+          </div>
+        </bit-item-content>
+        <button
+          *ngIf="i < fieldsEditThreshold && domain"
+          label="{{ 'remove' | i18n }}"
+          bitIconButton="bwi-minus-circle"
+          buttonType="danger"
+          size="small"
+          slot="end"
+          type="button"
+          (click)="removeDomain(i)"
+        ></button>
+      </bit-item>
+      <form [formGroup]="domainListForm">
+        <bit-card
+          formArrayName="domains"
+          *ngFor="let domain of domainForms.controls; let i = index"
+        >
+          <div [formGroupName]="i">
+            <bit-form-field>
+              <bit-label>
+                {{ "websiteItemLabel" | i18n: i + fieldsEditThreshold + 1 }}
+              </bit-label>
+              <input
+                #uriInput
+                appInputVerbatim
+                bitInput
+                id="targeting-rules-uri-{{ i + fieldsEditThreshold }}"
+                inputmode="url"
+                name="targeting-rules-uri-{{ i + fieldsEditThreshold }}"
+                type="text"
+                (change)="fieldChange()"
+                formControlName="domain"
+              />
+            </bit-form-field>
+            <div style="display: flex; align-content: center; flex-wrap: wrap; row-gap: 3px">
+              <!-- Username field -->
+              <div
+                class="field-row"
+                style="gap: 15px; display: flex; justify-content: flex-end; width: 100%"
+              >
+                <label style="flex: 1 1 25%">Username: </label>
+                <input
+                  style="
+                    flex: 1 1 75%;
+                    font-family: monospace;
+                    font-size: 0.75rem;
+                    font-weight: light;
+                  "
+                  appInputVerbatim
+                  type="text"
+                  formControlName="username"
+                  (change)="fieldChange()"
+                />
+              </div>
+
+              <!-- Password field -->
+              <div
+                class="field-row"
+                style="gap: 15px; display: flex; justify-content: flex-end; width: 100%"
+              >
+                <label style="flex: 1 1 25%">Password: </label>
+                <input
+                  style="
+                    flex: 1 1 75%;
+                    font-size: 0.75rem;
+                    font-weight: light;
+                    font-family: monospace;
+                  "
+                  appInputVerbatim
+                  type="text"
+                  formControlName="password"
+                  (change)="fieldChange()"
+                />
+              </div>
+
+              <!-- TOTP field -->
+              <div
+                class="field-row"
+                style="gap: 15px; display: flex; justify-content: flex-end; width: 100%"
+              >
+                <label style="flex: 1 1 25%">TOTP: </label>
+                <input
+                  style="
+                    flex: 1 1 75%;
+                    font-size: 0.75rem;
+                    font-weight: light;
+                    font-family: monospace;
+                  "
+                  appInputVerbatim
+                  type="text"
+                  formControlName="totp"
+                  (change)="fieldChange()"
+                />
+              </div>
+            </div>
+          </div>
+        </bit-card>
+        <button bitLink class="tw-pt-2" type="button" linkType="primary" (click)="addNewDomain()">
+          <i class="bwi bwi-plus-circle bwi-fw" aria-hidden="true"></i> {{ "addDomain" | i18n }}
+        </button>
+      </form>
+    </bit-section>
+  </div>
+  <popup-footer slot="footer">
+    <button
+      bitButton
+      buttonType="primary"
+      type="submit"
+      [disabled]="dataIsPristine"
+      (click)="saveChanges()"
+    >
+      {{ "save" | i18n }}
+    </button>
+    <button (click)="goBack()" bitButton type="button" buttonType="secondary">
+      {{ "cancel" | i18n }}
+    </button>
+  </popup-footer>
+</popup-page>

--- a/apps/browser/src/autofill/popup/settings/autofill-targeting-rules.component.html
+++ b/apps/browser/src/autofill/popup/settings/autofill-targeting-rules.component.html
@@ -21,7 +21,7 @@
     </bit-section>
     <bit-section *ngIf="!isLoading">
       <bit-section-header>
-        <h2 bitTypography="h6">{{ "domainsTitle" | i18n }}</h2>
+        <h2 bitTypography="h6">URLs</h2>
         <span bitTypography="body2" slot="end">{{
           viewTargetingRulesDomains.length + domainForms.value.length
         }}</span>
@@ -29,21 +29,52 @@
       <bit-item
         *ngFor="let domain of viewTargetingRulesDomains; let i = index; trackBy: trackByFunction"
       >
-        <bit-item-content *ngIf="i < fieldsEditThreshold">
-          <div id="uriTargetingRules{{ i }}">{{ domain }}</div>
+        <div
+          *ngIf="i < fieldsEditThreshold"
+          style="margin: 0.5rem 1rem; display: block; width: 90%"
+        >
+          <div
+            id="uriTargetingRules{{ i }}"
+            style="
+              -webkit-box-orient: vertical;
+              -webkit-line-clamp: 2;
+              line-clamp: 2;
+              display: -webkit-box;
+              max-height: 2rem;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: normal;
+              word-break: break-all;
+              font-family: monospace;
+              font-size: 0.7rem;
+            "
+            title="{{ domain }}"
+          >
+            {{ domain }}
+          </div>
           <div
             *ngIf="targetingRulesDomainsViewState[domain].username"
             title="{{ targetingRulesDomainsViewState[domain].username }}"
-            style="padding-left: 12px"
+            style="margin-left: 12px"
           >
             <div style="font-size: 0.8rem; font-weight: bold">Username:</div>
             <div
               style="
+                -webkit-box-orient: vertical;
+                -webkit-line-clamp: 3;
+                line-clamp: 3;
+                display: -webkit-box;
+                border-radius: 0.35rem;
+                background-color: rgb(var(--color-background-alt));
+                padding: 4px;
+                max-height: calc(2rem + 8px);
+                overflow: hidden;
+                text-overflow: ellipsis;
+                line-height: 0.75rem;
+                word-break: break-all;
+                font-family: monospace;
                 font-size: 0.7rem;
                 font-weight: lighter;
-                font-family: monospace;
-                text-overflow: ellipsis;
-                overflow-y: clip;
               "
             >
               {{ targetingRulesDomainsViewState[domain].username }}
@@ -52,16 +83,26 @@
           <div
             *ngIf="targetingRulesDomainsViewState[domain].password"
             title="{{ targetingRulesDomainsViewState[domain].password }}"
-            style="padding-left: 12px"
+            style="margin-left: 12px"
           >
             <div style="font-size: 0.8rem; font-weight: bold">Password:</div>
             <div
               style="
+                -webkit-box-orient: vertical;
+                -webkit-line-clamp: 3;
+                line-clamp: 3;
+                display: -webkit-box;
+                border-radius: 0.35rem;
+                background-color: rgb(var(--color-background-alt));
+                padding: 4px;
+                max-height: calc(2rem + 8px);
+                overflow: hidden;
+                text-overflow: ellipsis;
+                line-height: 0.75rem;
+                word-break: break-all;
+                font-family: monospace;
                 font-size: 0.7rem;
                 font-weight: lighter;
-                font-family: monospace;
-                text-overflow: ellipsis;
-                overflow-y: clip;
               "
             >
               {{ targetingRulesDomainsViewState[domain].password }}
@@ -70,22 +111,32 @@
           <div
             *ngIf="targetingRulesDomainsViewState[domain].totp"
             title="{{ targetingRulesDomainsViewState[domain].totp }}"
-            style="padding-left: 12px"
+            style="margin-left: 12px"
           >
             <div style="font-size: 0.8rem; font-weight: bold">TOTP:</div>
             <div
               style="
+                -webkit-box-orient: vertical;
+                -webkit-line-clamp: 3;
+                line-clamp: 3;
+                display: -webkit-box;
+                border-radius: 0.35rem;
+                background-color: rgb(var(--color-background-alt));
+                padding: 4px;
+                max-height: calc(2rem + 8px);
+                overflow: hidden;
+                text-overflow: ellipsis;
+                line-height: 0.75rem;
+                word-break: break-all;
+                font-family: monospace;
                 font-size: 0.7rem;
                 font-weight: lighter;
-                font-family: monospace;
-                text-overflow: ellipsis;
-                overflow-y: clip;
               "
             >
               {{ targetingRulesDomainsViewState[domain].totp }}
             </div>
           </div>
-        </bit-item-content>
+        </div>
         <button
           *ngIf="i < fieldsEditThreshold && domain"
           label="{{ 'remove' | i18n }}"
@@ -119,16 +170,31 @@
                 formControlName="domain"
               />
             </bit-form-field>
-            <div style="display: flex; align-content: center; flex-wrap: wrap; row-gap: 3px">
+            <div style="color: rgb(var(--color-text-muted)); font-size: 0.875rem">Fields</div>
+            <div
+              style="
+                row-gap: 4px;
+                display: flex;
+                flex-wrap: wrap;
+                align-content: center;
+                border: 1px solid rgb(var(--color-text-muted));
+                border-radius: 0.5rem;
+                background-color: rgb(var(--color-background-alt));
+                padding: 7px;
+                text-align: end;
+                font-size: 0.9rem;
+              "
+            >
               <!-- Username field -->
-              <div
-                class="field-row"
-                style="gap: 15px; display: flex; justify-content: flex-end; width: 100%"
-              >
+              <div style="gap: 5px; display: flex; justify-content: flex-end; width: 100%">
                 <label style="flex: 1 1 25%">Username: </label>
                 <input
                   style="
                     flex: 1 1 75%;
+                    border-width: 1px;
+                    border-style: solid;
+                    border-radius: 0.25rem;
+                    padding: 0 4px;
                     font-family: monospace;
                     font-size: 0.75rem;
                     font-weight: light;
@@ -141,17 +207,18 @@
               </div>
 
               <!-- Password field -->
-              <div
-                class="field-row"
-                style="gap: 15px; display: flex; justify-content: flex-end; width: 100%"
-              >
+              <div style="gap: 5px; display: flex; justify-content: flex-end; width: 100%">
                 <label style="flex: 1 1 25%">Password: </label>
                 <input
                   style="
                     flex: 1 1 75%;
+                    border-width: 1px;
+                    border-style: solid;
+                    border-radius: 0.25rem;
+                    padding: 0 4px;
+                    font-family: monospace;
                     font-size: 0.75rem;
                     font-weight: light;
-                    font-family: monospace;
                   "
                   appInputVerbatim
                   type="text"
@@ -161,17 +228,18 @@
               </div>
 
               <!-- TOTP field -->
-              <div
-                class="field-row"
-                style="gap: 15px; display: flex; justify-content: flex-end; width: 100%"
-              >
+              <div style="gap: 5px; display: flex; justify-content: flex-end; width: 100%">
                 <label style="flex: 1 1 25%">TOTP: </label>
                 <input
                   style="
                     flex: 1 1 75%;
+                    border-width: 1px;
+                    border-style: solid;
+                    border-radius: 0.25rem;
+                    padding: 0 4px;
+                    font-family: monospace;
                     font-size: 0.75rem;
                     font-weight: light;
-                    font-family: monospace;
                   "
                   appInputVerbatim
                   type="text"

--- a/apps/browser/src/autofill/popup/settings/autofill-targeting-rules.component.ts
+++ b/apps/browser/src/autofill/popup/settings/autofill-targeting-rules.component.ts
@@ -21,7 +21,6 @@ import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { DomainSettingsService } from "@bitwarden/common/autofill/services/domain-settings.service";
 import { AutofillTargetingRulesByDomain } from "@bitwarden/common/autofill/types";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
-import { Utils } from "@bitwarden/common/platform/misc/utils";
 import {
   ButtonModule,
   CardComponent,
@@ -185,46 +184,44 @@ export class AutofillTargetingRulesComponent implements AfterViewInit, OnDestroy
       const formGroup = control as FormGroup;
       const domain = formGroup.get("domain")?.value;
 
-      if (domain && domain !== "") {
-        const validatedHost = Utils.getHostname(domain);
+      const normalizedURI = this.domainSettingsService.normalizeAutofillTargetingURI(domain);
 
-        if (!validatedHost) {
-          this.toastService.showToast({
-            message: this.i18nService.t("blockedDomainsInvalidDomain", domain),
-            title: "",
-            variant: "error",
-          });
-          return;
-        }
+      if (!normalizedURI) {
+        this.toastService.showToast({
+          message: this.i18nService.t("blockedDomainsInvalidDomain", domain),
+          title: "",
+          variant: "error",
+        });
+        return;
+      }
 
-        const enteredUsername = formGroup.get("username")?.value;
-        const enteredPassword = formGroup.get("password")?.value;
-        const enteredTotp = formGroup.get("totp")?.value;
+      const enteredUsername = formGroup.get("username")?.value;
+      const enteredPassword = formGroup.get("password")?.value;
+      const enteredTotp = formGroup.get("totp")?.value;
 
-        if (!enteredUsername && !enteredPassword && !enteredTotp) {
-          this.toastService.showToast({
-            message: "No targeting rules were specified for the URL",
-            title: "",
-            variant: "error",
-          });
+      if (!enteredUsername && !enteredPassword && !enteredTotp) {
+        this.toastService.showToast({
+          message: "No targeting rules were specified for the URL",
+          title: "",
+          variant: "error",
+        });
 
-          return;
-        }
+        return;
+      }
 
-        newUriTargetingRulesSaveState[validatedHost] = {};
+      newUriTargetingRulesSaveState[normalizedURI] = {};
 
-        // Only add the property to the object if it has a value
-        if (enteredUsername) {
-          newUriTargetingRulesSaveState[validatedHost].username = enteredUsername;
-        }
+      // Only add the property to the object if it has a value
+      if (enteredUsername) {
+        newUriTargetingRulesSaveState[normalizedURI].username = enteredUsername;
+      }
 
-        if (enteredPassword) {
-          newUriTargetingRulesSaveState[validatedHost].password = enteredPassword;
-        }
+      if (enteredPassword) {
+        newUriTargetingRulesSaveState[normalizedURI].password = enteredPassword;
+      }
 
-        if (enteredTotp) {
-          newUriTargetingRulesSaveState[validatedHost].totp = enteredTotp;
-        }
+      if (enteredTotp) {
+        newUriTargetingRulesSaveState[normalizedURI].totp = enteredTotp;
       }
     });
 

--- a/apps/browser/src/autofill/popup/settings/autofill-targeting-rules.component.ts
+++ b/apps/browser/src/autofill/popup/settings/autofill-targeting-rules.component.ts
@@ -1,0 +1,286 @@
+import { CommonModule } from "@angular/common";
+import {
+  QueryList,
+  Component,
+  ElementRef,
+  OnDestroy,
+  AfterViewInit,
+  ViewChildren,
+} from "@angular/core";
+import {
+  FormsModule,
+  ReactiveFormsModule,
+  FormBuilder,
+  FormGroup,
+  FormArray,
+} from "@angular/forms";
+import { RouterModule } from "@angular/router";
+import { Subject, takeUntil } from "rxjs";
+
+import { JslibModule } from "@bitwarden/angular/jslib.module";
+import { DomainSettingsService } from "@bitwarden/common/autofill/services/domain-settings.service";
+import { AutofillTargetingRulesByDomain } from "@bitwarden/common/autofill/types";
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { Utils } from "@bitwarden/common/platform/misc/utils";
+import {
+  ButtonModule,
+  CardComponent,
+  FormFieldModule,
+  IconButtonModule,
+  ItemModule,
+  LinkModule,
+  SectionComponent,
+  SectionHeaderComponent,
+  ToastService,
+  TypographyModule,
+} from "@bitwarden/components";
+
+import { PopOutComponent } from "../../../platform/popup/components/pop-out.component";
+import { PopupFooterComponent } from "../../../platform/popup/layout/popup-footer.component";
+import { PopupHeaderComponent } from "../../../platform/popup/layout/popup-header.component";
+import { PopupPageComponent } from "../../../platform/popup/layout/popup-page.component";
+import { PopupRouterCacheService } from "../../../platform/popup/view-cache/popup-router-cache.service";
+
+@Component({
+  selector: "autofill-targeting-rules",
+  templateUrl: "autofill-targeting-rules.component.html",
+  imports: [
+    ButtonModule,
+    CardComponent,
+    CommonModule,
+    FormFieldModule,
+    FormsModule,
+    ReactiveFormsModule,
+    IconButtonModule,
+    ItemModule,
+    JslibModule,
+    LinkModule,
+    PopOutComponent,
+    PopupFooterComponent,
+    PopupHeaderComponent,
+    PopupPageComponent,
+    RouterModule,
+    SectionComponent,
+    SectionHeaderComponent,
+    TypographyModule,
+  ],
+})
+export class AutofillTargetingRulesComponent implements AfterViewInit, OnDestroy {
+  @ViewChildren("uriInput") uriInputElements: QueryList<ElementRef<HTMLInputElement>> =
+    new QueryList();
+
+  dataIsPristine = true;
+  isLoading = false;
+  /** Source-of-truth state from the service used to populate the view state */
+  storedTargetingRulesState: AutofillTargetingRulesByDomain = {};
+  /** Key names for the view state properties */
+  viewTargetingRulesDomains: string[] = [];
+  /** Tentative, unsaved state used to populate the view */
+  targetingRulesDomainsViewState: AutofillTargetingRulesByDomain = {};
+
+  protected domainListForm = new FormGroup({
+    domains: this.formBuilder.array([]),
+  });
+
+  // How many fields should be non-editable before editable fields
+  fieldsEditThreshold: number = 0;
+
+  private destroy$ = new Subject<void>();
+
+  constructor(
+    private domainSettingsService: DomainSettingsService,
+    private i18nService: I18nService,
+    private toastService: ToastService,
+    private formBuilder: FormBuilder,
+    private popupRouterCacheService: PopupRouterCacheService,
+  ) {}
+
+  get domainForms() {
+    return this.domainListForm.get("domains") as FormArray;
+  }
+
+  async ngAfterViewInit() {
+    this.domainSettingsService.autofillTargetingRules$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((targetingRulesSet: AutofillTargetingRulesByDomain) =>
+        this.handleStateUpdate(targetingRulesSet),
+      );
+
+    this.uriInputElements.changes.pipe(takeUntil(this.destroy$)).subscribe(({ last }) => {
+      this.focusNewUriInput(last);
+    });
+  }
+
+  ngOnDestroy() {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  /** Handles changes to the service state */
+  handleStateUpdate(targetingRulesSet: AutofillTargetingRulesByDomain) {
+    if (targetingRulesSet) {
+      this.storedTargetingRulesState = { ...targetingRulesSet };
+      this.viewTargetingRulesDomains = Object.keys(targetingRulesSet);
+      this.targetingRulesDomainsViewState = { ...targetingRulesSet };
+    }
+
+    // Do not allow the first x (pre-existing) fields to be edited
+    this.fieldsEditThreshold = this.viewTargetingRulesDomains.length;
+
+    this.dataIsPristine = true;
+    this.isLoading = false;
+  }
+
+  focusNewUriInput(elementRef: ElementRef) {
+    if (elementRef?.nativeElement) {
+      elementRef.nativeElement.focus();
+    }
+  }
+
+  async addNewDomain() {
+    this.domainForms.push(
+      this.formBuilder.group({
+        domain: null,
+        username: null,
+        password: null,
+        totp: null,
+      }),
+    );
+
+    await this.fieldChange();
+  }
+
+  async removeDomain(i: number) {
+    const removedDomainName = this.viewTargetingRulesDomains[i];
+    this.viewTargetingRulesDomains.splice(i, 1);
+    delete this.targetingRulesDomainsViewState[removedDomainName];
+
+    // If a pre-existing field was dropped, lower the edit threshold
+    if (i < this.fieldsEditThreshold) {
+      this.fieldsEditThreshold--;
+    }
+
+    await this.fieldChange();
+  }
+
+  async fieldChange() {
+    if (this.dataIsPristine) {
+      this.dataIsPristine = false;
+    }
+  }
+
+  async saveChanges() {
+    if (this.dataIsPristine) {
+      return;
+    }
+
+    this.isLoading = true;
+
+    const newUriTargetingRulesSaveState: AutofillTargetingRulesByDomain = {
+      ...this.targetingRulesDomainsViewState,
+    };
+
+    // Then process form values
+    this.domainForms.controls.forEach((control) => {
+      const formGroup = control as FormGroup;
+      const domain = formGroup.get("domain")?.value;
+
+      if (domain && domain !== "") {
+        const validatedHost = Utils.getHostname(domain);
+
+        if (!validatedHost) {
+          this.toastService.showToast({
+            message: this.i18nService.t("blockedDomainsInvalidDomain", domain),
+            title: "",
+            variant: "error",
+          });
+          return;
+        }
+
+        const enteredUsername = formGroup.get("username")?.value;
+        const enteredPassword = formGroup.get("password")?.value;
+        const enteredTotp = formGroup.get("totp")?.value;
+
+        if (!enteredUsername && !enteredPassword && !enteredTotp) {
+          this.toastService.showToast({
+            message: "No targeting rules were specified for the URL",
+            title: "",
+            variant: "error",
+          });
+
+          return;
+        }
+
+        newUriTargetingRulesSaveState[validatedHost] = {};
+
+        // Only add the property to the object if it has a value
+        if (enteredUsername) {
+          newUriTargetingRulesSaveState[validatedHost].username = enteredUsername;
+        }
+
+        if (enteredPassword) {
+          newUriTargetingRulesSaveState[validatedHost].password = enteredPassword;
+        }
+
+        if (enteredTotp) {
+          newUriTargetingRulesSaveState[validatedHost].totp = enteredTotp;
+        }
+      }
+    });
+
+    try {
+      const existingStateKeys = Object.keys(this.storedTargetingRulesState);
+      const newStateKeys = Object.keys(newUriTargetingRulesSaveState);
+
+      // Check if any domains were added or removed
+      const domainsChanged =
+        new Set([...existingStateKeys, ...newStateKeys]).size !== existingStateKeys.length;
+
+      // Check if any domain's properties were modified
+      const propertiesChanged = existingStateKeys.some((domain) => {
+        const oldRules = this.storedTargetingRulesState[domain];
+        const newRules = newUriTargetingRulesSaveState[domain];
+
+        // Check if any properties were added, removed, or modified
+        return (
+          !oldRules ||
+          !newRules ||
+          oldRules.username !== newRules.username ||
+          oldRules.password !== newRules.password ||
+          oldRules.totp !== newRules.totp
+        );
+      });
+
+      const stateIsChanged = domainsChanged || propertiesChanged;
+
+      if (stateIsChanged) {
+        await this.domainSettingsService.setAutofillTargetingRules(newUriTargetingRulesSaveState);
+      } else {
+        this.handleStateUpdate(this.storedTargetingRulesState);
+      }
+
+      this.toastService.showToast({
+        message: this.i18nService.t("blockedDomainsSavedSuccess"),
+        title: "",
+        variant: "success",
+      });
+
+      this.domainForms.clear();
+    } catch {
+      this.toastService.showToast({
+        message: this.i18nService.t("unexpectedError"),
+        title: "",
+        variant: "error",
+      });
+      this.isLoading = false;
+    }
+  }
+
+  async goBack() {
+    await this.popupRouterCacheService.back();
+  }
+
+  trackByFunction(index: number, _: string) {
+    return index;
+  }
+}

--- a/apps/browser/src/autofill/popup/settings/autofill.component.html
+++ b/apps/browser/src/autofill/popup/settings/autofill.component.html
@@ -285,5 +285,11 @@
         <i slot="end" class="bwi bwi-angle-right bwi-lg" aria-hidden="true"></i>
       </bit-item>
     </bit-section>
+    <bit-section disableMargin>
+      <bit-item>
+        <a bit-item-content routerLink="/autofill-targeting-rules">Autofill Targeting Rules</a>
+        <i slot="end" class="bwi bwi-angle-right bwi-lg" aria-hidden="true"></i>
+      </bit-item>
+    </bit-section>
   </div>
 </popup-page>

--- a/apps/browser/src/autofill/services/abstractions/autofill-overlay-content.service.ts
+++ b/apps/browser/src/autofill/services/abstractions/autofill-overlay-content.service.ts
@@ -36,7 +36,11 @@ export interface AutofillOverlayContentService {
   setupOverlayListeners(
     autofillFieldElement: ElementWithOpId<FormFieldElement>,
     autofillFieldData: AutofillField,
-    pageDetails: AutofillPageDetails,
+    pageDetails?: AutofillPageDetails,
+  ): Promise<void>;
+  setupOverlayListenersOnQualifiedField(
+    autofillFieldElement: ElementWithOpId<FormFieldElement>,
+    autofillFieldData: AutofillField,
   ): Promise<void>;
   blurMostRecentlyFocusedField(isClosingInlineMenu?: boolean): void;
   getOwnedInlineMenuTagNames(): string[];

--- a/apps/browser/src/autofill/services/abstractions/autofill.service.ts
+++ b/apps/browser/src/autofill/services/abstractions/autofill.service.ts
@@ -2,6 +2,7 @@
 // @ts-strict-ignore
 import { Observable } from "rxjs";
 
+import { AutofillTargetingRules } from "@bitwarden/common/autofill/types";
 import { UriMatchStrategySetting } from "@bitwarden/common/models/domain/domain-service";
 import { CommandDefinition } from "@bitwarden/common/platform/messaging";
 import { CipherType } from "@bitwarden/common/vault/enums";
@@ -49,6 +50,7 @@ export interface GenerateFillScriptOptions {
   cipher: CipherView;
   tabUrl: string;
   defaultUriMatch: UriMatchStrategySetting;
+  pageTargetingRules?: AutofillTargetingRules;
 }
 
 export type CollectPageDetailsResponseMessage = {
@@ -73,6 +75,7 @@ export abstract class AutofillService {
     triggeringOnPageLoad?: boolean,
   ) => Promise<void>;
   getFormsWithPasswordFields: (pageDetails: AutofillPageDetails) => FormData[];
+  getPageTagetingRules: (url: chrome.tabs.Tab["url"]) => Promise<AutofillTargetingRules>;
   doAutoFill: (options: AutoFillOptions) => Promise<string | null>;
   doAutoFillOnTab: (
     pageDetails: PageDetail[],

--- a/apps/browser/src/autofill/services/abstractions/collect-autofill-content.service.ts
+++ b/apps/browser/src/autofill/services/abstractions/collect-autofill-content.service.ts
@@ -1,3 +1,5 @@
+import { AutofillFieldQualifierType } from "@bitwarden/common/autofill/types";
+
 import AutofillField from "../../models/autofill-field";
 import AutofillForm from "../../models/autofill-form";
 import AutofillPageDetails from "../../models/autofill-page-details";
@@ -14,11 +16,13 @@ type UpdateAutofillDataAttributeParams = {
   dataTargetKey?: string;
 };
 
+type TargetedFields = { [type in AutofillFieldQualifierType | "totp"]?: Element };
+
 interface CollectAutofillContentService {
   autofillFormElements: AutofillFormElements;
   getPageDetails(): Promise<AutofillPageDetails>;
   getAutofillFieldElementByOpid(opid: string): HTMLElement | null;
-  getTargetedFields(): {[key: string]: Element} | null;
+  getTargetedFields(): TargetedFields;
   destroy(): void;
 }
 
@@ -27,4 +31,5 @@ export {
   AutofillFieldElements,
   UpdateAutofillDataAttributeParams,
   CollectAutofillContentService,
+  TargetedFields,
 };

--- a/apps/browser/src/autofill/services/abstractions/collect-autofill-content.service.ts
+++ b/apps/browser/src/autofill/services/abstractions/collect-autofill-content.service.ts
@@ -18,6 +18,7 @@ interface CollectAutofillContentService {
   autofillFormElements: AutofillFormElements;
   getPageDetails(): Promise<AutofillPageDetails>;
   getAutofillFieldElementByOpid(opid: string): HTMLElement | null;
+  getTargetedFields(): {[key: string]: Element} | null;
   destroy(): void;
 }
 

--- a/apps/browser/src/autofill/services/abstractions/collect-autofill-content.service.ts
+++ b/apps/browser/src/autofill/services/abstractions/collect-autofill-content.service.ts
@@ -1,4 +1,4 @@
-import { AutofillFieldQualifierType } from "@bitwarden/common/autofill/types";
+import { AutofillTargetingRuleTypes } from "@bitwarden/common/autofill/types";
 
 import AutofillField from "../../models/autofill-field";
 import AutofillForm from "../../models/autofill-form";
@@ -16,7 +16,7 @@ type UpdateAutofillDataAttributeParams = {
   dataTargetKey?: string;
 };
 
-type TargetedFields = { [type in AutofillFieldQualifierType | "totp"]?: Element };
+type TargetedFields = { [type in AutofillTargetingRuleTypes]?: Element };
 
 interface CollectAutofillContentService {
   autofillFormElements: AutofillFormElements;

--- a/apps/browser/src/autofill/services/abstractions/dom-query.service.ts
+++ b/apps/browser/src/autofill/services/abstractions/dom-query.service.ts
@@ -6,5 +6,6 @@ export interface DomQueryService {
     mutationObserver?: MutationObserver,
     forceDeepQueryAttempt?: boolean,
   ): T[];
+  queryDeepSelector(root: Document | ShadowRoot | Element, selector: string): Element[];
   checkPageContainsShadowDom(): boolean;
 }

--- a/apps/browser/src/autofill/services/autofill-overlay-content.service.ts
+++ b/apps/browser/src/autofill/services/autofill-overlay-content.service.ts
@@ -197,8 +197,17 @@ export class AutofillOverlayContentService implements AutofillOverlayContentServ
   async setupOverlayListeners(
     formFieldElement: ElementWithOpId<FormFieldElement>,
     autofillFieldData: AutofillField,
-    pageDetails: AutofillPageDetails,
+    pageDetails?: AutofillPageDetails,
   ) {
+    // This should get targeted fields only
+    if (formFieldElement && !pageDetails) {
+      this.formFieldElements.set(formFieldElement, autofillFieldData);
+      await this.setupFormFieldElementEventListeners(formFieldElement);
+      await this.triggerFormFieldFocusedAction(formFieldElement);
+
+      return;
+    }
+
     if (
       currentlyInSandboxedIframe() ||
       this.formFieldElements.has(formFieldElement) ||
@@ -1265,7 +1274,7 @@ export class AutofillOverlayContentService implements AutofillOverlayContentServ
    * @param formFieldElement - The form field element to set up the inline menu on.
    * @param autofillFieldData - Autofill field data captured from the form field element.
    */
-  private async setupOverlayListenersOnQualifiedField(
+  async setupOverlayListenersOnQualifiedField(
     formFieldElement: ElementWithOpId<FormFieldElement>,
     autofillFieldData: AutofillField,
   ) {

--- a/apps/browser/src/autofill/services/autofill.service.spec.ts
+++ b/apps/browser/src/autofill/services/autofill.service.spec.ts
@@ -747,6 +747,7 @@ describe("AutofillService", () => {
         {
           skipUsernameOnlyFill: autofillOptions.skipUsernameOnlyFill || false,
           onlyEmptyFields: autofillOptions.onlyEmptyFields || false,
+          pageTargetingRules: {},
           fillNewPassword: autofillOptions.fillNewPassword || false,
           allowTotpAutofill: autofillOptions.allowTotpAutofill || false,
           autoSubmitLogin: autofillOptions.allowTotpAutofill || false,

--- a/apps/browser/src/autofill/services/autofill.service.ts
+++ b/apps/browser/src/autofill/services/autofill.service.ts
@@ -431,7 +431,6 @@ export default class AutofillService implements AutofillServiceInterface {
    */
   async doAutoFill(options: AutoFillOptions): Promise<string | null> {
     const tab = options.tab;
-    const pageTargetingRules = await this.getPageTagetingRules(tab.url);
 
     if (!tab || !options.cipher || !options.pageDetails || !options.pageDetails.length) {
       throw new Error("Nothing to autofill.");
@@ -439,6 +438,7 @@ export default class AutofillService implements AutofillServiceInterface {
 
     let totp: string | null = null;
 
+    const pageTargetingRules = await this.getPageTagetingRules(tab.url);
     const activeAccount = await firstValueFrom(this.accountService.activeAccount$);
     const canAccessPremium = await firstValueFrom(
       this.billingAccountProfileStateService.hasPremiumFromAnySource$(activeAccount.id),
@@ -765,7 +765,7 @@ export default class AutofillService implements AutofillServiceInterface {
     const filledFields: { [id: string]: AutofillField } = {};
     const fields = options.cipher.fields;
     const pageTargetedFields = Object.keys(
-      options.pageTargetingRules,
+      options.pageTargetingRules || {},
     ) as AutofillFieldQualifierType[];
     const pageHasTargetingRules = !!pageTargetedFields.length;
 

--- a/apps/browser/src/autofill/services/collect-autofill-content.service.ts
+++ b/apps/browser/src/autofill/services/collect-autofill-content.service.ts
@@ -184,6 +184,10 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
       // Note - potential bottleneck at async lookup (alternatively, promise map)
       const foundTargetedFields = definedTargetingRuleFields.reduce((foundFields, fieldName) => {
         const targetingRule = this.pageTargetingRules[fieldName];
+        if (!targetingRule) {
+          return foundFields;
+        }
+
         const fieldMatches = this.domQueryService.queryDeepSelector(
           globalThis.document,
           targetingRule,

--- a/apps/browser/src/autofill/services/insert-autofill-content.service.spec.ts
+++ b/apps/browser/src/autofill/services/insert-autofill-content.service.spec.ts
@@ -409,17 +409,57 @@ describe("InsertAutofillContentService", () => {
           const scriptAction: FillScript = [action, opid, value];
           jest.spyOn(insertAutofillContentService["autofillInsertActions"], action);
 
-          // FIXME: Verify that this floating promise is intentional. If it is, add an explanatory comment and ensure there is proper error handling.
-          // eslint-disable-next-line @typescript-eslint/no-floating-promises
-          insertAutofillContentService["runFillScriptAction"](scriptAction, 0);
+          void insertAutofillContentService["runFillScriptAction"](scriptAction, 0);
           jest.advanceTimersByTime(20);
 
-          expect(
-            insertAutofillContentService["autofillInsertActions"][action],
-          ).toHaveBeenCalledWith({
-            opid,
-            value,
-          });
+          if (action === "fill_by_opid") {
+            expect(
+              insertAutofillContentService["autofillInsertActions"][action],
+            ).toHaveBeenCalledWith({
+              opid,
+              value,
+            });
+          } else {
+            expect(
+              insertAutofillContentService["autofillInsertActions"][action],
+            ).toHaveBeenCalledWith({
+              opid,
+            });
+          }
+        });
+      });
+    });
+
+    describe("given a valid fill script action and opid", () => {
+      const fillScriptActions: FillScriptActions[] = [
+        "fill_by_targeted_field_type",
+        "click_on_targeted_field_type",
+        "focus_by_targeted_field_type",
+      ];
+      fillScriptActions.forEach((action) => {
+        it(`triggers a ${action} action`, () => {
+          const fieldType = "username";
+          const value = "value";
+          const scriptAction: FillScript = [action, fieldType, value];
+          jest.spyOn(insertAutofillContentService["autofillInsertActions"], action);
+
+          void insertAutofillContentService["runFillScriptAction"](scriptAction, 0);
+          jest.advanceTimersByTime(20);
+
+          if (action === "fill_by_targeted_field_type") {
+            expect(
+              insertAutofillContentService["autofillInsertActions"][action],
+            ).toHaveBeenCalledWith({
+              fieldType,
+              value,
+            });
+          } else {
+            expect(
+              insertAutofillContentService["autofillInsertActions"][action],
+            ).toHaveBeenCalledWith({
+              fieldType,
+            });
+          }
         });
       });
     });

--- a/apps/browser/src/background/runtime.background.ts
+++ b/apps/browser/src/background/runtime.background.ts
@@ -79,6 +79,7 @@ export default class RuntimeBackground {
         BiometricsCommands.UnlockWithBiometricsForUser,
         BiometricsCommands.GetBiometricsStatusForUser,
         BiometricsCommands.CanEnableBiometricUnlock,
+        "getUrlAutofillTargetingRules",
         "getUserPremiumStatus",
       ];
 
@@ -203,6 +204,15 @@ export default class RuntimeBackground {
       }
       case BiometricsCommands.CanEnableBiometricUnlock: {
         return await this.main.biometricsService.canEnableBiometricUnlock();
+      }
+      case "getUrlAutofillTargetingRules": {
+        if (sender.tab?.url) {
+          const targetingRules = await this.autofillService.getPageTagetingRules(sender.tab.url);
+
+          return targetingRules;
+        }
+
+        return null;
       }
       case "getUserPremiumStatus": {
         const activeUserId = await firstValueFrom(

--- a/apps/browser/src/background/runtime.background.ts
+++ b/apps/browser/src/background/runtime.background.ts
@@ -360,6 +360,9 @@ export default class RuntimeBackground {
       case "getClickedElementResponse":
         this.platformUtilsService.copyToClipboard(msg.identifier);
         break;
+      case "getClickedElementPathResponse":
+        this.platformUtilsService.copyToClipboard(msg.path);
+        break;
       case "switchAccount": {
         await this.main.switchAccount(msg.userId);
         break;

--- a/apps/browser/src/popup/app-routing.module.ts
+++ b/apps/browser/src/popup/app-routing.module.ts
@@ -49,6 +49,7 @@ import { fido2AuthGuard } from "../auth/popup/guards/fido2-auth.guard";
 import { AccountSecurityComponent } from "../auth/popup/settings/account-security.component";
 import { ExtensionDeviceManagementComponent } from "../auth/popup/settings/extension-device-management.component";
 import { Fido2Component } from "../autofill/popup/fido2/fido2.component";
+import { AutofillTargetingRulesComponent } from "../autofill/popup/settings/autofill-targeting-rules.component";
 import { AutofillComponent } from "../autofill/popup/settings/autofill.component";
 import { BlockedDomainsComponent } from "../autofill/popup/settings/blocked-domains.component";
 import { ExcludedDomainsComponent } from "../autofill/popup/settings/excluded-domains.component";
@@ -280,6 +281,12 @@ const routes: Routes = [
   {
     path: "folders",
     component: FoldersV2Component,
+    canActivate: [authGuard],
+    data: { elevation: 2 } satisfies RouteDataProperties,
+  },
+  {
+    path: "autofill-targeting-rules",
+    component: AutofillTargetingRulesComponent,
     canActivate: [authGuard],
     data: { elevation: 2 } satisfies RouteDataProperties,
   },

--- a/apps/browser/src/types/tab-messages.ts
+++ b/apps/browser/src/types/tab-messages.ts
@@ -1,7 +1,8 @@
 export type TabMessage =
   | CopyTextTabMessage
   | ClearClipboardTabMessage
-  | GetClickedElementTabMessage;
+  | GetClickedElementTabMessage
+  | GetClickedElementPathTabMessage;
 
 export type TabMessageBase<T extends string> = {
   command: T;
@@ -14,3 +15,5 @@ type CopyTextTabMessage = TabMessageBase<"copyText"> & {
 type ClearClipboardTabMessage = TabMessageBase<"clearClipboard">;
 
 type GetClickedElementTabMessage = TabMessageBase<"getClickedElement">;
+
+type GetClickedElementPathTabMessage = TabMessageBase<"getClickedElementPath">;

--- a/libs/common/src/autofill/constants/index.ts
+++ b/libs/common/src/autofill/constants/index.ts
@@ -72,6 +72,34 @@ export const AutofillOverlayVisibility = {
   OnFieldFocus: 2,
 } as const;
 
+export const AutofillFieldQualifier = {
+  password: "password",
+  newPassword: "newPassword",
+  username: "username",
+  cardholderName: "cardholderName",
+  cardNumber: "cardNumber",
+  cardExpirationMonth: "cardExpirationMonth",
+  cardExpirationYear: "cardExpirationYear",
+  cardExpirationDate: "cardExpirationDate",
+  cardCvv: "cardCvv",
+  identityTitle: "identityTitle",
+  identityFirstName: "identityFirstName",
+  identityMiddleName: "identityMiddleName",
+  identityLastName: "identityLastName",
+  identityFullName: "identityFullName",
+  identityAddress1: "identityAddress1",
+  identityAddress2: "identityAddress2",
+  identityAddress3: "identityAddress3",
+  identityCity: "identityCity",
+  identityState: "identityState",
+  identityPostalCode: "identityPostalCode",
+  identityCountry: "identityCountry",
+  identityCompany: "identityCompany",
+  identityPhone: "identityPhone",
+  identityEmail: "identityEmail",
+  identityUsername: "identityUsername",
+} as const;
+
 export const BrowserClientVendors = {
   Chrome: "Chrome",
   Opera: "Opera",

--- a/libs/common/src/autofill/constants/index.ts
+++ b/libs/common/src/autofill/constants/index.ts
@@ -44,6 +44,7 @@ export const AUTOFILL_ID = "autofill";
 export const SHOW_AUTOFILL_BUTTON = "show-autofill-button";
 export const AUTOFILL_IDENTITY_ID = "autofill-identity";
 export const COPY_IDENTIFIER_ID = "copy-identifier";
+export const COPY_ELEMENT_PATH_ID = "copy-element-path";
 export const COPY_PASSWORD_ID = "copy-password";
 export const COPY_USERNAME_ID = "copy-username";
 export const COPY_VERIFICATION_CODE_ID = "copy-totp";

--- a/libs/common/src/autofill/services/domain-settings.service.ts
+++ b/libs/common/src/autofill/services/domain-settings.service.ts
@@ -154,7 +154,9 @@ export class DefaultDomainSettingsService implements DomainSettingsService {
     private accountService: AccountService,
   ) {
     this.autofillTargetingRulesState = this.stateProvider.getActive(AUTOFILL_TARGETING_RULES);
-    this.autofillTargetingRules$ = this.autofillTargetingRulesState.state$.pipe(map((x) => (x && Object.keys(x).length) ? x : {}));
+    this.autofillTargetingRules$ = this.autofillTargetingRulesState.state$.pipe(
+      map((x) => (x && Object.keys(x).length ? x : {})),
+    );
 
     this.showFaviconsState = this.stateProvider.getGlobal(SHOW_FAVICONS);
     this.showFavicons$ = this.showFaviconsState.state$.pipe(map((x) => x ?? true));

--- a/libs/common/src/autofill/types/index.ts
+++ b/libs/common/src/autofill/types/index.ts
@@ -22,9 +22,11 @@ export type AutofillFieldQualifierType =
   (typeof AutofillFieldQualifier)[keyof typeof AutofillFieldQualifier];
 
 export type AutofillTargetingRules = {
-  [type in AutofillFieldQualifierType]?: string;
+  [type in AutofillTargetingRuleTypes]?: string;
 };
 
+export type AutofillTargetingRuleTypes = keyof typeof AutofillFieldQualifier | "totp";
+
 export type AutofillTargetingRulesByDomain = {
-  [key: string]: AutofillTargetingRules
+  [key: string]: AutofillTargetingRules;
 };

--- a/libs/common/src/autofill/types/index.ts
+++ b/libs/common/src/autofill/types/index.ts
@@ -1,4 +1,5 @@
 import {
+  AutofillFieldQualifier,
   AutofillOverlayVisibility,
   BrowserClientVendors,
   BrowserShortcutsUris,
@@ -16,3 +17,14 @@ export type BrowserClientVendor = (typeof BrowserClientVendors)[keyof typeof Bro
 export type BrowserShortcutsUri = (typeof BrowserShortcutsUris)[keyof typeof BrowserShortcutsUris];
 export type DisablePasswordManagerUri =
   (typeof DisablePasswordManagerUris)[keyof typeof DisablePasswordManagerUris];
+
+export type AutofillFieldQualifierType =
+  (typeof AutofillFieldQualifier)[keyof typeof AutofillFieldQualifier];
+
+export type AutofillTargetingRules = {
+  [type in AutofillFieldQualifierType]?: string;
+};
+
+export type AutofillTargetingRulesByDomain = {
+  [key: string]: AutofillTargetingRules
+};


### PR DESCRIPTION
## 🎟️ Tracking

[PM-26476](https://bitwarden.atlassian.net/browse/PM-26476)

## 📔 Objective

A browser client feature "proof-of-concept"/prototype for page targeting rules. The feature allows users to map cipher attributes to fields specific to a URL. Changes include a settings view for adding and removing targeting rules (in Autofill Settings), a context menu entry to generate rules for a target field ("Copy element path"), and autofill logic to bypass heuristic filling and inline menu appearance in favor of user-specified targeting rules.

### Notes and Caveats

- This is a proof-of-concept feature which does not represent any finalized feature, user experience, design, or guarantee of release to the production product.
- This branch does not include feature flagging of the feature and related logic
- When at least one targeting rule mapping is active for a given URL and at least one targeted element is successfully found on the page, the inline menu will only appear for that element (if otherwise applicable); all other heuristics for displaying the inline menu will be disabled for the page
- When at least one targeting rule mapping is active for a given URL autofill actions will ONLY attempt to fill elements that have targeting rules. All other heuristics for autofilling fields will be skipped for the page.
- Targeting rules utilize [standard CSS queries](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_selectors) with an addition of the `>>>` combinator which denotes Shadow Root traversal.
- The "Copy element path" option in the context menu does not currently traverse closed shadow roots (open roots are fine) when generating a CSS query string. If the tool reaches a closed shadow DOM, it will return the query string built up to that point.
- The Targeting Rules management page does not presently allow editing rules; new rules will replace existing ones for the same URL

## 📸 Screenshots

https://github.com/user-attachments/assets/d491cc1c-12da-4047-8127-d464f9285d36

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-26476]: https://bitwarden.atlassian.net/browse/PM-26476?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ