### PR TITLE
Update Input Password Modal Title

### DIFF
--- a/libs/auth/src/angular/input-password/input-password.component.ts
+++ b/libs/auth/src/angular/input-password/input-password.component.ts
@@ -538,7 +538,7 @@ export class InputPasswordComponent implements OnInit {
       }
     } else if (passwordIsWeak) {
       const userAcceptedDialog = await this.dialogService.openSimpleDialog({
-        title: { key: "weakMasterPasswordDesc" },
+        title: { key: "weakMasterPassword" },
         content: { key: "weakMasterPasswordDesc" },
         type: "warning",
       });


### PR DESCRIPTION
## 🎟️ Tracking

[PM-24266](https://bitwarden.atlassian.net/browse/PM-24266)

## 📔 Objective

When a new user is registering and unchecks the "Check known data breaches for this password" option for their new Master Password, the modal title should be "Weak master password." Previously, it was the same as the modal body.

## 📸 Screenshots


https://github.com/user-attachments/assets/b1d6d0f7-ffc5-4b2d-a4dd-98cfc6f33b34



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-24266]: https://bitwarden.atlassian.net/browse/PM-24266?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ