### PR TITLE
Desktop Native enable cargo deny CI check

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -111,9 +111,11 @@ jobs:
         working-directory: ./apps/desktop/desktop_native
         run: cargo sort --workspace --check
 
-      - name: Run cargo deny
+      - name: Install cargo-deny
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-deny
+
+      - name: Run cargo deny
         working-directory: ./apps/desktop/desktop_native
         run: cargo deny --log-level error --all-features check all


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-26564

## 📔 Objective

Follow-up to https://github.com/bitwarden/clients/pull/16765

Adds the check in CI for linting our rust deps in Desktop Native.

## 📸 Screenshots

<img width="696" height="70" alt="Screenshot 2025-10-20 at 09 39 31" src="https://github.com/user-attachments/assets/b69b0846-8c4c-4f9f-b433-6caefa89dafd" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
