### PR TITLE
[PM-26956] Link help docs for Crowdstrike and Datadog

### DIFF
--- a/bitwarden_license/bit-web/src/app/dirt/organization-integrations/integration-card/integration-card.component.html
+++ b/bitwarden_license/bit-web/src/app/dirt/organization-integrations/integration-card/integration-card.component.html
@@ -15,6 +15,17 @@
         class="tw-block tw-mx-auto tw-h-auto tw-max-w-full tw-max-h-full"
       />
     </div>
+
+    @if (linkURL) {
+      <a
+        class="tw-block tw-mb-0 tw-font-bold hover:tw-no-underline focus:tw-outline-none after:tw-content-[''] after:tw-block after:tw-absolute after:tw-size-full after:tw-left-0 after:tw-top-0 after:tw-w-full after:tw-h-40"
+        [href]="linkURL"
+        rel="noopener noreferrer"
+        target="_blank"
+        title="{{ linkURL }}"
+      >
+      </a>
+    }
   </div>
   <div class="tw-p-5">
     <h3 class="tw-text-main tw-text-lg tw-font-semibold">
@@ -42,16 +53,6 @@
       </button>
     }
 
-    @if (linkURL) {
-      <a
-        class="tw-block tw-mb-0 tw-font-bold hover:tw-no-underline focus:tw-outline-none after:tw-content-[''] after:tw-block after:tw-absolute after:tw-size-full after:tw-left-0 after:tw-top-0"
-        [href]="linkURL"
-        rel="noopener noreferrer"
-        target="_blank"
-        title="{{ linkURL }}"
-      >
-      </a>
-    }
     @if (showNewBadge()) {
       <span bitBadge class="tw-mt-3" variant="secondary">
         {{ "new" | i18n }}

--- a/bitwarden_license/bit-web/src/app/dirt/organization-integrations/integrations.component.ts
+++ b/bitwarden_license/bit-web/src/app/dirt/organization-integrations/integrations.component.ts
@@ -269,25 +269,24 @@ export class AdminConsoleIntegrationsComponent implements OnInit, OnDestroy {
     if (this.isEventBasedIntegrationsEnabled) {
       const crowdstrikeIntegration: Integration = {
         name: OrganizationIntegrationServiceType.CrowdStrike,
-        linkURL: "",
+        linkURL: "https://bitwarden.com/help/crowdstrike-siem/",
         image: "../../../../../../../images/integrations/logo-crowdstrike-black.svg",
         type: IntegrationType.EVENT,
         description: "crowdstrikeEventIntegrationDesc",
         canSetupConnection: true,
-        integrationType: 5, // Assuming 5 corresponds to CrowdStrike in OrganizationIntegrationType
+        integrationType: OrganizationIntegrationType.Hec,
       };
 
       this.integrationsList.push(crowdstrikeIntegration);
 
       const datadogIntegration: Integration = {
         name: OrganizationIntegrationServiceType.Datadog,
-        // TODO: Update link when help article is published
-        linkURL: "",
+        linkURL: "https://bitwarden.com/help/datadog-siem/",
         image: "../../../../../../../images/integrations/logo-datadog-color.svg",
         type: IntegrationType.EVENT,
         description: "datadogEventIntegrationDesc",
         canSetupConnection: true,
-        integrationType: 6, // Assuming 6 corresponds to Datadog in OrganizationIntegrationType
+        integrationType: OrganizationIntegrationType.Datadog,
       };
 
       this.integrationsList.push(datadogIntegration);


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-25956

## 📔 Objective

Every integration card has a link to the help docs. This task sets a link for the Crowdstrike and DataDog integration cards.
The links will be 404 not found at this time, but will be ready when the feature goes live.

## 📸 Screenshots

### Crowdstrike
<img width="1256" height="841" alt="image" src="https://github.com/user-attachments/assets/d16189c1-1a48-4c2b-80ee-21ec30bf31b4" />

### DataDog
<img width="1256" height="841" alt="image" src="https://github.com/user-attachments/assets/186cf8c1-12fa-4660-a8fa-4ef1b7f36d43" />


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
