### PR TITLE
Fix biometric v2 windows unit test clippy lint

### DIFF
--- a/apps/desktop/desktop_native/core/src/biometric_v2/windows.rs
+++ b/apps/desktop/desktop_native/core/src/biometric_v2/windows.rs
@@ -376,6 +376,7 @@ unsafe fn as_mut_bytes(buffer: &IBuffer) -> Result<&mut [u8]> {
 }
 
 #[cfg(test)]
+#[allow(clippy::print_stdout)]
 mod tests {
     use crate::biometric_v2::{
         biometric_v2::{


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

This was a timing issue with merging of changes to main.
the changes to add the biometricv2 which added the println occurred yesterday: https://github.com/bitwarden/clients/commit/f65e5d52c23e3003c7171faa36edd4311ef15188

, and the change I added to enable to clippy lint had merged main in yesterday, but before the above change was merged, and when I got approvals and merged the clippy lint change in, this was as a result missed on the CI in my PR. https://github.com/bitwarden/clients/commit/8370f43aaeeecd7c3b759601010e3e3fec6c4ef1

There isn't a way in Cargo.toml to set a "global" allow on the lints for unit tests, that would be cool. I think the approach taken in my changes here makes the most sense given the situation. The closest would be `#[cfg_attr(test, allow(lint_name))]` but would need to be set in each workspace member's lib.rs.

The unit tests that have the printlns are also `#[ignore]`. If a unit tests is part of automation, and in general, IMO they shouldn't rely on printlns, but rely on assertions. and code comments if needed to explain what is going on. But since these unit tests seem to rely on manual execution, I guess it's ok to have them. I do wonder though about the usage of `#ignore` here, it could be a sign that these validations should take a different form. Exceptions like these (with regards to println) are prone to come up though.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
