### PR TITLE
[PM-27209] SDK returning `undefined` vs `null`

### DIFF
--- a/libs/vault/src/cipher-form/components/item-details/item-details-section.component.spec.ts
+++ b/libs/vault/src/cipher-form/components/item-details/item-details-section.component.spec.ts
@@ -135,7 +135,7 @@ describe("ItemDetailsSectionComponent", () => {
       tick();
 
       expect(cipherFormProvider.patchCipher).toHaveBeenCalled();
-      const patchFn = cipherFormProvider.patchCipher.mock.lastCall[0];
+      const patchFn = cipherFormProvider.patchCipher.mock.lastCall![0];
 
       const updatedCipher = patchFn(new CipherView());
 
@@ -165,7 +165,7 @@ describe("ItemDetailsSectionComponent", () => {
       tick();
 
       expect(cipherFormProvider.patchCipher).toHaveBeenCalled();
-      const patchFn = cipherFormProvider.patchCipher.mock.lastCall[0];
+      const patchFn = cipherFormProvider.patchCipher.mock.lastCall![0];
 
       const updatedCipher = patchFn(new CipherView());
 
@@ -440,7 +440,7 @@ describe("ItemDetailsSectionComponent", () => {
       await fixture.whenStable();
 
       expect(cipherFormProvider.patchCipher).toHaveBeenCalled();
-      const patchFn = cipherFormProvider.patchCipher.mock.lastCall[0];
+      const patchFn = cipherFormProvider.patchCipher.mock.lastCall![0];
 
       const updatedCipher = patchFn(new CipherView());
 
@@ -688,6 +688,35 @@ describe("ItemDetailsSectionComponent", () => {
           await component.ngOnInit();
 
           expect(disableFormFields).not.toHaveBeenCalled();
+          expect(enableFormFields).toHaveBeenCalled();
+        });
+      });
+
+      describe("setFormState behavior with null/undefined", () => {
+        it("calls disableFormFields when organizationId value is null", async () => {
+          component.originalCipherView.organizationId = null as any;
+          getInitialCipherView.mockReturnValue(component.originalCipherView);
+
+          await component.ngOnInit();
+
+          expect(disableFormFields).toHaveBeenCalled();
+        });
+
+        it("calls disableFormFields when organizationId value is undefined", async () => {
+          component.originalCipherView.organizationId = undefined;
+          getInitialCipherView.mockReturnValue(component.originalCipherView);
+
+          await component.ngOnInit();
+
+          expect(disableFormFields).toHaveBeenCalled();
+        });
+
+        it("calls enableFormFields when organizationId has a string value", async () => {
+          component.originalCipherView.organizationId = "org-id" as any;
+          getInitialCipherView.mockReturnValue(component.originalCipherView);
+
+          await component.ngOnInit();
+
           expect(enableFormFields).toHaveBeenCalled();
         });
       });

--- a/libs/vault/src/cipher-form/components/item-details/item-details-section.component.ts
+++ b/libs/vault/src/cipher-form/components/item-details/item-details-section.component.ts
@@ -125,7 +125,7 @@ export class ItemDetailsSectionComponent implements OnInit {
       this.itemDetailsForm.controls.organizationId.disabled ||
       (!this.allowPersonalOwnership &&
         this.config.originalCipher &&
-        this.itemDetailsForm.controls.organizationId.value === null)
+        this.itemDetailsForm.controls.organizationId.value == null)
     );
   }
 
@@ -252,7 +252,7 @@ export class ItemDetailsSectionComponent implements OnInit {
       // When editing a cipher and the user cannot have personal ownership
       // and the cipher is is not within the organization - force the user to
       // move the cipher within the organization first before editing any other field
-      if (this.itemDetailsForm.controls.organizationId.value === null) {
+      if (this.itemDetailsForm.controls.organizationId.value == null) {
         this.cipherFormContainer.disableFormFields();
         this.itemDetailsForm.controls.organizationId.enable();
         this.favoriteButtonDisabled = true;


### PR DESCRIPTION
## 🎟️ Tracking

[PM-27209](https://bitwarden.atlassian.net/browse/PM-27209)

## 📔 Objective

`pm-19941-migrate-cipher-domain-to-sdk` is enabled as a part of this release, the SDK returns `undefined` for values rather than `null`. This broke equality checks in the item details when checking the `organizationId`

Use loose equality checks `==`

## 📸 Screenshots

|Before|After|
|-|-|
|<video src="https://github.com/user-attachments/assets/70e5bedc-6d7c-4dd1-8234-6260cfac462e" />|<video src="https://github.com/user-attachments/assets/20459864-660b-4079-a04b-9ac666514b26" />|

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-27209]: https://bitwarden.atlassian.net/browse/PM-27209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ