### PR TITLE
build(nx): fix serve browser

### DIFF
--- a/apps/browser/project.json
+++ b/apps/browser/project.json
@@ -315,164 +315,53 @@
       }
     },
     "serve": {
-      "executor": "@nx/webpack:webpack",
+      "executor": "nx:run-commands",
       "defaultConfiguration": "chrome-dev",
       "options": {
-        "outputPath": "dist/apps/browser",
-        "webpackConfig": "apps/browser/webpack.config.js",
-        "tsConfig": "apps/browser/tsconfig.json",
-        "main": "apps/browser/src/popup/main.ts",
-        "target": "web",
-        "compiler": "tsc",
-        "watch": true
+        "cwd": "apps/browser"
       },
       "configurations": {
         "chrome-dev": {
-          "mode": "development",
-          "outputPath": "dist/apps/browser/chrome-dev",
-          "env": {
-            "BROWSER": "chrome",
-            "MANIFEST_VERSION": "3",
-            "NODE_ENV": "development"
-          }
+          "command": "cross-env BROWSER=chrome MANIFEST_VERSION=3 NODE_ENV=development NODE_OPTIONS=\"--max-old-space-size=8192\" webpack --watch --output-path=../../dist/apps/browser/chrome-dev"
         },
         "firefox-dev": {
-          "mode": "development",
-          "outputPath": "dist/apps/browser/firefox-dev",
-          "env": {
-            "BROWSER": "firefox",
-            "MANIFEST_VERSION": "3",
-            "NODE_ENV": "development"
-          }
+          "command": "cross-env BROWSER=firefox MANIFEST_VERSION=3 NODE_ENV=development NODE_OPTIONS=\"--max-old-space-size=8192\" webpack --watch --output-path=../../dist/apps/browser/firefox-dev"
         },
         "firefox-mv2-dev": {
-          "mode": "development",
-          "outputPath": "dist/apps/browser/firefox-mv2-dev",
-          "env": {
-            "BROWSER": "firefox",
-            "MANIFEST_VERSION": "2",
-            "NODE_ENV": "development"
-          }
+          "command": "cross-env BROWSER=firefox MANIFEST_VERSION=2 NODE_ENV=development NODE_OPTIONS=\"--max-old-space-size=8192\" webpack --watch --output-path=../../dist/apps/browser/firefox-mv2-dev"
         },
         "safari-dev": {
-          "mode": "development",
-          "outputPath": "dist/apps/browser/safari-dev",
-          "env": {
-            "BROWSER": "safari",
-            "MANIFEST_VERSION": "3",
-            "NODE_ENV": "development"
-          }
+          "command": "cross-env BROWSER=safari MANIFEST_VERSION=3 NODE_ENV=development NODE_OPTIONS=\"--max-old-space-size=8192\" webpack --watch --output-path=../../dist/apps/browser/safari-dev"
         },
         "safari-mv2-dev": {
-          "mode": "development",
-          "outputPath": "dist/apps/browser/safari-mv2-dev",
-          "env": {
-            "BROWSER": "safari",
-            "MANIFEST_VERSION": "2",
-            "NODE_ENV": "development"
-          }
+          "command": "cross-env BROWSER=safari MANIFEST_VERSION=2 NODE_ENV=development NODE_OPTIONS=\"--max-old-space-size=8192\" webpack --watch --output-path=../../dist/apps/browser/safari-mv2-dev"
         },
         "edge-dev": {
-          "mode": "development",
-          "outputPath": "dist/apps/browser/edge-dev",
-          "env": {
-            "BROWSER": "edge",
-            "MANIFEST_VERSION": "3",
-            "NODE_ENV": "development"
-          }
+          "command": "cross-env BROWSER=edge MANIFEST_VERSION=3 NODE_ENV=development NODE_OPTIONS=\"--max-old-space-size=8192\" webpack --watch --output-path=../../dist/apps/browser/edge-dev"
         },
         "opera-dev": {
-          "mode": "development",
-          "outputPath": "dist/apps/browser/opera-dev",
-          "env": {
-            "BROWSER": "opera",
-            "MANIFEST_VERSION": "3",
-            "NODE_ENV": "development"
-          }
+          "command": "cross-env BROWSER=opera MANIFEST_VERSION=3 NODE_ENV=development NODE_OPTIONS=\"--max-old-space-size=8192\" webpack --watch --output-path=../../dist/apps/browser/opera-dev"
         },
         "commercial-chrome-dev": {
-          "mode": "development",
-          "outputPath": "dist/apps/browser/commercial-chrome-dev",
-          "webpackConfig": "bitwarden_license/bit-browser/webpack.config.js",
-          "main": "bitwarden_license/bit-browser/src/popup/main.ts",
-          "tsConfig": "bitwarden_license/bit-browser/tsconfig.json",
-          "env": {
-            "BROWSER": "chrome",
-            "MANIFEST_VERSION": "3",
-            "NODE_ENV": "development"
-          }
+          "command": "cross-env BROWSER=chrome MANIFEST_VERSION=3 NODE_ENV=development NODE_OPTIONS=\"--max-old-space-size=8192\" webpack -c ../../bitwarden_license/bit-browser/webpack.config.js --watch --output-path=../../dist/apps/browser/commercial-chrome-dev"
         },
         "commercial-firefox-dev": {
-          "mode": "development",
-          "outputPath": "dist/apps/browser/commercial-firefox-dev",
-          "webpackConfig": "bitwarden_license/bit-browser/webpack.config.js",
-          "main": "bitwarden_license/bit-browser/src/popup/main.ts",
-          "tsConfig": "bitwarden_license/bit-browser/tsconfig.json",
-          "env": {
-            "BROWSER": "firefox",
-            "MANIFEST_VERSION": "3",
-            "NODE_ENV": "development"
-          }
+          "command": "cross-env BROWSER=firefox MANIFEST_VERSION=3 NODE_ENV=development NODE_OPTIONS=\"--max-old-space-size=8192\" webpack -c ../../bitwarden_license/bit-browser/webpack.config.js --watch --output-path=../../dist/apps/browser/commercial-firefox-dev"
         },
         "commercial-firefox-mv2-dev": {
-          "mode": "development",
-          "outputPath": "dist/apps/browser/commercial-firefox-mv2-dev",
-          "webpackConfig": "bitwarden_license/bit-browser/webpack.config.js",
-          "main": "bitwarden_license/bit-browser/src/popup/main.ts",
-          "tsConfig": "bitwarden_license/bit-browser/tsconfig.json",
-          "env": {
-            "BROWSER": "firefox",
-            "MANIFEST_VERSION": "2",
-            "NODE_ENV": "development"
-          }
+          "command": "cross-env BROWSER=firefox MANIFEST_VERSION=2 NODE_ENV=development NODE_OPTIONS=\"--max-old-space-size=8192\" webpack -c ../../bitwarden_license/bit-browser/webpack.config.js --watch --output-path=../../dist/apps/browser/commercial-firefox-mv2-dev"
         },
         "commercial-safari-dev": {
-          "mode": "development",
-          "outputPath": "dist/apps/browser/commercial-safari-dev",
-          "webpackConfig": "bitwarden_license/bit-browser/webpack.config.js",
-          "main": "bitwarden_license/bit-browser/src/popup/main.ts",
-          "tsConfig": "bitwarden_license/bit-browser/tsconfig.json",
-          "env": {
-            "BROWSER": "safari",
-            "MANIFEST_VERSION": "3",
-            "NODE_ENV": "development"
-          }
+          "command": "cross-env BROWSER=safari MANIFEST_VERSION=3 NODE_ENV=development NODE_OPTIONS=\"--max-old-space-size=8192\" webpack -c ../../bitwarden_license/bit-browser/webpack.config.js --watch --output-path=../../dist/apps/browser/commercial-safari-dev"
         },
         "commercial-safari-mv2-dev": {
-          "mode": "development",
-          "outputPath": "dist/apps/browser/commercial-safari-mv2-dev",
-          "webpackConfig": "bitwarden_license/bit-browser/webpack.config.js",
-          "main": "bitwarden_license/bit-browser/src/popup/main.ts",
-          "tsConfig": "bitwarden_license/bit-browser/tsconfig.json",
-          "env": {
-            "BROWSER": "safari",
-            "MANIFEST_VERSION": "2",
-            "NODE_ENV": "development"
-          }
+          "command": "cross-env BROWSER=safari MANIFEST_VERSION=2 NODE_ENV=development NODE_OPTIONS=\"--max-old-space-size=8192\" webpack -c ../../bitwarden_license/bit-browser/webpack.config.js --watch --output-path=../../dist/apps/browser/commercial-safari-mv2-dev"
         },
         "commercial-edge-dev": {
-          "mode": "development",
-          "outputPath": "dist/apps/browser/commercial-edge-dev",
-          "webpackConfig": "bitwarden_license/bit-browser/webpack.config.js",
-          "main": "bitwarden_license/bit-browser/src/popup/main.ts",
-          "tsConfig": "bitwarden_license/bit-browser/tsconfig.json",
-          "env": {
-            "BROWSER": "edge",
-            "MANIFEST_VERSION": "3",
-            "NODE_ENV": "development"
-          }
+          "command": "cross-env BROWSER=edge MANIFEST_VERSION=3 NODE_ENV=development NODE_OPTIONS=\"--max-old-space-size=8192\" webpack -c ../../bitwarden_license/bit-browser/webpack.config.js --watch --output-path=../../dist/apps/browser/commercial-edge-dev"
         },
         "commercial-opera-dev": {
-          "mode": "development",
-          "outputPath": "dist/apps/browser/commercial-opera-dev",
-          "webpackConfig": "bitwarden_license/bit-browser/webpack.config.js",
-          "main": "bitwarden_license/bit-browser/src/popup/main.ts",
-          "tsConfig": "bitwarden_license/bit-browser/tsconfig.json",
-          "env": {
-            "BROWSER": "opera",
-            "MANIFEST_VERSION": "3",
-            "NODE_ENV": "development"
-          }
+          "command": "cross-env BROWSER=opera MANIFEST_VERSION=3 NODE_ENV=development NODE_OPTIONS=\"--max-old-space-size=8192\" webpack -c ../../bitwarden_license/bit-browser/webpack.config.js --watch --output-path=../../dist/apps/browser/commercial-opera-dev"
         }
       }
     },


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-27215

## 📔 Objective

⚠️ **HACK ALERT**

`npx nx serve browser` is not watching and re-serving files. It's just building and exiting. To fix this I tried three things:

1. Using `watch` flags with the webpack executor. This made rebuilds painfully slow because of the hacks we have in place to ignore circular references in our nx build.
2. Using the webpack-dev-server executor. This has issues saving files to disk when an application's webpack config is an array of webpack objects instead of a single one. This seems like a bug with the executor. I'd like to file a bug report with the nx team, but haven't yet.
3. Wrapping the webpack-dev-server executor in a custom executor that forces saving files to disk. This failed miserably, the executor was conflicting with what I was doing and it just failed.

I eventually just used the `run-command` executor to run webpack directly. This isn't Nx-y, but we can change to the webpack executor later when our libraries are not as tangled. For now this is just as fast as `npm build:watch`.

## 📸 Screenshots

A served local extension and its watching process from `npx nx serve browser`
<img width="1030" height="1410" alt="Screenshot 2025-10-21 at 3 47 18 PM" src="https://github.com/user-attachments/assets/40a56133-85bf-466c-8b35-f7ef6a54a3c4" />
<img width="1756" height="1344" alt="Screenshot 2025-10-21 at 3 47 43 PM" src="https://github.com/user-attachments/assets/468cd8aa-5ee9-4d0a-8f3c-64f93183f188" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
