### PR TITLE
[PM-26119] Fix restart subscription modal showing twice from switcher

### DIFF
--- a/apps/web/src/app/layouts/org-switcher/org-switcher.component.html
+++ b/apps/web/src/app/layouts/org-switcher/org-switcher.component.html
@@ -22,7 +22,6 @@
       [route]="['../', org.id]"
       (mainContentClicked)="toggle()"
       [routerLinkActiveOptions]="{ exact: true }"
-      (click)="showInactiveSubscriptionDialog(org)"
     >
       <i
         slot="end"

--- a/apps/web/src/app/layouts/org-switcher/org-switcher.component.ts
+++ b/apps/web/src/app/layouts/org-switcher/org-switcher.component.ts
@@ -3,7 +3,7 @@
 import { CommonModule } from "@angular/common";
 import { Component, EventEmitter, Input, Output } from "@angular/core";
 import { ActivatedRoute } from "@angular/router";
-import { combineLatest, firstValueFrom, map, Observable, switchMap } from "rxjs";
+import { combineLatest, map, Observable, switchMap } from "rxjs";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
@@ -12,7 +12,6 @@ import { AccountService } from "@bitwarden/common/auth/abstractions/account.serv
 import { BillingApiServiceAbstraction } from "@bitwarden/common/billing/abstractions/billing-api.service.abstraction";
 import { DialogService, NavigationModule } from "@bitwarden/components";
 import { OrganizationWarningsModule } from "@bitwarden/web-vault/app/billing/organizations/warnings/organization-warnings.module";
-import { OrganizationWarningsService } from "@bitwarden/web-vault/app/billing/organizations/warnings/services";
 
 // FIXME(https://bitwarden.atlassian.net/browse/CL-764): Migrate to OnPush
 // eslint-disable-next-line @angular-eslint/prefer-on-push-component-change-detection
@@ -76,7 +75,6 @@ export class OrgSwitcherComponent {
     private organizationService: OrganizationService,
     protected billingApiService: BillingApiServiceAbstraction,
     private accountService: AccountService,
-    private organizationWarningsService: OrganizationWarningsService,
   ) {}
 
   protected toggle(event?: MouseEvent) {
@@ -84,9 +82,4 @@ export class OrgSwitcherComponent {
     this.open = !this.open;
     this.openChange.emit(this.open);
   }
-
-  showInactiveSubscriptionDialog = async (organization: Organization) =>
-    await firstValueFrom(
-      this.organizationWarningsService.showInactiveSubscriptionDialog$(organization),
-    );
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-26119

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

The org switcher is in a different injection context than the organization module so each was getting their own version of the `OrganizationWarningsService`.

I removed (click) event in the switcher because it's not necessary; the switcher just routes to the AC vault where the `OrganizationWarningsService` will run on component construction.

## 📸 Screenshots

https://github.com/user-attachments/assets/2196089e-c5d6-4ee9-b00d-165a336ac82d


<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
