### PR TITLE
Update Deploy Web Vault workflow - Escape dollar sign in URL

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -392,7 +392,7 @@ jobs:
           AZCOPY_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           _VAULT_NAME: ${{ steps.retrieve-secrets-azcopy.outputs.sa-bitwarden-web-vault-name }}
         run: |
-          azcopy sync ./build "https://$_VAULT_NAME.blob.core.windows.net/$web/" \
+          azcopy sync ./build "https://$_VAULT_NAME.blob.core.windows.net/\$web/" \
             --delete-destination="${{ inputs.force-delete-destination }}" --compare-hash="MD5"
 
       - name: Log out from Azure


### PR DESCRIPTION
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR escapes the dollar sign in the URL for the Azure Storage Account. We originally used single quotes, but Zizmor likes double quotes and the dollar sign was being interpreted as a bash variable.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
