### PR TITLE
[PM-27222] ci(cli): add linux arm64 artifacts to CLI release

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -91,7 +91,9 @@ jobs:
                       apps/cli/bw-macos-${{ env.PKG_VERSION }}.zip,
                       apps/cli/bw-macos-arm64-${{ env.PKG_VERSION }}.zip,
                       apps/cli/bw-oss-linux-${{ env.PKG_VERSION }}.zip,
+                      apps/cli/bw-oss-linux-arm64-${{ env.PKG_VERSION }}.zip,
                       apps/cli/bw-linux-${{ env.PKG_VERSION }}.zip,
+                      apps/cli/bw-linux-arm64-${{ env.PKG_VERSION }}.zip,
                       apps/cli/bitwarden-cli.${{ env.PKG_VERSION }}.nupkg,
                       apps/cli/bw_${{ env.PKG_VERSION }}_amd64.snap,
                       apps/cli/bitwarden-cli-${{ env.PKG_VERSION }}-npm-build.zip"


### PR DESCRIPTION
## 📔 Objective

Add Linux ARM64 artifacts to the release-cli workflow. Include
`apps/cli/bw-oss-linux-arm64` and `apps/cli/bw-linux-arm64` archives so
GitHub releases contain ARM64 CLI builds.

I found that I can download linux arm64 artifacts from the GitHub Actions build history, so there should be built linux arm64 artifacts, but the release-cli workflow missed publishing them to the GitHub release.

https://github.com/bitwarden/clients/actions/runs/18695972645

> ref: https://www.reddit.com/r/Bitwarden/comments/1l5u2jk/comment/mwn9cxg

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
