### PR TITLE
[PM-27199] Persist archive date through clone

### DIFF
--- a/libs/vault/src/cipher-form/components/cipher-form.component.spec.ts
+++ b/libs/vault/src/cipher-form/components/cipher-form.component.spec.ts
@@ -154,13 +154,13 @@ describe("CipherFormComponent", () => {
       expect(component["updatedCipherView"]?.login.fido2Credentials).toBeNull();
     });
 
-    it("clears archiveDate on updatedCipherView", async () => {
+    it("does not clear archiveDate on updatedCipherView", async () => {
       cipherView.archivedDate = new Date();
       decryptCipher.mockResolvedValue(cipherView);
 
       await component.ngOnInit();
 
-      expect(component["updatedCipherView"]?.archivedDate).toBeNull();
+      expect(component["updatedCipherView"]?.archivedDate).toBe(cipherView.archivedDate);
     });
   });
 

--- a/libs/vault/src/cipher-form/components/cipher-form.component.ts
+++ b/libs/vault/src/cipher-form/components/cipher-form.component.ts
@@ -263,7 +263,6 @@ export class CipherFormComponent implements AfterViewInit, OnInit, OnChanges, Ci
 
       if (this.config.mode === "clone") {
         this.updatedCipherView.id = null;
-        this.updatedCipherView.archivedDate = null;
 
         if (this.updatedCipherView.login) {
           this.updatedCipherView.login.fido2Credentials = null;


### PR DESCRIPTION
## 🎟️ Tracking

[PM-27199](https://bitwarden.atlassian.net/browse/PM-27199)

## 📔 Objective

When cloning an archived cipher the cloned cipher should stay in the archive.

## 📸 Screenshots

<video src="https://github.com/user-attachments/assets/61819870-0071-4c32-8e29-a167dd237650" />

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-27199]: https://bitwarden.atlassian.net/browse/PM-27199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ