### PR TITLE
[PM-27291] preserve critical app flags when generating new reports

### DIFF
--- a/bitwarden_license/bit-common/src/dirt/reports/risk-insights/services/domain/risk-insights-orchestrator.service.ts
+++ b/bitwarden_license/bit-common/src/dirt/reports/risk-insights/services/domain/risk-insights-orchestrator.service.ts
@@ -102,6 +102,7 @@ export class RiskInsightsOrchestratorService {
   private _initializeOrganizationTriggerSubject = new Subject<OrganizationId>();
   private _fetchReportTriggerSubject = new Subject<void>();
   private _markUnmarkUpdatesSubject = new Subject<ReportState>();
+  private _markUnmarkUpdates$ = this._markUnmarkUpdatesSubject.asObservable();
 
   private _reportStateSubscription: Subscription | null = null;
   private _migrationSubscription: Subscription | null = null;
@@ -407,11 +408,11 @@ export class RiskInsightsOrchestratorService {
           },
         };
       }),
-      catchError(() => {
+      catchError((): Observable<ReportState> => {
         return of({ loading: false, error: "Failed to generate or save report", data: null });
       }),
-      startWith({ loading: true, error: null, data: null }),
-    ) as Observable<ReportState>;
+      startWith<ReportState>({ loading: true, error: null, data: null }),
+    );
   }
 
   /**
@@ -719,7 +720,7 @@ export class RiskInsightsOrchestratorService {
       initialReportLoad$,
       manualReportFetch$,
       newReportGeneration$,
-      this._markUnmarkUpdatesSubject.asObservable(),
+      this._markUnmarkUpdates$,
     ).pipe(
       scan((prevState: ReportState, currState: ReportState) => ({
         ...prevState,


### PR DESCRIPTION
## 🎟️ Tracking

[27291](https://bitwarden.atlassian.net/browse/PM-27291) and [this comment](https://bitwarden.atlassian.net/browse/PM-27024?focusedCommentId=114797)

## 📔 Objective

## Problem

Critical application flags were being lost when running a new report after marking applications as critical.

**Root Cause:**
Mark/unmark operations were directly updating `_rawReportDataSubject`, bypassing the `mergedReportState$` pipeline. This caused the `scan` operator in `mergedReportState$` to maintain stale `prevState`, which had outdated critical flags (`isCritical: false`). When a new report was generated, it would use this stale state and overwrite the correct critical flags.

## Solution

Introduced `_markUnmarkUpdatesSubject` to funnel all mark/unmark state changes through the `mergedReportState$` pipeline alongside report generation events. This ensures the `scan` operator in `mergedReportState$` sees every state update and maintains accurate `prevState` for proper state merging.

**Changes:**
- Added `_markUnmarkUpdatesSubject: Subject<ReportState>`
- Updated `removeCriticalApplication$` and `saveCriticalApplications$` to emit to `_markUnmarkUpdatesSubject` instead of directly to `_rawReportDataSubject`
- Added `_markUnmarkUpdatesSubject` to the `merge()` operator in `mergedReportState$` pipeline

All state updates now follow a single path: `merge → scan → _rawReportDataSubject`, ensuring consistent state management.


## 📸 Screenshots

See Lotus's [video
](https://bitwarden.atlassian.net/browse/PM-27024?focusedCommentId=114797)
## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-27024]: https://bitwarden.atlassian.net/browse/PM-27024?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ