### PR TITLE
[PM-27338]Provider Portal link from Organization's Subscription page does not route to Provider Portal

### DIFF
--- a/apps/web/src/app/billing/organizations/organization-subscription-cloud.component.html
+++ b/apps/web/src/app/billing/organizations/organization-subscription-cloud.component.html
@@ -223,7 +223,7 @@
       <h2 bitTypography="h2">{{ "manageSubscription" | i18n }}</h2>
       <p bitTypography="body1" *ngIf="userOrg.isProviderUser; else isOrganizationOwner">
         {{ "manageSubscriptionFromThe" | i18n }}
-        <a [routerLink]="['/providers', userOrg.providerId, 'manage-client-organizations']">{{
+        <a [routerLink]="['/providers', userOrg.providerId, 'billing', 'subscription']">{{
           "providerPortal" | i18n
         }}</a
         >.


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-27338

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
The link on the Subscription page of a managed organization no longer takes the user to the Provider Portal’s Subscription Page. Instead the user is redirected back to their Password Manager

**Replication steps**

Currently repro’d in USDEV

Log in as a Provider Admin with a client organization

Go to the Admin Console for that organization

Navigate to Billing → Subscription

Click the Provider Portal link

**Actual Result:**

User is redirected to the Password Manager

**Expected Result:**

User is redirected to the Provider Portal subscription page
## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/5d516cc8-41b9-4769-b618-9308b20ad4bc


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
