### PR TITLE
icons and key connector urls for web development

### DIFF
--- a/apps/web/config/development.json
+++ b/apps/web/config/development.json
@@ -8,6 +8,7 @@
     "proxyIdentity": "http://localhost:33656",
     "proxyEvents": "http://localhost:46273",
     "proxyNotifications": "http://localhost:61840",
+    "proxyIcons": "http://localhost:50024",
     "wsConnectSrc": "ws://localhost:61840"
   },
   "additionalRegions": [

--- a/apps/web/config/selfhosted.json
+++ b/apps/web/config/selfhosted.json
@@ -4,6 +4,7 @@
     "proxyIdentity": "http://localhost:33657",
     "proxyEvents": "http://localhost:46274",
     "proxyNotifications": "http://localhost:61841",
+    "proxyKeyConnector": "http://localhost:5000",
     "port": 8081
   },
   "flags": {}

--- a/apps/web/webpack.base.js
+++ b/apps/web/webpack.base.js
@@ -276,6 +276,13 @@ module.exports.buildConfig = function buildConfig(params) {
               secure: false,
               changeOrigin: true,
             },
+            {
+              context: ["/key-connector"],
+              target: envConfig.dev?.proxyKeyConnector,
+              pathRewrite: { "^/key-connector": "" },
+              secure: false,
+              changeOrigin: true,
+            },
           ],
           headers: (req) => {
             if (!req.originalUrl.includes("connector.html")) {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

In web development environment, cipher icons does not show, due to missing server icon url.
Similarly for key connector, it is much easier for key connector to be under the same hostname.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
