### PR TITLE
[PM-26676] Changing the Org should update the access intelligence report

### DIFF
--- a/bitwarden_license/bit-common/src/dirt/reports/risk-insights/services/domain/risk-insights-orchestrator.service.ts
+++ b/bitwarden_license/bit-common/src/dirt/reports/risk-insights/services/domain/risk-insights-orchestrator.service.ts
@@ -165,6 +165,7 @@ export class RiskInsightsOrchestratorService {
   initializeForOrganization(organizationId: OrganizationId) {
     this.logService.debug("[RiskInsightsOrchestratorService] Initializing for org", organizationId);
     this._initializeOrganizationTriggerSubject.next(organizationId);
+    this.fetchReport();
   }
 
   removeCriticalApplication$(criticalApplication: string): Observable<ReportState> {
@@ -587,7 +588,7 @@ export class RiskInsightsOrchestratorService {
   private _setupEnrichedReportData() {
     // Setup the enriched report data pipeline
     const enrichmentSubscription = combineLatest([
-      this.rawReportData$.pipe(filter((data) => !!data && !!data?.data)),
+      this.rawReportData$,
       this._ciphers$.pipe(filter((data) => !!data)),
     ]).pipe(
       switchMap(([rawReportData, ciphers]) => {
@@ -627,7 +628,7 @@ export class RiskInsightsOrchestratorService {
       .pipe(
         withLatestFrom(this._userId$),
         filter(([orgId, userId]) => !!orgId && !!userId),
-        exhaustMap(([orgId, userId]) =>
+        switchMap(([orgId, userId]) =>
           this.organizationService.organizations$(userId!).pipe(
             getOrganizationById(orgId),
             map((org) => ({ organizationId: orgId!, organizationName: org?.name ?? "" })),
@@ -725,7 +726,7 @@ export class RiskInsightsOrchestratorService {
       scan((prevState: ReportState, currState: ReportState) => ({
         ...prevState,
         ...currState,
-        data: currState.data !== null ? currState.data : prevState.data,
+        data: currState.data,
       })),
       startWith({ loading: false, error: null, data: null }),
       shareReplay({ bufferSize: 1, refCount: true }),


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-26676

## 📔 Objective

When an Organization changes, refresh the Risk Insights report to reflect data for the new org

## 📸 Screenshots

### Page loads with data for an Org that does not have any ciphers
<img width="1984" height="903" alt="image" src="https://github.com/user-attachments/assets/2e7faf01-2e40-4300-9b13-1bbfcf6db1e7" />


### Organization changed and the console logs show the update for new org
<img width="1984" height="903" alt="image" src="https://github.com/user-attachments/assets/c885858b-20d9-40ac-8bc2-c76c792be967" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
