### PR TITLE
Address issues with eslint rules regarding signals and OnPush change detection

### DIFF
--- a/apps/web/src/app/admin-console/organizations/policies/auto-confirm-edit-policy-dialog.component.ts
+++ b/apps/web/src/app/admin-console/organizations/policies/auto-confirm-edit-policy-dialog.component.ts
@@ -63,6 +63,8 @@ export type AutoConfirmPolicyDialogData = PolicyEditDialogData & {
  * Satisfies the PolicyDialogComponent interface structurally
  * via its static open() function.
  */
+// FIXME(https://bitwarden.atlassian.net/browse/CL-764): Migrate to OnPush
+// eslint-disable-next-line @angular-eslint/prefer-on-push-component-change-detection
 @Component({
   templateUrl: "auto-confirm-edit-policy-dialog.component.html",
   imports: [SharedModule],
@@ -73,8 +75,8 @@ export class AutoConfirmPolicyDialogComponent
 {
   policyType = PolicyType;
 
-  protected firstTimeDialog = signal(false);
-  protected currentStep = signal(0);
+  protected readonly firstTimeDialog = signal(false);
+  protected readonly currentStep = signal(0);
   protected multiStepSubmit: Observable<MultiStepSubmit[]> = of([]);
   protected autoConfirmEnabled$: Observable<boolean> = this.accountService.activeAccount$.pipe(
     getUserId,
@@ -82,11 +84,13 @@ export class AutoConfirmPolicyDialogComponent
     map((policies) => policies.find((p) => p.type === PolicyType.AutoConfirm)?.enabled ?? false),
   );
 
-  private submitPolicy: Signal<TemplateRef<unknown> | undefined> = viewChild("step0");
-  private openExtension: Signal<TemplateRef<unknown> | undefined> = viewChild("step1");
+  private readonly submitPolicy: Signal<TemplateRef<unknown> | undefined> = viewChild("step0");
+  private readonly openExtension: Signal<TemplateRef<unknown> | undefined> = viewChild("step1");
 
-  private submitPolicyTitle: Signal<TemplateRef<unknown> | undefined> = viewChild("step0Title");
-  private openExtensionTitle: Signal<TemplateRef<unknown> | undefined> = viewChild("step1Title");
+  private readonly submitPolicyTitle: Signal<TemplateRef<unknown> | undefined> =
+    viewChild("step0Title");
+  private readonly openExtensionTitle: Signal<TemplateRef<unknown> | undefined> =
+    viewChild("step1Title");
 
   override policyComponent: AutoConfirmPolicyEditComponent | undefined;
 

--- a/apps/web/src/app/admin-console/organizations/policies/policy-edit-definitions/auto-confirm-policy.component.ts
+++ b/apps/web/src/app/admin-console/organizations/policies/policy-edit-definitions/auto-confirm-policy.component.ts
@@ -26,14 +26,16 @@ export class AutoConfirmPolicy extends BasePolicyEditDefinition {
   }
 }
 
+// FIXME(https://bitwarden.atlassian.net/browse/CL-764): Migrate to OnPush
+// eslint-disable-next-line @angular-eslint/prefer-on-push-component-change-detection
 @Component({
   templateUrl: "auto-confirm-policy.component.html",
   imports: [SharedModule],
 })
 export class AutoConfirmPolicyEditComponent extends BasePolicyEditComponent implements OnInit {
   protected readonly autoConfirmSvg = AutoConfirmSvg;
-  private policyForm: Signal<TemplateRef<any> | undefined> = viewChild("step0");
-  private extensionButton: Signal<TemplateRef<any> | undefined> = viewChild("step1");
+  private readonly policyForm: Signal<TemplateRef<any> | undefined> = viewChild("step0");
+  private readonly extensionButton: Signal<TemplateRef<any> | undefined> = viewChild("step1");
 
   protected step: number = 0;
   protected steps = [this.policyForm, this.extensionButton];


### PR DESCRIPTION
## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Fix some eslint issues that cause to be shown on various PRs as changes, when merging from main
Example: https://github.com/bitwarden/clients/pull/16664/files#diff-e0ca486abf0eb82c8d795259bafee54de96acafac28cb19e558f222be39429f0
## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
