### PR TITLE
Remove deprecated keypress event from simulated KeyboardEvents

### DIFF
--- a/apps/browser/src/autofill/services/insert-autofill-content.service.spec.ts
+++ b/apps/browser/src/autofill/services/insert-autofill-content.service.spec.ts
@@ -26,7 +26,6 @@ const eventsToTest = [
   EVENTS.CHANGE,
   EVENTS.INPUT,
   EVENTS.KEYDOWN,
-  EVENTS.KEYPRESS,
   EVENTS.KEYUP,
   "blur",
   "click",
@@ -1044,13 +1043,13 @@ describe("InsertAutofillContentService", () => {
   });
 
   describe("simulateUserKeyboardEventInteractions", () => {
-    it("will trigger `keydown`, `keypress`, and `keyup` events on the passed element", () => {
+    it("will trigger `keydown` and `keyup` events on the passed element", () => {
       const inputElement = document.querySelector('input[type="text"]') as HTMLInputElement;
       jest.spyOn(inputElement, "dispatchEvent");
 
       insertAutofillContentService["simulateUserKeyboardEventInteractions"](inputElement);
 
-      [EVENTS.KEYDOWN, EVENTS.KEYPRESS, EVENTS.KEYUP].forEach((eventName) => {
+      [EVENTS.KEYDOWN, EVENTS.KEYUP].forEach((eventName) => {
         expect(inputElement.dispatchEvent).toHaveBeenCalledWith(
           new KeyboardEvent(eventName, { bubbles: true }),
         );

--- a/apps/browser/src/autofill/services/insert-autofill-content.service.ts
+++ b/apps/browser/src/autofill/services/insert-autofill-content.service.ts
@@ -349,7 +349,7 @@ class InsertAutofillContentService implements InsertAutofillContentServiceInterf
    * @private
    */
   private simulateUserKeyboardEventInteractions(element: FormFieldElement): void {
-    const simulatedKeyboardEvents = [EVENTS.KEYDOWN, EVENTS.KEYPRESS, EVENTS.KEYUP];
+    const simulatedKeyboardEvents = [EVENTS.KEYDOWN, EVENTS.KEYUP];
     for (let index = 0; index < simulatedKeyboardEvents.length; index++) {
       element.dispatchEvent(new KeyboardEvent(simulatedKeyboardEvents[index], { bubbles: true }));
     }


### PR DESCRIPTION
## 🎟️ Tracking

[<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
](https://bitwarden.atlassian.net/browse/PM-24446)

## 📔 Objective

This PR prevents any site from using the default '0' keycode value of a keypress KeyboardEvent from triggering unspecified behavior (such as auto-submit). A further rationale behind removing this the event is that keypress is also currently deprecated (see [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Element/keypress_event)) and may cease to work at any time.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
