### PR TITLE
[PM-27501] Do not try to format cards that are in an unknown format

### DIFF
--- a/libs/angular/src/pipes/credit-card-number.pipe.ts
+++ b/libs/angular/src/pipes/credit-card-number.pipe.ts
@@ -42,9 +42,9 @@ export class CreditCardNumberPipe implements PipeTransform {
 
     const cardLength = creditCardNumber.length;
 
-    let matchingRule = rules.find((r) => r.cardLength == cardLength);
+    const matchingRule = rules.find((r) => r.cardLength == cardLength);
     if (matchingRule == null) {
-      matchingRule = rules[0];
+      return creditCardNumber;
     }
 
     const blocks = matchingRule.blocks;


### PR DESCRIPTION
## 🎟️ Tracking
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
Currently, the application attempts to format all card numbers, even when they don't match any known card format. This leads to incorrect results.  

For example, if a Visa card is added with the already formatted number `1234 5678 1234 5678`, then the application reformats it incorrectly, producing this:
<img width="352" height="70" alt="image" src="https://github.com/user-attachments/assets/c076e7eb-87e0-4c06-a9dd-f892931693ec" />

In this case, it would have been better to preserve the user's input, since it already was properly formatted.

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR changes the behavior so that unknown card formats are no longer reformatted. If the card number doesn't match any known pattern, the application will simply display it exactly as entered.

## 📸 Screenshots
<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
Before:
<img width="352" height="70" alt="image" src="https://github.com/user-attachments/assets/c076e7eb-87e0-4c06-a9dd-f892931693ec" />

After:
<img width="352" height="70" alt="image" src="https://github.com/user-attachments/assets/86bed4e6-9519-4831-9883-1b800b567ea3" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
