### PR TITLE
[PM 27535] Update the Subscription page for Families Trial

### DIFF
--- a/apps/web/src/app/billing/individual/premium/premium-vnext.component.html
+++ b/apps/web/src/app/billing/individual/premium/premium-vnext.component.html
@@ -38,7 +38,7 @@
           <billing-pricing-card
             [tagline]="'planDescFamiliesV2' | i18n"
             [price]="{ amount: familiesData.price, cadence: 'monthly' }"
-            [button]="{ type: 'secondary', text: ('upgradeToFamilies' | i18n) }"
+            [button]="{ type: 'secondary', text: ('startFreeFamiliesTrial' | i18n) }"
             [features]="familiesData.features"
             (buttonClick)="openUpgradeDialog('Families')"
           >

--- a/apps/web/src/app/billing/individual/upgrade/upgrade-account/upgrade-account.component.spec.ts
+++ b/apps/web/src/app/billing/individual/upgrade/upgrade-account/upgrade-account.component.spec.ts
@@ -98,7 +98,7 @@ describe("UpgradeAccountComponent", () => {
     expect(sut["familiesCardDetails"].price.amount).toBe(40 / 12);
     expect(sut["familiesCardDetails"].price.cadence).toBe("monthly");
     expect(sut["familiesCardDetails"].button.type).toBe("secondary");
-    expect(sut["familiesCardDetails"].button.text).toBe("upgradeToFamilies");
+    expect(sut["familiesCardDetails"].button.text).toBe("startFreeFamiliesTrial");
     expect(sut["familiesCardDetails"].features).toEqual(["Feature A", "Feature B", "Feature C"]);
   });
 

--- a/apps/web/src/app/billing/individual/upgrade/upgrade-account/upgrade-account.component.ts
+++ b/apps/web/src/app/billing/individual/upgrade/upgrade-account/upgrade-account.component.ts
@@ -119,7 +119,7 @@ export class UpgradeAccountComponent implements OnInit {
       },
       button: {
         text: this.i18nService.t(
-          this.isFamiliesPlan(tier.id) ? "upgradeToFamilies" : "upgradeToPremium",
+          this.isFamiliesPlan(tier.id) ? "startFreeFamiliesTrial" : "upgradeToPremium",
         ),
         type: buttonType,
       },

--- a/apps/web/src/app/billing/individual/upgrade/upgrade-payment/upgrade-payment.component.ts
+++ b/apps/web/src/app/billing/individual/upgrade/upgrade-payment/upgrade-payment.component.ts
@@ -161,7 +161,7 @@ export class UpgradePaymentComponent implements OnInit, AfterViewInit {
         };
 
         this.upgradeToMessage = this.i18nService.t(
-          this.isFamiliesPlan ? "upgradeToFamilies" : "upgradeToPremium",
+          this.isFamiliesPlan ? "startFreeFamiliesTrial" : "upgradeToPremium",
         );
       } else {
         this.complete.emit({ status: UpgradePaymentStatus.Closed, organizationId: null });

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -11975,5 +11975,8 @@
   },
   "cardNumberLabel": {
     "message": "Card number"
+  },
+  "startFreeFamiliesTrial": {
+    "message": "Start free Families trial"
   }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-27535
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
The Premium Settings > Subscription page will need to be updated to match the new Figma design. Rather than Upgrade to Families, the card should state “Start free Families trial” and once clicking to upgrade, the payment page should state “Start free Families trial” as well. 

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
<img width="1728" height="1117" alt="Screenshot 2025-10-29 at 10 36 30 AM" src="https://github.com/user-attachments/assets/9e293cd8-9275-4dbd-92d3-82e749908d44" />
<img width="1728" height="1117" alt="Screenshot 2025-10-29 at 10 34 41 AM" src="https://github.com/user-attachments/assets/02b65135-d420-47da-b4ca-6cb38f21cd26" />
<img width="1728" height="1117" alt="Screenshot 2025-10-29 at 10 34 31 AM" src="https://github.com/user-attachments/assets/fc283516-0ba9-4f7e-863d-b9638df8c725" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
