### PR TITLE
PM-23810 [error: cannot decrypt] shows in Member Access Report

### DIFF
--- a/bitwarden_license/bit-web/src/app/dirt/reports/member-access-report/services/member-access-report.service.spec.ts
+++ b/bitwarden_license/bit-web/src/app/dirt/reports/member-access-report/services/member-access-report.service.spec.ts
@@ -2,7 +2,6 @@ import { mock } from "jest-mock-extended";
 import { of } from "rxjs";
 
 import { EncryptService } from "@bitwarden/common/key-management/crypto/abstractions/encrypt.service";
-import { EncString } from "@bitwarden/common/key-management/crypto/models/enc-string";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
 import { mockAccountServiceWith } from "@bitwarden/common/spec";
@@ -164,50 +163,6 @@ describe("ImportService", () => {
           }),
         ]),
       );
-    });
-
-    it("should handle decryption errors by setting collection name to null", async () => {
-      const mockReportWithDecryptionError = [
-        {
-          userName: "Test User",
-          email: "test@email.com",
-          twoFactorEnabled: false,
-          accountRecoveryEnabled: false,
-          userGuid: "test-guid",
-          usesKeyConnector: false,
-          groupId: "g1",
-          collectionId: "c1",
-          groupName: "Test Group",
-          collectionName: {
-            encryptedString: "encrypted-collection-name",
-          },
-          itemCount: 5,
-          readOnly: false,
-          hidePasswords: false,
-          manage: false,
-          cipherIds: [] as string[],
-        },
-      ];
-
-      reportApiService.getMemberAccessData.mockImplementation(() =>
-        Promise.resolve(mockReportWithDecryptionError as any),
-      );
-
-      // Mock the EncString decrypt behavior to set decryptedValue to the error message
-      jest.spyOn(EncString.prototype, "decrypt").mockImplementation(async function (
-        this: EncString,
-        _orgId: string | null,
-        _key?: SymmetricCryptoKey | null,
-        _context?: string,
-      ) {
-        this.decryptedValue = "[error: cannot decrypt]";
-        return "[error: cannot decrypt]";
-      });
-
-      const result =
-        await memberAccessReportService.generateUserReportExportItems(mockOrganizationId);
-
-      expect(result[0].collection).toBe("memberAccessReportNoCollection");
     });
   });
 });

--- a/bitwarden_license/bit-web/src/app/dirt/reports/member-access-report/services/member-access-report.service.ts
+++ b/bitwarden_license/bit-web/src/app/dirt/reports/member-access-report/services/member-access-report.service.ts
@@ -95,7 +95,7 @@ export class MemberAccessReportService {
     const collectionNames = memberAccessReports.map((item) => item.collectionName.encryptedString);
 
     const collectionNameMap = new Map(
-      collectionNames.filter((col) => col != null).map((col) => [col, ""]),
+      collectionNames.filter((col) => col !== null).map((col) => [col, ""]),
     );
     for await (const key of collectionNameMap.keys()) {
       const encryptedCollectionName = new EncString(key);


### PR DESCRIPTION
## 🎟️ Tracking

[PM-23810](https://bitwarden.atlassian.net/jira/software/c/projects/BW/boards/222?assignee=712020%3Aa479bb6c-74c0-4e0d-bd65-bc64b95c604a&selectedIssue=PM-23810)

## 📔 Objective

Fixes a user experience with the member access report csv export. CSV export shows a '[error: cannot decrypt]' value under the 'Collection' column when a user is not a part of any collections or groups in a organization.

## 📸 Screenshots

Before:
<img width="1122" height="32" alt="image" src="https://github.com/user-attachments/assets/f84785ae-5a24-4f28-abf4-ebe21bc9e175" />

After:
<img width="1121" height="26" alt="image" src="https://github.com/user-attachments/assets/a9ffd623-971d-4b8f-94e7-bc5852ff193c" />


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-23810]: https://bitwarden.atlassian.net/browse/PM-23810?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ