### PR TITLE
[PM-27620][PM-27642] - [Defect] Org user should not have option to "Autofill and add this website" for a login with View permissions

### DIFF
--- a/apps/browser/src/vault/popup/components/vault-v2/autofill-confirmation-dialog/autofill-confirmation-dialog.component.html
+++ b/apps/browser/src/vault/popup/components/vault-v2/autofill-confirmation-dialog/autofill-confirmation-dialog.component.html
@@ -48,11 +48,13 @@
       </div>
     </bit-callout>
     <div class="tw-flex tw-justify-center tw-flex-col tw-gap-3 tw-mt-6">
-      <button type="button" bitButton buttonType="primary" (click)="autofillAndAddUrl()">
-        {{ "autofillAndAddWebsite" | i18n }}
-      </button>
+      @if (!viewOnly) {
+        <button type="button" bitButton buttonType="primary" (click)="autofillAndAddUrl()">
+          {{ "autofillAndAddWebsite" | i18n }}
+        </button>
+      }
       <button type="button" bitButton buttonType="secondary" (click)="autofillOnly()">
-        {{ "autofillWithoutAdding" | i18n }}
+        {{ (viewOnly ? "autofill" : "autofillWithoutAdding") | i18n }}
       </button>
       <button
         type="button"

--- a/apps/browser/src/vault/popup/components/vault-v2/autofill-confirmation-dialog/autofill-confirmation-dialog.component.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/autofill-confirmation-dialog/autofill-confirmation-dialog.component.ts
@@ -19,6 +19,7 @@ import {
 export interface AutofillConfirmationDialogParams {
   savedUrls?: string[];
   currentUrl: string;
+  viewOnly?: boolean;
 }
 
 export const AutofillConfirmationDialogResult = Object.freeze({
@@ -50,12 +51,14 @@ export class AutofillConfirmationDialogComponent {
   currentUrl: string = "";
   savedUrls: string[] = [];
   savedUrlsExpanded = false;
+  viewOnly: boolean = false;
 
   constructor(
     @Inject(DIALOG_DATA) protected params: AutofillConfirmationDialogParams,
     private dialogRef: DialogRef,
   ) {
     this.currentUrl = Utils.getHostname(params.currentUrl);
+    this.viewOnly = params.viewOnly ?? false;
     this.savedUrls =
       params.savedUrls?.map((url) => Utils.getHostname(url) ?? "").filter(Boolean) ?? [];
   }

--- a/apps/browser/src/vault/popup/components/vault-v2/item-more-options/item-more-options.component.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/item-more-options/item-more-options.component.ts
@@ -202,6 +202,10 @@ export class ItemMoreOptionsComponent {
   async doAutofill() {
     const cipher = await this.cipherService.getFullCipherView(this.cipher);
 
+    if (!(await this.passwordRepromptService.passwordRepromptCheck(this.cipher))) {
+      return;
+    }
+
     const showAutofillConfirmation = await firstValueFrom(this.showAutofillConfirmation$);
 
     if (!showAutofillConfirmation) {
@@ -236,6 +240,7 @@ export class ItemMoreOptionsComponent {
       data: {
         currentUrl: currentTab?.url || "",
         savedUrls: cipher.login?.uris?.filter((u) => u.uri).map((u) => u.uri!) ?? [],
+        viewOnly: !this.cipher.edit,
       },
     });
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-27620
https://bitwarden.atlassian.net/browse/PM-27642

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR does the following:


- view only users should no longer see the "Autofill and add website" button as they don't have write access to items.
- the "Autofill without adding" button language is adjusted to simply read "Autofill" for view only users
- MP reprompt will occur before the confirmation dialog is shown if it's enabled on an item

Specs were adjusted to reflect these new changes. Some changes to wording was done to more accurately describe the scenarios.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/65b44276-e75d-41a8-a11b-b7121e6d2ab9



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
