### PR TITLE
[PM-27141] Cancel new cipher on desktop

### DIFF
--- a/apps/desktop/src/vault/app/vault/vault-v2.component.ts
+++ b/apps/desktop/src/vault/app/vault/vault-v2.component.ts
@@ -792,7 +792,7 @@ export class VaultV2Component<C extends CipherViewLike>
   async cancelCipher(cipher: CipherView) {
     this.cipherId = cipher.id;
     this.cipher = cipher;
-    this.action = this.cipherId != null ? "view" : null;
+    this.action = this.cipherId ? "view" : null;
     await this.go().catch(() => {});
   }
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-27141](https://bitwarden.atlassian.net/browse/PM-27141)

## 📔 Objective

As a part of https://github.com/bitwarden/clients/pull/16463, `cipher.id` was changed from `null` to an empty string for new ciphers. The `cancelCipher` was checking for `null`/`undefined` resulting in an empty view state. I changed it to only show the view when the cipherId is truthy.

## 📸 Screenshots

|Before|After|
|-|-|
|<video src="https://github.com/user-attachments/assets/4855be89-493e-405d-9c40-56efdd375480" />|<video src="https://github.com/user-attachments/assets/1f672dd9-4d74-4409-9c4f-0026eb7a522a" />|

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes



[PM-27141]: https://bitwarden.atlassian.net/browse/PM-27141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ