### PR TITLE
[PM-27648] [Defect] The .zip option is displayed on organizational export in Admin Console

### DIFF
--- a/libs/tools/export/vault-export/vault-export-ui/src/components/export.component.ts
+++ b/libs/tools/export/vault-export/vault-export-ui/src/components/export.component.ts
@@ -356,7 +356,7 @@ export class ExportComponent implements OnInit, OnDestroy, AfterViewInit {
         // Admin Console: organizationId is already set via @Input, no update needed
       });
 
-    // Step 2: Set up dynamic format options based on the organizationId observable
+    // Set up dynamic format options based on the organizationId observable
     // This is the single source of truth for both export contexts
     this.formatOptions$ = this._organizationId$.pipe(
       map((organizationId) => {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-27648?atlOrigin=eyJpIjoiZDdjMzBkZjNiZDI0NGUyNjlmZWIxZjBlNTQ0ODlkNGYiLCJwIjoiaiJ9

## 📔 Objective

• Prevent the Admin Console from displaying a .zip file export option for an organizational import 
• Also fixes a related issue where the Admin Console would display a callout describing an individual vault export 
 
## 📸 Screenshots

<img width="1181" height="664" alt="image" src="https://github.com/user-attachments/assets/a76f9db7-1827-4aaa-be20-2912368a1811" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
