### PR TITLE
[PM-27500] Fix unassign item edit bug

### DIFF
--- a/libs/common/src/abstractions/api.service.ts
+++ b/libs/common/src/abstractions/api.service.ts
@@ -91,7 +91,7 @@ import { CipherShareRequest } from "../vault/models/request/cipher-share.request
 import { CipherRequest } from "../vault/models/request/cipher.request";
 import { AttachmentUploadDataResponse } from "../vault/models/response/attachment-upload-data.response";
 import { AttachmentResponse } from "../vault/models/response/attachment.response";
-import { CipherResponse } from "../vault/models/response/cipher.response";
+import { CipherMiniResponse, CipherResponse } from "../vault/models/response/cipher.response";
 import { OptionalCipherResponse } from "../vault/models/response/optional-cipher.response";
 
 /**
@@ -215,7 +215,10 @@ export abstract class ApiService {
     id: string,
     request: CipherCollectionsRequest,
   ): Promise<OptionalCipherResponse>;
-  abstract putCipherCollectionsAdmin(id: string, request: CipherCollectionsRequest): Promise<any>;
+  abstract putCipherCollectionsAdmin(
+    id: string,
+    request: CipherCollectionsRequest,
+  ): Promise<CipherMiniResponse>;
   abstract postPurgeCiphers(
     request: SecretVerificationRequest,
     organizationId?: string,

--- a/libs/common/src/vault/models/response/cipher.response.ts
+++ b/libs/common/src/vault/models/response/cipher.response.ts
@@ -14,6 +14,11 @@ import { SshKeyApi } from "../api/ssh-key.api";
 import { AttachmentResponse } from "./attachment.response";
 import { PasswordHistoryResponse } from "./password-history.response";
 
+export type CipherMiniResponse = Omit<
+  CipherResponse,
+  "edit" | "viewPassword" | "folderId" | "favorite" | "permissions"
+>;
+
 export class CipherResponse extends BaseResponse {
   id: string;
   organizationId: string;

--- a/libs/common/src/vault/services/cipher.service.ts
+++ b/libs/common/src/vault/services/cipher.service.ts
@@ -1117,7 +1117,13 @@ export class CipherService implements CipherServiceAbstraction {
   async saveCollectionsWithServerAdmin(cipher: Cipher): Promise<Cipher> {
     const request = new CipherCollectionsRequest(cipher.collectionIds);
     const response = await this.apiService.putCipherCollectionsAdmin(cipher.id, request);
-    const data = new CipherData(response);
+    // The response will be incomplete with several properties missing values
+    // We will assign those properties values so the SDK decryption can complete
+    const completedResponse = new CipherResponse(response);
+    completedResponse.edit = true;
+    completedResponse.viewPassword = true;
+    completedResponse.favorite = false;
+    const data = new CipherData(completedResponse);
     return new Cipher(data);
   }
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-27500](https://bitwarden.atlassian.net/browse/PM-27500)

## 📔 Objective

The `putCipherCollectionsAdmin` response was missing required keys, causing the SDK to throw decryption errors and display error notifications to users.

Updated `saveCollectionsWithServerAdmin` to ensure the response contains a fully populated cipher object before passing it to the SDK.

## 📸 Screen Recording

https://github.com/user-attachments/assets/5dcd62d8-7c9b-4196-99aa-cf037c07d165


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-27500]: https://bitwarden.atlassian.net/browse/PM-27500?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ