### PR TITLE
Desktop native disallow log crate macros

### DIFF
--- a/apps/desktop/desktop_native/Cargo.lock
+++ b/apps/desktop/desktop_native/Cargo.lock
@@ -454,7 +454,6 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "verifysign",
  "windows 0.61.1",
 ]
 
@@ -621,6 +620,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "verifysign",
  "windows 0.61.1",
 ]
 

--- a/apps/desktop/desktop_native/Cargo.toml
+++ b/apps/desktop/desktop_native/Cargo.toml
@@ -86,10 +86,13 @@ zbus_polkit = "=5.0.0"
 zeroizing-alloc = "=0.1.0"
 
 [workspace.lints.clippy]
+disallowed-macros = "deny"
+
 # Dis-allow println and eprintln, which are typically used in debugging.
 # Use `tracing` and `tracing-subscriber` crates for observability needs.
 print_stderr = "deny"
 print_stdout = "deny"
+
 string_slice = "warn"
 unused_async = "deny"
 unwrap_used = "deny"

--- a/apps/desktop/desktop_native/clippy.toml
+++ b/apps/desktop/desktop_native/clippy.toml
@@ -1,2 +1,10 @@
 allow-unwrap-in-tests=true
 allow-expect-in-tests=true
+
+disallowed-macros = [
+  { path = "log::trace", reason = "Use tracing for logging needs", replacement = "tracing::trace" },
+  { path = "log::debug", reason = "Use tracing for logging needs", replacement = "tracing::debug" },
+  { path = "log::info", reason = "Use tracing for logging needs", replacement = "tracing::info" },
+  { path = "log::warn", reason = "Use tracing for logging needs", replacement = "tracing::warn" },
+  { path = "log::error", reason = "Use tracing for logging needs", replacement = "tracing::error" },
+]

--- a/apps/desktop/desktop_native/macos_provider/src/lib.rs
+++ b/apps/desktop/desktop_native/macos_provider/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg(target_os = "macos")]
+#![allow(clippy::disallowed_macros)] // uniffi macros trip up clippy's evaluation
 
 use std::{
     collections::HashMap,


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-27665

## 📔 Objective

As part of https://github.com/bitwarden/clients/pull/16321 , adding a clippy check to help steer developers to use `tracing` instead of `log` as part of our standardization on the tracing crate.

Note that the `uniffi` macros created a false positive so I added an allow to that workspace member, this was the cleanest way I could see to handle that.

This felt like the most straightforward solution to the problem. If we wanted to be really thorough we could create a CI job that runs a script to grep for usages of the log crate in Cargo.toml and or in the code but that seems brittle.

I'd originally intended to use cargo-deny for this but I found out that there is no way for cargo-deny to skip recursing into dependencies so that became a non-viable solution, because we have dep crates that use `log` (and that's not something we want to prevent)

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
