### PR TITLE
Update pinned taiki-e/install-action and cargo-deny versions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -119,9 +119,9 @@ jobs:
         run: cargo sort --workspace --check
 
       - name: Install cargo-deny
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@81ee1d48d9194cdcab880cbdc7d36e87d39874cb # v2.62.45
         with:
-          tool: cargo-deny
+          tool: cargo-deny@0.18.5
 
       - name: Run cargo deny
         working-directory: ./apps/desktop/desktop_native


### PR DESCRIPTION
## 📔 Objective

Temporarily, bwwl was not linting properly. During that period, #16935 was merged with outstanding issues. Afterwards, @hinton found the merge and notified @team-appsec so we could fix the underlying issues. 

This PR should clean up this repository's issues:

* Pinning the `taiki-e/install-action` action to a specific hash
* Pinning the `cargo-deny` tool to a specific version

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
