### PR TITLE
[PM-26676] Replace Drawer with Dialog

### DIFF
--- a/bitwarden_license/bit-common/src/dirt/reports/risk-insights/services/domain/risk-insights-orchestrator.service.ts
+++ b/bitwarden_license/bit-common/src/dirt/reports/risk-insights/services/domain/risk-insights-orchestrator.service.ts
@@ -165,6 +165,7 @@ export class RiskInsightsOrchestratorService {
   initializeForOrganization(organizationId: OrganizationId) {
     this.logService.debug("[RiskInsightsOrchestratorService] Initializing for org", organizationId);
     this._initializeOrganizationTriggerSubject.next(organizationId);
+    this.fetchReport();
   }
 
   removeCriticalApplication$(criticalApplication: string): Observable<ReportState> {
@@ -587,7 +588,7 @@ export class RiskInsightsOrchestratorService {
   private _setupEnrichedReportData() {
     // Setup the enriched report data pipeline
     const enrichmentSubscription = combineLatest([
-      this.rawReportData$.pipe(filter((data) => !!data && !!data?.data)),
+      this.rawReportData$,
       this._ciphers$.pipe(filter((data) => !!data)),
     ]).pipe(
       switchMap(([rawReportData, ciphers]) => {
@@ -627,7 +628,7 @@ export class RiskInsightsOrchestratorService {
       .pipe(
         withLatestFrom(this._userId$),
         filter(([orgId, userId]) => !!orgId && !!userId),
-        exhaustMap(([orgId, userId]) =>
+        switchMap(([orgId, userId]) =>
           this.organizationService.organizations$(userId!).pipe(
             getOrganizationById(orgId),
             map((org) => ({ organizationId: orgId!, organizationName: org?.name ?? "" })),
@@ -725,7 +726,7 @@ export class RiskInsightsOrchestratorService {
       scan((prevState: ReportState, currState: ReportState) => ({
         ...prevState,
         ...currState,
-        data: currState.data !== null ? currState.data : prevState.data,
+        data: currState.data,
       })),
       startWith({ loading: false, error: null, data: null }),
       shareReplay({ bufferSize: 1, refCount: true }),


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-23375

## 📔 Objective

The Drawer component has been deprecated and instead we need to use the dialog service.
This PR removes the drawer component from Risk Insights and uses the dialog component instead.

## 📸 Screenshots

### Using dialog classes
<img width="1706" height="657" alt="image" src="https://github.com/user-attachments/assets/a9e3ed4d-c829-4114-9092-7cc3da3e93c6" />

### Org At Risk Members
<img width="1371" height="790" alt="image" src="https://github.com/user-attachments/assets/c08a63b2-62fd-448e-9b9a-5858c2519f9f" />

### Org At Risk Apps
<img width="1371" height="790" alt="image" src="https://github.com/user-attachments/assets/4b5227c4-fe67-4a57-8a11-2246800122f4" />

### App At risk members
<img width="1371" height="790" alt="image" src="https://github.com/user-attachments/assets/8c699605-58f7-44ce-8413-a950dacc18ab" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
