### PR TITLE
[PM-26908] feature flag for empty state component

### DIFF
--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/risk-insights.component.html
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/risk-insights.component.html
@@ -41,70 +41,40 @@
           <div class="tw-text-main tw-max-w-4xl tw-mb-2" *ngIf="appsCount > 0">
             {{ "reviewAtRiskPasswords" | i18n }}
           </div>
-          @if (dataLastUpdated) {
-            <div
-              class="tw-bg-primary-100 tw-rounded-lg tw-w-full tw-px-8 tw-py-4 tw-my-4 tw-flex tw-items-center"
-            >
-              <i
-                class="bwi bwi-exclamation-triangle bwi-lg tw-text-[1.2rem] tw-text-muted"
-                aria-hidden="true"
-              ></i>
+          @let isRunningReport = dataService.isGeneratingReport$ | async;
+          <div
+            class="tw-bg-primary-100 tw-rounded-lg tw-w-full tw-px-8 tw-py-4 tw-my-4 tw-flex tw-items-center"
+          >
+            <i
+              class="bwi bwi-exclamation-triangle bwi-lg tw-text-[1.2rem] tw-text-muted"
+              aria-hidden="true"
+            ></i>
+            @if (dataLastUpdated) {
               <span class="tw-mx-4">{{
                 "dataLastUpdated" | i18n: (dataLastUpdated | date: "MMMM d, y 'at' h:mm a")
               }}</span>
-              @let isRunningReport = dataService.isGeneratingReport$ | async;
-              <span class="tw-flex tw-justify-center">
-                <button
-                  *ngIf="!isRunningReport"
-                  type="button"
-                  bitButton
-                  buttonType="secondary"
-                  class="tw-border-none !tw-font-normal tw-cursor-pointer !tw-py-0"
-                  tabindex="0"
-                  [bitAction]="generateReport.bind(this)"
-                >
-                  {{ "riskInsightsRunReport" | i18n }}
-                </button>
-                <span>
-                  <i
-                    *ngIf="isRunningReport"
-                    class="bwi bwi-spinner bwi-spin tw-text-muted tw-text-[1.2rem]"
-                    aria-hidden="true"
-                  ></i>
-                </span>
+            }
+            <span class="tw-flex tw-justify-center">
+              <button
+                *ngIf="!isRunningReport"
+                type="button"
+                bitButton
+                buttonType="secondary"
+                class="tw-border-none !tw-font-normal tw-cursor-pointer !tw-py-0"
+                tabindex="0"
+                [bitAction]="generateReport.bind(this)"
+              >
+                {{ "riskInsightsRunReport" | i18n }}
+              </button>
+              <span>
+                <i
+                  *ngIf="isRunningReport"
+                  class="bwi bwi-spinner bwi-spin tw-text-muted tw-text-[1.2rem]"
+                  aria-hidden="true"
+                ></i>
               </span>
-            </div>
-          } @else {
-            @let isRunningReport = dataService.isGeneratingReport$ | async;
-            <div
-              class="tw-bg-primary-100 tw-rounded-lg tw-w-full tw-px-8 tw-py-4 tw-my-4 tw-flex tw-items-center"
-            >
-              <i
-                class="bwi bwi-exclamation-triangle bwi-lg tw-text-[1.2rem] tw-text-muted"
-                aria-hidden="true"
-              ></i>
-              <span class="tw-flex tw-justify-center">
-                <button
-                  *ngIf="!isRunningReport"
-                  type="button"
-                  bitButton
-                  buttonType="secondary"
-                  class="tw-border-none !tw-font-normal tw-cursor-pointer !tw-py-0"
-                  tabindex="0"
-                  [bitAction]="generateReport.bind(this)"
-                >
-                  {{ "riskInsightsRunReport" | i18n }}
-                </button>
-                <span>
-                  <i
-                    *ngIf="isRunningReport"
-                    class="bwi bwi-spinner bwi-spin tw-text-muted tw-text-[1.2rem]"
-                    aria-hidden="true"
-                  ></i>
-                </span>
-              </span>
-            </div>
-          }
+            </span>
+          </div>
         </div>
 
         <div class="tw-flex-1 tw-flex tw-flex-col">


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-26908

## 📔 Objective

We want the empty state component (no report data, no cipher data) to be behind the activity tab feature flag.

## 📸 Screenshots

No report data case:

<img width="2978" height="1420" alt="image" src="https://github.com/user-attachments/assets/bf687d00-c1a4-4b04-8fcb-e00b5c8b1e27" />


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
