### PR TITLE
[PM-27132] Missing cache website

### DIFF
--- a/libs/vault/src/cipher-form/components/autofill-options/autofill-options.component.spec.ts
+++ b/libs/vault/src/cipher-form/components/autofill-options/autofill-options.component.spec.ts
@@ -39,7 +39,8 @@ describe("AutofillOptionsComponent", () => {
 
   beforeEach(async () => {
     getInitialCipherView.mockClear();
-    cipherFormContainer = mock<CipherFormContainer>({ getInitialCipherView, formStatusChange$ });
+    cipherFormContainer = mock<CipherFormContainer>({ getInitialCipherView });
+    cipherFormContainer.formStatusChange$ = formStatusChange$.asObservable();
     liveAnnouncer = mock<LiveAnnouncer>();
     platformUtilsService = mock<PlatformUtilsService>();
     domainSettingsService = mock<DomainSettingsService>();
@@ -264,6 +265,23 @@ describe("AutofillOptionsComponent", () => {
     fixture.detectChanges();
 
     expect(component.autofillOptionsForm.value.uris.length).toEqual(1);
+  });
+
+  it("does not emit events when status changes to prevent a `valueChanges` call", () => {
+    fixture.detectChanges();
+
+    const enable = jest.spyOn(component.autofillOptionsForm, "enable");
+    const disable = jest.spyOn(component.autofillOptionsForm, "disable");
+
+    formStatusChange$.next("disabled");
+    fixture.detectChanges();
+
+    expect(disable).toHaveBeenCalledWith({ emitEvent: false });
+
+    formStatusChange$.next("enabled");
+    fixture.detectChanges();
+
+    expect(enable).toHaveBeenCalledWith({ emitEvent: false });
   });
 
   describe("Drag & Drop Functionality", () => {

--- a/libs/vault/src/cipher-form/components/autofill-options/autofill-options.component.ts
+++ b/libs/vault/src/cipher-form/components/autofill-options/autofill-options.component.ts
@@ -140,9 +140,9 @@ export class AutofillOptionsComponent implements OnInit {
     this.cipherFormContainer.formStatusChange$.pipe(takeUntilDestroyed()).subscribe((status) => {
       // Disable adding new URIs when the cipher form is disabled
       if (status === "disabled") {
-        this.autofillOptionsForm.disable();
+        this.autofillOptionsForm.disable({ emitEvent: false });
       } else if (!this.isPartialEdit) {
-        this.autofillOptionsForm.enable();
+        this.autofillOptionsForm.enable({ emitEvent: false });
       }
     });
   }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-27132](https://bitwarden.atlassian.net/browse/PM-27132)

## 📔 Objective

When opening the edit cipher screen after the extension loses focus, any associated URIs for a cipher were not being shown from the cached value. The `statusChange` event was triggering a valueChanges emission and thus causing the default state of the form to overwrite existing data. `{ emitEvent: false }` remediates the issue and stops a `valueChanges` from being emitted on the form.  

## 📸 Screenshots

<video src="https://github.com/user-attachments/assets/847a56e1-71eb-4d01-b23b-b93a4e7e34e6" />

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-27132]: https://bitwarden.atlassian.net/browse/PM-27132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ