### PR TITLE
[PM-26984] Use medium instead of semibold or bold

### DIFF
--- a/apps/browser/src/autofill/content/components/buttons/action-button.ts
+++ b/apps/browser/src/autofill/content/components/buttons/action-button.ts
@@ -68,7 +68,7 @@ const actionButtonStyles = ({
   overflow: hidden;
   text-align: center;
   text-overflow: ellipsis;
-  font-weight: 700;
+  font-weight: 500;
 
   ${disabled || isLoading
     ? `

--- a/apps/browser/src/autofill/content/components/notification/confirmation/message.ts
+++ b/apps/browser/src/autofill/content/components/notification/confirmation/message.ts
@@ -115,7 +115,7 @@ const notificationConfirmationButtonTextStyles = (theme: Theme) => css`
   ${baseTextStyles}
 
   color: ${themes[theme].primary[600]};
-  font-weight: 700;
+  font-weight: 500;
   cursor: pointer;
 `;
 

--- a/apps/browser/src/autofill/content/components/notification/header-message.ts
+++ b/apps/browser/src/autofill/content/components/notification/header-message.ts
@@ -21,5 +21,5 @@ const notificationHeaderMessageStyles = (theme: Theme) => css`
   color: ${themes[theme].text.main};
   font-family: Inter, sans-serif;
   font-size: 18px;
-  font-weight: 600;
+  font-weight: 500;
 `;

--- a/apps/browser/src/autofill/content/components/option-selection/option-items.ts
+++ b/apps/browser/src/autofill/content/components/option-selection/option-items.ts
@@ -94,7 +94,7 @@ const optionsLabelStyles = ({ theme }: { theme: Theme }) => css`
   user-select: none;
   padding: 0.375rem ${spacing["3"]};
   color: ${themes[theme].text.muted};
-  font-weight: 600;
+  font-weight: 500;
 `;
 
 export const optionsMenuItemMaxWidth = 260;

--- a/apps/browser/src/autofill/content/components/rows/action-row.ts
+++ b/apps/browser/src/autofill/content/components/rows/action-row.ts
@@ -34,7 +34,7 @@ const actionRowStyles = (theme: Theme) => css`
   min-height: 40px;
   text-align: left;
   color: ${themes[theme].primary["600"]};
-  font-weight: 700;
+  font-weight: 500;
 
   > span {
     display: block;

--- a/apps/browser/src/autofill/overlay/inline-menu/pages/list/list.scss
+++ b/apps/browser/src/autofill/overlay/inline-menu/pages/list/list.scss
@@ -82,7 +82,7 @@ body * {
   width: 100%;
   font-family: $font-family-sans-serif;
   font-size: 1.6rem;
-  font-weight: 700;
+  font-weight: 500;
   text-align: left;
   background: transparent;
   border: none;
@@ -187,7 +187,7 @@ body * {
   top: 0;
   z-index: 1;
   font-family: $font-family-sans-serif;
-  font-weight: 600;
+  font-weight: 500;
   font-size: 1rem;
   line-height: 1.3;
   letter-spacing: 0.025rem;

--- a/apps/desktop/src/autofill/components/autotype-shortcut.component.html
+++ b/apps/desktop/src/autofill/components/autotype-shortcut.component.html
@@ -1,6 +1,6 @@
 <form [bitSubmit]="submit" [formGroup]="setShortcutForm">
   <bit-dialog>
-    <div class="tw-font-semibold" bitDialogTitle>
+    <div class="tw-font-medium" bitDialogTitle>
       {{ "typeShortcut" | i18n }}
     </div>
     <div bitDialogContent>


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[PM-26984](https://bitwarden.atlassian.net/browse/PM-26984)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
At design's request, we are updating the look and feel of the client apps by removing all usages of bold and semibold font. These changes are broken up in one PR per team.

There will likely be a period of time where designs are lagging behind this change. Please check with design before adding new usages of bold or semibold.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-26984]: https://bitwarden.atlassian.net/browse/PM-26984?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ