### PR TITLE
[PM-27674] (Auth) Enter button starts SSO login if SSO Required

### DIFF
--- a/libs/auth/src/angular/login/login.component.html
+++ b/libs/auth/src/angular/login/login.component.html
@@ -21,7 +21,7 @@
         bitInput
         appAutofocus
         (input)="onEmailInput($event)"
-        (keyup.enter)="continuePressed()"
+        (keyup.enter)="ssoRequired ? handleSsoClick() : continuePressed()"
       />
     </bit-form-field>
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-27674](https://bitwarden.atlassian.net/browse/PM-27674)

## 📔 Objective

Feature Flags enabled: `pm-22110-disable-alternate-login-methods`

- If user's email is NOT in the `ssoRequiredCache`, pressing "enter" takes them to the MP login screen.
- If the user's email is in the `ssoRequiredCache`, pressing "enter" starts the SSO login process.

## 📸 Screen-shares

On all screen-shares below:
- `demo2@local.dev` - MP user hits "enter" &rarr; MP login screen
- `demo@local.dev` - SSO required user hits "enter" &rarr; start SSO login process

### Web

https://github.com/user-attachments/assets/7452503f-e66e-41e5-945c-5bcd2fe28480

### Extension

https://github.com/user-attachments/assets/cdd361f0-8930-4800-95ed-518e0c180e14

### Desktop

https://github.com/user-attachments/assets/de86cb80-a9d6-4cbc-b3b4-a4c4e02cc25c

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-27674]: https://bitwarden.atlassian.net/browse/PM-27674?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ