### PR TITLE
[PM-26984] Use medium instead of semibold or bold

### DIFF
--- a/apps/browser/src/tools/popup/send-v2/send-created/send-created.component.html
+++ b/apps/browser/src/tools/popup/send-v2/send-created/send-created.component.html
@@ -17,7 +17,7 @@
       <div class="tw-size-[95px] tw-content-center">
         <bit-icon [icon]="sendCreatedIcon"></bit-icon>
       </div>
-      <h3 tabindex="0" appAutofocus class="tw-font-semibold">
+      <h3 tabindex="0" appAutofocus class="tw-font-medium">
         {{ "createdSendSuccessfully" | i18n }}
       </h3>
       <p class="tw-text-center">

--- a/apps/web/src/app/tools/send/send.component.html
+++ b/apps/web/src/app/tools/send/send.component.html
@@ -21,7 +21,7 @@
   <div class="tw-col-span-3">
     <div class="tw-border tw-border-solid tw-border-secondary-300 tw-rounded" data-testid="filters">
       <div
-        class="tw-bg-background-alt tw-border-0 tw-border-b tw-border-solid tw-border-secondary-100 tw-rounded-t tw-px-5 tw-py-2.5 tw-font-semibold tw-uppercase"
+        class="tw-bg-background-alt tw-border-0 tw-border-b tw-border-solid tw-border-secondary-100 tw-rounded-t tw-px-5 tw-py-2.5 tw-font-medium tw-uppercase"
         data-testid="filters-header"
       >
         {{ "filters" | i18n }}

--- a/libs/importer/src/components/import.component.html
+++ b/libs/importer/src/components/import.component.html
@@ -11,7 +11,7 @@
 <form [formGroup]="formGroup" [bitSubmit]="submit" id="import_form_importForm">
   <bit-section>
     <bit-section-header>
-      <h2 class="tw-font-bold" bitTypography="h6">{{ "destination" | i18n }}</h2>
+      <h2 class="tw-font-medium" bitTypography="h6">{{ "destination" | i18n }}</h2>
     </bit-section-header>
     <bit-card>
       <bit-form-field [hidden]="isFromAC">
@@ -62,7 +62,7 @@
 
   <bit-section>
     <bit-section-header>
-      <h2 class="tw-font-bold" bitTypography="h6">{{ "data" | i18n }}</h2>
+      <h2 class="tw-font-medium" bitTypography="h6">{{ "data" | i18n }}</h2>
     </bit-section-header>
     <bit-card>
       <bit-form-field class="@2xl:tw-w-1/2">
@@ -70,7 +70,7 @@
         <bit-select formControlName="format">
           <bit-option value="" label="-- {{ 'select' | i18n }} --" />
           <bit-option
-            class="tw-font-bold tw-text-muted tw-text-xs"
+            class="tw-font-medium tw-text-muted tw-text-xs"
             value="-"
             label="{{ 'commonImportFormats' | i18n }}"
             disabled

--- a/libs/tools/send/send-ui/src/send-list-items-container/send-list-items-container.component.html
+++ b/libs/tools/send/send-ui/src/send-list-items-container/send-list-items-container.component.html
@@ -1,6 +1,6 @@
 <bit-section *ngIf="sends?.length > 0" disableMargin>
   <bit-section-header>
-    <h2 class="tw-font-bold" bitTypography="h6">
+    <h2 class="tw-font-medium" bitTypography="h6">
       {{ headerText }}
     </h2>
     <span bitTypography="body1" slot="end">{{ sends.length }}</span>


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[PM-26984](https://bitwarden.atlassian.net/browse/PM-26984)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
At design's request, we are updating the look and feel of the client apps by removing all usages of bold and semibold font. These changes are broken up in one PR per team.

There will likely be a period of time where designs are lagging behind this change. Please check with design before adding new usages of bold or semibold.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-26984]: https://bitwarden.atlassian.net/browse/PM-26984?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ