### PR TITLE
[PM-27562] Implement bulk member actions batching feature

### DIFF
--- a/apps/web/src/app/admin-console/common/people-table-data-source.spec.ts
+++ b/apps/web/src/app/admin-console/common/people-table-data-source.spec.ts
@@ -1,0 +1,180 @@
+import { OrganizationUserStatusType } from "@bitwarden/common/admin-console/enums";
+
+import { OrganizationUserView } from "../organizations/core/views/organization-user.view";
+
+import { PeopleTableDataSource } from "./people-table-data-source";
+
+// Create a concrete implementation for testing
+class TestPeopleTableDataSource extends PeopleTableDataSource<OrganizationUserView> {
+  protected statusType = OrganizationUserStatusType;
+}
+
+describe("PeopleTableDataSource", () => {
+  let dataSource: TestPeopleTableDataSource;
+
+  beforeEach(() => {
+    dataSource = new TestPeopleTableDataSource();
+  });
+
+  describe("checkAllFilteredUsers", () => {
+    let mockUsers: OrganizationUserView[];
+
+    beforeEach(() => {
+      // Create 600 mock users to test the limit
+      mockUsers = Array.from({ length: 600 }, (_, i) => ({
+        id: `user-${i}`,
+        email: `user${i}@example.com`,
+        name: `User ${i}`,
+        status: OrganizationUserStatusType.Confirmed,
+      })) as OrganizationUserView[];
+
+      dataSource.data = mockUsers;
+    });
+
+    it("should limit selection to 500 users when removeBatchLimit is false", () => {
+      dataSource.checkAllFilteredUsers(true, false);
+
+      const checkedUsers = dataSource.getCheckedUsers();
+      expect(checkedUsers).toHaveLength(500);
+    });
+
+    it("should select all users when removeBatchLimit is true", () => {
+      dataSource.checkAllFilteredUsers(true, true);
+
+      const checkedUsers = dataSource.getCheckedUsers();
+      expect(checkedUsers).toHaveLength(600);
+    });
+
+    it("should select all users when count is below 500 and removeBatchLimit is false", () => {
+      // Use only 300 users
+      const smallUserSet = mockUsers.slice(0, 300);
+      dataSource.data = smallUserSet;
+
+      dataSource.checkAllFilteredUsers(true, false);
+
+      const checkedUsers = dataSource.getCheckedUsers();
+      expect(checkedUsers).toHaveLength(300);
+    });
+
+    it("should select all users when count is below 500 and removeBatchLimit is true", () => {
+      // Use only 300 users
+      const smallUserSet = mockUsers.slice(0, 300);
+      dataSource.data = smallUserSet;
+
+      dataSource.checkAllFilteredUsers(true, true);
+
+      const checkedUsers = dataSource.getCheckedUsers();
+      expect(checkedUsers).toHaveLength(300);
+    });
+
+    it("should uncheck all users before selecting when select is true", () => {
+      // First, manually check some users
+      dataSource.checkUser(mockUsers[0], true);
+      dataSource.checkUser(mockUsers[1], true);
+      expect(dataSource.getCheckedUsers()).toHaveLength(2);
+
+      // Now call checkAllFilteredUsers with select=true
+      dataSource.checkAllFilteredUsers(true, false);
+
+      // Should have exactly 500 checked (the limit), not 502
+      const checkedUsers = dataSource.getCheckedUsers();
+      expect(checkedUsers).toHaveLength(500);
+    });
+
+    it("should uncheck all users when select is false", () => {
+      // First check all users
+      dataSource.checkAllFilteredUsers(true, false);
+      expect(dataSource.getCheckedUsers().length).toBeGreaterThan(0);
+
+      // Now uncheck all
+      dataSource.checkAllFilteredUsers(false, false);
+
+      const checkedUsers = dataSource.getCheckedUsers();
+      expect(checkedUsers).toHaveLength(0);
+    });
+
+    it("should handle exactly 500 users when removeBatchLimit is false", () => {
+      const exactUsers = mockUsers.slice(0, 500);
+      dataSource.data = exactUsers;
+
+      dataSource.checkAllFilteredUsers(true, false);
+
+      const checkedUsers = dataSource.getCheckedUsers();
+      expect(checkedUsers).toHaveLength(500);
+    });
+
+    it("should handle exactly 500 users when removeBatchLimit is true", () => {
+      const exactUsers = mockUsers.slice(0, 500);
+      dataSource.data = exactUsers;
+
+      dataSource.checkAllFilteredUsers(true, true);
+
+      const checkedUsers = dataSource.getCheckedUsers();
+      expect(checkedUsers).toHaveLength(500);
+    });
+
+    it("should work with filtered data when removeBatchLimit is true", () => {
+      // Set up a filter that only includes some users
+      dataSource.filter = "user-1"; // This will match user-1, user-10, user-11, etc.
+
+      dataSource.checkAllFilteredUsers(true, true);
+
+      const checkedUsers = dataSource.getCheckedUsers();
+      // The number of checked users should equal the number of filtered users
+      expect(checkedUsers.length).toBe(dataSource.filteredData.length);
+    });
+
+    it("should default removeBatchLimit to false when not provided", () => {
+      dataSource.checkAllFilteredUsers(true);
+
+      const checkedUsers = dataSource.getCheckedUsers();
+      expect(checkedUsers).toHaveLength(500);
+    });
+  });
+
+  describe("getCheckedUsers", () => {
+    it("should return only checked users", () => {
+      const users = Array.from({ length: 10 }, (_, i) => ({
+        id: `user-${i}`,
+        email: `user${i}@example.com`,
+        name: `User ${i}`,
+        status: OrganizationUserStatusType.Confirmed,
+      })) as OrganizationUserView[];
+
+      dataSource.data = users;
+
+      // Check only a few users
+      dataSource.checkUser(users[0], true);
+      dataSource.checkUser(users[2], true);
+      dataSource.checkUser(users[5], true);
+
+      const checkedUsers = dataSource.getCheckedUsers();
+      expect(checkedUsers).toHaveLength(3);
+      expect(checkedUsers).toContain(users[0]);
+      expect(checkedUsers).toContain(users[2]);
+      expect(checkedUsers).toContain(users[5]);
+    });
+  });
+
+  describe("uncheckAllUsers", () => {
+    it("should uncheck all users", () => {
+      const users = Array.from({ length: 10 }, (_, i) => ({
+        id: `user-${i}`,
+        email: `user${i}@example.com`,
+        name: `User ${i}`,
+        status: OrganizationUserStatusType.Confirmed,
+      })) as OrganizationUserView[];
+
+      dataSource.data = users;
+
+      // Check all users
+      users.forEach((user) => dataSource.checkUser(user, true));
+      expect(dataSource.getCheckedUsers()).toHaveLength(10);
+
+      // Uncheck all
+      dataSource.uncheckAllUsers();
+
+      expect(dataSource.getCheckedUsers()).toHaveLength(0);
+    });
+  });
+});

--- a/apps/web/src/app/admin-console/common/people-table-data-source.ts
+++ b/apps/web/src/app/admin-console/common/people-table-data-source.ts
@@ -92,8 +92,9 @@ export abstract class PeopleTableDataSource<T extends UserViewTypes> extends Tab
   /**
    * Check all filtered users (i.e. those rows that are currently visible)
    * @param select check the filtered users (true) or uncheck the filtered users (false)
+   * @param removeBatchLimit optional parameter to remove the 500 user limit (for feature flag testing)
    */
-  checkAllFilteredUsers(select: boolean) {
+  checkAllFilteredUsers(select: boolean, removeBatchLimit = false) {
     if (select) {
       // Reset checkbox selection first so we know nothing else is selected
       this.uncheckAllUsers();
@@ -101,8 +102,11 @@ export abstract class PeopleTableDataSource<T extends UserViewTypes> extends Tab
 
     const filteredUsers = this.filteredData;
 
-    const selectCount =
-      filteredUsers.length > MaxCheckedCount ? MaxCheckedCount : filteredUsers.length;
+    // If removeBatchLimit is true, select all users; otherwise apply the MaxCheckedCount limit
+    const selectCount = removeBatchLimit
+      ? filteredUsers.length
+      : Math.min(filteredUsers.length, MaxCheckedCount);
+
     for (let i = 0; i < selectCount; i++) {
       this.checkUser(filteredUsers[i], select);
     }

--- a/apps/web/src/app/admin-console/organizations/members/members.component.html
+++ b/apps/web/src/app/admin-console/organizations/members/members.component.html
@@ -91,7 +91,7 @@
                   type="checkbox"
                   bitCheckbox
                   class="tw-mr-1"
-                  (change)="dataSource.checkAllFilteredUsers($any($event.target).checked)"
+                  (change)="onSelectAllChange($any($event.target).checked)"
                   id="selectAll"
                 />
                 <label class="tw-mb-0 !tw-font-bold !tw-text-muted" for="selectAll">{{

--- a/apps/web/src/app/admin-console/organizations/members/members.component.ts
+++ b/apps/web/src/app/admin-console/organizations/members/members.component.ts
@@ -33,6 +33,8 @@ import { AccountService } from "@bitwarden/common/auth/abstractions/account.serv
 import { getUserId } from "@bitwarden/common/auth/services/account.service";
 import { OrganizationMetadataServiceAbstraction } from "@bitwarden/common/billing/abstractions/organization-metadata.service.abstraction";
 import { OrganizationBillingMetadataResponse } from "@bitwarden/common/billing/models/response/organization-billing-metadata.response";
+import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { ValidationService } from "@bitwarden/common/platform/abstractions/validation.service";
@@ -113,6 +115,7 @@ export class MembersComponent extends BaseMembersComponent<OrganizationUserView>
     private policyService: PolicyService,
     private policyApiService: PolicyApiServiceAbstraction,
     private organizationMetadataService: OrganizationMetadataServiceAbstraction,
+    private configService: ConfigService,
   ) {
     super(
       apiService,
@@ -203,6 +206,13 @@ export class MembersComponent extends BaseMembersComponent<OrganizationUserView>
 
   override async load(organization: Organization) {
     await super.load(organization);
+  }
+
+  async onSelectAllChange(checked: boolean) {
+    const isBatchingEnabled = await this.configService.getFeatureFlag(
+      FeatureFlag.BulkMemberActionsBatching,
+    );
+    this.dataSource.checkAllFilteredUsers(checked, isBatchingEnabled);
   }
 
   async getUsers(organization: Organization): Promise<OrganizationUserView[]> {

--- a/libs/common/src/enums/feature-flag.enum.ts
+++ b/libs/common/src/enums/feature-flag.enum.ts
@@ -13,6 +13,7 @@ export enum FeatureFlag {
   /* Admin Console Team */
   CreateDefaultLocation = "pm-19467-create-default-location",
   AutoConfirm = "pm-19934-auto-confirm-organization-users",
+  BulkMemberActionsBatching = "pm-bulk-member-actions-batching",
 
   /* Auth */
   PM22110_DisableAlternateLoginMethods = "pm-22110-disable-alternate-login-methods",
@@ -85,6 +86,7 @@ export const DefaultFeatureFlagValue = {
   /* Admin Console Team */
   [FeatureFlag.CreateDefaultLocation]: FALSE,
   [FeatureFlag.AutoConfirm]: FALSE,
+  [FeatureFlag.BulkMemberActionsBatching]: FALSE,
 
   /* Autofill */
   [FeatureFlag.MacOsNativeCredentialSync]: FALSE,


### PR DESCRIPTION
- Added a feature flag for bulk member actions batching.
- Updated `checkAllFilteredUsers` method to support an optional parameter for removing the 500 user limit.
- Created unit tests for `PeopleTableDataSource` to validate the new functionality.
- Refactored `MembersComponent` to handle the new batching logic in the checkbox selection.
- Enhanced `MemberActionsService` to process user reinvite requests in batches when the feature flag is enabled.

## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
