### PR TITLE
[PM-27810] Adding the removal from the access intelligence routing canActivate

### DIFF
--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/access-intelligence-routing.module.ts
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/access-intelligence-routing.module.ts
@@ -9,9 +9,7 @@ const routes: Routes = [
   { path: "", pathMatch: "full", redirectTo: "risk-insights" },
   {
     path: "risk-insights",
-    canActivate: [
-      organizationPermissionsGuard((org) => org.useRiskInsights && org.canAccessReports),
-    ],
+    canActivate: [organizationPermissionsGuard((org) => org.canAccessReports)],
     component: RiskInsightsComponent,
     data: {
       titleId: "RiskInsights",


### PR DESCRIPTION
## 🎟️ Tracking

[<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->](https://bitwarden.atlassian.net/browse/PM-27810)

## 📔 Objective

Remove the `useRiskInsights` org guard check for displaying access intelligence 

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
