### PR TITLE
[PM-27467] Log Out on Desktop Spins Forever

### DIFF
--- a/apps/desktop/src/app/app.component.ts
+++ b/apps/desktop/src/app/app.component.ts
@@ -736,8 +736,6 @@ export class AppComponent implements OnInit, OnDestroy {
       }
     }
 
-    await this.updateAppMenu();
-
     // This must come last otherwise the logout will prematurely trigger
     // a process reload before all the state service user data can be cleaned up
     this.authService.logOut(async () => {}, userBeingLoggedOut);


### PR DESCRIPTION
## 🎟️ Tracking

[PM-27467](https://bitwarden.atlassian.net/browse/PM-27467)

## 📔 Objective

Address an issue that would cause the _Desktop_ client to hang/spin forever on logout.

The `UserVerificationService.hasMasterPassword$` invocation in `updateAppMenu` _can_ return a non-deterministic state at evaluation time ([link](https://github.com/bitwarden/clients/blob/d364dfdda07dbba6561a0ee446d938fe2ea78c52/apps/desktop/src/app/app.component.ts#L586)): this can fall back to `ActiveUserState` in the event that the user is not found by userId (which it will not be while logout/cleanup is in progress). This is also addressed in #16894 in a more comprehensive way.

This PR removes the early call of `updateAppMenu` from the Desktop's `AppComponent.logOut` method and leaves the call site which is invoked on handle of the `AuthService`'s "loggedOut" message which is sent on log out from the [AuthService](https://github.com/bitwarden/clients/blob/cef503ee9a0de7a81d5c15cef527effd4e43df19/libs/common/src/auth/services/auth.service.ts#L103). This ensures account cleanup has successfully completed and maintains parity with other handled events, which are responsible for invoking `updateAppMenu`.

## 📸 Screenshots

Verified against QA to pull current QA feature flags.

https://github.com/user-attachments/assets/b866607c-224a-48a3-b452-379fdeccdefd



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-27467]: https://bitwarden.atlassian.net/browse/PM-27467?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ