### PR TITLE
[PM-279699] Clear premium interest when user subscribes or closes dialog

### DIFF
--- a/apps/web/src/app/billing/individual/upgrade/unified-upgrade-dialog/unified-upgrade-dialog.component.spec.ts
+++ b/apps/web/src/app/billing/individual/upgrade/unified-upgrade-dialog/unified-upgrade-dialog.component.spec.ts
@@ -3,10 +3,9 @@ import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
 import { Router } from "@angular/router";
 import { mock } from "jest-mock-extended";
-import { of } from "rxjs";
 
 import { PremiumInterestStateService } from "@bitwarden/angular/billing/services/premium-interest/premium-interest-state.service.abstraction";
-import { Account, AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { Account } from "@bitwarden/common/auth/abstractions/account.service";
 import {
   PersonalSubscriptionPricingTierId,
   PersonalSubscriptionPricingTierIds,
@@ -62,7 +61,6 @@ describe("UnifiedUpgradeDialogComponent", () => {
   let fixture: ComponentFixture<UnifiedUpgradeDialogComponent>;
   const mockDialogRef = mock<DialogRef>();
   const mockRouter = mock<Router>();
-  const mockAccountService = mock<AccountService>();
   const mockPremiumInterestStateService = mock<PremiumInterestStateService>();
 
   const mockAccount: Account = {
@@ -82,7 +80,6 @@ describe("UnifiedUpgradeDialogComponent", () => {
   beforeEach(async () => {
     // Reset mocks
     jest.clearAllMocks();
-    mockAccountService.activeAccount$ = of(mockAccount);
 
     await TestBed.configureTestingModule({
       imports: [NoopAnimationsModule, UnifiedUpgradeDialogComponent],
@@ -90,7 +87,6 @@ describe("UnifiedUpgradeDialogComponent", () => {
         { provide: DialogRef, useValue: mockDialogRef },
         { provide: DIALOG_DATA, useValue: defaultDialogData },
         { provide: Router, useValue: mockRouter },
-        { provide: AccountService, useValue: mockAccountService },
         { provide: PremiumInterestStateService, useValue: mockPremiumInterestStateService },
       ],
     })
@@ -129,15 +125,12 @@ describe("UnifiedUpgradeDialogComponent", () => {
       selectedPlan: PersonalSubscriptionPricingTierIds.Premium,
     };
 
-    mockAccountService.activeAccount$ = of(mockAccount);
-
     await TestBed.configureTestingModule({
       imports: [NoopAnimationsModule, UnifiedUpgradeDialogComponent],
       providers: [
         { provide: DialogRef, useValue: mockDialogRef },
         { provide: DIALOG_DATA, useValue: customDialogData },
         { provide: Router, useValue: mockRouter },
-        { provide: AccountService, useValue: mockAccountService },
         { provide: PremiumInterestStateService, useValue: mockPremiumInterestStateService },
       ],
     })
@@ -174,15 +167,12 @@ describe("UnifiedUpgradeDialogComponent", () => {
         planSelectionStepTitleOverride: "upgradeYourPlan",
       };
 
-      mockAccountService.activeAccount$ = of(mockAccount);
-
       await TestBed.configureTestingModule({
         imports: [NoopAnimationsModule, UnifiedUpgradeDialogComponent],
         providers: [
           { provide: DialogRef, useValue: mockDialogRef },
           { provide: DIALOG_DATA, useValue: customDialogData },
           { provide: Router, useValue: mockRouter },
-          { provide: AccountService, useValue: mockAccountService },
           { provide: PremiumInterestStateService, useValue: mockPremiumInterestStateService },
         ],
       })
@@ -240,15 +230,12 @@ describe("UnifiedUpgradeDialogComponent", () => {
         hideContinueWithoutUpgradingButton: true,
       };
 
-      mockAccountService.activeAccount$ = of(mockAccount);
-
       await TestBed.configureTestingModule({
         imports: [NoopAnimationsModule, UnifiedUpgradeDialogComponent],
         providers: [
           { provide: DialogRef, useValue: mockDialogRef },
           { provide: DIALOG_DATA, useValue: customDialogData },
           { provide: Router, useValue: mockRouter },
-          { provide: AccountService, useValue: mockAccountService },
           { provide: PremiumInterestStateService, useValue: mockPremiumInterestStateService },
         ],
       })
@@ -320,7 +307,6 @@ describe("UnifiedUpgradeDialogComponent", () => {
         redirectOnCompletion: true,
       };
 
-      mockAccountService.activeAccount$ = of(mockAccount);
       mockPremiumInterestStateService.getPremiumInterest.mockResolvedValue(false);
       mockRouter.navigate.mockResolvedValue(true);
 
@@ -330,7 +316,6 @@ describe("UnifiedUpgradeDialogComponent", () => {
           { provide: DialogRef, useValue: mockDialogRef },
           { provide: DIALOG_DATA, useValue: customDialogData },
           { provide: Router, useValue: mockRouter },
-          { provide: AccountService, useValue: mockAccountService },
           { provide: PremiumInterestStateService, useValue: mockPremiumInterestStateService },
         ],
       })
@@ -367,25 +352,6 @@ describe("UnifiedUpgradeDialogComponent", () => {
         organizationId: null,
       });
     });
-
-    it("should handle null account gracefully", async () => {
-      mockAccountService.activeAccount$ = of(null);
-      mockRouter.navigate.mockResolvedValue(true);
-
-      const result: UpgradePaymentResult = {
-        status: "upgradedToPremium",
-        organizationId: null,
-      };
-
-      await component["onComplete"](result);
-
-      expect(mockPremiumInterestStateService.getPremiumInterest).not.toHaveBeenCalled();
-      expect(mockPremiumInterestStateService.clearPremiumInterest).not.toHaveBeenCalled();
-      expect(mockDialogRef.close).toHaveBeenCalledWith({
-        status: "upgradedToPremium",
-        organizationId: null,
-      });
-    });
   });
 
   describe("onCloseClicked with premium interest", () => {
@@ -397,15 +363,6 @@ describe("UnifiedUpgradeDialogComponent", () => {
       expect(mockPremiumInterestStateService.clearPremiumInterest).toHaveBeenCalledWith(
         mockAccount.id,
       );
-      expect(mockDialogRef.close).toHaveBeenCalledWith({ status: "closed" });
-    });
-
-    it("should handle null account gracefully when closing", async () => {
-      mockAccountService.activeAccount$ = of(null);
-
-      await component["onCloseClicked"]();
-
-      expect(mockPremiumInterestStateService.clearPremiumInterest).not.toHaveBeenCalled();
       expect(mockDialogRef.close).toHaveBeenCalledWith({ status: "closed" });
     });
   });
@@ -431,7 +388,6 @@ describe("UnifiedUpgradeDialogComponent", () => {
         selectedPlan: PersonalSubscriptionPricingTierIds.Premium,
       };
 
-      mockAccountService.activeAccount$ = of(mockAccount);
       mockPremiumInterestStateService.clearPremiumInterest.mockResolvedValue();
 
       await TestBed.configureTestingModule({
@@ -440,7 +396,6 @@ describe("UnifiedUpgradeDialogComponent", () => {
           { provide: DialogRef, useValue: mockDialogRef },
           { provide: DIALOG_DATA, useValue: customDialogData },
           { provide: Router, useValue: mockRouter },
-          { provide: AccountService, useValue: mockAccountService },
           { provide: PremiumInterestStateService, useValue: mockPremiumInterestStateService },
         ],
       })
@@ -463,47 +418,6 @@ describe("UnifiedUpgradeDialogComponent", () => {
       expect(mockPremiumInterestStateService.clearPremiumInterest).toHaveBeenCalledWith(
         mockAccount.id,
       );
-      expect(mockDialogRef.close).toHaveBeenCalledWith({ status: "closed" });
-    });
-
-    it("should handle null account gracefully when backing out", async () => {
-      TestBed.resetTestingModule();
-
-      const customDialogData: UnifiedUpgradeDialogParams = {
-        account: mockAccount,
-        initialStep: UnifiedUpgradeDialogStep.Payment,
-        selectedPlan: PersonalSubscriptionPricingTierIds.Premium,
-      };
-
-      mockAccountService.activeAccount$ = of(null);
-
-      await TestBed.configureTestingModule({
-        imports: [NoopAnimationsModule, UnifiedUpgradeDialogComponent],
-        providers: [
-          { provide: DialogRef, useValue: mockDialogRef },
-          { provide: DIALOG_DATA, useValue: customDialogData },
-          { provide: Router, useValue: mockRouter },
-          { provide: AccountService, useValue: mockAccountService },
-          { provide: PremiumInterestStateService, useValue: mockPremiumInterestStateService },
-        ],
-      })
-        .overrideComponent(UnifiedUpgradeDialogComponent, {
-          remove: {
-            imports: [UpgradeAccountComponent, UpgradePaymentComponent],
-          },
-          add: {
-            imports: [MockUpgradeAccountComponent, MockUpgradePaymentComponent],
-          },
-        })
-        .compileComponents();
-
-      const customFixture = TestBed.createComponent(UnifiedUpgradeDialogComponent);
-      const customComponent = customFixture.componentInstance;
-      customFixture.detectChanges();
-
-      await customComponent["previousStep"]();
-
-      expect(mockPremiumInterestStateService.clearPremiumInterest).not.toHaveBeenCalled();
       expect(mockDialogRef.close).toHaveBeenCalledWith({ status: "closed" });
     });
   });


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-27699

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

This PR update the `unified-upgrade-dialog.component` to clear a user's premium interest:
1. After they subscribe to premium
2. If they close out of the dialog
3. If they back out of the dialog by going back on the first screen

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
