### PR TITLE
[PM-27808] Save modal dismissal to state

### DIFF
--- a/apps/web/src/app/billing/individual/upgrade/services/unified-upgrade-prompt.service.spec.ts
+++ b/apps/web/src/app/billing/individual/upgrade/services/unified-upgrade-prompt.service.spec.ts
@@ -7,6 +7,7 @@ import { AccountService, Account } from "@bitwarden/common/auth/abstractions/acc
 import { BillingAccountProfileStateService } from "@bitwarden/common/billing/abstractions/account/billing-account-profile-state.service";
 import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { SyncService } from "@bitwarden/common/platform/sync/sync.service";
 import { DialogRef, DialogService } from "@bitwarden/components";
@@ -17,7 +18,10 @@ import {
   UnifiedUpgradeDialogStatus,
 } from "../unified-upgrade-dialog/unified-upgrade-dialog.component";
 
-import { UnifiedUpgradePromptService } from "./unified-upgrade-prompt.service";
+import {
+  UnifiedUpgradePromptService,
+  PREMIUM_MODAL_DISMISSED_KEY,
+} from "./unified-upgrade-prompt.service";
 
 describe("UnifiedUpgradePromptService", () => {
   let sut: UnifiedUpgradePromptService;
@@ -31,6 +35,7 @@ describe("UnifiedUpgradePromptService", () => {
   const mockDialogOpen = jest.spyOn(UnifiedUpgradeDialogComponent, "open");
   const mockPlatformUtilsService = mock<PlatformUtilsService>();
   const mockStateProvider = mock<StateProvider>();
+  const mockLogService = mock<LogService>();
 
   /**
    * Creates a mock DialogRef that implements the required properties for testing
@@ -62,6 +67,7 @@ describe("UnifiedUpgradePromptService", () => {
       mockOrganizationService,
       mockPlatformUtilsService,
       mockStateProvider,
+      mockLogService,
     );
   }
 
@@ -306,7 +312,7 @@ describe("UnifiedUpgradePromptService", () => {
 
       // Assert
       expect(mockStateProvider.setUserState).toHaveBeenCalledWith(
-        expect.anything(),
+        PREMIUM_MODAL_DISMISSED_KEY,
         true,
         mockAccount.id,
       );

--- a/apps/web/src/app/billing/individual/upgrade/services/unified-upgrade-prompt.service.ts
+++ b/apps/web/src/app/billing/individual/upgrade/services/unified-upgrade-prompt.service.ts
@@ -8,11 +8,12 @@ import { AccountService } from "@bitwarden/common/auth/abstractions/account.serv
 import { BillingAccountProfileStateService } from "@bitwarden/common/billing/abstractions/account/billing-account-profile-state.service";
 import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { SyncService } from "@bitwarden/common/platform/sync/sync.service";
 import { UserId } from "@bitwarden/common/types/guid";
 import { DialogRef, DialogService } from "@bitwarden/components";
-import { BILLING_MEMORY, StateProvider, UserKeyDefinition } from "@bitwarden/state";
+import { BILLING_DISK, StateProvider, UserKeyDefinition } from "@bitwarden/state";
 
 import {
   UnifiedUpgradeDialogComponent,
@@ -22,7 +23,7 @@ import {
 
 // State key for tracking premium modal dismissal
 export const PREMIUM_MODAL_DISMISSED_KEY = new UserKeyDefinition<boolean>(
-  BILLING_MEMORY,
+  BILLING_DISK,
   "premiumModalDismissed",
   {
     deserializer: (value: boolean) => value,
@@ -45,6 +46,7 @@ export class UnifiedUpgradePromptService {
     private organizationService: OrganizationService,
     private platformUtilsService: PlatformUtilsService,
     private stateProvider: StateProvider,
+    private logService: LogService,
   ) {}
 
   private shouldShowPrompt$: Observable<boolean> = this.accountService.activeAccount$.pipe(
@@ -62,10 +64,7 @@ export class UnifiedUpgradePromptService {
         this.isProfileLessThanFiveMinutesOld(account.id),
       );
       const hasOrganizations$ = from(this.hasOrganizations(account.id));
-      const hasDismissedModal$ = this.stateProvider.getUserState$(
-        PREMIUM_MODAL_DISMISSED_KEY,
-        account.id,
-      );
+      const hasDismissedModal$ = this.hasDismissedModal$(account.id);
 
       return combineLatest([
         isProfileLessThanFiveMinutesOld$,
@@ -146,7 +145,13 @@ export class UnifiedUpgradePromptService {
 
     // Save dismissal state when the modal is closed without upgrading
     if (result?.status === UnifiedUpgradeDialogStatus.Closed) {
-      await this.stateProvider.setUserState(PREMIUM_MODAL_DISMISSED_KEY, true, account.id);
+      try {
+        await this.stateProvider.setUserState(PREMIUM_MODAL_DISMISSED_KEY, true, account.id);
+      } catch (error) {
+        // Log the error but don't block the dialog from closing
+        // The modal will still close properly even if persistence fails
+        this.logService.error("Failed to save premium modal dismissal state:", error);
+      }
     }
 
     // Return the result or null if the dialog was dismissed without a result
@@ -179,5 +184,16 @@ export class UnifiedUpgradePromptService {
     );
 
     return memberOrganizations.length > 0;
+  }
+
+  /**
+   * Checks if the user has previously dismissed the premium modal
+   * @param userId User ID to check
+   * @returns Observable that emits true if modal was dismissed, false otherwise
+   */
+  private hasDismissedModal$(userId: UserId): Observable<boolean> {
+    return this.stateProvider
+      .getUserState$(PREMIUM_MODAL_DISMISSED_KEY, userId)
+      .pipe(map((dismissed) => dismissed ?? false));
   }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-27808

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

This PR saves a user's dismissal of the premium modal to state so the application knows not to show it more than once.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->


https://github.com/user-attachments/assets/f4769e98-a3ae-4209-8636-0f48490ca8bd



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
