### PR TITLE
[PM-27604] use regular gap instead of column gap to fix spacing

### DIFF
--- a/libs/tools/generator/components/src/password-settings.component.html
+++ b/libs/tools/generator/components/src/password-settings.component.html
@@ -15,7 +15,7 @@
     <div>
       <bit-card>
         <div class="tw-mb-4">{{ "include" | i18n }}</div>
-        <div class="tw-flex tw-flex-wrap tw-gap-x-8">
+        <div class="tw-flex tw-flex-wrap tw-gap-8">
           <bit-form-control
             attr.aria-description="{{ 'uppercaseDescription' | i18n }}"
             title="{{ 'uppercaseDescription' | i18n }}"


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-27604

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

### Browser
#### Before
<img width="370" height="227" alt="image" src="https://github.com/user-attachments/assets/9c8df02e-f288-455b-b4a9-6a7ffcafa7f2" />


#### After
<img width="377" height="279" alt="image" src="https://github.com/user-attachments/assets/0150302c-99d4-49d5-aa4b-e565e1eae8d5" />

### Desktop
#### After
<img width="626" height="222" alt="image" src="https://github.com/user-attachments/assets/d61bfcaa-6447-4b5e-b9d6-4181592824fa" />

### Web
#### After
<img width="527" height="252" alt="image" src="https://github.com/user-attachments/assets/0dfb5e98-dfeb-4f40-bf54-37f8f0f6431f" />

#### Smaller screens
<img width="507" height="228" alt="image" src="https://github.com/user-attachments/assets/bf6ac9a4-d989-4c6f-ae17-b5ba1afb36d1" />


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
