### PR TITLE
[PM-27856] Do not autofill new password field with current password value on password reset

### DIFF
--- a/apps/browser/src/autofill/services/autofill-constants.ts
+++ b/apps/browser/src/autofill/services/autofill-constants.ts
@@ -67,6 +67,12 @@ export class AutoFillConstants {
     "create",
   ];
 
+  static readonly PasswordResetFormKeywords: string[] = ["password"];
+
+  static readonly PasswordResetFieldKeywords: string[] = ["old", "current", "new"];
+
+  static readonly PasswordResetOldPasswordKeywords: string[] = ["old", "current"];
+
   static readonly NewsletterFormNames: string[] = ["newsletter"];
 
   static readonly FieldIgnoreList: string[] = ["captcha", "findanything", "forgot"];


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
There is a bug in the browser extension when auto-filling in a password reset form. More specifically, when auto-filling the current/old password in a password reset form, the new password field is also filled. Below is a video demonstrating the bug:

https://github.com/user-attachments/assets/1dfce4ac-5156-4f41-8baa-b20516f6c15a

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR fixes the above mentioned issue. Auto-filling the current password in a password reset form will only fill that field, not any of the new password fields.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
The below video shows how it works with this fix implemented. Ignore the large white background of the update login popup, it's an unrelated bug that I've discovered.

https://github.com/user-attachments/assets/1fe07751-cf5b-4ac9-8b65-cab44eb6b8a4

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
