### PR TITLE
[PM-27773] only count critical apps with at-risk passwords

### DIFF
--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/activity/application-review-dialog/new-applications-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/activity/application-review-dialog/new-applications-dialog.component.html
@@ -32,8 +32,8 @@
 
     @if (currentView() === DialogView.AssignTasks) {
       <dirt-assign-tasks-view
-        [criticalApplicationsCount]="selectedApplications().size"
-        [totalApplicationsCount]="this.dialogParams.newApplications.length"
+        [criticalApplicationsCount]="atRiskCriticalApplicationsCount()"
+        [totalApplicationsCount]="totalCriticalApplicationsCount()"
         [atRiskCriticalMembersCount]="atRiskCriticalMembersCount()"
       >
       </dirt-assign-tasks-view>

--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/activity/application-review-dialog/new-applications-dialog.component.ts
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/activity/application-review-dialog/new-applications-dialog.component.ts
@@ -93,8 +93,8 @@ export class NewApplicationsDialogComponent {
   protected readonly selectedApplications = signal<Set<string>>(new Set());
 
   // Assign tasks variables
-  readonly criticalApplicationsCount = signal<number>(0);
-  readonly totalApplicationsCount = signal<number>(0);
+  readonly atRiskCriticalApplicationsCount = signal<number>(0);
+  readonly totalCriticalApplicationsCount = signal<number>(0);
   readonly atRiskCriticalMembersCount = signal<number>(0);
   readonly saving = signal<boolean>(false);
 
@@ -168,6 +168,15 @@ export class NewApplicationsDialogComponent {
     const onlyNewCriticalApplications = this.dialogParams.newApplications.filter((newApp) =>
       this.selectedApplications().has(newApp.applicationName),
     );
+
+    // Count only critical applications that have at-risk passwords
+    const atRiskCriticalApplicationsCount = onlyNewCriticalApplications.filter(
+      (app) => app.atRiskPasswordCount > 0,
+    ).length;
+    this.atRiskCriticalApplicationsCount.set(atRiskCriticalApplicationsCount);
+
+    // Total number of selected critical applications
+    this.totalCriticalApplicationsCount.set(onlyNewCriticalApplications.length);
 
     const atRiskCriticalMembersCount = getUniqueMembers(
       onlyNewCriticalApplications.flatMap((x) => x.atRiskMemberDetails),


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-27773

## 📔 Objective

When marking applications with strong passwords as critical, they were incorrectly counted as at-risk. Now only critical applications with atRiskPasswordCount > 0 are counted in the at-risk applications count.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
