### PR TITLE
[PM-23713] always append query param to premium redirect

### DIFF
--- a/libs/angular/src/billing/components/premium-upgrade-dialog/premium-upgrade-dialog.component.spec.ts
+++ b/libs/angular/src/billing/components/premium-upgrade-dialog/premium-upgrade-dialog.component.spec.ts
@@ -158,44 +158,11 @@ describe("PremiumUpgradeDialogComponent", () => {
   });
 
   describe("upgrade()", () => {
-    it("should launch URI with query parameter for cloud-hosted environments", async () => {
-      mockEnvironmentService.environment$ = of({
-        getWebVaultUrl: () => "https://vault.bitwarden.com",
-        getRegion: () => Region.US,
-      } as any);
-
+    it("should launch URI with query parameter", async () => {
       await component["upgrade"]();
 
       expect(mockPlatformUtilsService.launchUri).toHaveBeenCalledWith(
         "https://vault.bitwarden.com/#/settings/subscription/premium?callToAction=upgradeToPremium",
-      );
-      expect(mockDialogRef.close).toHaveBeenCalled();
-    });
-
-    it("should launch URI without query parameter for self-hosted environments", async () => {
-      mockEnvironmentService.environment$ = of({
-        getWebVaultUrl: () => "https://self-hosted.example.com",
-        getRegion: () => Region.SelfHosted,
-      } as any);
-
-      await component["upgrade"]();
-
-      expect(mockPlatformUtilsService.launchUri).toHaveBeenCalledWith(
-        "https://self-hosted.example.com/#/settings/subscription/premium",
-      );
-      expect(mockDialogRef.close).toHaveBeenCalled();
-    });
-
-    it("should launch URI with query parameter for EU cloud region", async () => {
-      mockEnvironmentService.environment$ = of({
-        getWebVaultUrl: () => "https://vault.bitwarden.eu",
-        getRegion: () => Region.EU,
-      } as any);
-
-      await component["upgrade"]();
-
-      expect(mockPlatformUtilsService.launchUri).toHaveBeenCalledWith(
-        "https://vault.bitwarden.eu/#/settings/subscription/premium?callToAction=upgradeToPremium",
       );
       expect(mockDialogRef.close).toHaveBeenCalled();
     });

--- a/libs/angular/src/billing/components/premium-upgrade-dialog/premium-upgrade-dialog.component.ts
+++ b/libs/angular/src/billing/components/premium-upgrade-dialog/premium-upgrade-dialog.component.ts
@@ -11,10 +11,7 @@ import {
   SubscriptionCadence,
   SubscriptionCadenceIds,
 } from "@bitwarden/common/billing/types/subscription-pricing-tier";
-import {
-  EnvironmentService,
-  Region,
-} from "@bitwarden/common/platform/abstractions/environment.service";
+import { EnvironmentService } from "@bitwarden/common/platform/abstractions/environment.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import {
@@ -82,10 +79,9 @@ export class PremiumUpgradeDialogComponent {
 
   protected async upgrade(): Promise<void> {
     const environment = await firstValueFrom(this.environmentService.environment$);
-    let vaultUrl = environment.getWebVaultUrl() + "/#/settings/subscription/premium";
-    if (environment.getRegion() !== Region.SelfHosted) {
-      vaultUrl += "?callToAction=upgradeToPremium";
-    }
+    const vaultUrl =
+      environment.getWebVaultUrl() +
+      "/#/settings/subscription/premium?callToAction=upgradeToPremium";
     this.platformUtilsService.launchUri(vaultUrl);
     this.dialogRef.close();
   }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-23713

## 📔 Objective

Always append the callToAction query param to the redirect link from browser or desktop, not only when SelfHosted===false.

This makes testing this functionality much simpler for QA because they always have to test using the self-hosted configuration option, even when they are pointing to a QA cloud server.

For actual self-hosted configurations, the query param will simply be ignored on the self-hosted web vault subscription page, so it will not impact anything there.

## 📸 Screenshots


https://github.com/user-attachments/assets/4d14124c-c2a8-41d7-b6e8-ab3e2c502d96



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
