### PR TITLE
[PM-27854] close dialog when redirecting to premium page

### DIFF
--- a/apps/web/src/app/vault/services/web-premium-upgrade-prompt.service.spec.ts
+++ b/apps/web/src/app/vault/services/web-premium-upgrade-prompt.service.spec.ts
@@ -187,6 +187,13 @@ describe("WebVaultPremiumUpgradePromptService", () => {
         expect(routerMock.navigate).toHaveBeenCalledWith(["settings/subscription/premium"]);
         expect(dialogServiceMock.openSimpleDialog).not.toHaveBeenCalled();
       });
+
+      it("should close dialog when redirecting to subscription page", async () => {
+        await service.promptForPremium();
+
+        expect(dialogRefMock.close).toHaveBeenCalledWith(VaultItemDialogResult.PremiumUpgrade);
+        expect(routerMock.navigate).toHaveBeenCalledWith(["settings/subscription/premium"]);
+      });
     });
 
     describe("when not self-hosted", () => {

--- a/apps/web/src/app/vault/services/web-premium-upgrade-prompt.service.ts
+++ b/apps/web/src/app/vault/services/web-premium-upgrade-prompt.service.ts
@@ -107,6 +107,9 @@ export class WebVaultPremiumUpgradePromptService implements PremiumUpgradePrompt
 
   private async redirectToSubscriptionPage() {
     await this.router.navigate([this.subscriptionPageRoute]);
+    if (this.dialog) {
+      this.dialog.close(VaultItemDialogResult.PremiumUpgrade);
+    }
   }
 
   private async openUpgradeDialog(account: Account) {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-27854

## 📔 Objective

Fixes a defect where an open dialog would not close when the premium badge redirected to the premium page on self-host.

## 📸 Screenshots


https://github.com/user-attachments/assets/11c1c358-b561-4ac2-9e11-7fd7cda51273



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
