### PR TITLE
PM-27759 adding title to risk insights empty state

### DIFF
--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/risk-insights.component.html
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/risk-insights.component.html
@@ -7,7 +7,7 @@
   } @else {
     <!-- Check final states after initial calls have been completed -->
     @if (isRiskInsightsActivityTabFeatureEnabled && !(dataService.hasReportData$ | async)) {
-      <h1 bitTypography="h1">{{ "riskInsights" | i18n }}</h1>
+      <h1 bitTypography="h1">{{ "accessIntelligence" | i18n }}</h1>
       <!-- Show empty state only when feature flag is enabled and there's no report data -->
       <div class="tw-flex tw-justify-center tw-items-center tw-min-h-[70vh] tw-w-full">
         @if (!hasCiphers) {
@@ -38,7 +38,7 @@
       <!-- Show screen when there is report data OR when feature flag is disabled (show tabs even without data) -->
       <div class="tw-min-h-screen tw-flex tw-flex-col">
         <div>
-          <h1 bitTypography="h1">{{ "riskInsights" | i18n }}</h1>
+          <h1 bitTypography="h1">{{ "accessIntelligence" | i18n }}</h1>
           <div class="tw-text-main tw-max-w-4xl tw-mb-2" *ngIf="appsCount > 0">
             {{ "reviewAtRiskPasswords" | i18n }}
           </div>


### PR DESCRIPTION
## 🎟️ Tracking
[PM-27759](https://bitwarden.atlassian.net/jira/software/c/projects/BW/boards/222?selectedIssue=PM-27759)

## 📔 Objective

Title "Access Intelligence" is missing when the report is in a empty state. I did change the title to be "Access Intelligence" when we do have report data.

## 📸 Screenshots

## Empty State
<img width="1577" height="1024" alt="image" src="https://github.com/user-attachments/assets/4a23f0e2-418a-4309-9b60-4186d575d21c" />

## With Report Data
<img width="1660" height="895" alt="image" src="https://github.com/user-attachments/assets/869732e1-48c5-47f0-b11b-dc816917f33e" />


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-27759]: https://bitwarden.atlassian.net/browse/PM-27759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ