### PR TITLE
PM-27883-Defect-Windows-Edge-browser-importer-is-not-enabled

### DIFF
--- a/libs/importer/src/services/default-import-metadata.service.ts
+++ b/libs/importer/src/services/default-import-metadata.service.ts
@@ -69,7 +69,7 @@ export class DefaultImportMetadataService implements ImportMetadataServiceAbstra
       return loaders;
     }
 
-    // Special handling for Brave, Chrome, and Edge CSV imports on Windows Desktop
+    // Special handling for Brave and Chrome CSV imports on Windows Desktop
     if (type === "bravecsv" || type === "chromecsv") {
       try {
         const device = this.system.environment.getDevice();


### PR DESCRIPTION
## 🎟️ Tracking


https://bitwarden.atlassian.net/browse/PM-27883


## 📔 Objective

Expose the Chromium direct importer option for Edge on Windows. x86 architecture only. 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
