### PR TITLE
[PM-27760] conditional review apps text

### DIFF
--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/activity/all-activity.component.ts
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/activity/all-activity.component.ts
@@ -143,6 +143,7 @@ export class AllActivityComponent implements OnInit {
     const dialogRef = NewApplicationsDialogComponent.open(this.dialogService, {
       newApplications: this.newApplications,
       organizationId: organizationId as OrganizationId,
+      hasExistingCriticalApplications: this.totalCriticalAppsCount > 0,
     });
 
     await lastValueFrom(dialogRef.closed);

--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/activity/application-review-dialog/new-applications-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/activity/application-review-dialog/new-applications-dialog.component.html
@@ -2,7 +2,9 @@
   <span bitDialogTitle>
     {{
       currentView() === DialogView.SelectApplications
-        ? ("reviewNewApplications" | i18n)
+        ? hasNoCriticalApplications()
+          ? ("prioritizeCriticalApplications" | i18n)
+          : ("reviewNewApplications" | i18n)
         : ("assignTasksToMembers" | i18n)
     }}
   </span>
@@ -11,7 +13,11 @@
     @if (currentView() === DialogView.SelectApplications) {
       <div>
         <p bitTypography="body1" class="tw-mb-5">
-          {{ "reviewNewApplicationsDescription" | i18n }}
+          {{
+            hasNoCriticalApplications()
+              ? ("selectCriticalApplicationsDescription" | i18n)
+              : ("reviewNewApplicationsDescription" | i18n)
+          }}
         </p>
 
         <div class="tw-flex tw-items-center tw-gap-2.5 tw-mb-5">

--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/activity/application-review-dialog/new-applications-dialog.component.ts
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/activity/application-review-dialog/new-applications-dialog.component.ts
@@ -45,6 +45,11 @@ export interface NewApplicationsDialogData {
    * the route subscription has fired.
    */
   organizationId: OrganizationId;
+  /**
+   * Whether the organization has any existing critical applications.
+   * Used to determine which title and description to show in the dialog.
+   */
+  hasExistingCriticalApplications: boolean;
 }
 
 /**
@@ -128,6 +133,14 @@ export class NewApplicationsDialogComponent {
 
   getApplications() {
     return this.dialogParams.newApplications;
+  }
+
+  /**
+   * Returns true if the organization has no existing critical applications.
+   * Used to conditionally show different titles and descriptions.
+   */
+  protected hasNoCriticalApplications(): boolean {
+    return !this.dialogParams.hasExistingCriticalApplications;
   }
 
   /**


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-27760?focusedCommentId=117075

## 📔 Objective

show correct title/description in new applications dialog based on critical apps state

- Show "Prioritize critical applications" when org has no critical apps
- Show "Review new applications" when org already has critical apps
- Add hasExistingCriticalApplications flag to dialog data
- Add reviewNewApplications i18n keys

## 📸 Screenshots

No apps marked as critical:
<img width="1546" height="1092" alt="image" src="https://github.com/user-attachments/assets/9f05433d-8dec-4562-befc-d5fedd2f8e06" />

Has apps marked as crit:
<img width="1532" height="1078" alt="image" src="https://github.com/user-attachments/assets/60da8ba4-311f-401c-9d70-8eca4aeff31e" />



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
