### PR TITLE
Remove team-tools-dev from owning localization

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -47,12 +47,12 @@ bitwarden_license/bit-web/src/app/dirt @bitwarden/team-data-insights-and-reporti
 libs/dirt @bitwarden/team-data-insights-and-reporting-dev
 libs/common/src/dirt @bitwarden/team-data-insights-and-reporting-dev
 
-## Localization/Crowdin (Platform and Tools team)
-apps/browser/src/_locales @bitwarden/team-tools-dev @bitwarden/team-platform-dev
-apps/browser/store/locales @bitwarden/team-tools-dev @bitwarden/team-platform-dev
-apps/cli/src/locales @bitwarden/team-tools-dev @bitwarden/team-platform-dev
-apps/desktop/src/locales @bitwarden/team-tools-dev @bitwarden/team-platform-dev
-apps/web/src/locales @bitwarden/team-tools-dev @bitwarden/team-platform-dev
+## Localization/Crowdin (Platform team)
+apps/browser/src/_locales @bitwarden/team-platform-dev
+apps/browser/store/locales @bitwarden/team-platform-dev
+apps/cli/src/locales @bitwarden/team-platform-dev
+apps/desktop/src/locales @bitwarden/team-platform-dev
+apps/web/src/locales @bitwarden/team-platform-dev
 
 ## Vault team files ##
 apps/browser/src/vault @bitwarden/team-vault-dev


### PR DESCRIPTION
## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Localization should now be 100% owned by @bitwarden/team-platform-dev. Removing partial ownership from @bitwarden/team-tools-dev.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
