### PR TITLE
build: swap to a workflow_dispatch trigger for sdk breaking change detection

### DIFF
--- a/.github/workflows/sdk-breaking-change-check.yml
+++ b/.github/workflows/sdk-breaking-change-check.yml
@@ -5,12 +5,8 @@ run-name: "SDK breaking change check (${{ github.event.inputs.sdk_version }})"
 on:
   workflow_dispatch:
     inputs:
-      pr_number:
-        description: "PR number"
-        required: true
-        type: string
       sdk_version:
-        description: "SDK version being tested"  
+        description: "SDK version being tested"
         required: true
         type: string
       source_repo:


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-22218
https://github.com/bitwarden/clients/pull/17314
https://github.com/bitwarden/sdk-internal/pull/538

## 📔 Objective

After discussion on https://github.com/bitwarden/sdk-internal/pull/538#discussion_r2499195607 we've pivoted to using `workflow_dispatch` as the trigger mechanism for client jobs in the SDK breaking change detection loop. This PR updated the still currently unused `clients` job to expect a `workflow_dispatch` trigger instead of a repository_dispatch trigger.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
