### PR TITLE
Refactor the review code prompt to precisely target our clients repo

### DIFF
--- a/.claude/prompts/review-code.md
+++ b/.claude/prompts/review-code.md
@@ -2,9 +2,9 @@
 
 ## Think Twice Before Recommending
 
-Angular has multiple valid patterns and ongoing migrations. Before suggesting changes:
+Angular has multiple valid patterns. Before suggesting changes:
 
-- **Consider the migration context** - Is this code part of an active modernization effort?
+- **Consider the context** - Is this code part of an active modernization effort?
 - **Check for established patterns** - Look for similar implementations in the codebase
 - **Avoid premature optimization** - Don't suggest refactoring stable, working code without clear benefit
 - **Respect incremental progress** - Teams may be modernizing gradually with feature flags
@@ -20,7 +20,7 @@ Angular has multiple valid patterns and ongoing migrations. Before suggesting ch
 **Standalone Components:**
 
 - New components should be standalone whenever feasible, but do not flag existing NgModule components as issues
-- Legacy patterns exist for valid reasons - consider migration effort vs benefit
+- Legacy patterns exist for valid reasons - consider modernization effort vs benefit
 
 **Typed Forms:**
 
@@ -34,7 +34,7 @@ Angular has multiple valid patterns and ongoing migrations. Before suggesting ch
 - Missing tw- prefix breaks styling completely
 - Check ALL Tailwind classes in modified files
 
-## Rust SDK Migrations - Tread Carefully
+## Rust SDK Adoption - Tread Carefully
 
 When reviewing cipher operations:
 


### PR DESCRIPTION
## 🎟️ Tracking

## 📔 Objective

I have closely analyzed the logs from our Claude code reviews.  I focused on duplicated information from Claude itself and our company prompt. I have changed the intention of the prompt here to be more precise; just like a funnel. The prompt's purpose is to be used to direct Claude's behavior when reviewing our code in this specific repo. I feel that this is a bit of a two-step dance with an AI partner; we're trying to lead them into making good decisions on what things are really findings and what things to avoid. 

Before reviewing, please read the following Claude Action function that generates the generic prompt. 
[claude-code-action/src/create-prompt/index.ts --> generateDefaultPrompt()](https://github.com/anthropics/claude-code-action/blob/main/src/create-prompt/index.ts#L471).

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
