### PR TITLE
[CL-806] Use header as autofocus target for dialog component

### DIFF
--- a/libs/components/src/dialog/dialog/dialog.component.html
+++ b/libs/components/src/dialog/dialog/dialog.component.html
@@ -20,7 +20,7 @@
       bitDialogTitleContainer
       bitTypography="h3"
       noMargin
-      class="tw-text-main tw-mb-0 tw-line-clamp-2 tw-text-ellipsis tw-break-words"
+      class="tw-text-main tw-mb-0 tw-line-clamp-2 tw-text-ellipsis tw-break-words focus-visible:tw-outline-none"
       cdkFocusInitial
       tabindex="-1"
     >


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[CL-806](https://bitwarden.atlassian.net/browse/CL-806)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
To better enable a11y focus management in this ticket (which is focused on the side nav links), I am fixing some focus behavior with the dialog. The dialog was not consistently autofocusing even though the cdk is used to set autofocus on the dialog container. Using this other cdk directive gives it a specific place to autofocus, which improves the behavior consistency. I picked the header because the header should always be there, unlike the close button or other dialog buttons/interactive elements. I removed the focus state to avoid having a noticeable distraction to sighted users, since this change is entirely for screenreader users.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

Before:

https://github.com/user-attachments/assets/8a47ac2b-e8d1-4a66-ab8d-e65a439928cb


After:

https://github.com/user-attachments/assets/931aba42-87c0-4478-b6d8-b21a7a569fb4



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[CL-806]: https://bitwarden.atlassian.net/browse/CL-806?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ