### PR TITLE
[PM-27915] Add additional global styling collision defenses for pseudo-elements

### DIFF
--- a/apps/browser/src/autofill/overlay/inline-menu/content/autofill-inline-menu-content.service.ts
+++ b/apps/browser/src/autofill/overlay/inline-menu/content/autofill-inline-menu-content.service.ts
@@ -240,8 +240,6 @@ export class AutofillInlineMenuContentService implements AutofillInlineMenuConte
 
     this.buttonElement = globalThis.document.createElement(customElementName);
     this.buttonElement.setAttribute("popover", "manual");
-
-    this.createInternalStyleNode(this.buttonElement);
   }
 
   /**
@@ -270,52 +268,6 @@ export class AutofillInlineMenuContentService implements AutofillInlineMenuConte
 
     this.listElement = globalThis.document.createElement(customElementName);
     this.listElement.setAttribute("popover", "manual");
-
-    this.createInternalStyleNode(this.listElement);
-  }
-
-  /**
-   * Builds and prepends an internal stylesheet to the container node with rules
-   * to prevent targeting by the host's global styling rules. This should only be
-   * used for pseudo elements such as `::backdrop` or `::before`. All other
-   * styles should be applied inline upon the parent container itself for improved
-   * specificity priority.
-   */
-  private createInternalStyleNode(parent: HTMLElement) {
-    const css = document.createTextNode(`
-      ${parent.tagName}[popover="manual"]::backdrop,
-      ${parent.tagName}[popover="manual"]::before,
-      ${parent.tagName}[popover="manual"]::after {
-        all: initial !important;
-        backdrop-filter: none !important;
-        filter: none !important;
-        inset: auto !important;
-        touch-action: auto !important;
-        user-select: text !important;
-        position: relative !important;
-        top: auto !important;
-        right: auto !important;
-        bottom: auto !important;
-        left: auto !important;
-        transform: none !important;
-        transform-origin: 50% 50% !important;
-        opacity: 1 !important;
-        mix-blend-mode: normal !important;
-        isolation: isolate !important;
-        z-index: 0 !important;
-        background: none !important;
-        background-color: transparent !important;
-        background-image: none !important;
-        width: 0 !important;
-        height: 0 !important;
-        content: "" !important;
-        pointer-events: all !important;
-      }
-    `);
-    const style = globalThis.document.createElement("style");
-    style.setAttribute("type", "text/css");
-    style.appendChild(css);
-    parent.prepend(style);
   }
 
   /**

--- a/apps/browser/src/autofill/overlay/inline-menu/iframe-content/autofill-inline-menu-iframe-element.ts
+++ b/apps/browser/src/autofill/overlay/inline-menu/iframe-content/autofill-inline-menu-iframe-element.ts
@@ -8,7 +8,10 @@ export class AutofillInlineMenuIframeElement {
     iframeTitle: string,
     ariaAlert?: string,
   ) {
+    const style = this.createInternalStyleNode();
     const shadow: ShadowRoot = element.attachShadow({ mode: "closed" });
+    shadow.prepend(style);
+
     const autofillInlineMenuIframeService = new AutofillInlineMenuIframeService(
       shadow,
       portName,
@@ -17,5 +20,51 @@ export class AutofillInlineMenuIframeElement {
       ariaAlert,
     );
     autofillInlineMenuIframeService.initMenuIframe();
+  }
+
+  /**
+   * Builds and prepends an internal stylesheet to the container node with rules
+   * to prevent targeting by the host's global styling rules. This should only be
+   * used for pseudo elements such as `::backdrop` or `::before`. All other
+   * styles should be applied inline upon the parent container itself for improved
+   * specificity priority.
+   */
+  private createInternalStyleNode() {
+    const css = document.createTextNode(`
+      :host::backdrop,
+      :host::before,
+      :host::after {
+        all: initial !important;
+        backdrop-filter: none !important;
+        filter: none !important;
+        inset: auto !important;
+        touch-action: auto !important;
+        user-select: text !important;
+        display: none !important;
+        position: relative !important;
+        top: auto !important;
+        right: auto !important;
+        bottom: auto !important;
+        left: auto !important;
+        transform: none !important;
+        transform-origin: 50% 50% !important;
+        opacity: 1 !important;
+        mix-blend-mode: normal !important;
+        isolation: isolate !important;
+        z-index: 0 !important;
+        background: none !important;
+        background-color: transparent !important;
+        background-image: none !important;
+        width: 0 !important;
+        height: 0 !important;
+        content: "" !important;
+        pointer-events: all !important;
+      }
+    `);
+    const style = globalThis.document.createElement("style");
+    style.setAttribute("type", "text/css");
+    style.appendChild(css);
+
+    return style;
   }
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-27915](https://bitwarden.atlassian.net/browse/PM-27915)

## 📔 Objective

- Add additional global styling collision defenses for pseudo-elements
- Move pseudo-element styling into the container shadow-dom

Resolves additional cases discussed in https://github.com/bitwarden/clients/issues/17277 and https://github.com/bitwarden/clients/issues/16240

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-27915]: https://bitwarden.atlassian.net/browse/PM-27915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ