### PR TITLE
[PM-20961] Access Intelligence App header added

### DIFF
--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/risk-insights.component.html
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/risk-insights.component.html
@@ -1,3 +1,5 @@
+<app-header> </app-header>
+
 <ng-container>
   @let status = dataService.reportStatus$ | async;
   @let hasCiphers = dataService.hasCiphers$ | async;
@@ -8,7 +10,6 @@
   } @else {
     <!-- Check final states after initial calls have been completed -->
     @if (isRiskInsightsActivityTabFeatureEnabled && !(dataService.hasReportData$ | async)) {
-      <h1 bitTypography="h1">{{ "accessIntelligence" | i18n }}</h1>
       <!-- Show empty state only when feature flag is enabled and there's no report data -->
       <div @fadeIn class="tw-flex tw-justify-center tw-items-center tw-min-h-[70vh] tw-w-full">
         @if (!hasCiphers) {
@@ -39,7 +40,6 @@
       <!-- Show screen when there is report data OR when feature flag is disabled (show tabs even without data) -->
       <div @fadeIn class="tw-min-h-screen tw-flex tw-flex-col">
         <div>
-          <h1 bitTypography="h1">{{ "accessIntelligence" | i18n }}</h1>
           <div class="tw-text-main tw-max-w-4xl tw-mb-2" *ngIf="appsCount > 0">
             {{ "reviewAtRiskPasswords" | i18n }}
           </div>


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-20961

## 📔 Objective

The app header (product switcher and user info) was missing on the Access Intelligence page.
This was due to issues with the drawer using bit-layout.
Now that the drawer has been removed, we can use the app-header.

## 📸 Screenshots

### Header
<img width="1185" height="673" alt="image" src="https://github.com/user-attachments/assets/a7063f15-ce49-4f49-8474-8711ce61df54" />

### User Info
<img width="1185" height="673" alt="image" src="https://github.com/user-attachments/assets/20d41982-d33c-49a3-9c12-30aec39336d1" />

### Product Switcher
<img width="1185" height="673" alt="image" src="https://github.com/user-attachments/assets/cab830ff-68ba-49a5-be14-0416e6cccde5" />




## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
