### PR TITLE
[BRE-1310] Remove FreeBSD desktop build and release

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -263,13 +263,6 @@ jobs:
           path: apps/desktop/dist/Bitwarden-${{ env._PACKAGE_VERSION }}-x86_64.rpm
           if-no-files-found: error
 
-      - name: Upload .freebsd artifact
-        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
-        with:
-          name: Bitwarden-${{ env._PACKAGE_VERSION }}-x64.freebsd
-          path: apps/desktop/dist/Bitwarden-${{ env._PACKAGE_VERSION }}-x64.freebsd
-          if-no-files-found: error
-
       - name: Upload .snap artifact
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -107,7 +107,6 @@ jobs:
         with:
           artifacts: "apps/desktop/artifacts/Bitwarden-${{ env.PKG_VERSION }}-amd64.deb,
             apps/desktop/artifacts/Bitwarden-${{ env.PKG_VERSION }}-x86_64.rpm,
-            apps/desktop/artifacts/Bitwarden-${{ env.PKG_VERSION }}-x64.freebsd,
             apps/desktop/artifacts/bitwarden_${{ env.PKG_VERSION }}_amd64.snap,
             apps/desktop/artifacts/bitwarden_${{ env.PKG_VERSION }}_arm64.snap,
             apps/desktop/artifacts/bitwarden_${{ env.PKG_VERSION }}_arm64.tar.gz,

--- a/apps/desktop/desktop_native/napi/index.js
+++ b/apps/desktop/desktop_native/napi/index.js
@@ -78,12 +78,6 @@ switch (platform) {
         throw new Error(`Unsupported architecture on macOS: ${arch}`);
     }
     break;
-  case "freebsd":
-    nativeBinding = loadFirstAvailable(
-      ["desktop_napi.freebsd-x64.node"],
-      "@bitwarden/desktop-napi-freebsd-x64",
-    );
-    break;
   case "linux":
     switch (arch) {
       case "x64":

--- a/apps/desktop/electron-builder.json
+++ b/apps/desktop/electron-builder.json
@@ -116,7 +116,7 @@
         "to": "libprocess_isolation.so"
       }
     ],
-    "target": ["deb", "freebsd", "rpm", "AppImage", "snap"],
+    "target": ["deb", "rpm", "AppImage", "snap"],
     "desktop": {
       "entry": {
         "Name": "Bitwarden",
@@ -251,9 +251,6 @@
   "rpm": {
     "artifactName": "${productName}-${version}-${arch}.${ext}",
     "fpm": ["--rpm-rpmbuild-define", "_build_id_links none"]
-  },
-  "freebsd": {
-    "artifactName": "${productName}-${version}-${arch}.${ext}"
   },
   "snap": {
     "summary": "Bitwarden is a secure and free password manager for all of your devices.",


### PR DESCRIPTION
## 🎟️ Tracking

[BRE-1310](https://bitwarden.atlassian.net/browse/bre-1310)

## 📔 Objective
We currently build a FreeBSD variant of our desktop app and include it in our releases. However, this variant is untested internally and not supported per our downloads page or support matrix. This leads to increased build times and unnecessary compute that we can clean up.

[BRE-1310]: https://bitwarden.atlassian.net/browse/BRE-1310?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ