### PR TITLE
[PM-28176] Revert broken actions/create-github-app-token version for BIT workflow

### DIFF
--- a/.github/workflows/test-browser-interactions.yml
+++ b/.github/workflows/test-browser-interactions.yml
@@ -49,7 +49,9 @@ jobs:
       uses: bitwarden/gh-actions/azure-logout@main
 
     - name: Generate GH App token
-      uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+      # NOTE: versions of actions/create-github-app-token after 2.0.3 break this workflow
+      # Remediation is tracked in https://bitwarden.atlassian.net/browse/PM-28174
+      uses: actions/create-github-app-token@30bf6253fa41bdc8d1501d202ad15287582246b4 # v2.0.3
       id: app-token
       with:
         app-id: ${{ steps.get-kv-secrets.outputs.BW-GHAPP-ID }}


### PR DESCRIPTION
## 🎟️ Tracking

[PM-28176](https://bitwarden.atlassian.net/browse/PM-28176)

## 📔 Objective

v2.1.1 and later of `actions/create-github-app-token` breaks the current clients/BIT workflow triggers configuration. For now, revert the `actions/create-github-app-token` version so we can restore functionality. Followup debug and remediation will be tracked in [PM-28174](https://bitwarden.atlassian.net/browse/PM-28174)

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-28176]: https://bitwarden.atlassian.net/browse/PM-28176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-28174]: https://bitwarden.atlassian.net/browse/PM-28174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ