### PR TITLE
[BEEEP|POC] Add infrastructure for native PRF passkey login on desktop

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,17 +4,17 @@ on:
   pull_request:
     types: [opened, synchronize]
     branches-ignore:
-      - 'l10n_master'
-      - 'cf-pages'
+      - "l10n_master"
+      - "cf-pages"
     paths-ignore:
-      - '.github/workflows/**'
+      - ".github/workflows/**"
   push:
     branches:
-      - 'main'
-      - 'rc'
-      - 'hotfix-rc-*'
+      - "main"
+      - "rc"
+      - "hotfix-rc-*"
     paths-ignore:
-      - '.github/workflows/**'
+      - ".github/workflows/**"
   workflow_dispatch:
     inputs: {}
 
@@ -65,8 +65,8 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
-          cache: 'npm'
-          cache-dependency-path: '**/package-lock.json'
+          cache: "npm"
+          cache-dependency-path: "**/package-lock.json"
           node-version: ${{ steps.retrieve-node-version.outputs.node_version }}
 
       - name: Install Node dependencies
@@ -100,6 +100,12 @@ jobs:
 
       - name: Check Rust version
         run: rustup --version
+
+      - name: Install linux dependencies
+        if: ${{ matrix.os=='ubuntu-24.04' }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libudev-dev
 
       - name: Run cargo fmt
         working-directory: ./apps/desktop/desktop_native

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,12 +8,11 @@ on:
       - "rc"
       - "hotfix-rc-*"
   pull_request:
-    types: [ opened, synchronize ]
+    types: [opened, synchronize]
 
 permissions: {}
 
 jobs:
-
   testing:
     name: Run tests
     runs-on: ubuntu-22.04
@@ -38,8 +37,8 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
-          cache: 'npm'
-          cache-dependency-path: '**/package-lock.json'
+          cache: "npm"
+          cache-dependency-path: "**/package-lock.json"
           node-version: ${{ steps.retrieve-node-version.outputs.node_version }}
 
       - name: Print environment
@@ -96,11 +95,11 @@ jobs:
       - name: Check Rust version
         run: rustup --version
 
-      - name: Install gnome-keyring
+      - name: Install linux dependencies
         if: ${{ matrix.os=='ubuntu-22.04' }}
         run: |
           sudo apt-get update
-          sudo apt-get install -y gnome-keyring dbus-x11
+          sudo apt-get install -y gnome-keyring dbus-x11 libudev-dev
 
       - name: Check out repo
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/apps/browser/src/popup/services/services.module.ts
+++ b/apps/browser/src/popup/services/services.module.ts
@@ -51,8 +51,10 @@ import { MasterPasswordApiService } from "@bitwarden/common/auth/abstractions/ma
 import { SsoLoginServiceAbstraction } from "@bitwarden/common/auth/abstractions/sso-login.service.abstraction";
 import { TokenService } from "@bitwarden/common/auth/abstractions/token.service";
 import { UserVerificationService } from "@bitwarden/common/auth/abstractions/user-verification/user-verification.service.abstraction";
+import { NavigatorCredentialsService } from "@bitwarden/common/auth/abstractions/webauthn/navigator-credentials.service";
 import { AuthRequestAnsweringService } from "@bitwarden/common/auth/services/auth-request-answering/auth-request-answering.service";
 import { PendingAuthRequestsStateService } from "@bitwarden/common/auth/services/auth-request-answering/pending-auth-requests.state";
+import { DefaultNavigatorCredentialsService } from "@bitwarden/common/auth/services/webauthn-login/default-navigator-credentials.service";
 import {
   AutofillSettingsService,
   AutofillSettingsServiceAbstraction,
@@ -716,6 +718,11 @@ const safeProviders: SafeProvider[] = [
     provide: NewDeviceVerificationComponentService,
     useClass: ExtensionNewDeviceVerificationComponentService,
     deps: [],
+  }),
+  safeProvider({
+    provide: NavigatorCredentialsService,
+    useClass: DefaultNavigatorCredentialsService,
+    deps: [WINDOW, PlatformUtilsService],
   }),
   safeProvider({
     provide: SessionTimeoutSettingsComponentService,

--- a/apps/desktop/desktop_native/Cargo.lock
+++ b/apps/desktop/desktop_native/Cargo.lock
@@ -114,9 +114,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.94"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1fd03a028ef38ba2276dce7e33fcd6369c158a1bca17946c4b1b701891c1ff7"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "arboard"
@@ -195,9 +195,9 @@ dependencies = [
 
 [[package]]
 name = "asn1-rs"
-version = "0.6.2"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
+checksum = "56624a96882bb8c26d61312ae18cb45868e5a9992ea73c58e45c3101e56a1e60"
 dependencies = [
  "asn1-rs-derive",
  "asn1-rs-impl",
@@ -205,15 +205,15 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "time",
 ]
 
 [[package]]
 name = "asn1-rs-derive"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -594,9 +594,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.4"
+version = "1.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9157bbaa6b165880c27a4293a474c91cdcf265cc68cc829bf10be0964a391caf"
+checksum = "ad0cf6e91fde44c773c6ee7ec6bba798504641a8bc2eb7e37a04ffbf4dfaa55a"
 dependencies = [
  "shlex",
 ]
@@ -661,6 +661,33 @@ dependencies = [
  "tracing",
  "verifysign",
  "windows 0.61.1",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -796,6 +823,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "crypto-bigint"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -820,22 +853,22 @@ dependencies = [
 
 [[package]]
 name = "ctap-hid-fido2"
-version = "3.5.1"
+version = "3.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee6473a333d82796d5b23529fde19386de33820ad19d368402f8e9de780e1723"
+checksum = "2b1d1ba802b7e50be2c6e007fe01d25f4a00060fee1920ce714f93a5285890f4"
 dependencies = [
  "aes",
  "anyhow",
  "base64",
  "byteorder",
  "cbc",
+ "ciborium",
  "hex",
  "hidapi",
  "num",
  "pad",
+ "rand 0.9.1",
  "ring",
- "serde",
- "serde_cbor",
  "strum",
  "strum_macros",
  "x509-parser",
@@ -981,9 +1014,9 @@ dependencies = [
 
 [[package]]
 name = "der-parser"
-version = "9.0.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
 dependencies = [
  "asn1-rs",
  "displaydoc",
@@ -1412,6 +1445,7 @@ name = "fido2_client"
 version = "0.0.0"
 dependencies = [
  "base64",
+ "cc",
  "ctap-hid-fido2",
  "pinentry",
  "secrecy",
@@ -1653,9 +1687,13 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "1.8.3"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
+checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1695,14 +1733,15 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hidapi"
-version = "1.5.0"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "798154e4b6570af74899d71155fb0072d5b17e6aa12f39c8ef22c60fb8ec99e7"
+checksum = "03b876ecf37e86b359573c16c8366bc3eba52b689884a0fc42ba3f67203d2a8b"
 dependencies = [
  "cc",
+ "cfg-if",
  "libc",
  "pkg-config",
- "winapi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2447,9 +2486,9 @@ dependencies = [
 
 [[package]]
 name = "oid-registry"
-version = "0.7.1"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
 dependencies = [
  "asn1-rs",
 ]
@@ -3033,9 +3072,9 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.9"
+version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e75ec5e92c4d8aede845126adc388046234541629e76029599ed35a003c7ed24"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
@@ -3309,16 +3348,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_cbor"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
-dependencies = [
- "half",
- "serde",
-]
-
-[[package]]
 name = "serde_derive"
 version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3563,20 +3592,19 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.26.3"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 
 [[package]]
 name = "strum_macros"
-version = "0.26.4"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "rustversion",
  "syn",
 ]
 
@@ -4931,9 +4959,9 @@ checksum = "ec107c4503ea0b4a98ef47356329af139c0a4f7750e621cf2973cd3385ebcb3d"
 
 [[package]]
 name = "x509-parser"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
+checksum = "4569f339c0c402346d4a75a9e39cf8dad310e287eef1ff56d4c68e5067f53460"
 dependencies = [
  "asn1-rs",
  "data-encoding",
@@ -4942,7 +4970,7 @@ dependencies = [
  "nom",
  "oid-registry",
  "rusticata-macros",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "time",
 ]
 

--- a/apps/desktop/desktop_native/Cargo.lock
+++ b/apps/desktop/desktop_native/Cargo.lock
@@ -194,6 +194,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "asn1-rs"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -608,7 +647,7 @@ dependencies = [
  "async-trait",
  "base64",
  "cbc",
- "dirs",
+ "dirs 6.0.0",
  "hex",
  "oo7",
  "pbkdf2",
@@ -692,7 +731,7 @@ checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
 dependencies = [
  "serde",
  "termcolor",
- "unicode-width",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -777,6 +816,29 @@ dependencies = [
  "generic-array",
  "rand_core 0.6.4",
  "typenum",
+]
+
+[[package]]
+name = "ctap-hid-fido2"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6473a333d82796d5b23529fde19386de33820ad19d368402f8e9de780e1723"
+dependencies = [
+ "aes",
+ "anyhow",
+ "base64",
+ "byteorder",
+ "cbc",
+ "hex",
+ "hidapi",
+ "num",
+ "pad",
+ "ring",
+ "serde",
+ "serde_cbor",
+ "strum",
+ "strum_macros",
+ "x509-parser",
 ]
 
 [[package]]
@@ -901,6 +963,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -909,6 +977,29 @@ dependencies = [
  "const-oid",
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "der-parser"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
+dependencies = [
+ "powerfmt",
 ]
 
 [[package]]
@@ -927,7 +1018,7 @@ dependencies = [
  "chacha20poly1305",
  "core-foundation",
  "desktop_objc",
- "dirs",
+ "dirs 6.0.0",
  "ed25519",
  "futures",
  "homedir",
@@ -975,6 +1066,7 @@ dependencies = [
  "base64",
  "chromium_importer",
  "desktop_core",
+ "fido2_client",
  "hex",
  "napi",
  "napi-build",
@@ -1031,11 +1123,32 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
+name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.4.6",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1046,7 +1159,7 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.5.0",
  "windows-sys 0.61.2",
 ]
 
@@ -1142,6 +1255,12 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elliptic-curve"
@@ -1287,6 +1406,18 @@ name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "fido2_client"
+version = "0.0.0"
+dependencies = [
+ "base64",
+ "ctap-hid-fido2",
+ "pinentry",
+ "secrecy",
+ "serde",
+ "sha2",
+]
 
 [[package]]
 name = "fixedbitset"
@@ -1521,6 +1652,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
+
+[[package]]
 name = "hashbrown"
 version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1555,6 +1692,18 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hidapi"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "798154e4b6570af74899d71155fb0072d5b17e6aa12f39c8ef22c60fb8ec99e7"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "winapi",
+]
 
 [[package]]
 name = "hkdf"
@@ -2158,6 +2307,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2291,6 +2446,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "oid-registry"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
+dependencies = [
+ "asn1-rs",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2398,6 +2562,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pad"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ad9b889f1b12e0b9ee24db044b5129150d5eada288edc800f789928dc8c0e3"
+dependencies = [
+ "unicode-width 0.1.14",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2498,6 +2671,20 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pinentry"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72268b7db3a2075ea65d4b93b755d086e99196e327837e690db6559b393a8d69"
+dependencies = [
+ "log",
+ "nom",
+ "percent-encoding",
+ "secrecy",
+ "which",
+ "zeroize",
+]
 
 [[package]]
 name = "piper"
@@ -2606,6 +2793,12 @@ checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -2779,6 +2972,17 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
@@ -2825,6 +3029,20 @@ checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
  "hmac",
  "subtle",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e75ec5e92c4d8aede845126adc388046234541629e76029599ed35a003c7ed24"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.16",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2885,6 +3103,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -3032,6 +3259,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "secrecy"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3070,6 +3306,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde_cbor"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
+dependencies = [
+ "half",
+ "serde",
 ]
 
 [[package]]
@@ -3316,6 +3562,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3441,6 +3706,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+
+[[package]]
+name = "time-macros"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -3695,6 +3991,12 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
@@ -3838,6 +4140,12 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -4005,6 +4313,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "998d2c24ec099a87daf9467808859f9d82b61f1d9c9701251aea037f514eae0e"
 dependencies = [
  "nom",
+]
+
+[[package]]
+name = "which"
+version = "4.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ad25fe5717e59ada8ea33511bbbf7420b11031730a24c65e82428766c307006"
+dependencies = [
+ "dirs 5.0.1",
+ "either",
+ "once_cell",
+ "rustix 0.38.44",
 ]
 
 [[package]]
@@ -4240,6 +4560,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -4599,6 +4928,23 @@ name = "x11rb-protocol"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec107c4503ea0b4a98ef47356329af139c0a4f7750e621cf2973cd3385ebcb3d"
+
+[[package]]
+name = "x509-parser"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
+]
 
 [[package]]
 name = "yoke"

--- a/apps/desktop/desktop_native/Cargo.toml
+++ b/apps/desktop/desktop_native/Cargo.toml
@@ -22,7 +22,7 @@ publish = false
 [workspace.dependencies]
 aes = "=0.8.4"
 aes-gcm = "=0.10.3"
-anyhow = "=1.0.94"
+anyhow = "=1.0.100"
 arboard = { version = "=3.6.0", default-features = false }
 ashpd = "=0.11.0"
 base64 = "=0.22.1"

--- a/apps/desktop/desktop_native/Cargo.toml
+++ b/apps/desktop/desktop_native/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "bitwarden_chromium_import_helper",
     "chromium_importer",
     "core",
+    "fido2_client",
     "macos_provider",
     "napi",
     "process_isolation",

--- a/apps/desktop/desktop_native/build.js
+++ b/apps/desktop/desktop_native/build.js
@@ -6,115 +6,135 @@ const process = require("process");
 
 // Map of the Node arch equivalents for the rust target triplets, used to move the file to the correct location
 const rustTargetsMap = {
-    "i686-pc-windows-msvc":       { nodeArch: 'ia32',  platform: 'win32'  },
-    "x86_64-pc-windows-msvc":     { nodeArch: 'x64',   platform: 'win32'  },
-    "aarch64-pc-windows-msvc":    { nodeArch: 'arm64', platform: 'win32'  },
-    "x86_64-apple-darwin":        { nodeArch: 'x64',   platform: 'darwin' },
-    "aarch64-apple-darwin":       { nodeArch: 'arm64', platform: 'darwin' },
-    'x86_64-unknown-linux-musl':  { nodeArch: 'x64',   platform: 'linux'  },
-    'aarch64-unknown-linux-musl': { nodeArch: 'arm64', platform: 'linux'  },
-}
+  "i686-pc-windows-msvc": { nodeArch: "ia32", platform: "win32" },
+  "x86_64-pc-windows-msvc": { nodeArch: "x64", platform: "win32" },
+  "aarch64-pc-windows-msvc": { nodeArch: "arm64", platform: "win32" },
+  "x86_64-apple-darwin": { nodeArch: "x64", platform: "darwin" },
+  "aarch64-apple-darwin": { nodeArch: "arm64", platform: "darwin" },
+  "x86_64-unknown-linux-musl": { nodeArch: "x64", platform: "linux" },
+  "aarch64-unknown-linux-musl": { nodeArch: "arm64", platform: "linux" },
+};
 
 // Ensure the dist directory exists
 fs.mkdirSync(path.join(__dirname, "dist"), { recursive: true });
 
 const args = process.argv.slice(2); // Get arguments passed to the script
 const mode = args.includes("--release") ? "release" : "debug";
-const targetArg = args.find(arg => arg.startsWith("--target="));
+const targetArg = args.find((arg) => arg.startsWith("--target="));
 const target = targetArg ? targetArg.split("=")[1] : null;
 
 let crossPlatform = process.argv.length > 2 && process.argv[2] === "cross-platform";
 
 function buildNapiModule(target, release = true) {
-    const targetArg = target ? `--target ${target}` : "";
-    const releaseArg = release ? "--release" : "";
-    child_process.execSync(`npm run build -- ${releaseArg} ${targetArg}`, { stdio: 'inherit', cwd: path.join(__dirname, "napi") });
+  const targetArg = target ? `--target ${target}` : "";
+  const releaseArg = release ? "--release" : "";
+  child_process.execSync(`npm run build -- ${releaseArg} ${targetArg}`, {
+    stdio: "inherit",
+    cwd: path.join(__dirname, "napi"),
+  });
 }
 
 function buildProxyBin(target, release = true) {
-    const targetArg = target ? `--target ${target}` : "";
-    const releaseArg = release ? "--release" : "";
-    child_process.execSync(`cargo build --bin desktop_proxy ${releaseArg} ${targetArg}`, {stdio: 'inherit', cwd: path.join(__dirname, "proxy")});
+  const targetArg = target ? `--target ${target}` : "";
+  const releaseArg = release ? "--release" : "";
+  child_process.execSync(`cargo build --bin desktop_proxy ${releaseArg} ${targetArg}`, {
+    stdio: "inherit",
+    cwd: path.join(__dirname, "proxy"),
+  });
 
-    if (target) {
-        // Copy the resulting binary to the dist folder
-        const targetFolder = release ? "release" : "debug";
-        const ext = process.platform === "win32" ? ".exe" : "";
-        const nodeArch = rustTargetsMap[target].nodeArch;
-        fs.copyFileSync(path.join(__dirname, "target", target, targetFolder, `desktop_proxy${ext}`), path.join(__dirname, "dist", `desktop_proxy.${process.platform}-${nodeArch}${ext}`));
-    }
+  if (target) {
+    // Copy the resulting binary to the dist folder
+    const targetFolder = release ? "release" : "debug";
+    const ext = process.platform === "win32" ? ".exe" : "";
+    const nodeArch = rustTargetsMap[target].nodeArch;
+    fs.copyFileSync(
+      path.join(__dirname, "target", target, targetFolder, `desktop_proxy${ext}`),
+      path.join(__dirname, "dist", `desktop_proxy.${process.platform}-${nodeArch}${ext}`),
+    );
+  }
 }
 
 function buildImporterBinaries(target, release = true) {
-    // These binaries are only built for Windows, so we can skip them on other platforms
-    if (process.platform !== "win32") {
-        return;
-    }
+  // These binaries are only built for Windows, so we can skip them on other platforms
+  if (process.platform !== "win32") {
+    return;
+  }
 
-    const bin = "bitwarden_chromium_import_helper";
-    const targetArg = target ? `--target ${target}` : "";
-    const releaseArg = release ? "--release" : "";
-    child_process.execSync(`cargo build --bin ${bin} ${releaseArg} ${targetArg}`);
+  const bin = "bitwarden_chromium_import_helper";
+  const targetArg = target ? `--target ${target}` : "";
+  const releaseArg = release ? "--release" : "";
+  child_process.execSync(`cargo build --bin ${bin} ${releaseArg} ${targetArg}`);
 
-    if (target) {
-        // Copy the resulting binary to the dist folder
-        const targetFolder = release ? "release" : "debug";
-        const nodeArch = rustTargetsMap[target].nodeArch;
-        fs.copyFileSync(path.join(__dirname, "target", target, targetFolder, `${bin}.exe`), path.join(__dirname, "dist", `${bin}.${process.platform}-${nodeArch}.exe`));
-    }
+  if (target) {
+    // Copy the resulting binary to the dist folder
+    const targetFolder = release ? "release" : "debug";
+    const nodeArch = rustTargetsMap[target].nodeArch;
+    fs.copyFileSync(
+      path.join(__dirname, "target", target, targetFolder, `${bin}.exe`),
+      path.join(__dirname, "dist", `${bin}.${process.platform}-${nodeArch}.exe`),
+    );
+  }
 }
 
 function buildProcessIsolation() {
-    if (process.platform !== "linux") {
-        return;
-    }
+  if (process.platform !== "linux") {
+    return;
+  }
 
-    child_process.execSync(`cargo build --release`, {
-        stdio: 'inherit',
-        cwd: path.join(__dirname, "process_isolation")
-    });
+  child_process.execSync(`cargo build --release`, {
+    stdio: "inherit",
+    cwd: path.join(__dirname, "process_isolation"),
+  });
 
-    console.log("Copying process isolation library to dist folder");
-    fs.copyFileSync(path.join(__dirname, "target", "release", "libprocess_isolation.so"), path.join(__dirname, "dist", `libprocess_isolation.so`));
+  console.log("Copying process isolation library to dist folder");
+  fs.copyFileSync(
+    path.join(__dirname, "target", "release", "libprocess_isolation.so"),
+    path.join(__dirname, "dist", `libprocess_isolation.so`),
+  );
 }
 
 function installTarget(target) {
-    child_process.execSync(`rustup target add ${target}`, { stdio: 'inherit', cwd: __dirname });
+  child_process.execSync(`rustup target add ${target}`, { stdio: "inherit", cwd: __dirname });
 }
 
 if (!crossPlatform && !target) {
-    console.log(`Building native modules in ${mode} mode for the native architecture`);
-    buildNapiModule(false, mode === "release");
-    buildProxyBin(false, mode === "release");
-    buildImporterBinaries(false, mode === "release");
-    buildProcessIsolation();
-    return;
+  console.log(`Building native modules in ${mode} mode for the native architecture`);
+  buildNapiModule(false, mode === "release");
+  buildProxyBin(false, mode === "release");
+  buildImporterBinaries(false, mode === "release");
+  buildProcessIsolation();
+  return;
 }
 
 if (target) {
-    console.log(`Building for target: ${target} in ${mode} mode`);
-    installTarget(target);
-    buildNapiModule(target, mode === "release");
-    buildProxyBin(target, mode === "release");
-    buildImporterBinaries(false, mode === "release");
-    buildProcessIsolation();
-    return;
+  console.log(`Building for target: ${target} in ${mode} mode`);
+  installTarget(target);
+  buildNapiModule(target, mode === "release");
+  buildProxyBin(target, mode === "release");
+  buildImporterBinaries(false, mode === "release");
+  buildProcessIsolation();
+  return;
 }
 
 // Filter the targets based on the current platform, and build for each of them
-let platformTargets = Object.entries(rustTargetsMap).filter(([_, { platform: p }]) => p === process.platform);
-console.log("Cross building native modules for the targets: ", platformTargets.map(([target, _]) => target).join(", "));
+let platformTargets = Object.entries(rustTargetsMap).filter(
+  ([_, { platform: p }]) => p === process.platform,
+);
+console.log(
+  "Cross building native modules for the targets: ",
+  platformTargets.map(([target, _]) => target).join(", "),
+);
 
 // When building for Linux, we need to set some environment variables to allow cross-compilation
 if (process.platform === "linux") {
-    process.env["PKG_CONFIG_ALLOW_CROSS"] = "1";
-    process.env["PKG_CONFIG_ALL_STATIC"] = "1";
+  process.env["PKG_CONFIG_ALLOW_CROSS"] = "1";
+  process.env["PKG_CONFIG_ALL_STATIC"] = "1";
 }
 
 platformTargets.forEach(([target, _]) => {
-    installTarget(target);
-    buildNapiModule(target);
-    buildProxyBin(target);
-    buildImporterBinaries(target);
-    buildProcessIsolation();
+  installTarget(target);
+  buildNapiModule(target);
+  buildProxyBin(target);
+  buildImporterBinaries(target);
+  buildProcessIsolation();
 });

--- a/apps/desktop/desktop_native/fido2_client/Cargo.toml
+++ b/apps/desktop/desktop_native/fido2_client/Cargo.toml
@@ -6,7 +6,7 @@ version = { workspace = true }
 publish = { workspace = true }
 
 [features]
-default = ["ctap-hid-fido2"]
+default = []
 ctap-hid-fido2 = ["dep:ctap-hid-fido2", "dep:pinentry", "dep:secrecy"]
 
 [dependencies]

--- a/apps/desktop/desktop_native/fido2_client/Cargo.toml
+++ b/apps/desktop/desktop_native/fido2_client/Cargo.toml
@@ -12,7 +12,7 @@ ctap-hid-fido2 = ["dep:ctap-hid-fido2", "dep:pinentry", "dep:secrecy"]
 [dependencies]
 base64 = { workspace = true }
 ctap-hid-fido2 = { version = "3.5.1", optional = true }
-pinentry = { version = "0.5.0", optional = true}
-serde = { workspace = true, features = ["derive"] }
+pinentry = { version = "0.5.0", optional = true }
 secrecy = { version = "0.8.0", optional = true }
+serde = { workspace = true, features = ["derive"] }
 sha2 = { workspace = true }

--- a/apps/desktop/desktop_native/fido2_client/Cargo.toml
+++ b/apps/desktop/desktop_native/fido2_client/Cargo.toml
@@ -6,7 +6,7 @@ version = { workspace = true }
 publish = { workspace = true }
 
 [features]
-default = []
+default = ["ctap-hid-fido2"]
 ctap-hid-fido2 = ["dep:ctap-hid-fido2", "dep:pinentry", "dep:secrecy"]
 
 [dependencies]

--- a/apps/desktop/desktop_native/fido2_client/Cargo.toml
+++ b/apps/desktop/desktop_native/fido2_client/Cargo.toml
@@ -5,10 +5,14 @@ license = { workspace = true }
 version = { workspace = true }
 publish = { workspace = true }
 
+[features]
+default = []
+ctap-hid-fido2 = ["dep:ctap-hid-fido2", "dep:pinentry", "dep:secrecy"]
+
 [dependencies]
 base64 = { workspace = true }
-ctap-hid-fido2 = "3.5.1"
-pinentry = "0.5.0"
+ctap-hid-fido2 = { version = "3.5.1", optional = true }
+pinentry = { version = "0.5.0", optional = true}
 serde = { workspace = true, features = ["derive"] }
-secrecy = "0.8.0"
+secrecy = { version = "0.8.0", optional = true }
 sha2 = { workspace = true }

--- a/apps/desktop/desktop_native/fido2_client/Cargo.toml
+++ b/apps/desktop/desktop_native/fido2_client/Cargo.toml
@@ -11,7 +11,8 @@ ctap-hid-fido2 = ["dep:ctap-hid-fido2", "dep:pinentry", "dep:secrecy"]
 
 [dependencies]
 base64 = { workspace = true }
-ctap-hid-fido2 = { version = "3.5.1", optional = true }
+cc = { version = "1.2.8" }
+ctap-hid-fido2 = { version = "3.5.5", optional = true }
 pinentry = { version = "0.5.0", optional = true }
 secrecy = { version = "0.8.0", optional = true }
 serde = { workspace = true, features = ["derive"] }

--- a/apps/desktop/desktop_native/fido2_client/Cargo.toml
+++ b/apps/desktop/desktop_native/fido2_client/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "fido2_client"
+edition = { workspace = true }
+license = { workspace = true }
+version = { workspace = true }
+publish = { workspace = true }
+
+[dependencies]
+base64 = { workspace = true }
+ctap-hid-fido2 = "3.5.1"
+pinentry = "0.5.0"
+serde = { workspace = true, features = ["derive"] }
+secrecy = "0.8.0"
+sha2 = { workspace = true }

--- a/apps/desktop/desktop_native/fido2_client/src/ctap_hid_fido2.rs
+++ b/apps/desktop/desktop_native/fido2_client/src/ctap_hid_fido2.rs
@@ -11,6 +11,12 @@ use crate::{
     PublicKeyCredentialRequestOptions,
 };
 
+/// Depending on the platform API, the platform MAY do this for you, or may require you to do it manually.
+fn prf_to_hmac(prf_salt: &[u8]) -> [u8; 32] {
+    use sha2::Digest;
+    sha2::Sha256::digest(&[b"WebAuthn PRF".as_slice(), &[0], prf_salt].concat()).into()
+}
+
 fn get_pin() -> Option<String> {
     if let Some(mut input) = PassphraseInput::with_default_binary() {
         input

--- a/apps/desktop/desktop_native/fido2_client/src/ctap_hid_fido2.rs
+++ b/apps/desktop/desktop_native/fido2_client/src/ctap_hid_fido2.rs
@@ -1,0 +1,145 @@
+use base64::{prelude::BASE64_URL_SAFE_NO_PAD, Engine};
+use ctap_hid_fido2::{
+    fidokey::{AssertionExtension, GetAssertionArgsBuilder},
+    Cfg, FidoKeyHidFactory,
+};
+use pinentry::PassphraseInput;
+use secrecy::ExposeSecret;
+
+use crate::{
+    prf_to_hmac, AuthenticatorAssertionResponse, Fido2ClientError, PublicKeyCredential,
+    PublicKeyCredentialRequestOptions,
+};
+
+fn get_pin() -> Option<String> {
+    if let Some(mut input) = PassphraseInput::with_default_binary() {
+        input
+            .with_description("Enter your FIDO2 Authenticator PIN:")
+            .with_prompt("PIN:")
+            .interact()
+            .ok()
+            .map(|p| p.expose_secret().to_owned())
+    } else {
+        None
+    }
+}
+
+pub fn available() -> bool {
+    true
+}
+
+fn make_assertion(
+    options: PublicKeyCredentialRequestOptions,
+    client_data_json: String,
+    credential: Option<&[u8]>,
+) -> Result<GetAssertionArgsBuilder, Fido2ClientError> {
+    let mut get_assertion_args =
+        GetAssertionArgsBuilder::new(options.rp_id.as_str(), client_data_json.as_bytes())
+            .extensions(&[AssertionExtension::HmacSecret(Some(prf_to_hmac(
+                &options.prf_eval_first,
+            )))]);
+
+    if let Some(cred) = credential {
+        get_assertion_args = get_assertion_args.credential_id(cred);
+    }
+    Ok(get_assertion_args)
+}
+
+pub fn get(
+    options: PublicKeyCredentialRequestOptions,
+) -> Result<PublicKeyCredential, Fido2ClientError> {
+    let device = FidoKeyHidFactory::create(&Cfg::init()).map_err(|_| Fido2ClientError::NoDevice)?;
+
+    let client_data_json = format!(
+        r#"{{"type":"webauthn.get","challenge":"{}","origin":"https://{}","crossOrigin": true}}"#,
+        BASE64_URL_SAFE_NO_PAD.encode(&options.challenge),
+        options.rp_id
+    );
+
+    let mut get_assertion_args = make_assertion(
+        options.clone(),
+        client_data_json.clone(),
+        options.allow_credentials.get(0).map(|v| v.as_slice()),
+    )?;
+
+    let pin: String;
+    if options.user_verification == crate::UserVerification::Required
+        || options.user_verification == crate::UserVerification::Preferred
+    {
+        pin = get_pin().ok_or(Fido2ClientError::WrongPin)?;
+        get_assertion_args = get_assertion_args.pin(pin.as_str());
+    }
+
+    let mut assertions = device
+        .get_assertion_with_args(&get_assertion_args.build())
+        .map_err(|_e| Fido2ClientError::AssertionError)?;
+
+    let assertion = if assertions.len() > 1 {
+        let first_assertion = &assertions[0];
+        let mut get_assertion_args = make_assertion(
+            options.clone(),
+            client_data_json.clone(),
+            Some(&first_assertion.credential_id),
+        )?;
+        let pin: String;
+        if options.user_verification == crate::UserVerification::Required
+            || options.user_verification == crate::UserVerification::Preferred
+        {
+            pin = get_pin().ok_or(Fido2ClientError::WrongPin)?;
+            get_assertion_args = get_assertion_args.pin(pin.as_str());
+        }
+
+        assertions = device
+            .get_assertion_with_args(&get_assertion_args.build())
+            .map_err(|_e| Fido2ClientError::AssertionError)?;
+        assertions.get(0).ok_or(Fido2ClientError::AssertionError)?
+    } else {
+        assertions.get(0).ok_or(Fido2ClientError::AssertionError)?
+    };
+
+    let prf_extension = assertion
+        .extensions
+        .iter()
+        .find_map(|ext| {
+            if let AssertionExtension::HmacSecret(results) = ext {
+                Some(*results)
+            } else {
+                None
+            }
+        })
+        .flatten();
+
+    Ok(PublicKeyCredential {
+        authenticator_attachment: "cross-platform".to_string(),
+        id: BASE64_URL_SAFE_NO_PAD.encode(&assertion.credential_id),
+        raw_id: assertion.credential_id.clone(),
+        response: AuthenticatorAssertionResponse {
+            authenticator_data: assertion.auth_data.clone(),
+            client_data_json: client_data_json.as_bytes().to_vec(),
+            signature: assertion.signature.clone(),
+            user_handle: assertion.user.id.clone(),
+        },
+        r#type: "public-key".to_string(),
+        prf: prf_extension,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{ctap_hid_fido2::get, PublicKeyCredentialRequestOptions};
+
+    #[test]
+    #[ignore]
+    fn assertion() {
+        get(PublicKeyCredentialRequestOptions {
+            challenge: vec![],
+            timeout: 0,
+            rp_id: "vault.usdev.bitwarden.pw".to_string(),
+            user_verification: crate::UserVerification::Required,
+            allow_credentials: vec![],
+            prf_eval_first: [0u8; 32],
+            prf_eval_second: None,
+        })
+        .unwrap();
+    }
+}

--- a/apps/desktop/desktop_native/fido2_client/src/ctap_hid_fido2.rs
+++ b/apps/desktop/desktop_native/fido2_client/src/ctap_hid_fido2.rs
@@ -14,7 +14,7 @@ use crate::{
 /// Depending on the platform API, the platform MAY do this for you, or may require you to do it manually.
 fn prf_to_hmac(prf_salt: &[u8]) -> [u8; 32] {
     use sha2::Digest;
-    sha2::Sha256::digest(&[b"WebAuthn PRF".as_slice(), &[0], prf_salt].concat()).into()
+    sha2::Sha256::digest([b"WebAuthn PRF".as_slice(), &[0], prf_salt].concat()).into()
 }
 
 fn get_pin() -> Option<String> {
@@ -68,7 +68,7 @@ pub fn get(
     let mut get_assertion_args = make_assertion(
         options.clone(),
         client_data_json.clone(),
-        options.allow_credentials.get(0).map(|v| v.as_slice()),
+        options.allow_credentials.first().map(|v| v.as_slice()),
     )?;
 
     let pin: String;
@@ -101,9 +101,9 @@ pub fn get(
         assertions = device
             .get_assertion_with_args(&get_assertion_args.build())
             .map_err(|_e| Fido2ClientError::AssertionError)?;
-        assertions.get(0).ok_or(Fido2ClientError::AssertionError)?
+        assertions.first().ok_or(Fido2ClientError::AssertionError)?
     } else {
-        assertions.get(0).ok_or(Fido2ClientError::AssertionError)?
+        assertions.first().ok_or(Fido2ClientError::AssertionError)?
     };
 
     let prf_extension = assertion

--- a/apps/desktop/desktop_native/fido2_client/src/ctap_hid_fido2.rs
+++ b/apps/desktop/desktop_native/fido2_client/src/ctap_hid_fido2.rs
@@ -30,7 +30,7 @@ fn get_pin() -> Option<String> {
     }
 }
 
-pub fn available() -> bool {
+pub(crate) fn available() -> bool {
     true
 }
 
@@ -54,7 +54,7 @@ fn make_assertion(
     Ok(get_assertion_args)
 }
 
-pub fn get(
+pub(crate) fn get(
     options: PublicKeyCredentialRequestOptions,
 ) -> Result<PublicKeyCredential, Fido2ClientError> {
     let device = FidoKeyHidFactory::create(&Cfg::init()).map_err(|_| Fido2ClientError::NoDevice)?;

--- a/apps/desktop/desktop_native/fido2_client/src/lib.rs
+++ b/apps/desktop/desktop_native/fido2_client/src/lib.rs
@@ -1,19 +1,12 @@
-#[cfg(all(target_os = "linux", target_env = "gnu"))]
+#[cfg(feature = "ctap-hid-fido2")]
 mod ctap_hid_fido2;
-#[cfg(all(target_os = "linux", target_env = "gnu"))]
+#[cfg(feature = "ctap-hid-fido2")]
 use ctap_hid_fido2::*;
 
-#[cfg(not(all(target_os = "linux", target_env = "gnu")))]
+#[cfg(not(feature = "ctap-hid-fido2"))]
 mod unimplemented;
-#[cfg(not(all(target_os = "linux", target_env = "gnu")))]
+#[cfg(not(feature = "ctap-hid-fido2"))]
 use unimplemented::*;
-
-#[cfg(all(target_os = "linux", target_env = "gnu"))]
-/// Depending on the platform API, the platform MAY do this for you, or may require you to do it manually.
-fn prf_to_hmac(prf_salt: &[u8]) -> [u8; 32] {
-    use sha2::Digest;
-    sha2::Sha256::digest(&[b"WebAuthn PRF".as_slice(), &[0], prf_salt].concat()).into()
-}
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum UserVerification {

--- a/apps/desktop/desktop_native/fido2_client/src/lib.rs
+++ b/apps/desktop/desktop_native/fido2_client/src/lib.rs
@@ -1,0 +1,78 @@
+#[cfg(all(target_os = "linux", target_env = "gnu"))]
+mod ctap_hid_fido2;
+#[cfg(all(target_os = "linux", target_env = "gnu"))]
+use ctap_hid_fido2::*;
+
+#[cfg(not(all(target_os = "linux", target_env = "gnu")))]
+mod unimplemented;
+#[cfg(not(all(target_os = "linux", target_env = "gnu")))]
+use unimplemented::*;
+
+#[cfg(all(target_os = "linux", target_env = "gnu"))]
+/// Depending on the platform API, the platform MAY do this for you, or may require you to do it manually.
+fn prf_to_hmac(prf_salt: &[u8]) -> [u8; 32] {
+    use sha2::Digest;
+    sha2::Sha256::digest(&[b"WebAuthn PRF".as_slice(), &[0], prf_salt].concat()).into()
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub enum UserVerification {
+    Discouraged,
+    Preferred,
+    Required,
+}
+
+#[derive(Debug, Clone)]
+pub struct PrfConfig {
+    pub first: Vec<u8>,
+    pub second: Option<Vec<u8>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct PublicKeyCredentialRequestOptions {
+    pub challenge: Vec<u8>,
+    pub timeout: u64,
+    pub rp_id: String,
+    pub user_verification: UserVerification,
+    pub allow_credentials: Vec<Vec<u8>>,
+    pub prf: Option<PrfConfig>,
+}
+
+#[derive(Debug)]
+pub struct AuthenticatorAssertionResponse {
+    pub authenticator_data: Vec<u8>,
+    pub client_data_json: Vec<u8>,
+    pub signature: Vec<u8>,
+    pub user_handle: Vec<u8>,
+}
+
+#[derive(Debug)]
+pub struct PublicKeyCredential {
+    pub authenticator_attachment: String,
+    pub id: String,
+    pub raw_id: Vec<u8>,
+    pub response: AuthenticatorAssertionResponse,
+    pub r#type: String,
+    pub prf: Option<[u8; 32]>,
+}
+
+#[derive(Debug)]
+pub enum Fido2ClientError {
+    WrongPin,
+    NoCredentials,
+    NoDevice,
+    InvalidInput,
+    AssertionError,
+}
+
+pub mod fido2_client {
+    pub fn get(
+        assertion_options: super::PublicKeyCredentialRequestOptions,
+    ) -> Result<super::PublicKeyCredential, super::Fido2ClientError> {
+        super::get(assertion_options)
+    }
+
+    pub fn available() -> bool {
+        super::available()
+    }
+}

--- a/apps/desktop/desktop_native/fido2_client/src/unimplemented.rs
+++ b/apps/desktop/desktop_native/fido2_client/src/unimplemented.rs
@@ -1,11 +1,11 @@
 use crate::{Fido2ClientError, PublicKeyCredential, PublicKeyCredentialRequestOptions};
 
-pub fn get(
+pub(crate) fn get(
     _options: PublicKeyCredentialRequestOptions,
 ) -> Result<PublicKeyCredential, Fido2ClientError> {
     todo!("Fido2Client is unimplemented on this platform");
 }
 
-pub fn available() -> bool {
+pub(crate) fn available() -> bool {
     false
 }

--- a/apps/desktop/desktop_native/fido2_client/src/unimplemented.rs
+++ b/apps/desktop/desktop_native/fido2_client/src/unimplemented.rs
@@ -1,0 +1,11 @@
+use crate::{Fido2ClientError, PublicKeyCredential, PublicKeyCredentialRequestOptions};
+
+pub fn get(
+    _options: PublicKeyCredentialRequestOptions,
+) -> Result<PublicKeyCredential, Fido2ClientError> {
+    todo!("Fido2Client is unimplemented on this platform");
+}
+
+pub fn available() -> bool {
+    false
+}

--- a/apps/desktop/desktop_native/napi/Cargo.toml
+++ b/apps/desktop/desktop_native/napi/Cargo.toml
@@ -19,6 +19,7 @@ autotype = { path = "../autotype" }
 base64 = { workspace = true }
 chromium_importer = { path = "../chromium_importer" }
 desktop_core = { path = "../core" }
+fido2_client = { path = "../fido2_client" }
 hex = { workspace = true }
 napi = { workspace = true, features = ["async"] }
 napi-derive = { workspace = true }

--- a/apps/desktop/desktop_native/napi/index.d.ts
+++ b/apps/desktop/desktop_native/napi/index.d.ts
@@ -5,31 +5,41 @@
 
 export declare namespace passwords {
   /** The error message returned when a password is not found during retrieval or deletion. */
-  export const PASSWORD_NOT_FOUND: string
+  export const PASSWORD_NOT_FOUND: string;
   /**
    * Fetch the stored password from the keychain.
    * Throws {@link Error} with message {@link PASSWORD_NOT_FOUND} if the password does not exist.
    */
-  export function getPassword(service: string, account: string): Promise<string>
+  export function getPassword(service: string, account: string): Promise<string>;
   /** Save the password to the keychain. Adds an entry if none exists otherwise updates the existing entry. */
-  export function setPassword(service: string, account: string, password: string): Promise<void>
+  export function setPassword(service: string, account: string, password: string): Promise<void>;
   /**
    * Delete the stored password from the keychain.
    * Throws {@link Error} with message {@link PASSWORD_NOT_FOUND} if the password does not exist.
    */
-  export function deletePassword(service: string, account: string): Promise<void>
+  export function deletePassword(service: string, account: string): Promise<void>;
   /** Checks if the os secure storage is available */
-  export function isAvailable(): Promise<boolean>
+  export function isAvailable(): Promise<boolean>;
 }
 export declare namespace biometrics {
-  export function prompt(hwnd: Buffer, message: string): Promise<boolean>
-  export function available(): Promise<boolean>
-  export function setBiometricSecret(service: string, account: string, secret: string, keyMaterial: KeyMaterial | undefined | null, ivB64: string): Promise<string>
+  export function prompt(hwnd: Buffer, message: string): Promise<boolean>;
+  export function available(): Promise<boolean>;
+  export function setBiometricSecret(
+    service: string,
+    account: string,
+    secret: string,
+    keyMaterial: KeyMaterial | undefined | null,
+    ivB64: string,
+  ): Promise<string>;
   /**
    * Retrieves the biometric secret for the given service and account.
    * Throws Error with message [`passwords::PASSWORD_NOT_FOUND`] if the secret does not exist.
    */
-  export function getBiometricSecret(service: string, account: string, keyMaterial?: KeyMaterial | undefined | null): Promise<string>
+  export function getBiometricSecret(
+    service: string,
+    account: string,
+    keyMaterial?: KeyMaterial | undefined | null,
+  ): Promise<string>;
   /**
    * Derives key material from biometric data. Returns a string encoded with a
    * base64 encoded key and the base64 encoded challenge used to create it
@@ -39,81 +49,105 @@ export declare namespace biometrics {
    *
    * `format!("<key_base64>|<iv_base64>")`
    */
-  export function deriveKeyMaterial(iv?: string | undefined | null): Promise<OsDerivedKey>
+  export function deriveKeyMaterial(iv?: string | undefined | null): Promise<OsDerivedKey>;
   export interface KeyMaterial {
-    osKeyPartB64: string
-    clientKeyPartB64?: string
+    osKeyPartB64: string;
+    clientKeyPartB64?: string;
   }
   export interface OsDerivedKey {
-    keyB64: string
-    ivB64: string
+    keyB64: string;
+    ivB64: string;
   }
 }
 export declare namespace biometrics_v2 {
-  export function initBiometricSystem(): BiometricLockSystem
-  export function authenticate(biometricLockSystem: BiometricLockSystem, hwnd: Buffer, message: string): Promise<boolean>
-  export function authenticateAvailable(biometricLockSystem: BiometricLockSystem): Promise<boolean>
-  export function enrollPersistent(biometricLockSystem: BiometricLockSystem, userId: string, key: Buffer): Promise<void>
-  export function provideKey(biometricLockSystem: BiometricLockSystem, userId: string, key: Buffer): Promise<void>
-  export function unlock(biometricLockSystem: BiometricLockSystem, userId: string, hwnd: Buffer): Promise<Buffer>
-  export function unlockAvailable(biometricLockSystem: BiometricLockSystem, userId: string): Promise<boolean>
-  export function hasPersistent(biometricLockSystem: BiometricLockSystem, userId: string): Promise<boolean>
-  export function unenroll(biometricLockSystem: BiometricLockSystem, userId: string): Promise<void>
-  export class BiometricLockSystem {   }
+  export function initBiometricSystem(): BiometricLockSystem;
+  export function authenticate(
+    biometricLockSystem: BiometricLockSystem,
+    hwnd: Buffer,
+    message: string,
+  ): Promise<boolean>;
+  export function authenticateAvailable(biometricLockSystem: BiometricLockSystem): Promise<boolean>;
+  export function enrollPersistent(
+    biometricLockSystem: BiometricLockSystem,
+    userId: string,
+    key: Buffer,
+  ): Promise<void>;
+  export function provideKey(
+    biometricLockSystem: BiometricLockSystem,
+    userId: string,
+    key: Buffer,
+  ): Promise<void>;
+  export function unlock(
+    biometricLockSystem: BiometricLockSystem,
+    userId: string,
+    hwnd: Buffer,
+  ): Promise<Buffer>;
+  export function unlockAvailable(
+    biometricLockSystem: BiometricLockSystem,
+    userId: string,
+  ): Promise<boolean>;
+  export function hasPersistent(
+    biometricLockSystem: BiometricLockSystem,
+    userId: string,
+  ): Promise<boolean>;
+  export function unenroll(biometricLockSystem: BiometricLockSystem, userId: string): Promise<void>;
+  export class BiometricLockSystem {}
 }
 export declare namespace clipboards {
-  export function read(): Promise<string>
-  export function write(text: string, password: boolean): Promise<void>
+  export function read(): Promise<string>;
+  export function write(text: string, password: boolean): Promise<void>;
 }
 export declare namespace sshagent {
   export interface PrivateKey {
-    privateKey: string
-    name: string
-    cipherId: string
+    privateKey: string;
+    name: string;
+    cipherId: string;
   }
   export interface SshKey {
-    privateKey: string
-    publicKey: string
-    keyFingerprint: string
+    privateKey: string;
+    publicKey: string;
+    keyFingerprint: string;
   }
   export interface SshUiRequest {
-    cipherId?: string
-    isList: boolean
-    processName: string
-    isForwarding: boolean
-    namespace?: string
+    cipherId?: string;
+    isList: boolean;
+    processName: string;
+    isForwarding: boolean;
+    namespace?: string;
   }
-  export function serve(callback: (err: Error | null, arg: SshUiRequest) => any): Promise<SshAgentState>
-  export function stop(agentState: SshAgentState): void
-  export function isRunning(agentState: SshAgentState): boolean
-  export function setKeys(agentState: SshAgentState, newKeys: Array<PrivateKey>): void
-  export function lock(agentState: SshAgentState): void
-  export function clearKeys(agentState: SshAgentState): void
-  export class SshAgentState {   }
+  export function serve(
+    callback: (err: Error | null, arg: SshUiRequest) => any,
+  ): Promise<SshAgentState>;
+  export function stop(agentState: SshAgentState): void;
+  export function isRunning(agentState: SshAgentState): boolean;
+  export function setKeys(agentState: SshAgentState, newKeys: Array<PrivateKey>): void;
+  export function lock(agentState: SshAgentState): void;
+  export function clearKeys(agentState: SshAgentState): void;
+  export class SshAgentState {}
 }
 export declare namespace processisolations {
-  export function disableCoredumps(): Promise<void>
-  export function isCoreDumpingDisabled(): Promise<boolean>
-  export function isolateProcess(): Promise<void>
+  export function disableCoredumps(): Promise<void>;
+  export function isCoreDumpingDisabled(): Promise<boolean>;
+  export function isolateProcess(): Promise<void>;
 }
 export declare namespace powermonitors {
-  export function onLock(callback: (err: Error | null, ) => any): Promise<void>
-  export function isLockMonitorAvailable(): Promise<boolean>
+  export function onLock(callback: (err: Error | null) => any): Promise<void>;
+  export function isLockMonitorAvailable(): Promise<boolean>;
 }
 export declare namespace windows_registry {
-  export function createKey(key: string, subkey: string, value: string): Promise<void>
-  export function deleteKey(key: string, subkey: string): Promise<void>
+  export function createKey(key: string, subkey: string, value: string): Promise<void>;
+  export function deleteKey(key: string, subkey: string): Promise<void>;
 }
 export declare namespace ipc {
   export interface IpcMessage {
-    clientId: number
-    kind: IpcMessageType
-    message?: string
+    clientId: number;
+    kind: IpcMessageType;
+    message?: string;
   }
   export const enum IpcMessageType {
     Connected = 0,
     Disconnected = 1,
-    Message = 2
+    Message = 2,
   }
   export class IpcServer {
     /**
@@ -122,73 +156,76 @@ export declare namespace ipc {
      * @param name The endpoint name to listen on. This name uniquely identifies the IPC connection and must be the same for both the server and client.
      * @param callback This function will be called whenever a message is received from a client.
      */
-    static listen(name: string, callback: (error: null | Error, message: IpcMessage) => void): Promise<IpcServer>
+    static listen(
+      name: string,
+      callback: (error: null | Error, message: IpcMessage) => void,
+    ): Promise<IpcServer>;
     /** Return the path to the IPC server. */
-    getPath(): string
+    getPath(): string;
     /** Stop the IPC server. */
-    stop(): void
+    stop(): void;
     /**
      * Send a message over the IPC server to all the connected clients
      *
      * @return The number of clients that the message was sent to. Note that the number of messages
      * actually received may be less, as some clients could disconnect before receiving the message.
      */
-    send(message: string): number
+    send(message: string): number;
   }
 }
 export declare namespace autostart {
-  export function setAutostart(autostart: boolean, params: Array<string>): Promise<void>
+  export function setAutostart(autostart: boolean, params: Array<string>): Promise<void>;
 }
 export declare namespace autofill {
-  export function runCommand(value: string): Promise<string>
+  export function runCommand(value: string): Promise<string>;
   export const enum UserVerification {
-    Preferred = 'preferred',
-    Required = 'required',
-    Discouraged = 'discouraged'
+    Preferred = "preferred",
+    Required = "required",
+    Discouraged = "discouraged",
   }
   export interface Position {
-    x: number
-    y: number
+    x: number;
+    y: number;
   }
   export interface PasskeyRegistrationRequest {
-    rpId: string
-    userName: string
-    userHandle: Array<number>
-    clientDataHash: Array<number>
-    userVerification: UserVerification
-    supportedAlgorithms: Array<number>
-    windowXy: Position
+    rpId: string;
+    userName: string;
+    userHandle: Array<number>;
+    clientDataHash: Array<number>;
+    userVerification: UserVerification;
+    supportedAlgorithms: Array<number>;
+    windowXy: Position;
   }
   export interface PasskeyRegistrationResponse {
-    rpId: string
-    clientDataHash: Array<number>
-    credentialId: Array<number>
-    attestationObject: Array<number>
+    rpId: string;
+    clientDataHash: Array<number>;
+    credentialId: Array<number>;
+    attestationObject: Array<number>;
   }
   export interface PasskeyAssertionRequest {
-    rpId: string
-    clientDataHash: Array<number>
-    userVerification: UserVerification
-    allowedCredentials: Array<Array<number>>
-    windowXy: Position
+    rpId: string;
+    clientDataHash: Array<number>;
+    userVerification: UserVerification;
+    allowedCredentials: Array<Array<number>>;
+    windowXy: Position;
   }
   export interface PasskeyAssertionWithoutUserInterfaceRequest {
-    rpId: string
-    credentialId: Array<number>
-    userName: string
-    userHandle: Array<number>
-    recordIdentifier?: string
-    clientDataHash: Array<number>
-    userVerification: UserVerification
-    windowXy: Position
+    rpId: string;
+    credentialId: Array<number>;
+    userName: string;
+    userHandle: Array<number>;
+    recordIdentifier?: string;
+    clientDataHash: Array<number>;
+    userVerification: UserVerification;
+    windowXy: Position;
   }
   export interface PasskeyAssertionResponse {
-    rpId: string
-    userHandle: Array<number>
-    signature: Array<number>
-    clientDataHash: Array<number>
-    authenticatorData: Array<number>
-    credentialId: Array<number>
+    rpId: string;
+    userHandle: Array<number>;
+    signature: Array<number>;
+    clientDataHash: Array<number>;
+    authenticatorData: Array<number>;
+    credentialId: Array<number>;
   }
   export class IpcServer {
     /**
@@ -197,18 +234,46 @@ export declare namespace autofill {
      * @param name The endpoint name to listen on. This name uniquely identifies the IPC connection and must be the same for both the server and client.
      * @param callback This function will be called whenever a message is received from a client.
      */
-    static listen(name: string, registrationCallback: (error: null | Error, clientId: number, sequenceNumber: number, message: PasskeyRegistrationRequest) => void, assertionCallback: (error: null | Error, clientId: number, sequenceNumber: number, message: PasskeyAssertionRequest) => void, assertionWithoutUserInterfaceCallback: (error: null | Error, clientId: number, sequenceNumber: number, message: PasskeyAssertionWithoutUserInterfaceRequest) => void): Promise<IpcServer>
+    static listen(
+      name: string,
+      registrationCallback: (
+        error: null | Error,
+        clientId: number,
+        sequenceNumber: number,
+        message: PasskeyRegistrationRequest,
+      ) => void,
+      assertionCallback: (
+        error: null | Error,
+        clientId: number,
+        sequenceNumber: number,
+        message: PasskeyAssertionRequest,
+      ) => void,
+      assertionWithoutUserInterfaceCallback: (
+        error: null | Error,
+        clientId: number,
+        sequenceNumber: number,
+        message: PasskeyAssertionWithoutUserInterfaceRequest,
+      ) => void,
+    ): Promise<IpcServer>;
     /** Return the path to the IPC server. */
-    getPath(): string
+    getPath(): string;
     /** Stop the IPC server. */
-    stop(): void
-    completeRegistration(clientId: number, sequenceNumber: number, response: PasskeyRegistrationResponse): number
-    completeAssertion(clientId: number, sequenceNumber: number, response: PasskeyAssertionResponse): number
-    completeError(clientId: number, sequenceNumber: number, error: string): number
+    stop(): void;
+    completeRegistration(
+      clientId: number,
+      sequenceNumber: number,
+      response: PasskeyRegistrationResponse,
+    ): number;
+    completeAssertion(
+      clientId: number,
+      sequenceNumber: number,
+      response: PasskeyAssertionResponse,
+    ): number;
+    completeError(clientId: number, sequenceNumber: number, error: string): number;
   }
 }
 export declare namespace passkey_authenticator {
-  export function register(): void
+  export function register(): void;
 }
 export declare namespace logging {
   export const enum LogLevel {
@@ -216,76 +281,81 @@ export declare namespace logging {
     Debug = 1,
     Info = 2,
     Warn = 3,
-    Error = 4
+    Error = 4,
   }
-  export function initNapiLog(jsLogFn: (err: Error | null, arg0: LogLevel, arg1: string) => any): void
+  export function initNapiLog(
+    jsLogFn: (err: Error | null, arg0: LogLevel, arg1: string) => any,
+  ): void;
 }
 export declare namespace chromium_importer {
   export interface ProfileInfo {
-    id: string
-    name: string
+    id: string;
+    name: string;
   }
   export interface Login {
-    url: string
-    username: string
-    password: string
-    note: string
+    url: string;
+    username: string;
+    password: string;
+    note: string;
   }
   export interface LoginImportFailure {
-    url: string
-    username: string
-    error: string
+    url: string;
+    username: string;
+    error: string;
   }
   export interface LoginImportResult {
-    login?: Login
-    failure?: LoginImportFailure
+    login?: Login;
+    failure?: LoginImportFailure;
   }
   export interface NativeImporterMetadata {
-    id: string
-    loaders: Array<string>
-    instructions: string
+    id: string;
+    loaders: Array<string>;
+    instructions: string;
   }
   /** Returns OS aware metadata describing supported Chromium based importers as a JSON string. */
-  export function getMetadata(): Record<string, NativeImporterMetadata>
-  export function getAvailableProfiles(browser: string): Array<ProfileInfo>
-  export function importLogins(browser: string, profileId: string): Promise<Array<LoginImportResult>>
+  export function getMetadata(): Record<string, NativeImporterMetadata>;
+  export function getAvailableProfiles(browser: string): Array<ProfileInfo>;
+  export function importLogins(
+    browser: string,
+    profileId: string,
+  ): Promise<Array<LoginImportResult>>;
 }
 export declare namespace autotype {
-  export function getForegroundWindowTitle(): string
-  export function typeInput(input: Array<number>, keyboardShortcut: Array<string>): void
+  export function getForegroundWindowTitle(): string;
+  export function typeInput(input: Array<number>, keyboardShortcut: Array<string>): void;
 }
 export declare namespace navigator_credentials {
   export const enum UserVerification {
-    Preferred = 'Preferred',
-    Required = 'Required',
-    Discouraged = 'Discouraged'
+    Preferred = "Preferred",
+    Required = "Required",
+    Discouraged = "Discouraged",
   }
   export interface PrfConfig {
-    first: Uint8Array
-    second?: Uint8Array
+    first: Uint8Array;
+    second?: Uint8Array;
   }
   export interface PublicKeyCredentialRequestOptions {
-    challenge: Uint8Array
-    timeout: number
-    rpId: string
-    userVerification: UserVerification
-    allowCredentials: Array<Uint8Array>
-    prf?: PrfConfig
+    challenge: Uint8Array;
+    timeout: number;
+    rpId: string;
+    userVerification: UserVerification;
+    allowCredentials: Array<Uint8Array>;
+    prf?: PrfConfig;
   }
   export interface AuthenticatorAssertionResponse {
-    authenticatorData: Uint8Array
-    clientDataJson: Uint8Array
-    signature: Uint8Array
-    userHandle: Uint8Array
+    authenticatorData: Uint8Array;
+    clientDataJson: Uint8Array;
+    signature: Uint8Array;
+    userHandle: Uint8Array;
   }
   export interface PublicKeyCredential {
-    authenticatorAttachment: string
-    id: string
-    rawId: Uint8Array
-    response: AuthenticatorAssertionResponse
-    type: string
-    prf?: Uint8Array
+    authenticatorAttachment: string;
+    id: string;
+    rawId: Uint8Array;
+    response: AuthenticatorAssertionResponse;
+    type: string;
+    prf?: Uint8Array;
   }
-  export function get(assertionOptions: PublicKeyCredentialRequestOptions): PublicKeyCredential
-  export function available(): boolean
+  export function get(assertionOptions: PublicKeyCredentialRequestOptions): PublicKeyCredential;
+  export function available(): boolean;
 }

--- a/apps/desktop/desktop_native/napi/index.d.ts
+++ b/apps/desktop/desktop_native/napi/index.d.ts
@@ -254,3 +254,38 @@ export declare namespace autotype {
   export function getForegroundWindowTitle(): string
   export function typeInput(input: Array<number>, keyboardShortcut: Array<string>): void
 }
+export declare namespace navigator_credentials {
+  export const enum UserVerification {
+    Preferred = 'Preferred',
+    Required = 'Required',
+    Discouraged = 'Discouraged'
+  }
+  export interface PrfConfig {
+    first: Uint8Array
+    second?: Uint8Array
+  }
+  export interface PublicKeyCredentialRequestOptions {
+    challenge: Uint8Array
+    timeout: number
+    rpId: string
+    userVerification: UserVerification
+    allowCredentials: Array<Uint8Array>
+    prf?: PrfConfig
+  }
+  export interface AuthenticatorAssertionResponse {
+    authenticatorData: Uint8Array
+    clientDataJson: Uint8Array
+    signature: Uint8Array
+    userHandle: Uint8Array
+  }
+  export interface PublicKeyCredential {
+    authenticatorAttachment: string
+    id: string
+    rawId: Uint8Array
+    response: AuthenticatorAssertionResponse
+    type: string
+    prf?: Uint8Array
+  }
+  export function get(assertionOptions: PublicKeyCredentialRequestOptions): PublicKeyCredential
+  export function available(): boolean
+}

--- a/apps/desktop/desktop_native/napi/index.d.ts
+++ b/apps/desktop/desktop_native/napi/index.d.ts
@@ -5,41 +5,31 @@
 
 export declare namespace passwords {
   /** The error message returned when a password is not found during retrieval or deletion. */
-  export const PASSWORD_NOT_FOUND: string;
+  export const PASSWORD_NOT_FOUND: string
   /**
    * Fetch the stored password from the keychain.
    * Throws {@link Error} with message {@link PASSWORD_NOT_FOUND} if the password does not exist.
    */
-  export function getPassword(service: string, account: string): Promise<string>;
+  export function getPassword(service: string, account: string): Promise<string>
   /** Save the password to the keychain. Adds an entry if none exists otherwise updates the existing entry. */
-  export function setPassword(service: string, account: string, password: string): Promise<void>;
+  export function setPassword(service: string, account: string, password: string): Promise<void>
   /**
    * Delete the stored password from the keychain.
    * Throws {@link Error} with message {@link PASSWORD_NOT_FOUND} if the password does not exist.
    */
-  export function deletePassword(service: string, account: string): Promise<void>;
+  export function deletePassword(service: string, account: string): Promise<void>
   /** Checks if the os secure storage is available */
-  export function isAvailable(): Promise<boolean>;
+  export function isAvailable(): Promise<boolean>
 }
 export declare namespace biometrics {
-  export function prompt(hwnd: Buffer, message: string): Promise<boolean>;
-  export function available(): Promise<boolean>;
-  export function setBiometricSecret(
-    service: string,
-    account: string,
-    secret: string,
-    keyMaterial: KeyMaterial | undefined | null,
-    ivB64: string,
-  ): Promise<string>;
+  export function prompt(hwnd: Buffer, message: string): Promise<boolean>
+  export function available(): Promise<boolean>
+  export function setBiometricSecret(service: string, account: string, secret: string, keyMaterial: KeyMaterial | undefined | null, ivB64: string): Promise<string>
   /**
    * Retrieves the biometric secret for the given service and account.
    * Throws Error with message [`passwords::PASSWORD_NOT_FOUND`] if the secret does not exist.
    */
-  export function getBiometricSecret(
-    service: string,
-    account: string,
-    keyMaterial?: KeyMaterial | undefined | null,
-  ): Promise<string>;
+  export function getBiometricSecret(service: string, account: string, keyMaterial?: KeyMaterial | undefined | null): Promise<string>
   /**
    * Derives key material from biometric data. Returns a string encoded with a
    * base64 encoded key and the base64 encoded challenge used to create it
@@ -49,105 +39,81 @@ export declare namespace biometrics {
    *
    * `format!("<key_base64>|<iv_base64>")`
    */
-  export function deriveKeyMaterial(iv?: string | undefined | null): Promise<OsDerivedKey>;
+  export function deriveKeyMaterial(iv?: string | undefined | null): Promise<OsDerivedKey>
   export interface KeyMaterial {
-    osKeyPartB64: string;
-    clientKeyPartB64?: string;
+    osKeyPartB64: string
+    clientKeyPartB64?: string
   }
   export interface OsDerivedKey {
-    keyB64: string;
-    ivB64: string;
+    keyB64: string
+    ivB64: string
   }
 }
 export declare namespace biometrics_v2 {
-  export function initBiometricSystem(): BiometricLockSystem;
-  export function authenticate(
-    biometricLockSystem: BiometricLockSystem,
-    hwnd: Buffer,
-    message: string,
-  ): Promise<boolean>;
-  export function authenticateAvailable(biometricLockSystem: BiometricLockSystem): Promise<boolean>;
-  export function enrollPersistent(
-    biometricLockSystem: BiometricLockSystem,
-    userId: string,
-    key: Buffer,
-  ): Promise<void>;
-  export function provideKey(
-    biometricLockSystem: BiometricLockSystem,
-    userId: string,
-    key: Buffer,
-  ): Promise<void>;
-  export function unlock(
-    biometricLockSystem: BiometricLockSystem,
-    userId: string,
-    hwnd: Buffer,
-  ): Promise<Buffer>;
-  export function unlockAvailable(
-    biometricLockSystem: BiometricLockSystem,
-    userId: string,
-  ): Promise<boolean>;
-  export function hasPersistent(
-    biometricLockSystem: BiometricLockSystem,
-    userId: string,
-  ): Promise<boolean>;
-  export function unenroll(biometricLockSystem: BiometricLockSystem, userId: string): Promise<void>;
-  export class BiometricLockSystem {}
+  export function initBiometricSystem(): BiometricLockSystem
+  export function authenticate(biometricLockSystem: BiometricLockSystem, hwnd: Buffer, message: string): Promise<boolean>
+  export function authenticateAvailable(biometricLockSystem: BiometricLockSystem): Promise<boolean>
+  export function enrollPersistent(biometricLockSystem: BiometricLockSystem, userId: string, key: Buffer): Promise<void>
+  export function provideKey(biometricLockSystem: BiometricLockSystem, userId: string, key: Buffer): Promise<void>
+  export function unlock(biometricLockSystem: BiometricLockSystem, userId: string, hwnd: Buffer): Promise<Buffer>
+  export function unlockAvailable(biometricLockSystem: BiometricLockSystem, userId: string): Promise<boolean>
+  export function hasPersistent(biometricLockSystem: BiometricLockSystem, userId: string): Promise<boolean>
+  export function unenroll(biometricLockSystem: BiometricLockSystem, userId: string): Promise<void>
+  export class BiometricLockSystem {   }
 }
 export declare namespace clipboards {
-  export function read(): Promise<string>;
-  export function write(text: string, password: boolean): Promise<void>;
+  export function read(): Promise<string>
+  export function write(text: string, password: boolean): Promise<void>
 }
 export declare namespace sshagent {
   export interface PrivateKey {
-    privateKey: string;
-    name: string;
-    cipherId: string;
+    privateKey: string
+    name: string
+    cipherId: string
   }
   export interface SshKey {
-    privateKey: string;
-    publicKey: string;
-    keyFingerprint: string;
+    privateKey: string
+    publicKey: string
+    keyFingerprint: string
   }
   export interface SshUiRequest {
-    cipherId?: string;
-    isList: boolean;
-    processName: string;
-    isForwarding: boolean;
-    namespace?: string;
+    cipherId?: string
+    isList: boolean
+    processName: string
+    isForwarding: boolean
+    namespace?: string
   }
-  export function serve(
-    callback: (err: Error | null, arg: SshUiRequest) => any,
-  ): Promise<SshAgentState>;
-  export function stop(agentState: SshAgentState): void;
-  export function isRunning(agentState: SshAgentState): boolean;
-  export function setKeys(agentState: SshAgentState, newKeys: Array<PrivateKey>): void;
-  export function lock(agentState: SshAgentState): void;
-  export function clearKeys(agentState: SshAgentState): void;
-  export class SshAgentState {}
+  export function serve(callback: (err: Error | null, arg: SshUiRequest) => any): Promise<SshAgentState>
+  export function stop(agentState: SshAgentState): void
+  export function isRunning(agentState: SshAgentState): boolean
+  export function setKeys(agentState: SshAgentState, newKeys: Array<PrivateKey>): void
+  export function lock(agentState: SshAgentState): void
+  export function clearKeys(agentState: SshAgentState): void
+  export class SshAgentState {   }
 }
 export declare namespace processisolations {
-  export function disableCoredumps(): Promise<void>;
-  export function isCoreDumpingDisabled(): Promise<boolean>;
-  export function isolateProcess(): Promise<void>;
+  export function disableCoredumps(): Promise<void>
+  export function isCoreDumpingDisabled(): Promise<boolean>
+  export function isolateProcess(): Promise<void>
 }
 export declare namespace powermonitors {
-  export function onLock(callback: (err: Error | null) => any): Promise<void>;
-  export function isLockMonitorAvailable(): Promise<boolean>;
+  export function onLock(callback: (err: Error | null, ) => any): Promise<void>
+  export function isLockMonitorAvailable(): Promise<boolean>
 }
 export declare namespace windows_registry {
-  export function createKey(key: string, subkey: string, value: string): Promise<void>;
-  export function deleteKey(key: string, subkey: string): Promise<void>;
+  export function createKey(key: string, subkey: string, value: string): Promise<void>
+  export function deleteKey(key: string, subkey: string): Promise<void>
 }
 export declare namespace ipc {
   export interface IpcMessage {
-    clientId: number;
-    kind: IpcMessageType;
-    message?: string;
+    clientId: number
+    kind: IpcMessageType
+    message?: string
   }
   export const enum IpcMessageType {
     Connected = 0,
     Disconnected = 1,
-    Message = 2,
+    Message = 2
   }
   export class IpcServer {
     /**
@@ -156,76 +122,73 @@ export declare namespace ipc {
      * @param name The endpoint name to listen on. This name uniquely identifies the IPC connection and must be the same for both the server and client.
      * @param callback This function will be called whenever a message is received from a client.
      */
-    static listen(
-      name: string,
-      callback: (error: null | Error, message: IpcMessage) => void,
-    ): Promise<IpcServer>;
+    static listen(name: string, callback: (error: null | Error, message: IpcMessage) => void): Promise<IpcServer>
     /** Return the path to the IPC server. */
-    getPath(): string;
+    getPath(): string
     /** Stop the IPC server. */
-    stop(): void;
+    stop(): void
     /**
      * Send a message over the IPC server to all the connected clients
      *
      * @return The number of clients that the message was sent to. Note that the number of messages
      * actually received may be less, as some clients could disconnect before receiving the message.
      */
-    send(message: string): number;
+    send(message: string): number
   }
 }
 export declare namespace autostart {
-  export function setAutostart(autostart: boolean, params: Array<string>): Promise<void>;
+  export function setAutostart(autostart: boolean, params: Array<string>): Promise<void>
 }
 export declare namespace autofill {
-  export function runCommand(value: string): Promise<string>;
+  export function runCommand(value: string): Promise<string>
   export const enum UserVerification {
-    Preferred = "preferred",
-    Required = "required",
-    Discouraged = "discouraged",
+    Preferred = 'preferred',
+    Required = 'required',
+    Discouraged = 'discouraged'
   }
   export interface Position {
-    x: number;
-    y: number;
+    x: number
+    y: number
   }
   export interface PasskeyRegistrationRequest {
-    rpId: string;
-    userName: string;
-    userHandle: Array<number>;
-    clientDataHash: Array<number>;
-    userVerification: UserVerification;
-    supportedAlgorithms: Array<number>;
-    windowXy: Position;
+    rpId: string
+    userName: string
+    userHandle: Array<number>
+    clientDataHash: Array<number>
+    userVerification: UserVerification
+    supportedAlgorithms: Array<number>
+    windowXy: Position
   }
   export interface PasskeyRegistrationResponse {
-    rpId: string;
-    clientDataHash: Array<number>;
-    credentialId: Array<number>;
-    attestationObject: Array<number>;
+    rpId: string
+    clientDataHash: Array<number>
+    credentialId: Array<number>
+    attestationObject: Array<number>
   }
   export interface PasskeyAssertionRequest {
-    rpId: string;
-    clientDataHash: Array<number>;
-    userVerification: UserVerification;
-    allowedCredentials: Array<Array<number>>;
-    windowXy: Position;
+    rpId: string
+    clientDataHash: Array<number>
+    userVerification: UserVerification
+    allowedCredentials: Array<Array<number>>
+    windowXy: Position
   }
   export interface PasskeyAssertionWithoutUserInterfaceRequest {
-    rpId: string;
-    credentialId: Array<number>;
-    userName: string;
-    userHandle: Array<number>;
-    recordIdentifier?: string;
-    clientDataHash: Array<number>;
-    userVerification: UserVerification;
-    windowXy: Position;
+    rpId: string
+    credentialId: Array<number>
+    userName: string
+    userHandle: Array<number>
+    recordIdentifier?: string
+    clientDataHash: Array<number>
+    userVerification: UserVerification
+    windowXy: Position
   }
   export interface PasskeyAssertionResponse {
-    rpId: string;
-    userHandle: Array<number>;
-    signature: Array<number>;
-    clientDataHash: Array<number>;
-    authenticatorData: Array<number>;
-    credentialId: Array<number>;
+    rpId: string
+    userHandle: Array<number>
+    signature: Array<number>
+    clientDataHash: Array<number>
+    authenticatorData: Array<number>
+    credentialId: Array<number>
   }
   export class IpcServer {
     /**
@@ -234,46 +197,18 @@ export declare namespace autofill {
      * @param name The endpoint name to listen on. This name uniquely identifies the IPC connection and must be the same for both the server and client.
      * @param callback This function will be called whenever a message is received from a client.
      */
-    static listen(
-      name: string,
-      registrationCallback: (
-        error: null | Error,
-        clientId: number,
-        sequenceNumber: number,
-        message: PasskeyRegistrationRequest,
-      ) => void,
-      assertionCallback: (
-        error: null | Error,
-        clientId: number,
-        sequenceNumber: number,
-        message: PasskeyAssertionRequest,
-      ) => void,
-      assertionWithoutUserInterfaceCallback: (
-        error: null | Error,
-        clientId: number,
-        sequenceNumber: number,
-        message: PasskeyAssertionWithoutUserInterfaceRequest,
-      ) => void,
-    ): Promise<IpcServer>;
+    static listen(name: string, registrationCallback: (error: null | Error, clientId: number, sequenceNumber: number, message: PasskeyRegistrationRequest) => void, assertionCallback: (error: null | Error, clientId: number, sequenceNumber: number, message: PasskeyAssertionRequest) => void, assertionWithoutUserInterfaceCallback: (error: null | Error, clientId: number, sequenceNumber: number, message: PasskeyAssertionWithoutUserInterfaceRequest) => void): Promise<IpcServer>
     /** Return the path to the IPC server. */
-    getPath(): string;
+    getPath(): string
     /** Stop the IPC server. */
-    stop(): void;
-    completeRegistration(
-      clientId: number,
-      sequenceNumber: number,
-      response: PasskeyRegistrationResponse,
-    ): number;
-    completeAssertion(
-      clientId: number,
-      sequenceNumber: number,
-      response: PasskeyAssertionResponse,
-    ): number;
-    completeError(clientId: number, sequenceNumber: number, error: string): number;
+    stop(): void
+    completeRegistration(clientId: number, sequenceNumber: number, response: PasskeyRegistrationResponse): number
+    completeAssertion(clientId: number, sequenceNumber: number, response: PasskeyAssertionResponse): number
+    completeError(clientId: number, sequenceNumber: number, error: string): number
   }
 }
 export declare namespace passkey_authenticator {
-  export function register(): void;
+  export function register(): void
 }
 export declare namespace logging {
   export const enum LogLevel {
@@ -281,81 +216,76 @@ export declare namespace logging {
     Debug = 1,
     Info = 2,
     Warn = 3,
-    Error = 4,
+    Error = 4
   }
-  export function initNapiLog(
-    jsLogFn: (err: Error | null, arg0: LogLevel, arg1: string) => any,
-  ): void;
+  export function initNapiLog(jsLogFn: (err: Error | null, arg0: LogLevel, arg1: string) => any): void
 }
 export declare namespace chromium_importer {
   export interface ProfileInfo {
-    id: string;
-    name: string;
+    id: string
+    name: string
   }
   export interface Login {
-    url: string;
-    username: string;
-    password: string;
-    note: string;
+    url: string
+    username: string
+    password: string
+    note: string
   }
   export interface LoginImportFailure {
-    url: string;
-    username: string;
-    error: string;
+    url: string
+    username: string
+    error: string
   }
   export interface LoginImportResult {
-    login?: Login;
-    failure?: LoginImportFailure;
+    login?: Login
+    failure?: LoginImportFailure
   }
   export interface NativeImporterMetadata {
-    id: string;
-    loaders: Array<string>;
-    instructions: string;
+    id: string
+    loaders: Array<string>
+    instructions: string
   }
   /** Returns OS aware metadata describing supported Chromium based importers as a JSON string. */
-  export function getMetadata(): Record<string, NativeImporterMetadata>;
-  export function getAvailableProfiles(browser: string): Array<ProfileInfo>;
-  export function importLogins(
-    browser: string,
-    profileId: string,
-  ): Promise<Array<LoginImportResult>>;
+  export function getMetadata(): Record<string, NativeImporterMetadata>
+  export function getAvailableProfiles(browser: string): Array<ProfileInfo>
+  export function importLogins(browser: string, profileId: string): Promise<Array<LoginImportResult>>
 }
 export declare namespace autotype {
-  export function getForegroundWindowTitle(): string;
-  export function typeInput(input: Array<number>, keyboardShortcut: Array<string>): void;
+  export function getForegroundWindowTitle(): string
+  export function typeInput(input: Array<number>, keyboardShortcut: Array<string>): void
 }
 export declare namespace navigator_credentials {
   export const enum UserVerification {
-    Preferred = "Preferred",
-    Required = "Required",
-    Discouraged = "Discouraged",
+    Preferred = 'Preferred',
+    Required = 'Required',
+    Discouraged = 'Discouraged'
   }
   export interface PrfConfig {
-    first: Uint8Array;
-    second?: Uint8Array;
+    first: Uint8Array
+    second?: Uint8Array
   }
   export interface PublicKeyCredentialRequestOptions {
-    challenge: Uint8Array;
-    timeout: number;
-    rpId: string;
-    userVerification: UserVerification;
-    allowCredentials: Array<Uint8Array>;
-    prf?: PrfConfig;
+    challenge: Uint8Array
+    timeout: number
+    rpId: string
+    userVerification: UserVerification
+    allowCredentials: Array<Uint8Array>
+    prf?: PrfConfig
   }
   export interface AuthenticatorAssertionResponse {
-    authenticatorData: Uint8Array;
-    clientDataJson: Uint8Array;
-    signature: Uint8Array;
-    userHandle: Uint8Array;
+    authenticatorData: Uint8Array
+    clientDataJson: Uint8Array
+    signature: Uint8Array
+    userHandle: Uint8Array
   }
   export interface PublicKeyCredential {
-    authenticatorAttachment: string;
-    id: string;
-    rawId: Uint8Array;
-    response: AuthenticatorAssertionResponse;
-    type: string;
-    prf?: Uint8Array;
+    authenticatorAttachment: string
+    id: string
+    rawId: Uint8Array
+    response: AuthenticatorAssertionResponse
+    type: string
+    prf?: Uint8Array
   }
-  export function get(assertionOptions: PublicKeyCredentialRequestOptions): PublicKeyCredential;
-  export function available(): boolean;
+  export function get(assertionOptions: PublicKeyCredentialRequestOptions): PublicKeyCredential
+  export function available(): boolean
 }

--- a/apps/desktop/desktop_native/napi/src/lib.rs
+++ b/apps/desktop/desktop_native/napi/src/lib.rs
@@ -1211,9 +1211,9 @@ pub mod navigator_credentials {
         Discouraged,
     }
 
-    impl Into<fido2_client::UserVerification> for UserVerification {
-        fn into(self) -> fido2_client::UserVerification {
-            match self {
+    impl From<UserVerification> for fido2_client::UserVerification {
+        fn from(val: UserVerification) -> Self {
+            match val {
                 UserVerification::Preferred => fido2_client::UserVerification::Preferred,
                 UserVerification::Required => fido2_client::UserVerification::Required,
                 UserVerification::Discouraged => fido2_client::UserVerification::Discouraged,
@@ -1227,11 +1227,11 @@ pub mod navigator_credentials {
         pub second: Option<Uint8Array>,
     }
 
-    impl Into<fido2_client::PrfConfig> for PrfConfig {
-        fn into(self) -> fido2_client::PrfConfig {
+    impl From<PrfConfig> for fido2_client::PrfConfig {
+        fn from(val: PrfConfig) -> Self {
             fido2_client::PrfConfig {
-                first: self.first.to_vec(),
-                second: self.second.map(|s| s.to_vec()),
+                first: val.first.to_vec(),
+                second: val.second.map(|s| s.to_vec()),
             }
         }
     }
@@ -1292,15 +1292,15 @@ pub mod navigator_credentials {
         pub prf: Option<Uint8Array>,
     }
 
-    impl Into<PublicKeyCredential> for fido2_client::PublicKeyCredential {
-        fn into(self) -> PublicKeyCredential {
+    impl From<fido2_client::PublicKeyCredential> for PublicKeyCredential {
+        fn from(val: fido2_client::PublicKeyCredential) -> Self {
             PublicKeyCredential {
-                authenticator_attachment: self.authenticator_attachment,
-                id: self.id,
-                raw_id: Uint8Array::from(self.raw_id),
-                response: self.response.into(),
-                r#type: self.r#type,
-                prf: self.prf.map(|p| Uint8Array::from(p)),
+                authenticator_attachment: val.authenticator_attachment,
+                id: val.id,
+                raw_id: Uint8Array::from(val.raw_id),
+                response: val.response.into(),
+                r#type: val.r#type,
+                prf: val.prf.map(Uint8Array::from),
             }
         }
     }

--- a/apps/desktop/desktop_native/napi/src/lib.rs
+++ b/apps/desktop/desktop_native/napi/src/lib.rs
@@ -1199,3 +1199,125 @@ pub mod autotype {
         })
     }
 }
+
+#[napi]
+pub mod navigator_credentials {
+    use napi::bindgen_prelude::Uint8Array;
+
+    #[napi(string_enum)]
+    pub enum UserVerification {
+        Preferred,
+        Required,
+        Discouraged,
+    }
+
+    impl Into<fido2_client::UserVerification> for UserVerification {
+        fn into(self) -> fido2_client::UserVerification {
+            match self {
+                UserVerification::Preferred => fido2_client::UserVerification::Preferred,
+                UserVerification::Required => fido2_client::UserVerification::Required,
+                UserVerification::Discouraged => fido2_client::UserVerification::Discouraged,
+            }
+        }
+    }
+
+    #[napi(object)]
+    pub struct PrfConfig {
+        pub first: Uint8Array,
+        pub second: Option<Uint8Array>,
+    }
+
+    impl Into<fido2_client::PrfConfig> for PrfConfig {
+        fn into(self) -> fido2_client::PrfConfig {
+            fido2_client::PrfConfig {
+                first: self.first.to_vec(),
+                second: self.second.map(|s| s.to_vec()),
+            }
+        }
+    }
+
+    #[napi(object)]
+    pub struct PublicKeyCredentialRequestOptions {
+        pub challenge: Uint8Array,
+        pub timeout: i64,
+        pub rp_id: String,
+        pub user_verification: UserVerification,
+        pub allow_credentials: Vec<Uint8Array>,
+        pub prf: Option<PrfConfig>,
+    }
+
+    impl TryInto<fido2_client::PublicKeyCredentialRequestOptions>
+        for PublicKeyCredentialRequestOptions
+    {
+        type Error = napi::Error;
+
+        fn try_into(self) -> Result<fido2_client::PublicKeyCredentialRequestOptions, Self::Error> {
+            Ok(fido2_client::PublicKeyCredentialRequestOptions {
+                challenge: self.challenge.to_vec(),
+                timeout: self.timeout as u64,
+                rp_id: self.rp_id,
+                user_verification: self.user_verification.into(),
+                allow_credentials: self.allow_credentials.iter().map(|c| c.to_vec()).collect(),
+                prf: self.prf.map(|p| p.into()),
+            })
+        }
+    }
+
+    #[napi(object)]
+    pub struct AuthenticatorAssertionResponse {
+        pub authenticator_data: Uint8Array,
+        pub client_data_json: Uint8Array,
+        pub signature: Uint8Array,
+        pub user_handle: Uint8Array,
+    }
+
+    impl From<fido2_client::AuthenticatorAssertionResponse> for AuthenticatorAssertionResponse {
+        fn from(response: fido2_client::AuthenticatorAssertionResponse) -> Self {
+            AuthenticatorAssertionResponse {
+                authenticator_data: Uint8Array::from(response.authenticator_data),
+                client_data_json: Uint8Array::from(response.client_data_json),
+                signature: Uint8Array::from(response.signature),
+                user_handle: Uint8Array::from(response.user_handle),
+            }
+        }
+    }
+
+    #[napi(object)]
+    pub struct PublicKeyCredential {
+        pub authenticator_attachment: String,
+        pub id: String,
+        pub raw_id: Uint8Array,
+        pub response: AuthenticatorAssertionResponse,
+        pub r#type: String,
+        pub prf: Option<Uint8Array>,
+    }
+
+    impl Into<PublicKeyCredential> for fido2_client::PublicKeyCredential {
+        fn into(self) -> PublicKeyCredential {
+            PublicKeyCredential {
+                authenticator_attachment: self.authenticator_attachment,
+                id: self.id,
+                raw_id: Uint8Array::from(self.raw_id),
+                response: self.response.into(),
+                r#type: self.r#type,
+                prf: self.prf.map(|p| Uint8Array::from(p)),
+            }
+        }
+    }
+
+    #[napi]
+    pub fn get(
+        assertion_options: PublicKeyCredentialRequestOptions,
+    ) -> napi::Result<PublicKeyCredential> {
+        let options: fido2_client::PublicKeyCredentialRequestOptions =
+            assertion_options.try_into()?;
+        fido2_client::fido2_client::get(options)
+            .map_err(|e| napi::Error::from_reason(format!("FIDO2 Authentication failed: {:?}", e)))
+            .map(|credential| credential.into())
+    }
+
+    #[napi]
+    pub fn available() -> bool {
+        fido2_client::fido2_client::available()
+    }
+}

--- a/apps/desktop/desktop_native/objc/Cargo.toml
+++ b/apps/desktop/desktop_native/objc/Cargo.toml
@@ -18,7 +18,7 @@ tracing = { workspace = true }
 core-foundation = "=0.10.1"
 
 [build-dependencies]
-cc = "=1.2.4"
+cc = "=1.2.8"
 glob = "=0.3.2"
 
 [lints]

--- a/apps/desktop/src/app/app-routing.module.ts
+++ b/apps/desktop/src/app/app-routing.module.ts
@@ -12,6 +12,7 @@ import {
   tdeDecryptionRequiredGuard,
   unauthGuardFn,
 } from "@bitwarden/angular/auth/guards";
+import { LoginViaWebAuthnComponent } from "@bitwarden/angular/auth/login-via-webauthn/login-via-webauthn.component";
 import { ChangePasswordComponent } from "@bitwarden/angular/auth/password-management/change-password";
 import { SetInitialPasswordComponent } from "@bitwarden/angular/auth/password-management/set-initial-password/set-initial-password.component";
 import {
@@ -23,6 +24,7 @@ import {
   VaultIcon,
   LockIcon,
   DomainIcon,
+  TwoFactorAuthSecurityKeyIcon,
 } from "@bitwarden/assets/svg";
 import {
   LoginComponent,
@@ -123,6 +125,27 @@ const routes: Routes = [
     path: "",
     component: AnonLayoutWrapperComponent,
     children: [
+      {
+        path: AuthRoute.LoginWithPasskey,
+        canActivate: [unauthGuardFn()],
+        data: {
+          pageIcon: TwoFactorAuthSecurityKeyIcon,
+          pageTitle: {
+            key: "logInWithPasskey",
+          },
+          pageSubtitle: {
+            key: "readingPasskeyLoadingInfo",
+          },
+        } satisfies RouteDataProperties & AnonLayoutWrapperData,
+        children: [
+          { path: "", component: LoginViaWebAuthnComponent },
+          {
+            path: "",
+            component: EnvironmentSelectorComponent,
+            outlet: "environment-selector",
+          },
+        ],
+      },
       {
         path: AuthRoute.SignUp,
         canActivate: [unauthGuardFn()],

--- a/apps/desktop/src/app/services/services.module.ts
+++ b/apps/desktop/src/app/services/services.module.ts
@@ -51,6 +51,7 @@ import {
 } from "@bitwarden/common/auth/abstractions/auth.service";
 import { MasterPasswordApiService } from "@bitwarden/common/auth/abstractions/master-password-api.service.abstraction";
 import { SsoLoginServiceAbstraction } from "@bitwarden/common/auth/abstractions/sso-login.service.abstraction";
+import { NavigatorCredentialsService } from "@bitwarden/common/auth/abstractions/webauthn/navigator-credentials.service";
 import { AutofillSettingsServiceAbstraction } from "@bitwarden/common/autofill/services/autofill-settings.service";
 import { BillingAccountProfileStateService } from "@bitwarden/common/billing/abstractions";
 import { ClientType } from "@bitwarden/common/enums";
@@ -119,6 +120,7 @@ import { DefaultSshImportPromptService, SshImportPromptService } from "@bitwarde
 import { DesktopLoginApprovalDialogComponentService } from "../../auth/login/desktop-login-approval-dialog-component.service";
 import { DesktopLoginComponentService } from "../../auth/login/desktop-login-component.service";
 import { DesktopTwoFactorAuthDuoComponentService } from "../../auth/services/desktop-two-factor-auth-duo-component.service";
+import { RendererNavigatorCredentialsService } from "../../auth/services/renderer-navigator-credentials.service";
 import { DesktopAutofillSettingsService } from "../../autofill/services/desktop-autofill-settings.service";
 import { DesktopAutofillService } from "../../autofill/services/desktop-autofill.service";
 import { DesktopAutotypeDefaultSettingPolicy } from "../../autofill/services/desktop-autotype-policy.service";
@@ -309,6 +311,11 @@ const safeProviders: SafeProvider[] = [
     provide: CryptoFunctionServiceAbstraction,
     useClass: WebCryptoFunctionService,
     deps: [WINDOW],
+  }),
+  safeProvider({
+    provide: NavigatorCredentialsService,
+    useClass: RendererNavigatorCredentialsService,
+    deps: [],
   }),
   safeProvider({
     provide: KeyServiceAbstraction,

--- a/apps/desktop/src/auth/preload.ts
+++ b/apps/desktop/src/auth/preload.ts
@@ -1,5 +1,7 @@
 import { ipcRenderer } from "electron";
 
+import { navigator_credentials } from "@bitwarden/desktop-napi";
+
 export default {
   loginRequest: (alertTitle: string, alertBody: string, buttonText: string): Promise<void> =>
     ipcRenderer.invoke("loginRequest", {
@@ -7,4 +9,10 @@ export default {
       alertBody,
       buttonText,
     }),
+  navigatorCredentialsGet: (
+    options: navigator_credentials.PublicKeyCredentialRequestOptions,
+  ): Promise<navigator_credentials.PublicKeyCredential | null> =>
+    ipcRenderer.invoke("navigatorCredentials.get", options),
+  navigatorCredentialsAvailable: (): Promise<boolean> =>
+    ipcRenderer.invoke("navigatorCredentials.available"),
 };

--- a/apps/desktop/src/auth/preload.ts
+++ b/apps/desktop/src/auth/preload.ts
@@ -1,5 +1,6 @@
 import { ipcRenderer } from "electron";
 
+import { PublicKeyCredential } from "@bitwarden/common/auth/abstractions/webauthn/navigator-credentials.service";
 import { navigator_credentials } from "@bitwarden/desktop-napi";
 
 export default {
@@ -11,8 +12,7 @@ export default {
     }),
   navigatorCredentialsGet: (
     options: navigator_credentials.PublicKeyCredentialRequestOptions,
-  ): Promise<navigator_credentials.PublicKeyCredential | null> =>
-    ipcRenderer.invoke("navigatorCredentials.get", options),
+  ): Promise<PublicKeyCredential | null> => ipcRenderer.invoke("navigatorCredentials.get", options),
   navigatorCredentialsAvailable: (): Promise<boolean> =>
     ipcRenderer.invoke("navigatorCredentials.available"),
 };

--- a/apps/desktop/src/auth/services/main-navigator-credentials.serivce.ts
+++ b/apps/desktop/src/auth/services/main-navigator-credentials.serivce.ts
@@ -7,7 +7,20 @@ export class MainNavigatorCredentialsService {
     ipcMain.handle(
       "navigatorCredentials.get",
       async (_event: any, message: navigator_credentials.PublicKeyCredentialRequestOptions) => {
-        return navigator_credentials.get(message);
+        const result = navigator_credentials.get(message);
+        return {
+          authenticatorAttachment: result.authenticatorAttachment,
+          id: result.id,
+          rawId: result.rawId,
+          response: {
+            clientDataJSON: result.response.clientDataJson,
+            authenticatorData: result.response.authenticatorData,
+            signature: result.response.signature,
+            userHandle: result.response.userHandle,
+          },
+          type: result.type,
+          prf: result.prf,
+        };
       },
     );
     ipcMain.handle("navigatorCredentials.available", async (_event: any, _message: any) => {

--- a/apps/desktop/src/auth/services/main-navigator-credentials.serivce.ts
+++ b/apps/desktop/src/auth/services/main-navigator-credentials.serivce.ts
@@ -1,0 +1,17 @@
+import { ipcMain } from "electron";
+
+import { navigator_credentials } from "@bitwarden/desktop-napi";
+
+export class MainNavigatorCredentialsService {
+  constructor() {
+    ipcMain.handle(
+      "navigatorCredentials.get",
+      async (_event: any, message: navigator_credentials.PublicKeyCredentialRequestOptions) => {
+        return navigator_credentials.get(message);
+      },
+    );
+    ipcMain.handle("navigatorCredentials.available", async (_event: any, _message: any) => {
+      return navigator_credentials.available();
+    });
+  }
+}

--- a/apps/desktop/src/auth/services/renderer-navigator-credentials.service.ts
+++ b/apps/desktop/src/auth/services/renderer-navigator-credentials.service.ts
@@ -1,0 +1,52 @@
+import { navigator_credentials } from "apps/desktop/desktop_native/napi";
+
+import { NavigatorCredentialsService } from "@bitwarden/common/auth/abstractions/webauthn/navigator-credentials.service";
+
+export class RendererNavigatorCredentialsService implements NavigatorCredentialsService {
+  constructor() {}
+
+  async get(options: CredentialRequestOptions): Promise<Credential | null> {
+    return await ipc.auth.navigatorCredentialsGet({
+      challenge: arrayBufferSourceToUint8Array(options.publicKey.challenge),
+      timeout: options.publicKey.timeout,
+      rpId: options.publicKey.rpId,
+      userVerification: convertUserVerification(options.publicKey.userVerification),
+      allowCredentials: options.publicKey.allowCredentials.map((cred) => {
+        return arrayBufferSourceToUint8Array(cred.id);
+      }),
+      prf: options.publicKey.extensions?.prf
+        ? {
+            first: arrayBufferSourceToUint8Array(options.publicKey.extensions!.prf!.eval.first),
+            second: undefined,
+          }
+        : undefined,
+    });
+  }
+
+  async available(): Promise<boolean> {
+    return await ipc.auth.navigatorCredentialsAvailable();
+  }
+}
+
+function arrayBufferSourceToUint8Array(source: BufferSource): Uint8Array {
+  if (source instanceof ArrayBuffer) {
+    return new Uint8Array(source);
+  } else {
+    return new Uint8Array(source.buffer, source.byteOffset, source.byteLength);
+  }
+}
+
+function convertUserVerification(
+  userVerification: UserVerificationRequirement | undefined,
+): navigator_credentials.UserVerification | undefined {
+  switch (userVerification) {
+    case "required":
+      return navigator_credentials.UserVerification.Required;
+    case "preferred":
+      return navigator_credentials.UserVerification.Preferred;
+    case "discouraged":
+      return navigator_credentials.UserVerification.Discouraged;
+    default:
+      return undefined;
+  }
+}

--- a/apps/desktop/src/auth/services/renderer-navigator-credentials.service.ts
+++ b/apps/desktop/src/auth/services/renderer-navigator-credentials.service.ts
@@ -1,11 +1,14 @@
 import { navigator_credentials } from "apps/desktop/desktop_native/napi";
 
-import { NavigatorCredentialsService } from "@bitwarden/common/auth/abstractions/webauthn/navigator-credentials.service";
+import {
+  NavigatorCredentialsService,
+  PublicKeyCredential,
+} from "@bitwarden/common/auth/abstractions/webauthn/navigator-credentials.service";
 
 export class RendererNavigatorCredentialsService implements NavigatorCredentialsService {
   constructor() {}
 
-  async get(options: CredentialRequestOptions): Promise<Credential | null> {
+  async get(options: CredentialRequestOptions): Promise<PublicKeyCredential | null> {
     return await ipc.auth.navigatorCredentialsGet({
       challenge: arrayBufferSourceToUint8Array(options.publicKey.challenge),
       timeout: options.publicKey.timeout,

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -34,6 +34,7 @@ import {
 import { SerializedMemoryStorageService, StorageServiceProvider } from "@bitwarden/storage-core";
 
 import { ChromiumImporterService } from "./app/tools/import/chromium-importer.service";
+import { MainNavigatorCredentialsService } from "./auth/services/main-navigator-credentials.serivce";
 import { MainDesktopAutotypeService } from "./autofill/main/main-desktop-autotype.service";
 import { MainSshAgentService } from "./autofill/main/main-ssh-agent.service";
 import { DesktopAutofillSettingsService } from "./autofill/services/desktop-autofill-settings.service";
@@ -284,6 +285,7 @@ export class Main {
       app.getPath("exe"),
       app.getAppPath(),
     );
+    new MainNavigatorCredentialsService();
 
     this.desktopAutofillSettingsService = new DesktopAutofillSettingsService(stateProvider);
 

--- a/apps/web/src/app/auth/core/services/webauthn-login/webauthn-login-admin.service.spec.ts
+++ b/apps/web/src/app/auth/core/services/webauthn-login/webauthn-login-admin.service.spec.ts
@@ -6,6 +6,10 @@ import { mock, MockProxy } from "jest-mock-extended";
 import { of } from "rxjs";
 
 import { UserVerificationService } from "@bitwarden/common/auth/abstractions/user-verification/user-verification.service.abstraction";
+import {
+  PublicKeyCredential as CustomPublicKeyCredential,
+  AuthenticatorAssertionResponse as CustomAuthenticatorAssertionResponse,
+} from "@bitwarden/common/auth/abstractions/webauthn/navigator-credentials.service";
 import { WebAuthnLoginPrfKeyServiceAbstraction } from "@bitwarden/common/auth/abstractions/webauthn/webauthn-login-prf-key.service.abstraction";
 import { WebAuthnLoginCredentialAssertionView } from "@bitwarden/common/auth/models/view/webauthn-login/webauthn-login-credential-assertion.view";
 import { WebAuthnLoginAssertionResponseRequest } from "@bitwarden/common/auth/services/webauthn-login/request/webauthn-login-assertion-response.request";
@@ -64,8 +68,6 @@ describe("WebauthnAdminService", () => {
 
     // Save original global class
     originalAuthenticatorAssertionResponse = global.AuthenticatorAssertionResponse;
-    // Mock the global AuthenticatorAssertionResponse class b/c the class is only available in secure contexts
-    global.AuthenticatorAssertionResponse = MockAuthenticatorAssertionResponse;
 
     keyService.userKey$.mockReturnValue(of(mockUserKey));
   });
@@ -117,7 +119,7 @@ describe("WebauthnAdminService", () => {
   describe("enableCredentialEncryption", () => {
     it("should call the necessary methods to update the credential", async () => {
       // Arrange
-      const response = new MockPublicKeyCredential();
+      const response = mockPublicKeyCredential;
       const prfKeySet = new RotateableKeySet<PrfKey>(
         new EncString("test_encryptedUserKey"),
         new EncString("test_encryptedPublicKey"),
@@ -154,7 +156,7 @@ describe("WebauthnAdminService", () => {
 
     it("should throw error when PRF Key is undefined", async () => {
       // Arrange
-      const response = new MockPublicKeyCredential();
+      const response = mockPublicKeyCredential;
 
       const assertionOptions: WebAuthnLoginCredentialAssertionView =
         new WebAuthnLoginCredentialAssertionView(
@@ -181,7 +183,7 @@ describe("WebauthnAdminService", () => {
     });
 
     test.each([null, undefined, ""])("should throw an error when userId is %p", async (userId) => {
-      const response = new MockPublicKeyCredential();
+      const response = mockPublicKeyCredential;
       const assertionOptions: WebAuthnLoginCredentialAssertionView =
         new WebAuthnLoginCredentialAssertionView(
           "enable_credential_encryption_test_token",
@@ -394,57 +396,21 @@ function createDeviceResponse({ prf = false }: { prf?: boolean } = {}): PublicKe
   return credential;
 }
 
-/**
- * Mocks for the PublicKeyCredential and AuthenticatorAssertionResponse classes copied from webauthn-login.service.spec.ts
- */
-
 // AuthenticatorAssertionResponse && PublicKeyCredential are only available in secure contexts
 // so we need to mock them and assign them to the global object to make them available
 // for the tests
-class MockAuthenticatorAssertionResponse implements AuthenticatorAssertionResponse {
-  clientDataJSON: ArrayBuffer = randomBytes(32).buffer;
-  authenticatorData: ArrayBuffer = randomBytes(196).buffer;
-  signature: ArrayBuffer = randomBytes(72).buffer;
-  userHandle: ArrayBuffer = randomBytes(16).buffer;
+const mockAuthenticatorAssertionResponse: CustomAuthenticatorAssertionResponse = {
+  clientDataJSON: randomBytes(32),
+  authenticatorData: randomBytes(196),
+  signature: randomBytes(72),
+  userHandle: randomBytes(16),
+};
 
-  clientDataJSONB64Str = Utils.fromBufferToUrlB64(this.clientDataJSON);
-  authenticatorDataB64Str = Utils.fromBufferToUrlB64(this.authenticatorData);
-  signatureB64Str = Utils.fromBufferToUrlB64(this.signature);
-  userHandleB64Str = Utils.fromBufferToUrlB64(this.userHandle);
-}
-
-class MockPublicKeyCredential implements PublicKeyCredential {
-  authenticatorAttachment = "cross-platform";
-  id = "mockCredentialId";
-  type = "public-key";
-  rawId: ArrayBuffer = randomBytes(32).buffer;
-  rawIdB64Str = Utils.fromBufferToUrlB64(this.rawId);
-
-  response: MockAuthenticatorAssertionResponse = new MockAuthenticatorAssertionResponse();
-
-  // Use random 64 character hex string (32 bytes - matters for symmetric key creation)
-  // to represent the prf key binary data and convert to ArrayBuffer
-  // Creating the array buffer from a known hex value allows us to
-  // assert on the value in tests
-  private prfKeyArrayBuffer: ArrayBuffer = Utils.hexStringToArrayBuffer(
-    "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
-  );
-
-  getClientExtensionResults(): any {
-    return {
-      prf: {
-        results: {
-          first: this.prfKeyArrayBuffer,
-        },
-      },
-    };
-  }
-
-  static isConditionalMediationAvailable(): Promise<boolean> {
-    return Promise.resolve(false);
-  }
-
-  static isUserVerifyingPlatformAuthenticatorAvailable(): Promise<boolean> {
-    return Promise.resolve(false);
-  }
-}
+const mockPublicKeyCredential: CustomPublicKeyCredential = {
+  authenticatorAttachment: "cross-platform",
+  id: "mockCredentialId",
+  type: "public-key",
+  rawId: randomBytes(32),
+  response: mockAuthenticatorAssertionResponse,
+  prf: randomBytes(32),
+};

--- a/apps/web/src/app/core/core.module.ts
+++ b/apps/web/src/app/core/core.module.ts
@@ -62,7 +62,9 @@ import { AccountService } from "@bitwarden/common/auth/abstractions/account.serv
 import { AuthService } from "@bitwarden/common/auth/abstractions/auth.service";
 import { MasterPasswordApiService } from "@bitwarden/common/auth/abstractions/master-password-api.service.abstraction";
 import { SsoLoginServiceAbstraction } from "@bitwarden/common/auth/abstractions/sso-login.service.abstraction";
+import { NavigatorCredentialsService } from "@bitwarden/common/auth/abstractions/webauthn/navigator-credentials.service";
 import { OrganizationInviteService } from "@bitwarden/common/auth/services/organization-invite/organization-invite.service";
+import { DefaultNavigatorCredentialsService } from "@bitwarden/common/auth/services/webauthn-login/default-navigator-credentials.service";
 import { BillingAccountProfileStateService } from "@bitwarden/common/billing/abstractions/account/billing-account-profile-state.service";
 import { ClientType } from "@bitwarden/common/enums";
 import { ProcessReloadServiceAbstraction } from "@bitwarden/common/key-management/abstractions/process-reload.service";
@@ -468,6 +470,11 @@ const safeProviders: SafeProvider[] = [
     provide: SystemService,
     useClass: WebSystemService,
     deps: [],
+  }),
+  safeProvider({
+    provide: NavigatorCredentialsService,
+    useClass: DefaultNavigatorCredentialsService,
+    deps: [WINDOW, PlatformUtilsService],
   }),
   safeProvider({
     provide: SessionTimeoutSettingsComponentService,

--- a/libs/angular/src/services/jslib-services.module.ts
+++ b/libs/angular/src/services/jslib-services.module.ts
@@ -105,6 +105,7 @@ import { TokenService as TokenServiceAbstraction } from "@bitwarden/common/auth/
 import { TwoFactorService as TwoFactorServiceAbstraction } from "@bitwarden/common/auth/abstractions/two-factor.service";
 import { UserVerificationApiServiceAbstraction } from "@bitwarden/common/auth/abstractions/user-verification/user-verification-api.service.abstraction";
 import { UserVerificationService as UserVerificationServiceAbstraction } from "@bitwarden/common/auth/abstractions/user-verification/user-verification.service.abstraction";
+import { NavigatorCredentialsService } from "@bitwarden/common/auth/abstractions/webauthn/navigator-credentials.service";
 import { WebAuthnLoginApiServiceAbstraction } from "@bitwarden/common/auth/abstractions/webauthn/webauthn-login-api.service.abstraction";
 import { WebAuthnLoginPrfKeyServiceAbstraction } from "@bitwarden/common/auth/abstractions/webauthn/webauthn-login-prf-key.service.abstraction";
 import { WebAuthnLoginServiceAbstraction } from "@bitwarden/common/auth/abstractions/webauthn/webauthn-login.service.abstraction";
@@ -1346,7 +1347,7 @@ const safeProviders: SafeProvider[] = [
       WebAuthnLoginApiServiceAbstraction,
       LoginStrategyServiceAbstraction,
       WebAuthnLoginPrfKeyServiceAbstraction,
-      WINDOW,
+      NavigatorCredentialsService,
       LogService,
     ],
   }),

--- a/libs/auth/src/angular/login/default-login-component.service.spec.ts
+++ b/libs/auth/src/angular/login/default-login-component.service.spec.ts
@@ -2,7 +2,6 @@ import { mock, MockProxy } from "jest-mock-extended";
 import { of } from "rxjs";
 
 import { SsoLoginServiceAbstraction } from "@bitwarden/common/auth/abstractions/sso-login.service.abstraction";
-import { ClientType } from "@bitwarden/common/enums";
 import { CryptoFunctionService } from "@bitwarden/common/key-management/crypto/abstractions/crypto-function.service";
 import {
   EnvironmentService,
@@ -54,18 +53,6 @@ describe("DefaultLoginComponentService", () => {
 
   it("creates without error", () => {
     expect(service).toBeTruthy();
-  });
-
-  describe("isLoginWithPasskeySupported", () => {
-    it("returns true when clientType is Web", () => {
-      service["clientType"] = ClientType.Web;
-      expect(service.isLoginWithPasskeySupported()).toBe(true);
-    });
-
-    it("returns false when clientType is not Web", () => {
-      service["clientType"] = ClientType.Desktop;
-      expect(service.isLoginWithPasskeySupported()).toBe(false);
-    });
   });
 
   describe("redirectToSsoLogin", () => {

--- a/libs/auth/src/angular/login/default-login-component.service.ts
+++ b/libs/auth/src/angular/login/default-login-component.service.ts
@@ -23,10 +23,6 @@ export class DefaultLoginComponentService implements LoginComponentService {
     this.clientType = this.platformUtilsService.getClientType();
   }
 
-  isLoginWithPasskeySupported(): boolean {
-    return this.clientType === ClientType.Web;
-  }
-
   /**
    * Redirects the user to the SSO login page, either via route or in a new browser window.
    * @param email The email address of the user attempting to log in

--- a/libs/auth/src/angular/login/login-component.service.ts
+++ b/libs/auth/src/angular/login/login-component.service.ts
@@ -26,11 +26,6 @@ export abstract class LoginComponentService {
   getOrgPoliciesFromOrgInvite?: (email: string) => Promise<PasswordPolicies | null>;
 
   /**
-   * Indicates whether login with passkey is supported on the given client
-   */
-  isLoginWithPasskeySupported: () => boolean;
-
-  /**
    * Redirects the user to the SSO login page, either via route or in a new browser window.
    */
   redirectToSsoLogin: (email: string) => Promise<void | null>;

--- a/libs/auth/src/angular/login/login.component.spec.ts
+++ b/libs/auth/src/angular/login/login.component.spec.ts
@@ -2,6 +2,7 @@ import { FormBuilder } from "@angular/forms";
 import { mock } from "jest-mock-extended";
 
 import { LoginStrategyServiceAbstraction } from "@bitwarden/auth/common";
+import { WebAuthnLoginServiceAbstraction } from "@bitwarden/common/auth/abstractions/webauthn/webauthn-login.service.abstraction";
 import { ClientType } from "@bitwarden/common/enums";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
@@ -45,6 +46,7 @@ describe("LoginComponent continue() integration", () => {
     configService.getFeatureFlag.mockResolvedValue(flagEnabled);
     const ssoLoginService: any = { ssoRequiredCache$: { pipe: () => ({}) } };
     const environmentService: any = { environment$: { pipe: () => ({}) } };
+    const webauthnLoginService = mock<WebAuthnLoginServiceAbstraction>();
 
     const component = new LoginComponent(
       activatedRoute,
@@ -71,6 +73,7 @@ describe("LoginComponent continue() integration", () => {
       configService,
       ssoLoginService,
       environmentService,
+      webauthnLoginService,
     );
 
     jest.spyOn(component as any, "toggleLoginUiState").mockResolvedValue(undefined);

--- a/libs/auth/src/angular/login/login.component.ts
+++ b/libs/auth/src/angular/login/login.component.ts
@@ -27,7 +27,7 @@ import { MasterPasswordPolicyOptions } from "@bitwarden/common/admin-console/mod
 import { Policy } from "@bitwarden/common/admin-console/models/domain/policy";
 import { DevicesApiServiceAbstraction } from "@bitwarden/common/auth/abstractions/devices-api.service.abstraction";
 import { SsoLoginServiceAbstraction } from "@bitwarden/common/auth/abstractions/sso-login.service.abstraction";
-import { WebauthnLoginServiceAbstraction } from "@bitwarden/common/auth/abstractions/webauthn-login/webauthn-login.service";
+import { WebAuthnLoginServiceAbstraction } from "@bitwarden/common/auth/abstractions/webauthn/webauthn-login.service.abstraction";
 import { AuthResult } from "@bitwarden/common/auth/models/domain/auth-result";
 import { ClientType, HttpStatusCode } from "@bitwarden/common/enums";
 import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
@@ -147,7 +147,7 @@ export class LoginComponent implements OnInit, OnDestroy {
     private configService: ConfigService,
     private ssoLoginService: SsoLoginServiceAbstraction,
     private environmentService: EnvironmentService,
-    private webauthnLoginService: WebauthnLoginServiceAbstraction,
+    private webauthnLoginService: WebAuthnLoginServiceAbstraction,
   ) {
     this.clientType = this.platformUtilsService.getClientType();
   }

--- a/libs/auth/src/angular/login/login.component.ts
+++ b/libs/auth/src/angular/login/login.component.ts
@@ -27,6 +27,7 @@ import { MasterPasswordPolicyOptions } from "@bitwarden/common/admin-console/mod
 import { Policy } from "@bitwarden/common/admin-console/models/domain/policy";
 import { DevicesApiServiceAbstraction } from "@bitwarden/common/auth/abstractions/devices-api.service.abstraction";
 import { SsoLoginServiceAbstraction } from "@bitwarden/common/auth/abstractions/sso-login.service.abstraction";
+import { WebauthnLoginServiceAbstraction } from "@bitwarden/common/auth/abstractions/webauthn-login/webauthn-login.service";
 import { AuthResult } from "@bitwarden/common/auth/models/domain/auth-result";
 import { ClientType, HttpStatusCode } from "@bitwarden/common/enums";
 import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
@@ -146,6 +147,7 @@ export class LoginComponent implements OnInit, OnDestroy {
     private configService: ConfigService,
     private ssoLoginService: SsoLoginServiceAbstraction,
     private environmentService: EnvironmentService,
+    private webauthnLoginService: WebauthnLoginServiceAbstraction,
   ) {
     this.clientType = this.platformUtilsService.getClientType();
   }
@@ -525,7 +527,7 @@ export class LoginComponent implements OnInit, OnDestroy {
   }
 
   isLoginWithPasskeySupported() {
-    return this.loginComponentService.isLoginWithPasskeySupported();
+    return this.webauthnLoginService.available();
   }
 
   protected async goToHint(): Promise<void> {

--- a/libs/auth/src/common/login-strategies/webauthn-login.strategy.spec.ts
+++ b/libs/auth/src/common/login-strategies/webauthn-login.strategy.spec.ts
@@ -365,3 +365,5 @@ const mockPublicKeyCredential: CustomPublicKeyCredential = {
   response: mockAuthenticatorAssertionResponse,
   prf: randomBytes(32),
 };
+
+export { mockPublicKeyCredential };

--- a/libs/auth/src/common/services/login-strategies/login-strategy.state.spec.ts
+++ b/libs/auth/src/common/services/login-strategies/login-strategy.state.spec.ts
@@ -15,10 +15,7 @@ import { PasswordLoginStrategyData } from "../../login-strategies/password-login
 import { SsoLoginStrategyData } from "../../login-strategies/sso-login.strategy";
 import { UserApiLoginStrategyData } from "../../login-strategies/user-api-login.strategy";
 import { WebAuthnLoginStrategyData } from "../../login-strategies/webauthn-login.strategy";
-import {
-  MockAuthenticatorAssertionResponse,
-  MockPublicKeyCredential,
-} from "../../login-strategies/webauthn-login.strategy.spec";
+import { mockPublicKeyCredential } from "../../login-strategies/webauthn-login.strategy.spec";
 import { AuthRequestLoginCredentials, WebAuthnLoginCredentials } from "../../models";
 
 import { CACHE_KEY } from "./login-strategy.state";
@@ -104,9 +101,8 @@ describe("LOGIN_STRATEGY_CACHE_KEY", () => {
   });
 
   it("should correctly deserialize WebAuthnLoginStrategyData", () => {
-    global.AuthenticatorAssertionResponse = MockAuthenticatorAssertionResponse;
     const actual = { webAuthn: new WebAuthnLoginStrategyData() };
-    const publicKeyCredential = new MockPublicKeyCredential();
+    const publicKeyCredential = mockPublicKeyCredential;
     const deviceResponse = new WebAuthnLoginAssertionResponseRequest(publicKeyCredential);
     const prfKey = new SymmetricCryptoKey(new Uint8Array(64)) as PrfKey;
     actual.webAuthn.credentials = new WebAuthnLoginCredentials("TOKEN", deviceResponse, prfKey);

--- a/libs/common/src/auth/abstractions/webauthn/navigator-credentials.service.ts
+++ b/libs/common/src/auth/abstractions/webauthn/navigator-credentials.service.ts
@@ -1,4 +1,20 @@
+export type AuthenticatorAssertionResponse = {
+  clientDataJSON: Uint8Array;
+  authenticatorData: Uint8Array;
+  signature: Uint8Array;
+  userHandle: Uint8Array | null;
+};
+
+export type PublicKeyCredential = {
+  authenticatorAttachment: string;
+  id: string;
+  rawId: Uint8Array;
+  response: AuthenticatorAssertionResponse;
+  type: string;
+  prf?: Uint8Array;
+};
+
 export abstract class NavigatorCredentialsService {
-  abstract get(options: CredentialRequestOptions): Promise<Credential | null>;
+  abstract get(options: CredentialRequestOptions): Promise<PublicKeyCredential | null>;
   abstract available(): Promise<boolean>;
 }

--- a/libs/common/src/auth/abstractions/webauthn/navigator-credentials.service.ts
+++ b/libs/common/src/auth/abstractions/webauthn/navigator-credentials.service.ts
@@ -1,0 +1,4 @@
+export abstract class NavigatorCredentialsService {
+  abstract get(options: CredentialRequestOptions): Promise<Credential | null>;
+  abstract available(): Promise<boolean>;
+}

--- a/libs/common/src/auth/abstractions/webauthn/webauthn-login.service.abstraction.ts
+++ b/libs/common/src/auth/abstractions/webauthn/webauthn-login.service.abstraction.ts
@@ -38,4 +38,9 @@ export abstract class WebAuthnLoginServiceAbstraction {
    * that needs to be validated for login.
    */
   abstract logIn(assertion: WebAuthnLoginCredentialAssertionView): Promise<AuthResult>;
+
+  /**
+   * Checks if WebAuthnLogin is available in the current environment.
+   */
+  abstract available(): Promise<boolean>;
 }

--- a/libs/common/src/auth/services/webauthn-login/default-navigator-credentials.service.ts
+++ b/libs/common/src/auth/services/webauthn-login/default-navigator-credentials.service.ts
@@ -23,7 +23,7 @@ export class DefaultNavigatorCredentialsService implements NavigatorCredentialsS
     const response: AuthenticatorAssertionResponse =
       result.response as AuthenticatorAssertionResponse;
     return {
-      authenticatorAttachment: result.authenticatorAttachment,
+      authenticatorAttachment: result!.authenticatorAttachment,
       id: result.id,
       rawId: new Uint8Array(result.rawId),
       response: {
@@ -42,7 +42,11 @@ export class DefaultNavigatorCredentialsService implements NavigatorCredentialsS
   }
 }
 
-function bufferSourceToUint8Array(source: BufferSource): Uint8Array {
+function bufferSourceToUint8Array(source: BufferSource | null): Uint8Array | null {
+  if (source === null) {
+    return null;
+  }
+
   if (source instanceof ArrayBuffer) {
     return new Uint8Array(source);
   } else {

--- a/libs/common/src/auth/services/webauthn-login/default-navigator-credentials.service.ts
+++ b/libs/common/src/auth/services/webauthn-login/default-navigator-credentials.service.ts
@@ -1,7 +1,10 @@
 import { ClientType } from "@bitwarden/client-type";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 
-import { NavigatorCredentialsService } from "../../abstractions/webauthn/navigator-credentials.service";
+import {
+  NavigatorCredentialsService,
+  PublicKeyCredential as CustomPublicKeyCredential,
+} from "../../abstractions/webauthn/navigator-credentials.service";
 
 export class DefaultNavigatorCredentialsService implements NavigatorCredentialsService {
   private navigatorCredentials: CredentialsContainer;
@@ -13,11 +16,36 @@ export class DefaultNavigatorCredentialsService implements NavigatorCredentialsS
     this.navigatorCredentials = this.window.navigator.credentials;
   }
 
-  async get(options: CredentialRequestOptions): Promise<Credential | null> {
-    return await this.navigatorCredentials.get(options);
+  async get(options: CredentialRequestOptions): Promise<CustomPublicKeyCredential | null> {
+    const result: PublicKeyCredential = (await this.navigatorCredentials.get(
+      options,
+    )) as PublicKeyCredential;
+    const response: AuthenticatorAssertionResponse =
+      result.response as AuthenticatorAssertionResponse;
+    return {
+      authenticatorAttachment: result.authenticatorAttachment,
+      id: result.id,
+      rawId: new Uint8Array(result.rawId),
+      response: {
+        clientDataJSON: new Uint8Array(response.clientDataJSON),
+        authenticatorData: new Uint8Array(response.authenticatorData),
+        signature: new Uint8Array(response.signature),
+        userHandle: response.userHandle ? new Uint8Array(response.userHandle) : null,
+      },
+      type: result.type,
+      prf: bufferSourceToUint8Array(result.getClientExtensionResults().prf?.results?.first),
+    };
   }
 
   async available(): Promise<boolean> {
     return this.platformUtilsService.getClientType() === ClientType.Web;
+  }
+}
+
+function bufferSourceToUint8Array(source: BufferSource): Uint8Array {
+  if (source instanceof ArrayBuffer) {
+    return new Uint8Array(source);
+  } else {
+    return new Uint8Array(source.buffer, source.byteOffset, source.byteLength);
   }
 }

--- a/libs/common/src/auth/services/webauthn-login/default-navigator-credentials.service.ts
+++ b/libs/common/src/auth/services/webauthn-login/default-navigator-credentials.service.ts
@@ -23,7 +23,7 @@ export class DefaultNavigatorCredentialsService implements NavigatorCredentialsS
     const response: AuthenticatorAssertionResponse =
       result.response as AuthenticatorAssertionResponse;
     return {
-      authenticatorAttachment: result!.authenticatorAttachment,
+      authenticatorAttachment: result!.authenticatorAttachment!,
       id: result.id,
       rawId: new Uint8Array(result.rawId),
       response: {
@@ -42,9 +42,9 @@ export class DefaultNavigatorCredentialsService implements NavigatorCredentialsS
   }
 }
 
-function bufferSourceToUint8Array(source: BufferSource | null): Uint8Array | null {
-  if (source === null) {
-    return null;
+function bufferSourceToUint8Array(source: BufferSource | undefined): Uint8Array | undefined {
+  if (source === undefined) {
+    return undefined;
   }
 
   if (source instanceof ArrayBuffer) {

--- a/libs/common/src/auth/services/webauthn-login/default-navigator-credentials.service.ts
+++ b/libs/common/src/auth/services/webauthn-login/default-navigator-credentials.service.ts
@@ -1,0 +1,23 @@
+import { ClientType } from "@bitwarden/client-type";
+import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
+
+import { NavigatorCredentialsServiceAbstraction } from "../../abstractions/webauthn/navigator-credentials.service";
+
+export class DefaultNavigatorCredentialsService implements NavigatorCredentialsServiceAbstraction {
+  private navigatorCredentials: CredentialsContainer;
+
+  constructor(
+    private window: Window,
+    private platformUtilsService: PlatformUtilsService,
+  ) {
+    this.navigatorCredentials = this.window.navigator.credentials;
+  }
+
+  async get(options: CredentialRequestOptions): Promise<Credential | null> {
+    return await this.navigatorCredentials.get(options);
+  }
+
+  async available(): Promise<boolean> {
+    return this.platformUtilsService.getClientType() === ClientType.Web;
+  }
+}

--- a/libs/common/src/auth/services/webauthn-login/default-navigator-credentials.service.ts
+++ b/libs/common/src/auth/services/webauthn-login/default-navigator-credentials.service.ts
@@ -1,9 +1,9 @@
 import { ClientType } from "@bitwarden/client-type";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 
-import { NavigatorCredentialsServiceAbstraction } from "../../abstractions/webauthn/navigator-credentials.service";
+import { NavigatorCredentialsService } from "../../abstractions/webauthn/navigator-credentials.service";
 
-export class DefaultNavigatorCredentialsService implements NavigatorCredentialsServiceAbstraction {
+export class DefaultNavigatorCredentialsService implements NavigatorCredentialsService {
   private navigatorCredentials: CredentialsContainer;
 
   constructor(

--- a/libs/common/src/auth/services/webauthn-login/request/webauthn-login-assertion-response.request.ts
+++ b/libs/common/src/auth/services/webauthn-login/request/webauthn-login-assertion-response.request.ts
@@ -2,6 +2,8 @@
 // @ts-strict-ignore
 import { Jsonify } from "type-fest";
 
+import { PublicKeyCredential } from "@bitwarden/common/auth/abstractions/webauthn/navigator-credentials.service";
+
 import { Utils } from "../../../../platform/misc/utils";
 
 import { WebAuthnLoginResponseRequest } from "./webauthn-login-response.request";
@@ -20,15 +22,15 @@ export class WebAuthnLoginAssertionResponseRequest extends WebAuthnLoginResponse
   constructor(credential: PublicKeyCredential) {
     super(credential);
 
-    if (!(credential.response instanceof AuthenticatorAssertionResponse)) {
-      throw new Error("Invalid authenticator response");
-    }
-
     this.response = {
-      authenticatorData: Utils.fromBufferToUrlB64(credential.response.authenticatorData),
-      signature: Utils.fromBufferToUrlB64(credential.response.signature),
-      clientDataJSON: Utils.fromBufferToUrlB64(credential.response.clientDataJSON),
-      userHandle: Utils.fromBufferToUrlB64(credential.response.userHandle),
+      authenticatorData: Utils.fromBufferToUrlB64(
+        credential.response.authenticatorData.buffer as ArrayBuffer,
+      ),
+      signature: Utils.fromBufferToUrlB64(credential.response.signature.buffer as ArrayBuffer),
+      clientDataJSON: Utils.fromBufferToUrlB64(
+        credential.response.clientDataJSON.buffer as ArrayBuffer,
+      ),
+      userHandle: Utils.fromBufferToUrlB64(credential.response.userHandle.buffer as ArrayBuffer),
     };
   }
 

--- a/libs/common/src/auth/services/webauthn-login/request/webauthn-login-response.request.ts
+++ b/libs/common/src/auth/services/webauthn-login/request/webauthn-login-response.request.ts
@@ -1,3 +1,5 @@
+import { PublicKeyCredential } from "@bitwarden/common/auth/abstractions/webauthn/navigator-credentials.service";
+
 import { Utils } from "../../../../platform/misc/utils";
 
 export abstract class WebAuthnLoginResponseRequest {
@@ -8,7 +10,7 @@ export abstract class WebAuthnLoginResponseRequest {
 
   constructor(credential: PublicKeyCredential) {
     this.id = credential.id;
-    this.rawId = Utils.fromBufferToUrlB64(credential.rawId);
+    this.rawId = Utils.fromBufferToUrlB64(credential.rawId.buffer as ArrayBuffer);
     this.type = credential.type;
 
     // WARNING: do not add PRF information here by mapping

--- a/libs/common/src/auth/services/webauthn-login/webauthn-login.service.spec.ts
+++ b/libs/common/src/auth/services/webauthn-login/webauthn-login.service.spec.ts
@@ -210,7 +210,7 @@ describe("WebAuthnLoginService", () => {
       const credentialAssertionOptions = buildCredentialAssertionOptions();
 
       // Mock the navigatorCredentials.get to return null
-      navigatorCredentials.get.mockResolvedValue(null);
+      mockNavigatorCredentialsService.get.mockResolvedValue(null);
 
       // Act
       const result = await webAuthnLoginService.assertCredential(credentialAssertionOptions);
@@ -226,7 +226,7 @@ describe("WebAuthnLoginService", () => {
 
       // Mock navigatorCredentials.get to throw an error
       const errorMessage = "Simulated error";
-      navigatorCredentials.get.mockRejectedValue(new Error(errorMessage));
+      mockNavigatorCredentialsService.get.mockRejectedValue(new Error(errorMessage));
 
       // Spy on logService.error
       const logServiceErrorSpy = jest.spyOn(logService, "error");

--- a/libs/common/src/auth/services/webauthn-login/webauthn-login.service.ts
+++ b/libs/common/src/auth/services/webauthn-login/webauthn-login.service.ts
@@ -23,7 +23,7 @@ export class WebAuthnLoginService implements WebAuthnLoginServiceAbstraction {
     protected webAuthnLoginPrfKeyService: WebAuthnLoginPrfKeyServiceAbstraction,
     protected navigatorCredentialsService: NavigatorCredentialsService,
     protected logService?: LogService,
-  ) { }
+  ) {}
 
   async getCredentialAssertionOptions(): Promise<WebAuthnLoginCredentialAssertionOptionsView> {
     const response = await this.webAuthnLoginApiService.getCredentialAssertionOptions();

--- a/libs/common/src/auth/services/webauthn-login/webauthn-login.service.ts
+++ b/libs/common/src/auth/services/webauthn-login/webauthn-login.service.ts
@@ -43,15 +43,13 @@ export class WebAuthnLoginService implements WebAuthnLoginServiceAbstraction {
 
     try {
       const response = await this.navigatorCredentialsService.get(nativeOptions);
-      if (!(response instanceof PublicKeyCredential)) {
-        return undefined;
-      }
       // TODO: Remove `any` when typescript typings add support for PRF
-      const prfResult = (response.getClientExtensionResults() as any).prf?.results?.first;
+      const prfResult = response.prf;
       let symmetricPrfKey: PrfKey | undefined;
       if (prfResult != undefined) {
-        symmetricPrfKey =
-          await this.webAuthnLoginPrfKeyService.createSymmetricKeyFromPrf(prfResult);
+        symmetricPrfKey = await this.webAuthnLoginPrfKeyService.createSymmetricKeyFromPrf(
+          prfResult.buffer as ArrayBuffer,
+        );
       }
 
       const deviceResponse = new WebAuthnLoginAssertionResponseRequest(response);

--- a/libs/common/src/auth/services/webauthn-login/webauthn-login.service.ts
+++ b/libs/common/src/auth/services/webauthn-login/webauthn-login.service.ts
@@ -23,7 +23,7 @@ export class WebAuthnLoginService implements WebAuthnLoginServiceAbstraction {
     protected webAuthnLoginPrfKeyService: WebAuthnLoginPrfKeyServiceAbstraction,
     protected navigatorCredentialsService: NavigatorCredentialsService,
     protected logService?: LogService,
-  ) {}
+  ) { }
 
   async getCredentialAssertionOptions(): Promise<WebAuthnLoginCredentialAssertionOptionsView> {
     const response = await this.webAuthnLoginApiService.getCredentialAssertionOptions();
@@ -32,7 +32,7 @@ export class WebAuthnLoginService implements WebAuthnLoginServiceAbstraction {
 
   async assertCredential(
     credentialAssertionOptions: WebAuthnLoginCredentialAssertionOptionsView,
-  ): Promise<WebAuthnLoginCredentialAssertionView> {
+  ): Promise<WebAuthnLoginCredentialAssertionView | undefined> {
     const nativeOptions: CredentialRequestOptions = {
       publicKey: credentialAssertionOptions.options,
     };
@@ -43,6 +43,10 @@ export class WebAuthnLoginService implements WebAuthnLoginServiceAbstraction {
 
     try {
       const response = await this.navigatorCredentialsService.get(nativeOptions);
+      if (response == null) {
+        return undefined;
+      }
+
       // TODO: Remove `any` when typescript typings add support for PRF
       const prfResult = response.prf;
       let symmetricPrfKey: PrfKey | undefined;

--- a/libs/common/src/auth/services/webauthn-login/webauthn-login.service.ts
+++ b/libs/common/src/auth/services/webauthn-login/webauthn-login.service.ts
@@ -6,6 +6,7 @@ import { LoginStrategyServiceAbstraction, WebAuthnLoginCredentials } from "@bitw
 
 import { LogService } from "../../../platform/abstractions/log.service";
 import { PrfKey } from "../../../types/key";
+import { NavigatorCredentialsService } from "../../abstractions/webauthn/navigator-credentials.service";
 import { WebAuthnLoginApiServiceAbstraction } from "../../abstractions/webauthn/webauthn-login-api.service.abstraction";
 import { WebAuthnLoginPrfKeyServiceAbstraction } from "../../abstractions/webauthn/webauthn-login-prf-key.service.abstraction";
 import { WebAuthnLoginServiceAbstraction } from "../../abstractions/webauthn/webauthn-login.service.abstraction";
@@ -16,17 +17,13 @@ import { WebAuthnLoginCredentialAssertionView } from "../../models/view/webauthn
 import { WebAuthnLoginAssertionResponseRequest } from "./request/webauthn-login-assertion-response.request";
 
 export class WebAuthnLoginService implements WebAuthnLoginServiceAbstraction {
-  private navigatorCredentials: CredentialsContainer;
-
   constructor(
     private webAuthnLoginApiService: WebAuthnLoginApiServiceAbstraction,
-    private loginStrategyService: LoginStrategyServiceAbstraction,
-    private webAuthnLoginPrfKeyService: WebAuthnLoginPrfKeyServiceAbstraction,
-    private window: Window,
-    private logService?: LogService,
-  ) {
-    this.navigatorCredentials = this.window.navigator.credentials;
-  }
+    protected loginStrategyService: LoginStrategyServiceAbstraction,
+    protected webAuthnLoginPrfKeyService: WebAuthnLoginPrfKeyServiceAbstraction,
+    protected navigatorCredentialsService: NavigatorCredentialsService,
+    protected logService?: LogService,
+  ) {}
 
   async getCredentialAssertionOptions(): Promise<WebAuthnLoginCredentialAssertionOptionsView> {
     const response = await this.webAuthnLoginApiService.getCredentialAssertionOptions();
@@ -45,7 +42,7 @@ export class WebAuthnLoginService implements WebAuthnLoginServiceAbstraction {
     } as any;
 
     try {
-      const response = await this.navigatorCredentials.get(nativeOptions);
+      const response = await this.navigatorCredentialsService.get(nativeOptions);
       if (!(response instanceof PublicKeyCredential)) {
         return undefined;
       }
@@ -84,5 +81,9 @@ export class WebAuthnLoginService implements WebAuthnLoginServiceAbstraction {
     );
     const result = await this.loginStrategyService.logIn(credential);
     return result;
+  }
+
+  async available(): Promise<boolean> {
+    return this.navigatorCredentialsService.available();
   }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective


Electron does not support PRF unlock and has no plans to do so. Therefore, to implement unlock with PRF, we need to use `desktop_native`. The simplest way to do so, is to move calls to the navigatorCredetials functions into a service, and on desktop route these through to `main` and then `desktop_native` so that we can use native functions implementing support.

This PR adds support for navigator credentials in `desktop_native`. Currently, the only implementation currently is for security keys via the `ctap-hid-fido2` crate as an example implementation. This implementation is gated behind a compile-time feature flag. The intent is to - for mac and windows - use the platform's native APIs to be able to use all authenticator types, not just security keys, before enabling support for these platforms.

### Windows / Mac support
To support windows / mac's native APIs, all that needs to be done is implement a single file in `desktop_native/fido2_client`. For windows, the `windows-rs` crate can be directly used. For mac, `swift-rs` + a swift module is a possible path. That is not done within this PR!

## 📸 Screenshots


https://github.com/user-attachments/assets/07734957-7b43-4bcd-af8f-2eadc2b4c160


https://github.com/user-attachments/assets/72fe6098-f208-43b0-805b-1af3b2612b62


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
