### PR TITLE
Add persistent storage for ignored phishing sites

### DIFF
--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -1473,6 +1473,7 @@ export default class MainBackground {
       this.logService,
       this.phishingDataService,
       messageListener,
+      this.globalStateProvider,
     );
 
     this.ipcContentScriptManagerService = new IpcContentScriptManagerService(this.configService);

--- a/apps/browser/src/dirt/phishing-detection/services/phishing-detection.service.spec.ts
+++ b/apps/browser/src/dirt/phishing-detection/services/phishing-detection.service.spec.ts
@@ -5,6 +5,7 @@ import { AccountService } from "@bitwarden/common/auth/abstractions/account.serv
 import { BillingAccountProfileStateService } from "@bitwarden/common/billing/abstractions";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+import { FakeGlobalStateProvider } from "@bitwarden/common/spec";
 import { MessageListener } from "@bitwarden/messaging";
 
 import { PhishingDataService } from "./phishing-data.service";
@@ -17,6 +18,7 @@ describe("PhishingDetectionService", () => {
   let logService: LogService;
   let phishingDataService: MockProxy<PhishingDataService>;
   let messageListener: MockProxy<MessageListener>;
+  let globalStateProvider: FakeGlobalStateProvider;
 
   beforeEach(() => {
     accountService = { getAccount$: jest.fn(() => of(null)) } as any;
@@ -29,6 +31,7 @@ describe("PhishingDetectionService", () => {
         return new Observable();
       },
     });
+    globalStateProvider = new FakeGlobalStateProvider();
   });
 
   it("should initialize without errors", () => {
@@ -40,6 +43,7 @@ describe("PhishingDetectionService", () => {
         logService,
         phishingDataService,
         messageListener,
+        globalStateProvider,
       );
     }).not.toThrow();
   });


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

- Add persistent storage for ignored phishing sites so users don't see the blocker again after clicking "Continue to this site (not recommended)"
- Store ignored hostnames in disk storage using GlobalStateProvider
- Load ignored hostnames on service initialization to avoid race conditions

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
