### PR TITLE
[PM-28071] add prod test domain for phishing detection

### DIFF
--- a/apps/browser/src/dirt/phishing-detection/services/phishing-data.service.ts
+++ b/apps/browser/src/dirt/phishing-detection/services/phishing-data.service.ts
@@ -58,6 +58,7 @@ export class PhishingDataService {
         new Set(
           (state?.domains?.filter((line) => line.trim().length > 0) ?? []).concat(
             this._testDomains,
+            "phishing.testcategory.com", // Included for QA to test in prod
           ),
         ),
     ),


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-28071

## 📔 Objective

Adds https://phishing.testcategory.com/ as a test/demo site that always triggers the phishing detector.

## 📸 Screenshots

<img width="1068" height="791" alt="image" src="https://github.com/user-attachments/assets/99dcda9d-a461-4e8a-a1b6-5b1a933508be" />


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
