### PR TITLE
[PM-28370] fix defect for self-hosted metadata

### DIFF
--- a/libs/angular/src/services/jslib-services.module.ts
+++ b/libs/angular/src/services/jslib-services.module.ts
@@ -1451,7 +1451,7 @@ const safeProviders: SafeProvider[] = [
   safeProvider({
     provide: OrganizationMetadataServiceAbstraction,
     useClass: DefaultOrganizationMetadataService,
-    deps: [BillingApiServiceAbstraction, ConfigService],
+    deps: [BillingApiServiceAbstraction, ConfigService, PlatformUtilsServiceAbstraction],
   }),
   safeProvider({
     provide: BillingAccountProfileStateService,

--- a/libs/common/src/billing/abstractions/billing-api.service.abstraction.ts
+++ b/libs/common/src/billing/abstractions/billing-api.service.abstraction.ts
@@ -25,6 +25,10 @@ export abstract class BillingApiServiceAbstraction {
     organizationId: OrganizationId,
   ): Promise<OrganizationBillingMetadataResponse>;
 
+  abstract getOrganizationBillingMetadataVNextSelfHost(
+    organizationId: OrganizationId,
+  ): Promise<OrganizationBillingMetadataResponse>;
+
   abstract getPlans(): Promise<ListResponse<PlanResponse>>;
 
   abstract getPremiumPlan(): Promise<PremiumPlanResponse>;

--- a/libs/common/src/billing/services/billing-api.service.ts
+++ b/libs/common/src/billing/services/billing-api.service.ts
@@ -62,6 +62,20 @@ export class BillingApiService implements BillingApiServiceAbstraction {
     return new OrganizationBillingMetadataResponse(r);
   }
 
+  async getOrganizationBillingMetadataVNextSelfHost(
+    organizationId: OrganizationId,
+  ): Promise<OrganizationBillingMetadataResponse> {
+    const r = await this.apiService.send(
+      "GET",
+      "/organizations/" + organizationId + "/billing/vnext/self-host/metadata",
+      null,
+      true,
+      true,
+    );
+
+    return new OrganizationBillingMetadataResponse(r);
+  }
+
   async getPlans(): Promise<ListResponse<PlanResponse>> {
     const r = await this.apiService.send("GET", "/plans", null, true, true);
     return new ListResponse(r, PlanResponse);

--- a/libs/common/src/billing/services/organization/organization-metadata.service.spec.ts
+++ b/libs/common/src/billing/services/organization/organization-metadata.service.spec.ts
@@ -4,6 +4,7 @@ import { BehaviorSubject, firstValueFrom } from "rxjs";
 import { BillingApiServiceAbstraction } from "@bitwarden/common/billing/abstractions";
 import { OrganizationBillingMetadataResponse } from "@bitwarden/common/billing/models/response/organization-billing-metadata.response";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
+import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { newGuid } from "@bitwarden/guid";
 
 import { FeatureFlag } from "../../../enums/feature-flag.enum";
@@ -15,6 +16,7 @@ describe("DefaultOrganizationMetadataService", () => {
   let service: DefaultOrganizationMetadataService;
   let billingApiService: jest.Mocked<BillingApiServiceAbstraction>;
   let configService: jest.Mocked<ConfigService>;
+  let platformUtilsService: jest.Mocked<PlatformUtilsService>;
   let featureFlagSubject: BehaviorSubject<boolean>;
 
   const mockOrganizationId = newGuid() as OrganizationId;
@@ -33,11 +35,17 @@ describe("DefaultOrganizationMetadataService", () => {
   beforeEach(() => {
     billingApiService = mock<BillingApiServiceAbstraction>();
     configService = mock<ConfigService>();
+    platformUtilsService = mock<PlatformUtilsService>();
     featureFlagSubject = new BehaviorSubject<boolean>(false);
 
     configService.getFeatureFlag$.mockReturnValue(featureFlagSubject.asObservable());
+    platformUtilsService.isSelfHost.mockReturnValue(false);
 
-    service = new DefaultOrganizationMetadataService(billingApiService, configService);
+    service = new DefaultOrganizationMetadataService(
+      billingApiService,
+      configService,
+      platformUtilsService,
+    );
   });
 
   afterEach(() => {
@@ -141,6 +149,24 @@ describe("DefaultOrganizationMetadataService", () => {
         expect(result2).toEqual(mockResponse2);
         expect(result3).toEqual(mockResponse1);
         expect(result4).toEqual(mockResponse2);
+      });
+
+      it("calls getOrganizationBillingMetadataVNextSelfHost when feature flag is on and isSelfHost is true", async () => {
+        platformUtilsService.isSelfHost.mockReturnValue(true);
+        const mockResponse = createMockMetadataResponse(true, 25);
+        billingApiService.getOrganizationBillingMetadataVNextSelfHost.mockResolvedValue(
+          mockResponse,
+        );
+
+        const result = await firstValueFrom(service.getOrganizationMetadata$(mockOrganizationId));
+
+        expect(platformUtilsService.isSelfHost).toHaveBeenCalled();
+        expect(billingApiService.getOrganizationBillingMetadataVNextSelfHost).toHaveBeenCalledWith(
+          mockOrganizationId,
+        );
+        expect(billingApiService.getOrganizationBillingMetadataVNext).not.toHaveBeenCalled();
+        expect(billingApiService.getOrganizationBillingMetadata).not.toHaveBeenCalled();
+        expect(result).toEqual(mockResponse);
       });
     });
 

--- a/libs/common/src/billing/services/organization/organization-metadata.service.ts
+++ b/libs/common/src/billing/services/organization/organization-metadata.service.ts
@@ -1,6 +1,7 @@
 import { BehaviorSubject, combineLatest, from, Observable, shareReplay, switchMap } from "rxjs";
 
 import { BillingApiServiceAbstraction } from "@bitwarden/common/billing/abstractions";
+import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 
 import { FeatureFlag } from "../../../enums/feature-flag.enum";
 import { ConfigService } from "../../../platform/abstractions/config/config.service";
@@ -17,6 +18,7 @@ export class DefaultOrganizationMetadataService implements OrganizationMetadataS
   constructor(
     private billingApiService: BillingApiServiceAbstraction,
     private configService: ConfigService,
+    private platformUtilsService: PlatformUtilsService,
   ) {}
   private refreshMetadataTrigger = new BehaviorSubject<void>(undefined);
 
@@ -67,7 +69,9 @@ export class DefaultOrganizationMetadataService implements OrganizationMetadataS
     featureFlagEnabled: boolean,
   ): Promise<OrganizationBillingMetadataResponse> {
     return featureFlagEnabled
-      ? await this.billingApiService.getOrganizationBillingMetadataVNext(organizationId)
+      ? this.platformUtilsService.isSelfHost()
+        ? await this.billingApiService.getOrganizationBillingMetadataVNextSelfHost(organizationId)
+        : await this.billingApiService.getOrganizationBillingMetadataVNext(organizationId)
       : await this.billingApiService.getOrganizationBillingMetadata(organizationId);
   }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-28370

## 📔 Objective

Fixes a release blocker defect where org metadata couldn't be pulled on self-hosted servers. Added a new endpoint in server in https://github.com/bitwarden/server/pull/6593 - this PR modifies the org metadata service to use that endpoint when self-hosted.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
