### PR TITLE
[PM-27542] Write fromMarketing value to state

### DIFF
--- a/libs/auth/src/angular/registration/registration-start/registration-start.component.ts
+++ b/libs/auth/src/angular/registration/registration-start/registration-start.component.ts
@@ -163,7 +163,7 @@ export class RegistrationStartComponent implements OnInit, OnDestroy {
       // we received a token, so the env doesn't support email verification
       // send the user directly to the finish registration page with the token as a query param
       await this.router.navigate(["/finish-signup"], {
-        queryParams: { token: result, email: this.email.value, fromMarketing: "premium" },
+        queryParams: { token: result, email: this.email.value },
       });
       return;
     }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-27542](https://bitwarden.atlassian.net/browse/PM-27542)

## 📔 Objective

If `/finish-signup` includes a `fromMarketing=premium` query param, set premium interest state to true after account registration & login success.

## 📸 Screenshots

User gets navigated to premium setup page upon registration & login success.

Note: I'm mocking the parameter locally by including the `fromMarketing=premium` in the `RegistrationStartComponent` when we route to `/finish-signup` (email verification disabled). A true implementation will have the param coming from the verification email link.

<img width="790" height="68" alt="Screenshot 2025-11-18 at 11 44 48 AM" src="https://github.com/user-attachments/assets/9639ebb8-8233-42a6-ac24-7eecd530aa8b" />

https://github.com/user-attachments/assets/8da4b73a-d815-4beb-946c-0d66c3ffc04f

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-27542]: https://bitwarden.atlassian.net/browse/PM-27542?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ