### PR TITLE
[PM-28364] Fix desktop not launching

### DIFF
--- a/apps/desktop/src/platform/popup-modal-styles.ts
+++ b/apps/desktop/src/platform/popup-modal-styles.ts
@@ -45,11 +45,11 @@ export function applyMainWindowStyles(window: BrowserWindow, existingWindowState
   // need to guard against null/undefined values
 
   if (existingWindowState?.width && existingWindowState?.height) {
-    window.setSize(existingWindowState.width, existingWindowState.height);
+    window.setSize(Math.floor(existingWindowState.width), Math.floor(existingWindowState.height));
   }
 
   if (existingWindowState?.x && existingWindowState?.y) {
-    window.setPosition(existingWindowState.x, existingWindowState.y);
+    window.setPosition(Math.floor(existingWindowState.x), Math.floor(existingWindowState.y));
   }
 
   window.setWindowButtonVisibility?.(true);


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-28364

## 📔 Objective

ApplyMainWindowStyles uses the existing window to set the size of the desktop app. ExistingWindow can have non-integer values. Non-integer values are not legal parameters for the resize / move functions, leading to a crash that breaks initialization of the app.

Introduced in https://github.com/bitwarden/clients/pull/16595

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
