### PR TITLE
[CL-923] Try silencing flaky chromatic tests from dialog border

### DIFF
--- a/libs/components/src/dialog/dialog/dialog.component.ts
+++ b/libs/components/src/dialog/dialog/dialog.component.ts
@@ -13,7 +13,7 @@ import {
   signal,
 } from "@angular/core";
 import { toObservable } from "@angular/core/rxjs-interop";
-import { combineLatest, switchMap, tap } from "rxjs";
+import { combineLatest, switchMap } from "rxjs";
 
 import { I18nPipe } from "@bitwarden/ui-common";
 
@@ -60,17 +60,9 @@ export class DialogComponent {
   private scrollBottom$ = toObservable(this.scrollBottom);
 
   protected isScrollable$ = combineLatest([this.scrollableBody$, this.scrollBottom$]).pipe(
-    tap(() => {
-      // eslint-disable-next-line
-      console.log("[isScrollable running]");
-    }),
     switchMap(([body, bottom]) =>
       hasScrollableContent$(body.getElementRef().nativeElement, bottom.nativeElement),
     ),
-    tap((result) => {
-      // eslint-disable-next-line
-      console.log(`[isScrollable result: ${result}]`);
-    }),
   );
 
   /** Background color */

--- a/libs/components/src/utils/has-scrollable-content.ts
+++ b/libs/components/src/utils/has-scrollable-content.ts
@@ -1,5 +1,5 @@
-import { animationFrameScheduler, Observable } from "rxjs";
-import { map, startWith, distinctUntilChanged, auditTime, observeOn } from "rxjs/operators";
+import { Observable, animationFrameScheduler } from "rxjs";
+import { auditTime, map, startWith, observeOn, distinctUntilChanged } from "rxjs/operators";
 
 import { intersectionObserver$ } from "./dom-observables";
 /**


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[CL-923](https://bitwarden.atlassian.net/browse/CL-923)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
We've been facing flakiness related to the visibility of the bottom border on the dialog component. Sometimes it appears even when the dialog is not scrollable.

I've included my research/observations on the ticket, but the tl;dr is that I still don't know what the root cause is, other than it seems to only happen in the Chromatic snapshot environment when the dialog service is used, and debugging logs showed that the intersection observer that we're using is firing way more than it should and with incorrect values. The snapshots have about a 50/50 chance of capturing the border being visible.

In the interest of moving on to higher priorities, I want to try using Chromatic's `ignore` option to ignore visual changes to the dialog border. This necessitated moving it to its own element instead of having it be part of the footer, which is an annoying change to make just to appease snapshot testing, but I think it is better than constantly having flaky results that other devs are having to manually accept on their unrelated PRs. (Assuming this actually ignores the changes as expected -- in Chromatic you can see that it is ignoring the element properly, and since the element dimensions aren't changing between intersection observer values, we shouldn't run into issues with [dimensions triggering diffs anyway](https://www.chromatic.com/docs/ignoring-elements/#dimension-changes-in-ignored-elements-still-trigger-diffs).)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[CL-923]: https://bitwarden.atlassian.net/browse/CL-923?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ