### PR TITLE
[PM-28428] - Improve flickering of items after Autofilling and Adding website to login

### DIFF
--- a/apps/browser/src/vault/popup/services/vault-popup-items.service.spec.ts
+++ b/apps/browser/src/vault/popup/services/vault-popup-items.service.spec.ts
@@ -515,24 +515,6 @@ describe("VaultPopupItemsService", () => {
       expect(tracked.emissions[0]).toBe(true);
       expect(tracked.emissions[1]).toBe(false);
     });
-
-    it("should cycle when cipherService.ciphers$ emits even if cipher lists don't re-emit", async () => {
-      await tracked.pauseUntilReceived(2);
-
-      const before = [...tracked.emissions];
-
-      ciphersSubject.next({});
-
-      await tracked.pauseUntilReceived(before.length + 2);
-
-      const after = tracked.emissions;
-
-      expect(after.length).toBeGreaterThan(before.length);
-
-      const tail = after.slice(before.length);
-      expect(tail[0]).toBe(true);
-      expect(tail[1]).toBe(false);
-    });
   });
 
   describe("applyFilter", () => {

--- a/apps/browser/src/vault/popup/services/vault-popup-items.service.ts
+++ b/apps/browser/src/vault/popup/services/vault-popup-items.service.ts
@@ -260,7 +260,7 @@ export class VaultPopupItemsService {
     // Turn loading on whenever we start processing ciphers
     this._ciphersLoading$.pipe(map(() => true)),
     // Turn loading off whenever the decrypted cipher list finishes updating
-    this._allDecryptedCiphers$.pipe(map(() => false)),
+    this.remainingCiphers$.pipe(map(() => false)),
   ).pipe(startWith(true), distinctUntilChanged(), shareReplay({ refCount: false, bufferSize: 1 }));
 
   /** Observable that indicates whether there is search text present.


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-28428

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Issue:
The popup UI was flickering after autofill which was exacerbated by the recent addition of `handleAutofillSuggestionUsed` because the cipher lists (autoFillCiphers$, favoriteCiphers$, remainingCiphers$) re-emitted even when their contents hadn’t actually changed. This caused unnecessary DOM updates and visible flicker in the list components.

Fix:
Added a stable comparator (ciphersEqualByIdAndOrder) and applied `distinctUntilChanged` to the relevant streams. The lists now only re-emit when their IDs or order truly change.

Result:
The popup no longer flickers on background updates, and the UI remains stable while still updating correctly when the data meaningfully changes.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/e37d0962-a500-43f3-9a59-3862bb32eb69


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
