### PR TITLE
[PM-28220] Fix desktop deb startup failure

### DIFF
--- a/apps/desktop/resources/linux-wrapper.sh
+++ b/apps/desktop/resources/linux-wrapper.sh
@@ -12,14 +12,6 @@ if [ -e "/usr/lib/x86_64-linux-gnu/libdbus-1.so.3" ]; then
   export LD_PRELOAD="/usr/lib/x86_64-linux-gnu/libdbus-1.so.3"
 fi
 
-# If running in non-snap, add libprocess_isolation.so from app path to LD_PRELOAD
-# This prevents debugger / memory dumping on all desktop processes
-if [ -z "$SNAP" ] && [ -f "$APP_PATH/libprocess_isolation.so" ]; then
-  LIBPROCESS_ISOLATION_SO="$APP_PATH/libprocess_isolation.so"
-  LD_PRELOAD="$LIBPROCESS_ISOLATION_SO${LD_PRELOAD:+:$LD_PRELOAD}"
-  export LD_PRELOAD
-fi
-
 PARAMS="--enable-features=UseOzonePlatform,WaylandWindowDecorations --ozone-platform-hint=auto"
 if [ "$USE_X11" = "true" ]; then
   PARAMS=""


### PR DESCRIPTION
## 🎟️ Tracking

[PM-28220](https://bitwarden.atlassian.net/browse/PM-28220)

## 📔 Objective

This PR reverts a change made to the desktop client in #16136 as it unfortunately resulted in the client failing to start for `deb` builds.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-28220]: https://bitwarden.atlassian.net/browse/PM-28220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ