### PR TITLE
Auth/PM-28506 - TwoFactorSetupYubikey - refactor to use rows so individual keys can be removed

### DIFF
--- a/apps/web/src/app/auth/settings/two-factor/two-factor-setup-yubikey.component.html
+++ b/apps/web/src/app/auth/settings/two-factor/two-factor-setup-yubikey.component.html
@@ -25,23 +25,21 @@
         <li>{{ "twoFactorYubikeySaveForm" | i18n }}</li>
       </ol>
       <hr />
-      <div class="tw-grid tw-grid-cols-12 tw-gap-4" formArrayName="formKeys">
-        <div class="tw-col-span-6" *ngFor="let k of keys; let i = index">
-          <div [formGroupName]="i">
-            <bit-label>{{ "yubikeyX" | i18n: (i + 1).toString() }}</bit-label>
-            <bit-form-field *ngIf="!keys[i].existingKey">
-              <input bitInput type="password" formControlName="key" appInputVerbatim />
-            </bit-form-field>
-            <div class="tw-flex tw-justify-between tw-mb-6" *ngIf="keys[i].existingKey">
-              <span class="tw-mr-2 tw-self-center">{{ keys[i].existingKey }}</span>
-              <button
-                bitIconButton="bwi-minus-circle"
-                type="button"
-                buttonType="danger"
-                (click)="remove(i)"
-                label="{{ 'remove' | i18n }}"
-              ></button>
-            </div>
+      <div class="tw-flex tw-flex-col tw-mt-4" formArrayName="formKeys">
+        <div *ngFor="let k of keys; let i = index" [formGroupName]="i">
+          <bit-label>{{ "yubikeyX" | i18n: (i + 1).toString() }}</bit-label>
+          <bit-form-field *ngIf="!keys[i].existingKey">
+            <input bitInput type="password" formControlName="key" appInputVerbatim />
+          </bit-form-field>
+          <div class="tw-flex tw-justify-between tw-mb-4" *ngIf="keys[i].existingKey">
+            <span class="tw-mr-2 tw-self-center">{{ keys[i].existingKey }}</span>
+            <button
+              bitIconButton="bwi-minus-circle"
+              type="button"
+              buttonType="danger"
+              (click)="remove(i)"
+              label="{{ 'remove' | i18n }}"
+            ></button>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## 🎟️ Tracking
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-28506

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
To allow users to remove configured 2FA yubikeys since the new font change has made the existing approach hide the delete button. 

## 📸 Screenshots
<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

Before:
<img width="1702" height="857" alt="Screenshot 2025-11-20 at 2 26 52 PM" src="https://github.com/user-attachments/assets/ee5b390e-4f87-406f-81c9-68bfb6330cf1" />

After:
<img width="1709" height="865" alt="Screenshot 2025-11-20 at 2 28 18 PM" src="https://github.com/user-attachments/assets/dc0d0d08-cefd-413e-a40d-bfef5d40bd34" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
