### PR TITLE
Revert "[deps]: Update Rust crate cc to v1.2.46"

### DIFF
--- a/apps/desktop/desktop_native/Cargo.lock
+++ b/apps/desktop/desktop_native/Cargo.lock
@@ -555,11 +555,10 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.46"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97463e1064cb1b1c1384ad0a0b9c8abd0988e2a91f52606c80ef14aadb63e36"
+checksum = "9157bbaa6b165880c27a4293a474c91cdcf265cc68cc829bf10be0964a391caf"
 dependencies = [
- "find-msvc-tools",
  "shlex",
 ]
 
@@ -1203,12 +1202,6 @@ name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
-
-[[package]]
-name = "find-msvc-tools"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
 
 [[package]]
 name = "fixedbitset"

--- a/apps/desktop/desktop_native/objc/Cargo.toml
+++ b/apps/desktop/desktop_native/objc/Cargo.toml
@@ -14,7 +14,7 @@ tokio = { workspace = true }
 tracing = { workspace = true }
 
 [target.'cfg(target_os = "macos")'.build-dependencies]
-cc = "=1.2.46"
+cc = "=1.2.4"
 glob = "=0.3.2"
 
 [lints]


### PR DESCRIPTION
This seems to cause flatpak release builds to run out of space consistently: https://github.com/bitwarden/clients/actions/runs/19571208077/job/56049563597