### PR TITLE
[PM-27012] Transfer Archived Cipher to Org

### DIFF
--- a/libs/common/src/vault/models/view/cipher.view.ts
+++ b/libs/common/src/vault/models/view/cipher.view.ts
@@ -166,10 +166,6 @@ export class CipherView implements View, InitializerMetadata {
   }
 
   get canAssignToCollections(): boolean {
-    if (this.isArchived) {
-      return false;
-    }
-
     if (this.organizationId == null) {
       return true;
     }

--- a/libs/vault/src/cipher-form/components/item-details/item-details-section.component.ts
+++ b/libs/vault/src/cipher-form/components/item-details/item-details-section.component.ts
@@ -192,11 +192,6 @@ export class ItemDetailsSectionComponent implements OnInit {
   }
 
   get showOwnership() {
-    // Don't show ownership field for archived ciphers
-    if (this.originalCipherView?.isArchived) {
-      return false;
-    }
-
     // Show ownership field when editing with available orgs
     const isEditingWithOrgs = this.organizations.length > 0 && this.config.mode === "edit";
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-27012](https://bitwarden.atlassian.net/browse/PM-27012)
Server PR: https://github.com/bitwarden/server/pull/6626

## 📔 Objective

With the change in underlying architecture, archived ciphers will be tied to the user rather than to the cipher. This removes checks that originally removed the ability to share a cipher. The bug ticket addressed here is around enforcing data ownership so that is what I captured in the videos.


## 📸 Screenshots

|web|desktop|browser|
|-|-|-|
|<video src="https://github.com/user-attachments/assets/773c96d3-8eb9-4f48-82fb-66cda8e64ee0" />|<video src="https://github.com/user-attachments/assets/9ab50f03-30b7-4bd6-8db0-d8e0fc7527a6" />|<video src="https://github.com/user-attachments/assets/9ee61651-040c-43a1-935c-dec95127a1ce" />|

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes





[PM-27012]: https://bitwarden.atlassian.net/browse/PM-27012?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ