### PR TITLE
[AC-1159] Fix disabledSso duplicate event log

### DIFF
--- a/apps/web/src/app/core/event.service.ts
+++ b/apps/web/src/app/core/event.service.ts
@@ -372,10 +372,7 @@ export class EventService {
         msg = humanReadableMsg = this.i18nService.t("enabledSso");
         break;
       case EventType.Organization_DisabledSso:
-        msg = humanReadableMsg =
-          this.i18nService.translationLocale === "en"
-            ? this.i18nService.t("ssoTurnedOff")
-            : this.i18nService.t("disabledSso");
+        msg = humanReadableMsg = this.i18nService.t("ssoTurnedOff");
         break;
       case EventType.Organization_EnabledKeyConnector:
         msg = humanReadableMsg = this.i18nService.t("enabledKeyConnector");

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -7122,9 +7122,6 @@
   "enabledSso": {
     "message": "SSO turned on"
   },
-  "disabledSso": {
-    "message": "SSO turned on"
-  },
   "ssoTurnedOff": {
     "message": "SSO turned off"
   },


### PR DESCRIPTION
## 🎟️ Tracking

[AC-1159](https://bitwarden.atlassian.net/browse/AC-1159)

## 📔 Objective

Whether enabling or disabling SSO, event logs would read "SSO turned on". Adjusted the `disabledSso` object to be "SSO turned off"

## 📸 Screenshots
New behavior:

<img width="514" height="237" alt="image" src="https://github.com/user-attachments/assets/b87725b8-d3da-45df-8f47-12e58882ca9c" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[AC-1159]: https://bitwarden.atlassian.net/browse/AC-1159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ