### PR TITLE
[PM-28656] Enhance item details display by adding text truncation for item name …

### DIFF
--- a/libs/vault/src/cipher-view/item-details/item-details-v2.component.html
+++ b/libs/vault/src/cipher-view/item-details/item-details-v2.component.html
@@ -10,7 +10,7 @@
       <div class="tw-flex tw-items-center tw-justify-center" style="width: 40px; height: 40px">
         <app-vault-icon [cipher]="cipher()" [coloredIcon]="true"></app-vault-icon>
       </div>
-      <h2 bitTypography="h4" class="tw-ml-2 tw-mt-2" data-testid="item-name">
+      <h2 bitTypography="h4" class="tw-ml-2 tw-mt-2 tw-truncate" data-testid="item-name">
         {{ cipher().name }}
       </h2>
     </div>


### PR DESCRIPTION
…in the cipher view component

## 🎟️ Tracking

https://github.com/bitwarden/clients/issues/17609

## 📔 Objective

Fixing truncation issue for notes header

## 📸 Screenshots

<img width="735" height="670" alt="image" src="https://github.com/user-attachments/assets/afc6ae42-73ca-489d-b49e-8a8b6864ece1" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
