### PR TITLE
[PM-28800] Enhance URL prefill validation in AddEditV2 and NewItemDropdownV2 com…

### DIFF
--- a/apps/browser/src/vault/popup/components/vault-v2/add-edit/add-edit-v2.component.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/add-edit/add-edit-v2.component.ts
@@ -365,8 +365,10 @@ export class AddEditV2Component implements OnInit {
     if (params.prefillNameAndURIFromTab) {
       const tab = await BrowserApi.getTabFromCurrentWindow();
 
-      initialValues.loginUri = tab.url;
-      initialValues.name = Utils.getHostname(tab.url);
+      if (tab?.url && (tab.url.startsWith("http://") || tab.url.startsWith("https://"))) {
+        initialValues.loginUri = tab.url;
+        initialValues.name = Utils.getHostname(tab.url);
+      }
     }
 
     return initialValues;

--- a/apps/browser/src/vault/popup/components/vault-v2/new-item-dropdown/new-item-dropdown-v2.component.ts
+++ b/apps/browser/src/vault/popup/components/vault-v2/new-item-dropdown/new-item-dropdown-v2.component.ts
@@ -69,7 +69,12 @@ export class NewItemDropdownV2Component implements OnInit {
 
     // When a Login Cipher is created and the extension is not popped out,
     // pass along the uri and name
-    if (!poppedOut && type === CipherType.Login && this.tab) {
+    if (
+      !poppedOut &&
+      type === CipherType.Login &&
+      this.tab?.url &&
+      (this.tab.url.startsWith("http://") || this.tab.url.startsWith("https://"))
+    ) {
       loginDetails.prefillNameAndURIFromTab = "true";
     }
 


### PR DESCRIPTION
…ponents

- Implement checks to ensure only valid web URLs (http:// or https://) are prefixed for login URI and name.
- Skip internal browser URLs like chrome://, edge://, and about: to improve user experience and prevent errors.

## 🎟️ Tracking

https://github.com/bitwarden/clients/issues/17645

## 📔 Objective

Prevents URLs auto-filling login item in browser extension if on a page that is not `https://` or `http://`. Maybe we can just filter for `edge://`, `chrome://` and such to be a bit safer, but feel as if `http://` and `https://` make sense and should be fine.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
