### PR TITLE
PM-28180 responsively hide deletion date column in sends table

### DIFF
--- a/apps/web/src/app/tools/send/send.component.html
+++ b/apps/web/src/app/tools/send/send.component.html
@@ -152,9 +152,8 @@
           </td>
           <td
             bitCell
-            class="tw-text-muted"
             (click)="editSend(s)"
-            class="tw-cursor-pointer @lg/send-table:tw-table-cell tw-hidden"
+            class="tw-text-muted tw-cursor-pointer @lg/send-table:tw-table-cell tw-hidden"
           >
             <small bitTypography="body2" appStopProp>
               {{ s.deletionDate | date: "medium" }}


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-28180

## 📔 Objective

updated the send table header to be responsive. depending on the available space for table. If there is not sufficient space hide the deletion date column.

## 📸 Screenshots

<img width="878" height="771" alt="Screenshot 2025-11-25 at 6 45 36 AM" src="https://github.com/user-attachments/assets/e5749258-b702-4298-937f-ca2b3a0afa44" />


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
