### PR TITLE
[PM-28979] Handle RTL positioning for inline autofill button 

### DIFF
--- a/apps/browser/src/autofill/background/overlay.background.spec.ts
+++ b/apps/browser/src/autofill/background/overlay.background.spec.ts
@@ -2950,6 +2950,37 @@ describe("OverlayBackground", () => {
           left: "1271px",
         });
       });
+      it("positions the inline menu button at the visual start for rtl inputs", () => {
+        const subframe = {
+          top: 0,
+          left: 0,
+          url: "",
+          frameId: 0,
+        };
+
+        overlayBackground["focusedFieldData"] = createFocusedFieldDataMock({
+          focusedFieldRects: {
+            width: 200,
+            height: 40,
+            top: 10,
+            left: 20,
+          },
+          focusedFieldStyles: {
+            paddingRight: "4px",
+            paddingLeft: "12px",
+            direction: "rtl",
+          },
+        });
+
+        const buttonPostion = overlayBackground["getInlineMenuButtonPosition"](subframe);
+
+        expect(buttonPostion).toEqual({
+          width: "23px",
+          height: "23px",
+          top: "18px",
+          left: "17px",
+        });
+      });
       it("sets button and menu width and position when multi-input totp field is focused", async () => {
         const subframe = {
           top: 0,

--- a/apps/browser/src/autofill/background/overlay.background.ts
+++ b/apps/browser/src/autofill/background/overlay.background.ts
@@ -1578,7 +1578,7 @@ export class OverlayBackground implements OverlayBackgroundInterface {
 
     const { width, height } = this.focusedFieldData.focusedFieldRects;
     let { top, left } = this.focusedFieldData.focusedFieldRects;
-    const { paddingRight, paddingLeft } = this.focusedFieldData.focusedFieldStyles;
+    const { paddingRight, paddingLeft, direction } = this.focusedFieldData.focusedFieldStyles;
 
     if (this.isTotpFieldForCurrentField()) {
       const totpFields = this.getTotpFields();
@@ -1592,15 +1592,20 @@ export class OverlayBackground implements OverlayBackgroundInterface {
       elementOffset = height >= 50 ? height * 0.47 : height * 0.42;
     }
 
-    const fieldPaddingRight = parseInt(paddingRight, 10);
-    const fieldPaddingLeft = parseInt(paddingLeft, 10);
+    const fieldDirection = direction?.toLowerCase() ?? "ltr";
+    const fieldPaddingRight = parseInt(paddingRight ?? "0", 10);
+    const fieldPaddingLeft = parseInt(paddingLeft ?? "0", 10);
     const elementHeight = height - elementOffset;
 
     const elementTopPosition = subFrameTopOffset + top + elementOffset / 2;
     const elementLeftPosition =
-      fieldPaddingRight > fieldPaddingLeft
-        ? subFrameLeftOffset + left + width - height - (fieldPaddingRight - elementOffset + 2)
-        : subFrameLeftOffset + left + width - height + elementOffset / 2;
+      fieldDirection === "rtl"
+        ? fieldPaddingLeft > fieldPaddingRight
+          ? subFrameLeftOffset + left + (fieldPaddingLeft - elementOffset + 2)
+          : subFrameLeftOffset + left + elementOffset / 2
+        : fieldPaddingRight > fieldPaddingLeft
+          ? subFrameLeftOffset + left + width - height - (fieldPaddingRight - elementOffset + 2)
+          : subFrameLeftOffset + left + width - height + elementOffset / 2;
 
     this.inlineMenuPosition.button = {
       top: Math.round(elementTopPosition),

--- a/apps/browser/src/autofill/services/autofill-overlay-content.service.ts
+++ b/apps/browser/src/autofill/services/autofill-overlay-content.service.ts
@@ -963,13 +963,13 @@ export class AutofillOverlayContentService implements AutofillOverlayContentServ
     }
 
     this.mostRecentlyFocusedField = formFieldElement;
-    const { paddingRight, paddingLeft } = globalThis.getComputedStyle(formFieldElement);
+    const { paddingRight, paddingLeft, direction } = globalThis.getComputedStyle(formFieldElement);
     const { width, height, top, left } =
       await this.getMostRecentlyFocusedFieldRects(formFieldElement);
     const autofillFieldData = this.formFieldElements.get(formFieldElement);
 
     this.focusedFieldData = {
-      focusedFieldStyles: { paddingRight, paddingLeft },
+      focusedFieldStyles: { paddingRight, paddingLeft, direction },
       focusedFieldRects: { width, height, top, left },
       inlineMenuFillType: autofillFieldData?.inlineMenuFillType,
       showPasskeys: !!autofillFieldData?.showPasskeys,

--- a/apps/browser/src/autofill/spec/autofill-mocks.ts
+++ b/apps/browser/src/autofill/spec/autofill-mocks.ts
@@ -262,6 +262,7 @@ export function createFocusedFieldDataMock(
     focusedFieldStyles: {
       paddingRight: "6px",
       paddingLeft: "6px",
+      direction: "ltr",
     },
     inlineMenuFillType: CipherType.Login,
     tabId: 1,


### PR DESCRIPTION
### This PR has been created  with AI and tested by me
I checked if the LTR is still LTR, I run lint and prettier.

## 🎟️ Tracking

[https://github.com/bitwarden/clients/issues/10519](https://github.com/bitwarden/clients/issues/10519)

## 📔 Objective

* capture an input field's text direction when focusing to inform inline menu positioning
* place the inline autofill button on the visual start side for RTL inputs while keeping current LTR behavior

## 📸 Screenshots

[edu.il](https://lgn.edu.gov.il/nidp/wsfed/ep?id=EduCombinedAuthUidPwd&sid=3&option=credential&sid=3)
<img width="566" height="590" alt="Screenshot_20251130_133447" src="https://github.com/user-attachments/assets/26c8d32a-f30c-4e53-8fda-de964a4bbf7f" />

[opus.co.il](https://www.opus.co.il/?id=login) (click on "כניסה למערכת" on the top left)
<img width="413" height="254" alt="Screenshot_20251130_134152" src="https://github.com/user-attachments/assets/d474662f-5cf2-4233-aebb-bfa42bbebcc5" />

