### PR TITLE
[PM-29020] Remove additional flag from organization layout html component

### DIFF
--- a/apps/web/src/app/admin-console/organizations/layouts/organization-layout.component.html
+++ b/apps/web/src/app/admin-console/organizations/layouts/organization-layout.component.html
@@ -4,7 +4,7 @@
     <org-switcher [filter]="orgFilter" [hideNewButton]="hideNewOrgButton$ | async"></org-switcher>
     <bit-nav-item
       icon="bwi-dashboard"
-      *ngIf="organization.useAccessIntelligence && organization.canAccessReports"
+      *ngIf="organization.canAccessReports"
       [text]="'accessIntelligence' | i18n"
       route="access-intelligence"
     ></bit-nav-item>


### PR DESCRIPTION
## 🎟️ Tracking

[PM-29020](https://bitwarden.atlassian.net/browse/PM-29020)

## 📔 Objective

This pull request is a follow up to [17216](https://github.com/bitwarden/clients/pull/17216) which removes the org check on `useRiskInsights`.

Access intelligence is unavailable to organizations without the organization level check due to the html within the route also checking for `useRiskInsights`.

Changes:

- Remove additional guard in organization-layout.component.html for `useRiskInsights`

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-29020]: https://bitwarden.atlassian.net/browse/PM-29020?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ