### PR TITLE
Revert "Bumped client version(s)"

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitwarden/web-vault",
-  "version": "2025.12.1",
+  "version": "2025.12.0",
   "scripts": {
     "build:oss": "webpack",
     "build:bit": "webpack -c ../../bitwarden_license/bit-web/webpack.config.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -292,7 +292,7 @@
     },
     "apps/web": {
       "name": "@bitwarden/web-vault",
-      "version": "2025.12.1"
+      "version": "2025.12.0"
     },
     "libs/admin-console": {
       "name": "@bitwarden/admin-console",


### PR DESCRIPTION
## 🎟️ Tracking

This reverts commit 406dbc80666ba95b77b243ebc4c747c6438f75d3.

## 📔 Objective

I was attempting to bump the web version on `hotfix-rc-web` by targeting that branch in the version bump workflow, but it bumped in `main` instead.  This reverts that change.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
