### PR TITLE
Allow repository-management.yml to run on workflow dispatch branch

### DIFF
--- a/.github/workflows/repository-management.yml
+++ b/.github/workflows/repository-management.yml
@@ -29,7 +29,7 @@ on:
         default: false
       target_ref:
         default: "main"
-        description: "Branch/Tag to target for cut"
+        description: "Branch/Tag to target for cut (ignored if not cutting rc)"
         required: true
         type: string
       version_number_override:
@@ -106,7 +106,7 @@ jobs:
       - name: Check out branch
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
-          ref: main
+          ref: ${{ github.ref }}
           token: ${{ steps.app-token.outputs.token }}
           persist-credentials: true
 


### PR DESCRIPTION
## 📔 Objective

Currently, the `repository-management.yml` workflow _only_ checks out `main`, even if you run the job on a different branch.

This introduces issues if we need to bump a version on a `hotfix-rc-*` branch that's "behind" `main`.  For example, we want to patch `2025.11.0` with `2025.11.1` when `rc` has already been cut for `2025.12.0`.  In that case, `main` is `2025.12.0`, but we need a way to get `hotfix-rc-*` bumped to `2025.11.1`.

This change would allow you to run the version bump workflow on `hotfix-rc-*` to do that bump.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
