### PR TITLE
[PM-29040] Prevent double decryption in decryptCiphersWithSdk

### DIFF
--- a/libs/common/src/vault/abstractions/cipher-encryption.service.ts
+++ b/libs/common/src/vault/abstractions/cipher-encryption.service.ts
@@ -67,7 +67,10 @@ export abstract class CipherEncryptionService {
    *
    * @returns A promise that resolves to an array of decrypted cipher views
    */
-  abstract decryptManyLegacy(ciphers: Cipher[], userId: UserId): Promise<CipherView[]>;
+  abstract decryptManyLegacy(
+    ciphers: Cipher[],
+    userId: UserId,
+  ): Promise<[CipherView[], CipherView[]]>;
   /**
    * Decrypts many ciphers using the SDK for the given userId, and returns a list of
    * failures.

--- a/libs/common/src/vault/services/cipher.service.spec.ts
+++ b/libs/common/src/vault/services/cipher.service.spec.ts
@@ -807,13 +807,18 @@ describe("Cipher Service", () => {
 
       // Set up expected results
       const expectedSuccessCipherViews = [
-        { id: mockCiphers[0].id, name: "Success 1" } as unknown as CipherListView,
+        { id: mockCiphers[0].id, name: "Success 1", decryptionFailure: false } as CipherView,
       ];
 
       const expectedFailedCipher = new CipherView(mockCiphers[1]);
       expectedFailedCipher.name = "[error: cannot decrypt]";
       expectedFailedCipher.decryptionFailure = true;
       const expectedFailedCipherViews = [expectedFailedCipher];
+
+      cipherEncryptionService.decryptManyLegacy.mockResolvedValue([
+        expectedSuccessCipherViews,
+        expectedFailedCipherViews,
+      ]);
 
       // Execute
       const [successes, failures] = await (cipherService as any).decryptCiphers(
@@ -822,10 +827,7 @@ describe("Cipher Service", () => {
       );
 
       // Verify the SDK was used for decryption
-      expect(cipherEncryptionService.decryptManyWithFailures).toHaveBeenCalledWith(
-        mockCiphers,
-        userId,
-      );
+      expect(cipherEncryptionService.decryptManyLegacy).toHaveBeenCalledWith(mockCiphers, userId);
 
       expect(successes).toEqual(expectedSuccessCipherViews);
       expect(failures).toEqual(expectedFailedCipherViews);

--- a/libs/common/src/vault/services/default-cipher-encryption.service.spec.ts
+++ b/libs/common/src/vault/services/default-cipher-encryption.service.spec.ts
@@ -496,9 +496,11 @@ describe("DefaultCipherEncryptionService", () => {
         .mockReturnValueOnce(expectedViews[0])
         .mockReturnValueOnce(expectedViews[1]);
 
-      const result = await cipherEncryptionService.decryptManyLegacy(ciphers, userId);
+      const [successfulDecryptions, failedDecryptions] =
+        await cipherEncryptionService.decryptManyLegacy(ciphers, userId);
 
-      expect(result).toEqual(expectedViews);
+      expect(successfulDecryptions).toEqual(expectedViews);
+      expect(failedDecryptions).toEqual([]);
       expect(mockSdkClient.vault().ciphers().decrypt).toHaveBeenCalledTimes(2);
       expect(CipherView.fromSdkCipherView).toHaveBeenCalledTimes(2);
     });

--- a/libs/common/src/vault/services/default-cipher-encryption.service.ts
+++ b/libs/common/src/vault/services/default-cipher-encryption.service.ts
@@ -168,7 +168,7 @@ export class DefaultCipherEncryptionService implements CipherEncryptionService {
     );
   }
 
-  decryptManyLegacy(ciphers: Cipher[], userId: UserId): Promise<CipherView[]> {
+  decryptManyLegacy(ciphers: Cipher[], userId: UserId): Promise<[CipherView[], CipherView[]]> {
     return firstValueFrom(
       this.sdkService.userClient$(userId).pipe(
         map((sdk) => {
@@ -178,38 +178,49 @@ export class DefaultCipherEncryptionService implements CipherEncryptionService {
 
           using ref = sdk.take();
 
-          return ciphers.map((cipher) => {
-            const sdkCipherView = ref.value.vault().ciphers().decrypt(cipher.toSdkCipher());
-            const clientCipherView = CipherView.fromSdkCipherView(sdkCipherView)!;
+          const successful: CipherView[] = [];
+          const failed: CipherView[] = [];
 
-            // Handle FIDO2 credentials if present
-            if (
-              clientCipherView.type === CipherType.Login &&
-              sdkCipherView.login?.fido2Credentials?.length
-            ) {
-              const fido2CredentialViews = ref.value
-                .vault()
-                .ciphers()
-                .decrypt_fido2_credentials(sdkCipherView);
+          ciphers.forEach((cipher) => {
+            try {
+              const sdkCipherView = ref.value.vault().ciphers().decrypt(cipher.toSdkCipher());
+              const clientCipherView = CipherView.fromSdkCipherView(sdkCipherView)!;
 
-              // TODO (PM-21259): Remove manual keyValue decryption for FIDO2 credentials.
-              // This is a temporary workaround until we can use the SDK for FIDO2 authentication.
-              const decryptedKeyValue = ref.value
-                .vault()
-                .ciphers()
-                .decrypt_fido2_private_key(sdkCipherView);
+              // Handle FIDO2 credentials if present
+              if (
+                clientCipherView.type === CipherType.Login &&
+                sdkCipherView.login?.fido2Credentials?.length
+              ) {
+                const fido2CredentialViews = ref.value
+                  .vault()
+                  .ciphers()
+                  .decrypt_fido2_credentials(sdkCipherView);
 
-              clientCipherView.login.fido2Credentials = fido2CredentialViews
-                .map((f) => {
-                  const view = Fido2CredentialView.fromSdkFido2CredentialView(f)!;
-                  view.keyValue = decryptedKeyValue;
-                  return view;
-                })
-                .filter((view): view is Fido2CredentialView => view !== undefined);
+                const decryptedKeyValue = ref.value
+                  .vault()
+                  .ciphers()
+                  .decrypt_fido2_private_key(sdkCipherView);
+
+                clientCipherView.login.fido2Credentials = fido2CredentialViews
+                  .map((f) => {
+                    const view = Fido2CredentialView.fromSdkFido2CredentialView(f)!;
+                    view.keyValue = decryptedKeyValue;
+                    return view;
+                  })
+                  .filter((view): view is Fido2CredentialView => view !== undefined);
+              }
+
+              successful.push(clientCipherView);
+            } catch (error) {
+              this.logService.error(`Failed to decrypt cipher ${cipher.id}: ${error}`);
+              const failedView = new CipherView(cipher);
+              failedView.name = "[error: cannot decrypt]";
+              failedView.decryptionFailure = true;
+              failed.push(failedView);
             }
-
-            return clientCipherView;
           });
+
+          return [successful, failed] as [CipherView[], CipherView[]];
         }),
         catchError((error: unknown) => {
           this.logService.error(`Failed to decrypt ciphers: ${error}`);


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-29040
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
The `decryptCiphersWithSdk` method was designed to handle both lightweight list views (`fullDecryption=false`) and full cipher views (`fullDecryption=true`). However, when full decryption is needed, it unnecessarily goes through the list view path first, then converts each list view to a full view via individual decryption calls.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
