### PR TITLE
[PM-29106]  Fix basic search for cipher login list view 

### DIFF
--- a/libs/common/src/vault/services/search.service.ts
+++ b/libs/common/src/vault/services/search.service.ts
@@ -335,8 +335,10 @@ export class SearchService implements SearchServiceAbstraction {
 
       if (
         login &&
-        login.uris.length &&
-        login.uris.some((loginUri) => loginUri?.uri?.toLowerCase().indexOf(query) > -1)
+        login.uris?.length &&
+        login.uris?.some(
+          (loginUri) => loginUri?.uri && loginUri.uri.toLowerCase().indexOf(query) > -1,
+        )
       ) {
         return true;
       }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-29106](https://bitwarden.atlassian.net/browse/PM-29106)

## 📔 Objective

The `LoginListView` model from the SDK allows `uris` to be undefined when there are no URIs for the cipher. This adds a missing check for undefined/null when doing basic search.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-29106]: https://bitwarden.atlassian.net/browse/PM-29106?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ