### PR TITLE
[PM-29168] Normalize lowercasing for cipher compared against lowercased input value

### DIFF
--- a/apps/browser/src/autofill/background/notification.background.ts
+++ b/apps/browser/src/autofill/background/notification.background.ts
@@ -658,7 +658,7 @@ export default class NotificationBackground {
       if (
         username !== null &&
         newPassword === null &&
-        cipher.login.username === normalizedUsername &&
+        cipher.login.username.toLowerCase() === normalizedUsername &&
         cipher.login.password === currentPassword
       ) {
         // Assumed to be a login


### PR DESCRIPTION
## 🎟️ Tracking

[PM-29168](https://bitwarden.atlassian.net/browse/PM-29168)

## 📔 Objective

When a stored cipher has a capital letter in it’s username, it will always trigger an update cipher notification, even if it hasn’t changed for the login. This fixes the value comparison check for those cases.

Note, this also presumes that a detected casing difference in the entered username _shouldn't_ be considered "changed".

Related: https://github.com/bitwarden/clients/issues/17405

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-29168]: https://bitwarden.atlassian.net/browse/PM-29168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ