### PR TITLE
Mark ActiveUserState deprecated

### DIFF
--- a/libs/state/src/core/user-state.ts
+++ b/libs/state/src/core/user-state.ts
@@ -19,7 +19,7 @@ export const activeMarker: unique symbol = Symbol("active");
 
 /**
  * @deprecated ActiveUserState is deprecated. Use SingleUserState instead.
- * See https://github.com/bitwarden/clients/tree/main/libs/state#should-i-use-activeuserstate
+ * See [state README](../../README.md#should-i-use-activeuserstate) for details.
  */
 export interface ActiveUserState<T> extends UserState<T> {
   readonly [activeMarker]: true;


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-11866

## 📔 Objective

We are actively discouraging the use of `ActiveUserState<T>` - see https://github.com/bitwarden/clients/tree/main/libs/state#should-i-use-activeuserstate.

This PR marks it as obsolete so that it will not accidentally be introduced for new state definitions.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
