### PR TITLE
Fix typo in `xPositionOffset` variable name

### DIFF
--- a/apps/desktop/src/autofill/services/desktop-autofill.service.ts
+++ b/apps/desktop/src/autofill/services/desktop-autofill.service.ts
@@ -448,10 +448,10 @@ export class DesktopAutofillService implements OnDestroy {
 
 function normalizePosition(position: { x: number; y: number }): { x: number; y: number } {
   // Add 100 pixels to the x-coordinate to offset the native OS dialog positioning.
-  const xPostionOffset = 100;
+  const xPositionOffset = 100;
 
   return {
-    x: Math.round(position.x + xPostionOffset),
+    x: Math.round(position.x + xPositionOffset),
     y: Math.round(position.y),
   };
 }


### PR DESCRIPTION
## 📔 Objective

While reviewing https://github.com/bitwarden/clients/pull/13963 comments to write followup tickets I found this typo issue and wanted to submit a quick fix.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
