### PR TITLE
[PM-29418] Fix SSH list not working while locked

### DIFF
--- a/apps/desktop/desktop_native/core/src/ssh_agent/mod.rs
+++ b/apps/desktop/desktop_native/core/src/ssh_agent/mod.rs
@@ -352,7 +352,7 @@ h+OIoPZCzns+OFFjjm2vAAAAAAECAwQF
         let keys = vec![(
             TEST_ED25519_KEY.to_string(),
             "test_key".to_string(),
-            "cipher_id_123".to_string(),
+            "cipher_id".to_string(),
         )];
 
         agent.set_keys(keys).unwrap();
@@ -373,7 +373,7 @@ h+OIoPZCzns+OFFjjm2vAAAAAAECAwQF
         let keys = vec![(
             TEST_ED25519_KEY.to_string(),
             "test_key".to_string(),
-            "cipher_id_123".to_string(),
+            "cipher_id".to_string(),
         )];
         agent.set_keys(keys).unwrap();
 
@@ -385,6 +385,7 @@ h+OIoPZCzns+OFFjjm2vAAAAAAECAwQF
         // Clear keys should set needs_unlock back to true
         agent.clear_keys().unwrap();
 
+        // Verify needs_unlock is true
         assert!(agent
             .needs_unlock
             .load(std::sync::atomic::Ordering::Relaxed));


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-29418

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
SSH agent was designed to not require unlock AFU (after first unlock) to list keys. When locking, the list request should still work. It seems this functionality was broken at some point by setting the wrong value into needs_unlock.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
