### PR TITLE
[PM-29419] Fix agent crashing when account switching

### DIFF
--- a/apps/desktop/src/autofill/services/ssh-agent.service.ts
+++ b/apps/desktop/src/autofill/services/ssh-agent.service.ts
@@ -46,8 +46,6 @@ export class SshAgentService implements OnDestroy {
 
   private authorizedSshKeys: Record<string, Date> = {};
 
-  private isFeatureFlagEnabled = false;
-
   private destroy$ = new Subject<void>();
 
   constructor(
@@ -91,6 +89,7 @@ export class SshAgentService implements OnDestroy {
         filter(({ enabled }) => enabled),
         map(({ message }) => message),
         withLatestFrom(this.authService.activeAccountStatus$, this.accountService.activeAccount$),
+        filter(([, , account]) => account != null),
         // This switchMap handles unlocking the vault if it is locked:
         //   - If the vault is locked, we will wait for it to be unlocked.
         //   - If the vault is not unlocked within the timeout, we will abort the flow.
@@ -127,7 +126,11 @@ export class SshAgentService implements OnDestroy {
 
                 throw error;
               }),
-              map(() => [message, account.id]),
+              concatMap(async () => {
+                // The active account may have switched with account switching during unlock
+                const updatedAccount = await firstValueFrom(this.accountService.activeAccount$);
+                return [message, updatedAccount.id] as const;
+              }),
             );
           }
 
@@ -200,10 +203,6 @@ export class SshAgentService implements OnDestroy {
 
     this.accountService.activeAccount$.pipe(skip(1), takeUntil(this.destroy$)).subscribe({
       next: (account) => {
-        if (!this.isFeatureFlagEnabled) {
-          return;
-        }
-
         this.authorizedSshKeys = {};
         this.logService.info("Active account changed, clearing SSH keys");
         ipc.platform.sshAgent
@@ -211,20 +210,12 @@ export class SshAgentService implements OnDestroy {
           .catch((e) => this.logService.error("Failed to clear SSH keys", e));
       },
       error: (e: unknown) => {
-        if (!this.isFeatureFlagEnabled) {
-          return;
-        }
-
         this.logService.error("Error in active account observable", e);
         ipc.platform.sshAgent
           .clearKeys()
           .catch((e) => this.logService.error("Failed to clear SSH keys", e));
       },
       complete: () => {
-        if (!this.isFeatureFlagEnabled) {
-          return;
-        }
-
         this.logService.info("Active account observable completed, clearing SSH keys");
         this.authorizedSshKeys = {};
         ipc.platform.sshAgent
@@ -239,10 +230,6 @@ export class SshAgentService implements OnDestroy {
     ])
       .pipe(
         concatMap(async ([, enabled]) => {
-          if (!this.isFeatureFlagEnabled) {
-            return;
-          }
-
           if (!enabled) {
             await ipc.platform.sshAgent.clearKeys();
             return;


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-29419

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
The observables failed to consider null values and changing accounts during account switching. This would either result in complete crashes of the renderer agent observable, requiring an application restart, or result in decryption failures because the wrong account was used for decrypting the vault item


## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
