### PR TITLE
[PM-29167] Prefilled Vault Filters

### DIFF
--- a/libs/components/src/chip-select/chip-select.component.spec.ts
+++ b/libs/components/src/chip-select/chip-select.component.spec.ts
@@ -451,6 +451,24 @@ describe("ChipSelectComponent", () => {
 
       expect(disabledMenuItem?.disabled).toBe(true);
     });
+
+    it("should handle writeValue called before options are initialized", async () => {
+      const testApp = fixture.componentInstance;
+
+      component["rootTree"] = null;
+
+      component.writeValue("opt1");
+
+      expect(component["pendingValue"]).toBe("opt1");
+      expect(component["selectedOption"]).toBeUndefined();
+
+      testApp.options.set(testOptions);
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      expect(component["selectedOption"]?.value).toBe("opt1");
+      expect(component["pendingValue"]).toBeUndefined();
+    });
   });
 });
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-29167](https://bitwarden.atlassian.net/browse/PM-29167)

## 📔 Objective

The vault filters are cached when the extension loses focus and then repopulated when the extension is opened. The filter values and results are correctly being restored but the filter UI is not updated to show the cached values.

After some (a lot) of console logging, I narrowed this down to `writeValue` being called before the options are set for the `ChipSelectComponent` and thus the component not catching that first value. I believe this stems from https://github.com/bitwarden/clients/pull/17136 but I don't know if it is caused by the introduction of the constructor and associated logic or `ChangeDetectionStrategy.OnPush` change.

The impacted vault component is `VaultListFiltersComponent`: [Class](https://github.com/bitwarden/clients/blob/main/apps/browser/src/vault/popup/components/vault-v2/vault-list-filters/vault-list-filters.component.ts) - [Template](https://github.com/bitwarden/clients/blob/main/apps/browser/src/vault/popup/components/vault-v2/vault-list-filters/vault-list-filters.component.html)

## 📸 Screenshots

|Before|After|
|-|-|
|<video src="https://github.com/user-attachments/assets/26426b22-1ac5-4265-a5d6-f3ecddb787e7" />|<video src="https://github.com/user-attachments/assets/8a36734f-5cfe-4a85-9de6-7a9fca7303b6" />|

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-29167]: https://bitwarden.atlassian.net/browse/PM-29167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ