### PR TITLE
[PM-28901] Fix kdf prompt not working on browser

### DIFF
--- a/libs/angular/src/key-management/encrypted-migration/encrypted-migrations-scheduler.service.ts
+++ b/libs/angular/src/key-management/encrypted-migration/encrypted-migrations-scheduler.service.ts
@@ -38,7 +38,7 @@ export const ENCRYPTED_MIGRATION_DISMISSED = new UserKeyDefinition<Date>(
   },
 );
 const DISMISS_TIME_HOURS = 24;
-const VAULT_ROUTE = "/vault";
+const VAULT_ROUTES = ["/vault", "/tabs/vault", "/tabs/current"];
 
 /**
  * This services schedules encrypted migrations for users on clients that are interactive (non-cli), and handles manual interaction,
@@ -87,7 +87,7 @@ export class DefaultEncryptedMigrationsSchedulerService
               ]).pipe(
                 filter(
                   ([authStatus, _date, url]) =>
-                    authStatus === AuthenticationStatus.Unlocked && url === VAULT_ROUTE,
+                    authStatus === AuthenticationStatus.Unlocked && VAULT_ROUTES.includes(url),
                 ),
                 concatMap(() => this.runMigrationsIfNeeded(userId)),
               ),


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-28901

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

The encrypted migration scheduler service waits to be on the vault screen to show the prompt. This works fine on web, but on browser the routes are different, making the prompt not show up. This adds a few more routes to the list that will end up in the encryption prompt triggering.

Note to KM reviewers: We should probably long-term figure out a better way that is less brittle here, but it's not necessary for the first release.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
