### PR TITLE
Desktop CI build in developer mode for PR artifacts

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -588,7 +588,9 @@ jobs:
         run: node build.js cross-platform "$env:MODE"
 
       - name: Build
-        run: npm run build
+        env:
+          BUILD_MODE: ${{ github.event_name == 'workflow_call' && 'build' || 'build:dev' }}
+        run: npm run "$env:BUILD_MODE"
 
       - name: Pack
         if: ${{ needs.setup.outputs.has_secrets == 'false' }}
@@ -853,7 +855,9 @@ jobs:
         run: node build.js cross-platform "$env:MODE"
 
       - name: Build
-        run: npm run build
+        env:
+          BUILD_MODE: ${{ github.event_name == 'workflow_call' && 'build' || 'build:dev' }}
+        run: npm run "$env:BUILD_MODE"
 
       - name: Pack
         if: ${{ needs.setup.outputs.has_secrets == 'false' }}
@@ -1211,7 +1215,9 @@ jobs:
         run: node build.js cross-platform "$MODE"
 
       - name: Build application (dev)
-        run: npm run build
+        env:
+          BUILD_MODE: ${{ github.event_name == 'workflow_call' && 'build' || 'build:dev' }}
+        run: npm run "$BUILD_MODE"
 
   browser-build:
     name: Browser Build
@@ -1436,7 +1442,9 @@ jobs:
 
       - name: Build
         if: steps.build-cache.outputs.cache-hit != 'true'
-        run: npm run build
+        env:
+          BUILD_MODE: ${{ github.event_name == 'workflow_call' && 'build' || 'build:dev' }}
+        run: npm run "$BUILD_MODE"
 
       - name: Download Browser artifact
         uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
@@ -1719,7 +1727,9 @@ jobs:
 
       - name: Build
         if: steps.build-cache.outputs.cache-hit != 'true'
-        run: npm run build
+        env:
+          BUILD_MODE: ${{ github.event_name == 'workflow_call' && 'build' || 'build:dev' }}
+        run: npm run "$BUILD_MODE"
 
       - name: Download Browser artifact
         uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-29587

## 📔 Objective

This toggles our desktop electron builds based on how the workflow is executed. When trigger is an upstream workflow calling (e.g. our release workflow), the mode is release. When other triggers (by PR, and by manual run in GH), developer mode.

Note that the Linux builds are still in release mode due to the slow unlock issue.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
