### PR TITLE
Specify app restart in desktop app

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -811,7 +811,7 @@
   "onSleep": {
     "message": "On system sleep"
   },
-  "onRestart": {
+  "onAppRestart": {
     "message": "On browser restart"
   },
   "never": {
@@ -5952,7 +5952,7 @@
   "sessionTimeoutSettingsPolicySetDefaultTimeoutToOnLocked": {
     "message": "Your organization has set the default session timeout to On system lock."
   },
-  "sessionTimeoutSettingsPolicySetDefaultTimeoutToOnRestart": {
+  "sessionTimeoutSettingsPolicySetDefaultTimeoutToOnAppRestart": {
     "message": "Your organization has set the default session timeout to On browser restart."
   },
   "sessionTimeoutSettingsPolicyMaximumError": {
@@ -5968,7 +5968,7 @@
       }
     }
   },
-  "sessionTimeoutOnRestart": {
+  "sessionTimeoutOnAppRestart": {
     "message": "On browser restart"
   },
   "sessionTimeoutSettingsSetUnlockMethodToChangeTimeoutAction": {

--- a/apps/browser/src/auth/popup/settings/account-security.component.ts
+++ b/apps/browser/src/auth/popup/settings/account-security.component.ts
@@ -211,7 +211,7 @@ export class AccountSecurityComponent implements OnInit, OnDestroy {
     }
 
     this.vaultTimeoutOptions.push({
-      name: this.i18nService.t("onRestart"),
+      name: this.i18nService.t("onAppRestart"),
       value: VaultTimeoutStringType.OnRestart,
     });
     this.vaultTimeoutOptions.push({

--- a/apps/desktop/src/app/accounts/settings.component.ts
+++ b/apps/desktop/src/app/accounts/settings.component.ts
@@ -1004,7 +1004,7 @@ export class SettingsComponent implements OnInit, OnDestroy {
     }
 
     vaultTimeoutOptions = vaultTimeoutOptions.concat([
-      { name: this.i18nService.t("onRestart"), value: VaultTimeoutStringType.OnRestart },
+      { name: this.i18nService.t("onAppRestart"), value: VaultTimeoutStringType.OnRestart },
       { name: this.i18nService.t("never"), value: VaultTimeoutStringType.Never },
     ]);
 

--- a/apps/desktop/src/auth/components/set-pin.component.html
+++ b/apps/desktop/src/auth/components/set-pin.component.html
@@ -22,7 +22,7 @@
           bitCheckbox
           formControlName="requireMasterPasswordOnClientRestart"
         />
-        <span>{{ "lockWithMasterPassOnRestart1" | i18n }}</span>
+        <span>{{ "lockWithMasterPassOnAppRestart1" | i18n }}</span>
       </label>
     </div>
     <ng-container bitDialogFooter>

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -1339,8 +1339,8 @@
   "onLocked": {
     "message": "On system lock"
   },
-  "onRestart": {
-    "message": "On restart"
+  "onAppRestart": {
+    "message": "On app restart"
   },
   "never": {
     "message": "Never"
@@ -1423,7 +1423,7 @@
     "message": "Language"
   },
   "languageDesc": {
-    "message": "Change the language used by the application. Restart is required."
+    "message": "Change the language used by the application. App restart is required."
   },
   "theme": {
     "message": "Theme"
@@ -1455,11 +1455,11 @@
       }
     }
   },
-  "restartToUpdate": {
-    "message": "Restart to update"
+  "restartAppToUpdate": {
+    "message": "Restart app to update"
   },
-  "restartToUpdateDesc": {
-    "message": "Version $VERSION_NUM$ is ready to install. You must restart the application to complete the installation. Do you want to restart and update now?",
+  "restartAppToUpdateDesc": {
+    "message": "Version $VERSION_NUM$ is ready to install. You must restart the application to complete the installation. Do you want to restart the app and update now?",
     "placeholders": {
       "version_num": {
         "content": "$1",
@@ -1903,8 +1903,8 @@
   "autoPromptTouchId": {
     "message": "Ask for Touch ID on app start"
   },
-  "lockWithMasterPassOnRestart1": {
-    "message": "Lock with master password on restart"
+  "lockWithMasterPassOnAppRestart1": {
+    "message": "Lock with master password on app restart"
   },
   "requireMasterPasswordOrPinOnAppRestart": {
     "message": "Require master password or PIN on app restart"
@@ -2211,7 +2211,7 @@
     "message": "Use hardware acceleration"
   },
   "enableHardwareAccelerationDesc": {
-    "message": "By default this setting is ON. Turn OFF only if you experience graphical issues. Restart is required."
+    "message": "By default this setting is ON. Turn OFF only if you experience graphical issues. App restart is required."
   },
   "approve": {
     "message": "Approve"
@@ -3733,11 +3733,11 @@
   "troubleshooting": {
     "message": "Troubleshooting"
   },
-  "disableHardwareAccelerationRestart": {
-    "message": "Disable hardware acceleration and restart"
+  "disableHardwareAccelerationAndRestartApp": {
+    "message": "Disable hardware acceleration and restart app"
   },
-  "enableHardwareAccelerationRestart": {
-    "message": "Enable hardware acceleration and restart"
+  "enableHardwareAccelerationAndRestartApp": {
+    "message": "Enable hardware acceleration and restart app"
   },
   "removePasskey": {
     "message": "Remove passkey"
@@ -4398,8 +4398,8 @@
   "sessionTimeoutSettingsPolicySetDefaultTimeoutToOnLocked": {
     "message": "Your organization has set the default session timeout to On system lock."
   },
-  "sessionTimeoutSettingsPolicySetDefaultTimeoutToOnRestart": {
-    "message": "Your organization has set the default session timeout to On restart."
+  "sessionTimeoutSettingsPolicySetDefaultTimeoutToOnAppRestart": {
+    "message": "Your organization has set the default session timeout to On app restart."
   },
   "sessionTimeoutSettingsPolicyMaximumError": {
     "message": "Maximum timeout cannot exceed $HOURS$ hour(s) and $MINUTES$ minute(s)",
@@ -4414,8 +4414,8 @@
       }
     }
   },
-  "sessionTimeoutOnRestart": {
-    "message": "On restart"
+  "sessionTimeoutOnAppRestart": {
+    "message": "On app restart"
   },
   "sessionTimeoutSettingsSetUnlockMethodToChangeTimeoutAction": {
     "message": "Set an unlock method to change your timeout action"

--- a/apps/desktop/src/main/menu/menu.help.ts
+++ b/apps/desktop/src/main/menu/menu.help.ts
@@ -233,8 +233,8 @@ export class HelpMenu implements IMenubarMenu {
         id: "hardwareAcceleration",
         label: this.localize(
           this.hardwareAccelerationEnabled
-            ? "disableHardwareAccelerationRestart"
-            : "enableHardwareAccelerationRestart",
+            ? "disableHardwareAccelerationAndRestartApp"
+            : "enableHardwareAccelerationAndRestartApp",
         ),
         click: async () => {
           await this.desktopSettingsService.setHardwareAcceleration(

--- a/apps/desktop/src/main/updater.main.ts
+++ b/apps/desktop/src/main/updater.main.ts
@@ -185,8 +185,8 @@ export class UpdaterMain {
     }
 
     this.openedNotification = new Notification({
-      title: this.i18nService.t("bitwarden") + " - " + this.i18nService.t("restartToUpdate"),
-      body: this.i18nService.t("restartToUpdateDesc", info.version),
+      title: this.i18nService.t("bitwarden") + " - " + this.i18nService.t("restartAppToUpdate"),
+      body: this.i18nService.t("restartAppToUpdateDesc", info.version),
       timeoutType: "never",
       silent: false,
     });
@@ -206,9 +206,9 @@ export class UpdaterMain {
   private async promptRestartUpdateUsingDialog(info: UpdateDownloadedEvent) {
     const result = await dialog.showMessageBox(this.windowMain.win, {
       type: "info",
-      title: this.i18nService.t("bitwarden") + " - " + this.i18nService.t("restartToUpdate"),
-      message: this.i18nService.t("restartToUpdate"),
-      detail: this.i18nService.t("restartToUpdateDesc", info.version),
+      title: this.i18nService.t("bitwarden") + " - " + this.i18nService.t("restartAppToUpdate"),
+      message: this.i18nService.t("restartAppToUpdate"),
+      detail: this.i18nService.t("restartAppToUpdateDesc", info.version),
       buttons: [this.i18nService.t("restart"), this.i18nService.t("later")],
       cancelId: 1,
       defaultId: 0,

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -12356,7 +12356,7 @@
       }
     }
   },
-  "sessionTimeoutSettingsPolicySetDefaultTimeoutToOnRestart": {
+  "sessionTimeoutSettingsPolicySetDefaultTimeoutToOnAppRestart": {
     "message": "Your organization has set the default session timeout to On browser refresh."
   },
   "sessionTimeoutSettingsPolicyMaximumError": {
@@ -12372,7 +12372,7 @@
       }
     }
   },
-  "sessionTimeoutOnRestart": {
+  "sessionTimeoutOnAppRestart": {
     "message": "On browser refresh"
   },
   "sessionTimeoutSettingsSetUnlockMethodToChangeTimeoutAction": {

--- a/libs/key-management-ui/src/session-timeout/components/session-timeout-input.component.spec.ts
+++ b/libs/key-management-ui/src/session-timeout/components/session-timeout-input.component.spec.ts
@@ -249,7 +249,9 @@ describe("SessionTimeoutInputComponent", () => {
         component["policyTimeoutMessage$"].subscribe((msg) => (message = msg));
         flush();
 
-        expect(message).toBe("sessionTimeoutSettingsPolicySetDefaultTimeoutToOnRestart-used-i18n");
+        expect(message).toBe(
+          "sessionTimeoutSettingsPolicySetDefaultTimeoutToOnAppRestart-used-i18n",
+        );
       }));
 
       it("should emit null when policy has never type and promoted value is Never", fakeAsync(() => {
@@ -315,7 +317,9 @@ describe("SessionTimeoutInputComponent", () => {
         component["policyTimeoutMessage$"].subscribe((msg) => (message = msg));
         flush();
 
-        expect(message).toBe("sessionTimeoutSettingsPolicySetDefaultTimeoutToOnRestart-used-i18n");
+        expect(message).toBe(
+          "sessionTimeoutSettingsPolicySetDefaultTimeoutToOnAppRestart-used-i18n",
+        );
       }));
 
       it("should emit onRestart message when never is promoted to OnRestart", fakeAsync(() => {
@@ -337,7 +341,9 @@ describe("SessionTimeoutInputComponent", () => {
         component["policyTimeoutMessage$"].subscribe((msg) => (message = msg));
         flush();
 
-        expect(message).toBe("sessionTimeoutSettingsPolicySetDefaultTimeoutToOnRestart-used-i18n");
+        expect(message).toBe(
+          "sessionTimeoutSettingsPolicySetDefaultTimeoutToOnAppRestart-used-i18n",
+        );
       }));
     });
 

--- a/libs/key-management-ui/src/session-timeout/components/session-timeout-input.component.ts
+++ b/libs/key-management-ui/src/session-timeout/components/session-timeout-input.component.ts
@@ -309,7 +309,7 @@ export class SessionTimeoutInputComponent implements ControlValueAccessor, Valid
       case VaultTimeoutStringType.OnLocked:
         return this.i18nService.t("sessionTimeoutSettingsPolicySetDefaultTimeoutToOnLocked");
       case VaultTimeoutStringType.OnRestart:
-        return this.i18nService.t("sessionTimeoutSettingsPolicySetDefaultTimeoutToOnRestart");
+        return this.i18nService.t("sessionTimeoutSettingsPolicySetDefaultTimeoutToOnAppRestart");
       default:
         if (isVaultTimeoutTypeNumeric(timeout)) {
           const hours = Math.floor((timeout as number) / 60);

--- a/libs/key-management-ui/src/session-timeout/services/session-timeout-settings-component.service.spec.ts
+++ b/libs/key-management-ui/src/session-timeout/services/session-timeout-settings-component.service.spec.ts
@@ -172,12 +172,12 @@ describe("SessionTimeoutSettingsComponentService", () => {
           });
           if (availableTimeoutOrPromoted === VaultTimeoutStringType.OnLocked) {
             expect(options).not.toContainEqual({
-              name: "sessionTimeoutOnRestart",
+              name: "sessionTimeoutOnAppRestart",
               value: VaultTimeoutStringType.OnRestart,
             });
           } else {
             expect(options).toContainEqual({
-              name: "sessionTimeoutOnRestart",
+              name: "sessionTimeoutOnAppRestart",
               value: VaultTimeoutStringType.OnRestart,
             });
           }
@@ -206,7 +206,7 @@ describe("SessionTimeoutSettingsComponentService", () => {
 
         assertNumericTimeoutTypes(options);
         expect(options).toContainEqual({
-          name: "sessionTimeoutOnRestart",
+          name: "sessionTimeoutOnAppRestart",
           value: VaultTimeoutStringType.OnRestart,
         });
         expect(options).toContainEqual({ name: "custom", value: VaultTimeoutStringType.Custom });
@@ -274,7 +274,7 @@ describe("SessionTimeoutSettingsComponentService", () => {
             value: VaultTimeoutStringType.OnSleep,
           });
           expect(options).not.toContainEqual({
-            name: "sessionTimeoutOnRestart",
+            name: "sessionTimeoutOnAppRestart",
             value: VaultTimeoutStringType.OnRestart,
           });
           expect(options).not.toContainEqual({
@@ -315,7 +315,7 @@ describe("SessionTimeoutSettingsComponentService", () => {
     expect(options).toContainEqual({ name: "onSleep", value: VaultTimeoutStringType.OnSleep });
     expect(options).toContainEqual({ name: "onLocked", value: VaultTimeoutStringType.OnLocked });
     expect(options).toContainEqual({
-      name: "sessionTimeoutOnRestart",
+      name: "sessionTimeoutOnAppRestart",
       value: VaultTimeoutStringType.OnRestart,
     });
     expect(options).toContainEqual({ name: "never", value: VaultTimeoutStringType.Never });

--- a/libs/key-management-ui/src/session-timeout/services/session-timeout-settings-component.service.ts
+++ b/libs/key-management-ui/src/session-timeout/services/session-timeout-settings-component.service.ts
@@ -150,7 +150,7 @@ export class SessionTimeoutSettingsComponentService {
       { name: "onIdle", value: VaultTimeoutStringType.OnIdle },
       { name: "onSleep", value: VaultTimeoutStringType.OnSleep },
       { name: "onLocked", value: VaultTimeoutStringType.OnLocked },
-      { name: "sessionTimeoutOnRestart", value: VaultTimeoutStringType.OnRestart },
+      { name: "sessionTimeoutOnAppRestart", value: VaultTimeoutStringType.OnRestart },
       { name: "never", value: VaultTimeoutStringType.Never },
       { name: "custom", value: VaultTimeoutStringType.Custom },
     ];


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-29648

## 📔 Objective

Updated all ambiguous "restart" strings in the desktop app (and related shared components) to explicitly say "app restart" instead of just "restart" to prevent confusion with OS restart.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
