### PR TITLE
PM-29652: Increase the limit of passkeys to 25

### DIFF
--- a/apps/web/src/app/auth/core/services/webauthn-login/webauthn-login-admin.service.ts
+++ b/apps/web/src/app/auth/core/services/webauthn-login/webauthn-login-admin.service.ts
@@ -40,7 +40,7 @@ import { WebAuthnLoginAdminApiService } from "./webauthn-login-admin-api.service
  * Service for managing WebAuthnLogin credentials.
  */
 export class WebauthnLoginAdminService implements UserKeyRotationDataProvider<WebauthnRotateCredentialRequest> {
-  static readonly MaxCredentialCount = 5;
+  static readonly MaxCredentialCount = 25;
 
   private navigatorCredentials: CredentialsContainer;
   private _refresh$ = new BehaviorSubject<void>(undefined);

--- a/apps/web/src/app/auth/settings/webauthn-login-settings/webauthn-login-settings.component.html
+++ b/apps/web/src/app/auth/settings/webauthn-login-settings/webauthn-login-settings.component.html
@@ -99,7 +99,7 @@
     </button>
   </ng-container>
 
-  <button *ngIf="hasMoreCredentials" type="button" bitLink (click)="toggleShowAll()">
+  <button *ngIf="hasMoreCredentials" type="button" bitLink (click)="toggleShowAll()" [attr.aria-label]="(showAll ? 'showLess' : 'showMore') | i18n">
     <ng-container *ngIf="!showAll"
       >{{ "showMore" | i18n }} ({{ (credentials?.length ?? 0) - displayLimit }})</ng-container
     >

--- a/apps/web/src/app/auth/settings/webauthn-login-settings/webauthn-login-settings.component.html
+++ b/apps/web/src/app/auth/settings/webauthn-login-settings/webauthn-login-settings.component.html
@@ -32,7 +32,7 @@
 </p>
 
 <table *ngIf="hasCredentials" class="tw-mb-5">
-  <tr *ngFor="let credential of credentials">
+  <tr *ngFor="let credential of displayedCredentials">
     <td class="tw-p-2 tw-pl-0 tw-font-medium">{{ credential.name }}</td>
     <td class="tw-p-2 tw-pr-10 tw-text-left">
       <ng-container *ngIf="credential.prfStatus === WebauthnLoginCredentialPrfStatus.Enabled">
@@ -75,25 +75,34 @@
 
 <p bitTypography="body2" *ngIf="limitReached">{{ "passkeyLimitReachedInfo" | i18n }}</p>
 
-<ng-container *ngIf="hasData && !limitReached && !requireSsoPolicyEnabled">
-  <button
-    *ngIf="hasCredentials"
-    type="button"
-    bitButton
-    [disabled]="loading"
-    (click)="createCredential()"
-  >
-    {{ "newPasskey" | i18n }}
-  </button>
+<div class="tw-flex tw-items-center tw-gap-4">
+  <ng-container *ngIf="hasData && !limitReached && !requireSsoPolicyEnabled">
+    <button
+      *ngIf="hasCredentials"
+      type="button"
+      bitButton
+      [disabled]="loading"
+      (click)="createCredential()"
+    >
+      {{ "newPasskey" | i18n }}
+    </button>
 
-  <button
-    *ngIf="!hasCredentials"
-    type="button"
-    bitButton
-    [attr.aria-label]="('enable' | i18n) + ' ' + ('logInWithPasskey' | i18n)"
-    [disabled]="loading"
-    (click)="createCredential()"
-  >
-    {{ "enable" | i18n }}
+    <button
+      *ngIf="!hasCredentials"
+      type="button"
+      bitButton
+      [attr.aria-label]="('enable' | i18n) + ' ' + ('logInWithPasskey' | i18n)"
+      [disabled]="loading"
+      (click)="createCredential()"
+    >
+      {{ "enable" | i18n }}
+    </button>
+  </ng-container>
+
+  <button *ngIf="hasMoreCredentials" type="button" bitLink (click)="toggleShowAll()">
+    <ng-container *ngIf="!showAll"
+      >{{ "showMore" | i18n }} ({{ (credentials?.length ?? 0) - displayLimit }})</ng-container
+    >
+    <ng-container *ngIf="showAll">{{ "showLess" | i18n }}</ng-container>
   </button>
-</ng-container>
+</div>

--- a/apps/web/src/app/auth/settings/webauthn-login-settings/webauthn-login-settings.component.ts
+++ b/apps/web/src/app/auth/settings/webauthn-login-settings/webauthn-login-settings.component.ts
@@ -33,6 +33,8 @@ export class WebauthnLoginSettingsComponent implements OnInit, OnDestroy {
 
   protected credentials?: WebauthnLoginCredentialView[];
   protected loading = true;
+  protected showAll = false;
+  protected readonly displayLimit = 10;
 
   protected requireSsoPolicyEnabled = false;
 
@@ -86,6 +88,24 @@ export class WebauthnLoginSettingsComponent implements OnInit, OnDestroy {
 
   get limitReached() {
     return (this.credentials?.length ?? 0) >= this.MaxCredentialCount;
+  }
+
+  get displayedCredentials(): WebauthnLoginCredentialView[] {
+    if (!this.credentials) {
+      return [];
+    }
+    if (this.showAll || this.credentials.length <= this.displayLimit) {
+      return this.credentials;
+    }
+    return this.credentials.slice(0, this.displayLimit);
+  }
+
+  get hasMoreCredentials(): boolean {
+    return (this.credentials?.length ?? 0) > this.displayLimit;
+  }
+
+  protected toggleShowAll() {
+    this.showAll = !this.showAll;
   }
 
   protected createCredential() {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-29652

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

This PR increases the limit of passkeys from 5 -> 25. 

When the UI has more than 10 passkeys, e.g. 12, it shows a button "Show more (2)".

Related to/soft dependent on: https://github.com/bitwarden/server/pull/6725

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<img width="984" height="627" alt="image" src="https://github.com/user-attachments/assets/6c40d68f-9e4b-4018-a335-dcc21910664c" />

<img width="983" height="704" alt="image" src="https://github.com/user-attachments/assets/a908a8c1-f253-4fbe-8269-d9bef7b28eb9" />


<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
