### PR TITLE
[PM-29759] Fix vertical alignment of Compact mode Beta badge

### DIFF
--- a/apps/browser/src/popup/scss/popup.scss
+++ b/apps/browser/src/popup/scss/popup.scss
@@ -48,3 +48,34 @@ $mfaTypes: 0, 2, 3, 4, 6;
     content: url("../images/two-factor/7-w.png");
   }
 }
+/**
+ * BETA BADGE VERTICAL ALIGNMENT FIX
+ * GitHub Issue: #17810
+ */
+
+bit-label {
+  &:has([bitBadge]) {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+
+    [bitBadge] {
+      align-self: center;
+      vertical-align: middle;
+      line-height: 1;
+      margin-top: 0;
+      margin-bottom: 0;
+    }
+  }
+}
+
+.tw-bit-compact {
+  bit-label:has([bitBadge]) {
+    gap: 0.25rem;
+
+    [bitBadge] {
+      font-size: 0.7rem;
+      padding: 0.125rem 0.375rem;
+    }
+  }
+}

--- a/apps/browser/src/vault/popup/settings/appearance-v2.component.html
+++ b/apps/browser/src/vault/popup/settings/appearance-v2.component.html
@@ -8,7 +8,9 @@
   <form [formGroup]="appearanceForm">
     <bit-card>
       <bit-form-field>
-        <bit-label>{{ "theme" | i18n }}</bit-label>
+        <bit-label class="tw-inline-flex tw-items-center tw-gap-1.5">{{
+          "theme" | i18n
+        }}</bit-label>
         <bit-select formControlName="theme">
           <bit-option
             *ngFor="let o of themeOptions"


### PR DESCRIPTION
## 🎟️ Tracking

Fixes #17810  
Vertical misalignment around the Compact mode "Beta" badge

## 📔 Objective

Fix the vertical and horizontal alignment of the "Beta" badge displayed next to **Compact mode** in **Settings → Appearance** within the browser extension.

**Issue:** The badge was visually misaligned relative to the label text and appeared too close horizontally, resulting in an uneven UI compared to other badges used in the extension.

**Solution:** Applied Tailwind flexbox utilities to the label container to ensure proper vertical centering and consistent spacing, supplemented by scoped SCSS rules for global badge alignment consistency.

## 📸 Screenshots

_Not available — changes are CSS/HTML layout adjustments that vertically center the badge with the label text and improve horizontal spacing. Visual verification can be performed by running the extension locally._

## ⏰ Reminders before review

- ✅ Contributor guidelines followed
- ✅ All formatters and local linters executed where applicable
- ✅ No unit or integration tests required (UI-only layout fix)
- ✅ No functional behavior changes introduced
- ✅ No feature flags required (non-breaking UI change)
- ✅ Existing i18n strings reused — no new translations needed
- ✅ No deployment or documentation updates required

## 🦮 Reviewer guidelines

Feedback welcome on:

- 🎨 Visual consistency with other badges across the extension
- 🌱 Preferred utility classes or spacing conventions
- ♻️ Potential reuse of this alignment pattern elsewhere in the codebase

## ✨ Additional context

- **Scope:** Pure UI fix (HTML + SCSS only), scoped to the browser extension
- **No logic, behavior, or state changes**
- **Safe to merge:** Non-breaking, follows existing design patterns
- **Testing:** Visual verification recommended via local extension build