### PR TITLE
Allow local Electron app signing for Windows dev builds [PM-18325]

### DIFF
--- a/apps/desktop/sign.js
+++ b/apps/desktop/sign.js
@@ -5,17 +5,22 @@ exports.default = async function (configuration) {
   const ext = configuration.path.split(".").at(-1);
   if (parseInt(process.env.ELECTRON_BUILDER_SIGN) === 1 && ext == "exe") {
     console.log(`[*] Signing file: ${configuration.path}`);
-    child_process.execSync(
-      `azuresigntool sign -v ` +
-        `-kvu ${process.env.SIGNING_VAULT_URL} ` +
-        `-kvi ${process.env.SIGNING_CLIENT_ID} ` +
-        `-kvt ${process.env.SIGNING_TENANT_ID} ` +
-        `-kvs ${process.env.SIGNING_CLIENT_SECRET} ` +
-        `-kvc ${process.env.SIGNING_CERT_NAME} ` +
-        `-fd ${configuration.hash} ` +
-        `-du ${configuration.site} ` +
-        `-tr http://timestamp.digicert.com ` +
-        `"${configuration.path}"`,
+    child_process.execFileSync(
+      "azuresigntool",
+      // prettier-ignore
+      [
+        "sign",
+        "-v",
+        "-kvu", process.env.SIGNING_VAULT_URL,
+        "-kvi", process.env.SIGNING_CLIENT_ID,
+        "-kvt", process.env.SIGNING_TENANT_ID,
+        "-kvs", process.env.SIGNING_CLIENT_SECRET,
+        "-kvc", process.env.SIGNING_CERT_NAME,
+        "-fd", configuration.hash,
+        "-du", configuration.site,
+        "-tr", "http://timestamp.digicert.com",
+        configuration.path,
+      ],
       {
         stdio: "inherit",
       },


### PR DESCRIPTION
## 🎟️ Tracking

[PM-18325](https://bitwarden.atlassian.net/browse/PM-18325)

## 📔 Objective

Signing the desktop app on Windows is only set up on CI. Some local testing flows require signed applications (like Windows passkey plugin, which must be run from an Appx, which must be signed to install.)

This allows a Windows developer to set environment variables to specify a path and password for a PKCS12 file to automatically sign executables.

## Notes

### Certificate Setup
For an Appx, the PKCS12 certificate must have the same subject name as provided in the `AppxManifest.xml` file, and must be imported into the "Trusted People" certificate store for the machine. This can be done using PowerShell:

```powershell
$publisher = (Get-Content apps/desktop/electron-builder.json | ConvertFrom-Json).appx.publisher

$cert = New-SelfSignedCertificate -Type Custom -KeyUsage DigitalSignature -CertStoreLocation "Cert:\CurrentUser\My" -TextExtension @("2.5.29.37={text}1.3.6.1.5.5.7.3.3", "2.5.29.19={text}") -Subject $publisher -FriendlyName "My Code Signing Certificate"

$password = Read-Host -AsSecureString -Prompt "Enter a password for the PFX"
# or, non-interactively
# $password = ConvertTo-SecureString -String "<password>" -Force -AsPlainText 

Export-PfxCertificate -cert "Cert:\CurrentUser\My\${$cert.thumbprint}" -FilePath mysigning.pfx -Password $password
```

You can import from an admin PowerShell window:
```powershell
Import-PfxCertificate -CertStoreLocation "Cert:\LocalMachine\TrustedPeople" -Password $password -FilePath mysigning.pfx
```

### Signing with certificate

To sign, just set the following environment variables before running a `pack:win:*` step:
- `ELECTRON_BUILDER_SIGN_CERT`: path to PKCS12 file
- `ELECTRON_BUILDER_SIGN_CERT_PW`: password for PKCS12 file

On Windows, if you right-click on the file > Properties > Digital Signatures tab, you should be able to see the details from your certificate in the list of embedded signatures.

I'm fine with renaming these environment variables as desired. I'll follow up with a PR to update the [related contributing docs page](https://contributing.bitwarden.com/getting-started/clients/desktop/microsoft-store).

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-18325]: https://bitwarden.atlassian.net/browse/PM-18325?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ