### PR TITLE
[PM-29848] Move isArchived Check

### DIFF
--- a/apps/web/src/app/vault/components/vault-item-dialog/vault-item-dialog.component.ts
+++ b/apps/web/src/app/vault/components/vault-item-dialog/vault-item-dialog.component.ts
@@ -253,7 +253,7 @@ export class VaultItemDialogComponent implements OnInit, OnDestroy {
 
   protected showRestore: boolean;
 
-  protected cipherIsArchived: boolean;
+  protected cipherIsArchived: boolean = false;
 
   protected get loadingForm() {
     return this.loadForm && !this.formReady;
@@ -350,6 +350,8 @@ export class VaultItemDialogComponent implements OnInit, OnDestroy {
         return;
       }
 
+      this.cipherIsArchived = this.cipher.isArchived;
+
       this.collections = this.formConfig.collections.filter((c) =>
         this.cipher.collectionIds?.includes(c.id),
       );
@@ -375,7 +377,6 @@ export class VaultItemDialogComponent implements OnInit, OnDestroy {
     this.filter = await firstValueFrom(this.routedVaultFilterService.filter$);
 
     this.showRestore = await this.canUserRestore();
-    this.cipherIsArchived = this.cipher.isArchived;
     this.performingInitialLoad = false;
   }
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-29848](https://bitwarden.atlassian.net/browse/PM-29848)

## 📔 Objective

When a new cipher is created the `this.cipher` object in the component is `undefined` and thus `isArchived` does not exist.
This moves the check into the `this.cipher` conditional.

There should be an added test here but each time I attempt a test I get the below error which I believe is related to the component being a dialog. After 45 minutes I'm moving this PR up to unblock automated tests. I'll keep tinkering and will follow up if I get a solution. 

```ts
Element matching '[cdkFocusInitial]' is not focusable. HTMLHeadingElement
```

## 📸 Screenshots

<video src="https://github.com/user-attachments/assets/edcdce63-6893-46af-b8d0-24e0274c1344" />

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-29848]: https://bitwarden.atlassian.net/browse/PM-29848?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ