### PR TITLE
[PM-29488] add padding between name and icons in health reports

### DIFF
--- a/apps/web/src/app/auth/settings/emergency-access/view/emergency-access-view.component.html
+++ b/apps/web/src/app/auth/settings/emergency-access/view/emergency-access-view.component.html
@@ -19,7 +19,7 @@
             >
             <ng-container *ngIf="currentCipher.organizationId">
               <i
-                class="bwi bwi-collection-shared"
+                class="bwi bwi-collection-shared tw-ml-1"
                 appStopProp
                 title="{{ 'shared' | i18n }}"
                 aria-hidden="true"
@@ -28,7 +28,7 @@
             </ng-container>
             <ng-container *ngIf="currentCipher.hasAttachments">
               <i
-                class="bwi bwi-paperclip"
+                class="bwi bwi-paperclip tw-ml-1"
                 appStopProp
                 title="{{ 'attachments' | i18n }}"
                 aria-hidden="true"

--- a/apps/web/src/app/dirt/reports/pages/exposed-passwords-report.component.html
+++ b/apps/web/src/app/dirt/reports/pages/exposed-passwords-report.component.html
@@ -58,7 +58,7 @@
             </ng-template>
             <ng-container *ngIf="!organization && row.organizationId">
               <i
-                class="bwi bwi-collection-shared"
+                class="bwi bwi-collection-shared tw-ml-1"
                 appStopProp
                 title="{{ 'shared' | i18n }}"
                 aria-hidden="true"
@@ -67,7 +67,7 @@
             </ng-container>
             <ng-container *ngIf="row.hasAttachments">
               <i
-                class="bwi bwi-paperclip"
+                class="bwi bwi-paperclip tw-ml-1"
                 appStopProp
                 title="{{ 'attachments' | i18n }}"
                 aria-hidden="true"

--- a/apps/web/src/app/dirt/reports/pages/inactive-two-factor-report.component.html
+++ b/apps/web/src/app/dirt/reports/pages/inactive-two-factor-report.component.html
@@ -62,7 +62,7 @@
                 </ng-template>
                 <ng-container *ngIf="!organization && r.organizationId">
                   <i
-                    class="bwi bwi-collection-shared"
+                    class="bwi bwi-collection-shared tw-ml-1"
                     appStopProp
                     title="{{ 'shared' | i18n }}"
                     aria-hidden="true"
@@ -71,7 +71,7 @@
                 </ng-container>
                 <ng-container *ngIf="r.hasAttachments">
                   <i
-                    class="bwi bwi-paperclip"
+                    class="bwi bwi-paperclip tw-ml-1"
                     appStopProp
                     title="{{ 'attachments' | i18n }}"
                     aria-hidden="true"

--- a/apps/web/src/app/dirt/reports/pages/reused-passwords-report.component.html
+++ b/apps/web/src/app/dirt/reports/pages/reused-passwords-report.component.html
@@ -60,7 +60,7 @@
             </ng-template>
             <ng-container *ngIf="!organization && row.organizationId">
               <i
-                class="bwi bwi-collection-shared"
+                class="bwi bwi-collection-shared tw-ml-1"
                 appStopProp
                 title="{{ 'shared' | i18n }}"
                 aria-hidden="true"
@@ -69,7 +69,7 @@
             </ng-container>
             <ng-container *ngIf="row.hasAttachments">
               <i
-                class="bwi bwi-paperclip"
+                class="bwi bwi-paperclip tw-ml-1"
                 appStopProp
                 title="{{ 'attachments' | i18n }}"
                 aria-hidden="true"

--- a/apps/web/src/app/dirt/reports/pages/unsecured-websites-report.component.html
+++ b/apps/web/src/app/dirt/reports/pages/unsecured-websites-report.component.html
@@ -62,7 +62,7 @@
               </ng-template>
               <ng-container *ngIf="!organization && r.organizationId">
                 <i
-                  class="bwi bwi-collection-shared"
+                  class="bwi bwi-collection-shared tw-ml-1"
                   appStopProp
                   title="{{ 'shared' | i18n }}"
                   aria-hidden="true"
@@ -71,7 +71,7 @@
               </ng-container>
               <ng-container *ngIf="r.hasAttachments">
                 <i
-                  class="bwi bwi-paperclip"
+                  class="bwi bwi-paperclip tw-ml-1"
                   appStopProp
                   title="{{ 'attachments' | i18n }}"
                   aria-hidden="true"

--- a/apps/web/src/app/dirt/reports/pages/weak-passwords-report.component.html
+++ b/apps/web/src/app/dirt/reports/pages/weak-passwords-report.component.html
@@ -62,7 +62,7 @@
             </ng-template>
             <ng-container *ngIf="!organization && row.organizationId">
               <i
-                class="bwi bwi-collection-shared"
+                class="bwi bwi-collection-shared tw-ml-1"
                 appStopProp
                 title="{{ 'shared' | i18n }}"
                 aria-hidden="true"
@@ -71,7 +71,7 @@
             </ng-container>
             <ng-container *ngIf="row.hasAttachments">
               <i
-                class="bwi bwi-paperclip"
+                class="bwi bwi-paperclip tw-ml-1"
                 appStopProp
                 title="{{ 'attachments' | i18n }}"
                 aria-hidden="true"


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

Added tw-ml-1 class to shared (bwi-collection-shared) and attachment (bwi-paperclip) icons in report tables to add spacing between the item name and icons.

Affected reports:
- Weak passwords
- Exposed passwords
- Reused passwords
- Unsecured websites
- Inactive two-factor
- Emergency access view

## 📸 Screenshots

Added spacing:
<img width="1274" height="958" alt="image" src="https://github.com/user-attachments/assets/18e8c693-3140-47bb-9200-4840e4e59aee" />


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
