### PR TITLE
[CL-961] feat(components): improve submenu support

### DIFF
--- a/libs/components/src/chip-select/chip-select.component.ts
+++ b/libs/components/src/chip-select/chip-select.component.ts
@@ -126,7 +126,7 @@ export class ChipSelectComponent<T = unknown> implements ControlValueAccessor {
       // Note: `isOpen` is intentionally accessed outside signal tracking (via `trigger?.isOpen`)
       // to avoid re-focusing when the menu state changes. We only want to focus during
       // submenu navigation, not on initial open/close.
-      if (items.length > 0 && trigger?.isOpen) {
+      if (items.length > 0 && trigger?.isOpen()) {
         currentMenu?.keyManager?.setFirstItemActive();
       }
     });

--- a/libs/components/src/menu/index.ts
+++ b/libs/components/src/menu/index.ts
@@ -3,3 +3,4 @@ export * from "./menu.component";
 export * from "./menu-trigger-for.directive";
 export * from "./menu-item.component";
 export * from "./menu-divider.component";
+export * from "./menu-positions";

--- a/libs/components/src/menu/menu-positions.ts
+++ b/libs/components/src/menu/menu-positions.ts
@@ -1,0 +1,87 @@
+import { ConnectedPosition } from "@angular/cdk/overlay";
+
+export type MenuPositionIdentifier =
+  | "below-left"
+  | "below-right"
+  | "above-left"
+  | "above-right"
+  | "right-top"
+  | "right-bottom"
+  | "left-top"
+  | "left-bottom";
+
+export interface MenuPosition extends ConnectedPosition {
+  id: MenuPositionIdentifier;
+}
+
+export const menuPositions: MenuPosition[] = [
+  /**
+   * The order of these positions matters. The Menu component will use
+   * the first position that fits within the viewport.
+   */
+
+  // Menu opens below trigger, aligned to left edge
+  {
+    id: "below-left",
+    originX: "start",
+    originY: "bottom",
+    overlayX: "start",
+    overlayY: "top",
+  },
+  // Menu opens below trigger, aligned to right edge
+  {
+    id: "below-right",
+    originX: "end",
+    originY: "bottom",
+    overlayX: "end",
+    overlayY: "top",
+  },
+  // Menu opens above trigger, aligned to left edge
+  {
+    id: "above-left",
+    originX: "start",
+    originY: "top",
+    overlayX: "start",
+    overlayY: "bottom",
+  },
+  // Menu opens above trigger, aligned to right edge
+  {
+    id: "above-right",
+    originX: "end",
+    originY: "top",
+    overlayX: "end",
+    overlayY: "bottom",
+  },
+  // Menu opens to right of trigger, aligned to top edge (for submenus)
+  {
+    id: "right-top",
+    originX: "end",
+    originY: "top",
+    overlayX: "start",
+    overlayY: "top",
+  },
+  // Menu opens to right of trigger, aligned to bottom edge (for submenus)
+  {
+    id: "right-bottom",
+    originX: "end",
+    originY: "bottom",
+    overlayX: "start",
+    overlayY: "bottom",
+  },
+  // Menu opens to left of trigger, aligned to top edge (for submenus)
+  {
+    id: "left-top",
+    originX: "start",
+    originY: "top",
+    overlayX: "end",
+    overlayY: "top",
+  },
+  // Menu opens to left of trigger, aligned to bottom edge (for submenus)
+  {
+    id: "left-bottom",
+    originX: "start",
+    originY: "bottom",
+    overlayX: "end",
+    overlayY: "bottom",
+  },
+];


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/CL-961

## 📔 Objective

Improve nested bit menu components:

- add a preferred position input (similar to `bit-tooltip`), so that new nested menus open to the right
- add a `disableClose` input, so that parent menus stay open when opening a nested menu
- propagate menu close to parent menus

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
