### PR TITLE
approach 1 of handling dialog close from menu item trigger

### DIFF
--- a/apps/web/src/app/vault/components/vault-item-dialog/vault-item-dialog.component.ts
+++ b/apps/web/src/app/vault/components/vault-item-dialog/vault-item-dialog.component.ts
@@ -49,6 +49,7 @@ import {
   ItemModule,
   ToastService,
   CenterPositionStrategy,
+  DialogConfig,
 } from "@bitwarden/components";
 import {
   AttachmentDialogCloseResult,
@@ -667,10 +668,15 @@ export class VaultItemDialogComponent implements OnInit, OnDestroy {
    * @param dialogService
    * @param params
    */
-  static open(dialogService: DialogService, params: VaultItemDialogParams) {
+  static open(
+    dialogService: DialogService,
+    params: VaultItemDialogParams,
+    dialogConfig?: DialogConfig,
+  ) {
     return dialogService.open<VaultItemDialogResult, VaultItemDialogParams>(
       VaultItemDialogComponent,
       {
+        ...dialogConfig,
         data: params,
       },
     );

--- a/apps/web/src/app/vault/individual-vault/vault-header/vault-header.component.ts
+++ b/apps/web/src/app/vault/individual-vault/vault-header/vault-header.component.ts
@@ -1,5 +1,12 @@
 import { CommonModule } from "@angular/common";
-import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from "@angular/core";
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+  viewChild,
+} from "@angular/core";
 import { Router } from "@angular/router";
 import { firstValueFrom, switchMap } from "rxjs";
 
@@ -55,6 +62,9 @@ export class VaultHeaderComponent {
   protected All = All;
   protected CollectionDialogTabType = CollectionDialogTabType;
   protected CipherType = CipherType;
+
+  /** Query for the NewCipherMenuComponent in the template */
+  readonly newCipherMenu = viewChild(NewCipherMenuComponent);
 
   /**
    * Boolean to determine the loading state of the header.

--- a/libs/components/src/button/button.component.ts
+++ b/libs/components/src/button/button.component.ts
@@ -148,7 +148,7 @@ export class ButtonComponent implements ButtonLikeAbstraction {
   );
 
   readonly disabled = model<boolean>(false);
-  private el = inject(ElementRef<HTMLButtonElement>);
+  readonly el = inject(ElementRef<HTMLButtonElement>);
 
   constructor() {
     ariaDisableElement(this.el.nativeElement, this.disabledAttr);

--- a/libs/components/src/dialog/dialog.service.ts
+++ b/libs/components/src/dialog/dialog.service.ts
@@ -62,7 +62,7 @@ export abstract class DialogRef<R = unknown, C = unknown> implements Pick<
 
 export type DialogConfig<D = unknown, R = unknown> = Pick<
   CdkDialogConfig<D, R>,
-  "data" | "disableClose" | "ariaModal" | "positionStrategy" | "height" | "width"
+  "data" | "disableClose" | "ariaModal" | "positionStrategy" | "height" | "width" | "restoreFocus"
 >;
 
 /**

--- a/libs/components/src/menu/menu.mdx
+++ b/libs/components/src/menu/menu.mdx
@@ -38,3 +38,8 @@ prior to being clicked and `aria-expanded="true"` after the user clicks the elem
 
 User should be able to navigate the opened menu via the up and down arrow keys and close the menu
 using the escape key or clicking out of the menu.
+
+Are you using a menu item to open a dialog? Be sure to pass the `restoreFocus` config option to the
+`dialog.open` method, specifying where the user's focus should return to upon dialog close. (The
+menu closes when the dialog launches, so the built-in strategy of returning focus to the trigger
+element is not possible, since the trigger element menu item is gone.)

--- a/libs/vault/src/components/add-edit-folder-dialog/add-edit-folder-dialog.component.ts
+++ b/libs/vault/src/components/add-edit-folder-dialog/add-edit-folder-dialog.component.ts
@@ -32,6 +32,7 @@ import {
   FormFieldModule,
   IconButtonModule,
   ToastService,
+  DialogConfig,
 } from "@bitwarden/components";
 import { KeyService } from "@bitwarden/key-management";
 
@@ -175,10 +176,17 @@ export class AddEditFolderDialogComponent implements AfterViewInit, OnInit {
     this.dialogRef.close(result);
   }
 
-  static open(dialogService: DialogService, data?: AddEditFolderDialogData) {
+  static open(
+    dialogService: DialogService,
+    data?: AddEditFolderDialogData,
+    dialogConfig?: DialogConfig,
+  ) {
     return dialogService.open<AddEditFolderDialogResult, AddEditFolderDialogData>(
       AddEditFolderDialogComponent,
-      { data },
+      {
+        ...dialogConfig,
+        data,
+      },
     );
   }
 }

--- a/libs/vault/src/components/new-cipher-menu/new-cipher-menu.component.html
+++ b/libs/vault/src/components/new-cipher-menu/new-cipher-menu.component.html
@@ -7,6 +7,7 @@
       [bitMenuTriggerFor]="addOptions"
       id="newItemDropdown"
       [appA11yTitle]="'new' | i18n"
+      #newItemDropdown
     >
       <i class="bwi bwi-plus" aria-hidden="true"></i>
       {{ "new" | i18n }}

--- a/libs/vault/src/components/new-cipher-menu/new-cipher-menu.component.ts
+++ b/libs/vault/src/components/new-cipher-menu/new-cipher-menu.component.ts
@@ -1,12 +1,12 @@
 import { CommonModule } from "@angular/common";
-import { Component, input, output } from "@angular/core";
+import { Component, input, output, viewChild } from "@angular/core";
 import { map, shareReplay } from "rxjs";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { CipherType } from "@bitwarden/common/vault/enums";
 import { RestrictedItemTypesService } from "@bitwarden/common/vault/services/restricted-item-types.service";
 import { CIPHER_MENU_ITEMS } from "@bitwarden/common/vault/types/cipher-menu-items";
-import { ButtonModule, MenuModule } from "@bitwarden/components";
+import { ButtonComponent, ButtonModule, MenuModule } from "@bitwarden/components";
 import { I18nPipe } from "@bitwarden/ui-common";
 
 // FIXME(https://bitwarden.atlassian.net/browse/CL-764): Migrate to OnPush
@@ -32,6 +32,8 @@ export class NewCipherMenuComponent {
   folderAdded = output();
   collectionAdded = output();
   cipherAdded = output<CipherType>();
+
+  readonly newCipherButton = viewChild<ButtonComponent>("newItemDropdown");
 
   constructor(private restrictedItemTypesService: RestrictedItemTypesService) {}
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

approach for handling dialog close when the dialog is opened from a menu item, which disappears once the dialog is opened. this pr puts focus back to the parent menu trigger element (i.e. a menu is opened attached to a button, so that button becomes the new focus target). as a POC this pr does this only for the New menu on the vault page 

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
