### PR TITLE
PM-29926: Improve SSH agent approval dialog UX

### DIFF
--- a/apps/desktop/src/platform/components/approve-ssh-request.html
+++ b/apps/desktop/src/platform/components/approve-ssh-request.html
@@ -13,10 +13,16 @@
       {{ "sshkeyApprovalMessageSuffix" | i18n }} {{ params.action | i18n }}
     </div>
     <ng-container bitDialogFooter>
-      <button type="submit" bitButton bitFormButton buttonType="primary">
+      <button
+        type="submit"
+        bitButton
+        bitFormButton
+        buttonType="primary"
+        [disabled]="!authorizeEnabled"
+      >
         <span>{{ "authorize" | i18n }}</span>
       </button>
-      <button type="button" bitButton bitFormButton buttonType="secondary" bitDialogClose>
+      <button type="button" bitButton bitFormButton buttonType="secondary" (click)="deny()">
         {{ "deny" | i18n }}
       </button>
     </ng-container>

--- a/apps/desktop/src/platform/components/approve-ssh-request.ts
+++ b/apps/desktop/src/platform/components/approve-ssh-request.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from "@angular/common";
-import { Component, Inject } from "@angular/core";
+import { Component, Inject, OnInit } from "@angular/core";
 import { FormBuilder, ReactiveFormsModule } from "@angular/forms";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
@@ -39,14 +39,23 @@ export interface ApproveSshRequestParams {
     CalloutModule,
   ],
 })
-export class ApproveSshRequestComponent {
+export class ApproveSshRequestComponent implements OnInit {
   approveSshRequestForm = this.formBuilder.group({});
+  authorizeEnabled = false;
+
+  private static readonly AUTHORIZE_DELAY_MS = 1500;
 
   constructor(
     @Inject(DIALOG_DATA) protected params: ApproveSshRequestParams,
     private dialogRef: DialogRef<boolean>,
     private formBuilder: FormBuilder,
   ) {}
+
+  ngOnInit(): void {
+    setTimeout(() => {
+      this.authorizeEnabled = true;
+    }, ApproveSshRequestComponent.AUTHORIZE_DELAY_MS);
+  }
 
   static open(
     dialogService: DialogService,
@@ -69,10 +78,15 @@ export class ApproveSshRequestComponent {
         isAgentForwarding,
         action: actioni18nKey,
       },
+      disableClose: true,
     });
   }
 
   submit = async () => {
     this.dialogRef.close(true);
   };
+
+  deny(): void {
+    this.dialogRef.close(false);
+  }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-29926

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

Improve the SSH agent approval dialog UX to prevent accidental authorization or denial when the popup appears unexpectedly (e.g., during script execution or while clicking elsewhere).

  1. Prevent backdrop dismissal: The dialog can no longer be closed by clicking outside of it (disableClose: true). Users must explicitly click "Authorize" or "Deny".
  2. Authorization delay: The "Authorize" button is disabled for 1.5 seconds after the dialog appears, preventing accidental clicks when the dialog pops up unexpectedly.
  3. Fix Deny button: Changed from bitDialogClose directive to explicit deny() method to ensure the dialog properly closes with false result. Because we twaeked thes close param on the modal, seems we need to close it programmatically.


## 📸 Screenshots

Unfortunately the click and keyboard events didn't make it in to the video, but I was clicking the background etc.

https://share.cleanshot.com/3hsLrqrZ
<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

##  Testing

Testing ssh is a bit finicky, here's what I did:

  1. Enable SSH Agent in Settings
  2. Add an SSH key to your vault
  3. Trigger a signing request: echo "test" | SSH_AUTH_SOCK=~/.bitwarden-ssh-agent.sock ssh-keygen -Y sign -f <pubkey> -n test
  4. Verify:
    - Clicking outside the dialog does not close it
    - "Authorize" button is grayed out for ~1.5 seconds
    - Both "Authorize" and "Deny" buttons work correctly


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
