### PR TITLE
[PM-29935] Integrations connection dialogs - delete button text

### DIFF
--- a/bitwarden_license/bit-web/src/app/dirt/organization-integrations/integration-dialog/connect-dialog/connect-dialog-datadog.component.html
+++ b/bitwarden_license/bit-web/src/app/dirt/organization-integrations/integration-dialog/connect-dialog/connect-dialog-datadog.component.html
@@ -47,8 +47,8 @@
             bitIconButton="bwi-trash"
             type="button"
             buttonType="danger"
-            label="'delete' | i18n"
-            [appA11yTitle]="'delete' | i18n"
+            label="{{ 'delete' | i18n }}"
+            appA11yTitle="{{ 'delete' | i18n }}"
             [bitAction]="delete"
           ></button>
         </div>

--- a/bitwarden_license/bit-web/src/app/dirt/organization-integrations/integration-dialog/connect-dialog/connect-dialog-hec.component.html
+++ b/bitwarden_license/bit-web/src/app/dirt/organization-integrations/integration-dialog/connect-dialog/connect-dialog-hec.component.html
@@ -53,8 +53,8 @@
             bitIconButton="bwi-trash"
             type="button"
             buttonType="danger"
-            label="'delete' | i18n"
-            [appA11yTitle]="'delete' | i18n"
+            label="{{ 'delete' | i18n }}"
+            appA11yTitle="{{ 'delete' | i18n }}"
             [bitAction]="delete"
           ></button>
         </div>


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-29935

## 📔 Objective

The delete button had text that didn't pipe through i18 pipe.
This has been fixed as seen in the screen shots below.

## 📸 Screenshots

### Original Issue
<img width="976" height="771" alt="image" src="https://github.com/user-attachments/assets/8772e3f4-4fdd-447a-88b4-c08ab353e54e" />

### Resolved to
<img width="976" height="771" alt="image" src="https://github.com/user-attachments/assets/a0d9e264-1ba4-4f6e-ab5e-f1c630850fad" />


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
