### PR TITLE
[PM-29278] correct virtual scroll rowSize for reports

### DIFF
--- a/apps/web/src/app/dirt/reports/pages/exposed-passwords-report.component.html
+++ b/apps/web/src/app/dirt/reports/pages/exposed-passwords-report.component.html
@@ -26,7 +26,7 @@
           </bit-toggle>
         </ng-container>
       </bit-toggle-group>
-      <bit-table-scroll [dataSource]="dataSource" [rowSize]="53">
+      <bit-table-scroll [dataSource]="dataSource" [rowSize]="75">
         <ng-container header>
           <th bitCell></th>
           <th bitCell bitSortable="name">{{ "name" | i18n }}</th>

--- a/apps/web/src/app/dirt/reports/pages/weak-passwords-report.component.html
+++ b/apps/web/src/app/dirt/reports/pages/weak-passwords-report.component.html
@@ -31,7 +31,7 @@
           </bit-toggle>
         </ng-container>
       </bit-toggle-group>
-      <bit-table-scroll [dataSource]="dataSource" [rowSize]="53">
+      <bit-table-scroll [dataSource]="dataSource" [rowSize]="75">
         <ng-container header>
           <th bitCell></th>
           <th bitCell bitSortable="name">{{ "name" | i18n }}</th>


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-29278

## 📔 Objective

The Exposed Passwords and Weak Passwords reports were using an incorrect rowSize value (53px instead of 75px) for their virtual scroll tables. This caused the \"Back to reports\" button to collide with table entries.

This fix aligns both reports with the Reused Passwords report which [correctly uses 75px](https://github.com/bitwarden/clients/blob/39bc4fb789e48707759426007db5023d3ecfd59d/apps/web/src/app/dirt/reports/pages/reused-passwords-report.component.html#L36) for identical row structures.

## 📸 Screenshots

Before:
<img width="1280" height="606" alt="image" src="https://github.com/user-attachments/assets/1e61a46f-b283-4c13-b883-7a97c5339dd9" />

After:
<img width="1110" height="580" alt="image" src="https://github.com/user-attachments/assets/9ea0a2f0-7734-4153-b79d-8b835aa81a9d" />


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
