### PR TITLE
[PM-30141] Fix page height and a11y by removing extra <main>

### DIFF
--- a/apps/browser/src/tools/popup/send-v2/send-created/send-created.component.html
+++ b/apps/browser/src/tools/popup/send-v2/send-created/send-created.component.html
@@ -1,39 +1,37 @@
-<main class="tw-top-0">
-  <popup-page>
-    <popup-header
-      slot="header"
-      [pageTitle]="'createdSend' | i18n"
-      showBackButton
-      [backAction]="goToEditSend.bind(this)"
-    >
-      <ng-container slot="end">
-        <app-pop-out></app-pop-out>
-      </ng-container>
-    </popup-header>
+<popup-page>
+  <popup-header
+    slot="header"
+    [pageTitle]="'createdSend' | i18n"
+    showBackButton
+    [backAction]="goToEditSend.bind(this)"
+  >
+    <ng-container slot="end">
+      <app-pop-out></app-pop-out>
+    </ng-container>
+  </popup-header>
 
-    <div
-      class="tw-flex tw-bg-background-alt tw-flex-col tw-justify-center tw-items-center tw-gap-2 tw-h-full tw-px-5"
-    >
-      <div class="tw-size-[95px] tw-content-center">
-        <bit-icon [icon]="sendCreatedIcon"></bit-icon>
-      </div>
-      <h3 tabindex="0" appAutofocus class="tw-font-medium">
-        {{ "createdSendSuccessfully" | i18n }}
-      </h3>
-      <p class="tw-text-center">
-        {{ formatExpirationDate() }}
-      </p>
-      <button bitButton type="button" buttonType="primary" (click)="copyLink()">
-        <b>{{ "copyLink" | i18n }}</b>
-      </button>
+  <div
+    class="tw-flex tw-bg-background-alt tw-flex-col tw-justify-center tw-items-center tw-gap-2 tw-h-full tw-px-5"
+  >
+    <div class="tw-size-[95px] tw-content-center">
+      <bit-icon [icon]="sendCreatedIcon"></bit-icon>
     </div>
-    <popup-footer slot="footer">
-      <button bitButton type="button" buttonType="primary" (click)="copyLink()">
-        <b>{{ "copyLink" | i18n }}</b>
-      </button>
-      <button bitButton type="button" buttonType="secondary" (click)="goBack()">
-        {{ "close" | i18n }}
-      </button>
-    </popup-footer>
-  </popup-page>
-</main>
+    <h3 tabindex="0" appAutofocus class="tw-font-medium">
+      {{ "createdSendSuccessfully" | i18n }}
+    </h3>
+    <p class="tw-text-center">
+      {{ formatExpirationDate() }}
+    </p>
+    <button bitButton type="button" buttonType="primary" (click)="copyLink()">
+      <b>{{ "copyLink" | i18n }}</b>
+    </button>
+  </div>
+  <popup-footer slot="footer">
+    <button bitButton type="button" buttonType="primary" (click)="copyLink()">
+      <b>{{ "copyLink" | i18n }}</b>
+    </button>
+    <button bitButton type="button" buttonType="secondary" (click)="goBack()">
+      {{ "close" | i18n }}
+    </button>
+  </popup-footer>
+</popup-page>


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[PM-30141](https://bitwarden.atlassian.net/browse/PM-30141)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
The sends created page was not filling the height of the extension. The cause was an extra `main` element wrapping the `popup-page` inside the sends created component, which was breaking the height inheritance and also causing an a11y violation because the `popup-page` already has a `main` region specified. Removing this wrapper element fixes both issues. This issue may have been brought to light by the removal of legacy global css in the browser, which was merged fairly recently and has not been released to prod yet.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
| Before | After |
|--------|--------|
| <img width="384" height="608" alt="Screenshot 2025-12-23 at 10 40 03 AM" src="https://github.com/user-attachments/assets/af554765-3e02-4e09-989e-6f25b140157c" /> | <img width="384" height="608" alt="Screenshot 2025-12-23 at 10 37 38 AM" src="https://github.com/user-attachments/assets/642bf634-0203-424a-b542-f6f5b91ef4c0" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-30141]: https://bitwarden.atlassian.net/browse/PM-30141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ