### PR TITLE
[CL-822] fix popover initial position

### DIFF
--- a/libs/components/src/popover/popover-trigger-for.directive.spec.ts
+++ b/libs/components/src/popover/popover-trigger-for.directive.spec.ts
@@ -208,16 +208,19 @@ describe("PopoverTriggerForDirective", () => {
       });
       fixture.detectChanges();
 
-      // Click before RAF completes
+      // Click to close before RAF completes - this should cancel the RAF and prevent overlay creation
       const button = fixture.nativeElement.querySelector("button");
       button.click();
       fixture.detectChanges();
 
+      // Verify popoverOpen was set to false
+      expect(directive.popoverOpen()).toBe(false);
+
       tick(16);
       tick(16);
 
-      // Should only create one overlay
-      expect(overlay.create).toHaveBeenCalledTimes(1);
+      // Should NOT have created any overlay because RAF was canceled
+      expect(overlay.create).not.toHaveBeenCalled();
 
       flush();
     }));

--- a/libs/components/src/popover/popover-trigger-for.directive.ts
+++ b/libs/components/src/popover/popover-trigger-for.directive.ts
@@ -146,7 +146,7 @@ export class PopoverTriggerForDirective implements OnDestroy {
   }
 
   private destroyPopover() {
-    if (!this.overlayRef || !this.popoverOpen()) {
+    if (!this.popoverOpen()) {
       return;
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/CL-822

## 📔 Objective
- fix positioning issues caused when popovers are open by default

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
