### PR TITLE
Fixed date initialization on test

### DIFF
--- a/libs/auth/src/angular/login-decryption-options/login-decryption-options.component.spec.ts
+++ b/libs/auth/src/angular/login-decryption-options/login-decryption-options.component.spec.ts
@@ -107,7 +107,7 @@ describe("LoginDecryptionOptionsComponent", () => {
       email: mockEmail,
       name: "Test User",
       emailVerified: true,
-      creationDate: new Date().toISOString(),
+      creationDate: new Date(),
     });
     platformUtilsService.getClientType.mockReturnValue(ClientType.Browser);
     deviceTrustService.getShouldTrustDevice.mockResolvedValue(true);


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-29545

## 📔 Objective

#17928 didn't account for a new initialization of the `creationDate` that was added with #17831, which was initializing it to a `string`.

I neglected to merge `main` in before merging my branch, causing this test to fail.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
