### PR TITLE
Remove notification on inactive and locked user feature flags

### DIFF
--- a/libs/common/src/enums/feature-flag.enum.ts
+++ b/libs/common/src/enums/feature-flag.enum.ts
@@ -70,8 +70,6 @@ export enum FeatureFlag {
 
   /* Platform */
   IpcChannelFramework = "ipc-channel-framework",
-  InactiveUserServerNotification = "pm-25130-receive-push-notifications-for-inactive-users",
-  PushNotificationsWhenLocked = "pm-19388-push-notifications-when-locked",
 
   /* Innovation */
   PM19148_InnovationArchive = "pm-19148-innovation-archive",
@@ -157,8 +155,6 @@ export const DefaultFeatureFlagValue = {
 
   /* Platform */
   [FeatureFlag.IpcChannelFramework]: FALSE,
-  [FeatureFlag.InactiveUserServerNotification]: FALSE,
-  [FeatureFlag.PushNotificationsWhenLocked]: FALSE,
 
   /* Innovation */
   [FeatureFlag.PM19148_InnovationArchive]: FALSE,

--- a/libs/common/src/platform/server-notifications/internal/default-server-notifications.multiuser.spec.ts
+++ b/libs/common/src/platform/server-notifications/internal/default-server-notifications.multiuser.spec.ts
@@ -5,7 +5,6 @@ import { BehaviorSubject, bufferCount, firstValueFrom, Subject, ObservedValueOf 
 import { LogoutReason } from "@bitwarden/auth/common";
 import { InternalPolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
 import { AuthRequestAnsweringServiceAbstraction } from "@bitwarden/common/auth/abstractions/auth-request-answering/auth-request-answering.service.abstraction";
-import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 
 import { mockAccountInfoWith } from "../../../../spec";
 import { AccountService } from "../../../auth/abstractions/account.service";
@@ -129,15 +128,6 @@ describe("DefaultServerNotificationsService (multi-user)", () => {
     });
 
     authRequestAnsweringService = mock<AuthRequestAnsweringServiceAbstraction>();
-
-    configService = mock<ConfigService>();
-    configService.getFeatureFlag$.mockImplementation((flag: FeatureFlag) => {
-      const flagValueByFlag: Partial<Record<FeatureFlag, boolean>> = {
-        [FeatureFlag.InactiveUserServerNotification]: true,
-        [FeatureFlag.PushNotificationsWhenLocked]: true,
-      };
-      return new BehaviorSubject(flagValueByFlag[flag] ?? false) as any;
-    });
 
     policyService = mock<InternalPolicyService>();
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-29983

## 📔 Objective

Removes the feature flags for adding notifications for locked and inactive users:

- `pm-19388-push-notifications-when-locked`
- `pm-25130-receive-push-notifications-for-inactive-users`

This required changing the observables in the `DefaultServerNotificationService` to remove the conditional for the feature flag check.

Both of these feature flags have been set to 100% rollout in all environments.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
