### PR TITLE
[PM-30265] fix(browser): improve Beta badge alignment in Compact mode checkbox

### DIFF
--- a/apps/browser/src/vault/popup/settings/appearance-v2.component.html
+++ b/apps/browser/src/vault/popup/settings/appearance-v2.component.html
@@ -25,10 +25,10 @@
 
       <bit-form-control>
         <input bitCheckbox formControlName="enableCompactMode" type="checkbox" />
-        <bit-label
-          >{{ "compactMode" | i18n }}
-          <span bitBadge variant="warning">{{ "beta" | i18n }}</span></bit-label
-        >
+        <bit-label>
+          {{ "compactMode" | i18n }}
+          <span bitBadge class="tw-ml-1" variant="warning">{{ "beta" | i18n }}</span>
+        </bit-label>
       </bit-form-control>
 
       <bit-form-control>


### PR DESCRIPTION
## Summary
- Add horizontal spacing (tw-ml-1) between 'Compact mode' text and Beta badge for better visual alignment

Fixes #17810

## Test plan
- Open browser extension Settings > Appearance
- Verify Beta badge next to "Compact mode" has proper spacing from text