### PR TITLE
fix(desktop): restore explicit target to Linux builds

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -255,7 +255,7 @@ jobs:
         # Note: It is important that we use the release build because some compute heavy
         # operations such as key derivation for oo7 on linux are too slow in debug mode
         run: |
-          node build.js --release
+          node build.js --target=x86_64-unknown-linux-gnu --release
 
       - name: Build application
         run: npm run dist:lin
@@ -418,7 +418,7 @@ jobs:
         # Note: It is important that we use the release build because some compute heavy
         # operations such as key derivation for oo7 on linux are too slow in debug mode
         run: |
-          node build.js --release
+          node build.js --target=aarch64-unknown-linux-gnu --release
 
       - name: Check index.d.ts generated
         if: github.event_name == 'pull_request' && steps.cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-30353

## 📔 Objective

Commit a3e654d (https://github.com/bitwarden/clients/pull/16053) removed explicit --target flags from the Linux desktop build workflow when removing musl support. This change inadvertently broke the build.js binary distribution logic, which only copies the desktop_proxy binary to the dist directory when an explicit target is specified. Without this binary in the expected location (/opt/Bitwarden/desktop_proxy), browser integration fails on Linux.

This fix restores explicit --target flags using gnu triplets instead of the previously removed musl triplets. The x64 build now uses --target=x86_64-unknown-linux-gnu and the arm64 build uses --target=aarch64-unknown-linux-gnu, ensuring build.js properly distributes the desktop_proxy binary and restoring browser integration functionality on Linux desktop.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
