### PR TITLE
[PM-30397] [BEEEP] Refactor automatic start on login into its own service

### DIFF
--- a/apps/desktop/src/app/accounts/settings.component.ts
+++ b/apps/desktop/src/app/accounts/settings.component.ts
@@ -66,6 +66,7 @@ import { SshAgentPromptType } from "../../autofill/models/ssh-agent-setting";
 import { DesktopAutofillSettingsService } from "../../autofill/services/desktop-autofill-settings.service";
 import { DesktopAutotypeService } from "../../autofill/services/desktop-autotype.service";
 import { DesktopBiometricsService } from "../../key-management/biometrics/desktop.biometrics.service";
+import { AutoStartService } from "../../platform/auto-start";
 import { DesktopSettingsService } from "../../platform/services/desktop-settings.service";
 import { DesktopPremiumUpgradePromptService } from "../../services/desktop-premium-upgrade-prompt.service";
 import { NativeMessagingManifestService } from "../services/native-messaging-manifest.service";
@@ -220,6 +221,7 @@ export class SettingsComponent implements OnInit, OnDestroy {
     private changeDetectorRef: ChangeDetectorRef,
     private toastService: ToastService,
     private billingAccountProfileStateService: BillingAccountProfileStateService,
+    private autoStartService: AutoStartService,
   ) {
     this.isMac = this.platformUtilsService.getDevice() === DeviceType.MacOsDesktop;
     this.isLinux = this.platformUtilsService.getDevice() === DeviceType.LinuxDesktop;
@@ -244,7 +246,9 @@ export class SettingsComponent implements OnInit, OnDestroy {
     this.startToTrayText = this.i18nService.t(startToTrayKey);
     this.startToTrayDescText = this.i18nService.t(startToTrayKey + "Desc");
 
-    this.showOpenAtLoginOption = !ipc.platform.isWindowsStore;
+    // Only show the auto-start setting if it's supported on this platform.
+    // The service handles platform-specific checks (Windows Store, Snap, etc.)
+    this.showOpenAtLoginOption = this.autoStartService.shouldDisplaySetting();
 
     // DuckDuckGo browser is only for macos initially
     this.showDuckDuckGoIntegrationOption = this.isMac;

--- a/apps/desktop/src/app/accounts/settings.component.ts
+++ b/apps/desktop/src/app/accounts/settings.component.ts
@@ -66,7 +66,6 @@ import { SshAgentPromptType } from "../../autofill/models/ssh-agent-setting";
 import { DesktopAutofillSettingsService } from "../../autofill/services/desktop-autofill-settings.service";
 import { DesktopAutotypeService } from "../../autofill/services/desktop-autotype.service";
 import { DesktopBiometricsService } from "../../key-management/biometrics/desktop.biometrics.service";
-import { AutoStartService } from "../../platform/auto-start";
 import { DesktopSettingsService } from "../../platform/services/desktop-settings.service";
 import { DesktopPremiumUpgradePromptService } from "../../services/desktop-premium-upgrade-prompt.service";
 import { NativeMessagingManifestService } from "../services/native-messaging-manifest.service";
@@ -221,7 +220,6 @@ export class SettingsComponent implements OnInit, OnDestroy {
     private changeDetectorRef: ChangeDetectorRef,
     private toastService: ToastService,
     private billingAccountProfileStateService: BillingAccountProfileStateService,
-    private autoStartService: AutoStartService,
   ) {
     this.isMac = this.platformUtilsService.getDevice() === DeviceType.MacOsDesktop;
     this.isLinux = this.platformUtilsService.getDevice() === DeviceType.LinuxDesktop;
@@ -247,8 +245,8 @@ export class SettingsComponent implements OnInit, OnDestroy {
     this.startToTrayDescText = this.i18nService.t(startToTrayKey + "Desc");
 
     // Only show the auto-start setting if it's supported on this platform.
-    // The service handles platform-specific checks (Windows Store, Snap, etc.)
-    this.showOpenAtLoginOption = this.autoStartService.shouldDisplaySetting();
+    // Windows Store apps and Snap packages don't support user-configurable auto-start.
+    this.showOpenAtLoginOption = this.desktopSettingsService.shouldDisplayAutoStartSetting();
 
     // DuckDuckGo browser is only for macos initially
     this.showDuckDuckGoIntegrationOption = this.isMac;

--- a/apps/desktop/src/app/accounts/settings.component.ts
+++ b/apps/desktop/src/app/accounts/settings.component.ts
@@ -245,7 +245,6 @@ export class SettingsComponent implements OnInit, OnDestroy {
     this.startToTrayDescText = this.i18nService.t(startToTrayKey + "Desc");
 
     // Only show the auto-start setting if it's supported on this platform.
-    // Windows Store apps and Snap packages don't support user-configurable auto-start.
     this.showOpenAtLoginOption = this.desktopSettingsService.shouldDisplayAutoStartSetting();
 
     // DuckDuckGo browser is only for macos initially

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -222,7 +222,10 @@ export class Main {
       this.mainCryptoFunctionService,
     );
 
-    this.autoStartService = new DefaultAutoStartService(this.logService);
+    this.autoStartService = new DefaultAutoStartService(
+      this.logService,
+      this.desktopSettingsService,
+    );
     this.messagingMain = new MessagingMain(
       this,
       this.desktopSettingsService,

--- a/apps/desktop/src/platform/auto-start/auto-start.service.abstraction.ts
+++ b/apps/desktop/src/platform/auto-start/auto-start.service.abstraction.ts
@@ -31,12 +31,4 @@ export abstract class AutoStartService {
    * @returns The auto-start status: `Enabled`, `Disabled`, or `Unknown` if the state cannot be determined.
    */
   abstract isEnabled(): Promise<AutoStartStatus>;
-
-  /**
-   * Determines whether the auto-start setting should be displayed in the application UI.
-   * Some platforms (e.g., Snap) manage auto-start externally via package configuration,
-   * so the setting should be hidden from the user.
-   * @returns `true` if the setting should be shown, `false` if it should be hidden.
-   */
-  abstract shouldDisplaySetting(): boolean;
 }

--- a/apps/desktop/src/platform/auto-start/auto-start.service.abstraction.ts
+++ b/apps/desktop/src/platform/auto-start/auto-start.service.abstraction.ts
@@ -1,0 +1,42 @@
+/**
+ * Represents the state of the auto-start configuration.
+ */
+export const AutoStartStatus = {
+  /** Auto-start is enabled */
+  Enabled: "enabled",
+  /** Auto-start is disabled */
+  Disabled: "disabled",
+  /** Auto-start state cannot be determined (e.g., Flatpak/Snap) */
+  Unknown: "unknown",
+} as const;
+
+export type AutoStartStatus = (typeof AutoStartStatus)[keyof typeof AutoStartStatus];
+
+/**
+ * Service for managing the application's auto-start behavior at system login.
+ */
+export abstract class AutoStartService {
+  /**
+   * Enables the application to automatically start when the user logs into their system.
+   */
+  abstract enable(): Promise<void>;
+
+  /**
+   * Disables the application from automatically starting when the user logs into their system.
+   */
+  abstract disable(): Promise<void>;
+
+  /**
+   * Checks whether the application is currently configured to start at login.
+   * @returns The auto-start status: `Enabled`, `Disabled`, or `Unknown` if the state cannot be determined.
+   */
+  abstract isEnabled(): Promise<AutoStartStatus>;
+
+  /**
+   * Determines whether the auto-start setting should be displayed in the application UI.
+   * Some platforms (e.g., Snap) manage auto-start externally via package configuration,
+   * so the setting should be hidden from the user.
+   * @returns `true` if the setting should be shown, `false` if it should be hidden.
+   */
+  abstract shouldDisplaySetting(): boolean;
+}

--- a/apps/desktop/src/platform/auto-start/auto-start.service.spec.ts
+++ b/apps/desktop/src/platform/auto-start/auto-start.service.spec.ts
@@ -1,0 +1,352 @@
+import * as fs from "fs";
+import * as path from "path";
+
+import { app } from "electron";
+import { mock, MockProxy } from "jest-mock-extended";
+
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+import { autostart } from "@bitwarden/desktop-napi";
+
+import * as utils from "../../utils";
+
+import { DefaultAutoStartService } from "./auto-start.service";
+import { AutoStartStatus } from "./auto-start.service.abstraction";
+
+// Mock modules
+jest.mock("fs");
+jest.mock("electron", () => ({
+  app: {
+    getVersion: jest.fn(),
+    getPath: jest.fn(),
+    setLoginItemSettings: jest.fn(),
+    getLoginItemSettings: jest.fn(),
+  },
+}));
+jest.mock("@bitwarden/desktop-napi", () => ({
+  autostart: {
+    setAutostart: jest.fn(),
+  },
+}));
+jest.mock("../../utils", () => ({
+  isFlatpak: jest.fn(),
+  isSnapStore: jest.fn(),
+  isWindowsStore: jest.fn(),
+}));
+
+describe("DefaultAutoStartService", () => {
+  let service: DefaultAutoStartService;
+  let logService: MockProxy<LogService>;
+  let originalPlatform: NodeJS.Platform;
+
+  beforeEach(() => {
+    logService = mock<LogService>();
+    service = new DefaultAutoStartService(logService);
+    originalPlatform = process.platform;
+    jest.clearAllMocks();
+
+    // Default mock implementations
+    (app.getVersion as jest.Mock).mockReturnValue("1.0.0");
+    (app.getPath as jest.Mock).mockImplementation((name: string) => {
+      if (name === "exe") {return "/usr/bin/bitwarden";}
+      if (name === "home") {return "/home/user";}
+      return "";
+    });
+    (utils.isFlatpak as jest.Mock).mockReturnValue(false);
+    (utils.isSnapStore as jest.Mock).mockReturnValue(false);
+    (utils.isWindowsStore as jest.Mock).mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, "platform", {
+      value: originalPlatform,
+    });
+  });
+
+  describe("Linux (Flatpak)", () => {
+    beforeEach(() => {
+      Object.defineProperty(process, "platform", {
+        value: "linux",
+      });
+      (utils.isFlatpak as jest.Mock).mockReturnValue(true);
+      (utils.isSnapStore as jest.Mock).mockReturnValue(false);
+    });
+
+    it("should enable autostart using the portal", async () => {
+      (autostart.setAutostart as jest.Mock).mockResolvedValue(undefined);
+
+      await service.enable();
+
+      expect(autostart.setAutostart).toHaveBeenCalledWith(true, []);
+    });
+
+    it("should disable autostart using the portal", async () => {
+      (autostart.setAutostart as jest.Mock).mockResolvedValue(undefined);
+
+      await service.disable();
+
+      expect(autostart.setAutostart).toHaveBeenCalledWith(false, []);
+    });
+
+    it("should handle portal errors gracefully when enabling", async () => {
+      const error = new Error("Portal error");
+      (autostart.setAutostart as jest.Mock).mockRejectedValue(error);
+
+      await service.enable();
+
+      expect(logService.error).toHaveBeenCalledWith(
+        "Failed to enable autostart via portal:",
+        error,
+      );
+    });
+
+    it("should handle portal errors gracefully when disabling", async () => {
+      const error = new Error("Portal error");
+      (autostart.setAutostart as jest.Mock).mockRejectedValue(error);
+
+      await service.disable();
+
+      expect(logService.error).toHaveBeenCalledWith(
+        "Failed to disable autostart via portal:",
+        error,
+      );
+    });
+
+    it("should return Unknown for isEnabled (cannot query portal state)", async () => {
+      const result = await service.isEnabled();
+
+      expect(result).toBe(AutoStartStatus.Unknown);
+    });
+
+    it("should display setting in UI", () => {
+      const result = service.shouldDisplaySetting();
+
+      expect(result).toBe(true);
+    });
+  });
+
+  describe("Linux (Snap)", () => {
+    beforeEach(() => {
+      Object.defineProperty(process, "platform", {
+        value: "linux",
+      });
+      (utils.isFlatpak as jest.Mock).mockReturnValue(false);
+      (utils.isSnapStore as jest.Mock).mockReturnValue(true);
+    });
+
+    it("should not create desktop file when enabling (snap manages autostart)", async () => {
+      await service.enable();
+
+      expect(fs.writeFileSync).not.toHaveBeenCalled();
+      expect(fs.mkdirSync).not.toHaveBeenCalled();
+    });
+
+    it("should not remove desktop file when disabling (snap manages autostart)", async () => {
+      await service.disable();
+
+      expect(fs.unlinkSync).not.toHaveBeenCalled();
+    });
+
+    it("should return Unknown for isEnabled (snap state cannot be queried)", async () => {
+      const result = await service.isEnabled();
+
+      expect(result).toBe(AutoStartStatus.Unknown);
+    });
+
+    it("should hide setting from UI (snap manages autostart)", () => {
+      const result = service.shouldDisplaySetting();
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("Linux (Standard)", () => {
+    beforeEach(() => {
+      Object.defineProperty(process, "platform", {
+        value: "linux",
+      });
+      (utils.isFlatpak as jest.Mock).mockReturnValue(false);
+      (utils.isSnapStore as jest.Mock).mockReturnValue(false);
+    });
+
+    it("should create desktop file when enabling", async () => {
+      (fs.existsSync as jest.Mock).mockReturnValue(true);
+
+      await service.enable();
+
+      const expectedPath = path.join("/home/user", ".config", "autostart", "bitwarden.desktop");
+      const expectedContent = `[Desktop Entry]
+Type=Application
+Version=1.0.0
+Name=Bitwarden
+Comment=Bitwarden startup script
+Exec=/usr/bin/bitwarden
+StartupNotify=false
+Terminal=false`;
+
+      expect(fs.writeFileSync).toHaveBeenCalledWith(expectedPath, expectedContent);
+    });
+
+    it("should create autostart directory if it does not exist", async () => {
+      (fs.existsSync as jest.Mock).mockReturnValue(false);
+
+      await service.enable();
+
+      const expectedDir = path.join("/home/user", ".config", "autostart");
+      expect(fs.mkdirSync).toHaveBeenCalledWith(expectedDir, { recursive: true });
+    });
+
+    it("should remove desktop file when disabling", async () => {
+      (fs.existsSync as jest.Mock).mockReturnValue(true);
+
+      await service.disable();
+
+      const expectedPath = path.join("/home/user", ".config", "autostart", "bitwarden.desktop");
+      expect(fs.unlinkSync).toHaveBeenCalledWith(expectedPath);
+    });
+
+    it("should not throw error when removing non-existent desktop file", async () => {
+      (fs.existsSync as jest.Mock).mockReturnValue(false);
+
+      await expect(service.disable()).resolves.not.toThrow();
+
+      expect(fs.unlinkSync).not.toHaveBeenCalled();
+    });
+
+    it("should return Enabled when desktop file exists", async () => {
+      (fs.existsSync as jest.Mock).mockReturnValue(true);
+
+      const result = await service.isEnabled();
+
+      expect(result).toBe(AutoStartStatus.Enabled);
+      const expectedPath = path.join("/home/user", ".config", "autostart", "bitwarden.desktop");
+      expect(fs.existsSync).toHaveBeenCalledWith(expectedPath);
+    });
+
+    it("should return Disabled when desktop file does not exist", async () => {
+      (fs.existsSync as jest.Mock).mockReturnValue(false);
+
+      const result = await service.isEnabled();
+
+      expect(result).toBe(AutoStartStatus.Disabled);
+    });
+
+    it("should display setting in UI", () => {
+      const result = service.shouldDisplaySetting();
+
+      expect(result).toBe(true);
+    });
+  });
+
+  describe("macOS", () => {
+    beforeEach(() => {
+      Object.defineProperty(process, "platform", {
+        value: "darwin",
+      });
+    });
+
+    it("should enable autostart using Electron API", async () => {
+      await service.enable();
+
+      expect(app.setLoginItemSettings).toHaveBeenCalledWith({ openAtLogin: true });
+    });
+
+    it("should disable autostart using Electron API", async () => {
+      await service.disable();
+
+      expect(app.setLoginItemSettings).toHaveBeenCalledWith({ openAtLogin: false });
+    });
+
+    it("should return Enabled when openAtLogin is enabled", async () => {
+      (app.getLoginItemSettings as jest.Mock).mockReturnValue({
+        openAtLogin: true,
+        openAsHidden: false,
+      });
+
+      const result = await service.isEnabled();
+
+      expect(result).toBe(AutoStartStatus.Enabled);
+    });
+
+    it("should return Disabled when openAtLogin is disabled", async () => {
+      (app.getLoginItemSettings as jest.Mock).mockReturnValue({
+        openAtLogin: false,
+        openAsHidden: false,
+      });
+
+      const result = await service.isEnabled();
+
+      expect(result).toBe(AutoStartStatus.Disabled);
+    });
+
+    it("should display setting in UI", () => {
+      const result = service.shouldDisplaySetting();
+
+      expect(result).toBe(true);
+    });
+  });
+
+  describe("Windows", () => {
+    beforeEach(() => {
+      Object.defineProperty(process, "platform", {
+        value: "win32",
+      });
+      (utils.isFlatpak as jest.Mock).mockReturnValue(false);
+      (utils.isSnapStore as jest.Mock).mockReturnValue(false);
+    });
+
+    it("should enable autostart using Electron API", async () => {
+      await service.enable();
+
+      expect(app.setLoginItemSettings).toHaveBeenCalledWith({ openAtLogin: true });
+    });
+
+    it("should disable autostart using Electron API", async () => {
+      await service.disable();
+
+      expect(app.setLoginItemSettings).toHaveBeenCalledWith({ openAtLogin: false });
+    });
+
+    it("should return Enabled when openAtLogin is enabled", async () => {
+      (app.getLoginItemSettings as jest.Mock).mockReturnValue({
+        openAtLogin: true,
+        openAsHidden: false,
+      });
+
+      const result = await service.isEnabled();
+
+      expect(result).toBe(AutoStartStatus.Enabled);
+    });
+
+    it("should return Disabled when openAtLogin is disabled", async () => {
+      (app.getLoginItemSettings as jest.Mock).mockReturnValue({
+        openAtLogin: false,
+        openAsHidden: false,
+      });
+
+      const result = await service.isEnabled();
+
+      expect(result).toBe(AutoStartStatus.Disabled);
+    });
+
+    it("should display setting in UI", () => {
+      const result = service.shouldDisplaySetting();
+
+      expect(result).toBe(true);
+    });
+  });
+
+  describe("Windows Store", () => {
+    beforeEach(() => {
+      Object.defineProperty(process, "platform", {
+        value: "win32",
+      });
+      (utils.isWindowsStore as jest.Mock).mockReturnValue(true);
+    });
+
+    it("should hide setting from UI (Windows Store doesn't support auto-start)", () => {
+      const result = service.shouldDisplaySetting();
+
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/apps/desktop/src/platform/auto-start/auto-start.service.ts
+++ b/apps/desktop/src/platform/auto-start/auto-start.service.ts
@@ -1,0 +1,130 @@
+import * as fs from "fs";
+import * as path from "path";
+
+import { app } from "electron";
+
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+import { autostart } from "@bitwarden/desktop-napi";
+
+import { isFlatpak, isSnapStore, isWindowsStore } from "../../utils";
+
+import { AutoStartService, AutoStartStatus } from "./auto-start.service.abstraction";
+
+/**
+ * Default implementation of the AutoStartService for managing desktop auto-start behavior.
+ *
+ * The implementation varies by platform:
+ * - **Linux (Flatpak)**: Uses the XDG autostart portal via desktop-napi
+ * - **Linux (Standard)**: Creates a .desktop file in ~/.config/autostart/
+ * - **Linux (Snap)**: Auto-start is managed by snap configuration (not handled here)
+ * - **macOS/Windows**: Uses Electron's app.setLoginItemSettings() API
+ */
+export class DefaultAutoStartService implements AutoStartService {
+  constructor(private logService: LogService) {}
+
+  async enable(): Promise<void> {
+    if (process.platform === "linux") {
+      if (isFlatpak()) {
+        // Use the XDG autostart portal for Flatpak
+        await autostart.setAutostart(true, []).catch((e) => {
+          this.logService.error("Failed to enable autostart via portal:", e);
+        });
+      } else if (!isSnapStore()) {
+        // For standard Linux, create a .desktop file in autostart directory
+        // Snap auto-start is configured via electron-builder snap configuration
+        this.createDesktopFile();
+      }
+    } else {
+      // macOS and Windows use Electron's native API
+      app.setLoginItemSettings({ openAtLogin: true });
+    }
+  }
+
+  async disable(): Promise<void> {
+    if (process.platform === "linux") {
+      if (isFlatpak()) {
+        // Use the XDG autostart portal for Flatpak
+        await autostart.setAutostart(false, []).catch((e) => {
+          this.logService.error("Failed to disable autostart via portal:", e);
+        });
+      } else if (!isSnapStore()) {
+        // For standard Linux, remove the .desktop file
+        // Snap auto-start is configured via electron-builder snap configuration
+        this.removeDesktopFile();
+      }
+    } else {
+      // macOS and Windows use Electron's native API
+      app.setLoginItemSettings({ openAtLogin: false });
+    }
+  }
+
+  async isEnabled(): Promise<AutoStartStatus> {
+    if (process.platform === "linux") {
+      if (isFlatpak() || isSnapStore()) {
+        // For Flatpak/Snap, we can't reliably check the state from within the app.
+        // The autostart portal (Flatpak) and snap configuration don't provide query APIs.
+        return AutoStartStatus.Unknown;
+      } else {
+        // For standard Linux, check if the desktop file exists.
+        return fs.existsSync(this.getLinuxDesktopFilePath())
+          ? AutoStartStatus.Enabled
+          : AutoStartStatus.Disabled;
+      }
+    } else {
+      // macOS and Windows use Electron's native API.
+      const loginSettings = app.getLoginItemSettings();
+      return loginSettings.openAtLogin ? AutoStartStatus.Enabled : AutoStartStatus.Disabled;
+    }
+  }
+
+  /**
+   * Creates the .desktop file for Linux autostart.
+   */
+  private createDesktopFile(): void {
+    const desktopFileContent = `[Desktop Entry]
+Type=Application
+Version=${app.getVersion()}
+Name=Bitwarden
+Comment=Bitwarden startup script
+Exec=${app.getPath("exe")}
+StartupNotify=false
+Terminal=false`;
+
+    const filePath = this.getLinuxDesktopFilePath();
+    const dir = path.dirname(filePath);
+
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+
+    fs.writeFileSync(filePath, desktopFileContent);
+  }
+
+  /**
+   * Removes the .desktop file for Linux autostart.
+   */
+  private removeDesktopFile(): void {
+    const filePath = this.getLinuxDesktopFilePath();
+    if (fs.existsSync(filePath)) {
+      fs.unlinkSync(filePath);
+    }
+  }
+
+  shouldDisplaySetting(): boolean {
+    // Windows Store apps don't support auto-start functionality.
+    // On Snap, auto-start is managed by the snap configuration (electron-builder.json).
+    if (isWindowsStore() || isSnapStore()) {
+      return false;
+    }
+
+    // All other platforms support user-configurable auto-start
+    return true;
+  }
+
+  /**
+   * Gets the path to the Linux autostart .desktop file.
+   */
+  private getLinuxDesktopFilePath(): string {
+    return path.join(app.getPath("home"), ".config", "autostart", "bitwarden.desktop");
+  }
+}

--- a/apps/desktop/src/platform/auto-start/auto-start.service.ts
+++ b/apps/desktop/src/platform/auto-start/auto-start.service.ts
@@ -6,7 +6,8 @@ import { app } from "electron";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { autostart } from "@bitwarden/desktop-napi";
 
-import { isFlatpak, isSnapStore, isWindowsStore } from "../../utils";
+import { isFlatpak, isSnapStore } from "../../utils";
+import { DesktopSettingsService } from "../services/desktop-settings.service";
 
 import { AutoStartService, AutoStartStatus } from "./auto-start.service.abstraction";
 
@@ -20,7 +21,10 @@ import { AutoStartService, AutoStartStatus } from "./auto-start.service.abstract
  * - **macOS/Windows**: Uses Electron's app.setLoginItemSettings() API
  */
 export class DefaultAutoStartService implements AutoStartService {
-  constructor(private logService: LogService) {}
+  constructor(
+    private logService: LogService,
+    private desktopSettingsService: DesktopSettingsService,
+  ) {}
 
   async enable(): Promise<void> {
     if (process.platform === "linux") {
@@ -108,17 +112,6 @@ Terminal=false`;
     if (fs.existsSync(filePath)) {
       fs.unlinkSync(filePath);
     }
-  }
-
-  shouldDisplaySetting(): boolean {
-    // Windows Store apps don't support auto-start functionality.
-    // On Snap, auto-start is managed by the snap configuration (electron-builder.json).
-    if (isWindowsStore() || isSnapStore()) {
-      return false;
-    }
-
-    // All other platforms support user-configurable auto-start
-    return true;
   }
 
   /**

--- a/apps/desktop/src/platform/auto-start/index.ts
+++ b/apps/desktop/src/platform/auto-start/index.ts
@@ -1,0 +1,2 @@
+export { AutoStartService, AutoStartStatus } from "./auto-start.service.abstraction";
+export { DefaultAutoStartService } from "./auto-start.service";

--- a/apps/desktop/src/platform/services/desktop-settings.service.spec.ts
+++ b/apps/desktop/src/platform/services/desktop-settings.service.spec.ts
@@ -3,15 +3,15 @@ import { of } from "rxjs";
 
 import { StateProvider, GlobalState } from "@bitwarden/common/platform/state";
 
-import * as utils from "../../utils";
-
 import { DesktopSettingsService } from "./desktop-settings.service";
 
-// Mock the utils module
-jest.mock("../../utils", () => ({
-  isWindowsStore: jest.fn(),
-  isSnapStore: jest.fn(),
-}));
+// Mock the global ipc object
+(global as any).ipc = {
+  platform: {
+    isWindowsStore: false,
+    isSnapStore: false,
+  },
+};
 
 describe("DesktopSettingsService", () => {
   let service: DesktopSettingsService;
@@ -33,9 +33,9 @@ describe("DesktopSettingsService", () => {
     service = new DesktopSettingsService(stateProvider);
     jest.clearAllMocks();
 
-    // Default: not Windows Store, not Snap
-    (utils.isWindowsStore as jest.Mock).mockReturnValue(false);
-    (utils.isSnapStore as jest.Mock).mockReturnValue(false);
+    // Reset ipc platform values to defaults
+    (global as any).ipc.platform.isWindowsStore = false;
+    (global as any).ipc.platform.isSnapStore = false;
   });
 
   describe("shouldDisplayAutoStartSetting", () => {
@@ -46,7 +46,7 @@ describe("DesktopSettingsService", () => {
     });
 
     it("should return false for Windows Store", () => {
-      (utils.isWindowsStore as jest.Mock).mockReturnValue(true);
+      (global as any).ipc.platform.isWindowsStore = true;
 
       const result = service.shouldDisplayAutoStartSetting();
 
@@ -54,7 +54,7 @@ describe("DesktopSettingsService", () => {
     });
 
     it("should return false for Snap", () => {
-      (utils.isSnapStore as jest.Mock).mockReturnValue(true);
+      (global as any).ipc.platform.isSnapStore = true;
 
       const result = service.shouldDisplayAutoStartSetting();
 
@@ -62,8 +62,8 @@ describe("DesktopSettingsService", () => {
     });
 
     it("should return false when both Windows Store and Snap are true", () => {
-      (utils.isWindowsStore as jest.Mock).mockReturnValue(true);
-      (utils.isSnapStore as jest.Mock).mockReturnValue(true);
+      (global as any).ipc.platform.isWindowsStore = true;
+      (global as any).ipc.platform.isSnapStore = true;
 
       const result = service.shouldDisplayAutoStartSetting();
 

--- a/apps/desktop/src/platform/services/desktop-settings.service.spec.ts
+++ b/apps/desktop/src/platform/services/desktop-settings.service.spec.ts
@@ -1,0 +1,73 @@
+import { mock, MockProxy } from "jest-mock-extended";
+import { of } from "rxjs";
+
+import { StateProvider, GlobalState } from "@bitwarden/common/platform/state";
+
+import * as utils from "../../utils";
+
+import { DesktopSettingsService } from "./desktop-settings.service";
+
+// Mock the utils module
+jest.mock("../../utils", () => ({
+  isWindowsStore: jest.fn(),
+  isSnapStore: jest.fn(),
+}));
+
+describe("DesktopSettingsService", () => {
+  let service: DesktopSettingsService;
+  let stateProvider: MockProxy<StateProvider>;
+
+  beforeEach(() => {
+    stateProvider = mock<StateProvider>();
+
+    // Mock getGlobal to return a mock state with state$ observable
+    const mockState = {
+      state$: of(null),
+      update: jest.fn(),
+    } as unknown as GlobalState<any>;
+
+    stateProvider.getGlobal.mockReturnValue(mockState);
+    stateProvider.getActive.mockReturnValue(mockState as any);
+    stateProvider.getUser.mockReturnValue(mockState as any);
+
+    service = new DesktopSettingsService(stateProvider);
+    jest.clearAllMocks();
+
+    // Default: not Windows Store, not Snap
+    (utils.isWindowsStore as jest.Mock).mockReturnValue(false);
+    (utils.isSnapStore as jest.Mock).mockReturnValue(false);
+  });
+
+  describe("shouldDisplayAutoStartSetting", () => {
+    it("should return true for standard platforms", () => {
+      const result = service.shouldDisplayAutoStartSetting();
+
+      expect(result).toBe(true);
+    });
+
+    it("should return false for Windows Store", () => {
+      (utils.isWindowsStore as jest.Mock).mockReturnValue(true);
+
+      const result = service.shouldDisplayAutoStartSetting();
+
+      expect(result).toBe(false);
+    });
+
+    it("should return false for Snap", () => {
+      (utils.isSnapStore as jest.Mock).mockReturnValue(true);
+
+      const result = service.shouldDisplayAutoStartSetting();
+
+      expect(result).toBe(false);
+    });
+
+    it("should return false when both Windows Store and Snap are true", () => {
+      (utils.isWindowsStore as jest.Mock).mockReturnValue(true);
+      (utils.isSnapStore as jest.Mock).mockReturnValue(true);
+
+      const result = service.shouldDisplayAutoStartSetting();
+
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/apps/desktop/src/platform/services/desktop-settings.service.ts
+++ b/apps/desktop/src/platform/services/desktop-settings.service.ts
@@ -19,6 +19,7 @@ import {
 import { UserId } from "@bitwarden/common/types/guid";
 
 import { SshAgentPromptType } from "../../autofill/models/ssh-agent-setting";
+import { isSnapStore, isWindowsStore } from "../../utils";
 import { ModalModeState, WindowState } from "../models/domain/window-state";
 
 export const HARDWARE_ACCELERATION = new KeyDefinition<boolean>(
@@ -353,5 +354,23 @@ export class DesktopSettingsService {
    */
   async setPreventScreenshots(value: boolean) {
     await this.preventScreenshotState.update(() => value);
+  }
+
+  /**
+   * Determines whether the auto-start setting should be displayed in the application UI.
+   * Some platforms (e.g., Windows Store, Snap) manage auto-start externally via
+   * package configuration, so the setting should be hidden from users on those platforms.
+   *
+   * @returns `true` if the setting should be shown, `false` if it should be hidden.
+   */
+  shouldDisplayAutoStartSetting(): boolean {
+    // Windows Store apps don't support auto-start functionality.
+    // On Snap, auto-start is managed by the snap configuration (electron-builder.json).
+    if (isWindowsStore() || isSnapStore()) {
+      return false;
+    }
+
+    // All other platforms support user-configurable auto-start
+    return true;
   }
 }

--- a/apps/desktop/src/platform/services/desktop-settings.service.ts
+++ b/apps/desktop/src/platform/services/desktop-settings.service.ts
@@ -19,7 +19,6 @@ import {
 import { UserId } from "@bitwarden/common/types/guid";
 
 import { SshAgentPromptType } from "../../autofill/models/ssh-agent-setting";
-import { isSnapStore, isWindowsStore } from "../../utils";
 import { ModalModeState, WindowState } from "../models/domain/window-state";
 
 export const HARDWARE_ACCELERATION = new KeyDefinition<boolean>(
@@ -366,7 +365,7 @@ export class DesktopSettingsService {
   shouldDisplayAutoStartSetting(): boolean {
     // Windows Store apps don't support auto-start functionality.
     // On Snap, auto-start is managed by the snap configuration (electron-builder.json).
-    if (isWindowsStore() || isSnapStore()) {
+    if (ipc.platform.isWindowsStore || ipc.platform.isSnapStore) {
       return false;
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-30397

## 📔 Objective

Configuration of automatic start on login was enmeshed in the `messaging.main.ts` file.

This PR pulls that out into a new, tested `AutoStartService`, which is responsible for enabling and disabling auto-start on the underlying platform.

In addition, for the "is auto-start enabled?" check, we return more context than just a boolean, because on some systems we do not have an API that tells us if it's actually enabled at the current time (i.e. we can enable and disable it, but we can't know whether it's been enabled or disabled by the user in the meantime):
- `Enabled` - we can guarantee that auto-start is enabled on the system
- `Disabled` - we can guarantee that auto-start is not enabled on the system
- `Unknown` - the current platform cannot tell us whether auto-start is enabled
  - In this case, we will keep the value that we store in state as-is. 
  - ⚠️ This has the potential for being confusing _if_ a user on Flatpak in particular disables auto-start outside of the Bitwarden application, as we'd still think it was enabled and the setting would show it as enabled.  A user would have to toggle the setting to sync it back up again.

In addition, this PR hides the "start at login" setting for snap as well as Windows store, because snap is configured in `electron-builder` configuration and not through the setting.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
