### PR TITLE
[PM-30135] deleted archive items restored to archive

### DIFF
--- a/apps/web/src/app/vault/individual-vault/vault-filter/shared/models/filter-function.ts
+++ b/apps/web/src/app/vault/individual-vault/vault-filter/shared/models/filter-function.ts
@@ -47,7 +47,11 @@ export function createFilterFunction(
       if (filter.type === "archive" && !CipherViewLikeUtils.isArchived(cipher)) {
         return false;
       }
-      if (filter.type !== "archive" && CipherViewLikeUtils.isArchived(cipher)) {
+      if (
+        filter.type !== "archive" &&
+        filter.type !== "trash" &&
+        CipherViewLikeUtils.isArchived(cipher)
+      ) {
         return false;
       }
     }

--- a/libs/common/src/vault/services/cipher.service.spec.ts
+++ b/libs/common/src/vault/services/cipher.service.spec.ts
@@ -868,7 +868,7 @@ describe("Cipher Service", () => {
       const result = await firstValueFrom(
         stateProvider.singleUser.getFake(mockUserId, ENCRYPTED_CIPHERS).state$,
       );
-      expect(result[cipherId].archivedDate).toBeNull();
+      expect(result[cipherId].archivedDate).toEqual("2024-01-01T12:00:00.000Z");
       expect(result[cipherId].deletedDate).toBeDefined();
     });
   });

--- a/libs/common/src/vault/services/cipher.service.ts
+++ b/libs/common/src/vault/services/cipher.service.ts
@@ -1461,7 +1461,6 @@ export class CipherService implements CipherServiceAbstraction {
         return;
       }
       ciphers[cipherId].deletedDate = new Date().toISOString();
-      ciphers[cipherId].archivedDate = null;
     };
 
     if (typeof id === "string") {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-30135](https://bitwarden.atlassian.net/browse/PM-30135)

## 📔 Objective

* preserve archiveDate on soft delete
* update filter so archived items with deletedDate show in trash

## 📸 Screen Recording


https://github.com/user-attachments/assets/0f276e27-139f-4cda-982a-285e5693e5c0



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-30135]: https://bitwarden.atlassian.net/browse/PM-30135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ