### PR TITLE
Consolidate deprecation message and instructions on KeyService abstraction

### DIFF
--- a/libs/key-management/src/abstractions/key.service.ts
+++ b/libs/key-management/src/abstractions/key.service.ts
@@ -158,7 +158,7 @@ export abstract class KeyService {
   abstract getOrDeriveMasterKey(password: string, userId: UserId): Promise<MasterKey>;
   /**
    * Generates a master key from the provided password
-   * @deprecated Interacting with the master key directly is prohibited.
+   * @deprecated Please use `makeMasterPasswordAuthenticationData`, `unwrapUserKeyFromMasterPasswordUnlockData` or `makeMasterPasswordUnlockData` in MasterPasswordService instead.
    * @param password The user's master password
    * @param email The user's email
    * @param KdfConfig The user's key derivation function configuration
@@ -167,7 +167,7 @@ export abstract class KeyService {
   abstract makeMasterKey(password: string, email: string, kdfConfig: KdfConfig): Promise<MasterKey>;
   /**
    * Encrypts the provided user key with the provided master key.
-   * @deprecated Interacting with the master key directly is prohibited. Use a high level function from MasterPasswordService instead.
+   * @deprecated Please use `makeMasterPasswordUnlockData` in {@link MasterPasswordService} instead.
    * @param masterKey The user's master key
    * @param userKey The user key
    * @throws Error when userKey or masterKey is null/undefined.
@@ -181,7 +181,7 @@ export abstract class KeyService {
    * Creates a master password hash from the user's master password. Can
    * be used for local authentication or for server authentication depending
    * on the hashPurpose provided.
-   * @deprecated Interacting with the master key directly is prohibited. Use a high level function from MasterPasswordService instead.
+   * @deprecated Please use `makeMasterPasswordAuthenticationData` in {@link MasterPasswordService} instead.
    * @param password The user's master password
    * @param key The user's master key or active's user master key.
    * @param hashPurpose The iterations to use for the hash. Defaults to {@link HashPurpose.ServerAuthorization}.

--- a/libs/key-management/src/key.service.ts
+++ b/libs/key-management/src/key.service.ts
@@ -168,9 +168,6 @@ export class DefaultKeyService implements KeyServiceAbstraction {
     return this.stateProvider.getUserState$(USER_KEY, userId);
   }
 
-  /**
-   * @deprecated Use {@link userKey$} with a required {@link UserId} instead.
-   */
   async getUserKey(userId?: UserId): Promise<UserKey> {
     const userKey = await firstValueFrom(this.stateProvider.getUserState$(USER_KEY, userId));
     return userKey;
@@ -248,9 +245,6 @@ export class DefaultKeyService implements KeyServiceAbstraction {
     await this.stateService.setUserKeyAutoUnlock(null, { userId: userId });
   }
 
-  /**
-   * @deprecated Please use `makeMasterPasswordAuthenticationData`, `unwrapUserKeyFromMasterPasswordUnlockData` or `makeMasterPasswordUnlockData` in @link MasterPasswordService instead.
-   */
   async getOrDeriveMasterKey(password: string, userId: UserId): Promise<MasterKey> {
     if (userId == null) {
       throw new Error("User ID is required.");
@@ -279,8 +273,6 @@ export class DefaultKeyService implements KeyServiceAbstraction {
   /**
    * Derive a master key from a password and email.
    *
-   * @deprecated Please use `makeMasterPasswordAuthenticationData`, `makeMasterPasswordAuthenticationData`, `unwrapUserKeyFromMasterPasswordUnlockData` in @link MasterPasswordService instead.
-   *
    * @remarks
    * Does not validate the kdf config to ensure it satisfies the minimum requirements for the given kdf type.
    */
@@ -298,9 +290,6 @@ export class DefaultKeyService implements KeyServiceAbstraction {
     return masterKey;
   }
 
-  /**
-   * @deprecated Please use `makeMasterPasswordUnlockData` in {@link MasterPasswordService} instead.
-   */
   async encryptUserKeyWithMasterKey(
     masterKey: MasterKey,
     userKey: UserKey,
@@ -315,9 +304,6 @@ export class DefaultKeyService implements KeyServiceAbstraction {
     return await this.buildProtectedSymmetricKey(masterKey, userKey);
   }
 
-  /**
-   * @deprecated Please use `makeMasterPasswordAuthenticationData` in {@link MasterPasswordService} instead.
-   */
   async hashMasterKey(
     password: string,
     key: MasterKey,


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-27044

## 📔 Objective

In working on replacing calls to `makeMasterKey()` we noticed that the deprecation instructions were split between the abstraction (which the IDE uses when looking at a method) and the implementation.  This PR consolidates them into the abstraction so they're visible to consumers.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
