### PR TITLE
[PM-28303] Fix failing typechecking in ApiService

### DIFF
--- a/libs/common/src/services/api.service.spec.ts
+++ b/libs/common/src/services/api.service.spec.ts
@@ -753,9 +753,10 @@ describe("ApiService", () => {
       // Mock accountService to return different active users based on when it's called
       accountService.activeAccount$ = of({
         id: activeUserId,
-        email: "user1@example.com",
-        emailVerified: true,
-        name: "Test Name",
+        ...mockAccountInfoWith({
+          email: "user1@example.com",
+          name: "Test Name",
+        }),
       } satisfies ObservedValueOf<AccountService["activeAccount$"]>);
 
       environmentService.getEnvironment$.calledWith(testActiveUser).mockReturnValue(
@@ -841,9 +842,10 @@ describe("ApiService", () => {
           activeUserId = testInactiveUser;
           accountService.activeAccount$ = of({
             id: testInactiveUser,
-            email: "user2@example.com",
-            emailVerified: true,
-            name: "Inactive User",
+            ...mockAccountInfoWith({
+              email: "user2@example.com",
+              name: "Inactive User",
+            }),
           } satisfies ObservedValueOf<AccountService["activeAccount$"]>);
 
           return Promise.resolve({


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-28303

## 📔 Objective

Fixes failing typechecking caused by https://github.com/bitwarden/clients/pull/17407 due to not initializing the `AccountInfo` with `creationDate` in new tests on `ApiService`.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
