### PR TITLE
Allow unmaintained crates in transient deps

### DIFF
--- a/apps/desktop/desktop_native/deny.toml
+++ b/apps/desktop/desktop_native/deny.toml
@@ -1,9 +1,10 @@
 # https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
 [advisories]
+# Allow unmaintained crates in transient deps but not direct
+unmaintained = "workspace"
 ignore = [
   # Vulnerability in `rsa` crate: https://rustsec.org/advisories/RUSTSEC-2023-0071.html
   { id = "RUSTSEC-2023-0071", reason = "There is no fix available yet." },
-  { id = "RUSTSEC-2024-0436", reason = "paste crate is unmaintained."}
 ]
 
 # https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-30530

## 📔 Objective

We're failing cargo deny on main due to https://rustsec.org/advisories/RUSTSEC-2025-0141.
That is a transient dep. This change adjusts our advisories checks to only fail on direct deps using unmaintained crates.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
