### PR TITLE
[PM-29940] Exclude deleted items from at-risk check

### DIFF
--- a/libs/common/src/vault/services/default-cipher-risk.service.ts
+++ b/libs/common/src/vault/services/default-cipher-risk.service.ts
@@ -71,7 +71,6 @@ export class DefaultCipherRiskService implements CipherRiskServiceAbstraction {
       passwordMap,
       checkExposed,
     });
-
     return results[0];
   }
 
@@ -103,7 +102,8 @@ export class DefaultCipherRiskService implements CipherRiskServiceAbstraction {
         return (
           cipher.type === CipherType.Login &&
           cipher.login?.password != null &&
-          cipher.login.password !== ""
+          cipher.login.password !== "" &&
+          !cipher.isDeleted
         );
       })
       .map(


### PR DESCRIPTION
## 🎟️ Tracking

[PM-29940](https://bitwarden.atlassian.net/browse/PM-29940)

## 📔 Objective

Excludes deleted items from at-risk check password checks so ciphers in a users vault do not incorrectly show the "At Risk" banner when viewing ciphers. 

## 📸 Screenshots

|Desktop|Web|Browser|
|-|-|-|
|<video src="https://github.com/user-attachments/assets/9956c86b-de28-43a4-ad13-5d9408770990"/>|<video src="https://github.com/user-attachments/assets/eb12997f-9451-4a26-9926-1ce555b827c1"/>|<video src="https://github.com/user-attachments/assets/5cbd1e3f-f151-420b-8b42-a517a6a695e6" />|

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-29940]: https://bitwarden.atlassian.net/browse/PM-29940?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ