### PR TITLE
[PM-30248] - allow deleting of failed decrypted ciphers

### DIFF
--- a/apps/browser/src/vault/popup/components/vault-v2/item-more-options/item-more-options.component.html
+++ b/apps/browser/src/vault/popup/components/vault-v2/item-more-options/item-more-options.component.html
@@ -4,61 +4,62 @@
     bitIconButton="bwi-ellipsis-v"
     size="small"
     [label]="'moreOptionsLabel' | i18n: cipher.name"
-    [disabled]="decryptionFailure"
     [bitMenuTriggerFor]="moreOptions"
   ></button>
   <bit-menu #moreOptions>
-    <ng-container *ngIf="canAutofill && !hideAutofillOptions">
-      <ng-container *ngIf="autofillAllowed$ | async">
-        <button type="button" bitMenuItem (click)="doAutofill()">
-          {{ "autofill" | i18n }}
+    @if (!decryptionFailure) {
+      <ng-container *ngIf="canAutofill && !hideAutofillOptions">
+        <ng-container *ngIf="autofillAllowed$ | async">
+          <button type="button" bitMenuItem (click)="doAutofill()">
+            {{ "autofill" | i18n }}
+          </button>
+        </ng-container>
+      </ng-container>
+      <ng-container *ngIf="showViewOption">
+        <button type="button" bitMenuItem (click)="onView()">
+          {{ "view" | i18n }}
         </button>
       </ng-container>
-    </ng-container>
-    <ng-container *ngIf="showViewOption">
-      <button type="button" bitMenuItem (click)="onView()">
-        {{ "view" | i18n }}
+      <button type="button" bitMenuItem (click)="toggleFavorite()">
+        {{ favoriteText | i18n }}
       </button>
-    </ng-container>
-    <button type="button" bitMenuItem (click)="toggleFavorite()">
-      {{ favoriteText | i18n }}
-    </button>
-    @if (canEdit) {
-      <button type="button" bitMenuItem (click)="edit()">
-        {{ "edit" | i18n }}
-      </button>
-    }
-    <ng-container *ngIf="canEdit && canViewPassword">
-      <a bitMenuItem (click)="clone()" *ngIf="canClone$ | async">
-        {{ "clone" | i18n }}
-      </a>
-      <a
-        bitMenuItem
-        *ngIf="canAssignCollections$ | async"
-        (click)="conditionallyNavigateToAssignCollections()"
-      >
-        {{ "assignToCollections" | i18n }}
-      </a>
-    </ng-container>
-    @if (showArchive$ | async) {
-      @if (canArchive$ | async) {
-        <button type="button" bitMenuItem (click)="archive()">
-          {{ "archiveVerb" | i18n }}
+      @if (canEdit) {
+        <button type="button" bitMenuItem (click)="edit()">
+          {{ "edit" | i18n }}
         </button>
-      } @else {
-        <button
-          type="button"
+      }
+      <ng-container *ngIf="canEdit && canViewPassword">
+        <a bitMenuItem (click)="clone()" *ngIf="canClone$ | async">
+          {{ "clone" | i18n }}
+        </a>
+        <a
           bitMenuItem
-          (click)="badge.promptForPremium($event)"
-          [attr.aria-label]="'upgradeToUseArchive' | i18n"
+          *ngIf="canAssignCollections$ | async"
+          (click)="conditionallyNavigateToAssignCollections()"
         >
-          <div class="tw-flex tw-flex-nowrap tw-items-center tw-gap-2">
+          {{ "assignToCollections" | i18n }}
+        </a>
+      </ng-container>
+      @if (showArchive$ | async) {
+        @if (canArchive$ | async) {
+          <button type="button" bitMenuItem (click)="archive()">
             {{ "archiveVerb" | i18n }}
-            <div aria-hidden>
-              <app-premium-badge #badge></app-premium-badge>
+          </button>
+        } @else {
+          <button
+            type="button"
+            bitMenuItem
+            (click)="badge.promptForPremium($event)"
+            [attr.aria-label]="'upgradeToUseArchive' | i18n"
+          >
+            <div class="tw-flex tw-flex-nowrap tw-items-center tw-gap-2">
+              {{ "archiveVerb" | i18n }}
+              <div aria-hidden>
+                <app-premium-badge #badge></app-premium-badge>
+              </div>
             </div>
-          </div>
-        </button>
+          </button>
+        }
       }
     }
     @if (canDelete$ | async) {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-30248

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR updates the cipher context menu in the browser to show the delete option for ciphers that failed to decrypt.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->


https://github.com/user-attachments/assets/6e72df91-4a57-4135-a478-41247371c5a2



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
