### PR TITLE
[PM-30494] Show upgrade badge for non-premium users

### DIFF
--- a/apps/browser/src/vault/popup/settings/vault-settings-v2.component.html
+++ b/apps/browser/src/vault/popup/settings/vault-settings-v2.component.html
@@ -52,9 +52,7 @@
           >
             <span class="tw-flex tw-items-center tw-gap-2">
               {{ "archiveNoun" | i18n }}
-              @if (!userHasArchivedItems()) {
-                <app-premium-badge></app-premium-badge>
-              }
+              <app-premium-badge></app-premium-badge>
             </span>
             <i slot="end" class="bwi bwi-angle-right" aria-hidden="true"></i>
           </a>

--- a/apps/browser/src/vault/popup/settings/vault-settings-v2.component.spec.ts
+++ b/apps/browser/src/vault/popup/settings/vault-settings-v2.component.spec.ts
@@ -195,10 +195,10 @@ describe("VaultSettingsV2Component", () => {
       expect(component["userHasArchivedItems"]()).toBe(false);
     });
 
-    it("hides premium badge when user has archived items", () => {
+    it("shows premium badge when user has archived items but cannot archive", () => {
       setArchiveState(false, [{ id: "cipher1" } as CipherView]);
 
-      expect(component["premiumBadgeComponent"]()).toBeUndefined();
+      expect(component["premiumBadgeComponent"]()).toBeTruthy();
       expect(component["userHasArchivedItems"]()).toBe(true);
     });
   });


### PR DESCRIPTION
## 🎟️ Tracking

[PM-30494](https://bitwarden.atlassian.net/browse/PM-30494)

## 📔 Objective

When a user has archive items and they lose their premium status, they should see the upgrade badge. Clicking on the Archive menu item will still allow them to view their archive items. This matches the experience on the web.

## 📸 Screenshots

<video src="https://github.com/user-attachments/assets/5fefe85c-817f-4777-b9b9-08bfb3241c87" />

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-30494]: https://bitwarden.atlassian.net/browse/PM-30494?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ