### PR TITLE
[PM-29166] updated cards to use dynamic styles

### DIFF
--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/activity/activity-card.component.ts
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/activity/activity-card.component.ts
@@ -13,7 +13,7 @@ import { ButtonModule, ButtonType, LinkModule, TypographyModule } from "@bitward
   imports: [CommonModule, TypographyModule, JslibModule, LinkModule, ButtonModule],
   host: {
     class:
-      "tw-box-border tw-bg-background tw-block tw-text-main tw-border-solid tw-border tw-border-secondary-300 tw-border [&:not(bit-layout_*)]:tw-rounded-lg tw-rounded-lg tw-p-6 tw-h-56 tw-max-h-56",
+      "tw-box-border tw-bg-background tw-block tw-text-main tw-border-solid tw-border tw-border-secondary-300 tw-border [&:not(bit-layout_*)]:tw-rounded-lg tw-rounded-lg tw-p-6 tw-min-h-56 tw-overflow-hidden",
   },
 })
 export class ActivityCardComponent {

--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/activity/activity-cards/password-change-metric.component.html
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/activity/activity-cards/password-change-metric.component.html
@@ -1,5 +1,5 @@
 <div
-  class="tw-flex tw-flex-col tw-p-6 tw-box-border tw-bg-background tw-text-main tw-border-solid tw-border tw-border-secondary-300 tw-rounded-lg tw-h-56 tw-max-h-56"
+  class="tw-box-border tw-bg-background tw-block tw-text-main tw-border-solid tw-border tw-border-secondary-300 [&:not(bit-layout_*)]:tw-rounded-lg tw-rounded-lg tw-p-6 tw-min-h-56 tw-overflow-hidden"
 >
   <div bitTypography="h6" class="tw-mb-2">
     {{ "passwordChangeProgress" | i18n }}

--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/activity/all-activity.component.html
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/activity/all-activity.component.html
@@ -2,9 +2,12 @@
   <dirt-report-loading></dirt-report-loading>
 } @else {
   <ul
-    class="tw-inline-grid tw-grid-cols-3 tw-gap-6 tw-m-0 tw-p-0 tw-w-full tw-auto-cols-auto tw-list-none"
+    class="tw-inline-grid tw-grid-cols-1 md:tw-grid-cols-2 lg:tw-grid-cols-3 tw-gap-6 tw-m-0 tw-p-0 tw-w-full tw-auto-cols-auto tw-list-none"
   >
-    <li class="tw-col-span-1" [ngClass]="{ 'tw-col-span-2': extendPasswordChangeWidget }">
+    <li
+      class="tw-col-span-1 md:tw-col-span-1 lg:tw-col-span-1"
+      [ngClass]="{ 'md:tw-col-span-2 lg:tw-col-span-2': extendPasswordChangeWidget }"
+    >
       <dirt-password-change-metric
         [organizationId]="this.organizationId()"
       ></dirt-password-change-metric>
@@ -62,7 +65,7 @@
     }
     <!-- Needs Review State (No apps have been reviewed) -->
     @else if (showNeedsReviewState) {
-      <li class="tw-col-span-2">
+      <li class="tw-col-span-1 md:tw-col-span-2 lg:tw-col-span-2">
         <dirt-activity-card
           [title]="'applicationsNeedingReview' | i18n"
           [cardMetrics]="'organizationHasItemsSavedForApplications' | i18n: totalApplicationCount"


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-29166

## 📔 Objective

The cards should resize dynamically. 
This should prevent text overflow and when there isn't enough space, the layout should show fewer columns

## 📸 Screenshots

### Default in a web browser
<img width="1329" height="910" alt="image" src="https://github.com/user-attachments/assets/b10bb1f2-afed-4f37-be11-339930b72877" />

### Resize, but text does not overflow
<img width="1329" height="910" alt="image" src="https://github.com/user-attachments/assets/afc64b40-14fb-4797-b66f-06a7a278dca3" />

### Layout shows fewer columns when there isn't enought space
<img width="756" height="1010" alt="image" src="https://github.com/user-attachments/assets/cd1ddd67-627c-4b8a-8391-67e4173da905" />

### Single column 
<img width="555" height="1039" alt="image" src="https://github.com/user-attachments/assets/d77e044b-eff1-443c-9e75-210a001d4ce4" />


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
