### PR TITLE
[PM-30734] hide the trash icon on the new item modal

### DIFF
--- a/apps/web/src/app/vault/components/vault-item-dialog/vault-item-dialog.component.html
+++ b/apps/web/src/app/vault/components/vault-item-dialog/vault-item-dialog.component.html
@@ -106,15 +106,17 @@
             ></button>
           }
         }
-        <button
-          bitIconButton="bwi-trash"
-          type="button"
-          buttonType="danger"
-          [label]="'delete' | i18n"
-          [bitAction]="delete"
-          [disabled]="!canDelete"
-          data-testid="delete-cipher-btn"
-        ></button>
+        @if (cipher) {
+          <button
+            bitIconButton="bwi-trash"
+            type="button"
+            buttonType="danger"
+            [label]="'delete' | i18n"
+            [bitAction]="delete"
+            [disabled]="!canDelete"
+            data-testid="delete-cipher-btn"
+          ></button>
+        }
       </div>
     }
   </ng-container>


### PR DESCRIPTION
## 🎟️ Tracking

[PM-30734](https://bitwarden.atlassian.net/browse/PM-30734)

## 📔 Objective

Hide the trash icon for the new item modal

## 📸 Screenshots

<img width="731" height="1149" alt="Screenshot 2026-01-13 at 9 58 48 AM" src="https://github.com/user-attachments/assets/69aac263-30bf-4e18-b1e3-e0d2c3ebf551" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-30734]: https://bitwarden.atlassian.net/browse/PM-30734?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ