### PR TITLE
BRE-1490 fix(build-desktop): job-level permissions

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -1890,6 +1890,8 @@ jobs:
     needs:
       - setup
       - linux
+    permissions:
+      contents: read
     env:
       _PACKAGE_VERSION: ${{ needs.setup.outputs.package_version }}
     steps:
@@ -1933,6 +1935,8 @@ jobs:
     needs:
       - setup
       - linux
+    permissions:
+      contents: read
     env:
       _PACKAGE_VERSION: ${{ needs.setup.outputs.package_version }}
     steps:
@@ -1974,6 +1978,8 @@ jobs:
     needs:
       - setup
       - linux
+    permissions:
+      contents: read
     env:
       _PACKAGE_VERSION: ${{ needs.setup.outputs.package_version }}
     steps:
@@ -2031,6 +2037,8 @@ jobs:
       - setup
       - linux
       - linux-arm64
+    permissions:
+      contents: read
     steps:
       - name: Check out repo
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
@@ -2081,6 +2089,8 @@ jobs:
       - setup
       - linux
       - linux-arm64
+    permissions:
+      contents: read
     env:
       _PACKAGE_VERSION: ${{ needs.setup.outputs.package_version }}
       _CPU_ARCH: ${{ matrix.os == 'ubuntu-22.04' && 'amd64' || 'arm64' }}
@@ -2126,6 +2136,8 @@ jobs:
     needs:
       - setup
       - macos-package-github
+    permissions:
+      contents: read
     env:
       _PACKAGE_VERSION: ${{ needs.setup.outputs.package_version }}
     steps:
@@ -2170,6 +2182,8 @@ jobs:
     needs:
       - setup
       - windows
+    permissions:
+      contents: read
     env:
       _PACKAGE_VERSION: ${{ needs.setup.outputs.package_version }}
     steps:


### PR DESCRIPTION

## 🎟️ Tracking

[BRE-1490](https://bitwarden.atlassian.net/browse/BRE-1490)

## 📔 Objective

Adding job-level `read` permissions to the follow jobs:
* validate-linux-x64-deb
* validate-linux-x64-appimage
* validate-linux-wayland
* validate-linux-flatpak
* validate-linux-snap
* validate-macos-dmg
* validate-windows-portable

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[BRE-1490]: https://bitwarden.atlassian.net/browse/BRE-1490?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ