### PR TITLE
[PM-29246] Fix Incorrect Policy Response Data

### DIFF
--- a/apps/web/src/app/admin-console/organizations/policies/base-policy-edit.component.ts
+++ b/apps/web/src/app/admin-console/organizations/policies/base-policy-edit.component.ts
@@ -6,7 +6,7 @@ import { Constructor } from "type-fest";
 import { PolicyType } from "@bitwarden/common/admin-console/enums";
 import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
 import { PolicyRequest } from "@bitwarden/common/admin-console/models/request/policy.request";
-import { PolicyResponse } from "@bitwarden/common/admin-console/models/response/policy.response";
+import { PolicyStatusResponse } from "@bitwarden/common/admin-console/models/response/policy-status.response";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { DialogConfig, DialogRef, DialogService } from "@bitwarden/components";
 
@@ -80,7 +80,7 @@ export abstract class BasePolicyEditDefinition {
 export abstract class BasePolicyEditComponent implements OnInit {
   // FIXME(https://bitwarden.atlassian.net/browse/CL-903): Migrate to Signals
   // eslint-disable-next-line @angular-eslint/prefer-signals
-  @Input() policyResponse: PolicyResponse | undefined;
+  @Input() policyResponse: PolicyStatusResponse | undefined;
   // FIXME(https://bitwarden.atlassian.net/browse/CL-903): Migrate to Signals
   // eslint-disable-next-line @angular-eslint/prefer-signals
   @Input() policy: BasePolicyEditDefinition | undefined;

--- a/apps/web/src/app/admin-console/organizations/policies/policy-edit-definitions/remove-unlock-with-pin.component.spec.ts
+++ b/apps/web/src/app/admin-console/organizations/policies/policy-edit-definitions/remove-unlock-with-pin.component.spec.ts
@@ -4,7 +4,7 @@ import { By } from "@angular/platform-browser";
 import { mock } from "jest-mock-extended";
 
 import { PolicyType } from "@bitwarden/common/admin-console/enums";
-import { PolicyResponse } from "@bitwarden/common/admin-console/models/response/policy.response";
+import { PolicyStatusResponse } from "@bitwarden/common/admin-console/models/response/policy-status.response";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 
 import {
@@ -42,8 +42,7 @@ describe("RemoveUnlockWithPinPolicyComponent", () => {
   });
 
   it("input selected on load when policy enabled", async () => {
-    component.policyResponse = new PolicyResponse({
-      id: "policy1",
+    component.policyResponse = new PolicyStatusResponse({
       organizationId: "org1",
       type: PolicyType.RemoveUnlockWithPin,
       enabled: true,
@@ -63,8 +62,7 @@ describe("RemoveUnlockWithPinPolicyComponent", () => {
   });
 
   it("input not selected on load when policy disabled", async () => {
-    component.policyResponse = new PolicyResponse({
-      id: "policy1",
+    component.policyResponse = new PolicyStatusResponse({
       organizationId: "org1",
       type: PolicyType.RemoveUnlockWithPin,
       enabled: false,
@@ -84,8 +82,7 @@ describe("RemoveUnlockWithPinPolicyComponent", () => {
   });
 
   it("turn on message label", async () => {
-    component.policyResponse = new PolicyResponse({
-      id: "policy1",
+    component.policyResponse = new PolicyStatusResponse({
       organizationId: "org1",
       type: PolicyType.RemoveUnlockWithPin,
       enabled: false,

--- a/libs/common/src/admin-console/abstractions/policy/policy-api.service.abstraction.ts
+++ b/libs/common/src/admin-console/abstractions/policy/policy-api.service.abstraction.ts
@@ -3,10 +3,11 @@ import { PolicyType } from "../../enums";
 import { MasterPasswordPolicyOptions } from "../../models/domain/master-password-policy-options";
 import { Policy } from "../../models/domain/policy";
 import { PolicyRequest } from "../../models/request/policy.request";
+import { PolicyStatusResponse } from "../../models/response/policy-status.response";
 import { PolicyResponse } from "../../models/response/policy.response";
 
 export abstract class PolicyApiServiceAbstraction {
-  abstract getPolicy: (organizationId: string, type: PolicyType) => Promise<PolicyResponse>;
+  abstract getPolicy: (organizationId: string, type: PolicyType) => Promise<PolicyStatusResponse>;
   abstract getPolicies: (organizationId: string) => Promise<ListResponse<PolicyResponse>>;
 
   abstract getPoliciesByToken: (

--- a/libs/common/src/admin-console/models/response/policy-status.response.ts
+++ b/libs/common/src/admin-console/models/response/policy-status.response.ts
@@ -1,0 +1,19 @@
+import { BaseResponse } from "../../../models/response/base.response";
+import { PolicyType } from "../../enums";
+
+export class PolicyStatusResponse extends BaseResponse {
+  organizationId: string;
+  type: PolicyType;
+  data: any;
+  enabled: boolean;
+  canToggleState: boolean;
+
+  constructor(response: any) {
+    super(response);
+    this.organizationId = this.getResponseProperty("OrganizationId");
+    this.type = this.getResponseProperty("Type");
+    this.data = this.getResponseProperty("Data");
+    this.enabled = this.getResponseProperty("Enabled");
+    this.canToggleState = this.getResponseProperty("CanToggleState") ?? true;
+  }
+}

--- a/libs/common/src/admin-console/services/policy/policy-api.service.ts
+++ b/libs/common/src/admin-console/services/policy/policy-api.service.ts
@@ -14,6 +14,7 @@ import { PolicyData } from "../../models/data/policy.data";
 import { MasterPasswordPolicyOptions } from "../../models/domain/master-password-policy-options";
 import { Policy } from "../../models/domain/policy";
 import { PolicyRequest } from "../../models/request/policy.request";
+import { PolicyStatusResponse } from "../../models/response/policy-status.response";
 import { PolicyResponse } from "../../models/response/policy.response";
 
 export class PolicyApiService implements PolicyApiServiceAbstraction {
@@ -23,7 +24,7 @@ export class PolicyApiService implements PolicyApiServiceAbstraction {
     private accountService: AccountService,
   ) {}
 
-  async getPolicy(organizationId: string, type: PolicyType): Promise<PolicyResponse> {
+  async getPolicy(organizationId: string, type: PolicyType): Promise<PolicyStatusResponse> {
     const r = await this.apiService.send(
       "GET",
       "/organizations/" + organizationId + "/policies/" + type,


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-29246

## 📔 Objective
We intentionally form a "just in time" policy record on the server to represent a disabled version of the requested policy. Because this is a conjured record that isn't persisted, it has no database metadata (and also has an additional calculated property).

To be accurate to our models, another policy model was created that reflects this different dataset. The base policy edit component was updated, and since no property names were changed, further updates are unnecessary. 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
