### PR TITLE
Update pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,27 +9,3 @@
 ## 📸 Screenshots
 
 <!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
-
-## ⏰ Reminders before review
-
-- Contributor guidelines followed
-- All formatters and local linters executed and passed
-- Written new unit and / or integration tests where applicable
-- Protected functional changes with optionality (feature flags)
-- Used internationalization (i18n) for all UI strings
-- CI builds passed
-- Communicated to DevOps any deployment requirements
-- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team
-
-## 🦮 Reviewer guidelines
-
-<!-- Suggested interactions but feel free to use (or not) as you desire! -->
-
-- 👍 (`:+1:`) or similar for great changes
-- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-- ❓ (`:question:`) for questions
-- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-- 🎨 (`:art:`) for suggestions / improvements
-- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-- ⛏ (`:pick:`) for minor or nitpick changes


### PR DESCRIPTION
## 📔 Objective

Per https://github.com/bitwarden/contributing-docs/pull/724#discussion_r2694492386 we should use the template from the template repo: https://github.com/bitwarden/template/blob/main/.github/PULL_REQUEST_TEMPLATE.md

(clarification; the rich feedback guidance has been moved out of the repo PR templates and into [general contributing docs guidance](https://contributing.bitwarden.com/contributing/pull-requests/code-review#providing-rich-feedback) )