### PR TITLE
[PM-30382] Make Send search bar full page width

### DIFF
--- a/apps/web/src/app/tools/send/send.component.html
+++ b/apps/web/src/app/tools/send/send.component.html
@@ -19,7 +19,7 @@
 </bit-callout>
 
 @if (SendUIRefresh$ | async) {
-  <div class="tw-mb-4 tw-max-w-md">
+  <div class="tw-mb-4">
     <bit-search
       [(ngModel)]="searchText"
       [placeholder]="'searchSends' | i18n"


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-30382

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
To ensure UI consistency this PR makes the Send search bar extend the full width of the page

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
Before

<img width="2557" height="596" alt="Screenshot 2026-01-15 at 11 18 45" src="https://github.com/user-attachments/assets/78d4f2ac-9089-4c3b-8540-110ad78d07b2" />

After

<img width="2558" height="557" alt="Screenshot 2026-01-15 at 11 19 33" src="https://github.com/user-attachments/assets/20eb5b10-57b4-4106-aeb4-fc2e0ae0d5fa" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
