### PR TITLE
[PM-30799] added  html clean up for the domain

### DIFF
--- a/apps/web/src/app/core/event.service.ts
+++ b/apps/web/src/app/core/event.service.ts
@@ -522,16 +522,25 @@ export class EventService {
         break;
       // Org Domain claiming events
       case EventType.OrganizationDomain_Added:
-        msg = humanReadableMsg = this.i18nService.t("addedDomain", ev.domainName);
+        msg = humanReadableMsg = this.i18nService.t("addedDomain", this.escapeHtml(ev.domainName));
         break;
       case EventType.OrganizationDomain_Removed:
-        msg = humanReadableMsg = this.i18nService.t("removedDomain", ev.domainName);
+        msg = humanReadableMsg = this.i18nService.t(
+          "removedDomain",
+          this.escapeHtml(ev.domainName),
+        );
         break;
       case EventType.OrganizationDomain_Verified:
-        msg = humanReadableMsg = this.i18nService.t("domainClaimedEvent", ev.domainName);
+        msg = humanReadableMsg = this.i18nService.t(
+          "domainClaimedEvent",
+          this.escapeHtml(ev.domainName),
+        );
         break;
       case EventType.OrganizationDomain_NotVerified:
-        msg = humanReadableMsg = this.i18nService.t("domainNotClaimedEvent", ev.domainName);
+        msg = humanReadableMsg = this.i18nService.t(
+          "domainNotClaimedEvent",
+          this.escapeHtml(ev.domainName),
+        );
         break;
       // Secrets Manager
       case EventType.Secret_Retrieved:
@@ -891,6 +900,15 @@ export class EventService {
 
   private getShortId(id: string) {
     return id?.substring(0, 8);
+  }
+
+  private escapeHtml(unsafe: string): string {
+    if (!unsafe) {
+      return unsafe;
+    }
+    const div = document.createElement("div");
+    div.textContent = unsafe;
+    return div.innerHTML;
   }
 
   private toDateTimeLocalString(date: Date) {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-30799

## 📔 Objective

The event log renders HTML as it needs to render links. Therefore, we need to set the `innerHtml` of a div.
However, input into the `innerHtml` can be sanitized. 
For the Domain we sanitize the HTML.

This PR is in addition to the server PR - where we validate the `domainName` model.

## 📸 Screenshots

### Input Sanitized
<img width="1086" height="961" alt="image" src="https://github.com/user-attachments/assets/6adbdd15-53d9-4a1b-95d2-bd1494efd7ff" />

### Input that was not sanitized 
<img width="1086" height="961" alt="image" src="https://github.com/user-attachments/assets/ef09b826-9767-472f-a498-a07252f4cbe3" />


