### PR TITLE
[PM-30794] Archive Filter In Desktop Truncate Fix

### DIFF
--- a/apps/desktop/src/vault/app/vault/vault-filter/filters/status-filter.component.html
+++ b/apps/desktop/src/vault/app/vault/vault-filter/filters/status-filter.component.html
@@ -30,14 +30,14 @@
       </span>
     </li>
     <li
-      class="filter-option tw-flex tw-items-center tw-gap-2 [&>span]:tw-w-min"
+      class="filter-option tw-flex tw-items-center tw-gap-2 [&>span]:tw-w-fit"
       [ngClass]="{ active: activeFilter.status === 'archive' }"
       *ngIf="!hideArchive"
     >
       <span class="filter-buttons">
         <button
           type="button"
-          class="filter-button"
+          class="filter-button !tw-max-w-none"
           (click)="handleArchiveFilter($event)"
           [attr.aria-pressed]="activeFilter.status === 'archive'"
         >


### PR DESCRIPTION
## 🎟️ Tracking

[PM-30794](https://bitwarden.atlassian.net/browse/PM-30794)

## 📔 Objective

Update styles for the Archive filter in desktop so it will no longer be truncated when active

## 📸 Screenshots

<img width="391" height="439" alt="PM-30794-premium" src="https://github.com/user-attachments/assets/0a567e55-1f98-4f2d-914d-98eed42a458c" />

<img width="441" height="343" alt="PM-30794-non-premium" src="https://github.com/user-attachments/assets/0f324265-c69d-4536-8efa-a3ea05b1b48a" />



[PM-30794]: https://bitwarden.atlassian.net/browse/PM-30794?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ