### PR TITLE
[PM-30904] Fix VaultFilterService abstraction import in AC Vault

### DIFF
--- a/apps/web/src/app/admin-console/organizations/collections/vault-filter/vault-filter.component.ts
+++ b/apps/web/src/app/admin-console/organizations/collections/vault-filter/vault-filter.component.ts
@@ -16,7 +16,7 @@ import { TreeNode } from "@bitwarden/common/vault/models/domain/tree-node";
 import { RestrictedItemTypesService } from "@bitwarden/common/vault/services/restricted-item-types.service";
 import { DialogService, ToastService } from "@bitwarden/components";
 import {
-  VaultFilterService,
+  VaultFilterServiceAbstraction,
   VaultFilterList,
   VaultFilterSection,
   VaultFilterType,
@@ -49,7 +49,7 @@ export class VaultFilterComponent
   protected destroy$: Subject<void>;
 
   constructor(
-    protected vaultFilterService: VaultFilterService,
+    protected vaultFilterService: VaultFilterServiceAbstraction,
     protected policyService: PolicyService,
     protected i18nService: I18nService,
     protected platformUtilsService: PlatformUtilsService,


### PR DESCRIPTION
## 🎟️ Tracking

[PM-30904](https://bitwarden.atlassian.net/browse/PM-30904)

## 📔 Objective

Use the `VaultFilterServiceAbstraction` instead of the implementation that was mistakenly swapped in #17919.

## 📸 Screenshots

<img width="1454" height="928" alt="image" src="https://github.com/user-attachments/assets/78ad71cc-948b-4ed1-9eac-8f1533a5caf9" />



[PM-30904]: https://bitwarden.atlassian.net/browse/PM-30904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ