### PR TITLE
[BRE-1498] rename selfhost dev image

### DIFF
--- a/.github/workflows/build-web.yml
+++ b/.github/workflows/build-web.yml
@@ -112,7 +112,7 @@ jobs:
             npm_command: dist:bit:selfhost
           - artifact_name: selfhosted-DEV
             license_type: "commercial"
-            image_name: web
+            image_name: web-dev
             npm_command: build:bit:selfhost:dev
             git_metadata: true
           - artifact_name: cloud-QA


### PR DESCRIPTION
## 🎟️ Tracking
[BRE-1498](https://bitwarden.atlassian.net/browse/BRE-1498)

## 📔 Objective
we were seeing intermittent git hashes on version numbers in the web vault UI as well as <environment-url>.com/version.json which is unexpected for production self hosts. this was a result of #16475 

there was a naming collision for the image, resulting in a race condition of which image finished second would be in place for `web`. The images were otherwise identical, the only difference being the inclusion of the git hash.

Updated the dev image with a unique name, tested on a self host with `web` and `web-dev` to validate I saw the git hash only on -dev

[BRE-1498]: https://bitwarden.atlassian.net/browse/BRE-1498?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ