### PR TITLE
Fix hashFiles including target

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -407,7 +407,7 @@ jobs:
             apps/desktop/desktop_native/dist/*
             ${{ env.RUNNER_TEMP }}/.cargo/registry
             ${{ env.RUNNER_TEMP }}/.cargo/git
-          key: rust-${{ runner.os }}-${{ hashFiles('apps/desktop/desktop_native/**/Cargo.*', 'apps/desktop/desktop_native/**/*.rs') }}
+          key: rust-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('apps/desktop/desktop_native/**/Cargo.*', 'apps/desktop/desktop_native/**/*.rs') }}
 
       - name: Build Native Module
         if: steps.cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

The "Cache Native Module" step takes almost 2min currently which sometimes times out. This is due to us caching the `target` directory which adds a significant amount of files to hash.

An alternative approach is to restore this cache before we restore the rust cache.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
