### PR TITLE
Set error cannot decrypt when collection name cannot be decrypted

### DIFF
--- a/libs/common/src/admin-console/models/collections/collection-admin.view.ts
+++ b/libs/common/src/admin-console/models/collections/collection-admin.view.ts
@@ -121,13 +121,13 @@ export class CollectionAdminView extends CollectionView {
     try {
       view.name = await encryptService.decryptString(new EncString(view.name), orgKey);
     } catch (e) {
+      view.name = "[error: cannot decrypt]";
       // Note: This should be replaced by the owning team with appropriate, domain-specific behavior.
       // eslint-disable-next-line no-console
       console.error(
         "[CollectionAdminView/fromCollectionAccessDetails] Error decrypting collection name",
         e,
       );
-      throw e;
     }
     view.assigned = collection.assigned;
     view.readOnly = collection.readOnly;

--- a/libs/common/src/admin-console/models/collections/collection.view.ts
+++ b/libs/common/src/admin-console/models/collections/collection.view.ts
@@ -126,7 +126,14 @@ export class CollectionView implements View, ITreeNodeObject {
   ): Promise<CollectionView> {
     const view = new CollectionView({ ...collection, name: "" });
 
-    view.name = await encryptService.decryptString(collection.name, key);
+    try {
+      view.name = await encryptService.decryptString(collection.name, key);
+    } catch (e) {
+      view.name = "[error: cannot decrypt]";
+      // eslint-disable-next-line no-console
+      console.error("[CollectionView] Error decrypting collection name", e);
+    }
+
     view.assigned = true;
     view.externalId = collection.externalId;
     view.readOnly = collection.readOnly;


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-28455
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
Mitigate a denial of service vulnerability where a single collection with a corrupted or tampered encrypted name could render the entire vault inaccessible for all organization members.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

https://github.com/user-attachments/assets/358a52a2-1155-4478-8cf6-32a392dcf3ad

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
