### PR TITLE
[PM-31000] Add SSH Agent key selection mode setting

### DIFF
--- a/apps/desktop/src/app/accounts/settings.component.html
+++ b/apps/desktop/src/app/accounts/settings.component.html
@@ -450,6 +450,24 @@
                   "sshAgentPromptBehaviorDesc" | i18n
                 }}</small>
               </div>
+              <div class="form-group" *ngIf="this.form.value.enableSshAgent">
+                <label for="sshAgentKeySelectionMode">{{
+                  "sshAgentKeySelectionMode" | i18n
+                }}</label>
+                <select
+                  id="sshAgentKeySelectionMode"
+                  aria-describedby="sshAgentKeySelectionModeHelp"
+                  formControlName="sshAgentKeySelectionMode"
+                  (change)="saveSshAgentKeySelectionMode()"
+                >
+                  <option *ngFor="let o of sshAgentKeySelectionModeOptions" [ngValue]="o.value">
+                    {{ o.name }}
+                  </option>
+                </select>
+                <small id="sshAgentKeySelectionModeHelp" class="help-block">{{
+                  "sshAgentKeySelectionModeDesc" | i18n
+                }}</small>
+              </div>
               <div class="form-group" *ngIf="!isLinux">
                 <div class="checkbox">
                   <label for="allowScreenshots">

--- a/apps/desktop/src/app/accounts/settings.component.ts
+++ b/apps/desktop/src/app/accounts/settings.component.ts
@@ -62,7 +62,10 @@ import { PermitCipherDetailsPopoverComponent } from "@bitwarden/vault";
 
 import { SetPinComponent } from "../../auth/components/set-pin.component";
 import { AutotypeShortcutComponent } from "../../autofill/components/autotype-shortcut.component";
-import { SshAgentPromptType } from "../../autofill/models/ssh-agent-setting";
+import {
+  SshAgentKeySelectionMode,
+  SshAgentPromptType,
+} from "../../autofill/models/ssh-agent-setting";
 import { DesktopAutofillSettingsService } from "../../autofill/services/desktop-autofill-settings.service";
 import { DesktopAutotypeService } from "../../autofill/services/desktop-autotype.service";
 import { DesktopBiometricsService } from "../../key-management/biometrics/desktop.biometrics.service";
@@ -112,6 +115,7 @@ export class SettingsComponent implements OnInit, OnDestroy {
   themeOptions: any[];
   clearClipboardOptions: any[];
   sshAgentPromptBehaviorOptions: any[];
+  sshAgentKeySelectionModeOptions: any[];
   supportsBiometric: boolean;
   private timerId: any;
   showAlwaysShowDock = false;
@@ -178,6 +182,7 @@ export class SettingsComponent implements OnInit, OnDestroy {
     enableHardwareAcceleration: true,
     enableSshAgent: false,
     sshAgentPromptBehavior: SshAgentPromptType.Always,
+    sshAgentKeySelectionMode: [SshAgentKeySelectionMode.AllKeys as SshAgentKeySelectionMode],
     allowScreenshots: false,
     enableDuckDuckGoBrowserIntegration: false,
     enableAutotype: this.formBuilder.control<boolean>({
@@ -285,6 +290,17 @@ export class SettingsComponent implements OnInit, OnDestroy {
       {
         name: this.i18nService.t("sshAgentPromptBehaviorRememberUntilLock"),
         value: SshAgentPromptType.RememberUntilLock,
+      },
+    ];
+
+    this.sshAgentKeySelectionModeOptions = [
+      {
+        name: this.i18nService.t("sshAgentKeySelectionModeAllKeys"),
+        value: SshAgentKeySelectionMode.AllKeys,
+      },
+      {
+        name: this.i18nService.t("sshAgentKeySelectionModeSelectKey"),
+        value: SshAgentKeySelectionMode.SelectKey,
       },
     ];
 
@@ -414,6 +430,9 @@ export class SettingsComponent implements OnInit, OnDestroy {
       enableSshAgent: await firstValueFrom(this.desktopSettingsService.sshAgentEnabled$),
       sshAgentPromptBehavior: await firstValueFrom(
         this.desktopSettingsService.sshAgentPromptBehavior$,
+      ),
+      sshAgentKeySelectionMode: await firstValueFrom(
+        this.desktopSettingsService.sshAgentKeySelectionMode$,
       ),
       allowScreenshots: !(await firstValueFrom(this.desktopSettingsService.preventScreenshots$)),
       enableAutotype: await firstValueFrom(this.desktopAutotypeService.autotypeEnabledUserSetting$),
@@ -927,6 +946,12 @@ export class SettingsComponent implements OnInit, OnDestroy {
   async saveSshAgentPromptBehavior() {
     await this.desktopSettingsService.setSshAgentPromptBehavior(
       this.form.value.sshAgentPromptBehavior,
+    );
+  }
+
+  async saveSshAgentKeySelectionMode() {
+    await this.desktopSettingsService.setSshAgentKeySelectionMode(
+      this.form.value.sshAgentKeySelectionMode,
     );
   }
 

--- a/apps/desktop/src/app/accounts/settings.component.ts
+++ b/apps/desktop/src/app/accounts/settings.component.ts
@@ -302,6 +302,10 @@ export class SettingsComponent implements OnInit, OnDestroy {
         name: this.i18nService.t("sshAgentKeySelectionModeSelectKey"),
         value: SshAgentKeySelectionMode.SelectKey,
       },
+      {
+        name: this.i18nService.t("sshAgentKeySelectionModeLoadSomeKeys"),
+        value: SshAgentKeySelectionMode.LoadSomeKeys,
+      },
     ];
 
     this.consolidatedSessionTimeoutComponent$ = this.configService.getFeatureFlag$(
@@ -950,9 +954,18 @@ export class SettingsComponent implements OnInit, OnDestroy {
   }
 
   async saveSshAgentKeySelectionMode() {
-    await this.desktopSettingsService.setSshAgentKeySelectionMode(
-      this.form.value.sshAgentKeySelectionMode,
-    );
+    const newMode = this.form.value.sshAgentKeySelectionMode;
+    const oldMode = await firstValueFrom(this.desktopSettingsService.sshAgentKeySelectionMode$);
+
+    await this.desktopSettingsService.setSshAgentKeySelectionMode(newMode);
+
+    // Clear selected keys when switching away from LoadSomeKeys
+    if (
+      oldMode === SshAgentKeySelectionMode.LoadSomeKeys &&
+      newMode !== SshAgentKeySelectionMode.LoadSomeKeys
+    ) {
+      await this.desktopSettingsService.setSshAgentSelectedKeyIds([]);
+    }
   }
 
   async savePreventScreenshots() {

--- a/apps/desktop/src/autofill/models/ssh-agent-setting.ts
+++ b/apps/desktop/src/autofill/models/ssh-agent-setting.ts
@@ -5,3 +5,11 @@ export enum SshAgentPromptType {
   Never = "never",
   RememberUntilLock = "rememberUntilLock",
 }
+
+export const SshAgentKeySelectionMode = Object.freeze({
+  AllKeys: "allKeys",
+  SelectKey: "selectKey",
+} as const);
+
+export type SshAgentKeySelectionMode =
+  (typeof SshAgentKeySelectionMode)[keyof typeof SshAgentKeySelectionMode];

--- a/apps/desktop/src/autofill/models/ssh-agent-setting.ts
+++ b/apps/desktop/src/autofill/models/ssh-agent-setting.ts
@@ -9,6 +9,7 @@ export enum SshAgentPromptType {
 export const SshAgentKeySelectionMode = Object.freeze({
   AllKeys: "allKeys",
   SelectKey: "selectKey",
+  LoadSomeKeys: "loadSomeKeys",
 } as const);
 
 export type SshAgentKeySelectionMode =

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -332,6 +332,30 @@
   "sshAgentPromptBehaviorRememberUntilLock": {
     "message": "Remember until vault is locked"
   },
+  "sshAgentKeySelectionMode": {
+    "message": "SSH key selection mode"
+  },
+  "sshAgentKeySelectionModeDesc": {
+    "message": "Choose whether to send all SSH keys to the agent or select a specific key for each request."
+  },
+  "sshAgentKeySelectionModeAllKeys": {
+    "message": "Send all SSH keys"
+  },
+  "sshAgentKeySelectionModeSelectKey": {
+    "message": "Select key for each request"
+  },
+  "selectSshKeyTitle": {
+    "message": "Select SSH Key"
+  },
+  "selectSshKeyMessageInfix": {
+    "message": "is requesting to use an SSH key. Please select which key to use:"
+  },
+  "selectSshKeyLabel": {
+    "message": "SSH Key"
+  },
+  "selectSshKeyHelp": {
+    "message": "The selected key will be used for this request only and removed from the agent after use."
+  },
   "premiumRequired": {
     "message": "Premium required"
   },

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -336,13 +336,31 @@
     "message": "SSH key selection mode"
   },
   "sshAgentKeySelectionModeDesc": {
-    "message": "Choose whether to send all SSH keys to the agent or select a specific key for each request."
+    "message": "Choose whether to send all SSH keys to the agent, select a specific key for each request, or pre-load specific keys to keep in memory."
   },
   "sshAgentKeySelectionModeAllKeys": {
     "message": "Send all SSH keys"
   },
   "sshAgentKeySelectionModeSelectKey": {
     "message": "Select key for each request"
+  },
+  "sshAgentKeySelectionModeLoadSomeKeys": {
+    "message": "Load some keys"
+  },
+  "loadSomeKeysTitle": {
+    "message": "Select SSH Keys to Load"
+  },
+  "loadSomeKeysMessage": {
+    "message": "Select one or more SSH keys to keep loaded in the agent. These keys will remain available until you lock your vault or disable the SSH agent."
+  },
+  "selectSshKeys": {
+    "message": "SSH Keys"
+  },
+  "loadSomeKeysHelp": {
+    "message": "Selected keys will be kept in the agent memory and automatically provided to SSH clients without prompts."
+  },
+  "loadKeys": {
+    "message": "Load Keys"
   },
   "selectSshKeyTitle": {
     "message": "Select SSH Key"

--- a/apps/desktop/src/platform/components/load-some-keys.html
+++ b/apps/desktop/src/platform/components/load-some-keys.html
@@ -1,0 +1,57 @@
+<form [bitSubmit]="submit" [formGroup]="loadSomeKeysForm">
+  <bit-dialog dialogSize="large">
+    <span bitDialogTitle>{{ "loadSomeKeysTitle" | i18n }}</span>
+    <div bitDialogContent>
+      <p class="tw-mb-4">{{ "loadSomeKeysMessage" | i18n }}</p>
+
+      <bit-search
+        class="tw-mb-4"
+        formControlName="searchText"
+        [placeholder]="'searchVault' | i18n"
+      ></bit-search>
+
+      <div class="tw-flex tw-flex-col tw-gap-2">
+        <label class="tw-font-semibold tw-text-sm">{{ "selectSshKeys" | i18n }}</label>
+        @for (key of filteredSshKeys; track key.id) {
+        <label
+          class="tw-flex tw-items-start tw-gap-3 tw-p-3 tw-rounded tw-border tw-border-secondary-300 hover:tw-bg-secondary-100 tw-cursor-pointer"
+        >
+          <input
+            type="checkbox"
+            bitCheckbox
+            [checked]="isKeySelected(key.id)"
+            (change)="toggleKeySelection(key.id)"
+          />
+          <div class="tw-flex-1">
+            <div class="tw-font-semibold">{{ key.name }}</div>
+            @if (getKeyFingerprint(key)) {
+            <div class="tw-text-sm tw-text-muted tw-mt-1">
+              <span class="tw-font-medium">{{ "sshFingerprint" | i18n }}:</span>
+              {{ getKeyFingerprint(key) }}
+            </div>
+            }
+          </div>
+        </label>
+        } @if (filteredSshKeys.length === 0) {
+        <p class="tw-text-muted tw-text-center tw-py-4">{{ "noItemsFound" | i18n }}</p>
+        }
+      </div>
+
+      <small class="tw-text-muted tw-block tw-mt-4">{{ "loadSomeKeysHelp" | i18n }}</small>
+    </div>
+    <ng-container bitDialogFooter>
+      <button
+        type="submit"
+        bitButton
+        bitFormButton
+        buttonType="primary"
+        [disabled]="selectedKeyIds.size === 0"
+      >
+        <span>{{ "loadKeys" | i18n }}</span>
+      </button>
+      <button type="button" bitButton bitFormButton buttonType="secondary" (click)="cancel()">
+        {{ "cancel" | i18n }}
+      </button>
+    </ng-container>
+  </bit-dialog>
+</form>

--- a/apps/desktop/src/platform/components/load-some-keys.ts
+++ b/apps/desktop/src/platform/components/load-some-keys.ts
@@ -1,0 +1,127 @@
+import { CommonModule } from "@angular/common";
+import { Component, Inject } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
+import { FormBuilder, ReactiveFormsModule } from "@angular/forms";
+
+import { JslibModule } from "@bitwarden/angular/jslib.module";
+import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+import {
+  DIALOG_DATA,
+  DialogRef,
+  AsyncActionsModule,
+  ButtonModule,
+  DialogModule,
+  FormFieldModule,
+  IconButtonModule,
+  DialogService,
+  CalloutModule,
+  SearchModule,
+  CheckboxModule,
+} from "@bitwarden/components";
+
+export interface LoadSomeKeysParams {
+  sshKeys: CipherView[];
+  currentlySelectedIds?: string[];
+}
+
+// FIXME(https://bitwarden.atlassian.net/browse/CL-764): Migrate to OnPush
+// eslint-disable-next-line @angular-eslint/prefer-on-push-component-change-detection
+@Component({
+  selector: "app-load-some-keys",
+  templateUrl: "load-some-keys.html",
+  imports: [
+    DialogModule,
+    CommonModule,
+    JslibModule,
+    ButtonModule,
+    IconButtonModule,
+    ReactiveFormsModule,
+    AsyncActionsModule,
+    FormFieldModule,
+    CalloutModule,
+    SearchModule,
+    CheckboxModule,
+  ],
+})
+export class LoadSomeKeysComponent {
+  loadSomeKeysForm = this.formBuilder.group({
+    searchText: [""],
+  });
+
+  filteredSshKeys: CipherView[] = [];
+  selectedKeyIds: Set<string> = new Set();
+
+  constructor(
+    @Inject(DIALOG_DATA) protected params: LoadSomeKeysParams,
+    private dialogRef: DialogRef<string[] | null>,
+    private formBuilder: FormBuilder,
+  ) {
+    this.filteredSshKeys = params.sshKeys || [];
+
+    // Pre-populate with currently selected keys
+    if (params.currentlySelectedIds) {
+      this.selectedKeyIds = new Set(params.currentlySelectedIds);
+    }
+
+    // Subscribe to search text changes
+    this.loadSomeKeysForm.controls.searchText.valueChanges
+      .pipe(takeUntilDestroyed())
+      .subscribe((searchText) => {
+        this.filterSshKeys(searchText || "");
+      });
+  }
+
+  private filterSshKeys(searchText: string): void {
+    if (!searchText) {
+      this.filteredSshKeys = this.params.sshKeys;
+      return;
+    }
+
+    const lowerSearchText = searchText.toLowerCase();
+    this.filteredSshKeys = this.params.sshKeys.filter((key) => {
+      return (
+        key.name?.toLowerCase().includes(lowerSearchText) ||
+        key.sshKey?.publicKey?.toLowerCase().includes(lowerSearchText) ||
+        key.sshKey?.keyFingerprint?.toLowerCase().includes(lowerSearchText)
+      );
+    });
+  }
+
+  toggleKeySelection(keyId: string): void {
+    if (this.selectedKeyIds.has(keyId)) {
+      this.selectedKeyIds.delete(keyId);
+    } else {
+      this.selectedKeyIds.add(keyId);
+    }
+  }
+
+  isKeySelected(keyId: string): boolean {
+    return this.selectedKeyIds.has(keyId);
+  }
+
+  getKeyFingerprint(key: CipherView): string {
+    return key.sshKey?.keyFingerprint || "";
+  }
+
+  static open(
+    dialogService: DialogService,
+    sshKeys: CipherView[],
+    currentlySelectedIds?: string[],
+  ) {
+    return dialogService.open<string[] | null, LoadSomeKeysParams>(LoadSomeKeysComponent, {
+      data: {
+        sshKeys,
+        currentlySelectedIds,
+      },
+    });
+  }
+
+  submit = async () => {
+    const selectedIds = Array.from(this.selectedKeyIds);
+    this.dialogRef.close(selectedIds);
+  };
+
+  cancel = () => {
+    this.dialogRef.close(null);
+  };
+}

--- a/apps/desktop/src/platform/components/select-ssh-key.html
+++ b/apps/desktop/src/platform/components/select-ssh-key.html
@@ -1,0 +1,57 @@
+<form [bitSubmit]="submit" [formGroup]="selectSshKeyForm">
+  <bit-dialog dialogSize="large">
+    <span bitDialogTitle>{{ "selectSshKeyTitle" | i18n }}</span>
+    <div bitDialogContent>
+      <p class="tw-mb-4">
+        <b>{{ params.applicationName }}</b> {{ "selectSshKeyMessageInfix" | i18n }}
+      </p>
+
+      <bit-search
+        class="tw-mb-4"
+        formControlName="searchText"
+        [placeholder]="'searchVault' | i18n"
+      ></bit-search>
+
+      <div class="tw-flex tw-flex-col tw-gap-2">
+        <label class="tw-font-semibold tw-text-sm">{{ "selectSshKeyLabel" | i18n }}</label>
+        <bit-radio-group formControlName="selectedKeyId">
+          @for (key of filteredSshKeys; track key.id) {
+          <label
+            class="tw-flex tw-items-start tw-gap-3 tw-p-3 tw-rounded tw-border tw-border-secondary-300 hover:tw-bg-secondary-100 tw-cursor-pointer"
+          >
+            <bit-radio-button [value]="key.id"></bit-radio-button>
+            <div class="tw-flex-1">
+              <div class="tw-font-semibold">{{ key.name }}</div>
+              @if (getKeyFingerprint(key)) {
+              <div class="tw-text-sm tw-text-muted tw-mt-1">
+                <span class="tw-font-medium">{{ "sshFingerprint" | i18n }}:</span> {{
+                getKeyFingerprint(key) }}
+              </div>
+              }
+            </div>
+          </label>
+          }
+        </bit-radio-group>
+        @if (filteredSshKeys.length === 0) {
+        <p class="tw-text-muted tw-text-center tw-py-4">{{ "noItemsFound" | i18n }}</p>
+        }
+      </div>
+
+      <small class="tw-text-muted tw-block tw-mt-4">{{ "selectSshKeyHelp" | i18n }}</small>
+    </div>
+    <ng-container bitDialogFooter>
+      <button
+        type="submit"
+        bitButton
+        bitFormButton
+        buttonType="primary"
+        [disabled]="!selectSshKeyForm.value.selectedKeyId"
+      >
+        <span>{{ "select" | i18n }}</span>
+      </button>
+      <button type="button" bitButton bitFormButton buttonType="secondary" (click)="cancel()">
+        {{ "cancel" | i18n }}
+      </button>
+    </ng-container>
+  </bit-dialog>
+</form>

--- a/apps/desktop/src/platform/components/select-ssh-key.ts
+++ b/apps/desktop/src/platform/components/select-ssh-key.ts
@@ -1,0 +1,113 @@
+import { CommonModule } from "@angular/common";
+import { Component, Inject } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
+import { FormBuilder, ReactiveFormsModule } from "@angular/forms";
+
+import { JslibModule } from "@bitwarden/angular/jslib.module";
+import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+import {
+  DIALOG_DATA,
+  DialogRef,
+  AsyncActionsModule,
+  ButtonModule,
+  DialogModule,
+  FormFieldModule,
+  IconButtonModule,
+  DialogService,
+  CalloutModule,
+  RadioButtonModule,
+  SearchModule,
+} from "@bitwarden/components";
+
+export interface SelectSshKeyParams {
+  sshKeys: CipherView[];
+  applicationName: string;
+  namespace: string;
+}
+
+// FIXME(https://bitwarden.atlassian.net/browse/CL-764): Migrate to OnPush
+// eslint-disable-next-line @angular-eslint/prefer-on-push-component-change-detection
+@Component({
+  selector: "app-select-ssh-key",
+  templateUrl: "select-ssh-key.html",
+  imports: [
+    DialogModule,
+    CommonModule,
+    JslibModule,
+    ButtonModule,
+    IconButtonModule,
+    ReactiveFormsModule,
+    AsyncActionsModule,
+    FormFieldModule,
+    CalloutModule,
+    RadioButtonModule,
+    SearchModule,
+  ],
+})
+export class SelectSshKeyComponent {
+  selectSshKeyForm = this.formBuilder.group({
+    selectedKeyId: [null as string | null],
+    searchText: [""],
+  });
+
+  filteredSshKeys: CipherView[] = [];
+
+  constructor(
+    @Inject(DIALOG_DATA) protected params: SelectSshKeyParams,
+    private dialogRef: DialogRef<string | null>,
+    private formBuilder: FormBuilder,
+  ) {
+    this.filteredSshKeys = params.sshKeys || [];
+
+    // Subscribe to search text changes
+    this.selectSshKeyForm.controls.searchText.valueChanges
+      .pipe(takeUntilDestroyed())
+      .subscribe((searchText) => {
+        this.filterSshKeys(searchText || "");
+      });
+  }
+
+  private filterSshKeys(searchText: string): void {
+    if (!searchText) {
+      this.filteredSshKeys = this.params.sshKeys;
+      return;
+    }
+
+    const lowerSearchText = searchText.toLowerCase();
+    this.filteredSshKeys = this.params.sshKeys.filter((key) => {
+      return (
+        key.name?.toLowerCase().includes(lowerSearchText) ||
+        key.sshKey?.publicKey?.toLowerCase().includes(lowerSearchText) ||
+        key.sshKey?.keyFingerprint?.toLowerCase().includes(lowerSearchText)
+      );
+    });
+  }
+
+  getKeyFingerprint(key: CipherView): string {
+    return key.sshKey?.keyFingerprint || "";
+  }
+
+  static open(
+    dialogService: DialogService,
+    sshKeys: CipherView[],
+    applicationName: string,
+    namespace: string,
+  ) {
+    return dialogService.open<string | null, SelectSshKeyParams>(SelectSshKeyComponent, {
+      data: {
+        sshKeys,
+        applicationName,
+        namespace,
+      },
+    });
+  }
+
+  submit = async () => {
+    const selectedKeyId = this.selectSshKeyForm.value.selectedKeyId;
+    this.dialogRef.close(selectedKeyId);
+  };
+
+  cancel = () => {
+    this.dialogRef.close(null);
+  };
+}

--- a/apps/desktop/src/platform/services/desktop-settings.service.ts
+++ b/apps/desktop/src/platform/services/desktop-settings.service.ts
@@ -102,6 +102,15 @@ const SSH_AGENT_KEY_SELECTION_MODE = new UserKeyDefinition<SshAgentKeySelectionM
   },
 );
 
+const SSH_AGENT_SELECTED_KEY_IDS = new UserKeyDefinition<string[]>(
+  DESKTOP_SETTINGS_DISK,
+  "sshAgentSelectedKeyIds",
+  {
+    deserializer: (ids) => ids ?? [],
+    clearOn: [],
+  },
+);
+
 const MINIMIZE_ON_COPY = new UserKeyDefinition<boolean>(DESKTOP_SETTINGS_DISK, "minimizeOnCopy", {
   deserializer: (b) => b,
   clearOn: [], // User setting, no need to clear
@@ -201,6 +210,13 @@ export class DesktopSettingsService {
   );
   sshAgentKeySelectionMode$ = this.sshAgentKeySelectionModeState.state$.pipe(
     map((v) => v ?? SshAgentKeySelectionMode.AllKeys),
+  );
+
+  private readonly sshAgentSelectedKeyIdsState = this.stateProvider.getActive(
+    SSH_AGENT_SELECTED_KEY_IDS,
+  );
+  readonly sshAgentSelectedKeyIds$ = this.sshAgentSelectedKeyIdsState.state$.pipe(
+    map((v) => v ?? []),
   );
 
   private readonly preventScreenshotState = this.stateProvider.getGlobal(PREVENT_SCREENSHOTS);
@@ -342,6 +358,10 @@ export class DesktopSettingsService {
 
   async setSshAgentKeySelectionMode(value: SshAgentKeySelectionMode) {
     await this.sshAgentKeySelectionModeState.update(() => value);
+  }
+
+  async setSshAgentSelectedKeyIds(value: string[]): Promise<void> {
+    await this.sshAgentSelectedKeyIdsState.update(() => value);
   }
 
   /**

--- a/apps/desktop/src/platform/services/desktop-settings.service.ts
+++ b/apps/desktop/src/platform/services/desktop-settings.service.ts
@@ -18,7 +18,10 @@ import {
 } from "@bitwarden/common/platform/state";
 import { UserId } from "@bitwarden/common/types/guid";
 
-import { SshAgentPromptType } from "../../autofill/models/ssh-agent-setting";
+import {
+  SshAgentKeySelectionMode,
+  SshAgentPromptType,
+} from "../../autofill/models/ssh-agent-setting";
 import { ModalModeState, WindowState } from "../models/domain/window-state";
 
 export const HARDWARE_ACCELERATION = new KeyDefinition<boolean>(
@@ -84,6 +87,15 @@ const SSH_AGENT_ENABLED = new KeyDefinition<boolean>(DESKTOP_SETTINGS_DISK, "ssh
 const SSH_AGENT_PROMPT_BEHAVIOR = new UserKeyDefinition<SshAgentPromptType>(
   DESKTOP_SETTINGS_DISK,
   "sshAgentRememberAuthorizations",
+  {
+    deserializer: (b) => b,
+    clearOn: [],
+  },
+);
+
+const SSH_AGENT_KEY_SELECTION_MODE = new UserKeyDefinition<SshAgentKeySelectionMode>(
+  DESKTOP_SETTINGS_DISK,
+  "sshAgentKeySelectionMode",
   {
     deserializer: (b) => b,
     clearOn: [],
@@ -182,6 +194,13 @@ export class DesktopSettingsService {
   private readonly sshAgentPromptBehavior = this.stateProvider.getActive(SSH_AGENT_PROMPT_BEHAVIOR);
   sshAgentPromptBehavior$ = this.sshAgentPromptBehavior.state$.pipe(
     map((v) => v ?? SshAgentPromptType.Always),
+  );
+
+  private readonly sshAgentKeySelectionModeState = this.stateProvider.getActive(
+    SSH_AGENT_KEY_SELECTION_MODE,
+  );
+  sshAgentKeySelectionMode$ = this.sshAgentKeySelectionModeState.state$.pipe(
+    map((v) => v ?? SshAgentKeySelectionMode.AllKeys),
   );
 
   private readonly preventScreenshotState = this.stateProvider.getGlobal(PREVENT_SCREENSHOTS);
@@ -319,6 +338,10 @@ export class DesktopSettingsService {
 
   async setSshAgentPromptBehavior(value: SshAgentPromptType) {
     await this.sshAgentPromptBehavior.update(() => value);
+  }
+
+  async setSshAgentKeySelectionMode(value: SshAgentKeySelectionMode) {
+    await this.sshAgentKeySelectionModeState.update(() => value);
   }
 
   /**


### PR DESCRIPTION
## Type of change
- [x] New feature development

## Objective
Add a new SSH Agent setting that allows users to choose between three key selection modes: sending all SSH keys, selecting a specific key for each request, or pre-loading specific keys to keep in memory.

## Code changes
**Desktop App:**
- `apps/desktop/src/autofill/models/ssh-agent-setting.ts`: Extended `SshAgentKeySelectionMode` const object with `AllKeys`, `SelectKey`, and `LoadSomeKeys` options
- `apps/desktop/src/autofill/services/ssh-agent.service.ts`: Implemented key selection logic for all three modes with proper lifecycle management and vault lock detection
- `apps/desktop/src/platform/components/select-ssh-key.ts`: Dialog component for single SSH key selection with search/filter functionality
- `apps/desktop/src/platform/components/select-ssh-key.html`: Dialog template displaying key names and fingerprints
- `apps/desktop/src/platform/components/load-some-keys.ts`: Multi-select dialog component for choosing multiple SSH keys to pre-load
- `apps/desktop/src/platform/components/load-some-keys.html`: Dialog template with checkboxes for multi-select functionality
- `apps/desktop/src/platform/services/desktop-settings.service.ts`: Added state management for SSH Agent key selection mode setting and selected key IDs storage
- `apps/desktop/src/app/accounts/settings.component.ts`: Integrated new setting into settings form with mode change handler
- `apps/desktop/src/app/accounts/settings.component.html`: Added UI controls for key selection mode
- `apps/desktop/src/locales/en/messages.json`: Added i18n strings for new UI elements

## New behavior

### Mode 1: "Send all SSH keys" (default)
- Existing behavior is preserved - all SSH keys are sent to the agent automatically
- Keys continuously synced to agent every second while vault is unlocked

### Mode 2: "Select key for each request"
1. User is prompted with a dialog to choose a specific SSH key when an SSH connection is requested
2. The dialog displays key names and fingerprints with search/filter functionality
3. Only the selected key is sent to the SSH agent for that specific connection
4. The key is automatically removed from the agent after use
5. User must re-select a key for each new connection (even to the same server)

### Mode 3: "Load some keys"
1. On first SSH connection attempt, user is prompted with a multi-select dialog
2. User selects one or multiple keys using checkboxes
3. Selected keys are loaded into the SSH agent and kept in memory
4. All subsequent SSH connections use the pre-loaded keys without prompts
5. Selection is automatically cleared when:
   - Vault is locked (allows re-selection on next unlock)
   - User switches to a different mode
6. Keys are continuously synced to agent every second (similar to AllKeys mode, but only selected keys)

## Security considerations
- Keys are cleared after each use in SelectKey mode to minimize exposure
- LoadSomeKeys mode provides granular control without exposing all keys
- User has explicit control over which keys are available to the agent
- Follows principle of least privilege by only exposing selected keys
- Selection automatically cleared on vault lock for security
- Per-user storage ensures different accounts maintain separate selections

## Implementation notes
- Follows Bitwarden architectural patterns:
  - Uses frozen const object instead of enum (ADR-0025)
  - Observable data services pattern (ADR-0003)
  - Proper RxJS subscription management with `concatMap` and `takeUntil`
- Consistent with existing SSH Agent settings structure
- All Tailwind CSS classes use required `tw-` prefix
- Vault lock detection via `authService.activeAccountStatus$`
- UserKeyDefinition ensures per-account storage with automatic switching

## Screenshots
<details><summary>UI changes</summary>
<p>

1. New setting in the Desktop settings page with three options:
<img width="518" height="229" alt="image" src="https://github.com/user-attachments/assets/0562bfef-ab59-456b-8d6a-2254786570c3" />
<br>
2. SSH key selection dialog (SelectKey mode - single selection):
<img width="649" height="355" alt="image" src="https://github.com/user-attachments/assets/b594009a-c0db-4945-914f-31fbd138638c" />
<br>
3. Multi-key selection dialog (LoadSomeKeys mode):
<img width="649" height="515" alt="image" src="https://github.com/user-attachments/assets/2ab26ac5-d726-4591-b23d-9ff2666ee484" />

<br>

</p>
</details> 

## Testing requirements
- [x] Verify "Send all SSH keys" mode works as before (default behavior unchanged)
- [x] Verify "Select key for each request" mode shows dialog on SSH connection
- [x] Verify search/filter functionality in key selection dialog
- [x] Verify selected key is cleared after use and re-requested on next connection
- [x] Verify "Load some keys" mode shows multi-select dialog on first connection
- [x] Verify selected keys persist across SSH connections without prompts
- [x] Verify selected keys are continuously synced while vault is unlocked
- [x] Verify selection is cleared when vault locks
- [x] Verify selection is cleared when switching away from LoadSomeKeys mode
- [x] Verify submit button is disabled when no keys are selected
- [x] Verify behavior when vault is locked during SSH request
- [x] Verify behavior when no SSH keys exist in vault
- [x] Verify account switching maintains separate selections per account
