### PR TITLE
[PM-31012] Improve loading time for lock component

### DIFF
--- a/libs/key-management-ui/src/lock/components/lock.component.ts
+++ b/libs/key-management-ui/src/lock/components/lock.component.ts
@@ -6,7 +6,6 @@ import {
   BehaviorSubject,
   filter,
   firstValueFrom,
-  interval,
   timer,
   mergeMap,
   Subject,


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-31012

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Replaces interval with timer. Timer allows specifying an initial delay, in this case zero. Interval emits for the first time after the interval has passed. This effectively means the first time the unlock component renders is delayed by one second

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

Before:
[Screencast_20260120_112254.webm](https://github.com/user-attachments/assets/3c4839c5-2910-48a2-b925-a644552f2a9b)



After:
[Screencast_20260120_112058.webm](https://github.com/user-attachments/assets/0328c5c3-2cfa-455b-90dc-0c42c169226e)

