### PR TITLE
[PM-31029] Remove padding on new-vault (desktop)

### DIFF
--- a/apps/desktop/src/app/app-routing.module.ts
+++ b/apps/desktop/src/app/app-routing.module.ts
@@ -41,7 +41,11 @@ import {
   NewDeviceVerificationComponent,
 } from "@bitwarden/auth/angular";
 import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
-import { AnonLayoutWrapperComponent, AnonLayoutWrapperData } from "@bitwarden/components";
+import {
+  AnonLayoutWrapperComponent,
+  AnonLayoutWrapperData,
+  Translation,
+} from "@bitwarden/components";
 import {
   LockComponent,
   ConfirmKeyConnectorDomainComponent,
@@ -63,10 +67,17 @@ import { SendV2Component } from "./tools/send-v2/send-v2.component";
 /**
  * Data properties acceptable for use in route objects in the desktop
  */
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface RouteDataProperties {
-  // For any new route data properties, add them here.
-  // then assert that the data object satisfies this interface in the route object.
+  /**
+   * The optional title of the page.
+   * If a string is provided, it will be presented as is (ex: Organization name)
+   * If a Translation object (supports placeholders) is provided, it will be translated
+   */
+  pageTitle?: string | Translation | null;
+  /**
+   * Temporary flag to remove padding from layout component during desktop ui migration
+   */
+  noPadding?: boolean;
 }
 
 const routes: Routes = [
@@ -359,6 +370,7 @@ const routes: Routes = [
       {
         path: "new-vault",
         component: VaultComponent,
+        data: { noPadding: true } satisfies RouteDataProperties,
       },
       {
         path: "new-sends",

--- a/apps/desktop/src/app/layout/desktop-layout.component.html
+++ b/apps/desktop/src/app/layout/desktop-layout.component.html
@@ -1,4 +1,4 @@
-<bit-layout class="!tw-h-full">
+<bit-layout class="!tw-h-full" [class.no-padding]="noPadding()">
   <app-side-nav slot="side-nav">
     <bit-nav-logo [openIcon]="logo" route="." [label]="'passwordManager' | i18n" />
 

--- a/apps/desktop/src/app/layout/desktop-layout.component.ts
+++ b/apps/desktop/src/app/layout/desktop-layout.component.ts
@@ -1,5 +1,7 @@
 import { Component, inject } from "@angular/core";
-import { RouterModule } from "@angular/router";
+import { toSignal } from "@angular/core/rxjs-interop";
+import { ActivatedRoute, NavigationEnd, Router, RouterModule } from "@angular/router";
+import { filter, map, startWith } from "rxjs";
 
 import { PasswordManagerLogo } from "@bitwarden/assets/svg";
 import { DialogService, LayoutComponent, NavigationModule } from "@bitwarden/components";
@@ -30,8 +32,18 @@ import { DesktopSideNavComponent } from "./desktop-side-nav.component";
 })
 export class DesktopLayoutComponent {
   private dialogService = inject(DialogService);
+  private router = inject(Router);
+  private route = inject(ActivatedRoute);
 
   protected readonly logo = PasswordManagerLogo;
+  protected readonly noPadding = toSignal(
+    this.router.events.pipe(
+      filter((event) => event instanceof NavigationEnd),
+      startWith(null),
+      map(() => Boolean(this.route.firstChild?.snapshot?.data?.["noPadding"])),
+    ),
+    { initialValue: false },
+  );
 
   protected openGenerator() {
     this.dialogService.open(CredentialGeneratorComponent);

--- a/apps/desktop/src/scss/migration.scss
+++ b/apps/desktop/src/scss/migration.scss
@@ -1,0 +1,5 @@
+// Styles for the desktop UI migration
+
+bit-layout.no-padding main {
+  padding: 0 !important;
+}

--- a/apps/desktop/src/scss/styles.scss
+++ b/apps/desktop/src/scss/styles.scss
@@ -17,3 +17,4 @@
 @import "plugins.scss";
 @import "../../../../libs/angular/src/scss/icons.scss";
 @import "../../../../libs/components/src/multi-select/scss/bw.theme";
+@import "migration.scss";


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-31029
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

We need to remove padding on certain pages (i.e. the vault page) but keeping it in others. This adds a temporary conditional `noPadding` route param that handles this.
