### PR TITLE
[PM-30828] added MP reprompt check to unarchive

### DIFF
--- a/libs/vault/src/services/archive-cipher-utilities.service.spec.ts
+++ b/libs/vault/src/services/archive-cipher-utilities.service.spec.ts
@@ -120,5 +120,19 @@ describe("ArchiveCipherUtilitiesService", () => {
         message: "errorOccurred",
       });
     });
+
+    it("calls password reprompt check when unarchiving", async () => {
+      await service.unarchiveCipher(mockCipher);
+
+      expect(passwordRepromptService.passwordRepromptCheck).toHaveBeenCalledWith(mockCipher);
+    });
+
+    it("returns early when password reprompt fails on unarchive", async () => {
+      passwordRepromptService.passwordRepromptCheck.mockResolvedValue(false);
+
+      await service.unarchiveCipher(mockCipher);
+
+      expect(cipherArchiveService.unarchiveWithServer).not.toHaveBeenCalled();
+    });
   });
 });

--- a/libs/vault/src/services/archive-cipher-utilities.service.ts
+++ b/libs/vault/src/services/archive-cipher-utilities.service.ts
@@ -74,7 +74,14 @@ export class ArchiveCipherUtilitiesService {
    * @param cipher The cipher to unarchive
    * @returns The unarchived cipher on success, or undefined on failure
    */
-  async unarchiveCipher(cipher: CipherView) {
+  async unarchiveCipher(cipher: CipherView, skipReprompt = false) {
+    if (!skipReprompt) {
+      const repromptPassed = await this.passwordRepromptService.passwordRepromptCheck(cipher);
+      if (!repromptPassed) {
+        return;
+      }
+    }
+
     const userId = await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId));
     try {
       const cipherResponse = await this.cipherArchiveService.unarchiveWithServer(


### PR DESCRIPTION
## 🎟️ Tracking

[PM-30828](https://bitwarden.atlassian.net/browse/PM-30828)

## 📔 Objective

Adding a check for MP reprompt in the `unarchiveCipher` in the `archive cipher utilities service`. 

## 📸 Screen Recording


https://github.com/user-attachments/assets/c0493376-5194-4e0e-b04c-5a8a01a20504




[PM-30828]: https://bitwarden.atlassian.net/browse/PM-30828?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ