### PR TITLE
[PM-30470] Revert to using X11 on Linux desktop

### DIFF
--- a/apps/desktop/resources/linux-wrapper.sh
+++ b/apps/desktop/resources/linux-wrapper.sh
@@ -12,6 +12,10 @@ if [ -e "/usr/lib/x86_64-linux-gnu/libdbus-1.so.3" ]; then
   export LD_PRELOAD="/usr/lib/x86_64-linux-gnu/libdbus-1.so.3"
 fi
 
+# A bug in Electron 39 (which now enables Wayland by default) causes a crash on
+# systems using Wayland with hardware acceleration. Platform decided to
+# configure Electron to use X11 (with an opt-out) until the upstream bug is
+# fixed. The follow-up task is https://bitwarden.atlassian.net/browse/PM-31080.
 PARAMS="--enable-features=UseOzonePlatform,WaylandWindowDecorations --ozone-platform-hint=auto"
 if [ "$USE_X11" != "false" ]; then
   PARAMS="--ozone-platform=x11"


### PR DESCRIPTION
## 🎟️ Tracking

[PM-30470](https://bitwarden.atlassian.net/browse/PM-30470)

## 📔 Objective

Electron 39 contains a bug on Linux desktop for Wayland when hardware acceleration is in use that results in a crash during startup. This PR changes the Linux desktop app's default usage of Wayland to X11 to mitigate this crash until the upstream bug is fixed.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->


[PM-30470]: https://bitwarden.atlassian.net/browse/PM-30470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ