### PR TITLE
[PM-30890] Archive Sync Desktop Improvements

### DIFF
--- a/libs/angular/src/vault/components/vault-items.component.ts
+++ b/libs/angular/src/vault/components/vault-items.component.ts
@@ -194,12 +194,7 @@ export class VaultItemsComponent<C extends CipherViewLike> implements OnDestroy 
           return this.searchService.searchCiphers(
             userId,
             searchText,
-            [
-              filter,
-              this.deletedFilter,
-              ...(this.deleted ? [] : [this.archivedFilter]),
-              restrictedTypeFilter,
-            ],
+            [filter, restrictedTypeFilter],
             allCiphers,
           );
         }),

--- a/libs/angular/src/vault/vault-filter/models/vault-filter.model.ts
+++ b/libs/angular/src/vault/vault-filter/models/vault-filter.model.ts
@@ -54,6 +54,12 @@ export class VaultFilter {
         cipherPassesFilter =
           CipherViewLikeUtils.isArchived(cipher) && !CipherViewLikeUtils.isDeleted(cipher);
       }
+
+      if (this.status !== "archive" && this.status !== "trash" && cipherPassesFilter) {
+        cipherPassesFilter =
+          !CipherViewLikeUtils.isArchived(cipher) && !CipherViewLikeUtils.isDeleted(cipher);
+      }
+
       if (this.cipherType != null && cipherPassesFilter) {
         cipherPassesFilter = CipherViewLikeUtils.getType(cipher) === this.cipherType;
       }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-30890](https://bitwarden.atlassian.net/browse/PM-30890)

## 📔 Objective

Previously using `Sync Now` while in archive or trash would remove the listed items. update vault-filter model in desktop to improve sync for archive and trash. Updates do not impact current flow. Archive Items will only show in filters `archive` and `trash` 

## 📸 Screen Recording

https://github.com/user-attachments/assets/1b1716b3-2a5c-4c0a-99e8-433fae4a7aef


[PM-30890]: https://bitwarden.atlassian.net/browse/PM-30890?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ