### PR TITLE
[PM-31072] Web Remove Unarchive Btn from Archived Trash Item

### DIFF
--- a/apps/web/src/app/vault/components/vault-item-dialog/vault-item-dialog.component.html
+++ b/apps/web/src/app/vault/components/vault-item-dialog/vault-item-dialog.component.html
@@ -87,7 +87,7 @@
     @if (showActionButtons) {
       <div class="tw-ml-auto">
         @if ((userCanArchive$ | async) && !params.isAdminConsoleAction) {
-          @if (isCipherArchived) {
+          @if (isCipherArchived && !cipher?.isDeleted) {
             <button
               type="button"
               class="tw-mr-1"


### PR DESCRIPTION
## 🎟️ Tracking

[PM-31072](https://bitwarden.atlassian.net/browse/PM-31072)

## 📔 Objective

When an archive item is in trash it should not have the `Unarchive` button in the footer of the modal.

## 📸 Screenshots

<img width="849" height="617" alt="PM-31072-trash-archive-item" src="https://github.com/user-attachments/assets/572e9031-52dd-437e-a582-34f5684726ee" />


[PM-31072]: https://bitwarden.atlassian.net/browse/PM-31072?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ