### PR TITLE
[PM-31142] Do not set extension width when ran in full browser tab

### DIFF
--- a/apps/browser/src/platform/popup/layout/popup-size.service.ts
+++ b/apps/browser/src/platform/popup/layout/popup-size.service.ts
@@ -37,7 +37,7 @@ export class PopupSizeService {
   /** Begin listening for state changes */
   async init() {
     this.width$.subscribe((width: PopupWidthOption) => {
-      PopupSizeService.setStyle(width);
+      void PopupSizeService.setStyle(width);
       localStorage.setItem(PopupSizeService.LocalStorageKey, width);
     });
   }
@@ -77,8 +77,9 @@ export class PopupSizeService {
     }
   }
 
-  private static setStyle(width: PopupWidthOption) {
-    if (!BrowserPopupUtils.inPopup(window)) {
+  private static async setStyle(width: PopupWidthOption) {
+    const isInTab = await BrowserPopupUtils.isInTab();
+    if (!BrowserPopupUtils.inPopup(window) || isInTab) {
       return;
     }
     const pxWidth = PopupWidthOptions[width] ?? PopupWidthOptions.default;
@@ -91,6 +92,6 @@ export class PopupSizeService {
    **/
   static initBodyWidthFromLocalStorage() {
     const storedValue = localStorage.getItem(PopupSizeService.LocalStorageKey);
-    this.setStyle(storedValue as any);
+    void this.setStyle(storedValue as any);
   }
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-31142](https://bitwarden.atlassian.net/browse/PM-31142)

## 📔 Objective

[#18376](https://github.com/bitwarden/clients/pull/18376/changes#diff-e3e9509468b5e6777120f1dfa7eebd433799e79819b83e4f1bcb96c399595f1aL86-R86) introduced a change to move from `minWidth` to `width` which is needed because the predefined sizes of the extension increase and decrease from the default. 

This caused an issue when the extension is opened in a full browser tab as the width would be smaller than expected in the window. This change does not set the `width` when the extension is opened in a full browser tab. 

## 📸 Screenshots

<video src="https://github.com/user-attachments/assets/5d3c6ac4-1f32-4b8f-b072-f4f89d1ecd8a" />


[PM-31142]: https://bitwarden.atlassian.net/browse/PM-31142?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ