### PR TITLE
[PM-31188] Desktop Trash Items Context Menu Updates

### DIFF
--- a/apps/desktop/src/vault/app/vault/vault-v2.component.ts
+++ b/apps/desktop/src/vault/app/vault/vault-v2.component.ts
@@ -642,83 +642,80 @@ export class VaultV2Component<C extends CipherViewLike>
       });
     }
 
-    switch (cipher.type) {
-      case CipherType.Login:
-        if (
-          cipher.login.canLaunch ||
-          cipher.login.username != null ||
-          cipher.login.password != null
-        ) {
-          menu.push({ type: "separator" });
-        }
-        if (cipher.isDeleted) {
+    if (!cipher.isDeleted) {
+      switch (cipher.type) {
+        case CipherType.Login:
+          if (
+            cipher.login.canLaunch ||
+            cipher.login.username != null ||
+            cipher.login.password != null
+          ) {
+            menu.push({ type: "separator" });
+          }
+          if (cipher.login.canLaunch) {
+            menu.push({
+              label: this.i18nService.t("launch"),
+              click: () => this.platformUtilsService.launchUri(cipher.login.launchUri),
+            });
+          }
+          if (cipher.login.username != null) {
+            menu.push({
+              label: this.i18nService.t("copyUsername"),
+              click: () => this.copyValue(cipher, cipher.login.username, "username", "Username"),
+            });
+          }
+          if (cipher.login.password != null && cipher.viewPassword) {
+            menu.push({
+              label: this.i18nService.t("copyPassword"),
+              click: () => {
+                this.copyValue(cipher, cipher.login.password, "password", "Password");
+                this.eventCollectionService
+                  .collect(EventType.Cipher_ClientCopiedPassword, cipher.id)
+                  .catch(() => {});
+              },
+            });
+          }
+          if (cipher.login.hasTotp && (cipher.organizationUseTotp || this.userHasPremiumAccess)) {
+            menu.push({
+              label: this.i18nService.t("copyVerificationCodeTotp"),
+              click: async () => {
+                const value = await firstValueFrom(
+                  this.totpService.getCode$(cipher.login.totp),
+                ).catch((): any => null);
+                if (value) {
+                  this.copyValue(cipher, value.code, "verificationCodeTotp", "TOTP");
+                }
+              },
+            });
+          }
           break;
-        }
-        if (cipher.login.canLaunch) {
-          menu.push({
-            label: this.i18nService.t("launch"),
-            click: () => this.platformUtilsService.launchUri(cipher.login.launchUri),
-          });
-        }
-        if (cipher.login.username != null) {
-          menu.push({
-            label: this.i18nService.t("copyUsername"),
-            click: () => this.copyValue(cipher, cipher.login.username, "username", "Username"),
-          });
-        }
-        if (cipher.login.password != null && cipher.viewPassword) {
-          menu.push({
-            label: this.i18nService.t("copyPassword"),
-            click: () => {
-              this.copyValue(cipher, cipher.login.password, "password", "Password");
-              this.eventCollectionService
-                .collect(EventType.Cipher_ClientCopiedPassword, cipher.id)
-                .catch(() => {});
-            },
-          });
-        }
-        if (cipher.login.hasTotp && (cipher.organizationUseTotp || this.userHasPremiumAccess)) {
-          menu.push({
-            label: this.i18nService.t("copyVerificationCodeTotp"),
-            click: async () => {
-              const value = await firstValueFrom(
-                this.totpService.getCode$(cipher.login.totp),
-              ).catch((): any => null);
-              if (value) {
-                this.copyValue(cipher, value.code, "verificationCodeTotp", "TOTP");
-              }
-            },
-          });
-        }
-        break;
-      case CipherType.Card:
-        if (cipher.isDeleted) {
+        case CipherType.Card:
+          if (cipher.card.number != null || cipher.card.code != null) {
+            menu.push({ type: "separator" });
+          }
+          if (cipher.card.number != null) {
+            menu.push({
+              label: this.i18nService.t("copyNumber"),
+              click: () => this.copyValue(cipher, cipher.card.number, "number", "Card Number"),
+            });
+          }
+          if (cipher.card.code != null) {
+            menu.push({
+              label: this.i18nService.t("copySecurityCode"),
+              click: () => {
+                this.copyValue(cipher, cipher.card.code, "securityCode", "Security Code");
+                this.eventCollectionService
+                  .collect(EventType.Cipher_ClientCopiedCardCode, cipher.id)
+                  .catch(() => {});
+              },
+            });
+          }
           break;
-        }
-        if (cipher.card.number != null || cipher.card.code != null) {
-          menu.push({ type: "separator" });
-        }
-        if (cipher.card.number != null) {
-          menu.push({
-            label: this.i18nService.t("copyNumber"),
-            click: () => this.copyValue(cipher, cipher.card.number, "number", "Card Number"),
-          });
-        }
-        if (cipher.card.code != null) {
-          menu.push({
-            label: this.i18nService.t("copySecurityCode"),
-            click: () => {
-              this.copyValue(cipher, cipher.card.code, "securityCode", "Security Code");
-              this.eventCollectionService
-                .collect(EventType.Cipher_ClientCopiedCardCode, cipher.id)
-                .catch(() => {});
-            },
-          });
-        }
-        break;
-      default:
-        break;
+        default:
+          break;
+      }
     }
+
     invokeMenu(menu);
   }
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-31188](https://bitwarden.atlassian.net/browse/PM-31188)

## 📔 Objective

An item that is in desktop trash should only not apply options such as `copy password` and `copy username`. Added a `isDeleted` check to the other options in the menu (matching the previously applied checks to Archive and Unarchive).

## 📸 Screenshots

<img width="1238" height="409" alt="Screenshot 2026-01-23 at 12 23 09 PM" src="https://github.com/user-attachments/assets/e198a633-8125-4a9f-b7c2-9bb9dae4c928" />

<img width="1232" height="443" alt="Screenshot 2026-01-23 at 12 22 59 PM" src="https://github.com/user-attachments/assets/020b24a1-f5bf-4d63-ad0d-1305e1e08356" />

<img width="1237" height="472" alt="Screenshot 2026-01-23 at 12 22 48 PM" src="https://github.com/user-attachments/assets/2ab2329e-eb1a-4f29-b700-42b2285efca3" />



[PM-31188]: https://bitwarden.atlassian.net/browse/PM-31188?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ