### PR TITLE
[PM-31182] Add HIBP icons URL to dev configuration for allowed Content-Security-Policy domains 

### DIFF
--- a/apps/web/webpack.base.js
+++ b/apps/web/webpack.base.js
@@ -319,7 +319,6 @@ module.exports.buildConfig = function buildConfig(params) {
                     https://*.paypal.com
                     https://www.paypalobjects.com
                     https://q.stripe.com
-                    https://haveibeenpwned.com
                     https://logos.haveibeenpwned.com
                     ;media-src
                     'self'


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-31182

## 📔 Objective
The updated location for Have I Been Pwned icons is added to allowed CSP domains to allow icons to properly load in the Data Breach report (see Adobe icon loading below) 

## 📸 Screenshots
<img width="1778" height="1191" alt="image" src="https://github.com/user-attachments/assets/9a371d70-fafd-4acb-bd2b-eeca4bb51829" />
