### PR TITLE
[PM-31253] Desktop Footer Tooltip Updates

### DIFF
--- a/apps/desktop/src/vault/app/vault/item-footer.component.html
+++ b/apps/desktop/src/vault/app/vault/item-footer.component.html
@@ -44,7 +44,7 @@
   @if (hasFooterAction) {
     <div class="right">
       @if (showArchiveButton) {
-        <button type="button" (click)="archive()" [appA11yTitle]="archiveTooltip">
+        <button type="button" (click)="archive()" appA11yTitle="{{ 'archiveVerb' | i18n }}">
           <i
             class="bwi bwi-archive bwi-lg bwi-fw"
             aria-hidden="true"
@@ -54,7 +54,7 @@
       }
 
       @if (showUnarchiveButton) {
-        <button type="button" (click)="unarchive()" [appA11yTitle]="unarchiveTooltip">
+        <button type="button" (click)="unarchive()" appA11yTitle="{{ 'unArchive' | i18n }}">
           <i
             class="bwi bwi-unarchive bwi-lg bwi-fw"
             aria-hidden="true"

--- a/apps/desktop/src/vault/app/vault/item-footer.component.ts
+++ b/apps/desktop/src/vault/app/vault/item-footer.component.ts
@@ -73,12 +73,6 @@ export class ItemFooterComponent implements OnInit, OnChanges {
   activeUserId: UserId | null = null;
   passwordReprompted: boolean = false;
 
-  protected readonly editTooltip = this.i18nService.t("edit");
-  protected readonly cloneTooltip = this.i18nService.t("clone");
-  protected readonly restoreTooltip = this.i18nService.t("restore");
-  protected readonly archiveTooltip = this.i18nService.t("archiveVerb");
-  protected readonly unarchiveTooltip = this.i18nService.t("unArchive");
-
   protected showArchiveButton = false;
   protected showUnarchiveButton = false;
   protected userCanArchive = false;


### PR DESCRIPTION
## 🎟️ Tracking

[PM-31253](https://bitwarden.atlassian.net/browse/PM-31253)

## 📔 Objective

The desktop footer buttons has tooltips through `appA11yTitle` that should appear on hover. This seemed to appear only when the user hovers over the button but not the icon. The icon pointer styling was overriding the `appA11yTitle`. 

* Updated the footer component to use `style="pointer-events: none"`
* Updated the footer component replacing `ngIf` with `@if`
* This bug ticket was initially for the `archive` and `unarchive` buttons. However the issue was occurring for all buttons in the footer, so the above changes were applied to all buttons. 

## 📸 Screen Recording

https://github.com/user-attachments/assets/8c9338ab-7f49-4efe-8a5d-da607c45b998


[PM-31253]: https://bitwarden.atlassian.net/browse/PM-31253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ