### PR TITLE
[PM-31185] Member Access Report: Show user's email when name is undefined

### DIFF
--- a/bitwarden_license/bit-web/src/app/dirt/reports/member-access-report/member-access-report.component.html
+++ b/bitwarden_license/bit-web/src/app/dirt/reports/member-access-report/member-access-report.component.html
@@ -47,12 +47,14 @@
         <bit-avatar size="small" [text]="row.name" class="tw-mr-3"></bit-avatar>
         <div class="tw-flex tw-flex-col">
           <button type="button" bitLink (click)="edit(row)">
-            {{ row.name }}
+            {{ row.name ?? row.email }}
           </button>
 
-          <div class="tw-text-sm tw-mt-1 tw-text-muted">
-            {{ row.email }}
-          </div>
+          @if (row.name) {
+            <div class="tw-text-sm tw-mt-1 tw-text-muted">
+              {{ row.email }}
+            </div>
+          }
         </div>
       </div>
     </td>


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-31185

## 📔 Objective
On the Member Access report, render the user's email as primary row content when the user's name is unset/unavailable.

## 📸 Screenshots
<img width="1778" height="1191" alt="image" src="https://github.com/user-attachments/assets/b1b63d66-a321-4536-a42e-0c02e81f4a7e" />
