### PR TITLE
PM-2035: Wire up DI for PRFUnlockService in desktop

### DIFF
--- a/apps/desktop/src/app/services/services.module.ts
+++ b/apps/desktop/src/app/services/services.module.ts
@@ -33,6 +33,7 @@ import {
   InternalUserDecryptionOptionsServiceAbstraction,
   LoginEmailService,
   SsoUrlService,
+  UserDecryptionOptionsServiceAbstraction,
 } from "@bitwarden/auth/common";
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import { OrganizationApiServiceAbstraction } from "@bitwarden/common/admin-console/abstractions/organization/organization-api.service.abstraction";
@@ -53,6 +54,7 @@ import {
 import { MasterPasswordApiService } from "@bitwarden/common/auth/abstractions/master-password-api.service.abstraction";
 import { SsoLoginServiceAbstraction } from "@bitwarden/common/auth/abstractions/sso-login.service.abstraction";
 import { TokenService } from "@bitwarden/common/auth/abstractions/token.service";
+import { WebAuthnLoginPrfKeyServiceAbstraction } from "@bitwarden/common/auth/abstractions/webauthn/webauthn-login-prf-key.service.abstraction";
 import { PendingAuthRequestsStateService } from "@bitwarden/common/auth/services/auth-request-answering/pending-auth-requests.state";
 import { AutofillSettingsServiceAbstraction } from "@bitwarden/common/autofill/services/autofill-settings.service";
 import { BillingAccountProfileStateService } from "@bitwarden/common/billing/abstractions";
@@ -123,6 +125,8 @@ import {
 import {
   LockComponentService,
   SessionTimeoutSettingsComponentService,
+  WebAuthnPrfUnlockService,
+  DefaultWebAuthnPrfUnlockService,
 } from "@bitwarden/key-management-ui";
 import { SerializedMemoryStorageService } from "@bitwarden/storage-core";
 import {
@@ -412,6 +416,21 @@ const safeProviders: SafeProvider[] = [
     provide: LockComponentService,
     useClass: DesktopLockComponentService,
     deps: [],
+  }),
+  safeProvider({
+    provide: WebAuthnPrfUnlockService,
+    useClass: DefaultWebAuthnPrfUnlockService,
+    deps: [
+      WebAuthnLoginPrfKeyServiceAbstraction,
+      KeyServiceAbstraction,
+      UserDecryptionOptionsServiceAbstraction,
+      EncryptService,
+      EnvironmentService,
+      PlatformUtilsServiceAbstraction,
+      WINDOW,
+      LogServiceAbstraction,
+      ConfigService,
+    ],
   }),
   safeProvider({
     provide: CLIENT_TYPE,


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-2035

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

This PR wires up missing DI for the desktop app.

Confirmed that the desktop app did not render unlock, but did so after this commit.

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<img width="1306" height="1244" alt="CleanShot 2026-01-27 at 10 01 58@2x" src="https://github.com/user-attachments/assets/c4c43154-c56b-48d7-94c3-e2d75aa70da9" />

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
