### PR TITLE
[PM-31264] Broken vault filters in milestone-1

### DIFF
--- a/apps/desktop/src/vault/app/vault-v3/vault.component.ts
+++ b/apps/desktop/src/vault/app/vault-v3/vault.component.ts
@@ -114,7 +114,6 @@ const BroadcasterSubscriptionId = "VaultComponent";
     VaultItemsV2Component,
   ],
   providers: [
-    RoutedVaultFilterService,
     {
       provide: CipherFormConfigService,
       useClass: DefaultCipherFormConfigService,


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-31264
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

https://github.com/bitwarden/clients/commit/3228e986af79c84ba793d162d7df3c66443f6e3e changed how vault filters behave which broke the milestone-1 desktop filters since it relies more on the web filters than desktop filters.

To resolve this. we now use the same `createFilterFunction` as web rather than the custom proxy like approach.

