### PR TITLE
"Testing" GH workflow oom kill fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lint:fix": "eslint . --cache --cache-strategy content --fix",
     "lint:clear": "rimraf .eslintcache",
     "prettier": "prettier --cache --write .",
-    "test": "jest",
+    "test": "node --max-old-space-size=3072 node_modules/.bin/jest",
     "test:watch": "jest --clearCache && jest --watch",
     "test:watch:all": "jest --watchAll",
     "test:types": "node ./scripts/test-types.js",


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

The "Testing" GH workflow seems to be OOM killed, due to 3 node processes eating 4.5 GB or more heap.
Since we spawn 3 node processes during testing, it can easily get close to maximum allowed memory for github runner (16 GB, excluding OS reserved memory).
Setting the limit to 3GB heap for node process should address the issue.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
