### PR TITLE
[PM-30808] Migrate Phishing Detection storage to PhishingIndexedDbService (#18517)

### DIFF
--- a/apps/browser/src/dirt/phishing-detection/phishing-resources.ts
+++ b/apps/browser/src/dirt/phishing-detection/phishing-resources.ts
@@ -1,6 +1,8 @@
 export type PhishingResource = {
   name?: string;
   remoteUrl: string;
+  /** Fallback URL to use if remoteUrl fails (e.g., due to SSL interception/cert issues) */
+  fallbackUrl: string;
   checksumUrl: string;
   todayUrl: string;
   /** Matcher used to decide whether a given URL matches an entry from this resource */
@@ -21,6 +23,8 @@ export const PHISHING_RESOURCES: Record<PhishingResourceType, PhishingResource[]
     {
       name: "Phishing.Database Domains",
       remoteUrl: "https://phish.co.za/latest/phishing-domains-ACTIVE.txt",
+      fallbackUrl:
+        "https://raw.githubusercontent.com/Phishing-Database/Phishing.Database/refs/heads/master/phishing-domains-ACTIVE.txt",
       checksumUrl:
         "https://raw.githubusercontent.com/Phishing-Database/checksums/refs/heads/master/phishing-domains-ACTIVE.txt.md5",
       todayUrl:
@@ -48,6 +52,8 @@ export const PHISHING_RESOURCES: Record<PhishingResourceType, PhishingResource[]
     {
       name: "Phishing.Database Links",
       remoteUrl: "https://phish.co.za/latest/phishing-links-ACTIVE.txt",
+      fallbackUrl:
+        "https://raw.githubusercontent.com/Phishing-Database/Phishing.Database/refs/heads/master/phishing-links-ACTIVE.txt",
       checksumUrl:
         "https://raw.githubusercontent.com/Phishing-Database/checksums/refs/heads/master/phishing-links-ACTIVE.txt.md5",
       todayUrl:
@@ -75,10 +81,10 @@ export const PHISHING_RESOURCES: Record<PhishingResourceType, PhishingResource[]
           return true;
         }
 
-        // Check if URL starts with entry (prefix match for subpaths/query/hash)
-        // e.g., entry "site.com/phish" matches "site.com/phish/subpage" or "site.com/phish?id=1"
+        // Check if URL starts with entry (prefix match for query/hash only, NOT subpaths)
+        // e.g., entry "site.com/phish" matches "site.com/phish?id=1" or "site.com/phish#section"
+        // but NOT "site.com/phish/subpage" (different endpoint)
         if (
-          urlNoProto.startsWith(entryNoProto + "/") ||
           urlNoProto.startsWith(entryNoProto + "?") ||
           urlNoProto.startsWith(entryNoProto + "#")
         ) {

--- a/apps/browser/src/dirt/phishing-detection/services/phishing-indexeddb.service.ts
+++ b/apps/browser/src/dirt/phishing-detection/services/phishing-indexeddb.service.ts
@@ -53,6 +53,9 @@ export class PhishingIndexedDbService {
    * @returns `true` if save succeeded, `false` on error
    */
   async saveUrls(urls: string[]): Promise<boolean> {
+    this.logService.debug(
+      `[PhishingIndexedDbService] Clearing and saving ${urls.length} to the store...`,
+    );
     let db: IDBDatabase | null = null;
     try {
       db = await this.openDatabase();
@@ -61,6 +64,29 @@ export class PhishingIndexedDbService {
       return true;
     } catch (error) {
       this.logService.error("[PhishingIndexedDbService] Save failed", error);
+      return false;
+    } finally {
+      db?.close();
+    }
+  }
+
+  /**
+   * Adds an array of phishing URLs to IndexedDB.
+   * Appends to existing data without clearing.
+   *
+   * @param urls - Array of phishing URLs to add
+   * @returns `true` if add succeeded, `false` on error
+   */
+  async addUrls(urls: string[]): Promise<boolean> {
+    this.logService.debug(`[PhishingIndexedDbService] Adding ${urls.length} to the store...`);
+
+    let db: IDBDatabase | null = null;
+    try {
+      db = await this.openDatabase();
+      await this.saveChunked(db, urls);
+      return true;
+    } catch (error) {
+      this.logService.error("[PhishingIndexedDbService] Add failed", error);
       return false;
     } finally {
       db?.close();
@@ -100,6 +126,8 @@ export class PhishingIndexedDbService {
    * @returns `true` if URL exists, `false` if not found or on error
    */
   async hasUrl(url: string): Promise<boolean> {
+    this.logService.debug(`[PhishingIndexedDbService] Checking if store contains ${url}...`);
+
     let db: IDBDatabase | null = null;
     try {
       db = await this.openDatabase();
@@ -130,6 +158,8 @@ export class PhishingIndexedDbService {
    * @returns Array of all stored URLs, or empty array on error
    */
   async loadAllUrls(): Promise<string[]> {
+    this.logService.debug("[PhishingIndexedDbService] Loading all urls from store...");
+
     let db: IDBDatabase | null = null;
     try {
       db = await this.openDatabase();
@@ -227,11 +257,16 @@ export class PhishingIndexedDbService {
    * @returns `true` if save succeeded, `false` on error
    */
   async saveUrlsFromStream(stream: ReadableStream<Uint8Array>): Promise<boolean> {
+    this.logService.debug("[PhishingIndexedDbService] Saving urls to the store from stream...");
+
     let db: IDBDatabase | null = null;
     try {
       db = await this.openDatabase();
       await this.clearStore(db);
       await this.processStream(db, stream);
+      this.logService.info(
+        "[PhishingIndexedDbService] Finished saving urls to the store from stream.",
+      );
       return true;
     } catch (error) {
       this.logService.error("[PhishingIndexedDbService] Stream save failed", error);


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-30808

## 📔 Objective

pulls in indexed db service code that our phishing blocker is dependent on and was not included in this cherry pick: https://github.com/bitwarden/clients/pull/18586

Required commits for Phishing Detection:
- [60c28dd](https://github.com/bitwarden/clients/commit/60c28dd182eb7cbdd73956eb19509976c1c875b5): Done [here](https://github.com/bitwarden/clients/commit/2c3701358d0ae9444128d885d3e51d07b0c3e1b1)
- [178fd9a](https://github.com/bitwarden/clients/commit/178fd9a5776f120516c9bf51d7234b9cf8bc4381): In this pull request