### PR TITLE
GH Testing workflow separation to fix OOM kill, timeout issues

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -301,6 +301,7 @@ jobs:
       - testing
       - rust
       - rust-coverage
+      - upload-codecov
     permissions:
       contents: read
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

"Testing" workflow seems to fail frequently due to timeout or other exit codes, all related [out of memory](https://github.com/actions/runner/issues/2468) and GH killing the running job.

This PR splits the node testing into separate jobs: web, desktop, cli, browser, libs, with reduced amount of workers from 3 to 2, which should reduce the amount of memory used by node processes in total.
In local vm, current heap memory usage at 13GB or more on 16GB max memory runner, with this change should be at 10GB maximum and have good margin for safety.
This also reduces the time needed to run the tests, from ~13 minutes to ~7 minutes.

The repository CI configuration requires "Run tests" job to run, which is now changed to check for success of all "Testing" workflow jobs.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
