### PR TITLE
PM-31294: Unlock Passkey using getWebVaultUrl over getHostname 

### DIFF
--- a/libs/key-management-ui/src/lock/services/default-webauthn-prf-unlock.service.ts
+++ b/libs/key-management-ui/src/lock/services/default-webauthn-prf-unlock.service.ts
@@ -14,6 +14,7 @@ import { ConfigService } from "@bitwarden/common/platform/abstractions/config/co
 import { EnvironmentService } from "@bitwarden/common/platform/abstractions/environment.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
+import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { Fido2Utils } from "@bitwarden/common/platform/services/fido2/fido2-utils";
 import { UserId } from "@bitwarden/common/types/guid";
 import { PrfKey, UserKey } from "@bitwarden/common/types/key";


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-31294

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

This bug only surfaced in "cloud" environments. 

The getHostname method returned different urls between local+selfhost and cloud. On cloud it did not use the vault prefix which caused passkeys to not be listed as available.

This PR fetches the full url and then massages it to the hostname instead. 

We still need the seemingly double url conversion because util gets the host (even though the method name is getHostname) which means that ports etc are still included.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

This was the API that caused different urls to be returned. I haven't touched it, just used the same method that the selfhost api called.

![image](https://github.com/user-attachments/assets/0aee3e61-278b-43e7-887c-0108fc5e6e39)