### PR TITLE
[PM-31330] Consolidate excluded domains copy to allow removal of service invocation

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -2738,9 +2738,6 @@
   "excludedDomainsDesc": {
     "message": "Bitwarden will not ask to save login details for these domains. You must refresh the page for changes to take effect."
   },
-  "excludedDomainsDescAlt": {
-    "message": "Bitwarden will not ask to save login details for these domains for all logged in accounts. You must refresh the page for changes to take effect."
-  },
   "blockedDomainsDesc": {
     "message": "Autofill and other related features will not be offered for these websites. You must refresh the page for changes to take effect."
   },

--- a/apps/browser/src/autofill/popup/settings/excluded-domains.component.html
+++ b/apps/browser/src/autofill/popup/settings/excluded-domains.component.html
@@ -7,11 +7,7 @@
 
   <div class="tw-bg-background-alt">
     <p>
-      {{
-        (accountSwitcherEnabled$ | async)
-          ? ("excludedDomainsDescAlt" | i18n)
-          : ("excludedDomainsDesc" | i18n)
-      }}
+      {{ "excludedDomainsDesc" | i18n }}
     </p>
     <bit-section *ngIf="!isLoading">
       <bit-section-header>

--- a/apps/browser/src/autofill/popup/settings/excluded-domains.component.ts
+++ b/apps/browser/src/autofill/popup/settings/excluded-domains.component.ts
@@ -15,7 +15,7 @@ import {
   FormArray,
 } from "@angular/forms";
 import { RouterModule } from "@angular/router";
-import { Observable, Subject, takeUntil } from "rxjs";
+import { Subject, takeUntil } from "rxjs";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { DomainSettingsService } from "@bitwarden/common/autofill/services/domain-settings.service";
@@ -35,7 +35,6 @@ import {
   TypographyModule,
 } from "@bitwarden/components";
 
-import { AccountSwitcherService } from "../../../auth/popup/account-switching/services/account-switcher.service";
 import { PopOutComponent } from "../../../platform/popup/components/pop-out.component";
 import { PopupFooterComponent } from "../../../platform/popup/layout/popup-footer.component";
 import { PopupHeaderComponent } from "../../../platform/popup/layout/popup-header.component";
@@ -74,8 +73,6 @@ export class ExcludedDomainsComponent implements AfterViewInit, OnDestroy {
   @ViewChildren("uriInput") uriInputElements: QueryList<ElementRef<HTMLInputElement>> =
     new QueryList();
 
-  readonly accountSwitcherEnabled$: Observable<boolean> =
-    this.accountSwitcherService.accountSwitchingEnabled$();
   dataIsPristine = true;
   isLoading = false;
   excludedDomainsState: string[] = [];
@@ -96,7 +93,6 @@ export class ExcludedDomainsComponent implements AfterViewInit, OnDestroy {
     private toastService: ToastService,
     private formBuilder: FormBuilder,
     private popupRouterCacheService: PopupRouterCacheService,
-    private accountSwitcherService: AccountSwitcherService,
   ) {}
 
   get domainForms() {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-31330](https://bitwarden.atlassian.net/browse/PM-31330)

## 📔 Objective

Validated with Product; we don't need to invoke a whole service just for this small (and otherwise implicit) copy difference.

## 📸 Screenshots


| Before | After |
| --- | --- |
| <img width="478" height="593" alt="Screenshot 2026-01-27 at 2 56 45 PM" src="https://github.com/user-attachments/assets/98fa4b1b-5846-417f-8388-7acd9f20e708" /> | <img width="480" height="604" alt="Screenshot 2026-01-27 at 3 37 35 PM" src="https://github.com/user-attachments/assets/5346c36e-5cba-4186-a476-9743e9968b0d" /> |

[PM-31330]: https://bitwarden.atlassian.net/browse/PM-31330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ