### PR TITLE
[BRE-1436] Add missing bw-linux-arm64 release artifact

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -89,10 +89,11 @@ jobs:
                       apps/cli/bw-oss-macos-${{ env.PKG_VERSION }}.zip,
                       apps/cli/bw-oss-macos-arm64-${{ env.PKG_VERSION }}.zip,
                       apps/cli/bw-macos-${{ env.PKG_VERSION }}.zip,
-                      apps/cli/bw-linux-arm64-${{ env.PKG_VERSION }}.zip,
                       apps/cli/bw-macos-arm64-${{ env.PKG_VERSION }}.zip,
                       apps/cli/bw-oss-linux-${{ env.PKG_VERSION }}.zip,
+                      apps/cli/bw-oss-linux-arm64-${{ env.PKG_VERSION }}.zip,
                       apps/cli/bw-linux-${{ env.PKG_VERSION }}.zip,
+                      apps/cli/bw-linux-arm64-${{ env.PKG_VERSION }}.zip,
                       apps/cli/bitwarden-cli.${{ env.PKG_VERSION }}.nupkg,
                       apps/cli/bw_${{ env.PKG_VERSION }}_amd64.snap,
                       apps/cli/bitwarden-cli-${{ env.PKG_VERSION }}-npm-build.zip"


### PR DESCRIPTION
## 🎟️ Tracking

Duplicating changes from https://github.com/bitwarden/clients/pull/15910 made by @RoboMagus for easier testing

## 📔 Objective

bw-linux-arm64 CLI is [being built](https://github.com/bitwarden/clients/actions/workflows/build-cli.yml) (Added in https://github.com/bitwarden/clients/pull/14270), but not added to the [release artifacts](https://github.com/bitwarden/clients/releases/tag/cli-v2025.7.0).

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
