### PR TITLE
[PM-31282] Pass organizationId through to API call when SDK feature flag is off

### DIFF
--- a/libs/common/src/vault/services/cipher.service.spec.ts
+++ b/libs/common/src/vault/services/cipher.service.spec.ts
@@ -1209,7 +1209,7 @@ describe("Cipher Service", () => {
 
       await cipherService.softDeleteManyWithServer(testCipherIds, userId, true, orgId);
 
-      expect(apiSpy).toHaveBeenCalled();
+      expect(apiSpy).toHaveBeenCalledWith({ ids: testCipherIds, organizationId: orgId });
     });
 
     it("should use SDK to soft delete multiple ciphers when feature flag is enabled", async () => {

--- a/libs/common/src/vault/services/cipher.service.ts
+++ b/libs/common/src/vault/services/cipher.service.ts
@@ -1619,7 +1619,7 @@ export class CipherService implements CipherServiceAbstraction {
       return;
     }
 
-    const request = new CipherBulkDeleteRequest(ids);
+    const request = new CipherBulkDeleteRequest(ids, orgId);
     if (asAdmin) {
       await this.apiService.putDeleteManyCiphersAdmin(request);
     } else {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-31282

## 📔 Objective

When migrating to use the SDK for DeleteCipher operations, I changed the code that calls the API to go through the cipherService. I failed to pass the orgId along into the API request, which was causing the API to fail, since orgId is a mandatory field when calling the Admin endpoint. This PR adds the orgId to the request.

## 📸 Screenshots


https://github.com/user-attachments/assets/d8d5cbf6-406c-47d8-83ec-016ecaa3c012


