### PR TITLE
[PM-31358] Fix biometric authentication in sandboxed environments (Flatpak, Snap, etc.)

### DIFF
--- a/apps/desktop/desktop_native/core/src/biometric_v2/linux.rs
+++ b/apps/desktop/desktop_native/core/src/biometric_v2/linux.rs
@@ -96,7 +96,32 @@ async fn polkit_authenticate_bitwarden_policy() -> Result<bool> {
 
     let connection = Connection::system().await?;
     let proxy = AuthorityProxy::new(&connection).await?;
-    let subject = Subject::new_for_owner(std::process::id(), None, None)?;
+
+    // Use system-bus-name instead of unix-process to avoid PID namespace issues in
+    // sandboxed environments (e.g., Flatpak). When using unix-process with a PID from
+    // inside the sandbox, polkit cannot validate it against the host PID namespace.
+    //
+    // By using system-bus-name, polkit queries D-Bus for the connection's credentials,
+    // which includes the correct host PID and UID, avoiding namespace mismatches.
+    //
+    // If D-Bus unique name is not available, fall back to the traditional unix-process
+    // approach for compatibility with non-sandboxed environments.
+    let subject = if let Some(bus_name) = connection.unique_name() {
+        use zbus::zvariant::{OwnedValue, Str};
+        let mut subject_details = std::collections::HashMap::new();
+        subject_details.insert(
+            "name".to_string(),
+            OwnedValue::from(Str::from(bus_name.as_str())),
+        );
+        Subject {
+            subject_kind: "system-bus-name".to_string(),
+            subject_details,
+        }
+    } else {
+        // Fallback: use unix-process with PID (may not work in sandboxed environments)
+        Subject::new_for_owner(std::process::id(), None, None)?
+    };
+
     let details = std::collections::HashMap::new();
     let authorization_result = proxy
         .check_authorization(


### PR DESCRIPTION
## 🎟️ Tracking

https://github.com/bitwarden/clients/issues/14263

## 📔 Objective

Biometric authentication was failing in Flatpak with the error "Unix process subject does not have uid set". This occurred because polkit could not validate the sandboxed PID against the host PID namespace (`std::process::id()` will return the sandboxed PID).

Use polkit's system-bus-name subject type instead of unix-process. This allows polkit to query D-Bus for the connection owner's host PID and credentials, bypassing the PID namespace issue. Includes fallback to unix-process for edge cases where D-Bus unique name is unavailable.

## 📸 Screenshots

Tested in Flatpak with biometric-v1.

<img width="715" height="631" alt="image" src="https://github.com/user-attachments/assets/6f914f0a-5dee-4b58-856e-78587983f460" />
