### PR TITLE
[PM-16863] Refactor autofill policy naming and update related translations

### DIFF
--- a/apps/web/src/app/admin-console/organizations/policies/pipes/policy-order.pipe.ts
+++ b/apps/web/src/app/admin-console/organizations/policies/pipes/policy-order.pipe.ts
@@ -20,7 +20,7 @@ const POLICY_ORDER_MAP = new Map<string, number>([
   ["removeUnlockWithPinPolicyTitle", 10],
   ["passwordGenerator", 11],
   ["uriMatchDetectionPolicy", 12],
-  ["activateAutofill", 13],
+  ["activateAutofillPolicy", 13],
   ["sendOptions", 14],
   ["disableSend", 15],
   ["restrictedItemTypePolicy", 16],

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -6937,17 +6937,17 @@
   "personalVaultExportPolicyInEffect": {
     "message": "One or more organization policies prevents you from exporting your individual vault."
   },
-  "activateAutofill": {
-    "message": "Activate auto-fill"
+  "activateAutofillPolicy": {
+    "message": "Activate autofill"
   },
   "activateAutofillPolicyDescription": {
     "message": "Activate the autofill on page load setting on the browser extension for all existing and new members."
   },
-  "experimentalFeature": {
-    "message": "Compromised or untrusted websites can exploit auto-fill on page load."
+  "autofillOnPageLoadExploitWarning": {
+    "message": "Compromised or untrusted websites can exploit autofill on page load."
   },
-  "learnMoreAboutAutofill": {
-    "message": "Learn more about auto-fill"
+  "learnMoreAboutAutofillPolicy": {
+    "message": "Learn more about autofill"
   },
   "selectType": {
     "message": "Select SSO type"

--- a/bitwarden_license/bit-web/src/app/admin-console/policies/policy-edit-definitions/activate-autofill.component.html
+++ b/bitwarden_license/bit-web/src/app/admin-console/policies/policy-edit-definitions/activate-autofill.component.html
@@ -1,11 +1,11 @@
 <bit-callout type="warning">
-  {{ "experimentalFeature" | i18n }}
+  {{ "autofillOnPageLoadExploitWarning" | i18n }}
   <a
     bitLink
     href="https://bitwarden.com/help/auto-fill-browser/"
     target="_blank"
     rel="noreferrer"
-    >{{ "learnMoreAboutAutofill" | i18n }}</a
+    >{{ "learnMoreAboutAutofillPolicy" | i18n }}</a
   >
 </bit-callout>
 

--- a/bitwarden_license/bit-web/src/app/admin-console/policies/policy-edit-definitions/activate-autofill.component.ts
+++ b/bitwarden_license/bit-web/src/app/admin-console/policies/policy-edit-definitions/activate-autofill.component.ts
@@ -11,7 +11,7 @@ import {
 import { SharedModule } from "@bitwarden/web-vault/app/shared";
 
 export class ActivateAutofillPolicy extends BasePolicyEditDefinition {
-  name = "activateAutofill";
+  name = "activateAutofillPolicy";
   description = "activateAutofillPolicyDescription";
   type = PolicyType.ActivateAutofill;
   component = ActivateAutofillPolicyComponent;


### PR DESCRIPTION
- Renamed `activateAutofill` to `activateAutofillPolicy` in the policy order map and component.
- Updated corresponding translation keys in `messages.json` for consistency.
- Adjusted warning message in the `activate-autofill.component.html` to reflect the new naming convention.

## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-16863

## 📔 Objective

Change "auto-fill" to "autofill" on policies page of app

## 📸 Screenshots

<img width="1904" height="860" alt="image" src="https://github.com/user-attachments/assets/f4614bd3-c551-48bd-943a-3d083446c39c" />
<img width="1905" height="933" alt="image" src="https://github.com/user-attachments/assets/03abcaec-b09e-4f82-bd38-a05182ae788e" />

