### PR TITLE
[PM-31387] Desktop Footer update archive/trash btn values

### DIFF
--- a/apps/desktop/src/vault/app/vault/item-footer.component.ts
+++ b/apps/desktop/src/vault/app/vault/item-footer.component.ts
@@ -255,12 +255,15 @@ export class ItemFooterComponent implements OnInit, OnChanges {
     this.userCanArchive = userCanArchive;
 
     this.showArchiveButton =
-      cipherCanBeArchived && userCanArchive && this.action === "view" && !this.cipher.isArchived;
+      cipherCanBeArchived &&
+      userCanArchive &&
+      (this.action === "view" || this.action === "edit") &&
+      !this.cipher.isArchived;
 
     // A user should always be able to unarchive an archived item
     this.showUnarchiveButton =
       hasArchiveFlagEnabled &&
-      this.action === "view" &&
+      (this.action === "view" || this.action === "edit") &&
       this.cipher.isArchived &&
       !this.cipher.isDeleted;
   }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-31387](https://bitwarden.atlassian.net/browse/PM-31387)

## 📔 Objective

The logic for `showArchiveButton` and `showUnarchiveButton` were not updating with the latest `action` value so when a user navigated from viewing an item to creating a new item, the `archive` and `trash` buttons would stay in the footer. Added the action to `ngOnChanges` here. 

## 📸 Screenshots

https://github.com/user-attachments/assets/9adc266f-31a2-45fe-b3f9-471da549a6d8




[PM-31387]: https://bitwarden.atlassian.net/browse/PM-31387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ