### PR TITLE
[PM-31395] fix(browser): align Beta badge vertically with Compact mode text

### DIFF
--- a/apps/browser/src/vault/popup/settings/appearance-v2.component.html
+++ b/apps/browser/src/vault/popup/settings/appearance-v2.component.html
@@ -27,7 +27,7 @@
         <input bitCheckbox formControlName="enableCompactMode" type="checkbox" />
         <bit-label
           >{{ "compactMode" | i18n }}
-          <span bitBadge variant="warning">{{ "beta" | i18n }}</span></bit-label
+          <span bitBadge variant="warning" class="!tw-align-middle tw-ml-1">{{ "beta" | i18n }}</span></bit-label
         >
       </bit-form-control>
 


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

Fixes #17810

The "Beta" badge next to "Compact mode" in Settings > Appearance was vertically misaligned with its corresponding text.

## Code changes

Added Tailwind utility classes to the badge element:
- `!tw-align-middle` - vertically centers the badge with the text
- `tw-ml-1` - adds proper horizontal spacing between text and badge

This matches the styling pattern already used elsewhere in the codebase (e.g., in `webauthn-login-settings.component.html`).

## Before / After

**Before:** Badge was vertically misaligned, appearing slightly higher than the text.

**After:** Badge is vertically centered with "Compact mode" text, with proper horizontal spacing.

## Screenshots

The fix applies the same alignment pattern visible in the premium badge examples from PR #17793.

## Testing

- Verified badge aligns correctly in browser extension appearance settings