### PR TITLE
Mark `getProfileCreationDate` as deprecated

### DIFF
--- a/libs/angular/src/vault/services/vault-profile.service.ts
+++ b/libs/angular/src/vault/services/vault-profile.service.ts
@@ -22,7 +22,8 @@ export class VaultProfileService {
    * Note: `Date`s are mutable in JS, creating a new
    * instance is important to avoid unwanted changes.
    *
-   * @deprecated use `creationDate` directly from the `AccountService.activeAccount$` instead.
+   * @deprecated use `creationDate` directly from the `AccountService.activeAccount$` instead,
+   * PM-31409 will replace all usages of this service.
    */
   async getProfileCreationDate(userId: string): Promise<Date> {
     if (this.profileCreatedDate && userId === this.userId) {


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

https://github.com/bitwarden/clients/pull/17892 added the creationDate to the Account object that is populated on first sync allowing us to remove the VaultProfileService and save the extra API calls in the future. Marking it as deprecated and nudging consumers to use the account service directly. 