### PR TITLE
[PM-31423] Show Archive Features in Individual Reports

### DIFF
--- a/apps/web/src/app/dirt/reports/pages/cipher-report.component.ts
+++ b/apps/web/src/app/dirt/reports/pages/cipher-report.component.ts
@@ -193,7 +193,7 @@ export abstract class CipherReportComponent implements OnDestroy {
       formConfig,
       activeCollectionId,
       disableForm,
-      isAdminConsoleAction: true,
+      isAdminConsoleAction: this.organization != null,
     });
 
     const result = await lastValueFrom(this.vaultItemDialogRef.closed);


### PR DESCRIPTION
## 🎟️ Tracking

[PM-31423](https://bitwarden.atlassian.net/browse/PM-31423)

## 📔 Objective

Archive features, `Archive` badge in the header, and `Archive/Unarchive` buttons in the footer, should appear for items in the reports page in the `View/Edit` modal. This should only happen for individual reports. Archive features will not appear for items in the Admin Console Reports page. 

Previous updates to address the removal of archive in AC also removed the features from individual reports.

## 📸 Screen Recording

https://github.com/user-attachments/assets/39565189-b270-4e03-a99d-e338fec56695




[PM-31423]: https://bitwarden.atlassian.net/browse/PM-31423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ