### PR TITLE
[PM-29951] add archive flag check to vault-v3 desktop (#18660)

### DIFF
--- a/apps/desktop/src/vault/app/vault-v3/vault.component.ts
+++ b/apps/desktop/src/vault/app/vault-v3/vault.component.ts
@@ -564,7 +564,7 @@ export class VaultComponent implements OnInit, OnDestroy, CopyClickListener {
       }
     }
 
-    if (!cipher.organizationId && !cipher.isDeleted && !cipher.isArchived) {
+    if (userCanArchive && !cipher.isDeleted && !cipher.isArchived) {
       menu.push({
         label: this.i18nService.t("archiveVerb"),
         click: async () => {
@@ -579,7 +579,7 @@ export class VaultComponent implements OnInit, OnDestroy, CopyClickListener {
       });
     }
 
-    if (cipher.isArchived) {
+    if (cipher.isArchived && !cipher.isDeleted) {
       menu.push({
         label: this.i18nService.t("unArchive"),
         click: async () => {


### PR DESCRIPTION
* add archive flag check to vault-v3 desktop, sync vault-v2 and vault-v3

(cherry picked from commit 50427beba643bd8d5e2e58f73ba3fcdf43948a3d)

## 🎟️ Tracking

[PM-29951](https://bitwarden.atlassian.net/browse/PM-29951)

## 📔 Objective

Synchronizing the archive logic for context menu options between desktop vault-v2 and vault-v3

## 📸 Screenshots

<img width="321" height="235" alt="Screenshot 2026-01-29 at 3 47 05 PM" src="https://github.com/user-attachments/assets/b5dbad5c-deb6-4c67-8ed4-f84d5e3b50f2" />



[PM-29951]: https://bitwarden.atlassian.net/browse/PM-29951?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ