### PR TITLE
[PM-29313] [Defect] TDE JIT Provisioning - Extension showing locked icon even if user already logged in

### DIFF
--- a/apps/browser/src/platform/badge/badge.service.ts
+++ b/apps/browser/src/platform/badge/badge.service.ts
@@ -83,7 +83,7 @@ export class BadgeService {
                 functions.map(([name, f]) =>
                   f(tab).pipe(
                     startWith(undefined),
-                    catchError((error) => {
+                    catchError((error: unknown) => {
                       this.logService.error(
                         `BadgeService: State function "${name}" threw an error`,
                         error,


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

Add better error handling to badge service. The registered functions were sometimes throwing errors which would cause the whole badge updater to stop working. This fixes the issue so one function can't break all of them. I've created a followup to look at the underlying error [PM-31458 Cipher decryption throwing errors when JIT Provisioning an SSO user](https://bitwarden.atlassian.net/browse/PM-31458)

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
