### PR TITLE
[PM-31435] Use muted colors for Send file and text type icons

### DIFF
--- a/libs/tools/send/send-ui/src/send-table/send-table.component.html
+++ b/libs/tools/send/send-ui/src/send-table/send-table.component.html
@@ -15,10 +15,10 @@
           <div class="tw-flex tw-gap-2 tw-items-center">
             <span aria-hidden="true">
               @if (s.type == sendType.File) {
-                <i class="bwi bwi-fw bwi-lg bwi-file"></i>
+                <i class="bwi bwi-fw bwi-lg bwi-file tw-text-muted"></i>
               }
               @if (s.type == sendType.Text) {
-                <i class="bwi bwi-fw bwi-lg bwi-file-text"></i>
+                <i class="bwi bwi-fw bwi-lg bwi-file-text tw-text-muted"></i>
               }
             </span>
             <button type="button" bitLink>


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-31435

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR updates the Send icons used to denote the type of Send to use muted colors to match the tables elsewhere in the app.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
_Before_

<img width="473" height="386" alt="Screenshot 2026-01-30 at 10 56 32" src="https://github.com/user-attachments/assets/5bb72281-05eb-46c0-9af9-7b53d4f6a6b9" />

_After_

<img width="352" height="336" alt="Screenshot 2026-01-30 at 10 55 33" src="https://github.com/user-attachments/assets/d9cb9ce1-5653-456e-9c16-ada291423223" />
