### PR TITLE
[PM-31400] Desktop: skip MP reprompt when archive/unarchive in footer

### DIFF
--- a/apps/desktop/src/vault/app/vault/item-footer.component.ts
+++ b/apps/desktop/src/vault/app/vault/item-footer.component.ts
@@ -229,12 +229,20 @@ export class ItemFooterComponent implements OnInit, OnChanges {
   }
 
   protected async archive() {
-    await this.archiveCipherUtilitiesService.archiveCipher(this.cipher);
+    /**
+     * When the Archive Button is used in the footer we can skip the reprompt since
+     * the user will have already passed the reprompt when they opened the item.
+     */
+    await this.archiveCipherUtilitiesService.archiveCipher(this.cipher, true);
     this.onArchiveToggle.emit();
   }
 
   protected async unarchive() {
-    await this.archiveCipherUtilitiesService.unarchiveCipher(this.cipher);
+    /**
+     * When the Unarchive Button is used in the footer we can skip the reprompt since
+     * the user will have already passed the reprompt when they opened the item.
+     */
+    await this.archiveCipherUtilitiesService.unarchiveCipher(this.cipher, true);
     this.onArchiveToggle.emit();
   }
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-31400](https://bitwarden.atlassian.net/browse/PM-31400)

## 📔 Objective

In Desktop, when user clicks the archive/unarchive buttons in the footer, we will skip the MP reprompt because the user will have already successfully passed the reprompt earlier in order to view the item.

Archiving and Unarchiving from the Context Menu remains unchanged.

## 📸 Screen Recording


https://github.com/user-attachments/assets/7c249fdf-8b61-4e8f-818d-c4a19f82a89b


[PM-31400]: https://bitwarden.atlassian.net/browse/PM-31400?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ