### PR TITLE
[PM-31282] Pass orgId through to CipherBulkDeleteRequest

### DIFF
--- a/libs/common/src/vault/services/cipher.service.spec.ts
+++ b/libs/common/src/vault/services/cipher.service.spec.ts
@@ -1092,7 +1092,7 @@ describe("Cipher Service", () => {
 
       await cipherService.deleteManyWithServer(testCipherIds, userId, true, orgId);
 
-      expect(apiSpy).toHaveBeenCalled();
+      expect(apiSpy).toHaveBeenCalledWith({ ids: testCipherIds, organizationId: orgId });
     });
 
     it("should use SDK to delete multiple ciphers when feature flag is enabled", async () => {

--- a/libs/common/src/vault/services/cipher.service.ts
+++ b/libs/common/src/vault/services/cipher.service.ts
@@ -1422,7 +1422,7 @@ export class CipherService implements CipherServiceAbstraction {
       return;
     }
 
-    const request = new CipherBulkDeleteRequest(ids);
+    const request = new CipherBulkDeleteRequest(ids, orgId);
     if (asAdmin) {
       await this.apiService.deleteManyCiphersAdmin(request);
     } else {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-31282

## 📔 Objective

Same fix as #18619 , for the hard delete endpoint. This fixes a bug where admin bulk Delete operations failed, caused by a failure to pass the orgId argument through to the API. This fixes that and updates the tests to verify it.