### PR TITLE
[PM-31434] Match Send table options button size to other tables

### DIFF
--- a/libs/tools/send/send-ui/src/send-table/send-table.component.html
+++ b/libs/tools/send/send-ui/src/send-table/send-table.component.html
@@ -85,6 +85,7 @@
         <td bitCell class="tw-w-0 tw-text-right">
           <button
             type="button"
+            size="small"
             [bitMenuTriggerFor]="sendOptions"
             bitIconButton="bwi-ellipsis-v"
             label="{{ 'options' | i18n }}"


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-31434

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR makes the three-dot "Options" button on the Send table smaller, bringing it in line with similar buttons elsewhere in the web app.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
_Before_

<img width="685" height="315" alt="Screenshot 2026-01-30 at 13 41 26" src="https://github.com/user-attachments/assets/44e4643c-c094-4f6b-ad9c-89992aa96d3f" />

_After_

<img width="684" height="326" alt="Screenshot 2026-01-30 at 13 40 26" src="https://github.com/user-attachments/assets/862a7289-030b-49de-95b9-92154ffbfa61" />
