### PR TITLE
PM-31474: Don't make PRF unlock available in non web/browser clients

### DIFF
--- a/libs/key-management-ui/src/lock/services/default-webauthn-prf-unlock.service.ts
+++ b/libs/key-management-ui/src/lock/services/default-webauthn-prf-unlock.service.ts
@@ -54,11 +54,12 @@ export class DefaultWebAuthnPrfUnlockService implements WebAuthnPrfUnlockService
         return false;
       }
 
-      // If we're in the browser extension, check if we're in a Chromium browser
-      if (
-        this.platformUtilsService.getClientType() === ClientType.Browser &&
-        !this.platformUtilsService.isChromium()
-      ) {
+      // PRF unlock is only supported on Web and Chromium-based browser extensions
+      const clientType = this.platformUtilsService.getClientType();
+      if (clientType === ClientType.Browser && !this.platformUtilsService.isChromium()) {
+        return false;
+      }
+      if (clientType !== ClientType.Web && clientType !== ClientType.Browser) {
         return false;
       }
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-31474

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

Electron claims that it does support the navigator.credential API's while in reality it doesn't. 

This PR actively blocks non web/browser clients and returns false.

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
