### PR TITLE
[PM-31621] When only password and new password fields have values and do not match any vault ciphers, trigger a new cipher notification

### DIFF
--- a/apps/browser/src/autofill/background/notification.background.spec.ts
+++ b/apps/browser/src/autofill/background/notification.background.spec.ts
@@ -1727,7 +1727,7 @@ describe("NotificationBackground", () => {
           expect(pushAddLoginToQueueSpy).not.toHaveBeenCalled();
         });
 
-        it("and no cipher update candidates match `password` or `newPassword`, do not trigger a notification", async () => {
+        it("and no cipher update candidates match `password` or `newPassword`, trigger a new cipher notification", async () => {
           const storedCiphersForURL = [
             mock<CipherView>({
               id: "cipher-id-1",
@@ -1745,7 +1745,15 @@ describe("NotificationBackground", () => {
           await notificationBackground.triggerCipherNotification(formEntryData, tab);
 
           expect(pushChangePasswordToQueueSpy).not.toHaveBeenCalled();
-          expect(pushAddLoginToQueueSpy).not.toHaveBeenCalled();
+          expect(pushAddLoginToQueueSpy).toHaveBeenCalledWith(
+            mockFormattedURI,
+            {
+              password: formEntryData.newPassword,
+              url: formEntryData.uri,
+              username: formEntryData.username,
+            },
+            sender.tab,
+          );
         });
       });
 

--- a/apps/browser/src/autofill/background/notification.background.ts
+++ b/apps/browser/src/autofill/background/notification.background.ts
@@ -992,6 +992,7 @@ export default class NotificationBackground {
             inputScenarios.usernameNewPassword,
             inputScenarios.usernamePassword,
             inputScenarios.username,
+            inputScenarios.passwordNewPassword,
           ] as InputScenario[]
         ).includes(inputScenario) &&
         newLoginNotificationIsEnabled


### PR DESCRIPTION
## 🎟️ Tracking

[PM-31621](https://bitwarden.atlassian.net/browse/PM-31621)

## 📔 Objective

Per the title, followup logic change for new post-submit notification triggering logic


[PM-31621]: https://bitwarden.atlassian.net/browse/PM-31621?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ