### PR TITLE
Run pre-commit hook on only changed files, excluding merges

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,11 @@
+#!/bin/sh
+
+# Skip hook if this is a merge commit
+if [ -f .git/MERGE_HEAD ]; then
+        exit 0
+fi
+
+FILES=$(git diff --cached --name-only --diff-filter=ACMR | sed 's| |\\ |g')
+[ -z "$FILES" ] && exit 0
+
 npx lint-staged


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.slack.com/archives/GRN5AAZ6Y/p1770127107341269?thread_ts=1769165727.198789&cid=GRN5AAZ6Y

## 📔 Objective

The Husky pre-commit hook that runs staged linting should operate on changed files and avoid merges.
