### PR TITLE
Fix bytes crate vuln RUSTSEC-2026-0007

### DIFF
--- a/apps/desktop/desktop_native/Cargo.lock
+++ b/apps/desktop/desktop_native/Cargo.lock
@@ -512,9 +512,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "camino"

--- a/apps/desktop/desktop_native/Cargo.toml
+++ b/apps/desktop/desktop_native/Cargo.toml
@@ -27,7 +27,7 @@ ashpd = "=0.12.0"
 base64 = "=0.22.1"
 bitwarden-russh = { git = "https://github.com/bitwarden/bitwarden-russh.git", rev = "a641316227227f8777fdf56ac9fa2d6b5f7fe662" }
 byteorder = "=1.5.0"
-bytes = "=1.11.0"
+bytes = "=1.11.1"
 cbc = "=0.1.2"
 chacha20poly1305 = "=0.10.1"
 core-foundation = "=0.10.1"


### PR DESCRIPTION
## 🎟️ Tracking

https://rustsec.org/advisories/RUSTSEC-2026-0007

## 📔 Objective

Fixes the vulnerability in `bytes` crate, which has been patched by the crate maintainers.

(before changes):

```
 cargo deny --log-level error --all-features check all
error[vulnerability]: Integer overflow in `BytesMut::reserve`
   ┌─ /Users/foo/workspace/bw/clients/apps/desktop/desktop_native/Cargo.lock:44:1
   │
44 │ bytes 1.11.0 registry+https://github.com/rust-lang/crates.io-index
   │ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ security vulnerability detected
   │
   ├ ID: RUSTSEC-2026-0007
   ├ Advisory: https://rustsec.org/advisories/RUSTSEC-2026-0007
   ├ In the unique reclaim path of `BytesMut::reserve`, the condition
     ```rs
     if v_capacity >= new_cap + offset
     ```
     uses an unchecked addition. When `new_cap + offset` overflows `usize` in release builds, this condition may incorrectly pass, causing `self.cap` to be set to a value that exceeds the actual allocated capacity. Subsequent APIs such as `spare_capacity_mut()` then trust this corrupted `cap` value and may create out-of-bounds slices, leading to UB.

     This behavior is observable in release builds (integer overflow wraps), whereas debug builds panic due to overflow checks.

     ## PoC

     ```rs
     use bytes::*;

     fn main() {
         let mut a = BytesMut::from(&b"hello world"[..]);
         let mut b = a.split_off(5);

         // Ensure b becomes the unique owner of the backing storage
         drop(a);

         // Trigger overflow in new_cap + offset inside reserve
         b.reserve(usize::MAX - 6);

         // This call relies on the corrupted cap and may cause UB & HBO
         b.put_u8(b'h');
     }
     ```

     # Workarounds

     Users of `BytesMut::reserve` are only affected if integer overflow checks are configured to wrap. When integer overflow is configured to panic, this issue does not apply.
   ├ Announcement: https://github.com/advisories/GHSA-434x-w66g-qw3r
   ├ Solution: Upgrade to >=1.11.1 (try `cargo update -p bytes`)
   ├ bytes v1.11.0
     ├── desktop_core v0.0.0
     │   ├── autofill_provider v0.0.0
     │   ├── desktop_napi v0.0.0
     │   ├── desktop_proxy v0.0.0
     │   └── process_isolation v0.0.0
     ├── tokio v1.48.0
     │   ├── ashpd v0.12.0
     │   │   ├── desktop_core v0.0.0 (*)
     │   │   └── oo7 v0.5.0
     │   │       ├── chromium_importer v0.0.0
     │   │       │   ├── bitwarden_chromium_import_helper v0.0.0
     │   │       │   └── desktop_napi v0.0.0 (*)
     │   │       └── desktop_core v0.0.0 (*)
     │   ├── autofill_provider v0.0.0 (*)
     │   ├── bitwarden-russh v0.1.0
     │   │   └── desktop_core v0.0.0 (*)
     │   ├── bitwarden_chromium_import_helper v0.0.0 (*)
     │   ├── chromium_importer v0.0.0 (*)
     │   ├── desktop_core v0.0.0 (*)
     │   ├── desktop_napi v0.0.0 (*)
     │   ├── desktop_objc v0.0.0
     │   │   └── desktop_core v0.0.0 (*)
     │   ├── desktop_proxy v0.0.0 (*)
     │   ├── interprocess v2.2.1
     │   │   └── desktop_core v0.0.0 (*)
     │   ├── napi v3.3.0
     │   │   └── desktop_napi v0.0.0 (*)
     │   ├── oo7 v0.5.0 (*)
     │   ├── tokio-util v0.7.17
     │   │   ├── bitwarden-russh v0.1.0 (*)
     │   │   ├── desktop_core v0.0.0 (*)
     │   │   └── desktop_proxy v0.0.0 (*)
     │   └── zbus v5.12.0
     │       ├── ashpd v0.12.0 (*)
     │       ├── desktop_core v0.0.0 (*)
     │       ├── oo7 v0.5.0 (*)
     │       └── zbus_polkit v5.0.0
     │           └── desktop_core v0.0.0 (*)
     ├── tokio-util v0.7.17 (*)
     ├── uniffi_core v0.28.3
     │   └── uniffi v0.28.3
     │       └── (build) autofill_provider v0.0.0 (*)
     └── uniffi_meta v0.28.3
         ├── uniffi_bindgen v0.28.3
         │   ├── uniffi v0.28.3 (*)
         │   └── uniffi_build v0.28.3
         │       └── uniffi v0.28.3 (*)
         ├── uniffi_macros v0.28.3
         │   └── uniffi v0.28.3 (*)
         └── uniffi_udl v0.28.3
             └── uniffi_bindgen v0.28.3 (*)

advisories FAILED, bans ok, licenses ok, sources ok
```
