### PR TITLE
[PM-31695] List org-groups on CLI

### DIFF
--- a/apps/cli/src/admin-console/models/response/organization-group.response.ts
+++ b/apps/cli/src/admin-console/models/response/organization-group.response.ts
@@ -1,0 +1,19 @@
+import { GroupResponse } from "@bitwarden/admin-console/common";
+
+import { BaseResponse } from "../../../models/response/base.response";
+
+export class OrganizationGroupResponse implements BaseResponse {
+  object: string;
+  id: string;
+  organizationId: string;
+  name: string;
+  externalId: string;
+
+  constructor(response: GroupResponse) {
+    this.object = "org-group";
+    this.id = response.id;
+    this.organizationId = response.organizationId;
+    this.name = response.name;
+    this.externalId = response.externalId;
+  }
+}

--- a/apps/cli/src/oss-serve-configurator.ts
+++ b/apps/cli/src/oss-serve-configurator.ts
@@ -80,6 +80,7 @@ export class OssServeConfigurator {
       this.serviceContainer.organizationService,
       this.serviceContainer.searchService,
       this.serviceContainer.organizationUserApiService,
+      this.serviceContainer.groupApiService,
       this.serviceContainer.apiService,
       this.serviceContainer.eventCollectionService,
       this.serviceContainer.accountService,

--- a/apps/cli/src/service-container/service-container.ts
+++ b/apps/cli/src/service-container/service-container.ts
@@ -9,6 +9,8 @@ import { firstValueFrom } from "rxjs";
 import {
   OrganizationUserApiService,
   DefaultOrganizationUserApiService,
+  GroupApiService,
+  DefaultGroupApiService,
   DefaultCollectionService,
 } from "@bitwarden/admin-console/common";
 import {
@@ -260,6 +262,7 @@ export class ServiceContainer {
   cipherService: CipherService;
   folderService: InternalFolderService;
   organizationUserApiService: OrganizationUserApiService;
+  groupApiService: GroupApiService;
   collectionService: DefaultCollectionService;
   vaultTimeoutService: VaultTimeoutService;
   masterPasswordService: InternalMasterPasswordServiceAbstraction;
@@ -1009,6 +1012,8 @@ export class ServiceContainer {
     this.providerApiService = new ProviderApiService(this.apiService);
 
     this.organizationUserApiService = new DefaultOrganizationUserApiService(this.apiService);
+
+    this.groupApiService = new DefaultGroupApiService(this.apiService);
 
     this.cipherAuthorizationService = new DefaultCipherAuthorizationService(
       this.collectionService,

--- a/apps/cli/src/utils.ts
+++ b/apps/cli/src/utils.ts
@@ -204,6 +204,16 @@ export class CliUtils {
     });
   }
 
+  static searchGroups<T extends { name: string }>(groups: T[], search: string): T[] {
+    search = search.toLowerCase();
+    return groups.filter((g) => {
+      if (g.name != null && g.name.toLowerCase().indexOf(search) > -1) {
+        return true;
+      }
+      return false;
+    });
+  }
+
   /**
    * Gets a password from all available sources. In order of priority these are:
    *   * passwordfile

--- a/apps/cli/src/vault.program.ts
+++ b/apps/cli/src/vault.program.ts
@@ -68,6 +68,7 @@ export class VaultProgram extends BaseProgram {
       "folders",
       "collections",
       "org-collections",
+      "org-groups",
       "org-members",
       "organizations",
     ];
@@ -109,6 +110,10 @@ export class VaultProgram extends BaseProgram {
           writeLn("    bw list items --archived");
         }
         writeLn("    bw list folders --search email");
+        writeLn("    bw list org-groups --organizationid 60556c31-e649-4b5d-8daf-fc1c391a1bf2");
+        writeLn(
+          "    bw list org-groups --organizationid 60556c31-e649-4b5d-8daf-fc1c391a1bf2 --search admin",
+        );
         writeLn("    bw list org-members --organizationid 60556c31-e649-4b5d-8daf-fc1c391a1bf2");
         writeLn("", true);
       })
@@ -125,6 +130,7 @@ export class VaultProgram extends BaseProgram {
           this.serviceContainer.organizationService,
           this.serviceContainer.searchService,
           this.serviceContainer.organizationUserApiService,
+          this.serviceContainer.groupApiService,
           this.serviceContainer.apiService,
           this.serviceContainer.eventCollectionService,
           this.serviceContainer.accountService,

--- a/libs/admin-console/src/common/group/abstractions/group-api.service.ts
+++ b/libs/admin-console/src/common/group/abstractions/group-api.service.ts
@@ -1,0 +1,34 @@
+import { ListResponse } from "@bitwarden/common/models/response/list.response";
+
+import { GroupDetailsResponse, GroupResponse } from "../models/responses";
+
+/**
+ * Service for interacting with Organization Groups via the API
+ */
+export abstract class GroupApiService {
+  /**
+   * Retrieve all groups that belong to the specified organization
+   * @param organizationId - Identifier for the organization
+   */
+  abstract getAll(organizationId: string): Promise<ListResponse<GroupResponse>>;
+
+  /**
+   * Retrieve all groups with collection details for the specified organization
+   * @param organizationId - Identifier for the organization
+   */
+  abstract getAllDetails(organizationId: string): Promise<ListResponse<GroupDetailsResponse>>;
+
+  /**
+   * Retrieve a single group by Id
+   * @param organizationId - Identifier for the group's organization
+   * @param groupId - Group identifier
+   */
+  abstract get(organizationId: string, groupId: string): Promise<GroupDetailsResponse>;
+
+  /**
+   * Retrieve all user IDs that belong to the specified group
+   * @param organizationId - Identifier for the group's organization
+   * @param groupId - Group identifier
+   */
+  abstract getUsers(organizationId: string, groupId: string): Promise<string[]>;
+}

--- a/libs/admin-console/src/common/group/abstractions/index.ts
+++ b/libs/admin-console/src/common/group/abstractions/index.ts
@@ -1,0 +1,1 @@
+export * from "./group-api.service";

--- a/libs/admin-console/src/common/group/index.ts
+++ b/libs/admin-console/src/common/group/index.ts
@@ -1,0 +1,3 @@
+export * from "./abstractions";
+export * from "./services";
+export * from "./models";

--- a/libs/admin-console/src/common/group/models/index.ts
+++ b/libs/admin-console/src/common/group/models/index.ts
@@ -1,0 +1,1 @@
+export * from "./responses";

--- a/libs/admin-console/src/common/group/models/responses/group.response.ts
+++ b/libs/admin-console/src/common/group/models/responses/group.response.ts
@@ -1,0 +1,35 @@
+import { SelectionReadOnlyResponse } from "@bitwarden/common/admin-console/models/response/selection-read-only.response";
+import { BaseResponse } from "@bitwarden/common/models/response/base.response";
+
+/**
+ * Response model for an organization group
+ */
+export class GroupResponse extends BaseResponse {
+  id: string;
+  organizationId: string;
+  name: string;
+  externalId: string;
+
+  constructor(response: any) {
+    super(response);
+    this.id = this.getResponseProperty("Id");
+    this.organizationId = this.getResponseProperty("OrganizationId");
+    this.name = this.getResponseProperty("Name");
+    this.externalId = this.getResponseProperty("ExternalId");
+  }
+}
+
+/**
+ * Response model for an organization group with collection details
+ */
+export class GroupDetailsResponse extends GroupResponse {
+  collections: SelectionReadOnlyResponse[] = [];
+
+  constructor(response: any) {
+    super(response);
+    const collections = this.getResponseProperty("Collections");
+    if (collections != null) {
+      this.collections = collections.map((c: any) => new SelectionReadOnlyResponse(c));
+    }
+  }
+}

--- a/libs/admin-console/src/common/group/models/responses/index.ts
+++ b/libs/admin-console/src/common/group/models/responses/index.ts
@@ -1,0 +1,1 @@
+export * from "./group.response";

--- a/libs/admin-console/src/common/group/services/default-group-api.service.ts
+++ b/libs/admin-console/src/common/group/services/default-group-api.service.ts
@@ -1,0 +1,53 @@
+import { ApiService } from "@bitwarden/common/abstractions/api.service";
+import { ListResponse } from "@bitwarden/common/models/response/list.response";
+
+import { GroupApiService } from "../abstractions";
+import { GroupDetailsResponse, GroupResponse } from "../models/responses";
+
+export class DefaultGroupApiService implements GroupApiService {
+  constructor(private apiService: ApiService) {}
+
+  async getAll(organizationId: string): Promise<ListResponse<GroupResponse>> {
+    const r = await this.apiService.send(
+      "GET",
+      `/organizations/${organizationId}/groups`,
+      null,
+      true,
+      true,
+    );
+    return new ListResponse(r, GroupResponse);
+  }
+
+  async getAllDetails(organizationId: string): Promise<ListResponse<GroupDetailsResponse>> {
+    const r = await this.apiService.send(
+      "GET",
+      `/organizations/${organizationId}/groups/details`,
+      null,
+      true,
+      true,
+    );
+    return new ListResponse(r, GroupDetailsResponse);
+  }
+
+  async get(organizationId: string, groupId: string): Promise<GroupDetailsResponse> {
+    const r = await this.apiService.send(
+      "GET",
+      `/organizations/${organizationId}/groups/${groupId}/details`,
+      null,
+      true,
+      true,
+    );
+    return new GroupDetailsResponse(r);
+  }
+
+  async getUsers(organizationId: string, groupId: string): Promise<string[]> {
+    const r = await this.apiService.send(
+      "GET",
+      `/organizations/${organizationId}/groups/${groupId}/users`,
+      null,
+      true,
+      true,
+    );
+    return r;
+  }
+}

--- a/libs/admin-console/src/common/group/services/index.ts
+++ b/libs/admin-console/src/common/group/services/index.ts
@@ -1,0 +1,1 @@
+export * from "./default-group-api.service";

--- a/libs/admin-console/src/common/index.ts
+++ b/libs/admin-console/src/common/index.ts
@@ -1,2 +1,3 @@
 export * from "./collections";
+export * from "./group";
 export * from "./organization-user";


### PR DESCRIPTION
## 📔 Objective
These changes enable the CLI to interact with organization groups, making it easier to manage and search for groups within organizations