### PR TITLE
[PM-31691] - Fixing Bulk Restore Model

### DIFF
--- a/libs/admin-console/src/common/organization-user/models/requests/organization-user-bulk-restore.request.ts
+++ b/libs/admin-console/src/common/organization-user/models/requests/organization-user-bulk-restore.request.ts
@@ -1,11 +1,11 @@
 import { EncString } from "@bitwarden/sdk-internal";
 
 export class OrganizationUserBulkRestoreRequest {
-  userIds: string[];
+  ids: string[];
   defaultUserCollectionName: EncString | undefined;
 
-  constructor(userIds: string[], defaultUserCollectionName?: EncString) {
-    this.userIds = userIds;
+  constructor(ids: string[], defaultUserCollectionName?: EncString) {
+    this.ids = ids;
     this.defaultUserCollectionName = defaultUserCollectionName;
   }
 }

--- a/libs/admin-console/src/common/organization-user/services/default-organization-user.service.spec.ts
+++ b/libs/admin-console/src/common/organization-user/services/default-organization-user.service.spec.ts
@@ -258,7 +258,7 @@ describe("DefaultOrganizationUserService", () => {
           ).toHaveBeenCalledWith(
             mockOrganization.id,
             expect.objectContaining({
-              userIds: mockUserIds,
+              ids: mockUserIds,
               defaultUserCollectionName: mockEncryptedCollectionName.encryptedString,
             }),
           );


### PR DESCRIPTION
## 🎟️ Tracking
[PM-31691](https://bitwarden.atlassian.net/browse/PM-31691)

## 📔 Objective
The list of ids to restore for the bulk endpoint was called userIds in clients but the server was expecting ids. Changing to match.

⏰ Reminders before review

    Contributor guidelines followed
    All formatters and local linters executed and passed
    Written new unit and / or integration tests where applicable
    Protected functional changes with optionality (feature flags)
    Used internationalization (i18n) for all UI strings
    CI builds passed
    Communicated to DevOps any deployment requirements
    Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

🦮 Reviewer guidelines

    👍 (:+1:) or similar for great changes
    📝 (:memo:) or ℹ️ (:information_source:) for notes or general info
    ❓ (:question:) for questions
    🤔 (:thinking:) or 💭 (:thought_balloon:) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
    🎨 (:art:) for suggestions / improvements
    ❌ (:x:) or ⚠️ (:warning:) for more significant problems or concerns needing attention
    🌱 (:seedling:) or ♻️ (:recycle:) for future improvements or indications of technical debt
    ⛏ (:pick:) for minor or nitpick changes


[PM-31691]: https://bitwarden.atlassian.net/browse/PM-31691?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ