### PR TITLE
[CL-1034] tooltip should only show on focus-visible

### DIFF
--- a/libs/components/src/tooltip/tooltip.directive.ts
+++ b/libs/components/src/tooltip/tooltip.directive.ts
@@ -28,8 +28,8 @@ export const TOOLTIP_DELAY_MS = 800;
   host: {
     "(mouseenter)": "showTooltip()",
     "(mouseleave)": "hideTooltip()",
-    "(focus)": "showTooltip()",
-    "(blur)": "hideTooltip()",
+    "(focusin)": "onFocusIn($event)",
+    "(focusout)": "onFocusOut()",
     "[attr.aria-describedby]": "resolvedDescribedByIds()",
   },
 })
@@ -124,6 +124,20 @@ export class TooltipDirective implements OnInit, OnDestroy {
   protected hideTooltip = () => {
     this.destroyTooltip();
   };
+
+  /**
+   * Show tooltip on focus-visible (keyboard navigation) but not on regular focus (mouse click).
+   */
+  protected onFocusIn(event: FocusEvent) {
+    const target = event.target as HTMLElement;
+    if (target.matches(":focus-visible")) {
+      this.showTooltip();
+    }
+  }
+
+  protected onFocusOut() {
+    this.hideTooltip();
+  }
 
   protected readonly resolvedDescribedByIds = computed(() => {
     if (this.addTooltipToDescribedby()) {

--- a/libs/components/src/tooltip/tooltip.spec.ts
+++ b/libs/components/src/tooltip/tooltip.spec.ts
@@ -103,13 +103,22 @@ describe("TooltipDirective (visibility only)", () => {
     expect(isVisible()).toBe(true);
   }));
 
-  it("sets isVisible to true on focus", fakeAsync(() => {
+  it("sets isVisible to true on focus-visible", fakeAsync(() => {
     const button: HTMLButtonElement = fixture.debugElement.query(By.css("button")).nativeElement;
     const directive = getDirective();
 
     const isVisible = (directive as unknown as { isVisible: () => boolean }).isVisible;
 
-    button.dispatchEvent(new Event("focus"));
+    // Mock matches to return true for :focus-visible (simulates keyboard navigation)
+    const originalMatches = button.matches.bind(button);
+    button.matches = jest.fn((selector: string) => {
+      if (selector === ":focus-visible") {
+        return true;
+      }
+      return originalMatches(selector);
+    });
+
+    button.dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
     tick(TOOLTIP_DELAY_MS);
     expect(isVisible()).toBe(true);
   }));


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/CL-1034

## 📔 Objective

Update the `bitTooltip` directive to show on focus visible instead of focus

## 📸 Screenshots

See Storybook
