### PR TITLE
[PM-31768][BUG FIX]-Collections Appearing When No Organizations Present in Desktop

### DIFF
--- a/apps/desktop/src/vault/app/vault-v3/vault-filter/vault-filter.component.ts
+++ b/apps/desktop/src/vault/app/vault-v3/vault-filter/vault-filter.component.ts
@@ -80,6 +80,7 @@ export class VaultFilterComponent implements OnInit {
   protected readonly showCollectionsFilter = computed<boolean>(() => {
     return (
       this.organizations() != null &&
+      this.nonIndividualVaultOrganizations().length > 0 &&
       !this.activeFilter()?.isMyVaultSelected &&
       !this.allOrganizationsDisabled()
     );
@@ -89,9 +90,13 @@ export class VaultFilterComponent implements OnInit {
     if (!this.organizations()) {
       return false;
     }
-    const orgs = this.organizations().children.filter((org) => org.node.id !== "MyVault");
+    const orgs = this.nonIndividualVaultOrganizations();
     return orgs.length > 0 && orgs.every((org) => !org.node.enabled);
   });
+
+  private nonIndividualVaultOrganizations() {
+    return this.organizations().children.filter((org) => org.node.id !== "MyVault");
+  }
 
   private async setActivePolicies() {
     this.activeOrganizationDataOwnershipPolicy = await firstValueFrom(


### PR DESCRIPTION
## 🎟️ Tracking

[JIRA](https://bitwarden.atlassian.net/browse/PM-31768?atlOrigin=eyJpIjoiMmMxYjczOTU3OGE5NDBkYWE1NjI3ZjU3MWY3MzAxZDkiLCJwIjoiaiJ9)
## 📔 Objective

Fixed an issue where 'Collections' nav-item in vault filters were still appearing when no organizations are present, aside from 'My Vault' in Desktop

## 📸 Screenshots

<img width="254" height="618" alt="Screenshot 2026-02-05 at 11 32 49 AM" src="https://github.com/user-attachments/assets/2c990653-ba96-4e1b-bd38-3bbe5c3877ab" />
