### PR TITLE
[PM-31788] Don't sync invalid password ciphers to native autofill store

### DIFF
--- a/apps/desktop/src/autofill/services/desktop-autofill.service.ts
+++ b/apps/desktop/src/autofill/services/desktop-autofill.service.ts
@@ -152,11 +152,13 @@ export class DesktopAutofillService implements OnDestroy {
       passwordCredentials = cipherViews
         .filter(
           (cipher) =>
+            !cipher.isDeleted &&
             cipher.type === CipherType.Login &&
             cipher.login.uris?.length > 0 &&
             cipher.login.uris.some((uri) => uri.match !== UriMatchStrategy.Never) &&
             cipher.login.uris.some((uri) => !Utils.isNullOrWhitespace(uri.uri)) &&
-            !Utils.isNullOrWhitespace(cipher.login.username),
+            !Utils.isNullOrWhitespace(cipher.login.username) &&
+            !Utils.isNullOrWhitespace(cipher.login.password),
         )
         .map((cipher) => ({
           type: "password",


### PR DESCRIPTION
## 🎟️ Tracking

[PM-31788](https://bitwarden.atlassian.net/browse/PM-31788)

## 📔 Objective

We're syncing all Login ciphers as passwords to native autofill, including deleted ones, and fields with empty passwords. This prevents us from doing that. This may preclude us from autofilling things that are not explicitly "passwords" (e.g. custom fields), but I think that's better not to give false positives here than false negatives.


[PM-31788]: https://bitwarden.atlassian.net/browse/PM-31788?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ