### PR TITLE
[PM-31790] Fix TS type warnings on public key credential descriptor

### DIFF
--- a/libs/common/src/platform/abstractions/fido2/fido2-authenticator.service.abstraction.ts
+++ b/libs/common/src/platform/abstractions/fido2/fido2-authenticator.service.abstraction.ts
@@ -68,7 +68,7 @@ export class Fido2AuthenticatorError extends Error {
 }
 
 export interface PublicKeyCredentialDescriptor {
-  id: ArrayBuffer;
+  id: BufferSource;
   transports?: ("ble" | "hybrid" | "internal" | "nfc" | "usb")[];
   type: "public-key";
 }


### PR DESCRIPTION
## 🎟️ Tracking
[PM-31790](https://bitwarden.atlassian.net/browse/PM-31790)

## 📔 Objective

The downstream usages of PublicKeyCredentialDescriptor all take a `BufferSource`. This removes TypeScript warnings in these files.

[PM-31790]: https://bitwarden.atlassian.net/browse/PM-31790?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ