### PR TITLE
[CL-1039] Set code ownership for global style files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,8 +5,8 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 ## Global styles are owned by UIF
-*scss @bitwarden/team-ui-foundation
-*css @bitwarden/team-ui-foundation
+*.scss @bitwarden/team-ui-foundation
+*.css @bitwarden/team-ui-foundation
 
 ## Desktop native module ##
 apps/desktop/desktop_native @bitwarden/team-platform-dev


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[CL-1039](https://bitwarden.atlassian.net/browse/CL-1039)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
UIF owns global and app-shell styles, and should review any new style additions since we are limiting the amount of new css that is added to the apps. We can accomplish this by setting us as the top-level codeowners of css and scss files. Specific team-owned files can be codeowned later in the file as overrides (like the existing autofill style files).



[CL-1039]: https://bitwarden.atlassian.net/browse/CL-1039?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ