### PR TITLE
[PM-31610] Blank Screen fix for SDK usage

### DIFF
--- a/libs/common/src/vault/services/cipher.service.ts
+++ b/libs/common/src/vault/services/cipher.service.ts
@@ -934,12 +934,17 @@ export class CipherService implements CipherServiceAbstraction {
     userId: UserId,
     orgAdmin?: boolean,
   ): Promise<CipherView | void> {
+    // Clear the cache before creating the cipher. The SDK internally updates the encrypted storage
+    // but the timing of the storage emitting the new values differs across platforms. Clearing the cache after
+    // `createWithServer` can cause race conditions where the cache is cleared after the
+    // encrypted storage has already been updated and thus downstream consumers not getting updated data.
+    await this.clearCache(userId);
+
     const resultCipherView = await this.cipherSdkService.createWithServer(
       cipherView,
       userId,
       orgAdmin,
     );
-    await this.clearCache(userId);
     return resultCipherView;
   }
 
@@ -993,13 +998,18 @@ export class CipherService implements CipherServiceAbstraction {
     originalCipherView?: CipherView,
     orgAdmin?: boolean,
   ): Promise<CipherView> {
+    // Clear the cache before updating the cipher. The SDK internally updates the encrypted storage
+    // but the timing of the storage emitting the new values differs across platforms. Clearing the cache after
+    // `updateWithServer` can cause race conditions where the cache is cleared after the
+    // encrypted storage has already been updated and thus downstream consumers not getting updated data.
+    await this.clearCache(userId);
+
     const resultCipherView = await this.cipherSdkService.updateWithServer(
       cipher,
       userId,
       originalCipherView,
       orgAdmin,
     );
-    await this.clearCache(userId);
     return resultCipherView;
   }
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-31610](https://bitwarden.atlassian.net/browse/PM-31610)

## 📔 Objective

Currently there is a bug in the extension where the view cipher screen can appear blank after creating or editing a cipher. This only occurs in the browser. After chasing down log statements, the encrypted state of the `ciphers$` was being updated by the SDK _before_ the cache was cleared and then the cache is cleared resulting in `cipherViews$` emitting `null` and not the updated list.

The solution is to move the clear cache statement before the `createWithServer` and `updateWithServer` calls

## 📸 Screenshots

|Browser|Web (regression check)|Desktop (regression check)|
|-|-|-|
|<video src="https://github.com/user-attachments/assets/dfc46080-973b-4d19-8202-e03b8068cf88" />|<video src="https://github.com/user-attachments/assets/0e9cc533-de7b-400b-aec4-354996a9328d"/>|<video src="https://github.com/user-attachments/assets/ee981cc3-ae26-4bb5-a47e-bd1602131093"/>|


[PM-31610]: https://bitwarden.atlassian.net/browse/PM-31610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ