### PR TITLE
Renovate ignore dep bitwarden-russh

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -79,7 +79,6 @@
       matchPackageNames: [
         "@emotion/css",
         "@webcomponents/custom-elements",
-        "bitwarden-russh",
         "concurrently",
         "cross-env",
         "del",
@@ -562,5 +561,6 @@
     "node-ipc",
     "@bitwarden/sdk-internal",
     "@bitwarden/commercial-sdk-internal",
+    "bitwarden-russh",
   ],
 }


### PR DESCRIPTION
## 🎟️ Tracking


## 📔 Objective

Since the russh fork is formally deprecated (https://github.com/bitwarden/bitwarden-russh/pull/17)

, and the v2 effort is in flight , adding an ignore for renovate. motivated by: https://github.com/bitwarden/clients/pull/16843

Opening a follow-up task in the v2 epic to track removal of this entry from renovate after the v2 has released to prod.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
