### PR TITLE
[PM-31758] CLI - Archive org ciphers

### DIFF
--- a/apps/cli/src/vault/archive.command.ts
+++ b/apps/cli/src/vault/archive.command.ts
@@ -99,9 +99,6 @@ export class ArchiveCommand {
           errorMessage: "Item is in the trash, the item must be restored before archiving.",
         };
       }
-      case cipher.organizationId != null: {
-        return { canArchive: false, errorMessage: "Cannot archive items in an organization." };
-      }
       default:
         return { canArchive: true };
     }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-31758](https://bitwarden.atlassian.net/browse/PM-31758)

## 📔 Objective

With the requirement change, organization ciphers can now be archived.

## 📸 Screenshots

<video src="https://github.com/user-attachments/assets/c02dfa93-e21e-4d13-b666-ad38c6878f12" />


[PM-31758]: https://bitwarden.atlassian.net/browse/PM-31758?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ