### PR TITLE
[PM-31742] CLI - Restoring a deleted archived cipher

### DIFF
--- a/apps/cli/src/commands/restore.command.ts
+++ b/apps/cli/src/commands/restore.command.ts
@@ -46,7 +46,9 @@ export class RestoreCommand {
       return Response.notFound();
     }
 
-    if (cipher.archivedDate && isArchivedVaultEnabled) {
+    // Determine if restoring from archive or trash
+    // When a cipher is archived and deleted, restore from the trash first
+    if (cipher.archivedDate && cipher.deletedDate == null && isArchivedVaultEnabled) {
       return this.restoreArchivedCipher(cipher, activeUserId);
     } else {
       return this.restoreDeletedCipher(cipher, activeUserId);


### PR DESCRIPTION
## 🎟️ Tracking

[PM-31742](https://bitwarden.atlassian.net/browse/PM-31742)

## 📔 Objective

When restoring an archived cipher that is deleted it should go back to the archived vault. Previously this was only removing the `archiveDate` and thus keeping the item in the trash.

## 📸 Screenshots

<video src="https://github.com/user-attachments/assets/af74e6aa-5655-41cd-9725-28d500b060a8" />


[PM-31742]: https://bitwarden.atlassian.net/browse/PM-31742?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ