### PR TITLE
Add settings.json for extra known marketplaces

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,10 @@
+{
+  "extraKnownMarketplaces": {
+    "bitwarden-marketplace": {
+      "source": {
+        "source": "github",
+        "repo": "bitwarden/ai-plugins"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## 🎟️ Tracking

Internal change

## 📔 Objective

This commit adds a configuration file for Claude to recognize the `bitwarden-marketplace` as an extra known marketplace.

PR duplicated from https://github.com/bitwarden/ios/pull/2328

Changes:
- Add `.claude/settings.json` to define custom marketplace settings.
- Specify `bitwarden-marketplace` with its source pointing to the `bitwarden/ai-plugins` GitHub repository.
