### PR TITLE
[BEEEP] Add deprecation notices to encstring encrypt API

### DIFF
--- a/libs/common/src/key-management/crypto/abstractions/encrypt.service.ts
+++ b/libs/common/src/key-management/crypto/abstractions/encrypt.service.ts
@@ -16,7 +16,7 @@ export abstract class EncryptService {
   /**
    * Encrypts bytes to an EncString
    * 
-   * @deprecated NOTE: You probably do not want to encrypt raw bytes. Please contact KM if you think
+   * @deprecated NOTE: You probably do not want to encrypt raw bytes. Please contact the Key-Management team if you think
    * you need to.
    * 
    * @param plainValue - The value to encrypt
@@ -138,7 +138,7 @@ export abstract class EncryptService {
    * Note: This does not establish sender authenticity
    * @see {@link https://en.wikipedia.org/wiki/Key_encapsulation_mechanism}
    * 
-   * @deprecated NOTE: You probably do not want to use this. Please contact KM if you think you need to.
+   * @deprecated NOTE: You probably do not want to use this. Please contact the Key-Management team if you think you need to.
    * 
    * @param sharedKey - The symmetric key that is to be shared
    * @param encapsulationKey - The encapsulation key (public key) of the receiver that the key is shared with

--- a/libs/common/src/key-management/crypto/abstractions/encrypt.service.ts
+++ b/libs/common/src/key-management/crypto/abstractions/encrypt.service.ts
@@ -5,12 +5,20 @@ import { EncString } from "../models/enc-string";
 export abstract class EncryptService {
   /**
    * Encrypts a string to an EncString
+   * 
+   * @deprecated NOTE: For new use-cases, prefer using the DataEnvelope inside the SDK instead. This
+   * is both safer and more maintainable.
+   * 
    * @param plainValue - The value to encrypt
    * @param key - The key to encrypt the value with
    */
   abstract encryptString(plainValue: string, key: SymmetricCryptoKey): Promise<EncString>;
   /**
    * Encrypts bytes to an EncString
+   * 
+   * @deprecated NOTE: You probably do not want to encrypt raw bytes. Please contact KM if you think
+   * you need to.
+   * 
    * @param plainValue - The value to encrypt
    * @param key - The key to encrypt the value with
    * @deprecated Bytes are not the right abstraction to encrypt in. Use e.g. key wrapping or file encryption instead
@@ -129,6 +137,9 @@ export abstract class EncryptService {
    * Encapsulates a symmetric key with an asymmetric public key
    * Note: This does not establish sender authenticity
    * @see {@link https://en.wikipedia.org/wiki/Key_encapsulation_mechanism}
+   * 
+   * @deprecated NOTE: You probably do not want to use this. Please contact KM if you think you need to.
+   * 
    * @param sharedKey - The symmetric key that is to be shared
    * @param encapsulationKey - The encapsulation key (public key) of the receiver that the key is shared with
    */

--- a/libs/common/src/key-management/crypto/abstractions/encrypt.service.ts
+++ b/libs/common/src/key-management/crypto/abstractions/encrypt.service.ts
@@ -5,20 +5,20 @@ import { EncString } from "../models/enc-string";
 export abstract class EncryptService {
   /**
    * Encrypts a string to an EncString
-   * 
+   *
    * @deprecated NOTE: For new use-cases, prefer using the DataEnvelope inside the SDK instead. This
    * is both safer and more maintainable.
-   * 
+   *
    * @param plainValue - The value to encrypt
    * @param key - The key to encrypt the value with
    */
   abstract encryptString(plainValue: string, key: SymmetricCryptoKey): Promise<EncString>;
   /**
    * Encrypts bytes to an EncString
-   * 
+   *
    * @deprecated NOTE: You probably do not want to encrypt raw bytes. Please contact the Key-Management team if you think
    * you need to.
-   * 
+   *
    * @param plainValue - The value to encrypt
    * @param key - The key to encrypt the value with
    * @deprecated Bytes are not the right abstraction to encrypt in. Use e.g. key wrapping or file encryption instead
@@ -137,9 +137,9 @@ export abstract class EncryptService {
    * Encapsulates a symmetric key with an asymmetric public key
    * Note: This does not establish sender authenticity
    * @see {@link https://en.wikipedia.org/wiki/Key_encapsulation_mechanism}
-   * 
+   *
    * @deprecated NOTE: You probably do not want to use this. Please contact the Key-Management team if you think you need to.
-   * 
+   *
    * @param sharedKey - The symmetric key that is to be shared
    * @param encapsulationKey - The encapsulation key (public key) of the receiver that the key is shared with
    */


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Adds deprecation notices to the encrypt-side API's so that new use-cases are evaluated by the teams consuming these APIs. EncString should not be used, but instead the safe primitive "DataEnvelope" should be used.

encryptBytes should just not be used. Key encapsulation should also probably not be used, and usage indicates that the team is building an unsafe key-sharing protocol that lacks sender authentication. This should be done via IdentityKeyEnvelope instead.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
