### PR TITLE
[PM-31680] remove archive buttons from footer for edit view desktop

### DIFF
--- a/apps/desktop/src/vault/app/vault/item-footer.component.ts
+++ b/apps/desktop/src/vault/app/vault/item-footer.component.ts
@@ -263,15 +263,12 @@ export class ItemFooterComponent implements OnInit, OnChanges {
     this.userCanArchive = userCanArchive;
 
     this.showArchiveButton =
-      cipherCanBeArchived &&
-      userCanArchive &&
-      (this.action === "view" || this.action === "edit") &&
-      !this.cipher.isArchived;
+      cipherCanBeArchived && userCanArchive && this.action === "view" && !this.cipher.isArchived;
 
     // A user should always be able to unarchive an archived item
     this.showUnarchiveButton =
       hasArchiveFlagEnabled &&
-      (this.action === "view" || this.action === "edit") &&
+      this.action === "view" &&
       this.cipher.isArchived &&
       !this.cipher.isDeleted;
   }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-31680](https://bitwarden.atlassian.net/browse/PM-31680)

## 📔 Objective

remove the `archive` and `unarchive` buttons from the desktop footer when user is in edit view.

## 📸 Screen Recording


https://github.com/user-attachments/assets/56f30e03-cdaf-4deb-9c1d-4d3eabf5ae96





[PM-31680]: https://bitwarden.atlassian.net/browse/PM-31680?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ