### PR TITLE
[PM-31938] refactor archive btn logic in web view modal

### DIFF
--- a/apps/web/src/app/vault/components/vault-item-dialog/vault-item-dialog.component.ts
+++ b/apps/web/src/app/vault/components/vault-item-dialog/vault-item-dialog.component.ts
@@ -10,7 +10,7 @@ import {
   OnInit,
   viewChild,
 } from "@angular/core";
-import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
+import { takeUntilDestroyed, toSignal } from "@angular/core/rxjs-interop";
 import { Router } from "@angular/router";
 import { firstValueFrom, Observable, Subject, switchMap } from "rxjs";
 import { map } from "rxjs/operators";
@@ -226,7 +226,9 @@ export class VaultItemDialogComponent implements OnInit, OnDestroy {
   );
 
   protected archiveFlagEnabled$ = this.archiveService.hasArchiveFlagEnabled$;
-  private _archiveFlagEnabled = false;
+  private readonly archiveFlagEnabled = toSignal(this.archiveFlagEnabled$, {
+    initialValue: false,
+  });
 
   protected userId$ = this.accountService.activeAccount$.pipe(getUserId);
 
@@ -237,6 +239,8 @@ export class VaultItemDialogComponent implements OnInit, OnDestroy {
   protected userCanArchive$ = this.userId$.pipe(
     switchMap((userId) => this.archiveService.userCanArchive$(userId)),
   );
+
+  private readonly userCanArchive = toSignal(this.userCanArchive$, { initialValue: false });
 
   protected get isTrashFilter() {
     return this.filter?.type === "trash";
@@ -294,16 +298,14 @@ export class VaultItemDialogComponent implements OnInit, OnDestroy {
     return this.cipher?.isArchived;
   }
 
-  private _userCanArchive = false;
-
   protected get showArchiveOptions(): boolean {
     return (
-      this._archiveFlagEnabled && !this.params.isAdminConsoleAction && this.params.mode === "view"
+      this.archiveFlagEnabled() && !this.params.isAdminConsoleAction && this.params.mode === "view"
     );
   }
 
   protected get showArchiveBtn(): boolean {
-    return this._userCanArchive && this.cipher?.canBeArchived;
+    return this.userCanArchive() && this.cipher?.canBeArchived;
   }
 
   protected get showUnarchiveBtn(): boolean {
@@ -358,11 +360,6 @@ export class VaultItemDialogComponent implements OnInit, OnDestroy {
         takeUntilDestroyed(),
       )
       .subscribe();
-
-    this.userCanArchive$.pipe(takeUntilDestroyed()).subscribe((v) => (this._userCanArchive = v));
-    this.archiveFlagEnabled$
-      .pipe(takeUntilDestroyed())
-      .subscribe((v) => (this._archiveFlagEnabled = v));
   }
 
   async ngOnInit() {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-31938](https://bitwarden.atlassian.net/browse/PM-31938)

## 📔 Objective

* The `unarchive` button in the view modal will always show no matter what the users premium status is
* move `userCanArchive` logic check from `showArchiveOptions` to only `showArchiveBtn`. 
* Add flag check to `showArchiveOptions` 

## 📸 Screen Recording


https://github.com/user-attachments/assets/3e9ba532-d9c8-4ee1-a4ea-237a2b985f73




[PM-31938]: https://bitwarden.atlassian.net/browse/PM-31938?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ