### PR TITLE
[PM-31740] Align Dialog Text

### DIFF
--- a/libs/vault/src/components/vault-items-transfer/leave-confirmation-dialog.component.html
+++ b/libs/vault/src/components/vault-items-transfer/leave-confirmation-dialog.component.html
@@ -1,9 +1,9 @@
 <bit-simple-dialog>
-  <i
+  <bit-icon
     bitDialogIcon
-    class="bwi bwi-exclamation-triangle tw-text-warning tw-text-3xl"
-    aria-hidden="true"
-  ></i>
+    name="bwi-exclamation-triangle"
+    class="tw-text-warning tw-text-3xl"
+  ></bit-icon>
 
   <span bitDialogTitle>{{ "leaveConfirmationDialogTitle" | i18n }}</span>
 
@@ -27,7 +27,7 @@
 
     <a bitLink href="#" (click)="openLearnMore($event)" class="tw-self-center tw-text-sm">
       {{ "howToManageMyVault" | i18n }}
-      <i class="bwi bwi-external-link tw-ml-1" aria-hidden="true"></i>
+      <bit-icon name="bwi-external-link" class="tw-ml-1"></bit-icon>
     </a>
   </ng-container>
 </bit-simple-dialog>

--- a/libs/vault/src/components/vault-items-transfer/leave-confirmation-dialog.component.ts
+++ b/libs/vault/src/components/vault-items-transfer/leave-confirmation-dialog.component.ts
@@ -10,6 +10,7 @@ import {
   DialogService,
   ButtonModule,
   DialogModule,
+  IconModule,
   LinkModule,
   TypographyModule,
   CenterPositionStrategy,
@@ -35,7 +36,7 @@ export type LeaveConfirmationDialogResultType = UnionOfValues<typeof LeaveConfir
 @Component({
   templateUrl: "./leave-confirmation-dialog.component.html",
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [ButtonModule, DialogModule, LinkModule, TypographyModule, JslibModule],
+  imports: [ButtonModule, DialogModule, IconModule, LinkModule, TypographyModule, JslibModule],
 })
 export class LeaveConfirmationDialogComponent {
   private readonly params = inject<LeaveConfirmationDialogParams>(DIALOG_DATA);

--- a/libs/vault/src/components/vault-items-transfer/transfer-items-dialog.component.html
+++ b/libs/vault/src/components/vault-items-transfer/transfer-items-dialog.component.html
@@ -16,7 +16,7 @@
 
     <a bitLink href="#" (click)="openLearnMore($event)" class="tw-self-center tw-text-sm">
       {{ "whyAmISeeingThis" | i18n }}
-      <i class="bwi bwi-external-link tw-ml-1" aria-hidden="true"></i>
+      <bit-icon name="bwi-external-link" class="tw-ml-1"></bit-icon>
     </a>
   </ng-container>
 </bit-simple-dialog>

--- a/libs/vault/src/components/vault-items-transfer/transfer-items-dialog.component.ts
+++ b/libs/vault/src/components/vault-items-transfer/transfer-items-dialog.component.ts
@@ -10,6 +10,7 @@ import {
   DialogService,
   ButtonModule,
   DialogModule,
+  IconModule,
   LinkModule,
   TypographyModule,
   CenterPositionStrategy,
@@ -35,7 +36,7 @@ export type TransferItemsDialogResultType = UnionOfValues<typeof TransferItemsDi
 @Component({
   templateUrl: "./transfer-items-dialog.component.html",
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [ButtonModule, DialogModule, LinkModule, TypographyModule, JslibModule],
+  imports: [ButtonModule, DialogModule, IconModule, LinkModule, TypographyModule, JslibModule],
 })
 export class TransferItemsDialogComponent {
   private readonly params = inject<TransferItemsDialogParams>(DIALOG_DATA);


### PR DESCRIPTION
## 🎟️ Tracking

[PM-31740](https://bitwarden.atlassian.net/browse/PM-31740)

## 📔 Objective

- Horizontally align links within the transfer dialogs
- Fix bit-icon warnings

## 📸 Screenshots

|Transfer Items|Decline Transfer|
|-|-|
|<img width="394" height="335" alt="Screenshot 2026-02-10 at 11 06 23 AM" src="https://github.com/user-attachments/assets/25f6e8e1-0225-475f-a33d-7586a9b26ae1" />|<img width="389" height="403" alt="Screenshot 2026-02-10 at 11 06 30 AM" src="https://github.com/user-attachments/assets/6a9f82f6-22ea-4cfe-a6e2-02a6de740920" />|


[PM-31740]: https://bitwarden.atlassian.net/browse/PM-31740?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ