### PR TITLE
[PM-31918] Bugfix - Do not show passkey dialog and notifications at the same time

### DIFF
--- a/apps/browser/src/autofill/background/notification.background.spec.ts
+++ b/apps/browser/src/autofill/background/notification.background.spec.ts
@@ -28,6 +28,7 @@ import { TaskService, SecurityTask } from "@bitwarden/common/vault/tasks";
 
 import { BrowserApi } from "../../platform/browser/browser-api";
 import { NotificationType } from "../enums/notification-type.enum";
+import { Fido2Background } from "../fido2/background/abstractions/fido2.background";
 import { FormData } from "../services/abstractions/autofill.service";
 import AutofillService from "../services/autofill.service";
 import { createAutofillPageDetailsMock, createChromeTabMock } from "../spec/autofill-mocks";
@@ -81,6 +82,8 @@ describe("NotificationBackground", () => {
   const configService = mock<ConfigService>();
   const accountService = mock<AccountService>();
   const organizationService = mock<OrganizationService>();
+  const fido2Background = mock<Fido2Background>();
+  fido2Background.isCredentialRequestInProgress.mockReturnValue(false);
 
   const userId = "testId" as UserId;
   const activeAccountSubject = new BehaviorSubject({
@@ -115,6 +118,7 @@ describe("NotificationBackground", () => {
       userNotificationSettingsService,
       taskService,
       messagingService,
+      fido2Background,
     );
   });
 
@@ -717,7 +721,6 @@ describe("NotificationBackground", () => {
           notificationBackground as any,
           "getEnableChangedPasswordPrompt",
         );
-
         pushChangePasswordToQueueSpy = jest.spyOn(
           notificationBackground as any,
           "pushChangePasswordToQueue",
@@ -774,6 +777,22 @@ describe("NotificationBackground", () => {
 
         activeAccountStatusMock$.next(AuthenticationStatus.Unlocked);
         getAllDecryptedForUrlSpy.mockResolvedValueOnce(storedCiphersForURL);
+
+        await notificationBackground.triggerCipherNotification(formEntryData, tab);
+
+        expectSkippedCheckingNotification();
+      });
+
+      it("skips checking if a notification should trigger if a fido2 credential request is in progress for the tab", async () => {
+        const formEntryData: ModifyLoginCipherFormData = {
+          newPassword: "",
+          password: "",
+          uri: mockFormURI,
+          username: "ADent",
+        };
+
+        activeAccountStatusMock$.next(AuthenticationStatus.Unlocked);
+        fido2Background.isCredentialRequestInProgress.mockReturnValueOnce(true);
 
         await notificationBackground.triggerCipherNotification(formEntryData, tab);
 

--- a/apps/browser/src/autofill/background/notification.background.ts
+++ b/apps/browser/src/autofill/background/notification.background.ts
@@ -61,6 +61,7 @@ import {
 } from "../content/components/cipher/types";
 import { CollectionView } from "../content/components/common-types";
 import { NotificationType } from "../enums/notification-type.enum";
+import { Fido2Background } from "../fido2/background/abstractions/fido2.background";
 import { AutofillService } from "../services/abstractions/autofill.service";
 import { TemporaryNotificationChangeLoginService } from "../services/notification-change-login-password.service";
 
@@ -164,6 +165,7 @@ export default class NotificationBackground {
     private userNotificationSettingsService: UserNotificationSettingsServiceAbstraction,
     private taskService: TaskService,
     protected messagingService: MessagingService,
+    private fido2Background: Fido2Background,
   ) {}
 
   init() {
@@ -657,6 +659,11 @@ export default class NotificationBackground {
     // If the entered data doesn't have an associated URI, exit early
     const loginDomain = Utils.getDomain(data.uri);
     if (loginDomain === null) {
+      return false;
+    }
+
+    // If there is an active passkey prompt, exit early
+    if (this.fido2Background.isCredentialRequestInProgress(tab.id)) {
       return false;
     }
 

--- a/apps/browser/src/autofill/fido2/background/abstractions/fido2.background.ts
+++ b/apps/browser/src/autofill/fido2/background/abstractions/fido2.background.ts
@@ -45,6 +45,8 @@ type Fido2BackgroundExtensionMessageHandlers = {
 
 interface Fido2Background {
   init(): void;
+  isCredentialRequestInProgress(tabId: number): boolean;
+  isPasskeySettingEnabled(): Promise<boolean>;
 }
 
 export {

--- a/apps/browser/src/autofill/fido2/services/browser-fido2-user-interface.service.ts
+++ b/apps/browser/src/autofill/fido2/services/browser-fido2-user-interface.service.ts
@@ -365,6 +365,9 @@ export class BrowserFido2UserInterfaceSession implements Fido2UserInterfaceSessi
       ),
     );
 
+    // Defensive measure in case an existing notification appeared before the passkey popout
+    await BrowserApi.tabSendMessageData(this.tab, "closeNotificationBar");
+
     const popoutId = await openFido2Popout(this.tab, {
       sessionId: this.sessionId,
       fallbackSupported: this.fallbackSupported,

--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -1375,6 +1375,7 @@ export default class MainBackground {
       this.userNotificationSettingsService,
       this.taskService,
       this.messagingService,
+      this.fido2Background,
     );
 
     this.overlayNotificationsBackground = new OverlayNotificationsBackground(


### PR DESCRIPTION
## 🎟️ Tracking

[PM-31918](https://bitwarden.atlassian.net/browse/PM-31918)

## 📔 Objective

Because passkey registration can accompany a username field, the feature-flagged (`undetermined-cipher-scenario-logic`) notification triggering logic will fire alongside the passkey dialog. The non-feature-flagged logic, on the other hand, is only coincidentally mutually exclusive to the passkey prompt owning to the logic in `shouldAttemptNotification`. Because the notification experience cannot presently handle passkey registration scenarios, we should not show it when a passkey scenario is triggered.

The solve for this is two-fold:
- Mirror the `getActiveRequest` pattern from `Fido2ActiveRequestManager` (which is not invoked during passkey registration) in `Fido2Background` (which handles passkey registration) to track if a passkey registration experience is active for a given tab.
- Close any notifications just before invoking `openFido2Popout` - this is needed because the notification and passkey scripts operate independently from each other and so can race.

[PM-31918]: https://bitwarden.atlassian.net/browse/PM-31918?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ