### PR TITLE
[PM-32088] Switch phishing data source to GitHub

### DIFF
--- a/apps/browser/src/dirt/phishing-detection/phishing-resources.ts
+++ b/apps/browser/src/dirt/phishing-detection/phishing-resources.ts
@@ -1,7 +1,6 @@
 export type PhishingResource = {
   name?: string;
   primaryUrl: string;
-  fallbackUrl: string;
   checksumUrl: string;
   todayUrl: string;
   /** Matcher used to decide whether a given URL matches an entry from this resource */
@@ -21,7 +20,6 @@ export const PHISHING_RESOURCES: Record<PhishingResourceType, PhishingResource[]
       name: "Phishing.Database Domains",
       primaryUrl:
         "https://raw.githubusercontent.com/Phishing-Database/Phishing.Database/refs/heads/master/phishing-domains-ACTIVE.txt",
-      fallbackUrl: "https://phish.co.za/latest/phishing-domains-ACTIVE.txt",
       checksumUrl:
         "https://raw.githubusercontent.com/Phishing-Database/checksums/refs/heads/master/phishing-domains-ACTIVE.txt.md5",
       todayUrl:
@@ -49,7 +47,6 @@ export const PHISHING_RESOURCES: Record<PhishingResourceType, PhishingResource[]
     {
       name: "Phishing.Database Links",
       primaryUrl: "https://assets.bitwarden.com/security/v1/link-blocklist.txt",
-      fallbackUrl: "https://phish.co.za/latest/phishing-links-ACTIVE.txt",
       checksumUrl:
         "https://raw.githubusercontent.com/Phishing-Database/checksums/refs/heads/master/phishing-links-ACTIVE.txt.md5",
       todayUrl:

--- a/apps/browser/src/dirt/phishing-detection/services/phishing-data.service.ts
+++ b/apps/browser/src/dirt/phishing-detection/services/phishing-data.service.ts
@@ -33,9 +33,6 @@ import { getPhishingResources, PhishingResourceType } from "../phishing-resource
 
 import { PhishingIndexedDbService } from "./phishing-indexeddb.service";
 
-/** When false, only the primaryUrl is used and fallbackUrl is ignored. */
-const USE_FALLBACK = false;
-
 /**
  * Metadata about the phishing data set
  */
@@ -312,7 +309,7 @@ export class PhishingDataService {
     }
 
     this.logService.info(`[PhishingDataService] Starting FULL update using ${resource.primaryUrl}`);
-    const primary$ = from(this.apiService.nativeFetch(new Request(resource.primaryUrl))).pipe(
+    return from(this.apiService.nativeFetch(new Request(resource.primaryUrl))).pipe(
       switchMap((response) => {
         if (!response.ok || !response.body) {
           return throwError(
@@ -324,37 +321,6 @@ export class PhishingDataService {
         }
 
         return from(this.indexedDbService.saveUrlsFromStream(response.body));
-      }),
-    );
-
-    if (!USE_FALLBACK) {
-      return primary$;
-    }
-
-    return primary$.pipe(
-      catchError((err: unknown) => {
-        this.logService.error(
-          `[PhishingDataService] Full dataset update failed using primary source ${err}`,
-        );
-        this.logService.warning(`[PhishingDataService] Falling back to: ${resource.fallbackUrl}`);
-        return from(this.apiService.nativeFetch(new Request(resource.fallbackUrl))).pipe(
-          switchMap((fallbackResponse) => {
-            if (!fallbackResponse.ok || !fallbackResponse.body) {
-              return throwError(
-                () =>
-                  new Error(
-                    `[PhishingDataService] Fallback fetch failed: ${fallbackResponse.status}, ${fallbackResponse.statusText}`,
-                  ),
-              );
-            }
-
-            return from(this.indexedDbService.saveUrlsFromStream(fallbackResponse.body));
-          }),
-          catchError((fallbackError: unknown) => {
-            this.logService.error(`[PhishingDataService] Fallback source failed`);
-            return throwError(() => fallbackError);
-          }),
-        );
       }),
     );
   }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-32088 - most recent
https://bitwarden.atlassian.net/browse/PM-32026

## 📔 Objective

Swap phishing urls to now use the bw owned url and remove all fallback logic.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
