### PR TITLE
fix: remove broken flatpak install command in validation job

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -2054,7 +2054,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libasound2 flatpak xvfb dbus-x11
           flatpak remote-add --if-not-exists --user flathub https://flathub.org/repo/flathub.flatpakrepo
-          flatpak install -y --user flathub
 
       - name: Install flatpak
         working-directory: apps/desktop/artifacts/linux/flatpak


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

The `flatpak install -y --user flathub` command was ambiguous and never specified a valid ref, causing an interactive prompt that fails in CI. The line is unnecessary since runtime dependencies are auto-resolved from the flathub remote when the Bitwarden bundle is installed.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
