### PR TITLE
[PM-30820] Update showDescription property in BasePolicyEditDefinition to false

### DIFF
--- a/apps/web/src/app/admin-console/organizations/policies/base-policy-edit.component.ts
+++ b/apps/web/src/app/admin-console/organizations/policies/base-policy-edit.component.ts
@@ -56,7 +56,7 @@ export abstract class BasePolicyEditDefinition {
    * If true, the {@link description} will be reused in the policy edit modal. Set this to false if you
    * have more complex requirements that you will implement in your template instead.
    **/
-  showDescription: boolean = true;
+  showDescription: boolean = false;
 
   /**
    * A method that determines whether to display this policy in the Admin Console Policies page.


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-30820

## 📔 Objective

Default description to be off for base-policy-edit so subtitle is not shown

## 📸 Screenshots

<img width="1643" height="933" alt="image" src="https://github.com/user-attachments/assets/65367843-cf92-495d-ad2f-74892852b8dd" />

