### PR TITLE
[PM-32070] Keyboard user on web cannot tell what item is selected when navigating the vault using tab

### DIFF
--- a/libs/components/src/link/link.component.ts
+++ b/libs/components/src/link/link.component.ts
@@ -56,6 +56,7 @@ const commonStyles = [
   "tw-cursor-pointer",
   "[&:hover_span]:tw-underline",
   "[&.tw-test-hover_span]:tw-underline",
+  "focus-visible:tw-underline",
   "[&:hover_span]:tw-decoration-[.125em]",
   "[&.tw-test-hover_span]:tw-decoration-[.125em]",
   "disabled:tw-no-underline",


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-32070

## 📔 Objective

Re-add an underline on the cipher name when a user is tabbing through the vault

## 📸 Screenshots

https://github.com/user-attachments/assets/e02d593e-cbbf-4a80-bce8-d37420ebd8b1

