### PR TITLE
[PM-31774] Remove toggle visibility callout on hidden text sends

### DIFF
--- a/apps/web/src/app/tools/send/send-access/send-access-text.component.html
+++ b/apps/web/src/app/tools/send/send-access/send-access-text.component.html
@@ -1,26 +1,16 @@
-<bit-callout *ngIf="send.text.hidden" type="info">{{ "sendHiddenByDefault" | i18n }}</bit-callout>
 <bit-form-field [formGroup]="formGroup">
   <textarea id="text" bitInput rows="8" name="Text" formControlName="sendText" readonly></textarea>
 </bit-form-field>
 <div class="tw-mb-3">
-  <button
-    bitButton
-    type="button"
-    buttonType="secondary"
-    [block]="true"
-    (click)="toggleText()"
-    *ngIf="send.text.hidden"
-  >
-    <i
-      class="bwi bwi-lg"
-      aria-hidden="true"
-      [ngClass]="{ 'bwi-eye': !showText, 'bwi-eye-slash': showText }"
-    ></i>
-    {{ "toggleVisibility" | i18n }}
-  </button>
+  @if (send.text.hidden) {
+    <button bitButton type="button" buttonType="secondary" [block]="true" (click)="toggleText()">
+      <bit-icon class="bwi-lg" [name]="showText ? 'bwi-eye' : 'bwi-eye-slash'"></bit-icon>
+      {{ "toggleVisibility" | i18n }}
+    </button>
+  }
 </div>
 <div class="tw-mb-3">
   <button bitButton type="button" buttonType="primary" [block]="true" (click)="copyText()">
-    <i class="bwi bwi-clone" aria-hidden="true"></i> {{ "copyValue" | i18n }}
+    <bit-icon name="bwi-clone"></bit-icon>{{ "copyValue" | i18n }}
   </button>
 </div>

--- a/apps/web/src/app/tools/send/send-access/send-access-text.component.ts
+++ b/apps/web/src/app/tools/send/send-access/send-access-text.component.ts
@@ -6,7 +6,7 @@ import { FormBuilder } from "@angular/forms";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { SendAccessView } from "@bitwarden/common/tools/send/models/view/send-access.view";
-import { ToastService } from "@bitwarden/components";
+import { IconModule, ToastService } from "@bitwarden/components";
 
 import { SharedModule } from "../../../shared";
 
@@ -15,7 +15,7 @@ import { SharedModule } from "../../../shared";
 @Component({
   selector: "app-send-access-text",
   templateUrl: "send-access-text.component.html",
-  imports: [SharedModule],
+  imports: [SharedModule, IconModule],
 })
 export class SendAccessTextComponent {
   private _send: SendAccessView = null;

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -5840,10 +5840,6 @@
     "message": "Don't know the password? Ask the sender for the password needed to access this Send.",
     "description": "'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated."
   },
-  "sendHiddenByDefault": {
-    "message": "This Send is hidden by default. You can toggle its visibility using the button below.",
-    "description": "'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated."
-  },
   "downloadAttachments": {
     "message": "Download attachments"
   },


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-31774

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR removes the callout on hidden text Sends to reduce visual clutter. Also update the HTML with a couple of best practices.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
__Before__

<img width="574" height="948" alt="Screenshot 2026-02-11 at 16 25 17" src="https://github.com/user-attachments/assets/4830ff34-9b99-4739-8202-d678d67fe1c4" />

__After__

<img width="500" height="836" alt="Screenshot 2026-02-11 at 16 22 57" src="https://github.com/user-attachments/assets/fdf7a106-6d7a-4968-a931-61282078dd53" />
