### PR TITLE
Fix phishing warning "Continue to this site" button not working

### DIFF
--- a/apps/browser/src/dirt/phishing-detection/popup/phishing-warning.component.ts
+++ b/apps/browser/src/dirt/phishing-detection/popup/phishing-warning.component.ts
@@ -4,7 +4,6 @@ import { ActivatedRoute, RouterModule } from "@angular/router";
 import { firstValueFrom, map } from "rxjs";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
-import { BrowserApi } from "@bitwarden/browser/platform/browser/browser-api";
 import {
   AsyncActionsModule,
   ButtonModule,
@@ -51,26 +50,44 @@ export class PhishingWarning {
   private messageSender = inject(MessageSender);
 
   private phishingUrl$ = this.activatedRoute.queryParamMap.pipe(
-    map((params) => params.get("phishingUrl") || ""),
+    map((params) => {
+      const encoded = params.get("phishingUrl");
+      if (!encoded) {
+        return "";
+      }
+      try {
+        return decodeURIComponent(encoded);
+      } catch {
+        return encoded;
+      }
+    }),
+  );
+  private tabId$ = this.activatedRoute.queryParamMap.pipe(
+    map((params) => {
+      const tabIdParam = params.get("tabId");
+      if (!tabIdParam) {
+        return undefined;
+      }
+      const parsed = parseInt(tabIdParam, 10);
+      return Number.isNaN(parsed) ? undefined : parsed;
+    }),
   );
   protected phishingHostname$ = this.phishingUrl$.pipe(map((url) => new URL(url).hostname));
 
   async closeTab() {
-    const tabId = await this.getTabId();
-    this.messageSender.send(PHISHING_DETECTION_CANCEL_COMMAND, {
-      tabId,
-    });
-  }
-  async continueAnyway() {
-    const url = await firstValueFrom(this.phishingUrl$);
-    const tabId = await this.getTabId();
-    this.messageSender.send(PHISHING_DETECTION_CONTINUE_COMMAND, {
-      tabId,
-      url,
-    });
+    const tabId = await firstValueFrom(this.tabId$);
+    if (tabId === undefined) {
+      return;
+    }
+    this.messageSender.send(PHISHING_DETECTION_CANCEL_COMMAND, { tabId });
   }
 
-  private async getTabId() {
-    return BrowserApi.getCurrentTab()?.then((tab) => tab.id);
+  async continueAnyway() {
+    const url = await firstValueFrom(this.phishingUrl$);
+    const tabId = await firstValueFrom(this.tabId$);
+    if (tabId === undefined) {
+      return;
+    }
+    this.messageSender.send(PHISHING_DETECTION_CONTINUE_COMMAND, { tabId, url });
   }
 }

--- a/apps/browser/src/dirt/phishing-detection/popup/phishing-warning.stories.ts
+++ b/apps/browser/src/dirt/phishing-detection/popup/phishing-warning.stories.ts
@@ -85,7 +85,7 @@ export default {
             }).asObservable(),
           },
         },
-        mockActivatedRoute({ phishingUrl: "http://malicious-example.com" }),
+        mockActivatedRoute({ phishingUrl: "http://malicious-example.com", tabId: "123" }),
       ],
     }),
   ],
@@ -111,7 +111,9 @@ type Story = StoryObj<StoryArgs & { pageIcon: any }>;
 export const Default: Story = {
   decorators: [
     moduleMetadata({
-      providers: [mockActivatedRoute({ phishingUrl: "http://malicious-example.com" })],
+      providers: [
+        mockActivatedRoute({ phishingUrl: "http://malicious-example.com", tabId: "123" }),
+      ],
     }),
   ],
 };
@@ -123,6 +125,7 @@ export const LongHostname: Story = {
         mockActivatedRoute({
           phishingUrl:
             "http://verylongsuspiciousphishingdomainnamethatmightwrapmaliciousexample.com",
+          tabId: "123",
         }),
       ],
     }),

--- a/apps/browser/src/dirt/phishing-detection/services/phishing-detection.service.ts
+++ b/apps/browser/src/dirt/phishing-detection/services/phishing-detection.service.ts
@@ -93,7 +93,7 @@ export class PhishingDetectionService {
 
         const phishingWarningPage = new URL(
           BrowserApi.getRuntimeURL("popup/index.html#/security/phishing-warning") +
-            `?phishingUrl=${url.toString()}`,
+            `?phishingUrl=${encodeURIComponent(url.toString())}&tabId=${tabId}`,
         );
         await BrowserApi.navigateTabToUrl(tabId, phishingWarningPage);
       }),


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

- Fixed redirect loop when clicking "Continue to this site" on phishing warning page
- Root cause: chrome.tabs.getCurrent() returns undefined for extension pages loaded in tabs, causing navigation to silently fail
- Pass tabId as URL query parameter when redirecting to warning page
- Read tabId from query params instead of using unreliable getCurrentTab() API
- Added URL encoding/decoding for phishingUrl to handle special characters
- Added try/catch for decodeURIComponent() to handle malformed URLs gracefully

## 📸 Screenshots

n/A