### PR TITLE
[CL-1046] Migrate auth settings dialogs to new form pattern

### DIFF
--- a/apps/web/src/app/auth/settings/emergency-access/emergency-access-add-edit.component.html
+++ b/apps/web/src/app/auth/settings/emergency-access/emergency-access-add-edit.component.html
@@ -1,69 +1,73 @@
-<form [formGroup]="addEditForm" [bitSubmit]="submit">
-  <bit-dialog dialogSize="large" [loading]="loading">
-    <span bitDialogTitle>
-      <app-premium-badge *ngIf="readOnly"></app-premium-badge>
-      {{ title }}
-      <small class="tw-text-muted" *ngIf="params.name">{{ params.name }}</small>
-    </span>
-    <ng-container bitDialogContent>
-      <ng-container *ngIf="!editMode">
-        <p bitTypography="body1">{{ "inviteEmergencyContactDesc" | i18n }}</p>
-        <bit-form-field>
-          <bit-label>{{ "email" | i18n }}</bit-label>
-          <input bitInput formControlName="email" />
-        </bit-form-field>
-      </ng-container>
-      <bit-radio-group formControlName="emergencyAccessType" [block]="true">
-        <bit-label>
-          {{ "userAccess" | i18n }}
-          <a
-            target="_blank"
-            rel="noreferrer"
-            bitLink
-            linkType="primary"
-            appA11yTitle="{{ 'learnMoreAboutUserAccess' | i18n }}"
-            href="https://bitwarden.com/help/emergency-access/#user-access"
-            slot="end"
-          >
-            <bit-icon name="bwi-question-circle"></bit-icon>
-          </a>
-        </bit-label>
-        <bit-radio-button id="emergencyTypeView" [value]="emergencyAccessType.View">
-          <bit-label>{{ "view" | i18n }}</bit-label>
-          <bit-hint>{{ "viewDesc" | i18n }}</bit-hint>
-        </bit-radio-button>
-
-        <bit-radio-button id="emergencyTypeTakeover" [value]="emergencyAccessType.Takeover">
-          <bit-label>{{ "takeover" | i18n }}</bit-label>
-          <bit-hint>{{ "takeoverDesc" | i18n }}</bit-hint>
-        </bit-radio-button>
-      </bit-radio-group>
-
-      <bit-form-field class="tw-w-1/2 tw-relative tw-px-2.5">
-        <bit-label>{{ "waitTime" | i18n }}</bit-label>
-        <bit-select formControlName="waitTime">
-          <bit-option *ngFor="let o of waitTimes" [value]="o.value" [label]="o.name"></bit-option>
-        </bit-select>
-        <bit-hint class="tw-text-sm">{{ "waitTimeDesc" | i18n }}</bit-hint>
+<form
+  [formGroup]="addEditForm"
+  [bitSubmit]="submit"
+  bit-dialog
+  dialogSize="large"
+  [loading]="loading"
+>
+  <span bitDialogTitle>
+    <app-premium-badge *ngIf="readOnly"></app-premium-badge>
+    {{ title }}
+    <small class="tw-text-muted" *ngIf="params.name">{{ params.name }}</small>
+  </span>
+  <ng-container bitDialogContent>
+    <ng-container *ngIf="!editMode">
+      <p bitTypography="body1">{{ "inviteEmergencyContactDesc" | i18n }}</p>
+      <bit-form-field>
+        <bit-label>{{ "email" | i18n }}</bit-label>
+        <input bitInput formControlName="email" />
       </bit-form-field>
     </ng-container>
-    <ng-container bitDialogFooter>
-      <button type="submit" buttonType="primary" bitButton bitFormButton [disabled]="readOnly">
-        {{ "save" | i18n }}
-      </button>
-      <button bitButton bitFormButton buttonType="secondary" type="button" bitDialogClose>
-        {{ "cancel" | i18n }}
-      </button>
-      <button
-        type="button"
-        bitFormButton
-        class="tw-ml-auto"
-        bitIconButton="bwi-trash"
-        buttonType="dangerGhost"
-        [bitAction]="delete"
-        *ngIf="editMode"
-        label="{{ 'delete' | i18n }}"
-      ></button>
-    </ng-container>
-  </bit-dialog>
+    <bit-radio-group formControlName="emergencyAccessType" [block]="true">
+      <bit-label>
+        {{ "userAccess" | i18n }}
+        <a
+          target="_blank"
+          rel="noreferrer"
+          bitLink
+          linkType="primary"
+          appA11yTitle="{{ 'learnMoreAboutUserAccess' | i18n }}"
+          href="https://bitwarden.com/help/emergency-access/#user-access"
+          slot="end"
+        >
+          <bit-icon name="bwi-question-circle"></bit-icon>
+        </a>
+      </bit-label>
+      <bit-radio-button id="emergencyTypeView" [value]="emergencyAccessType.View">
+        <bit-label>{{ "view" | i18n }}</bit-label>
+        <bit-hint>{{ "viewDesc" | i18n }}</bit-hint>
+      </bit-radio-button>
+
+      <bit-radio-button id="emergencyTypeTakeover" [value]="emergencyAccessType.Takeover">
+        <bit-label>{{ "takeover" | i18n }}</bit-label>
+        <bit-hint>{{ "takeoverDesc" | i18n }}</bit-hint>
+      </bit-radio-button>
+    </bit-radio-group>
+
+    <bit-form-field class="tw-w-1/2 tw-relative tw-px-2.5">
+      <bit-label>{{ "waitTime" | i18n }}</bit-label>
+      <bit-select formControlName="waitTime">
+        <bit-option *ngFor="let o of waitTimes" [value]="o.value" [label]="o.name"></bit-option>
+      </bit-select>
+      <bit-hint class="tw-text-sm">{{ "waitTimeDesc" | i18n }}</bit-hint>
+    </bit-form-field>
+  </ng-container>
+  <ng-container bitDialogFooter>
+    <button type="submit" buttonType="primary" bitButton bitFormButton [disabled]="readOnly">
+      {{ "save" | i18n }}
+    </button>
+    <button bitButton bitFormButton buttonType="secondary" type="button" bitDialogClose>
+      {{ "cancel" | i18n }}
+    </button>
+    <button
+      type="button"
+      bitFormButton
+      class="tw-ml-auto"
+      bitIconButton="bwi-trash"
+      buttonType="dangerGhost"
+      [bitAction]="delete"
+      *ngIf="editMode"
+      label="{{ 'delete' | i18n }}"
+    ></button>
+  </ng-container>
 </form>

--- a/apps/web/src/app/auth/settings/two-factor/two-factor-setup-authenticator.component.html
+++ b/apps/web/src/app/auth/settings/two-factor/two-factor-setup-authenticator.component.html
@@ -1,105 +1,103 @@
-<form *ngIf="authed" [formGroup]="formGroup" [bitSubmit]="submit">
-  <bit-dialog
-    dialogSize="default"
-    [title]="'twoStepLogin' | i18n"
-    [subtitle]="'authenticatorAppTitle' | i18n"
-  >
-    <ng-container bitDialogContent>
-      <ng-container *ngIf="enabled">
-        <bit-callout type="success" title="{{ 'enabled' | i18n }}" icon="bwi-check-circle">
-          <p bitTypography="body1">{{ "twoStepLoginProviderEnabled" | i18n }}</p>
-          {{ "twoStepAuthenticatorReaddDesc" | i18n }}
-        </bit-callout>
-        <p bitTypography="body1">{{ "twoStepAuthenticatorNeedApp" | i18n }}</p>
-      </ng-container>
-      <ng-container *ngIf="!enabled">
-        <p>
-          {{ "twoStepAuthenticatorInstructionPrefix" | i18n }}
-          <a
-            bitLink
-            target="_blank"
-            rel="noreferrer"
-            (click)="launchExternalUrl('https://getaegis.app')"
-            >Aegis</a
-          >
-          {{ "twoStepAuthenticatorInstructionInfix1" | i18n }}
-          <a
-            bitLink
-            target="_blank"
-            rel="noreferrer"
-            (click)="launchExternalUrl('https://2fas.com')"
-            >2FAS</a
-          >
-          {{ "twoStepAuthenticatorInstructionInfix2" | i18n }}
-          <a
-            bitLink
-            target="_blank"
-            rel="noreferrer"
-            (click)="launchBitwardenUrl('https://bitwarden.com/products/authenticator/')"
-            >Bitwarden Authenticator</a
-          >
-          {{ "twoStepAuthenticatorInstructionSuffix" | i18n }}
-        </p>
-
-        <p class="tw-text-center">
-          <a
-            href="https://apps.apple.com/ca/app/bitwarden-authenticator/id6497335175"
-            target="_blank"
-          >
-            <img
-              src="../../../images/download_apple_appstore.svg"
-              alt="Download on App Store"
-              max-width="120"
-              height="40"
-            />
-          </a>
-
-          <!--Margin to ensure compliance with google play badge usage guidelines (https://partnermarketinghub.withgoogle.com/brands/google-play/visual-identity/badge-guidelines/#:~:text=The%20clear%20space%20surrounding%20the%20badge%20must%20be%20equal%20to%20one%2Dquarter%20of%20the%20height%20of%20the%20badge.)-->
-          <a
-            href="https://play.google.com/store/apps/details?id=com.bitwarden.authenticator"
-            target="_blank"
-          >
-            <img
-              src="../../../images/download_google_playstore.svg"
-              alt="Get it on Google Play"
-              max-width="120"
-              height="40"
-              style="margin-left: 10px"
-            />
-          </a>
-        </p>
-        {{ "twoStepAuthenticatorScanCodeV2" | i18n }}
-      </ng-container>
-      <hr *ngIf="enabled" />
-      <p class="tw-text-center tw-mb-0">
-        <ng-container *ngIf="qrScriptError" class="tw-mt-2">
-          <bit-icon name="bwi-error" class="tw-text-3xl tw-text-danger"></bit-icon>
-          <p>
-            {{ "twoStepAuthenticatorQRCanvasError" | i18n }}
-          </p>
-        </ng-container>
-        <canvas *ngIf="!qrScriptError" id="qr"></canvas>
-        <br />
-        <code appA11yTitle="{{ 'key' | i18n }}">{{ key }}</code>
+<form
+  *ngIf="authed"
+  [formGroup]="formGroup"
+  [bitSubmit]="submit"
+  bit-dialog
+  dialogSize="default"
+  [title]="'twoStepLogin' | i18n"
+  [subtitle]="'authenticatorAppTitle' | i18n"
+>
+  <ng-container bitDialogContent>
+    <ng-container *ngIf="enabled">
+      <bit-callout type="success" title="{{ 'enabled' | i18n }}" icon="bwi-check-circle">
+        <p bitTypography="body1">{{ "twoStepLoginProviderEnabled" | i18n }}</p>
+        {{ "twoStepAuthenticatorReaddDesc" | i18n }}
+      </bit-callout>
+      <p bitTypography="body1">{{ "twoStepAuthenticatorNeedApp" | i18n }}</p>
+    </ng-container>
+    <ng-container *ngIf="!enabled">
+      <p>
+        {{ "twoStepAuthenticatorInstructionPrefix" | i18n }}
+        <a
+          bitLink
+          target="_blank"
+          rel="noreferrer"
+          (click)="launchExternalUrl('https://getaegis.app')"
+          >Aegis</a
+        >
+        {{ "twoStepAuthenticatorInstructionInfix1" | i18n }}
+        <a bitLink target="_blank" rel="noreferrer" (click)="launchExternalUrl('https://2fas.com')"
+          >2FAS</a
+        >
+        {{ "twoStepAuthenticatorInstructionInfix2" | i18n }}
+        <a
+          bitLink
+          target="_blank"
+          rel="noreferrer"
+          (click)="launchBitwardenUrl('https://bitwarden.com/products/authenticator/')"
+          >Bitwarden Authenticator</a
+        >
+        {{ "twoStepAuthenticatorInstructionSuffix" | i18n }}
       </p>
-      <bit-form-field *ngIf="!enabled" [disableMargin]="true">
-        <bit-label>{{ "twoStepAuthenticatorEnterCodeV2" | i18n }}</bit-label>
-        <input bitInput type="text" formControlName="token" appInputVerbatim />
-      </bit-form-field>
+
+      <p class="tw-text-center">
+        <a
+          href="https://apps.apple.com/ca/app/bitwarden-authenticator/id6497335175"
+          target="_blank"
+        >
+          <img
+            src="../../../images/download_apple_appstore.svg"
+            alt="Download on App Store"
+            max-width="120"
+            height="40"
+          />
+        </a>
+
+        <!--Margin to ensure compliance with google play badge usage guidelines (https://partnermarketinghub.withgoogle.com/brands/google-play/visual-identity/badge-guidelines/#:~:text=The%20clear%20space%20surrounding%20the%20badge%20must%20be%20equal%20to%20one%2Dquarter%20of%20the%20height%20of%20the%20badge.)-->
+        <a
+          href="https://play.google.com/store/apps/details?id=com.bitwarden.authenticator"
+          target="_blank"
+        >
+          <img
+            src="../../../images/download_google_playstore.svg"
+            alt="Get it on Google Play"
+            max-width="120"
+            height="40"
+            style="margin-left: 10px"
+          />
+        </a>
+      </p>
+      {{ "twoStepAuthenticatorScanCodeV2" | i18n }}
     </ng-container>
-    <ng-container bitDialogFooter>
-      <button
-        bitButton
-        bitFormButton
-        type="submit"
-        buttonType="primary"
-        (click)="validateTokenControl()"
-      >
-        {{ (enabled ? "disable" : "enable") | i18n }}
-      </button>
-      <button bitButton bitFormButton type="button" buttonType="secondary" bitDialogClose>
-        {{ "close" | i18n }}
-      </button>
-    </ng-container>
-  </bit-dialog>
+    <hr *ngIf="enabled" />
+    <p class="tw-text-center tw-mb-0">
+      <ng-container *ngIf="qrScriptError" class="tw-mt-2">
+        <bit-icon name="bwi-error" class="tw-text-3xl tw-text-danger"></bit-icon>
+        <p>
+          {{ "twoStepAuthenticatorQRCanvasError" | i18n }}
+        </p>
+      </ng-container>
+      <canvas *ngIf="!qrScriptError" id="qr"></canvas>
+      <br />
+      <code appA11yTitle="{{ 'key' | i18n }}">{{ key }}</code>
+    </p>
+    <bit-form-field *ngIf="!enabled" [disableMargin]="true">
+      <bit-label>{{ "twoStepAuthenticatorEnterCodeV2" | i18n }}</bit-label>
+      <input bitInput type="text" formControlName="token" appInputVerbatim />
+    </bit-form-field>
+  </ng-container>
+  <ng-container bitDialogFooter>
+    <button
+      bitButton
+      bitFormButton
+      type="submit"
+      buttonType="primary"
+      (click)="validateTokenControl()"
+    >
+      {{ (enabled ? "disable" : "enable") | i18n }}
+    </button>
+    <button bitButton bitFormButton type="button" buttonType="secondary" bitDialogClose>
+      {{ "close" | i18n }}
+    </button>
+  </ng-container>
 </form>

--- a/apps/web/src/app/auth/settings/two-factor/two-factor-setup-webauthn.component.html
+++ b/apps/web/src/app/auth/settings/two-factor/two-factor-setup-webauthn.component.html
@@ -1,120 +1,122 @@
-<form *ngIf="authed" [formGroup]="formGroup" [bitSubmit]="submit">
-  <bit-dialog
-    dialogSize="large"
-    [title]="'twoStepLogin' | i18n"
-    [subtitle]="'webAuthnTitle' | i18n"
-  >
-    <ng-container bitDialogContent>
-      <bit-callout
-        type="success"
-        title="{{ 'enabled' | i18n }}"
-        icon="bwi-check-circle"
-        *ngIf="enabled"
-      >
-        {{ "twoStepLoginProviderEnabled" | i18n }}
-      </bit-callout>
-      <ul class="bwi-ul">
-        <li *ngFor="let k of keys; let i = index" #removeKeyBtn [appApiAction]="k.removePromise">
-          <ng-container *ngIf="k.configured">
-            <bit-icon name="bwi-key" class="bwi-li"></bit-icon>
-            <span *ngIf="k.configured" bitTypography="body1" class="tw-font-medium">
-              {{ k.name || ("unnamedKey" | i18n) }}
-            </span>
-            <ng-container *ngIf="k.configured && !$any(removeKeyBtn).loading">
-              <ng-container *ngIf="k.migrated">
-                <span>{{ "webAuthnMigrated" | i18n }}</span>
-              </ng-container>
-            </ng-container>
-            <ng-container *ngIf="keysConfiguredCount > 1 && k.configured">
-              <bit-icon
-                name="bwi-spinner"
-                class="bwi-spin tw-text-muted bwi-fw"
-                [ariaLabel]="'loading' | i18n"
-                *ngIf="$any(removeKeyBtn).loading"
-              ></bit-icon>
-              -
-              <a bitLink href="#" appStopClick (click)="remove(k)">{{ "remove" | i18n }}</a>
+<form
+  *ngIf="authed"
+  [formGroup]="formGroup"
+  [bitSubmit]="submit"
+  bit-dialog
+  dialogSize="large"
+  [title]="'twoStepLogin' | i18n"
+  [subtitle]="'webAuthnTitle' | i18n"
+>
+  <ng-container bitDialogContent>
+    <bit-callout
+      type="success"
+      title="{{ 'enabled' | i18n }}"
+      icon="bwi-check-circle"
+      *ngIf="enabled"
+    >
+      {{ "twoStepLoginProviderEnabled" | i18n }}
+    </bit-callout>
+    <ul class="bwi-ul">
+      <li *ngFor="let k of keys; let i = index" #removeKeyBtn [appApiAction]="k.removePromise">
+        <ng-container *ngIf="k.configured">
+          <bit-icon name="bwi-key" class="bwi-li"></bit-icon>
+          <span *ngIf="k.configured" bitTypography="body1" class="tw-font-medium">
+            {{ k.name || ("unnamedKey" | i18n) }}
+          </span>
+          <ng-container *ngIf="k.configured && !$any(removeKeyBtn).loading">
+            <ng-container *ngIf="k.migrated">
+              <span>{{ "webAuthnMigrated" | i18n }}</span>
             </ng-container>
           </ng-container>
-        </li>
-      </ul>
-      <hr />
-      <p bitTypography="body1">{{ "twoFactorWebAuthnAdd" | i18n }}:</p>
-      <ol bitTypography="body1">
-        <li>{{ "twoFactorU2fGiveName" | i18n }}</li>
-        <li>{{ "twoFactorU2fPlugInReadKey" | i18n }}</li>
-        <li>{{ "twoFactorU2fTouchButton" | i18n }}</li>
-        <li>{{ "twoFactorU2fSaveForm" | i18n }}</li>
-      </ol>
-      <div class="tw-flex">
-        <bit-form-field class="tw-basis-1/2">
-          <bit-label>{{ "name" | i18n }}</bit-label>
-          <input bitInput type="text" formControlName="name" />
-        </bit-form-field>
-      </div>
-      <button
-        bitButton
-        bitFormButton
-        type="button"
-        [bitAction]="readKey"
-        buttonType="secondary"
-        [disabled]="
-          $any(readKeyBtn).loading() || webAuthnListening || !keyIdAvailable || formGroup.invalid
-        "
-        class="tw-mr-2"
-        #readKeyBtn
-      >
-        {{ "readKey" | i18n }}
-      </button>
-      <ng-container *ngIf="$any(readKeyBtn).loading()">
+          <ng-container *ngIf="keysConfiguredCount > 1 && k.configured">
+            <bit-icon
+              name="bwi-spinner"
+              class="bwi-spin tw-text-muted bwi-fw"
+              [ariaLabel]="'loading' | i18n"
+              *ngIf="$any(removeKeyBtn).loading"
+            ></bit-icon>
+            -
+            <a bitLink href="#" appStopClick (click)="remove(k)">{{ "remove" | i18n }}</a>
+          </ng-container>
+        </ng-container>
+      </li>
+    </ul>
+    <hr />
+    <p bitTypography="body1">{{ "twoFactorWebAuthnAdd" | i18n }}:</p>
+    <ol bitTypography="body1">
+      <li>{{ "twoFactorU2fGiveName" | i18n }}</li>
+      <li>{{ "twoFactorU2fPlugInReadKey" | i18n }}</li>
+      <li>{{ "twoFactorU2fTouchButton" | i18n }}</li>
+      <li>{{ "twoFactorU2fSaveForm" | i18n }}</li>
+    </ol>
+    <div class="tw-flex">
+      <bit-form-field class="tw-basis-1/2">
+        <bit-label>{{ "name" | i18n }}</bit-label>
+        <input bitInput type="text" formControlName="name" />
+      </bit-form-field>
+    </div>
+    <button
+      bitButton
+      bitFormButton
+      type="button"
+      [bitAction]="readKey"
+      buttonType="secondary"
+      [disabled]="
+        $any(readKeyBtn).loading() || webAuthnListening || !keyIdAvailable || formGroup.invalid
+      "
+      class="tw-mr-2"
+      #readKeyBtn
+    >
+      {{ "readKey" | i18n }}
+    </button>
+    <ng-container *ngIf="$any(readKeyBtn).loading()">
+      <bit-icon
+        name="bwi-spinner"
+        class="bwi-spin tw-text-muted"
+        [ariaLabel]="'loading' | i18n"
+      ></bit-icon>
+    </ng-container>
+    <ng-container *ngIf="!$any(readKeyBtn).loading()">
+      <ng-container *ngIf="webAuthnListening">
         <bit-icon
           name="bwi-spinner"
           class="bwi-spin tw-text-muted"
           [ariaLabel]="'loading' | i18n"
         ></bit-icon>
+        {{ "twoFactorU2fWaiting" | i18n }}...
       </ng-container>
-      <ng-container *ngIf="!$any(readKeyBtn).loading()">
-        <ng-container *ngIf="webAuthnListening">
-          <bit-icon
-            name="bwi-spinner"
-            class="bwi-spin tw-text-muted"
-            [ariaLabel]="'loading' | i18n"
-          ></bit-icon>
-          {{ "twoFactorU2fWaiting" | i18n }}...
-        </ng-container>
-        <ng-container *ngIf="webAuthnResponse">
-          <bit-icon name="bwi-check-circle" class="tw-text-success"></bit-icon>
-          {{ "twoFactorU2fClickSave" | i18n }}
-        </ng-container>
-        <ng-container *ngIf="webAuthnError">
-          <bit-icon name="bwi-exclamation-triangle" class="tw-text-danger"></bit-icon>
-          {{ "twoFactorU2fProblemReadingTryAgain" | i18n }}
-        </ng-container>
+      <ng-container *ngIf="webAuthnResponse">
+        <bit-icon name="bwi-check-circle" class="tw-text-success"></bit-icon>
+        {{ "twoFactorU2fClickSave" | i18n }}
+      </ng-container>
+      <ng-container *ngIf="webAuthnError">
+        <bit-icon name="bwi-exclamation-triangle" class="tw-text-danger"></bit-icon>
+        {{ "twoFactorU2fProblemReadingTryAgain" | i18n }}
       </ng-container>
     </ng-container>
-    <ng-container bitDialogFooter>
-      <button
-        bitButton
-        bitFormButton
-        type="submit"
-        buttonType="primary"
-        [disabled]="!webAuthnResponse"
-      >
-        {{ "save" | i18n }}
-      </button>
-      <button
-        bitButton
-        bitFormButton
-        *ngIf="enabled"
-        type="button"
-        buttonType="secondary"
-        [bitAction]="disable"
-      >
-        {{ "disableAllKeys" | i18n }}
-      </button>
-      <button bitButton bitFormButton type="button" buttonType="secondary" bitDialogClose>
-        {{ "close" | i18n }}
-      </button>
-    </ng-container>
-  </bit-dialog>
+  </ng-container>
+  <ng-container bitDialogFooter>
+    <button
+      bitButton
+      bitFormButton
+      type="submit"
+      buttonType="primary"
+      [disabled]="!webAuthnResponse"
+    >
+      {{ "save" | i18n }}
+    </button>
+    <button
+      bitButton
+      bitFormButton
+      *ngIf="enabled"
+      type="button"
+      buttonType="secondary"
+      [bitAction]="disable"
+    >
+      {{ "disableAllKeys" | i18n }}
+    </button>
+    <button bitButton bitFormButton type="button" buttonType="secondary" bitDialogClose>
+      {{ "close" | i18n }}
+    </button>
+  </ng-container>
 </form>

--- a/apps/web/src/app/auth/settings/webauthn-login-settings/create-credential-dialog/create-credential-dialog.component.html
+++ b/apps/web/src/app/auth/settings/webauthn-login-settings/create-credential-dialog/create-credential-dialog.component.html
@@ -1,76 +1,80 @@
-<form [formGroup]="formGroup" [bitSubmit]="submit">
-  <bit-dialog dialogSize="large" [loading]="loading$ | async">
-    <span bitDialogTitle
-      >{{ "logInWithPasskey" | i18n }}
-      <span class="tw-text-sm tw-normal-case tw-text-muted">{{ "newPasskey" | i18n }}</span>
-    </span>
-    <ng-container bitDialogContent>
-      <ng-container *ngIf="currentStep === 'userVerification'">
-        <ng-container formGroupName="userVerification">
-          <app-user-verification
-            formControlName="secret"
-            [(invalidSecret)]="invalidSecret"
-          ></app-user-verification>
-        </ng-container>
+<form
+  [formGroup]="formGroup"
+  [bitSubmit]="submit"
+  bit-dialog
+  dialogSize="large"
+  [loading]="loading$ | async"
+>
+  <span bitDialogTitle
+    >{{ "logInWithPasskey" | i18n }}
+    <span class="tw-text-sm tw-normal-case tw-text-muted">{{ "newPasskey" | i18n }}</span>
+  </span>
+  <ng-container bitDialogContent>
+    <ng-container *ngIf="currentStep === 'userVerification'">
+      <ng-container formGroupName="userVerification">
+        <app-user-verification
+          formControlName="secret"
+          [(invalidSecret)]="invalidSecret"
+        ></app-user-verification>
       </ng-container>
-
-      <div *ngIf="currentStep === 'credentialCreation'" class="tw-flex tw-flex-col tw-items-center">
-        <div class="tw-size-24 tw-content-center tw-mb-6">
-          <bit-svg [content]="Icons.TwoFactorAuthSecurityKeyIcon"></bit-svg>
-        </div>
-        <h3 bitTypography="h3">{{ "creatingPasskeyLoading" | i18n }}</h3>
-        <p bitTypography="body1">{{ "creatingPasskeyLoadingInfo" | i18n }}</p>
-      </div>
-
-      <div
-        *ngIf="currentStep === 'credentialCreationFailed'"
-        class="tw-flex tw-flex-col tw-items-center"
-      >
-        <div class="tw-size-24 tw-content-center tw-mb-6">
-          <bit-svg [content]="Icons.TwoFactorAuthSecurityKeyFailedIcon"></bit-svg>
-        </div>
-        <h3 bitTypography="h3">{{ "errorCreatingPasskey" | i18n }}</h3>
-        <p bitTypography="body1">{{ "errorCreatingPasskeyInfo" | i18n }}</p>
-      </div>
-
-      <div *ngIf="currentStep === 'credentialNaming'" formGroupName="credentialNaming">
-        <h3 bitTypography="h3">{{ "passkeySuccessfullyCreated" | i18n }}</h3>
-        <p bitTypography="body1">
-          {{ "customPasskeyNameInfo" | i18n }}
-        </p>
-        <bit-form-field class="!tw-mb-0">
-          <bit-label>{{ "name" | i18n }}</bit-label>
-          <input type="text" bitInput formControlName="name" appAutofocus />
-          <bit-hint>{{
-            "charactersCurrentAndMaximum"
-              | i18n: formGroup.value.credentialNaming.name.length : NameMaxCharacters
-          }}</bit-hint>
-        </bit-form-field>
-        <bit-form-control *ngIf="pendingCredential?.supportsPrf" class="!tw-mb-0 tw-mt-6">
-          <input type="checkbox" bitCheckbox formControlName="useForEncryption" />
-          <bit-label>{{ "useForVaultEncryption" | i18n }}</bit-label>
-          <bit-hint>{{ "useForVaultEncryptionInfo" | i18n }}</bit-hint>
-        </bit-form-control>
-      </div>
     </ng-container>
-    <ng-container bitDialogFooter>
-      <button type="submit" bitButton bitFormButton buttonType="primary">
-        <ng-container *ngIf="currentStep === 'userVerification'">
-          {{ "continue" | i18n }}
-        </ng-container>
-        <ng-container *ngIf="currentStep === 'credentialCreation'">
-          {{ "continue" | i18n }}
-        </ng-container>
-        <ng-container *ngIf="currentStep === 'credentialCreationFailed'">
-          {{ "tryAgain" | i18n }}
-        </ng-container>
-        <ng-container *ngIf="currentStep === 'credentialNaming'">
-          {{ ((hasPasskeys$ | async) ? "save" : "enable") | i18n }}
-        </ng-container>
-      </button>
-      <button type="button" bitButton bitFormButton buttonType="secondary" bitDialogClose>
-        {{ "cancel" | i18n }}
-      </button>
-    </ng-container>
-  </bit-dialog>
+
+    <div *ngIf="currentStep === 'credentialCreation'" class="tw-flex tw-flex-col tw-items-center">
+      <div class="tw-size-24 tw-content-center tw-mb-6">
+        <bit-svg [content]="Icons.TwoFactorAuthSecurityKeyIcon"></bit-svg>
+      </div>
+      <h3 bitTypography="h3">{{ "creatingPasskeyLoading" | i18n }}</h3>
+      <p bitTypography="body1">{{ "creatingPasskeyLoadingInfo" | i18n }}</p>
+    </div>
+
+    <div
+      *ngIf="currentStep === 'credentialCreationFailed'"
+      class="tw-flex tw-flex-col tw-items-center"
+    >
+      <div class="tw-size-24 tw-content-center tw-mb-6">
+        <bit-svg [content]="Icons.TwoFactorAuthSecurityKeyFailedIcon"></bit-svg>
+      </div>
+      <h3 bitTypography="h3">{{ "errorCreatingPasskey" | i18n }}</h3>
+      <p bitTypography="body1">{{ "errorCreatingPasskeyInfo" | i18n }}</p>
+    </div>
+
+    <div *ngIf="currentStep === 'credentialNaming'" formGroupName="credentialNaming">
+      <h3 bitTypography="h3">{{ "passkeySuccessfullyCreated" | i18n }}</h3>
+      <p bitTypography="body1">
+        {{ "customPasskeyNameInfo" | i18n }}
+      </p>
+      <bit-form-field class="!tw-mb-0">
+        <bit-label>{{ "name" | i18n }}</bit-label>
+        <input type="text" bitInput formControlName="name" appAutofocus />
+        <bit-hint>{{
+          "charactersCurrentAndMaximum"
+            | i18n: formGroup.value.credentialNaming.name.length : NameMaxCharacters
+        }}</bit-hint>
+      </bit-form-field>
+      <bit-form-control *ngIf="pendingCredential?.supportsPrf" class="!tw-mb-0 tw-mt-6">
+        <input type="checkbox" bitCheckbox formControlName="useForEncryption" />
+        <bit-label>{{ "useForVaultEncryption" | i18n }}</bit-label>
+        <bit-hint>{{ "useForVaultEncryptionInfo" | i18n }}</bit-hint>
+      </bit-form-control>
+    </div>
+  </ng-container>
+  <ng-container bitDialogFooter>
+    <button type="submit" bitButton bitFormButton buttonType="primary">
+      <ng-container *ngIf="currentStep === 'userVerification'">
+        {{ "continue" | i18n }}
+      </ng-container>
+      <ng-container *ngIf="currentStep === 'credentialCreation'">
+        {{ "continue" | i18n }}
+      </ng-container>
+      <ng-container *ngIf="currentStep === 'credentialCreationFailed'">
+        {{ "tryAgain" | i18n }}
+      </ng-container>
+      <ng-container *ngIf="currentStep === 'credentialNaming'">
+        {{ ((hasPasskeys$ | async) ? "save" : "enable") | i18n }}
+      </ng-container>
+    </button>
+    <button type="button" bitButton bitFormButton buttonType="secondary" bitDialogClose>
+      {{ "cancel" | i18n }}
+    </button>
+  </ng-container>
 </form>


### PR DESCRIPTION
## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)

## Tracking
https://bitwarden.atlassian.net/browse/CL-1046

## Description

Migrates auth settings dialogs (two-factor authentication, WebAuthn, and emergency access) to use the `<form bit-dialog>` pattern, fixing the height styling bug where dialogs break when wrapped in form elements.

⚠️ **Depends on:** #18929 - Must merge after component selector updates

### Changes:
- Update `two-factor-setup-authenticator` dialog to use `<form bit-dialog>` pattern
- Update `two-factor-setup-webauthn` dialog to use `<form bit-dialog>` pattern
- Update `emergency-access-add-edit` dialog to use `<form bit-dialog>` pattern
- Update `create-credential-dialog` (WebAuthn login) to use `<form bit-dialog>` pattern

### Files Changed:
- `apps/web/src/app/auth/settings/two-factor/two-factor-setup-authenticator.component.html`
- `apps/web/src/app/auth/settings/two-factor/two-factor-setup-webauthn.component.html`
- `apps/web/src/app/auth/settings/emergency-access/emergency-access-add-edit.component.html`
- `apps/web/src/app/auth/settings/webauthn-login-settings/create-credential-dialog/create-credential-dialog.component.html`

## Code review checklist
- [x] Tested on multiple browsers
- [x] Adheres to Bitwarden code style

## Notes

This PR (#18932) is part of a coordinated effort to migrate dialog forms across the codebase:
- #18929 - UI Foundation (foundational PR - must merge first) ⬅️ **Dependency**
- #18930 - Vault team dialogs
- #18931 - Tools team dialogs
- #18932 - Auth team dialogs (this PR)
- #18933 - Admin Console team dialogs
- #18934 - Secrets Manager dialogs

Fixes the height styling issue by making the form element itself the dialog container (`<form bit-dialog>`) instead of wrapping it (`<form><bit-dialog></bit-dialog></form>`).