### PR TITLE
[CL-1046] Migrate admin console dialogs to new form pattern

### DIFF
--- a/apps/web/src/app/admin-console/organizations/manage/group-add-edit.component.html
+++ b/apps/web/src/app/admin-console/organizations/manage/group-add-edit.component.html
@@ -1,87 +1,83 @@
-<form [formGroup]="groupForm" [bitSubmit]="submit">
-  <bit-dialog dialogSize="large">
-    <span bitDialogTitle>
-      {{ title }}
-      <span *ngIf="editMode" class="tw-text-sm tw-normal-case tw-text-muted">{{
-        group?.name
-      }}</span>
-    </span>
-    <div bitDialogContent>
-      <div *ngIf="loading">
-        <i
-          class="bwi bwi-spinner bwi-spin tw-text-muted"
-          title="{{ 'loading' | i18n }}"
-          aria-hidden="true"
-        ></i>
-        <span class="tw-sr-only">{{ "loading" | i18n }}</span>
-      </div>
-
-      <bit-tab-group *ngIf="!loading" [(selectedIndex)]="tabIndex">
-        <bit-tab label="{{ 'groupInfo' | i18n }}">
-          <bit-form-field>
-            <bit-label>{{ "name" | i18n }}</bit-label>
-            <input bitInput appAutofocus type="text" formControlName="name" />
-            <bit-hint>{{ "characterMaximum" | i18n: 100 }}</bit-hint>
-          </bit-form-field>
-          <bit-form-field *ngIf="isExternalIdVisible">
-            <bit-label>{{ "externalId" | i18n }}</bit-label>
-            <input bitInput type="text" formControlName="externalId" />
-            <bit-hint>{{ "externalIdDesc" | i18n }}</bit-hint>
-          </bit-form-field>
-        </bit-tab>
-
-        <bit-tab label="{{ 'members' | i18n }}">
-          <p>
-            {{ "editGroupMembersDesc" | i18n }}
-            <span *ngIf="cannotAddSelfToGroup$ | async">
-              {{ "restrictedGroupAccessDesc" | i18n }}
-            </span>
-          </p>
-          <bit-access-selector
-            formControlName="members"
-            [items]="members"
-            [showMemberRoles]="true"
-            [permissionMode]="PermissionMode.Hidden"
-            [columnHeader]="'member' | i18n"
-            [selectorLabelText]="'selectMembers' | i18n"
-            [emptySelectionText]="'noMembersAdded' | i18n"
-          ></bit-access-selector>
-        </bit-tab>
-
-        <bit-tab label="{{ 'collections' | i18n }}">
-          <p>
-            {{ "editGroupCollectionsDesc" | i18n }}
-            <span *ngIf="!(canAssignAccessToAnyCollection$ | async)">
-              {{ "restrictedCollectionAssignmentDesc" | i18n }}
-            </span>
-          </p>
-          <bit-access-selector
-            formControlName="collections"
-            [items]="collections"
-            [permissionMode]="PermissionMode.Edit"
-            [columnHeader]="'collection' | i18n"
-            [selectorLabelText]="'selectCollections' | i18n"
-            [emptySelectionText]="'noCollectionsAdded' | i18n"
-          ></bit-access-selector>
-        </bit-tab>
-      </bit-tab-group>
+<form [formGroup]="groupForm" [bitSubmit]="submit" bit-dialog dialogSize="large">
+  <span bitDialogTitle>
+    {{ title }}
+    <span *ngIf="editMode" class="tw-text-sm tw-normal-case tw-text-muted">{{ group?.name }}</span>
+  </span>
+  <div bitDialogContent>
+    <div *ngIf="loading">
+      <i
+        class="bwi bwi-spinner bwi-spin tw-text-muted"
+        title="{{ 'loading' | i18n }}"
+        aria-hidden="true"
+      ></i>
+      <span class="tw-sr-only">{{ "loading" | i18n }}</span>
     </div>
-    <ng-container bitDialogFooter>
-      <button bitButton buttonType="primary" bitFormButton type="submit">
-        {{ "save" | i18n }}
-      </button>
-      <button bitButton buttonType="secondary" type="button" [bitDialogClose]="ResultType.Canceled">
-        {{ "cancel" | i18n }}
-      </button>
-      <button
-        class="tw-ml-auto"
-        type="button"
-        buttonType="dangerGhost"
-        bitIconButton="bwi-trash"
-        bitFormButton
-        [bitAction]="delete"
-        [label]="'delete' | i18n"
-      ></button>
-    </ng-container>
-  </bit-dialog>
+
+    <bit-tab-group *ngIf="!loading" [(selectedIndex)]="tabIndex">
+      <bit-tab label="{{ 'groupInfo' | i18n }}">
+        <bit-form-field>
+          <bit-label>{{ "name" | i18n }}</bit-label>
+          <input bitInput appAutofocus type="text" formControlName="name" />
+          <bit-hint>{{ "characterMaximum" | i18n: 100 }}</bit-hint>
+        </bit-form-field>
+        <bit-form-field *ngIf="isExternalIdVisible">
+          <bit-label>{{ "externalId" | i18n }}</bit-label>
+          <input bitInput type="text" formControlName="externalId" />
+          <bit-hint>{{ "externalIdDesc" | i18n }}</bit-hint>
+        </bit-form-field>
+      </bit-tab>
+
+      <bit-tab label="{{ 'members' | i18n }}">
+        <p>
+          {{ "editGroupMembersDesc" | i18n }}
+          <span *ngIf="cannotAddSelfToGroup$ | async">
+            {{ "restrictedGroupAccessDesc" | i18n }}
+          </span>
+        </p>
+        <bit-access-selector
+          formControlName="members"
+          [items]="members"
+          [showMemberRoles]="true"
+          [permissionMode]="PermissionMode.Hidden"
+          [columnHeader]="'member' | i18n"
+          [selectorLabelText]="'selectMembers' | i18n"
+          [emptySelectionText]="'noMembersAdded' | i18n"
+        ></bit-access-selector>
+      </bit-tab>
+
+      <bit-tab label="{{ 'collections' | i18n }}">
+        <p>
+          {{ "editGroupCollectionsDesc" | i18n }}
+          <span *ngIf="!(canAssignAccessToAnyCollection$ | async)">
+            {{ "restrictedCollectionAssignmentDesc" | i18n }}
+          </span>
+        </p>
+        <bit-access-selector
+          formControlName="collections"
+          [items]="collections"
+          [permissionMode]="PermissionMode.Edit"
+          [columnHeader]="'collection' | i18n"
+          [selectorLabelText]="'selectCollections' | i18n"
+          [emptySelectionText]="'noCollectionsAdded' | i18n"
+        ></bit-access-selector>
+      </bit-tab>
+    </bit-tab-group>
+  </div>
+  <ng-container bitDialogFooter>
+    <button bitButton buttonType="primary" bitFormButton type="submit">
+      {{ "save" | i18n }}
+    </button>
+    <button bitButton buttonType="secondary" type="button" [bitDialogClose]="ResultType.Canceled">
+      {{ "cancel" | i18n }}
+    </button>
+    <button
+      class="tw-ml-auto"
+      type="button"
+      buttonType="dangerGhost"
+      bitIconButton="bwi-trash"
+      bitFormButton
+      [bitAction]="delete"
+      [label]="'delete' | i18n"
+    ></button>
+  </ng-container>
 </form>

--- a/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.html
+++ b/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.html
@@ -1,326 +1,322 @@
-<form [formGroup]="formGroup" [bitSubmit]="submit">
-  <bit-dialog dialogSize="large">
-    <span bitDialogTitle>
-      {{ title }}
-      @if (!loading && editParams$ && (editParams$ | async)?.name) {
-        <span class="tw-text-sm tw-normal-case tw-text-muted">{{
-          (editParams$ | async)?.name
-        }}</span>
-      }
-      @if (isRevoked) {
-        <span bitBadge variant="secondary">{{ "revoked" | i18n }}</span>
-      }
-    </span>
-    <div bitDialogContent>
-      @if (loading) {
-        <i
-          class="bwi bwi-spinner bwi-spin tw-text-muted"
-          title="{{ 'loading' | i18n }}"
-          aria-hidden="true"
-        ></i>
-        <span class="tw-sr-only">{{ "loading" | i18n }}</span>
-      }
-      @if (!loading && organization$ | async; as organization) {
-        <bit-tab-group [(selectedIndex)]="tabIndex">
-          <bit-tab [label]="'role' | i18n">
-            @if (!editMode) {
-              <p bitTypography="body1">{{ "inviteUserDesc" | i18n }}</p>
-              @if (
-                {
-                  remainingSeats: remainingSeats$ | async,
-                  batchLimit: emailBatchLimit$ | async,
-                  isDynamicSeatPlan: isDynamicSeatPlan$ | async,
-                };
-                as inviteInfo
-              ) {
-                <bit-form-field>
-                  <bit-label>{{ "email" | i18n }}</bit-label>
-                  <input id="emails" type="text" appAutoFocus bitInput formControlName="emails" />
-                  @if (inviteInfo.isDynamicSeatPlan) {
-                    <bit-hint>{{
-                      "inviteMultipleEmailsNoSeatLimit" | i18n: inviteInfo.batchLimit
-                    }}</bit-hint>
-                  }
-                  @if (!inviteInfo.isDynamicSeatPlan && inviteInfo.remainingSeats > 1) {
-                    <bit-hint>{{
-                      "inviteMultipleEmailsWithSeatLimit"
-                        | i18n: inviteInfo.batchLimit : inviteInfo.remainingSeats
-                    }}</bit-hint>
-                  }
-                  @if (!inviteInfo.isDynamicSeatPlan && inviteInfo.remainingSeats === 1) {
-                    <bit-hint>{{ "inviteSingleEmailDesc" | i18n }}</bit-hint>
-                  }
-                  @if (!inviteInfo.isDynamicSeatPlan && inviteInfo.remainingSeats <= 0) {
-                    <bit-hint>{{ "inviteZeroEmailDesc" | i18n }}</bit-hint>
-                  }
-                </bit-form-field>
-              }
-            }
-            <bit-radio-group formControlName="type">
-              <bit-label>
-                {{ "memberRole" | i18n }}
-                <a
-                  bitLink
-                  target="_blank"
-                  rel="noreferrer"
-                  appA11yTitle="{{ 'learnMoreAboutMemberRoles' | i18n }}"
-                  href="https://bitwarden.com/help/user-types-access-control/"
-                  slot="end"
-                >
-                  <i class="bwi bwi-question-circle" aria-hidden="true"></i>
-                </a>
-              </bit-label>
-              <bit-radio-button id="userTypeUser" [value]="organizationUserType.User">
-                <bit-label>{{ "user" | i18n }}</bit-label>
-                <bit-hint>{{ "userDesc" | i18n }}</bit-hint>
-              </bit-radio-button>
-              <bit-radio-button id="userTypeAdmin" [value]="organizationUserType.Admin">
-                <bit-label>{{ "admin" | i18n }}</bit-label>
-                <bit-hint>{{ "adminDesc" | i18n }}</bit-hint>
-              </bit-radio-button>
-              <bit-radio-button id="userTypeOwner" [value]="organizationUserType.Owner">
-                <bit-label>{{ "owner" | i18n }}</bit-label>
-                <bit-hint>{{ "ownerDesc" | i18n }}</bit-hint>
-              </bit-radio-button>
-              <bit-radio-button
-                id="userTypeCustom"
-                [value]="organizationUserType.Custom"
-                [disabled]="!organization.useCustomPermissions || null"
-              >
-                <bit-label>{{ "custom" | i18n }}</bit-label>
-                <bit-hint>
-                  @if (!organization.useCustomPermissions) {
-                    <p>
-                      {{ "customDescNonEnterpriseStart" | i18n
-                      }}<a
-                        bitLink
-                        href="https://bitwarden.com/contact/"
-                        target="_blank"
-                        rel="noreferrer"
-                        >{{ "customDescNonEnterpriseLink" | i18n }}</a
-                      >{{ "customDescNonEnterpriseEnd" | i18n }}
-                    </p>
-                  } @else {
-                    <p>{{ "customDesc" | i18n }}</p>
-                  }
-                </bit-hint>
-              </bit-radio-button>
-            </bit-radio-group>
-            @if (customUserTypeSelected) {
-              <div class="tw-grid tw-grid-cols-12 tw-gap-4" [formGroup]="permissionsGroup">
-                <div class="tw-col-span-4">
-                  <bit-form-control>
-                    <input type="checkbox" bitCheckbox formControlName="accessEventLogs" />
-                    <bit-label>{{ "accessEventLogs" | i18n }}</bit-label>
-                  </bit-form-control>
-                  <bit-form-control>
-                    <input type="checkbox" bitCheckbox formControlName="accessImportExport" />
-                    <bit-label>{{ "accessImportExport" | i18n }}</bit-label>
-                  </bit-form-control>
-                  <bit-form-control>
-                    <input type="checkbox" bitCheckbox formControlName="accessReports" />
-                    <bit-label>{{ "accessReports" | i18n }}</bit-label>
-                  </bit-form-control>
-                </div>
-                <div class="tw-col-span-4">
-                  <app-nested-checkbox
-                    parentId="manageAllCollections"
-                    [checkboxes]="permissionsGroup.controls.manageAllCollectionsGroup"
-                  >
-                  </app-nested-checkbox>
-                </div>
-                <div class="tw-col-span-4">
-                  <div class="tw-mb-3">
-                    <bit-form-control>
-                      <input type="checkbox" bitCheckbox formControlName="manageGroups" />
-                      <bit-label>{{ "manageGroups" | i18n }}</bit-label>
-                    </bit-form-control>
-                    <bit-form-control>
-                      <input type="checkbox" bitCheckbox formControlName="manageSso" />
-                      <bit-label>{{ "manageSso" | i18n }}</bit-label>
-                    </bit-form-control>
-                    <bit-form-control>
-                      <input type="checkbox" bitCheckbox formControlName="managePolicies" />
-                      <bit-label>{{ "managePolicies" | i18n }}</bit-label>
-                    </bit-form-control>
-                    <bit-form-control>
-                      <input
-                        id="manageUsers"
-                        type="checkbox"
-                        bitCheckbox
-                        formControlName="manageUsers"
-                      />
-                      <bit-label>{{ "manageUsers" | i18n }}</bit-label>
-                    </bit-form-control>
-                    <bit-form-control>
-                      <input type="checkbox" bitCheckbox formControlName="manageResetPassword" />
-                      <bit-label>{{ "manageAccountRecovery" | i18n }}</bit-label>
-                    </bit-form-control>
-                  </div>
-                </div>
-              </div>
-            }
-            @if (organization.useSecretsManager) {
-              <h3 class="tw-mt-4">
-                {{ "secretsManager" | i18n }}
-                <a
-                  bitLink
-                  target="_blank"
-                  rel="noreferrer"
-                  appA11yTitle="{{ 'learnMore' | i18n }}"
-                  href="https://bitwarden.com/help/manage-your-organization/#access-to-secrets-manager"
-                >
-                  <i class="bwi bwi-question-circle" aria-hidden="true"></i>
-                </a>
-              </h3>
-              <p class="tw-text-muted">{{ "secretsManagerAccessDescription" | i18n }}</p>
-              <bit-form-control>
-                <input
-                  type="checkbox"
-                  [disabled]="isOnSecretsManagerStandalone"
-                  bitCheckbox
-                  formControlName="accessSecretsManager"
-                />
-                <bit-label>
-                  {{ "userAccessSecretsManagerGA" | i18n }}
-                </bit-label>
-              </bit-form-control>
-            }
-            @if (isExternalIdVisible) {
-              <bit-form-field>
-                <bit-label>{{ "externalId" | i18n }}</bit-label>
-                <input bitInput type="text" formControlName="externalId" />
-                <bit-hint>{{ "externalIdDesc" | i18n }}</bit-hint>
-              </bit-form-field>
-            }
-            @if (isSsoExternalIdVisible) {
-              <bit-form-field>
-                <bit-label>{{ "ssoExternalId" | i18n }}</bit-label>
-                <input bitInput type="text" formControlName="ssoExternalId" />
-                <bit-hint>{{ "ssoExternalIdDesc" | i18n }}</bit-hint>
-              </bit-form-field>
-            }
-          </bit-tab>
-          @if (organization.useGroups) {
-            <bit-tab [label]="'groups' | i18n">
-              <div class="tw-mb-6">
-                {{
-                  (restrictEditingSelf$ | async)
-                    ? ("restrictedGroupAccess" | i18n)
-                    : ("groupAccessUserDesc" | i18n)
-                }}
-              </div>
-              <bit-access-selector
-                formControlName="groups"
-                [items]="groupAccessItems"
-                [columnHeader]="'groups' | i18n"
-                [selectorLabelText]="'selectGroups' | i18n"
-                [emptySelectionText]="'noGroupsAdded' | i18n"
-                [hideMultiSelect]="restrictEditingSelf$ | async"
-              ></bit-access-selector>
-            </bit-tab>
-          }
-          <bit-tab [label]="'collections' | i18n">
-            @if (restrictEditingSelf$ | async) {
-              <div class="tw-mb-6">
-                {{ "cannotAddYourselfToCollections" | i18n }}
-              </div>
-            }
+<form [formGroup]="formGroup" [bitSubmit]="submit" bit-dialog dialogSize="large">
+  <span bitDialogTitle>
+    {{ title }}
+    @if (!loading && editParams$ && (editParams$ | async)?.name) {
+      <span class="tw-text-sm tw-normal-case tw-text-muted">{{ (editParams$ | async)?.name }}</span>
+    }
+    @if (isRevoked) {
+      <span bitBadge variant="secondary">{{ "revoked" | i18n }}</span>
+    }
+  </span>
+  <div bitDialogContent>
+    @if (loading) {
+      <i
+        class="bwi bwi-spinner bwi-spin tw-text-muted"
+        title="{{ 'loading' | i18n }}"
+        aria-hidden="true"
+      ></i>
+      <span class="tw-sr-only">{{ "loading" | i18n }}</span>
+    }
+    @if (!loading && organization$ | async; as organization) {
+      <bit-tab-group [(selectedIndex)]="tabIndex">
+        <bit-tab [label]="'role' | i18n">
+          @if (!editMode) {
+            <p bitTypography="body1">{{ "inviteUserDesc" | i18n }}</p>
             @if (
-              !(restrictEditingSelf$ | async) &&
-              (organization.useGroups || !(canAssignAccessToAnyCollection$ | async))
+              {
+                remainingSeats: remainingSeats$ | async,
+                batchLimit: emailBatchLimit$ | async,
+                isDynamicSeatPlan: isDynamicSeatPlan$ | async,
+              };
+              as inviteInfo
             ) {
-              <div class="tw-mb-6">
-                @if (organization.useGroups) {
-                  <span>
-                    {{ "userPermissionOverrideHelperDesc" | i18n }}
-                  </span>
+              <bit-form-field>
+                <bit-label>{{ "email" | i18n }}</bit-label>
+                <input id="emails" type="text" appAutoFocus bitInput formControlName="emails" />
+                @if (inviteInfo.isDynamicSeatPlan) {
+                  <bit-hint>{{
+                    "inviteMultipleEmailsNoSeatLimit" | i18n: inviteInfo.batchLimit
+                  }}</bit-hint>
                 }
-                @if (!(canAssignAccessToAnyCollection$ | async)) {
-                  <span>
-                    {{ "restrictedCollectionAssignmentDesc" | i18n }}
-                  </span>
+                @if (!inviteInfo.isDynamicSeatPlan && inviteInfo.remainingSeats > 1) {
+                  <bit-hint>{{
+                    "inviteMultipleEmailsWithSeatLimit"
+                      | i18n: inviteInfo.batchLimit : inviteInfo.remainingSeats
+                  }}</bit-hint>
                 }
-              </div>
+                @if (!inviteInfo.isDynamicSeatPlan && inviteInfo.remainingSeats === 1) {
+                  <bit-hint>{{ "inviteSingleEmailDesc" | i18n }}</bit-hint>
+                }
+                @if (!inviteInfo.isDynamicSeatPlan && inviteInfo.remainingSeats <= 0) {
+                  <bit-hint>{{ "inviteZeroEmailDesc" | i18n }}</bit-hint>
+                }
+              </bit-form-field>
             }
+          }
+          <bit-radio-group formControlName="type">
+            <bit-label>
+              {{ "memberRole" | i18n }}
+              <a
+                bitLink
+                target="_blank"
+                rel="noreferrer"
+                appA11yTitle="{{ 'learnMoreAboutMemberRoles' | i18n }}"
+                href="https://bitwarden.com/help/user-types-access-control/"
+                slot="end"
+              >
+                <i class="bwi bwi-question-circle" aria-hidden="true"></i>
+              </a>
+            </bit-label>
+            <bit-radio-button id="userTypeUser" [value]="organizationUserType.User">
+              <bit-label>{{ "user" | i18n }}</bit-label>
+              <bit-hint>{{ "userDesc" | i18n }}</bit-hint>
+            </bit-radio-button>
+            <bit-radio-button id="userTypeAdmin" [value]="organizationUserType.Admin">
+              <bit-label>{{ "admin" | i18n }}</bit-label>
+              <bit-hint>{{ "adminDesc" | i18n }}</bit-hint>
+            </bit-radio-button>
+            <bit-radio-button id="userTypeOwner" [value]="organizationUserType.Owner">
+              <bit-label>{{ "owner" | i18n }}</bit-label>
+              <bit-hint>{{ "ownerDesc" | i18n }}</bit-hint>
+            </bit-radio-button>
+            <bit-radio-button
+              id="userTypeCustom"
+              [value]="organizationUserType.Custom"
+              [disabled]="!organization.useCustomPermissions || null"
+            >
+              <bit-label>{{ "custom" | i18n }}</bit-label>
+              <bit-hint>
+                @if (!organization.useCustomPermissions) {
+                  <p>
+                    {{ "customDescNonEnterpriseStart" | i18n
+                    }}<a
+                      bitLink
+                      href="https://bitwarden.com/contact/"
+                      target="_blank"
+                      rel="noreferrer"
+                      >{{ "customDescNonEnterpriseLink" | i18n }}</a
+                    >{{ "customDescNonEnterpriseEnd" | i18n }}
+                  </p>
+                } @else {
+                  <p>{{ "customDesc" | i18n }}</p>
+                }
+              </bit-hint>
+            </bit-radio-button>
+          </bit-radio-group>
+          @if (customUserTypeSelected) {
+            <div class="tw-grid tw-grid-cols-12 tw-gap-4" [formGroup]="permissionsGroup">
+              <div class="tw-col-span-4">
+                <bit-form-control>
+                  <input type="checkbox" bitCheckbox formControlName="accessEventLogs" />
+                  <bit-label>{{ "accessEventLogs" | i18n }}</bit-label>
+                </bit-form-control>
+                <bit-form-control>
+                  <input type="checkbox" bitCheckbox formControlName="accessImportExport" />
+                  <bit-label>{{ "accessImportExport" | i18n }}</bit-label>
+                </bit-form-control>
+                <bit-form-control>
+                  <input type="checkbox" bitCheckbox formControlName="accessReports" />
+                  <bit-label>{{ "accessReports" | i18n }}</bit-label>
+                </bit-form-control>
+              </div>
+              <div class="tw-col-span-4">
+                <app-nested-checkbox
+                  parentId="manageAllCollections"
+                  [checkboxes]="permissionsGroup.controls.manageAllCollectionsGroup"
+                >
+                </app-nested-checkbox>
+              </div>
+              <div class="tw-col-span-4">
+                <div class="tw-mb-3">
+                  <bit-form-control>
+                    <input type="checkbox" bitCheckbox formControlName="manageGroups" />
+                    <bit-label>{{ "manageGroups" | i18n }}</bit-label>
+                  </bit-form-control>
+                  <bit-form-control>
+                    <input type="checkbox" bitCheckbox formControlName="manageSso" />
+                    <bit-label>{{ "manageSso" | i18n }}</bit-label>
+                  </bit-form-control>
+                  <bit-form-control>
+                    <input type="checkbox" bitCheckbox formControlName="managePolicies" />
+                    <bit-label>{{ "managePolicies" | i18n }}</bit-label>
+                  </bit-form-control>
+                  <bit-form-control>
+                    <input
+                      id="manageUsers"
+                      type="checkbox"
+                      bitCheckbox
+                      formControlName="manageUsers"
+                    />
+                    <bit-label>{{ "manageUsers" | i18n }}</bit-label>
+                  </bit-form-control>
+                  <bit-form-control>
+                    <input type="checkbox" bitCheckbox formControlName="manageResetPassword" />
+                    <bit-label>{{ "manageAccountRecovery" | i18n }}</bit-label>
+                  </bit-form-control>
+                </div>
+              </div>
+            </div>
+          }
+          @if (organization.useSecretsManager) {
+            <h3 class="tw-mt-4">
+              {{ "secretsManager" | i18n }}
+              <a
+                bitLink
+                target="_blank"
+                rel="noreferrer"
+                appA11yTitle="{{ 'learnMore' | i18n }}"
+                href="https://bitwarden.com/help/manage-your-organization/#access-to-secrets-manager"
+              >
+                <i class="bwi bwi-question-circle" aria-hidden="true"></i>
+              </a>
+            </h3>
+            <p class="tw-text-muted">{{ "secretsManagerAccessDescription" | i18n }}</p>
+            <bit-form-control>
+              <input
+                type="checkbox"
+                [disabled]="isOnSecretsManagerStandalone"
+                bitCheckbox
+                formControlName="accessSecretsManager"
+              />
+              <bit-label>
+                {{ "userAccessSecretsManagerGA" | i18n }}
+              </bit-label>
+            </bit-form-control>
+          }
+          @if (isExternalIdVisible) {
+            <bit-form-field>
+              <bit-label>{{ "externalId" | i18n }}</bit-label>
+              <input bitInput type="text" formControlName="externalId" />
+              <bit-hint>{{ "externalIdDesc" | i18n }}</bit-hint>
+            </bit-form-field>
+          }
+          @if (isSsoExternalIdVisible) {
+            <bit-form-field>
+              <bit-label>{{ "ssoExternalId" | i18n }}</bit-label>
+              <input bitInput type="text" formControlName="ssoExternalId" />
+              <bit-hint>{{ "ssoExternalIdDesc" | i18n }}</bit-hint>
+            </bit-form-field>
+          }
+        </bit-tab>
+        @if (organization.useGroups) {
+          <bit-tab [label]="'groups' | i18n">
+            <div class="tw-mb-6">
+              {{
+                (restrictEditingSelf$ | async)
+                  ? ("restrictedGroupAccess" | i18n)
+                  : ("groupAccessUserDesc" | i18n)
+              }}
+            </div>
             <bit-access-selector
-              [permissionMode]="PermissionMode.Edit"
-              formControlName="access"
-              [showGroupColumn]="organization.useGroups"
-              [items]="collectionAccessItems"
-              [columnHeader]="'collection' | i18n"
-              [selectorLabelText]="'selectCollections' | i18n"
-              [emptySelectionText]="'noCollectionsAdded' | i18n"
+              formControlName="groups"
+              [items]="groupAccessItems"
+              [columnHeader]="'groups' | i18n"
+              [selectorLabelText]="'selectGroups' | i18n"
+              [emptySelectionText]="'noGroupsAdded' | i18n"
               [hideMultiSelect]="restrictEditingSelf$ | async"
-            ></bit-access-selector
-          ></bit-tab>
-        </bit-tab-group>
+            ></bit-access-selector>
+          </bit-tab>
+        }
+        <bit-tab [label]="'collections' | i18n">
+          @if (restrictEditingSelf$ | async) {
+            <div class="tw-mb-6">
+              {{ "cannotAddYourselfToCollections" | i18n }}
+            </div>
+          }
+          @if (
+            !(restrictEditingSelf$ | async) &&
+            (organization.useGroups || !(canAssignAccessToAnyCollection$ | async))
+          ) {
+            <div class="tw-mb-6">
+              @if (organization.useGroups) {
+                <span>
+                  {{ "userPermissionOverrideHelperDesc" | i18n }}
+                </span>
+              }
+              @if (!(canAssignAccessToAnyCollection$ | async)) {
+                <span>
+                  {{ "restrictedCollectionAssignmentDesc" | i18n }}
+                </span>
+              }
+            </div>
+          }
+          <bit-access-selector
+            [permissionMode]="PermissionMode.Edit"
+            formControlName="access"
+            [showGroupColumn]="organization.useGroups"
+            [items]="collectionAccessItems"
+            [columnHeader]="'collection' | i18n"
+            [selectorLabelText]="'selectCollections' | i18n"
+            [emptySelectionText]="'noCollectionsAdded' | i18n"
+            [hideMultiSelect]="restrictEditingSelf$ | async"
+          ></bit-access-selector
+        ></bit-tab>
+      </bit-tab-group>
+    }
+  </div>
+  <ng-container bitDialogFooter>
+    <button type="submit" bitButton bitFormButton buttonType="primary" [disabled]="loading">
+      {{ "save" | i18n }}
+    </button>
+    <button
+      type="button"
+      bitButton
+      bitFormButton
+      buttonType="secondary"
+      (click)="cancel()"
+      [disabled]="loading"
+    >
+      {{ "cancel" | i18n }}
+    </button>
+    <div class="tw-flex tw-gap-2 tw-ml-auto">
+      @if (editMode && isRevoked) {
+        <button
+          type="button"
+          bitButton
+          bitFormButton
+          buttonType="secondary"
+          [bitAction]="restore"
+          [disabled]="loading"
+        >
+          {{ "restore" | i18n }}
+        </button>
+      }
+      @if (editMode && !isRevoked) {
+        <button
+          type="button"
+          bitButton
+          bitFormButton
+          buttonType="secondary"
+          [bitAction]="revoke"
+          [disabled]="loading"
+        >
+          {{ "revoke" | i18n }}
+        </button>
+      }
+      @if (this.editMode && !(editParams$ | async)?.managedByOrganization) {
+        <button
+          type="button"
+          buttonType="danger"
+          bitButton
+          bitFormButton
+          [bitAction]="remove"
+          [disabled]="loading"
+        >
+          {{ "remove" | i18n }}
+        </button>
+      }
+      @if (this.editMode && (editParams$ | async)?.managedByOrganization) {
+        <button
+          type="button"
+          buttonType="danger"
+          bitButton
+          bitFormButton
+          [bitAction]="delete"
+          [disabled]="loading"
+        >
+          {{ "delete" | i18n }}
+        </button>
       }
     </div>
-    <ng-container bitDialogFooter>
-      <button type="submit" bitButton bitFormButton buttonType="primary" [disabled]="loading">
-        {{ "save" | i18n }}
-      </button>
-      <button
-        type="button"
-        bitButton
-        bitFormButton
-        buttonType="secondary"
-        (click)="cancel()"
-        [disabled]="loading"
-      >
-        {{ "cancel" | i18n }}
-      </button>
-      <div class="tw-flex tw-gap-2 tw-ml-auto">
-        @if (editMode && isRevoked) {
-          <button
-            type="button"
-            bitButton
-            bitFormButton
-            buttonType="secondary"
-            [bitAction]="restore"
-            [disabled]="loading"
-          >
-            {{ "restore" | i18n }}
-          </button>
-        }
-        @if (editMode && !isRevoked) {
-          <button
-            type="button"
-            bitButton
-            bitFormButton
-            buttonType="secondary"
-            [bitAction]="revoke"
-            [disabled]="loading"
-          >
-            {{ "revoke" | i18n }}
-          </button>
-        }
-        @if (this.editMode && !(editParams$ | async)?.managedByOrganization) {
-          <button
-            type="button"
-            buttonType="danger"
-            bitButton
-            bitFormButton
-            [bitAction]="remove"
-            [disabled]="loading"
-          >
-            {{ "remove" | i18n }}
-          </button>
-        }
-        @if (this.editMode && (editParams$ | async)?.managedByOrganization) {
-          <button
-            type="button"
-            buttonType="danger"
-            bitButton
-            bitFormButton
-            [bitAction]="delete"
-            [disabled]="loading"
-          >
-            {{ "delete" | i18n }}
-          </button>
-        }
-      </div>
-    </ng-container>
-  </bit-dialog>
+  </ng-container>
 </form>

--- a/apps/web/src/app/admin-console/organizations/shared/components/collection-dialog/collection-dialog.component.html
+++ b/apps/web/src/app/admin-console/organizations/shared/components/collection-dialog/collection-dialog.component.html
@@ -1,153 +1,150 @@
-<form [formGroup]="formGroup" [bitSubmit]="submit">
-  <bit-dialog dialogSize="large">
-    <span bitDialogTitle>
-      <ng-container *ngIf="editMode">
-        {{ (dialogReadonly ? "viewCollection" : "editCollection") | i18n }}
-        <span class="tw-text-sm tw-normal-case tw-text-muted" *ngIf="!loading">{{
-          collection.name
-        }}</span>
-      </ng-container>
-      <ng-container *ngIf="!editMode">
-        {{ "newCollection" | i18n }}
-      </ng-container>
-    </span>
-    <div bitDialogContent>
-      <ng-container *ngIf="loading" #spinner>
-        <i class="bwi bwi-spinner bwi-lg bwi-spin" aria-hidden="true"></i>
-      </ng-container>
-      <bit-tab-group *ngIf="!loading" [(selectedIndex)]="tabIndex">
-        <bit-tab label="{{ 'collectionInfo' | i18n }}">
-          <bit-form-field>
-            <bit-label>{{ "name" | i18n }}</bit-label>
-            <input bitInput appAutofocus formControlName="name" />
-          </bit-form-field>
-
-          <bit-form-field *ngIf="showOrgSelector">
-            <bit-label>{{ "organization" | i18n }}</bit-label>
-            <bit-select bitInput formControlName="selectedOrg">
-              <bit-option
-                *ngFor="let org of organizations$ | async"
-                icon="bwi-business"
-                [value]="org.id"
-                [label]="org.name"
-              >
-              </bit-option>
-            </bit-select>
-          </bit-form-field>
-
-          <bit-form-field *ngIf="isExternalIdVisible">
-            <bit-label>{{ "externalId" | i18n }}</bit-label>
-            <input bitInput formControlName="externalId" />
-            <bit-hint>{{ "externalIdDesc" | i18n }}</bit-hint>
-          </bit-form-field>
-
-          <bit-form-field>
-            <bit-label>{{ "nestCollectionUnder" | i18n }}</bit-label>
-            <bit-select bitInput formControlName="parent">
-              <bit-option [value]="undefined" [label]="'noCollection' | i18n"> </bit-option>
-              <bit-option
-                *ngIf="deletedParentName"
-                disabled
-                icon="bwi-collection-shared"
-                [value]="deletedParentName"
-                label="{{ deletedParentName }} ({{ 'deleted' | i18n }})"
-              >
-              </bit-option>
-              <bit-option
-                *ngFor="let collection of nestOptions"
-                icon="bwi-collection-shared"
-                [value]="collection.name"
-                [label]="collection.name"
-              >
-              </bit-option>
-            </bit-select>
-          </bit-form-field>
-        </bit-tab>
-        <bit-tab [label]="accessTabLabel">
-          <div class="tw-mb-3">
-            <ng-container *ngIf="dialogReadonly">
-              <span>{{ "readOnlyCollectionAccess" | i18n }}</span>
-            </ng-container>
-            <ng-container *ngIf="!dialogReadonly">
-              <bit-callout
-                title="{{ 'grantManageCollectionWarningTitle' | i18n }}"
-                type="warning"
-                *ngIf="showAddAccessWarning"
-              >
-                {{ "grantManageCollectionWarning" | i18n }}
-              </bit-callout>
-              <span *ngIf="organization.useGroups">{{ "grantCollectionAccess" | i18n }}</span>
-              <span *ngIf="!organization.useGroups">{{
-                "grantCollectionAccessMembersOnly" | i18n
-              }}</span>
-              <span *ngIf="organization.allowAdminAccessToAllCollectionItems">
-                {{ " " + ("adminCollectionAccess" | i18n) }}
-              </span>
-            </ng-container>
-          </div>
-          <div
-            class="tw-mb-3 tw-text-danger"
-            *ngIf="
-              formGroup.controls.access.hasError('managePermissionRequired') &&
-              !showAddAccessWarning
-            "
-          >
-            <i class="bwi bwi-error"></i> {{ "managePermissionRequired" | i18n }}
-          </div>
-          <bit-access-selector
-            *ngIf="organization.useGroups"
-            [permissionMode]="dialogReadonly ? PermissionMode.Readonly : PermissionMode.Edit"
-            formControlName="access"
-            [items]="accessItems"
-            [columnHeader]="'groupSlashMemberColumnHeader' | i18n"
-            [selectorLabelText]="'selectGroupsAndMembers' | i18n"
-            [selectorHelpText]="'userPermissionOverrideHelperDesc' | i18n"
-            [emptySelectionText]="'noMembersOrGroupsAdded' | i18n"
-            [initialPermission]="initialPermission"
-          ></bit-access-selector>
-          <bit-access-selector
-            *ngIf="!organization.useGroups"
-            [permissionMode]="dialogReadonly ? PermissionMode.Readonly : PermissionMode.Edit"
-            formControlName="access"
-            [items]="accessItems"
-            [columnHeader]="'memberColumnHeader' | i18n"
-            [selectorLabelText]="'selectMembers' | i18n"
-            [emptySelectionText]="'noMembersAdded' | i18n"
-          ></bit-access-selector>
-        </bit-tab>
-      </bit-tab-group>
-    </div>
-    <ng-container bitDialogFooter>
-      <button
-        type="submit"
-        bitButton
-        bitFormButton
-        buttonType="primary"
-        [disabled]="loading || dialogReadonly"
-      >
-        {{ buttonDisplayName | i18n }}
-      </button>
-      <button
-        type="button"
-        bitButton
-        bitFormButton
-        buttonType="secondary"
-        (click)="cancel()"
-        [disabled]="loading"
-      >
-        {{ "cancel" | i18n }}
-      </button>
-      <button
-        *ngIf="showDeleteButton"
-        type="button"
-        bitIconButton="bwi-trash"
-        buttonType="dangerGhost"
-        class="tw-ml-auto"
-        bitFormButton
-        [label]="'delete' | i18n"
-        [bitAction]="delete"
-        [disabled]="loading"
-      ></button>
+<form [formGroup]="formGroup" [bitSubmit]="submit" bit-dialog dialogSize="large">
+  <span bitDialogTitle>
+    <ng-container *ngIf="editMode">
+      {{ (dialogReadonly ? "viewCollection" : "editCollection") | i18n }}
+      <span class="tw-text-sm tw-normal-case tw-text-muted" *ngIf="!loading">{{
+        collection.name
+      }}</span>
     </ng-container>
-  </bit-dialog>
+    <ng-container *ngIf="!editMode">
+      {{ "newCollection" | i18n }}
+    </ng-container>
+  </span>
+  <div bitDialogContent>
+    <ng-container *ngIf="loading" #spinner>
+      <i class="bwi bwi-spinner bwi-lg bwi-spin" aria-hidden="true"></i>
+    </ng-container>
+    <bit-tab-group *ngIf="!loading" [(selectedIndex)]="tabIndex">
+      <bit-tab label="{{ 'collectionInfo' | i18n }}">
+        <bit-form-field>
+          <bit-label>{{ "name" | i18n }}</bit-label>
+          <input bitInput appAutofocus formControlName="name" />
+        </bit-form-field>
+
+        <bit-form-field *ngIf="showOrgSelector">
+          <bit-label>{{ "organization" | i18n }}</bit-label>
+          <bit-select bitInput formControlName="selectedOrg">
+            <bit-option
+              *ngFor="let org of organizations$ | async"
+              icon="bwi-business"
+              [value]="org.id"
+              [label]="org.name"
+            >
+            </bit-option>
+          </bit-select>
+        </bit-form-field>
+
+        <bit-form-field *ngIf="isExternalIdVisible">
+          <bit-label>{{ "externalId" | i18n }}</bit-label>
+          <input bitInput formControlName="externalId" />
+          <bit-hint>{{ "externalIdDesc" | i18n }}</bit-hint>
+        </bit-form-field>
+
+        <bit-form-field>
+          <bit-label>{{ "nestCollectionUnder" | i18n }}</bit-label>
+          <bit-select bitInput formControlName="parent">
+            <bit-option [value]="undefined" [label]="'noCollection' | i18n"> </bit-option>
+            <bit-option
+              *ngIf="deletedParentName"
+              disabled
+              icon="bwi-collection-shared"
+              [value]="deletedParentName"
+              label="{{ deletedParentName }} ({{ 'deleted' | i18n }})"
+            >
+            </bit-option>
+            <bit-option
+              *ngFor="let collection of nestOptions"
+              icon="bwi-collection-shared"
+              [value]="collection.name"
+              [label]="collection.name"
+            >
+            </bit-option>
+          </bit-select>
+        </bit-form-field>
+      </bit-tab>
+      <bit-tab [label]="accessTabLabel">
+        <div class="tw-mb-3">
+          <ng-container *ngIf="dialogReadonly">
+            <span>{{ "readOnlyCollectionAccess" | i18n }}</span>
+          </ng-container>
+          <ng-container *ngIf="!dialogReadonly">
+            <bit-callout
+              title="{{ 'grantManageCollectionWarningTitle' | i18n }}"
+              type="warning"
+              *ngIf="showAddAccessWarning"
+            >
+              {{ "grantManageCollectionWarning" | i18n }}
+            </bit-callout>
+            <span *ngIf="organization.useGroups">{{ "grantCollectionAccess" | i18n }}</span>
+            <span *ngIf="!organization.useGroups">{{
+              "grantCollectionAccessMembersOnly" | i18n
+            }}</span>
+            <span *ngIf="organization.allowAdminAccessToAllCollectionItems">
+              {{ " " + ("adminCollectionAccess" | i18n) }}
+            </span>
+          </ng-container>
+        </div>
+        <div
+          class="tw-mb-3 tw-text-danger"
+          *ngIf="
+            formGroup.controls.access.hasError('managePermissionRequired') && !showAddAccessWarning
+          "
+        >
+          <i class="bwi bwi-error"></i> {{ "managePermissionRequired" | i18n }}
+        </div>
+        <bit-access-selector
+          *ngIf="organization.useGroups"
+          [permissionMode]="dialogReadonly ? PermissionMode.Readonly : PermissionMode.Edit"
+          formControlName="access"
+          [items]="accessItems"
+          [columnHeader]="'groupSlashMemberColumnHeader' | i18n"
+          [selectorLabelText]="'selectGroupsAndMembers' | i18n"
+          [selectorHelpText]="'userPermissionOverrideHelperDesc' | i18n"
+          [emptySelectionText]="'noMembersOrGroupsAdded' | i18n"
+          [initialPermission]="initialPermission"
+        ></bit-access-selector>
+        <bit-access-selector
+          *ngIf="!organization.useGroups"
+          [permissionMode]="dialogReadonly ? PermissionMode.Readonly : PermissionMode.Edit"
+          formControlName="access"
+          [items]="accessItems"
+          [columnHeader]="'memberColumnHeader' | i18n"
+          [selectorLabelText]="'selectMembers' | i18n"
+          [emptySelectionText]="'noMembersAdded' | i18n"
+        ></bit-access-selector>
+      </bit-tab>
+    </bit-tab-group>
+  </div>
+  <ng-container bitDialogFooter>
+    <button
+      type="submit"
+      bitButton
+      bitFormButton
+      buttonType="primary"
+      [disabled]="loading || dialogReadonly"
+    >
+      {{ buttonDisplayName | i18n }}
+    </button>
+    <button
+      type="button"
+      bitButton
+      bitFormButton
+      buttonType="secondary"
+      (click)="cancel()"
+      [disabled]="loading"
+    >
+      {{ "cancel" | i18n }}
+    </button>
+    <button
+      *ngIf="showDeleteButton"
+      type="button"
+      bitIconButton="bwi-trash"
+      buttonType="dangerGhost"
+      class="tw-ml-auto"
+      bitFormButton
+      [label]="'delete' | i18n"
+      [bitAction]="delete"
+      [disabled]="loading"
+    ></button>
+  </ng-container>
 </form>

--- a/bitwarden_license/bit-web/src/app/admin-console/organizations/manage/domain-verification/domain-add-edit-dialog/domain-add-edit-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/admin-console/organizations/manage/domain-verification/domain-add-edit-dialog/domain-add-edit-dialog.component.html
@@ -2,80 +2,80 @@
   [formGroup]="domainForm"
   [bitSubmit]="data.orgDomain ? verifyDomain : saveDomain"
   [allowDisabledFormSubmit]="true"
+  bit-dialog
+  [dialogSize]="'default'"
 >
-  <bit-dialog [dialogSize]="'default'">
-    <span bitDialogTitle>
-      <span *ngIf="!data.orgDomain">{{ "newDomain" | i18n }}</span>
-      <span *ngIf="data.orgDomain">
-        {{ "claimDomain" | i18n }}
-      </span>
-
-      <span *ngIf="data?.orgDomain && !data.orgDomain?.verifiedDate" bitBadge variant="warning">
-        {{ "domainStatusPending" | i18n }}
-      </span>
-      <span *ngIf="data?.orgDomain && data?.orgDomain?.verifiedDate" bitBadge variant="success">
-        {{ "domainStatusClaimed" | i18n }}
-      </span>
+  <span bitDialogTitle>
+    <span *ngIf="!data.orgDomain">{{ "newDomain" | i18n }}</span>
+    <span *ngIf="data.orgDomain">
+      {{ "claimDomain" | i18n }}
     </span>
-    <div bitDialogContent>
-      <div *ngIf="data?.orgDomain && !data?.orgDomain?.verifiedDate" class="tw-space-y-2 tw-pb-4">
-        <p bitTypography="body1">{{ "automaticDomainClaimProcess1" | i18n }}</p>
-        <p bitTypography="body1">
-          {{ "automaticDomainClaimProcess2" | i18n }}
-          <a
-            bitLink
-            target="_blank"
-            rel="noreferrer"
-            href="https://bitwarden.com/help/claimed-accounts/"
-            class="tw-inline-flex tw-items-center tw-gap-1"
-            endIcon="bwi-external-link"
-          >
-            {{ "accountOwnershipChange" | i18n }}
-          </a>
-          {{ "automaticDomainClaimProcessEnd" | i18n }}
-        </p>
-      </div>
-      <bit-form-field>
-        <bit-label>{{ "domainName" | i18n }}</bit-label>
-        <input bitInput appAutofocus formControlName="domainName" [showErrorsWhenDisabled]="true" />
-      </bit-form-field>
 
-      <bit-form-field *ngIf="data?.orgDomain">
-        <bit-label>{{ "dnsTxtRecord" | i18n }}</bit-label>
-        <input bitInput formControlName="txt" />
-        <bit-hint>{{ "dnsTxtRecordInputHint" | i18n }}</bit-hint>
-        <button
-          type="button"
-          bitSuffix
-          bitIconButton="bwi-clone"
-          label="{{ 'copyDnsTxtRecord' | i18n }}"
-          (click)="copyDnsTxt()"
-        ></button>
-      </bit-form-field>
+    <span *ngIf="data?.orgDomain && !data.orgDomain?.verifiedDate" bitBadge variant="warning">
+      {{ "domainStatusPending" | i18n }}
+    </span>
+    <span *ngIf="data?.orgDomain && data?.orgDomain?.verifiedDate" bitBadge variant="success">
+      {{ "domainStatusClaimed" | i18n }}
+    </span>
+  </span>
+  <div bitDialogContent>
+    <div *ngIf="data?.orgDomain && !data?.orgDomain?.verifiedDate" class="tw-space-y-2 tw-pb-4">
+      <p bitTypography="body1">{{ "automaticDomainClaimProcess1" | i18n }}</p>
+      <p bitTypography="body1">
+        {{ "automaticDomainClaimProcess2" | i18n }}
+        <a
+          bitLink
+          target="_blank"
+          rel="noreferrer"
+          href="https://bitwarden.com/help/claimed-accounts/"
+          class="tw-inline-flex tw-items-center tw-gap-1"
+          endIcon="bwi-external-link"
+        >
+          {{ "accountOwnershipChange" | i18n }}
+        </a>
+        {{ "automaticDomainClaimProcessEnd" | i18n }}
+      </p>
     </div>
-    <ng-container bitDialogFooter>
-      <button type="submit" bitButton bitFormButton buttonType="primary">
-        <span *ngIf="!data?.orgDomain">{{ "next" | i18n }}</span>
-        <span *ngIf="data?.orgDomain && !data?.orgDomain?.verifiedDate">{{
-          "claimDomain" | i18n
-        }}</span>
-        <span *ngIf="data?.orgDomain?.verifiedDate">{{ "reclaimDomain" | i18n }}</span>
-      </button>
-      <button bitButton buttonType="secondary" (click)="dialogRef.close()" type="button">
-        {{ "cancel" | i18n }}
-      </button>
+    <bit-form-field>
+      <bit-label>{{ "domainName" | i18n }}</bit-label>
+      <input bitInput appAutofocus formControlName="domainName" [showErrorsWhenDisabled]="true" />
+    </bit-form-field>
 
+    <bit-form-field *ngIf="data?.orgDomain">
+      <bit-label>{{ "dnsTxtRecord" | i18n }}</bit-label>
+      <input bitInput formControlName="txt" />
+      <bit-hint>{{ "dnsTxtRecordInputHint" | i18n }}</bit-hint>
       <button
-        *ngIf="data.orgDomain"
-        class="tw-ml-auto"
-        bitIconButton="bwi-trash"
-        buttonType="dangerGhost"
-        size="default"
-        label="{{ 'delete' | i18n }}"
-        [bitAction]="deleteDomain"
-        type="submit"
-        bitFormButton
+        type="button"
+        bitSuffix
+        bitIconButton="bwi-clone"
+        label="{{ 'copyDnsTxtRecord' | i18n }}"
+        (click)="copyDnsTxt()"
       ></button>
-    </ng-container>
-  </bit-dialog>
+    </bit-form-field>
+  </div>
+  <ng-container bitDialogFooter>
+    <button type="submit" bitButton bitFormButton buttonType="primary">
+      <span *ngIf="!data?.orgDomain">{{ "next" | i18n }}</span>
+      <span *ngIf="data?.orgDomain && !data?.orgDomain?.verifiedDate">{{
+        "claimDomain" | i18n
+      }}</span>
+      <span *ngIf="data?.orgDomain?.verifiedDate">{{ "reclaimDomain" | i18n }}</span>
+    </button>
+    <button bitButton buttonType="secondary" (click)="dialogRef.close()" type="button">
+      {{ "cancel" | i18n }}
+    </button>
+
+    <button
+      *ngIf="data.orgDomain"
+      class="tw-ml-auto"
+      bitIconButton="bwi-trash"
+      buttonType="dangerGhost"
+      size="default"
+      label="{{ 'delete' | i18n }}"
+      [bitAction]="deleteDomain"
+      type="submit"
+      bitFormButton
+    ></button>
+  </ng-container>
 </form>

--- a/bitwarden_license/bit-web/src/app/admin-console/providers/manage/dialogs/add-edit-member-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/admin-console/providers/manage/dialogs/add-edit-member-dialog.component.html
@@ -1,68 +1,72 @@
-<form [formGroup]="formGroup" [bitSubmit]="submit">
-  <bit-dialog dialogSize="large" [loading]="loading">
-    <span bitDialogTitle>
-      {{ title | uppercase }}
-      <small class="tw-text-muted" *ngIf="dialogParams.user">{{ dialogParams.user.name }}</small>
-    </span>
-    <div bitDialogContent>
-      <ng-container *ngIf="!editing">
-        <p>{{ "providerInviteUserDesc" | i18n }}</p>
-        <div class="tw-mb-4">
-          <bit-form-field>
-            <bit-label>
-              {{ "email" | i18n }}
-            </bit-label>
-            <input type="text" bitInput formControlName="emails" />
-            <bit-hint>{{ "inviteMultipleEmailsNoSeatLimit" | i18n: 20 }}</bit-hint>
-          </bit-form-field>
-        </div>
-      </ng-container>
-      <ng-container>
-        <h3>
-          {{ "userType" | i18n | uppercase }}
-          <a
-            target="_blank"
-            rel="noreferrer"
-            appA11yTitle="{{ 'learnMore' | i18n }}"
-            href="https://bitwarden.com/help/provider-users/"
-          >
-            <i class="bwi bwi-question-circle" aria-hidden="true"></i>
-          </a>
-        </h3>
-        <bit-radio-group formControlName="type">
-          <bit-radio-button [value]="UserType.ServiceUser">
-            <bit-label>
-              {{ "serviceUser" | i18n }}
-            </bit-label>
-            <bit-hint>{{ "serviceUserDesc" | i18n }}</bit-hint>
-          </bit-radio-button>
-          <bit-radio-button [value]="UserType.ProviderAdmin">
-            <bit-label>
-              {{ "providerAdmin" | i18n }}
-            </bit-label>
-            <bit-hint>{{ "providerAdminDesc" | i18n }}</bit-hint>
-          </bit-radio-button>
-        </bit-radio-group>
-      </ng-container>
-    </div>
-    <ng-container bitDialogFooter>
-      <button type="submit" bitButton bitFormButton buttonType="primary" [disabled]="loading">
-        {{ "save" | i18n }}
-      </button>
-      <button bitButton buttonType="secondary" type="button" [bitDialogClose]="ResultType.Closed">
-        {{ "cancel" | i18n }}
-      </button>
-      <div class="tw-ml-auto" *ngIf="editing">
-        <button
-          type="button"
-          bitIconButton="bwi-trash"
-          buttonType="dangerGhost"
-          bitFormButton
-          [label]="'delete' | i18n"
-          [bitAction]="delete"
-          [disabled]="loading"
-        ></button>
+<form
+  [formGroup]="formGroup"
+  [bitSubmit]="submit"
+  bit-dialog
+  dialogSize="large"
+  [loading]="loading"
+>
+  <span bitDialogTitle>
+    {{ title | uppercase }}
+    <small class="tw-text-muted" *ngIf="dialogParams.user">{{ dialogParams.user.name }}</small>
+  </span>
+  <div bitDialogContent>
+    <ng-container *ngIf="!editing">
+      <p>{{ "providerInviteUserDesc" | i18n }}</p>
+      <div class="tw-mb-4">
+        <bit-form-field>
+          <bit-label>
+            {{ "email" | i18n }}
+          </bit-label>
+          <input type="text" bitInput formControlName="emails" />
+          <bit-hint>{{ "inviteMultipleEmailsNoSeatLimit" | i18n: 20 }}</bit-hint>
+        </bit-form-field>
       </div>
     </ng-container>
-  </bit-dialog>
+    <ng-container>
+      <h3>
+        {{ "userType" | i18n | uppercase }}
+        <a
+          target="_blank"
+          rel="noreferrer"
+          appA11yTitle="{{ 'learnMore' | i18n }}"
+          href="https://bitwarden.com/help/provider-users/"
+        >
+          <i class="bwi bwi-question-circle" aria-hidden="true"></i>
+        </a>
+      </h3>
+      <bit-radio-group formControlName="type">
+        <bit-radio-button [value]="UserType.ServiceUser">
+          <bit-label>
+            {{ "serviceUser" | i18n }}
+          </bit-label>
+          <bit-hint>{{ "serviceUserDesc" | i18n }}</bit-hint>
+        </bit-radio-button>
+        <bit-radio-button [value]="UserType.ProviderAdmin">
+          <bit-label>
+            {{ "providerAdmin" | i18n }}
+          </bit-label>
+          <bit-hint>{{ "providerAdminDesc" | i18n }}</bit-hint>
+        </bit-radio-button>
+      </bit-radio-group>
+    </ng-container>
+  </div>
+  <ng-container bitDialogFooter>
+    <button type="submit" bitButton bitFormButton buttonType="primary" [disabled]="loading">
+      {{ "save" | i18n }}
+    </button>
+    <button bitButton buttonType="secondary" type="button" [bitDialogClose]="ResultType.Closed">
+      {{ "cancel" | i18n }}
+    </button>
+    <div class="tw-ml-auto" *ngIf="editing">
+      <button
+        type="button"
+        bitIconButton="bwi-trash"
+        buttonType="dangerGhost"
+        bitFormButton
+        [label]="'delete' | i18n"
+        [bitAction]="delete"
+        [disabled]="loading"
+      ></button>
+    </div>
+  </ng-container>
 </form>


### PR DESCRIPTION
## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)

## Tracking
https://bitwarden.atlassian.net/browse/CL-1046

## Description

Migrates admin console dialogs (organization member, group, collection, provider, and domain verification) to use the `<form bit-dialog>` pattern, fixing the height styling bug where dialogs break when wrapped in form elements.

⚠️ **Depends on:** #18929 - Must merge after component selector updates

### Changes:
- Update `member-dialog` to use `<form bit-dialog>` pattern
- Update `group-add-edit` dialog to use `<form bit-dialog>` pattern
- Update `collection-dialog` to use `<form bit-dialog>` pattern
- Update provider `add-edit-member-dialog` to use `<form bit-dialog>` pattern
- Update `domain-add-edit-dialog` to use `<form bit-dialog>` pattern

### Files Changed:
- `apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.html`
- `apps/web/src/app/admin-console/organizations/manage/group-add-edit.component.html`
- `apps/web/src/app/admin-console/organizations/shared/components/collection-dialog/collection-dialog.component.html`
- `bitwarden_license/bit-web/src/app/admin-console/providers/manage/dialogs/add-edit-member-dialog.component.html`
- `bitwarden_license/bit-web/src/app/admin-console/organizations/manage/domain-verification/domain-add-edit-dialog/domain-add-edit-dialog.component.html`

## Code review checklist
- [x] Tested on multiple browsers
- [x] Adheres to Bitwarden code style

## Notes

This PR (#18933) is part of a coordinated effort to migrate dialog forms across the codebase:
- #18929 - UI Foundation (foundational PR - must merge first) ⬅️ **Dependency**
- #18930 - Vault team dialogs
- #18931 - Tools team dialogs
- #18932 - Auth team dialogs
- #18933 - Admin Console team dialogs (this PR)
- #18934 - Secrets Manager dialogs

Fixes the height styling issue by making the form element itself the dialog container (`<form bit-dialog>`) instead of wrapping it (`<form><bit-dialog></bit-dialog></form>`).