### PR TITLE
[CL-1046] Migrate Secrets Manager dialogs to new form pattern

### DIFF
--- a/bitwarden_license/bit-web/src/app/secrets-manager/projects/dialog/project-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/projects/dialog/project-dialog.component.html
@@ -1,22 +1,20 @@
-<form [formGroup]="formGroup" [bitSubmit]="submit">
-  <bit-dialog dialogSize="default">
-    <span bitDialogTitle>{{ title | i18n }}</span>
-    <span bitDialogContent>
-      <div *ngIf="loading" class="tw-text-center">
-        <i class="bwi bwi-spinner bwi-spin bwi-3x"></i>
-      </div>
-      <bit-form-field *ngIf="!loading">
-        <bit-label>{{ "projectName" | i18n }}</bit-label>
-        <input appAutofocus formControlName="name" bitInput />
-      </bit-form-field>
-    </span>
-    <ng-container bitDialogFooter>
-      <button type="submit" bitButton buttonType="primary" bitFormButton>
-        {{ "save" | i18n }}
-      </button>
-      <button type="button" bitButton buttonType="secondary" bitFormButton bitDialogClose>
-        {{ "cancel" | i18n }}
-      </button>
-    </ng-container>
-  </bit-dialog>
+<form [formGroup]="formGroup" [bitSubmit]="submit" bit-dialog dialogSize="default">
+  <span bitDialogTitle>{{ title | i18n }}</span>
+  <span bitDialogContent>
+    <div *ngIf="loading" class="tw-text-center">
+      <i class="bwi bwi-spinner bwi-spin bwi-3x"></i>
+    </div>
+    <bit-form-field *ngIf="!loading">
+      <bit-label>{{ "projectName" | i18n }}</bit-label>
+      <input appAutofocus formControlName="name" bitInput />
+    </bit-form-field>
+  </span>
+  <ng-container bitDialogFooter>
+    <button type="submit" bitButton buttonType="primary" bitFormButton>
+      {{ "save" | i18n }}
+    </button>
+    <button type="button" bitButton buttonType="secondary" bitFormButton bitDialogClose>
+      {{ "cancel" | i18n }}
+    </button>
+  </ng-container>
 </form>

--- a/bitwarden_license/bit-web/src/app/secrets-manager/secrets/dialog/secret-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/secrets/dialog/secret-dialog.component.html
@@ -1,97 +1,103 @@
-<form [formGroup]="formGroup" [bitSubmit]="submit">
-  <bit-dialog dialogSize="large" [loading]="loading" [title]="title | i18n" [subtitle]="subtitle">
-    <div bitDialogContent class="tw-relative">
-      <bit-tab-group [(selectedIndex)]="tabIndex">
-        <bit-tab label="{{ 'nameValuePair' | i18n }}">
-          <div class="tw-flex tw-gap-4 tw-pt-4">
-            <bit-form-field class="tw-w-1/3">
-              <bit-label>{{ "name" | i18n }}</bit-label>
-              <input appAutofocus formControlName="name" bitInput />
-            </bit-form-field>
-            <bit-form-field class="tw-w-full">
-              <bit-label>{{ "value" | i18n }}</bit-label>
-              <textarea bitInput rows="4" formControlName="value"></textarea>
-            </bit-form-field>
-          </div>
-          <bit-form-field>
-            <bit-label>{{ "notes" | i18n }}</bit-label>
-            <textarea bitInput rows="4" formControlName="notes"></textarea>
+<form
+  [formGroup]="formGroup"
+  [bitSubmit]="submit"
+  bit-dialog
+  dialogSize="large"
+  [loading]="loading"
+  [title]="title | i18n"
+  [subtitle]="subtitle"
+>
+  <div bitDialogContent class="tw-relative">
+    <bit-tab-group [(selectedIndex)]="tabIndex">
+      <bit-tab label="{{ 'nameValuePair' | i18n }}">
+        <div class="tw-flex tw-gap-4 tw-pt-4">
+          <bit-form-field class="tw-w-1/3">
+            <bit-label>{{ "name" | i18n }}</bit-label>
+            <input appAutofocus formControlName="name" bitInput />
           </bit-form-field>
-
-          <hr />
-
-          <bit-form-field class="tw-mb-0 tw-mt-3">
-            <bit-label>{{ "project" | i18n }}</bit-label>
-            <bit-select bitInput name="project" formControlName="project">
-              <bit-option value="" [label]="'selectPlaceholder' | i18n"></bit-option>
-              <bit-option
-                *ngFor="let p of projects"
-                [icon]="p.id === this.newProjectGuid ? 'bwi-plus-circle' : ''"
-                [value]="p.id"
-                [label]="p.name"
-              >
-              </bit-option>
-            </bit-select>
+          <bit-form-field class="tw-w-full">
+            <bit-label>{{ "value" | i18n }}</bit-label>
+            <textarea bitInput rows="4" formControlName="value"></textarea>
           </bit-form-field>
+        </div>
+        <bit-form-field>
+          <bit-label>{{ "notes" | i18n }}</bit-label>
+          <textarea bitInput rows="4" formControlName="notes"></textarea>
+        </bit-form-field>
 
-          <bit-form-field *ngIf="addNewProject == true">
-            <bit-label>{{ "projectName" | i18n }}</bit-label>
-            <input formControlName="newProjectName" bitInput />
-          </bit-form-field>
-        </bit-tab>
+        <hr />
 
-        <bit-tab label="{{ 'people' | i18n }}">
-          <p>
-            {{ "secretPeopleDescription" | i18n }}
-          </p>
-          <sm-access-policy-selector
-            formControlName="peopleAccessPolicies"
-            [addButtonMode]="false"
-            [items]="peopleAccessPolicyItems"
-            [label]="'people' | i18n"
-            [hint]="'projectPeopleSelectHint' | i18n"
-            [columnTitle]="'name' | i18n"
-            [emptyMessage]="'secretPeopleEmptyMessage' | i18n"
-          >
-          </sm-access-policy-selector>
-        </bit-tab>
+        <bit-form-field class="tw-mb-0 tw-mt-3">
+          <bit-label>{{ "project" | i18n }}</bit-label>
+          <bit-select bitInput name="project" formControlName="project">
+            <bit-option value="" [label]="'selectPlaceholder' | i18n"></bit-option>
+            <bit-option
+              *ngFor="let p of projects"
+              [icon]="p.id === this.newProjectGuid ? 'bwi-plus-circle' : ''"
+              [value]="p.id"
+              [label]="p.name"
+            >
+            </bit-option>
+          </bit-select>
+        </bit-form-field>
 
-        <bit-tab label="{{ 'machineAccounts' | i18n }}">
-          <p>
-            {{ "secretMachineAccountsDescription" | i18n }}
-          </p>
-          <sm-access-policy-selector
-            formControlName="serviceAccountAccessPolicies"
-            [addButtonMode]="false"
-            [items]="serviceAccountAccessPolicyItems"
-            [label]="'machineAccounts' | i18n"
-            [hint]="'projectMachineAccountsSelectHint' | i18n"
-            [columnTitle]="'machineAccounts' | i18n"
-            [emptyMessage]="'secretMachineAccountsEmptyMessage' | i18n"
-          >
-          </sm-access-policy-selector>
-        </bit-tab>
-      </bit-tab-group>
-    </div>
+        <bit-form-field *ngIf="addNewProject == true">
+          <bit-label>{{ "projectName" | i18n }}</bit-label>
+          <input formControlName="newProjectName" bitInput />
+        </bit-form-field>
+      </bit-tab>
 
-    <ng-container bitDialogFooter>
-      <button [loading]="loading" type="submit" bitButton buttonType="primary" bitFormButton>
-        {{ "save" | i18n }}
-      </button>
-      <button bitButton buttonType="secondary" type="button" bitDialogClose>
-        {{ "cancel" | i18n }}
-      </button>
-      <button
-        *ngIf="deleteButtonIsVisible"
-        class="tw-ml-auto"
-        [disabled]="loading"
-        type="button"
-        buttonType="dangerGhost"
-        bitIconButton="bwi-trash"
-        bitFormButton
-        [label]="'delete' | i18n"
-        [bitAction]="delete"
-      ></button>
-    </ng-container>
-  </bit-dialog>
+      <bit-tab label="{{ 'people' | i18n }}">
+        <p>
+          {{ "secretPeopleDescription" | i18n }}
+        </p>
+        <sm-access-policy-selector
+          formControlName="peopleAccessPolicies"
+          [addButtonMode]="false"
+          [items]="peopleAccessPolicyItems"
+          [label]="'people' | i18n"
+          [hint]="'projectPeopleSelectHint' | i18n"
+          [columnTitle]="'name' | i18n"
+          [emptyMessage]="'secretPeopleEmptyMessage' | i18n"
+        >
+        </sm-access-policy-selector>
+      </bit-tab>
+
+      <bit-tab label="{{ 'machineAccounts' | i18n }}">
+        <p>
+          {{ "secretMachineAccountsDescription" | i18n }}
+        </p>
+        <sm-access-policy-selector
+          formControlName="serviceAccountAccessPolicies"
+          [addButtonMode]="false"
+          [items]="serviceAccountAccessPolicyItems"
+          [label]="'machineAccounts' | i18n"
+          [hint]="'projectMachineAccountsSelectHint' | i18n"
+          [columnTitle]="'machineAccounts' | i18n"
+          [emptyMessage]="'secretMachineAccountsEmptyMessage' | i18n"
+        >
+        </sm-access-policy-selector>
+      </bit-tab>
+    </bit-tab-group>
+  </div>
+
+  <ng-container bitDialogFooter>
+    <button [loading]="loading" type="submit" bitButton buttonType="primary" bitFormButton>
+      {{ "save" | i18n }}
+    </button>
+    <button bitButton buttonType="secondary" type="button" bitDialogClose>
+      {{ "cancel" | i18n }}
+    </button>
+    <button
+      *ngIf="deleteButtonIsVisible"
+      class="tw-ml-auto"
+      [disabled]="loading"
+      type="button"
+      buttonType="dangerGhost"
+      bitIconButton="bwi-trash"
+      bitFormButton
+      [label]="'delete' | i18n"
+      [bitAction]="delete"
+    ></button>
+  </ng-container>
 </form>

--- a/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/access/dialogs/access-token-create-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/access/dialogs/access-token-create-dialog.component.html
@@ -1,31 +1,29 @@
-<form [formGroup]="formGroup" [bitSubmit]="submit">
-  <bit-dialog dialogSize="default">
-    <ng-container bitDialogTitle>
-      <span>{{ "createAccessToken" | i18n }}</span>
-      <span class="tw-text-sm tw-normal-case tw-text-muted">
-        {{ data.serviceAccountView.name }}
-      </span>
-    </ng-container>
+<form [formGroup]="formGroup" [bitSubmit]="submit" bit-dialog dialogSize="default">
+  <ng-container bitDialogTitle>
+    <span>{{ "createAccessToken" | i18n }}</span>
+    <span class="tw-text-sm tw-normal-case tw-text-muted">
+      {{ data.serviceAccountView.name }}
+    </span>
+  </ng-container>
 
-    <div bitDialogContent>
-      <bit-form-field>
-        <bit-label>{{ "name" | i18n }}</bit-label>
-        <input bitInput appAutofocus formControlName="name" />
-      </bit-form-field>
-      <sm-expiration-options
-        formControlName="expirationDateControl"
-        [expirationDayOptions]="expirationDayOptions"
-        [touched]="formGroup.controls.expirationDateControl.touched"
-      ></sm-expiration-options>
-    </div>
+  <div bitDialogContent>
+    <bit-form-field>
+      <bit-label>{{ "name" | i18n }}</bit-label>
+      <input bitInput appAutofocus formControlName="name" />
+    </bit-form-field>
+    <sm-expiration-options
+      formControlName="expirationDateControl"
+      [expirationDayOptions]="expirationDayOptions"
+      [touched]="formGroup.controls.expirationDateControl.touched"
+    ></sm-expiration-options>
+  </div>
 
-    <ng-container bitDialogFooter>
-      <button class="tw-normal-case" type="submit" bitButton buttonType="primary" bitFormButton>
-        {{ "createAccessToken" | i18n }}
-      </button>
-      <button type="button" bitButton buttonType="secondary" bitFormButton bitDialogClose>
-        {{ "cancel" | i18n }}
-      </button>
-    </ng-container>
-  </bit-dialog>
+  <ng-container bitDialogFooter>
+    <button class="tw-normal-case" type="submit" bitButton buttonType="primary" bitFormButton>
+      {{ "createAccessToken" | i18n }}
+    </button>
+    <button type="button" bitButton buttonType="secondary" bitFormButton bitDialogClose>
+      {{ "cancel" | i18n }}
+    </button>
+  </ng-container>
 </form>

--- a/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/dialog/service-account-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/dialog/service-account-dialog.component.html
@@ -1,24 +1,22 @@
-<form [formGroup]="formGroup" [bitSubmit]="submit">
-  <bit-dialog dialogSize="default">
-    <ng-container bitDialogTitle>{{ title | i18n }}</ng-container>
-    <div bitDialogContent>
-      <div *ngIf="loading" class="tw-text-center">
-        <i class="bwi bwi-spinner bwi-spin bwi-3x"></i>
-      </div>
-      <div *ngIf="!loading">
-        <bit-form-field>
-          <bit-label>{{ "machineAccountName" | i18n }}</bit-label>
-          <input appAutofocus formControlName="name" bitInput />
-        </bit-form-field>
-      </div>
+<form [formGroup]="formGroup" [bitSubmit]="submit" bit-dialog dialogSize="default">
+  <ng-container bitDialogTitle>{{ title | i18n }}</ng-container>
+  <div bitDialogContent>
+    <div *ngIf="loading" class="tw-text-center">
+      <i class="bwi bwi-spinner bwi-spin bwi-3x"></i>
     </div>
-    <ng-container bitDialogFooter>
-      <button type="submit" bitButton buttonType="primary" bitFormButton>
-        {{ "save" | i18n }}
-      </button>
-      <button type="button" bitButton buttonType="secondary" bitFormButton bitDialogClose>
-        {{ "cancel" | i18n }}
-      </button>
-    </ng-container>
-  </bit-dialog>
+    <div *ngIf="!loading">
+      <bit-form-field>
+        <bit-label>{{ "machineAccountName" | i18n }}</bit-label>
+        <input appAutofocus formControlName="name" bitInput />
+      </bit-form-field>
+    </div>
+  </div>
+  <ng-container bitDialogFooter>
+    <button type="submit" bitButton buttonType="primary" bitFormButton>
+      {{ "save" | i18n }}
+    </button>
+    <button type="button" bitButton buttonType="secondary" bitFormButton bitDialogClose>
+      {{ "cancel" | i18n }}
+    </button>
+  </ng-container>
 </form>


### PR DESCRIPTION
## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)

## Tracking
https://bitwarden.atlassian.net/browse/CL-1046

## Description

Migrates Secrets Manager dialogs (project, service account, access token, and secret) to use the `<form bit-dialog>` pattern, fixing the height styling bug where dialogs break when wrapped in form elements.

⚠️ **Depends on:** #18929 - Must merge after component selector updates

### Changes:
- Update `project-dialog` to use `<form bit-dialog>` pattern
- Update `service-account-dialog` to use `<form bit-dialog>` pattern
- Update `access-token-create-dialog` to use `<form bit-dialog>` pattern
- Update `secret-dialog` to use `<form bit-dialog>` pattern

### Files Changed:
- `bitwarden_license/bit-web/src/app/secrets-manager/projects/dialog/project-dialog.component.html`
- `bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/dialog/service-account-dialog.component.html`
- `bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/access/dialogs/access-token-create-dialog.component.html`
- `bitwarden_license/bit-web/src/app/secrets-manager/secrets/dialog/secret-dialog.component.html`

## Code review checklist
- [x] Tested on multiple browsers
- [x] Adheres to Bitwarden code style

## Notes

This PR (#18934) is part of a coordinated effort to migrate dialog forms across the codebase:
- #18929 - UI Foundation (foundational PR - must merge first) ⬅️ **Dependency**
- #18930 - Vault team dialogs
- #18931 - Tools team dialogs
- #18932 - Auth team dialogs
- #18933 - Admin Console team dialogs
- #18934 - Secrets Manager dialogs (this PR)

⚠️ **Note:** There is no explicit CODEOWNERS entry for Secrets Manager. This PR will be routed to default reviewers.

Fixes the height styling issue by making the form element itself the dialog container (`<form bit-dialog>`) instead of wrapping it (`<form><bit-dialog></bit-dialog></form>`).