### PR TITLE
Fix EventListener type errors in inline menu list

### DIFF
--- a/apps/browser/src/autofill/overlay/inline-menu/pages/list/autofill-inline-menu-list.ts
+++ b/apps/browser/src/autofill/overlay/inline-menu/pages/list/autofill-inline-menu-list.ts
@@ -1012,7 +1012,7 @@ export class AutofillInlineMenuList extends AutofillInlineMenuPageElement {
   private handleFillCipherClickEvent = (cipher: InlineMenuCipherData) => {
     const usePasskey = !!cipher.login?.passkey;
     return this.useEventHandlersMemo(
-      (event: MouseEvent) => {
+      (event: Event) => {
         /**
          * Reject synthetic events (not originating from the user agent)
          */
@@ -1140,7 +1140,7 @@ export class AutofillInlineMenuList extends AutofillInlineMenuPageElement {
    * @param cipher - The cipher to view.
    */
   private handleViewCipherClickEvent = (cipher: InlineMenuCipherData) => {
-    return this.useEventHandlersMemo((event: MouseEvent) => {
+    return this.useEventHandlersMemo((event: Event) => {
       /**
        * Reject synthetic events (not originating from the user agent)
        */


### PR DESCRIPTION
## Summary
- Fixed TypeScript strict mode errors in `AutofillInlineMenuList`
- Changed event parameter type from `MouseEvent` to `Event` in two event handlers to match the `EventListener` interface

## Changes
- `handleFillCipherClickEvent`: Updated event parameter from `MouseEvent` to `Event`
- `handleViewCipherClickEvent`: Updated event parameter from `MouseEvent` to `Event`

Both handlers only use the event to call `EventSecurity.isEventTrusted(event)` and don't access any MouseEvent-specific properties, making the base `Event` type appropriate.

## Test plan
- [x] Type tests pass: `npm run test:types`
- [x] No functionality changes - handlers work identically with base Event type

🤖 Generated with [Claude Code](https://claude.com/claude-code)