### PR TITLE
[PM-32182] Rename CLI flag --email to --emails 

### DIFF
--- a/apps/cli/src/tools/send/commands/create.command.spec.ts
+++ b/apps/cli/src/tools/send/commands/create.command.spec.ts
@@ -62,7 +62,7 @@ describe("SendCreateCommand", () => {
         };
 
         const cmdOptions = {
-          email: ["test@example.com"],
+          emails: ["test@example.com"],
         };
 
         sendService.encrypt.mockResolvedValue([
@@ -155,7 +155,7 @@ describe("SendCreateCommand", () => {
         };
 
         const cmdOptions = {
-          email: ["test@example.com"],
+          emails: ["test@example.com"],
           password: "testPassword123",
         };
 
@@ -246,7 +246,7 @@ describe("SendCreateCommand", () => {
         };
 
         const cmdOptions = {
-          email: ["cli@example.com"],
+          emails: ["cli@example.com"],
         };
 
         const response = await command.run(requestJson, cmdOptions);
@@ -282,7 +282,7 @@ describe("SendCreateCommand", () => {
         };
 
         const cmdOptions = {
-          email: ["cli@example.com"],
+          emails: ["cli@example.com"],
         };
 
         sendService.encrypt.mockResolvedValue([

--- a/apps/cli/src/tools/send/commands/create.command.ts
+++ b/apps/cli/src/tools/send/commands/create.command.ts
@@ -173,7 +173,7 @@ class Options {
     this.file = passedOptions?.file;
     this.text = passedOptions?.text;
     this.password = passedOptions?.password;
-    this.emails = passedOptions?.email;
+    this.emails = passedOptions?.emails;
     this.hidden = CliUtils.convertBooleanOption(passedOptions?.hidden);
     this.maxAccessCount =
       passedOptions?.maxAccessCount != null ? parseInt(passedOptions.maxAccessCount, null) : null;

--- a/apps/cli/src/tools/send/commands/edit.command.spec.ts
+++ b/apps/cli/src/tools/send/commands/edit.command.spec.ts
@@ -81,7 +81,7 @@ describe("SendEditCommand", () => {
         const requestJson = encodeRequest(requestData);
 
         const cmdOptions = {
-          email: ["test@example.com"],
+          emails: ["test@example.com"],
         };
 
         sendService.encrypt.mockResolvedValue([
@@ -155,7 +155,7 @@ describe("SendEditCommand", () => {
         const requestJson = encodeRequest(requestData);
 
         const cmdOptions = {
-          email: ["test@example.com"],
+          emails: ["test@example.com"],
           password: "testPassword123",
         };
 
@@ -239,7 +239,7 @@ describe("SendEditCommand", () => {
         const requestJson = encodeRequest(requestData);
 
         const cmdOptions = {
-          email: ["cli@example.com"],
+          emails: ["cli@example.com"],
         };
 
         const response = await command.run(requestJson, cmdOptions);
@@ -277,7 +277,7 @@ describe("SendEditCommand", () => {
         const requestJson = encodeRequest(requestData);
 
         const cmdOptions = {
-          email: ["cli@example.com"],
+          emails: ["cli@example.com"],
         };
 
         sendService.encrypt.mockResolvedValue([

--- a/apps/cli/src/tools/send/commands/edit.command.ts
+++ b/apps/cli/src/tools/send/commands/edit.command.ts
@@ -124,6 +124,6 @@ class Options {
   constructor(passedOptions: Record<string, any>) {
     this.itemId = passedOptions?.itemId || passedOptions?.itemid;
     this.password = passedOptions.password;
-    this.emails = passedOptions.email;
+    this.emails = passedOptions.emails;
   }
 }

--- a/apps/cli/src/tools/send/send.program.ts
+++ b/apps/cli/src/tools/send/send.program.ts
@@ -57,11 +57,11 @@ export class SendProgram extends BaseProgram {
         new Option(
           "--password <password>",
           "optional password to access this Send. Can also be specified in JSON.",
-        ).conflicts("email"),
+        ).conflicts("emails"),
       )
       .addOption(
         new Option(
-          "--email <email>",
+          "--emails <emails>",
           "optional emails to access this Send. Can also be specified in JSON.",
         ).argParser(parseEmail),
       )
@@ -85,9 +85,11 @@ export class SendProgram extends BaseProgram {
       .addCommand(this.removePasswordCommand())
       .addCommand(this.deleteCommand())
       .action(async (data: string, options: OptionValues) => {
-        if (options.email) {
+        if (options.emails) {
           if (!emailAuthEnabled) {
-            this.processResponse(Response.error("The --email feature is not currently available."));
+            this.processResponse(
+              Response.error("The --emails feature is not currently available."),
+            );
             return;
           }
         }
@@ -225,11 +227,13 @@ export class SendProgram extends BaseProgram {
       })
       .action(async (encodedJson: string, options: OptionValues, args: { parent: Command }) => {
         // subcommands inherit flags from their parent; they cannot override them
-        const { fullObject = false, email = undefined, password = undefined } = args.parent.opts();
+        const { fullObject = false, emails = undefined, password = undefined } = args.parent.opts();
 
-        if (email) {
+        if (emails) {
           if (!emailAuthEnabled) {
-            this.processResponse(Response.error("The --email feature is not currently available."));
+            this.processResponse(
+              Response.error("The --emails feature is not currently available."),
+            );
             return;
           }
         }
@@ -237,7 +241,7 @@ export class SendProgram extends BaseProgram {
         const mergedOptions = {
           ...options,
           fullObject: fullObject,
-          email,
+          emails,
           password,
         };
 
@@ -262,10 +266,12 @@ export class SendProgram extends BaseProgram {
       })
       .action(async (encodedJson: string, options: OptionValues, args: { parent: Command }) => {
         await this.exitIfLocked();
-        const { email = undefined, password = undefined } = args.parent.opts();
-        if (email) {
+        const { emails = undefined, password = undefined } = args.parent.opts();
+        if (emails) {
           if (!emailAuthEnabled) {
-            this.processResponse(Response.error("The --email feature is not currently available."));
+            this.processResponse(
+              Response.error("The --emails feature is not currently available."),
+            );
             return;
           }
         }
@@ -288,7 +294,7 @@ export class SendProgram extends BaseProgram {
 
         const mergedOptions = {
           ...options,
-          email,
+          emails,
           password,
         };
 
@@ -353,7 +359,7 @@ export class SendProgram extends BaseProgram {
       file: sendFile,
       text: sendText,
       type: type,
-      emails: options.email ?? undefined,
+      emails: options.emails ?? undefined,
     });
 
     return Buffer.from(JSON.stringify(template), "utf8").toString("base64");


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-32182

## 📔 Objective

The flag used to specify emails when creating or editing a send is currently --email but the backing model property is named emails. This story updates the command line flag to --emails for consistency. 
