### PR TITLE
[PM-31766]  Location of 'Send link' input is incorrect

### DIFF
--- a/libs/tools/send/send-ui/src/send-form/components/send-details/send-details.component.html
+++ b/libs/tools/send/send-ui/src/send-form/components/send-details/send-details.component.html
@@ -21,20 +21,6 @@
       [originalSendView]="originalSendView"
     ></tools-send-file-details>
 
-    <bit-form-field *ngIf="sendLink">
-      <bit-label>{{ "sendLink" | i18n }}</bit-label>
-      <input data-testid="send-link" bitInput type="text" [value]="sendLink" disabled />
-      <button
-        type="button"
-        bitSuffix
-        showToast
-        bitIconButton="bwi-clone"
-        [appCopyClick]="sendLink"
-        [valueLabel]="'sendLink' | i18n"
-        [label]="'copySendLink' | i18n"
-      ></button>
-    </bit-form-field>
-
     <bit-form-field>
       <bit-label>{{ "deletionDate" | i18n }}</bit-label>
       <bit-select
@@ -126,6 +112,20 @@
         <bit-hint>{{ "enterMultipleEmailsSeparatedByComma" | i18n }}</bit-hint>
       </bit-form-field>
     }
+
+    <bit-form-field *ngIf="sendLink" class="tw-mt-4">
+      <bit-label>{{ "sendLink" | i18n }}</bit-label>
+      <input data-testid="send-link" bitInput type="text" [value]="sendLink" disabled />
+      <button
+        type="button"
+        bitSuffix
+        showToast
+        bitIconButton="bwi-clone"
+        [appCopyClick]="sendLink"
+        [valueLabel]="'sendLink' | i18n"
+        [label]="'copySendLink' | i18n"
+      ></button>
+    </bit-form-field>
   </bit-card>
   <tools-send-options [config]="config" [originalSendView]="originalSendView"></tools-send-options>
 </bit-section>


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-31766

## 📔 Objective

The "Send Link" form field was not positioned according to [design specs](https://www.figma.com/design/Wqxyfz2gnEJBzxeIl6MHrl/Email-verification-for-Send?node-id=6708-22112&t=VWb23bBOT7vE8lyv-1)

## 📸 Screenshots

### No auth 
<img width="575" height="801" alt="Screenshot 2026-02-12 at 17 26 59" src="https://github.com/user-attachments/assets/53397311-a2a7-432c-9d09-226436d4f499" />

### Password auth 
<img width="575" height="801" alt="Screenshot 2026-02-12 at 17 27 19" src="https://github.com/user-attachments/assets/8e8b107f-8c5e-4578-97ea-4e0ed05a5a8d" />

### Email OTP auth
<img width="575" height="801" alt="Screenshot 2026-02-12 at 17 27 11" src="https://github.com/user-attachments/assets/5b8f8591-1098-4b6a-a97b-8824856065fb" />
