### PR TITLE
[BRE-1621] appx manifest fix poc

### DIFF
--- a/apps/desktop/custom-appx-manifest.xml
+++ b/apps/desktop/custom-appx-manifest.xml
@@ -5,7 +5,7 @@
     xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10"
     xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities">
     <!-- use single quotes to avoid double quotes escaping in the publisher value  -->
-    <Identity Name="${applicationId}"
+    <Identity Name="${identityName}"
         ProcessorArchitecture="${arch}"
         Publisher='${publisher}'
         Version="${version}" />

--- a/apps/desktop/electron-builder.beta.json
+++ b/apps/desktop/electron-builder.beta.json
@@ -63,7 +63,7 @@
     "backgroundColor": "#175DDC",
     "applicationId": "BitwardenBeta",
     "identityName": "8bitSolutionsLLC.BitwardenBeta",
-    "publisher": "CN=Bitwarden Inc., O=Bitwarden Inc., L=Santa Barbara, S=California, C=US, SERIALNUMBER=7654941, OID.2.5.4.15=Private Organization, OID.1.3.6.1.4.1.311.60.2.1.2=Delaware, OID.1.3.6.1.4.1.311.60.2.1.3=US",
+    "publisher": "CN=14D52771-DE3C-4886-B8BF-825BA7690418",
     "publisherDisplayName": "Bitwarden Inc",
     "languages": [
       "en-US",

--- a/apps/desktop/electron-builder.json
+++ b/apps/desktop/electron-builder.json
@@ -178,7 +178,7 @@
     "backgroundColor": "#175DDC",
     "applicationId": "bitwardendesktop",
     "identityName": "8bitSolutionsLLC.bitwardendesktop",
-    "publisher": "CN=Bitwarden Inc., O=Bitwarden Inc., L=Santa Barbara, S=California, C=US, SERIALNUMBER=7654941, OID.2.5.4.15=Private Organization, OID.1.3.6.1.4.1.311.60.2.1.2=Delaware, OID.1.3.6.1.4.1.311.60.2.1.3=US",
+    "publisher": "CN=14D52771-DE3C-4886-B8BF-825BA7690418",
     "publisherDisplayName": "Bitwarden Inc",
     "languages": [
       "en-US",

--- a/apps/desktop/scripts/appx-cross-build.ps1
+++ b/apps/desktop/scripts/appx-cross-build.ps1
@@ -177,6 +177,7 @@ $translationMap = @{
     'applicationId' = $builderConfig.appx.applicationId
     'displayName' = $productName
     'executable' = "app\${productName}.exe"
+    'identityName' = $builderConfig.appx.identityName
     'publisher' = $builderConfig.appx.publisher
     'publisherDisplayName' = $builderConfig.appx.publisherDisplayName
     'version' = $version

--- a/apps/desktop/sign.js
+++ b/apps/desktop/sign.js
@@ -3,7 +3,7 @@ const child_process = require("child_process");
 
 exports.default = async function (configuration) {
   const ext = configuration.path.split(".").at(-1);
-  if (parseInt(process.env.ELECTRON_BUILDER_SIGN) === 1 && ["exe", "appx"].includes(ext)) {
+  if (parseInt(process.env.ELECTRON_BUILDER_SIGN) === 1 && ["exe"].includes(ext)) {
     console.log(`[*] Signing file: ${configuration.path}`);
     child_process.execFileSync(
       "azuresigntool",


### PR DESCRIPTION
## 🎟️ Tracking
[BRE-1621](https://bitwarden.atlassian.net/browse/BRE-1621)

## 📔 Objective
We introduced a MinVersion key in the appx custom manifest that is too restrictive, resulting in our desktop app not showing up for users in the windows app store.

This PR reverts the use of a custom appx manifest, falling back to previous behavior of using electron-builder for the manifest generation which dynamically sets the MinVersion based on arm versus x64, among other changes

[BRE-1621]: https://bitwarden.atlassian.net/browse/BRE-1621?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ