### PR TITLE
[PM-32223] Fix file type Send access when using CLI receive command and email OTP authentication 

### DIFF
--- a/libs/common/src/tools/send/services/send-api.service.ts
+++ b/libs/common/src/tools/send/services/send-api.service.ts
@@ -105,7 +105,7 @@ export class SendApiService implements SendApiServiceAbstraction {
       "POST",
       "/sends/access/file/" + send.file.id,
       null,
-      true,
+      false,
       true,
       apiUrl,
       setAuthTokenHeader,


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-32223

## 📔 Objective

A logical bug was discovered when testing the CLI. Specifically, when the receive command was used to access a file type Send protected by email OTP authentication, the request headers erroneously identified the request as non-anonymous. 
