### PR TITLE
[PM-31322] Automatically focus accept button in delete Send confirmation dialog

### DIFF
--- a/libs/components/src/dialog/simple-dialog/simple-configurable-dialog/simple-configurable-dialog.component.html
+++ b/libs/components/src/dialog/simple-dialog/simple-configurable-dialog/simple-configurable-dialog.component.html
@@ -6,7 +6,7 @@
   <div bitDialogContent>{{ content }}</div>
 
   <ng-container bitDialogFooter>
-    <button type="submit" bitButton bitFormButton buttonType="primary">
+    <button type="submit" bitButton bitFormButton buttonType="primary" appAutoFocus>
       {{ acceptButtonText }}
     </button>
 

--- a/libs/tools/send/send-ui/src/send-table/send-table.component.html
+++ b/libs/tools/send/send-ui/src/send-table/send-table.component.html
@@ -101,7 +101,7 @@
                 {{ "removePassword" | i18n }}
               </button>
             }
-            <button type="button" bitMenuItem (click)="onDelete(s)">
+            <button type="button" bitMenuItem (click)="onDelete($event, s)">
               <span class="tw-text-danger">
                 <i class="bwi bwi-fw bwi-trash" aria-hidden="true"></i>
                 {{ "delete" | i18n }}

--- a/libs/tools/send/send-ui/src/send-table/send-table.component.ts
+++ b/libs/tools/send/send-ui/src/send-table/send-table.component.ts
@@ -88,7 +88,14 @@ export class SendTableComponent {
     this.removePassword.emit(send);
   }
 
-  protected onDelete(send: SendView): void {
+  protected onDelete(event: Event, send: SendView): void {
+    /**
+     * We stop the click event propagation here so that the options menu will not close; if it
+     * does close then the button that triggers the menu will steal the focus from the accept
+     * button of the simple delete confirmation dialog that we open in the base Send component.
+     * See the 'bitMenuTriggerFor' directive for where this occurs in code.
+     */
+    event.stopPropagation();
     this.deleteSend.emit(send);
   }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-31322

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR makes it so that the "Accept" button of a simple dialog is automatically focused when the dialog opens. 

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/c53bc594-b4dd-41f3-b314-57907ad03dd0
