### PR TITLE
[PM-32244]  The page header is incorrect when viewing a Password protected Send

### DIFF
--- a/apps/web/src/app/tools/send/send-access/send-auth.component.ts
+++ b/apps/web/src/app/tools/send/send-access/send-auth.component.ts
@@ -73,7 +73,6 @@ export class SendAuthComponent implements OnInit {
   ) {}
 
   ngOnInit() {
-    this.updatePageTitle();
     void this.onSubmit();
   }
 
@@ -226,6 +225,10 @@ export class SendAuthComponent implements OnInit {
           pageTitle: { key: "verifyYourEmailToViewThisSend" },
         });
       }
+    } else if (authType === AuthType.Password) {
+      this.anonLayoutWrapperDataService.setAnonLayoutWrapperData({
+        pageTitle: { key: "sendAccessPasswordTitle" },
+      });
     }
   }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-32244

## 📔 Objective

Update age header when accessing a password protected Send to better reflect expected user action. 

## 📸 Screenshots

<img width="477" height="598" alt="Screenshot 2026-02-13 at 15 53 16" src="https://github.com/user-attachments/assets/9284f776-5b3a-4f94-83e6-5e6d2b58de92" />

See https://github.com/bitwarden/clients/pull/18989 for other (in-flight) design changes to this component