### PR TITLE
[PM-32241]  Message is incorrectly formatted for password protected Send

### DIFF
--- a/apps/web/src/app/tools/send/send-access/send-access-password.component.html
+++ b/apps/web/src/app/tools/send/send-access/send-access-password.component.html
@@ -1,8 +1,7 @@
-<p bitTypography="body1">{{ "sendProtectedPassword" | i18n }}</p>
-<p bitTypography="body1">{{ "sendProtectedPasswordDontKnow" | i18n }}</p>
 <bit-form-field>
   <bit-label>{{ "password" | i18n }}</bit-label>
   <input bitInput type="password" [formControl]="password" required appInputVerbatim appAutofocus />
+  <bit-hint>{{ "sendProtectedPasswordDontKnow" | i18n }}</bit-hint>
   <button type="button" bitIconButton bitSuffix bitPasswordInputToggle></button>
 </bit-form-field>
 <div class="tw-flex">


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-32241

## 📔 Objective

When a recipient is accessing a password protected Send, the “Don’t know the password?…“ message should be converted as helper text. 

The “This Send is protected with a password. Please type the password below to continue.“ text can be removed. This is self-explanatory given the input is labeled “Password“

## 📸 Screenshots

<img width="477" height="598" alt="Screenshot 2026-02-13 at 16 05 04" src="https://github.com/user-attachments/assets/7b55621c-f3e0-4938-b4df-a9c152db89ba" />

See https://github.com/bitwarden/clients/pull/18988 for other (in-flight) design changes to this component