### PR TITLE
[PM-32342] Fix high CPU usage on flatpak / wayland

### DIFF
--- a/apps/desktop/resources/com.bitwarden.desktop.devel.yaml
+++ b/apps/desktop/resources/com.bitwarden.desktop.devel.yaml
@@ -53,4 +53,8 @@ modules:
           - export TMPDIR="$XDG_RUNTIME_DIR/app/$FLATPAK_ID"
           - export ZYPAK_LD_PRELOAD="/app/bin/libprocess_isolation.so"
           - export PROCESS_ISOLATION_LD_PRELOAD="/app/bin/libprocess_isolation.so"
-          - exec zypak-wrapper /app/bin/bitwarden-app "$@"
+          - PARAMS="--enable-features=UseOzonePlatform,WaylandWindowDecorations --ozone-platform-hint=auto"
+          - if [ "$USE_X11" != "false" ]; then
+          - PARAMS="--ozone-platform=x11"
+          - fi
+          - exec zypak-wrapper /app/bin/bitwarden-app "$@" "$PARAMS"


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-32342

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

While wayland is active, with electron 39 regressions, CPU usage goes to 100-400% even while the window is closed. Forcing X11 fixes this. This still leaves an opt-out via the USE_X11 environment variable.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
