### PR TITLE
[bre-1628] cherry pick release workflow change

### DIFF
--- a/.github/workflows/release-web.yml
+++ b/.github/workflows/release-web.yml
@@ -97,4 +97,3 @@ jobs:
           artifacts: "apps/web/artifacts/web-${{ needs.setup.outputs.release_version }}-selfhosted-COMMERCIAL.zip,
             apps/web/artifacts/web-${{ needs.setup.outputs.release_version }}-selfhosted-open-source.zip"
           token: ${{ secrets.GITHUB_TOKEN }}
-          draft: true


### PR DESCRIPTION
## 🎟️ Tracking

[bre-1628](https://bitwarden.atlassian.net/browse/bre-1628)

## 📔 Objective

We want to temporarily remove the draft: true key for testing release process enhancements for the next release. This key being passed results in the git tag not being created until we go and manually publish the draft GH release, meaning the following publish workflow will fail.