### PR TITLE
[PM-30122] allow no folders inside browser folder settings

### DIFF
--- a/apps/browser/src/vault/popup/settings/folders.component.spec.ts
+++ b/apps/browser/src/vault/popup/settings/folders.component.spec.ts
@@ -94,11 +94,12 @@ describe("FoldersComponent", () => {
     fixture.detectChanges();
   });
 
-  it("removes the last option in the folder array", (done) => {
+  it("should show all folders", (done) => {
     component.folders$.subscribe((folders) => {
       expect(folders).toEqual([
         { id: "1", name: "Folder 1" },
         { id: "2", name: "Folder 2" },
+        { id: "0", name: "No Folder" },
       ]);
       done();
     });

--- a/apps/browser/src/vault/popup/settings/folders.component.ts
+++ b/apps/browser/src/vault/popup/settings/folders.component.ts
@@ -53,13 +53,6 @@ export class FoldersComponent {
     this.folders$ = this.activeUserId$.pipe(
       filter((userId): userId is UserId => userId !== null),
       switchMap((userId) => this.folderService.folderViews$(userId)),
-      map((folders) => {
-        // Remove the last folder, which is the "no folder" option folder
-        if (folders.length > 0) {
-          return folders.slice(0, folders.length - 1);
-        }
-        return folders;
-      }),
     );
   }
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-30122](https://bitwarden.atlassian.net/browse/PM-30122)

## 📔 Objective

The screen recording below shows the initial bug not being reproduce-able, as well as showing the `No Folders` option inside the Folder Settings page. View ticket for more details.

## 📸 Screen Recording



https://github.com/user-attachments/assets/ea5a6c1a-5ec3-4842-8a44-855d172b42b3



[PM-30122]: https://bitwarden.atlassian.net/browse/PM-30122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ