### PR TITLE
[PM-32412] -  fix click on "Fill" text

### DIFF
--- a/apps/browser/src/vault/popup/components/vault/vault-list-items-container/vault-list-items-container.component.html
+++ b/apps/browser/src/vault/popup/components/vault/vault-list-items-container/vault-list-items-container.component.html
@@ -90,7 +90,13 @@
       </ng-container>
 
       <cdk-virtual-scroll-viewport [itemSize]="itemHeight$ | async" bitScrollLayout>
-        <bit-item *cdkVirtualFor="let cipher of group.ciphers" class="tw-group/vault-item">
+        <bit-item
+          *cdkVirtualFor="let cipher of group.ciphers"
+          class="tw-group/vault-item"
+          [ngClass]="{
+            'hover:tw-bg-hover-default hover:tw-cursor-pointer': showFillTextOnHover(),
+          }"
+        >
           <button
             bit-item-content
             type="button"
@@ -127,11 +133,13 @@
           <ng-container slot="end">
             @if (showFillTextOnHover()) {
               <bit-item-action>
-                <span
-                  class="tw-opacity-0 tw-text-sm tw-text-primary-600 tw-px-2 group-hover/vault-item:tw-opacity-100 group-focus-within/vault-item:tw-opacity-100 tw-cursor-pointer"
+                <button
+                  type="button"
+                  (click)="doAutofill(cipher)"
+                  class="tw-opacity-0 tw-text-primary-600 tw-px-2 tw-bg-transparent tw-border-0 group-hover/vault-item:tw-opacity-100 group-focus-within/vault-item:tw-opacity-100"
                 >
                   {{ "fill" | i18n }}
-                </span>
+                </button>
               </bit-item-action>
             }
             @if (showAutofillBadge()) {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-32412

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR fixes an issue where clicking directly on the "Fill" text didn't correctly autofill. It also fixes an issue where the cursor would change to arrow when within the padding of the `<bit-item>` and the background highlight would be lost.



## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

Before

https://github.com/user-attachments/assets/0727c852-713c-4998-ae17-28ffc35ac843

After

https://github.com/user-attachments/assets/87c236f3-d637-43a0-a742-d6ce28da9718

