### PR TITLE
[PM-32426] Add DIRT team standards documentation

### DIFF
--- a/bitwarden_license/bit-common/src/dirt/docs/standards/README.md
+++ b/bitwarden_license/bit-common/src/dirt/docs/standards/README.md
@@ -1,0 +1,118 @@
+# DIRT Team - Development Standards
+
+**Purpose:** Hub for all DIRT team development standards and conventions
+
+**Last Updated:** 2026-02-13
+
+---
+
+## 📚 Standards Files
+
+### Data Models
+
+**[model-standards.md](./model-standards.md)**
+
+View model construction patterns, 4-layer architecture (Api/Data/Domain/View), and EncString handling.
+
+---
+
+### Services
+
+**[service-standards.md](./service-standards.md)**
+
+Service responsibility patterns, helper function guidelines, and service design principles.
+
+---
+
+### RxJS
+
+**[rxjs-standards.md](./rxjs-standards.md)**
+
+Observable patterns, RxJS best practices, hot vs cold observables, and common import paths.
+
+---
+
+### Angular
+
+**[angular-standards.md](./angular-standards.md)**
+
+Angular-specific patterns including state management with Observables and Signals.
+
+---
+
+### Code Organization
+
+**[code-organization-standards.md](./code-organization-standards.md)**
+
+Naming conventions, file organization, comment standards, and where to document architectural decisions.
+
+---
+
+### Documentation
+
+**[documentation-standards.md](./documentation-standards.md)**
+
+Documentation file naming, metadata requirements, structure standards, and content guidelines.
+
+---
+
+### Testing - Services
+
+**[testing-standards-services.md](./testing-standards-services.md)**
+
+Testing standards for platform-agnostic services including test structure, mocking patterns, and coverage guidelines.
+
+---
+
+### Testing - Components
+
+**[testing-standards-components.md](./testing-standards-components.md)**
+
+Testing standards for Angular components including OnPush testing, Signal testing, and Storybook integration.
+
+---
+
+## 🎯 Quick Navigation
+
+**By Task:**
+
+| What are you doing?                    | Read this                                                            |
+| -------------------------------------- | -------------------------------------------------------------------- |
+| Implementing models (Data/Domain/View) | [model-standards.md](./model-standards.md)                           |
+| Implementing services                  | [service-standards.md](./service-standards.md)                       |
+| Working with Observables               | [rxjs-standards.md](./rxjs-standards.md)                             |
+| Building Angular components            | [angular-standards.md](./angular-standards.md)                       |
+| Organizing code/naming                 | [code-organization-standards.md](./code-organization-standards.md)   |
+| Writing documentation                  | [documentation-standards.md](./documentation-standards.md)           |
+| Writing service tests                  | [testing-standards-services.md](./testing-standards-services.md)     |
+| Writing component tests                | [testing-standards-components.md](./testing-standards-components.md) |
+
+---
+
+## 🆕 Adding New Standards
+
+**When to create a new standards file:**
+
+- New technology or framework adopted (e.g., signals-standards.md)
+- Existing file becomes too large (>500 lines)
+- New domain requires comprehensive guidelines
+
+**When to add to existing file:**
+
+- Extending existing standards with new patterns
+- Adding examples or clarifications
+- Small additions (<50 lines)
+
+**Process:**
+
+1. Follow [Documentation Playbook](../playbooks/documentation-playbook.md)
+2. Create new file in standards/ folder
+3. Add to this README with description
+4. Update related playbooks and guides
+5. Update getting-started.md if it's a primary entry point
+
+---
+
+**Document Version:** 1.0
+**Last Updated:** 2026-02-17
+**Maintainer:** DIRT Team

--- a/bitwarden_license/bit-common/src/dirt/docs/standards/angular-standards.md
+++ b/bitwarden_license/bit-common/src/dirt/docs/standards/angular-standards.md
@@ -1,0 +1,125 @@
+# Angular Standards
+
+**Purpose:** Standards for Angular-specific state management patterns, including Observable vs Signal usage, mutation patterns, and smart model implementation in Access Intelligence development
+
+---
+
+## Angular State Management
+
+### Observable vs Signal (ADR-0027 Compliance)
+
+**Service Layer (Platform-Agnostic):**
+
+- **Always use RxJS Observables** for domain services
+- Services expose state as `Observable<T>` (BehaviorSubject internally)
+- Ensures compatibility with web, desktop, browser, and CLI
+
+**Component Layer (Angular-Specific):**
+
+- **Preferred**: Convert Observable to Signal using `toSignal()`
+- **Acceptable**: Use `async` pipe in templates
+- **Avoid**: Manual subscriptions unless absolutely necessary
+
+**Example:**
+
+```typescript
+// Service (platform-agnostic)
+export class DefaultAccessIntelligenceDataService {
+  private _report = new BehaviorSubject<RiskInsightsView | null>(null);
+  readonly report$ = this._report.asObservable();
+}
+
+// Component (Angular-specific, uses OnPush)
+@Component({ changeDetection: ChangeDetectionStrategy.OnPush })
+export class RiskInsightsComponent {
+  protected report = toSignal(this.dataService.report$, { initialValue: null });
+
+  // Template: {{ report()?.summary.totalApplicationCount }}
+}
+```
+
+### Mutation vs Immutability
+
+**View Models are Mutable** (following CipherView pattern):
+
+- `RiskInsightsView`, `CipherView`, `FolderView` are all mutable
+- Update methods mutate in place and call `recomputeSummary()` or similar
+- Memory-efficient for large objects (10-15 MB reports)
+- Avoids expensive deep clones
+
+**Service emits after mutation to trigger subscribers:**
+
+```typescript
+// ✅ CORRECT - Mutation + emit
+const view = this._report.value;
+view.markApplicationAsCritical("github.com"); // Mutate in place
+this._report.next(view); // Emit same reference
+
+// ❌ WRONG - Creating new instance
+const newView = structuredClone(view); // 10-15 MB allocation!
+newView.markApplicationAsCritical("github.com");
+this._report.next(newView);
+```
+
+**Why mutation + Observable works with OnPush:**
+
+- `async` pipe calls `ChangeDetectorRef.markForCheck()` on ANY emission
+- Signal updates trigger automatic change detection
+- Reference equality doesn't matter - emission itself triggers update
+
+### Smart Models (CipherView Pattern)
+
+**View models should have business logic methods** - don't be "dumb data bags".
+
+**RiskInsightsView follows this pattern:**
+
+```typescript
+export class RiskInsightsView {
+  // Query Methods (read-only)
+  getAtRiskMembers(): MemberRegistryEntry[];
+  getCriticalApplications(): RiskInsightsReportView[];
+  getNewApplications(): RiskInsightsReportView[];
+  getApplicationByName(name: string): RiskInsightsReportView | undefined;
+  getTotalMemberCount(): number;
+
+  // Update Methods (mutate + recompute)
+  markApplicationAsCritical(appName: string): void;
+  unmarkApplicationAsCritical(appName: string): void;
+  markApplicationAsReviewed(appName: string, date?: Date): void;
+
+  // Computation Methods
+  recomputeSummary(): void;
+}
+```
+
+**Why:**
+
+- Business logic lives on the model, not scattered across services
+- Updating critical apps doesn't require full report regeneration
+- Clean, intuitive API: `view.markApplicationAsCritical(name)`
+- Easy to unit test
+
+---
+
+## Related Documentation
+
+**Standards:**
+
+- [Model Standards](./model-standards.md) - Smart models and view construction patterns
+- [RxJS Standards](./rxjs-standards.md) - Observable patterns for services
+- [Service Standards](./service-standards.md) - Service patterns and state management
+- [Testing Standards - Components](./testing-standards-components.md) - Testing OnPush components with Signals
+
+**Playbooks:**
+
+- [Component Migration Playbook](../playbooks/component-migration-playbook.md) - Migrating components to modern Angular patterns
+
+**Navigation:**
+
+- [Standards Hub](./README.md) - All DIRT team standards
+
+---
+
+**Document Version:** 1.0
+**Last Updated:** 2026-02-17
+**Maintainer:** DIRT Team

--- a/bitwarden_license/bit-common/src/dirt/docs/standards/code-organization-standards.md
+++ b/bitwarden_license/bit-common/src/dirt/docs/standards/code-organization-standards.md
@@ -1,0 +1,436 @@
+# Code Organization Standards
+
+**Purpose:** Standards for naming conventions, code organization, file structure, and documentation practices in Access Intelligence development
+
+---
+
+## Table of Contents
+
+1. [Naming Conventions and Code Organization](#naming-conventions-and-code-organization)
+   - [Observable Naming Convention](#observable-naming-convention)
+   - [Private Variable Naming](#private-variable-naming)
+   - [Hot vs Cold Observables](#hot-vs-cold-observables)
+   - [Function and Method Ordering](#function-and-method-ordering)
+   - [File and Service Naming](#file-and-service-naming)
+2. [Comment and Documentation Standards](#comment-and-documentation-standards)
+   - [Service Abstracts](#service-abstracts)
+   - [Implementation Comments](#implementation-comments)
+   - [TODO Comments](#todo-comments)
+
+---
+
+## Naming Conventions and Code Organization
+
+### Observable Naming Convention
+
+**Rule:** All Observables and functions returning Observables MUST end with `$` suffix.
+
+**Why:** Makes it immediately clear that a value is an Observable stream that can be subscribed to.
+
+**Pattern:**
+
+```typescript
+// ✅ CORRECT - Observable variables
+export class DefaultAccessIntelligenceDataService {
+  private _report = new BehaviorSubject<RiskInsightsView | null>(null);
+  readonly report$ = this._report.asObservable(); // Public observable with $
+
+  // ✅ CORRECT - Functions returning Observables
+  generateReport$(orgId: OrganizationId): Observable<RiskInsightsView> {
+    return this.reportGenerationService.generateReport$(ciphers, members, ...);
+  }
+
+  loadReport$(reportId: string): Observable<RiskInsightsView> {
+    return this.apiService.getReport$(reportId);
+  }
+}
+
+// ❌ WRONG - Missing $ suffix
+readonly report = this._report.asObservable(); // Hard to tell it's an Observable
+generateReport(orgId: OrganizationId): Observable<...> // Unclear return type
+```
+
+**Applies to:**
+
+- Observable variables (`report$`, `drawer$`, `ciphers$`)
+- Functions returning Observables (`generateReport$()`, `save$()`, `load$()`)
+- Observable properties in interfaces
+- Observable parameters (when not obvious from context)
+
+**Exception:** Parameters where type is clear from signature can omit `$` if it improves readability:
+
+```typescript
+// Acceptable - type signature is clear
+function combineReports(
+  current: Observable<RiskInsightsView>,
+  previous: Observable<RiskInsightsView>,
+): Observable<RiskInsightsView>;
+```
+
+### Private Variable Naming
+
+**Rule:** Private BehaviorSubject/Subject variables should use underscore prefix.
+
+**Why:**
+
+- Distinguishes private observable source from public observable stream
+- Common TypeScript/Angular convention
+- Makes the private/public pair relationship obvious
+
+**Pattern:**
+
+```typescript
+// ✅ CORRECT - Private source with _, public observable with $
+export class DefaultAccessIntelligenceDataService {
+  private _report = new BehaviorSubject<RiskInsightsView | null>(null);
+  readonly report$ = this._report.asObservable();
+
+  private _drawerState = new BehaviorSubject<DrawerState>(defaultState);
+  readonly drawerState$ = this._drawerState.asObservable();
+
+  updateReport(view: RiskInsightsView): void {
+    this._report.next(view); // Clearly using the private source
+  }
+}
+
+// ❌ WRONG - No underscore prefix
+private reportSubject = new BehaviorSubject<RiskInsightsView | null>(null);
+readonly report$ = this.reportSubject.asObservable();
+```
+
+**Applies to:**
+
+- BehaviorSubject instances
+- Subject instances
+- ReplaySubject instances
+
+**Does NOT apply to:**
+
+- Regular private methods
+- Regular private properties (non-Observable)
+- Private service dependencies
+
+### Hot vs Cold Observables
+
+Understanding the difference is critical for proper service design.
+
+**Cold Observables** (Each subscription creates new execution):
+
+```typescript
+// ❌ BAD - Every subscription triggers new HTTP request
+getReport$(id: string): Observable<RiskInsightsView> {
+  return this.http.get<RiskInsightsApi>(`/api/reports/${id}`).pipe(
+    map(api => RiskInsightsView.fromJSON(api))
+  );
+}
+
+// Usage - 3 subscriptions = 3 HTTP requests!
+service.getReport$("123").subscribe(...);
+service.getReport$("123").subscribe(...);
+service.getReport$("123").subscribe(...);
+```
+
+**Hot Observables** (Shared execution across subscriptions):
+
+```typescript
+// ✅ GOOD - BehaviorSubject shares state across all subscribers
+export class DefaultAccessIntelligenceDataService {
+  private _report = new BehaviorSubject<RiskInsightsView | null>(null);
+  readonly report$ = this._report.asObservable();
+
+  loadAndCacheReport$(id: string): Observable<RiskInsightsView> {
+    return this.http.get<RiskInsightsApi>(`/api/reports/${id}`).pipe(
+      map(api => RiskInsightsView.fromJSON(api)),
+      tap(view => this._report.next(view)) // Cache in BehaviorSubject
+    );
+  }
+}
+
+// Usage - 3 subscriptions to report$ = same data, no extra requests
+service.report$.subscribe(...);
+service.report$.subscribe(...);
+service.report$.subscribe(...);
+```
+
+**Converting Cold to Hot (shareReplay):**
+
+```typescript
+// ✅ GOOD - Use shareReplay to share execution
+generateReport$(orgId: OrganizationId): Observable<RiskInsightsView> {
+  return this.reportGenerationService.generateReport$(...).pipe(
+    shareReplay({ bufferSize: 1, refCount: true })
+  );
+  // Multiple subscribers = single execution
+}
+```
+
+**When to use which:**
+
+| Pattern             | Use When                                                 | Example                    |
+| ------------------- | -------------------------------------------------------- | -------------------------- |
+| **BehaviorSubject** | Shared state, needs current value                        | `report$`, `drawer$`       |
+| **Cold Observable** | One-time operations, each subscriber needs own execution | Single HTTP GET            |
+| **shareReplay**     | Expensive operation, want to share result                | Report generation pipeline |
+| **Subject**         | Event bus, no initial value needed                       | User action events         |
+
+### Function and Method Ordering
+
+**Rule:** Organize class members by visibility and feature, not alphabetically.
+
+**Standard Order:**
+
+```typescript
+export class DefaultReportGenerationService {
+  // 1. Constructor & DI
+  constructor(
+    private cipherHealthService: CipherHealthService,
+    private memberMappingService: MemberCipherMappingService,
+  ) {}
+
+  // 2. Public API Methods (grouped by feature)
+  // === Report Generation (Primary Feature) ===
+  generateReport$(
+    ciphers: CipherView[],
+    members: OrganizationUserView[],
+  ): Observable<RiskInsightsView> {
+    // ...
+  }
+
+  // === Health Checks (Secondary Feature) ===
+  checkCipherHealth$(ciphers: CipherView[]): Observable<HealthMap> {
+    // ...
+  }
+
+  // 3. Private Helper Methods (grouped by feature)
+  // === Private: Aggregation Helpers ===
+  private aggregateIntoReports(
+    ciphers: CipherView[],
+    healthMap: Map<string, CipherHealthView>,
+  ): RiskInsightsReportView[] {
+    // ...
+  }
+
+  private groupCiphersByApplication(ciphers: CipherView[]): Map<string, CipherView[]> {
+    // ...
+  }
+
+  // === Private: Summary Helpers ===
+  private computeSummary(reports: RiskInsightsReportView[]): RiskInsightsSummaryView {
+    // ...
+  }
+}
+```
+
+**Ordering Principles:**
+
+1. **Constructor first** - Always at the top
+2. **Public before private** - API surface is most important
+3. **Group by feature/responsibility** - Not alphabetical
+4. **Related methods together** - Easier to understand flow
+5. **Section comments** - Use `// ===` to mark feature groups
+
+**Angular Components (special case):**
+
+```typescript
+@Component({ ... })
+export class RiskInsightsComponent {
+  // 1. Inputs/Outputs
+  @Input() organizationId!: string;
+  @Output() reportGenerated = new EventEmitter<void>();
+
+  // 2. Public properties (used in template)
+  report = toSignal(this.dataService.report$);
+
+  // 3. Constructor
+  constructor(private dataService: AccessIntelligenceDataService) {}
+
+  // 4. Lifecycle hooks (in Angular lifecycle order)
+  ngOnInit() { ... }
+  ngOnDestroy() { ... }
+
+  // 5. Public methods (grouped by feature)
+  // === Report Actions ===
+  generateReport(): void { ... }
+
+  // === Application Actions ===
+  markAsCritical(name: string): void { ... }
+
+  // 6. Private methods
+  private loadData(): void { ... }
+}
+```
+
+**Why not alphabetical?**
+
+- Features are more important than names
+- Related methods should be adjacent
+- Easier to navigate and understand
+- Matches how code is typically read (top-down by feature)
+
+### File and Service Naming
+
+**Services:**
+
+- Prefix: `access-intelligence-*` or `ai-*` for this feature area
+- Suffix: `*.service.ts` for services
+- Kebab-case: `access-intelligence-data.service.ts`
+
+**Implementations:**
+
+- Prefix with `Default`: `default-access-intelligence-data.service.ts`
+- Alternative implementations: `mock-access-intelligence-data.service.ts`
+
+**Abstractions:**
+
+- Same name as implementation, in `abstractions/` folder
+- `abstractions/access-intelligence-data.service.ts`
+
+**Example Structure:**
+
+```
+services/
+├── abstractions/
+│   ├── report-generation.service.ts          (abstract class)
+│   ├── cipher-health.service.ts              (abstract class)
+│   └── member-cipher-mapping.service.ts      (abstract class)
+└── implementations/
+    ├── default-report-generation.service.ts
+    ├── default-cipher-health.service.ts
+    └── default-member-cipher-mapping.service.ts
+```
+
+### Documentation File Naming
+
+**See:** [Documentation Standards](./documentation-standards.md#naming-conventions) for complete documentation naming conventions.
+
+**Quick reference:**
+
+- **Meta files:** `README.md`, `CLAUDE.md` (ALL CAPS)
+- **Regular docs:** `lowercase-kebab-case.md`
+- **Playbooks:** `[topic]-playbook.md`
+- **ADRs:** `NNN-descriptive-title.md`
+
+---
+
+## Comment and Documentation Standards
+
+### Service Abstracts
+
+**Purpose:** API contract and primary documentation. Focus on WHAT, not WHY or HOW.
+
+**DO:**
+
+- Describe what the service does (1-2 sentences)
+- Document parameters with `@param`, returns with `@returns`
+- Provide usage examples with `@example`
+- Explain input/output structure
+
+**DON'T:**
+
+- Include architectural decisions (belongs in architecture docs)
+- Explain WHY certain approaches were chosen
+- Document performance characteristics or trade-offs
+- Add TODO comments
+
+**Good Example:**
+
+````typescript
+/**
+ * Generates Risk Insights reports from pre-loaded organization data.
+ *
+ * Orchestrates health checks, member mapping, aggregation, and summary computation
+ * to produce a complete RiskInsightsView. Does NOT handle data loading or persistence.
+ *
+ * @param ciphers - Organization ciphers to analyze
+ * @param members - Organization members/users
+ * @returns Observable of complete RiskInsightsView ready for persistence
+ *
+ * @example
+ * ```typescript
+ * this.reportGenService.generateReport(ciphers, members, collectionAccess, groupMemberships)
+ *   .pipe(switchMap(report => this.persistenceService.save(report)))
+ *   .subscribe();
+ * ```
+ */
+abstract generateReport(...): Observable<RiskInsightsView>;
+````
+
+### Implementation Comments
+
+**Purpose:** Explain HOW and WHY for maintainers, not API users.
+
+**DO:**
+
+- Comment on non-obvious implementation choices
+- Explain workarounds or edge cases
+- Document why certain patterns are used (if not obvious)
+
+**DON'T:**
+
+- Repeat what the code already says
+- Add TODO comments (use Jira tickets instead)
+- Over-comment simple operations
+
+**Good Example:**
+
+```typescript
+// Mutate in place to avoid 10-15 MB allocation on each update
+view.markApplicationAsCritical(appName);
+this._report.next(view); // Emit triggers subscribers even with same reference
+```
+
+### TODO Comments
+
+**Rule:** NO TODO comments in abstract classes or production code paths.
+
+**Instead:**
+
+1. Create a Jira ticket for future work
+2. Document in architecture docs if it's a known limitation
+3. Use stub with clear comment if implementation is deferred (rare)
+
+---
+
+## Where to Document Decisions
+
+**Rule:** Architectural decisions and design rationale do NOT belong in code comments or service abstracts.
+
+**See:** [Documentation Standards](./documentation-standards.md#document-location-rules) for guidance on where to document:
+
+- Architecture Decision Records (ADRs)
+- Architecture documentation
+- Implementation decisions
+- Design rationale
+
+**Quick reference:**
+
+- **ADRs** - Major architectural decisions (e.g., "Why Records instead of arrays")
+- **Architecture docs** - System design, flows, patterns
+- **Code comments** - Implementation details, non-obvious logic only
+- **Standards** - Team conventions and patterns
+
+---
+
+## Related Documentation
+
+**Standards:**
+
+- [Documentation Standards](./documentation-standards.md) - Documentation naming, structure, and location rules
+- [RxJS Standards](./rxjs-standards.md) - Observable naming and patterns
+- [Service Standards](./service-standards.md) - Service organization and helper function guidelines
+- [Angular Standards](./angular-standards.md) - Angular-specific patterns
+
+**Playbooks:**
+
+- [Service Implementation Playbook](../playbooks/service-implementation-playbook.md) - Implementing services
+- [Documentation Playbook](../playbooks/documentation-playbook.md) - Creating documentation
+
+**Navigation:**
+
+- [Standards Hub](./README.md) - All DIRT team standards
+
+---
+
+**Document Version:** 1.0
+**Last Updated:** 2026-02-17
+**Maintainer:** DIRT Team

--- a/bitwarden_license/bit-common/src/dirt/docs/standards/documentation-standards.md
+++ b/bitwarden_license/bit-common/src/dirt/docs/standards/documentation-standards.md
@@ -1,0 +1,924 @@
+# Documentation Standards
+
+**Purpose:** Standards and conventions for DIRT team documentation
+
+**Last Updated:** 2026-02-13
+
+---
+
+## Table of Contents
+
+1. [Single Responsibility Principle](#single-responsibility-principle)
+2. [Document Metadata Requirements](#document-metadata-requirements)
+3. [Version Numbering](#version-numbering)
+4. [Document Structure](#document-structure)
+5. [Naming Conventions](#naming-conventions)
+6. [README.md Files](#readmemd-files)
+7. [Document Location Rules](#document-location-rules)
+8. [Cross-Reference Standards](#cross-reference-standards)
+9. [Content Guidelines](#content-guidelines)
+10. [File Structure Diagrams](#file-structure-diagrams)
+
+---
+
+## Single Responsibility Principle
+
+**Rule:** Each document should answer ONE question and serve ONE purpose.
+
+**Why:** Prevents overlapping responsibilities, makes documents easier to maintain, and helps users find information quickly.
+
+### Examples of Single Responsibility
+
+| Document                       | Single Responsibility                                              |
+| ------------------------------ | ------------------------------------------------------------------ |
+| **getting-started.md**         | "WHAT should I read?" (Navigation hub)                             |
+| **documentation-structure.md** | "HOW is documentation organized?" (Structure explanation)          |
+| **integration-guide.md**       | "HOW do services and components integrate?" (Integration patterns) |
+| **standards.md**               | "WHAT are the coding rules?" (Code standards)                      |
+| **documentation-standards.md** | "WHAT are the documentation rules?" (Doc standards)                |
+| **[topic]-playbook.md**        | "HOW do I implement [topic]?" (Step-by-step guide)                 |
+
+### Testing Single Responsibility
+
+**Ask these questions:**
+
+1. **Can I summarize this document's purpose in one sentence?**
+   - ✅ Yes → Good single responsibility
+   - ❌ Need multiple sentences → May be multiple documents
+
+2. **If I remove this document, what information is lost?**
+   - ✅ One specific type of information → Good
+   - ❌ Multiple unrelated types → Split into multiple docs
+
+3. **Does every section support the main purpose?**
+   - ✅ All sections relate to main purpose → Good
+   - ❌ Some sections don't fit → Move to different document
+
+### Example: Overlap We Fixed
+
+**Problem:**
+
+- `documentation-structure.md` had "Which Documentation Should I Use?" (navigation)
+- `getting-started.md` also did navigation
+- Overlapping responsibilities
+
+**Fix:**
+
+- Moved all navigation to `getting-started.md` (single source of truth)
+- `documentation-structure.md` now only explains structure
+- Single responsibility restored
+
+---
+
+## Document Metadata Requirements
+
+**Rule:** Every document MUST include required metadata at top and bottom.
+
+### Required Metadata
+
+**At top of document:**
+
+```markdown
+# [Document Title]
+
+**Purpose:** [One-sentence description of what this document does]
+
+---
+
+[Content goes here]
+```
+
+**At bottom of document:**
+
+```markdown
+---
+
+**Document Version:** X.Y
+**Last Updated:** YYYY-MM-DD
+**Maintainer:** DIRT Team (or specific person/subteam)
+```
+
+### Metadata Field Descriptions
+
+| Field                | Location | Format              | Description                                        |
+| -------------------- | -------- | ------------------- | -------------------------------------------------- |
+| **Title**            | Top      | `# Title`           | Clear, descriptive title using sentence case       |
+| **Purpose**          | Top      | One sentence        | Answers "What question does this document answer?" |
+| **Document Version** | Bottom   | `X.Y`               | Version number (see Version Numbering section)     |
+| **Last Updated**     | Bottom   | `YYYY-MM-DD`        | Date of last significant update                    |
+| **Maintainer**       | Bottom   | Team or person name | Who maintains this document                        |
+
+### Purpose Statement Guidelines
+
+**Good purpose statements:**
+
+- ✅ "Step-by-step guide for creating or updating DIRT team documentation"
+- ✅ "Standards and conventions for DIRT team documentation"
+- ✅ "Explain how documentation is organized across packages"
+- ✅ "Guide for features that span both platform-agnostic services and Angular UI components"
+
+**Bad purpose statements:**
+
+- ❌ "Documentation" (too vague)
+- ❌ "This document covers standards, navigation, and examples" (multiple purposes)
+- ❌ "Guide" (doesn't say what it guides you through)
+
+**Format:**
+
+- One sentence only
+- No period at the end
+- Use present tense
+- Be specific about what the document does
+
+---
+
+## Version Numbering
+
+**Rule:** All documents must have version numbers using semantic versioning (X.Y format).
+
+### Version Format
+
+**Format:** `X.Y`
+
+- **X** = Major version (breaking changes, major restructures)
+- **Y** = Minor version (additions, clarifications, small updates)
+
+### When to Increment
+
+| Change Type           | Version Change       | Example                                      |
+| --------------------- | -------------------- | -------------------------------------------- |
+| **Initial creation**  | Start at `1.0`       | New document created → `1.0`                 |
+| **Minor updates**     | Increment Y          | Add section, clarify content → `1.0` → `1.1` |
+| **Bug fixes**         | Increment Y          | Fix typos, broken links → `1.1` → `1.2`      |
+| **Major restructure** | Increment X, reset Y | Complete reorganization → `1.5` → `2.0`      |
+| **Breaking changes**  | Increment X, reset Y | Change document purpose → `1.3` → `2.0`      |
+
+### Examples
+
+```markdown
+# Service Implementation Playbook
+
+**Purpose:** Step-by-step guide for implementing platform-agnostic services
+
+---
+
+[Content]
+
+---
+
+**Document Version:** 1.0
+**Last Updated:** 2026-02-13
+**Maintainer:** DIRT Team
+```
+
+**Update 1: Add new section**
+
+- Version: `1.0` → `1.1`
+- Last Updated: Update date
+
+**Update 2: Fix broken links**
+
+- Version: `1.1` → `1.2`
+- Last Updated: Update date
+
+**Update 3: Complete restructure**
+
+- Version: `1.2` → `2.0`
+- Last Updated: Update date
+
+---
+
+## Document Structure
+
+**Rule:** Documents should follow a consistent structure with required sections.
+
+### Required Sections
+
+**Every document must have:**
+
+1. **Title** (`# Title`)
+2. **Purpose statement** (one sentence)
+3. **Last Updated date** (top)
+4. **Horizontal rule separator** (`---`)
+5. **Content** (organized with clear headings)
+6. **Footer metadata** (version, last updated, maintainer)
+
+### Recommended Structure
+
+```markdown
+# [Document Title]
+
+**Purpose:** [One sentence]
+
+---
+
+## Optional: Table of Contents
+
+[For longer documents]
+
+## Section 1
+
+[Content]
+
+## Section 2
+
+[Content]
+
+---
+
+## Optional: Related Documentation
+
+[Links to related docs]
+
+---
+
+**Document Version:** X.Y
+**Last Updated:** YYYY-MM-DD
+**Maintainer:** DIRT Team
+```
+
+### Heading Levels
+
+**Use consistent heading hierarchy:**
+
+- `#` - Document title (once, at top)
+- `##` - Main sections
+- `###` - Subsections
+- `####` - Sub-subsections (use sparingly)
+
+**Pattern:**
+
+```markdown
+# Document Title
+
+## Main Section 1
+
+### Subsection 1.1
+
+#### Detail 1.1.1
+
+### Subsection 1.2
+
+## Main Section 2
+```
+
+### Section Organization
+
+**Order sections logically:**
+
+1. **Introduction/Overview** (if needed)
+2. **Core Content** (main sections)
+3. **Examples** (if applicable)
+4. **Related Documentation** (cross-references)
+5. **Maintenance** (when to update this doc)
+6. **Footer Metadata**
+
+---
+
+## Naming Conventions
+
+**Rule:** File naming must follow conventions based on document type.
+
+### Document Types and Naming
+
+| Type             | Naming Convention                      | Location                    | Example                      |
+| ---------------- | -------------------------------------- | --------------------------- | ---------------------------- |
+| **Meta files**   | `ALLCAPS.md`                           | Directory root              | `README.md`, `CLAUDE.md`     |
+| **Regular docs** | `lowercase-kebab-case.md`              | `docs/`                     | `getting-started.md`         |
+| **Playbooks**    | `[topic]-playbook.md`                  | `docs/playbooks/`           | `documentation-playbook.md`  |
+| **Standards**    | `[topic]-standards.md` or `[topic].md` | `docs/standards/`           | `documentation-standards.md` |
+| **ADRs**         | `NNN-title.md`                         | `docs/[feature]/decisions/` | `001-ground-up-rewrite.md`   |
+| **Feature docs** | `lowercase-kebab-case.md`              | `docs/[feature]/`           | `architecture-review.md`     |
+
+### Meta Files (ALL CAPS)
+
+**Use ALL CAPS for meta files:**
+
+- `README.md` - Directory overview and navigation
+- `CLAUDE.md` - AI tooling context and instructions
+- `CONTRIBUTING.md` - Contribution guidelines (if added)
+- `CHANGELOG.md` - Change log (if added)
+
+**Why ALL CAPS:**
+
+- Industry standard (README.md is universally ALL CAPS)
+- Immediately recognizable as meta files
+- Distinguishes from regular documentation
+
+### Regular Documentation (lowercase-kebab-case)
+
+**Use lowercase-kebab-case for all other docs:**
+
+- `getting-started.md`
+- `documentation-structure.md`
+- `integration-guide.md`
+- `component-migration-quickstart.md`
+
+**Why lowercase-kebab-case:**
+
+- Cross-platform compatibility (case-insensitive filesystems)
+- Auto-completion in terminals
+- URL-friendly (if docs ever hosted)
+- Consistency with codebase naming
+
+### Playbooks (-playbook suffix)
+
+**Format:** `[topic]-playbook.md`
+
+**Examples:**
+
+- `service-implementation-playbook.md`
+- `component-migration-playbook.md`
+- `documentation-playbook.md`
+- `testing-strategy-playbook.md` (future)
+
+**Why -playbook suffix:**
+
+- Enables filtering by filename (`*-playbook.md`)
+- Immediately identifies implementation guides
+- Distinguishes from standards or reference docs
+
+### Architecture Decision Records (numbered)
+
+**Format:** `NNN-descriptive-title.md`
+
+- NNN = 3-digit number (001, 002, 003, etc.)
+- descriptive-title = lowercase-kebab-case
+
+**Examples:**
+
+- `001-ground-up-rewrite.md`
+- `002-consolidate-app-metadata-services.md`
+- `003-report-persistence-backend-flexibility.md`
+
+**Why numbered:**
+
+- Standard ADR format
+- Chronological ordering
+- Easy to reference ("see ADR-003")
+
+---
+
+## README.md Files
+
+**Rule:** README.md files serve as brief directory overviews, not comprehensive guides.
+
+### Purpose of README.md
+
+**README.md is a meta-documentation file that:**
+
+- ✅ Provides a brief overview of what's in the directory
+- ✅ Links to detailed documentation (getting-started, structure guides, etc.)
+- ✅ Serves as a "directory in a lobby" - tells you where to find maps, not the map itself
+- ❌ Does NOT duplicate content from other documentation
+- ❌ Does NOT provide comprehensive guides or tutorials
+- ❌ Does NOT explain detailed structure (that's documentation-structure.md's job)
+- ❌ Does NOT provide navigation (that's getting-started.md's job)
+
+### README.md Template
+
+**Use this template for README.md files:**
+
+```markdown
+# [Directory Name]
+
+**Location:** `path/to/directory`
+**Purpose:** Brief overview of [directory purpose]
+
+---
+
+## 🎯 Start Here
+
+**New to [area]?** → [Link to getting started guide]
+
+**Looking for something specific?**
+
+- **"Question 1?"** → [Link to relevant doc]
+- **"Question 2?"** → [Link to relevant doc]
+- **"Question 3?"** → [Link to relevant doc]
+
+---
+
+## 📁 What's in This Folder
+
+| Document/Folder                  | Purpose           |
+| -------------------------------- | ----------------- |
+| **[doc-name.md](./doc-name.md)** | Brief description |
+| **[folder/](./folder/)**         | Brief description |
+
+---
+
+## 📝 [Optional: Brief Context Section]
+
+[1-2 paragraphs of high-level context if needed]
+
+---
+
+**Document Version:** X.Y
+**Last Updated:** YYYY-MM-DD
+**Maintainer:** [Team Name]
+```
+
+### What to Include
+
+**DO include in README.md:**
+
+- ✅ **Brief overview** - 1-2 sentences about the directory's purpose
+- ✅ **"Start Here" section** - Quick links for common tasks
+- ✅ **"What's in This Folder" table** - List of files/folders with brief descriptions
+- ✅ **Links to detailed docs** - Point to getting-started.md, documentation-structure.md, etc.
+- ✅ **High-level context** - 1-2 paragraphs if needed (optional)
+
+**DO NOT include in README.md:**
+
+- ❌ **Full directory trees** - Use placeholders, link to documentation-structure.md
+- ❌ **Navigation tables** - Link to getting-started.md instead
+- ❌ **Best practices sections** - These belong in standards/ folder
+- ❌ **Implementation guides** - These belong in playbooks/ folder
+- ❌ **Detailed structure explanations** - Link to documentation-structure.md
+- ❌ **Standards or conventions** - These belong in standards/ folder
+
+### Examples
+
+**Good README.md (brief overview):**
+
+```markdown
+# DIRT Team Documentation
+
+**Location:** `bitwarden_license/bit-common/src/dirt/docs/`
+**Purpose:** Overview of DIRT team documentation with navigation to detailed guides
+
+---
+
+## 🎯 Start Here
+
+**New to the DIRT team?** → [Getting Started](./getting-started.md)
+
+## 📁 What's in This Folder
+
+| Document/Folder                                | Purpose               |
+| ---------------------------------------------- | --------------------- |
+| **[getting-started.md](./getting-started.md)** | Navigation hub        |
+| **[playbooks/](./playbooks/)**                 | Implementation guides |
+| **[standards/](./standards/)**                 | Team standards        |
+```
+
+**Bad README.md (too comprehensive):**
+
+```markdown
+# DIRT Team Documentation
+
+## Complete Directory Structure
+
+[Full file tree with every file listed]
+
+## Documentation Best Practices
+
+[Long section explaining standards that belong in documentation-standards.md]
+
+## Quick Navigation
+
+[Navigation table that duplicates getting-started.md]
+
+## When to Use Each Location
+
+[Detailed explanation that belongs in documentation-structure.md]
+```
+
+### Common README.md Locations
+
+**Each location has a README.md with a specific scope:**
+
+| Location                       | README.md Scope       | Links To                                             |
+| ------------------------------ | --------------------- | ---------------------------------------------------- |
+| **`docs/README.md`**           | Team docs overview    | getting-started.md, documentation-structure.md       |
+| **`docs/playbooks/README.md`** | Playbooks overview    | Individual playbook files                            |
+| **`docs/standards/README.md`** | Standards overview    | Individual standards files                           |
+| **`docs/[feature]/README.md`** | Feature docs overview | Feature-specific architecture, implementation guides |
+
+### Testing Your README.md
+
+**Ask these questions:**
+
+1. **Is it brief?** (Should be ~50-100 lines, not 300+)
+2. **Does it link instead of duplicate?** (Links to getting-started.md instead of duplicating navigation)
+3. **Does it follow single responsibility?** (Overview only, not comprehensive guide)
+4. **Could a new person use it to find detailed docs?** (Clear links to where to go next)
+
+### When README.md Gets Too Long
+
+**If your README.md exceeds ~100 lines, you're probably:**
+
+1. **Duplicating content** - Move content to appropriate doc and link to it
+2. **Providing detailed guides** - Move to playbooks/ or standards/
+3. **Explaining structure in detail** - Move to documentation-structure.md
+4. **Providing navigation** - Move to getting-started.md
+
+**Fix:** Simplify README.md to brief overview with links, move content to appropriate locations.
+
+### README.md vs Other Meta Docs
+
+**Clear separation of concerns:**
+
+| Document                       | Purpose                  | Content                                     |
+| ------------------------------ | ------------------------ | ------------------------------------------- |
+| **README.md**                  | "What's in this folder?" | Brief overview, links to detailed docs      |
+| **getting-started.md**         | "What should I read?"    | Navigation hub, task-based links            |
+| **documentation-structure.md** | "How is it organized?"   | Complete structure explanation              |
+| **CLAUDE.md**                  | "Context for AI tooling" | AI-specific instructions, patterns, context |
+
+**Anti-pattern:** README.md trying to do all four jobs above.
+
+---
+
+## Document Location Rules
+
+**Rule:** Document placement depends on scope and purpose.
+
+### Location Decision Tree
+
+```
+What type of documentation?
+│
+├─ Meta file (README.md, CLAUDE.md)?
+│  └─ Place at directory root
+│     Examples: docs/README.md, docs/playbooks/README.md
+│
+├─ Cross-cutting (references multiple packages)?
+│  └─ Place at team docs root: docs/
+│     Examples: getting-started.md, integration-guide.md
+│
+├─ Feature-specific (platform-agnostic services)?
+│  └─ Place in feature folder: docs/[feature]/
+│     Examples: docs/access-intelligence/architecture/
+│
+├─ Component docs (Angular-specific)?
+│  └─ Place in bit-web: bit-web/src/app/dirt/[feature]/docs/
+│     Example: bit-web/src/app/dirt/access-intelligence/docs/
+│
+├─ Browser docs (browser extension)?
+│  └─ Place in apps/browser: apps/browser/src/dirt/[feature]/docs/
+│     Example: apps/browser/src/dirt/phishing-detection/docs/ (future)
+│
+├─ Playbook (implementation guide)?
+│  └─ Place in: docs/playbooks/
+│     Examples: service-implementation-playbook.md
+│
+├─ Standards (coding/doc standards)?
+│  └─ Place in: docs/standards/
+│     Examples: standards.md, documentation-standards.md
+│
+└─ ADR (architecture decision)?
+   └─ Place in: docs/[feature]/decisions/
+      Examples: docs/access-intelligence/decisions/001-rewrite.md
+```
+
+### Location Rules by Scope
+
+| Scope                    | Location                           | Example                                   |
+| ------------------------ | ---------------------------------- | ----------------------------------------- |
+| **Team-wide**            | `docs/`                            | getting-started.md, integration-guide.md  |
+| **Feature (services)**   | `docs/[feature]/`                  | docs/access-intelligence/architecture/    |
+| **Feature (components)** | `bit-web/.../[feature]/docs/`      | bit-web/.../access-intelligence/docs/     |
+| **Feature (browser)**    | `apps/browser/.../[feature]/docs/` | apps/browser/.../phishing-detection/docs/ |
+| **Playbooks**            | `docs/playbooks/`                  | documentation-playbook.md                 |
+| **Standards**            | `docs/standards/`                  | documentation-standards.md                |
+| **ADRs**                 | `docs/[feature]/decisions/`        | 001-ground-up-rewrite.md                  |
+
+### Package-Based Organization
+
+**Separation of concerns:**
+
+- **bit-common** - Platform-agnostic services and architecture
+  - Location: `bitwarden_license/bit-common/src/dirt/docs/`
+  - Purpose: Code that works on all platforms (web, desktop, browser, CLI)
+
+- **bit-web** - Angular web components
+  - Location: `bitwarden_license/bit-web/src/app/dirt/[feature]/docs/`
+  - Purpose: Web client only (Angular-specific)
+
+- **bit-browser** - Browser extension components
+  - Location: `apps/browser/src/dirt/[feature]/docs/`
+  - Purpose: Browser extension only
+
+---
+
+## Cross-Reference Standards
+
+**Rule:** Use consistent formatting for cross-references and follow path conventions.
+
+### Relative vs Absolute Paths
+
+**Use relative paths when:**
+
+- Linking within same directory tree
+- Example: `[standards.md](../standards/standards.md)` from `docs/playbooks/`
+
+**Use absolute paths when:**
+
+- Linking across package boundaries (bit-common → bit-web)
+- Example: `[bit-web docs](/bitwarden_license/bit-web/src/app/dirt/access-intelligence/docs/)`
+
+### Path Formats
+
+**Relative paths:**
+
+```markdown
+[Standards](../standards/standards.md)
+[Getting Started](../getting-started.md)
+[Playbook](./service-implementation-playbook.md)
+```
+
+**Absolute paths (from repo root):**
+
+```markdown
+[Component Docs](/bitwarden_license/bit-web/src/app/dirt/access-intelligence/docs/)
+[Browser Code](/apps/browser/src/dirt/phishing-detection/)
+```
+
+### Link Formatting
+
+**Good link formatting:**
+
+```markdown
+[Standards](../standards/standards.md) - Links to file
+[Playbooks](./playbooks/) - Links to directory
+[standards.md § Testing](../standards/standards.md#testing-standards) - Links to section
+```
+
+**Bad link formatting:**
+
+```markdown
+[Standards](../standards/standards.md/) - Extra slash for file
+[standards.md](../standards/standards.md) - Filename as link text (use descriptive text)
+```
+
+### Section References
+
+**Link to specific sections:**
+
+```markdown
+[Documentation Best Practices](../README.md#-documentation-best-practices)
+[Version Numbering](#version-numbering)
+```
+
+**Format:**
+
+- Use section heading as anchor (GitHub auto-generates)
+- Replace spaces with hyphens
+- Use lowercase
+- Remove special characters except hyphens
+
+---
+
+## Content Guidelines
+
+**Rule:** Write clear, concise content following consistent patterns.
+
+### Writing Style
+
+**Be clear and direct:**
+
+- ✅ "Use lowercase-kebab-case for regular documentation files"
+- ❌ "It might be good to consider using lowercase-kebab-case in some cases"
+
+**Use present tense:**
+
+- ✅ "This document explains..."
+- ❌ "This document will explain..."
+
+**Use active voice:**
+
+- ✅ "Create documentation following these standards"
+- ❌ "Documentation should be created following these standards"
+
+### Examples and Anti-Patterns
+
+**Always include examples:**
+
+```markdown
+### Good Example Pattern
+
+**Good examples:**
+
+- ✅ Example of correct pattern
+- ✅ Another correct example
+
+**Bad examples:**
+
+- ❌ Example of incorrect pattern
+- ❌ Another incorrect example
+```
+
+**Use visual indicators:**
+
+- ✅ for correct patterns
+- ❌ for incorrect patterns
+- ⚠️ for warnings or cautions
+
+### Code Blocks and Formatting
+
+**Use code blocks for:**
+
+- File paths: `` `docs/README.md` ``
+- Code examples: ` ```typescript ... ``` `
+- File structures: ` ```text ... ``` `
+- Commands: `` `npm test` ``
+
+**Use tables for comparisons:**
+
+```markdown
+| Pattern  | When to Use | Example   |
+| -------- | ----------- | --------- |
+| Option A | Scenario A  | Example A |
+| Option B | Scenario B  | Example B |
+```
+
+### Lists and Organization
+
+**Use bullet points for:**
+
+- Unordered items
+- Features or characteristics
+- Examples
+
+**Use numbered lists for:**
+
+- Sequential steps
+- Ordered procedures
+- Prioritized items
+
+**Example:**
+
+```markdown
+**Steps to follow:**
+
+1. First step
+2. Second step
+3. Third step
+
+**Features:**
+
+- Feature 1
+- Feature 2
+- Feature 3
+```
+
+---
+
+## File Structure Diagrams
+
+**Rule:** File structure diagrams should show **folders and meta files only**, using placeholders for other files.
+
+### What to Include in Diagrams
+
+**DO include:**
+
+- ✅ Folders/directories (all levels)
+- ✅ Meta files only: `README.md`, `CLAUDE.md`
+- ✅ Placeholder `...` to indicate other files exist
+
+**DO NOT include:**
+
+- ❌ Individual content files (analysis docs, architecture docs, etc.)
+- ❌ Implementation files (.ts, .js, etc.)
+- ❌ Test files (.spec.ts)
+
+### Good Example
+
+```markdown
+bitwarden_license/bit-common/src/dirt/
+├── CLAUDE.md ← Meta file
+│
+├── docs/ ← Folder
+│ ├── README.md ← Meta file
+│ ├── getting-started.md ← Exception: Core navigation file
+│ │
+│ ├── playbooks/ ← Folder
+│ │ ├── README.md ← Meta file
+│ │ └── ... ← Placeholder for other playbooks
+│ │
+│ └── standards/ ← Folder
+│ ├── README.md ← Meta file
+│ └── ... ← Placeholder for standard files
+│
+└── [feature]/ ← Folder pattern
+└── docs/ ← Folder
+├── README.md ← Meta file
+├── architecture/ ← Folder
+│ └── ... ← Placeholder for architecture files
+└── implementation/ ← Folder
+└── ... ← Placeholder for implementation files
+```
+
+### Bad Example
+
+```markdown
+❌ DON'T DO THIS:
+bitwarden_license/bit-common/src/dirt/docs/
+├── README.md
+├── getting-started.md
+├── documentation-structure.md ← Individual file (remove)
+├── integration-guide.md ← Individual file (remove)
+├── playbooks/
+│ ├── README.md
+│ ├── service-implementation-playbook.md ← Individual file (remove)
+│ ├── component-migration-playbook.md ← Individual file (remove)
+│ └── documentation-playbook.md ← Individual file (remove)
+└── access-intelligence/
+├── analysis-ngrx-signals.md ← Individual file (remove)
+└── architecture/
+├── architecture-review.md ← Individual file (remove)
+└── service-dependency-graph.md ← Individual file (remove)
+```
+
+### Why This Rule?
+
+**Problems with listing individual files:**
+
+1. **Maintenance burden** - Diagram needs updating every time a file is added/removed
+2. **Cluttered** - Hard to see the overall structure
+3. **Not scalable** - Large directories become unreadable
+4. **Focus on structure** - Diagram should show organization, not inventory
+
+**Benefits of folders + placeholders:**
+
+1. **Low maintenance** - Structure rarely changes even as files are added
+2. **Clear hierarchy** - Easy to understand organization at a glance
+3. **Scalable** - Works for any size directory
+4. **Purpose-focused** - Shows "where things go" not "what exists"
+
+### Exception: Core Navigation Files
+
+For the top-level `docs/` directory, you may include **core navigation files** that are essential entry points:
+
+- ✅ `getting-started.md` - Main entry point
+- ✅ `documentation-structure.md` - Core reference
+
+These exceptions should be rare and only for files that are critical to understanding the documentation structure.
+
+### Using Placeholders
+
+**Placeholder format:**
+
+```markdown
+├── playbooks/
+│ ├── README.md
+│ └── ... ← Indicates other playbook files exist
+```
+
+**Placeholder with description:**
+
+```markdown
+├── architecture/
+│ └── ... ← Architecture comparison files
+```
+
+**What placeholders communicate:**
+
+- "There are other files here"
+- "See README.md for details"
+- "Not listing every file to keep diagram clean"
+
+---
+
+## Related Documentation
+
+**Standards:**
+
+- [Coding Standards](./standards.md) - Code-specific standards and patterns
+- [Service Testing Standards](./testing-standards-services.md) - Service testing guidelines
+- [Component Testing Standards](./testing-standards-components.md) - Component testing guidelines
+
+**Playbooks:**
+
+- [Documentation Playbook](../playbooks/documentation-playbook.md) - Step-by-step guide for creating/updating docs
+
+**Navigation:**
+
+- [Getting Started](../getting-started.md) - Documentation navigation hub
+- [Documentation Structure](../documentation-structure.md) - How docs are organized
+
+---
+
+## Maintenance
+
+**When to update this document:**
+
+- Adding new documentation types
+- Changing naming conventions
+- Adding new metadata requirements
+- Discovering new standards or patterns
+
+**How to update:**
+
+1. Follow [Documentation Playbook](../playbooks/documentation-playbook.md)
+2. Update version number
+3. Update "Last Updated" date in footer
+4. Update related documentation if structure changes
+
+---
+
+**Document Version:** 1.0
+**Last Updated:** 2026-02-17
+**Maintainer:** DIRT Team

--- a/bitwarden_license/bit-common/src/dirt/docs/standards/model-standards.md
+++ b/bitwarden_license/bit-common/src/dirt/docs/standards/model-standards.md
@@ -1,0 +1,247 @@
+# Model Standards
+
+**Purpose:** Standards for view model construction, 4-layer model architecture, and working with encrypted strings in Access Intelligence development
+
+---
+
+## Table of Contents
+
+1. [View Model Construction Patterns](#view-model-construction-patterns)
+   - [When to Use Manual Construction vs fromJSON](#when-to-use-manual-construction-vs-fromjson)
+   - [Quick Reference Table](#quick-reference-table)
+2. [4-Layer Model Architecture](#4-layer-model-architecture)
+   - [Write Flow (Save)](#write-flow-save)
+   - [Read Flow (Load)](#read-flow-load)
+3. [Working with EncString](#working-with-encstring)
+   - [EncString Structure](#encstring-structure)
+   - [Common Operations](#common-operations)
+   - [Testing with EncString](#testing-with-encstring)
+   - [Quick Reference](#quick-reference)
+
+---
+
+## View Model Construction Patterns
+
+### When to Use Manual Construction vs fromJSON
+
+**Follow the Cipher pattern** - even in the 4-layer pipeline, Cipher uses manual construction when transforming Domain → View.
+
+#### Pattern 1: Manual Construction
+
+**Use when:** Creating a **NEW instance from computed/generated data**
+
+```typescript
+// ✅ CORRECT - Generating fresh report from raw data
+const view = new RiskInsightsView();
+view.id = "" as any; // Will be set by persistence service
+view.reports = computedReports; // Freshly computed
+view.memberRegistry = registry; // Freshly computed
+view.creationDate = new Date(); // NEW timestamp
+
+// ✅ CORRECT - Cipher Domain → View transformation (Cipher.decrypt)
+async decrypt(userKey: SymmetricCryptoKey): Promise<CipherView> {
+  const model = new CipherView(this); // Pass Domain object
+  model.name = await decrypt(this.name); // Manually populate fields
+  return model;
+}
+```
+
+**Why:** We're not deserializing existing data - we're **creating something new** from computation or transformation.
+
+#### Pattern 2: fromJSON (Deserialization)
+
+**Use when:** Reconstructing an instance from **serialized storage** (API, cache, localStorage)
+
+```typescript
+// ✅ CORRECT - Loading saved report from storage
+const savedData = await this.stateProvider.get(REPORT_KEY);
+const view = RiskInsightsView.fromJSON(savedData);
+
+// ✅ CORRECT - State deserialization (ciphers.state.ts)
+deserializer: (cipher: Jsonify<CipherView>) => CipherView.fromJSON(cipher);
+```
+
+**Why:** We're **deserializing** data that was previously saved using `toJSON()`.
+
+### Quick Reference Table
+
+| Scenario              | Pattern             | Example                                    |
+| --------------------- | ------------------- | ------------------------------------------ |
+| **Generate new data** | Manual construction | `new RiskInsightsView()` + populate fields |
+| **Domain → View**     | Manual construction | `new CipherView(this)` in `decrypt()`      |
+| **Load from storage** | `fromJSON()`        | `RiskInsightsView.fromJSON(savedData)`     |
+| **Save to storage**   | `toJSON()`          | `view.toJSON()` → serialize                |
+| **Test fixtures**     | Manual construction | `new RiskInsightsView()` + set test data   |
+
+---
+
+## 4-Layer Model Architecture
+
+All models in `bitwarden_license/bit-common/src/dirt/reports/risk-insights/models/` follow the 4-layer architecture:
+
+- **api/** - Wire format (SDK/API responses)
+- **data/** - Serializable format (cacheable, plain JSON)
+- **domain/** - Business logic layer (EncString fields, encrypted data)
+- **view/** - Presentation layer (decrypted, query methods)
+
+### Write Flow (Save)
+
+```typescript
+View (manual construction)
+  ↓ constructor or populate
+Domain (encrypted fields)
+  ↓ toData()
+Data (serializable)
+  ↓ toSdk() or save directly
+API (wire format) or Storage
+```
+
+**Example:**
+
+```typescript
+// ReportPersistenceService.save()
+const view = new RiskInsightsView(); // Manual construction
+const domain = new RiskInsights(view); // View → Domain
+const encrypted = await this.encrypt(domain); // Encrypt
+const data = encrypted.toData(); // Domain → Data
+await this.apiService.save(data.toSdk()); // Data → API
+```
+
+### Read Flow (Load)
+
+```typescript
+API (wire format) or Storage
+  ↓ fromResponse() or retrieve
+Data (serializable)
+  ↓ fromJSON()
+Domain (encrypted)
+  ↓ decrypt()
+View (manual construction inside decrypt)
+```
+
+**Example:**
+
+```typescript
+// ReportPersistenceService.load()
+const apiResponse = await this.apiService.get(id); // API
+const data = RiskInsightsData.fromJSON(apiResponse); // API → Data
+const domain = new RiskInsights(data); // Data → Domain
+const view = await domain.decrypt(key); // Domain → View (manual construction)
+return view;
+```
+
+---
+
+## Working with EncString
+
+### EncString Structure
+
+EncString objects have several properties for different use cases:
+
+```typescript
+interface EncString {
+  encryptedString: string; // Full encrypted data (MOST COMMON)
+  data: string; // Encrypted data without metadata
+  iv: string; // Initialization vector
+  mac: string; // Message authentication code
+}
+```
+
+### Common Operations
+
+**Checking if EncString has data:**
+
+```typescript
+// ✅ CORRECT - Check .encryptedString for API responses
+if (!encString || !encString.encryptedString || encString.encryptedString === "") {
+  throw new Error("No encrypted data");
+}
+
+// ❌ WRONG - Don't check .data for API responses
+if (!encString || encString.data === "") { ... }
+```
+
+**Extracting for storage/API:**
+
+```typescript
+// ✅ CORRECT - Use .encryptedString property
+const data = domain.toData();
+data.contentEncryptionKey = encString.encryptedString ?? "";
+data.reports = apiResponse.reportData.encryptedString ?? "";
+
+// ❌ WRONG - .data doesn't include encryption metadata
+data.contentEncryptionKey = encString.data ?? "";
+```
+
+**Validating API response EncStrings:**
+
+```typescript
+// ✅ CORRECT - Complete validation
+if (
+  !apiResponse.contentEncryptionKey ||
+  !apiResponse.contentEncryptionKey.encryptedString ||
+  apiResponse.contentEncryptionKey.encryptedString === ""
+) {
+  throw new Error("Report encryption key not found");
+}
+
+// ❌ WRONG - Incomplete check (might have empty .encryptedString)
+if (!apiResponse.contentEncryptionKey) {
+  throw new Error("Report encryption key not found");
+}
+```
+
+### Testing with EncString
+
+Always use `makeEncString` from `@bitwarden/common/spec`:
+
+```typescript
+import { makeEncString } from "@bitwarden/common/spec";
+
+// ✅ CORRECT - Use test utility
+const report = new RiskInsights();
+report.contentEncryptionKey = makeEncString("test-key");
+report.reports = makeEncString("encrypted-reports");
+
+// ❌ WRONG - Direct construction
+report.contentEncryptionKey = new EncString("test-key");
+```
+
+**Why:**
+
+- `makeEncString` creates properly formatted EncString with correct encryption type
+- Consistent test data format across all tests
+- Avoids subtle bugs from incorrect EncString construction
+
+### Quick Reference
+
+| Operation               | Property              | Example                                |
+| ----------------------- | --------------------- | -------------------------------------- |
+| API response validation | `.encryptedString`    | `if (!enc.encryptedString) { ... }`    |
+| Extract for persistence | `.encryptedString`    | `data.key = enc.encryptedString ?? ""` |
+| Testing                 | Use `makeEncString()` | `makeEncString("test-data")`           |
+| Never use               | `.data`               | ❌ Wrong for API responses             |
+
+---
+
+## Related Documentation
+
+**Standards:**
+
+- [Service Standards](./service-standards.md) - Service patterns for working with models
+- [Angular Standards](./angular-standards.md) - Smart models and mutation patterns
+- [Testing Standards - Services](./testing-standards-services.md) - Testing models and EncString
+
+**Playbooks:**
+
+- [Service Implementation Playbook](../playbooks/service-implementation-playbook.md) - Implementing services that use the 4-layer architecture
+
+**Navigation:**
+
+- [Standards Hub](./README.md) - All DIRT team standards
+
+---
+
+**Document Version:** 1.0
+**Last Updated:** 2026-02-17
+**Maintainer:** DIRT Team

--- a/bitwarden_license/bit-common/src/dirt/docs/standards/rxjs-standards.md
+++ b/bitwarden_license/bit-common/src/dirt/docs/standards/rxjs-standards.md
@@ -1,0 +1,247 @@
+# RxJS Standards
+
+**Purpose:** Standards for RxJS patterns, Observable error handling, and common import paths for reactive programming in Access Intelligence development
+
+---
+
+## Table of Contents
+
+1. [RxJS Patterns and Best Practices](#rxjs-patterns-and-best-practices)
+   - [Observable Error Handling](#observable-error-handling)
+   - [getUserId Pattern](#getuserid-pattern)
+   - [firstValueFrom Pattern](#firstvaluefrom-pattern)
+2. [Common Import Paths](#common-import-paths)
+   - [Auth & Account](#auth--account)
+   - [Types (GUIDs and Tagged Types)](#types-guids-and-tagged-types)
+   - [Crypto & Encryption](#crypto--encryption)
+   - [Test Utilities](#test-utilities)
+   - [RxJS](#rxjs)
+   - [Quick Reference Table](#quick-reference-table)
+
+---
+
+## RxJS Patterns and Best Practices
+
+### Observable Error Handling
+
+**Rule:** Methods returning Observables MUST use `throwError()` for errors, not synchronous throws.
+
+```typescript
+import { throwError } from "rxjs";
+
+// ✅ CORRECT - Use throwError() for Observable errors
+saveReport$(report: RiskInsights, organizationId: OrganizationId): Observable<OrganizationReportId> {
+  if (!report.contentEncryptionKey) {
+    return throwError(() => new Error("Report encryption key not found"));
+  }
+  return this.apiService.saveRiskInsightsReport$(requestPayload, organizationId);
+}
+
+// ❌ WRONG - Synchronous throw breaks Observable chain
+saveReport(report: RiskInsights, organizationId: OrganizationId): Observable<OrganizationReportId> {
+  if (!report.contentEncryptionKey) {
+    throw new Error("Report encryption key not found"); // Won't work with .rejects.toThrow()
+  }
+  return this.apiService.saveRiskInsightsReport$(requestPayload, organizationId);
+}
+```
+
+**Why:**
+
+- Observable tests use `.rejects.toThrow()` which only catches errors emitted through the Observable stream
+- Synchronous throws occur before Observable creation and won't be caught by subscribers
+- Consistent error handling throughout the Observable pipeline
+- Allows proper cleanup and error recovery in RxJS operators
+
+**Error Inside Observable Pipeline:**
+
+```typescript
+// Within switchMap/map/etc, synchronous throws work fine
+loadReport$(organizationId: OrganizationId): Observable<RiskInsightsView> {
+  return this.apiService.getRiskInsightsReport$(organizationId).pipe(
+    switchMap((apiResponse) => {
+      if (!apiResponse) {
+        return of(null);
+      }
+
+      // ✅ CORRECT - Inside operator, synchronous throw works
+      if (!apiResponse.contentEncryptionKey) {
+        throw new Error("Report encryption key not found");
+      }
+
+      return from(domain.decrypt(...));
+    })
+  );
+}
+```
+
+### getUserId Pattern
+
+**Pattern:** Getting user ID from AccountService
+
+```typescript
+import { getUserId } from "@bitwarden/common/auth/services/account.service";
+
+// ✅ CORRECT - getUserId takes Observable<Account>
+loadReport$(organizationId: OrganizationId): Observable<RiskInsightsView> {
+  return from(firstValueFrom(getUserId(this.accountService.activeAccount$))).pipe(
+    switchMap((userId) => {
+      if (!userId) {
+        throw new Error("User ID not found");
+      }
+      // Use userId...
+    })
+  );
+}
+
+// ❌ WRONG - getUserId doesn't take unwrapped Account
+const account = await firstValueFrom(this.accountService.activeAccount$);
+const userId = getUserId(account); // Type error!
+```
+
+**Important Notes:**
+
+- `getUserId` is an RxJS operator that expects `Observable<Account>`
+- It throws "Null or undefined account" when account is null (not "User ID not found")
+- Always wrap in `from(firstValueFrom(...))` to convert Promise back to Observable
+
+**Error Message Reference:**
+
+```typescript
+// getUserId throws this error when account is null:
+"Null or undefined account";
+
+// Your service logic can throw this when userId is falsy:
+"User ID not found";
+```
+
+### firstValueFrom Pattern
+
+**Pattern:** Converting cold Observables to Promises for easier composition
+
+```typescript
+// ✅ CORRECT - Get userId then use in Observable chain
+return from(firstValueFrom(getUserId(this.accountService.activeAccount$))).pipe(
+  switchMap((userId) => {
+    // Now we have userId as a value, not Observable
+    return this.apiService.getData$(organizationId, userId);
+  }),
+);
+
+// ❌ WRONG - Nesting Observables
+return getUserId(this.accountService.activeAccount$).pipe(
+  switchMap((userId) => {
+    return this.apiService
+      .getData$(organizationId, userId)
+      .pipe
+      // Nested pipes get messy fast
+      ();
+  }),
+);
+```
+
+**When to use:**
+
+- Converting single-value Observables to Promises for cleaner async/await
+- Getting values from Observables to pass to other services
+- Simplifying complex Observable chains
+
+---
+
+## Common Import Paths
+
+Quick reference for frequently used imports. Always use these exact paths to avoid import errors.
+
+### Auth & Account
+
+```typescript
+import { Account, AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { getUserId } from "@bitwarden/common/auth/services/account.service";
+```
+
+**Common mistake:** Importing `Account` from `@bitwarden/common/models/domain/account` (old path, no longer exists)
+
+### Types (GUIDs and Tagged Types)
+
+```typescript
+import {
+  CipherId,
+  CollectionId,
+  OrganizationId,
+  OrganizationReportId,
+  UserId,
+} from "@bitwarden/common/types/guid";
+```
+
+**Note:** These are Tagged types (branded strings), use type assertions in tests:
+
+```typescript
+const userId = "user-123" as UserId;
+const cipherId = "cipher-456" as CipherId;
+```
+
+### Crypto & Encryption
+
+```typescript
+import { EncString } from "@bitwarden/common/key-management/crypto/models/enc-string";
+import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
+```
+
+### Test Utilities
+
+```typescript
+import {
+  makeEncString,
+  makeStaticByteArray,
+  makeSymmetricCryptoKey,
+  GetUniqueString,
+} from "@bitwarden/common/spec";
+```
+
+**See:** [testing-standards-services.md](./testing-standards-services.md) for detailed usage of test utilities.
+
+### RxJS
+
+```typescript
+import { Observable, BehaviorSubject, Subject, firstValueFrom, throwError } from "rxjs";
+import { map, switchMap, tap, catchError, shareReplay } from "rxjs/operators";
+```
+
+**Note:** Operators are imported from `"rxjs"` directly in modern RxJS, not `"rxjs/operators"`.
+
+### Quick Reference Table
+
+| Type                        | Import Path                                                     | Common Aliases          |
+| --------------------------- | --------------------------------------------------------------- | ----------------------- |
+| `Account`, `AccountService` | `@bitwarden/common/auth/abstractions/account.service`           | -                       |
+| `getUserId`                 | `@bitwarden/common/auth/services/account.service`               | -                       |
+| `CipherId`, `UserId`, etc.  | `@bitwarden/common/types/guid`                                  | Tagged types            |
+| `EncString`                 | `@bitwarden/common/key-management/crypto/models/enc-string`     | -                       |
+| `SymmetricCryptoKey`        | `@bitwarden/common/platform/models/domain/symmetric-crypto-key` | -                       |
+| Test utilities              | `@bitwarden/common/spec`                                        | `makeEncString`, etc.   |
+| RxJS core                   | `rxjs`                                                          | `Observable`, operators |
+
+---
+
+## Related Documentation
+
+**Standards:**
+
+- [Service Standards](./service-standards.md) - Service patterns using Observables
+- [Angular Standards](./angular-standards.md) - Observable vs Signal usage in components
+- [Code Organization Standards](./code-organization-standards.md) - Observable naming conventions
+- [Testing Standards - Services](./testing-standards-services.md) - Testing Observable-based services
+
+**Playbooks:**
+
+- [Service Implementation Playbook](../playbooks/service-implementation-playbook.md) - Implementing services with Observables
+
+**Navigation:**
+
+- [Standards Hub](./README.md) - All DIRT team standards
+
+---
+
+**Document Version:** 1.0
+**Last Updated:** 2026-02-17
+**Maintainer:** DIRT Team

--- a/bitwarden_license/bit-common/src/dirt/docs/standards/service-standards.md
+++ b/bitwarden_license/bit-common/src/dirt/docs/standards/service-standards.md
@@ -1,0 +1,145 @@
+# Service Standards
+
+**Purpose:** Standards for service responsibility patterns, separation of concerns, and helper function extraction in Access Intelligence development
+
+---
+
+## Service Responsibility Patterns
+
+### Service Responsibility Matrix
+
+| Service                           | Loads Data | Generates Reports | Saves/Loads       | Exposes State      | Manages UI |
+| --------------------------------- | ---------- | ----------------- | ----------------- | ------------------ | ---------- |
+| **AccessIntelligenceDataService** | ✅ Yes     | ❌ No (delegates) | ❌ No (delegates) | ✅ Yes (`report$`) | ❌ No      |
+| **ReportGenerationService**       | ❌ No      | ✅ Yes            | ❌ No             | ❌ No              | ❌ No      |
+| **ReportPersistenceService**      | ❌ No      | ❌ No             | ✅ Yes            | ❌ No              | ❌ No      |
+| **CipherHealthService**           | ❌ No      | ❌ No             | ❌ No             | ❌ No              | ❌ No      |
+| **MemberCipherMappingService**    | ❌ No      | ❌ No             | ❌ No             | ❌ No              | ❌ No      |
+| **DrawerStateService**            | ❌ No      | ❌ No             | ❌ No             | ✅ Yes (`drawer$`) | ✅ Yes     |
+
+### AccessIntelligenceDataService (Orchestrator)
+
+**Single Responsibility:** Orchestrate data loading, generation, persistence, and state management.
+
+**Pattern:**
+
+```typescript
+export class DefaultAccessIntelligenceDataService {
+  private _report = new BehaviorSubject<RiskInsightsView | null>(null);
+  readonly report$ = this._report.asObservable();
+
+  generateNewReport(orgId: OrganizationId): Observable<void> {
+    // 1. Load data (this service's responsibility)
+    return forkJoin({
+      ciphers: from(this.cipherService.getAllFromApiForOrganization(orgId)),
+      members: from(this.organizationService.getOrganizationUsers(orgId)),
+      // ... load collections and groups
+    }).pipe(
+      // 2. Generate report (delegate to ReportGenerationService)
+      switchMap((data) => this.reportGenerationService.generateReport(...data)),
+
+      // 3. Save report (delegate to ReportPersistenceService)
+      switchMap((view) => this.reportPersistenceService.save(view)),
+
+      // 4. Update state (this service's responsibility)
+      tap((savedView) => this._reportSubject.next(savedView)),
+    );
+  }
+
+  markApplicationAsCritical(appName: string): Observable<void> {
+    const current = this._report.value;
+    current.markApplicationAsCritical(appName); // Mutate
+    this._report.next(current); // Emit
+    return this.reportPersistenceService.save(current); // Persist
+  }
+}
+```
+
+### ReportGenerationService (Pure Transformation)
+
+**Single Responsibility:** Transform pre-loaded data into RiskInsightsView.
+
+**Pattern:**
+
+```typescript
+export class DefaultReportGenerationService {
+  generateReport(
+    ciphers: CipherView[], // Pre-loaded by caller
+    members: OrganizationUserView[], // Pre-loaded by caller
+    collectionAccess: CollectionAccessDetails[], // Pre-loaded by caller
+    groupMemberships: GroupMembershipDetails[], // Pre-loaded by caller
+    previousApplications?: RiskInsightsApplicationView[],
+  ): Observable<RiskInsightsView> {
+    // Run health checks + member mapping → aggregate → build view
+    // Does NOT load data, does NOT save data
+  }
+}
+```
+
+**Why this pattern:**
+
+- Data service controls WHEN to reload vs reuse cached data
+- Generation service is pure transformation (easier to test)
+- Ciphers can be exposed via `ciphers$` for `getCipherIcon()` and other UI needs
+
+---
+
+## Helper Functions vs Service Methods
+
+**Rule:** Helper functions should only be extracted into separate files if they are **shared across multiple services**.
+
+**Pattern 1: Private Methods (Preferred)**
+
+```typescript
+// ✅ CORRECT - Used only by this service
+export class DefaultReportGenerationService {
+  private groupCiphersByApplication(ciphers: CipherView[]): Map<string, CipherView[]> {
+    // ... implementation
+  }
+}
+```
+
+**Pattern 2: Shared Helpers (Only when needed)**
+
+```typescript
+// ✅ CORRECT - Used by multiple services
+// helpers/risk-insights-data-mappers.ts
+export function getTrimmedCipherUris(cipher: CipherView): string[] {
+  // ... used by ReportGenerationService AND other services
+}
+```
+
+**Why:**
+
+- Reduces file bloat
+- Clearer ownership (method belongs to the service)
+- Only extract when reuse is proven, not speculative
+
+**User feedback that led to this standard:**
+
+> "Helper functions should only be taken out of services if they are going to be used in other services."
+
+---
+
+## Related Documentation
+
+**Standards:**
+
+- [Model Standards](./model-standards.md) - 4-layer model architecture used by services
+- [RxJS Standards](./rxjs-standards.md) - Observable patterns and error handling
+- [Code Organization Standards](./code-organization-standards.md) - Service naming and organization
+- [Testing Standards - Services](./testing-standards-services.md) - Testing service patterns
+
+**Playbooks:**
+
+- [Service Implementation Playbook](../playbooks/service-implementation-playbook.md) - Step-by-step service implementation guide
+
+**Navigation:**
+
+- [Standards Hub](./README.md) - All DIRT team standards
+
+---
+
+**Document Version:** 1.0
+**Last Updated:** 2026-02-17
+**Maintainer:** DIRT Team

--- a/bitwarden_license/bit-common/src/dirt/docs/standards/testing-standards-components.md
+++ b/bitwarden_license/bit-common/src/dirt/docs/standards/testing-standards-components.md
@@ -1,0 +1,544 @@
+# Access Intelligence - Component Testing Standards
+
+**Purpose:** Testing guidelines for Angular components in the Access Intelligence module
+
+**Related:** [testing-standards-services.md](./testing-standards-services.md) for service/model testing
+
+---
+
+## Table of Contents
+
+1. [Component Test Coverage Goals](#component-test-coverage-goals)
+2. [Angular Testing Utilities](#angular-testing-utilities)
+3. [Testing OnPush Components](#testing-onpush-components)
+4. [Testing Signal Inputs/Outputs](#testing-signal-inputsoutputs)
+5. [Testing with toSignal()](#testing-with-tosignal)
+6. [Storybook as Living Documentation](#storybook-as-living-documentation)
+7. [Component Test Structure](#component-test-structure)
+8. [Common Patterns](#common-patterns)
+9. [Running Component Tests](#running-component-tests)
+
+---
+
+## Component Test Coverage Goals
+
+**Follow Angular testing best practices** with comprehensive coverage for all component interactions.
+
+### Coverage Targets
+
+- **Component Creation:** Verify component initializes without errors
+- **Signal Inputs:** Test all input variations and edge cases
+- **Signal Outputs:** Test all event emissions
+- **User Interactions:** Test clicks, form inputs, keyboard events
+- **Computed Properties:** Test all derived state
+- **Conditional Rendering:** Test @if/@for blocks
+- **Edge Cases:** Empty states, loading states, error states
+
+### Example Coverage
+
+**V2 Reference Components:**
+
+- `risk-insights-v2.component.spec.ts` - Container with state management
+- `risk-insights-drawer-v2.component.spec.ts` - Pure presentation component
+
+---
+
+## Angular Testing Utilities
+
+### Required Imports
+
+```typescript
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { signal } from "@angular/core";
+import { By } from "@angular/platform-browser";
+```
+
+### TestBed Setup for OnPush Components
+
+```typescript
+describe("MyComponent", () => {
+  let component: MyComponent;
+  let fixture: ComponentFixture<MyComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MyComponent], // Standalone component
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(MyComponent);
+    component = fixture.componentInstance;
+  });
+
+  it("should create", () => {
+    expect(component).toBeTruthy();
+  });
+});
+```
+
+---
+
+## Testing OnPush Components
+
+**CRITICAL:** OnPush components only update when:
+
+- Signal changes (automatic)
+- Input references change
+- Events fire
+- `async` pipe emits
+
+### Pattern: Testing with OnPush
+
+```typescript
+it("should update when input changes", () => {
+  // Set initial input
+  fixture.componentRef.setInput("count", 5);
+  fixture.detectChanges();
+
+  expect(screen.getByText("Count: 5")).toBeInTheDocument();
+
+  // Change input
+  fixture.componentRef.setInput("count", 10);
+  fixture.detectChanges();
+
+  expect(screen.getByText("Count: 10")).toBeInTheDocument();
+});
+```
+
+**Key:** Always call `fixture.detectChanges()` after setting inputs or triggering events.
+
+---
+
+## Testing Signal Inputs/Outputs
+
+### Signal Inputs (`input<T>()` or `input.required<T>()`)
+
+**Angular 19+ Pattern:**
+
+```typescript
+// Component
+export class MyComponent {
+  count = input<number>(0);
+  name = input.required<string>();
+}
+
+// Test
+it("should handle signal inputs", () => {
+  fixture.componentRef.setInput("count", 5);
+  fixture.componentRef.setInput("name", "Test");
+  fixture.detectChanges();
+
+  expect(component.count()).toBe(5);
+  expect(component.name()).toBe("Test");
+});
+```
+
+### Signal Outputs (`output<T>()`)
+
+**Angular 19+ Pattern:**
+
+```typescript
+// Component
+export class MyComponent {
+  clicked = output<string>();
+
+  handleClick() {
+    this.clicked.emit("button-clicked");
+  }
+}
+
+// Test
+it("should emit output when clicked", () => {
+  const emitSpy = jest.fn();
+  component.clicked.subscribe(emitSpy);
+
+  component.handleClick();
+
+  expect(emitSpy).toHaveBeenCalledWith("button-clicked");
+});
+```
+
+---
+
+## Testing with toSignal()
+
+**Pattern:** Components convert Observables to Signals at the boundary
+
+```typescript
+// Component
+export class MyComponent {
+  private dataService = inject(AccessIntelligenceDataService);
+  report = toSignal(this.dataService.report$);
+}
+
+// Test - Mock the service
+it("should display report data", () => {
+  const mockReport = new RiskInsightsView();
+  mockReport.getTotalMemberCount = jest.fn(() => 42);
+
+  const mockDataService = {
+    report$: of(mockReport),
+  };
+
+  TestBed.overrideProvider(AccessIntelligenceDataService, {
+    useValue: mockDataService,
+  });
+
+  fixture = TestBed.createComponent(MyComponent);
+  component = fixture.componentInstance;
+  fixture.detectChanges();
+
+  expect(screen.getByText("42 members")).toBeInTheDocument();
+});
+```
+
+**Key Pattern:** Mock the service Observable, not the Signal.
+
+---
+
+## Storybook as Living Documentation
+
+**Every reusable component should have a Storybook.**
+
+### Storybook File Structure
+
+```typescript
+// my-component.stories.ts
+import type { Meta, StoryObj } from "@storybook/angular";
+import { MyComponent } from "./my-component.component";
+
+const meta: Meta<MyComponent> = {
+  title: "Access Intelligence/MyComponent",
+  component: MyComponent,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<MyComponent>;
+
+export const Default: Story = {
+  args: {
+    title: "Default Title",
+    count: 0,
+  },
+};
+
+export const WithData: Story = {
+  args: {
+    title: "With Data",
+    count: 42,
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    title: "Loading",
+    isLoading: true,
+  },
+};
+```
+
+### Storybook Coverage Goals
+
+- **Default state** - Base configuration
+- **With data** - Populated with realistic data
+- **Loading state** - Show loading indicators
+- **Error state** - Show error messages
+- **Empty state** - No data available
+- **Edge cases** - Long text, large numbers, etc.
+
+---
+
+## Component Test Structure
+
+### Recommended Test Organization
+
+```typescript
+describe("MyComponent", () => {
+  let component: MyComponent;
+  let fixture: ComponentFixture<MyComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MyComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(MyComponent);
+    component = fixture.componentInstance;
+  });
+
+  describe("Component Creation", () => {
+    it("should create", () => {
+      expect(component).toBeTruthy();
+    });
+  });
+
+  describe("Signal Inputs", () => {
+    it("should accept count input", () => {
+      fixture.componentRef.setInput("count", 10);
+      expect(component.count()).toBe(10);
+    });
+
+    it("should handle count changes", () => {
+      fixture.componentRef.setInput("count", 5);
+      fixture.detectChanges();
+      expect(screen.getByText("5")).toBeInTheDocument();
+
+      fixture.componentRef.setInput("count", 10);
+      fixture.detectChanges();
+      expect(screen.getByText("10")).toBeInTheDocument();
+    });
+  });
+
+  describe("Signal Outputs", () => {
+    it("should emit clicked event", () => {
+      const emitSpy = jest.fn();
+      component.clicked.subscribe(emitSpy);
+
+      const button = fixture.debugElement.query(By.css("button"));
+      button.nativeElement.click();
+
+      expect(emitSpy).toHaveBeenCalledWith("clicked");
+    });
+  });
+
+  describe("User Interactions", () => {
+    it("should handle button click", () => {
+      fixture.componentRef.setInput("count", 0);
+      fixture.detectChanges();
+
+      const button = fixture.debugElement.query(By.css("button"));
+      button.nativeElement.click();
+      fixture.detectChanges();
+
+      expect(component.count()).toBe(1);
+    });
+  });
+
+  describe("Computed Properties", () => {
+    it("should compute derived values", () => {
+      fixture.componentRef.setInput("count", 5);
+      expect(component.doubleCount()).toBe(10);
+    });
+  });
+
+  describe("Edge Cases", () => {
+    it("should handle empty state", () => {
+      fixture.componentRef.setInput("items", []);
+      fixture.detectChanges();
+
+      expect(screen.getByText("No items")).toBeInTheDocument();
+    });
+
+    it("should handle loading state", () => {
+      fixture.componentRef.setInput("isLoading", true);
+      fixture.detectChanges();
+
+      expect(screen.getByText("Loading...")).toBeInTheDocument();
+    });
+  });
+});
+```
+
+---
+
+## Common Patterns
+
+### Testing Conditional Rendering (@if)
+
+```typescript
+// Component template
+@if (showDetails()) {
+  <div>Details</div>
+}
+
+// Test
+it("should show details when flag is true", () => {
+  component.showDetails = signal(true);
+  fixture.detectChanges();
+
+  expect(screen.getByText("Details")).toBeInTheDocument();
+});
+
+it("should hide details when flag is false", () => {
+  component.showDetails = signal(false);
+  fixture.detectChanges();
+
+  expect(screen.queryByText("Details")).not.toBeInTheDocument();
+});
+```
+
+### Testing Loops (@for)
+
+```typescript
+// Component template
+@for (item of items(); track item.id) {
+  <div>{{ item.name }}</div>
+}
+
+// Test
+it("should render all items", () => {
+  const items = [
+    { id: 1, name: "Item 1" },
+    { id: 2, name: "Item 2" },
+  ];
+
+  component.items = signal(items);
+  fixture.detectChanges();
+
+  expect(screen.getByText("Item 1")).toBeInTheDocument();
+  expect(screen.getByText("Item 2")).toBeInTheDocument();
+});
+```
+
+### Testing Service Integration
+
+```typescript
+it("should call service method on action", () => {
+  const mockService = {
+    save: jest.fn().mockReturnValue(of(void 0)),
+  };
+
+  TestBed.overrideProvider(MyService, { useValue: mockService });
+
+  fixture = TestBed.createComponent(MyComponent);
+  component = fixture.componentInstance;
+  fixture.detectChanges();
+
+  const button = fixture.debugElement.query(By.css(".save-button"));
+  button.nativeElement.click();
+
+  expect(mockService.save).toHaveBeenCalled();
+});
+```
+
+### Testing Async Operations
+
+```typescript
+it("should handle async data loading", fakeAsync(() => {
+  const mockData = new RiskInsightsView();
+  const mockService = {
+    report$: of(mockData).pipe(delay(100)),
+  };
+
+  TestBed.overrideProvider(AccessIntelligenceDataService, {
+    useValue: mockService,
+  });
+
+  fixture = TestBed.createComponent(MyComponent);
+  component = fixture.componentInstance;
+  fixture.detectChanges();
+
+  // Initially loading
+  expect(component.report()).toBeUndefined();
+
+  // Advance time
+  tick(100);
+  fixture.detectChanges();
+
+  // Now loaded
+  expect(component.report()).toBe(mockData);
+}));
+```
+
+---
+
+## Running Component Tests
+
+### Run All Tests
+
+```bash
+npm test
+```
+
+### Run Specific Component Test
+
+```bash
+npm test -- my-component.component.spec.ts
+```
+
+### Run Tests in Watch Mode
+
+```bash
+npm test -- --watch
+```
+
+### Run Storybook
+
+```bash
+npm run storybook
+```
+
+### Type Check After Tests
+
+```bash
+npm run test:types
+```
+
+**ALWAYS run type check after tests** to catch TypeScript errors that Jest might miss.
+
+---
+
+## Testing Checklist
+
+Use this checklist for each component:
+
+- [ ] Component creates without errors
+- [ ] All signal inputs tested (default + edge cases)
+- [ ] All signal outputs tested (event emissions)
+- [ ] User interactions tested (clicks, forms, keyboard)
+- [ ] Computed properties tested (derived state)
+- [ ] Conditional rendering tested (@if blocks)
+- [ ] Loops tested (@for blocks with track)
+- [ ] Service integrations tested (mocked services)
+- [ ] Async operations tested (loading, error states)
+- [ ] Edge cases tested (empty, loading, error)
+- [ ] Storybook created with all variants
+- [ ] Type check passes (npm run test:types)
+
+---
+
+## Reference Components
+
+**V2 Components (completed, use as examples):**
+
+- `v2/risk-insights-v2.component.ts` - Container with state management
+  - Tests: Signal inputs, service integration, user actions
+- `v2/shared/risk-insights-drawer-v2.component.ts` - Pure presentation
+  - Tests: Signal inputs/outputs, conditional rendering
+
+**Study these for patterns:**
+
+- How to mock `AccessIntelligenceDataService`
+- How to test `toSignal()` conversions
+- How to test computed signals
+- How to test OnPush change detection
+
+---
+
+## Related Documentation
+
+**Playbooks:**
+
+- [Component Migration Playbook](../playbooks/component-migration-playbook.md) - Migrating components to modern patterns
+
+**Standards:**
+
+- [Angular Standards](./angular-standards.md) - Angular-specific patterns
+- [Service Testing Standards](./testing-standards-services.md) - Service/model testing
+- [Code Organization Standards](./code-organization-standards.md) - Naming and structure
+
+**External Resources:**
+
+- [Bitwarden Angular Guide](https://contributing.bitwarden.com/contributing/code-style/web/angular/)
+- [Angular Testing Guide](https://angular.io/guide/testing)
+- [Jest Documentation](https://jestjs.io/docs/getting-started)
+
+**Navigation:**
+
+- [Standards Hub](./README.md) - All DIRT team standards
+
+---
+
+**Document Version:** 1.0
+**Last Updated:** 2026-02-17
+**Maintainer:** DIRT Team

--- a/bitwarden_license/bit-common/src/dirt/docs/standards/testing-standards-services.md
+++ b/bitwarden_license/bit-common/src/dirt/docs/standards/testing-standards-services.md
@@ -1,0 +1,582 @@
+# Access Intelligence - Service Testing Standards
+
+**Purpose:** Testing guidelines for platform-agnostic services and domain models
+
+**Related:** [testing-standards-components.md](./testing-standards-components.md) for Angular component testing
+
+---
+
+## Table of Contents
+
+1. [Test Organization and Coverage](#test-organization-and-coverage)
+2. [Bitwarden Test Utilities](#bitwarden-test-utilities)
+3. [Shared Test Helpers](#shared-test-helpers)
+4. [Avoiding `any` Types in Tests](#avoiding-any-types-in-tests)
+5. [Test Structure and Patterns](#test-structure-and-patterns)
+6. [Manual Construction for Test Fixtures](#manual-construction-for-test-fixtures)
+7. [Testing View Model Methods](#testing-view-model-methods)
+8. [Running Tests](#running-tests)
+
+---
+
+## Test Organization and Coverage
+
+**Follow the CipherView pattern** - comprehensive test coverage for smart models and services.
+
+**Coverage Goals:**
+
+- **View Models**: 8-10 tests per model covering all query, update, and computation methods
+- **Services**: Test both integration flows and individual methods
+- **Test Files**: Co-locate with source (`*.spec.ts` next to `*.ts`)
+
+**Example Coverage:**
+
+- [risk-insights.view.spec.ts](../../reports/risk-insights/models/view/risk-insights.view.spec.ts) - 31 tests for RiskInsightsView
+- [risk-insights-report.view.spec.ts](../../reports/risk-insights/models/view/risk-insights-report.view.spec.ts) - 23 tests for RiskInsightsReportView
+- [default-report-generation.service.spec.ts](../../reports/risk-insights/services/implementations/default-report-generation.service.spec.ts) - 17 tests for service
+
+---
+
+## Bitwarden Test Utilities
+
+**ALWAYS use Bitwarden's built-in test utilities** from `@bitwarden/common/spec` instead of constructing test objects directly.
+
+### Available Utilities
+
+```typescript
+import {
+  makeEncString,
+  makeStaticByteArray,
+  makeSymmetricCryptoKey,
+  GetUniqueString,
+} from "@bitwarden/common/spec";
+```
+
+### makeEncString
+
+**Use for:** Creating test EncString objects
+
+```typescript
+// ✅ CORRECT - Use makeEncString
+const encKey = makeEncString("test-data");
+const report = new RiskInsights();
+report.contentEncryptionKey = makeEncString("encryption-key");
+
+// ❌ WRONG - Don't construct EncString directly
+const encKey = new EncString("test-data");
+```
+
+**Why:**
+
+- Properly constructed EncString with correct encryption type
+- Consistent test data format
+- Avoids subtle bugs from incorrect EncString construction
+
+### makeStaticByteArray
+
+**Use for:** Creating deterministic byte arrays for crypto operations
+
+```typescript
+// ✅ CORRECT - Creates [0, 1, 2, ..., 63]
+const key = makeStaticByteArray(64);
+
+// With offset - creates [10, 11, 12, ..., 73]
+const key = makeStaticByteArray(64, 10);
+```
+
+**Why:**
+
+- Deterministic - same input always produces same output
+- Predictable for testing crypto operations
+- No random failures from varying test data
+
+### makeSymmetricCryptoKey
+
+**Use for:** Creating test symmetric keys
+
+```typescript
+// ✅ CORRECT - Create 64-byte key with seed
+const userKey = makeSymmetricCryptoKey<UserKey>(64, 0);
+const orgKey = makeSymmetricCryptoKey<OrgKey>(64, 1);
+
+// Different seeds create different keys
+const key1 = makeSymmetricCryptoKey(64, 0);
+const key2 = makeSymmetricCryptoKey(64, 1);
+```
+
+**Parameters:**
+
+- `length`: Key size (32 or 64 bytes)
+- `seed`: Optional seed for deterministic generation (default: 0)
+
+### GetUniqueString
+
+**Use for:** Generating unique test identifiers
+
+```typescript
+// ✅ CORRECT - Creates unique strings
+const userId = GetUniqueString("user"); // "user_abc-123-def"
+const reportId = GetUniqueString("report"); // "report_xyz-456-ghi"
+
+// Without prefix
+const id = GetUniqueString(); // "abc-123-def-456"
+```
+
+**Why:**
+
+- Ensures test isolation (no ID collisions)
+- Readable test output (prefix helps identify what failed)
+- Already used by Access Intelligence shared helpers
+
+### Quick Reference
+
+| Utility                               | Use For                   | Example                           |
+| ------------------------------------- | ------------------------- | --------------------------------- |
+| `makeEncString(data?)`                | Test EncStrings           | `makeEncString("encrypted-data")` |
+| `makeStaticByteArray(len, start?)`    | Deterministic byte arrays | `makeStaticByteArray(64)`         |
+| `makeSymmetricCryptoKey(len?, seed?)` | Test crypto keys          | `makeSymmetricCryptoKey(64, 0)`   |
+| `GetUniqueString(prefix?)`            | Unique test IDs           | `GetUniqueString("user")`         |
+
+---
+
+## Shared Test Helpers
+
+**ALWAYS use shared test helpers** instead of duplicating helper functions.
+
+**Location:** [`testing/test-helpers.ts`](../../reports/risk-insights/testing/test-helpers.ts)
+
+### Available Helpers
+
+```typescript
+// RiskInsights View helpers
+createRiskInsights(options?) → RiskInsightsView
+createRiskInsightsSummary(counts?) → RiskInsightsSummaryView
+createRiskInsightsMetrics(counts?) → RiskInsightsMetrics
+
+// Member helpers
+createMember(id?, name?, email?) → OrganizationUserView
+createMemberRegistry(members[]) → MemberRegistry
+
+// Cipher helpers
+createCipher(id?, uris[], collectionIds[]) → CipherView
+createCipherHealth(isAtRisk, options?) → CipherHealthView
+
+// Collection & Group helpers
+createCollectionAccess(collectionId, userIds[], groupIds[]) → CollectionAccessDetails
+createGroupMembership(groupId, memberIds[]) → GroupMembershipDetails
+
+// Report & Application helpers
+createReport(appName, memberRefs{}, cipherRefs{}) → RiskInsightsReportView
+createApplication(name, isCritical, reviewedDate?) → RiskInsightsApplicationView
+
+// Composite helpers
+createTestScenario({ memberCount, applications[], ciphersPerApp }) → Complete test data
+```
+
+### Usage Example
+
+```typescript
+import {
+  createRiskInsights,
+  createRiskInsightsSummary,
+  createMember,
+  createCipher,
+  createReport,
+} from "../../testing/test-helpers";
+import { makeEncString } from "@bitwarden/common/spec";
+
+describe("MyService", () => {
+  it("should process data correctly", () => {
+    // Create full RiskInsights view
+    const riskInsights = createRiskInsights({
+      id: "report-123" as OrganizationReportId,
+      organizationId: "org-456" as OrganizationId,
+      reports: [createReport("github.com", { u1: true }, { c1: true })],
+      summary: createRiskInsightsSummary({
+        totalApplicationCount: 10,
+        totalMemberCount: 50,
+      }),
+    });
+
+    // Create individual test data
+    const member = createMember("u1", "Alice", "alice@example.com");
+    const cipher = createCipher("c1", ["https://github.com"], ["coll-1"]);
+
+    // Use Bitwarden utilities for crypto objects
+    const encKey = makeEncString("test-key");
+
+    // ... test logic
+  });
+});
+```
+
+### Benefits
+
+- ✅ **DRY** - No duplicate helper code
+- ✅ **Consistency** - Same test data patterns everywhere
+- ✅ **Maintainability** - Update once, affects all tests
+- ✅ **Integration** - Uses `GetUniqueString()` from `@bitwarden/common/spec`
+
+---
+
+## Avoiding `any` Types in Tests
+
+**Rule:** Avoid `any` types in test code. Use proper TypeScript typing.
+
+### Pattern 1: Type Test Objects Properly
+
+```typescript
+// ❌ WRONG - Using `any`
+const json: any = {
+  id: "report-123",
+  organizationId: "org-456",
+};
+
+// ✅ CORRECT - Using Partial<DeepJsonify<T>>
+const json: Partial<DeepJsonify<RiskInsightsView>> = {
+  id: "report-123" as OrganizationReportId,
+  organizationId: "org-456" as OrganizationId,
+};
+```
+
+**Why:**
+
+- Type safety catches errors at compile time
+- Better IDE autocomplete and refactoring support
+- Documents expected data structure
+
+### Pattern 2: Cast Tagged Types
+
+```typescript
+// For Tagged types (OrganizationId, OrganizationReportId, CipherId, etc.)
+const testData: ApplicationHealthReportDetail = {
+  applicationName: "github.com",
+  cipherIds: ["cipher-1" as CipherId, "cipher-2" as CipherId],
+  atRiskCipherIds: ["cipher-1" as CipherId],
+  // ... other fields
+};
+```
+
+### Pattern 3: Omit Properties Instead of Setting to `undefined`
+
+```typescript
+// ❌ WRONG - Setting to undefined (causes type errors)
+const json = {
+  applicationName: "github.com",
+  memberRefs: undefined, // Type error!
+  cipherRefs: undefined, // Type error!
+};
+
+// ✅ CORRECT - Omit the properties
+const json = {
+  applicationName: "github.com",
+  // memberRefs and cipherRefs intentionally omitted to test defaults
+};
+```
+
+### Pattern 4: Avoid Type Assertions for Incomplete Objects
+
+**Issue:** Type assertions (`as Type`) bypass TypeScript's type checking. When types evolve (new required fields), assertions hide compilation errors.
+
+```typescript
+// ❌ WRONG - Type assertion hides missing required fields
+const testData = {
+  applicationName: "github.com",
+  cipherIds: ["cipher-1"],
+  // Missing: passwordCount, atRiskPasswordCount, memberCount, atRiskMemberCount
+} as ApplicationHealthReportDetail;
+
+// ✅ CORRECT - Create complete object (compiler enforces all fields)
+const testData: ApplicationHealthReportDetail = {
+  applicationName: "github.com",
+  passwordCount: 2,
+  atRiskPasswordCount: 1,
+  cipherIds: ["cipher-1" as CipherId, "cipher-2" as CipherId],
+  atRiskCipherIds: ["cipher-1" as CipherId],
+  memberCount: 1,
+  atRiskMemberCount: 1,
+  memberDetails: [
+    {
+      userGuid: "member-1",
+      userName: "John Doe",
+      email: "john@example.com",
+      cipherId: "cipher-1",
+    },
+  ],
+  atRiskMemberDetails: [
+    {
+      userGuid: "member-1",
+      userName: "John Doe",
+      email: "john@example.com",
+      cipherId: "cipher-1",
+    },
+  ],
+};
+```
+
+**When Type Assertions Are Acceptable:**
+
+- Casting string to Tagged types: `"user-123" as UserId`
+- Test setup where partial object is intentional: `{} as any` for mock objects
+- Never for production-like test data structures
+
+---
+
+## Test Structure and Patterns
+
+### Standard Test Structure
+
+**Follow this structure:**
+
+```typescript
+describe("ServiceOrModelName", () => {
+  // ==================== Test Helpers (if needed) ====================
+
+  // Import shared helpers at the top
+  // Only create local helpers if they have a specific signature unique to this file
+
+  // ==================== Setup ====================
+
+  beforeEach(() => {
+    // Setup mocks, services, etc.
+  });
+
+  // ==================== Tests by Feature/Method ====================
+
+  describe("methodName", () => {
+    it("should handle typical case", () => {
+      // Arrange
+      const input = createTestData();
+
+      // Act
+      const result = method(input);
+
+      // Assert
+      expect(result).toBe(expected);
+    });
+
+    it("should handle edge case", () => {
+      // ...
+    });
+  });
+});
+```
+
+### Test Grouping
+
+- Group related tests with `describe()` blocks
+- Test one method/feature per describe block
+- Use clear, descriptive test names ("should X when Y")
+
+### Arrange-Act-Assert Pattern
+
+```typescript
+it("should compute summary correctly", () => {
+  // Arrange - Setup test data
+  const view = new RiskInsightsView();
+  view.reports = [createReport("github.com", { u1: true }, { c1: true })];
+
+  // Act - Execute the code under test
+  view.recomputeSummary();
+
+  // Assert - Verify the results
+  expect(view.summary.totalApplicationCount).toBe(1);
+  expect(view.summary.totalAtRiskApplicationCount).toBe(1);
+});
+```
+
+---
+
+## Manual Construction for Test Fixtures
+
+**Rule:** Use manual construction for test fixtures, NOT `fromJSON()`.
+
+```typescript
+// ✅ CORRECT - Manual construction
+const view = new RiskInsightsView();
+view.id = "test-id" as OrganizationReportId;
+view.reports = [createReport("github.com", {}, {})];
+view.memberRegistry = createMemberRegistry([...]);
+
+// ❌ WRONG - Using fromJSON for test fixtures
+const view = RiskInsightsView.fromJSON({
+  id: "test-id",
+  reports: [...],
+});
+```
+
+**Why:**
+
+- More explicit and readable
+- Easier to see what properties are being tested
+- Avoids coupling tests to serialization logic
+- Reserve `fromJSON()` tests for testing serialization itself
+
+**Exception:** Test `fromJSON()` itself
+
+```typescript
+describe("fromJSON", () => {
+  it("should deserialize correctly", () => {
+    const json: Partial<DeepJsonify<RiskInsightsView>> = {
+      id: "test-id" as OrganizationReportId,
+      reports: [...],
+    };
+
+    const view = RiskInsightsView.fromJSON(json);
+
+    expect(view.id).toBe("test-id");
+  });
+});
+```
+
+---
+
+## Testing View Model Methods
+
+**Pattern:** Test query methods, update methods, and computation methods separately.
+
+```typescript
+describe("RiskInsightsView", () => {
+  describe("Query Methods", () => {
+    describe("getAtRiskMembers", () => {
+      it("should return all unique at-risk members", () => { ... });
+      it("should deduplicate members across applications", () => { ... });
+      it("should return empty array when no at-risk members", () => { ... });
+    });
+  });
+
+  describe("Update Methods", () => {
+    describe("markApplicationAsCritical", () => {
+      it("should mark existing application as critical", () => { ... });
+      it("should add new application if not in list", () => { ... });
+      it("should trigger summary recomputation", () => { ... });
+    });
+  });
+
+  describe("Computation Methods", () => {
+    describe("recomputeSummary", () => {
+      it("should compute total counts correctly", () => { ... });
+      it("should deduplicate at-risk members", () => { ... });
+    });
+  });
+});
+```
+
+**Benefits:**
+
+- Clear organization by functionality
+- Easy to find tests for specific methods
+- Encourages comprehensive coverage of all method types
+
+---
+
+## Running Tests
+
+```bash
+# Run specific test file
+npm test -- path/to/file.spec.ts
+
+# Run all tests in a directory
+npm test -- bitwarden_license/bit-common/src/dirt/reports/risk-insights
+
+# Run tests with coverage
+npm test -- --coverage
+
+# Type-check after tests (catches TypeScript errors)
+npm run test:types
+
+# Lint check (catches import order, formatting issues)
+npm run lint
+
+# Auto-fix linting issues
+npm run lint -- --fix
+
+# Watch mode for development
+npm test -- --watch path/to/file.spec.ts
+```
+
+### Pre-Commit Checklist
+
+**Run these commands before committing:**
+
+```bash
+# 1. Run all tests
+npm test -- bitwarden_license/bit-common/src/dirt/reports/risk-insights
+
+# 2. Type-check
+npm run test:types
+
+# 3. Lint and auto-fix
+npm run lint -- --fix
+```
+
+**Why:**
+
+- Tests catch runtime issues
+- `test:types` catches TypeScript errors
+- `lint --fix` catches and auto-fixes import order, formatting, unused imports
+- Running all three ensures clean, working code
+
+### Test Output Tips
+
+**Filter tests by pattern:**
+
+```bash
+# Run only tests matching "saveReport"
+npm test -- default-report-persistence.service.spec.ts -t "saveReport"
+
+# Run tests in specific describe block
+npm test -- risk-insights.view.spec.ts -t "Query Methods"
+```
+
+**Debugging failed tests:**
+
+```bash
+# Run with verbose output
+npm test -- --verbose path/to/file.spec.ts
+
+# Run single test file without parallel execution
+npm test -- --runInBand path/to/file.spec.ts
+```
+
+---
+
+## Quick Reference
+
+| Do                                                     | Don't                                 |
+| ------------------------------------------------------ | ------------------------------------- |
+| ✅ Use `makeEncString()` from `@bitwarden/common/spec` | ❌ Use `new EncString()` directly     |
+| ✅ Use `Partial<DeepJsonify<T>>` for JSON test data    | ❌ Use `any` for test data            |
+| ✅ Import shared test helpers                          | ❌ Duplicate helper functions         |
+| ✅ Manual construction for fixtures                    | ❌ Use `fromJSON()` for fixtures      |
+| ✅ Cast Tagged types (`as CipherId`)                   | ❌ Type assert incomplete objects     |
+| ✅ Omit optional properties                            | ❌ Set properties to `undefined`      |
+| ✅ Create complete test objects                        | ❌ Hide missing fields with `as Type` |
+| ✅ Group tests by method/feature                       | ❌ Flat test structure                |
+| ✅ Clear, descriptive test names                       | ❌ Vague test names like "works"      |
+| ✅ Arrange-Act-Assert pattern                          | ❌ Mix setup and assertions           |
+
+---
+
+## Related Documentation
+
+**Standards:**
+
+- [Model Standards](./model-standards.md) - View model construction and EncString patterns
+- [Service Standards](./service-standards.md) - Service responsibility patterns to test
+- [RxJS Standards](./rxjs-standards.md) - Observable patterns and error handling
+- [Testing Standards - Components](./testing-standards-components.md) - Angular component testing
+
+**Playbooks:**
+
+- [Service Implementation Playbook](../playbooks/service-implementation-playbook.md) - Implementing testable services
+
+**Navigation:**
+
+- [Standards Hub](./README.md) - All DIRT team standards
+
+---
+
+**Document Version:** 1.0
+**Last Updated:** 2026-02-17
+**Maintainer:** DIRT Team


### PR DESCRIPTION
## 🎟️ Tracking

[PM-32426](https://bitwarden.atlassian.net/browse/PM-32426)

## 📔 Objective

This pull request adds dirt team standards to the dirt/docs. This is one of many pull requests to add team documentation.

**Changes**

Add files to the standards folder:
- **README.md**: Hub for all DIRT team development standards and conventions
- **angular-standards.md**: Standards for Angular-specific state management patterns, including Observable vs Signal usage, mutation patterns, and smart model implementation in Access Intelligence development
- **code-organization-standards.md:** Standards for naming conventions, code organization, file structure, and documentation practices in Access Intelligence development
- **documentation-standards.md:** Standards and conventions for DIRT team documentation
- **model-standards.md:** Standards for view model construction, 4-layer model architecture, and working with encrypted strings in Access Intelligence development
- **rxjs-standards.md:** Standards for RxJS patterns, Observable error handling, and common import paths for reactive programming in Access Intelligence development
- **service-standards.md:** Standards for service responsibility patterns, separation of concerns, and helper function extraction in Access Intelligence development
- **testing-standards-components.md:** Testing guidelines for Angular components in the Access Intelligence module
- **testing-standards-services.md:** Testing guidelines for platform-agnostic services and domain models

Related Pull Request: [[PM-32426] Add DIRT Core Docs](https://github.com/bitwarden/clients/pull/19048)

[PM-32426]: https://bitwarden.atlassian.net/browse/PM-32426?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-32426]: https://bitwarden.atlassian.net/browse/PM-32426?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ