### PR TITLE
[RELEASE-2377] hotfix: bump desktop and cargo dependency versions

### DIFF
--- a/apps/desktop/desktop_native/Cargo.lock
+++ b/apps/desktop/desktop_native/Cargo.lock
@@ -486,9 +486,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "camino"

--- a/apps/desktop/desktop_native/Cargo.toml
+++ b/apps/desktop/desktop_native/Cargo.toml
@@ -27,7 +27,7 @@ ashpd = "=0.12.0"
 base64 = "=0.22.1"
 bitwarden-russh = { git = "https://github.com/bitwarden/bitwarden-russh.git", rev = "a641316227227f8777fdf56ac9fa2d6b5f7fe662" }
 byteorder = "=1.5.0"
-bytes = "=1.11.0"
+bytes = "=1.11.1"
 cbc = "=0.1.2"
 chacha20poly1305 = "=0.10.1"
 core-foundation = "=0.10.1"


### PR DESCRIPTION
## 🎟️ Tracking

[RELEASE-2377](https://bitwarden.atlassian.net/browse/RELEASE-2377)

## 📔 Objective

Pulls in a fix for a vulnerable dependency.

[RELEASE-2377]: https://bitwarden.atlassian.net/browse/RELEASE-2377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ