### PR TITLE
[CL-1026] Cherry pick icon tile refresh to main

### DIFF
--- a/apps/browser/src/dirt/phishing-detection/popup/phishing-warning.component.html
+++ b/apps/browser/src/dirt/phishing-detection/popup/phishing-warning.component.html
@@ -1,6 +1,6 @@
 <div class="tw-flex tw-flex-col">
   <div class="tw-flex tw-gap-4 tw-items-baseline">
-    <bit-icon-tile size="large" icon="bwi-exclamation-triangle" variant="danger"></bit-icon-tile>
+    <bit-icon-tile size="lg" icon="bwi-exclamation-triangle" variant="danger"></bit-icon-tile>
     <h1 bitTypography="h2" noMargin class="!tw-mb-0">{{ "phishingPageTitleV2" | i18n }}</h1>
   </div>
 

--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/activity/application-review-dialog/assign-tasks-view.component.html
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/activity/application-review-dialog/assign-tasks-view.component.html
@@ -17,7 +17,7 @@
         <bit-icon-tile
           icon="bwi-users"
           variant="primary"
-          size="large"
+          size="lg"
           shape="circle"
           aria-hidden="true"
         ></bit-icon-tile>
@@ -36,7 +36,7 @@
         <bit-icon-tile
           icon="bwi-desktop"
           variant="warning"
-          size="large"
+          size="lg"
           shape="circle"
           aria-hidden="true"
         ></bit-icon-tile>

--- a/libs/components/src/icon-tile/icon-tile.component.html
+++ b/libs/components/src/icon-tile/icon-tile.component.html
@@ -1,7 +1,7 @@
 <div
-  [ngClass]="containerClasses()"
+  [class]="containerClasses()"
   [attr.aria-label]="ariaLabel()"
   [attr.role]="ariaLabel() ? 'img' : null"
 >
-  <i [ngClass]="iconClasses()" aria-hidden="true"></i>
+  <i [class]="iconClasses()" aria-hidden="true"></i>
 </div>

--- a/libs/components/src/icon-tile/icon-tile.component.spec.ts
+++ b/libs/components/src/icon-tile/icon-tile.component.spec.ts
@@ -1,0 +1,59 @@
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+
+import { IconTileComponent } from "./icon-tile.component";
+
+describe("IconTileComponent", () => {
+  let component: IconTileComponent;
+  let fixture: ComponentFixture<IconTileComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [IconTileComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(IconTileComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput("icon", "bwi-star");
+    fixture.detectChanges();
+  });
+
+  it("creates", () => {
+    expect(component).toBeTruthy();
+  });
+
+  it("has aria-hidden on icon element", () => {
+    const icon = fixture.nativeElement.querySelector("i");
+    expect(icon.getAttribute("aria-hidden")).toBe("true");
+  });
+
+  describe("accessibility", () => {
+    it("sets aria-label and role when ariaLabel is provided", () => {
+      fixture.componentRef.setInput("ariaLabel", "Success indicator");
+      fixture.detectChanges();
+
+      const container = fixture.nativeElement.children[0];
+      expect(container.getAttribute("aria-label")).toBe("Success indicator");
+      expect(container.getAttribute("role")).toBe("img");
+    });
+
+    it("does not set role when ariaLabel is not provided", () => {
+      const container = fixture.nativeElement.children[0];
+      expect(container.getAttribute("aria-label")).toBeNull();
+      expect(container.getAttribute("role")).toBeNull();
+    });
+
+    it("updates aria-label when input changes", () => {
+      fixture.componentRef.setInput("ariaLabel", "Initial label");
+      fixture.detectChanges();
+
+      let container = fixture.nativeElement.children[0];
+      expect(container.getAttribute("aria-label")).toBe("Initial label");
+
+      fixture.componentRef.setInput("ariaLabel", "Updated label");
+      fixture.detectChanges();
+
+      container = fixture.nativeElement.children[0];
+      expect(container.getAttribute("aria-label")).toBe("Updated label");
+    });
+  });
+});

--- a/libs/components/src/icon-tile/icon-tile.component.ts
+++ b/libs/components/src/icon-tile/icon-tile.component.ts
@@ -1,48 +1,57 @@
-import { NgClass } from "@angular/common";
-import { Component, computed, input } from "@angular/core";
+import { ChangeDetectionStrategy, Component, computed, input } from "@angular/core";
 
 import { BitwardenIcon } from "../shared/icon";
 
-export type IconTileVariant = "primary" | "success" | "warning" | "danger" | "muted";
+export type IconTileVariant =
+  | "primary"
+  | "success"
+  | "danger"
+  | "warning"
+  | "subtle"
+  | "dark"
+  | "contrast";
 
-export type IconTileSize = "small" | "default" | "large";
-
-export type IconTileShape = "square" | "circle";
+export type IconTileSize = "xs" | "sm" | "base" | "lg" | "xl";
 
 const variantStyles: Record<IconTileVariant, string[]> = {
-  primary: ["tw-bg-primary-100", "tw-text-primary-700"],
-  success: ["tw-bg-success-100", "tw-text-success-700"],
-  warning: ["tw-bg-warning-100", "tw-text-warning-700"],
-  danger: ["tw-bg-danger-100", "tw-text-danger-700"],
-  muted: ["tw-bg-secondary-100", "tw-text-secondary-700"],
+  primary: ["tw-bg-bg-brand-soft", "tw-border-border-brand-soft", "tw-text-fg-brand"],
+  success: ["tw-bg-bg-success-medium", "tw-border-border-success-soft", "tw-text-fg-success"],
+  danger: ["tw-bg-bg-danger-medium", "tw-border-border-danger-soft", "tw-text-fg-danger"],
+  warning: ["tw-bg-bg-warning-medium", "tw-border-border-warning-soft", "tw-text-fg-warning"],
+  subtle: ["tw-bg-bg-quaternary", "tw-border-border-base", "tw-text-fg-body"],
+  dark: ["tw-bg-bg-contrast", "tw-border-border-strong", "tw-text-fg-contrast"],
+  contrast: ["tw-bg-bg-primary", "tw-border-border-base", "tw-text-fg-dark"],
 };
 
 const sizeStyles: Record<IconTileSize, { container: string[]; icon: string[] }> = {
-  small: {
+  xs: {
+    container: ["tw-w-4", "tw-h-4"],
+    icon: ["tw-text-xs", "tw-leading-[0]"],
+  },
+  sm: {
     container: ["tw-w-6", "tw-h-6"],
-    icon: ["tw-text-sm"],
+    icon: ["tw-text-sm", "tw-leading-[0]"],
   },
-  default: {
-    container: ["tw-w-8", "tw-h-8"],
-    icon: ["tw-text-base"],
-  },
-  large: {
-    container: ["tw-w-10", "tw-h-10"],
+  base: {
+    container: ["tw-w-9", "tw-h-9"],
     icon: ["tw-text-lg"],
+  },
+  lg: {
+    container: ["tw-w-12", "tw-h-12"],
+    icon: ["tw-text-2xl"],
+  },
+  xl: {
+    container: ["tw-w-16", "tw-h-16"],
+    icon: ["tw-text-3xl"],
   },
 };
 
-const shapeStyles: Record<IconTileShape, Record<IconTileSize, string[]>> = {
-  square: {
-    small: ["tw-rounded"],
-    default: ["tw-rounded-md"],
-    large: ["tw-rounded-lg"],
-  },
-  circle: {
-    small: ["tw-rounded-full"],
-    default: ["tw-rounded-full"],
-    large: ["tw-rounded-full"],
-  },
+const borderRadius: Record<IconTileSize, string[]> = {
+  xs: ["tw-rounded"],
+  sm: ["tw-rounded"],
+  base: ["tw-rounded-lg"],
+  lg: ["tw-rounded-lg"],
+  xl: ["tw-rounded-xl"],
 };
 
 /**
@@ -56,12 +65,10 @@ const shapeStyles: Record<IconTileShape, Record<IconTileSize, string[]>> = {
  * - Create visual hierarchy in lists or cards
  * - Show app or service icons in a consistent format
  */
-// FIXME(https://bitwarden.atlassian.net/browse/CL-764): Migrate to OnPush
-// eslint-disable-next-line @angular-eslint/prefer-on-push-component-change-detection
 @Component({
   selector: "bit-icon-tile",
   templateUrl: "icon-tile.component.html",
-  imports: [NgClass],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class IconTileComponent {
   /**
@@ -77,12 +84,7 @@ export class IconTileComponent {
   /**
    * The size of the icon tile
    */
-  readonly size = input<IconTileSize>("default");
-
-  /**
-   * The shape of the icon tile
-   */
-  readonly shape = input<IconTileShape>("square");
+  readonly size = input<IconTileSize>("base");
 
   /**
    * Optional aria-label for accessibility when the icon has semantic meaning
@@ -92,16 +94,16 @@ export class IconTileComponent {
   protected readonly containerClasses = computed(() => {
     const variant = this.variant();
     const size = this.size();
-    const shape = this.shape();
 
     return [
       "tw-inline-flex",
       "tw-items-center",
       "tw-justify-center",
       "tw-flex-shrink-0",
+      "tw-border",
       ...variantStyles[variant],
       ...sizeStyles[size].container,
-      ...shapeStyles[shape][size],
+      ...borderRadius[size],
     ];
   });
 

--- a/libs/components/src/icon-tile/icon-tile.mdx
+++ b/libs/components/src/icon-tile/icon-tile.mdx
@@ -1,0 +1,98 @@
+import { Meta, Canvas, Primary, Controls, Title, Description } from "@storybook/addon-docs/blocks";
+
+import * as stories from "./icon-tile.stories";
+
+<Meta of={stories} />
+
+```ts
+import { IconTileComponent } from "@bitwarden/components";
+```
+
+<Title />
+<Description />
+
+<Primary />
+<Controls />
+
+## Variants
+
+Icon tiles support 7 color variants
+
+<Canvas of={stories.AllVariants} />
+
+### Primary
+
+Used for brand-colored indicators and primary visual elements.
+
+### Success
+
+Indicates successful operations, positive status, or completed states.
+
+### Danger
+
+Represents errors, destructive actions, or critical warnings.
+
+### Warning
+
+Used for caution states, alerts, or situations requiring attention.
+
+### Subtle
+
+Low-emphasis indicators on standard backgrounds, used for secondary or muted content.
+
+### Dark
+
+High-contrast indicators on light backgrounds, used for emphasis or navigation elements.
+
+### Contrast
+
+Used on colored or contrasting backgrounds to maintain visibility.
+
+## Sizes
+
+Icon tiles are available in 5 sizes to accommodate different layout contexts and visual hierarchies:
+
+- **xs** (16px) - Compact indicators for dense layouts or inline text
+- **sm** (24px) - Small indicators for list items or compact cards
+- **base** (36px) - Default size for most use cases
+- **lg** (48px) - Larger indicators for prominent features or cards
+- **xl** (64px) - Extra large for hero sections or feature highlights
+
+<Canvas of={stories.AllSizes} />
+
+## All Combinations
+
+View all variant and size combinations:
+
+<Canvas of={stories.AllCombinations} />
+
+## Accessibility
+
+Icon tiles are presentational elements and do not require interactive accessibility features.
+However, when an icon tile conveys semantic meaning (such as status or category), provide an
+`ariaLabel` to ensure screen reader users receive the same information.
+
+### When to use ariaLabel
+
+- Status indicators (success, error, warning states)
+- Category or type representations
+- Any icon tile that conveys information not otherwise available in text
+
+### When ariaLabel is not needed
+
+- Purely decorative icon tiles
+- Icon tiles adjacent to descriptive text that provides the same information
+- Icon tiles used only for visual styling or spacing
+
+### Example
+
+```html
+<!-- Semantic icon tile with aria-label -->
+<bit-icon-tile icon="bwi-check-circle" variant="success" ariaLabel="Payment successful" />
+
+<!-- Decorative icon tile without aria-label -->
+<bit-icon-tile icon="bwi-star" variant="primary" />
+```
+
+When `ariaLabel` is provided, the component automatically sets `role="img"` and ensures the inner
+icon element has `aria-hidden="true"` to prevent duplicate announcements.

--- a/libs/components/src/icon-tile/icon-tile.stories.ts
+++ b/libs/components/src/icon-tile/icon-tile.stories.ts
@@ -10,20 +10,16 @@ export default {
   args: {
     icon: "bwi-star",
     variant: "primary",
-    size: "default",
-    shape: "square",
+    size: "base",
+    borderRadius: "base",
   },
   argTypes: {
     variant: {
-      options: ["primary", "success", "warning", "danger", "muted"],
+      options: ["primary", "success", "warning", "danger", "subtle", "dark", "contrast"],
       control: { type: "select" },
     },
     size: {
-      options: ["small", "default", "large"],
-      control: { type: "select" },
-    },
-    shape: {
-      options: ["square", "circle"],
+      options: ["xs", "sm", "base", "lg", "xl"],
       control: { type: "select" },
     },
     icon: {
@@ -51,24 +47,32 @@ export const AllVariants: Story = {
     template: `
       <div class="tw-flex tw-gap-4 tw-items-center tw-flex-wrap">
         <div class="tw-flex tw-flex-col tw-items-center tw-gap-2">
-          <bit-icon-tile icon="bwi-collection" variant="primary"></bit-icon-tile>
+          <bit-icon-tile icon="bwi-clock" variant="primary"></bit-icon-tile>
           <span class="tw-text-sm tw-text-muted">Primary</span>
         </div>
         <div class="tw-flex tw-flex-col tw-items-center tw-gap-2">
-          <bit-icon-tile icon="bwi-check-circle" variant="success"></bit-icon-tile>
+          <bit-icon-tile icon="bwi-clock" variant="success"></bit-icon-tile>
           <span class="tw-text-sm tw-text-muted">Success</span>
         </div>
         <div class="tw-flex tw-flex-col tw-items-center tw-gap-2">
-          <bit-icon-tile icon="bwi-exclamation-triangle" variant="warning"></bit-icon-tile>
-          <span class="tw-text-sm tw-text-muted">Warning</span>
-        </div>
-        <div class="tw-flex tw-flex-col tw-items-center tw-gap-2">
-          <bit-icon-tile icon="bwi-error" variant="danger"></bit-icon-tile>
+          <bit-icon-tile icon="bwi-clock" variant="danger"></bit-icon-tile>
           <span class="tw-text-sm tw-text-muted">Danger</span>
         </div>
         <div class="tw-flex tw-flex-col tw-items-center tw-gap-2">
-          <bit-icon-tile icon="bwi-question-circle" variant="muted"></bit-icon-tile>
-          <span class="tw-text-sm tw-text-muted">Muted</span>
+          <bit-icon-tile icon="bwi-clock" variant="warning"></bit-icon-tile>
+          <span class="tw-text-sm tw-text-muted">Warning</span>
+        </div>
+        <div class="tw-flex tw-flex-col tw-items-center tw-gap-2">
+          <bit-icon-tile icon="bwi-clock" variant="subtle"></bit-icon-tile>
+          <span class="tw-text-sm tw-text-muted">Subtle</span>
+        </div>
+        <div class="tw-flex tw-flex-col tw-items-center tw-gap-2">
+          <bit-icon-tile icon="bwi-clock" variant="dark"></bit-icon-tile>
+          <span class="tw-text-sm tw-text-muted">Dark</span>
+        </div>
+        <div class="tw-flex tw-flex-col tw-items-center tw-gap-2">
+          <bit-icon-tile icon="bwi-clock" variant="contrast"></bit-icon-tile>
+          <span class="tw-text-sm tw-text-muted">Contrast</span>
         </div>
       </div>
     `,
@@ -78,35 +82,111 @@ export const AllVariants: Story = {
 export const AllSizes: Story = {
   render: () => ({
     template: `
-      <div class="tw-flex tw-gap-4 tw-items-center">
+      <div class="tw-flex tw-gap-4 tw-items-end">
         <div class="tw-flex tw-flex-col tw-items-center tw-gap-2">
-          <bit-icon-tile icon="bwi-star" variant="primary" size="small"></bit-icon-tile>
-          <span class="tw-text-sm tw-text-muted">Small</span>
+          <bit-icon-tile icon="bwi-star" variant="primary" size="xs"></bit-icon-tile>
+          <span class="tw-text-sm tw-text-muted">XS (16px)</span>
         </div>
         <div class="tw-flex tw-flex-col tw-items-center tw-gap-2">
-          <bit-icon-tile icon="bwi-star" variant="primary" size="default"></bit-icon-tile>
-          <span class="tw-text-sm tw-text-muted">Default</span>
+          <bit-icon-tile icon="bwi-star" variant="primary" size="sm"></bit-icon-tile>
+          <span class="tw-text-sm tw-text-muted">SM (24px)</span>
         </div>
         <div class="tw-flex tw-flex-col tw-items-center tw-gap-2">
-          <bit-icon-tile icon="bwi-star" variant="primary" size="large"></bit-icon-tile>
-          <span class="tw-text-sm tw-text-muted">Large</span>
+          <bit-icon-tile icon="bwi-star" variant="primary" size="base"></bit-icon-tile>
+          <span class="tw-text-sm tw-text-muted">Base (36px)</span>
+        </div>
+        <div class="tw-flex tw-flex-col tw-items-center tw-gap-2">
+          <bit-icon-tile icon="bwi-star" variant="primary" size="lg"></bit-icon-tile>
+          <span class="tw-text-sm tw-text-muted">LG (48px)</span>
+        </div>
+        <div class="tw-flex tw-flex-col tw-items-center tw-gap-2">
+          <bit-icon-tile icon="bwi-star" variant="primary" size="xl"></bit-icon-tile>
+          <span class="tw-text-sm tw-text-muted">XL (64px)</span>
         </div>
       </div>
     `,
   }),
 };
 
-export const AllShapes: Story = {
+export const AllCombinations: Story = {
   render: () => ({
     template: `
-      <div class="tw-flex tw-gap-4 tw-items-center">
-        <div class="tw-flex tw-flex-col tw-items-center tw-gap-2">
-          <bit-icon-tile icon="bwi-user" variant="primary" shape="square"></bit-icon-tile>
-          <span class="tw-text-sm tw-text-muted">Square</span>
+      <div class="tw-flex tw-flex-col tw-gap-8">
+        <div>
+          <h3 class="tw-text-lg tw-font-semibold tw-mb-4">Primary Variant - All Sizes</h3>
+          <div class="tw-flex tw-gap-4 tw-items-end">
+            <bit-icon-tile icon="bwi-collection" variant="primary" size="xs"></bit-icon-tile>
+            <bit-icon-tile icon="bwi-collection" variant="primary" size="sm"></bit-icon-tile>
+            <bit-icon-tile icon="bwi-collection" variant="primary" size="base"></bit-icon-tile>
+            <bit-icon-tile icon="bwi-collection" variant="primary" size="lg"></bit-icon-tile>
+            <bit-icon-tile icon="bwi-collection" variant="primary" size="xl"></bit-icon-tile>
+          </div>
         </div>
-        <div class="tw-flex tw-flex-col tw-items-center tw-gap-2">
-          <bit-icon-tile icon="bwi-user" variant="primary" shape="circle"></bit-icon-tile>
-          <span class="tw-text-sm tw-text-muted">Circle</span>
+
+        <div>
+          <h3 class="tw-text-lg tw-font-semibold tw-mb-4">Success Variant - All Sizes</h3>
+          <div class="tw-flex tw-gap-4 tw-items-end">
+            <bit-icon-tile icon="bwi-check-circle" variant="success" size="xs"></bit-icon-tile>
+            <bit-icon-tile icon="bwi-check-circle" variant="success" size="sm"></bit-icon-tile>
+            <bit-icon-tile icon="bwi-check-circle" variant="success" size="base"></bit-icon-tile>
+            <bit-icon-tile icon="bwi-check-circle" variant="success" size="lg"></bit-icon-tile>
+            <bit-icon-tile icon="bwi-check-circle" variant="success" size="xl"></bit-icon-tile>
+          </div>
+        </div>
+
+        <div>
+          <h3 class="tw-text-lg tw-font-semibold tw-mb-4">Danger Variant - All Sizes</h3>
+          <div class="tw-flex tw-gap-4 tw-items-end">
+            <bit-icon-tile icon="bwi-error" variant="danger" size="xs"></bit-icon-tile>
+            <bit-icon-tile icon="bwi-error" variant="danger" size="sm"></bit-icon-tile>
+            <bit-icon-tile icon="bwi-error" variant="danger" size="base"></bit-icon-tile>
+            <bit-icon-tile icon="bwi-error" variant="danger" size="lg"></bit-icon-tile>
+            <bit-icon-tile icon="bwi-error" variant="danger" size="xl"></bit-icon-tile>
+          </div>
+        </div>
+
+        <div>
+          <h3 class="tw-text-lg tw-font-semibold tw-mb-4">Warning Variant - All Sizes</h3>
+          <div class="tw-flex tw-gap-4 tw-items-end">
+            <bit-icon-tile icon="bwi-exclamation-triangle" variant="warning" size="xs"></bit-icon-tile>
+            <bit-icon-tile icon="bwi-exclamation-triangle" variant="warning" size="sm"></bit-icon-tile>
+            <bit-icon-tile icon="bwi-exclamation-triangle" variant="warning" size="base"></bit-icon-tile>
+            <bit-icon-tile icon="bwi-exclamation-triangle" variant="warning" size="lg"></bit-icon-tile>
+            <bit-icon-tile icon="bwi-exclamation-triangle" variant="warning" size="xl"></bit-icon-tile>
+          </div>
+        </div>
+
+        <div>
+          <h3 class="tw-text-lg tw-font-semibold tw-mb-4">Subtle Variant - All Sizes</h3>
+          <div class="tw-flex tw-gap-4 tw-items-end">
+            <bit-icon-tile icon="bwi-question-circle" variant="subtle" size="xs"></bit-icon-tile>
+            <bit-icon-tile icon="bwi-question-circle" variant="subtle" size="sm"></bit-icon-tile>
+            <bit-icon-tile icon="bwi-question-circle" variant="subtle" size="base"></bit-icon-tile>
+            <bit-icon-tile icon="bwi-question-circle" variant="subtle" size="lg"></bit-icon-tile>
+            <bit-icon-tile icon="bwi-question-circle" variant="subtle" size="xl"></bit-icon-tile>
+          </div>
+        </div>
+
+        <div>
+          <h3 class="tw-text-lg tw-font-semibold tw-mb-4">Dark Variant - All Sizes</h3>
+          <div class="tw-flex tw-gap-4 tw-items-end">
+            <bit-icon-tile icon="bwi-lock" variant="dark" size="xs"></bit-icon-tile>
+            <bit-icon-tile icon="bwi-lock" variant="dark" size="sm"></bit-icon-tile>
+            <bit-icon-tile icon="bwi-lock" variant="dark" size="base"></bit-icon-tile>
+            <bit-icon-tile icon="bwi-lock" variant="dark" size="lg"></bit-icon-tile>
+            <bit-icon-tile icon="bwi-lock" variant="dark" size="xl"></bit-icon-tile>
+          </div>
+        </div>
+
+        <div>
+          <h3 class="tw-text-lg tw-font-semibold tw-mb-4">Contrast Variant - All Sizes</h3>
+          <div class="tw-flex tw-gap-4 tw-items-end">
+            <bit-icon-tile icon="bwi-star" variant="contrast" size="xs"></bit-icon-tile>
+            <bit-icon-tile icon="bwi-star" variant="contrast" size="sm"></bit-icon-tile>
+            <bit-icon-tile icon="bwi-star" variant="contrast" size="base"></bit-icon-tile>
+            <bit-icon-tile icon="bwi-star" variant="contrast" size="lg"></bit-icon-tile>
+            <bit-icon-tile icon="bwi-star" variant="contrast" size="xl"></bit-icon-tile>
+          </div>
         </div>
       </div>
     `,


### PR DESCRIPTION
Cherry pick of [4a7b382](https://github.com/bitwarden/clients/pull/19063/commits/4a7b382873a994d8dafe107a6ceaa1f13280f4f3) onto `main`. We were originally going to add other components into this feature branch, but that is no longer the case.