### PR TITLE
[PM-32488] Disables autocomplete when explicitly requested

### DIFF
--- a/apps/browser/src/autofill/services/collect-autofill-content.service.ts
+++ b/apps/browser/src/autofill/services/collect-autofill-content.service.ts
@@ -79,7 +79,7 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
     private domQueryService: DomQueryService,
     private autofillOverlayContentService?: AutofillOverlayContentService,
   ) {
-    let inputQuery = "input:not([data-bwignore])";
+    let inputQuery = "input:not([data-bwignore], [autocomplete=off])";
     for (const type of this.ignoredInputTypes) {
       inputQuery += `:not([type="${type}"])`;
     }


### PR DESCRIPTION
Sometimes the plugin misinterprets the need to offer autocomplete.

This happens, for example, when the word ‘email’ is present in a field label and that field does not expect an email address.

The autocomplete attribute set to off is an expected way of indicating this, and should be taken into account.