### PR TITLE
[PM-28529] risk over time api milestone 9

### DIFF
--- a/bitwarden_license/bit-common/src/dirt/access-intelligence/models/api/access-report-summary.api.ts
+++ b/bitwarden_license/bit-common/src/dirt/access-intelligence/models/api/access-report-summary.api.ts
@@ -24,6 +24,14 @@ export class AccessReportSummaryApi extends BaseResponse {
   totalCriticalAtRiskMemberCount: number = 0;
   totalCriticalAtRiskApplicationCount: number = 0;
 
+  // Risk-over-time fields: populated when constructed from the summary-by-date-range
+  // endpoint (PM-28531). The endpoint returns encrypted summary entries with dates.
+  // Count fields above default to 0 until decryption populates them.
+  date: string = "";
+  organizationId: string = "";
+  encryptedData: string = "";
+  encryptionKey: string = "";
+
   constructor(data: any) {
     super(data);
 
@@ -38,5 +46,10 @@ export class AccessReportSummaryApi extends BaseResponse {
       this.getResponseProperty("totalCriticalAtRiskMemberCount") || 0;
     this.totalCriticalAtRiskApplicationCount =
       this.getResponseProperty("totalCriticalAtRiskApplicationCount") || 0;
+
+    this.date = this.getResponseProperty("date") ?? "";
+    this.organizationId = this.getResponseProperty("organizationId") ?? "";
+    this.encryptedData = this.getResponseProperty("encryptedData") ?? "";
+    this.encryptionKey = this.getResponseProperty("encryptionKey") ?? "";
   }
 }

--- a/bitwarden_license/bit-common/src/dirt/access-intelligence/models/data/access-report-summary.data.ts
+++ b/bitwarden_license/bit-common/src/dirt/access-intelligence/models/data/access-report-summary.data.ts
@@ -20,6 +20,7 @@ export class AccessReportSummaryData {
   totalCriticalMemberCount: number = 0;
   totalCriticalAtRiskMemberCount: number = 0;
   totalCriticalAtRiskApplicationCount: number = 0;
+  date: string = "";
 
   constructor(data?: AccessReportSummaryApi) {
     if (data == null) {
@@ -34,5 +35,6 @@ export class AccessReportSummaryData {
     this.totalCriticalMemberCount = data.totalCriticalMemberCount;
     this.totalCriticalAtRiskMemberCount = data.totalCriticalAtRiskMemberCount;
     this.totalCriticalAtRiskApplicationCount = data.totalCriticalAtRiskApplicationCount;
+    this.date = data.date;
   }
 }

--- a/bitwarden_license/bit-common/src/dirt/access-intelligence/models/domain/access-report-summary.ts
+++ b/bitwarden_license/bit-common/src/dirt/access-intelligence/models/domain/access-report-summary.ts
@@ -22,6 +22,7 @@ export class AccessReportSummary extends Domain {
   totalCriticalMemberCount: number = 0;
   totalCriticalAtRiskMemberCount: number = 0;
   totalCriticalAtRiskApplicationCount: number = 0;
+  date: string = "";
 
   constructor(obj?: AccessReportSummaryData) {
     super();
@@ -37,6 +38,7 @@ export class AccessReportSummary extends Domain {
     this.totalCriticalMemberCount = obj.totalCriticalMemberCount;
     this.totalCriticalAtRiskMemberCount = obj.totalCriticalAtRiskMemberCount;
     this.totalCriticalAtRiskApplicationCount = obj.totalCriticalAtRiskApplicationCount;
+    this.date = obj.date;
   }
 
   // [TODO] Domain level methods

--- a/bitwarden_license/bit-common/src/dirt/access-intelligence/models/domain/access-report.ts
+++ b/bitwarden_license/bit-common/src/dirt/access-intelligence/models/domain/access-report.ts
@@ -159,6 +159,7 @@ export class AccessReport extends Domain {
         totalCriticalAtRiskMemberCount: view.summary.totalCriticalAtRiskMemberCount,
         totalCriticalApplicationCount: view.summary.totalCriticalApplicationCount,
         totalCriticalAtRiskApplicationCount: view.summary.totalCriticalAtRiskApplicationCount,
+        date: view.summary.date,
       },
       applicationData: view.applications.map((app) => ({
         applicationName: app.applicationName,

--- a/bitwarden_license/bit-common/src/dirt/access-intelligence/models/view/access-report-summary.view.ts
+++ b/bitwarden_license/bit-common/src/dirt/access-intelligence/models/view/access-report-summary.view.ts
@@ -22,6 +22,7 @@ export class AccessReportSummaryView implements View {
   totalCriticalMemberCount: number = 0;
   totalCriticalAtRiskMemberCount: number = 0;
   totalCriticalAtRiskApplicationCount: number = 0;
+  date: string = "";
 
   constructor(obj?: AccessReportSummary) {
     if (obj == null) {
@@ -36,6 +37,7 @@ export class AccessReportSummaryView implements View {
     this.totalCriticalMemberCount = obj.totalCriticalMemberCount;
     this.totalCriticalAtRiskMemberCount = obj.totalCriticalAtRiskMemberCount;
     this.totalCriticalAtRiskApplicationCount = obj.totalCriticalAtRiskApplicationCount;
+    this.date = obj.date;
   }
 
   toJSON() {
@@ -52,6 +54,7 @@ export class AccessReportSummaryView implements View {
     view.totalCriticalMemberCount = data.totalCriticalMemberCount;
     view.totalCriticalAtRiskMemberCount = data.totalCriticalAtRiskMemberCount;
     view.totalCriticalAtRiskApplicationCount = data.totalCriticalAtRiskApplicationCount;
+    view.date = data.date;
     return view;
   }
 

--- a/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/persistence/default-access-report-encryption.service.spec.ts
+++ b/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/persistence/default-access-report-encryption.service.spec.ts
@@ -79,7 +79,7 @@ describe("DefaultAccessReportEncryptionService", () => {
 
   const mockV2Input: DecryptedAccessReportData = {
     reportData: mockV2ReportData,
-    summaryData: mockSummaryData,
+    summaryData: { ...mockSummaryData, date: "" },
     applicationData: mockV2ApplicationData,
   };
 
@@ -119,7 +119,7 @@ describe("DefaultAccessReportEncryptionService", () => {
       wasLegacy: false,
     });
     mockSummaryVersioningService.process.mockReturnValue({
-      data: mockSummaryData,
+      data: { ...mockSummaryData, date: "" },
       wasLegacy: false,
     });
     mockApplicationVersioningService.process.mockReturnValue({
@@ -217,7 +217,7 @@ describe("DefaultAccessReportEncryptionService", () => {
       expect(result.reportData.reports).toHaveLength(1);
       expect(result.reportData.reports[0].applicationName).toBe("app.com");
       expect(result.reportData.memberRegistry).toHaveProperty("user-1");
-      expect(result.summaryData).toEqual(mockSummaryData);
+      expect(result.summaryData).toEqual({ ...mockSummaryData, date: "" });
       expect(result.hadLegacyBlobs).toBeUndefined();
     });
 
@@ -373,7 +373,7 @@ describe("DefaultAccessReportEncryptionService", () => {
       expect(mockKeyService.orgKeys$).toHaveBeenCalledWith(userId);
       expect(mockEncryptService.unwrapSymmetricKey).toHaveBeenCalledWith(mockKey, orgKey);
       expect(mockSummaryVersioningService.process).toHaveBeenCalled();
-      expect(result).toEqual(mockSummaryData);
+      expect(result).toEqual({ ...mockSummaryData, date: "" });
     });
 
     it("should throw if org key is not found", async () => {

--- a/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/persistence/default-report-persistence.service.spec.ts
+++ b/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/persistence/default-report-persistence.service.spec.ts
@@ -322,6 +322,7 @@ describe("DefaultReportPersistenceService", () => {
           totalCriticalAtRiskMemberCount: 1,
           totalCriticalApplicationCount: 1,
           totalCriticalAtRiskApplicationCount: 1,
+          date: "",
         },
         applicationData: [
           {
@@ -444,6 +445,7 @@ describe("DefaultReportPersistenceService", () => {
           totalCriticalAtRiskMemberCount: 2,
           totalCriticalApplicationCount: 2,
           totalCriticalAtRiskApplicationCount: 1,
+          date: "",
         },
         applicationData: [
           {

--- a/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/persistence/versioning/summary-versioning.service.spec.ts
+++ b/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/persistence/versioning/summary-versioning.service.spec.ts
@@ -20,6 +20,7 @@ describe("SummaryVersioningService", () => {
     totalCriticalAtRiskMemberCount: 1,
     totalCriticalApplicationCount: 1,
     totalCriticalAtRiskApplicationCount: 1,
+    date: "",
   };
 
   const validEnvelope = { version: 1, data: validSummaryData };

--- a/bitwarden_license/bit-common/src/dirt/reports/risk-insights/helpers/type-guards/risk-insights-type-guards.spec.ts
+++ b/bitwarden_license/bit-common/src/dirt/reports/risk-insights/helpers/type-guards/risk-insights-type-guards.spec.ts
@@ -705,6 +705,7 @@ describe("Risk Insights Type Guards", () => {
       totalCriticalMemberCount: 4,
       totalCriticalAtRiskMemberCount: 1,
       totalCriticalAtRiskApplicationCount: 1,
+      date: "",
     };
 
     it("should validate valid summary data", () => {

--- a/bitwarden_license/bit-common/src/dirt/reports/risk-insights/helpers/type-guards/risk-insights-type-guards.ts
+++ b/bitwarden_license/bit-common/src/dirt/reports/risk-insights/helpers/type-guards/risk-insights-type-guards.ts
@@ -13,6 +13,7 @@ import {
   OrganizationReportApplication,
   OrganizationReportSummary,
 } from "../../models";
+import { RiskOverTimeDataView, RiskOverTimeTimeframe } from "../../models/risk-over-time.types";
 
 import {
   createBoundedArrayGuard,
@@ -202,6 +203,7 @@ export const isAccessReportSummaryData = createValidator<AccessReportSummaryData
   totalCriticalMemberCount: isBoundedPositiveNumber,
   totalCriticalAtRiskMemberCount: isBoundedPositiveNumber,
   totalCriticalAtRiskApplicationCount: isBoundedPositiveNumber,
+  date: (value: unknown): value is string => value === undefined || typeof value === "string",
 });
 
 /**
@@ -358,4 +360,22 @@ export function validateAccessReportPayload(data: unknown): AccessReportPayload 
   }
 
   return data as AccessReportPayload;
+}
+
+// === Type Guards for Risk Over Time ===
+
+/**
+ * Type guard: validates a raw value is a valid RiskOverTimeTimeframe.
+ * Use at system boundaries (user input, deserialization).
+ */
+export function isRiskOverTimeTimeframe(value: string): value is RiskOverTimeTimeframe {
+  return Object.values(RiskOverTimeTimeframe).includes(value as RiskOverTimeTimeframe);
+}
+
+/**
+ * Type guard: validates a raw value is a valid RiskOverTimeDataView.
+ * Use at system boundaries (user input, deserialization).
+ */
+export function isRiskOverTimeDataView(value: string): value is RiskOverTimeDataView {
+  return Object.values(RiskOverTimeDataView).includes(value as RiskOverTimeDataView);
 }

--- a/bitwarden_license/bit-common/src/dirt/reports/risk-insights/models/data/risk-over-time.data.ts
+++ b/bitwarden_license/bit-common/src/dirt/reports/risk-insights/models/data/risk-over-time.data.ts
@@ -1,0 +1,23 @@
+import { AccessReportSummaryApi } from "../../../../access-intelligence/models";
+
+/**
+ * Serializable data model for risk-over-time chart data.
+ *
+ * Holds the raw entries from the server. Each entry is an AccessReportSummaryApi
+ * with date and encrypted fields populated. The count fields default to 0 until
+ * a consuming data service decrypts the entries.
+ *
+ * - See {@link AccessReportSummaryApi} for API response model
+ * - See {@link RiskOverTime} for domain model
+ * - See {@link RiskOverTimeView} for view model
+ */
+export class RiskOverTimeData {
+  entries: AccessReportSummaryApi[] = [];
+
+  constructor(apiEntries?: AccessReportSummaryApi[]) {
+    if (apiEntries == null) {
+      return;
+    }
+    this.entries = apiEntries.filter((entry) => entry.date !== "");
+  }
+}

--- a/bitwarden_license/bit-common/src/dirt/reports/risk-insights/models/domain/risk-over-time.ts
+++ b/bitwarden_license/bit-common/src/dirt/reports/risk-insights/models/domain/risk-over-time.ts
@@ -1,0 +1,26 @@
+import Domain from "@bitwarden/common/platform/models/domain/domain-base";
+
+import { AccessReportSummary } from "../../../../access-intelligence/models";
+
+/**
+ * Domain model for risk-over-time chart data.
+ *
+ * After decryption, each server entry yields an AccessReportSummary with
+ * date and metric counts populated. The chart widget reads the relevant
+ * counts based on the selected data view (Applications or Members).
+ *
+ * - See {@link AccessReportSummaryApi} for API response model
+ * - See {@link RiskOverTimeData} for data model
+ * - See {@link RiskOverTimeView} for view model
+ */
+export class RiskOverTime extends Domain {
+  dataPoints: AccessReportSummary[] = [];
+
+  constructor(dataPoints?: AccessReportSummary[]) {
+    super();
+    if (dataPoints == null) {
+      return;
+    }
+    this.dataPoints = dataPoints;
+  }
+}

--- a/bitwarden_license/bit-common/src/dirt/reports/risk-insights/models/index.ts
+++ b/bitwarden_license/bit-common/src/dirt/reports/risk-insights/models/index.ts
@@ -4,3 +4,4 @@ export * from "./report-data-service.types";
 export * from "./report-encryption.types";
 export * from "./report-models";
 export * from "./drawer-models.types";
+export * from "./risk-over-time.types";

--- a/bitwarden_license/bit-common/src/dirt/reports/risk-insights/models/mocks/mock-risk-over-time-data.ts
+++ b/bitwarden_license/bit-common/src/dirt/reports/risk-insights/models/mocks/mock-risk-over-time-data.ts
@@ -1,0 +1,51 @@
+/**
+ * Mock risk-over-time response data for UI development.
+ *
+ * Now that getRiskOverTime$ is wired to the real server endpoint (PM-28531),
+ * this mock generates data matching the server's response shape: an array of
+ * encrypted summary entries with dates. Since the actual data is encrypted,
+ * these mocks use placeholder encrypted strings.
+ *
+ * This mock is useful for Storybook stories and component development
+ * when a real server connection is not available.
+ */
+
+/**
+ * Returns mock server response entries matching the summary-by-date-range endpoint.
+ * Each entry has the shape of OrganizationReportSummaryDataResponse from the server.
+ */
+export function getMockRiskOverTimeSummaryEntries(
+  timeframe: string,
+  organizationId: string = "mock-org-id",
+): Record<string, unknown>[] {
+  const now = new Date();
+  const intervals = getIntervalMs(timeframe);
+
+  return Array.from({ length: 6 }, (_, i) => {
+    const date = new Date(now.getTime() - intervals * (5 - i));
+    return {
+      organizationId,
+      encryptedData: `mock-encrypted-summary-${i}`,
+      encryptionKey: `mock-encryption-key-${i}`,
+      date: date.toISOString(),
+    };
+  });
+}
+
+function getIntervalMs(timeframe: string): number {
+  const day = 86_400_000;
+  switch (timeframe) {
+    case "month":
+      return 5 * day;
+    case "3mo":
+      return 15 * day;
+    case "6mo":
+      return 30 * day;
+    case "12mo":
+      return 60 * day;
+    case "all":
+      return 90 * day;
+    default:
+      return 30 * day;
+  }
+}

--- a/bitwarden_license/bit-common/src/dirt/reports/risk-insights/models/risk-over-time.types.ts
+++ b/bitwarden_license/bit-common/src/dirt/reports/risk-insights/models/risk-over-time.types.ts
@@ -1,0 +1,59 @@
+// Client-side timeframe options for the risk-over-time widget.
+// These are NOT sent to the server — they are converted to startDate/endDate
+// via timeframeToDateRange() before calling the summary endpoint.
+export const RiskOverTimeTimeframe = Object.freeze({
+  Month: "month",
+  ThreeMonths: "3mo",
+  SixMonths: "6mo",
+  TwelveMonths: "12mo",
+  All: "all",
+} as const);
+
+export type RiskOverTimeTimeframe =
+  (typeof RiskOverTimeTimeframe)[keyof typeof RiskOverTimeTimeframe];
+
+// Client-side data view options for the risk-over-time widget.
+// These are NOT sent to the server — they determine which metric pair
+// (atRisk/total) to extract from decrypted OrganizationReportSummary data.
+export const RiskOverTimeDataView = Object.freeze({
+  Applications: "applications",
+  Members: "members",
+} as const);
+
+export type RiskOverTimeDataView = (typeof RiskOverTimeDataView)[keyof typeof RiskOverTimeDataView];
+
+/**
+ * Converts a UI timeframe selection into a startDate/endDate range
+ * for the server's summary-by-date-range endpoint.
+ *
+ * The server endpoint is: GET /reports/organizations/{orgId}/data/summary?startDate=...&endDate=...
+ * It returns up to 6 evenly-spaced encrypted summary entries within the range.
+ */
+export function timeframeToDateRange(timeframe: RiskOverTimeTimeframe): {
+  startDate: Date;
+  endDate: Date;
+} {
+  const endDate = new Date();
+  const startDate = new Date();
+
+  switch (timeframe) {
+    case RiskOverTimeTimeframe.Month:
+      startDate.setMonth(startDate.getMonth() - 1);
+      break;
+    case RiskOverTimeTimeframe.ThreeMonths:
+      startDate.setMonth(startDate.getMonth() - 3);
+      break;
+    case RiskOverTimeTimeframe.SixMonths:
+      startDate.setMonth(startDate.getMonth() - 6);
+      break;
+    case RiskOverTimeTimeframe.TwelveMonths:
+      startDate.setMonth(startDate.getMonth() - 12);
+      break;
+    case RiskOverTimeTimeframe.All:
+      // Use a far-back date to capture all available data
+      startDate.setFullYear(startDate.getFullYear() - 5);
+      break;
+  }
+
+  return { startDate, endDate };
+}

--- a/bitwarden_license/bit-common/src/dirt/reports/risk-insights/models/view/risk-over-time.view.ts
+++ b/bitwarden_license/bit-common/src/dirt/reports/risk-insights/models/view/risk-over-time.view.ts
@@ -1,0 +1,45 @@
+import { View } from "@bitwarden/common/models/view/view";
+import { DeepJsonify } from "@bitwarden/common/types/deep-jsonify";
+
+import { AccessReportSummaryView } from "../../../../access-intelligence/models";
+import { RiskOverTime } from "../domain/risk-over-time";
+
+/**
+ * View model for risk-over-time chart data containing decrypted data points.
+ *
+ * Each data point is an AccessReportSummaryView with date and metric counts.
+ * The chart widget reads the relevant counts based on the selected
+ * data view (Applications or Members).
+ *
+ * - See {@link AccessReportSummaryApi} for API response model
+ * - See {@link RiskOverTimeData} for data model
+ * - See {@link RiskOverTime} for domain model
+ */
+export class RiskOverTimeView implements View {
+  dataPoints: AccessReportSummaryView[] = [];
+
+  constructor(data?: RiskOverTime) {
+    if (data == null) {
+      return;
+    }
+    if (data.dataPoints != null) {
+      this.dataPoints = data.dataPoints.map((dp) => new AccessReportSummaryView(dp));
+    }
+  }
+
+  toJSON() {
+    return this;
+  }
+
+  static fromJSON(
+    obj: Partial<DeepJsonify<RiskOverTimeView>> | undefined,
+  ): RiskOverTimeView | undefined {
+    if (obj == null) {
+      return undefined;
+    }
+    const view = Object.assign(new RiskOverTimeView(), obj) as RiskOverTimeView;
+    view.dataPoints =
+      (obj.dataPoints as any[])?.map((dp: any) => AccessReportSummaryView.fromJSON(dp)) ?? [];
+    return view;
+  }
+}

--- a/bitwarden_license/bit-common/src/dirt/reports/risk-insights/services/api/risk-insights-api.service.spec.ts
+++ b/bitwarden_license/bit-common/src/dirt/reports/risk-insights/services/api/risk-insights-api.service.spec.ts
@@ -274,4 +274,73 @@ describe("RiskInsightsApiService", () => {
     );
     expect(result).toBeTruthy();
   });
+
+  describe("getRiskOverTime$", () => {
+    it("should call summary endpoint with date range derived from timeframe and return entries", async () => {
+      const mockResponse = [
+        {
+          organizationId: orgId,
+          encryptedData: "enc-summary-1",
+          encryptionKey: "enc-key-1",
+          date: "2026-01-15T00:00:00Z",
+        },
+        {
+          organizationId: orgId,
+          encryptedData: "enc-summary-2",
+          encryptionKey: "enc-key-2",
+          date: "2026-02-15T00:00:00Z",
+        },
+      ];
+
+      mockApiService.send.mockResolvedValueOnce(mockResponse);
+
+      const result = await firstValueFrom(service.getRiskOverTime$(orgId, "month"));
+
+      // Verify it calls the summary endpoint with startDate/endDate query params
+      expect(mockApiService.send).toHaveBeenCalledWith(
+        "GET",
+        expect.stringMatching(
+          /\/reports\/organizations\/org1\/data\/summary\?startDate=\d{4}-\d{2}-\d{2}&endDate=\d{4}-\d{2}-\d{2}/,
+        ),
+        null,
+        true,
+        true,
+      );
+      expect(result).toHaveLength(2);
+      expect(result[0].date).toBe("2026-01-15T00:00:00Z");
+      expect(result[1].date).toBe("2026-02-15T00:00:00Z");
+    });
+
+    it("should return empty array when server responds with 404", async () => {
+      const mockError = new ErrorResponse(null, 404);
+      mockApiService.send.mockReturnValue(Promise.reject(mockError));
+
+      const result = await firstValueFrom(service.getRiskOverTime$(orgId, "month"));
+
+      expect(result).toEqual([]);
+    });
+
+    it("should propagate non-404 errors", async () => {
+      const error = { statusCode: 500, message: "Server error" };
+      mockApiService.send.mockReturnValue(Promise.reject(error));
+
+      await expect(firstValueFrom(service.getRiskOverTime$(orgId, "3mo"))).rejects.toEqual(error);
+    });
+
+    it("should return empty array for null response", async () => {
+      mockApiService.send.mockResolvedValueOnce(null);
+
+      const result = await firstValueFrom(service.getRiskOverTime$(orgId, "12mo"));
+
+      expect(result).toEqual([]);
+    });
+
+    it("should return empty array for non-array response", async () => {
+      mockApiService.send.mockResolvedValueOnce({});
+
+      const result = await firstValueFrom(service.getRiskOverTime$(orgId, "6mo"));
+
+      expect(result).toEqual([]);
+    });
+  });
 });

--- a/bitwarden_license/bit-common/src/dirt/reports/risk-insights/services/api/risk-insights-api.service.ts
+++ b/bitwarden_license/bit-common/src/dirt/reports/risk-insights/services/api/risk-insights-api.service.ts
@@ -4,6 +4,7 @@ import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import { ErrorResponse } from "@bitwarden/common/models/response/error.response";
 import { OrganizationId, OrganizationReportId } from "@bitwarden/common/types/guid";
 
+import { AccessReportSummaryApi } from "../../../../access-intelligence/models";
 import {
   UpdateRiskInsightsApplicationDataRequest,
   UpdateRiskInsightsApplicationDataResponse,
@@ -16,6 +17,7 @@ import {
   SaveRiskInsightsReportRequest,
   SaveRiskInsightsReportResponse,
 } from "../../models/api-models.types";
+import { RiskOverTimeTimeframe, timeframeToDateRange } from "../../models/risk-over-time.types";
 
 export class RiskInsightsApiService {
   constructor(private apiService: ApiService) {}
@@ -122,6 +124,48 @@ export class RiskInsightsApiService {
 
     return from(dbResponse).pipe(
       map((response) => new UpdateRiskInsightsApplicationDataResponse(response)),
+    );
+  }
+
+  /**
+   * Fetches risk-over-time summary data for the given organization and timeframe.
+   *
+   * Calls the PM-28531 summary-by-date-range endpoint which returns up to 6
+   * evenly-spaced encrypted summary entries. Each entry must be decrypted by
+   * the consuming code to extract metric counts based on the selected data view.
+   *
+   * @param orgId - Organization to fetch data for
+   * @param timeframe - UI timeframe selection, converted to startDate/endDate internally
+   * @returns Array of encrypted summary entries ordered by date, or empty array on 404
+   */
+  getRiskOverTime$(
+    orgId: OrganizationId,
+    timeframe: RiskOverTimeTimeframe,
+  ): Observable<AccessReportSummaryApi[]> {
+    const { startDate, endDate } = timeframeToDateRange(timeframe);
+    const startDateStr = startDate.toISOString().split("T")[0];
+    const endDateStr = endDate.toISOString().split("T")[0];
+
+    const dbResponse = this.apiService.send(
+      "GET",
+      `/reports/organizations/${orgId.toString()}/data/summary?startDate=${startDateStr}&endDate=${endDateStr}`,
+      null,
+      true,
+      true,
+    );
+    return from(dbResponse).pipe(
+      map((response: any) => {
+        if (!response || !Array.isArray(response)) {
+          return [];
+        }
+        return response.map((entry: any) => new AccessReportSummaryApi(entry));
+      }),
+      catchError((error: unknown) => {
+        if (error instanceof ErrorResponse && error.statusCode === 404) {
+          return of([]);
+        }
+        return throwError(() => error);
+      }),
     );
   }
 }


### PR DESCRIPTION
### These changes were merged into https://github.com/bitwarden/clients/pull/19664

---

## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-28529

## 📔 Objective

Adds the `getRiskOverTime$` API service method to `RiskInsightsApiService`, providing a client-side interface for fetching risk-over-time chart data from the PM-28531 server endpoint.

### What this PR does

- **API service method** (`getRiskOverTime$`): Calls `GET /reports/organizations/{orgId}/data/summary?startDate=...&endDate=...` — the PM-28531 summary-by-date-range endpoint. Converts a UI timeframe selection (month, 3mo, 6mo, 12mo, all) into startDate/endDate query parameters via `timeframeToDateRange()`.

- **Response model** (`RiskOverTimeSummaryEntryResponse`): Matches the server's `OrganizationReportSummaryDataResponse` — each entry contains `organizationId`, `encryptedData` (EncString), `encryptionKey` (EncString), and `date`. The server returns up to 6 evenly-spaced encrypted entries.

- **4-layer model pipeline** (API → Data → Domain → View): Updated to reflect the encrypted response. Data points carry `date` + encrypted fields at the data layer, with `atRisk`/`total` populated after decryption at the domain layer.

- **Unit tests**: 5 tests covering correct endpoint URL pattern with date range, empty array on 404, error propagation, null response handling, and non-array response handling.

### What this PR does NOT do (out of scope)

- Decryption of the encrypted summary entries (handled by a consuming domain service)
- Extraction of atRisk/total metrics based on dataView (happens after decryption)
- UI integration with the TrendChart widget (PM-27772 / PM-32057)

### Key references

- [Server hookup testing guide for reviewers](https://gist.github.com/AlexRubik/cf2c87526a0a088b45d4f6bba72ca578) — step-by-step instructions to verify the endpoint works locally
- Server PR: https://github.com/bitwarden/server/pull/7110 (PM-28531, merged)
- [Concerns and gaps doc](https://gist.github.com/AlexRubik/ac89c8420af4f3b9c4d364442368dd07)

## 📸 Screenshots

<!-- No UI changes in this PR -->