### PR TITLE
Fix type error on main

### DIFF
--- a/libs/components/src/a11y/router-focus-manager.service.spec.ts
+++ b/libs/components/src/a11y/router-focus-manager.service.spec.ts
@@ -72,7 +72,7 @@ describe("RouterFocusManagerService", () => {
           return featureFlagSubject.asObservable();
         }
         return new BehaviorSubject(false).asObservable();
-      }),
+      }) as ConfigService["getFeatureFlag$"],
     };
 
     // Spy on document.querySelector and console.warn


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

https://github.com/bitwarden/clients/pull/18849 introduced a change of inferred types for the feature flags by using a numeric feature flag. This broke a test on `main` that wasn't in the feature branch. Adding a cast here to satisfy typescript. 

## 📸 Screenshots

N/A
