### PR TITLE
Revert Browser item ordering and search result changes

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -6145,12 +6145,6 @@
   "whyAmISeeingThis": {
     "message": "Why am I seeing this?"
   },
-  "items": {
-    "message": "Items"
-  },
-  "searchResults": {
-    "message": "Search results"
-  },
   "resizeSideNavigation": {
     "message": "Resize side navigation"
   },

--- a/apps/browser/src/vault/popup/components/vault/vault.component.html
+++ b/apps/browser/src/vault/popup/components/vault/vault.component.html
@@ -107,32 +107,20 @@
     @if (vaultState === null) {
       <vault-fade-in-out>
         @if (!(loading$ | async)) {
-          <!--If there is search text fold all the filtered ciphers into one container-->
-          @if (hasSearchText$ | async) {
-            <app-vault-list-items-container
-              [title]="'searchResults' | i18n"
-              [ciphers]="(filteredCiphers$ | async) || []"
-              id="allItems"
-              disableSectionMargin
-              collapsibleKey="allItems"
-            ></app-vault-list-items-container>
-          } @else {
-            <app-autofill-vault-list-items></app-autofill-vault-list-items>
-            <app-vault-list-items-container
-              [title]="'favorites' | i18n"
-              [ciphers]="(favoriteCiphers$ | async) || []"
-              id="favorites"
-              collapsibleKey="favorites"
-            ></app-vault-list-items-container>
-            <!--Change the title header when a filter is applied-->
-            <app-vault-list-items-container
-              [title]="((numberOfAppliedFilters$ | async) === 0 ? 'allItems' : 'items') | i18n"
-              [ciphers]="(remainingCiphers$ | async) || []"
-              id="allItems"
-              disableSectionMargin
-              collapsibleKey="allItems"
-            ></app-vault-list-items-container>
-          }
+          <app-autofill-vault-list-items></app-autofill-vault-list-items>
+          <app-vault-list-items-container
+            [title]="'favorites' | i18n"
+            [ciphers]="(favoriteCiphers$ | async) || []"
+            id="favorites"
+            collapsibleKey="favorites"
+          ></app-vault-list-items-container>
+          <app-vault-list-items-container
+            [title]="'allItems' | i18n"
+            [ciphers]="(remainingCiphers$ | async) || []"
+            id="allItems"
+            disableSectionMargin
+            collapsibleKey="allItems"
+          ></app-vault-list-items-container>
         }
       </vault-fade-in-out>
     }

--- a/apps/browser/src/vault/popup/components/vault/vault.component.spec.ts
+++ b/apps/browser/src/vault/popup/components/vault/vault.component.spec.ts
@@ -44,7 +44,6 @@ import { VaultPopupAutofillService } from "../../services/vault-popup-autofill.s
 import { VaultPopupCopyButtonsService } from "../../services/vault-popup-copy-buttons.service";
 import { VaultPopupItemsService } from "../../services/vault-popup-items.service";
 import { VaultPopupListFiltersService } from "../../services/vault-popup-list-filters.service";
-import { VaultPopupLoadingService } from "../../services/vault-popup-loading.service";
 import { VaultPopupScrollPositionService } from "../../services/vault-popup-scroll-position.service";
 import { AtRiskPasswordCalloutComponent } from "../at-risk-callout/at-risk-password-callout.component";
 
@@ -175,21 +174,15 @@ describe("VaultComponent", () => {
     showDeactivatedOrg$: new BehaviorSubject<boolean>(false),
     favoriteCiphers$: new BehaviorSubject<any[]>([]),
     remainingCiphers$: new BehaviorSubject<any[]>([]),
-    filteredCiphers$: new BehaviorSubject<any[]>([]),
     cipherCount$: new BehaviorSubject<number>(0),
-    hasSearchText$: new BehaviorSubject<boolean>(false),
+    loading$: new BehaviorSubject<boolean>(true),
   } as Partial<VaultPopupItemsService>;
 
-  const filtersSvc: any = {
+  const filtersSvc = {
     allFilters$: new Subject<any>(),
     filters$: new BehaviorSubject<any>({}),
     filterVisibilityState$: new BehaviorSubject<any>({}),
-    numberOfAppliedFilters$: new BehaviorSubject<number>(0),
-  };
-
-  const loadingSvc: any = {
-    loading$: new BehaviorSubject<boolean>(false),
-  };
+  } as Partial<VaultPopupListFiltersService>;
 
   const activeAccount$ = new BehaviorSubject<FakeAccount | null>({ id: "user-1" });
 
@@ -247,7 +240,6 @@ describe("VaultComponent", () => {
         provideNoopAnimations(),
         { provide: VaultPopupItemsService, useValue: itemsSvc },
         { provide: VaultPopupListFiltersService, useValue: filtersSvc },
-        { provide: VaultPopupLoadingService, useValue: loadingSvc },
         { provide: VaultPopupScrollPositionService, useValue: scrollSvc },
         {
           provide: AccountService,
@@ -374,18 +366,18 @@ describe("VaultComponent", () => {
   });
 
   it("loading$ is true when items loading or filters missing; false when both ready", () => {
-    const vaultLoading$ = loadingSvc.loading$ as unknown as BehaviorSubject<boolean>;
+    const itemsLoading$ = itemsSvc.loading$ as unknown as BehaviorSubject<boolean>;
     const allFilters$ = filtersSvc.allFilters$ as unknown as Subject<any>;
     const readySubject$ = component["readySubject"] as unknown as BehaviorSubject<boolean>;
 
     const values: boolean[] = [];
     getObs<boolean>(component, "loading$").subscribe((v) => values.push(!!v));
 
-    vaultLoading$.next(true);
+    itemsLoading$.next(true);
 
     allFilters$.next({});
 
-    vaultLoading$.next(false);
+    itemsLoading$.next(false);
 
     readySubject$.next(true);
 
@@ -397,7 +389,7 @@ describe("VaultComponent", () => {
     const component = fixture.componentInstance;
 
     const readySubject$ = component["readySubject"] as unknown as BehaviorSubject<boolean>;
-    const vaultLoading$ = loadingSvc.loading$ as unknown as BehaviorSubject<boolean>;
+    const itemsLoading$ = itemsSvc.loading$ as unknown as BehaviorSubject<boolean>;
     const allFilters$ = filtersSvc.allFilters$ as unknown as Subject<any>;
 
     fixture.detectChanges();
@@ -408,7 +400,7 @@ describe("VaultComponent", () => {
     ) as HTMLElement;
 
     // Unblock loading
-    vaultLoading$.next(false);
+    itemsLoading$.next(false);
     readySubject$.next(true);
     allFilters$.next({});
     tick();
@@ -597,127 +589,6 @@ describe("VaultComponent", () => {
 
     const spotlights = queryAllSpotlights(fixture);
     expect(spotlights.length).toBe(0);
-  }));
-
-  it("does not render app-autofill-vault-list-items or favorites item container when hasSearchText$ is true", () => {
-    itemsSvc.hasSearchText$.next(true);
-
-    const fixture = TestBed.createComponent(VaultComponent);
-    component = fixture.componentInstance;
-
-    const readySubject$ = component["readySubject"];
-    const allFilters$ = filtersSvc.allFilters$ as unknown as Subject<any>;
-
-    // Unblock loading
-    readySubject$.next(true);
-    allFilters$.next({});
-    fixture.detectChanges();
-
-    const autofillElement = fixture.debugElement.query(By.css("app-autofill-vault-list-items"));
-    expect(autofillElement).toBeFalsy();
-
-    const favoritesElement = fixture.debugElement.query(By.css("#favorites"));
-    expect(favoritesElement).toBeFalsy();
-  });
-
-  it("does render app-autofill-vault-list-items and favorites item container when hasSearchText$ is false", () => {
-    // Ensure vaultState is null (not Empty, NoResults, or DeactivatedOrg)
-    itemsSvc.emptyVault$.next(false);
-    itemsSvc.noFilteredResults$.next(false);
-    itemsSvc.showDeactivatedOrg$.next(false);
-    itemsSvc.hasSearchText$.next(false);
-    loadingSvc.loading$.next(false);
-
-    const fixture = TestBed.createComponent(VaultComponent);
-    component = fixture.componentInstance;
-
-    const readySubject$ = component["readySubject"];
-    const allFilters$ = filtersSvc.allFilters$ as unknown as Subject<any>;
-
-    // Unblock loading
-    readySubject$.next(true);
-    allFilters$.next({});
-    fixture.detectChanges();
-
-    const autofillElement = fixture.debugElement.query(By.css("app-autofill-vault-list-items"));
-    expect(autofillElement).toBeTruthy();
-
-    const favoritesElement = fixture.debugElement.query(By.css("#favorites"));
-    expect(favoritesElement).toBeTruthy();
-  });
-
-  it("does set the title for allItems container to allItems when hasSearchText$ and numberOfAppliedFilters$ are false and 0 respectively", () => {
-    // Ensure vaultState is null (not Empty, NoResults, or DeactivatedOrg)
-    itemsSvc.emptyVault$.next(false);
-    itemsSvc.noFilteredResults$.next(false);
-    itemsSvc.showDeactivatedOrg$.next(false);
-    itemsSvc.hasSearchText$.next(false);
-    filtersSvc.numberOfAppliedFilters$.next(0);
-    loadingSvc.loading$.next(false);
-
-    const fixture = TestBed.createComponent(VaultComponent);
-    component = fixture.componentInstance;
-
-    const readySubject$ = component["readySubject"];
-    const allFilters$ = filtersSvc.allFilters$ as unknown as Subject<any>;
-
-    // Unblock loading
-    readySubject$.next(true);
-    allFilters$.next({});
-    fixture.detectChanges();
-
-    const allItemsElement = fixture.debugElement.query(By.css("#allItems"));
-    const allItemsTitle = allItemsElement.componentInstance.title();
-    expect(allItemsTitle).toBe("allItems");
-  });
-
-  it("does set the title for allItems container to searchResults when hasSearchText$ is true", () => {
-    // Ensure vaultState is null (not Empty, NoResults, or DeactivatedOrg)
-    itemsSvc.emptyVault$.next(false);
-    itemsSvc.noFilteredResults$.next(false);
-    itemsSvc.showDeactivatedOrg$.next(false);
-    itemsSvc.hasSearchText$.next(true);
-    loadingSvc.loading$.next(false);
-
-    const fixture = TestBed.createComponent(VaultComponent);
-    component = fixture.componentInstance;
-
-    const readySubject$ = component["readySubject"];
-    const allFilters$ = filtersSvc.allFilters$ as unknown as Subject<any>;
-
-    // Unblock loading
-    readySubject$.next(true);
-    allFilters$.next({});
-    fixture.detectChanges();
-
-    const allItemsElement = fixture.debugElement.query(By.css("#allItems"));
-    const allItemsTitle = allItemsElement.componentInstance.title();
-    expect(allItemsTitle).toBe("searchResults");
-  });
-
-  it("does set the title for allItems container to items when numberOfAppliedFilters$ is > 0", fakeAsync(() => {
-    // Ensure vaultState is null (not Empty, NoResults, or DeactivatedOrg)
-    itemsSvc.emptyVault$.next(false);
-    itemsSvc.noFilteredResults$.next(false);
-    itemsSvc.showDeactivatedOrg$.next(false);
-    itemsSvc.hasSearchText$.next(false);
-    filtersSvc.numberOfAppliedFilters$.next(1);
-    loadingSvc.loading$.next(false);
-
-    const fixture = TestBed.createComponent(VaultComponent);
-    component = fixture.componentInstance;
-
-    const readySubject$ = component["readySubject"];
-    const allFilters$ = filtersSvc.allFilters$ as unknown as Subject<any>;
-
-    // Unblock loading
-    readySubject$.next(true);
-    allFilters$.next({});
-    fixture.detectChanges();
-
-    const allItemsElement = fixture.debugElement.query(By.css("#allItems"));
-    const allItemsTitle = allItemsElement.componentInstance.title();
-    expect(allItemsTitle).toBe("items");
   }));
 
   describe("AutoConfirmExtensionSetupDialog", () => {

--- a/apps/browser/src/vault/popup/components/vault/vault.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/vault.component.ts
@@ -158,11 +158,6 @@ export class VaultComponent implements OnInit, OnDestroy {
     FeatureFlag.BrowserPremiumSpotlight,
   );
 
-  protected readonly hasSearchText$ = this.vaultPopupItemsService.hasSearchText$;
-  protected readonly numberOfAppliedFilters$ =
-    this.vaultPopupListFiltersService.numberOfAppliedFilters$;
-
-  protected filteredCiphers$ = this.vaultPopupItemsService.filteredCiphers$;
   protected favoriteCiphers$ = this.vaultPopupItemsService.favoriteCiphers$;
   protected remainingCiphers$ = this.vaultPopupItemsService.remainingCiphers$;
   protected allFilters$ = this.vaultPopupListFiltersService.allFilters$;

--- a/apps/browser/src/vault/popup/services/vault-popup-items.service.spec.ts
+++ b/apps/browser/src/vault/popup/services/vault-popup-items.service.spec.ts
@@ -323,25 +323,6 @@ describe("VaultPopupItemsService", () => {
     });
   });
 
-  describe("filteredCiphers$", () => {
-    it("should filter filteredCipher$ down to search term", (done) => {
-      const cipherList = Object.values(allCiphers);
-      const searchText = "Login";
-
-      searchService.searchCiphers.mockImplementation(async () => {
-        return cipherList.filter((cipher) => {
-          return cipher.name.includes(searchText);
-        });
-      });
-
-      service.filteredCiphers$.subscribe((ciphers) => {
-        // There are 10 ciphers but only 3 with "Login" in the name
-        expect(ciphers.length).toBe(3);
-        done();
-      });
-    });
-  });
-
   describe("favoriteCiphers$", () => {
     it("should exclude autofill ciphers", (done) => {
       service.favoriteCiphers$.subscribe((ciphers) => {

--- a/apps/browser/src/vault/popup/services/vault-popup-items.service.ts
+++ b/apps/browser/src/vault/popup/services/vault-popup-items.service.ts
@@ -201,15 +201,6 @@ export class VaultPopupItemsService {
   );
 
   /**
-   * List of ciphers that are filtered using filters and search.
-   * Includes favorite ciphers and ciphers currently suggested for autofill.
-   * Ciphers are sorted by name.
-   */
-  filteredCiphers$: Observable<PopupCipherViewLike[]> = this._filteredCipherList$.pipe(
-    shareReplay({ refCount: false, bufferSize: 1 }),
-  );
-
-  /**
    * List of ciphers that can be used for autofill on the current tab. Includes cards and/or identities
    * if enabled in the vault settings. Ciphers are sorted by type, then by last used date, then by name.
    *


### PR DESCRIPTION
## 🎟️ Tracking

[PM-26704](https://bitwarden.atlassian.net/browse/PM-26704)
[PM-26706](https://bitwarden.atlassian.net/browse/PM-26706)


## 📔 Objective

Revert these two changes as other autofill related behavior changes were not ready for release.

- `Autofill Suggestions` section remains when showing search results 
-  All Items sections excludes items in the above Autofill Suggestions and Favorites sections

## 📸 Screenshots



https://github.com/user-attachments/assets/b6fabe6b-8a02-4b62-9a88-27df038e1612



[PM-26704]: https://bitwarden.atlassian.net/browse/PM-26704?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-26706]: https://bitwarden.atlassian.net/browse/PM-26706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ