### PR TITLE
[PM-28651] - truncate long item names to two lines

### DIFF
--- a/libs/vault/src/cipher-view/item-details/item-details-v2.component.html
+++ b/libs/vault/src/cipher-view/item-details/item-details-v2.component.html
@@ -12,7 +12,7 @@
       </div>
       <h2
         bitTypography="h4"
-        class="tw-ml-2 tw-mt-2 tw-select-auto tw-flex-1"
+        class="tw-ml-2 tw-mt-2 tw-select-auto tw-flex-1 tw-break-all tw-line-clamp-2"
         data-testid="item-name"
       >
         {{ cipher().name }}


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-28651

Resolves #17613 and #17609

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
Web

<img width="1780" height="1020" alt="Screenshot 2026-02-20 at 4 54 47 PM" src="https://github.com/user-attachments/assets/17e80980-6dd2-4170-857b-ee422e0396da" />

Desktop

<img width="1777" height="983" alt="Screenshot 2026-02-20 at 4 57 27 PM" src="https://github.com/user-attachments/assets/a7e8bc31-dc87-45b1-b9d3-19294fb8d38d" />

Browser

<img width="486" height="601" alt="Screenshot 2026-02-20 at 4 57 59 PM" src="https://github.com/user-attachments/assets/fcb2f64a-2c0d-4929-aa03-a40eef9f80a5" />


