### PR TITLE
Block renovate from updating `actions/create-github-app-token`

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -543,6 +543,12 @@
 
     // ==================== Special Version Constraints ====================
     {
+      matchPackageNames: ["actions/create-github-app-token"],
+      matchFileNames: [".github/workflows/test-browser-interactions.yml"],
+      allowedVersions: "<= 2.0.3",
+      description: "Versions after v2.0.3 break the test-browser-interactions workflow. Remediation tracked in PM-28174.",
+    },
+    {
       // Any versions of lowdb above 1.0.0 are not compatible with CommonJS.
       matchPackageNames: ["lowdb"],
       allowedVersions: "1.0.0",


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

`actions/create-github-app-token` breaks test-browser-interactions.yml if updated past v2.0.3 according to Autofill. This PR will pin the verison untill the team can look into the issue.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
