### PR TITLE
[CL-1057] remove desktop global styles from `bitLink`

### DIFF
--- a/apps/desktop/src/scss/base.scss
+++ b/apps/desktop/src/scss/base.scss
@@ -51,7 +51,7 @@ img {
   border: none;
 }
 
-a {
+a:not([bitlink]) {
   text-decoration: none;
 
   @include themify($themes) {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/CL-1057

## 📔 Objective

Prevent the global legacy styles in Desktop from effecting `bitLink`

## 📸 Screenshots

<img width="728" height="693" alt="image" src="https://github.com/user-attachments/assets/e47173e3-9aca-4c96-9851-033e3a8ae60b" />

