### PR TITLE
[PM-32596] fix: trim whitespace from verification code inputs

### DIFF
--- a/libs/auth/src/angular/new-device-verification/new-device-verification.component.ts
+++ b/libs/auth/src/angular/new-device-verification/new-device-verification.component.ts
@@ -144,7 +144,7 @@ export class NewDeviceVerificationComponent implements OnInit, OnDestroy {
 
     try {
       const authResult = await this.loginStrategyService.logInNewDeviceVerification(
-        codeControl.value,
+        codeControl.value?.trim(),
       );
 
       if (authResult.requiresTwoFactor) {

--- a/libs/auth/src/angular/two-factor-auth/child-components/two-factor-auth-authenticator/two-factor-auth-authenticator.component.ts
+++ b/libs/auth/src/angular/two-factor-auth/child-components/two-factor-auth-authenticator/two-factor-auth-authenticator.component.ts
@@ -42,7 +42,7 @@ export class TwoFactorAuthAuthenticatorComponent {
   @Output() tokenChange = new EventEmitter<{ token: string }>();
 
   onTokenChange(event: Event) {
-    const tokenValue = (event.target as HTMLInputElement).value || "";
+    const tokenValue = (event.target as HTMLInputElement).value?.trim() || "";
     this.tokenChange.emit({ token: tokenValue });
   }
 }

--- a/libs/auth/src/angular/two-factor-auth/child-components/two-factor-auth-email/two-factor-auth-email.component.ts
+++ b/libs/auth/src/angular/two-factor-auth/child-components/two-factor-auth-email/two-factor-auth-email.component.ts
@@ -103,7 +103,7 @@ export class TwoFactorAuthEmailComponent implements OnInit {
    * @param event - The event object from the input field
    */
   onTokenChange(event: Event) {
-    const tokenValue = (event.target as HTMLInputElement).value || "";
+    const tokenValue = (event.target as HTMLInputElement).value?.trim() || "";
     this.tokenChange.emit({ token: tokenValue });
   }
 

--- a/libs/auth/src/angular/user-verification/user-verification-form-input.component.ts
+++ b/libs/auth/src/angular/user-verification/user-verification-form-input.component.ts
@@ -333,7 +333,7 @@ export class UserVerificationFormInputComponent implements ControlValueAccessor,
 
     this.onChange({
       type: this.determineVerificationWithSecretType(),
-      secret: Utils.isNullOrWhitespace(secret) ? null : secret,
+      secret: Utils.isNullOrWhitespace(secret) ? null : secret?.trim(),
     });
   }
 


### PR DESCRIPTION
## Description

This fix addresses issue #14258 where verification codes copied from emails would fail if they contained trailing whitespace.

## Changes

Added `.trim()` to all verification code inputs before they are processed:

1. **user-verification-form-input.component.ts** - Trim secret in `processSecretChanges()`
2. **two-factor-auth-email.component.ts** - Trim token in `onTokenChange()`
3. **two-factor-auth-authenticator.component.ts** - Trim token in `onTokenChange()`
4. **new-device-verification.component.ts** - Trim code in `submit()`

## Testing

The fix ensures that:
- Users can copy-paste verification codes from emails without failure
- Leading and trailing whitespace is stripped before validation
- No functional changes for codes without whitespace

## Related Issue

Fixes #14258