### PR TITLE
Migrate takeUntil to takeUntilDestroyed (autofill - browser)

### DIFF
--- a/apps/browser/src/autofill/popup/fido2/fido2.component.ts
+++ b/apps/browser/src/autofill/popup/fido2/fido2.component.ts
@@ -1,7 +1,8 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
 import { CommonModule } from "@angular/common";
-import { Component, OnDestroy, OnInit } from "@angular/core";
+import { Component, DestroyRef, inject, OnInit } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { FormsModule } from "@angular/forms";
 import { ActivatedRoute, Router } from "@angular/router";
 import {
@@ -12,9 +13,7 @@ import {
   firstValueFrom,
   map,
   Observable,
-  Subject,
   take,
-  takeUntil,
 } from "rxjs";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
@@ -93,8 +92,8 @@ interface ViewData {
     SectionHeaderComponent,
   ],
 })
-export class Fido2Component implements OnInit, OnDestroy {
-  private destroy$ = new Subject<void>();
+export class Fido2Component implements OnInit {
+  private readonly destroyRef = inject(DestroyRef);
   private message$ = new BehaviorSubject<BrowserFido2Message>(null);
   protected BrowserFido2MessageTypes = BrowserFido2MessageTypes;
   protected cipher: CipherView;
@@ -174,7 +173,7 @@ export class Fido2Component implements OnInit, OnDestroy {
           return message;
         }),
         filter((message) => !!message),
-        takeUntil(this.destroy$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe((message) => {
         this.message$.next(message);
@@ -261,10 +260,10 @@ export class Fido2Component implements OnInit, OnDestroy {
         };
       }),
 
-      takeUntil(this.destroy$),
+      takeUntilDestroyed(this.destroyRef),
     );
 
-    queryParams$.pipe(takeUntil(this.destroy$)).subscribe((queryParams) => {
+    queryParams$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((queryParams) => {
       this.send({
         sessionId: queryParams.sessionId,
         type: BrowserFido2MessageTypes.ConnectResponse,
@@ -415,11 +414,6 @@ export class Fido2Component implements OnInit, OnDestroy {
       type: BrowserFido2MessageTypes.AbortResponse,
       fallbackRequested: fallback,
     });
-  }
-
-  ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   private buildCipher(name: string, username: string) {

--- a/apps/browser/src/autofill/popup/settings/blocked-domains.component.ts
+++ b/apps/browser/src/autofill/popup/settings/blocked-domains.component.ts
@@ -2,11 +2,13 @@ import { CommonModule } from "@angular/common";
 import {
   QueryList,
   Component,
+  DestroyRef,
   ElementRef,
-  OnDestroy,
+  inject,
   AfterViewInit,
   ViewChildren,
 } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import {
   FormsModule,
   ReactiveFormsModule,
@@ -15,7 +17,6 @@ import {
   FormArray,
 } from "@angular/forms";
 import { RouterModule } from "@angular/router";
-import { Subject, takeUntil } from "rxjs";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { DomainSettingsService } from "@bitwarden/common/autofill/services/domain-settings.service";
@@ -67,7 +68,7 @@ import { PopupRouterCacheService } from "../../../platform/popup/view-cache/popu
     TypographyModule,
   ],
 })
-export class BlockedDomainsComponent implements AfterViewInit, OnDestroy {
+export class BlockedDomainsComponent implements AfterViewInit {
   // FIXME(https://bitwarden.atlassian.net/browse/CL-903): Migrate to Signals
   // eslint-disable-next-line @angular-eslint/prefer-signals
   @ViewChildren("uriInput") uriInputElements: QueryList<ElementRef<HTMLInputElement>> =
@@ -85,7 +86,7 @@ export class BlockedDomainsComponent implements AfterViewInit, OnDestroy {
   // How many fields should be non-editable before editable fields
   fieldsEditThreshold: number = 0;
 
-  private destroy$ = new Subject<void>();
+  private readonly destroyRef = inject(DestroyRef);
 
   constructor(
     private domainSettingsService: DomainSettingsService,
@@ -101,17 +102,14 @@ export class BlockedDomainsComponent implements AfterViewInit, OnDestroy {
 
   async ngAfterViewInit() {
     this.domainSettingsService.blockedInteractionsUris$
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((neverDomains: NeverDomains) => this.handleStateUpdate(neverDomains));
 
-    this.uriInputElements.changes.pipe(takeUntil(this.destroy$)).subscribe(({ last }) => {
-      this.focusNewUriInput(last);
-    });
-  }
-
-  ngOnDestroy() {
-    this.destroy$.next();
-    this.destroy$.complete();
+    this.uriInputElements.changes
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(({ last }) => {
+        this.focusNewUriInput(last);
+      });
   }
 
   handleStateUpdate(neverDomains: NeverDomains) {

--- a/apps/browser/src/autofill/popup/settings/excluded-domains.component.ts
+++ b/apps/browser/src/autofill/popup/settings/excluded-domains.component.ts
@@ -2,11 +2,13 @@ import { CommonModule } from "@angular/common";
 import {
   QueryList,
   Component,
+  DestroyRef,
   ElementRef,
-  OnDestroy,
+  inject,
   AfterViewInit,
   ViewChildren,
 } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import {
   FormsModule,
   ReactiveFormsModule,
@@ -15,7 +17,6 @@ import {
   FormArray,
 } from "@angular/forms";
 import { RouterModule } from "@angular/router";
-import { Subject, takeUntil } from "rxjs";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { DomainSettingsService } from "@bitwarden/common/autofill/services/domain-settings.service";
@@ -67,7 +68,9 @@ import { PopupRouterCacheService } from "../../../platform/popup/view-cache/popu
     TypographyModule,
   ],
 })
-export class ExcludedDomainsComponent implements AfterViewInit, OnDestroy {
+export class ExcludedDomainsComponent implements AfterViewInit {
+  private readonly destroyRef = inject(DestroyRef);
+
   // FIXME(https://bitwarden.atlassian.net/browse/CL-903): Migrate to Signals
   // eslint-disable-next-line @angular-eslint/prefer-signals
   @ViewChildren("uriInput") uriInputElements: QueryList<ElementRef<HTMLInputElement>> =
@@ -85,8 +88,6 @@ export class ExcludedDomainsComponent implements AfterViewInit, OnDestroy {
   // How many fields should be non-editable before editable fields
   fieldsEditThreshold: number = 0;
 
-  private destroy$ = new Subject<void>();
-
   constructor(
     private domainSettingsService: DomainSettingsService,
     private i18nService: I18nService,
@@ -101,17 +102,14 @@ export class ExcludedDomainsComponent implements AfterViewInit, OnDestroy {
 
   async ngAfterViewInit() {
     this.domainSettingsService.neverDomains$
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((neverDomains: NeverDomains) => this.handleStateUpdate(neverDomains));
 
-    this.uriInputElements.changes.pipe(takeUntil(this.destroy$)).subscribe(({ last }) => {
-      this.focusNewUriInput(last);
-    });
-  }
-
-  ngOnDestroy() {
-    this.destroy$.next();
-    this.destroy$.complete();
+    this.uriInputElements.changes
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(({ last }) => {
+        this.focusNewUriInput(last);
+      });
   }
 
   handleStateUpdate(neverDomains: NeverDomains) {


### PR DESCRIPTION
## Summary

- Replaces `takeUntil(this.destroy$)` pattern with `takeUntilDestroyed(this.destroyRef)`
- Removes destroy `Subject` fields and cleanup-only `ngOnDestroy` methods
- Simplifies constructor-body calls to `takeUntilDestroyed()` (no arg, injection context)

**Files:** `apps/browser/src/autofill/popup/`

## Test plan

- [ ] Verify components still subscribe/unsubscribe correctly at lifecycle boundaries
- [ ] Check that any retained `ngOnDestroy` methods still execute their non-destroy logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Sibling PRs

- #19165 auth
- #19167 autofill (desktop)
- #19168 tools
- #19169 vault
- #19170 admin console
- #19171 billing
- #19172 data insights & reporting
- #19173 key management
- #19174 UI foundation
- #19175 secrets manager
- #19176 platform / app shell