### PR TITLE
Migrate takeUntil to takeUntilDestroyed (autofill - desktop)

### DIFF
--- a/apps/desktop/src/autofill/modal/credentials/fido2-vault.component.ts
+++ b/apps/desktop/src/autofill/modal/credentials/fido2-vault.component.ts
@@ -1,16 +1,8 @@
 import { CommonModule } from "@angular/common";
-import { ChangeDetectionStrategy, Component, OnInit, OnDestroy } from "@angular/core";
+import { ChangeDetectionStrategy, Component, DestroyRef, inject, OnInit } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { RouterModule, Router } from "@angular/router";
-import {
-  firstValueFrom,
-  map,
-  combineLatest,
-  of,
-  BehaviorSubject,
-  Observable,
-  Subject,
-  takeUntil,
-} from "rxjs";
+import { firstValueFrom, map, combineLatest, of, BehaviorSubject, Observable } from "rxjs";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { BitwardenShield } from "@bitwarden/assets/svg";
@@ -58,9 +50,9 @@ import {
   templateUrl: "fido2-vault.component.html",
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class Fido2VaultComponent implements OnInit, OnDestroy {
+export class Fido2VaultComponent implements OnInit {
+  private readonly destroyRef = inject(DestroyRef);
   session?: DesktopFido2UserInterfaceSession = null;
-  private destroy$ = new Subject<void>();
   private ciphersSubject = new BehaviorSubject<CipherView[]>([]);
   ciphers$: Observable<CipherView[]> = this.ciphersSubject.asObservable();
   cipherIds$: Observable<string[]> | undefined;
@@ -81,11 +73,6 @@ export class Fido2VaultComponent implements OnInit, OnDestroy {
     this.session = this.fido2UserInterfaceService.getCurrentSession();
     this.cipherIds$ = this.session?.availableCipherIds$;
     await this.loadCiphers();
-  }
-
-  async ngOnDestroy(): Promise<void> {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   async chooseCipher(cipher: CipherView): Promise<void> {
@@ -143,7 +130,7 @@ export class Fido2VaultComponent implements OnInit, OnDestroy {
 
           return activeCiphers;
         }),
-        takeUntil(this.destroy$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe({
         next: (ciphers) => this.ciphersSubject.next(ciphers as CipherView[]),

--- a/apps/desktop/src/autofill/services/desktop-autofill.service.ts
+++ b/apps/desktop/src/autofill/services/desktop-autofill.service.ts
@@ -1,6 +1,6 @@
-import { Injectable, OnDestroy } from "@angular/core";
+import { DestroyRef, Injectable, inject } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import {
-  Subject,
   combineLatest,
   debounceTime,
   distinctUntilChanged,
@@ -9,7 +9,6 @@ import {
   map,
   mergeMap,
   switchMap,
-  takeUntil,
   tap,
 } from "rxjs";
 
@@ -48,8 +47,8 @@ import {
 import type { NativeWindowObject } from "./desktop-fido2-user-interface.service";
 
 @Injectable()
-export class DesktopAutofillService implements OnDestroy {
-  private destroy$ = new Subject<void>();
+export class DesktopAutofillService {
+  private readonly destroyRef = inject(DestroyRef);
   private registrationRequest: autofill.PasskeyRegistrationRequest;
   private featureFlag?: typeof FeatureFlag.MacOsNativeCredentialSync;
   private isEnabled: boolean = false;
@@ -101,7 +100,7 @@ export class DesktopAutofillService implements OnDestroy {
         filter((cipherViewMap) => cipherViewMap !== null),
 
         mergeMap((cipherViewMap) => this.sync(Object.values(cipherViewMap ?? []))),
-        takeUntil(this.destroy$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe();
 
@@ -110,7 +109,7 @@ export class DesktopAutofillService implements OnDestroy {
       .pipe(
         filter((status) => status === AuthenticationStatus.LoggedOut),
         mergeMap(() => this.sync([])), // sync an empty array
-        takeUntil(this.destroy$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe();
 
@@ -415,11 +414,6 @@ export class DesktopAutofillService implements OnDestroy {
       authenticatorData: Array.from(new Uint8Array(response.authenticatorData)),
       credentialId: Array.from(new Uint8Array(response.selectedCredential.id)),
     };
-  }
-
-  ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 }
 

--- a/apps/desktop/src/autofill/services/desktop-autotype.service.ts
+++ b/apps/desktop/src/autofill/services/desktop-autotype.service.ts
@@ -1,4 +1,5 @@
-import { Injectable, OnDestroy } from "@angular/core";
+import { DestroyRef, inject, Injectable } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import {
   combineLatest,
   concatMap,
@@ -8,9 +9,7 @@ import {
   map,
   Observable,
   of,
-  Subject,
   switchMap,
-  takeUntil,
 } from "rxjs";
 
 import { Account, AccountService } from "@bitwarden/common/auth/abstractions/account.service";
@@ -61,7 +60,8 @@ export const AUTOTYPE_KEYBOARD_SHORTCUT = new KeyDefinition<string[]>(
 @Injectable({
   providedIn: "root",
 })
-export class DesktopAutotypeService implements OnDestroy {
+export class DesktopAutotypeService {
+  private readonly destroyRef = inject(DestroyRef);
   private readonly autotypeEnabledState = this.globalStateProvider.get(AUTOTYPE_ENABLED);
   private readonly autotypeKeyboardShortcut = this.globalStateProvider.get(
     AUTOTYPE_KEYBOARD_SHORTCUT,
@@ -74,8 +74,6 @@ export class DesktopAutotypeService implements OnDestroy {
   autotypeEnabledUserSetting$: Observable<boolean> = of(false);
 
   autotypeKeyboardShortcut$: Observable<string[]> = of(DEFAULT_KEYBOARD_SHORTCUT);
-
-  private destroy$ = new Subject<void>();
 
   constructor(
     private accountService: AccountService,
@@ -91,7 +89,7 @@ export class DesktopAutotypeService implements OnDestroy {
     this.autotypeEnabledUserSetting$ = this.autotypeEnabledState.state$.pipe(
       map((enabled) => enabled ?? false),
       distinctUntilChanged(), // Only emit when the boolean result changes
-      takeUntil(this.destroy$),
+      takeUntilDestroyed(),
     );
 
     this.isPremiumAccount$ = this.accountService.activeAccount$.pipe(
@@ -100,12 +98,12 @@ export class DesktopAutotypeService implements OnDestroy {
         this.billingAccountProfileStateService.hasPremiumFromAnySource$(account.id),
       ),
       distinctUntilChanged(), // Only emit when the boolean result changes
-      takeUntil(this.destroy$),
+      takeUntilDestroyed(),
     );
 
     this.autotypeKeyboardShortcut$ = this.autotypeKeyboardShortcut.state$.pipe(
       map((shortcut) => shortcut ?? DEFAULT_KEYBOARD_SHORTCUT),
-      takeUntil(this.destroy$),
+      takeUntilDestroyed(),
     );
   }
 
@@ -141,7 +139,7 @@ export class DesktopAutotypeService implements OnDestroy {
             this.logService.error("Failed to set Autotype enabled state.");
           }
         }),
-        takeUntil(this.destroy$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe();
 
@@ -154,7 +152,7 @@ export class DesktopAutotypeService implements OnDestroy {
           };
           ipc.autofill.configureAutotype(config);
         }),
-        takeUntil(this.destroy$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe();
 
@@ -163,7 +161,7 @@ export class DesktopAutotypeService implements OnDestroy {
         concatMap(async (enabled) => {
           ipc.autofill.toggleAutotype(enabled);
         }),
-        takeUntil(this.destroy$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe();
   }
@@ -188,7 +186,7 @@ export class DesktopAutotypeService implements OnDestroy {
           isPremiumAcct,
       ),
       distinctUntilChanged(), // Only emit when the boolean result changes
-      takeUntil(this.destroy$),
+      takeUntilDestroyed(this.destroyRef),
     );
   }
 
@@ -232,11 +230,6 @@ export class DesktopAutotypeService implements OnDestroy {
     });
 
     return possibleCiphers;
-  }
-
-  ngOnDestroy() {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 }
 

--- a/apps/desktop/src/autofill/services/ssh-agent.service.ts
+++ b/apps/desktop/src/autofill/services/ssh-agent.service.ts
@@ -1,6 +1,7 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
-import { Injectable, OnDestroy } from "@angular/core";
+import { DestroyRef, inject, Injectable } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import {
   catchError,
   combineLatest,
@@ -12,9 +13,7 @@ import {
   map,
   of,
   skip,
-  Subject,
   switchMap,
-  takeUntil,
   timeout,
   TimeoutError,
   timer,
@@ -39,14 +38,14 @@ import { SshAgentPromptType } from "../models/ssh-agent-setting";
 @Injectable({
   providedIn: "root",
 })
-export class SshAgentService implements OnDestroy {
+export class SshAgentService {
   SSH_REFRESH_INTERVAL = 1000;
   SSH_VAULT_UNLOCK_REQUEST_TIMEOUT = 60_000;
   SSH_REQUEST_UNLOCK_POLLING_INTERVAL = 100;
 
   private authorizedSshKeys: Record<string, Date> = {};
 
-  private destroy$ = new Subject<void>();
+  private readonly destroyRef = inject(DestroyRef);
 
   constructor(
     private cipherService: CipherService,
@@ -68,7 +67,7 @@ export class SshAgentService implements OnDestroy {
             await ipc.platform.sshAgent.init();
           }
         }),
-        takeUntil(this.destroy$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe();
 
@@ -196,32 +195,34 @@ export class SshAgentService implements OnDestroy {
             return ipc.platform.sshAgent.signRequestResponse(requestId, true);
           }
         }),
-        takeUntil(this.destroy$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe();
 
-    this.accountService.activeAccount$.pipe(skip(1), takeUntil(this.destroy$)).subscribe({
-      next: (account) => {
-        this.authorizedSshKeys = {};
-        this.logService.info("Active account changed, clearing SSH keys");
-        ipc.platform.sshAgent
-          .clearKeys()
-          .catch((e) => this.logService.error("Failed to clear SSH keys", e));
-      },
-      error: (e: unknown) => {
-        this.logService.error("Error in active account observable", e);
-        ipc.platform.sshAgent
-          .clearKeys()
-          .catch((e) => this.logService.error("Failed to clear SSH keys", e));
-      },
-      complete: () => {
-        this.logService.info("Active account observable completed, clearing SSH keys");
-        this.authorizedSshKeys = {};
-        ipc.platform.sshAgent
-          .clearKeys()
-          .catch((e) => this.logService.error("Failed to clear SSH keys", e));
-      },
-    });
+    this.accountService.activeAccount$
+      .pipe(skip(1), takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (account) => {
+          this.authorizedSshKeys = {};
+          this.logService.info("Active account changed, clearing SSH keys");
+          ipc.platform.sshAgent
+            .clearKeys()
+            .catch((e) => this.logService.error("Failed to clear SSH keys", e));
+        },
+        error: (e: unknown) => {
+          this.logService.error("Error in active account observable", e);
+          ipc.platform.sshAgent
+            .clearKeys()
+            .catch((e) => this.logService.error("Failed to clear SSH keys", e));
+        },
+        complete: () => {
+          this.logService.info("Active account observable completed, clearing SSH keys");
+          this.authorizedSshKeys = {};
+          ipc.platform.sshAgent
+            .clearKeys()
+            .catch((e) => this.logService.error("Failed to clear SSH keys", e));
+        },
+      });
 
     combineLatest([
       timer(0, this.SSH_REFRESH_INTERVAL),
@@ -260,14 +261,9 @@ export class SshAgentService implements OnDestroy {
           });
           await ipc.platform.sshAgent.setKeys(keys);
         }),
-        takeUntil(this.destroy$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe();
-  }
-
-  ngOnDestroy() {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   private async rememberAuthorization(cipherId: string): Promise<void> {


### PR DESCRIPTION
## Summary

- Replaces `takeUntil(this.destroy$)` pattern with `takeUntilDestroyed(this.destroyRef)`
- Removes destroy `Subject` fields and cleanup-only `ngOnDestroy` methods
- Simplifies constructor-body calls to `takeUntilDestroyed()` (no arg, injection context)

**Files:** `apps/desktop/src/autofill/`

## Test plan

- [ ] Verify components still subscribe/unsubscribe correctly at lifecycle boundaries
- [ ] Check that any retained `ngOnDestroy` methods still execute their non-destroy logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Sibling PRs

- #19165 auth
- #19166 autofill (browser)
- #19168 tools
- #19169 vault
- #19170 admin console
- #19171 billing
- #19172 data insights & reporting
- #19173 key management
- #19174 UI foundation
- #19175 secrets manager
- #19176 platform / app shell