### PR TITLE
Migrate takeUntil to takeUntilDestroyed (vault)

### DIFF
--- a/apps/desktop/src/vault/app/vault-v3/vault-filter/vault-filter.component.ts
+++ b/apps/desktop/src/vault/app/vault-v3/vault-filter/vault-filter.component.ts
@@ -1,9 +1,9 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
 import { CommonModule } from "@angular/common";
-import { Component, inject, OnInit, output, computed, signal } from "@angular/core";
-import { toSignal } from "@angular/core/rxjs-interop";
-import { firstValueFrom, Subject, takeUntil } from "rxjs";
+import { Component, DestroyRef, inject, OnInit, output, computed, signal } from "@angular/core";
+import { takeUntilDestroyed, toSignal } from "@angular/core/rxjs-interop";
+import { firstValueFrom } from "rxjs";
 
 import { PolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
 import { PolicyType } from "@bitwarden/common/admin-console/enums";
@@ -62,7 +62,7 @@ export class VaultFilterComponent implements OnInit {
   private folderService: FolderService = inject(FolderService);
   private policyService: PolicyService = inject(PolicyService);
   private dialogService: DialogService = inject(DialogService);
-  private componentIsDestroyed$ = new Subject<boolean>();
+  private readonly destroyRef = inject(DestroyRef);
 
   protected readonly activeFilter = signal<VaultFilter | null>(null);
   protected onFilterChange = output<VaultFilter>();
@@ -121,7 +121,7 @@ export class VaultFilterComponent implements OnInit {
     );
 
     this.routedVaultFilterBridgeService.activeFilter$
-      .pipe(takeUntil(this.componentIsDestroyed$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((filter) => {
         this.activeFilter.set(filter);
       });

--- a/apps/desktop/src/vault/app/vault-v3/vault.component.ts
+++ b/apps/desktop/src/vault/app/vault-v3/vault.component.ts
@@ -5,24 +5,17 @@ import {
   ChangeDetectorRef,
   Component,
   computed,
+  DestroyRef,
+  inject,
   NgZone,
   OnDestroy,
   OnInit,
   signal,
   ViewChild,
 } from "@angular/core";
-import { toSignal } from "@angular/core/rxjs-interop";
+import { takeUntilDestroyed, toSignal } from "@angular/core/rxjs-interop";
 import { ActivatedRoute, Router } from "@angular/router";
-import {
-  combineLatest,
-  firstValueFrom,
-  Subject,
-  takeUntil,
-  switchMap,
-  lastValueFrom,
-  Observable,
-  from,
-} from "rxjs";
+import { combineLatest, firstValueFrom, switchMap, lastValueFrom, Observable, from } from "rxjs";
 import { filter, map, take } from "rxjs/operators";
 
 import { CollectionService } from "@bitwarden/admin-console/common";
@@ -152,6 +145,8 @@ const BroadcasterSubscriptionId = "VaultComponent";
   ],
 })
 export class VaultComponent implements OnInit, OnDestroy, CopyClickListener {
+  private readonly destroyRef = inject(DestroyRef);
+
   // FIXME(https://bitwarden.atlassian.net/browse/CL-903): Migrate to Signals
   // eslint-disable-next-line @angular-eslint/prefer-signals
   @ViewChild(VaultItemsV2Component, { static: true })
@@ -223,7 +218,6 @@ export class VaultComponent implements OnInit, OnDestroy, CopyClickListener {
     ),
   );
 
-  private componentIsDestroyed$ = new Subject<boolean>();
   private allOrganizations: Organization[] = [];
   private allCollections: CollectionView[] = [];
   private filteredCollections: CollectionView[] = [];
@@ -274,7 +268,7 @@ export class VaultComponent implements OnInit, OnDestroy, CopyClickListener {
         switchMap(([vaultFilter, routedFilter, archiveEnabled]) =>
           from(this.applyVaultFilter(vaultFilter, routedFilter, archiveEnabled)),
         ),
-        takeUntil(this.componentIsDestroyed$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe();
 
@@ -399,7 +393,7 @@ export class VaultComponent implements OnInit, OnDestroy, CopyClickListener {
           map((ciphers) => ciphers?.filter((c) => !c.isDeleted) ?? []),
           filter((ciphers) => ciphers.length > 0),
           take(1),
-          takeUntil(this.componentIsDestroyed$),
+          takeUntilDestroyed(this.destroyRef),
         )
         .subscribe((ciphers) => {
           DecryptionFailureDialogComponent.open(this.dialogService, {
@@ -408,7 +402,7 @@ export class VaultComponent implements OnInit, OnDestroy, CopyClickListener {
         });
     }
 
-    this.organizations$.pipe(takeUntil(this.componentIsDestroyed$)).subscribe((orgs) => {
+    this.organizations$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((orgs) => {
       this.allOrganizations = orgs;
     });
 
@@ -418,13 +412,13 @@ export class VaultComponent implements OnInit, OnDestroy, CopyClickListener {
 
     this.collectionService
       .decryptedCollections$(this.activeUserId)
-      .pipe(takeUntil(this.componentIsDestroyed$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((collections) => {
         this.allCollections = collections;
       });
 
     this.vaultFilterService.filteredCollections$
-      .pipe(takeUntil(this.componentIsDestroyed$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((collections) => {
         this.filteredCollections = collections;
       });
@@ -435,8 +429,6 @@ export class VaultComponent implements OnInit, OnDestroy, CopyClickListener {
   ngOnDestroy() {
     this.searchBarService.setEnabled(false);
     this.broadcasterService.unsubscribe(BroadcasterSubscriptionId);
-    this.componentIsDestroyed$.next(true);
-    this.componentIsDestroyed$.complete();
   }
 
   async load() {

--- a/apps/desktop/src/vault/app/vault/vault-v2.component.ts
+++ b/apps/desktop/src/vault/app/vault/vault-v2.component.ts
@@ -3,6 +3,8 @@ import {
   ChangeDetectorRef,
   Component,
   computed,
+  DestroyRef,
+  inject,
   NgZone,
   OnDestroy,
   OnInit,
@@ -10,11 +12,10 @@ import {
   ViewChild,
   ViewContainerRef,
 } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { ActivatedRoute, Router } from "@angular/router";
 import {
   firstValueFrom,
-  Subject,
-  takeUntil,
   switchMap,
   lastValueFrom,
   Observable,
@@ -234,7 +235,7 @@ export class VaultV2Component<C extends CipherViewLike>
     ),
   );
 
-  private componentIsDestroyed$ = new Subject<boolean>();
+  private readonly destroyRef = inject(DestroyRef);
   private allOrganizations: Organization[] = [];
   private allCollections: CollectionView[] = [];
 
@@ -277,7 +278,7 @@ export class VaultV2Component<C extends CipherViewLike>
         switchMap((account) =>
           this.billingAccountProfileStateService.hasPremiumFromAnySource$(account.id),
         ),
-        takeUntil(this.componentIsDestroyed$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe((canAccessPremium: boolean) => {
         this.userHasPremiumAccess = canAccessPremium;
@@ -406,7 +407,7 @@ export class VaultV2Component<C extends CipherViewLike>
           map((ciphers) => ciphers?.filter((c) => !c.isDeleted) ?? []),
           filter((ciphers) => ciphers.length > 0),
           take(1),
-          takeUntil(this.componentIsDestroyed$),
+          takeUntilDestroyed(this.destroyRef),
         )
         .subscribe((ciphers) => {
           DecryptionFailureDialogComponent.open(this.dialogService, {
@@ -415,7 +416,7 @@ export class VaultV2Component<C extends CipherViewLike>
         });
     }
 
-    this.organizations$.pipe(takeUntil(this.componentIsDestroyed$)).subscribe((orgs) => {
+    this.organizations$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((orgs) => {
       this.allOrganizations = orgs;
     });
 
@@ -425,7 +426,7 @@ export class VaultV2Component<C extends CipherViewLike>
 
     this.collectionService
       .decryptedCollections$(this.activeUserId)
-      .pipe(takeUntil(this.componentIsDestroyed$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((collections) => {
         this.allCollections = collections;
       });
@@ -436,8 +437,6 @@ export class VaultV2Component<C extends CipherViewLike>
   ngOnDestroy() {
     this.searchBarService.setEnabled(false);
     this.broadcasterService.unsubscribe(BroadcasterSubscriptionId);
-    this.componentIsDestroyed$.next(true);
-    this.componentIsDestroyed$.complete();
   }
 
   async load() {

--- a/apps/web/src/app/vault/individual-vault/vault-filter/components/organization-options.component.ts
+++ b/apps/web/src/app/vault/individual-vault/vault-filter/components/organization-options.component.ts
@@ -1,13 +1,6 @@
-import { Component, Inject, OnDestroy, OnInit } from "@angular/core";
-import {
-  combineLatest,
-  firstValueFrom,
-  map,
-  Observable,
-  Subject,
-  switchMap,
-  takeUntil,
-} from "rxjs";
+import { Component, DestroyRef, inject, Inject, OnInit } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
+import { combineLatest, firstValueFrom, map, Observable, switchMap } from "rxjs";
 
 import {
   OrganizationUserApiService,
@@ -46,15 +39,14 @@ import { OptionsInput } from "../shared/components/vault-filter-section.componen
   templateUrl: "organization-options.component.html",
   standalone: false,
 })
-export class OrganizationOptionsComponent implements OnInit, OnDestroy {
+export class OrganizationOptionsComponent implements OnInit {
+  private readonly destroyRef = inject(DestroyRef);
   protected actionPromise?: Promise<void | boolean>;
   protected resetPasswordPolicy?: Policy | undefined;
   protected loaded = false;
   protected hideMenu = false;
   protected showLeaveOrgOption = false;
   protected organization!: OrganizationFilter;
-
-  private destroy$ = new Subject<void>();
 
   constructor(
     @Inject(OptionsInput) protected organization$: Observable<OrganizationFilter>,
@@ -101,7 +93,7 @@ export class OrganizationOptionsComponent implements OnInit, OnDestroy {
       ),
       managingOrg$,
     ])
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(([organization, resetPasswordPolicies, decryptionOptions, managingOrg]) => {
         this.organization = organization;
         this.resetPasswordPolicy = resetPasswordPolicies.find(
@@ -123,11 +115,6 @@ export class OrganizationOptionsComponent implements OnInit, OnDestroy {
 
         this.loaded = true;
       });
-  }
-
-  ngOnDestroy() {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   allowEnrollmentChanges(org: OrganizationFilter): boolean {

--- a/apps/web/src/app/vault/individual-vault/vault-filter/components/vault-filter.component.ts
+++ b/apps/web/src/app/vault/individual-vault/vault-filter/components/vault-filter.component.ts
@@ -1,4 +1,5 @@
-import { Component, EventEmitter, inject, Input, OnDestroy, OnInit, Output } from "@angular/core";
+import { Component, DestroyRef, EventEmitter, inject, Input, OnInit, Output } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import {
   combineLatest,
   distinctUntilChanged,
@@ -6,9 +7,7 @@ import {
   map,
   merge,
   shareReplay,
-  Subject,
   switchMap,
-  takeUntil,
 } from "rxjs";
 
 import { PolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
@@ -50,7 +49,9 @@ import { OrganizationOptionsComponent } from "./organization-options.component";
   templateUrl: "vault-filter.component.html",
   standalone: false,
 })
-export class VaultFilterComponent implements OnInit, OnDestroy {
+export class VaultFilterComponent implements OnInit {
+  private readonly destroyRef = inject(DestroyRef);
+
   filters?: VaultFilterList;
   // FIXME(https://bitwarden.atlassian.net/browse/CL-903): Migrate to Signals
   // eslint-disable-next-line @angular-eslint/prefer-signals
@@ -68,7 +69,6 @@ export class VaultFilterComponent implements OnInit, OnDestroy {
 
   isLoaded = false;
 
-  protected destroy$: Subject<void> = new Subject<void>();
   get filtersList() {
     return this.filters ? Object.values(this.filters) : [];
   }
@@ -197,7 +197,7 @@ export class VaultFilterComponent implements OnInit, OnDestroy {
       )
       .pipe(
         switchMap(() => this.addOrganizationFilter()),
-        takeUntil(this.destroy$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe((orgFilters) => {
         if (!this.filters) {
@@ -205,11 +205,6 @@ export class VaultFilterComponent implements OnInit, OnDestroy {
         }
         this.filters.organizationFilter = orgFilters;
       });
-  }
-
-  ngOnDestroy() {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   onSearchTextChanged(t: string) {

--- a/apps/web/src/app/vault/individual-vault/vault-filter/shared/components/vault-filter-section.component.ts
+++ b/apps/web/src/app/vault/individual-vault/vault-filter/shared/components/vault-filter-section.component.ts
@@ -1,7 +1,16 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
-import { Component, InjectionToken, Injector, Input, OnDestroy, OnInit } from "@angular/core";
-import { firstValueFrom, Observable, Subject, takeUntil } from "rxjs";
+import {
+  Component,
+  DestroyRef,
+  inject,
+  InjectionToken,
+  Injector,
+  Input,
+  OnInit,
+} from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
+import { firstValueFrom, Observable } from "rxjs";
 import { map } from "rxjs/operators";
 
 import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
@@ -22,8 +31,8 @@ import {
   templateUrl: "vault-filter-section.component.html",
   standalone: false,
 })
-export class VaultFilterSectionComponent implements OnInit, OnDestroy {
-  private destroy$ = new Subject<void>();
+export class VaultFilterSectionComponent implements OnInit {
+  private readonly destroyRef = inject(DestroyRef);
   private activeUserId$ = getUserId(this.accountService.activeAccount$);
 
   // FIXME(https://bitwarden.atlassian.net/browse/CL-903): Migrate to Signals
@@ -43,22 +52,15 @@ export class VaultFilterSectionComponent implements OnInit, OnDestroy {
     private injector: Injector,
     private accountService: AccountService,
   ) {
-    this.vaultFilterService.collapsedFilterNodes$
-      .pipe(takeUntil(this.destroy$))
-      .subscribe((nodes) => {
-        this.collapsedFilterNodes = nodes;
-      });
-  }
-
-  async ngOnInit() {
-    this.section?.data$?.pipe(takeUntil(this.destroy$)).subscribe((data) => {
-      this.data = data;
+    this.vaultFilterService.collapsedFilterNodes$.pipe(takeUntilDestroyed()).subscribe((nodes) => {
+      this.collapsedFilterNodes = nodes;
     });
   }
 
-  ngOnDestroy() {
-    this.destroy$.next();
-    this.destroy$.complete();
+  async ngOnInit() {
+    this.section?.data$?.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data) => {
+      this.data = data;
+    });
   }
 
   get headerNode() {

--- a/apps/web/src/app/vault/individual-vault/vault-onboarding/vault-onboarding.component.ts
+++ b/apps/web/src/app/vault/individual-vault/vault-onboarding/vault-onboarding.component.ts
@@ -3,15 +3,17 @@
 import { CommonModule } from "@angular/common";
 import {
   Component,
-  OnInit,
-  Input,
-  Output,
+  DestroyRef,
   EventEmitter,
-  OnDestroy,
-  SimpleChanges,
+  inject,
+  Input,
   OnChanges,
+  OnInit,
+  Output,
+  SimpleChanges,
 } from "@angular/core";
-import { Subject, takeUntil, Observable, firstValueFrom, fromEvent, switchMap } from "rxjs";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
+import { Observable, firstValueFrom, fromEvent, switchMap } from "rxjs";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
@@ -45,7 +47,8 @@ import { VaultOnboardingService, VaultOnboardingTasks } from "./services/vault-o
   selector: "app-vault-onboarding",
   templateUrl: "vault-onboarding.component.html",
 })
-export class VaultOnboardingComponent implements OnInit, OnChanges, OnDestroy {
+export class VaultOnboardingComponent implements OnInit, OnChanges {
+  private readonly destroyRef = inject(DestroyRef);
   // FIXME(https://bitwarden.atlassian.net/browse/CL-903): Migrate to Signals
   // eslint-disable-next-line @angular-eslint/prefer-signals
   @Input() ciphers: CipherViewLike[];
@@ -58,7 +61,6 @@ export class VaultOnboardingComponent implements OnInit, OnChanges, OnDestroy {
 
   extensionUrl: string;
   isIndividualPolicyVault: boolean;
-  private destroy$ = new Subject<void>();
   isNewAccount: boolean;
   private readonly onboardingReleaseDate = new Date("2024-04-02");
 
@@ -98,15 +100,10 @@ export class VaultOnboardingComponent implements OnInit, OnChanges, OnDestroy {
     }
   }
 
-  ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
-  }
-
   checkForBrowserExtension() {
     if (this.showOnboarding) {
       fromEvent<MessageEvent>(window, "message")
-        .pipe(takeUntil(this.destroy$))
+        .pipe(takeUntilDestroyed(this.destroyRef))
         .subscribe((event) => {
           void this.getMessages(event);
         });
@@ -176,7 +173,7 @@ export class VaultOnboardingComponent implements OnInit, OnChanges, OnDestroy {
         switchMap((userId) =>
           this.policyService.policyAppliesToUser$(PolicyType.OrganizationDataOwnership, userId),
         ),
-        takeUntil(this.destroy$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe((data) => {
         this.isIndividualPolicyVault = data;

--- a/apps/web/src/app/vault/individual-vault/vault.component.ts
+++ b/apps/web/src/app/vault/individual-vault/vault.component.ts
@@ -1,4 +1,14 @@
-import { ChangeDetectorRef, Component, NgZone, OnDestroy, OnInit, viewChild } from "@angular/core";
+import {
+  ChangeDetectorRef,
+  Component,
+  DestroyRef,
+  inject,
+  NgZone,
+  OnDestroy,
+  OnInit,
+  viewChild,
+} from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { ActivatedRoute, NavigationExtras, Params, Router } from "@angular/router";
 import { combineLatest, firstValueFrom, lastValueFrom, Observable, of, Subject } from "rxjs";
 import {
@@ -12,7 +22,6 @@ import {
   startWith,
   switchMap,
   take,
-  takeUntil,
   tap,
 } from "rxjs/operators";
 
@@ -197,9 +206,10 @@ export class VaultComponent<C extends CipherViewLike> implements OnInit, OnDestr
   protected currentSearchText$: Observable<string> = this.route.queryParams.pipe(
     map((queryParams) => queryParams.search),
   );
+  private readonly destroyRef = inject(DestroyRef);
+
   private searchText$ = new Subject<string>();
   private refresh$ = new Subject<void>();
-  private destroy$ = new Subject<void>();
 
   private vaultItemDialogRef?: DialogRef<VaultItemDialogResult> | undefined;
 
@@ -374,7 +384,7 @@ export class VaultComponent<C extends CipherViewLike> implements OnInit, OnDestr
     });
 
     this.routedVaultFilterBridgeService.activeFilter$
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((activeFilter) => {
         this.activeFilter = activeFilter;
       });
@@ -390,7 +400,7 @@ export class VaultComponent<C extends CipherViewLike> implements OnInit, OnDestr
       .pipe(
         debounceTime(SearchTextDebounceInterval),
         distinctUntilChanged(),
-        takeUntil(this.destroy$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe((searchText) =>
         this.router.navigate([], {
@@ -541,7 +551,7 @@ export class VaultComponent<C extends CipherViewLike> implements OnInit, OnDestr
             }
           }
         }),
-        takeUntil(this.destroy$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe();
 
@@ -552,7 +562,7 @@ export class VaultComponent<C extends CipherViewLike> implements OnInit, OnDestr
         map((ciphers) => ciphers.filter((c) => !c.isDeleted)),
         filter((ciphers) => ciphers.length > 0),
         take(1),
-        takeUntil(this.destroy$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe((ciphers) => {
         DecryptionFailureDialogComponent.open(this.dialogService, {
@@ -567,7 +577,7 @@ export class VaultComponent<C extends CipherViewLike> implements OnInit, OnDestr
         switchMap((organization) =>
           this.organizationWarningsService.showInactiveSubscriptionDialog$(organization),
         ),
-        takeUntil(this.destroy$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe();
 
@@ -586,7 +596,7 @@ export class VaultComponent<C extends CipherViewLike> implements OnInit, OnDestr
             selectedCollection$,
           ]),
         ),
-        takeUntil(this.destroy$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe(
         ([
@@ -626,8 +636,6 @@ export class VaultComponent<C extends CipherViewLike> implements OnInit, OnDestr
 
   ngOnDestroy() {
     this.broadcasterService.unsubscribe(BroadcasterSubscriptionId);
-    this.destroy$.next();
-    this.destroy$.complete();
     this.vaultFilterService.clearOrganizationFilter();
   }
 

--- a/libs/vault/src/components/assign-collections.component.ts
+++ b/libs/vault/src/components/assign-collections.component.ts
@@ -4,25 +4,17 @@ import { CommonModule } from "@angular/common";
 import {
   AfterViewInit,
   Component,
+  DestroyRef,
   EventEmitter,
+  inject,
   Input,
-  OnDestroy,
   OnInit,
   Output,
   ViewChild,
 } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { FormBuilder, ReactiveFormsModule, Validators } from "@angular/forms";
-import {
-  combineLatest,
-  firstValueFrom,
-  map,
-  Observable,
-  shareReplay,
-  Subject,
-  switchMap,
-  takeUntil,
-  tap,
-} from "rxjs";
+import { combineLatest, firstValueFrom, map, Observable, shareReplay, switchMap, tap } from "rxjs";
 
 // This import has been flagged as unallowed for this class. It may be involved in a circular dependency loop.
 // eslint-disable-next-line no-restricted-imports
@@ -57,7 +49,6 @@ import {
   SelectModule,
   ToastService,
 } from "@bitwarden/components";
-
 export interface CollectionAssignmentParams {
   organizationId: OrganizationId;
 
@@ -113,7 +104,9 @@ const MY_VAULT_ID = "MyVault";
     DialogModule,
   ],
 })
-export class AssignCollectionsComponent implements OnInit, OnDestroy, AfterViewInit {
+export class AssignCollectionsComponent implements OnInit, AfterViewInit {
+  private readonly destroyRef = inject(DestroyRef);
+
   // FIXME(https://bitwarden.atlassian.net/browse/CL-903): Migrate to Signals
   // eslint-disable-next-line @angular-eslint/prefer-signals
   @ViewChild(BitSubmitDirective)
@@ -205,7 +198,6 @@ export class AssignCollectionsComponent implements OnInit, OnDestroy, AfterViewI
   private get selectedOrgId(): OrganizationId {
     return this.formGroup.getRawValue().selectedOrg || this.params.organizationId;
   }
-  private destroy$ = new Subject<void>();
 
   constructor(
     private cipherService: CipherService,
@@ -234,7 +226,7 @@ export class AssignCollectionsComponent implements OnInit, OnDestroy, AfterViewI
   }
 
   ngAfterViewInit(): void {
-    this.bitSubmit.loading$.pipe(takeUntil(this.destroy$)).subscribe((loading) => {
+    this.bitSubmit.loading$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((loading) => {
       if (!this.submitBtn) {
         return;
       }
@@ -242,18 +234,13 @@ export class AssignCollectionsComponent implements OnInit, OnDestroy, AfterViewI
       this.submitBtn.loading.set(loading);
     });
 
-    this.bitSubmit.disabled$.pipe(takeUntil(this.destroy$)).subscribe((disabled) => {
+    this.bitSubmit.disabled$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((disabled) => {
       if (!this.submitBtn) {
         return;
       }
 
       this.submitBtn.disabled.set(disabled);
     });
-  }
-
-  ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   selectCollections(items: SelectItemView[]) {
@@ -444,7 +431,7 @@ export class AssignCollectionsComponent implements OnInit, OnDestroy, AfterViewI
         switchMap((orgId) => {
           return this.getCollectionsForOrganization(orgId as OrganizationId);
         }),
-        takeUntil(this.destroy$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe((collections) => {
         this.availableCollections = collections.map((c) => ({

--- a/libs/vault/src/components/can-delete-cipher.directive.ts
+++ b/libs/vault/src/components/can-delete-cipher.directive.ts
@@ -1,5 +1,5 @@
-import { Directive, Input, OnDestroy, TemplateRef, ViewContainerRef } from "@angular/core";
-import { Subject, takeUntil } from "rxjs";
+import { DestroyRef, Directive, inject, Input, TemplateRef, ViewContainerRef } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 
 import { CipherAuthorizationService } from "@bitwarden/common/vault/services/cipher-authorization.service";
 import { CipherViewLike } from "@bitwarden/common/vault/utils/cipher-view-like-utils";
@@ -10,8 +10,8 @@ import { CipherViewLike } from "@bitwarden/common/vault/utils/cipher-view-like-u
 @Directive({
   selector: "[appCanDeleteCipher]",
 })
-export class CanDeleteCipherDirective implements OnDestroy {
-  private destroy$ = new Subject<void>();
+export class CanDeleteCipherDirective {
+  private readonly destroyRef = inject(DestroyRef);
 
   // FIXME(https://bitwarden.atlassian.net/browse/CL-903): Migrate to Signals
   // eslint-disable-next-line @angular-eslint/prefer-signals
@@ -20,7 +20,7 @@ export class CanDeleteCipherDirective implements OnDestroy {
 
     this.cipherAuthorizationService
       .canDeleteCipher$(cipher)
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((canDelete: boolean) => {
         if (canDelete) {
           this.viewContainer.createEmbeddedView(this.templateRef);
@@ -35,9 +35,4 @@ export class CanDeleteCipherDirective implements OnDestroy {
     private viewContainer: ViewContainerRef,
     private cipherAuthorizationService: CipherAuthorizationService,
   ) {}
-
-  ngOnDestroy() {
-    this.destroy$.next();
-    this.destroy$.complete();
-  }
 }

--- a/libs/vault/src/services/routed-vault-filter.service.ts
+++ b/libs/vault/src/services/routed-vault-filter.service.ts
@@ -1,6 +1,7 @@
-import { Injectable, OnDestroy, inject } from "@angular/core";
+import { Injectable, inject } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { ActivatedRoute, NavigationExtras } from "@angular/router";
-import { combineLatest, map, Observable, Subject, takeUntil } from "rxjs";
+import { combineLatest, map, Observable } from "rxjs";
 
 import { CollectionId, OrganizationId } from "@bitwarden/common/types/guid";
 import { SafeInjectionToken } from "@bitwarden/ui-common";
@@ -23,8 +24,7 @@ export const VAULT_FILTER_BASE_ROUTE = new SafeInjectionToken<string>("VaultFilt
  * also contains a method for generating routes to corresponding to those params.
  */
 @Injectable()
-export class RoutedVaultFilterService implements OnDestroy {
-  private onDestroy = new Subject<void>();
+export class RoutedVaultFilterService {
   private baseRoute: string = inject(VAULT_FILTER_BASE_ROUTE, { optional: true }) ?? "";
 
   /**
@@ -51,7 +51,7 @@ export class RoutedVaultFilterService implements OnDestroy {
           type,
         };
       }),
-      takeUntil(this.onDestroy),
+      takeUntilDestroyed(),
     );
   }
 
@@ -86,10 +86,5 @@ export class RoutedVaultFilterService implements OnDestroy {
       },
     };
     return [commands, extras];
-  }
-
-  ngOnDestroy(): void {
-    this.onDestroy.next();
-    this.onDestroy.complete();
   }
 }


### PR DESCRIPTION
## Summary

- Replaces `takeUntil(this.destroy$)` pattern with `takeUntilDestroyed(this.destroyRef)`
- Removes destroy `Subject` fields and cleanup-only `ngOnDestroy` methods
- Simplifies constructor-body calls to `takeUntilDestroyed()` (no arg, injection context)

**Files:** `apps/desktop/src/vault/`, `apps/web/src/app/vault/`, `libs/vault/`

## Test plan

- [ ] Verify components still subscribe/unsubscribe correctly at lifecycle boundaries
- [ ] Check that any retained `ngOnDestroy` methods still execute their non-destroy logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Sibling PRs

- #19165 auth
- #19166 autofill (browser)
- #19167 autofill (desktop)
- #19168 tools
- #19170 admin console
- #19171 billing
- #19172 data insights & reporting
- #19173 key management
- #19174 UI foundation
- #19175 secrets manager
- #19176 platform / app shell