### PR TITLE
Migrate takeUntil to takeUntilDestroyed (admin console)

### DIFF
--- a/apps/web/src/app/admin-console/common/base.events.component.ts
+++ b/apps/web/src/app/admin-console/common/base.events.component.ts
@@ -1,9 +1,10 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
-import { Directive, OnDestroy, signal } from "@angular/core";
+import { DestroyRef, Directive, inject, signal } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { FormControl, FormGroup } from "@angular/forms";
 import { ActivatedRoute } from "@angular/router";
-import { combineLatest, filter, map, Observable, Subject, switchMap, takeUntil } from "rxjs";
+import { combineLatest, filter, map, Observable, switchMap } from "rxjs";
 
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
@@ -21,7 +22,7 @@ import { EventOptions, EventService } from "../../core";
 import { EventExportService } from "../../tools/event-export";
 
 @Directive()
-export abstract class BaseEventsComponent implements OnDestroy {
+export abstract class BaseEventsComponent {
   readonly loading = signal(true);
   readonly loaded = signal(false);
   readonly events = signal<EventView[]>([]);
@@ -36,14 +37,11 @@ export abstract class BaseEventsComponent implements OnDestroy {
     end: new FormControl(null),
   });
 
+  protected readonly destroyRef = inject(DestroyRef);
+
   protected canUseSM$: Observable<boolean>;
   protected activeOrganization$: Observable<Organization | undefined>;
   protected organizations$: Observable<Organization[]>;
-  private destroySubject$ = new Subject<void>();
-
-  protected get destroy$(): Observable<void> {
-    return this.destroySubject$.asObservable();
-  }
 
   constructor(
     protected eventService: EventService,
@@ -76,14 +74,9 @@ export abstract class BaseEventsComponent implements OnDestroy {
       map((org) => org?.canAccessSecretsManager ?? false),
     );
 
-    this.canUseSM$.pipe(takeUntil(this.destroy$)).subscribe((value) => {
+    this.canUseSM$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((value) => {
       this.canUseSM = value;
     });
-  }
-
-  ngOnDestroy(): void {
-    this.destroySubject$.next();
-    this.destroySubject$.complete();
   }
 
   get start(): string {

--- a/apps/web/src/app/admin-console/organizations/collections/bulk-collections-dialog/bulk-collections-dialog.component.ts
+++ b/apps/web/src/app/admin-console/organizations/collections/bulk-collections-dialog/bulk-collections-dialog.component.ts
@@ -1,8 +1,9 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
-import { Component, Inject, OnDestroy } from "@angular/core";
+import { Component, Inject } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { FormBuilder } from "@angular/forms";
-import { combineLatest, of, Subject, switchMap, takeUntil } from "rxjs";
+import { combineLatest, of, switchMap } from "rxjs";
 
 import {
   CollectionAdminService,
@@ -57,7 +58,7 @@ export enum BulkCollectionsDialogResult {
   selector: "app-bulk-collections-dialog",
   templateUrl: "bulk-collections-dialog.component.html",
 })
-export class BulkCollectionsDialogComponent implements OnDestroy {
+export class BulkCollectionsDialogComponent {
   protected readonly PermissionMode = PermissionMode;
 
   protected formGroup = this.formBuilder.group({
@@ -67,8 +68,6 @@ export class BulkCollectionsDialogComponent implements OnDestroy {
   protected organization: Organization;
   protected accessItems: AccessItemView[] = [];
   protected numCollections: number;
-
-  private destroy$ = new Subject<void>();
 
   constructor(
     @Inject(DIALOG_DATA) private params: BulkCollectionsDialogParams,
@@ -105,7 +104,7 @@ export class BulkCollectionsDialogComponent implements OnDestroy {
       groups$,
       this.organizationUserApiService.getAllMiniUserDetails(this.params.organizationId),
     ])
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed())
       .subscribe(([organization, groups, users]) => {
         this.organization = organization;
 
@@ -116,11 +115,6 @@ export class BulkCollectionsDialogComponent implements OnDestroy {
 
         this.loading = false;
       });
-  }
-
-  ngOnDestroy() {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   submit = async () => {

--- a/apps/web/src/app/admin-console/organizations/collections/vault.component.ts
+++ b/apps/web/src/app/admin-console/organizations/collections/vault.component.ts
@@ -1,4 +1,13 @@
-import { ChangeDetectorRef, Component, NgZone, OnDestroy, OnInit, ViewChild } from "@angular/core";
+import {
+  ChangeDetectorRef,
+  Component,
+  DestroyRef,
+  inject,
+  NgZone,
+  OnDestroy,
+  OnInit,
+  ViewChild,
+} from "@angular/core";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { ActivatedRoute, NavigationExtras, Params, Router } from "@angular/router";
 import {
@@ -24,7 +33,6 @@ import {
   startWith,
   switchMap,
   take,
-  takeUntil,
 } from "rxjs/operators";
 
 import { CollectionAdminService, CollectionService } from "@bitwarden/admin-console/common";
@@ -192,9 +200,10 @@ export class VaultComponent implements OnInit, OnDestroy {
   protected filter$: Observable<RoutedVaultFilterModel>;
   private organizationId$: Observable<OrganizationId>;
 
+  private readonly destroyRef = inject(DestroyRef);
+
   private searchText$ = new Subject<string>();
   protected refreshingSubject$ = new BehaviorSubject<boolean>(true);
-  private destroy$ = new Subject<void>();
   protected addAccessStatus$ = new BehaviorSubject<AddAccessStatusType>(0);
   private vaultItemDialogRef?: DialogRef<VaultItemDialogResult> | undefined;
 
@@ -506,7 +515,7 @@ export class VaultComponent implements OnInit, OnDestroy {
           return collectionsToReturn;
         },
       ),
-      takeUntil(this.destroy$),
+      takeUntilDestroyed(this.destroyRef),
       shareReplay({ refCount: true, bufferSize: 1 }),
     );
 
@@ -570,7 +579,7 @@ export class VaultComponent implements OnInit, OnDestroy {
     });
 
     this.routedVaultFilterBridgeService.activeFilter$
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((activeFilter) => {
         this.activeFilter = activeFilter;
 
@@ -581,7 +590,7 @@ export class VaultComponent implements OnInit, OnDestroy {
       });
 
     this.searchText$
-      .pipe(debounceTime(SearchTextDebounceInterval), takeUntil(this.destroy$))
+      .pipe(debounceTime(SearchTextDebounceInterval), takeUntilDestroyed(this.destroyRef))
       .subscribe((searchText) =>
         this.router.navigate([], {
           queryParams: { search: Utils.isNullOrEmpty(searchText) ? null : searchText },
@@ -656,7 +665,7 @@ export class VaultComponent implements OnInit, OnDestroy {
             });
           }
         }),
-        takeUntil(this.destroy$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe();
 
@@ -686,7 +695,7 @@ export class VaultComponent implements OnInit, OnDestroy {
             });
           }
         }),
-        takeUntil(this.destroy$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe();
 
@@ -696,7 +705,7 @@ export class VaultComponent implements OnInit, OnDestroy {
     firstSetup$
       .pipe(
         switchMap(() => this.allCollections$),
-        takeUntil(this.destroy$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe((allCollections) => {
         // This is a temporary fix to avoid double fetching collections.
@@ -729,8 +738,6 @@ export class VaultComponent implements OnInit, OnDestroy {
 
   ngOnDestroy() {
     this.broadcasterService.unsubscribe(BroadcasterSubscriptionId);
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   async onVaultItemsEvent(event: VaultItemEvent<CipherView>) {

--- a/apps/web/src/app/admin-console/organizations/manage/events.component.ts
+++ b/apps/web/src/app/admin-console/organizations/manage/events.component.ts
@@ -1,8 +1,9 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
-import { Component, OnDestroy, OnInit, ChangeDetectionStrategy } from "@angular/core";
+import { Component, OnInit, ChangeDetectionStrategy } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { ActivatedRoute } from "@angular/router";
-import { concatMap, firstValueFrom, lastValueFrom, map, of, switchMap, takeUntil, tap } from "rxjs";
+import { concatMap, firstValueFrom, lastValueFrom, map, of, switchMap, tap } from "rxjs";
 
 import { OrganizationUserApiService } from "@bitwarden/admin-console/common";
 import { UserNamePipe } from "@bitwarden/angular/pipes/user-name.pipe";
@@ -52,7 +53,7 @@ const EVENT_SYSTEM_USER_TO_TRANSLATION: Record<EventSystemUser, string> = {
   templateUrl: "events.component.html",
   imports: [SharedModule, HeaderModule],
 })
-export class EventsComponent extends BaseEventsComponent implements OnInit, OnDestroy {
+export class EventsComponent extends BaseEventsComponent implements OnInit {
   exportFileName = "org-events";
   organizationId: string;
   organization: Organization;
@@ -122,7 +123,7 @@ export class EventsComponent extends BaseEventsComponent implements OnInit, OnDe
 
           await this.load();
         }),
-        takeUntil(this.destroy$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe();
   }

--- a/apps/web/src/app/admin-console/organizations/manage/group-add-edit.component.ts
+++ b/apps/web/src/app/admin-console/organizations/manage/group-add-edit.component.ts
@@ -1,6 +1,7 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
-import { ChangeDetectorRef, Component, Inject, OnDestroy, OnInit } from "@angular/core";
+import { ChangeDetectorRef, Component, DestroyRef, inject, Inject, OnInit } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { FormBuilder, Validators } from "@angular/forms";
 import {
   catchError,
@@ -11,9 +12,7 @@ import {
   Observable,
   of,
   shareReplay,
-  Subject,
   switchMap,
-  takeUntil,
 } from "rxjs";
 
 import {
@@ -114,7 +113,7 @@ export const openGroupAddEditDialog = (
   templateUrl: "group-add-edit.component.html",
   standalone: false,
 })
-export class GroupAddEditComponent implements OnInit, OnDestroy {
+export class GroupAddEditComponent implements OnInit {
   private organization$ = this.accountService.activeAccount$.pipe(
     switchMap((account) =>
       this.organizationService
@@ -157,7 +156,7 @@ export class GroupAddEditComponent implements OnInit, OnDestroy {
     return this.groupId != null;
   }
 
-  private destroy$ = new Subject<void>();
+  private readonly destroyRef = inject(DestroyRef);
 
   private orgCollections$ = this.accountService.activeAccount$.pipe(
     getUserId,
@@ -270,7 +269,7 @@ export class GroupAddEditComponent implements OnInit, OnDestroy {
       this.accountService.activeAccount$,
       this.organization$,
     ])
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(
         ([collections, members, group, restrictGroupAccess, activeAccount, organization]) => {
           this.members = members;
@@ -309,11 +308,6 @@ export class GroupAddEditComponent implements OnInit, OnDestroy {
           this.loading = false;
         },
       );
-  }
-
-  ngOnDestroy() {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   submit = async () => {

--- a/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.ts
+++ b/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.ts
@@ -1,18 +1,9 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
-import { Component, Inject, OnDestroy } from "@angular/core";
+import { Component, Inject } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { FormBuilder, Validators } from "@angular/forms";
-import {
-  combineLatest,
-  firstValueFrom,
-  map,
-  Observable,
-  of,
-  shareReplay,
-  Subject,
-  switchMap,
-  takeUntil,
-} from "rxjs";
+import { combineLatest, firstValueFrom, map, Observable, of, shareReplay, switchMap } from "rxjs";
 
 import {
   CollectionAdminService,
@@ -112,7 +103,7 @@ export enum MemberDialogResult {
   templateUrl: "member-dialog.component.html",
   standalone: false,
 })
-export class MemberDialogComponent implements OnDestroy {
+export class MemberDialogComponent {
   loading = true;
   editMode = false;
   isRevoked = false;
@@ -172,8 +163,6 @@ export class MemberDialogComponent implements OnDestroy {
   get customUserTypeSelected(): boolean {
     return this.formGroup.value.type === OrganizationUserType.Custom;
   }
-
-  private destroy$ = new Subject<void>();
 
   isEditDialogParams(
     params: EditMemberDialogParams | AddMemberDialogParams,
@@ -265,7 +254,7 @@ export class MemberDialogComponent implements OnDestroy {
       shareReplay({ refCount: true, bufferSize: 1 }),
     );
 
-    this.restrictEditingSelf$.pipe(takeUntil(this.destroy$)).subscribe((restrictEditingSelf) => {
+    this.restrictEditingSelf$.pipe(takeUntilDestroyed()).subscribe((restrictEditingSelf) => {
       if (restrictEditingSelf) {
         this.formGroup.controls.groups.disable();
       } else {
@@ -299,7 +288,7 @@ export class MemberDialogComponent implements OnDestroy {
       userDetails: userDetails$,
       groups: groups$,
     })
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed())
       .subscribe(({ organization, collections, userDetails, groups }) => {
         this.setFormValidators(organization);
 
@@ -726,11 +715,6 @@ export class MemberDialogComponent implements OnDestroy {
 
     this.close(MemberDialogResult.Deleted);
   };
-
-  ngOnDestroy() {
-    this.destroy$.next();
-    this.destroy$.complete();
-  }
 
   protected async cancel() {
     this.close(MemberDialogResult.Canceled);

--- a/apps/web/src/app/admin-console/organizations/members/components/member-dialog/nested-checkbox.component.ts
+++ b/apps/web/src/app/admin-console/organizations/members/components/member-dialog/nested-checkbox.component.ts
@@ -1,9 +1,9 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
 import { KeyValue } from "@angular/common";
-import { Component, Input, OnInit, OnDestroy } from "@angular/core";
+import { Component, DestroyRef, inject, Input, OnInit } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { FormControl, FormGroup } from "@angular/forms";
-import { Subject, takeUntil } from "rxjs";
 
 import { Utils } from "@bitwarden/common/platform/misc/utils";
 
@@ -14,8 +14,8 @@ import { Utils } from "@bitwarden/common/platform/misc/utils";
   templateUrl: "nested-checkbox.component.html",
   standalone: false,
 })
-export class NestedCheckboxComponent implements OnInit, OnDestroy {
-  private destroy$ = new Subject<void>();
+export class NestedCheckboxComponent implements OnInit {
+  private readonly destroyRef = inject(DestroyRef);
 
   // FIXME(https://bitwarden.atlassian.net/browse/CL-903): Migrate to Signals
   // eslint-disable-next-line @angular-eslint/prefer-signals
@@ -33,7 +33,7 @@ export class NestedCheckboxComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.checkboxes.controls[this.parentId].valueChanges
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((value) => {
         Object.values(this.checkboxes.controls).forEach((control) =>
           control.setValue(value, { emitEvent: false }),
@@ -56,11 +56,6 @@ export class NestedCheckboxComponent implements OnInit, OnDestroy {
 
   protected key(index: number, item: KeyValue<string, FormControl<boolean>>) {
     return item.key;
-  }
-
-  ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   pascalize(s: string) {

--- a/apps/web/src/app/admin-console/organizations/settings/account.component.ts
+++ b/apps/web/src/app/admin-console/organizations/settings/account.component.ts
@@ -1,19 +1,10 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
-import { Component, OnDestroy, OnInit } from "@angular/core";
+import { Component, DestroyRef, inject, OnInit } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { FormBuilder, Validators } from "@angular/forms";
 import { ActivatedRoute, Router } from "@angular/router";
-import {
-  combineLatest,
-  firstValueFrom,
-  from,
-  lastValueFrom,
-  map,
-  of,
-  Subject,
-  switchMap,
-  takeUntil,
-} from "rxjs";
+import { combineLatest, firstValueFrom, from, lastValueFrom, map, of, switchMap } from "rxjs";
 
 import { OrganizationApiServiceAbstraction } from "@bitwarden/common/admin-console/abstractions/organization/organization-api.service.abstraction";
 import {
@@ -45,7 +36,7 @@ import { DeleteOrganizationDialogResult, openDeleteOrganizationDialog } from "./
   templateUrl: "account.component.html",
   standalone: false,
 })
-export class AccountComponent implements OnInit, OnDestroy {
+export class AccountComponent implements OnInit {
   selfHosted = false;
   canEditSubscription = true;
   loading = true;
@@ -81,7 +72,7 @@ export class AccountComponent implements OnInit, OnDestroy {
   protected organizationId: string;
   protected publicKeyBuffer: Uint8Array;
 
-  private destroy$ = new Subject<void>();
+  private readonly destroyRef = inject(DestroyRef);
 
   constructor(
     private i18nService: I18nService,
@@ -117,7 +108,7 @@ export class AccountComponent implements OnInit, OnDestroy {
             from(this.organizationApiService.getKeys(organization.id)),
           ]);
         }),
-        takeUntil(this.destroy$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe(([organization, orgResponse, orgKeys]) => {
         // Set domain level organization variables
@@ -154,12 +145,6 @@ export class AccountComponent implements OnInit, OnDestroy {
 
         this.loading = false;
       });
-  }
-
-  ngOnDestroy(): void {
-    // You must first call .next() in order for the notifier to properly close subscriptions using takeUntil
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   submit = async () => {

--- a/apps/web/src/app/admin-console/organizations/settings/components/delete-organization-dialog.component.ts
+++ b/apps/web/src/app/admin-console/organizations/settings/components/delete-organization-dialog.component.ts
@@ -1,8 +1,9 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
-import { Component, Inject, OnDestroy, OnInit } from "@angular/core";
+import { Component, DestroyRef, inject, Inject, OnInit } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { FormBuilder, FormControl, Validators } from "@angular/forms";
-import { combineLatest, firstValueFrom, Subject, takeUntil } from "rxjs";
+import { combineLatest, firstValueFrom } from "rxjs";
 
 import { OrganizationApiServiceAbstraction } from "@bitwarden/common/admin-console/abstractions/organization/organization-api.service.abstraction";
 import {
@@ -85,8 +86,8 @@ export enum DeleteOrganizationDialogResult {
   imports: [SharedModule, UserVerificationModule],
   templateUrl: "delete-organization-dialog.component.html",
 })
-export class DeleteOrganizationDialogComponent implements OnInit, OnDestroy {
-  private destroy$ = new Subject<void>();
+export class DeleteOrganizationDialogComponent implements OnInit {
+  private readonly destroyRef = inject(DestroyRef);
 
   loaded: boolean;
   deleteOrganizationRequestType: "InvalidFamiliesForEnterprise" | "RegularDelete" = "RegularDelete";
@@ -113,11 +114,6 @@ export class DeleteOrganizationDialogComponent implements OnInit, OnDestroy {
     private toastService: ToastService,
   ) {}
 
-  ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
-  }
-
   async ngOnInit(): Promise<void> {
     this.deleteOrganizationRequestType = this.params.requestType;
     const userId = await firstValueFrom(getUserId(this.accountService.activeAccount$));
@@ -128,7 +124,7 @@ export class DeleteOrganizationDialogComponent implements OnInit, OnDestroy {
         .pipe(getOrganizationById(this.params.organizationId)),
       this.cipherService.getAllFromApiForOrganization(this.params.organizationId),
     ])
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(([organization, ciphers]) => {
         this.organization = organization;
         this.organizationContentSummary = this.buildOrganizationContentSummary(ciphers);

--- a/apps/web/src/app/admin-console/organizations/settings/two-factor-setup.component.ts
+++ b/apps/web/src/app/admin-console/organizations/settings/two-factor-setup.component.ts
@@ -1,8 +1,9 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
 import { Component, OnInit } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { ActivatedRoute } from "@angular/router";
-import { concatMap, takeUntil, map, lastValueFrom, firstValueFrom } from "rxjs";
+import { concatMap, map, lastValueFrom, firstValueFrom } from "rxjs";
 import { first, tap } from "rxjs/operators";
 
 import {
@@ -79,7 +80,7 @@ export class TwoFactorSetupComponent extends BaseTwoFactorSetupComponent impleme
           this.organization = mapResponse.organization;
         }),
         concatMap(async () => await super.ngOnInit()),
-        takeUntil(this.destroy$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe();
   }
@@ -109,7 +110,7 @@ export class TwoFactorSetupComponent extends BaseTwoFactorSetupComponent impleme
           },
         );
         this.twoFactorSetupSubscription = duoComp.componentInstance.onChangeStatus
-          .pipe(first(), takeUntil(this.destroy$))
+          .pipe(first(), takeUntilDestroyed(this.destroyRef))
           .subscribe((enabled: boolean) => {
             duoComp.close();
             this.updateStatus(enabled, TwoFactorProviderType.OrganizationDuo);

--- a/apps/web/src/app/admin-console/organizations/shared/components/access-selector/access-selector.component.ts
+++ b/apps/web/src/app/admin-console/organizations/shared/components/access-selector/access-selector.component.ts
@@ -1,6 +1,7 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
-import { Component, forwardRef, Input, OnDestroy, OnInit } from "@angular/core";
+import { Component, DestroyRef, forwardRef, inject, Input, OnInit } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import {
   ControlValueAccessor,
   FormBuilder,
@@ -8,7 +9,6 @@ import {
   FormGroup,
   NG_VALUE_ACCESSOR,
 } from "@angular/forms";
-import { Subject, takeUntil } from "rxjs";
 
 import { ControlsOf } from "@bitwarden/angular/types/controls-of";
 import { FormSelectionList } from "@bitwarden/angular/utils/form-selection-list";
@@ -59,8 +59,8 @@ export enum PermissionMode {
   ],
   standalone: false,
 })
-export class AccessSelectorComponent implements ControlValueAccessor, OnInit, OnDestroy {
-  private destroy$ = new Subject<void>();
+export class AccessSelectorComponent implements ControlValueAccessor, OnInit {
+  private readonly destroyRef = inject(DestroyRef);
   private notifyOnChange: (v: unknown) => void;
   private notifyOnTouch: () => void;
   private pauseChangeNotification: boolean;
@@ -308,23 +308,20 @@ export class AccessSelectorComponent implements ControlValueAccessor, OnInit, On
   async ngOnInit() {
     this.permissionList = getPermissionList();
     // Watch the internal formArray for changes and propagate them
-    this.selectionList.formArray.valueChanges.pipe(takeUntil(this.destroy$)).subscribe((v) => {
-      if (!this.notifyOnChange || this.pauseChangeNotification) {
-        return;
-      }
-      // Disabled form arrays emit values for disabled controls, we override this to emit an empty array to avoid
-      // emitting values for disabled controls that are "readonly" in the table
-      if (this.selectionList.formArray.disabled) {
-        this.notifyOnChange([]);
-        return;
-      }
-      this.notifyOnChange(v);
-    });
-  }
-
-  ngOnDestroy() {
-    this.destroy$.next();
-    this.destroy$.complete();
+    this.selectionList.formArray.valueChanges
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((v) => {
+        if (!this.notifyOnChange || this.pauseChangeNotification) {
+          return;
+        }
+        // Disabled form arrays emit values for disabled controls, we override this to emit an empty array to avoid
+        // emitting values for disabled controls that are "readonly" in the table
+        if (this.selectionList.formArray.disabled) {
+          this.notifyOnChange([]);
+          return;
+        }
+        this.notifyOnChange(v);
+      });
   }
 
   protected handleBlur() {

--- a/apps/web/src/app/admin-console/organizations/shared/components/collection-dialog/collection-dialog.component.ts
+++ b/apps/web/src/app/admin-console/organizations/shared/components/collection-dialog/collection-dialog.component.ts
@@ -1,6 +1,7 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
-import { ChangeDetectorRef, Component, Inject, OnDestroy, OnInit } from "@angular/core";
+import { ChangeDetectorRef, Component, DestroyRef, inject, Inject, OnInit } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { AbstractControl, FormBuilder, Validators } from "@angular/forms";
 import {
   combineLatest,
@@ -9,7 +10,6 @@ import {
   Observable,
   of,
   shareReplay,
-  Subject,
   switchMap,
   takeUntil,
   tap,
@@ -124,8 +124,8 @@ export enum CollectionDialogAction {
   templateUrl: "collection-dialog.component.html",
   imports: [SharedModule, AccessSelectorModule, SelectModule],
 })
-export class CollectionDialogComponent implements OnInit, OnDestroy {
-  private destroy$ = new Subject<void>();
+export class CollectionDialogComponent implements OnInit {
+  private readonly destroyRef = inject(DestroyRef);
   protected organizations$: Observable<Organization[]>;
 
   protected tabIndex: CollectionDialogTabType;
@@ -176,7 +176,7 @@ export class CollectionDialogComponent implements OnInit, OnDestroy {
     if (this.params.showOrgSelector) {
       this.showOrgSelector = true;
       this.formGroup.controls.selectedOrg.valueChanges
-        .pipe(takeUntil(this.destroy$))
+        .pipe(takeUntilDestroyed(this.destroyRef))
         .subscribe((id) => this.loadOrg(id));
       this.organizations$ = this.organizationService.organizations$(userId).pipe(
         first(),
@@ -216,7 +216,7 @@ export class CollectionDialogComponent implements OnInit, OnDestroy {
         }),
         filter(() => this.organizationSelected.errors?.cannotCreateCollections),
         switchMap((organizationId) => this.organizations$.pipe(getById(organizationId))),
-        takeUntil(this.destroy$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe((org) => {
         this.orgExceedingCollectionLimit = org;
@@ -252,7 +252,10 @@ export class CollectionDialogComponent implements OnInit, OnDestroy {
       groups: groups$,
       users: this.organizationUserApiService.getAllMiniUserDetails(orgId),
     })
-      .pipe(takeUntil(this.formGroup.controls.selectedOrg.valueChanges), takeUntil(this.destroy$))
+      .pipe(
+        takeUntilDestroyed(this.destroyRef),
+        takeUntil(this.formGroup.controls.selectedOrg.valueChanges),
+      )
       .subscribe(({ organization, collections: allCollections, groups, users }) => {
         this.organization = organization;
 
@@ -479,11 +482,6 @@ export class CollectionDialogComponent implements OnInit, OnDestroy {
 
     this.close(CollectionDialogAction.Deleted, this.collection);
   };
-
-  ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
-  }
 
   private changePlan(org: Organization) {
     openChangePlanDialog(this.dialogService, {

--- a/apps/web/src/app/admin-console/organizations/sponsorships/families-for-enterprise-setup.component.ts
+++ b/apps/web/src/app/admin-console/organizations/sponsorships/families-for-enterprise-setup.component.ts
@@ -1,10 +1,11 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
-import { Component, OnDestroy, OnInit, ViewChild } from "@angular/core";
+import { Component, DestroyRef, inject, OnInit, ViewChild } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { FormBuilder, Validators } from "@angular/forms";
 import { ActivatedRoute, Router } from "@angular/router";
-import { firstValueFrom, lastValueFrom, Observable, Subject } from "rxjs";
-import { first, map, takeUntil } from "rxjs/operators";
+import { firstValueFrom, lastValueFrom, Observable } from "rxjs";
+import { first, map } from "rxjs/operators";
 
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
@@ -35,7 +36,7 @@ import {
   templateUrl: "families-for-enterprise-setup.component.html",
   imports: [SharedModule, OrganizationPlansComponent],
 })
-export class FamiliesForEnterpriseSetupComponent implements OnInit, OnDestroy {
+export class FamiliesForEnterpriseSetupComponent implements OnInit {
   // FIXME(https://bitwarden.atlassian.net/browse/CL-903): Migrate to Signals
   // eslint-disable-next-line @angular-eslint/prefer-signals
   @ViewChild(OrganizationPlansComponent, { static: false })
@@ -63,7 +64,7 @@ export class FamiliesForEnterpriseSetupComponent implements OnInit, OnDestroy {
   preValidateSponsorshipResponse!: PreValidateSponsorshipResponse;
   _selectedFamilyOrganizationId = "";
 
-  private _destroy = new Subject<void>();
+  private readonly destroyRef = inject(DestroyRef);
   private _familyPlan: PlanType;
   formGroup = this.formBuilder.group({
     selectedFamilyOrganizationId: ["", Validators.required],
@@ -145,19 +146,16 @@ export class FamiliesForEnterpriseSetupComponent implements OnInit, OnDestroy {
         ),
       );
 
-    this.existingFamilyOrganizations$.pipe(takeUntil(this._destroy)).subscribe((orgs) => {
-      if (orgs.length === 0) {
-        this.selectedFamilyOrganizationId = "createNew";
-      }
-    });
-    this.formGroup.valueChanges.pipe(takeUntil(this._destroy)).subscribe((val) => {
+    this.existingFamilyOrganizations$
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((orgs) => {
+        if (orgs.length === 0) {
+          this.selectedFamilyOrganizationId = "createNew";
+        }
+      });
+    this.formGroup.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((val) => {
       this.selectedFamilyOrganizationId = val.selectedFamilyOrganizationId;
     });
-  }
-
-  ngOnDestroy(): void {
-    this._destroy.next();
-    this._destroy.complete();
   }
 
   submit = async () => {

--- a/apps/web/src/app/admin-console/settings/create-organization.component.ts
+++ b/apps/web/src/app/admin-console/settings/create-organization.component.ts
@@ -1,8 +1,8 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
-import { Component, OnDestroy, OnInit } from "@angular/core";
+import { Component, DestroyRef, inject, OnInit } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { ActivatedRoute } from "@angular/router";
-import { Subject, takeUntil } from "rxjs";
 import { first } from "rxjs/operators";
 
 import { PlanType, ProductTierType, ProductType } from "@bitwarden/common/billing/enums";
@@ -19,7 +19,8 @@ import { SharedModule } from "../../shared";
   templateUrl: "create-organization.component.html",
   imports: [SharedModule, OrganizationPlansComponent, HeaderModule],
 })
-export class CreateOrganizationComponent implements OnInit, OnDestroy {
+export class CreateOrganizationComponent implements OnInit {
+  private readonly destroyRef = inject(DestroyRef);
   protected secretsManager = false;
   protected plan: PlanType = PlanType.Free;
   protected productTier: ProductTierType = ProductTierType.Free;
@@ -29,8 +30,6 @@ export class CreateOrganizationComponent implements OnInit, OnDestroy {
     private configService: ConfigService,
   ) {}
 
-  private destroy$ = new Subject<void>();
-
   async ngOnInit(): Promise<void> {
     const milestone3FeatureEnabled = await this.configService.getFeatureFlag(
       FeatureFlag.PM26462_Milestone_3,
@@ -39,33 +38,30 @@ export class CreateOrganizationComponent implements OnInit, OnDestroy {
       ? PlanType.FamiliesAnnually
       : PlanType.FamiliesAnnually2025;
 
-    this.route.queryParams.pipe(first(), takeUntil(this.destroy$)).subscribe((qParams) => {
-      if (qParams.plan === "families" || qParams.productTier == ProductTierType.Families) {
-        this.plan = familyPlan;
-        this.productTier = ProductTierType.Families;
-      } else if (qParams.plan === "teams" || qParams.productTier == ProductTierType.Teams) {
-        this.plan = PlanType.TeamsAnnually;
-        this.productTier = ProductTierType.Teams;
-      } else if (
-        qParams.plan === "teamsStarter" ||
-        qParams.productTier == ProductTierType.TeamsStarter
-      ) {
-        this.plan = PlanType.TeamsStarter;
-        this.productTier = ProductTierType.TeamsStarter;
-      } else if (
-        qParams.plan === "enterprise" ||
-        qParams.productTier == ProductTierType.Enterprise
-      ) {
-        this.plan = PlanType.EnterpriseAnnually;
-        this.productTier = ProductTierType.Enterprise;
-      }
+    this.route.queryParams
+      .pipe(first(), takeUntilDestroyed(this.destroyRef))
+      .subscribe((qParams) => {
+        if (qParams.plan === "families" || qParams.productTier == ProductTierType.Families) {
+          this.plan = familyPlan;
+          this.productTier = ProductTierType.Families;
+        } else if (qParams.plan === "teams" || qParams.productTier == ProductTierType.Teams) {
+          this.plan = PlanType.TeamsAnnually;
+          this.productTier = ProductTierType.Teams;
+        } else if (
+          qParams.plan === "teamsStarter" ||
+          qParams.productTier == ProductTierType.TeamsStarter
+        ) {
+          this.plan = PlanType.TeamsStarter;
+          this.productTier = ProductTierType.TeamsStarter;
+        } else if (
+          qParams.plan === "enterprise" ||
+          qParams.productTier == ProductTierType.Enterprise
+        ) {
+          this.plan = PlanType.EnterpriseAnnually;
+          this.productTier = ProductTierType.Enterprise;
+        }
 
-      this.secretsManager = qParams.product == ProductType.SecretsManager;
-    });
-  }
-
-  ngOnDestroy() {
-    this.destroy$.next();
-    this.destroy$.complete();
+        this.secretsManager = qParams.product == ProductType.SecretsManager;
+      });
   }
 }

--- a/bitwarden_license/bit-web/src/app/admin-console/organizations/manage/device-approvals/device-approvals.component.ts
+++ b/bitwarden_license/bit-web/src/app/admin-console/organizations/manage/device-approvals/device-approvals.component.ts
@@ -1,8 +1,9 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
-import { Component, OnDestroy, OnInit } from "@angular/core";
+import { Component, DestroyRef, inject, OnInit } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { ActivatedRoute } from "@angular/router";
-import { BehaviorSubject, Subject, switchMap, takeUntil, tap } from "rxjs";
+import { BehaviorSubject, switchMap, tap } from "rxjs";
 
 import { OrganizationUserApiService } from "@bitwarden/admin-console/common";
 import { SafeProvider, safeProvider } from "@bitwarden/angular/platform/utils/safe-provider";
@@ -47,7 +48,8 @@ import { SharedModule } from "@bitwarden/web-vault/app/shared/shared.module";
   ] satisfies SafeProvider[],
   imports: [SharedModule, NoItemsModule, HeaderModule],
 })
-export class DeviceApprovalsComponent implements OnInit, OnDestroy {
+export class DeviceApprovalsComponent implements OnInit {
+  private readonly destroyRef = inject(DestroyRef);
   tableDataSource = new TableDataSource<PendingAuthRequestWithFingerprintView>();
   organizationId: string;
   loading = true;
@@ -55,7 +57,6 @@ export class DeviceApprovalsComponent implements OnInit, OnDestroy {
 
   protected readonly DevicesIcon = DevicesIcon;
 
-  private destroy$ = new Subject<void>();
   private refresh$ = new BehaviorSubject<void>(null);
 
   constructor(
@@ -83,7 +84,7 @@ export class DeviceApprovalsComponent implements OnInit, OnDestroy {
             ),
           ),
         ),
-        takeUntil(this.destroy$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe((r) => {
         this.tableDataSource.data = r;
@@ -177,10 +178,5 @@ export class DeviceApprovalsComponent implements OnInit, OnDestroy {
     } finally {
       this.actionInProgress = false;
     }
-  }
-
-  ngOnDestroy() {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 }

--- a/bitwarden_license/bit-web/src/app/admin-console/organizations/manage/domain-verification/domain-add-edit-dialog/domain-add-edit-dialog.component.ts
+++ b/bitwarden_license/bit-web/src/app/admin-console/organizations/manage/domain-verification/domain-add-edit-dialog/domain-add-edit-dialog.component.ts
@@ -1,8 +1,8 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
-import { Component, Inject, OnDestroy, OnInit } from "@angular/core";
+import { Component, DestroyRef, inject, Inject, OnInit } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { FormBuilder, FormControl, FormGroup, ValidatorFn, Validators } from "@angular/forms";
-import { Subject, takeUntil } from "rxjs";
 
 import { OrgDomainApiServiceAbstraction } from "@bitwarden/common/admin-console/abstractions/organization-domain/org-domain-api.service.abstraction";
 import { OrgDomainServiceAbstraction } from "@bitwarden/common/admin-console/abstractions/organization-domain/org-domain.service.abstraction";
@@ -28,8 +28,8 @@ export interface DomainAddEditDialogData {
   templateUrl: "domain-add-edit-dialog.component.html",
   standalone: false,
 })
-export class DomainAddEditDialogComponent implements OnInit, OnDestroy {
-  private componentDestroyed$: Subject<void> = new Subject();
+export class DomainAddEditDialogComponent implements OnInit {
+  private readonly destroyRef = inject(DestroyRef);
 
   domainForm: FormGroup;
 
@@ -77,11 +77,6 @@ export class DomainAddEditDialogComponent implements OnInit, OnDestroy {
     await this.populateForm();
   }
 
-  ngOnDestroy(): void {
-    this.componentDestroyed$.next();
-    this.componentDestroyed$.complete();
-  }
-
   // End Angular Method Implementations
 
   // Form methods
@@ -99,7 +94,7 @@ export class DomainAddEditDialogComponent implements OnInit, OnDestroy {
   setupFormListeners(): void {
     // <bit-form-field> suppresses touched state on change for reactive form controls
     // Manually set touched to show validation errors as the user stypes
-    this.domainForm.valueChanges.pipe(takeUntil(this.componentDestroyed$)).subscribe(() => {
+    this.domainForm.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
       this.domainForm.markAllAsTouched();
     });
   }

--- a/bitwarden_license/bit-web/src/app/admin-console/organizations/manage/domain-verification/domain-verification.component.ts
+++ b/bitwarden_license/bit-web/src/app/admin-console/organizations/manage/domain-verification/domain-verification.component.ts
@@ -1,17 +1,9 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
-import { Component, OnDestroy, OnInit } from "@angular/core";
+import { Component, DestroyRef, inject, OnInit } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { ActivatedRoute, Params } from "@angular/router";
-import {
-  concatMap,
-  firstValueFrom,
-  map,
-  Observable,
-  Subject,
-  switchMap,
-  take,
-  takeUntil,
-} from "rxjs";
+import { concatMap, firstValueFrom, map, Observable, switchMap, take } from "rxjs";
 
 import { DomainIcon } from "@bitwarden/assets/svg";
 import { OrgDomainApiServiceAbstraction } from "@bitwarden/common/admin-console/abstractions/organization-domain/org-domain-api.service.abstraction";
@@ -40,8 +32,8 @@ import {
   templateUrl: "domain-verification.component.html",
   standalone: false,
 })
-export class DomainVerificationComponent implements OnInit, OnDestroy {
-  private componentDestroyed$ = new Subject<void>();
+export class DomainVerificationComponent implements OnInit {
+  private readonly destroyRef = inject(DestroyRef);
   private singleOrgPolicyEnabled = false;
   protected domainIcon = DomainIcon;
 
@@ -75,7 +67,7 @@ export class DomainVerificationComponent implements OnInit, OnDestroy {
           this.organizationId = params.organizationId;
           await this.load();
         }),
-        takeUntil(this.componentDestroyed$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe();
   }
@@ -243,10 +235,5 @@ export class DomainVerificationComponent implements OnInit, OnDestroy {
       title: null,
       message: this.i18nService.t("domainRemoved"),
     });
-  }
-
-  ngOnDestroy(): void {
-    this.componentDestroyed$.next();
-    this.componentDestroyed$.complete();
   }
 }

--- a/bitwarden_license/bit-web/src/app/admin-console/providers/clients/manage-clients.component.ts
+++ b/bitwarden_license/bit-web/src/app/admin-console/providers/clients/manage-clients.component.ts
@@ -1,16 +1,8 @@
-import { Component, OnDestroy, OnInit } from "@angular/core";
+import { Component, DestroyRef, inject, OnInit } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { FormControl } from "@angular/forms";
 import { ActivatedRoute } from "@angular/router";
-import {
-  firstValueFrom,
-  lastValueFrom,
-  map,
-  combineLatest,
-  switchMap,
-  Observable,
-  Subject,
-  takeUntil,
-} from "rxjs";
+import { firstValueFrom, lastValueFrom, map, combineLatest, switchMap, Observable } from "rxjs";
 import { debounceTime, first } from "rxjs/operators";
 
 import { ProviderApiServiceAbstraction } from "@bitwarden/common/admin-console/abstractions/provider/provider-api.service.abstraction";
@@ -68,7 +60,7 @@ import { ReplacePipe } from "./replace.pipe";
     ReplacePipe,
   ],
 })
-export class ManageClientsComponent implements OnInit, OnDestroy {
+export class ManageClientsComponent implements OnInit {
   loading = true;
   dataSource: TableDataSource<ProviderOrganizationOrganizationDetailsResponse> =
     new TableDataSource();
@@ -105,7 +97,7 @@ export class ManageClientsComponent implements OnInit, OnDestroy {
     map(([isAdminOrServiceUser, providerEnabled]) => isAdminOrServiceUser && !providerEnabled),
   );
 
-  private destroy$ = new Subject<void>();
+  private readonly destroyRef = inject(DestroyRef);
 
   constructor(
     private billingApiService: BillingApiServiceAbstraction,
@@ -123,7 +115,7 @@ export class ManageClientsComponent implements OnInit, OnDestroy {
 
   async ngOnInit() {
     this.activatedRoute.queryParams
-      .pipe(first(), takeUntil(this.destroy$))
+      .pipe(first(), takeUntilDestroyed(this.destroyRef))
       .subscribe((queryParams) => {
         this.searchControl.setValue(queryParams.search);
       });
@@ -131,16 +123,11 @@ export class ManageClientsComponent implements OnInit, OnDestroy {
     await this.load();
 
     this.searchControl.valueChanges
-      .pipe(debounceTime(200), takeUntil(this.destroy$))
+      .pipe(debounceTime(200), takeUntilDestroyed(this.destroyRef))
       .subscribe((searchText) => {
         this.dataSource.filter = (data) =>
           data.organizationName.toLowerCase().indexOf(searchText.toLowerCase()) > -1;
       });
-  }
-
-  ngOnDestroy() {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   async load() {

--- a/bitwarden_license/bit-web/src/app/admin-console/providers/providers-layout.component.ts
+++ b/bitwarden_license/bit-web/src/app/admin-console/providers/providers-layout.component.ts
@@ -1,10 +1,10 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
 import { CommonModule } from "@angular/common";
-import { Component, OnDestroy, OnInit } from "@angular/core";
+import { Component, DestroyRef, inject, OnInit } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { ActivatedRoute, RouterModule } from "@angular/router";
-import { combineLatest, map, Observable, Subject, switchMap } from "rxjs";
-import { takeUntil } from "rxjs/operators";
+import { combineLatest, map, Observable, switchMap } from "rxjs";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { BusinessUnitPortalLogo, BitSvg, ProviderPortalLogo } from "@bitwarden/assets/svg";
@@ -35,10 +35,10 @@ import { ProviderWarningsService } from "../../billing/providers/warnings/servic
     TaxIdWarningComponent,
   ],
 })
-export class ProvidersLayoutComponent implements OnInit, OnDestroy {
+export class ProvidersLayoutComponent implements OnInit {
   protected readonly logo = ProviderPortalLogo;
 
-  private destroy$ = new Subject<void>();
+  private readonly destroyRef = inject(DestroyRef);
   protected provider$: Observable<Provider>;
 
   protected logo$: Observable<BitSvg>;
@@ -69,7 +69,7 @@ export class ProvidersLayoutComponent implements OnInit, OnDestroy {
       this.accountService.activeAccount$.pipe(getUserId),
     ]).pipe(
       switchMap(([providerId, userId]) => this.providerService.get$(providerId, userId)),
-      takeUntil(this.destroy$),
+      takeUntilDestroyed(this.destroyRef),
     );
 
     this.logo$ = this.provider$.pipe(
@@ -93,7 +93,7 @@ export class ProvidersLayoutComponent implements OnInit, OnDestroy {
         switchMap((provider) =>
           this.providerWarningsService.showProviderSuspendedDialog$(provider),
         ),
-        takeUntil(this.destroy$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe();
 
@@ -108,11 +108,6 @@ export class ProvidersLayoutComponent implements OnInit, OnDestroy {
       this.provider$.pipe(
         switchMap((provider) => this.providerWarningsService.getTaxIdWarning$(provider)),
       );
-  }
-
-  ngOnDestroy() {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   showManageTab(provider: Provider) {

--- a/bitwarden_license/bit-web/src/app/admin-console/providers/settings/account.component.ts
+++ b/bitwarden_license/bit-web/src/app/admin-console/providers/settings/account.component.ts
@@ -1,9 +1,10 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
-import { Component, OnDestroy, OnInit } from "@angular/core";
+import { Component, DestroyRef, inject, OnInit } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { FormBuilder, Validators } from "@angular/forms";
 import { ActivatedRoute, Router } from "@angular/router";
-import { Subject, switchMap, takeUntil } from "rxjs";
+import { switchMap } from "rxjs";
 
 import { UserVerificationDialogComponent } from "@bitwarden/auth/angular";
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
@@ -24,13 +25,13 @@ import { DialogService, ToastService } from "@bitwarden/components";
   templateUrl: "account.component.html",
   standalone: false,
 })
-export class AccountComponent implements OnDestroy, OnInit {
+export class AccountComponent implements OnInit {
+  private readonly destroyRef = inject(DestroyRef);
   selfHosted = false;
   loading = true;
   provider: ProviderResponse;
   taxFormPromise: Promise<any>;
 
-  private destroy$ = new Subject<void>();
   private providerId: string;
   protected formGroup = this.formBuilder.group({
     providerName: ["" as ProviderResponse["name"]],
@@ -70,13 +71,9 @@ export class AccountComponent implements OnDestroy, OnInit {
             this.loading = false;
           }
         }),
-        takeUntil(this.destroy$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe();
-  }
-  ngOnDestroy() {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
   submit = async () => {
     const request = new ProviderUpdateRequest();

--- a/bitwarden_license/bit-web/src/app/admin-console/providers/setup/setup.component.ts
+++ b/bitwarden_license/bit-web/src/app/admin-console/providers/setup/setup.component.ts
@@ -1,8 +1,9 @@
-import { Component, OnDestroy, OnInit, ViewChild } from "@angular/core";
+import { Component, DestroyRef, inject, OnInit, ViewChild } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { FormBuilder, Validators } from "@angular/forms";
 import { ActivatedRoute, Router } from "@angular/router";
-import { firstValueFrom, Subject, switchMap } from "rxjs";
-import { first, takeUntil } from "rxjs/operators";
+import { firstValueFrom, switchMap } from "rxjs";
+import { first } from "rxjs/operators";
 
 import { ProviderApiServiceAbstraction } from "@bitwarden/common/admin-console/abstractions/provider/provider-api.service.abstraction";
 import { ProviderSetupRequest } from "@bitwarden/common/admin-console/models/request/provider/provider-setup.request";
@@ -27,7 +28,8 @@ import {
   templateUrl: "setup.component.html",
   standalone: false,
 })
-export class SetupComponent implements OnInit, OnDestroy {
+export class SetupComponent implements OnInit {
+  private readonly destroyRef = inject(DestroyRef);
   // FIXME(https://bitwarden.atlassian.net/browse/CL-903): Migrate to Signals
   // eslint-disable-next-line @angular-eslint/prefer-signals
   @ViewChild(EnterPaymentMethodComponent) enterPaymentMethodComponent!: EnterPaymentMethodComponent;
@@ -42,8 +44,6 @@ export class SetupComponent implements OnInit, OnDestroy {
     paymentMethod: EnterPaymentMethodComponent.getFormGroup(),
     billingAddress: EnterBillingAddressComponent.getFormGroup(),
   });
-
-  private destroy$ = new Subject<void>();
 
   constructor(
     private router: Router,
@@ -106,14 +106,9 @@ export class SetupComponent implements OnInit, OnDestroy {
             return await this.router.navigate(["/"]);
           }
         }),
-        takeUntil(this.destroy$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe();
-  }
-
-  ngOnDestroy() {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   submit = async () => {


### PR DESCRIPTION
## Summary

- Replaces `takeUntil(this.destroy$)` pattern with `takeUntilDestroyed(this.destroyRef)`
- Removes destroy `Subject` fields and cleanup-only `ngOnDestroy` methods
- Simplifies constructor-body calls to `takeUntilDestroyed()` (no arg, injection context)

**Files:** `apps/web/src/app/admin-console/`, `bitwarden_license/bit-web/src/app/admin-console/`

## Test plan

- [ ] Verify components still subscribe/unsubscribe correctly at lifecycle boundaries
- [ ] Check that any retained `ngOnDestroy` methods still execute their non-destroy logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Sibling PRs

- #19165 auth
- #19166 autofill (browser)
- #19167 autofill (desktop)
- #19168 tools
- #19169 vault
- #19171 billing
- #19172 data insights & reporting
- #19173 key management
- #19174 UI foundation
- #19175 secrets manager
- #19176 platform / app shell