### PR TITLE
Migrate takeUntil to takeUntilDestroyed (billing)

### DIFF
--- a/apps/web/src/app/billing/organizations/adjust-subscription.component.ts
+++ b/apps/web/src/app/billing/organizations/adjust-subscription.component.ts
@@ -1,8 +1,9 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
-import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from "@angular/core";
+import { Component, DestroyRef, EventEmitter, inject, Input, OnInit, Output } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { FormBuilder, Validators } from "@angular/forms";
-import { Subject, firstValueFrom, takeUntil } from "rxjs";
+import { firstValueFrom } from "rxjs";
 
 import { OrganizationApiServiceAbstraction } from "@bitwarden/common/admin-console/abstractions/organization/organization-api.service.abstraction";
 import {
@@ -25,7 +26,7 @@ import { ToastService } from "@bitwarden/components";
 })
 // FIXME(https://bitwarden.atlassian.net/browse/PM-28231): Use Component suffix
 // eslint-disable-next-line @angular-eslint/component-class-suffix
-export class AdjustSubscription implements OnInit, OnDestroy {
+export class AdjustSubscription implements OnInit {
   // FIXME(https://bitwarden.atlassian.net/browse/CL-903): Migrate to Signals
   // eslint-disable-next-line @angular-eslint/prefer-signals
   @Input() organizationId: string;
@@ -45,7 +46,7 @@ export class AdjustSubscription implements OnInit, OnDestroy {
   // eslint-disable-next-line @angular-eslint/prefer-output-emitter-ref
   @Output() onAdjusted = new EventEmitter();
 
-  private destroy$ = new Subject<void>();
+  private readonly destroyRef = inject(DestroyRef);
 
   adjustSubscriptionForm = this.formBuilder.group({
     newSeatCount: [0, [Validators.min(0)]],
@@ -63,16 +64,18 @@ export class AdjustSubscription implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit() {
-    this.adjustSubscriptionForm.valueChanges.pipe(takeUntil(this.destroy$)).subscribe((value) => {
-      const maxAutoscaleSeatsControl = this.adjustSubscriptionForm.controls.newMaxSeats;
+    this.adjustSubscriptionForm.valueChanges
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((value) => {
+        const maxAutoscaleSeatsControl = this.adjustSubscriptionForm.controls.newMaxSeats;
 
-      if (value.limitSubscription) {
-        maxAutoscaleSeatsControl.setValidators([Validators.min(value.newSeatCount)]);
-        maxAutoscaleSeatsControl.enable({ emitEvent: false });
-      } else {
-        maxAutoscaleSeatsControl.disable({ emitEvent: false });
-      }
-    });
+        if (value.limitSubscription) {
+          maxAutoscaleSeatsControl.setValidators([Validators.min(value.newSeatCount)]);
+          maxAutoscaleSeatsControl.enable({ emitEvent: false });
+        } else {
+          maxAutoscaleSeatsControl.disable({ emitEvent: false });
+        }
+      });
 
     this.adjustSubscriptionForm.patchValue({
       newSeatCount: this.currentSeatCount,
@@ -141,10 +144,5 @@ export class AdjustSubscription implements OnInit, OnDestroy {
 
   get limitSubscription(): boolean {
     return this.adjustSubscriptionForm.value.limitSubscription;
-  }
-
-  ngOnDestroy() {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 }

--- a/apps/web/src/app/billing/organizations/change-plan-dialog.component.ts
+++ b/apps/web/src/app/billing/organizations/change-plan-dialog.component.ts
@@ -2,17 +2,19 @@
 // @ts-strict-ignore
 import {
   Component,
+  DestroyRef,
   EventEmitter,
+  inject,
   Inject,
   Input,
-  OnDestroy,
   OnInit,
   Output,
   ViewChild,
 } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { FormBuilder, Validators } from "@angular/forms";
 import { Router } from "@angular/router";
-import { combineLatest, firstValueFrom, map, Subject, switchMap, takeUntil } from "rxjs";
+import { combineLatest, firstValueFrom, map, switchMap } from "rxjs";
 import { debounceTime } from "rxjs/operators";
 
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
@@ -119,7 +121,7 @@ interface OnSuccessArgs {
   ],
   providers: [SubscriberBillingClient, PreviewInvoiceClient],
 })
-export class ChangePlanDialogComponent implements OnInit, OnDestroy {
+export class ChangePlanDialogComponent implements OnInit {
   // FIXME(https://bitwarden.atlassian.net/browse/CL-903): Migrate to Signals
   // eslint-disable-next-line @angular-eslint/prefer-signals
   @ViewChild(EnterPaymentMethodComponent) enterPaymentMethodComponent: EnterPaymentMethodComponent;
@@ -229,7 +231,7 @@ export class ChangePlanDialogComponent implements OnInit, OnDestroy {
   paymentMethod: MaskedPaymentMethod | null;
   billingAddress: BillingAddress | null;
 
-  private destroy$ = new Subject<void>();
+  private readonly destroyRef = inject(DestroyRef);
 
   constructor(
     @Inject(DIALOG_DATA) private dialogParams: ChangePlanDialogParams,
@@ -324,7 +326,7 @@ export class ChangePlanDialogComponent implements OnInit, OnDestroy {
         switchMap((userId) =>
           this.policyService.policyAppliesToUser$(PolicyType.SingleOrg, userId),
         ),
-        takeUntil(this.destroy$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe((policyAppliesToActiveUser) => {
         this.singleOrgPolicyAppliesToActiveUser = policyAppliesToActiveUser;
@@ -361,7 +363,7 @@ export class ChangePlanDialogComponent implements OnInit, OnDestroy {
       .pipe(
         debounceTime(1000),
         switchMap(async () => await this.refreshSalesTax()),
-        takeUntil(this.destroy$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe();
 
@@ -527,11 +529,6 @@ export class ChangePlanDialogComponent implements OnInit, OnDestroy {
     } catch {
       this.estimatedTax = 0;
     }
-  }
-
-  ngOnDestroy() {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   get upgradeRequiresPaymentMethod() {

--- a/apps/web/src/app/billing/organizations/organization-billing-history-view.component.ts
+++ b/apps/web/src/app/billing/organizations/organization-billing-history-view.component.ts
@@ -1,8 +1,9 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
-import { Component, OnDestroy, OnInit } from "@angular/core";
+import { Component, DestroyRef, inject, OnInit } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { ActivatedRoute } from "@angular/router";
-import { concatMap, Subject, takeUntil } from "rxjs";
+import { concatMap } from "rxjs";
 
 import { OrganizationBillingApiServiceAbstraction } from "@bitwarden/common/billing/abstractions/organizations/organization-billing-api.service.abstraction";
 import {
@@ -16,7 +17,8 @@ import {
   templateUrl: "organization-billing-history-view.component.html",
   standalone: false,
 })
-export class OrgBillingHistoryViewComponent implements OnInit, OnDestroy {
+export class OrgBillingHistoryViewComponent implements OnInit {
+  private readonly destroyRef = inject(DestroyRef);
   loading = false;
   firstLoaded = false;
   openInvoices: BillingInvoiceResponse[] = [];
@@ -24,8 +26,6 @@ export class OrgBillingHistoryViewComponent implements OnInit, OnDestroy {
   transactions: BillingTransactionResponse[] = [];
   organizationId: string;
   hasAdditionalHistory: boolean = false;
-
-  private destroy$ = new Subject<void>();
 
   constructor(
     private organizationBillingApiService: OrganizationBillingApiServiceAbstraction,
@@ -40,14 +40,9 @@ export class OrgBillingHistoryViewComponent implements OnInit, OnDestroy {
           await this.load();
           this.firstLoaded = true;
         }),
-        takeUntil(this.destroy$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe();
-  }
-
-  ngOnDestroy() {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   async load() {

--- a/apps/web/src/app/billing/organizations/organization-plans.component.ts
+++ b/apps/web/src/app/billing/organizations/organization-plans.component.ts
@@ -4,14 +4,16 @@ import {
   Component,
   EventEmitter,
   Input,
-  OnDestroy,
   OnInit,
   Output,
   ViewChild,
+  inject,
+  DestroyRef,
 } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { FormBuilder, Validators } from "@angular/forms";
 import { Router } from "@angular/router";
-import { firstValueFrom, merge, Subject, takeUntil } from "rxjs";
+import { firstValueFrom, merge } from "rxjs";
 import { debounceTime, map, switchMap } from "rxjs/operators";
 
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
@@ -89,7 +91,9 @@ const Allowed2020PlansForLegacyProviders = [
   ],
   providers: [SubscriberBillingClient, PreviewInvoiceClient],
 })
-export class OrganizationPlansComponent implements OnInit, OnDestroy {
+export class OrganizationPlansComponent implements OnInit {
+  private readonly destroyRef = inject(DestroyRef);
+
   // FIXME(https://bitwarden.atlassian.net/browse/CL-903): Migrate to Signals
   // eslint-disable-next-line @angular-eslint/prefer-signals
   @ViewChild(EnterPaymentMethodComponent) enterPaymentMethodComponent!: EnterPaymentMethodComponent;
@@ -198,8 +202,6 @@ export class OrganizationPlansComponent implements OnInit, OnDestroy {
   protected estimatedTax: number = 0;
   protected total: number = 0;
 
-  private destroy$: Subject<void> = new Subject<void>();
-
   constructor(
     private apiService: ApiService,
     private i18nService: I18nService,
@@ -300,7 +302,7 @@ export class OrganizationPlansComponent implements OnInit, OnDestroy {
         switchMap((userId) =>
           this.policyService.policyAppliesToUser$(PolicyType.SingleOrg, userId),
         ),
-        takeUntil(this.destroy$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe((policyAppliesToActiveUser) => {
         this.singleOrgPolicyAppliesToActiveUser = policyAppliesToActiveUser;
@@ -323,7 +325,7 @@ export class OrganizationPlansComponent implements OnInit, OnDestroy {
       .pipe(
         debounceTime(1000),
         switchMap(async () => await this.refreshSalesTax()),
-        takeUntil(this.destroy$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe();
 
@@ -334,11 +336,6 @@ export class OrganizationPlansComponent implements OnInit, OnDestroy {
         additionalServiceAccounts: 0,
       });
     }
-  }
-
-  ngOnDestroy() {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   get singleOrgPolicyBlock() {

--- a/apps/web/src/app/billing/organizations/organization-subscription-selfhost.component.ts
+++ b/apps/web/src/app/billing/organizations/organization-subscription-selfhost.component.ts
@@ -1,9 +1,10 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
-import { Component, OnDestroy, OnInit } from "@angular/core";
+import { Component, DestroyRef, inject, OnInit } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { FormControl, FormGroup } from "@angular/forms";
 import { ActivatedRoute } from "@angular/router";
-import { concatMap, firstValueFrom, Subject, takeUntil } from "rxjs";
+import { concatMap, firstValueFrom } from "rxjs";
 
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import { OrganizationApiServiceAbstraction } from "@bitwarden/common/admin-console/abstractions/organization/organization-api.service.abstraction";
@@ -40,7 +41,8 @@ enum LicenseOptions {
   templateUrl: "organization-subscription-selfhost.component.html",
   standalone: false,
 })
-export class OrganizationSubscriptionSelfhostComponent implements OnInit, OnDestroy {
+export class OrganizationSubscriptionSelfhostComponent implements OnInit {
+  private readonly destroyRef = inject(DestroyRef);
   subscription: SelfHostedOrganizationSubscriptionView;
   organizationId: string;
   userOrg: Organization;
@@ -58,8 +60,6 @@ export class OrganizationSubscriptionSelfhostComponent implements OnInit, OnDest
   loading = false;
 
   private _existingBillingSyncConnection: OrganizationConnectionResponse<BillingSyncConfigApi>;
-
-  private destroy$ = new Subject<void>();
 
   set existingBillingSyncConnection(value: OrganizationConnectionResponse<BillingSyncConfigApi>) {
     this._existingBillingSyncConnection = value;
@@ -111,14 +111,9 @@ export class OrganizationSubscriptionSelfhostComponent implements OnInit, OnDest
           await this.loadOrganizationConnection();
           this.firstLoaded = true;
         }),
-        takeUntil(this.destroy$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe();
-  }
-
-  ngOnDestroy() {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   async load() {

--- a/apps/web/src/app/billing/organizations/payment-details/organization-payment-details.component.ts
+++ b/apps/web/src/app/billing/organizations/payment-details/organization-payment-details.component.ts
@@ -1,4 +1,5 @@
-import { Component, OnDestroy, OnInit } from "@angular/core";
+import { Component, DestroyRef, inject, OnInit } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { ActivatedRoute } from "@angular/router";
 import {
   BehaviorSubject,
@@ -10,10 +11,8 @@ import {
   Observable,
   of,
   shareReplay,
-  Subject,
   switchMap,
   take,
-  takeUntil,
   tap,
   withLatestFrom,
 } from "rxjs";
@@ -72,7 +71,7 @@ const BANK_ACCOUNT_VERIFIED_COMMAND = new CommandDefinition<{ organizationId: st
     SharedModule,
   ],
 })
-export class OrganizationPaymentDetailsComponent implements OnInit, OnDestroy {
+export class OrganizationPaymentDetailsComponent implements OnInit {
   private viewState$ = new BehaviorSubject<View | null>(null);
 
   protected organization$ = this.accountService.activeAccount$.pipe(
@@ -114,7 +113,7 @@ export class OrganizationPaymentDetailsComponent implements OnInit, OnDestroy {
     this.viewState$.pipe(filter((view): view is View => view !== null)),
   ).pipe(shareReplay({ bufferSize: 1, refCount: true }));
 
-  private destroy$ = new Subject<void>();
+  private readonly destroyRef = inject(DestroyRef);
 
   constructor(
     private accountService: AccountService,
@@ -148,7 +147,7 @@ export class OrganizationPaymentDetailsComponent implements OnInit, OnDestroy {
             ),
           ]),
         ),
-        takeUntil(this.destroy$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe(([taxIdWarning, billingAddress]) => {
         if (this.viewState$.value) {
@@ -180,14 +179,9 @@ export class OrganizationPaymentDetailsComponent implements OnInit, OnDestroy {
             this.setBillingAddress(billingAddress);
           }
         }),
-        takeUntil(this.destroy$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe();
-  }
-
-  ngOnDestroy() {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   changePaymentMethod = async () => {

--- a/apps/web/src/app/billing/organizations/sm-adjust-subscription.component.ts
+++ b/apps/web/src/app/billing/organizations/sm-adjust-subscription.component.ts
@@ -1,8 +1,9 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
-import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from "@angular/core";
+import { Component, DestroyRef, EventEmitter, inject, Input, OnInit, Output } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { FormBuilder, Validators } from "@angular/forms";
-import { Subject, firstValueFrom, takeUntil } from "rxjs";
+import { firstValueFrom } from "rxjs";
 
 import { OrganizationApiServiceAbstraction } from "@bitwarden/common/admin-console/abstractions/organization/organization-api.service.abstraction";
 import {
@@ -63,7 +64,7 @@ export interface SecretsManagerSubscriptionOptions {
   templateUrl: "sm-adjust-subscription.component.html",
   standalone: false,
 })
-export class SecretsManagerAdjustSubscriptionComponent implements OnInit, OnDestroy {
+export class SecretsManagerAdjustSubscriptionComponent implements OnInit {
   // FIXME(https://bitwarden.atlassian.net/browse/CL-903): Migrate to Signals
   // eslint-disable-next-line @angular-eslint/prefer-signals
   @Input() organizationId: string;
@@ -74,7 +75,7 @@ export class SecretsManagerAdjustSubscriptionComponent implements OnInit, OnDest
   // eslint-disable-next-line @angular-eslint/prefer-output-emitter-ref
   @Output() onAdjusted = new EventEmitter();
 
-  private destroy$ = new Subject<void>();
+  private readonly destroyRef = inject(DestroyRef);
 
   formGroup = this.formBuilder.group({
     seatCount: [0, [Validators.required, Validators.min(1)]],
@@ -125,7 +126,7 @@ export class SecretsManagerAdjustSubscriptionComponent implements OnInit, OnDest
   ) {}
 
   ngOnInit() {
-    this.formGroup.valueChanges.pipe(takeUntil(this.destroy$)).subscribe((value) => {
+    this.formGroup.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((value) => {
       const maxAutoscaleSeatsControl = this.formGroup.controls.maxAutoscaleSeats;
       const maxAutoscaleServiceAccountsControl =
         this.formGroup.controls.maxAutoscaleServiceAccounts;
@@ -202,9 +203,4 @@ export class SecretsManagerAdjustSubscriptionComponent implements OnInit, OnDest
 
     this.onAdjusted.emit();
   };
-
-  ngOnDestroy() {
-    this.destroy$.next();
-    this.destroy$.complete();
-  }
 }

--- a/apps/web/src/app/billing/payment/components/enter-billing-address.component.ts
+++ b/apps/web/src/app/billing/payment/components/enter-billing-address.component.ts
@@ -1,6 +1,7 @@
-import { Component, Input, OnDestroy, OnInit } from "@angular/core";
+import { Component, DestroyRef, inject, Input, OnInit } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { FormControl, FormGroup, Validators } from "@angular/forms";
-import { map, Observable, startWith, Subject, takeUntil } from "rxjs";
+import { map, Observable, startWith } from "rxjs";
 
 import { ControlsOf } from "@bitwarden/angular/types/controls-of";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
@@ -160,7 +161,9 @@ type Scenario =
   standalone: true,
   imports: [SharedModule],
 })
-export class EnterBillingAddressComponent implements OnInit, OnDestroy {
+export class EnterBillingAddressComponent implements OnInit {
+  private readonly destroyRef = inject(DestroyRef);
+
   // FIXME(https://bitwarden.atlassian.net/browse/CL-903): Migrate to Signals
   // eslint-disable-next-line @angular-eslint/prefer-signals
   @Input({ required: true }) scenario!: Scenario;
@@ -170,8 +173,6 @@ export class EnterBillingAddressComponent implements OnInit, OnDestroy {
 
   protected selectableCountries = selectableCountries;
   protected supportsTaxId$!: Observable<boolean>;
-
-  private destroy$ = new Subject<void>();
 
   constructor(private i18nService: I18nService) {}
 
@@ -202,18 +203,13 @@ export class EnterBillingAddressComponent implements OnInit, OnDestroy {
       }),
     );
 
-    this.supportsTaxId$.pipe(takeUntil(this.destroy$)).subscribe((supportsTaxId) => {
+    this.supportsTaxId$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((supportsTaxId) => {
       if (supportsTaxId) {
         this.group.controls.taxId.enable();
       } else {
         this.group.controls.taxId.disable();
       }
     });
-  }
-
-  ngOnDestroy() {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   disableAddressControls = () => {

--- a/apps/web/src/app/billing/payment/components/enter-payment-method.component.ts
+++ b/apps/web/src/app/billing/payment/components/enter-payment-method.component.ts
@@ -1,6 +1,15 @@
-import { ChangeDetectionStrategy, Component, input, OnDestroy, OnInit } from "@angular/core";
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  inject,
+  input,
+  OnDestroy,
+  OnInit,
+} from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { FormControl, FormGroup, Validators } from "@angular/forms";
-import { map, Observable, of, startWith, Subject, takeUntil } from "rxjs";
+import { map, Observable, of, startWith } from "rxjs";
 
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
@@ -234,6 +243,8 @@ type PaymentMethodFormGroup = FormGroup<{
   imports: [BillingServicesModule, PaymentLabelComponent, PopoverModule, SharedModule],
 })
 export class EnterPaymentMethodComponent implements OnInit, OnDestroy {
+  private readonly destroyRef = inject(DestroyRef);
+
   protected readonly instanceId = Utils.newGuid();
 
   readonly group = input.required<PaymentMethodFormGroup>();
@@ -245,8 +256,6 @@ export class EnterPaymentMethodComponent implements OnInit, OnDestroy {
 
   protected showBankAccount$!: Observable<boolean>;
   protected selectableCountries = selectableCountries;
-
-  private destroy$ = new Subject<void>();
 
   constructor(
     private braintreeService: BraintreeService,
@@ -288,7 +297,7 @@ export class EnterPaymentMethodComponent implements OnInit, OnDestroy {
     this.group()
       .controls.type.valueChanges.pipe(
         startWith(this.group().controls.type.value),
-        takeUntil(this.destroy$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe((selected) => {
         if (selected === "bankAccount") {
@@ -317,7 +326,7 @@ export class EnterPaymentMethodComponent implements OnInit, OnDestroy {
         }
       });
 
-    this.showBankAccount$.pipe(takeUntil(this.destroy$)).subscribe((showBankAccount) => {
+    this.showBankAccount$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((showBankAccount) => {
       if (!showBankAccount && this.selected === "bankAccount") {
         this.select("card");
       }
@@ -326,8 +335,6 @@ export class EnterPaymentMethodComponent implements OnInit, OnDestroy {
 
   ngOnDestroy() {
     this.stripeService.unloadStripe(this.instanceId);
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   select = (paymentMethod: PaymentMethodOption) =>

--- a/apps/web/src/app/billing/settings/sponsored-families.component.ts
+++ b/apps/web/src/app/billing/settings/sponsored-families.component.ts
@@ -1,6 +1,7 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
-import { Component, OnDestroy, OnInit } from "@angular/core";
+import { Component, DestroyRef, inject, OnInit } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import {
   FormBuilder,
   FormControl,
@@ -11,7 +12,7 @@ import {
   ValidationErrors,
 } from "@angular/forms";
 import { Router } from "@angular/router";
-import { combineLatest, firstValueFrom, map, Observable, Subject, takeUntil } from "rxjs";
+import { combineLatest, firstValueFrom, map, Observable } from "rxjs";
 
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
@@ -40,7 +41,8 @@ interface RequestSponsorshipForm {
   templateUrl: "sponsored-families.component.html",
   standalone: false,
 })
-export class SponsoredFamiliesComponent implements OnInit, OnDestroy {
+export class SponsoredFamiliesComponent implements OnInit {
+  private readonly destroyRef = inject(DestroyRef);
   loading = false;
 
   availableSponsorshipOrgs$: Observable<Organization[]>;
@@ -52,8 +54,6 @@ export class SponsoredFamiliesComponent implements OnInit, OnDestroy {
   formPromise: Promise<void>;
 
   sponsorshipForm: FormGroup<RequestSponsorshipForm>;
-
-  private _destroy = new Subject<void>();
 
   constructor(
     private apiService: ApiService,
@@ -108,7 +108,7 @@ export class SponsoredFamiliesComponent implements OnInit, OnDestroy {
       ),
     );
 
-    this.availableSponsorshipOrgs$.pipe(takeUntil(this._destroy)).subscribe((orgs) => {
+    this.availableSponsorshipOrgs$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((orgs) => {
       if (orgs.length === 1) {
         this.sponsorshipForm.patchValue({
           selectedSponsorshipOrgId: orgs[0].id,
@@ -130,17 +130,12 @@ export class SponsoredFamiliesComponent implements OnInit, OnDestroy {
 
     this.sponsorshipForm
       .get("sponsorshipEmail")
-      .valueChanges.pipe(takeUntil(this._destroy))
+      .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((val) => {
         if (this.sponsorshipEmailControl.hasError("email")) {
           this.sponsorshipEmailControl.setErrors([{ message: this.i18nService.t("invalidEmail") }]);
         }
       });
-  }
-
-  ngOnDestroy(): void {
-    this._destroy.next();
-    this._destroy.complete();
   }
 
   private async preventAccessToFreeFamiliesPage() {

--- a/apps/web/src/app/billing/shared/sm-subscribe.component.ts
+++ b/apps/web/src/app/billing/shared/sm-subscribe.component.ts
@@ -1,8 +1,9 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
-import { Component, Input, OnDestroy, OnInit } from "@angular/core";
+import { Component, DestroyRef, inject, Input, OnInit } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { FormBuilder, FormGroup, Validators } from "@angular/forms";
-import { Subject, startWith, takeUntil } from "rxjs";
+import { startWith } from "rxjs";
 
 import { ControlsOf } from "@bitwarden/angular/types/controls-of";
 import { SecretsManagerAlt } from "@bitwarden/assets/svg";
@@ -36,7 +37,8 @@ export const secretsManagerSubscribeFormFactory = (
   templateUrl: "sm-subscribe.component.html",
   standalone: false,
 })
-export class SecretsManagerSubscribeComponent implements OnInit, OnDestroy {
+export class SecretsManagerSubscribeComponent implements OnInit {
+  private readonly destroyRef = inject(DestroyRef);
   // FIXME(https://bitwarden.atlassian.net/browse/CL-903): Migrate to Signals
   // eslint-disable-next-line @angular-eslint/prefer-signals
   @Input() formGroup: FormGroup<ControlsOf<SecretsManagerSubscription>>;
@@ -56,13 +58,11 @@ export class SecretsManagerSubscribeComponent implements OnInit, OnDestroy {
   logo = SecretsManagerAlt;
   productTypes = ProductTierType;
 
-  private destroy$ = new Subject<void>();
-
   constructor(private i18nService: I18nService) {}
 
   ngOnInit() {
     this.formGroup.controls.enabled.valueChanges
-      .pipe(startWith(this.formGroup.value.enabled), takeUntil(this.destroy$))
+      .pipe(startWith(this.formGroup.value.enabled), takeUntilDestroyed(this.destroyRef))
       .subscribe((enabled) => {
         if (enabled) {
           this.formGroup.controls.userSeats.enable();
@@ -72,11 +72,6 @@ export class SecretsManagerSubscribeComponent implements OnInit, OnDestroy {
           this.formGroup.controls.additionalServiceAccounts.disable();
         }
       });
-  }
-
-  ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   discountPrice = (price: number) => {

--- a/apps/web/src/app/billing/shared/trial-payment-dialog/trial-payment-dialog.component.ts
+++ b/apps/web/src/app/billing/shared/trial-payment-dialog/trial-payment-dialog.component.ts
@@ -1,15 +1,17 @@
 import {
   Component,
+  DestroyRef,
   EventEmitter,
+  inject,
   Inject,
-  OnDestroy,
   OnInit,
   Output,
   signal,
   ViewChild,
 } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { FormGroup } from "@angular/forms";
-import { combineLatest, firstValueFrom, map, Subject, takeUntil } from "rxjs";
+import { combineLatest, firstValueFrom, map } from "rxjs";
 import { debounceTime, startWith, switchMap } from "rxjs/operators";
 
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
@@ -78,7 +80,7 @@ interface OnSuccessArgs {
   standalone: false,
   providers: [SubscriberBillingClient, PreviewInvoiceClient],
 })
-export class TrialPaymentDialogComponent implements OnInit, OnDestroy {
+export class TrialPaymentDialogComponent implements OnInit {
   // FIXME(https://bitwarden.atlassian.net/browse/CL-903): Migrate to Signals
   // eslint-disable-next-line @angular-eslint/prefer-signals
   @ViewChild(EnterPaymentMethodComponent) enterPaymentMethodComponent!: EnterPaymentMethodComponent;
@@ -106,7 +108,7 @@ export class TrialPaymentDialogComponent implements OnInit, OnDestroy {
     billingAddress: EnterBillingAddressComponent.getFormGroup(),
   });
 
-  private destroy$ = new Subject<void>();
+  private readonly destroyRef = inject(DestroyRef);
 
   constructor(
     @Inject(DIALOG_DATA) private dialogParams: TrialPaymentDialogParams,
@@ -195,14 +197,9 @@ export class TrialPaymentDialogComponent implements OnInit, OnDestroy {
         switchMap(() => {
           return this.refreshPricingSummary();
         }),
-        takeUntil(this.destroy$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe();
-  }
-
-  ngOnDestroy() {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   static open = (

--- a/apps/web/src/app/billing/trial-initiation/complete-trial-initiation/complete-trial-initiation.component.ts
+++ b/apps/web/src/app/billing/trial-initiation/complete-trial-initiation/complete-trial-initiation.component.ts
@@ -1,8 +1,9 @@
 import { StepperSelectionEvent } from "@angular/cdk/stepper";
-import { Component, OnDestroy, OnInit, ViewChild } from "@angular/core";
+import { Component, DestroyRef, inject, OnInit, ViewChild } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { FormBuilder, Validators } from "@angular/forms";
 import { ActivatedRoute, Router } from "@angular/router";
-import { firstValueFrom, map, Subject, switchMap, takeUntil } from "rxjs";
+import { firstValueFrom, map, switchMap } from "rxjs";
 
 import {
   InputPasswordFlow,
@@ -47,7 +48,8 @@ export type InitiationPath =
   templateUrl: "complete-trial-initiation.component.html",
   standalone: false,
 })
-export class CompleteTrialInitiationComponent implements OnInit, OnDestroy {
+export class CompleteTrialInitiationComponent implements OnInit {
+  private readonly destroyRef = inject(DestroyRef);
   // FIXME(https://bitwarden.atlassian.net/browse/CL-903): Migrate to Signals
   // eslint-disable-next-line @angular-eslint/prefer-signals
   @ViewChild("stepper", { static: false }) verticalStepper!: VerticalStepperComponent;
@@ -95,7 +97,6 @@ export class CompleteTrialInitiationComponent implements OnInit, OnDestroy {
     billingEmail: [""],
   });
 
-  private destroy$ = new Subject<void>();
   protected readonly ProductType = ProductType;
   protected trialPaymentOptional$ = this.configService.getFeatureFlag$(
     FeatureFlag.TrialPaymentOptional,
@@ -121,7 +122,7 @@ export class CompleteTrialInitiationComponent implements OnInit, OnDestroy {
   ) {}
 
   async ngOnInit(): Promise<void> {
-    this.route.queryParams.pipe(takeUntil(this.destroy$)).subscribe((qParams) => {
+    this.route.queryParams.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((qParams) => {
       // Retrieve email from query params
       if (qParams.email != null && qParams.email.indexOf("@") > -1) {
         this.email = qParams.email;
@@ -197,7 +198,7 @@ export class CompleteTrialInitiationComponent implements OnInit, OnDestroy {
         .pipe(
           getUserId,
           switchMap((userId) => this.policyService.masterPasswordPolicyOptions$(userId, policies)),
-          takeUntil(this.destroy$),
+          takeUntilDestroyed(this.destroyRef),
         )
         .subscribe((enforcedPasswordPolicyOptions) => {
           this.enforcedPolicyOptions = enforcedPasswordPolicyOptions;
@@ -205,17 +206,12 @@ export class CompleteTrialInitiationComponent implements OnInit, OnDestroy {
     }
 
     this.orgInfoFormGroup.controls.name.valueChanges
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(() => {
         this.orgInfoFormGroup.controls.name.markAsTouched();
       });
 
     this.initializing = false;
-  }
-
-  ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   /** Handle manual stepper change */

--- a/bitwarden_license/bit-web/src/app/billing/providers/payment-details/provider-payment-details.component.ts
+++ b/bitwarden_license/bit-web/src/app/billing/providers/payment-details/provider-payment-details.component.ts
@@ -1,4 +1,5 @@
-import { Component, OnDestroy, OnInit } from "@angular/core";
+import { Component, DestroyRef, inject, OnInit } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { ActivatedRoute } from "@angular/router";
 import {
   BehaviorSubject,
@@ -9,10 +10,8 @@ import {
   Observable,
   of,
   shareReplay,
-  Subject,
   switchMap,
   take,
-  takeUntil,
   tap,
   withLatestFrom,
 } from "rxjs";
@@ -69,7 +68,8 @@ const BANK_ACCOUNT_VERIFIED_COMMAND = new CommandDefinition<{
     SharedModule,
   ],
 })
-export class ProviderPaymentDetailsComponent implements OnInit, OnDestroy {
+export class ProviderPaymentDetailsComponent implements OnInit {
+  private readonly destroyRef = inject(DestroyRef);
   private viewState$ = new BehaviorSubject<View | null>(null);
 
   private provider$ = combineLatest([
@@ -115,8 +115,6 @@ export class ProviderPaymentDetailsComponent implements OnInit, OnDestroy {
     this.viewState$.pipe(filter((view): view is View => view !== null)),
   ).pipe(shareReplay({ bufferSize: 1, refCount: true }));
 
-  private destroy$ = new Subject<void>();
-
   constructor(
     private accountService: AccountService,
     private activatedRoute: ActivatedRoute,
@@ -139,7 +137,7 @@ export class ProviderPaymentDetailsComponent implements OnInit, OnDestroy {
             ),
           ]),
         ),
-        takeUntil(this.destroy$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe(([taxIdWarning, billingAddress]) => {
         if (this.viewState$.value) {
@@ -174,14 +172,9 @@ export class ProviderPaymentDetailsComponent implements OnInit, OnDestroy {
             this.setBillingAddress(billingAddress);
           }
         }),
-        takeUntil(this.destroy$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe();
-  }
-
-  ngOnDestroy() {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   setBillingAddress = (billingAddress: BillingAddress) => {

--- a/bitwarden_license/bit-web/src/app/billing/providers/subscription/provider-subscription.component.ts
+++ b/bitwarden_license/bit-web/src/app/billing/providers/subscription/provider-subscription.component.ts
@@ -1,8 +1,9 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
-import { Component, OnDestroy, OnInit } from "@angular/core";
+import { Component, DestroyRef, inject, OnInit } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { ActivatedRoute } from "@angular/router";
-import { concatMap, Subject, takeUntil } from "rxjs";
+import { concatMap } from "rxjs";
 
 import { BillingApiServiceAbstraction } from "@bitwarden/common/billing/abstractions/billing-api.service.abstraction";
 import {
@@ -18,13 +19,13 @@ import { BillingNotificationService } from "@bitwarden/web-vault/app/billing/ser
   templateUrl: "./provider-subscription.component.html",
   standalone: false,
 })
-export class ProviderSubscriptionComponent implements OnInit, OnDestroy {
+export class ProviderSubscriptionComponent implements OnInit {
+  private readonly destroyRef = inject(DestroyRef);
   private providerId: string;
   protected subscription: ProviderSubscriptionResponse;
 
   protected firstLoaded = false;
   protected loading: boolean;
-  private destroy$ = new Subject<void>();
   protected totalCost: number;
 
   constructor(
@@ -41,7 +42,7 @@ export class ProviderSubscriptionComponent implements OnInit, OnDestroy {
           await this.load();
           this.firstLoaded = true;
         }),
-        takeUntil(this.destroy$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe();
   }
@@ -89,11 +90,6 @@ export class ProviderSubscriptionComponent implements OnInit, OnDestroy {
 
   private sumCost(plans: ProviderPlanResponse[]): number {
     return plans.reduce((acc, plan) => acc + plan.cost, 0);
-  }
-
-  ngOnDestroy() {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   protected get activePlans(): ProviderPlanResponse[] {

--- a/libs/angular/src/billing/directives/premium.directive.ts
+++ b/libs/angular/src/billing/directives/premium.directive.ts
@@ -1,5 +1,13 @@
-import { Directive, OnDestroy, OnInit, TemplateRef, ViewContainerRef } from "@angular/core";
-import { of, Subject, switchMap, takeUntil } from "rxjs";
+import {
+  DestroyRef,
+  Directive,
+  inject,
+  OnInit,
+  TemplateRef,
+  ViewContainerRef,
+} from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
+import { of, switchMap } from "rxjs";
 
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { BillingAccountProfileStateService } from "@bitwarden/common/billing/abstractions/account/billing-account-profile-state.service";
@@ -10,8 +18,8 @@ import { BillingAccountProfileStateService } from "@bitwarden/common/billing/abs
 @Directive({
   selector: "[appPremium]",
 })
-export class PremiumDirective implements OnInit, OnDestroy {
-  private directiveIsDestroyed$ = new Subject<boolean>();
+export class PremiumDirective implements OnInit {
+  private readonly destroyRef = inject(DestroyRef);
 
   constructor(
     private templateRef: TemplateRef<any>,
@@ -28,7 +36,7 @@ export class PremiumDirective implements OnInit, OnDestroy {
             ? this.billingAccountProfileStateService.hasPremiumFromAnySource$(account.id)
             : of(false),
         ),
-        takeUntil(this.directiveIsDestroyed$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe((premium: boolean) => {
         if (premium) {
@@ -37,10 +45,5 @@ export class PremiumDirective implements OnInit, OnDestroy {
           this.viewContainer.clear();
         }
       });
-  }
-
-  ngOnDestroy() {
-    this.directiveIsDestroyed$.next(true);
-    this.directiveIsDestroyed$.complete();
   }
 }


### PR DESCRIPTION
## Summary

- Replaces `takeUntil(this.destroy$)` pattern with `takeUntilDestroyed(this.destroyRef)`
- Removes destroy `Subject` fields and cleanup-only `ngOnDestroy` methods
- Simplifies constructor-body calls to `takeUntilDestroyed()` (no arg, injection context)

**Files:** `apps/web/src/app/billing/`, `libs/angular/src/billing/`, `bitwarden_license/bit-web/src/app/billing/`

## Test plan

- [ ] Verify components still subscribe/unsubscribe correctly at lifecycle boundaries
- [ ] Check that any retained `ngOnDestroy` methods still execute their non-destroy logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Sibling PRs

- #19165 auth
- #19166 autofill (browser)
- #19167 autofill (desktop)
- #19168 tools
- #19169 vault
- #19170 admin console
- #19172 data insights & reporting
- #19173 key management
- #19174 UI foundation
- #19175 secrets manager
- #19176 platform / app shell