### PR TITLE
Migrate takeUntil to takeUntilDestroyed (data insights & reporting)

### DIFF
--- a/apps/web/src/app/dirt/reports/pages/cipher-report.component.ts
+++ b/apps/web/src/app/dirt/reports/pages/cipher-report.component.ts
@@ -1,13 +1,6 @@
-import { Directive, OnDestroy } from "@angular/core";
-import {
-  BehaviorSubject,
-  lastValueFrom,
-  Observable,
-  Subject,
-  firstValueFrom,
-  switchMap,
-  takeUntil,
-} from "rxjs";
+import { Directive } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
+import { BehaviorSubject, lastValueFrom, Observable, firstValueFrom, switchMap } from "rxjs";
 
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
@@ -34,7 +27,7 @@ import {
 import { AdminConsoleCipherFormConfigService } from "../../../vault/org-vault/services/admin-console-cipher-form-config.service";
 
 @Directive()
-export abstract class CipherReportComponent implements OnDestroy {
+export abstract class CipherReportComponent {
   isAdminConsoleActive = false;
 
   loading = false;
@@ -54,7 +47,6 @@ export abstract class CipherReportComponent implements OnDestroy {
   vaultMsg: string = "vault";
   currentFilterStatus: number | string = 0;
   protected filterOrgStatus$ = new BehaviorSubject<number | string>(0);
-  protected destroyed$: Subject<void> = new Subject();
   private vaultItemDialogRef?: DialogRef<VaultItemDialogResult> | undefined;
 
   constructor(
@@ -73,14 +65,9 @@ export abstract class CipherReportComponent implements OnDestroy {
       switchMap((userId) => this.organizationService.organizations$(userId)),
     );
 
-    this.organizations$.pipe(takeUntil(this.destroyed$)).subscribe((orgs) => {
+    this.organizations$.pipe(takeUntilDestroyed()).subscribe((orgs) => {
       this.organizations = orgs;
     });
-  }
-
-  ngOnDestroy(): void {
-    this.destroyed$.next();
-    this.destroyed$.complete();
   }
 
   getName(filterId: string | number) {

--- a/apps/web/src/app/dirt/reports/pages/organizations/exposed-passwords-report.component.ts
+++ b/apps/web/src/app/dirt/reports/pages/organizations/exposed-passwords-report.component.ts
@@ -1,6 +1,7 @@
-import { Component, OnInit } from "@angular/core";
+import { Component, DestroyRef, inject, OnInit } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { ActivatedRoute } from "@angular/router";
-import { firstValueFrom, takeUntil, tap } from "rxjs";
+import { firstValueFrom, tap } from "rxjs";
 
 import { AuditService } from "@bitwarden/common/abstractions/audit.service";
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
@@ -47,6 +48,7 @@ export class ExposedPasswordsReportComponent
   extends BaseExposedPasswordsReportComponent
   implements OnInit
 {
+  private readonly destroyRef = inject(DestroyRef);
   private manageableCiphers: Cipher[] = [];
 
   constructor(
@@ -87,7 +89,7 @@ export class ExposedPasswordsReportComponent
           );
           this.manageableCiphers = await this.cipherService.getAll(userId);
         }),
-        takeUntil(this.destroyed$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe();
   }

--- a/apps/web/src/app/dirt/reports/pages/organizations/inactive-two-factor-report.component.ts
+++ b/apps/web/src/app/dirt/reports/pages/organizations/inactive-two-factor-report.component.ts
@@ -1,6 +1,14 @@
-import { ChangeDetectorRef, Component, OnInit, ChangeDetectionStrategy } from "@angular/core";
+import {
+  ChangeDetectorRef,
+  Component,
+  DestroyRef,
+  inject,
+  OnInit,
+  ChangeDetectionStrategy,
+} from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { ActivatedRoute } from "@angular/router";
-import { firstValueFrom, takeUntil, tap } from "rxjs";
+import { firstValueFrom, tap } from "rxjs";
 
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
@@ -46,6 +54,7 @@ export class InactiveTwoFactorReportComponent
   extends BaseInactiveTwoFactorReportComponent
   implements OnInit
 {
+  private readonly destroyRef = inject(DestroyRef);
   // Contains a list of ciphers, the user running the report, can manage
   private manageableCiphers: Cipher[] = [];
 
@@ -92,7 +101,7 @@ export class InactiveTwoFactorReportComponent
           await super.ngOnInit();
           this.changeDetectorRef.markForCheck();
         }),
-        takeUntil(this.destroyed$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe();
   }

--- a/apps/web/src/app/dirt/reports/pages/organizations/reused-passwords-report.component.ts
+++ b/apps/web/src/app/dirt/reports/pages/organizations/reused-passwords-report.component.ts
@@ -1,6 +1,7 @@
-import { Component, OnInit } from "@angular/core";
+import { Component, DestroyRef, inject, OnInit } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { ActivatedRoute } from "@angular/router";
-import { firstValueFrom, takeUntil, tap } from "rxjs";
+import { firstValueFrom, tap } from "rxjs";
 
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
@@ -46,6 +47,7 @@ export class ReusedPasswordsReportComponent
   extends BaseReusedPasswordsReportComponent
   implements OnInit
 {
+  private readonly destroyRef = inject(DestroyRef);
   manageableCiphers: Cipher[] = [];
 
   constructor(
@@ -86,7 +88,7 @@ export class ReusedPasswordsReportComponent
           this.manageableCiphers = await this.cipherService.getAll(userId);
           await super.ngOnInit();
         }),
-        takeUntil(this.destroyed$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe();
   }

--- a/apps/web/src/app/dirt/reports/pages/organizations/unsecured-websites-report.component.ts
+++ b/apps/web/src/app/dirt/reports/pages/organizations/unsecured-websites-report.component.ts
@@ -1,6 +1,7 @@
-import { Component, OnInit } from "@angular/core";
+import { Component, DestroyRef, inject, OnInit } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { ActivatedRoute } from "@angular/router";
-import { firstValueFrom, takeUntil, tap } from "rxjs";
+import { firstValueFrom, tap } from "rxjs";
 
 import { CollectionService } from "@bitwarden/admin-console/common";
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
@@ -47,6 +48,7 @@ export class UnsecuredWebsitesReportComponent
   extends BaseUnsecuredWebsitesReportComponent
   implements OnInit
 {
+  private readonly destroyRef = inject(DestroyRef);
   // Contains a list of ciphers, the user running the report, can manage
   private manageableCiphers: Cipher[] = [];
 
@@ -89,7 +91,7 @@ export class UnsecuredWebsitesReportComponent
           this.manageableCiphers = await this.cipherService.getAll(userId);
           await super.ngOnInit();
         }),
-        takeUntil(this.destroyed$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe();
   }

--- a/apps/web/src/app/dirt/reports/pages/organizations/weak-passwords-report.component.ts
+++ b/apps/web/src/app/dirt/reports/pages/organizations/weak-passwords-report.component.ts
@@ -1,6 +1,7 @@
-import { Component, OnInit } from "@angular/core";
+import { Component, DestroyRef, inject, OnInit } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { ActivatedRoute } from "@angular/router";
-import { firstValueFrom, takeUntil, tap } from "rxjs";
+import { firstValueFrom, tap } from "rxjs";
 
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
@@ -47,6 +48,7 @@ export class WeakPasswordsReportComponent
   extends BaseWeakPasswordsReportComponent
   implements OnInit
 {
+  private readonly destroyRef = inject(DestroyRef);
   private manageableCiphers: Cipher[] = [];
 
   constructor(
@@ -88,7 +90,7 @@ export class WeakPasswordsReportComponent
           this.manageableCiphers = await this.cipherService.getAll(userId);
           await super.ngOnInit();
         }),
-        takeUntil(this.destroyed$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe();
   }

--- a/bitwarden_license/bit-web/src/app/dirt/organization-integrations/integration-card/integration-card.component.ts
+++ b/bitwarden_license/bit-web/src/app/dirt/organization-integrations/integration-card/integration-card.component.ts
@@ -1,14 +1,16 @@
 import {
   AfterViewInit,
   Component,
+  DestroyRef,
   ElementRef,
   Inject,
+  inject,
   Input,
-  OnDestroy,
   ViewChild,
 } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { ActivatedRoute } from "@angular/router";
-import { Observable, Subject, combineLatest, lastValueFrom, takeUntil } from "rxjs";
+import { Observable, combineLatest, lastValueFrom } from "rxjs";
 
 import { SYSTEM_THEME_OBSERVABLE } from "@bitwarden/angular/services/injection-tokens";
 import { Integration } from "@bitwarden/bit-common/dirt/organization-integrations/models/integration";
@@ -50,8 +52,8 @@ import {
   templateUrl: "./integration-card.component.html",
   imports: [SharedModule, BaseCardComponent, CardContentComponent],
 })
-export class IntegrationCardComponent implements AfterViewInit, OnDestroy {
-  private destroyed$: Subject<void> = new Subject();
+export class IntegrationCardComponent implements AfterViewInit {
+  private readonly destroyRef = inject(DestroyRef);
   // FIXME(https://bitwarden.atlassian.net/browse/CL-903): Migrate to Signals
   // eslint-disable-next-line @angular-eslint/prefer-signals
   @ViewChild("imageEle") imageEle!: ElementRef<HTMLImageElement>;
@@ -112,7 +114,7 @@ export class IntegrationCardComponent implements AfterViewInit, OnDestroy {
 
   ngAfterViewInit() {
     combineLatest([this.themeStateService.selectedTheme$, this.systemTheme$])
-      .pipe(takeUntil(this.destroyed$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(([theme, systemTheme]) => {
         // When the card doesn't have a dark mode image, exit early
         if (!this.imageDarkMode) {
@@ -133,11 +135,6 @@ export class IntegrationCardComponent implements AfterViewInit, OnDestroy {
           this.imageEle.nativeElement.src = this.image;
         }
       });
-  }
-
-  ngOnDestroy(): void {
-    this.destroyed$.next();
-    this.destroyed$.complete();
   }
 
   /** Show the "new" badge when expiration is in the future */


### PR DESCRIPTION
## Summary

- Replaces `takeUntil(this.destroy$)` pattern with `takeUntilDestroyed(this.destroyRef)`
- Removes destroy `Subject` fields and cleanup-only `ngOnDestroy` methods
- Simplifies constructor-body calls to `takeUntilDestroyed()` (no arg, injection context)

**Files:** `apps/web/src/app/dirt/`, `bitwarden_license/bit-web/src/app/dirt/`

## Test plan

- [ ] Verify components still subscribe/unsubscribe correctly at lifecycle boundaries
- [ ] Check that any retained `ngOnDestroy` methods still execute their non-destroy logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Sibling PRs

- #19165 auth
- #19166 autofill (browser)
- #19167 autofill (desktop)
- #19168 tools
- #19169 vault
- #19170 admin console
- #19171 billing
- #19173 key management
- #19174 UI foundation
- #19175 secrets manager
- #19176 platform / app shell