### PR TITLE
Migrate takeUntil to takeUntilDestroyed (key management)

### DIFF
--- a/apps/web/src/app/key-management/change-kdf/change-kdf.component.ts
+++ b/apps/web/src/app/key-management/change-kdf/change-kdf.component.ts
@@ -1,6 +1,7 @@
-import { Component, OnDestroy, OnInit } from "@angular/core";
+import { Component, DestroyRef, inject, OnInit } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { FormBuilder, FormControl, Validators } from "@angular/forms";
-import { Subject, firstValueFrom, takeUntil, Observable } from "rxjs";
+import { firstValueFrom, Observable } from "rxjs";
 
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { getUserId } from "@bitwarden/common/auth/services/account.service";
@@ -25,10 +26,10 @@ import { ChangeKdfConfirmationComponent } from "./change-kdf-confirmation.compon
   templateUrl: "change-kdf.component.html",
   standalone: false,
 })
-export class ChangeKdfComponent implements OnInit, OnDestroy {
+export class ChangeKdfComponent implements OnInit {
+  private readonly destroyRef = inject(DestroyRef);
   kdfConfig: KdfConfig = DEFAULT_KDF_CONFIG;
   kdfOptions: any[] = [];
-  private destroy$ = new Subject<void>();
 
   protected formGroup = this.formBuilder.group({
     kdf: new FormControl<KdfType>(KdfType.PBKDF2_SHA256, [Validators.required]),
@@ -71,7 +72,7 @@ export class ChangeKdfComponent implements OnInit, OnDestroy {
     this.setFormValidators(this.kdfConfig.kdfType);
 
     this.formGroup.controls.kdf.valueChanges
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((newValue) => {
         this.updateKdfConfig(newValue!);
       });
@@ -142,11 +143,6 @@ export class ChangeKdfComponent implements OnInit, OnDestroy {
       kdfConfigFormGroup.controls.memory.setValue(kdfConfig.memory);
       kdfConfigFormGroup.controls.parallelism.setValue(kdfConfig.parallelism);
     }
-  }
-
-  ngOnDestroy() {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   isPBKDF2(t: KdfConfig): t is PBKDF2KdfConfig {

--- a/apps/web/src/app/settings/preferences.component.ts
+++ b/apps/web/src/app/settings/preferences.component.ts
@@ -1,18 +1,9 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
-import { Component, OnDestroy, OnInit } from "@angular/core";
+import { Component, DestroyRef, inject, OnInit } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { FormBuilder } from "@angular/forms";
-import {
-  concatMap,
-  filter,
-  firstValueFrom,
-  map,
-  Observable,
-  Subject,
-  switchMap,
-  takeUntil,
-  tap,
-} from "rxjs";
+import { concatMap, filter, firstValueFrom, map, Observable, switchMap, tap } from "rxjs";
 
 import { PolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
 import { PolicyType } from "@bitwarden/common/admin-console/enums";
@@ -56,7 +47,7 @@ import { SharedModule } from "../shared";
     SessionTimeoutInputLegacyComponent,
   ],
 })
-export class PreferencesComponent implements OnInit, OnDestroy {
+export class PreferencesComponent implements OnInit {
   // For use in template
   protected readonly VaultTimeoutAction = VaultTimeoutAction;
 
@@ -70,8 +61,8 @@ export class PreferencesComponent implements OnInit, OnDestroy {
   localeOptions: any[];
   themeOptions: any[];
 
+  private readonly destroyRef = inject(DestroyRef);
   private startingLocale: string;
-  private destroy$ = new Subject<void>();
 
   form = this.formBuilder.group({
     vaultTimeout: [null as VaultTimeout | null],
@@ -174,7 +165,7 @@ export class PreferencesComponent implements OnInit, OnDestroy {
             }
           }
         }),
-        takeUntil(this.destroy$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe();
 
@@ -231,9 +222,4 @@ export class PreferencesComponent implements OnInit, OnDestroy {
       );
     }
   };
-
-  ngOnDestroy() {
-    this.destroy$.next();
-    this.destroy$.complete();
-  }
 }

--- a/bitwarden_license/bit-web/src/app/key-management/policies/session-timeout.component.ts
+++ b/bitwarden_license/bit-web/src/app/key-management/policies/session-timeout.component.ts
@@ -1,13 +1,7 @@
-import { Component, OnDestroy, OnInit } from "@angular/core";
+import { Component, DestroyRef, inject, OnInit } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { FormBuilder, FormControl, Validators } from "@angular/forms";
-import {
-  BehaviorSubject,
-  concatMap,
-  firstValueFrom,
-  Subject,
-  takeUntil,
-  withLatestFrom,
-} from "rxjs";
+import { BehaviorSubject, concatMap, firstValueFrom, withLatestFrom } from "rxjs";
 
 import { PolicyType } from "@bitwarden/common/admin-console/enums";
 import {
@@ -42,10 +36,7 @@ const DEFAULT_MINUTES = 0;
   templateUrl: "session-timeout.component.html",
   imports: [SharedModule],
 })
-export class SessionTimeoutPolicyComponent
-  extends BasePolicyEditComponent
-  implements OnInit, OnDestroy
-{
+export class SessionTimeoutPolicyComponent extends BasePolicyEditComponent implements OnInit {
   actionOptions: { name: string; value: SessionTimeoutAction }[];
   typeOptions: { name: string; value: SessionTimeoutType }[];
   data = this.formBuilder.group({
@@ -67,7 +58,7 @@ export class SessionTimeoutPolicyComponent
     action: new FormControl<SessionTimeoutAction>(null),
   });
 
-  private destroy$ = new Subject<void>();
+  private readonly destroyRef = inject(DestroyRef);
   private lastConfirmedType$ = new BehaviorSubject<SessionTimeoutType>(null);
 
   constructor(
@@ -108,14 +99,9 @@ export class SessionTimeoutPolicyComponent
             typeControl.setValue(lastConfirmedType, { emitEvent: false });
           }
         }),
-        takeUntil(this.destroy$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe();
-  }
-
-  ngOnDestroy() {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   protected override loadData() {

--- a/libs/key-management-ui/src/lock/components/lock.component.ts
+++ b/libs/key-management-ui/src/lock/components/lock.component.ts
@@ -1,18 +1,9 @@
 import { CommonModule } from "@angular/common";
-import { Component, NgZone, OnDestroy, OnInit } from "@angular/core";
+import { Component, NgZone, OnDestroy, OnInit, inject, DestroyRef } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from "@angular/forms";
 import { Router, ActivatedRoute } from "@angular/router";
-import {
-  BehaviorSubject,
-  filter,
-  firstValueFrom,
-  timer,
-  mergeMap,
-  Subject,
-  switchMap,
-  takeUntil,
-  tap,
-} from "rxjs";
+import { BehaviorSubject, filter, firstValueFrom, timer, mergeMap, switchMap, tap } from "rxjs";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { LogoutService } from "@bitwarden/auth/common";
@@ -105,7 +96,7 @@ const BIOMETRIC_UNLOCK_TEMPORARY_UNAVAILABLE_STATUSES = [
   ],
 })
 export class LockComponent implements OnInit, OnDestroy {
-  private destroy$ = new Subject<void>();
+  private readonly destroyRef = inject(DestroyRef);
   protected loading = true;
 
   activeAccount: Account | null = null;
@@ -220,7 +211,7 @@ export class LockComponent implements OnInit, OnDestroy {
             }
           }
         }),
-        takeUntil(this.destroy$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe();
   }
@@ -228,7 +219,7 @@ export class LockComponent implements OnInit, OnDestroy {
   // Base component methods
   private listenForActiveUnlockOptionChanges() {
     this.activeUnlockOption$
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((activeUnlockOption: UnlockOptionValue | null) => {
         if (activeUnlockOption === UnlockOption.Pin) {
           this.buildPinForm();
@@ -258,7 +249,7 @@ export class LockComponent implements OnInit, OnDestroy {
           await this.handleActiveAccountChange(account);
           this.loading = false;
         }),
-        takeUntil(this.destroy$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe();
   }
@@ -750,9 +741,6 @@ export class LockComponent implements OnInit, OnDestroy {
   // -----------------------------------------------------------------------------------------------
 
   ngOnDestroy() {
-    this.destroy$.next();
-    this.destroy$.complete();
-
     if (this.clientType === "desktop") {
       this.broadcasterService.unsubscribe(BroadcasterSubscriptionId);
     }

--- a/libs/key-management-ui/src/lock/components/master-password-lock/master-password-lock.component.ts
+++ b/libs/key-management-ui/src/lock/components/master-password-lock/master-password-lock.component.ts
@@ -1,15 +1,16 @@
 import {
   Component,
   computed,
+  DestroyRef,
   inject,
   input,
   model,
-  OnDestroy,
   OnInit,
   output,
 } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from "@angular/forms";
-import { firstValueFrom, Subject, takeUntil } from "rxjs";
+import { firstValueFrom } from "rxjs";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { ClientType } from "@bitwarden/client-type";
@@ -53,7 +54,8 @@ import { UnlockViaPrfComponent } from "../unlock-via-prf.component";
     UnlockViaPrfComponent,
   ],
 })
-export class MasterPasswordLockComponent implements OnInit, OnDestroy {
+export class MasterPasswordLockComponent implements OnInit {
+  private readonly destroyRef = inject(DestroyRef);
   private readonly accountService = inject(AccountService);
   private readonly masterPasswordUnlockService = inject(MasterPasswordUnlockService);
   private readonly i18nService = inject(I18nService);
@@ -82,7 +84,6 @@ export class MasterPasswordLockComponent implements OnInit, OnDestroy {
   logOut = output<void>();
 
   protected showPassword = false;
-  private destroy$ = new Subject<void>();
 
   formGroup = new FormGroup({
     masterPassword: new FormControl("", {
@@ -95,16 +96,11 @@ export class MasterPasswordLockComponent implements OnInit, OnDestroy {
     if (this.platformUtilsService.getClientType() === ClientType.Desktop) {
       this.messageListener
         .messages$(new CommandDefinition("windowHidden"))
-        .pipe(takeUntil(this.destroy$))
+        .pipe(takeUntilDestroyed(this.destroyRef))
         .subscribe(() => {
           this.showPassword = false;
         });
     }
-  }
-
-  ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   submit = async () => {

--- a/libs/key-management-ui/src/session-timeout/components/session-timeout-input-legacy.component.ts
+++ b/libs/key-management-ui/src/session-timeout/components/session-timeout-input-legacy.component.ts
@@ -1,7 +1,8 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
 import { CommonModule } from "@angular/common";
-import { Component, Input, OnChanges, OnDestroy, OnInit } from "@angular/core";
+import { Component, DestroyRef, inject, Input, OnChanges, OnInit } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import {
   AbstractControl,
   ControlValueAccessor,
@@ -14,7 +15,7 @@ import {
   ValidationErrors,
   Validator,
 } from "@angular/forms";
-import { filter, map, Observable, Subject, switchMap, takeUntil } from "rxjs";
+import { filter, map, Observable, switchMap } from "rxjs";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { PolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
@@ -67,7 +68,7 @@ type VaultTimeoutFormValue = VaultTimeoutForm["value"];
   ],
 })
 export class SessionTimeoutInputLegacyComponent
-  implements ControlValueAccessor, Validator, OnInit, OnDestroy, OnChanges
+  implements ControlValueAccessor, Validator, OnInit, OnChanges
 {
   static CUSTOM_VALUE = -100;
   static MIN_CUSTOM_MINUTES = 0;
@@ -92,7 +93,7 @@ export class SessionTimeoutInputLegacyComponent
   protected canLockVault$: Observable<boolean>;
   private onChange: (vaultTimeout: VaultTimeout) => void;
   private validatorChange: () => void;
-  private destroy$ = new Subject<void>();
+  private readonly destroyRef = inject(DestroyRef);
 
   constructor(
     private formBuilder: FormBuilder,
@@ -145,14 +146,14 @@ export class SessionTimeoutInputLegacyComponent
         ),
         getFirstPolicy,
         filter((policy) => policy != null),
-        takeUntil(this.destroy$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe((policy) => {
         this.vaultTimeoutPolicy = policy;
         this.applyVaultTimeoutPolicy();
       });
     this.form.valueChanges
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((value: VaultTimeoutFormValue) => {
         if (this.onChange) {
           this.onChange(this.getVaultTimeout(value));
@@ -166,7 +167,7 @@ export class SessionTimeoutInputLegacyComponent
     this.form.controls.vaultTimeout.valueChanges
       .pipe(
         filter((value) => value !== SessionTimeoutInputLegacyComponent.CUSTOM_VALUE),
-        takeUntil(this.destroy$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe((value) => {
         const current = typeof value === "string" ? 0 : Math.max(value, 0);
@@ -188,11 +189,6 @@ export class SessionTimeoutInputLegacyComponent
     this.canLockVault$ = this.vaultTimeoutSettingsService
       .availableVaultTimeoutActions$()
       .pipe(map((actions) => actions.includes(VaultTimeoutAction.Lock)));
-  }
-
-  ngOnDestroy() {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   ngOnChanges() {


### PR DESCRIPTION
## Summary

- Replaces `takeUntil(this.destroy$)` pattern with `takeUntilDestroyed(this.destroyRef)`
- Removes destroy `Subject` fields and cleanup-only `ngOnDestroy` methods
- Simplifies constructor-body calls to `takeUntilDestroyed()` (no arg, injection context)

**Files:** `apps/web/src/app/key-management/`, `apps/web/src/app/settings/`, `bitwarden_license/bit-web/src/app/key-management/`, `libs/key-management-ui/`

## Test plan

- [ ] Verify components still subscribe/unsubscribe correctly at lifecycle boundaries
- [ ] Check that any retained `ngOnDestroy` methods still execute their non-destroy logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Sibling PRs

- #19165 auth
- #19166 autofill (browser)
- #19167 autofill (desktop)
- #19168 tools
- #19169 vault
- #19170 admin console
- #19171 billing
- #19172 data insights & reporting
- #19174 UI foundation
- #19175 secrets manager
- #19176 platform / app shell