### PR TITLE
Migrate takeUntil to takeUntilDestroyed (UI foundation)

### DIFF
--- a/apps/browser/src/platform/popup/layout/popup-page.component.ts
+++ b/apps/browser/src/platform/popup/layout/popup-page.component.ts
@@ -3,7 +3,6 @@ import {
   booleanAttribute,
   ChangeDetectionStrategy,
   Component,
-  DestroyRef,
   ElementRef,
   inject,
   input,
@@ -27,8 +26,6 @@ import { IconModule, ScrollLayoutHostDirective, ScrollLayoutService } from "@bit
 export class PopupPageComponent {
   protected i18nService = inject(I18nService);
   private scrollLayout = inject(ScrollLayoutService);
-  private destroyRef = inject(DestroyRef);
-
   readonly loading = input<boolean>(false);
 
   readonly disablePadding = input(false, { transform: booleanAttribute });
@@ -49,7 +46,7 @@ export class PopupPageComponent {
             map(() => ref.nativeElement.scrollTop !== 0),
           ),
         ),
-        takeUntilDestroyed(this.destroyRef),
+        takeUntilDestroyed(),
       )
       .subscribe((isScrolled) => this.scrolled.set(isScrolled));
   }

--- a/apps/browser/src/popup/components/extension-anon-layout-wrapper/extension-anon-layout-wrapper.component.ts
+++ b/apps/browser/src/popup/components/extension-anon-layout-wrapper/extension-anon-layout-wrapper.component.ts
@@ -1,9 +1,10 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
 import { CommonModule } from "@angular/common";
-import { Component, OnDestroy, OnInit } from "@angular/core";
+import { Component, DestroyRef, inject, OnInit } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { ActivatedRoute, Data, NavigationEnd, Router, RouterModule } from "@angular/router";
-import { Subject, filter, switchMap, takeUntil, tap } from "rxjs";
+import { filter, switchMap, tap } from "rxjs";
 
 import { BitwardenLogo, BitSvg } from "@bitwarden/assets/svg";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
@@ -45,8 +46,8 @@ export interface ExtensionAnonLayoutWrapperData extends AnonLayoutWrapperData {
     RouterModule,
   ],
 })
-export class ExtensionAnonLayoutWrapperComponent implements OnInit, OnDestroy {
-  private destroy$ = new Subject<void>();
+export class ExtensionAnonLayoutWrapperComponent implements OnInit {
+  private readonly destroyRef = inject(DestroyRef);
 
   protected showAcctSwitcher: boolean;
   protected showBackButton: boolean;
@@ -81,7 +82,7 @@ export class ExtensionAnonLayoutWrapperComponent implements OnInit, OnDestroy {
     this.listenForServiceDataChanges();
 
     this.accountSwitcherService.availableAccounts$
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((accounts) => {
         this.hasLoggedInAccount = accounts.some((account) => account.id !== "addAccount");
       });
@@ -94,7 +95,7 @@ export class ExtensionAnonLayoutWrapperComponent implements OnInit, OnDestroy {
         // reset page data on page changes
         tap(() => this.resetPageData()),
         switchMap(() => this.route.firstChild?.data || null),
-        takeUntil(this.destroy$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe((firstChildRouteData: Data | null) => {
         this.setAnonLayoutWrapperDataFromRouteData(firstChildRouteData);
@@ -142,7 +143,7 @@ export class ExtensionAnonLayoutWrapperComponent implements OnInit, OnDestroy {
   private listenForServiceDataChanges() {
     this.extensionAnonLayoutWrapperDataService
       .anonLayoutWrapperData$()
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((data: ExtensionAnonLayoutWrapperData) => {
         this.setAnonLayoutWrapperData(data);
       });
@@ -215,10 +216,5 @@ export class ExtensionAnonLayoutWrapperComponent implements OnInit, OnDestroy {
     this.maxWidth = null;
     this.hideFooter = null;
     this.hideCardWrapper = null;
-  }
-
-  ngOnDestroy() {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 }


### PR DESCRIPTION
## Summary

- Replaces `takeUntil(this.destroy$)` pattern with `takeUntilDestroyed(this.destroyRef)`
- Removes destroy `Subject` fields and cleanup-only `ngOnDestroy` methods
- Simplifies constructor-body calls to `takeUntilDestroyed()` (no arg, injection context)

**Files:** `apps/browser/src/platform/popup/layout/`, `apps/browser/src/popup/components/extension-anon-layout-wrapper/`

## Test plan

- [ ] Verify components still subscribe/unsubscribe correctly at lifecycle boundaries
- [ ] Check that any retained `ngOnDestroy` methods still execute their non-destroy logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Sibling PRs

- #19165 auth
- #19166 autofill (browser)
- #19167 autofill (desktop)
- #19168 tools
- #19169 vault
- #19170 admin console
- #19171 billing
- #19172 data insights & reporting
- #19173 key management
- #19175 secrets manager
- #19176 platform / app shell