### PR TITLE
Migrate takeUntil to takeUntilDestroyed (secrets manager)

### DIFF
--- a/bitwarden_license/bit-web/src/app/secrets-manager/layout/navigation.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/layout/navigation.component.ts
@@ -1,6 +1,7 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
-import { Component, OnDestroy, OnInit } from "@angular/core";
+import { Component, DestroyRef, inject, OnInit } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { ActivatedRoute } from "@angular/router";
 import {
   combineLatest,
@@ -10,9 +11,7 @@ import {
   map,
   Observable,
   startWith,
-  Subject,
   switchMap,
-  takeUntil,
 } from "rxjs";
 
 import { SecretsManagerLogo } from "@bitwarden/assets/svg";
@@ -38,13 +37,13 @@ import { CountService } from "../shared/counts/count.service";
   templateUrl: "./navigation.component.html",
   standalone: false,
 })
-export class NavigationComponent implements OnInit, OnDestroy {
+export class NavigationComponent implements OnInit {
+  private readonly destroyRef = inject(DestroyRef);
   protected readonly logo = SecretsManagerLogo;
   protected orgFilter = (org: Organization) => org.canAccessSecretsManager;
   protected isAdmin$: Observable<boolean>;
   protected isOrgEnabled$: Observable<boolean>;
   protected organizationCounts: OrganizationCounts;
-  private destroy$: Subject<void> = new Subject<void>();
 
   constructor(
     protected route: ActivatedRoute,
@@ -69,17 +68,17 @@ export class NavigationComponent implements OnInit, OnDestroy {
         ),
       ),
       distinctUntilChanged(),
-      takeUntil(this.destroy$),
+      takeUntilDestroyed(this.destroyRef),
     );
 
     this.isAdmin$ = org$.pipe(
       map((org) => org?.isAdmin),
-      takeUntil(this.destroy$),
+      takeUntilDestroyed(this.destroyRef),
     );
 
     this.isOrgEnabled$ = org$.pipe(
       map((org) => org?.enabled),
-      takeUntil(this.destroy$),
+      takeUntilDestroyed(this.destroyRef),
     );
 
     combineLatest([
@@ -92,7 +91,7 @@ export class NavigationComponent implements OnInit, OnDestroy {
       .pipe(
         filter(([org]) => org?.enabled),
         switchMap(([org]) => this.countService.getOrganizationCounts(org.id)),
-        takeUntil(this.destroy$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe((organizationCounts) => {
         this.organizationCounts = {
@@ -101,10 +100,5 @@ export class NavigationComponent implements OnInit, OnDestroy {
           serviceAccounts: organizationCounts.serviceAccounts,
         };
       });
-  }
-
-  ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 }

--- a/bitwarden_license/bit-web/src/app/secrets-manager/overview/overview.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/overview/overview.component.ts
@@ -1,13 +1,12 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
-import { Component, OnDestroy, OnInit } from "@angular/core";
+import { Component, OnInit, inject, DestroyRef } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { ActivatedRoute, Router } from "@angular/router";
 import {
   map,
   Observable,
   switchMap,
-  Subject,
-  takeUntil,
   combineLatest,
   startWith,
   distinctUntilChanged,
@@ -82,8 +81,8 @@ type OrganizationTasks = {
   templateUrl: "./overview.component.html",
   standalone: false,
 })
-export class OverviewComponent implements OnInit, OnDestroy {
-  private destroy$: Subject<void> = new Subject<void>();
+export class OverviewComponent implements OnInit {
+  private readonly destroyRef = inject(DestroyRef);
   private tableSize = 10;
   private organizationId: string;
   protected organizationName: string;
@@ -137,7 +136,7 @@ export class OverviewComponent implements OnInit, OnDestroy {
       ),
     );
 
-    org$.pipe(takeUntil(this.destroy$)).subscribe((org) => {
+    org$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((org) => {
       this.organizationId = org.id;
       this.organization = org;
       this.organizationName = org.name;
@@ -208,7 +207,7 @@ export class OverviewComponent implements OnInit, OnDestroy {
     orgId$
       .pipe(
         switchMap(() => this.view$.pipe(take(1))),
-        takeUntil(this.destroy$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe((view) => {
         this.showOnboarding = Object.values(view.tasks).includes(false);
@@ -223,11 +222,6 @@ export class OverviewComponent implements OnInit, OnDestroy {
         state: { launchPaymentModalAutomatically: true },
       },
     );
-  }
-
-  ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   private getRecentItems<T extends { revisionDate: string }[]>(items: T, length: number): T {

--- a/bitwarden_license/bit-web/src/app/secrets-manager/projects/project/project-people.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/projects/project/project-people.component.ts
@@ -1,9 +1,10 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
-import { ChangeDetectorRef, Component, OnDestroy, OnInit } from "@angular/core";
+import { ChangeDetectorRef, Component, DestroyRef, inject, OnInit } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { FormControl, FormGroup } from "@angular/forms";
 import { ActivatedRoute, Router } from "@angular/router";
-import { combineLatest, Subject, switchMap, takeUntil, catchError } from "rxjs";
+import { combineLatest, switchMap, catchError } from "rxjs";
 
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
@@ -31,9 +32,9 @@ import { AccessPolicyService } from "../../shared/access-policies/access-policy.
   templateUrl: "./project-people.component.html",
   standalone: false,
 })
-export class ProjectPeopleComponent implements OnInit, OnDestroy {
+export class ProjectPeopleComponent implements OnInit {
+  private readonly destroyRef = inject(DestroyRef);
   private currentAccessPolicies: ApItemViewType[];
-  private destroy$ = new Subject<void>();
   private organizationId: string;
   private projectId: string;
 
@@ -82,22 +83,17 @@ export class ProjectPeopleComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit(): void {
-    this.route.params.pipe(takeUntil(this.destroy$)).subscribe((params) => {
+    this.route.params.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((params) => {
       this.organizationId = params.organizationId;
       this.projectId = params.projectId;
     });
 
     combineLatest([this.potentialGrantees$, this.currentAccessPolicies$])
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(([potentialGrantees, currentAccessPolicies]) => {
         this.potentialGrantees = potentialGrantees;
         this.setSelected(currentAccessPolicies);
       });
-  }
-
-  ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   submit = async () => {

--- a/bitwarden_license/bit-web/src/app/secrets-manager/projects/project/project-service-accounts.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/projects/project/project-service-accounts.component.ts
@@ -1,9 +1,10 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
-import { ChangeDetectorRef, Component, OnDestroy, OnInit } from "@angular/core";
+import { ChangeDetectorRef, Component, DestroyRef, inject, OnInit } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { FormControl, FormGroup } from "@angular/forms";
 import { ActivatedRoute } from "@angular/router";
-import { combineLatest, Subject, switchMap, takeUntil } from "rxjs";
+import { combineLatest, switchMap } from "rxjs";
 
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
@@ -29,9 +30,9 @@ import { AccessPolicyService } from "../../shared/access-policies/access-policy.
   templateUrl: "./project-service-accounts.component.html",
   standalone: false,
 })
-export class ProjectServiceAccountsComponent implements OnInit, OnDestroy {
+export class ProjectServiceAccountsComponent implements OnInit {
+  private readonly destroyRef = inject(DestroyRef);
   private currentAccessPolicies: ApItemViewType[];
-  private destroy$ = new Subject<void>();
   private organizationId: string;
   private projectId: string;
 
@@ -74,23 +75,18 @@ export class ProjectServiceAccountsComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit(): void {
-    this.route.params.pipe(takeUntil(this.destroy$)).subscribe((params) => {
+    this.route.params.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((params) => {
       this.organizationId = params.organizationId;
       this.projectId = params.projectId;
     });
 
     combineLatest([this.potentialGrantees$, this.currentAccessPolicies$])
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(([potentialGrantees, currentAccessPolicies]) => {
         this.potentialGrantees = potentialGrantees;
         this.items = this.getItems(potentialGrantees, currentAccessPolicies);
         this.setSelected(currentAccessPolicies);
       });
-  }
-
-  ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   submit = async () => {

--- a/bitwarden_license/bit-web/src/app/secrets-manager/projects/project/project.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/projects/project/project.component.ts
@@ -1,18 +1,9 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
-import { Component, OnDestroy, OnInit } from "@angular/core";
+import { Component, DestroyRef, inject, OnInit } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { ActivatedRoute } from "@angular/router";
-import {
-  combineLatest,
-  filter,
-  Observable,
-  startWith,
-  Subject,
-  switchMap,
-  takeUntil,
-  map,
-  concatMap,
-} from "rxjs";
+import { combineLatest, filter, Observable, startWith, switchMap, map, concatMap } from "rxjs";
 
 import {
   getOrganizationById,
@@ -41,14 +32,14 @@ import { ProjectService } from "../project.service";
   templateUrl: "./project.component.html",
   standalone: false,
 })
-export class ProjectComponent implements OnInit, OnDestroy {
+export class ProjectComponent implements OnInit {
+  private readonly destroyRef = inject(DestroyRef);
   protected project$: Observable<ProjectView>;
   protected projectCounts: ProjectCounts;
 
   private organizationId: string;
   private projectId: string;
   private organizationEnabled: boolean;
-  private destroy$ = new Subject<void>();
 
   constructor(
     private route: ActivatedRoute,
@@ -92,7 +83,7 @@ export class ProjectComponent implements OnInit, OnDestroy {
     ]).pipe(switchMap(([params]) => this.countService.getProjectCounts(params.projectId)));
 
     combineLatest([projectId$, organization$, projectCounts$])
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(([projectId, organization, projectCounts]) => {
         this.organizationId = organization.id;
         this.projectId = projectId;
@@ -103,11 +94,6 @@ export class ProjectComponent implements OnInit, OnDestroy {
           serviceAccounts: projectCounts.serviceAccounts,
         };
       });
-  }
-
-  ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   async openEditDialog() {

--- a/bitwarden_license/bit-web/src/app/secrets-manager/secrets/dialog/secret-dialog.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/secrets/dialog/secret-dialog.component.ts
@@ -1,8 +1,9 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
-import { ChangeDetectorRef, Component, Inject, OnDestroy, OnInit } from "@angular/core";
+import { ChangeDetectorRef, Component, DestroyRef, inject, Inject, OnInit } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { FormControl, FormGroup, Validators } from "@angular/forms";
-import { firstValueFrom, lastValueFrom, Subject, takeUntil } from "rxjs";
+import { firstValueFrom, lastValueFrom } from "rxjs";
 
 import {
   getOrganizationById,
@@ -74,7 +75,9 @@ export interface SecretOperation {
   templateUrl: "./secret-dialog.component.html",
   standalone: false,
 })
-export class SecretDialogComponent implements OnInit, OnDestroy {
+export class SecretDialogComponent implements OnInit {
+  private readonly destroyRef = inject(DestroyRef);
+
   loading = true;
   projects: ProjectListView[];
   addNewProject = false;
@@ -102,7 +105,6 @@ export class SecretDialogComponent implements OnInit, OnDestroy {
   protected peopleAccessPolicyItems: ApItemViewType[];
   protected serviceAccountAccessPolicyItems: ApItemViewType[];
 
-  private destroy$ = new Subject<void>();
   private currentPeopleAccessPolicies: ApItemViewType[];
 
   constructor(
@@ -161,11 +163,6 @@ export class SecretDialogComponent implements OnInit, OnDestroy {
     }
 
     this.loading = false;
-  }
-
-  ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   submit = async () => {
@@ -322,7 +319,7 @@ export class SecretDialogComponent implements OnInit, OnDestroy {
   private addNewProjectOptionToProjectsDropDown() {
     this.formGroup
       .get("project")
-      .valueChanges.pipe(takeUntil(this.destroy$))
+      .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((val: string) => {
         this.dropDownSelected(val);
       });

--- a/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/access/access-tokens.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/access/access-tokens.component.ts
@@ -1,16 +1,9 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
-import { Component, OnDestroy, OnInit } from "@angular/core";
+import { Component, DestroyRef, inject, OnInit } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { ActivatedRoute } from "@angular/router";
-import {
-  combineLatestWith,
-  firstValueFrom,
-  Observable,
-  startWith,
-  Subject,
-  switchMap,
-  takeUntil,
-} from "rxjs";
+import { combineLatestWith, firstValueFrom, Observable, startWith, switchMap } from "rxjs";
 
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
@@ -31,10 +24,10 @@ import { AccessTokenCreateDialogComponent } from "./dialogs/access-token-create-
   templateUrl: "./access-tokens.component.html",
   standalone: false,
 })
-export class AccessTokenComponent implements OnInit, OnDestroy {
+export class AccessTokenComponent implements OnInit {
+  private readonly destroyRef = inject(DestroyRef);
   accessTokens$: Observable<AccessTokenView[]>;
 
-  private destroy$ = new Subject<void>();
   private serviceAccountView: ServiceAccountView;
 
   constructor(
@@ -66,16 +59,11 @@ export class AccessTokenComponent implements OnInit, OnDestroy {
             params.organizationId,
           ),
         ),
-        takeUntil(this.destroy$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe((serviceAccountView) => {
         this.serviceAccountView = serviceAccountView;
       });
-  }
-
-  ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   protected async revoke(tokens: AccessTokenView[]) {

--- a/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/access/dialogs/expiration-options.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/access/dialogs/expiration-options.component.ts
@@ -1,7 +1,8 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
 import { DatePipe } from "@angular/common";
-import { Component, Input, OnDestroy, OnInit } from "@angular/core";
+import { Component, DestroyRef, inject, Input, OnInit } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import {
   AbstractControl,
   ControlValueAccessor,
@@ -14,7 +15,6 @@ import {
   ValidatorFn,
   Validators,
 } from "@angular/forms";
-import { Subject, takeUntil } from "rxjs";
 
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 
@@ -37,10 +37,8 @@ import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.servic
   ],
   standalone: false,
 })
-export class ExpirationOptionsComponent
-  implements ControlValueAccessor, Validator, OnInit, OnDestroy
-{
-  private destroy$ = new Subject<void>();
+export class ExpirationOptionsComponent implements ControlValueAccessor, Validator, OnInit {
+  private readonly destroyRef = inject(DestroyRef);
 
   // FIXME(https://bitwarden.atlassian.net/browse/CL-903): Migrate to Signals
   // eslint-disable-next-line @angular-eslint/prefer-signals
@@ -67,14 +65,9 @@ export class ExpirationOptionsComponent
   ) {}
 
   async ngOnInit() {
-    this.form.valueChanges.pipe(takeUntil(this.destroy$)).subscribe(() => {
+    this.form.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
       this._onChange(this.getExpiresDate());
     });
-  }
-
-  ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   private _onChange = (_value: Date | null): void => undefined;

--- a/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/config/config.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/config/config.component.ts
@@ -1,8 +1,9 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
-import { Component, OnDestroy, OnInit } from "@angular/core";
+import { Component, DestroyRef, inject, OnInit } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { ActivatedRoute } from "@angular/router";
-import { Subject, combineLatest, from, switchMap, takeUntil } from "rxjs";
+import { combineLatest, from, switchMap } from "rxjs";
 
 import {
   Environment,
@@ -31,7 +32,8 @@ class ServiceAccountConfig {
   templateUrl: "./config.component.html",
   standalone: false,
 })
-export class ServiceAccountConfigComponent implements OnInit, OnDestroy {
+export class ServiceAccountConfigComponent implements OnInit {
+  private readonly destroyRef = inject(DestroyRef);
   identityUrl: string;
   apiUrl: string;
   organizationId: string;
@@ -39,7 +41,6 @@ export class ServiceAccountConfigComponent implements OnInit, OnDestroy {
   projects: ProjectListView[];
   hasProjects = false;
 
-  private destroy$ = new Subject<void>();
   loading = true;
 
   constructor(
@@ -58,7 +59,7 @@ export class ServiceAccountConfigComponent implements OnInit, OnDestroy {
         switchMap(([params, env]) =>
           from(this.load(env, params.organizationId, params.serviceAccountId)),
         ),
-        takeUntil(this.destroy$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe((smConfig) => {
         this.identityUrl = smConfig.identityUrl;
@@ -129,9 +130,4 @@ export class ServiceAccountConfigComponent implements OnInit, OnDestroy {
       message: this.i18nService.t("valueCopied", this.i18nService.t("organizationId")),
     });
   };
-
-  ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
-  }
 }

--- a/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/event-logs/service-accounts-events.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/event-logs/service-accounts-events.component.ts
@@ -1,8 +1,8 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
-import { ChangeDetectionStrategy, Component, OnDestroy, OnInit } from "@angular/core";
+import { ChangeDetectionStrategy, Component, DestroyRef, inject, OnInit } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { ActivatedRoute } from "@angular/router";
-import { takeUntil } from "rxjs";
 
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
@@ -23,10 +23,9 @@ import { ServiceAccountEventLogApiService } from "./service-account-event-log-ap
   templateUrl: "./service-accounts-events.component.html",
   standalone: false,
 })
-export class ServiceAccountEventsComponent
-  extends BaseEventsComponent
-  implements OnInit, OnDestroy
-{
+export class ServiceAccountEventsComponent extends BaseEventsComponent implements OnInit {
+  private readonly destroyRef = inject(DestroyRef);
+
   exportFileName = "machine-account-events";
   private serviceAccountId: string;
 
@@ -60,7 +59,7 @@ export class ServiceAccountEventsComponent
   async ngOnInit() {
     this.initBase();
     // eslint-disable-next-line rxjs/no-async-subscribe
-    this.route.params.pipe(takeUntil(this.destroy$)).subscribe(async (params) => {
+    this.route.params.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(async (params) => {
       this.serviceAccountId = params.serviceAccountId;
       await this.load();
     });

--- a/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/people/service-account-people.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/people/service-account-people.component.ts
@@ -1,9 +1,10 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
-import { ChangeDetectorRef, Component, OnDestroy, OnInit } from "@angular/core";
+import { ChangeDetectorRef, Component, DestroyRef, inject, OnInit } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { FormControl, FormGroup } from "@angular/forms";
 import { ActivatedRoute, Router } from "@angular/router";
-import { combineLatest, Subject, switchMap, takeUntil } from "rxjs";
+import { combineLatest, switchMap } from "rxjs";
 
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
@@ -32,9 +33,9 @@ import { AccessPolicyService } from "../../shared/access-policies/access-policy.
   templateUrl: "./service-account-people.component.html",
   standalone: false,
 })
-export class ServiceAccountPeopleComponent implements OnInit, OnDestroy {
+export class ServiceAccountPeopleComponent implements OnInit {
+  private readonly destroyRef = inject(DestroyRef);
   private currentAccessPolicies: ApItemViewType[];
-  private destroy$ = new Subject<void>();
   private organizationId: string;
   private serviceAccountId: string;
 
@@ -80,22 +81,17 @@ export class ServiceAccountPeopleComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit(): void {
-    this.route.params.pipe(takeUntil(this.destroy$)).subscribe((params) => {
+    this.route.params.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((params) => {
       this.organizationId = params.organizationId;
       this.serviceAccountId = params.serviceAccountId;
     });
 
     combineLatest([this.potentialGrantees$, this.currentAccessPolicies$])
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(([potentialGrantees, currentAccessPolicies]) => {
         this.potentialGrantees = potentialGrantees;
         this.setSelected(currentAccessPolicies);
       });
-  }
-
-  ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   submit = async () => {

--- a/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/projects/service-account-projects.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/projects/service-account-projects.component.ts
@@ -1,9 +1,10 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
-import { ChangeDetectorRef, Component, OnDestroy, OnInit } from "@angular/core";
+import { ChangeDetectorRef, Component, DestroyRef, inject, OnInit } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { FormControl, FormGroup } from "@angular/forms";
 import { ActivatedRoute } from "@angular/router";
-import { combineLatest, Subject, switchMap, takeUntil } from "rxjs";
+import { combineLatest, switchMap } from "rxjs";
 
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
@@ -29,9 +30,9 @@ import { AccessPolicyService } from "../../shared/access-policies/access-policy.
   templateUrl: "./service-account-projects.component.html",
   standalone: false,
 })
-export class ServiceAccountProjectsComponent implements OnInit, OnDestroy {
+export class ServiceAccountProjectsComponent implements OnInit {
+  private readonly destroyRef = inject(DestroyRef);
   private currentAccessPolicies: ApItemViewType[];
-  private destroy$ = new Subject<void>();
   private organizationId: string;
   private serviceAccountId: string;
 
@@ -73,13 +74,13 @@ export class ServiceAccountProjectsComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit(): void {
-    this.route.params.pipe(takeUntil(this.destroy$)).subscribe((params) => {
+    this.route.params.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((params) => {
       this.organizationId = params.organizationId;
       this.serviceAccountId = params.serviceAccountId;
     });
 
     combineLatest([this.potentialGrantees$, this.currentAccessPolicies$])
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(([potentialGrantees, currentAccessPolicies]) => {
         this.potentialGrantees = this.getPotentialGrantees(
           potentialGrantees,
@@ -87,11 +88,6 @@ export class ServiceAccountProjectsComponent implements OnInit, OnDestroy {
         );
         this.setSelected(currentAccessPolicies);
       });
-  }
-
-  ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   submit = async () => {

--- a/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/service-account.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/service-account.component.ts
@@ -1,8 +1,9 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
-import { Component, OnDestroy, OnInit } from "@angular/core";
+import { Component, DestroyRef, inject, OnInit } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { ActivatedRoute } from "@angular/router";
-import { Subject, combineLatest, filter, startWith, switchMap, takeUntil } from "rxjs";
+import { combineLatest, filter, startWith, switchMap } from "rxjs";
 
 import { DialogService } from "@bitwarden/components";
 
@@ -22,8 +23,8 @@ import { ServiceAccountService } from "./service-account.service";
   templateUrl: "./service-account.component.html",
   standalone: false,
 })
-export class ServiceAccountComponent implements OnInit, OnDestroy {
-  private destroy$ = new Subject<void>();
+export class ServiceAccountComponent implements OnInit {
+  private readonly destroyRef = inject(DestroyRef);
   private serviceAccountId: string;
 
   private onChange$ = this.serviceAccountService.serviceAccount$.pipe(
@@ -64,7 +65,7 @@ export class ServiceAccountComponent implements OnInit, OnDestroy {
     );
 
     combineLatest([this.serviceAccount$, serviceAccountCounts$])
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(([serviceAccountView, serviceAccountCounts]) => {
         this.serviceAccountView = serviceAccountView;
         this.serviceAccountCounts = {
@@ -73,11 +74,6 @@ export class ServiceAccountComponent implements OnInit, OnDestroy {
           accessTokens: serviceAccountCounts.accessTokens,
         };
       });
-  }
-
-  ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   protected openNewAccessTokenDialog() {

--- a/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/service-accounts-list.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/service-accounts-list.component.ts
@@ -1,9 +1,10 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
 import { SelectionModel } from "@angular/cdk/collections";
-import { Component, EventEmitter, Input, OnDestroy, Output, OnInit } from "@angular/core";
+import { Component, DestroyRef, EventEmitter, inject, Input, Output, OnInit } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { ActivatedRoute } from "@angular/router";
-import { catchError, concatMap, map, Observable, of, Subject, switchMap, takeUntil } from "rxjs";
+import { catchError, concatMap, map, Observable, of, switchMap } from "rxjs";
 
 import {
   getOrganizationById,
@@ -28,7 +29,8 @@ import {
   templateUrl: "./service-accounts-list.component.html",
   standalone: false,
 })
-export class ServiceAccountsListComponent implements OnDestroy, OnInit {
+export class ServiceAccountsListComponent implements OnInit {
+  private readonly destroyRef = inject(DestroyRef);
   protected dataSource = new TableDataSource<ServiceAccountSecretsDetailsView>();
 
   // FIXME(https://bitwarden.atlassian.net/browse/CL-903): Migrate to Signals
@@ -65,7 +67,6 @@ export class ServiceAccountsListComponent implements OnDestroy, OnInit {
   // eslint-disable-next-line @angular-eslint/prefer-output-emitter-ref
   @Output() editServiceAccountEvent = new EventEmitter<string>();
 
-  private destroy$: Subject<void> = new Subject<void>();
   protected viewEventsAllowed$: Observable<boolean>;
   protected isAdmin$: Observable<boolean>;
   selection = new SelectionModel<string>(true, []);
@@ -80,7 +81,7 @@ export class ServiceAccountsListComponent implements OnDestroy, OnInit {
     private logService: LogService,
   ) {
     this.selection.changed
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed())
       .subscribe((_) => this.onServiceAccountCheckedEvent.emit(this.selection.selected));
   }
 
@@ -108,13 +109,8 @@ export class ServiceAccountsListComponent implements OnDestroy, OnInit {
         }
         return of(false);
       }),
-      takeUntil(this.destroy$),
+      takeUntilDestroyed(this.destroyRef),
     );
-  }
-
-  ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   isAllSelected() {

--- a/bitwarden_license/bit-web/src/app/secrets-manager/settings/porting/sm-export.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/settings/porting/sm-export.component.ts
@@ -1,9 +1,10 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
-import { Component, OnDestroy, OnInit } from "@angular/core";
+import { Component, DestroyRef, inject, OnInit } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { FormControl, FormGroup, Validators } from "@angular/forms";
 import { ActivatedRoute } from "@angular/router";
-import { firstValueFrom, Subject, switchMap, takeUntil } from "rxjs";
+import { firstValueFrom, switchMap } from "rxjs";
 
 import {
   getOrganizationById,
@@ -33,8 +34,8 @@ type ExportFormat = {
   templateUrl: "./sm-export.component.html",
   standalone: false,
 })
-export class SecretsManagerExportComponent implements OnInit, OnDestroy {
-  private destroy$ = new Subject<void>();
+export class SecretsManagerExportComponent implements OnInit {
+  private readonly destroyRef = inject(DestroyRef);
 
   protected orgName: string;
   protected orgId: string;
@@ -69,7 +70,7 @@ export class SecretsManagerExportComponent implements OnInit, OnDestroy {
               .pipe(getOrganizationById(params.organizationId)),
           );
         }),
-        takeUntil(this.destroy$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe((organization) => {
         this.orgName = organization.name;
@@ -77,11 +78,6 @@ export class SecretsManagerExportComponent implements OnInit, OnDestroy {
       });
 
     this.formGroup.get("format").disable();
-  }
-
-  async ngOnDestroy() {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   submit = async () => {

--- a/bitwarden_license/bit-web/src/app/secrets-manager/settings/porting/sm-import.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/settings/porting/sm-import.component.ts
@@ -1,9 +1,9 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
-import { Component, OnDestroy, OnInit } from "@angular/core";
+import { Component, DestroyRef, inject, OnInit } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { FormControl, FormGroup } from "@angular/forms";
 import { ActivatedRoute } from "@angular/router";
-import { Subject, takeUntil } from "rxjs";
 
 import { FileDownloadService } from "@bitwarden/common/platform/abstractions/file-download/file-download.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
@@ -25,8 +25,8 @@ import { SecretsManagerPortingApiService } from "../services/sm-porting-api.serv
   templateUrl: "./sm-import.component.html",
   standalone: false,
 })
-export class SecretsManagerImportComponent implements OnInit, OnDestroy {
-  private destroy$ = new Subject<void>();
+export class SecretsManagerImportComponent implements OnInit {
+  private readonly destroyRef = inject(DestroyRef);
   protected orgId: string = null;
   protected selectedFile: File;
   protected formGroup = new FormGroup({
@@ -44,14 +44,9 @@ export class SecretsManagerImportComponent implements OnInit, OnDestroy {
   ) {}
 
   async ngOnInit() {
-    this.route.params.pipe(takeUntil(this.destroy$)).subscribe((params) => {
+    this.route.params.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((params) => {
       this.orgId = params.organizationId;
     });
-  }
-
-  async ngOnDestroy() {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   submit = async () => {

--- a/bitwarden_license/bit-web/src/app/secrets-manager/shared/access-policies/access-policy-selector/access-policy-selector.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/shared/access-policies/access-policy-selector/access-policy-selector.component.ts
@@ -1,6 +1,7 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
-import { Component, forwardRef, Input, OnDestroy, OnInit } from "@angular/core";
+import { Component, DestroyRef, forwardRef, inject, Input, OnInit } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import {
   ControlValueAccessor,
   FormBuilder,
@@ -8,7 +9,6 @@ import {
   FormGroup,
   NG_VALUE_ACCESSOR,
 } from "@angular/forms";
-import { Subject, takeUntil } from "rxjs";
 
 import { ControlsOf } from "@bitwarden/angular/types/controls-of";
 import { FormSelectionList } from "@bitwarden/angular/utils/form-selection-list";
@@ -34,8 +34,8 @@ import { ApPermissionEnum } from "./models/enums/ap-permission.enum";
   ],
   standalone: false,
 })
-export class AccessPolicySelectorComponent implements ControlValueAccessor, OnInit, OnDestroy {
-  private destroy$ = new Subject<void>();
+export class AccessPolicySelectorComponent implements ControlValueAccessor, OnInit {
+  private readonly destroyRef = inject(DestroyRef);
   private notifyOnChange: (v: unknown) => void;
   private notifyOnTouch: () => void;
   private pauseChangeNotification: boolean;
@@ -236,24 +236,21 @@ export class AccessPolicySelectorComponent implements ControlValueAccessor, OnIn
 
   ngOnInit() {
     // Watch the internal formArray for changes and propagate them
-    this.selectionList.formArray.valueChanges.pipe(takeUntil(this.destroy$)).subscribe((v) => {
-      if (!this.notifyOnChange || this.pauseChangeNotification) {
-        return;
-      }
+    this.selectionList.formArray.valueChanges
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((v) => {
+        if (!this.notifyOnChange || this.pauseChangeNotification) {
+          return;
+        }
 
-      // Disabled form arrays emit values for disabled controls, we override this to emit an empty array to avoid
-      // emitting values for disabled controls that are "readonly" in the table
-      if (this.selectionList.formArray.disabled) {
-        this.notifyOnChange([]);
-        return;
-      }
-      this.notifyOnChange(v);
-    });
-  }
-
-  ngOnDestroy() {
-    this.destroy$.next();
-    this.destroy$.complete();
+        // Disabled form arrays emit values for disabled controls, we override this to emit an empty array to avoid
+        // emitting values for disabled controls that are "readonly" in the table
+        if (this.selectionList.formArray.disabled) {
+          this.notifyOnChange([]);
+          return;
+        }
+        this.notifyOnChange(v);
+      });
   }
 
   protected handleBlur() {

--- a/bitwarden_license/bit-web/src/app/secrets-manager/shared/new-menu.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/shared/new-menu.component.ts
@@ -1,8 +1,9 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
-import { Component, OnDestroy, OnInit } from "@angular/core";
+import { Component, DestroyRef, inject, OnInit } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { ActivatedRoute } from "@angular/router";
-import { Subject, takeUntil, concatMap, firstValueFrom } from "rxjs";
+import { concatMap, firstValueFrom } from "rxjs";
 
 import {
   getOrganizationById,
@@ -33,10 +34,10 @@ import {
   templateUrl: "./new-menu.component.html",
   standalone: false,
 })
-export class NewMenuComponent implements OnInit, OnDestroy {
+export class NewMenuComponent implements OnInit {
+  private readonly destroyRef = inject(DestroyRef);
   private organizationId: string;
   private organizationEnabled: boolean;
-  private destroy$: Subject<void> = new Subject<void>();
   constructor(
     private route: ActivatedRoute,
     private dialogService: DialogService,
@@ -55,17 +56,12 @@ export class NewMenuComponent implements OnInit, OnDestroy {
               .pipe(getOrganizationById(params.organizationId)),
           );
         }),
-        takeUntil(this.destroy$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe((org) => {
         this.organizationId = org.id;
         this.organizationEnabled = org.enabled;
       });
-  }
-
-  ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   openSecretDialog() {

--- a/bitwarden_license/bit-web/src/app/secrets-manager/shared/projects-list.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/shared/projects-list.component.ts
@@ -1,9 +1,10 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
 import { SelectionModel } from "@angular/cdk/collections";
-import { Component, EventEmitter, Input, Output, OnInit } from "@angular/core";
+import { Component, DestroyRef, EventEmitter, inject, Input, Output, OnInit } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { ActivatedRoute } from "@angular/router";
-import { catchError, concatMap, map, Observable, of, Subject, switchMap, takeUntil } from "rxjs";
+import { catchError, concatMap, map, Observable, of, switchMap } from "rxjs";
 
 import {
   getOrganizationById,
@@ -40,9 +41,9 @@ export class ProjectsListComponent implements OnInit {
     this.dataSource.data = projects;
   }
   private _projects: ProjectListView[];
+  private readonly destroyRef = inject(DestroyRef);
   protected viewEventsAllowed$: Observable<boolean>;
   protected isAdmin$: Observable<boolean>;
-  private destroy$: Subject<void> = new Subject<void>();
 
   // FIXME(https://bitwarden.atlassian.net/browse/CL-903): Migrate to Signals
   // eslint-disable-next-line @angular-eslint/prefer-signals
@@ -110,7 +111,7 @@ export class ProjectsListComponent implements OnInit {
         }
         return of(false);
       }),
-      takeUntil(this.destroy$),
+      takeUntilDestroyed(this.destroyRef),
     );
   }
 

--- a/bitwarden_license/bit-web/src/app/secrets-manager/shared/secrets-list.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/shared/secrets-list.component.ts
@@ -1,9 +1,10 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
 import { SelectionModel } from "@angular/cdk/collections";
-import { Component, EventEmitter, Input, OnDestroy, Output, OnInit } from "@angular/core";
+import { Component, DestroyRef, EventEmitter, inject, Input, Output, OnInit } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { ActivatedRoute } from "@angular/router";
-import { catchError, concatMap, map, Observable, of, Subject, switchMap, takeUntil } from "rxjs";
+import { catchError, concatMap, map, Observable, of, switchMap } from "rxjs";
 
 import {
   getOrganizationById,
@@ -28,7 +29,8 @@ import { SecretService } from "../secrets/secret.service";
   templateUrl: "./secrets-list.component.html",
   standalone: false,
 })
-export class SecretsListComponent implements OnDestroy, OnInit {
+export class SecretsListComponent implements OnInit {
+  private readonly destroyRef = inject(DestroyRef);
   protected dataSource = new TableDataSource<SecretListView>();
 
   // FIXME(https://bitwarden.atlassian.net/browse/CL-903): Migrate to Signals
@@ -84,8 +86,6 @@ export class SecretsListComponent implements OnDestroy, OnInit {
   // eslint-disable-next-line @angular-eslint/prefer-output-emitter-ref
   @Output() restoreSecretsEvent = new EventEmitter();
 
-  private destroy$: Subject<void> = new Subject<void>();
-
   selection = new SelectionModel<string>(true, []);
   protected viewEventsAllowed$: Observable<boolean>;
   protected isAdmin$: Observable<boolean>;
@@ -100,7 +100,7 @@ export class SecretsListComponent implements OnDestroy, OnInit {
     private logService: LogService,
   ) {
     this.selection.changed
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed())
       .subscribe((_) => this.onSecretCheckedEvent.emit(this.selection.selected));
   }
 
@@ -128,13 +128,8 @@ export class SecretsListComponent implements OnDestroy, OnInit {
         }
         return of(false);
       }),
-      takeUntil(this.destroy$),
+      takeUntilDestroyed(this.destroyRef),
     );
-  }
-
-  ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   isAllSelected() {


### PR DESCRIPTION
## Summary

- Replaces `takeUntil(this.destroy$)` pattern with `takeUntilDestroyed(this.destroyRef)`
- Removes destroy `Subject` fields and cleanup-only `ngOnDestroy` methods
- Simplifies constructor-body calls to `takeUntilDestroyed()` (no arg, injection context)

**Files:** `bitwarden_license/bit-web/src/app/secrets-manager/`

## Test plan

- [ ] Verify components still subscribe/unsubscribe correctly at lifecycle boundaries
- [ ] Check that any retained `ngOnDestroy` methods still execute their non-destroy logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Sibling PRs

- #19165 auth
- #19166 autofill (browser)
- #19167 autofill (desktop)
- #19168 tools
- #19169 vault
- #19170 admin console
- #19171 billing
- #19172 data insights & reporting
- #19173 key management
- #19174 UI foundation
- #19176 platform / app shell