### PR TITLE
chore: bump sdk-internal to 0.2.0-main.551

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,7 +149,9 @@
     "webpack": "5.104.1",
     "webpack-cli": "6.0.1",
     "webpack-dev-server": "5.2.2",
-    "webpack-node-externals": "3.0.0"
+    "webpack-node-externals": "3.0.0",
+    "@bitwarden/sdk-internal": "0.2.0-main.551",
+    "@bitwarden/sdk-internal-commercial": "0.2.0-main.551"
   },
   "dependencies": {
     "@angular/animations": "20.3.16",
@@ -162,7 +164,7 @@
     "@angular/platform-browser-dynamic": "20.3.16",
     "@angular/router": "20.3.16",
     "@bitwarden/commercial-sdk-internal": "0.2.0-main.550",
-    "@bitwarden/sdk-internal": "0.2.0-main.550",
+    "@bitwarden/sdk-internal": "0.2.0-main.551",
     "@electron/fuses": "1.8.0",
     "@emotion/css": "11.13.5",
     "@koa/multer": "4.0.0",
@@ -206,7 +208,8 @@
     "utf-8-validate": "6.0.5",
     "vite-tsconfig-paths": "5.1.4",
     "zone.js": "0.15.1",
-    "zxcvbn": "4.4.2"
+    "zxcvbn": "4.4.2",
+    "@bitwarden/sdk-internal-commercial": "0.2.0-main.551"
   },
   "overrides": {
     "eslint-plugin-rxjs": {


### PR DESCRIPTION
Updates `@bitwarden/sdk-internal` and `@bitwarden/sdk-internal-commercial` to `0.2.0-main.551`.