### PR TITLE
chore: bump sdk-internal to 0.2.0-main.559

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,8 +23,8 @@
         "@angular/platform-browser": "20.3.16",
         "@angular/platform-browser-dynamic": "20.3.16",
         "@angular/router": "20.3.16",
-        "@bitwarden/commercial-sdk-internal": "0.2.0-main.556",
-        "@bitwarden/sdk-internal": "0.2.0-main.556",
+        "@bitwarden/commercial-sdk-internal": "0.2.0-main.559",
+        "@bitwarden/sdk-internal": "0.2.0-main.559",
         "@electron/fuses": "1.8.0",
         "@emotion/css": "11.13.5",
         "@koa/multer": "4.0.0",
@@ -4941,9 +4941,9 @@
       "link": true
     },
     "node_modules/@bitwarden/commercial-sdk-internal": {
-      "version": "0.2.0-main.556",
-      "resolved": "https://registry.npmjs.org/@bitwarden/commercial-sdk-internal/-/commercial-sdk-internal-0.2.0-main.556.tgz",
-      "integrity": "sha512-o6iT5+OkXm6j5fteYjTvQVn73pbIYcTCysksaHDVHTrRlGPXVopcFmwMpRHoeGC3ubCMQppI39MEkzYP70ddWw==",
+      "version": "0.2.0-main.559",
+      "resolved": "https://registry.npmjs.org/@bitwarden/commercial-sdk-internal/-/commercial-sdk-internal-0.2.0-main.559.tgz",
+      "integrity": "sha512-HP2vZTW5oY9GVi9NVP39EpfvQZOLuD0XPsz8WFs3s5WjVo5kvunB2Hkvk9GfXm3rwnzqEfdiacqJoZwJ5B+xuA==",
       "license": "BITWARDEN SOFTWARE DEVELOPMENT KIT LICENSE AGREEMENT",
       "dependencies": {
         "type-fest": "^5.0.0"
@@ -5049,9 +5049,9 @@
       "link": true
     },
     "node_modules/@bitwarden/sdk-internal": {
-      "version": "0.2.0-main.556",
-      "resolved": "https://registry.npmjs.org/@bitwarden/sdk-internal/-/sdk-internal-0.2.0-main.556.tgz",
-      "integrity": "sha512-F73d7LlR9ZkI1Tx9HppP64x0u83NmwGXi3iTJcaf4e1h0B7umQypkp89iLaekSe7QAWbIiShBV6oydz6ImgR6Q==",
+      "version": "0.2.0-main.559",
+      "resolved": "https://registry.npmjs.org/@bitwarden/sdk-internal/-/sdk-internal-0.2.0-main.559.tgz",
+      "integrity": "sha512-0HwX/ae08Z1ZXu8oItG/6FtGEsguligFVgg3pM3LXQA+8FsM7qDZEteS+d+6l/U7GTbYVfsog9P7Ti0xwHG2Bg==",
       "license": "GPL-3.0",
       "dependencies": {
         "type-fest": "^5.0.0"

--- a/package.json
+++ b/package.json
@@ -149,7 +149,9 @@
     "webpack": "5.104.1",
     "webpack-cli": "6.0.1",
     "webpack-dev-server": "5.2.2",
-    "webpack-node-externals": "3.0.0"
+    "webpack-node-externals": "3.0.0",
+    "@bitwarden/sdk-internal": "0.2.0-main.559",
+    "@bitwarden/sdk-internal-commercial": "0.2.0-main.559"
   },
   "dependencies": {
     "@angular/animations": "20.3.16",
@@ -161,8 +163,8 @@
     "@angular/platform-browser": "20.3.16",
     "@angular/platform-browser-dynamic": "20.3.16",
     "@angular/router": "20.3.16",
-    "@bitwarden/commercial-sdk-internal": "0.2.0-main.556",
-    "@bitwarden/sdk-internal": "0.2.0-main.556",
+    "@bitwarden/commercial-sdk-internal": "0.2.0-main.559",
+    "@bitwarden/sdk-internal": "0.2.0-main.559",
     "@electron/fuses": "1.8.0",
     "@emotion/css": "11.13.5",
     "@koa/multer": "4.0.0",
@@ -206,7 +208,8 @@
     "utf-8-validate": "6.0.5",
     "vite-tsconfig-paths": "5.1.4",
     "zone.js": "0.15.1",
-    "zxcvbn": "4.4.2"
+    "zxcvbn": "4.4.2",
+    "@bitwarden/sdk-internal-commercial": "0.2.0-main.559"
   },
   "overrides": {
     "eslint-plugin-rxjs": {


### PR DESCRIPTION
Updates `@bitwarden/sdk-internal` and `@bitwarden/sdk-internal-commercial` to `0.2.0-main.559`.