### PR TITLE
[PM-31198] Parse the CommunicationServerConfigResponse within the ConfigService

### DIFF
--- a/libs/common/src/platform/abstractions/config/config.service.ts
+++ b/libs/common/src/platform/abstractions/config/config.service.ts
@@ -3,6 +3,8 @@
 import { Observable } from "rxjs";
 import { SemVer } from "semver";
 
+import { ServerCommunicationConfig } from "@bitwarden/sdk-internal";
+
 import { FeatureFlag, FeatureFlagValueType } from "../../../enums/feature-flag.enum";
 import { UserId } from "../../../types/guid";
 import { ServerSettings } from "../../models/domain/server-settings";
@@ -13,6 +15,12 @@ import { ServerConfig } from "./server-config";
 export abstract class ConfigService {
   /** The server config of the currently active user */
   serverConfig$: Observable<ServerConfig | null>;
+  /**
+   * Emits whenever a server config is successfully fetched, pairing the server's
+   * API URL with the parsed ServerCommunicationConfig. Use this to react to
+   * communication config changes without coupling to the config fetch pipeline.
+   */
+  serverCommunicationConfig$: Observable<{ hostname: string; config: ServerCommunicationConfig }>;
   /** The server settings of the currently active user */
   serverSettings$: Observable<ServerSettings | null>;
   /** The cloud region of the currently active user */

--- a/libs/common/src/platform/models/response/server-config.response.ts
+++ b/libs/common/src/platform/models/response/server-config.response.ts
@@ -13,6 +13,7 @@ export class ServerConfigResponse extends BaseResponse {
   featureStates: { [key: string]: AllowedFeatureFlagTypes } = {};
   push: PushSettingsConfigResponse;
   settings: ServerSettings;
+  communication: CommunicationServerConfigResponse;
 
   constructor(response: any) {
     super(response);
@@ -28,6 +29,9 @@ export class ServerConfigResponse extends BaseResponse {
     this.featureStates = this.getResponseProperty("FeatureStates");
     this.push = new PushSettingsConfigResponse(this.getResponseProperty("Push"));
     this.settings = new ServerSettings(this.getResponseProperty("Settings"));
+    this.communication = new CommunicationServerConfigResponse(
+      this.getResponseProperty("Communication"),
+    );
   }
 }
 
@@ -84,5 +88,39 @@ export class ThirdPartyServerConfigResponse extends BaseResponse {
 
     this.name = this.getResponseProperty("Name");
     this.url = this.getResponseProperty("Url");
+  }
+}
+
+export class CommunicationServerConfigResponse extends BaseResponse {
+  bootstrap: BootstrapServerConfigResponse;
+
+  constructor(data: any = null) {
+    super(data);
+
+    if (data == null) {
+      return;
+    }
+
+    this.bootstrap = new BootstrapServerConfigResponse(this.getResponseProperty("Bootstrap"));
+  }
+}
+
+export class BootstrapServerConfigResponse extends BaseResponse {
+  type: string;
+  idpLoginUrl: string;
+  cookieName: string;
+  cookieDomain: string;
+
+  constructor(data: any = null) {
+    super(data);
+
+    if (data == null) {
+      return;
+    }
+
+    this.type = this.getResponseProperty("Type");
+    this.idpLoginUrl = this.getResponseProperty("IdpLoginUrl");
+    this.cookieName = this.getResponseProperty("CookieName");
+    this.cookieDomain = this.getResponseProperty("CookieDomain");
   }
 }


### PR DESCRIPTION
## 🎟️ Tracking
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-31198

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Parse the CommunicationServerConfigResponse within the ConfigService and emit changes via an observable.

Model was introduced on the server with https://github.com/bitwarden/server/pull/6892

The tracking task was split to parse the response and introduce an observable, that emits the changes. In another PR, I'll add the subscription to the ServerCommunicationConfigService which is introduced with https://github.com/bitwarden/clients/pull/18837
