### PR TITLE
[PM-31406] fix: update tsconfig.base.json for TypeScript 5.9 compatibility

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -12,7 +12,6 @@
     "emitDecoratorMetadata": true,
     "declaration": false,
     "outDir": "dist",
-    "baseUrl": ".",
     "resolveJsonModule": true,
     "allowJs": true,
     "sourceMap": true,


### PR DESCRIPTION
https://bitwarden.atlassian.net/browse/PM-31406

## Summary
Migrates to uint8 array for typescript 5.9 compatibility. See https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-9.html#notable-behavioral-changes