### PR TITLE
[PM-32642] Hide delete button for users without deletion permissions

### DIFF
--- a/apps/desktop/src/vault/app/vault/item-footer.component.html
+++ b/apps/desktop/src/vault/app/vault/item-footer.component.html
@@ -63,14 +63,21 @@
         </button>
       }
 
-      <button
-        type="button"
-        (click)="delete()"
-        class="danger"
-        appA11yTitle="{{ (cipher.isDeleted ? 'permanentlyDelete' : 'delete') | i18n }}"
-      >
-        <i class="bwi bwi-trash bwi-lg bwi-fw" aria-hidden="true" style="pointer-events: none"></i>
-      </button>
+      @if (canDelete) {
+        <button
+          type="button"
+          (click)="delete()"
+          class="danger"
+          appA11yTitle="{{ (cipher.isDeleted ? 'permanentlyDelete' : 'delete') | i18n }}"
+          data-test-id="footer-delete-button"
+        >
+          <i
+            class="bwi bwi-trash bwi-lg bwi-fw"
+            aria-hidden="true"
+            style="pointer-events: none"
+          ></i>
+        </button>
+      }
     </div>
   }
 </div>

--- a/apps/desktop/src/vault/app/vault/item-footer.component.spec.ts
+++ b/apps/desktop/src/vault/app/vault/item-footer.component.spec.ts
@@ -1,0 +1,172 @@
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { By } from "@angular/platform-browser";
+import { mock } from "jest-mock-extended";
+import { of } from "rxjs";
+
+import { JslibModule } from "@bitwarden/angular/jslib.module";
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+import { Utils } from "@bitwarden/common/platform/misc/utils";
+import { FakeAccountService, mockAccountServiceWith } from "@bitwarden/common/spec";
+import { UserId } from "@bitwarden/common/types/guid";
+import { CipherArchiveService } from "@bitwarden/common/vault/abstractions/cipher-archive.service";
+import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
+import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+import { CipherAuthorizationService } from "@bitwarden/common/vault/services/cipher-authorization.service";
+import { ButtonModule, DialogService, ToastService } from "@bitwarden/components";
+import { ArchiveCipherUtilitiesService, PasswordRepromptService } from "@bitwarden/vault";
+
+import { ItemFooterComponent } from "./item-footer.component";
+
+describe("ItemFooterComponent", () => {
+  let component: ItemFooterComponent;
+  let fixture: ComponentFixture<ItemFooterComponent>;
+  let accountService: FakeAccountService;
+
+  const mockUserId = Utils.newGuid() as UserId;
+
+  beforeEach(async () => {
+    accountService = mockAccountServiceWith(mockUserId);
+
+    const cipherArchiveService = {
+      userCanArchive$: jest.fn().mockReturnValue(of(false)),
+      hasArchiveFlagEnabled$: of(false),
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [ItemFooterComponent, ButtonModule, JslibModule],
+      providers: [
+        { provide: AccountService, useValue: accountService },
+        { provide: CipherService, useValue: mock<CipherService>() },
+        { provide: DialogService, useValue: mock<DialogService>() },
+        { provide: PasswordRepromptService, useValue: mock<PasswordRepromptService>() },
+        { provide: CipherAuthorizationService, useValue: mock<CipherAuthorizationService>() },
+        { provide: ToastService, useValue: mock<ToastService>() },
+        { provide: I18nService, useValue: { t: (key: string) => key } },
+        { provide: LogService, useValue: mock<LogService>() },
+        { provide: CipherArchiveService, useValue: cipherArchiveService },
+        { provide: ArchiveCipherUtilitiesService, useValue: mock<ArchiveCipherUtilitiesService>() },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ItemFooterComponent);
+    component = fixture.componentInstance;
+  });
+
+  const createCipherView = (overrides: Partial<CipherView> = {}): CipherView => {
+    const cipher = new CipherView();
+    cipher.id = "test-cipher-id";
+    cipher.permissions = {
+      delete: false,
+      restore: false,
+      manage: false,
+      edit: false,
+      view: false,
+      viewPassword: false,
+    };
+    return Object.assign(cipher, overrides);
+  };
+
+  describe("delete button visibility", () => {
+    it("shows the delete button when cipher.permissions.delete is true and action is 'view'", async () => {
+      const cipher = createCipherView({
+        permissions: {
+          delete: true,
+          restore: false,
+          manage: false,
+          edit: false,
+          view: false,
+          viewPassword: false,
+        },
+      });
+
+      component.cipher = cipher;
+      component.action = "view";
+
+      await component.ngOnInit();
+      fixture.detectChanges();
+
+      const deleteButton = fixture.debugElement.query(
+        By.css('[data-test-id="footer-delete-button"]'),
+      );
+
+      expect(deleteButton).toBeTruthy();
+    });
+
+    it("shows the delete button when cipher.permissions.delete is true and action is 'edit'", async () => {
+      const cipher = createCipherView({
+        permissions: {
+          delete: true,
+          restore: false,
+          manage: false,
+          edit: false,
+          view: false,
+          viewPassword: false,
+        },
+      });
+
+      component.cipher = cipher;
+      component.action = "edit";
+
+      await component.ngOnInit();
+      fixture.detectChanges();
+
+      const deleteButton = fixture.debugElement.query(
+        By.css('[data-test-id="footer-delete-button"]'),
+      );
+
+      expect(deleteButton).toBeTruthy();
+    });
+
+    it("does not show the delete button when cipher.permissions.delete is false", async () => {
+      const cipher = createCipherView({
+        permissions: {
+          delete: false,
+          restore: false,
+          manage: false,
+          edit: false,
+          view: false,
+          viewPassword: false,
+        },
+      });
+
+      component.cipher = cipher;
+      component.action = "view";
+
+      await component.ngOnInit();
+      fixture.detectChanges();
+
+      const deleteButton = fixture.debugElement.query(
+        By.css('[data-test-id="footer-delete-button"]'),
+      );
+
+      expect(deleteButton).toBeFalsy();
+    });
+
+    it("does not show the delete button when action is not 'view' or 'edit'", async () => {
+      const cipher = createCipherView({
+        permissions: {
+          delete: true,
+          restore: false,
+          manage: false,
+          edit: false,
+          view: false,
+          viewPassword: false,
+        },
+      });
+
+      component.cipher = cipher;
+      component.action = "add";
+
+      await component.ngOnInit();
+      fixture.detectChanges();
+
+      const deleteButton = fixture.debugElement.query(
+        By.css('[data-test-id="footer-delete-button"]'),
+      );
+
+      expect(deleteButton).toBeFalsy();
+    });
+  });
+});

--- a/apps/desktop/src/vault/app/vault/item-footer.component.ts
+++ b/apps/desktop/src/vault/app/vault/item-footer.component.ts
@@ -128,11 +128,7 @@ export class ItemFooterComponent implements OnInit, OnChanges {
   }
 
   protected get hasFooterAction() {
-    return (
-      this.showArchiveButton ||
-      this.showUnarchiveButton ||
-      (this.cipher.permissions?.delete && (this.action === "edit" || this.action === "view"))
-    );
+    return this.showArchiveButton || this.showUnarchiveButton || this.canDelete;
   }
 
   protected get showCloneOption() {
@@ -143,6 +139,10 @@ export class ItemFooterComponent implements OnInit, OnChanges {
       this.action === "view" &&
       (!this.cipher.isArchived || this.userCanArchive)
     );
+  }
+
+  protected get canDelete() {
+    return this.cipher.permissions?.delete && (this.action === "edit" || this.action === "view");
   }
 
   cancel() {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-32642](https://bitwarden.atlassian.net/browse/PM-32642)

## 📔 Objective

When the archive buttons were introduced the logic to show the right aligned footer actions properly considered the `delete` permissions but the logic wasn't added to hide the individual delete button when the user can not delete a cipher. This is applicable when an organization has the  `Restrict item deletion to members with the Manage Collection permission`

## 📸 Screenshots

|Non-manage collections|Manage collections|
|-|-|
|<video src="https://github.com/user-attachments/assets/c6c789c8-5f32-47da-b11e-7faebb83a17e" />|<video src="https://github.com/user-attachments/assets/cd752f51-bca4-4522-82d8-2bd2f9107e66"/>

[PM-32642]: https://bitwarden.atlassian.net/browse/PM-32642?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ