### PR TITLE
[PM-32643] My Items not default selected on desktop

### DIFF
--- a/apps/desktop/src/vault/app/vault-v3/vault.component.ts
+++ b/apps/desktop/src/vault/app/vault-v3/vault.component.ts
@@ -1009,7 +1009,7 @@ export class VaultComponent implements OnInit, OnDestroy, CopyClickListener {
       ...this.config.initialValues,
       folderId: this.folderId,
       organizationId: this.addOrganizationId as OrganizationId,
-      collectionIds: this.addCollectionIds as CollectionId[],
+      collectionIds: this.addCollectionIds ? (this.addCollectionIds as CollectionId[]) : [],
     };
   }
 

--- a/apps/desktop/src/vault/app/vault/vault-v2.component.ts
+++ b/apps/desktop/src/vault/app/vault/vault-v2.component.ts
@@ -1054,7 +1054,7 @@ export class VaultV2Component<C extends CipherViewLike>
       ...this.config.initialValues,
       organizationId: this.addOrganizationId as OrganizationId,
       folderId: this.folderId,
-      collectionIds: this.addCollectionIds as CollectionId[],
+      collectionIds: this.addCollectionIds ? (this.addCollectionIds as CollectionId[]) : [],
     };
   }
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-32643](https://bitwarden.atlassian.net/browse/PM-32643)

## 📔 Objective

The default value of `addCollectionIds` is `null` and can be passed as such downstream into the cipher form components in the initial values of `collectionIds` on the cipher form configuration. None of the downstream components are expecting `null`. 

## 📸 Screenshots

<video src="https://github.com/user-attachments/assets/7d72b4d0-80f4-4a96-9103-7b4a883a3805" />


[PM-32643]: https://bitwarden.atlassian.net/browse/PM-32643?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ