### PR TITLE
[PM-32595] Cherry-pick: Revert PM-31803 report permission filtering

### DIFF
--- a/apps/web/src/app/dirt/reports/pages/exposed-passwords-report.component.spec.ts
+++ b/apps/web/src/app/dirt/reports/pages/exposed-passwords-report.component.spec.ts
@@ -122,16 +122,19 @@ describe("ExposedPasswordsReportComponent", () => {
     expect(component).toBeTruthy();
   });
 
-  it("should get ciphers with exposed passwords regardless of edit access", async () => {
+  it('should get only ciphers with exposed passwords that the user has "Can Edit" access to', async () => {
+    const expectedIdOne: any = "cbea34a8-bde4-46ad-9d19-b05001228ab2";
+    const expectedIdTwo = "cbea34a8-bde4-46ad-9d19-b05001228cd3";
+
     jest.spyOn(auditService, "passwordLeaked").mockReturnValue(Promise.resolve<any>(1234));
     jest.spyOn(component as any, "getAllCiphers").mockReturnValue(Promise.resolve<any>(cipherData));
     await component.setCiphers();
 
-    const cipherIds = component.ciphers.map((c) => c.id);
-    expect(cipherIds).toContain("cbea34a8-bde4-46ad-9d19-b05001228ab1");
-    expect(cipherIds).toContain("cbea34a8-bde4-46ad-9d19-b05001228ab2");
-    expect(cipherIds).toContain("cbea34a8-bde4-46ad-9d19-b05001228cd3");
-    expect(component.ciphers.length).toEqual(3);
+    expect(component.ciphers.length).toEqual(2);
+    expect(component.ciphers[0].id).toEqual(expectedIdOne);
+    expect(component.ciphers[0].edit).toEqual(true);
+    expect(component.ciphers[1].id).toEqual(expectedIdTwo);
+    expect(component.ciphers[1].edit).toEqual(true);
   });
 
   it("should call fullSync method of syncService", () => {

--- a/apps/web/src/app/dirt/reports/pages/exposed-passwords-report.component.ts
+++ b/apps/web/src/app/dirt/reports/pages/exposed-passwords-report.component.ts
@@ -64,12 +64,14 @@ export class ExposedPasswordsReportComponent extends CipherReportComponent imple
     this.filterStatus = [0];
 
     allCiphers.forEach((ciph) => {
-      const { type, login, isDeleted } = ciph;
+      const { type, login, isDeleted, edit, viewPassword } = ciph;
       if (
         type !== CipherType.Login ||
         login.password == null ||
         login.password === "" ||
-        isDeleted
+        isDeleted ||
+        (!this.organization && !edit) ||
+        !viewPassword
       ) {
         return;
       }

--- a/apps/web/src/app/dirt/reports/pages/inactive-two-factor-report.component.spec.ts
+++ b/apps/web/src/app/dirt/reports/pages/inactive-two-factor-report.component.spec.ts
@@ -95,7 +95,9 @@ describe("InactiveTwoFactorReportComponent", () => {
     expect(component).toBeTruthy();
   });
 
-  it("should get ciphers with domains in the 2fa directory regardless of edit access", async () => {
+  it('should get only ciphers with domains in the 2fa directory that they have "Can Edit" access to', async () => {
+    const expectedIdOne: any = "cbea34a8-bde4-46ad-9d19-b05001228xy4";
+    const expectedIdTwo: any = "cbea34a8-bde4-46ad-9d19-b05001227nm5";
     component.services.set(
       "101domain.com",
       "https://help.101domain.com/account-management/account-security/enabling-disabling-two-factor-verification",
@@ -108,10 +110,11 @@ describe("InactiveTwoFactorReportComponent", () => {
     jest.spyOn(component as any, "getAllCiphers").mockReturnValue(Promise.resolve<any>(cipherData));
     await component.setCiphers();
 
-    const cipherIds = component.ciphers.map((c) => c.id);
-    expect(cipherIds).toContain("cbea34a8-bde4-46ad-9d19-b05001228xy4");
-    expect(cipherIds).toContain("cbea34a8-bde4-46ad-9d19-b05001227nm5");
     expect(component.ciphers.length).toEqual(2);
+    expect(component.ciphers[0].id).toEqual(expectedIdOne);
+    expect(component.ciphers[0].edit).toEqual(true);
+    expect(component.ciphers[1].id).toEqual(expectedIdTwo);
+    expect(component.ciphers[1].edit).toEqual(true);
   });
 
   it("should call fullSync method of syncService", () => {
@@ -194,7 +197,7 @@ describe("InactiveTwoFactorReportComponent", () => {
       expect(doc).toBe("");
     });
 
-    it("should return true for cipher without edit access", () => {
+    it("should return false if cipher does not have edit access and no organization", () => {
       component.organization = null;
       const cipher = createCipherView({
         edit: false,
@@ -203,11 +206,11 @@ describe("InactiveTwoFactorReportComponent", () => {
         },
       });
       const [doc, isInactive] = (component as any).isInactive2faCipher(cipher);
-      expect(isInactive).toBe(true);
-      expect(doc).toBe("https://example.com/2fa-doc");
+      expect(isInactive).toBe(false);
+      expect(doc).toBe("");
     });
 
-    it("should return true for cipher without viewPassword", () => {
+    it("should return false if cipher does not have viewPassword", () => {
       const cipher = createCipherView({
         viewPassword: false,
         login: {
@@ -215,8 +218,8 @@ describe("InactiveTwoFactorReportComponent", () => {
         },
       });
       const [doc, isInactive] = (component as any).isInactive2faCipher(cipher);
-      expect(isInactive).toBe(true);
-      expect(doc).toBe("https://example.com/2fa-doc");
+      expect(isInactive).toBe(false);
+      expect(doc).toBe("");
     });
 
     it("should check all uris and return true if any matches domain or host", () => {

--- a/apps/web/src/app/dirt/reports/pages/inactive-two-factor-report.component.ts
+++ b/apps/web/src/app/dirt/reports/pages/inactive-two-factor-report.component.ts
@@ -92,12 +92,14 @@ export class InactiveTwoFactorReportComponent extends CipherReportComponent impl
     let docFor2fa: string = "";
     let isInactive2faCipher: boolean = false;
 
-    const { type, login, isDeleted } = cipher;
+    const { type, login, isDeleted, edit, viewPassword } = cipher;
     if (
       type !== CipherType.Login ||
       (login.totp != null && login.totp !== "") ||
       !login.hasUris ||
-      isDeleted
+      isDeleted ||
+      (!this.organization && !edit) ||
+      !viewPassword
     ) {
       return [docFor2fa, isInactive2faCipher];
     }

--- a/apps/web/src/app/dirt/reports/pages/reused-passwords-report.component.spec.ts
+++ b/apps/web/src/app/dirt/reports/pages/reused-passwords-report.component.spec.ts
@@ -109,15 +109,17 @@ describe("ReusedPasswordsReportComponent", () => {
     expect(component).toBeTruthy();
   });
 
-  it("should get ciphers with reused passwords regardless of edit access", async () => {
+  it('should get ciphers with reused passwords that the user has "Can Edit" access to', async () => {
+    const expectedIdOne: any = "cbea34a8-bde4-46ad-9d19-b05001228ab2";
+    const expectedIdTwo = "cbea34a8-bde4-46ad-9d19-b05001228cd3";
     jest.spyOn(component as any, "getAllCiphers").mockReturnValue(Promise.resolve<any>(cipherData));
     await component.setCiphers();
 
-    const cipherIds = component.ciphers.map((c) => c.id);
-    expect(cipherIds).toContain("cbea34a8-bde4-46ad-9d19-b05001228ab1");
-    expect(cipherIds).toContain("cbea34a8-bde4-46ad-9d19-b05001228ab2");
-    expect(cipherIds).toContain("cbea34a8-bde4-46ad-9d19-b05001228cd3");
-    expect(component.ciphers.length).toEqual(3);
+    expect(component.ciphers.length).toEqual(2);
+    expect(component.ciphers[0].id).toEqual(expectedIdOne);
+    expect(component.ciphers[0].edit).toEqual(true);
+    expect(component.ciphers[1].id).toEqual(expectedIdTwo);
+    expect(component.ciphers[1].edit).toEqual(true);
   });
 
   it("should call fullSync method of syncService", () => {

--- a/apps/web/src/app/dirt/reports/pages/reused-passwords-report.component.ts
+++ b/apps/web/src/app/dirt/reports/pages/reused-passwords-report.component.ts
@@ -71,12 +71,14 @@ export class ReusedPasswordsReportComponent extends CipherReportComponent implem
     this.filterStatus = [0];
 
     ciphers.forEach((ciph) => {
-      const { type, login, isDeleted } = ciph;
+      const { type, login, isDeleted, edit, viewPassword } = ciph;
       if (
         type !== CipherType.Login ||
         login.password == null ||
         login.password === "" ||
-        isDeleted
+        isDeleted ||
+        (!this.organization && !edit) ||
+        !viewPassword
       ) {
         return;
       }

--- a/apps/web/src/app/dirt/reports/pages/unsecured-websites-report.component.spec.ts
+++ b/apps/web/src/app/dirt/reports/pages/unsecured-websites-report.component.spec.ts
@@ -118,14 +118,17 @@ describe("UnsecuredWebsitesReportComponent", () => {
     expect(component).toBeTruthy();
   });
 
-  it("should get unsecured ciphers regardless of edit access", async () => {
+  it('should get only unsecured ciphers that the user has "Can Edit" access to', async () => {
+    const expectedIdOne: any = "cbea34a8-bde4-46ad-9d19-b05001228ab2";
+    const expectedIdTwo = "cbea34a8-bde4-46ad-9d19-b05001228cd3";
     jest.spyOn(component as any, "getAllCiphers").mockReturnValue(Promise.resolve<any>(cipherData));
     await component.setCiphers();
 
-    const cipherIds = component.ciphers.map((c) => c.id);
-    expect(cipherIds).toContain("cbea34a8-bde4-46ad-9d19-b05001228ab2");
-    expect(cipherIds).toContain("cbea34a8-bde4-46ad-9d19-b05001228cd3");
     expect(component.ciphers.length).toEqual(2);
+    expect(component.ciphers[0].id).toEqual(expectedIdOne);
+    expect(component.ciphers[0].edit).toEqual(true);
+    expect(component.ciphers[1].id).toEqual(expectedIdTwo);
+    expect(component.ciphers[1].edit).toEqual(true);
   });
 
   it("should call fullSync method of syncService", () => {

--- a/apps/web/src/app/dirt/reports/pages/unsecured-websites-report.component.ts
+++ b/apps/web/src/app/dirt/reports/pages/unsecured-websites-report.component.ts
@@ -71,7 +71,12 @@ export class UnsecuredWebsitesReportComponent extends CipherReportComponent impl
    * @param cipher Current cipher with unsecured uri
    */
   private cipherContainsUnsecured(cipher: CipherView): boolean {
-    if (cipher.type !== CipherType.Login || !cipher.login.hasUris || cipher.isDeleted) {
+    if (
+      cipher.type !== CipherType.Login ||
+      !cipher.login.hasUris ||
+      cipher.isDeleted ||
+      (!this.organization && !cipher.edit)
+    ) {
       return false;
     }
 

--- a/apps/web/src/app/dirt/reports/pages/weak-passwords-report.component.spec.ts
+++ b/apps/web/src/app/dirt/reports/pages/weak-passwords-report.component.spec.ts
@@ -114,7 +114,10 @@ describe("WeakPasswordsReportComponent", () => {
     expect(component).toBeTruthy();
   });
 
-  it("should get ciphers with weak passwords regardless of edit access", async () => {
+  it('should get only ciphers with weak passwords that the user has "Can Edit" access to', async () => {
+    const expectedIdOne: any = "cbea34a8-bde4-46ad-9d19-b05001228ab2";
+    const expectedIdTwo = "cbea34a8-bde4-46ad-9d19-b05001228cd3";
+
     jest.spyOn(passwordStrengthService, "getPasswordStrength").mockReturnValue({
       password: "123",
       score: 0,
@@ -122,11 +125,11 @@ describe("WeakPasswordsReportComponent", () => {
     jest.spyOn(component as any, "getAllCiphers").mockReturnValue(Promise.resolve<any>(cipherData));
     await component.setCiphers();
 
-    const cipherIds = component.ciphers.map((c) => c.id);
-    expect(cipherIds).toContain("cbea34a8-bde4-46ad-9d19-b05001228ab1");
-    expect(cipherIds).toContain("cbea34a8-bde4-46ad-9d19-b05001228ab2");
-    expect(cipherIds).toContain("cbea34a8-bde4-46ad-9d19-b05001228cd3");
-    expect(component.ciphers.length).toEqual(3);
+    expect(component.ciphers.length).toEqual(2);
+    expect(component.ciphers[0].id).toEqual(expectedIdOne);
+    expect(component.ciphers[0].edit).toEqual(true);
+    expect(component.ciphers[1].id).toEqual(expectedIdTwo);
+    expect(component.ciphers[1].edit).toEqual(true);
   });
 
   it("should call fullSync method of syncService", () => {

--- a/apps/web/src/app/dirt/reports/pages/weak-passwords-report.component.ts
+++ b/apps/web/src/app/dirt/reports/pages/weak-passwords-report.component.ts
@@ -103,8 +103,15 @@ export class WeakPasswordsReportComponent extends CipherReportComponent implemen
   }
 
   protected determineWeakPasswordScore(ciph: CipherView): ReportResult | null {
-    const { type, login, isDeleted } = ciph;
-    if (type !== CipherType.Login || login.password == null || login.password === "" || isDeleted) {
+    const { type, login, isDeleted, edit, viewPassword } = ciph;
+    if (
+      type !== CipherType.Login ||
+      login.password == null ||
+      login.password === "" ||
+      isDeleted ||
+      (!this.organization && !edit) ||
+      !viewPassword
+    ) {
       return;
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-32595

## 📔 Objective

Cherry-pick of [#19153](https://github.com/bitwarden/clients/pull/19153) into rc.

Reverts the [PM-31803](https://bitwarden.atlassian.net/browse/PM-31803) changes that removed `edit`/`viewPassword` permission checks from five PM report components. Automation tests failed after the original change — the pre-existing behavior was correct.

Original merge commit on main: `bc14512a02`

## 📸 Screenshots

Not applicable — no UI changes.

[PM-31803]: https://bitwarden.atlassian.net/browse/PM-31803?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ