### PR TITLE
[PM-30373] Safari fails to load

### DIFF
--- a/libs/platform/src/util.spec.ts
+++ b/libs/platform/src/util.spec.ts
@@ -17,6 +17,21 @@ describe("urlOriginsMatch", () => {
       "chrome-extension://abc123/popup.html",
       "chrome-extension://abc123/bg.js",
     ],
+    [
+      "safari extension GUID uppercase in suspect",
+      "safari-web-extension://d8726ae3-f81f-4d3a-85a0-64c2cb453e39/",
+      "safari-web-extension://D8726AE3-F81F-4D3A-85A0-64C2CB453E39/",
+    ],
+    [
+      "safari extension GUID uppercase in canonical",
+      "safari-web-extension://D8726AE3-F81F-4D3A-85A0-64C2CB453E39/",
+      "safari-web-extension://d8726ae3-f81f-4d3a-85a0-64c2cb453e39/",
+    ],
+    [
+      "safari extension GUID uppercase on both sides",
+      "safari-web-extension://D8726AE3-F81F-4D3A-85A0-64C2CB453E39/popup.html",
+      "safari-web-extension://D8726AE3-F81F-4D3A-85A0-64C2CB453E39/bg.js",
+    ],
   ])("returns true when %s", (_, canonical, suspect) => {
     expect(urlOriginsMatch(canonical as string | URL, suspect as string | URL)).toBe(true);
   });
@@ -31,6 +46,11 @@ describe("urlOriginsMatch", () => {
       "https://sub.example.com",
     ],
     ["non-special scheme hosts differ", "chrome-extension://abc123/", "chrome-extension://xyz789/"],
+    [
+      "safari extension GUIDs differ (mixed case)",
+      "safari-web-extension://D8726AE3-F81F-4D3A-85A0-64C2CB453E39/",
+      "safari-web-extension://AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE/",
+    ],
   ])("returns false when %s", (_, canonical, suspect) => {
     expect(urlOriginsMatch(canonical, suspect)).toBe(false);
   });

--- a/libs/platform/src/util.ts
+++ b/libs/platform/src/util.ts
@@ -45,9 +45,14 @@ export function urlOriginsMatch(canonical: string | URL, suspect: string | URL):
   const canonicalOrigin = effectiveOrigin(canonicalUrl);
   const suspectOrigin = effectiveOrigin(suspectUrl);
 
-  if (!canonicalOrigin || !suspectOrigin) {
+  // Safari sends the extension GUID in uppercase while the canonical URL is lowercase,
+  // Normalize both to lowercase and trim trailing slashes to avoid browser specific issues.
+  const normalizedCanonicalOrigin = canonicalOrigin?.replace(/\/$/, "").toLowerCase();
+  const normalizedSuspectOrigin = suspectOrigin?.replace(/\/$/, "").toLowerCase();
+
+  if (!normalizedCanonicalOrigin || !normalizedSuspectOrigin) {
     return false;
   }
 
-  return canonicalOrigin === suspectOrigin;
+  return normalizedCanonicalOrigin === normalizedSuspectOrigin;
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-30373](https://bitwarden.atlassian.net/browse/PM-30373)

## 📔 Objective

Safari sends the extension URL in uppercase while the canonical is in lowercase. This causes the comparison to fail and the extension fail to load.

This existed beforehand but was accidentally removed in: https://github.com/bitwarden/clients/pull/19076

## 📸 Screenshots

|Failure|Vault Load|
|-|-|
|<video src="https://github.com/user-attachments/assets/cd433a93-6865-4768-8e80-c4a6949a2833" />|<img width="1734" height="1081" alt="Screenshot 2026-02-24 at 3 51 54 PM" src="https://github.com/user-attachments/assets/3b0b939f-7a25-41ce-be84-6ed2883d8284" />|


[PM-30373]: https://bitwarden.atlassian.net/browse/PM-30373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ