### PR TITLE
[PM-32697] Fix excessive phishing blocklist CDN downloads

### DIFF
--- a/apps/browser/src/dirt/phishing-detection/services/phishing-data.service.spec.ts
+++ b/apps/browser/src/dirt/phishing-detection/services/phishing-data.service.spec.ts
@@ -296,131 +296,159 @@ describe("PhishingDataService", () => {
     });
   });
 
-  describe("phishing meta data updates", () => {
-    it("should not update metadata when no data updates occur", async () => {
-      // Set up existing metadata
-      const existingMeta = {
-        checksum: "existing-checksum",
-        timestamp: Date.now() - 1000, // 1 second ago (not expired)
-        applicationVersion: "1.0.0",
-      };
-      await fakeGlobalStateProvider.get(PHISHING_DOMAINS_META_KEY).update(() => existingMeta);
-
-      // Mock conditions where no update is needed
-      fetchChecksumSpy.mockResolvedValue("existing-checksum"); // Same checksum
-      platformUtilsService.getApplicationVersion.mockResolvedValue("1.0.0"); // Same version
-      const mockResponse = {
-        ok: true,
-        body: {} as ReadableStream,
-      } as Response;
-      apiService.nativeFetch.mockResolvedValue(mockResponse);
-
-      // Trigger background update
-      const result = await firstValueFrom(service["_backgroundUpdate"](existingMeta));
-
-      // Verify metadata was NOT updated (same reference returned)
-      expect(result).toEqual(existingMeta);
-      expect(result?.timestamp).toBe(existingMeta.timestamp);
-
-      // Verify no data updates were performed
-      expect(mockIndexedDbService.saveUrlsFromStream).not.toHaveBeenCalled();
-      expect(mockIndexedDbService.addUrls).not.toHaveBeenCalled();
-    });
-
-    it("should update metadata when full dataset update occurs due to checksum change", async () => {
-      // Set up existing metadata
-      const existingMeta = {
-        checksum: "old-checksum",
+  describe("rate limiting", () => {
+    it("should skip update when last check was within 24h", async () => {
+      const recentMeta = {
+        checksum: "any",
         timestamp: Date.now() - 1000,
         applicationVersion: "1.0.0",
       };
-      await fakeGlobalStateProvider.get(PHISHING_DOMAINS_META_KEY).update(() => existingMeta);
 
-      // Mock conditions for full update
-      fetchChecksumSpy.mockResolvedValue("new-checksum"); // Different checksum
+      const result = await firstValueFrom(service["_backgroundUpdate"](recentMeta));
+
+      expect(result).toEqual(recentMeta);
+      expect(apiService.nativeFetch).not.toHaveBeenCalled();
+      expect(mockIndexedDbService.saveUrlsFromStream).not.toHaveBeenCalled();
+    });
+
+    it("should allow update when last check was over 24h ago", async () => {
+      const expiredMeta = {
+        checksum: "old",
+        timestamp: Date.now() - 25 * 60 * 60 * 1000,
+        applicationVersion: "1.0.0",
+      };
+      await fakeGlobalStateProvider.get(PHISHING_DOMAINS_META_KEY).update(() => expiredMeta);
+
+      fetchChecksumSpy.mockResolvedValue("new-checksum");
       platformUtilsService.getApplicationVersion.mockResolvedValue("1.0.0");
-      const mockResponse = {
+      apiService.nativeFetch.mockResolvedValue({
         ok: true,
         body: {} as ReadableStream,
-      } as Response;
-      apiService.nativeFetch.mockResolvedValue(mockResponse);
+      } as Response);
 
-      // Trigger background update
-      const result = await firstValueFrom(service["_backgroundUpdate"](existingMeta));
+      const result = await firstValueFrom(service["_backgroundUpdate"](expiredMeta));
 
-      // Verify metadata WAS updated with new values
-      expect(result?.checksum).toBe("new-checksum");
-      expect(result?.timestamp).toBeGreaterThan(existingMeta.timestamp);
-
-      // Verify full update was performed
       expect(mockIndexedDbService.saveUrlsFromStream).toHaveBeenCalled();
-      expect(mockIndexedDbService.addUrls).not.toHaveBeenCalled(); // Daily should not run
+      expect(result?.timestamp).toBeGreaterThan(expiredMeta.timestamp);
     });
 
-    it("should update metadata when full dataset update occurs due to version change", async () => {
-      // Set up existing metadata
-      const existingMeta = {
+    it("should allow update on first run with null metadata", async () => {
+      fetchChecksumSpy.mockResolvedValue("first-checksum");
+      platformUtilsService.getApplicationVersion.mockResolvedValue("1.0.0");
+      apiService.nativeFetch.mockResolvedValue({
+        ok: true,
+        body: {} as ReadableStream,
+      } as Response);
+
+      const result = await firstValueFrom(service["_backgroundUpdate"](null));
+
+      expect(mockIndexedDbService.saveUrlsFromStream).toHaveBeenCalled();
+      expect(result?.checksum).toBe("first-checksum");
+    });
+  });
+
+  describe("checksum-based skip", () => {
+    it("should skip CDN download when checksum is unchanged", async () => {
+      const meta = {
         checksum: "same-checksum",
-        timestamp: Date.now() - 1000,
+        timestamp: Date.now() - 25 * 60 * 60 * 1000,
         applicationVersion: "1.0.0",
       };
-      await fakeGlobalStateProvider.get(PHISHING_DOMAINS_META_KEY).update(() => existingMeta);
+      await fakeGlobalStateProvider.get(PHISHING_DOMAINS_META_KEY).update(() => meta);
 
-      // Mock conditions for full update
       fetchChecksumSpy.mockResolvedValue("same-checksum");
-      platformUtilsService.getApplicationVersion.mockResolvedValue("2.0.0"); // Different version
-      const mockResponse = {
-        ok: true,
-        body: {} as ReadableStream,
-      } as Response;
-      apiService.nativeFetch.mockResolvedValue(mockResponse);
+      platformUtilsService.getApplicationVersion.mockResolvedValue("1.0.0");
 
-      // Trigger background update
-      const result = await firstValueFrom(service["_backgroundUpdate"](existingMeta));
+      const result = await firstValueFrom(service["_backgroundUpdate"](meta));
 
-      // Verify metadata WAS updated
-      expect(result?.applicationVersion).toBe("2.0.0");
-      expect(result?.timestamp).toBeGreaterThan(existingMeta.timestamp);
-
-      // Verify full update was performed
-      expect(mockIndexedDbService.saveUrlsFromStream).toHaveBeenCalled();
-      expect(mockIndexedDbService.addUrls).not.toHaveBeenCalled();
+      expect(fetchChecksumSpy).toHaveBeenCalled();
+      expect(mockIndexedDbService.saveUrlsFromStream).not.toHaveBeenCalled();
+      expect(result?.timestamp).toBeGreaterThan(meta.timestamp);
     });
 
-    it("should update metadata when daily update occurs due to cache expiration", async () => {
-      // Set up existing metadata (expired cache)
-      const existingMeta = {
-        checksum: "same-checksum",
-        timestamp: Date.now() - 25 * 60 * 60 * 1000, // 25 hours ago (expired)
+    it("should download when checksum has changed", async () => {
+      const meta = {
+        checksum: "old-checksum",
+        timestamp: Date.now() - 25 * 60 * 60 * 1000,
         applicationVersion: "1.0.0",
       };
-      await fakeGlobalStateProvider.get(PHISHING_DOMAINS_META_KEY).update(() => existingMeta);
+      await fakeGlobalStateProvider.get(PHISHING_DOMAINS_META_KEY).update(() => meta);
 
-      // Mock conditions for daily update only
-      fetchChecksumSpy.mockResolvedValue("same-checksum"); // Same checksum (no full update)
-      platformUtilsService.getApplicationVersion.mockResolvedValue("1.0.0"); // Same version
-      const mockFullResponse = {
+      fetchChecksumSpy.mockResolvedValue("new-checksum");
+      platformUtilsService.getApplicationVersion.mockResolvedValue("1.0.0");
+      apiService.nativeFetch.mockResolvedValue({
         ok: true,
         body: {} as ReadableStream,
-      } as Response;
-      const mockDailyResponse = {
+      } as Response);
+
+      const result = await firstValueFrom(service["_backgroundUpdate"](meta));
+
+      expect(mockIndexedDbService.saveUrlsFromStream).toHaveBeenCalled();
+      expect(result?.checksum).toBe("new-checksum");
+    });
+  });
+
+  describe("update triggers", () => {
+    it("should download full dataset on app version change", async () => {
+      const meta = {
+        checksum: "same",
+        timestamp: Date.now() - 25 * 60 * 60 * 1000,
+        applicationVersion: "1.0.0",
+      };
+      await fakeGlobalStateProvider.get(PHISHING_DOMAINS_META_KEY).update(() => meta);
+
+      fetchChecksumSpy.mockResolvedValue("same");
+      platformUtilsService.getApplicationVersion.mockResolvedValue("2.0.0");
+      apiService.nativeFetch.mockResolvedValue({
         ok: true,
-        text: jest.fn().mockResolvedValue("newdomain.com"),
-      } as unknown as Response;
-      apiService.nativeFetch
-        .mockResolvedValueOnce(mockFullResponse)
-        .mockResolvedValueOnce(mockDailyResponse);
+        body: {} as ReadableStream,
+      } as Response);
 
-      // Trigger background update
-      const result = await firstValueFrom(service["_backgroundUpdate"](existingMeta));
+      const result = await firstValueFrom(service["_backgroundUpdate"](meta));
 
-      // Verify metadata WAS updated
-      expect(result?.timestamp).toBeGreaterThan(existingMeta.timestamp);
-      expect(result?.checksum).toBe("same-checksum");
+      expect(mockIndexedDbService.saveUrlsFromStream).toHaveBeenCalled();
+      expect(result?.applicationVersion).toBe("2.0.0");
+    });
 
-      // Verify only daily update was performed
-      expect(mockIndexedDbService.saveUrlsFromStream).not.toHaveBeenCalled();
-      expect(mockIndexedDbService.addUrls).toHaveBeenCalledWith(["newdomain.com"]);
+    it("should always save metadata with fresh timestamp", async () => {
+      const meta = {
+        checksum: "old",
+        timestamp: Date.now() - 25 * 60 * 60 * 1000,
+        applicationVersion: "1.0.0",
+      };
+      await fakeGlobalStateProvider.get(PHISHING_DOMAINS_META_KEY).update(() => meta);
+
+      fetchChecksumSpy.mockResolvedValue("new");
+      platformUtilsService.getApplicationVersion.mockResolvedValue("1.0.0");
+      apiService.nativeFetch.mockResolvedValue({
+        ok: true,
+        body: {} as ReadableStream,
+      } as Response);
+
+      const result = await firstValueFrom(service["_backgroundUpdate"](meta));
+
+      expect(result?.timestamp).toBeGreaterThan(meta.timestamp);
+      expect(result?.checksum).toBe("new");
+    });
+
+    it("should never invoke daily delta (mechanism removed)", async () => {
+      const meta = {
+        checksum: "same",
+        timestamp: Date.now() - 25 * 60 * 60 * 1000,
+        applicationVersion: "1.0.0",
+      };
+      await fakeGlobalStateProvider.get(PHISHING_DOMAINS_META_KEY).update(() => meta);
+
+      fetchChecksumSpy.mockResolvedValue("different");
+      platformUtilsService.getApplicationVersion.mockResolvedValue("1.0.0");
+      apiService.nativeFetch.mockResolvedValue({
+        ok: true,
+        body: {} as ReadableStream,
+      } as Response);
+
+      await firstValueFrom(service["_backgroundUpdate"](meta));
+
+      expect(mockIndexedDbService.addUrls).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/browser/src/dirt/phishing-detection/services/phishing-data.service.ts
+++ b/apps/browser/src/dirt/phishing-detection/services/phishing-data.service.ts
@@ -344,6 +344,14 @@ export class PhishingDataService {
     // Use defer to restart timer if retry is activated
     return defer(() => {
       const startTime = Date.now();
+
+      if (previous?.timestamp && Date.now() - previous.timestamp < this.UPDATE_INTERVAL_DURATION) {
+        this.logService.debug(
+          `[PhishingDataService] Skipping update — last check was ${Math.round((Date.now() - previous.timestamp) / 1000 / 60)}m ago (interval: ${this.UPDATE_INTERVAL_DURATION / 1000 / 60}m)`,
+        );
+        return of(previous);
+      }
+
       this.logService.info(`[PhishingDataService] Update triggered...`);
 
       // Get updated meta info

--- a/apps/browser/src/dirt/phishing-detection/services/phishing-data.service.ts
+++ b/apps/browser/src/dirt/phishing-detection/services/phishing-data.service.ts
@@ -372,18 +372,6 @@ export class PhishingDataService {
             of({ meta: newMeta, updated: false }),
           ),
         ),
-        // Update daily data set if last update was more than UPDATE_INTERVAL_DURATION ago
-        concatMap((result) =>
-          iif(
-            () => {
-              const isCacheExpired =
-                Date.now() - (previous?.timestamp ?? 0) > this.UPDATE_INTERVAL_DURATION;
-              return isCacheExpired;
-            },
-            this._updateDailyDataSet().pipe(map(() => ({ meta: result.meta, updated: true }))),
-            of(result),
-          ),
-        ),
         concatMap((result) => {
           if (!result.updated) {
             this.logService.debug(`[PhishingDataService] No update needed, metadata unchanged`);

--- a/apps/browser/src/dirt/phishing-detection/services/phishing-data.service.ts
+++ b/apps/browser/src/dirt/phishing-detection/services/phishing-data.service.ts
@@ -102,7 +102,7 @@ export class PhishingDataService {
     startWith(undefined), // Always emit once
     switchMap(() =>
       this._phishingMetaState.state$.pipe(
-        first(), // Only take the first value to avoid an infinite loop when updating the cache below
+        first((meta) => meta !== undefined),
         tap((metaState) => {
           // Perform any updates in the background
           this._backgroundUpdateTrigger$.next(metaState);

--- a/apps/browser/src/dirt/phishing-detection/services/phishing-data.service.ts
+++ b/apps/browser/src/dirt/phishing-detection/services/phishing-data.service.ts
@@ -12,7 +12,7 @@ import {
   Observable,
   of,
   retry,
-  share,
+  shareReplay,
   takeUntil,
   startWith,
   Subject,
@@ -114,7 +114,7 @@ export class PhishingDataService {
       ),
     ),
     takeUntil(this._destroy$),
-    share(),
+    shareReplay({ bufferSize: 1, refCount: false }),
   );
 
   constructor(

--- a/apps/browser/src/dirt/phishing-detection/services/phishing-data.service.ts
+++ b/apps/browser/src/dirt/phishing-detection/services/phishing-data.service.ts
@@ -7,7 +7,6 @@ import {
   first,
   forkJoin,
   from,
-  iif,
   map,
   Observable,
   of,
@@ -354,46 +353,48 @@ export class PhishingDataService {
 
       this.logService.info(`[PhishingDataService] Update triggered...`);
 
-      // Get updated meta info
       return this._getUpdatedMeta().pipe(
-        // Update full data set if application version or checksum changed
-        concatMap((newMeta) =>
-          iif(
-            () => {
-              const appVersionChanged = newMeta.applicationVersion !== previous?.applicationVersion;
-              const checksumChanged = newMeta.checksum !== previous?.checksum;
+        concatMap((newMeta) => {
+          const appVersionChanged = newMeta.applicationVersion !== previous?.applicationVersion;
+          const checksumChanged = newMeta.checksum !== previous?.checksum;
+          const isFirstRun = !previous?.timestamp;
 
-              this.logService.info(
-                `[PhishingDataService] Checking if full update is needed: appVersionChanged=${appVersionChanged}, checksumChanged=${checksumChanged}`,
-              );
-              return appVersionChanged || checksumChanged;
-            },
-            this._updateFullDataSet().pipe(map(() => ({ meta: newMeta, updated: true }))),
-            of({ meta: newMeta, updated: false }),
-          ),
-        ),
-        concatMap((result) => {
-          if (!result.updated) {
-            this.logService.debug(`[PhishingDataService] No update needed, metadata unchanged`);
-            return of(previous);
+          // Download when: first run, app version change, or checksum changed
+          // Skip download when: checksum unchanged (blocklist hasn't been updated)
+          const needsDownload = isFirstRun || appVersionChanged || checksumChanged;
+
+          if (!needsDownload) {
+            this.logService.info(
+              `[PhishingDataService] Checksum unchanged — skipping CDN download`,
+            );
+            return of(newMeta);
           }
 
-          this.logService.debug(`[PhishingDataService] Updated phishing meta data:`, result.meta);
-          return from(this._phishingMetaState.update(() => result.meta)).pipe(
+          this.logService.info(
+            `[PhishingDataService] Downloading: isFirstRun=${isFirstRun}, ` +
+              `appVersionChanged=${appVersionChanged}, checksumChanged=${checksumChanged}`,
+          );
+          return this._updateFullDataSet().pipe(map(() => newMeta));
+        }),
+        // Always save metadata — refreshes timestamp even when download was skipped.
+        // This is critical for the rate-limit guard: a fresh timestamp ensures
+        // subsequent SW restarts within 24h are no-ops.
+        concatMap((meta) => {
+          return from(this._phishingMetaState.update(() => meta)).pipe(
             tap(() => {
               const elapsed = Date.now() - startTime;
-              this.logService.info(`[PhishingDataService] Updated data set in ${elapsed}ms`);
+              this.logService.info(`[PhishingDataService] Update completed in ${elapsed}ms`);
             }),
           );
         }),
         retry({
-          count: 2, // Total 3 attempts (initial + 2 retries)
+          count: 2,
           delay: (error, retryCount) => {
             this.logService.error(
               `[PhishingDataService] Attempt ${retryCount} failed. Retrying in 5m...`,
               error,
             );
-            return timer(5 * 60 * 1000); // Wait 5 mins before next attempt
+            return timer(5 * 60 * 1000);
           },
         }),
         catchError((err: unknown) => {

--- a/apps/browser/src/dirt/phishing-detection/services/phishing-data.service.ts
+++ b/apps/browser/src/dirt/phishing-detection/services/phishing-data.service.ts
@@ -210,7 +210,7 @@ export class PhishingDataService {
   }
 
   // [FIXME] Pull fetches into api service
-  private async fetchPhishingChecksum(type: PhishingResourceType = PhishingResourceType.Domains) {
+  private async fetchPhishingChecksum(type: PhishingResourceType = this.resourceType) {
     const checksumUrl = getPhishingResources(type)!.checksumUrl;
     this.logService.debug(`[PhishingDataService] Fetching checksum from: ${checksumUrl}`);
 
@@ -222,7 +222,8 @@ export class PhishingDataService {
         );
       }
 
-      return await response.text();
+      const text = await response.text();
+      return text.trim();
     } catch (error) {
       this.logService.error(
         `[PhishingDataService] Checksum fetch failed from ${checksumUrl}`,


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-32697

## 📔 Objective

Fix excessive CDN downloads in phishing detection. The browser extension was re-downloading the full phishing blocklist on every MV3 service worker restart instead of once per day. At 5% rollout this was generating 20-25 TB/hour of CDN egress.

### Root cause

The primary root cause was the use of RxJS `iif` in `_backgroundUpdate`. The `iif` operator **eagerly evaluates both branch observables** at subscription time, even though only one branch is subscribed to based on the condition. Since `_updateFullDataSet()` constructs a `Request` and calls `nativeFetch` as part of its observable creation, the CDN fetch was being triggered on every update cycle regardless of whether `checksumChanged` or `appVersionChanged` was true. The same issue affected the `_updateDailyDataSet()` branch.

This is resolved in commit [`1bed3a3`](https://github.com/bitwarden/clients/commit/1bed3a393d) which replaces `iif` with `if/else` inside `concatMap`, ensuring the fetch observables are only created when the conditions are met.

### Additional issues addressed

Beyond the `iif` root cause, several other issues compounded the excessive download frequency:

1. **No rate limit** — `_backgroundUpdate` had no guard preventing repeated runs. Every MV3 service worker restart triggered a full update cycle.
2. **Metadata race condition** — `first()` could read `undefined` before the persisted disk value loaded via `chrome.storage.local`, causing the service to treat every restart as a first-run scenario.
3. **`share()` reset on re-subscription** — lock/unlock and account switch caused `phishingDetectionActive$` to toggle, resetting `share()` and firing `startWith(undefined)` again.
4. **Stale daily delta** — The `todayUrl` (`phishing-links-NEW-today.txt`) hasn't been updated in ~2 months, making `_updateDailyDataSet()` dead code that fetched a stale file on every cycle.
5. **Metadata not always saved** — The timestamp was only persisted when data was actually downloaded, leaving it stale in code paths where no download occurred.

### Fixes (by commit)

1. [`1d9c94d`](https://github.com/bitwarden/clients/commit/1d9c94db9c) — Add 24h rate-limit guard at top of `_backgroundUpdate`
2. [`b4bd6e1`](https://github.com/bitwarden/clients/commit/b4bd6e1305) — Wait for persisted state before reading metadata (`first(meta => meta !== undefined)`)
3. [`4116a29`](https://github.com/bitwarden/clients/commit/4116a2969f) — Replace `share()` with `shareReplay({ bufferSize: 1, refCount: false })`
4. [`f3c2989`](https://github.com/bitwarden/clients/commit/f3c2989eeb) — Remove stale daily delta mechanism from pipeline
5. [`1bed3a3`](https://github.com/bitwarden/clients/commit/1bed3a393d) — Replace `iif` with `if/else` inside `concatMap` (fixes the primary root cause); simplify pipeline; always save metadata; use checksum to skip CDN download on quiet days
6. [`05ef70d`](https://github.com/bitwarden/clients/commit/05ef70df9f) — Trim checksum response whitespace, fix `fetchPhishingChecksum` default parameter
7. [`49f1728`](https://github.com/bitwarden/clients/commit/49f1728fca) — Rewrite tests for new update logic

## 📸 Screenshots

Not applicable — no UI changes.