### PR TITLE
[PM-31198] Call setCommunicationType when ConfigService.serverCommunicationConfi…

### DIFF
--- a/libs/angular/src/services/jslib-services.module.ts
+++ b/libs/angular/src/services/jslib-services.module.ts
@@ -1307,7 +1307,11 @@ const safeProviders: SafeProvider[] = [
   safeProvider({
     provide: ServerCommunicationConfigService,
     useClass: DefaultServerCommunicationConfigService,
-    deps: [ServerCommunicationConfigRepository, NoopServerCommunicationConfigPlatformApiService],
+    deps: [
+      ServerCommunicationConfigRepository,
+      NoopServerCommunicationConfigPlatformApiService,
+      ConfigService,
+    ],
   }),
   safeProvider({
     provide: DefaultConfigService,

--- a/libs/common/src/platform/services/server-communication-config/default-server-communication-config.service.spec.ts
+++ b/libs/common/src/platform/services/server-communication-config/default-server-communication-config.service.spec.ts
@@ -1,4 +1,4 @@
-import { firstValueFrom } from "rxjs";
+import { firstValueFrom, of } from "rxjs";
 
 import {
   ServerCommunicationConfig,
@@ -6,6 +6,7 @@ import {
 } from "@bitwarden/sdk-internal";
 
 import { awaitAsync, FakeAccountService, FakeStateProvider } from "../../../../spec";
+import { ConfigService } from "../../abstractions/config/config.service";
 
 import { DefaultServerCommunicationConfigService } from "./default-server-communication-config.service";
 import { ServerCommunicationConfigRepository } from "./server-communication-config.repository";
@@ -22,6 +23,7 @@ jest.mock("@bitwarden/sdk-internal", () => ({
   ServerCommunicationConfigClient: jest.fn().mockImplementation(() => ({
     needsBootstrap: jest.fn(),
     cookies: jest.fn(),
+    setCommunicationType: jest.fn(),
   })),
 }));
 
@@ -29,6 +31,7 @@ describe("DefaultServerCommunicationConfigService", () => {
   let stateProvider: FakeStateProvider;
   let repository: ServerCommunicationConfigRepository;
   let mockPlatformApi: ServerCommunicationConfigPlatformApi;
+  let mockConfigService: jest.Mocked<Pick<ConfigService, "serverCommunicationConfig$">>;
   let service: DefaultServerCommunicationConfigService;
   let mockClient: any;
 
@@ -42,30 +45,38 @@ describe("DefaultServerCommunicationConfigService", () => {
       acquireCookies: jest.fn(),
     };
 
-    service = new DefaultServerCommunicationConfigService(repository, mockPlatformApi);
+    mockConfigService = {
+      serverCommunicationConfig$: of(),
+    };
+
+    service = new DefaultServerCommunicationConfigService(
+      repository,
+      mockPlatformApi,
+      mockConfigService as unknown as ConfigService,
+    );
     await service.init();
     mockClient = (service as any).client;
   });
 
-  // describe("init", () => {
-  //   it("calls setCommunicationType for each emission on serverCommunicationConfig$", async () => {
-  //     const config: ServerCommunicationConfig = { bootstrap: { type: "direct" } };
-  //     mockConfigService.serverCommunicationConfig$ = of({
-  //       hostname: "https://api.example.com",
-  //       config,
-  //     });
+  describe("init", () => {
+    it("calls setCommunicationType for each emission on serverCommunicationConfig$", async () => {
+      const config: ServerCommunicationConfig = { bootstrap: { type: "direct" } };
+      mockConfigService.serverCommunicationConfig$ = of({
+        hostname: "https://api.example.com",
+        config,
+      });
 
-  //     await service.init();
-  //     mockClient = (service as any).client;
+      await service.init();
+      mockClient = (service as any).client;
 
-  //     await awaitAsync();
+      await awaitAsync();
 
-  //     expect(mockClient.setCommunicationType).toHaveBeenCalledWith(
-  //       "https://api.example.com",
-  //       config,
-  //     );
-  //   });
-  // });
+      expect(mockClient.setCommunicationType).toHaveBeenCalledWith(
+        "https://api.example.com",
+        config,
+      );
+    });
+  });
 
   describe("needsBootstrap$", () => {
     it("emits false when direct bootstrap configured", async () => {

--- a/libs/common/src/platform/services/server-communication-config/default-server-communication-config.service.ts
+++ b/libs/common/src/platform/services/server-communication-config/default-server-communication-config.service.ts
@@ -5,6 +5,7 @@ import {
   ServerCommunicationConfigPlatformApi,
 } from "@bitwarden/sdk-internal";
 
+import { ConfigService } from "../../abstractions/config/config.service";
 import { SdkLoadService } from "../../abstractions/sdk/sdk-load.service";
 import { ServerCommunicationConfigService } from "../../abstractions/server-communication-config/server-communication-config.service";
 
@@ -35,6 +36,7 @@ export class DefaultServerCommunicationConfigService implements ServerCommunicat
   constructor(
     protected repository: ServerCommunicationConfigRepository,
     protected platformApi: ServerCommunicationConfigPlatformApi,
+    private configService: ConfigService,
   ) {}
 
   async init() {
@@ -42,6 +44,10 @@ export class DefaultServerCommunicationConfigService implements ServerCommunicat
     await SdkLoadService.Ready;
     // Initialize SDK client with repository and platform API
     this.client = new ServerCommunicationConfigClient(this.repository, this.platformApi);
+    // Forward each server communication config update to the SDK client
+    this.configService.serverCommunicationConfig$.subscribe(({ hostname, config }) => {
+      void this.client.setCommunicationType(hostname, config);
+    });
   }
 
   needsBootstrap$(hostname: string): Observable<boolean> {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-31198

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This is a stacked PR and these changes won't go straight to `main`, but will merge into the feature branch: `ps/pm-29149/add-server-communication-config-service`

With https://github.com/bitwarden/clients/pull/19184 I introduced the `serverCommunicationConfig$` observable on the ConfigService, which is now being subscribed to in the `DefaultServerCommunicationConfigService`.
Now whenever the server has a bootstrap configuration, it will emit via the `serverCommunicationConfig$`and that information is passed on to the SDK via the `setCommunicationType`-method of the `ServerCommunicationConfigClient`