### PR TITLE
[Client] Fix excessive asset fetching in phishing detection pipeline

### DIFF
--- a/apps/browser/src/dirt/phishing-detection/services/phishing-data.service.spec.ts
+++ b/apps/browser/src/dirt/phishing-detection/services/phishing-data.service.spec.ts
@@ -41,9 +41,9 @@ describe("PhishingDataService", () => {
     mockIndexedDbService.hasUrl.mockResolvedValue(false);
     mockIndexedDbService.loadAllUrls.mockResolvedValue([]);
     mockIndexedDbService.findMatchingUrl.mockResolvedValue(false);
-    mockIndexedDbService.saveUrls.mockResolvedValue(undefined);
-    mockIndexedDbService.addUrls.mockResolvedValue(undefined);
-    mockIndexedDbService.saveUrlsFromStream.mockResolvedValue(undefined);
+    mockIndexedDbService.saveUrls.mockResolvedValue(true);
+    mockIndexedDbService.addUrls.mockResolvedValue(true);
+    mockIndexedDbService.saveUrlsFromStream.mockResolvedValue(true);
 
     platformUtilsService = mock<PlatformUtilsService>();
     platformUtilsService.getApplicationVersion.mockResolvedValue("1.0.0");
@@ -309,11 +309,6 @@ describe("PhishingDataService", () => {
       // Mock conditions where no update is needed
       fetchChecksumSpy.mockResolvedValue("existing-checksum"); // Same checksum
       platformUtilsService.getApplicationVersion.mockResolvedValue("1.0.0"); // Same version
-      const mockResponse = {
-        ok: true,
-        body: {} as ReadableStream,
-      } as Response;
-      apiService.nativeFetch.mockResolvedValue(mockResponse);
 
       // Trigger background update
       const result = await firstValueFrom(service["_backgroundUpdate"](existingMeta));
@@ -322,7 +317,8 @@ describe("PhishingDataService", () => {
       expect(result).toEqual(existingMeta);
       expect(result?.timestamp).toBe(existingMeta.timestamp);
 
-      // Verify no data updates were performed
+      // Verify no fetches or data updates were performed
+      expect(apiService.nativeFetch).not.toHaveBeenCalled();
       expect(mockIndexedDbService.saveUrlsFromStream).not.toHaveBeenCalled();
       expect(mockIndexedDbService.addUrls).not.toHaveBeenCalled();
     });
@@ -399,17 +395,11 @@ describe("PhishingDataService", () => {
       // Mock conditions for daily update only
       fetchChecksumSpy.mockResolvedValue("same-checksum"); // Same checksum (no full update)
       platformUtilsService.getApplicationVersion.mockResolvedValue("1.0.0"); // Same version
-      const mockFullResponse = {
-        ok: true,
-        body: {} as ReadableStream,
-      } as Response;
       const mockDailyResponse = {
         ok: true,
         text: jest.fn().mockResolvedValue("newdomain.com"),
       } as unknown as Response;
-      apiService.nativeFetch
-        .mockResolvedValueOnce(mockFullResponse)
-        .mockResolvedValueOnce(mockDailyResponse);
+      apiService.nativeFetch.mockResolvedValue(mockDailyResponse);
 
       // Trigger background update
       const result = await firstValueFrom(service["_backgroundUpdate"](existingMeta));

--- a/apps/browser/src/dirt/phishing-detection/services/phishing-data.service.ts
+++ b/apps/browser/src/dirt/phishing-detection/services/phishing-data.service.ts
@@ -7,7 +7,6 @@ import {
   first,
   forkJoin,
   from,
-  iif,
   map,
   Observable,
   of,
@@ -345,37 +344,38 @@ export class PhishingDataService {
     return defer(() => {
       const startTime = Date.now();
       this.logService.info(`[PhishingDataService] Update triggered...`);
+      this.logService.debug("[PhishingDataService] Previous metadata state:", previous);
 
       // Get updated meta info
       return this._getUpdatedMeta().pipe(
         // Update full data set if application version or checksum changed
-        concatMap((newMeta) =>
-          iif(
-            () => {
-              const appVersionChanged = newMeta.applicationVersion !== previous?.applicationVersion;
-              const checksumChanged = newMeta.checksum !== previous?.checksum;
+        concatMap((newMeta) => {
+          const appVersionChanged = newMeta.applicationVersion !== previous?.applicationVersion;
+          const checksumChanged = newMeta.checksum !== previous?.checksum;
 
-              this.logService.info(
-                `[PhishingDataService] Checking if full update is needed: appVersionChanged=${appVersionChanged}, checksumChanged=${checksumChanged}`,
-              );
-              return appVersionChanged || checksumChanged;
-            },
-            this._updateFullDataSet().pipe(map(() => ({ meta: newMeta, updated: true }))),
-            of({ meta: newMeta, updated: false }),
-          ),
-        ),
+          this.logService.info(
+            `[PhishingDataService] Checking if full update is needed: appVersionChanged=${appVersionChanged}, checksumChanged=${checksumChanged}`,
+          );
+
+          if (appVersionChanged || checksumChanged) {
+            return this._updateFullDataSet().pipe(map(() => ({ meta: newMeta, updated: true })));
+          }
+
+          return of({ meta: newMeta, updated: false });
+        }),
         // Update daily data set if last update was more than UPDATE_INTERVAL_DURATION ago
-        concatMap((result) =>
-          iif(
-            () => {
-              const isCacheExpired =
-                Date.now() - (previous?.timestamp ?? 0) > this.UPDATE_INTERVAL_DURATION;
-              return isCacheExpired;
-            },
-            this._updateDailyDataSet().pipe(map(() => ({ meta: result.meta, updated: true }))),
-            of(result),
-          ),
-        ),
+        concatMap((result) => {
+          const isCacheExpired =
+            Date.now() - (previous?.timestamp ?? 0) > this.UPDATE_INTERVAL_DURATION;
+
+          if (isCacheExpired) {
+            return this._updateDailyDataSet().pipe(
+              map(() => ({ meta: result.meta, updated: true })),
+            );
+          }
+
+          return of(result);
+        }),
         concatMap((result) => {
           if (!result.updated) {
             this.logService.debug(`[PhishingDataService] No update needed, metadata unchanged`);


### PR DESCRIPTION
## 🎟️ Tracking

[PM-32724](https://bitwarden.atlassian.net/browse/PM-32724)

## 📔 Objective

Change usage of `iif` to `concatMap` with a factory function to only run the api fetch when needed.

This fixes excessive downloading of the full active links list from assets.bitwarden.com

## 📸 Screenshots

Screenshot shows in the network tab on reloading the extension NOT downloading the full file from assets.bitwarden.com. 

<img width="1285" height="303" alt="Screenshot 2026-02-25 at 9 26 53 AM" src="https://github.com/user-attachments/assets/9a669f66-4a35-4caa-a116-b6d059a56d76" />

Screenshot to be added: Showing the full download file when metadata is available before the bug fix.

[PM-32724]: https://bitwarden.atlassian.net/browse/PM-32724?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ