### PR TITLE
[PM-32728] Attachments edit permissions for Vaultv3

### DIFF
--- a/apps/desktop/src/vault/app/vault-v3/vault.component.ts
+++ b/apps/desktop/src/vault/app/vault-v3/vault.component.ts
@@ -501,6 +501,7 @@ export class VaultComponent implements OnInit, OnDestroy, CopyClickListener {
     }
     const dialogRef = AttachmentsV2Component.open(this.dialogService, {
       cipherId: this.cipherId as CipherId,
+      canEditCipher: this.cipher().edit,
     });
     const result = await firstValueFrom(dialogRef.closed).catch((): any => null);
     if (


### PR DESCRIPTION
## 🎟️ Tracking

[PM-32728](https://bitwarden.atlassian.net/browse/PM-32728)

## 📔 Objective

The `canEditCipher` param was not being passed to the attachments dialog on the `v3` vault. This property controls the dialog text of Closed vs Upload. 

Doubled checked all other instances:
- [Desktop Vault v2](https://github.com/bitwarden/clients/blob/dbb5f9d5ce046ffd659b727d4895701e3b3f58d1/apps/desktop/src/vault/app/vault/vault-v2.component.ts#L523)
- [Web VaultItemDialog](https://github.com/bitwarden/clients/blob/dbb5f9d5ce046ffd659b727d4895701e3b3f58d1/apps/web/src/app/vault/components/vault-item-dialog/vault-item-dialog.component.ts#L535)
- [Web Vault](https://github.com/bitwarden/clients/blob/dbb5f9d5ce046ffd659b727d4895701e3b3f58d1/apps/web/src/app/vault/individual-vault/vault.component.ts#L905)

## 📸 Screenshots

|Before|After|
|-|-|
|<img width="1659" height="1089" alt="Screenshot 2026-02-25 at 10 16 32 AM" src="https://github.com/user-attachments/assets/154bd5c5-9169-4f8b-9c2e-40896e08a803" />|<video src="https://github.com/user-attachments/assets/43aa1abf-a8d6-4a81-9051-0744394f9d28" />


[PM-32728]: https://bitwarden.atlassian.net/browse/PM-32728?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ