### PR TITLE
Fix TimePeriod type errors in TrendWidget stories

### DIFF
--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/activity/trend-widget/trend-widget.stories.ts
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/activity/trend-widget/trend-widget.stories.ts
@@ -14,6 +14,8 @@ import { ThemeStateService } from "@bitwarden/common/platform/theming/theme-stat
 import { IconButtonModule } from "@bitwarden/components";
 import { PreloadedEnglishI18nModule } from "@bitwarden/web-vault/app/core/tests";
 
+import { TimePeriod } from "../period-selector/period-selector.types";
+
 import { TrendWidgetComponent } from "./trend-widget.component";
 
 // Create shared theme observables that will be updated by the decorator
@@ -54,7 +56,7 @@ export default {
   ],
   args: {
     data: {
-      timeframe: "past-month",
+      timeframe: TimePeriod.PastMonth,
       dataView: "applications",
       dataPoints: [
         { timestamp: "2026-02-13T00:00:00Z", atRisk: 38, total: 165 },
@@ -109,7 +111,7 @@ type Story = StoryObj<TrendWidgetComponent>;
 export const Default: Story = {
   args: {
     data: {
-      timeframe: "past-month",
+      timeframe: TimePeriod.PastMonth,
       dataView: "applications",
       dataPoints: [
         { timestamp: "2026-02-13T00:00:00Z", atRisk: 38, total: 165 },
@@ -131,7 +133,7 @@ export const Default: Story = {
 export const EmptyState: Story = {
   args: {
     data: {
-      timeframe: "past-month",
+      timeframe: TimePeriod.PastMonth,
       dataView: "applications",
       dataPoints: [],
     },
@@ -146,7 +148,7 @@ export const EmptyState: Story = {
 export const Loading: Story = {
   args: {
     data: {
-      timeframe: "past-month",
+      timeframe: TimePeriod.PastMonth,
       dataView: "applications",
       dataPoints: [],
     },
@@ -161,7 +163,7 @@ export const Loading: Story = {
 export const Error: Story = {
   args: {
     data: {
-      timeframe: "past-month",
+      timeframe: TimePeriod.PastMonth,
       dataView: "applications",
       dataPoints: [],
     },
@@ -176,7 +178,7 @@ export const Error: Story = {
 export const SingleDataPoint: Story = {
   args: {
     data: {
-      timeframe: "past-month",
+      timeframe: TimePeriod.PastMonth,
       dataView: "passwords",
       dataPoints: [{ timestamp: "2026-02-18T00:00:00Z", atRisk: 45, total: 180 }],
     },
@@ -191,7 +193,7 @@ export const SingleDataPoint: Story = {
 export const TwoDataPoints: Story = {
   args: {
     data: {
-      timeframe: "past-month",
+      timeframe: TimePeriod.PastMonth,
       dataView: "passwords",
       dataPoints: [
         { timestamp: "2026-02-18T00:00:00Z", atRisk: 45, total: 180 },
@@ -209,7 +211,7 @@ export const TwoDataPoints: Story = {
 export const TwentyFourDataPoints: Story = {
   args: {
     data: {
-      timeframe: "past-month",
+      timeframe: TimePeriod.PastMonth,
       dataView: "members",
       dataPoints: [
         { timestamp: "2026-01-20T00:00:00Z", atRisk: 120, total: 450 },


### PR DESCRIPTION
## 🎟️ Tracking

n/a, milestone 9: [PM-26961](https://bitwarden.atlassian.net/browse/PM-26961)

## 📔 Objective

Fix 8 strict TypeScript errors in the TrendWidget Storybook stories file. The stories used invalid `"past-month"` string literals for the `timeframe` field, but the `TimePeriod` type expects `"month"` (via `TimePeriod.PastMonth`). This replaces all occurrences with the correct constant.

### Note on pre-existing lint errors
The repo-wide ESLint run surfaces 206 errors and 696 warnings, but none are in files changed by the M9 TrendWidget branch. They are pre-existing issues in other teams' code (e.g., `import/no-restricted-paths` violations in `libs/vault`, `libs/tools`, and `no-bwi-class-usage` warnings across various components). These are unrelated to the DIRT team or the M9 widget work.

## 📸 Screenshots

<!-- No UI changes -->

[PM-26961]: https://bitwarden.atlassian.net/browse/PM-26961?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ