### PR TITLE
Add Chart.js packages to DIRT team owned deps

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -355,6 +355,12 @@
       commitMessagePrefix: "[deps] KM:",
       reviewers: ["team:team-key-management-dev"],
     },
+    {
+      matchPackageNames: ["chart.js", "chartjs-adapter-date-fns"],
+      description: "DIRT owned dependencies",
+      commitMessagePrefix: "[deps] DIRT:",
+      reviewers: ["team:team-data-insights-and-reporting-dev"],
+    },
 
     // ==================== Grouping Rules ====================
     // These come after any specific team assignment rules to ensure


### PR DESCRIPTION
This changes will fix the linting error on the feature branch. All packages must be assigned team ownership in the `renovate.json5` file