### PR TITLE
disable claude attribution

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,8 @@
 {
+  "attribution": {
+    "commit": "",
+    "pr": ""
+  },
   "extraKnownMarketplaces": {
     "bitwarden-marketplace": {
       "source": {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-32790

## 📔 Objective

Disable attribution messages output by Claude when it commits or writes a PR.