### PR TITLE
[PM-32612] Revise logic around when Subscription menu option shows for Premium

### DIFF
--- a/apps/web/src/app/billing/individual/premium/cloud-hosted-premium.component.html
+++ b/apps/web/src/app/billing/individual/premium/cloud-hosted-premium.component.html
@@ -1,5 +1,5 @@
 <div class="tw-max-w-3xl tw-mx-auto">
-  <bit-section *ngIf="shouldShowNewDesign$ | async">
+  <bit-section>
     <div class="tw-text-center">
       <div class="tw-mt-8 tw-mb-6">
         <span bitBadge variant="secondary" [truncate]="false">

--- a/apps/web/src/app/billing/individual/premium/cloud-hosted-premium.component.ts
+++ b/apps/web/src/app/billing/individual/premium/cloud-hosted-premium.component.ts
@@ -71,7 +71,6 @@ export class CloudHostedPremiumComponent {
   protected hasPremiumFromAnyOrganization$: Observable<boolean>;
   protected hasPremiumPersonally$: Observable<boolean>;
   protected hasSubscription$: Observable<boolean>;
-  protected shouldShowNewDesign$: Observable<boolean>;
   protected shouldShowUpgradeDialogOnInit$: Observable<boolean>;
   protected personalPricingTiers$: Observable<PersonalSubscriptionPricingTier[]>;
   protected premiumCardData$: Observable<{
@@ -131,25 +130,15 @@ export class CloudHostedPremiumComponent {
         this.subscriber = subscriber;
       });
 
-    this.shouldShowNewDesign$ = combineLatest([
-      this.hasPremiumFromAnyOrganization$,
-      this.hasPremiumPersonally$,
-    ]).pipe(map(([hasOrgPremium, hasPersonalPremium]) => !hasOrgPremium && !hasPersonalPremium));
-
-    // redirect to user subscription page if they already have premium personally
-    // redirect to individual vault if they already have premium from an org
-    combineLatest([
-      this.hasPremiumFromAnyOrganization$,
-      this.hasPremiumPersonally$,
-      this.hasSubscription$,
-    ])
+    combineLatest([this.hasSubscription$, this.hasPremiumFromAnyOrganization$])
       .pipe(
         takeUntilDestroyed(this.destroyRef),
-        switchMap(([hasPremiumFromOrg, hasPremiumPersonally, hasSubscription]) => {
-          if (hasPremiumPersonally && hasSubscription) {
+        take(1),
+        switchMap(([hasSubscription, hasPremiumFromAnyOrganization]) => {
+          if (hasSubscription) {
             return from(this.navigateToSubscriptionPage());
           }
-          if (hasPremiumFromOrg) {
+          if (hasPremiumFromAnyOrganization) {
             return from(this.navigateToIndividualVault());
           }
           return of(true);

--- a/apps/web/src/app/billing/individual/subscription.component.html
+++ b/apps/web/src/app/billing/individual/subscription.component.html
@@ -1,9 +1,10 @@
 <app-header>
   @if (!selfHosted) {
     <bit-tab-nav-bar slot="tabs">
-      <bit-tab-link [route]="(hasPremium$ | async) ? 'user-subscription' : 'premium'">{{
-        "subscription" | i18n
-      }}</bit-tab-link>
+      <bit-tab-link
+        [route]="(showSubscriptionPageLink$ | async) ? 'user-subscription' : 'premium'"
+        >{{ "subscription" | i18n }}</bit-tab-link
+      >
       <bit-tab-link route="payment-details">{{ "paymentDetails" | i18n }}</bit-tab-link>
       <bit-tab-link route="billing-history">{{ "billingHistory" | i18n }}</bit-tab-link>
     </bit-tab-nav-bar>

--- a/apps/web/src/app/billing/individual/subscription.component.ts
+++ b/apps/web/src/app/billing/individual/subscription.component.ts
@@ -19,7 +19,7 @@ import { AccountBillingClient } from "../clients/account-billing.client";
   providers: [AccountBillingClient],
 })
 export class SubscriptionComponent implements OnInit {
-  hasPremium$: Observable<boolean>;
+  showSubscriptionPageLink$: Observable<boolean>;
   selfHosted: boolean;
 
   constructor(
@@ -27,9 +27,9 @@ export class SubscriptionComponent implements OnInit {
     billingAccountProfileStateService: BillingAccountProfileStateService,
     accountService: AccountService,
     configService: ConfigService,
-    private accountBillingClient: AccountBillingClient,
+    accountBillingClient: AccountBillingClient,
   ) {
-    this.hasPremium$ = combineLatest([
+    this.showSubscriptionPageLink$ = combineLatest([
       configService.getFeatureFlag$(FeatureFlag.PM29594_UpdateIndividualSubscriptionPage),
       accountService.activeAccount$,
     ]).pipe(

--- a/apps/web/src/app/layouts/user-layout.component.html
+++ b/apps/web/src/app/layouts/user-layout.component.html
@@ -20,11 +20,10 @@
       } @else {
         <bit-nav-item [text]="'preferences' | i18n" route="settings/preferences"></bit-nav-item>
       }
-      <bit-nav-item
-        [text]="'subscription' | i18n"
-        route="settings/subscription"
-        *ngIf="showSubscription$ | async"
-      ></bit-nav-item>
+      @let subscriptionRoute = subscriptionRoute$ | async;
+      @if (subscriptionRoute) {
+        <bit-nav-item [text]="'subscription' | i18n" [route]="subscriptionRoute"></bit-nav-item>
+      }
       <bit-nav-item [text]="'domainRules' | i18n" route="settings/domain-rules"></bit-nav-item>
       @if (showEmergencyAccess()) {
         <bit-nav-item


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-32612

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Follow-up to PR #19209. Revises how the Subscription nav link and subscription-related redirects behave across the billing UI.

### Changes

**`user-layout.component.ts` / `.html`** — Replaced the separate `showSubscription$` boolean and static `"settings/subscription"` route with a single `subscriptionRoute$` observable that returns the correct child route (`user-subscription` or `premium`) or `null` to hide the link. Removed the `hasPremiumPersonally$` dependency — visibility now depends only on `hasPremiumFromAnyOrganization$` and `hasSubscription$`. Free users without a subscription now see the nav link (routing them to the premium upgrade page).

**`cloud-hosted-premium.component.ts` / `.html`** — Simplified the redirect logic from a three-observable `combineLatest` to two (`hasSubscription$` + `hasPremiumFromAnyOrganization$`). The redirect now fires once on init via `take(1)` instead of re-evaluating on every emission. Removed `shouldShowNewDesign$` — the premium page content renders unconditionally.

**`account-subscription.component.ts`** — Added `hasPremiumFromAnyOrganization` signal so the resource loader can redirect org-premium users without a subscription to `/vault` instead of the premium upgrade page. Moved `hasPremiumFromAnyOrganization` out of the resource `params` (read inside the loader instead) to avoid unnecessary re-fetching when the signal resolves. Made `account` a reactive param so the resource correctly re-fetches on account changes.

**`subscription.component.ts` / `.html`** — Renamed `hasPremium$` to `showSubscriptionPageLink$` for clarity. Removed unnecessary `private` modifier on `accountBillingClient`.