### PR TITLE
[PM-32160] Web uses shared Send list component, move functionality in…

### DIFF
--- a/apps/desktop/src/app/tools/send-v2/send-v2.component.html
+++ b/apps/desktop/src/app/tools/send-v2/send-v2.component.html
@@ -18,6 +18,7 @@
       (copySend)="onCopySend($event)"
       (deleteSend)="onDeleteSend($event)"
       (removePassword)="onRemovePassword($event)"
+      [showSearchFilters]="false"
     >
       <tools-new-send-dropdown-v2
         slot="empty-button"
@@ -34,8 +35,13 @@
       <!-- Header with Send title and New button -->
       <app-header class="tw-block tw-pt-6 tw-px-6">
         @if (!disableSend()) {
-          <button type="button" bitButton buttonType="primary" (click)="addSendWithoutType()">
-            <i class="bwi bwi-plus" aria-hidden="true"></i>
+          <button
+            type="button"
+            bitButton
+            startIcon="bwi-plus"
+            buttonType="primary"
+            (click)="addSendWithoutType()"
+          >
             {{ "new" | i18n }}
           </button>
         }
@@ -52,6 +58,7 @@
           (copySend)="onCopySend($event)"
           (deleteSend)="onDeleteSend($event)"
           (removePassword)="onRemovePassword($event)"
+          [showSearchFilters]="false"
         >
           <button
             slot="empty-button"

--- a/apps/desktop/src/app/tools/send-v2/send-v2.component.spec.ts
+++ b/apps/desktop/src/app/tools/send-v2/send-v2.component.spec.ts
@@ -86,6 +86,7 @@ describe("SendV2Component", () => {
 
     // Mock SendListFiltersService
     sendListFiltersService = mock<SendListFiltersService>();
+    sendListFiltersService.filters$ = of({ sendType: null });
 
     // Mock sendViews$ observable
     sendService.sendViews$ = of([]);

--- a/apps/desktop/src/app/tools/send-v2/send-v2.component.ts
+++ b/apps/desktop/src/app/tools/send-v2/send-v2.component.ts
@@ -1,31 +1,21 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
 import { Component, computed, DestroyRef, inject, signal, viewChild } from "@angular/core";
-import { toSignal } from "@angular/core/rxjs-interop";
-import { combineLatest, map, switchMap, lastValueFrom } from "rxjs";
+import { takeUntilDestroyed, toSignal } from "@angular/core/rxjs-interop";
+import { lastValueFrom } from "rxjs";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
-import { PolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
-import { PolicyType } from "@bitwarden/common/admin-console/enums";
-import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
-import { getUserId } from "@bitwarden/common/auth/services/account.service";
+import { SendComponent as BaseSendComponent } from "@bitwarden/angular/tools/send/send.component";
 import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
-import { EnvironmentService } from "@bitwarden/common/platform/abstractions/environment.service";
-import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
-import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
-import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { SendView } from "@bitwarden/common/tools/send/models/view/send.view";
-import { SendApiService } from "@bitwarden/common/tools/send/services/send-api.service.abstraction";
 import { SendType } from "@bitwarden/common/tools/send/types/send-type";
 import { SendId } from "@bitwarden/common/types/guid";
 import { PremiumUpgradePromptService } from "@bitwarden/common/vault/abstractions/premium-upgrade-prompt.service";
-import { ButtonModule, DialogRef, DialogService, ToastService } from "@bitwarden/components";
+import { ButtonModule, DialogRef } from "@bitwarden/components";
 import {
   NewSendDropdownV2Component,
-  SendItemsService,
   SendListComponent,
-  SendListState,
   SendAddEditDialogComponent,
   DefaultSendFormConfigService,
   SendItemDialogResult,
@@ -67,24 +57,14 @@ type Action = (typeof Action)[keyof typeof Action];
   ],
   templateUrl: "./send-v2.component.html",
 })
-export class SendV2Component {
+export class SendV2Component extends BaseSendComponent {
   protected readonly addEditComponent = viewChild(AddEditComponent);
 
   protected readonly sendId = signal<string | null>(null);
   protected readonly action = signal<Action>(Action.None);
 
   private sendFormConfigService = inject(DefaultSendFormConfigService);
-  private sendItemsService = inject(SendItemsService);
-  private policyService = inject(PolicyService);
-  private accountService = inject(AccountService);
   private configService = inject(ConfigService);
-  private i18nService = inject(I18nService);
-  private platformUtilsService = inject(PlatformUtilsService);
-  private environmentService = inject(EnvironmentService);
-  private sendApiService = inject(SendApiService);
-  private dialogService = inject(DialogService);
-  private toastService = inject(ToastService);
-  private logService = inject(LogService);
   private destroyRef = inject(DestroyRef);
 
   private activeDrawerRef?: DialogRef<SendItemDialogResult>;
@@ -94,47 +74,16 @@ export class SendV2Component {
     { initialValue: false },
   );
 
-  protected readonly filteredSends = toSignal(this.sendItemsService.filteredAndSortedSends$, {
-    initialValue: [],
-  });
-
-  protected readonly loading = toSignal(this.sendItemsService.loading$, { initialValue: true });
-
-  protected readonly currentSearchText = toSignal(this.sendItemsService.latestSearchText$, {
-    initialValue: "",
-  });
-
-  protected readonly disableSend = toSignal(
-    this.accountService.activeAccount$.pipe(
-      getUserId,
-      switchMap((userId) =>
-        this.policyService.policyAppliesToUser$(PolicyType.DisableSend, userId),
-      ),
-    ),
-    { initialValue: false },
-  );
-
-  protected readonly listState = toSignal(
-    combineLatest([
-      this.sendItemsService.emptyList$,
-      this.sendItemsService.noFilteredResults$,
-    ]).pipe(
-      map(([emptyList, noFilteredResults]): SendListState | null => {
-        if (emptyList) {
-          return SendListState.Empty;
-        }
-        if (noFilteredResults) {
-          return SendListState.NoResults;
-        }
-        return null;
-      }),
-    ),
-    { initialValue: null },
-  );
-
   constructor() {
+    super();
     this.destroyRef.onDestroy(() => {
       this.activeDrawerRef?.close();
+    });
+    // If the Send we are editing becomes invisible due to search filtering, close the edit drawer
+    this.sendItemsService.filteredAndSortedSends$.pipe(takeUntilDestroyed()).subscribe((sends) => {
+      if (this.sendId() && !sends.some((s) => s.id === this.sendId())) {
+        this.addEditComponent().cancel();
+      }
     });
   }
 

--- a/apps/web/src/app/tools/send/send.component.html
+++ b/apps/web/src/app/tools/send/send.component.html
@@ -1,76 +1,37 @@
 <app-header>
   <ng-container slot="title-suffix">
-    <small #actionSpinner [appApiAction]="actionPromise">
-      <ng-container *ngIf="$any(actionSpinner).loading">
-        <i
-          class="bwi bwi-spinner bwi-spin tw-text-muted"
-          title="{{ 'loading' | i18n }}"
-          aria-hidden="true"
-        ></i>
-        <span class="tw-sr-only">{{ "loading" | i18n }}</span>
-      </ng-container>
-    </small>
+    <div class="tw-h-full tw-flex tw-items-center" #actionSpinner [appApiAction]="actionPromise">
+      @if ($any(actionSpinner).loading) {
+        <bit-spinner size="small" class="tw-text-muted"></bit-spinner>
+      }
+    </div>
   </ng-container>
-  <tools-new-send-dropdown *ngIf="!disableSend"></tools-new-send-dropdown>
+  @if (!disableSend()) {
+    <tools-new-send-dropdown></tools-new-send-dropdown>
+  }
 </app-header>
 
-<bit-callout type="warning" title="{{ 'sendDisabled' | i18n }}" *ngIf="disableSend">
-  {{ "sendDisabledWarning" | i18n }}
-</bit-callout>
+@if (disableSend()) {
+  <bit-callout type="warning" title="{{ 'sendDisabled' | i18n }}">
+    {{ "sendDisabledWarning" | i18n }}
+  </bit-callout>
+}
 
 @if (SendUIRefresh$ | async) {
-  <div class="tw-mb-4">
-    <bit-search
-      [(ngModel)]="searchText"
-      [placeholder]="'searchSends' | i18n"
-      (ngModelChange)="searchTextChanged()"
-      appAutofocus
-    />
-  </div>
-
-  <div class="tw-mb-4">
-    <bit-toggle-group [selected]="selectedToggleValue" (selectedChange)="onToggleChange($event)">
-      <bit-toggle [value]="'all'">{{ "allSends" | i18n }}</bit-toggle>
-      <bit-toggle [value]="'text'">{{ "sendTypeText" | i18n }}</bit-toggle>
-      <bit-toggle [value]="'file'">{{ "sendTypeFile" | i18n }}</bit-toggle>
-    </bit-toggle-group>
-  </div>
-
-  <div>
-    <div class="tw-@container/send-table">
-      <tools-send-table
-        *ngIf="filteredSends && filteredSends.length"
-        [dataSource]="dataSource"
-        [disableSend]="disableSend"
-        (editSend)="editSend($event)"
-        (copySend)="copy($event)"
-        (removePassword)="removePassword($event)"
-        (deleteSend)="delete($event)"
-      />
-
-      <div *ngIf="filteredSends && !filteredSends.length">
-        <ng-container *ngIf="!loaded">
-          <i
-            class="bwi bwi-spinner bwi-spin tw-text-muted"
-            title="{{ 'loading' | i18n }}"
-            aria-hidden="true"
-          ></i>
-          <span class="tw-sr-only">{{ "loading" | i18n }}</span>
-        </ng-container>
-        <ng-container *ngIf="loaded">
-          <bit-no-items [icon]="noItemIcon" class="tw-text-main">
-            <ng-container slot="title">{{ "sendsTitleNoItems" | i18n }}</ng-container>
-            <ng-container slot="description">{{ "sendsBodyNoItems" | i18n }}</ng-container>
-            <tools-new-send-dropdown
-              [hideIcon]="true"
-              *ngIf="!disableSend"
-              slot="button"
-            ></tools-new-send-dropdown>
-          </bit-no-items>
-        </ng-container>
-      </div>
-    </div>
-  </div>
+  <tools-send-list
+    [sends]="filteredSends()"
+    [loading]="loading()"
+    [disableSend]="disableSend()"
+    [listState]="listState()"
+    [searchText]="currentSearchText()"
+    [searchFilter]="currentSearchFilter()"
+    (editSend)="editSend($event)"
+    (copySend)="copy($event)"
+    (deleteSend)="delete($event)"
+    (removePassword)="removePassword($event)"
+  >
+    <tools-new-send-dropdown slot="empty-button" [hideIcon]="true" buttonType="primary" />
+  </tools-send-list>
 } @else {
   <div class="tw-grid tw-grid-cols-12 tw-gap-4">
     <div class="tw-col-span-3">
@@ -87,18 +48,25 @@
         <div class="tw-p-5" data-testid="filters-body">
           <div class="tw-mb-4">
             <bit-search
-              [(ngModel)]="searchText"
               [placeholder]="'searchSends' | i18n"
-              (input)="searchTextChanged()"
+              (input)="searchTextChanged($event)"
               appAutofocus
             />
           </div>
           <div class="filter">
             <ul class="filter-options">
-              <li class="filter-option" [ngClass]="{ active: selectedAll }">
+              <li
+                class="filter-option"
+                [ngClass]="{ active: selectedSendFilter === SendFilterType.All }"
+              >
                 <span class="filter-buttons">
-                  <button type="button" class="filter-button" appStopClick (click)="selectAll()">
-                    <i class="bwi bwi-fw bwi-filter"></i>{{ "allSends" | i18n }}
+                  <button
+                    type="button"
+                    class="filter-button"
+                    appStopClick
+                    (click)="selectType(SendFilterType.All)"
+                  >
+                    <bit-icon name="bwi-filter" class="bwi-fw"></bit-icon>{{ "allSends" | i18n }}
                   </button>
                 </span>
               </li>
@@ -109,27 +77,34 @@
               <h3>{{ "types" | i18n }}</h3>
             </div>
             <ul class="filter-options">
-              <li class="filter-option" [ngClass]="{ active: selectedType === sendType.Text }">
+              <li
+                class="filter-option"
+                [ngClass]="{ active: selectedSendFilter === SendFilterType.Text }"
+              >
                 <span class="filter-buttons">
                   <button
                     type="button"
                     class="filter-button"
                     appStopClick
-                    (click)="selectType(sendType.Text)"
+                    (click)="selectType(SendFilterType.Text)"
                   >
-                    <i class="bwi bwi-fw bwi-file-text"></i>{{ "sendTypeText" | i18n }}
+                    <bit-icon name="bwi-file-text" class="bwi-fw"></bit-icon
+                    >{{ "sendTypeText" | i18n }}
                   </button>
                 </span>
               </li>
-              <li class="filter-option" [ngClass]="{ active: selectedType === sendType.File }">
+              <li
+                class="filter-option"
+                [ngClass]="{ active: selectedSendFilter === SendFilterType.File }"
+              >
                 <span class="filter-buttons">
                   <button
                     type="button"
                     class="filter-button"
                     appStopClick
-                    (click)="selectType(sendType.File)"
+                    (click)="selectType(SendFilterType.File)"
                   >
-                    <i class="bwi bwi-fw bwi-file"></i>{{ "sendTypeFile" | i18n }}
+                    <bit-icon name="bwi-file" class="bwi-fw"></bit-icon>{{ "sendTypeFile" | i18n }}
                   </button>
                 </span>
               </li>
@@ -139,37 +114,29 @@
       </div>
     </div>
     <div class="tw-col-span-9 tw-@container/send-table">
-      <!--Listing Table-->
-      <tools-send-table
-        *ngIf="filteredSends && filteredSends.length"
-        [dataSource]="dataSource"
-        [disableSend]="disableSend"
-        (editSend)="editSend($event)"
-        (copySend)="copy($event)"
-        (removePassword)="removePassword($event)"
-        (deleteSend)="delete($event)"
-      />
-      <div *ngIf="filteredSends && !filteredSends.length">
-        <ng-container *ngIf="!loaded">
-          <i
-            class="bwi bwi-spinner bwi-spin tw-text-muted"
-            title="{{ 'loading' | i18n }}"
-            aria-hidden="true"
-          ></i>
-          <span class="tw-sr-only">{{ "loading" | i18n }}</span>
-        </ng-container>
-        <ng-container *ngIf="loaded">
+      @if (filteredSends() && filteredSends().length) {
+        <!--Listing Table-->
+        <tools-send-table
+          [dataSource]="dataSource"
+          [disableSend]="disableSend()"
+          (editSend)="editSend($event)"
+          (copySend)="copy($event)"
+          (removePassword)="removePassword($event)"
+          (deleteSend)="delete($event)"
+        />
+      } @else {
+        @if (loading()) {
+          <bit-spinner class="tw-text-muted"></bit-spinner>
+        } @else {
           <bit-no-items [icon]="noItemIcon" class="tw-text-main">
             <ng-container slot="title">{{ "sendsTitleNoItems" | i18n }}</ng-container>
             <ng-container slot="description">{{ "sendsBodyNoItems" | i18n }}</ng-container>
-            <tools-new-send-dropdown
-              [hideIcon]="true"
-              *ngIf="!disableSend"
-              slot="button"
-            ></tools-new-send-dropdown>
+            @if (!disableSend()) {
+              <tools-new-send-dropdown [hideIcon]="true" slot="button"></tools-new-send-dropdown>
+            }
           </bit-no-items>
-        </ng-container>
-      </div>
+        }
+      }
     </div>
   </div>
 }

--- a/apps/web/src/app/tools/send/send.component.ts
+++ b/apps/web/src/app/tools/send/send.component.ts
@@ -1,36 +1,21 @@
-// FIXME: Update this file to be type safe and remove this and next line
-// @ts-strict-ignore
-import { Component, NgZone, OnInit, OnDestroy } from "@angular/core";
+import { Component, OnDestroy } from "@angular/core";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { ActivatedRoute, Router } from "@angular/router";
-import { lastValueFrom, Observable, switchMap, EMPTY } from "rxjs";
+import { EMPTY, lastValueFrom, Observable, switchMap } from "rxjs";
 
 import { SendComponent as BaseSendComponent } from "@bitwarden/angular/tools/send/send.component";
 import { NoSendsIcon } from "@bitwarden/assets/svg";
-import { PolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
-import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
-import { BroadcasterService } from "@bitwarden/common/platform/abstractions/broadcaster.service";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
-import { EnvironmentService } from "@bitwarden/common/platform/abstractions/environment.service";
-import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
-import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
-import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { SendView } from "@bitwarden/common/tools/send/models/view/send.view";
-import { SendApiService } from "@bitwarden/common/tools/send/services/send-api.service.abstraction";
-import { SendService } from "@bitwarden/common/tools/send/services/send.service.abstraction";
 import { SendFilterType } from "@bitwarden/common/tools/send/types/send-filter-type";
-import { SendType } from "@bitwarden/common/tools/send/types/send-type";
 import { SendId } from "@bitwarden/common/types/guid";
-import { SearchService } from "@bitwarden/common/vault/abstractions/search.service";
 import {
   DialogRef,
-  DialogService,
   NoItemsModule,
   SearchModule,
   TableDataSource,
-  ToastService,
-  ToggleGroupModule,
+  SpinnerComponent,
 } from "@bitwarden/components";
 import {
   DefaultSendFormConfigService,
@@ -38,6 +23,7 @@ import {
   SendAddEditDialogComponent,
   SendItemDialogResult,
   SendTableComponent,
+  SendListComponent,
 } from "@bitwarden/send-ui";
 
 import { HeaderModule } from "../../layouts/header/header.module";
@@ -45,8 +31,6 @@ import { SharedModule } from "../../shared";
 
 import { NewSendDropdownComponent } from "./new-send/new-send-dropdown.component";
 import { SendSuccessDrawerDialogComponent } from "./shared";
-
-const BroadcasterSubscriptionId = "SendComponent";
 
 // FIXME(https://bitwarden.atlassian.net/browse/CL-764): Migrate to OnPush
 // eslint-disable-next-line @angular-eslint/prefer-on-push-component-change-detection
@@ -58,65 +42,33 @@ const BroadcasterSubscriptionId = "SendComponent";
     NoItemsModule,
     HeaderModule,
     NewSendDropdownComponent,
-    ToggleGroupModule,
     SendTableComponent,
+    SpinnerComponent,
+    SendListComponent,
   ],
   templateUrl: "send.component.html",
   providers: [DefaultSendFormConfigService],
 })
-export class SendComponent extends BaseSendComponent implements OnInit, OnDestroy {
+export class SendComponent extends BaseSendComponent implements OnDestroy {
   private sendItemDialogRef?: DialogRef<SendItemDialogResult> | undefined;
+  SendFilterType = SendFilterType;
+
+  // These should be removed once the Send UI refresh is live
+  protected dataSource = new TableDataSource<SendView>();
+  selectedSendFilter: SendFilterType = SendFilterType.All;
   noItemIcon = NoSendsIcon;
-  selectedToggleValue?: SendFilterType;
   SendUIRefresh$: Observable<boolean>;
 
-  override set filteredSends(filteredSends: SendView[]) {
-    super.filteredSends = filteredSends;
-    this.dataSource.data = filteredSends;
-  }
-
-  override get filteredSends() {
-    return super.filteredSends;
-  }
-
-  protected dataSource = new TableDataSource<SendView>();
-
   constructor(
-    sendService: SendService,
-    i18nService: I18nService,
-    platformUtilsService: PlatformUtilsService,
-    environmentService: EnvironmentService,
-    ngZone: NgZone,
-    searchService: SearchService,
-    policyService: PolicyService,
-    private broadcasterService: BroadcasterService,
-    logService: LogService,
-    sendApiService: SendApiService,
-    dialogService: DialogService,
-    toastService: ToastService,
     private addEditFormConfigService: DefaultSendFormConfigService,
-    accountService: AccountService,
     private route: ActivatedRoute,
     private router: Router,
     private configService: ConfigService,
   ) {
-    super(
-      sendService,
-      i18nService,
-      platformUtilsService,
-      environmentService,
-      ngZone,
-      searchService,
-      policyService,
-      logService,
-      sendApiService,
-      dialogService,
-      toastService,
-      accountService,
-    );
-
+    super();
     this.SendUIRefresh$ = this.configService.getFeatureFlag$(FeatureFlag.SendUIRefresh);
 
+    // Ensure the component filters react to changes in query params
     this.SendUIRefresh$.pipe(
       switchMap((sendUiRefreshEnabled) => {
         if (sendUiRefreshEnabled) {
@@ -127,57 +79,31 @@ export class SendComponent extends BaseSendComponent implements OnInit, OnDestro
       takeUntilDestroyed(),
     ).subscribe((params) => {
       const typeParam = params.get("type");
-      const value = (
-        typeParam === SendFilterType.Text || typeParam === SendFilterType.File
-          ? typeParam
-          : SendFilterType.All
-      ) as SendFilterType;
-      this.selectedToggleValue = value;
-
-      if (this.loaded) {
-        this.applyTypeFilter(value);
-      }
+      const sendType = this.sendFilterTypeToSendType(typeParam as SendFilterType);
+      this.sendListFiltersService.filterForm.patchValue({ sendType });
     });
-  }
-
-  async ngOnInit() {
-    await super.ngOnInit();
-    this.onSuccessfulLoad = async () => {
-      this.applyTypeFilter(this.selectedToggleValue);
-    };
-
-    await this.load();
-
-    // Broadcaster subscription - load if sync completes in the background
-    this.broadcasterService.subscribe(BroadcasterSubscriptionId, (message: any) => {
-      // FIXME: Verify that this floating promise is intentional. If it is, add an explanatory comment and ensure there is proper error handling.
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      this.ngZone.run(async () => {
-        switch (message.command) {
-          case "syncCompleted":
-            if (message.successfully) {
-              await this.load();
-            }
-            break;
-        }
-      });
+    // Ensure that query params are updated when the component changes filters
+    this.sendListFiltersService.filters$.pipe(takeUntilDestroyed()).subscribe((value) => {
+      const type = this.sendTypeToSendFilterType(value.sendType);
+      this.router
+        .navigate([], {
+          relativeTo: this.route,
+          queryParams: { type },
+          queryParamsHandling: "merge",
+        })
+        .catch((err) => {
+          this.logService.error("Failed to update route query params:", err);
+        });
+    });
+    // Pre-refresh data setup. Can be removed once Send UI refresh is live.
+    this.sendItemsService.filteredAndSortedSends$.pipe(takeUntilDestroyed()).subscribe((sends) => {
+      this.dataSource.data = sends;
     });
   }
 
   ngOnDestroy() {
     this.dialogService.closeAll();
     this.dialogService.closeDrawer();
-    this.broadcasterService.unsubscribe(BroadcasterSubscriptionId);
-  }
-
-  async addSend() {
-    if (this.disableSend) {
-      return;
-    }
-
-    const config = await this.addEditFormConfigService.buildConfig("add", null, 0);
-
-    await this.openSendItemDialog(config);
   }
 
   async editSend(send: SendView) {
@@ -214,14 +140,6 @@ export class SendComponent extends BaseSendComponent implements OnInit, OnDestro
     const result: SendItemDialogResult = await lastValueFrom(this.sendItemDialogRef.closed);
     this.sendItemDialogRef = undefined;
 
-    // If the dialog was closed by deleting the cipher, refresh the vault.
-    if (
-      result?.result === SendItemDialogResult.Deleted ||
-      result?.result === SendItemDialogResult.Saved
-    ) {
-      await this.load();
-    }
-
     if (
       result?.result === SendItemDialogResult.Saved &&
       result?.send &&
@@ -233,27 +151,16 @@ export class SendComponent extends BaseSendComponent implements OnInit, OnDestro
     }
   }
 
-  private applyTypeFilter(value: SendFilterType) {
-    if (value === SendFilterType.All) {
-      this.selectAll();
-    } else if (value === SendFilterType.Text) {
-      this.selectType(SendType.Text);
-    } else if (value === SendFilterType.File) {
-      this.selectType(SendType.File);
+  /** Pre-Refresh methods. Can be removed once Send UI refresh is live */
+  searchTextChanged(event: Event) {
+    if (event instanceof InputEvent) {
+      this.sendItemsService.applyFilter(event.data ?? "");
     }
   }
 
-  onToggleChange(value: SendFilterType) {
-    const queryParams = value === SendFilterType.All ? { type: null } : { type: value };
-
-    this.router
-      .navigate([], {
-        relativeTo: this.route,
-        queryParams,
-        queryParamsHandling: "merge",
-      })
-      .catch((err) => {
-        this.logService.error("Failed to update route query params:", err);
-      });
+  selectType(type: SendFilterType) {
+    this.selectedSendFilter = type;
+    const sendType = this.sendFilterTypeToSendType(type);
+    this.sendListFiltersService.filterForm.patchValue({ sendType });
   }
 }

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -13028,5 +13028,11 @@
         "example": "Jan 1, 1970"
       }
     }
+  },
+  "sendsTitleNoSearchResults": {
+    "message": "No search results returned"
+  },
+  "sendsBodyNoSearchResults": {
+    "message": "Clear filters or try another search term"
   }
 }

--- a/libs/angular/src/tools/send/send.component.ts
+++ b/libs/angular/src/tools/send/send.component.ts
@@ -1,16 +1,8 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
-import { Directive, NgZone, OnDestroy, OnInit } from "@angular/core";
-import {
-  BehaviorSubject,
-  Subject,
-  firstValueFrom,
-  mergeMap,
-  from,
-  switchMap,
-  takeUntil,
-  combineLatest,
-} from "rxjs";
+import { Directive, inject } from "@angular/core";
+import { toSignal } from "@angular/core/rxjs-interop";
+import { firstValueFrom, switchMap, combineLatest, map } from "rxjs";
 
 import { PolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
 import { PolicyType } from "@bitwarden/common/admin-console/enums";
@@ -22,163 +14,100 @@ import { LogService } from "@bitwarden/common/platform/abstractions/log.service"
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { SendView } from "@bitwarden/common/tools/send/models/view/send.view";
 import { SendApiService } from "@bitwarden/common/tools/send/services/send-api.service.abstraction";
-import { SendService } from "@bitwarden/common/tools/send/services/send.service.abstraction";
+import { SendFilterType } from "@bitwarden/common/tools/send/types/send-filter-type";
 import { SendType } from "@bitwarden/common/tools/send/types/send-type";
-import { SearchService } from "@bitwarden/common/vault/abstractions/search.service";
 import { DialogService, ToastService } from "@bitwarden/components";
+import { SendItemsService, SendListState, SendListFiltersService } from "@bitwarden/send-ui";
 
 @Directive()
-export class SendComponent implements OnInit, OnDestroy {
-  disableSend = false;
+export class SendComponent {
   sendType = SendType;
-  loaded = false;
-  loading = true;
-  refreshing = false;
-  expired = false;
-  type: SendType = null;
-  sends: SendView[] = [];
-  selectedType: SendType;
-  selectedAll: boolean;
-  filter: (cipher: SendView) => boolean;
-  searchPending = false;
-  hasSearched = false; // search() function called - returns true if text qualifies for search
 
   actionPromise: any;
-  onSuccessfulRemovePassword: () => Promise<any>;
-  onSuccessfulDelete: () => Promise<any>;
-  onSuccessfulLoad: () => Promise<any>;
 
-  private searchTimeout: any;
-  private destroy$ = new Subject<void>();
-  private _filteredSends: SendView[];
-  private _searchText$ = new BehaviorSubject<string>("");
-  protected isSearchable: boolean = false;
+  protected sendItemsService = inject(SendItemsService);
+  protected sendListFiltersService = inject(SendListFiltersService);
+  protected dialogService = inject(DialogService);
+  protected i18nService = inject(I18nService);
+  protected sendApiService = inject(SendApiService);
+  protected toastService = inject(ToastService);
+  protected logService = inject(LogService);
+  protected platformUtilsService = inject(PlatformUtilsService);
+  protected environmentService = inject(EnvironmentService);
 
-  get filteredSends(): SendView[] {
-    return this._filteredSends;
-  }
+  private accountService = inject(AccountService);
+  private policyService = inject(PolicyService);
 
-  set filteredSends(filteredSends: SendView[]) {
-    this._filteredSends = filteredSends;
-  }
+  protected readonly filteredSends = toSignal(this.sendItemsService.filteredAndSortedSends$, {
+    initialValue: [],
+  });
 
-  get searchText() {
-    return this._searchText$.value;
-  }
+  protected readonly loading = toSignal(this.sendItemsService.loading$, { initialValue: true });
 
-  set searchText(value: string) {
-    this._searchText$.next(value);
-  }
+  protected readonly disableSend = toSignal(
+    this.accountService.activeAccount$.pipe(
+      getUserId,
+      switchMap((userId) =>
+        this.policyService.policyAppliesToUser$(PolicyType.DisableSend, userId),
+      ),
+    ),
+    { initialValue: false },
+  );
 
-  constructor(
-    protected sendService: SendService,
-    protected i18nService: I18nService,
-    protected platformUtilsService: PlatformUtilsService,
-    protected environmentService: EnvironmentService,
-    protected ngZone: NgZone,
-    protected searchService: SearchService,
-    protected policyService: PolicyService,
-    protected logService: LogService,
-    protected sendApiService: SendApiService,
-    protected dialogService: DialogService,
-    protected toastService: ToastService,
-    private accountService: AccountService,
-  ) {}
+  protected readonly listState = toSignal(
+    combineLatest([
+      this.sendItemsService.emptyList$,
+      this.sendItemsService.noFilteredResults$,
+    ]).pipe(
+      map(([emptyList, noFilteredResults]): SendListState | null => {
+        if (emptyList) {
+          return SendListState.Empty;
+        }
+        if (noFilteredResults) {
+          return SendListState.NoResults;
+        }
+        return null;
+      }),
+    ),
+    { initialValue: null },
+  );
 
-  async ngOnInit() {
-    this.accountService.activeAccount$
-      .pipe(
-        getUserId,
-        switchMap((userId) =>
-          this.policyService.policyAppliesToUser$(PolicyType.DisableSend, userId),
-        ),
-        takeUntil(this.destroy$),
-      )
-      .subscribe((policyAppliesToUser) => {
-        this.disableSend = policyAppliesToUser;
-      });
+  protected readonly currentSearchText = toSignal(this.sendItemsService.latestSearchText$, {
+    initialValue: "",
+  });
 
-    combineLatest([this._searchText$, this.accountService.activeAccount$.pipe(getUserId)])
-      .pipe(
-        switchMap(([searchText, userId]) =>
-          from(this.searchService.isSearchable(userId, searchText)),
-        ),
-        takeUntil(this.destroy$),
-      )
-      .subscribe((isSearchable) => {
-        this.isSearchable = isSearchable;
-      });
-  }
+  protected readonly currentSearchFilter = toSignal(
+    this.sendListFiltersService.filters$.pipe(
+      map((value): SendFilterType => this.sendTypeToSendFilterType(value.sendType)),
+    ),
+    { initialValue: SendFilterType.All },
+  );
 
-  ngOnDestroy() {
-    this.destroy$.next();
-    this.destroy$.complete();
-  }
-
-  async load(filter: (send: SendView) => boolean = null) {
-    this.loading = true;
-    this.sendService.sendViews$
-      .pipe(
-        mergeMap(async (sends) => {
-          this.sends = sends;
-          await this.search(null);
-        }),
-        takeUntil(this.destroy$),
-      )
-      .subscribe();
-    if (this.onSuccessfulLoad != null) {
-      await this.onSuccessfulLoad();
-    } else {
-      // Default action
-      this.selectAll();
-    }
-    this.loading = false;
-    this.loaded = true;
-  }
-
-  async reload(filter: (send: SendView) => boolean = null) {
-    this.loaded = false;
-    this.sends = [];
-    await this.load(filter);
-  }
-
-  async refresh() {
-    try {
-      this.refreshing = true;
-      await this.reload(this.filter);
-    } finally {
-      this.refreshing = false;
+  protected sendFilterTypeToSendType(filterType: SendFilterType): SendType | null {
+    switch (filterType) {
+      case SendFilterType.Text:
+        return SendType.Text;
+      case SendFilterType.File:
+        return SendType.File;
+      default: // SendFilterType.All
+        return null;
     }
   }
 
-  async applyFilter(filter: (send: SendView) => boolean = null) {
-    this.filter = filter;
-    await this.search(null);
-  }
-
-  async search(timeout: number = null) {
-    this.searchPending = false;
-    if (this.searchTimeout != null) {
-      clearTimeout(this.searchTimeout);
+  protected sendTypeToSendFilterType(sendType: SendType | null): SendFilterType {
+    switch (sendType) {
+      case SendType.Text:
+        return SendFilterType.Text;
+      case SendType.File:
+        return SendFilterType.File;
+      default:
+        return SendFilterType.All;
     }
-    if (timeout == null) {
-      this.hasSearched = this.isSearchable;
-      this.filteredSends = this.sends.filter((s) => this.filter == null || this.filter(s));
-      this.applyTextSearch();
-      return;
-    }
-    this.searchPending = true;
-    this.searchTimeout = setTimeout(async () => {
-      this.hasSearched = this.isSearchable;
-      this.filteredSends = this.sends.filter((s) => this.filter == null || this.filter(s));
-      this.applyTextSearch();
-      this.searchPending = false;
-    }, timeout);
   }
 
   async removePassword(s: SendView): Promise<boolean> {
     if (this.actionPromise != null || s.password == null) {
-      return;
+      return false;
     }
 
     const confirmed = await this.dialogService.openSimpleDialog({
@@ -194,23 +123,16 @@ export class SendComponent implements OnInit, OnDestroy {
     try {
       this.actionPromise = this.sendApiService.removePassword(s.id);
       await this.actionPromise;
-      if (this.onSuccessfulRemovePassword != null) {
-        // FIXME: Verify that this floating promise is intentional. If it is, add an explanatory comment and ensure there is proper error handling.
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        this.onSuccessfulRemovePassword();
-      } else {
-        // Default actions
-        this.toastService.showToast({
-          variant: "success",
-          title: null,
-          message: this.i18nService.t("removedPassword"),
-        });
-        await this.load();
-      }
+      this.toastService.showToast({
+        variant: "success",
+        title: null,
+        message: this.i18nService.t("removedPassword"),
+      });
     } catch (e) {
       this.logService.error(e);
     }
     this.actionPromise = null;
+    return true;
   }
 
   async delete(s: SendView): Promise<boolean> {
@@ -231,20 +153,11 @@ export class SendComponent implements OnInit, OnDestroy {
     try {
       this.actionPromise = this.sendApiService.delete(s.id);
       await this.actionPromise;
-
-      if (this.onSuccessfulDelete != null) {
-        // FIXME: Verify that this floating promise is intentional. If it is, add an explanatory comment and ensure there is proper error handling.
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        this.onSuccessfulDelete();
-      } else {
-        // Default actions
-        this.toastService.showToast({
-          variant: "success",
-          title: null,
-          message: this.i18nService.t("deletedSend"),
-        });
-        await this.refresh();
-      }
+      this.toastService.showToast({
+        variant: "success",
+        title: null,
+        message: this.i18nService.t("deletedSend"),
+      });
     } catch (e) {
       this.logService.error(e);
     }
@@ -261,38 +174,5 @@ export class SendComponent implements OnInit, OnDestroy {
       title: null,
       message: this.i18nService.t("valueCopied", this.i18nService.t("sendLink")),
     });
-  }
-
-  searchTextChanged() {
-    // FIXME: Verify that this floating promise is intentional. If it is, add an explanatory comment and ensure there is proper error handling.
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    this.search(200);
-  }
-
-  selectAll() {
-    this.clearSelections();
-    this.selectedAll = true;
-    // FIXME: Verify that this floating promise is intentional. If it is, add an explanatory comment and ensure there is proper error handling.
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    this.applyFilter(null);
-  }
-
-  selectType(type: SendType) {
-    this.clearSelections();
-    this.selectedType = type;
-    // FIXME: Verify that this floating promise is intentional. If it is, add an explanatory comment and ensure there is proper error handling.
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    this.applyFilter((s) => s.type === type);
-  }
-
-  clearSelections() {
-    this.selectedAll = false;
-    this.selectedType = null;
-  }
-
-  private applyTextSearch() {
-    if (this.searchText != null) {
-      this.filteredSends = this.searchService.searchSends(this.filteredSends, this.searchText);
-    }
   }
 }

--- a/libs/tools/send/send-ui/src/send-list/send-list.component.html
+++ b/libs/tools/send/send-ui/src/send-list/send-list.component.html
@@ -3,7 +3,7 @@
 } @else {
   @if (showSearchBar()) {
     <!-- Search Bar - hidden when no Sends exist -->
-    <tools-send-search></tools-send-search>
+    <tools-send-search [showSearchFilters]="showSearchFilters()"></tools-send-search>
   }
   <tools-send-table
     [dataSource]="dataSource"

--- a/libs/tools/send/send-ui/src/send-list/send-list.component.ts
+++ b/libs/tools/send/send-ui/src/send-list/send-list.component.ts
@@ -4,6 +4,7 @@ import { ChangeDetectionStrategy, Component, computed, effect, input, output } f
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { NoResults, NoSendsIcon } from "@bitwarden/assets/svg";
 import { SendView } from "@bitwarden/common/tools/send/models/view/send.view";
+import { SendFilterType } from "@bitwarden/common/tools/send/types/send-filter-type";
 import {
   ButtonModule,
   NoItemsModule,
@@ -18,7 +19,7 @@ import { SendTableComponent } from "../send-table/send-table.component";
 export const SendListState = Object.freeze({
   /** No Sends exist at all (File or Text). */
   Empty: "Empty",
-  /** Sends exist, but none match the current Side Nav Filter (File or Text). */
+  /** Sends exist, but none match the current filters (text search and/or type) */
   NoResults: "NoResults",
 } as const);
 
@@ -53,13 +54,19 @@ export class SendListComponent {
   readonly disableSend = input<boolean>(false);
   readonly listState = input<SendListState | null>(null);
   readonly searchText = input<string>("");
+  readonly searchFilter = input<SendFilterType>(SendFilterType.All);
+  readonly showSearchFilters = input<boolean>(true);
+
+  private readonly searchApplied = computed(
+    () => this.searchText().length > 0 || this.searchFilter() !== SendFilterType.All,
+  );
 
   protected readonly showSearchBar = computed(
-    () => this.sends().length > 0 || this.searchText().length > 0,
+    () => this.sends().length > 0 || this.searchApplied() || this.showSearchFilters(),
   );
 
   protected readonly noSearchResults = computed(
-    () => this.showSearchBar() && this.sends().length === 0,
+    () => this.showSearchBar() && this.sends().length === 0 && this.searchApplied(),
   );
 
   // Reusable data source instance - updated reactively when sends change

--- a/libs/tools/send/send-ui/src/send-search/send-search.component.html
+++ b/libs/tools/send/send-ui/src/send-search/send-search.component.html
@@ -1,1 +1,8 @@
 <bit-search [placeholder]="'search' | i18n" [(ngModel)]="searchText" appAutofocus />
+@if (showSearchFilters()) {
+  <bit-toggle-group class="tw-mt-4" [(selected)]="searchFilter">
+    <bit-toggle [value]="SendFilterType.All">{{ "allSends" | i18n }}</bit-toggle>
+    <bit-toggle [value]="SendFilterType.Text">{{ "sendTypeText" | i18n }}</bit-toggle>
+    <bit-toggle [value]="SendFilterType.File">{{ "sendTypeFile" | i18n }}</bit-toggle>
+  </bit-toggle-group>
+}

--- a/libs/tools/send/send-ui/src/send-search/send-search.component.ts
+++ b/libs/tools/send/send-ui/src/send-search/send-search.component.ts
@@ -1,12 +1,15 @@
-import { ChangeDetectionStrategy, Component, inject, model } from "@angular/core";
+import { ChangeDetectionStrategy, Component, inject, input, model } from "@angular/core";
 import { takeUntilDestroyed, toObservable } from "@angular/core/rxjs-interop";
 import { FormsModule } from "@angular/forms";
 import { debounceTime, filter } from "rxjs";
 
-import { SearchModule } from "@bitwarden/components";
+import { SendFilterType } from "@bitwarden/common/tools/send/types/send-filter-type";
+import { SendType } from "@bitwarden/common/tools/send/types/send-type";
+import { SearchModule, ToggleGroupModule } from "@bitwarden/components";
 import { I18nPipe } from "@bitwarden/ui-common";
 
 import { SendItemsService } from "../services/send-items.service";
+import { SendListFiltersService } from "../services/send-list-filters.service";
 
 const SearchTextDebounceInterval = 200;
 
@@ -19,18 +22,25 @@ const SearchTextDebounceInterval = 200;
 @Component({
   selector: "tools-send-search",
   templateUrl: "send-search.component.html",
-  imports: [FormsModule, I18nPipe, SearchModule],
+  imports: [FormsModule, I18nPipe, SearchModule, ToggleGroupModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class SendSearchComponent {
   private sendListItemService = inject(SendItemsService);
+  private sendListFiltersService = inject(SendListFiltersService);
+
+  protected readonly showSearchFilters = input<boolean>(true);
+  protected readonly SendFilterType = SendFilterType;
 
   /** The current search text entered by the user. */
   protected readonly searchText = model("");
+  /** The current search filter selected by the user */
+  protected readonly searchFilter = model<SendFilterType>(SendFilterType.All);
 
   constructor() {
     this.subscribeToLatestSearchText();
     this.subscribeToApplyFilter();
+    this.subscribeToPatchFilters();
   }
 
   private subscribeToLatestSearchText(): void {
@@ -45,7 +55,7 @@ export class SendSearchComponent {
   }
 
   /**
-   * Applies the search filter to the Send list with a debounce delay.
+   * Applies the search text filter to the Send list with a debounce delay.
    * This prevents excessive filtering while the user is still typing.
    */
   private subscribeToApplyFilter(): void {
@@ -53,6 +63,28 @@ export class SendSearchComponent {
       .pipe(debounceTime(SearchTextDebounceInterval), takeUntilDestroyed())
       .subscribe((data) => {
         this.sendListItemService.applyFilter(data);
+      });
+  }
+
+  /**
+   * Applies the search filter (SendType) to the Send list
+   */
+  private subscribeToPatchFilters() {
+    toObservable(this.searchFilter)
+      .pipe(takeUntilDestroyed())
+      .subscribe((value) => {
+        let sendType: SendType;
+        switch (value) {
+          case SendFilterType.Text:
+            sendType = SendType.Text;
+            break;
+          case SendFilterType.File:
+            sendType = SendType.File;
+            break;
+          default:
+            sendType = null;
+        }
+        this.sendListFiltersService.filterForm.patchValue({ sendType });
       });
   }
 }


### PR DESCRIPTION
…to base Send component and update web and desktop

## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-32160

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR began with just updating the web Send component to use the shared `SendListComponent` recently introduced and used by desktop. As part of this I had to add the SendType filter toggle group to the `SendSearchComponent` and add logic for conditionally hiding it (as desktop uses the nav menu to apply the filters instead). In the spirit of reducing code duplication as mentioned in the ticket I then decided to move as much functionality as possible into the base Send component that the web component extends and update the desktop Send component to extend the base class as well. I also modernized the base Send component to use the same services that the `SendListComponent` does and cleaned up all components throughout.

This whole process should result in minimal UI changes. When using search filters (either text of SendType) that result in no Sends being shown the web will now match the desktop and show a "No search results returned" message.