### PR TITLE
[PM-32783] Add caching layer to electron to speed up unlock, and all app interaction

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -307,6 +307,7 @@ export class Main {
     );
 
     app.on("will-quit", () => {
+      this.storageService.dispose();
       this.mainDesktopAutotypeService.dispose();
     });
   }

--- a/apps/desktop/src/platform/main/electron-storage.service.ts
+++ b/apps/desktop/src/platform/main/electron-storage.service.ts
@@ -27,6 +27,10 @@ type Options = BaseOptions<"get"> | BaseOptions<"has"> | SaveOptions | BaseOptio
 
 export class ElectronStorageService implements AbstractStorageService {
   private store: ElectronStore;
+  private readonly flushDelayMs = 1000;
+  private cache: Record<string, unknown>;
+  private isDirty = false;
+  private flushTimeout: NodeJS.Timeout | null = null;
   private updatesSubject = new Subject<StorageUpdate>();
   updates$;
 
@@ -41,6 +45,7 @@ export class ElectronStorageService implements AbstractStorageService {
       configFileMode: fileMode,
     };
     this.store = new ElectronStore(storeConfig);
+    this.cache = { ...this.store.store };
     this.updates$ = this.updatesSubject.asObservable();
 
     ipcMain.handle("storageService", (event, options: Options) => {
@@ -62,12 +67,12 @@ export class ElectronStorageService implements AbstractStorageService {
   }
 
   get<T>(key: string): Promise<T> {
-    const val = this.store.get(key) as T;
+    const val = this.cache[key] as T;
     return Promise.resolve(val != null ? val : null);
   }
 
   has(key: string): Promise<boolean> {
-    const val = this.store.get(key);
+    const val = this.cache[key];
     return Promise.resolve(val != null);
   }
 
@@ -80,14 +85,63 @@ export class ElectronStorageService implements AbstractStorageService {
       obj = Array.from(obj);
     }
 
-    this.store.set(key, obj);
+    this.cache[key] = obj;
+    this.markDirty();
     this.updatesSubject.next({ key, updateType: "save" });
     return Promise.resolve();
   }
 
   remove(key: string): Promise<void> {
-    this.store.delete(key);
+    delete this.cache[key];
+    this.markDirty();
     this.updatesSubject.next({ key, updateType: "remove" });
     return Promise.resolve();
+  }
+
+  list(): Promise<string[]> {
+    return Promise.resolve(Object.keys(this.cache));
+  }
+
+  dispose(): void {
+    this.clearScheduledFlush();
+    this.flushToDisk();
+  }
+
+  private markDirty() {
+    if (this.isDirty) {
+      return;
+    }
+
+    this.isDirty = true;
+    this.scheduleFlush();
+  }
+
+  private scheduleFlush() {
+    if (this.flushTimeout != null) {
+      return;
+    }
+
+    this.flushTimeout = setTimeout(() => {
+      this.clearScheduledFlush();
+      this.flushToDisk();
+    }, this.flushDelayMs);
+  }
+
+  private clearScheduledFlush() {
+    if (this.flushTimeout == null) {
+      return;
+    }
+
+    clearTimeout(this.flushTimeout);
+    this.flushTimeout = null;
+  }
+
+  private flushToDisk() {
+    if (!this.isDirty) {
+      return;
+    }
+
+    this.store.store = { ...this.cache };
+    this.isDirty = false;
   }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-32783

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Makes login, unlock and general UI interaction **_several orders of magnitude faster_** on desktop. Electron store is blocking the main thread with json seralization and deserialization, which makes both persistent state but also in-memory state access slow. This compounds if there is a lot of reads or writes, which blocks UI.

The caching layer here reads the state once, and then never again. Writing happens on a timer, at a maximum of once per second, with an additional flush when the application quits.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
