### PR TITLE
[PM-32817] Deprecated `SharedModule`s

### DIFF
--- a/apps/desktop/src/app/shared/shared.module.ts
+++ b/apps/desktop/src/app/shared/shared.module.ts
@@ -12,6 +12,12 @@ import { IconModule } from "@bitwarden/components";
 import { AvatarComponent } from "../components/avatar.component";
 import { ServicesModule } from "../services/services.module";
 
+/**
+ * @deprecated Please directly import the relevant directive/pipe/component.
+ *
+ * This module is overly large and adds many unrelated modules to your dependency tree.
+ * https://angular.dev/guide/ngmodules/overview recommends not using `NgModule`s for new code.
+ */
 @NgModule({
   imports: [
     CommonModule,

--- a/apps/web/src/app/shared/shared.module.ts
+++ b/apps/web/src/app/shared/shared.module.ts
@@ -35,11 +35,10 @@ import {
 } from "@bitwarden/components";
 
 /**
- * This NgModule should contain the most basic shared directives, pipes, and components. They
- * should be widely used by other modules to be considered for adding to this module. If in doubt
- * do not add to this module.
+ * @deprecated Please directly import the relevant directive/pipe/component.
  *
- * See: https://angular.io/guide/module-types#shared-ngmodules
+ * This module is overly large and adds many unrelated modules to your dependency tree.
+ * https://angular.dev/guide/ngmodules/overview recommends not using `NgModule`s for new code.
  */
 @NgModule({
   imports: [


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-32817
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Follows up the #19186 and deprecates the two `SharedModule`s.
