### PR TITLE
Share inline menu qualification service implementation of keyword matching with autofill service

### DIFF
--- a/apps/browser/src/autofill/content/auto-submit-login.ts
+++ b/apps/browser/src/autofill/content/auto-submit-login.ts
@@ -9,12 +9,12 @@ import { DomQueryService } from "../services/dom-query.service";
 import InsertAutofillContentService from "../services/insert-autofill-content.service";
 import {
   elementIsInputElement,
-  getSubmitButtonKeywordsSet,
   nodeIsButtonElement,
   nodeIsFormElement,
   nodeIsTypeSubmitElement,
   sendExtensionMessage,
 } from "../utils";
+import { getSubmitButtonKeywordsSet } from "../utils/qualification";
 
 (function (globalContext) {
   const domQueryService = new DomQueryService();

--- a/apps/browser/src/autofill/services/abstractions/inline-menu-field-qualifications.service.ts
+++ b/apps/browser/src/autofill/services/abstractions/inline-menu-field-qualifications.service.ts
@@ -1,14 +1,6 @@
 import AutofillField from "../../models/autofill-field";
 import AutofillPageDetails from "../../models/autofill-page-details";
 
-export type AutofillKeywordsMap = WeakMap<
-  AutofillField,
-  {
-    keywordsSet: Set<string>;
-    stringValue: string;
-  }
->;
-
 export type SubmitButtonKeywordsMap = WeakMap<HTMLElement, string>;
 
 export interface InlineMenuFieldQualificationService {

--- a/apps/browser/src/autofill/services/autofill-constants.ts
+++ b/apps/browser/src/autofill/services/autofill-constants.ts
@@ -68,6 +68,37 @@ export class AutoFillConstants {
     "create",
   ];
 
+  static readonly AccountCreationFieldKeywords: string[] = [
+    // Field-level keywords indicating account creation / registration context.
+    // Broader than RegistrationKeywords (which is used at the form level).
+    "register",
+    "registration",
+    "create password",
+    "create a password",
+    "create an account",
+    "create account password",
+    "create user password",
+    "confirm password",
+    "confirm account password",
+    "confirm user password",
+    "new user",
+    "new email",
+    "new e-mail",
+    "new password",
+    "new-password",
+    "neuer benutzer",
+    "neues passwort",
+    "neue e-mail",
+    "pwdcheck",
+  ];
+
+  static readonly UpdatePasswordFieldKeywords: string[] = [
+    "update password",
+    "change password",
+    "current password",
+    "kennwort ändern",
+  ];
+
   static readonly NewsletterFormNames: string[] = ["newsletter"];
 
   static readonly FieldIgnoreList: string[] = ["captcha", "findanything", "forgot"];

--- a/apps/browser/src/autofill/services/autofill-constants.ts
+++ b/apps/browser/src/autofill/services/autofill-constants.ts
@@ -105,7 +105,17 @@ export class AutoFillConstants {
     "kennwort ändern",
   ];
 
-  static readonly NewsletterFormNames: string[] = ["newsletter"];
+  /**
+   * Form-level keywords indicating a non-login context such as newsletter signup or
+   * subscription forms. Used to exclude fields within these forms from login autofill.
+   */
+  static readonly NonLoginFormKeywords: string[] = [
+    "newsletter",
+    "subscribe",
+    "subscription",
+    "unsubscribe",
+    "mailing",
+  ];
 
   static readonly FieldIgnoreList: string[] = ["captcha", "findanything", "forgot"];
 
@@ -434,6 +444,7 @@ export class IdentityAutoFillConstants {
     "label-top",
     "data-recurly",
     "accountCreationFieldType",
+    "type",
   ];
 
   static readonly FullNameFieldNames: string[] = ["name", "full-name", "your-name"];

--- a/apps/browser/src/autofill/services/autofill-constants.ts
+++ b/apps/browser/src/autofill/services/autofill-constants.ts
@@ -68,9 +68,11 @@ export class AutoFillConstants {
     "create",
   ];
 
+  /**
+   * Field-level keywords indicating account creation or registration context.
+   * Broader than {@link RegistrationKeywords}, which is used at the form level.
+   */
   static readonly AccountCreationFieldKeywords: string[] = [
-    // Field-level keywords indicating account creation / registration context.
-    // Broader than RegistrationKeywords (which is used at the form level).
     "register",
     "registration",
     "create password",
@@ -92,6 +94,10 @@ export class AutoFillConstants {
     "pwdcheck",
   ];
 
+  /**
+   * Field-level keywords indicating a password update or change context, as distinguished
+   * from a new account creation or initial login context.
+   */
   static readonly UpdatePasswordFieldKeywords: string[] = [
     "update password",
     "change password",

--- a/apps/browser/src/autofill/services/autofill-constants.ts
+++ b/apps/browser/src/autofill/services/autofill-constants.ts
@@ -111,10 +111,12 @@ export class AutoFillConstants {
    */
   static readonly NonLoginFormKeywords: string[] = [
     "newsletter",
-    "subscribe",
-    "subscription",
-    "unsubscribe",
-    "mailing",
+    // @TODO expand list thoughtfully
+    // consider possible collisions with login forms
+    // consider using a "maybe" check
+    // "subscribe",
+    // "subscription",
+    // "unsubscribe",
   ];
 
   static readonly FieldIgnoreList: string[] = ["captcha", "findanything", "forgot"];

--- a/apps/browser/src/autofill/services/autofill.service.spec.ts
+++ b/apps/browser/src/autofill/services/autofill.service.spec.ts
@@ -4505,7 +4505,6 @@ describe("AutofillService", () => {
       });
       pageDetails.fields = [usernameField, passwordField];
       jest.spyOn(AutofillService, "forCustomFieldsOnly");
-      jest.spyOn(autofillService as any, "findMatchingFieldIndex");
     });
 
     it("returns null when passed a field that is a `span` element", () => {
@@ -4665,7 +4664,7 @@ describe("AutofillService", () => {
       expect(result).toBe(null);
     });
 
-    it("returns the username field whose attributes most closely describe the username of the password field", () => {
+    it("returns the field in the same form whose attributes most closely describe a username, stopping early at that match", () => {
       const usernameField2 = createAutofillFieldMock({
         opid: "username-field-2",
         type: "text",
@@ -4677,7 +4676,7 @@ describe("AutofillService", () => {
         opid: "username-field-3",
         type: "text",
         form: "validFormId",
-        elementNumber: 1,
+        elementNumber: 2,
       });
       passwordField.elementNumber = 3;
       pageDetails.fields = [usernameField, usernameField2, usernameField3, passwordField];
@@ -4690,12 +4689,10 @@ describe("AutofillService", () => {
         false,
       );
 
+      // usernameField2 matches username keywords and is in the same form, so it is
+      // returned early; usernameField3 (which has no username keywords) is never considered.
       expect(result).toBe(usernameField2);
-      expect(autofillService["findMatchingFieldIndex"]).toHaveBeenCalledTimes(2);
-      expect(autofillService["findMatchingFieldIndex"]).not.toHaveBeenCalledWith(
-        usernameField3,
-        AutoFillConstants.UsernameFieldNames,
-      );
+      expect(result).not.toBe(usernameField3);
     });
   });
 

--- a/apps/browser/src/autofill/services/autofill.service.spec.ts
+++ b/apps/browser/src/autofill/services/autofill.service.spec.ts
@@ -4513,7 +4513,6 @@ describe("AutofillService", () => {
 
       const result = autofillService["findUsernameField"](pageDetails, field, false, false, false);
 
-      expect(AutofillService.forCustomFieldsOnly).toHaveBeenCalledWith(field);
       expect(result).toBe(null);
     });
 

--- a/apps/browser/src/autofill/services/autofill.service.spec.ts
+++ b/apps/browser/src/autofill/services/autofill.service.spec.ts
@@ -58,6 +58,7 @@ import {
   createGenerateFillScriptOptionsMock,
 } from "../spec/autofill-mocks";
 import { flushPromises, triggerTestFailure } from "../spec/testing-utils";
+import * as qualification from "../utils/qualification";
 
 import {
   AutoFillOptions,
@@ -1798,7 +1799,7 @@ describe("AutofillService", () => {
       jest.spyOn(autofillService as any, "inUntrustedIframe");
       jest.spyOn(AutofillService, "loadPasswordFields");
       jest.spyOn(autofillService as any, "findUsernameField");
-      jest.spyOn(AutofillService, "fieldIsFuzzyMatch");
+      jest.spyOn(qualification, "fieldContainsKeyword");
       jest.spyOn(AutofillService, "fillByOpid");
       jest.spyOn(AutofillService, "setFillScriptForFocus");
 
@@ -1812,7 +1813,7 @@ describe("AutofillService", () => {
       expect(autofillService["inUntrustedIframe"]).not.toHaveBeenCalled();
       expect(AutofillService.loadPasswordFields).not.toHaveBeenCalled();
       expect(autofillService["findUsernameField"]).not.toHaveBeenCalled();
-      expect(AutofillService.fieldIsFuzzyMatch).not.toHaveBeenCalled();
+      expect(qualification.fieldContainsKeyword).not.toHaveBeenCalled();
       expect(AutofillService.fillByOpid).not.toHaveBeenCalled();
       expect(AutofillService.setFillScriptForFocus).not.toHaveBeenCalled();
       expect(value).toBeNull();
@@ -2350,11 +2351,11 @@ describe("AutofillService", () => {
             totpFieldView,
             nonViewableFieldView,
           ];
-          jest.spyOn(AutofillService, "fieldIsFuzzyMatch");
+          jest.spyOn(qualification, "fieldContainsKeyword");
           jest.spyOn(AutofillService, "fillByOpid");
         });
 
-        it("will attempt to fuzzy match a username to a viewable text, email or tel field if no password fields are found and the username fill is not being skipped", async () => {
+        it("will attempt to keyword match a username to a viewable text, email or tel field if no password fields are found and the username fill is not being skipped", async () => {
           await autofillService["generateLoginFillScript"](
             fillScript,
             pageDetails,
@@ -2362,35 +2363,40 @@ describe("AutofillService", () => {
             options,
           );
 
-          expect(AutofillService.fieldIsFuzzyMatch).toHaveBeenCalledWith(
+          expect(qualification.fieldContainsKeyword).toHaveBeenCalledWith(
             usernameField,
             AutoFillConstants.UsernameFieldNames,
           );
-          expect(AutofillService.fieldIsFuzzyMatch).toHaveBeenCalledWith(
+          expect(qualification.fieldContainsKeyword).toHaveBeenCalledWith(
             emailField,
             AutoFillConstants.UsernameFieldNames,
           );
-          expect(AutofillService.fieldIsFuzzyMatch).toHaveBeenCalledWith(
+          expect(qualification.fieldContainsKeyword).toHaveBeenCalledWith(
             telephoneField,
             AutoFillConstants.UsernameFieldNames,
           );
-          expect(AutofillService.fieldIsFuzzyMatch).toHaveBeenCalledWith(
+          expect(qualification.fieldContainsKeyword).toHaveBeenCalledWith(
             totpField,
             AutoFillConstants.UsernameFieldNames,
           );
-          expect(AutofillService.fieldIsFuzzyMatch).not.toHaveBeenCalledWith(
+          expect(qualification.fieldContainsKeyword).not.toHaveBeenCalledWith(
             nonViewableField,
             AutoFillConstants.UsernameFieldNames,
           );
-          expect(AutofillService.fillByOpid).toHaveBeenCalledTimes(1);
+          expect(AutofillService.fillByOpid).toHaveBeenCalledTimes(2);
           expect(AutofillService.fillByOpid).toHaveBeenCalledWith(
             fillScript,
             usernameField,
             options.cipher.login.username,
           );
+          expect(AutofillService.fillByOpid).toHaveBeenCalledWith(
+            fillScript,
+            emailField,
+            options.cipher.login.username,
+          );
         });
 
-        it("will not attempt to fuzzy match a username if the username fill is being skipped", async () => {
+        it("will not attempt to keyword match a username if the username fill is being skipped", async () => {
           options.skipUsernameOnlyFill = true;
 
           await autofillService["generateLoginFillScript"](
@@ -2400,13 +2406,13 @@ describe("AutofillService", () => {
             options,
           );
 
-          expect(AutofillService.fieldIsFuzzyMatch).not.toHaveBeenCalledWith(
+          expect(qualification.fieldContainsKeyword).not.toHaveBeenCalledWith(
             expect.anything(),
             AutoFillConstants.UsernameFieldNames,
           );
         });
 
-        it("will attempt to fuzzy match a totp field if totp autofill is allowed", async () => {
+        it("will attempt to keyword match a totp field if totp autofill is allowed", async () => {
           options.allowTotpAutofill = true;
 
           await autofillService["generateLoginFillScript"](
@@ -2416,13 +2422,13 @@ describe("AutofillService", () => {
             options,
           );
 
-          expect(AutofillService.fieldIsFuzzyMatch).toHaveBeenCalledWith(
+          expect(qualification.fieldContainsKeyword).toHaveBeenCalledWith(
             expect.anything(),
             AutoFillConstants.TotpFieldNames,
           );
         });
 
-        it("will not attempt to fuzzy match a totp field if totp autofill is not allowed", async () => {
+        it("will not attempt to keyword match a totp field if totp autofill is not allowed", async () => {
           options.allowTotpAutofill = false;
           jest.spyOn(autofillService as any, "findMatchingFieldIndex");
 
@@ -2590,7 +2596,6 @@ describe("AutofillService", () => {
         jest.spyOn(autofillService as any, "inUntrustedIframe");
         jest.spyOn(AutofillService, "loadPasswordFields");
         jest.spyOn(autofillService as any, "findUsernameField");
-        jest.spyOn(AutofillService, "fieldIsFuzzyMatch");
         jest.spyOn(AutofillService, "fillByOpid");
         jest.spyOn(AutofillService, "setFillScriptForFocus");
 
@@ -4717,7 +4722,6 @@ describe("AutofillService", () => {
       pageDetails.fields = [passwordField, totpField];
       jest.spyOn(AutofillService, "forCustomFieldsOnly");
       jest.spyOn(autofillService as any, "findMatchingFieldIndex");
-      jest.spyOn(AutofillService, "fieldIsFuzzyMatch");
     });
 
     it("returns null when passed a field that is a `span` element", () => {
@@ -5062,107 +5066,6 @@ describe("AutofillService", () => {
 
         expect(result).toBe(true);
       });
-    });
-  });
-
-  describe("fieldIsFuzzyMatch", () => {
-    let field: AutofillField;
-    const fieldProperties = [
-      "htmlID",
-      "htmlName",
-      "label-aria",
-      "label-tag",
-      "label-top",
-      "label-left",
-      "placeholder",
-    ];
-
-    beforeEach(() => {
-      field = createAutofillFieldMock();
-      jest.spyOn(AutofillService, "hasValue");
-      jest.spyOn(AutofillService as any, "fuzzyMatch");
-    });
-
-    it("returns false if the field properties do not have any values", () => {
-      fieldProperties.forEach((property) => {
-        field[property] = "";
-      });
-
-      const result = AutofillService["fieldIsFuzzyMatch"](field, ["some-value"]);
-
-      expect(result).toBe(false);
-    });
-
-    it("returns false if the field properties do not have a value that is a fuzzy match", () => {
-      fieldProperties.forEach((property) => {
-        field[property] = "some-false-value";
-
-        const result = AutofillService["fieldIsFuzzyMatch"](field, ["some-value"]);
-
-        expect(AutofillService.hasValue).toHaveBeenCalled();
-        expect(AutofillService["fuzzyMatch"]).toHaveBeenCalledWith(
-          ["some-value"],
-          "some-false-value",
-        );
-        expect(result).toBe(false);
-
-        field[property] = "";
-      });
-    });
-
-    it("returns true if the field property has a value that is a fuzzy match", () => {
-      fieldProperties.forEach((property) => {
-        field[property] = "some-value";
-
-        const result = AutofillService["fieldIsFuzzyMatch"](field, ["some-value"]);
-
-        expect(AutofillService.hasValue).toHaveBeenCalled();
-        expect(AutofillService["fuzzyMatch"]).toHaveBeenCalledWith(["some-value"], "some-value");
-        expect(result).toBe(true);
-
-        field[property] = "";
-      });
-    });
-  });
-
-  describe("fuzzyMatch", () => {
-    it("returns false if the passed options is null", () => {
-      const result = AutofillService["fuzzyMatch"](null, "some-value");
-
-      expect(result).toBe(false);
-    });
-
-    it("returns false if the passed options contains an empty array", () => {
-      const result = AutofillService["fuzzyMatch"]([], "some-value");
-
-      expect(result).toBe(false);
-    });
-
-    it("returns false if the passed value is null", () => {
-      const result = AutofillService["fuzzyMatch"](["some-value"], null);
-
-      expect(result).toBe(false);
-    });
-
-    it("returns false if the passed value is an empty string", () => {
-      const result = AutofillService["fuzzyMatch"](["some-value"], "");
-
-      expect(result).toBe(false);
-    });
-
-    it("returns false if the passed value is not present in the options array", () => {
-      const result = AutofillService["fuzzyMatch"](["some-value"], "some-other-value");
-
-      expect(result).toBe(false);
-    });
-
-    it("returns true if the passed value is within the options array", () => {
-      const result = AutofillService["fuzzyMatch"](
-        ["some-other-value", "some-value"],
-        "some-value",
-      );
-
-      expect(result).toBe(true);
     });
   });
 

--- a/apps/browser/src/autofill/services/autofill.service.ts
+++ b/apps/browser/src/autofill/services/autofill.service.ts
@@ -55,7 +55,7 @@ import { AutofillPort } from "../enums/autofill-port.enum";
 import AutofillField from "../models/autofill-field";
 import AutofillPageDetails from "../models/autofill-page-details";
 import AutofillScript from "../models/autofill-script";
-import { fieldContainsKeyword } from "../utils/qualification";
+import { fieldContainsKeyword, isNonLoginFormContext } from "../utils/qualification";
 
 import {
   AutoFillOptions,
@@ -1083,7 +1083,8 @@ export default class AutofillService implements AutofillServiceInterface {
         const isUsernameField =
           !options.skipUsernameOnlyFill &&
           ["email", "tel", "text"].some((t) => t === field.type) &&
-          fieldContainsKeyword(field, AutoFillConstants.UsernameFieldNames);
+          fieldContainsKeyword(field, AutoFillConstants.UsernameFieldNames) &&
+          !isNonLoginFormContext(field, pageDetails);
 
         // Reliable TOTP signals win unconditionally; username wins over ambiguous TOTP signals.
         switch (true) {
@@ -2497,53 +2498,63 @@ export default class AutofillService implements AutofillServiceInterface {
     canBeReadOnly: boolean,
     withoutForm: boolean,
   ): AutofillField | null {
-    let usernameField: AutofillField | null = null;
-    let usernameFieldInSameForm: AutofillField | null = null;
+    let sameFormCandidate: AutofillField | null = null;
+    let bestCandidate: AutofillField | null = null;
 
-    for (let i = 0; i < pageDetails.fields.length; i++) {
-      const f = pageDetails.fields[i];
-      if (AutofillService.forCustomFieldsOnly(f)) {
+    const fieldsPrecedingPassword = pageDetails.fields.filter(
+      (f) => f.elementNumber < passwordField.elementNumber,
+    );
+
+    for (const field of fieldsPrecedingPassword) {
+      if (AutofillService.forCustomFieldsOnly(field)) {
         continue;
       }
 
-      if (f.elementNumber >= passwordField.elementNumber) {
-        break;
+      if (isNonLoginFormContext(field, pageDetails)) {
+        continue;
       }
 
-      const includesUsernameFieldName = fieldContainsKeyword(
-        f,
-        AutoFillConstants.UsernameFieldNames,
-      );
-      // only consider fields in same form if both have non-null form values
+      const isUsernameFieldType =
+        field.type === "text" || field.type === "email" || field.type === "tel";
+      if (!isUsernameFieldType) {
+        continue;
+      }
+
+      // Only consider fields with non-null form values as being in the same form;
       // null forms are treated as separate
       const isInSameForm =
-        f.form != null && passwordField.form != null && f.form === passwordField.form;
+        field.form != null && passwordField.form != null && field.form === passwordField.form;
 
-      // An email or tel field in the same form as the password field is likely a qualified
-      // candidate for autofill, even if visibility checks are unreliable
-      const isQualifiedUsernameField = isInSameForm && (f.type === "email" || f.type === "tel");
+      const includesUsernameKeyword = fieldContainsKeyword(
+        field,
+        AutoFillConstants.UsernameFieldNames,
+      );
 
-      if (
-        !f.disabled &&
-        (canBeReadOnly || !f.readonly) &&
-        (withoutForm || isInSameForm || includesUsernameFieldName) &&
-        (canBeHidden || f.viewable || isQualifiedUsernameField) &&
-        (f.type === "text" || f.type === "email" || f.type === "tel")
-      ) {
-        // Prioritize fields in the same form as the password field
-        if (isInSameForm) {
-          usernameFieldInSameForm = f;
-          if (includesUsernameFieldName) {
-            return f;
-          }
-        } else {
-          usernameField = f;
+      // Email/tel fields in the same form are strong candidates even when visibility
+      // checks are unreliable
+      const isQualifiedByType = isInSameForm && (field.type === "email" || field.type === "tel");
+
+      const isAccessible = !field.disabled && (canBeReadOnly || !field.readonly);
+      const isVisible = canBeHidden || field.viewable || isQualifiedByType;
+      const isReachable = withoutForm || isInSameForm || includesUsernameKeyword;
+
+      if (!isAccessible || !isVisible || !isReachable) {
+        continue;
+      }
+
+      if (isInSameForm) {
+        sameFormCandidate = field;
+        // A same-form field explicitly named for username is the best possible match
+        if (includesUsernameKeyword) {
+          return field;
         }
+      } else {
+        bestCandidate = field;
       }
     }
 
-    // Prefer username field in same form, fall back to any username field
-    return usernameFieldInSameForm || usernameField;
+    // Prefer a same-form candidate, fall back to any matching field
+    return bestCandidate || sameFormCandidate;
   }
 
   /**

--- a/apps/browser/src/autofill/services/autofill.service.ts
+++ b/apps/browser/src/autofill/services/autofill.service.ts
@@ -2510,8 +2510,10 @@ export default class AutofillService implements AutofillServiceInterface {
         break;
       }
 
-      const includesUsernameFieldName =
-        this.findMatchingFieldIndex(f, AutoFillConstants.UsernameFieldNames) > -1;
+      const includesUsernameFieldName = fieldContainsKeyword(
+        f,
+        AutoFillConstants.UsernameFieldNames,
+      );
       // only consider fields in same form if both have non-null form values
       // null forms are treated as separate
       const isInSameForm =

--- a/apps/browser/src/autofill/services/autofill.service.ts
+++ b/apps/browser/src/autofill/services/autofill.service.ts
@@ -2554,7 +2554,7 @@ export default class AutofillService implements AutofillServiceInterface {
     }
 
     // Prefer a same-form candidate, fall back to any matching field
-    return bestCandidate || sameFormCandidate;
+    return sameFormCandidate || bestCandidate;
   }
 
   /**

--- a/apps/browser/src/autofill/services/autofill.service.ts
+++ b/apps/browser/src/autofill/services/autofill.service.ts
@@ -55,6 +55,7 @@ import { AutofillPort } from "../enums/autofill-port.enum";
 import AutofillField from "../models/autofill-field";
 import AutofillPageDetails from "../models/autofill-page-details";
 import AutofillScript from "../models/autofill-script";
+import { fieldContainsKeyword } from "../utils/qualification";
 
 import {
   AutoFillOptions,
@@ -908,14 +909,12 @@ export default class AutofillService implements AutofillServiceInterface {
       (focusedField.type === "text" ||
         focusedField.type === "number" ||
         focusedField.type === "tel") &&
-      (AutofillService.fieldIsFuzzyMatch(focusedField, [
+      (fieldContainsKeyword(focusedField, [
         ...AutoFillConstants.TotpFieldNames,
         ...AutoFillConstants.AmbiguousTotpFieldNames,
       ]) ||
         focusedField.autoCompleteType === "one-time-code") &&
-      !AutofillService.fieldIsFuzzyMatch(focusedField, [
-        ...AutoFillConstants.RecoveryCodeFieldNames,
-      ]);
+      !fieldContainsKeyword(focusedField, [...AutoFillConstants.RecoveryCodeFieldNames]);
 
     const focusedUsernameField =
       focusedField &&
@@ -1070,21 +1069,21 @@ export default class AutofillService implements AutofillServiceInterface {
         const isTotpCandidate =
           options.allowTotpAutofill &&
           ["number", "tel", "text"].some((t) => t === field.type) &&
-          !AutofillService.fieldIsFuzzyMatch(field, [...AutoFillConstants.RecoveryCodeFieldNames]);
+          !fieldContainsKeyword(field, [...AutoFillConstants.RecoveryCodeFieldNames]);
 
         const isTotpField =
           isTotpCandidate &&
-          (AutofillService.fieldIsFuzzyMatch(field, AutoFillConstants.TotpFieldNames) ||
+          (fieldContainsKeyword(field, AutoFillConstants.TotpFieldNames) ||
             field.autoCompleteType === "one-time-code");
 
         const maybeTotpField =
           isTotpCandidate &&
-          AutofillService.fieldIsFuzzyMatch(field, AutoFillConstants.AmbiguousTotpFieldNames);
+          fieldContainsKeyword(field, AutoFillConstants.AmbiguousTotpFieldNames);
 
         const isUsernameField =
           !options.skipUsernameOnlyFill &&
           ["email", "tel", "text"].some((t) => t === field.type) &&
-          AutofillService.fieldIsFuzzyMatch(field, AutoFillConstants.UsernameFieldNames);
+          fieldContainsKeyword(field, AutoFillConstants.UsernameFieldNames);
 
         // Reliable TOTP signals win unconditionally; username wins over ambiguous TOTP signals.
         switch (true) {
@@ -2413,7 +2412,7 @@ export default class AutofillService implements AutofillServiceInterface {
       }
 
       // We want to avoid treating TOTP fields as password fields
-      if (AutofillService.fieldIsFuzzyMatch(f, AutoFillConstants.TotpFieldNames)) {
+      if (fieldContainsKeyword(f, AutoFillConstants.TotpFieldNames)) {
         return;
       }
 
@@ -2582,11 +2581,11 @@ export default class AutofillService implements AutofillServiceInterface {
           f.type === "number" ||
           // sites will commonly use tel in order to get the digit pad against semantic recommendations
           f.type === "tel") &&
-        AutofillService.fieldIsFuzzyMatch(f, [
+        fieldContainsKeyword(f, [
           ...AutoFillConstants.TotpFieldNames,
           ...AutoFillConstants.AmbiguousTotpFieldNames,
         ]) &&
-        !AutofillService.fieldIsFuzzyMatch(f, [...AutoFillConstants.RecoveryCodeFieldNames])
+        !fieldContainsKeyword(f, [...AutoFillConstants.RecoveryCodeFieldNames])
       ) {
         totpField = f;
 
@@ -2736,96 +2735,6 @@ export default class AutofillService implements AutofillServiceInterface {
     }
 
     return fieldVal.toLowerCase() === name;
-  }
-
-  /**
-   * Accepts a field and returns true if the field contains a
-   * value that matches any of the names in the provided list.
-   *
-   * Returns boolean and attr of value that was matched as a tuple if showMatch is set to true.
-   *
-   * @param {AutofillField} field
-   * @param {string[]} names
-   * @param {boolean} showMatch
-   * @returns {boolean | [boolean, { attr: string; value: string }?]}
-   */
-  static fieldIsFuzzyMatch(
-    field: AutofillField,
-    names: string[],
-    showMatch: true,
-  ): [boolean, { attr: string; value: string }?];
-  static fieldIsFuzzyMatch(field: AutofillField, names: string[]): boolean;
-  static fieldIsFuzzyMatch(
-    field: AutofillField,
-    names: string[],
-    showMatch: boolean = false,
-  ): boolean | [boolean, { attr: string; value: string }?] {
-    const attrs = [
-      "htmlID",
-      "htmlName",
-      "label-tag",
-      "placeholder",
-      "label-left",
-      "label-right",
-      "label-top",
-      "label-aria",
-      "dataSetValues",
-    ];
-
-    for (const attr of attrs) {
-      const value = field[attr];
-      if (!AutofillService.hasValue(value)) {
-        continue;
-      }
-      if (AutofillService.fuzzyMatch(names, value)) {
-        return showMatch ? [true, { attr, value }] : true;
-      }
-    }
-    return showMatch ? [false] : false;
-  }
-
-  /**
-   * Accepts a list of options and a value and returns
-   * true if the value matches any of the options.
-   * @param {string[]} options
-   * @param {string} value
-   * @returns {boolean}
-   * @private
-   */
-  private static fuzzyMatch(options: string[], value: string): boolean {
-    if (!options || !value) {
-      return false;
-    }
-
-    value = value
-      .replace(/(?:\r\n|\r|\n)/g, "")
-      .trim()
-      .toLowerCase();
-
-    return options.some((o) => o === value);
-
-    if (
-      options == null ||
-      options.length === 0 ||
-      value == null ||
-      typeof value !== "string" ||
-      value.length < 1
-    ) {
-      return false;
-    }
-
-    value = value
-      .replace(/(?:\r\n|\r|\n)/g, "")
-      .trim()
-      .toLowerCase();
-
-    for (let i = 0; i < options.length; i++) {
-      if (value.indexOf(options[i]) > -1) {
-        return true;
-      }
-    }
-
-    return false;
   }
 
   /**

--- a/apps/browser/src/autofill/services/autofill.service.ts
+++ b/apps/browser/src/autofill/services/autofill.service.ts
@@ -1077,8 +1077,7 @@ export default class AutofillService implements AutofillServiceInterface {
             field.autoCompleteType === "one-time-code");
 
         const maybeTotpField =
-          isTotpCandidate &&
-          fieldContainsKeyword(field, AutoFillConstants.AmbiguousTotpFieldNames);
+          isTotpCandidate && fieldContainsKeyword(field, AutoFillConstants.AmbiguousTotpFieldNames);
 
         const isUsernameField =
           !options.skipUsernameOnlyFill &&

--- a/apps/browser/src/autofill/services/autofill.service.ts
+++ b/apps/browser/src/autofill/services/autofill.service.ts
@@ -2793,6 +2793,17 @@ export default class AutofillService implements AutofillServiceInterface {
    * @private
    */
   private static fuzzyMatch(options: string[], value: string): boolean {
+    if (!options || !value) {
+      return false;
+    }
+
+    value = value
+      .replace(/(?:\r\n|\r|\n)/g, "")
+      .trim()
+      .toLowerCase();
+
+    return options.some((o) => o === value);
+
     if (
       options == null ||
       options.length === 0 ||

--- a/apps/browser/src/autofill/services/inline-menu-field-qualification.service.ts
+++ b/apps/browser/src/autofill/services/inline-menu-field-qualification.service.ts
@@ -32,7 +32,7 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
   private newPasswordAutoCompleteValue = "new-password";
   private submitButtonKeywordsMap: SubmitButtonKeywordsMap = new WeakMap();
   private newEmailFieldKeywords = new Set(AutoFillConstants.NewEmailFieldKeywords);
-  private newsletterFormKeywords = new Set(AutoFillConstants.NewsletterFormNames);
+  private = new Set(AutoFillConstants.NonLoginFormKeywords);
   private creditCardFieldKeywords = [
     ...new Set([
       ...CreditCardAutoFillConstants.CardHolderFieldNames,

--- a/apps/browser/src/autofill/services/inline-menu-field-qualification.service.ts
+++ b/apps/browser/src/autofill/services/inline-menu-field-qualification.service.ts
@@ -1218,7 +1218,8 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
     keywords: string[],
     fuzzyMatchKeywords = true,
   ) {
-    const searchedValues = this.getAutofillFieldDataKeywords(autofillFieldData, fuzzyMatchKeywords);
+    const returnStringValue = fuzzyMatchKeywords;
+    const searchedValues = this.getAutofillFieldDataKeywords(autofillFieldData, returnStringValue);
     const parsedKeywords = keywords.map((keyword) => keyword.replace(/-/g, ""));
 
     if (typeof searchedValues === "string") {

--- a/apps/browser/src/autofill/services/inline-menu-field-qualification.service.ts
+++ b/apps/browser/src/autofill/services/inline-menu-field-qualification.service.ts
@@ -1,7 +1,11 @@
 import AutofillField from "../models/autofill-field";
 import AutofillPageDetails from "../models/autofill-page-details";
 import { sendExtensionMessage } from "../utils";
-import { fieldContainsKeyword, getSubmitButtonKeywordsSet } from "../utils/qualification";
+import {
+  fieldContainsKeyword,
+  getSubmitButtonKeywordsSet,
+  isNonLoginFormContext,
+} from "../utils/qualification";
 
 import {
   InlineMenuFieldQualificationService as InlineMenuFieldQualificationServiceInterface,
@@ -32,7 +36,6 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
   private newPasswordAutoCompleteValue = "new-password";
   private submitButtonKeywordsMap: SubmitButtonKeywordsMap = new WeakMap();
   private newEmailFieldKeywords = new Set(AutoFillConstants.NewEmailFieldKeywords);
-  private = new Set(AutoFillConstants.NonLoginFormKeywords);
   private creditCardFieldKeywords = [
     ...new Set([
       ...CreditCardAutoFillConstants.CardHolderFieldNames,
@@ -137,39 +140,6 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
 
       for (let keywordIndex = 0; keywordIndex < matchFieldAttributeValues.length; keywordIndex++) {
         if (this.newEmailFieldKeywords.has(attributeValueToMatch)) {
-          return true;
-        }
-      }
-    }
-
-    return false;
-  }
-
-  /**
-   * Validates the provided form to indicate if the form is related to newsletter registration.
-   *
-   * @param parentForm - The form to validate
-   */
-  private isNewsletterForm(parentForm: any): boolean {
-    if (!parentForm) {
-      return false;
-    }
-
-    const matchFieldAttributeValues = [
-      parentForm.type,
-      parentForm.htmlName,
-      parentForm.htmlID,
-      parentForm.placeholder,
-    ];
-
-    for (let attrIndex = 0; attrIndex < matchFieldAttributeValues.length; attrIndex++) {
-      const attrValue = matchFieldAttributeValues[attrIndex];
-      if (!attrValue || typeof attrValue !== "string") {
-        continue;
-      }
-      const attrValueLower = attrValue.toLowerCase();
-      for (const keyword of this.newsletterFormKeywords) {
-        if (attrValueLower.includes(keyword.toLowerCase())) {
           return true;
         }
       }
@@ -469,7 +439,11 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
     }
     const passwordFieldsInPageDetails = pageDetails.fields.filter(this.isCurrentPasswordField);
 
-    if (this.isNewsletterForm(parentForm)) {
+    /**
+     * If a field is part of a newsletter form, or other recognized non-login type forms, it isn't a username
+     * {@link AutoFillConstants.NonLoginFormKeywords}
+     */
+    if (isNonLoginFormContext(field, pageDetails)) {
       return false;
     }
 

--- a/apps/browser/src/autofill/services/inline-menu-field-qualification.service.ts
+++ b/apps/browser/src/autofill/services/inline-menu-field-qualification.service.ts
@@ -1,9 +1,9 @@
 import AutofillField from "../models/autofill-field";
 import AutofillPageDetails from "../models/autofill-page-details";
-import { getSubmitButtonKeywordsSet, sendExtensionMessage } from "../utils";
+import { sendExtensionMessage } from "../utils";
+import { fieldContainsKeyword, getSubmitButtonKeywordsSet } from "../utils/qualification";
 
 import {
-  AutofillKeywordsMap,
   InlineMenuFieldQualificationService as InlineMenuFieldQualificationServiceInterface,
   SubmitButtonKeywordsMap,
 } from "./abstractions/inline-menu-field-qualifications.service";
@@ -14,7 +14,6 @@ import {
   SubmitChangePasswordButtonNames,
   SubmitLoginButtonNames,
 } from "./autofill-constants";
-import AutofillService from "./autofill.service";
 
 export class InlineMenuFieldQualificationService implements InlineMenuFieldQualificationServiceInterface {
   private searchFieldNamesSet = new Set(AutoFillConstants.SearchFieldNames);
@@ -31,7 +30,6 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
   private fieldIgnoreListString = AutoFillConstants.FieldIgnoreList.join(",");
   private currentPasswordAutocompleteValue = "current-password";
   private newPasswordAutoCompleteValue = "new-password";
-  private autofillFieldKeywordsMap: AutofillKeywordsMap = new WeakMap();
   private submitButtonKeywordsMap: SubmitButtonKeywordsMap = new WeakMap();
   private accountCreationFieldKeywords = [
     "register",
@@ -282,7 +280,7 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
         return false;
       }
 
-      return this.keywordsFoundInFieldData(field, this.creditCardFieldKeywords);
+      return fieldContainsKeyword(field, this.creditCardFieldKeywords);
     }
 
     // If the field has a parent form, check the fields from that form exclusively
@@ -302,7 +300,7 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
       return false;
     }
 
-    return this.keywordsFoundInFieldData(field, [...this.creditCardFieldKeywords]);
+    return fieldContainsKeyword(field, [...this.creditCardFieldKeywords]);
   }
 
   /** Validates the provided field as a field for an account creation form.
@@ -340,7 +338,7 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
 
       // If no password fields are found on the page, check for keywords that indicate the field is
       // part of an account creation form.
-      return this.keywordsFoundInFieldData(field, this.accountCreationFieldKeywords);
+      return fieldContainsKeyword(field, this.accountCreationFieldKeywords);
     }
 
     // If the field has a parent form, check the fields from that form exclusively
@@ -350,7 +348,7 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
       return true;
     }
 
-    return this.keywordsFoundInFieldData(field, this.accountCreationFieldKeywords);
+    return fieldContainsKeyword(field, this.accountCreationFieldKeywords);
   }
 
   /**
@@ -483,7 +481,7 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
 
     // If any keywords in the field's data indicates that this is a field for a "new" or "changed"
     // username, we should assume that this field is not for a login form.
-    if (this.keywordsFoundInFieldData(field, this.accountCreationFieldKeywords)) {
+    if (fieldContainsKeyword(field, this.accountCreationFieldKeywords)) {
       return false;
     }
 
@@ -584,11 +582,7 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
       return true;
     }
 
-    return this.keywordsFoundInFieldData(
-      field,
-      CreditCardAutoFillConstants.CardHolderFieldNames,
-      false,
-    );
+    return fieldContainsKeyword(field, CreditCardAutoFillConstants.CardHolderFieldNames, true);
   };
 
   /**
@@ -601,11 +595,7 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
       return true;
     }
 
-    return this.keywordsFoundInFieldData(
-      field,
-      CreditCardAutoFillConstants.CardNumberFieldNames,
-      false,
-    );
+    return fieldContainsKeyword(field, CreditCardAutoFillConstants.CardNumberFieldNames, true);
   };
 
   /**
@@ -620,11 +610,7 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
       return true;
     }
 
-    return this.keywordsFoundInFieldData(
-      field,
-      CreditCardAutoFillConstants.CardExpiryFieldNames,
-      false,
-    );
+    return fieldContainsKeyword(field, CreditCardAutoFillConstants.CardExpiryFieldNames, true);
   };
 
   /**
@@ -639,11 +625,7 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
       return true;
     }
 
-    return this.keywordsFoundInFieldData(
-      field,
-      CreditCardAutoFillConstants.ExpiryMonthFieldNames,
-      false,
-    );
+    return fieldContainsKeyword(field, CreditCardAutoFillConstants.ExpiryMonthFieldNames, true);
   };
 
   /**
@@ -658,11 +640,7 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
       return true;
     }
 
-    return this.keywordsFoundInFieldData(
-      field,
-      CreditCardAutoFillConstants.ExpiryYearFieldNames,
-      false,
-    );
+    return fieldContainsKeyword(field, CreditCardAutoFillConstants.ExpiryYearFieldNames, true);
   };
 
   /**
@@ -675,7 +653,7 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
       return true;
     }
 
-    return this.keywordsFoundInFieldData(field, CreditCardAutoFillConstants.CVVFieldNames, false);
+    return fieldContainsKeyword(field, CreditCardAutoFillConstants.CVVFieldNames, true);
   };
 
   /**
@@ -690,7 +668,7 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
       return true;
     }
 
-    return this.keywordsFoundInFieldData(field, IdentityAutoFillConstants.TitleFieldNames, false);
+    return fieldContainsKeyword(field, IdentityAutoFillConstants.TitleFieldNames, true);
   };
 
   /**
@@ -703,11 +681,7 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
       return true;
     }
 
-    return this.keywordsFoundInFieldData(
-      field,
-      IdentityAutoFillConstants.FirstnameFieldNames,
-      false,
-    );
+    return fieldContainsKeyword(field, IdentityAutoFillConstants.FirstnameFieldNames, true);
   };
 
   /**
@@ -720,11 +694,7 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
       return true;
     }
 
-    return this.keywordsFoundInFieldData(
-      field,
-      IdentityAutoFillConstants.MiddlenameFieldNames,
-      false,
-    );
+    return fieldContainsKeyword(field, IdentityAutoFillConstants.MiddlenameFieldNames, true);
   };
 
   /**
@@ -737,11 +707,7 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
       return true;
     }
 
-    return this.keywordsFoundInFieldData(
-      field,
-      IdentityAutoFillConstants.LastnameFieldNames,
-      false,
-    );
+    return fieldContainsKeyword(field, IdentityAutoFillConstants.LastnameFieldNames, true);
   };
 
   /**
@@ -754,11 +720,7 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
       return true;
     }
 
-    return this.keywordsFoundInFieldData(
-      field,
-      IdentityAutoFillConstants.FullNameFieldNames,
-      false,
-    );
+    return fieldContainsKeyword(field, IdentityAutoFillConstants.FullNameFieldNames, true);
   };
 
   /**
@@ -771,13 +733,13 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
       return true;
     }
 
-    return this.keywordsFoundInFieldData(
+    return fieldContainsKeyword(
       field,
       [
         ...IdentityAutoFillConstants.AddressFieldNames,
         ...IdentityAutoFillConstants.Address1FieldNames,
       ],
-      false,
+      true,
     );
   };
 
@@ -791,11 +753,7 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
       return true;
     }
 
-    return this.keywordsFoundInFieldData(
-      field,
-      IdentityAutoFillConstants.Address2FieldNames,
-      false,
-    );
+    return fieldContainsKeyword(field, IdentityAutoFillConstants.Address2FieldNames, true);
   };
 
   /**
@@ -808,11 +766,7 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
       return true;
     }
 
-    return this.keywordsFoundInFieldData(
-      field,
-      IdentityAutoFillConstants.Address3FieldNames,
-      false,
-    );
+    return fieldContainsKeyword(field, IdentityAutoFillConstants.Address3FieldNames, true);
   };
 
   /**
@@ -825,7 +779,7 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
       return true;
     }
 
-    return this.keywordsFoundInFieldData(field, IdentityAutoFillConstants.CityFieldNames, false);
+    return fieldContainsKeyword(field, IdentityAutoFillConstants.CityFieldNames, true);
   };
 
   /**
@@ -838,7 +792,7 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
       return true;
     }
 
-    return this.keywordsFoundInFieldData(field, IdentityAutoFillConstants.StateFieldNames, false);
+    return fieldContainsKeyword(field, IdentityAutoFillConstants.StateFieldNames, true);
   };
 
   /**
@@ -851,11 +805,7 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
       return true;
     }
 
-    return this.keywordsFoundInFieldData(
-      field,
-      IdentityAutoFillConstants.PostalCodeFieldNames,
-      false,
-    );
+    return fieldContainsKeyword(field, IdentityAutoFillConstants.PostalCodeFieldNames, true);
   };
 
   /**
@@ -868,7 +818,7 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
       return true;
     }
 
-    return this.keywordsFoundInFieldData(field, IdentityAutoFillConstants.CountryFieldNames, false);
+    return fieldContainsKeyword(field, IdentityAutoFillConstants.CountryFieldNames, true);
   };
 
   /**
@@ -881,7 +831,7 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
       return true;
     }
 
-    return this.keywordsFoundInFieldData(field, IdentityAutoFillConstants.CompanyFieldNames, false);
+    return fieldContainsKeyword(field, IdentityAutoFillConstants.CompanyFieldNames, true);
   };
 
   /**
@@ -894,7 +844,7 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
       return true;
     }
 
-    return this.keywordsFoundInFieldData(field, IdentityAutoFillConstants.PhoneFieldNames, false);
+    return fieldContainsKeyword(field, IdentityAutoFillConstants.PhoneFieldNames, true);
   };
 
   /**
@@ -915,7 +865,7 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
       return true;
     }
 
-    return this.keywordsFoundInFieldData(field, IdentityAutoFillConstants.EmailFieldNames, false);
+    return fieldContainsKeyword(field, IdentityAutoFillConstants.EmailFieldNames, true);
   };
 
   /**
@@ -928,11 +878,7 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
       return true;
     }
 
-    return this.keywordsFoundInFieldData(
-      field,
-      IdentityAutoFillConstants.UserNameFieldNames,
-      false,
-    );
+    return fieldContainsKeyword(field, IdentityAutoFillConstants.UserNameFieldNames, true);
   };
 
   /**
@@ -952,7 +898,7 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
       return false;
     }
 
-    return this.keywordsFoundInFieldData(field, AutoFillConstants.UsernameFieldNames);
+    return fieldContainsKeyword(field, AutoFillConstants.UsernameFieldNames);
   };
 
   /**
@@ -967,7 +913,7 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
 
     return (
       !this.isExcludedFieldType(field, this.excludedAutofillFieldTypesSet) &&
-      this.keywordsFoundInFieldData(field, AutoFillConstants.EmailFieldNames)
+      fieldContainsKeyword(field, AutoFillConstants.EmailFieldNames)
     );
   };
 
@@ -979,7 +925,7 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
   isCurrentPasswordField = (field: AutofillField): boolean => {
     if (
       this.fieldContainsAutocompleteValues(field, this.newPasswordAutoCompleteValue) ||
-      this.keywordsFoundInFieldData(field, this.accountCreationFieldKeywords)
+      fieldContainsKeyword(field, this.accountCreationFieldKeywords)
     ) {
       return false;
     }
@@ -998,8 +944,7 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
     }
 
     return (
-      this.isPasswordField(field) &&
-      this.keywordsFoundInFieldData(field, this.updatePasswordFieldKeywords)
+      this.isPasswordField(field) && fieldContainsKeyword(field, this.updatePasswordFieldKeywords)
     );
   };
 
@@ -1014,8 +959,7 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
     }
 
     return (
-      this.isPasswordField(field) &&
-      this.keywordsFoundInFieldData(field, this.accountCreationFieldKeywords)
+      this.isPasswordField(field) && fieldContainsKeyword(field, this.accountCreationFieldKeywords)
     );
   };
 
@@ -1090,7 +1034,7 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
    * @param field - The field to validate
    */
   isTotpField = (field: AutofillField): boolean => {
-    if (AutofillService.fieldIsFuzzyMatch(field, [...AutoFillConstants.RecoveryCodeFieldNames])) {
+    if (fieldContainsKeyword(field, [...AutoFillConstants.RecoveryCodeFieldNames])) {
       return false;
     }
 
@@ -1100,7 +1044,7 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
 
     return (
       !this.isExcludedFieldType(field, this.excludedAutofillFieldTypesSet) &&
-      this.keywordsFoundInFieldData(field, AutoFillConstants.TotpFieldNames)
+      fieldContainsKeyword(field, AutoFillConstants.TotpFieldNames)
     );
   };
 
@@ -1204,93 +1148,6 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
     }
 
     return this.submitButtonKeywordsMap.get(element) || "";
-  }
-
-  /**
-   * Validates the provided field to indicate if the field has any of the provided keywords.
-   *
-   * @param autofillFieldData - The field data to search for keywords
-   * @param keywords - The keywords to search for
-   * @param fuzzyMatchKeywords - Indicates if the keywords should be matched in a fuzzy manner
-   */
-  private keywordsFoundInFieldData(
-    autofillFieldData: AutofillField,
-    keywords: string[],
-    fuzzyMatchKeywords = true,
-  ) {
-    const returnStringValue = fuzzyMatchKeywords;
-    const searchedValues = this.getAutofillFieldDataKeywords(autofillFieldData, returnStringValue);
-    const parsedKeywords = keywords.map((keyword) => keyword.replace(/-/g, ""));
-
-    if (typeof searchedValues === "string") {
-      return parsedKeywords.some((keyword) => searchedValues.indexOf(keyword) > -1);
-    }
-
-    return parsedKeywords.some((keyword) => searchedValues.has(keyword));
-  }
-
-  /**
-   * Retrieves the keywords from the provided autofill field data.
-   *
-   * @param autofillFieldData - The field data to search for keywords
-   * @param returnStringValue - Indicates if the method should return a string value
-   */
-  private getAutofillFieldDataKeywords(
-    autofillFieldData: AutofillField,
-    returnStringValue: boolean,
-  ) {
-    if (!this.autofillFieldKeywordsMap.has(autofillFieldData)) {
-      const keywords = [
-        autofillFieldData.htmlID,
-        autofillFieldData.htmlName,
-        autofillFieldData.htmlClass,
-        autofillFieldData.type,
-        autofillFieldData.title,
-        autofillFieldData.placeholder,
-        autofillFieldData.autoCompleteType,
-        autofillFieldData.dataSetValues,
-        autofillFieldData["label-data"],
-        autofillFieldData["label-aria"],
-        autofillFieldData["label-left"],
-        autofillFieldData["label-right"],
-        autofillFieldData["label-tag"],
-        autofillFieldData["label-top"],
-      ];
-      const keywordsSet = new Set<string>();
-      for (let i = 0; i < keywords.length; i++) {
-        const attributeValue = keywords[i];
-        if (attributeValue && typeof attributeValue === "string") {
-          let keywordEl = attributeValue.toLowerCase();
-          keywordsSet.add(keywordEl);
-
-          // Remove hyphens from all potential keywords, we want to treat these as a single word.
-          keywordEl = keywordEl.replace(/-/g, "");
-
-          // Split the keyword by non-alphanumeric characters to get the keywords without treating a space as a separator.
-          keywordEl.split(/[^\p{L}\d]+/gu).forEach((keyword: string) => {
-            if (keyword) {
-              keywordsSet.add(keyword);
-            }
-          });
-
-          // Collapse all spaces and split by non-alphanumeric characters to get the keywords
-          keywordEl
-            .replace(/\s/g, "")
-            .split(/[^\p{L}\d]+/gu)
-            .forEach((keyword: string) => {
-              if (keyword) {
-                keywordsSet.add(keyword);
-              }
-            });
-        }
-      }
-
-      const stringValue = Array.from(keywordsSet).join(",");
-      this.autofillFieldKeywordsMap.set(autofillFieldData, { keywordsSet, stringValue });
-    }
-
-    const mapValues = this.autofillFieldKeywordsMap.get(autofillFieldData);
-    return mapValues ? (returnStringValue ? mapValues.stringValue : mapValues.keywordsSet) : "";
   }
 
   /**

--- a/apps/browser/src/autofill/services/inline-menu-field-qualification.service.ts
+++ b/apps/browser/src/autofill/services/inline-menu-field-qualification.service.ts
@@ -31,35 +31,8 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
   private currentPasswordAutocompleteValue = "current-password";
   private newPasswordAutoCompleteValue = "new-password";
   private submitButtonKeywordsMap: SubmitButtonKeywordsMap = new WeakMap();
-  private accountCreationFieldKeywords = [
-    "register",
-    "registration",
-    "create password",
-    "create a password",
-    "create an account",
-    "create account password",
-    "create user password",
-    "confirm password",
-    "confirm account password",
-    "confirm user password",
-    "new user",
-    "new email",
-    "new e-mail",
-    "new password",
-    "new-password",
-    "neuer benutzer",
-    "neues passwort",
-    "neue e-mail",
-    "pwdcheck",
-  ];
   private newEmailFieldKeywords = new Set(AutoFillConstants.NewEmailFieldKeywords);
   private newsletterFormKeywords = new Set(AutoFillConstants.NewsletterFormNames);
-  private updatePasswordFieldKeywords = [
-    "update password",
-    "change password",
-    "current password",
-    "kennwort ändern",
-  ];
   private creditCardFieldKeywords = [
     ...new Set([
       ...CreditCardAutoFillConstants.CardHolderFieldNames,
@@ -338,7 +311,7 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
 
       // If no password fields are found on the page, check for keywords that indicate the field is
       // part of an account creation form.
-      return fieldContainsKeyword(field, this.accountCreationFieldKeywords);
+      return fieldContainsKeyword(field, AutoFillConstants.AccountCreationFieldKeywords);
     }
 
     // If the field has a parent form, check the fields from that form exclusively
@@ -348,7 +321,7 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
       return true;
     }
 
-    return fieldContainsKeyword(field, this.accountCreationFieldKeywords);
+    return fieldContainsKeyword(field, AutoFillConstants.AccountCreationFieldKeywords);
   }
 
   /**
@@ -481,7 +454,7 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
 
     // If any keywords in the field's data indicates that this is a field for a "new" or "changed"
     // username, we should assume that this field is not for a login form.
-    if (fieldContainsKeyword(field, this.accountCreationFieldKeywords)) {
+    if (fieldContainsKeyword(field, AutoFillConstants.AccountCreationFieldKeywords)) {
       return false;
     }
 
@@ -925,7 +898,7 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
   isCurrentPasswordField = (field: AutofillField): boolean => {
     if (
       this.fieldContainsAutocompleteValues(field, this.newPasswordAutoCompleteValue) ||
-      fieldContainsKeyword(field, this.accountCreationFieldKeywords)
+      fieldContainsKeyword(field, AutoFillConstants.AccountCreationFieldKeywords)
     ) {
       return false;
     }
@@ -944,7 +917,8 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
     }
 
     return (
-      this.isPasswordField(field) && fieldContainsKeyword(field, this.updatePasswordFieldKeywords)
+      this.isPasswordField(field) &&
+      fieldContainsKeyword(field, AutoFillConstants.UpdatePasswordFieldKeywords)
     );
   };
 
@@ -959,7 +933,8 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
     }
 
     return (
-      this.isPasswordField(field) && fieldContainsKeyword(field, this.accountCreationFieldKeywords)
+      this.isPasswordField(field) &&
+      fieldContainsKeyword(field, AutoFillConstants.AccountCreationFieldKeywords)
     );
   };
 

--- a/apps/browser/src/autofill/services/inline-menu-field-qualification.service.ts
+++ b/apps/browser/src/autofill/services/inline-menu-field-qualification.service.ts
@@ -555,7 +555,7 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
       return true;
     }
 
-    return fieldContainsKeyword(field, CreditCardAutoFillConstants.CardHolderFieldNames, true);
+    return fieldContainsKeyword(field, CreditCardAutoFillConstants.CardHolderFieldNames, false);
   };
 
   /**
@@ -568,7 +568,7 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
       return true;
     }
 
-    return fieldContainsKeyword(field, CreditCardAutoFillConstants.CardNumberFieldNames, true);
+    return fieldContainsKeyword(field, CreditCardAutoFillConstants.CardNumberFieldNames, false);
   };
 
   /**
@@ -583,7 +583,7 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
       return true;
     }
 
-    return fieldContainsKeyword(field, CreditCardAutoFillConstants.CardExpiryFieldNames, true);
+    return fieldContainsKeyword(field, CreditCardAutoFillConstants.CardExpiryFieldNames, false);
   };
 
   /**
@@ -598,7 +598,7 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
       return true;
     }
 
-    return fieldContainsKeyword(field, CreditCardAutoFillConstants.ExpiryMonthFieldNames, true);
+    return fieldContainsKeyword(field, CreditCardAutoFillConstants.ExpiryMonthFieldNames, false);
   };
 
   /**
@@ -613,7 +613,7 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
       return true;
     }
 
-    return fieldContainsKeyword(field, CreditCardAutoFillConstants.ExpiryYearFieldNames, true);
+    return fieldContainsKeyword(field, CreditCardAutoFillConstants.ExpiryYearFieldNames, false);
   };
 
   /**
@@ -626,7 +626,7 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
       return true;
     }
 
-    return fieldContainsKeyword(field, CreditCardAutoFillConstants.CVVFieldNames, true);
+    return fieldContainsKeyword(field, CreditCardAutoFillConstants.CVVFieldNames, false);
   };
 
   /**
@@ -641,7 +641,7 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
       return true;
     }
 
-    return fieldContainsKeyword(field, IdentityAutoFillConstants.TitleFieldNames, true);
+    return fieldContainsKeyword(field, IdentityAutoFillConstants.TitleFieldNames, false);
   };
 
   /**
@@ -654,7 +654,7 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
       return true;
     }
 
-    return fieldContainsKeyword(field, IdentityAutoFillConstants.FirstnameFieldNames, true);
+    return fieldContainsKeyword(field, IdentityAutoFillConstants.FirstnameFieldNames, false);
   };
 
   /**
@@ -667,7 +667,7 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
       return true;
     }
 
-    return fieldContainsKeyword(field, IdentityAutoFillConstants.MiddlenameFieldNames, true);
+    return fieldContainsKeyword(field, IdentityAutoFillConstants.MiddlenameFieldNames, false);
   };
 
   /**
@@ -680,7 +680,7 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
       return true;
     }
 
-    return fieldContainsKeyword(field, IdentityAutoFillConstants.LastnameFieldNames, true);
+    return fieldContainsKeyword(field, IdentityAutoFillConstants.LastnameFieldNames, false);
   };
 
   /**
@@ -693,7 +693,7 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
       return true;
     }
 
-    return fieldContainsKeyword(field, IdentityAutoFillConstants.FullNameFieldNames, true);
+    return fieldContainsKeyword(field, IdentityAutoFillConstants.FullNameFieldNames, false);
   };
 
   /**
@@ -712,7 +712,7 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
         ...IdentityAutoFillConstants.AddressFieldNames,
         ...IdentityAutoFillConstants.Address1FieldNames,
       ],
-      true,
+      false,
     );
   };
 
@@ -726,7 +726,7 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
       return true;
     }
 
-    return fieldContainsKeyword(field, IdentityAutoFillConstants.Address2FieldNames, true);
+    return fieldContainsKeyword(field, IdentityAutoFillConstants.Address2FieldNames, false);
   };
 
   /**
@@ -739,7 +739,7 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
       return true;
     }
 
-    return fieldContainsKeyword(field, IdentityAutoFillConstants.Address3FieldNames, true);
+    return fieldContainsKeyword(field, IdentityAutoFillConstants.Address3FieldNames, false);
   };
 
   /**
@@ -752,7 +752,7 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
       return true;
     }
 
-    return fieldContainsKeyword(field, IdentityAutoFillConstants.CityFieldNames, true);
+    return fieldContainsKeyword(field, IdentityAutoFillConstants.CityFieldNames, false);
   };
 
   /**
@@ -765,7 +765,7 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
       return true;
     }
 
-    return fieldContainsKeyword(field, IdentityAutoFillConstants.StateFieldNames, true);
+    return fieldContainsKeyword(field, IdentityAutoFillConstants.StateFieldNames, false);
   };
 
   /**
@@ -778,7 +778,7 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
       return true;
     }
 
-    return fieldContainsKeyword(field, IdentityAutoFillConstants.PostalCodeFieldNames, true);
+    return fieldContainsKeyword(field, IdentityAutoFillConstants.PostalCodeFieldNames, false);
   };
 
   /**
@@ -791,7 +791,7 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
       return true;
     }
 
-    return fieldContainsKeyword(field, IdentityAutoFillConstants.CountryFieldNames, true);
+    return fieldContainsKeyword(field, IdentityAutoFillConstants.CountryFieldNames, false);
   };
 
   /**
@@ -804,7 +804,7 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
       return true;
     }
 
-    return fieldContainsKeyword(field, IdentityAutoFillConstants.CompanyFieldNames, true);
+    return fieldContainsKeyword(field, IdentityAutoFillConstants.CompanyFieldNames, false);
   };
 
   /**
@@ -817,7 +817,7 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
       return true;
     }
 
-    return fieldContainsKeyword(field, IdentityAutoFillConstants.PhoneFieldNames, true);
+    return fieldContainsKeyword(field, IdentityAutoFillConstants.PhoneFieldNames, false);
   };
 
   /**
@@ -838,7 +838,7 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
       return true;
     }
 
-    return fieldContainsKeyword(field, IdentityAutoFillConstants.EmailFieldNames, true);
+    return fieldContainsKeyword(field, IdentityAutoFillConstants.EmailFieldNames, false);
   };
 
   /**
@@ -851,7 +851,7 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
       return true;
     }
 
-    return fieldContainsKeyword(field, IdentityAutoFillConstants.UserNameFieldNames, true);
+    return fieldContainsKeyword(field, IdentityAutoFillConstants.UserNameFieldNames, false);
   };
 
   /**

--- a/apps/browser/src/autofill/utils/index.spec.ts
+++ b/apps/browser/src/autofill/utils/index.spec.ts
@@ -5,12 +5,12 @@ import { logoIcon, logoLockedIcon } from "./svg-icons";
 
 import {
   buildSvgDomElement,
+  debounce,
   generateRandomCustomElementName,
   sendExtensionMessage,
   setElementStyles,
-  setupExtensionDisconnectAction,
   setupAutofillInitDisconnectAction,
-  debounce,
+  setupExtensionDisconnectAction,
 } from "./index";
 
 describe("buildSvgDomElement", () => {

--- a/apps/browser/src/autofill/utils/index.ts
+++ b/apps/browser/src/autofill/utils/index.ts
@@ -420,47 +420,6 @@ export function debounce<FunctionType extends (...args: unknown[]) => unknown>(
 }
 
 /**
- * Gathers and normalizes keywords from a potential submit button element. Used
- * to verify if the element submits a login or change password form.
- *
- * @param element - The element to gather keywords from.
- */
-export function getSubmitButtonKeywordsSet(element: HTMLElement): Set<string> {
-  const keywords = [
-    element.textContent,
-    element.getAttribute("type"),
-    element.getAttribute("value"),
-    element.getAttribute("aria-label"),
-    element.getAttribute("aria-labelledby"),
-    element.getAttribute("aria-describedby"),
-    element.getAttribute("title"),
-    element.getAttribute("id"),
-    element.getAttribute("name"),
-    element.getAttribute("class"),
-  ];
-
-  const keywordsSet = new Set<string>();
-  for (let i = 0; i < keywords.length; i++) {
-    const keyword = keywords[i];
-    if (typeof keyword === "string") {
-      // Iterate over all keywords metadata and split them by non-letter characters.
-      // This ensures we check against individual words and not the entire string.
-      keyword
-        .toLowerCase()
-        .replace(/[-\s]/g, "")
-        .split(/[^\p{L}]+/gu)
-        .forEach((splitKeyword) => {
-          if (splitKeyword) {
-            keywordsSet.add(splitKeyword);
-          }
-        });
-    }
-  }
-
-  return keywordsSet;
-}
-
-/**
  * Generates the origin and subdomain match patterns for the URL.
  *
  * @param url - The URL of the tab

--- a/apps/browser/src/autofill/utils/qualification.spec.ts
+++ b/apps/browser/src/autofill/utils/qualification.spec.ts
@@ -42,4 +42,51 @@ describe("fieldContainsKeyword", () => {
     expect(result1).toBe(true);
     expect(result2).toBe(true);
   });
+
+  it("hyphenated keyword: strips hyphens before matching so 'new-password' matches htmlName 'newpassword'", () => {
+    const field = createAutofillFieldMock({ htmlName: "newpassword" });
+
+    expect(fieldContainsKeyword(field, ["new-password"])).toBe(true);
+  });
+
+  it("multi-word keyword: does not match when the words appear non-contiguously in the field value", () => {
+    // "create password" should not match "Create your password" — the intervening word breaks
+    // the contiguous substring. This documents that multi-word keywords require an exact phrase match.
+    const field = createAutofillFieldMock({ placeholder: "Create your password" });
+
+    expect(fieldContainsKeyword(field, ["create password"])).toBe(false);
+  });
+
+  it("label attributes: matches a keyword found in label-tag when not present in htmlID or htmlName", () => {
+    const field = createAutofillFieldMock({
+      htmlID: "oid",
+      htmlName: "oid",
+      "label-tag": "User ID",
+    });
+
+    // "User ID" tokenizes to include "userid", which is in UsernameFieldNames.
+    // This is the label-awareness introduced by this PR.
+    expect(fieldContainsKeyword(field, ["userid"])).toBe(true);
+  });
+
+  it("null/falsy attributes: returns false without throwing when all checked attributes are empty", () => {
+    const field = createAutofillFieldMock({
+      htmlID: "",
+      htmlName: "",
+      htmlClass: "",
+      type: "",
+      title: "",
+      placeholder: "",
+      autoCompleteType: "",
+      dataSetValues: "",
+      "label-data": "",
+      "label-aria": "",
+      "label-left": "",
+      "label-right": "",
+      "label-tag": "",
+      "label-top": "",
+    });
+
+    expect(fieldContainsKeyword(field, ["username"])).toBe(false);
+  });
 });

--- a/apps/browser/src/autofill/utils/qualification.spec.ts
+++ b/apps/browser/src/autofill/utils/qualification.spec.ts
@@ -24,13 +24,13 @@ describe("fieldContainsKeyword", () => {
   it("exact mode: matches a keyword that is exactly a token", () => {
     const field = createAutofillFieldMock({ htmlName: "email" });
 
-    expect(fieldContainsKeyword(field, ["email"], true)).toBe(true);
+    expect(fieldContainsKeyword(field, ["email"], false)).toBe(true);
   });
 
   it("exact mode: does not match a keyword that is only a substring of a token", () => {
     const field = createAutofillFieldMock({ htmlName: "emailaddress" });
 
-    expect(fieldContainsKeyword(field, ["email"], true)).toBe(false);
+    expect(fieldContainsKeyword(field, ["email"], false)).toBe(false);
   });
 
   it("caching: second call on same field uses cached data without re-computing", () => {

--- a/apps/browser/src/autofill/utils/qualification.spec.ts
+++ b/apps/browser/src/autofill/utils/qualification.spec.ts
@@ -1,0 +1,45 @@
+import { createAutofillFieldMock } from "../spec/autofill-mocks";
+
+import { fieldContainsKeyword } from "./qualification";
+
+describe("fieldContainsKeyword", () => {
+  it("returns false if the field has no matching attribute values", () => {
+    const field = createAutofillFieldMock({ htmlID: "unrelated", htmlName: "unrelated" });
+
+    expect(fieldContainsKeyword(field, ["password"])).toBe(false);
+  });
+
+  it("substring mode (default): matches a keyword appearing within a token", () => {
+    const field = createAutofillFieldMock({ htmlID: "my-password-field" });
+
+    expect(fieldContainsKeyword(field, ["password"])).toBe(true);
+  });
+
+  it("substring mode: matches via tokenization of a hyphenated field ID", () => {
+    const field = createAutofillFieldMock({ htmlID: "credit-card-number" });
+
+    expect(fieldContainsKeyword(field, ["creditcardnumber"])).toBe(true);
+  });
+
+  it("exact mode: matches a keyword that is exactly a token", () => {
+    const field = createAutofillFieldMock({ htmlName: "email" });
+
+    expect(fieldContainsKeyword(field, ["email"], true)).toBe(true);
+  });
+
+  it("exact mode: does not match a keyword that is only a substring of a token", () => {
+    const field = createAutofillFieldMock({ htmlName: "emailaddress" });
+
+    expect(fieldContainsKeyword(field, ["email"], true)).toBe(false);
+  });
+
+  it("caching: second call on same field uses cached data without re-computing", () => {
+    const field = createAutofillFieldMock({ htmlID: "username" });
+
+    const result1 = fieldContainsKeyword(field, ["username"]);
+    const result2 = fieldContainsKeyword(field, ["username"]);
+
+    expect(result1).toBe(true);
+    expect(result2).toBe(true);
+  });
+});

--- a/apps/browser/src/autofill/utils/qualification.ts
+++ b/apps/browser/src/autofill/utils/qualification.ts
@@ -5,6 +5,11 @@ const autofillFieldKeywordsCache: WeakMap<
   { keywordsSet: Set<string>; stringValue: string }
 > = new WeakMap();
 
+/**
+ * Normalizes and tokenizes a single attribute value string into a set of keyword tokens.
+ * Produces the full lowercased value, tokens split on non-alphanumeric characters (after
+ * hyphen removal), and tokens split after additional space removal (e.g. "user id" → "userid").
+ */
 function tokenizeValue(value: string): Set<string> {
   const keywordsSet = new Set<string>();
   let keywordEl = value.toLowerCase();
@@ -26,6 +31,11 @@ function tokenizeValue(value: string): Set<string> {
   return keywordsSet;
 }
 
+/**
+ * Collects and tokenizes all qualifying attribute values from a field into a unified
+ * keyword set and a comma-joined string value. Results are cached per field reference
+ * in {@link autofillFieldKeywordsCache} to avoid redundant computation across repeated calls.
+ */
 function buildAutofillFieldKeywords(field: AutofillField) {
   if (autofillFieldKeywordsCache.has(field)) {
     return autofillFieldKeywordsCache.get(field)!;

--- a/apps/browser/src/autofill/utils/qualification.ts
+++ b/apps/browser/src/autofill/utils/qualification.ts
@@ -5,6 +5,27 @@ const autofillFieldKeywordsCache: WeakMap<
   { keywordsSet: Set<string>; stringValue: string }
 > = new WeakMap();
 
+function tokenizeValue(value: string): Set<string> {
+  const keywordsSet = new Set<string>();
+  let keywordEl = value.toLowerCase();
+  keywordsSet.add(keywordEl);
+  keywordEl = keywordEl.replace(/-/g, "");
+  keywordEl.split(/[^\p{L}\d]+/gu).forEach((k) => {
+    if (k) {
+      keywordsSet.add(k);
+    }
+  });
+  keywordEl
+    .replace(/\s/g, "")
+    .split(/[^\p{L}\d]+/gu)
+    .forEach((k) => {
+      if (k) {
+        keywordsSet.add(k);
+      }
+    });
+  return keywordsSet;
+}
+
 function buildAutofillFieldKeywords(field: AutofillField) {
   if (autofillFieldKeywordsCache.has(field)) {
     return autofillFieldKeywordsCache.get(field)!;
@@ -30,22 +51,7 @@ function buildAutofillFieldKeywords(field: AutofillField) {
     if (!attributeValue || typeof attributeValue !== "string") {
       continue;
     }
-    let keywordEl = attributeValue.toLowerCase();
-    keywordsSet.add(keywordEl);
-    keywordEl = keywordEl.replace(/-/g, "");
-    keywordEl.split(/[^\p{L}\d]+/gu).forEach((k) => {
-      if (k) {
-        keywordsSet.add(k);
-      }
-    });
-    keywordEl
-      .replace(/\s/g, "")
-      .split(/[^\p{L}\d]+/gu)
-      .forEach((k) => {
-        if (k) {
-          keywordsSet.add(k);
-        }
-      });
+    tokenizeValue(attributeValue).forEach((k) => keywordsSet.add(k));
   }
   const result = { keywordsSet, stringValue: Array.from(keywordsSet).join(",") };
   autofillFieldKeywordsCache.set(field, result);

--- a/apps/browser/src/autofill/utils/qualification.ts
+++ b/apps/browser/src/autofill/utils/qualification.ts
@@ -1,5 +1,8 @@
 import AutofillField from "../models/autofill-field";
+import AutofillPageDetails from "../models/autofill-page-details";
+import { AutoFillConstants } from "../services/autofill-constants";
 
+// Module-level cache
 const autofillFieldKeywordsCache: WeakMap<
   AutofillField,
   { keywordsSet: Set<string>; stringValue: string }
@@ -74,20 +77,20 @@ function buildAutofillFieldKeywords(field: AutofillField) {
  *
  * @param field - The AutofillField to check
  * @param keywords - Keywords to search for
- * @param exactMatch - If true, keyword must be an exact token in the field's normalized
- *   attribute data. If false (default), keyword is searched as a substring across all tokens.
+ * @param substringMatch - If true (default), keyword is searched as a substring across the
+ *   field's normalized attribute data. If false, keyword must be an exact token in the set.
  */
 export function fieldContainsKeyword(
   field: AutofillField,
   keywords: string[],
-  exactMatch = false,
+  substringMatch = true,
 ): boolean {
   const parsedKeywords = keywords.map((k) => k.replace(/-/g, ""));
   const { keywordsSet, stringValue } = buildAutofillFieldKeywords(field);
-  if (exactMatch) {
-    return parsedKeywords.some((k) => keywordsSet.has(k));
+  if (substringMatch) {
+    return parsedKeywords.some((k) => stringValue.indexOf(k) > -1);
   }
-  return parsedKeywords.some((k) => stringValue.indexOf(k) > -1);
+  return parsedKeywords.some((k) => keywordsSet.has(k));
 }
 
 /**
@@ -111,8 +114,7 @@ export function getSubmitButtonKeywordsSet(element: HTMLElement): Set<string> {
   ];
 
   const keywordsSet = new Set<string>();
-  for (let i = 0; i < keywords.length; i++) {
-    const keyword = keywords[i];
+  for (const keyword of keywords) {
     if (typeof keyword === "string") {
       // Iterate over all keywords metadata and split them by non-letter characters.
       // This ensures we check against individual words and not the entire string.
@@ -129,4 +131,43 @@ export function getSubmitButtonKeywordsSet(element: HTMLElement): Set<string> {
   }
 
   return keywordsSet;
+}
+
+/**
+ * Returns true if the field's parent form contains keywords indicating a non-login
+ * context (e.g. newsletter signup, subscription forms). Checks the form's {@link AutofillForm.htmlID},
+ * {@link AutofillForm.htmlName}, and {@link AutofillForm.htmlAction} attributes against
+ * {@link AutoFillConstants.NonLoginFormKeywords}. Returns false when the field has no parent form.
+ *
+ * @param field - The AutofillField whose parent form is to be checked
+ * @param pageDetails - Page details containing the forms map
+ */
+export function isNonLoginFormContext(
+  field: AutofillField,
+  pageDetails: AutofillPageDetails,
+): boolean {
+  const fieldForm = field.form;
+  if (!fieldForm) {
+    return false;
+  }
+
+  const parentForm = pageDetails.forms?.[fieldForm];
+  if (!parentForm) {
+    return false;
+  }
+
+  const formAttributes = [parentForm.htmlID, parentForm.htmlName, parentForm.htmlAction];
+  for (const attr of formAttributes) {
+    if (!attr || typeof attr !== "string") {
+      continue;
+    }
+    const attrLower = attr.toLowerCase();
+    for (const keyword of AutoFillConstants.NonLoginFormKeywords) {
+      if (attrLower.includes(keyword)) {
+        return true;
+      }
+    }
+  }
+
+  return false;
 }

--- a/apps/browser/src/autofill/utils/qualification.ts
+++ b/apps/browser/src/autofill/utils/qualification.ts
@@ -1,0 +1,116 @@
+import AutofillField from "../models/autofill-field";
+
+const autofillFieldKeywordsCache: WeakMap<
+  AutofillField,
+  { keywordsSet: Set<string>; stringValue: string }
+> = new WeakMap();
+
+function buildAutofillFieldKeywords(field: AutofillField) {
+  if (autofillFieldKeywordsCache.has(field)) {
+    return autofillFieldKeywordsCache.get(field)!;
+  }
+  const attributeValues = [
+    field.htmlID,
+    field.htmlName,
+    field.htmlClass,
+    field.type,
+    field.title,
+    field.placeholder,
+    field.autoCompleteType,
+    field.dataSetValues,
+    field["label-data"],
+    field["label-aria"],
+    field["label-left"],
+    field["label-right"],
+    field["label-tag"],
+    field["label-top"],
+  ];
+  const keywordsSet = new Set<string>();
+  for (const attributeValue of attributeValues) {
+    if (!attributeValue || typeof attributeValue !== "string") {
+      continue;
+    }
+    let keywordEl = attributeValue.toLowerCase();
+    keywordsSet.add(keywordEl);
+    keywordEl = keywordEl.replace(/-/g, "");
+    keywordEl.split(/[^\p{L}\d]+/gu).forEach((k) => {
+      if (k) {
+        keywordsSet.add(k);
+      }
+    });
+    keywordEl
+      .replace(/\s/g, "")
+      .split(/[^\p{L}\d]+/gu)
+      .forEach((k) => {
+        if (k) {
+          keywordsSet.add(k);
+        }
+      });
+  }
+  const result = { keywordsSet, stringValue: Array.from(keywordsSet).join(",") };
+  autofillFieldKeywordsCache.set(field, result);
+  return result;
+}
+
+/**
+ * Returns true if any of the provided keywords is found in the field's attributes.
+ * Strips hyphens from input keywords before matching.
+ *
+ * @param field - The AutofillField to check
+ * @param keywords - Keywords to search for
+ * @param exactMatch - If true, keyword must be an exact token in the field's normalized
+ *   attribute data. If false (default), keyword is searched as a substring across all tokens.
+ */
+export function fieldContainsKeyword(
+  field: AutofillField,
+  keywords: string[],
+  exactMatch = false,
+): boolean {
+  const parsedKeywords = keywords.map((k) => k.replace(/-/g, ""));
+  const { keywordsSet, stringValue } = buildAutofillFieldKeywords(field);
+  if (exactMatch) {
+    return parsedKeywords.some((k) => keywordsSet.has(k));
+  }
+  return parsedKeywords.some((k) => stringValue.indexOf(k) > -1);
+}
+
+/**
+ * Gathers and normalizes keywords from a potential submit button element. Used
+ * to verify if the element submits a login or change password form.
+ *
+ * @param element - The element to gather keywords from.
+ */
+export function getSubmitButtonKeywordsSet(element: HTMLElement): Set<string> {
+  const keywords = [
+    element.textContent,
+    element.getAttribute("type"),
+    element.getAttribute("value"),
+    element.getAttribute("aria-label"),
+    element.getAttribute("aria-labelledby"),
+    element.getAttribute("aria-describedby"),
+    element.getAttribute("title"),
+    element.getAttribute("id"),
+    element.getAttribute("name"),
+    element.getAttribute("class"),
+  ];
+
+  const keywordsSet = new Set<string>();
+  for (let i = 0; i < keywords.length; i++) {
+    const keyword = keywords[i];
+    if (typeof keyword === "string") {
+      // Iterate over all keywords metadata and split them by non-letter characters.
+      // This ensures we check against individual words and not the entire string.
+      keyword
+        .toLowerCase()
+        .replace(/[-\s]/g, "")
+        .split(/[^\p{L}]+/gu)
+        .forEach((splitKeyword) => {
+          if (splitKeyword) {
+            keywordsSet.add(splitKeyword);
+          }
+        });
+    }
+  }
+
+  return keywordsSet;
+}


### PR DESCRIPTION
## 🎟️ Tracking

[PM-30478](https://bitwarden.atlassian.net/browse/PM-30478)

## 📔 Objective

Creates `utils/qualification.ts` to share implementation of field attribute keyword matching functions between inline menu and autofill services. (favored inline menu, which was more exhaustive, including labels). Also includes `getSubmitButtonKeywordsSet`. Expanding qualification in autofill service to labels allows a field with an ambiguous ID (like "oid" on username input, but only "user ID" in label, on BoA) to be qualified identically in both services and properly autofilled. 

Removes "fuzzy" misnomer everywhere in autofill concerns (substring or exact tokenized keyword matching are the only current matching methods). (i.e. `fieldContainsKeyword`)

Begins consolidation of keywords/keyphrases in autofill-constants.


[PM-30478]: https://bitwarden.atlassian.net/browse/PM-30478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ