### PR TITLE
feat(components): add BitButtonGroup component

### DIFF
--- a/libs/components/src/button-group/button-group.component.html
+++ b/libs/components/src/button-group/button-group.component.html
@@ -1,0 +1,1 @@
+<ng-content></ng-content>

--- a/libs/components/src/button-group/button-group.component.ts
+++ b/libs/components/src/button-group/button-group.component.ts
@@ -1,0 +1,11 @@
+import { ChangeDetectionStrategy, Component } from "@angular/core";
+
+@Component({
+  selector: "bit-button-group",
+  templateUrl: "./button-group.component.html",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    class: "tw-flex tw-flex-wrap tw-gap-3",
+  },
+})
+export class ButtonGroupComponent {}

--- a/libs/components/src/button-group/button-group.module.ts
+++ b/libs/components/src/button-group/button-group.module.ts
@@ -1,0 +1,9 @@
+import { NgModule } from "@angular/core";
+
+import { ButtonGroupComponent } from "./button-group.component";
+
+@NgModule({
+  imports: [ButtonGroupComponent],
+  exports: [ButtonGroupComponent],
+})
+export class ButtonGroupModule {}

--- a/libs/components/src/button-group/button-group.stories.ts
+++ b/libs/components/src/button-group/button-group.stories.ts
@@ -1,0 +1,64 @@
+import { Meta, StoryObj, moduleMetadata } from "@storybook/angular";
+
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+
+import { ButtonModule } from "../button";
+import { I18nMockService } from "../utils/i18n-mock.service";
+
+import { ButtonGroupComponent } from "./button-group.component";
+
+export default {
+  title: "Component Library/Button Group",
+  component: ButtonGroupComponent,
+  decorators: [
+    moduleMetadata({
+      imports: [ButtonModule],
+      providers: [
+        {
+          provide: I18nService,
+          useFactory: () => new I18nMockService({ loading: "Loading" }),
+        },
+      ],
+    }),
+  ],
+} as Meta<ButtonGroupComponent>;
+
+type Story = StoryObj<ButtonGroupComponent>;
+
+export const Default: Story = {
+  render: () => ({
+    template: /* HTML */ `
+      <bit-button-group>
+        <button type="button" bitButton buttonType="primary">Save</button>
+        <button type="button" bitButton buttonType="secondary">Cancel</button>
+      </bit-button-group>
+    `,
+  }),
+};
+
+export const ManyButtons: Story = {
+  render: () => ({
+    template: /* HTML */ `
+      <bit-button-group>
+        <button type="button" bitButton buttonType="primary">Create</button>
+        <button type="button" bitButton buttonType="secondary">Edit</button>
+        <button type="button" bitButton buttonType="secondary">Duplicate</button>
+        <button type="button" bitButton buttonType="danger">Delete</button>
+      </bit-button-group>
+    `,
+  }),
+};
+
+export const Wrapping: Story = {
+  render: () => ({
+    template: /* HTML */ `
+      <div style="max-width: 220px;">
+        <bit-button-group>
+          <button type="button" bitButton buttonType="primary">Save changes</button>
+          <button type="button" bitButton buttonType="secondary">Cancel</button>
+          <button type="button" bitButton buttonType="danger">Delete</button>
+        </bit-button-group>
+      </div>
+    `,
+  }),
+};

--- a/libs/components/src/button-group/index.ts
+++ b/libs/components/src/button-group/index.ts
@@ -1,0 +1,2 @@
+export * from "./button-group.component";
+export * from "./button-group.module";

--- a/libs/components/src/index.ts
+++ b/libs/components/src/index.ts
@@ -10,6 +10,7 @@ export * from "./banner";
 export * from "./berry";
 export * from "./breadcrumbs";
 export * from "./button";
+export * from "./button-group";
 export * from "./callout";
 export * from "./card";
 export * from "./checkbox";


### PR DESCRIPTION
Adds a new `bit-button-group` layout component that arranges buttons in a flex row with `tw-gap-3` spacing, wrapping to individual rows when space is insufficient. Includes Storybook stories.

## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
