### PR TITLE
[PM-32466] Icons on the send page are not announced by the screen reader

### DIFF
--- a/libs/tools/send/send-ui/src/send-table/send-table.component.html
+++ b/libs/tools/send/send-ui/src/send-table/send-table.component.html
@@ -23,6 +23,23 @@
             </span>
             <button type="button" bitLink>
               {{ s.name }}
+              @if (s.disabled) {
+                <span class="tw-sr-only">, {{ "disabled" | i18n }}</span>
+              }
+              @if (s.authType !== authType.None) {
+                @let titleKey =
+                  s.authType === authType.Email ? "emailProtected" : "passwordProtected";
+                <span class="tw-sr-only">, {{ titleKey | i18n }}</span>
+              }
+              @if (s.maxAccessCountReached) {
+                <span class="tw-sr-only">, {{ "maxAccessCountReached" | i18n }}</span>
+              }
+              @if (s.expired) {
+                <span class="tw-sr-only">, {{ "expired" | i18n }}</span>
+              }
+              @if (s.pendingDelete) {
+                <span class="tw-sr-only">, {{ "pendingDeletion" | i18n }}</span>
+              }
             </button>
             @if (s.disabled) {
               <i
@@ -31,7 +48,6 @@
                 title="{{ 'disabled' | i18n }}"
                 aria-hidden="true"
               ></i>
-              <span class="tw-sr-only">{{ "disabled" | i18n }}</span>
             }
             @if (s.authType !== authType.None) {
               @let titleKey =
@@ -42,7 +58,6 @@
                 title="{{ titleKey | i18n }}"
                 aria-hidden="true"
               ></i>
-              <span class="tw-sr-only">{{ titleKey | i18n }}</span>
             }
             @if (s.maxAccessCountReached) {
               <i
@@ -51,7 +66,6 @@
                 title="{{ 'maxAccessCountReached' | i18n }}"
                 aria-hidden="true"
               ></i>
-              <span class="tw-sr-only">{{ "maxAccessCountReached" | i18n }}</span>
             }
             @if (s.expired) {
               <i
@@ -60,7 +74,6 @@
                 title="{{ 'expired' | i18n }}"
                 aria-hidden="true"
               ></i>
-              <span class="tw-sr-only">{{ "expired" | i18n }}</span>
             }
             @if (s.pendingDelete) {
               <i
@@ -69,7 +82,6 @@
                 title="{{ 'pendingDeletion' | i18n }}"
                 aria-hidden="true"
               ></i>
-              <span class="tw-sr-only">{{ "pendingDeletion" | i18n }}</span>
             }
           </div>
         </td>


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-32466

## 📔 Objective

This PR resolves a defect where icons on the Send list view are not announced by a screen reader.

PR #18940 introduced a regression involving icon announcements by replacing `aria-hidden` + `<span class="tw-sr-only">` with `aria-label` + `tabindex="0"` on `<i>` elements. Screen readers ignore `aria-label` on `<i>` elements. The `tabindex` also introduced unnecessary tab stops on non-interactive elements. This PR restores the original pattern.   

## 📸 Screenshots

<img width="1840" height="945" alt="Screenshot 2026-02-26 at 15 43 37" src="https://github.com/user-attachments/assets/85e710b0-31d0-4c93-b31a-37034a25cbb3" />

<br><br>

<img width="1563" height="844" alt="Screenshot 2026-02-26 at 15 40 28" src="https://github.com/user-attachments/assets/aeb862b1-2bad-40bd-ba19-935c9e16ef00" />

<br><br>

<img width="1719" height="690" alt="Screenshot 2026-02-26 at 15 32 52" src="https://github.com/user-attachments/assets/a98df4d1-aaab-47f5-a5db-35a15792ebb9" />

