### PR TITLE
[PM-29841] Account Security page: fix flickering form values

### DIFF
--- a/apps/browser/src/auth/popup/settings/account-security.component.html
+++ b/apps/browser/src/auth/popup/settings/account-security.component.html
@@ -12,7 +12,9 @@
     (onDismiss)="dismissAccountSecurityNudge()"
     class="tw-mb-6"
   ></bit-spotlight>
-  @if (!loading()) {
+  @if (loading()) {
+    <div class="tw-h-full tw-place-content-center"><bit-spinner></bit-spinner></div>
+  } @else {
     <div [formGroup]="form">
       <bit-section>
         <bit-section-header>

--- a/apps/browser/src/auth/popup/settings/account-security.component.ts
+++ b/apps/browser/src/auth/popup/settings/account-security.component.ts
@@ -65,6 +65,7 @@ import {
   TypographyModule,
   ToastService,
   SwitchComponent,
+  SpinnerComponent,
 } from "@bitwarden/components";
 import {
   KeyService,
@@ -115,6 +116,7 @@ import { AwaitDesktopDialogComponent } from "./await-desktop-dialog.component";
     TypographyModule,
     SessionTimeoutInputLegacyComponent,
     SwitchComponent,
+    SpinnerComponent,
   ],
 })
 export class AccountSecurityComponent implements OnInit, OnDestroy {


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-29841

## 📔 Objective
Originally to fix the phishing detection form control in the Account Security component from switching after load, but all fields in this component have the same issue. Adds a loading state to prevent the values from flickering during load.

## 📸 Screenshots
**Before**

https://github.com/user-attachments/assets/f50601a0-a293-4b83-a02f-3b629bfa0cdf



**After**


https://github.com/user-attachments/assets/99fc02c8-aa8b-49b6-a836-c94ed61bbc75


