### PR TITLE
Fix broken audit test

### DIFF
--- a/libs/common/src/services/audit.service.spec.ts
+++ b/libs/common/src/services/audit.service.spec.ts
@@ -21,7 +21,7 @@ describe("AuditService", () => {
 
   beforeEach(() => {
     mockCrypto = {
-      hash: jest.fn().mockResolvedValue(Buffer.from("AABBCCDDEEFF", "hex")),
+      hash: jest.fn().mockResolvedValue(new Uint8Array([0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff])),
     } as unknown as jest.Mocked<CryptoFunctionService>;
 
     mockApi = {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

Fix jsdom Uint8Array polyfill issue in audit service tests

- Fixed `TypeError: arr.toHex is not a function` in `audit.service.spec.ts` by changing the hash mock to return new `Uint8Array(...)` instead of `Buffer.from(...)`
- In jsdom, `Buffer` extends Node's native `Uint8Array` which has a separate prototype from jsdom's `Uint8Array`. The core-js `toHex` polyfill only patches jsdom's version, so `Buffer` instances don't have it.
