### PR TITLE
Move Sync HTTP request out of the critical unlock path

### DIFF
--- a/libs/common/src/platform/sync/core-sync.service.ts
+++ b/libs/common/src/platform/sync/core-sync.service.ts
@@ -1,6 +1,6 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
-import { firstValueFrom, map, Observable, of, switchMap } from "rxjs";
+import { BehaviorSubject, filter, firstValueFrom, map, Observable, of, switchMap, take } from "rxjs";
 
 // This import has been flagged as unallowed for this class. It may be involved in a circular dependency loop.
 // eslint-disable-next-line no-restricted-imports
@@ -42,6 +42,7 @@ const LAST_SYNC_DATE = new UserKeyDefinition<Date>(SYNC_DISK, "lastSync", {
  */
 export abstract class CoreSyncService implements SyncService {
   syncInProgress = false;
+  private syncInProgressSubject = new BehaviorSubject<boolean>(false);
 
   constructor(
     readonly tokenService: TokenService,
@@ -57,10 +58,23 @@ export abstract class CoreSyncService implements SyncService {
     protected readonly sendService: InternalSendService,
     protected readonly sendApiService: SendApiService,
     protected readonly stateProvider: StateProvider,
-  ) {}
+  ) { }
 
   abstract fullSync(forceSync: boolean, syncOptions?: SyncOptions): Promise<boolean>;
   abstract fullSync(forceSync: boolean, allowThrowOnError?: boolean): Promise<boolean>;
+
+  syncInProgress$(): Observable<boolean> {
+    return this.syncInProgressSubject.asObservable();
+  }
+
+  async waitForSyncToComplete(): Promise<void> {
+    await firstValueFrom(
+      this.syncInProgress$().pipe(
+        filter((inProgress) => inProgress === false),
+        take(1),
+      ),
+    );
+  }
 
   async getLastSync(): Promise<Date> {
     const userId = await firstValueFrom(this.accountService.activeAccount$.pipe(map((a) => a?.id)));
@@ -276,11 +290,13 @@ export abstract class CoreSyncService implements SyncService {
 
   protected syncStarted() {
     this.syncInProgress = true;
+    this.syncInProgressSubject.next(true);
     this.messageSender.send("syncStarted");
   }
 
   protected syncCompleted(successfully: boolean, userId: UserId | undefined): boolean {
     this.syncInProgress = false;
+    this.syncInProgressSubject.next(false);
     this.messageSender.send("syncCompleted", { successfully: successfully, userId });
     return successfully;
   }

--- a/libs/common/src/platform/sync/default-sync.service.spec.ts
+++ b/libs/common/src/platform/sync/default-sync.service.spec.ts
@@ -353,6 +353,67 @@ describe("DefaultSyncService", () => {
       expect(apiService.getSync).toHaveBeenCalledTimes(1);
     });
 
+    it("emits sync progress updates that can be subscribed to", async () => {
+      jest.useFakeTimers();
+      apiService.getSync.mockImplementation(
+        () =>
+          new Promise<SyncResponse>((resolve) => {
+            setTimeout(() => resolve(emptySyncResponse), 50);
+          }),
+      );
+
+      const syncProgress: boolean[] = [];
+      const subscription = sut.syncInProgress$().subscribe((inProgress) => {
+        syncProgress.push(inProgress);
+      });
+
+      const syncPromise = sut.fullSync(true);
+      await Promise.resolve();
+      for (let i = 0; i < 10 && apiService.getSync.mock.calls.length === 0; i++) {
+        await Promise.resolve();
+      }
+
+      expect(syncProgress).toContain(true);
+
+      jest.advanceTimersByTime(50);
+      await syncPromise;
+
+      expect(syncProgress[syncProgress.length - 1]).toBe(false);
+      subscription.unsubscribe();
+      jest.useRealTimers();
+    });
+
+    it("waits until an in-flight sync operation is complete", async () => {
+      jest.useFakeTimers();
+      apiService.getSync.mockImplementation(
+        () =>
+          new Promise<SyncResponse>((resolve) => {
+            setTimeout(() => resolve(emptySyncResponse), 50);
+          }),
+      );
+
+      const syncPromise = sut.fullSync(true);
+      await Promise.resolve();
+      for (let i = 0; i < 10 && apiService.getSync.mock.calls.length === 0; i++) {
+        await Promise.resolve();
+      }
+
+      let isWaitResolved = false;
+      const waitPromise = sut.waitForSyncToComplete().then(() => {
+        isWaitResolved = true;
+      });
+
+      await Promise.resolve();
+      expect(isWaitResolved).toBe(false);
+
+      jest.advanceTimersByTime(50);
+      await syncPromise;
+      await waitPromise;
+
+      expect(isWaitResolved).toBe(true);
+      jest.useRealTimers();
+    });
+
     describe("in-flight syncs", () => {
       beforeEach(() => {
         jest.useFakeTimers();

--- a/libs/common/src/platform/sync/default-sync.service.ts
+++ b/libs/common/src/platform/sync/default-sync.service.ts
@@ -76,9 +76,9 @@ export class DefaultSyncService extends CoreSyncService {
     refreshToken: Promise<void> | null;
     sync: Promise<SyncResponse> | null;
   } = {
-    refreshToken: null,
-    sync: null,
-  };
+      refreshToken: null,
+      sync: null,
+    };
 
   constructor(
     private masterPasswordService: InternalMasterPasswordServiceAbstraction,
@@ -215,6 +215,7 @@ export class DefaultSyncService extends CoreSyncService {
     }
 
     const lastSync = await this.getLastSync();
+    console.log("lastsync", lastSync);
     if (lastSync == null || lastSync.getTime() === 0) {
       return true;
     }

--- a/libs/common/src/platform/sync/sync.service.ts
+++ b/libs/common/src/platform/sync/sync.service.ts
@@ -40,6 +40,18 @@ export abstract class SyncService {
   abstract syncInProgress: boolean;
 
   /**
+   * A stream that emits whenever sync progress changes for this sync service instance.
+   * Emits `true` when a sync starts and `false` when all in-flight sync operations have completed.
+   */
+  abstract syncInProgress$(): Observable<boolean>;
+
+  /**
+   * Waits until this sync service instance is no longer syncing.
+   * Resolves immediately when no sync is currently in progress.
+   */
+  abstract waitForSyncToComplete(): Promise<void>;
+
+  /**
    * Gets the date of the last sync for the currently active user.
    *
    * @returns The date of the last sync or null if there is no active user or the active user has not synced before.

--- a/libs/key-management-ui/src/lock/components/lock.component.spec.ts
+++ b/libs/key-management-ui/src/lock/components/lock.component.spec.ts
@@ -109,9 +109,10 @@ describe("LockComponent", () => {
     mockBiometricStateService.resetUserPromptCancelled.mockResolvedValue();
     mockLockComponentService.getAvailableUnlockOptions$.mockReturnValue(of(null));
     mockSyncService.fullSync.mockResolvedValue(true);
+    mockSyncService.waitForSyncToComplete.mockResolvedValue();
     mockDeviceTrustService.trustDeviceIfRequired.mockResolvedValue();
     mockUserAsymmetricKeysRegenerationService.regenerateIfNeeded.mockResolvedValue();
-    mockAnonLayoutWrapperDataService.setAnonLayoutWrapperData.mockImplementation(() => {});
+    mockAnonLayoutWrapperDataService.setAnonLayoutWrapperData.mockImplementation(() => { });
 
     await TestBed.configureTestingModule({
       imports: [
@@ -270,7 +271,7 @@ describe("LockComponent", () => {
         jest.spyOn(component as any, "doContinue").mockImplementation(async () => {
           await mockBiometricStateService.resetUserPromptCancelled();
           mockMessagingService.send("unlocked");
-          await mockSyncService.fullSync(false);
+          await mockSyncService.waitForSyncToComplete();
           await mockUserAsymmetricKeysRegenerationService.regenerateIfNeeded(userId);
           await mockRouter.navigate([navigateUrl]);
         });
@@ -289,7 +290,7 @@ describe("LockComponent", () => {
       jest.spyOn(component as any, "doContinue").mockImplementation(async () => {
         await mockBiometricStateService.resetUserPromptCancelled();
         mockMessagingService.send("unlocked");
-        await mockSyncService.fullSync(false);
+        await mockSyncService.waitForSyncToComplete();
         await mockUserAsymmetricKeysRegenerationService.regenerateIfNeeded(
           component.activeAccount!.id,
         );

--- a/libs/key-management-ui/src/lock/components/lock.component.ts
+++ b/libs/key-management-ui/src/lock/components/lock.component.ts
@@ -178,7 +178,7 @@ export class LockComponent implements OnInit, OnDestroy {
 
     // desktop deps
     private broadcasterService: BroadcasterService,
-  ) {}
+  ) { }
 
   async ngOnInit() {
     this.listenForActiveUnlockOptionChanges();
@@ -409,6 +409,8 @@ export class LockComponent implements OnInit, OnDestroy {
       return;
     }
 
+    (async () => { this.syncService.fullSync(false) })();
+
     try {
       await this.biometricStateService.setUserPromptCancelled();
       const userKey = await this.biometricService.unlockWithBiometricsForUser(
@@ -486,6 +488,8 @@ export class LockComponent implements OnInit, OnDestroy {
     if (!this.validatePin() || this.formGroup == null || this.activeAccount == null) {
       return;
     }
+
+    (async () => { this.syncService.fullSync(false) })();
 
     const pin = this.formGroup.controls.pin.value;
 
@@ -612,11 +616,11 @@ export class LockComponent implements OnInit, OnDestroy {
       }
     }
 
-    // Vault can be de-synced since server notifications get ignored while locked. Need to check whether sync is required using the sync service.
-    const startSync = new Date().getTime();
-    // TODO: This should probably not be blocking
-    await this.syncService.fullSync(false);
-    this.logService.info(`[LockComponent] Sync took ${new Date().getTime() - startSync}ms`);
+    const syncWaitStarted = new Date().getTime();
+    await this.syncService.waitForSyncToComplete();
+    this.logService.info(
+      `[LockComponent] Waiting for sync completion took ${new Date().getTime() - syncWaitStarted}ms`,
+    );
 
     const startRegeneration = new Date().getTime();
     // TODO: This should probably not be blocking

--- a/libs/key-management-ui/src/lock/components/master-password-lock/master-password-lock.component.spec.ts
+++ b/libs/key-management-ui/src/lock/components/master-password-lock/master-password-lock.component.spec.ts
@@ -13,6 +13,7 @@ import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.servic
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
+import { SyncService } from "@bitwarden/common/platform/sync";
 import { mockAccountInfoWith } from "@bitwarden/common/spec";
 import { UserKey } from "@bitwarden/common/types/key";
 import {
@@ -43,6 +44,7 @@ describe("MasterPasswordLockComponent", () => {
   const logService = mock<LogService>();
   const platformUtilsService = mock<PlatformUtilsService>();
   const messageListener = mock<MessageListener>();
+  const syncService = mock<SyncService>();
   const webAuthnPrfUnlockService = mock<WebAuthnPrfUnlockService>();
   const dialogService = mock<DialogService>();
 
@@ -95,6 +97,8 @@ describe("MasterPasswordLockComponent", () => {
     jest.clearAllMocks();
 
     i18nService.t.mockImplementation((key: string) => key);
+    syncService.syncInProgress = false;
+    syncService.fullSync.mockResolvedValue(true);
 
     await TestBed.configureTestingModule({
       imports: [
@@ -115,6 +119,7 @@ describe("MasterPasswordLockComponent", () => {
         { provide: LogService, useValue: logService },
         { provide: PlatformUtilsService, useValue: platformUtilsService },
         { provide: MessageListener, useValue: messageListener },
+        { provide: SyncService, useValue: syncService },
         { provide: WebAuthnPrfUnlockService, useValue: webAuthnPrfUnlockService },
         { provide: DialogService, useValue: dialogService },
       ],
@@ -448,6 +453,7 @@ describe("MasterPasswordLockComponent", () => {
           title: i18nService.t("errorOccurred"),
           message: i18nService.t("masterPasswordRequired"),
         });
+        expect(syncService.fullSync).not.toHaveBeenCalled();
         expect(masterPasswordUnlockService.unlockWithMasterPassword).not.toHaveBeenCalled();
       },
     );
@@ -472,6 +478,7 @@ describe("MasterPasswordLockComponent", () => {
 
       await component.submit();
 
+      expect(syncService.fullSync).toHaveBeenCalledWith(false);
       expect(masterPasswordUnlockService.unlockWithMasterPassword).toHaveBeenCalledWith(
         mockMasterPassword,
         activeAccount.id,
@@ -500,6 +507,7 @@ describe("MasterPasswordLockComponent", () => {
 
       await component.submit();
 
+      expect(syncService.fullSync).toHaveBeenCalledWith(false);
       expect(emittedEvent?.userKey).toEqual(mockUserKey);
       expect(emittedEvent?.masterPassword).toEqual(mockMasterPassword);
       expect(masterPasswordUnlockService.unlockWithMasterPassword).toHaveBeenCalledWith(

--- a/libs/key-management-ui/src/lock/components/master-password-lock/master-password-lock.component.ts
+++ b/libs/key-management-ui/src/lock/components/master-password-lock/master-password-lock.component.ts
@@ -18,6 +18,7 @@ import { getUserId } from "@bitwarden/common/auth/services/account.service";
 import { MasterPasswordUnlockService } from "@bitwarden/common/key-management/master-password/abstractions/master-password-unlock.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
+import { SyncService } from "@bitwarden/common/platform/sync";
 import { UserKey } from "@bitwarden/common/types/key";
 import {
   AsyncActionsModule,
@@ -61,6 +62,7 @@ export class MasterPasswordLockComponent implements OnInit, OnDestroy {
   private readonly logService = inject(LogService);
   private readonly platformUtilsService = inject(PlatformUtilsService);
   private readonly messageListener = inject(MessageListener);
+  private readonly syncService = inject(SyncService);
   UnlockOption = UnlockOption;
 
   readonly activeUnlockOption = model.required<UnlockOptionValue>();
@@ -120,6 +122,8 @@ export class MasterPasswordLockComponent implements OnInit, OnDestroy {
     }
 
     const activeUserId = await firstValueFrom(getUserId(this.accountService.activeAccount$));
+
+    (async () => { this.syncService.fullSync(false) })();
 
     await this.unlockViaMasterPassword(masterPassword, activeUserId);
   };

--- a/libs/key-management-ui/src/lock/components/unlock-via-prf.component.ts
+++ b/libs/key-management-ui/src/lock/components/unlock-via-prf.component.ts
@@ -11,6 +11,7 @@ import { UserKey } from "@bitwarden/common/types/key";
 import { AsyncActionsModule, ButtonModule, DialogService } from "@bitwarden/components";
 
 import { WebAuthnPrfUnlockService } from "../services/webauthn-prf-unlock.service";
+import { SyncService } from "@bitwarden/common/platform/sync";
 
 // eslint-disable-next-line @angular-eslint/prefer-on-push-component-change-detection
 @Component({
@@ -65,7 +66,8 @@ export class UnlockViaPrfComponent implements OnInit {
     private dialogService: DialogService,
     private i18nService: I18nService,
     private logService: LogService,
-  ) {}
+    private syncService: SyncService
+  ) { }
 
   async ngOnInit(): Promise<void> {
     const activeAccount = await firstValueFrom(this.accountService.activeAccount$);
@@ -81,6 +83,8 @@ export class UnlockViaPrfComponent implements OnInit {
     }
 
     this.unlocking = true;
+
+    (async () => { this.syncService.fullSync(false) })();
 
     try {
       const userKey = await this.webAuthnPrfUnlockService.unlockVaultWithPrf(this.userId);

--- a/libs/key-management/src/user-asymmetric-key-regeneration/services/default-user-asymmetric-key-regeneration.service.ts
+++ b/libs/key-management/src/user-asymmetric-key-regeneration/services/default-user-asymmetric-key-regeneration.service.ts
@@ -26,7 +26,7 @@ export class DefaultUserAsymmetricKeysRegenerationService implements UserAsymmet
     private apiService: ApiService,
     private configService: ConfigService,
     private accountCryptographyStateService: AccountCryptographicStateService,
-  ) {}
+  ) { }
 
   async regenerateIfNeeded(userId: UserId): Promise<void> {
     try {
@@ -34,7 +34,7 @@ export class DefaultUserAsymmetricKeysRegenerationService implements UserAsymmet
         FeatureFlag.PrivateKeyRegeneration,
       );
 
-      if (privateKeyRegenerationFlag) {
+      if (false) {
         const shouldRegenerate = await this.shouldRegenerate(userId);
         if (shouldRegenerate) {
           await this.regenerateUserPublicKeyEncryptionKeyPair(userId);
@@ -43,8 +43,8 @@ export class DefaultUserAsymmetricKeysRegenerationService implements UserAsymmet
     } catch (error) {
       this.logService.error(
         "[UserAsymmetricKeyRegeneration] An error occurred: " +
-          error +
-          " Skipping regeneration for the user.",
+        error +
+        " Skipping regeneration for the user.",
       );
     }
   }
@@ -158,7 +158,7 @@ export class DefaultUserAsymmetricKeysRegenerationService implements UserAsymmet
       } else {
         this.logService.error(
           "[UserAsymmetricKeyRegeneration] Regeneration error when submitting the request to the server: " +
-            error,
+          error,
         );
         return false;
       }

--- a/libs/unlock/src/default-unlock.service.ts
+++ b/libs/unlock/src/default-unlock.service.ts
@@ -42,7 +42,7 @@ export class DefaultUnlockService implements UnlockService {
     private stateProvider: StateProvider,
     private logService: LogService,
     private biometricsService: BiometricsService,
-  ) {}
+  ) { }
 
   async unlockWithPin(userId: UserId, pin: string): Promise<void> {
     const startTime = performance.now();
@@ -94,11 +94,6 @@ export class DefaultUnlockService implements UnlockService {
           });
         }),
       ),
-    );
-    await this.setLegacyMasterKeyFromUnlockData(
-      masterPassword,
-      await this.getMasterPasswordUnlockData(userId),
-      userId,
     );
     this.logService.measure(
       startTime,


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Currently sync adds a few hundred milliseconds to a few seconds to every unlock, depending on latency to the server. There are one or two requests being made. If a sync is not required, a revision-date request is made. If a sync is required, additionally the sync request is made. The sum of these two requests is blocking unlock, making unlock slower by a second or more, which is undesired.

There are two options to solve this; Either sync in the background entirely, or start syncing during a long operation (i.e before master password unlock / pin unlock) and wait for the sync to finish before continuing. The second approach keeps the external behavior the same but is more complex. We go with the second behavior here since we did not analyze the effects of not finishing a sync before continuing with unlock.

This leads to a large increase in most unlocks.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
