### PR TITLE
[PM-32782] Fix auto confirm action to use correct userId

### DIFF
--- a/libs/auto-confirm/src/abstractions/auto-confirm.service.abstraction.ts
+++ b/libs/auto-confirm/src/abstractions/auto-confirm.service.abstraction.ts
@@ -27,12 +27,14 @@ export abstract class AutomaticUserConfirmationService {
   /**
    * Calls the API endpoint to initiate automatic user confirmation.
    * @param userId The userId of the logged in admin performing auto confirmation. This is neccesary to perform the key exchange and for permissions checks.
-   * @param confirmedUserId The userId of the member being confirmed.
+   * @param confirmedUserId The userId of the member being confirmed (for key exchange).
+   * @param confirmedOrganizationUserId The Organization userId of the member being confirmed (for confirm action).
    * @param organization the organization the member is being auto confirmed to.
    **/
   abstract autoConfirmUser(
     userId: UserId,
     confirmedUserId: UserId,
+    confirmedOrganizationUserId: UserId,
     organization: OrganizationId,
   ): Promise<void>;
 }

--- a/libs/auto-confirm/src/services/default-auto-confirm.service.spec.ts
+++ b/libs/auto-confirm/src/services/default-auto-confirm.service.spec.ts
@@ -39,6 +39,7 @@ describe("DefaultAutomaticUserConfirmationService", () => {
 
   const mockUserId = newGuid() as UserId;
   const mockConfirmingUserId = newGuid() as UserId;
+  const mockConfirmingOrganizationUserId = newGuid() as UserId;
   const mockOrganizationId = newGuid() as OrganizationId;
   let mockOrganization: Organization;
 
@@ -401,7 +402,12 @@ describe("DefaultAutomaticUserConfirmationService", () => {
     });
 
     it("should successfully auto-confirm a user with organizationId", async () => {
-      await service.autoConfirmUser(mockUserId, mockConfirmingUserId, mockOrganizationId);
+      await service.autoConfirmUser(
+        mockUserId,
+        mockConfirmingUserId,
+        mockConfirmingOrganizationUserId,
+        mockOrganizationId,
+      );
 
       expect(apiService.getUserPublicKey).toHaveBeenCalledWith(mockConfirmingUserId);
       expect(organizationUserService.buildConfirmRequest).toHaveBeenCalledWith(
@@ -410,7 +416,7 @@ describe("DefaultAutomaticUserConfirmationService", () => {
       );
       expect(organizationUserApiService.postOrganizationUserAutoConfirm).toHaveBeenCalledWith(
         mockOrganizationId,
-        mockConfirmingUserId,
+        mockConfirmingOrganizationUserId,
         mockConfirmRequest,
       );
     });
@@ -418,7 +424,12 @@ describe("DefaultAutomaticUserConfirmationService", () => {
     it("should return early when canManageAutoConfirm returns false", async () => {
       configService.getFeatureFlag$.mockReturnValue(of(false));
 
-      await service.autoConfirmUser(mockUserId, mockConfirmingUserId, mockOrganizationId);
+      await service.autoConfirmUser(
+        mockUserId,
+        mockConfirmingUserId,
+        mockConfirmingOrganizationUserId,
+        mockOrganizationId,
+      );
 
       expect(apiService.getUserPublicKey).not.toHaveBeenCalled();
       expect(organizationUserApiService.postOrganizationUserAutoConfirm).not.toHaveBeenCalled();
@@ -433,29 +444,24 @@ describe("DefaultAutomaticUserConfirmationService", () => {
         mockUserId,
       );
 
-      await service.autoConfirmUser(mockUserId, mockConfirmingUserId, mockOrganizationId);
-
-      expect(apiService.getUserPublicKey).not.toHaveBeenCalled();
-      expect(organizationUserApiService.postOrganizationUserAutoConfirm).not.toHaveBeenCalled();
-    });
-
-    it("should return early when auto-confirm is disabled in configuration", async () => {
-      const disabledConfig = new AutoConfirmState();
-      disabledConfig.enabled = false;
-      await stateProvider.setUserState(
-        AUTO_CONFIRM_STATE,
-        { [mockUserId]: disabledConfig },
+      await service.autoConfirmUser(
         mockUserId,
+        mockConfirmingUserId,
+        mockConfirmingOrganizationUserId,
+        mockOrganizationId,
       );
-
-      await service.autoConfirmUser(mockUserId, mockConfirmingUserId, mockOrganizationId);
 
       expect(apiService.getUserPublicKey).not.toHaveBeenCalled();
       expect(organizationUserApiService.postOrganizationUserAutoConfirm).not.toHaveBeenCalled();
     });
 
     it("should build confirm request with organization and public key", async () => {
-      await service.autoConfirmUser(mockUserId, mockConfirmingUserId, mockOrganizationId);
+      await service.autoConfirmUser(
+        mockUserId,
+        mockConfirmingUserId,
+        mockConfirmingOrganizationUserId,
+        mockOrganizationId,
+      );
 
       expect(organizationUserService.buildConfirmRequest).toHaveBeenCalledWith(
         mockOrganization,
@@ -464,11 +470,16 @@ describe("DefaultAutomaticUserConfirmationService", () => {
     });
 
     it("should call API with correct parameters", async () => {
-      await service.autoConfirmUser(mockUserId, mockConfirmingUserId, mockOrganizationId);
+      await service.autoConfirmUser(
+        mockUserId,
+        mockConfirmingUserId,
+        mockConfirmingOrganizationUserId,
+        mockOrganizationId,
+      );
 
       expect(organizationUserApiService.postOrganizationUserAutoConfirm).toHaveBeenCalledWith(
         mockOrganizationId,
-        mockConfirmingUserId,
+        mockConfirmingOrganizationUserId,
         mockConfirmRequest,
       );
     });
@@ -478,7 +489,12 @@ describe("DefaultAutomaticUserConfirmationService", () => {
       apiService.getUserPublicKey.mockRejectedValue(apiError);
 
       await expect(
-        service.autoConfirmUser(mockUserId, mockConfirmingUserId, mockOrganizationId),
+        service.autoConfirmUser(
+          mockUserId,
+          mockConfirmingUserId,
+          mockConfirmingOrganizationUserId,
+          mockOrganizationId,
+        ),
       ).rejects.toThrow("API Error");
 
       expect(organizationUserApiService.postOrganizationUserAutoConfirm).not.toHaveBeenCalled();
@@ -489,7 +505,12 @@ describe("DefaultAutomaticUserConfirmationService", () => {
       organizationUserService.buildConfirmRequest.mockReturnValue(throwError(() => buildError));
 
       await expect(
-        service.autoConfirmUser(mockUserId, mockConfirmingUserId, mockOrganizationId),
+        service.autoConfirmUser(
+          mockUserId,
+          mockConfirmingUserId,
+          mockConfirmingOrganizationUserId,
+          mockOrganizationId,
+        ),
       ).rejects.toThrow("Build Error");
 
       expect(organizationUserApiService.postOrganizationUserAutoConfirm).not.toHaveBeenCalled();

--- a/libs/auto-confirm/src/services/default-auto-confirm.service.ts
+++ b/libs/auto-confirm/src/services/default-auto-confirm.service.ts
@@ -68,6 +68,7 @@ export class DefaultAutomaticUserConfirmationService implements AutomaticUserCon
   async autoConfirmUser(
     userId: UserId,
     confirmedUserId: UserId,
+    confirmedOrganizationUserId: UserId,
     organizationId: OrganizationId,
   ): Promise<void> {
     const canManage = await firstValueFrom(this.canManageAutoConfirm$(userId));
@@ -104,7 +105,7 @@ export class DefaultAutomaticUserConfirmationService implements AutomaticUserCon
         switchMap((request) =>
           this.organizationUserApiService.postOrganizationUserAutoConfirm(
             organizationId,
-            confirmedUserId,
+            confirmedOrganizationUserId,
             request,
           ),
         ),

--- a/libs/common/src/models/response/notification.response.ts
+++ b/libs/common/src/models/response/notification.response.ts
@@ -218,9 +218,11 @@ export class AutoConfirmMemberNotification extends BaseResponse {
   userId: string;
   targetUserId: string;
   organizationId: string;
+  targetOrganizationUserId: string;
 
   constructor(response: any) {
     super(response);
+    this.targetOrganizationUserId = this.getResponseProperty("TargetOrganizationUserId");
     this.targetUserId = this.getResponseProperty("TargetUserId");
     this.userId = this.getResponseProperty("UserId");
     this.organizationId = this.getResponseProperty("OrganizationId");

--- a/libs/common/src/platform/server-notifications/internal/default-server-notifications.service.spec.ts
+++ b/libs/common/src/platform/server-notifications/internal/default-server-notifications.service.spec.ts
@@ -521,6 +521,7 @@ describe("NotificationsService", () => {
           payload: {
             UserId: mockUser1,
             TargetUserId: "target-user-id",
+            TargetOrganizationUserId: "target-org-user-id",
             OrganizationId: "org-id",
           },
           contextId: "different-app-id",
@@ -531,6 +532,7 @@ describe("NotificationsService", () => {
         expect(autoConfirmService.autoConfirmUser).toHaveBeenCalledWith(
           mockUser1,
           "target-user-id",
+          "target-org-user-id",
           "org-id",
         );
       });

--- a/libs/common/src/platform/server-notifications/internal/default-server-notifications.service.ts
+++ b/libs/common/src/platform/server-notifications/internal/default-server-notifications.service.ts
@@ -299,6 +299,7 @@ export class DefaultServerNotificationsService implements ServerNotificationsSer
         await this.autoConfirmService.autoConfirmUser(
           notification.payload.userId,
           notification.payload.targetUserId,
+          notification.payload.targetOrganizationUserId,
           notification.payload.organizationId,
         );
         break;


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-32782
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
When calling the auto confirm API, the wrong userId is passed in (the admins). This is fixed to use the correct userId (the confirmed users) to fix the vault being undecypyable.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
