### PR TITLE
Remove CreditCardNumberPipe from JslibModule

### DIFF
--- a/libs/angular/src/jslib.module.ts
+++ b/libs/angular/src/jslib.module.ts
@@ -35,7 +35,6 @@ import { LaunchClickDirective } from "./directives/launch-click.directive";
 import { StopClickDirective } from "./directives/stop-click.directive";
 import { StopPropDirective } from "./directives/stop-prop.directive";
 import { TextDragDirective } from "./directives/text-drag.directive";
-import { CreditCardNumberPipe } from "./pipes/credit-card-number.pipe";
 import { PluralizePipe } from "./pipes/pluralize.pipe";
 import { SearchPipe } from "./pipes/search.pipe";
 import { UserNamePipe } from "./pipes/user-name.pipe";
@@ -86,7 +85,6 @@ import { IconComponent } from "./vault/components/icon.component";
   declarations: [
     ApiActionDirective,
     BoxRowDirective,
-    CreditCardNumberPipe,
     EllipsisPipe,
     I18nPipe,
     IconComponent,
@@ -108,7 +106,6 @@ import { IconComponent } from "./vault/components/icon.component";
     AutofocusDirective,
     ToastModule,
     BoxRowDirective,
-    CreditCardNumberPipe,
     EllipsisPipe,
     I18nPipe,
     IconComponent,
@@ -126,14 +123,6 @@ import { IconComponent } from "./vault/components/icon.component";
     TwoFactorIconComponent,
     TextDragDirective,
   ],
-  providers: [
-    CreditCardNumberPipe,
-    DatePipe,
-    I18nPipe,
-    SearchPipe,
-    UserNamePipe,
-    UserTypePipe,
-    PluralizePipe,
-  ],
+  providers: [DatePipe, I18nPipe, SearchPipe, UserNamePipe, UserTypePipe, PluralizePipe],
 })
 export class JslibModule {}

--- a/libs/angular/src/pipes/credit-card-number.pipe.ts
+++ b/libs/angular/src/pipes/credit-card-number.pipe.ts
@@ -30,7 +30,6 @@ const numberFormats: Record<string, CardRuleEntry[]> = {
 
 @Pipe({
   name: "creditCardNumber",
-  standalone: false,
 })
 export class CreditCardNumberPipe implements PipeTransform {
   transform(creditCardNumber: string, brand: string): string {

--- a/libs/vault/src/cipher-view/card-details/card-details-view.component.ts
+++ b/libs/vault/src/cipher-view/card-details/card-details-view.component.ts
@@ -4,6 +4,7 @@ import { CommonModule } from "@angular/common";
 import { Component, Input, OnChanges, SimpleChanges } from "@angular/core";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
+import { CreditCardNumberPipe } from "@bitwarden/angular/pipes/credit-card-number.pipe";
 import { EventCollectionService } from "@bitwarden/common/abstractions/event/event-collection.service";
 import { EventType } from "@bitwarden/common/enums";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
@@ -30,6 +31,7 @@ import { ReadOnlyCipherCardComponent } from "../read-only-cipher-card/read-only-
     FormFieldModule,
     IconButtonModule,
     ReadOnlyCipherCardComponent,
+    CreditCardNumberPipe,
   ],
 })
 export class CardDetailsComponent implements OnChanges {


### PR DESCRIPTION
## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
In am effort to remove more things from the now marked as deprecated JslibModule, this PR removes the CreditCardNumberPipe from it.

- Make CreditCardNumberPipe standalone
- Import it into `libs/vault/src/cipher-view/card-details/card-details-view.component.ts`as it's the only place that uses it
- Remove CreditCardNumberPipe from `jslib.module`

Verified that build succeeds and the credit number still gets displayed in blocks as it previously did