### PR TITLE
[PM-28967] Add credentialless attribute to injected iframes

### DIFF
--- a/apps/browser/src/autofill/overlay/inline-menu/iframe-content/__snapshots__/autofill-inline-menu-iframe.service.spec.ts.snap
+++ b/apps/browser/src/autofill/overlay/inline-menu/iframe-content/__snapshots__/autofill-inline-menu-iframe.service.spec.ts.snap
@@ -3,6 +3,7 @@
 exports[`AutofillInlineMenuIframeService initMenuIframe sets up the iframe's attributes 1`] = `
 <iframe
   allowtransparency="true"
+  credentialless=""
   scrolling="no"
   src="chrome-extension://id/overlay/menu.html"
   style="all: initial !important; position: fixed !important; display: block !important; z-index: 2147483647 !important; line-height: 0 !important; overflow: hidden !important; transition: opacity 125ms ease-out 0s !important; visibility: visible !important; clip-path: none !important; pointer-events: auto !important; margin: 0px !important; padding: 0px !important; color-scheme: normal !important; opacity: 0 !important; height: 0px;"

--- a/apps/browser/src/autofill/overlay/inline-menu/iframe-content/autofill-inline-menu-iframe.service.ts
+++ b/apps/browser/src/autofill/overlay/inline-menu/iframe-content/autofill-inline-menu-iframe.service.ts
@@ -45,6 +45,7 @@ export class AutofillInlineMenuIframeService implements AutofillInlineMenuIframe
   private defaultIframeAttributes: Record<string, string> = {
     src: "",
     title: "",
+    credentialless: "",
     allowtransparency: "true",
     tabIndex: "-1",
     scrolling: "no",

--- a/apps/browser/src/autofill/overlay/inline-menu/pages/menu-container/autofill-inline-menu-container.ts
+++ b/apps/browser/src/autofill/overlay/inline-menu/pages/menu-container/autofill-inline-menu-container.ts
@@ -62,6 +62,7 @@ export class AutofillInlineMenuContainer {
     src: "",
     title: "",
     sandbox: "allow-scripts",
+    credentialless: "",
     allowtransparency: "true",
     tabIndex: "-1",
   };

--- a/apps/browser/src/autofill/overlay/notifications/content/__snapshots__/overlay-notifications-content.service.spec.ts.snap
+++ b/apps/browser/src/autofill/overlay/notifications/content/__snapshots__/overlay-notifications-content.service.spec.ts.snap
@@ -6,6 +6,7 @@ exports[`OverlayNotificationsContentService opening the notification bar creates
   style="height: 400px !important; width: 430px !important; max-width: calc(100% - 20px) !important; min-height: initial !important; top: 10px !important; right: 0px !important; padding: 0px !important; position: fixed !important; z-index: 2147483647 !important; visibility: visible !important; border-radius: 4px !important; background-color: transparent !important; overflow: hidden !important; transition: box-shadow 0.15s ease !important; transition-delay: 0.15s;"
 >
   <iframe
+    credentialless=""
     id="bit-notification-bar-iframe"
     src="chrome-extension://id/notification/bar.html?parentOrigin=http%3A%2F%2Flocalhost"
     style="width: 100% !important; height: 100% !important; border: 0px !important; display: block !important; position: relative !important; transition: transform 0.15s ease-out, opacity 0.15s ease !important; border-radius: 4px !important; color-scheme: auto !important; transform: translateX(0) !important; opacity: 0;"

--- a/apps/browser/src/autofill/overlay/notifications/content/overlay-notifications-content.service.ts
+++ b/apps/browser/src/autofill/overlay/notifications/content/overlay-notifications-content.service.ts
@@ -192,6 +192,7 @@ export class OverlayNotificationsContentService implements OverlayNotificationsC
     const iframeUrl = new URL(BrowserApi.getRuntimeURL("notification/bar.html"));
     iframeUrl.searchParams.set("parentOrigin", parentOrigin);
     this.notificationBarIframeElement.src = iframeUrl.toString();
+    this.notificationBarIframeElement.setAttribute("credentialless", "");
     setElementStyles(
       this.notificationBarIframeElement,
       {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-28967](https://bitwarden.atlassian.net/browse/PM-28967)

## 📔 Objective

Add credentialless attribute to injected iframes; achieves the same results as https://github.com/bitwarden/clients/pull/18875 but without modifying `use_dynamic_url` in the manifest


[PM-28967]: https://bitwarden.atlassian.net/browse/PM-28967?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ