### PR TITLE
[PM-32820] suspended icon for suspended orgs is not showing up in sidebar

### DIFF
--- a/apps/web/src/app/layouts/org-switcher/org-switcher.component.html
+++ b/apps/web/src/app/layouts/org-switcher/org-switcher.component.html
@@ -11,6 +11,7 @@
     slot="end"
     *ngIf="!activeOrganization.enabled"
     name="bwi-exclamation-triangle"
+    class="tw-my-auto"
     [ariaLabel]="'organizationIsDisabled' | i18n"
     appA11yTitle="{{ 'organizationIsDisabled' | i18n }}"
   ></bit-icon>

--- a/libs/components/src/navigation/nav-group.component.html
+++ b/libs/components/src/navigation/nav-group.component.html
@@ -34,10 +34,6 @@
       <ng-container slot="start">
         <ng-container *ngTemplateOutlet="button"></ng-container>
       </ng-container>
-    } @else {
-      <ng-container slot="start">
-        <ng-content select="[slot=start]"></ng-content>
-      </ng-container>
     }
     <ng-container slot="end">
       <ng-content select="[slot=end]"></ng-content>


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-32820

## 📔 Objective

Adds suspended icon to left of suspended org in admin console sidebar

## 📸 Screenshots

<img width="1918" height="934" alt="image" src="https://github.com/user-attachments/assets/29f72a37-00f2-4e67-bef4-70d7b109fd1f" />
<img width="1918" height="863" alt="image" src="https://github.com/user-attachments/assets/daab659a-82aa-403a-afb5-3aadcbb99c07" />

