### PR TITLE
[PM-30345] Fix incorrect GNOME Snap tray icon

### DIFF
--- a/apps/desktop/resources/linux-wrapper.sh
+++ b/apps/desktop/resources/linux-wrapper.sh
@@ -12,6 +12,11 @@ if [ -e "/usr/lib/x86_64-linux-gnu/libdbus-1.so.3" ]; then
   export LD_PRELOAD="/usr/lib/x86_64-linux-gnu/libdbus-1.so.3"
 fi
 
+# fix Bitwarden logo tray icon not appearing with the Snap on GNOME
+if [ -n "$SNAP" ]; then
+  export XDG_CURRENT_DESKTOP=Unity
+fi
+
 # A bug in Electron 39 (which now enables Wayland by default) causes a crash on
 # systems using Wayland with hardware acceleration. Platform decided to
 # configure Electron to use X11 (with an opt-out) until the upstream bug is


### PR DESCRIPTION
## 🎟️ Tracking

[PM-30345](https://bitwarden.atlassian.net/browse/PM-30345)
fixes https://github.com/bitwarden/clients/issues/15207

## 📔 Objective

This PR fixes the desktop tray icon not appearing as the Bitwarden logo when running the Snap on GNOME. This matches what the Flatpak is already configured for.

[PM-30345]: https://bitwarden.atlassian.net/browse/PM-30345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ