### PR TITLE
Remove dependency on JslibModule for export components

### DIFF
--- a/libs/tools/export/vault-export/vault-export-ui/src/components/export-scope-callout.component.ts
+++ b/libs/tools/export/vault-export/vault-export-ui/src/components/export-scope-callout.component.ts
@@ -4,13 +4,13 @@ import { CommonModule } from "@angular/common";
 import { Component, effect, input } from "@angular/core";
 import { firstValueFrom, map } from "rxjs";
 
-import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { getUserId } from "@bitwarden/common/auth/services/account.service";
 import { getById } from "@bitwarden/common/platform/misc/rxjs-operators";
 import { OrganizationId } from "@bitwarden/common/types/guid";
 import { CalloutModule } from "@bitwarden/components";
+import { I18nPipe } from "@bitwarden/ui-common";
 import { ExportFormat } from "@bitwarden/vault-export-core";
 
 // FIXME(https://bitwarden.atlassian.net/browse/CL-764): Migrate to OnPush
@@ -18,7 +18,7 @@ import { ExportFormat } from "@bitwarden/vault-export-core";
 @Component({
   selector: "tools-export-scope-callout",
   templateUrl: "export-scope-callout.component.html",
-  imports: [CommonModule, JslibModule, CalloutModule],
+  imports: [CommonModule, I18nPipe, CalloutModule],
 })
 export class ExportScopeCalloutComponent {
   show = false;

--- a/libs/tools/export/vault-export/vault-export-ui/src/components/export.component.ts
+++ b/libs/tools/export/vault-export/vault-export-ui/src/components/export.component.ts
@@ -31,7 +31,6 @@ import {
 } from "rxjs";
 
 import { CollectionService } from "@bitwarden/admin-console/common";
-import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { PasswordStrengthV2Component } from "@bitwarden/angular/tools/password-strength/password-strength-v2.component";
 import { UserVerificationDialogComponent } from "@bitwarden/auth/angular";
 import { EventCollectionService } from "@bitwarden/common/abstractions/event/event-collection.service";
@@ -55,6 +54,7 @@ import {
   BitSubmitDirective,
   ButtonModule,
   CalloutModule,
+  CopyClickDirective,
   DialogService,
   FormFieldModule,
   IconButtonModule,
@@ -64,6 +64,7 @@ import {
 } from "@bitwarden/components";
 import { GeneratorServicesModule } from "@bitwarden/generator-components";
 import { CredentialGeneratorService, GenerateRequest, Type } from "@bitwarden/generator-core";
+import { I18nPipe } from "@bitwarden/ui-common";
 import {
   ExportedVault,
   ExportFormatMetadata,
@@ -82,7 +83,7 @@ import { ExportScopeCalloutComponent } from "./export-scope-callout.component";
   imports: [
     CommonModule,
     ReactiveFormsModule,
-    JslibModule,
+    I18nPipe,
     FormFieldModule,
     AsyncActionsModule,
     ButtonModule,
@@ -93,6 +94,7 @@ import { ExportScopeCalloutComponent } from "./export-scope-callout.component";
     ExportScopeCalloutComponent,
     PasswordStrengthV2Component,
     GeneratorServicesModule,
+    CopyClickDirective,
   ],
 })
 export class ExportComponent implements OnInit, OnDestroy, AfterViewInit {


### PR DESCRIPTION
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
With the recent deprecation of `JslibModule`, this ensures the standalone export components, import their own dependencies instead of relying on `JslibModule`