### PR TITLE
[PM-33077] Add missing myItems key

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -4866,7 +4866,7 @@
     "message": "Copy address"
   },
   "myItems": {
-    "message": "My items"
+    "message": "My Items"
   },
   "adminConsole": {
     "message": "Admin Console"


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-33077
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
This missing entry caused auto confirm to encrypt an empty string as the `defaultUserCollectionName`.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
