### PR TITLE
[CL-1078] chore(dev): enable Tailwind IntelliSense for tw- class strings in TypeScript

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,6 @@
   },
   "rust-analyzer.linkedProjects": ["apps/desktop/desktop_native/Cargo.toml"],
   "typescript.tsdk": "node_modules/typescript/lib",
-  "eslint.useFlatConfig": true
+  "eslint.useFlatConfig": true,
+  "tailwindCSS.experimental.classRegex": ["[\"'`]([^\"'`\\n]*tw-[^\"'`\\n]*)[\"'`]"]
 }


### PR DESCRIPTION
Tracking: 
https://bitwarden.atlassian.net/browse/CL-1078

---

Adds a `classRegex` to `.vscode/settings.json` so the Tailwind CSS IntelliSense extension activates on any quoted string containing a `tw-` prefixed class — covering TypeScript files (variant maps, computed class arrays, host bindings) in addition to HTML templates which are already handled by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)