### PR TITLE
[PM-33123] fix: update Chrome Web Store URL to new format

### DIFF
--- a/apps/web/src/app/vault/components/browser-extension-prompt/browser-extension-prompt-install.component.spec.ts
+++ b/apps/web/src/app/vault/components/browser-extension-prompt/browser-extension-prompt-install.component.spec.ts
@@ -90,7 +90,7 @@ describe("BrowserExtensionInstallComponent", () => {
       const link = fixture.debugElement.query(By.css("a")).nativeElement;
 
       expect(link.getAttribute("href")).toBe(
-        "https://chrome.google.com/webstore/detail/bitwarden-password-manage/nngceckbapebfimnlniiiahkandclblb",
+        "https://chromewebstore.google.com/detail/bitwarden-password-manage/nngceckbapebfimnlniiiahkandclblb",
       );
     });
 

--- a/apps/web/src/app/vault/components/browser-extension-prompt/browser-extension-prompt-install.component.ts
+++ b/apps/web/src/app/vault/components/browser-extension-prompt/browser-extension-prompt-install.component.ts
@@ -15,7 +15,7 @@ import {
 /** Device specific Urls for the extension  */
 const WebStoreUrls: Partial<Record<DeviceType, string>> = {
   [DeviceType.ChromeBrowser]:
-    "https://chrome.google.com/webstore/detail/bitwarden-password-manage/nngceckbapebfimnlniiiahkandclblb",
+    "https://chromewebstore.google.com/detail/bitwarden-password-manage/nngceckbapebfimnlniiiahkandclblb",
   [DeviceType.FirefoxBrowser]:
     "https://addons.mozilla.org/en-US/firefox/addon/bitwarden-password-manager/",
   [DeviceType.SafariBrowser]: "https://apps.apple.com/us/app/bitwarden/id1352778147?mt=12",


### PR DESCRIPTION
## What
Updates the Chrome Web Store URL in the browser extension prompt component (and its corresponding test) from the deprecated `chrome.google.com/webstore` format to the current `chromewebstore.google.com` format.

## Why
Google has migrated the Chrome Web Store to a new domain; the old URLs are deprecated and this change ensures Bitwarden points users to the current, supported URL.

## Testing
- [ ] Verify the updated URL in `browser-extension-prompt-install.component.ts` resolves to the correct Bitwarden listing
- [ ] Run `browser-extension-prompt-install.component.spec.ts` and confirm the test passes with the new URL expectation
- [ ] Build the web vault and confirm the install prompt links work end-to-end

---
*Contributed by [theluckystrike](https://github.com/theluckystrike) | [Zovo](https://zovo.one) — Chrome Extension Studio*