### PR TITLE
[CL-1074] Update chromatic workflow to run on all internal PRs

### DIFF
--- a/.github/workflows/chromatic-target.yml
+++ b/.github/workflows/chromatic-target.yml
@@ -1,0 +1,32 @@
+# This workflow is intended to be run when we need to run Chromatic and produce artifacts that
+# require secrets when the PR source branch does not have access to secrets (e.g. a fork). It will
+# fail until an approved user has manually re-run the workflow. This workflow will then run in the 
+# context of the target of the PR and have access to secrets. This should only be done after
+# reviewing the PR to ensure that no malicious code has been introduced, as it could allow the code
+# on the forked branch to have access to workflow secrets.
+
+name: Chromatic on PR Target
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+    branches:
+      - "main"
+
+jobs:
+  check-run:
+    name: Check PR run
+    uses: bitwarden/gh-actions/.github/workflows/check-run.yml@main
+    permissions:
+      contents: read
+
+  run-workflow:
+    name: Chromatic
+    needs: check-run
+    if: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
+    uses: ./.github/workflows/chromatic.yml
+    secrets: inherit
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,3 +1,8 @@
+# This workflow will run in the context of the source of the PR.
+# On a PR from a fork, the pull_request workflow is skipped because the fork will not have access to
+# secrets. To run it successfully from a fork, manually re-run the chromatic-target.yml workflow 
+# which will have run and failed on a fork. See chromatic-target.yml for re-run instructions.
+
 name: Chromatic
 
 on:
@@ -6,24 +11,29 @@ on:
       - "main"
       - "rc"
       - "hotfix-rc"
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened]
-    branches:
-      - "main"
+  workflow_call:
+    inputs: {}
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
-  check-run:
-    name: Check PR run
-    uses: bitwarden/gh-actions/.github/workflows/check-run.yml@main
-    permissions:
-      contents: read
+  check-event-source:
+    name: Check event and source
+    runs-on: ubuntu-24.04
+    # Only run this job if the event is workflow_call or the PR is from the same repository (not a fork)
+    # This avoids running it twice for forks that are already running the pull_request_target workflow
+    if: github.event_name == 'workflow_call' || github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - name: Check PR event and source
+        run: echo "This PR is from the same repository (Not a fork) or called via workflow_call."
 
   chromatic:
     name: Chromatic
     runs-on: ubuntu-22.04
-    needs: check-run
+    needs: check-event-source
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[CL-1074](https://bitwarden.atlassian.net/browse/CL-1074)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
We want Chromatic to run on all internal PRs so that we can review changes on branches targeting bases other than `main` (for example, feature branches). To accomplish this while also protecting us from external PR workflow risks, we need to split off a second workflow so that we have the configuration for internal and external PRs separated. This follows the pattern used by other split workflows like building web, desktop, and browser.



[CL-1074]: https://bitwarden.atlassian.net/browse/CL-1074?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ