### PR TITLE
[PM-29493] Folders not persisting through cache

### DIFF
--- a/apps/browser/src/vault/popup/services/vault-popup-list-filters.service.ts
+++ b/apps/browser/src/vault/popup/services/vault-popup-list-filters.service.ts
@@ -132,9 +132,13 @@ export class VaultPopupListFiltersService {
   }
 
   private deserializeFilters(state: CachedFilterState): void {
-    combineLatest([this.organizations$, this.collections$, this.folders$])
+    combineLatest([
+      this.organizations$,
+      this.collections$,
+      this.activeUserId$.pipe(switchMap((userId) => this.folderService.folderViews$(userId))),
+    ])
       .pipe(take(1))
-      .subscribe(([orgOptions, collectionOptions, folderOptions]) => {
+      .subscribe(([orgOptions, collectionOptions, folderViews]) => {
         const patchValue: PopupListFilter = {
           organization: null,
           collection: null,
@@ -159,9 +163,7 @@ export class VaultPopupListFiltersService {
         }
 
         if (state.folderId) {
-          const folder = folderOptions
-            .flatMap((f) => this.flattenOptions(f))
-            .find((f) => f.value?.id === state.folderId)?.value;
+          const folder = folderViews.find((f) => f.id === state.folderId);
           patchValue.folder = folder || null;
         }
 
@@ -374,7 +376,7 @@ export class VaultPopupListFiltersService {
         this.filters$.pipe(
           distinctUntilChanged(
             (previousFilter, currentFilter) =>
-              // Only update the collections when the organizationId filter changes
+              // Only update the folders when the organizationId filter changes
               previousFilter.organization?.id === currentFilter.organization?.id,
           ),
         ),


### PR DESCRIPTION
## 🎟️ Tracking

[PM-29493](https://bitwarden.atlassian.net/browse/PM-29493)

## 📔 Objective

`deserializeFilters()` was using `this.folders$` to find the cached folder to restore. However, `folders$` depends on `this.filters$` (the form value) to filter folders based on the selected organization. This created a circular dependency:

1. `deserializeFilters()` waits for `folders$` to emit
2. `folders$` waits for `filters$` to know which organization is selected
3. `filters$` won't update until `deserializeFilters()` patches the form

Since the organization filter hadn't been restored yet, `folders$` could filter out the target folder entirely, causing it to never be found.

## Solution

Use `folderService.folderViews$()` directly instead of the derived `folders$` observable. This returns the raw, unfiltered folder list, ensuring the cached folder can always be found by ID regardless of the current filter state.
## 📸 Screenshots

|Before|After|
|-|-|
|<video src="https://github.com/user-attachments/assets/9a4a36e5-3069-4308-b2d9-1da57f31265c" />|<video src="https://github.com/user-attachments/assets/53433916-67dd-4f8d-881d-1dcfc7c3ef52" />|


[PM-29493]: https://bitwarden.atlassian.net/browse/PM-29493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ