### PR TITLE
[PM-10699]  [Defect] CLI - Password length command is not taking effect 

### DIFF
--- a/apps/cli/src/tools/generate.command.spec.ts
+++ b/apps/cli/src/tools/generate.command.spec.ts
@@ -46,10 +46,14 @@ describe("GenerateCommand", () => {
     accountService.activeAccount$ = of(null);
   }
 
-  function mockEnforce(overrides: Partial<PasswordGeneratorOptions>) {
+  function mockEnforce(
+    overrides: Partial<PasswordGeneratorOptions>,
+    policyOverrides: Partial<PasswordGeneratorPolicyOptions> = {},
+  ) {
+    const policy = Object.assign(new PasswordGeneratorPolicyOptions(), policyOverrides);
     passwordGenerationService.enforcePasswordGeneratorPoliciesOnOptions.mockImplementation(
       async (options) =>
-        [{ ...options, ...overrides }, new PasswordGeneratorPolicyOptions()] as [
+        [{ ...options, ...overrides }, policy] as [
           PasswordGeneratorOptions,
           PasswordGeneratorPolicyOptions,
         ],
@@ -123,6 +127,40 @@ describe("GenerateCommand", () => {
         expect(response.success).toBe(false);
         expect(response.message).toContain("--minSpecial 0");
         expect(response.message).toContain("policy requires a minimum of 3 special characters");
+      });
+
+      it("shows the raw user-typed value in the error when CLI clamps the input", async () => {
+        // User types --length 2; CLI clamps to 5 internally, but error should show 2
+        mockEnforce({ length: 20 });
+
+        const response = await command.run({ length: 2 });
+
+        expect(response.success).toBe(false);
+        expect(response.message).toContain("--length 2");
+        expect(response.message).not.toContain("--length 5");
+      });
+
+      it("explains when effective minimum length exceeds the configured policy minimum", async () => {
+        // Policy minLength=10, but character minimums force effective floor to 12
+        mockEnforce({ length: 12 }, { minLength: 10 });
+
+        const response = await command.run({ length: 8 });
+
+        expect(response.success).toBe(false);
+        expect(response.message).toContain("policy requires a minimum length of 12");
+        expect(response.message).toContain("raised from 10");
+        expect(response.message).toContain("minimum character requirements");
+      });
+
+      it("does not show raised-from note when effective length equals the configured minimum", async () => {
+        // Policy minLength=20, effective length also 20 — no adjustment note needed
+        mockEnforce({ length: 20 }, { minLength: 20 });
+
+        const response = await command.run({ length: 8 });
+
+        expect(response.success).toBe(false);
+        expect(response.message).toContain("policy requires a minimum length of 20");
+        expect(response.message).not.toContain("raised from");
       });
 
       it("reports all numeric conflicts in a single response", async () => {

--- a/apps/cli/src/tools/generate.command.ts
+++ b/apps/cli/src/tools/generate.command.ts
@@ -2,6 +2,7 @@
 // @ts-strict-ignore
 import { firstValueFrom, of, switchMap } from "rxjs";
 
+import { PasswordGeneratorPolicyOptions } from "@bitwarden/common/admin-console/models/domain/password-generator-policy-options";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { TokenService } from "@bitwarden/common/auth/abstractions/token.service";
 import {
@@ -27,6 +28,11 @@ type ExplicitFlags = {
   minNumber: boolean;
   minSpecial: boolean;
   words: boolean;
+  // Raw values as typed by the user, before CLI normalization/clamping
+  rawLength: number | null;
+  rawMinNumber: number | null;
+  rawMinSpecial: number | null;
+  rawWords: number | null;
 };
 
 export class GenerateCommand {
@@ -65,17 +71,26 @@ export class GenerateCommand {
         }),
       ),
     );
+
     // snapshot before the service mutates options in place
     const optionsBeforeEnforcement = { ...options };
-    const enforcedOptions = shouldEnforceOptions
-      ? (await this.passwordGenerationService.enforcePasswordGeneratorPoliciesOnOptions(options))[0]
-      : options;
+    let policyOptions: PasswordGeneratorPolicyOptions | null = null;
+    let enforcedOptions: PasswordGeneratorOptions;
+    if (shouldEnforceOptions) {
+      const result =
+        await this.passwordGenerationService.enforcePasswordGeneratorPoliciesOnOptions(options);
+      enforcedOptions = result[0];
+      policyOptions = result[1];
+    } else {
+      enforcedOptions = options;
+    }
 
     if (shouldEnforceOptions) {
       const conflicts = this.detectPolicyConflicts(
         normalizedOptions.explicit,
         optionsBeforeEnforcement,
         enforcedOptions,
+        policyOptions,
       );
       if (conflicts.length > 0) {
         const msg =
@@ -95,24 +110,33 @@ export class GenerateCommand {
     explicit: ExplicitFlags,
     before: PasswordGeneratorOptions,
     after: PasswordGeneratorOptions,
+    policy: PasswordGeneratorPolicyOptions | null,
   ): string[] {
     const conflicts: string[] = [];
     const isPassword = before.type !== "passphrase";
 
     if (isPassword) {
       if (explicit.length && after.length > before.length) {
+        const userValue = explicit.rawLength ?? before.length;
+        const configuredMin = policy?.minLength > 0 ? policy.minLength : null;
+        const raisedNote =
+          configuredMin != null && after.length > configuredMin
+            ? ` (raised from ${configuredMin} to accommodate minimum character requirements)`
+            : "";
         conflicts.push(
-          `--length ${before.length}: policy requires a minimum length of ${after.length}.`,
+          `--length ${userValue}: policy requires a minimum length of ${after.length}${raisedNote}.`,
         );
       }
       if (explicit.minNumber && after.minNumber > before.minNumber) {
+        const userValue = explicit.rawMinNumber ?? before.minNumber;
         conflicts.push(
-          `--minNumber ${before.minNumber}: policy requires a minimum of ${after.minNumber} numbers.`,
+          `--minNumber ${userValue}: policy requires a minimum of ${after.minNumber} numbers.`,
         );
       }
       if (explicit.minSpecial && after.minSpecial > before.minSpecial) {
+        const userValue = explicit.rawMinSpecial ?? before.minSpecial;
         conflicts.push(
-          `--minSpecial ${before.minSpecial}: policy requires a minimum of ${after.minSpecial} special characters.`,
+          `--minSpecial ${userValue}: policy requires a minimum of ${after.minSpecial} special characters.`,
         );
       }
 
@@ -135,8 +159,9 @@ export class GenerateCommand {
       }
     } else {
       if (explicit.words && after.numWords > before.numWords) {
+        const userValue = explicit.rawWords ?? before.numWords;
         conflicts.push(
-          `--words ${before.numWords}: policy requires a minimum of ${after.numWords} words.`,
+          `--words ${userValue}: policy requires a minimum of ${after.numWords} words.`,
         );
       }
     }
@@ -171,6 +196,22 @@ class Options {
       minNumber: passedOptions?.minNumber != null,
       minSpecial: passedOptions?.minSpecial != null,
       words: passedOptions?.words != null,
+      rawLength:
+        passedOptions?.length != null
+          ? CliUtils.convertNumberOption(passedOptions.length, null)
+          : null,
+      rawMinNumber:
+        passedOptions?.minNumber != null
+          ? CliUtils.convertNumberOption(passedOptions.minNumber, null)
+          : null,
+      rawMinSpecial:
+        passedOptions?.minSpecial != null
+          ? CliUtils.convertNumberOption(passedOptions.minSpecial, null)
+          : null,
+      rawWords:
+        passedOptions?.words != null
+          ? CliUtils.convertNumberOption(passedOptions.words, null)
+          : null,
     };
 
     this.uppercase = CliUtils.convertBooleanOption(passedOptions?.uppercase);


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-10699

## 📔 Objective

Organization policies regarding password generation will supersede command options supplied during password generation in the CLI, which may lead to surprising behavior. In order to avoid user confusion, this PR compares user supplied options to the `bw generate` command and if any conflict with organizational policies, the command will fail with descriptive error output. 


## 📸 Screenshots

<img width="425" height="549" alt="Screenshot 2026-03-04 at 18 25 04" src="https://github.com/user-attachments/assets/3e8f737b-481d-4692-9ccc-5e670fbde208" />

<img width="787" height="122" alt="Screenshot 2026-03-04 at 18 35 58" src="https://github.com/user-attachments/assets/fc678771-ebcc-44b5-bf3b-f937a8d4e640" />
