### PR TITLE
[PM-33175] Remove most JslibModule usages from desktop

### DIFF
--- a/apps/desktop/src/app/accounts/settings.component.ts
+++ b/apps/desktop/src/app/accounts/settings.component.ts
@@ -8,7 +8,6 @@ import { BehaviorSubject, Observable, Subject, combineLatest, firstValueFrom, of
 import { concatMap, map, pairwise, startWith, switchMap, takeUntil, timeout } from "rxjs/operators";
 
 import { PremiumBadgeComponent } from "@bitwarden/angular/billing/components/premium-badge";
-import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { PolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
 import { PolicyType } from "@bitwarden/common/admin-console/enums";
 import { getFirstPolicy } from "@bitwarden/common/admin-console/services/policy/default-policy.service";
@@ -59,6 +58,7 @@ import {
   SessionTimeoutInputLegacyComponent,
   SessionTimeoutSettingsComponent,
 } from "@bitwarden/key-management-ui";
+import { I18nPipe } from "@bitwarden/ui-common";
 import { PermitCipherDetailsPopoverComponent } from "@bitwarden/vault";
 
 import { SetPinComponent } from "../../auth/components/set-pin.component";
@@ -92,7 +92,7 @@ import { NativeMessagingManifestService } from "../services/native-messaging-man
     IconButtonModule,
     IconModule,
     ItemModule,
-    JslibModule,
+    I18nPipe,
     LinkModule,
     RouterModule,
     SectionComponent,

--- a/apps/desktop/src/app/app.module.ts
+++ b/apps/desktop/src/app/app.module.ts
@@ -6,6 +6,7 @@ import "../platform/app/locales";
 import { NgModule } from "@angular/core";
 import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
 
+import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { PremiumUpgradePromptService } from "@bitwarden/common/vault/abstractions/premium-upgrade-prompt.service";
 import { CalloutModule, DialogModule } from "@bitwarden/components";
 import { AssignCollectionsComponent } from "@bitwarden/vault";
@@ -41,6 +42,7 @@ import { SharedModule } from "./shared/shared.module";
     NavComponent,
     AssignCollectionsComponent,
     VaultV2Component,
+    JslibModule,
   ],
   declarations: [
     AccountSwitcherComponent,

--- a/apps/desktop/src/app/components/browser-sync-verification-dialog.component.ts
+++ b/apps/desktop/src/app/components/browser-sync-verification-dialog.component.ts
@@ -1,6 +1,5 @@
 import { Component, Inject } from "@angular/core";
 
-import { JslibModule } from "@bitwarden/angular/jslib.module";
 import {
   DIALOG_DATA,
   ButtonModule,
@@ -8,6 +7,7 @@ import {
   DialogService,
   CenterPositionStrategy,
 } from "@bitwarden/components";
+import { I18nPipe } from "@bitwarden/ui-common";
 
 export type BrowserSyncVerificationDialogParams = {
   fingerprint: string[];
@@ -17,7 +17,7 @@ export type BrowserSyncVerificationDialogParams = {
 // eslint-disable-next-line @angular-eslint/prefer-on-push-component-change-detection
 @Component({
   templateUrl: "browser-sync-verification-dialog.component.html",
-  imports: [JslibModule, ButtonModule, DialogModule],
+  imports: [I18nPipe, ButtonModule, DialogModule],
 })
 export class BrowserSyncVerificationDialogComponent {
   constructor(@Inject(DIALOG_DATA) protected params: BrowserSyncVerificationDialogParams) {}

--- a/apps/desktop/src/app/components/user-verification.component.ts
+++ b/apps/desktop/src/app/components/user-verification.component.ts
@@ -4,8 +4,8 @@ import { Component } from "@angular/core";
 import { FormsModule, NG_VALUE_ACCESSOR, ReactiveFormsModule } from "@angular/forms";
 
 import { UserVerificationComponent as BaseComponent } from "@bitwarden/angular/auth/components/user-verification.component";
-import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { FormFieldModule } from "@bitwarden/components";
+import { I18nPipe } from "@bitwarden/ui-common";
 
 /**
  * @deprecated Jan 24, 2024: Use new libs/auth UserVerificationDialogComponent or UserVerificationFormInputComponent instead.
@@ -15,7 +15,7 @@ import { FormFieldModule } from "@bitwarden/components";
 // eslint-disable-next-line @angular-eslint/prefer-on-push-component-change-detection
 @Component({
   selector: "app-user-verification",
-  imports: [CommonModule, JslibModule, ReactiveFormsModule, FormFieldModule, FormsModule],
+  imports: [CommonModule, I18nPipe, ReactiveFormsModule, FormFieldModule, FormsModule],
   templateUrl: "user-verification.component.html",
   providers: [
     {

--- a/apps/desktop/src/app/components/verify-native-messaging-dialog.component.ts
+++ b/apps/desktop/src/app/components/verify-native-messaging-dialog.component.ts
@@ -1,6 +1,5 @@
 import { Component, Inject } from "@angular/core";
 
-import { JslibModule } from "@bitwarden/angular/jslib.module";
 import {
   DIALOG_DATA,
   ButtonModule,
@@ -8,6 +7,7 @@ import {
   DialogService,
   CenterPositionStrategy,
 } from "@bitwarden/components";
+import { I18nPipe } from "@bitwarden/ui-common";
 
 export type VerifyNativeMessagingDialogData = {
   applicationName: string;
@@ -17,7 +17,7 @@ export type VerifyNativeMessagingDialogData = {
 // eslint-disable-next-line @angular-eslint/prefer-on-push-component-change-detection
 @Component({
   templateUrl: "verify-native-messaging-dialog.component.html",
-  imports: [JslibModule, ButtonModule, DialogModule],
+  imports: [I18nPipe, ButtonModule, DialogModule],
 })
 export class VerifyNativeMessagingDialogComponent {
   constructor(@Inject(DIALOG_DATA) protected data: VerifyNativeMessagingDialogData) {}

--- a/apps/desktop/src/app/shared/shared.module.ts
+++ b/apps/desktop/src/app/shared/shared.module.ts
@@ -6,8 +6,8 @@ import { CommonModule, DatePipe } from "@angular/common";
 import { NgModule } from "@angular/core";
 import { FormsModule, ReactiveFormsModule } from "@angular/forms";
 
-import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { IconModule } from "@bitwarden/components";
+import { I18nPipe } from "@bitwarden/ui-common";
 
 import { AvatarComponent } from "../components/avatar.component";
 import { ServicesModule } from "../services/services.module";
@@ -25,7 +25,7 @@ import { ServicesModule } from "../services/services.module";
     DragDropModule,
     FormsModule,
     IconModule,
-    JslibModule,
+    I18nPipe,
     OverlayModule,
     ReactiveFormsModule,
     ScrollingModule,
@@ -39,7 +39,7 @@ import { ServicesModule } from "../services/services.module";
     DragDropModule,
     FormsModule,
     IconModule,
-    JslibModule,
+    I18nPipe,
     OverlayModule,
     ReactiveFormsModule,
     ScrollingModule,

--- a/apps/desktop/src/app/tools/export/export-desktop.component.ts
+++ b/apps/desktop/src/app/tools/export/export-desktop.component.ts
@@ -1,8 +1,8 @@
 import { CommonModule } from "@angular/common";
 import { Component } from "@angular/core";
 
-import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { DialogRef, AsyncActionsModule, ButtonModule, DialogModule } from "@bitwarden/components";
+import { I18nPipe } from "@bitwarden/ui-common";
 import { ExportComponent } from "@bitwarden/vault-export-ui";
 
 // FIXME(https://bitwarden.atlassian.net/browse/CL-764): Migrate to OnPush
@@ -11,7 +11,7 @@ import { ExportComponent } from "@bitwarden/vault-export-ui";
   templateUrl: "export-desktop.component.html",
   imports: [
     CommonModule,
-    JslibModule,
+    I18nPipe,
     DialogModule,
     AsyncActionsModule,
     ButtonModule,

--- a/apps/desktop/src/app/tools/generator/credential-generator.component.ts
+++ b/apps/desktop/src/app/tools/generator/credential-generator.component.ts
@@ -1,18 +1,18 @@
 import { Component } from "@angular/core";
 
-import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { ButtonModule, DialogModule, DialogService, ItemModule } from "@bitwarden/components";
 import {
   CredentialGeneratorHistoryDialogComponent,
   GeneratorModule,
 } from "@bitwarden/generator-components";
+import { I18nPipe } from "@bitwarden/ui-common";
 
 // FIXME(https://bitwarden.atlassian.net/browse/CL-764): Migrate to OnPush
 // eslint-disable-next-line @angular-eslint/prefer-on-push-component-change-detection
 @Component({
   selector: "credential-generator",
   templateUrl: "credential-generator.component.html",
-  imports: [DialogModule, ButtonModule, JslibModule, GeneratorModule, ItemModule],
+  imports: [DialogModule, ButtonModule, I18nPipe, GeneratorModule, ItemModule],
 })
 export class CredentialGeneratorComponent {
   constructor(private dialogService: DialogService) {}

--- a/apps/desktop/src/app/tools/import/import-desktop.component.ts
+++ b/apps/desktop/src/app/tools/import/import-desktop.component.ts
@@ -1,7 +1,6 @@
 import { CommonModule } from "@angular/common";
 import { Component } from "@angular/core";
 
-import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { DialogRef, AsyncActionsModule, ButtonModule, DialogModule } from "@bitwarden/components";
 import type { chromium_importer } from "@bitwarden/desktop-napi";
 import { ImportMetadataServiceAbstraction } from "@bitwarden/importer-core";
@@ -10,7 +9,7 @@ import {
   ImporterProviders,
   SYSTEM_SERVICE_PROVIDER,
 } from "@bitwarden/importer-ui";
-import { safeProvider } from "@bitwarden/ui-common";
+import { I18nPipe, safeProvider } from "@bitwarden/ui-common";
 
 import { DesktopImportMetadataService } from "./desktop-import-metadata.service";
 
@@ -20,7 +19,7 @@ import { DesktopImportMetadataService } from "./desktop-import-metadata.service"
   templateUrl: "import-desktop.component.html",
   imports: [
     CommonModule,
-    JslibModule,
+    I18nPipe,
     DialogModule,
     AsyncActionsModule,
     ButtonModule,

--- a/apps/desktop/src/app/tools/send-v2/send-v2.component.ts
+++ b/apps/desktop/src/app/tools/send-v2/send-v2.component.ts
@@ -4,7 +4,6 @@ import { Component, computed, DestroyRef, inject, signal, viewChild } from "@ang
 import { toSignal } from "@angular/core/rxjs-interop";
 import { combineLatest, map, switchMap, lastValueFrom } from "rxjs";
 
-import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { PolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
 import { PolicyType } from "@bitwarden/common/admin-console/enums";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
@@ -30,6 +29,7 @@ import {
   DefaultSendFormConfigService,
   SendItemDialogResult,
 } from "@bitwarden/send-ui";
+import { I18nPipe } from "@bitwarden/ui-common";
 
 import { DesktopPremiumUpgradePromptService } from "../../../services/desktop-premium-upgrade-prompt.service";
 import { DesktopHeaderComponent } from "../../layout/header";
@@ -51,7 +51,7 @@ type Action = (typeof Action)[keyof typeof Action];
 @Component({
   selector: "app-send-v2",
   imports: [
-    JslibModule,
+    I18nPipe,
     ButtonModule,
     AddEditComponent,
     SendListComponent,

--- a/apps/desktop/src/auth/components/account-switcher/account-switcher-v2.component.ts
+++ b/apps/desktop/src/auth/components/account-switcher/account-switcher-v2.component.ts
@@ -9,7 +9,6 @@ import { toSignal } from "@angular/core/rxjs-interop";
 import { Router } from "@angular/router";
 import { combineLatest, firstValueFrom, map, Observable, switchMap } from "rxjs";
 
-import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { AccountInfo, AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { AuthService } from "@bitwarden/common/auth/abstractions/auth.service";
 import { AvatarService } from "@bitwarden/common/auth/abstractions/avatar.service";
@@ -21,6 +20,7 @@ import { MessagingService } from "@bitwarden/common/platform/abstractions/messag
 import { CommandDefinition, MessageListener } from "@bitwarden/common/platform/messaging";
 import { UserId } from "@bitwarden/common/types/guid";
 import { AvatarModule, IconButtonModule } from "@bitwarden/components";
+import { I18nPipe } from "@bitwarden/ui-common";
 
 import { DesktopBiometricsService } from "../../../key-management/biometrics/desktop.biometrics.service";
 
@@ -41,7 +41,7 @@ type InactiveAccount = ActiveAccount & {
 @Component({
   selector: "app-account-switcher-v2",
   templateUrl: "account-switcher-v2.component.html",
-  imports: [CommonModule, OverlayModule, A11yModule, JslibModule, AvatarModule, IconButtonModule],
+  imports: [CommonModule, OverlayModule, A11yModule, I18nPipe, AvatarModule, IconButtonModule],
   animations: [
     trigger("transformPanel", [
       state(

--- a/apps/desktop/src/auth/components/set-pin.component.ts
+++ b/apps/desktop/src/auth/components/set-pin.component.ts
@@ -3,7 +3,6 @@ import { Component } from "@angular/core";
 import { ReactiveFormsModule } from "@angular/forms";
 
 import { SetPinComponent as BaseSetPinComponent } from "@bitwarden/angular/auth/components/set-pin.component";
-import { JslibModule } from "@bitwarden/angular/jslib.module";
 import {
   AsyncActionsModule,
   ButtonModule,
@@ -12,6 +11,7 @@ import {
   FormFieldModule,
   IconButtonModule,
 } from "@bitwarden/components";
+import { I18nPipe } from "@bitwarden/ui-common";
 // FIXME(https://bitwarden.atlassian.net/browse/CL-764): Migrate to OnPush
 // eslint-disable-next-line @angular-eslint/prefer-on-push-component-change-detection
 @Component({
@@ -19,7 +19,7 @@ import {
   imports: [
     DialogModule,
     CommonModule,
-    JslibModule,
+    I18nPipe,
     ButtonModule,
     IconButtonModule,
     ReactiveFormsModule,

--- a/apps/desktop/src/auth/delete-account.component.ts
+++ b/apps/desktop/src/auth/delete-account.component.ts
@@ -3,7 +3,6 @@
 import { Component } from "@angular/core";
 import { FormBuilder, ReactiveFormsModule } from "@angular/forms";
 
-import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { AccountApiService } from "@bitwarden/common/auth/abstractions/account-api.service";
 import { VerificationWithSecret } from "@bitwarden/common/auth/types/verification";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
@@ -17,6 +16,7 @@ import {
   DialogService,
   ToastService,
 } from "@bitwarden/components";
+import { I18nPipe } from "@bitwarden/ui-common";
 
 import { UserVerificationComponent } from "../app/components/user-verification.component";
 
@@ -26,7 +26,7 @@ import { UserVerificationComponent } from "../app/components/user-verification.c
   selector: "app-delete-account",
   templateUrl: "delete-account.component.html",
   imports: [
-    JslibModule,
+    I18nPipe,
     UserVerificationComponent,
     ButtonModule,
     CalloutModule,

--- a/apps/desktop/src/autofill/components/approve-ssh-request.ts
+++ b/apps/desktop/src/autofill/components/approve-ssh-request.ts
@@ -2,7 +2,6 @@ import { CommonModule } from "@angular/common";
 import { Component, Inject } from "@angular/core";
 import { FormBuilder, ReactiveFormsModule } from "@angular/forms";
 
-import { JslibModule } from "@bitwarden/angular/jslib.module";
 import {
   DIALOG_DATA,
   DialogRef,
@@ -14,6 +13,7 @@ import {
   DialogService,
   CalloutModule,
 } from "@bitwarden/components";
+import { I18nPipe } from "@bitwarden/ui-common";
 
 export interface ApproveSshRequestParams {
   cipherName: string;
@@ -30,7 +30,7 @@ export interface ApproveSshRequestParams {
   imports: [
     DialogModule,
     CommonModule,
-    JslibModule,
+    I18nPipe,
     ButtonModule,
     IconButtonModule,
     ReactiveFormsModule,

--- a/apps/desktop/src/autofill/components/autotype-shortcut.component.ts
+++ b/apps/desktop/src/autofill/components/autotype-shortcut.component.ts
@@ -9,7 +9,6 @@ import {
   ValidationErrors,
 } from "@angular/forms";
 
-import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
 import {
@@ -21,6 +20,7 @@ import {
   FormFieldModule,
   IconButtonModule,
 } from "@bitwarden/components";
+import { I18nPipe } from "@bitwarden/ui-common";
 
 // FIXME(https://bitwarden.atlassian.net/browse/CL-764): Migrate to OnPush
 // eslint-disable-next-line @angular-eslint/prefer-on-push-component-change-detection
@@ -29,7 +29,7 @@ import {
   imports: [
     DialogModule,
     CommonModule,
-    JslibModule,
+    I18nPipe,
     ButtonModule,
     IconButtonModule,
     ReactiveFormsModule,

--- a/apps/desktop/src/autofill/modal/credentials/fido2-create.component.ts
+++ b/apps/desktop/src/autofill/modal/credentials/fido2-create.component.ts
@@ -5,7 +5,7 @@ import { ChangeDetectionStrategy, Component, OnInit, OnDestroy } from "@angular/
 import { RouterModule, Router } from "@angular/router";
 import { combineLatest, map, Observable, Subject, switchMap } from "rxjs";
 
-import { JslibModule } from "@bitwarden/angular/jslib.module";
+import { IconComponent } from "@bitwarden/angular/vault/components/icon.component";
 import { BitwardenShield, NoResults } from "@bitwarden/assets/svg";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { DomainSettingsService } from "@bitwarden/common/autofill/services/domain-settings.service";
@@ -26,6 +26,7 @@ import {
   BitIconButtonComponent,
   SimpleDialogOptions,
 } from "@bitwarden/components";
+import { I18nPipe } from "@bitwarden/ui-common";
 import { PasswordRepromptService } from "@bitwarden/vault";
 
 import { DesktopAutofillService } from "../../../autofill/services/desktop-autofill.service";
@@ -43,13 +44,14 @@ import {
     SectionHeaderComponent,
     BitIconButtonComponent,
     TableModule,
-    JslibModule,
+    I18nPipe,
     SvgModule,
     ButtonModule,
     DialogModule,
     SectionComponent,
     ItemModule,
     BadgeModule,
+    IconComponent,
   ],
   templateUrl: "fido2-create.component.html",
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/apps/desktop/src/autofill/modal/credentials/fido2-excluded-ciphers.component.ts
+++ b/apps/desktop/src/autofill/modal/credentials/fido2-excluded-ciphers.component.ts
@@ -4,7 +4,6 @@ import { CommonModule } from "@angular/common";
 import { ChangeDetectionStrategy, Component, OnInit, OnDestroy } from "@angular/core";
 import { RouterModule, Router } from "@angular/router";
 
-import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { BitwardenShield, NoResults } from "@bitwarden/assets/svg";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import {
@@ -18,6 +17,7 @@ import {
   SectionHeaderComponent,
   BitIconButtonComponent,
 } from "@bitwarden/components";
+import { I18nPipe } from "@bitwarden/ui-common";
 
 import { DesktopSettingsService } from "../../../platform/services/desktop-settings.service";
 import {
@@ -33,7 +33,7 @@ import {
     SectionHeaderComponent,
     BitIconButtonComponent,
     TableModule,
-    JslibModule,
+    I18nPipe,
     SvgModule,
     ButtonModule,
     DialogModule,

--- a/apps/desktop/src/autofill/modal/credentials/fido2-vault.component.ts
+++ b/apps/desktop/src/autofill/modal/credentials/fido2-vault.component.ts
@@ -14,7 +14,7 @@ import {
   takeUntil,
 } from "rxjs";
 
-import { JslibModule } from "@bitwarden/angular/jslib.module";
+import { IconComponent } from "@bitwarden/angular/vault/components/icon.component";
 import { BitwardenShield } from "@bitwarden/assets/svg";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
@@ -33,6 +33,7 @@ import {
   BitIconButtonComponent,
   SectionHeaderComponent,
 } from "@bitwarden/components";
+import { I18nPipe } from "@bitwarden/ui-common";
 import { PasswordRepromptService } from "@bitwarden/vault";
 
 import { DesktopSettingsService } from "../../../platform/services/desktop-settings.service";
@@ -49,13 +50,14 @@ import {
     SectionHeaderComponent,
     BitIconButtonComponent,
     TableModule,
-    JslibModule,
+    I18nPipe,
     SvgModule,
     ButtonModule,
     DialogModule,
     SectionComponent,
     ItemModule,
     BadgeModule,
+    IconComponent,
   ],
   templateUrl: "fido2-vault.component.html",
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/apps/desktop/src/vault/app/vault-v3/vault-items/vault-cipher-row.component.ts
+++ b/apps/desktop/src/vault/app/vault-v3/vault-items/vault-cipher-row.component.ts
@@ -4,7 +4,7 @@ import { NgClass } from "@angular/common";
 import { Component, HostListener, ViewChild, computed, inject, input, output } from "@angular/core";
 
 import { PremiumBadgeComponent } from "@bitwarden/angular/billing/components/premium-badge/premium-badge.component";
-import { JslibModule } from "@bitwarden/angular/jslib.module";
+import { IconComponent } from "@bitwarden/angular/vault/components/icon.component";
 import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { CipherType } from "@bitwarden/common/vault/enums";
@@ -20,6 +20,7 @@ import {
   TooltipDirective,
   TableModule,
 } from "@bitwarden/components";
+import { I18nPipe } from "@bitwarden/ui-common";
 import {
   CopyAction,
   CopyCipherFieldDirective,
@@ -42,7 +43,7 @@ interface CopyFieldConfig {
   templateUrl: "vault-cipher-row.component.html",
   imports: [
     NgClass,
-    JslibModule,
+    I18nPipe,
     TableModule,
     AriaDisableDirective,
     OrganizationNameBadgeComponent,
@@ -52,6 +53,7 @@ interface CopyFieldConfig {
     CopyCipherFieldDirective,
     PremiumBadgeComponent,
     GetOrgNameFromIdPipe,
+    IconComponent,
   ],
 })
 export class VaultCipherRowComponent<C extends CipherViewLike> {

--- a/apps/desktop/src/vault/app/vault-v3/vault-items/vault-collection-row.component.ts
+++ b/apps/desktop/src/vault/app/vault-v3/vault-items/vault-collection-row.component.ts
@@ -4,13 +4,13 @@ import { NgClass } from "@angular/common";
 import { Component, input } from "@angular/core";
 import { RouterLink } from "@angular/router";
 
-import { JslibModule } from "@bitwarden/angular/jslib.module";
 import {
   CollectionView,
   CollectionTypes,
 } from "@bitwarden/common/admin-console/models/collections";
 import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
 import { TableModule } from "@bitwarden/components";
+import { I18nPipe } from "@bitwarden/ui-common";
 import { GetOrgNameFromIdPipe, OrganizationNameBadgeComponent } from "@bitwarden/vault";
 
 // FIXME(https://bitwarden.atlassian.net/browse/CL-764): Migrate to OnPush
@@ -21,7 +21,7 @@ import { GetOrgNameFromIdPipe, OrganizationNameBadgeComponent } from "@bitwarden
   imports: [
     TableModule,
     NgClass,
-    JslibModule,
+    I18nPipe,
     RouterLink,
     OrganizationNameBadgeComponent,
     GetOrgNameFromIdPipe,

--- a/apps/desktop/src/vault/app/vault/assign-collections/assign-collections-desktop.component.ts
+++ b/apps/desktop/src/vault/app/vault/assign-collections/assign-collections-desktop.component.ts
@@ -3,9 +3,9 @@
 import { DIALOG_DATA, DialogConfig, DialogRef } from "@angular/cdk/dialog";
 import { Component, Inject } from "@angular/core";
 
-import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { PluralizePipe } from "@bitwarden/angular/pipes/pluralize.pipe";
 import { ButtonModule, DialogModule, DialogService } from "@bitwarden/components";
+import { I18nPipe } from "@bitwarden/ui-common";
 import {
   AssignCollectionsComponent,
   CollectionAssignmentParams,
@@ -17,7 +17,7 @@ import {
 @Component({
   standalone: true,
   templateUrl: "./assign-collections-desktop.component.html",
-  imports: [AssignCollectionsComponent, PluralizePipe, DialogModule, ButtonModule, JslibModule],
+  imports: [AssignCollectionsComponent, PluralizePipe, DialogModule, ButtonModule, I18nPipe],
 })
 export class AssignCollectionsDesktopComponent {
   protected editableItemCount: number;

--- a/apps/desktop/src/vault/app/vault/credential-generator-dialog.component.ts
+++ b/apps/desktop/src/vault/app/vault/credential-generator-dialog.component.ts
@@ -1,7 +1,6 @@
 import { CommonModule } from "@angular/common";
 import { Component, Inject } from "@angular/core";
 
-import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { UnionOfValues } from "@bitwarden/common/vault/types/union-of-values";
 import {
@@ -12,12 +11,14 @@ import {
   ItemModule,
   LinkModule,
   DialogRef,
+  A11yTitleDirective,
 } from "@bitwarden/components";
 import {
   CredentialGeneratorHistoryDialogComponent,
   GeneratorModule,
 } from "@bitwarden/generator-components";
 import { AlgorithmInfo } from "@bitwarden/generator-core";
+import { I18nPipe } from "@bitwarden/ui-common";
 import { CipherFormGeneratorComponent } from "@bitwarden/vault";
 
 type CredentialGeneratorParams = {
@@ -45,11 +46,12 @@ type CredentialGeneratorDialogAction = UnionOfValues<typeof CredentialGeneratorD
   selector: "credential-generator-dialog",
   templateUrl: "credential-generator-dialog.component.html",
   imports: [
+    A11yTitleDirective,
     CipherFormGeneratorComponent,
     CommonModule,
     DialogModule,
     ButtonModule,
-    JslibModule,
+    I18nPipe,
     GeneratorModule,
     ItemModule,
     LinkModule,


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-33175
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

This replaces most JslibModule usages in desktop with `I18nPipe` and any other relevant import. The remaining imports are either files that are scheduled to be removed or in the main `AppModule` which still declares some usages.
