### PR TITLE
[CL-1074] Fix conditional workflow run for push events

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -23,11 +23,11 @@ jobs:
   check-event-source:
     name: Check event and source
     runs-on: ubuntu-24.04
-    # Only run this job if a) it's from one of the push triggers, b) the event is workflow_call
-    # (aka triggered by the chromatic-target workflow, like a forked PR would), or c) the PR is from
-    # the same repository (not a fork)
-    # This avoids running it twice for forked PRs that are already running the pull_request_target workflow
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.full_name == github.repository
+    # Only run on events other than pull_request, and if it is a pull_request event, only run if
+    # the PR comes from an internal contributor
+    # This check avoids running the workflow twice for external/forked PRs that are already running
+    # the pull_request_target workflow
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Check PR event and source
         run: echo "This PR is from the same repository (Not a fork) or called via workflow_call."


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[CL-1074](https://bitwarden.atlassian.net/browse/CL-1074)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Fix the "check event source" workflow filter to check for workflows triggered by `push` events, like on `main` or `rc`. Previously, it was only running on PR event triggers. Now it will support push events and the PR triggers.


[CL-1074]: https://bitwarden.atlassian.net/browse/CL-1074?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ