### PR TITLE
Sanitize branch ref with toJSON

### DIFF
--- a/.github/workflows/test-browser-interactions.yml
+++ b/.github/workflows/test-browser-interactions.yml
@@ -83,5 +83,5 @@ jobs:
         client-payload: |-
           {
             "origin_issue": ${{ github.event.workflow_run.pull_requests[0].number }},
-            "origin_branch": "${{ toJSON(github.event.workflow_run.pull_requests[0].head.ref) }}"
+            "origin_branch": ${{ toJSON(github.event.workflow_run.pull_requests[0].head.ref) }}
           }

--- a/.github/workflows/test-browser-interactions.yml
+++ b/.github/workflows/test-browser-interactions.yml
@@ -83,5 +83,5 @@ jobs:
         client-payload: |-
           {
             "origin_issue": ${{ github.event.workflow_run.pull_requests[0].number }},
-            "origin_branch": "${{ github.event.workflow_run.pull_requests[0].head.ref }}"
+            "origin_branch": "${{ toJSON(github.event.workflow_run.pull_requests[0].head.ref) }}"
           }


### PR DESCRIPTION
## 🎟️ Tracking

Found during actions audit

## 📔 Objective

sanitize branch ref with toJSON to prevent JSON injection in CI workflow

