### PR TITLE
pm-33009: Add email validation to data breach report

### DIFF
--- a/apps/web/src/app/dirt/reports/pages/breach-report.component.html
+++ b/apps/web/src/app/dirt/reports/pages/breach-report.component.html
@@ -4,26 +4,26 @@
   <p>{{ "breachDesc" | i18n }}</p>
   <form [bitSubmit]="submit" [formGroup]="formGroup">
     <bit-form-field class="tw-w-1/2" disableMargin>
-      <bit-label>{{ "username" | i18n }}</bit-label>
-      <input id="username" type="text" formControlName="username" bitInput />
+      <bit-label>{{ "email" | i18n }}</bit-label>
+      <input id="email" type="text" formControlName="email" bitInput />
     </bit-form-field>
-    <small class="tw-mb-4 tw-block tw-text-muted">{{ "breachCheckUsernameEmail" | i18n }}</small>
+    <small class="tw-mb-4 tw-block tw-text-muted">{{ "breachCheckEmail" | i18n }}</small>
     <button type="submit" buttonType="primary" bitButton [loading]="loading">
       {{ "checkBreaches" | i18n }}
     </button>
   </form>
-  @if (!loading && checkedUsername) {
+  @if (!loading && checkedEmail) {
     <div class="tw-mt-4">
       @if (error) {
         <p>{{ "reportError" | i18n }}...</p>
       } @else {
         @if (!breachedAccounts.length) {
           <bit-callout type="success" title="{{ 'goodNews' | i18n }}">
-            {{ "breachUsernameNotFound" | i18n: checkedUsername }}
+            {{ "breachEmailNotFound" | i18n: checkedEmail }}
           </bit-callout>
         } @else {
           <bit-callout type="danger" title="{{ 'breachFound' | i18n }}">
-            {{ "breachUsernameFound" | i18n: checkedUsername : breachedAccounts.length }}
+            {{ "breachEmailFound" | i18n: checkedEmail : breachedAccounts.length }}
           </bit-callout>
           <ul
             class="tw-list-none tw-flex-col tw-divide-x-0 tw-divide-y tw-divide-solid tw-divide-secondary-300 tw-rounded tw-border tw-border-solid tw-border-secondary-300 tw-p-0"

--- a/apps/web/src/app/dirt/reports/pages/breach-report.component.spec.ts
+++ b/apps/web/src/app/dirt/reports/pages/breach-report.component.spec.ts
@@ -98,38 +98,38 @@ describe("BreachReportComponent", () => {
   });
 
   it("should initialize form with account email", async () => {
-    expect(component.formGroup.get("username").value).toEqual("test@example.com");
+    expect(component.formGroup.get("email").value).toEqual("test@example.com");
   });
 
   it("should mark form as touched and show validation error if form is invalid on submit", async () => {
-    component.formGroup.get("username").setValue("");
+    component.formGroup.get("email").setValue("");
     await component.submit();
 
     expect(component.formGroup.touched).toBe(true);
     expect(component.formGroup.invalid).toBe(true);
   });
 
-  it("should call auditService.breachedAccounts with lowercase username", async () => {
+  it("should call auditService.breachedAccounts with lowercase email", async () => {
     auditService.breachedAccounts.mockResolvedValue(breachedAccounts);
-    component.formGroup.get("username").setValue("ValidUser@example.com");
+    component.formGroup.get("email").setValue("ValidUser@example.com");
 
     await component.submit();
 
     expect(auditService.breachedAccounts).toHaveBeenCalledWith("validuser@example.com");
   });
 
-  it("should set breachedAccounts and checkedUsername after successful submit", async () => {
+  it("should set breachedAccounts and checkedEmail after successful submit", async () => {
     auditService.breachedAccounts.mockResolvedValue(breachedAccounts);
 
     await component.submit();
 
     expect(component.breachedAccounts).toEqual(breachedAccounts);
-    expect(component.checkedUsername).toEqual("test@example.com");
+    expect(component.checkedEmail).toEqual("test@example.com");
   });
 
   it("should set error to true if auditService.breachedAccounts throws an error", async () => {
     auditService.breachedAccounts.mockRejectedValue(new Error("test error"));
-    component.formGroup.get("username").setValue("valid@example.com");
+    component.formGroup.get("email").setValue("valid@example.com");
 
     await component.submit();
 
@@ -138,7 +138,7 @@ describe("BreachReportComponent", () => {
 
   it("should set loading to false after submit", async () => {
     auditService.breachedAccounts.mockResolvedValue([]);
-    component.formGroup.get("username").setValue("valid@example.com");
+    component.formGroup.get("email").setValue("valid@example.com");
 
     await component.submit();
 
@@ -146,21 +146,21 @@ describe("BreachReportComponent", () => {
   });
 
   it("should mark form as invalid when email format is invalid", () => {
-    component.formGroup.get("username").setValue("invalid-email");
+    component.formGroup.get("email").setValue("invalid-email");
 
-    expect(component.formGroup.get("username").hasError("email")).toBe(true);
+    expect(component.formGroup.get("email").hasError("email")).toBe(true);
     expect(component.formGroup.invalid).toBe(true);
   });
 
   it("should mark form as valid when email format is valid", () => {
-    component.formGroup.get("username").setValue("valid@example.com");
+    component.formGroup.get("email").setValue("valid@example.com");
 
-    expect(component.formGroup.get("username").hasError("email")).toBe(false);
+    expect(component.formGroup.get("email").hasError("email")).toBe(false);
     expect(component.formGroup.invalid).toBe(false);
   });
 
   it("should not call auditService when email format is invalid", async () => {
-    component.formGroup.get("username").setValue("invalid-email");
+    component.formGroup.get("email").setValue("invalid-email");
 
     await component.submit();
 

--- a/apps/web/src/app/dirt/reports/pages/breach-report.component.ts
+++ b/apps/web/src/app/dirt/reports/pages/breach-report.component.ts
@@ -18,10 +18,10 @@ import { BreachAccountResponse } from "@bitwarden/common/dirt/models/response/br
 export class BreachReportComponent implements OnInit {
   loading = false;
   error = false;
-  checkedUsername: string;
+  checkedEmail: string;
   breachedAccounts: BreachAccountResponse[] = [];
   formGroup = this.formBuilder.group({
-    username: ["", { validators: [Validators.required, Validators.email], updateOn: "change" }],
+    email: ["", { validators: [Validators.required, Validators.email], updateOn: "change" }],
   });
 
   constructor(
@@ -32,7 +32,7 @@ export class BreachReportComponent implements OnInit {
 
   async ngOnInit() {
     this.formGroup
-      .get("username")
+      .get("email")
       .setValue(
         await firstValueFrom(this.accountService.activeAccount$.pipe(map((a) => a?.email))),
       );
@@ -47,15 +47,15 @@ export class BreachReportComponent implements OnInit {
 
     this.error = false;
     this.loading = true;
-    const username = this.formGroup.value.username.toLowerCase();
+    const email = this.formGroup.value.email.toLowerCase();
     try {
-      this.breachedAccounts = await this.auditService.breachedAccounts(username);
+      this.breachedAccounts = await this.auditService.breachedAccounts(email);
     } catch {
       this.error = true;
     } finally {
       this.loading = false;
     }
 
-    this.checkedUsername = username;
+    this.checkedEmail = email;
   };
 }

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -3047,16 +3047,16 @@
   "breachDesc": {
     "message": "Breached accounts can expose your personal information. Secure breached accounts by enabling 2FA or creating a stronger password."
   },
-  "breachCheckUsernameEmail": {
-    "message": "Check any usernames or email addresses that you use."
+  "breachCheckEmail": {
+    "message": "Check any email addresses that you use."
   },
   "checkBreaches": {
     "message": "Check breaches"
   },
-  "breachUsernameNotFound": {
-    "message": "$USERNAME$ was not found in any known data breaches.",
+  "breachEmailNotFound": {
+    "message": "$EMAIL$ was not found in any known data breaches.",
     "placeholders": {
-      "username": {
+      "email": {
         "content": "$1",
         "example": "user@example.com"
       }
@@ -3066,10 +3066,10 @@
     "message": "Good news",
     "description": "ex. Good News, No Breached Accounts Found!"
   },
-  "breachUsernameFound": {
-    "message": "$USERNAME$ was found in $COUNT$ different data breaches online.",
+  "breachEmailFound": {
+    "message": "$EMAIL$ was found in $COUNT$ different data breaches online.",
     "placeholders": {
-      "username": {
+      "email": {
         "content": "$1",
         "example": "user@example.com"
       },


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-33009

## 📔 Objective

- Add Validators.email to username field in breach report form
- Update existing tests to use valid email formats
- Add tests to verify email format validation prevents submission

## 📸 Screenshots

<img width="1247" height="672" alt="image" src="https://github.com/user-attachments/assets/f850a09f-e82d-4b7d-8e04-fc38aa359a38" />


