### PR TITLE
[PM-33210] fix(login): clear validation errors on region change

### DIFF
--- a/libs/auth/src/angular/login/login.component.ts
+++ b/libs/auth/src/angular/login/login.component.ts
@@ -11,7 +11,7 @@ import {
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { FormBuilder, FormControl, ReactiveFormsModule, Validators } from "@angular/forms";
 import { ActivatedRoute, Router, RouterModule } from "@angular/router";
-import { firstValueFrom, Subject, take, takeUntil } from "rxjs";
+import { firstValueFrom, Subject, take, takeUntil, skip } from "rxjs";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { VaultIcon, WaveIcon } from "@bitwarden/assets/svg";
@@ -210,6 +210,25 @@ export class LoginComponent implements OnInit, OnDestroy {
     // This SSO required check should come after email has had a chance to be pre-filled (if it
     // was found in query params or was the remembered email)
     await this.determineIfSsoRequired();
+
+    // Listen for region/environment changes after initialization.
+    // If the user switches region while on the password entry screen, we need to clear
+    // any stale authentication errors from the previous region and refresh the prelogin
+    // data (KDF settings) for the new environment.
+    this.environmentService.environment$
+      .pipe(
+        skip(1), // Skip the initial emission, only react to subsequent changes
+        takeUntil(this.destroy$),
+      )
+      .subscribe((env) => {
+        if (this.loginUiState === LoginUiState.MASTER_PASSWORD_ENTRY) {
+          // Clear previous login attempt errors as they are no longer valid for the new region
+          this.formGroup.controls.masterPassword.setErrors(null);
+          this.formGroup.controls.masterPassword.updateValueAndValidity();
+          // Fetch new prelogin data for the updated region
+          this.makePasswordPreloginCall().catch((err) => this.logService.error(err));
+        }
+      });
   }
 
   private async desktopOnInit(): Promise<void> {


### PR DESCRIPTION
## 🎟️ Tracking
Resolves #19399
## 📔 Objective
When a user enters a wrong password and then switches server region, the error message stays there even if it doesn't make sense anymore. 

This fix clears validation errors when the region changes and re triggers getPasswordPrelogin as it's result depend on the region used.

It's a minimal change that fits into the existing error handling. Didn't want to touch too much without discussing it first. Open to suggestions if you'd prefer a different approach.