### PR TITLE
[PM-32085] - popup width migration

### DIFF
--- a/apps/browser/src/platform/popup/layout/popup-size.service.ts
+++ b/apps/browser/src/platform/popup/layout/popup-size.service.ts
@@ -100,7 +100,7 @@ export class PopupSizeService {
       localStorage.setItem(PopupSizeService.LocalStorageKey, storedValue);
     }
 
-    void this.setStyle(storedValue as any);
+    void this.setStyle(PopupSizeService.toPopupWidthOption(migratedValue));
   }
 
   /**
@@ -112,5 +112,17 @@ export class PopupSizeService {
       return "wide";
     }
     return value;
+  }
+
+  private static isPopupWidthOption(value: string | null): value is PopupWidthOption {
+    return value != null && value in PopupWidthOptions;
+  }
+
+  private static toPopupWidthOption(value: string | null): PopupWidthOption {
+    const migrated = PopupSizeService.migrateOldWidthOption(value);
+    if (PopupSizeService.isPopupWidthOption(migrated)) {
+      return migrated;
+    }
+    return "default";
   }
 }

--- a/apps/browser/src/platform/popup/layout/popup-size.service.ts
+++ b/apps/browser/src/platform/popup/layout/popup-size.service.ts
@@ -91,7 +91,26 @@ export class PopupSizeService {
    * To keep the popup size from flickering on bootstrap, we store the width in `localStorage` so we can quickly & synchronously reference it.
    **/
   static initBodyWidthFromLocalStorage() {
-    const storedValue = localStorage.getItem(PopupSizeService.LocalStorageKey);
+    let storedValue = localStorage.getItem(PopupSizeService.LocalStorageKey);
+
+    // Migrate old width option keys that no longer exist
+    const migratedValue = PopupSizeService.migrateOldWidthOption(storedValue);
+    if (migratedValue !== storedValue && migratedValue != null) {
+      storedValue = migratedValue;
+      localStorage.setItem(PopupSizeService.LocalStorageKey, storedValue);
+    }
+
     void this.setStyle(storedValue as any);
+  }
+
+  /**
+   * Maps old popup width option keys to their new equivalents.
+   * Old "wide" (480px) is now "default", and old "extraWide" (600px) is now "wide".
+   */
+  private static migrateOldWidthOption(value: string | null): string | null {
+    if (value === "extraWide") {
+      return "wide";
+    }
+    return value;
   }
 }

--- a/libs/state/src/state-migrations/migrate.ts
+++ b/libs/state/src/state-migrations/migrate.ts
@@ -72,12 +72,13 @@ import { RemoveAccountDeprovisioningBannerDismissed } from "./migrations/72-remo
 import { AddMasterPasswordUnlockData } from "./migrations/73-add-master-password-unlock-data";
 import { RemoveLegacyPin } from "./migrations/74-remove-legacy-pin";
 import { RemoveUserEncryptedPrivateKey } from "./migrations/75-remove-user-encrypted-private-key";
+import { MigratePopupWidthOptions } from "./migrations/76-migrate-popup-width-options";
 import { MoveStateVersionMigrator } from "./migrations/8-move-state-version";
 import { MoveBrowserSettingsToGlobal } from "./migrations/9-move-browser-settings-to-global";
 import { MinVersionMigrator } from "./migrations/min-version";
 
 export const MIN_VERSION = 3;
-export const CURRENT_VERSION = 75;
+export const CURRENT_VERSION = 76;
 export type MinVersion = typeof MIN_VERSION;
 
 export function createMigrationBuilder() {
@@ -154,7 +155,8 @@ export function createMigrationBuilder() {
     .with(RemoveAccountDeprovisioningBannerDismissed, 71, 72)
     .with(AddMasterPasswordUnlockData, 72, 73)
     .with(RemoveLegacyPin, 73, 74)
-    .with(RemoveUserEncryptedPrivateKey, 74, CURRENT_VERSION);
+    .with(RemoveUserEncryptedPrivateKey, 74, 75)
+    .with(MigratePopupWidthOptions, 75, CURRENT_VERSION);
 }
 
 export async function currentVersion(

--- a/libs/state/src/state-migrations/migrations/76-migrate-popup-width-options.spec.ts
+++ b/libs/state/src/state-migrations/migrations/76-migrate-popup-width-options.spec.ts
@@ -1,0 +1,62 @@
+import { runMigrator } from "../migration-helper.spec";
+import { IRREVERSIBLE } from "../migrator";
+
+import { MigratePopupWidthOptions } from "./76-migrate-popup-width-options";
+
+describe("MigratePopupWidthOptions", () => {
+  const sut = new MigratePopupWidthOptions(75, 76);
+
+  describe("migrate", () => {
+    it("migrates 'wide' to 'default'", async () => {
+      const output = await runMigrator(sut, {
+        "global_popupStyle_popup-width": "wide",
+      });
+
+      expect(output).toEqual({
+        "global_popupStyle_popup-width": "default",
+      });
+    });
+
+    it("migrates 'extraWide' to 'wide'", async () => {
+      const output = await runMigrator(sut, {
+        "global_popupStyle_popup-width": "extraWide",
+      });
+
+      expect(output).toEqual({
+        "global_popupStyle_popup-width": "wide",
+      });
+    });
+
+    it("does not modify 'default'", async () => {
+      const output = await runMigrator(sut, {
+        "global_popupStyle_popup-width": "default",
+      });
+
+      expect(output).toEqual({
+        "global_popupStyle_popup-width": "default",
+      });
+    });
+
+    it("does not modify 'narrow'", async () => {
+      const output = await runMigrator(sut, {
+        "global_popupStyle_popup-width": "narrow",
+      });
+
+      expect(output).toEqual({
+        "global_popupStyle_popup-width": "narrow",
+      });
+    });
+
+    it("does nothing when no width is set", async () => {
+      const output = await runMigrator(sut, {});
+
+      expect(output).toEqual({});
+    });
+  });
+
+  describe("rollback", () => {
+    it("is irreversible", async () => {
+      await expect(runMigrator(sut, {}, "rollback")).rejects.toThrow(IRREVERSIBLE);
+    });
+  });
+});

--- a/libs/state/src/state-migrations/migrations/76-migrate-popup-width-options.spec.ts
+++ b/libs/state/src/state-migrations/migrations/76-migrate-popup-width-options.spec.ts
@@ -17,9 +17,9 @@ describe("MigratePopupWidthOptions", () => {
       });
     });
 
-    it("migrates 'extraWide' to 'wide'", async () => {
+    it("migrates 'extra-wide' to 'wide'", async () => {
       const output = await runMigrator(sut, {
-        "global_popupStyle_popup-width": "extraWide",
+        "global_popupStyle_popup-width": "extra-wide",
       });
 
       expect(output).toEqual({

--- a/libs/state/src/state-migrations/migrations/76-migrate-popup-width-options.ts
+++ b/libs/state/src/state-migrations/migrations/76-migrate-popup-width-options.ts
@@ -1,0 +1,27 @@
+import { KeyDefinitionLike, MigrationHelper } from "../migration-helper";
+import { IRREVERSIBLE, Migrator } from "../migrator";
+
+/** Maps old popup width option keys to their new equivalents. */
+const OLD_TO_NEW_WIDTH_MAP: Record<string, string> = {
+  wide: "default",
+  extraWide: "wide",
+};
+
+export const POPUP_WIDTH_KEY: KeyDefinitionLike = {
+  key: "popup-width",
+  stateDefinition: { name: "popupStyle" },
+};
+
+export class MigratePopupWidthOptions extends Migrator<75, 76> {
+  async migrate(helper: MigrationHelper): Promise<void> {
+    const currentWidth = await helper.getFromGlobal<string>(POPUP_WIDTH_KEY);
+
+    if (currentWidth != null && currentWidth in OLD_TO_NEW_WIDTH_MAP) {
+      await helper.setToGlobal(POPUP_WIDTH_KEY, OLD_TO_NEW_WIDTH_MAP[currentWidth]);
+    }
+  }
+
+  async rollback(helper: MigrationHelper): Promise<void> {
+    throw IRREVERSIBLE;
+  }
+}

--- a/libs/state/src/state-migrations/migrations/76-migrate-popup-width-options.ts
+++ b/libs/state/src/state-migrations/migrations/76-migrate-popup-width-options.ts
@@ -4,7 +4,7 @@ import { IRREVERSIBLE, Migrator } from "../migrator";
 /** Maps old popup width option keys to their new equivalents. */
 const OLD_TO_NEW_WIDTH_MAP: Record<string, string> = {
   wide: "default",
-  extraWide: "wide",
+  "extra-wide": "wide",
 };
 
 export const POPUP_WIDTH_KEY: KeyDefinitionLike = {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-32085

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

This PR includes a script for migrating from the old to new popup widths that was previously missed in the [original PR](https://github.com/bitwarden/clients/pull/18376) where the `extra-wide` option was removed and the `narrow` option was added.

The migration will do the following:

`wide` -> `default`
`extra-wide` -> `wide`


## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->


https://github.com/user-attachments/assets/019c5b4b-e3dc-4b3d-8345-46625971c212

