### PR TITLE
[BEEEP] Desktop Native: napi type macro helpers

### DIFF
--- a/apps/desktop/desktop_native/napi/index.d.ts
+++ b/apps/desktop/desktop_native/napi/index.d.ts
@@ -297,24 +297,20 @@ export declare namespace sshagent_v2 {
     unlock(): void
   }
   export type SSHAgentState = SshAgentState
-  /** SSH public key data */
   export interface PublicKey {
     alg: string
     blob: Array<number>
   }
-  /** SSH sign request fields. */
   export interface SignRequest {
     publicKey: PublicKey
     processName?: string
     isForwarding: boolean
     namespace?: SignRequestNamespace
   }
-  /** Data for a sign request, including vault cipher context. */
   export interface SignRequestData {
     signRequest: SignRequest
     cipherId?: string
   }
-  /** Namespace of a sign request. */
   export const enum SignRequestNamespace {
     Git = 'Git',
     File = 'File',

--- a/apps/desktop/desktop_native/napi/src/chromium_importer.rs
+++ b/apps/desktop/desktop_native/napi/src/chromium_importer.rs
@@ -2,12 +2,9 @@
 pub mod chromium_importer {
     use std::collections::HashMap;
 
-    use chromium_importer::{
-        chromium::{
-            DefaultInstalledBrowserRetriever, LoginImportResult as _LoginImportResult,
-            ProfileInfo as _ProfileInfo,
-        },
-        metadata::NativeImporterMetadata as _NativeImporterMetadata,
+    use chromium_importer::chromium::{
+        DefaultInstalledBrowserRetriever, LoginImportResult as _LoginImportResult,
+        ProfileInfo as _ProfileInfo,
     };
 
     #[napi(object)]
@@ -37,11 +34,14 @@ pub mod chromium_importer {
         pub failure: Option<LoginImportFailure>,
     }
 
-    #[napi(object)]
-    pub struct NativeImporterMetadata {
-        pub id: String,
-        pub loaders: Vec<String>,
-        pub instructions: String,
+    napi_mirrors! {
+        "chromium_importer" => {
+            object NativeImporterMetadata from chromium_importer::metadata::NativeImporterMetadata {
+                id: String,
+                loaders: Vec<String>,
+                instructions: String,
+            }
+        }
     }
 
     impl From<_LoginImportResult> for LoginImportResult {
@@ -73,16 +73,6 @@ pub mod chromium_importer {
             ProfileInfo {
                 id: p.folder,
                 name: p.name,
-            }
-        }
-    }
-
-    impl From<_NativeImporterMetadata> for NativeImporterMetadata {
-        fn from(m: _NativeImporterMetadata) -> Self {
-            NativeImporterMetadata {
-                id: m.id,
-                loaders: m.loaders,
-                instructions: m.instructions,
             }
         }
     }

--- a/apps/desktop/desktop_native/napi/src/ipc.rs
+++ b/apps/desktop/desktop_native/napi/src/ipc.rs
@@ -3,24 +3,18 @@ pub mod ipc {
     use desktop_core::ipc::server::{Message, MessageType};
     use napi::threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode};
 
-    #[napi(object)]
-    pub struct IpcMessage {
-        pub client_id: u32,
-        pub kind: IpcMessageType,
-        pub message: Option<String>,
-    }
-
-    impl From<Message> for IpcMessage {
-        fn from(message: Message) -> Self {
-            IpcMessage {
-                client_id: message.client_id,
-                kind: message.kind.into(),
-                message: message.message,
+    napi_mirrors! {
+        "ipc" => {
+            object IpcMessage from Message {
+                client_id: u32,
+                kind: IpcMessageType,
+                message: Option<String>,
             }
         }
     }
 
     #[napi]
+    #[derive(Debug, Clone, PartialEq)]
     pub enum IpcMessageType {
         Connected,
         Disconnected,

--- a/apps/desktop/desktop_native/napi/src/lib.rs
+++ b/apps/desktop/desktop_native/napi/src/lib.rs
@@ -1,6 +1,9 @@
 #[macro_use]
 extern crate napi_derive;
 
+#[macro_use]
+mod macros;
+
 mod passkey_authenticator_internal;
 mod registry;
 

--- a/apps/desktop/desktop_native/napi/src/macros.rs
+++ b/apps/desktop/desktop_native/napi/src/macros.rs
@@ -1,0 +1,373 @@
+/// Declares multiple napi mirror types under a single namespace string.
+///
+/// Use this inside a `#[napi] pub mod` to generate mirrored napi types without repeating
+/// the namespace on every declaration. The namespace is written once and applied to every
+/// entry in the block.
+///
+/// Each entry is prefixed with either `string_enum` or `object` to select the kind of
+/// mirror. Entries may carry outer attributes (`#[doc = "..."]` etc.).
+///
+/// Because `#[napi] pub mod` proc macros run before inner `macro_rules!` expand, generated
+/// items would not be seen by the module proc macro and would end up at the TypeScript root.
+/// This macro works around that by attaching `namespace = "..."` directly to each generated
+/// `#[napi(...)]` attribute.
+///
+/// # Example
+///
+/// ```rust
+/// // Inside a `#[napi] pub mod my_module`:
+/// napi_mirrors! {
+///     "my_module" => {
+///         string_enum Direction from some_crate::Direction {
+///             North, South,
+///         }
+///         object Point from some_crate::Point {
+///             x: f64,
+///             y: f64,
+///             label: Option<String>,
+///         }
+///     }
+/// }
+/// ```
+macro_rules! napi_mirrors {
+    // Base case — nothing left to process.
+    ($ns:literal => {}) => {};
+
+    // string_enum entry.
+    (
+        $ns:literal => {
+            $(#[$meta:meta])*
+            string_enum $Name:ident from $Source:path {
+                $( $Variant:ident ),* $(,)?
+            }
+            $($rest:tt)*
+        }
+    ) => {
+        napi_mirror_string_enum! {
+            $(#[$meta])*
+            enum $Name from $Source {
+                $($Variant,)*
+            } in $ns
+        }
+        napi_mirrors!($ns => { $($rest)* });
+    };
+
+    // object entry.
+    (
+        $ns:literal => {
+            $(#[$meta:meta])*
+            object $Name:ident from $Source:path {
+                $($fields:tt)*
+            }
+            $($rest:tt)*
+        }
+    ) => {
+        napi_mirror_object! {
+            $(#[$meta])*
+            struct $Name from $Source {
+                $($fields)*
+            } in $ns
+        }
+        napi_mirrors!($ns => { $($rest)* });
+    };
+}
+
+/// Generates an `#[napi(string_enum)]` enum and a `From<Source>` impl that maps
+/// each variant by name.
+///
+/// Called internally by [`napi_mirrors!`] — prefer that macro at call sites.
+///
+/// The `} in "namespace"` suffix (after the closing brace) is required. It supplies the
+/// namespace explicitly via `#[napi(string_enum, namespace = "...")]`, working around the
+/// limitation that `#[napi] pub mod` proc macros cannot see through `macro_rules!`
+/// expansions.
+macro_rules! napi_mirror_string_enum {
+    // The `in "..."` goes after the closing brace because `path` cannot be followed by `in`.
+    (
+        $(#[$meta:meta])*
+        enum $Name:ident from $Source:path {
+            $( $Variant:ident ),* $(,)?
+        } in $ns:literal
+    ) => {
+        #[napi(string_enum, namespace = $ns)]
+        #[derive(Debug, Clone, PartialEq)]
+        $(#[$meta])*
+        pub enum $Name {
+            $($Variant,)*
+        }
+
+        impl From<$Source> for $Name {
+            fn from(val: $Source) -> Self {
+                use $Source as __Src;
+                match val {
+                    $(__Src::$Variant => Self::$Variant,)*
+                }
+            }
+        }
+    };
+}
+
+/// Generates an `#[napi(object)]` struct and a `From<Source>` impl via push-down
+/// accumulation, so that the `#[napi(object)]` proc macro sees a complete struct
+/// definition rather than an inner macro call.
+///
+/// Called internally by [`napi_mirrors!`] — prefer that macro at call sites.
+///
+/// - Plain fields use `.into()`, relying on Rust's identity blanket impl for same-type fields and
+///   any explicit `From` impls for mirrored types.
+/// - `Option<T>` fields automatically use `.map(Into::into)`, since std has no blanket `impl<T, U:
+///   From<T>> From<Option<T>> for Option<U>`.
+/// - `Vec<T>` fields automatically use `.into_iter().map(Into::into).collect()`, for the same
+///   reason.
+///
+/// The `} in "namespace"` suffix (after the closing brace) is required. It supplies the
+/// namespace explicitly via `#[napi(object, namespace = "...")]`, working around the
+/// limitation that `#[napi] pub mod` proc macros cannot see through `macro_rules!`
+/// expansions.
+macro_rules! napi_mirror_object {
+    // Entry point — the `in "..."` goes after the closing brace because `path` cannot be
+    // followed by `in`.
+    (
+        $(#[$meta:meta])*
+        struct $Name:ident from $Source:path {
+            $($fields:tt)*
+        } in $ns:literal
+    ) => {
+        napi_mirror_object!(
+            @collect
+            attrs  = [$(#[$meta])*],
+            name   = [$Name],
+            source = [$Source],
+            param  = [val],
+            ns     = [$ns],
+            sf     = [],
+            ff     = [],
+            rest   = [$($fields)*]
+        );
+    };
+
+    // Base case: all fields consumed — emit the struct and From impl.
+    (
+        @collect
+        attrs  = [$($attr:tt)*],
+        name   = [$Name:ident],
+        source = [$($src:tt)*],
+        param  = [$param:ident],
+        ns     = [$ns:literal],
+        sf     = [$($sf:tt)*],
+        ff     = [$($ff:tt)*],
+        rest   = []
+    ) => {
+        #[napi(object, namespace = $ns)]
+        #[derive(Debug, Clone, PartialEq)]
+        $($attr)*
+        pub struct $Name {
+            $($sf)*
+        }
+
+        impl From<$($src)*> for $Name {
+            fn from($param: $($src)*) -> Self {
+                Self { $($ff)* }
+            }
+        }
+    };
+
+    // Option<T> field — converted via `.map(Into::into)`, which handles the case where
+    // std has no blanket `impl<T, U: From<T>> From<Option<T>> for Option<U>`.
+    // This arm must appear before the plain-field arm since `$ty:ty` would also match `Option<T>`.
+    (
+        @collect
+        attrs  = [$($attr:tt)*],
+        name   = [$Name:ident],
+        source = [$($src:tt)*],
+        param  = [$param:ident],
+        ns     = [$ns:literal],
+        sf     = [$($sf:tt)*],
+        ff     = [$($ff:tt)*],
+        rest   = [$field:ident : Option<$inner:ty>, $($rest:tt)*]
+    ) => {
+        napi_mirror_object!(
+            @collect
+            attrs  = [$($attr)*],
+            name   = [$Name],
+            source = [$($src)*],
+            param  = [$param],
+            ns     = [$ns],
+            sf     = [$($sf)* pub $field: Option<$inner>,],
+            ff     = [$($ff)* $field: $param.$field.map(Into::into),],
+            rest   = [$($rest)*]
+        );
+    };
+
+    // Vec<T> field — converted via `.into_iter().map(Into::into).collect()`, which handles the
+    // case where std has no blanket `impl<T, U: From<T>> From<Vec<T>> for Vec<U>`.
+    // This arm must appear before the plain-field arm since `$ty:ty` would also match `Vec<T>`.
+    (
+        @collect
+        attrs  = [$($attr:tt)*],
+        name   = [$Name:ident],
+        source = [$($src:tt)*],
+        param  = [$param:ident],
+        ns     = [$ns:literal],
+        sf     = [$($sf:tt)*],
+        ff     = [$($ff:tt)*],
+        rest   = [$field:ident : Vec<$inner:ty>, $($rest:tt)*]
+    ) => {
+        napi_mirror_object!(
+            @collect
+            attrs  = [$($attr)*],
+            name   = [$Name],
+            source = [$($src)*],
+            param  = [$param],
+            ns     = [$ns],
+            sf     = [$($sf)* pub $field: Vec<$inner>,],
+            ff     = [$($ff)* $field: $param.$field.into_iter().map(Into::into).collect(),],
+            rest   = [$($rest)*]
+        );
+    };
+
+    // Plain field — converted via `.into()` (trailing comma required).
+    (
+        @collect
+        attrs  = [$($attr:tt)*],
+        name   = [$Name:ident],
+        source = [$($src:tt)*],
+        param  = [$param:ident],
+        ns     = [$ns:literal],
+        sf     = [$($sf:tt)*],
+        ff     = [$($ff:tt)*],
+        rest   = [$field:ident : $ty:ty, $($rest:tt)*]
+    ) => {
+        napi_mirror_object!(
+            @collect
+            attrs  = [$($attr)*],
+            name   = [$Name],
+            source = [$($src)*],
+            param  = [$param],
+            ns     = [$ns],
+            sf     = [$($sf)* pub $field: $ty,],
+            ff     = [$($ff)* $field: $param.$field.into(),],
+            rest   = [$($rest)*]
+        );
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    // ── source types ─────────────────────────────────────────────────────────
+    // Simulate types defined in a foreign crate that we want to mirror via napi.
+
+    enum SourceStatus {
+        Active,
+        Inactive,
+    }
+
+    struct SourceRecord {
+        id: String,
+        active: bool,
+        status: Option<SourceStatus>,
+        note: Option<String>,
+        tags: Vec<SourceStatus>,
+        counts: Vec<u32>,
+    }
+
+    // ── mirror types ─────────────────────────────────────────────────────────
+
+    napi_mirrors! {
+        "test" => {
+            string_enum Status from SourceStatus {
+                Active, Inactive,
+            }
+            object Record from SourceRecord {
+                id: String,
+                active: bool,
+                status: Option<Status>,
+                note: Option<String>,
+                tags: Vec<Status>,
+                counts: Vec<u32>,
+            }
+        }
+    }
+
+    // ── tests ─────────────────────────────────────────────────────────────────
+
+    fn make_source(
+        status: Option<SourceStatus>,
+        note: Option<&str>,
+        tags: Vec<SourceStatus>,
+    ) -> SourceRecord {
+        SourceRecord {
+            id: String::new(),
+            active: false,
+            status,
+            note: note.map(str::to_string),
+            tags,
+            counts: vec![],
+        }
+    }
+
+    #[test]
+    fn string_enum_converts_each_variant() {
+        assert_eq!(Status::from(SourceStatus::Active), Status::Active);
+        assert_eq!(Status::from(SourceStatus::Inactive), Status::Inactive);
+    }
+
+    #[test]
+    fn object_plain_fields_are_transferred() {
+        let source = SourceRecord {
+            id: "abc".to_string(),
+            active: true,
+            status: None,
+            note: None,
+            tags: vec![],
+            counts: vec![],
+        };
+        let record = Record::from(source);
+        assert_eq!(record.id, "abc");
+        assert!(record.active);
+    }
+
+    #[test]
+    fn object_option_mirrored_type_some_converts() {
+        let record = Record::from(make_source(Some(SourceStatus::Active), None, vec![]));
+        assert_eq!(record.status, Some(Status::Active));
+    }
+
+    #[test]
+    fn object_option_none_passes_through() {
+        let record = Record::from(make_source(None, None, vec![]));
+        assert!(record.status.is_none());
+        assert!(record.note.is_none());
+    }
+
+    #[test]
+    fn object_option_same_type_some_passes_through() {
+        let record = Record::from(make_source(None, Some("a note"), vec![]));
+        assert_eq!(record.note, Some("a note".to_string()));
+    }
+
+    #[test]
+    fn object_vec_mirrored_type_converts() {
+        let source = make_source(
+            None,
+            None,
+            vec![SourceStatus::Active, SourceStatus::Inactive],
+        );
+        let record = Record::from(source);
+        assert_eq!(record.tags, vec![Status::Active, Status::Inactive]);
+    }
+
+    #[test]
+    fn object_vec_same_type_passes_through() {
+        let mut source = make_source(None, None, vec![]);
+        source.counts = vec![1, 2, 3];
+        let record = Record::from(source);
+        assert_eq!(record.counts, vec![1u32, 2, 3]);
+    }
+
+    #[test]
+    fn object_vec_empty_passes_through() {
+        let record = Record::from(make_source(None, None, vec![]));
+        assert!(record.tags.is_empty());
+    }
+}

--- a/apps/desktop/desktop_native/napi/src/sshagent_v2.rs
+++ b/apps/desktop/desktop_native/napi/src/sshagent_v2.rs
@@ -11,8 +11,8 @@ pub mod sshagent_v2 {
     use async_trait::async_trait;
     use napi::threadsafe_function::ThreadsafeFunction;
     use ssh_agent::{
-        ApprovalRequester, BitwardenSSHAgent, InMemoryEncryptedKeyStore,
-        SignApprovalRequest as SSHSignApprovalRequest,
+        ApprovalRequester, BitwardenSSHAgent, InMemoryEncryptedKeyStore, PublicKey as SSHPublicKey,
+        SignApprovalRequest as SSHSignApprovalRequest, SignRequest as SSHSignRequest,
         SignRequestNamespace as SSHSignRequestNamespace,
     };
     use tracing::{debug, error};
@@ -26,70 +26,24 @@ pub mod sshagent_v2 {
         pub cipher_id: String,
     }
 
-    /// SSH public key data
-    #[napi(object)]
-    #[derive(Debug, Clone)]
-    pub struct PublicKey {
-        pub alg: String,
-        pub blob: Vec<u8>,
-    }
-
-    /// Namespace of a sign request.
-    #[napi(string_enum)]
-    #[derive(Debug)]
-    pub enum SignRequestNamespace {
-        Git,
-        File,
-        Unsupported,
-    }
-
-    impl From<SSHSignRequestNamespace> for SignRequestNamespace {
-        fn from(ns: SSHSignRequestNamespace) -> Self {
-            match ns {
-                SSHSignRequestNamespace::Git => Self::Git,
-                SSHSignRequestNamespace::File => Self::File,
-                SSHSignRequestNamespace::Unsupported => Self::Unsupported,
+    napi_mirrors! {
+        "sshagent_v2" => {
+            string_enum SignRequestNamespace from SSHSignRequestNamespace {
+                Git, File, Unsupported,
             }
-        }
-    }
-
-    /// SSH sign request fields.
-    #[napi(object)]
-    #[derive(Debug)]
-    pub struct SignRequest {
-        pub public_key: PublicKey,
-        pub process_name: Option<String>,
-        pub is_forwarding: bool,
-        pub namespace: Option<SignRequestNamespace>,
-    }
-
-    impl From<ssh_agent::SignRequest> for SignRequest {
-        fn from(r: ssh_agent::SignRequest) -> Self {
-            Self {
-                public_key: PublicKey {
-                    alg: r.public_key.alg,
-                    blob: r.public_key.blob,
-                },
-                process_name: r.process_name,
-                is_forwarding: r.is_forwarding,
-                namespace: r.namespace.map(Into::into),
+            object PublicKey from SSHPublicKey {
+                alg: String,
+                blob: Vec<u8>,
             }
-        }
-    }
-
-    /// Data for a sign request, including vault cipher context.
-    #[napi(object)]
-    #[derive(Debug)]
-    pub struct SignRequestData {
-        pub sign_request: SignRequest,
-        pub cipher_id: Option<String>,
-    }
-
-    impl From<SSHSignApprovalRequest> for SignRequestData {
-        fn from(request: SSHSignApprovalRequest) -> Self {
-            Self {
-                sign_request: request.sign_request.into(),
-                cipher_id: request.cipher_id,
+            object SignRequest from SSHSignRequest {
+                public_key: PublicKey,
+                process_name: Option<String>,
+                is_forwarding: bool,
+                namespace: Option<SignRequestNamespace>,
+            }
+            object SignRequestData from SSHSignApprovalRequest {
+                sign_request: SignRequest,
+                cipher_id: Option<String>,
             }
         }
     }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-33264

## 📔 Objective

note: macros can be controversial and there are tradeoffs to adding them. I believe I've made these documented and tested and that the usage is fairly straight forward. It was a BEEEP project I wanted to explore and I'm open to criticism of it.

Existing pattern: define a type in the napi module for a given desktop native crate’s correlate, and the type is a 1-1 mapping of the crate’s type, but with the napi macros on it.

The “problem”: either a boilerplate From is needs to be implemented, or just copying the struct fields in-line.

We want to preserve the boundary on napi, i.e., not creating a dependency on the source crates to napi.

In order to achieve this, I propose the introduction of a couple macros that are highly test-able and documented, and still make the callsite readable, and clear what is going on.

### Details:

Each type that needs to cross the Electron boundary is re-declared in the napi crate using napi_mirrors!, which generates both the #[napi(object/string_enum)]-annotated type and a From<SourceType> impl. The source crates (ssh_agent, chromium_importer, etc.) are untouched.

The macros eliminate the boilerplate of re-declaring types and writing From impls by hand, while keeping the code readable, editor-navigable, and free of cross-crate coupling.
  
Alternatives considered:
- Alternative 1: annotate types in the source crates directly.
    - Would require the source crates to depend on napi-rs. Those crates are pure Rust business logic and shouldn't know anything about Electron or the binding layer. Adding napi attributes there would permanently couple core logic to an Electron-specific dependency, breaking any future non-Electron consumer of those crates.

- Alternative 2: build.rs code generation.
    - A build script could parse source type definitions and emit the napi wrapper code. This works but adds meaningful build-time complexity: you need to parse Rust source (fragile against formatting/attribute changes), the generated output is invisible to the editor and harder to debug, and errors surface at build time with poor diagnostics. The macro approach keeps everything visible in normal source files with standard compiler errors.



## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
