### PR TITLE
[PM-33285] Enhance privacy in password leak detection with response padding

### DIFF
--- a/libs/common/src/services/audit.service.spec.ts
+++ b/libs/common/src/services/audit.service.spec.ts
@@ -72,6 +72,16 @@ describe("AuditService", () => {
     expect(mockApi.nativeFetch).toHaveBeenCalledTimes(4);
   });
 
+  it("should include Add-Padding header when checking leaked passwords", async () => {
+    const result = await auditService.passwordLeaked("password");
+
+    expect(result).toBe(4);
+    expect(mockApi.nativeFetch).toHaveBeenCalledTimes(1);
+    const request = mockApi.nativeFetch.mock.calls[0][0] as any;
+    expect(request.url).toBe("https://api.pwnedpasswords.com/range/AABBC");
+    expect(request.headers).toEqual(expect.objectContaining({ "Add-Padding": "true" }));
+  });
+
   it("should return empty array for breachedAccounts when no breaches found", async () => {
     // Server returns 200 with empty array (correct REST semantics)
     mockHibpApi.getHibpBreach.mockResolvedValueOnce([]);

--- a/libs/common/src/services/audit.service.ts
+++ b/libs/common/src/services/audit.service.ts
@@ -59,7 +59,10 @@ export class AuditService implements AuditServiceAbstraction {
     const hashStart = hash.substr(0, 5);
     const hashEnding = hash.substr(5);
 
-    const response = await this.apiService.nativeFetch(new Request(PwnedPasswordsApi + hashStart));
+    const request = new Request(PwnedPasswordsApi + hashStart, {
+      headers: { "Add-Padding": "true" },
+    });
+    const response = await this.apiService.nativeFetch(request);
     const leakedHashes = await response.text();
     const match = leakedHashes.split(/\r?\n/).find((v) => {
       return v.split(":")[0] === hashEnding;


### PR DESCRIPTION
Use [padding](https://haveibeenpwned.com/API/v3#PwnedPasswordsPadding) in the API request to obfuscate size of the response payload.

## 🎟️ Tracking

N/A, I took up the initiative on my own since it was a pretty simple change.

## 📔 Objective

It enhances the user's privacy.
