### PR TITLE
[CL] refactor(kitchen-sink): restructure stories with router-based layout

### DIFF
--- a/libs/components/src/stories/kitchen-sink/components/dialog-virtual-scroll-block.component.ts
+++ b/libs/components/src/stories/kitchen-sink/components/dialog-virtual-scroll-block.component.ts
@@ -11,7 +11,6 @@ import { TableDataSource, TableModule } from "../../../table";
 // eslint-disable-next-line @angular-eslint/prefer-on-push-component-change-detection
 @Component({
   selector: "dialog-virtual-scroll-block",
-  standalone: true,
   imports: [
     DialogModule,
     IconButtonModule,
@@ -20,7 +19,7 @@ import { TableDataSource, TableModule } from "../../../table";
     ScrollingModule,
     ScrollLayoutDirective,
   ],
-  template: /*html*/ `<bit-section>
+  template: `<bit-section>
     <cdk-virtual-scroll-viewport bitScrollLayout itemSize="49.5">
       <bit-table [dataSource]="dataSource">
         <ng-container header>

--- a/libs/components/src/stories/kitchen-sink/components/kitchen-sink-app.component.ts
+++ b/libs/components/src/stories/kitchen-sink/components/kitchen-sink-app.component.ts
@@ -1,0 +1,27 @@
+import { Component } from "@angular/core";
+
+import { PasswordManagerLogo } from "@bitwarden/assets/svg";
+
+import { KitchenSinkSharedModule } from "../kitchen-sink-shared.module";
+
+// FIXME(https://bitwarden.atlassian.net/browse/CL-764): Migrate to OnPush
+// eslint-disable-next-line @angular-eslint/prefer-on-push-component-change-detection
+@Component({
+  selector: "bit-kitchen-sink-app",
+  imports: [KitchenSinkSharedModule],
+  template: `
+    <bit-layout>
+      <bit-side-nav>
+        <bit-nav-logo [openIcon]="logo" route="." [label]="'Kitchen Sink'"></bit-nav-logo>
+        <bit-nav-item text="Home" route="bitwarden" icon="bwi-vault"></bit-nav-item>
+        <bit-nav-group text="Examples" icon="bwi-cog" [open]="true">
+          <bit-nav-item text="Virtual Scroll" route="virtual-scroll" icon="bwi-list"></bit-nav-item>
+        </bit-nav-group>
+      </bit-side-nav>
+      <router-outlet></router-outlet>
+    </bit-layout>
+  `,
+})
+export class KitchenSinkAppComponent {
+  protected readonly logo = PasswordManagerLogo;
+}

--- a/libs/components/src/stories/kitchen-sink/components/kitchen-sink-empty.component.ts
+++ b/libs/components/src/stories/kitchen-sink/components/kitchen-sink-empty.component.ts
@@ -1,0 +1,24 @@
+import { Component } from "@angular/core";
+
+import { KitchenSinkSharedModule } from "../kitchen-sink-shared.module";
+
+// FIXME(https://bitwarden.atlassian.net/browse/CL-764): Migrate to OnPush
+// eslint-disable-next-line @angular-eslint/prefer-on-push-component-change-detection
+@Component({
+  selector: "bit-kitchen-sink-empty",
+  imports: [KitchenSinkSharedModule],
+  template: `
+    <div class="tw-flex tw-items-center tw-justify-center tw-min-h-96">
+      <bit-no-items>
+        <ng-container slot="icon">
+          <bit-icon name="bwi-filter" aria-hidden="true"></bit-icon>
+        </ng-container>
+        <ng-container slot="title">No items to display</ng-container>
+        <ng-container slot="description">
+          This is an example of an empty state using the bit-no-items component.
+        </ng-container>
+      </bit-no-items>
+    </div>
+  `,
+})
+export class KitchenSinkEmptyComponent {}

--- a/libs/components/src/stories/kitchen-sink/components/kitchen-sink-form.component.ts
+++ b/libs/components/src/stories/kitchen-sink/components/kitchen-sink-form.component.ts
@@ -78,7 +78,7 @@ import { KitchenSinkSharedModule } from "../kitchen-sink-shared.module";
             type="button"
             slot="end"
           >
-            <i class="bwi bwi-question-circle"></i>
+            <bit-icon name="bwi-question-circle" />
           </button>
         </bit-label>
         <input bitInput type="password" formControlName="password" />

--- a/libs/components/src/stories/kitchen-sink/components/kitchen-sink-main.component.ts
+++ b/libs/components/src/stories/kitchen-sink/components/kitchen-sink-main.component.ts
@@ -1,12 +1,8 @@
 import { DialogRef } from "@angular/cdk/dialog";
-import { Component, signal } from "@angular/core";
+import { Component } from "@angular/core";
 
 import { DialogService } from "../../../dialog";
 import { KitchenSinkSharedModule } from "../kitchen-sink-shared.module";
-
-import { KitchenSinkFormComponent } from "./kitchen-sink-form.component";
-import { KitchenSinkTableComponent } from "./kitchen-sink-table.component";
-import { KitchenSinkToggleListComponent } from "./kitchen-sink-toggle-list.component";
 
 // FIXME(https://bitwarden.atlassian.net/browse/CL-764): Migrate to OnPush
 // eslint-disable-next-line @angular-eslint/prefer-on-push-component-change-detection
@@ -83,7 +79,7 @@ import { KitchenSinkToggleListComponent } from "./kitchen-sink-toggle-list.compo
     </bit-dialog>
   `,
 })
-class KitchenSinkDialogComponent {
+export class KitchenSinkDialogComponent {
   constructor(public dialogRef: DialogRef) {}
 }
 
@@ -91,85 +87,35 @@ class KitchenSinkDialogComponent {
 // eslint-disable-next-line @angular-eslint/prefer-on-push-component-change-detection
 @Component({
   selector: "bit-tab-main",
-  imports: [
-    KitchenSinkSharedModule,
-    KitchenSinkTableComponent,
-    KitchenSinkToggleListComponent,
-    KitchenSinkFormComponent,
-  ],
+  imports: [KitchenSinkSharedModule],
   template: `
-    <bit-banner bannerType="info"> Kitchen Sink test zone </bit-banner>
-
-    <p class="tw-mt-4">
-      <bit-breadcrumbs>
+    <bit-header title="Kitchen Sink" icon="bwi-collection">
+      <bit-breadcrumbs slot="breadcrumbs">
         @for (item of navItems; track item) {
           <bit-breadcrumb [icon]="item.icon" [route]="[item.route]">
             {{ item.name }}
           </bit-breadcrumb>
         }
       </bit-breadcrumbs>
-    </p>
-
-    <div class="tw-my-6">
-      <h1 bitTypography="h1">Bitwarden Kitchen Sink<bit-avatar text="Bit Warden"></bit-avatar></h1>
-      <a bitLink href="#">This is a link</a>
-      <p bitTypography="body1" class="tw-inline">
-        &nbsp;and this is a link button popover trigger:&nbsp;
-      </p>
+      <bit-search />
       <button
         bitLink
         [bitPopoverTriggerFor]="myPopover"
         #triggerRef="popoverTrigger"
         type="button"
-        slot="end"
         aria-label="Popover trigger link"
+        slot="secondary"
       >
-        <i class="bwi bwi-question-circle"></i>
+        <bit-icon name="bwi-question-circle" />
       </button>
-    </div>
+      <bit-avatar text="BW"></bit-avatar>
+      <bit-tab-nav-bar slot="tabs">
+        <bit-tab-link [route]="['bitwarden']">Vault</bit-tab-link>
+        <bit-tab-link [route]="['empty']">Empty</bit-tab-link>
+      </bit-tab-nav-bar>
+    </bit-header>
 
-    <bit-callout type="info" title="About the Kitchen Sink">
-      <p bitTypography="body1">
-        The purpose of this story is to compose together all of our components. When snapshot tests
-        run, we'll be able to spot-check visual changes in a more app-like environment than just the
-        isolated stories. The stories for the Kitchen Sink exist to be tested by the Chromatic UI
-        tests.
-      </p>
-    </bit-callout>
-
-    <bit-tab-group label="Main content tabs" class="tw-text-main">
-      <bit-tab label="Evaluation">
-        <bit-section>
-          <h2 bitTypography="h2" class="tw-mb-6">About</h2>
-          <bit-kitchen-sink-table></bit-kitchen-sink-table>
-
-          <button type="button" bitButton (click)="openDialog()">Open Dialog</button>
-          <button type="button" bitButton (click)="openDrawer()">Open Drawer</button>
-        </bit-section>
-        <bit-section>
-          <h2 bitTypography="h2" class="tw-mb-6">Companies using Bitwarden</h2>
-          <bit-kitchen-sink-toggle-list></bit-kitchen-sink-toggle-list>
-        </bit-section>
-        <bit-section>
-          <h2 bitTypography="h2" class="tw-mb-6">Survey</h2>
-          <bit-kitchen-sink-form></bit-kitchen-sink-form>
-        </bit-section>
-      </bit-tab>
-
-      <bit-tab label="Empty tab" data-testid="empty-tab">
-        <bit-section>
-          <h2 bitTypography="h2" class="tw-mb-6">Tab Number 2</h2>
-          <bit-no-items class="tw-text-main">
-            <ng-container slot="title">This tab is empty</ng-container>
-            <ng-container slot="description">
-              <p bitTypography="body2">Try searching for what you are looking for:</p>
-              <bit-search></bit-search>
-              <p bitTypography="helper">Note that the search bar is not functional</p>
-            </ng-container>
-          </bit-no-items>
-        </bit-section>
-      </bit-tab>
-    </bit-tab-group>
+    <router-outlet></router-outlet>
 
     <bit-popover title="Educational Popover" #myPopover>
       <div>You can learn more things at:</div>
@@ -182,8 +128,6 @@ class KitchenSinkDialogComponent {
 })
 export class KitchenSinkMainComponent {
   constructor(public dialogService: DialogService) {}
-
-  protected readonly drawerOpen = signal(false);
 
   openDialog() {
     this.dialogService.open(KitchenSinkDialogComponent);

--- a/libs/components/src/stories/kitchen-sink/components/kitchen-sink-vault.component.ts
+++ b/libs/components/src/stories/kitchen-sink/components/kitchen-sink-vault.component.ts
@@ -1,0 +1,49 @@
+import { Component } from "@angular/core";
+
+import { DialogService } from "../../../dialog";
+import { KitchenSinkSharedModule } from "../kitchen-sink-shared.module";
+
+import { KitchenSinkFormComponent } from "./kitchen-sink-form.component";
+import { KitchenSinkDialogComponent } from "./kitchen-sink-main.component";
+import { KitchenSinkTableComponent } from "./kitchen-sink-table.component";
+import { KitchenSinkToggleListComponent } from "./kitchen-sink-toggle-list.component";
+
+// FIXME(https://bitwarden.atlassian.net/browse/CL-764): Migrate to OnPush
+// eslint-disable-next-line @angular-eslint/prefer-on-push-component-change-detection
+@Component({
+  selector: "bit-kitchen-sink-vault",
+  imports: [
+    KitchenSinkSharedModule,
+    KitchenSinkTableComponent,
+    KitchenSinkToggleListComponent,
+    KitchenSinkFormComponent,
+  ],
+  template: `
+    <bit-section>
+      <h2 bitTypography="h2" class="tw-mb-6">Table Example</h2>
+      <bit-kitchen-sink-table></bit-kitchen-sink-table>
+
+      <button type="button" bitButton (click)="openDialog()">Open Dialog</button>
+      <button type="button" bitButton (click)="openDrawer()">Open Drawer</button>
+    </bit-section>
+    <bit-section>
+      <h2 bitTypography="h2" class="tw-mb-6">Companies using Bitwarden</h2>
+      <bit-kitchen-sink-toggle-list></bit-kitchen-sink-toggle-list>
+    </bit-section>
+    <bit-section>
+      <h2 bitTypography="h2" class="tw-mb-6">Survey Form</h2>
+      <bit-kitchen-sink-form></bit-kitchen-sink-form>
+    </bit-section>
+  `,
+})
+export class KitchenSinkVaultComponent {
+  constructor(public dialogService: DialogService) {}
+
+  openDialog() {
+    this.dialogService.open(KitchenSinkDialogComponent);
+  }
+
+  openDrawer() {
+    this.dialogService.openDrawer(KitchenSinkDialogComponent);
+  }
+}

--- a/libs/components/src/stories/kitchen-sink/kitchen-sink-shared.module.ts
+++ b/libs/components/src/stories/kitchen-sink/kitchen-sink-shared.module.ts
@@ -15,6 +15,8 @@ import { ColorPasswordModule } from "../../color-password";
 import { DialogModule } from "../../dialog";
 import { FormControlModule } from "../../form-control";
 import { FormFieldModule } from "../../form-field";
+import { HeaderComponent } from "../../header";
+import { IconComponent } from "../../icon";
 import { IconButtonModule } from "../../icon-button";
 import { InputModule } from "../../input";
 import { LayoutComponent } from "../../layout";
@@ -28,7 +30,6 @@ import { RadioButtonModule } from "../../radio-button";
 import { SearchModule } from "../../search";
 import { SectionComponent } from "../../section";
 import { SelectModule } from "../../select";
-import { SharedModule } from "../../shared";
 import { SvgModule } from "../../svg";
 import { TableModule } from "../../table";
 import { TabsModule } from "../../tabs";
@@ -51,7 +52,9 @@ import { TypographyModule } from "../../typography";
     FormControlModule,
     FormFieldModule,
     FormsModule,
+    HeaderComponent,
     IconButtonModule,
+    IconComponent,
     SvgModule,
     InputModule,
     LayoutComponent,
@@ -67,7 +70,6 @@ import { TypographyModule } from "../../typography";
     SearchModule,
     SectionComponent,
     SelectModule,
-    SharedModule,
     TableModule,
     TabsModule,
     ToggleGroupModule,
@@ -88,7 +90,9 @@ import { TypographyModule } from "../../typography";
     FormControlModule,
     FormFieldModule,
     FormsModule,
+    HeaderComponent,
     IconButtonModule,
+    IconComponent,
     SvgModule,
     InputModule,
     LayoutComponent,
@@ -104,7 +108,6 @@ import { TypographyModule } from "../../typography";
     SearchModule,
     SectionComponent,
     SelectModule,
-    SharedModule,
     TableModule,
     TabsModule,
     ToggleGroupModule,

--- a/libs/components/src/stories/kitchen-sink/kitchen-sink.stories.ts
+++ b/libs/components/src/stories/kitchen-sink/kitchen-sink.stories.ts
@@ -4,35 +4,39 @@ import { RouterModule } from "@angular/router";
 import { Meta, StoryObj, applicationConfig, moduleMetadata } from "@storybook/angular";
 import { userEvent, getAllByRole, getByRole, fireEvent, getAllByLabelText } from "storybook/test";
 
-import { PasswordManagerLogo } from "@bitwarden/assets/svg";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { GlobalStateProvider } from "@bitwarden/state";
 
-import { LayoutComponent } from "../../layout";
 import { I18nMockService } from "../../utils/i18n-mock.service";
 import { StorybookGlobalStateProvider } from "../../utils/state-mock";
 import { positionFixedWrapperDecorator } from "../storybook-decorators";
 
 import { DialogVirtualScrollBlockComponent } from "./components/dialog-virtual-scroll-block.component";
+import { KitchenSinkAppComponent } from "./components/kitchen-sink-app.component";
+import { KitchenSinkEmptyComponent } from "./components/kitchen-sink-empty.component";
 import { KitchenSinkFormComponent } from "./components/kitchen-sink-form.component";
 import { KitchenSinkMainComponent } from "./components/kitchen-sink-main.component";
 import { KitchenSinkTableComponent } from "./components/kitchen-sink-table.component";
 import { KitchenSinkToggleListComponent } from "./components/kitchen-sink-toggle-list.component";
+import { KitchenSinkVaultComponent } from "./components/kitchen-sink-vault.component";
 import { KitchenSinkSharedModule } from "./kitchen-sink-shared.module";
 
 export default {
   title: "Documentation / Kitchen Sink",
-  component: LayoutComponent,
+  component: KitchenSinkAppComponent,
   decorators: [
     positionFixedWrapperDecorator(),
     moduleMetadata({
       imports: [
         KitchenSinkSharedModule,
+        KitchenSinkAppComponent,
+        KitchenSinkEmptyComponent,
         KitchenSinkFormComponent,
         KitchenSinkMainComponent,
         KitchenSinkTableComponent,
         KitchenSinkToggleListComponent,
+        KitchenSinkVaultComponent,
       ],
     }),
     applicationConfig({
@@ -41,9 +45,16 @@ export default {
         importProvidersFrom(
           RouterModule.forRoot(
             [
-              { path: "", redirectTo: "bitwarden", pathMatch: "full" },
-              { path: "bitwarden", component: KitchenSinkMainComponent },
-              { path: "virtual-scroll", component: DialogVirtualScrollBlockComponent },
+              {
+                path: "",
+                component: KitchenSinkMainComponent,
+                children: [
+                  { path: "", redirectTo: "bitwarden", pathMatch: "full" },
+                  { path: "bitwarden", component: KitchenSinkVaultComponent },
+                  { path: "empty", component: KitchenSinkEmptyComponent },
+                  { path: "virtual-scroll", component: DialogVirtualScrollBlockComponent },
+                ],
+              },
             ],
             { useHash: true },
           ),
@@ -54,6 +65,7 @@ export default {
             return new I18nMockService({
               close: "Close",
               search: "Search",
+              selectPlaceholder: "-- Select --",
               skipToContent: "Skip to content",
               submenu: "submenu",
               toggleCollapse: "toggle collapse",
@@ -81,7 +93,7 @@ export default {
   ],
 } as Meta;
 
-type Story = StoryObj<LayoutComponent>;
+type Story = StoryObj<KitchenSinkAppComponent>;
 
 type KitchenSinkRoute = "/bitwarden" | "/virtual-scroll";
 
@@ -100,34 +112,6 @@ async function openSideNav(canvas: HTMLElement) {
 }
 
 export const Default: Story = {
-  render: (args) => {
-    return {
-      props: {
-        ...args,
-        logo: PasswordManagerLogo,
-      },
-      template: /* HTML */ `<bit-layout>
-        <bit-side-nav>
-          <bit-nav-logo [openIcon]="logo" route="." [label]="Logo"></bit-nav-logo>
-          <bit-nav-group text="Password Managers" icon="bwi-collection-shared" [open]="true">
-            <bit-nav-item text="Child A" route="a" icon="bwi-filter"></bit-nav-item>
-            <bit-nav-item text="Child B" route="b"></bit-nav-item>
-            <bit-nav-item
-              text="Virtual Scroll"
-              route="virtual-scroll"
-              icon="bwi-filter"
-            ></bit-nav-item>
-          </bit-nav-group>
-          <bit-nav-group text="Favorites" icon="bwi-filter">
-            <bit-nav-item text="Favorites Child A" icon="bwi-filter"></bit-nav-item>
-            <bit-nav-item text="Favorites Child B"></bit-nav-item>
-            <bit-nav-item text="Favorites Child C" icon="bwi-filter"></bit-nav-item>
-          </bit-nav-group>
-        </bit-side-nav>
-        <router-outlet></router-outlet>
-      </bit-layout>`,
-    };
-  },
   parameters: {
     chromatic: {
       viewports: [640, 1280],
@@ -136,12 +120,10 @@ export const Default: Story = {
 };
 
 export const MenuOpen: Story = {
-  render: Default.render,
   play: async (context) => {
     const canvas = context.canvasElement;
     await navigateTo("/bitwarden");
     const table = getByRole(canvas, "table");
-
     const menuButton = getAllByRole(table, "button")[0];
     await userEvent.click(menuButton);
   },
@@ -151,7 +133,6 @@ export const MenuOpen: Story = {
 };
 
 export const DialogOpen: Story = {
-  render: Default.render,
   play: async (context) => {
     const canvas = context.canvasElement;
     await navigateTo("/bitwarden");
@@ -165,7 +146,6 @@ export const DialogOpen: Story = {
 };
 
 export const DrawerOpen: Story = {
-  render: Default.render,
   play: async (context) => {
     const canvas = context.canvasElement;
     await navigateTo("/bitwarden");
@@ -179,7 +159,6 @@ export const DrawerOpen: Story = {
 };
 
 export const PopoverOpen: Story = {
-  render: Default.render,
   play: async (context) => {
     const canvas = context.canvasElement;
     await navigateTo("/bitwarden");
@@ -192,7 +171,6 @@ export const PopoverOpen: Story = {
 };
 
 export const SimpleDialogOpen: Story = {
-  render: Default.render,
   play: async (context) => {
     const canvas = context.canvasElement;
     await navigateTo("/bitwarden");
@@ -206,17 +184,15 @@ export const SimpleDialogOpen: Story = {
 };
 
 export const EmptyTab: Story = {
-  render: Default.render,
   play: async (context) => {
     const canvas = context.canvasElement;
     await navigateTo("/bitwarden");
-    const emptyTab = getByRole(canvas, "tab", { name: "Empty tab" });
+    const emptyTab = getByRole(canvas, "link", { name: "Empty" });
     await userEvent.click(emptyTab);
   },
 };
 
 export const VirtualScrollBlockingDialog: Story = {
-  render: Default.render,
   play: async (context) => {
     const canvas = context.canvasElement;
     await navigateTo("/virtual-scroll");
@@ -258,7 +234,6 @@ export const DrawerOpenBeforeSideNavOpen: Story = {
 };
 
 export const ResponsiveSidebar: Story = {
-  render: Default.render,
   parameters: {
     chromatic: {
       viewports: [640, 1024, 1280, 1440],


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Replace with actual ticket -->

## 📔 Objective

Refactors the Kitchen Sink Storybook stories to use a router-based layout structure. This is a cherry-pick base extracted from [#18755](https://github.com/bitwarden/clients/pull/18755) with guided tour logic removed.

**Structural changes:**
- Extract `KitchenSinkAppComponent` as the layout/side-nav shell
- Extract `KitchenSinkVaultComponent` for the main vault content (table, dialogs, forms)
- Add `KitchenSinkEmptyComponent` for an empty state route
- Replace `bit-tab-group` with router-based child routes (`/bitwarden`, `/empty`)
- Replace inline layout template in stories with `KitchenSinkAppComponent`
- Add `HeaderComponent` and `IconComponent` to the shared module
- Remove `SharedModule` dependency

**Not included:**
- Guided tour logic (`KitchenSinkTourService`, spotlight popovers, `bitPopoverAnchorFor`) — those land in #18755