### PR TITLE
[CL-822] Disable popover Chromatic snapshots

### DIFF
--- a/libs/components/src/popover/popover.stories.ts
+++ b/libs/components/src/popover/popover.stories.ts
@@ -35,6 +35,10 @@ export default {
       type: "figma",
       url: "https://www.figma.com/design/Zt3YSeb6E6lebAffrNLa0h/Tailwind-Component-Library?node-id=16329-40852&t=b5tDKylm5sWm2yKo-4",
     },
+    // TODO: fix flakiness of popover positioning https://bitwarden.atlassian.net/browse/CL-822
+    chromatic: {
+      disableSnapshot: true,
+    },
   },
   argTypes: {
     position: {


### PR DESCRIPTION
## Summary

- Re-adds `chromatic: { disableSnapshot: true }` to the popover stories meta, which was accidentally removed in #18755
- Popover positioning remains flaky (tracked in [CL-822](https://bitwarden.atlassian.net/browse/CL-822))

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation update

## Checklist

- [x] I have added necessary documentation (if appropriate)
- [x] I have tested my changes (including the expected behavior)

[CL-822]: https://bitwarden.atlassian.net/browse/CL-822?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ