### PR TITLE
[PM-29314] Member access report - show all members, include empty collections they can access

### DIFF
--- a/bitwarden_license/bit-web/src/app/dirt/reports/member-access-report/services/member-access-report.service.spec.ts
+++ b/bitwarden_license/bit-web/src/app/dirt/reports/member-access-report/services/member-access-report.service.spec.ts
@@ -578,6 +578,121 @@ describe("MemberAccessReportService", () => {
 
       expect(result[0].name).toBe("user1@test.com");
     });
+
+    it("should include users assigned to empty collections (PM-29314)", async () => {
+      const userId1 = "user-1";
+      const collectionId1 = "collection-1";
+
+      // Collection has a direct user assignment but NO ciphers reference it
+      mockCollectionAdminService.collectionAdminViews$.mockReturnValue(
+        of([
+          createMockCollection(collectionId1, "Empty Collection", [
+            { id: userId1, readOnly: false, hidePasswords: false, manage: false },
+          ]),
+        ] as CollectionAdminView[]),
+      );
+
+      mockOrganizationUserApiService.getAllUsers.mockResolvedValue({
+        data: [
+          createMockOrganizationUser(userId1, "user1@test.com", "User One", {
+            twoFactorEnabled: true,
+            usesKeyConnector: false,
+            resetPasswordEnrolled: true,
+            groups: [],
+          }),
+        ],
+      } as ListResponse<OrganizationUserUserDetailsResponse>);
+
+      // No ciphers at all — the collection is truly empty
+      mockCipherService.getAllFromApiForOrganization.mockResolvedValue([] as CipherView[]);
+
+      const result =
+        await memberAccessReportService.generateMemberAccessReportViewV2(mockOrganizationId);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        email: "user1@test.com",
+        collectionsCount: 1, // Has access to 1 empty collection
+        groupsCount: 0,
+        itemsCount: 0, // Collection has no ciphers
+      });
+    });
+
+    it("should report groups assigned to empty collections (PM-29314)", async () => {
+      const userId1 = "user-1";
+      const groupId1 = "group-1";
+      const collectionId1 = "collection-1";
+
+      // Collection with group assignment, no direct user assignment
+      mockCollectionAdminService.collectionAdminViews$.mockReturnValue(
+        of([
+          createMockCollection(
+            collectionId1,
+            "Empty Collection",
+            [],
+            [{ id: groupId1, readOnly: false, hidePasswords: false, manage: false }],
+          ),
+        ] as CollectionAdminView[]),
+      );
+
+      mockOrganizationUserApiService.getAllUsers.mockResolvedValue({
+        data: [
+          createMockOrganizationUser(userId1, "user1@test.com", "User One", {
+            twoFactorEnabled: false,
+            usesKeyConnector: false,
+            resetPasswordEnrolled: false,
+            groups: [groupId1],
+          }),
+        ],
+      } as ListResponse<OrganizationUserUserDetailsResponse>);
+
+      mockCipherService.getAllFromApiForOrganization.mockResolvedValue([] as CipherView[]);
+
+      const result =
+        await memberAccessReportService.generateMemberAccessReportViewV2(mockOrganizationId);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        email: "user1@test.com",
+        collectionsCount: 1,
+        groupsCount: 1, // Group is reported
+        itemsCount: 0,
+      });
+    });
+
+    it("should include users with zero access in report with 0 counts", async () => {
+      const userId1 = "user-1";
+
+      // No collections at all
+      mockCollectionAdminService.collectionAdminViews$.mockReturnValue(
+        of([] as CollectionAdminView[]),
+      );
+
+      mockOrganizationUserApiService.getAllUsers.mockResolvedValue({
+        data: [
+          createMockOrganizationUser(userId1, "user1@test.com", "User One", {
+            twoFactorEnabled: true,
+            usesKeyConnector: false,
+            resetPasswordEnrolled: true,
+            groups: [],
+          }),
+        ],
+      } as ListResponse<OrganizationUserUserDetailsResponse>);
+
+      // No ciphers
+      mockCipherService.getAllFromApiForOrganization.mockResolvedValue([] as CipherView[]);
+
+      const result =
+        await memberAccessReportService.generateMemberAccessReportViewV2(mockOrganizationId);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        email: "user1@test.com",
+        collectionsCount: 0,
+        groupsCount: 0,
+        itemsCount: 0,
+      });
+    });
   });
 
   describe("generateUserReportExportItemsV2", () => {
@@ -837,6 +952,226 @@ describe("MemberAccessReportService", () => {
 
       expect(result).toHaveLength(1);
       expect(result[0].totalItems).toBe("1"); // Only counts valid cipher
+    });
+
+    it("should include users with no access in export with zero counts", async () => {
+      const userId1 = "user-1";
+      const userId2 = "user-2";
+      const collectionId1 = "collection-1";
+      const cipherId1 = "cipher-1";
+
+      mockCollectionAdminService.collectionAdminViews$.mockReturnValue(
+        of([
+          createMockCollection(collectionId1, "Test Collection", [
+            { id: userId1, readOnly: false, hidePasswords: false, manage: false },
+          ]),
+        ] as CollectionAdminView[]),
+      );
+
+      mockOrganizationUserApiService.getAllUsers.mockResolvedValue({
+        data: [
+          createMockOrganizationUser(userId1, "user1@test.com", "User One", {
+            twoFactorEnabled: true,
+            usesKeyConnector: false,
+            resetPasswordEnrolled: true,
+            groups: [],
+          }),
+          createMockOrganizationUser(userId2, "user2@test.com", "User Two", {
+            twoFactorEnabled: false,
+            usesKeyConnector: false,
+            resetPasswordEnrolled: false,
+            groups: [],
+          }),
+        ],
+      } as ListResponse<OrganizationUserUserDetailsResponse>);
+
+      mockCipherService.getAllFromApiForOrganization.mockResolvedValue([
+        createMockCipher(cipherId1, [collectionId1]),
+      ] as CipherView[]);
+
+      const result =
+        await memberAccessReportService.generateUserReportExportItemsV2(mockOrganizationId);
+
+      // Should have 2 items: user1 with access, user2 with no access
+      expect(result).toHaveLength(2);
+
+      const user1Item = result.find((item) => item.email === "user1@test.com");
+      const user2Item = result.find((item) => item.email === "user2@test.com");
+
+      expect(user1Item).toMatchObject({
+        email: "user1@test.com",
+        name: "User One",
+        totalItems: "1",
+        collection: "Test Collection",
+      });
+
+      expect(user2Item).toMatchObject({
+        email: "user2@test.com",
+        name: "User Two",
+        totalItems: "0",
+        group: "memberAccessReportNoGroup",
+        collection: "memberAccessReportNoCollection",
+      });
+    });
+
+    it("should handle users assigned to empty collections with zero ciphers", async () => {
+      const userId1 = "user-1";
+      const collectionId1 = "collection-1";
+
+      mockCollectionAdminService.collectionAdminViews$.mockReturnValue(
+        of([
+          createMockCollection(collectionId1, "Empty Collection", [
+            { id: userId1, readOnly: false, hidePasswords: false, manage: false },
+          ]),
+        ] as CollectionAdminView[]),
+      );
+
+      mockOrganizationUserApiService.getAllUsers.mockResolvedValue({
+        data: [
+          createMockOrganizationUser(userId1, "user1@test.com", "User One", {
+            twoFactorEnabled: true,
+            usesKeyConnector: false,
+            resetPasswordEnrolled: true,
+            groups: [],
+          }),
+        ],
+      } as ListResponse<OrganizationUserUserDetailsResponse>);
+
+      // No ciphers at all
+      mockCipherService.getAllFromApiForOrganization.mockResolvedValue([] as CipherView[]);
+
+      const result =
+        await memberAccessReportService.generateUserReportExportItemsV2(mockOrganizationId);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        email: "user1@test.com",
+        name: "User One",
+        collection: "Empty Collection",
+        totalItems: "0",
+        group: "memberAccessReportNoGroup",
+      });
+    });
+
+    it("should include group members assigned to empty collections", async () => {
+      const userId1 = "user-1";
+      const groupId1 = "group-1";
+      const collectionId1 = "collection-1";
+
+      mockCollectionAdminService.collectionAdminViews$.mockReturnValue(
+        of([
+          createMockCollection(
+            collectionId1,
+            "Empty Collection",
+            [],
+            [{ id: groupId1, readOnly: false, hidePasswords: false, manage: false }],
+          ),
+        ] as CollectionAdminView[]),
+      );
+
+      mockOrganizationUserApiService.getAllUsers.mockResolvedValue({
+        data: [
+          createMockOrganizationUser(userId1, "user1@test.com", "User One", {
+            twoFactorEnabled: false,
+            usesKeyConnector: false,
+            resetPasswordEnrolled: false,
+            groups: [groupId1],
+          }),
+        ],
+      } as ListResponse<OrganizationUserUserDetailsResponse>);
+
+      mockGroupApiService.getAll.mockResolvedValue([createMockGroup(groupId1, "Empty Group")]);
+
+      mockCipherService.getAllFromApiForOrganization.mockResolvedValue([] as CipherView[]);
+
+      const result =
+        await memberAccessReportService.generateUserReportExportItemsV2(mockOrganizationId);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        email: "user1@test.com",
+        name: "User One",
+        collection: "Empty Collection",
+        group: "Empty Group",
+        totalItems: "0",
+      });
+    });
+
+    it("should correctly set twoStepLogin and accountRecovery based on user metadata", async () => {
+      setupSingleUserWithDirectAccess("user-1", "collection-1", ["cipher-1"], {
+        email: "user1@test.com",
+        name: "User One",
+        twoFactorEnabled: false,
+        resetPasswordEnrolled: false,
+      });
+
+      const result =
+        await memberAccessReportService.generateUserReportExportItemsV2(mockOrganizationId);
+
+      expect(result[0]).toMatchObject({
+        twoStepLogin: "memberAccessReportTwoFactorEnabledFalse",
+        accountRecovery: "memberAccessReportAuthenticationEnabledFalse",
+      });
+    });
+
+    it("should include collectionPermission in export items", async () => {
+      setupSingleUserWithDirectAccess("user-1", "collection-1", ["cipher-1"], {
+        email: "user1@test.com",
+        name: "User One",
+      });
+
+      const result =
+        await memberAccessReportService.generateUserReportExportItemsV2(mockOrganizationId);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toHaveProperty("collectionPermission");
+      expect(result[0].collectionPermission).toBeTruthy();
+    });
+
+    it("should handle multiple users with overlapping collection access", async () => {
+      const userId1 = "user-1";
+      const userId2 = "user-2";
+      const collectionId1 = "collection-1";
+      const cipherId1 = "cipher-1";
+      const cipherId2 = "cipher-2";
+
+      mockCollectionAdminService.collectionAdminViews$.mockReturnValue(
+        of([
+          createMockCollection(collectionId1, "Shared Collection", [
+            { id: userId1, readOnly: false, hidePasswords: false, manage: false },
+            { id: userId2, readOnly: true, hidePasswords: true, manage: false },
+          ]),
+        ] as CollectionAdminView[]),
+      );
+
+      mockOrganizationUserApiService.getAllUsers.mockResolvedValue({
+        data: [
+          createMockOrganizationUser(userId1, "user1@test.com", "User One", {
+            twoFactorEnabled: true,
+            usesKeyConnector: false,
+            resetPasswordEnrolled: true,
+            groups: [],
+          }),
+          createMockOrganizationUser(userId2, "user2@test.com", "User Two", {
+            twoFactorEnabled: false,
+            usesKeyConnector: true,
+            resetPasswordEnrolled: false,
+            groups: [],
+          }),
+        ],
+      } as ListResponse<OrganizationUserUserDetailsResponse>);
+
+      mockCipherService.getAllFromApiForOrganization.mockResolvedValue([
+        createMockCipher(cipherId1, [collectionId1]),
+        createMockCipher(cipherId2, [collectionId1]),
+      ] as CipherView[]);
+
+      const result =
+        await memberAccessReportService.generateUserReportExportItemsV2(mockOrganizationId);
+
+      expect(result).toHaveLength(2);
+      expect(result.every((item) => item.collection === "Shared Collection")).toBe(true);
+      expect(result.every((item) => item.totalItems === "2")).toBe(true);
     });
   });
 });

--- a/bitwarden_license/bit-web/src/app/dirt/reports/member-access-report/services/member-access-report.service.ts
+++ b/bitwarden_license/bit-web/src/app/dirt/reports/member-access-report/services/member-access-report.service.ts
@@ -675,6 +675,25 @@ export class MemberAccessReportService {
       });
     }
 
+    // include users who have no access to any collections/ciphers/groups to ensure they appear in the report with 0 counts
+    const exportedUserIds = new Set(Array.from(accessMap.values()).map((a) => a.access.userId));
+    for (const [userId, metadata] of orgData.organizationUserDataMap.entries()) {
+      if (!exportedUserIds.has(userId)) {
+        exportItems.push({
+          email: metadata.email,
+          name: metadata.name,
+          twoStepLogin: metadata.twoFactorEnabled ? twoFactorEnabledTrue : twoFactorEnabledFalse,
+          accountRecovery: metadata.resetPasswordEnrolled
+            ? accountRecoveryEnabledTrue
+            : accountRecoveryEnabledFalse,
+          group: noGroup,
+          collection: noCollection,
+          collectionPermission: noCollectionPermission,
+          totalItems: "0",
+        });
+      }
+    }
+
     return exportItems;
   }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-29314

## 📔 Objective

Member access report should list all users (even those with zero collections, ciphers)
It should report all collections, even those with zero ciphers in them
it should report all groups that the user belongs to and which are assigned to a collection.

## 📸 Screenshots

<img width="1139" height="824" alt="image" src="https://github.com/user-attachments/assets/a8d96250-502f-415f-a4cb-e4f8673ecb23" />

