### PR TITLE
[CL-854] fix: add readonly to web-header component properties

### DIFF
--- a/apps/web/src/app/layouts/header/web-header.component.ts
+++ b/apps/web/src/app/layouts/header/web-header.component.ts
@@ -22,7 +22,7 @@ import { AccountMenuComponent } from "./account-menu.component";
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class WebHeaderComponent {
-  private route = inject(ActivatedRoute);
+  private readonly route = inject(ActivatedRoute);
 
   /**
    * Custom title that overrides the route data `titleId`
@@ -34,7 +34,7 @@ export class WebHeaderComponent {
    */
   readonly icon = input<string>();
 
-  protected routeData$: Observable<{ titleId: string }> = this.route.data.pipe(
+  protected readonly routeData$: Observable<{ titleId: string }> = this.route.data.pipe(
     map((params) => {
       return {
         titleId: params.titleId,


### PR DESCRIPTION
## Summary
- Add `readonly` modifier to `route` and `routeData$` properties in `WebHeaderComponent` to satisfy the `enforce-readonly-angular-properties` ESLint rule

## Test plan
- [ ] Verify lint passes: `npx nx lint web`