### PR TITLE
[CL-1074] Fix chromatic workflow when changedFiles is false

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -89,7 +89,6 @@ jobs:
         run: npm ci
 
       - name: Log in to Azure
-        if: steps.get-changed-files.outputs.storyFiles == 'true'
         uses: bitwarden/gh-actions/azure-login@main
         with:
           subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
@@ -97,7 +96,6 @@ jobs:
           client_id: ${{ secrets.AZURE_CLIENT_ID }}
   
       - name: Get Azure Key Vault secrets
-        if: steps.get-changed-files.outputs.storyFiles == 'true'
         id: get-kv-secrets
         uses: bitwarden/gh-actions/get-keyvault-secrets@main
         with:
@@ -105,7 +103,6 @@ jobs:
           secrets: "CHROMATIC-PROJECT-TOKEN,CHROMATIC-PROJECT-TOKEN-AUTOFILL"
   
       - name: Log out from Azure
-        if: steps.get-changed-files.outputs.storyFiles == 'true'
         uses: bitwarden/gh-actions/azure-logout@main
 
       # Manually build the Storybook to resolve a bug related to TurboSnap


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[CL-1074](https://bitwarden.atlassian.net/browse/CL-1074)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
I added some skips to the Azure Key Vault steps in the Chromatic workflow to try to avoid running unnecessary steps. They actually are necessary due to the way we skip the Chromatic publish action -- we still need to run the action in order to tell Chromatic to skip its spawned steps, so we do need the Azure Key Vault outputs to do that.


[CL-1074]: https://bitwarden.atlassian.net/browse/CL-1074?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ