### PR TITLE
[PM-33380] Fix Access Intelligence drawer not opening on row click

### DIFF
--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/all-applications/applications.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/all-applications/applications.component.spec.ts
@@ -263,6 +263,27 @@ describe("ApplicationsComponent", () => {
     });
   });
 
+  describe("showAppAtRiskMembers", () => {
+    it("should call dataService.setDrawerForAppAtRiskMembers with the application name", async () => {
+      mockDataService.setDrawerForAppAtRiskMembers.mockResolvedValue(undefined);
+
+      await component.showAppAtRiskMembers("GitHub");
+
+      expect(mockDataService.setDrawerForAppAtRiskMembers).toHaveBeenCalledWith("GitHub");
+    });
+
+    it("should preserve this context when invoked as a standalone function", async () => {
+      mockDataService.setDrawerForAppAtRiskMembers.mockResolvedValue(undefined);
+
+      // Simulate how the child component invokes this callback:
+      // it receives the function reference and calls it without this binding
+      const callbackRef = component.showAppAtRiskMembers;
+      await callbackRef("Slack");
+
+      expect(mockDataService.setDrawerForAppAtRiskMembers).toHaveBeenCalledWith("Slack");
+    });
+  });
+
   describe("checkbox selection", () => {
     const mockApplicationData: ApplicationTableDataSource[] = [
       {

--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/all-applications/applications.component.ts
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/all-applications/applications.component.ts
@@ -327,7 +327,7 @@ export class ApplicationsComponent implements OnInit {
     }
   }
 
-  showAppAtRiskMembers = async (applicationName: string) => {
+  readonly showAppAtRiskMembers = async (applicationName: string) => {
     await this.dataService.setDrawerForAppAtRiskMembers(applicationName);
   };
 

--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/all-applications/applications.component.ts
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/all-applications/applications.component.ts
@@ -327,9 +327,9 @@ export class ApplicationsComponent implements OnInit {
     }
   }
 
-  async showAppAtRiskMembers(applicationName: string) {
+  showAppAtRiskMembers = async (applicationName: string) => {
     await this.dataService.setDrawerForAppAtRiskMembers(applicationName);
-  }
+  };
 
   onCheckboxChange({ applicationName, checked }: { applicationName: string; checked: boolean }) {
     this.selectedUrls.update((selectedUrls) => {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-33380

## 📔 Objective

Fix the "All Applications" tab row click handler that silently crashes when opening the at-risk members drawer.

The `showAppAtRiskMembers` method was converted from an arrow function to a regular method in [#18990](https://github.com/bitwarden/clients/pull/18990) ([PM-32127](https://bitwarden.atlassian.net/browse/PM-32127)). Because this method is passed as a callback to a child component via Angular input binding, the regular method loses `this` context when invoked, causing a TypeError.

This PR converts it back to an arrow function property, matching the identical pattern in `critical-applications.component.ts`.


[PM-32127]: https://bitwarden.atlassian.net/browse/PM-32127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ