### PR TITLE
[PM-32684] Enforce transfer when policy enforces it

### DIFF
--- a/libs/vault/src/services/default-vault-items-transfer.service.spec.ts
+++ b/libs/vault/src/services/default-vault-items-transfer.service.spec.ts
@@ -141,10 +141,55 @@ describe("DefaultVaultItemsTransferService", () => {
       });
     });
 
-    describe("when policy exists", () => {
+    describe("when policy exists with enableIndividualItemsTransfer: false", () => {
+      beforeEach(() => {
+        setupMocksForMigrationScenario({
+          policies: [
+            {
+              organizationId: organizationId,
+              revisionDate: new Date("2024-01-01"),
+              data: { enableIndividualItemsTransfer: false },
+            } as Policy,
+          ],
+          organizations: [{ id: organizationId, name: "Test Org" } as Organization],
+          ciphers: [{ id: "cipher-1" } as CipherView],
+        });
+      });
+
+      it("returns requiresMigration: false", async () => {
+        const result = await firstValueFrom(service.userMigrationInfo$(userId));
+
+        expect(result).toEqual({ requiresMigration: false });
+      });
+    });
+
+    describe("when policy exists without enableIndividualItemsTransfer set", () => {
+      beforeEach(() => {
+        setupMocksForMigrationScenario({
+          policies: [
+            {
+              organizationId: organizationId,
+              revisionDate: new Date("2024-01-01"),
+              data: {},
+            } as Policy,
+          ],
+          organizations: [{ id: organizationId, name: "Test Org" } as Organization],
+          ciphers: [{ id: "cipher-1" } as CipherView],
+        });
+      });
+
+      it("returns requiresMigration: false", async () => {
+        const result = await firstValueFrom(service.userMigrationInfo$(userId));
+
+        expect(result).toEqual({ requiresMigration: false });
+      });
+    });
+
+    describe("when policy exists with enableIndividualItemsTransfer: true", () => {
       const policy = {
         organizationId: organizationId,
         revisionDate: new Date("2024-01-01"),
+        data: { enableIndividualItemsTransfer: true },
       } as Policy;
       const organization = {
         id: organizationId,
@@ -229,14 +274,25 @@ describe("DefaultVaultItemsTransferService", () => {
     });
 
     describe("when multiple policies exist", () => {
+      const oldestPolicy = {
+        organizationId: "oldest-org-id" as OrganizationId,
+        revisionDate: new Date("2023-09-13"),
+        data: { enableIndividualItemsTransfer: false },
+      } as Policy;
       const olderPolicy = {
         organizationId: "older-org-id" as OrganizationId,
         revisionDate: new Date("2024-01-01"),
+        data: { enableIndividualItemsTransfer: true },
       } as Policy;
       const newerPolicy = {
         organizationId: organizationId,
         revisionDate: new Date("2024-06-01"),
+        data: { enableIndividualItemsTransfer: true },
       } as Policy;
+      const oldestOrganization = {
+        id: "oldest-org-id" as OrganizationId,
+        name: "Oldest Org",
+      } as Organization;
       const olderOrganization = {
         id: "older-org-id" as OrganizationId,
         name: "Older Org",
@@ -248,13 +304,13 @@ describe("DefaultVaultItemsTransferService", () => {
 
       beforeEach(() => {
         setupMocksForMigrationScenario({
-          policies: [newerPolicy, olderPolicy],
-          organizations: [olderOrganization, newerOrganization],
+          policies: [newerPolicy, olderPolicy, oldestPolicy],
+          organizations: [oldestOrganization, olderOrganization, newerOrganization],
           ciphers: [{ id: "cipher-1" } as CipherView],
         });
       });
 
-      it("uses the oldest policy when selecting enforcing organization", async () => {
+      it("uses the oldest enforced policy when selecting enforcing organization", async () => {
         const result = await firstValueFrom(service.userMigrationInfo$(userId));
 
         expect(result).toEqual({
@@ -543,6 +599,7 @@ describe("DefaultVaultItemsTransferService", () => {
     const policy = {
       organizationId: organizationId,
       revisionDate: new Date("2024-01-01"),
+      data: { enableIndividualItemsTransfer: true },
     } as Policy;
     const organization = {
       id: organizationId,
@@ -858,6 +915,7 @@ describe("DefaultVaultItemsTransferService", () => {
     const policy = {
       organizationId: organizationId,
       revisionDate: new Date("2024-01-01"),
+      data: { enableIndividualItemsTransfer: true },
     } as Policy;
     const organization = {
       id: organizationId,
@@ -943,6 +1001,7 @@ describe("DefaultVaultItemsTransferService", () => {
     const policy = {
       organizationId: organizationId,
       revisionDate: new Date("2024-01-01"),
+      data: { enableIndividualItemsTransfer: true },
     } as Policy;
     const organization = {
       id: organizationId,

--- a/libs/vault/src/services/default-vault-items-transfer.service.ts
+++ b/libs/vault/src/services/default-vault-items-transfer.service.ts
@@ -72,7 +72,9 @@ export class DefaultVaultItemsTransferService implements VaultItemsTransferServi
     return this.policyService.policiesByType$(PolicyType.OrganizationDataOwnership, userId).pipe(
       map(
         (policies) =>
-          policies.sort((a, b) => a.revisionDate.getTime() - b.revisionDate.getTime())?.[0],
+          policies
+            .filter((p) => p.data?.enableIndividualItemsTransfer === true)
+            .sort((a, b) => a.revisionDate.getTime() - b.revisionDate.getTime())?.[0],
       ),
       switchMap((policy) => {
         if (policy == null) {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-32684](https://bitwarden.atlassian.net/browse/PM-32684)

## 📔 Objective

Verifies that `enableIndividualItemsTransfer` is true for organization ownership policy enforcement

## 📸 Screenshots

|Browser|Web|Desktop|
|-|-|-|
|<video src="https://github.com/user-attachments/assets/562f6be4-3672-43b8-a48f-72bd9eb3f81d" />|<video src="https://github.com/user-attachments/assets/a662e3b3-88ed-4ea2-a59b-1b7092a01bee" />|<video src="https://github.com/user-attachments/assets/ac4fe168-92ed-4cc1-b6a8-647f0806f990" />|


[PM-32684]: https://bitwarden.atlassian.net/browse/PM-32684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ