### PR TITLE
[CL-1096] Fix icon button width shrinking in flex containers

### DIFF
--- a/libs/components/src/icon-button/icon-button.component.ts
+++ b/libs/components/src/icon-button/icon-button.component.ts
@@ -78,7 +78,7 @@ export class BitIconButtonComponent implements ButtonLikeAbstraction, FocusableE
     const classes: string[] = [];
 
     // Icon-button specific layout styles
-    classes.push("tw-relative", "tw-inline-block", "tw-align-middle");
+    classes.push("tw-relative", "tw-inline-block", "tw-align-middle", "tw-shrink-0");
 
     // Add icon-button specific size styles (color styles are applied by BaseButtonDirective)
     classes.push(...getIconButtonSizeStyles(this.size()));


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Fix icon button width when used inside flex containers. Previously, the button would shrink below its defined size.

## Code changes
- Added `tw-shrink-0` (`flex-shrink: 0`) to the icon button's class list so the button maintains its fixed `tw-size-{n}` dimensions regardless of the flex container's available space.

## Before you submit
- [ ] Please check that the PR fulfills the requirements of the applicable checklist in CONTRIBUTING.md