### PR TITLE
add empty selector to hide span

### DIFF
--- a/libs/components/src/form-field/form-field.stories.ts
+++ b/libs/components/src/form-field/form-field.stories.ts
@@ -136,8 +136,7 @@ export const LabelWithIcon: Story = {
         <bit-form-field>
           <bit-label>
             Label
-            <a href="#" slot="end" bitLink aria-label="More info" title="More info">
-              <i class="bwi bwi-question-circle" aria-hidden="true"></i>
+            <a href="#" slot="end" bitLink startIcon="bwi-question-circle" aria-label="More info" title="More info">
             </a>
           </bit-label>
           <input bitInput formControlName="name" />
@@ -167,8 +166,7 @@ export const LongLabel: Story = {
         <bit-form-field>
           <bit-label>
             Hello I am a very long label with lots of very cool helpful information
-            <a href="#" slot="end" bitLink aria-label="More info" title="More info">
-              <i class="bwi bwi-question-circle" aria-hidden="true"></i>
+            <a href="#" slot="end" bitLink startIcon="bwi-question-circle" aria-label="More info" title="More info">
             </a>
           </bit-label>
           <input bitInput formControlName="name" />
@@ -306,8 +304,7 @@ export const ButtonInputGroup: Story = {
       <bit-form-field>
         <bit-label>
           Label
-          <a href="#" slot="end" bitLink [appA11yTitle]="'More info'">
-            <i class="bwi bwi-question-circle" aria-hidden="true"></i>
+          <a href="#" slot="end" startIcon="bwi-question-circle" bitLink [appA11yTitle]="'More info'">
           </a>
         </bit-label>
         <button type="button" bitPrefix bitIconButton="bwi-star" label="Favorite Label"></button>

--- a/libs/components/src/link/link.component.html
+++ b/libs/components/src/link/link.component.html
@@ -2,7 +2,7 @@
   @if (startIcon()) {
     <i [class]="['bwi', startIcon()]" aria-hidden="true"></i>
   }
-  <span>
+  <span class="empty:tw-hidden">
     <ng-content></ng-content>
   </span>
   @if (endIcon()) {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

Fixes issue where flex gap still appeared when content was empty

See where issue was first noticed [here](https://github.com/bitwarden/clients/pull/19486#discussion_r2927078470)

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
