### PR TITLE
[CL-1098] Fix danger icon button color in form field suffix

### DIFF
--- a/libs/components/src/form-field/form-field.stories.ts
+++ b/libs/components/src/form-field/form-field.stories.ts
@@ -321,6 +321,20 @@ export const ButtonInputGroup: Story = {
   args: {},
 };
 
+export const DangerButtonInputGroup: Story = {
+  render: (args) => ({
+    props: args,
+    template: /*html*/ `
+      <bit-form-field>
+        <bit-label>Label</bit-label>
+        <input bitInput placeholder="Placeholder" />
+        <button type="button" bitSuffix bitIconButton="bwi-minus-circle" buttonType="danger" label="Remove"></button>
+      </bit-form-field>
+    `,
+  }),
+  args: {},
+};
+
 export const DisabledButtonInputGroup: Story = {
   render: (args) => ({
     props: args,

--- a/libs/components/src/form-field/suffix.directive.ts
+++ b/libs/components/src/form-field/suffix.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, OnInit, Optional } from "@angular/core";
+import { Directive, inject, OnInit } from "@angular/core";
 
 import { BitIconButtonComponent } from "../icon-button/icon-button.component";
 
@@ -9,11 +9,9 @@ import { BitIconButtonComponent } from "../icon-button/icon-button.component";
   },
 })
 export class BitSuffixDirective implements OnInit {
-  readonly classList: string[];
+  private iconButtonComponent = inject(BitIconButtonComponent, { optional: true });
 
-  constructor(@Optional() private iconButtonComponent: BitIconButtonComponent) {
-    this.classList = this.iconButtonComponent ? [] : ["tw-text-muted"];
-  }
+  readonly classList = this.iconButtonComponent ? [] : ["tw-text-muted"];
 
   ngOnInit() {
     if (this.iconButtonComponent) {


### PR DESCRIPTION
## Summary

- `BitSuffixDirective` was unconditionally applying `tw-text-muted` to its host element
- When a `buttonType="danger"` icon button is used as a suffix, this overrode the button's own `tw-text-fg-contrast` color from `BaseButtonDirective`, resulting in a blue icon on a red background
- Fix: skip `tw-text-muted` when the suffix host is an icon button, since icon buttons manage their own text color via `buttonType`

## Test plan

- [ ] Verify danger icon button suffix in the Cipher Form story renders with correct icon color (white/contrast on red background)
- [ ] Verify non-icon-button suffixes (plain text) still render with muted text color
- [ ] Verify other `buttonType` variants (primary, secondary, etc.) as suffixes are unaffected