### PR TITLE
[CL-1102] Fix help icon size in bit-label

### DIFF
--- a/libs/components/src/form-control/label.component.ts
+++ b/libs/components/src/form-control/label.component.ts
@@ -29,8 +29,6 @@ export class BitLabelComponent {
     "tw-items-baseline",
     "tw-flex-row",
     "tw-min-w-0",
-    "[&_.bwi]:tw-text-xl",
-    "[&_.bwi]:tw-leading-none",
   ];
 
   @HostBinding("title") get title() {

--- a/libs/vault/src/cipher-form/components/login-details-section/login-details-section.component.html
+++ b/libs/vault/src/cipher-form/components/login-details-section/login-details-section.component.html
@@ -100,7 +100,7 @@
           [appA11yTitle]="'learnMoreAboutAuthenticators' | i18n"
           slot="end"
         >
-          <i class="bwi bwi-sm bwi-question-circle" aria-hidden="true"></i>
+          <i class="bwi bwi-question-circle" aria-hidden="true"></i>
         </button>
         <bit-popover #totpPopover [title]="'totpHelperTitle' | i18n">
           <p class="tw-mb-0">


### PR DESCRIPTION
## Summary
Removing usage of `bwi-sm` class from the lone instance of it's usage within a label. 

Will revisit proper icon size/placement in a future update/API change
