### PR TITLE
[PM-33454] - pass null in cipherService.clear to prevent flicker

### DIFF
--- a/libs/common/src/vault/services/cipher.service.ts
+++ b/libs/common/src/vault/services/cipher.service.ts
@@ -2343,7 +2343,9 @@ export class CipherService implements CipherServiceAbstraction {
   }
 
   private async clearEncryptedCiphersState(userId: UserId) {
-    await this.stateProvider.setUserState(ENCRYPTED_CIPHERS, {}, userId);
+    // Use null (not {}) so that cipherListViews$/cipherViews$ filter it out
+    // and don't emit an empty array during sync.
+    await this.stateProvider.setUserState(ENCRYPTED_CIPHERS, null, userId);
   }
 
   private async clearDecryptedCiphersState(userId: UserId) {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-33454

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Fix vault flickering on sync caused by an intermediate empty cipher emission.

During a full sync, `cipherService.clear()` is called before `syncCiphers()` to ensure ciphers removed server-side (e.g., after leaving an org) are properly cleaned up. However, `clearEncryptedCiphersState` was writing `{}` to the encrypted ciphers state, which both `cipherListViews$` and `cipherViews$` treat as valid data — `Object.values({})` produces `[]`, causing the vault to briefly render an empty item list before the new ciphers arrive.

### Root cause

In `CipherService.clearEncryptedCiphersState()`, the encrypted ciphers state was set to `{}` (empty object). The cipher observables filter on `cipherDataState != null`, but `{}` is not `null` — it passes through and emits an empty decrypted array.

### Fix

Changed `clearEncryptedCiphersState` to write `null` instead of `{}`. Both `cipherListViews$` and `cipherViews$` already filter out `null` state, so the intermediate emission is suppressed. The `clear()` call in `fullSync` is preserved so that ciphers no longer belonging to the user are properly removed.

This is safe because `replace()` (called by `syncCiphers`) already handles `null` current state via `?? {}`.

### Expected emission sequence after fix

| # | Event | Emitted | Visible |
|---|-------|---------|---------|
| 1 | Pre-sync | `[cipher1, cipher2, ...]` | Normal vault |
| 2 | `clear()` → sets encrypted state to `null` | *(suppressed by filter)* | No change |
| 3 | `clear()` → `clearCache()` | `null` via `perUserCache$` | Filtered out |
| 4 | `replace()` → writes new ciphers | `[newCipher1, newCipher2, ...]` | Updated vault |

## ⏰ Reminders before review

- Contributor guidelines followed
- All tests passing


## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/26729098-85e7-4dcb-b8d4-50435f4eba94

