### PR TITLE
[PM-33480] Fix false success toasts in integration save/delete

### DIFF
--- a/bitwarden_license/bit-web/src/app/dirt/organization-integrations/integration-card/integration-card.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/dirt/organization-integrations/integration-card/integration-card.component.spec.ts
@@ -514,5 +514,105 @@ describe("IntegrationCardComponent", () => {
         message: mockI18nService.t("mustBeOrgOwnerToPerformAction"),
       });
     });
+
+    it("should show error toast when save returns success: false", async () => {
+      (openHecConnectDialog as jest.Mock).mockReturnValue({
+        closed: of({
+          success: IntegrationDialogResultStatus.Edited,
+          url: "test-url",
+          bearerToken: "token",
+          index: "index",
+        }),
+      });
+
+      jest.spyOn(component, "isUpdateAvailable", "get").mockReturnValue(false);
+      mockIntegrationService.save.mockResolvedValue({
+        mustBeOwner: false,
+        success: false,
+        organizationIntegrationResult: undefined,
+      });
+
+      await component.setupConnection();
+
+      expect(toastService.showToast).toHaveBeenCalledWith({
+        variant: "error",
+        title: "",
+        message: mockI18nService.t("failedToSaveIntegration"),
+      });
+      expect(stateService.updateIntegrationSettings).not.toHaveBeenCalled();
+    });
+
+    it("should show success toast when save returns success: true", async () => {
+      (openHecConnectDialog as jest.Mock).mockReturnValue({
+        closed: of({
+          success: IntegrationDialogResultStatus.Edited,
+          url: "test-url",
+          bearerToken: "token",
+          index: "index",
+        }),
+      });
+
+      jest.spyOn(component, "isUpdateAvailable", "get").mockReturnValue(false);
+      mockIntegrationService.save.mockResolvedValue({
+        mustBeOwner: false,
+        success: true,
+        organizationIntegrationResult: {} as any,
+      });
+
+      await component.setupConnection();
+
+      expect(toastService.showToast).toHaveBeenCalledWith({
+        variant: "success",
+        title: "",
+        message: mockI18nService.t("integrationConnectedSuccessfully"),
+      });
+      expect(stateService.updateIntegrationSettings).toHaveBeenCalled();
+    });
+
+    it("should show error toast when delete returns success: false", async () => {
+      (openHecConnectDialog as jest.Mock).mockReturnValue({
+        closed: of({
+          success: IntegrationDialogResultStatus.Delete,
+        }),
+      });
+
+      mockIntegrationService.delete.mockResolvedValue({
+        mustBeOwner: false,
+        success: false,
+        organizationIntegrationResult: undefined,
+      });
+
+      await component.setupConnection();
+
+      expect(toastService.showToast).toHaveBeenCalledWith({
+        variant: "error",
+        title: "",
+        message: mockI18nService.t("failedToDeleteIntegration"),
+      });
+      expect(stateService.deleteIntegrationSettings).not.toHaveBeenCalled();
+    });
+
+    it("should show success toast and update state when delete returns success: true", async () => {
+      (openHecConnectDialog as jest.Mock).mockReturnValue({
+        closed: of({
+          success: IntegrationDialogResultStatus.Delete,
+        }),
+      });
+
+      mockIntegrationService.delete.mockResolvedValue({
+        mustBeOwner: false,
+        success: true,
+        organizationIntegrationResult: undefined,
+      });
+
+      await component.setupConnection();
+
+      expect(toastService.showToast).toHaveBeenCalledWith({
+        variant: "success",
+        title: "",
+        message: mockI18nService.t("success"),
+      });
+      expect(stateService.deleteIntegrationSettings).toHaveBeenCalled();
+    });
   });
 });

--- a/bitwarden_license/bit-web/src/app/dirt/organization-integrations/integration-card/integration-card.component.ts
+++ b/bitwarden_license/bit-web/src/app/dirt/organization-integrations/integration-card/integration-card.component.ts
@@ -250,22 +250,28 @@ export class IntegrationCardComponent implements AfterViewInit, OnDestroy {
       return;
     }
 
-    // update local state with the new integration settings
     if (response.success && response.organizationIntegrationResult) {
+      // update local state with the new integration settings
       this.state.updateIntegrationSettings(
         this.integrationSettings().name,
         response.organizationIntegrationResult,
       );
-    }
 
-    this.toastService.showToast({
-      variant: "success",
-      title: "",
-      message: this.i18nService.t(
-        "integrationConnectedSuccessfully",
-        this.integrationSettings().name,
-      ),
-    });
+      this.toastService.showToast({
+        variant: "success",
+        title: "",
+        message: this.i18nService.t(
+          "integrationConnectedSuccessfully",
+          this.integrationSettings().name,
+        ),
+      });
+    } else {
+      this.toastService.showToast({
+        variant: "error",
+        title: "",
+        message: this.i18nService.t("failedToSaveIntegration"),
+      });
+    }
   }
 
   /**

--- a/bitwarden_license/bit-web/src/app/dirt/organization-integrations/integration-card/integration-card.component.ts
+++ b/bitwarden_license/bit-web/src/app/dirt/organization-integrations/integration-card/integration-card.component.ts
@@ -299,13 +299,19 @@ export class IntegrationCardComponent implements AfterViewInit, OnDestroy {
 
     if (response.success) {
       this.state.deleteIntegrationSettings(this.integrationSettings().name);
-    }
 
-    this.toastService.showToast({
-      variant: "success",
-      title: "",
-      message: this.i18nService.t("success"),
-    });
+      this.toastService.showToast({
+        variant: "success",
+        title: "",
+        message: this.i18nService.t("success"),
+      });
+    } else {
+      this.toastService.showToast({
+        variant: "error",
+        title: "",
+        message: this.i18nService.t("failedToDeleteIntegration"),
+      });
+    }
   }
 
   /**


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-33480

## 📔 Objective

Defensive code correctness fix for toast notification logic in the organization integrations card component.

The `saveIntegration()` and `deleteIntegration()` methods in `IntegrationCardComponent` display success toasts unconditionally after the `mustBeOwner` check, regardless of the `response.success` value. While the `success: false` path is **currently unreachable** (the service builders always return objects or throw, and thrown errors are already handled correctly by `handleIntegrationDialogResult`), the toast placement is structurally incorrect and would cause false success messages if a future change makes that path reachable.

### Changes:
- Moved success toasts inside the `if (response.success)` blocks
- Added error toasts (using existing i18n keys) in `else` branches for the failure path
- Added 4 new unit tests covering both success and failure paths for save and delete

## ⚠️ Reproducibility Note

**This bug is not currently reproducible through the UI.** The `success: false` return path requires `mapResponsesToOrganizationIntegration()` to return `null`, which requires `OrgIntegrationBuilder.buildConfiguration()` or `buildTemplate()` to return a falsy value. Both builders always return an object or throw — they never return null. Verification should rely on the unit tests, which directly mock `{ success: false }` and confirm correct toast behavior.

## 📸 Screenshots

Not applicable — no UI changes. Toast notification behavior change only.

## 🧪 QA Note

**Feature flags required:** `EventManagementForDataDogAndCrowdStrike` and/or `EventManagementForHuntress` must be enabled for SIEM cards to show in-app connect dialogs (Admin Console → Integrations → Event management). Enterprise/Teams plan org required.

Since the error path is unreachable, QA should verify the **happy path still works**:
1. Connect an integration (CrowdStrike/Datadog) with dummy values → success toast appears
2. Disconnect the integration → success toast appears
3. Both operations should behave identically to `main`