### PR TITLE
[PM-32542] - show warning before closing desktop while editing a form

### DIFF
--- a/apps/desktop/src/app/app.component.ts
+++ b/apps/desktop/src/app/app.component.ts
@@ -203,6 +203,12 @@ export class AppComponent implements OnInit, OnDestroy {
       window.onmousedown = () => this.recordActivity();
       window.onscroll = () => this.recordActivity();
       window.onkeypress = () => this.recordActivity();
+
+      window.onbeforeunload = (e: BeforeUnloadEvent) => {
+        if (document.querySelectorAll("vault-cipher-form .ng-dirty").length > 0) {
+          e.returnValue = false;
+        }
+      };
     });
 
     /// ############ DEPRECATED ############

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -201,6 +201,7 @@ export class Main {
       this.logService,
       this.storageService,
       this.desktopSettingsService,
+      this.i18nService,
       (arg) => this.processDeepLink(arg),
       (win) => this.trayMain.setupWindowListeners(win),
     );

--- a/apps/desktop/src/main/window.main.ts
+++ b/apps/desktop/src/main/window.main.ts
@@ -4,9 +4,10 @@ import { once } from "node:events";
 import * as path from "path";
 import * as url from "url";
 
-import { app, BrowserWindow, ipcMain, nativeTheme, screen, session } from "electron";
+import { app, BrowserWindow, dialog, ipcMain, nativeTheme, screen, session } from "electron";
 import { concatMap, firstValueFrom, pairwise } from "rxjs";
 
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { AbstractStorageService } from "@bitwarden/common/platform/abstractions/storage.service";
 import { ThemeTypes, Theme } from "@bitwarden/common/platform/enums";
@@ -47,6 +48,7 @@ export class WindowMain {
     private logService: LogService,
     private storageService: AbstractStorageService,
     private desktopSettingsService: DesktopSettingsService,
+    private i18nService: I18nService,
     private argvCallback: (argv: string[]) => void = null,
     private createWindowCallback: (win: BrowserWindow) => void,
   ) {}
@@ -376,6 +378,22 @@ export class WindowMain {
     this.win.on("close", async () => {
       this.isClosing = true;
       await this.updateWindowState(mainWindowSizeKey, this.win);
+    });
+
+    this.win.webContents.on("will-prevent-unload", (e) => {
+      const result = dialog.showMessageBoxSync(this.win, {
+        type: "warning",
+        title: this.i18nService.t("unsavedChangesTitle"),
+        message: this.i18nService.t("unsavedChangesTitle"),
+        detail: this.i18nService.t("unsavedChangesConfirmation"),
+        buttons: [this.i18nService.t("yes"), this.i18nService.t("no")],
+        cancelId: 1,
+        defaultId: 1,
+        noLink: true,
+      });
+      if (result === 0) {
+        e.preventDefault();
+      }
     });
 
     this.win.on("maximize", async () => {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-32542

## 📔 Objective

Prevent users from accidentally losing unsaved changes when closing the desktop app while editing a vault cipher form.

This adds a `beforeunload` guard in the renderer that detects dirty (unsaved) cipher form fields, and a corresponding `will-prevent-unload` handler in the main process that shows a native confirmation dialog asking the user whether they really want to close the window.

**Changes:**
- **app.component.ts** – Added a `window.onbeforeunload` handler that cancels the close event when the vault cipher form contains unsaved changes (`.ng-dirty`).
- **window.main.ts** – Added a `will-prevent-unload` listener on the main `BrowserWindow` that displays a native warning dialog via `dialog.showMessageBoxSync`, using localized strings. Injected `I18nService` for translations.
- **main.ts** – Passed `i18nService` to the `WindowMain` constructor.

<!-- Add a screenshot of the native confirmation dialog -->
## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/4ff37ad0-24ce-4e5e-8a88-8cb3162f9f82


