### PR TITLE
[PM-32505] - add validation service for handling server error messages

### DIFF
--- a/libs/common/src/platform/services/validation.service.spec.ts
+++ b/libs/common/src/platform/services/validation.service.spec.ts
@@ -1,0 +1,150 @@
+import { mock } from "jest-mock-extended";
+
+import { ErrorResponse } from "../../models/response/error.response";
+import { I18nService } from "../abstractions/i18n.service";
+import { PlatformUtilsService } from "../abstractions/platform-utils.service";
+
+import { ValidationService } from "./validation.service";
+
+describe("ValidationService", () => {
+  let service: ValidationService;
+  const i18nService = mock<I18nService>();
+  const platformUtilsService = mock<PlatformUtilsService>();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    i18nService.t.mockImplementation((key: string) => {
+      if (key === "unexpectedError") {
+        return "An unexpected error has occurred.";
+      }
+      if (key === "errorOccurred") {
+        return "An error has occurred.";
+      }
+      return key;
+    });
+    service = new ValidationService(i18nService, platformUtilsService);
+  });
+
+  describe("showError", () => {
+    it("shows string errors directly", () => {
+      const result = service.showError("Something went wrong");
+
+      expect(result).toEqual(["Something went wrong"]);
+      expect(platformUtilsService.showToast).toHaveBeenCalledWith(
+        "error",
+        "An error has occurred.",
+        "Something went wrong",
+      );
+    });
+
+    it("shows default error message for null data", () => {
+      const result = service.showError(null);
+
+      expect(result).toEqual(["An unexpected error has occurred."]);
+    });
+
+    it("shows default error message for undefined data", () => {
+      const result = service.showError(undefined);
+
+      expect(result).toEqual(["An unexpected error has occurred."]);
+    });
+
+    it("shows validation errors from ErrorResponse objects", () => {
+      const errorResponse = new ErrorResponse(
+        {
+          message: "The model state is invalid.",
+          validationErrors: {
+            Notes: [
+              "The field Notes exceeds the maximum encrypted value length of 10000 characters.",
+            ],
+          },
+        },
+        400,
+      );
+
+      const result = service.showError(errorResponse);
+
+      expect(result).toEqual([
+        "The field Notes exceeds the maximum encrypted value length of 10000 characters.",
+      ]);
+    });
+
+    it("shows ErrorResponse message when no validation errors exist", () => {
+      const errorResponse = new ErrorResponse(
+        {
+          message: "Something failed.",
+        },
+        500,
+      );
+
+      const result = service.showError(errorResponse);
+
+      expect(result).toEqual(["Something failed."]);
+    });
+
+    it("extracts validation errors from SDK-style error messages", () => {
+      const sdkError = new Error(
+        '[400 Bad Request] {"message":"The model state is invalid.","validationErrors":{"Notes":["The field Notes exceeds the maximum encrypted value length of 10000 characters."]},"exceptionMessage":null,"exceptionStackTrace":null,"innerExceptionMessage":null,"object":"error"}',
+      );
+
+      const result = service.showError(sdkError);
+
+      expect(result).toEqual([
+        "The field Notes exceeds the maximum encrypted value length of 10000 characters.",
+      ]);
+      expect(platformUtilsService.showToast).toHaveBeenCalledWith(
+        "error",
+        "An error has occurred.",
+        "The field Notes exceeds the maximum encrypted value length of 10000 characters.",
+      );
+    });
+
+    it("extracts API message from SDK-style errors without validation errors", () => {
+      const sdkError = new Error(
+        '[500 Internal Server Error] {"message":"An internal error occurred.","validationErrors":null,"object":"error"}',
+      );
+
+      const result = service.showError(sdkError);
+
+      expect(result).toEqual(["An internal error occurred."]);
+    });
+
+    it("extracts multiple validation errors from SDK-style error messages", () => {
+      const sdkError = new Error(
+        '[400 Bad Request] {"message":"The model state is invalid.","validationErrors":{"Name":["Name is required."],"Notes":["The field Notes exceeds the maximum length."]},"object":"error"}',
+      );
+
+      const result = service.showError(sdkError);
+
+      expect(result).toEqual(["Name is required.", "The field Notes exceeds the maximum length."]);
+      expect(platformUtilsService.showToast).toHaveBeenCalledWith(
+        "error",
+        "An error has occurred.",
+        ["Name is required.", "The field Notes exceeds the maximum length."],
+        { timeout: 10000 },
+      );
+    });
+
+    it("falls back to raw message for errors without embedded JSON", () => {
+      const error = new Error("Some plain error message");
+
+      const result = service.showError(error);
+
+      expect(result).toEqual(["Some plain error message"]);
+    });
+
+    it("falls back to raw message for errors with invalid JSON", () => {
+      const error = new Error("[400 Bad Request] {invalid json");
+
+      const result = service.showError(error);
+
+      expect(result).toEqual(["[400 Bad Request] {invalid json"]);
+    });
+
+    it("shows default error message for error objects without a message", () => {
+      const result = service.showError({});
+
+      expect(result).toEqual(["An unexpected error has occurred."]);
+    });
+  });
+});

--- a/libs/common/src/platform/services/validation.service.ts
+++ b/libs/common/src/platform/services/validation.service.ts
@@ -20,7 +20,12 @@ export class ValidationService implements ValidationServiceAbstraction {
     } else if (data.validationErrors != null) {
       errors = errors.concat((data as ErrorResponse).getAllMessages());
     } else {
-      errors.push(data.message ? data.message : defaultErrorMessage);
+      const extracted = this.extractErrorMessagesFromMessage(data.message);
+      if (extracted.length > 0) {
+        errors = errors.concat(extracted);
+      } else {
+        errors.push(data.message ? data.message : defaultErrorMessage);
+      }
     }
 
     if (errors.length === 1) {
@@ -32,5 +37,38 @@ export class ValidationService implements ValidationServiceAbstraction {
     }
 
     return errors;
+  }
+
+  /**
+   * Attempts to extract user-friendly error messages from an error message string
+   * that may contain an embedded JSON API response (e.g., SDK errors with the format
+   * "[400 Bad Request] {json body}").
+   */
+  private extractErrorMessagesFromMessage(message: string): string[] {
+    if (!message) {
+      return [];
+    }
+
+    const jsonStart = message.indexOf("{");
+    if (jsonStart === -1) {
+      return [];
+    }
+
+    try {
+      const json = JSON.parse(message.substring(jsonStart));
+      const errorResponse = new ErrorResponse(json, 0);
+
+      if (errorResponse.validationErrors != null) {
+        return errorResponse.getAllMessages();
+      }
+
+      if (errorResponse.message) {
+        return [errorResponse.message];
+      }
+    } catch {
+      // Message did not contain valid JSON
+    }
+
+    return [];
   }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Link to relevant issue -->
https://bitwarden.atlassian.net/browse/PM-32505

## 📔 Objective

When saving a vault item with notes exceeding 10,000 characters, the error toast displayed the raw JSON API response:

> [400 Bad Request] {"message":"The model state is invalid.","validationErrors":{"Notes":["The field Notes exceeds the maximum encrypted value length of 10000 characters."]},...}

This occurred because the SDK throws API errors as JavaScript `Error` objects with the full HTTP status and JSON body embedded in the `message` string. The `ValidationService.showError()` method didn't recognize these as structured API errors — it only checked for a `validationErrors` property directly on the error object, which SDK errors don't have.

### Changes

**`libs/common/src/platform/services/validation.service.ts`**
- Added `extractErrorMessagesFromMessage()` to detect and parse embedded JSON API responses from error message strings
- When an error object has no `validationErrors` property, the method now attempts to extract validation errors or a user-friendly message from embedded JSON before falling back to the raw message

**`libs/common/src/platform/services/validation.service.spec.ts`** *(new)*
- Added 11 unit tests covering all `showError()` code paths, including SDK-style error extraction, direct `ErrorResponse` handling, string errors, and fallback behavior

### Result

The toast now correctly displays:

> The field Notes exceeds the maximum encrypted value length of 10000 characters.

## 📸 Screenshots

<!-- Before/after screenshots of the error toast -->


https://github.com/user-attachments/assets/ab66bd17-530e-4785-b060-330096a049fb

