### PR TITLE
[CL-1049] Simplify dialog autofocus using lifecycle ordering

### DIFF
--- a/apps/web/src/app/vault/components/vault-item-dialog/vault-item-dialog.component.spec.ts
+++ b/apps/web/src/app/vault/components/vault-item-dialog/vault-item-dialog.component.spec.ts
@@ -404,7 +404,7 @@ describe("VaultItemDialogComponent", () => {
     });
 
     it("refocuses the dialog header", async () => {
-      const focusOnHeaderSpy = jest.spyOn(component["dialogComponent"](), "handleAutofocus");
+      const focusOnHeaderSpy = jest.spyOn(component["dialogComponent"](), "focusHeader");
 
       await component["changeMode"]("view");
 

--- a/apps/web/src/app/vault/components/vault-item-dialog/vault-item-dialog.component.ts
+++ b/apps/web/src/app/vault/components/vault-item-dialog/vault-item-dialog.component.ts
@@ -715,7 +715,7 @@ export class VaultItemDialogComponent implements OnInit, OnDestroy {
     this.dialogContent().nativeElement.parentElement.scrollTop = 0;
 
     // Refocus on title element, the built-in focus management of the dialog only works for the initial open.
-    this.dialogComponent().handleAutofocus();
+    this.dialogComponent().focusHeader();
 
     // Update the URL query params to reflect the new mode.
     await this.router.navigate([], {

--- a/libs/components/src/dialog/dialog/dialog.component.html
+++ b/libs/components/src/dialog/dialog/dialog.component.html
@@ -25,6 +25,7 @@
       noMargin
       class="tw-text-main tw-mb-0 tw-line-clamp-2 tw-text-ellipsis tw-break-words focus-visible:tw-outline-none"
       tabindex="-1"
+      appAutofocus
       #dialogHeader
     >
       {{ title() }}

--- a/libs/components/src/dialog/dialog/dialog.component.ts
+++ b/libs/components/src/dialog/dialog/dialog.component.ts
@@ -9,19 +9,16 @@ import {
   input,
   booleanAttribute,
   ElementRef,
-  DestroyRef,
   computed,
   signal,
-  AfterViewInit,
-  NgZone,
 } from "@angular/core";
 import { toObservable } from "@angular/core/rxjs-interop";
-import { combineLatest, firstValueFrom, switchMap } from "rxjs";
+import { combineLatest, switchMap } from "rxjs";
 
 import { I18nPipe } from "@bitwarden/ui-common";
 
 import { BitIconButtonComponent } from "../../icon-button/icon-button.component";
-import { queryForAutofocusDescendents } from "../../input";
+import { AutofocusDirective } from "../../input";
 import { getRootFontSizePx } from "../../shared";
 import { SpinnerComponent } from "../../spinner";
 import { TypographyDirective } from "../../typography/typography.directive";
@@ -73,12 +70,10 @@ export const drawerSizeToWidthRem: Record<string, number> = {
     CdkTrapFocus,
     CdkScrollable,
     SpinnerComponent,
+    AutofocusDirective,
   ],
 })
-export class DialogComponent implements AfterViewInit {
-  private readonly destroyRef = inject(DestroyRef);
-  private readonly ngZone = inject(NgZone);
-  private readonly el = inject<ElementRef<HTMLElement>>(ElementRef);
+export class DialogComponent {
   private readonly drawerService = inject(DrawerService);
 
   constructor() {
@@ -190,53 +185,13 @@ export class DialogComponent implements AfterViewInit {
     this.animationCompleted.set(true);
   }
 
-  async ngAfterViewInit() {
-    /**
-     * Wait for the zone to stabilize before performing any focus behaviors. This ensures that all
-     * child elements are rendered and stable.
-     */
-    if (this.ngZone.isStable) {
-      this.handleAutofocus();
-    } else {
-      await firstValueFrom(this.ngZone.onStable);
-      this.handleAutofocus();
-    }
-  }
-
   /**
-   * Ensure that the user's focus is in the dialog by autofocusing the appropriate element.
+   * Manually focus the dialog header.
    *
-   * If there is a descendant of the dialog with the AutofocusDirective applied, we defer to that.
-   * If not, we want to fallback to a default behavior of focusing the dialog's header element. We
-   * choose the dialog header as the default fallback for dialog focus because it is always present,
-   * unlike possible interactive elements.
+   * Useful in situations where focus needs to be explicitly reset, e.g. when transitioning
+   * between dialog modes.
    */
-  handleAutofocus() {
-    /**
-     * Angular's contentChildren query cannot see into the internal templates of child components.
-     * We need to use a regular DOM query instead to see if there are descendants using the
-     * AutofocusDirective.
-     */
-    const dialogRef = this.el.nativeElement;
-    const autofocusDescendants = queryForAutofocusDescendents(dialogRef);
-    const hasAutofocusDescendants = autofocusDescendants.length > 0;
-
-    if (!hasAutofocusDescendants) {
-      /**
-       * Wait a tick for any focus management to occur on the trigger element before moving focus
-       * to the dialog header.
-       *
-       * We are doing this manually instead of using Angular's built-in focus management
-       * directives (`cdkTrapFocusAutoCapture` and `cdkFocusInitial`) because we need this delay
-       * behavior.
-       *
-       * And yes, we need the timeout even though we are already waiting for ngZone to stabilize.
-       */
-      const headerFocusTimeout = setTimeout(() => {
-        this.dialogHeader().nativeElement.focus();
-      }, 0);
-
-      this.destroyRef.onDestroy(() => clearTimeout(headerFocusTimeout));
-    }
+  focusHeader() {
+    this.dialogHeader().nativeElement.focus();
   }
 }

--- a/libs/components/src/dialog/simple-dialog/simple-dialog.component.html
+++ b/libs/components/src/dialog/simple-dialog/simple-dialog.component.html
@@ -1,4 +1,6 @@
 <div
+  appAutofocus="button"
+  appAutofocusFallback="[bitDialogTitleContainer]"
   class="tw-my-4 tw-pb-6 tw-pt-8 tw-flex tw-max-h-screen tw-w-96 tw-max-w-90vw tw-flex-col tw-overflow-hidden tw-rounded-3xl tw-border tw-border-solid tw-border-secondary-100 tw-shadow-lg tw-bg-text-contrast tw-text-main"
   @fadeIn
 >
@@ -14,6 +16,7 @@
       bitDialogTitleContainer
       bitTypography="h3"
       noMargin
+      tabindex="-1"
       class="tw-w-full tw-text-main tw-break-words tw-hyphens-auto"
     >
       <ng-content select="[bitDialogTitle]"></ng-content>

--- a/libs/components/src/dialog/simple-dialog/simple-dialog.component.ts
+++ b/libs/components/src/dialog/simple-dialog/simple-dialog.component.ts
@@ -1,5 +1,6 @@
 import { booleanAttribute, Component, ContentChild, Directive, input } from "@angular/core";
 
+import { AutofocusDirective } from "../../input";
 import { TypographyDirective } from "../../typography/typography.directive";
 import { fadeIn } from "../animations";
 import { DialogTitleContainerDirective } from "../directives/dialog-title-container.directive";
@@ -15,7 +16,7 @@ export class IconDirective {}
   selector: "bit-simple-dialog, [bit-simple-dialog]",
   templateUrl: "./simple-dialog.component.html",
   animations: [fadeIn],
-  imports: [DialogTitleContainerDirective, TypographyDirective],
+  imports: [DialogTitleContainerDirective, TypographyDirective, AutofocusDirective],
 })
 export class SimpleDialogComponent {
   // FIXME(https://bitwarden.atlassian.net/browse/CL-903): Migrate to Signals

--- a/libs/components/src/input/autofocus.directive.ts
+++ b/libs/components/src/input/autofocus.directive.ts
@@ -1,8 +1,9 @@
 import {
   AfterContentChecked,
-  booleanAttribute,
+  DestroyRef,
   Directive,
   ElementRef,
+  inject,
   input,
   NgZone,
   Optional,
@@ -22,7 +23,19 @@ import { FocusableElement } from "../shared/focusable-element";
  */
 export function queryForAutofocusDescendents(el: Document | Element) {
   // ensure selectors match the directive selectors
-  return el.querySelectorAll("[appAutofocus], [bitAutofocus]");
+  // Use lowercase — Angular serializes directive attribute names as lowercase in the DOM.
+  return el.querySelectorAll("[appautofocus]");
+}
+
+/**
+ * Transform for the appAutofocus input. Converts attribute presence (`""`) to `true`,
+ * passes CSS selector strings through as-is, and preserves `false`.
+ */
+function autofocusAttribute(value: string | boolean): string | boolean {
+  if (value === "" || value === true) {
+    return true;
+  }
+  return value;
 }
 
 /**
@@ -32,17 +45,31 @@ export function queryForAutofocusDescendents(el: Document | Element) {
  *
  * Will focus the element once, when it becomes visible.
  *
+ * When used without a value (`<h2 appAutofocus>`), the host element itself is focused.
+ *
+ * When used with a CSS selector (`<div appAutofocus="button">`), the first matching
+ * descendant is focused instead. Combine with `fallback` to specify a selector queried
+ * from the host's parent if the primary yields no match.
+ *
  * If the component provides the `FocusableElement` interface, the `focus`
- * method will be called. Otherwise, the native element will be focused. *
+ * method will be called. Otherwise, the native element will be focused.
  */
 @Directive({
-  selector: "[appAutofocus], [bitAutofocus]",
+  selector: "[appAutofocus]",
 })
 export class AutofocusDirective implements AfterContentChecked {
-  readonly appAutofocus = input(undefined, { transform: booleanAttribute });
+  readonly appAutofocus = input(undefined, { transform: autofocusAttribute });
+
+  /**
+   * Fallback CSS selector queried from the host element if the primary `appAutofocus`
+   * selector yields no match.
+   */
+  readonly appAutofocusFallback = input<string>();
 
   // Track if we have already focused the element.
   private focused = false;
+
+  private readonly destroyRef = inject(DestroyRef);
 
   constructor(
     private el: ElementRef,
@@ -69,6 +96,10 @@ export class AutofocusDirective implements AfterContentChecked {
       return;
     }
 
+    // Set before scheduling to prevent duplicate subscriptions if ngAfterContentChecked
+    // is called multiple times while the zone is unstable.
+    this.focused = true;
+
     if (this.ngZone.isStable) {
       this.focus();
     } else {
@@ -77,19 +108,48 @@ export class AutofocusDirective implements AfterContentChecked {
   }
 
   /**
-   * Attempt to focus the element. If successful we set focused to true to prevent further focus
-   * attempts.
+   * Wait a tick for any focus management to occur on the trigger element before moving
+   * focus. We need the timeout even though we are already waiting for ngZone to
+   * stabilize — CDK's focus trap and dialog focus-restore bookkeeping may still be
+   * in-flight within the same macrotask.
    */
   private focus() {
-    const el = this.getElement();
+    const focusTimeout = setTimeout(() => {
+      const el = this.getElement();
 
-    if (el) {
-      el.focus();
-      this.focused = el === document.activeElement;
-    }
+      if (!el) {
+        return;
+      }
+
+      const focusScope = this.el.nativeElement.closest("[cdkTrapFocus]") ?? document;
+      const activeInScope = focusScope.contains(document.activeElement);
+      // Check for our own marker attribute rather than the directive selector attribute,
+      // because Angular doesn't write DOM attributes for signal/property bindings.
+      const activeWasAutofocused = document.activeElement?.hasAttribute("data-appautofocus");
+
+      if (activeInScope && activeWasAutofocused) {
+        return;
+      }
+
+      el.setAttribute("data-appautofocus", "");
+      this.ngZone.runOutsideAngular(() => el.focus());
+    }, 0);
+
+    this.destroyRef.onDestroy(() => clearTimeout(focusTimeout));
   }
 
   private getElement(): HTMLElement | undefined {
+    const value = this.appAutofocus();
+
+    if (typeof value === "string") {
+      const container = this.el.nativeElement as HTMLElement;
+      const fallback = this.appAutofocusFallback();
+      return (
+        container.querySelector<HTMLElement>(value) ??
+        (fallback ? (container.querySelector<HTMLElement>(fallback) ?? undefined) : undefined)
+      );
+    }
+
     if (this.focusableElement) {
       return this.focusableElement.getFocusTarget();
     }

--- a/libs/components/src/input/autofocus.stories.ts
+++ b/libs/components/src/input/autofocus.stories.ts
@@ -1,4 +1,5 @@
 import { Meta, moduleMetadata, StoryObj } from "@storybook/angular";
+import { expect, waitFor } from "storybook/test";
 
 import { FormFieldModule } from "../form-field";
 
@@ -23,4 +24,7 @@ export const AutofocusField: StoryObj = {
       </bit-form-field>
     `,
   }),
+  play: async ({ canvasElement }) => {
+    await waitFor(() => expect(canvasElement.querySelector("input")).toHaveFocus());
+  },
 };

--- a/libs/components/src/stories/kitchen-sink/components/kitchen-sink-main.component.ts
+++ b/libs/components/src/stories/kitchen-sink/components/kitchen-sink-main.component.ts
@@ -88,6 +88,31 @@ export class KitchenSinkDialogComponent {
 // FIXME(https://bitwarden.atlassian.net/browse/CL-764): Migrate to OnPush
 // eslint-disable-next-line @angular-eslint/prefer-on-push-component-change-detection
 @Component({
+  template: `
+    <bit-dialog title="Dialog Title" dialogSize="small">
+      <ng-container bitDialogContent>
+        <bit-form-field>
+          <bit-label>Username</bit-label>
+          <input bitInput [appAutofocus]="true" />
+        </bit-form-field>
+      </ng-container>
+      <ng-container bitDialogFooter>
+        <button type="button" bitButton buttonType="primary" (click)="dialogRef.close()">
+          Save
+        </button>
+        <button type="button" bitButton buttonType="secondary" bitDialogClose>Cancel</button>
+      </ng-container>
+    </bit-dialog>
+  `,
+  imports: [KitchenSinkSharedModule],
+})
+export class KitchenSinkDialogWithAutofocusComponent {
+  constructor(public dialogRef: DialogRef) {}
+}
+
+// FIXME(https://bitwarden.atlassian.net/browse/CL-764): Migrate to OnPush
+// eslint-disable-next-line @angular-eslint/prefer-on-push-component-change-detection
+@Component({
   selector: "bit-tab-main",
   imports: [KitchenSinkSharedModule],
   template: `

--- a/libs/components/src/stories/kitchen-sink/components/kitchen-sink-vault.component.ts
+++ b/libs/components/src/stories/kitchen-sink/components/kitchen-sink-vault.component.ts
@@ -4,7 +4,10 @@ import { DialogService } from "../../../dialog";
 import { KitchenSinkSharedModule } from "../kitchen-sink-shared.module";
 
 import { KitchenSinkFormComponent } from "./kitchen-sink-form.component";
-import { KitchenSinkDialogComponent } from "./kitchen-sink-main.component";
+import {
+  KitchenSinkDialogComponent,
+  KitchenSinkDialogWithAutofocusComponent,
+} from "./kitchen-sink-main.component";
 import { KitchenSinkTableComponent } from "./kitchen-sink-table.component";
 import { KitchenSinkToggleListComponent } from "./kitchen-sink-toggle-list.component";
 import { KitchenSinkTourService } from "./kitchen-sink-tour.service";
@@ -37,6 +40,14 @@ import { KitchenSinkTourService } from "./kitchen-sink-tour.service";
         Open Dialog
       </button>
       <button type="button" bitButton (click)="openDrawer()">Open Drawer</button>
+      <button type="button" bitButton [bitMenuTriggerFor]="focusMenu">Open Dialog from Menu</button>
+      <bit-menu #focusMenu>
+        <button type="button" bitMenuItem (click)="openDialog()">Open Dialog</button>
+        <button type="button" bitMenuItem (click)="openDialogWithAutofocus()">
+          Open Dialog with Autofocus
+        </button>
+        <button type="button" bitMenuItem (click)="openSimpleDialog()">Open Simple Dialog</button>
+      </bit-menu>
       <button bitButton type="button" (click)="tourService.startTour()">Start Tour</button>
     </bit-section>
     <bit-section>
@@ -97,5 +108,19 @@ export class KitchenSinkVaultComponent {
 
   openDrawer() {
     this.dialogService.openDrawer(KitchenSinkDialogComponent);
+  }
+
+  openDialogWithAutofocus() {
+    this.dialogService.open(KitchenSinkDialogWithAutofocusComponent);
+  }
+
+  openSimpleDialog() {
+    void this.dialogService.openSimpleDialog({
+      title: "Confirm Action",
+      content: "Are you sure you want to proceed?",
+      type: "primary",
+      acceptButtonText: "Yes",
+      cancelButtonText: "No",
+    });
   }
 }

--- a/libs/components/src/stories/kitchen-sink/kitchen-sink-autofocus.stories.ts
+++ b/libs/components/src/stories/kitchen-sink/kitchen-sink-autofocus.stories.ts
@@ -1,0 +1,75 @@
+import { Meta, StoryObj } from "@storybook/angular";
+import { expect, fireEvent, getByRole, waitFor } from "storybook/test";
+
+import { KitchenSinkAppComponent } from "./components/kitchen-sink-app.component";
+import kitchenSinkMeta from "./kitchen-sink.stories";
+
+export default {
+  ...kitchenSinkMeta,
+  title: "Documentation / Kitchen Sink / Tests / Autofocus",
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
+} as Meta;
+
+type Story = StoryObj<KitchenSinkAppComponent>;
+
+async function navigateTo(path: string) {
+  window.location.hash = path;
+  await new Promise((resolve) => setTimeout(resolve, 50));
+}
+
+/**
+ * Dialog opened from a menu item — focus should land on the dialog header since no
+ * child element has appAutofocus.
+ */
+export const DialogHeaderFocus: Story = {
+  play: async (context) => {
+    const canvas = context.canvasElement;
+    await navigateTo("/bitwarden");
+    await fireEvent.click(getByRole(canvas, "button", { name: "Open Dialog from Menu" }));
+    await fireEvent.click(
+      getByRole(canvas.ownerDocument.body, "menuitem", { name: "Open Dialog" }),
+    );
+    await waitFor(() =>
+      expect(
+        getByRole(canvas.ownerDocument.body, "heading", { name: "Dialog Title" }),
+      ).toHaveFocus(),
+    );
+  },
+};
+
+/**
+ * Dialog with an appAutofocus field opened from a menu item — focus should land on
+ * the input, not the dialog header.
+ */
+export const DialogAutofocusFieldFocus: Story = {
+  play: async (context) => {
+    const canvas = context.canvasElement;
+    await navigateTo("/bitwarden");
+    await fireEvent.click(getByRole(canvas, "button", { name: "Open Dialog from Menu" }));
+    await fireEvent.click(
+      getByRole(canvas.ownerDocument.body, "menuitem", { name: "Open Dialog with Autofocus" }),
+    );
+    await waitFor(() =>
+      expect(getByRole(canvas.ownerDocument.body, "textbox", { name: "Username" })).toHaveFocus(),
+    );
+  },
+};
+
+/**
+ * Simple dialog opened from a menu item — focus should land on the first footer button.
+ */
+export const SimpleDialogButtonFocus: Story = {
+  play: async (context) => {
+    const canvas = context.canvasElement;
+    await navigateTo("/bitwarden");
+    await fireEvent.click(getByRole(canvas, "button", { name: "Open Dialog from Menu" }));
+    await fireEvent.click(
+      getByRole(canvas.ownerDocument.body, "menuitem", { name: "Open Simple Dialog" }),
+    );
+    await waitFor(() =>
+      expect(getByRole(canvas.ownerDocument.body, "button", { name: "Yes" })).toHaveFocus(),
+    );
+  },
+};

--- a/libs/components/src/stories/kitchen-sink/kitchen-sink-shared.module.ts
+++ b/libs/components/src/stories/kitchen-sink/kitchen-sink-shared.module.ts
@@ -18,7 +18,7 @@ import { FormFieldModule } from "../../form-field";
 import { HeaderComponent } from "../../header";
 import { IconComponent } from "../../icon";
 import { IconButtonModule } from "../../icon-button";
-import { InputModule } from "../../input";
+import { AutofocusDirective, InputModule } from "../../input";
 import { LayoutComponent } from "../../layout";
 import { LinkModule } from "../../link";
 import { MenuModule } from "../../menu";
@@ -38,6 +38,7 @@ import { TypographyModule } from "../../typography";
 
 @NgModule({
   imports: [
+    AutofocusDirective,
     AsyncActionsModule,
     AvatarModule,
     BadgeModule,
@@ -76,6 +77,7 @@ import { TypographyModule } from "../../typography";
     TypographyModule,
   ],
   exports: [
+    AutofocusDirective,
     AsyncActionsModule,
     AvatarModule,
     BadgeModule,

--- a/libs/components/src/stories/kitchen-sink/kitchen-sink.stories.ts
+++ b/libs/components/src/stories/kitchen-sink/kitchen-sink.stories.ts
@@ -16,7 +16,10 @@ import { DialogVirtualScrollBlockComponent } from "./components/dialog-virtual-s
 import { KitchenSinkAppComponent } from "./components/kitchen-sink-app.component";
 import { KitchenSinkEmptyComponent } from "./components/kitchen-sink-empty.component";
 import { KitchenSinkFormComponent } from "./components/kitchen-sink-form.component";
-import { KitchenSinkMainComponent } from "./components/kitchen-sink-main.component";
+import {
+  KitchenSinkDialogWithAutofocusComponent,
+  KitchenSinkMainComponent,
+} from "./components/kitchen-sink-main.component";
 import { KitchenSinkTableComponent } from "./components/kitchen-sink-table.component";
 import { KitchenSinkToggleListComponent } from "./components/kitchen-sink-toggle-list.component";
 import { KitchenSinkVaultComponent } from "./components/kitchen-sink-vault.component";
@@ -31,6 +34,7 @@ export default {
       imports: [
         KitchenSinkSharedModule,
         KitchenSinkAppComponent,
+        KitchenSinkDialogWithAutofocusComponent,
         KitchenSinkEmptyComponent,
         KitchenSinkFormComponent,
         KitchenSinkMainComponent,


### PR DESCRIPTION
## 🎟️ Tracking

[CL-1049](https://bitwarden.atlassian.net/browse/CL-1049)

## 📔 Objective

Alternative approach to #19561.

Instead of a new `AutofocusFallbackDirective`, this extends the existing `appAutofocus` directive with two new capabilities:

- **`appAutofocus="<selector>"`** — queries the host element for the first matching descendant to focus
- **`appAutofocusFallback="<selector>"`** — fallback selector queried from the host if the primary yields no match

The "first to fire wins" behavior is enforced by checking whether an `[appAutofocus]` element within the same `cdkTrapFocus` scope already has focus before stealing it. Angular's lifecycle ordering (projected content initializes before the host's view children) ensures consumer-supplied `appAutofocus` naturally takes precedence over the dialog's own default.

### Changes

- `appAutofocus` — adds `selector`/`fallback` inputs; adds `document.activeElement` guard scoped to the nearest `cdkTrapFocus` ancestor; removes `[bitAutofocus]` as a selector alias
- `DialogComponent` — removes `ngAfterViewInit`/`handleAutofocus`; adds `appAutofocus` to the header template; exposes a simple `focusHeader()` for programmatic use (e.g. mode switching)
- `SimpleDialogComponent` — adds `appAutofocus="button" appAutofocusFallback="[bitDialogTitleContainer]"` to the outer container; focuses the first footer button by default, falling back to the header
- `VaultItemDialogComponent` — updates `handleAutofocus()` → `focusHeader()`

[CL-1049]: https://bitwarden.atlassian.net/browse/CL-1049?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ