### PR TITLE
Add publisherName to Electron build process

### DIFF
--- a/apps/desktop/electron-builder.beta.json
+++ b/apps/desktop/electron-builder.beta.json
@@ -34,7 +34,8 @@
     "target": ["portable", "nsis-web", "appx"],
     "signExts": [".dll", ".node"],
     "signtoolOptions": {
-      "sign": "./sign.js"
+      "sign": "./sign.js",
+      "publisherName": "Bitwarden Inc."
     },
     "extraFiles": [
       {
@@ -49,7 +50,6 @@
   },
   "nsisWeb": {
     "oneClick": false,
-    "publisherName": "Bitwarden Inc.",
     "perMachine": false,
     "allowToChangeInstallationDirectory": false,
     "artifactName": "Bitwarden-Beta-Installer-${version}.${ext}",

--- a/apps/desktop/electron-builder.json
+++ b/apps/desktop/electron-builder.json
@@ -95,7 +95,8 @@
     "target": ["portable", "nsis-web", "appx"],
     "signExts": [".dll", ".node"],
     "signtoolOptions": {
-      "sign": "./sign.js"
+      "sign": "./sign.js",
+      "publisherName": "Bitwarden Inc."
     },
     "extraFiles": [
       {
@@ -164,7 +165,6 @@
   },
   "nsisWeb": {
     "oneClick": false,
-    "publisherName": "Bitwarden Inc.",
     "perMachine": false,
     "allowToChangeInstallationDirectory": false,
     "artifactName": "${productName}-Installer-${version}.${ext}",


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-33717

## 📔 Objective

This adds the publisherName field to the Electron build process. Without this field, Electron skips Authenticode signature verification (https://github.com/electron-userland/electron-builder/blob/ed422f36540a93e9bd2a19bc7a5e729bf2b033ea/packages/electron-updater/src/NsisUpdater.ts#L113-L114). 

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
