### PR TITLE
[PM-33775] fix(browser): null check on autoCompleteType in autofill overlay

### DIFF
--- a/apps/browser/src/autofill/services/autofill-overlay-content.service.ts
+++ b/apps/browser/src/autofill/services/autofill-overlay-content.service.ts
@@ -1129,7 +1129,8 @@ export class AutofillOverlayContentService implements AutofillOverlayContentServ
     }
 
     autofillFieldData.inlineMenuFillType = CipherType.Login;
-    autofillFieldData.showPasskeys = autofillFieldData.autoCompleteType.includes("webauthn");
+    autofillFieldData.showPasskeys =
+      autofillFieldData.autoCompleteType?.includes("webauthn") ?? false;
 
     this.qualifyAccountCreationFieldType(autofillFieldData);
   }


### PR DESCRIPTION
## 🎟️ Tracking

`autoCompleteType` is typed as `string | null` on `AutofillField`, but
`setQualifiedLoginFillType` calls `.includes()` on it without a null
check. This throws a TypeError on form fields that don't have an
`autocomplete` attribute, since `getAttribute("autocomplete")` returns
`null`.

Add optional chaining to handle the null case.

## 📔 Objective

Prevent a TypeError crash in the autofill overlay when processing form
fields that don't have an `autocomplete` attribute:
```
bootstrap-autofill-overlay-notifications.js:8041 Uncaught (in promise) TypeError: Cannot read properties of null (reading 'includes')
    at AutofillOverlayContentService.<anonymous> (bootstrap-autofill-overlay-notifications.js:8041:81)
    at Generator.next (<anonymous>)
    at bootstrap-autofill-overlay-notifications.js:7001:71
    at new Promise (<anonymous>)
    at autofill_overlay_content_service_awaiter (bootstrap-autofill-overlay-notifications.js:6997:12)
    at AutofillOverlayContentService.setQualifiedLoginFillType (bootstrap-autofill-overlay-notifications.js:8034:16)
    at AutofillOverlayContentService.isIgnoredField (bootstrap-autofill-overlay-notifications.js:8009:23)
    at AutofillOverlayContentService.<anonymous> (bootstrap-autofill-overlay-notifications.js:7460:22)
    at Generator.next (<anonymous>)
    at bootstrap-autofill-overlay-notifications.js:7001:71
(anonymous) @ bootstrap-autofill-overlay-notifications.js:8041
(anonymous) @ bootstrap-autofill-overlay-notifications.js:7001
autofill_overlay_content_service_awaiter @ bootstrap-autofill-overlay-notifications.js:6997
setQualifiedLoginFillType @ bootstrap-autofill-overlay-notifications.js:8034
isIgnoredField @ bootstrap-autofill-overlay-notifications.js:8009
(anonymous) @ bootstrap-autofill-overlay-notifications.js:7460
(anonymous) @ bootstrap-autofill-overlay-notifications.js:7001
autofill_overlay_content_service_awaiter @ bootstrap-autofill-overlay-notifications.js:6997
setupOverlayListeners @ bootstrap-autofill-overlay-notifications.js:7457
setupOverlayOnField @ bootstrap-autofill-overlay-notifications.js:22098
(anonymous) @ bootstrap-autofill-overlay-notifications.js:22083
setupOverlayListeners @ bootstrap-autofill-overlay-notifications.js:22082
(anonymous) @ bootstrap-autofill-overlay-notifications.js:21232
fulfilled @ bootstrap-autofill-overlay-notifications.js:20939
Promise.then
step @ bootstrap-autofill-overlay-notifications.js:20941
(anonymous) @ bootstrap-autofill-overlay-notifications.js:20942
collect_autofill_content_service_awaiter @ bootstrap-autofill-overlay-notifications.js:20938
getPageDetails @ bootstrap-autofill-overlay-notifications.js:21205
(anonymous) @ bootstrap-autofill-overlay-notifications.js:22540
(anonymous) @ bootstrap-autofill-overlay-notifications.js:22448
autofill_init_awaiter @ bootstrap-autofill-overlay-notifications.js:22444
collectPageDetails @ bootstrap-autofill-overlay-notifications.js:22539
collectPageDetails @ bootstrap-autofill-overlay-notifications.js:22472
AutofillInit.handleExtensionMessage @ bootstrap-autofill-overlay-notifications.js:22496Understand this error
```
