### PR TITLE
[PM-33779] Use tw-hidden instead of tw-invisible to avoid CSS animation when loa…

### DIFF
--- a/libs/components/src/icon-button/icon-button.component.html
+++ b/libs/components/src/icon-button/icon-button.component.html
@@ -4,7 +4,7 @@
   </span>
   <span
     class="tw-absolute tw-inset-0 tw-flex tw-items-center tw-justify-center"
-    [ngClass]="{ 'tw-invisible': !showLoadingStyle() }"
+    [ngClass]="{ 'tw-hidden': !showLoadingStyle() }"
   >
     <bit-spinner size="fill" noColor></bit-spinner>
   </span>


### PR DESCRIPTION
…ding svg is hidden

## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

Fixes #17041 

Potentially: #17149

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

`tw-invisible` makes the element invisible, while animation is still working, consuming CPU. Changing it to `tw-hidden` stops CSS animation when the element is not visible.