### PR TITLE
remove default icons on non-semantic variants

### DIFF
--- a/libs/components/src/badge/badge.component.ts
+++ b/libs/components/src/badge/badge.component.ts
@@ -74,7 +74,7 @@ const commonStyles = [
 ];
 
 const defaultIconMap: Record<BadgeVariant, BitwardenIcon | null> = {
-  info: "bwi-info-circle",
+  info: null,
   subtle: null,
   secondary: null,
   primary: null,


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/CL-1118

## 📔 Objective

- Remove default badge icons on non-semantic variants

## 📸 Screenshots
<img width="588" height="539" alt="image" src="https://github.com/user-attachments/assets/ebb3486c-a1d3-4dca-87e5-42ad2717130f" />

