### PR TITLE
[BRE-1718] Fix macOS CLI notarization

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -275,12 +275,6 @@ jobs:
           echo "Submit binary for notarization"
           xcrun notarytool submit bw-notarization-temp.zip --keychain-profile "notarytool-profile" --wait
 
-          echo "Staple notarization ticket to binary"
-          xcrun stapler staple ./bw
-
-          echo "Verify stapling succeeded"
-          xcrun stapler validate ./bw
-
           echo "Cleanup temporary zip"
           rm bw-notarization-temp.zip
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/BRE-1718

## 📔 Objective

Testing the following to see if it fixes MacOS CLI signing issue.
- Notarize binary instead of ZIP archive
- Staple notarization ticket with xcrun stapler
- Create distribution ZIP after notarization completes
- Split Unix zip into separate Linux and macOS steps

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
