### PR TITLE
fix(reports): skip malformed login ciphers and guard splice index in …

### DIFF
--- a/apps/web/src/app/dirt/reports/pages/cipher-report.component.ts
+++ b/apps/web/src/app/dirt/reports/pages/cipher-report.component.ts
@@ -252,7 +252,7 @@ export abstract class CipherReportComponent implements OnDestroy {
       const index = this.ciphers.findIndex((c) => c.id === updatedCipherView.id);
 
       // the updated cipher does not meet the criteria for the report, it returns a null
-      if (updatedReportResult === null) {
+      if (updatedReportResult === null && index > -1) {
         this.ciphers.splice(index, 1);
       }
 

--- a/apps/web/src/app/dirt/reports/pages/weak-passwords-report.component.ts
+++ b/apps/web/src/app/dirt/reports/pages/weak-passwords-report.component.ts
@@ -86,7 +86,11 @@ export class WeakPasswordsReportComponent extends CipherReportComponent implemen
     const index = this.weakPasswordCiphers.findIndex((c) => c.id === updatedCipherView.id);
 
     if (index !== -1) {
-      this.weakPasswordCiphers[index] = updatedReportStatus;
+      if (updatedReportStatus !== null) {
+        this.weakPasswordCiphers[index] = updatedReportStatus;
+      } else {
+        this.weakPasswordCiphers.splice(index, 1);
+      }
     }
 
     return updatedReportStatus;
@@ -106,6 +110,7 @@ export class WeakPasswordsReportComponent extends CipherReportComponent implemen
     const { type, login, isDeleted, edit, viewPassword } = ciph;
     if (
       type !== CipherType.Login ||
+      login == null ||
       login.password == null ||
       login.password === "" ||
       isDeleted ||


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-12710

## 📔 Objective

Login-type ciphers with a missing login object (malformed/corrupted data) caused an unhandled crash mid-loop, leaving loading permanently true and the report stuck on the spinner. Fixed by adding a login == null guard in determineWeakPasswordScore.