### PR TITLE
[PM-33797] AIV2: Standardize Models and Services: Services

### DIFF
--- a/bitwarden_license/bit-common/src/dirt/access-intelligence/index.ts
+++ b/bitwarden_license/bit-common/src/dirt/access-intelligence/index.ts
@@ -1,2 +1,2 @@
 export * from "./models";
-// export * from "./services"; services export added in upcoming pr once service layer exists
+export * from "./services";

--- a/bitwarden_license/bit-common/src/dirt/access-intelligence/models/view/access-report.view.spec.ts
+++ b/bitwarden_license/bit-common/src/dirt/access-intelligence/models/view/access-report.view.spec.ts
@@ -1,0 +1,744 @@
+import { OrganizationId, OrganizationReportId } from "@bitwarden/common/types/guid";
+
+import {
+  createApplication,
+  createMemberRegistry,
+  createReport,
+  createRiskInsights,
+  createRiskInsightsSummary,
+} from "../../../reports/risk-insights/testing/test-helpers";
+
+import { AccessReportSettingsView } from "./access-report-settings.view";
+import { AccessReportView } from "./access-report.view";
+import { ApplicationHealthView } from "./application-health.view";
+import { MemberRegistryEntryView } from "./member-registry-entry.view";
+
+describe("AccessReportView", () => {
+  // ==================== Constructor Tests ====================
+
+  describe("constructor", () => {
+    it("should create empty view when no parameter provided", () => {
+      const view = new AccessReportView();
+
+      expect(view.id).toBe("");
+      expect(view.organizationId).toBe("");
+      expect(view.reports).toEqual([]);
+      expect(view.applications).toEqual([]);
+      expect(view.memberRegistry).toEqual({});
+      expect(view.creationDate).toBeInstanceOf(Date);
+    });
+
+    it("should initialize from domain model", () => {
+      const mockDomain = {
+        id: "report-123" as OrganizationReportId,
+        organizationId: "org-456" as OrganizationId,
+        creationDate: new Date("2024-01-15"),
+        contentEncryptionKey: undefined,
+      } as any;
+
+      const view = new AccessReportView(mockDomain);
+
+      expect(view.id).toBe("report-123");
+      expect(view.organizationId).toBe("org-456");
+      expect(view.creationDate).toEqual(new Date("2024-01-15"));
+    });
+  });
+
+  // ==================== Query Methods ====================
+
+  describe("getAtRiskMembers", () => {
+    it("should return all unique at-risk members across applications", () => {
+      const view = new AccessReportView();
+      view.memberRegistry = createMemberRegistry([
+        { id: "u1", name: "Alice", email: "alice@example.com" },
+        { id: "u2", name: "Bob", email: "bob@example.com" },
+        { id: "u3", name: "Charlie", email: "charlie@example.com" },
+      ]);
+
+      view.reports = [
+        createReport("github.com", { u1: true, u2: false }, {}),
+        createReport("gitlab.com", { u1: true, u3: true }, {}),
+      ];
+
+      const atRiskMembers = view.getAtRiskMembers();
+
+      expect(atRiskMembers).toHaveLength(2);
+      expect(atRiskMembers.map((m) => m.id).sort()).toEqual(["u1", "u3"]);
+    });
+
+    it("should deduplicate members appearing in multiple applications", () => {
+      const view = new AccessReportView();
+      view.memberRegistry = createMemberRegistry([
+        { id: "u1", name: "Alice", email: "alice@example.com" },
+      ]);
+
+      view.reports = [
+        createReport("github.com", { u1: true }, {}),
+        createReport("gitlab.com", { u1: true }, {}),
+        createReport("bitbucket.com", { u1: true }, {}),
+      ];
+
+      const atRiskMembers = view.getAtRiskMembers();
+
+      expect(atRiskMembers).toHaveLength(1);
+      expect(atRiskMembers[0].id).toBe("u1");
+    });
+
+    it("should return empty array when no at-risk members exist", () => {
+      const view = new AccessReportView();
+      view.memberRegistry = createMemberRegistry([
+        { id: "u1", name: "Alice", email: "alice@example.com" },
+      ]);
+
+      view.reports = [createReport("github.com", { u1: false }, {})];
+
+      const atRiskMembers = view.getAtRiskMembers();
+
+      expect(atRiskMembers).toHaveLength(0);
+    });
+
+    it("should filter out members not in registry", () => {
+      const view = new AccessReportView();
+      view.memberRegistry = createMemberRegistry([
+        { id: "u1", name: "Alice", email: "alice@example.com" },
+      ]);
+
+      view.reports = [createReport("github.com", { u1: true, u999: true }, {})];
+
+      const atRiskMembers = view.getAtRiskMembers();
+
+      expect(atRiskMembers).toHaveLength(1);
+      expect(atRiskMembers[0].id).toBe("u1");
+    });
+  });
+
+  describe("getCriticalApplications", () => {
+    it("should return only critical application reports", () => {
+      const view = new AccessReportView();
+      view.applications = [
+        createApplication("github.com", true),
+        createApplication("gitlab.com", false),
+        createApplication("bitbucket.com", true),
+      ];
+
+      view.reports = [
+        createReport("github.com", {}, {}),
+        createReport("gitlab.com", {}, {}),
+        createReport("bitbucket.com", {}, {}),
+      ];
+
+      const criticalApps = view.getCriticalApplications();
+
+      expect(criticalApps).toHaveLength(2);
+      expect(criticalApps.map((r) => r.applicationName).sort()).toEqual([
+        "bitbucket.com",
+        "github.com",
+      ]);
+    });
+
+    it("should return empty array when no critical applications exist", () => {
+      const view = new AccessReportView();
+      view.applications = [createApplication("github.com", false)];
+      view.reports = [createReport("github.com", {}, {})];
+
+      const criticalApps = view.getCriticalApplications();
+
+      expect(criticalApps).toHaveLength(0);
+    });
+  });
+
+  describe("getNewApplications", () => {
+    it("should return only unreviewed applications", () => {
+      const view = new AccessReportView();
+      view.applications = [
+        createApplication("github.com", false, new Date("2024-01-15")),
+        createApplication("gitlab.com", false, undefined),
+        createApplication("bitbucket.com", false, undefined),
+      ];
+
+      view.reports = [
+        createReport("github.com", {}, {}),
+        createReport("gitlab.com", {}, {}),
+        createReport("bitbucket.com", {}, {}),
+      ];
+
+      const newApps = view.getNewApplications();
+
+      expect(newApps).toHaveLength(2);
+      expect(newApps.map((r) => r.applicationName).sort()).toEqual(["bitbucket.com", "gitlab.com"]);
+    });
+
+    it("should return empty array when all applications are reviewed", () => {
+      const view = new AccessReportView();
+      view.applications = [createApplication("github.com", false, new Date())];
+      view.reports = [createReport("github.com", {}, {})];
+
+      const newApps = view.getNewApplications();
+
+      expect(newApps).toHaveLength(0);
+    });
+  });
+
+  describe("getApplicationByName", () => {
+    it("should find application by exact name match", () => {
+      const view = new AccessReportView();
+      view.reports = [createReport("github.com", {}, {}), createReport("gitlab.com", {}, {})];
+
+      const app = view.getApplicationByName("github.com");
+
+      expect(app).toBeDefined();
+      expect(app?.applicationName).toBe("github.com");
+    });
+
+    it("should return undefined when application not found", () => {
+      const view = new AccessReportView();
+      view.reports = [createReport("github.com", {}, {})];
+
+      const app = view.getApplicationByName("gitlab.com");
+
+      expect(app).toBeUndefined();
+    });
+  });
+
+  describe("getTotalMemberCount", () => {
+    it("should return count of members in registry", () => {
+      const view = new AccessReportView();
+      view.memberRegistry = createMemberRegistry([
+        { id: "u1", name: "Alice", email: "alice@example.com" },
+        { id: "u2", name: "Bob", email: "bob@example.com" },
+        { id: "u3", name: "Charlie", email: "charlie@example.com" },
+      ]);
+
+      expect(view.getTotalMemberCount()).toBe(3);
+    });
+
+    it("should return 0 when registry is empty", () => {
+      const view = new AccessReportView();
+      view.memberRegistry = {};
+
+      expect(view.getTotalMemberCount()).toBe(0);
+    });
+  });
+
+  describe("getAtRiskPasswordCountForMember", () => {
+    it("should count at-risk passwords for member across all applications", () => {
+      const view = new AccessReportView();
+      view.memberRegistry = createMemberRegistry([
+        { id: "u1", name: "Alice", email: "alice@example.com" },
+      ]);
+
+      view.reports = [
+        createReport("github.com", { u1: true }, { c1: true, c2: true }), // 2 at-risk
+        createReport("gitlab.com", { u1: true }, { c3: true, c4: false }), // 1 at-risk
+        createReport("bitbucket.com", { u1: false }, { c5: true }), // Not at-risk, should not count
+      ];
+
+      const count = view.getAtRiskPasswordCountForMember("u1");
+
+      expect(count).toBe(3); // 2 from github + 1 from gitlab
+    });
+
+    it("should return 0 when member is not at-risk in any application", () => {
+      const view = new AccessReportView();
+      view.memberRegistry = createMemberRegistry([
+        { id: "u1", name: "Alice", email: "alice@example.com" },
+      ]);
+
+      view.reports = [
+        createReport("github.com", { u1: false }, { c1: true }), // Not at-risk
+        createReport("gitlab.com", { u1: false }, { c2: true }), // Not at-risk
+      ];
+
+      const count = view.getAtRiskPasswordCountForMember("u1");
+
+      expect(count).toBe(0);
+    });
+
+    it("should count passwords for specific application when applicationName provided", () => {
+      const view = new AccessReportView();
+      view.memberRegistry = createMemberRegistry([
+        { id: "u1", name: "Alice", email: "alice@example.com" },
+      ]);
+
+      view.reports = [
+        createReport("github.com", { u1: true }, { c1: true, c2: true, c3: true }), // 3 at-risk
+        createReport("gitlab.com", { u1: true }, { c4: true }), // 1 at-risk
+      ];
+
+      const count = view.getAtRiskPasswordCountForMember("u1", "github.com");
+
+      expect(count).toBe(3); // Only github.com
+    });
+
+    it("should return 0 when member not at-risk in specific application", () => {
+      const view = new AccessReportView();
+      view.memberRegistry = createMemberRegistry([
+        { id: "u1", name: "Alice", email: "alice@example.com" },
+      ]);
+
+      view.reports = [
+        createReport("github.com", { u1: false }, { c1: true, c2: true }), // Not at-risk
+        createReport("gitlab.com", { u1: true }, { c3: true }), // At-risk
+      ];
+
+      const count = view.getAtRiskPasswordCountForMember("u1", "github.com");
+
+      expect(count).toBe(0); // Not at-risk in github
+    });
+
+    it("should return 0 when application not found", () => {
+      const view = new AccessReportView();
+      view.memberRegistry = createMemberRegistry([
+        { id: "u1", name: "Alice", email: "alice@example.com" },
+      ]);
+
+      view.reports = [createReport("github.com", { u1: true }, { c1: true })];
+
+      const count = view.getAtRiskPasswordCountForMember("u1", "nonexistent.com");
+
+      expect(count).toBe(0);
+    });
+
+    it("should return 0 when member not in any application", () => {
+      const view = new AccessReportView();
+      view.memberRegistry = createMemberRegistry([
+        { id: "u1", name: "Alice", email: "alice@example.com" },
+      ]);
+
+      view.reports = [createReport("github.com", { u2: true }, { c1: true })];
+
+      const count = view.getAtRiskPasswordCountForMember("u1");
+
+      expect(count).toBe(0);
+    });
+  });
+
+  // ==================== Update Methods ====================
+
+  describe("markApplicationsAsCritical", () => {
+    it("should mark existing application as critical", () => {
+      const view = new AccessReportView();
+      view.applications = [createApplication("github.com", false)];
+      view.reports = [createReport("github.com", {}, {})];
+
+      view.markApplicationsAsCritical(["github.com"]);
+
+      const app = view.applications.find((a) => a.applicationName === "github.com");
+      expect(app?.isCritical).toBe(true);
+    });
+
+    it("should add new application if not in list", () => {
+      const view = new AccessReportView();
+      view.applications = [];
+
+      view.markApplicationsAsCritical(["github.com"]);
+
+      expect(view.applications).toHaveLength(1);
+      expect(view.applications[0].applicationName).toBe("github.com");
+      expect(view.applications[0].isCritical).toBe(true);
+    });
+
+    it("should trigger summary recomputation once for multiple apps", () => {
+      const view = new AccessReportView();
+      view.memberRegistry = createMemberRegistry([
+        { id: "u1", name: "Alice", email: "alice@example.com" },
+      ]);
+      view.reports = [
+        createReport("github.com", { u1: true }, { c1: true }),
+        createReport("gitlab.com", { u1: true }, { c2: true }),
+      ];
+      view.applications = [
+        createApplication("github.com", false),
+        createApplication("gitlab.com", false),
+      ];
+
+      view.markApplicationsAsCritical(["github.com", "gitlab.com"]);
+
+      expect(view.summary.totalCriticalApplicationCount).toBe(2);
+    });
+  });
+
+  describe("unmarkApplicationsAsCritical", () => {
+    it("should unmark existing application as critical", () => {
+      const view = new AccessReportView();
+      view.applications = [createApplication("github.com", true)];
+      view.reports = [createReport("github.com", {}, {})];
+
+      view.unmarkApplicationsAsCritical(["github.com"]);
+
+      const app = view.applications.find((a) => a.applicationName === "github.com");
+      expect(app?.isCritical).toBe(false);
+    });
+
+    it("should unmark multiple applications in a single operation", () => {
+      const view = new AccessReportView();
+      view.applications = [
+        createApplication("github.com", true),
+        createApplication("gitlab.com", true),
+      ];
+      view.reports = [createReport("github.com", {}, {}), createReport("gitlab.com", {}, {})];
+
+      view.unmarkApplicationsAsCritical(["github.com", "gitlab.com"]);
+
+      expect(view.applications.find((a) => a.applicationName === "github.com")?.isCritical).toBe(
+        false,
+      );
+      expect(view.applications.find((a) => a.applicationName === "gitlab.com")?.isCritical).toBe(
+        false,
+      );
+    });
+
+    it("should trigger summary recomputation when application exists", () => {
+      const view = new AccessReportView();
+      view.memberRegistry = createMemberRegistry([
+        { id: "u1", name: "Alice", email: "alice@example.com" },
+      ]);
+      view.reports = [createReport("github.com", { u1: true }, { c1: true })];
+      view.applications = [createApplication("github.com", true)];
+
+      view.unmarkApplicationsAsCritical(["github.com"]);
+
+      expect(view.summary.totalCriticalApplicationCount).toBe(0);
+    });
+
+    it("should do nothing if application not found", () => {
+      const view = new AccessReportView();
+      view.applications = [];
+
+      view.unmarkApplicationsAsCritical(["github.com"]);
+
+      expect(view.applications).toHaveLength(0);
+    });
+  });
+
+  describe("markApplicationAsReviewed", () => {
+    it("should mark existing application as reviewed with current date", () => {
+      const view = new AccessReportView();
+      view.applications = [createApplication("github.com", false)];
+
+      const beforeDate = new Date();
+      view.markApplicationAsReviewed("github.com");
+      const afterDate = new Date();
+
+      const app = view.applications.find((a) => a.applicationName === "github.com");
+      expect(app?.reviewedDate).toBeDefined();
+      expect(app!.reviewedDate!.getTime()).toBeGreaterThanOrEqual(beforeDate.getTime());
+      expect(app!.reviewedDate!.getTime()).toBeLessThanOrEqual(afterDate.getTime());
+    });
+
+    it("should mark application with specific date", () => {
+      const view = new AccessReportView();
+      view.applications = [createApplication("github.com", false)];
+
+      const specificDate = new Date("2024-01-15");
+      view.markApplicationAsReviewed("github.com", specificDate);
+
+      const app = view.applications.find((a) => a.applicationName === "github.com");
+      expect(app?.reviewedDate).toEqual(specificDate);
+    });
+
+    it("should add new application if not in list", () => {
+      const view = new AccessReportView();
+      view.applications = [];
+
+      view.markApplicationAsReviewed("github.com");
+
+      expect(view.applications).toHaveLength(1);
+      expect(view.applications[0].applicationName).toBe("github.com");
+      expect(view.applications[0].reviewedDate).toBeDefined();
+    });
+
+    it("should not trigger summary recomputation", () => {
+      const view = new AccessReportView();
+      view.applications = [createApplication("github.com", false)];
+
+      // Manually set summary to verify it doesn't change
+      view.summary.totalApplicationCount = 99;
+
+      view.markApplicationAsReviewed("github.com");
+
+      // Summary should remain unchanged
+      expect(view.summary.totalApplicationCount).toBe(99);
+    });
+  });
+
+  // ==================== Computation Methods ====================
+
+  describe("recomputeSummary", () => {
+    it("should compute total counts correctly", () => {
+      const view = new AccessReportView();
+      view.memberRegistry = createMemberRegistry([
+        { id: "u1", name: "Alice", email: "alice@example.com" },
+        { id: "u2", name: "Bob", email: "bob@example.com" },
+      ]);
+
+      view.reports = [
+        createReport("github.com", { u1: true, u2: false }, { c1: true, c2: false }),
+        createReport("gitlab.com", { u2: false }, { c3: false }),
+      ];
+
+      view.applications = [];
+
+      view.recomputeSummary();
+
+      expect(view.summary.totalMemberCount).toBe(2);
+      expect(view.summary.totalApplicationCount).toBe(2);
+      expect(view.summary.totalAtRiskApplicationCount).toBe(1); // github.com has at-risk cipher
+      expect(view.summary.totalAtRiskMemberCount).toBe(1); // u1
+    });
+
+    it("should deduplicate at-risk members across applications", () => {
+      const view = new AccessReportView();
+      view.memberRegistry = createMemberRegistry([
+        { id: "u1", name: "Alice", email: "alice@example.com" },
+      ]);
+
+      view.reports = [
+        createReport("github.com", { u1: true }, { c1: true }),
+        createReport("gitlab.com", { u1: true }, { c2: true }),
+      ];
+
+      view.applications = [];
+
+      view.recomputeSummary();
+
+      expect(view.summary.totalAtRiskMemberCount).toBe(1); // u1 counted once
+    });
+
+    it("should compute critical application counts", () => {
+      const view = new AccessReportView();
+      view.memberRegistry = createMemberRegistry([
+        { id: "u1", name: "Alice", email: "alice@example.com" },
+        { id: "u2", name: "Bob", email: "bob@example.com" },
+      ]);
+
+      view.reports = [
+        createReport("github.com", { u1: true }, { c1: true }),
+        createReport("gitlab.com", { u2: false }, { c2: false }),
+      ];
+
+      view.applications = [
+        createApplication("github.com", true),
+        createApplication("gitlab.com", true),
+      ];
+
+      view.recomputeSummary();
+
+      expect(view.summary.totalCriticalApplicationCount).toBe(2);
+      expect(view.summary.totalCriticalAtRiskApplicationCount).toBe(1); // github.com
+      expect(view.summary.totalCriticalMemberCount).toBe(2); // u1 and u2
+      expect(view.summary.totalCriticalAtRiskMemberCount).toBe(1); // u1
+    });
+
+    it("should handle empty reports and applications", () => {
+      const view = new AccessReportView();
+      view.memberRegistry = {};
+      view.reports = [];
+      view.applications = [];
+
+      view.recomputeSummary();
+
+      expect(view.summary.totalMemberCount).toBe(0);
+      expect(view.summary.totalApplicationCount).toBe(0);
+      expect(view.summary.totalAtRiskApplicationCount).toBe(0);
+      expect(view.summary.totalAtRiskMemberCount).toBe(0);
+      expect(view.summary.totalCriticalApplicationCount).toBe(0);
+      expect(view.summary.totalCriticalAtRiskApplicationCount).toBe(0);
+      expect(view.summary.totalCriticalMemberCount).toBe(0);
+      expect(view.summary.totalCriticalAtRiskMemberCount).toBe(0);
+    });
+  });
+
+  describe("toMetrics", () => {
+    it("should compute complete metrics including password counts", () => {
+      const view = new AccessReportView();
+      view.memberRegistry = createMemberRegistry([
+        { id: "u1", name: "Alice", email: "alice@example.com" },
+        { id: "u2", name: "Bob", email: "bob@example.com" },
+      ]);
+
+      view.reports = [
+        createReport("github.com", { u1: true }, { c1: true, c2: false, c3: true }), // 3 passwords, 2 at-risk
+        createReport("gitlab.com", { u2: false }, { c4: false, c5: false }), // 2 passwords, 0 at-risk
+      ];
+
+      view.applications = [
+        createApplication("github.com", true), // Critical
+        createApplication("gitlab.com", false), // Not critical
+      ];
+
+      view.recomputeSummary(); // Compute summary first
+
+      const metrics = view.toMetrics();
+
+      // Summary counts (copied from summary)
+      expect(metrics.totalMemberCount).toBe(2);
+      expect(metrics.totalAtRiskMemberCount).toBe(1); // u1
+      expect(metrics.totalApplicationCount).toBe(2);
+      expect(metrics.totalAtRiskApplicationCount).toBe(1); // github.com
+      expect(metrics.totalCriticalApplicationCount).toBe(1); // github.com
+      expect(metrics.totalCriticalAtRiskApplicationCount).toBe(1); // github.com
+      expect(metrics.totalCriticalMemberCount).toBe(1); // u1
+      expect(metrics.totalCriticalAtRiskMemberCount).toBe(1); // u1
+
+      // Password counts (computed from reports)
+      expect(metrics.totalPasswordCount).toBe(5); // 3 + 2
+      expect(metrics.totalAtRiskPasswordCount).toBe(2); // 2 + 0
+      expect(metrics.totalCriticalPasswordCount).toBe(3); // github.com only
+      expect(metrics.totalCriticalAtRiskPasswordCount).toBe(2); // github.com at-risk only
+    });
+
+    it("should compute metrics with no critical applications", () => {
+      const view = new AccessReportView();
+      view.memberRegistry = createMemberRegistry([
+        { id: "u1", name: "Alice", email: "alice@example.com" },
+      ]);
+
+      view.reports = [
+        createReport("github.com", { u1: true }, { c1: true, c2: true }), // 2 passwords, 2 at-risk
+      ];
+
+      view.applications = [
+        createApplication("github.com", false), // Not critical
+      ];
+
+      view.recomputeSummary();
+
+      const metrics = view.toMetrics();
+
+      expect(metrics.totalPasswordCount).toBe(2);
+      expect(metrics.totalAtRiskPasswordCount).toBe(2);
+      expect(metrics.totalCriticalPasswordCount).toBe(0); // No critical apps
+      expect(metrics.totalCriticalAtRiskPasswordCount).toBe(0); // No critical apps
+    });
+
+    it("should compute metrics with all critical applications", () => {
+      const view = new AccessReportView();
+      view.memberRegistry = createMemberRegistry([
+        { id: "u1", name: "Alice", email: "alice@example.com" },
+        { id: "u2", name: "Bob", email: "bob@example.com" },
+      ]);
+
+      view.reports = [
+        createReport("github.com", { u1: true }, { c1: true, c2: false }), // 2 passwords, 1 at-risk
+        createReport("gitlab.com", { u2: true }, { c3: true }), // 1 password, 1 at-risk
+      ];
+
+      view.applications = [
+        createApplication("github.com", true),
+        createApplication("gitlab.com", true),
+      ];
+
+      view.recomputeSummary();
+
+      const metrics = view.toMetrics();
+
+      expect(metrics.totalPasswordCount).toBe(3); // 2 + 1
+      expect(metrics.totalAtRiskPasswordCount).toBe(2); // 1 + 1
+      expect(metrics.totalCriticalPasswordCount).toBe(3); // All apps are critical
+      expect(metrics.totalCriticalAtRiskPasswordCount).toBe(2); // All apps are critical
+    });
+
+    it("should handle empty reports and applications", () => {
+      const view = new AccessReportView();
+      view.memberRegistry = {};
+      view.reports = [];
+      view.applications = [];
+
+      view.recomputeSummary();
+
+      const metrics = view.toMetrics();
+
+      expect(metrics.totalPasswordCount).toBe(0);
+      expect(metrics.totalAtRiskPasswordCount).toBe(0);
+      expect(metrics.totalCriticalPasswordCount).toBe(0);
+      expect(metrics.totalCriticalAtRiskPasswordCount).toBe(0);
+      expect(metrics.totalMemberCount).toBe(0);
+      expect(metrics.totalAtRiskMemberCount).toBe(0);
+      expect(metrics.totalApplicationCount).toBe(0);
+      expect(metrics.totalAtRiskApplicationCount).toBe(0);
+    });
+
+    it("should compute metrics with applications not in report", () => {
+      const view = new AccessReportView();
+      view.memberRegistry = createMemberRegistry([
+        { id: "u1", name: "Alice", email: "alice@example.com" },
+      ]);
+
+      view.reports = [
+        createReport("github.com", { u1: true }, { c1: true }), // 1 password, 1 at-risk
+      ];
+
+      view.applications = [
+        createApplication("github.com", true),
+        createApplication("gitlab.com", true), // Marked critical but not in reports
+      ];
+
+      view.recomputeSummary();
+
+      const metrics = view.toMetrics();
+
+      expect(metrics.totalPasswordCount).toBe(1);
+      expect(metrics.totalAtRiskPasswordCount).toBe(1);
+      expect(metrics.totalCriticalPasswordCount).toBe(1); // Only github.com has passwords
+      expect(metrics.totalCriticalAtRiskPasswordCount).toBe(1);
+    });
+  });
+
+  // ==================== Serialization ====================
+
+  describe("fromJSON", () => {
+    it("should initialize nested objects", () => {
+      const input = createRiskInsights({
+        id: "report-123" as OrganizationReportId,
+        organizationId: "org-456" as OrganizationId,
+        reports: [createReport("github.com", { u1: true }, { c1: true })],
+        applications: [createApplication("github.com", true)],
+        memberRegistry: createMemberRegistry([
+          { id: "u1", name: "Alice", email: "alice@example.com" },
+        ]),
+        summary: createRiskInsightsSummary({
+          totalMemberCount: 1,
+          totalApplicationCount: 1,
+          totalAtRiskMemberCount: 1,
+          totalAtRiskApplicationCount: 1,
+          totalCriticalApplicationCount: 1,
+          totalCriticalMemberCount: 1,
+          totalCriticalAtRiskMemberCount: 1,
+          totalCriticalAtRiskApplicationCount: 1,
+        }),
+      });
+
+      const view = AccessReportView.fromJSON(JSON.parse(JSON.stringify(input)));
+
+      expect(view.id).toBe("report-123");
+      expect(view.organizationId).toBe("org-456");
+      expect(view.reports).toHaveLength(1);
+      expect(view.reports[0]).toBeInstanceOf(ApplicationHealthView);
+      expect(view.applications).toHaveLength(1);
+      expect(view.applications[0]).toBeInstanceOf(AccessReportSettingsView);
+      expect(view.memberRegistry["u1"]).toBeInstanceOf(MemberRegistryEntryView);
+      expect(view.memberRegistry["u1"].id).toBe("u1");
+      expect(view.memberRegistry["u1"].userName).toBe("Alice");
+      expect(view.memberRegistry["u1"].email).toBe("alice@example.com");
+    });
+
+    it("should handle null input", () => {
+      const view = AccessReportView.fromJSON(null as any);
+
+      expect(view).toBeInstanceOf(AccessReportView);
+      expect(view.reports).toEqual([]);
+      expect(view.applications).toEqual([]);
+      expect(view.memberRegistry).toEqual({});
+    });
+
+    it("should handle undefined input", () => {
+      const view = AccessReportView.fromJSON(undefined as any);
+
+      expect(view).toBeInstanceOf(AccessReportView);
+      expect(view.reports).toEqual([]);
+      expect(view.applications).toEqual([]);
+      expect(view.memberRegistry).toEqual({});
+    });
+  });
+});

--- a/bitwarden_license/bit-common/src/dirt/access-intelligence/models/view/application-health.view.spec.ts
+++ b/bitwarden_license/bit-common/src/dirt/access-intelligence/models/view/application-health.view.spec.ts
@@ -1,0 +1,335 @@
+import {
+  createMemberRegistry,
+  createReport,
+} from "../../../reports/risk-insights/testing/test-helpers";
+import { ApplicationHealthData } from "../data/application-health.data";
+
+import { ApplicationHealthView } from "./application-health.view";
+
+describe("ApplicationHealthView", () => {
+  // Test helpers imported from shared testing utilities
+
+  // Local helper with specific signature for this test file
+  const createReportWithCounts = (
+    memberRefs: Record<string, boolean>,
+    cipherRefs: Record<string, boolean>,
+    atRiskPasswordCount: number,
+  ): ApplicationHealthView => {
+    const report = createReport("test-app", memberRefs, cipherRefs);
+    report.atRiskPasswordCount = atRiskPasswordCount; // Override if needed
+    return report;
+  };
+
+  // ==================== Member Methods ====================
+
+  describe("getAllMembers", () => {
+    it("should return all members for the application", () => {
+      const registry = createMemberRegistry([
+        { id: "u1", name: "Alice", email: "alice@example.com" },
+        { id: "u2", name: "Bob", email: "bob@example.com" },
+        { id: "u3", name: "Charlie", email: "charlie@example.com" },
+      ]);
+
+      const report = createReportWithCounts({ u1: true, u2: false }, {}, 0);
+
+      const members = report.getAllMembers(registry);
+
+      expect(members).toHaveLength(2);
+      expect(members.map((m) => m.id).sort()).toEqual(["u1", "u2"]);
+    });
+
+    it("should filter out members not in registry", () => {
+      const registry = createMemberRegistry([
+        { id: "u1", name: "Alice", email: "alice@example.com" },
+      ]);
+
+      const report = createReportWithCounts({ u1: true, u999: false }, {}, 0);
+
+      const members = report.getAllMembers(registry);
+
+      expect(members).toHaveLength(1);
+      expect(members[0].id).toBe("u1");
+    });
+
+    it("should return empty array when no members", () => {
+      const registry = createMemberRegistry([]);
+      const report = createReportWithCounts({}, {}, 0);
+
+      const members = report.getAllMembers(registry);
+
+      expect(members).toHaveLength(0);
+    });
+  });
+
+  describe("getAtRiskMembers", () => {
+    it("should return only at-risk members", () => {
+      const registry = createMemberRegistry([
+        { id: "u1", name: "Alice", email: "alice@example.com" },
+        { id: "u2", name: "Bob", email: "bob@example.com" },
+        { id: "u3", name: "Charlie", email: "charlie@example.com" },
+      ]);
+
+      const report = createReportWithCounts({ u1: true, u2: false, u3: true }, {}, 0);
+
+      const atRiskMembers = report.getAtRiskMembers(registry);
+
+      expect(atRiskMembers).toHaveLength(2);
+      expect(atRiskMembers.map((m) => m.id).sort()).toEqual(["u1", "u3"]);
+    });
+
+    it("should filter out members not in registry", () => {
+      const registry = createMemberRegistry([
+        { id: "u1", name: "Alice", email: "alice@example.com" },
+      ]);
+
+      const report = createReportWithCounts({ u1: true, u999: true }, {}, 0);
+
+      const atRiskMembers = report.getAtRiskMembers(registry);
+
+      expect(atRiskMembers).toHaveLength(1);
+      expect(atRiskMembers[0].id).toBe("u1");
+    });
+
+    it("should return empty array when no at-risk members", () => {
+      const registry = createMemberRegistry([
+        { id: "u1", name: "Alice", email: "alice@example.com" },
+      ]);
+
+      const report = createReportWithCounts({ u1: false }, {}, 0);
+
+      const atRiskMembers = report.getAtRiskMembers(registry);
+
+      expect(atRiskMembers).toHaveLength(0);
+    });
+  });
+
+  describe("hasMember", () => {
+    it("should return true if member has access", () => {
+      const report = createReportWithCounts({ u1: true, u2: false }, {}, 0);
+
+      expect(report.hasMember("u1")).toBe(true);
+      expect(report.hasMember("u2")).toBe(true);
+    });
+
+    it("should return false if member does not have access", () => {
+      const report = createReportWithCounts({ u1: true }, {}, 0);
+
+      expect(report.hasMember("u999")).toBe(false);
+    });
+  });
+
+  describe("isMemberAtRisk", () => {
+    it("should return true if member is at-risk", () => {
+      const report = createReportWithCounts({ u1: true, u2: false }, {}, 0);
+
+      expect(report.isMemberAtRisk("u1")).toBe(true);
+    });
+
+    it("should return false if member is not at-risk", () => {
+      const report = createReportWithCounts({ u1: true, u2: false }, {}, 0);
+
+      expect(report.isMemberAtRisk("u2")).toBe(false);
+    });
+
+    it("should return false if member does not have access", () => {
+      const report = createReportWithCounts({ u1: true }, {}, 0);
+
+      expect(report.isMemberAtRisk("u999")).toBe(false);
+    });
+  });
+
+  // ==================== Cipher Methods ====================
+
+  describe("getAllCipherIds", () => {
+    it("should return all cipher IDs", () => {
+      const report = createReportWithCounts({}, { c1: true, c2: false, c3: true }, 2);
+
+      const cipherIds = report.getAllCipherIds();
+
+      expect(cipherIds).toHaveLength(3);
+      expect(cipherIds.sort()).toEqual(["c1", "c2", "c3"]);
+    });
+
+    it("should return empty array when no ciphers", () => {
+      const report = createReportWithCounts({}, {}, 0);
+
+      const cipherIds = report.getAllCipherIds();
+
+      expect(cipherIds).toHaveLength(0);
+    });
+  });
+
+  describe("getAtRiskCipherIds", () => {
+    it("should return only at-risk cipher IDs", () => {
+      const report = createReportWithCounts({}, { c1: true, c2: false, c3: true }, 2);
+
+      const atRiskCipherIds = report.getAtRiskCipherIds();
+
+      expect(atRiskCipherIds).toHaveLength(2);
+      expect(atRiskCipherIds.sort()).toEqual(["c1", "c3"]);
+    });
+
+    it("should return empty array when no at-risk ciphers", () => {
+      const report = createReportWithCounts({}, { c1: false, c2: false }, 0);
+
+      const atRiskCipherIds = report.getAtRiskCipherIds();
+
+      expect(atRiskCipherIds).toHaveLength(0);
+    });
+  });
+
+  // ==================== At-Risk Check ====================
+
+  describe("isAtRisk", () => {
+    it("should return true when application has at-risk passwords", () => {
+      const report = createReportWithCounts({}, { c1: true }, 1);
+
+      expect(report.isAtRisk()).toBe(true);
+    });
+
+    it("should return false when application has no at-risk passwords", () => {
+      const report = createReportWithCounts({}, { c1: false }, 0);
+
+      expect(report.isAtRisk()).toBe(false);
+    });
+
+    it("should return false when atRiskPasswordCount is 0", () => {
+      const report = new ApplicationHealthView();
+      report.atRiskPasswordCount = 0;
+
+      expect(report.isAtRisk()).toBe(false);
+    });
+  });
+
+  // ==================== Factory Methods ====================
+
+  describe("fromData", () => {
+    it("should map all standard fields from ApplicationHealthData", () => {
+      const data = new ApplicationHealthData();
+      data.applicationName = "github.com";
+      data.passwordCount = 10;
+      data.atRiskPasswordCount = 3;
+      data.memberRefs = { u1: true, u2: false };
+      data.cipherRefs = { c1: true, c2: false, c3: false };
+      data.memberCount = 2;
+      data.atRiskMemberCount = 1;
+
+      const view = ApplicationHealthView.fromData(data);
+
+      expect(view).toBeInstanceOf(ApplicationHealthView);
+      expect(view.applicationName).toBe("github.com");
+      expect(view.passwordCount).toBe(10);
+      expect(view.atRiskPasswordCount).toBe(3);
+      expect(view.memberRefs).toEqual({ u1: true, u2: false });
+      expect(view.cipherRefs).toEqual({ c1: true, c2: false, c3: false });
+      expect(view.memberCount).toBe(2);
+      expect(view.atRiskMemberCount).toBe(1);
+    });
+
+    it("should create independent copies of memberRefs and cipherRefs", () => {
+      const data = new ApplicationHealthData();
+      data.memberRefs = { u1: true };
+      data.cipherRefs = { c1: false };
+
+      const view = ApplicationHealthView.fromData(data);
+
+      // Mutating the view should not affect the source data
+      view.memberRefs["u2"] = false;
+      view.cipherRefs["c2"] = true;
+
+      expect(data.memberRefs).not.toHaveProperty("u2");
+      expect(data.cipherRefs).not.toHaveProperty("c2");
+    });
+
+    it("should set optional icon fields when provided", () => {
+      const data = new ApplicationHealthData();
+      data.applicationName = "app.com";
+      data.iconUri = "https://icons.example.com/app.ico";
+      data.iconCipherId = "cipher-123";
+
+      const view = ApplicationHealthView.fromData(data);
+
+      expect(view.iconUri).toBe("https://icons.example.com/app.ico");
+      expect(view.iconCipherId).toBe("cipher-123");
+    });
+
+    it("should leave icon fields undefined when not set on data", () => {
+      const data = new ApplicationHealthData();
+      data.applicationName = "app.com";
+
+      const view = ApplicationHealthView.fromData(data);
+
+      expect(view.iconUri).toBeUndefined();
+      expect(view.iconCipherId).toBeUndefined();
+    });
+  });
+
+  // ==================== Serialization ====================
+
+  describe("fromJSON", () => {
+    it("should initialize from JSON object", () => {
+      const json = {
+        applicationName: "github.com",
+        passwordCount: 10,
+        atRiskPasswordCount: 3,
+        memberRefs: { u1: true, u2: false },
+        cipherRefs: { c1: true, c2: false },
+        memberCount: 2,
+        atRiskMemberCount: 1,
+      };
+
+      const report = ApplicationHealthView.fromJSON(json);
+
+      expect(report).toBeInstanceOf(ApplicationHealthView);
+      expect(report.applicationName).toBe("github.com");
+      expect(report.passwordCount).toBe(10);
+      expect(report.atRiskPasswordCount).toBe(3);
+      expect(report.memberRefs).toEqual({ u1: true, u2: false });
+      expect(report.cipherRefs).toEqual({ c1: true, c2: false });
+      expect(report.memberCount).toBe(2);
+      expect(report.atRiskMemberCount).toBe(1);
+    });
+
+    it("should handle undefined input", () => {
+      const report = ApplicationHealthView.fromJSON(undefined);
+
+      expect(report).toBeInstanceOf(ApplicationHealthView);
+      expect(report.applicationName).toBe("");
+      expect(report.memberRefs).toEqual({});
+      expect(report.cipherRefs).toEqual({});
+    });
+
+    it("should ensure memberRefs and cipherRefs are objects when missing", () => {
+      const json = {
+        applicationName: "github.com",
+      };
+
+      const report = ApplicationHealthView.fromJSON(json);
+
+      expect(report.memberRefs).toEqual({});
+      expect(report.cipherRefs).toEqual({});
+    });
+  });
+
+  // ==================== Constructor ====================
+
+  describe("constructor", () => {
+    it("should create empty report when no parameter provided", () => {
+      const report = new ApplicationHealthView();
+
+      expect(report.applicationName).toBe("");
+      expect(report.passwordCount).toBe(0);
+      expect(report.atRiskPasswordCount).toBe(0);
+      expect(report.memberRefs).toEqual({});
+      expect(report.cipherRefs).toEqual({});
+      expect(report.memberCount).toBe(0);
+      expect(report.atRiskMemberCount).toBe(0);
+    });
+
+    it("should create report with domain model parameter", () => {
+      const report = new ApplicationHealthView(null as any);
+
+      expect(report).toBeInstanceOf(ApplicationHealthView);
+    });
+  });
+});

--- a/bitwarden_license/bit-common/src/dirt/access-intelligence/services/abstractions/access-intelligence-data.service.ts
+++ b/bitwarden_license/bit-common/src/dirt/access-intelligence/services/abstractions/access-intelligence-data.service.ts
@@ -1,0 +1,183 @@
+import { Observable } from "rxjs";
+
+import { OrganizationId } from "@bitwarden/common/types/guid";
+import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+
+import { ReportProgress } from "../../../reports/risk-insights/models/report-models";
+import { AccessReportView } from "../../models";
+
+/**
+ * Orchestrates Access Intelligence (Risk Insights) data loading, generation, and persistence.
+ *
+ * Serves as the single source of truth for report data. Components subscribe to observables
+ * for reactive state updates. Coordinates with ReportGenerationService for report creation
+ * and ReportPersistenceService for storage.
+ *
+ * Platform-agnostic service using RxJS Observables for compatibility across web, desktop,
+ * browser, and CLI clients.
+ */
+export abstract class AccessIntelligenceDataService {
+  /**
+   * Current report state (single source of truth)
+   *
+   * Emits the latest report or null if no report loaded.
+   * All UI components derive state from this observable.
+   */
+  abstract readonly report$: Observable<AccessReportView | null>;
+
+  /**
+   * Organization ciphers for display purposes
+   *
+   * Exposed for UI needs like getCipherIcon(). Loaded during report generation
+   * and stored for the current session.
+   */
+  abstract readonly ciphers$: Observable<CipherView[]>;
+
+  /**
+   * Loading state indicator
+   *
+   * True during report generation or loading operations.
+   * Components use this to show loading spinners.
+   */
+  abstract readonly loading$: Observable<boolean>;
+
+  /**
+   * Error state
+   *
+   * Emits error messages when operations fail.
+   * Null when no error present.
+   */
+  abstract readonly error$: Observable<string | null>;
+
+  /**
+   * Report generation progress
+   *
+   * Emits progress steps during report generation (FetchingMembers → Complete).
+   * Null when no generation is in progress.
+   */
+  abstract readonly reportProgress$: Observable<ReportProgress | null>;
+
+  /**
+   * Initialize service for a specific organization
+   *
+   * Loads organization data and existing report if available.
+   * Call this when user navigates to Access Intelligence page.
+   *
+   * @param orgId - Organization to initialize for
+   * @returns Observable that completes when initialization finishes
+   *
+   * @example
+   * ```typescript
+   * this.dataService.initializeForOrganization$(orgId).subscribe(() => {
+   *   console.log('Ready to display report');
+   * });
+   * ```
+   */
+  abstract initializeForOrganization$(orgId: OrganizationId): Observable<void>;
+
+  /**
+   * Generate a new report from latest organization data
+   *
+   * Loads fresh data from API, generates report, saves, and emits via report$.
+   * Carries over previous application metadata (critical flags, review dates).
+   *
+   * @param orgId - Organization to generate report for
+   * @returns Observable that completes when generation and save finish
+   *
+   * @example
+   * ```typescript
+   * this.dataService.generateNewReport$(orgId).subscribe({
+   *   next: () => console.log('Report generated'),
+   *   error: (err) => console.error('Generation failed', err)
+   * });
+   * ```
+   */
+  abstract generateNewReport$(orgId: OrganizationId): Observable<void>;
+
+  /**
+   * Load existing report from persistence
+   *
+   * Fetches saved report, decrypts, and emits via report$.
+   * Returns immediately if no report exists (report$ emits null).
+   *
+   * @param orgId - Organization to load report for
+   * @returns Observable that completes when load finishes
+   *
+   * @example
+   * ```typescript
+   * this.dataService.loadExistingReport$(orgId).subscribe(() => {
+   *   console.log('Report loaded or null emitted');
+   * });
+   * ```
+   */
+  abstract loadExistingReport$(orgId: OrganizationId): Observable<void>;
+
+  /**
+   * Refresh report with latest data
+   *
+   * Re-generates report from current organization data while preserving
+   * application metadata (critical flags, review dates).
+   *
+   * @param orgId - Organization to refresh report for
+   * @returns Observable that completes when refresh finishes
+   *
+   * @example
+   * ```typescript
+   * this.dataService.refreshReport$(orgId).subscribe(() => {
+   *   console.log('Report refreshed with latest data');
+   * });
+   * ```
+   */
+  abstract refreshReport$(orgId: OrganizationId): Observable<void>;
+
+  /**
+   * Mark one or more applications as critical in a single save operation
+   *
+   * Mutates all view models at once, recomputes the summary once, and persists
+   * once to avoid multiple round-trips.
+   * Also marks each application as reviewed if not already reviewed.
+   *
+   * @param appNames - Application names to mark as critical
+   * @returns Observable that completes when save finishes
+   *
+   * @example
+   * ```typescript
+   * this.dataService.markApplicationsAsCritical$(['github.com', 'gitlab.com']).subscribe();
+   * ```
+   */
+  abstract markApplicationsAsCritical$(appNames: string[]): Observable<void>;
+
+  /**
+   * Unmark one or more applications as critical in a single save operation
+   *
+   * Mutates all view models at once, recomputes the summary once, and persists
+   * once to avoid multiple round-trips.
+   *
+   * @param appNames - Application names to unmark as critical
+   * @returns Observable that completes when save finishes
+   *
+   * @example
+   * ```typescript
+   * this.dataService.unmarkApplicationsAsCritical$(['github.com', 'gitlab.com']).subscribe();
+   * ```
+   */
+  abstract unmarkApplicationsAsCritical$(appNames: string[]): Observable<void>;
+
+  /**
+   * Mark one or more applications as reviewed in a single save operation
+   *
+   * Mutates all view models at once and persists once to avoid multiple
+   * round-trips.
+   * Does NOT recompute summary (review status is not part of summary).
+   *
+   * @param appNames - Application names to mark as reviewed
+   * @param date - Review date (defaults to current date)
+   * @returns Observable that completes when save finishes
+   *
+   * @example
+   * ```typescript
+   * this.dataService.markApplicationsAsReviewed$(['github.com', 'gitlab.com']).subscribe();
+   * ```
+   */
+  abstract markApplicationsAsReviewed$(appNames: string[], date?: Date): Observable<void>;
+}

--- a/bitwarden_license/bit-common/src/dirt/access-intelligence/services/abstractions/cipher-health.service.ts
+++ b/bitwarden_license/bit-common/src/dirt/access-intelligence/services/abstractions/cipher-health.service.ts
@@ -1,0 +1,59 @@
+import { Observable } from "rxjs";
+
+import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+
+import { CipherHealthView } from "../../models";
+
+/**
+ * Analyzes cipher password health including weak passwords, reuse, and HIBP breaches.
+ *
+ * Platform-agnostic domain service used by ReportGenerationService.
+ */
+export abstract class CipherHealthService {
+  /**
+   * Analyzes password health for multiple ciphers.
+   *
+   * Checks all ciphers for weak passwords (zxcvbn score <= 2), password reuse,
+   * and HIBP exposure. HIBP calls are concurrency-limited (max 5 concurrent) to
+   * prevent rate limiting.
+   *
+   * @param ciphers - Array of ciphers to analyze
+   * @returns Map of cipher ID to health results for O(1) lookups
+   *
+   * @example
+   * ```typescript
+   * // In ReportGenerationService
+   * this.cipherHealthService.checkCipherHealth(ciphers).pipe(
+   *   map(healthMap => {
+   *     const atRiskCiphers = ciphers.filter(c =>
+   *       healthMap.get(c.id)?.isAtRisk()
+   *     );
+   *     return this.buildReport(ciphers, healthMap);
+   *   })
+   * )
+   * ```
+   */
+  abstract checkCipherHealth(ciphers: CipherView[]): Observable<Map<string, CipherHealthView>>;
+
+  /**
+   * Analyzes password health for a single cipher.
+   *
+   * Checks for weak password and HIBP exposure. Cannot detect password reuse
+   * without other ciphers for comparison (use checkCipherHealth for reuse detection).
+   *
+   * @param cipher - Single cipher to analyze
+   * @returns Health results for the cipher
+   */
+  abstract checkSingleCipherHealth(cipher: CipherView): Observable<CipherHealthView>;
+
+  /**
+   * Detects password reuse across all ciphers.
+   *
+   * Groups ciphers by password to identify reuse. Only returns passwords
+   * used by 2+ ciphers (unique passwords are excluded).
+   *
+   * @param ciphers - Array of ciphers to analyze
+   * @returns Map of password to array of cipher IDs sharing that password
+   */
+  abstract detectPasswordReuse(ciphers: CipherView[]): Observable<Map<string, string[]>>;
+}

--- a/bitwarden_license/bit-common/src/dirt/access-intelligence/services/abstractions/drawer-state.service.ts
+++ b/bitwarden_license/bit-common/src/dirt/access-intelligence/services/abstractions/drawer-state.service.ts
@@ -1,0 +1,74 @@
+import { Signal } from "@angular/core";
+
+/**
+ * Manages drawer UI state for Access Intelligence.
+ *
+ * This is a presentational service that only handles drawer open/close state.
+ * Drawer CONTENT is computed by components from report$ observable and view model query methods.
+ *
+ * @remarks
+ * - Angular-only service (uses Signals per ADR-0027)
+ * - No domain logic or data fetching
+ * - Components derive content via: combineLatest([toObservable(drawerState), report$]).pipe(...)
+ */
+export abstract class DrawerStateService {
+  /**
+   * Current drawer state (open, type, invokerId).
+   * Components derive content from report$ + view methods, not from this service.
+   */
+  abstract drawerState: Signal<DrawerState>;
+
+  /**
+   * Opens a drawer of the specified type.
+   * @param type - Type of drawer (OrgAtRiskMembers, AppAtRiskMembers, etc.)
+   * @param invokerId - Identifier for what triggered the drawer (e.g., card ID, app hostname)
+   */
+  abstract openDrawer(type: DrawerType, invokerId: string): void;
+
+  /**
+   * Closes the currently open drawer.
+   */
+  abstract closeDrawer(): void;
+
+  /**
+   * Toggles drawer - closes if already open with same type/invoker, opens otherwise.
+   * @param type - Type of drawer
+   * @param invokerId - Identifier for invoker
+   */
+  abstract toggleDrawer(type: DrawerType, invokerId: string): void;
+
+  /**
+   * Checks if a specific drawer type is currently active.
+   * @param type - The drawer type to check
+   */
+  abstract isActiveDrawerType(type: DrawerType): boolean;
+
+  /**
+   * Checks if drawer is open for a specific invoker.
+   * @param invokerId - The invoker ID to check
+   */
+  abstract isDrawerOpenForInvoker(invokerId: string): boolean;
+}
+
+/**
+ * Drawer types for Access Intelligence drawers.
+ */
+export const DrawerType = Object.freeze({
+  None: 0,
+  OrgAtRiskMembers: 1,
+  AppAtRiskMembers: 2,
+  OrgAtRiskApps: 3,
+  CriticalAtRiskMembers: 4,
+  CriticalAtRiskApps: 5,
+} as const);
+export type DrawerType = (typeof DrawerType)[keyof typeof DrawerType];
+
+/**
+ * State object for drawer.
+ * Includes open status, type, and invoker ID (what triggered the drawer).
+ */
+export interface DrawerState {
+  open: boolean;
+  type: DrawerType;
+  invokerId: string;
+}

--- a/bitwarden_license/bit-common/src/dirt/access-intelligence/services/abstractions/member-cipher-mapping.service.ts
+++ b/bitwarden_license/bit-common/src/dirt/access-intelligence/services/abstractions/member-cipher-mapping.service.ts
@@ -1,0 +1,164 @@
+import { Observable } from "rxjs";
+
+import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+
+import { MemberRegistry } from "../../models";
+
+/**
+ * Organization User View (simplified interface for type safety)
+ *
+ * This represents an organization member. The actual OrganizationUserView
+ * may have additional fields, but we only need these for member mapping.
+ */
+export interface OrganizationUserView {
+  id: string; // Organization user ID (userGuid)
+  name: string | null;
+  email: string;
+}
+
+/**
+ * Group View (simplified interface for type safety)
+ *
+ * Represents an organization group that can be assigned to collections.
+ */
+export interface GroupView {
+  id: string;
+  name: string;
+}
+
+/**
+ * Collection Access Details
+ *
+ * Defines which users and groups have access to a collection.
+ * Used to resolve cipher-to-member relationships.
+ */
+export interface CollectionAccessDetails {
+  collectionId: string;
+  users: Set<string>; // Organization user IDs
+  groups: Set<string>; // Group IDs
+}
+
+/**
+ * Group Membership Details
+ *
+ * Defines which users are members of a group.
+ */
+export interface GroupMembershipDetails {
+  groupId: string;
+  users: Set<string>; // Organization user IDs
+}
+
+/**
+ * Member Cipher Mapping Result
+ *
+ * Contains the cipher-to-member mapping and deduplicated member registry.
+ */
+export interface MemberCipherMappingResult {
+  /**
+   * Mapping from cipher ID to array of organization user IDs
+   *
+   * For each cipher, this contains the list of members who have access
+   * to it via collections and groups.
+   */
+  mapping: Map<string, string[]>;
+
+  /**
+   * Deduplicated member registry
+   *
+   * Contains each unique member once, eliminating duplication across
+   * applications. Members are referenced by ID from the mapping.
+   */
+  registry: MemberRegistry;
+}
+
+/**
+ * Maps ciphers to organization members via collections and groups (client-side).
+ *
+ * This is a pure transformation service - it takes already-loaded organization data
+ * and computes which members have access to which ciphers based on collection and
+ * group assignments. No API calls are made.
+ *
+ * **Replaces:** Server-side `getMemberCipherDetails` API endpoint that was timing out
+ * for large organizations.
+ *
+ * **Performance:** For a 10K member org, reduces report size from ~786MB to ~150MB
+ * by eliminating duplicate member objects across applications (81% reduction).
+ *
+ * Platform-agnostic domain service used by ReportGenerationService.
+ */
+export abstract class MemberCipherMappingService {
+  /**
+   * Maps ciphers to organization members via collection and group resolution.
+   *
+   * **Resolution Logic:**
+   * 1. For each cipher, find collections it belongs to (cipher.collectionIds)
+   * 2. For each collection, find:
+   *    - Users directly assigned to the collection
+   *    - Groups assigned to the collection
+   * 3. For each group, find all users who are members of that group
+   * 4. Deduplicate all found users for each cipher
+   * 5. Build member registry containing each unique member once
+   *
+   * **Important:** This is a pure transformation. The orchestrator (ReportGenerationService)
+   * is responsible for fetching org data (members, groups, collections). This service
+   * only computes the mapping from the provided data.
+   *
+   * @param ciphers - Organization ciphers to map
+   * @param members - Organization users/members
+   * @param collectionAccess - Collection access details (which users/groups can access each collection)
+   * @param groupMemberships - Group membership details (which users are in each group)
+   * @returns Observable of mapping result with cipher-to-member mapping and member registry
+   *
+   * @example
+   * ```typescript
+   * // In ReportGenerationService
+   * forkJoin({
+   *   ciphers: this.cipherService.getAllDecrypted(),
+   *   members: this.organizationService.getMembers(orgId),
+   *   collectionAccess: this.getCollectionAccess(orgId),
+   *   groupMemberships: this.getGroupMemberships(orgId),
+   * }).pipe(
+   *   switchMap(({ ciphers, members, collectionAccess, groupMemberships }) =>
+   *     this.memberMappingService.mapCiphersToMembers(
+   *       ciphers,
+   *       members,
+   *       collectionAccess,
+   *       groupMemberships
+   *     )
+   *   ),
+   *   map(({ mapping, registry }) => {
+   *     // Use mapping to build application reports
+   *     // Use registry for member lookup by ID
+   *   })
+   * )
+   * ```
+   */
+  abstract mapCiphersToMembers(
+    ciphers: CipherView[],
+    members: OrganizationUserView[],
+    collectionAccess: CollectionAccessDetails[],
+    groupMemberships: GroupMembershipDetails[],
+  ): Observable<MemberCipherMappingResult>;
+
+  /**
+   * Builds a member registry from an array of members.
+   *
+   * Utility method to create a deduplicated member registry. This can be used
+   * independently of the full cipher mapping when you only need to deduplicate
+   * members without computing cipher relationships.
+   *
+   * @param members - Organization users/members to add to registry
+   * @returns Observable of member registry
+   *
+   * @example
+   * ```typescript
+   * this.memberMappingService.buildMemberRegistry(allMembers).pipe(
+   *   map(registry => {
+   *     console.log(`Registry size: ${registry.size()}`);
+   *     const alice = registry.get("user-id-123");
+   *   })
+   * )
+   * ```
+   */
+  abstract buildMemberRegistry(members: OrganizationUserView[]): Observable<MemberRegistry>;
+}

--- a/bitwarden_license/bit-common/src/dirt/access-intelligence/services/abstractions/report-generation.service.ts
+++ b/bitwarden_license/bit-common/src/dirt/access-intelligence/services/abstractions/report-generation.service.ts
@@ -1,0 +1,56 @@
+import { Observable } from "rxjs";
+
+import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+
+import { AccessReportSettingsView, AccessReportView } from "../../models";
+
+import {
+  CollectionAccessDetails,
+  GroupMembershipDetails,
+  OrganizationUserView,
+} from "./member-cipher-mapping.service";
+
+/**
+ * Generates Risk Insights reports from pre-loaded organization data.
+ *
+ * Orchestrates health checks, member mapping, aggregation, and summary computation
+ * to produce a complete AccessReportView. Does NOT handle data loading or persistence.
+ *
+ * Platform-agnostic domain service used by AccessIntelligenceDataService.
+ */
+export abstract class ReportGenerationService {
+  /**
+   * Generates a new Risk Insights report from organization data.
+   *
+   * Runs health checks on ciphers, maps ciphers to members via collections and groups,
+   * aggregates into per-application reports, carries over application metadata from
+   * the previous report, and computes summary statistics.
+   *
+   * @param ciphers - Organization ciphers to analyze
+   * @param members - Organization members/users
+   * @param collectionAccess - Collection access details (which users/groups can access each collection)
+   * @param groupMemberships - Group membership details (which users are in each group)
+   * @param previousApplications - Previous application metadata to preserve critical flags and review dates
+   * @returns Observable of complete AccessReportView ready for persistence
+   *
+   * @example
+   * ```typescript
+   * // In AccessIntelligenceDataService
+   * const ciphers = await this.cipherService.getAllFromApiForOrganization(orgId);
+   * const members = await this.organizationService.getOrganizationUsers(orgId);
+   * // ... load collections and groups, transform to access details
+   *
+   * this.reportGenerationService
+   *   .generateReport(ciphers, members, collectionAccess, groupMemberships, previousApps)
+   *   .pipe(switchMap(report => this.persistenceService.save(report)))
+   *   .subscribe();
+   * ```
+   */
+  abstract generateReport(
+    ciphers: CipherView[],
+    members: OrganizationUserView[],
+    collectionAccess: CollectionAccessDetails[],
+    groupMemberships: GroupMembershipDetails[],
+    previousApplications?: AccessReportSettingsView[],
+  ): Observable<AccessReportView>;
+}

--- a/bitwarden_license/bit-common/src/dirt/access-intelligence/services/abstractions/report-persistence.service.ts
+++ b/bitwarden_license/bit-common/src/dirt/access-intelligence/services/abstractions/report-persistence.service.ts
@@ -1,0 +1,86 @@
+import { Observable } from "rxjs";
+
+import { EncString } from "@bitwarden/common/key-management/crypto/models/enc-string";
+import { OrganizationId, OrganizationReportId } from "@bitwarden/common/types/guid";
+
+import { AccessReportView } from "../../models";
+
+/**
+ * Service for persisting Risk Insights reports with backend flexibility.
+ *
+ * Handles encryption, compression, and storage coordination. The abstract
+ * interface stays stable while implementations can vary (DB, blob storage, etc.).
+ *
+ * Platform-agnostic domain service used by AccessIntelligenceDataService.
+ */
+export abstract class ReportPersistenceService {
+  /**
+   * Save a complete report (payload + metadata + summary)
+   *
+   * Encrypts and compresses the full report, then saves to the configured
+   * storage backend. Computes metrics from view using view.toMetrics().
+   *
+   * @param view - View model containing decrypted report data
+   * @param organizationId - Organization this report belongs to
+   * @returns Observable emitting server-assigned report ID
+   *
+   * @example
+   * ```typescript
+   * this.persistenceService.saveReport$(generatedReport, orgId).subscribe((reportId) => {
+   *   generatedReport.id = reportId;
+   *   console.log('Saved:', reportId);
+   * });
+   * ```
+   */
+  abstract saveReport$(
+    view: AccessReportView,
+    organizationId: OrganizationId,
+  ): Observable<{ id: OrganizationReportId; contentEncryptionKey: EncString }>;
+
+  /**
+   * Update application metadata (critical flags, review dates) and summary
+   *
+   * Called after user mutates the report via view model methods.
+   * The view model handles business logic and recomputes the summary,
+   * this service encrypts and persists the updated state. Computes metrics
+   * from view using view.toMetrics().
+   *
+   * @param view - Updated view model with mutated applications/summary
+   * @returns Observable that completes when update finishes
+   *
+   * @example
+   * ```typescript
+   * report.markApplicationAsCritical('github.com');
+   * this.persistenceService.saveApplicationMetadata$(report).subscribe();
+   * ```
+   */
+  abstract saveApplicationMetadata$(view: AccessReportView): Observable<void>;
+
+  /**
+   * Load the latest report for an organization
+   *
+   * Fetches from storage backend, decrypts, decompresses, and assembles
+   * into a complete AccessReportView. Returns null if no report exists.
+   *
+   * The `hadLegacyBlobs` flag is `true` when the loaded report contained any V1-format
+   * blobs that were inline-converted to V2 during decryption. Callers should re-save the
+   * report when this flag is set so the stored blobs are upgraded to V2 format.
+   *
+   * @param organizationId - Organization to load report for
+   * @returns Observable emitting `{ report, hadLegacyBlobs }`, or null if none exists
+   *
+   * @example
+   * ```typescript
+   * this.persistenceService.loadReport$(orgId).subscribe((result) => {
+   *   if (result) {
+   *     console.log('Loaded:', result.report.id, 'legacy blobs:', result.hadLegacyBlobs);
+   *   } else {
+   *     console.log('No report, generate new one');
+   *   }
+   * });
+   * ```
+   */
+  abstract loadReport$(
+    organizationId: OrganizationId,
+  ): Observable<{ report: AccessReportView; hadLegacyBlobs: boolean } | null>;
+}

--- a/bitwarden_license/bit-common/src/dirt/access-intelligence/services/abstractions/versioning.service.ts
+++ b/bitwarden_license/bit-common/src/dirt/access-intelligence/services/abstractions/versioning.service.ts
@@ -1,0 +1,104 @@
+/**
+ * A versioned envelope that wraps any encrypted blob payload.
+ *
+ * Separates envelope metadata (version) from payload content (data), so that:
+ * - Validators only receive payload data — never envelope metadata
+ * - Version routing is handled before payload validation
+ * - Legacy (unversioned) blobs are detected by the absence of this envelope shape
+ *
+ * @example
+ * // On-disk format:
+ * { "version": 1, "data": { "reports": [...], "memberRegistry": {...} } }
+ *
+ * // Detection:
+ * if (isVersionEnvelope(json)) { ... } // versioned
+ * else { ... }                         // legacy (unversioned)
+ */
+export interface VersionEnvelope<T> {
+  version: number;
+  data: T;
+}
+
+/**
+ * Returns true if `value` matches the `VersionEnvelope` shape:
+ * a plain object with a numeric `version` field and a `data` field.
+ *
+ * Returns false for legacy (unversioned) blobs — arrays, plain flat objects, null, etc.
+ */
+export function isVersionEnvelope(value: unknown): value is VersionEnvelope<unknown> {
+  if (value == null || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  const obj = value as Record<string, unknown>;
+  return typeof obj["version"] === "number" && "data" in obj;
+}
+
+/**
+ * Thrown when an encrypted blob carries an unrecognized version number.
+ *
+ * Unversioned (legacy) blobs are transformed inline and do not throw this error.
+ * This error is only thrown when a version number is present but not handled —
+ * meaning the application may need to be updated.
+ */
+export class UnsupportedVersionError extends Error {
+  constructor(readonly foundVersion: number | undefined) {
+    super(
+      foundVersion === undefined
+        ? "Version not supported."
+        : `Version ${foundVersion} is not supported. The application may need to be updated.`,
+    );
+    this.name = "UnsupportedVersionError";
+  }
+}
+
+/**
+ * Handles format versioning for a single encrypted blob type.
+ *
+ * Responsibilities:
+ * - Detect versioned (`VersionEnvelope`) vs legacy (unversioned) format
+ * - Validate and return the typed payload from an envelope
+ * - Transform legacy blobs inline to the current payload shape
+ * - Serialize a typed payload to a JSON string for encryption
+ *
+ * This service has no knowledge of encryption — it operates entirely on
+ * parsed JSON (`unknown` → typed data) and serialized strings.
+ *
+ * @typeParam T - The typed payload this service processes and serializes.
+ *
+ * @example
+ * class ReportVersioningService extends VersioningService<AccessReportPayload> {
+ *   readonly currentVersion = 1;
+ *   process(json: unknown): { data: AccessReportPayload; wasLegacy: boolean } { ... }
+ *   serialize(data: AccessReportPayload): string { ... }
+ * }
+ */
+export abstract class VersioningService<T> {
+  /**
+   * The version number written into newly serialized envelopes.
+   * Used by `process()` to validate incoming versioned blobs.
+   */
+  abstract readonly currentVersion: number;
+
+  /**
+   * Parses and validates a decrypted blob, transforming legacy format if needed.
+   *
+   * - If `json` is a `VersionEnvelope` at `currentVersion`: validates and returns the inner payload.
+   * - If `json` is a legacy (unversioned) blob: transforms inline to the current payload shape.
+   * - If `json` is a `VersionEnvelope` at an unknown version: throws `UnsupportedVersionError`.
+   *
+   * @param json - The result of `JSON.parse()` on the decrypted blob string.
+   * @returns The typed payload and whether the input was in legacy format.
+   * @throws `UnsupportedVersionError` if the envelope version is unrecognized.
+   * @throws `Error` if the data fails payload validation.
+   */
+  abstract process(json: unknown): { data: T; wasLegacy: boolean };
+
+  /**
+   * Serializes a typed payload to a JSON string for encryption.
+   * Wraps the payload in a `VersionEnvelope` at `currentVersion`.
+   *
+   * @param data - The typed payload to serialize.
+   * @returns A JSON string representing `{ version: currentVersion, data }`.
+   */
+  abstract serialize(data: T): string;
+}

--- a/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/domain/default-cipher-health.service.spec.ts
+++ b/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/domain/default-cipher-health.service.spec.ts
@@ -1,0 +1,370 @@
+import { mock, MockProxy } from "jest-mock-extended";
+import { firstValueFrom } from "rxjs";
+import { ZXCVBNResult } from "zxcvbn";
+
+import { AuditService } from "@bitwarden/common/abstractions/audit.service";
+import { PasswordStrengthServiceAbstraction } from "@bitwarden/common/tools/password-strength";
+import { CipherType } from "@bitwarden/common/vault/enums";
+import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+
+import { CipherHealthView } from "../../../../access-intelligence/models";
+
+import { DefaultCipherHealthService } from "./default-cipher-health.service";
+
+describe("DefaultCipherHealthService", () => {
+  let service: DefaultCipherHealthService;
+  let auditService: MockProxy<AuditService>;
+  let passwordStrengthService: MockProxy<PasswordStrengthServiceAbstraction>;
+
+  beforeEach(() => {
+    auditService = mock<AuditService>();
+    passwordStrengthService = mock<PasswordStrengthServiceAbstraction>();
+    service = new DefaultCipherHealthService(auditService, passwordStrengthService);
+  });
+
+  // Helper to create mock ciphers
+  const createMockCipher = (options: {
+    id?: string;
+    password?: string;
+    username?: string;
+  }): CipherView => {
+    return mock<CipherView>({
+      id: options.id ?? "cipher-id",
+      type: CipherType.Login,
+      login: {
+        password: options.password ?? "password123",
+        username: options.username ?? "user@example.com",
+      },
+      isDeleted: false,
+      viewPassword: true,
+    });
+  };
+
+  describe("checkSingleCipherHealth", () => {
+    it("should detect weak passwords and provide UI helper methods", (done) => {
+      const cipher = createMockCipher({ password: "password123" });
+      passwordStrengthService.getPasswordStrength.mockReturnValue({ score: 1 } as ZXCVBNResult);
+      auditService.passwordLeaked.mockResolvedValue(0);
+
+      service.checkSingleCipherHealth(cipher).subscribe((health) => {
+        expect(health.hasWeakPassword).toBe(true);
+        expect(health.weakPasswordScore).toBe(1);
+
+        // Verify helper methods work
+        expect(health.getPasswordStrengthLabel()).toBe("veryWeak");
+        expect(health.getPasswordStrengthBadgeVariant()).toBe("danger");
+        expect(health.isAtRisk()).toBe(true);
+        done();
+      });
+    });
+
+    it("should detect exposed passwords", (done) => {
+      const cipher = createMockCipher({ password: "Password123!" });
+      passwordStrengthService.getPasswordStrength.mockReturnValue({ score: 3 } as ZXCVBNResult);
+      auditService.passwordLeaked.mockResolvedValue(5);
+
+      service.checkSingleCipherHealth(cipher).subscribe((health) => {
+        expect(health.hasExposedPassword).toBe(true);
+        expect(health.exposedCount).toBe(5);
+        expect(health.hasWeakPassword).toBe(false); // Score 3 is not weak
+        expect(health.getPasswordStrengthLabel()).toBe("good");
+        expect(health.getPasswordStrengthBadgeVariant()).toBe("primary");
+        done();
+      });
+    });
+
+    it("should handle strong passwords correctly", (done) => {
+      const cipher = createMockCipher({ password: "Xk9#mP2$vL8@qR4!" });
+      passwordStrengthService.getPasswordStrength.mockReturnValue({ score: 4 } as ZXCVBNResult);
+      auditService.passwordLeaked.mockResolvedValue(0);
+
+      service.checkSingleCipherHealth(cipher).subscribe((health) => {
+        expect(health.hasWeakPassword).toBe(false);
+        expect(health.hasExposedPassword).toBe(false);
+        expect(health.weakPasswordScore).toBe(4);
+        expect(health.getPasswordStrengthLabel()).toBe("strong");
+        expect(health.getPasswordStrengthBadgeVariant()).toBe("success");
+        expect(health.isAtRisk()).toBe(false);
+        done();
+      });
+    });
+
+    it("should return safe defaults for invalid cipher", (done) => {
+      const cipher = mock<CipherView>({
+        id: "invalid-cipher",
+        type: CipherType.Card, // Not a login cipher
+        isDeleted: false,
+        viewPassword: true,
+      });
+
+      service.checkSingleCipherHealth(cipher).subscribe((health) => {
+        expect(health.cipherId).toBe("invalid-cipher");
+        expect(health.hasWeakPassword).toBe(false);
+        expect(health.hasReusedPassword).toBe(false);
+        expect(health.hasExposedPassword).toBe(false);
+        expect(health.exposedCount).toBe(0);
+        done();
+      });
+    });
+
+    it("should return safe defaults for cipher with no password", (done) => {
+      const cipher = mock<CipherView>({
+        id: "no-password",
+        type: CipherType.Login,
+        login: { password: undefined },
+        isDeleted: false,
+        viewPassword: true,
+      });
+
+      service.checkSingleCipherHealth(cipher).subscribe((health) => {
+        expect(health.hasWeakPassword).toBe(false);
+        expect(health.hasReusedPassword).toBe(false);
+        expect(health.hasExposedPassword).toBe(false);
+        done();
+      });
+    });
+  });
+
+  describe("detectPasswordReuse", () => {
+    it("should detect password reuse", (done) => {
+      const ciphers = [
+        createMockCipher({ id: "1", password: "SharedPassword" }),
+        createMockCipher({ id: "2", password: "SharedPassword" }),
+        createMockCipher({ id: "3", password: "UniquePassword" }),
+      ];
+
+      service.detectPasswordReuse(ciphers).subscribe((reuseMap) => {
+        expect(reuseMap.size).toBe(1);
+        expect(reuseMap.get("SharedPassword")).toEqual(["1", "2"]);
+        expect(reuseMap.has("UniquePassword")).toBe(false); // Unique passwords excluded
+        done();
+      });
+    });
+
+    it("should return empty map when no passwords are reused", (done) => {
+      const ciphers = [
+        createMockCipher({ id: "1", password: "Password1" }),
+        createMockCipher({ id: "2", password: "Password2" }),
+        createMockCipher({ id: "3", password: "Password3" }),
+      ];
+
+      service.detectPasswordReuse(ciphers).subscribe((reuseMap) => {
+        expect(reuseMap.size).toBe(0);
+        done();
+      });
+    });
+
+    it("should handle multiple sets of reused passwords", (done) => {
+      const ciphers = [
+        createMockCipher({ id: "1", password: "Password1" }),
+        createMockCipher({ id: "2", password: "Password1" }),
+        createMockCipher({ id: "3", password: "Password2" }),
+        createMockCipher({ id: "4", password: "Password2" }),
+        createMockCipher({ id: "5", password: "Password2" }),
+        createMockCipher({ id: "6", password: "Unique" }),
+      ];
+
+      service.detectPasswordReuse(ciphers).subscribe((reuseMap) => {
+        expect(reuseMap.size).toBe(2);
+        expect(reuseMap.get("Password1")).toEqual(["1", "2"]);
+        expect(reuseMap.get("Password2")).toEqual(["3", "4", "5"]);
+        expect(reuseMap.has("Unique")).toBe(false);
+        done();
+      });
+    });
+  });
+
+  describe("checkCipherHealth", () => {
+    beforeEach(() => {
+      // Default mocks
+      passwordStrengthService.getPasswordStrength.mockReturnValue({ score: 3 } as ZXCVBNResult);
+      auditService.passwordLeaked.mockResolvedValue(0);
+    });
+
+    it("should return empty map for empty cipher array", (done) => {
+      service.checkCipherHealth([]).subscribe((healthMap) => {
+        expect(healthMap.size).toBe(0);
+        done();
+      });
+    });
+
+    it("should check health for all ciphers with password reuse detection", (done) => {
+      const ciphers = [
+        createMockCipher({ id: "1", password: "SharedWeak" }),
+        createMockCipher({ id: "2", password: "SharedWeak" }),
+        createMockCipher({ id: "3", password: "StrongUnique" }),
+      ];
+
+      passwordStrengthService.getPasswordStrength.mockImplementation((password: string) => {
+        return { score: password === "SharedWeak" ? 1 : 4 } as ZXCVBNResult;
+      });
+
+      service.checkCipherHealth(ciphers).subscribe((healthMap) => {
+        expect(healthMap.size).toBe(3);
+
+        const health1 = healthMap.get("1");
+        expect(health1?.hasWeakPassword).toBe(true);
+        expect(health1?.hasReusedPassword).toBe(true); // SharedWeak is reused
+        expect(health1?.isAtRisk()).toBe(true);
+
+        const health2 = healthMap.get("2");
+        expect(health2?.hasWeakPassword).toBe(true);
+        expect(health2?.hasReusedPassword).toBe(true); // SharedWeak is reused
+
+        const health3 = healthMap.get("3");
+        expect(health3?.hasWeakPassword).toBe(false);
+        expect(health3?.hasReusedPassword).toBe(false); // StrongUnique is unique
+        expect(health3?.isAtRisk()).toBe(false);
+
+        done();
+      });
+    });
+
+    it("should limit concurrent HIBP calls", async () => {
+      const ciphers = Array.from({ length: 20 }, (_, i) =>
+        createMockCipher({ id: `${i}`, password: `password${i}` }),
+      );
+
+      let concurrentCalls = 0;
+      let maxConcurrent = 0;
+
+      auditService.passwordLeaked.mockImplementation(() => {
+        concurrentCalls++;
+        maxConcurrent = Math.max(maxConcurrent, concurrentCalls);
+
+        return new Promise((resolve) => {
+          setTimeout(() => {
+            concurrentCalls--;
+            resolve(0);
+          }, 10);
+        });
+      });
+
+      await firstValueFrom(service.checkCipherHealth(ciphers));
+
+      expect(maxConcurrent).toBeLessThanOrEqual(5);
+    });
+
+    it("should filter out invalid ciphers", (done) => {
+      const ciphers = [
+        createMockCipher({ id: "1", password: "Valid" }),
+        mock<CipherView>({
+          id: "2",
+          type: CipherType.Card, // Invalid type
+          isDeleted: false,
+          viewPassword: true,
+        }),
+        createMockCipher({ id: "3", password: "AlsoValid" }),
+      ];
+
+      service.checkCipherHealth(ciphers).subscribe((healthMap) => {
+        expect(healthMap.size).toBe(2);
+        expect(healthMap.has("1")).toBe(true);
+        expect(healthMap.has("2")).toBe(false); // Invalid cipher excluded
+        expect(healthMap.has("3")).toBe(true);
+        done();
+      });
+    });
+
+    it("should detect exposed passwords with count", (done) => {
+      const ciphers = [
+        createMockCipher({ id: "1", password: "ExposedPassword" }),
+        createMockCipher({ id: "2", password: "SafePassword" }),
+      ];
+
+      auditService.passwordLeaked.mockImplementation((password: string) => {
+        return Promise.resolve(password === "ExposedPassword" ? 42 : 0);
+      });
+
+      service.checkCipherHealth(ciphers).subscribe((healthMap) => {
+        const health1 = healthMap.get("1");
+        expect(health1?.hasExposedPassword).toBe(true);
+        expect(health1?.exposedCount).toBe(42);
+
+        const health2 = healthMap.get("2");
+        expect(health2?.hasExposedPassword).toBe(false);
+        expect(health2?.exposedCount).toBe(0);
+
+        done();
+      });
+    });
+  });
+
+  describe("CipherHealthView helper methods", () => {
+    it("should provide correct labels for all password strength scores", (done) => {
+      const testCases = [
+        { score: 0, label: "veryWeak", badge: "danger" as const },
+        { score: 1, label: "veryWeak", badge: "danger" as const },
+        { score: 2, label: "weak", badge: "warning" as const },
+        { score: 3, label: "good", badge: "primary" as const },
+        { score: 4, label: "strong", badge: "success" as const },
+      ];
+
+      let completed = 0;
+
+      testCases.forEach(({ score, label, badge }) => {
+        const cipher = createMockCipher({ password: `password-score-${score}` });
+        passwordStrengthService.getPasswordStrength.mockReturnValue({ score } as ZXCVBNResult);
+        auditService.passwordLeaked.mockResolvedValue(0);
+
+        service.checkSingleCipherHealth(cipher).subscribe((health) => {
+          expect(health.weakPasswordScore).toBe(score);
+          expect(health.getPasswordStrengthLabel()).toBe(label);
+          expect(health.getPasswordStrengthBadgeVariant()).toBe(badge);
+          expect(health.hasWeakPassword).toBe(score <= 2);
+
+          completed++;
+          if (completed === testCases.length) {
+            done();
+          }
+        });
+      });
+    });
+
+    it("should handle missing password score gracefully", (done) => {
+      const cipher = mock<CipherView>({
+        id: "no-password",
+        type: CipherType.Login,
+        login: { password: undefined },
+        isDeleted: false,
+        viewPassword: true,
+      });
+
+      service.checkSingleCipherHealth(cipher).subscribe((health) => {
+        expect(health.weakPasswordScore).toBeUndefined();
+        expect(health.getPasswordStrengthLabel()).toBe("unknown");
+        expect(health.getPasswordStrengthBadgeVariant()).toBe("warning");
+        done();
+      });
+    });
+
+    it("should correctly identify at-risk passwords", (done) => {
+      const testCases = [
+        { score: 0, exposed: false, reused: false, expectedAtRisk: true }, // Weak
+        { score: 4, exposed: true, reused: false, expectedAtRisk: true }, // Exposed
+        { score: 4, exposed: false, reused: true, expectedAtRisk: true }, // Reused
+        { score: 4, exposed: false, reused: false, expectedAtRisk: false }, // Safe
+      ];
+
+      let completed = 0;
+
+      testCases.forEach(({ score, exposed, reused, expectedAtRisk }) => {
+        const health = new CipherHealthView({
+          cipherId: "test",
+          hasWeakPassword: score <= 2,
+          hasExposedPassword: exposed,
+          hasReusedPassword: reused,
+          exposedCount: exposed ? 1 : 0,
+          weakPasswordScore: score,
+        });
+
+        expect(health.isAtRisk()).toBe(expectedAtRisk);
+
+        completed++;
+        if (completed === testCases.length) {
+          done();
+        }
+      });
+    });
+  });
+});

--- a/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/domain/default-cipher-health.service.ts
+++ b/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/domain/default-cipher-health.service.ts
@@ -1,0 +1,206 @@
+import { forkJoin, from, map, mergeMap, Observable, of, toArray } from "rxjs";
+
+import { AuditService } from "@bitwarden/common/abstractions/audit.service";
+import { Utils } from "@bitwarden/common/platform/misc/utils";
+import { PasswordStrengthServiceAbstraction } from "@bitwarden/common/tools/password-strength";
+import { CipherType } from "@bitwarden/common/vault/enums";
+import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+
+import { CipherHealthView } from "../../../models";
+import { CipherHealthService } from "../../abstractions/cipher-health.service";
+
+/**
+ * Default implementation of CipherHealthService.
+ *
+ * Concurrency-limits HIBP calls to prevent rate limiting.
+ */
+export class DefaultCipherHealthService extends CipherHealthService {
+  private readonly MAX_CONCURRENT_HIBP_CALLS = 5;
+
+  constructor(
+    private auditService: AuditService,
+    private passwordStrengthService: PasswordStrengthServiceAbstraction,
+  ) {
+    super();
+  }
+
+  checkCipherHealth(ciphers: CipherView[]): Observable<Map<string, CipherHealthView>> {
+    const validCiphers = ciphers.filter((c) => this.isValidCipher(c));
+
+    if (validCiphers.length === 0) {
+      return of(new Map());
+    }
+
+    // Detect password reuse across all ciphers
+    const reuseMap$ = this.detectPasswordReuse(validCiphers);
+
+    // Check each cipher's health (weak password + HIBP exposure)
+    const healthChecks$ = from(validCiphers).pipe(
+      // Limit concurrent HIBP calls to avoid rate limiting
+      mergeMap(
+        (cipher) => this.checkSingleCipherHealthInternal(cipher),
+        this.MAX_CONCURRENT_HIBP_CALLS,
+      ),
+      toArray(),
+    );
+
+    // Combine reuse detection with individual health checks
+    return forkJoin({
+      reuseMap: reuseMap$,
+      healthResults: healthChecks$,
+    }).pipe(
+      map(({ reuseMap, healthResults }) => {
+        const healthMap = new Map<string, CipherHealthView>();
+
+        healthResults.forEach((health) => {
+          // Check if this cipher's password is reused
+          const password = this.getCipherPassword(
+            validCiphers.find((c) => c.id === health.cipherId)!,
+          );
+          const reusedCipherIds = password ? reuseMap.get(password) : undefined;
+          health.hasReusedPassword = reusedCipherIds ? reusedCipherIds.length > 1 : false;
+
+          healthMap.set(health.cipherId, health);
+        });
+
+        return healthMap;
+      }),
+    );
+  }
+
+  checkSingleCipherHealth(cipher: CipherView): Observable<CipherHealthView> {
+    if (!this.isValidCipher(cipher)) {
+      return of(
+        new CipherHealthView({
+          cipherId: cipher.id,
+          hasWeakPassword: false,
+          hasReusedPassword: false,
+          hasExposedPassword: false,
+          exposedCount: 0,
+        }),
+      );
+    }
+
+    return this.checkSingleCipherHealthInternal(cipher);
+  }
+
+  detectPasswordReuse(ciphers: CipherView[]): Observable<Map<string, string[]>> {
+    const passwordMap = new Map<string, string[]>();
+
+    ciphers.forEach((cipher) => {
+      if (!this.isValidCipher(cipher)) {
+        return;
+      }
+
+      const password = this.getCipherPassword(cipher);
+      if (!password) {
+        return;
+      }
+
+      if (!passwordMap.has(password)) {
+        passwordMap.set(password, []);
+      }
+      passwordMap.get(password)!.push(cipher.id);
+    });
+
+    // Only keep passwords that are reused (2+ ciphers)
+    const reuseMap = new Map<string, string[]>();
+    passwordMap.forEach((cipherIds, password) => {
+      if (cipherIds.length > 1) {
+        reuseMap.set(password, cipherIds);
+      }
+    });
+
+    return of(reuseMap);
+  }
+
+  private checkSingleCipherHealthInternal(cipher: CipherView): Observable<CipherHealthView> {
+    const password = this.getCipherPassword(cipher);
+    if (!password) {
+      return of(
+        new CipherHealthView({
+          cipherId: cipher.id,
+          hasWeakPassword: false,
+          hasReusedPassword: false,
+          hasExposedPassword: false,
+          exposedCount: 0,
+        }),
+      );
+    }
+
+    // Check weak password
+    const weakPasswordScore = this.getPasswordStrength(cipher);
+    const hasWeakPassword = weakPasswordScore != null && weakPasswordScore <= 2;
+
+    // Check HIBP exposure
+    return from(this.auditService.passwordLeaked(password)).pipe(
+      map((exposedCount) => {
+        return new CipherHealthView({
+          cipherId: cipher.id,
+          hasWeakPassword,
+          hasReusedPassword: false, // Will be set by caller if checking multiple ciphers
+          hasExposedPassword: exposedCount > 0,
+          exposedCount,
+          weakPasswordScore,
+        });
+      }),
+    );
+  }
+
+  private getPasswordStrength(cipher: CipherView): number | undefined {
+    if (!this.isValidCipher(cipher)) {
+      return undefined;
+    }
+
+    const password = this.getCipherPassword(cipher);
+    if (!password) {
+      return undefined;
+    }
+
+    // Extract username parts for better strength analysis
+    const userInput = this.isUsernameNotEmpty(cipher)
+      ? this.extractUsernameParts(cipher.login.username!)
+      : undefined;
+
+    const { score } = this.passwordStrengthService.getPasswordStrength(
+      password,
+      undefined, // No email available in this context
+      userInput,
+    );
+
+    return score;
+  }
+
+  private extractUsernameParts(cipherUsername: string): string[] {
+    const atPosition = cipherUsername.indexOf("@");
+    const userNameToProcess =
+      atPosition > -1 ? cipherUsername.substring(0, atPosition) : cipherUsername;
+
+    return userNameToProcess
+      .trim()
+      .toLowerCase()
+      .split(/[^A-Za-z0-9]/);
+  }
+
+  private isUsernameNotEmpty(cipher: CipherView): boolean {
+    return !Utils.isNullOrWhitespace(cipher.login.username);
+  }
+
+  private getCipherPassword(cipher: CipherView): string | undefined {
+    return cipher.login?.password || undefined;
+  }
+
+  private isValidCipher(cipher: CipherView): boolean {
+    const { type, login, isDeleted, viewPassword } = cipher;
+    if (
+      type !== CipherType.Login ||
+      login?.password == null ||
+      login.password === "" ||
+      isDeleted ||
+      !viewPassword
+    ) {
+      return false;
+    }
+    return true;
+  }
+}

--- a/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/domain/default-member-cipher-mapping.service.spec.ts
+++ b/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/domain/default-member-cipher-mapping.service.spec.ts
@@ -1,0 +1,321 @@
+import { firstValueFrom } from "rxjs";
+
+import { CipherType } from "@bitwarden/common/vault/enums";
+import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+
+import {
+  CollectionAccessDetails,
+  GroupMembershipDetails,
+  OrganizationUserView,
+} from "../../abstractions/member-cipher-mapping.service";
+
+import { DefaultMemberCipherMappingService } from "./default-member-cipher-mapping.service";
+
+describe("DefaultMemberCipherMappingService", () => {
+  let service: DefaultMemberCipherMappingService;
+
+  beforeEach(() => {
+    service = new DefaultMemberCipherMappingService();
+  });
+
+  // Test helpers
+
+  const createCipher = (id: string, collectionIds: string[]): CipherView => {
+    const cipher = new CipherView();
+    cipher.id = id;
+    cipher.type = CipherType.Login;
+    cipher.collectionIds = collectionIds;
+    return cipher;
+  };
+
+  const createMember = (id: string, name: string, email: string): OrganizationUserView => ({
+    id,
+    name,
+    email,
+  });
+
+  const createCollectionAccess = (
+    collectionId: string,
+    userIds: string[],
+    groupIds: string[],
+  ): CollectionAccessDetails => ({
+    collectionId,
+    users: new Set(userIds),
+    groups: new Set(groupIds),
+  });
+
+  const createGroupMembership = (groupId: string, userIds: string[]): GroupMembershipDetails => ({
+    groupId,
+    users: new Set(userIds),
+  });
+
+  // Tests
+
+  describe("mapCiphersToMembers", () => {
+    it("should map cipher to directly assigned users", async () => {
+      const ciphers = [createCipher("cipher-1", ["collection-1"])];
+      const members = [
+        createMember("user-1", "Alice", "alice@example.com"),
+        createMember("user-2", "Bob", "bob@example.com"),
+      ];
+      const collectionAccess = [createCollectionAccess("collection-1", ["user-1", "user-2"], [])];
+      const groupMemberships: GroupMembershipDetails[] = [];
+
+      const result = await firstValueFrom(
+        service.mapCiphersToMembers(ciphers, members, collectionAccess, groupMemberships),
+      );
+
+      expect(result.mapping.get("cipher-1")).toEqual(expect.arrayContaining(["user-1", "user-2"]));
+      expect(result.mapping.get("cipher-1")?.length).toBe(2);
+      expect(Object.keys(result.registry).length).toBe(2);
+      expect(result.registry["user-1"]).toEqual({
+        id: "user-1",
+        userName: "Alice",
+        email: "alice@example.com",
+      });
+    });
+
+    it("should map cipher to users via group membership", async () => {
+      const ciphers = [createCipher("cipher-1", ["collection-1"])];
+      const members = [
+        createMember("user-1", "Alice", "alice@example.com"),
+        createMember("user-2", "Bob", "bob@example.com"),
+      ];
+      const collectionAccess = [createCollectionAccess("collection-1", [], ["group-1"])];
+      const groupMemberships = [createGroupMembership("group-1", ["user-1", "user-2"])];
+
+      const result = await firstValueFrom(
+        service.mapCiphersToMembers(ciphers, members, collectionAccess, groupMemberships),
+      );
+
+      expect(result.mapping.get("cipher-1")).toEqual(expect.arrayContaining(["user-1", "user-2"]));
+      expect(result.mapping.get("cipher-1")?.length).toBe(2);
+      expect(Object.keys(result.registry).length).toBe(2);
+    });
+
+    it("should combine direct users and group members", async () => {
+      const ciphers = [createCipher("cipher-1", ["collection-1"])];
+      const members = [
+        createMember("user-1", "Alice", "alice@example.com"),
+        createMember("user-2", "Bob", "bob@example.com"),
+        createMember("user-3", "Charlie", "charlie@example.com"),
+      ];
+      const collectionAccess = [createCollectionAccess("collection-1", ["user-1"], ["group-1"])];
+      const groupMemberships = [createGroupMembership("group-1", ["user-2", "user-3"])];
+
+      const result = await firstValueFrom(
+        service.mapCiphersToMembers(ciphers, members, collectionAccess, groupMemberships),
+      );
+
+      expect(result.mapping.get("cipher-1")).toEqual(
+        expect.arrayContaining(["user-1", "user-2", "user-3"]),
+      );
+      expect(result.mapping.get("cipher-1")?.length).toBe(3);
+      expect(Object.keys(result.registry).length).toBe(3);
+    });
+
+    it("should deduplicate users across multiple collections", async () => {
+      const ciphers = [createCipher("cipher-1", ["collection-1", "collection-2"])];
+      const members = [createMember("user-1", "Alice", "alice@example.com")];
+      const collectionAccess = [
+        createCollectionAccess("collection-1", ["user-1"], []),
+        createCollectionAccess("collection-2", ["user-1"], []),
+      ];
+      const groupMemberships: GroupMembershipDetails[] = [];
+
+      const result = await firstValueFrom(
+        service.mapCiphersToMembers(ciphers, members, collectionAccess, groupMemberships),
+      );
+
+      // User should appear only once despite being in multiple collections
+      expect(result.mapping.get("cipher-1")).toEqual(["user-1"]);
+      expect(result.mapping.get("cipher-1")?.length).toBe(1);
+      expect(Object.keys(result.registry).length).toBe(1);
+    });
+
+    it("should deduplicate users from direct access and group membership", async () => {
+      const ciphers = [createCipher("cipher-1", ["collection-1"])];
+      const members = [createMember("user-1", "Alice", "alice@example.com")];
+      const collectionAccess = [createCollectionAccess("collection-1", ["user-1"], ["group-1"])];
+      const groupMemberships = [createGroupMembership("group-1", ["user-1"])];
+
+      const result = await firstValueFrom(
+        service.mapCiphersToMembers(ciphers, members, collectionAccess, groupMemberships),
+      );
+
+      // User should appear only once despite having both direct and group access
+      expect(result.mapping.get("cipher-1")).toEqual(["user-1"]);
+      expect(result.mapping.get("cipher-1")?.length).toBe(1);
+      expect(Object.keys(result.registry).length).toBe(1);
+    });
+
+    it("should handle multiple ciphers with different member access", async () => {
+      const ciphers = [
+        createCipher("cipher-1", ["collection-1"]),
+        createCipher("cipher-2", ["collection-2"]),
+      ];
+      const members = [
+        createMember("user-1", "Alice", "alice@example.com"),
+        createMember("user-2", "Bob", "bob@example.com"),
+      ];
+      const collectionAccess = [
+        createCollectionAccess("collection-1", ["user-1"], []),
+        createCollectionAccess("collection-2", ["user-2"], []),
+      ];
+      const groupMemberships: GroupMembershipDetails[] = [];
+
+      const result = await firstValueFrom(
+        service.mapCiphersToMembers(ciphers, members, collectionAccess, groupMemberships),
+      );
+
+      expect(result.mapping.get("cipher-1")).toEqual(["user-1"]);
+      expect(result.mapping.get("cipher-2")).toEqual(["user-2"]);
+      expect(Object.keys(result.registry).length).toBe(2);
+    });
+
+    it("should handle multiple ciphers with overlapping member access", async () => {
+      const ciphers = [
+        createCipher("cipher-1", ["collection-1"]),
+        createCipher("cipher-2", ["collection-2"]),
+      ];
+      const members = [
+        createMember("user-1", "Alice", "alice@example.com"),
+        createMember("user-2", "Bob", "bob@example.com"),
+      ];
+      const collectionAccess = [
+        createCollectionAccess("collection-1", ["user-1", "user-2"], []),
+        createCollectionAccess("collection-2", ["user-2"], []),
+      ];
+      const groupMemberships: GroupMembershipDetails[] = [];
+
+      const result = await firstValueFrom(
+        service.mapCiphersToMembers(ciphers, members, collectionAccess, groupMemberships),
+      );
+
+      expect(result.mapping.get("cipher-1")).toEqual(expect.arrayContaining(["user-1", "user-2"]));
+      expect(result.mapping.get("cipher-2")).toEqual(["user-2"]);
+      // Registry should contain both users (deduplicated)
+      expect(Object.keys(result.registry).length).toBe(2);
+    });
+
+    it("should handle cipher with no collections", async () => {
+      const ciphers = [createCipher("cipher-1", [])];
+      const members = [createMember("user-1", "Alice", "alice@example.com")];
+      const collectionAccess: CollectionAccessDetails[] = [];
+      const groupMemberships: GroupMembershipDetails[] = [];
+
+      const result = await firstValueFrom(
+        service.mapCiphersToMembers(ciphers, members, collectionAccess, groupMemberships),
+      );
+
+      expect(result.mapping.get("cipher-1")).toEqual([]);
+      expect(Object.keys(result.registry).length).toBe(0);
+    });
+
+    it("should handle cipher with collection but no access defined", async () => {
+      const ciphers = [createCipher("cipher-1", ["collection-1"])];
+      const members = [createMember("user-1", "Alice", "alice@example.com")];
+      const collectionAccess: CollectionAccessDetails[] = []; // No access defined
+      const groupMemberships: GroupMembershipDetails[] = [];
+
+      const result = await firstValueFrom(
+        service.mapCiphersToMembers(ciphers, members, collectionAccess, groupMemberships),
+      );
+
+      expect(result.mapping.get("cipher-1")).toEqual([]);
+      expect(Object.keys(result.registry).length).toBe(0);
+    });
+
+    it("should handle empty inputs", async () => {
+      const result = await firstValueFrom(service.mapCiphersToMembers([], [], [], []));
+
+      expect(result.mapping.size).toBe(0);
+      expect(Object.keys(result.registry).length).toBe(0);
+    });
+
+    it("should handle member with null name", async () => {
+      const ciphers = [createCipher("cipher-1", ["collection-1"])];
+      const members = [createMember("user-1", null as any, "alice@example.com")];
+      const collectionAccess = [createCollectionAccess("collection-1", ["user-1"], [])];
+      const groupMemberships: GroupMembershipDetails[] = [];
+
+      const result = await firstValueFrom(
+        service.mapCiphersToMembers(ciphers, members, collectionAccess, groupMemberships),
+      );
+
+      expect(result.registry["user-1"]?.userName).toBeUndefined();
+    });
+
+    it("should handle complex scenario with multiple groups and collections", async () => {
+      const ciphers = [createCipher("cipher-1", ["collection-1", "collection-2"])];
+      const members = [
+        createMember("user-1", "Alice", "alice@example.com"),
+        createMember("user-2", "Bob", "bob@example.com"),
+        createMember("user-3", "Charlie", "charlie@example.com"),
+        createMember("user-4", "David", "david@example.com"),
+      ];
+      const collectionAccess = [
+        // Collection 1: user-1 directly + group-1 (user-2, user-3)
+        createCollectionAccess("collection-1", ["user-1"], ["group-1"]),
+        // Collection 2: user-1 directly + group-2 (user-3, user-4)
+        createCollectionAccess("collection-2", ["user-1"], ["group-2"]),
+      ];
+      const groupMemberships = [
+        createGroupMembership("group-1", ["user-2", "user-3"]),
+        createGroupMembership("group-2", ["user-3", "user-4"]),
+      ];
+
+      const result = await firstValueFrom(
+        service.mapCiphersToMembers(ciphers, members, collectionAccess, groupMemberships),
+      );
+
+      // Cipher should have access for all 4 users (deduplicated)
+      // user-1: direct access to both collections
+      // user-2: group-1 → collection-1
+      // user-3: group-1 → collection-1, group-2 → collection-2
+      // user-4: group-2 → collection-2
+      expect(result.mapping.get("cipher-1")).toEqual(
+        expect.arrayContaining(["user-1", "user-2", "user-3", "user-4"]),
+      );
+      expect(result.mapping.get("cipher-1")?.length).toBe(4);
+      expect(Object.keys(result.registry).length).toBe(4);
+    });
+  });
+
+  describe("buildMemberRegistry", () => {
+    it("should build registry from members", async () => {
+      const members = [
+        createMember("user-1", "Alice", "alice@example.com"),
+        createMember("user-2", "Bob", "bob@example.com"),
+      ];
+
+      const registry = await firstValueFrom(service.buildMemberRegistry(members));
+
+      expect(Object.keys(registry).length).toBe(2);
+      expect(registry["user-1"]).toEqual({
+        id: "user-1",
+        userName: "Alice",
+        email: "alice@example.com",
+      });
+      expect(registry["user-2"]).toEqual({
+        id: "user-2",
+        userName: "Bob",
+        email: "bob@example.com",
+      });
+    });
+
+    it("should handle empty members array", async () => {
+      const registry = await firstValueFrom(service.buildMemberRegistry([]));
+
+      expect(Object.keys(registry).length).toBe(0);
+    });
+
+    it("should handle member with null name", async () => {
+      const members = [createMember("user-1", null as any, "alice@example.com")];
+
+      const registry = await firstValueFrom(service.buildMemberRegistry(members));
+
+      expect(registry["user-1"]?.userName).toBeUndefined();
+    });
+  });
+});

--- a/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/domain/default-member-cipher-mapping.service.ts
+++ b/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/domain/default-member-cipher-mapping.service.ts
@@ -1,0 +1,182 @@
+import { Observable, of } from "rxjs";
+
+import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+
+import { MemberRegistryEntryView, MemberRegistry } from "../../../models";
+import {
+  CollectionAccessDetails,
+  GroupMembershipDetails,
+  MemberCipherMappingResult,
+  MemberCipherMappingService,
+  OrganizationUserView,
+} from "../../abstractions/member-cipher-mapping.service";
+
+/**
+ * Default implementation of MemberCipherMappingService
+ *
+ * Computes cipher-to-member mappings client-side via collection and group resolution.
+ * This is a pure transformation service with no external dependencies.
+ */
+export class DefaultMemberCipherMappingService extends MemberCipherMappingService {
+  /**
+   * Maps ciphers to organization members via collection and group resolution.
+   *
+   * This is a synchronous operation wrapped in an Observable for consistency
+   * with the service pattern. No async operations are performed.
+   */
+  mapCiphersToMembers(
+    ciphers: CipherView[],
+    members: OrganizationUserView[],
+    collectionAccess: CollectionAccessDetails[],
+    groupMemberships: GroupMembershipDetails[],
+  ): Observable<MemberCipherMappingResult> {
+    // Build lookup maps for O(1) access
+    const collectionAccessMap = this.buildCollectionAccessMap(collectionAccess);
+    const groupMembershipMap = this.buildGroupMembershipMap(groupMemberships);
+    const memberMap = this.buildMemberMap(members);
+
+    // Mapping from cipher ID to set of member IDs (using Set for automatic deduplication)
+    const cipherToMembersMap = new Map<string, Set<string>>();
+
+    // Set of all unique member IDs across all ciphers (for registry building)
+    const allMemberIds = new Set<string>();
+
+    // Process each cipher
+    for (const cipher of ciphers) {
+      const memberIds = this.resolveCipherMembers(cipher, collectionAccessMap, groupMembershipMap);
+
+      cipherToMembersMap.set(cipher.id, memberIds);
+
+      // Add all member IDs to the global set for registry building
+      memberIds.forEach((id) => allMemberIds.add(id));
+    }
+
+    // Build the member registry from all unique member IDs
+    const registry: MemberRegistry = {};
+    allMemberIds.forEach((id) => {
+      const member = memberMap.get(id);
+      if (member) {
+        registry[id] = MemberRegistryEntryView.fromData({
+          id: member.id,
+          userName: member.name || undefined,
+          email: member.email,
+        });
+      }
+    });
+
+    // Convert Set to Array for the final mapping
+    const mapping = new Map<string, string[]>();
+    cipherToMembersMap.forEach((memberIds, cipherId) => {
+      mapping.set(cipherId, Array.from(memberIds));
+    });
+
+    return of({ mapping, registry });
+  }
+
+  /**
+   * Builds a member registry from an array of members.
+   */
+  buildMemberRegistry(members: OrganizationUserView[]): Observable<MemberRegistry> {
+    const registry: MemberRegistry = {};
+
+    members.forEach((member) => {
+      registry[member.id] = MemberRegistryEntryView.fromData({
+        id: member.id,
+        userName: member.name || undefined,
+        email: member.email,
+      });
+    });
+
+    return of(registry);
+  }
+
+  /**
+   * Resolves which members have access to a cipher via collections and groups.
+   *
+   * Resolution logic:
+   * 1. Find all collections the cipher belongs to (cipher.collectionIds)
+   * 2. For each collection, find:
+   *    - Users directly assigned to the collection
+   *    - Groups assigned to the collection
+   * 3. For each group, find all users who are members of that group
+   * 4. Return deduplicated set of member IDs
+   *
+   * @param cipher - The cipher to resolve members for
+   * @param collectionAccessMap - Map of collection ID to access details
+   * @param groupMembershipMap - Map of group ID to membership details
+   * @returns Set of organization user IDs who have access to this cipher
+   */
+  private resolveCipherMembers(
+    cipher: CipherView,
+    collectionAccessMap: Map<string, CollectionAccessDetails>,
+    groupMembershipMap: Map<string, GroupMembershipDetails>,
+  ): Set<string> {
+    const memberIds = new Set<string>();
+
+    // If cipher has no collections, no one has access (except owner, but that's not tracked here)
+    if (!cipher.collectionIds || cipher.collectionIds.length === 0) {
+      return memberIds;
+    }
+
+    // For each collection the cipher belongs to
+    for (const collectionId of cipher.collectionIds) {
+      const access = collectionAccessMap.get(collectionId);
+      if (!access) {
+        continue;
+      }
+
+      // Add all users directly assigned to this collection
+      access.users.forEach((userId) => memberIds.add(userId));
+
+      // For each group assigned to this collection
+      for (const groupId of access.groups) {
+        const membership = groupMembershipMap.get(groupId);
+        if (!membership) {
+          continue;
+        }
+
+        // Add all users who are members of this group
+        membership.users.forEach((userId) => memberIds.add(userId));
+      }
+    }
+
+    return memberIds;
+  }
+
+  /**
+   * Builds a lookup map from collection ID to access details for O(1) access.
+   */
+  private buildCollectionAccessMap(
+    collectionAccess: CollectionAccessDetails[],
+  ): Map<string, CollectionAccessDetails> {
+    const map = new Map<string, CollectionAccessDetails>();
+    collectionAccess.forEach((access) => {
+      map.set(access.collectionId, access);
+    });
+    return map;
+  }
+
+  /**
+   * Builds a lookup map from group ID to membership details for O(1) access.
+   */
+  private buildGroupMembershipMap(
+    groupMemberships: GroupMembershipDetails[],
+  ): Map<string, GroupMembershipDetails> {
+    const map = new Map<string, GroupMembershipDetails>();
+    groupMemberships.forEach((membership) => {
+      map.set(membership.groupId, membership);
+    });
+    return map;
+  }
+
+  /**
+   * Builds a lookup map from member ID to member object for O(1) access.
+   */
+  private buildMemberMap(members: OrganizationUserView[]): Map<string, OrganizationUserView> {
+    const map = new Map<string, OrganizationUserView>();
+    members.forEach((member) => {
+      map.set(member.id, member);
+    });
+    return map;
+  }
+}

--- a/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/domain/default-report-generation.service.spec.ts
+++ b/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/domain/default-report-generation.service.spec.ts
@@ -1,0 +1,693 @@
+import { mock, MockProxy } from "jest-mock-extended";
+import { firstValueFrom, of } from "rxjs";
+
+import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+import { LogService } from "@bitwarden/logging";
+
+import {
+  createCipher,
+  createMember,
+  createCollectionAccess,
+  createCipherHealth,
+  createApplication,
+  createMemberRegistry,
+} from "../../../../reports/risk-insights/testing/test-helpers";
+import { CipherHealthService } from "../../abstractions/cipher-health.service";
+import {
+  CollectionAccessDetails,
+  GroupMembershipDetails,
+  MemberCipherMappingService,
+  OrganizationUserView,
+} from "../../abstractions/member-cipher-mapping.service";
+
+import { DefaultReportGenerationService } from "./default-report-generation.service";
+
+describe("DefaultReportGenerationService", () => {
+  let service: DefaultReportGenerationService;
+  let cipherHealthService: MockProxy<CipherHealthService>;
+  let memberCipherMappingService: MockProxy<MemberCipherMappingService>;
+  let logService: MockProxy<LogService>;
+
+  beforeEach(() => {
+    cipherHealthService = mock<CipherHealthService>();
+    memberCipherMappingService = mock<MemberCipherMappingService>();
+    logService = mock<LogService>();
+
+    service = new DefaultReportGenerationService(
+      cipherHealthService,
+      memberCipherMappingService,
+      logService,
+    );
+  });
+
+  // Test helpers imported from shared testing utilities
+  // Using: createCipher, createMember, createCollectionAccess, createCipherHealth, createApplication
+
+  // ==================== Integration Tests ====================
+
+  describe("generateReport - Integration", () => {
+    it("should generate complete report with valid data", async () => {
+      // Arrange
+      const ciphers = [
+        createCipher("c1", ["https://github.com/login"], ["coll-1"]),
+        createCipher("c2", ["https://github.com/signup"], ["coll-1"]),
+        createCipher("c3", ["https://gitlab.com"], ["coll-2"]),
+      ];
+
+      const members = [
+        createMember("u1", "Alice", "alice@example.com"),
+        createMember("u2", "Bob", "bob@example.com"),
+      ];
+
+      const collectionAccess = [
+        createCollectionAccess("coll-1", ["u1"], []),
+        createCollectionAccess("coll-2", ["u2"], []),
+      ];
+
+      const groupMemberships: GroupMembershipDetails[] = [];
+
+      // Mock health checks: c1 at-risk, others safe
+      const healthMap = new Map([
+        ["c1", createCipherHealth(true)],
+        ["c2", createCipherHealth(false)],
+        ["c3", createCipherHealth(false)],
+      ]);
+      cipherHealthService.checkCipherHealth.mockReturnValue(of(healthMap));
+
+      // Mock member mapping
+      const mapping = new Map([
+        ["c1", ["u1"]],
+        ["c2", ["u1"]],
+        ["c3", ["u2"]],
+      ]);
+      const registry = createMemberRegistry([
+        { id: "u1", name: "Alice", email: "alice@example.com" },
+        { id: "u2", name: "Bob", email: "bob@example.com" },
+      ]);
+      memberCipherMappingService.mapCiphersToMembers.mockReturnValue(of({ mapping, registry }));
+
+      // Act
+      const result = await firstValueFrom(
+        service.generateReport(ciphers, members, collectionAccess, groupMemberships),
+      );
+
+      // Assert
+      expect(result.reports.length).toBe(2); // github.com and gitlab.com
+      expect(result.applications.length).toBe(2);
+      expect(result.memberRegistry).toEqual(registry);
+      expect(result.summary.totalApplicationCount).toBe(2);
+      expect(result.summary.totalMemberCount).toBe(2);
+      expect(result.summary.totalAtRiskApplicationCount).toBe(1); // github.com has c1 at-risk
+    });
+
+    it("should handle empty cipher array", async () => {
+      const ciphers: CipherView[] = [];
+      const members = [createMember("u1", "Alice", "alice@example.com")];
+      const collectionAccess: CollectionAccessDetails[] = [];
+      const groupMemberships: GroupMembershipDetails[] = [];
+
+      cipherHealthService.checkCipherHealth.mockReturnValue(of(new Map()));
+      memberCipherMappingService.mapCiphersToMembers.mockReturnValue(
+        of({ mapping: new Map(), registry: {} }),
+      );
+
+      const result = await firstValueFrom(
+        service.generateReport(ciphers, members, collectionAccess, groupMemberships),
+      );
+
+      expect(result.reports.length).toBe(0);
+      expect(result.applications.length).toBe(0);
+      expect(result.summary.totalApplicationCount).toBe(0);
+      expect(result.summary.totalAtRiskApplicationCount).toBe(0);
+    });
+
+    it("should handle empty member array", async () => {
+      const ciphers = [createCipher("c1", ["https://github.com"], ["coll-1"])];
+      const members: OrganizationUserView[] = [];
+      const collectionAccess: CollectionAccessDetails[] = [];
+      const groupMemberships: GroupMembershipDetails[] = [];
+
+      const healthMap = new Map([["c1", createCipherHealth(false)]]);
+      cipherHealthService.checkCipherHealth.mockReturnValue(of(healthMap));
+      memberCipherMappingService.mapCiphersToMembers.mockReturnValue(
+        of({ mapping: new Map([["c1", []]]), registry: {} }),
+      );
+
+      const result = await firstValueFrom(
+        service.generateReport(ciphers, members, collectionAccess, groupMemberships),
+      );
+
+      expect(result.reports.length).toBe(1);
+      expect(result.reports[0].memberCount).toBe(0);
+      expect(result.memberRegistry).toEqual({});
+      expect(result.summary.totalMemberCount).toBe(0);
+    });
+  });
+
+  // ==================== Aggregation Tests ====================
+
+  describe("aggregateIntoReports", () => {
+    it("should group ciphers by trimmed URI", async () => {
+      const ciphers = [
+        createCipher("c1", ["https://github.com/login"], ["coll-1"]),
+        createCipher("c2", ["https://github.com/signup"], ["coll-1"]),
+        createCipher("c3", ["https://gitlab.com"], ["coll-1"]),
+      ];
+
+      const members = [createMember("u1", "Alice", "alice@example.com")];
+      const collectionAccess = [createCollectionAccess("coll-1", ["u1"], [])];
+      const groupMemberships: GroupMembershipDetails[] = [];
+
+      const healthMap = new Map([
+        ["c1", createCipherHealth(false)],
+        ["c2", createCipherHealth(false)],
+        ["c3", createCipherHealth(false)],
+      ]);
+      cipherHealthService.checkCipherHealth.mockReturnValue(of(healthMap));
+
+      const mapping = new Map([
+        ["c1", ["u1"]],
+        ["c2", ["u1"]],
+        ["c3", ["u1"]],
+      ]);
+      const registry = createMemberRegistry([
+        { id: "u1", name: "Alice", email: "alice@example.com" },
+      ]);
+      memberCipherMappingService.mapCiphersToMembers.mockReturnValue(of({ mapping, registry }));
+
+      const result = await firstValueFrom(
+        service.generateReport(ciphers, members, collectionAccess, groupMemberships),
+      );
+
+      // Both c1 and c2 should be grouped under github.com
+      const githubReport = result.reports.find((r) => r.applicationName === "github.com");
+      expect(githubReport).toBeDefined();
+      expect(githubReport?.passwordCount).toBe(2);
+      expect(Object.keys(githubReport?.cipherRefs ?? {}).length).toBe(2);
+
+      const gitlabReport = result.reports.find((r) => r.applicationName === "gitlab.com");
+      expect(gitlabReport).toBeDefined();
+      expect(gitlabReport?.passwordCount).toBe(1);
+    });
+
+    it("should build cipherRefs Record with at-risk flags", async () => {
+      const ciphers = [
+        createCipher("c1", ["https://github.com"], ["coll-1"]),
+        createCipher("c2", ["https://github.com"], ["coll-1"]),
+      ];
+
+      const members = [createMember("u1", "Alice", "alice@example.com")];
+      const collectionAccess = [createCollectionAccess("coll-1", ["u1"], [])];
+      const groupMemberships: GroupMembershipDetails[] = [];
+
+      const healthMap = new Map([
+        ["c1", createCipherHealth(true)], // At-risk
+        ["c2", createCipherHealth(false)], // Safe
+      ]);
+      cipherHealthService.checkCipherHealth.mockReturnValue(of(healthMap));
+
+      const mapping = new Map([
+        ["c1", ["u1"]],
+        ["c2", ["u1"]],
+      ]);
+      const registry = createMemberRegistry([
+        { id: "u1", name: "Alice", email: "alice@example.com" },
+      ]);
+      memberCipherMappingService.mapCiphersToMembers.mockReturnValue(of({ mapping, registry }));
+
+      const result = await firstValueFrom(
+        service.generateReport(ciphers, members, collectionAccess, groupMemberships),
+      );
+
+      const report = result.reports[0];
+      expect(report.cipherRefs["c1"]).toBe(true); // At-risk
+      expect(report.cipherRefs["c2"]).toBe(false); // Safe
+      expect(report.passwordCount).toBe(2);
+      expect(report.atRiskPasswordCount).toBe(1);
+    });
+
+    it("should build memberRefs Record with at-risk flags", async () => {
+      const ciphers = [
+        createCipher("c1", ["https://github.com"], ["coll-1"]), // u1 has access
+        createCipher("c2", ["https://github.com"], ["coll-2"]), // u2 has access
+      ];
+
+      const members = [
+        createMember("u1", "Alice", "alice@example.com"),
+        createMember("u2", "Bob", "bob@example.com"),
+      ];
+
+      const collectionAccess = [
+        createCollectionAccess("coll-1", ["u1"], []),
+        createCollectionAccess("coll-2", ["u2"], []),
+      ];
+      const groupMemberships: GroupMembershipDetails[] = [];
+
+      const healthMap = new Map([
+        ["c1", createCipherHealth(true)], // At-risk
+        ["c2", createCipherHealth(false)], // Safe
+      ]);
+      cipherHealthService.checkCipherHealth.mockReturnValue(of(healthMap));
+
+      const mapping = new Map([
+        ["c1", ["u1"]],
+        ["c2", ["u2"]],
+      ]);
+      const registry = createMemberRegistry([
+        { id: "u1", name: "Alice", email: "alice@example.com" },
+        { id: "u2", name: "Bob", email: "bob@example.com" },
+      ]);
+      memberCipherMappingService.mapCiphersToMembers.mockReturnValue(of({ mapping, registry }));
+
+      const result = await firstValueFrom(
+        service.generateReport(ciphers, members, collectionAccess, groupMemberships),
+      );
+
+      const report = result.reports[0];
+      expect(report.memberRefs["u1"]).toBe(true); // u1 has access to at-risk c1
+      expect(report.memberRefs["u2"]).toBe(false); // u2 has access to safe c2
+      expect(report.memberCount).toBe(2);
+      expect(report.atRiskMemberCount).toBe(1);
+    });
+
+    it("should handle cipher with multiple URIs appearing in multiple applications", async () => {
+      const ciphers = [
+        createCipher("c1", ["https://github.com", "https://gitlab.com"], ["coll-1"]),
+      ];
+
+      const members = [createMember("u1", "Alice", "alice@example.com")];
+      const collectionAccess = [createCollectionAccess("coll-1", ["u1"], [])];
+      const groupMemberships: GroupMembershipDetails[] = [];
+
+      const healthMap = new Map([["c1", createCipherHealth(true)]]);
+      cipherHealthService.checkCipherHealth.mockReturnValue(of(healthMap));
+
+      const mapping = new Map([["c1", ["u1"]]]);
+      const registry = createMemberRegistry([
+        { id: "u1", name: "Alice", email: "alice@example.com" },
+      ]);
+      memberCipherMappingService.mapCiphersToMembers.mockReturnValue(of({ mapping, registry }));
+
+      const result = await firstValueFrom(
+        service.generateReport(ciphers, members, collectionAccess, groupMemberships),
+      );
+
+      // Cipher should appear in both github.com and gitlab.com
+      expect(result.reports.length).toBe(2);
+
+      const githubReport = result.reports.find((r) => r.applicationName === "github.com");
+      expect(githubReport?.cipherRefs["c1"]).toBe(true);
+      expect(githubReport?.passwordCount).toBe(1);
+      expect(githubReport?.atRiskPasswordCount).toBe(1);
+
+      const gitlabReport = result.reports.find((r) => r.applicationName === "gitlab.com");
+      expect(gitlabReport?.cipherRefs["c1"]).toBe(true);
+      expect(gitlabReport?.passwordCount).toBe(1);
+      expect(gitlabReport?.atRiskPasswordCount).toBe(1);
+    });
+
+    it("should deduplicate members within application", async () => {
+      const ciphers = [
+        createCipher("c1", ["https://github.com"], ["coll-1"]), // u1 has access
+        createCipher("c2", ["https://github.com"], ["coll-2"]), // u1 also has access
+      ];
+
+      const members = [createMember("u1", "Alice", "alice@example.com")];
+      const collectionAccess = [
+        createCollectionAccess("coll-1", ["u1"], []),
+        createCollectionAccess("coll-2", ["u1"], []),
+      ];
+      const groupMemberships: GroupMembershipDetails[] = [];
+
+      const healthMap = new Map([
+        ["c1", createCipherHealth(true)],
+        ["c2", createCipherHealth(false)],
+      ]);
+      cipherHealthService.checkCipherHealth.mockReturnValue(of(healthMap));
+
+      const mapping = new Map([
+        ["c1", ["u1"]],
+        ["c2", ["u1"]],
+      ]);
+      const registry = createMemberRegistry([
+        { id: "u1", name: "Alice", email: "alice@example.com" },
+      ]);
+      memberCipherMappingService.mapCiphersToMembers.mockReturnValue(of({ mapping, registry }));
+
+      const result = await firstValueFrom(
+        service.generateReport(ciphers, members, collectionAccess, groupMemberships),
+      );
+
+      const report = result.reports[0];
+      // u1 should appear only once despite having access to both ciphers
+      expect(Object.keys(report.memberRefs).length).toBe(1);
+      expect(report.memberRefs["u1"]).toBe(true); // At-risk because c1 is at-risk
+      expect(report.memberCount).toBe(1);
+      expect(report.atRiskMemberCount).toBe(1);
+    });
+  });
+
+  // ==================== Carry-Over Tests ====================
+
+  describe("carryOverApplicationMetadata", () => {
+    it("should carry over isCritical flag from previous report", async () => {
+      const ciphers = [createCipher("c1", ["https://github.com"], ["coll-1"])];
+      const members = [createMember("u1", "Alice", "alice@example.com")];
+      const collectionAccess = [createCollectionAccess("coll-1", ["u1"], [])];
+      const groupMemberships: GroupMembershipDetails[] = [];
+
+      const healthMap = new Map([["c1", createCipherHealth(false)]]);
+      cipherHealthService.checkCipherHealth.mockReturnValue(of(healthMap));
+
+      const mapping = new Map([["c1", ["u1"]]]);
+      const registry = createMemberRegistry([
+        { id: "u1", name: "Alice", email: "alice@example.com" },
+      ]);
+      memberCipherMappingService.mapCiphersToMembers.mockReturnValue(of({ mapping, registry }));
+
+      const previousApplications = [createApplication("github.com", true)];
+
+      const result = await firstValueFrom(
+        service.generateReport(
+          ciphers,
+          members,
+          collectionAccess,
+          groupMemberships,
+          previousApplications,
+        ),
+      );
+
+      const app = result.applications.find((a) => a.applicationName === "github.com");
+      expect(app?.isCritical).toBe(true);
+    });
+
+    it("should carry over reviewedDate from previous report", async () => {
+      const ciphers = [createCipher("c1", ["https://github.com"], ["coll-1"])];
+      const members = [createMember("u1", "Alice", "alice@example.com")];
+      const collectionAccess = [createCollectionAccess("coll-1", ["u1"], [])];
+      const groupMemberships: GroupMembershipDetails[] = [];
+
+      const healthMap = new Map([["c1", createCipherHealth(false)]]);
+      cipherHealthService.checkCipherHealth.mockReturnValue(of(healthMap));
+
+      const mapping = new Map([["c1", ["u1"]]]);
+      const registry = createMemberRegistry([
+        { id: "u1", name: "Alice", email: "alice@example.com" },
+      ]);
+      memberCipherMappingService.mapCiphersToMembers.mockReturnValue(of({ mapping, registry }));
+
+      const reviewedDate = new Date("2024-01-15");
+      const previousApplications = [createApplication("github.com", false, reviewedDate)];
+
+      const result = await firstValueFrom(
+        service.generateReport(
+          ciphers,
+          members,
+          collectionAccess,
+          groupMemberships,
+          previousApplications,
+        ),
+      );
+
+      const app = result.applications.find((a) => a.applicationName === "github.com");
+      expect(app?.reviewedDate).toEqual(reviewedDate);
+    });
+
+    it("should default new applications to isCritical=false and reviewedDate=undefined", async () => {
+      const ciphers = [createCipher("c1", ["https://github.com"], ["coll-1"])];
+      const members = [createMember("u1", "Alice", "alice@example.com")];
+      const collectionAccess = [createCollectionAccess("coll-1", ["u1"], [])];
+      const groupMemberships: GroupMembershipDetails[] = [];
+
+      const healthMap = new Map([["c1", createCipherHealth(false)]]);
+      cipherHealthService.checkCipherHealth.mockReturnValue(of(healthMap));
+
+      const mapping = new Map([["c1", ["u1"]]]);
+      const registry = createMemberRegistry([
+        { id: "u1", name: "Alice", email: "alice@example.com" },
+      ]);
+      memberCipherMappingService.mapCiphersToMembers.mockReturnValue(of({ mapping, registry }));
+
+      // No previous applications
+      const result = await firstValueFrom(
+        service.generateReport(ciphers, members, collectionAccess, groupMemberships),
+      );
+
+      const app = result.applications.find((a) => a.applicationName === "github.com");
+      expect(app?.isCritical).toBe(false);
+      expect(app?.reviewedDate).toBeUndefined();
+    });
+
+    it("should not include deleted applications from previous report", async () => {
+      const ciphers = [createCipher("c1", ["https://github.com"], ["coll-1"])];
+      const members = [createMember("u1", "Alice", "alice@example.com")];
+      const collectionAccess = [createCollectionAccess("coll-1", ["u1"], [])];
+      const groupMemberships: GroupMembershipDetails[] = [];
+
+      const healthMap = new Map([["c1", createCipherHealth(false)]]);
+      cipherHealthService.checkCipherHealth.mockReturnValue(of(healthMap));
+
+      const mapping = new Map([["c1", ["u1"]]]);
+      const registry = createMemberRegistry([
+        { id: "u1", name: "Alice", email: "alice@example.com" },
+      ]);
+      memberCipherMappingService.mapCiphersToMembers.mockReturnValue(of({ mapping, registry }));
+
+      // Previous report had gitlab.com which no longer exists
+      const previousApplications = [
+        createApplication("github.com", true),
+        createApplication("gitlab.com", true), // Deleted app
+      ];
+
+      const result = await firstValueFrom(
+        service.generateReport(
+          ciphers,
+          members,
+          collectionAccess,
+          groupMemberships,
+          previousApplications,
+        ),
+      );
+
+      expect(result.applications.length).toBe(1);
+      expect(result.applications.find((a) => a.applicationName === "gitlab.com")).toBeUndefined();
+    });
+  });
+
+  // ==================== Summary Tests ====================
+
+  describe("recomputeSummary", () => {
+    it("should compute correct total counts", async () => {
+      const ciphers = [
+        createCipher("c1", ["https://github.com"], ["coll-1"]),
+        createCipher("c2", ["https://gitlab.com"], ["coll-2"]),
+      ];
+
+      const members = [
+        createMember("u1", "Alice", "alice@example.com"),
+        createMember("u2", "Bob", "bob@example.com"),
+      ];
+
+      const collectionAccess = [
+        createCollectionAccess("coll-1", ["u1"], []),
+        createCollectionAccess("coll-2", ["u2"], []),
+      ];
+      const groupMemberships: GroupMembershipDetails[] = [];
+
+      const healthMap = new Map([
+        ["c1", createCipherHealth(true)], // At-risk
+        ["c2", createCipherHealth(false)], // Safe
+      ]);
+      cipherHealthService.checkCipherHealth.mockReturnValue(of(healthMap));
+
+      const mapping = new Map([
+        ["c1", ["u1"]],
+        ["c2", ["u2"]],
+      ]);
+      const registry = createMemberRegistry([
+        { id: "u1", name: "Alice", email: "alice@example.com" },
+        { id: "u2", name: "Bob", email: "bob@example.com" },
+      ]);
+      memberCipherMappingService.mapCiphersToMembers.mockReturnValue(of({ mapping, registry }));
+
+      const result = await firstValueFrom(
+        service.generateReport(ciphers, members, collectionAccess, groupMemberships),
+      );
+
+      expect(result.summary.totalApplicationCount).toBe(2);
+      expect(result.summary.totalAtRiskApplicationCount).toBe(1); // github.com
+      expect(result.summary.totalMemberCount).toBe(2);
+      expect(result.summary.totalAtRiskMemberCount).toBe(1); // u1 has access to at-risk c1
+    });
+
+    it("should deduplicate at-risk members across applications", async () => {
+      const ciphers = [
+        createCipher("c1", ["https://github.com"], ["coll-1"]), // u1 has access
+        createCipher("c2", ["https://gitlab.com"], ["coll-2"]), // u1 also has access
+      ];
+
+      const members = [createMember("u1", "Alice", "alice@example.com")];
+
+      const collectionAccess = [
+        createCollectionAccess("coll-1", ["u1"], []),
+        createCollectionAccess("coll-2", ["u1"], []),
+      ];
+      const groupMemberships: GroupMembershipDetails[] = [];
+
+      const healthMap = new Map([
+        ["c1", createCipherHealth(true)], // At-risk
+        ["c2", createCipherHealth(true)], // At-risk
+      ]);
+      cipherHealthService.checkCipherHealth.mockReturnValue(of(healthMap));
+
+      const mapping = new Map([
+        ["c1", ["u1"]],
+        ["c2", ["u1"]],
+      ]);
+      const registry = createMemberRegistry([
+        { id: "u1", name: "Alice", email: "alice@example.com" },
+      ]);
+      memberCipherMappingService.mapCiphersToMembers.mockReturnValue(of({ mapping, registry }));
+
+      const result = await firstValueFrom(
+        service.generateReport(ciphers, members, collectionAccess, groupMemberships),
+      );
+
+      // u1 appears in both applications, but should be counted once
+      expect(result.summary.totalAtRiskMemberCount).toBe(1);
+    });
+
+    it("should compute correct critical application counts", async () => {
+      const ciphers = [
+        createCipher("c1", ["https://github.com"], ["coll-1"]),
+        createCipher("c2", ["https://gitlab.com"], ["coll-2"]),
+      ];
+
+      const members = [
+        createMember("u1", "Alice", "alice@example.com"),
+        createMember("u2", "Bob", "bob@example.com"),
+      ];
+
+      const collectionAccess = [
+        createCollectionAccess("coll-1", ["u1"], []),
+        createCollectionAccess("coll-2", ["u2"], []),
+      ];
+      const groupMemberships: GroupMembershipDetails[] = [];
+
+      const healthMap = new Map([
+        ["c1", createCipherHealth(true)], // At-risk
+        ["c2", createCipherHealth(false)], // Safe
+      ]);
+      cipherHealthService.checkCipherHealth.mockReturnValue(of(healthMap));
+
+      const mapping = new Map([
+        ["c1", ["u1"]],
+        ["c2", ["u2"]],
+      ]);
+      const registry = createMemberRegistry([
+        { id: "u1", name: "Alice", email: "alice@example.com" },
+        { id: "u2", name: "Bob", email: "bob@example.com" },
+      ]);
+      memberCipherMappingService.mapCiphersToMembers.mockReturnValue(of({ mapping, registry }));
+
+      // Mark github.com as critical
+      const previousApplications = [createApplication("github.com", true)];
+
+      const result = await firstValueFrom(
+        service.generateReport(
+          ciphers,
+          members,
+          collectionAccess,
+          groupMemberships,
+          previousApplications,
+        ),
+      );
+
+      expect(result.summary.totalCriticalApplicationCount).toBe(1); // github.com
+      expect(result.summary.totalCriticalAtRiskApplicationCount).toBe(1); // github.com is at-risk
+      expect(result.summary.totalCriticalMemberCount).toBe(1); // u1
+      expect(result.summary.totalCriticalAtRiskMemberCount).toBe(1); // u1 is at-risk
+    });
+  });
+
+  // ==================== Member Registry Tests ====================
+
+  describe("Member Registry", () => {
+    it("should create registry with all unique members", async () => {
+      const ciphers = [
+        createCipher("c1", ["https://github.com"], ["coll-1"]),
+        createCipher("c2", ["https://gitlab.com"], ["coll-2"]),
+      ];
+
+      const members = [
+        createMember("u1", "Alice", "alice@example.com"),
+        createMember("u2", "Bob", "bob@example.com"),
+      ];
+
+      const collectionAccess = [
+        createCollectionAccess("coll-1", ["u1"], []),
+        createCollectionAccess("coll-2", ["u2"], []),
+      ];
+      const groupMemberships: GroupMembershipDetails[] = [];
+
+      const healthMap = new Map([
+        ["c1", createCipherHealth(false)],
+        ["c2", createCipherHealth(false)],
+      ]);
+      cipherHealthService.checkCipherHealth.mockReturnValue(of(healthMap));
+
+      const mapping = new Map([
+        ["c1", ["u1"]],
+        ["c2", ["u2"]],
+      ]);
+      const registry = createMemberRegistry([
+        { id: "u1", name: "Alice", email: "alice@example.com" },
+        { id: "u2", name: "Bob", email: "bob@example.com" },
+      ]);
+      memberCipherMappingService.mapCiphersToMembers.mockReturnValue(of({ mapping, registry }));
+
+      const result = await firstValueFrom(
+        service.generateReport(ciphers, members, collectionAccess, groupMemberships),
+      );
+
+      expect(Object.keys(result.memberRegistry).length).toBe(2);
+      expect(result.memberRegistry["u1"]).toEqual({
+        id: "u1",
+        userName: "Alice",
+        email: "alice@example.com",
+      });
+      expect(result.memberRegistry["u2"]).toEqual({
+        id: "u2",
+        userName: "Bob",
+        email: "bob@example.com",
+      });
+    });
+
+    it("should ensure all report memberRefs exist in registry", async () => {
+      const ciphers = [createCipher("c1", ["https://github.com"], ["coll-1"])];
+      const members = [createMember("u1", "Alice", "alice@example.com")];
+      const collectionAccess = [createCollectionAccess("coll-1", ["u1"], [])];
+      const groupMemberships: GroupMembershipDetails[] = [];
+
+      const healthMap = new Map([["c1", createCipherHealth(false)]]);
+      cipherHealthService.checkCipherHealth.mockReturnValue(of(healthMap));
+
+      const mapping = new Map([["c1", ["u1"]]]);
+      const registry = createMemberRegistry([
+        { id: "u1", name: "Alice", email: "alice@example.com" },
+      ]);
+      memberCipherMappingService.mapCiphersToMembers.mockReturnValue(of({ mapping, registry }));
+
+      const result = await firstValueFrom(
+        service.generateReport(ciphers, members, collectionAccess, groupMemberships),
+      );
+
+      // All member IDs in reports should exist in registry
+      result.reports.forEach((report) => {
+        Object.keys(report.memberRefs).forEach((memberId) => {
+          expect(result.memberRegistry[memberId]).toBeDefined();
+        });
+      });
+    });
+  });
+});

--- a/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/domain/default-report-generation.service.ts
+++ b/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/domain/default-report-generation.service.ts
@@ -1,0 +1,222 @@
+import { forkJoin, map, Observable } from "rxjs";
+
+import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+import { LogService } from "@bitwarden/logging";
+
+import { getTrimmedCipherUris } from "../../../../reports/risk-insights/helpers";
+import {
+  AccessReportSettingsView,
+  ApplicationHealthView,
+  AccessReportView,
+  MemberRegistry,
+} from "../../../models";
+import { CipherHealthService } from "../../abstractions/cipher-health.service";
+import {
+  CollectionAccessDetails,
+  GroupMembershipDetails,
+  MemberCipherMappingService,
+  OrganizationUserView,
+} from "../../abstractions/member-cipher-mapping.service";
+import { ReportGenerationService } from "../../abstractions/report-generation.service";
+
+/**
+ * Default implementation of ReportGenerationService.
+ *
+ * Orchestrates health checks, member mapping, aggregation, and summary computation
+ * from pre-loaded organization data.
+ */
+export class DefaultReportGenerationService extends ReportGenerationService {
+  constructor(
+    private cipherHealthService: CipherHealthService,
+    private memberCipherMappingService: MemberCipherMappingService,
+    private logService: LogService,
+  ) {
+    super();
+  }
+
+  generateReport(
+    ciphers: CipherView[],
+    members: OrganizationUserView[],
+    collectionAccess: CollectionAccessDetails[],
+    groupMemberships: GroupMembershipDetails[],
+    previousApplications?: AccessReportSettingsView[],
+  ): Observable<AccessReportView> {
+    this.logService.debug("[DefaultReportGenerationService] Starting report generation", {
+      cipherCount: ciphers.length,
+      memberCount: members.length,
+      collectionCount: collectionAccess.length,
+      groupCount: groupMemberships.length,
+    });
+
+    return this.runHealthAndMappingPipeline(
+      ciphers,
+      members,
+      collectionAccess,
+      groupMemberships,
+    ).pipe(
+      map(({ ciphers: processedCiphers, healthMap, memberMapping, registry }) => {
+        const reports = this.aggregateIntoReports(processedCiphers, healthMap, memberMapping);
+
+        // Build view and populate with generated data
+        const view = new AccessReportView();
+        view.id = "" as any; // Temporary ID, will be set by persistence service on save
+        view.reports = reports;
+        view.memberRegistry = registry;
+        view.creationDate = new Date();
+
+        // Carry over application metadata from previous report
+        this.carryOverApplicationMetadata(view, previousApplications ?? []);
+
+        // Compute summary (delegates to smart model method)
+        view.recomputeSummary();
+
+        return view;
+      }),
+    );
+  }
+
+  /**
+   * Runs health checks and member mapping in parallel
+   */
+  private runHealthAndMappingPipeline(
+    ciphers: CipherView[],
+    members: OrganizationUserView[],
+    collectionAccess: CollectionAccessDetails[],
+    groupMemberships: GroupMembershipDetails[],
+  ): Observable<{
+    ciphers: CipherView[];
+    healthMap: Map<string, any>;
+    memberMapping: Map<string, string[]>;
+    registry: MemberRegistry;
+  }> {
+    this.logService.debug("[DefaultReportGenerationService] Running health and mapping pipeline");
+
+    return forkJoin({
+      healthMap: this.cipherHealthService.checkCipherHealth(ciphers),
+      mappingResult: this.memberCipherMappingService.mapCiphersToMembers(
+        ciphers,
+        members,
+        collectionAccess,
+        groupMemberships,
+      ),
+    }).pipe(
+      map(({ healthMap, mappingResult }) => ({
+        ciphers,
+        healthMap,
+        memberMapping: mappingResult.mapping,
+        registry: mappingResult.registry,
+      })),
+    );
+  }
+
+  /**
+   * Aggregates ciphers into per-application reports
+   *
+   * Groups ciphers by trimmed URI and builds memberRefs/cipherRefs Records
+   */
+  private aggregateIntoReports(
+    ciphers: CipherView[],
+    healthMap: Map<string, any>,
+    memberMapping: Map<string, string[]>,
+  ): ApplicationHealthView[] {
+    const applicationMap = this.groupCiphersByApplication(ciphers);
+
+    const reports: ApplicationHealthView[] = [];
+
+    applicationMap.forEach((cipherGroup, applicationName) => {
+      const report = new ApplicationHealthView();
+      report.applicationName = applicationName;
+
+      const allMemberIds = new Set<string>();
+      const atRiskMemberIds = new Set<string>();
+
+      cipherGroup.forEach((cipher) => {
+        const health = healthMap.get(cipher.id);
+        const isAtRisk = health?.isAtRisk() ?? false;
+
+        // Add cipher to cipherRefs Record
+        report.cipherRefs[cipher.id] = isAtRisk;
+
+        if (isAtRisk) {
+          report.atRiskPasswordCount++;
+        }
+
+        // Get members who have access to this cipher
+        const memberIds = memberMapping.get(cipher.id) ?? [];
+        memberIds.forEach((memberId) => {
+          allMemberIds.add(memberId);
+          if (isAtRisk) {
+            atRiskMemberIds.add(memberId);
+          }
+        });
+      });
+
+      // Build memberRefs Record from collected member IDs
+      allMemberIds.forEach((memberId) => {
+        report.memberRefs[memberId] = atRiskMemberIds.has(memberId);
+      });
+
+      // Set computed counts
+      report.passwordCount = cipherGroup.length;
+      report.memberCount = allMemberIds.size;
+      report.atRiskMemberCount = atRiskMemberIds.size;
+
+      // Pre-compute icon metadata from first cipher for display efficiency
+      if (cipherGroup.length > 0) {
+        const firstCipher = cipherGroup[0];
+        report.iconCipherId = firstCipher.id;
+        report.iconUri = firstCipher.login?.uris?.[0]?.uri ?? applicationName;
+      }
+
+      reports.push(report);
+    });
+
+    return reports;
+  }
+
+  /**
+   * Groups ciphers by trimmed URI (application name)
+   */
+  private groupCiphersByApplication(ciphers: CipherView[]): Map<string, CipherView[]> {
+    const applicationMap = new Map<string, CipherView[]>();
+
+    ciphers.forEach((cipher) => {
+      const trimmedUris = getTrimmedCipherUris(cipher);
+
+      trimmedUris.forEach((uri) => {
+        const existing = applicationMap.get(uri) ?? [];
+        existing.push(cipher);
+        applicationMap.set(uri, existing);
+      });
+    });
+
+    return applicationMap;
+  }
+
+  /**
+   * Carries over application metadata from previous report
+   *
+   * Populates the view's applications array by matching report names with
+   * previous application data, preserving critical flags and review dates.
+   *
+   * @param view - The view to populate with applications
+   * @param previousApplications - Previous application metadata to carry over
+   */
+  private carryOverApplicationMetadata(
+    view: AccessReportView,
+    previousApplications: AccessReportSettingsView[],
+  ): void {
+    const previousMap = new Map(previousApplications.map((app) => [app.applicationName, app]));
+
+    view.applications = view.reports.map((report) => {
+      const previous = previousMap.get(report.applicationName);
+
+      const app = new AccessReportSettingsView();
+      app.applicationName = report.applicationName;
+      app.isCritical = previous?.isCritical ?? false;
+      app.reviewedDate = previous?.reviewedDate;
+
+      return app;
+    });
+  }
+}

--- a/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/legacy/legacy-risk-insights-encryption.service.spec.ts
+++ b/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/legacy/legacy-risk-insights-encryption.service.spec.ts
@@ -1,0 +1,457 @@
+import { mock } from "jest-mock-extended";
+import { BehaviorSubject } from "rxjs";
+
+import { KeyGenerationService } from "@bitwarden/common/key-management/crypto";
+import { EncryptService } from "@bitwarden/common/key-management/crypto/abstractions/encrypt.service";
+import { EncString } from "@bitwarden/common/key-management/crypto/models/enc-string";
+import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
+import { makeSymmetricCryptoKey } from "@bitwarden/common/spec";
+import { OrganizationId, UserId } from "@bitwarden/common/types/guid";
+import { OrgKey } from "@bitwarden/common/types/key";
+import { KeyService } from "@bitwarden/key-management";
+import { LogService } from "@bitwarden/logging";
+
+import {
+  MemberRegistryEntryData,
+  ApplicationHealthData,
+} from "../../../../access-intelligence/models";
+import { DecryptedReportData } from "../../../../reports/risk-insights/models";
+import {
+  mockApplicationData,
+  mockReportData,
+  mockSummaryData,
+} from "../../../../reports/risk-insights/models/mocks/mock-data";
+import { EncryptedReportData } from "../../abstractions/access-report-encryption.service";
+
+import { LegacyRiskInsightsEncryptionService } from "./legacy-risk-insights-encryption.service";
+
+describe("LegacyRiskInsightsEncryptionService", () => {
+  let service: LegacyRiskInsightsEncryptionService;
+  const mockKeyService = mock<KeyService>();
+  const mockEncryptService = mock<EncryptService>();
+  const mockKeyGenerationService = mock<KeyGenerationService>();
+  const mockLogService = mock<LogService>();
+
+  const ENCRYPTED_TEXT = "This data has been encrypted";
+  const ENCRYPTED_KEY = "Re-encrypted Cipher Key";
+  const orgId = "org-123" as OrganizationId;
+  const userId = "user-123" as UserId;
+  const orgKey = makeSymmetricCryptoKey<OrgKey>();
+  const contentEncryptionKey = new SymmetricCryptoKey(new Uint8Array(64));
+  const testData = { foo: "bar" };
+  const OrgRecords: Record<OrganizationId, OrgKey> = {
+    [orgId]: orgKey,
+    ["testOrg" as OrganizationId]: makeSymmetricCryptoKey<OrgKey>(),
+  };
+  const orgKey$ = new BehaviorSubject(OrgRecords);
+
+  let mockDecryptedData: DecryptedReportData;
+  let mockEncryptedData: EncryptedReportData;
+  let mockKey: EncString;
+
+  beforeEach(() => {
+    service = new LegacyRiskInsightsEncryptionService(
+      mockKeyService,
+      mockEncryptService,
+      mockKeyGenerationService,
+      mockLogService,
+    );
+
+    jest.clearAllMocks();
+
+    // Always use the same contentEncryptionKey for both encrypt and decrypt tests
+    mockKeyGenerationService.createKey.mockResolvedValue(contentEncryptionKey);
+    mockEncryptService.wrapSymmetricKey.mockResolvedValue(new EncString(ENCRYPTED_KEY));
+    mockEncryptService.encryptString.mockResolvedValue(new EncString(ENCRYPTED_TEXT));
+    mockEncryptService.unwrapSymmetricKey.mockResolvedValue(contentEncryptionKey);
+    mockEncryptService.decryptString.mockResolvedValue(JSON.stringify(testData));
+    mockKeyService.orgKeys$.mockReturnValue(orgKey$);
+
+    mockKey = new EncString("wrapped-key");
+    mockEncryptedData = {
+      encryptedReportData: new EncString(JSON.stringify(mockReportData)),
+      encryptedSummaryData: new EncString(JSON.stringify(mockSummaryData)),
+      encryptedApplicationData: new EncString(JSON.stringify(mockApplicationData)),
+    };
+    mockDecryptedData = {
+      reportData: mockReportData,
+      summaryData: mockSummaryData,
+      applicationData: mockApplicationData,
+    };
+  });
+
+  describe("encryptRiskInsightsReport", () => {
+    it("should encrypt data and return encrypted packet", async () => {
+      // arrange: setup our mocks
+      mockKeyService.orgKeys$.mockReturnValue(orgKey$);
+
+      // Act: call the method under test
+      const result = await service.encryptRiskInsightsReport(
+        { organizationId: orgId, userId },
+        mockDecryptedData,
+      );
+
+      // Assert: ensure that the methods were called with the expected parameters
+      expect(mockKeyService.orgKeys$).toHaveBeenCalledWith(userId);
+      expect(mockKeyGenerationService.createKey).toHaveBeenCalledWith(512);
+
+      // Assert all variables were encrypted
+      expect(mockEncryptService.encryptString).toHaveBeenCalledWith(
+        JSON.stringify(mockDecryptedData.reportData),
+        contentEncryptionKey,
+      );
+      expect(mockEncryptService.encryptString).toHaveBeenCalledWith(
+        JSON.stringify(mockDecryptedData.summaryData),
+        contentEncryptionKey,
+      );
+      expect(mockEncryptService.encryptString).toHaveBeenCalledWith(
+        JSON.stringify(mockDecryptedData.applicationData),
+        contentEncryptionKey,
+      );
+
+      expect(mockEncryptService.wrapSymmetricKey).toHaveBeenCalledWith(
+        contentEncryptionKey,
+        orgKey,
+      );
+
+      // Mocked encrypt returns ENCRYPTED_TEXT
+      expect(result).toEqual({
+        organizationId: orgId,
+        encryptedReportData: new EncString(ENCRYPTED_TEXT),
+        encryptedSummaryData: new EncString(ENCRYPTED_TEXT),
+        encryptedApplicationData: new EncString(ENCRYPTED_TEXT),
+        contentEncryptionKey: new EncString(ENCRYPTED_KEY),
+      });
+    });
+
+    it("should throw an error when encrypted text is null or empty", async () => {
+      // arrange: setup our mocks
+      mockKeyService.orgKeys$.mockReturnValue(orgKey$);
+      mockEncryptService.encryptString.mockResolvedValue(new EncString(""));
+      mockEncryptService.wrapSymmetricKey.mockResolvedValue(new EncString(ENCRYPTED_KEY));
+
+      // Act & Assert: call the method under test and expect rejection
+      await expect(
+        service.encryptRiskInsightsReport({ organizationId: orgId, userId }, mockDecryptedData),
+      ).rejects.toThrow("Encryption failed, encrypted strings are null");
+    });
+
+    it("should throw an error when encrypted key is null or empty", async () => {
+      // arrange: setup our mocks
+      mockKeyService.orgKeys$.mockReturnValue(orgKey$);
+      mockEncryptService.encryptString.mockResolvedValue(new EncString(ENCRYPTED_TEXT));
+      mockEncryptService.wrapSymmetricKey.mockResolvedValue(new EncString(""));
+
+      // Act & Assert: call the method under test and expect rejection
+      await expect(
+        service.encryptRiskInsightsReport({ organizationId: orgId, userId }, mockDecryptedData),
+      ).rejects.toThrow("Encryption failed, encrypted strings are null");
+    });
+
+    it("should throw if org key is not found", async () => {
+      // when we cannot get an organization key, we should throw an error
+      mockKeyService.orgKeys$.mockReturnValue(new BehaviorSubject({}));
+
+      await expect(
+        service.encryptRiskInsightsReport({ organizationId: orgId, userId }, mockDecryptedData),
+      ).rejects.toThrow("Organization key not found");
+    });
+  });
+
+  describe("decryptRiskInsightsReport", () => {
+    it("should decrypt data and return original object", async () => {
+      // Arrange: setup our mocks with valid data structures
+      mockKeyService.orgKeys$.mockReturnValue(orgKey$);
+      mockEncryptService.unwrapSymmetricKey.mockResolvedValue(contentEncryptionKey);
+
+      // Mock decryption to return valid data for each call
+      mockEncryptService.decryptString
+        .mockResolvedValueOnce(JSON.stringify(mockReportData))
+        .mockResolvedValueOnce(JSON.stringify(mockSummaryData))
+        .mockResolvedValueOnce(JSON.stringify(mockApplicationData));
+
+      // act: call the decrypt method
+      const result = await service.decryptRiskInsightsReport(
+        { organizationId: orgId, userId },
+        mockEncryptedData,
+        mockKey,
+      );
+
+      expect(mockKeyService.orgKeys$).toHaveBeenCalledWith(userId);
+      expect(mockEncryptService.unwrapSymmetricKey).toHaveBeenCalledWith(mockKey, orgKey);
+      expect(mockEncryptService.decryptString).toHaveBeenCalledTimes(3);
+
+      // Verify decrypted data matches the mocked valid data
+      expect(result).toEqual({
+        reportData: mockReportData,
+        summaryData: mockSummaryData,
+        applicationData: mockApplicationData,
+      });
+    });
+
+    it("should invoke data type validation method during decryption", async () => {
+      // Arrange: setup our mocks with valid data structures
+      mockKeyService.orgKeys$.mockReturnValue(orgKey$);
+      mockEncryptService.unwrapSymmetricKey.mockResolvedValue(contentEncryptionKey);
+
+      // Mock decryption to return valid data for each call
+      mockEncryptService.decryptString
+        .mockResolvedValueOnce(JSON.stringify(mockReportData))
+        .mockResolvedValueOnce(JSON.stringify(mockSummaryData))
+        .mockResolvedValueOnce(JSON.stringify(mockApplicationData));
+
+      // act: call the decrypt method
+      const result = await service.decryptRiskInsightsReport(
+        { organizationId: orgId, userId },
+        mockEncryptedData,
+        mockKey,
+      );
+
+      // Verify that validation passed and returned the correct data
+      expect(result).toEqual({
+        reportData: mockReportData,
+        summaryData: mockSummaryData,
+        applicationData: mockApplicationData,
+      });
+    });
+
+    it("should return null if org key is not found", async () => {
+      mockKeyService.orgKeys$.mockReturnValue(new BehaviorSubject({}));
+      await expect(
+        service.decryptRiskInsightsReport(
+          { organizationId: orgId, userId },
+
+          mockEncryptedData,
+          mockKey,
+        ),
+      ).rejects.toEqual(Error("Organization key not found"));
+    });
+
+    it("should throw if decrypt throws", async () => {
+      mockKeyService.orgKeys$.mockReturnValue(orgKey$);
+      mockEncryptService.unwrapSymmetricKey.mockRejectedValue(new Error("fail"));
+
+      await expect(
+        service.decryptRiskInsightsReport(
+          { organizationId: orgId, userId },
+
+          mockEncryptedData,
+          mockKey,
+        ),
+      ).rejects.toEqual(Error("fail"));
+    });
+
+    it("should throw error when report data validation fails", async () => {
+      mockKeyService.orgKeys$.mockReturnValue(orgKey$);
+      mockEncryptService.unwrapSymmetricKey.mockResolvedValue(contentEncryptionKey);
+
+      // Mock decryption to return invalid data
+      mockEncryptService.decryptString
+        .mockResolvedValueOnce(JSON.stringify([{ invalid: "data" }])) // invalid report data
+        .mockResolvedValueOnce(JSON.stringify(mockSummaryData))
+        .mockResolvedValueOnce(JSON.stringify(mockApplicationData));
+
+      await expect(
+        service.decryptRiskInsightsReport(
+          { organizationId: orgId, userId },
+          mockEncryptedData,
+          mockKey,
+        ),
+      ).rejects.toThrow(
+        /Report data validation failed.*This may indicate data corruption or tampering/,
+      );
+    });
+
+    it("should throw error when summary data validation fails", async () => {
+      mockKeyService.orgKeys$.mockReturnValue(orgKey$);
+      mockEncryptService.unwrapSymmetricKey.mockResolvedValue(contentEncryptionKey);
+
+      // Clear and reset the mock
+      mockEncryptService.decryptString.mockReset();
+
+      // Mock decryption - report data should succeed, summary should fail
+      mockEncryptService.decryptString
+        .mockResolvedValueOnce(JSON.stringify(mockReportData)) // valid
+        .mockResolvedValueOnce(JSON.stringify({ invalid: "summary" })) // invalid summary data - fails here
+        .mockResolvedValueOnce(JSON.stringify(mockApplicationData)); // won't be called but prevents fallback
+
+      await expect(
+        service.decryptRiskInsightsReport(
+          { organizationId: orgId, userId },
+          mockEncryptedData,
+          mockKey,
+        ),
+      ).rejects.toThrow(
+        /Summary data validation failed.*This may indicate data corruption or tampering/,
+      );
+    });
+
+    it("should throw error when application data validation fails", async () => {
+      mockKeyService.orgKeys$.mockReturnValue(orgKey$);
+      mockEncryptService.unwrapSymmetricKey.mockResolvedValue(contentEncryptionKey);
+
+      // Clear and reset the mock
+      mockEncryptService.decryptString.mockReset();
+
+      // Mock decryption - report and summary should succeed, application should fail
+      mockEncryptService.decryptString
+        .mockResolvedValueOnce(JSON.stringify(mockReportData)) // valid
+        .mockResolvedValueOnce(JSON.stringify(mockSummaryData)) // valid
+        .mockResolvedValueOnce(JSON.stringify([{ invalid: "application" }])); // invalid app data
+
+      await expect(
+        service.decryptRiskInsightsReport(
+          { organizationId: orgId, userId },
+          mockEncryptedData,
+          mockKey,
+        ),
+      ).rejects.toThrow(
+        /Application data validation failed.*This may indicate data corruption or tampering/,
+      );
+    });
+
+    it("should transform V2 blob into V1 ApplicationHealthReportDetail[] without throwing", async () => {
+      mockKeyService.orgKeys$.mockReturnValue(orgKey$);
+      mockEncryptService.unwrapSymmetricKey.mockResolvedValue(contentEncryptionKey);
+
+      const registry: Record<string, MemberRegistryEntryData> = {
+        "member-1": { id: "member-1", userName: "Alice", email: "alice@example.com" },
+        "member-2": { id: "member-2", userName: "Bob", email: "bob@example.com" },
+      };
+      const v2Report: ApplicationHealthData = Object.assign(new ApplicationHealthData(), {
+        applicationName: "app.example.com",
+        passwordCount: 3,
+        atRiskPasswordCount: 1,
+        memberCount: 2,
+        atRiskMemberCount: 1,
+        memberRefs: { "member-1": true, "member-2": false },
+        cipherRefs: { "cipher-a": true, "cipher-b": false, "cipher-c": false },
+      });
+      const v2Blob = { version: 1, data: { reports: [v2Report], memberRegistry: registry } };
+
+      mockEncryptService.decryptString
+        .mockResolvedValueOnce(JSON.stringify(v2Blob))
+        .mockResolvedValueOnce(JSON.stringify(mockSummaryData))
+        .mockResolvedValueOnce(JSON.stringify(mockApplicationData));
+
+      const result = await service.decryptRiskInsightsReport(
+        { organizationId: orgId, userId },
+        mockEncryptedData,
+        mockKey,
+      );
+
+      expect(result.reportData).toHaveLength(1);
+      const app = result.reportData[0];
+      expect(app.applicationName).toBe("app.example.com");
+      expect(app.passwordCount).toBe(3);
+      expect(app.atRiskPasswordCount).toBe(1);
+      expect(app.memberCount).toBe(2);
+      expect(app.atRiskMemberCount).toBe(1);
+      expect(app.cipherIds).toContain("cipher-a");
+      expect(app.cipherIds).toContain("cipher-b");
+      expect(app.atRiskCipherIds).toEqual(["cipher-a"]);
+      expect(app.memberDetails).toHaveLength(2);
+      expect(app.memberDetails.find((m) => m.email === "alice@example.com")).toBeDefined();
+      expect(app.memberDetails.find((m) => m.email === "bob@example.com")).toBeDefined();
+      expect(app.atRiskMemberDetails).toHaveLength(1);
+      expect(app.atRiskMemberDetails[0].email).toBe("alice@example.com");
+      // cipherId sentinel
+      expect(
+        app.memberDetails.every((m) => m.cipherId === "00000000-0000-0000-0000-000000000000"),
+      ).toBe(true);
+    });
+
+    it("should return empty reportData array when V2 blob has empty reports", async () => {
+      mockKeyService.orgKeys$.mockReturnValue(orgKey$);
+      mockEncryptService.unwrapSymmetricKey.mockResolvedValue(contentEncryptionKey);
+
+      const v2Blob = {
+        version: 1,
+        data: {
+          reports: [] as ApplicationHealthData[],
+          memberRegistry: {} as Record<string, MemberRegistryEntryData>,
+        },
+      };
+
+      mockEncryptService.decryptString
+        .mockResolvedValueOnce(JSON.stringify(v2Blob))
+        .mockResolvedValueOnce(JSON.stringify(mockSummaryData))
+        .mockResolvedValueOnce(JSON.stringify(mockApplicationData));
+
+      const result = await service.decryptRiskInsightsReport(
+        { organizationId: orgId, userId },
+        mockEncryptedData,
+        mockKey,
+      );
+
+      expect(result.reportData).toEqual([]);
+    });
+
+    it("should skip members not found in registry during V2 downgrade", async () => {
+      mockKeyService.orgKeys$.mockReturnValue(orgKey$);
+      mockEncryptService.unwrapSymmetricKey.mockResolvedValue(contentEncryptionKey);
+
+      const registry: Record<string, MemberRegistryEntryData> = {
+        "member-1": { id: "member-1", userName: "Alice", email: "alice@example.com" },
+        // member-2 intentionally missing from registry
+      };
+      const v2Report: ApplicationHealthData = Object.assign(new ApplicationHealthData(), {
+        applicationName: "app.example.com",
+        passwordCount: 1,
+        atRiskPasswordCount: 0,
+        memberCount: 2,
+        atRiskMemberCount: 0,
+        memberRefs: { "member-1": false, "member-2": false },
+        cipherRefs: {},
+      });
+      const v2Blob = { version: 1, data: { reports: [v2Report], memberRegistry: registry } };
+
+      mockEncryptService.decryptString
+        .mockResolvedValueOnce(JSON.stringify(v2Blob))
+        .mockResolvedValueOnce(JSON.stringify(mockSummaryData))
+        .mockResolvedValueOnce(JSON.stringify(mockApplicationData));
+
+      const result = await service.decryptRiskInsightsReport(
+        { organizationId: orgId, userId },
+        mockEncryptedData,
+        mockKey,
+      );
+
+      // Only the member found in registry appears
+      expect(result.reportData[0].memberDetails).toHaveLength(1);
+      expect(result.reportData[0].memberDetails[0].email).toBe("alice@example.com");
+    });
+
+    it("should throw error for invalid date in application data", async () => {
+      mockKeyService.orgKeys$.mockReturnValue(orgKey$);
+      mockEncryptService.unwrapSymmetricKey.mockResolvedValue(contentEncryptionKey);
+
+      const invalidApplicationData = [
+        {
+          applicationName: "Test App",
+          isCritical: true,
+          reviewedDate: "invalid-date-string",
+        },
+      ];
+
+      // Clear and reset the mock
+      mockEncryptService.decryptString.mockReset();
+
+      // Mock decryption - report and summary succeed, application with invalid date fails
+      mockEncryptService.decryptString
+        .mockResolvedValueOnce(JSON.stringify(mockReportData)) // valid
+        .mockResolvedValueOnce(JSON.stringify(mockSummaryData)) // valid
+        .mockResolvedValueOnce(JSON.stringify(invalidApplicationData)); // invalid date
+
+      await expect(
+        service.decryptRiskInsightsReport(
+          { organizationId: orgId, userId },
+          mockEncryptedData,
+          mockKey,
+        ),
+      ).rejects.toThrow(
+        /Application data validation failed.*This may indicate data corruption or tampering/,
+      );
+    });
+  });
+});

--- a/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/legacy/legacy-risk-insights-encryption.service.ts
+++ b/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/legacy/legacy-risk-insights-encryption.service.ts
@@ -1,0 +1,365 @@
+import { firstValueFrom, map } from "rxjs";
+
+import { KeyGenerationService } from "@bitwarden/common/key-management/crypto";
+import { EncryptService } from "@bitwarden/common/key-management/crypto/abstractions/encrypt.service";
+import { EncString } from "@bitwarden/common/key-management/crypto/models/enc-string";
+import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
+import { CipherId, OrganizationId, UserId } from "@bitwarden/common/types/guid";
+import { KeyService } from "@bitwarden/key-management";
+import { LogService } from "@bitwarden/logging";
+
+import {
+  createNewSummaryData,
+  validateAccessReportPayload,
+  validateApplicationHealthReportDetailArray,
+  validateOrganizationReportApplicationArray,
+  validateOrganizationReportSummary,
+} from "../../../../reports/risk-insights/helpers";
+import {
+  ApplicationHealthReportDetail,
+  DecryptedReportData,
+  MemberDetails,
+  OrganizationReportApplication,
+  OrganizationReportSummary,
+} from "../../../../reports/risk-insights/models";
+import { MemberRegistryEntryData, ApplicationHealthData } from "../../../models";
+import {
+  EncryptedDataWithKey,
+  EncryptedReportData,
+} from "../../abstractions/access-report-encryption.service";
+import { isVersionEnvelope } from "../../abstractions/versioning.service";
+
+/**
+ * @deprecated V1 encryption service. Used only by the V1 orchestrator, V1 report service,
+ * and the V1→V2 migration path. Will be deleted when the V1 code tree is removed.
+ * For V2, use {@link DefaultAccessReportEncryptionService}.
+ */
+export class LegacyRiskInsightsEncryptionService {
+  /**
+   * Sentinel value for MemberDetails.cipherId in downgraded V2→V1 reports.
+   * V2 does not store per-cipher member associations (that mapping was already lossy in V1
+   * due to email-based deduplication — see report-data-model-evolution.md). An empty string
+   * fails isBoundedString, and using the userId risks confusion, so we use the nil UUID.
+   */
+  private readonly _nilCipherId = "00000000-0000-0000-0000-000000000000" as CipherId;
+
+  constructor(
+    private keyService: KeyService,
+    private encryptService: EncryptService,
+    private keyGeneratorService: KeyGenerationService,
+    private logService: LogService,
+  ) {}
+
+  async encryptRiskInsightsReport(
+    context: {
+      organizationId: OrganizationId;
+      userId: UserId;
+    },
+    data: DecryptedReportData,
+    wrappedKey?: EncString,
+  ): Promise<EncryptedDataWithKey> {
+    this.logService.info("[LegacyRiskInsightsEncryptionService] Encrypting risk insights report");
+    const { userId, organizationId } = context;
+    const orgKey = await firstValueFrom(
+      this.keyService
+        .orgKeys$(userId)
+        .pipe(
+          map((organizationKeysById) =>
+            organizationKeysById ? organizationKeysById[organizationId] : null,
+          ),
+        ),
+    );
+
+    if (!orgKey) {
+      this.logService.warning(
+        "[LegacyRiskInsightsEncryptionService] Attempted to encrypt report data without org id",
+      );
+      throw new Error("Organization key not found");
+    }
+
+    let contentEncryptionKey: SymmetricCryptoKey;
+    try {
+      if (!wrappedKey) {
+        // Generate a new key
+        contentEncryptionKey = await this.keyGeneratorService.createKey(512);
+      } else {
+        // Unwrap the existing key
+        contentEncryptionKey = await this.encryptService.unwrapSymmetricKey(wrappedKey, orgKey);
+      }
+    } catch (error: unknown) {
+      this.logService.error(
+        "[LegacyRiskInsightsEncryptionService] Failed to get encryption key",
+        error,
+      );
+      throw new Error("Failed to get encryption key");
+    }
+
+    const { reportData, summaryData, applicationData } = data;
+
+    // Encrypt the data
+    const encryptedReportData = await this.encryptService.encryptString(
+      JSON.stringify(reportData),
+      contentEncryptionKey,
+    );
+    const encryptedSummaryData = await this.encryptService.encryptString(
+      JSON.stringify(summaryData),
+      contentEncryptionKey,
+    );
+    const encryptedApplicationData = await this.encryptService.encryptString(
+      JSON.stringify(applicationData),
+      contentEncryptionKey,
+    );
+
+    const wrappedEncryptionKey = await this.encryptService.wrapSymmetricKey(
+      contentEncryptionKey,
+      orgKey,
+    );
+
+    if (
+      !encryptedReportData.encryptedString ||
+      !encryptedSummaryData.encryptedString ||
+      !encryptedApplicationData.encryptedString ||
+      !wrappedEncryptionKey.encryptedString
+    ) {
+      this.logService.error(
+        "[LegacyRiskInsightsEncryptionService] Encryption failed, encrypted strings are null",
+      );
+      throw new Error("Encryption failed, encrypted strings are null");
+    }
+
+    const encryptedDataPacket: EncryptedDataWithKey = {
+      organizationId,
+      encryptedReportData: encryptedReportData,
+      encryptedSummaryData: encryptedSummaryData,
+      encryptedApplicationData: encryptedApplicationData,
+      contentEncryptionKey: wrappedEncryptionKey,
+    };
+
+    return encryptedDataPacket;
+  }
+
+  async decryptRiskInsightsReport(
+    context: {
+      organizationId: OrganizationId;
+      userId: UserId;
+    },
+    encryptedData: EncryptedReportData,
+    wrappedKey: EncString,
+  ): Promise<DecryptedReportData> {
+    this.logService.info("[LegacyRiskInsightsEncryptionService] Decrypting risk insights report");
+
+    const { userId, organizationId } = context;
+    const orgKey = await firstValueFrom(
+      this.keyService
+        .orgKeys$(userId)
+        .pipe(
+          map((organizationKeysById) =>
+            organizationKeysById ? organizationKeysById[organizationId] : null,
+          ),
+        ),
+    );
+
+    if (!orgKey) {
+      this.logService.warning(
+        "[LegacyRiskInsightsEncryptionService] Attempted to decrypt report data without org id",
+      );
+      throw new Error("Organization key not found");
+    }
+
+    const unwrappedEncryptionKey = await this.encryptService.unwrapSymmetricKey(wrappedKey, orgKey);
+    if (!unwrappedEncryptionKey) {
+      this.logService.error("[LegacyRiskInsightsEncryptionService] Encryption key not found");
+      throw Error("Encryption key not found");
+    }
+
+    const { encryptedReportData, encryptedSummaryData, encryptedApplicationData } = encryptedData;
+
+    // Decrypt the data
+    const decryptedReportData = await this._handleDecryptReport(
+      encryptedReportData,
+      unwrappedEncryptionKey,
+    );
+    const decryptedSummaryData = await this._handleDecryptSummary(
+      encryptedSummaryData,
+      unwrappedEncryptionKey,
+    );
+    const decryptedApplicationData = await this._handleDecryptApplication(
+      encryptedApplicationData,
+      unwrappedEncryptionKey,
+    );
+
+    const decryptedFullReport = {
+      reportData: decryptedReportData,
+      summaryData: decryptedSummaryData,
+      applicationData: decryptedApplicationData,
+    };
+
+    return decryptedFullReport;
+  }
+
+  private async _handleDecryptReport(
+    encryptedData: EncString | null,
+    key: SymmetricCryptoKey,
+  ): Promise<ApplicationHealthReportDetail[]> {
+    if (encryptedData == null) {
+      return [];
+    }
+
+    try {
+      const decryptedData = await this.encryptService.decryptString(encryptedData, key);
+      const parsedData = JSON.parse(decryptedData);
+
+      // Downgrade path: V2 blob detected in V1 context (feature flag was reverted).
+      // Validate and reconstruct V1 structure from V2 payload using the member registry.
+      if (isVersionEnvelope(parsedData)) {
+        this.logService.warning(
+          "[LegacyRiskInsightsEncryptionService] V2 report detected in V1 path, running downgrade transform",
+        );
+        const payload = validateAccessReportPayload(parsedData.data);
+        return this._convertV2ReportToV1(payload.reports, payload.memberRegistry);
+      }
+
+      // Normal V1 path: validate parsed data structure with runtime type guards
+      return validateApplicationHealthReportDetailArray(parsedData);
+    } catch (error: unknown) {
+      // Log detailed error for debugging
+      this.logService.error(
+        "[LegacyRiskInsightsEncryptionService] Failed to decrypt report",
+        error,
+      );
+      // Always throw generic message to prevent information disclosure
+      // Original error with detailed validation info is logged, not exposed to caller
+      throw new Error(
+        "Report data validation failed. This may indicate data corruption or tampering.",
+      );
+    }
+  }
+
+  private async _handleDecryptSummary(
+    encryptedData: EncString | null,
+    key: SymmetricCryptoKey,
+  ): Promise<OrganizationReportSummary> {
+    if (encryptedData == null) {
+      return createNewSummaryData();
+    }
+
+    try {
+      const decryptedData = await this.encryptService.decryptString(encryptedData, key);
+      const parsedData = JSON.parse(decryptedData);
+
+      // Downgrade path: V2 summary blob is a VersionEnvelope wrapping the summary payload.
+      // Extract the inner data before validating.
+      if (isVersionEnvelope(parsedData)) {
+        this.logService.warning(
+          "[LegacyRiskInsightsEncryptionService] Versioned summary detected in legacy path, extracting payload",
+        );
+        return validateOrganizationReportSummary(parsedData.data);
+      }
+
+      return validateOrganizationReportSummary(parsedData);
+    } catch (error: unknown) {
+      // Log detailed error for debugging
+      this.logService.error(
+        "[LegacyRiskInsightsEncryptionService] Failed to decrypt report summary",
+        error,
+      );
+      // Always throw generic message to prevent information disclosure
+      // Original error with detailed validation info is logged, not exposed to caller
+      throw new Error(
+        "Summary data validation failed. This may indicate data corruption or tampering.",
+      );
+    }
+  }
+
+  private async _handleDecryptApplication(
+    encryptedData: EncString | null,
+    key: SymmetricCryptoKey,
+  ): Promise<OrganizationReportApplication[]> {
+    if (encryptedData == null) {
+      return [];
+    }
+
+    try {
+      const decryptedData = await this.encryptService.decryptString(encryptedData, key);
+      const parsedData = JSON.parse(decryptedData);
+
+      // Downgrade path: V2 application blob is a VersionEnvelope wrapping an array.
+      // Extract the array and convert reviewedDate: string|undefined → Date|null for V1 consumers.
+      if (isVersionEnvelope(parsedData)) {
+        this.logService.warning(
+          "[LegacyRiskInsightsEncryptionService] V2 application format detected in V1 path, running downgrade transform",
+        );
+        return (parsedData.data as Record<string, unknown>[]).map((app) => ({
+          applicationName: app["applicationName"] as string,
+          isCritical: app["isCritical"] as boolean,
+          reviewedDate:
+            typeof app["reviewedDate"] === "string" ? new Date(app["reviewedDate"]) : null,
+        }));
+      }
+
+      // Normal V1 path: validate parsed data structure with runtime type guards
+      return validateOrganizationReportApplicationArray(parsedData);
+    } catch (error: unknown) {
+      // Log detailed error for debugging
+      this.logService.error(
+        "[LegacyRiskInsightsEncryptionService] Failed to decrypt report applications",
+        error,
+      );
+      // Always throw generic message to prevent information disclosure
+      // Original error with detailed validation info is logged, not exposed to caller
+      throw new Error(
+        "Application data validation failed. This may indicate data corruption or tampering.",
+      );
+    }
+  }
+
+  /**
+   * Reconstructs a V1 ApplicationHealthReportDetail[] from a V2 report payload.
+   * Used when a V2-format blob is encountered during V1 decryption (feature flag downgrade).
+   */
+  private _convertV2ReportToV1(
+    reports: ApplicationHealthData[],
+    memberRegistry: Record<string, MemberRegistryEntryData>,
+  ): ApplicationHealthReportDetail[] {
+    return reports.map((report) => {
+      const cipherIds = Object.keys(report.cipherRefs) as CipherId[];
+      const atRiskCipherIds = Object.entries(report.cipherRefs)
+        .filter(([, isAtRisk]) => isAtRisk)
+        .map(([id]) => id as CipherId);
+
+      const toMemberDetails = (userId: string): MemberDetails | null => {
+        const entry = memberRegistry[userId];
+        if (!entry) {
+          return null;
+        }
+        return {
+          userGuid: entry.id,
+          userName: entry.userName ?? null, // V1 uses null; V2 uses undefined
+          email: entry.email,
+          cipherId: this._nilCipherId,
+        };
+      };
+
+      const memberDetails = Object.keys(report.memberRefs)
+        .map(toMemberDetails)
+        .filter((m): m is MemberDetails => m !== null);
+
+      const atRiskMemberDetails = Object.entries(report.memberRefs)
+        .filter(([, isAtRisk]) => isAtRisk)
+        .map(([userId]) => toMemberDetails(userId))
+        .filter((m): m is MemberDetails => m !== null);
+
+      return {
+        applicationName: report.applicationName,
+        passwordCount: report.passwordCount,
+        atRiskPasswordCount: report.atRiskPasswordCount,
+        memberCount: report.memberCount,
+        atRiskMemberCount: report.atRiskMemberCount,
+        cipherIds,
+        atRiskCipherIds,
+        memberDetails,
+        atRiskMemberDetails,
+      };
+    });
+  }
+}

--- a/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/persistence/default-access-report-encryption.service.spec.ts
+++ b/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/persistence/default-access-report-encryption.service.spec.ts
@@ -1,0 +1,441 @@
+import { mock } from "jest-mock-extended";
+import { BehaviorSubject, firstValueFrom } from "rxjs";
+
+import { KeyGenerationService } from "@bitwarden/common/key-management/crypto";
+import { EncryptService } from "@bitwarden/common/key-management/crypto/abstractions/encrypt.service";
+import { EncString } from "@bitwarden/common/key-management/crypto/models/enc-string";
+import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
+import { makeSymmetricCryptoKey } from "@bitwarden/common/spec";
+import { OrganizationId, UserId } from "@bitwarden/common/types/guid";
+import { OrgKey } from "@bitwarden/common/types/key";
+import { KeyService } from "@bitwarden/key-management";
+import { LogService } from "@bitwarden/logging";
+
+import { AccessReportSettingsData } from "../../../../access-intelligence/models";
+import { mockSummaryData } from "../../../../reports/risk-insights/models/mocks/mock-data";
+import {
+  AccessReportPayload,
+  DecryptedAccessReportData,
+  EncryptedReportData,
+} from "../../abstractions/access-report-encryption.service";
+import { UnsupportedVersionError } from "../../abstractions/versioning.service";
+
+import { DefaultAccessReportEncryptionService } from "./default-access-report-encryption.service";
+import { ApplicationVersioningService } from "./versioning/application-versioning.service";
+import { ReportVersioningService } from "./versioning/report-versioning.service";
+import { SummaryVersioningService } from "./versioning/summary-versioning.service";
+
+describe("DefaultAccessReportEncryptionService", () => {
+  let service: DefaultAccessReportEncryptionService;
+  const mockKeyService = mock<KeyService>();
+  const mockEncryptService = mock<EncryptService>();
+  const mockKeyGenerationService = mock<KeyGenerationService>();
+  const mockLogService = mock<LogService>();
+  const mockReportVersioningService = mock<ReportVersioningService>();
+  const mockApplicationVersioningService = mock<ApplicationVersioningService>();
+  const mockSummaryVersioningService = mock<SummaryVersioningService>();
+
+  const ENCRYPTED_TEXT = "This data has been encrypted";
+  const ENCRYPTED_KEY = "Re-encrypted Cipher Key";
+  const SERIALIZED_REPORT = '{"version":1,"data":{"serialized":"report"}}';
+  const SERIALIZED_SUMMARY = '{"version":1,"data":{"serialized":"summary"}}';
+  const SERIALIZED_APPLICATION = '{"version":1,"data":{"serialized":"application"}}';
+
+  const orgId = "org-123" as OrganizationId;
+  const userId = "user-123" as UserId;
+  const orgKey = makeSymmetricCryptoKey<OrgKey>();
+  const contentEncryptionKey = new SymmetricCryptoKey(new Uint8Array(64));
+  const OrgRecords: Record<OrganizationId, OrgKey> = {
+    [orgId]: orgKey,
+  };
+  const orgKey$ = new BehaviorSubject(OrgRecords);
+
+  const mockV2ReportData: AccessReportPayload = {
+    reports: [
+      {
+        applicationName: "app.com",
+        passwordCount: 3,
+        atRiskPasswordCount: 1,
+        memberRefs: { "user-1": true, "user-2": false },
+        cipherRefs: { "cipher-1": true, "cipher-2": false },
+        memberCount: 2,
+        atRiskMemberCount: 1,
+      },
+    ],
+    memberRegistry: {
+      "user-1": { id: "user-1", userName: "Alice", email: "alice@example.com" },
+      "user-2": { id: "user-2", userName: "Bob", email: "bob@example.com" },
+    },
+  };
+
+  const mockV2ApplicationData: AccessReportSettingsData[] = [
+    {
+      applicationName: "application1.com",
+      isCritical: true,
+      reviewedDate: "2024-01-15T10:30:00.000Z",
+    },
+    { applicationName: "application2.com", isCritical: false, reviewedDate: undefined },
+  ];
+
+  const mockV2Input: DecryptedAccessReportData = {
+    reportData: mockV2ReportData,
+    summaryData: mockSummaryData,
+    applicationData: mockV2ApplicationData,
+  };
+
+  let mockEncryptedData: EncryptedReportData;
+  let mockKey: EncString;
+
+  beforeEach(() => {
+    service = new DefaultAccessReportEncryptionService(
+      mockKeyService,
+      mockEncryptService,
+      mockKeyGenerationService,
+      mockReportVersioningService,
+      mockApplicationVersioningService,
+      mockSummaryVersioningService,
+      mockLogService,
+    );
+
+    jest.clearAllMocks();
+
+    mockKeyGenerationService.createKey.mockResolvedValue(contentEncryptionKey);
+    mockEncryptService.wrapSymmetricKey.mockResolvedValue(new EncString(ENCRYPTED_KEY));
+    mockEncryptService.encryptString.mockResolvedValue(new EncString(ENCRYPTED_TEXT));
+    mockEncryptService.unwrapSymmetricKey.mockResolvedValue(contentEncryptionKey);
+    mockKeyService.orgKeys$.mockReturnValue(orgKey$);
+
+    // Default: decryptString returns parseable JSON (overridden per-test as needed)
+    mockEncryptService.decryptString.mockResolvedValue("{}");
+
+    // Versioning service serialize mocks
+    mockReportVersioningService.serialize.mockReturnValue(SERIALIZED_REPORT);
+    mockSummaryVersioningService.serialize.mockReturnValue(SERIALIZED_SUMMARY);
+    mockApplicationVersioningService.serialize.mockReturnValue(SERIALIZED_APPLICATION);
+
+    // Versioning service process mocks — return valid data by default
+    mockReportVersioningService.process.mockReturnValue({
+      data: mockV2ReportData,
+      wasLegacy: false,
+    });
+    mockSummaryVersioningService.process.mockReturnValue({
+      data: mockSummaryData,
+      wasLegacy: false,
+    });
+    mockApplicationVersioningService.process.mockReturnValue({
+      data: mockV2ApplicationData,
+      wasLegacy: false,
+    });
+
+    mockKey = new EncString("wrapped-key");
+    mockEncryptedData = {
+      encryptedReportData: new EncString("encrypted-reports"),
+      encryptedSummaryData: new EncString("encrypted-summary"),
+      encryptedApplicationData: new EncString("encrypted-applications"),
+    };
+  });
+
+  describe("encryptReport$", () => {
+    it("should encrypt V2 data and return EncryptedDataWithKey", async () => {
+      const result = await firstValueFrom(
+        service.encryptReport$({ organizationId: orgId, userId }, mockV2Input),
+      );
+
+      expect(mockKeyService.orgKeys$).toHaveBeenCalledWith(userId);
+      expect(mockKeyGenerationService.createKey).toHaveBeenCalledWith(512);
+      expect(mockReportVersioningService.serialize).toHaveBeenCalledWith(mockV2Input.reportData);
+      expect(mockSummaryVersioningService.serialize).toHaveBeenCalledWith(mockV2Input.summaryData);
+      expect(mockApplicationVersioningService.serialize).toHaveBeenCalledWith(
+        mockV2Input.applicationData,
+      );
+      expect(mockEncryptService.encryptString).toHaveBeenCalledWith(
+        SERIALIZED_REPORT,
+        contentEncryptionKey,
+      );
+      expect(mockEncryptService.encryptString).toHaveBeenCalledWith(
+        SERIALIZED_SUMMARY,
+        contentEncryptionKey,
+      );
+      expect(mockEncryptService.encryptString).toHaveBeenCalledWith(
+        SERIALIZED_APPLICATION,
+        contentEncryptionKey,
+      );
+      expect(mockEncryptService.wrapSymmetricKey).toHaveBeenCalledWith(
+        contentEncryptionKey,
+        orgKey,
+      );
+
+      expect(result).toEqual({
+        organizationId: orgId,
+        encryptedReportData: new EncString(ENCRYPTED_TEXT),
+        encryptedSummaryData: new EncString(ENCRYPTED_TEXT),
+        encryptedApplicationData: new EncString(ENCRYPTED_TEXT),
+        contentEncryptionKey: new EncString(ENCRYPTED_KEY),
+      });
+    });
+
+    it("should reuse existing key when wrappedKey is provided", async () => {
+      await firstValueFrom(
+        service.encryptReport$({ organizationId: orgId, userId }, mockV2Input, mockKey),
+      );
+
+      expect(mockKeyGenerationService.createKey).not.toHaveBeenCalled();
+      expect(mockEncryptService.unwrapSymmetricKey).toHaveBeenCalledWith(mockKey, orgKey);
+    });
+
+    it("should throw if org key is not found", async () => {
+      mockKeyService.orgKeys$.mockReturnValue(new BehaviorSubject({}));
+
+      await expect(
+        firstValueFrom(service.encryptReport$({ organizationId: orgId, userId }, mockV2Input)),
+      ).rejects.toThrow("Organization key not found");
+    });
+
+    it("should throw if key operation fails", async () => {
+      mockKeyGenerationService.createKey.mockRejectedValue(new Error("Key generation failed"));
+
+      await expect(
+        firstValueFrom(service.encryptReport$({ organizationId: orgId, userId }, mockV2Input)),
+      ).rejects.toThrow("Failed to get encryption key");
+    });
+
+    it("should throw when encrypted strings are empty", async () => {
+      mockEncryptService.encryptString.mockResolvedValue(new EncString(""));
+
+      await expect(
+        firstValueFrom(service.encryptReport$({ organizationId: orgId, userId }, mockV2Input)),
+      ).rejects.toThrow("Encryption failed, encrypted strings are null");
+    });
+  });
+
+  describe("decryptReport$", () => {
+    it("should decrypt V2 data and return DecryptedAccessReportData", async () => {
+      const result = await firstValueFrom(
+        service.decryptReport$({ organizationId: orgId, userId }, mockEncryptedData, mockKey),
+      );
+
+      expect(result.reportData.reports).toHaveLength(1);
+      expect(result.reportData.reports[0].applicationName).toBe("app.com");
+      expect(result.reportData.memberRegistry).toHaveProperty("user-1");
+      expect(result.summaryData).toEqual(mockSummaryData);
+      expect(result.hadLegacyBlobs).toBeUndefined();
+    });
+
+    it("should set hadLegacyBlobs when any blob was legacy", async () => {
+      mockReportVersioningService.process.mockReturnValue({
+        data: mockV2ReportData,
+        wasLegacy: true,
+      });
+
+      const result = await firstValueFrom(
+        service.decryptReport$({ organizationId: orgId, userId }, mockEncryptedData, mockKey),
+      );
+
+      expect(result.hadLegacyBlobs).toBe(true);
+    });
+
+    it("should throw when report format is not recognized", async () => {
+      mockReportVersioningService.process.mockImplementation(() => {
+        throw new UnsupportedVersionError(undefined);
+      });
+
+      await expect(
+        firstValueFrom(
+          service.decryptReport$({ organizationId: orgId, userId }, mockEncryptedData, mockKey),
+        ),
+      ).rejects.toThrow(UnsupportedVersionError);
+    });
+
+    it("should throw when report blob is null", async () => {
+      const encryptedDataWithNullReport: EncryptedReportData = {
+        encryptedReportData: null as unknown as EncString,
+        encryptedSummaryData: new EncString("encrypted-summary"),
+        encryptedApplicationData: new EncString("encrypted-applications"),
+      };
+
+      await expect(
+        firstValueFrom(
+          service.decryptReport$(
+            { organizationId: orgId, userId },
+            encryptedDataWithNullReport,
+            mockKey,
+          ),
+        ),
+      ).rejects.toThrow("Report data is missing. Run migration before loading this report.");
+    });
+
+    it("should throw if org key is not found", async () => {
+      mockKeyService.orgKeys$.mockReturnValue(new BehaviorSubject({}));
+
+      await expect(
+        firstValueFrom(
+          service.decryptReport$({ organizationId: orgId, userId }, mockEncryptedData, mockKey),
+        ),
+      ).rejects.toThrow("Organization key not found");
+    });
+
+    it("should throw if content encryption key is null after unwrap", async () => {
+      mockEncryptService.unwrapSymmetricKey.mockResolvedValue(
+        null as unknown as SymmetricCryptoKey,
+      );
+
+      await expect(
+        firstValueFrom(
+          service.decryptReport$({ organizationId: orgId, userId }, mockEncryptedData, mockKey),
+        ),
+      ).rejects.toThrow("Encryption key not found");
+    });
+
+    it("should throw when summary data validation fails", async () => {
+      mockSummaryVersioningService.process.mockImplementation(() => {
+        throw new Error(
+          "Summary data validation failed. This may indicate data corruption or tampering.",
+        );
+      });
+
+      await expect(
+        firstValueFrom(
+          service.decryptReport$({ organizationId: orgId, userId }, mockEncryptedData, mockKey),
+        ),
+      ).rejects.toThrow(
+        /Summary data validation failed.*This may indicate data corruption or tampering/,
+      );
+    });
+
+    it("should throw when application data validation fails", async () => {
+      mockApplicationVersioningService.process.mockImplementation(() => {
+        throw new Error(
+          "Application data validation failed. This may indicate data corruption or tampering.",
+        );
+      });
+
+      await expect(
+        firstValueFrom(
+          service.decryptReport$({ organizationId: orgId, userId }, mockEncryptedData, mockKey),
+        ),
+      ).rejects.toThrow(
+        /Application data validation failed.*This may indicate data corruption or tampering/,
+      );
+    });
+
+    it("should throw when summary blob is null", async () => {
+      const encryptedDataWithNullSummary: EncryptedReportData = {
+        encryptedReportData: new EncString("encrypted-reports"),
+        encryptedSummaryData: null as unknown as EncString,
+        encryptedApplicationData: new EncString("encrypted-applications"),
+      };
+
+      await expect(
+        firstValueFrom(
+          service.decryptReport$(
+            { organizationId: orgId, userId },
+            encryptedDataWithNullSummary,
+            mockKey,
+          ),
+        ),
+      ).rejects.toThrow("Summary data not found");
+    });
+
+    it("should return empty application array when application blob is null", async () => {
+      const encryptedDataWithNullApps: EncryptedReportData = {
+        encryptedReportData: new EncString("encrypted-reports"),
+        encryptedSummaryData: new EncString("encrypted-summary"),
+        encryptedApplicationData: null as unknown as EncString,
+      };
+
+      mockApplicationVersioningService.process.mockReturnValue({
+        data: [],
+        wasLegacy: false,
+      });
+
+      const result = await firstValueFrom(
+        service.decryptReport$(
+          { organizationId: orgId, userId },
+          encryptedDataWithNullApps,
+          mockKey,
+        ),
+      );
+
+      expect(result.applicationData).toEqual([]);
+    });
+  });
+
+  describe("decryptSummary$", () => {
+    it("should decrypt summary data and return AccessReportSummaryData", async () => {
+      const result = await firstValueFrom(
+        service.decryptSummary$(
+          { organizationId: orgId, userId },
+          new EncString("encrypted-summary"),
+          mockKey,
+        ),
+      );
+
+      expect(mockKeyService.orgKeys$).toHaveBeenCalledWith(userId);
+      expect(mockEncryptService.unwrapSymmetricKey).toHaveBeenCalledWith(mockKey, orgKey);
+      expect(mockSummaryVersioningService.process).toHaveBeenCalled();
+      expect(result).toEqual(mockSummaryData);
+    });
+
+    it("should throw if org key is not found", async () => {
+      mockKeyService.orgKeys$.mockReturnValue(new BehaviorSubject({}));
+
+      await expect(
+        firstValueFrom(
+          service.decryptSummary$(
+            { organizationId: orgId, userId },
+            new EncString("encrypted-summary"),
+            mockKey,
+          ),
+        ),
+      ).rejects.toThrow("Organization key not found");
+    });
+
+    it("should throw if content encryption key is null after unwrap", async () => {
+      mockEncryptService.unwrapSymmetricKey.mockResolvedValue(
+        null as unknown as SymmetricCryptoKey,
+      );
+
+      await expect(
+        firstValueFrom(
+          service.decryptSummary$(
+            { organizationId: orgId, userId },
+            new EncString("encrypted-summary"),
+            mockKey,
+          ),
+        ),
+      ).rejects.toThrow("Encryption key not found");
+    });
+
+    it("should throw when summary blob is null", async () => {
+      await expect(
+        firstValueFrom(
+          service.decryptSummary$(
+            { organizationId: orgId, userId },
+            null as unknown as EncString,
+            mockKey,
+          ),
+        ),
+      ).rejects.toThrow("Summary data not found");
+    });
+
+    it("should throw when summary data validation fails", async () => {
+      mockSummaryVersioningService.process.mockImplementation(() => {
+        throw new Error(
+          "Summary data validation failed. This may indicate data corruption or tampering.",
+        );
+      });
+
+      await expect(
+        firstValueFrom(
+          service.decryptSummary$(
+            { organizationId: orgId, userId },
+            new EncString("encrypted-summary"),
+            mockKey,
+          ),
+        ),
+      ).rejects.toThrow(
+        /Summary data validation failed.*This may indicate data corruption or tampering/,
+      );
+    });
+  });
+});

--- a/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/persistence/default-access-report-encryption.service.ts
+++ b/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/persistence/default-access-report-encryption.service.ts
@@ -1,0 +1,258 @@
+import { Observable, catchError, forkJoin, from, map, switchMap, take } from "rxjs";
+
+import { KeyGenerationService } from "@bitwarden/common/key-management/crypto";
+import { EncryptService } from "@bitwarden/common/key-management/crypto/abstractions/encrypt.service";
+import { EncString } from "@bitwarden/common/key-management/crypto/models/enc-string";
+import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
+import { OrganizationId, UserId } from "@bitwarden/common/types/guid";
+import { KeyService } from "@bitwarden/key-management";
+import { LogService } from "@bitwarden/logging";
+
+import { AccessReportSummaryData } from "../../../models";
+import {
+  AccessReportEncryptionService,
+  DecryptedAccessReportData,
+  EncryptedDataWithKey,
+  EncryptedReportData,
+} from "../../abstractions/access-report-encryption.service";
+
+import { ApplicationVersioningService } from "./versioning/application-versioning.service";
+import { ReportVersioningService } from "./versioning/report-versioning.service";
+import { SummaryVersioningService } from "./versioning/summary-versioning.service";
+
+export class DefaultAccessReportEncryptionService extends AccessReportEncryptionService {
+  constructor(
+    private keyService: KeyService,
+    private encryptService: EncryptService,
+    private keyGeneratorService: KeyGenerationService,
+    private reportVersioningService: ReportVersioningService,
+    private applicationVersioningService: ApplicationVersioningService,
+    private summaryVersioningService: SummaryVersioningService,
+    private logService: LogService,
+  ) {
+    super();
+  }
+
+  encryptReport$(
+    context: { organizationId: OrganizationId; userId: UserId },
+    data: DecryptedAccessReportData,
+    wrappedKey?: EncString,
+  ): Observable<EncryptedDataWithKey> {
+    this.logService.info("[DefaultAccessReportEncryptionService] Encrypting report");
+    const { userId, organizationId } = context;
+
+    return this.keyService.orgKeys$(userId).pipe(
+      take(1),
+      map((keys) => (keys ? keys[organizationId] : null)),
+      switchMap((orgKey) => {
+        if (!orgKey) {
+          this.logService.warning(
+            "[DefaultAccessReportEncryptionService] Attempted to encrypt without org key",
+          );
+          throw new Error("Organization key not found");
+        }
+
+        const contentKey$ = (
+          wrappedKey
+            ? from(this.encryptService.unwrapSymmetricKey(wrappedKey, orgKey))
+            : from(this.keyGeneratorService.createKey(512))
+        ).pipe(
+          catchError((error: unknown) => {
+            this.logService.error(
+              "[DefaultAccessReportEncryptionService] Failed to get encryption key",
+              error,
+            );
+            throw new Error("Failed to get encryption key");
+          }),
+        );
+
+        return contentKey$.pipe(
+          switchMap((contentEncryptionKey) => {
+            const { reportData, summaryData, applicationData } = data;
+
+            return forkJoin({
+              encryptedReportData: from(
+                this.encryptService.encryptString(
+                  this.reportVersioningService.serialize(reportData),
+                  contentEncryptionKey,
+                ),
+              ),
+              encryptedSummaryData: from(
+                this.encryptService.encryptString(
+                  this.summaryVersioningService.serialize(summaryData),
+                  contentEncryptionKey,
+                ),
+              ),
+              encryptedApplicationData: from(
+                this.encryptService.encryptString(
+                  this.applicationVersioningService.serialize(applicationData),
+                  contentEncryptionKey,
+                ),
+              ),
+              wrappedEncryptionKey: from(
+                this.encryptService.wrapSymmetricKey(contentEncryptionKey, orgKey),
+              ),
+            });
+          }),
+          map(
+            ({
+              encryptedReportData,
+              encryptedSummaryData,
+              encryptedApplicationData,
+              wrappedEncryptionKey,
+            }) => {
+              if (
+                !encryptedReportData.encryptedString ||
+                !encryptedSummaryData.encryptedString ||
+                !encryptedApplicationData.encryptedString ||
+                !wrappedEncryptionKey.encryptedString
+              ) {
+                this.logService.error(
+                  "[DefaultAccessReportEncryptionService] Encryption failed, encrypted strings are null",
+                );
+                throw new Error("Encryption failed, encrypted strings are null");
+              }
+
+              return {
+                organizationId,
+                encryptedReportData,
+                encryptedSummaryData,
+                encryptedApplicationData,
+                contentEncryptionKey: wrappedEncryptionKey,
+              } satisfies EncryptedDataWithKey;
+            },
+          ),
+        );
+      }),
+    );
+  }
+
+  decryptReport$(
+    context: { organizationId: OrganizationId; userId: UserId },
+    encryptedData: EncryptedReportData,
+    wrappedKey: EncString,
+  ): Observable<DecryptedAccessReportData> {
+    this.logService.info("[DefaultAccessReportEncryptionService] Decrypting report");
+    const { userId, organizationId } = context;
+
+    return this.keyService.orgKeys$(userId).pipe(
+      take(1),
+      map((keys) => (keys ? keys[organizationId] : null)),
+      switchMap((orgKey) => {
+        if (!orgKey) {
+          this.logService.warning(
+            "[DefaultAccessReportEncryptionService] Attempted to decrypt without org key",
+          );
+          throw new Error("Organization key not found");
+        }
+
+        return from(this.encryptService.unwrapSymmetricKey(wrappedKey, orgKey)).pipe(
+          switchMap((contentEncryptionKey) => {
+            if (!contentEncryptionKey) {
+              this.logService.error(
+                "[DefaultAccessReportEncryptionService] Encryption key not found",
+              );
+              throw new Error("Encryption key not found");
+            }
+
+            const { encryptedReportData, encryptedSummaryData, encryptedApplicationData } =
+              encryptedData;
+
+            return forkJoin({
+              report: from(this._decryptBlob(encryptedReportData, contentEncryptionKey, "report")),
+              summary: from(
+                this._decryptBlob(encryptedSummaryData, contentEncryptionKey, "summary"),
+              ),
+              application: from(
+                this._decryptBlob(encryptedApplicationData, contentEncryptionKey, "application"),
+              ),
+            }).pipe(
+              map(({ report, summary, application }) => {
+                const reportResult = this.reportVersioningService.process(report);
+                const summaryResult = this.summaryVersioningService.process(summary);
+                const applicationResult = this.applicationVersioningService.process(application);
+
+                const hadLegacyBlobs =
+                  reportResult.wasLegacy || summaryResult.wasLegacy || applicationResult.wasLegacy;
+
+                return {
+                  reportData: reportResult.data,
+                  summaryData: summaryResult.data,
+                  applicationData: applicationResult.data,
+                  ...(hadLegacyBlobs ? { hadLegacyBlobs: true } : {}),
+                };
+              }),
+            );
+          }),
+        );
+      }),
+    );
+  }
+
+  decryptSummary$(
+    context: { organizationId: OrganizationId; userId: UserId },
+    encryptedSummary: EncString,
+    wrappedKey: EncString,
+  ): Observable<AccessReportSummaryData> {
+    this.logService.info("[DefaultAccessReportEncryptionService] Decrypting summary");
+    const { userId, organizationId } = context;
+
+    return this.keyService.orgKeys$(userId).pipe(
+      take(1),
+      map((keys) => (keys ? keys[organizationId] : null)),
+      switchMap((orgKey) => {
+        if (!orgKey) {
+          this.logService.warning(
+            "[DefaultAccessReportEncryptionService] Attempted to decrypt without org key",
+          );
+          throw new Error("Organization key not found");
+        }
+
+        return from(this.encryptService.unwrapSymmetricKey(wrappedKey, orgKey)).pipe(
+          switchMap((contentEncryptionKey) => {
+            if (!contentEncryptionKey) {
+              this.logService.error(
+                "[DefaultAccessReportEncryptionService] Encryption key not found",
+              );
+              throw new Error("Encryption key not found");
+            }
+
+            return from(this._decryptBlob(encryptedSummary, contentEncryptionKey, "summary")).pipe(
+              map((json) => this.summaryVersioningService.process(json).data),
+            );
+          }),
+        );
+      }),
+    );
+  }
+
+  private async _decryptBlob(
+    encryptedData: EncString | null,
+    key: SymmetricCryptoKey,
+    blobType: "report" | "summary" | "application",
+  ): Promise<unknown> {
+    if (encryptedData == null) {
+      if (blobType === "report") {
+        throw new Error("Report data is missing. Run migration before loading this report.");
+      }
+      if (blobType === "summary") {
+        throw new Error("Summary data not found");
+      }
+      // Application blob may be absent for new or migrating reports
+      return [];
+    }
+
+    try {
+      const decrypted = await this.encryptService.decryptString(encryptedData, key);
+      return JSON.parse(decrypted);
+    } catch (error: unknown) {
+      this.logService.error(
+        `[DefaultAccessReportEncryptionService] Failed to decrypt ${blobType} blob`,
+        error,
+      );
+      throw new Error(
+        `${blobType.charAt(0).toUpperCase() + blobType.slice(1)} data decryption failed. This may indicate data corruption or tampering.`,
+      );
+    }
+  }
+}

--- a/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/persistence/default-report-persistence.service.spec.ts
+++ b/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/persistence/default-report-persistence.service.spec.ts
@@ -1,0 +1,483 @@
+import { mock, MockProxy } from "jest-mock-extended";
+import { firstValueFrom, of, throwError } from "rxjs";
+
+import { Account, AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { makeEncString } from "@bitwarden/common/spec";
+import { OrganizationId, OrganizationReportId, UserId } from "@bitwarden/common/types/guid";
+import { LogService } from "@bitwarden/logging";
+
+import {
+  AccessReport,
+  AccessReportSettingsView,
+  AccessReportView,
+} from "../../../../access-intelligence/models";
+import {
+  GetRiskInsightsReportResponse,
+  SaveRiskInsightsReportResponse,
+} from "../../../../reports/risk-insights/models/api-models.types";
+import { RiskInsightsApiService } from "../../../../reports/risk-insights/services/api/risk-insights-api.service";
+import {
+  createRiskInsights,
+  createAccessReportMetrics,
+  createRiskInsightsSummary,
+} from "../../../../reports/risk-insights/testing/test-helpers";
+import {
+  AccessReportEncryptionService,
+  DecryptedAccessReportData,
+} from "../../abstractions/access-report-encryption.service";
+
+import { DefaultReportPersistenceService } from "./default-report-persistence.service";
+
+describe("DefaultReportPersistenceService", () => {
+  let service: DefaultReportPersistenceService;
+  let mockApiService: MockProxy<RiskInsightsApiService>;
+  let mockEncryptionService: MockProxy<AccessReportEncryptionService>;
+  let mockAccountService: MockProxy<AccountService>;
+  let mockLogService: MockProxy<LogService>;
+
+  const organizationId = "org-123" as OrganizationId;
+  const reportId = "report-456" as OrganizationReportId;
+  const userId = "user-789" as UserId;
+
+  beforeEach(() => {
+    mockApiService = mock<RiskInsightsApiService>();
+    mockEncryptionService = mock<AccessReportEncryptionService>();
+    mockAccountService = mock<AccountService>();
+    mockLogService = mock<LogService>();
+
+    const mockAccount = { id: userId } as Account;
+    mockAccountService.activeAccount$ = of(mockAccount);
+
+    service = new DefaultReportPersistenceService(
+      mockApiService,
+      mockEncryptionService,
+      mockAccountService,
+      mockLogService,
+    );
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("saveReport", () => {
+    it("should save report and return report ID", async () => {
+      // Create view model using helper
+      const view = createRiskInsights({
+        organizationId,
+        creationDate: new Date(),
+      });
+
+      // Mock RiskInsights.fromView() to return domain model with encrypted data
+      const mockDomain = new AccessReport();
+      mockDomain.organizationId = organizationId;
+      mockDomain.reports = makeEncString("encrypted-reports");
+      mockDomain.summary = makeEncString("encrypted-summary");
+      mockDomain.applications = makeEncString("encrypted-applications");
+      mockDomain.contentEncryptionKey = makeEncString("encryption-key");
+      mockDomain.creationDate = new Date();
+
+      jest.spyOn(AccessReport, "fromView").mockReturnValue(of(mockDomain));
+
+      const saveResponse = new SaveRiskInsightsReportResponse({ id: reportId });
+      mockApiService.saveRiskInsightsReport$.mockReturnValue(of(saveResponse));
+
+      const result = await firstValueFrom(service.saveReport$(view, organizationId));
+
+      expect(result.id).toBe(reportId);
+      expect(result.contentEncryptionKey).toBeDefined();
+      expect(AccessReport.fromView).toHaveBeenCalledWith(view, mockEncryptionService, {
+        organizationId,
+        userId,
+      });
+      expect(mockApiService.saveRiskInsightsReport$).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            organizationId,
+            reportData: expect.any(String),
+            summaryData: expect.any(String),
+            applicationData: expect.any(String),
+            contentEncryptionKey: expect.any(String),
+          }),
+        }),
+        organizationId,
+      );
+      expect(mockLogService.debug).toHaveBeenCalledWith(
+        "[DefaultReportPersistenceService] Saving report",
+        { organizationId },
+      );
+    });
+
+    it("should throw error if report has no encryption key", async () => {
+      const view = createRiskInsights({ organizationId });
+
+      // Mock domain model without encryption key
+      const mockDomain = new AccessReport();
+      mockDomain.organizationId = organizationId;
+      mockDomain.contentEncryptionKey = undefined;
+
+      jest.spyOn(AccessReport, "fromView").mockReturnValue(of(mockDomain));
+
+      await expect(firstValueFrom(service.saveReport$(view, organizationId))).rejects.toThrow(
+        "Report encryption key not found",
+      );
+    });
+
+    it("should handle API errors gracefully", async () => {
+      const view = createRiskInsights({
+        organizationId,
+        creationDate: new Date(),
+      });
+
+      const mockDomain = new AccessReport();
+      mockDomain.organizationId = organizationId;
+      mockDomain.contentEncryptionKey = makeEncString("key");
+      mockDomain.reports = makeEncString("reports");
+      mockDomain.summary = makeEncString("summary");
+      mockDomain.applications = makeEncString("apps");
+      mockDomain.creationDate = new Date();
+
+      jest.spyOn(AccessReport, "fromView").mockReturnValue(of(mockDomain));
+
+      mockApiService.saveRiskInsightsReport$.mockReturnValue(
+        throwError(() => new Error("API error")),
+      );
+
+      await expect(firstValueFrom(service.saveReport$(view, organizationId))).rejects.toThrow(
+        "API error",
+      );
+    });
+  });
+
+  describe("saveApplicationMetadata", () => {
+    it("should save application metadata and summary", async () => {
+      const app1 = new AccessReportSettingsView();
+      app1.applicationName = "github.com";
+      app1.isCritical = true;
+      app1.reviewedDate = new Date();
+
+      const app2 = new AccessReportSettingsView();
+      app2.applicationName = "gitlab.com";
+      app2.isCritical = false;
+      app2.reviewedDate = undefined;
+
+      const summary = createRiskInsightsSummary({
+        totalApplicationCount: 2,
+        totalAtRiskApplicationCount: 1,
+        totalMemberCount: 10,
+        totalAtRiskMemberCount: 3,
+      });
+
+      // Create full view model using helper
+      const view = createRiskInsights({
+        id: reportId,
+        organizationId,
+        applications: [app1, app2],
+        summary,
+      });
+
+      // Mock toMetrics() to return proper RiskInsightsMetrics instance
+      const mockMetrics = createAccessReportMetrics({
+        totalApplicationCount: 2,
+        totalAtRiskApplicationCount: 1,
+        totalMemberCount: 10,
+        totalAtRiskMemberCount: 3,
+      });
+      jest.spyOn(view, "toMetrics").mockReturnValue(mockMetrics);
+
+      // Mock RiskInsights.fromView() to return domain model
+      const mockDomain = new AccessReport();
+      mockDomain.reports = makeEncString("encrypted-reports");
+      mockDomain.summary = makeEncString("encrypted-summary");
+      mockDomain.applications = makeEncString("encrypted-apps");
+      mockDomain.contentEncryptionKey = makeEncString("key");
+
+      jest.spyOn(AccessReport, "fromView").mockReturnValue(of(mockDomain));
+
+      // Using {} as any for mock response (acceptable per testing standards for mock objects)
+      mockApiService.updateRiskInsightsApplicationData$.mockReturnValue(of({} as any));
+      mockApiService.updateRiskInsightsSummary$.mockReturnValue(of(undefined));
+
+      await firstValueFrom(service.saveApplicationMetadata$(view));
+
+      expect(AccessReport.fromView).toHaveBeenCalledWith(view, mockEncryptionService, {
+        organizationId,
+        userId,
+      });
+
+      expect(mockApiService.updateRiskInsightsApplicationData$).toHaveBeenCalledWith(
+        reportId,
+        organizationId,
+        expect.objectContaining({
+          data: {
+            applicationData: expect.any(String),
+          },
+        }),
+      );
+
+      expect(mockApiService.updateRiskInsightsSummary$).toHaveBeenCalledWith(
+        reportId,
+        organizationId,
+        expect.objectContaining({
+          data: {
+            summaryData: expect.any(String),
+            metrics: expect.objectContaining({
+              totalApplicationCount: 2,
+              totalAtRiskApplicationCount: 1,
+            }),
+          },
+        }),
+      );
+
+      expect(view.toMetrics).toHaveBeenCalled();
+    });
+
+    it("should throw error if user ID not found", async () => {
+      mockAccountService.activeAccount$ = of(null as any);
+
+      const view = createRiskInsights({
+        id: reportId,
+        organizationId,
+      });
+
+      await expect(firstValueFrom(service.saveApplicationMetadata$(view))).rejects.toThrow(
+        "Null or undefined account",
+      );
+    });
+
+    it("should handle encryption errors", async () => {
+      const view = createRiskInsights({
+        id: reportId,
+        organizationId,
+      });
+
+      jest
+        .spyOn(AccessReport, "fromView")
+        .mockReturnValue(throwError(() => new Error("Encryption failed")));
+
+      await expect(firstValueFrom(service.saveApplicationMetadata$(view))).rejects.toThrow(
+        "Encryption failed",
+      );
+    });
+
+    it("should handle API update failures", async () => {
+      const view = createRiskInsights({
+        id: reportId,
+        organizationId,
+      });
+
+      const mockDomain = new AccessReport();
+      mockDomain.reports = makeEncString("encrypted-reports");
+      mockDomain.summary = makeEncString("encrypted-summary");
+      mockDomain.applications = makeEncString("encrypted-apps");
+      mockDomain.contentEncryptionKey = makeEncString("key");
+
+      jest.spyOn(AccessReport, "fromView").mockReturnValue(of(mockDomain));
+
+      mockApiService.updateRiskInsightsApplicationData$.mockReturnValue(
+        throwError(() => new Error("Update failed")),
+      );
+
+      await expect(firstValueFrom(service.saveApplicationMetadata$(view))).rejects.toThrow(
+        "Update failed",
+      );
+    });
+  });
+
+  describe("loadReport", () => {
+    it("should load and decrypt report successfully", async () => {
+      const apiResponse = new GetRiskInsightsReportResponse({
+        id: reportId,
+        organizationId,
+        creationDate: new Date().toISOString(),
+        reportData: "encrypted-reports",
+        summaryData: "encrypted-summary",
+        applicationData: "encrypted-apps",
+        contentEncryptionKey: "encryption-key",
+      });
+
+      const decryptedData: DecryptedAccessReportData = {
+        reportData: {
+          reports: [
+            {
+              applicationName: "github.com",
+              passwordCount: 2,
+              atRiskPasswordCount: 1,
+              memberCount: 1,
+              atRiskMemberCount: 1,
+              cipherRefs: { "cipher-1": true, "cipher-2": false },
+              memberRefs: { "member-1": true },
+            },
+          ],
+          memberRegistry: {
+            "member-1": { id: "member-1", userName: "John Doe", email: "john@example.com" },
+          },
+        },
+        summaryData: {
+          totalMemberCount: 10,
+          totalAtRiskMemberCount: 3,
+          totalApplicationCount: 5,
+          totalAtRiskApplicationCount: 2,
+          totalCriticalMemberCount: 2,
+          totalCriticalAtRiskMemberCount: 1,
+          totalCriticalApplicationCount: 1,
+          totalCriticalAtRiskApplicationCount: 1,
+        },
+        applicationData: [
+          {
+            applicationName: "github.com",
+            isCritical: true,
+            reviewedDate: "2024-01-15T10:30:00.000Z",
+          },
+        ],
+      };
+
+      mockApiService.getRiskInsightsReport$.mockReturnValue(of(apiResponse));
+      mockEncryptionService.decryptReport$.mockReturnValue(of(decryptedData));
+
+      const result = await firstValueFrom(service.loadReport$(organizationId));
+
+      expect(result!.report).toBeInstanceOf(AccessReportView);
+      expect(result!.report.id).toBe(reportId);
+      expect(result!.report.organizationId).toBe(organizationId);
+      expect(result!.report.reports).toHaveLength(1);
+      expect(result!.report.applications).toHaveLength(1);
+      expect(result!.report.summary.totalApplicationCount).toBe(5);
+
+      expect(mockLogService.debug).toHaveBeenCalledWith(
+        "[DefaultReportPersistenceService] Loading report",
+        { organizationId },
+      );
+    });
+
+    it("should return null if no report exists", async () => {
+      mockApiService.getRiskInsightsReport$.mockReturnValue(of(null));
+
+      const result = await firstValueFrom(service.loadReport$(organizationId));
+
+      expect(result).toBeNull();
+      expect(mockEncryptionService.decryptReport$).not.toHaveBeenCalled();
+    });
+
+    it("should throw error if encryption key missing", async () => {
+      const apiResponse = new GetRiskInsightsReportResponse({
+        id: reportId,
+        organizationId,
+        creationDate: new Date().toISOString(),
+        reportData: "encrypted-reports",
+        summaryData: "encrypted-summary",
+        applicationData: "encrypted-apps",
+        contentEncryptionKey: "",
+      });
+
+      mockApiService.getRiskInsightsReport$.mockReturnValue(of(apiResponse));
+
+      await expect(firstValueFrom(service.loadReport$(organizationId))).rejects.toThrow(
+        "Report encryption key not found",
+      );
+    });
+
+    it("should throw error if user ID not found", async () => {
+      mockAccountService.activeAccount$ = of(null as any);
+
+      await expect(firstValueFrom(service.loadReport$(organizationId))).rejects.toThrow(
+        "Null or undefined account",
+      );
+    });
+
+    it("should handle decryption errors", async () => {
+      const apiResponse = new GetRiskInsightsReportResponse({
+        id: reportId,
+        organizationId,
+        creationDate: new Date().toISOString(),
+        reportData: "encrypted-reports",
+        summaryData: "encrypted-summary",
+        applicationData: "encrypted-apps",
+        contentEncryptionKey: "encryption-key",
+      });
+
+      mockApiService.getRiskInsightsReport$.mockReturnValue(of(apiResponse));
+      mockEncryptionService.decryptReport$.mockReturnValue(
+        throwError(() => new Error("Decryption failed")),
+      );
+
+      await expect(firstValueFrom(service.loadReport$(organizationId))).rejects.toThrow(
+        "Decryption failed",
+      );
+    });
+
+    it("should convert report data to view models correctly", async () => {
+      const apiResponse = new GetRiskInsightsReportResponse({
+        id: reportId,
+        organizationId,
+        creationDate: new Date().toISOString(),
+        reportData: "encrypted-reports",
+        summaryData: "encrypted-summary",
+        applicationData: "encrypted-apps",
+        contentEncryptionKey: "encryption-key",
+      });
+
+      const decryptedData: DecryptedAccessReportData = {
+        reportData: {
+          reports: [
+            {
+              applicationName: "gitlab.com",
+              passwordCount: 3,
+              atRiskPasswordCount: 1,
+              memberCount: 2,
+              atRiskMemberCount: 1,
+              cipherRefs: { c1: false, c2: true, c3: false },
+              memberRefs: { m1: true, m2: false },
+            },
+          ],
+          memberRegistry: {
+            m1: { id: "m1", userName: "Alice", email: "alice@example.com" },
+            m2: { id: "m2", userName: "Bob", email: "bob@example.com" },
+          },
+        },
+        summaryData: {
+          totalMemberCount: 20,
+          totalAtRiskMemberCount: 5,
+          totalApplicationCount: 10,
+          totalAtRiskApplicationCount: 3,
+          totalCriticalMemberCount: 4,
+          totalCriticalAtRiskMemberCount: 2,
+          totalCriticalApplicationCount: 2,
+          totalCriticalAtRiskApplicationCount: 1,
+        },
+        applicationData: [
+          {
+            applicationName: "gitlab.com",
+            isCritical: false,
+            reviewedDate: undefined,
+          },
+        ],
+      };
+
+      mockApiService.getRiskInsightsReport$.mockReturnValue(of(apiResponse));
+      mockEncryptionService.decryptReport$.mockReturnValue(of(decryptedData));
+
+      const result = await firstValueFrom(service.loadReport$(organizationId));
+
+      expect(result!.report.reports[0].applicationName).toBe("gitlab.com");
+      expect(result!.report.reports[0].passwordCount).toBe(3);
+      expect(result!.report.reports[0].atRiskPasswordCount).toBe(1);
+      expect(result!.report.reports[0].memberCount).toBe(2);
+      expect(result!.report.reports[0].atRiskMemberCount).toBe(1);
+
+      expect(result!.report.reports[0].cipherRefs["c1"]).toBe(false);
+      expect(result!.report.reports[0].cipherRefs["c2"]).toBe(true);
+      expect(result!.report.reports[0].cipherRefs["c3"]).toBe(false);
+
+      expect(result!.report.reports[0].memberRefs["m1"]).toBe(true);
+      expect(result!.report.reports[0].memberRefs["m2"]).toBe(false);
+
+      expect(result!.report.applications[0].applicationName).toBe("gitlab.com");
+      expect(result!.report.applications[0].isCritical).toBe(false);
+      expect(result!.report.applications[0].reviewedDate).toBeUndefined();
+
+      expect(result!.report.summary.totalMemberCount).toBe(20);
+      expect(result!.report.summary.totalAtRiskMemberCount).toBe(5);
+    });
+  });
+});

--- a/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/persistence/default-report-persistence.service.ts
+++ b/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/persistence/default-report-persistence.service.ts
@@ -1,0 +1,188 @@
+import { firstValueFrom, forkJoin, from, map, Observable, of, switchMap, throwError } from "rxjs";
+
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { getUserId } from "@bitwarden/common/auth/services/account.service";
+import { EncString } from "@bitwarden/common/key-management/crypto/models/enc-string";
+import { OrganizationId, OrganizationReportId } from "@bitwarden/common/types/guid";
+import { LogService } from "@bitwarden/logging";
+
+import { RiskInsightsApiService } from "../../../../reports/risk-insights/services/api/risk-insights-api.service";
+import { AccessReportData, AccessReport, AccessReportView } from "../../../models";
+import { AccessReportEncryptionService } from "../../abstractions/access-report-encryption.service";
+import { ReportPersistenceService } from "../../abstractions/report-persistence.service";
+
+/**
+ * Default implementation of ReportPersistenceService using current DB backend.
+ *
+ * Delegates encryption/decryption to domain model.
+ * Orchestrates API calls for persistence operations.
+ */
+export class DefaultReportPersistenceService extends ReportPersistenceService {
+  constructor(
+    private riskInsightsApiService: RiskInsightsApiService,
+    private riskInsightsEncryptionService: AccessReportEncryptionService,
+    private accountService: AccountService,
+    private logService: LogService,
+  ) {
+    super();
+  }
+
+  saveReport$(
+    view: AccessReportView,
+    organizationId: OrganizationId,
+  ): Observable<{ id: OrganizationReportId; contentEncryptionKey: EncString }> {
+    this.logService.debug("[DefaultReportPersistenceService] Saving report", {
+      organizationId,
+    });
+
+    return from(firstValueFrom(getUserId(this.accountService.activeAccount$))).pipe(
+      switchMap((userId) => {
+        if (!userId) {
+          throw new Error("User ID not found");
+        }
+
+        // Encrypt view to domain model
+        return from(
+          AccessReport.fromView(view, this.riskInsightsEncryptionService, {
+            organizationId,
+            userId,
+          }),
+        ).pipe(
+          switchMap((domain) => {
+            if (!domain.contentEncryptionKey) {
+              return throwError(() => new Error("Report encryption key not found"));
+            }
+
+            // Extract encrypted data and compute metrics from view
+            const data = domain.toData();
+            const metrics = view.toMetrics();
+
+            const requestPayload = {
+              data: {
+                organizationId,
+                creationDate: data.creationDate,
+                reportData: data.reports,
+                summaryData: data.summary,
+                applicationData: data.applications,
+                contentEncryptionKey: data.contentEncryptionKey,
+                metrics: metrics.toAccessReportMetricsData(),
+              },
+            };
+
+            return this.riskInsightsApiService
+              .saveRiskInsightsReport$(requestPayload, organizationId)
+              .pipe(
+                map((response) => ({
+                  id: response.id,
+                  contentEncryptionKey: domain.contentEncryptionKey!,
+                })),
+              );
+          }),
+        );
+      }),
+    );
+  }
+
+  saveApplicationMetadata$(view: AccessReportView): Observable<void> {
+    this.logService.debug("[DefaultReportPersistenceService] Saving application metadata", {
+      reportId: view.id,
+      organizationId: view.organizationId,
+      applicationCount: view.applications.length,
+    });
+
+    return from(firstValueFrom(getUserId(this.accountService.activeAccount$))).pipe(
+      switchMap((userId) => {
+        if (!userId) {
+          throw new Error("User ID not found");
+        }
+
+        // Encrypt view to domain model
+        return from(
+          AccessReport.fromView(view, this.riskInsightsEncryptionService, {
+            organizationId: view.organizationId,
+            userId,
+          }),
+        ).pipe(
+          switchMap((domain) => {
+            const data = domain.toData();
+            const metrics = view.toMetrics();
+
+            const updateApplicationsCall =
+              this.riskInsightsApiService.updateRiskInsightsApplicationData$(
+                view.id,
+                view.organizationId,
+                {
+                  data: {
+                    applicationData: data.applications,
+                  },
+                },
+              );
+
+            const updateSummaryCall = this.riskInsightsApiService.updateRiskInsightsSummary$(
+              view.id,
+              view.organizationId,
+              {
+                data: {
+                  summaryData: data.summary,
+                  metrics: metrics.toAccessReportMetricsData(),
+                },
+              },
+            );
+
+            return forkJoin([updateApplicationsCall, updateSummaryCall]).pipe(
+              map(() => undefined as void),
+            );
+          }),
+        );
+      }),
+    );
+  }
+
+  // TODO Rename to loadLastReport$
+  loadReport$(
+    organizationId: OrganizationId,
+  ): Observable<{ report: AccessReportView; hadLegacyBlobs: boolean } | null> {
+    this.logService.debug("[DefaultReportPersistenceService] Loading report", { organizationId });
+
+    return from(firstValueFrom(getUserId(this.accountService.activeAccount$))).pipe(
+      switchMap((userId) => {
+        if (!userId) {
+          throw new Error("User ID not found");
+        }
+
+        return this.riskInsightsApiService.getRiskInsightsReport$(organizationId).pipe(
+          switchMap((apiResponse) => {
+            if (!apiResponse) {
+              return of(null);
+            }
+
+            if (
+              !apiResponse.contentEncryptionKey ||
+              !apiResponse.contentEncryptionKey.encryptedString ||
+              apiResponse.contentEncryptionKey.encryptedString === ""
+            ) {
+              throw new Error("Report encryption key not found");
+            }
+
+            // Convert API → Data → Domain → View (following 4-layer architecture)
+            const data = new AccessReportData();
+            data.id = apiResponse.id;
+            data.organizationId = apiResponse.organizationId;
+            data.reports = apiResponse.reportData.encryptedString ?? "";
+            data.summary = apiResponse.summaryData.encryptedString ?? "";
+            data.applications = apiResponse.applicationData.encryptedString ?? "";
+            data.creationDate = apiResponse.creationDate.toISOString();
+            data.contentEncryptionKey = apiResponse.contentEncryptionKey.encryptedString ?? "";
+
+            const domain = new AccessReport(data);
+
+            // Domain handles its own decryption
+            return from(
+              domain.decrypt(this.riskInsightsEncryptionService, { organizationId, userId }),
+            ).pipe(map(({ view, hadLegacyBlobs }) => ({ report: view, hadLegacyBlobs })));
+          }),
+        );
+      }),
+    );
+  }
+}

--- a/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/persistence/versioning/application-versioning.service.spec.ts
+++ b/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/persistence/versioning/application-versioning.service.spec.ts
@@ -1,0 +1,90 @@
+import { mock } from "jest-mock-extended";
+
+import { LogService } from "@bitwarden/logging";
+
+import { OrganizationReportApplication } from "../../../../../reports/risk-insights/models";
+import { UnsupportedVersionError } from "../../../abstractions/versioning.service";
+
+import { ApplicationVersioningService } from "./application-versioning.service";
+
+describe("ApplicationVersioningService", () => {
+  let service: ApplicationVersioningService;
+  const mockLogService = mock<LogService>();
+
+  const validData = [
+    { applicationName: "app.com", isCritical: true, reviewedDate: "2024-01-01T00:00:00.000Z" },
+    { applicationName: "app2.com", isCritical: false, reviewedDate: undefined },
+  ];
+
+  const validEnvelope = { version: 1, data: validData };
+
+  beforeEach(() => {
+    service = new ApplicationVersioningService(mockLogService);
+    jest.clearAllMocks();
+  });
+
+  describe("process", () => {
+    it("should accept versioned envelope and return wasLegacy: false", () => {
+      const result = service.process(validEnvelope);
+
+      expect(result.wasLegacy).toBe(false);
+      expect(result.data).toHaveLength(2);
+      expect(result.data[0].applicationName).toBe("app.com");
+    });
+
+    it("should accept legacy array and return wasLegacy: true with reviewedDate converted to string", () => {
+      const legacyApps = [
+        { applicationName: "app.com", isCritical: true, reviewedDate: new Date("2024-01-01") },
+      ];
+
+      const result = service.process(legacyApps);
+
+      expect(result.wasLegacy).toBe(true);
+      expect(result.data[0].reviewedDate).toBe("2024-01-01T00:00:00.000Z");
+    });
+
+    it("should convert legacy null reviewedDate to undefined", () => {
+      const legacyApps: OrganizationReportApplication[] = [
+        { applicationName: "app.com", isCritical: false, reviewedDate: null },
+      ];
+
+      const result = service.process(legacyApps);
+
+      expect(result.wasLegacy).toBe(true);
+      expect(result.data[0].reviewedDate).toBeUndefined();
+    });
+
+    it("should throw UnsupportedVersionError for unknown version in envelope", () => {
+      expect(() => service.process({ version: 99, data: [] })).toThrow(UnsupportedVersionError);
+    });
+
+    it("should throw for non-array non-envelope input", () => {
+      expect(() => service.process({ invalid: true })).toThrow(
+        /Application data validation failed/,
+      );
+    });
+
+    it("should throw for null input", () => {
+      expect(() => service.process(null)).toThrow(/Application data validation failed/);
+    });
+  });
+
+  describe("serialize", () => {
+    it("should serialize as versioned envelope with version 1", () => {
+      const serialized = service.serialize(validData);
+      const parsed = JSON.parse(serialized);
+
+      expect(parsed.version).toBe(1);
+      expect(parsed.data).toEqual(validData);
+    });
+
+    it("should produce output that process accepts as versioned", () => {
+      const serialized = service.serialize(validData);
+      const parsed = JSON.parse(serialized);
+
+      const result = service.process(parsed);
+      expect(result.wasLegacy).toBe(false);
+      expect(result.data).toHaveLength(2);
+    });
+  });
+});

--- a/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/persistence/versioning/application-versioning.service.ts
+++ b/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/persistence/versioning/application-versioning.service.ts
@@ -1,0 +1,58 @@
+import { Injectable } from "@angular/core";
+
+import { LogService } from "@bitwarden/logging";
+
+import {
+  validateAccessReportSettingsDataArray,
+  validateOrganizationReportApplicationArray,
+} from "../../../../../reports/risk-insights/helpers";
+import { AccessReportSettingsData } from "../../../../models";
+import {
+  UnsupportedVersionError,
+  VersioningService,
+  isVersionEnvelope,
+} from "../../../abstractions/versioning.service";
+
+@Injectable()
+export class ApplicationVersioningService extends VersioningService<AccessReportSettingsData[]> {
+  readonly currentVersion = 1;
+
+  constructor(private logService: LogService) {
+    super();
+  }
+
+  process(json: unknown): { data: AccessReportSettingsData[]; wasLegacy: boolean } {
+    if (isVersionEnvelope(json)) {
+      if (json.version !== this.currentVersion) {
+        throw new UnsupportedVersionError(json.version);
+      }
+      this.logService.debug(
+        `[ApplicationVersioningService] Application blob: version ${this.currentVersion} — no transformation needed`,
+      );
+      const data = validateAccessReportSettingsDataArray(json.data);
+      return { data, wasLegacy: false };
+    }
+
+    // Legacy: plain array (original unversioned format)
+    if (Array.isArray(json)) {
+      this.logService.warning(
+        `[ApplicationVersioningService] Application blob: unversioned (legacy) format detected — transforming reviewedDate to string, targeting version ${this.currentVersion}`,
+      );
+      const legacyApps = validateOrganizationReportApplicationArray(json);
+      const data: AccessReportSettingsData[] = legacyApps.map((app) => ({
+        applicationName: app.applicationName,
+        isCritical: app.isCritical,
+        reviewedDate: app.reviewedDate instanceof Date ? app.reviewedDate.toISOString() : undefined,
+      }));
+      return { data, wasLegacy: true };
+    }
+
+    throw new Error(
+      "Application data validation failed: expected array or versioned envelope object.",
+    );
+  }
+
+  serialize(data: AccessReportSettingsData[]): string {
+    return JSON.stringify({ version: this.currentVersion, data });
+  }
+}

--- a/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/persistence/versioning/report-versioning.service.spec.ts
+++ b/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/persistence/versioning/report-versioning.service.spec.ts
@@ -1,0 +1,192 @@
+import { mock } from "jest-mock-extended";
+
+import { CipherId } from "@bitwarden/common/types/guid";
+import { LogService } from "@bitwarden/logging";
+
+import {
+  ApplicationHealthReportDetail,
+  MemberDetails,
+} from "../../../../../reports/risk-insights/models";
+import { mockReportData } from "../../../../../reports/risk-insights/models/mocks/mock-data";
+import { AccessReportPayload } from "../../../abstractions/access-report-encryption.service";
+import { UnsupportedVersionError } from "../../../abstractions/versioning.service";
+
+import { ReportVersioningService } from "./report-versioning.service";
+
+describe("ReportVersioningService", () => {
+  let service: ReportVersioningService;
+  const mockLogService = mock<LogService>();
+
+  const validPayload: AccessReportPayload = {
+    reports: [
+      {
+        applicationName: "app.com",
+        passwordCount: 3,
+        atRiskPasswordCount: 1,
+        memberRefs: { "user-1": true, "user-2": false },
+        cipherRefs: { "cipher-1": true },
+        memberCount: 2,
+        atRiskMemberCount: 1,
+      },
+    ],
+    memberRegistry: {
+      "user-1": { id: "user-1", userName: "Alice", email: "alice@example.com" },
+      "user-2": { id: "user-2", userName: "Bob", email: "bob@example.com" },
+    },
+  };
+
+  const validEnvelope = { version: 1, data: validPayload };
+
+  beforeEach(() => {
+    service = new ReportVersioningService(mockLogService);
+    jest.clearAllMocks();
+  });
+
+  describe("process", () => {
+    it("should accept versioned envelope and return wasLegacy: false", () => {
+      const result = service.process(validEnvelope);
+
+      expect(result.wasLegacy).toBe(false);
+      expect(result.data.reports).toHaveLength(1);
+      expect(result.data.reports[0].applicationName).toBe("app.com");
+      expect(result.data.memberRegistry).toHaveProperty("user-1");
+    });
+
+    it("should transform legacy array to payload and return wasLegacy: true", () => {
+      const result = service.process(mockReportData);
+
+      expect(result.wasLegacy).toBe(true);
+      expect(result.data.reports).toHaveLength(mockReportData.length);
+      expect(result.data.memberRegistry).toBeDefined();
+    });
+
+    it("should build member registry from legacy memberDetails", () => {
+      const legacyData: ApplicationHealthReportDetail[] = [
+        {
+          applicationName: "app.com",
+          passwordCount: 1,
+          atRiskPasswordCount: 0,
+          memberCount: 1,
+          atRiskMemberCount: 0,
+          memberDetails: [
+            {
+              userGuid: "u1",
+              userName: "Alice",
+              email: "alice@test.com",
+              cipherId: "c1" as CipherId,
+            },
+          ],
+          atRiskMemberDetails: [] as MemberDetails[],
+          cipherIds: ["c1" as CipherId],
+          atRiskCipherIds: [] as CipherId[],
+        },
+      ];
+
+      const result = service.process(legacyData);
+
+      expect(result.data.memberRegistry["u1"]).toEqual({
+        id: "u1",
+        userName: "Alice",
+        email: "alice@test.com",
+      });
+    });
+
+    it("should convert legacy memberDetails and cipherIds to memberRefs and cipherRefs", () => {
+      const legacyData: ApplicationHealthReportDetail[] = [
+        {
+          applicationName: "app.com",
+          passwordCount: 2,
+          atRiskPasswordCount: 1,
+          memberCount: 2,
+          atRiskMemberCount: 1,
+          memberDetails: [
+            { userGuid: "u1", userName: "Alice", email: "a@test.com", cipherId: "c1" as CipherId },
+            { userGuid: "u2", userName: "Bob", email: "b@test.com", cipherId: "c2" as CipherId },
+          ],
+          atRiskMemberDetails: [
+            { userGuid: "u1", userName: "Alice", email: "a@test.com", cipherId: "c1" as CipherId },
+          ],
+          cipherIds: ["c1" as CipherId, "c2" as CipherId],
+          atRiskCipherIds: ["c1" as CipherId],
+        },
+      ];
+
+      const result = service.process(legacyData);
+
+      const report = result.data.reports[0];
+      expect(report.memberRefs).toEqual({ u1: true, u2: false });
+      expect(report.cipherRefs).toEqual({ c1: true, c2: false });
+    });
+
+    it("should deduplicate members across legacy apps in registry", () => {
+      const sharedMember: MemberDetails = {
+        userGuid: "u1",
+        userName: "Alice",
+        email: "a@test.com",
+        cipherId: "c1" as CipherId,
+      };
+      const legacyData: ApplicationHealthReportDetail[] = [
+        {
+          applicationName: "app1.com",
+          passwordCount: 1,
+          atRiskPasswordCount: 0,
+          memberCount: 1,
+          atRiskMemberCount: 0,
+          memberDetails: [sharedMember],
+          atRiskMemberDetails: [] as MemberDetails[],
+          cipherIds: ["c1" as CipherId],
+          atRiskCipherIds: [] as CipherId[],
+        },
+        {
+          applicationName: "app2.com",
+          passwordCount: 1,
+          atRiskPasswordCount: 0,
+          memberCount: 1,
+          atRiskMemberCount: 0,
+          memberDetails: [sharedMember],
+          atRiskMemberDetails: [] as MemberDetails[],
+          cipherIds: ["c2" as CipherId],
+          atRiskCipherIds: [] as CipherId[],
+        },
+      ];
+
+      const result = service.process(legacyData);
+
+      expect(Object.keys(result.data.memberRegistry)).toHaveLength(1);
+    });
+
+    it("should throw UnsupportedVersionError for unknown version in envelope", () => {
+      expect(() =>
+        service.process({ version: 99, data: { reports: [], memberRegistry: {} } }),
+      ).toThrow(UnsupportedVersionError);
+    });
+
+    it("should throw UnsupportedVersionError for non-array non-envelope object", () => {
+      expect(() => service.process({ someField: "value" })).toThrow(UnsupportedVersionError);
+    });
+
+    it("should throw UnsupportedVersionError for null input", () => {
+      expect(() => service.process(null)).toThrow(UnsupportedVersionError);
+    });
+  });
+
+  describe("serialize", () => {
+    it("should serialize as versioned envelope with version 1", () => {
+      const serialized = service.serialize(validPayload);
+      const parsed = JSON.parse(serialized);
+
+      expect(parsed.version).toBe(1);
+      expect(parsed.data.reports).toEqual(validPayload.reports);
+      expect(parsed.data.memberRegistry).toEqual(validPayload.memberRegistry);
+    });
+
+    it("should produce output that process accepts as versioned", () => {
+      const serialized = service.serialize(validPayload);
+      const parsed = JSON.parse(serialized);
+
+      const result = service.process(parsed);
+      expect(result.wasLegacy).toBe(false);
+      expect(result.data).toMatchObject(validPayload);
+    });
+  });
+});

--- a/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/persistence/versioning/report-versioning.service.ts
+++ b/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/persistence/versioning/report-versioning.service.ts
@@ -1,0 +1,113 @@
+import { Injectable } from "@angular/core";
+
+import { LogService } from "@bitwarden/logging";
+
+import {
+  validateAccessReportPayload,
+  validateApplicationHealthReportDetailArray,
+} from "../../../../../reports/risk-insights/helpers";
+import {
+  ApplicationHealthReportDetail,
+  MemberDetails,
+} from "../../../../../reports/risk-insights/models";
+import { MemberRegistryEntryData, ApplicationHealthData } from "../../../../models";
+import { AccessReportPayload } from "../../../abstractions/access-report-encryption.service";
+import {
+  UnsupportedVersionError,
+  VersioningService,
+  isVersionEnvelope,
+} from "../../../abstractions/versioning.service";
+
+@Injectable()
+export class ReportVersioningService extends VersioningService<AccessReportPayload> {
+  readonly currentVersion = 1;
+
+  constructor(private logService: LogService) {
+    super();
+  }
+
+  process(json: unknown): { data: AccessReportPayload; wasLegacy: boolean } {
+    if (isVersionEnvelope(json)) {
+      if (json.version !== this.currentVersion) {
+        throw new UnsupportedVersionError(json.version);
+      }
+      this.logService.debug(
+        `[ReportVersioningService] Report blob: version ${this.currentVersion} — no transformation needed`,
+      );
+      const data = validateAccessReportPayload(json.data);
+      return { data, wasLegacy: false };
+    }
+
+    // Legacy: plain array (original unversioned format)
+    if (Array.isArray(json)) {
+      this.logService.warning(
+        `[ReportVersioningService] Report blob: unversioned (legacy) format detected — transforming to version ${this.currentVersion}`,
+      );
+      const v1Data = validateApplicationHealthReportDetailArray(json);
+      const data = this._transformLegacyReportToPayload(v1Data);
+      return { data, wasLegacy: true };
+    }
+
+    const version =
+      typeof json === "object" && json !== null
+        ? (json as Record<string, unknown>)["version"]
+        : undefined;
+    throw new UnsupportedVersionError(typeof version === "number" ? version : undefined);
+  }
+
+  serialize(data: AccessReportPayload): string {
+    return JSON.stringify({ version: this.currentVersion, data });
+  }
+
+  /**
+   * Transforms a legacy report payload (ApplicationHealthReportDetail[]) into an
+   * AccessReportPayload by building a deduplicated member registry and converting
+   * member/cipher arrays to Record<id, isAtRisk> maps.
+   */
+  private _transformLegacyReportToPayload(
+    legacyData: ApplicationHealthReportDetail[],
+  ): AccessReportPayload {
+    const memberRegistry: Record<string, MemberRegistryEntryData> = {};
+
+    for (const app of legacyData) {
+      for (const member of app.memberDetails) {
+        if (!memberRegistry[member.userGuid]) {
+          memberRegistry[member.userGuid] = {
+            id: member.userGuid,
+            userName: member.userName ?? undefined,
+            email: member.email,
+          };
+        }
+      }
+    }
+
+    const reports: ApplicationHealthData[] = legacyData.map((app) => {
+      const atRiskMemberSet = new Set(
+        app.atRiskMemberDetails.map((m: MemberDetails) => m.userGuid),
+      );
+      const atRiskCipherSet = new Set(app.atRiskCipherIds);
+
+      const memberRefs: Record<string, boolean> = {};
+      for (const member of app.memberDetails) {
+        memberRefs[member.userGuid] = atRiskMemberSet.has(member.userGuid);
+      }
+
+      const cipherRefs: Record<string, boolean> = {};
+      for (const cipherId of app.cipherIds) {
+        cipherRefs[cipherId] = atRiskCipherSet.has(cipherId);
+      }
+
+      return {
+        applicationName: app.applicationName,
+        passwordCount: app.passwordCount,
+        atRiskPasswordCount: app.atRiskPasswordCount,
+        memberCount: app.memberCount,
+        atRiskMemberCount: app.atRiskMemberCount,
+        memberRefs,
+        cipherRefs,
+      };
+    });
+
+    return { reports, memberRegistry };
+  }
+}

--- a/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/persistence/versioning/summary-versioning.service.spec.ts
+++ b/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/persistence/versioning/summary-versioning.service.spec.ts
@@ -1,0 +1,96 @@
+import { mock } from "jest-mock-extended";
+
+import { LogService } from "@bitwarden/logging";
+
+import { mockSummaryData } from "../../../../../reports/risk-insights/models/mocks/mock-data";
+import { UnsupportedVersionError } from "../../../abstractions/versioning.service";
+
+import { SummaryVersioningService } from "./summary-versioning.service";
+
+describe("SummaryVersioningService", () => {
+  let service: SummaryVersioningService;
+  const mockLogService = mock<LogService>();
+
+  const validSummaryData = {
+    totalMemberCount: 5,
+    totalAtRiskMemberCount: 2,
+    totalApplicationCount: 3,
+    totalAtRiskApplicationCount: 1,
+    totalCriticalMemberCount: 1,
+    totalCriticalAtRiskMemberCount: 1,
+    totalCriticalApplicationCount: 1,
+    totalCriticalAtRiskApplicationCount: 1,
+  };
+
+  const validEnvelope = { version: 1, data: validSummaryData };
+
+  beforeEach(() => {
+    service = new SummaryVersioningService(mockLogService);
+    jest.clearAllMocks();
+  });
+
+  describe("process", () => {
+    it("should accept versioned envelope and return wasLegacy: false", () => {
+      const result = service.process(validEnvelope);
+
+      expect(result.wasLegacy).toBe(false);
+      expect(result.data).toMatchObject(validSummaryData);
+    });
+
+    it("should accept legacy flat object and return wasLegacy: true", () => {
+      const result = service.process(validSummaryData);
+
+      expect(result.wasLegacy).toBe(true);
+      expect(result.data).toMatchObject(validSummaryData);
+    });
+
+    it("should accept mockSummaryData as legacy", () => {
+      const result = service.process(mockSummaryData);
+
+      expect(result.wasLegacy).toBe(true);
+      expect(result.data).toMatchObject(mockSummaryData);
+    });
+
+    it("should throw UnsupportedVersionError for unknown version in envelope", () => {
+      expect(() => service.process({ version: 99, data: validSummaryData })).toThrow(
+        UnsupportedVersionError,
+      );
+    });
+
+    it("should throw when required fields are missing", () => {
+      expect(() => service.process({ invalid: "summary" })).toThrow(
+        /Summary data validation failed/,
+      );
+    });
+
+    it("should throw for null input", () => {
+      expect(() => service.process(null)).toThrow(/Summary data validation failed/);
+    });
+  });
+
+  describe("serialize", () => {
+    it("should serialize as versioned envelope with version 1", () => {
+      const serialized = service.serialize(validSummaryData);
+      const parsed = JSON.parse(serialized);
+
+      expect(parsed.version).toBe(1);
+      expect(parsed.data).toMatchObject(validSummaryData);
+    });
+
+    it("should not include version as a sibling field alongside data fields", () => {
+      const serialized = service.serialize(validSummaryData);
+      const parsed = JSON.parse(serialized);
+
+      expect(parsed.totalMemberCount).toBeUndefined();
+      expect(parsed.data.totalMemberCount).toBe(validSummaryData.totalMemberCount);
+    });
+
+    it("should produce output that process accepts as versioned", () => {
+      const serialized = service.serialize(validSummaryData);
+      const parsed = JSON.parse(serialized);
+
+      const result = service.process(parsed);
+      expect(result.wasLegacy).toBe(false);
+    });
+  });
+});

--- a/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/persistence/versioning/summary-versioning.service.ts
+++ b/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/persistence/versioning/summary-versioning.service.ts
@@ -1,0 +1,50 @@
+import { Injectable } from "@angular/core";
+
+import { LogService } from "@bitwarden/logging";
+
+import { isAccessReportSummaryData } from "../../../../../reports/risk-insights/helpers";
+import { AccessReportSummaryData } from "../../../../models";
+import {
+  UnsupportedVersionError,
+  VersioningService,
+  isVersionEnvelope,
+} from "../../../abstractions/versioning.service";
+
+@Injectable()
+export class SummaryVersioningService extends VersioningService<AccessReportSummaryData> {
+  readonly currentVersion = 1;
+
+  constructor(private logService: LogService) {
+    super();
+  }
+
+  process(json: unknown): { data: AccessReportSummaryData; wasLegacy: boolean } {
+    if (isVersionEnvelope(json)) {
+      if (json.version !== this.currentVersion) {
+        throw new UnsupportedVersionError(json.version);
+      }
+      this.logService.debug(
+        `[SummaryVersioningService] Summary blob: version ${this.currentVersion} — no transformation needed`,
+      );
+      if (!isAccessReportSummaryData(json.data)) {
+        const errors = isAccessReportSummaryData.explain(json.data).join("; ");
+        throw new Error(`Summary data validation failed: ${errors}`);
+      }
+      return { data: json.data, wasLegacy: false };
+    }
+
+    // Legacy: plain object without envelope (original unversioned format)
+    this.logService.warning(
+      `[SummaryVersioningService] Summary blob: unversioned (legacy) format detected — will be re-saved at version ${this.currentVersion}`,
+    );
+    if (!isAccessReportSummaryData(json)) {
+      const errors = isAccessReportSummaryData.explain(json).join("; ");
+      throw new Error(`Summary data validation failed: ${errors}`);
+    }
+    return { data: json, wasLegacy: true };
+  }
+
+  serialize(data: AccessReportSummaryData): string {
+    return JSON.stringify({ version: this.currentVersion, data });
+  }
+}

--- a/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/view/default-access-intelligence-data.service.spec.ts
+++ b/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/view/default-access-intelligence-data.service.spec.ts
@@ -1,0 +1,543 @@
+import { firstValueFrom, of, skip, throwError } from "rxjs";
+
+import {
+  OrganizationUserApiService,
+  OrganizationUserUserDetailsResponse,
+} from "@bitwarden/admin-console/common";
+import { EncString } from "@bitwarden/common/key-management/crypto/models/enc-string";
+import { OrganizationId, OrganizationReportId } from "@bitwarden/common/types/guid";
+import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
+import { LogService } from "@bitwarden/logging";
+
+import { ReportProgress } from "../../../../reports/risk-insights/models/report-models";
+import {
+  createCipher,
+  createRiskInsights,
+  createReport,
+} from "../../../../reports/risk-insights/testing/test-helpers";
+import { ReportGenerationService } from "../../abstractions/report-generation.service";
+import { ReportPersistenceService } from "../../abstractions/report-persistence.service";
+
+import { DefaultAccessIntelligenceDataService } from "./default-access-intelligence-data.service";
+
+describe("DefaultAccessIntelligenceDataService", () => {
+  let service: DefaultAccessIntelligenceDataService;
+  let cipherService: jest.Mocked<CipherService>;
+  let organizationUserApiService: jest.Mocked<OrganizationUserApiService>;
+  let reportGenerationService: jest.Mocked<ReportGenerationService>;
+  let reportPersistenceService: jest.Mocked<ReportPersistenceService>;
+  let logService: jest.Mocked<LogService>;
+
+  const orgId = "org-123" as OrganizationId;
+  const testReport = createRiskInsights({
+    reports: [createReport("test-app.com")],
+  });
+  const testCiphers = [createCipher(), createCipher()];
+
+  beforeEach(() => {
+    // Create mocks
+    cipherService = {
+      getAllFromApiForOrganization: jest.fn(),
+    } as any;
+
+    organizationUserApiService = {
+      getAllUsers: jest.fn(),
+    } as any;
+
+    reportGenerationService = {
+      generateReport: jest.fn(),
+    } as any;
+
+    reportPersistenceService = {
+      loadReport$: jest.fn(),
+      saveReport$: jest.fn(),
+      saveApplicationMetadata$: jest.fn(),
+    } as any;
+
+    logService = {
+      debug: jest.fn(),
+      error: jest.fn(),
+      info: jest.fn(),
+    } as any;
+
+    service = new DefaultAccessIntelligenceDataService(
+      cipherService,
+      organizationUserApiService,
+      reportGenerationService,
+      reportPersistenceService,
+      logService,
+    );
+  });
+
+  describe("Initialization", () => {
+    it("should load existing report and emit via report$", async () => {
+      reportPersistenceService.loadReport$.mockReturnValue(
+        of({ report: testReport, hadLegacyBlobs: false }),
+      );
+
+      await firstValueFrom(service.initializeForOrganization$(orgId));
+
+      const report = await firstValueFrom(service.report$);
+      expect(report).toBe(testReport);
+      expect(reportPersistenceService.loadReport$).toHaveBeenCalledWith(orgId);
+    });
+
+    it("should emit null if no report exists", async () => {
+      reportPersistenceService.loadReport$.mockReturnValue(of(null));
+
+      await firstValueFrom(service.initializeForOrganization$(orgId));
+
+      const report = await firstValueFrom(service.report$);
+      expect(report).toBeNull();
+    });
+
+    it("should re-save report when V1 blobs are detected", async () => {
+      const legacyReport = createRiskInsights({
+        reports: [createReport("v1-app.com")],
+      });
+
+      const newId = "report-id-123" as OrganizationReportId;
+      const newKey = new EncString("new-key");
+      reportPersistenceService.loadReport$.mockReturnValue(
+        of({ report: legacyReport, hadLegacyBlobs: true }),
+      );
+      reportPersistenceService.saveReport$.mockReturnValue(
+        of({ id: newId, contentEncryptionKey: newKey }),
+      );
+
+      await firstValueFrom(service.initializeForOrganization$(orgId));
+
+      expect(reportPersistenceService.saveReport$).toHaveBeenCalledWith(legacyReport, orgId);
+      const report = await firstValueFrom(service.report$);
+      expect(report).toBe(legacyReport);
+      expect(report?.id).toBe(newId);
+    });
+
+    it("should handle load errors gracefully", async () => {
+      reportPersistenceService.loadReport$.mockReturnValue(
+        throwError(() => new Error("Load failed")),
+      );
+
+      await firstValueFrom(service.initializeForOrganization$(orgId));
+
+      const error = await firstValueFrom(service.error$);
+      expect(error).toBe("Failed to initialize");
+
+      const report = await firstValueFrom(service.report$);
+      expect(report).toBeNull();
+    });
+  });
+
+  describe("Report Generation", () => {
+    beforeEach(() => {
+      cipherService.getAllFromApiForOrganization.mockResolvedValue(testCiphers);
+      organizationUserApiService.getAllUsers.mockResolvedValue({
+        data: [
+          {
+            id: "user-1",
+            name: "Alice",
+            email: "alice@example.com",
+            collections: [{ id: "col-1", readOnly: false, hidePasswords: false, manage: true }],
+            groups: ["group-1"],
+          } as OrganizationUserUserDetailsResponse,
+        ],
+      } as any);
+      reportGenerationService.generateReport.mockReturnValue(of(testReport));
+      reportPersistenceService.loadReport$.mockReturnValue(of(null));
+      reportPersistenceService.saveReport$.mockReturnValue(
+        of({
+          id: "report-id-123" as OrganizationReportId,
+          contentEncryptionKey: new EncString(""),
+        }),
+      );
+    });
+
+    it("should load data, generate, save, and emit report", async () => {
+      await firstValueFrom(service.generateNewReport$(orgId));
+
+      const report = await firstValueFrom(service.report$);
+      expect(report).toBe(testReport);
+      expect(report?.id).toBe("report-id-123" as OrganizationReportId);
+      expect(report?.organizationId).toBe(orgId);
+
+      expect(cipherService.getAllFromApiForOrganization).toHaveBeenCalledWith(orgId);
+      expect(organizationUserApiService.getAllUsers).toHaveBeenCalledWith(orgId, {
+        includeCollections: true,
+        includeGroups: true,
+      });
+      expect(reportGenerationService.generateReport).toHaveBeenCalled();
+      expect(reportPersistenceService.saveReport$).toHaveBeenCalledWith(testReport, orgId);
+    });
+
+    it("should carry over previous application metadata", async () => {
+      const previousReport = createRiskInsights({
+        applications: [
+          { applicationName: "github.com", isCritical: true, reviewedDate: new Date() } as any,
+        ],
+      });
+
+      // Prime in-memory report state via initialize so generateNewReport$ can read it
+      reportPersistenceService.loadReport$.mockReturnValue(
+        of({ report: previousReport, hadLegacyBlobs: false }),
+      );
+      await firstValueFrom(service.initializeForOrganization$(orgId));
+
+      await firstValueFrom(service.generateNewReport$(orgId));
+
+      expect(reportGenerationService.generateReport).toHaveBeenCalledWith(
+        testCiphers,
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        previousReport.applications,
+      );
+    });
+
+    it("should store ciphers for UI", async () => {
+      await firstValueFrom(service.generateNewReport$(orgId));
+
+      const ciphers = await firstValueFrom(service.ciphers$);
+      expect(ciphers).toEqual(testCiphers);
+    });
+
+    it("should handle generation errors and keep previous report", async () => {
+      reportPersistenceService.loadReport$.mockReturnValue(
+        of({ report: testReport, hadLegacyBlobs: false }),
+      );
+      await firstValueFrom(service.initializeForOrganization$(orgId));
+
+      reportGenerationService.generateReport.mockReturnValue(
+        throwError(() => new Error("Generation failed")),
+      );
+
+      await expect(firstValueFrom(service.generateNewReport$(orgId))).rejects.toThrow(
+        "Generation failed",
+      );
+
+      const report = await firstValueFrom(service.report$);
+      expect(report).toBe(testReport); // Previous report still present
+    });
+
+    it("should handle save errors and keep generated report", async () => {
+      reportPersistenceService.saveReport$.mockReturnValue(
+        throwError(() => new Error("Save failed")),
+      );
+
+      await expect(firstValueFrom(service.generateNewReport$(orgId))).rejects.toThrow(
+        "Save failed",
+      );
+
+      const error = await firstValueFrom(service.error$);
+      expect(error).toBe("Failed to generate report");
+    });
+
+    it("should emit full progress sequence", async () => {
+      const progressSteps: (ReportProgress | null)[] = [];
+      const sub = service.reportProgress$
+        .pipe(skip(1))
+        .subscribe((step) => progressSteps.push(step));
+
+      await firstValueFrom(service.generateNewReport$(orgId));
+      sub.unsubscribe();
+
+      expect(progressSteps).toEqual([
+        null, // reset at start
+        ReportProgress.FetchingMembers,
+        ReportProgress.AnalyzingPasswords,
+        ReportProgress.CalculatingRisks,
+        ReportProgress.GeneratingReport,
+        ReportProgress.Saving,
+        ReportProgress.Complete,
+      ]);
+    });
+
+    it("should reset reportProgress$ to null on generation error", async () => {
+      reportGenerationService.generateReport.mockReturnValue(
+        throwError(() => new Error("Generation failed")),
+      );
+
+      await expect(firstValueFrom(service.generateNewReport$(orgId))).rejects.toThrow(
+        "Generation failed",
+      );
+
+      const progress = await firstValueFrom(service.reportProgress$);
+      expect(progress).toBeNull();
+    });
+  });
+
+  describe("Load Existing Report", () => {
+    it("should load and emit report", async () => {
+      reportPersistenceService.loadReport$.mockReturnValue(
+        of({ report: testReport, hadLegacyBlobs: false }),
+      );
+
+      await firstValueFrom(service.loadExistingReport$(orgId));
+
+      const report = await firstValueFrom(service.report$);
+      expect(report).toBe(testReport);
+    });
+
+    it("should emit null if no report exists", async () => {
+      reportPersistenceService.loadReport$.mockReturnValue(of(null));
+
+      await firstValueFrom(service.loadExistingReport$(orgId));
+
+      const report = await firstValueFrom(service.report$);
+      expect(report).toBeNull();
+    });
+  });
+
+  describe("Application Metadata Updates", () => {
+    let mockReport: any;
+
+    beforeEach(() => {
+      mockReport = createRiskInsights({
+        applications: [
+          { applicationName: "github.com", isCritical: false, reviewedDate: undefined } as any,
+        ],
+      });
+      mockReport.markApplicationsAsCritical = jest.fn();
+      mockReport.unmarkApplicationsAsCritical = jest.fn();
+      mockReport.markApplicationAsReviewed = jest.fn();
+
+      reportPersistenceService.loadReport$.mockReturnValue(
+        of({ report: mockReport, hadLegacyBlobs: false }),
+      );
+      reportPersistenceService.saveApplicationMetadata$.mockReturnValue(of(undefined as void));
+    });
+
+    it("should mark applications as critical and persist", async () => {
+      await firstValueFrom(service.initializeForOrganization$(orgId));
+      await firstValueFrom(service.markApplicationsAsCritical$(["github.com"]));
+
+      expect(mockReport.markApplicationsAsCritical).toHaveBeenCalledWith(["github.com"]);
+      expect(reportPersistenceService.saveApplicationMetadata$).toHaveBeenCalledWith(mockReport);
+
+      const report = await firstValueFrom(service.report$);
+      expect(report?.applications).toBe(mockReport.applications);
+    });
+
+    it("should unmark applications as critical and persist", async () => {
+      mockReport.applications[0].isCritical = true;
+
+      await firstValueFrom(service.initializeForOrganization$(orgId));
+      await firstValueFrom(service.unmarkApplicationsAsCritical$(["github.com"]));
+
+      expect(mockReport.unmarkApplicationsAsCritical).toHaveBeenCalledWith(["github.com"]);
+      expect(reportPersistenceService.saveApplicationMetadata$).toHaveBeenCalledWith(mockReport);
+    });
+
+    it("should mark applications as reviewed and persist", async () => {
+      await firstValueFrom(service.initializeForOrganization$(orgId));
+      const reviewDate = new Date();
+      await firstValueFrom(service.markApplicationsAsReviewed$(["github.com"], reviewDate));
+
+      expect(mockReport.markApplicationAsReviewed).toHaveBeenCalledWith("github.com", reviewDate);
+      expect(reportPersistenceService.saveApplicationMetadata$).toHaveBeenCalledWith(mockReport);
+    });
+
+    it("should throw error if no report loaded", async () => {
+      reportPersistenceService.loadReport$.mockReturnValue(of(null));
+      await firstValueFrom(service.initializeForOrganization$(orgId));
+
+      await expect(
+        firstValueFrom(service.markApplicationsAsCritical$(["github.com"])),
+      ).rejects.toThrow("No report loaded");
+    });
+
+    it("should rollback mutation on save failure (mark critical)", async () => {
+      mockReport.applications[0].isCritical = false;
+
+      await firstValueFrom(service.initializeForOrganization$(orgId));
+
+      reportPersistenceService.saveApplicationMetadata$.mockReturnValue(
+        throwError(() => new Error("Save failed")),
+      );
+
+      await expect(
+        firstValueFrom(service.markApplicationsAsCritical$(["github.com"])),
+      ).rejects.toThrow("Save failed");
+
+      // Rollback restores isCritical to its original value via direct property assignment
+      expect(mockReport.applications[0].isCritical).toBe(false);
+    });
+
+    it("should emit updated report after mutation", async () => {
+      await firstValueFrom(service.initializeForOrganization$(orgId));
+
+      let emitCount = 0;
+      service.report$.subscribe(() => emitCount++);
+
+      await firstValueFrom(service.markApplicationsAsCritical$(["github.com"]));
+
+      expect(emitCount).toBeGreaterThan(1); // Initial + mutation emit
+    });
+
+    it("should use correct organizationId when marking critical after report generation", async () => {
+      cipherService.getAllFromApiForOrganization.mockResolvedValue(testCiphers);
+      organizationUserApiService.getAllUsers.mockResolvedValue({ data: [] } as any);
+      reportPersistenceService.loadReport$.mockReturnValue(of(null));
+      reportPersistenceService.saveReport$.mockReturnValue(
+        of({
+          id: "report-id-123" as OrganizationReportId,
+          contentEncryptionKey: new EncString(""),
+        }),
+      );
+      reportGenerationService.generateReport.mockReturnValue(of(testReport));
+
+      await firstValueFrom(service.generateNewReport$(orgId));
+      await firstValueFrom(service.markApplicationsAsCritical$(["test-app.com"]));
+
+      expect(reportPersistenceService.saveApplicationMetadata$).toHaveBeenCalledWith(
+        expect.objectContaining({ organizationId: orgId }),
+      );
+    });
+
+    it("should rollback mutation on save failure (unmark critical)", async () => {
+      mockReport.applications[0].isCritical = true;
+
+      await firstValueFrom(service.initializeForOrganization$(orgId));
+
+      reportPersistenceService.saveApplicationMetadata$.mockReturnValue(
+        throwError(() => new Error("Save failed")),
+      );
+
+      await expect(
+        firstValueFrom(service.unmarkApplicationsAsCritical$(["github.com"])),
+      ).rejects.toThrow("Save failed");
+
+      // Rollback restores isCritical to its original value via direct property assignment
+      expect(mockReport.applications[0].isCritical).toBe(true);
+    });
+
+    it("should rollback mutation on save failure (mark reviewed)", async () => {
+      const originalDate = new Date("2024-01-01");
+      mockReport.applications[0].reviewedDate = originalDate;
+
+      mockReport.markApplicationAsReviewed.mockImplementation((_name: string, date?: Date) => {
+        mockReport.applications[0].reviewedDate = date;
+      });
+
+      await firstValueFrom(service.initializeForOrganization$(orgId));
+
+      reportPersistenceService.saveApplicationMetadata$.mockReturnValue(
+        throwError(() => new Error("Save failed")),
+      );
+
+      const newDate = new Date("2025-06-01");
+      await expect(
+        firstValueFrom(service.markApplicationsAsReviewed$(["github.com"], newDate)),
+      ).rejects.toThrow("Save failed");
+
+      expect(mockReport.applications[0].reviewedDate).toBe(originalDate);
+    });
+  });
+
+  describe("Organization Switching", () => {
+    it("should reset state when switching organizations", async () => {
+      reportPersistenceService.loadReport$.mockReturnValue(
+        of({ report: testReport, hadLegacyBlobs: false }),
+      );
+
+      await firstValueFrom(service.initializeForOrganization$(orgId));
+      const firstReport = await firstValueFrom(service.report$);
+      expect(firstReport).toBe(testReport);
+
+      // Switch to different org
+      const newOrgId = "org-456" as OrganizationId;
+      reportPersistenceService.loadReport$.mockReturnValue(of(null));
+
+      await firstValueFrom(service.initializeForOrganization$(newOrgId));
+      const secondReport = await firstValueFrom(service.report$);
+      expect(secondReport).toBeNull();
+    });
+  });
+
+  describe("Edge Cases", () => {
+    it("should expose ciphers$ for UI icon display", async () => {
+      cipherService.getAllFromApiForOrganization.mockResolvedValue(testCiphers);
+      organizationUserApiService.getAllUsers.mockResolvedValue({ data: [] } as any);
+      reportGenerationService.generateReport.mockReturnValue(of(testReport));
+      reportPersistenceService.loadReport$.mockReturnValue(of(null));
+      reportPersistenceService.saveReport$.mockReturnValue(
+        of({ id: "report-id" as OrganizationReportId, contentEncryptionKey: new EncString("") }),
+      );
+
+      await firstValueFrom(service.generateNewReport$(orgId));
+
+      const ciphers = await firstValueFrom(service.ciphers$);
+      expect(ciphers).toEqual(testCiphers);
+    });
+
+    it("should clear error after successful operation", async () => {
+      // First operation fails
+      reportPersistenceService.loadReport$.mockReturnValue(
+        throwError(() => new Error("Load failed")),
+      );
+      await firstValueFrom(service.initializeForOrganization$(orgId));
+
+      let error = await firstValueFrom(service.error$);
+      expect(error).toBe("Failed to initialize");
+
+      // Second operation succeeds
+      reportPersistenceService.loadReport$.mockReturnValue(
+        of({ report: testReport, hadLegacyBlobs: false }),
+      );
+      await firstValueFrom(service.initializeForOrganization$(orgId));
+
+      error = await firstValueFrom(service.error$);
+      expect(error).toBeNull();
+    });
+  });
+
+  describe("Data Transformation", () => {
+    it("should transform organization user data correctly", async () => {
+      const apiUsers = [
+        {
+          id: "user-1",
+          name: "Alice",
+          email: "alice@example.com",
+          collections: [{ id: "col-1", readOnly: false, hidePasswords: false, manage: true }],
+          groups: ["group-1"],
+        } as OrganizationUserUserDetailsResponse,
+        {
+          id: "user-2",
+          name: "Bob",
+          email: "bob@example.com",
+          collections: [{ id: "col-1", readOnly: false, hidePasswords: false, manage: false }],
+          groups: ["group-2"],
+        } as OrganizationUserUserDetailsResponse,
+      ];
+
+      cipherService.getAllFromApiForOrganization.mockResolvedValue(testCiphers);
+      organizationUserApiService.getAllUsers.mockResolvedValue({ data: apiUsers } as any);
+      reportGenerationService.generateReport.mockReturnValue(of(testReport));
+      reportPersistenceService.loadReport$.mockReturnValue(of(null));
+      reportPersistenceService.saveReport$.mockReturnValue(
+        of({ id: "report-id" as OrganizationReportId, contentEncryptionKey: new EncString("") }),
+      );
+
+      await firstValueFrom(service.generateNewReport$(orgId));
+
+      expect(reportGenerationService.generateReport).toHaveBeenCalledWith(
+        testCiphers,
+        expect.arrayContaining([
+          { id: "user-1", name: "Alice", email: "alice@example.com" },
+          { id: "user-2", name: "Bob", email: "bob@example.com" },
+        ]),
+        expect.arrayContaining([
+          {
+            collectionId: "col-1",
+            users: expect.any(Set),
+            groups: expect.any(Set),
+          },
+        ]),
+        expect.arrayContaining([
+          { groupId: "group-1", users: expect.any(Set) },
+          { groupId: "group-2", users: expect.any(Set) },
+        ]),
+        expect.anything(),
+      );
+    });
+  });
+});

--- a/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/view/default-access-intelligence-data.service.ts
+++ b/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/view/default-access-intelligence-data.service.ts
@@ -1,0 +1,523 @@
+import {
+  BehaviorSubject,
+  catchError,
+  forkJoin,
+  from,
+  map,
+  Observable,
+  of,
+  switchMap,
+  take,
+  tap,
+  throwError,
+} from "rxjs";
+
+import {
+  OrganizationUserApiService,
+  OrganizationUserUserDetailsResponse,
+} from "@bitwarden/admin-console/common";
+import type { ListResponse } from "@bitwarden/common/models/response/list.response";
+import { OrganizationId } from "@bitwarden/common/types/guid";
+import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
+import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+import { LogService } from "@bitwarden/logging";
+
+import { ReportProgress } from "../../../../reports/risk-insights/models/report-models";
+import { AccessReportView } from "../../../models";
+import { AccessIntelligenceDataService } from "../../abstractions/access-intelligence-data.service";
+import {
+  CollectionAccessDetails,
+  GroupMembershipDetails,
+  OrganizationUserView,
+} from "../../abstractions/member-cipher-mapping.service";
+import { ReportGenerationService } from "../../abstractions/report-generation.service";
+import { ReportPersistenceService } from "../../abstractions/report-persistence.service";
+
+/**
+ * Default implementation of AccessIntelligenceDataService.
+ *
+ * Orchestrates data loading, report generation, and persistence for Access Intelligence.
+ */
+export class DefaultAccessIntelligenceDataService extends AccessIntelligenceDataService {
+  private _report = new BehaviorSubject<AccessReportView | null>(null);
+  private _ciphers = new BehaviorSubject<CipherView[]>([]);
+  private _loading = new BehaviorSubject<boolean>(false);
+  private _error = new BehaviorSubject<string | null>(null);
+  private _currentOrgId = new BehaviorSubject<OrganizationId | null>(null);
+  private _reportProgress = new BehaviorSubject<ReportProgress | null>(null);
+
+  readonly report$ = this._report.asObservable();
+  readonly ciphers$ = this._ciphers.asObservable();
+  readonly loading$ = this._loading.asObservable();
+  readonly error$ = this._error.asObservable();
+  readonly reportProgress$ = this._reportProgress.asObservable();
+
+  constructor(
+    private cipherService: CipherService,
+    private organizationUserApiService: OrganizationUserApiService,
+    private reportGenerationService: ReportGenerationService,
+    private reportPersistenceService: ReportPersistenceService,
+    private logService: LogService,
+  ) {
+    super();
+  }
+
+  initializeForOrganization$(orgId: OrganizationId): Observable<void> {
+    this.logService.debug(
+      "[DefaultAccessIntelligenceDataService] Initializing for organization",
+      orgId,
+    );
+
+    // Reset state if switching organizations
+    const previousOrgId = this._currentOrgId.value;
+    if (previousOrgId && previousOrgId !== orgId) {
+      this.resetState();
+    }
+
+    this._currentOrgId.next(orgId);
+    this._loading.next(true);
+    this._error.next(null);
+
+    return this.reportPersistenceService.loadReport$(orgId).pipe(
+      switchMap((result) => {
+        if (!result) {
+          return of(null);
+        }
+
+        const { report, hadLegacyBlobs } = result;
+
+        if (hadLegacyBlobs) {
+          this.logService.info(
+            "[DefaultAccessIntelligenceDataService] Legacy blobs detected, re-saving in current format",
+          );
+          return this.reportPersistenceService.saveReport$(report, orgId).pipe(
+            tap(({ id, contentEncryptionKey }) => {
+              report.id = id;
+              report.contentEncryptionKey = contentEncryptionKey;
+              this.logService.info(
+                "[DefaultAccessIntelligenceDataService] Legacy blobs re-saved in current format",
+              );
+            }),
+            map(() => report),
+          );
+        }
+
+        return of(report);
+      }),
+      switchMap((report) => {
+        if (report) {
+          this.logService.debug("[DefaultAccessIntelligenceDataService] Report loaded");
+        } else {
+          this.logService.debug("[DefaultAccessIntelligenceDataService] No reports found");
+        }
+        this._report.next(report);
+        this._loading.next(false);
+        return of(undefined as void);
+      }),
+      catchError((error: unknown) => {
+        this.logService.error(
+          "[DefaultAccessIntelligenceDataService] Initialization failed",
+          error,
+        );
+        this._error.next("Failed to initialize");
+        this._loading.next(false);
+        this._report.next(null);
+        return of(undefined as void);
+      }),
+    );
+  }
+
+  generateNewReport$(orgId: OrganizationId): Observable<void> {
+    this.logService.debug(
+      "[DefaultAccessIntelligenceDataService] Generating new report for organization",
+      orgId,
+    );
+
+    this._loading.next(true);
+    this._error.next(null);
+    this._reportProgress.next(null); // Reset progress
+
+    // Emit FetchingMembers before parallel data load begins
+    this._reportProgress.next(ReportProgress.FetchingMembers);
+
+    return forkJoin({
+      previousReport: this._report.pipe(take(1)),
+      orgData: this.loadOrganizationData$(orgId),
+    }).pipe(
+      switchMap(({ previousReport, orgData }) => {
+        const previousApps = previousReport?.applications ?? [];
+        // Transform API users to members, collection access, group memberships
+        const { members, collectionAccess, groupMemberships } = this.transformOrganizationUserData(
+          orgData.apiUsers.data,
+        );
+
+        this.logService.debug(
+          "[DefaultAccessIntelligenceDataService] Organization data loaded and transformed",
+          {
+            cipherCount: orgData.ciphers.length,
+            memberCount: members.length,
+            collectionCount: collectionAccess.length,
+            groupCount: groupMemberships.length,
+          },
+        );
+
+        // Emit AnalyzingPasswords then CalculatingRisks before report generation
+        this._reportProgress.next(ReportProgress.AnalyzingPasswords);
+        this._reportProgress.next(ReportProgress.CalculatingRisks);
+
+        // Generate report
+        return this.reportGenerationService
+          .generateReport(
+            orgData.ciphers,
+            members,
+            collectionAccess,
+            groupMemberships,
+            previousApps,
+          )
+          .pipe(
+            // Store ciphers for icon display and emit GeneratingReport after generation completes
+            tap(() => {
+              this._ciphers.next(orgData.ciphers);
+              this._reportProgress.next(ReportProgress.GeneratingReport);
+            }),
+            // Save report
+            switchMap((generatedReport) => {
+              // Emit Saving before persistence call
+              this._reportProgress.next(ReportProgress.Saving);
+              return this.reportPersistenceService.saveReport$(generatedReport, orgId).pipe(
+                map(({ id, contentEncryptionKey }) => {
+                  generatedReport.id = id;
+                  generatedReport.organizationId = orgId;
+                  generatedReport.contentEncryptionKey = contentEncryptionKey;
+                  return generatedReport;
+                }),
+              );
+            }),
+          );
+      }),
+      tap((savedReport) => {
+        this._report.next(savedReport);
+        this._reportProgress.next(ReportProgress.Complete);
+        this._loading.next(false);
+        this.logService.debug(
+          "[DefaultAccessIntelligenceDataService] Report generation complete",
+          savedReport.id,
+        );
+      }),
+      map(() => undefined as void),
+      catchError((error: unknown) => {
+        this.logService.error(
+          "[DefaultAccessIntelligenceDataService] Report generation failed",
+          error,
+        );
+        this._error.next("Failed to generate report");
+        this._reportProgress.next(null); // Reset progress on error
+        this._loading.next(false);
+        return throwError(() => error);
+      }),
+    );
+  }
+
+  loadExistingReport$(orgId: OrganizationId): Observable<void> {
+    this.logService.debug(
+      "[DefaultAccessIntelligenceDataService] Loading existing report for organization",
+      orgId,
+    );
+
+    this._loading.next(true);
+    this._error.next(null);
+
+    return this.reportPersistenceService.loadReport$(orgId).pipe(
+      tap((result) => {
+        this._report.next(result?.report ?? null);
+        this._loading.next(false);
+        this.logService.debug(
+          "[DefaultAccessIntelligenceDataService] Load complete",
+          result ? "Report loaded" : "No existing report",
+        );
+      }),
+      map(() => undefined as void),
+      catchError((error: unknown) => {
+        this.logService.error("[DefaultAccessIntelligenceDataService] Load failed", error);
+        this._error.next("Failed to load report");
+        this._loading.next(false);
+        return throwError(() => error);
+      }),
+    );
+  }
+
+  refreshReport$(orgId: OrganizationId): Observable<void> {
+    this.logService.debug(
+      "[DefaultAccessIntelligenceDataService] Refreshing report for organization",
+      orgId,
+    );
+
+    // Refresh is the same as generate - both load latest data
+    return this.generateNewReport$(orgId);
+  }
+
+  markApplicationsAsCritical$(appNames: string[]): Observable<void> {
+    const report = this._report.value;
+    if (!report) {
+      return throwError(() => new Error("No report loaded"));
+    }
+
+    if (appNames.length === 0) {
+      return of(undefined as void);
+    }
+
+    this.logService.debug(
+      "[DefaultAccessIntelligenceDataService] Marking applications as critical",
+      appNames,
+    );
+
+    // Save previous states for rollback
+    const previousStates = appNames.map((appName) => {
+      const existingApp = report.applications.find((a) => a.applicationName === appName);
+      return {
+        appName,
+        isCritical: existingApp?.isCritical ?? false,
+        reviewedDate: existingApp?.reviewedDate,
+      };
+    });
+
+    // Mutate all apps at once (single recomputeSummary call)
+    report.markApplicationsAsCritical(appNames);
+
+    // Persist once
+    return this.reportPersistenceService.saveApplicationMetadata$(report).pipe(
+      tap(() => {
+        this._report.next(report);
+        this.logService.debug(
+          "[DefaultAccessIntelligenceDataService] Applications marked as critical",
+          appNames,
+        );
+      }),
+      map(() => undefined as void),
+      catchError((error: unknown) => {
+        this.logService.error(
+          "[DefaultAccessIntelligenceDataService] Failed to mark applications as critical",
+          error,
+        );
+
+        // Rollback all mutations then recompute summary once
+        previousStates.forEach(({ appName, isCritical, reviewedDate }) => {
+          const app = report.applications.find((a) => a.applicationName === appName);
+          if (app) {
+            app.isCritical = isCritical;
+            app.reviewedDate = reviewedDate;
+          }
+        });
+        report.recomputeSummary();
+        this._report.next(report);
+
+        this._error.next("Failed to mark applications as critical");
+        return throwError(() => error);
+      }),
+    );
+  }
+
+  unmarkApplicationsAsCritical$(appNames: string[]): Observable<void> {
+    const report = this._report.value;
+    if (!report) {
+      return throwError(() => new Error("No report loaded"));
+    }
+
+    if (appNames.length === 0) {
+      return of(undefined as void);
+    }
+
+    this.logService.debug(
+      "[DefaultAccessIntelligenceDataService] Unmarking applications as critical",
+      appNames,
+    );
+
+    // Save previous states for rollback
+    const previousStates = appNames.map((appName) => ({
+      appName,
+      isCritical:
+        report.applications.find((a) => a.applicationName === appName)?.isCritical ?? false,
+    }));
+
+    // Mutate all apps at once (single recomputeSummary call)
+    report.unmarkApplicationsAsCritical(appNames);
+
+    // Persist once
+    return this.reportPersistenceService.saveApplicationMetadata$(report).pipe(
+      tap(() => {
+        this._report.next(report);
+        this.logService.debug(
+          "[DefaultAccessIntelligenceDataService] Applications unmarked as critical",
+          appNames,
+        );
+      }),
+      map(() => undefined as void),
+      catchError((error: unknown) => {
+        this.logService.error(
+          "[DefaultAccessIntelligenceDataService] Failed to unmark applications as critical",
+          error,
+        );
+
+        // Rollback all mutations then recompute summary once
+        previousStates.forEach(({ appName, isCritical }) => {
+          const app = report.applications.find((a) => a.applicationName === appName);
+          if (app) {
+            app.isCritical = isCritical;
+          }
+        });
+        report.recomputeSummary();
+        this._report.next(report);
+
+        this._error.next("Failed to unmark applications as critical");
+        return throwError(() => error);
+      }),
+    );
+  }
+
+  markApplicationsAsReviewed$(appNames: string[], date?: Date): Observable<void> {
+    const report = this._report.value;
+    if (!report) {
+      return throwError(() => new Error("No report loaded"));
+    }
+
+    if (appNames.length === 0) {
+      return of(undefined as void);
+    }
+
+    this.logService.debug(
+      "[DefaultAccessIntelligenceDataService] Marking applications as reviewed",
+      appNames,
+    );
+
+    // Save previous states for rollback
+    const previousStates = appNames.map((appName) => ({
+      appName,
+      reviewedDate: report.applications.find((a) => a.applicationName === appName)?.reviewedDate,
+    }));
+
+    // Mutate all apps at once
+    appNames.forEach((name) => report.markApplicationAsReviewed(name, date));
+
+    // Persist once
+    return this.reportPersistenceService.saveApplicationMetadata$(report).pipe(
+      tap(() => {
+        this._report.next(report);
+        this.logService.debug(
+          "[DefaultAccessIntelligenceDataService] Applications marked as reviewed",
+          appNames,
+        );
+      }),
+      map(() => undefined as void),
+      catchError((error: unknown) => {
+        this.logService.error(
+          "[DefaultAccessIntelligenceDataService] Failed to mark applications as reviewed",
+          error,
+        );
+
+        // Rollback all mutations
+        previousStates.forEach(({ appName, reviewedDate }) => {
+          const app = report.applications.find((a) => a.applicationName === appName);
+          if (app) {
+            app.reviewedDate = reviewedDate;
+          }
+        });
+        this._report.next(report);
+
+        this._error.next("Failed to mark applications as reviewed");
+        return throwError(() => error);
+      }),
+    );
+  }
+
+  /**
+   * Load organization data in parallel (ciphers and users with collections/groups)
+   */
+  private loadOrganizationData$(orgId: OrganizationId): Observable<{
+    ciphers: CipherView[];
+    apiUsers: ListResponse<OrganizationUserUserDetailsResponse>;
+  }> {
+    return forkJoin({
+      ciphers: from(this.cipherService.getAllFromApiForOrganization(orgId)),
+      apiUsers: from(
+        this.organizationUserApiService.getAllUsers(orgId, {
+          includeCollections: true,
+          includeGroups: true,
+        }),
+      ),
+    });
+  }
+
+  /**
+   * Transform organization user data from API format to service format
+   *
+   * Inverts user→collections/groups mappings to collection→users and group→users
+   * for use by MemberCipherMappingService.
+   */
+  private transformOrganizationUserData(apiUsers: OrganizationUserUserDetailsResponse[]): {
+    members: OrganizationUserView[];
+    collectionAccess: CollectionAccessDetails[];
+    groupMemberships: GroupMembershipDetails[];
+  } {
+    // 1. Extract members (simple mapping)
+    const members: OrganizationUserView[] = apiUsers.map((user) => ({
+      id: user.id,
+      name: user.name,
+      email: user.email,
+    }));
+
+    // 2. Invert user→collections to collection→users/groups
+    const collectionMap = new Map<string, { users: Set<string>; groups: Set<string> }>();
+
+    apiUsers.forEach((user) => {
+      // For each collection the user has access to, add the user
+      user.collections?.forEach((collection: { id: string }) => {
+        if (!collectionMap.has(collection.id)) {
+          collectionMap.set(collection.id, { users: new Set(), groups: new Set() });
+        }
+        collectionMap.get(collection.id)!.users.add(user.id);
+      });
+    });
+
+    // Note: Groups that grant collection access are handled implicitly:
+    // If a user is in a group that has collection access, the user.collections
+    // array already includes those collections (server-side expansion)
+
+    const collectionAccess: CollectionAccessDetails[] = Array.from(collectionMap.entries()).map(
+      ([collectionId, access]) => ({
+        collectionId,
+        users: access.users,
+        groups: access.groups, // May be empty if server expands groups to users
+      }),
+    );
+
+    // 3. Invert user→groups to group→users
+    const groupMap = new Map<string, Set<string>>();
+
+    apiUsers.forEach((user) => {
+      user.groups?.forEach((groupId: string) => {
+        if (!groupMap.has(groupId)) {
+          groupMap.set(groupId, new Set());
+        }
+        groupMap.get(groupId)!.add(user.id);
+      });
+    });
+
+    const groupMemberships: GroupMembershipDetails[] = Array.from(groupMap.entries()).map(
+      ([groupId, users]) => ({ groupId, users }),
+    );
+
+    return { members, collectionAccess, groupMemberships };
+  }
+
+  /**
+   * Reset state when switching organizations
+   */
+  private resetState(): void {
+    this.logService.debug("[DefaultAccessIntelligenceDataService] Resetting state for org switch");
+    this._report.next(null);
+    this._ciphers.next([]);
+    this._error.next(null);
+    this._loading.next(false);
+    this._reportProgress.next(null);
+  }
+}

--- a/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/view/default-drawer-state.service.ts
+++ b/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/view/default-drawer-state.service.ts
@@ -1,0 +1,62 @@
+import { Injectable, signal, Signal } from "@angular/core";
+
+import {
+  DrawerState,
+  DrawerStateService,
+  DrawerType,
+} from "../../abstractions/drawer-state.service";
+
+/**
+ * Default implementation of DrawerStateService using Angular Signals.
+ *
+ * This is an Angular-only service that manages drawer UI state.
+ * Drawer content is derived in components from report$ observable, not stored here.
+ */
+@Injectable()
+export class DefaultDrawerStateService implements DrawerStateService {
+  private readonly _drawerState = signal<DrawerState>({
+    open: false,
+    type: DrawerType.None,
+    invokerId: "",
+  });
+
+  readonly drawerState: Signal<DrawerState> = this._drawerState.asReadonly();
+
+  openDrawer(type: DrawerType, invokerId: string): void {
+    this._drawerState.set({
+      open: true,
+      type,
+      invokerId,
+    });
+  }
+
+  closeDrawer(): void {
+    this._drawerState.set({
+      open: false,
+      type: DrawerType.None,
+      invokerId: "",
+    });
+  }
+
+  toggleDrawer(type: DrawerType, invokerId: string): void {
+    const current = this._drawerState();
+
+    if (current.open && current.type === type && current.invokerId === invokerId) {
+      // Already open with same type and invoker - close it
+      this.closeDrawer();
+    } else {
+      // Open with new type/invoker
+      this.openDrawer(type, invokerId);
+    }
+  }
+
+  isActiveDrawerType(type: DrawerType): boolean {
+    const current = this._drawerState();
+    return current.open && current.type === type;
+  }
+
+  isDrawerOpenForInvoker(invokerId: string): boolean {
+    const current = this._drawerState();
+    return current.open && current.invokerId === invokerId;
+  }
+}

--- a/bitwarden_license/bit-common/src/dirt/access-intelligence/services/index.ts
+++ b/bitwarden_license/bit-common/src/dirt/access-intelligence/services/index.ts
@@ -1,2 +1,28 @@
 // Abstractions
+export * from "./abstractions/access-intelligence-data.service";
 export * from "./abstractions/access-report-encryption.service";
+export * from "./abstractions/cipher-health.service";
+export * from "./abstractions/drawer-state.service";
+export * from "./abstractions/member-cipher-mapping.service";
+export * from "./abstractions/report-generation.service";
+export * from "./abstractions/report-persistence.service";
+export * from "./abstractions/versioning.service";
+
+// Domain implementations
+export * from "./implementations/domain/default-cipher-health.service";
+export * from "./implementations/domain/default-member-cipher-mapping.service";
+export * from "./implementations/domain/default-report-generation.service";
+
+// Persistence implementations
+export * from "./implementations/persistence/default-access-report-encryption.service";
+export * from "./implementations/persistence/default-report-persistence.service";
+export * from "./implementations/persistence/versioning/application-versioning.service";
+export * from "./implementations/persistence/versioning/report-versioning.service";
+export * from "./implementations/persistence/versioning/summary-versioning.service";
+
+// View implementations
+export * from "./implementations/view/default-access-intelligence-data.service";
+export * from "./implementations/view/default-drawer-state.service";
+
+// Legacy implementations
+export * from "./implementations/legacy/legacy-risk-insights-encryption.service";

--- a/bitwarden_license/bit-common/src/dirt/reports/risk-insights/testing/test-helpers.ts
+++ b/bitwarden_license/bit-common/src/dirt/reports/risk-insights/testing/test-helpers.ts
@@ -1,0 +1,442 @@
+/**
+ * Shared test helpers for Risk Insights tests
+ *
+ * This module provides factory functions and utilities for creating test data
+ * used across Risk Insights view tests, service tests, and integration tests.
+ *
+ * Usage:
+ * - Import specific helpers: `import { createMember, createReport } from './testing/test-helpers';`
+ * - Use in tests to create consistent, reusable test data
+ *
+ * Guidelines:
+ * - Keep helpers simple and focused on data creation
+ * - Use descriptive names following the `create*` pattern
+ * - Leverage existing utilities from @bitwarden/common/spec when appropriate
+ */
+
+import { GetUniqueString } from "@bitwarden/common/spec";
+import { OrganizationId, OrganizationReportId } from "@bitwarden/common/types/guid";
+import { CipherType } from "@bitwarden/common/vault/enums";
+import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+import { LoginUriView } from "@bitwarden/common/vault/models/view/login-uri.view";
+import { LoginView } from "@bitwarden/common/vault/models/view/login.view";
+
+import {
+  AccessReportMetrics,
+  CipherHealthView,
+  MemberRegistryEntryView,
+  AccessReportSettingsView,
+  ApplicationHealthView,
+  AccessReportSummaryView,
+  AccessReportView,
+  MemberRegistry,
+} from "../../../access-intelligence/models";
+import {
+  CollectionAccessDetails,
+  GroupMembershipDetails,
+  OrganizationUserView,
+} from "../../../access-intelligence/services/abstractions/member-cipher-mapping.service";
+
+// ==================== Member Helpers ====================
+
+/**
+ * Creates a test member (organization user)
+ *
+ * @param id - Member ID (defaults to unique string)
+ * @param name - Display name (defaults to unique string)
+ * @param email - Email address (defaults to unique string)
+ * @returns OrganizationUserView for testing
+ *
+ * @example
+ * const alice = createMember("u1", "Alice", "alice@example.com");
+ * const randomMember = createMember(); // Auto-generated unique values
+ */
+export function createMember(id?: string, name?: string, email?: string): OrganizationUserView {
+  const uniqueId = id ?? GetUniqueString("member");
+  return {
+    id: uniqueId,
+    name: name ?? `User-${uniqueId}`,
+    email: email ?? `${uniqueId}@example.com`,
+  };
+}
+
+/**
+ * Creates a member registry from an array of member definitions
+ *
+ * @param members - Array of member objects with id, name, email
+ * @returns MemberRegistry (Record<string, MemberRegistryEntry>)
+ *
+ * @example
+ * const registry = createMemberRegistry([
+ *   { id: "u1", name: "Alice", email: "alice@example.com" },
+ *   { id: "u2", name: "Bob", email: "bob@example.com" },
+ * ]);
+ */
+export function createMemberRegistry(
+  members: Array<{ id: string; name: string; email: string }>,
+): MemberRegistry {
+  const registry: MemberRegistry = {};
+  members.forEach((m) => {
+    registry[m.id] = MemberRegistryEntryView.fromData({
+      id: m.id,
+      userName: m.name,
+      email: m.email,
+    });
+  });
+  return registry;
+}
+
+// ==================== Cipher Helpers ====================
+
+/**
+ * Creates a test cipher with login URIs and collection assignments
+ *
+ * @param id - Cipher ID (defaults to unique string)
+ * @param uris - Array of URI strings
+ * @param collectionIds - Array of collection IDs cipher belongs to
+ * @returns CipherView for testing
+ *
+ * @example
+ * const githubCipher = createCipher("c1", ["https://github.com/login"], ["coll-1"]);
+ */
+export function createCipher(
+  id?: string,
+  uris: string[] = [],
+  collectionIds: string[] = [],
+): CipherView {
+  const cipher = new CipherView();
+  cipher.id = id ?? GetUniqueString("cipher");
+  cipher.type = CipherType.Login;
+  cipher.collectionIds = collectionIds;
+
+  const login = new LoginView();
+  login.uris = uris.map((uri) => {
+    const uriView = new LoginUriView();
+    uriView.uri = uri;
+    return uriView;
+  });
+  cipher.login = login;
+
+  return cipher;
+}
+
+/**
+ * Creates a cipher health result
+ *
+ * @param isAtRisk - Whether the cipher is at-risk
+ * @param options - Optional health details (weak, reused, exposed)
+ * @returns CipherHealthView for testing
+ *
+ * @example
+ * const atRiskHealth = createCipherHealth(true);
+ * const weakPassword = createCipherHealth(true, { hasWeakPassword: true });
+ */
+export function createCipherHealth(
+  isAtRisk: boolean,
+  options?: {
+    hasWeakPassword?: boolean;
+    hasReusedPassword?: boolean;
+    hasExposedPassword?: boolean;
+    exposedCount?: number;
+    weakPasswordScore?: number;
+  },
+): CipherHealthView {
+  return new CipherHealthView({
+    cipherId: GetUniqueString("cipher"),
+    hasWeakPassword: options?.hasWeakPassword ?? isAtRisk,
+    hasReusedPassword: options?.hasReusedPassword ?? false,
+    hasExposedPassword: options?.hasExposedPassword ?? false,
+    exposedCount: options?.exposedCount ?? 0,
+    weakPasswordScore: options?.weakPasswordScore ?? (isAtRisk ? 1 : 4),
+  });
+}
+
+// ==================== Collection & Group Helpers ====================
+
+/**
+ * Creates collection access details
+ *
+ * @param collectionId - Collection ID
+ * @param userIds - Array of user IDs with access
+ * @param groupIds - Array of group IDs with access
+ * @returns CollectionAccessDetails for testing
+ *
+ * @example
+ * const access = createCollectionAccess("coll-1", ["u1", "u2"], ["g1"]);
+ */
+export function createCollectionAccess(
+  collectionId: string,
+  userIds: string[] = [],
+  groupIds: string[] = [],
+): CollectionAccessDetails {
+  return {
+    collectionId,
+    users: new Set(userIds),
+    groups: new Set(groupIds),
+  };
+}
+
+/**
+ * Creates group membership details
+ *
+ * @param groupId - Group ID
+ * @param memberIds - Array of member IDs in the group
+ * @returns GroupMembershipDetails for testing
+ *
+ * @example
+ * const devGroup = createGroupMembership("g1", ["u1", "u2", "u3"]);
+ */
+export function createGroupMembership(
+  groupId: string,
+  memberIds: string[] = [],
+): GroupMembershipDetails {
+  return {
+    groupId,
+    users: new Set(memberIds),
+  };
+}
+
+// ==================== RiskInsights View Helpers ====================
+
+/**
+ * Creates a AccessReportView with sensible defaults
+ *
+ * @param options - Optional overrides for view properties
+ * @returns AccessReportView for testing
+ *
+ * @example
+ * // Minimal usage
+ * const riskInsights = createRiskInsights();
+ *
+ * // With custom properties
+ * const riskInsights = createRiskInsights({
+ *   id: "report-123" as OrganizationReportId,
+ *   organizationId: "org-456" as OrganizationId,
+ *   reports: [createReport("github.com", {}, {})],
+ * });
+ */
+export function createRiskInsights(
+  options?: Partial<{
+    id: OrganizationReportId;
+    organizationId: OrganizationId;
+    reports: ApplicationHealthView[];
+    applications: AccessReportSettingsView[];
+    memberRegistry: MemberRegistry;
+    summary: AccessReportSummaryView;
+    creationDate: Date;
+  }>,
+): AccessReportView {
+  const view = new AccessReportView();
+  if (options?.id) {
+    view.id = options.id;
+  }
+  if (options?.organizationId) {
+    view.organizationId = options.organizationId;
+  }
+  view.reports = options?.reports ?? [];
+  view.applications = options?.applications ?? [];
+  view.memberRegistry = options?.memberRegistry ?? {};
+  view.summary = options?.summary ?? new AccessReportSummaryView();
+  view.creationDate = options?.creationDate ?? new Date();
+  return view;
+}
+
+/**
+ * Creates a AccessReportSummaryView with specific counts
+ *
+ * @param counts - Optional count overrides (defaults to 0)
+ * @returns AccessReportSummaryView for testing
+ *
+ * @example
+ * const summary = createRiskInsightsSummary({
+ *   totalApplicationCount: 10,
+ *   totalAtRiskApplicationCount: 3,
+ *   totalMemberCount: 50,
+ *   totalAtRiskMemberCount: 10,
+ * });
+ */
+export function createRiskInsightsSummary(
+  counts?: Partial<{
+    totalApplicationCount: number;
+    totalAtRiskApplicationCount: number;
+    totalCriticalApplicationCount: number;
+    totalCriticalAtRiskApplicationCount: number;
+    totalMemberCount: number;
+    totalAtRiskMemberCount: number;
+    totalCriticalMemberCount: number;
+    totalCriticalAtRiskMemberCount: number;
+  }>,
+): AccessReportSummaryView {
+  const summary = new AccessReportSummaryView();
+  summary.totalApplicationCount = counts?.totalApplicationCount ?? 0;
+  summary.totalAtRiskApplicationCount = counts?.totalAtRiskApplicationCount ?? 0;
+  summary.totalCriticalApplicationCount = counts?.totalCriticalApplicationCount ?? 0;
+  summary.totalCriticalAtRiskApplicationCount = counts?.totalCriticalAtRiskApplicationCount ?? 0;
+  summary.totalMemberCount = counts?.totalMemberCount ?? 0;
+  summary.totalAtRiskMemberCount = counts?.totalAtRiskMemberCount ?? 0;
+  summary.totalCriticalMemberCount = counts?.totalCriticalMemberCount ?? 0;
+  summary.totalCriticalAtRiskMemberCount = counts?.totalCriticalAtRiskMemberCount ?? 0;
+  return summary;
+}
+
+/**
+ * Creates AccessReportMetrics with specific counts
+ *
+ * @param counts - Optional count overrides (defaults to 0)
+ * @returns AccessReportMetrics for testing
+ *
+ * @example
+ * const metrics = createAccessReportMetrics({
+ *   totalPasswordCount: 100,
+ *   totalAtRiskPasswordCount: 20,
+ * });
+ */
+export function createAccessReportMetrics(
+  counts?: Partial<{
+    totalApplicationCount: number;
+    totalAtRiskApplicationCount: number;
+    totalCriticalApplicationCount: number;
+    totalCriticalAtRiskApplicationCount: number;
+    totalMemberCount: number;
+    totalAtRiskMemberCount: number;
+    totalCriticalMemberCount: number;
+    totalCriticalAtRiskMemberCount: number;
+    totalPasswordCount: number;
+    totalAtRiskPasswordCount: number;
+    totalCriticalPasswordCount: number;
+    totalCriticalAtRiskPasswordCount: number;
+  }>,
+): AccessReportMetrics {
+  const metrics = new AccessReportMetrics();
+  metrics.totalApplicationCount = counts?.totalApplicationCount ?? 0;
+  metrics.totalAtRiskApplicationCount = counts?.totalAtRiskApplicationCount ?? 0;
+  metrics.totalCriticalApplicationCount = counts?.totalCriticalApplicationCount ?? 0;
+  metrics.totalCriticalAtRiskApplicationCount = counts?.totalCriticalAtRiskApplicationCount ?? 0;
+  metrics.totalMemberCount = counts?.totalMemberCount ?? 0;
+  metrics.totalAtRiskMemberCount = counts?.totalAtRiskMemberCount ?? 0;
+  metrics.totalCriticalMemberCount = counts?.totalCriticalMemberCount ?? 0;
+  metrics.totalCriticalAtRiskMemberCount = counts?.totalCriticalAtRiskMemberCount ?? 0;
+  metrics.totalPasswordCount = counts?.totalPasswordCount ?? 0;
+  metrics.totalAtRiskPasswordCount = counts?.totalAtRiskPasswordCount ?? 0;
+  metrics.totalCriticalPasswordCount = counts?.totalCriticalPasswordCount ?? 0;
+  metrics.totalCriticalAtRiskPasswordCount = counts?.totalCriticalAtRiskPasswordCount ?? 0;
+  return metrics;
+}
+
+// ==================== Report & Application Helpers ====================
+
+/**
+ * Creates a risk insights report for an application
+ *
+ * @param applicationName - Name of the application (e.g., "github.com")
+ * @param memberRefs - Record mapping member IDs to at-risk status
+ * @param cipherRefs - Record mapping cipher IDs to at-risk status
+ * @returns ApplicationHealthView for testing
+ *
+ * @example
+ * const report = createReport(
+ *   "github.com",
+ *   { u1: true, u2: false },
+ *   { c1: true, c2: false }
+ * );
+ */
+export function createReport(
+  applicationName: string,
+  memberRefs: Record<string, boolean> = {},
+  cipherRefs: Record<string, boolean> = {},
+): ApplicationHealthView {
+  const report = new ApplicationHealthView();
+  report.applicationName = applicationName;
+  report.memberRefs = memberRefs;
+  report.cipherRefs = cipherRefs;
+  report.passwordCount = Object.keys(cipherRefs).length;
+  report.atRiskPasswordCount = Object.values(cipherRefs).filter((v) => v).length;
+  report.memberCount = Object.keys(memberRefs).length;
+  report.atRiskMemberCount = Object.values(memberRefs).filter((v) => v).length;
+  return report;
+}
+
+/**
+ * Creates an application metadata entry
+ *
+ * @param name - Application name
+ * @param isCritical - Whether application is marked critical
+ * @param reviewedDate - Optional review date
+ * @returns AccessReportSettingsView for testing
+ *
+ * @example
+ * const criticalApp = createApplication("github.com", true);
+ * const reviewedApp = createApplication("gitlab.com", false, new Date("2024-01-15"));
+ */
+export function createApplication(
+  name: string,
+  isCritical = false,
+  reviewedDate?: Date,
+): AccessReportSettingsView {
+  const app = new AccessReportSettingsView();
+  app.applicationName = name;
+  app.isCritical = isCritical;
+  app.reviewedDate = reviewedDate;
+  return app;
+}
+
+// ==================== Composite Helpers ====================
+
+/**
+ * Creates a complete test scenario with members, ciphers, and access
+ *
+ * @param options - Configuration for the scenario
+ * @returns Object containing all created test data
+ *
+ * @example
+ * const scenario = createTestScenario({
+ *   memberCount: 3,
+ *   applications: ["github.com", "gitlab.com"],
+ * });
+ */
+export function createTestScenario(options: {
+  memberCount?: number;
+  applications?: string[];
+  ciphersPerApp?: number;
+}) {
+  const memberCount = options.memberCount ?? 2;
+  const applications = options.applications ?? ["github.com"];
+  const ciphersPerApp = options.ciphersPerApp ?? 2;
+
+  // Create members
+  const members: OrganizationUserView[] = [];
+  for (let i = 0; i < memberCount; i++) {
+    members.push(createMember(`u${i + 1}`, `User${i + 1}`, `user${i + 1}@example.com`));
+  }
+
+  // Create ciphers for each application
+  const ciphers: CipherView[] = [];
+  const collections: CollectionAccessDetails[] = [];
+
+  applications.forEach((app, appIndex) => {
+    const collectionId = `coll-${appIndex + 1}`;
+
+    // Create ciphers for this app
+    for (let i = 0; i < ciphersPerApp; i++) {
+      ciphers.push(
+        createCipher(`c${appIndex * ciphersPerApp + i + 1}`, [`https://${app}`], [collectionId]),
+      );
+    }
+
+    // Give all members access to this collection
+    collections.push(
+      createCollectionAccess(
+        collectionId,
+        members.map((m) => m.id),
+        [],
+      ),
+    );
+  });
+
+  return {
+    members,
+    ciphers,
+    collections,
+    groups: [] as GroupMembershipDetails[],
+  };
+}


### PR DESCRIPTION
## 🎟️ Tracking
**[PM-33797](https://bitwarden.atlassian.net/browse/PM-33797)** — Access Intelligence V2: Standardize Models and Services
**Source / reference:** [Draft PR #19600](https://github.com/bitwarden/clients/pull/19600)

This is part of a series of incremental changes to introduce the V2 architecture for
Access Intelligence. The full series introduces, in order:

1. V2 data model family and encryption service abstraction
2. Type guards expansion
3. **V2 service layer (bit-common) (current)**
4. Access security tasks service refactor (bit-web)
5. V2 shared UI components
6. V2 page-level UI components
7. Module/routing wiring and V1 component updates
8. Model renames and old model cleanup

## 📔 Objective

Introduces the V2 service layer for Access Intelligence in `bit-common`. Adds abstract
service contracts and default implementations for cipher health checking, member-cipher
mapping, report generation, report persistence, and the top-level data service that
wires them together. Also adds a shared test helpers file and view model specs that
depend on this service layer.

## Dependencies

> ✅ Depends on: PR 1 ([#19612 - V2 Models](https://github.com/bitwarden/clients/pull/19612))
> ✅ Depends on: PR 2 ([#19621 - V2 Typeguard Expansion](https://github.com/bitwarden/clients/pull/19621))

## Changes

### New Files
- `services/abstractions/` — 7 service contracts (cipher health, member-cipher mapping, report generation, report persistence, access intelligence data, drawer state, versioning)
- `services/implementations/domain/` — `DefaultCipherHealthService`, `DefaultMemberCipherMappingService`, `DefaultReportGenerationService` + specs
- `services/implementations/persistence/` — `DefaultReportPersistenceService`, `DefaultAccessReportEncryptionService` + specs
- `services/implementations/persistence/versioning/` — `ApplicationVersioningService`, `ReportVersioningService`, `SummaryVersioningService` + specs
- `services/implementations/view/` — `DefaultAccessIntelligenceDataService` + spec, `DefaultDrawerStateService`
- `services/implementations/legacy/` — `LegacyRiskInsightsEncryptionService` + spec _(bridges V1 encryption into the V2 persistence layer; removed in cleanup step)_
- `services/index.ts` — barrel export for the service layer
- `reports/risk-insights/testing/test-helpers.ts` — shared test fixtures used across service specs
- `models/view/access-report.view.spec.ts`, `models/view/application-health.view.spec.ts` — view model specs that depend on test-helpers.ts

### Modified Files
- `access-intelligence/index.ts` — restores `export * from "./services"` (commented out in PR 1 pending this layer)

## 🔜 Follow-up Work
- `ReportProgress.AnalyzingPasswords` will be renamed to `AnalyzingCredentials` (with string values) in PR 7 alongside the `report-models.ts` update
- DI wiring for these services lands in series step **Module/routing wiring and V1 component updates**


[PM-33797]: https://bitwarden.atlassian.net/browse/PM-33797?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ