### PR TITLE
Prototype for consolidating reports

### DIFF
--- a/apps/web/src/app/dirt/reports/pages/cipher-report.component.ts
+++ b/apps/web/src/app/dirt/reports/pages/cipher-report.component.ts
@@ -17,6 +17,7 @@ import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.servic
 import { CipherId, CollectionId, OrganizationId } from "@bitwarden/common/types/guid";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.service.abstraction";
+import { CipherType } from "@bitwarden/common/vault/enums";
 import { CipherRepromptType } from "@bitwarden/common/vault/enums/cipher-reprompt-type";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { DialogRef, TableDataSource, DialogService } from "@bitwarden/components";
@@ -282,6 +283,20 @@ export abstract class CipherReportComponent implements OnDestroy {
       c.reprompt === CipherRepromptType.None ||
       (await this.passwordRepromptService.showPasswordPrompt())
     );
+  }
+
+  protected filterCiphersByPermissions(ciphers: CipherView[]): CipherView[] {
+    return ciphers.filter((ciph) => {
+      const { type, login, isDeleted, edit, viewPassword } = ciph;
+      return (
+        type === CipherType.Login &&
+        login.password != null &&
+        login.password !== "" &&
+        !isDeleted &&
+        (!!this.organization || edit) &&
+        viewPassword
+      );
+    });
   }
 
   protected async getAllCiphers(): Promise<CipherView[]> {

--- a/apps/web/src/app/dirt/reports/pages/exposed-passwords-report.component.spec.ts
+++ b/apps/web/src/app/dirt/reports/pages/exposed-passwords-report.component.spec.ts
@@ -3,13 +3,13 @@ import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { mock, MockProxy } from "jest-mock-extended";
 import { of } from "rxjs";
 
-import { AuditService } from "@bitwarden/common/abstractions/audit.service";
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { FakeAccountService, mockAccountServiceWith } from "@bitwarden/common/spec";
 import { UserId } from "@bitwarden/common/types/guid";
+import { CipherRiskService } from "@bitwarden/common/vault/abstractions/cipher-risk.service";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.service.abstraction";
 import {
@@ -21,6 +21,7 @@ import {
 import { I18nPipe } from "@bitwarden/ui-common";
 import { CipherFormConfigService, PasswordRepromptService } from "@bitwarden/vault";
 
+import { VaultItemDialogResult } from "../../../vault/components/vault-item-dialog/vault-item-dialog.component";
 import { AdminConsoleCipherFormConfigService } from "../../../vault/org-vault/services/admin-console-cipher-form-config.service";
 
 import { ExposedPasswordsReportComponent } from "./exposed-passwords-report.component";
@@ -45,17 +46,16 @@ class MockBitContainerComponent {}
 describe("ExposedPasswordsReportComponent", () => {
   let component: ExposedPasswordsReportComponent;
   let fixture: ComponentFixture<ExposedPasswordsReportComponent>;
-  let auditService: MockProxy<AuditService>;
+  let cipherRiskService: MockProxy<CipherRiskService>;
   let organizationService: MockProxy<OrganizationService>;
   let syncServiceMock: MockProxy<SyncService>;
-  let adminConsoleCipherFormConfigServiceMock: MockProxy<AdminConsoleCipherFormConfigService>;
   const userId = Utils.newGuid() as UserId;
   const accountService: FakeAccountService = mockAccountServiceWith(userId);
 
   beforeEach(async () => {
-    let cipherFormConfigServiceMock: MockProxy<CipherFormConfigService>;
+    const cipherFormConfigServiceMock = mock<CipherFormConfigService>();
     syncServiceMock = mock<SyncService>();
-    auditService = mock<AuditService>();
+    cipherRiskService = mock<CipherRiskService>();
     organizationService = mock<OrganizationService>();
     organizationService.organizations$.mockReturnValue(of([]));
     await TestBed.configureTestingModule({
@@ -71,8 +71,8 @@ describe("ExposedPasswordsReportComponent", () => {
           useValue: mock<CipherService>(),
         },
         {
-          provide: AuditService,
-          useValue: auditService,
+          provide: CipherRiskService,
+          useValue: cipherRiskService,
         },
         {
           provide: OrganizationService,
@@ -104,7 +104,7 @@ describe("ExposedPasswordsReportComponent", () => {
         },
         {
           provide: AdminConsoleCipherFormConfigService,
-          useValue: adminConsoleCipherFormConfigServiceMock,
+          useValue: mock<AdminConsoleCipherFormConfigService>(),
         },
       ],
       schemas: [],
@@ -123,10 +123,23 @@ describe("ExposedPasswordsReportComponent", () => {
   });
 
   it('should get only ciphers with exposed passwords that the user has "Can Edit" access to', async () => {
-    const expectedIdOne: any = "cbea34a8-bde4-46ad-9d19-b05001228ab2";
+    const expectedIdOne = "cbea34a8-bde4-46ad-9d19-b05001228ab2";
     const expectedIdTwo = "cbea34a8-bde4-46ad-9d19-b05001228cd3";
 
-    jest.spyOn(auditService, "passwordLeaked").mockReturnValue(Promise.resolve<any>(1234));
+    cipherRiskService.computeRiskForCiphers.mockResolvedValue([
+      {
+        id: expectedIdOne,
+        password_strength: 0,
+        exposed_result: { type: "Found", value: 1234 },
+        reuse_count: undefined,
+      },
+      {
+        id: expectedIdTwo,
+        password_strength: 0,
+        exposed_result: { type: "Found", value: 1234 },
+        reuse_count: undefined,
+      },
+    ]);
     jest.spyOn(component as any, "getAllCiphers").mockReturnValue(Promise.resolve<any>(cipherData));
     await component.setCiphers();
 
@@ -135,6 +148,53 @@ describe("ExposedPasswordsReportComponent", () => {
     expect(component.ciphers[0].edit).toEqual(true);
     expect(component.ciphers[1].id).toEqual(expectedIdTwo);
     expect(component.ciphers[1].edit).toEqual(true);
+
+    // Verify non-editable cipher was excluded before calling the risk service
+    const calledCiphers = cipherRiskService.computeRiskForCiphers.mock.calls[0][0];
+    const calledIds = calledCiphers.map((c: any) => c.id);
+    expect(calledIds).toHaveLength(2);
+    expect(calledIds).not.toContain("cbea34a8-bde4-46ad-9d19-b05001228ab1");
+  });
+
+  describe("determinedUpdatedCipherReportStatus", () => {
+    it("should return updated cipher with exposedXTimes when password is still exposed", async () => {
+      const cipher = cipherData[1] as any;
+      cipherRiskService.computeRiskForCiphers.mockResolvedValueOnce([
+        {
+          id: cipher.id,
+          password_strength: 0,
+          exposed_result: { type: "Found", value: 500 },
+          reuse_count: undefined,
+        },
+      ] as any);
+
+      const result = await component.determinedUpdatedCipherReportStatus(
+        VaultItemDialogResult.Saved,
+        cipher,
+      );
+
+      expect(result).not.toBeNull();
+      expect((result as any).exposedXTimes).toBe(500);
+    });
+
+    it("should return null when password is no longer exposed", async () => {
+      const cipher = cipherData[1] as any;
+      cipherRiskService.computeRiskForCiphers.mockResolvedValueOnce([
+        {
+          id: cipher.id,
+          password_strength: 0,
+          exposed_result: { type: "NotChecked" },
+          reuse_count: undefined,
+        },
+      ] as any);
+
+      const result = await component.determinedUpdatedCipherReportStatus(
+        VaultItemDialogResult.Saved,
+        cipher,
+      );
+
+      expect(result).toBeNull();
+    });
   });
 
   it("should call fullSync method of syncService", () => {

--- a/apps/web/src/app/dirt/reports/pages/exposed-passwords-report.component.ts
+++ b/apps/web/src/app/dirt/reports/pages/exposed-passwords-report.component.ts
@@ -1,12 +1,14 @@
 import { Component, OnInit } from "@angular/core";
+import { firstValueFrom } from "rxjs";
 
-import { AuditService } from "@bitwarden/common/abstractions/audit.service";
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { getUserId } from "@bitwarden/common/auth/services/account.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { uuidAsString } from "@bitwarden/common/platform/abstractions/sdk/sdk.service";
+import { CipherRiskService } from "@bitwarden/common/vault/abstractions/cipher-risk.service";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.service.abstraction";
-import { CipherType } from "@bitwarden/common/vault/enums";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { DialogService } from "@bitwarden/components";
 import { CipherFormConfigService, PasswordRepromptService } from "@bitwarden/vault";
@@ -30,7 +32,7 @@ export class ExposedPasswordsReportComponent extends CipherReportComponent imple
 
   constructor(
     protected cipherService: CipherService,
-    protected auditService: AuditService,
+    protected cipherRiskService: CipherRiskService,
     protected organizationService: OrganizationService,
     dialogService: DialogService,
     accountService: AccountService,
@@ -59,47 +61,36 @@ export class ExposedPasswordsReportComponent extends CipherReportComponent imple
 
   async setCiphers() {
     const allCiphers = await this.getAllCiphers();
+    const filteredCiphers = this.filterCiphersByPermissions(allCiphers);
+
+    const userId = await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId));
+    const results = await this.cipherRiskService.computeRiskForCiphers(filteredCiphers, userId, {
+      checkExposed: true,
+    });
+
     const exposedPasswordCiphers: ReportResult[] = [];
-    const promises: Promise<void>[] = [];
+    const cipherMap = new Map(filteredCiphers.map((c) => [c.id, c]));
     this.filterStatus = [0];
 
-    allCiphers.forEach((ciph) => {
-      const { type, login, isDeleted, edit, viewPassword } = ciph;
-      if (
-        type !== CipherType.Login ||
-        login.password == null ||
-        login.password === "" ||
-        isDeleted ||
-        (!this.organization && !edit) ||
-        !viewPassword
-      ) {
-        return;
+    for (const result of results) {
+      if (result.exposed_result.type === "Error") {
+        // eslint-disable-next-line no-console
+        console.warn(`[ExposedPasswords] Failed to check breach status for cipher ${result.id}`);
+        continue;
       }
-
-      const promise = this.isPasswordExposed(ciph).then((result) => {
-        if (result) {
-          exposedPasswordCiphers.push(result);
+      if (result.exposed_result.type === "Found" && result.exposed_result.value > 0) {
+        const cipher = cipherMap.get(uuidAsString(result.id));
+        if (cipher) {
+          exposedPasswordCiphers.push({
+            ...cipher,
+            exposedXTimes: result.exposed_result.value,
+          } as ReportResult);
         }
-      });
-      promises.push(promise);
-    });
-    await Promise.all(promises);
+      }
+    }
 
     this.filterCiphersByOrg(exposedPasswordCiphers);
     this.dataSource.sort = { column: "exposedXTimes", direction: "desc" };
-  }
-
-  private async isPasswordExposed(cv: CipherView): Promise<ReportResult | null> {
-    const { login } = cv;
-    if (login.password == null) {
-      return null;
-    }
-    return await this.auditService.passwordLeaked(login.password).then((exposedCount) => {
-      if (exposedCount > 0) {
-        return { ...cv, exposedXTimes: exposedCount } as ReportResult;
-      }
-      return null;
-    });
   }
 
   protected canManageCipher(c: CipherView): boolean {
@@ -111,6 +102,25 @@ export class ExposedPasswordsReportComponent extends CipherReportComponent imple
     result: VaultItemDialogResult,
     updatedCipherView: CipherView,
   ): Promise<CipherView | null> {
-    return await this.isPasswordExposed(updatedCipherView);
+    const userId = await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId));
+    const results = await this.cipherRiskService.computeRiskForCiphers(
+      [updatedCipherView],
+      userId,
+      { checkExposed: true },
+    );
+
+    const riskResult = results[0];
+    if (riskResult?.exposed_result.type === "Error") {
+      // eslint-disable-next-line no-console
+      console.warn(`[ExposedPasswords] Failed to check breach status for cipher ${riskResult.id}`);
+    }
+    if (riskResult?.exposed_result.type === "Found" && riskResult.exposed_result.value > 0) {
+      return {
+        ...updatedCipherView,
+        exposedXTimes: riskResult.exposed_result.value,
+      } as ReportResult;
+    }
+
+    return null;
   }
 }

--- a/apps/web/src/app/dirt/reports/pages/organizations/exposed-passwords-report.component.ts
+++ b/apps/web/src/app/dirt/reports/pages/organizations/exposed-passwords-report.component.ts
@@ -2,12 +2,12 @@ import { Component, OnInit } from "@angular/core";
 import { ActivatedRoute } from "@angular/router";
 import { firstValueFrom, takeUntil, tap } from "rxjs";
 
-import { AuditService } from "@bitwarden/common/abstractions/audit.service";
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { getUserId } from "@bitwarden/common/auth/services/account.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { getById } from "@bitwarden/common/platform/misc";
+import { CipherRiskService } from "@bitwarden/common/vault/abstractions/cipher-risk.service";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.service.abstraction";
 import { Cipher } from "@bitwarden/common/vault/models/domain/cipher";
@@ -51,7 +51,7 @@ export class ExposedPasswordsReportComponent
 
   constructor(
     cipherService: CipherService,
-    auditService: AuditService,
+    cipherRiskService: CipherRiskService,
     dialogService: DialogService,
     organizationService: OrganizationService,
     protected accountService: AccountService,
@@ -64,7 +64,7 @@ export class ExposedPasswordsReportComponent
   ) {
     super(
       cipherService,
-      auditService,
+      cipherRiskService,
       organizationService,
       dialogService,
       accountService,

--- a/apps/web/src/app/dirt/reports/pages/organizations/reused-passwords-report.component.ts
+++ b/apps/web/src/app/dirt/reports/pages/organizations/reused-passwords-report.component.ts
@@ -7,6 +7,7 @@ import { AccountService } from "@bitwarden/common/auth/abstractions/account.serv
 import { getUserId } from "@bitwarden/common/auth/services/account.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { getById } from "@bitwarden/common/platform/misc";
+import { CipherRiskService } from "@bitwarden/common/vault/abstractions/cipher-risk.service";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.service.abstraction";
 import { Cipher } from "@bitwarden/common/vault/models/domain/cipher";
@@ -50,6 +51,7 @@ export class ReusedPasswordsReportComponent
 
   constructor(
     cipherService: CipherService,
+    cipherRiskService: CipherRiskService,
     dialogService: DialogService,
     private route: ActivatedRoute,
     organizationService: OrganizationService,
@@ -62,6 +64,7 @@ export class ReusedPasswordsReportComponent
   ) {
     super(
       cipherService,
+      cipherRiskService,
       organizationService,
       dialogService,
       accountService,

--- a/apps/web/src/app/dirt/reports/pages/organizations/weak-passwords-report.component.ts
+++ b/apps/web/src/app/dirt/reports/pages/organizations/weak-passwords-report.component.ts
@@ -7,7 +7,7 @@ import { AccountService } from "@bitwarden/common/auth/abstractions/account.serv
 import { getUserId } from "@bitwarden/common/auth/services/account.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { getById } from "@bitwarden/common/platform/misc";
-import { PasswordStrengthServiceAbstraction } from "@bitwarden/common/tools/password-strength";
+import { CipherRiskService } from "@bitwarden/common/vault/abstractions/cipher-risk.service";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.service.abstraction";
 import { Cipher } from "@bitwarden/common/vault/models/domain/cipher";
@@ -51,7 +51,7 @@ export class WeakPasswordsReportComponent
 
   constructor(
     cipherService: CipherService,
-    passwordStrengthService: PasswordStrengthServiceAbstraction,
+    cipherRiskService: CipherRiskService,
     dialogService: DialogService,
     private route: ActivatedRoute,
     organizationService: OrganizationService,
@@ -64,7 +64,7 @@ export class WeakPasswordsReportComponent
   ) {
     super(
       cipherService,
-      passwordStrengthService,
+      cipherRiskService,
       organizationService,
       dialogService,
       accountService,

--- a/apps/web/src/app/dirt/reports/pages/reused-passwords-report.component.html
+++ b/apps/web/src/app/dirt/reports/pages/reused-passwords-report.component.html
@@ -109,7 +109,7 @@
             }
             <td bitCell class="tw-text-right">
               <span bitBadge variant="warning">
-                {{ "reusedXTimes" | i18n: passwordUseMap.get(row.login.password) }}
+                {{ "reusedXTimes" | i18n: reuseCountMap.get(row.id) }}
               </span>
             </td>
           </ng-template>

--- a/apps/web/src/app/dirt/reports/pages/reused-passwords-report.component.spec.ts
+++ b/apps/web/src/app/dirt/reports/pages/reused-passwords-report.component.spec.ts
@@ -9,12 +9,14 @@ import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.servic
 import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { FakeAccountService, mockAccountServiceWith } from "@bitwarden/common/spec";
 import { UserId } from "@bitwarden/common/types/guid";
+import { CipherRiskService } from "@bitwarden/common/vault/abstractions/cipher-risk.service";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.service.abstraction";
 import { DialogService } from "@bitwarden/components";
 import { I18nPipe } from "@bitwarden/ui-common";
 import { CipherFormConfigService, PasswordRepromptService } from "@bitwarden/vault";
 
+import { VaultItemDialogResult } from "../../../vault/components/vault-item-dialog/vault-item-dialog.component";
 import { AdminConsoleCipherFormConfigService } from "../../../vault/org-vault/services/admin-console-cipher-form-config.service";
 
 import { cipherData } from "./reports-ciphers.mock";
@@ -39,17 +41,18 @@ class MockBitContainerComponent {}
 describe("ReusedPasswordsReportComponent", () => {
   let component: ReusedPasswordsReportComponent;
   let fixture: ComponentFixture<ReusedPasswordsReportComponent>;
+  let cipherRiskService: MockProxy<CipherRiskService>;
   let organizationService: MockProxy<OrganizationService>;
   let syncServiceMock: MockProxy<SyncService>;
-  let adminConsoleCipherFormConfigServiceMock: MockProxy<AdminConsoleCipherFormConfigService>;
   const userId = Utils.newGuid() as UserId;
   const accountService: FakeAccountService = mockAccountServiceWith(userId);
 
   beforeEach(async () => {
-    let cipherFormConfigServiceMock: MockProxy<CipherFormConfigService>;
+    const cipherFormConfigServiceMock = mock<CipherFormConfigService>();
     organizationService = mock<OrganizationService>();
     organizationService.organizations$.mockReturnValue(of([]));
     syncServiceMock = mock<SyncService>();
+    cipherRiskService = mock<CipherRiskService>();
     await TestBed.configureTestingModule({
       declarations: [
         ReusedPasswordsReportComponent,
@@ -61,6 +64,10 @@ describe("ReusedPasswordsReportComponent", () => {
         {
           provide: CipherService,
           useValue: mock<CipherService>(),
+        },
+        {
+          provide: CipherRiskService,
+          useValue: cipherRiskService,
         },
         {
           provide: OrganizationService,
@@ -92,7 +99,7 @@ describe("ReusedPasswordsReportComponent", () => {
         },
         {
           provide: AdminConsoleCipherFormConfigService,
-          useValue: adminConsoleCipherFormConfigServiceMock,
+          useValue: mock<AdminConsoleCipherFormConfigService>(),
         },
       ],
       schemas: [],
@@ -110,8 +117,25 @@ describe("ReusedPasswordsReportComponent", () => {
   });
 
   it('should get ciphers with reused passwords that the user has "Can Edit" access to', async () => {
-    const expectedIdOne: any = "cbea34a8-bde4-46ad-9d19-b05001228ab2";
+    const expectedIdOne = "cbea34a8-bde4-46ad-9d19-b05001228ab2";
     const expectedIdTwo = "cbea34a8-bde4-46ad-9d19-b05001228cd3";
+    const passwordMap = { "123": 2 };
+
+    cipherRiskService.buildPasswordReuseMap.mockResolvedValue(passwordMap as any);
+    cipherRiskService.computeRiskForCiphers.mockResolvedValue([
+      {
+        id: expectedIdOne,
+        password_strength: 0,
+        exposed_result: { type: "NotChecked" },
+        reuse_count: 2,
+      },
+      {
+        id: expectedIdTwo,
+        password_strength: 0,
+        exposed_result: { type: "NotChecked" },
+        reuse_count: 2,
+      },
+    ] as any);
     jest.spyOn(component as any, "getAllCiphers").mockReturnValue(Promise.resolve<any>(cipherData));
     await component.setCiphers();
 
@@ -120,6 +144,74 @@ describe("ReusedPasswordsReportComponent", () => {
     expect(component.ciphers[0].edit).toEqual(true);
     expect(component.ciphers[1].id).toEqual(expectedIdTwo);
     expect(component.ciphers[1].edit).toEqual(true);
+
+    // Verify non-editable cipher was excluded before calling the risk service
+    const calledCiphers = cipherRiskService.computeRiskForCiphers.mock.calls[0][0];
+    const calledIds = calledCiphers.map((c: any) => c.id);
+    expect(calledIds).toHaveLength(2);
+    expect(calledIds).not.toContain("cbea34a8-bde4-46ad-9d19-b05001228ab1");
+
+    // Verify the passwordMap from buildPasswordReuseMap was passed to computeRiskForCiphers
+    expect(cipherRiskService.computeRiskForCiphers).toHaveBeenCalledWith(
+      expect.any(Array),
+      userId,
+      expect.objectContaining({ passwordMap }),
+    );
+  });
+
+  describe("determinedUpdatedCipherReportStatus", () => {
+    it("should remove cipher from ciphersToCheckForReusedPasswords when deleted", async () => {
+      const cipher = cipherData[1] as any;
+      component.ciphersToCheckForReusedPasswords = [cipher];
+
+      const result = await component.determinedUpdatedCipherReportStatus(
+        VaultItemDialogResult.Deleted,
+        cipher,
+      );
+
+      expect(result).toBeNull();
+      expect(component.ciphersToCheckForReusedPasswords).toHaveLength(0);
+    });
+
+    it("should update the cipher in the list and recompute when saved", async () => {
+      const cipher = cipherData[1] as any;
+      component.ciphersToCheckForReusedPasswords = [cipher];
+      cipherRiskService.buildPasswordReuseMap.mockResolvedValueOnce({} as any);
+      cipherRiskService.computeRiskForCiphers.mockResolvedValueOnce([
+        {
+          id: cipher.id,
+          password_strength: 0,
+          exposed_result: { type: "NotChecked" },
+          reuse_count: 2,
+        },
+      ] as any);
+
+      const result = await component.determinedUpdatedCipherReportStatus(
+        VaultItemDialogResult.Saved,
+        cipher,
+      );
+
+      expect(result).not.toBeNull();
+      expect(result!.id).toBe(cipher.id);
+    });
+
+    it("should recompute and exclude cipher no longer reused when saved", async () => {
+      const cipher = cipherData[1] as any;
+      component.ciphersToCheckForReusedPasswords = [cipher];
+      cipherRiskService.buildPasswordReuseMap.mockResolvedValueOnce({} as any);
+      cipherRiskService.computeRiskForCiphers.mockResolvedValueOnce([
+        {
+          id: cipher.id,
+          password_strength: 0,
+          exposed_result: { type: "NotChecked" },
+          reuse_count: 1,
+        },
+      ] as any);
+
+      await component.determinedUpdatedCipherReportStatus(VaultItemDialogResult.Saved, cipher);
+
+      expect(component.ciphers).toHaveLength(0);
+    });
   });
 
   it("should call fullSync method of syncService", () => {

--- a/apps/web/src/app/dirt/reports/pages/reused-passwords-report.component.ts
+++ b/apps/web/src/app/dirt/reports/pages/reused-passwords-report.component.ts
@@ -1,13 +1,16 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
 import { Component, OnInit } from "@angular/core";
+import { firstValueFrom } from "rxjs";
 
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { getUserId } from "@bitwarden/common/auth/services/account.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { uuidAsString } from "@bitwarden/common/platform/abstractions/sdk/sdk.service";
+import { CipherRiskService } from "@bitwarden/common/vault/abstractions/cipher-risk.service";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.service.abstraction";
-import { CipherType } from "@bitwarden/common/vault/enums";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { DialogService } from "@bitwarden/components";
 import { CipherFormConfigService, PasswordRepromptService } from "@bitwarden/vault";
@@ -26,11 +29,12 @@ import { CipherReportComponent } from "./cipher-report.component";
 })
 export class ReusedPasswordsReportComponent extends CipherReportComponent implements OnInit {
   ciphersToCheckForReusedPasswords: CipherView[] = [];
-  passwordUseMap: Map<string, number>;
+  reuseCountMap: Map<string, number> = new Map();
   disabled = true;
 
   constructor(
     protected cipherService: CipherService,
+    protected cipherRiskService: CipherRiskService,
     protected organizationService: OrganizationService,
     dialogService: DialogService,
     accountService: AccountService,
@@ -58,44 +62,11 @@ export class ReusedPasswordsReportComponent extends CipherReportComponent implem
   }
 
   async setCiphers() {
-    this.ciphersToCheckForReusedPasswords = await this.getAllCiphers();
-    const reusedPasswordCiphers = await this.checkCiphersForReusedPasswords(
-      this.ciphersToCheckForReusedPasswords,
-    );
-    this.filterCiphersByOrg(reusedPasswordCiphers);
-  }
-
-  protected async checkCiphersForReusedPasswords(ciphers: CipherView[]): Promise<CipherView[]> {
-    const ciphersWithPasswords: CipherView[] = [];
-    this.passwordUseMap = new Map<string, number>();
+    const allCiphers = await this.getAllCiphers();
+    this.ciphersToCheckForReusedPasswords = this.filterCiphersByPermissions(allCiphers);
     this.filterStatus = [0];
 
-    ciphers.forEach((ciph) => {
-      const { type, login, isDeleted, edit, viewPassword } = ciph;
-      if (
-        type !== CipherType.Login ||
-        login.password == null ||
-        login.password === "" ||
-        isDeleted ||
-        (!this.organization && !edit) ||
-        !viewPassword
-      ) {
-        return;
-      }
-
-      ciphersWithPasswords.push(ciph);
-      if (this.passwordUseMap.has(login.password)) {
-        this.passwordUseMap.set(login.password, this.passwordUseMap.get(login.password) + 1);
-      } else {
-        this.passwordUseMap.set(login.password, 1);
-      }
-    });
-    const reusedPasswordCiphers = ciphersWithPasswords.filter(
-      (c) =>
-        this.passwordUseMap.has(c.login.password) && this.passwordUseMap.get(c.login.password) > 1,
-    );
-
-    return reusedPasswordCiphers;
+    await this.computeReusedPasswords();
   }
 
   protected canManageCipher(c: CipherView): boolean {
@@ -127,14 +98,32 @@ export class ReusedPasswordsReportComponent extends CipherReportComponent implem
     }
 
     // Re-check the passwords for reused passwords for all ciphers
-    const reusedPasswordCiphers = await this.checkCiphersForReusedPasswords(
-      this.ciphersToCheckForReusedPasswords,
-    );
-
-    // set the updated ciphers list to the filtered reused passwords
-    this.filterCiphersByOrg(reusedPasswordCiphers);
+    await this.computeReusedPasswords();
 
     // return the updated cipher view
     return updatedCipherView;
+  }
+
+  private async computeReusedPasswords(): Promise<void> {
+    const ciphers = this.ciphersToCheckForReusedPasswords;
+    const userId = await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId));
+
+    const passwordMap = await this.cipherRiskService.buildPasswordReuseMap(ciphers, userId);
+    const results = await this.cipherRiskService.computeRiskForCiphers(ciphers, userId, {
+      passwordMap,
+    });
+
+    this.reuseCountMap = new Map<string, number>();
+    const reusedCipherIds = new Set<string>();
+
+    for (const result of results) {
+      if ((result.reuse_count ?? 1) > 1) {
+        this.reuseCountMap.set(uuidAsString(result.id), result.reuse_count);
+        reusedCipherIds.add(uuidAsString(result.id));
+      }
+    }
+
+    const reusedPasswordCiphers = ciphers.filter((c) => reusedCipherIds.has(c.id));
+    this.filterCiphersByOrg(reusedPasswordCiphers);
   }
 }

--- a/apps/web/src/app/dirt/reports/pages/weak-passwords-report.component.spec.ts
+++ b/apps/web/src/app/dirt/reports/pages/weak-passwords-report.component.spec.ts
@@ -8,14 +8,15 @@ import { AccountService } from "@bitwarden/common/auth/abstractions/account.serv
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { FakeAccountService, mockAccountServiceWith } from "@bitwarden/common/spec";
-import { PasswordStrengthServiceAbstraction } from "@bitwarden/common/tools/password-strength";
 import { UserId } from "@bitwarden/common/types/guid";
+import { CipherRiskService } from "@bitwarden/common/vault/abstractions/cipher-risk.service";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.service.abstraction";
 import { DialogService } from "@bitwarden/components";
 import { I18nPipe } from "@bitwarden/ui-common";
 import { CipherFormConfigService, PasswordRepromptService } from "@bitwarden/vault";
 
+import { VaultItemDialogResult } from "../../../vault/components/vault-item-dialog/vault-item-dialog.component";
 import { AdminConsoleCipherFormConfigService } from "../../../vault/org-vault/services/admin-console-cipher-form-config.service";
 
 import { cipherData } from "./reports-ciphers.mock";
@@ -40,17 +41,16 @@ class MockBitContainerComponent {}
 describe("WeakPasswordsReportComponent", () => {
   let component: WeakPasswordsReportComponent;
   let fixture: ComponentFixture<WeakPasswordsReportComponent>;
-  let passwordStrengthService: MockProxy<PasswordStrengthServiceAbstraction>;
+  let cipherRiskService: MockProxy<CipherRiskService>;
   let organizationService: MockProxy<OrganizationService>;
   let syncServiceMock: MockProxy<SyncService>;
-  let adminConsoleCipherFormConfigServiceMock: MockProxy<AdminConsoleCipherFormConfigService>;
   const userId = Utils.newGuid() as UserId;
   const accountService: FakeAccountService = mockAccountServiceWith(userId);
 
   beforeEach(async () => {
-    let cipherFormConfigServiceMock: MockProxy<CipherFormConfigService>;
+    const cipherFormConfigServiceMock = mock<CipherFormConfigService>();
     syncServiceMock = mock<SyncService>();
-    passwordStrengthService = mock<PasswordStrengthServiceAbstraction>();
+    cipherRiskService = mock<CipherRiskService>();
     organizationService = mock<OrganizationService>();
     organizationService.organizations$.mockReturnValue(of([]));
 
@@ -63,8 +63,8 @@ describe("WeakPasswordsReportComponent", () => {
           useValue: mock<CipherService>(),
         },
         {
-          provide: PasswordStrengthServiceAbstraction,
-          useValue: passwordStrengthService,
+          provide: CipherRiskService,
+          useValue: cipherRiskService,
         },
         {
           provide: OrganizationService,
@@ -97,7 +97,7 @@ describe("WeakPasswordsReportComponent", () => {
 
         {
           provide: AdminConsoleCipherFormConfigService,
-          useValue: adminConsoleCipherFormConfigServiceMock,
+          useValue: mock<AdminConsoleCipherFormConfigService>(),
         },
       ],
       schemas: [],
@@ -115,13 +115,23 @@ describe("WeakPasswordsReportComponent", () => {
   });
 
   it('should get only ciphers with weak passwords that the user has "Can Edit" access to', async () => {
-    const expectedIdOne: any = "cbea34a8-bde4-46ad-9d19-b05001228ab2";
+    const expectedIdOne = "cbea34a8-bde4-46ad-9d19-b05001228ab2";
     const expectedIdTwo = "cbea34a8-bde4-46ad-9d19-b05001228cd3";
 
-    jest.spyOn(passwordStrengthService, "getPasswordStrength").mockReturnValue({
-      password: "123",
-      score: 0,
-    } as any);
+    cipherRiskService.computeRiskForCiphers.mockResolvedValue([
+      {
+        id: expectedIdOne,
+        password_strength: 0,
+        exposed_result: { type: "NotChecked" },
+        reuse_count: undefined,
+      },
+      {
+        id: expectedIdTwo,
+        password_strength: 0,
+        exposed_result: { type: "NotChecked" },
+        reuse_count: undefined,
+      },
+    ] as any);
     jest.spyOn(component as any, "getAllCiphers").mockReturnValue(Promise.resolve<any>(cipherData));
     await component.setCiphers();
 
@@ -130,6 +140,92 @@ describe("WeakPasswordsReportComponent", () => {
     expect(component.ciphers[0].edit).toEqual(true);
     expect(component.ciphers[1].id).toEqual(expectedIdTwo);
     expect(component.ciphers[1].edit).toEqual(true);
+
+    // Verify non-editable cipher was excluded before calling the risk service
+    const calledCiphers = cipherRiskService.computeRiskForCiphers.mock.calls[0][0];
+    const calledIds = calledCiphers.map((c: any) => c.id);
+    expect(calledIds).toHaveLength(2);
+    expect(calledIds).not.toContain("cbea34a8-bde4-46ad-9d19-b05001228ab1");
+  });
+
+  describe("determinedUpdatedCipherReportStatus", () => {
+    it("should remove cipher from weakPasswordCiphers when deleted", async () => {
+      const cipher = cipherData[1] as any;
+      component.weakPasswordCiphers = [{ ...cipher, score: 0 }] as any;
+
+      const result = await component.determinedUpdatedCipherReportStatus(
+        VaultItemDialogResult.Deleted,
+        cipher,
+      );
+
+      expect(result).toBeNull();
+      expect(component.weakPasswordCiphers).toHaveLength(0);
+    });
+
+    it("should update cipher in weakPasswordCiphers when it is still weak", async () => {
+      const cipher = cipherData[1] as any;
+      component.weakPasswordCiphers = [{ ...cipher, score: 0 }] as any;
+      cipherRiskService.computeRiskForCiphers.mockResolvedValueOnce([
+        {
+          id: cipher.id,
+          password_strength: 2,
+          exposed_result: { type: "NotChecked" },
+          reuse_count: undefined,
+        },
+      ] as any);
+
+      const result = await component.determinedUpdatedCipherReportStatus(
+        VaultItemDialogResult.Saved,
+        cipher,
+      );
+
+      expect(result).not.toBeNull();
+      expect((result as any).score).toBe(2);
+      expect(component.weakPasswordCiphers[0].score).toBe(2);
+    });
+
+    it("should remove cipher from weakPasswordCiphers when password is no longer weak", async () => {
+      const cipher = cipherData[1] as any;
+      component.weakPasswordCiphers = [{ ...cipher, score: 0 }] as any;
+      cipherRiskService.computeRiskForCiphers.mockResolvedValueOnce([
+        {
+          id: cipher.id,
+          password_strength: 3,
+          exposed_result: { type: "NotChecked" },
+          reuse_count: undefined,
+        },
+      ] as any);
+
+      const result = await component.determinedUpdatedCipherReportStatus(
+        VaultItemDialogResult.Saved,
+        cipher,
+      );
+
+      expect(result).toBeNull();
+      expect(component.weakPasswordCiphers).toHaveLength(0);
+    });
+
+    it("should add cipher to weakPasswordCiphers when it becomes newly weak", async () => {
+      const cipher = cipherData[1] as any;
+      component.weakPasswordCiphers = [];
+      cipherRiskService.computeRiskForCiphers.mockResolvedValueOnce([
+        {
+          id: cipher.id,
+          password_strength: 0,
+          exposed_result: { type: "NotChecked" },
+          reuse_count: undefined,
+        },
+      ] as any);
+
+      const result = await component.determinedUpdatedCipherReportStatus(
+        VaultItemDialogResult.Saved,
+        cipher,
+      );
+
+      expect(result).not.toBeNull();
+      expect(component.weakPasswordCiphers).toHaveLength(1);
+      expect(component.weakPasswordCiphers[0].id).toBe(cipher.id);
+    });
   });
 
   it("should call fullSync method of syncService", () => {

--- a/apps/web/src/app/dirt/reports/pages/weak-passwords-report.component.ts
+++ b/apps/web/src/app/dirt/reports/pages/weak-passwords-report.component.ts
@@ -1,15 +1,16 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
 import { Component, OnInit } from "@angular/core";
+import { firstValueFrom } from "rxjs";
 
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { getUserId } from "@bitwarden/common/auth/services/account.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
-import { Utils } from "@bitwarden/common/platform/misc/utils";
-import { PasswordStrengthServiceAbstraction } from "@bitwarden/common/tools/password-strength";
+import { uuidAsString } from "@bitwarden/common/platform/abstractions/sdk/sdk.service";
+import { CipherRiskService } from "@bitwarden/common/vault/abstractions/cipher-risk.service";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.service.abstraction";
-import { CipherType } from "@bitwarden/common/vault/enums";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { BadgeVariant, DialogService } from "@bitwarden/components";
 import { CipherFormConfigService, PasswordRepromptService } from "@bitwarden/vault";
@@ -36,7 +37,7 @@ export class WeakPasswordsReportComponent extends CipherReportComponent implemen
 
   constructor(
     protected cipherService: CipherService,
-    protected passwordStrengthService: PasswordStrengthServiceAbstraction,
+    protected cipherRiskService: CipherRiskService,
     protected organizationService: OrganizationService,
     dialogService: DialogService,
     protected accountService: AccountService,
@@ -65,9 +66,32 @@ export class WeakPasswordsReportComponent extends CipherReportComponent implemen
 
   async setCiphers() {
     const allCiphers = await this.getAllCiphers();
+    const filteredCiphers = this.filterCiphersByPermissions(allCiphers);
+
+    const userId = await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId));
+    const results = await this.cipherRiskService.computeRiskForCiphers(filteredCiphers, userId);
+
     this.weakPasswordCiphers = [];
     this.filterStatus = [0];
-    this.findWeakPasswords(allCiphers);
+
+    const cipherMap = new Map(filteredCiphers.map((c) => [c.id, c]));
+
+    for (const result of results) {
+      if (result.password_strength <= 2) {
+        const cipher = cipherMap.get(uuidAsString(result.id));
+        if (cipher) {
+          const scoreValue = this.scoreKey(result.password_strength);
+          this.weakPasswordCiphers.push({
+            ...cipher,
+            score: result.password_strength,
+            reportValue: scoreValue,
+            scoreKey: scoreValue.sortOrder,
+          } as ReportResult);
+        }
+      }
+    }
+
+    this.filterCiphersByOrg(this.weakPasswordCiphers);
   }
 
   async determinedUpdatedCipherReportStatus(
@@ -81,79 +105,38 @@ export class WeakPasswordsReportComponent extends CipherReportComponent implemen
       return null;
     }
 
-    const updatedReportStatus = await this.determineWeakPasswordScore(updatedCipherView);
+    const userId = await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId));
+    const results = await this.cipherRiskService.computeRiskForCiphers([updatedCipherView], userId);
 
-    const index = this.weakPasswordCiphers.findIndex((c) => c.id === updatedCipherView.id);
+    const riskResult = results[0];
+    let updatedReportStatus: ReportResult | null = null;
 
-    if (index !== -1) {
-      this.weakPasswordCiphers[index] = updatedReportStatus;
-    }
-
-    return updatedReportStatus;
-  }
-
-  protected findWeakPasswords(ciphers: CipherView[]): void {
-    ciphers.forEach((ciph) => {
-      const row = this.determineWeakPasswordScore(ciph);
-      if (row != null) {
-        this.weakPasswordCiphers.push(row);
-      }
-    });
-    this.filterCiphersByOrg(this.weakPasswordCiphers);
-  }
-
-  protected determineWeakPasswordScore(ciph: CipherView): ReportResult | null {
-    const { type, login, isDeleted, edit, viewPassword } = ciph;
-    if (
-      type !== CipherType.Login ||
-      login.password == null ||
-      login.password === "" ||
-      isDeleted ||
-      (!this.organization && !edit) ||
-      !viewPassword
-    ) {
-      return;
-    }
-
-    const hasUserName = this.isUserNameNotEmpty(ciph);
-    let userInput: string[] = [];
-    if (hasUserName) {
-      const atPosition = login.username.indexOf("@");
-      if (atPosition > -1) {
-        userInput = userInput
-          .concat(
-            login.username
-              .substr(0, atPosition)
-              .trim()
-              .toLowerCase()
-              .split(/[^A-Za-z0-9]/),
-          )
-          .filter((i) => i.length >= 3);
-      } else {
-        userInput = login.username
-          .trim()
-          .toLowerCase()
-          .split(/[^A-Za-z0-9]/)
-          .filter((i) => i.length >= 3);
-      }
-    }
-    const result = this.passwordStrengthService.getPasswordStrength(
-      login.password,
-      null,
-      userInput.length > 0 ? userInput : null,
-    );
-
-    if (result.score != null && result.score <= 2) {
-      const scoreValue = this.scoreKey(result.score);
-      return {
-        ...ciph,
-        score: result.score,
+    if (riskResult && riskResult.password_strength <= 2) {
+      const scoreValue = this.scoreKey(riskResult.password_strength);
+      updatedReportStatus = {
+        ...updatedCipherView,
+        score: riskResult.password_strength,
         reportValue: scoreValue,
         scoreKey: scoreValue.sortOrder,
       } as ReportResult;
     }
 
-    return null;
+    const index = this.weakPasswordCiphers.findIndex((c) => c.id === updatedCipherView.id);
+
+    if (updatedReportStatus) {
+      if (index !== -1) {
+        this.weakPasswordCiphers[index] = updatedReportStatus;
+      } else {
+        this.weakPasswordCiphers.push(updatedReportStatus);
+        // Newly weak cipher — sync the data source so it appears in the table
+        this.filterCiphersByOrg(this.weakPasswordCiphers);
+        return updatedReportStatus;
+      }
+    } else if (index !== -1) {
+      this.weakPasswordCiphers.splice(index, 1);
+    }
+
+    return updatedReportStatus;
   }
 
   protected canManageCipher(c: CipherView): boolean {
@@ -161,16 +144,8 @@ export class WeakPasswordsReportComponent extends CipherReportComponent implemen
     return true;
   }
 
-  private isUserNameNotEmpty(c: CipherView): boolean {
-    return !Utils.isNullOrWhitespace(c.login.username);
-  }
-
   private scoreKey(score: number): ReportScore {
     switch (score) {
-      case 4:
-        return { label: "strong", badgeVariant: "success", sortOrder: 1 };
-      case 3:
-        return { label: "good", badgeVariant: "primary", sortOrder: 2 };
       case 2:
         return { label: "weak", badgeVariant: "warning", sortOrder: 3 };
       default:


### PR DESCRIPTION
# Prototype for research spike: Consolidated Password Health Report via CipherRiskClient

## Context

The web client has three separate password health reports (Weak, Reused, Exposed), each on its own route with its own component. The SDK now exposes `CipherRiskClient.compute_risk()` which evaluates **all three risk dimensions in a single WASM call**. This prototype migrated the three report components to use `CipherRiskService` (which wraps the SDK client). 

## Evaluated

### SDK API

| Method | Input | Output | Notes |
|--------|-------|--------|-------|
| `computeRiskForCiphers(ciphers, userId, options?)` | `CipherView[]`, `UserId`, `CipherRiskOptions` | `CipherRiskResult[]` | Single call returns strength + reuse + exposure for every cipher |
| `buildPasswordReuseMap(ciphers, userId)` | `CipherView[]`, `UserId` | `PasswordReuseMap` | Must be called first and passed via `options.passwordMap` for reuse counts |
| `computeCipherRiskForUser(cipherId, userId, checkExposed?)` | `CipherId`, `UserId`, `boolean` | `CipherRiskResult` | Single-cipher convenience method; fetches all ciphers internally |

**`CipherRiskResult` shape:**
```ts
{
  id: CipherId;
  password_strength: number;        // 0 (weakest) – 4 (strongest)
  exposed_result: ExposedPasswordResult; // "NotChecked" | { "Found", value } | { "Error", value }
  reuse_count: number | undefined;  // undefined if no passwordMap provided
}
```

**`CipherRiskOptions`:** `{ passwordMap?, checkExposed?, hibpBaseUrl? }`

### Current architecture

- **3 separate routes** per context (personal + org admin = 6 total routes)
- **Shared base class** `CipherReportComponent` handles table, filtering, editing, org ownership filter
- **Each report** overrides `setCiphers()` and `determinedUpdatedCipherReportStatus()`
- **Identical permission filter** duplicated in all 3 components:
  ```
  type === Login && password != null && !isDeleted && (org || edit) && viewPassword
  ```
- **Tables are nearly identical** — same columns (icon, name, owner) plus one report-specific badge column

### Gaps / functional parity: None

The SDK covers all three report types with full parity:
- Weak: ZXCVBN scoring with username context (SDK handles tokenization internally)
- Reused: Password occurrence counting via `buildPasswordReuseMap`
- Exposed: HIBP k-anonymity check via `checkExposed: true`
- Error handling: `ExposedPasswordResult.Error` variant captures per-cipher HIBP failures

---

## Remaining Question: Consolidated Report UX

### Option A: Single "Password Health" Dashboard

One route, one component, one SDK call. Dashboard shows all at-risk ciphers with risk indicators per row. 


**Pros:**
- One API/SDK call instead of three
- User sees full risk picture per credential without switching pages
- Eliminates ~500 lines of duplicated component/template code
- Matches the SDK's data model naturally

**Cons:**
- Needs design work for the new risk dashboard
- HIBP calls happen for all ciphers upfront (current Exposed report has an explicit "Check" button to defer this)
- Breaking change to report URLs (need redirects)

### Option B: Keep 3 pages, share a cached service

Keep the current 3-page UX but add a `PasswordHealthCacheService` that makes one SDK call and caches results. Each report page reads from the cache.

**Pros:**
- No UX change
- Still gets single-call efficiency if user visits multiple reports
- Smaller implementation scope

**Cons:**
- Cache invalidation complexity (cipher edits, vault sync)
- Still 3 sets of components/templates to maintain
- Doesn't improve the user experience