### PR TITLE
[PM-33446] Clear the cipher key when performing a clone operation

### DIFF
--- a/libs/vault/src/cipher-form/components/cipher-form.component.spec.ts
+++ b/libs/vault/src/cipher-form/components/cipher-form.component.spec.ts
@@ -102,7 +102,7 @@ describe("CipherFormComponent", () => {
 
     it("should return null if updatedCipherView.login is undefined", () => {
       component["updatedCipherView"] = new CipherView();
-      delete component["updatedCipherView"].login;
+      component["updatedCipherView"].login = undefined as any;
       expect(component.website).toBeNull();
     });
 
@@ -140,6 +140,7 @@ describe("CipherFormComponent", () => {
   describe("clone", () => {
     const cipherView = new CipherView();
     cipherView.id = "test-id";
+    cipherView.key = "existingCipherKey" as any;
     cipherView.login.fido2Credentials = [new Fido2CredentialView()];
 
     beforeEach(() => {
@@ -155,6 +156,12 @@ describe("CipherFormComponent", () => {
       await component.ngOnInit();
 
       expect(component["updatedCipherView"]?.id).toBeNull();
+    });
+
+    it("clears key on updatedCipherView so a new cipher key is generated", async () => {
+      await component.ngOnInit();
+
+      expect(component["updatedCipherView"]?.key).toBeUndefined();
     });
 
     it("clears fido2Credentials on updatedCipherView", async () => {

--- a/libs/vault/src/cipher-form/components/cipher-form.component.ts
+++ b/libs/vault/src/cipher-form/components/cipher-form.component.ts
@@ -281,6 +281,8 @@ export class CipherFormComponent implements AfterViewInit, OnInit, OnChanges, Ci
 
       if (this.config.mode === "clone") {
         this.updatedCipherView.id = null;
+        // Ensure the cloned cipher generates a new cipher key
+        this.updatedCipherView.key = undefined;
 
         if (this.updatedCipherView.login) {
           this.updatedCipherView.login.fido2Credentials = null;


### PR DESCRIPTION
## 🎟️ Tracking

[PM-33446](https://bitwarden.atlassian.net/browse/PM-33446)

## 📔 Objective

When cloning a cipher, ensure the original cipher key is cleared from the new cloned cipher so that a new key is generated.

## 📸 Screenshots

https://github.com/user-attachments/assets/3d584a42-a43a-4ad8-9140-a5f7c2ad9ac9



[PM-33446]: https://bitwarden.atlassian.net/browse/PM-33446?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ