### PR TITLE
[PM-33874] fix(browser): add composed:true to autofill synthetic events

### DIFF
--- a/apps/browser/src/autofill/services/insert-autofill-content.service.spec.ts
+++ b/apps/browser/src/autofill/services/insert-autofill-content.service.spec.ts
@@ -1067,7 +1067,7 @@ describe("InsertAutofillContentService", () => {
 
       [EVENTS.KEYDOWN, EVENTS.KEYUP].forEach((eventName) => {
         expect(inputElement.dispatchEvent).toHaveBeenCalledWith(
-          new KeyboardEvent(eventName, { bubbles: true }),
+          new KeyboardEvent(eventName, { bubbles: true, composed: true }),
         );
       });
     });
@@ -1082,7 +1082,7 @@ describe("InsertAutofillContentService", () => {
 
       [EVENTS.INPUT, EVENTS.CHANGE].forEach((eventName) => {
         expect(inputElement.dispatchEvent).toHaveBeenCalledWith(
-          new Event(eventName, { bubbles: true }),
+          new Event(eventName, { bubbles: true, composed: true }),
         );
       });
     });

--- a/apps/browser/src/autofill/services/insert-autofill-content.service.ts
+++ b/apps/browser/src/autofill/services/insert-autofill-content.service.ts
@@ -363,7 +363,9 @@ class InsertAutofillContentService implements InsertAutofillContentServiceInterf
   private simulateUserKeyboardEventInteractions(element: FormFieldElement): void {
     const simulatedKeyboardEvents = [EVENTS.KEYDOWN, EVENTS.KEYUP];
     for (let index = 0; index < simulatedKeyboardEvents.length; index++) {
-      element.dispatchEvent(new KeyboardEvent(simulatedKeyboardEvents[index], { bubbles: true }));
+      element.dispatchEvent(
+        new KeyboardEvent(simulatedKeyboardEvents[index], { bubbles: true, composed: true }),
+      );
     }
   }
 
@@ -376,7 +378,9 @@ class InsertAutofillContentService implements InsertAutofillContentServiceInterf
   private simulateInputElementChangedEvent(element: FormFieldElement): void {
     const simulatedInputEvents = [EVENTS.INPUT, EVENTS.CHANGE];
     for (let index = 0; index < simulatedInputEvents.length; index++) {
-      element.dispatchEvent(new Event(simulatedInputEvents[index], { bubbles: true }));
+      element.dispatchEvent(
+        new Event(simulatedInputEvents[index], { bubbles: true, composed: true }),
+      );
     }
   }
 }


### PR DESCRIPTION
## 🎟️ Tracking

Resolves #19065

## 📔 Objective

When Bitwarden autofills a form field, it dispatches synthetic `input`, `change`, `keydown`, and `keyup` events to simulate user interaction. These events were created with `{ bubbles: true }` but were missing the `composed: true` flag.

Per the [W3C UI Events spec](https://www.w3.org/TR/uievents/), native `input`, `change`, and keyboard events all have `composed: true` by default, which lets them propagate across Shadow DOM boundaries. Because Bitwarden's synthetic events lacked this flag, any web component that wraps an `<input>` inside a Shadow Root (e.g. Lit, Shoelace, Ionic) would never see the events — the value changes silently without triggering any framework reactivity.

This PR adds `composed: true` to both `simulateUserKeyboardEventInteractions` and `simulateInputElementChangedEvent` so the dispatched events match browser-native behavior and propagate through Shadow DOM correctly.

## 📸 Screenshots

Not applicable (no UI changes).