### PR TITLE
Remove trend widget empty state storybook

### DIFF
--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/activity/trend-widget/trend-widget.stories.ts
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/activity/trend-widget/trend-widget.stories.ts
@@ -149,21 +149,6 @@ export const Default: Story = {
 };
 
 /**
- * Empty state with no data points.
- */
-export const EmptyState: Story = {
-  args: {
-    data: {
-      timeframe: TimePeriod.PastMonth,
-      dataView: "applications",
-      dataPoints: [],
-    },
-    loading: false,
-    error: null,
-  },
-};
-
-/**
  * Loading state while data is being fetched.
  */
 export const Loading: Story = {


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

### Background

Chart.js defaults to a live date when no data points are passed in. We show storybooks for one or more data points, which captures how the graph looks as well as alternative states. Supporting configuration on the axis for the min and max date requires a larger change to the component. For now, we will remove the empty state storybook to remove the change detection from chromatic triggering on other pull requests.

### Change

Removes empty state storybook for **TrendWidget**. 
