### PR TITLE
Add .nxignore to omit scripts directory from NX projects graph

### DIFF
--- a/.nxignore
+++ b/.nxignore
@@ -1,0 +1,1 @@
+scripts


### PR DESCRIPTION
## 🎟️ Tracking

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR fixes a problem with the NX build commands caused by the recent addition of a [reverse proxy emulator script](https://github.com/bitwarden/clients/pull/19361). No changes in functionality are expected.

## 📷 Screenshots
Not applicable