### PR TITLE
[PM-33426 ] - add popup focus wrap directive

### DIFF
--- a/apps/browser/src/platform/popup/components/popup-focus-wrap.directive.ts
+++ b/apps/browser/src/platform/popup/components/popup-focus-wrap.directive.ts
@@ -1,0 +1,91 @@
+import { AfterViewInit, Directive, ElementRef, OnDestroy, Renderer2 } from "@angular/core";
+
+/**
+ * Directive that wraps Tab focus within the host element.
+ *
+ * Firefox does not cycle focus within extension popups — after the last focusable
+ * element, focus moves to the document body and gets stuck instead of wrapping
+ * back to the first element (https://bugzilla.mozilla.org/show_bug.cgi?id=1594459).
+ *
+ * This directive adds invisible sentinel elements at the start and end of the host.
+ * When a sentinel receives focus (via Tab / Shift+Tab), focus is redirected to the
+ * opposite end of the focusable elements within the host.
+ */
+@Directive({
+  selector: "[appPopupFocusWrap]",
+  standalone: true,
+})
+export class PopupFocusWrapDirective implements AfterViewInit, OnDestroy {
+  private sentinels: { start: HTMLElement; end: HTMLElement } | undefined;
+  private cleanupFns: (() => void)[] = [];
+
+  constructor(
+    private el: ElementRef<HTMLElement>,
+    private renderer: Renderer2,
+  ) {}
+
+  ngAfterViewInit() {
+    const start = this.createSentinel();
+    const end = this.createSentinel();
+    this.sentinels = { start, end };
+
+    const host = this.el.nativeElement;
+    this.renderer.insertBefore(host, start, host.firstChild);
+    this.renderer.appendChild(host, end);
+
+    this.cleanupFns.push(
+      this.renderer.listen(start, "focus", () => {
+        this.focusLast();
+      }),
+    );
+
+    this.cleanupFns.push(
+      this.renderer.listen(end, "focus", () => {
+        this.focusFirst();
+      }),
+    );
+  }
+
+  ngOnDestroy() {
+    for (const fn of this.cleanupFns) {
+      fn();
+    }
+  }
+
+  private createSentinel(): HTMLElement {
+    const sentinel = this.renderer.createElement("div");
+    this.renderer.setAttribute(sentinel, "tabindex", "0");
+    this.renderer.setAttribute(sentinel, "aria-hidden", "true");
+    this.renderer.setStyle(sentinel, "position", "fixed");
+    this.renderer.setStyle(sentinel, "width", "0");
+    this.renderer.setStyle(sentinel, "height", "0");
+    this.renderer.setStyle(sentinel, "overflow", "hidden");
+    return sentinel;
+  }
+
+  private getFocusableElements(): HTMLElement[] {
+    const selector = [
+      'a[href]:not([tabindex="-1"])',
+      'button:not([disabled]):not([tabindex="-1"])',
+      'input:not([disabled]):not([tabindex="-1"])',
+      'select:not([disabled]):not([tabindex="-1"])',
+      'textarea:not([disabled]):not([tabindex="-1"])',
+      '[tabindex]:not([tabindex="-1"])',
+    ].join(",");
+
+    return Array.from(this.el.nativeElement.querySelectorAll<HTMLElement>(selector)).filter(
+      (el) =>
+        el !== this.sentinels?.start && el !== this.sentinels?.end && el.offsetParent !== null,
+    );
+  }
+
+  private focusFirst() {
+    const elements = this.getFocusableElements();
+    elements[0]?.focus();
+  }
+
+  private focusLast() {
+    const elements = this.getFocusableElements();
+    elements[elements.length - 1]?.focus();
+  }
+}

--- a/apps/browser/src/platform/popup/components/popup-focus-wrap.directive.ts
+++ b/apps/browser/src/platform/popup/components/popup-focus-wrap.directive.ts
@@ -5,7 +5,7 @@ import { AfterViewInit, Directive, ElementRef, OnDestroy, Renderer2 } from "@ang
  *
  * Firefox does not cycle focus within extension popups — after the last focusable
  * element, focus moves to the document body and gets stuck instead of wrapping
- * back to the first element (https://bugzilla.mozilla.org/show_bug.cgi?id=1594459).
+ * back to the first element.
  *
  * This directive adds invisible sentinel elements at the start and end of the host.
  * When a sentinel receives focus (via Tab / Shift+Tab), focus is redirected to the

--- a/apps/browser/src/popup/app.component.html
+++ b/apps/browser/src/popup/app.component.html
@@ -14,7 +14,7 @@
   </div>
 } @else {
   <!-- eslint-disable-next-line -->
-  <div class="tw-h-screen tw-w-screen">
+  <div class="tw-h-screen tw-w-screen" appPopupFocusWrap>
     <div [@routerTransition]="getRouteElevation(outlet)" class="tw-size-full">
       <router-outlet #outlet="outlet"></router-outlet>
     </div>

--- a/apps/browser/src/popup/app.module.ts
+++ b/apps/browser/src/popup/app.module.ts
@@ -27,6 +27,7 @@ import { AccountSecurityComponent } from "../auth/popup/settings/account-securit
 import { AutofillComponent } from "../autofill/popup/settings/autofill.component";
 import { NotificationsSettingsComponent } from "../autofill/popup/settings/notifications.component";
 import { PopOutComponent } from "../platform/popup/components/pop-out.component";
+import { PopupFocusWrapDirective } from "../platform/popup/components/popup-focus-wrap.directive";
 import { PopupFooterComponent } from "../platform/popup/layout/popup-footer.component";
 import { PopupHeaderComponent } from "../platform/popup/layout/popup-header.component";
 import { PopupPageComponent } from "../platform/popup/layout/popup-page.component";
@@ -69,6 +70,7 @@ import "../platform/popup/locales";
     ButtonModule,
     NotificationsSettingsComponent,
     PopOutComponent,
+    PopupFocusWrapDirective,
     PopupPageComponent,
     PopupTabNavigationComponent,
     PopupFooterComponent,


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-33426

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
In Firefox, after tabbing past the last focusable element (Settings tab button), focus moves to the document body and gets stuck — repeatedly cycling between the last element and the body instead of wrapping to the first element.

**Root cause:**  Firefox does not cycle focus within extension popups, unlike Chrome which wraps automatically.

**Fix (`apps/browser/src/platform/popup/components/`):**

- **New `PopupFocusWrapDirective`** (`popup-focus-wrap.directive.ts`) — Adds invisible sentinel `<div tabindex="0" aria-hidden="true">` elements at the start and end of the host. When the end sentinel receives focus (Tab past last element), it redirects to the first focusable element; when the start sentinel receives focus (Shift+Tab past first element), it redirects to the last.
- **`app.component.html`** — Applied `appPopupFocusWrap` to the main popup container.
- **`app.module.ts`** — Imported the new directive.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->


https://github.com/user-attachments/assets/97af958b-ad78-4bc2-b8c8-0387492b0d28

