### PR TITLE
feat: add block-no-verify PreToolUse hook to .claude/settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,5 +10,18 @@
         "repo": "bitwarden/ai-plugins"
       }
     }
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx block-no-verify@1.1.2"
+          }
+        ]
+      }
+    ]
   }
 }


### PR DESCRIPTION
## Summary\n\nAdds `block-no-verify@1.1.2` as a `PreToolUse` Bash hook in `.claude/settings.json`.\n\nCloses #19674\n\n---\n_Disclosure: I am the author and maintainer of `block-no-verify`._