### PR TITLE
[PM-33877] - handle blank custom field values in cipher form

### DIFF
--- a/libs/vault/src/cipher-view/custom-fields/custom-fields-v2.component.html
+++ b/libs/vault/src/cipher-view/custom-fields/custom-fields-v2.component.html
@@ -14,7 +14,7 @@
         <textarea
           readonly
           bitInput
-          [value]="field.value"
+          [value]="field.value ?? ''"
           aria-readonly="true"
           vaultAutosizeReadOnlyTextArea
         ></textarea>
@@ -35,7 +35,7 @@
           readonly
           bitInput
           type="password"
-          [value]="field.value"
+          [value]="field.value ?? ''"
           aria-readonly="true"
           class="tw-font-mono"
           *ngIf="!revealedHiddenFields.includes(i)"


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-33877

Fixes #19654

## 📔 Objective

Custom fields in the cipher form allow blank values for Text and Hidden field types which results in `undefined` being applied to the form values. This PR properly handles those values.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->




https://github.com/user-attachments/assets/700cb13c-8212-4f18-b5a9-313986d52e0c


