### PR TITLE
[PM-33850] Prevent the KM state used in SDK from caching and rxjs observable becoming hot observable

### DIFF
--- a/libs/common/src/key-management/pin/pin.state.ts
+++ b/libs/common/src/key-management/pin/pin.state.ts
@@ -29,6 +29,8 @@ export const PIN_PROTECTED_USER_KEY_ENVELOPE_EPHEMERAL =
     {
       deserializer: (jsonValue) => jsonValue,
       clearOn: ["logout"],
+      // Prevents the state from caching and rxjs observable becoming hot observable.
+      cleanupDelayMs: 0,
     },
   );
 

--- a/libs/common/src/platform/services/key-state/local-user-data-key.state.ts
+++ b/libs/common/src/platform/services/key-state/local-user-data-key.state.ts
@@ -7,5 +7,7 @@ export const LOCAL_USER_DATA_KEY = UserKeyDefinition.record<LocalUserDataKey>(
   {
     deserializer: (obj) => obj,
     clearOn: ["logout"],
+    // Prevents the state from caching and rxjs observable becoming hot observable.
+    cleanupDelayMs: 0,
   },
 );

--- a/libs/common/src/platform/services/key-state/user-key.state.ts
+++ b/libs/common/src/platform/services/key-state/user-key.state.ts
@@ -14,4 +14,6 @@ export const USER_EVER_HAD_USER_KEY = new UserKeyDefinition<boolean>(
 export const USER_KEY = UserKeyDefinition.record<UserKey>(CRYPTO_MEMORY, "userKey", {
   deserializer: (obj) => SymmetricCryptoKey.fromJSON(obj) as UserKey,
   clearOn: ["logout", "lock"],
+  // Prevents the state from caching and rxjs observable becoming hot observable.
+  cleanupDelayMs: 0,
 });


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-33850

## 📔 Objective

Prevent the KM state from caching and rxjs observable becoming hot observable. This is specifically applied to SDK's client managed state only. This also affects the unlock with SDK initiative of Encryption V2 rollout, hopefully without any impact with this workaround.

Note, while the bug have been discovered in Cli, the same bug might surface in other clients, since the root cause is platform independent.

Root cause: A race condition between write and read on the underlying [rxjs hot observable state in TS clients and firstValueFrom function](https://github.com/bitwarden/clients/blob/363f6445e379d0e760639ae9f3a59aca00616f78/libs/common/src/platform/services/sdk/client-managed-state.ts#L106). The failure comes from the SDK, where write is immediately followed by read.

Observations: This is specifically problematic, since we apply the reactive state nature of rxjs into (a)synchronous state operations in SDK repositories. I don't think other teams will expect that.
For [ciphers state](https://github.com/bitwarden/clients/blob/d72dd2ea7671c9d4518eb36c76b1ec85711500cd/libs/common/src/vault/services/key-state/ciphers.state.ts#L17) specifically, disabling caching in state would cause a major performance hit for larger vaults, since all read operations will have to read from disk, hence this can't be applied.

Ideal fix (outside of scope for this PR): All modifying operations should be guaranteed to be reflected in state - something like "dirty" flag, which is set immediately after any modifying operation, which will "flush" any held value from rxjs hot observable.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
