### PR TITLE
[PM-29927] update reseller notifications

### DIFF
--- a/apps/web/src/app/billing/organizations/warnings/services/organization-warnings.service.spec.ts
+++ b/apps/web/src/app/billing/organizations/warnings/services/organization-warnings.service.spec.ts
@@ -77,10 +77,14 @@ describe("OrganizationWarningsService", () => {
           return "Your free trial ends today.";
         case "resellerRenewalWarningMsg":
           return `Your subscription will renew soon. To ensure uninterrupted service, contact ${args[0]} to confirm your renewal before ${args[1]}.`;
+        case "resellerRenewalWarningMsgV2":
+          return `Your subscription will renew soon. To ensure uninterrupted service, contact your Bitwarden provider to confirm your renewal before ${args[0]}.`;
         case "resellerOpenInvoiceWarningMgs":
           return `An invoice for your subscription was issued on ${args[1]}. To ensure uninterrupted service, contact ${args[0]} to confirm your renewal before ${args[2]}.`;
         case "resellerPastDueWarningMsg":
           return `The invoice for your subscription has not been paid. To ensure uninterrupted service, contact ${args[0]} to confirm your renewal before ${args[1]}.`;
+        case "resellerPastDueWarningMsgV2":
+          return `The invoice for your subscription has not been paid. To ensure uninterrupted service, contact your Bitwarden provider before ${args[0]}.`;
         case "suspendedOrganizationTitle":
           return `${args[0]} subscription suspended`;
         case "close":
@@ -247,18 +251,17 @@ describe("OrganizationWarningsService", () => {
 
         expect(result).toEqual({
           type: "info",
-          message: `Your subscription will renew soon. To ensure uninterrupted service, contact Test Reseller Inc to confirm your renewal before ${expectedFormattedDate}.`,
+          message: `Your subscription will renew soon. To ensure uninterrupted service, contact your Bitwarden provider to confirm your renewal before ${expectedFormattedDate}.`,
         });
         expect(i18nService.t).toHaveBeenCalledWith(
-          "resellerRenewalWarningMsg",
-          "Test Reseller Inc",
+          "resellerRenewalWarningMsgV2",
           expectedFormattedDate,
         );
         done();
       });
     });
 
-    it("should return issued warning with correct type and message", (done) => {
+    it("should return null for issued warning type", (done) => {
       const issuedDate = new Date(2024, 10, 15);
       const dueDate = new Date(2024, 11, 15);
       const warning = {
@@ -270,19 +273,7 @@ describe("OrganizationWarningsService", () => {
       } as OrganizationWarningsResponse);
 
       service.getResellerRenewalWarning$(organization).subscribe((result) => {
-        const expectedIssuedDate = format(issuedDate);
-        const expectedDueDate = format(dueDate);
-
-        expect(result).toEqual({
-          type: "info",
-          message: `An invoice for your subscription was issued on ${expectedIssuedDate}. To ensure uninterrupted service, contact Test Reseller Inc to confirm your renewal before ${expectedDueDate}.`,
-        });
-        expect(i18nService.t).toHaveBeenCalledWith(
-          "resellerOpenInvoiceWarningMgs",
-          "Test Reseller Inc",
-          expectedIssuedDate,
-          expectedDueDate,
-        );
+        expect(result).toBeNull();
         done();
       });
     });
@@ -301,12 +292,11 @@ describe("OrganizationWarningsService", () => {
         const expectedSuspensionDate = format(suspensionDate);
 
         expect(result).toEqual({
-          type: "warning",
-          message: `The invoice for your subscription has not been paid. To ensure uninterrupted service, contact Test Reseller Inc to confirm your renewal before ${expectedSuspensionDate}.`,
+          type: "info",
+          message: `The invoice for your subscription has not been paid. To ensure uninterrupted service, contact your Bitwarden provider before ${expectedSuspensionDate}.`,
         });
         expect(i18nService.t).toHaveBeenCalledWith(
-          "resellerPastDueWarningMsg",
-          "Test Reseller Inc",
+          "resellerPastDueWarningMsgV2",
           expectedSuspensionDate,
         );
         done();

--- a/apps/web/src/app/billing/organizations/warnings/services/organization-warnings.service.ts
+++ b/apps/web/src/app/billing/organizations/warnings/services/organization-warnings.service.ts
@@ -123,29 +123,19 @@ export class OrganizationWarningsService {
             return {
               type: "info",
               message: this.i18nService.t(
-                "resellerRenewalWarningMsg",
-                organization.providerName,
+                "resellerRenewalWarningMsgV2",
                 format(warning.upcoming!.renewalDate),
               ),
             };
           }
           case "issued": {
-            return {
-              type: "info",
-              message: this.i18nService.t(
-                "resellerOpenInvoiceWarningMgs",
-                organization.providerName,
-                format(warning.issued!.issuedDate),
-                format(warning.issued!.dueDate),
-              ),
-            };
+            return null;
           }
           case "past_due": {
             return {
-              type: "warning",
+              type: "info",
               message: this.i18nService.t(
-                "resellerPastDueWarningMsg",
-                organization.providerName,
+                "resellerPastDueWarningMsgV2",
                 format(warning.pastDue!.suspensionDate),
               ),
             };

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -11811,6 +11811,15 @@
       }
     }
   },
+  "resellerRenewalWarningMsgV2": {
+    "message": "Your subscription will renew soon. To ensure uninterrupted service, contact your Bitwarden provider to confirm your renewal before $RENEWAL_DATE$.",
+    "placeholders": {
+      "renewal_date": {
+        "content": "$1",
+        "example": "01/01/2024"
+      }
+    }
+  },
   "resellerOpenInvoiceWarningMgs": {
     "message": "An invoice for your subscription was issued on $ISSUED_DATE$. To ensure uninterrupted service, contact $RESELLER$ to confirm your renewal before $DUE_DATE$.",
     "placeholders": {
@@ -11837,6 +11846,15 @@
       },
       "grace_period_end": {
         "content": "$2",
+        "example": "02/14/2024"
+      }
+    }
+  },
+  "resellerPastDueWarningMsgV2": {
+    "message": "The invoice for your subscription has not been paid. To ensure uninterrupted service, contact your Bitwarden provider before $GRACE_PERIOD_END$.",
+    "placeholders": {
+      "grace_period_end": {
+        "content": "$1",
         "example": "02/14/2024"
       }
     }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-29927

## 📔 Objective

Updates reseller-managed organization renewal notification copy

  - Removes the reseller name from banner copy, replacing it with the hardcoded phrase "your Bitwarden provider"
  - Suppresses the issued state banner (shown when a renewal invoice is issued but the subscription is still active)
  - Changes the past_due banner type from warning to info for consistency with the component template and requirements

New i18n keys resellerRenewalWarningMsgV2 and resellerPastDueWarningMsgV2 are introduced rather than modifying the existing keys, as deployed i18n strings are immutable.

## 📸 Screenshots
<img width="1673" height="980" alt="image" src="https://github.com/user-attachments/assets/b4139614-1353-47a0-808b-80066a87b126" />

<img width="1674" height="977" alt="image" src="https://github.com/user-attachments/assets/0c0c936b-3b27-4c4e-b233-5fd689d28cef" />


