### PR TITLE
Refactor member dialog to use chip input for email entry

### DIFF
--- a/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.html
+++ b/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.html
@@ -27,7 +27,10 @@
             <p bitTypography="body1">{{ "inviteUserDesc" | i18n }}</p>
             <bit-form-field *ngIf="{ seats: remainingSeats$ | async } as remaining">
               <bit-label>{{ "email" | i18n }}</bit-label>
-              <input id="emails" type="text" appAutoFocus bitInput formControlName="emails" />
+              <bit-chip-input
+                formControlName="emails"
+                placeholder="{{ 'typeEmailAndPressComma' | i18n }}"
+              ></bit-chip-input>
 
               <bit-hint *ngIf="remaining.seats > 1">{{
                 "inviteMultipleEmailDesc" | i18n: remaining.seats

--- a/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.html
+++ b/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.html
@@ -30,6 +30,7 @@
               <bit-chip-input
                 formControlName="emails"
                 placeholder="{{ 'typeEmailAndPressComma' | i18n }}"
+                [validate]="isValidEmail"
               ></bit-chip-input>
 
               <bit-hint *ngIf="remaining.seats > 1">{{

--- a/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.ts
+++ b/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.ts
@@ -1,7 +1,7 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
 import { Component, Inject, OnDestroy } from "@angular/core";
-import { FormBuilder, Validators } from "@angular/forms";
+import { AbstractControl, FormBuilder, Validators } from "@angular/forms";
 import {
   combineLatest,
   firstValueFrom,
@@ -127,6 +127,8 @@ export class MemberDialogComponent implements OnDestroy {
   protected organization$: Observable<Organization>;
   protected collectionAccessItems: AccessItemView[] = [];
   protected groupAccessItems: AccessItemView[] = [];
+  protected readonly isValidEmail = (email: string): boolean =>
+    Validators.email({ value: email } as AbstractControl) === null;
   protected tabIndex: MemberDialogTab;
   protected formGroup = this.formBuilder.group({
     emails: [[] as string[]],

--- a/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.ts
+++ b/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.ts
@@ -129,7 +129,7 @@ export class MemberDialogComponent implements OnDestroy {
   protected groupAccessItems: AccessItemView[] = [];
   protected tabIndex: MemberDialogTab;
   protected formGroup = this.formBuilder.group({
-    emails: [""],
+    emails: [[] as string[]],
     type: OrganizationUserType.User,
     externalId: this.formBuilder.control({ value: "", disabled: true }),
     ssoExternalId: this.formBuilder.control({ value: "", disabled: true }),
@@ -540,7 +540,7 @@ export class MemberDialogComponent implements OnDestroy {
   }
 
   private async handleInviteUsers(userView: OrganizationUserAdminView, organization: Organization) {
-    const emails = [...new Set(this.formGroup.value.emails.trim().split(/\s*,\s*/))];
+    const emails = [...new Set(this.formGroup.value.emails as string[])];
 
     await this.userService.invite(emails, userView);
 

--- a/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.module.ts
+++ b/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.module.ts
@@ -1,6 +1,6 @@
 import { NgModule } from "@angular/core";
 
-import { RadioButtonModule } from "@bitwarden/components";
+import { ChipInputComponent, RadioButtonModule } from "@bitwarden/components";
 
 import { SharedOrganizationModule } from "../../../shared";
 
@@ -9,7 +9,7 @@ import { NestedCheckboxComponent } from "./nested-checkbox.component";
 
 @NgModule({
   declarations: [MemberDialogComponent, NestedCheckboxComponent],
-  imports: [SharedOrganizationModule, RadioButtonModule],
+  imports: [SharedOrganizationModule, RadioButtonModule, ChipInputComponent],
   exports: [MemberDialogComponent],
 })
 export class UserDialogModule {}

--- a/apps/web/src/app/admin-console/organizations/members/components/member-dialog/validators/comma-separated-emails.validator.ts
+++ b/apps/web/src/app/admin-console/organizations/members/components/member-dialog/validators/comma-separated-emails.validator.ts
@@ -1,17 +1,28 @@
 import { AbstractControl, ValidationErrors, Validators } from "@angular/forms";
 
-function validateEmails(emails: string) {
-  return (
-    emails
-      .split(",")
-      .map((email) => Validators.email(<AbstractControl>{ value: email.trim() }))
-      .find((_) => _ !== null) === undefined
-  );
+function isValidEmail(email: string): boolean {
+  return Validators.email({ value: email.trim() } as AbstractControl) === null;
 }
 
 export function commaSeparatedEmails(control: AbstractControl): ValidationErrors | null {
-  if (control.value === "" || !control.value || validateEmails(control.value)) {
+  const value = control.value;
+
+  if (!value) {
     return null;
   }
-  return { multipleEmails: { message: "multipleInputEmails" } };
+
+  const emails: string[] = Array.isArray(value)
+    ? value
+    : (value as string)
+        .split(",")
+        .map((e: string) => e.trim())
+        .filter(Boolean);
+
+  if (emails.length === 0) {
+    return null;
+  }
+
+  const hasInvalidEmail = emails.some((email) => !isValidEmail(email));
+
+  return hasInvalidEmail ? { multipleEmails: { message: "multipleInputEmails" } } : null;
 }

--- a/apps/web/src/app/admin-console/organizations/members/components/member-dialog/validators/input-email-limit.validator.ts
+++ b/apps/web/src/app/admin-console/organizations/members/components/member-dialog/validators/input-email-limit.validator.ts
@@ -3,17 +3,22 @@ import { AbstractControl, ValidationErrors, ValidatorFn } from "@angular/forms";
 import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
 import { ProductTierType } from "@bitwarden/common/billing/enums";
 
-function getUniqueInputEmails(control: AbstractControl): string[] {
-  const emails: string[] = control.value
-    .split(",")
-    .filter((email: string) => email && email.trim() !== "");
-  const uniqueEmails: string[] = Array.from(new Set(emails));
+function getUniqueEmails(control: AbstractControl): string[] {
+  const value = control.value;
 
-  return uniqueEmails;
+  if (!value) {
+    return [];
+  }
+
+  const emails: string[] = Array.isArray(value)
+    ? value
+    : (value as string).split(",").filter((email: string) => email && email.trim() !== "");
+
+  return Array.from(new Set(emails.map((e) => e.trim()).filter(Boolean)));
 }
 
 /**
- * Ensure the number of unique emails in an input does not exceed the allowed maximum.
+ * Ensure the number of unique emails does not exceed the allowed maximum.
  * @param organization An object representing the organization
  * @param getErrorMessage A callback function that generates the error message. It takes the `maxEmailsCount` as a parameter.
  * @returns A function that validates an `AbstractControl` and returns `ValidationErrors` or `null`
@@ -23,13 +28,15 @@ export function inputEmailLimitValidator(
   getErrorMessage: (maxEmailsCount: number) => string,
 ): ValidatorFn {
   return (control: AbstractControl): ValidationErrors | null => {
-    if (!control.value?.trim()) {
+    const value = control.value;
+    const isEmpty = Array.isArray(value) ? value.length === 0 : !value?.trim();
+    if (isEmpty) {
       return null;
     }
 
     const maxEmailsCount = organization.productTierType === ProductTierType.TeamsStarter ? 10 : 20;
 
-    const uniqueEmails = getUniqueInputEmails(control);
+    const uniqueEmails = getUniqueEmails(control);
 
     if (uniqueEmails.length <= maxEmailsCount) {
       return null;

--- a/apps/web/src/app/admin-console/organizations/members/components/member-dialog/validators/org-seat-limit-reached.validator.ts
+++ b/apps/web/src/app/admin-console/organizations/members/components/member-dialog/validators/org-seat-limit-reached.validator.ts
@@ -19,7 +19,9 @@ export function orgSeatLimitReachedValidator(
   occupiedSeatCount: number,
 ): ValidatorFn {
   return (control: AbstractControl): ValidationErrors | null => {
-    if (!control.value?.trim()) {
+    const value = control.value;
+    const isEmpty = Array.isArray(value) ? value.length === 0 : !value?.trim();
+    if (isEmpty) {
       return null;
     }
 
@@ -57,18 +59,20 @@ function getUniqueNewEmailCount(
   allOrganizationUserEmails: string[],
   control: AbstractControl,
 ): number {
+  const value = control.value;
+
+  const inputEmails: string[] = Array.isArray(value)
+    ? value
+    : (value as string)
+        .split(",")
+        .map((e: string) => e.trim())
+        .filter(Boolean);
+
   const newEmailsToAdd = Array.from(
     new Set(
-      control.value
-        .split(",")
-        .filter(
-          (newEmailToAdd: string) =>
-            newEmailToAdd &&
-            newEmailToAdd.trim() !== "" &&
-            !allOrganizationUserEmails.some(
-              (existingEmail) => existingEmail === newEmailToAdd.trim(),
-            ),
-        ),
+      inputEmails.filter(
+        (email) => !allOrganizationUserEmails.some((existing) => existing === email),
+      ),
     ),
   );
 

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -3901,6 +3901,9 @@
   "inviteUserDesc": {
     "message": "Invite a new user to your organization by entering their Bitwarden account email address below. If they do not have a Bitwarden account already, they will be prompted to create a new account."
   },
+  "typeEmailAndPressComma": {
+    "message": "Type an email and press comma or Enter..."
+  },
   "inviteMultipleEmailDesc": {
     "message": "Enter up to $COUNT$ emails by separating with a comma.",
     "placeholders": {

--- a/libs/components/src/chip-input/chip-input.component.html
+++ b/libs/components/src/chip-input/chip-input.component.html
@@ -29,7 +29,7 @@
     [attr.aria-describedby]="ariaDescribedBy || null"
     [placeholder]="chips().length === 0 ? placeholder() : ''"
     [disabled]="disabled() || null"
-    [value]="inputValue"
+    [value]="inputValue()"
     (input)="onInput($event)"
     (keydown)="onKeydown($event)"
     (paste)="onPaste($event)"

--- a/libs/components/src/chip-input/chip-input.component.html
+++ b/libs/components/src/chip-input/chip-input.component.html
@@ -3,16 +3,22 @@
   [class.tw-cursor-not-allowed]="disabled()"
   [class.tw-opacity-60]="disabled()"
 >
-  @for (chip of chips(); track chip; let i = $index) {
+  @for (chip of chipsWithValidity(); track chip.value; let i = $index) {
     <span
-      class="tw-inline-flex tw-items-center tw-gap-0.5 tw-py-0.5 tw-ps-2.5 tw-pe-1 tw-rounded-full tw-bg-secondary-300 tw-text-main tw-text-sm tw-leading-none tw-max-w-52"
+      class="tw-inline-flex tw-items-center tw-gap-0.5 tw-py-0.5 tw-ps-2.5 tw-pe-1 tw-rounded-full tw-text-sm tw-leading-none tw-max-w-52"
+      [class.tw-bg-secondary-300]="!chip.invalid"
+      [class.tw-text-main]="!chip.invalid"
+      [class.tw-bg-danger-100]="chip.invalid"
+      [class.tw-text-danger-700]="chip.invalid"
     >
-      <span class="tw-truncate">{{ chip }}</span>
+      <span class="tw-truncate">{{ chip.value }}</span>
       @if (!disabled()) {
         <button
           type="button"
-          class="tw-inline-flex tw-items-center tw-justify-center tw-rounded-full tw-w-[1.125rem] tw-h-[1.125rem] tw-shrink-0 tw-border-none tw-bg-transparent hover:tw-bg-secondary-500 tw-text-muted hover:tw-text-main tw-outline-none focus-visible:tw-ring-1 focus-visible:tw-ring-primary-600 tw-cursor-pointer"
-          [attr.aria-label]="'removeItem' | i18n: chip"
+          class="tw-inline-flex tw-items-center tw-justify-center tw-rounded-full tw-w-[1.125rem] tw-h-[1.125rem] tw-shrink-0 tw-border-none tw-bg-transparent tw-text-current tw-outline-none focus-visible:tw-ring-1 focus-visible:tw-ring-primary-600 tw-cursor-pointer"
+          [class.hover:tw-bg-secondary-500]="!chip.invalid"
+          [class.hover:tw-bg-danger-200]="chip.invalid"
+          [attr.aria-label]="'removeItem' | i18n: chip.value"
           (click)="removeChip(i)"
         >
           <i class="bwi bwi-close tw-text-xs" aria-hidden="true"></i>

--- a/libs/components/src/chip-input/chip-input.component.html
+++ b/libs/components/src/chip-input/chip-input.component.html
@@ -1,0 +1,38 @@
+<div
+  class="tw-flex tw-flex-wrap tw-items-center tw-gap-1.5 tw-w-full tw-min-h-7 tw-py-1"
+  [class.tw-cursor-not-allowed]="disabled()"
+  [class.tw-opacity-60]="disabled()"
+>
+  @for (chip of chips(); track chip; let i = $index) {
+    <span
+      class="tw-inline-flex tw-items-center tw-gap-0.5 tw-py-0.5 tw-ps-2.5 tw-pe-1 tw-rounded-full tw-bg-secondary-300 tw-text-main tw-text-sm tw-leading-none tw-max-w-52"
+    >
+      <span class="tw-truncate">{{ chip }}</span>
+      @if (!disabled()) {
+        <button
+          type="button"
+          class="tw-inline-flex tw-items-center tw-justify-center tw-rounded-full tw-w-[1.125rem] tw-h-[1.125rem] tw-shrink-0 tw-border-none tw-bg-transparent hover:tw-bg-secondary-500 tw-text-muted hover:tw-text-main tw-outline-none focus-visible:tw-ring-1 focus-visible:tw-ring-primary-600 tw-cursor-pointer"
+          [attr.aria-label]="'removeItem' | i18n: chip"
+          (click)="removeChip(i)"
+        >
+          <i class="bwi bwi-close tw-text-xs" aria-hidden="true"></i>
+        </button>
+      }
+    </span>
+  }
+
+  <input
+    #inputRef
+    type="text"
+    class="tw-flex-1 tw-min-w-28 tw-bg-transparent tw-border-none tw-outline-none tw-text-main tw-placeholder-text-muted tw-text-sm tw-p-0 disabled:tw-cursor-not-allowed"
+    [attr.id]="id()"
+    [attr.aria-describedby]="ariaDescribedBy || null"
+    [placeholder]="chips().length === 0 ? placeholder() : ''"
+    [disabled]="disabled() || null"
+    [value]="inputValue"
+    (input)="onInput($event)"
+    (keydown)="onKeydown($event)"
+    (paste)="onPaste($event)"
+    (blur)="onBlur()"
+  />
+</div>

--- a/libs/components/src/chip-input/chip-input.component.ts
+++ b/libs/components/src/chip-input/chip-input.component.ts
@@ -1,0 +1,162 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  Optional,
+  Self,
+  booleanAttribute,
+  computed,
+  input,
+  signal,
+  viewChild,
+} from "@angular/core";
+import { ControlValueAccessor, NgControl, Validators } from "@angular/forms";
+
+import { I18nPipe } from "@bitwarden/ui-common";
+
+import { BitFormFieldControl } from "../form-field/form-field-control";
+import { FocusableElement } from "../shared/focusable-element";
+
+let nextId = 0;
+
+/**
+ * `<bit-chip-input>` renders a list of text chips with an inline input for adding new entries.
+ * Comma or Enter key separates entries; backspace on an empty input removes the last chip.
+ *
+ * Implements `ControlValueAccessor` (value type: `string[]`) and `BitFormFieldControl` so it can
+ * be nested inside `<bit-form-field>`.
+ */
+@Component({
+  selector: "bit-chip-input",
+  templateUrl: "chip-input.component.html",
+  imports: [I18nPipe],
+  providers: [
+    { provide: BitFormFieldControl, useExisting: ChipInputComponent },
+    { provide: FocusableElement, useExisting: ChipInputComponent },
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ChipInputComponent
+  implements ControlValueAccessor, BitFormFieldControl, FocusableElement
+{
+  private readonly inputRef = viewChild<ElementRef<HTMLInputElement>>("inputRef");
+
+  /** BitFormFieldControl */
+  readonly id = signal(`bit-chip-input-${nextId++}`);
+  readonly ariaDescribedBy?: string;
+  readonly readOnly = false;
+  // type and spellcheck are optional on BitFormFieldControl
+
+  get labelForId(): string {
+    return this.id();
+  }
+
+  get required(): boolean {
+    return this.ngControl?.control?.hasValidator(Validators.required) ?? false;
+  }
+
+  get hasError(): boolean {
+    return !!(this.ngControl?.status === "INVALID" && this.ngControl?.touched);
+  }
+
+  get error(): [string, any] {
+    const errors = this.ngControl?.errors ?? {};
+    const key = Object.keys(errors)[0];
+    return [key, errors[key]];
+  }
+
+  focus(): void {
+    this.inputRef()?.nativeElement.focus();
+  }
+
+  /** FocusableElement */
+  getFocusTarget(): HTMLElement | undefined {
+    return this.inputRef()?.nativeElement;
+  }
+
+  /** Placeholder text shown in the input when no chips are present */
+  readonly placeholder = input<string>("");
+
+  protected readonly disabledInput = input<boolean, unknown>(false, {
+    alias: "disabled",
+    transform: booleanAttribute,
+  });
+
+  private readonly disabledState = signal(false);
+
+  readonly disabled = computed(() => this.disabledInput() || this.disabledState());
+
+  protected readonly chips = signal<string[]>([]);
+
+  protected readonly inputValue = "";
+
+  constructor(@Optional() @Self() private readonly ngControl: NgControl) {
+    if (this.ngControl) {
+      this.ngControl.valueAccessor = this;
+    }
+  }
+
+  protected addChip(value: string): void {
+    const trimmed = value.trim();
+    if (!trimmed || this.chips().includes(trimmed)) {
+      this.inputValue = "";
+      return;
+    }
+    this.chips.update((chips) => [...chips, trimmed]);
+    this.inputValue = "";
+    this.notifyOnChange?.(this.chips());
+  }
+
+  protected removeChip(index: number): void {
+    this.chips.update((chips) => chips.filter((_, i) => i !== index));
+    this.notifyOnChange?.(this.chips());
+  }
+
+  protected onInput(event: Event): void {
+    this.inputValue = (event.target as HTMLInputElement).value;
+  }
+
+  protected onKeydown(event: KeyboardEvent): void {
+    if (event.key === "," || event.key === "Enter") {
+      event.preventDefault();
+      this.addChip(this.inputValue);
+    } else if (event.key === "Backspace" && !this.inputValue) {
+      this.chips.update((chips) => chips.slice(0, -1));
+      this.notifyOnChange?.(this.chips());
+    }
+  }
+
+  protected onPaste(event: ClipboardEvent): void {
+    event.preventDefault();
+    const pastedText = event.clipboardData?.getData("text") ?? "";
+    pastedText.split(",").forEach((value) => this.addChip(value));
+  }
+
+  protected onBlur(): void {
+    if (this.inputValue.trim()) {
+      this.addChip(this.inputValue);
+    }
+    this.notifyOnTouched?.();
+  }
+
+  /** ControlValueAccessor */
+
+  private readonly notifyOnChange?: (value: string[]) => void;
+  private readonly notifyOnTouched?: () => void;
+
+  writeValue(values: string[]): void {
+    this.chips.set(Array.isArray(values) ? values : []);
+  }
+
+  registerOnChange(fn: (value: string[]) => void): void {
+    this.notifyOnChange = fn;
+  }
+
+  registerOnTouched(fn: () => void): void {
+    this.notifyOnTouched = fn;
+  }
+
+  setDisabledState(isDisabled: boolean): void {
+    this.disabledState.set(isDisabled);
+  }
+}

--- a/libs/components/src/chip-input/chip-input.component.ts
+++ b/libs/components/src/chip-input/chip-input.component.ts
@@ -1,3 +1,5 @@
+// FIXME(https://bitwarden.atlassian.net/browse/CL-1062): `OnPush` components should not use mutable properties
+/* eslint-disable @bitwarden/components/enforce-readonly-angular-properties */
 import {
   ChangeDetectionStrategy,
   Component,
@@ -43,8 +45,8 @@ export class ChipInputComponent
 
   /** BitFormFieldControl */
   readonly id = signal(`bit-chip-input-${nextId++}`);
-  readonly ariaDescribedBy?: string;
-  readonly readOnly = false;
+  ariaDescribedBy?: string;
+  readOnly = false;
   // type and spellcheck are optional on BitFormFieldControl
 
   get labelForId(): string {
@@ -88,7 +90,7 @@ export class ChipInputComponent
 
   protected readonly chips = signal<string[]>([]);
 
-  protected readonly inputValue = "";
+  protected readonly inputValue = signal("");
 
   constructor(@Optional() @Self() private readonly ngControl: NgControl) {
     if (this.ngControl) {
@@ -99,30 +101,30 @@ export class ChipInputComponent
   protected addChip(value: string): void {
     const trimmed = value.trim();
     if (!trimmed || this.chips().includes(trimmed)) {
-      this.inputValue = "";
+      this.inputValue.set("");
       return;
     }
     this.chips.update((chips) => [...chips, trimmed]);
-    this.inputValue = "";
-    this.notifyOnChange?.(this.chips());
+    this.inputValue.set("");
+    this.cvaCallbacks.onChange?.(this.chips());
   }
 
   protected removeChip(index: number): void {
     this.chips.update((chips) => chips.filter((_, i) => i !== index));
-    this.notifyOnChange?.(this.chips());
+    this.cvaCallbacks.onChange?.(this.chips());
   }
 
   protected onInput(event: Event): void {
-    this.inputValue = (event.target as HTMLInputElement).value;
+    this.inputValue.set((event.target as HTMLInputElement).value);
   }
 
   protected onKeydown(event: KeyboardEvent): void {
     if (event.key === "," || event.key === "Enter") {
       event.preventDefault();
-      this.addChip(this.inputValue);
-    } else if (event.key === "Backspace" && !this.inputValue) {
+      this.addChip(this.inputValue());
+    } else if (event.key === "Backspace" && !this.inputValue()) {
       this.chips.update((chips) => chips.slice(0, -1));
-      this.notifyOnChange?.(this.chips());
+      this.cvaCallbacks.onChange?.(this.chips());
     }
   }
 
@@ -133,27 +135,29 @@ export class ChipInputComponent
   }
 
   protected onBlur(): void {
-    if (this.inputValue.trim()) {
-      this.addChip(this.inputValue);
+    if (this.inputValue().trim()) {
+      this.addChip(this.inputValue());
     }
-    this.notifyOnTouched?.();
+    this.cvaCallbacks.onTouched?.();
   }
 
   /** ControlValueAccessor */
 
-  private readonly notifyOnChange?: (value: string[]) => void;
-  private readonly notifyOnTouched?: () => void;
+  private readonly cvaCallbacks: {
+    onChange?: (value: string[]) => void;
+    onTouched?: () => void;
+  } = {};
 
   writeValue(values: string[]): void {
     this.chips.set(Array.isArray(values) ? values : []);
   }
 
   registerOnChange(fn: (value: string[]) => void): void {
-    this.notifyOnChange = fn;
+    this.cvaCallbacks.onChange = fn;
   }
 
   registerOnTouched(fn: () => void): void {
-    this.notifyOnTouched = fn;
+    this.cvaCallbacks.onTouched = fn;
   }
 
   setDisabledState(isDisabled: boolean): void {

--- a/libs/components/src/chip-input/chip-input.component.ts
+++ b/libs/components/src/chip-input/chip-input.component.ts
@@ -79,6 +79,9 @@ export class ChipInputComponent
   /** Placeholder text shown in the input when no chips are present */
   readonly placeholder = input<string>("");
 
+  /** Optional per-chip validator. Return false to mark a chip as invalid. */
+  readonly validate = input<(value: string) => boolean>();
+
   protected readonly disabledInput = input<boolean, unknown>(false, {
     alias: "disabled",
     transform: booleanAttribute,
@@ -89,6 +92,14 @@ export class ChipInputComponent
   readonly disabled = computed(() => this.disabledInput() || this.disabledState());
 
   protected readonly chips = signal<string[]>([]);
+
+  protected readonly chipsWithValidity = computed(() => {
+    const validateFn = this.validate();
+    return this.chips().map((value) => ({
+      value,
+      invalid: validateFn ? !validateFn(value) : false,
+    }));
+  });
 
   protected readonly inputValue = signal("");
 

--- a/libs/components/src/chip-input/chip-input.stories.ts
+++ b/libs/components/src/chip-input/chip-input.stories.ts
@@ -107,6 +107,29 @@ export const ManyValues: Story = {
   },
 };
 
+export const WithValidation: Story = {
+  render: (args) => ({
+    props: {
+      ...args,
+      isValidEmail: (v: string) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v),
+    },
+    template: /* html */ `
+      <bit-form-field>
+        <bit-label>Emails</bit-label>
+        <bit-chip-input
+          placeholder="Add email address..."
+          [ngModel]="value"
+          [validate]="isValidEmail"
+        ></bit-chip-input>
+        <bit-hint>Invalid emails are highlighted in red.</bit-hint>
+      </bit-form-field>
+    `,
+  }),
+  args: {
+    value: ["alice@example.com", "not-an-email", "bob@example.com", "also-invalid"],
+  },
+};
+
 export const Disabled: Story = {
   render: (args) => ({
     props: {

--- a/libs/components/src/chip-input/chip-input.stories.ts
+++ b/libs/components/src/chip-input/chip-input.stories.ts
@@ -1,0 +1,156 @@
+import { FormsModule } from "@angular/forms";
+import { Meta, StoryObj, moduleMetadata } from "@storybook/angular";
+import { userEvent, within } from "storybook/test";
+
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+
+import { FormFieldModule } from "../form-field";
+import { I18nMockService } from "../utils/i18n-mock.service";
+
+import { ChipInputComponent } from "./chip-input.component";
+
+export default {
+  title: "Component Library/Chip Input",
+  component: ChipInputComponent,
+  decorators: [
+    moduleMetadata({
+      imports: [FormsModule, FormFieldModule],
+      providers: [
+        {
+          provide: I18nService,
+          useFactory: () => {
+            return new I18nMockService({
+              removeItem: (name: string) => `Remove ${name}`,
+              required: "required",
+            });
+          },
+        },
+      ],
+    }),
+  ],
+  parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/Zt3YSeb6E6lebAffrNLa0h/Tailwind-Component-Library",
+    },
+  },
+} as Meta<ChipInputComponent>;
+
+type Story = StoryObj<ChipInputComponent & { value: string[] }>;
+
+export const Default: Story = {
+  render: (args) => ({
+    props: {
+      ...args,
+    },
+    template: /* html */ `
+      <bit-form-field>
+        <bit-label>Emails</bit-label>
+        <bit-chip-input
+          placeholder="Add email address..."
+        ></bit-chip-input>
+        <bit-hint>Type an email and press comma or Enter to add it.</bit-hint>
+      </bit-form-field>
+    `,
+  }),
+};
+
+export const WithValues: Story = {
+  render: (args) => ({
+    props: {
+      ...args,
+    },
+    template: /* html */ `
+      <bit-form-field>
+        <bit-label>Emails</bit-label>
+        <bit-chip-input
+          placeholder="Add email address..."
+          [ngModel]="value"
+        ></bit-chip-input>
+        <bit-hint>Type an email and press comma or Enter to add it.</bit-hint>
+      </bit-form-field>
+    `,
+  }),
+  args: {
+    value: ["alice@example.com", "bob@example.com", "carol@example.com"],
+  },
+};
+
+export const ManyValues: Story = {
+  render: (args) => ({
+    props: {
+      ...args,
+    },
+    template: /* html */ `
+      <bit-form-field>
+        <bit-label>Emails</bit-label>
+        <bit-chip-input
+          placeholder="Add email address..."
+          [ngModel]="value"
+        ></bit-chip-input>
+      </bit-form-field>
+    `,
+  }),
+  args: {
+    value: [
+      "alice@example.com",
+      "bob@example.com",
+      "carol@example.com",
+      "dave@example.com",
+      "eve@example.com",
+      "frank@example.com",
+      "grace@example.com",
+      "heidi@example.com",
+      "ivan@example.com",
+      "judy@example.com",
+    ],
+  },
+};
+
+export const Disabled: Story = {
+  render: (args) => ({
+    props: {
+      ...args,
+    },
+    template: /* html */ `
+      <bit-form-field>
+        <bit-label>Emails</bit-label>
+        <bit-chip-input
+          placeholder="Add email address..."
+          [ngModel]="value"
+          disabled
+        ></bit-chip-input>
+      </bit-form-field>
+    `,
+  }),
+  args: {
+    value: ["alice@example.com", "bob@example.com"],
+  },
+};
+
+export const WithTyping: Story = {
+  render: (args) => ({
+    props: {
+      ...args,
+    },
+    template: /* html */ `
+      <bit-form-field>
+        <bit-label>Emails</bit-label>
+        <bit-chip-input
+          placeholder="Add email address..."
+          [ngModel]="value"
+        ></bit-chip-input>
+        <bit-hint>Type an email and press comma or Enter to add it.</bit-hint>
+      </bit-form-field>
+    `,
+  }),
+  args: {
+    value: ["alice@example.com"],
+  },
+  play: async (context) => {
+    const canvas = context.canvasElement;
+    const input = within(canvas).getByRole("textbox");
+    await userEvent.click(input);
+    await userEvent.type(input, "bob@example.com,");
+  },
+};

--- a/libs/components/src/chip-input/index.ts
+++ b/libs/components/src/chip-input/index.ts
@@ -1,0 +1,1 @@
+export * from "./chip-input.component";

--- a/libs/components/src/index.ts
+++ b/libs/components/src/index.ts
@@ -13,6 +13,7 @@ export * from "./button";
 export * from "./callout";
 export * from "./card";
 export * from "./checkbox";
+export * from "./chip-input";
 export * from "./chip-select";
 export * from "./color-password";
 export * from "./container";


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

Adds a new component to UI library called `chip-input` which can be used for comma separated type inputs within the app to better modernize the Bitwarden app.

## 📸 Screenshots

<img width="840" height="683" alt="image" src="https://github.com/user-attachments/assets/728a5ab4-15c7-4c00-b9b3-ca4dcdf92eb5" />

<img width="1917" height="933" alt="image" src="https://github.com/user-attachments/assets/e9530a1d-3d63-424f-8ed6-13f4c824cfa6" />

<img width="1429" height="934" alt="image" src="https://github.com/user-attachments/assets/35653c84-e856-4a2f-8435-edbbdc4a45f0" />

