### PR TITLE
[PM-33952] Fix cipher key encryption logic when editing ciphers

### DIFF
--- a/libs/common/src/vault/services/cipher.service.ts
+++ b/libs/common/src/vault/services/cipher.service.ts
@@ -321,8 +321,8 @@ export class CipherService implements CipherServiceAbstraction {
 
     if (
       // prevent unprivileged users from migrating to cipher key encryption
-      (model.viewPassword || originalCipher?.key) &&
-      (await this.getCipherKeyEncryptionEnabled())
+      (model.viewPassword && (await this.getCipherKeyEncryptionEnabled())) ||
+      originalCipher?.key
     ) {
       cipher.key = originalCipher?.key ?? null;
       const userOrOrgKey = await this.getKeyForCipherKeyDecryption(cipher, userId);


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-33952

## 📔 Objective

When cipher-key-encryption and SDK encryption are both off, editing a cipher will rollback the cipher key. This also has potential to cause cipher corruption  with some a server versions.

Note: This code path is dead with `pm-22136-sdk-cipher-encryption` turned on, but worth fixing just in case.