### PR TITLE
[PM-34008] Autofill behavior from more option component asks to save URI for non login cipher types

### DIFF
--- a/apps/browser/src/vault/popup/components/vault/item-more-options/item-more-options.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/item-more-options/item-more-options.component.ts
@@ -198,6 +198,12 @@ export class ItemMoreOptionsComponent {
       return;
     }
 
+    //for non login types that are still auto-fillable
+    if (CipherViewLikeUtils.getType(cipher) !== CipherType.Login) {
+      await this.vaultPopupAutofillService.doAutofill(cipher, true, true);
+      return;
+    }
+
     const uris = cipher.login?.uris ?? [];
     const uriMatchStrategy = await firstValueFrom(this.uriMatchStrategy$);
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-34008

## 📔 Objective

To not show the `AutofillConfirmationDialogComponent` when autofilling a non login type cipher from the more options menu.
