### PR TITLE
[PM-33797] AIV2: Standardize Models and Services: Web Services

### DIFF
--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/shared/security-tasks.service.ts
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/shared/security-tasks.service.ts
@@ -13,6 +13,11 @@ import { DefaultAdminTaskService } from "../../../vault/services/default-admin-t
 
 /**
  * Service for managing security tasks related to Access Intelligence features
+ *
+ * @deprecated Use {@link AccessSecurityTasksService} instead.
+ * This service will be removed when V1 components are updated to inject
+ * the abstract token and the module wiring switches to {@link LegacyAccessSecurityTasksService}
+ * which exposes observables instead of promises.
  */
 export class AccessIntelligenceSecurityTasksService {
   private _tasksSubject$ = new BehaviorSubject<SecurityTask[]>([]);

--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/v2/services/abstractions/access-security-tasks.service.ts
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/v2/services/abstractions/access-security-tasks.service.ts
@@ -1,0 +1,103 @@
+import { Observable } from "rxjs";
+
+import { TaskMetrics } from "@bitwarden/bit-common/dirt/reports/risk-insights/services";
+import { OrganizationId } from "@bitwarden/common/types/guid";
+import { SecurityTask } from "@bitwarden/common/vault/tasks";
+
+/**
+ * Manages security tasks for Access Intelligence.
+ *
+ * Provides a reactive view of current tasks and derived state for which
+ * critical cipher IDs still need password-change requests. Implementations
+ * differ in which report data source they use to compute unassigned cipher IDs.
+ */
+export abstract class AccessSecurityTasksService {
+  /**
+   * Current security tasks for the active organization.
+   *
+   * Emits the latest loaded task list. Empty array until {@link loadTasks$} is called.
+   *
+   * @example
+   * ```typescript
+   * this.accessSecurityTasksService.tasks$.subscribe(tasks => {
+   *   console.log(`${tasks.length} tasks loaded`);
+   * });
+   * ```
+   */
+  abstract readonly tasks$: Observable<SecurityTask[]>;
+
+  /**
+   * Cipher IDs of critical at-risk passwords that have no active or recently
+   * completed security task.
+   *
+   * A cipher ID is considered "unassigned" when:
+   * - No task with status Pending references it, AND
+   * - No task with status Completed references it with a completion date
+   *   after the current report was generated.
+   *
+   * This observable is the single source of truth for which ciphers still
+   * need a password-change request. Multiple components can subscribe without
+   * duplicating the computation.
+   *
+   * @example
+   * ```typescript
+   * this.accessSecurityTasksService.unassignedCriticalCipherIds$.subscribe(ids => {
+   *   this.enableRequestButton = ids.length > 0;
+   * });
+   * ```
+   */
+  abstract readonly unassignedCriticalCipherIds$: Observable<string[]>;
+
+  /**
+   * Fetch task completion metrics for the given organization.
+   *
+   * @param organizationId - The organization to fetch metrics for
+   * @returns Observable emitting completed and total task counts
+   *
+   * @example
+   * ```typescript
+   * this.accessSecurityTasksService.getTaskMetrics$(orgId).subscribe(metrics => {
+   *   console.log(`${metrics.completedTasks} / ${metrics.totalTasks} complete`);
+   * });
+   * ```
+   */
+  abstract getTaskMetrics$(organizationId: OrganizationId): Observable<TaskMetrics>;
+
+  /**
+   * Load security tasks for the given organization.
+   *
+   * Fetches tasks from the API and updates the internal subject, causing
+   * {@link tasks$} and {@link unassignedCriticalCipherIds$} to re-emit.
+   *
+   * @param organizationId - The organization to load tasks for
+   * @returns Observable that completes when tasks are loaded
+   *
+   * @example
+   * ```typescript
+   * this.accessSecurityTasksService.loadTasks$(orgId).subscribe();
+   * ```
+   */
+  abstract loadTasks$(organizationId: OrganizationId): Observable<void>;
+
+  /**
+   * Bulk-request password changes for critical at-risk ciphers.
+   *
+   * Creates one pending task per cipher ID, then reloads tasks so that
+   * {@link unassignedCriticalCipherIds$} updates immediately.
+   *
+   * @param organizationId - The organization the ciphers belong to
+   * @param criticalApplicationIds - Cipher IDs that need password-change requests
+   * @returns Observable that completes when tasks are created and reloaded
+   *
+   * @example
+   * ```typescript
+   * this.accessSecurityTasksService
+   *   .requestPasswordChangeForCriticalApplications$(orgId, this.unassignedCipherIds())
+   *   .subscribe();
+   * ```
+   */
+  abstract requestPasswordChangeForCriticalApplications$(
+    organizationId: OrganizationId,
+    criticalApplicationIds: string[],
+  ): Observable<void>;
+}

--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/v2/services/implementations/default-access-security-tasks.service.ts
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/v2/services/implementations/default-access-security-tasks.service.ts
@@ -1,0 +1,99 @@
+import { BehaviorSubject, combineLatest, from, Observable } from "rxjs";
+import { map, shareReplay, switchMap, tap } from "rxjs/operators";
+
+import { AccessIntelligenceDataService } from "@bitwarden/bit-common/dirt/access-intelligence/services";
+import {
+  SecurityTasksApiService,
+  TaskMetrics,
+} from "@bitwarden/bit-common/dirt/reports/risk-insights/services";
+import { OrganizationId } from "@bitwarden/common/types/guid";
+import { SecurityTask, SecurityTaskStatus, SecurityTaskType } from "@bitwarden/common/vault/tasks";
+
+import {
+  AdminTaskService,
+  CreateTasksRequest,
+} from "../../../../../vault/services/abstractions/admin-task.abstraction";
+import { AccessSecurityTasksService } from "../abstractions/access-security-tasks.service";
+
+export class DefaultAccessSecurityTasksService extends AccessSecurityTasksService {
+  private readonly _tasks$ = new BehaviorSubject<SecurityTask[]>([]);
+  readonly tasks$ = this._tasks$.asObservable();
+
+  readonly unassignedCriticalCipherIds$: Observable<string[]>;
+
+  constructor(
+    private readonly adminTaskService: AdminTaskService,
+    private readonly securityTasksApiService: SecurityTasksApiService,
+    private readonly dataService: AccessIntelligenceDataService,
+  ) {
+    super();
+
+    // Derive unassigned cipher IDs by combining the loaded task list with the
+    // current report. Using getCriticalAtRiskApplications() + getAtRiskCipherIds()
+    // on the view model ensures the "critical only" rule is enforced in one place
+    // rather than duplicated across callers.
+    this.unassignedCriticalCipherIds$ = combineLatest([this.tasks$, this.dataService.report$]).pipe(
+      map(([tasks, report]) => {
+        if (!report) {
+          return [];
+        }
+
+        const atRiskCipherIds = report
+          .getCriticalAtRiskApplications()
+          .flatMap((app) => app.getAtRiskCipherIds());
+
+        if (tasks.length === 0) {
+          return atRiskCipherIds;
+        }
+
+        const inProgressTaskIds = new Set<string>(
+          tasks
+            .filter((task) => task.status === SecurityTaskStatus.Pending && task.cipherId != null)
+            .map((task) => task.cipherId as string),
+        );
+
+        const completedTaskIds = new Set<string>(
+          tasks
+            .filter(
+              (task) =>
+                task.status === SecurityTaskStatus.Completed &&
+                task.cipherId != null &&
+                new Date(task.revisionDate) >= report.creationDate,
+            )
+            .map((task) => task.cipherId as string),
+        );
+
+        return atRiskCipherIds.filter(
+          (id) => !inProgressTaskIds.has(id) && !completedTaskIds.has(id),
+        );
+      }),
+      shareReplay({ bufferSize: 1, refCount: true }),
+    );
+  }
+
+  getTaskMetrics$(organizationId: OrganizationId): Observable<TaskMetrics> {
+    return this.securityTasksApiService.getTaskMetrics(organizationId);
+  }
+
+  loadTasks$(organizationId: OrganizationId): Observable<void> {
+    return from(this.securityTasksApiService.getAllTasks(organizationId)).pipe(
+      tap((tasks) => this._tasks$.next(tasks)),
+      map((): void => undefined),
+    );
+  }
+
+  requestPasswordChangeForCriticalApplications$(
+    organizationId: OrganizationId,
+    criticalApplicationIds: string[],
+  ): Observable<void> {
+    const distinctCipherIds = Array.from(new Set(criticalApplicationIds));
+    const tasks: CreateTasksRequest[] = distinctCipherIds.map((cipherId) => ({
+      cipherId: cipherId as CreateTasksRequest["cipherId"],
+      type: SecurityTaskType.UpdateAtRiskCredential,
+    }));
+
+    return from(this.adminTaskService.bulkCreateTasks(organizationId, tasks)).pipe(
+      switchMap(() => this.loadTasks$(organizationId)),
+    );
+  }
+}

--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/v2/services/implementations/legacy-access-security-tasks.service.spec.ts
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/v2/services/implementations/legacy-access-security-tasks.service.spec.ts
@@ -1,0 +1,89 @@
+import { TestBed } from "@angular/core/testing";
+import { mock } from "jest-mock-extended";
+import { firstValueFrom } from "rxjs";
+
+import {
+  RiskInsightsDataService,
+  SecurityTasksApiService,
+} from "@bitwarden/bit-common/dirt/reports/risk-insights";
+import { CipherId, OrganizationId } from "@bitwarden/common/types/guid";
+import { SecurityTaskType } from "@bitwarden/common/vault/tasks";
+
+import { AdminTaskService } from "../../../../../vault/services/abstractions/admin-task.abstraction";
+
+import { LegacyAccessSecurityTasksService } from "./legacy-access-security-tasks.service";
+
+describe("LegacyAccessSecurityTasksService", () => {
+  let service: LegacyAccessSecurityTasksService;
+  const adminTaskServiceMock = mock<AdminTaskService>();
+  const securityTasksApiServiceMock = mock<SecurityTasksApiService>();
+  const riskInsightsDataServiceMock = mock<RiskInsightsDataService>();
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = new LegacyAccessSecurityTasksService(
+      adminTaskServiceMock,
+      securityTasksApiServiceMock,
+      riskInsightsDataServiceMock,
+    );
+  });
+
+  it("should be created", () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe("assignTasks", () => {
+    it("should call requestPasswordChangeForCriticalApplications$ and setTaskCreatedCount", async () => {
+      // Set up test data
+      const organizationId = "org-1" as OrganizationId;
+      const mockCipherIds = ["cid1" as CipherId, "cid2" as CipherId];
+      adminTaskServiceMock.bulkCreateTasks.mockResolvedValue(undefined);
+      securityTasksApiServiceMock.getAllTasks.mockResolvedValue([]);
+      const spy = jest.spyOn(service, "requestPasswordChangeForCriticalApplications$");
+
+      // Call the method
+      await firstValueFrom(
+        service.requestPasswordChangeForCriticalApplications$(organizationId, mockCipherIds),
+      );
+
+      // Verify that the method was called with correct parameters
+      expect(spy).toHaveBeenCalledWith(organizationId, mockCipherIds);
+    });
+  });
+
+  describe("requestPasswordChangeForCriticalApplications$", () => {
+    it("should create tasks for distinct cipher ids and show success toast", async () => {
+      // Set up test data
+      const organizationId = "org-2" as OrganizationId;
+      const mockCipherIds = ["cid1" as CipherId, "cid2" as CipherId];
+      adminTaskServiceMock.bulkCreateTasks.mockResolvedValue(undefined);
+      securityTasksApiServiceMock.getAllTasks.mockResolvedValue([]);
+      const spy = jest.spyOn(service, "requestPasswordChangeForCriticalApplications$");
+
+      // Call the method
+      await firstValueFrom(
+        service.requestPasswordChangeForCriticalApplications$(organizationId, mockCipherIds),
+      );
+
+      // Verify that bulkCreateTasks was called with distinct cipher ids
+      expect(adminTaskServiceMock.bulkCreateTasks).toHaveBeenCalledWith(organizationId, [
+        { cipherId: "cid1", type: SecurityTaskType.UpdateAtRiskCredential },
+        { cipherId: "cid2", type: SecurityTaskType.UpdateAtRiskCredential },
+      ]);
+      // Verify that the method was called with correct parameters
+      expect(spy).toHaveBeenCalledWith(organizationId, mockCipherIds);
+    });
+
+    it("should handle error if adminTaskService errors", async () => {
+      const organizationId = "org-3" as OrganizationId;
+      const mockCipherIds = ["cid3" as CipherId];
+      adminTaskServiceMock.bulkCreateTasks.mockRejectedValue(new Error("API fail error"));
+
+      await expect(
+        firstValueFrom(
+          service.requestPasswordChangeForCriticalApplications$(organizationId, mockCipherIds),
+        ),
+      ).rejects.toThrow("API fail error");
+    });
+  });
+});

--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/v2/services/implementations/legacy-access-security-tasks.service.ts
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/v2/services/implementations/legacy-access-security-tasks.service.ts
@@ -1,0 +1,92 @@
+import { BehaviorSubject, combineLatest, from, Observable } from "rxjs";
+import { map, shareReplay, switchMap, tap } from "rxjs/operators";
+
+import {
+  RiskInsightsDataService,
+  SecurityTasksApiService,
+  TaskMetrics,
+} from "@bitwarden/bit-common/dirt/reports/risk-insights";
+import { CipherId, OrganizationId } from "@bitwarden/common/types/guid";
+import { SecurityTask, SecurityTaskStatus, SecurityTaskType } from "@bitwarden/common/vault/tasks";
+
+import {
+  AdminTaskService,
+  CreateTasksRequest,
+} from "../../../../../vault/services/abstractions/admin-task.abstraction";
+import { AccessSecurityTasksService } from "../abstractions/access-security-tasks.service";
+
+export class LegacyAccessSecurityTasksService extends AccessSecurityTasksService {
+  private readonly _tasks$ = new BehaviorSubject<SecurityTask[]>([]);
+  readonly tasks$ = this._tasks$.asObservable();
+
+  readonly unassignedCriticalCipherIds$: Observable<CipherId[]>;
+
+  constructor(
+    private adminTaskService: AdminTaskService,
+    private securityTasksApiService: SecurityTasksApiService,
+    private riskInsightsDataService: RiskInsightsDataService,
+  ) {
+    super();
+
+    this.unassignedCriticalCipherIds$ = combineLatest([
+      this.tasks$,
+      this.riskInsightsDataService.criticalApplicationAtRiskCipherIds$,
+      this.riskInsightsDataService.enrichedReportData$,
+    ]).pipe(
+      map(([tasks, atRiskCipherIds, reportData]) => {
+        if (tasks.length === 0) {
+          return atRiskCipherIds;
+        }
+
+        const inProgressTaskIds = new Set(
+          tasks
+            .filter((task) => task.status === SecurityTaskStatus.Pending)
+            .map((task) => task.cipherId),
+        );
+
+        const reportGeneratedAt = reportData?.creationDate;
+        const completedTaskIds = new Set(
+          (reportGeneratedAt
+            ? tasks.filter(
+                (task) =>
+                  task.status === SecurityTaskStatus.Completed &&
+                  new Date(task.revisionDate) >= reportGeneratedAt,
+              )
+            : []
+          ).map((task) => task.cipherId),
+        );
+
+        return atRiskCipherIds.filter(
+          (id) => !inProgressTaskIds.has(id) && !completedTaskIds.has(id),
+        );
+      }),
+      shareReplay({ bufferSize: 1, refCount: true }),
+    );
+  }
+
+  getTaskMetrics$(organizationId: OrganizationId): Observable<TaskMetrics> {
+    return this.securityTasksApiService.getTaskMetrics(organizationId);
+  }
+
+  loadTasks$(organizationId: OrganizationId): Observable<void> {
+    return from(this.securityTasksApiService.getAllTasks(organizationId)).pipe(
+      tap((tasks) => this._tasks$.next(tasks)),
+      map((): void => undefined),
+    );
+  }
+
+  requestPasswordChangeForCriticalApplications$(
+    organizationId: OrganizationId,
+    criticalApplicationIds: string[],
+  ): Observable<void> {
+    const distinctCipherIds = Array.from(new Set(criticalApplicationIds));
+    const tasks: CreateTasksRequest[] = distinctCipherIds.map((cipherId) => ({
+      cipherId: cipherId as CipherId,
+      type: SecurityTaskType.UpdateAtRiskCredential,
+    }));
+
+    return from(this.adminTaskService.bulkCreateTasks(organizationId, tasks)).pipe(
+      switchMap(() => this.loadTasks$(organizationId)),
+    );
+  }
+}


### PR DESCRIPTION
## 🎟️ Tracking
**[PM-33797](https://bitwarden.atlassian.net/browse/PM-33797)** — Access Intelligence V2: Standardize Models and Services
**Source / reference:** [Draft PR #19600](https://github.com/bitwarden/clients/pull/19600)

This is part of a series of incremental changes to introduce the V2 architecture for
Access Intelligence. The full series introduces, in order:

1. V2 data model family and encryption service abstraction
2. Type guards expansion
3. V2 service layer (bit-common)
4. Access security tasks service refactor (bit-web) **(current)**
5. V2 shared UI components
6. V2 page-level UI components
7. Module/routing wiring and V1 component updates
8. Model renames and old model cleanup

## 📔 Objective

Introduces the V2 security tasks service layer for Access Intelligence in `bit-web`. Adds an abstract `AccessSecurityTasksService` with a fully Observable-based API and two concrete implementations: `DefaultAccessSecurityTasksService` (backed by the new V2 `AccessIntelligenceDataService`) and `LegacyAccessSecurityTasksService` (backed by the legacy `RiskInsightsDataService`, functionally equivalent to the existing `shared/security-tasks.service.ts`). No DI wiring or component changes are included — those
land in step 7.

## Dependencies

> ✅  Depends on:  ([V2 service layer](https://github.com/bitwarden/clients/pull/19633))

## Changes

### New Files

- `v2/services/abstractions/access-security-tasks.service.ts` — abstract `AccessSecurityTasksService` defining the Observable-based task management contract
- `v2/services/implementations/default-access-security-tasks.service.ts` — V2 implementation using `AccessIntelligenceDataService`; derives `unassignedCriticalCipherIds$` from the V2 report view model
- `v2/services/implementations/legacy-access-security-tasks.service.ts` — legacy implementation using `RiskInsightsDataService`; preserves existing behavior for V1 components until they are migrated in step 7 _(replaces `shared/security-tasks.service.ts` which will be deleted in step 7)_
- `v2/services/implementations/legacy-access-security-tasks.service.spec.ts` — unit tests for the legacy implementation

### Modified Files

- `shared/security-tasks.service.ts` — marked `@deprecated`; points to `AccessSecurityTasksService` and `LegacyAccessSecurityTasksService` as the replacement

## 🔜 Follow-up Work

- DI wiring (binding `AccessSecurityTasksService` to the correct implementation per feature flag) and V1 component migration from the old Promise-based API to the Observable-based API land in step 7
- `shared/security-tasks.service.ts` and its spec are deleted in step 7 alongside the component migration


[PM-33797]: https://bitwarden.atlassian.net/browse/PM-33797?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ