### PR TITLE
Do not show uri confirmation dialog for non-login type ciphers

### DIFF
--- a/apps/browser/src/vault/popup/components/vault/item-more-options/item-more-options.component.spec.ts
+++ b/apps/browser/src/vault/popup/components/vault/item-more-options/item-more-options.component.spec.ts
@@ -158,6 +158,19 @@ describe("ItemMoreOptionsComponent", () => {
       expect(autofillSvc.doAutofillAndSave).not.toHaveBeenCalled();
     });
 
+    it("directly autofills without showing the confirmation dialog for card ciphers", async () => {
+      const cardCipher = { ...baseCipher, type: CipherType.Card, login: undefined };
+      component.cipher = cardCipher;
+      cipherService.getFullCipherView.mockResolvedValue(cardCipher);
+      autofillSvc.currentAutofillTab$.next({ url: "https://page.example.com" });
+      const openSpy = jest.spyOn(AutofillConfirmationDialogComponent, "open");
+
+      await component.doAutofill();
+
+      expect(openSpy).not.toHaveBeenCalled();
+      expect(autofillSvc.doAutofill).toHaveBeenCalledWith(cardCipher, true, true);
+    });
+
     describe("autofill confirmation dialog", () => {
       beforeEach(() => {
         uriMatchStrategy$.next(UriMatchStrategy.Domain);

--- a/apps/browser/src/vault/popup/components/vault/item-more-options/item-more-options.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/item-more-options/item-more-options.component.ts
@@ -198,6 +198,12 @@ export class ItemMoreOptionsComponent {
       return;
     }
 
+    // Do not show exact match dialog for non login types
+    if (CipherViewLikeUtils.getType(cipher) !== CipherType.Login) {
+      await this.vaultPopupAutofillService.doAutofill(cipher, true, true);
+      return;
+    }
+
     const uris = cipher.login?.uris ?? [];
     const uriMatchStrategy = await firstValueFrom(this.uriMatchStrategy$);
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-34008

## 📔 Objective

Do not show the autofill confirmation dialog for non-login item types

## 📸 Screenshots

Before:

https://github.com/user-attachments/assets/24e34a42-caa9-49c7-8d19-0efd0307f6a7

After fix:

https://github.com/user-attachments/assets/7c39e08f-0a6c-4464-9548-7b195751812c

