### PR TITLE
[PM-34064] - remove unnecessary wrapper div around web extension prompt dialog

### DIFF
--- a/apps/web/src/app/vault/components/web-vault-extension-prompt/web-vault-extension-prompt-dialog.component.html
+++ b/apps/web/src/app/vault/components/web-vault-extension-prompt/web-vault-extension-prompt-dialog.component.html
@@ -1,13 +1,11 @@
 <div
   class="tw-max-w-3xl tw-p-9 tw-border tw-border-solid tw-border-border-base tw-rounded-xl tw-bg-background tw-text-center"
 >
-  <div [attr.alt]="'extensionPromptImageAlt' | i18n" class="tw-mb-[1.875rem]">
-    <bit-svg
-      [content]="extensionMockLogin"
-      [ariaLabel]="'extensionPromptImageAlt' | i18n"
-      class="tw-mb-[1.875rem]"
-    ></bit-svg>
-  </div>
+  <bit-svg
+    [content]="extensionMockLogin"
+    [ariaLabel]="'extensionPromptImageAlt' | i18n"
+    class="tw-mb-[1.875rem]"
+  ></bit-svg>
   <div class="tw-flex tw-flex-col tw-gap-[1.6875rem]">
     <h2 class="tw-mb-0">
       {{ "extensionPromptHeading" | i18n }}


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-34064

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR removes an unnecessary wrapper div around the extension prompt dialog image.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
<img width="1797" height="1060" alt="Screenshot 2026-03-23 at 2 36 55 PM" src="https://github.com/user-attachments/assets/594ca879-12f2-450c-8aa4-7eca762bdfa3" />