### PR TITLE
[PM-34047] Change column header in at-risk member drawers to "At-risk applications"

### DIFF
--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/shared/risk-insights-drawer-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/shared/risk-insights-drawer-dialog.component.html
@@ -29,7 +29,7 @@
               {{ "email" | i18n }}
             </div>
             <div bitTypography="body2" class="tw-text-sm tw-font-bold">
-              {{ "atRiskPasswords" | i18n }}
+              {{ "atRiskApplications" | i18n }}
             </div>
           </div>
           @for (member of drawerDetails.atRiskMemberDetails; track member.email) {
@@ -100,7 +100,7 @@
               {{ "application" | i18n }}
             </div>
             <div bitTypography="body2" class="tw-text-sm tw-font-bold">
-              {{ "atRiskPasswords" | i18n }}
+              {{ "atRiskApplications" | i18n }}
             </div>
           </div>
           @for (app of drawerDetails.atRiskAppDetails; track app.applicationName) {

--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/shared/risk-insights-drawer-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/shared/risk-insights-drawer-dialog.component.html
@@ -100,7 +100,7 @@
               {{ "application" | i18n }}
             </div>
             <div bitTypography="body2" class="tw-text-sm tw-font-bold">
-              {{ "atRiskApplications" | i18n }}
+              {{ "atRiskPasswords" | i18n }}
             </div>
           </div>
           @for (app of drawerDetails.atRiskAppDetails; track app.applicationName) {


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-34047

## 📔 Objective
Updates the "At-risk members" drawers in Access Intelligence to read "At-risk applications". This change is necessary because the column does not display at-risk passwords, as it currently reads. It is instead a count of the # of applications each member has access to.


## 📸 Screenshots
See the drawer on the right hand side of the screen.

**Activity tab drawer**
<img width="2610" height="1527" alt="image" src="https://github.com/user-attachments/assets/01fe34ba-97c0-469f-8476-9ca73854607b" />

**All applications tab drawer**
<img width="2610" height="1527" alt="image" src="https://github.com/user-attachments/assets/7579f877-cb32-41e7-8826-8c77686c99d2" />

**Critical applications tab drawer**
<img width="2610" height="1527" alt="image" src="https://github.com/user-attachments/assets/aae4ee3c-ccd2-4d2d-af13-d83dd3d885ed" />
