### PR TITLE
[PM-34058] fix vault timeout on MV2 Firefox

### DIFF
--- a/apps/browser/src/platform/browser/browser-api.spec.ts
+++ b/apps/browser/src/platform/browser/browser-api.spec.ts
@@ -320,9 +320,10 @@ describe("BrowserApi", () => {
   });
 
   describe("isPopupOpen", () => {
-    describe("when chrome.runtime.getContexts is available", () => {
+    describe("when MV3 and chrome.runtime.getContexts is available", () => {
       beforeEach(() => {
         (chrome.runtime as any).getContexts = jest.fn();
+        jest.spyOn(BrowserApi, "manifestVersion", "get").mockReturnValue(3);
       });
 
       afterEach(() => {
@@ -352,9 +353,9 @@ describe("BrowserApi", () => {
       });
     });
 
-    describe("when chrome.runtime.getContexts is not available (MV2/Safari)", () => {
+    describe("when MV2, falls back to getExtensionViews", () => {
       beforeEach(() => {
-        delete (chrome.runtime as any).getContexts;
+        jest.spyOn(BrowserApi, "manifestVersion", "get").mockReturnValue(2);
       });
 
       it("returns true if the popup is open", async () => {
@@ -368,13 +369,30 @@ describe("BrowserApi", () => {
 
         expect(await BrowserApi.isPopupOpen()).toBe(false);
       });
+
+      it("ignores getContexts even when available (Firefox MV2 background page bug)", async () => {
+        // Firefox 128+ exposes getContexts in MV2, but classifies the persistent
+        // background page as contextType "POPUP". Without the MV3 guard, this would
+        // cause isPopupOpen() to always return true and prevent vault timeout.
+        (chrome.runtime as any).getContexts = jest
+          .fn()
+          .mockResolvedValue([
+            { contextType: "POPUP", documentUrl: "chrome-extension://id/background.html" },
+          ]);
+        chrome.extension.getViews = jest.fn().mockReturnValue([]);
+
+        expect(await BrowserApi.isPopupOpen()).toBe(false);
+
+        delete (chrome.runtime as any).getContexts;
+      });
     });
   });
 
   describe("isAnyViewFocused", () => {
-    describe("when chrome.runtime.getContexts is available", () => {
+    describe("when MV3 and chrome.runtime.getContexts is available", () => {
       beforeEach(() => {
         (chrome.runtime as any).getContexts = jest.fn();
+        jest.spyOn(BrowserApi, "manifestVersion", "get").mockReturnValue(3);
       });
 
       afterEach(() => {
@@ -434,8 +452,25 @@ describe("BrowserApi", () => {
       });
     });
 
-    describe("when chrome.runtime.getContexts is not available (MV2/Safari)", () => {
+    describe("when MV2, falls back to getExtensionViews", () => {
       beforeEach(() => {
+        jest.spyOn(BrowserApi, "manifestVersion", "get").mockReturnValue(2);
+        delete (chrome.runtime as any).getContexts;
+      });
+
+      it("ignores getContexts even when available (Firefox MV2 background page bug)", async () => {
+        // Firefox 128+ exposes getContexts in MV2, but classifies the persistent
+        // background page as contextType "POPUP". Without the MV3 guard, this would
+        // cause isAnyViewFocused() to permanently return true and block vault timeout.
+        (chrome.runtime as any).getContexts = jest
+          .fn()
+          .mockResolvedValue([
+            { contextType: "POPUP", documentUrl: "chrome-extension://id/background.html" },
+          ]);
+        chrome.extension.getViews = jest.fn().mockReturnValue([]);
+
+        expect(await BrowserApi.isAnyViewFocused()).toBe(false);
+
         delete (chrome.runtime as any).getContexts;
       });
 

--- a/apps/browser/src/platform/browser/browser-api.ts
+++ b/apps/browser/src/platform/browser/browser-api.ts
@@ -467,11 +467,14 @@ export class BrowserApi {
   /**
    * Returns true if the vault popup is currently open.
    *
-   * Uses `chrome.runtime.getContexts()` when available (MV3/Chrome),
-   * and falls back to `chrome.extension.getViews()` for MV2/Safari.
+   * Uses `chrome.runtime.getContexts()` on MV3 (Chrome/Edge),
+   * and falls back to `chrome.extension.getViews()` for MV2 (Firefox) and Safari.
    */
   static async isPopupOpen(): Promise<boolean> {
-    if (typeof (chrome.runtime as any).getContexts === "function") {
+    if (
+      typeof (chrome.runtime as any).getContexts === "function" &&
+      BrowserApi.isManifestVersion(3)
+    ) {
       const contexts = await chrome.runtime.getContexts({});
       return contexts.some((context) => context.contextType === "POPUP");
     }
@@ -487,11 +490,19 @@ export class BrowserApi {
    * - Sidebar: always considered focused (always visible).
    * - Popout windows: only focused if the window is currently focused.
    *
-   * Uses `chrome.runtime.getContexts()` when available (MV3/Chrome),
-   * and falls back to `chrome.extension.getViews()` for MV2/Safari.
+   * Uses `chrome.runtime.getContexts()` on MV3 (Chrome/Edge),
+   * and falls back to `chrome.extension.getViews()` for MV2 (Firefox) and Safari.
+   *
+   * NOTE: The `getContexts` path is restricted to MV3. Firefox MV2's persistent
+   * background page is classified as a "POPUP" context by `runtime.getContexts()`,
+   * which would cause `isAnyViewFocused` to permanently return true and block vault
+   * timeout. The `getExtensionViews` path only returns actually-visible views.
    */
   static async isAnyViewFocused(): Promise<boolean> {
-    if (typeof (chrome.runtime as any).getContexts === "function") {
+    if (
+      typeof (chrome.runtime as any).getContexts === "function" &&
+      BrowserApi.isManifestVersion(3)
+    ) {
       const contexts = await chrome.runtime.getContexts({});
 
       if (contexts.some((c) => c.contextType === "POPUP" || c.contextType === "SIDE_PANEL")) {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-34058
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
#19019 changed our heartbeat strategy for popup detection with browser APIs. However, the check for MV2 assumes that `runtime.getContexts` isn't available. FIrefox seems to have added that API for both MV2 and MV3.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/cec36af4-e26d-423b-9b53-8b732946d435

