### PR TITLE
[CL-1136] Updated disabled org trailing icon color

### DIFF
--- a/apps/desktop/src/vault/app/vault-v3/vault-filter/filters/organization-filter.component.html
+++ b/apps/desktop/src/vault/app/vault-v3/vault-filter/filters/organization-filter.component.html
@@ -22,7 +22,7 @@
           <bit-icon
             slot="end"
             name="bwi-exclamation-triangle"
-            [attr.aria-label]="'organizationIsDisabled' | i18n"
+            [ariaLabel]="'organizationIsDisabled' | i18n"
             [appA11yTitle]="'organizationIsDisabled' | i18n"
           />
         }

--- a/apps/desktop/src/vault/app/vault-v3/vault-filter/filters/organization-filter.component.html
+++ b/apps/desktop/src/vault/app/vault-v3/vault-filter/filters/organization-filter.component.html
@@ -19,7 +19,12 @@
         (click)="applyFilter($event, organization)"
       >
         @if (!organization.node.enabled) {
-          <bit-icon slot="end" name="bwi-exclamation-triangle" />
+          <bit-icon
+            slot="end"
+            name="bwi-exclamation-triangle"
+            [attr.aria-label]="'organizationIsDisabled' | i18n"
+            [appA11yTitle]="'organizationIsDisabled' | i18n"
+          />
         }
       </bit-nav-item>
     }

--- a/apps/desktop/src/vault/app/vault-v3/vault-filter/filters/organization-filter.component.html
+++ b/apps/desktop/src/vault/app/vault-v3/vault-filter/filters/organization-filter.component.html
@@ -19,12 +19,7 @@
         (click)="applyFilter($event, organization)"
       >
         @if (!organization.node.enabled) {
-          <i
-            slot="end"
-            class="bwi bwi-fw bwi-exclamation-triangle text-danger mr-auto"
-            [attr.aria-label]="'organizationIsDisabled' | i18n"
-            [appA11yTitle]="'organizationIsDisabled' | i18n"
-          ></i>
+          <bit-icon slot="end" name="bwi-exclamation-triangle" />
         }
       </bit-nav-item>
     }

--- a/apps/desktop/src/vault/app/vault-v3/vault-filter/filters/organization-filter.component.ts
+++ b/apps/desktop/src/vault/app/vault-v3/vault-filter/filters/organization-filter.component.ts
@@ -5,7 +5,12 @@ import { Component, computed, input, inject } from "@angular/core";
 import { DisplayMode } from "@bitwarden/angular/vault/vault-filter/models/display-mode";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { TreeNode } from "@bitwarden/common/vault/models/domain/tree-node";
-import { ToastService, NavigationModule, A11yTitleDirective } from "@bitwarden/components";
+import {
+  ToastService,
+  NavigationModule,
+  A11yTitleDirective,
+  IconModule,
+} from "@bitwarden/components";
 import { I18nPipe } from "@bitwarden/ui-common";
 import { OrganizationFilter, VaultFilter, VaultFilterServiceAbstraction } from "@bitwarden/vault";
 
@@ -14,7 +19,7 @@ import { OrganizationFilter, VaultFilter, VaultFilterServiceAbstraction } from "
 @Component({
   selector: "app-organization-filter",
   templateUrl: "organization-filter.component.html",
-  imports: [A11yTitleDirective, NavigationModule, I18nPipe],
+  imports: [A11yTitleDirective, NavigationModule, I18nPipe, IconModule],
 })
 export class OrganizationFilterComponent {
   private toastService: ToastService = inject(ToastService);


### PR DESCRIPTION
## 🎟️ Tracking

[JIRA](https://bitwarden.atlassian.net/browse/CL-1136?atlOrigin=eyJpIjoiMWY4NDQxOTYzYTJlNDFjMmI0ZmMwYjg2ODlmZmZmMGQiLCJwIjoiaiJ9)

## 📔 Objective

Updated the disabled organization nav item's trailing icon color from 'danger' to default text/foreground color, allowing for better contrast and visibility.

## 📸 Screenshots

(Before)
<img width="283" height="184" alt="Screenshot 2026-03-25 at 11 22 06 AM" src="https://github.com/user-attachments/assets/8f010fef-c09e-4917-b547-9049e5827059" />
(After)
<img width="287" height="178" alt="Screenshot 2026-03-25 at 11 22 28 AM" src="https://github.com/user-attachments/assets/de37c626-27f6-4646-bba9-b9bcec398303" />

