### PR TITLE
[PM-33022] Add readonly Send view to browser extension

### DIFF
--- a/apps/browser/src/tools/popup/send-v2/add-edit/send-add-edit.component.html
+++ b/apps/browser/src/tools/popup/send-v2/add-edit/send-add-edit.component.html
@@ -7,26 +7,38 @@
     (onSendCreated)="onSendCreated($event)"
     (onSendUpdated)="onSendUpdated($event)"
     (openPasswordGenerator)="openGenerator()"
-    [submitBtn]="submitBtn"
-    [editing]="true"
+    [editing]="editing()"
   >
   </tools-send-form>
 
   <popup-footer slot="footer">
-    <button bitButton type="submit" form="sendForm" buttonType="primary" #submitBtn>
-      {{ "save" | i18n }}
-    </button>
-    <button bitButton type="button" buttonType="secondary" [popupBackAction]>
-      {{ "cancel" | i18n }}
-    </button>
-    <button
-      *ngIf="config?.mode !== 'add'"
-      type="button"
-      buttonType="danger"
-      slot="end"
-      bitIconButton="bwi-trash"
-      [bitAction]="deleteSend"
-      label="{{ 'delete' | i18n }}"
-    ></button>
+    @if (editing()) {
+      <button bitButton type="submit" form="sendForm" buttonType="primary" #submitBtn>
+        {{ "save" | i18n }}
+      </button>
+      @if (config?.mode !== "add") {
+        <button bitButton type="button" buttonType="secondary" (click)="cancelEditSend()">
+          {{ "cancel" | i18n }}
+        </button>
+      } @else {
+        <button bitButton type="button" buttonType="secondary" [popupBackAction]>
+          {{ "cancel" | i18n }}
+        </button>
+      }
+    } @else {
+      <button bitButton type="button" buttonType="secondary" (click)="editSend()">
+        {{ "edit" | i18n }}
+      </button>
+    }
+    @if (config?.mode !== "add") {
+      <button
+        type="button"
+        buttonType="danger"
+        slot="end"
+        bitIconButton="bwi-trash"
+        [bitAction]="deleteSend"
+        label="{{ 'delete' | i18n }}"
+      ></button>
+    }
   </popup-footer>
 </popup-page>

--- a/apps/browser/src/tools/popup/send-v2/add-edit/send-add-edit.component.ts
+++ b/apps/browser/src/tools/popup/send-v2/add-edit/send-add-edit.component.ts
@@ -1,13 +1,12 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
 import { CommonModule, Location } from "@angular/common";
-import { Component, inject, viewChild } from "@angular/core";
+import { Component, inject, signal, viewChild } from "@angular/core";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { FormsModule } from "@angular/forms";
 import { ActivatedRoute, Params, Router } from "@angular/router";
 import { map, switchMap } from "rxjs";
 
-import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { SendView } from "@bitwarden/common/tools/send/models/view/send.view";
 import { SendApiService } from "@bitwarden/common/tools/send/services/send-api.service.abstraction";
@@ -30,6 +29,7 @@ import {
   SendFormMode,
   SendFormModule,
 } from "@bitwarden/send-ui";
+import { I18nPipe } from "@bitwarden/ui-common";
 
 import { PopupBackBrowserDirective } from "../../../../platform/popup/layout/popup-back.directive";
 import { PopupFooterComponent } from "../../../../platform/popup/layout/popup-footer.component";
@@ -79,7 +79,7 @@ export type AddEditQueryParams = Partial<Record<keyof QueryParams, string>>;
   imports: [
     CommonModule,
     SearchModule,
-    JslibModule,
+    I18nPipe,
     FormsModule,
     ButtonModule,
     IconButtonModule,
@@ -101,6 +101,11 @@ export class SendAddEditComponent {
    * The configuration for the send form.
    */
   config: SendFormConfig;
+
+  /**
+   * Whether the Send is actively being edited
+   */
+  protected readonly editing = signal(false);
 
   private sendFormGenerationService = inject(SendFormGenerationService);
   private readonly sendFormComponent = viewChild(SendFormComponent);
@@ -201,6 +206,7 @@ export class SendAddEditComponent {
       )
       .subscribe((config) => {
         this.config = config;
+        this.editing.set(config.mode === "add");
         this.headerText = this.getHeaderText(config.mode, config.sendType);
       });
   }
@@ -218,5 +224,13 @@ export class SendAddEditComponent {
       [SendType.File]: isEditMode ? "editItemHeaderFileSend" : "newItemHeaderFileSend",
     };
     return this.i18nService.t(translation[type]);
+  }
+
+  protected editSend() {
+    this.editing.set(true);
+  }
+
+  protected async cancelEditSend() {
+    this.editing.set(false);
   }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-33022 (the browser extension subtask)
https://bitwarden.atlassian.net/browse/PM-32586 (the parent story for adding a readonly Send view)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR adds a readonly view to the Send edit flow in the browser extension to bring it in line with the Vault item editing experience and visually in line with mobile (and with [web/desktop](https://github.com/bitwarden/clients/pull/19688)). Existing Sends are opened into this readonly view with any field that is not specified hidden from view, while new Sends are opened directly into the editable mode.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/847446b7-c649-4983-a742-e31288b3a602
