### PR TITLE
[PM-33529] Update web nx serve configuration names to match CLI and docs

### DIFF
--- a/apps/web/project.json
+++ b/apps/web/project.json
@@ -153,16 +153,16 @@
         "port": 8080
       },
       "configurations": {
-        "oss": {
+        "oss-dev": {
           "buildTarget": "web:build:oss-dev"
         },
-        "commercial": {
+        "commercial-dev": {
           "buildTarget": "web:build:commercial-dev"
         },
-        "oss-selfhost": {
+        "oss-selfhost-dev": {
           "buildTarget": "web:build:oss-selfhost-dev"
         },
-        "commercial-selfhost": {
+        "commercial-selfhost-dev": {
           "buildTarget": "web:build:commercial-selfhost-dev"
         }
       }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-33529

## 📔 Objective

The `serve` configurations for web did not match CLI or the [docs](https://contributing.bitwarden.com/getting-started/clients/web-vault/#build-instructions).

With this change, the following commands work as expected:

### `oss-dev`
<img width="1004" height="182" alt="image" src="https://github.com/user-attachments/assets/3b1650ee-fd92-4c80-94c9-cb1673d0967e" />

### `commercial-dev`
<img width="855" height="182" alt="image" src="https://github.com/user-attachments/assets/96f9b2e9-0b85-4ca5-9f66-d0a09ba05878" />
