### PR TITLE
chore: update sm code ownership for sm owned files in bw license

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -96,7 +96,7 @@ libs/subscription @bitwarden/team-billing-dev
 bitwarden_license/bit-web/src/app/billing @bitwarden/team-billing-dev
 
 ## Secrets Manager team files ##
-bitwarden_license/bit-web/src/app/secrets-manager/* @bitwarden/team-secrets-manager-dev
+bitwarden_license/bit-web/src/app/secrets-manager @bitwarden/team-secrets-manager-dev
 
 ## Platform team files ##
 apps/browser/src/platform @bitwarden/team-platform-dev

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -95,6 +95,9 @@ libs/pricing @bitwarden/team-billing-dev
 libs/subscription @bitwarden/team-billing-dev
 bitwarden_license/bit-web/src/app/billing @bitwarden/team-billing-dev
 
+## Secrets Manager team files ##
+bitwarden_license/bit-web/src/app/secrets-manager/* @bitwarden/team-secrets-manager-dev
+
 ## Platform team files ##
 apps/browser/src/platform @bitwarden/team-platform-dev
 apps/cli/src/platform @bitwarden/team-platform-dev


### PR DESCRIPTION
## 📔 Objective

> SM code ownership was missing for all SM owned code within the `bitwarden_license/bit-web/src/app/secrets-manager` directory. The `CODEOWNERS` file has been updated to reflect the proper ownership.
