### PR TITLE
Add workflow for removing reviewers from community PRs

### DIFF
--- a/.github/workflows/community-pr-management.yml
+++ b/.github/workflows/community-pr-management.yml
@@ -1,13 +1,13 @@
 name: Community PR management
 
 on:
-  pull_request:
-    types: [opened]
+  pull_request_target:
+    types: [labeled]
 
 jobs:
   remove-individual-reviewers:
     name: Remove individual reviewers from community PRs
-    if: contains(github.event.pull_request.labels.*.name, 'community-pr')
+    if: github.event.label.name == 'community-pr'
     runs-on: ubuntu-22.04
     permissions:
       pull-requests: write


### PR DESCRIPTION
## 🎟️ Tracking

## 📔 Objective

Github round-robin assigns reviewers from CODEOWNER teams when a community PR opens.

This makes the implicit assumption that the community PR is ready for review by the engineering team at that point, when the [review process](https://contributing.bitwarden.com/contributing/pull-requests/community-pr-process#product-assessment) requires additional steps.  This puts that assigned engineer in a position of managing questions about PR status while they are not yet in control of the work.

This PR introduces a workflow that will act on the application of `community-pr` labels and remove any individual assignees from the PR.

This will remove any manually-added assignees as well.  If there are workflows in which we would have manual assignees that we would want to keep, we will need to revisit this as a solution.
