### PR TITLE
SSH Agent v2: add v1 deprecation note

### DIFF
--- a/apps/desktop/desktop_native/core/src/ssh_agent/mod.rs
+++ b/apps/desktop/desktop_native/core/src/ssh_agent/mod.rs
@@ -1,3 +1,12 @@
+//! V1 Bitwarden SSH Agent implementation
+//!
+//! WARNING !!!
+//!
+//! This crate is deprecated as the v2 implementation is in
+//! progress. Only security patches and critical bug fixes will
+//! be accepted for this crate. After the v2 is released, the v1
+//! implementation will be removed.
+
 use std::{
     collections::HashMap,
     sync::{

--- a/apps/desktop/desktop_native/napi/src/lib.rs
+++ b/apps/desktop/desktop_native/napi/src/lib.rs
@@ -21,6 +21,6 @@ pub mod passkey_authenticator;
 pub mod passwords;
 pub mod powermonitors;
 pub mod processisolations;
-pub mod sshagent;
+pub mod sshagent; // deprecated
 pub mod sshagent_v2;
 pub mod windows_registry;


### PR DESCRIPTION
## 📔 Objective

The v2 is underway and, in lieu of a community forums note, we want to warn users before considering proposing any more changes to the v1 implementation.
