### PR TITLE
Fix autofill prompt to save new credentials when the vault is locked

### DIFF
--- a/apps/browser/src/autofill/background/notification.background.spec.ts
+++ b/apps/browser/src/autofill/background/notification.background.spec.ts
@@ -930,7 +930,7 @@ describe("NotificationBackground", () => {
         expectSkippedCheckingNotification();
       });
 
-      it("skips checking if a notification should trigger if the vault is locked and there is no value for the `newPassword` field", async () => {
+      it("triggers an add login notification if the vault is locked and there is no value for the `newPassword` field but username and password are set", async () => {
         const formEntryData: ModifyLoginCipherFormData = {
           newPassword: "",
           password: "Beeblebrox4Prez",
@@ -938,16 +938,18 @@ describe("NotificationBackground", () => {
           username: "ADent",
         };
 
-        const storedCiphersForURL = [
-          mock<CipherView>({ login: { username: "ADent", password: "I<3VogonPoetry" } }),
-        ];
-
         activeAccountStatusMock$.next(AuthenticationStatus.Locked);
-        getAllDecryptedForUrlSpy.mockResolvedValueOnce(storedCiphersForURL);
 
         await notificationBackground.triggerCipherNotification(formEntryData, tab);
 
-        expectSkippedCheckingNotification();
+        expect(getAllDecryptedForUrlSpy).not.toHaveBeenCalled();
+        expect(pushChangePasswordToQueueSpy).not.toHaveBeenCalled();
+        expect(pushAddLoginToQueueSpy).toHaveBeenCalledWith(
+          mockFormattedURI,
+          { username: "ADent", password: "Beeblebrox4Prez", url: mockFormURI },
+          tab,
+          true,
+        );
       });
 
       describe("when `username` and `password` and `newPassword` fields are filled, ", () => {

--- a/apps/browser/src/autofill/background/notification.background.ts
+++ b/apps/browser/src/autofill/background/notification.background.ts
@@ -739,7 +739,11 @@ export default class NotificationBackground {
       if (!newPasswordFieldHasValue) {
         // If the vault is locked and there is no new password value, the best we can do is prompt to add a new login if the username field has a value,
         // since we can't compare against existing ciphers to determine if a change scenario is present.
-        if (newLoginNotificationIsEnabled && usernameFieldHasValue) {
+        if (
+          newLoginNotificationIsEnabled &&
+          usernameFieldHasValue &&
+          currentPasswordFieldHasValue
+        ) {
           await this.pushAddLoginToQueue(
             loginDomain,
             { username: usernameFieldValue, password: currentPasswordFieldValue, url: data.uri },


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-34100

## 📔 Objective

Fixes a bug where the autofill notification was not showing when the vault is locked.

## 📸 Screenshots

After fix:

https://github.com/user-attachments/assets/bac4ec08-464c-4b43-81a8-c724c081ee0d

