### PR TITLE
[PM-34199] [Extension] Change Password Routing Fix

### DIFF
--- a/apps/browser/src/auth/popup/constants/auth-extension-route.constant.ts
+++ b/apps/browser/src/auth/popup/constants/auth-extension-route.constant.ts
@@ -2,15 +2,21 @@
 export const AuthExtensionRoute = Object.freeze({
   AccountSecurity: "account-security",
   /**
-   * `AuthExtensionRoute.SettingsChangePassword` uses `ChangePasswordPageComponent` and is used when the user intentionally navigates
+   * `AuthExtensionRoute.SettingsPassword` uses `ChangePasswordPageComponent` and is used when the user intentionally navigates
    * to Settings > Account Security to change their password.
    *
    * This is distinct from `AuthRoute.ChangePassword`, which uses `ExtensionAnonLayoutWrapperComponent`, and is used when
    * `ForceSetPasswordReason` forces the user to change their password due to either `AdminForcePasswordReset` or `WeakMasterPassword`
    *
-   * TODO: PM-34240 - move auth settings to a nested routing structure, e.g. `/settings/account-security/change-password`
+   * IMPORTANT: This `AuthExtensionRoute.SettingsPassword` route path must NOT contain the substring "change-password". The `authGuard`
+   * uses a substring check (`url.includes("change-password")`) to exempt the forced `/change-password` route from redirection — a route
+   * containing that substring would be incorrectly exempted. This mirrors the existing pattern on Web, where the equivalent route is
+   * `/settings/security/password`, not `/settings/security/change-password`. See PM-34258 for further explanation/future cleanup.
+   *
+   * TODO: PM-34240 - move auth settings to a nested routing structure, e.g. `/settings/account-security/change-password`,
+   * and update the `authGuard` substring check accordingly (though it might already have been updated by PM-34258)
    */
-  SettingsChangePassword: "settings-change-password",
+  SettingsPassword: "settings-password",
   DeviceManagement: "device-management",
   AccountSwitcher: "account-switcher",
 } as const);

--- a/apps/browser/src/auth/popup/constants/auth-extension-route.constant.ts
+++ b/apps/browser/src/auth/popup/constants/auth-extension-route.constant.ts
@@ -1,7 +1,16 @@
 // Full routes that auth owns in the extension
 export const AuthExtensionRoute = Object.freeze({
   AccountSecurity: "account-security",
-  ChangePassword: "change-password",
+  /**
+   * `SettingsChangePassword` is used when the user intentionally navigates to Settings > Account Security
+   * to change their password.
+   *
+   * This is distinct from `AuthRoute.ChangePassword` (nested under `ExtensionAnonLayoutWrapperComponent`), which is used when
+   * `ForceSetPasswordReason` forces the user to change their password due to either `AdminForcePasswordReset` or `WeakMasterPassword`
+   *
+   * TODO: eventually we should move to a parent/child routing structure, e.g. `/settings/change-password`
+   */
+  SettingsChangePassword: "settings-change-password",
   DeviceManagement: "device-management",
   AccountSwitcher: "account-switcher",
 } as const);

--- a/apps/browser/src/auth/popup/constants/auth-extension-route.constant.ts
+++ b/apps/browser/src/auth/popup/constants/auth-extension-route.constant.ts
@@ -2,13 +2,13 @@
 export const AuthExtensionRoute = Object.freeze({
   AccountSecurity: "account-security",
   /**
-   * `SettingsChangePassword` is used when the user intentionally navigates to Settings > Account Security
-   * to change their password.
+   * `AuthExtensionRoute.SettingsChangePassword` uses `ChangePasswordPageComponent` and is used when the user intentionally navigates
+   * to Settings > Account Security to change their password.
    *
-   * This is distinct from `AuthRoute.ChangePassword` (nested under `ExtensionAnonLayoutWrapperComponent`), which is used when
+   * This is distinct from `AuthRoute.ChangePassword`, which uses `ExtensionAnonLayoutWrapperComponent`, and is used when
    * `ForceSetPasswordReason` forces the user to change their password due to either `AdminForcePasswordReset` or `WeakMasterPassword`
    *
-   * TODO: eventually we should move to a parent/child routing structure, e.g. `/settings/change-password`
+   * TODO: PM-34240 - move auth settings to a nested routing structure, e.g. `/settings/account-security/change-password`
    */
   SettingsChangePassword: "settings-change-password",
   DeviceManagement: "device-management",

--- a/apps/browser/src/auth/popup/settings/account-security.component.ts
+++ b/apps/browser/src/auth/popup/settings/account-security.component.ts
@@ -506,7 +506,7 @@ export class AccountSecurityComponent implements OnInit, OnDestroy {
     );
 
     if (multiClientPasswordManagementFlagEnabled) {
-      await this.router.navigate(["/" + AuthExtensionRoute.ChangePassword]);
+      await this.router.navigate(["/" + AuthExtensionRoute.SettingsChangePassword]);
       return;
     }
 

--- a/apps/browser/src/auth/popup/settings/account-security.component.ts
+++ b/apps/browser/src/auth/popup/settings/account-security.component.ts
@@ -506,7 +506,7 @@ export class AccountSecurityComponent implements OnInit, OnDestroy {
     );
 
     if (multiClientPasswordManagementFlagEnabled) {
-      await this.router.navigate(["/" + AuthExtensionRoute.SettingsChangePassword]);
+      await this.router.navigate(["/" + AuthExtensionRoute.SettingsPassword]);
       return;
     }
 

--- a/apps/browser/src/popup/app-routing.module.ts
+++ b/apps/browser/src/popup/app-routing.module.ts
@@ -292,7 +292,7 @@ const routes: Routes = [
     data: { elevation: 1 } satisfies RouteDataProperties,
   },
   {
-    path: AuthExtensionRoute.SettingsChangePassword,
+    path: AuthExtensionRoute.SettingsPassword,
     component: ChangePasswordPageComponent,
     canActivate: [
       // TODO: PM-32419 - remove feature flag check

--- a/apps/browser/src/popup/app-routing.module.ts
+++ b/apps/browser/src/popup/app-routing.module.ts
@@ -292,7 +292,7 @@ const routes: Routes = [
     data: { elevation: 1 } satisfies RouteDataProperties,
   },
   {
-    path: AuthExtensionRoute.ChangePassword,
+    path: AuthExtensionRoute.SettingsChangePassword,
     component: ChangePasswordPageComponent,
     canActivate: [
       // TODO: PM-32419 - remove feature flag check

--- a/apps/web/src/app/auth/constants/auth-web-route.constant.ts
+++ b/apps/web/src/app/auth/constants/auth-web-route.constant.ts
@@ -5,6 +5,11 @@ export const AuthWebRouteSegment = Object.freeze({
   EmergencyAccess: "emergency-access",
 
   // settings/security routes
+  /**
+   * IMPORTANT: This `AuthWebRouteSegment.Password` route path must NOT contain the substring "change-password". The `authGuard`
+   * uses a substring check (`url.includes("change-password")`) to exempt the forced `/change-password` route from redirection — a route
+   * containing that substring would be incorrectly exempted. See PM-34258 for further explanation/future cleanup.
+   */
   Password: "password",
   TwoFactor: "two-factor",
   SecurityKeys: "security-keys",


### PR DESCRIPTION
## 🎟️ Tracking

[PM-34199](https://bitwarden.atlassian.net/browse/PM-34199)

## 📔 Objective

The `AuthExtensionRoute.ChangePassword` route (with `canAccessFeature(FeatureFlag.PM32413_MultiClientPasswordManagement)`) is preventing routing to the pre-existing `"change-password"` route for users with `ForceSetPasswordReason.AdminForcePasswordReset` or `ForceSetPasswordReason.WeakMasterPassword`.

This PR makes a distinct `"settings-change-password"` route - to be used when the user initiates changing their password by navigating to Settings > Account Recovery. This route is feature flagged and uses the `ChangePasswordPageComponent`.

The already existing `change-password` can then still be used when the user is required to change their password due to the `ForceSetPasswordReason`s mentioned above. This route is not feature flagged and is nested under the `ExtensionAnonLayoutWrapperComponent`.

## 📸 Screenshots

### Account Recovery - `FeatureFlag.PM32413_MultiClientPasswordManagement` off 🔴

https://github.com/user-attachments/assets/43554419-c9b7-4770-b578-6c9544d7e4ac

<br />

### Account Recovery - `FeatureFlag.PM32413_MultiClientPasswordManagement` on 🟢

Video shows that both account recovery follow-up (`ForceSetPasswordReason.AdminForcePasswordReset`) and regular change password (via Settings) are working.

https://github.com/user-attachments/assets/298ea6f4-9e1a-475a-ab1c-e145a8b03eb4

<br />

### Weak MP - `FeatureFlag.PM32413_MultiClientPasswordManagement` off 🔴

https://github.com/user-attachments/assets/9c1a12f5-928f-43ab-ac56-2d07967e174a

<br />

### Weak MP - `FeatureFlag.PM32413_MultiClientPasswordManagement` on 🟢

Video shows that both weak master password follow-up (`ForceSetPasswordReason.WeakMasterPassword`) and regular change password (via Settings) are working.

https://github.com/user-attachments/assets/ee00cb86-1d18-4121-86c0-e25bdea8e282

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->


[PM-34199]: https://bitwarden.atlassian.net/browse/PM-34199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ