### PR TITLE
[PM-32096] Collection name style fix

### DIFF
--- a/apps/web/src/app/vault/components/vault-items/vault-collection-row.component.html
+++ b/apps/web/src/app/vault/components/vault-items/vault-collection-row.component.html
@@ -27,7 +27,7 @@
       bitLink
       [disabled]="disabled"
       type="button"
-      class="tw-flex tw-text-start tw-leading-snug tw-truncate"
+      class="tw-flex tw-text-start tw-leading-snug tw-max-w-56"
       linkType="secondary"
       title="{{ 'viewCollectionWithName' | i18n: collection.name }}"
       [routerLink]="[]"
@@ -35,17 +35,17 @@
       queryParamsHandling="merge"
       appStopProp
     >
-      <span class="tw-truncate tw-mr-1">{{ collection.name }}</span>
+      <div class="tw-truncate tw-mr-1 tw-max-w-56">{{ collection.name }}</div>
     </button>
     @if (showAddAccess) {
-      <button
+      <span
         bitBadge
-        type="button"
+        role="button"
         (click)="addAccess(CollectionPermission.Manage)"
         variant="warning"
       >
         {{ "addAccess" | i18n }}
-      </button>
+      </span>
     }
   </div>
 </td>

--- a/apps/web/src/app/vault/components/vault-items/vault-collection-row.component.html
+++ b/apps/web/src/app/vault/components/vault-items/vault-collection-row.component.html
@@ -43,6 +43,7 @@
         role="button"
         (click)="addAccess(CollectionPermission.Manage)"
         variant="warning"
+        class="tw-cursor-pointer"
       >
         {{ "addAccess" | i18n }}
       </span>


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-32096
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
Fixes the styling for collection names and add access button
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots
Main:
<img width="824" height="424" alt="Screenshot 2026-03-27 at 10 19 34 AM" src="https://github.com/user-attachments/assets/17caad13-ebce-40f4-a4bd-4dfc4fd0aed4" />

Fixed:
<img width="830" height="429" alt="Screenshot 2026-03-27 at 10 20 11 AM" src="https://github.com/user-attachments/assets/83a65240-e225-4d7a-803c-0a13f98bdf22" />


<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
