### PR TITLE
[CL-941] Remove router focus flag from client

### DIFF
--- a/libs/common/src/enums/feature-flag.enum.ts
+++ b/libs/common/src/enums/feature-flag.enum.ts
@@ -89,9 +89,6 @@ export enum FeatureFlag {
   /* Desktop */
   DesktopUiMigrationMilestone3 = "desktop-ui-migration-milestone-3",
   DesktopUiMigrationMilestone4 = "desktop-ui-migration-milestone-4",
-
-  /* UIF */
-  RouterFocusManagement = "router-focus-management",
 }
 
 export type AllowedFeatureFlagTypes = boolean | number | string;
@@ -187,9 +184,6 @@ export const DefaultFeatureFlagValue = {
   /* Desktop */
   [FeatureFlag.DesktopUiMigrationMilestone3]: FALSE,
   [FeatureFlag.DesktopUiMigrationMilestone4]: FALSE,
-
-  /* UIF */
-  [FeatureFlag.RouterFocusManagement]: FALSE,
 } satisfies Record<FeatureFlag, AllowedFeatureFlagTypes>;
 
 export type DefaultFeatureFlagValueType = typeof DefaultFeatureFlagValue;

--- a/libs/components/src/a11y/router-focus-manager.service.spec.ts
+++ b/libs/components/src/a11y/router-focus-manager.service.spec.ts
@@ -10,10 +10,7 @@ import {
 import { TestBed } from "@angular/core/testing";
 import { Event, Navigation, NavigationEnd, Router } from "@angular/router";
 import { mock } from "jest-mock-extended";
-import { BehaviorSubject, Subject } from "rxjs";
-
-import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
-import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
+import { Subject } from "rxjs";
 
 import { RouterFocusManagerService } from "./router-focus-manager.service";
 
@@ -55,26 +52,13 @@ describe("RouterFocusManagerService", () => {
   }
 
   let service: RouterFocusManagerService;
-  let featureFlagSubject: BehaviorSubject<boolean>;
   let mockRouter: MockRouter;
-  let mockConfigService: Partial<ConfigService>;
   let mockNgZoneRef: MockNgZone;
 
   let querySelectorSpy: jest.SpyInstance;
   let consoleWarnSpy: jest.SpyInstance;
 
   beforeEach(() => {
-    // Mock ConfigService
-    featureFlagSubject = new BehaviorSubject<boolean>(true);
-    mockConfigService = {
-      getFeatureFlag$: jest.fn((flag: FeatureFlag) => {
-        if (flag === FeatureFlag.RouterFocusManagement) {
-          return featureFlagSubject.asObservable();
-        }
-        return new BehaviorSubject(false).asObservable();
-      }) as ConfigService["getFeatureFlag$"],
-    };
-
     // Spy on document.querySelector and console.warn
     querySelectorSpy = jest.spyOn(document, "querySelector");
     consoleWarnSpy = jest.spyOn(console, "warn").mockImplementation();
@@ -83,7 +67,6 @@ describe("RouterFocusManagerService", () => {
       providers: [
         RouterFocusManagerService,
         { provide: Router, useClass: MockRouter },
-        { provide: ConfigService, useValue: mockConfigService },
         { provide: NgZone, useClass: MockNgZone },
         { provide: DestroyRef, useValue: { onDestroy: jest.fn() } },
       ],
@@ -183,51 +166,6 @@ describe("RouterFocusManagerService", () => {
       expect(consoleWarnSpy).toHaveBeenCalledWith(
         'RouterFocusManager: Could not find element with selector "#non-existent"',
       );
-    });
-  });
-
-  // Remove describe block when FeatureFlag.RouterFocusManagement is removed
-  describe("feature flag", () => {
-    it("should not activate when RouterFocusManagement flag is disabled", () => {
-      const mainElement = document.createElement("main");
-      mainElement.focus = jest.fn();
-      querySelectorSpy.mockReturnValue(mainElement);
-
-      // Disable feature flag
-      featureFlagSubject.next(false);
-
-      // Subscribe to start the service
-      service.start$.subscribe();
-
-      // Emit first navigation (should be skipped)
-      mockRouter.routerEventsSubject.next(new NavigationEnd(1, "/first", "/first"));
-
-      // Emit second navigation with flag disabled
-      mockRouter.routerEventsSubject.next(new NavigationEnd(2, "/test", "/test"));
-
-      expect(querySelectorSpy).not.toHaveBeenCalled();
-      expect(mainElement.focus).not.toHaveBeenCalled();
-    });
-
-    it("should activate when RouterFocusManagement flag is enabled", () => {
-      const mainElement = document.createElement("main");
-      mainElement.focus = jest.fn();
-      querySelectorSpy.mockReturnValue(mainElement);
-
-      // Ensure feature flag is enabled
-      featureFlagSubject.next(true);
-
-      // Subscribe to start the service
-      service.start$.subscribe();
-
-      // Emit first navigation (should be skipped)
-      mockRouter.routerEventsSubject.next(new NavigationEnd(1, "/first", "/first"));
-
-      // Emit second navigation with flag enabled
-      mockRouter.routerEventsSubject.next(new NavigationEnd(2, "/test", "/test"));
-
-      expect(querySelectorSpy).toHaveBeenCalledWith("main");
-      expect(mainElement.focus).toHaveBeenCalled();
     });
   });
 

--- a/libs/components/src/a11y/router-focus-manager.service.ts
+++ b/libs/components/src/a11y/router-focus-manager.service.ts
@@ -1,10 +1,7 @@
 import { inject, Injectable, NgZone } from "@angular/core";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { NavigationEnd, Router } from "@angular/router";
-import { skip, filter, combineLatestWith, tap, map, firstValueFrom } from "rxjs";
-
-import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
-import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
+import { skip, filter, tap, map, firstValueFrom } from "rxjs";
 
 import { queryForAutofocusDescendents } from "../input";
 
@@ -12,8 +9,6 @@ import { queryForAutofocusDescendents } from "../input";
 export class RouterFocusManagerService {
   private router = inject(Router);
   private ngZone = inject(NgZone);
-
-  private configService = inject(ConfigService);
 
   /**
    * See associated router-focus-manager.mdx page for documentation on what this pipeline does and
@@ -27,8 +22,6 @@ export class RouterFocusManagerService {
      * so we opt out of the default focus management behavior.
      */
     skip(1),
-    combineLatestWith(this.configService.getFeatureFlag$(FeatureFlag.RouterFocusManagement)),
-    filter(([_navEvent, flagEnabled]) => flagEnabled),
     map(() => {
       const currentNavExtras = this.router.currentNavigation()?.extras;
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[CL-941](https://bitwarden.atlassian.net/browse/CL-941)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Begin removal of router focus management feature flag by removing clientside usage.


[CL-941]: https://bitwarden.atlassian.net/browse/CL-941?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ