### PR TITLE
[PM-30190] Add validator for revoked emails when inviting users

### DIFF
--- a/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.ts
+++ b/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.ts
@@ -50,6 +50,7 @@ import {
   OrganizationUserAdminView,
   UserAdminService,
 } from "../../../core";
+import { OrganizationUserView } from "../../../core/views/organization-user.view";
 import {
   AccessItemType,
   AccessItemValue,
@@ -63,6 +64,7 @@ import { DeleteManagedMemberWarningService } from "../../services/delete-managed
 import { commaSeparatedEmails } from "./validators/comma-separated-emails.validator";
 import { inputEmailLimitValidator } from "./validators/input-email-limit.validator";
 import { orgSeatLimitReachedValidator } from "./validators/org-seat-limit-reached.validator";
+import { revokedEmailsValidator } from "./validators/revoked-emails.validator";
 
 // FIXME: update to use a const object instead of a typescript enum
 // eslint-disable-next-line @bitwarden/platform/no-enums
@@ -81,6 +83,7 @@ export interface AddMemberDialogParams extends CommonMemberDialogParams {
   kind: "Add";
   occupiedSeatCount: number;
   allOrganizationUserEmails: string[];
+  allOrganizationUsers: OrganizationUserView[];
 }
 
 export interface EditMemberDialogParams extends CommonMemberDialogParams {
@@ -350,6 +353,10 @@ export class MemberDialogComponent implements OnDestroy {
       commaSeparatedEmails,
       inputEmailLimitValidator(organization, (maxEmailsCount: number) =>
         this.i18nService.t("tooManyEmails", maxEmailsCount),
+      ),
+      revokedEmailsValidator(
+        this.params.allOrganizationUsers,
+        this.i18nService.t("revokedEmailError"),
       ),
       orgSeatLimitReachedValidator(
         organization,

--- a/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.ts
+++ b/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.ts
@@ -82,7 +82,6 @@ interface CommonMemberDialogParams {
 export interface AddMemberDialogParams extends CommonMemberDialogParams {
   kind: "Add";
   occupiedSeatCount: number;
-  allOrganizationUserEmails: string[];
   allOrganizationUsers: OrganizationUserView[];
 }
 
@@ -360,7 +359,7 @@ export class MemberDialogComponent implements OnDestroy {
       ),
       orgSeatLimitReachedValidator(
         organization,
-        this.params.allOrganizationUserEmails,
+        this.params.allOrganizationUsers.map((u) => u.email),
         this.i18nService.t("subscriptionUpgrade", organization.seats),
         this.params.occupiedSeatCount,
       ),

--- a/apps/web/src/app/admin-console/organizations/members/components/member-dialog/validators/revoked-emails.validator.spec.ts
+++ b/apps/web/src/app/admin-console/organizations/members/components/member-dialog/validators/revoked-emails.validator.spec.ts
@@ -1,0 +1,69 @@
+import { FormControl } from "@angular/forms";
+
+import { OrganizationUserStatusType } from "@bitwarden/common/admin-console/enums";
+
+import { OrganizationUserView } from "../../../../core/views/organization-user.view";
+
+import { revokedEmailsValidator } from "./revoked-emails.validator";
+
+const userFactory = (props: Partial<OrganizationUserView> = {}) =>
+  Object.assign(
+    new OrganizationUserView(),
+    { status: OrganizationUserStatusType.Confirmed },
+    props,
+  );
+
+const errorMessage =
+  "1 or more emails belong to revoked members. Restore their access to reinvite.";
+
+const revokedUser = userFactory({
+  email: "revoked@example.com",
+  status: OrganizationUserStatusType.Revoked,
+});
+const activeUser = userFactory({
+  email: "active@example.com",
+  status: OrganizationUserStatusType.Confirmed,
+});
+
+const validate = (users: OrganizationUserView[], value: string | null) =>
+  revokedEmailsValidator(users, errorMessage)(new FormControl(value));
+
+describe("revokedEmailsValidator", () => {
+  it.each(["", null, "  "])("returns null for empty/blank input %p", (value) => {
+    expect(validate([revokedUser], value)).toBeNull();
+  });
+
+  it("returns null when no revoked users exist", () => {
+    expect(validate([activeUser], "active@example.com")).toBeNull();
+  });
+
+  it("returns null when revoked user email is not in the input", () => {
+    expect(validate([revokedUser], "other@example.com")).toBeNull();
+  });
+
+  it("returns null when comma-separated input contains no revoked emails", () => {
+    expect(validate([activeUser, revokedUser], "active@example.com, new@example.com")).toBeNull();
+  });
+
+  it("returns error when input matches a revoked user email", () => {
+    expect(validate([revokedUser], "revoked@example.com")).toEqual({
+      revokedEmails: { message: errorMessage },
+    });
+  });
+
+  it("returns error for case-insensitive match", () => {
+    const uppercaseRevoked = userFactory({
+      email: "Revoked@Example.COM",
+      status: OrganizationUserStatusType.Revoked,
+    });
+    expect(validate([uppercaseRevoked], "revoked@example.com")).toEqual({
+      revokedEmails: { message: errorMessage },
+    });
+  });
+
+  it("returns error when any email in a comma-separated list is revoked", () => {
+    expect(validate([activeUser, revokedUser], "active@example.com, revoked@example.com")).toEqual({
+      revokedEmails: { message: errorMessage },
+    });
+  });
+});

--- a/apps/web/src/app/admin-console/organizations/members/components/member-dialog/validators/revoked-emails.validator.ts
+++ b/apps/web/src/app/admin-console/organizations/members/components/member-dialog/validators/revoked-emails.validator.ts
@@ -1,0 +1,35 @@
+import { AbstractControl, ValidationErrors, ValidatorFn } from "@angular/forms";
+
+import { OrganizationUserStatusType } from "@bitwarden/common/admin-console/enums";
+
+import { OrganizationUserView } from "../../../../core/views/organization-user.view";
+
+/**
+ * Checks if any of the entered emails belong to members in a revoked status
+ * @param allOrganizationUsers An array of existing organization users
+ * @param errorMessage A localized string to display if validation fails
+ * @returns A function that validates an `AbstractControl` and returns `ValidationErrors` or `null`
+ */
+export function revokedEmailsValidator(
+  allOrganizationUsers: OrganizationUserView[],
+  errorMessage: string,
+): ValidatorFn {
+  return (control: AbstractControl): ValidationErrors | null => {
+    if (!control.value?.trim()) {
+      return null;
+    }
+
+    const inputEmails: string[] = control.value
+      .split(",")
+      .map((e: string) => e.trim())
+      .filter(Boolean);
+
+    const revokedEmails = allOrganizationUsers
+      .filter((u) => u.status === OrganizationUserStatusType.Revoked)
+      .map((u) => u.email.toLowerCase());
+
+    const hasRevoked = inputEmails.some((email) => revokedEmails.includes(email.toLowerCase()));
+
+    return hasRevoked ? { revokedEmails: { message: errorMessage } } : null;
+  };
+}

--- a/apps/web/src/app/admin-console/organizations/members/members.component.ts
+++ b/apps/web/src/app/admin-console/organizations/members/members.component.ts
@@ -324,12 +324,12 @@ export class MembersComponent {
       return;
     }
 
-    const allUserEmails = this.dataSource().data?.map((user) => user.email) ?? [];
+    const allUsers = this.dataSource().data ?? [];
 
     const result = await this.memberDialogManager.openInviteDialog(
       organization,
       billingMetadata,
-      allUserEmails,
+      allUsers,
     );
 
     if (result === MemberDialogResult.Saved) {

--- a/apps/web/src/app/admin-console/organizations/members/services/member-dialog-manager/member-dialog-manager.service.spec.ts
+++ b/apps/web/src/app/admin-console/organizations/members/services/member-dialog-manager/member-dialog-manager.service.spec.ts
@@ -85,12 +85,15 @@ describe("MemberDialogManagerService", () => {
       const mockDialogRef = { closed: of(MemberDialogResult.Saved) };
       dialogService.open.mockReturnValue(mockDialogRef as any);
 
-      const allUserEmails = ["user1@example.com", "user2@example.com"];
+      const allUsers = [
+        { email: "user1@example.com" } as OrganizationUserView,
+        { email: "user2@example.com" } as OrganizationUserView,
+      ];
 
       const result = await service.openInviteDialog(
         mockOrganization,
         mockBillingMetadata,
-        allUserEmails,
+        allUsers,
       );
 
       expect(dialogService.open).toHaveBeenCalledWith(
@@ -99,7 +102,7 @@ describe("MemberDialogManagerService", () => {
           data: {
             kind: "Add",
             organizationId: mockOrganization.id,
-            allOrganizationUserEmails: allUserEmails,
+            allOrganizationUsers: allUsers,
             occupiedSeatCount: 10,
             isOnSecretsManagerStandalone: false,
           },

--- a/apps/web/src/app/admin-console/organizations/members/services/member-dialog-manager/member-dialog-manager.service.ts
+++ b/apps/web/src/app/admin-console/organizations/members/services/member-dialog-manager/member-dialog-manager.service.ts
@@ -52,7 +52,6 @@ export class MemberDialogManagerService {
       data: {
         kind: "Add",
         organizationId: organization.id,
-        allOrganizationUserEmails: allUsers.map((u) => u.email),
         allOrganizationUsers: allUsers,
         occupiedSeatCount: billingMetadata?.organizationOccupiedSeats ?? 0,
         isOnSecretsManagerStandalone: billingMetadata?.isOnSecretsManagerStandalone ?? false,

--- a/apps/web/src/app/admin-console/organizations/members/services/member-dialog-manager/member-dialog-manager.service.ts
+++ b/apps/web/src/app/admin-console/organizations/members/services/member-dialog-manager/member-dialog-manager.service.ts
@@ -46,13 +46,14 @@ export class MemberDialogManagerService {
   async openInviteDialog(
     organization: Organization,
     billingMetadata: OrganizationBillingMetadataResponse,
-    allUserEmails: string[],
+    allUsers: OrganizationUserView[],
   ): Promise<MemberDialogResult> {
     const dialog = openUserAddEditDialog(this.dialogService, {
       data: {
         kind: "Add",
         organizationId: organization.id,
-        allOrganizationUserEmails: allUserEmails,
+        allOrganizationUserEmails: allUsers.map((u) => u.email),
+        allOrganizationUsers: allUsers,
         occupiedSeatCount: billingMetadata?.organizationOccupiedSeats ?? 0,
         isOnSecretsManagerStandalone: billingMetadata?.isOnSecretsManagerStandalone ?? false,
       },

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -4292,6 +4292,9 @@
       }
     }
   },
+  "revokedEmailError": {
+    "message": "1 or more emails belong to revoked members. Restore their access to reinvite."
+  },
   "restoredUserId": {
     "message": "Restored organization access for $ID$.",
     "placeholders": {


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-30190
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
Adds form validation to prevent manually inviting revoked users and showing an incorrect success dialog when no invite was sent.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
