### PR TITLE
[PM-34192] Adds null check for startingSelection when setting default...

### DIFF
--- a/libs/vault/src/cipher-form/components/item-details/item-details-section.component.ts
+++ b/libs/vault/src/cipher-form/components/item-details/item-details-section.component.ts
@@ -239,7 +239,7 @@ export class ItemDetailsSectionComponent implements OnInit {
         collectionIds: [],
         favorite: false,
       });
-      await this.updateCollectionOptions(this.initialValues?.collectionIds);
+      await this.updateCollectionOptions(this.initialValues?.collectionIds ?? []);
     }
 
     this.setFormState();
@@ -473,7 +473,7 @@ export class ItemDetailsSectionComponent implements OnInit {
       return;
     }
 
-    if (startingSelection.filter(Boolean).length > 0) {
+    if (startingSelection?.filter(Boolean).length > 0) {
       collectionsControl.setValue(
         this.collectionOptions.filter((c) => startingSelection.includes(c.id as CollectionId)),
       );


### PR DESCRIPTION
… collection (#19793)

(cherry picked from commit 9f17ef313ec1a274895b05d9e3b526b952a970be)

## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-34192

## 📔 Objective

Fix default collection autopopulation when creating a new cipher.