### PR TITLE
[CL-1140] BUG FIX: desktop nav group anchor link color and cipher name styles

### DIFF
--- a/apps/desktop/src/vault/app/vault-v3/vault-items/vault-cipher-row.component.html
+++ b/apps/desktop/src/vault/app/vault-v3/vault-items/vault-cipher-row.component.html
@@ -9,7 +9,6 @@
         (click)="viewCipher()"
         title="{{ 'editItemWithName' | i18n: cipher().name }}"
         type="button"
-        appStopProp
         aria-haspopup="true"
       >
         {{ cipher().name }}
@@ -17,7 +16,6 @@
       @if (hasAttachments()) {
         <i
           class="bwi bwi-paperclip tw-ml-2 tw-leading-normal"
-          appStopProp
           title="{{ 'attachments' | i18n }}"
           aria-hidden="true"
         ></i>
@@ -25,7 +23,6 @@
         @if (showFixOldAttachments()) {
           <i
             class="bwi bwi-exclamation-triangle tw-ml-2 tw-leading-normal tw-text-warning"
-            appStopProp
             title="{{ 'attachmentsNeedFix' | i18n }}"
             aria-hidden="true"
           ></i>
@@ -34,7 +31,7 @@
       }
     </div>
     <br />
-    <span class="tw-text-sm tw-text-muted" appStopProp>{{ subtitle() }}</span>
+    <span class="tw-text-sm tw-text-muted">{{ subtitle() }}</span>
   </div>
 </td>
 @if (showOwner()) {
@@ -43,7 +40,6 @@
       [disabled]="disabled()"
       [organizationId]="cipher().organizationId"
       [organizationName]="cipher().organizationId | orgNameFromId: organizations()"
-      appStopProp
     >
     </app-org-badge>
   </td>
@@ -57,7 +53,6 @@
       bitIconButton="bwi-ellipsis-v"
       type="button"
       label="{{ 'options' | i18n }}"
-      appStopProp
     ></button>
     <bit-menu #corruptedCipherOptions>
       @if (canDeleteCipher()) {
@@ -75,7 +70,6 @@
         [disabled]="disabled()"
         bitIconButton="bwi-external-link"
         type="button"
-        appStopProp
         label="{{ 'launch' | i18n }}"
         (click)="handleLaunch()"
       ></button>
@@ -86,7 +80,6 @@
         [disabled]="disabled()"
         bitIconButton="bwi-clone"
         type="button"
-        appStopProp
         label="{{ 'copyValue' | i18n }}"
       ></button>
       <bit-menu #copyOptions>
@@ -104,7 +97,6 @@
       [disabled]="disabled()"
       bitIconButton="bwi-ellipsis-v"
       type="button"
-      appStopProp
       label="{{ 'options' | i18n }}"
     ></button>
     <bit-menu #cipherOptions>

--- a/apps/desktop/src/vault/app/vault-v3/vault-items/vault-cipher-row.component.ts
+++ b/apps/desktop/src/vault/app/vault-v3/vault-items/vault-cipher-row.component.ts
@@ -19,6 +19,7 @@ import {
   MenuTriggerForDirective,
   TooltipDirective,
   TableModule,
+  LinkModule,
 } from "@bitwarden/components";
 import { I18nPipe } from "@bitwarden/ui-common";
 import {
@@ -54,6 +55,7 @@ interface CopyFieldConfig {
     PremiumBadgeComponent,
     GetOrgNameFromIdPipe,
     IconComponent,
+    LinkModule,
   ],
 })
 export class VaultCipherRowComponent<C extends CipherViewLike> {

--- a/apps/desktop/src/vault/app/vault-v3/vault-items/vault-collection-row.component.html
+++ b/apps/desktop/src/vault/app/vault-v3/vault-items/vault-collection-row.component.html
@@ -20,7 +20,6 @@
       [routerLink]="[]"
       [queryParams]="{ collectionId: collection().id }"
       queryParamsHandling="merge"
-      appStopProp
     >
       <span class="tw-truncate tw-mr-1">{{ collection().name }}</span>
     </button>
@@ -32,7 +31,6 @@
       [disabled]="disabled()"
       [organizationId]="collection().organizationId"
       [organizationName]="collection().organizationId | orgNameFromId: organizations()"
-      appStopProp
     >
     </app-org-badge>
   </td>

--- a/apps/desktop/src/vault/app/vault-v3/vault-items/vault-collection-row.component.ts
+++ b/apps/desktop/src/vault/app/vault-v3/vault-items/vault-collection-row.component.ts
@@ -9,7 +9,7 @@ import {
   CollectionTypes,
 } from "@bitwarden/common/admin-console/models/collections";
 import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
-import { TableModule } from "@bitwarden/components";
+import { LinkModule, TableModule } from "@bitwarden/components";
 import { I18nPipe } from "@bitwarden/ui-common";
 import { GetOrgNameFromIdPipe, OrganizationNameBadgeComponent } from "@bitwarden/vault";
 
@@ -20,6 +20,7 @@ import { GetOrgNameFromIdPipe, OrganizationNameBadgeComponent } from "@bitwarden
   templateUrl: "vault-collection-row.component.html",
   imports: [
     TableModule,
+    LinkModule,
     NgClass,
     I18nPipe,
     RouterLink,

--- a/libs/components/src/navigation/nav-item.component.html
+++ b/libs/components/src/navigation/nav-item.component.html
@@ -1,6 +1,6 @@
 @let open = sideNavService.open();
 @let containerClasses =
-  "tw-size-full tw-px-0 tw-block tw-truncate tw-border-none tw-text-start hover:tw-no-underline focus:tw-outline-none [&_i]:tw-leading-[1.5rem]";
+  "tw-size-full tw-px-0 tw-block tw-truncate tw-border-none !tw-text-fg-nav tw-text-start hover:tw-no-underline focus:tw-outline-none [&_i]:tw-leading-[1.5rem]";
 
 <div class="tw-cursor-pointer tw-ps-3 tw-pe-3">
   @if (open || icon()) {


### PR DESCRIPTION
## 🎟️ Tracking

[JIRA](https://bitwarden.atlassian.net/browse/CL-1140?atlOrigin=eyJpIjoiYmJkZDA0YTNhMmRhNDJhOTg5MTQ1OWQ0N2ZkYTAwOTciLCJwIjoiaiJ9)

## 📔 Objective

Fixed desktop nav group anchor link color
- Set nav item text color to `!important` to prevent overrides

Fixed desktop cipher name styles
- Added missing `LinkModule` import to `vault-cipher-row` and `vault-collection-row` to apply `bitLink` styles
- `StopPropDirective` was also missing from the standalone `vault-cipher-row` and `vault-collection-row`, but since this is from the deprecated `JsLibModule`, we should remove `appStopProp` attributes instead since there are no click handlers in parent elements

## 📸 Screenshots

(Before)
<img width="260" height="121" alt="image (5)" src="https://github.com/user-attachments/assets/af6fda7b-4b68-451a-bcf3-144ad50e5b93" />
(After)
<img width="284" height="105" alt="Screenshot 2026-03-27 at 1 15 35 PM" src="https://github.com/user-attachments/assets/c6007dc4-96fd-415f-b255-c307d0350be9" />

(Before)
<img width="490" height="574" alt="Screenshot 2026-03-27 at 1 17 15 PM" src="https://github.com/user-attachments/assets/817966f3-5aff-45d5-b3ca-66cb733156ce" />
(After)
<img width="491" height="571" alt="Screenshot 2026-03-27 at 1 16 28 PM" src="https://github.com/user-attachments/assets/d02f0d42-538f-4b07-814c-d5916f8d787a" />