### PR TITLE
Magnify: handle lock/logout/account switch

### DIFF
--- a/apps/desktop/src/app/services/services.module.ts
+++ b/apps/desktop/src/app/services/services.module.ts
@@ -538,7 +538,7 @@ const safeProviders: SafeProvider[] = [
   }),
   safeProvider({
     provide: DesktopMagnifyService,
-    deps: [ActiveUserStateProvider],
+    deps: [ActiveUserStateProvider, AuthService],
   }),
   safeProvider({
     provide: DesktopAutotypeDefaultSettingPolicy,

--- a/apps/desktop/src/autofill/main/main-desktop-magnify.service.ts
+++ b/apps/desktop/src/autofill/main/main-desktop-magnify.service.ts
@@ -44,6 +44,11 @@ export class MainDesktopMagnifyService {
     ipcMain.handle(MAGNIFY_IPC_CHANNELS.MAGNIFY_COMMAND, (event, command) =>
       this.commandHandler(event, command),
     );
+
+    // Close the magnify window if the main BW window is closed
+    this.windowMain.win.on("closed", () => {
+      this.magnifyWindow?.close();
+    });
   }
 
   // Deregister the keyboard shortcut if registered.

--- a/apps/desktop/src/autofill/services/desktop-magnify.service.ts
+++ b/apps/desktop/src/autofill/services/desktop-magnify.service.ts
@@ -1,6 +1,17 @@
 import { Injectable, OnDestroy } from "@angular/core";
-import { concatMap, distinctUntilChanged, map, Observable, of, Subject, takeUntil } from "rxjs";
+import {
+  combineLatest,
+  concatMap,
+  distinctUntilChanged,
+  map,
+  Observable,
+  of,
+  Subject,
+  takeUntil,
+} from "rxjs";
 
+import { AuthService } from "@bitwarden/common/auth/abstractions/auth.service";
+import { AuthenticationStatus } from "@bitwarden/common/auth/enums/authentication-status";
 import {
   ActiveUserStateProvider,
   MAGNIFY_SETTINGS_DISK,
@@ -29,18 +40,36 @@ export class DesktopMagnifyService implements OnDestroy {
   // The enabled/disabled state from the user settings menu
   magnifyEnabledUserSetting$: Observable<boolean> = of(false);
 
+  // Magnify is only active when the user has the setting enabled and the vault is unlocked
+  private magnifyFeatureEnabled$: Observable<boolean> = of(false);
+
   private destroy$ = new Subject<void>();
 
-  constructor(private activeUserStateProvider: ActiveUserStateProvider) {
+  constructor(
+    private activeUserStateProvider: ActiveUserStateProvider,
+    private authService: AuthService,
+  ) {
     this.magnifyEnabledUserSetting$ = this.magnifyEnabledState.state$.pipe(
       map((enabled) => enabled ?? false),
-      distinctUntilChanged(), // Only emit when the boolean result changes
+      distinctUntilChanged(),
+      takeUntil(this.destroy$),
+    );
+
+    this.magnifyFeatureEnabled$ = combineLatest([
+      this.magnifyEnabledUserSetting$,
+      this.authService.activeAccountStatus$,
+    ]).pipe(
+      map(
+        ([settingEnabled, authStatus]) =>
+          settingEnabled && authStatus === AuthenticationStatus.Unlocked,
+      ),
+      distinctUntilChanged(),
       takeUntil(this.destroy$),
     );
   }
 
   async init() {
-    this.magnifyEnabledUserSetting$
+    this.magnifyFeatureEnabled$
       .pipe(
         concatMap(async (enabled) => {
           ipc.autofill.toggleMagnify(enabled);


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

with this change the magnify is not activated when:
- vault is locked
- user logs out
- account is switched and new account does not have feature enabled

additionally, it fixes an issue where you could close the main app window and still have the magnify window open

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
