### PR TITLE
[PM-30311] focus management creation in effect to account for async menu item changes

### DIFF
--- a/libs/components/src/menu/menu.component.ts
+++ b/libs/components/src/menu/menu.component.ts
@@ -4,7 +4,7 @@ import {
   Output,
   TemplateRef,
   EventEmitter,
-  AfterContentInit,
+  effect,
   input,
   viewChild,
   contentChildren,
@@ -20,7 +20,7 @@ import { MenuItemComponent } from "./menu-item.component";
   exportAs: "menuComponent",
   imports: [CdkTrapFocus],
 })
-export class MenuComponent implements AfterContentInit {
+export class MenuComponent {
   readonly templateRef = viewChild.required(TemplateRef);
   // FIXME(https://bitwarden.atlassian.net/browse/CL-903): Migrate to Signals
   // eslint-disable-next-line @angular-eslint/prefer-output-emitter-ref
@@ -32,11 +32,13 @@ export class MenuComponent implements AfterContentInit {
 
   readonly ariaLabel = input<string>();
 
-  ngAfterContentInit() {
-    if (this.ariaRole() === "menu") {
-      this.keyManager = new FocusKeyManager(this.menuItems())
-        .withWrap()
-        .skipPredicate((item) => !!item.disabled);
-    }
+  constructor() {
+    effect(() => {
+      if (this.ariaRole() === "menu") {
+        this.keyManager = new FocusKeyManager(this.menuItems())
+          .withWrap()
+          .skipPredicate((item) => !!item.disabled);
+      }
+    });
   }
 }


### PR DESCRIPTION

## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-30311

## 📔 Objective

The bug: MenuComponent.ngAfterContentInit() creates the FocusKeyManager with a static snapshot of this.menuItems(). At that moment, the @for (menuItem of cipherMenuItems$ | async; ...) loop hasn't resolved yet, so the only MenuItemComponent in the DOM is the folder button. The FocusKeyManager never learns about the cipher items added later.

When the menu opens and menu-trigger-for.directive.ts:146 calls menu.keyManager.setFirstItemActive(), the key manager only knows one item — the folder button — and focuses it.

The fix is in [menu.component.ts:35-41](vscode-webview://03fut6vedkt0fc6v7vt3c3bf3adagcqnqrdf03nlsimgu89je00j/libs/components/src/menu/menu.component.ts#L35-L41): replace ngAfterContentInit with an Angular effect() so the FocusKeyManager is recreated reactively whenever the menuItems() signal changes:

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
