### PR TITLE
[PM-33928] Fix: Can view MyItems Passwords in Org Vault Health Reports

### DIFF
--- a/apps/web/src/app/dirt/reports/pages/organizations/exposed-passwords-report.component.ts
+++ b/apps/web/src/app/dirt/reports/pages/organizations/exposed-passwords-report.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from "@angular/core";
 import { ActivatedRoute } from "@angular/router";
 import { firstValueFrom, takeUntil, tap } from "rxjs";
 
+import { CollectionService } from "@bitwarden/admin-console/common";
 import { AuditService } from "@bitwarden/common/abstractions/audit.service";
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
@@ -10,7 +11,6 @@ import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.servic
 import { getById } from "@bitwarden/common/platform/misc";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.service.abstraction";
-import { Cipher } from "@bitwarden/common/vault/models/domain/cipher";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { CipherViewLikeUtils } from "@bitwarden/common/vault/utils/cipher-view-like-utils";
 import { BerryComponent, ChipFilterComponent, DialogService } from "@bitwarden/components";
@@ -55,7 +55,8 @@ export class ExposedPasswordsReportComponent
   extends BaseExposedPasswordsReportComponent
   implements OnInit
 {
-  private manageableCiphers: Cipher[] = [];
+  private manageableCipherIds = new Set<string>();
+  private sharedCollectionIds = new Set<string>();
 
   constructor(
     cipherService: CipherService,
@@ -69,6 +70,7 @@ export class ExposedPasswordsReportComponent
     syncService: SyncService,
     cipherFormService: CipherFormConfigService,
     adminConsoleCipherFormConfigService: AdminConsoleCipherFormConfigService,
+    private collectionService: CollectionService,
   ) {
     super(
       cipherService,
@@ -93,7 +95,17 @@ export class ExposedPasswordsReportComponent
           this.organization = await firstValueFrom(
             this.organizationService.organizations$(userId).pipe(getById(params.organizationId)),
           );
-          this.manageableCiphers = await this.cipherService.getAll(userId);
+          const manageableCiphers = await this.cipherService.getAll(userId);
+          this.manageableCipherIds = new Set(manageableCiphers.map((c) => c.id as string));
+          const collections = await firstValueFrom(
+            this.collectionService.decryptedCollections$(userId),
+          );
+          this.sharedCollectionIds = new Set(
+            collections
+              .filter((c) => !c.isDefaultCollection && c.organizationId === this.organization?.id)
+              .map((c) => c.id as string),
+          );
+          await super.ngOnInit();
         }),
         takeUntil(this.destroyed$),
       )
@@ -108,12 +120,15 @@ export class ExposedPasswordsReportComponent
   }
 
   canManageCipher(c: CipherView): boolean {
-    if (CipherViewLikeUtils.isUnassigned(c)) {
+    if (
+      CipherViewLikeUtils.isUnassigned(c) ||
+      !c.collectionIds?.some((id) => this.sharedCollectionIds.has(id))
+    ) {
       return false;
     }
     if (this.organization?.allowAdminAccessToAllCollectionItems) {
       return true;
     }
-    return this.manageableCiphers.some((x) => x.id === c.id);
+    return this.manageableCipherIds.has(c.id);
   }
 }

--- a/apps/web/src/app/dirt/reports/pages/organizations/exposed-passwords-report.component.ts
+++ b/apps/web/src/app/dirt/reports/pages/organizations/exposed-passwords-report.component.ts
@@ -12,6 +12,7 @@ import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.servi
 import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.service.abstraction";
 import { Cipher } from "@bitwarden/common/vault/models/domain/cipher";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+import { CipherViewLikeUtils } from "@bitwarden/common/vault/utils/cipher-view-like-utils";
 import { BerryComponent, ChipFilterComponent, DialogService } from "@bitwarden/components";
 import {
   PasswordRepromptService,
@@ -107,8 +108,8 @@ export class ExposedPasswordsReportComponent
   }
 
   canManageCipher(c: CipherView): boolean {
-    if (c.collectionIds.length === 0) {
-      return true;
+    if (CipherViewLikeUtils.isUnassigned(c)) {
+      return false;
     }
     if (this.organization?.allowAdminAccessToAllCollectionItems) {
       return true;

--- a/apps/web/src/app/dirt/reports/pages/organizations/exposed-passwords-report.component.ts
+++ b/apps/web/src/app/dirt/reports/pages/organizations/exposed-passwords-report.component.ts
@@ -96,7 +96,7 @@ export class ExposedPasswordsReportComponent
             this.organizationService.organizations$(userId).pipe(getById(params.organizationId)),
           );
           const manageableCiphers = await this.cipherService.getAll(userId);
-          this.manageableCipherIds = new Set(manageableCiphers.map((c) => c.id as string));
+          this.manageableCipherIds = new Set(manageableCiphers.map((c) => c.id));
           const collections = await firstValueFrom(
             this.collectionService.decryptedCollections$(userId),
           );

--- a/apps/web/src/app/dirt/reports/pages/organizations/inactive-two-factor-report.component.ts
+++ b/apps/web/src/app/dirt/reports/pages/organizations/inactive-two-factor-report.component.ts
@@ -4,6 +4,7 @@ import { ChangeDetectorRef, Component, OnInit, ChangeDetectionStrategy } from "@
 import { ActivatedRoute } from "@angular/router";
 import { firstValueFrom, takeUntil, tap } from "rxjs";
 
+import { CollectionService } from "@bitwarden/admin-console/common";
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { getUserId } from "@bitwarden/common/auth/services/account.service";
@@ -12,7 +13,6 @@ import { LogService } from "@bitwarden/common/platform/abstractions/log.service"
 import { getById } from "@bitwarden/common/platform/misc";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.service.abstraction";
-import { Cipher } from "@bitwarden/common/vault/models/domain/cipher";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { CipherViewLikeUtils } from "@bitwarden/common/vault/utils/cipher-view-like-utils";
 import {
@@ -62,8 +62,8 @@ export class InactiveTwoFactorReportComponent
   extends BaseInactiveTwoFactorReportComponent
   implements OnInit
 {
-  // Contains a list of ciphers, the user running the report, can manage
-  private manageableCiphers: Cipher[] = [];
+  private manageableCipherIds = new Set<string>();
+  private sharedCollectionIds = new Set<string>();
 
   constructor(
     cipherService: CipherService,
@@ -78,6 +78,7 @@ export class InactiveTwoFactorReportComponent
     cipherFormConfigService: CipherFormConfigService,
     adminConsoleCipherFormConfigService: AdminConsoleCipherFormConfigService,
     protected changeDetectorRef: ChangeDetectorRef,
+    private collectionService: CollectionService,
   ) {
     super(
       cipherService,
@@ -104,7 +105,16 @@ export class InactiveTwoFactorReportComponent
           this.organization = await firstValueFrom(
             this.organizationService.organizations$(userId).pipe(getById(params.organizationId)),
           );
-          this.manageableCiphers = await this.cipherService.getAll(userId);
+          const manageableCiphers = await this.cipherService.getAll(userId);
+          this.manageableCipherIds = new Set(manageableCiphers.map((c) => c.id as string));
+          const collections = await firstValueFrom(
+            this.collectionService.decryptedCollections$(userId),
+          );
+          this.sharedCollectionIds = new Set(
+            collections
+              .filter((c) => !c.isDefaultCollection && c.organizationId === this.organization?.id)
+              .map((c) => c.id as string),
+          );
           await super.ngOnInit();
           this.changeDetectorRef.markForCheck();
         }),
@@ -121,12 +131,15 @@ export class InactiveTwoFactorReportComponent
   }
 
   protected canManageCipher(c: CipherView): boolean {
-    if (CipherViewLikeUtils.isUnassigned(c)) {
+    if (
+      CipherViewLikeUtils.isUnassigned(c) ||
+      !c.collectionIds?.some((id) => this.sharedCollectionIds.has(id))
+    ) {
       return false;
     }
     if (this.organization?.allowAdminAccessToAllCollectionItems) {
       return true;
     }
-    return this.manageableCiphers.some((x) => x.id === c.id);
+    return this.manageableCipherIds.has(c.id);
   }
 }

--- a/apps/web/src/app/dirt/reports/pages/organizations/inactive-two-factor-report.component.ts
+++ b/apps/web/src/app/dirt/reports/pages/organizations/inactive-two-factor-report.component.ts
@@ -106,7 +106,7 @@ export class InactiveTwoFactorReportComponent
             this.organizationService.organizations$(userId).pipe(getById(params.organizationId)),
           );
           const manageableCiphers = await this.cipherService.getAll(userId);
-          this.manageableCipherIds = new Set(manageableCiphers.map((c) => c.id as string));
+          this.manageableCipherIds = new Set(manageableCiphers.map((c) => c.id));
           const collections = await firstValueFrom(
             this.collectionService.decryptedCollections$(userId),
           );

--- a/apps/web/src/app/dirt/reports/pages/organizations/inactive-two-factor-report.component.ts
+++ b/apps/web/src/app/dirt/reports/pages/organizations/inactive-two-factor-report.component.ts
@@ -14,6 +14,7 @@ import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.servi
 import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.service.abstraction";
 import { Cipher } from "@bitwarden/common/vault/models/domain/cipher";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+import { CipherViewLikeUtils } from "@bitwarden/common/vault/utils/cipher-view-like-utils";
 import {
   BerryComponent,
   ChipActionComponent,
@@ -120,8 +121,8 @@ export class InactiveTwoFactorReportComponent
   }
 
   protected canManageCipher(c: CipherView): boolean {
-    if (c.collectionIds.length === 0) {
-      return true;
+    if (CipherViewLikeUtils.isUnassigned(c)) {
+      return false;
     }
     if (this.organization?.allowAdminAccessToAllCollectionItems) {
       return true;

--- a/apps/web/src/app/dirt/reports/pages/organizations/reused-passwords-report.component.ts
+++ b/apps/web/src/app/dirt/reports/pages/organizations/reused-passwords-report.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from "@angular/core";
 import { ActivatedRoute } from "@angular/router";
 import { firstValueFrom, takeUntil, tap } from "rxjs";
 
+import { CollectionService } from "@bitwarden/admin-console/common";
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { getUserId } from "@bitwarden/common/auth/services/account.service";
@@ -9,7 +10,6 @@ import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.servic
 import { getById } from "@bitwarden/common/platform/misc";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.service.abstraction";
-import { Cipher } from "@bitwarden/common/vault/models/domain/cipher";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { CipherViewLikeUtils } from "@bitwarden/common/vault/utils/cipher-view-like-utils";
 import { BerryComponent, ChipFilterComponent, DialogService } from "@bitwarden/components";
@@ -54,7 +54,8 @@ export class ReusedPasswordsReportComponent
   extends BaseReusedPasswordsReportComponent
   implements OnInit
 {
-  manageableCiphers: Cipher[] = [];
+  private manageableCipherIds = new Set<string>();
+  private sharedCollectionIds = new Set<string>();
 
   constructor(
     cipherService: CipherService,
@@ -67,6 +68,7 @@ export class ReusedPasswordsReportComponent
     syncService: SyncService,
     cipherFormConfigService: CipherFormConfigService,
     adminConsoleCipherFormConfigService: AdminConsoleCipherFormConfigService,
+    private collectionService: CollectionService,
   ) {
     super(
       cipherService,
@@ -91,7 +93,16 @@ export class ReusedPasswordsReportComponent
           this.organization = await firstValueFrom(
             this.organizationService.organizations$(userId).pipe(getById(params.organizationId)),
           );
-          this.manageableCiphers = await this.cipherService.getAll(userId);
+          const manageableCiphers = await this.cipherService.getAll(userId);
+          this.manageableCipherIds = new Set(manageableCiphers.map((c) => c.id as string));
+          const collections = await firstValueFrom(
+            this.collectionService.decryptedCollections$(userId),
+          );
+          this.sharedCollectionIds = new Set(
+            collections
+              .filter((c) => !c.isDefaultCollection && c.organizationId === this.organization?.id)
+              .map((c) => c.id as string),
+          );
           await super.ngOnInit();
         }),
         takeUntil(this.destroyed$),
@@ -107,12 +118,15 @@ export class ReusedPasswordsReportComponent
   }
 
   canManageCipher(c: CipherView): boolean {
-    if (CipherViewLikeUtils.isUnassigned(c)) {
+    if (
+      CipherViewLikeUtils.isUnassigned(c) ||
+      !c.collectionIds?.some((id) => this.sharedCollectionIds.has(id))
+    ) {
       return false;
     }
     if (this.organization?.allowAdminAccessToAllCollectionItems) {
       return true;
     }
-    return this.manageableCiphers.some((x) => x.id === c.id);
+    return this.manageableCipherIds.has(c.id);
   }
 }

--- a/apps/web/src/app/dirt/reports/pages/organizations/reused-passwords-report.component.ts
+++ b/apps/web/src/app/dirt/reports/pages/organizations/reused-passwords-report.component.ts
@@ -94,7 +94,7 @@ export class ReusedPasswordsReportComponent
             this.organizationService.organizations$(userId).pipe(getById(params.organizationId)),
           );
           const manageableCiphers = await this.cipherService.getAll(userId);
-          this.manageableCipherIds = new Set(manageableCiphers.map((c) => c.id as string));
+          this.manageableCipherIds = new Set(manageableCiphers.map((c) => c.id));
           const collections = await firstValueFrom(
             this.collectionService.decryptedCollections$(userId),
           );

--- a/apps/web/src/app/dirt/reports/pages/organizations/reused-passwords-report.component.ts
+++ b/apps/web/src/app/dirt/reports/pages/organizations/reused-passwords-report.component.ts
@@ -11,6 +11,7 @@ import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.servi
 import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.service.abstraction";
 import { Cipher } from "@bitwarden/common/vault/models/domain/cipher";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+import { CipherViewLikeUtils } from "@bitwarden/common/vault/utils/cipher-view-like-utils";
 import { BerryComponent, ChipFilterComponent, DialogService } from "@bitwarden/components";
 import {
   CipherFormConfigService,
@@ -106,8 +107,8 @@ export class ReusedPasswordsReportComponent
   }
 
   canManageCipher(c: CipherView): boolean {
-    if (c.collectionIds.length === 0) {
-      return true;
+    if (CipherViewLikeUtils.isUnassigned(c)) {
+      return false;
     }
     if (this.organization?.allowAdminAccessToAllCollectionItems) {
       return true;

--- a/apps/web/src/app/dirt/reports/pages/organizations/unsecured-websites-report.component.ts
+++ b/apps/web/src/app/dirt/reports/pages/organizations/unsecured-websites-report.component.ts
@@ -10,7 +10,6 @@ import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.servic
 import { getById } from "@bitwarden/common/platform/misc";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.service.abstraction";
-import { Cipher } from "@bitwarden/common/vault/models/domain/cipher";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { CipherViewLikeUtils } from "@bitwarden/common/vault/utils/cipher-view-like-utils";
 import { BerryComponent, ChipFilterComponent, DialogService } from "@bitwarden/components";
@@ -55,8 +54,8 @@ export class UnsecuredWebsitesReportComponent
   extends BaseUnsecuredWebsitesReportComponent
   implements OnInit
 {
-  // Contains a list of ciphers, the user running the report, can manage
-  private manageableCiphers: Cipher[] = [];
+  private manageableCipherIds = new Set<string>();
+  private sharedCollectionIds = new Set<string>();
 
   constructor(
     cipherService: CipherService,
@@ -94,7 +93,16 @@ export class UnsecuredWebsitesReportComponent
           this.organization = await firstValueFrom(
             this.organizationService.organizations$(userId).pipe(getById(params.organizationId)),
           );
-          this.manageableCiphers = await this.cipherService.getAll(userId);
+          const manageableCiphers = await this.cipherService.getAll(userId);
+          this.manageableCipherIds = new Set(manageableCiphers.map((c) => c.id as string));
+          const collections = await firstValueFrom(
+            this.collectionService.decryptedCollections$(userId),
+          );
+          this.sharedCollectionIds = new Set(
+            collections
+              .filter((c) => !c.isDefaultCollection && c.organizationId === this.organization?.id)
+              .map((c) => c.id as string),
+          );
           await super.ngOnInit();
         }),
         takeUntil(this.destroyed$),
@@ -110,12 +118,15 @@ export class UnsecuredWebsitesReportComponent
   }
 
   protected canManageCipher(c: CipherView): boolean {
-    if (CipherViewLikeUtils.isUnassigned(c)) {
+    if (
+      CipherViewLikeUtils.isUnassigned(c) ||
+      !c.collectionIds?.some((id) => this.sharedCollectionIds.has(id))
+    ) {
       return false;
     }
     if (this.organization?.allowAdminAccessToAllCollectionItems) {
       return true;
     }
-    return this.manageableCiphers.some((x) => x.id === c.id);
+    return this.manageableCipherIds.has(c.id);
   }
 }

--- a/apps/web/src/app/dirt/reports/pages/organizations/unsecured-websites-report.component.ts
+++ b/apps/web/src/app/dirt/reports/pages/organizations/unsecured-websites-report.component.ts
@@ -94,7 +94,7 @@ export class UnsecuredWebsitesReportComponent
             this.organizationService.organizations$(userId).pipe(getById(params.organizationId)),
           );
           const manageableCiphers = await this.cipherService.getAll(userId);
-          this.manageableCipherIds = new Set(manageableCiphers.map((c) => c.id as string));
+          this.manageableCipherIds = new Set(manageableCiphers.map((c) => c.id));
           const collections = await firstValueFrom(
             this.collectionService.decryptedCollections$(userId),
           );

--- a/apps/web/src/app/dirt/reports/pages/organizations/unsecured-websites-report.component.ts
+++ b/apps/web/src/app/dirt/reports/pages/organizations/unsecured-websites-report.component.ts
@@ -12,6 +12,7 @@ import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.servi
 import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.service.abstraction";
 import { Cipher } from "@bitwarden/common/vault/models/domain/cipher";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+import { CipherViewLikeUtils } from "@bitwarden/common/vault/utils/cipher-view-like-utils";
 import { BerryComponent, ChipFilterComponent, DialogService } from "@bitwarden/components";
 import {
   CipherFormConfigService,
@@ -109,8 +110,8 @@ export class UnsecuredWebsitesReportComponent
   }
 
   protected canManageCipher(c: CipherView): boolean {
-    if (c.collectionIds.length === 0) {
-      return true;
+    if (CipherViewLikeUtils.isUnassigned(c)) {
+      return false;
     }
     if (this.organization?.allowAdminAccessToAllCollectionItems) {
       return true;

--- a/apps/web/src/app/dirt/reports/pages/organizations/weak-passwords-report.component.ts
+++ b/apps/web/src/app/dirt/reports/pages/organizations/weak-passwords-report.component.ts
@@ -12,6 +12,7 @@ import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.servi
 import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.service.abstraction";
 import { Cipher } from "@bitwarden/common/vault/models/domain/cipher";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+import { CipherViewLikeUtils } from "@bitwarden/common/vault/utils/cipher-view-like-utils";
 import { BerryComponent, ChipFilterComponent, DialogService } from "@bitwarden/components";
 import {
   CipherFormConfigService,
@@ -108,8 +109,8 @@ export class WeakPasswordsReportComponent
   }
 
   canManageCipher(c: CipherView): boolean {
-    if (c.collectionIds.length === 0) {
-      return true;
+    if (CipherViewLikeUtils.isUnassigned(c)) {
+      return false;
     }
     if (this.organization?.allowAdminAccessToAllCollectionItems) {
       return true;

--- a/apps/web/src/app/dirt/reports/pages/organizations/weak-passwords-report.component.ts
+++ b/apps/web/src/app/dirt/reports/pages/organizations/weak-passwords-report.component.ts
@@ -96,7 +96,7 @@ export class WeakPasswordsReportComponent
             this.organizationService.organizations$(userId).pipe(getById(params.organizationId)),
           );
           const manageableCiphers = await this.cipherService.getAll(userId);
-          this.manageableCipherIds = new Set(manageableCiphers.map((c) => c.id as string));
+          this.manageableCipherIds = new Set(manageableCiphers.map((c) => c.id));
           const collections = await firstValueFrom(
             this.collectionService.decryptedCollections$(userId),
           );

--- a/apps/web/src/app/dirt/reports/pages/organizations/weak-passwords-report.component.ts
+++ b/apps/web/src/app/dirt/reports/pages/organizations/weak-passwords-report.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from "@angular/core";
 import { ActivatedRoute } from "@angular/router";
 import { firstValueFrom, takeUntil, tap } from "rxjs";
 
+import { CollectionService } from "@bitwarden/admin-console/common";
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { getUserId } from "@bitwarden/common/auth/services/account.service";
@@ -10,7 +11,6 @@ import { getById } from "@bitwarden/common/platform/misc";
 import { PasswordStrengthServiceAbstraction } from "@bitwarden/common/tools/password-strength";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.service.abstraction";
-import { Cipher } from "@bitwarden/common/vault/models/domain/cipher";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { CipherViewLikeUtils } from "@bitwarden/common/vault/utils/cipher-view-like-utils";
 import { BerryComponent, ChipFilterComponent, DialogService } from "@bitwarden/components";
@@ -55,7 +55,8 @@ export class WeakPasswordsReportComponent
   extends BaseWeakPasswordsReportComponent
   implements OnInit
 {
-  private manageableCiphers: Cipher[] = [];
+  private manageableCipherIds = new Set<string>();
+  private sharedCollectionIds = new Set<string>();
 
   constructor(
     cipherService: CipherService,
@@ -69,6 +70,7 @@ export class WeakPasswordsReportComponent
     cipherFormConfigService: CipherFormConfigService,
     protected accountService: AccountService,
     adminConsoleCipherFormConfigService: AdminConsoleCipherFormConfigService,
+    private collectionService: CollectionService,
   ) {
     super(
       cipherService,
@@ -93,7 +95,16 @@ export class WeakPasswordsReportComponent
           this.organization = await firstValueFrom(
             this.organizationService.organizations$(userId).pipe(getById(params.organizationId)),
           );
-          this.manageableCiphers = await this.cipherService.getAll(userId);
+          const manageableCiphers = await this.cipherService.getAll(userId);
+          this.manageableCipherIds = new Set(manageableCiphers.map((c) => c.id as string));
+          const collections = await firstValueFrom(
+            this.collectionService.decryptedCollections$(userId),
+          );
+          this.sharedCollectionIds = new Set(
+            collections
+              .filter((c) => !c.isDefaultCollection && c.organizationId === this.organization?.id)
+              .map((c) => c.id as string),
+          );
           await super.ngOnInit();
         }),
         takeUntil(this.destroyed$),
@@ -109,12 +120,15 @@ export class WeakPasswordsReportComponent
   }
 
   canManageCipher(c: CipherView): boolean {
-    if (CipherViewLikeUtils.isUnassigned(c)) {
+    if (
+      CipherViewLikeUtils.isUnassigned(c) ||
+      !c.collectionIds?.some((id) => this.sharedCollectionIds.has(id))
+    ) {
       return false;
     }
     if (this.organization?.allowAdminAccessToAllCollectionItems) {
       return true;
     }
-    return this.manageableCiphers.some((x) => x.id === c.id);
+    return this.manageableCipherIds.has(c.id);
   }
 }

--- a/apps/web/src/app/dirt/reports/pages/unsecured-websites-report.component.ts
+++ b/apps/web/src/app/dirt/reports/pages/unsecured-websites-report.component.ts
@@ -34,7 +34,7 @@ export class UnsecuredWebsitesReportComponent extends CipherReportComponent impl
     passwordRepromptService: PasswordRepromptService,
     i18nService: I18nService,
     syncService: SyncService,
-    private collectionService: CollectionService,
+    protected collectionService: CollectionService,
     cipherFormConfigService: CipherFormConfigService,
     adminConsoleCipherFormConfigService: AdminConsoleCipherFormConfigService,
   ) {


### PR DESCRIPTION
## 🎟️ Tracking

[[PM-33928] Can view MyItems Passwords in Org Vault Health Reports](https://bitwarden.atlassian.net/browse/PM-33928)

## 📔 Objective

Org vault health reports include items from users' **My Items** collections, the personal `DefaultUserCollection` created by the _Enforce organization data ownership_ policy. The `canManageCipher` method in each org report component was not accounting for these collections, making those rows clickable and editable by admins even though admins cannot manage items in another member's personal collection.

The fix loads the org's shared (non-default) collections via `CollectionService.decryptedCollections$` on init and builds a `sharedCollectionIds` set. `canManageCipher` now returns false for any cipher whose collectionIds have no overlap with that set meaning the cipher exists only in a member's **My Items** collection. Those report rows now render as non-clickable text.

The `manageableCiphers` array lookup was also converted to a set for more performant per-row lookups.

### Note 

These changes are scoped to fix the bug. The `manageableCiphers` improvement was a small enough change for a performance boost that I chose to include. Other improvements to this area of code are out of scope for this ticket, but comments on follow up improvements are welcome.

## 📸 Screenshots

After changes, "My Item in Test Org" row cannot be clicked:

<img width="1552" height="1289" alt="image" src="https://github.com/user-attachments/assets/eb869c6e-51a6-44e4-b4f6-cd7314b9d6ee" />



[PM-33928]: https://bitwarden.atlassian.net/browse/PM-33928?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ