### PR TITLE
[PM-33993] Fix CLI bug that allowed File Send downloads to save at arbitrary paths

### DIFF
--- a/apps/cli/src/tools/send/commands/receive.command.spec.ts
+++ b/apps/cli/src/tools/send/commands/receive.command.spec.ts
@@ -163,6 +163,38 @@ describe("SendReceiveCommand", () => {
 
       expect(response.success).toBe(false);
     });
+
+    it("should remove leading directory components of File Send filename to prevent path traversal", async () => {
+      const fileName = "test.pdf";
+      const mockSendResponse = {
+        id: testSendId,
+        type: SendType.File,
+        file: {
+          id: "file-123",
+          fileName: `../../${fileName}`,
+          size: 1024,
+        },
+      };
+      sendApiService.postSendAccess.mockResolvedValue({} as any);
+      jest.spyOn(SendAccess.prototype, "decrypt").mockResolvedValueOnce(mockSendResponse as any);
+      const fileDownloadUrl = "https://example.com/download";
+      sendApiService.getSendFileDownloadData.mockResolvedValue({
+        url: fileDownloadUrl,
+      } as any);
+
+      const saveAttachmentToFileSpy = jest
+        .spyOn(command as any, "saveAttachmentToFile")
+        .mockResolvedValue(Response.success());
+
+      await command.run(testUrl, {});
+
+      expect(saveAttachmentToFileSpy).toHaveBeenCalledWith(
+        fileDownloadUrl,
+        fileName,
+        expect.any(Function),
+        undefined,
+      );
+    });
   });
 
   describe("V2 Flow (Feature Flag On)", () => {
@@ -417,6 +449,43 @@ describe("SendReceiveCommand", () => {
           expect.any(Object),
           mockToken,
           "https://api.bitwarden.com",
+        );
+      });
+
+      it("should remove leading directory components of File Send filename to prevent path traversal", async () => {
+        const mockToken = new SendAccessToken("test-token", Date.now() + 3600000);
+        sendTokenService.tryGetSendAccessToken$.mockReturnValue(of(mockToken));
+
+        const fileName = "test.pdf";
+        const mockSendResponse = {
+          id: testSendId,
+          type: SendType.File,
+          file: {
+            id: "file-123",
+            fileName: `../../${fileName}`,
+            size: 1024,
+          },
+        };
+
+        sendApiService.postSendAccessV2.mockResolvedValue({} as any);
+        jest.spyOn(SendAccess.prototype, "decrypt").mockResolvedValueOnce(mockSendResponse as any);
+        const fileDownloadUrl = "https://example.com/download";
+        sendApiService.getSendFileDownloadDataV2.mockResolvedValue({
+          url: fileDownloadUrl,
+        } as any);
+
+        encryptService.decryptFileData.mockResolvedValue(new ArrayBuffer(1024) as any);
+        const saveAttachmentToFileSpy = jest
+          .spyOn(command as any, "saveAttachmentToFile")
+          .mockResolvedValue(Response.success());
+
+        await command.run(testUrl, {});
+
+        expect(saveAttachmentToFileSpy).toHaveBeenCalledWith(
+          fileDownloadUrl,
+          fileName,
+          expect.any(Function),
+          undefined,
         );
       });
     });

--- a/apps/cli/src/tools/send/commands/receive.command.ts
+++ b/apps/cli/src/tools/send/commands/receive.command.ts
@@ -1,5 +1,7 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
+import * as path from "path";
+
 import { OptionValues } from "commander";
 import * as inquirer from "inquirer";
 import { firstValueFrom } from "rxjs";
@@ -168,7 +170,7 @@ export class SendReceiveCommand extends DownloadCommand {
 
         return await this.saveAttachmentToFile(
           downloadData.url,
-          response?.file?.fileName,
+          path.basename(response?.file?.fileName ?? `BitwardenSendFile-${Date.now()}`),
           decryptBufferFn,
           options.output,
         );
@@ -432,7 +434,7 @@ export class SendReceiveCommand extends DownloadCommand {
 
           return await this.saveAttachmentToFile(
             downloadData.url,
-            decryptedView?.file?.fileName,
+            path.basename(decryptedView?.file?.fileName ?? `BitwardenSendFile-${Date.now()}`),
             decryptBufferFn,
             options.output,
           );


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-33993

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR adds a fix for the CLI fixing a vulnerability that allowed File Sends with maliciously-named files to save at arbitrary locations in the client's file structure, and adds two tests to ensure the behavior does not regress.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
No visual changes