### PR TITLE
Add script to install Rust env. Use in CI and pre-commit hooks.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -127,24 +127,17 @@ jobs:
         env:
           RUSTFLAGS: "-D warnings"
 
-      - name: Install cargo-sort
-        run: cargo install cargo-sort --locked --git https://github.com/DevinR528/cargo-sort.git --rev ac6e328faf467a39e38ab48dc60dcf4f6a46d7a5 # v2.0.2
+      - name: Install cargo tool dependencies
+        working-directory: ./scripts
+        run: ./prepare-env-rust.sh
 
       - name: Cargo sort
         working-directory: ./apps/desktop/desktop_native
         run: cargo sort --workspace --check
 
-      - name: Install cargo-udeps
-        run: cargo install cargo-udeps --version 0.1.57 --locked
-
       - name: Cargo udeps
         working-directory: ./apps/desktop/desktop_native
         run: cargo +nightly udeps --workspace --all-features --all-targets
-
-      - name: Install cargo-deny
-        uses: taiki-e/install-action@205eb1d74c6feda89abb1f3a09360601953286c0 # v2.68.18
-        with:
-          tool: cargo-deny@0.18.6
 
       - name: Run cargo deny
         working-directory: ./apps/desktop/desktop_native

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -128,8 +128,7 @@ jobs:
           RUSTFLAGS: "-D warnings"
 
       - name: Install cargo tool dependencies
-        working-directory: ./scripts
-        run: ./prepare-env-rust.sh
+        run: ./scripts/prepare-env-rust.sh
 
       - name: Cargo sort
         working-directory: ./apps/desktop/desktop_native

--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -11,10 +11,12 @@ export default {
     ];
   },
   "apps/desktop/desktop_native/**/Cargo.toml": () => {
+    const hint =
+      "\nIf you are missing the required Rust tools, you can install them with scripts/prepare-env-rust.sh\n";
     return [
-      `sh -c 'cd apps/desktop/desktop_native && cargo sort --workspace --check'`,
-      `sh -c 'cd apps/desktop/desktop_native && cargo +nightly udeps --workspace --all-features --all-targets'`,
-      `sh -c 'cd apps/desktop/desktop_native && cargo deny --log-level error --all-features check all'`,
+      `sh -c 'cd apps/desktop/desktop_native && cargo sort --workspace --check || (echo "${hint}" && exit 1)'`,
+      `sh -c 'cd apps/desktop/desktop_native && cargo +nightly udeps --workspace --all-features --all-targets || (echo "${hint}" && exit 1)'`,
+      `sh -c 'cd apps/desktop/desktop_native && cargo deny --log-level error --all-features check all || (echo "${hint}" && exit 1)'`,
     ];
   },
 };

--- a/scripts/prepare-env-rust.sh
+++ b/scripts/prepare-env-rust.sh
@@ -1,10 +1,21 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# This script prepares the environment for developing in Rust for the clients repo,
+# specifically Desktop Native. This script is used by both developers locally, and
+# in CI.
+#
+# NOTE: The cargo tools installed in this script, are installed to the default location
+# (user's $HOME dir). If you prefer another location, please install the vesrions
+# specified below, and ensure they are in your $PATH.
+
+
 CARGO_DENY_VERSION="0.18.6"
 CARGO_SORT_VERSION="2.0.2"
 CARGO_UDEPS_VERSION="0.1.57"
 
+# Ensures the active toolchain is installed, and that nightly is installed
+# for the cargo tools
 toolchain_is_installed() {
   if ! command -v rustup >/dev/null 2>&1; then
     echo "Installing Rust..."

--- a/scripts/prepare-env-rust.sh
+++ b/scripts/prepare-env-rust.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CARGO_DENY_VERSION="0.18.6"
+CARGO_SORT_VERSION="2.0.2"
+CARGO_UDEPS_VERSION="0.1.57"
+
+toolchain_is_installed() {
+  if ! command -v rustup >/dev/null 2>&1; then
+    echo "Installing Rust..."
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
+  fi
+
+  # Ensure cargo/rustup are on PATH
+  if [ -f "${HOME}/.cargo/env" ]; then
+    source "${HOME}/.cargo/env"
+  fi
+
+  # Determine desired toolchain and ensure it's installed.
+  ACTIVE_TOOLCHAIN="$(cd apps/desktop/desktop_native && rustup show active-toolchain 2>/dev/null || true)"
+  ACTIVE_TOOLCHAIN="${ACTIVE_TOOLCHAIN%% *}"  # keep only the first token
+  if [ -z "${ACTIVE_TOOLCHAIN}" ]; then
+    # No active toolchain yet: fall back to env override or default to stable.
+    ACTIVE_TOOLCHAIN="${RUSTUP_TOOLCHAIN:-stable}"
+    rustup default "${ACTIVE_TOOLCHAIN}"
+  fi
+
+  # For building desktop_native
+  rustup toolchain install "${ACTIVE_TOOLCHAIN}"
+
+  # For the cargo tools used in pre-commit hooks and CI
+  rustup toolchain install nightly
+
+  rustup show
+  echo
+}
+
+# Checks version of tool and installs if needed
+# Usage: maybe_install_cargo_tool <tool-name> <version>
+# Note: cargo-* tools are invoked as "cargo <subcommand>", not as direct binaries
+maybe_install_cargo_tool() {
+  local tool="$1"
+  local version="$2"
+  local version_cmd="cargo ${tool#cargo-}"
+  local version_pattern="${3:-${tool} ${version}}"
+
+  if ! $version_cmd --version 2>/dev/null | grep -q "^${version_pattern}"; then
+    echo "$tool $version is not installed. Installing ..."
+    cargo install "$tool" --version "$version" --force --locked
+  else
+    echo "$tool $version is already installed."
+  fi
+}
+
+toolchain_is_installed
+
+maybe_install_cargo_tool cargo-deny "${CARGO_DENY_VERSION}"
+maybe_install_cargo_tool cargo-sort "${CARGO_SORT_VERSION}"
+maybe_install_cargo_tool cargo-udeps "${CARGO_UDEPS_VERSION}"


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-34175

## 📔 Objective

Centralizes the required environment setup for Rust development in clients repo. The script is:
- used in the CI workflows that do the lint-style checks
- used by developers
- referenced in the pre-commit hook failure case, as a hint, in case the developer doesn't already have the tooling installed.

Follow-up PR to contributing docs to reference this script in the Getting Started -> Tools -> Local Environment sections (moving it up out of the Desktop Native page, since it can be required for non-Desktop Native work, if merge conflicts occur).

## Testing done

```
❯ ./scripts/prepare-env-rust.sh
info: syncing channel updates for 1.91.1-aarch64-apple-darwin

  1.91.1-aarch64-apple-darwin unchanged - rustc 1.91.1 (ed61e7d7e 2025-11-07)

info: checking for self-update (current version: 1.29.0)
info: syncing channel updates for nightly-aarch64-apple-darwin

  nightly-aarch64-apple-darwin unchanged - rustc 1.96.0-nightly (48cc71ee8 2026-03-31)

info: checking for self-update (current version: 1.29.0)
Default host: aarch64-apple-darwin
rustup home:  /Users/foo/.rustup

installed toolchains
--------------------
stable-aarch64-apple-darwin (active, default)
nightly-aarch64-apple-darwin
nightly-x86_64-unknown-linux-gnu
nightly-2025-08-07-aarch64-apple-darwin
1.85.0-aarch64-apple-darwin
1.85.0-x86_64-unknown-linux-gnu
1.87.0-aarch64-apple-darwin
1.87.0-x86_64-unknown-linux-gnu
1.91.0-aarch64-apple-darwin
1.91.1-aarch64-apple-darwin
1.91.1-x86_64-unknown-linux-gnu
1.94.1-aarch64-apple-darwin
1.94.1-x86_64-unknown-linux-gnu

active toolchain
----------------
name: stable-aarch64-apple-darwin
active because: it's the default toolchain
installed targets:
  aarch64-apple-darwin
  aarch64-apple-ios
  aarch64-apple-ios-sim
  x86_64-apple-ios

cargo-deny 0.18.6 is already installed.
cargo-sort 2.0.2 is not installed. Installing ...
    Updating crates.io index
  Installing cargo-sort v2.0.2
    Updating crates.io index
    Updating crates.io index
   Compiling libc v0.2.172
   Compiling proc-macro2 v1.0.95
   Compiling unicode-ident v1.0.18
   Compiling rustix v1.0.7
   Compiling utf8parse v0.2.2
   Compiling bitflags v2.9.1
   Compiling colorchoice v1.0.4
   Compiling anstyle-query v1.1.3
   Compiling anstyle v1.0.11
   Compiling is_terminal_polyfill v1.70.1
   Compiling heck v0.5.0
   Compiling clap_lex v0.7.5
   Compiling strsim v0.11.1
   Compiling hashbrown v0.15.4
   Compiling equivalent v1.0.2
   Compiling anstyle-parse v0.2.7
   Compiling toml_datetime v0.6.11
   Compiling toml_write v0.1.2
   Compiling winnow v0.7.10
   Compiling termcolor v1.4.1
   Compiling glob v0.3.2
   Compiling anstream v0.6.19
   Compiling indexmap v2.9.0
   Compiling quote v1.0.40
   Compiling toml_edit v0.22.27
   Compiling syn v2.0.101
   Compiling errno v0.3.12
   Compiling terminal_size v0.4.2
   Compiling clap_builder v4.5.40
   Compiling clap_derive v4.5.40
   Compiling clap v4.5.40
   Compiling cargo-sort v2.0.2
    Finished `release` profile [optimized] target(s) in 8.97s
  Installing /Users/foo/.cargo/bin/cargo-sort
   Installed package `cargo-sort v2.0.2` (executable `cargo-sort`)
cargo-udeps 0.1.57 is already installed.
```

```
❯ git commit -am "."
✔ Backed up original state in git stash (14d49a41d2)
⚠ Running tasks for staged files...
  ❯ lint-staged.config.mjs — 1 file
    ✔ * — 1 file
    ↓ *.ts — no files
    ↓ apps/desktop/desktop_native/**/*.rs — no files
    ❯ apps/desktop/desktop_native/**/Cargo.toml — 1 file
      ✖ sh -c 'cd apps/desktop/desktop_native && cargo sort --workspace --check || (echo "
        If you are missing the required Rust tools, you can install them with scripts/prepare-env-rust.sh
        " && exit 1)' [FAILED]
      ◼ sh -c 'cd apps/desktop/desktop_native && cargo +nightly udeps --workspace --all-features --all-targets || (echo "
        If you are missing the required Rust tools, you can install them with scripts/prepare-env-rust.sh
        " && exit 1)'
      ◼ sh -c 'cd apps/desktop/desktop_native && cargo deny --log-level error --all-features check all || (echo "
        If you are missing the required Rust tools, you can install them with scripts/prepare-env-rust.sh
        " && exit 1)'
↓ Skipped because of errors from tasks.
✔ Reverting to original state because of errors...
✔ Cleaning up temporary files...

✖ sh -c 'cd apps/desktop/desktop_native && cargo sort --workspace --check || (echo "
If you are missing the required Rust tools, you can install them with scripts/prepare-env-rust.sh
" && exit 1)':
error: no such command: `sort`

help: a command with a similar name exists: `about`

help: view all installed commands with `cargo --list`
help: find a package to install `sort` with `cargo search cargo-sort`

If you are missing the required Rust tools, you can install them with scripts/prepare-env-rust.sh

husky - pre-commit script failed (code 1)
```