### PR TITLE
Remove artifact name from dispatch interface.

### DIFF
--- a/.github/workflows/sdk-breaking-change-check.yml
+++ b/.github/workflows/sdk-breaking-change-check.yml
@@ -17,10 +17,6 @@ on:
         description: "Artifacts run ID"
         required: true
         type: string
-      artifact_name:
-        description: "Artifact name"
-        required: true
-        type: string
 
 permissions:
   contents: read
@@ -36,7 +32,6 @@ jobs:
       _SOURCE_REPO: ${{ github.event.inputs.source_repo }}
       _SDK_VERSION: ${{ github.event.inputs.sdk_version }}
       _ARTIFACTS_RUN_ID: ${{ github.event.inputs.artifacts_run_id }}
-      _ARTIFACT_NAME: ${{ github.event.inputs.artifact_name }}
       
     steps:
       - name: Log in to Azure
@@ -113,7 +108,7 @@ jobs:
           workflow: build-wasm-internal.yml
           workflow_conclusion: success
           run_id: ${{ env._ARTIFACTS_RUN_ID }}
-          artifacts: ${{ env._ARTIFACT_NAME }}
+          artifacts: sdk-internal
           repo: ${{ env._SOURCE_REPO }}
           path: ./sdk-internal
           if_no_artifact_found: fail


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-27825

## 📔 Objective

We are looking to add in breaking change detection for Android.  For Android, multiple artifacts are needed in order to perform the change detection.  As such, it does not make sense to pass in the artifact when it is the responsibility of each platform to determine which artifact(s) are necessary in order to properly test.

This change removes the artifact from the inputs and allows the workflow to set it to the same value that is currently being passed in, which is `sdk-internal`.  See [here](https://github.com/bitwarden/sdk-internal/blob/4ec0ce1f1be263d64acd400297554bbbec4804c2/.github/workflows/detect-breaking-changes.yml#L50) for where it's being passed in and defaulting to `sdk-internal` in all cases.

This can be done ahead of any other changes because `workflow_dispatch` receivers will ignore extra parameters.
