### PR TITLE
[PM-31885] Bump SendControls Policy Enum Value

### DIFF
--- a/libs/common/src/admin-console/enums/policy-type.enum.ts
+++ b/libs/common/src/admin-console/enums/policy-type.enum.ts
@@ -21,5 +21,5 @@ export enum PolicyType {
   AutotypeDefaultSetting = 17, // Sets the default autotype setting for desktop app
   AutoConfirm = 18, // Enables the auto confirmation feature for admins to enable in their client
   BlockClaimedDomainAccountCreation = 19, // Prevents users from creating personal accounts using email addresses from verified domains
-  SendControls = 20, // Supersedes DisableSend and SendOptions when pm-31885-send-controls flag is active
+  SendControls = 21, // Supersedes DisableSend and SendOptions when pm-31885-send-controls flag is active
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-31885

## 📔 Objective

While https://github.com/bitwarden/server/pull/7113 was in QA, a new PolicyType `OrganizationUserNotification` was introduced and assigned the enum value of `20` which conflicts with the `SendControls` policy. This PR bumps `SendControls` to have enum value 21, matching changes to the server branch. 

