### PR TITLE
[PM-34507] Fix auto-fill not recognizing email fields with capitalized name attribute

### DIFF
--- a/apps/browser/src/autofill/services/inline-menu-field-qualification.service.spec.ts
+++ b/apps/browser/src/autofill/services/inline-menu-field-qualification.service.spec.ts
@@ -1024,6 +1024,32 @@ describe("InlineMenuFieldQualificationService", () => {
     });
   });
 
+  describe("isFieldForIdentityEmail", () => {
+    it("returns true if the field htmlName is 'email' (case-insensitive)", () => {
+      const field = mock<AutofillField>({
+        placeholder: "",
+        autoCompleteType: "",
+        type: "text",
+        htmlName: "Email",
+        htmlID: "email-field",
+      });
+
+      expect(inlineMenuFieldQualificationService.isFieldForIdentityEmail(field)).toBe(true);
+    });
+
+    it("returns true if the field htmlName is 'email' (lowercase)", () => {
+      const field = mock<AutofillField>({
+        placeholder: "",
+        autoCompleteType: "",
+        type: "text",
+        htmlName: "email",
+        htmlID: "email-field",
+      });
+
+      expect(inlineMenuFieldQualificationService.isFieldForIdentityEmail(field)).toBe(true);
+    });
+  });
+
   describe("isEmailField", () => {
     it("returns true if the field type is of `email`", () => {
       const field = mock<AutofillField>({

--- a/apps/browser/src/autofill/services/inline-menu-field-qualification.service.ts
+++ b/apps/browser/src/autofill/services/inline-menu-field-qualification.service.ts
@@ -910,7 +910,7 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
     if (
       this.fieldContainsAutocompleteValues(field, this.emailAutocompleteValue) ||
       field.type === "email" ||
-      field.htmlName === "email"
+      field.htmlName?.toLowerCase() === "email"
     ) {
       return true;
     }


### PR DESCRIPTION
## Tracking
Fixes https://github.com/bitwarden/clients/issues/19900

## Objective
Fix browser extension auto-fill not recognizing email fields when the HTML `name` attribute is capitalized (e.g., `name="Email"` instead of `name="email"`).

## Changes
- Modified `isFieldForIdentityEmail()` in `inline-menu-field-qualification.service.ts` to make `htmlName` comparison case-insensitive
- Added 2 test cases to verify case-insensitive matching

## Testing
All 55 tests pass in the inline-menu-field-qualification service spec.