### PR TITLE
[CL-1130] Fix storybook a11y and console errors for platform files

### DIFF
--- a/apps/web/src/app/shared/components/onboarding/onboarding-task.component.html
+++ b/apps/web/src/app/shared/components/onboarding/onboarding-task.component.html
@@ -12,7 +12,7 @@
   ></span>
 </ng-template>
 
-<li class="tw-list-none">
+<span>
   <a bitLink *ngIf="route" [routerLink]="route">
     <ng-container *ngTemplateOutlet="content"></ng-container>
   </a>
@@ -26,4 +26,4 @@
   >
     <ng-content></ng-content>
   </div>
-</li>
+</span>

--- a/apps/web/src/app/shared/components/onboarding/onboarding-task.component.ts
+++ b/apps/web/src/app/shared/components/onboarding/onboarding-task.component.ts
@@ -11,6 +11,7 @@ import { BitwardenIcon } from "@bitwarden/components";
   templateUrl: "./onboarding-task.component.html",
   host: {
     class: "tw-max-w-max",
+    role: "listitem",
   },
   standalone: false,
 })

--- a/apps/web/src/app/shared/components/onboarding/onboarding.component.html
+++ b/apps/web/src/app/shared/components/onboarding/onboarding.component.html
@@ -9,9 +9,9 @@
       <bit-icon [name]="open ? 'bwi-angle-down' : 'bwi-angle-up'" class="tw-my-auto"></bit-icon>
     </div>
   </summary>
-  <ul class="tw-mb-0 tw-ml-6 tw-flex tw-flex-col tw-gap-4">
+  <div class="tw-mb-0 tw-ml-6 tw-flex tw-flex-col tw-gap-4 tw-ps-10" role="list">
     <ng-content></ng-content>
-  </ul>
+  </div>
   <div class="tw-p-4 tw-pt-0">
     <button bitLink type="button" class="tw-ml-auto tw-block" (click)="dismiss.emit()">
       {{ "dismiss" | i18n }}


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[CL-1130](https://bitwarden.atlassian.net/browse/CL-1130)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
We are working through Storybook errors related to accessibility and general console errors (usually story setup issues). This PR fixes current errors in platform-owned code. Specifically the fixes in this PR are:
- [`ul` cannot contain any child elements that are not `li`](https://dequeuniversity.com/rules/axe/4.10/list?application=axeAPI). Due to how Angular components add another element into the DOM, I opted for a quick fix of using aria roles on the proper elements. `ul` has some global css associated so I also added the same styles to the element that is now a `div`. Please note that this fix affects prod code and not just story code.


[CL-1130]: https://bitwarden.atlassian.net/browse/CL-1130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ