### PR TITLE
[PM-34530] Display cart-level discount on personal subscription page

### DIFF
--- a/libs/common/src/billing/models/response/cart.response.ts
+++ b/libs/common/src/billing/models/response/cart.response.ts
@@ -66,7 +66,7 @@ export class CartResponse extends BaseResponse implements Cart {
     additionalServiceAccounts?: CartItem;
   };
   cadence: SubscriptionCadence;
-  discount?: Discount;
+  discounts?: Discount[];
   estimatedTax: number;
 
   constructor(response: any) {
@@ -89,7 +89,7 @@ export class CartResponse extends BaseResponse implements Cart {
 
     const discount = this.getResponseProperty("Discount");
     if (discount) {
-      this.discount = new DiscountResponse(discount);
+      this.discounts = [new DiscountResponse(discount)];
     }
 
     this.estimatedTax = this.getResponseProperty("EstimatedTax");


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-34530

## 📔 Objective

`CartResponse` was parsing the server's cart-level `discount` object into a singular `discount` property, but the `Cart` type and `CartSummaryComponent` expect a `discounts` array. This mismatch meant the cart-level discount was silently dropped and never rendered on the personal subscription page.

This PR fixes the mapping in `CartResponse` to wrap the singular discount into a `discounts` array, aligning it with the existing `Cart` type contract.

`server` PR: https://github.com/bitwarden/server/pull/7375

## 📸 Screenshots

<img width="951" height="529" alt="image" src="https://github.com/user-attachments/assets/016c53d1-f5a0-4912-b8d1-193858846702" />