### PR TITLE
Downloading an attachment, appends a file extension. Even if original file didn't have one

### DIFF
--- a/libs/common/src/platform/abstractions/file-download/file-download.builder.ts
+++ b/libs/common/src/platform/abstractions/file-download/file-download.builder.ts
@@ -45,7 +45,7 @@ export class FileDownloadBuilder {
     } else if (fileNameLower.endsWith(".gif")) {
       return "image/gif";
     }
-    return null;
+    return "application/octet-stream";
   }
 
   constructor(private readonly _request: FileDownloadRequest) {}


### PR DESCRIPTION
## 🎟️ Tracking

[JIRA](https://bitwarden.atlassian.net/browse/PM-5495)

## 📔 Objective

Prevent the browser from adding an extension automatically when downloading a file attachment without a file extension.