### PR TITLE
[Shared Unlock] [PM-34073] Disable process reload in dev mode

### DIFF
--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -1319,7 +1319,7 @@ export default class MainBackground {
       this.accountService,
       this.logService,
       this.authService,
-      this.platformUtilsService
+      this.platformUtilsService,
     );
 
     // Background

--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -1319,6 +1319,7 @@ export default class MainBackground {
       this.accountService,
       this.logService,
       this.authService,
+      this.platformUtilsService
     );
 
     // Background

--- a/apps/desktop/src/app/services/services.module.ts
+++ b/apps/desktop/src/app/services/services.module.ts
@@ -307,6 +307,7 @@ const safeProviders: SafeProvider[] = [
       AccountServiceAbstraction,
       LogService,
       AuthServiceAbstraction,
+      PlatformUtilsServiceAbstraction,
     ],
   }),
   safeProvider({

--- a/apps/web/src/app/core/core.module.ts
+++ b/apps/web/src/app/core/core.module.ts
@@ -388,7 +388,7 @@ const safeProviders: SafeProvider[] = [
   safeProvider({
     provide: ProcessReloadServiceAbstraction,
     useClass: WebProcessReloadService,
-    deps: [WINDOW],
+    deps: [WINDOW, PlatformUtilsService, Router],
   }),
   safeProvider({
     provide: LoginEmailService,

--- a/apps/web/src/app/key-management/services/web-process-reload.service.ts
+++ b/apps/web/src/app/key-management/services/web-process-reload.service.ts
@@ -1,10 +1,21 @@
+import { Router } from "@angular/router";
+
 import { ProcessReloadServiceAbstraction } from "@bitwarden/common/key-management/abstractions/process-reload.service";
+import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 
 export class WebProcessReloadService implements ProcessReloadServiceAbstraction {
-  constructor(private window: Window) {}
+  constructor(
+    private window: Window,
+    private platformUtilsService: PlatformUtilsService,
+    private router: Router,
+  ) {}
 
   async startProcessReload(): Promise<void> {
-    this.window.location.reload();
+    if (!this.platformUtilsService.isDev()) {
+      this.window.location.reload();
+    } else {
+      await this.router.navigate(["/"]);
+    }
   }
 
   cancelProcessReload(): void {

--- a/libs/common/src/key-management/services/default-process-reload.service.ts
+++ b/libs/common/src/key-management/services/default-process-reload.service.ts
@@ -2,6 +2,7 @@
 // @ts-strict-ignore
 import { firstValueFrom, map, timeout } from "rxjs";
 
+import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 // This import has been flagged as unallowed for this class. It may be involved in a circular dependency loop.
 // eslint-disable-next-line no-restricted-imports
 import { BiometricStateService } from "@bitwarden/key-management";
@@ -31,9 +32,17 @@ export class DefaultProcessReloadService implements ProcessReloadServiceAbstract
     private accountService: AccountService,
     private logService: LogService,
     private authService: AuthService,
+    private platformUtilsService: PlatformUtilsService,
   ) {}
 
   async startProcessReload(): Promise<void> {
+    if (this.platformUtilsService.isDev()) {
+      this.logService.info("[Process Reload Service] Process reload prevented in dev environment");
+      return;
+    } else {
+      this.logService.info("[Process Reload Service] Is not dev");
+    }
+
     const accounts = await firstValueFrom(this.accountService.accounts$);
     if (accounts != null) {
       const keys = Object.keys(accounts);


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-34073

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Debugging gets harder when process reload is active, and process reload is not really needed in dev mode. This PR disables process reload in dev mode. This makes debugging a few things around lock (and shared unlock) significantly easier.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
