### PR TITLE
[PM-34561] improving UI for receive file upload results page

### DIFF
--- a/apps/web/src/app/tools/receive/receive-file-upload.component.html
+++ b/apps/web/src/app/tools/receive/receive-file-upload.component.html
@@ -1,12 +1,9 @@
-<div class="tw-mb-4">
-  @if (sharedData.value(); as data) {
-    <p class="tw-text-center">
-      <b>{{ data.name }}</b>
-    </p>
-    <p class="tw-text-center tw-mb-0">{{ "sentYouThisRequest" | i18n: data.ownerEmail }}</p>
-  }
-</div>
 @if (showFileUploadResult()) {
+  <div class="tw-mb-4">
+    <p class="tw-text-center">
+      <b>{{ "successfullyUploadedDocuments" | i18n }}</b>
+    </p>
+  </div>
   <p class="tw-text-center tw-mb-0">{{ "filesUploadedSuccessfully" | i18n }}</p>
   <p class="tw-text-center tw-text-muted tw-text-sm tw-mb-0">
     @if (filesUploaded() == 1) {
@@ -21,6 +18,14 @@
     </button>
   </p>
 } @else {
+  <div class="tw-mb-4">
+    @if (sharedData.value(); as data) {
+      <p class="tw-text-center">
+        <b>{{ data.name }}</b>
+      </p>
+      <p class="tw-text-center tw-mb-0">{{ "sentYouThisRequest" | i18n: data.ownerEmail }}</p>
+    }
+  </div>
   <form [formGroup]="form" [bitSubmit]="uploadFiles">
     <bit-file-upload
       [maxFileSize]="500"

--- a/apps/web/src/app/tools/receive/receive-file-upload.component.ts
+++ b/apps/web/src/app/tools/receive/receive-file-upload.component.ts
@@ -10,6 +10,7 @@ import { toSignal } from "@angular/core/rxjs-interop";
 import { FormGroup, ReactiveFormsModule } from "@angular/forms";
 import { ActivatedRoute } from "@angular/router";
 
+import { ActiveSendIcon, Party } from "@bitwarden/assets/svg";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { ReceiveFileUploadInput } from "@bitwarden/common/tools/receive/models/receive-file-upload-input";
@@ -18,6 +19,7 @@ import { ReceiveFileService } from "@bitwarden/common/tools/receive/services/rec
 import { ReceiveService } from "@bitwarden/common/tools/receive/services/receive.service";
 import { ReceiveId } from "@bitwarden/common/types/guid";
 import {
+  AnonLayoutWrapperDataService,
   AsyncActionsModule,
   ButtonModule,
   FileUploadComponent,
@@ -46,6 +48,7 @@ export class ReceiveFileUploadComponent {
   private readonly receiveService = inject(ReceiveService);
   private readonly receiveFileService = inject(ReceiveFileService);
   private readonly route = inject(ActivatedRoute);
+  private readonly anonLayoutWrapperDataService = inject(AnonLayoutWrapperDataService);
 
   private readonly params = toSignal(this.route.paramMap);
   private readonly urlData = computed<ReceiveUrlData>(() => {
@@ -87,6 +90,7 @@ export class ReceiveFileUploadComponent {
   protected uploadMoreFiles() {
     this.files.set([]);
     this.showFileUploadResult.set(false);
+    this.anonLayoutWrapperDataService.setAnonLayoutWrapperData({ pageIcon: ActiveSendIcon });
   }
 
   protected readonly uploadFiles = async () => {
@@ -105,6 +109,7 @@ export class ReceiveFileUploadComponent {
     }
     this.filesUploaded.set(count);
     this.showFileUploadResult.set(true);
+    this.anonLayoutWrapperDataService.setAnonLayoutWrapperData({ pageIcon: Party });
   };
 
   private async uploadFile(file: File) {

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -46,6 +46,9 @@
       }
     }
   },
+  "successfullyUploadedDocuments": {
+    "message": "Successfully uploaded documents"
+  },
   "allApplications": {
     "message": "All applications"
   },


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-34561

## 📔 Objective

Show party icon instead of the active send icon after you upload files. Change the wording after you upload files to better represent the action

## 📸 Screenshots

<img width="497" height="340" alt="image" src="https://github.com/user-attachments/assets/6cf8db2c-896e-4a8e-9e51-b56744e052c7" />
