### PR TITLE
[CL-1149] BUG FIX: avatar color syncing between client apps

### DIFF
--- a/apps/desktop/src/auth/components/account-switcher/account-switcher-v2.component.ts
+++ b/apps/desktop/src/auth/components/account-switcher/account-switcher-v2.component.ts
@@ -106,8 +106,11 @@ export class AccountSwitcherV2Component implements OnInit {
     private biometricsService: DesktopBiometricsService,
     private configService: ConfigService,
   ) {
-    this.activeAccount$ = this.accountService.activeAccount$.pipe(
-      switchMap(async (active) => {
+    this.activeAccount$ = combineLatest([
+      this.accountService.activeAccount$,
+      this.avatarService.avatarColor$,
+    ]).pipe(
+      switchMap(async ([active, avatarColor]) => {
         if (active == null) {
           return null;
         }
@@ -121,7 +124,7 @@ export class AccountSwitcherV2Component implements OnInit {
           id: active.id,
           name: active.name,
           email: active.email,
-          avatarColor: await firstValueFrom(this.avatarService.avatarColor$),
+          avatarColor,
           server: (
             await firstValueFrom(this.environmentService.getEnvironment$(active.id))
           )?.getHostname(),


### PR DESCRIPTION
## 🎟️ Tracking

[JIRA](https://bitwarden.atlassian.net/browse/CL-1149?atlOrigin=eyJpIjoiZWY3Zjk3NzgzMWUyNDcxZmJhNTk1YWRkOGM3Njc3MmEiLCJwIjoiaiJ9)

## 📔 Objective

Fixed desktop account switcher avatar color not updating when changed in web unless user locks or logs in/out

## Testing

1. Login to an env on web
2. Login to the same account/env on desktop
3. On web, change the color of the avatar
4. See that desktop does not change colors

**Expected** - avatar color changes to the desired color immediately

## Screen Recording


https://github.com/user-attachments/assets/105fc7e7-02cd-4975-b8ff-b4c0997c1fb7

