### PR TITLE
Misc cleanup to make the components use modern angular

### DIFF
--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -1083,6 +1083,7 @@ export default class MainBackground {
       this.keyGenerationService,
       this.receiveApiService,
       this.stateProvider,
+      this.environmentService,
     );
 
     this.syncService = new DefaultSyncService(

--- a/apps/cli/src/service-container/service-container.ts
+++ b/apps/cli/src/service-container/service-container.ts
@@ -657,6 +657,7 @@ export class ServiceContainer {
       this.keyGenerationService,
       this.receiveApiService,
       this.stateProvider,
+      this.environmentService,
     );
 
     this.sendPasswordService = new DefaultSendPasswordService(this.cryptoFunctionService);
@@ -952,6 +953,7 @@ export class ServiceContainer {
       this.keyGenerationService,
       this.receiveApiService,
       this.stateProvider,
+      this.environmentService,
     );
 
     this.syncService = new DefaultSyncService(

--- a/apps/web/src/app/tools/receive/receive-files-view.component.html
+++ b/apps/web/src/app/tools/receive/receive-files-view.component.html
@@ -1,34 +1,23 @@
-@if (receiveView()?.fileData?.length > 0) {
-  <bit-section>
-    <bit-section-header>
-      <h2 bitTypography="h6">
-        {{ "receives" | i18n }} {{ "(" + receiveView().fileData?.length + ")" }}
-      </h2>
-    </bit-section-header>
-    <bit-card>
-      <bit-item-group>
-        @for (file of receiveView().fileData; track file.id) {
-          <bit-item>
-            <bit-item-content>
-              <bit-icon-tile slot="start" icon="bwi-file" />
-              <span data-testid="file-name">{{ file.fileName }}</span>
-              <span slot="secondary">{{ file.sizeName }}</span>
-            </bit-item-content>
-            <ng-container slot="end">
-              <bit-item-action>
-                <button
-                  type="button"
-                  bitIconButton="bwi-download"
-                  buttonType="main"
-                  size="small"
-                  [label]="'download' | i18n"
-                  [bitAction]="downloadFile(file)"
-                ></button>
-              </bit-item-action>
-            </ng-container>
-          </bit-item>
-        }
-      </bit-item-group>
-    </bit-card>
-  </bit-section>
-}
+<bit-item-group>
+  @for (file of receiveView().fileData; track file.id) {
+    <bit-item>
+      <bit-item-content>
+        <bit-icon-tile slot="start" icon="bwi-file" />
+        <span data-testid="file-name">{{ file.fileName }}</span>
+        <span slot="secondary">{{ file.sizeName }}</span>
+      </bit-item-content>
+      <ng-container slot="end">
+        <bit-item-action>
+          <button
+            type="button"
+            bitIconButton="bwi-download"
+            buttonType="main"
+            size="small"
+            [label]="'download' | i18n"
+            [bitAction]="downloadFile(file)"
+          ></button>
+        </bit-item-action>
+      </ng-container>
+    </bit-item>
+  }
+</bit-item-group>

--- a/apps/web/src/app/tools/receive/receive-files-view.component.ts
+++ b/apps/web/src/app/tools/receive/receive-files-view.component.ts
@@ -8,11 +8,7 @@ import {
   BitActionDirective,
   IconButtonModule,
   ItemModule,
-  SectionHeaderComponent,
-  TypographyModule,
   IconTileComponent,
-  CardComponent,
-  SectionComponent,
 } from "@bitwarden/components";
 import { I18nPipe } from "@bitwarden/ui-common";
 
@@ -25,13 +21,7 @@ import { I18nPipe } from "@bitwarden/ui-common";
     IconButtonModule,
     ItemModule,
     BitActionDirective,
-    SectionHeaderComponent,
-    TypographyModule,
-    SectionComponent,
-    SectionHeaderComponent,
-    CardComponent,
     IconTileComponent,
-    TypographyModule,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/apps/web/src/app/tools/receive/receive-success.component.ts
+++ b/apps/web/src/app/tools/receive/receive-success.component.ts
@@ -1,11 +1,9 @@
-import { ChangeDetectionStrategy, Component, computed, inject } from "@angular/core";
+import { ChangeDetectionStrategy, Component, inject } from "@angular/core";
 import { toSignal } from "@angular/core/rxjs-interop";
-import { map } from "rxjs";
 
 import { ActiveSendIcon } from "@bitwarden/assets/svg";
-import { EnvironmentService } from "@bitwarden/common/platform/abstractions/environment.service";
-import { buildReceiveUrl } from "@bitwarden/common/tools/receive/models/receive-url-data";
 import { ReceiveView } from "@bitwarden/common/tools/receive/models/view/receive.view";
+import { ReceiveService } from "@bitwarden/common/tools/receive/services/receive.service";
 import {
   ButtonModule,
   CopyClickDirective,
@@ -35,18 +33,7 @@ import { I18nPipe } from "@bitwarden/ui-common";
 export class ReceiveSuccessComponent {
   protected readonly activeReceiveIcon = ActiveSendIcon;
   protected readonly receive = inject<ReceiveView>(DIALOG_DATA);
+  private readonly receiveService = inject(ReceiveService);
 
-  private readonly environmentService = inject(EnvironmentService);
-
-  private readonly baseReceiveUrl = toSignal(
-    this.environmentService.environment$.pipe(map((env) => env.getWebVaultUrl() + "/#/receive")),
-  );
-
-  protected readonly receiveLink = computed(() => {
-    const baseUrl = this.baseReceiveUrl();
-    if (!baseUrl) {
-      return null;
-    }
-    return buildReceiveUrl(this.receive, baseUrl);
-  });
+  protected readonly receiveLink = toSignal(this.receiveService.buildReceiveUrl$(this.receive));
 }

--- a/apps/web/src/app/tools/receive/receive-table.component.html
+++ b/apps/web/src/app/tools/receive/receive-table.component.html
@@ -11,44 +11,36 @@
       </tr>
     </ng-container>
     <ng-template body let-rows$>
-      <tr bitRow *ngFor="let r of rows$ | async">
-        <td bitCell (click)="onViewReceive(r)" class="tw-cursor-pointer">
+      <tr
+        bitRow
+        *ngFor="let r of rows$ | async"
+        (click)="onViewReceive(r)"
+        class="tw-cursor-pointer"
+      >
+        <td bitCell>
           <div class="tw-flex tw-gap-2 tw-items-center">
             <button type="button" bitLink>
               {{ r.name }}
-              @if (isExpired(r)) {
+              @if (r.expired) {
                 <span class="tw-sr-only">, {{ "expired" | i18n }}</span>
               }
             </button>
-            @if (isExpired(r)) {
-              <i
-                class="bwi bwi-clock"
-                appStopProp
-                title="{{ 'expired' | i18n }}"
-                aria-hidden="true"
-              ></i>
+            @if (r.expired) {
+              <bit-icon name="bwi-clock" appStopProp title="{{ 'expired' | i18n }}" />
             }
           </div>
         </td>
-        <td
-          bitCell
-          (click)="onViewReceive(r)"
-          class="tw-text-muted tw-cursor-pointer @lg/receive-table:tw-table-cell tw-hidden"
-        >
+        <td bitCell class="tw-text-muted @lg/receive-table:tw-table-cell tw-hidden">
           <small bitTypography="body2" appStopProp>
             {{ r.fileData?.length ?? 0 }}
           </small>
         </td>
-        <td
-          bitCell
-          (click)="onViewReceive(r)"
-          class="tw-text-muted tw-cursor-pointer @lg/receive-table:tw-table-cell tw-hidden"
-        >
+        <td bitCell class="tw-text-muted @lg/receive-table:tw-table-cell tw-hidden">
           <small bitTypography="body2" appStopProp>
             {{ r.expirationDate | date: "medium" }}
           </small>
         </td>
-        <td bitCell class="tw-w-0 tw-text-right">
+        <td bitCell class="tw-w-0 tw-text-right" appStopProp>
           <button
             type="button"
             size="small"
@@ -58,12 +50,12 @@
           ></button>
           <bit-menu #receiveOptions>
             <button type="button" bitMenuItem (click)="onCopy(r)">
-              <i class="bwi bwi-fw bwi-clone" aria-hidden="true"></i>
+              <bit-icon name="bwi-clone" fixedWidth />
               {{ "copyReceiveLink" | i18n }}
             </button>
             <button type="button" bitMenuItem (click)="onDelete(r)">
               <span class="tw-text-danger">
-                <i class="bwi bwi-fw bwi-trash" aria-hidden="true"></i>
+                <bit-icon name="bwi-trash" fixedWidth />
                 {{ "delete" | i18n }}
               </span>
             </button>

--- a/apps/web/src/app/tools/receive/receive-table.component.ts
+++ b/apps/web/src/app/tools/receive/receive-table.component.ts
@@ -7,18 +7,23 @@ import {
   BadgeModule,
   ButtonModule,
   IconButtonModule,
+  IconModule,
   LinkModule,
   MenuModule,
   TableDataSource,
   TableModule,
   TypographyModule,
 } from "@bitwarden/components";
+import { I18nPipe } from "@bitwarden/ui-common";
+
+import { ReceiveRow } from "./receive.component";
 
 @Component({
   selector: "app-receive-table",
   templateUrl: "./receive-table.component.html",
   imports: [
     CommonModule,
+    I18nPipe,
     JslibModule,
     TableModule,
     ButtonModule,
@@ -26,13 +31,13 @@ import {
     IconButtonModule,
     MenuModule,
     BadgeModule,
+    IconModule,
     TypographyModule,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ReceiveTableComponent {
-  readonly dataSource = input<TableDataSource<ReceiveView>>();
-  readonly disableReceive = input(false);
+  readonly dataSource = input<TableDataSource<ReceiveRow>>();
 
   readonly viewReceive = output<ReceiveView>();
   readonly copyReceive = output<ReceiveView>();
@@ -48,9 +53,5 @@ export class ReceiveTableComponent {
 
   protected onDelete(receive: ReceiveView): void {
     this.deleteReceive.emit(receive);
-  }
-
-  protected isExpired(view: ReceiveView): boolean {
-    return view.expirationDate != null && view.expirationDate < new Date();
   }
 }

--- a/apps/web/src/app/tools/receive/receive-view.component.html
+++ b/apps/web/src/app/tools/receive/receive-view.component.html
@@ -6,8 +6,8 @@
         {{ "receiveExpiredCallout" | i18n }}
       </bit-callout>
     }
-    <bit-section class="tw-mb-4">
-      <bit-section-header class="tw-mt-2">
+    <bit-section>
+      <bit-section-header>
         <h2 bitTypography="h6">Receive Details</h2>
       </bit-section-header>
       <bit-card>
@@ -20,7 +20,9 @@
             bitSuffix
             [label]="'copyLink' | i18n"
             [disabled]="isExpired()"
-            (click)="copyLink()"
+            [appCopyClick]="receiveLink()"
+            showToast
+            [valueLabel]="'receiveLink' | i18n"
           ></button>
         </bit-form-field>
         <dl>
@@ -30,7 +32,18 @@
       </bit-card>
     </bit-section>
 
-    <app-receive-files-view [receiveView]="receive"></app-receive-files-view>
+    @if (receive.fileData?.length > 0) {
+      <bit-section>
+        <bit-section-header>
+          <h2 bitTypography="h6">
+            {{ "receives" | i18n }} {{ "(" + receive.fileData?.length + ")" }}
+          </h2>
+        </bit-section-header>
+        <bit-card>
+          <app-receive-files-view [receiveView]="receive" />
+        </bit-card>
+      </bit-section>
+    }
   </ng-container>
   <ng-container bitDialogFooter>
     <button type="button" bitButton buttonType="primary" (click)="openEdit()">

--- a/apps/web/src/app/tools/receive/receive-view.component.ts
+++ b/apps/web/src/app/tools/receive/receive-view.component.ts
@@ -1,17 +1,14 @@
 import { DatePipe } from "@angular/common";
-import { ChangeDetectionStrategy, Component, computed, Inject } from "@angular/core";
+import { ChangeDetectionStrategy, Component, computed, inject } from "@angular/core";
 import { toSignal } from "@angular/core/rxjs-interop";
-import { map } from "rxjs";
 
-import { EnvironmentService } from "@bitwarden/common/platform/abstractions/environment.service";
-import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
-import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
-import { buildReceiveUrl } from "@bitwarden/common/tools/receive/models/receive-url-data";
 import { ReceiveView } from "@bitwarden/common/tools/receive/models/view/receive.view";
+import { ReceiveService } from "@bitwarden/common/tools/receive/services/receive.service";
 import {
   ButtonModule,
   CalloutModule,
   CardComponent,
+  CopyClickDirective,
   DIALOG_DATA,
   DialogModule,
   DialogRef,
@@ -20,7 +17,6 @@ import {
   IconButtonModule,
   SectionComponent,
   SectionHeaderComponent,
-  ToastService,
   TypographyModule,
 } from "@bitwarden/components";
 import { I18nPipe } from "@bitwarden/ui-common";
@@ -32,6 +28,7 @@ import { ReceiveFilesViewComponent } from "./receive-files-view.component";
   templateUrl: "./receive-view.component.html",
   imports: [
     CalloutModule,
+    CopyClickDirective,
     DatePipe,
     DialogModule,
     ButtonModule,
@@ -47,43 +44,16 @@ import { ReceiveFilesViewComponent } from "./receive-files-view.component";
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ReceiveViewComponent {
-  private readonly baseReceiveUrl = toSignal(
-    this.environmentService.environment$.pipe(map((env) => env.getWebVaultUrl() + "/#/receive")),
-  );
+  protected readonly receive = inject<ReceiveView>(DIALOG_DATA);
+  private readonly dialogRef = inject(DialogRef);
+  private readonly dialogService = inject(DialogService);
+  private readonly receiveService = inject(ReceiveService);
 
   protected readonly isExpired = computed(
     () => this.receive.expirationDate != null && this.receive.expirationDate < new Date(),
   );
 
-  protected readonly receiveLink = computed(() => {
-    const baseUrl = this.baseReceiveUrl();
-    if (!baseUrl) {
-      return null;
-    }
-    return buildReceiveUrl(this.receive, baseUrl);
-  });
-
-  constructor(
-    @Inject(DIALOG_DATA) protected readonly receive: ReceiveView,
-    private readonly dialogRef: DialogRef,
-    private readonly dialogService: DialogService,
-    private readonly i18nService: I18nService,
-    private readonly platformUtilsService: PlatformUtilsService,
-    private readonly toastService: ToastService,
-    private readonly environmentService: EnvironmentService,
-  ) {}
-
-  protected copyLink(): void {
-    const receiveLink = this.receiveLink();
-    if (!receiveLink) {
-      return;
-    }
-    this.platformUtilsService.copyToClipboard(receiveLink);
-    this.toastService.showToast({
-      variant: "success",
-      message: this.i18nService.t("valueCopied", this.i18nService.t("receiveLink")),
-    });
-  }
+  protected readonly receiveLink = toSignal(this.receiveService.buildReceiveUrl$(this.receive));
 
   protected openEdit(): void {
     this.dialogRef.close();

--- a/apps/web/src/app/tools/receive/receive-view.ts
+++ b/apps/web/src/app/tools/receive/receive-view.ts
@@ -1,5 +1,0 @@
-export const ReceiveListState = Object.freeze({
-  Empty: "Empty",
-  NoResults: "NoResults",
-} as const);
-export type ReceiveListState = (typeof ReceiveListState)[keyof typeof ReceiveListState];

--- a/apps/web/src/app/tools/receive/receive.component.html
+++ b/apps/web/src/app/tools/receive/receive.component.html
@@ -4,33 +4,28 @@
   </button>
 </app-header>
 
-<div>
-  @if (loading()) {
-    <bit-spinner />
-  } @else {
-    <bit-search
-      [ngModel]="currentSearchText()"
-      (ngModelChange)="searchTextChanged($event)"
-      [placeholder]="'search' | i18n"
-      appAutofocus
-    />
-    <app-receive-table
-      [dataSource]="dataSource"
-      (viewReceive)="openViewReceiveDrawer($event)"
-      (copyReceive)="copyReceiveLink($event)"
-    />
-    @if (noSearchResults()) {
+@if (loading()) {
+  <bit-spinner />
+} @else {
+  <bit-search [(ngModel)]="searchText" [placeholder]="'search' | i18n" appAutofocus />
+  <app-receive-table
+    [dataSource]="dataSource"
+    (viewReceive)="openViewReceiveDrawer($event)"
+    (copyReceive)="copyReceiveLink($event)"
+    (deleteReceive)="confirmDeleteReceive($event)"
+  />
+  @switch (listState()) {
+    @case (ReceiveListState.NoSearchResults) {
       <bit-no-items [icon]="noResultsIcon">
         <ng-container slot="title">{{ "receivesTitleNoSearchResults" | i18n }}</ng-container>
         <ng-container slot="description">{{ "receivesBodyNoSearchResults" | i18n }}</ng-container>
       </bit-no-items>
-    } @else if (
-      listState() === ReceiveListState.NoResults || listState() === ReceiveListState.Empty
-    ) {
+    }
+    @case (ReceiveListState.Empty) {
       <bit-no-items [icon]="noItemIcon">
         <ng-container slot="title">{{ "receivesTitleNoItems" | i18n }}</ng-container>
         <ng-container slot="description">{{ "receivesBodyNoItems" | i18n }}</ng-container>
       </bit-no-items>
     }
   }
-</div>
+}

--- a/apps/web/src/app/tools/receive/receive.component.ts
+++ b/apps/web/src/app/tools/receive/receive.component.ts
@@ -1,18 +1,18 @@
-import { Component, computed, signal } from "@angular/core";
-import { takeUntilDestroyed, toSignal } from "@angular/core/rxjs-interop";
+import { ChangeDetectionStrategy, Component, computed, effect, inject, model } from "@angular/core";
+import { toSignal } from "@angular/core/rxjs-interop";
 import { FormsModule } from "@angular/forms";
-import { map, switchMap } from "rxjs";
+import { firstValueFrom, switchMap } from "rxjs";
 
-import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { NoResults, NoSendsIcon } from "@bitwarden/assets/svg";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { getUserId } from "@bitwarden/common/auth/services/account.service";
-import { EnvironmentService } from "@bitwarden/common/platform/abstractions/environment.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
-import { buildReceiveUrl } from "@bitwarden/common/tools/receive/models/receive-url-data";
 import { ReceiveView } from "@bitwarden/common/tools/receive/models/view/receive.view";
-import { ReceiveService } from "@bitwarden/common/tools/receive/services/receive.service";
+import {
+  InternalReceiveService,
+  ReceiveService,
+} from "@bitwarden/common/tools/receive/services/receive.service";
 import {
   ButtonModule,
   DialogService,
@@ -29,18 +29,22 @@ import { HeaderModule } from "../../layouts/header/header.module";
 
 import { ReceiveAddEditComponent } from "./receive-add-edit.component";
 import { ReceiveTableComponent } from "./receive-table.component";
-import { ReceiveListState } from "./receive-view";
 import { ReceiveViewComponent } from "./receive-view.component";
 
-// FIXME(https://bitwarden.atlassian.net/browse/CL-764): Migrate to OnPush
-// eslint-disable-next-line @angular-eslint/prefer-on-push-component-change-detection
+export type ReceiveRow = ReceiveView & { expired: boolean };
+
+export const ReceiveListState = Object.freeze({
+  Empty: "Empty",
+  NoSearchResults: "NoSearchResults",
+} as const);
+export type ReceiveListState = (typeof ReceiveListState)[keyof typeof ReceiveListState];
+
 @Component({
   selector: "app-receive",
   templateUrl: "receive.component.html",
   imports: [
     FormsModule,
     I18nPipe,
-    JslibModule,
     ButtonModule,
     SearchModule,
     NoItemsModule,
@@ -49,69 +53,81 @@ import { ReceiveViewComponent } from "./receive-view.component";
     ToggleGroupModule,
     ReceiveTableComponent,
   ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ReceiveComponent {
   protected readonly noItemIcon = NoSendsIcon;
   protected readonly noResultsIcon = NoResults;
   protected readonly ReceiveListState = ReceiveListState;
 
-  protected readonly loading = signal(true);
-  protected readonly listState = signal<ReceiveListState | null>(null);
-  protected readonly currentSearchText = signal("");
-  protected readonly dataSource = new TableDataSource<ReceiveView>();
+  private readonly dialogService = inject(DialogService);
+  private readonly receiveService = inject(InternalReceiveService);
+  private readonly accountService = inject(AccountService);
+  private readonly i18nService = inject(I18nService);
+  private readonly platformUtilsService = inject(PlatformUtilsService);
+  private readonly toastService = inject(ToastService);
+  private readonly receiveUrlService = inject(ReceiveService);
 
-  protected readonly noSearchResults = computed(
-    () => this.currentSearchText().length > 0 && this.dataSource.filteredData?.length === 0,
+  protected readonly searchText = model("");
+  protected readonly dataSource = new TableDataSource<ReceiveRow>();
+
+  private readonly receives = toSignal(
+    this.accountService.activeAccount$.pipe(
+      getUserId,
+      switchMap((userId) => this.receiveService.receiveViews$(userId)),
+    ),
   );
 
-  private readonly baseReceiveUrl = toSignal(
-    this.environmentService.environment$.pipe(map((env) => env.getWebVaultUrl() + "/#/receive")),
-  );
+  protected readonly loading = computed(() => this.receives() == null);
 
-  constructor(
-    private readonly dialogService: DialogService,
-    private readonly receiveService: ReceiveService,
-    private readonly accountService: AccountService,
-    private readonly environmentService: EnvironmentService,
-    private readonly i18nService: I18nService,
-    private readonly platformUtilsService: PlatformUtilsService,
-    private readonly toastService: ToastService,
-  ) {
-    this.accountService.activeAccount$
-      .pipe(
-        getUserId,
-        switchMap((userId) => this.receiveService.receiveViews$(userId)),
-        takeUntilDestroyed(),
-      )
-      .subscribe((receives) => {
-        this.dataSource.data = receives;
-        this.loading.set(false);
-        this.listState.set(receives.length === 0 ? ReceiveListState.Empty : null);
-      });
+  protected readonly listState = computed<ReceiveListState | null>(() => {
+    const receives = this.receives();
+    if (receives == null) {
+      return null;
+    }
+    if (receives.length === 0) {
+      return ReceiveListState.Empty;
+    }
+    if (this.searchText().length > 0 && this.dataSource.filteredData?.length === 0) {
+      return ReceiveListState.NoSearchResults;
+    }
+    return null;
+  });
+
+  constructor() {
+    effect(() => {
+      const receives = this.receives();
+      if (receives != null) {
+        const now = new Date();
+        this.dataSource.data = receives.map((r) => ({
+          ...r,
+          expired: r.expirationDate != null && r.expirationDate < now,
+        }));
+      }
+    });
+
+    effect(() => {
+      this.dataSource.filter = this.receiveFilter(this.searchText());
+    });
   }
 
-  openNewReceiveDrawer(): void {
+  protected openNewReceiveDrawer(): void {
     this.dialogService.openDrawer(ReceiveAddEditComponent, { closeOnNavigation: true });
   }
 
-  openViewReceiveDrawer(receive: ReceiveView): void {
+  protected openViewReceiveDrawer(receive: ReceiveView): void {
     this.dialogService.openDrawer(ReceiveViewComponent, {
       data: receive,
       closeOnNavigation: true,
     });
   }
 
-  searchTextChanged(newSearchText: string): void {
-    this.currentSearchText.set(newSearchText);
-    this.dataSource.filter = this.receiveFilter(newSearchText);
-  }
-
-  private receiveFilter(query: string): (receive: ReceiveView) => boolean {
+  private receiveFilter(query: string): (receive: ReceiveRow) => boolean {
     const normalizedQuery = query.trim().toLowerCase();
     if (!normalizedQuery) {
       return () => true;
     }
-    return (receive: ReceiveView) => {
+    return (receive: ReceiveRow) => {
       if (receive.name?.toLowerCase().includes(normalizedQuery)) {
         return true;
       }
@@ -122,18 +138,36 @@ export class ReceiveComponent {
     };
   }
 
-  protected copyReceiveLink(receive: ReceiveView): void {
-    const baseUrl = this.baseReceiveUrl();
-    if (!baseUrl) {
+  protected async copyReceiveLink(receive: ReceiveView): Promise<void> {
+    const receiveLink = await firstValueFrom(this.receiveUrlService.buildReceiveUrl$(receive));
+    if (!receiveLink) {
       return;
     }
-
-    const receiveLink = buildReceiveUrl(receive, baseUrl);
 
     this.platformUtilsService.copyToClipboard(receiveLink);
     this.toastService.showToast({
       variant: "success",
       message: this.i18nService.t("valueCopied", this.i18nService.t("receiveLink")),
+    });
+  }
+
+  async confirmDeleteReceive($event: ReceiveView) {
+    const confirmed = await this.dialogService.openSimpleDialog({
+      title: { key: "deleteReceive" },
+      content: { key: "deleteReceivePermanentConfirmation" },
+      type: "warning",
+    });
+
+    if (!confirmed) {
+      return;
+    }
+
+    const userId = await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId));
+    await this.receiveService.delete($event.id, userId);
+
+    this.toastService.showToast({
+      variant: "success",
+      message: this.i18nService.t("receiveDeleted"),
     });
   }
 }

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -6466,6 +6466,18 @@
   "generateLink": {
     "message": "Generate Link"
   },
+  "deleteReceive": {
+    "message": "Delete Receive",
+    "description": "'Receive' is a noun and the name of a feature called 'Bitwarden Receive'. It should not be translated."
+  },
+  "deleteReceivePermanentConfirmation": {
+    "message": "Are you sure you want to permanently delete this Receive?",
+    "description": "'Receive' is a noun and the name of a feature called 'Bitwarden Receive'. It should not be translated."
+  },
+  "deletedReceive": {
+    "message": "Receive deleted",
+    "description": "'Receive' is a noun and the name of a feature called 'Bitwarden Receive'. It should not be translated."
+  },
   "sendAccessTaglineProductDesc": {
     "message": "Bitwarden Send transmits sensitive, temporary information to others easily and securely.",
     "description": "'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated."

--- a/libs/angular/src/services/jslib-services.module.ts
+++ b/libs/angular/src/services/jslib-services.module.ts
@@ -899,7 +899,14 @@ const safeProviders: SafeProvider[] = [
   safeProvider({
     provide: InternalReceiveService,
     useClass: DefaultReceiveService,
-    deps: [EncryptService, KeyService, KeyGenerationService, ReceiveApiService, StateProvider],
+    deps: [
+      EncryptService,
+      KeyService,
+      KeyGenerationService,
+      ReceiveApiService,
+      StateProvider,
+      EnvironmentService,
+    ],
   }),
   safeProvider({
     provide: ReceiveApiService,

--- a/libs/common/src/tools/receive/services/default-receive.service.spec.ts
+++ b/libs/common/src/tools/receive/services/default-receive.service.spec.ts
@@ -9,6 +9,7 @@ import { UserId } from "@bitwarden/user-core";
 import { KeyGenerationService } from "../../../key-management/crypto";
 import { EncryptService } from "../../../key-management/crypto/abstractions/encrypt.service";
 import { EncString } from "../../../key-management/crypto/models/enc-string";
+import { EnvironmentService } from "../../../platform/abstractions/environment.service";
 import { Utils } from "../../../platform/misc/utils";
 import { SymmetricCryptoKey } from "../../../platform/models/domain/symmetric-crypto-key";
 import { CsprngArray } from "../../../types/csprng";
@@ -25,6 +26,7 @@ describe("DefaultReceiveService", () => {
   const keyGenerationService = mock<KeyGenerationService>();
   const receiveApiService = mock<ReceiveApiService>();
   const stateProvider = mock<StateProvider>();
+  const environmentService = mock<EnvironmentService>();
 
   const mockUserId = Utils.newGuid() as UserId;
   const mockUserKey = new SymmetricCryptoKey(new Uint8Array(64) as CsprngArray) as UserKey;
@@ -71,6 +73,7 @@ describe("DefaultReceiveService", () => {
       keyGenerationService,
       receiveApiService,
       stateProvider,
+      environmentService,
     );
   });
 

--- a/libs/common/src/tools/receive/services/default-receive.service.ts
+++ b/libs/common/src/tools/receive/services/default-receive.service.ts
@@ -3,6 +3,7 @@ import { combineLatest, firstValueFrom, map, Observable, of, switchMap } from "r
 import { KeyGenerationService } from "@bitwarden/common/key-management/crypto";
 import { EncryptService } from "@bitwarden/common/key-management/crypto/abstractions/encrypt.service";
 import { EncString } from "@bitwarden/common/key-management/crypto/models/enc-string";
+import { EnvironmentService } from "@bitwarden/common/platform/abstractions/environment.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
 import { ReceiveId } from "@bitwarden/common/types/guid";
@@ -17,7 +18,7 @@ import { Receive } from "../models/domain/receive";
 import { ReceiveFile } from "../models/domain/receive-file";
 import { ReceiveCreateInput } from "../models/receive-create-input";
 import { ReceiveSharedData } from "../models/receive-shared-data";
-import { ReceiveUrlData } from "../models/receive-url-data";
+import { buildReceiveUrl, ReceiveUrlData } from "../models/receive-url-data";
 import { CreateReceiveRequest } from "../models/requests/create-receive.request";
 import { UpdateReceiveRequest } from "../models/requests/update-receive.request";
 import { ReceiveSharedDataResponse } from "../models/response/receive-shared-data.response";
@@ -42,9 +43,10 @@ export class DefaultReceiveService implements InternalReceiveService {
     private keyGenerationService: KeyGenerationService,
     private receiveApiService: ReceiveApiService,
     private stateProvider: StateProvider,
+    private environmentService: EnvironmentService,
   ) {}
 
-  receives$(userId: UserId): Observable<Receive[]> {
+  private receives$(userId: UserId): Observable<Receive[]> {
     return this.stateProvider.getUser(userId, RECEIVE_ENCRYPTED_RECEIVES).state$.pipe(
       map((receives) => {
         if (receives == null) {
@@ -90,6 +92,12 @@ export class DefaultReceiveService implements InternalReceiveService {
     await this.upsert(data, userId);
   }
 
+  buildReceiveUrl$(receive: ReceiveView): Observable<string | null> {
+    return this.environmentService.environment$.pipe(
+      map((env) => buildReceiveUrl(receive, env.getWebVaultUrl() + "/#/receive")),
+    );
+  }
+
   async getSharedData(urlData: ReceiveUrlData): Promise<ReceiveSharedData> {
     const response = await this.receiveApiService.postReceiveAccess(
       urlData.receiveId,
@@ -124,6 +132,18 @@ export class DefaultReceiveService implements InternalReceiveService {
   async get(id: ReceiveId, userId: UserId): Promise<Receive | undefined> {
     const receives = await firstValueFrom(this.receives$(userId));
     return receives.find((r) => r.id === id);
+  }
+
+  async delete(id: ReceiveId, userId: UserId): Promise<void> {
+    await this.receiveApiService.deleteReceive(id);
+
+    await this.stateProvider.getUser(userId, RECEIVE_ENCRYPTED_RECEIVES).update((receives) => {
+      if (receives == null) {
+        return receives;
+      }
+      delete receives[id];
+      return receives;
+    });
   }
 
   private async decryptResponse(

--- a/libs/common/src/tools/receive/services/receive.service.ts
+++ b/libs/common/src/tools/receive/services/receive.service.ts
@@ -11,8 +11,6 @@ import { ReceiveUrlData } from "../models/receive-url-data";
 import { ReceiveView } from "../models/view/receive.view";
 
 export abstract class ReceiveService {
-  // Get all the encrypted receives for the user.
-  abstract receives$(userId: UserId): Observable<Receive[]>;
   // Get all the decrypted receive views for the user.
   abstract receiveViews$(userId: UserId): Observable<ReceiveView[]>;
   // Create a new receive with the given input and return the created receive.
@@ -21,6 +19,9 @@ export abstract class ReceiveService {
   abstract update(receiveView: ReceiveView, userId: UserId): Promise<void>;
 
   abstract getSharedData(urlData: ReceiveUrlData): Promise<ReceiveSharedData>;
+
+  // Build the full shareable URL for a receive, based on the current environment.
+  abstract buildReceiveUrl$(receive: ReceiveView): Observable<string | null>;
 }
 
 export abstract class InternalReceiveService extends ReceiveService {
@@ -30,4 +31,6 @@ export abstract class InternalReceiveService extends ReceiveService {
   abstract upsert(receiveData: ReceiveData | ReceiveData[], userId: UserId): Promise<void>;
   // Used to get local state by receive id & userId for sync notification processing.
   abstract get(id: ReceiveId, userId: UserId): Promise<Receive | undefined>;
+  // Delete a receive by id for the user.
+  abstract delete(id: ReceiveId, userId: UserId): Promise<void>;
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-34599
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
- Extracts duplicated receive URL construction into `ReceiveService.buildReceiveUrl$()`, removing identical `baseReceiveUrl` / `buildReceiveUrl` patterns from 3 components (`ReceiveViewComponent`, `ReceiveSuccessComponent`, `ReceiveComponent`)
- Modernizes `ReceiveComponent` to OnPush change detection with signals (`toSignal`, `computed`, `model`, `effect`) replacing imperative `takeUntilDestroyed` subscription
- Converts `ReceiveViewComponent` from constructor DI to `inject()` and replaces manual copy-to-clipboard with `appCopyClick` directive
- Simplifies `ReceiveTableComponent` by pre-computing `expired` state in a `ReceiveRow` type and moving the row click handler to `<tr>`
- Cleans up `ReceiveFilesViewComponent` template — removes redundant section/card wrapper (now handled by parent)
- Adds delete confirmation flow with `confirmDeleteReceive` and new i18n messages
- Removes unused `receive-view.ts` file and `receives$` from public `ReceiveService` API (moved to `private` in implementation); adds `delete()` to `InternalReceiveService`

