### PR TITLE
[PM-34685][Defect] Subscription status for organizations not updating with feature flag enabled

### DIFF
--- a/apps/web/src/app/billing/organizations/organization-subscription-cloud.component.ts
+++ b/apps/web/src/app/billing/organizations/organization-subscription-cloud.component.ts
@@ -331,9 +331,12 @@ export class OrganizationSubscriptionCloudComponent implements OnInit, OnDestroy
   }
 
   get subscriptionMarkedForCancel() {
-    return (
-      this.subscription != null && !this.subscription.cancelled && this.subscription.cancelAtEndDate
-    );
+    if (!this.subscription || this.subscription.cancelled) {
+      return false;
+    }
+
+    const { status, cancelAtEndDate, cancelledDate } = this.subscription;
+    return cancelAtEndDate || (status === "active" && !!cancelledDate);
   }
 
   cancelSubscription = async () => {

--- a/apps/web/src/app/billing/organizations/subscription-status.component.spec.ts
+++ b/apps/web/src/app/billing/organizations/subscription-status.component.spec.ts
@@ -1,0 +1,114 @@
+import { DatePipe } from "@angular/common";
+import { TestBed } from "@angular/core/testing";
+import { mock } from "jest-mock-extended";
+
+import { OrganizationSubscriptionResponse } from "@bitwarden/common/billing/models/response/organization-subscription.response";
+import { BillingSubscriptionResponse } from "@bitwarden/common/billing/models/response/subscription.response";
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+
+import { SubscriptionStatusComponent } from "./subscription-status.component";
+
+function makeSubscription(
+  overrides: Partial<BillingSubscriptionResponse> = {},
+): BillingSubscriptionResponse {
+  return {
+    status: "active",
+    cancelAtEndDate: false,
+    cancelledDate: null,
+    cancelled: false,
+    items: [],
+    ...overrides,
+  } as BillingSubscriptionResponse;
+}
+
+function makeOrgResponse(
+  subscription: BillingSubscriptionResponse | null,
+): OrganizationSubscriptionResponse {
+  return { subscription } as OrganizationSubscriptionResponse;
+}
+
+describe("SubscriptionStatusComponent", () => {
+  let component: SubscriptionStatusComponent;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        SubscriptionStatusComponent,
+        { provide: I18nService, useValue: mock<I18nService>() },
+        { provide: DatePipe, useValue: mock<DatePipe>() },
+      ],
+    });
+
+    component = TestBed.inject(SubscriptionStatusComponent);
+  });
+
+  describe("status getter", () => {
+    it("returns 'free' when there is no subscription", () => {
+      component.organizationSubscriptionResponse = makeOrgResponse(null);
+      expect(component.status).toBe("free");
+    });
+
+    it("returns the subscription status when no cancellation is pending", () => {
+      component.organizationSubscriptionResponse = makeOrgResponse(
+        makeSubscription({ status: "active" }),
+      );
+      expect(component.status).toBe("active");
+    });
+
+    it("returns 'pending_cancellation' when cancelAtEndDate is true", () => {
+      component.organizationSubscriptionResponse = makeOrgResponse(
+        makeSubscription({ cancelAtEndDate: true }),
+      );
+      expect(component.status).toBe("pending_cancellation");
+    });
+
+    it("returns 'pending_cancellation' when cancelledDate is set (phase-based cancellation)", () => {
+      component.organizationSubscriptionResponse = makeOrgResponse(
+        makeSubscription({ cancelledDate: "2026-05-01" }),
+      );
+      expect(component.status).toBe("pending_cancellation");
+    });
+
+    it("returns 'canceled' even when cancelAtEndDate is true", () => {
+      component.organizationSubscriptionResponse = makeOrgResponse(
+        makeSubscription({ status: "canceled", cancelAtEndDate: true }),
+      );
+      expect(component.status).toBe("canceled");
+    });
+
+    it("returns 'canceled' even when cancelledDate is set", () => {
+      component.organizationSubscriptionResponse = makeOrgResponse(
+        makeSubscription({ status: "canceled", cancelledDate: "2026-05-01" }),
+      );
+      expect(component.status).toBe("canceled");
+    });
+
+    it("returns 'trialing' when status is trialing", () => {
+      component.organizationSubscriptionResponse = makeOrgResponse(
+        makeSubscription({ status: "trialing" }),
+      );
+      expect(component.status).toBe("trialing");
+    });
+
+    it("returns 'past_due' when status is past_due", () => {
+      component.organizationSubscriptionResponse = makeOrgResponse(
+        makeSubscription({ status: "past_due" }),
+      );
+      expect(component.status).toBe("past_due");
+    });
+
+    it("returns 'unpaid' when status is unpaid", () => {
+      component.organizationSubscriptionResponse = makeOrgResponse(
+        makeSubscription({ status: "unpaid" }),
+      );
+      expect(component.status).toBe("unpaid");
+    });
+
+    it("returns 'incomplete_expired' when status is incomplete_expired", () => {
+      component.organizationSubscriptionResponse = makeOrgResponse(
+        makeSubscription({ status: "incomplete_expired" }),
+      );
+      expect(component.status).toBe("incomplete_expired");
+    });
+  });
+});

--- a/apps/web/src/app/billing/organizations/subscription-status.component.ts
+++ b/apps/web/src/app/billing/organizations/subscription-status.component.ts
@@ -58,8 +58,7 @@ export class SubscriptionStatusComponent {
     }
 
     const { status, cancelAtEndDate, cancelledDate } = this.subscription;
-    const pendingCancellation =
-      cancelAtEndDate || (status === "active" && !!cancelledDate);
+    const pendingCancellation = cancelAtEndDate || (status === "active" && !!cancelledDate);
 
     if (status !== "canceled" && pendingCancellation) {
       return "pending_cancellation";

--- a/apps/web/src/app/billing/organizations/subscription-status.component.ts
+++ b/apps/web/src/app/billing/organizations/subscription-status.component.ts
@@ -53,11 +53,19 @@ export class SubscriptionStatusComponent {
   }
 
   get status(): string {
-    return this.subscription
-      ? this.subscription.status != "canceled" && this.subscription.cancelAtEndDate
-        ? "pending_cancellation"
-        : this.subscription.status
-      : "free";
+    if (!this.subscription) {
+      return "free";
+    }
+
+    const { status, cancelAtEndDate, cancelledDate } = this.subscription;
+    const pendingCancellation =
+      cancelAtEndDate || (status === "active" && !!cancelledDate);
+
+    if (status !== "canceled" && pendingCancellation) {
+      return "pending_cancellation";
+    }
+
+    return status;
   }
 
   get subscription() {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-34685

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Updates logic for determining subscription cancellation and status in organization billing components, and adds comprehensive unit tests for the `SubscriptionStatusComponent`. The changes ensure that both scheduled and phase-based cancellations are properly recognized and reflected in the UI.

The issue was `cancel_at_end_of_period` is not updated when schedules are being used, however, `cancel_at` is set when a schedule is updated. Scoping the check to `active` status of a subscription minimizes overlap with any other statuses.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->



https://github.com/user-attachments/assets/b4b0e37d-5c4e-4c31-9723-9a01c9d32a70


