### PR TITLE
[PM-34142] BUGFIX: Allow moving a newly created cipher to org

### DIFF
--- a/libs/vault/src/cipher-form/services/default-cipher-form.service.ts
+++ b/libs/vault/src/cipher-form/services/default-cipher-form.service.ts
@@ -51,7 +51,7 @@ export class DefaultCipherFormService implements CipherFormService {
     const newCollectionIds = new Set(cipher.collectionIds ?? []);
 
     // Call shareWithServer if the owner is changing from a user to an organization
-    if (config.originalCipher.organizationId === null && cipher.organizationId != null) {
+    if (config.originalCipher.organizationId == null && cipher.organizationId != null) {
       // shareWithServer expects the cipher to have no organizationId set
       const organizationId = cipher.organizationId as OrganizationId;
       cipher.organizationId = null;


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-34142

## 📔 Objective

When a personal cipher is newly created using the SDK, it is saved with `cipher.organizationId = undefined`. The strict null check when re-encrypting the cipher fails, and the admin endpoint is called which tries to decrypt the cipher with the wrong key.

This doesn't affectc ciphers stored using the `sync` endpoint, as those come back with `cipher.organizationId = null` - by removing the strict null check in favor of `==`, it now catches both `null` and `undefined` values, allowing us to share the newly created cipher to an organization.

## 📸 Screenshots


https://github.com/user-attachments/assets/27bc7207-7666-42f6-b5eb-3bde657f215d


