### PR TITLE
[PM-32463] Do not filter disabled orgs for Admin Console

### DIFF
--- a/apps/web/src/app/vault/org-vault/services/admin-console-cipher-form-config.service.spec.ts
+++ b/apps/web/src/app/vault/org-vault/services/admin-console-cipher-form-config.service.spec.ts
@@ -175,6 +175,37 @@ describe("AdminConsoleCipherFormConfigService", () => {
       expect(result.organizations).toEqual([testOrg, testOrg2]);
     });
 
+    it("includes disabled organizations when cloning", async () => {
+      const disabledOrg = {
+        ...testOrg2,
+        id: "disabled-org-id",
+        name: "Disabled Org",
+        enabled: false,
+      };
+      orgs$.next([testOrg, testOrg2, disabledOrg] as Organization[]);
+
+      const result = await adminConsoleConfigService.buildConfig("clone", cipherId);
+
+      expect(result.organizations).toEqual(
+        expect.arrayContaining([expect.objectContaining({ id: "disabled-org-id" })]),
+      );
+    });
+
+    it("includes disabled organization as current org for non-clone modes", async () => {
+      const disabledOrg = {
+        ...testOrg,
+        enabled: false,
+      };
+      orgs$.next([disabledOrg] as Organization[]);
+
+      const result = await adminConsoleConfigService.buildConfig("edit", cipherId);
+
+      expect(result.organizations).toEqual([expect.objectContaining({ enabled: false })]);
+
+      // Reset orgs$ to avoid side effects on subsequent tests
+      orgs$.next([testOrg, testOrg2] as Organization[]);
+    });
+
     it("retrieves the cipher from the admin service when canEditAllCiphers is true", async () => {
       getCipherAdmin.mockResolvedValue({ id: cipherId, name: "Test Cipher - (admin)" });
       testOrg.canEditAllCiphers = true;

--- a/apps/web/src/app/vault/org-vault/services/admin-console-cipher-form-config.service.ts
+++ b/apps/web/src/app/vault/org-vault/services/admin-console-cipher-form-config.service.ts
@@ -53,7 +53,7 @@ export class AdminConsoleCipherFormConfigService implements CipherFormConfigServ
       this.organizationService.organizations$(userId).pipe(
         map((orgs) => {
           return orgs.filter(
-            (o) => o.isMember && o.enabled && o.status === OrganizationUserStatusType.Confirmed,
+            (o) => o.isMember && o.status === OrganizationUserStatusType.Confirmed,
           );
         }),
       ),


### PR DESCRIPTION
## 🎟️ Tracking

[PM-32463](https://bitwarden.atlassian.net/browse/PM-32463)

## 📔 Objective

Avoid filtering out disabled orgs when building the cipher form. This allows disabled organization to still view their items without crashing the Admin Console.


[PM-32463]: https://bitwarden.atlassian.net/browse/PM-32463?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ