### PR TITLE
Enable the custom.regex package manager to enable rust toolchain updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,7 +1,7 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: ["github>bitwarden/renovate-config"], // Extends our default configuration for pinned dependencies
-  enabledManagers: ["cargo", "github-actions", "npm"],
+  enabledManagers: ["cargo", "github-actions", "npm", "custom.regex"],
   packageRules: [
     // ==================== Repo-Wide Update Behavior Rules ====================
     {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

We've been manually bumping the Rust toolchain version and this seems to be the reason why. The custom regex package manager wasn't included in the enabledManagers.

It's what the sdk-internal is doing here: https://github.com/bitwarden/sdk-internal/blob/d0baa0e8138d48540cc343e3272e2c01dfac32a1/.github/renovate.json5#L5

, and the toolchain updates are working in that repo.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
