### PR TITLE
[CL-1128] Fix OnPush Lit Ignore Kitchen Sink Stories

### DIFF
--- a/libs/components/src/stories/kitchen-sink/components/dialog-virtual-scroll-block.component.ts
+++ b/libs/components/src/stories/kitchen-sink/components/dialog-virtual-scroll-block.component.ts
@@ -1,5 +1,5 @@
 import { ScrollingModule } from "@angular/cdk/scrolling";
-import { Component, OnInit } from "@angular/core";
+import { ChangeDetectionStrategy, Component, OnInit, inject } from "@angular/core";
 
 import { DialogModule, DialogService } from "../../../dialog";
 import { IconButtonModule } from "../../../icon-button";
@@ -7,9 +7,8 @@ import { ScrollLayoutDirective } from "../../../layout";
 import { SectionComponent } from "../../../section";
 import { TableDataSource, TableModule } from "../../../table";
 
-// FIXME(https://bitwarden.atlassian.net/browse/CL-764): Migrate to OnPush
-// eslint-disable-next-line @angular-eslint/prefer-on-push-component-change-detection
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: "dialog-virtual-scroll-block",
   imports: [
     DialogModule,
@@ -48,9 +47,12 @@ import { TableDataSource, TableModule } from "../../../table";
   </bit-section>`,
 })
 export class DialogVirtualScrollBlockComponent implements OnInit {
-  constructor(public dialogService: DialogService) {}
-
-  protected dataSource = new TableDataSource<{ id: number; name: string; other: string }>();
+  protected readonly dialogService = inject(DialogService);
+  protected readonly dataSource = new TableDataSource<{
+    id: number;
+    name: string;
+    other: string;
+  }>();
 
   ngOnInit(): void {
     this.dataSource.data = [...Array(100).keys()].map((i) => ({

--- a/libs/components/src/stories/kitchen-sink/components/kitchen-sink-app.component.ts
+++ b/libs/components/src/stories/kitchen-sink/components/kitchen-sink-app.component.ts
@@ -1,12 +1,11 @@
-import { Component } from "@angular/core";
+import { ChangeDetectionStrategy, Component } from "@angular/core";
 
 import { PasswordManagerLogo } from "@bitwarden/assets/svg";
 
 import { KitchenSinkSharedModule } from "../kitchen-sink-shared.module";
 
-// FIXME(https://bitwarden.atlassian.net/browse/CL-764): Migrate to OnPush
-// eslint-disable-next-line @angular-eslint/prefer-on-push-component-change-detection
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: "bit-kitchen-sink-app",
   imports: [KitchenSinkSharedModule],
   template: `

--- a/libs/components/src/stories/kitchen-sink/components/kitchen-sink-empty.component.ts
+++ b/libs/components/src/stories/kitchen-sink/components/kitchen-sink-empty.component.ts
@@ -1,10 +1,9 @@
-import { Component } from "@angular/core";
+import { ChangeDetectionStrategy, Component } from "@angular/core";
 
 import { KitchenSinkSharedModule } from "../kitchen-sink-shared.module";
 
-// FIXME(https://bitwarden.atlassian.net/browse/CL-764): Migrate to OnPush
-// eslint-disable-next-line @angular-eslint/prefer-on-push-component-change-detection
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: "bit-kitchen-sink-empty",
   imports: [KitchenSinkSharedModule],
   template: `

--- a/libs/components/src/stories/kitchen-sink/components/kitchen-sink-form.component.ts
+++ b/libs/components/src/stories/kitchen-sink/components/kitchen-sink-form.component.ts
@@ -1,4 +1,4 @@
-import { Component } from "@angular/core";
+import { ChangeDetectionStrategy, Component, inject } from "@angular/core";
 import { FormBuilder, Validators } from "@angular/forms";
 
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
@@ -7,9 +7,8 @@ import { DialogService } from "../../../dialog";
 import { I18nMockService } from "../../../utils/i18n-mock.service";
 import { KitchenSinkSharedModule } from "../kitchen-sink-shared.module";
 
-// FIXME(https://bitwarden.atlassian.net/browse/CL-764): Migrate to OnPush
-// eslint-disable-next-line @angular-eslint/prefer-on-push-component-change-detection
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: "bit-kitchen-sink-form",
   imports: [KitchenSinkSharedModule],
   providers: [
@@ -134,12 +133,10 @@ import { KitchenSinkSharedModule } from "../kitchen-sink-shared.module";
   `,
 })
 export class KitchenSinkFormComponent {
-  constructor(
-    public dialogService: DialogService,
-    public formBuilder: FormBuilder,
-  ) {}
+  protected readonly dialogService = inject(DialogService);
+  private readonly formBuilder = inject(FormBuilder);
 
-  formObj = this.formBuilder.group({
+  protected readonly formObj = this.formBuilder.group({
     favFeature: ["", [Validators.required]],
     favColor: [undefined as string | undefined, [Validators.required]],
     topWorstPasswords: [undefined as string | undefined],
@@ -149,7 +146,7 @@ export class KitchenSinkFormComponent {
     password: ["", [Validators.required]],
   });
 
-  submit = async () => {
+  protected readonly submit = async () => {
     await this.dialogService.openSimpleDialog({
       title: "Confirm",
       content: "Are you sure you want to submit?",
@@ -165,13 +162,13 @@ export class KitchenSinkFormComponent {
     this.dialogService.closeAll();
   }
 
-  colors = [
+  protected readonly colors = [
     { value: "blue", name: "Blue" },
     { value: "white", name: "White" },
     { value: "gray", name: "Gray" },
   ];
 
-  worstPasswords = [
+  protected readonly worstPasswords = [
     { id: "1", listName: "1234", labelName: "1234" },
     { id: "2", listName: "admin", labelName: "admin" },
     { id: "3", listName: "password", labelName: "password" },

--- a/libs/components/src/stories/kitchen-sink/components/kitchen-sink-main.component.ts
+++ b/libs/components/src/stories/kitchen-sink/components/kitchen-sink-main.component.ts
@@ -1,14 +1,13 @@
 import { DialogRef } from "@angular/cdk/dialog";
-import { Component, inject } from "@angular/core";
+import { ChangeDetectionStrategy, Component, inject } from "@angular/core";
 
 import { DialogService } from "../../../dialog";
 import { KitchenSinkSharedModule } from "../kitchen-sink-shared.module";
 
 import { KitchenSinkTourService } from "./kitchen-sink-tour.service";
 
-// FIXME(https://bitwarden.atlassian.net/browse/CL-764): Migrate to OnPush
-// eslint-disable-next-line @angular-eslint/prefer-on-push-component-change-detection
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [KitchenSinkSharedModule],
   template: `
     <bit-dialog title="Dialog Title" dialogSize="small">
@@ -82,12 +81,11 @@ import { KitchenSinkTourService } from "./kitchen-sink-tour.service";
   `,
 })
 export class KitchenSinkDialogComponent {
-  constructor(public dialogRef: DialogRef) {}
+  protected readonly dialogRef = inject(DialogRef);
 }
 
-// FIXME(https://bitwarden.atlassian.net/browse/CL-764): Migrate to OnPush
-// eslint-disable-next-line @angular-eslint/prefer-on-push-component-change-detection
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <bit-dialog title="Dialog Title" dialogSize="small">
       <ng-container bitDialogContent>
@@ -107,12 +105,11 @@ export class KitchenSinkDialogComponent {
   imports: [KitchenSinkSharedModule],
 })
 export class KitchenSinkDialogWithAutofocusComponent {
-  constructor(public dialogRef: DialogRef) {}
+  protected readonly dialogRef = inject(DialogRef);
 }
 
-// FIXME(https://bitwarden.atlassian.net/browse/CL-764): Migrate to OnPush
-// eslint-disable-next-line @angular-eslint/prefer-on-push-component-change-detection
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: "bit-tab-main",
   imports: [KitchenSinkSharedModule],
   template: `
@@ -176,8 +173,7 @@ export class KitchenSinkDialogWithAutofocusComponent {
   `,
 })
 export class KitchenSinkMainComponent {
-  constructor(public dialogService: DialogService) {}
-
+  protected readonly dialogService = inject(DialogService);
   protected readonly tourService = inject(KitchenSinkTourService);
 
   openDialog() {
@@ -188,7 +184,7 @@ export class KitchenSinkMainComponent {
     this.dialogService.openDrawer(KitchenSinkDialogComponent);
   }
 
-  navItems = [
+  protected readonly navItems = [
     { icon: "bwi-collection-shared", name: "Password Managers", route: "/" },
     { icon: "bwi-collection-shared", name: "Favorites", route: "/" },
   ];

--- a/libs/components/src/stories/kitchen-sink/components/kitchen-sink-table.component.ts
+++ b/libs/components/src/stories/kitchen-sink/components/kitchen-sink-table.component.ts
@@ -1,10 +1,9 @@
-import { Component } from "@angular/core";
+import { ChangeDetectionStrategy, Component } from "@angular/core";
 
 import { KitchenSinkSharedModule } from "../kitchen-sink-shared.module";
 
-// FIXME(https://bitwarden.atlassian.net/browse/CL-764): Migrate to OnPush
-// eslint-disable-next-line @angular-eslint/prefer-on-push-component-change-detection
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: "bit-kitchen-sink-table",
   imports: [KitchenSinkSharedModule],
   template: `

--- a/libs/components/src/stories/kitchen-sink/components/kitchen-sink-toggle-list.component.ts
+++ b/libs/components/src/stories/kitchen-sink/components/kitchen-sink-toggle-list.component.ts
@@ -1,15 +1,18 @@
-import { Component } from "@angular/core";
+import { ChangeDetectionStrategy, Component, signal } from "@angular/core";
 
 import { KitchenSinkSharedModule } from "../kitchen-sink-shared.module";
 
-// FIXME(https://bitwarden.atlassian.net/browse/CL-764): Migrate to OnPush
-// eslint-disable-next-line @angular-eslint/prefer-on-push-component-change-detection
 @Component({
   selector: "bit-kitchen-sink-toggle-list",
+  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [KitchenSinkSharedModule],
   template: `
     <div class="tw-my-6">
-      <bit-toggle-group [(selected)]="selectedToggle" aria-label="Company list filter">
+      <bit-toggle-group
+        [selected]="selectedToggle()"
+        (selectedChange)="selectedToggle.set($event)"
+        aria-label="Company list filter"
+      >
         <bit-toggle value="all"> All <bit-berry [value]="3"></bit-berry> </bit-toggle>
 
         <bit-toggle value="large"> Enterprise <bit-berry [value]="2"></bit-berry> </bit-toggle>
@@ -19,7 +22,7 @@ import { KitchenSinkSharedModule } from "../kitchen-sink-shared.module";
     </div>
     @for (company of companyList; track company) {
       <ul>
-        @if (company.size === selectedToggle || selectedToggle === "all") {
+        @if (company.size === selectedToggle() || selectedToggle() === "all") {
           <li>
             {{ company.name }}
           </li>
@@ -29,9 +32,9 @@ import { KitchenSinkSharedModule } from "../kitchen-sink-shared.module";
   `,
 })
 export class KitchenSinkToggleListComponent {
-  selectedToggle: "all" | "large" | "small" = "all";
+  protected readonly selectedToggle = signal<"all" | "large" | "small">("all");
 
-  companyList = [
+  readonly companyList = [
     { name: "A large enterprise company", size: "large" },
     { name: "Another enterprise company", size: "large" },
     { name: "A smaller company", size: "small" },

--- a/libs/components/src/stories/kitchen-sink/components/kitchen-sink-vault.component.ts
+++ b/libs/components/src/stories/kitchen-sink/components/kitchen-sink-vault.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject } from "@angular/core";
+import { ChangeDetectionStrategy, Component, inject } from "@angular/core";
 
 import { DialogService } from "../../../dialog";
 import { KitchenSinkSharedModule } from "../kitchen-sink-shared.module";
@@ -12,9 +12,8 @@ import { KitchenSinkTableComponent } from "./kitchen-sink-table.component";
 import { KitchenSinkToggleListComponent } from "./kitchen-sink-toggle-list.component";
 import { KitchenSinkTourService } from "./kitchen-sink-tour.service";
 
-// FIXME(https://bitwarden.atlassian.net/browse/CL-764): Migrate to OnPush
-// eslint-disable-next-line @angular-eslint/prefer-on-push-component-change-detection
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: "bit-kitchen-sink-vault",
   imports: [
     KitchenSinkSharedModule,
@@ -98,8 +97,7 @@ import { KitchenSinkTourService } from "./kitchen-sink-tour.service";
   `,
 })
 export class KitchenSinkVaultComponent {
-  constructor(public dialogService: DialogService) {}
-
+  protected readonly dialogService = inject(DialogService);
   protected readonly tourService = inject(KitchenSinkTourService);
 
   openDialog() {


### PR DESCRIPTION
**Overview:**

The goal of this PR is to migrate all eight Kitchen Sink story components from the default change detection strategy to OnPush, resolving the long-standing CL-764 lint suppressions.

**Key Changes:**
- Added `ChangeDetectionStrategy.OnPush` to all 8 components
- Removed all `// FIXME(CL-764)` and `// eslint-disable-next-line @angular-eslint/prefer-on-push-component-change-detection` comment pairs
- Converted `selectedToggle` in `KitchenSinkToggleListComponent` from a plain property to an Angular signal
- Replaced constructor injection with `inject()` in `KitchenSinkDialogComponent`, `KitchenSinkDialogWithAutofocusComponent`, and `KitchenSinkMainComponent`
- Added protected readonly visibility modifiers to class members where applicable

**Summary:**

The kitchen sink story components previously suppressed the prefer-on-push-component-change-detection lint rule while awaiting a migration, that migration is now. The toggle list component required a signal conversion to remain compatible with `OnPush` since the two-way binding shorthand `[( )]` does not work with signal based state. All changes are confined to `libs/components/src/stories/kitchen-sink/components/` with no impact on prod