### PR TITLE
eslint: error on importing bitwarden licensed code into /libs**/*

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -128,6 +128,11 @@ export default tseslint.config(
               message: "Libs should not import app-specific code.",
             },
             {
+              target: ["libs/**/*"],
+              from: ["bitwarden_license/**/*"],
+              message: "Libs should not import licensed code from bitwarden_license/.",
+            },
+            {
               // avoid specific frameworks or large dependencies in common
               target: "./libs/common/**/*",
               from: [


### PR DESCRIPTION
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Follow up from https://github.com/bitwarden/clients/pull/11954, since the eslint system has evolved with bringing nx on.

This PR adds a eslint rule to prevent devs from importing bitwarden-licensed code into libs/

Extending the existing files array [as suggested by](https://github.com/bitwarden/clients/pull/11954#pullrequestreview-2426922925) @eliykat would not work:

> In ESLint flat config, when multiple blocks match the same file, the last matching block wins for the same rule. There are 17+ later blocks like libs/common/src/**/*.ts, libs/auth/src/**/*.ts, etc. that each define their own no-restricted-imports rule. Those later blocks would override this one for their matched files, losing the bitwarden_license/** restriction.
> 
> For example, [eslint.config.mjs:385](https://github.com/bitwarden/clients/blob/main/eslint.config.mjs#L385) defines no-restricted-imports for libs/common/src/**/*.ts — that would replace (not merge with) the rule from [line 299](https://github.com/bitwarden/clients/blob/main/eslint.config.mjs#L299), so libs/common would lose the bitwarden_license restriction.
> 
> That's why the import/no-restricted-paths zone approach works better — it's a separate rule that doesn't conflict with the per-lib no-restricted-imports blocks. 