### PR TITLE
[PM-34037] New event log for 2fa recovery

### DIFF
--- a/apps/web/src/app/dirt/event-logs/services/event.service.ts
+++ b/apps/web/src/app/dirt/event-logs/services/event.service.ts
@@ -299,6 +299,13 @@ export class EventService {
           this.getShortId(ev.organizationUserId),
         );
         break;
+      case EventType.OrganizationUser_AdminResetTwoFactor:
+        msg = this.i18nService.t("eventAdminResetTwoFactor", this.formatOrgUserId(ev));
+        humanReadableMsg = this.i18nService.t(
+          "eventAdminResetTwoFactor",
+          this.getShortId(ev.organizationUserId),
+        );
+        break;
       case EventType.OrganizationUser_ResetSsoLink:
         msg = this.i18nService.t("eventResetSsoLink", this.formatOrgUserId(ev));
         humanReadableMsg = this.i18nService.t(

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -6619,6 +6619,15 @@
       }
     }
   },
+  "eventAdminResetTwoFactor": {
+    "message": "Two-step login reset for user $ID$.",
+    "placeholders": {
+      "id": {
+        "content": "$1",
+        "example": "John Smith"
+      }
+    }
+  },
   "eventResetSsoLink": {
     "message": "Reset SSO link for user $ID$",
     "placeholders": {

--- a/libs/common/src/dirt/event-logs/enums/event-category.enum.ts
+++ b/libs/common/src/dirt/event-logs/enums/event-category.enum.ts
@@ -68,6 +68,7 @@ export const EventCategoryEventTypes: Record<EventCategory, EventType[]> = {
     EventType.OrganizationUser_ResetPassword_Enroll,
     EventType.OrganizationUser_ResetPassword_Withdraw,
     EventType.OrganizationUser_AdminResetPassword,
+    EventType.OrganizationUser_AdminResetTwoFactor,
     EventType.OrganizationUser_ResetSsoLink,
     EventType.OrganizationUser_FirstSsoLogin,
     EventType.OrganizationUser_Revoked,

--- a/libs/common/src/dirt/event-logs/enums/event-type.enum.ts
+++ b/libs/common/src/dirt/event-logs/enums/event-type.enum.ts
@@ -62,6 +62,7 @@ export enum EventType {
   OrganizationUser_Left = 1516,
   OrganizationUser_AutomaticallyConfirmed = 1517,
   OrganizationUser_SelfRevoked = 1518,
+  OrganizationUser_AdminResetTwoFactor = 1519,
 
   Organization_Updated = 1600,
   Organization_PurgedVault = 1601,


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-34037

## 📔 Objective

Add event log to clients for 2fa recovery, mirroring password reset implementation.

This PR extends the work done in https://github.com/bitwarden/clients/pull/19894