### PR TITLE
[PM-31270] New default argon2id in change kdf component

### DIFF
--- a/apps/web/src/app/auth/emergency-access/services/emergency-access.service.ts
+++ b/apps/web/src/app/auth/emergency-access/services/emergency-access.service.ts
@@ -313,8 +313,8 @@ export class EmergencyAccessService implements UserKeyRotationKeyRecoveryProvide
       case KdfType.Argon2id:
         config = new Argon2KdfConfig(
           takeoverResponse.kdfIterations,
-          takeoverResponse.kdfMemory,
-          takeoverResponse.kdfParallelism,
+          takeoverResponse.kdfMemory!,
+          takeoverResponse.kdfParallelism!,
         );
         break;
     }

--- a/apps/web/src/app/key-management/change-kdf/change-kdf.component.spec.ts
+++ b/apps/web/src/app/key-management/change-kdf/change-kdf.component.spec.ts
@@ -231,8 +231,8 @@ describe("ChangeKdfComponent", () => {
         // Assert form values update to Argon2id defaults
         expect(formGroup.controls.kdf.value).toBe(KdfType.Argon2id);
         const kdfConfigFormGroup = formGroup.controls.kdfConfig;
-        expect(kdfConfigFormGroup.controls.iterations.value).toBe(3); // Argon2id default
-        expect(kdfConfigFormGroup.controls.memory.value).toBe(64); // Argon2id default
+        expect(kdfConfigFormGroup.controls.iterations.value).toBe(6); // Argon2id default
+        expect(kdfConfigFormGroup.controls.memory.value).toBe(32); // Argon2id default
         expect(kdfConfigFormGroup.controls.parallelism.value).toBe(4); // Argon2id default
       });
 

--- a/apps/web/src/app/key-management/change-kdf/change-kdf.component.ts
+++ b/apps/web/src/app/key-management/change-kdf/change-kdf.component.ts
@@ -10,7 +10,6 @@ import { DialogService } from "@bitwarden/components";
 import {
   KdfConfigService,
   Argon2KdfConfig,
-  DEFAULT_KDF_CONFIG,
   KdfConfig,
   PBKDF2KdfConfig,
   KdfType,
@@ -26,7 +25,7 @@ import { ChangeKdfConfirmationComponent } from "./change-kdf-confirmation.compon
   standalone: false,
 })
 export class ChangeKdfComponent implements OnInit, OnDestroy {
-  kdfConfig: KdfConfig = DEFAULT_KDF_CONFIG;
+  kdfConfig: KdfConfig = PBKDF2KdfConfig.createDefault();
   kdfOptions: any[] = [];
   private destroy$ = new Subject<void>();
 
@@ -81,10 +80,10 @@ export class ChangeKdfComponent implements OnInit, OnDestroy {
 
     switch (newValue) {
       case KdfType.PBKDF2_SHA256:
-        config = new PBKDF2KdfConfig();
+        config = PBKDF2KdfConfig.createDefault();
         break;
       case KdfType.Argon2id:
-        config = new Argon2KdfConfig();
+        config = Argon2KdfConfig.createDefault();
         break;
       default:
         throw new Error("Unknown KDF type.");
@@ -165,11 +164,13 @@ export class ChangeKdfComponent implements OnInit, OnDestroy {
 
     const kdfConfigFormGroup = this.formGroup.controls.kdfConfig;
     if (this.kdfConfig.kdfType === KdfType.PBKDF2_SHA256) {
-      this.kdfConfig.iterations = kdfConfigFormGroup.controls.iterations.value!;
+      this.kdfConfig = new PBKDF2KdfConfig(kdfConfigFormGroup.controls.iterations.value!);
     } else if (this.kdfConfig.kdfType === KdfType.Argon2id) {
-      this.kdfConfig.iterations = kdfConfigFormGroup.controls.iterations.value!;
-      this.kdfConfig.memory = kdfConfigFormGroup.controls.memory.value!;
-      this.kdfConfig.parallelism = kdfConfigFormGroup.controls.parallelism.value!;
+      this.kdfConfig = new Argon2KdfConfig(
+        kdfConfigFormGroup.controls.iterations.value!,
+        kdfConfigFormGroup.controls.memory.value!,
+        kdfConfigFormGroup.controls.parallelism.value!,
+      );
     }
     this.dialogService.open(ChangeKdfConfirmationComponent, {
       data: {

--- a/libs/angular/src/auth/password-management/change-password/default-change-password.service.spec.ts
+++ b/libs/angular/src/auth/password-management/change-password/default-change-password.service.spec.ts
@@ -59,7 +59,7 @@ describe("DefaultChangePasswordService", () => {
     newServerMasterKeyHash: "newServerMasterKeyHash",
     newLocalMasterKeyHash: "newLocalMasterKeyHash",
 
-    kdfConfig: new PBKDF2KdfConfig(),
+    kdfConfig: PBKDF2KdfConfig.createDefault(),
     newApisWithInputPasswordFlagEnabled: false,
   };
 

--- a/libs/auth/src/common/login-strategies/login.strategy.spec.ts
+++ b/libs/auth/src/common/login-strategies/login.strategy.spec.ts
@@ -180,7 +180,7 @@ describe("LoginStrategy", () => {
     tokenService.decodeAccessToken.calledWith(accessToken).mockResolvedValue(decodedToken);
 
     passwordPreloginService.getPreloginData$.mockReturnValue(
-      of(new PasswordPreloginData(new PBKDF2KdfConfig())),
+      of(new PasswordPreloginData(PBKDF2KdfConfig.createDefault())),
     );
     keyService.makeMasterKey.mockResolvedValue({} as any);
 

--- a/libs/auth/src/common/login-strategies/password-login.strategy.spec.ts
+++ b/libs/auth/src/common/login-strategies/password-login.strategy.spec.ts
@@ -127,7 +127,7 @@ describe("PasswordLoginStrategy", () => {
     });
 
     passwordPreloginService.getPreloginData$.mockReturnValue(
-      of(new PasswordPreloginData(new PBKDF2KdfConfig())),
+      of(new PasswordPreloginData(PBKDF2KdfConfig.createDefault())),
     );
     keyService.makeMasterKey.mockResolvedValue(masterKey);
 
@@ -291,7 +291,7 @@ describe("PasswordLoginStrategy", () => {
     });
 
     it("does not call getPreloginData$ when preFetchedPreloginData is provided", async () => {
-      const preloginData = new PasswordPreloginData(new PBKDF2KdfConfig());
+      const preloginData = new PasswordPreloginData(PBKDF2KdfConfig.createDefault());
       const credentialsWithPrefetch = new PasswordLoginCredentials(
         email,
         masterPassword,

--- a/libs/auth/src/common/services/login-strategies/login-strategy.service.spec.ts
+++ b/libs/auth/src/common/services/login-strategies/login-strategy.service.spec.ts
@@ -132,7 +132,7 @@ describe("LoginStrategyService", () => {
     passwordPreloginService = mock<PasswordPreloginService>();
 
     passwordPreloginService.getPreloginData$.mockReturnValue(
-      of(new PasswordPreloginData(new PBKDF2KdfConfig())),
+      of(new PasswordPreloginData(PBKDF2KdfConfig.createDefault())),
     );
     keyService.makeMasterKey.mockResolvedValue({} as any);
 

--- a/libs/common/src/auth/models/response/identity-token.response.spec.ts
+++ b/libs/common/src/auth/models/response/identity-token.response.spec.ts
@@ -8,6 +8,7 @@ describe("IdentityTokenResponse", () => {
   const expiresIn = 3600;
   const refreshToken = "testRefreshToken";
   const encryptedUserKey = makeEncString("testUserKey");
+  const kdfFields = { Kdf: 0, KdfIterations: 600_000 };
 
   it("should throw an error when access token is missing", () => {
     const response = {
@@ -35,6 +36,7 @@ describe("IdentityTokenResponse", () => {
     const response = {
       access_token: accessToken,
       token_type: tokenType,
+      ...kdfFields,
     };
 
     const identityTokenResponse = new IdentityTokenResponse(response);
@@ -49,6 +51,7 @@ describe("IdentityTokenResponse", () => {
       access_token: accessToken,
       token_type: tokenType,
       expires_in: expiresIn,
+      ...kdfFields,
     };
 
     const identityTokenResponse = new IdentityTokenResponse(response);
@@ -64,6 +67,7 @@ describe("IdentityTokenResponse", () => {
       token_type: tokenType,
       expires_in: expiresIn,
       refresh_token: refreshToken,
+      ...kdfFields,
     };
 
     const identityTokenResponse = new IdentityTokenResponse(response);
@@ -78,6 +82,7 @@ describe("IdentityTokenResponse", () => {
       access_token: accessToken,
       token_type: tokenType,
       Key: undefined as unknown,
+      ...kdfFields,
     };
 
     const identityTokenResponse = new IdentityTokenResponse(response);
@@ -89,6 +94,7 @@ describe("IdentityTokenResponse", () => {
       access_token: accessToken,
       token_type: tokenType,
       Key: encryptedUserKey.encryptedString,
+      ...kdfFields,
     };
 
     const identityTokenResponse = new IdentityTokenResponse(response);
@@ -100,6 +106,7 @@ describe("IdentityTokenResponse", () => {
       access_token: accessToken,
       token_type: tokenType,
       UserDecryptionOptions: undefined as unknown,
+      ...kdfFields,
     };
 
     const identityTokenResponse = new IdentityTokenResponse(response);
@@ -111,6 +118,7 @@ describe("IdentityTokenResponse", () => {
       access_token: accessToken,
       token_type: tokenType,
       UserDecryptionOptions: {},
+      ...kdfFields,
     };
 
     const identityTokenResponse = new IdentityTokenResponse(response);
@@ -122,6 +130,7 @@ describe("IdentityTokenResponse", () => {
       access_token: accessToken,
       token_type: tokenType,
       AccountKeys: null as unknown,
+      ...kdfFields,
     };
 
     const identityTokenResponse = new IdentityTokenResponse(response);
@@ -140,6 +149,7 @@ describe("IdentityTokenResponse", () => {
       access_token: accessToken,
       token_type: tokenType,
       AccountKeys: accountKeysData,
+      ...kdfFields,
     };
 
     const identityTokenResponse = new IdentityTokenResponse(response);

--- a/libs/common/src/auth/password-prelogin/password-prelogin.model.ts
+++ b/libs/common/src/auth/password-prelogin/password-prelogin.model.ts
@@ -19,7 +19,11 @@ export class PasswordPreloginData {
     const kdfConfig =
       response.kdf === KdfType.PBKDF2_SHA256
         ? new PBKDF2KdfConfig(response.kdfIterations)
-        : new Argon2KdfConfig(response.kdfIterations, response.kdfMemory, response.kdfParallelism);
+        : new Argon2KdfConfig(
+            response.kdfIterations,
+            response.kdfMemory!,
+            response.kdfParallelism!,
+          );
     kdfConfig.validateKdfConfigForPrelogin();
     return new PasswordPreloginData(kdfConfig);
   }

--- a/libs/common/src/platform/services/sdk/default-sdk.service.spec.ts
+++ b/libs/common/src/platform/services/sdk/default-sdk.service.spec.ts
@@ -99,7 +99,7 @@ describe("DefaultSdkService", () => {
         });
         kdfConfigService.getKdfConfig$
           .calledWith(userId)
-          .mockReturnValue(of(new PBKDF2KdfConfig()));
+          .mockReturnValue(of(PBKDF2KdfConfig.createDefault()));
         keyService.userKey$
           .calledWith(userId)
           .mockReturnValue(of(new SymmetricCryptoKey(new Uint8Array(64)) as UserKey));

--- a/libs/common/src/services/api.service.spec.ts
+++ b/libs/common/src/services/api.service.spec.ts
@@ -40,6 +40,7 @@ describe("ApiService", () => {
 
   const testActiveUser = "activeUser" as UserId;
   const testInactiveUser = "inactiveUser" as UserId;
+  const kdfFields = { Kdf: 0, KdfIterations: 600_000 };
 
   beforeEach(() => {
     tokenService = mock();
@@ -300,6 +301,7 @@ describe("ApiService", () => {
                 access_token: `${expectedEffectiveUser}_new_access_token`,
                 token_type: "Bearer",
                 refresh_token: `${expectedEffectiveUser}_new_refresh_token`,
+                ...kdfFields,
               }),
           } satisfies Partial<Response> as Response);
         }
@@ -540,6 +542,7 @@ describe("ApiService", () => {
                 access_token: "new_access_token",
                 token_type: "Bearer",
                 refresh_token: "new_refresh_token",
+                ...kdfFields,
               }),
           } satisfies Partial<Response> as Response);
         }
@@ -869,6 +872,7 @@ describe("ApiService", () => {
                 access_token: "active_new_access_token",
                 token_type: "Bearer",
                 refresh_token: "active_new_refresh_token",
+                ...kdfFields,
               }),
           } satisfies Partial<Response> as Response);
         }
@@ -987,6 +991,7 @@ describe("ApiService", () => {
                 access_token: "new_access_token",
                 token_type: "Bearer",
                 refresh_token: "new_refresh_token",
+                ...kdfFields,
               }),
           } satisfies Partial<Response> as Response);
         }
@@ -1100,6 +1105,8 @@ describe("ApiService", () => {
                       access_token: "new_access_token",
                       token_type: "Bearer",
                       refresh_token: "new_refresh_token",
+                      Kdf: 0,
+                      KdfIterations: 600_000,
                     }),
                 } satisfies Partial<Response> as Response),
               100,

--- a/libs/key-management/src/models/kdf-config.spec.ts
+++ b/libs/key-management/src/models/kdf-config.spec.ts
@@ -3,18 +3,18 @@ import { KdfType } from "../enums/kdf-type.enum";
 import { Argon2KdfConfig, PBKDF2KdfConfig } from "./kdf-config";
 
 describe("KdfConfig", () => {
-  describe("PBKDF2KdfConfig default constructor", () => {
-    it("should use default iterations when none provided", () => {
-      const kdfConfig = new PBKDF2KdfConfig();
+  describe("PBKDF2KdfConfig.createDefault()", () => {
+    it("should create with default iterations", () => {
+      const kdfConfig = PBKDF2KdfConfig.createDefault();
 
       expect(kdfConfig.iterations).toBe(600_000);
       expect(kdfConfig.kdfType).toBe(KdfType.PBKDF2_SHA256);
     });
   });
 
-  describe("Argon2KdfConfig default constructor", () => {
-    it("should use default values when none provided", () => {
-      const kdfConfig = new Argon2KdfConfig();
+  describe("Argon2KdfConfig.createDefault()", () => {
+    it("should create with default values", () => {
+      const kdfConfig = Argon2KdfConfig.createDefault();
 
       expect(kdfConfig.iterations).toBe(6);
       expect(kdfConfig.memory).toBe(32);

--- a/libs/key-management/src/models/kdf-config.spec.ts
+++ b/libs/key-management/src/models/kdf-config.spec.ts
@@ -23,6 +23,58 @@ describe("KdfConfig", () => {
     });
   });
 
+  describe("PBKDF2KdfConfig constructor", () => {
+    it("should throw when iterations is null", () => {
+      expect(() => new PBKDF2KdfConfig(null as unknown as number)).toThrow(
+        "iterations is null or undefined.",
+      );
+    });
+
+    it("should throw when iterations is undefined", () => {
+      expect(() => new PBKDF2KdfConfig(undefined as unknown as number)).toThrow(
+        "iterations is null or undefined.",
+      );
+    });
+  });
+
+  describe("Argon2KdfConfig constructor", () => {
+    it("should throw when iterations is null", () => {
+      expect(() => new Argon2KdfConfig(null as unknown as number, 64, 4)).toThrow(
+        "iterations is null or undefined.",
+      );
+    });
+
+    it("should throw when iterations is undefined", () => {
+      expect(() => new Argon2KdfConfig(undefined as unknown as number, 64, 4)).toThrow(
+        "iterations is null or undefined.",
+      );
+    });
+
+    it("should throw when memory is null", () => {
+      expect(() => new Argon2KdfConfig(3, null as unknown as number, 4)).toThrow(
+        "memory is null or undefined.",
+      );
+    });
+
+    it("should throw when memory is undefined", () => {
+      expect(() => new Argon2KdfConfig(3, undefined as unknown as number, 4)).toThrow(
+        "memory is null or undefined.",
+      );
+    });
+
+    it("should throw when parallelism is null", () => {
+      expect(() => new Argon2KdfConfig(3, 64, null as unknown as number)).toThrow(
+        "parallelism is null or undefined.",
+      );
+    });
+
+    it("should throw when parallelism is undefined", () => {
+      expect(() => new Argon2KdfConfig(3, 64, undefined as unknown as number)).toThrow(
+        "parallelism is null or undefined.",
+      );
+    });
+  });
+
   it("validateKdfConfigForSetting(): should validate the PBKDF2 KDF config", () => {
     const kdfConfig: PBKDF2KdfConfig = new PBKDF2KdfConfig(600_000);
     expect(() => kdfConfig.validateKdfConfigForSetting()).not.toThrow();

--- a/libs/key-management/src/models/kdf-config.spec.ts
+++ b/libs/key-management/src/models/kdf-config.spec.ts
@@ -1,6 +1,28 @@
+import { KdfType } from "../enums/kdf-type.enum";
+
 import { Argon2KdfConfig, PBKDF2KdfConfig } from "./kdf-config";
 
 describe("KdfConfig", () => {
+  describe("PBKDF2KdfConfig default constructor", () => {
+    it("should use default iterations when none provided", () => {
+      const kdfConfig = new PBKDF2KdfConfig();
+
+      expect(kdfConfig.iterations).toBe(600_000);
+      expect(kdfConfig.kdfType).toBe(KdfType.PBKDF2_SHA256);
+    });
+  });
+
+  describe("Argon2KdfConfig default constructor", () => {
+    it("should use default values when none provided", () => {
+      const kdfConfig = new Argon2KdfConfig();
+
+      expect(kdfConfig.iterations).toBe(6);
+      expect(kdfConfig.memory).toBe(32);
+      expect(kdfConfig.parallelism).toBe(4);
+      expect(kdfConfig.kdfType).toBe(KdfType.Argon2id);
+    });
+  });
+
   it("validateKdfConfigForSetting(): should validate the PBKDF2 KDF config", () => {
     const kdfConfig: PBKDF2KdfConfig = new PBKDF2KdfConfig(600_000);
     expect(() => kdfConfig.validateKdfConfigForSetting()).not.toThrow();

--- a/libs/key-management/src/models/kdf-config.ts
+++ b/libs/key-management/src/models/kdf-config.ts
@@ -1,5 +1,6 @@
 import { Jsonify } from "type-fest";
 
+import { assertNonNullish } from "@bitwarden/common/auth/utils";
 import { RangeWithDefault } from "@bitwarden/common/platform/misc/range-with-default";
 import { Kdf } from "@bitwarden/sdk-internal";
 
@@ -18,7 +19,9 @@ export class PBKDF2KdfConfig {
   static PRELOGIN_ITERATIONS_MIN = 5000;
   kdfType: KdfType.PBKDF2_SHA256 = KdfType.PBKDF2_SHA256;
 
-  constructor(readonly iterations: number) {}
+  constructor(readonly iterations: number) {
+    assertNonNullish(iterations, "iterations");
+  }
 
   static createDefault(): PBKDF2KdfConfig {
     return new PBKDF2KdfConfig(PBKDF2KdfConfig.ITERATIONS.defaultValue);
@@ -79,7 +82,11 @@ export class Argon2KdfConfig {
     readonly iterations: number,
     readonly memory: number,
     readonly parallelism: number,
-  ) {}
+  ) {
+    assertNonNullish(iterations, "iterations");
+    assertNonNullish(memory, "memory");
+    assertNonNullish(parallelism, "parallelism");
+  }
 
   static createDefault(): Argon2KdfConfig {
     return new Argon2KdfConfig(

--- a/libs/key-management/src/models/kdf-config.ts
+++ b/libs/key-management/src/models/kdf-config.ts
@@ -64,9 +64,9 @@ export class PBKDF2KdfConfig {
  * Argon2 KDF configuration.
  */
 export class Argon2KdfConfig {
-  static MEMORY = new RangeWithDefault(16, 1024, 64);
+  static MEMORY = new RangeWithDefault(16, 1024, 32);
   static PARALLELISM = new RangeWithDefault(1, 16, 4);
-  static ITERATIONS = new RangeWithDefault(2, 10, 3);
+  static ITERATIONS = new RangeWithDefault(2, 10, 6);
 
   static PRELOGIN_MEMORY_MIN = 16;
   static PRELOGIN_PARALLELISM_MIN = 1;

--- a/libs/key-management/src/models/kdf-config.ts
+++ b/libs/key-management/src/models/kdf-config.ts
@@ -17,10 +17,11 @@ export class PBKDF2KdfConfig {
   static ITERATIONS = new RangeWithDefault(600_000, 2_000_000, 600_000);
   static PRELOGIN_ITERATIONS_MIN = 5000;
   kdfType: KdfType.PBKDF2_SHA256 = KdfType.PBKDF2_SHA256;
-  iterations: number;
 
-  constructor(iterations?: number) {
-    this.iterations = iterations ?? PBKDF2KdfConfig.ITERATIONS.defaultValue;
+  constructor(readonly iterations: number) {}
+
+  static createDefault(): PBKDF2KdfConfig {
+    return new PBKDF2KdfConfig(PBKDF2KdfConfig.ITERATIONS.defaultValue);
   }
 
   /**
@@ -73,14 +74,19 @@ export class Argon2KdfConfig {
   static PRELOGIN_ITERATIONS_MIN = 2;
 
   kdfType: KdfType.Argon2id = KdfType.Argon2id;
-  iterations: number;
-  memory: number;
-  parallelism: number;
 
-  constructor(iterations?: number, memory?: number, parallelism?: number) {
-    this.iterations = iterations ?? Argon2KdfConfig.ITERATIONS.defaultValue;
-    this.memory = memory ?? Argon2KdfConfig.MEMORY.defaultValue;
-    this.parallelism = parallelism ?? Argon2KdfConfig.PARALLELISM.defaultValue;
+  constructor(
+    readonly iterations: number,
+    readonly memory: number,
+    readonly parallelism: number,
+  ) {}
+
+  static createDefault(): Argon2KdfConfig {
+    return new Argon2KdfConfig(
+      Argon2KdfConfig.ITERATIONS.defaultValue,
+      Argon2KdfConfig.MEMORY.defaultValue,
+      Argon2KdfConfig.PARALLELISM.defaultValue,
+    );
   }
 
   /**


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-31270

## 📔 Objective

Adjusted default Argon2 configuration when user manually selects Argon2Id in change kdf component to:
Iterations: 6
Memory: 32MB
Parallelism: 4

Also refactored `PBKDF2KdfConfig` and `Argon2KdfConfig`:
- explicit defaults with `createDefault` function, instead of relying on the constructor with all optional arguments.
- kdf fields are readonly, immutable - prevents `change-kdf.component.ts` from modifying the global const, like it was before.

## 📸 Screenshots

New Argon2Id defaults when changing KDF

https://github.com/user-attachments/assets/15e45995-cbda-45a4-a9c2-122705a1c35e


