### PR TITLE
[PM-34575] Stop allCiphers$ firing twice

### DIFF
--- a/apps/web/src/app/admin-console/organizations/collections/vault.component.ts
+++ b/apps/web/src/app/admin-console/organizations/collections/vault.component.ts
@@ -318,6 +318,7 @@ export class VaultComponent implements OnInit, OnDestroy {
       this.restrictedItemTypesService.restricted$,
       this.refreshingSubject$,
     ]).pipe(
+      filter(([, , , refreshing]) => refreshing),
       switchMap(async ([organization, userId, restricted]) => {
         // If user swaps organization reset the addAccessToggle
         if (!this.showAddAccessToggle || organization) {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-34575

## 📔 Objective

Stops the allCiphers$ from firing twice causing the search index on the collections page to run twice which is unneeded
