### PR TITLE
[PM-34818] [codex] Defer popup autofill enrichment until after first render

### DIFF
--- a/apps/browser/src/vault/popup/components/vault/autofill-vault-list-items/autofill-vault-list-items.component.html
+++ b/apps/browser/src/vault/popup/components/vault/autofill-vault-list-items/autofill-vault-list-items.component.html
@@ -1,12 +1,12 @@
 @if (autofillCiphers$ | async; as ciphers) {
-  @let showTip = showEmptyAutofillTip$ | async;
+  @let description = description$ | async;
 
   <app-vault-list-items-container
     [ciphers]="ciphers"
     [title]="((currentURIIsBlocked$ | async) ? 'itemSuggestions' : 'autofillSuggestions') | i18n"
-    [description]="showTip ? ('autofillSuggestionsTip' | i18n) : undefined"
+    [description]="description ? (description | i18n) : undefined"
     [showRefresh]="showRefresh"
-    [disableDescriptionMargin]="showTip"
+    [disableDescriptionMargin]="disableDescriptionMargin$ | async"
     [groupByType]="groupByType()"
     [primaryActionAutofill]="clickItemsToAutofillVaultView$ | async"
     isAutofillList

--- a/apps/browser/src/vault/popup/components/vault/autofill-vault-list-items/autofill-vault-list-items.component.spec.ts
+++ b/apps/browser/src/vault/popup/components/vault/autofill-vault-list-items/autofill-vault-list-items.component.spec.ts
@@ -32,6 +32,8 @@ describe("AutofillVaultListItemsComponent", () => {
   const autofillAllowed$ = new BehaviorSubject<boolean>(true);
   const currentTabIsOnBlocklist$ = new BehaviorSubject<boolean>(false);
   const clickItemsToAutofillVaultView$ = new BehaviorSubject<boolean>(true);
+  const autofillEnrichmentLoading$ = new BehaviorSubject<boolean>(false);
+  const startAutofillEnrichment = jest.fn();
 
   beforeEach(async () => {
     // Mock getAnimations for all span elements before any components are created
@@ -41,6 +43,7 @@ describe("AutofillVaultListItemsComponent", () => {
 
     jest.spyOn(BrowserPopupUtils, "inSidebar").mockReturnValue(false);
     jest.spyOn(BrowserPopupUtils, "inPopup").mockReturnValue(false);
+    startAutofillEnrichment.mockClear();
 
     await TestBed.configureTestingModule({
       imports: [AutofillVaultListItemsComponent],
@@ -77,9 +80,11 @@ describe("AutofillVaultListItemsComponent", () => {
           provide: VaultPopupAutofillService,
           useValue: {
             autofillAllowed$,
+            autofillEnrichmentLoading$,
             currentTabIsOnBlocklist$,
             refreshCurrentTab: jest.fn(),
             currentAutofillTab$: of(null),
+            startAutofillEnrichment,
           },
         },
         {
@@ -113,5 +118,22 @@ describe("AutofillVaultListItemsComponent", () => {
         fixture.debugElement.query(By.directive(SimplifiedAutofillInfoComponent)),
       ).not.toBeNull();
     });
+  });
+
+  it("starts autofill enrichment after the first render", () => {
+    expect(startAutofillEnrichment).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows loading placeholder while autofill enrichment is in progress", async () => {
+    autoFillCiphers$.next([{ type: CipherType.Login } as PopupCipherViewLike]);
+    autofillEnrichmentLoading$.next(true);
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const listContainer = fixture.debugElement.query(By.css("app-vault-list-items-container"))
+      .componentInstance;
+
+    expect(listContainer.description()).toBe("loading");
   });
 });

--- a/apps/browser/src/vault/popup/components/vault/autofill-vault-list-items/autofill-vault-list-items.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/autofill-vault-list-items/autofill-vault-list-items.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from "@angular/common";
-import { Component } from "@angular/core";
+import { afterNextRender, Component } from "@angular/core";
 import { toSignal } from "@angular/core/rxjs-interop";
 import { combineLatest, map, Observable, startWith } from "rxjs";
 
@@ -72,6 +72,27 @@ export class AutofillVaultListItemsComponent {
     ),
   );
 
+  protected autofillEnrichmentLoading$: Observable<boolean> =
+    this.vaultPopupAutofillService.autofillEnrichmentLoading$;
+
+  protected description$: Observable<string | undefined> = combineLatest([
+    this.showEmptyAutofillTip$,
+    this.autofillEnrichmentLoading$,
+  ]).pipe(
+    map(([showTip, loading]) => {
+      if (loading) {
+        return "loading";
+      }
+
+      return showTip ? "autofillSuggestionsTip" : undefined;
+    }),
+  );
+
+  protected disableDescriptionMargin$: Observable<boolean> = combineLatest([
+    this.showEmptyAutofillTip$,
+    this.autofillEnrichmentLoading$,
+  ]).pipe(map(([showTip, loading]) => showTip && !loading));
+
   /**
    * Flag indicating that the current tab location is blocked
    */
@@ -82,7 +103,9 @@ export class AutofillVaultListItemsComponent {
     private vaultPopupItemsService: VaultPopupItemsService,
     private vaultPopupAutofillService: VaultPopupAutofillService,
     private vaultSettingsService: VaultSettingsService,
-  ) {}
+  ) {
+    afterNextRender(() => this.vaultPopupAutofillService.startAutofillEnrichment());
+  }
 
   /**
    * Refreshes the current tab to re-populate the autofill ciphers.
@@ -90,5 +113,7 @@ export class AutofillVaultListItemsComponent {
    */
   protected refreshCurrentTab() {
     this.vaultPopupAutofillService.refreshCurrentTab();
+    // Let the current tab observable settle before kicking off the next lazy scan.
+    setTimeout(() => this.vaultPopupAutofillService.startAutofillEnrichment());
   }
 }

--- a/apps/browser/src/vault/popup/services/vault-popup-autofill.service.spec.ts
+++ b/apps/browser/src/vault/popup/services/vault-popup-autofill.service.spec.ts
@@ -67,7 +67,16 @@ describe("VaultPopupAutofillService", () => {
       .mockReturnValue(true);
 
     mockAutofillService.collectPageDetailsFromTab$.mockReturnValue(new BehaviorSubject([]));
+    mockAutofillService.doAutoFill.mockResolvedValue(null);
     mockDomainSettingsService.blockedInteractionsUris$ = new BehaviorSubject({});
+    mockPasswordRepromptService.showPasswordPrompt.mockResolvedValue(true);
+    mockPlatformUtilsService.copyToClipboard.mockImplementation();
+    mockPlatformUtilsService.isFirefox.mockReturnValue(false);
+    mockPlatformUtilsService.isSafari.mockReturnValue(false);
+    mockToastService.showToast.mockImplementation();
+    mockCipherService.updateWithServer.mockResolvedValue(null);
+    mockCipherService.updateLastUsedDate.mockResolvedValue(undefined);
+    mockMessagingService.send.mockImplementation();
 
     testBed = TestBed.configureTestingModule({
       providers: [
@@ -99,11 +108,17 @@ describe("VaultPopupAutofillService", () => {
   });
 
   afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
     jest.clearAllMocks();
   });
 
   it("should be created", () => {
     expect(service).toBeTruthy();
+  });
+
+  it("does not collect page details on construction", () => {
+    expect(mockAutofillService.collectPageDetailsFromTab$).not.toHaveBeenCalled();
   });
 
   describe("currentAutofillTab$", () => {
@@ -169,8 +184,48 @@ describe("VaultPopupAutofillService", () => {
   describe("refreshCurrentTab()", () => {
     it("should refresh currentAutofillTab$", async () => {
       const tracked = subscribeTo(service.currentAutofillTab$);
+
+      await tracked.pauseUntilReceived(1);
       service.refreshCurrentTab();
       await tracked.pauseUntilReceived(2);
+    });
+  });
+
+  describe("autofill enrichment", () => {
+    it("emits default non-login cipher types before enrichment starts", (done) => {
+      service.nonLoginCipherTypesOnPage$.subscribe((types) => {
+        expect(types).toEqual({
+          [CipherType.Card]: false,
+          [CipherType.Identity]: false,
+        });
+        done();
+      });
+    });
+
+    it("starts enrichment only once per tab cycle", async () => {
+      const tracked = subscribeTo(service.autofillEnrichmentLoading$);
+
+      service.startAutofillEnrichment();
+      service.startAutofillEnrichment();
+
+      await tracked.pauseUntilReceived(3, 200);
+
+      expect(mockAutofillService.collectPageDetailsFromTab$).toHaveBeenCalledTimes(1);
+    });
+
+    it("allows a new scan after the current tab is refreshed", async () => {
+      const tracked = subscribeTo(service.autofillEnrichmentLoading$);
+
+      service.startAutofillEnrichment();
+
+      await tracked.pauseUntilReceived(3, 200);
+
+      service.refreshCurrentTab();
+      service.startAutofillEnrichment();
+
+      await tracked.pauseUntilReceived(6, 200);
+
+      expect(mockAutofillService.collectPageDetailsFromTab$).toHaveBeenCalledTimes(2);
     });
   });
 
@@ -187,6 +242,7 @@ describe("VaultPopupAutofillService", () => {
       mockPageDetails$ = new BehaviorSubject(mockPageDetails);
 
       mockAutofillService.collectPageDetailsFromTab$.mockReturnValue(mockPageDetails$);
+      mockAutofillService.collectPageDetailsFromTab$.mockClear();
 
       expectedAutofillArgs = {
         tab: mockCurrentTab,
@@ -199,10 +255,17 @@ describe("VaultPopupAutofillService", () => {
 
       // Refresh the current tab so the mockedPageDetails$ are used
       service.refreshCurrentTab();
-      (service as any)._currentPageDetails$ = of(mockPageDetails);
     });
 
     describe("doAutofill()", () => {
+      it("collects page details on demand when enrichment has not started", async () => {
+        mockAutofillService.doAutoFill.mockResolvedValue(null);
+
+        await service.doAutofill(mockCipher);
+
+        expect(mockAutofillService.collectPageDetailsFromTab$).toHaveBeenCalledTimes(1);
+      });
+
       it("should return true if autofill is successful", async () => {
         mockCipher.id = "test-cipher-id";
         mockAutofillService.doAutoFill.mockResolvedValue(null);
@@ -287,20 +350,26 @@ describe("VaultPopupAutofillService", () => {
         });
 
         it("should close popup by default when in popup", async () => {
-          await service.doAutofill(mockCipher);
+          const autofillPromise = service.doAutofill(mockCipher);
+          await jest.advanceTimersByTimeAsync(50);
+          await autofillPromise;
           expect(BrowserApi.closePopup).toHaveBeenCalled();
         });
 
         it("should not close popup when closePopup is set to false", async () => {
-          await service.doAutofill(mockCipher, false);
+          const autofillPromise = service.doAutofill(mockCipher, false);
+          await jest.advanceTimersByTimeAsync(50);
+          await autofillPromise;
           expect(BrowserApi.closePopup).not.toHaveBeenCalled();
         });
 
         it("should close popup after a timeout for chromium browsers", async () => {
           mockPlatformUtilsService.isFirefox.mockReturnValue(false);
           jest.spyOn(global, "setTimeout");
-          await service.doAutofill(mockCipher);
-          jest.advanceTimersByTime(50);
+          const autofillPromise = service.doAutofill(mockCipher);
+          await jest.advanceTimersByTimeAsync(50);
+          await autofillPromise;
+          await jest.advanceTimersByTimeAsync(50);
           expect(setTimeout).toHaveBeenCalledTimes(1);
           expect(BrowserApi.closePopup).toHaveBeenCalled();
         });
@@ -308,7 +377,9 @@ describe("VaultPopupAutofillService", () => {
         it("should show a successful toast message if login form is populated", async () => {
           jest.spyOn(BrowserPopupUtils, "inSingleActionPopout").mockReturnValue(true);
           (service as any).currentAutofillTab$ = of({ id: 1234 });
-          await service.doAutofill(mockCipher);
+          const autofillPromise = service.doAutofill(mockCipher);
+          await jest.advanceTimersByTimeAsync(50);
+          await autofillPromise;
           expect(mockToastService.showToast).toHaveBeenCalledWith({
             variant: "success",
             title: null,

--- a/apps/browser/src/vault/popup/services/vault-popup-autofill.service.ts
+++ b/apps/browser/src/vault/popup/services/vault-popup-autofill.service.ts
@@ -3,12 +3,12 @@
 import { Injectable } from "@angular/core";
 import { ActivatedRoute } from "@angular/router";
 import {
+  BehaviorSubject,
   combineLatest,
   debounceTime,
   firstValueFrom,
   map,
   Observable,
-  of,
   shareReplay,
   startWith,
   Subject,
@@ -44,7 +44,19 @@ import { closeViewVaultItemPopout, VaultPopoutType } from "../utils/vault-popout
   providedIn: "root",
 })
 export class VaultPopupAutofillService {
+  private static readonly defaultNonLoginCipherTypesOnPage = {
+    [CipherType.Card]: false,
+    [CipherType.Identity]: false,
+  } as const;
+
   private _refreshCurrentTab$ = new Subject<void>();
+  private _autofillEnrichmentLoading$ = new BehaviorSubject(false);
+  private _nonLoginCipherTypesOnPage$ = new BehaviorSubject<{
+    [CipherType.Card]: boolean;
+    [CipherType.Identity]: boolean;
+  }>(VaultPopupAutofillService.defaultNonLoginCipherTypesOnPage);
+  private _currentPageDetailsPromise: Promise<PageDetail[]> | null = null;
+  private _autofillEnrichmentGeneration = 0;
   private senderTabId$: Observable<number | undefined> = this.route.queryParams.pipe(
     map((params) => (params?.senderTabId ? parseInt(params.senderTabId, 10) : undefined)),
   );
@@ -146,69 +158,14 @@ export class VaultPopupAutofillService {
    */
   autofillAllowed$: Observable<boolean> = this.currentAutofillTab$.pipe(map((tab) => !!tab));
 
-  private _currentPageDetails$: Observable<PageDetail[]> = this.currentAutofillTab$.pipe(
-    switchMap((tab) => {
-      if (!tab) {
-        return of([]);
-      }
-
-      return this.domainSettingsService.blockedInteractionsUris$.pipe(
-        switchMap((blockedURLs) => {
-          if (blockedURLs && tab?.url?.length) {
-            const tabIsBlocked = isUrlInList(tab.url, blockedURLs);
-
-            if (tabIsBlocked) {
-              return of([]);
-            }
-          }
-
-          return this.autofillService.collectPageDetailsFromTab$(tab);
-        }),
-      );
-    }),
-    debounceTime(50),
+  autofillEnrichmentLoading$: Observable<boolean> = this._autofillEnrichmentLoading$.pipe(
     shareReplay({ refCount: false, bufferSize: 1 }),
   );
 
   nonLoginCipherTypesOnPage$: Observable<{
     [CipherType.Card]: boolean;
     [CipherType.Identity]: boolean;
-  }> = this._currentPageDetails$.pipe(
-    map((pageDetails) => {
-      let pageHasCardFields = false;
-      let pageHasIdentityFields = false;
-
-      try {
-        if (!pageDetails) {
-          throw Error("No page details were provided");
-        }
-
-        for (const details of pageDetails) {
-          for (const field of details.details.fields) {
-            if (!pageHasCardFields) {
-              pageHasCardFields = this.inlineMenuFieldQualificationService.isFieldForCreditCardForm(
-                field,
-                details.details,
-              );
-            }
-
-            if (!pageHasIdentityFields) {
-              pageHasIdentityFields =
-                this.inlineMenuFieldQualificationService.isFieldForIdentityForm(
-                  field,
-                  details.details,
-                );
-            }
-          }
-        }
-      } catch (error) {
-        // no-op on failure; do not show extra cipher types
-        this.logService.warning(error.message);
-      }
-
-      return { [CipherType.Card]: pageHasCardFields, [CipherType.Identity]: pageHasIdentityFields };
-    }),
-  );
+  }> = this._nonLoginCipherTypesOnPage$.pipe(shareReplay({ refCount: false, bufferSize: 1 }));
 
   constructor(
     private autofillService: AutofillService,
@@ -223,8 +180,105 @@ export class VaultPopupAutofillService {
     private accountService: AccountService,
     private logService: LogService,
     private inlineMenuFieldQualificationService: InlineMenuFieldQualificationService,
-  ) {
-    this._currentPageDetails$.subscribe();
+  ) {}
+
+  startAutofillEnrichment() {
+    if (this._currentPageDetailsPromise) {
+      return;
+    }
+
+    void this._getOrCollectPageDetails().catch(() => {
+      // no-op, callers observe loading state and page details are handled in _getOrCollectPageDetails
+    });
+  }
+
+  private async _getOrCollectPageDetails(tab?: chrome.tabs.Tab | null): Promise<PageDetail[]> {
+    if (this._currentPageDetailsPromise) {
+      return this._currentPageDetailsPromise;
+    }
+
+    const generation = this._autofillEnrichmentGeneration;
+    this._autofillEnrichmentLoading$.next(true);
+
+    this._currentPageDetailsPromise = this._collectCurrentPageDetails(tab, generation);
+
+    return this._currentPageDetailsPromise;
+  }
+
+  private async _collectCurrentPageDetails(
+    tab: chrome.tabs.Tab | null | undefined,
+    generation: number,
+  ): Promise<PageDetail[]> {
+    const currentTab = tab ?? (await firstValueFrom(this.currentAutofillTab$));
+    const blockedInteractionsUrls = await firstValueFrom(
+      this.domainSettingsService.blockedInteractionsUris$,
+    );
+
+    if (!currentTab) {
+      this._finalizeAutofillEnrichment([], generation);
+      return [];
+    }
+
+    if (blockedInteractionsUrls && currentTab.url?.length) {
+      const tabIsBlocked = isUrlInList(currentTab.url, blockedInteractionsUrls);
+
+      if (tabIsBlocked) {
+        this._finalizeAutofillEnrichment([], generation);
+        return [];
+      }
+    }
+
+    const pageDetails = await firstValueFrom(
+      this.autofillService.collectPageDetailsFromTab$(currentTab).pipe(debounceTime(50)),
+    ).catch(() => []);
+
+    this._finalizeAutofillEnrichment(pageDetails, generation);
+    return pageDetails;
+  }
+
+  private _finalizeAutofillEnrichment(pageDetails: PageDetail[], generation: number) {
+    if (generation !== this._autofillEnrichmentGeneration) {
+      return;
+    }
+
+    this._nonLoginCipherTypesOnPage$.next(this._extractNonLoginCipherTypes(pageDetails));
+    this._autofillEnrichmentLoading$.next(false);
+  }
+
+  private _extractNonLoginCipherTypes(pageDetails: PageDetail[]): {
+    [CipherType.Card]: boolean;
+    [CipherType.Identity]: boolean;
+  } {
+    let pageHasCardFields = false;
+    let pageHasIdentityFields = false;
+
+    try {
+      for (const details of pageDetails) {
+        for (const field of details.details.fields) {
+          if (!pageHasCardFields) {
+            pageHasCardFields = this.inlineMenuFieldQualificationService.isFieldForCreditCardForm(
+              field,
+              details.details,
+            );
+          }
+
+          if (!pageHasIdentityFields) {
+            pageHasIdentityFields = this.inlineMenuFieldQualificationService.isFieldForIdentityForm(
+              field,
+              details.details,
+            );
+          }
+        }
+      }
+    } catch (error) {
+      // no-op on failure; do not show extra cipher types
+      this.logService.warning(error.message);
+    }
+
+    return {
+      [CipherType.Card]: pageHasCardFields,
+      [CipherType.Identity]: pageHasIdentityFields,
+    };
   }
 
   private async _internalDoAutofill(
@@ -308,6 +362,12 @@ export class VaultPopupAutofillService {
    * Re-fetch the current tab
    */
   refreshCurrentTab() {
+    this._autofillEnrichmentGeneration++;
+    this._currentPageDetailsPromise = null;
+    this._autofillEnrichmentLoading$.next(false);
+    this._nonLoginCipherTypesOnPage$.next(
+      VaultPopupAutofillService.defaultNonLoginCipherTypesOnPage,
+    );
     this._refreshCurrentTab$.next(null);
   }
 
@@ -324,7 +384,7 @@ export class VaultPopupAutofillService {
     skipPasswordReprompt = false,
   ): Promise<boolean> {
     const tab = await firstValueFrom(this.currentAutofillTab$);
-    const pageDetails = await firstValueFrom(this._currentPageDetails$);
+    const pageDetails = await this._getOrCollectPageDetails(tab);
 
     const didAutofill = await this._internalDoAutofill(
       cipher,
@@ -372,8 +432,8 @@ export class VaultPopupAutofillService {
       return false;
     }
 
-    const pageDetails = await firstValueFrom(this._currentPageDetails$);
     const tab = await firstValueFrom(this.currentAutofillTab$);
+    const pageDetails = await this._getOrCollectPageDetails(tab);
 
     const didAutofill = await this._internalDoAutofill(
       cipher,

--- a/apps/browser/src/vault/popup/services/vault-popup-items.service.spec.ts
+++ b/apps/browser/src/vault/popup/services/vault-popup-items.service.spec.ts
@@ -310,6 +310,23 @@ describe("VaultPopupItemsService", () => {
         done();
       });
     });
+
+    it("emits autofill ciphers before non-login enrichment adds extra types", (done) => {
+      (vaultAutofillServiceMock.nonLoginCipherTypesOnPage$ as BehaviorSubject<any>).next({
+        [CipherType.Card]: false,
+        [CipherType.Identity]: false,
+      });
+
+      service.autoFillCiphers$.subscribe((ciphers) => {
+        expect(cipherServiceMock.filterCiphersForUrl).toHaveBeenCalledWith(
+          expect.anything(),
+          "https://example.com",
+          [],
+        );
+        expect(ciphers.length).toBe(2);
+        done();
+      });
+    });
   });
 
   describe("filteredCiphers$", () => {


### PR DESCRIPTION
## Summary
- defer popup autofill enrichment until after the first render so the vault list can appear before page scanning finishes
- keep eager tab/blocklist checks intact while making page detail collection opt-in for the autofill section
- trigger page scanning on first render of the autofill section and on-demand before actual autofill actions

## Root cause
The popup was collecting page details during service startup. In Safari that page scan can be slow or temporarily unresponsive, and it sat on the critical path for rendering popup autofill state.

## What changed
- removed eager `collectPageDetailsFromTab$` work from `VaultPopupAutofillService`
- added lazy enrichment state with a default non-login cipher type snapshot and an explicit `startAutofillEnrichment()` trigger
- reset enrichment state on `refreshCurrentTab()` and force page detail collection before `doAutofill()` / `doAutofillAndSave()` when needed
- started enrichment after first render in the autofill vault list component and surfaced a lightweight `loading` placeholder in the section description
- updated popup service and component specs to cover the lazy enrichment path

## Impact
- login suggestions can render without waiting for a page scan
- card and identity enrichment now happen after the first render instead of during popup bootstrap
- manual autofill behavior stays correct because page details are still collected on demand before filling

## Validation
- `./node_modules/.bin/jest --config apps/browser/jest.config.js --runInBand --forceExit --runTestsByPath apps/browser/src/vault/popup/components/vault/autofill-vault-list-items/autofill-vault-list-items.component.spec.ts`
- `./node_modules/.bin/jest --config apps/browser/jest.config.js --runInBand --forceExit --runTestsByPath apps/browser/src/vault/popup/services/vault-popup-items.service.spec.ts`
- targeted `vault-popup-autofill.service.spec.ts` shards and individual `doAutofill()` cases covering enrichment, closePopup, doAutofillAndSave, and the new on-demand page detail path
