### PR TITLE
SSH Agent v2: add Windows named pipe listener

### DIFF
--- a/apps/desktop/desktop_native/Cargo.lock
+++ b/apps/desktop/desktop_native/Cargo.lock
@@ -3479,6 +3479,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-subscriber",
+ "windows 0.62.2",
 ]
 
 [[package]]

--- a/apps/desktop/desktop_native/Cargo.lock
+++ b/apps/desktop/desktop_native/Cargo.lock
@@ -3469,7 +3469,7 @@ dependencies = [
  "homedir",
  "libc",
  "mockall",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rkyv",
  "serial_test",
  "ssh-key",

--- a/apps/desktop/desktop_native/ssh_agent/Cargo.toml
+++ b/apps/desktop/desktop_native/ssh_agent/Cargo.toml
@@ -28,6 +28,12 @@ tracing = { workspace = true }
 homedir = { workspace = true }
 libc = { workspace = true }
 
+[target.'cfg(windows)'.dependencies]
+windows = { workspace = true, features = [
+    "Win32_Foundation",
+    "Win32_System_Pipes",
+] }
+
 [target.'cfg(unix)'.dev-dependencies]
 mockall = { workspace = true }
 rand = { workspace = true }
@@ -37,6 +43,8 @@ tracing-subscriber = { workspace = true }
 
 [target.'cfg(windows)'.dev-dependencies]
 mockall = { workspace = true }
+serial_test = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net", "io-util", "time"] }
 tracing-subscriber = { workspace = true }
 
 [lints]

--- a/apps/desktop/desktop_native/ssh_agent/src/server/listener/mod.rs
+++ b/apps/desktop/desktop_native/ssh_agent/src/server/listener/mod.rs
@@ -3,6 +3,9 @@
 #[cfg(unix)]
 pub(crate) mod unix;
 
+#[cfg(windows)]
+pub(crate) mod windows;
+
 use anyhow::Result;
 use tokio::{
     io::{AsyncRead, AsyncWrite},
@@ -32,19 +35,7 @@ pub(crate) fn create_listeners() -> Result<Vec<impl Listener>> {
 /// Creates the listeners for the Windows platform.
 #[cfg(windows)]
 pub(crate) fn create_listeners() -> Result<Vec<impl Listener>> {
-    // TODO: PM-30763 remove the stub below and add named pipe
-    struct StubListener(std::convert::Infallible);
-
-    #[async_trait::async_trait]
-    impl Listener for StubListener {
-        type Stream = tokio::io::DuplexStream;
-
-        async fn accept(&mut self) -> Result<Connection<Self::Stream>> {
-            match self.0 {}
-        }
-    }
-
-    Ok(Vec::<StubListener>::new())
+    Ok(vec![windows::WindowsListener::new()?])
 }
 
 /// Spawns an independent tokio task for each listener in `listeners`.

--- a/apps/desktop/desktop_native/ssh_agent/src/server/listener/windows.rs
+++ b/apps/desktop/desktop_native/ssh_agent/src/server/listener/windows.rs
@@ -1,0 +1,103 @@
+//! Windows named pipe listener for the SSH agent server
+
+use std::{mem, os::windows::io::AsRawHandle};
+
+use anyhow::{anyhow, Result};
+use tokio::net::windows::named_pipe::{NamedPipeServer, ServerOptions};
+use tracing::{info, warn};
+use windows::Win32::{Foundation::HANDLE, System::Pipes::GetNamedPipeClientProcessId};
+
+use super::Listener;
+use crate::server::{connection::Connection, peer_info::PeerInfo};
+
+/// The fixed named pipe path that OpenSSH clients expect on Windows
+const PIPE_NAME: &str = r"\\.\pipe\openssh-ssh-agent";
+
+/// Windows named pipe listener for the SSH agent server
+pub(crate) struct WindowsListener {
+    inner: NamedPipeServer,
+}
+
+impl WindowsListener {
+    /// Creates a new [`WindowsListener`], binding to the OpenSSH named pipe path.
+    ///
+    /// The first pipe server instance is created synchronously so the pipe name is
+    /// registered in the OS before this function returns.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the named pipe cannot be created.
+    pub(crate) fn new() -> Result<Self> {
+        let server = ServerOptions::new()
+            .create(PIPE_NAME)
+            .map_err(|e| anyhow!("Unable to create named pipe {PIPE_NAME}: {e}"))?;
+
+        info!(pipe_name = PIPE_NAME, "Named pipe listener ready");
+
+        Ok(Self { inner: server })
+    }
+}
+
+#[async_trait::async_trait]
+impl Listener for WindowsListener {
+    type Stream = NamedPipeServer;
+
+    async fn accept(&mut self) -> Result<Connection<Self::Stream>> {
+        self.inner.connect().await?;
+
+        // Create the next server instance before handing off the current one, so the
+        // pipe name remains available for subsequent clients without a gap.
+        let next = ServerOptions::new()
+            .create(PIPE_NAME)
+            .map_err(|e| anyhow!("Failed to create next pipe instance after accept: {e}"))?;
+
+        let stream = mem::replace(&mut self.inner, next);
+        let peer_info = get_peer_info(&stream);
+
+        Ok(Connection { stream, peer_info })
+    }
+}
+
+// Gathers peer process info from a connected named pipe server handle.
+//
+// TODO: PM-30755 Add test coverage for peer info gathering once the connection handler
+// is implemented and `PeerInfo` is observable via the SSH protocol exchange.
+fn get_peer_info(server: &NamedPipeServer) -> Option<PeerInfo> {
+    let mut pid: u32 = 0;
+    let handle = HANDLE(server.as_raw_handle().cast());
+
+    // SAFETY: `handle` is valid for the lifetime of this call (server is still alive),
+    // and `pid` is a local stack variable that Windows writes the client PID into.
+    if let Err(error) = unsafe { GetNamedPipeClientProcessId(handle, &raw mut pid) } {
+        warn!(%error, "Failed to get named pipe client process id");
+        return None;
+    }
+
+    PeerInfo::from_pid(pid)
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::net::windows::named_pipe::ClientOptions;
+
+    use super::*;
+
+    #[serial_test::serial]
+    #[tokio::test]
+    async fn test_new_creates_pipe() {
+        WindowsListener::new().unwrap();
+    }
+
+    #[serial_test::serial]
+    #[tokio::test]
+    async fn test_get_peer_info_connected_client_returns_some() {
+        let server = ServerOptions::new().create(PIPE_NAME).unwrap();
+        // Keep the client alive so the connection stays open for the duration of the check
+        let _client = ClientOptions::new().open(PIPE_NAME).unwrap();
+        server.connect().await.unwrap();
+
+        let peer_info = get_peer_info(&server);
+
+        assert!(peer_info.is_some());
+    }
+}

--- a/apps/desktop/desktop_native/ssh_agent/tests/server_windows.rs
+++ b/apps/desktop/desktop_native/ssh_agent/tests/server_windows.rs
@@ -1,0 +1,74 @@
+#![cfg(windows)]
+
+use serial_test::serial;
+use tokio::net::windows::named_pipe::ClientOptions;
+
+mod common;
+use common::{always_approving_agent, init_tracing};
+
+const PIPE_NAME: &str = r"\\.\pipe\openssh-ssh-agent";
+
+fn setup() {
+    init_tracing();
+}
+
+#[serial]
+#[tokio::test(flavor = "multi_thread")]
+async fn test_start_creates_pipe() {
+    setup();
+    let mut agent = always_approving_agent();
+
+    agent.start_server().unwrap();
+
+    // The pipe is created synchronously before start_server() returns,
+    // so no sleep is needed — the OS accepts the connection immediately.
+    let result = ClientOptions::new().open(PIPE_NAME);
+    assert!(
+        result.is_ok(),
+        "client connection to named pipe should succeed"
+    );
+    agent.stop_server();
+}
+
+#[serial]
+#[tokio::test(flavor = "multi_thread")]
+async fn test_client_can_connect() {
+    setup();
+    let mut agent = always_approving_agent();
+    agent.start_server().unwrap();
+
+    let result = ClientOptions::new().open(PIPE_NAME);
+
+    assert!(
+        result.is_ok(),
+        "client connection to named pipe should succeed"
+    );
+    agent.stop_server();
+}
+
+#[serial]
+#[tokio::test(flavor = "multi_thread")]
+async fn test_stop_clears_running_state() {
+    setup();
+    let mut agent = always_approving_agent();
+    agent.start_server().unwrap();
+
+    agent.stop_server();
+
+    assert!(!agent.is_running());
+}
+
+#[serial]
+#[tokio::test(flavor = "multi_thread")]
+async fn test_server_can_restart() {
+    setup();
+    let mut agent = always_approving_agent();
+
+    agent.start_server().unwrap();
+    agent.stop_server();
+    agent.start_server().unwrap();
+
+    assert!(agent.is_running());
+    assert!(ClientOptions::new().open(PIPE_NAME).is_ok());
+    agent.stop_server();
+}


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-30763

## 📔 Objective

The Windows analog to #20046 , adds a Windows listener for the ssh agent v2 server, using a named pipe.

Parity with the v1 implementation, adjusted to match the design of the v2.

Added unit and integration tests.

## 📸 Testing Done

The integration tests, on native windows

```
     Running tests\server_windows.rs 
running 4 tests
2026-04-09T15:28:43.270098Z  INFO desktop_core::secure_memory::secure_key:  is not a valid secure key container backend, using automatic selection
2026-04-09T15:28:43.270330Z  INFO desktop_core::secure_memory::secure_key: Using DPAPI for secure key storage
2026-04-09T15:28:43.271068Z  INFO ssh_agent::server::listener::windows: Named pipe listener ready pipe_name="\\\\.\\pipe\\openssh-ssh-agent"
2026-04-09T15:28:43.271248Z  INFO ssh_agent::server: Starting server
2026-04-09T15:28:43.271508Z  INFO ssh_agent::server: Server started
2026-04-09T15:28:43.271515Z  INFO ssh_agent::server: Accept loop starting
2026-04-09T15:28:43.271627Z  INFO ssh_agent::server: Stopping server
2026-04-09T15:28:43.271776Z  INFO ssh_agent::server: Server stopped
2026-04-09T15:28:43.272462Z  INFO desktop_core::secure_memory::secure_key:  is not a valid secure key container backend, using automatic selection
test test_stop_clears_running_state ... ok
2026-04-09T15:28:43.272563Z  INFO desktop_core::secure_memory::secure_key: Using DPAPI for secure key storage
2026-04-09T15:28:43.272842Z  INFO ssh_agent::server::listener::windows: Named pipe listener ready pipe_name="\\\\.\\pipe\\openssh-ssh-agent"
2026-04-09T15:28:43.272935Z  INFO ssh_agent::server: Starting server
2026-04-09T15:28:43.273008Z  INFO ssh_agent::server: Server started
2026-04-09T15:28:43.273037Z  INFO ssh_agent::server: Accept loop starting
2026-04-09T15:28:43.273099Z  INFO ssh_agent::server: Stopping server
2026-04-09T15:28:43.273156Z  INFO ssh_agent::server: Server stopped
2026-04-09T15:28:43.274007Z  INFO desktop_core::secure_memory::secure_key:  is not a valid secure key container backend, using automatic selection
2026-04-09T15:28:43.274080Z  INFO desktop_core::secure_memory::secure_key: Using DPAPI for secure key storage
2026-04-09T15:28:43.274208Z  INFO ssh_agent::server::listener::windows: Named pipe listener ready pipe_name="\\\\.\\pipe\\openssh-ssh-agent"
2026-04-09T15:28:43.274241Z  INFO ssh_agent::server: Starting server
2026-04-09T15:28:43.274270Z  INFO ssh_agent::server: Server started
2026-04-09T15:28:43.274330Z  INFO ssh_agent::server: Stopping server
2026-04-09T15:28:43.274357Z  INFO ssh_agent::server: Server stopped
2026-04-09T15:28:43.274414Z  INFO ssh_agent::server::listener::windows: Named pipe listener ready pipe_name="\\\\.\\pipe\\openssh-ssh-agent"
2026-04-09T15:28:43.274443Z  INFO ssh_agent::server: Starting server
2026-04-09T15:28:43.274471Z  INFO ssh_agent::server: Server started
2026-04-09T15:28:43.274296Z  INFO ssh_agent::server: Accept loop starting
2026-04-09T15:28:43.274615Z  INFO ssh_agent::server: Accept loop exited
2026-04-09T15:28:43.274587Z  INFO ssh_agent::server: Stopping server
2026-04-09T15:28:43.274674Z  INFO ssh_agent::server: Server stopped
2026-04-09T15:28:43.274496Z  INFO ssh_agent::server: Accept loop starting
2026-04-09T15:28:43.275411Z  INFO ssh_agent::server: Accept loop exited
2026-04-09T15:28:43.275300Z  INFO desktop_core::secure_memory::secure_key:  is not a valid secure key container backend, using automatic selection
2026-04-09T15:28:43.275586Z  INFO desktop_core::secure_memory::secure_key: Using DPAPI for secure key storage
test test_server_can_restart ... ok
2026-04-09T15:28:43.275746Z  INFO ssh_agent::server::listener::windows: Named pipe listener ready pipe_name="\\\\.\\pipe\\openssh-ssh-agent"
2026-04-09T15:28:43.275880Z  INFO ssh_agent::server: Starting server
2026-04-09T15:28:43.275945Z  INFO ssh_agent::server: Server started
2026-04-09T15:28:43.275980Z  INFO ssh_agent::server: Accept loop starting
2026-04-09T15:28:43.276047Z  INFO ssh_agent::server: Stopping server
2026-04-09T15:28:43.276083Z  INFO ssh_agent::server: Server stopped
test test_client_can_connect ... ok
test test_start_creates_pipe ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s
```