### PR TITLE
[PM-29549] Update PhishingDetectionService to use constructor, add unit tests

### DIFF
--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -531,6 +531,7 @@ export default class MainBackground {
   // DIRT
   private phishingDataService: PhishingDataService;
   private phishingDetectionSettingsService: PhishingDetectionSettingsServiceAbstraction;
+  private phishingDetectionService: PhishingDetectionService;
 
   constructor() {
     const logoutCallback = async (logoutReason: LogoutReason, userId?: UserId) =>
@@ -1551,7 +1552,7 @@ export default class MainBackground {
       this.stateProvider,
     );
 
-    PhishingDetectionService.initialize(
+    this.phishingDetectionService = new PhishingDetectionService(
       this.logService,
       this.phishingDataService,
       this.phishingDetectionSettingsService,

--- a/apps/browser/src/dirt/phishing-detection/services/phishing-detection.service.spec.ts
+++ b/apps/browser/src/dirt/phishing-detection/services/phishing-detection.service.spec.ts
@@ -264,42 +264,4 @@ describe("PhishingDetectionService", () => {
       expect(BrowserApi.closeTab).toHaveBeenCalledWith(42);
     });
   });
-
-  describe("settings toggle", () => {
-    it("starts checking after being enabled", async () => {
-      buildService();
-      phishingDataService.isPhishingWebAddress.mockResolvedValue(true);
-
-      onEnabled$.next(true);
-      tabUpdatedListener(1, { status: "complete" }, makeTab("https://evil.com"));
-      await Promise.resolve();
-
-      expect(phishingDataService.isPhishingWebAddress).toHaveBeenCalled();
-    });
-
-    it("stops checking when disabled", async () => {
-      buildService();
-      onEnabled$.next(true);
-      onEnabled$.next(false);
-
-      tabUpdatedListener(1, { status: "complete" }, makeTab("https://evil.com"));
-      await Promise.resolve();
-
-      expect(phishingDataService.isPhishingWebAddress).not.toHaveBeenCalled();
-    });
-
-    it("resumes checking after being re-enabled", async () => {
-      buildService();
-      phishingDataService.isPhishingWebAddress.mockResolvedValue(false);
-
-      onEnabled$.next(true);
-      onEnabled$.next(false);
-      onEnabled$.next(true);
-
-      tabUpdatedListener(1, { status: "complete" }, makeTab("https://safe.com"));
-      await Promise.resolve();
-
-      expect(phishingDataService.isPhishingWebAddress).toHaveBeenCalled();
-    });
-  });
 });

--- a/apps/browser/src/dirt/phishing-detection/services/phishing-detection.service.spec.ts
+++ b/apps/browser/src/dirt/phishing-detection/services/phishing-detection.service.spec.ts
@@ -1,87 +1,305 @@
-import { mock, MockProxy } from "jest-mock-extended";
-import { Observable, of } from "rxjs";
+import { Subject, of } from "rxjs";
 
 import { PhishingDetectionSettingsServiceAbstraction } from "@bitwarden/common/dirt/services/abstractions/phishing-detection-settings.service.abstraction";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { MessageListener } from "@bitwarden/messaging";
 
+import { BrowserApi } from "../../../platform/browser/browser-api";
+
 import { PhishingDataService } from "./phishing-data.service";
-import { PhishingDetectionService } from "./phishing-detection.service";
+import {
+  PHISHING_DETECTION_CANCEL_COMMAND,
+  PHISHING_DETECTION_CONTINUE_COMMAND,
+  PhishingDetectionService,
+} from "./phishing-detection.service";
+
+type TabUpdatedListener = (
+  tabId: number,
+  changeInfo: chrome.tabs.OnUpdatedInfo,
+  tab: chrome.tabs.Tab,
+) => void;
+
+function makeTab(url?: string): chrome.tabs.Tab {
+  return { url } as chrome.tabs.Tab;
+}
 
 describe("PhishingDetectionService", () => {
   let logService: LogService;
-  let phishingDataService: MockProxy<PhishingDataService>;
-  let messageListener: MockProxy<MessageListener>;
-  let phishingDetectionSettingsService: MockProxy<PhishingDetectionSettingsServiceAbstraction>;
+  let phishingDataService: jest.Mocked<
+    Pick<PhishingDataService, "isPhishingWebAddress" | "update$">
+  >;
+  let phishingDetectionSettingsService: jest.Mocked<PhishingDetectionSettingsServiceAbstraction>;
+  let messageSubject: Subject<{ command: string; [key: string]: unknown }>;
+  let onEnabled$: Subject<boolean>;
+  let tabUpdatedListener: TabUpdatedListener;
 
   beforeEach(() => {
-    logService = { info: jest.fn(), debug: jest.fn(), warning: jest.fn(), error: jest.fn() } as any;
-    phishingDataService = mock();
-    messageListener = mock<MessageListener>({
-      messages$(_commandDefinition) {
-        return new Observable();
-      },
+    logService = {
+      info: jest.fn(),
+      debug: jest.fn(),
+      warning: jest.fn(),
+      error: jest.fn(),
+    } as unknown as LogService;
+
+    phishingDataService = {
+      isPhishingWebAddress: jest.fn().mockResolvedValue(false),
+      update$: of(undefined),
+    } as unknown as jest.Mocked<Pick<PhishingDataService, "isPhishingWebAddress" | "update$">>;
+
+    onEnabled$ = new Subject<boolean>();
+    phishingDetectionSettingsService = {
+      on$: onEnabled$.asObservable(),
+    } as unknown as jest.Mocked<PhishingDetectionSettingsServiceAbstraction>;
+
+    messageSubject = new Subject();
+
+    jest.spyOn(BrowserApi, "addListener").mockImplementation((_event, listener) => {
+      tabUpdatedListener = listener as TabUpdatedListener;
     });
-    phishingDetectionSettingsService = mock<PhishingDetectionSettingsServiceAbstraction>({
-      on$: of(true),
-    });
+    jest.spyOn(BrowserApi, "navigateTabToUrl").mockResolvedValue(undefined);
+    jest.spyOn(BrowserApi, "closeTab").mockResolvedValue(undefined);
+    jest
+      .spyOn(BrowserApi, "getRuntimeURL")
+      .mockReturnValue("chrome-extension://abc123/popup/index.html#/security/phishing-warning");
   });
 
-  it("should initialize without errors", () => {
-    expect(() => {
-      PhishingDetectionService.initialize(
-        logService,
-        phishingDataService,
-        phishingDetectionSettingsService,
-        messageListener,
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  function buildService() {
+    const listener = new MessageListener(messageSubject.asObservable() as any);
+    return new PhishingDetectionService(
+      logService,
+      phishingDataService as unknown as PhishingDataService,
+      phishingDetectionSettingsService,
+      listener,
+    );
+  }
+
+  function sendMessage(command: string, payload: Record<string, unknown> = {}) {
+    messageSubject.next({ command, ...payload });
+  }
+
+  describe("initialization", () => {
+    it("registers a chrome.tabs.onUpdated listener via BrowserApi", () => {
+      buildService();
+      expect(BrowserApi.addListener).toHaveBeenCalledWith(
+        chrome.tabs.onUpdated,
+        expect.any(Function),
       );
-    }).not.toThrow();
+    });
   });
 
-  // TODO
-  // it("should enable phishing detection for premium account", (done) => {
-  //   const premiumAccount = { id: "user1" };
-  //   accountService = { activeAccount$: of(premiumAccount) } as any;
-  //   configService = { getFeatureFlag$: jest.fn(() => of(true)) } as any;
-  //   billingAccountProfileStateService = {
-  //     hasPremiumFromAnySource$: jest.fn(() => of(true)),
-  //   } as any;
+  describe("when phishing detection is disabled", () => {
+    beforeEach(() => {
+      buildService();
+      onEnabled$.next(false);
+    });
 
-  //   // Run the initialization
-  //   PhishingDetectionService.initialize(
-  //     accountService,
-  //     billingAccountProfileStateService,
-  //     configService,
-  //     logService,
-  //     phishingDataService,
-  //     messageListener,
-  //     phishingDetectionSettingsService,
-  //   );
-  // });
+    it("does not check phishing on tab navigation", async () => {
+      tabUpdatedListener(1, { status: "complete" }, makeTab("https://evil.com"));
+      await Promise.resolve();
+      expect(phishingDataService.isPhishingWebAddress).not.toHaveBeenCalled();
+    });
 
-  // TODO
-  // it("should not enable phishing detection for non-premium account", (done) => {
-  //   const nonPremiumAccount = { id: "user2" };
-  //   accountService = { activeAccount$: of(nonPremiumAccount) } as any;
-  //   configService = { getFeatureFlag$: jest.fn(() => of(true)) } as any;
-  //   billingAccountProfileStateService = {
-  //     hasPremiumFromAnySource$: jest.fn(() => of(false)),
-  //   } as any;
+    it("ignores continue commands", async () => {
+      sendMessage(PHISHING_DETECTION_CONTINUE_COMMAND.command, {
+        tabId: 1,
+        url: "https://evil.com",
+      });
+      await Promise.resolve();
+      expect(BrowserApi.navigateTabToUrl).not.toHaveBeenCalled();
+    });
 
-  //   // Run the initialization
-  //   PhishingDetectionService.initialize(
-  //     accountService,
-  //     billingAccountProfileStateService,
-  //     configService,
-  //     logService,
-  //     phishingDataService,
-  //     messageListener,
-  //     phishingDetectionSettingsService,
-  //   );
-  // });
+    it("ignores cancel commands", async () => {
+      sendMessage(PHISHING_DETECTION_CANCEL_COMMAND.command, { tabId: 1 });
+      await Promise.resolve();
+      expect(BrowserApi.closeTab).not.toHaveBeenCalled();
+    });
+  });
 
-  // TODO
-  // it("should not enable phishing detection for safari", () => {
-  //
-  // });
+  describe("tab update filtering", () => {
+    beforeEach(() => {
+      buildService();
+      onEnabled$.next(true);
+    });
+
+    it("ignores events where status is not 'complete'", async () => {
+      tabUpdatedListener(1, { status: "loading" }, makeTab("https://evil.com"));
+      await Promise.resolve();
+      expect(phishingDataService.isPhishingWebAddress).not.toHaveBeenCalled();
+    });
+
+    it("ignores events where tab.url is undefined", async () => {
+      tabUpdatedListener(1, { status: "complete" }, makeTab(undefined));
+      await Promise.resolve();
+      expect(phishingDataService.isPhishingWebAddress).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      "chrome-extension://abc/popup.html",
+      "moz-extension://abc/popup.html",
+      "safari-extension://abc/popup.html",
+      "safari-web-extension://abc/popup.html",
+    ])("ignores extension page URL: %s", async (url) => {
+      tabUpdatedListener(1, { status: "complete" }, makeTab(url));
+      await Promise.resolve();
+      expect(phishingDataService.isPhishingWebAddress).not.toHaveBeenCalled();
+    });
+
+    it("does not re-check the same tab+URL consecutively", async () => {
+      const tab = makeTab("https://safe.com");
+      tabUpdatedListener(1, { status: "complete" }, tab);
+      tabUpdatedListener(1, { status: "complete" }, tab);
+      await Promise.resolve();
+      expect(phishingDataService.isPhishingWebAddress).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("phishing detection", () => {
+    beforeEach(() => {
+      buildService();
+      onEnabled$.next(true);
+    });
+
+    it("does not redirect if URL is not phishing", async () => {
+      phishingDataService.isPhishingWebAddress.mockResolvedValue(false);
+      tabUpdatedListener(1, { status: "complete" }, makeTab("https://safe.com"));
+      await Promise.resolve();
+      expect(BrowserApi.navigateTabToUrl).not.toHaveBeenCalled();
+    });
+
+    it("redirects to warning page if URL is phishing", async () => {
+      phishingDataService.isPhishingWebAddress.mockResolvedValue(true);
+      tabUpdatedListener(1, { status: "complete" }, makeTab("https://evil.com"));
+      await Promise.resolve();
+      expect(BrowserApi.navigateTabToUrl).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({ href: expect.stringContaining("phishing-warning") }),
+      );
+    });
+
+    it("includes the phishing URL as a query param in the warning page URL", async () => {
+      phishingDataService.isPhishingWebAddress.mockResolvedValue(true);
+      tabUpdatedListener(1, { status: "complete" }, makeTab("https://evil.com/path"));
+      await Promise.resolve();
+      const redirectUrl: URL = (BrowserApi.navigateTabToUrl as jest.Mock).mock.calls[0][1];
+      expect(redirectUrl.href).toContain("?phishingUrl=https://evil.com/path");
+    });
+  });
+
+  describe("continue command", () => {
+    beforeEach(() => {
+      buildService();
+      onEnabled$.next(true);
+    });
+
+    it("navigates to the continued URL", async () => {
+      sendMessage(PHISHING_DETECTION_CONTINUE_COMMAND.command, {
+        tabId: 1,
+        url: "https://evil.com",
+      });
+      await Promise.resolve();
+      expect(BrowserApi.navigateTabToUrl).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({ hostname: "evil.com" }),
+      );
+    });
+
+    it("skips the phishing check on the next navigation to the same host", async () => {
+      sendMessage(PHISHING_DETECTION_CONTINUE_COMMAND.command, {
+        tabId: 1,
+        url: "https://evil.com",
+      });
+      await Promise.resolve();
+
+      (BrowserApi.navigateTabToUrl as jest.Mock).mockClear();
+      phishingDataService.isPhishingWebAddress.mockResolvedValue(true);
+
+      tabUpdatedListener(1, { status: "complete" }, makeTab("https://evil.com/other-page"));
+      await Promise.resolve();
+
+      // Should not redirect to warning page — was ignored
+      expect(BrowserApi.navigateTabToUrl).not.toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ href: expect.stringContaining("phishing-warning") }),
+      );
+    });
+
+    it("blocks again on the visit after the ignored one", async () => {
+      phishingDataService.isPhishingWebAddress.mockResolvedValue(true);
+
+      sendMessage(PHISHING_DETECTION_CONTINUE_COMMAND.command, {
+        tabId: 1,
+        url: "https://evil.com",
+      });
+      await Promise.resolve();
+
+      // First visit after continue — ignored
+      tabUpdatedListener(1, { status: "complete" }, makeTab("https://evil.com/page1"));
+      await Promise.resolve();
+      (BrowserApi.navigateTabToUrl as jest.Mock).mockClear();
+
+      // Second visit — should block again
+      tabUpdatedListener(2, { status: "complete" }, makeTab("https://evil.com/page2"));
+      await Promise.resolve();
+
+      expect(BrowserApi.navigateTabToUrl).toHaveBeenCalledWith(
+        2,
+        expect.objectContaining({ href: expect.stringContaining("phishing-warning") }),
+      );
+    });
+  });
+
+  describe("cancel command", () => {
+    beforeEach(() => {
+      buildService();
+      onEnabled$.next(true);
+    });
+
+    it("closes the tab with the given tabId", async () => {
+      sendMessage(PHISHING_DETECTION_CANCEL_COMMAND.command, { tabId: 42 });
+      await Promise.resolve();
+      expect(BrowserApi.closeTab).toHaveBeenCalledWith(42);
+    });
+  });
+
+  describe("settings toggle", () => {
+    it("starts checking after being enabled", async () => {
+      buildService();
+      phishingDataService.isPhishingWebAddress.mockResolvedValue(true);
+
+      onEnabled$.next(true);
+      tabUpdatedListener(1, { status: "complete" }, makeTab("https://evil.com"));
+      await Promise.resolve();
+
+      expect(phishingDataService.isPhishingWebAddress).toHaveBeenCalled();
+    });
+
+    it("stops checking when disabled", async () => {
+      buildService();
+      onEnabled$.next(true);
+      onEnabled$.next(false);
+
+      tabUpdatedListener(1, { status: "complete" }, makeTab("https://evil.com"));
+      await Promise.resolve();
+
+      expect(phishingDataService.isPhishingWebAddress).not.toHaveBeenCalled();
+    });
+
+    it("resumes checking after being re-enabled", async () => {
+      buildService();
+      phishingDataService.isPhishingWebAddress.mockResolvedValue(false);
+
+      onEnabled$.next(true);
+      onEnabled$.next(false);
+      onEnabled$.next(true);
+
+      tabUpdatedListener(1, { status: "complete" }, makeTab("https://safe.com"));
+      await Promise.resolve();
+
+      expect(phishingDataService.isPhishingWebAddress).toHaveBeenCalled();
+    });
+  });
 });

--- a/apps/browser/src/dirt/phishing-detection/services/phishing-detection.service.ts
+++ b/apps/browser/src/dirt/phishing-detection/services/phishing-detection.service.ts
@@ -30,11 +30,11 @@ export const PHISHING_DETECTION_CANCEL_COMMAND = new CommandDefinition<{
 }>("phishing-detection-cancel");
 
 export class PhishingDetectionService {
-  private static _tabUpdated$ = new Subject<PhishingDetectionNavigationEvent>();
-  private static _ignoredHostnames = new Set<string>();
-  private static _didInit = false;
+  private _tabUpdated$ = new Subject<PhishingDetectionNavigationEvent>();
+  private _ignoredHostnames = new Set<string>();
+  private _didInit = false;
 
-  static initialize(
+  constructor(
     logService: LogService,
     phishingDataService: PhishingDataService,
     phishingDetectionSettingsService: PhishingDetectionSettingsServiceAbstraction,
@@ -105,7 +105,7 @@ export class PhishingDetectionService {
 
     const phishingDetectionActive$ = phishingDetectionSettingsService.on$;
 
-    const initSub = phishingDetectionActive$
+    phishingDetectionActive$
       .pipe(
         distinctUntilChanged(),
         switchMap((activeUserHasAccess) => {
@@ -128,24 +128,9 @@ export class PhishingDetectionService {
       .subscribe();
 
     this._didInit = true;
-    return () => {
-      // Dispose phishing data service resources
-      phishingDataService.dispose();
-
-      initSub.unsubscribe();
-      this._didInit = false;
-
-      // Manually type cast to satisfy the listener signature due to the mixture
-      // of static and instance methods in this class. To be fixed when refactoring
-      // this class to be instance-based while providing a singleton instance in usage
-      BrowserApi.removeListener(
-        chrome.tabs.onUpdated,
-        PhishingDetectionService._handleTabUpdated as (...args: readonly unknown[]) => unknown,
-      );
-    };
   }
 
-  private static _handleTabUpdated(
+  private _handleTabUpdated(
     tabId: number,
     changeInfo: chrome.tabs.OnUpdatedInfo,
     tab: chrome.tabs.Tab,
@@ -156,7 +141,7 @@ export class PhishingDetectionService {
     return true;
   }
 
-  private static _isExtensionPage(url: string): boolean {
+  private _isExtensionPage(url: string): boolean {
     // Check against all common extension protocols
     return (
       url.startsWith("chrome-extension://") ||


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-29549

## 📔 Objective
PhishingDetectionService is updated to remove static methods/intialization, and updated to use constructor object creation. 

Unit tests covering functionality of the service are added: 
- Continue command handling (user chooses to navigate to phishing link)
- Cancel command handling (user stops navigation to phishing link)
- Phishing link detection/handling (navigate tab to phishing blocker page)
- No phishing link checks when the feature is disabled.

## 📸 Screenshots
N/A - no UI changes included