### PR TITLE
PM-34863 Org name has a contrast issue

### DIFF
--- a/apps/web/src/app/dirt/reports/pages/exposed-passwords-report.component.html
+++ b/apps/web/src/app/dirt/reports/pages/exposed-passwords-report.component.html
@@ -105,9 +105,9 @@
               </td>
             }
             <td bitCell class="tw-text-right">
-              <span bitBadge variant="warning" size="small">
+              <bit-badge variant="warning" size="small">
                 {{ "exposedXTimes" | i18n: (row.exposedXTimes | number) }}
-              </span>
+              </bit-badge>
             </td>
           </ng-template>
         </bit-table-scroll>

--- a/apps/web/src/app/dirt/reports/pages/exposed-passwords-report.component.html
+++ b/apps/web/src/app/dirt/reports/pages/exposed-passwords-report.component.html
@@ -98,7 +98,7 @@
                     {{ row.organizationId | orgNameFromId: (organizations$ | async) }}
                   </bit-badge>
                 } @else {
-                  <bit-badge variant="secondary">
+                  <bit-badge variant="secondary" size="small">
                     {{ "me" | i18n }}
                   </bit-badge>
                 }

--- a/apps/web/src/app/dirt/reports/pages/exposed-passwords-report.component.html
+++ b/apps/web/src/app/dirt/reports/pages/exposed-passwords-report.component.html
@@ -105,7 +105,7 @@
               </td>
             }
             <td bitCell class="tw-text-right">
-              <span bitBadge variant="warning" class="tw-text-xs">
+              <span bitBadge variant="warning" size="small">
                 {{ "exposedXTimes" | i18n: (row.exposedXTimes | number) }}
               </span>
             </td>

--- a/apps/web/src/app/dirt/reports/pages/exposed-passwords-report.component.html
+++ b/apps/web/src/app/dirt/reports/pages/exposed-passwords-report.component.html
@@ -93,21 +93,19 @@
             </td>
             @if (!isAdminConsoleActive) {
               <td bitCell>
-                @if (!organization) {
-                  <app-org-badge
-                    [disabled]="disabled"
-                    [organizationId]="row.organizationId"
-                    [organizationName]="
-                      row.organizationId | orgNameFromId: (organizations$ | async)
-                    "
-                    appStopProp
-                  >
-                  </app-org-badge>
+                @if (row.organizationId) {
+                  <bit-badge variant="secondary">
+                    {{ row.organizationId | orgNameFromId: (organizations$ | async) }}
+                  </bit-badge>
+                } @else {
+                  <bit-badge variant="secondary">
+                    {{ "me" | i18n }}
+                  </bit-badge>
                 }
               </td>
             }
             <td bitCell class="tw-text-right">
-              <span bitBadge variant="warning">
+              <span bitBadge variant="warning" class="tw-text-xs">
                 {{ "exposedXTimes" | i18n: (row.exposedXTimes | number) }}
               </span>
             </td>

--- a/apps/web/src/app/dirt/reports/pages/exposed-passwords-report.component.html
+++ b/apps/web/src/app/dirt/reports/pages/exposed-passwords-report.component.html
@@ -94,7 +94,7 @@
             @if (!isAdminConsoleActive) {
               <td bitCell>
                 @if (row.organizationId) {
-                  <bit-badge variant="secondary">
+                  <bit-badge variant="secondary" size="small">
                     {{ row.organizationId | orgNameFromId: (organizations$ | async) }}
                   </bit-badge>
                 } @else {

--- a/apps/web/src/app/dirt/reports/pages/inactive-two-factor-report.component.html
+++ b/apps/web/src/app/dirt/reports/pages/inactive-two-factor-report.component.html
@@ -94,15 +94,14 @@
             </td>
             @if (!isAdminConsoleActive) {
               <td bitCell>
-                @if (!organization) {
-                  <app-org-badge
-                    [disabled]="disabled"
-                    [organizationId]="row.organizationId"
-                    [organizationName]="
-                      row.organizationId | orgNameFromId: (organizations$ | async)
-                    "
-                    appStopProp
-                  />
+                @if (row.organizationId) {
+                  <bit-badge variant="secondary">
+                    {{ row.organizationId | orgNameFromId: (organizations$ | async) }}
+                  </bit-badge>
+                } @else {
+                  <bit-badge variant="secondary">
+                    {{ "me" | i18n }}
+                  </bit-badge>
                 }
               </td>
             }

--- a/apps/web/src/app/dirt/reports/pages/reused-passwords-report.component.html
+++ b/apps/web/src/app/dirt/reports/pages/reused-passwords-report.component.html
@@ -106,9 +106,9 @@
               </td>
             }
             <td bitCell class="tw-text-right">
-              <span bitBadge variant="warning" size="small">
+              <bit-badge variant="warning" size="small">
                 {{ "reusedXTimes" | i18n: passwordUseMap.get(row.login.password) }}
-              </span>
+              </bit-badge>
             </td>
           </ng-template>
         </bit-table-scroll>

--- a/apps/web/src/app/dirt/reports/pages/reused-passwords-report.component.html
+++ b/apps/web/src/app/dirt/reports/pages/reused-passwords-report.component.html
@@ -99,7 +99,7 @@
                     {{ row.organizationId | orgNameFromId: (organizations$ | async) }}
                   </bit-badge>
                 } @else {
-                  <bit-badge variant="secondary">
+                  <bit-badge variant="secondary" size="small">
                     {{ "me" | i18n }}
                   </bit-badge>
                 }

--- a/apps/web/src/app/dirt/reports/pages/reused-passwords-report.component.html
+++ b/apps/web/src/app/dirt/reports/pages/reused-passwords-report.component.html
@@ -95,7 +95,7 @@
             @if (!isAdminConsoleActive) {
               <td bitCell>
                 @if (row.organizationId) {
-                  <bit-badge variant="secondary">
+                  <bit-badge variant="secondary" size="small">
                     {{ row.organizationId | orgNameFromId: (organizations$ | async) }}
                   </bit-badge>
                 } @else {

--- a/apps/web/src/app/dirt/reports/pages/reused-passwords-report.component.html
+++ b/apps/web/src/app/dirt/reports/pages/reused-passwords-report.component.html
@@ -106,7 +106,7 @@
               </td>
             }
             <td bitCell class="tw-text-right">
-              <span bitBadge variant="warning" class="tw-text-xs">
+              <span bitBadge variant="warning" size="small">
                 {{ "reusedXTimes" | i18n: passwordUseMap.get(row.login.password) }}
               </span>
             </td>

--- a/apps/web/src/app/dirt/reports/pages/reused-passwords-report.component.html
+++ b/apps/web/src/app/dirt/reports/pages/reused-passwords-report.component.html
@@ -94,21 +94,19 @@
             </td>
             @if (!isAdminConsoleActive) {
               <td bitCell>
-                @if (!organization) {
-                  <app-org-badge
-                    [disabled]="disabled"
-                    [organizationId]="row.organizationId"
-                    [organizationName]="
-                      row.organizationId | orgNameFromId: (organizations$ | async)
-                    "
-                    appStopProp
-                  >
-                  </app-org-badge>
+                @if (row.organizationId) {
+                  <bit-badge variant="secondary">
+                    {{ row.organizationId | orgNameFromId: (organizations$ | async) }}
+                  </bit-badge>
+                } @else {
+                  <bit-badge variant="secondary">
+                    {{ "me" | i18n }}
+                  </bit-badge>
                 }
               </td>
             }
             <td bitCell class="tw-text-right">
-              <span bitBadge variant="warning">
+              <span bitBadge variant="warning" class="tw-text-xs">
                 {{ "reusedXTimes" | i18n: passwordUseMap.get(row.login.password) }}
               </span>
             </td>

--- a/apps/web/src/app/dirt/reports/pages/unsecured-websites-report.component.html
+++ b/apps/web/src/app/dirt/reports/pages/unsecured-websites-report.component.html
@@ -93,16 +93,14 @@
             </td>
             @if (!isAdminConsoleActive) {
               <td bitCell>
-                @if (!organization) {
-                  <app-org-badge
-                    [disabled]="disabled"
-                    [organizationId]="row.organizationId"
-                    [organizationName]="
-                      row.organizationId | orgNameFromId: (organizations$ | async)
-                    "
-                    appStopProp
-                  >
-                  </app-org-badge>
+                @if (row.organizationId) {
+                  <bit-badge variant="secondary">
+                    {{ row.organizationId | orgNameFromId: (organizations$ | async) }}
+                  </bit-badge>
+                } @else {
+                  <bit-badge variant="secondary">
+                    {{ "me" | i18n }}
+                  </bit-badge>
                 }
               </td>
             }

--- a/apps/web/src/app/dirt/reports/pages/weak-passwords-report.component.html
+++ b/apps/web/src/app/dirt/reports/pages/weak-passwords-report.component.html
@@ -99,7 +99,7 @@
             @if (!isAdminConsoleActive) {
               <td bitCell>
                 @if (row.organizationId) {
-                  <bit-badge variant="secondary">
+                  <bit-badge variant="secondary" size="small">
                     {{ row.organizationId | orgNameFromId: (organizations$ | async) }}
                   </bit-badge>
                 } @else {

--- a/apps/web/src/app/dirt/reports/pages/weak-passwords-report.component.html
+++ b/apps/web/src/app/dirt/reports/pages/weak-passwords-report.component.html
@@ -110,9 +110,9 @@
               </td>
             }
             <td bitCell class="tw-text-right">
-              <span bitBadge [variant]="row.reportValue.badgeVariant" size="small">
+              <bit-badge [variant]="row.reportValue.badgeVariant" size="small">
                 {{ row.reportValue.label | i18n }}
-              </span>
+              </bit-badge>
             </td>
           </ng-template>
         </bit-table-scroll>

--- a/apps/web/src/app/dirt/reports/pages/weak-passwords-report.component.html
+++ b/apps/web/src/app/dirt/reports/pages/weak-passwords-report.component.html
@@ -98,21 +98,19 @@
             </td>
             @if (!isAdminConsoleActive) {
               <td bitCell>
-                @if (!organization) {
-                  <app-org-badge
-                    [disabled]="disabled"
-                    [organizationId]="row.organizationId"
-                    [organizationName]="
-                      row.organizationId | orgNameFromId: (organizations$ | async)
-                    "
-                    appStopProp
-                  >
-                  </app-org-badge>
+                @if (row.organizationId) {
+                  <bit-badge variant="secondary">
+                    {{ row.organizationId | orgNameFromId: (organizations$ | async) }}
+                  </bit-badge>
+                } @else {
+                  <bit-badge variant="secondary">
+                    {{ "me" | i18n }}
+                  </bit-badge>
                 }
               </td>
             }
             <td bitCell class="tw-text-right">
-              <span bitBadge [variant]="row.reportValue.badgeVariant">
+              <span bitBadge [variant]="row.reportValue.badgeVariant" class="tw-text-xs">
                 {{ row.reportValue.label | i18n }}
               </span>
             </td>

--- a/apps/web/src/app/dirt/reports/pages/weak-passwords-report.component.html
+++ b/apps/web/src/app/dirt/reports/pages/weak-passwords-report.component.html
@@ -103,7 +103,7 @@
                     {{ row.organizationId | orgNameFromId: (organizations$ | async) }}
                   </bit-badge>
                 } @else {
-                  <bit-badge variant="secondary">
+                  <bit-badge variant="secondary" size="small">
                     {{ "me" | i18n }}
                   </bit-badge>
                 }

--- a/apps/web/src/app/dirt/reports/pages/weak-passwords-report.component.html
+++ b/apps/web/src/app/dirt/reports/pages/weak-passwords-report.component.html
@@ -110,7 +110,7 @@
               </td>
             }
             <td bitCell class="tw-text-right">
-              <span bitBadge [variant]="row.reportValue.badgeVariant" class="tw-text-xs">
+              <span bitBadge [variant]="row.reportValue.badgeVariant" size="small">
                 {{ row.reportValue.label | i18n }}
               </span>
             </td>


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-34863
https://bitwarden.atlassian.net/browse/PM-34882

## 📔 Objective

The issue in PM-34863 was that the `app-org-badge` component has a disabled mode which does not have contrast. The RCA recommends using a the `bit-badge` component as a replacement

## 📸 Screenshots

Fixes on the following pages:

** exposed passwords **
<img width="1030" height="871" alt="image" src="https://github.com/user-attachments/assets/8d2bb064-d035-4d58-a956-a793f60247f2" />

** reused passwords **
<img width="1030" height="871" alt="image" src="https://github.com/user-attachments/assets/875d7ff4-c86b-48be-abc1-5629584a72c9" />

** weak passwords **
<img width="1030" height="871" alt="image" src="https://github.com/user-attachments/assets/4075572f-534a-4b83-aa46-6484573c5861" />

** unsecure websites **
<img width="1030" height="871" alt="image" src="https://github.com/user-attachments/assets/f691ffd1-e75f-49bb-9dfc-b5f67633408c" />


** inactive two-fa **
<img width="1030" height="871" alt="image" src="https://github.com/user-attachments/assets/305aa8db-35af-4948-9719-77d429e5b07b" />
