### PR TITLE
Improve secure key env var match default case

### DIFF
--- a/apps/desktop/desktop_native/core/src/secure_memory/secure_key/mod.rs
+++ b/apps/desktop/desktop_native/core/src/secure_memory/secure_key/mod.rs
@@ -8,7 +8,7 @@
 //! The implementations include DPAPI on Windows, `keyctl` on Linux, and `memfd_secret` on Linux,
 //! and a fallback implementation using mlock.
 
-use tracing::info;
+use tracing::{debug, info, warn};
 
 mod crypto;
 #[cfg(target_os = "windows")]
@@ -174,14 +174,21 @@ fn get_env_forced_container() -> Option<CrossPlatformSecureKeyContainer> {
             ))
         }
         Ok(env_var) => {
-            info!(
+            warn!(
                 env_var,
                 "is not a valid secure key container backend, using automatic selection"
             );
             None
         }
+        Err(std::env::VarError::NotPresent) => {
+            debug!(
+                env_var = ENV_VAR_SECURE_KEY_CONTAINER_BACKEND,
+                "is not set, using automatic selection"
+            );
+            None
+        }
         Err(error) => {
-            info!(
+            warn!(
                 %error,
                 env_var = ENV_VAR_SECURE_KEY_CONTAINER_BACKEND,
                 "failed to read environment variable, using automatic selection"

--- a/apps/desktop/desktop_native/core/src/secure_memory/secure_key/mod.rs
+++ b/apps/desktop/desktop_native/core/src/secure_memory/secure_key/mod.rs
@@ -140,7 +140,9 @@ impl SecureKeyContainer for CrossPlatformSecureKeyContainer {
 }
 
 fn get_env_forced_container() -> Option<CrossPlatformSecureKeyContainer> {
-    let env_var = std::env::var("SECURE_KEY_CONTAINER_BACKEND");
+    const ENV_VAR_SECURE_KEY_CONTAINER_BACKEND: &str = "SECURE_KEY_CONTAINER_BACKEND";
+    let env_var = std::env::var(ENV_VAR_SECURE_KEY_CONTAINER_BACKEND);
+
     match env_var.as_deref() {
         #[cfg(target_os = "windows")]
         Ok("dpapi") => {
@@ -171,10 +173,18 @@ fn get_env_forced_container() -> Option<CrossPlatformSecureKeyContainer> {
                 mlock::MlockSecureKeyContainer::from_key(crypto::MemoryEncryptionKey::new()),
             ))
         }
-        _ => {
+        Ok(env_var) => {
             info!(
-                "{} is not a valid secure key container backend, using automatic selection",
-                env_var.unwrap_or_default()
+                env_var,
+                "is not a valid secure key container backend, using automatic selection"
+            );
+            None
+        }
+        Err(error) => {
+            info!(
+                %error,
+                env_var = ENV_VAR_SECURE_KEY_CONTAINER_BACKEND,
+                "failed to read environment variable, using automatic selection"
             );
             None
         }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-35122

## 📔 Objective

Improves the logging of the default case for the secure key env var check.

I noticed this while observing tracing output from ssh agent. It reads:

```
2026-04-07T21:00:21.928081Z  INFO desktop_core::secure_memory::secure_key:  is not a valid secure key container backend, using automatic selection
```

, notably, the default match case is currently doing two things that could be improved: if the env var is not set, the log statement doesn't reflect that because it's an empty string. It doesn't delineate between the Ok(string) case and the Err case. Even though both result in a None return, it's more clear to read the logs what is going on.

Sine the existing code had `info` for both cases, I'm assuming the env var is not required/expected (hence using info for the Err case, instead of something like error or warn).
