### PR TITLE
[PM-35072] Allow account recovery for revoked members

### DIFF
--- a/apps/web/src/app/admin-console/organizations/members/components/account-recovery/account-recovery-dialog-v2.component.ts
+++ b/apps/web/src/app/admin-console/organizations/members/components/account-recovery/account-recovery-dialog-v2.component.ts
@@ -101,7 +101,7 @@ export class AccountRecoveryDialogV2Component {
 
   protected readonly form = this.formBuilder.group({
     resetMasterPassword: [true],
-    resetTwoFactor: [false],
+    resetTwoFactor: [{ value: false, disabled: !this.dialogData.twoFactorEnabled }],
   });
 
   constructor(

--- a/apps/web/src/app/admin-console/organizations/members/components/account-recovery/account-recovery-dialog.component.ts
+++ b/apps/web/src/app/admin-console/organizations/members/components/account-recovery/account-recovery-dialog.component.ts
@@ -53,6 +53,12 @@ export type AccountRecoveryDialogData = {
    * The organization user's role type, used to determine policy exemption
    */
   organizationUserType: OrganizationUserType;
+
+  /**
+   * Whether the organization user currently has two-step login enabled.
+   * Used to disable the reset two-step login option when not applicable.
+   */
+  twoFactorEnabled: boolean;
 };
 
 export const AccountRecoveryDialogResultType = {

--- a/apps/web/src/app/admin-console/organizations/members/members.component.html
+++ b/apps/web/src/app/admin-console/organizations/members/members.component.html
@@ -344,6 +344,7 @@
                   <span class="tw-sr-only">{{ "userUsingTwoStep" | i18n }}</span>
                 }
                 @let resetPasswordPolicyEnabled = resetPasswordPolicyEnabled$ | async;
+                @let adminResetTwoFactorEnabled = adminResetTwoFactorEnabled$ | async;
                 @if (showEnrolledStatus(u, organization, resetPasswordPolicyEnabled)) {
                   <i
                     class="bwi bwi-key"
@@ -431,7 +432,14 @@
                   }
 
                   <!-- Account recovery is available to all users with appropriate permissions -->
-                  @if (allowResetPassword(u, organization, resetPasswordPolicyEnabled)) {
+                  @if (
+                    allowResetPassword(
+                      u,
+                      organization,
+                      resetPasswordPolicyEnabled,
+                      adminResetTwoFactorEnabled
+                    )
+                  ) {
                     <button
                       type="button"
                       bitMenuItem

--- a/apps/web/src/app/admin-console/organizations/members/members.component.ts
+++ b/apps/web/src/app/admin-console/organizations/members/members.component.ts
@@ -16,6 +16,7 @@ import {
   shareReplay,
   switchMap,
   take,
+  startWith,
 } from "rxjs";
 
 import { UserNamePipe } from "@bitwarden/angular/pipes/user-name.pipe";
@@ -33,6 +34,8 @@ import { AccountService } from "@bitwarden/common/auth/abstractions/account.serv
 import { getUserId } from "@bitwarden/common/auth/services/account.service";
 import { OrganizationMetadataServiceAbstraction } from "@bitwarden/common/billing/abstractions/organization-metadata.service.abstraction";
 import { OrganizationBillingMetadataResponse } from "@bitwarden/common/billing/models/response/organization-billing-metadata.response";
+import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { EnvironmentService } from "@bitwarden/common/platform/abstractions/environment.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
@@ -100,6 +103,7 @@ export class MembersComponent {
   private organizationMetadataService = inject(OrganizationMetadataServiceAbstraction);
   private environmentService = inject(EnvironmentService);
   private memberExportService = inject(MemberExportService);
+  private configService = inject(ConfigService);
 
   private userId$: Observable<UserId> = this.accountService.activeAccount$.pipe(getUserId);
 
@@ -147,6 +151,7 @@ export class MembersComponent {
   protected billingMetadata$: Observable<OrganizationBillingMetadataResponse>;
 
   protected resetPasswordPolicyEnabled$: Observable<boolean>;
+  protected adminResetTwoFactorEnabled$: Observable<boolean>;
 
   // Fixed sizes used for cdkVirtualScroll
   protected rowHeight = 66;
@@ -191,6 +196,10 @@ export class MembersComponent {
             .find((p) => p.organizationId === organization.id)?.enabled ?? false,
       ),
     );
+
+    this.adminResetTwoFactorEnabled$ = from(
+      this.configService.getFeatureFlag(FeatureFlag.AdminResetTwoFactor),
+    ).pipe(startWith(false));
 
     combineLatest([this.route.queryParams, organization$])
       .pipe(
@@ -296,11 +305,13 @@ export class MembersComponent {
     orgUser: OrganizationUserView,
     organization: Organization,
     orgResetPasswordPolicyEnabled: boolean,
+    adminResetTwoFactorEnabled: boolean,
   ): boolean {
     return this.memberActionsService.allowResetPassword(
       orgUser,
       organization,
       orgResetPasswordPolicyEnabled,
+      adminResetTwoFactorEnabled,
     );
   }
 

--- a/apps/web/src/app/admin-console/organizations/members/members.component.ts
+++ b/apps/web/src/app/admin-console/organizations/members/members.component.ts
@@ -16,7 +16,6 @@ import {
   shareReplay,
   switchMap,
   take,
-  startWith,
 } from "rxjs";
 
 import { UserNamePipe } from "@bitwarden/angular/pipes/user-name.pipe";
@@ -197,9 +196,9 @@ export class MembersComponent {
       ),
     );
 
-    this.adminResetTwoFactorEnabled$ = from(
-      this.configService.getFeatureFlag(FeatureFlag.AdminResetTwoFactor),
-    ).pipe(startWith(false));
+    this.adminResetTwoFactorEnabled$ = this.configService.getFeatureFlag$(
+      FeatureFlag.AdminResetTwoFactor,
+    );
 
     combineLatest([this.route.queryParams, organization$])
       .pipe(

--- a/apps/web/src/app/admin-console/organizations/members/services/member-actions/member-actions.service.spec.ts
+++ b/apps/web/src/app/admin-console/organizations/members/services/member-actions/member-actions.service.spec.ts
@@ -635,12 +635,14 @@ describe("MemberActionsService", () => {
 
   describe("allowResetPassword", () => {
     const resetPasswordEnabled = true;
+    const adminResetTwoFactorEnabled = true;
 
     it("should allow reset password for Owner over User", () => {
       const result = service.allowResetPassword(
         mockOrgUser,
         mockOrganization,
         resetPasswordEnabled,
+        adminResetTwoFactorEnabled,
       );
 
       expect(result).toBe(true);
@@ -649,7 +651,12 @@ describe("MemberActionsService", () => {
     it("should allow reset password for Admin over User", () => {
       const adminOrg = { ...mockOrganization, type: OrganizationUserType.Admin } as Organization;
 
-      const result = service.allowResetPassword(mockOrgUser, adminOrg, resetPasswordEnabled);
+      const result = service.allowResetPassword(
+        mockOrgUser,
+        adminOrg,
+        resetPasswordEnabled,
+        adminResetTwoFactorEnabled,
+      );
 
       expect(result).toBe(true);
     });
@@ -661,7 +668,12 @@ describe("MemberActionsService", () => {
         type: OrganizationUserType.Owner,
       } as OrganizationUserView;
 
-      const result = service.allowResetPassword(ownerUser, adminOrg, resetPasswordEnabled);
+      const result = service.allowResetPassword(
+        ownerUser,
+        adminOrg,
+        resetPasswordEnabled,
+        adminResetTwoFactorEnabled,
+      );
 
       expect(result).toBe(false);
     });
@@ -669,7 +681,12 @@ describe("MemberActionsService", () => {
     it("should allow reset password for Custom over User", () => {
       const customOrg = { ...mockOrganization, type: OrganizationUserType.Custom } as Organization;
 
-      const result = service.allowResetPassword(mockOrgUser, customOrg, resetPasswordEnabled);
+      const result = service.allowResetPassword(
+        mockOrgUser,
+        customOrg,
+        resetPasswordEnabled,
+        adminResetTwoFactorEnabled,
+      );
 
       expect(result).toBe(true);
     });
@@ -681,7 +698,12 @@ describe("MemberActionsService", () => {
         type: OrganizationUserType.Admin,
       } as OrganizationUserView;
 
-      const result = service.allowResetPassword(adminUser, customOrg, resetPasswordEnabled);
+      const result = service.allowResetPassword(
+        adminUser,
+        customOrg,
+        resetPasswordEnabled,
+        adminResetTwoFactorEnabled,
+      );
 
       expect(result).toBe(false);
     });
@@ -693,7 +715,12 @@ describe("MemberActionsService", () => {
         type: OrganizationUserType.Owner,
       } as OrganizationUserView;
 
-      const result = service.allowResetPassword(ownerUser, customOrg, resetPasswordEnabled);
+      const result = service.allowResetPassword(
+        ownerUser,
+        customOrg,
+        resetPasswordEnabled,
+        adminResetTwoFactorEnabled,
+      );
 
       expect(result).toBe(false);
     });
@@ -701,7 +728,12 @@ describe("MemberActionsService", () => {
     it("should not allow reset password when organization cannot manage users password", () => {
       const org = { ...mockOrganization, canManageUsersPassword: false } as Organization;
 
-      const result = service.allowResetPassword(mockOrgUser, org, resetPasswordEnabled);
+      const result = service.allowResetPassword(
+        mockOrgUser,
+        org,
+        resetPasswordEnabled,
+        adminResetTwoFactorEnabled,
+      );
 
       expect(result).toBe(false);
     });
@@ -709,7 +741,12 @@ describe("MemberActionsService", () => {
     it("should not allow reset password when organization does not use reset password", () => {
       const org = { ...mockOrganization, useResetPassword: false } as Organization;
 
-      const result = service.allowResetPassword(mockOrgUser, org, resetPasswordEnabled);
+      const result = service.allowResetPassword(
+        mockOrgUser,
+        org,
+        resetPasswordEnabled,
+        adminResetTwoFactorEnabled,
+      );
 
       expect(result).toBe(false);
     });
@@ -717,18 +754,55 @@ describe("MemberActionsService", () => {
     it("should not allow reset password when user is not enrolled in reset password", () => {
       const user = { ...mockOrgUser, resetPasswordEnrolled: false } as OrganizationUserView;
 
-      const result = service.allowResetPassword(user, mockOrganization, resetPasswordEnabled);
+      const result = service.allowResetPassword(
+        user,
+        mockOrganization,
+        resetPasswordEnabled,
+        adminResetTwoFactorEnabled,
+      );
 
       expect(result).toBe(false);
     });
 
-    it("should not allow reset password when user status is not confirmed", () => {
+    it("should allow reset password when user status is revoked and AdminResetTwoFactor is enabled", () => {
+      const user = {
+        ...mockOrgUser,
+        status: OrganizationUserStatusType.Revoked,
+      } as OrganizationUserView;
+
+      const result = service.allowResetPassword(user, mockOrganization, resetPasswordEnabled, true);
+
+      expect(result).toBe(true);
+    });
+
+    it("should not allow reset password when user status is revoked and AdminResetTwoFactor is disabled", () => {
+      const user = {
+        ...mockOrgUser,
+        status: OrganizationUserStatusType.Revoked,
+      } as OrganizationUserView;
+
+      const result = service.allowResetPassword(
+        user,
+        mockOrganization,
+        resetPasswordEnabled,
+        false,
+      );
+
+      expect(result).toBe(false);
+    });
+
+    it("should not allow reset password when user status is invited", () => {
       const user = {
         ...mockOrgUser,
         status: OrganizationUserStatusType.Invited,
       } as OrganizationUserView;
 
-      const result = service.allowResetPassword(user, mockOrganization, resetPasswordEnabled);
+      const result = service.allowResetPassword(
+        user,
+        mockOrganization,
+        resetPasswordEnabled,
+        adminResetTwoFactorEnabled,
+      );
 
       expect(result).toBe(false);
     });

--- a/apps/web/src/app/admin-console/organizations/members/services/member-actions/member-actions.service.ts
+++ b/apps/web/src/app/admin-console/organizations/members/services/member-actions/member-actions.service.ts
@@ -215,6 +215,7 @@ export class MemberActionsService {
     orgUser: OrganizationUserView,
     organization: Organization,
     resetPasswordEnabled: boolean,
+    adminResetTwoFactorEnabled: boolean,
   ): boolean {
     let callingUserHasPermission = false;
 
@@ -232,6 +233,10 @@ export class MemberActionsService {
         break;
     }
 
+    const statusAllowed =
+      orgUser.status === OrganizationUserStatusType.Confirmed ||
+      (adminResetTwoFactorEnabled && orgUser.status === OrganizationUserStatusType.Revoked);
+
     return (
       organization.canManageUsersPassword &&
       callingUserHasPermission &&
@@ -239,7 +244,7 @@ export class MemberActionsService {
       organization.hasPublicAndPrivateKeys &&
       orgUser.resetPasswordEnrolled &&
       resetPasswordEnabled &&
-      orgUser.status === OrganizationUserStatusType.Confirmed
+      statusAllowed
     );
   }
 

--- a/apps/web/src/app/admin-console/organizations/members/services/member-dialog-manager/member-dialog-manager.service.spec.ts
+++ b/apps/web/src/app/admin-console/organizations/members/services/member-dialog-manager/member-dialog-manager.service.spec.ts
@@ -82,6 +82,7 @@ describe("MemberDialogManagerService", () => {
       hasMasterPassword: true,
       accessSecretsManager: false,
       managedByOrganization: false,
+      twoFactorEnabled: false,
     } as OrganizationUserView;
 
     mockBillingMetadata = {
@@ -213,6 +214,7 @@ describe("MemberDialogManagerService", () => {
       organizationId: "org-id",
       organizationUserId: "user-id",
       organizationUserType: OrganizationUserType.User,
+      twoFactorEnabled: false,
     };
 
     it("should open the v1 dialog when AdminResetTwoFactor flag is off", async () => {

--- a/apps/web/src/app/admin-console/organizations/members/services/member-dialog-manager/member-dialog-manager.service.ts
+++ b/apps/web/src/app/admin-console/organizations/members/services/member-dialog-manager/member-dialog-manager.service.ts
@@ -105,6 +105,7 @@ export class MemberDialogManagerService {
             organizationId: organization.id as OrganizationId,
             organizationUserId: user.id,
             organizationUserType: user.type,
+            twoFactorEnabled: user.twoFactorEnabled,
           },
         })
       : AccountRecoveryDialogComponent.open(this.dialogService, {
@@ -114,6 +115,7 @@ export class MemberDialogManagerService {
             organizationId: organization.id as OrganizationId,
             organizationUserId: user.id,
             organizationUserType: user.type,
+            twoFactorEnabled: user.twoFactorEnabled,
           },
         });
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-35072

## 📔 Objective

- Add support for recovery from revoked status.
- Disable 2fa recovery checkbox if the user is not using 2fa.

## Screenshots

<img width="2065" height="1285" alt="image" src="https://github.com/user-attachments/assets/e2e41c8d-465c-4a14-b433-6689363ba017" />
<img width="733" height="842" alt="image" src="https://github.com/user-attachments/assets/ab46e2d2-84ad-47ab-82e0-fd1e904efee8" />
