### PR TITLE
[PM-34902] - [Defect] "Do not autofill" button is not centered

### DIFF
--- a/apps/browser/src/vault/popup/components/vault/autofill-confirmation-dialog/autofill-confirmation-dialog.component.html
+++ b/apps/browser/src/vault/popup/components/vault/autofill-confirmation-dialog/autofill-confirmation-dialog.component.html
@@ -74,7 +74,7 @@
         bitLink
         linkType="secondary"
         (click)="close()"
-        class="tw-mt-2 tw-font-medium tw-text-sm tw-justify-center tw-text-center"
+        class="tw-mt-2 tw-font-medium tw-text-sm [&>div]:tw-justify-center"
       >
         {{ "doNotAutofill" | i18n }}
       </button>


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste link to Jira/GitHub issue -->
https://bitwarden.atlassian.net/browse/PM-34902

## 📔 Objective

Fixes the "Do not autofill" button not being visually centered in the autofill confirmation dialog.

The button uses the `bitLink` component, which wraps its content in an inner `<div class="tw-flex">`. The previous fix attempt applied `tw-justify-center` and `tw-text-center` to the host `<button>` element, but these had no effect on the inner flex container. Changed to `[&>div]:tw-justify-center` to correctly target the inner div rendered by `bitLink`'s template.

## 📸 Screenshots

<img width="482" height="600" alt="Screenshot 2026-04-10 at 3 23 43 PM" src="https://github.com/user-attachments/assets/549201fe-1847-4d2b-9651-5841fe6d9cb7" />
