### PR TITLE
[PM-34822] Consistency in handling 400 and 404 in Org Integrations

### DIFF
--- a/bitwarden_license/bit-common/src/dirt/organization-integrations/services/organization-integration-service.spec.ts
+++ b/bitwarden_license/bit-common/src/dirt/organization-integrations/services/organization-integration-service.spec.ts
@@ -238,8 +238,8 @@ describe("OrganizationIntegrationService", () => {
       ).rejects.toThrow("Organization ID mismatch");
     });
 
-    it("should return mustBeOwner true when API returns 403", async () => {
-      const error = new ErrorResponse({}, 403);
+    it("should return mustBeOwner true when API returns 422", async () => {
+      const error = new ErrorResponse({}, 422);
       integrationApiService.createOrganizationIntegration.mockRejectedValue(error);
 
       const result = await service.save(orgId, OrganizationIntegrationType.Hec, config, template);
@@ -252,7 +252,7 @@ describe("OrganizationIntegrationService", () => {
       });
     });
 
-    it("should rethrow non-403 and non-409 errors", async () => {
+    it("should rethrow non-422 and non-409 errors", async () => {
       const error = new Error("Server error");
       integrationApiService.createOrganizationIntegration.mockRejectedValue(error);
 
@@ -261,8 +261,8 @@ describe("OrganizationIntegrationService", () => {
       ).rejects.toThrow("Server error");
     });
 
-    it("should handle configuration creation failure with 403", async () => {
-      const error = new ErrorResponse({}, 403);
+    it("should handle configuration creation failure with 422", async () => {
+      const error = new ErrorResponse({}, 422);
       integrationApiService.createOrganizationIntegration.mockResolvedValue(
         mockIntegrationResponse,
       );
@@ -398,8 +398,8 @@ describe("OrganizationIntegrationService", () => {
       ).rejects.toThrow("Organization ID mismatch");
     });
 
-    it("should return mustBeOwner true when API returns 403", async () => {
-      const error = new ErrorResponse({}, 403);
+    it("should return mustBeOwner true when API returns 422", async () => {
+      const error = new ErrorResponse({}, 422);
       integrationApiService.updateOrganizationIntegration.mockRejectedValue(error);
 
       await new Promise((resolve) => setTimeout(resolve, 100));
@@ -420,7 +420,7 @@ describe("OrganizationIntegrationService", () => {
       });
     });
 
-    it("should rethrow non-403 and non-409 errors", async () => {
+    it("should rethrow non-422 and non-409 errors", async () => {
       const error = new Error("Server error");
       integrationApiService.updateOrganizationIntegration.mockRejectedValue(error);
 
@@ -554,8 +554,8 @@ describe("OrganizationIntegrationService", () => {
       );
     });
 
-    it("should return mustBeOwner true when API returns 403", async () => {
-      const error = new ErrorResponse({}, 403);
+    it("should return mustBeOwner true when API returns 422", async () => {
+      const error = new ErrorResponse({}, 422);
       integrationConfigurationApiService.deleteOrganizationIntegrationConfiguration.mockRejectedValue(
         error,
       );
@@ -571,7 +571,7 @@ describe("OrganizationIntegrationService", () => {
       });
     });
 
-    it("should rethrow non-403 and non-409 errors", async () => {
+    it("should rethrow non-422 and non-409 errors", async () => {
       const error = new Error("Server error");
       integrationConfigurationApiService.deleteOrganizationIntegrationConfiguration.mockRejectedValue(
         error,
@@ -584,8 +584,8 @@ describe("OrganizationIntegrationService", () => {
       );
     });
 
-    it("should handle 403 error when deleting integration", async () => {
-      const error = new ErrorResponse({}, 403);
+    it("should handle 422 error when deleting integration", async () => {
+      const error = new ErrorResponse({}, 422);
       integrationConfigurationApiService.deleteOrganizationIntegrationConfiguration.mockResolvedValue(
         undefined,
       );

--- a/bitwarden_license/bit-common/src/dirt/organization-integrations/services/organization-integration-service.spec.ts
+++ b/bitwarden_license/bit-common/src/dirt/organization-integrations/services/organization-integration-service.spec.ts
@@ -238,8 +238,8 @@ describe("OrganizationIntegrationService", () => {
       ).rejects.toThrow("Organization ID mismatch");
     });
 
-    it("should return mustBeOwner true when API returns 404", async () => {
-      const error = new ErrorResponse({}, 404);
+    it("should return mustBeOwner true when API returns 403", async () => {
+      const error = new ErrorResponse({}, 403);
       integrationApiService.createOrganizationIntegration.mockRejectedValue(error);
 
       const result = await service.save(orgId, OrganizationIntegrationType.Hec, config, template);
@@ -261,8 +261,8 @@ describe("OrganizationIntegrationService", () => {
       ).rejects.toThrow("Server error");
     });
 
-    it("should handle configuration creation failure with 404", async () => {
-      const error = new ErrorResponse({}, 404);
+    it("should handle configuration creation failure with 403", async () => {
+      const error = new ErrorResponse({}, 403);
       integrationApiService.createOrganizationIntegration.mockResolvedValue(
         mockIntegrationResponse,
       );
@@ -398,8 +398,8 @@ describe("OrganizationIntegrationService", () => {
       ).rejects.toThrow("Organization ID mismatch");
     });
 
-    it("should return mustBeOwner true when API returns 404", async () => {
-      const error = new ErrorResponse({}, 404);
+    it("should return mustBeOwner true when API returns 403", async () => {
+      const error = new ErrorResponse({}, 403);
       integrationApiService.updateOrganizationIntegration.mockRejectedValue(error);
 
       await new Promise((resolve) => setTimeout(resolve, 100));
@@ -554,8 +554,8 @@ describe("OrganizationIntegrationService", () => {
       );
     });
 
-    it("should return mustBeOwner true when API returns 404", async () => {
-      const error = new ErrorResponse({}, 404);
+    it("should return mustBeOwner true when API returns 403", async () => {
+      const error = new ErrorResponse({}, 403);
       integrationConfigurationApiService.deleteOrganizationIntegrationConfiguration.mockRejectedValue(
         error,
       );
@@ -564,7 +564,11 @@ describe("OrganizationIntegrationService", () => {
 
       const result = await service.delete(orgId, integrationId, configurationId);
 
-      expect(result).toEqual({ mustBeOwner: true, success: false });
+      expect(result).toEqual({
+        mustBeOwner: true,
+        success: false,
+        organizationIntegrationResult: undefined,
+      });
     });
 
     it("should rethrow non-404 errors", async () => {
@@ -580,8 +584,8 @@ describe("OrganizationIntegrationService", () => {
       );
     });
 
-    it("should handle 404 error when deleting integration", async () => {
-      const error = new ErrorResponse({}, 404);
+    it("should handle 403 error when deleting integration", async () => {
+      const error = new ErrorResponse({}, 403);
       integrationConfigurationApiService.deleteOrganizationIntegrationConfiguration.mockResolvedValue(
         undefined,
       );
@@ -591,7 +595,11 @@ describe("OrganizationIntegrationService", () => {
 
       const result = await service.delete(orgId, integrationId, configurationId);
 
-      expect(result).toEqual({ mustBeOwner: true, success: false });
+      expect(result).toEqual({
+        mustBeOwner: true,
+        success: false,
+        organizationIntegrationResult: undefined,
+      });
     });
   });
 

--- a/bitwarden_license/bit-common/src/dirt/organization-integrations/services/organization-integration-service.spec.ts
+++ b/bitwarden_license/bit-common/src/dirt/organization-integrations/services/organization-integration-service.spec.ts
@@ -238,8 +238,8 @@ describe("OrganizationIntegrationService", () => {
       ).rejects.toThrow("Organization ID mismatch");
     });
 
-    it("should return mustBeOwner true when API returns 422", async () => {
-      const error = new ErrorResponse({}, 422);
+    it("should return mustBeOwner true when API returns 404", async () => {
+      const error = new ErrorResponse({}, 404);
       integrationApiService.createOrganizationIntegration.mockRejectedValue(error);
 
       const result = await service.save(orgId, OrganizationIntegrationType.Hec, config, template);
@@ -252,7 +252,7 @@ describe("OrganizationIntegrationService", () => {
       });
     });
 
-    it("should rethrow non-422 and non-409 errors", async () => {
+    it("should rethrow non-404 and non-409 errors", async () => {
       const error = new Error("Server error");
       integrationApiService.createOrganizationIntegration.mockRejectedValue(error);
 
@@ -261,8 +261,8 @@ describe("OrganizationIntegrationService", () => {
       ).rejects.toThrow("Server error");
     });
 
-    it("should handle configuration creation failure with 422", async () => {
-      const error = new ErrorResponse({}, 422);
+    it("should handle configuration creation failure with 404", async () => {
+      const error = new ErrorResponse({}, 404);
       integrationApiService.createOrganizationIntegration.mockResolvedValue(
         mockIntegrationResponse,
       );
@@ -398,8 +398,8 @@ describe("OrganizationIntegrationService", () => {
       ).rejects.toThrow("Organization ID mismatch");
     });
 
-    it("should return mustBeOwner true when API returns 422", async () => {
-      const error = new ErrorResponse({}, 422);
+    it("should return mustBeOwner true when API returns 404", async () => {
+      const error = new ErrorResponse({}, 404);
       integrationApiService.updateOrganizationIntegration.mockRejectedValue(error);
 
       await new Promise((resolve) => setTimeout(resolve, 100));
@@ -420,7 +420,7 @@ describe("OrganizationIntegrationService", () => {
       });
     });
 
-    it("should rethrow non-422 and non-409 errors", async () => {
+    it("should rethrow non-404 and non-409 errors", async () => {
       const error = new Error("Server error");
       integrationApiService.updateOrganizationIntegration.mockRejectedValue(error);
 
@@ -554,8 +554,8 @@ describe("OrganizationIntegrationService", () => {
       );
     });
 
-    it("should return mustBeOwner true when API returns 422", async () => {
-      const error = new ErrorResponse({}, 422);
+    it("should return mustBeOwner true when API returns 404", async () => {
+      const error = new ErrorResponse({}, 404);
       integrationConfigurationApiService.deleteOrganizationIntegrationConfiguration.mockRejectedValue(
         error,
       );
@@ -571,7 +571,7 @@ describe("OrganizationIntegrationService", () => {
       });
     });
 
-    it("should rethrow non-422 and non-409 errors", async () => {
+    it("should rethrow non-404 and non-409 errors", async () => {
       const error = new Error("Server error");
       integrationConfigurationApiService.deleteOrganizationIntegrationConfiguration.mockRejectedValue(
         error,
@@ -584,8 +584,8 @@ describe("OrganizationIntegrationService", () => {
       );
     });
 
-    it("should handle 422 error when deleting integration", async () => {
-      const error = new ErrorResponse({}, 422);
+    it("should handle 404 error when deleting integration", async () => {
+      const error = new ErrorResponse({}, 404);
       integrationConfigurationApiService.deleteOrganizationIntegrationConfiguration.mockResolvedValue(
         undefined,
       );

--- a/bitwarden_license/bit-common/src/dirt/organization-integrations/services/organization-integration-service.spec.ts
+++ b/bitwarden_license/bit-common/src/dirt/organization-integrations/services/organization-integration-service.spec.ts
@@ -252,7 +252,7 @@ describe("OrganizationIntegrationService", () => {
       });
     });
 
-    it("should rethrow non-404 errors", async () => {
+    it("should rethrow non-403 and non-409 errors", async () => {
       const error = new Error("Server error");
       integrationApiService.createOrganizationIntegration.mockRejectedValue(error);
 
@@ -420,7 +420,7 @@ describe("OrganizationIntegrationService", () => {
       });
     });
 
-    it("should rethrow non-404 errors", async () => {
+    it("should rethrow non-403 and non-409 errors", async () => {
       const error = new Error("Server error");
       integrationApiService.updateOrganizationIntegration.mockRejectedValue(error);
 
@@ -571,7 +571,7 @@ describe("OrganizationIntegrationService", () => {
       });
     });
 
-    it("should rethrow non-404 errors", async () => {
+    it("should rethrow non-403 and non-409 errors", async () => {
       const error = new Error("Server error");
       integrationConfigurationApiService.deleteOrganizationIntegrationConfiguration.mockRejectedValue(
         error,

--- a/bitwarden_license/bit-common/src/dirt/organization-integrations/services/organization-integration-service.ts
+++ b/bitwarden_license/bit-common/src/dirt/organization-integrations/services/organization-integration-service.ts
@@ -121,7 +121,7 @@ export class OrganizationIntegrationService {
         organizationIntegrationResult: newIntegration ?? undefined,
       };
     } catch (error) {
-      if (error instanceof ErrorResponse && error.statusCode === 422) {
+      if (error instanceof ErrorResponse && error.statusCode === 404) {
         return {
           mustBeOwner: true,
           success: false,
@@ -204,7 +204,7 @@ export class OrganizationIntegrationService {
         organizationIntegrationResult: updatedIntegration ?? undefined,
       };
     } catch (error) {
-      if (error instanceof ErrorResponse && error.statusCode === 422) {
+      if (error instanceof ErrorResponse && error.statusCode === 404) {
         return { mustBeOwner: true, success: false, organizationIntegrationResult: undefined };
       }
       throw error;
@@ -247,7 +247,7 @@ export class OrganizationIntegrationService {
 
       return { mustBeOwner: false, success: true, organizationIntegrationResult: undefined };
     } catch (error) {
-      if (error instanceof ErrorResponse && error.statusCode === 422) {
+      if (error instanceof ErrorResponse && error.statusCode === 404) {
         return { mustBeOwner: true, success: false, organizationIntegrationResult: undefined };
       }
       throw error;

--- a/bitwarden_license/bit-common/src/dirt/organization-integrations/services/organization-integration-service.ts
+++ b/bitwarden_license/bit-common/src/dirt/organization-integrations/services/organization-integration-service.ts
@@ -121,7 +121,7 @@ export class OrganizationIntegrationService {
         organizationIntegrationResult: newIntegration ?? undefined,
       };
     } catch (error) {
-      if (error instanceof ErrorResponse && error.statusCode === 404) {
+      if (error instanceof ErrorResponse && error.statusCode === 403) {
         return {
           mustBeOwner: true,
           success: false,
@@ -204,7 +204,7 @@ export class OrganizationIntegrationService {
         organizationIntegrationResult: updatedIntegration ?? undefined,
       };
     } catch (error) {
-      if (error instanceof ErrorResponse && error.statusCode === 404) {
+      if (error instanceof ErrorResponse && error.statusCode === 403) {
         return { mustBeOwner: true, success: false, organizationIntegrationResult: undefined };
       }
       throw error;
@@ -247,7 +247,7 @@ export class OrganizationIntegrationService {
 
       return { mustBeOwner: false, success: true, organizationIntegrationResult: undefined };
     } catch (error) {
-      if (error instanceof ErrorResponse && error.statusCode === 404) {
+      if (error instanceof ErrorResponse && error.statusCode === 403) {
         return { mustBeOwner: true, success: false, organizationIntegrationResult: undefined };
       }
       throw error;

--- a/bitwarden_license/bit-common/src/dirt/organization-integrations/services/organization-integration-service.ts
+++ b/bitwarden_license/bit-common/src/dirt/organization-integrations/services/organization-integration-service.ts
@@ -121,7 +121,7 @@ export class OrganizationIntegrationService {
         organizationIntegrationResult: newIntegration ?? undefined,
       };
     } catch (error) {
-      if (error instanceof ErrorResponse && error.statusCode === 403) {
+      if (error instanceof ErrorResponse && error.statusCode === 422) {
         return {
           mustBeOwner: true,
           success: false,
@@ -204,7 +204,7 @@ export class OrganizationIntegrationService {
         organizationIntegrationResult: updatedIntegration ?? undefined,
       };
     } catch (error) {
-      if (error instanceof ErrorResponse && error.statusCode === 403) {
+      if (error instanceof ErrorResponse && error.statusCode === 422) {
         return { mustBeOwner: true, success: false, organizationIntegrationResult: undefined };
       }
       throw error;
@@ -247,7 +247,7 @@ export class OrganizationIntegrationService {
 
       return { mustBeOwner: false, success: true, organizationIntegrationResult: undefined };
     } catch (error) {
-      if (error instanceof ErrorResponse && error.statusCode === 403) {
+      if (error instanceof ErrorResponse && error.statusCode === 422) {
         return { mustBeOwner: true, success: false, organizationIntegrationResult: undefined };
       }
       throw error;


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-34822

## 📔 Objective

When users have insufficient permissions, the server returns a 403 Forbid() response instead of 404 Not found exception
Use this response to show that the user must be an owner of an org to update permissions.
Retain the 409 Conflict() treatment - no changes there.
## 📸 Screenshots

### 400 badrequest on update
<img width="1224" height="925" alt="Screenshot 2026-04-23 at 9 18 19 AM" src="https://github.com/user-attachments/assets/1b1170c7-d25c-456e-9d96-6b335e379e7c" />

### 409 Conflict 
<img width="1224" height="925" alt="Screenshot 2026-04-23 at 9 17 16 AM" src="https://github.com/user-attachments/assets/bc43c1d7-dbae-44f3-95a0-3585dddefff6" />

### 400 Badrequest on create
<img width="2037" height="920" alt="Screenshot 2026-04-23 at 9 15 13 AM" src="https://github.com/user-attachments/assets/1a74a3df-7aa2-466f-9aee-6b464b9ba70a" />
