### PR TITLE
[PM-34910] badges replace div with span and set a tab index

### DIFF
--- a/libs/components/src/badge/badge.component.html
+++ b/libs/components/src/badge/badge.component.html
@@ -1,4 +1,4 @@
-<div class="tw-inline-flex tw-min-w-0 tw-w-full tw-max-w-full tw-items-center tw-gap-0.5">
+<span class="tw-inline-flex tw-min-w-0 tw-w-full tw-max-w-full tw-items-center tw-gap-0.5">
   @if (computedIcon()) {
     <bit-icon [name]="computedIcon()" [class]="iconSizeStyles()" />
   }
@@ -6,4 +6,4 @@
   <span [class]="contentClasses()">
     <ng-content></ng-content>
   </span>
-</div>
+</span>

--- a/libs/components/src/badge/badge.component.spec.ts
+++ b/libs/components/src/badge/badge.component.spec.ts
@@ -1,0 +1,71 @@
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+
+import { BadgeComponent } from "./badge.component";
+
+describe("BadgeComponent", () => {
+  let component: BadgeComponent;
+  let fixture: ComponentFixture<BadgeComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [BadgeComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(BadgeComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it("creates", () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe("focusability", () => {
+    it("has tabindex=0 when badge has title content (truncated text)", () => {
+      fixture.componentRef.setInput("title", "My badge label");
+      fixture.detectChanges();
+
+      const host: HTMLElement = fixture.nativeElement;
+      expect(host.getAttribute("tabindex")).toBe("0");
+    });
+
+    it("does not have tabindex when truncate is false", () => {
+      fixture.componentRef.setInput("truncate", false);
+      fixture.detectChanges();
+
+      const host: HTMLElement = fixture.nativeElement;
+      expect(host.getAttribute("tabindex")).toBeNull();
+    });
+  });
+
+  describe("VoiceOver / screen reader", () => {
+    it("uses a span (not div) as the inner wrapper to preserve inline reading flow", () => {
+      const host: HTMLElement = fixture.nativeElement;
+      const wrapper = host.firstElementChild as HTMLElement;
+      expect(wrapper.tagName.toLowerCase()).toBe("span");
+    });
+
+    it("does not set aria-label when ariaLabel input is not provided", () => {
+      const host: HTMLElement = fixture.nativeElement;
+      expect(host.getAttribute("aria-label")).toBeNull();
+    });
+
+    it("sets aria-label on the host when ariaLabel input is provided", () => {
+      fixture.componentRef.setInput("ariaLabel", "5 unread notifications");
+      fixture.detectChanges();
+
+      const host: HTMLElement = fixture.nativeElement;
+      expect(host.getAttribute("aria-label")).toBe("5 unread notifications");
+    });
+
+    it("updates aria-label when ariaLabel input changes", () => {
+      fixture.componentRef.setInput("ariaLabel", "Initial label");
+      fixture.detectChanges();
+      expect(fixture.nativeElement.getAttribute("aria-label")).toBe("Initial label");
+
+      fixture.componentRef.setInput("ariaLabel", "Updated label");
+      fixture.detectChanges();
+      expect(fixture.nativeElement.getAttribute("aria-label")).toBe("Updated label");
+    });
+  });
+});

--- a/libs/components/src/badge/badge.component.ts
+++ b/libs/components/src/badge/badge.component.ts
@@ -98,6 +98,8 @@ const getDefaultIconForVariant = (variant: BadgeVariant) => defaultIconMap[varia
   host: {
     "[class]": "classList()",
     "[attr.title]": "titleContent()",
+    "[attr.tabindex]": "titleContent() ? 0 : null",
+    "[attr.aria-label]": "ariaLabel()",
   },
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
@@ -137,6 +139,15 @@ export class BadgeComponent {
   readonly maxWidthClass = input<`tw-max-w-${string}`>("tw-max-w-[calc(25ch_-_theme(spacing.2))]");
 
   readonly startIcon = input<BitwardenIcon | null | undefined>(undefined);
+
+  /**
+   * Optional accessible label override. Use when the visual text content alone
+   * is insufficient for screen readers (e.g., a badge showing "5" where the
+   * accessible name should be "5 unread notifications").
+   *
+   * When not provided, screen readers announce the badge's text content directly.
+   */
+  readonly ariaLabel = input<string>();
 
   protected readonly computedIcon = computed(() => {
     if (this.startIcon() === null) {

--- a/libs/components/src/badge/badge.mdx
+++ b/libs/components/src/badge/badge.mdx
@@ -41,4 +41,21 @@ The warning badge is used to indicate a status waiting on an additional action f
 
 ## Accessibility
 
-Follows color WCAG color contrast guidelines for small text.
+Follows WCAG color contrast guidelines for small text.
+
+### Keyboard navigation
+
+Badges with truncated text are focusable via Tab — they receive `tabindex="0"` automatically when
+the badge has title content (truncated text or a custom `[title]`). This allows keyboard users to
+reach a badge and trigger its tooltip to see the full text.
+
+### Screen readers
+
+Badge text content is announced inline by screen readers. When the visual label alone is not
+sufficient — for example, a badge displaying only `"5"` — supply a descriptive `ariaLabel`:
+
+```html
+<bit-badge [ariaLabel]="'5 unread notifications'">5</bit-badge>
+```
+
+Screen readers will announce the `ariaLabel` value instead of the raw text content.


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-34910

## 📔 Objective

`<bit-badge>` or `span[bitBadge]` uses a `div` which makes it non-focusable. Replaced this with a `span`
Also there was no tab index - and now this is set to 0
An `aria-label` is provided to set a text, if the text on the badge is insufficient for a screen reader

## 📸 Screenshots

** changes to the bit-badge **
https://github.com/user-attachments/assets/20077988-701b-4a89-8a66-b0033b93dc59

** usage in the reports **
https://github.com/user-attachments/assets/891d8489-7e73-40f2-baba-04c532723768

