### PR TITLE
[PM-32853] Add FromMarketing Property for TrialInitiation Path

### DIFF
--- a/apps/web/src/app/billing/clients/account-billing.client.ts
+++ b/apps/web/src/app/billing/clients/account-billing.client.ts
@@ -58,7 +58,7 @@ export class AccountBillingClient {
     paymentMethod: TokenizedPaymentMethod | NonTokenizedPaymentMethod,
     billingAddress: Pick<BillingAddress, "country" | "postalCode">,
     coupons?: string[],
-    fromMarketing?: string,
+    fromMarketing?: string | null,
   ): Promise<void> => {
     const path = `${this.endpoint}/subscription`;
 

--- a/apps/web/src/app/billing/clients/account-billing.client.ts
+++ b/apps/web/src/app/billing/clients/account-billing.client.ts
@@ -58,6 +58,7 @@ export class AccountBillingClient {
     paymentMethod: TokenizedPaymentMethod | NonTokenizedPaymentMethod,
     billingAddress: Pick<BillingAddress, "country" | "postalCode">,
     coupons?: string[],
+    fromMarketing?: string,
   ): Promise<void> => {
     const path = `${this.endpoint}/subscription`;
 
@@ -70,6 +71,7 @@ export class AccountBillingClient {
     const request = {
       ...base,
       ...(coupons?.length ? { coupons } : {}),
+      ...(fromMarketing ? { fromMarketing } : {}),
     };
 
     await this.apiService.send("POST", path, request, true, true);

--- a/apps/web/src/app/billing/individual/upgrade/unified-upgrade-dialog/unified-upgrade-dialog.component.html
+++ b/apps/web/src/app/billing/individual/upgrade/unified-upgrade-dialog/unified-upgrade-dialog.component.html
@@ -9,6 +9,7 @@
   <app-upgrade-payment
     [selectedPlanId]="selectedPlan()"
     [account]="account()"
+    [fromMarketing]="fromMarketing()"
     (goBack)="previousStep()"
     (complete)="onComplete($event)"
   />

--- a/apps/web/src/app/billing/individual/upgrade/unified-upgrade-dialog/unified-upgrade-dialog.component.spec.ts
+++ b/apps/web/src/app/billing/individual/upgrade/unified-upgrade-dialog/unified-upgrade-dialog.component.spec.ts
@@ -53,6 +53,7 @@ class MockUpgradeAccountComponent {
 class MockUpgradePaymentComponent {
   readonly selectedPlanId = input<PersonalSubscriptionPricingTierId | null>(null);
   readonly account = input<Account | null>(null);
+  readonly fromMarketing = input<string | null>(null);
   goBack = output<void>();
   complete = output<UpgradePaymentResult>();
 }

--- a/apps/web/src/app/billing/individual/upgrade/unified-upgrade-dialog/unified-upgrade-dialog.component.ts
+++ b/apps/web/src/app/billing/individual/upgrade/unified-upgrade-dialog/unified-upgrade-dialog.component.ts
@@ -1,6 +1,13 @@
 import { DIALOG_DATA } from "@angular/cdk/dialog";
 import { CommonModule } from "@angular/common";
-import { ChangeDetectionStrategy, Component, Inject, OnInit, signal } from "@angular/core";
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  Inject,
+  OnInit,
+  signal,
+} from "@angular/core";
 import { Router } from "@angular/router";
 
 import { PremiumInterestStateService } from "@bitwarden/angular/billing/services/premium-interest/premium-interest-state.service.abstraction";
@@ -40,6 +47,7 @@ export type UnifiedUpgradeDialogResult = {
   status: UnifiedUpgradeDialogStatus;
   organizationId?: string | null;
 };
+const FROM_MARKETING_DEFAULT = "premium";
 
 /**
  * Parameters for the UnifiedUpgradeDialog component.
@@ -84,6 +92,14 @@ export class UnifiedUpgradeDialogComponent implements OnInit {
   protected readonly planSelectionStepTitleOverride = signal<string | null>(null);
   protected readonly hideContinueWithoutUpgradingButton = signal<boolean>(false);
   protected readonly hasPremiumInterest = signal(false);
+
+  // Determines if user originated from a marketing flow for premium upgrade
+  protected readonly fromMarketing = computed(() => {
+    if (this.hasPremiumInterest()) {
+      return FROM_MARKETING_DEFAULT;
+    }
+    return null;
+  });
 
   protected readonly PaymentStep = UnifiedUpgradeDialogStep.Payment;
   protected readonly PlanSelectionStep = UnifiedUpgradeDialogStep.PlanSelection;

--- a/apps/web/src/app/billing/individual/upgrade/upgrade-payment/services/upgrade-payment.service.spec.ts
+++ b/apps/web/src/app/billing/individual/upgrade/upgrade-payment/services/upgrade-payment.service.spec.ts
@@ -570,6 +570,7 @@ describe("UpgradePaymentService", () => {
         mockTokenizedPaymentMethod,
         mockBillingAddress,
         undefined,
+        undefined,
       );
       expect(mockSyncService.fullSync).toHaveBeenCalledWith(true);
     });
@@ -589,6 +590,7 @@ describe("UpgradePaymentService", () => {
         accountCreditPaymentMethod,
         mockBillingAddress,
         undefined,
+        undefined,
       );
       expect(mockSyncService.fullSync).toHaveBeenCalledWith(true);
     });
@@ -605,6 +607,7 @@ describe("UpgradePaymentService", () => {
         mockTokenizedPaymentMethod,
         mockBillingAddress,
         ["coupon-abc"],
+        undefined,
       );
     });
 
@@ -620,6 +623,28 @@ describe("UpgradePaymentService", () => {
         mockTokenizedPaymentMethod,
         mockBillingAddress,
         undefined,
+        undefined,
+      );
+    });
+
+    it("passes fromMarketing to purchaseSubscription when provided", async () => {
+      // Arrange
+      mockAccountBillingClient.purchaseSubscription.mockResolvedValue();
+
+      // Act
+      await sut.upgradeToPremium(
+        mockTokenizedPaymentMethod,
+        mockBillingAddress,
+        undefined,
+        "premium",
+      );
+
+      // Assert
+      expect(mockAccountBillingClient.purchaseSubscription).toHaveBeenCalledWith(
+        mockTokenizedPaymentMethod,
+        mockBillingAddress,
+        undefined,
+        "premium",
       );
     });
 

--- a/apps/web/src/app/billing/individual/upgrade/upgrade-payment/services/upgrade-payment.service.ts
+++ b/apps/web/src/app/billing/individual/upgrade/upgrade-payment/services/upgrade-payment.service.ts
@@ -148,10 +148,16 @@ export class UpgradePaymentService {
     paymentMethod: TokenizedPaymentMethod | NonTokenizedPaymentMethod,
     billingAddress: Pick<BillingAddress, "country" | "postalCode">,
     coupons?: string[],
+    fromMarketing?: string | null,
   ): Promise<void> {
     this.validatePaymentAndBillingInfo(paymentMethod, billingAddress);
 
-    await this.accountBillingClient.purchaseSubscription(paymentMethod, billingAddress, coupons);
+    await this.accountBillingClient.purchaseSubscription(
+      paymentMethod,
+      billingAddress,
+      coupons,
+      fromMarketing,
+    );
 
     await this.refreshAndSync();
   }

--- a/apps/web/src/app/billing/individual/upgrade/upgrade-payment/upgrade-payment.component.ts
+++ b/apps/web/src/app/billing/individual/upgrade/upgrade-payment/upgrade-payment.component.ts
@@ -107,6 +107,7 @@ export class UpgradePaymentComponent implements OnInit, AfterViewInit {
   private readonly INITIAL_TAX_VALUE = 0;
   protected readonly selectedPlanId = input.required<PersonalSubscriptionPricingTierId>();
   protected readonly account = input.required<Account>();
+  protected readonly fromMarketing = input<string | null>(null);
   protected goBack = output<void>();
   protected complete = output<UpgradePaymentResult>();
 
@@ -388,6 +389,7 @@ export class UpgradePaymentComponent implements OnInit, AfterViewInit {
       paymentMethod,
       billingAddress,
       this.eligibleCouponIds(),
+      this.fromMarketing(),
     );
     return { status: UpgradePaymentStatus.UpgradedToPremium, organizationId: null };
   }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-32853

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Introduces support for tracking whether a user upgrade originates from a marketing campaign throughout the billing upgrade flow. The main changes include propagating a new `fromMarketing` parameter from the dialog component, through the payment component and service, down to the billing client and API request.

Note: Connected to https://github.com/bitwarden/devops/pull/4524
## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

### Default Product-Initiated Workflow
https://github.com/user-attachments/assets/55878e0c-7767-44e0-a0c0-64a99abbca4c

### Market-Initiated Workflow
https://github.com/user-attachments/assets/143d6cfd-64b3-4458-8be5-9b238bd7da7d