### PR TITLE
[PM-32677] Fix changelog generation to correctly render sdk-internal PRs

### DIFF
--- a/.github/workflows/sdk-update.yml
+++ b/.github/workflows/sdk-update.yml
@@ -265,14 +265,13 @@ jobs:
 
           if [ -n "$OLD_REF" ] && [ -n "$NEW_REF" ]; then
             echo "Fetching changelog for sdk-internal: $OLD_REF...$NEW_REF"
-            CHANGELOG=$(gh api "repos/bitwarden/sdk-internal/compare/$OLD_REF...$NEW_REF" \
-              --jq '.commits | map("- " + .commit.message | split("\n")[0]) | join("\n")' 2>/dev/null || echo "")
+            CHANGELOG=$(./scripts/get-repo-changelog.sh "bitwarden/sdk-internal" "$OLD_REF" "$NEW_REF" 2>/dev/null || echo "")
 
             if [ -n "$CHANGELOG" ]; then
               echo "changelog<<__CHANGELOG_END__" >> "$GITHUB_OUTPUT"
               echo "$CHANGELOG" >> "$GITHUB_OUTPUT"
               echo "__CHANGELOG_END__" >> "$GITHUB_OUTPUT"
-              echo "✅ Generated changelog with $(echo "$CHANGELOG" | wc -l) commits"
+              echo "✅ Generated changelog"
             else
               echo "::warning::Could not generate changelog"
             fi

--- a/scripts/get-repo-changelog.sh
+++ b/scripts/get-repo-changelog.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Script to get changelog from a repo between two git refs
+# Usage: ./scripts/get-repo-changelog.sh <repo> <current-ref> <new-ref>
+
+set -euo pipefail
+
+if [ $# -lt 3 ]; then
+    echo "Usage: $0 <repo> <current-ref> <new-ref>"
+    echo "Example: $0 bitwarden/sdk-internal 9fe3aeda fix-wasm-import"
+    exit 1
+fi
+
+REPO="$1"
+CURRENT_REF="$2"
+NEW_REF="$3"
+
+CHANGELOG=$(gh api "repos/$REPO/compare/$CURRENT_REF...$NEW_REF" \
+    --jq '.commits[] | "- \(.commit.message | split("\n")[0])"')
+
+if [ -z "$CHANGELOG" ]; then
+    echo "No changes found between $CURRENT_REF and $NEW_REF"
+    exit 0
+fi
+
+# GitHub renders org/repo#123 as a link to a PR, removing the commit message when a PR ID is found
+# including the raw changelog in a collapsible section in case the pattern matching fails
+CLEANED_CHANGELOG=$(echo "$CHANGELOG" | sed -E "s|.*\(#([0-9]+)\).*|- $REPO#\1|")
+
+echo "$CLEANED_CHANGELOG"
+echo
+echo "<details>
+<summary>Raw changelog</summary>
+
+\`\`\`
+$CHANGELOG
+\`\`\`
+</details>
+"

--- a/scripts/get-repo-changelog.sh
+++ b/scripts/get-repo-changelog.sh
@@ -25,7 +25,7 @@ fi
 
 # GitHub renders org/repo#123 as a link to a PR, removing the commit message when a PR ID is found
 # including the raw changelog in a collapsible section in case the pattern matching fails
-CLEANED_CHANGELOG=$(echo "$CHANGELOG" | sed -E "s|.*\(#([0-9]+)\).*|- $REPO#\1|")
+CLEANED_CHANGELOG=$(echo "$CHANGELOG" | sed -E "s|.*\(#([0-9]+)\).*|- ${REPO}#\1|")
 
 echo "$CLEANED_CHANGELOG"
 echo


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-32677

## 📔 Objective

Previous SDK update PRs included links using the `#123` syntax, which Github interprets as `clients` PRs, incorrectly.  See https://github.com/bitwarden/clients/pull/20132 for an example.

This changes to use the same method as `bitwarden/android`, which has a separate script to calculate the changelog, producing output like this: https://github.com/bitwarden/android/pull/6780.

(Note this cannot be tested on the branch because the script is not in `main`).
