### PR TITLE
Replace deprecated typescript.tsdk with js/ts.tsdk.path

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,7 +7,7 @@
     "**/_locales/*[^n]/messages.json": true
   },
   "rust-analyzer.linkedProjects": ["apps/desktop/desktop_native/Cargo.toml"],
-  "typescript.tsdk": "node_modules/typescript/lib",
   "eslint.useFlatConfig": true,
-  "tailwindCSS.experimental.classRegex": ["[\"'`]([^\"'`\\n]*tw-[^\"'`\\n]*)[\"'`]"]
+  "tailwindCSS.experimental.classRegex": ["[\"'`]([^\"'`\\n]*tw-[^\"'`\\n]*)[\"'`]"],
+  "js/ts.tsdk.path": "node_modules/typescript/lib"
 }


### PR DESCRIPTION
## 🎟️ Tracking

N/A — developer tooling change

## 📔 Objective

Replaces the deprecated `typescript.tsdk` VS Code setting with `js/ts.tsdk.path`, which is the current setting for configuring the workspace TypeScript installation used by the language server.

This ensures the `typescript-strict-plugin` language service plugin is loaded correctly, so strict type errors surface inline in the editor without requiring manual configuration.

## 📸 Screenshots

N/A