### PR TITLE
PM-33122: Rename feature flag pm-34500-strict-cipher-decryption

### DIFF
--- a/libs/common/src/enums/feature-flag.enum.ts
+++ b/libs/common/src/enums/feature-flag.enum.ts
@@ -84,7 +84,7 @@ export enum FeatureFlag {
   PM31039ItemActionInExtension = "pm-31039-item-action-in-extension",
   PM32180PremiumUpsellAccountAge = "pm-32180-premium-upsell-account-age",
   PM28091_AddCopyAndQuickLaunchActions = "pm-28091-add-copy-and-quick-launch-actions",
-  PM34500_StrictCipherDecryption = "PM-34500-strict-cipher-decryption",
+  PM34500_StrictCipherDecryption = "pm-34500-strict-cipher-decryption",
 
   /* Platform */
   ContentScriptIpcChannelFramework = "content-script-ipc-channel-framework",


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-33122

## 📔 Objective

The feature flag name in LD is different than the key it sends - this fixes the case matching, allowing the flag to pass through.
