### PR TITLE
[PM-35138] Update targeting rules data on vault sync

### DIFF
--- a/apps/browser/src/autofill/services/targeting-rules-data.service.ts
+++ b/apps/browser/src/autofill/services/targeting-rules-data.service.ts
@@ -2,11 +2,11 @@ import {
   catchError,
   defer,
   EMPTY,
-  exhaustMap,
   firstValueFrom,
   from,
   retry,
   Subject,
+  switchMap,
   takeUntil,
   tap,
   timer,
@@ -27,13 +27,18 @@ import {
   KeyDefinition,
 } from "@bitwarden/state";
 
-/** Fallback URI used when the server does not provide a targeting rules URI */
-const DEFAULT_TARGETING_RULES_SOURCE_URL =
-  "https://github.com/bitwarden/map-the-web/releases/latest/download/forms.v1.json";
+/** Fallback manifest URI when the server does not provide one */
+const DEFAULT_MANIFEST_URL =
+  "https://github.com/bitwarden/map-the-web/releases/latest/download/manifest.json";
+
+/** Manifest key for the forms map version this client targets */
+const TARGET_FORMS_VERSION = "v1";
 
 type TargetingRulesDataMeta = {
-  /** The last time the data set was updated  */
+  /** The last time the data source was checked */
   timestamp: number;
+  /** Content hash (cid) of the forms map file last stored to state */
+  cid?: string;
 };
 
 const SERVER_TARGETING_RULES_META = KeyDefinition.record<TargetingRulesDataMeta, string>(
@@ -42,6 +47,7 @@ const SERVER_TARGETING_RULES_META = KeyDefinition.record<TargetingRulesDataMeta,
   {
     deserializer: (value: TargetingRulesDataMeta) => ({
       timestamp: value?.timestamp ?? 0,
+      cid: value?.cid,
     }),
   },
 );
@@ -56,7 +62,8 @@ export class TargetingRulesDataService {
 
   // guard against accidental leaks.
   private _destroy$ = new Subject<void>();
-  private _triggerUpdate$ = new Subject<void>();
+  /** Emits `true` to skip the cache-age check, `false`/`undefined` for normal interval */
+  private _triggerUpdate$ = new Subject<boolean>();
   private _metaState: GlobalState<Record<string, TargetingRulesDataMeta>>;
 
   constructor(
@@ -78,7 +85,7 @@ export class TargetingRulesDataService {
    */
   async init(): Promise<void> {
     this.taskSchedulerService.registerTaskHandler(ScheduledTaskNames.targetingRulesUpdate, () =>
-      this._triggerUpdate$.next(),
+      this._triggerUpdate$.next(false),
     );
 
     this.taskSchedulerService.setInterval(
@@ -88,7 +95,10 @@ export class TargetingRulesDataService {
 
     this._triggerUpdate$
       .pipe(
-        exhaustMap(() => this._backgroundUpdate()),
+        // switchMap cancels any in-progress update (including retry delays)
+        // when a new trigger arrives, ensuring account/environment switches
+        // are not blocked by a stale retry chain
+        switchMap((skipCacheCheck) => this._backgroundUpdate(skipCacheCheck)),
         takeUntil(this._destroy$),
       )
       .subscribe();
@@ -98,8 +108,17 @@ export class TargetingRulesDataService {
     // behind environment$, so reacting here ensures _resolveSourceUrl
     // reads the correct config for the active environment.
     this.configService.serverConfig$.pipe(takeUntil(this._destroy$)).subscribe(() => {
-      this._triggerUpdate$.next();
+      this._triggerUpdate$.next(false);
     });
+  }
+
+  /**
+   * Forces an immediate manifest check, bypassing the cache-age interval.
+   * The manifest cid comparison still prevents unnecessary downloads.
+   * Intended for user-initiated actions (e.g. vault sync).
+   */
+  forceUpdate(): void {
+    this._triggerUpdate$.next(true);
   }
 
   private async _resetMeta(): Promise<void> {
@@ -117,12 +136,12 @@ export class TargetingRulesDataService {
     this._destroy$.complete();
   }
 
-  private _backgroundUpdate() {
+  private _backgroundUpdate(skipCacheCheck = false) {
     // Use defer to restart timer if retry is activated
     return defer(() => {
       const startTime = Date.now();
 
-      return from(this._fetchAndStoreRules()).pipe(
+      return from(this._fetchAndStoreRules(skipCacheCheck)).pipe(
         tap(() => {
           const elapsed = Date.now() - startTime;
           this.logService.info(`[TargetingRulesDataService] Update completed in ${elapsed}ms`);
@@ -159,7 +178,7 @@ export class TargetingRulesDataService {
     });
   }
 
-  private async _fetchAndStoreRules(): Promise<void> {
+  private async _fetchAndStoreRules(skipCacheCheck = false): Promise<void> {
     const isEnabled = await this.configService.getFeatureFlag(FeatureFlag.FillAssistTargetingRules);
     if (!isEnabled) {
       this.logService.debug("[TargetingRulesDataService] Feature is not enabled, skipping fetch.");
@@ -176,22 +195,51 @@ export class TargetingRulesDataService {
     const meta = allMeta?.[apiUrl];
     const cacheAge = Date.now() - (meta?.timestamp ?? 0);
 
-    if (cacheAge < TargetingRulesDataService.UPDATE_INTERVAL) {
+    if (!skipCacheCheck && cacheAge < TargetingRulesDataService.UPDATE_INTERVAL) {
       this.logService.debug("[TargetingRulesDataService] Cache is still fresh, skipping fetch.");
       return;
     }
 
-    const sourceUrl = new URL(await this._resolveSourceUrl());
+    const manifestUrl = await this._resolveManifestUrl();
 
-    // Add query for CDN cache-busting; we're already caching at intervals locally
-    sourceUrl.searchParams.set("_", Date.now().toString());
+    // Step 1: Fetch the lightweight manifest to check if the data has changed
+    this.logService.info(`[TargetingRulesDataService] Checking manifest at ${manifestUrl}`);
 
-    this.logService.info(
-      `[TargetingRulesDataService] Fetching targeting rules from ${sourceUrl.href}`,
-    );
+    const manifestResponse = await this.apiService.nativeFetch(new Request(manifestUrl));
+    if (!manifestResponse.ok) {
+      throw new Error(
+        `Failed to fetch manifest: ${manifestResponse.status} ${manifestResponse.statusText}`,
+      );
+    }
 
-    const response = await this.apiService.nativeFetch(new Request(sourceUrl.href));
+    const manifest = await manifestResponse.json();
 
+    // Locate the forms map entry for our target version
+    const formsEntry = manifest?.maps?.forms?.[TARGET_FORMS_VERSION];
+    if (!formsEntry?.name) {
+      throw new Error(`Manifest contains no forms map entry for ${TARGET_FORMS_VERSION}`);
+    }
+
+    const remoteCid = formsEntry.cid;
+
+    // If the content hash matches, the data hasn't changed; skip download
+    if (remoteCid && meta?.cid && meta.cid === remoteCid) {
+      this.logService.debug(
+        `[TargetingRulesDataService] Data unchanged (cid match), skipping download.`,
+      );
+      await this._metaState.update((existing) => ({
+        ...existing,
+        [apiUrl]: { ...meta, timestamp: Date.now() },
+      }));
+      return;
+    }
+
+    // Step 2: Data has changed (or first fetch); download the map file
+    const baseUrl = manifestUrl.substring(0, manifestUrl.lastIndexOf("/") + 1);
+    const formsMapUrl = new URL(formsEntry.name, baseUrl).href;
+    this.logService.info(`[TargetingRulesDataService] Fetching updated data from ${formsMapUrl}`);
+
+    const response = await this.apiService.nativeFetch(new Request(formsMapUrl));
     if (!response.ok) {
       throw new Error(`Failed to fetch rules: ${response.status} ${response.statusText}`);
     }
@@ -202,12 +250,6 @@ export class TargetingRulesDataService {
       throw new Error("Invalid targeting rules resource: not an object");
     }
 
-    // Reject incompatible schema versions (current: v1.x)
-    const version = resource.schemaVersion;
-    if (typeof version === "string" && !version.startsWith("1.")) {
-      throw new Error(`Unsupported targeting rules schema version: ${version}`);
-    }
-
     if (
       typeof resource.hosts !== "object" ||
       resource.hosts === null ||
@@ -216,16 +258,12 @@ export class TargetingRulesDataService {
       throw new Error("Invalid targeting rules resource: missing or malformed 'hosts'");
     }
 
-    if (version) {
-      this.logService.debug(`[TargetingRulesDataService] Resource schema version: ${version}`);
-    }
-
     const rules: TargetingRulesByDomain = resource.hosts;
 
     await this.domainSettingsService.setTargetingRules(rules);
     await this._metaState.update((existing) => ({
       ...existing,
-      [apiUrl]: { timestamp: Date.now() },
+      [apiUrl]: { timestamp: Date.now(), cid: remoteCid },
     }));
 
     this.logService.info(
@@ -234,11 +272,11 @@ export class TargetingRulesDataService {
   }
 
   /**
-   * Resolves the targeting rules source URL by checking the server config first,
-   * falling back to the hardcoded default if unavailable.
+   * Resolves the manifest URL by checking the server config first,
+   * falling back to the hardcoded default.
    */
-  private async _resolveSourceUrl(): Promise<string> {
+  private async _resolveManifestUrl(): Promise<string> {
     const serverConfig = await firstValueFrom(this.configService.serverConfig$);
-    return serverConfig?.environment?.fillAssistRules || DEFAULT_TARGETING_RULES_SOURCE_URL;
+    return serverConfig?.environment?.fillAssistRules || DEFAULT_MANIFEST_URL;
   }
 }

--- a/apps/browser/src/autofill/services/targeting-rules-data.service.ts
+++ b/apps/browser/src/autofill/services/targeting-rules-data.service.ts
@@ -98,14 +98,14 @@ export class TargetingRulesDataService {
         // switchMap cancels any in-progress update (including retry delays)
         // when a new trigger arrives, ensuring account/environment switches
         // are not blocked by a stale retry chain
-        switchMap((skipCacheCheck) => this._backgroundUpdate(skipCacheCheck)),
+        switchMap((skipCacheAgeCheck) => this._backgroundUpdate(skipCacheAgeCheck)),
         takeUntil(this._destroy$),
       )
       .subscribe();
 
     // Trigger a fetch whenever the server config changes (e.g. after
     // unlock, account switch, or environment change). The config lags
-    // behind environment$, so reacting here ensures _resolveSourceUrl
+    // behind environment$, so reacting here ensures _resolveManifestUrl
     // reads the correct config for the active environment.
     this.configService.serverConfig$.pipe(takeUntil(this._destroy$)).subscribe(() => {
       this._triggerUpdate$.next(false);
@@ -126,7 +126,7 @@ export class TargetingRulesDataService {
     const apiUrl = env.getApiUrl();
     await this._metaState.update((existing) => ({
       ...existing,
-      [apiUrl]: { timestamp: 0 },
+      [apiUrl]: { cid: undefined, timestamp: 0 },
     }));
   }
 
@@ -136,12 +136,12 @@ export class TargetingRulesDataService {
     this._destroy$.complete();
   }
 
-  private _backgroundUpdate(skipCacheCheck = false) {
+  private _backgroundUpdate(skipCacheAgeCheck = false) {
     // Use defer to restart timer if retry is activated
     return defer(() => {
       const startTime = Date.now();
 
-      return from(this._fetchAndStoreRules(skipCacheCheck)).pipe(
+      return from(this._fetchAndStoreRules(skipCacheAgeCheck)).pipe(
         tap(() => {
           const elapsed = Date.now() - startTime;
           this.logService.info(`[TargetingRulesDataService] Update completed in ${elapsed}ms`);
@@ -178,7 +178,7 @@ export class TargetingRulesDataService {
     });
   }
 
-  private async _fetchAndStoreRules(skipCacheCheck = false): Promise<void> {
+  private async _fetchAndStoreRules(skipCacheAgeCheck = false): Promise<void> {
     const isEnabled = await this.configService.getFeatureFlag(FeatureFlag.FillAssistTargetingRules);
     if (!isEnabled) {
       this.logService.debug("[TargetingRulesDataService] Feature is not enabled, skipping fetch.");
@@ -195,7 +195,7 @@ export class TargetingRulesDataService {
     const meta = allMeta?.[apiUrl];
     const cacheAge = Date.now() - (meta?.timestamp ?? 0);
 
-    if (!skipCacheCheck && cacheAge < TargetingRulesDataService.UPDATE_INTERVAL) {
+    if (!skipCacheAgeCheck && cacheAge < TargetingRulesDataService.UPDATE_INTERVAL) {
       this.logService.debug("[TargetingRulesDataService] Cache is still fresh, skipping fetch.");
       return;
     }
@@ -205,7 +205,13 @@ export class TargetingRulesDataService {
     // Step 1: Fetch the lightweight manifest to check if the data has changed
     this.logService.info(`[TargetingRulesDataService] Checking manifest at ${manifestUrl}`);
 
-    const manifestResponse = await this.apiService.nativeFetch(new Request(manifestUrl));
+    // Add CDN cache-buster
+    const manifestRequestURL = new URL(manifestUrl);
+    manifestRequestURL.searchParams.set("_", Date.now().toString());
+
+    const manifestResponse = await this.apiService.nativeFetch(
+      new Request(manifestRequestURL.href),
+    );
     if (!manifestResponse.ok) {
       throw new Error(
         `Failed to fetch manifest: ${manifestResponse.status} ${manifestResponse.statusText}`,
@@ -216,8 +222,14 @@ export class TargetingRulesDataService {
 
     // Locate the forms map entry for our target version
     const formsEntry = manifest?.maps?.forms?.[TARGET_FORMS_VERSION];
-    if (!formsEntry?.name) {
-      throw new Error(`Manifest contains no forms map entry for ${TARGET_FORMS_VERSION}`);
+    if (
+      !formsEntry?.filename ||
+      typeof formsEntry.filename !== "string" ||
+      !formsEntry.filename.endsWith(".json") ||
+      formsEntry.filename.includes("/") ||
+      formsEntry.filename.includes("\\")
+    ) {
+      throw new Error(`Manifest contains no valid forms map entry for ${TARGET_FORMS_VERSION}`);
     }
 
     const remoteCid = formsEntry.cid;
@@ -235,8 +247,7 @@ export class TargetingRulesDataService {
     }
 
     // Step 2: Data has changed (or first fetch); download the map file
-    const baseUrl = manifestUrl.substring(0, manifestUrl.lastIndexOf("/") + 1);
-    const formsMapUrl = new URL(formsEntry.name, baseUrl).href;
+    const formsMapUrl = new URL(formsEntry.filename, manifestRequestURL.href).href;
     this.logService.info(`[TargetingRulesDataService] Fetching updated data from ${formsMapUrl}`);
 
     const response = await this.apiService.nativeFetch(new Request(formsMapUrl));

--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -552,7 +552,7 @@ export default class MainBackground {
   private popupViewCacheBackgroundService: PopupViewCacheBackgroundService;
   private popupRouterCacheBackgroundService: PopupRouterCacheBackgroundService;
 
-  private targetingRulesDataService: TargetingRulesDataService;
+  targetingRulesDataService: TargetingRulesDataService;
 
   // DIRT
   private phishingDataService: PhishingDataService;

--- a/apps/browser/src/background/runtime.background.ts
+++ b/apps/browser/src/background/runtime.background.ts
@@ -323,6 +323,7 @@ export default class RuntimeBackground {
           await this.main.updateOverlayCiphers();
 
           await this.autofillService.setAutoFillOnPageLoadOrgPolicy();
+          void this.main.targetingRulesDataService.forceUpdate();
         }
         break;
       case "openPopup":


### PR DESCRIPTION
## 🎟️ Tracking

[PM-35138](https://bitwarden.atlassian.net/browse/PM-35138)

## 📔 Objective

We want to decouple fetching all data for targeting rules from checking for changes in the data. This enables us to check for data updates more aggressively (or on-demand) without incurring potentially costly payload transport.

[PM-35138]: https://bitwarden.atlassian.net/browse/PM-35138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Note: this update depends on [PM-35128](https://bitwarden.atlassian.net/browse/PM-35128) being implemented by the data provider

[PM-35128]: https://bitwarden.atlassian.net/browse/PM-35128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ