### PR TITLE
[CL-1162] Fix text color of link buttons on desktop

### DIFF
--- a/apps/desktop/src/scss/base.scss
+++ b/apps/desktop/src/scss/base.scss
@@ -51,7 +51,7 @@ img {
   border: none;
 }
 
-a:not([bitlink], [bitButton]) {
+a:not([bitlink], [bitbutton]) {
   text-decoration: none;
 
   @include themify($themes) {

--- a/apps/desktop/src/scss/base.scss
+++ b/apps/desktop/src/scss/base.scss
@@ -51,7 +51,7 @@ img {
   border: none;
 }
 
-a:not([bitlink]) {
+a:not([bitlink], [bitButton]) {
   text-decoration: none;
 
   @include themify($themes) {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[CL-1162](https://bitwarden.atlassian.net/browse/CL-1162)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Desktop's legacy css has global styles for anchor tags. We use our `bitButton` component on anchor tags occasionally, and the styling was getting overridden by the legacy css.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

| Before | After |
|--------|--------|
| <img width="1000" height="627" alt="Screenshot 2026-04-14 at 4 09 04 PM" src="https://github.com/user-attachments/assets/48d61dcf-481c-41b0-815e-b2c292a0e5eb" /> | <img width="1000" height="627" alt="Screenshot 2026-04-14 at 4 10 59 PM" src="https://github.com/user-attachments/assets/98fe781e-9693-4027-9716-4a02155ba52b" /> |


[CL-1162]: https://bitwarden.atlassian.net/browse/CL-1162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ