### PR TITLE
[PM-34751] inline menu autofill bypasses untrusted iframe check

### DIFF
--- a/apps/browser/src/autofill/services/autofill.service.spec.ts
+++ b/apps/browser/src/autofill/services/autofill.service.spec.ts
@@ -961,6 +961,15 @@ describe("AutofillService", () => {
       expect(logService.info).not.toHaveBeenCalledWith(
         "Autofill on page load was blocked due to an untrusted iframe.",
       );
+      expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(
+        autofillOptions.pageDetails[0].tab.id,
+        expect.objectContaining({
+          command: "fillForm",
+          fillScript: expect.objectContaining({ untrustedIframe: true }),
+        }),
+        expect.any(Object),
+        expect.any(Function),
+      );
     });
 
     it("skips updating the cipher's last used date if the passed options indicate that we should skip the last used cipher", async () => {
@@ -3507,9 +3516,9 @@ describe("AutofillService", () => {
       expect(result).toBe(false);
     });
 
-    it("returns a false value if the passed pageUrl matches the domain of the tabUrl", async () => {
-      const pageUrl = "https://subdomain.example.com";
-      const tabUrl = "https://www.example.com";
+    it("returns false when same origin and the page URL matches the cipher", async () => {
+      const pageUrl = "https://www.example.com/iframe/path";
+      const tabUrl = "https://www.example.com/top/path";
       const equivalentDomains = new Set([
         "ejemplo.es",
         "example.co.uk",
@@ -3519,29 +3528,6 @@ describe("AutofillService", () => {
       const generateFillScriptOptions = createGenerateFillScriptOptionsMock({ tabUrl });
       generateFillScriptOptions.cipher.login.matchesUri = jest.fn().mockReturnValueOnce(true);
 
-      const result = await autofillService["inUntrustedIframe"](pageUrl, generateFillScriptOptions);
-
-      expect(generateFillScriptOptions.cipher.login.matchesUri).toHaveBeenCalledWith(
-        pageUrl,
-        equivalentDomains,
-        generateFillScriptOptions.defaultUriMatch,
-      );
-      expect(result).toBe(false);
-    });
-
-    it("returns a true value if the passed pageUrl does not match the domain of the tabUrl", async () => {
-      const equivalentDomains = new Set([
-        "ejemplo.es",
-        "example.co.uk",
-        "example.com",
-        "exampleapp.com",
-      ]);
-      const pageUrl = "https://subdomain.example.com";
-      const tabUrl = "https://www.not-example.com";
-      const generateFillScriptOptions = createGenerateFillScriptOptionsMock({ tabUrl });
-      generateFillScriptOptions.cipher.login.matchesUri = jest.fn().mockReturnValueOnce(false);
-
-      // Mock getUrlEquivalentDomains to return the expected domains
       jest
         .spyOn(domainSettingsService, "getUrlEquivalentDomains")
         .mockReturnValue(of(equivalentDomains));
@@ -3553,6 +3539,44 @@ describe("AutofillService", () => {
         equivalentDomains,
         generateFillScriptOptions.defaultUriMatch,
       );
+      expect(result).toBe(false);
+    });
+
+    it("returns true when same origin but the page URL does not match the cipher", async () => {
+      const equivalentDomains = new Set([
+        "ejemplo.es",
+        "example.co.uk",
+        "example.com",
+        "exampleapp.com",
+      ]);
+      const pageUrl = "https://www.example.com/iframe";
+      const tabUrl = "https://www.example.com/top";
+      const generateFillScriptOptions = createGenerateFillScriptOptionsMock({ tabUrl });
+      generateFillScriptOptions.cipher.login.matchesUri = jest.fn().mockReturnValueOnce(false);
+
+      jest
+        .spyOn(domainSettingsService, "getUrlEquivalentDomains")
+        .mockReturnValue(of(equivalentDomains));
+
+      const result = await autofillService["inUntrustedIframe"](pageUrl, generateFillScriptOptions);
+
+      expect(generateFillScriptOptions.cipher.login.matchesUri).toHaveBeenCalledWith(
+        pageUrl,
+        equivalentDomains,
+        generateFillScriptOptions.defaultUriMatch,
+      );
+      expect(result).toBe(true);
+    });
+
+    it("returns true when the page origin differs from the tab origin (cross-origin iframe)", async () => {
+      const pageUrl = "https://other-origin.example.com/form";
+      const tabUrl = "https://www.example.com/embedder";
+      const generateFillScriptOptions = createGenerateFillScriptOptionsMock({ tabUrl });
+      generateFillScriptOptions.cipher.login.matchesUri = jest.fn();
+
+      const result = await autofillService["inUntrustedIframe"](pageUrl, generateFillScriptOptions);
+
+      expect(generateFillScriptOptions.cipher.login.matchesUri).not.toHaveBeenCalled();
       expect(result).toBe(true);
     });
   });

--- a/apps/browser/src/autofill/services/autofill.service.ts
+++ b/apps/browser/src/autofill/services/autofill.service.ts
@@ -1566,8 +1566,17 @@ export default class AutofillService implements AutofillServiceInterface {
       return false;
     }
 
-    // Check the pageUrl against cipher URIs using the configured match detection.
-    // Remember: if we are in this function, the tabUrl already matches a saved URI for the login.
+    // Different origin than the top level tab so we will treat as untrusted.
+    try {
+      if (new URL(pageUrl).origin !== new URL(options.tabUrl).origin) {
+        return true;
+      }
+    } catch {
+      // Fall through to legacy check for unparseable URLs
+    }
+
+    // Otherwise, check the pageUrl against cipher URIs using the configured match detection.
+    // Remember: if we are in this part of the function, the tabUrl already matches a saved URI for the login.
     // We need to verify the pageUrl also matches.
     const equivalentDomains = await firstValueFrom(
       this.domainSettingsService.getUrlEquivalentDomains(pageUrl),

--- a/apps/browser/src/autofill/services/insert-autofill-content.service.ts
+++ b/apps/browser/src/autofill/services/insert-autofill-content.service.ts
@@ -112,7 +112,7 @@ class InsertAutofillContentService implements InsertAutofillContentServiceInterf
 
     const confirmationWarning = [
       chrome.i18n.getMessage("autofillIframeWarning"),
-      chrome.i18n.getMessage("autofillIframeWarningTip", [globalThis.location.hostname]),
+      chrome.i18n.getMessage("autofillIframeWarningTip", [globalThis.location.href]),
     ].join("\n\n");
 
     return !globalThis.confirm(confirmationWarning);

--- a/apps/browser/src/autofill/services/insert-autofill-content.service.ts
+++ b/apps/browser/src/autofill/services/insert-autofill-content.service.ts
@@ -112,7 +112,7 @@ class InsertAutofillContentService implements InsertAutofillContentServiceInterf
 
     const confirmationWarning = [
       chrome.i18n.getMessage("autofillIframeWarning"),
-      chrome.i18n.getMessage("autofillIframeWarningTip", [globalThis.location.href]),
+      chrome.i18n.getMessage("autofillIframeWarningTip", [`${globalThis.location.origin}`]),
     ].join("\n\n");
 
     return !globalThis.confirm(confirmationWarning);


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-34751
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
To achieve feature parity, add an alert for cross-origin forms when their URLs differ. Additionally, update the alert to display the full href, including ports, to provide greater clarity for users.

I avoided recommendations due to the short circuit giving a dead inline menu that silently short circuited. 

> [!NOTE]
> Additional work will follow up this which is being tracked here https://bitwarden.atlassian.net/browse/PM-35071


## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
<img width="568" height="317" alt="Screenshot 2026-04-15 at 8 10 08 AM" src="https://github.com/user-attachments/assets/898719a3-0743-4914-bf2b-eee9e015a9a0" />
