### PR TITLE
[PM-33875] Revocation Reason Messages

### DIFF
--- a/apps/web/src/app/dirt/event-logs/services/event.service.ts
+++ b/apps/web/src/app/dirt/event-logs/services/event.service.ts
@@ -372,6 +372,14 @@ export class EventService {
       case EventType.OrganizationUser_SelfRevoked:
         msg = humanReadableMsg = this.i18nService.t("userSelfRevokedOrganizationOwnership");
         break;
+      case EventType.OrganizationUser_Revoked_TwoFactorNonCompliance:
+        msg = humanReadableMsg = this.i18nService.t("revocationReasonTwoFactorNonCompliance");
+        break;
+      case EventType.OrganizationUser_Revoked_SingleOrganizationNonCompliance:
+        msg = humanReadableMsg = this.i18nService.t(
+          "revocationReasonSingleOrganizationNonCompliance",
+        );
+        break;
       // Org
       case EventType.Organization_Updated:
         msg = humanReadableMsg = this.i18nService.t("editedOrgSettings");

--- a/apps/web/src/app/dirt/event-logs/services/event.service.ts
+++ b/apps/web/src/app/dirt/event-logs/services/event.service.ts
@@ -373,11 +373,20 @@ export class EventService {
         msg = humanReadableMsg = this.i18nService.t("userSelfRevokedOrganizationOwnership");
         break;
       case EventType.OrganizationUser_Revoked_TwoFactorNonCompliance:
-        msg = humanReadableMsg = this.i18nService.t("revocationReasonTwoFactorNonCompliance");
+        msg = this.i18nService.t("revokedUserIdTwoFactorNonCompliance", this.formatOrgUserId(ev));
+        humanReadableMsg = this.i18nService.t(
+          "revokedUserIdTwoFactorNonCompliance",
+          this.getShortId(ev.organizationUserId),
+        );
         break;
       case EventType.OrganizationUser_Revoked_SingleOrganizationNonCompliance:
-        msg = humanReadableMsg = this.i18nService.t(
-          "revocationReasonSingleOrganizationNonCompliance",
+        msg = this.i18nService.t(
+          "revokedUserIdSingleOrganizationNonCompliance",
+          this.formatOrgUserId(ev),
+        );
+        humanReadableMsg = this.i18nService.t(
+          "revokedUserIdSingleOrganizationNonCompliance",
+          this.getShortId(ev.organizationUserId),
         );
         break;
       // Org

--- a/apps/web/src/app/dirt/event-logs/services/event.service.ts
+++ b/apps/web/src/app/dirt/event-logs/services/event.service.ts
@@ -490,7 +490,11 @@ export class EventService {
         msg = humanReadableMsg = this.i18nService.t("userAcceptedTransfer");
         break;
       case EventType.Organization_ItemOrganization_Declined:
-        msg = humanReadableMsg = this.i18nService.t("userDeclinedTransfer");
+        msg = this.i18nService.t("revokedUserIdDeclinedTransfer", this.formatOrgUserId(ev));
+        humanReadableMsg = this.i18nService.t(
+          "revokedUserIdDeclinedTransfer",
+          this.getShortId(ev.organizationUserId),
+        );
         break;
       case EventType.Organization_AutoConfirmEnabled_Admin:
         msg = humanReadableMsg = this.i18nService.t("autoConfirmEnabledByAdmin");

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -4343,6 +4343,15 @@
   "revokedEmailError": {
     "message": "1 or more emails belong to revoked members. Restore their access to reinvite."
   },
+  "revocationReasonManual": {
+    "message": "Revoked by an admin"
+  },
+  "revocationReasonTwoFactorNonCompliance": {
+    "message": "Not in compliance with two-step login policy"
+  },
+  "revocationReasonSingleOrganizationNonCompliance": {
+    "message": "Not in compliance with single organization policy"
+  },
   "restoredUserId": {
     "message": "Restored organization access for $ID$.",
     "placeholders": {

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -4352,6 +4352,24 @@
   "revocationReasonSingleOrganizationNonCompliance": {
     "message": "Not in compliance with single organization policy"
   },
+  "revokedUserIdTwoFactorNonCompliance": {
+    "message": "Revoked organization access for $ID$ for non-compliance with the two-factor organization policy.",
+    "placeholders": {
+      "id": {
+        "content": "$1",
+        "example": "John Smith"
+      }
+    }
+  },
+  "revokedUserIdSingleOrganizationNonCompliance": {
+    "message": "Revoked organization access for $ID$ for non-compliance with the single organization policy.",
+    "placeholders": {
+      "id": {
+        "content": "$1",
+        "example": "John Smith"
+      }
+    }
+  },
   "restoredUserId": {
     "message": "Restored organization access for $ID$.",
     "placeholders": {

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -4370,6 +4370,15 @@
       }
     }
   },
+  "revokedUserIdDeclinedTransfer": {
+    "message": "Revoked organization access for $ID$ for declining transfer to organization ownership.",
+    "placeholders": {
+      "id": {
+        "content": "$1",
+        "example": "John Smith"
+      }
+    }
+  },
   "restoredUserId": {
     "message": "Restored organization access for $ID$.",
     "placeholders": {

--- a/libs/common/src/dirt/event-logs/enums/event-category.enum.ts
+++ b/libs/common/src/dirt/event-logs/enums/event-category.enum.ts
@@ -78,6 +78,8 @@ export const EventCategoryEventTypes: Record<EventCategory, EventType[]> = {
     EventType.OrganizationUser_Deleted,
     EventType.OrganizationUser_Left,
     EventType.OrganizationUser_SelfRevoked,
+    EventType.OrganizationUser_Revoked_TwoFactorNonCompliance,
+    EventType.OrganizationUser_Revoked_SingleOrganizationNonCompliance,
   ],
   [EventCategory.OrganizationEvents]: [
     EventType.Organization_Updated,

--- a/libs/common/src/dirt/event-logs/enums/event-type.enum.ts
+++ b/libs/common/src/dirt/event-logs/enums/event-type.enum.ts
@@ -63,6 +63,8 @@ export enum EventType {
   OrganizationUser_AutomaticallyConfirmed = 1517,
   OrganizationUser_SelfRevoked = 1518,
   OrganizationUser_AdminResetTwoFactor = 1519,
+  OrganizationUser_Revoked_TwoFactorNonCompliance = 1520,
+  OrganizationUser_Revoked_SingleOrganizationNonCompliance = 1521,
 
   Organization_Updated = 1600,
   Organization_PurgedVault = 1601,


### PR DESCRIPTION
## 🎟️ Tracking
[PM-33875](https://bitwarden.atlassian.net/browse/PM-33875)

## 📔 Objective
This PR supports revocation reasons added in the [corresponding server PR](https://github.com/bitwarden/server/pull/7473). Messages were sourced from the figma in the [upcoming UI ticket](https://bitwarden.atlassian.net/browse/PM-33887). I. did not add a specific organization data ownership event/message since it's already covered.


[PM-33885]: https://bitwarden.atlassian.net/browse/PM-33885?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PM-33875]: https://bitwarden.atlassian.net/browse/PM-33875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ