### PR TITLE
[PM-34788] Fix silent error swallowing in saveRiskInsightsReport$

### DIFF
--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -4719,6 +4719,9 @@
   "reportGenerationDone": {
     "message": "Done!"
   },
+  "reportGenerationFailed": {
+    "message": "An error occurred while generating the report. Try again."
+  },
   "riskInsightsRunReport": {
     "message": "Run report"
   },

--- a/bitwarden_license/bit-common/src/dirt/reports/risk-insights/services/domain/risk-insights-orchestrator.service.spec.ts
+++ b/bitwarden_license/bit-common/src/dirt/reports/risk-insights/services/domain/risk-insights-orchestrator.service.spec.ts
@@ -209,8 +209,7 @@ describe("RiskInsightsOrchestratorService", () => {
         mockRiskInsightsEncryptionService,
       );
 
-      const privateOrganizationDetailsSubject =
-        testService["_organizationDetailsSubject"];
+      const privateOrganizationDetailsSubject = testService["_organizationDetailsSubject"];
       const privateUserIdSubject = testService["_userIdSubject"];
 
       privateOrganizationDetailsSubject.next({

--- a/bitwarden_license/bit-common/src/dirt/reports/risk-insights/services/domain/risk-insights-orchestrator.service.spec.ts
+++ b/bitwarden_license/bit-common/src/dirt/reports/risk-insights/services/domain/risk-insights-orchestrator.service.spec.ts
@@ -190,6 +190,45 @@ describe("RiskInsightsOrchestratorService", () => {
       });
     });
 
+    it("should emit error ReportState when saveRiskInsightsReport$ throws", (done) => {
+      // Override the save mock to throw before creating the service
+      mockReportService.saveRiskInsightsReport$ = jest
+        .fn()
+        .mockReturnValue(throwError(() => new Error("Save failed")));
+
+      const testService = new RiskInsightsOrchestratorService(
+        mockAccountService,
+        mockCipherService,
+        mockCriticalAppsService,
+        mockLogService,
+        mockMemberCipherDetailsApiService,
+        mockOrganizationService,
+        mockPasswordHealthService,
+        mockReportApiService,
+        mockReportService,
+        mockRiskInsightsEncryptionService,
+      );
+
+      const privateOrganizationDetailsSubject =
+        testService["_organizationDetailsSubject"];
+      const privateUserIdSubject = testService["_userIdSubject"];
+
+      privateOrganizationDetailsSubject.next({
+        organizationId: mockOrgId,
+        organizationName: mockOrgName,
+      });
+      privateUserIdSubject.next(mockUserId);
+
+      testService.generateReport();
+
+      testService.rawReportData$.subscribe((state) => {
+        if (state.status === ReportStatus.Error) {
+          expect(state.error).toBe("Failed to generate or save report");
+          done();
+        }
+      });
+    });
+
     describe("destroy", () => {
       it("should complete destroy$ subject and unsubscribe reportStateSubscription", () => {
         const privateDestroy = (service as any)._destroy$;

--- a/bitwarden_license/bit-common/src/dirt/reports/risk-insights/services/domain/risk-insights-orchestrator.service.ts
+++ b/bitwarden_license/bit-common/src/dirt/reports/risk-insights/services/domain/risk-insights-orchestrator.service.ts
@@ -777,6 +777,7 @@ export class RiskInsightsOrchestratorService {
         };
       }),
       catchError((): Observable<ReportState> => {
+        this._reportProgressSubject.next(null);
         return of({
           status: ReportStatus.Error,
           error: "Failed to generate or save report",

--- a/bitwarden_license/bit-common/src/dirt/reports/risk-insights/services/domain/risk-insights-report.service.spec.ts
+++ b/bitwarden_license/bit-common/src/dirt/reports/risk-insights/services/domain/risk-insights-report.service.spec.ts
@@ -1,5 +1,5 @@
 import { mock } from "jest-mock-extended";
-import { firstValueFrom, of } from "rxjs";
+import { firstValueFrom, of, throwError } from "rxjs";
 
 import { ErrorResponse } from "@bitwarden/common/models/response/error.response";
 import { makeEncString } from "@bitwarden/common/spec";
@@ -146,6 +146,70 @@ describe("RiskInsightsReportService", () => {
             if (error instanceof ErrorResponse && error.statusCode) {
               expect(error.message).toBe("Invalid response from API");
             }
+            done();
+          },
+        });
+    });
+
+    it("should propagate encryption errors", (done) => {
+      mockRiskInsightsEncryptionService.encryptRiskInsightsReport.mockRejectedValue(
+        new Error("Encryption failed"),
+      );
+
+      service
+        .saveRiskInsightsReport$(
+          mockReportData,
+          mockSummaryData,
+          mockApplicationData,
+          new RiskInsightsMetrics(),
+          {
+            organizationId: mockOrganizationId,
+            userId: mockUserId,
+          },
+        )
+        .subscribe({
+          next: () => {
+            done.fail("Expected error to propagate");
+          },
+          error: (error: unknown) => {
+            expect((error as Error).message).toBe("Encryption failed");
+            done();
+          },
+        });
+    });
+
+    it("should propagate API save errors", (done) => {
+      const mockEncryptedOutput: EncryptedDataWithKey = {
+        organizationId: mockOrganizationId,
+        encryptedReportData: mockReportEnc,
+        encryptedSummaryData: mockSummaryEnc,
+        encryptedApplicationData: mockApplicationsEnc,
+        contentEncryptionKey: mockEncryptedKey,
+      };
+      mockRiskInsightsEncryptionService.encryptRiskInsightsReport.mockResolvedValue(
+        mockEncryptedOutput,
+      );
+      mockRiskInsightsApiService.saveRiskInsightsReport$.mockReturnValue(
+        throwError(() => new Error("API save failed")),
+      );
+
+      service
+        .saveRiskInsightsReport$(
+          mockReportData,
+          mockSummaryData,
+          mockApplicationData,
+          new RiskInsightsMetrics(),
+          {
+            organizationId: mockOrganizationId,
+            userId: mockUserId,
+          },
+        )
+        .subscribe({
+          next: () => {
+            done.fail("Expected error to propagate");
+          },
+          error: (error: unknown) => {
+            expect((error as Error).message).toBe("API save failed");
             done();
           },
         });

--- a/bitwarden_license/bit-common/src/dirt/reports/risk-insights/services/domain/risk-insights-report.service.ts
+++ b/bitwarden_license/bit-common/src/dirt/reports/risk-insights/services/domain/risk-insights-report.service.ts
@@ -1,4 +1,4 @@
-import { catchError, EMPTY, from, map, Observable, of, switchMap, throwError } from "rxjs";
+import { catchError, from, map, Observable, of, switchMap, throwError } from "rxjs";
 
 import { EncString } from "@bitwarden/common/key-management/crypto/models/enc-string";
 import {
@@ -297,9 +297,6 @@ export class RiskInsightsReportService {
             })),
           ),
       ),
-      catchError((error: unknown) => {
-        return EMPTY;
-      }),
       map((result) => {
         if (!isSaveRiskInsightsReportResponse(result.response)) {
           throw new Error("Invalid response from API");

--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/risk-insights.component.ts
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/risk-insights.component.ts
@@ -14,7 +14,7 @@ import {
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { ActivatedRoute, Router } from "@angular/router";
 import { concat, EMPTY, firstValueFrom, of } from "rxjs";
-import { concatMap, delay, distinctUntilChanged, map, skip, switchMap, tap } from "rxjs/operators";
+import { concatMap, delay, distinctUntilChanged, filter, map, skip, switchMap, tap } from "rxjs/operators";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 import {
@@ -35,6 +35,7 @@ import {
   DialogRef,
   DialogService,
   TabsModule,
+  ToastService,
 } from "@bitwarden/components";
 import { ExportHelper } from "@bitwarden/vault-export-core";
 import { exportToCSV } from "@bitwarden/web-vault/app/dirt/reports/report-utils";
@@ -122,6 +123,7 @@ export class RiskInsightsComponent implements OnInit, OnDestroy {
     private fileDownloadService: FileDownloadService,
     private logService: LogService,
     private configService: ConfigService,
+    private toastService: ToastService,
   ) {
     this.route.queryParams.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(({ tabIndex }) => {
       this.tabIndex = !isNaN(Number(tabIndex)) ? Number(tabIndex) : RiskInsightsTabType.AllActivity;
@@ -157,6 +159,19 @@ export class RiskInsightsComponent implements OnInit, OnDestroy {
         // Update report state
         this.appsCount = report?.reportData.length ?? 0;
         this.dataLastUpdated = report?.creationDate ?? null;
+      });
+
+    // Show error toast when report generation or save fails
+    this.dataService.reportStatus$
+      .pipe(
+        filter((status) => status === ReportStatus.Error),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(() => {
+        this.toastService.showToast({
+          message: this.i18nService.t("reportGenerationFailed"),
+          variant: "error",
+        });
       });
 
     // Subscribe to drawer state changes

--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/risk-insights.component.ts
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/risk-insights.component.ts
@@ -14,7 +14,16 @@ import {
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { ActivatedRoute, Router } from "@angular/router";
 import { concat, EMPTY, firstValueFrom, of } from "rxjs";
-import { concatMap, delay, distinctUntilChanged, filter, map, skip, switchMap, tap } from "rxjs/operators";
+import {
+  concatMap,
+  delay,
+  distinctUntilChanged,
+  filter,
+  map,
+  skip,
+  switchMap,
+  tap,
+} from "rxjs/operators";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 import {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-34788

## 📔 Objective

`saveRiskInsightsReport$()` in the V1 report service caught all errors and returned `EMPTY`, silently swallowing encryption and API failures. This caused the UI to hang permanently on "Compiling insights..." with no error feedback and silent data loss of the generated report.

Removing the `catchError(() => EMPTY)` block in `risk-insights-report.service.ts` lets errors propagate naturally through the RxJS pipe to the orchestrator's existing `catchError` handler in `risk-insights-orchestrator.service.ts`, which produces a `ReportStatus.Error` state. The inner `catchError` was intercepting errors first and converting them to a silent completion, so the orchestrator's handler never saw them.

The orchestrator's `catchError` also needed to reset `_reportProgressSubject` to `null` so the loading component hides instead of hanging on "Compiling insights...", and the component needed to subscribe to `ReportStatus.Error` to show an error toast.

**What changed:**
- Removed the `catchError(() => EMPTY)` block in `risk-insights-report.service.ts` and cleaned up the unused `EMPTY` import
- Reset `_reportProgressSubject` in the orchestrator's `catchError` to hide the progress bar on error (`risk-insights-orchestrator.service.ts`)
- Added error toast in `risk-insights.component.ts` that subscribes to `reportStatus$` and shows "An error occurred while generating the report. Try again." on `ReportStatus.Error`
- Added `reportGenerationFailed` i18n key in `messages.json`
- Added unit tests for encryption error propagation and API save error propagation in `risk-insights-report.service.spec.ts`
- Added an orchestrator test verifying save errors produce `ReportStatus.Error` in `risk-insights-orchestrator.service.spec.ts`

This is a V1-only fix. The V2 code path (`DefaultReportPersistenceService`) already has proper error handling. This bug goes away when V1 is removed ([PM-31947](https://bitwarden.atlassian.net/browse/PM-31947)), but V1 is still the active production path for orgs without the V2 flag enabled.

**Related:**
- [PM-27694](https://bitwarden.atlassian.net/browse/PM-27694): Prior fix for the same `return EMPTY` pattern in the fetch method of the same file
- [PM-33067](https://bitwarden.atlassian.net/browse/PM-33067): Similar silent error swallowing fix in mark/unmark critical apps API

## 📸 Screenshots

### Before
https://github.com/user-attachments/assets/b49d4d47-c75f-4849-8e13-a603d01491a1

### After

https://github.com/user-attachments/assets/bc01cbca-6425-4031-9472-6cf0d9ac5967




[PM-34788]: https://bitwarden.atlassian.net/browse/PM-34788

[PM-31947]: https://bitwarden.atlassian.net/browse/PM-31947?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ