### PR TITLE
Add Skunkworks as co-owners of native passkeys

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,9 +10,6 @@
 
 ## Desktop native module ##
 apps/desktop/desktop_native @bitwarden/team-platform-dev
-apps/desktop/desktop_native/objc/src/native/autofill @bitwarden/team-desktop-native-dev
-apps/desktop/desktop_native/core/src/autofill @bitwarden/team-desktop-native-dev
-apps/desktop/desktop_native/autofill_provider @bitwarden/team-desktop-native-dev
 apps/desktop/desktop_native/core/src/secure_memory @bitwarden/team-key-management-dev
 
 ## No ownership for Cargo.lock and Cargo.toml to allow dependency updates
@@ -166,16 +163,24 @@ libs/common/src/autofill @bitwarden/team-autofill-dev
 
 ## Desktop Native team files ##
 apps/desktop/src/autofill @bitwarden/team-desktop-native-dev
-apps/desktop/macos/autofill-extension @bitwarden/team-desktop-native-dev
-apps/desktop/src/app/components/fido2placeholder.component.ts @bitwarden/team-desktop-native-dev
-apps/desktop/desktop_native/windows_plugin_authenticator @bitwarden/team-desktop-native-dev
 apps/desktop/desktop_native/autotype @bitwarden/team-desktop-native-dev
 apps/desktop/desktop_native/core/src/ssh_agent @bitwarden/team-desktop-native-dev @bitwarden/wg-ssh-keys
 apps/desktop/desktop_native/ssh_agent @bitwarden/team-desktop-native-dev @bitwarden/wg-ssh-keys
-apps/desktop/desktop_native/napi/src/autofill.rs @bitwarden/team-desktop-native-dev
 apps/desktop/desktop_native/napi/src/autotype.rs @bitwarden/team-desktop-native-dev
 apps/desktop/desktop_native/napi/src/sshagent.rs @bitwarden/team-desktop-native-dev
 apps/desktop/desktop_native/napi/src/sshagent_v2.rs @bitwarden/team-desktop-native-dev
+
+## Desktop Native + Skunkworks co-owned files 
+apps/desktop/desktop_native/autofill_provider @bitwarden/team-desktop-native-dev @bitwarden/team-skunkworks
+apps/desktop/desktop_native/core/src/autofill @bitwarden/team-desktop-native-dev @bitwarden/team-skunkworks
+apps/desktop/desktop_native/napi/src/autofill.rs @bitwarden/team-desktop-native-dev @bitwarden/team-skunkworks
+apps/desktop/desktop_native/objc/src/native/autofill @bitwarden/team-desktop-native-dev @bitwarden/team-skunkworks
+apps/desktop/desktop_native/win_webauthn @bitwarden/team-desktop-native-dev @bitwarden/team-skunkworks
+apps/desktop/desktop_native/windows_plugin_authenticator @bitwarden/team-desktop-native-dev @bitwarden/team-skunkworks
+apps/desktop/macos/autofill-extension @bitwarden/team-desktop-native-dev @bitwarden/team-skunkworks
+apps/desktop/src/autofill/modal/credentials @bitwarden/team-desktop-native-dev @bitwarden/team-skunkworks
+apps/desktop/src/autofill/services/desktop-autofill* @bitwarden/team-desktop-native-dev @bitwarden/team-skunkworks
+apps/desktop/src/autofill/services/desktop-fido2* @bitwarden/team-desktop-native-dev @bitwarden/team-skunkworks
 
 # DuckDuckGo integration
 apps/desktop/native-messaging-test-runner @bitwarden/team-desktop-native-dev


### PR DESCRIPTION
## 🎟️ Tracking

## 📔 Objective

Allow Skunkworks team to review and merge native passkey work while in development.