### PR TITLE
[PM-35222] feat(autofill): support RTL positioning for inline menu icon

### DIFF
--- a/apps/browser/src/autofill/background/overlay.background.spec.ts
+++ b/apps/browser/src/autofill/background/overlay.background.spec.ts
@@ -2978,6 +2978,45 @@ describe("OverlayBackground", () => {
           left: "1271px",
         });
       });
+
+      it("sets button position correctly when direction is RTL", async () => {
+        const subframe = {
+          top: 0,
+          left: 0,
+          url: "",
+          frameId: 0,
+        };
+
+        overlayBackground["focusedFieldData"] = createFocusedFieldDataMock({
+          focusedFieldRects: {
+            width: 500,
+            height: 40,
+            top: 100,
+            left: 200,
+          },
+          focusedFieldStyles: {
+            direction: "rtl",
+            paddingLeft: "10px",
+            paddingRight: "0px",
+          },
+        });
+
+        const buttonPostion = overlayBackground["getInlineMenuButtonPosition"](subframe);
+
+        // height = 40. elementOffset = 40 * 0.42 = 16.8 (since height >= 35)
+        // elementHeight = 40 - 16.8 = 23.2
+        // elementTopPosition = 100 + 16.8 / 2 = 108.4
+        // isRtl = true. fieldPaddingLeft = 10, fieldPaddingRight = 0.
+        // fieldPaddingLeft > fieldPaddingRight is true.
+        // elementLeftPosition = 200 + (10 - 23.2 - 2) = 200 - 15.2 = 184.8
+
+        expect(buttonPostion).toEqual({
+          width: "23px",
+          height: "23px",
+          top: "108px",
+          left: "185px",
+        });
+      });
       it("sets button and menu width and position when multi-input totp field is focused", async () => {
         const subframe = {
           top: 0,

--- a/apps/browser/src/autofill/background/overlay.background.ts
+++ b/apps/browser/src/autofill/background/overlay.background.ts
@@ -1793,7 +1793,7 @@ export class OverlayBackground implements OverlayBackgroundInterface {
 
     const { width, height } = this.focusedFieldData.focusedFieldRects;
     let { top, left } = this.focusedFieldData.focusedFieldRects;
-    const { paddingRight, paddingLeft } = this.focusedFieldData.focusedFieldStyles;
+    const { paddingRight, paddingLeft, direction } = this.focusedFieldData.focusedFieldStyles;
 
     if (this.isTotpFieldForCurrentField()) {
       const totpFields = this.getTotpFields();
@@ -1828,8 +1828,12 @@ export class OverlayBackground implements OverlayBackgroundInterface {
     const elementHeight = height - elementOffset;
 
     const elementTopPosition = subFrameTopOffset + top + elementOffset / 2;
-    const elementLeftPosition =
-      fieldPaddingRight > fieldPaddingLeft
+    const isRtl = direction === "rtl";
+    const elementLeftPosition = isRtl
+      ? fieldPaddingLeft > fieldPaddingRight
+        ? subFrameLeftOffset + left + (fieldPaddingLeft - elementHeight - 2)
+        : subFrameLeftOffset + left + elementOffset / 2
+      : fieldPaddingRight > fieldPaddingLeft
         ? subFrameLeftOffset + left + width - height - (fieldPaddingRight - elementOffset + 2)
         : subFrameLeftOffset + left + width - height + elementOffset / 2;
 

--- a/apps/browser/src/autofill/services/autofill-overlay-content.service.ts
+++ b/apps/browser/src/autofill/services/autofill-overlay-content.service.ts
@@ -1012,13 +1012,13 @@ export class AutofillOverlayContentService implements AutofillOverlayContentServ
     }
 
     this.mostRecentlyFocusedField = formFieldElement;
-    const { paddingRight, paddingLeft } = globalThis.getComputedStyle(formFieldElement);
+    const { paddingRight, paddingLeft, direction } = globalThis.getComputedStyle(formFieldElement);
     const { width, height, top, left } =
       await this.getMostRecentlyFocusedFieldRects(formFieldElement);
     const autofillFieldData = this.formFieldElements.get(formFieldElement);
 
     this.focusedFieldData = {
-      focusedFieldStyles: { paddingRight, paddingLeft },
+      focusedFieldStyles: { paddingRight, paddingLeft, direction },
       focusedFieldRects: { width, height, top, left },
       inlineMenuFillType: autofillFieldData?.inlineMenuFillType,
       showPasskeys: !!autofillFieldData?.showPasskeys,


### PR DESCRIPTION
When a field has RTL direction (e.g. for Hebrew or Arabic), the Bitwarden icon should be positioned on the left side to avoid overlapping with the text.

- Collect 'direction' style in AutofillOverlayContentService.
- Adjust button positioning in OverlayBackground based on direction.
- Add unit test for RTL positioning.

## 🎟️ Tracking
Closes [#10519](https://github.com/bitwarden/clients/issues/10519)
Related to [#17739](https://github.com/bitwarden/clients/pull/17739)

## 📔 Objective

This PR provides a refined implementation for RTL (Right-to-Left) autofill icon positioning, improving upon the work in #17739.

**Key Improvements:**
- **Capture `direction` style**: Correctly identifies the text direction from the input field's computed styles.
- **Symmetric Positioning**: Implements a robust coordinate calculation that mirrors the LTR logic for RTL fields, ensuring the icon stays within the field's padding and doesn't overlap text.
- **Unit Test Coverage**: Includes a new unit test in `overlay.background.spec.ts` to verify the RTL positioning logic, which was missing in the previous PR.
- **Code Standards**: Fully linted and formatted using the project's Prettier and ESLint rules.

## 📸 Screenshots



<img width="762" height="448" alt="image" src="https://github.com/user-attachments/assets/fdb6613f-7f59-45ae-a3b6-c66f2bf40052" />

<img width="484" height="347" alt="image" src="https://github.com/user-attachments/assets/f3179b3d-f398-4965-9842-69b964d7e05c" />

<img width="414" height="197" alt="image" src="https://github.com/user-attachments/assets/93016e20-c3f3-4712-a0ce-473ba82aeb3e" />
