### PR TITLE
Update cancel survey options for Teams and Enterprise orgs

### DIFF
--- a/apps/web/src/app/billing/organizations/organization-subscription-cloud.component.ts
+++ b/apps/web/src/app/billing/organizations/organization-subscription-cloud.component.ts
@@ -345,6 +345,7 @@ export class OrganizationSubscriptionCloudComponent implements OnInit, OnDestroy
         type: "Organization",
         id: this.organizationId,
         plan: this.sub.plan.type,
+        productTier: this.sub.plan.productTier,
       },
     });
 

--- a/apps/web/src/app/billing/shared/offboarding-survey.component.ts
+++ b/apps/web/src/app/billing/shared/offboarding-survey.component.ts
@@ -7,6 +7,7 @@ import { FormBuilder, Validators } from "@angular/forms";
 
 import { BillingApiServiceAbstraction as BillingApiService } from "@bitwarden/common/billing/abstractions/billing-api.service.abstraction";
 import { PlanType } from "@bitwarden/common/billing/enums";
+import { ProductTierType } from "@bitwarden/common/billing/enums/product-tier-type.enum";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import {
@@ -25,6 +26,7 @@ type OrganizationOffboardingParams = {
   type: "Organization";
   id: string;
   plan: PlanType;
+  productTier: ProductTierType;
 };
 
 export type OffboardingSurveyDialogParams = UserOffboardingParams | OrganizationOffboardingParams;
@@ -76,32 +78,31 @@ export class OffboardingSurveyComponent {
     private platformUtilsService: PlatformUtilsService,
     private toastService: ToastService,
   ) {
+    const isBusiness = this.isBusinessPlan();
+
     this.reasons = [
-      {
-        value: null,
-        text: this.i18nService.t("selectPlaceholder"),
-      },
+      { value: null, text: this.i18nService.t("selectPlaceholder") },
       {
         value: "missing_features",
-        text: this.i18nService.t("missingFeatures"),
+        text: this.i18nService.t(isBusiness ? "cancelSurveyDidntMeetNeeds" : "missingFeatures"),
       },
       {
         value: "switched_service",
-        text: this.i18nService.t("movingToAnotherTool"),
+        text: this.i18nService.t(
+          isBusiness ? "cancelSurveyTeamPrioritiesChanged" : "movingToAnotherTool",
+        ),
       },
       {
         value: "too_complex",
-        text: this.i18nService.t("tooDifficultToUse"),
+        text: this.i18nService.t(isBusiness ? "cancelSurveyOrgRestructuring" : "tooDifficultToUse"),
       },
       {
         value: "unused",
-        text: this.i18nService.t("notUsingEnough"),
+        text: this.i18nService.t(isBusiness ? "cancelSurveyDidntUseIt" : "notUsingEnough"),
       },
-      this.getSwitchingReason(),
-      {
-        value: "other",
-        text: this.i18nService.t("other"),
-      },
+      ...(isBusiness
+        ? [{ value: "too_expensive", text: this.i18nService.t("cancelSurveyNotInBudget") }]
+        : [this.getSwitchingReason(), { value: "other", text: this.i18nService.t("other") }]),
     ];
   }
 
@@ -129,6 +130,15 @@ export class OffboardingSurveyComponent {
 
     this.dialogRef.close(this.ResultType.Submitted);
   };
+
+  private isBusinessPlan(): boolean {
+    return (
+      this.dialogParams.type === "Organization" &&
+      [ProductTierType.Teams, ProductTierType.Enterprise, ProductTierType.TeamsStarter].includes(
+        this.dialogParams.productTier,
+      )
+    );
+  }
 
   private getSwitchingReason(): Reason {
     if (this.dialogParams.type === "User") {

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -10375,6 +10375,26 @@
     "message": "Switching to free organization",
     "description": "An option for the offboarding survey shown when a user cancels their subscription."
   },
+  "cancelSurveyDidntMeetNeeds": {
+    "message": "It didn't meet our needs",
+    "description": "An option for the offboarding survey shown when a Teams or Enterprise organization cancels their subscription."
+  },
+  "cancelSurveyTeamPrioritiesChanged": {
+    "message": "Our team or priorities have changed",
+    "description": "An option for the offboarding survey shown when a Teams or Enterprise organization cancels their subscription."
+  },
+  "cancelSurveyOrgRestructuring": {
+    "message": "Our organization is restructuring or closing",
+    "description": "An option for the offboarding survey shown when a Teams or Enterprise organization cancels their subscription."
+  },
+  "cancelSurveyDidntUseIt": {
+    "message": "We didn't end up using it",
+    "description": "An option for the offboarding survey shown when a Teams or Enterprise organization cancels their subscription."
+  },
+  "cancelSurveyNotInBudget": {
+    "message": "It's not in our budget right now",
+    "description": "An option for the offboarding survey shown when a Teams or Enterprise organization cancels their subscription."
+  },
   "freeForOneYear": {
     "message": "Free for 1 year"
   },


### PR DESCRIPTION
## Summary

[PM-35243](https://bitwarden.atlassian.net/browse/PM-35243)

- Updates the offboarding survey component to show Teams/Enterprise-specific display text for cancellation reasons
- Removes the "other" option from the survey dropdown for Teams, Enterprise, and Teams Starter plans
- Adds `productTier` to `OrganizationOffboardingParams` for clean plan detection via `ProductTierType`
- No changes to the API contract — the Stripe reason values sent to the server are unchanged
- No changes for Premium or Families subscriptions

## Type of change
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Test plan
- [ ] Cancel a Teams subscription → survey shows: "It didn't meet our needs", "Our team or priorities have changed", "Our organization is restructuring or closing", "We didn't end up using it", "It's not in our budget right now". No "other" option.
- [ ] Cancel an Enterprise subscription → same options as Teams
- [ ] Cancel a Families subscription → survey shows original options including "other"
- [ ] Cancel a Premium subscription → survey shows original options including "other"

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

[PM-35243]: https://bitwarden.atlassian.net/browse/PM-35243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ