### PR TITLE
Support partial-edit for desktop (unreachable)

### DIFF
--- a/apps/desktop/src/vault/app/vault-v3/vault.component.ts
+++ b/apps/desktop/src/vault/app/vault-v3/vault.component.ts
@@ -594,7 +594,7 @@ export class VaultComponent<C extends CipherViewLike> implements OnInit, OnDestr
       return;
     }
     const formConfig = await this.cipherFormConfigService.buildConfig(
-      "edit",
+      cipher.edit ? "edit" : "partial-edit",
       cipher.id as CipherId,
       cipher.type,
     );


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-28167
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

https://github.com/bitwarden/clients/pull/19341#issuecomment-4258753507

`editCipher` previously set the mode to `edit` or `partial-edit` depending on if you could edit the cipher or not. This mode is unreachable but for our future sanity this brings back the logic.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
