### PR TITLE
Add percentage complete translation for progress bar

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -6154,6 +6154,15 @@
   "sessionTimeoutSuppressedByConnectedDevice": {
     "message": "Managed by the Bitwarden desktop app. Open the desktop app to edit."
   },
+  "percentageCompleted": {
+    "message": "$PERCENT$% complete",
+    "placeholders": {
+      "percent": {
+        "content": "$1",
+        "example": "75"
+      }
+    }
+  },
   "upgrade": {
     "message": "Upgrade"
   },

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -4795,6 +4795,15 @@
   "organizationIsSuspendedDesc": {
     "message": "Items in suspended organizations cannot be accessed. Contact your organization owner for assistance."
   },
+  "percentageCompleted": {
+    "message": "$PERCENT$% complete",
+    "placeholders": {
+      "percent": {
+        "content": "$1",
+        "example": "75"
+      }
+    }
+  },
   "noItemsInTrash": {
     "message": "No items in trash"
   },


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

Adds the percentage complete translation for the progress bar for desktop and extension. This was already present in the web translations. 

## 📸 Screenshots

|Desktop|Extension|
|-|-|
|<img width="536" height="457" alt="Screenshot 2026-04-16 at 11 20 38 AM" src="https://github.com/user-attachments/assets/574d30bc-7dd4-4125-b6c1-fd8e6d71d2a6" />|<img width="530" height="670" alt="Screenshot 2026-04-16 at 11 17 58 AM" src="https://github.com/user-attachments/assets/5bb1fa64-bc75-4b68-80f1-af24ae32cf36" />|