### PR TITLE
[PM-35258] Add archive confirmation to Desktop and fix right click menu

### DIFF
--- a/apps/desktop/src/vault/app/vault-v3/vault-items/vault-cipher-row.component.html
+++ b/apps/desktop/src/vault/app/vault-v3/vault-items/vault-cipher-row.component.html
@@ -93,6 +93,7 @@
     }
 
     <button
+      #optionsMenuTrigger="menuTrigger"
       [bitMenuTriggerFor]="cipherOptions"
       [disabled]="disabled()"
       bitIconButton="bwi-ellipsis-v"

--- a/apps/desktop/src/vault/app/vault-v3/vault-items/vault-cipher-row.component.ts
+++ b/apps/desktop/src/vault/app/vault-v3/vault-items/vault-cipher-row.component.ts
@@ -99,7 +99,6 @@ export class VaultCipherRowComponent<C extends CipherViewLike> {
 
   protected readonly showArchiveButton = computed(() => {
     return (
-      !this.cipher().organizationId &&
       !CipherViewLikeUtils.isArchived(this.cipher()) &&
       !CipherViewLikeUtils.isDeleted(this.cipher())
     );

--- a/apps/desktop/src/vault/app/vault-v3/vault-items/vault-cipher-row.component.ts
+++ b/apps/desktop/src/vault/app/vault-v3/vault-items/vault-cipher-row.component.ts
@@ -1,7 +1,7 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
 import { NgClass } from "@angular/common";
-import { Component, HostListener, ViewChild, computed, inject, input, output } from "@angular/core";
+import { Component, HostListener, computed, inject, input, output, viewChild } from "@angular/core";
 
 import { PremiumBadgeComponent } from "@bitwarden/angular/billing/components/premium-badge/premium-badge.component";
 import { IconComponent } from "@bitwarden/angular/vault/components/icon.component";
@@ -13,11 +13,9 @@ import {
   CipherViewLikeUtils,
 } from "@bitwarden/common/vault/utils/cipher-view-like-utils";
 import {
-  AriaDisableDirective,
   BitIconButtonComponent,
   MenuModule,
   MenuTriggerForDirective,
-  TooltipDirective,
   TableModule,
   LinkModule,
 } from "@bitwarden/components";
@@ -46,9 +44,7 @@ interface CopyFieldConfig {
     NgClass,
     I18nPipe,
     TableModule,
-    AriaDisableDirective,
     OrganizationNameBadgeComponent,
-    TooltipDirective,
     BitIconButtonComponent,
     MenuModule,
     CopyCipherFieldDirective,
@@ -61,9 +57,7 @@ interface CopyFieldConfig {
 export class VaultCipherRowComponent<C extends CipherViewLike> {
   protected RowHeightClass = `tw-h-[75px]`;
 
-  // FIXME(https://bitwarden.atlassian.net/browse/CL-903): Migrate to Signals
-  // eslint-disable-next-line @angular-eslint/prefer-signals
-  @ViewChild(MenuTriggerForDirective, { static: false }) menuTrigger: MenuTriggerForDirective;
+  protected readonly menuTrigger = viewChild<MenuTriggerForDirective>("optionsMenuTrigger");
 
   protected readonly disabled = input<boolean>();
   protected readonly cipher = input<C>();
@@ -294,8 +288,8 @@ export class VaultCipherRowComponent<C extends CipherViewLike> {
       return;
     }
 
-    if (!this.disabled() && this.menuTrigger) {
-      this.menuTrigger.toggleMenuOnRightClick(event);
+    if (!this.disabled() && this.menuTrigger()) {
+      this.menuTrigger().toggleMenuOnRightClick(event);
     }
   }
 }

--- a/apps/desktop/src/vault/app/vault-v3/vault.component.ts
+++ b/apps/desktop/src/vault/app/vault-v3/vault.component.ts
@@ -521,7 +521,7 @@ export class VaultComponent<C extends CipherViewLike> implements OnInit, OnDestr
       case "archive":
         if (event.items.length === 1) {
           const cipher = await this.cipherService.getFullCipherView(event.items[0]);
-          if (!cipher.organizationId && !cipher.isDeleted && !cipher.isArchived) {
+          if (!cipher.isDeleted && !cipher.isArchived) {
             if (!(await firstValueFrom(this.userCanArchive$))) {
               await this.premiumUpgradePromptService.promptForPremium();
               return;

--- a/libs/vault/src/vault-item-dialog/vault-item-dialog.component.spec.ts
+++ b/libs/vault/src/vault-item-dialog/vault-item-dialog.component.spec.ts
@@ -249,6 +249,20 @@ describe("VaultItemDialogComponent", () => {
   });
 
   describe("archive", () => {
+    it("shows a confirmation dialog before archiving", async () => {
+      component.setTestCipher({ id: "cipher-id", collectionIds: [] } as any);
+      jest.spyOn(component as any, "updateCipherFromResponse").mockResolvedValue(undefined);
+
+      await component.archive();
+
+      expect(mockDialogService.openSimpleDialog).toHaveBeenCalledWith({
+        title: { key: "archiveItem" },
+        content: { key: "archiveItemDialogContent" },
+        acceptButtonText: { key: "archiveVerb" },
+        type: "info",
+      });
+    });
+
     it("calls archiveService.archiveWithServer with the cipher id and active user id", async () => {
       component.setTestCipher({ id: "cipher-id", collectionIds: [] } as any);
       jest.spyOn(component as any, "updateCipherFromResponse").mockResolvedValue(undefined);
@@ -259,6 +273,15 @@ describe("VaultItemDialogComponent", () => {
         "cipher-id",
         "test-user-id",
       );
+    });
+
+    it("does not archive when the user cancels the confirmation", async () => {
+      component.setTestCipher({ id: "cipher-id", collectionIds: [] } as any);
+      mockDialogService.openSimpleDialog.mockResolvedValueOnce(false);
+
+      await component.archive();
+
+      expect(mockArchiveService.archiveWithServer).not.toHaveBeenCalled();
     });
   });
 

--- a/libs/vault/src/vault-item-dialog/vault-item-dialog.component.ts
+++ b/libs/vault/src/vault-item-dialog/vault-item-dialog.component.ts
@@ -592,6 +592,17 @@ export class VaultItemDialogComponent implements OnInit, OnDestroy {
   };
 
   archive = async () => {
+    const confirmed = await this.dialogService.openSimpleDialog({
+      title: { key: "archiveItem" },
+      content: { key: "archiveItemDialogContent" },
+      acceptButtonText: { key: "archiveVerb" },
+      type: "info",
+    });
+
+    if (!confirmed) {
+      return;
+    }
+
     const activeUserId = await firstValueFrom(this.userId$);
     try {
       const cipherResponse = await this.archiveService.archiveWithServer(


### PR DESCRIPTION
## 🎟️ Tracking

[PM-35258](https://bitwarden.atlassian.net/browse/PM-35258)

## 📔 Objective

Fixes several archive-related issues in the Desktop vault drawer migration:

- The archive confirmation dialog was not being shown when archiving an item from the View item drawer. Added the missing confirmation dialog to `VaultItemDialogComponent`.
- The archive option was missing from the right-click context menu for organization items. Removed an incorrect `organizationId` guard from `showArchiveButton` in `VaultCipherRowComponent`.
- The right-click context menu trigger was mistakenly grabbing the new copy actions menu trigger. Add explicit naming for the `viewChild`.
- Organization users could not archive from the item's more menu. Removed the same guard from the archive event handler in `VaultComponent`.

## 📸 Screenshots

### Archive Confirmation
https://github.com/user-attachments/assets/d39f3d42-7a0a-48e1-a8f8-2fe3bf53f7c4

### Fixed Right Click Menu
https://github.com/user-attachments/assets/78af5504-8eff-45f2-98cd-7f3e4dbc4f81



[PM-35258]: https://bitwarden.atlassian.net/browse/PM-35258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ