### PR TITLE
[PM-35287] feat: auto-close sso tab after authentication completes

### DIFF
--- a/apps/browser/src/background/runtime.background.ts
+++ b/apps/browser/src/background/runtime.background.ts
@@ -224,6 +224,31 @@ export default class RuntimeBackground {
       case "getUrlAutofillTargetingRules": {
         return await this.main.domainSettingsService.getTargetingRulesForUrl(sender.tab?.url);
       }
+      case "authResult": {
+        if (!(await this.isValidVaultReferrer(msg.referrer))) {
+          return;
+        }
+
+        if (msg.lastpass) {
+          this.messagingService.send("importCallbackLastPass", {
+            code: msg.code,
+            state: msg.state,
+          });
+        } else {
+          try {
+            await openSsoAuthResultPopout(msg);
+          } catch {
+            this.logService.error("Unable to open sso popout tab");
+          }
+        }
+
+        if (sender.tab?.id) {
+          await BrowserApi.closeTab(sender.tab.id).catch((error) => {
+            this.logService.error("Unable to close SSO tab", error);
+          });
+        }
+        break;
+      }
     }
   }
 
@@ -352,25 +377,6 @@ export default class RuntimeBackground {
         break;
       case "bgReseedStorage": {
         await this.main.reseedStorage();
-        break;
-      }
-      case "authResult": {
-        if (!(await this.isValidVaultReferrer(msg.referrer))) {
-          return;
-        }
-
-        if (msg.lastpass) {
-          this.messagingService.send("importCallbackLastPass", {
-            code: msg.code,
-            state: msg.state,
-          });
-        } else {
-          try {
-            await openSsoAuthResultPopout(msg);
-          } catch {
-            this.logService.error("Unable to open sso popout tab");
-          }
-        }
         break;
       }
       case "webAuthnResult": {


### PR DESCRIPTION
## 🎟️ Tracking

Running a pilot with a few hundred users — most of them find the extra browser tab that stays open after SSO really annoying.

## 📔 Objective

After SSO login, the tab that opens for authentication stays open with a message telling you to close it yourself. That's unnecessary friction. This PR makes the extension close that tab automatically once it has the auth result, so users don't have to deal with it.

Moved the `authResult` handler from `processMessage` to `processMessageWithSender` to get access to the sender's tab ID, then call `BrowserApi.closeTab` after the SSO result popout opens.