### PR TITLE
Add dev tag to GHCR

### DIFF
--- a/.github/workflows/build-web.yml
+++ b/.github/workflows/build-web.yml
@@ -313,7 +313,7 @@ jobs:
         run: |
           ACR_NAME="$_AZ_REGISTRY/${PROJECT_NAME}:${IMAGE_TAG}"
           echo "name=$ACR_NAME" >> "$GITHUB_OUTPUT"
-          if [[ "$IMAGE_TAG" == "rc" || "$IMAGE_TAG" == "hotfix-rc-web" ]]; then
+          if [[ "$IMAGE_TAG" == "dev" || "$IMAGE_TAG" == "rc" || "$IMAGE_TAG" == "hotfix-rc-web" ]]; then
             echo "tags=$ACR_NAME,$_GHCR_REGISTRY/${PROJECT_NAME}:${IMAGE_TAG}" >> "$GITHUB_OUTPUT"
           else
             echo "tags=$ACR_NAME" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR adds the `dev` tag to GHCR for Web to align with how we push `dev` tags for all the Server images to GHCR.

