### PR TITLE
[PM-35187] Store new default avatar colors as hexes

### DIFF
--- a/apps/web/src/app/auth/settings/account/change-avatar-dialog.component.ts
+++ b/apps/web/src/app/auth/settings/account/change-avatar-dialog.component.ts
@@ -18,11 +18,11 @@ import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/pl
 import { Utils } from "@bitwarden/common/platform/misc/utils";
 import {
   AvatarDefaultColors,
+  defaultAvatarColors,
   DIALOG_DATA,
   DialogConfig,
   DialogRef,
   DialogService,
-  isAvatarColor,
   ToastService,
 } from "@bitwarden/components";
 
@@ -52,7 +52,7 @@ export class ChangeAvatarDialogComponent implements OnInit, OnDestroy {
 
   defaultColorPalette: NamedAvatarColor[] = AvatarDefaultColors.map((color) => {
     return {
-      color,
+      color: defaultAvatarColors[color],
       name: this.i18nService.t(color === "brand" ? "blue" : color),
     };
   });
@@ -99,9 +99,8 @@ export class ChangeAvatarDialogComponent implements OnInit, OnDestroy {
   }
 
   submit = async () => {
-    const defaultColorSelected = isAvatarColor(this.currentSelection);
     const isValidHex = Utils.validateHexColor(this.currentSelection);
-    const isValidSelection = this.currentSelection == null || defaultColorSelected || isValidHex;
+    const isValidSelection = this.currentSelection == null || isValidHex;
 
     if (isValidSelection) {
       await this.avatarService.setAvatarColor(this.currentSelection);

--- a/libs/components/src/avatar/avatar.component.ts
+++ b/libs/components/src/avatar/avatar.component.ts
@@ -32,11 +32,11 @@ const sizeClasses: Record<AvatarSize, string[]> = {
  * dark mode.
  */
 export const defaultAvatarColors: Record<AvatarColor, string> = {
-  teal: "var(--color-bg-avatar-teal)",
-  coral: "var(--color-bg-avatar-coral)",
-  brand: "var(--color-bg-avatar-brand)",
-  green: "var(--color-bg-avatar-green)",
-  purple: "var(--color-bg-avatar-purple)",
+  teal: "#007c95",
+  coral: "#c71800",
+  brand: "#175ddc",
+  green: "#008236",
+  purple: "#8200db",
 };
 
 /**
@@ -45,11 +45,11 @@ export const defaultAvatarColors: Record<AvatarColor, string> = {
  * dark mode.
  */
 export const defaultAvatarHoverColors: Record<AvatarColor, string> = {
-  teal: "var(--color-bg-avatar-teal-hover)",
-  coral: "var(--color-bg-avatar-coral-hover)",
-  brand: "var(--color-bg-avatar-brand-hover)",
-  green: "var(--color-bg-avatar-green-hover)",
-  purple: "var(--color-bg-avatar-purple-hover)",
+  teal: "#006278",
+  coral: "#a81400",
+  brand: "#0d43af",
+  green: "#016630",
+  purple: "#6e11b0",
 };
 
 // Typeguard to check if a given color is an AvatarColor

--- a/libs/components/src/avatar/avatar.stories.ts
+++ b/libs/components/src/avatar/avatar.stories.ts
@@ -122,12 +122,21 @@ export const DefaultColors: Story = {
         </div>
 
         <span class="tw-font-bold">Interactive</span>
-        <div class="tw-flex tw-gap-2">
+        <div class="tw-flex tw-gap-2 tw-mb-10">
           <button bit-avatar [color]="'brand'" [text]="'Walt Walterson'"></button>
           <button bit-avatar [color]="'teal'" [text]="'Walt Walterson'"></button>
           <button bit-avatar [color]="'coral'" [text]="'Walt Walterson'"></button>
           <button bit-avatar [color]="'green'" [text]="'Walt Walterson'"></button>
           <button bit-avatar [color]="'purple'" [text]="'Walt Walterson'"></button>
+        </div>
+
+        <span class="tw-font-bold">Interactive (Defaults as Hexes)</span>
+        <div class="tw-flex tw-gap-2">
+          <button bit-avatar [color]="'#175ddc'" [text]="'Walt Walterson'"></button>
+          <button bit-avatar [color]="'#007c95'" [text]="'Walt Walterson'"></button>
+          <button bit-avatar [color]="'#c71800'" [text]="'Walt Walterson'"></button>
+          <button bit-avatar [color]="'#008236'" [text]="'Walt Walterson'"></button>
+          <button bit-avatar [color]="'#8200db'" [text]="'Walt Walterson'"></button>
         </div>
       `,
     };


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[PM-35187](https://bitwarden.atlassian.net/browse/PM-35187)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
#18975 changed how the default avatar colors are stored, in order to take advantage of theme variables for light and dark mode. Instead of using hexes, it switched to color strings like `brand` for the defaults. The new strings were handled on web but not on the mobile clients, which also use the avatar colors and are expecting hexes.

This PR reverts back to using hexes for the default colors. This is meant to be a quick fix that supports both hexes and the color strings on web (for anyone who has already switched to them on web) and treats the default color hexes as "custom" colors while we work on a follow-up larger fix to adjust the overall approach while keeping theming differences.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

After fix, web app now stores hex for default color choice:
 

https://github.com/user-attachments/assets/5f72ee78-ea43-40f0-9445-e6626fccbcce


[PM-35187]: https://bitwarden.atlassian.net/browse/PM-35187?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ