### PR TITLE
[PM-32833] Remove Input Password Flag from SetInitialPasswordComponent

### DIFF
--- a/apps/desktop/src/app/services/set-initial-password/desktop-set-initial-password.service.spec.ts
+++ b/apps/desktop/src/app/services/set-initial-password/desktop-set-initial-password.service.spec.ts
@@ -90,8 +90,7 @@ describe("DesktopSetInitialPasswordService", () => {
   });
 
   /**
-   * @deprecated To be removed in PM-28143. When you remove this, check also if there are any imports/properties
-   * in the test setup above that are now un-used and can also be removed.
+   * @deprecated use `initializePasswordJitPasswordUserV2Encryption()` instead
    */
   describe("setInitialPassword(...)", () => {
     // Mock function parameters

--- a/apps/desktop/src/app/services/set-initial-password/desktop-set-initial-password.service.ts
+++ b/apps/desktop/src/app/services/set-initial-password/desktop-set-initial-password.service.ts
@@ -57,9 +57,6 @@ export class DesktopSetInitialPasswordService
 
   /**
    * @deprecated use `initializePasswordJitPasswordUserV2Encryption()` instead
-   *
-   * When you remove this, check also if there are any imports/properties
-   * in the test setup above that are now un-used and can also be removed.
    */
   override async setInitialPassword(
     credentials: SetInitialPasswordCredentials,

--- a/apps/desktop/src/app/services/set-initial-password/desktop-set-initial-password.service.ts
+++ b/apps/desktop/src/app/services/set-initial-password/desktop-set-initial-password.service.ts
@@ -56,7 +56,10 @@ export class DesktopSetInitialPasswordService
   }
 
   /**
-   * @deprecated To be removed in PM-28143
+   * @deprecated use `initializePasswordJitPasswordUserV2Encryption()` instead
+   *
+   * When you remove this, check also if there are any imports/properties
+   * in the test setup above that are now un-used and can also be removed.
    */
   override async setInitialPassword(
     credentials: SetInitialPasswordCredentials,

--- a/apps/web/src/app/auth/core/services/password-management/set-initial-password/web-set-initial-password.service.spec.ts
+++ b/apps/web/src/app/auth/core/services/password-management/set-initial-password/web-set-initial-password.service.spec.ts
@@ -90,8 +90,7 @@ describe("WebSetInitialPasswordService", () => {
   });
 
   /**
-   * @deprecated To be removed in PM-28143. When you remove this, check also if there are any imports/properties
-   * in the test setup above that are now un-used and can also be removed.
+   * @deprecated use `setInitialPasswordJitMPUserV2Encryption()` instead
    */
   describe("setInitialPassword(...)", () => {
     // Mock function parameters

--- a/apps/web/src/app/auth/core/services/password-management/set-initial-password/web-set-initial-password.service.spec.ts
+++ b/apps/web/src/app/auth/core/services/password-management/set-initial-password/web-set-initial-password.service.spec.ts
@@ -90,7 +90,10 @@ describe("WebSetInitialPasswordService", () => {
   });
 
   /**
-   * @deprecated use `setInitialPasswordJitMPUserV2Encryption()` instead
+   * @deprecated use `initializePasswordJitPasswordUserV2Encryption()` instead
+   *
+   * When you remove this, check also if there are any imports/properties
+   * in the test setup above that are now un-used and can also be removed.
    */
   describe("setInitialPassword(...)", () => {
     // Mock function parameters

--- a/apps/web/src/app/auth/core/services/password-management/set-initial-password/web-set-initial-password.service.ts
+++ b/apps/web/src/app/auth/core/services/password-management/set-initial-password/web-set-initial-password.service.ts
@@ -57,7 +57,7 @@ export class WebSetInitialPasswordService
   }
 
   /**
-   * @deprecated To be removed in PM-28143
+   * @deprecated use `setInitialPasswordJitMPUserV2Encryption()` instead
    */
   override async setInitialPassword(
     credentials: SetInitialPasswordCredentials,

--- a/apps/web/src/app/auth/core/services/password-management/set-initial-password/web-set-initial-password.service.ts
+++ b/apps/web/src/app/auth/core/services/password-management/set-initial-password/web-set-initial-password.service.ts
@@ -57,7 +57,7 @@ export class WebSetInitialPasswordService
   }
 
   /**
-   * @deprecated use `setInitialPasswordJitMPUserV2Encryption()` instead
+   * @deprecated use `initializePasswordJitPasswordUserV2Encryption()` instead
    */
   override async setInitialPassword(
     credentials: SetInitialPasswordCredentials,

--- a/libs/angular/src/auth/password-management/set-initial-password/default-set-initial-password.service.implementation.ts
+++ b/libs/angular/src/auth/password-management/set-initial-password/default-set-initial-password.service.implementation.ts
@@ -46,7 +46,6 @@ import {
   SetInitialPasswordCredentials,
   SetInitialPasswordService,
   SetInitialPasswordUserType,
-  SetInitialPasswordTdeOffboardingCredentialsOld,
   SetInitialPasswordTdeOffboardingCredentials,
   SetInitialPasswordTdeUserWithPermissionCredentials,
 } from "./set-initial-password.service.abstraction";
@@ -261,49 +260,6 @@ export class DefaultSetInitialPasswordService implements SetInitialPasswordServi
     await this.masterPasswordApiService.putUpdateTdeOffboardingPassword(request);
 
     // TODO: investigate removing this call to clear forceSetPasswordReason in https://bitwarden.atlassian.net/browse/PM-32660
-    // Clear force set password reason to allow navigation back to vault.
-    await this.masterPasswordService.setForceSetPasswordReason(ForceSetPasswordReason.None, userId);
-  }
-
-  /**
-   * @deprecated To be removed in PM-28143
-   */
-  async setInitialPasswordTdeOffboardingOld(
-    credentials: SetInitialPasswordTdeOffboardingCredentialsOld,
-    userId: UserId,
-  ) {
-    const { newMasterKey, newServerMasterKeyHash, newPasswordHint } = credentials;
-    for (const [key, value] of Object.entries(credentials)) {
-      if (value == null) {
-        throw new Error(`${key} not found. Could not set password.`);
-      }
-    }
-
-    if (userId == null) {
-      throw new Error("userId not found. Could not set password.");
-    }
-
-    const userKey = await firstValueFrom(this.keyService.userKey$(userId));
-    if (userKey == null) {
-      throw new Error("userKey not found. Could not set password.");
-    }
-
-    const newMasterKeyEncryptedUserKey = await this.keyService.encryptUserKeyWithMasterKey(
-      newMasterKey,
-      userKey,
-    );
-
-    if (!newMasterKeyEncryptedUserKey[1].encryptedString) {
-      throw new Error("newMasterKeyEncryptedUserKey not found. Could not set password.");
-    }
-
-    const request = new UpdateTdeOffboardingPasswordRequest();
-    request.key = newMasterKeyEncryptedUserKey[1].encryptedString;
-    request.newMasterPasswordHash = newServerMasterKeyHash;
-    request.masterPasswordHint = newPasswordHint;
-
-    await this.masterPasswordApiService.putUpdateTdeOffboardingPassword(request);
-
     // Clear force set password reason to allow navigation back to vault.
     await this.masterPasswordService.setForceSetPasswordReason(ForceSetPasswordReason.None, userId);
   }

--- a/libs/angular/src/auth/password-management/set-initial-password/default-set-initial-password.service.implementation.ts
+++ b/libs/angular/src/auth/password-management/set-initial-password/default-set-initial-password.service.implementation.ts
@@ -67,8 +67,7 @@ export class DefaultSetInitialPasswordService implements SetInitialPasswordServi
   ) {}
 
   /**
-   * @deprecated To be removed in PM-28143. When you remove this, also check for any objects/methods
-   * in this default service that are now un-used and can also be removed.
+   * @deprecated use `setInitialPasswordJitMPUserV2Encryption()` instead
    */
   async setInitialPassword(
     credentials: SetInitialPasswordCredentials,
@@ -425,7 +424,7 @@ export class DefaultSetInitialPasswordService implements SetInitialPasswordServi
   }
 
   /**
-   * @deprecated To be removed in PM-28143
+   * @deprecated along with `setInitialPassword()` deprecation
    */
   private async makeMasterKeyEncryptedUserKey(
     masterKey: MasterKey,
@@ -447,6 +446,9 @@ export class DefaultSetInitialPasswordService implements SetInitialPasswordServi
     return masterKeyEncryptedUserKey;
   }
 
+  /**
+   * @deprecated along with `setInitialPassword()` deprecation
+   */
   private async updateAccountDecryptionProperties(
     masterKey: MasterKey,
     kdfConfig: KdfConfig,
@@ -504,7 +506,7 @@ export class DefaultSetInitialPasswordService implements SetInitialPasswordServi
   }
 
   /**
-   * @deprecated To be removed in PM-28143
+   * @deprecated along with `setInitialPassword()` deprecation
    *
    * As part of [PM-28494], adding this setting path to accommodate the changes that are
    * emerging with pm-23246-unlock-with-master-password-unlock-data.
@@ -530,7 +532,7 @@ export class DefaultSetInitialPasswordService implements SetInitialPasswordServi
   }
 
   /**
-   * @deprecated To be removed in PM-28143
+   * @deprecated
    *
    * This method is now deprecated because it is used with the deprecated `setInitialPassword()` method,
    * which handles both JIT MP and TDE + Permission user flows.

--- a/libs/angular/src/auth/password-management/set-initial-password/default-set-initial-password.service.implementation.ts
+++ b/libs/angular/src/auth/password-management/set-initial-password/default-set-initial-password.service.implementation.ts
@@ -67,7 +67,7 @@ export class DefaultSetInitialPasswordService implements SetInitialPasswordServi
   ) {}
 
   /**
-   * @deprecated use `setInitialPasswordJitMPUserV2Encryption()` instead
+   * @deprecated use `initializePasswordJitPasswordUserV2Encryption()` instead
    */
   async setInitialPassword(
     credentials: SetInitialPasswordCredentials,

--- a/libs/angular/src/auth/password-management/set-initial-password/default-set-initial-password.service.spec.ts
+++ b/libs/angular/src/auth/password-management/set-initial-password/default-set-initial-password.service.spec.ts
@@ -127,6 +127,12 @@ describe("DefaultSetInitialPasswordService", () => {
     expect(sut).not.toBeFalsy();
   });
 
+  /**
+   * @deprecated use `initializePasswordJitPasswordUserV2Encryption()` instead
+   *
+   * When you remove this, check also if there are any imports/properties
+   * in the test setup above that are now un-used and can also be removed.
+   */
   describe("setInitialPassword(...)", () => {
     // Mock function parameters
     let credentials: SetInitialPasswordCredentials;

--- a/libs/angular/src/auth/password-management/set-initial-password/default-set-initial-password.service.spec.ts
+++ b/libs/angular/src/auth/password-management/set-initial-password/default-set-initial-password.service.spec.ts
@@ -127,10 +127,6 @@ describe("DefaultSetInitialPasswordService", () => {
     expect(sut).not.toBeFalsy();
   });
 
-  /**
-   * @deprecated To be removed in PM-28143. When you remove this, check also if there are any imports/properties
-   * in the test setup above that are now un-used and can also be removed.
-   */
   describe("setInitialPassword(...)", () => {
     // Mock function parameters
     let credentials: SetInitialPasswordCredentials;

--- a/libs/angular/src/auth/password-management/set-initial-password/default-set-initial-password.service.spec.ts
+++ b/libs/angular/src/auth/password-management/set-initial-password/default-set-initial-password.service.spec.ts
@@ -1386,7 +1386,7 @@ describe("DefaultSetInitialPasswordService", () => {
 
         it("should throw if orgPublicKeyEncryptedUserKey.encryptedString is not found", async () => {
           // Arrange
-          orgPublicKeyEncryptedUserKey.encryptedString = null as unknown as EncryptedString;
+          orgPublicKeyEncryptedUserKey.encryptedString = null as unknown as any;
 
           // Act
           const promise = sut.setInitialPasswordTdeUserWithPermission(credentials, userId);

--- a/libs/angular/src/auth/password-management/set-initial-password/default-set-initial-password.service.spec.ts
+++ b/libs/angular/src/auth/password-management/set-initial-password/default-set-initial-password.service.spec.ts
@@ -64,7 +64,6 @@ import {
   SetInitialPasswordCredentials,
   SetInitialPasswordService,
   SetInitialPasswordTdeOffboardingCredentials,
-  SetInitialPasswordTdeOffboardingCredentialsOld,
   SetInitialPasswordTdeUserWithPermissionCredentials,
   SetInitialPasswordUserType,
 } from "./set-initial-password.service.abstraction";
@@ -830,7 +829,7 @@ describe("DefaultSetInitialPasswordService", () => {
 
       it(`should throw if the userId was not passed in`, async () => {
         // Arrange
-        userId = null;
+        userId = null as unknown as UserId;
 
         // Act
         const promise = sut.setInitialPasswordTdeOffboarding(credentials, userId);
@@ -890,120 +889,6 @@ describe("DefaultSetInitialPasswordService", () => {
         ForceSetPasswordReason.None,
         userId,
       );
-    });
-  });
-
-  /**
-   * @deprecated To be removed in PM-28143. When you remove this, check also if there are any imports/properties
-   * in the test setup above that are now un-used and can also be removed.
-   */
-  describe("setInitialPasswordTdeOffboardingOld(...)", () => {
-    // Mock function parameters
-    let credentials: SetInitialPasswordTdeOffboardingCredentialsOld;
-
-    beforeEach(() => {
-      // Mock function parameters
-      credentials = {
-        newMasterKey: new SymmetricCryptoKey(new Uint8Array(32)) as MasterKey,
-        newServerMasterKeyHash: "newServerMasterKeyHash",
-        newPasswordHint: "newPasswordHint",
-      };
-    });
-
-    function setupTdeOffboardingMocks() {
-      keyService.userKey$.mockReturnValue(of(userKey));
-      keyService.encryptUserKeyWithMasterKey.mockResolvedValue(masterKeyEncryptedUserKey);
-    }
-
-    it("should successfully set an initial password for the TDE offboarding user", async () => {
-      // Arrange
-      setupTdeOffboardingMocks();
-
-      const request = new UpdateTdeOffboardingPasswordRequest();
-      request.key = masterKeyEncryptedUserKey[1].encryptedString;
-      request.newMasterPasswordHash = credentials.newServerMasterKeyHash;
-      request.masterPasswordHint = credentials.newPasswordHint;
-
-      // Act
-      await sut.setInitialPasswordTdeOffboardingOld(credentials, userId);
-
-      // Assert
-      expect(masterPasswordApiService.putUpdateTdeOffboardingPassword).toHaveBeenCalledTimes(1);
-      expect(masterPasswordApiService.putUpdateTdeOffboardingPassword).toHaveBeenCalledWith(
-        request,
-      );
-    });
-
-    describe("given the initial password has been successfully set", () => {
-      it("should clear the ForceSetPasswordReason by setting it to None", async () => {
-        // Arrange
-        setupTdeOffboardingMocks();
-
-        // Act
-        await sut.setInitialPasswordTdeOffboardingOld(credentials, userId);
-
-        // Assert
-        expect(masterPasswordApiService.putUpdateTdeOffboardingPassword).toHaveBeenCalledTimes(1);
-        expect(masterPasswordService.setForceSetPasswordReason).toHaveBeenCalledWith(
-          ForceSetPasswordReason.None,
-          userId,
-        );
-      });
-    });
-
-    describe("general error handling", () => {
-      ["newMasterKey", "newServerMasterKeyHash", "newPasswordHint"].forEach((key) => {
-        it(`should throw if ${key} is not provided on the SetInitialPasswordTdeOffboardingCredentials object`, async () => {
-          // Arrange
-          const invalidCredentials: SetInitialPasswordTdeOffboardingCredentialsOld = {
-            ...credentials,
-            [key]: null,
-          };
-
-          // Act
-          const promise = sut.setInitialPasswordTdeOffboardingOld(invalidCredentials, userId);
-
-          // Assert
-          await expect(promise).rejects.toThrow(`${key} not found. Could not set password.`);
-        });
-      });
-
-      it(`should throw if the userId was not passed in`, async () => {
-        // Arrange
-        userId = null;
-
-        // Act
-        const promise = sut.setInitialPasswordTdeOffboardingOld(credentials, userId);
-
-        // Assert
-        await expect(promise).rejects.toThrow("userId not found. Could not set password.");
-      });
-
-      it(`should throw if the userKey was not found`, async () => {
-        // Arrange
-        keyService.userKey$.mockReturnValue(of(null));
-
-        // Act
-        const promise = sut.setInitialPasswordTdeOffboardingOld(credentials, userId);
-
-        // Assert
-        await expect(promise).rejects.toThrow("userKey not found. Could not set password.");
-      });
-
-      it(`should throw if a newMasterKeyEncryptedUserKey was not returned`, async () => {
-        // Arrange
-        masterKeyEncryptedUserKey[1].encryptedString = "" as EncryptedString;
-
-        setupTdeOffboardingMocks();
-
-        // Act
-        const promise = sut.setInitialPasswordTdeOffboardingOld(credentials, userId);
-
-        // Assert
-        await expect(promise).rejects.toThrow(
-          "newMasterKeyEncryptedUserKey not found. Could not set password.",
-        );
-      });
     });
   });
 
@@ -1345,7 +1230,7 @@ describe("DefaultSetInitialPasswordService", () => {
 
       it("should throw if userId is not given", async () => {
         // Arrange
-        userId = null;
+        userId = null as unknown as UserId;
 
         // Act
         const promise = sut.setInitialPasswordTdeUserWithPermission(credentials, userId);
@@ -1472,12 +1357,14 @@ describe("DefaultSetInitialPasswordService", () => {
           enrollmentRequest = new OrganizationUserResetPasswordEnrollmentRequest();
           enrollmentRequest.masterPasswordHash =
             authenticationData.masterPasswordAuthenticationHash;
-          enrollmentRequest.resetPasswordKey = orgPublicKeyEncryptedUserKey.encryptedString;
+          enrollmentRequest.resetPasswordKey = orgPublicKeyEncryptedUserKey.encryptedString!;
         });
 
         it("should throw if organization keys are not found", async () => {
           // Arrange
-          organizationApiService.getKeys.mockResolvedValue(null);
+          organizationApiService.getKeys.mockResolvedValue(
+            null as unknown as OrganizationKeysResponse,
+          );
 
           // Act
           const promise = sut.setInitialPasswordTdeUserWithPermission(credentials, userId);
@@ -1490,7 +1377,7 @@ describe("DefaultSetInitialPasswordService", () => {
 
         it("should throw if orgPublicKeyEncryptedUserKey is not found", async () => {
           // Arrange
-          encryptService.encapsulateKeyUnsigned.mockResolvedValue(null);
+          encryptService.encapsulateKeyUnsigned.mockResolvedValue(null as unknown as EncString);
 
           // Act
           const promise = sut.setInitialPasswordTdeUserWithPermission(credentials, userId);
@@ -1503,7 +1390,7 @@ describe("DefaultSetInitialPasswordService", () => {
 
         it("should throw if orgPublicKeyEncryptedUserKey.encryptedString is not found", async () => {
           // Arrange
-          orgPublicKeyEncryptedUserKey.encryptedString = null;
+          orgPublicKeyEncryptedUserKey.encryptedString = null as unknown as EncryptedString;
 
           // Act
           const promise = sut.setInitialPasswordTdeUserWithPermission(credentials, userId);

--- a/libs/angular/src/auth/password-management/set-initial-password/set-initial-password.component.ts
+++ b/libs/angular/src/auth/password-management/set-initial-password/set-initial-password.component.ts
@@ -311,7 +311,7 @@ export class SetInitialPasswordComponent implements OnInit {
   }
 
   /**
-   * @deprecated To be removed in PM-28143
+   * @deprecated use `setInitialPasswordJitMPUserV2Encryption()` instead
    */
   private async setInitialPassword(passwordInputResult: PasswordInputResult) {
     const ctx = "Could not set initial password.";

--- a/libs/angular/src/auth/password-management/set-initial-password/set-initial-password.component.ts
+++ b/libs/angular/src/auth/password-management/set-initial-password/set-initial-password.component.ts
@@ -47,7 +47,6 @@ import {
   SetInitialPasswordCredentials,
   SetInitialPasswordService,
   SetInitialPasswordTdeOffboardingCredentials,
-  SetInitialPasswordTdeOffboardingCredentialsOld,
   SetInitialPasswordTdeUserWithPermissionCredentials,
   SetInitialPasswordUserType,
 } from "./set-initial-password.service.abstraction";
@@ -184,22 +183,10 @@ export class SetInitialPasswordComponent implements OnInit {
         break;
       }
       case SetInitialPasswordUserType.TDE_ORG_USER_RESET_PASSWORD_PERMISSION_REQUIRES_MP:
-        if (passwordInputResult.newApisWithInputPasswordFlagEnabled) {
-          await this.setInitialPasswordTdeUserWithPermission(passwordInputResult);
-          return; // EARLY RETURN for flagged logic
-        }
-
-        await this.setInitialPassword(passwordInputResult);
-
+        await this.setInitialPasswordTdeUserWithPermission(passwordInputResult);
         break;
       case SetInitialPasswordUserType.OFFBOARDED_TDE_ORG_USER:
-        if (passwordInputResult.newApisWithInputPasswordFlagEnabled) {
-          await this.setInitialPasswordTdeOffboarding(passwordInputResult);
-          return;
-        }
-
-        await this.setInitialPasswordTdeOffboardingOld(passwordInputResult);
-
+        await this.setInitialPasswordTdeOffboarding(passwordInputResult);
         break;
       default:
         this.logService.error(
@@ -457,41 +444,6 @@ export class SetInitialPasswordComponent implements OnInit {
       this.showSuccessToastByUserType();
 
       // TODO: investigate refactoring logout and follow-up routing in https://bitwarden.atlassian.net/browse/PM-32660
-      await this.logoutService.logout(this.userId);
-      // navigate to root so redirect guard can properly route next active user or null user to correct page
-      await this.router.navigate(["/"]);
-    } catch (e) {
-      this.logService.error("Error setting initial password during TDE offboarding", e);
-      this.validationService.showError(e);
-    } finally {
-      this.submitting = false;
-    }
-  }
-
-  /**
-   * @deprecated To be removed in PM-28143
-   */
-  private async setInitialPasswordTdeOffboardingOld(passwordInputResult: PasswordInputResult) {
-    const ctx = "Could not set initial password.";
-    assertTruthy(passwordInputResult.newMasterKey, "newMasterKey", ctx);
-    assertTruthy(passwordInputResult.newServerMasterKeyHash, "newServerMasterKeyHash", ctx);
-    assertTruthy(this.userId, "userId", ctx);
-    assertNonNullish(passwordInputResult.newPasswordHint, "newPasswordHint", ctx); // can have an empty string as a valid value, so check non-nullish
-
-    try {
-      const credentials: SetInitialPasswordTdeOffboardingCredentialsOld = {
-        newMasterKey: passwordInputResult.newMasterKey,
-        newServerMasterKeyHash: passwordInputResult.newServerMasterKeyHash,
-        newPasswordHint: passwordInputResult.newPasswordHint,
-      };
-
-      await this.setInitialPasswordService.setInitialPasswordTdeOffboardingOld(
-        credentials,
-        this.userId,
-      );
-
-      this.showSuccessToastByUserType();
-
       await this.logoutService.logout(this.userId);
       // navigate to root so redirect guard can properly route next active user or null user to correct page
       await this.router.navigate(["/"]);

--- a/libs/angular/src/auth/password-management/set-initial-password/set-initial-password.component.ts
+++ b/libs/angular/src/auth/password-management/set-initial-password/set-initial-password.component.ts
@@ -121,65 +121,42 @@ export class SetInitialPasswordComponent implements OnInit {
 
     switch (this.userType) {
       case SetInitialPasswordUserType.JIT_PROVISIONED_MP_ORG_USER: {
-        /**
-         * "KM flag"   = EnableAccountEncryptionV2JitPasswordRegistration
-         * "Auth flag" = PM27086_UpdateAuthenticationApisForInputPassword (checked in InputPasswordComponent and
-         *                                                                 passed through via PasswordInputResult)
-         *
-         * Flag unwinding for this specific `case` will depend on which flag gets unwound first:
-         * - If KM flag gets unwound first, remove all code (in this `case`) after the call
-         *   to setInitialPasswordJitMPUserV2Encryption(), as the V2Encryption method is the
-         *   end-goal for this `case`.
-         * - If Auth flag gets unwound first (in PM-28143), keep the KM code & early return,
-         *   but unwind the auth flagging logic and then remove the method call marked with
-         *   the "Default Scenario" comment.
-         */
-
         const accountEncryptionV2 = await this.configService.getFeatureFlag(
           FeatureFlag.EnableAccountEncryptionV2JitPasswordRegistration,
         );
 
-        // Scenario 1: KM flag ON
         if (accountEncryptionV2) {
           await this.setInitialPasswordJitMPUserV2Encryption(passwordInputResult);
           return;
         }
 
-        // Scenario 2: KM flag OFF, Auth flag ON
-        if (passwordInputResult.newApisWithInputPasswordFlagEnabled) {
-          /**
-           * If the Auth flag is enabled, it means the InputPasswordComponent will not emit a newMasterKey,
-           * newServerMasterKeyHash. So we must create them here and add them late
-           * to the PasswordInputResult before calling setInitialPassword().
-           *
-           * This is a temporary state. The end-goal will be to use KM's V2Encryption method above.
-           */
-          const ctx = "Could not set initial password.";
-          assertTruthy(passwordInputResult.newPassword, "newPassword", ctx);
-          assertNonNullish(passwordInputResult.kdfConfig, "kdfConfig", ctx);
-          assertTruthy(this.email, "email", ctx);
+        /**
+         * Assuming the KM flag above is off, this JIT_PROVISIONED_MP_ORG_USER case still relies on us making
+         * `newMasterKey` and `newServerMasterKeyHash` here in the component. This is a temporary state. This
+         * flow will be updated to use the new `MasterPasswordAuthenticationData` and `MasterPasswordUnlockData`
+         * as part of https://bitwarden.atlassian.net/browse/PM-32526
+         */
 
-          const newMasterKey = await this.keyService.makeMasterKey(
-            passwordInputResult.newPassword,
-            this.email.trim().toLowerCase(),
-            passwordInputResult.kdfConfig,
-          );
+        const ctx = "Could not set initial password.";
+        assertTruthy(passwordInputResult.newPassword, "newPassword", ctx);
+        assertNonNullish(passwordInputResult.kdfConfig, "kdfConfig", ctx);
+        assertTruthy(this.email, "email", ctx);
 
-          const newServerMasterKeyHash = await this.keyService.hashMasterKey(
-            passwordInputResult.newPassword,
-            newMasterKey,
-          );
+        const newMasterKey = await this.keyService.makeMasterKey(
+          passwordInputResult.newPassword,
+          this.email.trim().toLowerCase(),
+          passwordInputResult.kdfConfig,
+        );
 
-          passwordInputResult.newMasterKey = newMasterKey;
-          passwordInputResult.newServerMasterKeyHash = newServerMasterKeyHash;
+        const newServerMasterKeyHash = await this.keyService.hashMasterKey(
+          passwordInputResult.newPassword,
+          newMasterKey,
+        );
 
-          await this.setInitialPassword(passwordInputResult); // passwordInputResult masterKey properties generated on the SetInitialPasswordComponent (just above)
-          return;
-        }
+        passwordInputResult.newMasterKey = newMasterKey;
+        passwordInputResult.newServerMasterKeyHash = newServerMasterKeyHash;
 
-        // Default Scenario: both flags OFF
-        await this.setInitialPassword(passwordInputResult); // passwordInputResult masterKey properties generated on the InputPasswordComponent (default)
-
+        await this.setInitialPassword(passwordInputResult);
         break;
       }
       case SetInitialPasswordUserType.TDE_ORG_USER_RESET_PASSWORD_PERMISSION_REQUIRES_MP:

--- a/libs/angular/src/auth/password-management/set-initial-password/set-initial-password.service.abstraction.ts
+++ b/libs/angular/src/auth/password-management/set-initial-password/set-initial-password.service.abstraction.ts
@@ -97,7 +97,7 @@ export interface InitializeJitPasswordCredentials {
  */
 export abstract class SetInitialPasswordService {
   /**
-   * @deprecated use `setInitialPasswordJitMPUserV2Encryption()` instead
+   * @deprecated use `initializePasswordJitPasswordUserV2Encryption()` instead
    *
    * Sets an initial password for an existing authed user who is either:
    * - {@link SetInitialPasswordUserType.JIT_PROVISIONED_MP_ORG_USER}

--- a/libs/angular/src/auth/password-management/set-initial-password/set-initial-password.service.abstraction.ts
+++ b/libs/angular/src/auth/password-management/set-initial-password/set-initial-password.service.abstraction.ts
@@ -97,7 +97,7 @@ export interface InitializeJitPasswordCredentials {
  */
 export abstract class SetInitialPasswordService {
   /**
-   * @deprecated To be removed in PM-28143
+   * @deprecated use `setInitialPasswordJitMPUserV2Encryption()` instead
    *
    * Sets an initial password for an existing authed user who is either:
    * - {@link SetInitialPasswordUserType.JIT_PROVISIONED_MP_ORG_USER}

--- a/libs/angular/src/auth/password-management/set-initial-password/set-initial-password.service.abstraction.ts
+++ b/libs/angular/src/auth/password-management/set-initial-password/set-initial-password.service.abstraction.ts
@@ -64,15 +64,6 @@ export interface SetInitialPasswordTdeUserWithPermissionCredentials {
   resetPasswordAutoEnroll: boolean;
 }
 
-/**
- * @deprecated To be removed in PM-28143
- */
-export interface SetInitialPasswordTdeOffboardingCredentialsOld {
-  newMasterKey: MasterKey;
-  newServerMasterKeyHash: string;
-  newPasswordHint: string;
-}
-
 export interface SetInitialPasswordTdeOffboardingCredentials {
   newPassword: string;
   salt: MasterPasswordSalt;
@@ -132,21 +123,6 @@ export abstract class SetInitialPasswordService {
    */
   abstract setInitialPasswordTdeUserWithPermission: (
     credentials: SetInitialPasswordTdeUserWithPermissionCredentials,
-    userId: UserId,
-  ) => Promise<void>;
-
-  /**
-   * @deprecated To be removed in PM-28143
-   *
-   * Sets an initial password for a user who logs in after their org offboarded from
-   * trusted device encryption and is now a master-password-encryption org:
-   * - {@link SetInitialPasswordUserType.OFFBOARDED_TDE_ORG_USER}
-   *
-   * @param passwordInputResult credentials object received from the `InputPasswordComponent`
-   * @param userId the account `userId`
-   */
-  abstract setInitialPasswordTdeOffboardingOld: (
-    credentials: SetInitialPasswordTdeOffboardingCredentialsOld,
     userId: UserId,
   ) => Promise<void>;
 

--- a/libs/angular/src/auth/password-management/set-initial-password/set-initial-password.service.abstraction.ts
+++ b/libs/angular/src/auth/password-management/set-initial-password/set-initial-password.service.abstraction.ts
@@ -42,6 +42,9 @@ export const SetInitialPasswordUserType: Readonly<{
   [K in keyof typeof _SetInitialPasswordUserType]: SetInitialPasswordUserType;
 }> = Object.freeze(_SetInitialPasswordUserType);
 
+/**
+ * @deprecated along with `setInitialPassword()` deprecation
+ */
 export interface SetInitialPasswordCredentials {
   newMasterKey: MasterKey;
   newServerMasterKeyHash: string;

--- a/libs/auth/src/angular/input-password/password-input-result.ts
+++ b/libs/auth/src/angular/input-password/password-input-result.ts
@@ -29,8 +29,16 @@ export interface PasswordInputResult {
   /** @deprecated */
   currentServerMasterKeyHash?: string;
 
-  /** @deprecated */
+  /**
+   * @deprecated Still required by the JIT_PROVISIONED_MP_ORG_USER flow in SetInitialPasswordComponent.
+   * Will be removed when that flow is updated to use MasterPasswordAuthenticationData and
+   * MasterPasswordUnlockData as part of https://bitwarden.atlassian.net/browse/PM-32526
+   */
   newMasterKey?: MasterKey;
-  /** @deprecated */
+  /**
+   * @deprecated Still required by the JIT_PROVISIONED_MP_ORG_USER flow in SetInitialPasswordComponent.
+   * Will be removed when that flow is updated to use MasterPasswordAuthenticationData and
+   * MasterPasswordUnlockData as part of https://bitwarden.atlassian.net/browse/PM-32526
+   */
   newServerMasterKeyHash?: string;
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-32833](https://bitwarden.atlassian.net/browse/PM-32833)

## 📔 Objective

This PR removes `pm-27086-update-authentication-apis-for-input-password` feature flag usage from the `SetInitialPasswordComponent` and related files.

<br />

> [!NOTE]
> This PR is part of a larger group of PRs (split up for easier review) that will each get merged into a base branch for this flag removal work: `auth/pm-32833/remove-input-password-flag-base`. That base branch is the one that will get merged to `main`.
>
> Breakdown of branching structure:
> ```
> main
>  └── auth/pm-32833/remove-input-password-flag-base  ← targets main; accumulates sub-PRs
>      ├── auth/pm-32833/registration-finish            ← targets base
>      ├── auth/pm-32833/set-initial-password           ← targets base [THIS PR 🟢]
>      ├── auth/pm-32833/change-password                ← targets base
>      ├── auth/pm-32833/emergency-access               ← targets base
>      ├── auth/pm-32833/account-recovery               ← targets base
>      └── auth/pm-32833/input-password-component       ← targets base; reviewed LAST
> ```

[PM-32833]: https://bitwarden.atlassian.net/browse/PM-32833?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ