### PR TITLE
feat(survey): [PM-35243] Update cancel survey options for Teams and Enterprise

### DIFF
--- a/apps/web/src/app/billing/organizations/organization-subscription-cloud.component.ts
+++ b/apps/web/src/app/billing/organizations/organization-subscription-cloud.component.ts
@@ -345,6 +345,7 @@ export class OrganizationSubscriptionCloudComponent implements OnInit, OnDestroy
         type: "Organization",
         id: this.organizationId,
         plan: this.sub.plan.type,
+        productTier: this.sub.plan.productTier,
       },
     });
 

--- a/apps/web/src/app/billing/shared/offboarding-survey.component.html
+++ b/apps/web/src/app/billing/shared/offboarding-survey.component.html
@@ -5,16 +5,32 @@
     </span>
     <div bitDialogContent>
       <p>{{ "sorryToSeeYouGo" | i18n }}</p>
-      <bit-form-field>
-        <bit-label>
-          {{ "selectCancellationReason" | i18n }}
-        </bit-label>
-        <select bitInput formControlName="reason">
-          <option *ngFor="let reason of reasons" [ngValue]="reason.value">
-            {{ reason.text }}
-          </option>
-        </select>
-      </bit-form-field>
+      @if (isBusiness) {
+        <bit-radio-group formControlName="reason" [block]="true">
+          <bit-label>
+            {{ "selectCancellationReason" | i18n }}
+          </bit-label>
+          @for (reason of businessReasons; track reason.value) {
+            <bit-radio-button [value]="reason.value">
+              <bit-label>{{ reason.labelKey | i18n }}</bit-label>
+              @if (reason.hintKey) {
+                <bit-hint>{{ reason.hintKey | i18n }}</bit-hint>
+              }
+            </bit-radio-button>
+          }
+        </bit-radio-group>
+      } @else {
+        <bit-form-field>
+          <bit-label>
+            {{ "selectCancellationReason" | i18n }}
+          </bit-label>
+          <select bitInput formControlName="reason">
+            <option *ngFor="let reason of reasons" [ngValue]="reason.value">
+              {{ reason.text }}
+            </option>
+          </select>
+        </bit-form-field>
+      }
       <bit-form-field>
         <bit-label>
           {{ "anyOtherFeedback" | i18n }}

--- a/apps/web/src/app/billing/shared/offboarding-survey.component.ts
+++ b/apps/web/src/app/billing/shared/offboarding-survey.component.ts
@@ -7,6 +7,7 @@ import { FormBuilder, Validators } from "@angular/forms";
 
 import { BillingApiServiceAbstraction as BillingApiService } from "@bitwarden/common/billing/abstractions/billing-api.service.abstraction";
 import { PlanType } from "@bitwarden/common/billing/enums";
+import { ProductTierType } from "@bitwarden/common/billing/enums/product-tier-type.enum";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import {
@@ -25,6 +26,7 @@ type OrganizationOffboardingParams = {
   type: "Organization";
   id: string;
   plan: PlanType;
+  productTier: ProductTierType;
 };
 
 export type OffboardingSurveyDialogParams = UserOffboardingParams | OrganizationOffboardingParams;
@@ -39,6 +41,12 @@ export enum OffboardingSurveyDialogResultType {
 type Reason = {
   value: string;
   text: string;
+};
+
+type BusinessReason = {
+  value: string;
+  labelKey: string;
+  hintKey: string | null;
 };
 
 export const openOffboardingSurvey = (
@@ -62,6 +70,41 @@ export class OffboardingSurveyComponent {
 
   protected readonly reasons: Reason[] = [];
 
+  protected readonly businessReasons: BusinessReason[] = [
+    {
+      value: "missing_features",
+      labelKey: "cancelSurveyMissingFeaturesLabel",
+      hintKey: "cancelSurveyMissingFeaturesHint",
+    },
+    {
+      value: "switched_service",
+      labelKey: "cancelSurveyTooComplexLabel",
+      hintKey: "cancelSurveyTooComplexHint",
+    },
+    {
+      value: "too_complex",
+      labelKey: "cancelSurveyNotEnoughValueLabel",
+      hintKey: "cancelSurveyNotEnoughValueHint",
+    },
+    {
+      value: "unused",
+      labelKey: "cancelSurveyNotEnoughUsageLabel",
+      hintKey: "cancelSurveyNotEnoughUsageHint",
+    },
+    {
+      value: "too_expensive",
+      labelKey: "cancelSurveyNeedsChangedLabel",
+      hintKey: "cancelSurveyNeedsChangedHint",
+    },
+    {
+      value: "other",
+      labelKey: "other",
+      hintKey: null,
+    },
+  ];
+
+  protected readonly isBusiness: boolean;
+
   protected formGroup = this.formBuilder.group({
     reason: [null, [Validators.required]],
     feedback: ["", [Validators.maxLength(this.MaxFeedbackLength)]],
@@ -76,6 +119,8 @@ export class OffboardingSurveyComponent {
     private platformUtilsService: PlatformUtilsService,
     private toastService: ToastService,
   ) {
+    this.isBusiness = this.isBusinessPlan();
+
     this.reasons = [
       {
         value: null,
@@ -129,6 +174,15 @@ export class OffboardingSurveyComponent {
 
     this.dialogRef.close(this.ResultType.Submitted);
   };
+
+  private isBusinessPlan(): boolean {
+    return (
+      this.dialogParams.type === "Organization" &&
+      [ProductTierType.Teams, ProductTierType.Enterprise, ProductTierType.TeamsStarter].includes(
+        this.dialogParams.productTier,
+      )
+    );
+  }
 
   private getSwitchingReason(): Reason {
     if (this.dialogParams.type === "User") {

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -10273,6 +10273,46 @@
     "message": "Switching to free organization",
     "description": "An option for the offboarding survey shown when a user cancels their subscription."
   },
+  "cancelSurveyMissingFeaturesLabel": {
+    "message": "Missing features or functionality",
+    "description": "Label for a cancel survey radio option shown when a Teams or Enterprise organization cancels their subscription."
+  },
+  "cancelSurveyMissingFeaturesHint": {
+    "message": "Something we needed wasn't available",
+    "description": "Hint for a cancel survey radio option shown when a Teams or Enterprise organization cancels their subscription."
+  },
+  "cancelSurveyTooComplexLabel": {
+    "message": "Too difficult to set up or manage",
+    "description": "Label for a cancel survey radio option shown when a Teams or Enterprise organization cancels their subscription."
+  },
+  "cancelSurveyTooComplexHint": {
+    "message": "Onboarding, admin, or day-to-day use was too complex",
+    "description": "Hint for a cancel survey radio option shown when a Teams or Enterprise organization cancels their subscription."
+  },
+  "cancelSurveyNotEnoughValueLabel": {
+    "message": "We're not getting enough value for the cost",
+    "description": "Label for a cancel survey radio option shown when a Teams or Enterprise organization cancels their subscription."
+  },
+  "cancelSurveyNotEnoughValueHint": {
+    "message": "The price doesn't match what we're getting out of it",
+    "description": "Hint for a cancel survey radio option shown when a Teams or Enterprise organization cancels their subscription."
+  },
+  "cancelSurveyNotEnoughUsageLabel": {
+    "message": "Not enough usage by our team",
+    "description": "Label for a cancel survey radio option shown when a Teams or Enterprise organization cancels their subscription."
+  },
+  "cancelSurveyNotEnoughUsageHint": {
+    "message": "We couldn't get people to actually use it",
+    "description": "Hint for a cancel survey radio option shown when a Teams or Enterprise organization cancels their subscription."
+  },
+  "cancelSurveyNeedsChangedLabel": {
+    "message": "Our needs changed",
+    "description": "Label for a cancel survey radio option shown when a Teams or Enterprise organization cancels their subscription."
+  },
+  "cancelSurveyNeedsChangedHint": {
+    "message": "Reorg, acquisition, shift in priorities, or we no longer need a password manager",
+    "description": "Hint for a cancel survey radio option shown when a Teams or Enterprise organization cancels their subscription."
+  },
   "freeForOneYear": {
     "message": "Free for 1 year"
   },


### PR DESCRIPTION
Per leadership direction, show the business-plan cancel survey as a bit-radio-group with block hints instead of a `<select>`. Each option's label and hint are separate i18n keys so translators handle them independently. Premium and Families continue to use the existing dropdown.
