### PR TITLE
Add warnings around org key subscriptions

### DIFF
--- a/libs/key-management/src/abstractions/key.service.ts
+++ b/libs/key-management/src/abstractions/key.service.ts
@@ -320,6 +320,7 @@ export abstract class KeyService {
 
   /**
    * Retrieves all the keys needed for decrypting Ciphers
+   * @deprecated Do not subcribe to this frequently as this will trigger slow organization crypto initialization and may result in multi-minute performance impacts for large operations. Ideally, move your encryption and decryption to the SDK.
    * @param userId The user id of the keys to retrieve or null if the user is not Unlocked
    * @param legacySupport `true` if you need to support retrieving the legacy version of the users key, `false` if
    * you do not need legacy support. Use `true` by necessity only. Defaults to `false`. Legacy support is for users
@@ -334,6 +335,7 @@ export abstract class KeyService {
 
   /**
    * Gets an observable of org keys for the given user.
+   * @deprecated Do not subcribe to this frequently as this will trigger slow organization crypto initialization and may result in multi-minute performance impacts for large operations. Ideally, move your encryption and decryption to the SDK.
    * @param userId The user id of the user of which to get the keys for.
    * @return An observable stream of the users organization keys if they are unlocked, or null if the user is not unlocked.
    * The observable will stay alive through locks/unlocks.

--- a/libs/key-management/src/key.service.ts
+++ b/libs/key-management/src/key.service.ts
@@ -891,8 +891,10 @@ export class DefaultKeyService implements KeyServiceAbstraction {
                   continue;
                 }
                 decrypted = await encrypted.decrypt(this.encryptService, providerKeys!);
+                this.logService.info("WARNING: Decrypting provider key. This is slow and should only happen once on unlock! If this happens frequently in a loop, please investigate.");
               } else {
                 decrypted = await encrypted.decrypt(this.encryptService, userPrivateKey);
+                this.logService.info("WARNING: Decrypting organization key. This is slow and should only happen once on unlock! If this happens frequently in a loop, please investigate.");
               }
 
               result[orgId] = decrypted;

--- a/libs/key-management/src/key.service.ts
+++ b/libs/key-management/src/key.service.ts
@@ -891,10 +891,14 @@ export class DefaultKeyService implements KeyServiceAbstraction {
                   continue;
                 }
                 decrypted = await encrypted.decrypt(this.encryptService, providerKeys!);
-                this.logService.info("WARNING: Decrypting provider key. This is slow and should only happen once on unlock! If this happens frequently in a loop, please investigate.");
+                this.logService.info(
+                  "WARNING: Decrypting provider key. This is slow and should only happen once on unlock! If this happens frequently in a loop, please investigate.",
+                );
               } else {
                 decrypted = await encrypted.decrypt(this.encryptService, userPrivateKey);
-                this.logService.info("WARNING: Decrypting organization key. This is slow and should only happen once on unlock! If this happens frequently in a loop, please investigate.");
+                this.logService.info(
+                  "WARNING: Decrypting organization key. This is slow and should only happen once on unlock! If this happens frequently in a loop, please investigate.",
+                );
               }
 
               result[orgId] = decrypted;


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Some teams invoke getting the orgkeys in a loop. Specifically, when importing to an organization, both the cipher encryption, and collection encryption each trigger a subscription for each encrypted item. Each subscription is not cached and will trigger a decryption of all organization and provider keys. This may mean tens or hundreds-of-thousands of RSA operations when importing a large vault.

This operation then takes multiple minutes instead of <1 second. This PR adds logs and deprecation notes that make this bad access pattern visible. Users should either make a bulk decryption operation, getting the keys once, or just move to the SDK which holds the keys in the key store.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
