### PR TITLE
[PM-35835] Use SDK cipher decryption for admin-console

### DIFF
--- a/libs/common/src/vault/services/cipher.service.ts
+++ b/libs/common/src/vault/services/cipher.service.ts
@@ -825,16 +825,11 @@ export class CipherService implements CipherServiceAbstraction {
       return [];
     }
 
+    const userId = await firstValueFrom(this.accountService.activeAccount$.pipe(map((a) => a?.id)));
     const ciphers = response.data.map((cr) => new Cipher(new CipherData(cr)));
-    const key = await this.keyService.getOrgKey(organizationId);
-    const decCiphers: CipherView[] = await Promise.all(
-      ciphers.map(async (cipher) => {
-        return await cipher.decrypt(key);
-      }),
-    );
-
-    decCiphers.sort(this.getLocaleSortingFunction());
-    return decCiphers;
+    let [decrypted, _] = await this.cipherEncryptionService.decryptManyLegacy(ciphers, userId);
+    decrypted.sort(this.getLocaleSortingFunction());
+    return decrypted;
   }
 
   async getLastUsedForUrl(


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-35835

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Cuts decryption time by 90% for admin console access for large vaults. (Measured ~38-40 seconds to 5 seconds).

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
