### PR TITLE
[PM-796] Fix boolean parsing when using serve command

### DIFF
--- a/apps/cli/src/utils.spec.ts
+++ b/apps/cli/src/utils.spec.ts
@@ -1,0 +1,57 @@
+import { CliUtils } from "./utils";
+
+describe("CliUtils.convertBooleanOption", () => {
+  describe("native booleans (commander argv flow)", () => {
+    it("returns true for true", () => {
+      expect(CliUtils.convertBooleanOption(true)).toBe(true);
+    });
+
+    it("returns false for false", () => {
+      expect(CliUtils.convertBooleanOption(false)).toBe(false);
+    });
+  });
+
+  describe("string values (serve query parameters)", () => {
+    it('returns true for "true"', () => {
+      expect(CliUtils.convertBooleanOption("true")).toBe(true);
+    });
+
+    it('returns false for "false"', () => {
+      expect(CliUtils.convertBooleanOption("false")).toBe(false);
+    });
+
+    it('is case-insensitive for "TRUE"', () => {
+      expect(CliUtils.convertBooleanOption("TRUE")).toBe(true);
+    });
+
+    it('is case-insensitive for "False"', () => {
+      expect(CliUtils.convertBooleanOption("False")).toBe(false);
+    });
+
+    it("returns true for empty string (flag present without value)", () => {
+      expect(CliUtils.convertBooleanOption("")).toBe(true);
+    });
+
+    it('returns false for unrelated strings like "yes"', () => {
+      expect(CliUtils.convertBooleanOption("yes")).toBe(false);
+    });
+  });
+
+  describe("nullish and other values", () => {
+    it("returns false for undefined", () => {
+      expect(CliUtils.convertBooleanOption(undefined)).toBe(false);
+    });
+
+    it("returns false for null", () => {
+      expect(CliUtils.convertBooleanOption(null)).toBe(false);
+    });
+
+    it("returns false for the number 0", () => {
+      expect(CliUtils.convertBooleanOption(0)).toBe(false);
+    });
+
+    it("returns false for the number 1", () => {
+      expect(CliUtils.convertBooleanOption(1)).toBe(false);
+    });
+  });
+});

--- a/apps/cli/src/utils.ts
+++ b/apps/cli/src/utils.ts
@@ -252,8 +252,14 @@ export class CliUtils {
     return password;
   }
 
-  static convertBooleanOption(optionValue: any) {
-    return optionValue || optionValue === "" ? true : false;
+  static convertBooleanOption(optionValue: any): boolean {
+    if (typeof optionValue === "boolean") {
+      return optionValue;
+    }
+    if (typeof optionValue === "string") {
+      return optionValue === "" || optionValue.toLowerCase() === "true";
+    }
+    return false;
   }
 
   static convertNumberOption(optionValue: any, defaultValue: number) {


### PR DESCRIPTION
## 🎟️ Tracking
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-796

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Fixes https://github.com/bitwarden/clients/issues/4387

Query parameters are passed in as string and then need to be converted into boolean. The current implementation failed certain scenarios and the value wouldn't be converted properly.

example 
`GET http://localhost:8087/generate?capitalize=false`
"false" was considered truthy as a value(string) was set, so it isn't undefined which would result to false.

This PR addresses this and generally improved boolean conversion, even when using the standard Bitwarden CLI command arguments.

Added unit tests to verify the behaviour.