### PR TITLE
[PM-26417] Remove eager AccessIntelligenceModule import to enable proper lazy loading

### DIFF
--- a/bitwarden_license/bit-web/src/app/app.module.ts
+++ b/bitwarden_license/bit-web/src/app/app.module.ts
@@ -17,7 +17,6 @@ import { OrganizationsModule } from "./admin-console/organizations/organizations
 import { bitPolicyEditRegister } from "./admin-console/policies";
 import { AppRoutingModule } from "./app-routing.module";
 import { AppComponent } from "./app.component";
-import { AccessIntelligenceModule } from "./dirt/access-intelligence/access-intelligence.module";
 
 /**
  * This is the AppModule for the commercial version of Bitwarden.
@@ -38,7 +37,6 @@ import { AccessIntelligenceModule } from "./dirt/access-intelligence/access-inte
     AppRoutingModule,
     OssRoutingModule,
     OrganizationsModule, // Must be after OssRoutingModule for competing routes to resolve properly
-    AccessIntelligenceModule,
     RouterModule,
     WildcardRoutingModule, // Needs to be last to catch all non-existing routes
   ],


### PR DESCRIPTION
## 🎟️ Tracking

[PM-26417](https://bitwarden.atlassian.net/browse/PM-26417)

## 📔 Objective

`AccessIntelligenceModule` was registered both eagerly (in `AppModule.imports`) and lazily (via `loadChildren` in `OrganizationsRoutingModule`). The eager registration wins, so every provider in the module became an application-scoped singleton and the lazy chunk was effectively dead for DI purposes. Services such as `RiskInsightsOrchestratorService` and `RiskInsightsDataService` therefore persist for the whole tab lifetime instead of being torn down when the user leaves `/organizations/:id/access-intelligence`.

This PR removes the eager import so Angular honors the lazy route. The feature-module injector is now created on first navigation and destroyed when the user leaves the route, matching the pattern already used by `OrganizationIntegrationsModule` in the same routing module and complying with the team rule "Never both eagerly and lazy load the same module."

No consumer of the module's providers lives outside the lazy-route subtree (verified via repo-wide grep), so there is no functional change for users.

### Known follow-up (TBD, out of scope for this PR)

`RiskInsightsOrchestratorService.destroy()` at `bitwarden_license/bit-common/src/dirt/reports/risk-insights/services/domain/risk-insights-orchestrator.service.ts:178` and `RiskInsightsDataService.destroy()` at `bitwarden_license/bit-common/src/dirt/reports/risk-insights/services/view/risk-insights-data.service.ts:85` exist as custom methods but are not wired to Angular's `ngOnDestroy` lifecycle. After this PR, the feature-module injector is correctly destroyed when the user leaves the route, but these custom `destroy()` methods will not fire automatically on that teardown. Wiring them up (implement `OnDestroy` and delegate, or rename `destroy()` to `ngOnDestroy`) is deliberately out of scope here because it is separate from the module-scoping fix the ticket asks for.

TBD with reviewers: file a follow-up ticket now, or fold it into an existing tech-debt ticket? Happy to do either before this merges.

## 📸 Screenshots

Not applicable, structural refactor with no UI changes.

## 🧪 E2E Testing

End-to-end Playwright results (route resolution, lazy-chunk confirmation, tab interaction, leave-and-return, sibling-route regression): https://gist.github.com/AlexRubik/8be5c06579cddc8baa0d9f2f5230a3f2

[PM-26417]: https://bitwarden.atlassian.net/browse/PM-26417?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
