### PR TITLE
[PM-35458] fix status check

### DIFF
--- a/apps/web/src/app/admin-console/organizations/policies/policy-edit-dialogs/multi-step-policy-edit-dialog.component.ts
+++ b/apps/web/src/app/admin-console/organizations/policies/policy-edit-dialogs/multi-step-policy-edit-dialog.component.ts
@@ -66,7 +66,7 @@ export class MultiStepPolicyEditDialogComponent
         if (policyComponent?.data) {
           return policyComponent.data.statusChanges.pipe(
             startWith(policyComponent.data.status),
-            map((status) => status !== "VALID"),
+            map((status) => status === "INVALID"),
           );
         }
         return of(false);


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-35458
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
When the "turn on" checkbox is unchecked, the `enableIndividualItemsTransfer` control gets disabled. When a FormGroup has all controls disabled, Angular reports its status as `DISABLED` (not `VALID`). The save-disabled check `status !== "VALID"` incorrectly treated `DISABLED` as "save should be blocked."

fix: Changed `status !== "VALID"` → `status === "INVALID"`. Both `VALID` and `DISABLED` states now correctly allow saving, only genuinely invalid forms block the button.

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
