### PR TITLE
[PM-34159] - Decouple Auto Confrim and Single Org

### DIFF
--- a/apps/desktop/src/vault/app/vault-v3/vault-filter/vault-filter.component.ts
+++ b/apps/desktop/src/vault/app/vault-v3/vault-filter/vault-filter.component.ts
@@ -5,6 +5,7 @@ import { Component, inject, OnInit, output, computed, signal } from "@angular/co
 import { toSignal } from "@angular/core/rxjs-interop";
 import { firstValueFrom, Subject, takeUntil } from "rxjs";
 
+import { singleOrganizationPolicyApplies$ } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { PolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
 import { PolicyType } from "@bitwarden/common/admin-console/enums";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
@@ -103,7 +104,7 @@ export class VaultFilterComponent implements OnInit {
       ),
     );
     this.activeSingleOrganizationPolicy = await firstValueFrom(
-      this.policyService.policyAppliesToUser$(PolicyType.SingleOrg, this.activeUserId),
+      singleOrganizationPolicyApplies$(this.activeUserId, this.policyService),
     );
   }
 

--- a/apps/web/src/app/admin-console/organizations/layouts/organization-layout.component.ts
+++ b/apps/web/src/app/admin-console/organizations/layouts/organization-layout.component.ts
@@ -17,10 +17,11 @@ import {
   canAccessSettingsTab,
   canAccessVaultTab,
   OrganizationService,
+  singleOrganizationPolicyApplies$,
 } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { PolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
 import { ProviderService } from "@bitwarden/common/admin-console/abstractions/provider.service";
-import { PolicyType, ProviderStatusType } from "@bitwarden/common/admin-console/enums";
+import { ProviderStatusType } from "@bitwarden/common/admin-console/enums";
 import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { getUserId } from "@bitwarden/common/auth/services/account.service";
@@ -109,7 +110,7 @@ export class OrganizationLayoutComponent implements OnInit {
 
     this.hideNewOrgButton$ = this.accountService.activeAccount$.pipe(
       getUserId,
-      switchMap((userId) => this.policyService.policyAppliesToUser$(PolicyType.SingleOrg, userId)),
+      switchMap((userId) => singleOrganizationPolicyApplies$(userId, this.policyService)),
     );
 
     const provider$ = combineLatest([

--- a/apps/web/src/app/billing/organizations/change-plan-dialog.component.ts
+++ b/apps/web/src/app/billing/organizations/change-plan-dialog.component.ts
@@ -20,9 +20,9 @@ import { OrganizationApiServiceAbstraction } from "@bitwarden/common/admin-conso
 import {
   getOrganizationById,
   OrganizationService,
+  singleOrganizationPolicyApplies$,
 } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { PolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
-import { PolicyType } from "@bitwarden/common/admin-console/enums";
 import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
 import { OrganizationKeysRequest } from "@bitwarden/common/admin-console/models/request/organization-keys.request";
 import { OrganizationUpgradeRequest } from "@bitwarden/common/admin-console/models/request/organization-upgrade.request";
@@ -312,9 +312,7 @@ export class ChangePlanDialogComponent implements OnInit, OnDestroy {
     this.accountService.activeAccount$
       .pipe(
         getUserId,
-        switchMap((userId) =>
-          this.policyService.policyAppliesToUser$(PolicyType.SingleOrg, userId),
-        ),
+        switchMap((userId) => singleOrganizationPolicyApplies$(userId, this.policyService)),
         takeUntil(this.destroy$),
       )
       .subscribe((policyAppliesToActiveUser) => {

--- a/apps/web/src/app/billing/organizations/organization-plans.component.ts
+++ b/apps/web/src/app/billing/organizations/organization-plans.component.ts
@@ -19,10 +19,10 @@ import { OrganizationApiServiceAbstraction } from "@bitwarden/common/admin-conso
 import {
   getOrganizationById,
   OrganizationService,
+  singleOrganizationPolicyApplies$,
 } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { PolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
 import { ProviderApiServiceAbstraction } from "@bitwarden/common/admin-console/abstractions/provider/provider-api.service.abstraction";
-import { PolicyType } from "@bitwarden/common/admin-console/enums";
 import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
 import { OrganizationCreateRequest } from "@bitwarden/common/admin-console/models/request/organization-create.request";
 import { OrganizationKeysRequest } from "@bitwarden/common/admin-console/models/request/organization-keys.request";
@@ -558,9 +558,7 @@ export class OrganizationPlansComponent implements OnInit, OnDestroy {
     this.accountService.activeAccount$
       .pipe(
         getUserId,
-        switchMap((userId) =>
-          this.policyService.policyAppliesToUser$(PolicyType.SingleOrg, userId),
-        ),
+        switchMap((userId) => singleOrganizationPolicyApplies$(userId, this.policyService)),
         takeUntil(this.destroy$),
       )
       .subscribe((policyAppliesToActiveUser) => {

--- a/apps/web/src/app/layouts/product-switcher/shared/product-switcher.service.ts
+++ b/apps/web/src/app/layouts/product-switcher/shared/product-switcher.service.ts
@@ -16,14 +16,11 @@ import {
 import {
   canAccessOrgAdmin,
   OrganizationService,
+  singleOrganizationPolicyApplies$,
 } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { PolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
 import { ProviderService } from "@bitwarden/common/admin-console/abstractions/provider.service";
-import {
-  OrganizationUserType,
-  PolicyType,
-  ProviderType,
-} from "@bitwarden/common/admin-console/enums";
+import { OrganizationUserType, ProviderType } from "@bitwarden/common/admin-console/enums";
 import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
 import { Provider } from "@bitwarden/common/admin-console/models/domain/provider";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
@@ -134,7 +131,7 @@ export class ProductSwitcherService {
 
   userHasSingleOrgPolicy$ = this.accountService.activeAccount$.pipe(
     getUserId,
-    switchMap((userId) => this.policyService.policyAppliesToUser$(PolicyType.SingleOrg, userId)),
+    switchMap((userId) => singleOrganizationPolicyApplies$(userId, this.policyService)),
   );
 
   shouldShowPremiumUpgradeButton$: Observable<boolean> = combineLatest([

--- a/apps/web/src/app/vault/individual-vault/vault-filter/components/vault-filter.component.ts
+++ b/apps/web/src/app/vault/individual-vault/vault-filter/components/vault-filter.component.ts
@@ -11,6 +11,7 @@ import {
   takeUntil,
 } from "rxjs";
 
+import { singleOrganizationPolicyApplies$ } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { PolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
 import { PolicyType } from "@bitwarden/common/admin-console/enums";
 import { getFirstPolicy } from "@bitwarden/common/admin-console/services/policy/default-policy.service";
@@ -191,6 +192,7 @@ export class VaultFilterComponent implements OnInit, OnDestroy {
         switchMap((userId) =>
           merge(
             this.policyService.policiesByType$(PolicyType.SingleOrg, userId).pipe(getFirstPolicy),
+            this.policyService.policiesByType$(PolicyType.AutoConfirm, userId).pipe(getFirstPolicy),
             this.policyService
               .policiesByType$(PolicyType.OrganizationDataOwnership, userId)
               .pipe(getFirstPolicy),
@@ -270,9 +272,7 @@ export class VaultFilterComponent implements OnInit, OnDestroy {
     const singleOrgPolicy = await firstValueFrom(
       this.accountService.activeAccount$.pipe(
         getUserId,
-        switchMap((userId) =>
-          this.policyService.policyAppliesToUser$(PolicyType.SingleOrg, userId),
-        ),
+        switchMap((userId) => singleOrganizationPolicyApplies$(userId, this.policyService)),
       ),
     );
 

--- a/libs/common/src/admin-console/abstractions/organization/organization.service.abstraction.spec.ts
+++ b/libs/common/src/admin-console/abstractions/organization/organization.service.abstraction.spec.ts
@@ -1,0 +1,61 @@
+import { mock, MockProxy } from "jest-mock-extended";
+import { firstValueFrom, of } from "rxjs";
+
+import { newGuid } from "@bitwarden/guid";
+
+import { UserId } from "../../../types/guid";
+import { PolicyType } from "../../enums";
+import { PolicyService } from "../policy/policy.service.abstraction";
+
+import { singleOrganizationPolicyApplies$ } from "./organization.service.abstraction";
+
+describe("singleOrganizationPolicyApplies$", () => {
+  const userId = newGuid() as UserId;
+  let policyService: MockProxy<PolicyService>;
+
+  beforeEach(() => {
+    policyService = mock<PolicyService>();
+  });
+
+  it("returns true when SingleOrg applies and AutoConfirm does not", async () => {
+    policyService.policyAppliesToUser$.mockImplementation((policyType) => {
+      if (policyType === PolicyType.SingleOrg) {
+        return of(true);
+      }
+      return of(false);
+    });
+
+    const result = await firstValueFrom(singleOrganizationPolicyApplies$(userId, policyService));
+
+    expect(result).toBe(true);
+  });
+
+  it("returns true when AutoConfirm applies and SingleOrg does not", async () => {
+    policyService.policyAppliesToUser$.mockImplementation((policyType) => {
+      if (policyType === PolicyType.AutoConfirm) {
+        return of(true);
+      }
+      return of(false);
+    });
+
+    const result = await firstValueFrom(singleOrganizationPolicyApplies$(userId, policyService));
+
+    expect(result).toBe(true);
+  });
+
+  it("returns true when both SingleOrg and AutoConfirm apply", async () => {
+    policyService.policyAppliesToUser$.mockReturnValue(of(true));
+
+    const result = await firstValueFrom(singleOrganizationPolicyApplies$(userId, policyService));
+
+    expect(result).toBe(true);
+  });
+
+  it("returns false when neither SingleOrg nor AutoConfirm applies", async () => {
+    policyService.policyAppliesToUser$.mockReturnValue(of(false));
+
+    const result = await firstValueFrom(singleOrganizationPolicyApplies$(userId, policyService));
+
+    expect(result).toBe(false);
+  });
+});

--- a/libs/common/src/admin-console/abstractions/organization/organization.service.abstraction.ts
+++ b/libs/common/src/admin-console/abstractions/organization/organization.service.abstraction.ts
@@ -1,4 +1,4 @@
-import { map, Observable } from "rxjs";
+import { combineLatest, map, Observable } from "rxjs";
 
 import { UserId } from "../../../types/guid";
 import { PolicyType } from "../../enums";
@@ -69,6 +69,18 @@ export function canAccessEmergencyAccess(userId: UserId, policyService: PolicySe
   return policyService
     .policyAppliesToUser$(PolicyType.AutoConfirm, userId)
     .pipe(map((policyAppliesToUser) => !policyAppliesToUser));
+}
+
+/**
+ * Returns true when the user is constrained to a single organization.
+ * Combines SingleOrg and AutoConfirm policy checks — AutoConfirm implies
+ * a single-organization constraint for all members.
+ */
+export function singleOrganizationPolicyApplies$(userId: UserId, policyService: PolicyService) {
+  return combineLatest([
+    policyService.policyAppliesToUser$(PolicyType.SingleOrg, userId),
+    policyService.policyAppliesToUser$(PolicyType.AutoConfirm, userId),
+  ]).pipe(map(([singleOrg, autoConfirm]) => singleOrg || autoConfirm));
 }
 
 /**

--- a/libs/common/src/admin-console/services/policy/default-policy.service.spec.ts
+++ b/libs/common/src/admin-console/services/policy/default-policy.service.spec.ts
@@ -623,7 +623,7 @@ describe("PolicyService", () => {
     });
 
     describe("SingleOrg policy exemptions", () => {
-      it("returns true for SingleOrg policy when AutoConfirm is enabled, even for users who can manage policies", async () => {
+      it("returns false for SingleOrg policy when user can manage policies, even when AutoConfirm is enabled", async () => {
         singleUserState.nextState(
           arrayToRecord([
             policyData("policy1", "org6", PolicyType.SingleOrg, true),
@@ -635,7 +635,7 @@ describe("PolicyService", () => {
           policyService.policyAppliesToUser$(PolicyType.SingleOrg, userId),
         );
 
-        expect(result).toBe(true);
+        expect(result).toBe(false);
       });
 
       it("returns false for SingleOrg policy when user can manage policies and AutoConfirm is not enabled", async () => {

--- a/libs/common/src/admin-console/services/policy/default-policy.service.spec.ts
+++ b/libs/common/src/admin-console/services/policy/default-policy.service.spec.ts
@@ -650,21 +650,6 @@ describe("PolicyService", () => {
         expect(result).toBe(false);
       });
 
-      it("returns false for SingleOrg policy when user can manage policies and AutoConfirm is disabled", async () => {
-        singleUserState.nextState(
-          arrayToRecord([
-            policyData("policy1", "org6", PolicyType.SingleOrg, true),
-            policyData("policy2", "org6", PolicyType.AutoConfirm, false),
-          ]),
-        );
-
-        const result = await firstValueFrom(
-          policyService.policyAppliesToUser$(PolicyType.SingleOrg, userId),
-        );
-
-        expect(result).toBe(false);
-      });
-
       it("returns true for SingleOrg policy for regular users when AutoConfirm is not enabled", async () => {
         singleUserState.nextState(
           arrayToRecord([policyData("policy1", "org1", PolicyType.SingleOrg, true)]),

--- a/libs/common/src/admin-console/services/policy/default-policy.service.ts
+++ b/libs/common/src/admin-console/services/policy/default-policy.service.ts
@@ -297,13 +297,7 @@ export class DefaultPolicyService implements PolicyService {
         // organization data ownership policy applies to everyone except admins and owners
         return organization.isAdmin;
       case PolicyType.SingleOrg:
-        // Check if AutoConfirm policy is enabled for this organization
-        return allPolicies.find(
-          (p) =>
-            p.organizationId === organization.id && p.type === PolicyType.AutoConfirm && p.enabled,
-        )
-          ? false
-          : organization.canManagePolicies;
+        return organization.canManagePolicies;
       default:
         return organization.canManagePolicies;
     }

--- a/libs/vault/src/services/vault-filter.service.spec.ts
+++ b/libs/vault/src/services/vault-filter.service.spec.ts
@@ -50,6 +50,7 @@ describe("vault filter service", () => {
   let cipherViews: ReplaySubject<CipherView[]>;
   let organizationDataOwnershipPolicy: ReplaySubject<boolean>;
   let singleOrgPolicy: ReplaySubject<boolean>;
+  let autoConfirmPolicy: ReplaySubject<boolean>;
   let stateProvider: FakeStateProvider;
   let configService: MockProxy<ConfigService>;
 
@@ -75,6 +76,7 @@ describe("vault filter service", () => {
     cipherViews = new ReplaySubject<CipherView[]>(1);
     organizationDataOwnershipPolicy = new ReplaySubject<boolean>(1);
     singleOrgPolicy = new ReplaySubject<boolean>(1);
+    autoConfirmPolicy = new ReplaySubject<boolean>(1);
 
     configService.getFeatureFlag$.mockReturnValue(of(true));
     organizationService.memberOrganizations$.mockReturnValue(organizations);
@@ -86,6 +88,9 @@ describe("vault filter service", () => {
     policyService.policyAppliesToUser$
       .calledWith(PolicyType.SingleOrg, mockUserId)
       .mockReturnValue(singleOrgPolicy);
+    policyService.policyAppliesToUser$
+      .calledWith(PolicyType.AutoConfirm, mockUserId)
+      .mockReturnValue(autoConfirmPolicy);
     cipherService.cipherListViews$.mockReturnValue(cipherViews);
 
     vaultFilterService = new VaultFilterService(
@@ -134,6 +139,7 @@ describe("vault filter service", () => {
       organizations.next(storedOrgs);
       organizationDataOwnershipPolicy.next(false);
       singleOrgPolicy.next(false);
+      autoConfirmPolicy.next(false);
     });
 
     it("returns a nested tree", async () => {

--- a/libs/vault/src/services/vault-filter.service.ts
+++ b/libs/vault/src/services/vault-filter.service.ts
@@ -15,7 +15,10 @@ import {
 // eslint-disable-next-line no-restricted-imports
 import { CollectionService } from "@bitwarden/admin-console/common";
 import { sortDefaultCollections } from "@bitwarden/angular/vault/vault-filter/services/vault-filter.service";
-import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
+import {
+  OrganizationService,
+  singleOrganizationPolicyApplies$,
+} from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { PolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
 import { PolicyType } from "@bitwarden/common/admin-console/enums";
 import {
@@ -65,7 +68,7 @@ export class VaultFilterService implements VaultFilterServiceAbstraction {
   organizationTree$: Observable<TreeNode<OrganizationFilter>> = combineLatest([
     this.memberOrganizations$,
     this.activeUserId$.pipe(
-      switchMap((userId) => this.policyService.policyAppliesToUser$(PolicyType.SingleOrg, userId)),
+      switchMap((userId) => singleOrganizationPolicyApplies$(userId, this.policyService)),
     ),
     this.activeUserId$.pipe(
       switchMap((userId) =>


### PR DESCRIPTION
## 🎟️ Tracking
[PM-34159](https://bitwarden.atlassian.net/browse/PM-34159)

## 📔 Objective
With plans to move the policy enforcement logic to the SDK, we need to first separate the SIngleOrg and AutoConfirm dependency from the policy definition logic. This moves that check to a helper method that checks if the user needs to have single org membership enforced on them.  All call sites were updated to use helper method instead of only checking single org.

[PM-34159]: https://bitwarden.atlassian.net/browse/PM-34159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ