### PR TITLE
[CL-1169] add disableMargin to switches inside cards

### DIFF
--- a/apps/browser/src/auth/popup/settings/account-security.component.html
+++ b/apps/browser/src/auth/popup/settings/account-security.component.html
@@ -104,7 +104,7 @@
           <h2 bitTypography="h6">{{ "phishingBlocker" | i18n }}</h2>
         </bit-section-header>
         <bit-card>
-          <bit-form-control>
+          <bit-form-control disableMargin>
             <bit-switch
               formControlName="enablePhishingDetection"
               id="phishingDetectionAction"

--- a/apps/browser/src/vault/popup/settings/admin-settings.component.html
+++ b/apps/browser/src/vault/popup/settings/admin-settings.component.html
@@ -14,7 +14,7 @@
 
     <form [formGroup]="adminForm">
       <bit-card>
-        <bit-form-control>
+        <bit-form-control disableMargin>
           <bit-switch formControlName="autoConfirm"></bit-switch>
           <bit-label>
             <span class="tw-text-sm">


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/CL-1169

## 📔 Objective
NOTE: this is merging to a feature branch

After moving to rendering switches inside `bit-from-field` to match other field implementations, there were a couple that needed to have the margin removed from them to fix a small visual regression. As `bit-form-field` automatically applies 16px of margin-bottom unless opted out

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
