### PR TITLE
Auth/PM-35336 - TokenService - prevent stale access token retrieval to fix logout on org user confirm

### DIFF
--- a/libs/common/src/auth/abstractions/token.service.ts
+++ b/libs/common/src/auth/abstractions/token.service.ts
@@ -42,8 +42,10 @@ export abstract class TokenService {
 
   /**
    * Sets the access token in memory or disk based on the given vaultTimeoutAction and vaultTimeout
-   * and the user id read off the access token
-   * Note: for platforms that support secure storage, the access & refresh tokens are stored in secure storage instead of on disk.
+   * and the user id read off the access token. The other storage location is always cleared to
+   * enforce the invariant that only one location holds the token at a time.
+   * Note: for platforms that support secure storage, the access token is encrypted with a key stored
+   * in secure storage and the encrypted value is written to disk.
    * @param accessToken The access token to set.
    * @param vaultTimeoutAction The action to take when the vault times out.
    * @param vaultTimeout The timeout for the vault.
@@ -82,7 +84,9 @@ export abstract class TokenService {
   abstract getRefreshToken(userId: UserId): Promise<string | null>;
 
   /**
-   * Sets the API Key Client ID for the active user id in memory or disk based on the given vaultTimeoutAction and vaultTimeout.
+   * Sets the API Key Client ID for the active user id in memory or disk based on the given
+   * vaultTimeoutAction and vaultTimeout. The other storage location is always cleared to enforce
+   * the invariant that only one location holds the value at a time.
    * @param clientId The API Key Client ID to set.
    * @param vaultTimeoutAction The action to take when the vault times out.
    * @param vaultTimeout The timeout for the vault.
@@ -102,7 +106,9 @@ export abstract class TokenService {
   abstract getClientId(userId: UserId): Promise<string | undefined>;
 
   /**
-   * Sets the API Key Client Secret for the active user id in memory or disk based on the given vaultTimeoutAction and vaultTimeout.
+   * Sets the API Key Client Secret for the active user id in memory or disk based on the given
+   * vaultTimeoutAction and vaultTimeout. The other storage location is always cleared to enforce
+   * the invariant that only one location holds the value at a time.
    * @param clientSecret The API Key Client Secret to set.
    * @param vaultTimeoutAction The action to take when the vault times out.
    * @param vaultTimeout The timeout for the vault.

--- a/libs/common/src/auth/services/token.service.spec.ts
+++ b/libs/common/src/auth/services/token.service.spec.ts
@@ -406,6 +406,134 @@ describe("TokenService", () => {
           expect(result).toEqual(accessTokenJwt);
         });
       });
+
+      describe("cross-location clearing", () => {
+        it("Disk path clears Memory: seeded Memory value is null after disk write", async () => {
+          // Arrange: pre-seed ACCESS_TOKEN_MEMORY so we can verify it is cleared
+          singleUserStateProvider
+            .getFake(userIdFromAccessToken, ACCESS_TOKEN_MEMORY)
+            .nextState(accessTokenJwt);
+
+          // Act: write to Disk path (Lock + numeric timeout → Disk)
+          await tokenService.setAccessToken(
+            accessTokenJwt,
+            diskVaultTimeoutAction,
+            diskVaultTimeout,
+          );
+
+          // Assert: the Memory location was cleared after the Disk write
+          expect(
+            singleUserStateProvider.getFake(userIdFromAccessToken, ACCESS_TOKEN_MEMORY).nextMock,
+          ).toHaveBeenCalledWith(null);
+        });
+
+        it("Memory path clears Disk: seeded Disk value is null after memory write", async () => {
+          // Arrange: pre-seed ACCESS_TOKEN_DISK so we can verify it is cleared
+          singleUserStateProvider
+            .getFake(userIdFromAccessToken, ACCESS_TOKEN_DISK)
+            .nextState(accessTokenJwt);
+
+          // Act: write to Memory path (LogOut + numeric timeout → Memory)
+          await tokenService.setAccessToken(
+            accessTokenJwt,
+            memoryVaultTimeoutAction,
+            memoryVaultTimeout,
+          );
+
+          // Assert: the Disk location was cleared after the Memory write
+          expect(
+            singleUserStateProvider.getFake(userIdFromAccessToken, ACCESS_TOKEN_DISK).nextMock,
+          ).toHaveBeenCalledWith(null);
+        });
+
+        describe("SecureStorage path (secure storage supported)", () => {
+          const accessTokenKey = new SymmetricCryptoKey(
+            new Uint8Array(64) as CsprngArray,
+          ) as AccessTokenKey;
+
+          const accessTokenKeyB64 = {
+            keyB64:
+              "lI7lSoejJ1HsrTkRs2Ipm0x+YcZMKpgm7WQGCNjAWmFAyGOKossXwBJvvtbxcYDZ0G0XNY8Gp7DBXZV2tWAO5w==",
+          };
+
+          beforeEach(() => {
+            tokenService = createTokenService(true /* supportsSecureStorage */);
+          });
+
+          it("happy path clears Memory: seeded Memory value is null after encrypted disk write", async () => {
+            // Arrange: pre-seed ACCESS_TOKEN_MEMORY
+            singleUserStateProvider
+              .getFake(userIdFromAccessToken, ACCESS_TOKEN_MEMORY)
+              .nextState(accessTokenJwt);
+
+            keyGenerationService.createKey.mockResolvedValue(accessTokenKey);
+            encryptService.encryptString.mockResolvedValue({
+              encryptedString: "encryptedAccessToken",
+            } as any);
+            secureStorageService.get
+              .mockResolvedValueOnce(null)
+              .mockResolvedValue(accessTokenKeyB64);
+
+            // Act
+            await tokenService.setAccessToken(
+              accessTokenJwt,
+              diskVaultTimeoutAction,
+              diskVaultTimeout,
+            );
+
+            // Assert: Memory was cleared after the encrypted disk write
+            expect(
+              singleUserStateProvider.getFake(userIdFromAccessToken, ACCESS_TOKEN_MEMORY).nextMock,
+            ).toHaveBeenCalledWith(null);
+          });
+
+          it("fallback (silent key failure) clears Memory: seeded Memory value is null after fallback disk write", async () => {
+            // Arrange: pre-seed ACCESS_TOKEN_MEMORY; key retrieval returns null → triggers catch
+            singleUserStateProvider
+              .getFake(userIdFromAccessToken, ACCESS_TOKEN_MEMORY)
+              .nextState(accessTokenJwt);
+
+            keyGenerationService.createKey.mockResolvedValue(accessTokenKey);
+            // Both get calls return null: first (before save) → null key, second (after save) → null
+            // key, which causes the "key unable to be retrieved" error and falls into the catch block.
+            secureStorageService.get.mockResolvedValue(null);
+
+            // Act
+            await tokenService.setAccessToken(
+              accessTokenJwt,
+              diskVaultTimeoutAction,
+              diskVaultTimeout,
+            );
+
+            // Assert: Memory was cleared even when falling back to plaintext disk
+            expect(
+              singleUserStateProvider.getFake(userIdFromAccessToken, ACCESS_TOKEN_MEMORY).nextMock,
+            ).toHaveBeenCalledWith(null);
+          });
+
+          it("fallback (secure storage error) clears Memory: seeded Memory value is null after fallback disk write", async () => {
+            // Arrange: pre-seed ACCESS_TOKEN_MEMORY; secure storage throws → triggers catch
+            singleUserStateProvider
+              .getFake(userIdFromAccessToken, ACCESS_TOKEN_MEMORY)
+              .nextState(accessTokenJwt);
+
+            keyGenerationService.createKey.mockResolvedValue(accessTokenKey);
+            secureStorageService.get.mockRejectedValue(new Error("Secure storage error"));
+
+            // Act
+            await tokenService.setAccessToken(
+              accessTokenJwt,
+              diskVaultTimeoutAction,
+              diskVaultTimeout,
+            );
+
+            // Assert: Memory was cleared even when falling back to plaintext disk
+            expect(
+              singleUserStateProvider.getFake(userIdFromAccessToken, ACCESS_TOKEN_MEMORY).nextMock,
+            ).toHaveBeenCalledWith(null);
+          });
+        });
+      });
     });
 
     describe("getAccessToken", () => {
@@ -1499,6 +1627,99 @@ describe("TokenService", () => {
           );
         });
       });
+
+      describe("cross-location clearing", () => {
+        it("Disk path clears Memory: seeded Memory value is null after disk write", async () => {
+          // Arrange: pre-seed REFRESH_TOKEN_MEMORY
+          singleUserStateProvider
+            .getFake(userIdFromAccessToken, REFRESH_TOKEN_MEMORY)
+            .nextState(refreshToken);
+
+          // Act: write to Disk path (Lock + numeric timeout → Disk)
+          await (tokenService as any).setRefreshToken(
+            refreshToken,
+            diskVaultTimeoutAction,
+            diskVaultTimeout,
+            userIdFromAccessToken,
+          );
+
+          // Assert: the Memory location was cleared after the Disk write
+          expect(
+            singleUserStateProvider.getFake(userIdFromAccessToken, REFRESH_TOKEN_MEMORY).nextMock,
+          ).toHaveBeenCalledWith(null);
+        });
+
+        it("Memory path clears Disk: seeded Disk value is null after memory write", async () => {
+          // Arrange: pre-seed REFRESH_TOKEN_DISK
+          singleUserStateProvider
+            .getFake(userIdFromAccessToken, REFRESH_TOKEN_DISK)
+            .nextState(refreshToken);
+
+          // Act: write to Memory path (LogOut + numeric timeout → Memory)
+          await (tokenService as any).setRefreshToken(
+            refreshToken,
+            memoryVaultTimeoutAction,
+            memoryVaultTimeout,
+            userIdFromAccessToken,
+          );
+
+          // Assert: the Disk location was cleared after the Memory write
+          expect(
+            singleUserStateProvider.getFake(userIdFromAccessToken, REFRESH_TOKEN_DISK).nextMock,
+          ).toHaveBeenCalledWith(null);
+        });
+
+        describe("SecureStorage path (secure storage supported)", () => {
+          beforeEach(() => {
+            tokenService = createTokenService(true /* supportsSecureStorage */);
+          });
+
+          it("fallback (null read-back) clears Memory: seeded Memory value is null after fallback disk write", async () => {
+            // Arrange: pre-seed REFRESH_TOKEN_MEMORY; get returns null so the read-back check
+            // throws ("Refresh token failed to save to secure storage"), triggering the catch block.
+            singleUserStateProvider
+              .getFake(userIdFromAccessToken, REFRESH_TOKEN_MEMORY)
+              .nextState(refreshToken);
+
+            secureStorageService.get.mockResolvedValue(null);
+
+            // Act
+            await (tokenService as any).setRefreshToken(
+              refreshToken,
+              diskVaultTimeoutAction,
+              diskVaultTimeout,
+              userIdFromAccessToken,
+            );
+
+            // Assert: Memory was cleared even when falling back to plaintext disk
+            expect(
+              singleUserStateProvider.getFake(userIdFromAccessToken, REFRESH_TOKEN_MEMORY).nextMock,
+            ).toHaveBeenCalledWith(null);
+          });
+
+          it("fallback (secure storage error) clears Memory: seeded Memory value is null after fallback disk write", async () => {
+            // Arrange: pre-seed REFRESH_TOKEN_MEMORY; save throws so the catch block runs.
+            singleUserStateProvider
+              .getFake(userIdFromAccessToken, REFRESH_TOKEN_MEMORY)
+              .nextState(refreshToken);
+
+            secureStorageService.save.mockRejectedValue(new Error("Secure storage not supported"));
+
+            // Act
+            await (tokenService as any).setRefreshToken(
+              refreshToken,
+              diskVaultTimeoutAction,
+              diskVaultTimeout,
+              userIdFromAccessToken,
+            );
+
+            // Assert: Memory was cleared even when falling back to plaintext disk
+            expect(
+              singleUserStateProvider.getFake(userIdFromAccessToken, REFRESH_TOKEN_MEMORY).nextMock,
+            ).toHaveBeenCalledWith(null);
+          });
+        });
+      });
     });
 
     describe("getRefreshToken", () => {
@@ -1813,6 +2034,49 @@ describe("TokenService", () => {
           ).toHaveBeenCalledWith(clientId);
         });
       });
+
+      describe("cross-location clearing", () => {
+        it("Disk path clears Memory: seeded Memory value is null after disk write", async () => {
+          // Arrange: pre-seed API_KEY_CLIENT_ID_MEMORY
+          singleUserStateProvider
+            .getFake(userIdFromAccessToken, API_KEY_CLIENT_ID_MEMORY)
+            .nextState(clientId);
+
+          // Act: write to Disk path
+          await tokenService.setClientId(
+            clientId,
+            diskVaultTimeoutAction,
+            diskVaultTimeout,
+            userIdFromAccessToken,
+          );
+
+          // Assert: the Memory location was cleared after the Disk write
+          expect(
+            singleUserStateProvider.getFake(userIdFromAccessToken, API_KEY_CLIENT_ID_MEMORY)
+              .nextMock,
+          ).toHaveBeenCalledWith(null);
+        });
+
+        it("Memory path clears Disk: seeded Disk value is null after memory write", async () => {
+          // Arrange: pre-seed API_KEY_CLIENT_ID_DISK
+          singleUserStateProvider
+            .getFake(userIdFromAccessToken, API_KEY_CLIENT_ID_DISK)
+            .nextState(clientId);
+
+          // Act: write to Memory path
+          await tokenService.setClientId(
+            clientId,
+            memoryVaultTimeoutAction,
+            memoryVaultTimeout,
+            userIdFromAccessToken,
+          );
+
+          // Assert: the Disk location was cleared after the Memory write
+          expect(
+            singleUserStateProvider.getFake(userIdFromAccessToken, API_KEY_CLIENT_ID_DISK).nextMock,
+          ).toHaveBeenCalledWith(null);
+        });
+      });
     });
 
     describe("getClientId", () => {
@@ -2025,6 +2289,50 @@ describe("TokenService", () => {
             singleUserStateProvider.getFake(userIdFromAccessToken, API_KEY_CLIENT_SECRET_DISK)
               .nextMock,
           ).toHaveBeenCalledWith(clientSecret);
+        });
+      });
+
+      describe("cross-location clearing", () => {
+        it("Disk path clears Memory: seeded Memory value is null after disk write", async () => {
+          // Arrange: pre-seed API_KEY_CLIENT_SECRET_MEMORY
+          singleUserStateProvider
+            .getFake(userIdFromAccessToken, API_KEY_CLIENT_SECRET_MEMORY)
+            .nextState(clientSecret);
+
+          // Act: write to Disk path
+          await tokenService.setClientSecret(
+            clientSecret,
+            diskVaultTimeoutAction,
+            diskVaultTimeout,
+            userIdFromAccessToken,
+          );
+
+          // Assert: the Memory location was cleared after the Disk write
+          expect(
+            singleUserStateProvider.getFake(userIdFromAccessToken, API_KEY_CLIENT_SECRET_MEMORY)
+              .nextMock,
+          ).toHaveBeenCalledWith(null);
+        });
+
+        it("Memory path clears Disk: seeded Disk value is null after memory write", async () => {
+          // Arrange: pre-seed API_KEY_CLIENT_SECRET_DISK
+          singleUserStateProvider
+            .getFake(userIdFromAccessToken, API_KEY_CLIENT_SECRET_DISK)
+            .nextState(clientSecret);
+
+          // Act: write to Memory path
+          await tokenService.setClientSecret(
+            clientSecret,
+            memoryVaultTimeoutAction,
+            memoryVaultTimeout,
+            userIdFromAccessToken,
+          );
+
+          // Assert: the Disk location was cleared after the Memory write
+          expect(
+            singleUserStateProvider.getFake(userIdFromAccessToken, API_KEY_CLIENT_SECRET_DISK)
+              .nextMock,
+          ).toHaveBeenCalledWith(null);
         });
       });
     });

--- a/libs/common/src/auth/services/token.service.spec.ts
+++ b/libs/common/src/auth/services/token.service.spec.ts
@@ -1674,6 +1674,37 @@ describe("TokenService", () => {
             tokenService = createTokenService(true /* supportsSecureStorage */);
           });
 
+          it("happy path clears both Disk and Memory: both locations are null after secure storage write", async () => {
+            // Arrange: pre-seed both locations so we can verify both are cleared
+            singleUserStateProvider
+              .getFake(userIdFromAccessToken, REFRESH_TOKEN_DISK)
+              .nextState(refreshToken);
+
+            singleUserStateProvider
+              .getFake(userIdFromAccessToken, REFRESH_TOKEN_MEMORY)
+              .nextState(refreshToken);
+
+            // Read-back returns the token, so the save is confirmed and the happy path runs
+            secureStorageService.get.mockResolvedValue(refreshToken);
+
+            // Act
+            await (tokenService as any).setRefreshToken(
+              refreshToken,
+              diskVaultTimeoutAction,
+              diskVaultTimeout,
+              userIdFromAccessToken,
+            );
+
+            // Assert: both locations were cleared — unlike the access token path which only clears
+            // Memory, the refresh token happy path clears both Disk and Memory
+            expect(
+              singleUserStateProvider.getFake(userIdFromAccessToken, REFRESH_TOKEN_DISK).nextMock,
+            ).toHaveBeenCalledWith(null);
+            expect(
+              singleUserStateProvider.getFake(userIdFromAccessToken, REFRESH_TOKEN_MEMORY).nextMock,
+            ).toHaveBeenCalledWith(null);
+          });
+
           it("fallback (null read-back) clears Memory: seeded Memory value is null after fallback disk write", async () => {
             // Arrange: pre-seed REFRESH_TOKEN_MEMORY; get returns null so the read-back check
             // throws ("Refresh token failed to save to secure storage"), triggering the catch block.

--- a/libs/common/src/auth/services/token.service.ts
+++ b/libs/common/src/auth/services/token.service.ts
@@ -371,10 +371,8 @@ export class TokenService implements TokenServiceAbstraction {
           // so that the caller can use it immediately.
           decryptedAccessToken = accessToken;
 
-          // TODO: PM-6408
-          // 2024-02-20: Remove access token from memory so that we migrate to encrypt the access token over time.
-          // Remove this call to remove the access token from memory after 3 months.
-          await this.singleUserStateProvider.get(userId, ACCESS_TOKEN_MEMORY).update((_) => null);
+          // Then, we can clear the memory state location to enforce that a single location holds the access token at a time.
+          await this.clearAccessTokenMemoryLocation(userId);
         } catch (error) {
           this.logService.error(
             `SetAccessToken: storing encrypted access token in secure storage failed. Falling back to disk storage.`,
@@ -387,22 +385,32 @@ export class TokenService implements TokenServiceAbstraction {
             .update((_) => accessToken, {
               shouldUpdate: (previousValue) => previousValue !== accessToken,
             });
+          // Then, we can clear the memory state location to enforce that a single location holds the access token at a time.
+          await this.clearAccessTokenMemoryLocation(userId);
         }
 
         return decryptedAccessToken;
       }
-      case TokenStorageLocation.Disk:
+      case TokenStorageLocation.Disk: {
         // Access token stored on disk unencrypted as platform does not support secure storage
-        return await this.singleUserStateProvider
+        const newAccessToken = await this.singleUserStateProvider
           .get(userId, ACCESS_TOKEN_DISK)
           .update((_) => accessToken, {
             shouldUpdate: (previousValue) => previousValue !== accessToken,
           });
-      case TokenStorageLocation.Memory:
+        // Then, we can clear the memory state location to enforce that a single location holds the access token at a time.
+        await this.clearAccessTokenMemoryLocation(userId);
+        return newAccessToken;
+      }
+      case TokenStorageLocation.Memory: {
         // Access token stored in memory due to vault timeout settings
-        return await this.singleUserStateProvider
+        const newAccessToken = await this.singleUserStateProvider
           .get(userId, ACCESS_TOKEN_MEMORY)
           .update((_) => accessToken);
+        // Then, we can clear the disk state location to enforce that a single location holds the access token at a time.
+        await this.clearAccessTokenDiskLocation(userId);
+        return newAccessToken;
+      }
     }
   }
 
@@ -453,11 +461,19 @@ export class TokenService implements TokenServiceAbstraction {
       await this.clearAccessTokenKey(userId);
     }
 
-    // Clear tokens from disk storage (all platforms)
+    // Clear from disk and memory.
+    await this.clearAccessTokenDiskLocation(userId);
+    await this.clearAccessTokenMemoryLocation(userId);
+  }
+
+  private async clearAccessTokenMemoryLocation(userId: UserId): Promise<void> {
+    await this.singleUserStateProvider.get(userId, ACCESS_TOKEN_MEMORY).update((_) => null);
+  }
+
+  private async clearAccessTokenDiskLocation(userId: UserId): Promise<void> {
     await this.singleUserStateProvider.get(userId, ACCESS_TOKEN_DISK).update((_) => null, {
       shouldUpdate: (previousValue) => previousValue !== null,
     });
-    await this.singleUserStateProvider.get(userId, ACCESS_TOKEN_MEMORY).update((_) => null);
   }
 
   async getAccessToken(userId: UserId): Promise<string | null> {
@@ -601,13 +617,8 @@ export class TokenService implements TokenServiceAbstraction {
           // so that the caller can use it immediately.
           decryptedRefreshToken = refreshToken;
 
-          // TODO: PM-6408
-          // 2024-02-20: Remove refresh token from memory and disk so that we migrate to secure storage over time.
-          // Remove these 2 calls to remove the refresh token from memory and disk after 3 months.
-          await this.singleUserStateProvider.get(userId, REFRESH_TOKEN_DISK).update((_) => null, {
-            shouldUpdate: (previousValue) => previousValue !== null,
-          });
-          await this.singleUserStateProvider.get(userId, REFRESH_TOKEN_MEMORY).update((_) => null);
+          await this.clearRefreshTokenDiskLocation(userId);
+          await this.clearRefreshTokenMemoryLocation(userId);
         } catch (error) {
           // This case could be hit for both Linux users who don't have secure storage configured
           // or for Windows users who have intermittent issues with secure storage.
@@ -622,21 +633,28 @@ export class TokenService implements TokenServiceAbstraction {
             .update((_) => refreshToken, {
               shouldUpdate: (previousValue) => previousValue !== refreshToken,
             });
+          await this.clearRefreshTokenMemoryLocation(userId);
         }
 
         return decryptedRefreshToken;
       }
-      case TokenStorageLocation.Disk:
-        return await this.singleUserStateProvider
+      case TokenStorageLocation.Disk: {
+        const newRefreshToken = await this.singleUserStateProvider
           .get(userId, REFRESH_TOKEN_DISK)
           .update((_) => refreshToken, {
             shouldUpdate: (previousValue) => previousValue !== refreshToken,
           });
+        await this.clearRefreshTokenMemoryLocation(userId);
+        return newRefreshToken;
+      }
 
-      case TokenStorageLocation.Memory:
-        return await this.singleUserStateProvider
+      case TokenStorageLocation.Memory: {
+        const newRefreshToken = await this.singleUserStateProvider
           .get(userId, REFRESH_TOKEN_MEMORY)
           .update((_) => refreshToken);
+        await this.clearRefreshTokenDiskLocation(userId);
+        return newRefreshToken;
+      }
     }
   }
 
@@ -708,7 +726,15 @@ export class TokenService implements TokenServiceAbstraction {
     }
 
     // Platform doesn't support secure storage, so use state provider implementation
+    await this.clearRefreshTokenMemoryLocation(userId);
+    await this.clearRefreshTokenDiskLocation(userId);
+  }
+
+  private async clearRefreshTokenMemoryLocation(userId: UserId): Promise<void> {
     await this.singleUserStateProvider.get(userId, REFRESH_TOKEN_MEMORY).update((_) => null);
+  }
+
+  private async clearRefreshTokenDiskLocation(userId: UserId): Promise<void> {
     await this.singleUserStateProvider.get(userId, REFRESH_TOKEN_DISK).update((_) => null, {
       shouldUpdate: (previousValue) => previousValue !== null,
     });
@@ -743,13 +769,17 @@ export class TokenService implements TokenServiceAbstraction {
     );
 
     if (storageLocation === TokenStorageLocation.Disk) {
-      return await this.singleUserStateProvider
+      const newClientId = await this.singleUserStateProvider
         .get(userId, API_KEY_CLIENT_ID_DISK)
         .update((_) => clientId);
+      await this.clearClientIdMemoryLocation(userId);
+      return newClientId;
     } else if (storageLocation === TokenStorageLocation.Memory) {
-      return await this.singleUserStateProvider
+      const newClientId = await this.singleUserStateProvider
         .get(userId, API_KEY_CLIENT_ID_MEMORY)
         .update((_) => clientId);
+      await this.clearClientIdDiskLocation(userId);
+      return newClientId;
     }
   }
 
@@ -784,8 +814,15 @@ export class TokenService implements TokenServiceAbstraction {
     // we can't determine storage location w/out vaultTimeoutAction and vaultTimeout
     // but we can simply clear both locations to avoid the need to require those parameters
 
-    // Platform doesn't support secure storage, so use state provider implementation
+    await this.clearClientIdMemoryLocation(userId);
+    await this.clearClientIdDiskLocation(userId);
+  }
+
+  private async clearClientIdMemoryLocation(userId: UserId): Promise<void> {
     await this.singleUserStateProvider.get(userId, API_KEY_CLIENT_ID_MEMORY).update((_) => null);
+  }
+
+  private async clearClientIdDiskLocation(userId: UserId): Promise<void> {
     await this.singleUserStateProvider.get(userId, API_KEY_CLIENT_ID_DISK).update((_) => null);
   }
 
@@ -817,13 +854,17 @@ export class TokenService implements TokenServiceAbstraction {
     );
 
     if (storageLocation === TokenStorageLocation.Disk) {
-      return await this.singleUserStateProvider
+      const newClientSecret = await this.singleUserStateProvider
         .get(userId, API_KEY_CLIENT_SECRET_DISK)
         .update((_) => clientSecret);
+      await this.clearClientSecretMemoryLocation(userId);
+      return newClientSecret;
     } else if (storageLocation === TokenStorageLocation.Memory) {
-      return await this.singleUserStateProvider
+      const newClientSecret = await this.singleUserStateProvider
         .get(userId, API_KEY_CLIENT_SECRET_MEMORY)
         .update((_) => clientSecret);
+      await this.clearClientSecretDiskLocation(userId);
+      return newClientSecret;
     }
   }
 
@@ -858,10 +899,17 @@ export class TokenService implements TokenServiceAbstraction {
     // we can't determine storage location w/out vaultTimeoutAction and vaultTimeout
     // but we can simply clear both locations to avoid the need to require those parameters
 
-    // Platform doesn't support secure storage, so use state provider implementation
+    await this.clearClientSecretMemoryLocation(userId);
+    await this.clearClientSecretDiskLocation(userId);
+  }
+
+  private async clearClientSecretMemoryLocation(userId: UserId): Promise<void> {
     await this.singleUserStateProvider
       .get(userId, API_KEY_CLIENT_SECRET_MEMORY)
       .update((_) => null);
+  }
+
+  private async clearClientSecretDiskLocation(userId: UserId): Promise<void> {
     await this.singleUserStateProvider.get(userId, API_KEY_CLIENT_SECRET_DISK).update((_) => null);
   }
 

--- a/libs/common/src/key-management/vault-timeout/services/vault-timeout-settings.service.spec.ts
+++ b/libs/common/src/key-management/vault-timeout/services/vault-timeout-settings.service.spec.ts
@@ -969,8 +969,9 @@ describe("VaultTimeoutSettingsService", () => {
       expect(keyService.refreshAdditionalKeys).toHaveBeenCalled();
     });
 
-    it("should clear the tokens when the timeout is not never and the action is log out", async () => {
+    it("should re-store the tokens when the timeout is not never and the action is log out", async () => {
       // Arrange
+
       const action = VaultTimeoutAction.LogOut;
       const timeout = 30;
       tokenService.getAccessToken.mockResolvedValue(mockAccessToken);
@@ -978,8 +979,15 @@ describe("VaultTimeoutSettingsService", () => {
       // Act
       await vaultTimeoutSettingsService.setVaultTimeoutOptions(mockUserId, timeout, action);
 
-      // Assert
-      expect(tokenService.clearTokens).toHaveBeenCalled();
+      // Assert: setTokens is called to re-store tokens in the correct location
+      // (eviction of other storage locations is managed by the token service)
+      expect(tokenService.setTokens).toHaveBeenCalledWith(
+        mockAccessToken,
+        action,
+        timeout,
+        undefined, // refreshToken not mocked
+        [undefined, undefined], // clientId / clientSecret not mocked
+      );
     });
 
     it("should not clear the tokens when the timeout is never and the action is log out", async () => {

--- a/libs/common/src/key-management/vault-timeout/services/vault-timeout-settings.service.ts
+++ b/libs/common/src/key-management/vault-timeout/services/vault-timeout-settings.service.ts
@@ -261,11 +261,6 @@ export class VaultTimeoutSettingsService implements VaultTimeoutSettingsServiceA
     const clientId = await this.tokenService.getClientId(userId);
     const clientSecret = await this.tokenService.getClientSecret(userId);
 
-    if (timeout != VaultTimeoutStringType.Never && action === VaultTimeoutAction.LogOut) {
-      // Switching to LogOut: clear tokens from disk before re-storing in memory
-      await this.tokenService.clearTokens(userId);
-    }
-
     if (!accessToken) {
       return;
     }


### PR DESCRIPTION
## 🎟️ Tracking
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-35336

Original attempted fix: https://github.com/bitwarden/clients/pull/20309
We initially thought this was due to StateProvider providing state data so there's a bunch of atomicity improvements in that PR that proved unnecessary to fix the actual bug at play. We swapped to this PR to strip down the changes to only what is absolutely necessary to fix the bug for the next release as it is a release blocker. 

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
To solve the below bug: 

## Bug Description

When a user is JIT-provisioned via SSO into an **MP encryption org** (non-TDE), they are unexpectedly
logged out immediately after being confirmed to the organization. This happens in both auto-confirm
and manual confirm flows.

<details>
<summary>Root Cause</summary>

All four token types share a dual-storage pattern: a `_MEMORY` key and a `_DISK` key. Every getter
reads Memory first and falls back to Disk. But no setter cleared the other location on write —
meaning Memory and Disk could silently diverge. In the `TokenService`, we erroneously counted on external clears instead of internally enforcing the single token storage location invariant.

The divergence was triggered by the following sequence:

1. **Token written to Memory on login**: New users JIT-provisioned via SSO use the default vault
   timeout settings (`LogOut + 15min`), causing the access token to be written to
   `ACCESS_TOKEN_MEMORY` only. Note: the fact that we have [dev overrides](https://github.com/bitwarden/clients/blob/main/apps/web/src/app/core/core.module.ts#L193-L198) for the default vault timeout made this originally unable to be reproduced locally. 

2. **JIT provisioning triggers a background token migration**: Once JIT-provisioned and after the user set's an initial MP, the user's password becomes available, making `Lock` a valid vault timeout action. Since
   https://github.com/bitwarden/clients/pull/17731 made `availableVaultTimeoutActions$`
   fully reactive and https://github.com/bitwarden/clients/pull/19594 introduced token migration as a side effect, this availability change is observed mid-session — firing a `null → Lock`
   transition that calls `migrateTokenStorage` and copies the token to `ACCESS_TOKEN_DISK`.
   Memory is **not** cleared.

3. **`refreshIdentityToken` writes the new token to Disk only**: The org confirmation triggers a
   `SyncOrgKeys` push notification → `fullSync` → `refreshIdentityToken()`, which writes the new
   JWT (containing the new org claim) to `ACCESS_TOKEN_DISK`. Memory is **not** updated.

4. **Every `getAccessToken` call returns the stale Memory value**: The getter's Memory-first read
   always returns the old token — the one without the org claim. This causes a 403 on subsequent
   API calls, which triggers logout.

</details>

The correct fix will be to have the `TokenService` enforce storing data in a single slot only at a time by clearing the other locations on sets. 


## Detailed Changes

<details>
<summary>Abstractions</summary>

**`libs/common/src/auth/abstractions/token.service.ts`**
1. Updated JSDoc for `setAccessToken`, `setClientId`, and `setClientSecret` to document the new single-storage-location invariant — each setter now guarantees the alternate storage location is cleared after writing, so no token can exist in both memory and disk simultaneously.
2. Corrected the `setAccessToken` note about secure storage: previously described as storing tokens in secure storage, now accurately describes encrypting the token with a key held in secure storage and writing the ciphertext to disk.

</details>

<details>
<summary>Services</summary>

**`libs/common/src/auth/services/token.service.ts`**
1. `setAccessToken` — added cross-location clearing after every write path (SecureStorage happy path, SecureStorage key-failure fallback, SecureStorage error fallback, Disk, and Memory) so only one location holds the access token at any time; before this change, switching from Memory→Disk or Disk→Memory could leave a stale value in the evicted location.
2. Extracted private `clearAccessTokenMemoryLocation(userId)` and `clearAccessTokenDiskLocation(userId)` helpers to DRY up the repeated clear patterns and removed the stale `// TODO: PM-6408` inline eviction comment in the SecureStorage path that was partially doing this job.
3. `setRefreshToken` — same cross-location clearing pattern applied to all write paths, plus extraction of `clearRefreshTokenMemoryLocation(userId)` and `clearRefreshTokenDiskLocation(userId)` helpers.
4. `setClientId` / `setClientSecret` — same pattern applied; extracted `clearClientIdMemoryLocation`, `clearClientIdDiskLocation`, `clearClientSecretMemoryLocation`, and `clearClientSecretDiskLocation` helpers.
5. `clearAccessToken` / `clearRefreshToken` refactored to delegate to the new private helpers instead of duplicating the inline state update calls.

**`libs/common/src/key-management/vault-timeout/services/vault-timeout-settings.service.ts`**
1. Removed the `tokenService.clearTokens(userId)` pre-eviction call that ran before `setTokens` when switching to the LogOut action — this explicit eviction is now redundant because each `setToken*` setter already clears the alternate location internally, making the prior call both unnecessary and a latent race condition source.

</details>

<details>
<summary>Tests</summary>

**`libs/common/src/auth/services/token.service.spec.ts`**
1. Added `cross-location clearing` describe blocks under `setAccessToken`, `setRefreshToken`, `setClientId`, and `setClientSecret`; each block seeds the alternate storage location and asserts it is nulled out after a write — covering the Disk→clears-Memory and Memory→clears-Disk paths for all four token types.
2. Added SecureStorage sub-blocks for `setAccessToken` and `setRefreshToken` covering the happy path, silent key-retrieval failure, and secure-storage error fallback — verifying that Memory is cleared even when the SecureStorage write falls back to plaintext disk.

**`libs/common/src/key-management/vault-timeout/services/vault-timeout-settings.service.spec.ts`**
1. Updated the "should clear the tokens when the timeout is not never and the action is log out" test to assert `tokenService.setTokens` is called (not `tokenService.clearTokens`) — reflecting that storage migration is now handled internally by the token service rather than by a separate pre-eviction step in `VaultTimeoutSettingsService`.

</details>


## 📸 Screenshots
<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

New video just on these changes

https://github.com/user-attachments/assets/bb5560d5-f5cb-43e6-96e9-3b1cb0d9e1db

