### PR TITLE
[BRE-1841] Fix truncate logic for container images tags in Build Web workflow

### DIFF
--- a/.github/workflows/build-web.yml
+++ b/.github/workflows/build-web.yml
@@ -289,7 +289,6 @@ jobs:
           if [[ "${{ github.event.pull_request.head.repo.fork }}" == "true" ]]; then
             SANITIZED_REPO_NAME=$(echo "$_GITHUB_PR_REPO_NAME" | sed "s/[^a-zA-Z0-9]/-/g") # Sanitize repo name to alphanumeric only
             IMAGE_TAG="$SANITIZED_REPO_NAME-$IMAGE_TAG" # Add repo name to the tag
-            IMAGE_TAG=${IMAGE_TAG:0:128}  # Limit to 128 characters, as that's the max length for Docker image tags
           fi
 
           if [[ "$IMAGE_TAG" == "main" ]]; then
@@ -302,6 +301,7 @@ jobs:
             IMAGE_TAG="$IMAGE_TAG-$TAG_EXTENSION"
           fi
 
+          IMAGE_TAG=${IMAGE_TAG:0:128}  # Limit to 128 characters, as that's the max length for Docker image tags
           echo "image_tag=$IMAGE_TAG" >> "$GITHUB_OUTPUT"
 
       ########## Build Image ##########


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
- [BRE-1841](https://bitwarden.atlassian.net/browse/BRE-1841)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR fixes the truncate logic for container images in the Build Web workflow. All image tags are now truncated to 128 characters which is the max length of a tag.


[BRE-1841]: https://bitwarden.atlassian.net/browse/BRE-1841?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ