### PR TITLE
Update Publish CLI Workflow with fixes for installing the latest NPM

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -103,7 +103,7 @@ jobs:
       _PKG_VERSION: ${{ needs.setup.outputs.release_version }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
@@ -151,7 +151,7 @@ jobs:
       _PKG_VERSION: ${{ needs.setup.outputs.release_version }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
@@ -203,7 +203,7 @@ jobs:
       _PKG_VERSION: ${{ needs.setup.outputs.release_version }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -103,7 +103,7 @@ jobs:
       _PKG_VERSION: ${{ needs.setup.outputs.release_version }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           persist-credentials: false
 
@@ -151,7 +151,7 @@ jobs:
       _PKG_VERSION: ${{ needs.setup.outputs.release_version }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           persist-credentials: false
 
@@ -192,7 +192,7 @@ jobs:
   npm:
     name: Publish NPM
     environment: CLI - NPM
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: setup
     permissions:
       contents: read
@@ -203,7 +203,7 @@ jobs:
       _PKG_VERSION: ${{ needs.setup.outputs.release_version }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           persist-credentials: false
 
@@ -223,6 +223,7 @@ jobs:
 
       - name: Install NPM
         run: |
+          npm install -g --prefix="$(npm prefix -g)" promise-retry
           npm install -g npm@latest # npm 11.5.1 or later is required to publish w/ OIDC
           npm --version
 


### PR DESCRIPTION
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This fixes an issue with the `promise-retry` module failing to install when trying to install the latest NPM.

