### PR TITLE
[PM-35789] fix(desktop): repair ipcRenderer listener leak in messagingService ch…

### DIFF
--- a/apps/desktop/src/platform/preload.ts
+++ b/apps/desktop/src/platform/preload.ts
@@ -99,6 +99,11 @@ const localhostCallbackService = {
   },
 };
 
+const _messagingListeners = new Map<
+  (message: any) => void,
+  (_event: any, message: any) => void
+>();
+
 export default {
   versions: {
     app: (): Promise<string> => ipcRenderer.invoke("appVersion"),
@@ -153,18 +158,20 @@ export default {
     ipcRenderer.send("messagingService", message),
   onMessage: {
     addListener: (callback: (message: { command: string } & any) => void) => {
-      ipcRenderer.addListener("messagingService", (_event, message: any) => {
+      const wrapper = (_event: any, message: any) => {
         if (message.command) {
           callback(message);
         }
-      });
+      };
+      _messagingListeners.set(callback, wrapper);
+      ipcRenderer.addListener("messagingService", wrapper);
     },
     removeListener: (callback: (message: { command: string } & any) => void) => {
-      ipcRenderer.removeListener("messagingService", (_event, message: any) => {
-        if (message.command) {
-          callback(message);
-        }
-      });
+      const wrapper = _messagingListeners.get(callback);
+      if (wrapper) {
+        ipcRenderer.removeListener("messagingService", wrapper);
+        _messagingListeners.delete(callback);
+      }
     },
   },
 


### PR DESCRIPTION
…annel

The removeListener implementation in apps/desktop/src/platform/preload.ts created a new anonymous function on every call instead of reusing the reference originally passed to addListener. Because ipcRenderer.removeListener requires exact reference equality to match and remove a listener, every removal attempt was silently a no-op.

As a result, every subscription to fromIpcMessaging() that was later unsubscribed permanently leaked one ipcRenderer listener bound to the "messagingService" channel. Listeners accumulated across login/logout cycles and component navigation without bound.

Fix: maintain a module-scope Map from each caller callback to its internal wrapper function. addListener stores the wrapper before registering it; removeListener looks up the stored wrapper by callback reference and passes that exact same reference to ipcRenderer.removeListener.

## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
