### PR TITLE
[PM-35906] Focus first vault item on enter keypress in search field

### DIFF
--- a/apps/desktop/src/app/layout/search/search-bar.service.ts
+++ b/apps/desktop/src/app/layout/search/search-bar.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from "@angular/core";
-import { BehaviorSubject } from "rxjs";
+import { BehaviorSubject, Subject } from "rxjs";
 
 export type SearchBarState = {
   enabled: boolean;
@@ -10,6 +10,9 @@ export type SearchBarState = {
 export class SearchBarService {
   private searchTextSubject = new BehaviorSubject<string | null>(null);
   searchText$ = this.searchTextSubject.asObservable();
+
+  private enterPressedSubject = new Subject<void>();
+  enterPressed$ = this.enterPressedSubject.asObservable();
 
   private _state = {
     enabled: false,
@@ -31,6 +34,10 @@ export class SearchBarService {
 
   setSearchText(value: string) {
     this.searchTextSubject.next(value);
+  }
+
+  onEnterPressed() {
+    this.enterPressedSubject.next();
   }
 
   private updateState() {

--- a/apps/desktop/src/app/layout/search/search.component.html
+++ b/apps/desktop/src/app/layout/search/search.component.html
@@ -5,6 +5,7 @@
     id="search"
     autocomplete="off"
     [formControl]="searchText"
+    (keydown.enter)="onEnterPressed()"
     appAutofocus
   />
   <bit-icon name="bwi-search"></bit-icon>

--- a/apps/desktop/src/app/layout/search/search.component.ts
+++ b/apps/desktop/src/app/layout/search/search.component.ts
@@ -47,4 +47,8 @@ export class SearchComponent implements OnInit, OnDestroy {
   ngOnDestroy() {
     this.activeAccountSubscription.unsubscribe();
   }
+
+  onEnterPressed() {
+    this.searchBarService.onEnterPressed();
+  }
 }

--- a/apps/desktop/src/vault/app/vault/vault-items-v2.component.html
+++ b/apps/desktop/src/vault/app/vault/vault-items-v2.component.html
@@ -29,6 +29,7 @@
           type="button"
           *cdkVirtualFor="let c of ciphers; trackBy: trackByFn"
           appStopClick
+          cipherListItem
           (click)="selectCipher(c)"
           (contextmenu)="rightClickCipher(c)"
           title="{{ 'viewItem' | i18n }}"

--- a/apps/desktop/src/vault/app/vault/vault-items-v2.component.ts
+++ b/apps/desktop/src/vault/app/vault/vault-items-v2.component.ts
@@ -1,6 +1,6 @@
 import { ScrollingModule } from "@angular/cdk/scrolling";
 import { CommonModule } from "@angular/common";
-import { Component, input, output } from "@angular/core";
+import { Component, ElementRef, inject, input, output } from "@angular/core";
 import { takeUntilDestroyed, toSignal } from "@angular/core/rxjs-interop";
 import { distinctUntilChanged, debounceTime } from "rxjs";
 
@@ -70,6 +70,19 @@ export class VaultItemsV2Component<C extends CipherViewLike> extends BaseVaultIt
       .subscribe((searchText) => {
         this.searchText = searchText!;
       });
+
+    this.searchBarService.enterPressed$
+      .pipe(takeUntilDestroyed())
+      .subscribe(() => this.focusFirstItem());
+  }
+
+  private elementRef = inject(ElementRef);
+
+  private focusFirstItem(): void {
+    const firstButton = this.elementRef.nativeElement.querySelector(
+      "button[cipherListItem]",
+    ) as HTMLElement | null;
+    firstButton?.focus();
   }
 
   async navigateToGetPremium() {


### PR DESCRIPTION
## 🎟️ Tracking

My own initiative, sorry :)

## 📔 Objective

One of the recent updates, which added the left sidebar with the vault list, broke my workflow of using bitwarden with just keyboard: `Ctrl`+`F`, enter search term, `Tab` x2 (or 3? to focus the first search result), `Enter` (to activate it), `Ctrl`+`P` to copy password. After the update, after tabbing, focus goes into the left vaults menu. So, I am adding a feature to focus the first item when Enter is pressed in the search bar.

## 📸 Screenshots

no visual changes per se, but this is what the UI looks like after `Ctrl`+`F`, type, `Enter`:

<img width="1606" height="450" alt="image" src="https://github.com/user-attachments/assets/a1325d1d-c0d8-486d-bc2a-f53a93e53116" />

