### PR TITLE
chore(deps): group electron in Renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -461,6 +461,7 @@
       matchPackageNames: ["@types/jest", "jest", "ts-jest", "jest-preset-angular"],
     },
     {
+      // Some electron packages are version coupled
       groupName: "electron",
       matchPackageNames: [
         "@electron/fuses",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -460,6 +460,16 @@
       groupName: "jest",
       matchPackageNames: ["@types/jest", "jest", "ts-jest", "jest-preset-angular"],
     },
+    {
+      groupName: "electron",
+      matchPackageNames: [
+        "@electron/fuses",
+        "@electron/rebuild",
+        "electron",
+        "electron-builder",
+        "electron-updater",
+      ],
+    },
 
     // ==================== Dashboard Rules ====================
     {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-35927

## 📔 Objective

Electron and its tooling packages are tightly version-coupled. Upgrading them separately causes build and packaging complications.

This PR groups all electron-related packages so Renovate raises a single PR for them. This includes:

- electron
- @electron/fuses
-  @electron/rebuild
- electron-builder
- electron-updater