### PR TITLE
[PM-35038] Fix Link SSO button not rendering in org options menu

### DIFF
--- a/apps/web/src/app/vault/individual-vault/vault-filter/components/organization-options.component.html
+++ b/apps/web/src/app/vault/individual-vault/vault-filter/components/organization-options.component.html
@@ -43,12 +43,10 @@
                   {{ "unlinkSso" | i18n }}
                 </button>
               } @else {
-                <ng-template #linkSso>
-                  <button type="button" bitMenuItem (click)="handleLinkSso(organization)">
-                    <i class="bwi bwi-fw bwi-plus-circle"></i>
-                    {{ "linkSso" | i18n }}
-                  </button>
-                </ng-template>
+                <button type="button" bitMenuItem (click)="handleLinkSso(organization)">
+                  <i class="bwi bwi-fw bwi-plus-circle"></i>
+                  {{ "linkSso" | i18n }}
+                </button>
               }
             </ng-container>
           }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-35038

## 📔 Objective

During a migration from the legacy `*ngIf/else` template syntax to Angular's new `@if/@else` control flow, the "Link SSO" button in the organization options menu was accidentally wrapped in a `<ng-template>` in the `@else` branch.

In the old syntax, `*ngIf="condition; else linkSso"` worked because Angular's `*ngIf` directive explicitly instantiates the named `<ng-template>` as its else branch. In the new `@if/@else` syntax, the `@else` block renders its children directly — a `<ng-template>` wrapper is inert and never rendered.

This meant that for users in an organization with SSO configured but not yet linked (`ssoBound = false`), the "Link SSO" button was silently discarded. The `hideMenu` logic still evaluated to `false` (because `showSsoOptions()` returned `true`), so the 3-dot menu button would render but display an empty menu.

The fix removes the spurious `<ng-template>` wrapper so the "Link SSO" button renders directly in the `@else` branch.

## 📸 Screenshots

QA to verify: org with SSO configured + claimed member with ssoBound = false should show "Link SSO" in the 3-dot menu, not an empty bar