### PR TITLE
BRE-1854: Add actions:write permission to build-web-target workflow

### DIFF
--- a/.github/workflows/build-web-target.yml
+++ b/.github/workflows/build-web-target.yml
@@ -42,4 +42,5 @@ jobs:
       id-token: write
       security-events: write
       packages: write
+      actions: write
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/BRE-1854

## 📔 Objective

Fixes startup failures caused by missing actions:write permission. The trigger-web-vault-deploy job in build-web.yml requires this permission to dispatch workflows using GITHUB_TOKEN.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
