### PR TITLE
[PM-34388] Add API method to update organization invite link allowed domains

### DIFF
--- a/libs/organization-invite-link/src/abstractions/organization-invite-link-api.service.ts
+++ b/libs/organization-invite-link/src/abstractions/organization-invite-link-api.service.ts
@@ -1,4 +1,5 @@
 import { OrganizationInviteLinkCreateRequest } from "../models/requests/organization-invite-link-create.request";
+import { OrganizationInviteLinkUpdateRequest } from "../models/requests/organization-invite-link-update.request";
 import { OrganizationInviteLinkResponseModel } from "../models/responses/organization-invite-link.response";
 
 export abstract class OrganizationInviteLinkApiService {
@@ -8,7 +9,13 @@ export abstract class OrganizationInviteLinkApiService {
     request: OrganizationInviteLinkCreateRequest,
   ): Promise<OrganizationInviteLinkResponseModel>;
 
-  /** Retrieve the current invite link for the given organization */
+  /** Update allowed domains on the invite link for the given organization */
+  abstract update(
+    organizationId: string,
+    request: OrganizationInviteLinkUpdateRequest,
+  ): Promise<OrganizationInviteLinkResponseModel>;
+
+  /** Retrieve the invite link for the given organization */
   abstract get(organizationId: string): Promise<OrganizationInviteLinkResponseModel>;
 
   /** Delete (revoke) the invite link for the given organization */

--- a/libs/organization-invite-link/src/models/requests/index.ts
+++ b/libs/organization-invite-link/src/models/requests/index.ts
@@ -1,1 +1,2 @@
 export * from "./organization-invite-link-create.request";
+export * from "./organization-invite-link-update.request";

--- a/libs/organization-invite-link/src/models/requests/organization-invite-link-update.request.ts
+++ b/libs/organization-invite-link/src/models/requests/organization-invite-link-update.request.ts
@@ -1,0 +1,10 @@
+export class OrganizationInviteLinkUpdateRequest {
+  allowedDomains: string[];
+
+  constructor(c: { allowedDomains: string[] }) {
+    if (!c.allowedDomains || c.allowedDomains.length === 0) {
+      throw new Error("At least one allowed domain is required.");
+    }
+    this.allowedDomains = c.allowedDomains;
+  }
+}

--- a/libs/organization-invite-link/src/services/default-organization-invite-link-api.service.ts
+++ b/libs/organization-invite-link/src/services/default-organization-invite-link-api.service.ts
@@ -2,6 +2,7 @@ import { ApiService } from "@bitwarden/common/abstractions/api.service";
 
 import { OrganizationInviteLinkApiService } from "../abstractions/organization-invite-link-api.service";
 import { OrganizationInviteLinkCreateRequest } from "../models/requests/organization-invite-link-create.request";
+import { OrganizationInviteLinkUpdateRequest } from "../models/requests/organization-invite-link-update.request";
 import { OrganizationInviteLinkResponseModel } from "../models/responses/organization-invite-link.response";
 
 export class DefaultOrganizationInviteLinkApiService implements OrganizationInviteLinkApiService {
@@ -26,6 +27,20 @@ export class DefaultOrganizationInviteLinkApiService implements OrganizationInvi
       "GET",
       `/organizations/${organizationId}/invite-link`,
       null,
+      true,
+      true,
+    );
+    return new OrganizationInviteLinkResponseModel(r);
+  }
+
+  async update(
+    organizationId: string,
+    request: OrganizationInviteLinkUpdateRequest,
+  ): Promise<OrganizationInviteLinkResponseModel> {
+    const r = await this.apiService.send(
+      "PUT",
+      `/organizations/${organizationId}/invite-link`,
+      request,
       true,
       true,
     );


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-34388

## 📔 Objective

Add `OrganizationInviteLinkApiService.update(...)` to call the new invite-link update endpoint and return `OrganizationInviteLinkResponseModel`.

[Server PR](https://github.com/bitwarden/server/pull/7560).