### PR TITLE
[PM-36047] Add tech-leads group as owners of the CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,6 +4,9 @@
 #
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
+# CODEOWNERS owners
+.github/CODEOWNERS @bitwarden/tech-leads
+
 ## Global styles are owned by UIF
 *.scss @bitwarden/team-ui-foundation
 *.css @bitwarden/team-ui-foundation
@@ -172,7 +175,7 @@ apps/desktop/desktop_native/napi/src/autotype.rs @bitwarden/team-desktop-native-
 apps/desktop/desktop_native/napi/src/sshagent.rs @bitwarden/team-desktop-native-dev
 apps/desktop/desktop_native/napi/src/sshagent_v2.rs @bitwarden/team-desktop-native-dev
 
-## Desktop Native + Skunkworks co-owned files 
+## Desktop Native + Skunkworks co-owned files
 apps/desktop/desktop_native/autofill_provider @bitwarden/team-desktop-native-dev @bitwarden/team-skunkworks
 apps/desktop/desktop_native/core/src/autofill @bitwarden/team-desktop-native-dev @bitwarden/team-skunkworks
 apps/desktop/desktop_native/napi/src/autofill.rs @bitwarden/team-desktop-native-dev @bitwarden/team-skunkworks


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-36047

## 📔 Objective

For some existing repositories, there is no owner for the CODEOWNERS file itself. This presents a couple of concerns. The main initial concern is that a team’s ownership can change without them knowing or being approvers of the change.

This could be fixed in multiple ways, but two were discussed:

1. CODEOWNERS changes require approval from all teams whose ownership is changing. This is the better solution, but GitHub doesn’t seem to provide this capability. Something custom would have to be created, so this option is more effort.
2. CODEOWNERS changes require approval from the Tech Lead group. This is a less ideal solution compared to `#1`, but it should help provide more approval from the tech lead owners of files, and give them notifications on any changes.

For now, this change goes route `#2`. We aim to apply these changes only on monorepos. Team specific repositories shouldn't have this change.
