### PR TITLE
[PM-36048] - redirect back to vault after coachmark tour ends

### DIFF
--- a/apps/web/src/app/vault/components/coachmark/coachmark.service.spec.ts
+++ b/apps/web/src/app/vault/components/coachmark/coachmark.service.spec.ts
@@ -218,6 +218,7 @@ describe("CoachmarkService", () => {
 
       expect(service.isRunning()).toBe(false);
       expect(setUserState).toHaveBeenCalled();
+      expect(navigate).toHaveBeenCalledWith(["/vault"]);
     }));
 
     it("should do nothing if tour is not running", fakeAsync(() => {
@@ -289,6 +290,7 @@ describe("CoachmarkService", () => {
 
       expect(service.isRunning()).toBe(true);
 
+      navigate.mockClear();
       void service.completeTour();
       tick(200);
 
@@ -296,6 +298,7 @@ describe("CoachmarkService", () => {
       expect(service.activeStepId()).toBeNull();
       expect(service.totalSteps()).toBe(0);
       expect(setUserState).toHaveBeenCalledWith(expect.anything(), true, mockUserId);
+      expect(navigate).toHaveBeenCalledWith(["/vault"]);
     }));
 
     it("should not persist if no active account", fakeAsync(() => {

--- a/apps/web/src/app/vault/components/coachmark/coachmark.service.ts
+++ b/apps/web/src/app/vault/components/coachmark/coachmark.service.ts
@@ -178,7 +178,8 @@ export class CoachmarkService {
   }
 
   /**
-   * Completes the tour and persists the completion state.
+   * Completes the tour, persists the completion state, and navigates back to the vault
+   * so users are reminded to add items via the checklist and empty state UX.
    */
   async completeTour(): Promise<void> {
     this.activeStepId.set(null);
@@ -188,5 +189,7 @@ export class CoachmarkService {
     if (account) {
       await this.stateProvider.setUserState(COACHMARK_TOUR_COMPLETED_KEY, true, account.id);
     }
+
+    await this.router.navigate(["/vault"]);
   }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Link to Jira ticket -->
https://bitwarden.atlassian.net/browse/PM-36048

## 📔 Objective

The 3-step welcome tour previously left users on the Reports page after finishing. This was confusing because it left users stranded away from the primary starting point for setting up their vault.

This change updates `completeTour()` in `CoachmarkService` to navigate the user back to `/vault` upon tour completion — whether they finish the last step or dismiss the tour early. This ensures users land on the Vault page where the checklist and empty-state UX guide them to import data or add items.


## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/085ed3b5-3b4e-4c27-9067-5833ec15035f

