### PR TITLE
[PM-36015] Fix dialog size for 1-column add-item grid layout

### DIFF
--- a/libs/vault/src/components/add-item-dialog/add-item-dialog.component.html
+++ b/libs/vault/src/components/add-item-dialog/add-item-dialog.component.html
@@ -1,4 +1,4 @@
-<bit-dialog dialogSize="large" background="alt">
+<bit-dialog [dialogSize]="dialogSize()" background="alt">
   <span bitDialogTitle>
     {{ "chooseItemToAdd" | i18n }}
   </span>

--- a/libs/vault/src/components/add-item-dialog/add-item-dialog.component.spec.ts
+++ b/libs/vault/src/components/add-item-dialog/add-item-dialog.component.spec.ts
@@ -5,7 +5,10 @@ import { BehaviorSubject } from "rxjs";
 
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { CipherType } from "@bitwarden/common/vault/enums";
-import { RestrictedItemTypesService } from "@bitwarden/common/vault/services/restricted-item-types.service";
+import {
+  RestrictedCipherType,
+  RestrictedItemTypesService,
+} from "@bitwarden/common/vault/services/restricted-item-types.service";
 import { DIALOG_DATA, DialogRef } from "@bitwarden/components";
 
 import { AddItemGridComponent } from "../add-item-grid/add-item-grid.component";
@@ -22,7 +25,7 @@ describe("AddItemDialogComponent", () => {
 
   const close = jest.fn();
   const dialogRef = { close };
-  const restricted$ = new BehaviorSubject<[]>([]);
+  const restricted$ = new BehaviorSubject<RestrictedCipherType[]>([]);
 
   beforeEach(async () => {
     close.mockClear();

--- a/libs/vault/src/components/add-item-dialog/add-item-dialog.component.spec.ts
+++ b/libs/vault/src/components/add-item-dialog/add-item-dialog.component.spec.ts
@@ -93,4 +93,41 @@ describe("AddItemDialogComponent", () => {
 
     expect(close).toHaveBeenCalledWith({ result: AddItemDialogResult.Collection });
   });
+
+  describe("dialogSize", () => {
+    it('is "large" when the grid has 6 or more items', () => {
+      createComponent({
+        canCreateFolder: false,
+        canCreateCollection: false,
+        canCreateSshKey: true,
+      });
+
+      expect(fixture.componentInstance["dialogSize"]()).toBe("large");
+    });
+
+    it('is "default" when the grid has fewer than 6 items', () => {
+      createComponent({
+        canCreateFolder: false,
+        canCreateCollection: false,
+        canCreateSshKey: false,
+      });
+
+      expect(fixture.componentInstance["dialogSize"]()).toBe("default");
+    });
+
+    it('switches to "default" when a cipher type becomes restricted', () => {
+      createComponent({
+        canCreateFolder: false,
+        canCreateCollection: false,
+        canCreateSshKey: true,
+      });
+
+      expect(fixture.componentInstance["dialogSize"]()).toBe("large");
+
+      restricted$.next([{ cipherType: CipherType.Card, allowViewOrgIds: [] } as any]);
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance["dialogSize"]()).toBe("default");
+    });
+  });
 });

--- a/libs/vault/src/components/add-item-dialog/add-item-dialog.component.ts
+++ b/libs/vault/src/components/add-item-dialog/add-item-dialog.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, inject } from "@angular/core";
+import { ChangeDetectionStrategy, Component, computed, inject, viewChild } from "@angular/core";
 
 import { DIALOG_DATA, DialogModule, DialogRef, DialogService } from "@bitwarden/components";
 import { I18nPipe } from "@bitwarden/ui-common";
@@ -23,6 +23,11 @@ export type AddItemDialogData = {
 export class AddItemDialogComponent {
   protected readonly dialogRef = inject<DialogRef<AddItemDialogCloseResult>>(DialogRef);
   protected readonly data = inject<AddItemDialogData>(DIALOG_DATA);
+
+  private readonly grid = viewChild.required(AddItemGridComponent);
+  protected readonly dialogSize = computed(() =>
+    this.grid().items().length >= 6 ? "large" : "default",
+  );
 
   protected onItemSelected(closeResult: AddItemDialogCloseResult): void {
     void this.dialogRef.close(closeResult);

--- a/libs/vault/src/components/add-item-grid/add-item-grid.component.ts
+++ b/libs/vault/src/components/add-item-grid/add-item-grid.component.ts
@@ -52,7 +52,7 @@ export class AddItemGridComponent {
     initialValue: [] as RestrictedCipherType[],
   });
 
-  protected readonly items = computed<GridItem[]>(() => {
+  readonly items = computed<GridItem[]>(() => {
     const restrictedTypes = this.restrictedTypes();
     const items: GridItem[] = DIALOG_CIPHER_MENU_ITEMS.filter((item) => {
       if (!this.canCreateSshKey() && item.type === CipherType.SshKey) {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-36015](https://bitwarden.atlassian.net/browse/PM-36015)

## 📔 Objective

When an org policy (e.g. "Remove card item type") reduces the add-item grid to fewer than 6 items, the grid correctly switches to a 1-column layout, but the wrapping dialog remained hardcoded to `dialogSize="large"`. This PR makes the dialog size reactive: it uses `"large"` for 6+ items and `"default"` for fewer, matching the grid's column count. 

## 📸 Screenshots

|Before|After|
|-|-|
|<img width="1727" height="910" alt="Screenshot 2026-04-29 at 8 43 27 PM" src="https://github.com/user-attachments/assets/9cd90aea-2b14-4230-9ff2-4e5b8a4b71d6" />|<img width="1726" height="911" alt="Screenshot 2026-04-29 at 8 42 31 PM" src="https://github.com/user-attachments/assets/df39e999-f628-4d30-bd8b-38b3b313c1b2" />|

[PM-36015]: https://bitwarden.atlassian.net/browse/PM-36015?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ