### PR TITLE
fix BIT workflow call

### DIFF
--- a/.github/workflows/test-browser-interactions.yml
+++ b/.github/workflows/test-browser-interactions.yml
@@ -56,7 +56,6 @@ jobs:
         private-key: ${{ steps.get-kv-secrets.outputs.BW-GHAPP-KEY }}
         owner: bitwarden
         repositories: browser-interactions-testing
-        permission-actions: write
         permission-contents: write
 
     - name: Get changed files
@@ -74,13 +73,14 @@ jobs:
 
     - name: Trigger test-all workflow in browser-interactions-testing
       if: steps.changed-files.outputs.monitored == 'true'
-      uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
-      with:
-        token: ${{ steps.app-token.outputs.token }}
-        repository: "bitwarden/browser-interactions-testing"
-        event-type: trigger-bit-tests
-        client-payload: |-
-          {
-            "origin_issue": ${{ github.event.workflow_run.pull_requests[0].number }},
-            "origin_branch": ${{ toJSON(github.event.workflow_run.pull_requests[0].head.ref) }}
-          }
+      env:
+        GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        ORIGIN_ISSUE: ${{ github.event.workflow_run.pull_requests[0].number }}
+        ORIGIN_BRANCH: ${{ github.event.workflow_run.pull_requests[0].head.ref }}
+      run: |
+        gh api repos/bitwarden/browser-interactions-testing/dispatches \
+          --method POST \
+          --input - <<< "$(jq -n \
+            --argjson origin_issue "$ORIGIN_ISSUE" \
+            --arg origin_branch "$ORIGIN_BRANCH" \
+            '{event_type: "trigger-bit-tests", client_payload: {origin_issue: $origin_issue, origin_branch: $origin_branch}}')"


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

Replaces the peter-evans/repository-dispatch third-party action with a native gh api + jq call to trigger the BIT repository_dispatch event. Also removes permission-actions: write from the app token request (only contents: write is needed), which fixes token generation failures caused by the permission not being granted to the app installation.