### PR TITLE
[bre-1874] switch BIT to workflow dispatch

### DIFF
--- a/.github/workflows/test-browser-interactions.yml
+++ b/.github/workflows/test-browser-interactions.yml
@@ -56,7 +56,7 @@ jobs:
         private-key: ${{ steps.get-kv-secrets.outputs.BW-GHAPP-KEY }}
         owner: bitwarden
         repositories: browser-interactions-testing
-        permission-contents: write
+        permission-actions: write
 
     - name: Get changed files
       id: changed-files
@@ -78,9 +78,11 @@ jobs:
         ORIGIN_ISSUE: ${{ github.event.workflow_run.pull_requests[0].number }}
         ORIGIN_BRANCH: ${{ github.event.workflow_run.pull_requests[0].head.ref }}
       run: |
-        gh api repos/bitwarden/browser-interactions-testing/dispatches \
-          --method POST \
-          --input - <<< "$(jq -n \
-            --argjson origin_issue "$ORIGIN_ISSUE" \
-            --arg origin_branch "$ORIGIN_BRANCH" \
-            '{event_type: "trigger-bit-tests", client_payload: {origin_issue: $origin_issue, origin_branch: $origin_branch}}')"
+        gh workflow run test-all.yml \
+          --repo bitwarden/browser-interactions-testing \
+          --field CLIENTS_BRANCH="$ORIGIN_BRANCH" \
+          --field origin_issue="$ORIGIN_ISSUE"
+        gh workflow run test-all-custom-flags.yml \
+          --repo bitwarden/browser-interactions-testing \
+          --field CLIENTS_BRANCH="$ORIGIN_BRANCH" \
+          --field origin_issue="$ORIGIN_ISSUE"


### PR DESCRIPTION
## 🎟️ Tracking

[bre-1874](https://bitwarden.atlassian.net/browse/bre-1874)

## 📔 Objective

[BIT repo workflow](https://github.com/bitwarden/browser-interactions-testing/pull/483)
Switches the BIT trigger to `workflow_dispatch` to be compatible with app perms

Also triggers `test-all-custom-flags.yml` explicitly, matching the previous behavior where both workflows fired on every dispatch.