### PR TITLE
[PM-36186] use mousedown for ng-select outside-click detection

### DIFF
--- a/libs/components/src/multi-select/multi-select.component.html
+++ b/libs/components/src/multi-select/multi-select.component.html
@@ -18,6 +18,7 @@
   [labelForId]="labelForId"
   [keyDownFn]="keyDown"
   appendTo="body"
+  outsideClickEvent="mousedown"
 >
   <ng-template ng-loadingspinner-tmp>
     <bit-spinner size="small"></bit-spinner>

--- a/libs/components/src/select/select.component.html
+++ b/libs/components/src/select/select.component.html
@@ -9,6 +9,7 @@
   [clearable]="false"
   (close)="onClose()"
   appendTo="body"
+  outsideClickEvent="mousedown"
   [keyDownFn]="onKeyDown"
   [attr.aria-label]="selectedOption()?.label ?? placeholder()"
 >


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-36186

## 📔 Objective
Problem: After upgrading @ng-select/ng-select to v20.7.0, dropdowns on the Provider setup page close immediately after the first click. When the user clicks the trigger, ng-select opens the panel synchronously (via detectChanges()) during the mousedown event, which registers a document-level click capture listener. The subsequent click event (from the same interaction) fires that listener before the target receives it, _checkToClose() determines the click is outside the select, and the dropdown closes itself.

Fix: ng-select 20.7.0 introduced an outsideClickEvent input for exactly this case. Setting it to "mousedown" means the panel's outside-click listener is registered during the mousedown event — after the document's capture phase for that event has already passed. The opening mousedown can therefore never re-trigger its own close listener. Subsequent mousedowns outside the select still close it correctly.

- Fix bug in provider setup where select dropdown menus open then close immediately 

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
