### PR TITLE
[PM-32833] Remove Input Password Flag from InputPasswordComponent

### DIFF
--- a/libs/auth/src/angular/input-password/input-password.component.ts
+++ b/libs/auth/src/angular/input-password/input-password.component.ts
@@ -11,9 +11,7 @@ import {
 import { AuditService } from "@bitwarden/common/abstractions/audit.service";
 import { PolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
 import { MasterPasswordPolicyOptions } from "@bitwarden/common/admin-console/models/domain/master-password-policy-options";
-import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { MasterPasswordServiceAbstraction } from "@bitwarden/common/key-management/master-password/abstractions/master-password.service.abstraction";
-import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { ValidationService } from "@bitwarden/common/platform/abstractions/validation.service";
@@ -36,12 +34,7 @@ import {
   Translation,
 } from "@bitwarden/components";
 import { PasswordGenerationServiceAbstraction } from "@bitwarden/generator-legacy";
-import {
-  DEFAULT_KDF_CONFIG,
-  KdfConfig,
-  KdfConfigService,
-  KeyService,
-} from "@bitwarden/key-management";
+import { DEFAULT_KDF_CONFIG, KdfConfig, KdfConfigService } from "@bitwarden/key-management";
 
 import { PasswordCalloutComponent } from "../password-callout/password-callout.component";
 import { compareInputs, ValidationGoal } from "../validators/compare-inputs.validator";
@@ -210,12 +203,10 @@ export class InputPasswordComponent implements OnInit {
   constructor(
     private auditService: AuditService,
     private cipherService: CipherService,
-    private configService: ConfigService,
     private dialogService: DialogService,
     private formBuilder: FormBuilder,
     private i18nService: I18nService,
     private kdfConfigService: KdfConfigService,
-    private keyService: KeyService,
     private masterPasswordService: MasterPasswordServiceAbstraction,
     private passwordGenerationService: PasswordGenerationServiceAbstraction,
     private platformUtilsService: PlatformUtilsService,
@@ -351,11 +342,6 @@ export class InputPasswordComponent implements OnInit {
         throw new Error("Salt not found.");
       }
 
-      // When you unwind the flag in PM-28143, also remove the ConfigService if it is un-used.
-      const newApisWithInputPasswordFlagEnabled = await this.configService.getFeatureFlag(
-        FeatureFlag.PM27086_UpdateAuthenticationApisForInputPassword,
-      );
-
       // 3. Verify new password
       const newPasswordVerified = await this.verifyNewPassword(
         newPassword,
@@ -366,79 +352,26 @@ export class InputPasswordComponent implements OnInit {
         return;
       }
 
-      if (newApisWithInputPasswordFlagEnabled) {
-        // 4. Build a PasswordInputResult object
-        const passwordInputResult: PasswordInputResult = {
-          newPassword,
-          kdfConfig: this.kdfConfig,
-          salt,
-          newPasswordHint,
-          newApisWithInputPasswordFlagEnabled, // To be removed in PM-28143
-        };
-
-        if (
-          this.flow === InputPasswordFlow.ChangePassword ||
-          this.flow === InputPasswordFlow.ChangePasswordWithOptionalUserKeyRotation
-        ) {
-          passwordInputResult.currentPassword = currentPassword;
-        }
-
-        if (this.flow === InputPasswordFlow.ChangePasswordWithOptionalUserKeyRotation) {
-          passwordInputResult.rotateUserKey = this.formGroup.controls.rotateUserKey?.value;
-        }
-
-        // 5. Emit and return PasswordInputResult object
-        this.onPasswordFormSubmit.emit(passwordInputResult);
-        return passwordInputResult;
-      }
-
-      /*******************************************************************
-       * The following code (within this `try`) to be removed in PM-28143
-       *******************************************************************/
-
-      // 4. Create cryptographic keys and build a PasswordInputResult object
-      const newMasterKey = await this.keyService.makeMasterKey(
-        newPassword,
-        this.email,
-        this.kdfConfig,
-      );
-
-      const newServerMasterKeyHash = await this.keyService.hashMasterKey(newPassword, newMasterKey);
-
+      // 4. Build a PasswordInputResult object
       const passwordInputResult: PasswordInputResult = {
         newPassword,
-        salt,
-        newMasterKey,
-        newServerMasterKeyHash,
-        newPasswordHint,
         kdfConfig: this.kdfConfig,
+        salt,
+        newPasswordHint,
       };
 
       if (
         this.flow === InputPasswordFlow.ChangePassword ||
         this.flow === InputPasswordFlow.ChangePasswordWithOptionalUserKeyRotation
       ) {
-        const currentMasterKey = await this.keyService.makeMasterKey(
-          currentPassword,
-          this.email,
-          this.kdfConfig,
-        );
-
-        const currentServerMasterKeyHash = await this.keyService.hashMasterKey(
-          currentPassword,
-          currentMasterKey,
-        );
-
         passwordInputResult.currentPassword = currentPassword;
-        passwordInputResult.currentMasterKey = currentMasterKey;
-        passwordInputResult.currentServerMasterKeyHash = currentServerMasterKeyHash;
       }
 
       if (this.flow === InputPasswordFlow.ChangePasswordWithOptionalUserKeyRotation) {
         passwordInputResult.rotateUserKey = this.formGroup.controls.rotateUserKey?.value;
       }
 
-      // 5. Emit cryptographic keys and other password related properties
+      // 5. Emit and return PasswordInputResult object
       this.onPasswordFormSubmit.emit(passwordInputResult);
       return passwordInputResult;
     } catch (e) {

--- a/libs/auth/src/angular/input-password/input-password.stories.ts
+++ b/libs/auth/src/angular/input-password/input-password.stories.ts
@@ -10,7 +10,6 @@ import { PolicyService } from "@bitwarden/common/admin-console/abstractions/poli
 import { MasterPasswordPolicyOptions } from "@bitwarden/common/admin-console/models/domain/master-password-policy-options";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { MasterPasswordServiceAbstraction } from "@bitwarden/common/key-management/master-password/abstractions/master-password.service.abstraction";
-import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { ValidationService } from "@bitwarden/common/platform/abstractions/validation.service";
 import { PasswordStrengthServiceAbstraction } from "@bitwarden/common/tools/password-strength";
@@ -20,7 +19,7 @@ import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.servi
 // eslint-disable-next-line no-restricted-imports
 import { DialogService, ToastService } from "@bitwarden/components";
 import { PasswordGenerationServiceAbstraction } from "@bitwarden/generator-legacy";
-import { DEFAULT_KDF_CONFIG, KdfConfigService, KeyService } from "@bitwarden/key-management";
+import { DEFAULT_KDF_CONFIG, KdfConfigService } from "@bitwarden/key-management";
 
 // FIXME: remove `/apps` import from `/libs`
 // FIXME: remove `src` and fix import
@@ -60,13 +59,6 @@ export default {
             getAllDecrypted: () => Promise.resolve([]),
           },
         },
-        // Can remove ConfigService from component and stories in PM-28143 (if it is no longer used)
-        {
-          provide: ConfigService,
-          useValue: {
-            getFeatureFlag: () => false, // default to false since flag does not effect UI
-          },
-        },
         {
           provide: KdfConfigService,
           useValue: {
@@ -84,13 +76,6 @@ export default {
           useValue: {
             launchUri: () => Promise.resolve(true),
             copyToClipboard: () => true,
-          },
-        },
-        {
-          provide: KeyService,
-          useValue: {
-            makeMasterKey: () => Promise.resolve("example-master-key"),
-            hashMasterKey: () => Promise.resolve("example-master-key-hash"),
           },
         },
         {

--- a/libs/auth/src/angular/input-password/password-input-result.ts
+++ b/libs/auth/src/angular/input-password/password-input-result.ts
@@ -11,25 +11,6 @@ export interface PasswordInputResult {
   rotateUserKey?: boolean;
 
   /**
-   * Temporary property that persists the flag state through the entire set/change password process.
-   * This allows flows to consume this value instead of re-checking the flag state via ConfigService themselves.
-   *
-   * The ChangePasswordDelegation flows (Emergency Access Takeover and Account Recovery), however, only ever
-   * require a raw newPassword from the InputPasswordComponent regardless of whether the flag is on or off.
-   * Flagging for those 2 flows will be done via the ConfigService in their respective services.
-   *
-   * To be removed in PM-28143
-   */
-  newApisWithInputPasswordFlagEnabled?: boolean;
-
-  // The deprecated properties below will be removed in PM-28143: https://bitwarden.atlassian.net/browse/PM-28143
-
-  /** @deprecated This low-level cryptographic state will be removed. It will be replaced by high level calls to masterpassword service, in the consumers of this interface. */
-  currentMasterKey?: MasterKey;
-  /** @deprecated */
-  currentServerMasterKeyHash?: string;
-
-  /**
    * @deprecated Still required by the JIT_PROVISIONED_MP_ORG_USER flow in SetInitialPasswordComponent.
    * Will be removed when that flow is updated to use MasterPasswordAuthenticationData and
    * MasterPasswordUnlockData as part of https://bitwarden.atlassian.net/browse/PM-32526

--- a/libs/common/src/enums/feature-flag.enum.ts
+++ b/libs/common/src/enums/feature-flag.enum.ts
@@ -18,7 +18,6 @@ export enum FeatureFlag {
   PolicyDrawers = "pm-34804-policy-drawers",
 
   /* Auth */
-  PM27086_UpdateAuthenticationApisForInputPassword = "pm-27086-update-authentication-apis-for-input-password",
   SafariAccountSwitching = "pm-5594-safari-account-switching",
   PM30811_ChangeEmailNewAuthenticationApis = "pm-30811-change-email-new-authentication-apis",
   PM31088_MasterPasswordServiceEmitSalt = "pm-31088-master-password-service-emit-salt",
@@ -167,7 +166,6 @@ export const DefaultFeatureFlagValue = {
   [FeatureFlag.PM34500_StrictCipherDecryption]: FALSE,
 
   /* Auth */
-  [FeatureFlag.PM27086_UpdateAuthenticationApisForInputPassword]: FALSE,
   [FeatureFlag.SafariAccountSwitching]: FALSE,
   [FeatureFlag.PM30811_ChangeEmailNewAuthenticationApis]: FALSE,
   [FeatureFlag.PM31088_MasterPasswordServiceEmitSalt]: FALSE,


### PR DESCRIPTION
## 🎟️ Tracking

[PM-32833](https://bitwarden.atlassian.net/browse/PM-32833)

## 📔 Objective

This PR removes `pm-27086-update-authentication-apis-for-input-password` feature flag usage from the `InputPasswordComponent` and related files.

<br />

> [!NOTE]
> This PR is part of a larger group of PRs (split up for easier review) that will each get merged into a base branch for this flag removal work: `auth/pm-32833/remove-input-password-flag-base` ([base PR](https://github.com/bitwarden/clients/pull/20306)). That base branch is the one that will get merged to `main`.
>
> Breakdown of branching structure:
> ```
> main
>  └── auth/pm-32833/remove-input-password-flag-base  ← targets main; accumulates sub-PRs
>      ├── auth/pm-32833/registration-finish            ← targets base
>      ├── auth/pm-32833/set-initial-password           ← targets base
>      ├── auth/pm-32833/change-password                ← targets base
>      ├── auth/pm-32833/emergency-access               ← targets base
>      ├── auth/pm-32833/account-recovery               ← targets base
>      └── auth/pm-32833/input-password-component       ← targets base; reviewed LAST [THIS PR 🟢]
> ```

[PM-32833]: https://bitwarden.atlassian.net/browse/PM-32833?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
