### PR TITLE
[PM-35153] Revert collection encrypt implementation

### DIFF
--- a/libs/admin-console/src/common/collections/abstractions/collection-encryption.service.ts
+++ b/libs/admin-console/src/common/collections/abstractions/collection-encryption.service.ts
@@ -25,14 +25,4 @@ export abstract class CollectionEncryptionService {
    * @returns A promise that resolves to an array of decrypted collection views
    */
   abstract decryptMany(collections: Collection[], userId: UserId): Promise<CollectionView[]>;
-
-  /**
-   * Encrypts a collection view using the SDK for the given userId.
-   *
-   * @param collectionView The decrypted collection view to encrypt
-   * @param userId The user ID whose keys will be used for encryption
-   *
-   * @returns A promise that resolves to the encrypted collection
-   */
-  abstract encrypt(collectionView: CollectionView, userId: UserId): Promise<Collection>;
 }

--- a/libs/admin-console/src/common/collections/services/default-collection-encryption.service.spec.ts
+++ b/libs/admin-console/src/common/collections/services/default-collection-encryption.service.spec.ts
@@ -206,36 +206,4 @@ describe("DefaultCollectionEncryptionService", () => {
       );
     });
   });
-
-  describe("encrypt", () => {
-    it("encrypts a collection view and maps the result to a Collection", async () => {
-      const view = new CollectionView({
-        id: collectionId,
-        organizationId: orgId,
-        name: "My Collection",
-      });
-      jest.spyOn(view, "toSdkCollectionView").mockReturnValue({} as SdkCollectionView);
-      mockEncrypt.mockReturnValue(stubSdkCollection);
-
-      const result = await service.encrypt(view, userId);
-
-      expect(mockEncrypt).toHaveBeenCalled();
-      expect(result).toBeInstanceOf(Collection);
-    });
-
-    it("logs the error and rejects when the SDK throws during encrypt", async () => {
-      const view = new CollectionView({
-        id: collectionId,
-        organizationId: orgId,
-        name: "My Collection",
-      });
-      jest.spyOn(view, "toSdkCollectionView").mockReturnValue({} as SdkCollectionView);
-      mockEncrypt.mockImplementation(() => {
-        throw new Error("encrypt failure");
-      });
-
-      await expect(service.encrypt(view, userId)).rejects.toThrow();
-      expect(logService.error).toHaveBeenCalledWith(expect.stringContaining("Failed to encrypt"));
-    });
-  });
 });

--- a/libs/admin-console/src/common/collections/services/default-collection-encryption.service.ts
+++ b/libs/admin-console/src/common/collections/services/default-collection-encryption.service.ts
@@ -56,27 +56,4 @@ export class DefaultCollectionEncryptionService implements CollectionEncryptionS
       ),
     );
   }
-
-  async encrypt(collectionView: CollectionView, userId: UserId): Promise<Collection> {
-    return firstValueFrom(
-      this.sdkService.userClient$(userId).pipe(
-        concatMap(async (sdk) => {
-          if (!sdk) {
-            throw new Error("SDK not available");
-          }
-
-          using ref = sdk.take();
-          const sdkCollection = (ref.value.vault().collections() as any).encrypt(
-            collectionView.toSdkCollectionView(),
-          );
-
-          return Collection.fromSdkCollection(sdkCollection);
-        }),
-        catchError((error: unknown) => {
-          this.logService.error(`Failed to encrypt collection: ${error}`);
-          throw error;
-        }),
-      ),
-    );
-  }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-34918
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
`CollectionEncryptionService.encrypt` was implemented but not properly wired up to the SDK. The SDK implementation also needs some work. Reverting this method in the meantime so that nobody starts using it.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
