### PR TITLE
Improve TOTP field detection by accepting auth_code as unambiguous TOTP and checking div-name in case of ambiguity.

### DIFF
--- a/apps/browser/src/autofill/models/autofill-field.ts
+++ b/apps/browser/src/autofill/models/autofill-field.ts
@@ -135,6 +135,16 @@ export default class AutofillField {
    * used for totp multiline calculations
    */
   fieldRect?: FieldRect;
+
+  /**
+   * The `id` of the closest ancestor div, used for TOTP container detection
+   */
+  containerHtmlID?: string | null;
+
+  /**
+   * The `class` of the closest ancestor div, used for TOTP container detection
+   */
+  containerHtmlClass?: string | null;
 }
 
 /** `readonly` / `disabled` from collected field data; a full {@link AutofillField} is assignable. */

--- a/apps/browser/src/autofill/services/autofill-constants.ts
+++ b/apps/browser/src/autofill/services/autofill-constants.ts
@@ -81,6 +81,7 @@ export class AutoFillConstants {
     "totpcode",
     "2facode",
     "approvals_code",
+    "auth_code",
     "mfacode",
     "otc-code",
     "onetimecode",
@@ -92,13 +93,22 @@ export class AutoFillConstants {
     "twofactor",
     "twofa",
     "twofactorcode",
+    "tfa_code",
     "verificationcode",
     "verification code",
   ];
 
   static readonly RecoveryCodeFieldNames: string[] = ["backup", "recovery"];
 
-  static readonly AmbiguousTotpFieldNames: string[] = ["code", "pin", "otc", "otp", "2fa", "mfa"];
+  static readonly AmbiguousTotpFieldNames: string[] = [
+    "code",
+    "pin",
+    "otc",
+    "otp",
+    "token",
+    "2fa",
+    "mfa",
+  ];
 
   static readonly SearchFieldNames: string[] = ["search", "query", "find", "go"];
 

--- a/apps/browser/src/autofill/services/collect-autofill-content.service.ts
+++ b/apps/browser/src/autofill/services/collect-autofill-content.service.ts
@@ -531,6 +531,9 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
       return existingAutofillField;
     }
 
+    // Capture the closest ancestor div's id/class so TOTP field qualification can
+    // upgrade ambiguous signals to strong when the container carries TOTP keywords.
+    const containerDiv = element.closest("div");
     const autofillFieldBase: AutofillField = {
       opid: element.opid,
       elementNumber: index,
@@ -543,6 +546,8 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
       title: this.getPropertyOrAttribute(element, AUTOFILL_ATTRIBUTES.TITLE),
       tagName: this.getAttributeLowerCase(element, "tagName"),
       dataSetValues: this.getDataSetValues(element),
+      containerHtmlID: containerDiv?.id ?? null,
+      containerHtmlClass: containerDiv?.className ?? null,
     };
 
     if (!autofillFieldBase.viewable) {

--- a/apps/browser/src/autofill/utils/qualification.ts
+++ b/apps/browser/src/autofill/utils/qualification.ts
@@ -58,6 +58,10 @@ function buildAutofillFieldKeywords(field: AutofillField) {
     field["label-right"],
     field["label-tag"],
     field["label-top"],
+    // Parent container attributes let ambiguous TOTP fields inside a
+    // TOTP-signaling container get upgraded to a strong TOTP match.
+    field.containerHtmlID,
+    field.containerHtmlClass,
   ];
   const keywordsSet = new Set<string>();
   for (const attributeValue of attributeValues) {


### PR DESCRIPTION
## 🎟️ Tracking

Untracked, but I am also addressing the learnings from #14237 and #17959 by adding `token` as ambiguous as well as `tfa_code` as non-ambiguous without knowing which websites this applies to.

## 📔 Objective

I would like to be able to auto-fill the TOTP on any Bugzilla-instance as well as on https://accounts.hetzner.com/, https://rsync.net/ and some other websites.

## 📸 Screenshots

n/a