### PR TITLE
Remove unused NgIf import from SetupExtensionComponent

### DIFF
--- a/apps/web/src/app/vault/components/setup-extension/setup-extension.component.ts
+++ b/apps/web/src/app/vault/components/setup-extension/setup-extension.component.ts
@@ -1,4 +1,3 @@
-import { NgIf } from "@angular/common";
 import { Component, DestroyRef, inject, OnDestroy, OnInit, DOCUMENT } from "@angular/core";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { Router, RouterModule } from "@angular/router";
@@ -48,7 +47,6 @@ type SetupExtensionState = UnionOfValues<typeof SetupExtensionState>;
   selector: "vault-setup-extension",
   templateUrl: "./setup-extension.component.html",
   imports: [
-    NgIf,
     JslibModule,
     ButtonComponent,
     LinkModule,


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

Remove the unused `NgIf` import from `SetupExtensionComponent`. The template uses Angular's `@if` control flow syntax exclusively, so `NgIf` was never needed and was producing a build warning.

## 📸 Screenshots

N/A