### PR TITLE
[PM-36629] Cipher Filter Refactor + Feature Flags

### DIFF
--- a/apps/desktop/src/app/services/services.module.ts
+++ b/apps/desktop/src/app/services/services.module.ts
@@ -571,6 +571,7 @@ const safeProviders: SafeProvider[] = [
       StateProvider,
       CollectionService,
       AccountServiceAbstraction,
+      ConfigService,
     ],
   }),
   safeProvider({

--- a/apps/web/src/app/admin-console/organizations/collections/vault-filter/vault-filter.component.spec.ts
+++ b/apps/web/src/app/admin-console/organizations/collections/vault-filter/vault-filter.component.spec.ts
@@ -69,6 +69,7 @@ describe("OrganizationVaultFilterComponent", () => {
       },
       { id: "login", name: "typeLogin", type: CipherType.Login, icon: "bwi-globe" },
       { id: "card", name: "typeCard", type: CipherType.Card, icon: "bwi-credit-card" },
+      { id: "bankAccount", name: "bankAccount", type: CipherType.BankAccount, icon: "bwi-bank" },
       { id: "identity", name: "typeIdentity", type: CipherType.Identity, icon: "bwi-id-card" },
       { id: "note", name: "typeSecureNote", type: CipherType.SecureNote, icon: "bwi-sticky-note" },
       { id: "sshKey", name: "typeSshKey", type: CipherType.SshKey, icon: "bwi-key" },

--- a/apps/web/src/app/admin-console/organizations/collections/vault-filter/vault-filter.component.spec.ts
+++ b/apps/web/src/app/admin-console/organizations/collections/vault-filter/vault-filter.component.spec.ts
@@ -5,7 +5,6 @@ import { BehaviorSubject, firstValueFrom, Observable, of } from "rxjs";
 
 import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
-import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { mockAccountServiceWith } from "@bitwarden/common/spec";
 import { OrganizationId, UserId } from "@bitwarden/common/types/guid";
@@ -61,6 +60,19 @@ describe("OrganizationVaultFilterComponent", () => {
       return of(headNode);
     });
     vaultFilterService.collapsedFilterNodes$ = of(new Set<string>());
+    vaultFilterService.cipherTypeFilters$ = of([
+      {
+        id: "favorites",
+        name: "favorites",
+        type: "favorites" as CipherTypeFilter["type"],
+        icon: "bwi-star",
+      },
+      { id: "login", name: "typeLogin", type: CipherType.Login, icon: "bwi-globe" },
+      { id: "card", name: "typeCard", type: CipherType.Card, icon: "bwi-credit-card" },
+      { id: "identity", name: "typeIdentity", type: CipherType.Identity, icon: "bwi-id-card" },
+      { id: "note", name: "typeSecureNote", type: CipherType.SecureNote, icon: "bwi-sticky-note" },
+      { id: "sshKey", name: "typeSshKey", type: CipherType.SshKey, icon: "bwi-key" },
+    ]);
     vaultFilterService.setCollapsedFilterNodes = jest.fn().mockResolvedValue(undefined);
     vaultFilterService.setOrganizationFilter = jest.fn();
 
@@ -81,10 +93,6 @@ describe("OrganizationVaultFilterComponent", () => {
         {
           provide: RestrictedItemTypesService,
           useValue: { restricted$: restrictedSubject.asObservable() },
-        },
-        {
-          provide: ConfigService,
-          useValue: { getFeatureFlag$: jest.fn().mockReturnValue(of(true)) },
         },
       ],
     }).compileComponents();

--- a/apps/web/src/app/admin-console/organizations/collections/vault-filter/vault-filter.component.ts
+++ b/apps/web/src/app/admin-console/organizations/collections/vault-filter/vault-filter.component.ts
@@ -222,8 +222,9 @@ export class VaultFilterComponent {
     const data$ = combineLatest([
       this.restrictedItemTypesService.restricted$,
       this.ciphers$(),
+      this.configService.getFeatureFlag$(FeatureFlag.PM32009NewItemTypes),
     ]).pipe(
-      map(([restrictedTypes, ciphers]) => {
+      map(([restrictedTypes, ciphers, newItemTypes]) => {
         const restrictedForUser = restrictedTypes
           .filter((r) => {
             if (r.allowViewOrgIds.length === 0) {
@@ -245,7 +246,13 @@ export class VaultFilterComponent {
           .map((r) => r.cipherType);
 
         const toExclude = [...excludeTypes, ...restrictedForUser];
-        return this.allTypeFilters.filter((f) => !toExclude.includes(f.type));
+        return this.allTypeFilters
+          .filter((f) => !toExclude.includes(f.type))
+          .map((f): CipherTypeFilter => {
+            if (newItemTypes && f.type === CipherType.Login) {return { ...f, icon: "bwi-lock" };}
+            if (newItemTypes && f.type === CipherType.Identity) {return { ...f, icon: "bwi-user" };}
+            return f;
+          });
       }),
       switchMap((allowed) => this.vaultFilterService.buildTypeTree(allFilter, allowed)),
       distinctUntilChanged(),

--- a/apps/web/src/app/admin-console/organizations/collections/vault-filter/vault-filter.component.ts
+++ b/apps/web/src/app/admin-console/organizations/collections/vault-filter/vault-filter.component.ts
@@ -249,8 +249,12 @@ export class VaultFilterComponent {
         return this.allTypeFilters
           .filter((f) => !toExclude.includes(f.type))
           .map((f): CipherTypeFilter => {
-            if (newItemTypes && f.type === CipherType.Login) {return { ...f, icon: "bwi-lock" };}
-            if (newItemTypes && f.type === CipherType.Identity) {return { ...f, icon: "bwi-user" };}
+            if (newItemTypes && f.type === CipherType.Login) {
+              return { ...f, icon: "bwi-lock" };
+            }
+            if (newItemTypes && f.type === CipherType.Identity) {
+              return { ...f, icon: "bwi-user" };
+            }
             return f;
           });
       }),

--- a/apps/web/src/app/admin-console/organizations/collections/vault-filter/vault-filter.component.ts
+++ b/apps/web/src/app/admin-console/organizations/collections/vault-filter/vault-filter.component.ts
@@ -24,8 +24,6 @@ import {
 import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { getUserId } from "@bitwarden/common/auth/services/account.service";
-import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
-import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { uuidAsString } from "@bitwarden/common/platform/abstractions/sdk/sdk.service";
 import { CipherType } from "@bitwarden/common/vault/enums";
@@ -56,7 +54,6 @@ export class VaultFilterComponent {
   private readonly accountService = inject(AccountService);
   private readonly restrictedItemTypesService = inject(RestrictedItemTypesService);
   private readonly destroyRef = inject(DestroyRef);
-  private readonly configService = inject(ConfigService);
 
   readonly activeFilter = input<VaultFilter>(new VaultFilter());
   readonly searchText = model("");
@@ -75,39 +72,6 @@ export class VaultFilterComponent {
   });
 
   private readonly activeUserId$ = this.accountService.activeAccount$.pipe(getUserId);
-
-  readonly allTypeFilters: CipherTypeFilter[] = [
-    {
-      id: "login",
-      name: this.i18nService.t("typeLogin"),
-      type: CipherType.Login,
-      icon: "bwi-globe",
-    },
-    {
-      id: "card",
-      name: this.i18nService.t("typeCard"),
-      type: CipherType.Card,
-      icon: "bwi-credit-card",
-    },
-    {
-      id: "identity",
-      name: this.i18nService.t("typeIdentity"),
-      type: CipherType.Identity,
-      icon: "bwi-id-card",
-    },
-    {
-      id: "note",
-      name: this.i18nService.t("note"),
-      type: CipherType.SecureNote,
-      icon: "bwi-sticky-note",
-    },
-    {
-      id: "sshKey",
-      name: this.i18nService.t("typeSshKey"),
-      type: CipherType.SshKey,
-      icon: "bwi-key",
-    },
-  ];
 
   get searchPlaceholder() {
     const filter = this.activeFilter();
@@ -222,9 +186,9 @@ export class VaultFilterComponent {
     const data$ = combineLatest([
       this.restrictedItemTypesService.restricted$,
       this.ciphers$(),
-      this.configService.getFeatureFlag$(FeatureFlag.PM32009NewItemTypes),
+      this.vaultFilterService.cipherTypeFilters$,
     ]).pipe(
-      map(([restrictedTypes, ciphers, newItemTypes]) => {
+      map(([restrictedTypes, ciphers, cipherTypeFilters]) => {
         const restrictedForUser = restrictedTypes
           .filter((r) => {
             if (r.allowViewOrgIds.length === 0) {
@@ -246,17 +210,7 @@ export class VaultFilterComponent {
           .map((r) => r.cipherType);
 
         const toExclude = [...excludeTypes, ...restrictedForUser];
-        return this.allTypeFilters
-          .filter((f) => !toExclude.includes(f.type))
-          .map((f): CipherTypeFilter => {
-            if (newItemTypes && f.type === CipherType.Login) {
-              return { ...f, icon: "bwi-lock" };
-            }
-            if (newItemTypes && f.type === CipherType.Identity) {
-              return { ...f, icon: "bwi-user" };
-            }
-            return f;
-          });
+        return cipherTypeFilters.filter((f) => !toExclude.includes(f.type));
       }),
       switchMap((allowed) => this.vaultFilterService.buildTypeTree(allFilter, allowed)),
       distinctUntilChanged(),
@@ -274,14 +228,7 @@ export class VaultFilterComponent {
   }
 
   async buildAllFilters(): Promise<VaultFilterList> {
-    const newTypesEnabled = await firstValueFrom(
-      this.configService.getFeatureFlag$(FeatureFlag.PM32009NewItemTypes),
-    );
-
     const excludeTypes: CipherStatus[] = ["favorites"];
-    if (!newTypesEnabled) {
-      excludeTypes.push(CipherType.BankAccount);
-    }
 
     const builderFilter = {} as VaultFilterList;
     builderFilter.typeFilter = await this.addTypeFilter(excludeTypes, this.organization()?.id);

--- a/apps/web/src/app/admin-console/organizations/collections/vault-filter/vault-filter.component.ts
+++ b/apps/web/src/app/admin-console/organizations/collections/vault-filter/vault-filter.component.ts
@@ -84,6 +84,9 @@ export class VaultFilterComponent {
     if (filter.cipherType === CipherType.Card) {
       return "searchCard";
     }
+    if (filter.cipherType === CipherType.BankAccount) {
+      return "searchBankAccount";
+    }
     if (filter.cipherType === CipherType.Identity) {
       return "searchIdentity";
     }

--- a/apps/web/src/app/admin-console/organizations/collections/vault-filter/vault-filter.service.ts
+++ b/apps/web/src/app/admin-console/organizations/collections/vault-filter/vault-filter.service.ts
@@ -6,6 +6,7 @@ import { OrganizationService } from "@bitwarden/common/admin-console/abstraction
 import { PolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
 import { CollectionAdminView } from "@bitwarden/common/admin-console/models/collections";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { StateProvider } from "@bitwarden/common/platform/state";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
@@ -33,6 +34,7 @@ export class VaultFilterService extends BaseVaultFilterService implements OnDest
     stateProvider: StateProvider,
     collectionService: CollectionService,
     accountService: AccountService,
+    configService: ConfigService,
   ) {
     super(
       organizationService,
@@ -43,6 +45,7 @@ export class VaultFilterService extends BaseVaultFilterService implements OnDest
       stateProvider,
       collectionService,
       accountService,
+      configService,
     );
   }
 

--- a/apps/web/src/app/vault/individual-vault/vault-filter/components/vault-filter.component.spec.ts
+++ b/apps/web/src/app/vault/individual-vault/vault-filter/components/vault-filter.component.spec.ts
@@ -6,7 +6,6 @@ import { BehaviorSubject, firstValueFrom, of } from "rxjs";
 import { PolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { BillingApiServiceAbstraction } from "@bitwarden/common/billing/abstractions/billing-api.service.abstraction";
-import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { mockAccountServiceWith } from "@bitwarden/common/spec";
@@ -63,6 +62,19 @@ describe("VaultFilterComponent", () => {
       });
       return of(headNode);
     });
+    vaultFilterService.cipherTypeFilters$ = of([
+      {
+        id: "favorites",
+        name: "favorites",
+        type: "favorites" as CipherTypeFilter["type"],
+        icon: "bwi-star",
+      },
+      { id: "login", name: "typeLogin", type: CipherType.Login, icon: "bwi-globe" },
+      { id: "card", name: "typeCard", type: CipherType.Card, icon: "bwi-credit-card" },
+      { id: "identity", name: "typeIdentity", type: CipherType.Identity, icon: "bwi-id-card" },
+      { id: "note", name: "typeSecureNote", type: CipherType.SecureNote, icon: "bwi-sticky-note" },
+      { id: "sshKey", name: "typeSshKey", type: CipherType.SshKey, icon: "bwi-key" },
+    ]);
 
     const policyService = mock<PolicyService>();
     policyService.policyAppliesToUser$.mockReturnValue(of(false));
@@ -98,7 +110,6 @@ describe("VaultFilterComponent", () => {
         { provide: CipherArchiveService, useValue: mock<CipherArchiveService>() },
         { provide: PremiumUpgradePromptService, useValue: mock<PremiumUpgradePromptService>() },
         { provide: OrganizationWarningsService, useValue: mock<OrganizationWarningsService>() },
-        { provide: ConfigService, useValue: mock<ConfigService>() },
       ],
     }).compileComponents();
 

--- a/apps/web/src/app/vault/individual-vault/vault-filter/components/vault-filter.component.ts
+++ b/apps/web/src/app/vault/individual-vault/vault-filter/components/vault-filter.component.ts
@@ -372,8 +372,12 @@ export class VaultFilterComponent implements OnInit, OnDestroy {
         return this.allTypeFilters
           .filter((f) => !toExclude.includes(f.type))
           .map((f): CipherTypeFilter => {
-            if (newItemTypes && f.type === CipherType.Login) {return { ...f, icon: "bwi-lock" };}
-            if (newItemTypes && f.type === CipherType.Identity) {return { ...f, icon: "bwi-user" };}
+            if (newItemTypes && f.type === CipherType.Login) {
+              return { ...f, icon: "bwi-lock" };
+            }
+            if (newItemTypes && f.type === CipherType.Identity) {
+              return { ...f, icon: "bwi-user" };
+            }
             return f;
           });
       }),

--- a/apps/web/src/app/vault/individual-vault/vault-filter/components/vault-filter.component.ts
+++ b/apps/web/src/app/vault/individual-vault/vault-filter/components/vault-filter.component.ts
@@ -341,8 +341,9 @@ export class VaultFilterComponent implements OnInit, OnDestroy {
     const data$ = combineLatest([
       this.restrictedItemTypesService.restricted$,
       this.cipherService.cipherListViews$(userId),
+      this.configService.getFeatureFlag$(FeatureFlag.PM32009NewItemTypes),
     ]).pipe(
-      map(([restrictedTypes, ciphers]) => {
+      map(([restrictedTypes, ciphers, newItemTypes]) => {
         const restrictedForUser = restrictedTypes
           .filter((r) => {
             // - All orgs restrict the type
@@ -368,7 +369,13 @@ export class VaultFilterComponent implements OnInit, OnDestroy {
           .map((r) => r.cipherType);
 
         const toExclude = [...excludeTypes, ...restrictedForUser];
-        return this.allTypeFilters.filter((f) => !toExclude.includes(f.type));
+        return this.allTypeFilters
+          .filter((f) => !toExclude.includes(f.type))
+          .map((f): CipherTypeFilter => {
+            if (newItemTypes && f.type === CipherType.Login) {return { ...f, icon: "bwi-lock" };}
+            if (newItemTypes && f.type === CipherType.Identity) {return { ...f, icon: "bwi-user" };}
+            return f;
+          });
       }),
       switchMap((allowed) => this.vaultFilterService.buildTypeTree(allFilter, allowed)),
       distinctUntilChanged(),

--- a/apps/web/src/app/vault/individual-vault/vault-filter/components/vault-filter.component.ts
+++ b/apps/web/src/app/vault/individual-vault/vault-filter/components/vault-filter.component.ts
@@ -18,8 +18,6 @@ import { getFirstPolicy } from "@bitwarden/common/admin-console/services/policy/
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { getUserId } from "@bitwarden/common/auth/services/account.service";
 import { BillingApiServiceAbstraction } from "@bitwarden/common/billing/abstractions/billing-api.service.abstraction";
-import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
-import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { uuidAsString } from "@bitwarden/common/platform/abstractions/sdk/sdk.service";
@@ -80,51 +78,6 @@ export class VaultFilterComponent implements OnInit, OnDestroy {
 
   protected organizationWarningsService = inject(OrganizationWarningsService);
 
-  allTypeFilters: CipherTypeFilter[] = [
-    {
-      id: "favorites",
-      name: this.i18nService.t("favorites"),
-      type: "favorites",
-      icon: "bwi-star",
-    },
-    {
-      id: "login",
-      name: this.i18nService.t("typeLogin"),
-      type: CipherType.Login,
-      icon: "bwi-globe",
-    },
-    {
-      id: "card",
-      name: this.i18nService.t("typeCard"),
-      type: CipherType.Card,
-      icon: "bwi-credit-card",
-    },
-    {
-      id: "identity",
-      name: this.i18nService.t("typeIdentity"),
-      type: CipherType.Identity,
-      icon: "bwi-id-card",
-    },
-    {
-      id: "note",
-      name: this.i18nService.t("note"),
-      type: CipherType.SecureNote,
-      icon: "bwi-sticky-note",
-    },
-    {
-      id: "sshKey",
-      name: this.i18nService.t("typeSshKey"),
-      type: CipherType.SshKey,
-      icon: "bwi-key",
-    },
-    {
-      id: "bankAccount",
-      name: this.i18nService.t("bankAccount"),
-      type: CipherType.BankAccount,
-      icon: "bwi-bank",
-    },
-  ];
-
   get searchPlaceholder() {
     if (this.activeFilter.isFavorites) {
       return "searchFavorites";
@@ -184,7 +137,6 @@ export class VaultFilterComponent implements OnInit, OnDestroy {
     protected cipherService: CipherService,
     protected cipherArchiveService: CipherArchiveService,
     private premiumUpgradePromptService: PremiumUpgradePromptService,
-    protected configService: ConfigService,
   ) {}
 
   async ngOnInit(): Promise<void> {
@@ -268,21 +220,11 @@ export class VaultFilterComponent implements OnInit, OnDestroy {
   };
 
   async buildAllFilters(): Promise<VaultFilterList> {
-    const [userId, newItemTypesEnabled] = await firstValueFrom(
-      combineLatest([
-        this.accountService.activeAccount$.pipe(getUserId),
-        this.configService.getFeatureFlag$(FeatureFlag.PM32009NewItemTypes),
-      ]),
-    );
-
-    const excludeTypes: CipherStatus[] = [];
-    if (!newItemTypesEnabled) {
-      excludeTypes.push(CipherType.BankAccount);
-    }
+    const userId = await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId));
 
     const builderFilter = {} as VaultFilterList;
     builderFilter.organizationFilter = await this.addOrganizationFilter();
-    builderFilter.typeFilter = await this.addTypeFilter(excludeTypes);
+    builderFilter.typeFilter = await this.addTypeFilter();
     builderFilter.folderFilter = await this.addFolderFilter();
     builderFilter.collectionFilter = await this.addCollectionFilter();
     builderFilter.archiveFilter = await this.addArchiveFilter(userId);
@@ -341,9 +283,9 @@ export class VaultFilterComponent implements OnInit, OnDestroy {
     const data$ = combineLatest([
       this.restrictedItemTypesService.restricted$,
       this.cipherService.cipherListViews$(userId),
-      this.configService.getFeatureFlag$(FeatureFlag.PM32009NewItemTypes),
+      this.vaultFilterService.cipherTypeFilters$,
     ]).pipe(
-      map(([restrictedTypes, ciphers, newItemTypes]) => {
+      map(([restrictedTypes, ciphers, cipherTypeFilters]) => {
         const restrictedForUser = restrictedTypes
           .filter((r) => {
             // - All orgs restrict the type
@@ -369,17 +311,7 @@ export class VaultFilterComponent implements OnInit, OnDestroy {
           .map((r) => r.cipherType);
 
         const toExclude = [...excludeTypes, ...restrictedForUser];
-        return this.allTypeFilters
-          .filter((f) => !toExclude.includes(f.type))
-          .map((f): CipherTypeFilter => {
-            if (newItemTypes && f.type === CipherType.Login) {
-              return { ...f, icon: "bwi-lock" };
-            }
-            if (newItemTypes && f.type === CipherType.Identity) {
-              return { ...f, icon: "bwi-user" };
-            }
-            return f;
-          });
+        return cipherTypeFilters.filter((f) => !toExclude.includes(f.type));
       }),
       switchMap((allowed) => this.vaultFilterService.buildTypeTree(allFilter, allowed)),
       distinctUntilChanged(),

--- a/libs/vault/src/abstractions/vault-filter.service.ts
+++ b/libs/vault/src/abstractions/vault-filter.service.ts
@@ -26,6 +26,7 @@ export abstract class VaultFilterService {
   folderTree$: Observable<TreeNode<FolderFilter>>;
   collectionTree$: Observable<TreeNode<CollectionFilter>>;
   cipherTypeTree$: Observable<TreeNode<CipherTypeFilter>>;
+  cipherTypeFilters$: Observable<CipherTypeFilter[]>;
   abstract getCollectionNodeFromTree: (id: string) => Promise<TreeNode<CollectionFilter>>;
   abstract setCollapsedFilterNodes: (
     collapsedFilterNodes: Set<string>,

--- a/libs/vault/src/services/vault-filter.service.spec.ts
+++ b/libs/vault/src/services/vault-filter.service.spec.ts
@@ -102,6 +102,7 @@ describe("vault filter service", () => {
       stateProvider,
       collectionService,
       accountService,
+      configService,
     );
     collapsedGroupingsState = stateProvider.singleUser.getFake(mockUserId, COLLAPSED_GROUPINGS);
     organizations.next([]);

--- a/libs/vault/src/services/vault-filter.service.spec.ts
+++ b/libs/vault/src/services/vault-filter.service.spec.ts
@@ -25,6 +25,7 @@ import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { CollectionId, OrganizationId, UserId } from "@bitwarden/common/types/guid";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { FolderService } from "@bitwarden/common/vault/abstractions/folder/folder.service.abstraction";
+import { CipherType } from "@bitwarden/common/vault/enums";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { FolderView } from "@bitwarden/common/vault/models/view/folder.view";
 import { COLLAPSED_GROUPINGS } from "@bitwarden/common/vault/services/key-state/collapsed-groupings.state";
@@ -363,6 +364,78 @@ describe("vault filter service", () => {
           storedOrgs,
           i18nService.collator,
         );
+      });
+    });
+  });
+
+  describe("cipherTypeFilters$", () => {
+    describe("when PM32009NewItemTypes flag is disabled", () => {
+      beforeEach(() => {
+        configService.getFeatureFlag$.mockReturnValue(of(false));
+        vaultFilterService = new VaultFilterService(
+          organizationService,
+          folderService,
+          cipherService,
+          policyService,
+          i18nService,
+          stateProvider,
+          collectionService,
+          accountService,
+          configService,
+        );
+      });
+
+      it("omits bankAccount", async () => {
+        const filters = await firstValueFrom(vaultFilterService.cipherTypeFilters$);
+
+        expect(filters.map((f) => f.id)).not.toContain("bankAccount");
+      });
+
+      it("uses bwi-globe for login", async () => {
+        const filters = await firstValueFrom(vaultFilterService.cipherTypeFilters$);
+
+        expect(filters.find((f) => f.type === CipherType.Login)?.icon).toBe("bwi-globe");
+      });
+
+      it("uses bwi-id-card for identity", async () => {
+        const filters = await firstValueFrom(vaultFilterService.cipherTypeFilters$);
+
+        expect(filters.find((f) => f.type === CipherType.Identity)?.icon).toBe("bwi-id-card");
+      });
+    });
+
+    describe("when PM32009NewItemTypes flag is enabled", () => {
+      it("emits filters in the correct order", async () => {
+        const filters = await firstValueFrom(vaultFilterService.cipherTypeFilters$);
+
+        expect(filters.map((f) => f.id)).toEqual([
+          "favorites",
+          "login",
+          "card",
+          "bankAccount",
+          "identity",
+          "note",
+          "sshKey",
+        ]);
+      });
+
+      it("includes bankAccount as the 4th filter", async () => {
+        const filters = await firstValueFrom(vaultFilterService.cipherTypeFilters$);
+
+        expect(filters[3].id).toBe("bankAccount");
+        expect(filters[3].type).toBe(CipherType.BankAccount);
+      });
+
+      it("uses bwi-lock for login", async () => {
+        const filters = await firstValueFrom(vaultFilterService.cipherTypeFilters$);
+
+        expect(filters.find((f) => f.type === CipherType.Login)?.icon).toBe("bwi-lock");
+      });
+
+      it("uses bwi-user for identity", async () => {
+        const filters = await firstValueFrom(vaultFilterService.cipherTypeFilters$);
+
+        expect(filters.find((f) => f.type === CipherType.Identity)?.icon).toBe("bwi-user");
       });
     });
   });

--- a/libs/vault/src/services/vault-filter.service.ts
+++ b/libs/vault/src/services/vault-filter.service.ts
@@ -30,6 +30,8 @@ import { cloneCollection } from "@bitwarden/common/admin-console/utils/collectio
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { getUserId } from "@bitwarden/common/auth/services/account.service";
 import { ProductTierType } from "@bitwarden/common/billing/enums";
+import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { SingleUserState, StateProvider } from "@bitwarden/common/platform/state";
 import { OrganizationId, UserId } from "@bitwarden/common/types/guid";
@@ -131,6 +133,7 @@ export class VaultFilterService implements VaultFilterServiceAbstraction {
     protected stateProvider: StateProvider,
     protected collectionService: CollectionService,
     protected accountService: AccountService,
+    protected configService: ConfigService,
   ) {}
 
   async getCollectionNodeFromTree(id: string) {
@@ -325,51 +328,58 @@ export class VaultFilterService implements VaultFilterServiceAbstraction {
   }
 
   protected buildCipherTypeTree(): Observable<TreeNode<CipherTypeFilter>> {
-    const allTypeFilters: CipherTypeFilter[] = [
-      {
-        id: "favorites",
-        name: this.i18nService.t("favorites"),
-        type: "favorites",
-        icon: "bwi-star",
-      },
-      {
-        id: "login",
-        name: this.i18nService.t("typeLogin"),
-        type: CipherType.Login,
-        icon: "bwi-globe",
-      },
-      {
-        id: "card",
-        name: this.i18nService.t("typeCard"),
-        type: CipherType.Card,
-        icon: "bwi-credit-card",
-      },
-      {
-        id: "identity",
-        name: this.i18nService.t("typeIdentity"),
-        type: CipherType.Identity,
-        icon: "bwi-id-card",
-      },
-      {
-        id: "note",
-        name: this.i18nService.t("typeSecureNote"),
-        type: CipherType.SecureNote,
-        icon: "bwi-sticky-note",
-      },
-      {
-        id: "sshKey",
-        name: this.i18nService.t("typeSshKey"),
-        type: CipherType.SshKey,
-        icon: "bwi-key",
-      },
-      {
-        id: "bankAccount",
-        name: this.i18nService.t("bankAccount"),
-        type: CipherType.BankAccount,
-        icon: "bwi-bank",
-      },
-    ];
+    return this.configService.getFeatureFlag$(FeatureFlag.PM32009NewItemTypes).pipe(
+      switchMap((newItemTypes) => {
+        const allTypeFilters: CipherTypeFilter[] = [
+          {
+            id: "favorites",
+            name: this.i18nService.t("favorites"),
+            type: "favorites",
+            icon: "bwi-star",
+          },
+          {
+            id: "login",
+            name: this.i18nService.t("typeLogin"),
+            type: CipherType.Login,
+            icon: newItemTypes ? "bwi-lock" : "bwi-globe",
+          },
+          {
+            id: "card",
+            name: this.i18nService.t("typeCard"),
+            type: CipherType.Card,
+            icon: "bwi-credit-card",
+          },
+          {
+            id: "identity",
+            name: this.i18nService.t("typeIdentity"),
+            type: CipherType.Identity,
+            icon: newItemTypes ? "bwi-user" : "bwi-id-card",
+          },
+          {
+            id: "note",
+            name: this.i18nService.t("typeSecureNote"),
+            type: CipherType.SecureNote,
+            icon: "bwi-sticky-note",
+          },
+          {
+            id: "sshKey",
+            name: this.i18nService.t("typeSshKey"),
+            type: CipherType.SshKey,
+            icon: "bwi-key",
+          },
+          {
+            id: "bankAccount",
+            name: this.i18nService.t("bankAccount"),
+            type: CipherType.BankAccount,
+            icon: "bwi-bank",
+          },
+        ];
 
-    return this.buildTypeTree({ id: "AllItems", name: "allItems", type: "all" }, allTypeFilters);
+        return this.buildTypeTree(
+          { id: "AllItems", name: "allItems", type: "all" },
+          allTypeFilters,
+        );
+      }),
+    );
   }
 }

--- a/libs/vault/src/services/vault-filter.service.ts
+++ b/libs/vault/src/services/vault-filter.service.ts
@@ -118,6 +118,62 @@ export class VaultFilterService implements VaultFilterServiceAbstraction {
     map(([collections, organizations]) => this.buildCollectionTree(collections, organizations)),
   );
 
+  cipherTypeFilters$: Observable<CipherTypeFilter[]> = this.configService
+    .getFeatureFlag$(FeatureFlag.PM32009NewItemTypes)
+    .pipe(
+      map((newItemTypes) => {
+        const filters: CipherTypeFilter[] = [
+          {
+            id: "favorites",
+            name: this.i18nService.t("favorites"),
+            type: "favorites",
+            icon: "bwi-star",
+          },
+          {
+            id: "login",
+            name: this.i18nService.t("typeLogin"),
+            type: CipherType.Login,
+            icon: newItemTypes ? "bwi-lock" : "bwi-globe",
+          },
+          {
+            id: "card",
+            name: this.i18nService.t("typeCard"),
+            type: CipherType.Card,
+            icon: "bwi-credit-card",
+          },
+          ...(newItemTypes
+            ? [
+                {
+                  id: "bankAccount",
+                  name: this.i18nService.t("bankAccount"),
+                  type: CipherType.BankAccount,
+                  icon: "bwi-bank",
+                } as CipherTypeFilter,
+              ]
+            : []),
+          {
+            id: "identity",
+            name: this.i18nService.t("typeIdentity"),
+            type: CipherType.Identity,
+            icon: newItemTypes ? "bwi-user" : "bwi-id-card",
+          },
+          {
+            id: "note",
+            name: this.i18nService.t("typeSecureNote"),
+            type: CipherType.SecureNote,
+            icon: "bwi-sticky-note",
+          },
+          {
+            id: "sshKey",
+            name: this.i18nService.t("typeSshKey"),
+            type: CipherType.SshKey,
+            icon: "bwi-key",
+          },
+        ];
+        return filters;
+      }),
+    );
+
   cipherTypeTree$: Observable<TreeNode<CipherTypeFilter>> = this.buildCipherTypeTree();
 
   private collapsedGroupingsState(userId: UserId): SingleUserState<string[]> {
@@ -328,58 +384,10 @@ export class VaultFilterService implements VaultFilterServiceAbstraction {
   }
 
   protected buildCipherTypeTree(): Observable<TreeNode<CipherTypeFilter>> {
-    return this.configService.getFeatureFlag$(FeatureFlag.PM32009NewItemTypes).pipe(
-      switchMap((newItemTypes) => {
-        const allTypeFilters: CipherTypeFilter[] = [
-          {
-            id: "favorites",
-            name: this.i18nService.t("favorites"),
-            type: "favorites",
-            icon: "bwi-star",
-          },
-          {
-            id: "login",
-            name: this.i18nService.t("typeLogin"),
-            type: CipherType.Login,
-            icon: newItemTypes ? "bwi-lock" : "bwi-globe",
-          },
-          {
-            id: "card",
-            name: this.i18nService.t("typeCard"),
-            type: CipherType.Card,
-            icon: "bwi-credit-card",
-          },
-          {
-            id: "identity",
-            name: this.i18nService.t("typeIdentity"),
-            type: CipherType.Identity,
-            icon: newItemTypes ? "bwi-user" : "bwi-id-card",
-          },
-          {
-            id: "note",
-            name: this.i18nService.t("typeSecureNote"),
-            type: CipherType.SecureNote,
-            icon: "bwi-sticky-note",
-          },
-          {
-            id: "sshKey",
-            name: this.i18nService.t("typeSshKey"),
-            type: CipherType.SshKey,
-            icon: "bwi-key",
-          },
-          {
-            id: "bankAccount",
-            name: this.i18nService.t("bankAccount"),
-            type: CipherType.BankAccount,
-            icon: "bwi-bank",
-          },
-        ];
-
-        return this.buildTypeTree(
-          { id: "AllItems", name: "allItems", type: "all" },
-          allTypeFilters,
-        );
-      }),
+    return this.cipherTypeFilters$.pipe(
+      switchMap((filters) =>
+        this.buildTypeTree({ id: "AllItems", name: "allItems", type: "all" }, filters),
+      ),
     );
   }
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-36629](https://bitwarden.atlassian.net/browse/PM-36629)

## 📔 Objective

This PR solves a few things:
- The `PM32009NewItemTypes` feature flag swaps the icons for login and identity icons and gates the new item types from showing. This logic was duplicated across the web and admin console vaults.
- The AC vault also did not have bank account as it was originally missed. 


This adds `cipherTypeFilters$` to `VaultFilterServiceAbstraction` as the single source of truth, and updates the web components to consume it directly instead of maintaining their own `allTypeFilters` arrays with redundant flag subscriptions.

## 📸 Screenshots

|Desktop|Web|Admin Console|
|-|-|-|
|<img width="251" height="613" alt="Screenshot 2026-05-06 at 3 58 15 PM" src="https://github.com/user-attachments/assets/a92f6fc1-7266-4d09-ac86-6e5f947d43ae" />|<img width="361" height="705" alt="Screenshot 2026-05-06 at 3 58 00 PM" src="https://github.com/user-attachments/assets/7436007f-e8aa-45df-8498-d24f8ee85800" />|<img width="367" height="502" alt="Screenshot 2026-05-06 at 3 57 56 PM" src="https://github.com/user-attachments/assets/1888b9ae-15f1-4b90-81c1-04c157bad039" />|



[PM-36629]: https://bitwarden.atlassian.net/browse/PM-36629?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ