### PR TITLE
fix: Removed broken part of ssh nudge message

### DIFF
--- a/libs/vault/src/cipher-form/components/new-item-nudge/new-item-nudge.component.ts
+++ b/libs/vault/src/cipher-form/components/new-item-nudge/new-item-nudge.component.ts
@@ -70,12 +70,9 @@ export class NewItemNudgeComponent {
         return NudgeType.NewNoteItemStatus;
 
       case CipherType.SshKey: {
-        const sshPartOne = this.i18nService.t("newSshNudgeBodyOne");
-        const sshPartTwo = this.i18nService.t("newSshNudgeBodyTwo");
-
         this.dismissalNudgeType = NudgeType.NewSshItemStatus;
         this.nudgeTitle = this.i18nService.t("newSshNudgeTitle");
-        this.nudgeBody = `${sshPartOne} <a href="https://bitwarden.com/help/ssh-agent" class="tw-text-primary-600 tw-font-medium" target="_blank">${sshPartTwo}</a>`;
+        this.nudgeBody = this.i18nService.t("newSshNudgeBodyOne");
         return NudgeType.NewSshItemStatus;
       }
       case CipherType.BankAccount:


### PR DESCRIPTION
The SSH nudge message had a second part with an <a> tag, that didn't render properly. It was shortened to only the first part, since the other one "Learn more..." doesn't make sense without a link attached.

## 🎟️ Tracking

https://github.com/bitwarden/clients/issues/20492

## 📔 Objective

This PR removes the broken link part of the SSH nudge message.

## 📸 Screenshots

**Before**
<img width="1480" height="598" alt="image" src="https://github.com/user-attachments/assets/a088ddf0-27c5-477c-bcb8-9417465e3e3b" />

**After**
<img width="1480" height="598" alt="image" src="https://github.com/user-attachments/assets/e791771f-9382-4ece-86d3-685fc2c0f3b0" />
