### PR TITLE
[PM-36045] Fix application of bitLink selector in desktop usages

### DIFF
--- a/apps/desktop/src/autofill/modal/credentials/fido2-create.component.html
+++ b/apps/desktop/src/autofill/modal/credentials/fido2-create.component.html
@@ -48,14 +48,8 @@
           <span bitBadge slot="end">{{ "save" | i18n }}</span>
         </button>
       </bit-item>
-      <bit-item class="">
-        <button
-          bitLink
-          linkType="primary"
-          type="button"
-          bit-item-content
-          (click)="confirmPasskey()"
-        >
+      <bit-item>
+        <button type="button" bit-item-content (click)="confirmPasskey()">
           <a bitLink linkType="primary" class="tw-font-medium tw-text-base">
             {{ "saveNewPasskey" | i18n }}
           </a>

--- a/apps/desktop/src/vault/app/vault/credential-generator-dialog.component.html
+++ b/apps/desktop/src/vault/app/vault/credential-generator-dialog.component.html
@@ -8,14 +8,7 @@
       (algorithmSelected)="onAlgorithmSelected($event)"
     />
     <bit-item>
-      <button
-        type="button"
-        bitLink
-        linkType="primary"
-        bit-item-content
-        aria-haspopup="dialog"
-        (click)="openHistoryDialog()"
-      >
+      <button type="button" bit-item-content aria-haspopup="dialog" (click)="openHistoryDialog()">
         {{ "generatorHistory" | i18n }}
         <i slot="end" class="bwi bwi-angle-right" aria-hidden="true"></i>
       </button>


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[PM-36045](https://bitwarden.atlassian.net/browse/PM-36045)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
The password generator dialog in the desktop "edit cipher" page was not opening properly and was therefore not accessible to screenreaders. The root cause ended up being that there were two Angular component selectors applied to one element inside of the dialog, which is not supported. (The `bitLink` component recently updated from directive to component, so previously this worked but was not common to do.) This PR removes the `bitLink` selector from the affected element and also from one other instance that had the same problem. In both cases, `bitLink` was unnecessary (in the fido2 case, because the child element is also a `bitLink`; in the generator case, removing the `bitLink` styles will now match the existing browser/web styles).

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

Before:

https://github.com/user-attachments/assets/6645e15e-bb82-43d0-a145-8b10073b6ceb



After:


https://github.com/user-attachments/assets/54bf7d9f-4863-415f-b0ec-52643846646b



[PM-36045]: https://bitwarden.atlassian.net/browse/PM-36045?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ