### PR TITLE
Use globalEnvironment$ on environment selector

### DIFF
--- a/libs/angular/src/auth/environment-selector/environment-selector.component.ts
+++ b/libs/angular/src/auth/environment-selector/environment-selector.component.ts
@@ -33,7 +33,7 @@ export class EnvironmentSelectorComponent implements OnDestroy {
   protected ServerEnvironmentType = Region;
   protected availableRegions = this.environmentService.availableRegions();
   protected selectedRegion$: Observable<RegionConfig | undefined> =
-    this.environmentService.environment$.pipe(
+    this.environmentService.globalEnvironment$.pipe(
       map((e) => e.getRegion()),
       map((r) => this.availableRegions.find((ar) => ar.key === r)),
     );


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-30715

## 📔 Objective

We currently subscribe to the `environment$` observable on the `EnvironmentSelector`.

The `environment$` makes [decisions](https://github.com/bitwarden/clients/blob/f6f443f6f6eee8d7bfa3ff3b78e669977c9176a4/libs/common/src/platform/services/default-environment.service.ts#L164-L165) based on whether the user is logged in or not, which may result in race conditions on logout, when the application is transitioning from an authenticated to unauthenticated state.

This added complexity is not necessary on the `EnvironmentSelector`, as by definition when you're selecting an environment to log into, you're not logged in, and therefore user-scoped state is not in play.  The `EnvironmentSelector` should only care about the "global" (non-user-scoped) environment.

The screenshot below shows that login and logout work as expected, and the environment does change correctly.  The issue this is trying to reproduce does not occur consistently on any environment, and only on environments that use MDM for setting the environment.

📓 Note that follow-up work will be done to deprecate `environment$` and replace with an `accountEnvironment$` that is explicitly scoped to the logged-in user.  This will be done separately and by the Platform team.  This is tracked in https://bitwarden.atlassian.net/browse/PM-36480.

## 📸 Screenshots

https://github.com/user-attachments/assets/4e52a4c2-88d8-46e2-87f8-038dca68b3d0