### PR TITLE
Small fix for ssh namespace mismatch

### DIFF
--- a/apps/desktop/desktop_native/napi/index.d.ts
+++ b/apps/desktop/desktop_native/napi/index.d.ts
@@ -305,9 +305,9 @@ export declare namespace sshagent_v2 {
   }
   /** A sign request's SIG namespace */
   export const enum SIGNamespace {
-    Git = 'Git',
-    File = 'File',
-    Unsupported = 'Unsupported'
+    Git = 'git',
+    File = 'file',
+    Unsupported = 'unsupported'
   }
   /** SSH sign request fields. */
   export interface SignRequest {

--- a/apps/desktop/desktop_native/napi/src/sshagent_v2.rs
+++ b/apps/desktop/desktop_native/napi/src/sshagent_v2.rs
@@ -37,7 +37,7 @@ pub mod sshagent_v2 {
     }
 
     /// A sign request's SIG namespace
-    #[napi(string_enum)]
+    #[napi(string_enum = "camelCase")]
     #[derive(Debug)]
     pub enum SIGNamespace {
         Git,

--- a/apps/desktop/src/autofill/components/approve-ssh-request.ts
+++ b/apps/desktop/src/autofill/components/approve-ssh-request.ts
@@ -56,7 +56,7 @@ export class ApproveSshRequestComponent {
     namespace: string,
   ) {
     let actioni18nKey = "sshActionLogin";
-    if (namespace === "git") {
+    if (namespace === "git" || namespace === "Git") {
       actioni18nKey = "sshActionGitSign";
     } else if (namespace != null && namespace != "") {
       actioni18nKey = "sshActionSign";

--- a/apps/desktop/src/autofill/components/approve-ssh-request.ts
+++ b/apps/desktop/src/autofill/components/approve-ssh-request.ts
@@ -56,7 +56,7 @@ export class ApproveSshRequestComponent {
     namespace: string,
   ) {
     let actioni18nKey = "sshActionLogin";
-    if (namespace === "git" || namespace === "Git") {
+    if (namespace === "git") {
       actioni18nKey = "sshActionGitSign";
     } else if (namespace != null && namespace != "") {
       actioni18nKey = "sshActionSign";


### PR DESCRIPTION
## 🎟️ Tracking

None

## 📔 Objective

This PR aims to fix a _potential_ case mismatch in the ssh agent v1 and v2 "namespace" implementations. It may not be accurate, but here is the concept:

Line 59 of `clients/apps/desktop/src/autofill/components/approve-ssh-request.ts` checks the namespace string, currently matching on `"git"` for v1. However, v2's `SIGNamespace.Git` enum variant from `clients/apps/desktop/desktop_native/napi/src/sshagent_v2.rs` ends up being `"Git"`, according to line 308 in `clients/apps/desktop/desktop_native/napi/index.d.ts`.

`"Git"` won't match here, so `actioni18nKey` will end up being `"sshActionSign"`, rather than `"sshActionGitSign"`.

There may be a better way to fix this, or this may be the intended behavior, and this PR is not needed. Just throwing this PR up as a starting point for conversation, and as a potential fix.

If the bug identified _is_ accurate, then we'll want to verify this doesn't break anything on the ssh v1 side.
