### PR TITLE
[PM-36571] Custom field hidden field right buttons are in the wrong place

### DIFF
--- a/libs/vault/src/cipher-view/custom-fields/custom-fields-v2.component.html
+++ b/libs/vault/src/cipher-view/custom-fields/custom-fields-v2.component.html
@@ -74,23 +74,25 @@
               ></button>
             }
             @if (canViewPassword) {
-              <ng-container bitSuffix>
-                <button
-                  type="button"
-                  bitIconButton
-                  bitPasswordInputToggle
-                  (toggledChange)="toggleHiddenField($event, i)"
-                ></button>
-                <button
-                  bitIconButton="bwi-clone"
-                  type="button"
-                  [appCopyClick]="field.value"
-                  showToast
-                  [valueLabel]="field.name"
-                  [label]="'copyCustomField' | i18n: field.name"
-                  (click)="logCopyEvent()"
-                ></button>
-              </ng-container>
+              <button
+                bitSuffix
+                type="button"
+                bitIconButton
+                bitPasswordInputToggle
+                (toggledChange)="toggleHiddenField($event, i)"
+              ></button>
+            }
+            @if (canViewPassword) {
+              <button
+                bitSuffix
+                bitIconButton="bwi-clone"
+                type="button"
+                [appCopyClick]="field.value"
+                showToast
+                [valueLabel]="field.name"
+                [label]="'copyCustomField' | i18n: field.name"
+                (click)="logCopyEvent()"
+              ></button>
             }
           </bit-form-field>
         }

--- a/libs/vault/src/cipher-view/custom-fields/custom-fields-v2.component.html
+++ b/libs/vault/src/cipher-view/custom-fields/custom-fields-v2.component.html
@@ -74,23 +74,23 @@
               ></button>
             }
             @if (canViewPassword) {
-              <button
-                bitSuffix
-                type="button"
-                bitIconButton
-                bitPasswordInputToggle
-                (toggledChange)="toggleHiddenField($event, i)"
-              ></button>
-              <button
-                bitIconButton="bwi-clone"
-                bitSuffix
-                type="button"
-                [appCopyClick]="field.value"
-                showToast
-                [valueLabel]="field.name"
-                [label]="'copyCustomField' | i18n: field.name"
-                (click)="logCopyEvent()"
-              ></button>
+              <ng-container bitSuffix>
+                <button
+                  type="button"
+                  bitIconButton
+                  bitPasswordInputToggle
+                  (toggledChange)="toggleHiddenField($event, i)"
+                ></button>
+                <button
+                  bitIconButton="bwi-clone"
+                  type="button"
+                  [appCopyClick]="field.value"
+                  showToast
+                  [valueLabel]="field.name"
+                  [label]="'copyCustomField' | i18n: field.name"
+                  (click)="logCopyEvent()"
+                ></button>
+              </ng-container>
             }
           </bit-form-field>
         }

--- a/libs/vault/src/cipher-view/custom-fields/custom-fields-v2.component.html
+++ b/libs/vault/src/cipher-view/custom-fields/custom-fields-v2.component.html
@@ -84,8 +84,8 @@
             }
             @if (canViewPassword) {
               <button
-                bitSuffix
                 bitIconButton="bwi-clone"
+                bitSuffix
                 type="button"
                 [appCopyClick]="field.value"
                 showToast


### PR DESCRIPTION
## 📔 Objective

Fixes content projection for bitSuffix that has to do with `@if` only allowing a single projectable node at its root.

Before:
<img width="756" height="793" alt="Screenshot 2026-05-05 at 9 55 16 AM" src="https://github.com/user-attachments/assets/03e3248c-4fb4-4460-a0cd-41dc6e06f769" />


After:
<img width="756" height="793" alt="Screenshot 2026-05-05 at 9 57 27 AM" src="https://github.com/user-attachments/assets/634408a9-ceba-416d-9350-694ebed683b7" />
