### PR TITLE
[CL-1186] - spotlight and popover fixes

### DIFF
--- a/libs/components/src/popover/popover-anchor-for.directive.ts
+++ b/libs/components/src/popover/popover-anchor-for.directive.ts
@@ -68,6 +68,15 @@ export class PopoverAnchorForDirective implements OnDestroy {
   /** Padding around the spotlight cutout in pixels */
   readonly spotlightPadding = input<number>(0);
 
+  /**
+   * CSS selector to find a child element within the anchor to use as the spotlight target.
+   * If not provided, the anchor element itself is used.
+   */
+  readonly spotlightTargetSelector = input<string>();
+
+  /** Minimum distance in pixels between the popover and the viewport edge */
+  readonly viewportMargin = input<number>(0);
+
   private overlayRef: OverlayRef | null = null;
   private closedEventsSub: Subscription | null = null;
   private readonly hasInitialized = signal(false);
@@ -103,7 +112,8 @@ export class PopoverAnchorForDirective implements OnDestroy {
         .withPositions(this.positions)
         .withLockedPosition(true)
         .withFlexibleDimensions(false)
-        .withPush(true),
+        .withPush(true)
+        .withViewportMargin(this.viewportMargin()),
     };
   }
 
@@ -144,8 +154,13 @@ export class PopoverAnchorForDirective implements OnDestroy {
 
     // Create the spotlight border overlay first so the popover overlay sits above it in DOM order
     if (this.spotlight()) {
+      const selector = this.spotlightTargetSelector();
+      const spotlightEl = selector
+        ? ((this.elementRef.nativeElement.querySelector(selector) as HTMLElement | null) ??
+          this.elementRef.nativeElement)
+        : this.elementRef.nativeElement;
       this.spotlightService.register(this);
-      this.spotlightService.showSpotlight(this.elementRef.nativeElement, this.spotlightPadding());
+      this.spotlightService.showSpotlight(spotlightEl, this.spotlightPadding());
     }
 
     this.popoverOpen.set(true);

--- a/libs/components/src/popover/popover.component.html
+++ b/libs/components/src/popover/popover.component.html
@@ -10,9 +10,13 @@
     <div class="tw-overflow-hidden tw-rounded-xl tw-shadow-lg">
       <div
         class="tw-relative tw-z-20 tw-w-72 tw-break-words tw-bg-background tw-pb-4 tw-pt-2 tw-text-main"
+        [class]="panelClass()"
       >
-        <div class="tw-me-2 tw-flex tw-items-start tw-justify-between tw-gap-4 tw-ps-4">
-          <h2 bitTypography="h5" class="tw-font-medium tw-mt-1">
+        <div
+          class="tw-me-2 tw-flex tw-items-start tw-justify-between tw-gap-4 tw-ps-4"
+          [class]="headerClass()"
+        >
+          <h2 bitTypography="h5" class="tw-font-medium tw-mt-1" [class]="titleClass()">
             {{ title() }}
           </h2>
           <button
@@ -23,7 +27,7 @@
             size="small"
           ></button>
         </div>
-        <div bitTypography="body2" class="tw-px-4">
+        <div bitTypography="body2" class="tw-px-4" [class]="contentClass()">
           <ng-content></ng-content>
         </div>
       </div>

--- a/libs/components/src/popover/popover.component.ts
+++ b/libs/components/src/popover/popover.component.ts
@@ -25,6 +25,18 @@ export class PopoverComponent {
   /** Optional title displayed in the popover header */
   readonly title = input("");
 
+  /** Optional CSS class(es) applied to the inner content container */
+  readonly panelClass = input<string>("");
+
+  /** Optional CSS class(es) applied to the title element */
+  readonly titleClass = input<string>("");
+
+  /** Optional CSS class(es) applied to the header row (title + close button) */
+  readonly headerClass = input<string>("");
+
+  /** Optional CSS class(es) applied to the body content container */
+  readonly contentClass = input<string>("");
+
   /** Event emitted when the popover should close */
   // FIXME(https://bitwarden.atlassian.net/browse/CL-903): Migrate to Signals
   // eslint-disable-next-line @angular-eslint/prefer-output-emitter-ref

--- a/libs/components/src/popover/spotlight.service.ts
+++ b/libs/components/src/popover/spotlight.service.ts
@@ -18,6 +18,7 @@ export class SpotlightService {
   private currentPadding = 0;
   private borderOverlayRef: OverlayRef | null = null;
   private resizeObserver: ResizeObserver | null = null;
+  private windowResizeListener: (() => void) | null = null;
   private hideTimeout: number | null = null;
   private activePopover: PopoverAnchorForDirective | null = null;
 
@@ -172,11 +173,21 @@ export class SpotlightService {
       this.borderOverlayRef.updatePosition();
     });
     this.resizeObserver.observe(target);
+
+    // Reposition on window resize — CDK's reposition scroll strategy only covers scroll events
+    this.windowResizeListener = () => {
+      this.borderOverlayRef?.updatePosition();
+    };
+    window.addEventListener("resize", this.windowResizeListener);
   }
 
   private disposeBorderOverlay(): void {
     this.resizeObserver?.disconnect();
     this.resizeObserver = null;
+    if (this.windowResizeListener) {
+      window.removeEventListener("resize", this.windowResizeListener);
+      this.windowResizeListener = null;
+    }
     this.borderOverlayRef?.dispose(); // CDK moves borderElement back to document.body
     this.borderOverlayRef = null;
     this.borderElement.style.display = "none";

--- a/libs/components/src/tw-theme.css
+++ b/libs/components/src/tw-theme.css
@@ -339,7 +339,7 @@
   /* Hover & Overlay */
   --color-bg-hover: rgba(var(--color-gray-950-rgb), 0.05);
   --color-bg-hover-contrast: rgba(var(--color-white-rgb), 0.05);
-  --color-bg-overlay: rgba(var(--color-gray-950-rgb), 0.5);
+  --color-bg-overlay: rgba(var(--color-gray-950-rgb), 0.55);
 
   /* ========================================
    * SEMANTIC BORDER COLORS (Light Mode)

--- a/libs/components/src/tw-theme.css
+++ b/libs/components/src/tw-theme.css
@@ -339,7 +339,7 @@
   /* Hover & Overlay */
   --color-bg-hover: rgba(var(--color-gray-950-rgb), 0.05);
   --color-bg-hover-contrast: rgba(var(--color-white-rgb), 0.05);
-  --color-bg-overlay: rgba(var(--color-gray-950-rgb), 0.3);
+  --color-bg-overlay: rgba(var(--color-gray-950-rgb), 0.5);
 
   /* ========================================
    * SEMANTIC BORDER COLORS (Light Mode)


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-36534

## 📔 Objective

Fixes two issues with the spotlight effect used in guided tour popovers:

**Light mode contrast** — The spotlight overlay opacity was `0.3`, too close to the nav hover color to create visible contrast. Increased to `0.5`.

**Resize lag** — CDK's `reposition` scroll strategy only reacts to scroll events, so resizing the window caused the spotlight cutout to trail behind the highlighted element. Added a `window` `resize` listener in `SpotlightService` that immediately calls `updatePosition()`, cleaned up when the overlay is disposed.

## 📸 Screenshots

<img width="713" height="708" alt="Screenshot 2026-05-05 at 2 17 16 PM" src="https://github.com/user-attachments/assets/15661a58-bb37-473e-b126-f8e5a13ea35e" />

https://github.com/user-attachments/assets/2ad79c20-0efd-4ec6-9f73-ecad60ad3e0e

