### PR TITLE
[PM-36609] Add regex manager for updating electronVersion on electron updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -9,6 +9,14 @@
       matchStrings: ["(?<depName>[a-z][a-z0-9-]+)=(?<currentValue>[\\d.]+)"],
       datasourceTemplate: "crate",
     },
+    {
+      // Keep electronVersion in electron-builder.json in sync with the electron package.
+      customType: "regex",
+      fileMatch: ["apps/desktop/electron-builder\\.json$"],
+      matchStrings: ['"electronVersion":\\s*"(?<currentValue>[\\d.]+)"'],
+      depNameTemplate: "electron",
+      datasourceTemplate: "npm",
+    },
   ],
   packageRules: [
     // ==================== Repo-Wide Update Behavior Rules ====================


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-36609

## 📔 Objective

We currently have to manually update the `electron-builder.json` `electronVersion` for each electron update.

This PR adds in a custom `regex` manager to look in `electron-builder.json` and update the version when `electron` updates.

This is similar to what we do for the Rust toolchain update already.