### PR TITLE
[PM-34389] Wire refreshInviteLink to dedicated server refresh endpoint

### DIFF
--- a/libs/organization-invite-link/src/abstractions/organization-invite-link-api.service.ts
+++ b/libs/organization-invite-link/src/abstractions/organization-invite-link-api.service.ts
@@ -1,4 +1,5 @@
 import { OrganizationInviteLinkCreateRequest } from "../models/requests/organization-invite-link-create.request";
+import { OrganizationInviteLinkRefreshRequest } from "../models/requests/organization-invite-link-refresh.request";
 import { OrganizationInviteLinkUpdateRequest } from "../models/requests/organization-invite-link-update.request";
 import { OrganizationInviteLinkResponseModel } from "../models/responses/organization-invite-link.response";
 
@@ -13,6 +14,12 @@ export abstract class OrganizationInviteLinkApiService {
   abstract update(
     organizationId: string,
     request: OrganizationInviteLinkUpdateRequest,
+  ): Promise<OrganizationInviteLinkResponseModel>;
+
+  /** Refresh the invite link for the given organization, issuing a new code and key */
+  abstract refresh(
+    organizationId: string,
+    request: OrganizationInviteLinkRefreshRequest,
   ): Promise<OrganizationInviteLinkResponseModel>;
 
   /** Retrieve the invite link for the given organization */

--- a/libs/organization-invite-link/src/abstractions/organization-invite-link.service.ts
+++ b/libs/organization-invite-link/src/abstractions/organization-invite-link.service.ts
@@ -19,7 +19,7 @@ export abstract class OrganizationInviteLinkService {
   ): Promise<string>;
 
   /**
-   * Refresh the invite link using cached allowed domains.
+   * Refresh the invite link via the server endpoint.
    * Emits the shareable URL once, then completes.
    */
   abstract refreshInviteLink(userId: UserId, orgId: OrganizationId): Promise<string>;

--- a/libs/organization-invite-link/src/models/requests/index.ts
+++ b/libs/organization-invite-link/src/models/requests/index.ts
@@ -1,2 +1,3 @@
 export * from "./organization-invite-link-create.request";
+export * from "./organization-invite-link-refresh.request";
 export * from "./organization-invite-link-update.request";

--- a/libs/organization-invite-link/src/models/requests/organization-invite-link-refresh.request.ts
+++ b/libs/organization-invite-link/src/models/requests/organization-invite-link-refresh.request.ts
@@ -1,0 +1,14 @@
+import { EncString } from "@bitwarden/common/key-management/crypto/models/enc-string";
+
+export class OrganizationInviteLinkRefreshRequest {
+  encryptedInviteKey: string;
+  encryptedOrgKey: string | null;
+
+  constructor(c: { encryptedInviteKey: EncString; encryptedOrgKey?: EncString | null }) {
+    if (!c.encryptedInviteKey?.encryptedString) {
+      throw new Error("EncryptedInviteKey is required.");
+    }
+    this.encryptedInviteKey = c.encryptedInviteKey.encryptedString;
+    this.encryptedOrgKey = c.encryptedOrgKey?.encryptedString ?? null;
+  }
+}

--- a/libs/organization-invite-link/src/services/default-organization-invite-link-api.service.ts
+++ b/libs/organization-invite-link/src/services/default-organization-invite-link-api.service.ts
@@ -2,6 +2,7 @@ import { ApiService } from "@bitwarden/common/abstractions/api.service";
 
 import { OrganizationInviteLinkApiService } from "../abstractions/organization-invite-link-api.service";
 import { OrganizationInviteLinkCreateRequest } from "../models/requests/organization-invite-link-create.request";
+import { OrganizationInviteLinkRefreshRequest } from "../models/requests/organization-invite-link-refresh.request";
 import { OrganizationInviteLinkUpdateRequest } from "../models/requests/organization-invite-link-update.request";
 import { OrganizationInviteLinkResponseModel } from "../models/responses/organization-invite-link.response";
 
@@ -15,6 +16,20 @@ export class DefaultOrganizationInviteLinkApiService implements OrganizationInvi
     const r = await this.apiService.send(
       "POST",
       `/organizations/${organizationId}/invite-link`,
+      request,
+      true,
+      true,
+    );
+    return new OrganizationInviteLinkResponseModel(r);
+  }
+
+  async refresh(
+    organizationId: string,
+    request: OrganizationInviteLinkRefreshRequest,
+  ): Promise<OrganizationInviteLinkResponseModel> {
+    const r = await this.apiService.send(
+      "POST",
+      `/organizations/${organizationId}/invite-link/refresh`,
       request,
       true,
       true,

--- a/libs/organization-invite-link/src/services/default-organization-invite-link.service.spec.ts
+++ b/libs/organization-invite-link/src/services/default-organization-invite-link.service.spec.ts
@@ -160,42 +160,39 @@ describe("DefaultOrganizationInviteLinkService", () => {
   });
 
   describe("refreshInviteLink", () => {
-    it("re-uses cached domains", async () => {
-      const cached = makeResponse({ allowedDomains: ["cached.com"] });
-      await sut.upsert(mockUserId, cached);
-
+    it("generates new key, calls apiService.refresh, caches state, and returns URL", async () => {
       const rawKey = makeKey("refreshed==");
       const orgKey = makeKey();
       const encryptedKey = mock<EncString>();
       (encryptedKey as any).encryptedString = "2.enc=|iv=|mac=";
-      const response = makeResponse({ code: "refreshed", allowedDomains: ["cached.com"] });
+      const response = makeResponse({ code: "refreshed", allowedDomains: ["example.com"] });
 
       keyGenerationService.createKey.mockResolvedValue(rawKey);
       keyService.orgKeys$.mockReturnValue(new BehaviorSubject({ [mockOrgId]: orgKey as OrgKey }));
       encryptService.wrapSymmetricKey.mockResolvedValue(encryptedKey);
-      apiService.create.mockResolvedValue(response);
+      apiService.refresh.mockResolvedValue(response);
 
       const url = await sut.refreshInviteLink(mockUserId, mockOrgId);
 
-      expect(apiService.create).toHaveBeenCalledWith(
+      expect(keyGenerationService.createKey).toHaveBeenCalledWith(256);
+      expect(encryptService.wrapSymmetricKey).toHaveBeenCalledWith(rawKey, orgKey);
+      expect(apiService.refresh).toHaveBeenCalledWith(
         mockOrgId,
-        expect.objectContaining({ allowedDomains: ["cached.com"] }),
+        expect.objectContaining({ encryptedInviteKey: "2.enc=|iv=|mac=" }),
       );
       expect(url).toBe("/#/join/refreshed?key=refreshed==");
+
+      const stored = await firstValueFrom(sut.inviteLink$(mockUserId));
+      expect(stored).toEqual(response);
     });
 
-    it("falls back to empty domains when no cache, propagating the domain validation error", async () => {
+    it("errors when orgKey is null", async () => {
       const rawKey = makeKey();
-      const orgKey = makeKey();
-      const encryptedKey = mock<EncString>();
-      (encryptedKey as any).encryptedString = "2.enc=|iv=|mac=";
-
       keyGenerationService.createKey.mockResolvedValue(rawKey);
-      keyService.orgKeys$.mockReturnValue(new BehaviorSubject({ [mockOrgId]: orgKey as OrgKey }));
-      encryptService.wrapSymmetricKey.mockResolvedValue(encryptedKey);
+      keyService.orgKeys$.mockReturnValue(new BehaviorSubject(null));
 
       await expect(sut.refreshInviteLink(mockUserId, mockOrgId)).rejects.toThrow(
-        "At least one allowed domain is required.",
+        `Organization key not found for org ${mockOrgId}`,
       );
     });
   });

--- a/libs/organization-invite-link/src/services/default-organization-invite-link.service.ts
+++ b/libs/organization-invite-link/src/services/default-organization-invite-link.service.ts
@@ -5,12 +5,14 @@ import { EncryptService } from "@bitwarden/common/key-management/crypto/abstract
 import { EncString } from "@bitwarden/common/key-management/crypto/models/enc-string";
 import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
 import { OrganizationId, UserId } from "@bitwarden/common/types/guid";
+import { OrgKey } from "@bitwarden/common/types/key";
 import { KeyService } from "@bitwarden/key-management";
 import { StateProvider } from "@bitwarden/state";
 
 import { OrganizationInviteLinkApiService } from "../abstractions/organization-invite-link-api.service";
 import { OrganizationInviteLinkService } from "../abstractions/organization-invite-link.service";
 import { OrganizationInviteLinkCreateRequest } from "../models/requests/organization-invite-link-create.request";
+import { OrganizationInviteLinkRefreshRequest } from "../models/requests/organization-invite-link-refresh.request";
 import { OrganizationInviteLinkResponseModel } from "../models/responses/organization-invite-link.response";
 import { ORGANIZATION_INVITE_LINK_KEY } from "../state/organization-invite-link-state";
 
@@ -34,22 +36,10 @@ export class DefaultOrganizationInviteLinkService implements OrganizationInviteL
     orgId: OrganizationId,
     domains: string[],
   ): Promise<string> {
-    const rawInviteKey = await this.generateCryptoBundle();
-
-    const orgKey = await firstValueFrom(
-      this.keyService.orgKeys$(userId).pipe(
-        map((orgKeys) => {
-          const orgKey = orgKeys?.[orgId as OrganizationId] ?? undefined;
-          if (orgKey == null) {
-            throw new Error(`Organization key not found for org ${orgId}`);
-          }
-
-          return orgKey;
-        }),
-      ),
+    const { rawInviteKey, encryptedInviteKey } = await this.generateEncryptedKeyBundle(
+      userId,
+      orgId,
     );
-
-    const encryptedInviteKey = await this.encryptService.wrapSymmetricKey(rawInviteKey, orgKey);
 
     const request = new OrganizationInviteLinkCreateRequest({
       allowedDomains: domains,
@@ -63,9 +53,17 @@ export class DefaultOrganizationInviteLinkService implements OrganizationInviteL
   }
 
   async refreshInviteLink(userId: UserId, orgId: OrganizationId): Promise<string> {
-    const cached = await firstValueFrom(this.inviteLink$(userId));
-    const domains = cached?.allowedDomains ?? [];
-    return this.createInviteLink(userId, orgId, domains);
+    const { rawInviteKey, encryptedInviteKey } = await this.generateEncryptedKeyBundle(
+      userId,
+      orgId,
+    );
+
+    const request = new OrganizationInviteLinkRefreshRequest({ encryptedInviteKey });
+
+    const response = await this.apiService.refresh(orgId, request);
+    await this.upsert(userId, response);
+
+    return this.buildInviteUrl(response.code, rawInviteKey.keyB64);
   }
 
   async reconstructUrl(userId: UserId, orgId: OrganizationId): Promise<string | undefined> {
@@ -113,11 +111,29 @@ export class DefaultOrganizationInviteLinkService implements OrganizationInviteL
   }
 
   /**
-   * Generates a raw symmetric key for the invite link.
+   * Generates a raw symmetric key and wraps it with the organization key.
    *
    * TODO: Replace with `generateOrganizationInviteCryptoBundle` from the SDK once available.
    */
-  private async generateCryptoBundle(): Promise<SymmetricCryptoKey> {
-    return this.keyGenerationService.createKey(256);
+  private async generateEncryptedKeyBundle(
+    userId: UserId,
+    orgId: OrganizationId,
+  ): Promise<{ rawInviteKey: SymmetricCryptoKey; encryptedInviteKey: EncString }> {
+    const rawInviteKey = await this.keyGenerationService.createKey(256);
+
+    const orgKey = await firstValueFrom(
+      this.keyService.orgKeys$(userId).pipe(
+        map((orgKeys) => {
+          const key: OrgKey | undefined = orgKeys?.[orgId as OrganizationId] ?? undefined;
+          if (key == null) {
+            throw new Error(`Organization key not found for org ${orgId}`);
+          }
+          return key;
+        }),
+      ),
+    );
+
+    const encryptedInviteKey = await this.encryptService.wrapSymmetricKey(rawInviteKey, orgKey);
+    return { rawInviteKey, encryptedInviteKey };
   }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-34389

## 📔 Objective

Updates `refreshInviteLink` to call the new `POST .../invite-link/refresh` endpoint instead of re-using create, and extracts shared org-key encryption logic into a generateEncryptedKeyBundle helper shared by both flows.

[Server PR](https://github.com/bitwarden/server/pull/7588).