### PR TITLE
PM-36610 derive users from cache after import

### DIFF
--- a/bitwarden_license/bit-common/src/dirt/access-intelligence/services/abstractions/access-intelligence-data.service.ts
+++ b/bitwarden_license/bit-common/src/dirt/access-intelligence/services/abstractions/access-intelligence-data.service.ts
@@ -1,6 +1,6 @@
 import { Observable } from "rxjs";
 
-import { OrganizationId, UserId } from "@bitwarden/common/types/guid";
+import { OrganizationId } from "@bitwarden/common/types/guid";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 
 import { ReportProgress } from "../../../reports/risk-insights/models/report-models";
@@ -56,6 +56,14 @@ export abstract class AccessIntelligenceDataService {
    * Null when no generation is in progress.
    */
   abstract readonly reportProgress$: Observable<ReportProgress | null>;
+
+  /**
+   * Whether the organization has any ciphers
+   *
+   * Emits true once ciphers are loaded during initialization.
+   * Emits false before initialization or when the org has no ciphers.
+   */
+  abstract readonly hasCiphers$: Observable<boolean>;
 
   /**
    * Initialize service for a specific organization
@@ -180,18 +188,4 @@ export abstract class AccessIntelligenceDataService {
    * ```
    */
   abstract markApplicationsAsReviewed$(appNames: string[], date?: Date): Observable<void>;
-
-  /** ------------------------- Utility Methods -------------------------
-   * Access Intelligence only loads ciphers when generating a new report,
-   * which is excellent for performance.
-   *
-   * This method determines if there are ciphers in access-intelligence
-   * or in the cipher cache for the user, which is necessary for conditional UI rendering.
-   *
-   * Returns true if ciphers are found in either place, false otherwise.
-   *
-   * @param userId - User ID to check for ciphers
-   * @returns Observable that emits true if ciphers exist, false if not
-   */
-  abstract doesUserHaveCiphers(userId: UserId): Observable<boolean>;
 }

--- a/bitwarden_license/bit-common/src/dirt/access-intelligence/services/abstractions/access-intelligence-data.service.ts
+++ b/bitwarden_license/bit-common/src/dirt/access-intelligence/services/abstractions/access-intelligence-data.service.ts
@@ -58,14 +58,6 @@ export abstract class AccessIntelligenceDataService {
   abstract readonly reportProgress$: Observable<ReportProgress | null>;
 
   /**
-   * Whether the organization has any ciphers
-   *
-   * Emits true once ciphers are loaded during initialization.
-   * Emits false before initialization or when the org has no ciphers.
-   */
-  abstract readonly hasCiphers$: Observable<boolean>;
-
-  /**
    * Initialize service for a specific organization
    *
    * Loads organization data and existing report if available.

--- a/bitwarden_license/bit-common/src/dirt/access-intelligence/services/abstractions/access-intelligence-data.service.ts
+++ b/bitwarden_license/bit-common/src/dirt/access-intelligence/services/abstractions/access-intelligence-data.service.ts
@@ -1,6 +1,6 @@
 import { Observable } from "rxjs";
 
-import { OrganizationId } from "@bitwarden/common/types/guid";
+import { OrganizationId, UserId } from "@bitwarden/common/types/guid";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 
 import { ReportProgress } from "../../../reports/risk-insights/models/report-models";
@@ -180,4 +180,18 @@ export abstract class AccessIntelligenceDataService {
    * ```
    */
   abstract markApplicationsAsReviewed$(appNames: string[], date?: Date): Observable<void>;
+
+  /** ------------------------- Utility Methods -------------------------
+   * Access Intelligence only loads ciphers when generating a new report,
+   * which is excellent for performance.
+   *
+   * This method determines if there are ciphers in access-intelligence
+   * or in the cipher cache for the user, which is necessary for conditional UI rendering.
+   *
+   * Returns true if ciphers are found in either place, false otherwise.
+   *
+   * @param userId - User ID to check for ciphers
+   * @returns Observable that emits true if ciphers exist, false if not
+   */
+  abstract doesUserHaveCiphers(userId: UserId): Observable<boolean>;
 }

--- a/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/view/default-access-intelligence-data.service.spec.ts
+++ b/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/view/default-access-intelligence-data.service.spec.ts
@@ -541,31 +541,4 @@ describe("DefaultAccessIntelligenceDataService", () => {
       );
     });
   });
-
-  describe("hasCiphers$", () => {
-    it("should emit false before initialization", async () => {
-      const hasCiphers = await firstValueFrom(service.hasCiphers$);
-      expect(hasCiphers).toBe(false);
-    });
-
-    it("should emit true after init when org has ciphers", async () => {
-      cipherService.getAllFromApiForOrganization.mockResolvedValue(testCiphers);
-      reportPersistenceService.loadLastReport$.mockReturnValue(of(null));
-
-      await firstValueFrom(service.initializeForOrganization$(orgId));
-
-      const hasCiphers = await firstValueFrom(service.hasCiphers$);
-      expect(hasCiphers).toBe(true);
-    });
-
-    it("should emit false after init when org has no ciphers", async () => {
-      cipherService.getAllFromApiForOrganization.mockResolvedValue([]);
-      reportPersistenceService.loadLastReport$.mockReturnValue(of(null));
-
-      await firstValueFrom(service.initializeForOrganization$(orgId));
-
-      const hasCiphers = await firstValueFrom(service.hasCiphers$);
-      expect(hasCiphers).toBe(false);
-    });
-  });
 });

--- a/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/view/default-access-intelligence-data.service.spec.ts
+++ b/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/view/default-access-intelligence-data.service.spec.ts
@@ -37,7 +37,7 @@ describe("DefaultAccessIntelligenceDataService", () => {
   beforeEach(() => {
     // Create mocks
     cipherService = {
-      getAllFromApiForOrganization: jest.fn(),
+      getAllFromApiForOrganization: jest.fn().mockResolvedValue([]),
     } as any;
 
     organizationUserApiService = {
@@ -435,6 +435,7 @@ describe("DefaultAccessIntelligenceDataService", () => {
 
   describe("Organization Switching", () => {
     it("should reset state when switching organizations", async () => {
+      cipherService.getAllFromApiForOrganization.mockResolvedValue([]);
       reportPersistenceService.loadLastReport$.mockReturnValue(
         of({ report: testReport, hadLegacyBlobs: false }),
       );
@@ -538,6 +539,33 @@ describe("DefaultAccessIntelligenceDataService", () => {
         ]),
         expect.anything(),
       );
+    });
+  });
+
+  describe("hasCiphers$", () => {
+    it("should emit false before initialization", async () => {
+      const hasCiphers = await firstValueFrom(service.hasCiphers$);
+      expect(hasCiphers).toBe(false);
+    });
+
+    it("should emit true after init when org has ciphers", async () => {
+      cipherService.getAllFromApiForOrganization.mockResolvedValue(testCiphers);
+      reportPersistenceService.loadLastReport$.mockReturnValue(of(null));
+
+      await firstValueFrom(service.initializeForOrganization$(orgId));
+
+      const hasCiphers = await firstValueFrom(service.hasCiphers$);
+      expect(hasCiphers).toBe(true);
+    });
+
+    it("should emit false after init when org has no ciphers", async () => {
+      cipherService.getAllFromApiForOrganization.mockResolvedValue([]);
+      reportPersistenceService.loadLastReport$.mockReturnValue(of(null));
+
+      await firstValueFrom(service.initializeForOrganization$(orgId));
+
+      const hasCiphers = await firstValueFrom(service.hasCiphers$);
+      expect(hasCiphers).toBe(false);
     });
   });
 });

--- a/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/view/default-access-intelligence-data.service.ts
+++ b/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/view/default-access-intelligence-data.service.ts
@@ -436,9 +436,13 @@ export class DefaultAccessIntelligenceDataService extends AccessIntelligenceData
   }
 
   private loadCiphersOnly$(orgId: OrganizationId): Observable<CipherView[]> {
-    return from(this.cipherService.getAllFromApiForOrganization(orgId));
+    return from(this.cipherService.getAllFromApiForOrganization(orgId)).pipe(
+      catchError((err) => {
+        this.logService.error("[DefaultAccessIntelligenceDataService] Cipher load failed", err);
+        return of([] as CipherView[]);
+      }),
+    );
   }
-
   /**
    * Load organization data in parallel (ciphers and users with collections/groups)
    */

--- a/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/view/default-access-intelligence-data.service.ts
+++ b/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/view/default-access-intelligence-data.service.ts
@@ -1,7 +1,6 @@
 import {
   BehaviorSubject,
   catchError,
-  filter,
   forkJoin,
   from,
   map,
@@ -18,7 +17,7 @@ import {
   OrganizationUserUserDetailsResponse,
 } from "@bitwarden/admin-console/common";
 import type { ListResponse } from "@bitwarden/common/models/response/list.response";
-import { OrganizationId, UserId } from "@bitwarden/common/types/guid";
+import { OrganizationId } from "@bitwarden/common/types/guid";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { LogService } from "@bitwarden/logging";
@@ -52,6 +51,7 @@ export class DefaultAccessIntelligenceDataService extends AccessIntelligenceData
   readonly loading$ = this._loading.asObservable();
   readonly error$ = this._error.asObservable();
   readonly reportProgress$ = this._reportProgress.asObservable();
+  readonly hasCiphers$ = this.ciphers$.pipe(map((ciphers) => ciphers.length > 0));
 
   constructor(
     private cipherService: CipherService,
@@ -79,13 +79,18 @@ export class DefaultAccessIntelligenceDataService extends AccessIntelligenceData
     this._loading.next(true);
     this._error.next(null);
 
-    return this.reportPersistenceService.loadLastReport$(orgId).pipe(
-      switchMap((result) => {
-        if (!result) {
+    return forkJoin({
+      reportResult: this.reportPersistenceService.loadLastReport$(orgId),
+      ciphers: this.loadCiphersOnly$(orgId),
+    }).pipe(
+      switchMap(({ reportResult, ciphers }) => {
+        this._ciphers.next(ciphers);
+
+        if (!reportResult) {
           return of(null);
         }
 
-        const { report, hadLegacyBlobs } = result;
+        const { report, hadLegacyBlobs } = reportResult;
 
         if (hadLegacyBlobs) {
           this.logService.info(
@@ -125,26 +130,6 @@ export class DefaultAccessIntelligenceDataService extends AccessIntelligenceData
         this._report.next(null);
         return of(undefined as void);
       }),
-    );
-  }
-
-  doesUserHaveCiphers(userId: UserId): Observable<boolean> {
-    this.logService.debug(
-      "[DefaultAccessIntelligenceDataService] Checking if user has ciphers",
-      userId,
-    );
-
-    if (this._ciphers.value.length > 0) {
-      return of(true);
-    }
-
-    // check if there are ciphers in cache
-    return this.cipherService.cipherViews$(userId).pipe(
-      filter(
-        (ciphers) =>
-          ciphers.filter((c) => c.organizationId === this._currentOrgId.value).length > 0,
-      ),
-      map((ciphers) => ciphers.length > 0),
     );
   }
 
@@ -448,6 +433,10 @@ export class DefaultAccessIntelligenceDataService extends AccessIntelligenceData
         return throwError(() => error);
       }),
     );
+  }
+
+  private loadCiphersOnly$(orgId: OrganizationId): Observable<CipherView[]> {
+    return from(this.cipherService.getAllFromApiForOrganization(orgId));
   }
 
   /**

--- a/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/view/default-access-intelligence-data.service.ts
+++ b/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/view/default-access-intelligence-data.service.ts
@@ -1,6 +1,7 @@
 import {
   BehaviorSubject,
   catchError,
+  filter,
   forkJoin,
   from,
   map,
@@ -17,7 +18,7 @@ import {
   OrganizationUserUserDetailsResponse,
 } from "@bitwarden/admin-console/common";
 import type { ListResponse } from "@bitwarden/common/models/response/list.response";
-import { OrganizationId } from "@bitwarden/common/types/guid";
+import { OrganizationId, UserId } from "@bitwarden/common/types/guid";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { LogService } from "@bitwarden/logging";
@@ -124,6 +125,26 @@ export class DefaultAccessIntelligenceDataService extends AccessIntelligenceData
         this._report.next(null);
         return of(undefined as void);
       }),
+    );
+  }
+
+  doesUserHaveCiphers(userId: UserId): Observable<boolean> {
+    this.logService.debug(
+      "[DefaultAccessIntelligenceDataService] Checking if user has ciphers",
+      userId,
+    );
+
+    if (this._ciphers.value.length > 0) {
+      return of(true);
+    }
+
+    // check if there are ciphers in cache
+    return this.cipherService.cipherViews$(userId).pipe(
+      filter(
+        (ciphers) =>
+          ciphers.filter((c) => c.organizationId === this._currentOrgId.value).length > 0,
+      ),
+      map((ciphers) => ciphers.length > 0),
     );
   }
 

--- a/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/view/default-access-intelligence-data.service.ts
+++ b/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/view/default-access-intelligence-data.service.ts
@@ -51,7 +51,6 @@ export class DefaultAccessIntelligenceDataService extends AccessIntelligenceData
   readonly loading$ = this._loading.asObservable();
   readonly error$ = this._error.asObservable();
   readonly reportProgress$ = this._reportProgress.asObservable();
-  readonly hasCiphers$ = this.ciphers$.pipe(map((ciphers) => ciphers.length > 0));
 
   constructor(
     private cipherService: CipherService,
@@ -437,7 +436,7 @@ export class DefaultAccessIntelligenceDataService extends AccessIntelligenceData
 
   private loadCiphersOnly$(orgId: OrganizationId): Observable<CipherView[]> {
     return from(this.cipherService.getAllFromApiForOrganization(orgId)).pipe(
-      catchError((err) => {
+      catchError((err: unknown) => {
         this.logService.error("[DefaultAccessIntelligenceDataService] Cipher load failed", err);
         return of([] as CipherView[]);
       }),

--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/v2/access-intelligence-page/access-intelligence-page.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/v2/access-intelligence-page/access-intelligence-page.component.spec.ts
@@ -425,7 +425,9 @@ describe("AccessIntelligencePageComponent", () => {
     });
 
     it("should report ciphers present when vault has items", async () => {
-      hasCiphersSubject.next(true);
+      mockAccessIntelligenceService.ciphers$.next([
+        { id: "c1", name: "Test Cipher", type: 1 } as CipherView,
+      ]);
 
       await component.ngOnInit();
       fixture.detectChanges();

--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/v2/access-intelligence-page/access-intelligence-page.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/v2/access-intelligence-page/access-intelligence-page.component.spec.ts
@@ -63,7 +63,7 @@ describe("AccessIntelligencePageComponent", () => {
     paramMap: BehaviorSubject<any>;
     queryParams: BehaviorSubject<any>;
   };
-  let doesUserHaveCiphersSubject: BehaviorSubject<boolean>;
+  let hasCiphersSubject: BehaviorSubject<boolean>;
 
   /**
    * Helper to access protected/private members for testing.
@@ -88,7 +88,7 @@ describe("AccessIntelligencePageComponent", () => {
   });
 
   beforeEach(async () => {
-    doesUserHaveCiphersSubject = new BehaviorSubject<boolean>(false);
+    hasCiphersSubject = new BehaviorSubject<boolean>(false);
 
     // Create mock services
     mockAccessIntelligenceService = {
@@ -99,7 +99,7 @@ describe("AccessIntelligencePageComponent", () => {
       initializeForOrganization$: jest.fn(),
       generateNewReport$: jest.fn(),
       ciphers$: new BehaviorSubject<CipherView[]>([]),
-      hasCiphers$: doesUserHaveCiphersSubject.asObservable(),
+      hasCiphers$: hasCiphersSubject.asObservable(),
     };
 
     mockDrawerStateService = {
@@ -425,7 +425,7 @@ describe("AccessIntelligencePageComponent", () => {
     });
 
     it("should report ciphers present when vault has items", async () => {
-      doesUserHaveCiphersSubject.next(true);
+      hasCiphersSubject.next(true);
 
       await component.ngOnInit();
       fixture.detectChanges();

--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/v2/access-intelligence-page/access-intelligence-page.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/v2/access-intelligence-page/access-intelligence-page.component.spec.ts
@@ -1,7 +1,7 @@
 import { NO_ERRORS_SCHEMA } from "@angular/core";
 import { ComponentFixture, fakeAsync, TestBed, tick } from "@angular/core/testing";
 import { ActivatedRoute, Router } from "@angular/router";
-import { BehaviorSubject, of, throwError } from "rxjs";
+import { BehaviorSubject, Observable, of, throwError } from "rxjs";
 
 import {
   AccessIntelligenceDataService,
@@ -16,10 +16,12 @@ import {
   createReport,
   createRiskInsights,
 } from "@bitwarden/bit-common/dirt/reports/risk-insights/testing/test-helpers";
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
-import { OrganizationId } from "@bitwarden/common/types/guid";
+import { mockAccountServiceWith } from "@bitwarden/common/spec";
+import { OrganizationId, UserId } from "@bitwarden/common/types/guid";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { DialogService } from "@bitwarden/components";
 
@@ -46,7 +48,10 @@ type MockAccessIntelligenceDataService = {
   ciphers$: BehaviorSubject<CipherView[]>;
   initializeForOrganization$: jest.Mock;
   generateNewReport$: jest.Mock;
+  doesUserHaveCiphers: (userId: UserId) => Observable<boolean>;
 };
+
+const USER_ID = "user-1" as unknown as UserId;
 
 describe("AccessIntelligencePageComponent", () => {
   let component: AccessIntelligencePageComponent;
@@ -62,6 +67,9 @@ describe("AccessIntelligencePageComponent", () => {
     paramMap: BehaviorSubject<any>;
     queryParams: BehaviorSubject<any>;
   };
+  let doesUserHaveCiphersSubject: BehaviorSubject<boolean>;
+
+  const mockAccountService = mockAccountServiceWith(USER_ID);
 
   /**
    * Helper to access protected/private members for testing.
@@ -86,6 +94,8 @@ describe("AccessIntelligencePageComponent", () => {
   });
 
   beforeEach(async () => {
+    doesUserHaveCiphersSubject = new BehaviorSubject<boolean>(false);
+
     // Create mock services
     mockAccessIntelligenceService = {
       report$: new BehaviorSubject<AccessReportView | null>(null),
@@ -95,6 +105,7 @@ describe("AccessIntelligencePageComponent", () => {
       initializeForOrganization$: jest.fn(),
       generateNewReport$: jest.fn(),
       ciphers$: new BehaviorSubject<CipherView[]>([]),
+      doesUserHaveCiphers: (_userId: UserId) => doesUserHaveCiphersSubject.asObservable(),
     };
 
     mockDrawerStateService = {
@@ -141,6 +152,7 @@ describe("AccessIntelligencePageComponent", () => {
         { provide: ConfigService, useValue: mockConfigService },
         { provide: Router, useValue: mockRouter },
         { provide: ActivatedRoute, useValue: mockActivatedRoute },
+        { provide: AccountService, useValue: mockAccountService },
       ],
       schemas: [NO_ERRORS_SCHEMA], // Ignore child component errors for unit testing
     })
@@ -420,7 +432,7 @@ describe("AccessIntelligencePageComponent", () => {
     });
 
     it("should report ciphers present when vault has items", async () => {
-      mockAccessIntelligenceService.ciphers$.next([new CipherView()]);
+      doesUserHaveCiphersSubject.next(true);
 
       await component.ngOnInit();
       fixture.detectChanges();

--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/v2/access-intelligence-page/access-intelligence-page.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/v2/access-intelligence-page/access-intelligence-page.component.spec.ts
@@ -16,12 +16,10 @@ import {
   createReport,
   createRiskInsights,
 } from "@bitwarden/bit-common/dirt/reports/risk-insights/testing/test-helpers";
-import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
-import { mockAccountServiceWith } from "@bitwarden/common/spec";
-import { OrganizationId, UserId } from "@bitwarden/common/types/guid";
+import { OrganizationId } from "@bitwarden/common/types/guid";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { DialogService } from "@bitwarden/components";
 
@@ -46,12 +44,10 @@ type MockAccessIntelligenceDataService = {
   error$: BehaviorSubject<string | null>;
   reportProgress$: BehaviorSubject<ReportProgress | null>;
   ciphers$: BehaviorSubject<CipherView[]>;
+  hasCiphers$: Observable<boolean>;
   initializeForOrganization$: jest.Mock;
   generateNewReport$: jest.Mock;
-  doesUserHaveCiphers: (userId: UserId) => Observable<boolean>;
 };
-
-const USER_ID = "user-1" as unknown as UserId;
 
 describe("AccessIntelligencePageComponent", () => {
   let component: AccessIntelligencePageComponent;
@@ -68,8 +64,6 @@ describe("AccessIntelligencePageComponent", () => {
     queryParams: BehaviorSubject<any>;
   };
   let doesUserHaveCiphersSubject: BehaviorSubject<boolean>;
-
-  const mockAccountService = mockAccountServiceWith(USER_ID);
 
   /**
    * Helper to access protected/private members for testing.
@@ -105,7 +99,7 @@ describe("AccessIntelligencePageComponent", () => {
       initializeForOrganization$: jest.fn(),
       generateNewReport$: jest.fn(),
       ciphers$: new BehaviorSubject<CipherView[]>([]),
-      doesUserHaveCiphers: (_userId: UserId) => doesUserHaveCiphersSubject.asObservable(),
+      hasCiphers$: doesUserHaveCiphersSubject.asObservable(),
     };
 
     mockDrawerStateService = {
@@ -152,7 +146,6 @@ describe("AccessIntelligencePageComponent", () => {
         { provide: ConfigService, useValue: mockConfigService },
         { provide: Router, useValue: mockRouter },
         { provide: ActivatedRoute, useValue: mockActivatedRoute },
-        { provide: AccountService, useValue: mockAccountService },
       ],
       schemas: [NO_ERRORS_SCHEMA], // Ignore child component errors for unit testing
     })

--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/v2/access-intelligence-page/access-intelligence-page.component.ts
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/v2/access-intelligence-page/access-intelligence-page.component.ts
@@ -147,9 +147,11 @@ export class AccessIntelligencePageComponent implements OnInit, OnDestroy {
     { initialValue: false },
   );
 
-  protected readonly hasCiphers = toSignal(this.accessIntelligenceService.hasCiphers$, {
-    initialValue: false,
+  protected readonly ciphers = toSignal(this.accessIntelligenceService.ciphers$, {
+    initialValue: [],
   });
+
+  protected readonly hasCiphers = computed(() => this.ciphers().length > 0);
 
   protected readonly invokedFrom = signal<{ source: string; status: string } | null>(null);
 

--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/v2/access-intelligence-page/access-intelligence-page.component.ts
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/v2/access-intelligence-page/access-intelligence-page.component.ts
@@ -27,13 +27,11 @@ import {
   AccessReportView,
 } from "@bitwarden/bit-common/dirt/access-intelligence/models";
 import { ReportProgress } from "@bitwarden/bit-common/dirt/reports/risk-insights";
-import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
-import { getUserId } from "@bitwarden/common/auth/services/account.service";
 import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
-import { OrganizationId, UserId } from "@bitwarden/common/types/guid";
+import { OrganizationId } from "@bitwarden/common/types/guid";
 import { skeletonLoadingDelay } from "@bitwarden/common/vault/utils/skeleton-loading.operator";
 import {
   AsyncActionsModule,
@@ -149,14 +147,9 @@ export class AccessIntelligencePageComponent implements OnInit, OnDestroy {
     { initialValue: false },
   );
 
-  protected readonly activeUserId = toSignal(this.accountService.activeAccount$.pipe(getUserId), {
-    initialValue: null,
+  protected readonly hasCiphers = toSignal(this.accessIntelligenceService.hasCiphers$, {
+    initialValue: false,
   });
-
-  protected readonly hasCiphers = toSignal(
-    this.accessIntelligenceService.doesUserHaveCiphers(this.activeUserId() as UserId),
-    { initialValue: false },
-  );
 
   protected readonly invokedFrom = signal<{ source: string; status: string } | null>(null);
 
@@ -169,7 +162,6 @@ export class AccessIntelligencePageComponent implements OnInit, OnDestroy {
     private readonly dialogService: DialogService,
     private readonly logService: LogService,
     private readonly configService: ConfigService,
-    private readonly accountService: AccountService,
   ) {
     this.route.queryParams
       .pipe(takeUntilDestroyed(this.destroyRef))

--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/v2/access-intelligence-page/access-intelligence-page.component.ts
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/v2/access-intelligence-page/access-intelligence-page.component.ts
@@ -27,11 +27,13 @@ import {
   AccessReportView,
 } from "@bitwarden/bit-common/dirt/access-intelligence/models";
 import { ReportProgress } from "@bitwarden/bit-common/dirt/reports/risk-insights";
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { getUserId } from "@bitwarden/common/auth/services/account.service";
 import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
-import { OrganizationId } from "@bitwarden/common/types/guid";
+import { OrganizationId, UserId } from "@bitwarden/common/types/guid";
 import { skeletonLoadingDelay } from "@bitwarden/common/vault/utils/skeleton-loading.operator";
 import {
   AsyncActionsModule,
@@ -147,10 +149,14 @@ export class AccessIntelligencePageComponent implements OnInit, OnDestroy {
     { initialValue: false },
   );
 
-  private readonly ciphers = toSignal(this.accessIntelligenceService.ciphers$, {
-    initialValue: [],
+  protected readonly activeUserId = toSignal(this.accountService.activeAccount$.pipe(getUserId), {
+    initialValue: null,
   });
-  protected readonly hasCiphers = computed(() => this.ciphers().length > 0);
+
+  protected readonly hasCiphers = toSignal(
+    this.accessIntelligenceService.doesUserHaveCiphers(this.activeUserId() as UserId),
+    { initialValue: false },
+  );
 
   protected readonly invokedFrom = signal<{ source: string; status: string } | null>(null);
 
@@ -163,6 +169,7 @@ export class AccessIntelligencePageComponent implements OnInit, OnDestroy {
     private readonly dialogService: DialogService,
     private readonly logService: LogService,
     private readonly configService: ConfigService,
+    private readonly accountService: AccountService,
   ) {
     this.route.queryParams
       .pipe(takeUntilDestroyed(this.destroyRef))


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-36610

## 📔 Objective

Applies to access intelligence V2
After importing data, check in the ciphers cache if there are ciphers imported/created for the org
This helps determine the next step for the user.

## 📸 Screenshots

none at this time.
