### PR TITLE
[PM-32693] Desktop Driver's License

### DIFF
--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -150,7 +150,7 @@
     "message": "View bank account",
     "description": "Header for view bank account item type"
   },
-  "viewItemHeaderDriversLicense": {
+  "viewItemHeaderLicense": {
     "message": "View license",
     "description": "Header for view license item type"
   },
@@ -214,7 +214,7 @@
     "message": "Edit bank account",
     "description": "Header for edit bank account item type"
   },
-  "editItemHeaderDriversLicense": {
+  "editItemHeaderLicense": {
     "message": "Edit license",
     "description": "Header for edit license item type"
   },
@@ -381,6 +381,51 @@
   },
   "licenseNumber": {
     "message": "License number"
+  },
+  "copyLicenseNumber": {
+    "message": "Copy license number"
+  },
+  "driversLicenseDetails": {
+    "message": "License details"
+  },
+  "dateOfBirth": {
+    "message": "Date of birth"
+  },
+  "birthMonth": {
+    "message": "Birth month"
+  },
+  "birthDay": {
+    "message": "Birth day"
+  },
+  "birthYear": {
+    "message": "Birth year"
+  },
+  "issuingCountry": {
+    "message": "Issuing country"
+  },
+  "issuingState": {
+    "message": "Issuing state / province"
+  },
+  "issuingAuthority": {
+    "message": "Issuing authority"
+  },
+  "issueDate": {
+    "message": "Issue date"
+  },
+  "issueMonth": {
+    "message": "Issue month"
+  },
+  "issueDay": {
+    "message": "Issue day"
+  },
+  "issueYear": {
+    "message": "Issue year"
+  },
+  "expirationDay": {
+    "message": "Expiration day"
+  },
+  "licenseClass": {
+    "message": "License class"
   },
   "email": {
     "message": "Email"

--- a/apps/desktop/src/vault/app/vault-v3/vault-items/vault-cipher-row.component.ts
+++ b/apps/desktop/src/vault/app/vault-v3/vault-items/vault-cipher-row.component.ts
@@ -226,6 +226,13 @@ export class VaultCipherRowComponent<C extends CipherViewLike> {
           { field: "pin", title: "copyPin" },
           { field: "iban", title: "copyIban" },
         ];
+      case CipherType.DriversLicense:
+        return [
+          { field: "firstName", title: "copyFirstName" },
+          { field: "middleName", title: "copyMiddleName" },
+          { field: "lastName", title: "copyLastName" },
+          { field: "licenseNumber", title: "copyLicenseNumber" },
+        ];
       default:
         return [];
     }

--- a/apps/desktop/src/vault/app/vault-v3/vault-orig.component.ts
+++ b/apps/desktop/src/vault/app/vault-v3/vault-orig.component.ts
@@ -623,6 +623,41 @@ export class VaultComponent implements OnInit, OnDestroy, CopyClickListener {
       });
     }
 
+    const addDriverLicenseFields = () => {
+      const fields = ["firstName", "middleName", "lastName", "licenseNumber"] as const;
+      const fieldLabels: Record<(typeof fields)[number], { copyLabelKey: string; aType?: string }> =
+        {
+          firstName: {
+            copyLabelKey: "copyFirstName",
+          },
+          middleName: {
+            copyLabelKey: "copyMiddleName",
+          },
+          lastName: {
+            copyLabelKey: "copyLastName",
+          },
+          licenseNumber: {
+            copyLabelKey: "copyLicenseNumber",
+            aType: "License Number",
+          },
+        };
+      const hasAnyField = fields.some((field) => cipher.driversLicense?.[field] != null);
+      if (hasAnyField) {
+        menu.push({ type: "separator" });
+      }
+
+      fields.forEach((field) => {
+        const value = cipher.driversLicense?.[field];
+        if (value != null) {
+          const { copyLabelKey, aType } = fieldLabels[field];
+          menu.push({
+            label: this.i18nService.t(copyLabelKey),
+            click: () => this.copyValue(cipher, value, field, aType),
+          });
+        }
+      });
+    };
+
     switch (cipher.type) {
       case CipherType.Login:
         if (
@@ -731,6 +766,9 @@ export class VaultComponent implements OnInit, OnDestroy, CopyClickListener {
             click: () => this.copyValue(cipher, cipher.bankAccount.iban, "iban", "IBAN"),
           });
         }
+        break;
+      case CipherType.DriversLicense:
+        addDriverLicenseFields();
         break;
       default:
         break;

--- a/libs/common/src/vault/utils/cipher-view-like-utils.ts
+++ b/libs/common/src/vault/utils/cipher-view-like-utils.ts
@@ -292,6 +292,12 @@ export class CipherViewLikeUtils {
         return !!cipher.bankAccount?.iban;
       case "licenseNumber":
         return !!cipher.driversLicense?.licenseNumber;
+      case "firstName":
+        return !!cipher.driversLicense?.firstName;
+      case "middleName":
+        return !!cipher.driversLicense?.middleName;
+      case "lastName":
+        return !!cipher.driversLicense?.lastName;
       default:
         return false;
     }

--- a/libs/vault/src/components/copy-cipher-field.directive.ts
+++ b/libs/vault/src/components/copy-cipher-field.directive.ts
@@ -150,6 +150,12 @@ export class CopyCipherFieldDirective implements OnChanges {
         return _cipher.bankAccount?.iban;
       case "licenseNumber":
         return _cipher.driversLicense?.licenseNumber;
+      case "firstName":
+        return _cipher.driversLicense?.firstName;
+      case "middleName":
+        return _cipher.driversLicense?.middleName;
+      case "lastName":
+        return _cipher.driversLicense?.lastName;
       default:
         return null;
     }

--- a/libs/vault/src/services/copy-cipher-field.service.ts
+++ b/libs/vault/src/services/copy-cipher-field.service.ts
@@ -37,7 +37,10 @@ export type CopyAction =
   | "routingNumber"
   | "pin"
   | "iban"
-  | "licenseNumber";
+  | "licenseNumber"
+  | "firstName"
+  | "middleName"
+  | "lastName";
 
 /**
  * Copy actions that can be used with the appCopyField directive.
@@ -96,6 +99,9 @@ const CopyActions: Record<CopyAction, CopyActionInfo> = {
     protected: true,
     event: EventType.Cipher_ClientCopiedLicenseNumber,
   },
+  firstName: { typeI18nKey: "firstName", protected: false },
+  middleName: { typeI18nKey: "middleName", protected: false },
+  lastName: { typeI18nKey: "lastName", protected: false },
   hiddenField: {
     typeI18nKey: "value",
     protected: true,

--- a/libs/vault/src/services/password-reprompt.service.ts
+++ b/libs/vault/src/services/password-reprompt.service.ts
@@ -33,6 +33,7 @@ export class PasswordRepromptService {
       "Account Number",
       "IBAN",
       "SWIFT",
+      "License Number",
     ];
   }
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-32693](https://bitwarden.atlassian.net/browse/PM-32693)

> ⚠️ Stacked on #20461 — rebase onto \`main\` after that PR merges.

## 📔 Objective

Adds Driver's License type support to the desktop app, building on the shared components introduced in #20461 (web).

- Adds missing i18n strings for the Driver's License form/view (date of birth, issuing country/state/authority, issue & expiration date fields, license class, and \`copyLicenseNumber\`)
- Renames \`viewItemHeaderDriversLicense\` / \`editItemHeaderDriversLicense\` to \`viewItemHeaderLicense\` / \`editItemHeaderLicense\` to align with the shared \`vault-item-dialog\` component
- Adds a \`DriversLicense\` case to the vault list row copy menu with first name, middle name, last name, and license number
- Adds a Driver's License branch to the system tray context menu with the same copyable fields
- Extends \`CopyAction\`, \`hasCopyableValue\`, and \`CopyCipherFieldDirective\` to support \`firstName\`, \`middleName\`, and \`lastName\` as copyable fields
- Adds "License Number" to the password reprompt protected field list

## Screenshots

|Milestone 3 off | Milestone 3 on|
|-|-|
|<video src="https://github.com/user-attachments/assets/cdd2180d-193e-43ff-bf40-7874677733c1"/>|<video src="https://github.com/user-attachments/assets/8e4519be-63f7-4d80-a861-66bb0d2dcba7"/>|

[PM-32693]: https://bitwarden.atlassian.net/browse/PM-32693?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ