### PR TITLE
[CL-1193] document banner dismiss button binding behavior

### DIFF
--- a/libs/components/src/banner/banner.component.ts
+++ b/libs/components/src/banner/banner.component.ts
@@ -69,6 +69,10 @@ export class BannerComponent implements OnInit {
   readonly useAlertRole = input(true);
 
   private readonly dismiss$ = new Subject<void>();
+  /**
+   * Emitted when the user clicks the close button. The close button is only rendered when this
+   * output is bound by the consumer; if no listener is attached, the banner has no dismiss control.
+   */
   readonly dismiss = outputFromObservable(this.dismiss$);
   protected readonly isDismissible = signal(false);
 

--- a/libs/components/src/banner/banner.mdx
+++ b/libs/components/src/banner/banner.mdx
@@ -52,6 +52,13 @@ input. Pass `[icon]="null"` to suppress the icon entirely.
 
 <Canvas of={stories.AllVariantsCustomIcon} />
 
+## Dismissibility
+
+The close (X) button is only rendered when the consumer binds the `(dismiss)` output. If no listener
+is attached, the banner has no dismiss control. This applies to both simple and titled banners.
+
+<Canvas of={stories.NotDismissible} />
+
 ## Accessibility
 
 Banners set the `role="status"` and `aria-live="polite"` attributes to ensure screen readers

--- a/libs/components/src/banner/banner.stories.ts
+++ b/libs/components/src/banner/banner.stories.ts
@@ -153,6 +153,29 @@ export const BannerSimpleLargeText: Story = {
   },
 };
 
+export const NotDismissible: Story = {
+  render: (args) => ({
+    props: args,
+    template: /*html*/ `
+      <div class="tw-flex tw-flex-col tw-gap-4">
+        <bit-banner [variant]="variant">
+          Bitwarden is the most trusted password manager. The close button is hidden because no <code>(dismiss)</code> handler is bound.
+        </bit-banner>
+        <bit-banner [variant]="variant" title="Integration is the key">
+          Bitwarden is the most trusted password manager. With many tools to make your work even more efficient.
+          <ng-container slot="actions">
+            <button bitButton type="button" [buttonType]="variant + 'Outline'" size="small">Cancel</button>
+            <button bitButton type="button" [buttonType]="variant" size="small">Continue</button>
+          </ng-container>
+        </bit-banner>
+      </div>
+    `,
+  }),
+  args: {
+    variant: "primary",
+  },
+};
+
 export const AllVariantsNoTitle: Story = {
   render: () => ({
     template: /*html*/ `


### PR DESCRIPTION
## 🎟️ Tracking

[CL-1193](https://bitwarden.atlassian.net/browse/CL-1193)

## 📔 Objective

The banner's close (X) button is intentionally omitted when consumers do not bind the `(dismiss)` output (driven by `dismiss$.observed` in `ngOnInit`). That behavior was undocumented.

This PR:

- Adds a JSDoc comment on the `dismiss` output describing the conditional rendering.
- Adds a `NotDismissible` Storybook story showing both a simple banner and a titled banner (with actions slot) rendered without a `(dismiss)` handler, so reviewers can see the close button is absent in both layouts.

No behavior changes.

## 📸 Screenshots

N/A — Storybook-only addition; viewable under `Component Library/Banner/Not Dismissible` once Storybook is built.

[CL-1193]: https://bitwarden.atlassian.net/browse/CL-1193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ