### PR TITLE
Fix desktop biometric auto-prompt on focus

### DIFF
--- a/libs/key-management-ui/src/lock/components/lock.component.spec.ts
+++ b/libs/key-management-ui/src/lock/components/lock.component.spec.ts
@@ -62,6 +62,7 @@ describe("LockComponent", () => {
   let fixture: ComponentFixture<LockComponent>;
 
   const userId = "test-user-id" as UserId;
+  const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0));
 
   // Mock services
   const mockAccountService = mockAccountServiceWith(userId);
@@ -757,5 +758,75 @@ describe("LockComponent", () => {
 
       expect(setDefaultSpy).not.toHaveBeenCalled();
     }));
+  });
+
+  describe("desktop biometric auto-prompt", () => {
+    const desktopUnlockOptions: UnlockOptions = {
+      masterPassword: { enabled: false },
+      pin: { enabled: false },
+      biometrics: { enabled: true, biometricsStatus: BiometricsStatus.Available },
+      prf: { enabled: false },
+    };
+
+    beforeEach(() => {
+      mockPlatformUtilsService.getClientType.mockReturnValue(ClientType.Desktop);
+      mockBiometricStateService.promptAutomatically$ = of(true);
+      mockBiometricStateService.promptCancelled$ = of(false);
+      mockBiometricService.getBiometricsStatusForUser.mockResolvedValue(BiometricsStatus.Available);
+      mockBiometricService.getShouldAutopromptNow.mockResolvedValue(true);
+      mockLockComponentService.getAvailableUnlockOptions$.mockReturnValue(of(desktopUnlockOptions));
+      mockLockComponentService.isWindowVisible.mockResolvedValue(true);
+    });
+
+    it("sets the client type before active account handling can auto-prompt", async () => {
+      const unlockViaBiometricsSpy = jest
+        .spyOn(component, "unlockViaBiometrics")
+        .mockResolvedValue();
+
+      await component.ngOnInit();
+      await flushPromises();
+      component.ngOnDestroy();
+
+      expect(unlockViaBiometricsSpy).toHaveBeenCalled();
+    });
+
+    it("tries auto-prompting again when the desktop window gains focus", async () => {
+      let broadcasterCallback: ((message: any) => void) | undefined;
+      mockBroadcasterService.subscribe.mockImplementation((_, callback) => {
+        broadcasterCallback = callback;
+      });
+
+      component.clientType = ClientType.Desktop;
+      component.unlockOptions = desktopUnlockOptions;
+      const unlockViaBiometricsSpy = jest
+        .spyOn(component, "unlockViaBiometrics")
+        .mockResolvedValue();
+
+      await component.desktopOnInit();
+      broadcasterCallback?.({ command: "windowIsFocused", windowIsFocused: true });
+      await flushPromises();
+
+      expect(unlockViaBiometricsSpy).toHaveBeenCalled();
+    });
+
+    it("does not auto-prompt on focus when automatic prompting is disabled", async () => {
+      let broadcasterCallback: ((message: any) => void) | undefined;
+      mockBroadcasterService.subscribe.mockImplementation((_, callback) => {
+        broadcasterCallback = callback;
+      });
+      mockBiometricStateService.promptAutomatically$ = of(false);
+
+      component.clientType = ClientType.Desktop;
+      component.unlockOptions = desktopUnlockOptions;
+      const unlockViaBiometricsSpy = jest
+        .spyOn(component, "unlockViaBiometrics")
+        .mockResolvedValue();
+
+      await component.desktopOnInit();
+      broadcasterCallback?.({ command: "windowIsFocused", windowIsFocused: true });
+      await flushPromises();
+
+      expect(unlockViaBiometricsSpy).not.toHaveBeenCalled();
+    });
   });
 });

--- a/libs/key-management-ui/src/lock/components/lock.component.ts
+++ b/libs/key-management-ui/src/lock/components/lock.component.ts
@@ -147,6 +147,7 @@ export class LockComponent implements OnInit, OnDestroy {
   // Desktop properties:
   private deferFocus: boolean | null = null;
   private biometricAsked = false;
+  private biometricAutoPromptPending = false;
 
   defaultUnlockOptionSetForUser = false;
 
@@ -186,15 +187,15 @@ export class LockComponent implements OnInit, OnDestroy {
   ) {}
 
   async ngOnInit() {
+    // Identify client before subscribing to account state; activeAccount$ can synchronously emit.
+    this.clientType = this.platformUtilsService.getClientType();
+
     this.listenForActiveUnlockOptionChanges();
 
     // Listen for active account changes
     this.listenForActiveAccountChanges();
 
     this.listenForUnlockOptionsChanges();
-
-    // Identify client
-    this.clientType = this.platformUtilsService.getClientType();
 
     if (this.clientType === ClientType.Desktop) {
       await this.desktopOnInit();
@@ -309,6 +310,7 @@ export class LockComponent implements OnInit, OnDestroy {
 
     // Desktop properties:
     this.biometricAsked = false;
+    this.biometricAutoPromptPending = false;
   }
 
   private setEmailAsPageSubtitle(email: string) {
@@ -346,14 +348,14 @@ export class LockComponent implements OnInit, OnDestroy {
 
     // TODO: PM-12546 - we need to make our biometric autoprompt experience consistent between the
     // desktop and extension.
-    if (this.clientType === "desktop") {
+    if (this.clientType === ClientType.Desktop) {
       if (autoPromptBiometrics) {
         this.loading = false;
         await this.desktopAutoPromptBiometrics();
       }
     }
 
-    if (this.clientType === "browser") {
+    if (this.clientType === ClientType.Browser) {
       if (
         this.unlockOptions?.biometrics.enabled &&
         autoPromptBiometrics &&
@@ -748,6 +750,14 @@ export class LockComponent implements OnInit, OnDestroy {
               this.focusInput();
               this.deferFocus = false;
             }
+            if (message.windowIsFocused) {
+              void this.desktopAutoPromptBiometricsIfEnabled().catch((e) =>
+                this.logService.error(
+                  "[LockComponent] Failed to auto-prompt biometrics on focus.",
+                  e,
+                ),
+              );
+            }
             break;
           default:
         }
@@ -756,25 +766,49 @@ export class LockComponent implements OnInit, OnDestroy {
     this.messagingService.send("getWindowIsFocused");
   }
 
+  private async desktopAutoPromptBiometricsIfEnabled() {
+    if (this.clientType !== ClientType.Desktop) {
+      return;
+    }
+
+    const autoPromptBiometrics = await firstValueFrom(
+      this.biometricStateService.promptAutomatically$,
+    );
+
+    if (autoPromptBiometrics) {
+      await this.desktopAutoPromptBiometrics();
+    }
+  }
+
   private async desktopAutoPromptBiometrics() {
-    if (!this.unlockOptions?.biometrics?.enabled || this.biometricAsked) {
+    if (
+      !this.unlockOptions?.biometrics?.enabled ||
+      this.biometricAsked ||
+      this.biometricAutoPromptPending ||
+      this.unlockingViaBiometrics
+    ) {
       return;
     }
 
-    if (!(await this.biometricService.getShouldAutopromptNow())) {
-      return;
-    }
+    this.biometricAutoPromptPending = true;
+    try {
+      if (!(await this.biometricService.getShouldAutopromptNow())) {
+        return;
+      }
 
-    // prevent the biometric prompt from showing if the user has already cancelled it
-    if (await firstValueFrom(this.biometricStateService.promptCancelled$)) {
-      return;
-    }
+      // prevent the biometric prompt from showing if the user has already cancelled it
+      if (await firstValueFrom(this.biometricStateService.promptCancelled$)) {
+        return;
+      }
 
-    const windowVisible = await this.lockComponentService.isWindowVisible();
+      const windowVisible = await this.lockComponentService.isWindowVisible();
 
-    if (windowVisible) {
-      this.biometricAsked = true;
-      await this.unlockViaBiometrics();
+      if (windowVisible) {
+        this.biometricAsked = true;
+        await this.unlockViaBiometrics();
+      }
+    } finally {
+      this.biometricAutoPromptPending = false;
     }
   }
 


### PR DESCRIPTION
Updated desktop biometric auto-prompt state handling by adding a pending guard and resetting it on active-account changes.