### PR TITLE
Set nav component host display to block; add nav-item tour stop

### DIFF
--- a/libs/components/src/navigation/nav-divider.component.ts
+++ b/libs/components/src/navigation/nav-divider.component.ts
@@ -9,6 +9,9 @@ import { SideNavService } from "./side-nav.service";
   selector: "bit-nav-divider",
   templateUrl: "./nav-divider.component.html",
   changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    class: "tw-block",
+  },
 })
 export class NavDividerComponent {
   protected readonly sideNavService = inject(SideNavService);

--- a/libs/components/src/navigation/nav-group.component.ts
+++ b/libs/components/src/navigation/nav-group.component.ts
@@ -28,6 +28,9 @@ import { SideNavService } from "./side-nav.service";
   ],
   imports: [NavItemComponent, IconButtonModule, I18nPipe],
   changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    class: "tw-block",
+  },
 })
 export class NavGroupComponent extends NavBaseComponent {
   protected readonly sideNavService = inject(SideNavService);

--- a/libs/components/src/navigation/nav-item.component.ts
+++ b/libs/components/src/navigation/nav-item.component.ts
@@ -29,6 +29,7 @@ export abstract class NavGroupAbstraction {
   imports: [NgTemplateOutlet, IconButtonModule, RouterModule, IconComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
+    class: "tw-block",
     "(focusin)": "onFocusIn($event.target)",
     "(focusout)": "onFocusOut()",
   },

--- a/libs/components/src/stories/kitchen-sink/components/kitchen-sink-app.component.ts
+++ b/libs/components/src/stories/kitchen-sink/components/kitchen-sink-app.component.ts
@@ -1,8 +1,10 @@
-import { ChangeDetectionStrategy, Component } from "@angular/core";
+import { ChangeDetectionStrategy, Component, inject } from "@angular/core";
 
 import { PasswordManagerLogo } from "@bitwarden/assets/svg";
 
 import { KitchenSinkSharedModule } from "../kitchen-sink-shared.module";
+
+import { KitchenSinkTourService } from "./kitchen-sink-tour.service";
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -12,15 +14,38 @@ import { KitchenSinkSharedModule } from "../kitchen-sink-shared.module";
     <bit-layout>
       <bit-side-nav>
         <bit-nav-logo [openIcon]="logo" route="." [label]="'Kitchen Sink'"></bit-nav-logo>
-        <bit-nav-item text="Home" route="bitwarden" icon="bwi-vault"></bit-nav-item>
+        <bit-nav-item
+          text="Home"
+          route="bitwarden"
+          icon="bwi-vault"
+          [bitPopoverAnchorFor]="tourStep2"
+          [popoverOpen]="tourService.tourStep() === 2"
+          [spotlight]="true"
+          [spotlightPadding]="4"
+          [position]="'right-center'"
+        ></bit-nav-item>
         <bit-nav-group text="Examples" icon="bwi-cog" [open]="true">
           <bit-nav-item text="Virtual Scroll" route="virtual-scroll" icon="bwi-list"></bit-nav-item>
         </bit-nav-group>
       </bit-side-nav>
       <router-outlet></router-outlet>
     </bit-layout>
+
+    <bit-popover [title]="'Step 2: Navigation'" (closed)="tourService.endTour()" #tourStep2>
+      <div>Use the <strong>side navigation</strong> to move between sections of the app.</div>
+      <p class="tw-mt-2 tw-mb-0">Nav items group related pages and surface the current location.</p>
+      <div class="tw-flex tw-gap-2 tw-mt-4">
+        <button type="button" bitButton buttonType="primary" (click)="tourService.nextStep()">
+          Next
+        </button>
+        <button type="button" bitButton buttonType="secondary" (click)="tourService.endTour()">
+          Skip Tour
+        </button>
+      </div>
+    </bit-popover>
   `,
 })
 export class KitchenSinkAppComponent {
   protected readonly logo = PasswordManagerLogo;
+  protected readonly tourService = inject(KitchenSinkTourService);
 }

--- a/libs/components/src/stories/kitchen-sink/components/kitchen-sink-tour.service.ts
+++ b/libs/components/src/stories/kitchen-sink/components/kitchen-sink-tour.service.ts
@@ -2,14 +2,14 @@ import { Injectable, signal, WritableSignal } from "@angular/core";
 
 @Injectable({ providedIn: "root" })
 export class KitchenSinkTourService {
-  readonly tourStep: WritableSignal<0 | 1 | 2 | 3> = signal(0);
+  readonly tourStep: WritableSignal<0 | 1 | 2 | 3 | 4> = signal(0);
 
   startTour(): void {
     this.tourStep.set(1);
   }
 
   nextStep(): void {
-    this.tourStep.update((prev) => (prev > 0 && prev < 3 ? ((prev + 1) as 1 | 2 | 3) : 0));
+    this.tourStep.update((prev) => (prev > 0 && prev < 4 ? ((prev + 1) as 1 | 2 | 3 | 4) : 0));
   }
 
   endTour(): void {

--- a/libs/components/src/stories/kitchen-sink/components/kitchen-sink-vault.component.ts
+++ b/libs/components/src/stories/kitchen-sink/components/kitchen-sink-vault.component.ts
@@ -30,8 +30,8 @@ import { KitchenSinkTourService } from "./kitchen-sink-tour.service";
         type="button"
         bitButton
         (click)="openDialog()"
-        [bitPopoverAnchorFor]="tourStep2"
-        [popoverOpen]="tourService.tourStep() === 2"
+        [bitPopoverAnchorFor]="tourStep3"
+        [popoverOpen]="tourService.tourStep() === 3"
         [spotlight]="true"
         [spotlightPadding]="12"
         [position]="'below-start'"
@@ -54,8 +54,8 @@ import { KitchenSinkTourService } from "./kitchen-sink-tour.service";
       <bit-kitchen-sink-toggle-list></bit-kitchen-sink-toggle-list>
     </bit-section>
     <bit-section
-      [bitPopoverAnchorFor]="tourStep3"
-      [popoverOpen]="tourService.tourStep() === 3"
+      [bitPopoverAnchorFor]="tourStep4"
+      [popoverOpen]="tourService.tourStep() === 4"
       [spotlight]="true"
       [spotlightPadding]="12"
       [position]="'right-center'"
@@ -65,7 +65,7 @@ import { KitchenSinkTourService } from "./kitchen-sink-tour.service";
     </bit-section>
 
     <!-- Tour Popovers -->
-    <bit-popover [title]="'Step 2: Dialogs'" (closed)="tourService.endTour()" #tourStep2>
+    <bit-popover [title]="'Step 3: Dialogs'" (closed)="tourService.endTour()" #tourStep3>
       <div>Click buttons to <strong>open dialogs</strong> for important actions and forms.</div>
       <p class="tw-mt-2 tw-mb-0">
         Dialogs help focus user attention and collect input for critical operations.
@@ -80,7 +80,7 @@ import { KitchenSinkTourService } from "./kitchen-sink-tour.service";
       </div>
     </bit-popover>
 
-    <bit-popover [title]="'Step 3: Forms'" (closed)="tourService.endTour()" #tourStep3>
+    <bit-popover [title]="'Step 4: Forms'" (closed)="tourService.endTour()" #tourStep4>
       <div>Fill out <strong>forms</strong> to collect and manage user information.</div>
       <p class="tw-mt-2 tw-mb-0">
         Our form components provide consistent styling and validation patterns.

--- a/libs/components/src/stories/kitchen-sink/kitchen-sink.stories.ts
+++ b/libs/components/src/stories/kitchen-sink/kitchen-sink.stories.ts
@@ -2,7 +2,14 @@ import { importProvidersFrom } from "@angular/core";
 import { provideNoopAnimations } from "@angular/platform-browser/animations";
 import { RouterModule } from "@angular/router";
 import { Meta, StoryObj, applicationConfig, moduleMetadata } from "@storybook/angular";
-import { userEvent, getAllByRole, getByRole, fireEvent, getAllByLabelText } from "storybook/test";
+import {
+  userEvent,
+  getAllByRole,
+  getByRole,
+  fireEvent,
+  getAllByLabelText,
+  waitFor,
+} from "storybook/test";
 
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
@@ -258,6 +265,11 @@ export const GuidedTour: Story = {
 
     // workaround for userEvent not firing in FF https://github.com/testing-library/user-event/issues/1075
     await fireEvent.click(tourButton);
+
+    // Advance from the search popover to the nav-item popover so the story lands on
+    // the navigation tour stop.
+    await waitFor(() => getByRole(canvas.ownerDocument.body, "button", { name: "Next" }));
+    await fireEvent.click(getByRole(canvas.ownerDocument.body, "button", { name: "Next" }));
   },
   parameters: {
     chromatic: { disableSnapshot: true },


### PR DESCRIPTION
## 🎟️ Tracking

No ticket.

## 📔 Objective

`bit-nav-item`, `bit-nav-group`, and `bit-nav-divider` are custom elements that did not declare a host `display`, leaving their hosts at the browser default of `inline`. The visible layout was only correct because their inner templates wrap content in block-level `<div>`s — the host elements themselves had no layout box, couldn't take margin/border, and were unreliable as positioning anchors (e.g. for popovers).

This PR sets `display: block` on the host of all three components via `host: { class: "tw-block" }`, aligning the host with their semantic block-level role.

To exercise nav-item as a popover anchor end-to-end, this also adds a step 2 ("Navigation") to the kitchen sink guided tour. The `GuidedTour` story now advances past the initial search popover so the new nav-item tour stop is the demonstrated state.

### Changes

- `nav-item.component.ts`, `nav-group.component.ts`, `nav-divider.component.ts` — `host: { class: "tw-block" }`
- `kitchen-sink-tour.service.ts` — extend tour step type from `1|2|3` to `1|2|3|4`
- `kitchen-sink-app.component.ts` — anchor a "Step 2: Navigation" popover on the Home `bit-nav-item`
- `kitchen-sink-vault.component.ts` — renumber Dialog (2 → 3) and Forms (3 → 4) tour stops
- `kitchen-sink.stories.ts` — `GuidedTour` story advances to step 2 using `waitFor`

## 📸 Screenshots

<!-- TODO: capture the kitchen sink GuidedTour story showing the nav-item popover anchored on the Home item. -->
<!-- TODO: capture the side nav at default and collapsed widths to confirm no layout regressions from the host display change. -->