### PR TITLE
[PM-36616] Fix fido2 script injection not respecting blocked domains

### DIFF
--- a/libs/common/src/platform/services/fido2/fido2-client.service.spec.ts
+++ b/libs/common/src/platform/services/fido2/fido2-client.service.spec.ts
@@ -724,12 +724,12 @@ describe("FidoAuthenticatorService", () => {
       expect(result).toBe(false);
     });
 
-    it("returns false when the hostname is a subdomain of a `blockedInteractionsUris` entry", async () => {
+    it("returns true when the hostname is a subdomain of a `blockedInteractionsUris` entry", async () => {
       domainSettingsService.blockedInteractionsUris$ = of({ "example.com": null });
 
       const result = await client.isFido2FeatureEnabled(hostname, origin);
 
-      expect(result).toBe(false);
+      expect(result).toBe(true);
     });
 
     it("returns true when `blockedInteractionsUris` is empty", async () => {
@@ -749,7 +749,7 @@ describe("FidoAuthenticatorService", () => {
     });
 
     it("rejects via `blockedInteractionsUris` regardless of `neverDomains` state", async () => {
-      domainSettingsService.blockedInteractionsUris$ = of({ "example.com": null });
+      domainSettingsService.blockedInteractionsUris$ = of({ "sub.example.com": null });
       domainSettingsService.neverDomains$ = of({});
 
       const result = await client.isFido2FeatureEnabled(hostname, origin);

--- a/libs/common/src/platform/services/fido2/fido2-client.service.spec.ts
+++ b/libs/common/src/platform/services/fido2/fido2-client.service.spec.ts
@@ -85,6 +85,7 @@ describe("FidoAuthenticatorService", () => {
     configService.serverConfig$ = of({ environment: { vault: VaultUrl } } as any);
     vaultSettingsService.enablePasskeys$ = of(true);
     domainSettingsService.neverDomains$ = of({});
+    domainSettingsService.blockedInteractionsUris$ = of({});
     authService.activeAccountStatus$ = of(AuthenticationStatus.Unlocked);
     windowReference = Utils.newGuid();
   });
@@ -709,6 +710,52 @@ describe("FidoAuthenticatorService", () => {
         signature: randomBytes(64),
       };
     }
+  });
+
+  describe("isFido2FeatureEnabled", () => {
+    const hostname = "sub.example.com";
+    const origin = "https://sub.example.com";
+
+    it("returns false when the hostname exactly matches a `blockedInteractionsUris` entry", async () => {
+      domainSettingsService.blockedInteractionsUris$ = of({ "sub.example.com": null });
+
+      const result = await client.isFido2FeatureEnabled(hostname, origin);
+
+      expect(result).toBe(false);
+    });
+
+    it("returns false when the hostname is a subdomain of a `blockedInteractionsUris` entry", async () => {
+      domainSettingsService.blockedInteractionsUris$ = of({ "example.com": null });
+
+      const result = await client.isFido2FeatureEnabled(hostname, origin);
+
+      expect(result).toBe(false);
+    });
+
+    it("returns true when `blockedInteractionsUris` is empty", async () => {
+      domainSettingsService.blockedInteractionsUris$ = of({});
+
+      const result = await client.isFido2FeatureEnabled(hostname, origin);
+
+      expect(result).toBe(true);
+    });
+
+    it("returns true when no `blockedInteractionsUris` entry matches the hostname", async () => {
+      domainSettingsService.blockedInteractionsUris$ = of({ "bitwarden.com": null });
+
+      const result = await client.isFido2FeatureEnabled(hostname, origin);
+
+      expect(result).toBe(true);
+    });
+
+    it("rejects via `blockedInteractionsUris` regardless of `neverDomains` state", async () => {
+      domainSettingsService.blockedInteractionsUris$ = of({ "example.com": null });
+      domainSettingsService.neverDomains$ = of({});
+
+      const result = await client.isFido2FeatureEnabled(hostname, origin);
+
+      expect(result).toBe(false);
+    });
   });
 });
 

--- a/libs/common/src/platform/services/fido2/fido2-client.service.ts
+++ b/libs/common/src/platform/services/fido2/fido2-client.service.ts
@@ -93,11 +93,7 @@ export class Fido2ClientService<
     const blockedInteractionsUris = await firstValueFrom(
       this.domainSettingsService.blockedInteractionsUris$,
     );
-    const isBlockedDomain =
-      blockedInteractionsUris != null &&
-      Object.keys(blockedInteractionsUris).some((blockedHostname) =>
-        hostname.endsWith(blockedHostname),
-      );
+    const isBlockedDomain = blockedInteractionsUris != null && hostname in blockedInteractionsUris;
     if (isBlockedDomain) {
       return false;
     }

--- a/libs/common/src/platform/services/fido2/fido2-client.service.ts
+++ b/libs/common/src/platform/services/fido2/fido2-client.service.ts
@@ -90,6 +90,18 @@ export class Fido2ClientService<
       return false;
     }
 
+    const blockedInteractionsUris = await firstValueFrom(
+      this.domainSettingsService.blockedInteractionsUris$,
+    );
+    const isBlockedDomain =
+      blockedInteractionsUris != null &&
+      Object.keys(blockedInteractionsUris).some((blockedHostname) =>
+        hostname.endsWith(blockedHostname),
+      );
+    if (isBlockedDomain) {
+      return false;
+    }
+
     const neverDomains = await firstValueFrom(this.domainSettingsService.neverDomains$);
 
     const isExcludedDomain = neverDomains != null && hostname in neverDomains;


### PR DESCRIPTION
## 🎟️ Tracking

[PM-36616](https://bitwarden.atlassian.net/browse/PM-36616)

## 📔 Objective

Fix fido2 script injection not respecting blocked domains


[PM-36616]: https://bitwarden.atlassian.net/browse/PM-36616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ