### PR TITLE
Add autofill check for autocomplete="current-password"

### DIFF
--- a/apps/browser/src/autofill/services/abstractions/inline-menu-field-qualifications.service.ts
+++ b/apps/browser/src/autofill/services/abstractions/inline-menu-field-qualifications.service.ts
@@ -38,4 +38,5 @@ export interface InlineMenuFieldQualificationService {
   isElementLoginSubmitButton(element: Element): boolean;
   isElementChangePasswordSubmitButton(element: Element): boolean;
   isTotpField(field: AutofillField): boolean;
+  hasCurrentPasswordAutocomplete(field: AutofillField): boolean;
 }

--- a/apps/browser/src/autofill/services/autofill-overlay-content.service.ts
+++ b/apps/browser/src/autofill/services/autofill-overlay-content.service.ts
@@ -1213,6 +1213,12 @@ export class AutofillOverlayContentService implements AutofillOverlayContentServ
       autofillFieldData.autoCompleteType || ([] as string[])
     ).includes("webauthn");
 
+    if (
+      this.inlineMenuFieldQualificationService.hasCurrentPasswordAutocomplete(autofillFieldData)
+    ) {
+      return;
+    }
+
     this.qualifyAccountCreationFieldType(autofillFieldData);
   }
 

--- a/apps/browser/src/autofill/services/inline-menu-field-qualification.service.spec.ts
+++ b/apps/browser/src/autofill/services/inline-menu-field-qualification.service.spec.ts
@@ -1037,4 +1037,33 @@ describe("InlineMenuFieldQualificationService", () => {
       expect(inlineMenuFieldQualificationService.isEmailField(field)).toBe(true);
     });
   });
+
+  describe("hasCurrentPasswordAutocomplete", () => {
+    it("returns true when the autocomplete attribute contains `current-password`", () => {
+      const field = mock<AutofillField>({
+        type: "password",
+        autoCompleteType: "current-password",
+      });
+
+      expect(inlineMenuFieldQualificationService.hasCurrentPasswordAutocomplete(field)).toBe(true);
+    });
+
+    it("returns false when the autocomplete attribute is `new-password`", () => {
+      const field = mock<AutofillField>({
+        type: "password",
+        autoCompleteType: "new-password",
+      });
+
+      expect(inlineMenuFieldQualificationService.hasCurrentPasswordAutocomplete(field)).toBe(false);
+    });
+
+    it("returns false when the autocomplete attribute is missing", () => {
+      const field = mock<AutofillField>({
+        type: "password",
+        autoCompleteType: "",
+      });
+
+      expect(inlineMenuFieldQualificationService.hasCurrentPasswordAutocomplete(field)).toBe(false);
+    });
+  });
 });

--- a/apps/browser/src/autofill/services/inline-menu-field-qualification.service.ts
+++ b/apps/browser/src/autofill/services/inline-menu-field-qualification.service.ts
@@ -1128,4 +1128,13 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
 
     return false;
   }
+
+  /**
+   * Validates the provided field has `current-password` attribute
+   *
+   * * @param field - The field to validate
+   */
+  hasCurrentPasswordAutocomplete = (field: AutofillField): boolean => {
+    return this.fieldContainsAutocompleteValues(field, this.currentPasswordAutocompleteValue);
+  };
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-36852 

## 📔 Objective

Add a method to check for the `autocomplete="current-password"` identifier. 