### PR TITLE
[PM-36858] Fix routing number copy toast showing generic message

### DIFF
--- a/libs/vault/src/cipher-view/bank-account-sections/bank-account-view.component.html
+++ b/libs/vault/src/cipher-view/bank-account-sections/bank-account-view.component.html
@@ -88,9 +88,8 @@
           bitSuffix
           type="button"
           [label]="'copyRoutingNumber' | i18n"
-          [appCopyClick]="bankAccount().routingNumber"
-          showToast
-          [valueLabel]="'routingNumber' | i18n"
+          appCopyField="routingNumber"
+          [cipher]="cipher()"
         ></button>
       </bit-form-field>
     }

--- a/libs/vault/src/cipher-view/bank-account-sections/bank-account-view.component.ts
+++ b/libs/vault/src/cipher-view/bank-account-sections/bank-account-view.component.ts
@@ -10,7 +10,6 @@ import {
   TypographyModule,
   FormFieldModule,
   IconButtonModule,
-  CopyClickDirective,
 } from "@bitwarden/components";
 import { I18nPipe } from "@bitwarden/ui-common";
 
@@ -28,7 +27,6 @@ import { ReadOnlyCipherCardComponent } from "../read-only-cipher-card/read-only-
     TypographyModule,
     FormFieldModule,
     IconButtonModule,
-    CopyClickDirective,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })


### PR DESCRIPTION
## 🎟️ Tracking

[PM-36858](https://bitwarden.atlassian.net/browse/PM-36858)

## 📔 Objective

Fixes the routing number copy button in the bank account vault item view showing a generic "Copy Successful" toast instead of "Routing number copied".
- I verified that the translation is already in all three platform translation file. [browser](https://github.com/bitwarden/clients/blob/vault/PM-34109/desktop-drivers-license/apps/browser/src/_locales/en/messages.json#L6426-L6428), [desktop](https://github.com/bitwarden/clients/blob/vault/PM-34109/desktop-drivers-license/apps/desktop/src/locales/en/messages.json#L5131-L5133), [web](https://github.com/bitwarden/clients/blob/vault/PM-34109/desktop-drivers-license/apps/web/src/locales/en/messages.json#L13620-L13622)

## 📸 Screenshots

<img width="1515" height="1057" alt="Screenshot 2026-05-08 at 2 17 17 PM" src="https://github.com/user-attachments/assets/a2aa838b-74e3-46b4-8938-1071316cbc2a" />

[PM-36858]: https://bitwarden.atlassian.net/browse/PM-36858?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ