### PR TITLE
[PM-36973] lazy-loading jsdom

### DIFF
--- a/apps/cli/src/service-container/service-container.ts
+++ b/apps/cli/src/service-container/service-container.ts
@@ -3,7 +3,6 @@
 import * as fs from "fs";
 import * as path from "path";
 
-import * as jsdom from "jsdom";
 import { firstValueFrom } from "rxjs";
 
 import {
@@ -244,9 +243,6 @@ import { LowdbStorageService } from "../platform/services/lowdb-storage.service"
 import { NodeApiService } from "../platform/services/node-api.service";
 import { NodeEnvSecureStorageService } from "../platform/services/node-env-secure-storage.service";
 import { CliRestrictedItemTypesService } from "../vault/services/cli-restricted-item-types.service";
-
-// Polyfills
-global.DOMParser = new jsdom.JSDOM().window.DOMParser;
 
 // eslint-disable-next-line
 const packageJson = require("../../package.json");

--- a/apps/cli/src/tools/import.command.ts
+++ b/apps/cli/src/tools/import.command.ts
@@ -63,6 +63,13 @@ export class ImportCommand {
     if (filepath == null || filepath === "") {
       return Response.badRequest("`filepath` was not provided.");
     }
+
+    // Lazy-load jsdom and polyfill DOMParser only when actually running an import.
+    // jsdom is heavy and only needed by the XML/HTML importers; loading it eagerly
+    // slows CLI startup for every other command.
+    const { JSDOM } = await import("jsdom");
+    global.DOMParser = new JSDOM().window.DOMParser;
+
     const promptForPassword_callback = async () => {
       return await this.promptPassword();
     };


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-36973

## 📔 Objective

Switch from eager to lazy loading the `jsdom` library for the CLI client to improve initialization performance of other commands that don't require `jsdom`

Benchmarks...

Benchmark 1 (eager loading): ./bw.js --version
Time (mean ± σ): 1.402 s ± 0.195 s [User: 0.689 s, System: 0.113 s]
Range (min … max): 1.217 s … 1.869 s 20 runs

Benchmark 2 (lazy loading): ./bw.js --version
Time (mean ± σ): 1.267 s ± 0.132 s [User: 0.575 s, System: 0.089 s]
Range (min … max): 1.086 s … 1.476 s 20 runs

User Time:  ~17% decrease
System Time: ~21% decrease

