### PR TITLE
Update rkyv vuln due to RUSTSEC-2026-0122

### DIFF
--- a/apps/desktop/desktop_native/Cargo.lock
+++ b/apps/desktop/desktop_native/Cargo.lock
@@ -1548,6 +1548,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
 name = "hashlink"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2898,13 +2904,13 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.8.14"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "360b333c61ae24e5af3ae7c8660bd6b21ccd8200dbbc5d33c2454421e85b9c69"
+checksum = "73389e0c99e664f919275ab5b5b0471391fe9a8de61e1dff9b1eaf56a90f16e3"
 dependencies = [
  "bytecheck",
  "bytes",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "indexmap 2.9.0",
  "munge",
  "ptr_meta",
@@ -2917,9 +2923,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.8.14"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02f8cdd12b307ab69fe0acf4cd2249c7460eb89dce64a0febadf934ebb6a9e"
+checksum = "5d2ed0b54125315fb36bd021e82d314d1c126548f871634b483f46b31d13cac6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/apps/desktop/desktop_native/ssh_agent/Cargo.toml
+++ b/apps/desktop/desktop_native/ssh_agent/Cargo.toml
@@ -11,7 +11,7 @@ async-trait = { workspace = true }
 base64 = { workspace = true }
 desktop_core = { path = "../core" }
 mockall = { workspace = true }
-rkyv = "=0.8.14"
+rkyv = "=0.8.16"
 ssh-key = { version = "=0.6.7", features = [
     "encryption",
     "ed25519",


### PR DESCRIPTION
## 📔 Objective

Update `rkyv` per [RUSTSEC-2026-0122](https://rustsec.org/advisories/RUSTSEC-2026-0122.html)

Discovered via this CI run: https://github.com/bitwarden/clients/actions/runs/25671123728/job/75356343484?pr=20010

```
Run cargo deny --log-level error --all-features check all
error[unsound]: Panic safety bugs in `InlineVec::clear` and `SerVec::clear` enable arbitrary code execution
    ┌─ /Users/runner/work/clients/clients/apps/desktop/desktop_native/Cargo.lock:274:1
    │
274 │ rkyv 0.8.14 registry+https://github.com/rust-lang/crates.io-index
    │ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ unsound advisory detected
    │
    ├ ID: RUSTSEC-2026-0122
    ├ Advisory: https://rustsec.org/advisories/RUSTSEC-2026-0122
    ├ `InlineVec::clear()` and `SerVec::clear()` in `rkyv` were not panic-safe.
      Both functions iterate over their elements and call `drop_in_place` on each,
      updating `self.len` only *after* the loop. If an element's `Drop` implementation
      panics during the loop, `self.len` is left at its original value.
      
      A subsequent invocation of `clear()` on the same container then re-visits the
      already-freed elements:
      
      - `InlineVec::clear()` is called again from `InlineVec`'s own `Drop`
        implementation when the value is later dropped.
      - `SerVec::clear()` is called again by `SerVec::with_capacity()` after the
        user closure returns.
      
      
      ## Technical Impact
      
      - **CWE-415 (Double Free):** Heap corruption when element type holds `Box<T>`  
      - **CWE-416 (Use-After-Free):** Memory corruption when element reads from heap during `Drop`
      
      Both vulnerabilities are triggerable entirely from safe Rust via `std::panic::catch_unwind`
      and require no special privileges.
    ├ Announcement: https://github.com/rkyv/rkyv/commit/5828cf5c27b664eb4432c4a93d4769e12e5e42fb
    ├ Solution: Upgrade to >=0.8.16 (try `cargo update -p rkyv`)
    ├ rkyv v0.8.14
      └── ssh_agent v0.0.0
          └── desktop_napi v0.0.0

advisories FAILED, bans ok, licenses ok, sources ok
```