### PR TITLE
[PM-36947] Restrict bank account PIN field to numeric characters only

### DIFF
--- a/libs/vault/src/cipher-form/components/bank-account-section/bank-account-section.component.html
+++ b/libs/vault/src/cipher-form/components/bank-account-section/bank-account-section.component.html
@@ -53,7 +53,7 @@
 
     <bit-form-field>
       <bit-label>{{ "pin" | i18n }}</bit-label>
-      <input bitInput formControlName="pin" type="password" data-testid="pin" />
+      <input bitInput formControlName="pin" type="password" data-testid="pin" inputmode="numeric" />
       <button
         type="button"
         bitIconButton

--- a/libs/vault/src/cipher-form/components/bank-account-section/bank-account-section.component.spec.ts
+++ b/libs/vault/src/cipher-form/components/bank-account-section/bank-account-section.component.spec.ts
@@ -1,0 +1,100 @@
+import { CommonModule } from "@angular/common";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { ReactiveFormsModule } from "@angular/forms";
+import { mock, MockProxy } from "jest-mock-extended";
+import { Subject } from "rxjs";
+
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { BankAccountView } from "@bitwarden/common/vault/models/view/bank-account.view";
+import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+
+import { CipherFormContainer } from "../../cipher-form-container";
+
+import { BankAccountSectionComponent } from "./bank-account-section.component";
+
+describe("BankAccountSectionComponent", () => {
+  let component: BankAccountSectionComponent;
+  let fixture: ComponentFixture<BankAccountSectionComponent>;
+  let cipherFormProvider: MockProxy<CipherFormContainer>;
+  let registerChildFormSpy: jest.SpyInstance;
+  let patchCipherSpy: jest.SpyInstance;
+  let formStatusChange$: Subject<"enabled" | "disabled">;
+
+  const getInitialCipherView = jest.fn((): any => null);
+
+  beforeEach(async () => {
+    formStatusChange$ = new Subject<"enabled" | "disabled">();
+    cipherFormProvider = mock<CipherFormContainer>({ getInitialCipherView, formStatusChange$ });
+    registerChildFormSpy = jest.spyOn(cipherFormProvider, "registerChildForm");
+    patchCipherSpy = jest.spyOn(cipherFormProvider, "patchCipher");
+
+    await TestBed.configureTestingModule({
+      imports: [BankAccountSectionComponent, CommonModule, ReactiveFormsModule],
+      providers: [
+        { provide: CipherFormContainer, useValue: cipherFormProvider },
+        { provide: I18nService, useValue: { t: (key: string) => key } },
+      ],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(BankAccountSectionComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it("registers `bankAccountForm` with `CipherFormContainer`", () => {
+    expect(registerChildFormSpy).toHaveBeenCalledWith(
+      "bankAccountDetails",
+      component.bankAccountForm,
+    );
+  });
+
+  it("patches `bankAccountForm` changes to cipherFormContainer", () => {
+    component.bankAccountForm.patchValue({ bankName: "First National" });
+
+    expect(patchCipherSpy).toHaveBeenCalled();
+    const patchFn = patchCipherSpy.mock.lastCall[0];
+    const updatedCipher = patchFn(new CipherView());
+    expect(updatedCipher.bankAccount?.bankName).toBe("First National");
+  });
+
+  it("initializes `bankAccountForm` from `getInitialCipherView`", () => {
+    const bankAccountView = new BankAccountView();
+    bankAccountView.bankName = "First National";
+    bankAccountView.pin = "1234";
+
+    getInitialCipherView.mockReturnValueOnce({ bankAccount: bankAccountView });
+
+    component.ngOnInit();
+
+    expect(component.bankAccountForm.value.bankName).toBe("First National");
+    expect(component.bankAccountForm.value.pin).toBe("1234");
+  });
+
+  describe("PIN numeric filter", () => {
+    it("strips non-numeric characters from PIN", () => {
+      component.bankAccountForm.controls.pin.setValue("abc123$!");
+
+      expect(component.bankAccountForm.controls.pin.value).toBe("123");
+    });
+
+    it("leaves numeric-only PIN unchanged", () => {
+      component.bankAccountForm.controls.pin.setValue("1234");
+
+      expect(component.bankAccountForm.controls.pin.value).toBe("1234");
+    });
+
+    it("does not alter an empty PIN", () => {
+      component.bankAccountForm.controls.pin.setValue("");
+
+      expect(component.bankAccountForm.controls.pin.value).toBe("");
+    });
+
+    it("strips all characters when PIN has no digits", () => {
+      component.bankAccountForm.controls.pin.setValue("abcd$!");
+
+      expect(component.bankAccountForm.controls.pin.value).toBe("");
+    });
+  });
+});

--- a/libs/vault/src/cipher-form/components/bank-account-section/bank-account-section.component.ts
+++ b/libs/vault/src/cipher-form/components/bank-account-section/bank-account-section.component.ts
@@ -7,7 +7,7 @@ import {
   OnInit,
 } from "@angular/core";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
-import { FormBuilder, ReactiveFormsModule } from "@angular/forms";
+import { AbstractControl, FormBuilder, ReactiveFormsModule } from "@angular/forms";
 
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { BankAccountType } from "@bitwarden/common/vault/enums/bank-account-type";
@@ -89,6 +89,8 @@ export class BankAccountSectionComponent implements OnInit {
       { label: this.i18nService.t("bankAccountTypeOther"), value: BankAccountType.Other },
     ];
 
+    this.setupNumericFilter(this.bankAccountForm.controls.pin);
+
     this.cipherFormContainer.registerChildForm("bankAccountDetails", this.bankAccountForm);
     this.bankAccountForm.valueChanges.pipe(takeUntilDestroyed()).subscribe((value) => {
       const data = new BankAccountView();
@@ -130,6 +132,18 @@ export class BankAccountSectionComponent implements OnInit {
           this.bankAccountForm.enable();
         }
       });
+  }
+
+  private setupNumericFilter(ctrl: AbstractControl): void {
+    ctrl.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((value: string) => {
+      if (!value) {
+        return;
+      }
+      const filtered = value.replace(/\D/g, "");
+      if (filtered !== value) {
+        ctrl.setValue(filtered, { emitEvent: false });
+      }
+    });
   }
 
   private setInitialValues(bankAccountView: BankAccountView) {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-36947](https://bitwarden.atlassian.net/browse/PM-36947)

## 📔 Objective

Restrict the bank account PIN field to numeric characters only by stripping non-digit input as it is typed.

## 📸 Screenshots

You can't really capture keystrokes in a video but I am mashing characters here. I figured copy and pasting non-numeric values is the best visual representation. 


https://github.com/user-attachments/assets/0e191226-573e-4536-bd2b-e3051ef35d1e


[PM-36947]: https://bitwarden.atlassian.net/browse/PM-36947?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ