### PR TITLE
[PM-34109] Add copy actions for bank account cipher type

### DIFF
--- a/libs/vault/src/components/item-copy-actions/item-copy-actions.component.html
+++ b/libs/vault/src/components/item-copy-actions/item-copy-actions.component.html
@@ -213,3 +213,42 @@
     </bit-menu>
   </bit-item-action>
 }
+
+@if (CipherViewLikeUtils.getType(_cipher) === CipherType.BankAccount) {
+  @if (singleCopyableBankAccount) {
+    <button
+      type="button"
+      bitIconButton="bwi-clone"
+      size="small"
+      [label]="'copyFieldCipherName' | i18n: singleCopyableBankAccount.key : _cipher.name"
+      [appCopyField]="singleCopyableBankAccount.field"
+      [cipher]="_cipher"
+      showToast
+    ></button>
+  } @else {
+    <button
+      type="button"
+      bitIconButton="bwi-clone"
+      size="small"
+      [label]="
+        hasBankAccountValues ? ('copyInfoTitle' | i18n: _cipher.name) : ('noValuesToCopy' | i18n)
+      "
+      [disabled]="!hasBankAccountValues"
+      [bitMenuTriggerFor]="bankAccountOptions"
+    ></button>
+    <bit-menu #bankAccountOptions>
+      <button type="button" bitMenuItem appCopyField="accountNumber" [cipher]="_cipher">
+        {{ "copyAccountNumber" | i18n }}
+      </button>
+      <button type="button" bitMenuItem appCopyField="routingNumber" [cipher]="_cipher">
+        {{ "copyRoutingNumber" | i18n }}
+      </button>
+      <button type="button" bitMenuItem appCopyField="pin" [cipher]="_cipher">
+        {{ "copyPin" | i18n }}
+      </button>
+      <button type="button" bitMenuItem appCopyField="iban" [cipher]="_cipher">
+        {{ "copyIban" | i18n }}
+      </button>
+    </bit-menu>
+  }
+}

--- a/libs/vault/src/components/item-copy-actions/item-copy-actions.component.spec.ts
+++ b/libs/vault/src/components/item-copy-actions/item-copy-actions.component.spec.ts
@@ -59,6 +59,14 @@ describe("VaultItemCopyActionsComponent", () => {
       notes: null,
       copyableFields: [],
     } as unknown as CipherViewLike);
+
+    jest
+      .spyOn(CipherViewLikeUtils, "hasCopyableValue")
+      .mockImplementation(
+        (cipher: CipherViewLike & { __copyable?: Record<string, boolean> }, field) => {
+          return Boolean(cipher.__copyable?.[field]);
+        },
+      );
   });
 
   afterEach(() => {
@@ -66,16 +74,6 @@ describe("VaultItemCopyActionsComponent", () => {
   });
 
   describe("findSingleCopyableItem", () => {
-    beforeEach(() => {
-      jest
-        .spyOn(CipherViewLikeUtils, "hasCopyableValue")
-        .mockImplementation(
-          (cipher: CipherViewLike & { __copyable?: Record<string, boolean> }, field) => {
-            return Boolean(cipher.__copyable?.[field]);
-          },
-        );
-    });
-
     it("returns the single item with value and translates its key", () => {
       const items = [
         { key: "copyUsername", field: "username" as const },
@@ -130,16 +128,6 @@ describe("VaultItemCopyActionsComponent", () => {
   });
 
   describe("singleCopyableLogin", () => {
-    beforeEach(() => {
-      jest
-        .spyOn(CipherViewLikeUtils, "hasCopyableValue")
-        .mockImplementation(
-          (cipher: CipherViewLike & { __copyable?: Record<string, boolean> }, field) => {
-            return Boolean(cipher.__copyable?.[field]);
-          },
-        );
-    });
-
     it("returns username with special-case logic when password is hidden and both username/password exist and no totp", () => {
       (component.cipher() as CipherView).viewPassword = false;
 
@@ -214,16 +202,6 @@ describe("VaultItemCopyActionsComponent", () => {
   });
 
   describe("singleCopyableCard", () => {
-    beforeEach(() => {
-      jest
-        .spyOn(CipherViewLikeUtils, "hasCopyableValue")
-        .mockImplementation(
-          (cipher: CipherViewLike & { __copyable?: Record<string, boolean> }, field) => {
-            return Boolean(cipher.__copyable?.[field]);
-          },
-        );
-    });
-
     it("returns security code when it is the only available card value", () => {
       (component.cipher() as any).__copyable = {
         securityCode: true,
@@ -252,16 +230,6 @@ describe("VaultItemCopyActionsComponent", () => {
   });
 
   describe("singleCopyableIdentity", () => {
-    beforeEach(() => {
-      jest
-        .spyOn(CipherViewLikeUtils, "hasCopyableValue")
-        .mockImplementation(
-          (cipher: CipherViewLike & { __copyable?: Record<string, boolean> }, field) => {
-            return Boolean(cipher.__copyable?.[field]);
-          },
-        );
-    });
-
     it("returns the only copyable identity field", () => {
       (component.cipher() as any).__copyable = {
         address: false,
@@ -293,12 +261,63 @@ describe("VaultItemCopyActionsComponent", () => {
     });
   });
 
-  describe("has*Values in non-list view", () => {
+  describe("singleCopyableBankAccount", () => {
+    it("returns the only copyable bank account field", () => {
+      (component.cipher() as any).__copyable = {
+        accountNumber: true,
+        routingNumber: false,
+        pin: false,
+        iban: false,
+      };
+
+      const result = component.singleCopyableBankAccount;
+
+      expect(result).toEqual({
+        key: "translated-accountNumber",
+        field: "accountNumber",
+      });
+      expect(i18nService.t).toHaveBeenCalledWith("accountNumber");
+    });
+
+    it("returns null when multiple bank account fields are available", () => {
+      (component.cipher() as any).__copyable = {
+        accountNumber: true,
+        routingNumber: true,
+        pin: false,
+        iban: false,
+      };
+
+      const result = component.singleCopyableBankAccount;
+
+      expect(result).toBeNull();
+    });
+
+    it("returns null when no bank account fields are available", () => {
+      (component.cipher() as any).__copyable = {
+        accountNumber: false,
+        routingNumber: false,
+        pin: false,
+        iban: false,
+      };
+
+      const result = component.singleCopyableBankAccount;
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("has Values in non-list view", () => {
     beforeEach(() => {
       jest.spyOn(CipherViewLikeUtils, "isCipherListView").mockReturnValue(false);
     });
 
     it("computes hasLoginValues from login fields", () => {
+      (component.cipher() as any).__copyable = {
+        username: true,
+        password: false,
+        totp: false,
+      };
+
       (component.cipher() as CipherView).login = {
         username: "user",
         password: null,
@@ -306,6 +325,12 @@ describe("VaultItemCopyActionsComponent", () => {
       } as any;
 
       expect(component.hasLoginValues).toBe(true);
+
+      (component.cipher() as any).__copyable = {
+        username: false,
+        password: false,
+        totp: false,
+      };
 
       (component.cipher() as CipherView).login = {
         username: null,
@@ -323,13 +348,6 @@ describe("VaultItemCopyActionsComponent", () => {
         password: true,
         totp: false,
       };
-      jest
-        .spyOn(CipherViewLikeUtils, "hasCopyableValue")
-        .mockImplementation(
-          (cipher: CipherViewLike & { __copyable?: Record<string, boolean> }, field) => {
-            return Boolean(cipher.__copyable?.[field]);
-          },
-        );
 
       expect(component.hasLoginValues).toBe(false);
     });
@@ -390,6 +408,26 @@ describe("VaultItemCopyActionsComponent", () => {
       } as any;
 
       expect(component.hasSshKeyValues).toBe(false);
+    });
+
+    it("computes hasBankAccountValues from bankAccount fields", () => {
+      (component.cipher() as CipherView).bankAccount = {
+        accountNumber: "123456",
+        routingNumber: null,
+        pin: null,
+        iban: null,
+      } as any;
+
+      expect(component.hasBankAccountValues).toBe(true);
+
+      (component.cipher() as CipherView).bankAccount = {
+        accountNumber: null,
+        routingNumber: null,
+        pin: null,
+        iban: null,
+      } as any;
+
+      expect(component.hasBankAccountValues).toBe(false);
     });
   });
 
@@ -462,6 +500,20 @@ describe("VaultItemCopyActionsComponent", () => {
       ] as CopyableCipherFields[];
 
       expect(component.hasSshKeyValues).toBe(false);
+    });
+
+    it("uses copyableFields for bank account values", () => {
+      (component.cipher() as CipherListView).copyableFields = [
+        "BankAccountAccountNumber",
+      ] as CopyableCipherFields[];
+
+      expect(component.hasBankAccountValues).toBe(true);
+
+      (component.cipher() as CipherListView).copyableFields = [
+        "LoginUsername",
+      ] as CopyableCipherFields[];
+
+      expect(component.hasBankAccountValues).toBe(false);
     });
   });
 });

--- a/libs/vault/src/components/item-copy-actions/item-copy-actions.component.ts
+++ b/libs/vault/src/components/item-copy-actions/item-copy-actions.component.ts
@@ -76,6 +76,16 @@ export class VaultItemCopyActionsComponent {
     return this.findSingleCopyableItem(this.cipher(), identityItems);
   }
 
+  get singleCopyableBankAccount() {
+    const bankAccountItems: CipherItem[] = [
+      { key: "accountNumber", field: "accountNumber" },
+      { key: "routingNumber", field: "routingNumber" },
+      { key: "pin", field: "pin" },
+      { key: "iban", field: "iban" },
+    ];
+    return this.findSingleCopyableItem(this.cipher(), bankAccountItems);
+  }
+
   /*
    * Given a list of CipherItems, if there is only one item with a value,
    * return it with the translated key. Otherwise return null.
@@ -108,6 +118,10 @@ export class VaultItemCopyActionsComponent {
 
   get hasSshKeyValues() {
     return this.getNumberOfSshKeyValues(this.cipher()) > 0;
+  }
+
+  get hasBankAccountValues() {
+    return this.getNumberOfBankAccountValues(this.cipher()) > 0;
   }
 
   /** Sets the number of populated login values for the cipher */
@@ -167,5 +181,27 @@ export class VaultItemCopyActionsComponent {
     return [cipher.sshKey.privateKey, cipher.sshKey.publicKey, cipher.sshKey.keyFingerprint].filter(
       Boolean,
     ).length;
+  }
+
+  /** Sets the number of populated bank account values for the cipher */
+  private getNumberOfBankAccountValues(cipher: CipherViewLike) {
+    if (CipherViewLikeUtils.isCipherListView(cipher)) {
+      const copyableBankAccountFields: CopyableCipherFields[] = [
+        "BankAccountAccountNumber",
+        "BankAccountRoutingNumber",
+        "BankAccountPin",
+        "BankAccountIban",
+      ];
+
+      return cipher.copyableFields.filter((field) => copyableBankAccountFields.includes(field))
+        .length;
+    }
+
+    return [
+      cipher.bankAccount.accountNumber,
+      cipher.bankAccount.routingNumber,
+      cipher.bankAccount.pin,
+      cipher.bankAccount.iban,
+    ].filter(Boolean).length;
   }
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-34109](https://bitwarden.atlassian.net/browse/PM-34109)

## 📔 Objective

Adds copy action support for the bank account cipher type to the `VaultItemCopyActionsComponent`, bringing it to parity with the existing login, card, identity, and SSH key cipher types.

## 📸 Screenshots


https://github.com/user-attachments/assets/40d8ed39-9696-49d2-8274-49836ca388b3


[PM-34109]: https://bitwarden.atlassian.net/browse/PM-34109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ