### PR TITLE
[PM-34111] Add Driver's License item type to the CLI

### DIFF
--- a/apps/cli/src/commands/get.command.ts
+++ b/apps/cli/src/commands/get.command.ts
@@ -18,6 +18,7 @@ import { BankAccountExport } from "@bitwarden/common/models/export/bank-account.
 import { CardExport } from "@bitwarden/common/models/export/card.export";
 import { CipherExport } from "@bitwarden/common/models/export/cipher.export";
 import { CollectionExport } from "@bitwarden/common/models/export/collection.export";
+import { DriversLicenseExport } from "@bitwarden/common/models/export/drivers-license.export";
 import { FieldExport } from "@bitwarden/common/models/export/field.export";
 import { FolderExport } from "@bitwarden/common/models/export/folder.export";
 import { IdentityExport } from "@bitwarden/common/models/export/identity.export";
@@ -591,6 +592,16 @@ export class GetCommand extends DownloadCommand {
           return Response.badRequest("Bank account item type is not available.");
         }
         template = BankAccountExport.template();
+        break;
+      }
+      case "item.driverslicense": {
+        const newItemTypesEnabled = await firstValueFrom(
+          this.configService.getFeatureFlag$(FeatureFlag.PM32009NewItemTypes),
+        );
+        if (!newItemTypesEnabled) {
+          return Response.badRequest("Driver's license item type is not available.");
+        }
+        template = DriversLicenseExport.template();
         break;
       }
       case "folder":

--- a/apps/cli/src/vault/create.command.ts
+++ b/apps/cli/src/vault/create.command.ts
@@ -101,7 +101,10 @@ export class CreateCommand {
 
       const cipherView = CipherExport.toView(req);
 
-      if (cipherView.type === CipherType.BankAccount) {
+      if (
+        cipherView.type === CipherType.BankAccount ||
+        cipherView.type === CipherType.DriversLicense
+      ) {
         const newItemTypesEnabled = await firstValueFrom(
           this.configService.getFeatureFlag$(FeatureFlag.PM32009NewItemTypes),
         );

--- a/libs/common/src/models/export/cipher.export.ts
+++ b/libs/common/src/models/export/cipher.export.ts
@@ -6,6 +6,7 @@ import { CipherView } from "../../vault/models/view/cipher.view";
 
 import { BankAccountExport } from "./bank-account.export";
 import { CardExport } from "./card.export";
+import { DriversLicenseExport } from "./drivers-license.export";
 import { FieldExport } from "./field.export";
 import { IdentityExport } from "./identity.export";
 import { LoginExport } from "./login.export";
@@ -79,6 +80,11 @@ export class CipherExport {
           view.bankAccount = BankAccountExport.toView(req.bankAccount)!;
         }
         break;
+      case CipherType.DriversLicense:
+        if (req.driversLicense != null) {
+          view.driversLicense = DriversLicenseExport.toView(req.driversLicense)!;
+        }
+        break;
     }
 
     if (req.passwordHistory != null) {
@@ -139,6 +145,11 @@ export class CipherExport {
           domain.bankAccount = BankAccountExport.toDomain(req.bankAccount);
         }
         break;
+      case CipherType.DriversLicense:
+        if (req.driversLicense != null) {
+          domain.driversLicense = DriversLicenseExport.toDomain(req.driversLicense);
+        }
+        break;
     }
 
     if (req.passwordHistory != null) {
@@ -166,6 +177,7 @@ export class CipherExport {
   identity?: IdentityExport;
   sshKey?: SshKeyExport;
   bankAccount?: BankAccountExport;
+  driversLicense?: DriversLicenseExport;
   reprompt: CipherRepromptType = CipherRepromptType.None;
   passwordHistory?: PasswordHistoryExport[];
   revisionDate?: Date;
@@ -211,6 +223,9 @@ export class CipherExport {
         break;
       case CipherType.BankAccount:
         this.bankAccount = new BankAccountExport(o.bankAccount);
+        break;
+      case CipherType.DriversLicense:
+        this.driversLicense = new DriversLicenseExport(o.driversLicense);
         break;
     }
 

--- a/libs/common/src/models/export/drivers-license.export.ts
+++ b/libs/common/src/models/export/drivers-license.export.ts
@@ -1,0 +1,92 @@
+import { EncString } from "../../key-management/crypto/models/enc-string";
+import { DriversLicense as DriversLicenseDomain } from "../../vault/models/domain/drivers-license";
+import { DriversLicenseView } from "../../vault/models/view/drivers-license.view";
+
+import { safeGetString } from "./utils";
+
+export class DriversLicenseExport {
+  static template(): DriversLicenseExport {
+    const req = new DriversLicenseExport();
+    req.firstName = "Jane";
+    req.middleName = "A.";
+    req.lastName = "Smith";
+    req.dateOfBirth = "1990-01-15";
+    req.licenseNumber = "D12345678";
+    req.issuingCountry = "US";
+    req.issuingState = "CA";
+    req.issueDate = "2020-06-01";
+    req.expirationDate = "2028-06-01";
+    req.issuingAuthority = "California DMV";
+    req.licenseClass = "C";
+    return req;
+  }
+
+  static toView(
+    req?: DriversLicenseExport,
+    view = new DriversLicenseView(),
+  ): DriversLicenseView | undefined {
+    if (req == null) {
+      return undefined;
+    }
+
+    view.firstName = req.firstName;
+    view.middleName = req.middleName;
+    view.lastName = req.lastName;
+    view.dateOfBirth = req.dateOfBirth;
+    view.licenseNumber = req.licenseNumber;
+    view.issuingCountry = req.issuingCountry;
+    view.issuingState = req.issuingState;
+    view.issueDate = req.issueDate;
+    view.expirationDate = req.expirationDate;
+    view.issuingAuthority = req.issuingAuthority;
+    view.licenseClass = req.licenseClass;
+    return view;
+  }
+
+  static toDomain(req: DriversLicenseExport, domain = new DriversLicenseDomain()) {
+    domain.firstName = req.firstName ? new EncString(req.firstName) : undefined;
+    domain.middleName = req.middleName ? new EncString(req.middleName) : undefined;
+    domain.lastName = req.lastName ? new EncString(req.lastName) : undefined;
+    domain.dateOfBirth = req.dateOfBirth ? new EncString(req.dateOfBirth) : undefined;
+    domain.licenseNumber = req.licenseNumber ? new EncString(req.licenseNumber) : undefined;
+    domain.issuingCountry = req.issuingCountry ? new EncString(req.issuingCountry) : undefined;
+    domain.issuingState = req.issuingState ? new EncString(req.issuingState) : undefined;
+    domain.issueDate = req.issueDate ? new EncString(req.issueDate) : undefined;
+    domain.expirationDate = req.expirationDate ? new EncString(req.expirationDate) : undefined;
+    domain.issuingAuthority = req.issuingAuthority
+      ? new EncString(req.issuingAuthority)
+      : undefined;
+    domain.licenseClass = req.licenseClass ? new EncString(req.licenseClass) : undefined;
+    return domain;
+  }
+
+  firstName: string | undefined = undefined;
+  middleName: string | undefined = undefined;
+  lastName: string | undefined = undefined;
+  dateOfBirth: string | undefined = undefined;
+  licenseNumber: string | undefined = undefined;
+  issuingCountry: string | undefined = undefined;
+  issuingState: string | undefined = undefined;
+  issueDate: string | undefined = undefined;
+  expirationDate: string | undefined = undefined;
+  issuingAuthority: string | undefined = undefined;
+  licenseClass: string | undefined = undefined;
+
+  constructor(o?: DriversLicenseView | DriversLicenseDomain) {
+    if (o == null) {
+      return;
+    }
+
+    this.firstName = safeGetString(o.firstName);
+    this.middleName = safeGetString(o.middleName);
+    this.lastName = safeGetString(o.lastName);
+    this.dateOfBirth = safeGetString(o.dateOfBirth);
+    this.licenseNumber = safeGetString(o.licenseNumber);
+    this.issuingCountry = safeGetString(o.issuingCountry);
+    this.issuingState = safeGetString(o.issuingState);
+    this.issueDate = safeGetString(o.issueDate);
+    this.expirationDate = safeGetString(o.expirationDate);
+    this.issuingAuthority = safeGetString(o.issuingAuthority);
+    this.licenseClass = safeGetString(o.licenseClass);
+  }
+}


### PR DESCRIPTION
## 🎟️ Tracking

[PM-34111](https://bitwarden.atlassian.net/browse/PM-34111)
Stacked on top of https://github.com/bitwarden/clients/pull/20461

## 📔 Objective

Adds Driver's License support to the CLI, gated behind the `PM32009NewItemTypes` feature flag.

- `bw get template item.driverslicense` returns a JSON template with all 11 fields
- `bw create item` accepts Driver's License items

## Screenshots

| Template | Create | Get |
|-|-|-|
|<img width="461" height="276" alt="Screenshot 2026-05-12 at 1 44 12 PM" src="https://github.com/user-attachments/assets/06487b59-5a7d-485a-93ee-3e1157a2f27e" />|<img width="514" height="915" alt="Screenshot 2026-05-12 at 1 47 21 PM" src="https://github.com/user-attachments/assets/dd9ae5bd-4d90-4ad4-ad87-3d2074ce2a2c" />|<img width="510" height="497" alt="Screenshot 2026-05-12 at 1 48 30 PM" src="https://github.com/user-attachments/assets/6712c604-e122-49ff-bf56-0ffed19a98dc" />|

[PM-34111]: https://bitwarden.atlassian.net/browse/PM-34111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ