### PR TITLE
Remove BW-GHAPP tokens and GPG from repository-management workflow

### DIFF
--- a/.github/workflows/repository-management.yml
+++ b/.github/workflows/repository-management.yml
@@ -70,8 +70,8 @@ jobs:
       version_desktop: ${{ steps.set-final-version-output.outputs.version_desktop }}
       version_web: ${{ steps.set-final-version-output.outputs.version_web }}
     permissions:
-      id-token: write
       contents: write
+      pull-requests: write
 
     steps:
       - name: Validate version input format
@@ -80,61 +80,17 @@ jobs:
         with:
           version: ${{ inputs.version_number_override }}
 
-      - name: Log in to Azure
-        uses: bitwarden/gh-actions/azure-login@main
-        with:
-          subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-          tenant_id: ${{ secrets.AZURE_TENANT_ID }}
-          client_id: ${{ secrets.AZURE_CLIENT_ID }}
-
-      - name: Get Azure Key Vault secrets
-        id: get-kv-secrets
-        uses: bitwarden/gh-actions/get-keyvault-secrets@main
-        with:
-          keyvault: gh-org-bitwarden
-          secrets: "BW-GHAPP-ID,BW-GHAPP-KEY"
-
-      - name: Retrieve GPG secrets
-        id: retrieve-gpg-secrets
-        uses: bitwarden/gh-actions/get-keyvault-secrets@main
-        with:
-          keyvault: "bitwarden-ci"
-          secrets: "github-gpg-private-key, github-gpg-private-key-passphrase"
-
-      - name: Log out from Azure
-        uses: bitwarden/gh-actions/azure-logout@main
-
-      - name: Generate GH App token
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
-        id: app-token
-        with:
-          app-id: ${{ steps.get-kv-secrets.outputs.BW-GHAPP-ID }}
-          private-key: ${{ steps.get-kv-secrets.outputs.BW-GHAPP-KEY }}
-          permission-contents: write # for committing and pushing to main (bypasses rulesets)
-
       - name: Check out branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.ref }}
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ github.token }}
           persist-credentials: true
 
       - name: Configure Git
         run: |
-          git config --local user.email "106330231+bitwarden-devops-bot@users.noreply.github.com"
-          git config --local user.name "bitwarden-devops-bot"
-
-      - name: Setup GPG signing
-        env:
-          GPG_PRIVATE_KEY: ${{ steps.retrieve-gpg-secrets.outputs.github-gpg-private-key }}
-          GPG_PASSPHRASE: ${{ steps.retrieve-gpg-secrets.outputs.github-gpg-private-key-passphrase }}
-        run: |
-          echo "$GPG_PRIVATE_KEY" | gpg --import --batch
-          GPG_KEY_ID=$(gpg --list-secret-keys --keyid-format=long | grep -o "rsa[0-9]\+/[A-F0-9]\+" | head -n1 | cut -d'/' -f2)
-          git config --local user.signingkey "$GPG_KEY_ID"
-          git config --local commit.gpgsign true
-          export GPG_TTY=$(tty)
-          echo "test" | gpg --clearsign --pinentry-mode=loopback --passphrase "$GPG_PASSPHRASE" > /dev/null 2>&1
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
 
       ########################
       # VERSION BUMP SECTION #
@@ -446,15 +402,34 @@ jobs:
             echo "No changes to commit!";
           fi
 
-      - name: Commit version bumps with GPG signature
+      - name: Create branch name
         if: ${{ steps.version-changed.outputs.changes_to_commit == 'TRUE' }}
+        id: create-branch-name
         run: |
+          TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+          BRANCH_NAME="version-bump-${TIMESTAMP}"
+          echo "branch_name=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
+
+      - name: Create branch and commit version bumps
+        if: ${{ steps.version-changed.outputs.changes_to_commit == 'TRUE' }}
+        env:
+          BRANCH_NAME: ${{ steps.create-branch-name.outputs.branch_name }}
+        run: |
+          git checkout -b "$BRANCH_NAME"
           git commit -m "Bumped client version(s)" -a
 
-      - name: Push changes to main
+      - name: Push branch and create PR
         if: ${{ steps.version-changed.outputs.changes_to_commit == 'TRUE' }}
+        env:
+          BRANCH_NAME: ${{ steps.create-branch-name.outputs.branch_name }}
+          GH_TOKEN: ${{ github.token }}
         run: |
-          git push
+          git push -u origin "$BRANCH_NAME"
+          gh pr create \
+            --title "Bump client version(s)" \
+            --body "Automated version bump created by repository-management workflow" \
+            --base main \
+            --head "$BRANCH_NAME"
 
   cut_branch:
     name: Cut branch
@@ -464,39 +439,14 @@ jobs:
       - bump_version
     runs-on: ubuntu-24.04
     permissions:
-      id-token: write
+      contents: write
 
     steps:
-      - name: Log in to Azure
-        uses: bitwarden/gh-actions/azure-login@main
-        with:
-          subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-          tenant_id: ${{ secrets.AZURE_TENANT_ID }}
-          client_id: ${{ secrets.AZURE_CLIENT_ID }}
-
-      - name: Get Azure Key Vault secrets
-        id: get-kv-secrets
-        uses: bitwarden/gh-actions/get-keyvault-secrets@main
-        with:
-          keyvault: gh-org-bitwarden
-          secrets: "BW-GHAPP-ID,BW-GHAPP-KEY"
-
-      - name: Log out from Azure
-        uses: bitwarden/gh-actions/azure-logout@main
-
-      - name: Generate GH App token
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
-        id: app-token
-        with:
-          app-id: ${{ steps.get-kv-secrets.outputs.BW-GHAPP-ID }}
-          private-key: ${{ steps.get-kv-secrets.outputs.BW-GHAPP-KEY }}
-          permission-contents: write # for creating and pushing new branch
-
       - name: Check out target ref
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.target_ref }}
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ github.token }}
           persist-credentials: true
 
       - name: Check if ${{ needs.setup.outputs.branch }} branch exists


### PR DESCRIPTION
- Remove all Azure Key Vault and BW-GHAPP token generation
- Remove GPG signing steps
- Use github.token instead of app token
- Use github-actions[bot] email instead of bitwarden-devops-bot
- Create PR with version bump instead of pushing directly to main
- Update permissions (remove id-token, add pull-requests)

## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
