### PR TITLE
[BEEEP] [PM-37492] Make jest tests faster

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,7 +119,7 @@ jobs:
         # maxWorkers is a workaround for a memory leak that crashes tests in CI:
         # https://github.com/facebook/jest/issues/9430#issuecomment-1149882002
         # Reduced to 2 workers and split tests across parallel jobs to prevent OOM kills
-        run: npm test -- ${{ matrix.test-group.paths }} --coverage --maxWorkers=2
+        run: npm test -- ${{ matrix.test-group.paths }} --coverage --maxWorkers=2 --workerIdleMemoryLimit=1500MiB
         env:
           JEST_JUNIT_OUTPUT_NAME: ${{ matrix.test-group.junit }}
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -71,5 +71,6 @@ module.exports = {
   // Workaround for a memory leak that crashes tests in CI:
   // https://github.com/facebook/jest/issues/9430#issuecomment-1149882002
   // Also anecdotally improves performance when run locally
-  maxWorkers: 3,
+  maxWorkers: 8,
+  workerIdleMemoryLimit: "1500MiB",
 };

--- a/libs/shared/jest.config.ts.js
+++ b/libs/shared/jest.config.ts.js
@@ -7,7 +7,8 @@ module.exports = {
   // Workaround for a memory leak that crashes tests in CI:
   // https://github.com/facebook/jest/issues/9430#issuecomment-1149882002
   // Also anecdotally improves performance when run locally
-  maxWorkers: 3,
+  maxWorkers: 8,
+  workerIdleMemoryLimit: "1500MiB",
 
   setupFiles: ["<rootDir>/../../libs/shared/polyfill-node-globals.ts"],
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-37492

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Makes test runs 2x as fast, mainly by limiting allowed memory for each jest instance to prevent memory leaks and by running more test workers in parallel. Experimenting with a few values for the parameters, these values work best on an M5 Pro macbook.

More workers or more memory generally didn't result in much of a speed-up.

Please note that the CI machines have too few cores for this to result in a speed-up. The speed-up is local only.

## Experimental Validation

`time npm run test` in project root.

After:
```
________________________________________________________
Executed in   57.45 secs    fish           external
   usr time  535.37 secs    0.26 millis  535.37 secs
   sys time   73.43 secs    1.43 millis   73.43 secs
```

Before:
```
________________________________________________________
Executed in  101.18 secs    fish           external
   usr time  498.51 secs    0.34 millis  498.51 secs
   sys time   31.66 secs    1.49 millis   31.66 secs
```


## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
