### PR TITLE
[PM-36972] [PM-37468] Update revocation reason tooltips 

### DIFF
--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -4562,8 +4562,8 @@
   "revokedEmailError": {
     "message": "1 or more emails belong to revoked members. Restore their access to reinvite."
   },
-  "revocationReasonUnknown": {
-    "message": "Unknown reason"
+  "revocationReasonNotLogged": {
+    "message": "No reason logged"
   },
   "revocationReasonManual": {
     "message": "Revoked by an admin"
@@ -4573,6 +4573,9 @@
   },
   "revocationReasonSingleOrganizationNonCompliance": {
     "message": "Not in compliance with single organization policy"
+  },
+  "revocationReasonDeclinedItemTransfer": {
+    "message": "Declined item transfer to organization"
   },
   "revokedUserIdTwoFactorNonCompliance": {
     "message": "Revoked organization access for $ID$ for non-compliance with the two-factor organization policy.",

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -4652,9 +4652,6 @@
   "userAcceptedTransfer": {
     "message": "Accepted transfer to organization ownership."
   },
-  "userDeclinedTransfer": {
-    "message": "Revoked for declining transfer to organization ownership."
-  },
   "invitedUserId": {
     "message": "Invited user $ID$.",
     "placeholders": {

--- a/libs/common/src/admin-console/enums/revocation-reasons-enum.ts
+++ b/libs/common/src/admin-console/enums/revocation-reasons-enum.ts
@@ -7,10 +7,10 @@ export const RevocationReasonType = Object.freeze({
 } as const);
 
 export const RevocationReasonMessageMap: Record<RevocationReasonType, string> = {
-  "0": "revocationReasonUnknown",
+  "0": "revocationReasonNotLogged",
   "1": "revocationReasonManual",
   "2": "revocationReasonTwoFactorNonCompliance",
-  "3": "userDeclinedTransfer",
+  "3": "revocationReasonDeclinedItemTransfer",
   "4": "revocationReasonSingleOrganizationNonCompliance",
 };
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-37468
https://bitwarden.atlassian.net/browse/PM-36972

## 📔 Objective

> Update "unknown reason" tooltip to "No reason logged". Fix discrepancy with tooltip shown when user declines My Items vault transfer.