### PR TITLE
[PM-34112] Add Passport copy actions to browser extension

### DIFF
--- a/libs/common/src/vault/utils/cipher-view-like-utils.ts
+++ b/libs/common/src/vault/utils/cipher-view-like-utils.ts
@@ -306,6 +306,18 @@ export class CipherViewLikeUtils {
         return !!cipher.passport?.passportNumber;
       case "nationalIdentificationNumber":
         return !!cipher.passport?.nationalIdentificationNumber;
+      case "sex":
+        return !!cipher.passport?.sex;
+      case "birthPlace":
+        return !!cipher.passport?.birthPlace;
+      case "nationality":
+        return !!cipher.passport?.nationality;
+      case "issuingCountry":
+        return !!cipher.passport?.issuingCountry;
+      case "passportType":
+        return !!cipher.passport?.passportType;
+      case "issuingAuthority":
+        return !!cipher.passport?.issuingAuthority;
       default:
         return false;
     }

--- a/libs/common/src/vault/utils/cipher-view-like-utils.ts
+++ b/libs/common/src/vault/utils/cipher-view-like-utils.ts
@@ -306,18 +306,10 @@ export class CipherViewLikeUtils {
         return !!cipher.passport?.passportNumber;
       case "nationalIdentificationNumber":
         return !!cipher.passport?.nationalIdentificationNumber;
-      case "sex":
-        return !!cipher.passport?.sex;
-      case "birthPlace":
-        return !!cipher.passport?.birthPlace;
-      case "nationality":
-        return !!cipher.passport?.nationality;
-      case "issuingCountry":
-        return !!cipher.passport?.issuingCountry;
-      case "passportType":
-        return !!cipher.passport?.passportType;
-      case "issuingAuthority":
-        return !!cipher.passport?.issuingAuthority;
+      case "givenName":
+        return !!cipher.passport?.givenName;
+      case "surname":
+        return !!cipher.passport?.surname;
       default:
         return false;
     }

--- a/libs/vault/src/components/copy-cipher-field.directive.ts
+++ b/libs/vault/src/components/copy-cipher-field.directive.ts
@@ -160,6 +160,18 @@ export class CopyCipherFieldDirective implements OnChanges {
         return _cipher.passport?.passportNumber;
       case "nationalIdentificationNumber":
         return _cipher.passport?.nationalIdentificationNumber;
+      case "sex":
+        return _cipher.passport?.sex;
+      case "birthPlace":
+        return _cipher.passport?.birthPlace;
+      case "nationality":
+        return _cipher.passport?.nationality;
+      case "issuingCountry":
+        return _cipher.passport?.issuingCountry;
+      case "passportType":
+        return _cipher.passport?.passportType;
+      case "issuingAuthority":
+        return _cipher.passport?.issuingAuthority;
       default:
         return null;
     }

--- a/libs/vault/src/components/copy-cipher-field.directive.ts
+++ b/libs/vault/src/components/copy-cipher-field.directive.ts
@@ -160,18 +160,10 @@ export class CopyCipherFieldDirective implements OnChanges {
         return _cipher.passport?.passportNumber;
       case "nationalIdentificationNumber":
         return _cipher.passport?.nationalIdentificationNumber;
-      case "sex":
-        return _cipher.passport?.sex;
-      case "birthPlace":
-        return _cipher.passport?.birthPlace;
-      case "nationality":
-        return _cipher.passport?.nationality;
-      case "issuingCountry":
-        return _cipher.passport?.issuingCountry;
-      case "passportType":
-        return _cipher.passport?.passportType;
-      case "issuingAuthority":
-        return _cipher.passport?.issuingAuthority;
+      case "givenName":
+        return _cipher.passport?.givenName;
+      case "surname":
+        return _cipher.passport?.surname;
       default:
         return null;
     }

--- a/libs/vault/src/components/item-copy-actions/item-copy-actions.component.html
+++ b/libs/vault/src/components/item-copy-actions/item-copy-actions.component.html
@@ -281,6 +281,12 @@
         [bitMenuTriggerFor]="passportOptions"
       ></button>
       <bit-menu #passportOptions>
+        <button type="button" bitMenuItem appCopyField="givenName" [cipher]="_cipher">
+          {{ "copyFirstName" | i18n }}
+        </button>
+        <button type="button" bitMenuItem appCopyField="surname" [cipher]="_cipher">
+          {{ "copyLastName" | i18n }}
+        </button>
         <button type="button" bitMenuItem appCopyField="passportNumber" [cipher]="_cipher">
           {{ "copyPassportNumber" | i18n }}
         </button>
@@ -291,24 +297,6 @@
           [cipher]="_cipher"
         >
           {{ "copyNationalIdentificationNumber" | i18n }}
-        </button>
-        <button type="button" bitMenuItem appCopyField="sex" [cipher]="_cipher">
-          {{ "copySex" | i18n }}
-        </button>
-        <button type="button" bitMenuItem appCopyField="birthPlace" [cipher]="_cipher">
-          {{ "copyBirthPlace" | i18n }}
-        </button>
-        <button type="button" bitMenuItem appCopyField="nationality" [cipher]="_cipher">
-          {{ "copyNationality" | i18n }}
-        </button>
-        <button type="button" bitMenuItem appCopyField="issuingCountry" [cipher]="_cipher">
-          {{ "copyIssuingCountry" | i18n }}
-        </button>
-        <button type="button" bitMenuItem appCopyField="passportType" [cipher]="_cipher">
-          {{ "copyPassportType" | i18n }}
-        </button>
-        <button type="button" bitMenuItem appCopyField="issuingAuthority" [cipher]="_cipher">
-          {{ "copyIssuingAuthority" | i18n }}
         </button>
       </bit-menu>
     }

--- a/libs/vault/src/components/item-copy-actions/item-copy-actions.component.html
+++ b/libs/vault/src/components/item-copy-actions/item-copy-actions.component.html
@@ -256,3 +256,61 @@
     }
   </bit-item-action>
 }
+
+@if (CipherViewLikeUtils.getType(_cipher) === CipherType.Passport) {
+  <bit-item-action>
+    @if (singleCopyablePassport) {
+      <button
+        type="button"
+        bitIconButton="bwi-clone"
+        size="small"
+        [label]="'copyFieldCipherName' | i18n: singleCopyablePassport.key : _cipher.name"
+        [appCopyField]="singleCopyablePassport.field"
+        [cipher]="_cipher"
+        showToast
+      ></button>
+    } @else {
+      <button
+        type="button"
+        bitIconButton="bwi-clone"
+        size="small"
+        [label]="
+          hasPassportValues ? ('copyInfoTitle' | i18n: _cipher.name) : ('noValuesToCopy' | i18n)
+        "
+        [disabled]="!hasPassportValues"
+        [bitMenuTriggerFor]="passportOptions"
+      ></button>
+      <bit-menu #passportOptions>
+        <button type="button" bitMenuItem appCopyField="passportNumber" [cipher]="_cipher">
+          {{ "copyPassportNumber" | i18n }}
+        </button>
+        <button
+          type="button"
+          bitMenuItem
+          appCopyField="nationalIdentificationNumber"
+          [cipher]="_cipher"
+        >
+          {{ "copyNationalIdentificationNumber" | i18n }}
+        </button>
+        <button type="button" bitMenuItem appCopyField="sex" [cipher]="_cipher">
+          {{ "copySex" | i18n }}
+        </button>
+        <button type="button" bitMenuItem appCopyField="birthPlace" [cipher]="_cipher">
+          {{ "copyBirthPlace" | i18n }}
+        </button>
+        <button type="button" bitMenuItem appCopyField="nationality" [cipher]="_cipher">
+          {{ "copyNationality" | i18n }}
+        </button>
+        <button type="button" bitMenuItem appCopyField="issuingCountry" [cipher]="_cipher">
+          {{ "copyIssuingCountry" | i18n }}
+        </button>
+        <button type="button" bitMenuItem appCopyField="passportType" [cipher]="_cipher">
+          {{ "copyPassportType" | i18n }}
+        </button>
+        <button type="button" bitMenuItem appCopyField="issuingAuthority" [cipher]="_cipher">
+          {{ "copyIssuingAuthority" | i18n }}
+        </button>
+      </bit-menu>
+    }
+  </bit-item-action>
+}

--- a/libs/vault/src/components/item-copy-actions/item-copy-actions.component.spec.ts
+++ b/libs/vault/src/components/item-copy-actions/item-copy-actions.component.spec.ts
@@ -539,5 +539,112 @@ describe("VaultItemCopyActionsComponent", () => {
 
       expect(component.hasDriversLicenseValues).toBe(false);
     });
+
+    it("uses copyableFields for passport values", () => {
+      (component.cipher() as CipherListView).copyableFields = [
+        "PassportPassportNumber",
+      ] as CopyableCipherFields[];
+
+      expect(component.hasPassportValues).toBe(true);
+
+      (component.cipher() as CipherListView).copyableFields = [
+        "LoginUsername",
+      ] as CopyableCipherFields[];
+
+      expect(component.hasPassportValues).toBe(false);
+    });
+  });
+
+  describe("singleCopyablePassport", () => {
+    beforeEach(() => {
+      jest
+        .spyOn(CipherViewLikeUtils, "hasCopyableValue")
+        .mockImplementation(
+          (cipher: CipherViewLike & { __copyable?: Record<string, boolean> }, field) => {
+            return Boolean(cipher.__copyable?.[field]);
+          },
+        );
+    });
+
+    it("returns the single populated passport field", () => {
+      (component.cipher() as any).__copyable = {
+        passportNumber: true,
+        nationalIdentificationNumber: false,
+        sex: false,
+        birthPlace: false,
+        nationality: false,
+        issuingCountry: false,
+        passportType: false,
+        issuingAuthority: false,
+      };
+
+      const result = component.singleCopyablePassport;
+
+      expect(result).toEqual({
+        key: "translated-passportNumber",
+        field: "passportNumber",
+      });
+    });
+
+    it("returns null when multiple passport fields are populated", () => {
+      (component.cipher() as any).__copyable = {
+        passportNumber: true,
+        nationalIdentificationNumber: true,
+        sex: false,
+        birthPlace: false,
+        nationality: false,
+        issuingCountry: false,
+        passportType: false,
+        issuingAuthority: false,
+      };
+
+      const result = component.singleCopyablePassport;
+
+      expect(result).toBeNull();
+    });
+
+    it("returns null when no passport fields are populated", () => {
+      (component.cipher() as any).__copyable = {
+        passportNumber: false,
+        nationalIdentificationNumber: false,
+        sex: false,
+        birthPlace: false,
+        nationality: false,
+        issuingCountry: false,
+        passportType: false,
+        issuingAuthority: false,
+      };
+
+      const result = component.singleCopyablePassport;
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("hasPassportValues in non-list view", () => {
+    beforeEach(() => {
+      jest.spyOn(CipherViewLikeUtils, "isCipherListView").mockReturnValue(false);
+    });
+
+    it("returns true when at least one passport field is populated", () => {
+      (component.cipher() as any).passport = { passportNumber: "AB123456" };
+
+      expect(component.hasPassportValues).toBe(true);
+    });
+
+    it("returns false when all passport fields are empty", () => {
+      (component.cipher() as any).passport = {
+        passportNumber: null,
+        nationalIdentificationNumber: null,
+        sex: null,
+        birthPlace: null,
+        nationality: null,
+        issuingCountry: null,
+        passportType: null,
+        issuingAuthority: null,
+      };
+
+      expect(component.hasPassportValues).toBe(false);
+    });
   });
 });

--- a/libs/vault/src/components/item-copy-actions/item-copy-actions.component.spec.ts
+++ b/libs/vault/src/components/item-copy-actions/item-copy-actions.component.spec.ts
@@ -568,14 +568,10 @@ describe("VaultItemCopyActionsComponent", () => {
 
     it("returns the single populated passport field", () => {
       (component.cipher() as any).__copyable = {
+        givenName: false,
+        surname: false,
         passportNumber: true,
         nationalIdentificationNumber: false,
-        sex: false,
-        birthPlace: false,
-        nationality: false,
-        issuingCountry: false,
-        passportType: false,
-        issuingAuthority: false,
       };
 
       const result = component.singleCopyablePassport;
@@ -588,14 +584,10 @@ describe("VaultItemCopyActionsComponent", () => {
 
     it("returns null when multiple passport fields are populated", () => {
       (component.cipher() as any).__copyable = {
+        givenName: false,
+        surname: false,
         passportNumber: true,
         nationalIdentificationNumber: true,
-        sex: false,
-        birthPlace: false,
-        nationality: false,
-        issuingCountry: false,
-        passportType: false,
-        issuingAuthority: false,
       };
 
       const result = component.singleCopyablePassport;
@@ -605,14 +597,10 @@ describe("VaultItemCopyActionsComponent", () => {
 
     it("returns null when no passport fields are populated", () => {
       (component.cipher() as any).__copyable = {
+        givenName: false,
+        surname: false,
         passportNumber: false,
         nationalIdentificationNumber: false,
-        sex: false,
-        birthPlace: false,
-        nationality: false,
-        issuingCountry: false,
-        passportType: false,
-        issuingAuthority: false,
       };
 
       const result = component.singleCopyablePassport;
@@ -634,14 +622,10 @@ describe("VaultItemCopyActionsComponent", () => {
 
     it("returns false when all passport fields are empty", () => {
       (component.cipher() as any).passport = {
+        givenName: null,
+        surname: null,
         passportNumber: null,
         nationalIdentificationNumber: null,
-        sex: null,
-        birthPlace: null,
-        nationality: null,
-        issuingCountry: null,
-        passportType: null,
-        issuingAuthority: null,
       };
 
       expect(component.hasPassportValues).toBe(false);

--- a/libs/vault/src/components/item-copy-actions/item-copy-actions.component.ts
+++ b/libs/vault/src/components/item-copy-actions/item-copy-actions.component.ts
@@ -124,6 +124,24 @@ export class VaultItemCopyActionsComponent {
     return this.getNumberOfDriversLicenseValues(this.cipher()) > 0;
   }
 
+  get hasPassportValues() {
+    return this.getNumberOfPassportValues(this.cipher()) > 0;
+  }
+
+  get singleCopyablePassport(): CipherItem | null {
+    const passportItems: CipherItem[] = [
+      { key: "passportNumber", field: "passportNumber" },
+      { key: "nationalIdentificationNumber", field: "nationalIdentificationNumber" },
+      { key: "sex", field: "sex" },
+      { key: "birthPlace", field: "birthPlace" },
+      { key: "nationality", field: "nationality" },
+      { key: "issuingCountry", field: "issuingCountry" },
+      { key: "passportType", field: "passportType" },
+      { key: "issuingAuthority", field: "issuingAuthority" },
+    ];
+    return this.findSingleCopyableItem(this.cipher(), passportItems);
+  }
+
   /** Sets the number of populated login values for the cipher */
   private getNumberOfLoginValues(cipher: CipherViewLike) {
     return this.getLoginCopyableItems(cipher)
@@ -170,6 +188,24 @@ export class VaultItemCopyActionsComponent {
     }
 
     return cipher.notes ? 1 : 0;
+  }
+
+  /** Sets the number of populated passport values for the cipher */
+  private getNumberOfPassportValues(cipher: CipherViewLike) {
+    if (CipherViewLikeUtils.isCipherListView(cipher)) {
+      const copyablePassportFields: CopyableCipherFields[] = ["PassportPassportNumber"];
+      return cipher.copyableFields.filter((field) => copyablePassportFields.includes(field)).length;
+    }
+    return [
+      cipher.passport?.passportNumber,
+      cipher.passport?.nationalIdentificationNumber,
+      cipher.passport?.sex,
+      cipher.passport?.birthPlace,
+      cipher.passport?.nationality,
+      cipher.passport?.issuingCountry,
+      cipher.passport?.passportType,
+      cipher.passport?.issuingAuthority,
+    ].filter(Boolean).length;
   }
 
   /** Sets the number of populated SSH key values for the cipher */

--- a/libs/vault/src/components/item-copy-actions/item-copy-actions.component.ts
+++ b/libs/vault/src/components/item-copy-actions/item-copy-actions.component.ts
@@ -130,14 +130,10 @@ export class VaultItemCopyActionsComponent {
 
   get singleCopyablePassport(): CipherItem | null {
     const passportItems: CipherItem[] = [
+      { key: "givenName", field: "givenName" },
+      { key: "surname", field: "surname" },
       { key: "passportNumber", field: "passportNumber" },
       { key: "nationalIdentificationNumber", field: "nationalIdentificationNumber" },
-      { key: "sex", field: "sex" },
-      { key: "birthPlace", field: "birthPlace" },
-      { key: "nationality", field: "nationality" },
-      { key: "issuingCountry", field: "issuingCountry" },
-      { key: "passportType", field: "passportType" },
-      { key: "issuingAuthority", field: "issuingAuthority" },
     ];
     return this.findSingleCopyableItem(this.cipher(), passportItems);
   }
@@ -197,14 +193,10 @@ export class VaultItemCopyActionsComponent {
       return cipher.copyableFields.filter((field) => copyablePassportFields.includes(field)).length;
     }
     return [
+      cipher.passport?.givenName,
+      cipher.passport?.surname,
       cipher.passport?.passportNumber,
       cipher.passport?.nationalIdentificationNumber,
-      cipher.passport?.sex,
-      cipher.passport?.birthPlace,
-      cipher.passport?.nationality,
-      cipher.passport?.issuingCountry,
-      cipher.passport?.passportType,
-      cipher.passport?.issuingAuthority,
     ].filter(Boolean).length;
   }
 

--- a/libs/vault/src/services/copy-cipher-field.service.ts
+++ b/libs/vault/src/services/copy-cipher-field.service.ts
@@ -43,12 +43,8 @@ export type CopyAction =
   | "licenseNumber"
   | "passportNumber"
   | "nationalIdentificationNumber"
-  | "sex"
-  | "birthPlace"
-  | "nationality"
-  | "issuingCountry"
-  | "passportType"
-  | "issuingAuthority";
+  | "givenName"
+  | "surname";
 
 /**
  * Copy actions that can be used with the appCopyField directive.
@@ -119,12 +115,8 @@ const CopyActions: Record<CopyAction, CopyActionInfo> = {
     typeI18nKey: "nationalIdentificationNumber",
     protected: true,
   },
-  sex: { typeI18nKey: "sex", protected: true },
-  birthPlace: { typeI18nKey: "birthPlace", protected: true },
-  nationality: { typeI18nKey: "nationality", protected: true },
-  issuingCountry: { typeI18nKey: "issuingCountry", protected: true },
-  passportType: { typeI18nKey: "passportType", protected: true },
-  issuingAuthority: { typeI18nKey: "issuingAuthority", protected: true },
+  givenName: { typeI18nKey: "firstName", protected: true },
+  surname: { typeI18nKey: "lastName", protected: true },
   hiddenField: {
     typeI18nKey: "value",
     protected: true,

--- a/libs/vault/src/services/copy-cipher-field.service.ts
+++ b/libs/vault/src/services/copy-cipher-field.service.ts
@@ -42,7 +42,13 @@ export type CopyAction =
   | "lastName"
   | "licenseNumber"
   | "passportNumber"
-  | "nationalIdentificationNumber";
+  | "nationalIdentificationNumber"
+  | "sex"
+  | "birthPlace"
+  | "nationality"
+  | "issuingCountry"
+  | "passportType"
+  | "issuingAuthority";
 
 /**
  * Copy actions that can be used with the appCopyField directive.
@@ -113,6 +119,12 @@ const CopyActions: Record<CopyAction, CopyActionInfo> = {
     typeI18nKey: "nationalIdentificationNumber",
     protected: true,
   },
+  sex: { typeI18nKey: "sex", protected: true },
+  birthPlace: { typeI18nKey: "birthPlace", protected: true },
+  nationality: { typeI18nKey: "nationality", protected: true },
+  issuingCountry: { typeI18nKey: "issuingCountry", protected: true },
+  passportType: { typeI18nKey: "passportType", protected: true },
+  issuingAuthority: { typeI18nKey: "issuingAuthority", protected: true },
   hiddenField: {
     typeI18nKey: "value",
     protected: true,


### PR DESCRIPTION
## 🎟️ Tracking

[PM-34112](https://bitwarden.atlassian.net/browse/PM-34112)

## 📔 Objective

Adds Passport cipher type copy actions to the browser extension vault item list, following the same pattern established for Driver's License (PM-32693/PM-34108).

## 📸 Screenshots

<video src="https://github.com/user-attachments/assets/18c68ba7-176d-41c0-a7ba-4ec4a2db4c0b" />

[PM-34112]: https://bitwarden.atlassian.net/browse/PM-34112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ