### PR TITLE
[PM-37485] Bugfix: Autofill settings do not save in browser extension

### DIFF
--- a/apps/browser/src/autofill/popup/settings/autofill.component.ts
+++ b/apps/browser/src/autofill/popup/settings/autofill.component.ts
@@ -636,7 +636,7 @@ export class AutofillComponent implements OnInit {
     }
 
     const result = await chrome.storage.session.get("pendingDefaultPasswordManagerApply");
-    return Boolean(result.pendingDefaultPasswordManagerApply);
+    return Boolean(result?.pendingDefaultPasswordManagerApply);
   }
 
   async updateShowCardsCurrentTab() {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-37485

## 📔 Objective

`chrome.storage.session.get("pendingDefaultPasswordManagerApply");` was returning `undefined`, causing the next line to throw an error, blocking any settings from saving. This prevents the throw, allowing the function to return `false` as normal.

## 📸 Screenshots

https://github.com/user-attachments/assets/ac18659a-ed1e-4387-aa4a-13f79ef350f3


