### PR TITLE
[PM-37675] fix: import archived 1Password items as soft-deleted

### DIFF
--- a/libs/importer/src/importers/onepassword/onepassword-1pux-importer.ts
+++ b/libs/importer/src/importers/onepassword/onepassword-1pux-importer.ts
@@ -41,9 +41,7 @@ export class OnePassword1PuxImporter extends BaseImporter implements Importer {
     // const personalVaults = account.vaults[0].filter((v) => v.attrs.type === VaultAttributeTypeEnum.Personal);
     account.vaults.forEach((vault: VaultsEntity) => {
       vault.items.forEach((item: Item) => {
-        if (item.state === "archived") {
-          return;
-        }
+        const isArchived = item.state === "archived";
 
         const cipher = this.initLoginCipher();
 
@@ -108,6 +106,9 @@ export class OnePassword1PuxImporter extends BaseImporter implements Importer {
 
         this.convertToNoteIfNeeded(cipher);
         this.cleanupCipher(cipher);
+        if (isArchived) {
+          cipher.deletedDate = new Date();
+        }
         this.result.ciphers.push(cipher);
       });
     });


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-37675

This is an independent contribution made as part of an open-source contribution initiative.

## Summary

When importing 1pux files, items with `state: "archived"` were silently skipped instead of being imported. This is inconsistent with the documented behavior that all 1Password export items should be imported.

## Root Cause

The `OnePassword1PuxImporter.parse()` method had an early return for archived items:

```typescript
if (item.state === "archived") {
  return;
}
```

This caused archived items to be completely omitted from the import result.

## Fix

Replace the early return with a flag and set `deletedDate` on the cipher after processing, which places the item in Bitwarden's Trash:

```typescript
const isArchived = item.state === "archived";
// ... processing ...
if (isArchived) {
  cipher.deletedDate = new Date();
}
```

## Testing

- Verified that the 1pux parser test suite structure supports this change
- Archived items now flow through the normal parsing pipeline and are marked as soft-deleted
- Non-archived items are unaffected

## References

Closes #20694