### PR TITLE
[CL-1046] Add no-bit-dialog-wrapper lint rule

### DIFF
--- a/apps/browser/src/auth/popup/components/set-pin.component.html
+++ b/apps/browser/src/auth/popup/components/set-pin.component.html
@@ -1,37 +1,32 @@
-<form [bitSubmit]="submit" [formGroup]="setPinForm">
-  <bit-dialog>
-    <div class="tw-font-medium" bitDialogTitle>
-      {{ "setYourPinTitle" | i18n }}
-    </div>
-    <div bitDialogContent>
-      <p>
-        {{ "setPinCode" | i18n }}
-      </p>
-      <bit-form-field>
-        <bit-label>{{ "pin" | i18n }}</bit-label>
-        <input class="tw-font-mono" bitInput type="password" formControlName="pin" />
-        <button type="button" bitIconButton bitSuffix bitPasswordInputToggle></button>
-      </bit-form-field>
-      <label
-        class="tw-flex tw-items-start tw-gap-2"
-        *ngIf="showMasterPasswordOnClientRestartOption"
-      >
-        <input
-          class="tw-mt-1"
-          type="checkbox"
-          bitCheckbox
-          formControlName="requireMasterPasswordOnClientRestart"
-        />
-        <span>{{ "lockWithMasterPassOnRestart1" | i18n }}</span>
-      </label>
-    </div>
-    <ng-container bitDialogFooter>
-      <button type="submit" bitButton bitFormButton buttonType="primary">
-        <span>{{ "setYourPinButton" | i18n }}</span>
-      </button>
-      <button type="button" bitButton bitFormButton buttonType="secondary" bitDialogClose>
-        {{ "cancel" | i18n }}
-      </button>
-    </ng-container>
-  </bit-dialog>
+<form [bitSubmit]="submit" [formGroup]="setPinForm" bit-dialog>
+  <div class="tw-font-medium" bitDialogTitle>
+    {{ "setYourPinTitle" | i18n }}
+  </div>
+  <div bitDialogContent>
+    <p>
+      {{ "setPinCode" | i18n }}
+    </p>
+    <bit-form-field>
+      <bit-label>{{ "pin" | i18n }}</bit-label>
+      <input class="tw-font-mono" bitInput type="password" formControlName="pin" />
+      <button type="button" bitIconButton bitSuffix bitPasswordInputToggle></button>
+    </bit-form-field>
+    <label class="tw-flex tw-items-start tw-gap-2" *ngIf="showMasterPasswordOnClientRestartOption">
+      <input
+        class="tw-mt-1"
+        type="checkbox"
+        bitCheckbox
+        formControlName="requireMasterPasswordOnClientRestart"
+      />
+      <span>{{ "lockWithMasterPassOnRestart1" | i18n }}</span>
+    </label>
+  </div>
+  <ng-container bitDialogFooter>
+    <button type="submit" bitButton bitFormButton buttonType="primary">
+      <span>{{ "setYourPinButton" | i18n }}</span>
+    </button>
+    <button type="button" bitButton bitFormButton buttonType="secondary" bitDialogClose>
+      {{ "cancel" | i18n }}
+    </button>
+  </ng-container>
 </form>

--- a/apps/desktop/src/auth/components/set-pin.component.html
+++ b/apps/desktop/src/auth/components/set-pin.component.html
@@ -1,37 +1,32 @@
-<form [bitSubmit]="submit" [formGroup]="setPinForm">
-  <bit-dialog>
-    <div class="tw-font-medium" bitDialogTitle>
-      {{ "unlockWithPin" | i18n }}
-    </div>
-    <div bitDialogContent>
-      <p>
-        {{ "setYourPinCode" | i18n }}
-      </p>
-      <bit-form-field>
-        <bit-label>{{ "pin" | i18n }}</bit-label>
-        <input class="tw-font-mono" bitInput type="password" formControlName="pin" />
-        <button type="button" bitIconButton bitSuffix bitPasswordInputToggle></button>
-      </bit-form-field>
-      <label
-        class="tw-flex tw-items-start tw-gap-2"
-        *ngIf="showMasterPasswordOnClientRestartOption"
-      >
-        <input
-          class="tw-mt-1"
-          type="checkbox"
-          bitCheckbox
-          formControlName="requireMasterPasswordOnClientRestart"
-        />
-        <span>{{ "lockWithMasterPassOnRestart1" | i18n }}</span>
-      </label>
-    </div>
-    <ng-container bitDialogFooter>
-      <button type="submit" bitButton bitFormButton buttonType="primary">
-        <span>{{ "ok" | i18n }}</span>
-      </button>
-      <button type="button" bitButton bitFormButton buttonType="secondary" bitDialogClose>
-        {{ "cancel" | i18n }}
-      </button>
-    </ng-container>
-  </bit-dialog>
+<form [bitSubmit]="submit" [formGroup]="setPinForm" bit-dialog>
+  <div class="tw-font-medium" bitDialogTitle>
+    {{ "unlockWithPin" | i18n }}
+  </div>
+  <div bitDialogContent>
+    <p>
+      {{ "setYourPinCode" | i18n }}
+    </p>
+    <bit-form-field>
+      <bit-label>{{ "pin" | i18n }}</bit-label>
+      <input class="tw-font-mono" bitInput type="password" formControlName="pin" />
+      <button type="button" bitIconButton bitSuffix bitPasswordInputToggle></button>
+    </bit-form-field>
+    <label class="tw-flex tw-items-start tw-gap-2" *ngIf="showMasterPasswordOnClientRestartOption">
+      <input
+        class="tw-mt-1"
+        type="checkbox"
+        bitCheckbox
+        formControlName="requireMasterPasswordOnClientRestart"
+      />
+      <span>{{ "lockWithMasterPassOnRestart1" | i18n }}</span>
+    </label>
+  </div>
+  <ng-container bitDialogFooter>
+    <button type="submit" bitButton bitFormButton buttonType="primary">
+      <span>{{ "ok" | i18n }}</span>
+    </button>
+    <button type="button" bitButton bitFormButton buttonType="secondary" bitDialogClose>
+      {{ "cancel" | i18n }}
+    </button>
+  </ng-container>
 </form>

--- a/apps/desktop/src/autofill/components/approve-ssh-request.html
+++ b/apps/desktop/src/autofill/components/approve-ssh-request.html
@@ -1,24 +1,22 @@
-<form [bitSubmit]="submit" [formGroup]="approveSshRequestForm">
-  <bit-dialog>
-    <div class="tw-font-medium" bitDialogTitle>{{ "sshkeyApprovalTitle" | i18n }}</div>
-    <div bitDialogContent>
-      @if (params.isAgentForwarding) {
-      <bit-callout type="warning" title="{{ 'agentForwardingWarningTitle' | i18n }}">
-        {{ 'agentForwardingWarningText' | i18n }}
-      </bit-callout>
-      }
+<form [bitSubmit]="submit" [formGroup]="approveSshRequestForm" bit-dialog>
+  <div class="tw-font-medium" bitDialogTitle>{{ "sshkeyApprovalTitle" | i18n }}</div>
+  <div bitDialogContent>
+    @if (params.isAgentForwarding) {
+    <bit-callout type="warning" title="{{ 'agentForwardingWarningTitle' | i18n }}">
+      {{ 'agentForwardingWarningText' | i18n }}
+    </bit-callout>
+    }
 
-      <b>{{params.applicationName}}</b> {{ "sshkeyApprovalMessageInfix" | i18n }}
-      <b>{{params.cipherName}}</b>
-      {{ "sshkeyApprovalMessageSuffix" | i18n }} {{ params.action | i18n }}
-    </div>
-    <ng-container bitDialogFooter>
-      <button type="submit" bitButton bitFormButton buttonType="primary">
-        <span>{{ "authorize" | i18n }}</span>
-      </button>
-      <button type="button" bitButton bitFormButton buttonType="secondary" bitDialogClose>
-        {{ "deny" | i18n }}
-      </button>
-    </ng-container>
-  </bit-dialog>
+    <b>{{params.applicationName}}</b> {{ "sshkeyApprovalMessageInfix" | i18n }}
+    <b>{{params.cipherName}}</b>
+    {{ "sshkeyApprovalMessageSuffix" | i18n }} {{ params.action | i18n }}
+  </div>
+  <ng-container bitDialogFooter>
+    <button type="submit" bitButton bitFormButton buttonType="primary">
+      <span>{{ "authorize" | i18n }}</span>
+    </button>
+    <button type="button" bitButton bitFormButton buttonType="secondary" bitDialogClose>
+      {{ "deny" | i18n }}
+    </button>
+  </ng-container>
 </form>

--- a/apps/desktop/src/autofill/components/autotype-shortcut.component.html
+++ b/apps/desktop/src/autofill/components/autotype-shortcut.component.html
@@ -1,33 +1,31 @@
-<form [bitSubmit]="submit" [formGroup]="setShortcutForm">
-  <bit-dialog>
-    <div class="tw-font-medium" bitDialogTitle>
-      {{ "typeShortcut" | i18n }}
-    </div>
-    <div bitDialogContent>
-      <p>
-        {{ "editAutotypeKeyboardModifiersDescription" | i18n }}
-      </p>
-      <bit-form-field>
-        <bit-label>{{ "typeShortcut" | i18n }}</bit-label>
-        <input
-          class="tw-font-mono"
-          bitInput
-          type="text"
-          formControlName="shortcut"
-          (keydown)="onShortcutKeydown($event)"
-          autocomplete="off"
-          autocorrect="off"
-          autocapitalize="off"
-        />
-      </bit-form-field>
-    </div>
-    <ng-container bitDialogFooter>
-      <button type="submit" bitButton bitFormButton buttonType="primary">
-        <span>{{ "save" | i18n }}</span>
-      </button>
-      <button type="button" bitButton bitFormButton buttonType="secondary" bitDialogClose>
-        {{ "cancel" | i18n }}
-      </button>
-    </ng-container>
-  </bit-dialog>
+<form [bitSubmit]="submit" [formGroup]="setShortcutForm" bit-dialog>
+  <div class="tw-font-medium" bitDialogTitle>
+    {{ "typeShortcut" | i18n }}
+  </div>
+  <div bitDialogContent>
+    <p>
+      {{ "editAutotypeKeyboardModifiersDescription" | i18n }}
+    </p>
+    <bit-form-field>
+      <bit-label>{{ "typeShortcut" | i18n }}</bit-label>
+      <input
+        class="tw-font-mono"
+        bitInput
+        type="text"
+        formControlName="shortcut"
+        (keydown)="onShortcutKeydown($event)"
+        autocomplete="off"
+        autocorrect="off"
+        autocapitalize="off"
+      />
+    </bit-form-field>
+  </div>
+  <ng-container bitDialogFooter>
+    <button type="submit" bitButton bitFormButton buttonType="primary">
+      <span>{{ "save" | i18n }}</span>
+    </button>
+    <button type="button" bitButton bitFormButton buttonType="secondary" bitDialogClose>
+      {{ "cancel" | i18n }}
+    </button>
+  </ng-container>
 </form>

--- a/apps/web/src/app/admin-console/organizations/collections/bulk-collections-dialog/bulk-collections-dialog.component.html
+++ b/apps/web/src/app/admin-console/organizations/collections/bulk-collections-dialog/bulk-collections-dialog.component.html
@@ -1,41 +1,45 @@
-<form [formGroup]="formGroup" [bitSubmit]="submit">
-  <bit-dialog [loading]="loading" dialogSize="large">
-    <span bitDialogTitle>
-      {{ "assignCollectionAccess" | i18n }}
-      <span class="tw-text-sm tw-normal-case tw-text-muted">
-        {{ numCollections }} {{ (numCollections == 1 ? "collection" : "collections") | i18n }}
-      </span>
+<form
+  [formGroup]="formGroup"
+  [bitSubmit]="submit"
+  bit-dialog
+  [loading]="loading"
+  dialogSize="large"
+>
+  <span bitDialogTitle>
+    {{ "assignCollectionAccess" | i18n }}
+    <span class="tw-text-sm tw-normal-case tw-text-muted">
+      {{ numCollections }} {{ (numCollections == 1 ? "collection" : "collections") | i18n }}
     </span>
+  </span>
 
-    <div bitDialogContent>
-      <bit-access-selector
-        *ngIf="organization?.useGroups"
-        [permissionMode]="PermissionMode.Edit"
-        formControlName="access"
-        [items]="accessItems"
-        [columnHeader]="'groupSlashMemberColumnHeader' | i18n"
-        [selectorLabelText]="'selectGroupsAndMembers' | i18n"
-        [selectorHelpText]="'userPermissionOverrideHelperDesc' | i18n"
-        [emptySelectionText]="'noMembersOrGroupsAdded' | i18n"
-      ></bit-access-selector>
-      <bit-access-selector
-        *ngIf="!organization?.useGroups"
-        [permissionMode]="PermissionMode.Edit"
-        formControlName="access"
-        [items]="accessItems"
-        [columnHeader]="'memberColumnHeader' | i18n"
-        [selectorLabelText]="'selectMembers' | i18n"
-        [emptySelectionText]="'noMembersAdded' | i18n"
-      ></bit-access-selector>
-    </div>
+  <div bitDialogContent>
+    <bit-access-selector
+      *ngIf="organization?.useGroups"
+      [permissionMode]="PermissionMode.Edit"
+      formControlName="access"
+      [items]="accessItems"
+      [columnHeader]="'groupSlashMemberColumnHeader' | i18n"
+      [selectorLabelText]="'selectGroupsAndMembers' | i18n"
+      [selectorHelpText]="'userPermissionOverrideHelperDesc' | i18n"
+      [emptySelectionText]="'noMembersOrGroupsAdded' | i18n"
+    ></bit-access-selector>
+    <bit-access-selector
+      *ngIf="!organization?.useGroups"
+      [permissionMode]="PermissionMode.Edit"
+      formControlName="access"
+      [items]="accessItems"
+      [columnHeader]="'memberColumnHeader' | i18n"
+      [selectorLabelText]="'selectMembers' | i18n"
+      [emptySelectionText]="'noMembersAdded' | i18n"
+    ></bit-access-selector>
+  </div>
 
-    <ng-container bitDialogFooter>
-      <button type="submit" bitButton bitFormButton buttonType="primary">
-        {{ "save" | i18n }}
-      </button>
-      <button type="button" bitButton bitFormButton buttonType="secondary" bitDialogClose>
-        {{ "cancel" | i18n }}
-      </button>
-    </ng-container>
-  </bit-dialog>
+  <ng-container bitDialogFooter>
+    <button type="submit" bitButton bitFormButton buttonType="primary">
+      {{ "save" | i18n }}
+    </button>
+    <button type="button" bitButton bitFormButton buttonType="secondary" bitDialogClose>
+      {{ "cancel" | i18n }}
+    </button>
+  </ng-container>
 </form>

--- a/apps/web/src/app/admin-console/organizations/manage/group-add-edit.component.html
+++ b/apps/web/src/app/admin-console/organizations/manage/group-add-edit.component.html
@@ -1,87 +1,83 @@
-<form [formGroup]="groupForm" [bitSubmit]="submit">
-  <bit-dialog dialogSize="large">
-    <span bitDialogTitle>
-      {{ title }}
-      <span *ngIf="editMode" class="tw-text-sm tw-normal-case tw-text-muted">{{
-        group?.name
-      }}</span>
-    </span>
-    <div bitDialogContent>
-      <div *ngIf="loading">
-        <i
-          class="bwi bwi-spinner bwi-spin tw-text-muted"
-          title="{{ 'loading' | i18n }}"
-          aria-hidden="true"
-        ></i>
-        <span class="tw-sr-only">{{ "loading" | i18n }}</span>
-      </div>
-
-      <bit-tab-group *ngIf="!loading" [(selectedIndex)]="tabIndex">
-        <bit-tab label="{{ 'groupInfo' | i18n }}">
-          <bit-form-field>
-            <bit-label>{{ "name" | i18n }}</bit-label>
-            <input bitInput appAutofocus type="text" formControlName="name" />
-            <bit-hint>{{ "characterMaximum" | i18n: 100 }}</bit-hint>
-          </bit-form-field>
-          <bit-form-field *ngIf="isExternalIdVisible">
-            <bit-label>{{ "externalId" | i18n }}</bit-label>
-            <input bitInput type="text" formControlName="externalId" />
-            <bit-hint>{{ "externalIdDesc" | i18n }}</bit-hint>
-          </bit-form-field>
-        </bit-tab>
-
-        <bit-tab label="{{ 'members' | i18n }}">
-          <p>
-            {{ "editGroupMembersDesc" | i18n }}
-            <span *ngIf="cannotAddSelfToGroup$ | async">
-              {{ "restrictedGroupAccessDesc" | i18n }}
-            </span>
-          </p>
-          <bit-access-selector
-            formControlName="members"
-            [items]="members"
-            [showMemberRoles]="true"
-            [permissionMode]="PermissionMode.Hidden"
-            [columnHeader]="'member' | i18n"
-            [selectorLabelText]="'selectMembers' | i18n"
-            [emptySelectionText]="'noMembersAdded' | i18n"
-          ></bit-access-selector>
-        </bit-tab>
-
-        <bit-tab label="{{ 'collections' | i18n }}">
-          <p>
-            {{ "editGroupCollectionsDesc" | i18n }}
-            <span *ngIf="!(canAssignAccessToAnyCollection$ | async)">
-              {{ "restrictedCollectionAssignmentDesc" | i18n }}
-            </span>
-          </p>
-          <bit-access-selector
-            formControlName="collections"
-            [items]="collections"
-            [permissionMode]="PermissionMode.Edit"
-            [columnHeader]="'collection' | i18n"
-            [selectorLabelText]="'selectCollections' | i18n"
-            [emptySelectionText]="'noCollectionsAdded' | i18n"
-          ></bit-access-selector>
-        </bit-tab>
-      </bit-tab-group>
+<form [formGroup]="groupForm" [bitSubmit]="submit" bit-dialog dialogSize="large">
+  <span bitDialogTitle>
+    {{ title }}
+    <span *ngIf="editMode" class="tw-text-sm tw-normal-case tw-text-muted">{{ group?.name }}</span>
+  </span>
+  <div bitDialogContent>
+    <div *ngIf="loading">
+      <i
+        class="bwi bwi-spinner bwi-spin tw-text-muted"
+        title="{{ 'loading' | i18n }}"
+        aria-hidden="true"
+      ></i>
+      <span class="tw-sr-only">{{ "loading" | i18n }}</span>
     </div>
-    <ng-container bitDialogFooter>
-      <button bitButton buttonType="primary" bitFormButton type="submit">
-        {{ "save" | i18n }}
-      </button>
-      <button bitButton buttonType="secondary" type="button" [bitDialogClose]="ResultType.Canceled">
-        {{ "cancel" | i18n }}
-      </button>
-      <button
-        class="tw-ml-auto"
-        type="button"
-        buttonType="dangerGhost"
-        bitIconButton="bwi-trash"
-        bitFormButton
-        [bitAction]="delete"
-        [label]="'delete' | i18n"
-      ></button>
-    </ng-container>
-  </bit-dialog>
+
+    <bit-tab-group *ngIf="!loading" [(selectedIndex)]="tabIndex">
+      <bit-tab label="{{ 'groupInfo' | i18n }}">
+        <bit-form-field>
+          <bit-label>{{ "name" | i18n }}</bit-label>
+          <input bitInput appAutofocus type="text" formControlName="name" />
+          <bit-hint>{{ "characterMaximum" | i18n: 100 }}</bit-hint>
+        </bit-form-field>
+        <bit-form-field *ngIf="isExternalIdVisible">
+          <bit-label>{{ "externalId" | i18n }}</bit-label>
+          <input bitInput type="text" formControlName="externalId" />
+          <bit-hint>{{ "externalIdDesc" | i18n }}</bit-hint>
+        </bit-form-field>
+      </bit-tab>
+
+      <bit-tab label="{{ 'members' | i18n }}">
+        <p>
+          {{ "editGroupMembersDesc" | i18n }}
+          <span *ngIf="cannotAddSelfToGroup$ | async">
+            {{ "restrictedGroupAccessDesc" | i18n }}
+          </span>
+        </p>
+        <bit-access-selector
+          formControlName="members"
+          [items]="members"
+          [showMemberRoles]="true"
+          [permissionMode]="PermissionMode.Hidden"
+          [columnHeader]="'member' | i18n"
+          [selectorLabelText]="'selectMembers' | i18n"
+          [emptySelectionText]="'noMembersAdded' | i18n"
+        ></bit-access-selector>
+      </bit-tab>
+
+      <bit-tab label="{{ 'collections' | i18n }}">
+        <p>
+          {{ "editGroupCollectionsDesc" | i18n }}
+          <span *ngIf="!(canAssignAccessToAnyCollection$ | async)">
+            {{ "restrictedCollectionAssignmentDesc" | i18n }}
+          </span>
+        </p>
+        <bit-access-selector
+          formControlName="collections"
+          [items]="collections"
+          [permissionMode]="PermissionMode.Edit"
+          [columnHeader]="'collection' | i18n"
+          [selectorLabelText]="'selectCollections' | i18n"
+          [emptySelectionText]="'noCollectionsAdded' | i18n"
+        ></bit-access-selector>
+      </bit-tab>
+    </bit-tab-group>
+  </div>
+  <ng-container bitDialogFooter>
+    <button bitButton buttonType="primary" bitFormButton type="submit">
+      {{ "save" | i18n }}
+    </button>
+    <button bitButton buttonType="secondary" type="button" [bitDialogClose]="ResultType.Canceled">
+      {{ "cancel" | i18n }}
+    </button>
+    <button
+      class="tw-ml-auto"
+      type="button"
+      buttonType="dangerGhost"
+      bitIconButton="bwi-trash"
+      bitFormButton
+      [bitAction]="delete"
+      [label]="'delete' | i18n"
+    ></button>
+  </ng-container>
 </form>

--- a/apps/web/src/app/admin-console/organizations/manage/user-confirm.component.html
+++ b/apps/web/src/app/admin-console/organizations/manage/user-confirm.component.html
@@ -1,36 +1,34 @@
-<form [formGroup]="formGroup" [bitSubmit]="submit">
-  <bit-dialog dialogSize="default">
-    <span bitDialogTitle>
-      {{ "confirmUser" | i18n }}
-      <span class="tw-text-muted" bitTypography="body1">{{ name }}</span>
-    </span>
-    <ng-container bitDialogContent>
-      <p bitTypography="body1">
-        {{ "fingerprintEnsureIntegrityVerify" | i18n }}
-        <a
-          bitLink
-          href="https://bitwarden.com/help/fingerprint-phrase/"
-          target="_blank"
-          rel="noreferrer"
-        >
-          {{ "learnMore" | i18n }}</a
-        >
-      </p>
-      <p bitTypography="body1">
-        <code>{{ fingerprint }}</code>
-      </p>
-      <bit-form-control>
-        <input type="checkbox" bitCheckbox formControlName="dontAskAgain" />
-        <bit-label>{{ "dontAskFingerprintAgain" | i18n }}</bit-label>
-      </bit-form-control>
-    </ng-container>
-    <ng-container bitDialogFooter>
-      <button bitButton bitFormButton type="submit" buttonType="primary">
-        {{ "confirm" | i18n }}
-      </button>
-      <button bitButton bitFormButton type="button" buttonType="secondary" bitDialogClose>
-        {{ "cancel" | i18n }}
-      </button>
-    </ng-container>
-  </bit-dialog>
+<form [formGroup]="formGroup" [bitSubmit]="submit" bit-dialog dialogSize="default">
+  <span bitDialogTitle>
+    {{ "confirmUser" | i18n }}
+    <span class="tw-text-muted" bitTypography="body1">{{ name }}</span>
+  </span>
+  <ng-container bitDialogContent>
+    <p bitTypography="body1">
+      {{ "fingerprintEnsureIntegrityVerify" | i18n }}
+      <a
+        bitLink
+        href="https://bitwarden.com/help/fingerprint-phrase/"
+        target="_blank"
+        rel="noreferrer"
+      >
+        {{ "learnMore" | i18n }}</a
+      >
+    </p>
+    <p bitTypography="body1">
+      <code>{{ fingerprint }}</code>
+    </p>
+    <bit-form-control>
+      <input type="checkbox" bitCheckbox formControlName="dontAskAgain" />
+      <bit-label>{{ "dontAskFingerprintAgain" | i18n }}</bit-label>
+    </bit-form-control>
+  </ng-container>
+  <ng-container bitDialogFooter>
+    <button bitButton bitFormButton type="submit" buttonType="primary">
+      {{ "confirm" | i18n }}
+    </button>
+    <button bitButton bitFormButton type="button" buttonType="secondary" bitDialogClose>
+      {{ "cancel" | i18n }}
+    </button>
+  </ng-container>
 </form>

--- a/apps/web/src/app/admin-console/organizations/members/components/invite-members-dialog/invite-members-dialog.component.html
+++ b/apps/web/src/app/admin-console/organizations/members/components/invite-members-dialog/invite-members-dialog.component.html
@@ -1,210 +1,206 @@
 @let organization = organization$ | async;
-<form [formGroup]="formGroup" [bitSubmit]="submit">
-  <bit-dialog dialogSize="large">
-    <span bitDialogTitle>{{ "inviteMembers" | i18n }}</span>
-    <div bitDialogContent>
-      @if (organization.useInviteLinks) {
-        <bit-tab-group
-          [selectedIndex]="selectedTabIndex()"
-          (selectedIndexChange)="selectedTabIndex.set($event)"
-        >
-          <bit-tab [label]="'byEmail' | i18n">
-            <ng-container
-              *ngTemplateOutlet="byEmailForm; context: { organization: organization }"
-            ></ng-container>
-          </bit-tab>
-          <bit-tab [label]="'byLink' | i18n">
-            <app-by-link-tab [organizationId]="params.organizationId" />
-          </bit-tab>
-        </bit-tab-group>
-      } @else {
-        <ng-container
-          *ngTemplateOutlet="byEmailForm; context: { organization: organization }"
-        ></ng-container>
-      }
-    </div>
-    <ng-container bitDialogFooter>
-      @if (selectedTabIndex() === 0) {
-        <button
-          type="submit"
-          bitButton
-          bitFormButton
-          buttonType="primary"
-          [disabled]="formGroup.controls.emails.invalid"
-        >
-          {{ "invite" | i18n }}
-        </button>
-      } @else {
-        <button
-          type="button"
-          bitButton
-          buttonType="primary"
-          [bitAction]="copyLink"
-          [disabled]="byLinkTabDirty() || !(byLinkTabHasUrl$ | async)"
-        >
-          {{ "copyLink" | i18n }}
-        </button>
-      }
-      <button type="button" bitButton buttonType="secondary" (click)="cancel()">
-        {{ "cancel" | i18n }}
+<form [formGroup]="formGroup" [bitSubmit]="submit" bit-dialog dialogSize="large">
+  <span bitDialogTitle>{{ "inviteMembers" | i18n }}</span>
+  <div bitDialogContent>
+    @if (organization.useInviteLinks) {
+      <bit-tab-group
+        [selectedIndex]="selectedTabIndex()"
+        (selectedIndexChange)="selectedTabIndex.set($event)"
+      >
+        <bit-tab [label]="'byEmail' | i18n">
+          <ng-container
+            *ngTemplateOutlet="byEmailForm; context: { organization: organization }"
+          ></ng-container>
+        </bit-tab>
+        <bit-tab [label]="'byLink' | i18n">
+          <app-by-link-tab [organizationId]="params.organizationId" />
+        </bit-tab>
+      </bit-tab-group>
+    } @else {
+      <ng-container
+        *ngTemplateOutlet="byEmailForm; context: { organization: organization }"
+      ></ng-container>
+    }
+  </div>
+  <ng-container bitDialogFooter>
+    @if (selectedTabIndex() === 0) {
+      <button
+        type="submit"
+        bitButton
+        bitFormButton
+        buttonType="primary"
+        [disabled]="formGroup.controls.emails.invalid"
+      >
+        {{ "invite" | i18n }}
       </button>
-    </ng-container>
+    } @else {
+      <button
+        type="button"
+        bitButton
+        buttonType="primary"
+        [bitAction]="copyLink"
+        [disabled]="byLinkTabDirty() || !(byLinkTabHasUrl$ | async)"
+      >
+        {{ "copyLink" | i18n }}
+      </button>
+    }
+    <button type="button" bitButton buttonType="secondary" (click)="cancel()">
+      {{ "cancel" | i18n }}
+    </button>
+  </ng-container>
 
-    <ng-template #byEmailForm let-organization="organization">
-      <p bitTypography="body1">{{ "inviteUserDesc" | i18n }}</p>
-      @if (
-        {
-          remainingSeats: remainingSeats$ | async,
-          batchLimit: emailBatchLimit$ | async,
-          isDynamicSeatPlan: isDynamicSeatPlan$ | async,
-        };
-        as inviteInfo
-      ) {
-        <bit-form-field>
-          <bit-label>{{ "email" | i18n }}</bit-label>
-          <input id="emails" type="text" appAutoFocus bitInput formControlName="emails" />
-          @if (inviteInfo.isDynamicSeatPlan) {
-            <bit-hint>{{
-              "inviteMultipleEmailsNoSeatLimit" | i18n: inviteInfo.batchLimit
-            }}</bit-hint>
-          }
-          @if (!inviteInfo.isDynamicSeatPlan && inviteInfo.remainingSeats > 1) {
-            <bit-hint>{{
-              "inviteMultipleEmailsWithSeatLimit"
-                | i18n: inviteInfo.batchLimit : inviteInfo.remainingSeats
-            }}</bit-hint>
-          }
-          @if (!inviteInfo.isDynamicSeatPlan && inviteInfo.remainingSeats === 1) {
-            <bit-hint>{{ "inviteSingleEmailDesc" | i18n }}</bit-hint>
-          }
-          @if (!inviteInfo.isDynamicSeatPlan && inviteInfo.remainingSeats <= 0) {
-            <bit-hint>{{ "inviteZeroEmailDesc" | i18n }}</bit-hint>
-          }
-        </bit-form-field>
-      }
+  <ng-template #byEmailForm let-organization="organization">
+    <p bitTypography="body1">{{ "inviteUserDesc" | i18n }}</p>
+    @if (
+      {
+        remainingSeats: remainingSeats$ | async,
+        batchLimit: emailBatchLimit$ | async,
+        isDynamicSeatPlan: isDynamicSeatPlan$ | async,
+      };
+      as inviteInfo
+    ) {
       <bit-form-field>
-        <bit-label>
-          {{ "memberRole" | i18n }}
+        <bit-label>{{ "email" | i18n }}</bit-label>
+        <input id="emails" type="text" appAutoFocus bitInput formControlName="emails" />
+        @if (inviteInfo.isDynamicSeatPlan) {
+          <bit-hint>{{ "inviteMultipleEmailsNoSeatLimit" | i18n: inviteInfo.batchLimit }}</bit-hint>
+        }
+        @if (!inviteInfo.isDynamicSeatPlan && inviteInfo.remainingSeats > 1) {
+          <bit-hint>{{
+            "inviteMultipleEmailsWithSeatLimit"
+              | i18n: inviteInfo.batchLimit : inviteInfo.remainingSeats
+          }}</bit-hint>
+        }
+        @if (!inviteInfo.isDynamicSeatPlan && inviteInfo.remainingSeats === 1) {
+          <bit-hint>{{ "inviteSingleEmailDesc" | i18n }}</bit-hint>
+        }
+        @if (!inviteInfo.isDynamicSeatPlan && inviteInfo.remainingSeats <= 0) {
+          <bit-hint>{{ "inviteZeroEmailDesc" | i18n }}</bit-hint>
+        }
+      </bit-form-field>
+    }
+    <bit-form-field>
+      <bit-label>
+        {{ "memberRole" | i18n }}
+        <a
+          bitLink
+          target="_blank"
+          rel="noreferrer"
+          appA11yTitle="{{ 'learnMoreAboutMemberRoles' | i18n }}"
+          href="https://bitwarden.com/help/user-types-access-control/"
+          slot="end"
+          startIcon="bwi-question-circle"
+        ></a>
+      </bit-label>
+      <bit-select formControlName="type" data-testid="role">
+        <bit-option [value]="organizationUserType.User" [label]="'user' | i18n"></bit-option>
+        <bit-option [value]="organizationUserType.Admin" [label]="'admin' | i18n"></bit-option>
+        <bit-option [value]="organizationUserType.Owner" [label]="'owner' | i18n"></bit-option>
+        <bit-option
+          [value]="organizationUserType.Custom"
+          [label]="'custom' | i18n"
+          [disabled]="!organization.useCustomPermissions"
+        ></bit-option>
+      </bit-select>
+    </bit-form-field>
+
+    @if (customUserTypeSelected()) {
+      <div class="tw-grid tw-grid-cols-12 tw-gap-4" [formGroup]="permissionsGroup">
+        <div class="tw-col-span-4">
+          <bit-form-control>
+            <input type="checkbox" bitCheckbox formControlName="accessEventLogs" />
+            <bit-label>{{ "accessEventLogs" | i18n }}</bit-label>
+          </bit-form-control>
+          <bit-form-control>
+            <input type="checkbox" bitCheckbox formControlName="accessImportExport" />
+            <bit-label>{{ "accessImportExport" | i18n }}</bit-label>
+          </bit-form-control>
+          <bit-form-control>
+            <input type="checkbox" bitCheckbox formControlName="accessReports" />
+            <bit-label>{{ "accessReports" | i18n }}</bit-label>
+          </bit-form-control>
+        </div>
+        <div class="tw-col-span-4">
+          <div class="tw-mb-3">
+            <bit-form-control>
+              <input type="checkbox" bitCheckbox formControlName="manageGroups" />
+              <bit-label>{{ "manageGroups" | i18n }}</bit-label>
+            </bit-form-control>
+            <bit-form-control>
+              <input type="checkbox" bitCheckbox formControlName="manageSso" />
+              <bit-label>{{ "manageSso" | i18n }}</bit-label>
+            </bit-form-control>
+            <bit-form-control>
+              <input type="checkbox" bitCheckbox formControlName="managePolicies" />
+              <bit-label>{{ "managePolicies" | i18n }}</bit-label>
+            </bit-form-control>
+            <bit-form-control>
+              <input id="manageUsers" type="checkbox" bitCheckbox formControlName="manageUsers" />
+              <bit-label>{{ "manageUsers" | i18n }}</bit-label>
+            </bit-form-control>
+            <bit-form-control>
+              <input type="checkbox" bitCheckbox formControlName="manageResetPassword" />
+              <bit-label>{{ "manageAccountRecovery" | i18n }}</bit-label>
+            </bit-form-control>
+          </div>
+        </div>
+      </div>
+    }
+    @if (organization.useSecretsManager) {
+      <bit-form-control>
+        <div class="tw-flex tw-flex-row tw-gap-2 tw-items-center">
+          <input
+            type="checkbox"
+            [disabled]="isOnSecretsManagerStandalone"
+            bitCheckbox
+            formControlName="accessSecretsManager"
+          />
+          <bit-label>
+            {{ "grantSecretsManager" | i18n }}
+          </bit-label>
           <a
             bitLink
             target="_blank"
             rel="noreferrer"
-            appA11yTitle="{{ 'learnMoreAboutMemberRoles' | i18n }}"
-            href="https://bitwarden.com/help/user-types-access-control/"
-            slot="end"
-            startIcon="bwi-question-circle"
-          ></a>
-        </bit-label>
-        <bit-select formControlName="type" data-testid="role">
-          <bit-option [value]="organizationUserType.User" [label]="'user' | i18n"></bit-option>
-          <bit-option [value]="organizationUserType.Admin" [label]="'admin' | i18n"></bit-option>
-          <bit-option [value]="organizationUserType.Owner" [label]="'owner' | i18n"></bit-option>
-          <bit-option
-            [value]="organizationUserType.Custom"
-            [label]="'custom' | i18n"
-            [disabled]="!organization.useCustomPermissions"
-          ></bit-option>
-        </bit-select>
-      </bit-form-field>
-
-      @if (customUserTypeSelected()) {
-        <div class="tw-grid tw-grid-cols-12 tw-gap-4" [formGroup]="permissionsGroup">
-          <div class="tw-col-span-4">
-            <bit-form-control>
-              <input type="checkbox" bitCheckbox formControlName="accessEventLogs" />
-              <bit-label>{{ "accessEventLogs" | i18n }}</bit-label>
-            </bit-form-control>
-            <bit-form-control>
-              <input type="checkbox" bitCheckbox formControlName="accessImportExport" />
-              <bit-label>{{ "accessImportExport" | i18n }}</bit-label>
-            </bit-form-control>
-            <bit-form-control>
-              <input type="checkbox" bitCheckbox formControlName="accessReports" />
-              <bit-label>{{ "accessReports" | i18n }}</bit-label>
-            </bit-form-control>
-          </div>
-          <div class="tw-col-span-4">
-            <div class="tw-mb-3">
-              <bit-form-control>
-                <input type="checkbox" bitCheckbox formControlName="manageGroups" />
-                <bit-label>{{ "manageGroups" | i18n }}</bit-label>
-              </bit-form-control>
-              <bit-form-control>
-                <input type="checkbox" bitCheckbox formControlName="manageSso" />
-                <bit-label>{{ "manageSso" | i18n }}</bit-label>
-              </bit-form-control>
-              <bit-form-control>
-                <input type="checkbox" bitCheckbox formControlName="managePolicies" />
-                <bit-label>{{ "managePolicies" | i18n }}</bit-label>
-              </bit-form-control>
-              <bit-form-control>
-                <input id="manageUsers" type="checkbox" bitCheckbox formControlName="manageUsers" />
-                <bit-label>{{ "manageUsers" | i18n }}</bit-label>
-              </bit-form-control>
-              <bit-form-control>
-                <input type="checkbox" bitCheckbox formControlName="manageResetPassword" />
-                <bit-label>{{ "manageAccountRecovery" | i18n }}</bit-label>
-              </bit-form-control>
-            </div>
-          </div>
+            appA11yTitle="{{ 'learnMore' | i18n }}"
+            href="https://bitwarden.com/help/manage-your-organization/#access-to-secrets-manager"
+          >
+            <bit-icon name="bwi-question-circle" slot="end"> </bit-icon>
+          </a>
         </div>
-      }
-      @if (organization.useSecretsManager) {
-        <bit-form-control>
-          <div class="tw-flex tw-flex-row tw-gap-2 tw-items-center">
-            <input
-              type="checkbox"
-              [disabled]="isOnSecretsManagerStandalone"
-              bitCheckbox
-              formControlName="accessSecretsManager"
-            />
-            <bit-label>
-              {{ "grantSecretsManager" | i18n }}
-            </bit-label>
-            <a
-              bitLink
-              target="_blank"
-              rel="noreferrer"
-              appA11yTitle="{{ 'learnMore' | i18n }}"
-              href="https://bitwarden.com/help/manage-your-organization/#access-to-secrets-manager"
-            >
-              <bit-icon name="bwi-question-circle" slot="end"> </bit-icon>
-            </a>
-          </div>
-        </bit-form-control>
-      }
-      <button
-        type="button"
-        bitButton
-        buttonType="primaryGhost"
-        class="tw-mb-4 tw-block"
-        [bitDisclosureTriggerFor]="moreSettingsRef"
-      >
-        {{ "moreSettings" | i18n }}
-        <bit-icon [name]="moreSettingsOpen() ? 'bwi-angle-up' : 'bwi-angle-down'"> </bit-icon>
-      </button>
-      <bit-disclosure #moreSettingsRef [(open)]="moreSettingsOpen">
-        @if (organization.useGroups) {
-          <bit-access-selector
-            formControlName="groups"
-            [items]="(groupAccessItems$ | async) ?? []"
-            [columnHeader]="'groups' | i18n"
-            [selectorLabelText]="'groups' | i18n"
-            [hideTable]="true"
-            multiSelectTestId="groups"
-          ></bit-access-selector>
-        }
+      </bit-form-control>
+    }
+    <button
+      type="button"
+      bitButton
+      buttonType="primaryGhost"
+      class="tw-mb-4 tw-block"
+      [bitDisclosureTriggerFor]="moreSettingsRef"
+    >
+      {{ "moreSettings" | i18n }}
+      <bit-icon [name]="moreSettingsOpen() ? 'bwi-angle-up' : 'bwi-angle-down'"> </bit-icon>
+    </button>
+    <bit-disclosure #moreSettingsRef [(open)]="moreSettingsOpen">
+      @if (organization.useGroups) {
         <bit-access-selector
-          [permissionMode]="PermissionMode.Edit"
-          formControlName="access"
-          [showGroupColumn]="organization.useGroups"
-          [items]="(collectionAccessItems$ | async) ?? []"
-          [columnHeader]="'collection' | i18n"
-          [selectorLabelText]="'collections' | i18n"
-          [emptySelectionText]="'noCollectionsAdded' | i18n"
-          multiSelectTestId="collections"
+          formControlName="groups"
+          [items]="(groupAccessItems$ | async) ?? []"
+          [columnHeader]="'groups' | i18n"
+          [selectorLabelText]="'groups' | i18n"
+          [hideTable]="true"
+          multiSelectTestId="groups"
         ></bit-access-selector>
-      </bit-disclosure>
-    </ng-template>
-  </bit-dialog>
+      }
+      <bit-access-selector
+        [permissionMode]="PermissionMode.Edit"
+        formControlName="access"
+        [showGroupColumn]="organization.useGroups"
+        [items]="(collectionAccessItems$ | async) ?? []"
+        [columnHeader]="'collection' | i18n"
+        [selectorLabelText]="'collections' | i18n"
+        [emptySelectionText]="'noCollectionsAdded' | i18n"
+        multiSelectTestId="collections"
+      ></bit-access-selector>
+    </bit-disclosure>
+  </ng-template>
 </form>

--- a/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.html
+++ b/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.html
@@ -1,326 +1,322 @@
-<form [formGroup]="formGroup" [bitSubmit]="submit">
-  <bit-dialog dialogSize="large">
-    <span bitDialogTitle>
-      {{ title }}
-      @if (!loading && editParams$ && (editParams$ | async)?.name) {
-        <span class="tw-text-sm tw-normal-case tw-text-muted">{{
-          (editParams$ | async)?.name
-        }}</span>
-      }
-      @if (isRevoked) {
-        <span bitBadge variant="secondary">{{ "revoked" | i18n }}</span>
-      }
-    </span>
-    <div bitDialogContent>
-      @if (loading) {
-        <i
-          class="bwi bwi-spinner bwi-spin tw-text-muted"
-          title="{{ 'loading' | i18n }}"
-          aria-hidden="true"
-        ></i>
-        <span class="tw-sr-only">{{ "loading" | i18n }}</span>
-      }
-      @if (!loading && organization$ | async; as organization) {
-        <bit-tab-group [(selectedIndex)]="tabIndex">
-          <bit-tab [label]="'role' | i18n">
-            @if (!editMode) {
-              <p bitTypography="body1">{{ "inviteUserDesc" | i18n }}</p>
-              @if (
-                {
-                  remainingSeats: remainingSeats$ | async,
-                  batchLimit: emailBatchLimit$ | async,
-                  isDynamicSeatPlan: isDynamicSeatPlan$ | async,
-                };
-                as inviteInfo
-              ) {
-                <bit-form-field>
-                  <bit-label>{{ "email" | i18n }}</bit-label>
-                  <input id="emails" type="text" appAutoFocus bitInput formControlName="emails" />
-                  @if (inviteInfo.isDynamicSeatPlan) {
-                    <bit-hint>{{
-                      "inviteMultipleEmailsNoSeatLimit" | i18n: inviteInfo.batchLimit
-                    }}</bit-hint>
-                  }
-                  @if (!inviteInfo.isDynamicSeatPlan && inviteInfo.remainingSeats > 1) {
-                    <bit-hint>{{
-                      "inviteMultipleEmailsWithSeatLimit"
-                        | i18n: inviteInfo.batchLimit : inviteInfo.remainingSeats
-                    }}</bit-hint>
-                  }
-                  @if (!inviteInfo.isDynamicSeatPlan && inviteInfo.remainingSeats === 1) {
-                    <bit-hint>{{ "inviteSingleEmailDesc" | i18n }}</bit-hint>
-                  }
-                  @if (!inviteInfo.isDynamicSeatPlan && inviteInfo.remainingSeats <= 0) {
-                    <bit-hint>{{ "inviteZeroEmailDesc" | i18n }}</bit-hint>
-                  }
-                </bit-form-field>
-              }
-            }
-            <bit-radio-group formControlName="type">
-              <bit-label>
-                {{ "memberRole" | i18n }}
-                <a
-                  bitLink
-                  target="_blank"
-                  rel="noreferrer"
-                  appA11yTitle="{{ 'learnMoreAboutMemberRoles' | i18n }}"
-                  href="https://bitwarden.com/help/user-types-access-control/"
-                  slot="end"
-                >
-                  <i class="bwi bwi-question-circle" aria-hidden="true"></i>
-                </a>
-              </bit-label>
-              <bit-radio-button id="userTypeUser" [value]="organizationUserType.User">
-                <bit-label>{{ "user" | i18n }}</bit-label>
-                <bit-hint>{{ "userDesc" | i18n }}</bit-hint>
-              </bit-radio-button>
-              <bit-radio-button id="userTypeAdmin" [value]="organizationUserType.Admin">
-                <bit-label>{{ "admin" | i18n }}</bit-label>
-                <bit-hint>{{ "adminDesc" | i18n }}</bit-hint>
-              </bit-radio-button>
-              <bit-radio-button id="userTypeOwner" [value]="organizationUserType.Owner">
-                <bit-label>{{ "owner" | i18n }}</bit-label>
-                <bit-hint>{{ "ownerDesc" | i18n }}</bit-hint>
-              </bit-radio-button>
-              <bit-radio-button
-                id="userTypeCustom"
-                [value]="organizationUserType.Custom"
-                [disabled]="!organization.useCustomPermissions || null"
-              >
-                <bit-label>{{ "custom" | i18n }}</bit-label>
-                <bit-hint>
-                  @if (!organization.useCustomPermissions) {
-                    <p>
-                      {{ "customDescNonEnterpriseStart" | i18n
-                      }}<a
-                        bitLink
-                        href="https://bitwarden.com/contact/"
-                        target="_blank"
-                        rel="noreferrer"
-                        >{{ "customDescNonEnterpriseLink" | i18n }}</a
-                      >{{ "customDescNonEnterpriseEnd" | i18n }}
-                    </p>
-                  } @else {
-                    <p>{{ "customDesc" | i18n }}</p>
-                  }
-                </bit-hint>
-              </bit-radio-button>
-            </bit-radio-group>
-            @if (customUserTypeSelected) {
-              <div class="tw-grid tw-grid-cols-12 tw-gap-4" [formGroup]="permissionsGroup">
-                <div class="tw-col-span-4">
-                  <bit-form-control>
-                    <input type="checkbox" bitCheckbox formControlName="accessEventLogs" />
-                    <bit-label>{{ "accessEventLogs" | i18n }}</bit-label>
-                  </bit-form-control>
-                  <bit-form-control>
-                    <input type="checkbox" bitCheckbox formControlName="accessImportExport" />
-                    <bit-label>{{ "accessImportExport" | i18n }}</bit-label>
-                  </bit-form-control>
-                  <bit-form-control>
-                    <input type="checkbox" bitCheckbox formControlName="accessReports" />
-                    <bit-label>{{ "accessReports" | i18n }}</bit-label>
-                  </bit-form-control>
-                </div>
-                <div class="tw-col-span-4">
-                  <app-nested-checkbox
-                    parentId="manageAllCollections"
-                    [checkboxes]="permissionsGroup.controls.manageAllCollectionsGroup"
-                  >
-                  </app-nested-checkbox>
-                </div>
-                <div class="tw-col-span-4">
-                  <div class="tw-mb-3">
-                    <bit-form-control>
-                      <input type="checkbox" bitCheckbox formControlName="manageGroups" />
-                      <bit-label>{{ "manageGroups" | i18n }}</bit-label>
-                    </bit-form-control>
-                    <bit-form-control>
-                      <input type="checkbox" bitCheckbox formControlName="manageSso" />
-                      <bit-label>{{ "manageSso" | i18n }}</bit-label>
-                    </bit-form-control>
-                    <bit-form-control>
-                      <input type="checkbox" bitCheckbox formControlName="managePolicies" />
-                      <bit-label>{{ "managePolicies" | i18n }}</bit-label>
-                    </bit-form-control>
-                    <bit-form-control>
-                      <input
-                        id="manageUsers"
-                        type="checkbox"
-                        bitCheckbox
-                        formControlName="manageUsers"
-                      />
-                      <bit-label>{{ "manageUsers" | i18n }}</bit-label>
-                    </bit-form-control>
-                    <bit-form-control>
-                      <input type="checkbox" bitCheckbox formControlName="manageResetPassword" />
-                      <bit-label>{{ "manageAccountRecovery" | i18n }}</bit-label>
-                    </bit-form-control>
-                  </div>
-                </div>
-              </div>
-            }
-            @if (organization.useSecretsManager) {
-              <h3 class="tw-mt-4">
-                {{ "secretsManager" | i18n }}
-                <a
-                  bitLink
-                  target="_blank"
-                  rel="noreferrer"
-                  appA11yTitle="{{ 'learnMore' | i18n }}"
-                  href="https://bitwarden.com/help/manage-your-organization/#access-to-secrets-manager"
-                >
-                  <i class="bwi bwi-question-circle" aria-hidden="true"></i>
-                </a>
-              </h3>
-              <p class="tw-text-muted">{{ "secretsManagerAccessDescription" | i18n }}</p>
-              <bit-form-control>
-                <input
-                  type="checkbox"
-                  [disabled]="isOnSecretsManagerStandalone"
-                  bitCheckbox
-                  formControlName="accessSecretsManager"
-                />
-                <bit-label>
-                  {{ "userAccessSecretsManagerGA" | i18n }}
-                </bit-label>
-              </bit-form-control>
-            }
-            @if (isExternalIdVisible) {
-              <bit-form-field>
-                <bit-label>{{ "externalId" | i18n }}</bit-label>
-                <input bitInput type="text" formControlName="externalId" />
-                <bit-hint>{{ "externalIdDesc" | i18n }}</bit-hint>
-              </bit-form-field>
-            }
-            @if (isSsoExternalIdVisible) {
-              <bit-form-field>
-                <bit-label>{{ "ssoExternalId" | i18n }}</bit-label>
-                <input bitInput type="text" formControlName="ssoExternalId" />
-                <bit-hint>{{ "ssoExternalIdDesc" | i18n }}</bit-hint>
-              </bit-form-field>
-            }
-          </bit-tab>
-          @if (organization.useGroups) {
-            <bit-tab [label]="'groups' | i18n">
-              <div class="tw-mb-6">
-                {{
-                  (restrictEditingSelf$ | async)
-                    ? ("restrictedGroupAccess" | i18n)
-                    : ("groupAccessUserDesc" | i18n)
-                }}
-              </div>
-              <bit-access-selector
-                formControlName="groups"
-                [items]="groupAccessItems"
-                [columnHeader]="'groups' | i18n"
-                [selectorLabelText]="'selectGroups' | i18n"
-                [emptySelectionText]="'noGroupsAdded' | i18n"
-                [hideMultiSelect]="restrictEditingSelf$ | async"
-              ></bit-access-selector>
-            </bit-tab>
-          }
-          <bit-tab [label]="'collections' | i18n">
-            @if (restrictEditingSelf$ | async) {
-              <div class="tw-mb-6">
-                {{ "cannotAddYourselfToCollections" | i18n }}
-              </div>
-            }
+<form [formGroup]="formGroup" [bitSubmit]="submit" bit-dialog dialogSize="large">
+  <span bitDialogTitle>
+    {{ title }}
+    @if (!loading && editParams$ && (editParams$ | async)?.name) {
+      <span class="tw-text-sm tw-normal-case tw-text-muted">{{ (editParams$ | async)?.name }}</span>
+    }
+    @if (isRevoked) {
+      <span bitBadge variant="secondary">{{ "revoked" | i18n }}</span>
+    }
+  </span>
+  <div bitDialogContent>
+    @if (loading) {
+      <i
+        class="bwi bwi-spinner bwi-spin tw-text-muted"
+        title="{{ 'loading' | i18n }}"
+        aria-hidden="true"
+      ></i>
+      <span class="tw-sr-only">{{ "loading" | i18n }}</span>
+    }
+    @if (!loading && organization$ | async; as organization) {
+      <bit-tab-group [(selectedIndex)]="tabIndex">
+        <bit-tab [label]="'role' | i18n">
+          @if (!editMode) {
+            <p bitTypography="body1">{{ "inviteUserDesc" | i18n }}</p>
             @if (
-              !(restrictEditingSelf$ | async) &&
-              (organization.useGroups || !(canAssignAccessToAnyCollection$ | async))
+              {
+                remainingSeats: remainingSeats$ | async,
+                batchLimit: emailBatchLimit$ | async,
+                isDynamicSeatPlan: isDynamicSeatPlan$ | async,
+              };
+              as inviteInfo
             ) {
-              <div class="tw-mb-6">
-                @if (organization.useGroups) {
-                  <span>
-                    {{ "userPermissionOverrideHelperDesc" | i18n }}
-                  </span>
+              <bit-form-field>
+                <bit-label>{{ "email" | i18n }}</bit-label>
+                <input id="emails" type="text" appAutoFocus bitInput formControlName="emails" />
+                @if (inviteInfo.isDynamicSeatPlan) {
+                  <bit-hint>{{
+                    "inviteMultipleEmailsNoSeatLimit" | i18n: inviteInfo.batchLimit
+                  }}</bit-hint>
                 }
-                @if (!(canAssignAccessToAnyCollection$ | async)) {
-                  <span>
-                    {{ "restrictedCollectionAssignmentDesc" | i18n }}
-                  </span>
+                @if (!inviteInfo.isDynamicSeatPlan && inviteInfo.remainingSeats > 1) {
+                  <bit-hint>{{
+                    "inviteMultipleEmailsWithSeatLimit"
+                      | i18n: inviteInfo.batchLimit : inviteInfo.remainingSeats
+                  }}</bit-hint>
                 }
-              </div>
+                @if (!inviteInfo.isDynamicSeatPlan && inviteInfo.remainingSeats === 1) {
+                  <bit-hint>{{ "inviteSingleEmailDesc" | i18n }}</bit-hint>
+                }
+                @if (!inviteInfo.isDynamicSeatPlan && inviteInfo.remainingSeats <= 0) {
+                  <bit-hint>{{ "inviteZeroEmailDesc" | i18n }}</bit-hint>
+                }
+              </bit-form-field>
             }
+          }
+          <bit-radio-group formControlName="type">
+            <bit-label>
+              {{ "memberRole" | i18n }}
+              <a
+                bitLink
+                target="_blank"
+                rel="noreferrer"
+                appA11yTitle="{{ 'learnMoreAboutMemberRoles' | i18n }}"
+                href="https://bitwarden.com/help/user-types-access-control/"
+                slot="end"
+              >
+                <i class="bwi bwi-question-circle" aria-hidden="true"></i>
+              </a>
+            </bit-label>
+            <bit-radio-button id="userTypeUser" [value]="organizationUserType.User">
+              <bit-label>{{ "user" | i18n }}</bit-label>
+              <bit-hint>{{ "userDesc" | i18n }}</bit-hint>
+            </bit-radio-button>
+            <bit-radio-button id="userTypeAdmin" [value]="organizationUserType.Admin">
+              <bit-label>{{ "admin" | i18n }}</bit-label>
+              <bit-hint>{{ "adminDesc" | i18n }}</bit-hint>
+            </bit-radio-button>
+            <bit-radio-button id="userTypeOwner" [value]="organizationUserType.Owner">
+              <bit-label>{{ "owner" | i18n }}</bit-label>
+              <bit-hint>{{ "ownerDesc" | i18n }}</bit-hint>
+            </bit-radio-button>
+            <bit-radio-button
+              id="userTypeCustom"
+              [value]="organizationUserType.Custom"
+              [disabled]="!organization.useCustomPermissions || null"
+            >
+              <bit-label>{{ "custom" | i18n }}</bit-label>
+              <bit-hint>
+                @if (!organization.useCustomPermissions) {
+                  <p>
+                    {{ "customDescNonEnterpriseStart" | i18n
+                    }}<a
+                      bitLink
+                      href="https://bitwarden.com/contact/"
+                      target="_blank"
+                      rel="noreferrer"
+                      >{{ "customDescNonEnterpriseLink" | i18n }}</a
+                    >{{ "customDescNonEnterpriseEnd" | i18n }}
+                  </p>
+                } @else {
+                  <p>{{ "customDesc" | i18n }}</p>
+                }
+              </bit-hint>
+            </bit-radio-button>
+          </bit-radio-group>
+          @if (customUserTypeSelected) {
+            <div class="tw-grid tw-grid-cols-12 tw-gap-4" [formGroup]="permissionsGroup">
+              <div class="tw-col-span-4">
+                <bit-form-control>
+                  <input type="checkbox" bitCheckbox formControlName="accessEventLogs" />
+                  <bit-label>{{ "accessEventLogs" | i18n }}</bit-label>
+                </bit-form-control>
+                <bit-form-control>
+                  <input type="checkbox" bitCheckbox formControlName="accessImportExport" />
+                  <bit-label>{{ "accessImportExport" | i18n }}</bit-label>
+                </bit-form-control>
+                <bit-form-control>
+                  <input type="checkbox" bitCheckbox formControlName="accessReports" />
+                  <bit-label>{{ "accessReports" | i18n }}</bit-label>
+                </bit-form-control>
+              </div>
+              <div class="tw-col-span-4">
+                <app-nested-checkbox
+                  parentId="manageAllCollections"
+                  [checkboxes]="permissionsGroup.controls.manageAllCollectionsGroup"
+                >
+                </app-nested-checkbox>
+              </div>
+              <div class="tw-col-span-4">
+                <div class="tw-mb-3">
+                  <bit-form-control>
+                    <input type="checkbox" bitCheckbox formControlName="manageGroups" />
+                    <bit-label>{{ "manageGroups" | i18n }}</bit-label>
+                  </bit-form-control>
+                  <bit-form-control>
+                    <input type="checkbox" bitCheckbox formControlName="manageSso" />
+                    <bit-label>{{ "manageSso" | i18n }}</bit-label>
+                  </bit-form-control>
+                  <bit-form-control>
+                    <input type="checkbox" bitCheckbox formControlName="managePolicies" />
+                    <bit-label>{{ "managePolicies" | i18n }}</bit-label>
+                  </bit-form-control>
+                  <bit-form-control>
+                    <input
+                      id="manageUsers"
+                      type="checkbox"
+                      bitCheckbox
+                      formControlName="manageUsers"
+                    />
+                    <bit-label>{{ "manageUsers" | i18n }}</bit-label>
+                  </bit-form-control>
+                  <bit-form-control>
+                    <input type="checkbox" bitCheckbox formControlName="manageResetPassword" />
+                    <bit-label>{{ "manageAccountRecovery" | i18n }}</bit-label>
+                  </bit-form-control>
+                </div>
+              </div>
+            </div>
+          }
+          @if (organization.useSecretsManager) {
+            <h3 class="tw-mt-4">
+              {{ "secretsManager" | i18n }}
+              <a
+                bitLink
+                target="_blank"
+                rel="noreferrer"
+                appA11yTitle="{{ 'learnMore' | i18n }}"
+                href="https://bitwarden.com/help/manage-your-organization/#access-to-secrets-manager"
+              >
+                <i class="bwi bwi-question-circle" aria-hidden="true"></i>
+              </a>
+            </h3>
+            <p class="tw-text-muted">{{ "secretsManagerAccessDescription" | i18n }}</p>
+            <bit-form-control>
+              <input
+                type="checkbox"
+                [disabled]="isOnSecretsManagerStandalone"
+                bitCheckbox
+                formControlName="accessSecretsManager"
+              />
+              <bit-label>
+                {{ "userAccessSecretsManagerGA" | i18n }}
+              </bit-label>
+            </bit-form-control>
+          }
+          @if (isExternalIdVisible) {
+            <bit-form-field>
+              <bit-label>{{ "externalId" | i18n }}</bit-label>
+              <input bitInput type="text" formControlName="externalId" />
+              <bit-hint>{{ "externalIdDesc" | i18n }}</bit-hint>
+            </bit-form-field>
+          }
+          @if (isSsoExternalIdVisible) {
+            <bit-form-field>
+              <bit-label>{{ "ssoExternalId" | i18n }}</bit-label>
+              <input bitInput type="text" formControlName="ssoExternalId" />
+              <bit-hint>{{ "ssoExternalIdDesc" | i18n }}</bit-hint>
+            </bit-form-field>
+          }
+        </bit-tab>
+        @if (organization.useGroups) {
+          <bit-tab [label]="'groups' | i18n">
+            <div class="tw-mb-6">
+              {{
+                (restrictEditingSelf$ | async)
+                  ? ("restrictedGroupAccess" | i18n)
+                  : ("groupAccessUserDesc" | i18n)
+              }}
+            </div>
             <bit-access-selector
-              [permissionMode]="PermissionMode.Edit"
-              formControlName="access"
-              [showGroupColumn]="organization.useGroups"
-              [items]="collectionAccessItems"
-              [columnHeader]="'collection' | i18n"
-              [selectorLabelText]="'selectCollections' | i18n"
-              [emptySelectionText]="'noCollectionsAdded' | i18n"
+              formControlName="groups"
+              [items]="groupAccessItems"
+              [columnHeader]="'groups' | i18n"
+              [selectorLabelText]="'selectGroups' | i18n"
+              [emptySelectionText]="'noGroupsAdded' | i18n"
               [hideMultiSelect]="restrictEditingSelf$ | async"
-            ></bit-access-selector
-          ></bit-tab>
-        </bit-tab-group>
+            ></bit-access-selector>
+          </bit-tab>
+        }
+        <bit-tab [label]="'collections' | i18n">
+          @if (restrictEditingSelf$ | async) {
+            <div class="tw-mb-6">
+              {{ "cannotAddYourselfToCollections" | i18n }}
+            </div>
+          }
+          @if (
+            !(restrictEditingSelf$ | async) &&
+            (organization.useGroups || !(canAssignAccessToAnyCollection$ | async))
+          ) {
+            <div class="tw-mb-6">
+              @if (organization.useGroups) {
+                <span>
+                  {{ "userPermissionOverrideHelperDesc" | i18n }}
+                </span>
+              }
+              @if (!(canAssignAccessToAnyCollection$ | async)) {
+                <span>
+                  {{ "restrictedCollectionAssignmentDesc" | i18n }}
+                </span>
+              }
+            </div>
+          }
+          <bit-access-selector
+            [permissionMode]="PermissionMode.Edit"
+            formControlName="access"
+            [showGroupColumn]="organization.useGroups"
+            [items]="collectionAccessItems"
+            [columnHeader]="'collection' | i18n"
+            [selectorLabelText]="'selectCollections' | i18n"
+            [emptySelectionText]="'noCollectionsAdded' | i18n"
+            [hideMultiSelect]="restrictEditingSelf$ | async"
+          ></bit-access-selector
+        ></bit-tab>
+      </bit-tab-group>
+    }
+  </div>
+  <ng-container bitDialogFooter>
+    <button type="submit" bitButton bitFormButton buttonType="primary" [disabled]="loading">
+      {{ "save" | i18n }}
+    </button>
+    <button
+      type="button"
+      bitButton
+      bitFormButton
+      buttonType="secondary"
+      (click)="cancel()"
+      [disabled]="loading"
+    >
+      {{ "cancel" | i18n }}
+    </button>
+    <div class="tw-flex tw-gap-2 tw-ml-auto">
+      @if (editMode && isRevoked) {
+        <button
+          type="button"
+          bitButton
+          bitFormButton
+          buttonType="secondary"
+          [bitAction]="restore"
+          [disabled]="loading"
+        >
+          {{ "restore" | i18n }}
+        </button>
+      }
+      @if (editMode && !isRevoked) {
+        <button
+          type="button"
+          bitButton
+          bitFormButton
+          buttonType="secondary"
+          [bitAction]="revoke"
+          [disabled]="loading"
+        >
+          {{ "revoke" | i18n }}
+        </button>
+      }
+      @if (this.editMode && !(editParams$ | async)?.managedByOrganization) {
+        <button
+          type="button"
+          buttonType="danger"
+          bitButton
+          bitFormButton
+          [bitAction]="remove"
+          [disabled]="loading"
+        >
+          {{ "remove" | i18n }}
+        </button>
+      }
+      @if (this.editMode && (editParams$ | async)?.managedByOrganization) {
+        <button
+          type="button"
+          buttonType="danger"
+          bitButton
+          bitFormButton
+          [bitAction]="delete"
+          [disabled]="loading"
+        >
+          {{ "delete" | i18n }}
+        </button>
       }
     </div>
-    <ng-container bitDialogFooter>
-      <button type="submit" bitButton bitFormButton buttonType="primary" [disabled]="loading">
-        {{ "save" | i18n }}
-      </button>
-      <button
-        type="button"
-        bitButton
-        bitFormButton
-        buttonType="secondary"
-        (click)="cancel()"
-        [disabled]="loading"
-      >
-        {{ "cancel" | i18n }}
-      </button>
-      <div class="tw-flex tw-gap-2 tw-ml-auto">
-        @if (editMode && isRevoked) {
-          <button
-            type="button"
-            bitButton
-            bitFormButton
-            buttonType="secondary"
-            [bitAction]="restore"
-            [disabled]="loading"
-          >
-            {{ "restore" | i18n }}
-          </button>
-        }
-        @if (editMode && !isRevoked) {
-          <button
-            type="button"
-            bitButton
-            bitFormButton
-            buttonType="secondary"
-            [bitAction]="revoke"
-            [disabled]="loading"
-          >
-            {{ "revoke" | i18n }}
-          </button>
-        }
-        @if (this.editMode && !(editParams$ | async)?.managedByOrganization) {
-          <button
-            type="button"
-            buttonType="danger"
-            bitButton
-            bitFormButton
-            [bitAction]="remove"
-            [disabled]="loading"
-          >
-            {{ "remove" | i18n }}
-          </button>
-        }
-        @if (this.editMode && (editParams$ | async)?.managedByOrganization) {
-          <button
-            type="button"
-            buttonType="danger"
-            bitButton
-            bitFormButton
-            [bitAction]="delete"
-            [disabled]="loading"
-          >
-            {{ "delete" | i18n }}
-          </button>
-        }
-      </div>
-    </ng-container>
-  </bit-dialog>
+  </ng-container>
 </form>

--- a/apps/web/src/app/admin-console/organizations/settings/components/delete-organization-dialog.component.html
+++ b/apps/web/src/app/admin-console/organizations/settings/components/delete-organization-dialog.component.html
@@ -1,40 +1,35 @@
-<form [formGroup]="formGroup" [bitSubmit]="submit">
-  <bit-dialog [loading]="!loaded">
-    <span bitDialogTitle>{{ "deleteOrganization" | i18n }}</span>
-    <div bitDialogContent>
-      <bit-callout type="warning">
-        {{ "deletingOrganizationIsPermanentWarning" | i18n: organization?.name }}
-      </bit-callout>
-      <p id="organizationDeleteDescription">
-        <ng-container
-          *ngIf="
-            deleteOrganizationRequestType === 'InvalidFamiliesForEnterprise';
-            else regularDelete
-          "
-        >
-          {{ "orgCreatedSponsorshipInvalid" | i18n }}
+<form [formGroup]="formGroup" [bitSubmit]="submit" bit-dialog [loading]="!loaded">
+  <span bitDialogTitle>{{ "deleteOrganization" | i18n }}</span>
+  <div bitDialogContent>
+    <bit-callout type="warning">
+      {{ "deletingOrganizationIsPermanentWarning" | i18n: organization?.name }}
+    </bit-callout>
+    <p id="organizationDeleteDescription">
+      <ng-container
+        *ngIf="deleteOrganizationRequestType === 'InvalidFamiliesForEnterprise'; else regularDelete"
+      >
+        {{ "orgCreatedSponsorshipInvalid" | i18n }}
+      </ng-container>
+      <ng-template #regularDelete>
+        <ng-container *ngIf="organizationContentSummary.totalItemCount > 0">
+          {{ "deletingOrganizationContentWarning" | i18n: organization?.name }}
+          <ul>
+            <li *ngFor="let type of organizationContentSummary.itemCountByType">
+              {{ type.count }} {{ type.localizationKey | i18n }}
+            </li>
+          </ul>
+          {{ "deletingOrganizationActiveUserAccountsWarning" | i18n }}
         </ng-container>
-        <ng-template #regularDelete>
-          <ng-container *ngIf="organizationContentSummary.totalItemCount > 0">
-            {{ "deletingOrganizationContentWarning" | i18n: organization?.name }}
-            <ul>
-              <li *ngFor="let type of organizationContentSummary.itemCountByType">
-                {{ type.count }} {{ type.localizationKey | i18n }}
-              </li>
-            </ul>
-            {{ "deletingOrganizationActiveUserAccountsWarning" | i18n }}
-          </ng-container>
-        </ng-template>
-      </p>
-      <app-user-verification formControlName="secret"> </app-user-verification>
-    </div>
-    <ng-container bitDialogFooter>
-      <button type="submit" bitButton bitFormButton buttonType="danger" [disabled]="!loaded">
-        {{ "deleteOrganization" | i18n }}
-      </button>
-      <button type="button" bitButton bitFormButton buttonType="secondary" bitDialogClose>
-        {{ "cancel" | i18n }}
-      </button>
-    </ng-container>
-  </bit-dialog>
+      </ng-template>
+    </p>
+    <app-user-verification formControlName="secret"> </app-user-verification>
+  </div>
+  <ng-container bitDialogFooter>
+    <button type="submit" bitButton bitFormButton buttonType="danger" [disabled]="!loaded">
+      {{ "deleteOrganization" | i18n }}
+    </button>
+    <button type="button" bitButton bitFormButton buttonType="secondary" bitDialogClose>
+      {{ "cancel" | i18n }}
+    </button>
+  </ng-container>
 </form>

--- a/apps/web/src/app/admin-console/organizations/shared/components/collection-dialog/collection-dialog.component.html
+++ b/apps/web/src/app/admin-console/organizations/shared/components/collection-dialog/collection-dialog.component.html
@@ -1,153 +1,150 @@
-<form [formGroup]="formGroup" [bitSubmit]="submit">
-  <bit-dialog dialogSize="large">
-    <span bitDialogTitle>
-      <ng-container *ngIf="editMode">
-        {{ (dialogReadonly ? "viewCollection" : "editCollection") | i18n }}
-        <span class="tw-text-sm tw-normal-case tw-text-muted" *ngIf="!loading">{{
-          collection.name
-        }}</span>
-      </ng-container>
-      <ng-container *ngIf="!editMode">
-        {{ "newCollection" | i18n }}
-      </ng-container>
-    </span>
-    <div bitDialogContent>
-      <ng-container *ngIf="loading" #spinner>
-        <i class="bwi bwi-spinner bwi-lg bwi-spin" aria-hidden="true"></i>
-      </ng-container>
-      <bit-tab-group *ngIf="!loading" [(selectedIndex)]="tabIndex">
-        <bit-tab label="{{ 'collectionInfo' | i18n }}">
-          <bit-form-field>
-            <bit-label>{{ "name" | i18n }}</bit-label>
-            <input bitInput appAutofocus formControlName="name" />
-          </bit-form-field>
-
-          <bit-form-field *ngIf="showOrgSelector">
-            <bit-label>{{ "organization" | i18n }}</bit-label>
-            <bit-select bitInput formControlName="selectedOrg">
-              <bit-option
-                *ngFor="let org of organizations$ | async"
-                icon="bwi-business"
-                [value]="org.id"
-                [label]="org.name"
-              >
-              </bit-option>
-            </bit-select>
-          </bit-form-field>
-
-          <bit-form-field *ngIf="isExternalIdVisible">
-            <bit-label>{{ "externalId" | i18n }}</bit-label>
-            <input bitInput formControlName="externalId" />
-            <bit-hint>{{ "externalIdDesc" | i18n }}</bit-hint>
-          </bit-form-field>
-
-          <bit-form-field>
-            <bit-label>{{ "nestCollectionUnder" | i18n }}</bit-label>
-            <bit-select bitInput formControlName="parent">
-              <bit-option [value]="undefined" [label]="'noCollection' | i18n"> </bit-option>
-              <bit-option
-                *ngIf="deletedParentName"
-                disabled
-                icon="bwi-collection-shared"
-                [value]="deletedParentName"
-                label="{{ deletedParentName }} ({{ 'deleted' | i18n }})"
-              >
-              </bit-option>
-              <bit-option
-                *ngFor="let collection of nestOptions"
-                icon="bwi-collection-shared"
-                [value]="collection.name"
-                [label]="collection.name"
-              >
-              </bit-option>
-            </bit-select>
-          </bit-form-field>
-        </bit-tab>
-        <bit-tab [label]="accessTabLabel">
-          <div class="tw-mb-3">
-            <ng-container *ngIf="dialogReadonly">
-              <span>{{ "readOnlyCollectionAccess" | i18n }}</span>
-            </ng-container>
-            <ng-container *ngIf="!dialogReadonly">
-              <bit-callout
-                title="{{ 'grantManageCollectionWarningTitle' | i18n }}"
-                type="warning"
-                *ngIf="showAddAccessWarning"
-              >
-                {{ "grantManageCollectionWarning" | i18n }}
-              </bit-callout>
-              <span *ngIf="organization.useGroups">{{ "grantCollectionAccess" | i18n }}</span>
-              <span *ngIf="!organization.useGroups">{{
-                "grantCollectionAccessMembersOnly" | i18n
-              }}</span>
-              <span *ngIf="organization.allowAdminAccessToAllCollectionItems">
-                {{ " " + ("adminCollectionAccess" | i18n) }}
-              </span>
-            </ng-container>
-          </div>
-          <div
-            class="tw-mb-3 tw-text-danger"
-            *ngIf="
-              formGroup.controls.access.hasError('managePermissionRequired') &&
-              !showAddAccessWarning
-            "
-          >
-            <i class="bwi bwi-error"></i> {{ "managePermissionRequired" | i18n }}
-          </div>
-          <bit-access-selector
-            *ngIf="organization.useGroups"
-            [permissionMode]="dialogReadonly ? PermissionMode.Readonly : PermissionMode.Edit"
-            formControlName="access"
-            [items]="accessItems"
-            [columnHeader]="'groupSlashMemberColumnHeader' | i18n"
-            [selectorLabelText]="'selectGroupsAndMembers' | i18n"
-            [selectorHelpText]="'userPermissionOverrideHelperDesc' | i18n"
-            [emptySelectionText]="'noMembersOrGroupsAdded' | i18n"
-            [initialPermission]="initialPermission"
-          ></bit-access-selector>
-          <bit-access-selector
-            *ngIf="!organization.useGroups"
-            [permissionMode]="dialogReadonly ? PermissionMode.Readonly : PermissionMode.Edit"
-            formControlName="access"
-            [items]="accessItems"
-            [columnHeader]="'memberColumnHeader' | i18n"
-            [selectorLabelText]="'selectMembers' | i18n"
-            [emptySelectionText]="'noMembersAdded' | i18n"
-          ></bit-access-selector>
-        </bit-tab>
-      </bit-tab-group>
-    </div>
-    <ng-container bitDialogFooter>
-      <button
-        type="submit"
-        bitButton
-        bitFormButton
-        buttonType="primary"
-        [disabled]="loading || dialogReadonly"
-      >
-        {{ buttonDisplayName | i18n }}
-      </button>
-      <button
-        type="button"
-        bitButton
-        bitFormButton
-        buttonType="secondary"
-        (click)="cancel()"
-        [disabled]="loading"
-      >
-        {{ "cancel" | i18n }}
-      </button>
-      <button
-        *ngIf="showDeleteButton"
-        type="button"
-        bitIconButton="bwi-trash"
-        buttonType="dangerGhost"
-        class="tw-ml-auto"
-        bitFormButton
-        [label]="'delete' | i18n"
-        [bitAction]="delete"
-        [disabled]="loading"
-      ></button>
+<form [formGroup]="formGroup" [bitSubmit]="submit" bit-dialog dialogSize="large">
+  <span bitDialogTitle>
+    <ng-container *ngIf="editMode">
+      {{ (dialogReadonly ? "viewCollection" : "editCollection") | i18n }}
+      <span class="tw-text-sm tw-normal-case tw-text-muted" *ngIf="!loading">{{
+        collection.name
+      }}</span>
     </ng-container>
-  </bit-dialog>
+    <ng-container *ngIf="!editMode">
+      {{ "newCollection" | i18n }}
+    </ng-container>
+  </span>
+  <div bitDialogContent>
+    <ng-container *ngIf="loading" #spinner>
+      <i class="bwi bwi-spinner bwi-lg bwi-spin" aria-hidden="true"></i>
+    </ng-container>
+    <bit-tab-group *ngIf="!loading" [(selectedIndex)]="tabIndex">
+      <bit-tab label="{{ 'collectionInfo' | i18n }}">
+        <bit-form-field>
+          <bit-label>{{ "name" | i18n }}</bit-label>
+          <input bitInput appAutofocus formControlName="name" />
+        </bit-form-field>
+
+        <bit-form-field *ngIf="showOrgSelector">
+          <bit-label>{{ "organization" | i18n }}</bit-label>
+          <bit-select bitInput formControlName="selectedOrg">
+            <bit-option
+              *ngFor="let org of organizations$ | async"
+              icon="bwi-business"
+              [value]="org.id"
+              [label]="org.name"
+            >
+            </bit-option>
+          </bit-select>
+        </bit-form-field>
+
+        <bit-form-field *ngIf="isExternalIdVisible">
+          <bit-label>{{ "externalId" | i18n }}</bit-label>
+          <input bitInput formControlName="externalId" />
+          <bit-hint>{{ "externalIdDesc" | i18n }}</bit-hint>
+        </bit-form-field>
+
+        <bit-form-field>
+          <bit-label>{{ "nestCollectionUnder" | i18n }}</bit-label>
+          <bit-select bitInput formControlName="parent">
+            <bit-option [value]="undefined" [label]="'noCollection' | i18n"> </bit-option>
+            <bit-option
+              *ngIf="deletedParentName"
+              disabled
+              icon="bwi-collection-shared"
+              [value]="deletedParentName"
+              label="{{ deletedParentName }} ({{ 'deleted' | i18n }})"
+            >
+            </bit-option>
+            <bit-option
+              *ngFor="let collection of nestOptions"
+              icon="bwi-collection-shared"
+              [value]="collection.name"
+              [label]="collection.name"
+            >
+            </bit-option>
+          </bit-select>
+        </bit-form-field>
+      </bit-tab>
+      <bit-tab [label]="accessTabLabel">
+        <div class="tw-mb-3">
+          <ng-container *ngIf="dialogReadonly">
+            <span>{{ "readOnlyCollectionAccess" | i18n }}</span>
+          </ng-container>
+          <ng-container *ngIf="!dialogReadonly">
+            <bit-callout
+              title="{{ 'grantManageCollectionWarningTitle' | i18n }}"
+              type="warning"
+              *ngIf="showAddAccessWarning"
+            >
+              {{ "grantManageCollectionWarning" | i18n }}
+            </bit-callout>
+            <span *ngIf="organization.useGroups">{{ "grantCollectionAccess" | i18n }}</span>
+            <span *ngIf="!organization.useGroups">{{
+              "grantCollectionAccessMembersOnly" | i18n
+            }}</span>
+            <span *ngIf="organization.allowAdminAccessToAllCollectionItems">
+              {{ " " + ("adminCollectionAccess" | i18n) }}
+            </span>
+          </ng-container>
+        </div>
+        <div
+          class="tw-mb-3 tw-text-danger"
+          *ngIf="
+            formGroup.controls.access.hasError('managePermissionRequired') && !showAddAccessWarning
+          "
+        >
+          <i class="bwi bwi-error"></i> {{ "managePermissionRequired" | i18n }}
+        </div>
+        <bit-access-selector
+          *ngIf="organization.useGroups"
+          [permissionMode]="dialogReadonly ? PermissionMode.Readonly : PermissionMode.Edit"
+          formControlName="access"
+          [items]="accessItems"
+          [columnHeader]="'groupSlashMemberColumnHeader' | i18n"
+          [selectorLabelText]="'selectGroupsAndMembers' | i18n"
+          [selectorHelpText]="'userPermissionOverrideHelperDesc' | i18n"
+          [emptySelectionText]="'noMembersOrGroupsAdded' | i18n"
+          [initialPermission]="initialPermission"
+        ></bit-access-selector>
+        <bit-access-selector
+          *ngIf="!organization.useGroups"
+          [permissionMode]="dialogReadonly ? PermissionMode.Readonly : PermissionMode.Edit"
+          formControlName="access"
+          [items]="accessItems"
+          [columnHeader]="'memberColumnHeader' | i18n"
+          [selectorLabelText]="'selectMembers' | i18n"
+          [emptySelectionText]="'noMembersAdded' | i18n"
+        ></bit-access-selector>
+      </bit-tab>
+    </bit-tab-group>
+  </div>
+  <ng-container bitDialogFooter>
+    <button
+      type="submit"
+      bitButton
+      bitFormButton
+      buttonType="primary"
+      [disabled]="loading || dialogReadonly"
+    >
+      {{ buttonDisplayName | i18n }}
+    </button>
+    <button
+      type="button"
+      bitButton
+      bitFormButton
+      buttonType="secondary"
+      (click)="cancel()"
+      [disabled]="loading"
+    >
+      {{ "cancel" | i18n }}
+    </button>
+    <button
+      *ngIf="showDeleteButton"
+      type="button"
+      bitIconButton="bwi-trash"
+      buttonType="dangerGhost"
+      class="tw-ml-auto"
+      bitFormButton
+      [label]="'delete' | i18n"
+      [bitAction]="delete"
+      [disabled]="loading"
+    ></button>
+  </ng-container>
 </form>

--- a/apps/web/src/app/auth/settings/account/deauthorize-sessions.component.html
+++ b/apps/web/src/app/auth/settings/account/deauthorize-sessions.component.html
@@ -1,21 +1,25 @@
-<form [formGroup]="deauthForm" [bitSubmit]="submit">
-  <bit-dialog dialogSize="default" [title]="'deauthorizeSessions' | i18n">
-    <ng-container bitDialogContent>
-      <p bitTypography="body1">{{ "deauthorizeSessionsDesc" | i18n }}</p>
-      <bit-callout type="warning">{{ "deauthorizeSessionsWarning" | i18n }}</bit-callout>
-      <app-user-verification-form-input
-        formControlName="verification"
-        name="verification"
-        [(invalidSecret)]="invalidSecret"
-      ></app-user-verification-form-input>
-    </ng-container>
-    <ng-container bitDialogFooter>
-      <button bitButton bitFormButton type="submit" buttonType="danger">
-        {{ "deauthorizeSessions" | i18n }}
-      </button>
-      <button bitButton bitFormButton type="button" buttonType="secondary" bitDialogClose>
-        {{ "close" | i18n }}
-      </button>
-    </ng-container>
-  </bit-dialog>
+<form
+  [formGroup]="deauthForm"
+  [bitSubmit]="submit"
+  bit-dialog
+  dialogSize="default"
+  [title]="'deauthorizeSessions' | i18n"
+>
+  <ng-container bitDialogContent>
+    <p bitTypography="body1">{{ "deauthorizeSessionsDesc" | i18n }}</p>
+    <bit-callout type="warning">{{ "deauthorizeSessionsWarning" | i18n }}</bit-callout>
+    <app-user-verification-form-input
+      formControlName="verification"
+      name="verification"
+      [(invalidSecret)]="invalidSecret"
+    ></app-user-verification-form-input>
+  </ng-container>
+  <ng-container bitDialogFooter>
+    <button bitButton bitFormButton type="submit" buttonType="danger">
+      {{ "deauthorizeSessions" | i18n }}
+    </button>
+    <button bitButton bitFormButton type="button" buttonType="secondary" bitDialogClose>
+      {{ "close" | i18n }}
+    </button>
+  </ng-container>
 </form>

--- a/apps/web/src/app/auth/settings/account/set-account-verify-devices-dialog.component.html
+++ b/apps/web/src/app/auth/settings/account/set-account-verify-devices-dialog.component.html
@@ -1,43 +1,41 @@
-<form [formGroup]="setVerifyDevicesForm" [bitSubmit]="submit">
-  <bit-dialog dialogSize="default" [title]="'newDeviceLoginProtection' | i18n">
-    <ng-container bitDialogContent>
-      <p *ngIf="verifyNewDeviceLogin" bitTypography="body1">
-        {{ "turnOffNewDeviceLoginProtectionModalDesc" | i18n }}
-      </p>
-      <p *ngIf="!verifyNewDeviceLogin" bitTypography="body1">
-        {{ "turnOnNewDeviceLoginProtectionModalDesc" | i18n }}
-      </p>
-      <bit-callout *ngIf="verifyNewDeviceLogin && !has2faConfigured" type="warning">{{
-        "turnOffNewDeviceLoginProtectionWarning" | i18n
-      }}</bit-callout>
-      <app-user-verification-form-input
-        formControlName="verification"
-        name="verification"
-        [(invalidSecret)]="invalidSecret"
-      ></app-user-verification-form-input>
-    </ng-container>
-    <ng-container bitDialogFooter>
-      <button
-        bitButton
-        *ngIf="verifyNewDeviceLogin"
-        bitFormButton
-        type="submit"
-        buttonType="danger"
-      >
-        {{ "disable" | i18n }}
-      </button>
-      <button
-        bitButton
-        *ngIf="!verifyNewDeviceLogin"
-        bitFormButton
-        type="submit"
-        buttonType="primary"
-      >
-        {{ "enable" | i18n }}
-      </button>
-      <button bitButton bitFormButton type="button" buttonType="secondary" bitDialogClose>
-        {{ "close" | i18n }}
-      </button>
-    </ng-container>
-  </bit-dialog>
+<form
+  [formGroup]="setVerifyDevicesForm"
+  [bitSubmit]="submit"
+  bit-dialog
+  dialogSize="default"
+  [title]="'newDeviceLoginProtection' | i18n"
+>
+  <ng-container bitDialogContent>
+    <p *ngIf="verifyNewDeviceLogin" bitTypography="body1">
+      {{ "turnOffNewDeviceLoginProtectionModalDesc" | i18n }}
+    </p>
+    <p *ngIf="!verifyNewDeviceLogin" bitTypography="body1">
+      {{ "turnOnNewDeviceLoginProtectionModalDesc" | i18n }}
+    </p>
+    <bit-callout *ngIf="verifyNewDeviceLogin && !has2faConfigured" type="warning">{{
+      "turnOffNewDeviceLoginProtectionWarning" | i18n
+    }}</bit-callout>
+    <app-user-verification-form-input
+      formControlName="verification"
+      name="verification"
+      [(invalidSecret)]="invalidSecret"
+    ></app-user-verification-form-input>
+  </ng-container>
+  <ng-container bitDialogFooter>
+    <button bitButton *ngIf="verifyNewDeviceLogin" bitFormButton type="submit" buttonType="danger">
+      {{ "disable" | i18n }}
+    </button>
+    <button
+      bitButton
+      *ngIf="!verifyNewDeviceLogin"
+      bitFormButton
+      type="submit"
+      buttonType="primary"
+    >
+      {{ "enable" | i18n }}
+    </button>
+    <button bitButton bitFormButton type="button" buttonType="secondary" bitDialogClose>
+      {{ "close" | i18n }}
+    </button>
+  </ng-container>
 </form>

--- a/apps/web/src/app/auth/settings/emergency-access/confirm/emergency-access-confirm.component.html
+++ b/apps/web/src/app/auth/settings/emergency-access/confirm/emergency-access-confirm.component.html
@@ -1,37 +1,41 @@
-<form [formGroup]="confirmForm" [bitSubmit]="submit">
-  <bit-dialog dialogSize="large" [loading]="loading">
-    <span bitDialogTitle>
-      {{ "confirmUser" | i18n }}
-      <small class="tw-text-muted">{{ params.name }}</small>
-    </span>
-    <div bitDialogContent>
-      <p bitTypography="body1">
-        {{ "fingerprintEnsureIntegrityVerify" | i18n }}
-        <a
-          bitLink
-          href="https://bitwarden.com/help/fingerprint-phrase/"
-          target="_blank"
-          rel="noreferrer"
-        >
-          {{ "learnMore" | i18n }}</a
-        >
-      </p>
-      <p bitTypography="body1">
-        <code>{{ fingerprint }}</code>
-      </p>
+<form
+  [formGroup]="confirmForm"
+  [bitSubmit]="submit"
+  bit-dialog
+  dialogSize="large"
+  [loading]="loading"
+>
+  <span bitDialogTitle>
+    {{ "confirmUser" | i18n }}
+    <small class="tw-text-muted">{{ params.name }}</small>
+  </span>
+  <div bitDialogContent>
+    <p bitTypography="body1">
+      {{ "fingerprintEnsureIntegrityVerify" | i18n }}
+      <a
+        bitLink
+        href="https://bitwarden.com/help/fingerprint-phrase/"
+        target="_blank"
+        rel="noreferrer"
+      >
+        {{ "learnMore" | i18n }}</a
+      >
+    </p>
+    <p bitTypography="body1">
+      <code>{{ fingerprint }}</code>
+    </p>
 
-      <bit-form-control>
-        <input type="checkbox" bitCheckbox formControlName="dontAskAgain" />
-        <bit-label> {{ "dontAskFingerprintAgain" | i18n }}</bit-label>
-      </bit-form-control>
-    </div>
-    <ng-container bitDialogFooter>
-      <button type="submit" buttonType="primary" bitButton bitFormButton>
-        <span>{{ "confirm" | i18n }}</span>
-      </button>
-      <button bitButton bitFormButton buttonType="secondary" type="button" bitDialogClose>
-        {{ "cancel" | i18n }}
-      </button>
-    </ng-container>
-  </bit-dialog>
+    <bit-form-control>
+      <input type="checkbox" bitCheckbox formControlName="dontAskAgain" />
+      <bit-label> {{ "dontAskFingerprintAgain" | i18n }}</bit-label>
+    </bit-form-control>
+  </div>
+  <ng-container bitDialogFooter>
+    <button type="submit" buttonType="primary" bitButton bitFormButton>
+      <span>{{ "confirm" | i18n }}</span>
+    </button>
+    <button bitButton bitFormButton buttonType="secondary" type="button" bitDialogClose>
+      {{ "cancel" | i18n }}
+    </button>
+  </ng-container>
 </form>

--- a/apps/web/src/app/auth/settings/emergency-access/emergency-access-add-edit.component.html
+++ b/apps/web/src/app/auth/settings/emergency-access/emergency-access-add-edit.component.html
@@ -1,69 +1,73 @@
-<form [formGroup]="addEditForm" [bitSubmit]="submit">
-  <bit-dialog dialogSize="large" [loading]="loading">
-    <span bitDialogTitle>
-      <app-premium-badge *ngIf="readOnly"></app-premium-badge>
-      {{ title }}
-      <small class="tw-text-muted" *ngIf="params.name">{{ params.name }}</small>
-    </span>
-    <ng-container bitDialogContent>
-      <ng-container *ngIf="!editMode">
-        <p bitTypography="body1">{{ "inviteEmergencyContactDesc" | i18n }}</p>
-        <bit-form-field>
-          <bit-label>{{ "email" | i18n }}</bit-label>
-          <input bitInput formControlName="email" />
-        </bit-form-field>
-      </ng-container>
-      <bit-radio-group formControlName="emergencyAccessType" [block]="true">
-        <bit-label>
-          {{ "userAccess" | i18n }}
-          <a
-            target="_blank"
-            rel="noreferrer"
-            bitLink
-            linkType="primary"
-            appA11yTitle="{{ 'learnMoreAboutUserAccess' | i18n }}"
-            href="https://bitwarden.com/help/emergency-access/#user-access"
-            slot="end"
-          >
-            <bit-icon name="bwi-question-circle"></bit-icon>
-          </a>
-        </bit-label>
-        <bit-radio-button id="emergencyTypeView" [value]="emergencyAccessType.View">
-          <bit-label>{{ "view" | i18n }}</bit-label>
-          <bit-hint>{{ "viewDesc" | i18n }}</bit-hint>
-        </bit-radio-button>
-
-        <bit-radio-button id="emergencyTypeTakeover" [value]="emergencyAccessType.Takeover">
-          <bit-label>{{ "takeover" | i18n }}</bit-label>
-          <bit-hint>{{ "takeoverDesc" | i18n }}</bit-hint>
-        </bit-radio-button>
-      </bit-radio-group>
-
-      <bit-form-field class="tw-w-1/2 tw-relative tw-px-2.5">
-        <bit-label>{{ "waitTime" | i18n }}</bit-label>
-        <bit-select formControlName="waitTime">
-          <bit-option *ngFor="let o of waitTimes" [value]="o.value" [label]="o.name"></bit-option>
-        </bit-select>
-        <bit-hint class="tw-text-sm">{{ "waitTimeDesc" | i18n }}</bit-hint>
+<form
+  [formGroup]="addEditForm"
+  [bitSubmit]="submit"
+  bit-dialog
+  dialogSize="large"
+  [loading]="loading"
+>
+  <span bitDialogTitle>
+    <app-premium-badge *ngIf="readOnly"></app-premium-badge>
+    {{ title }}
+    <small class="tw-text-muted" *ngIf="params.name">{{ params.name }}</small>
+  </span>
+  <ng-container bitDialogContent>
+    <ng-container *ngIf="!editMode">
+      <p bitTypography="body1">{{ "inviteEmergencyContactDesc" | i18n }}</p>
+      <bit-form-field>
+        <bit-label>{{ "email" | i18n }}</bit-label>
+        <input bitInput formControlName="email" />
       </bit-form-field>
     </ng-container>
-    <ng-container bitDialogFooter>
-      <button type="submit" buttonType="primary" bitButton bitFormButton [disabled]="readOnly">
-        {{ "save" | i18n }}
-      </button>
-      <button bitButton bitFormButton buttonType="secondary" type="button" bitDialogClose>
-        {{ "cancel" | i18n }}
-      </button>
-      <button
-        type="button"
-        bitFormButton
-        class="tw-ml-auto"
-        bitIconButton="bwi-trash"
-        buttonType="dangerGhost"
-        [bitAction]="delete"
-        *ngIf="editMode"
-        label="{{ 'delete' | i18n }}"
-      ></button>
-    </ng-container>
-  </bit-dialog>
+    <bit-radio-group formControlName="emergencyAccessType" [block]="true">
+      <bit-label>
+        {{ "userAccess" | i18n }}
+        <a
+          target="_blank"
+          rel="noreferrer"
+          bitLink
+          linkType="primary"
+          appA11yTitle="{{ 'learnMoreAboutUserAccess' | i18n }}"
+          href="https://bitwarden.com/help/emergency-access/#user-access"
+          slot="end"
+        >
+          <bit-icon name="bwi-question-circle"></bit-icon>
+        </a>
+      </bit-label>
+      <bit-radio-button id="emergencyTypeView" [value]="emergencyAccessType.View">
+        <bit-label>{{ "view" | i18n }}</bit-label>
+        <bit-hint>{{ "viewDesc" | i18n }}</bit-hint>
+      </bit-radio-button>
+
+      <bit-radio-button id="emergencyTypeTakeover" [value]="emergencyAccessType.Takeover">
+        <bit-label>{{ "takeover" | i18n }}</bit-label>
+        <bit-hint>{{ "takeoverDesc" | i18n }}</bit-hint>
+      </bit-radio-button>
+    </bit-radio-group>
+
+    <bit-form-field class="tw-w-1/2 tw-relative tw-px-2.5">
+      <bit-label>{{ "waitTime" | i18n }}</bit-label>
+      <bit-select formControlName="waitTime">
+        <bit-option *ngFor="let o of waitTimes" [value]="o.value" [label]="o.name"></bit-option>
+      </bit-select>
+      <bit-hint class="tw-text-sm">{{ "waitTimeDesc" | i18n }}</bit-hint>
+    </bit-form-field>
+  </ng-container>
+  <ng-container bitDialogFooter>
+    <button type="submit" buttonType="primary" bitButton bitFormButton [disabled]="readOnly">
+      {{ "save" | i18n }}
+    </button>
+    <button bitButton bitFormButton buttonType="secondary" type="button" bitDialogClose>
+      {{ "cancel" | i18n }}
+    </button>
+    <button
+      type="button"
+      bitFormButton
+      class="tw-ml-auto"
+      bitIconButton="bwi-trash"
+      buttonType="dangerGhost"
+      [bitAction]="delete"
+      *ngIf="editMode"
+      label="{{ 'delete' | i18n }}"
+    ></button>
+  </ng-container>
 </form>

--- a/apps/web/src/app/auth/settings/security/api-key.component.html
+++ b/apps/web/src/app/auth/settings/security/api-key.component.html
@@ -1,42 +1,40 @@
-<form [formGroup]="formGroup" [bitSubmit]="submit">
-  <bit-dialog>
-    <span bitDialogTitle>{{ data.apiKeyTitle | i18n }}</span>
-    <div bitDialogContent>
-      <p bitTypography="body1">{{ data.apiKeyDescription | i18n }}</p>
-      <app-user-verification-form-input formControlName="masterPassword" *ngIf="!clientSecret">
-      </app-user-verification-form-input>
-      <bit-callout type="warning" *ngIf="clientSecret">{{ data.apiKeyWarning | i18n }}</bit-callout>
-      <bit-callout
-        type="info"
-        title="{{ 'oauth2ClientCredentials' | i18n }}"
-        icon="bwi-key"
-        *ngIf="clientSecret"
-      >
-        <p bitTypography="body1" class="tw-mb-1">
-          <strong>client_id:</strong><br />
-          <code>{{ clientId }}</code>
-        </p>
-        <p bitTypography="body1" class="tw-mb-1">
-          <strong>client_secret:</strong><br />
-          <code>{{ clientSecret }}</code>
-        </p>
-        <p bitTypography="body1" class="tw-mb-1">
-          <strong>scope:</strong><br />
-          <code>{{ data.scope }}</code>
-        </p>
-        <p bitTypography="body1" class="tw-mb-0">
-          <strong>grant_type:</strong><br />
-          <code>{{ data.grantType }}</code>
-        </p>
-      </bit-callout>
-    </div>
-    <ng-container bitDialogFooter>
-      <button type="submit" buttonType="primary" *ngIf="!clientSecret" bitButton bitFormButton>
-        <span>{{ (data.isRotation ? "rotateApiKey" : "viewApiKey") | i18n }}</span>
-      </button>
-      <button type="button" bitButton bitFormButton bitDialogClose>
-        {{ "close" | i18n }}
-      </button>
-    </ng-container>
-  </bit-dialog>
+<form [formGroup]="formGroup" [bitSubmit]="submit" bit-dialog>
+  <span bitDialogTitle>{{ data.apiKeyTitle | i18n }}</span>
+  <div bitDialogContent>
+    <p bitTypography="body1">{{ data.apiKeyDescription | i18n }}</p>
+    <app-user-verification-form-input formControlName="masterPassword" *ngIf="!clientSecret">
+    </app-user-verification-form-input>
+    <bit-callout type="warning" *ngIf="clientSecret">{{ data.apiKeyWarning | i18n }}</bit-callout>
+    <bit-callout
+      type="info"
+      title="{{ 'oauth2ClientCredentials' | i18n }}"
+      icon="bwi-key"
+      *ngIf="clientSecret"
+    >
+      <p bitTypography="body1" class="tw-mb-1">
+        <strong>client_id:</strong><br />
+        <code>{{ clientId }}</code>
+      </p>
+      <p bitTypography="body1" class="tw-mb-1">
+        <strong>client_secret:</strong><br />
+        <code>{{ clientSecret }}</code>
+      </p>
+      <p bitTypography="body1" class="tw-mb-1">
+        <strong>scope:</strong><br />
+        <code>{{ data.scope }}</code>
+      </p>
+      <p bitTypography="body1" class="tw-mb-0">
+        <strong>grant_type:</strong><br />
+        <code>{{ data.grantType }}</code>
+      </p>
+    </bit-callout>
+  </div>
+  <ng-container bitDialogFooter>
+    <button type="submit" buttonType="primary" *ngIf="!clientSecret" bitButton bitFormButton>
+      <span>{{ (data.isRotation ? "rotateApiKey" : "viewApiKey") | i18n }}</span>
+    </button>
+    <button type="button" bitButton bitFormButton bitDialogClose>
+      {{ "close" | i18n }}
+    </button>
+  </ng-container>
 </form>

--- a/apps/web/src/app/auth/settings/two-factor/two-factor-setup-authenticator.component.html
+++ b/apps/web/src/app/auth/settings/two-factor/two-factor-setup-authenticator.component.html
@@ -1,105 +1,103 @@
-<form *ngIf="authed" [formGroup]="formGroup" [bitSubmit]="submit">
-  <bit-dialog
-    dialogSize="default"
-    [title]="'twoStepLogin' | i18n"
-    [subtitle]="'authenticatorAppTitle' | i18n"
-  >
-    <ng-container bitDialogContent>
-      <ng-container *ngIf="enabled">
-        <bit-callout type="success" title="{{ 'enabled' | i18n }}" icon="bwi-check-circle">
-          <p bitTypography="body1">{{ "twoStepLoginProviderEnabled" | i18n }}</p>
-          {{ "twoStepAuthenticatorReaddDesc" | i18n }}
-        </bit-callout>
-        <p bitTypography="body1">{{ "twoStepAuthenticatorNeedApp" | i18n }}</p>
-      </ng-container>
-      <ng-container *ngIf="!enabled">
-        <p>
-          {{ "twoStepAuthenticatorInstructionPrefix" | i18n }}
-          <a
-            bitLink
-            target="_blank"
-            rel="noreferrer"
-            (click)="launchExternalUrl('https://getaegis.app')"
-            >Aegis</a
-          >
-          {{ "twoStepAuthenticatorInstructionInfix1" | i18n }}
-          <a
-            bitLink
-            target="_blank"
-            rel="noreferrer"
-            (click)="launchExternalUrl('https://2fas.com')"
-            >2FAS</a
-          >
-          {{ "twoStepAuthenticatorInstructionInfix2" | i18n }}
-          <a
-            bitLink
-            target="_blank"
-            rel="noreferrer"
-            (click)="launchBitwardenUrl('https://bitwarden.com/products/authenticator/')"
-            >Bitwarden Authenticator</a
-          >
-          {{ "twoStepAuthenticatorInstructionSuffix" | i18n }}
-        </p>
-
-        <p class="tw-text-center">
-          <a
-            href="https://apps.apple.com/ca/app/bitwarden-authenticator/id6497335175"
-            target="_blank"
-          >
-            <img
-              src="../../../images/download_apple_appstore.svg"
-              alt="Download on App Store"
-              max-width="120"
-              height="40"
-            />
-          </a>
-
-          <!--Margin to ensure compliance with google play badge usage guidelines (https://partnermarketinghub.withgoogle.com/brands/google-play/visual-identity/badge-guidelines/#:~:text=The%20clear%20space%20surrounding%20the%20badge%20must%20be%20equal%20to%20one%2Dquarter%20of%20the%20height%20of%20the%20badge.)-->
-          <a
-            href="https://play.google.com/store/apps/details?id=com.bitwarden.authenticator"
-            target="_blank"
-          >
-            <img
-              src="../../../images/download_google_playstore.svg"
-              alt="Get it on Google Play"
-              max-width="120"
-              height="40"
-              style="margin-left: 10px"
-            />
-          </a>
-        </p>
-        {{ "twoStepAuthenticatorScanCodeV2" | i18n }}
-      </ng-container>
-      <hr *ngIf="enabled" />
-      <p class="tw-text-center tw-mb-0">
-        <ng-container *ngIf="qrScriptError" class="tw-mt-2">
-          <bit-icon name="bwi-error" class="tw-text-3xl tw-text-danger"></bit-icon>
-          <p>
-            {{ "twoStepAuthenticatorQRCanvasError" | i18n }}
-          </p>
-        </ng-container>
-        <canvas *ngIf="!qrScriptError" id="qr"></canvas>
-        <br />
-        <code appA11yTitle="{{ 'key' | i18n }}">{{ key }}</code>
+<form
+  *ngIf="authed"
+  [formGroup]="formGroup"
+  [bitSubmit]="submit"
+  bit-dialog
+  dialogSize="default"
+  [title]="'twoStepLogin' | i18n"
+  [subtitle]="'authenticatorAppTitle' | i18n"
+>
+  <ng-container bitDialogContent>
+    <ng-container *ngIf="enabled">
+      <bit-callout type="success" title="{{ 'enabled' | i18n }}" icon="bwi-check-circle">
+        <p bitTypography="body1">{{ "twoStepLoginProviderEnabled" | i18n }}</p>
+        {{ "twoStepAuthenticatorReaddDesc" | i18n }}
+      </bit-callout>
+      <p bitTypography="body1">{{ "twoStepAuthenticatorNeedApp" | i18n }}</p>
+    </ng-container>
+    <ng-container *ngIf="!enabled">
+      <p>
+        {{ "twoStepAuthenticatorInstructionPrefix" | i18n }}
+        <a
+          bitLink
+          target="_blank"
+          rel="noreferrer"
+          (click)="launchExternalUrl('https://getaegis.app')"
+          >Aegis</a
+        >
+        {{ "twoStepAuthenticatorInstructionInfix1" | i18n }}
+        <a bitLink target="_blank" rel="noreferrer" (click)="launchExternalUrl('https://2fas.com')"
+          >2FAS</a
+        >
+        {{ "twoStepAuthenticatorInstructionInfix2" | i18n }}
+        <a
+          bitLink
+          target="_blank"
+          rel="noreferrer"
+          (click)="launchBitwardenUrl('https://bitwarden.com/products/authenticator/')"
+          >Bitwarden Authenticator</a
+        >
+        {{ "twoStepAuthenticatorInstructionSuffix" | i18n }}
       </p>
-      <bit-form-field *ngIf="!enabled" [disableMargin]="true">
-        <bit-label>{{ "twoStepAuthenticatorEnterCodeV2" | i18n }}</bit-label>
-        <input bitInput type="text" formControlName="token" appInputVerbatim />
-      </bit-form-field>
+
+      <p class="tw-text-center">
+        <a
+          href="https://apps.apple.com/ca/app/bitwarden-authenticator/id6497335175"
+          target="_blank"
+        >
+          <img
+            src="../../../images/download_apple_appstore.svg"
+            alt="Download on App Store"
+            max-width="120"
+            height="40"
+          />
+        </a>
+
+        <!--Margin to ensure compliance with google play badge usage guidelines (https://partnermarketinghub.withgoogle.com/brands/google-play/visual-identity/badge-guidelines/#:~:text=The%20clear%20space%20surrounding%20the%20badge%20must%20be%20equal%20to%20one%2Dquarter%20of%20the%20height%20of%20the%20badge.)-->
+        <a
+          href="https://play.google.com/store/apps/details?id=com.bitwarden.authenticator"
+          target="_blank"
+        >
+          <img
+            src="../../../images/download_google_playstore.svg"
+            alt="Get it on Google Play"
+            max-width="120"
+            height="40"
+            style="margin-left: 10px"
+          />
+        </a>
+      </p>
+      {{ "twoStepAuthenticatorScanCodeV2" | i18n }}
     </ng-container>
-    <ng-container bitDialogFooter>
-      <button
-        bitButton
-        bitFormButton
-        type="submit"
-        buttonType="primary"
-        (click)="validateTokenControl()"
-      >
-        {{ (enabled ? "disable" : "enable") | i18n }}
-      </button>
-      <button bitButton bitFormButton type="button" buttonType="secondary" bitDialogClose>
-        {{ "close" | i18n }}
-      </button>
-    </ng-container>
-  </bit-dialog>
+    <hr *ngIf="enabled" />
+    <p class="tw-text-center tw-mb-0">
+      <ng-container *ngIf="qrScriptError" class="tw-mt-2">
+        <bit-icon name="bwi-error" class="tw-text-3xl tw-text-danger"></bit-icon>
+        <p>
+          {{ "twoStepAuthenticatorQRCanvasError" | i18n }}
+        </p>
+      </ng-container>
+      <canvas *ngIf="!qrScriptError" id="qr"></canvas>
+      <br />
+      <code appA11yTitle="{{ 'key' | i18n }}">{{ key }}</code>
+    </p>
+    <bit-form-field *ngIf="!enabled" [disableMargin]="true">
+      <bit-label>{{ "twoStepAuthenticatorEnterCodeV2" | i18n }}</bit-label>
+      <input bitInput type="text" formControlName="token" appInputVerbatim />
+    </bit-form-field>
+  </ng-container>
+  <ng-container bitDialogFooter>
+    <button
+      bitButton
+      bitFormButton
+      type="submit"
+      buttonType="primary"
+      (click)="validateTokenControl()"
+    >
+      {{ (enabled ? "disable" : "enable") | i18n }}
+    </button>
+    <button bitButton bitFormButton type="button" buttonType="secondary" bitDialogClose>
+      {{ "close" | i18n }}
+    </button>
+  </ng-container>
 </form>

--- a/apps/web/src/app/auth/settings/two-factor/two-factor-setup-duo.component.html
+++ b/apps/web/src/app/auth/settings/two-factor/two-factor-setup-duo.component.html
@@ -1,46 +1,52 @@
-<form [formGroup]="formGroup" [bitSubmit]="submit" *ngIf="authed" autocomplete="off">
-  <bit-dialog [title]="'twoStepLogin' | i18n" [subtitle]="'Duo'">
-    <ng-container bitDialogContent>
-      <ng-container *ngIf="enabled">
-        <bit-callout type="success" [title]="'enabled' | i18n" icon="bwi-check-circle">
-          {{ "twoStepLoginProviderEnabled" | i18n }}
-        </bit-callout>
-        <strong>{{ "twoFactorDuoClientId" | i18n }}:</strong> {{ clientId }}
-        <br />
-        <strong>{{ "twoFactorDuoClientSecret" | i18n }}:</strong> {{ clientSecret }}
-        <br />
-        <strong>{{ "twoFactorDuoApiHostname" | i18n }}:</strong> {{ host }}
-      </ng-container>
-      <ng-container *ngIf="!enabled">
-        <p bitTypography="body1">{{ "twoFactorDuoDesc" | i18n }}</p>
-        <bit-form-field>
-          <bit-label>{{ "twoFactorDuoClientId" | i18n }}</bit-label>
-          <input bitInput type="text" formControlName="clientId" appInputVerbatim />
-        </bit-form-field>
-        <bit-form-field>
-          <bit-label>{{ "twoFactorDuoClientSecret" | i18n }}</bit-label>
-          <input bitInput type="password" formControlName="clientSecret" appInputVerbatim />
-        </bit-form-field>
-        <bit-form-field>
-          <bit-label>{{ "twoFactorDuoApiHostname" | i18n }}</bit-label>
-          <input
-            bitInput
-            type="text"
-            formControlName="host"
-            placeholder="{{ 'ex' | i18n }} api-xxxxxxxx.duosecurity.com"
-            appInputVerbatim
-          />
-        </bit-form-field>
-      </ng-container>
+<form
+  [formGroup]="formGroup"
+  [bitSubmit]="submit"
+  *ngIf="authed"
+  autocomplete="off"
+  bit-dialog
+  [title]="'twoStepLogin' | i18n"
+  [subtitle]="'Duo'"
+>
+  <ng-container bitDialogContent>
+    <ng-container *ngIf="enabled">
+      <bit-callout type="success" [title]="'enabled' | i18n" icon="bwi-check-circle">
+        {{ "twoStepLoginProviderEnabled" | i18n }}
+      </bit-callout>
+      <strong>{{ "twoFactorDuoClientId" | i18n }}:</strong> {{ clientId }}
+      <br />
+      <strong>{{ "twoFactorDuoClientSecret" | i18n }}:</strong> {{ clientSecret }}
+      <br />
+      <strong>{{ "twoFactorDuoApiHostname" | i18n }}:</strong> {{ host }}
     </ng-container>
-    <ng-container bitDialogFooter>
-      <button bitButton bitFormButton type="submit" buttonType="primary">
-        <span *ngIf="!enabled">{{ "enable" | i18n }}</span>
-        <span *ngIf="enabled">{{ "disable" | i18n }}</span>
-      </button>
-      <button bitButton bitFormButton type="button" buttonType="secondary" bitDialogClose>
-        {{ "close" | i18n }}
-      </button>
+    <ng-container *ngIf="!enabled">
+      <p bitTypography="body1">{{ "twoFactorDuoDesc" | i18n }}</p>
+      <bit-form-field>
+        <bit-label>{{ "twoFactorDuoClientId" | i18n }}</bit-label>
+        <input bitInput type="text" formControlName="clientId" appInputVerbatim />
+      </bit-form-field>
+      <bit-form-field>
+        <bit-label>{{ "twoFactorDuoClientSecret" | i18n }}</bit-label>
+        <input bitInput type="password" formControlName="clientSecret" appInputVerbatim />
+      </bit-form-field>
+      <bit-form-field>
+        <bit-label>{{ "twoFactorDuoApiHostname" | i18n }}</bit-label>
+        <input
+          bitInput
+          type="text"
+          formControlName="host"
+          placeholder="{{ 'ex' | i18n }} api-xxxxxxxx.duosecurity.com"
+          appInputVerbatim
+        />
+      </bit-form-field>
     </ng-container>
-  </bit-dialog>
+  </ng-container>
+  <ng-container bitDialogFooter>
+    <button bitButton bitFormButton type="submit" buttonType="primary">
+      <span *ngIf="!enabled">{{ "enable" | i18n }}</span>
+      <span *ngIf="enabled">{{ "disable" | i18n }}</span>
+    </button>
+    <button bitButton bitFormButton type="button" buttonType="secondary" bitDialogClose>
+      {{ "close" | i18n }}
+    </button>
+  </ng-container>
 </form>

--- a/apps/web/src/app/auth/settings/two-factor/two-factor-setup-email.component.html
+++ b/apps/web/src/app/auth/settings/two-factor/two-factor-setup-email.component.html
@@ -1,46 +1,51 @@
-<form [formGroup]="formGroup" [bitSubmit]="submit" *ngIf="authed">
-  <bit-dialog [title]="'twoStepLogin' | i18n" [subtitle]="'emailTitle' | i18n">
-    <ng-container bitDialogContent>
-      <ng-container *ngIf="enabled">
-        <bit-callout type="success" title="{{ 'enabled' | i18n }}" icon="bwi-check-circle">
-          {{ "twoStepLoginProviderEnabled" | i18n }}
-        </bit-callout>
-        <strong>{{ "email" | i18n }}:</strong> {{ email }}
-      </ng-container>
-      <ng-container *ngIf="!enabled">
-        <p>{{ "twoFactorEmailDesc" | i18n }}</p>
-        <bit-form-field>
-          <bit-label>1. {{ "twoFactorEmailEnterEmail" | i18n }}</bit-label>
-          <input
-            bitInput
-            type="text"
-            formControlName="email"
-            inputmode="email"
-            appInputVerbatim="false"
-          />
-        </bit-form-field>
-        <div class="tw-mb-3 tw-flex tw-items-center">
-          <button bitButton type="button" buttonType="primary" [bitAction]="sendEmail">
-            {{ "sendEmail" | i18n }}
-          </button>
-          <span class="tw-text-success tw-ml-3" *ngIf="sentEmail">
-            {{ "emailSent" | i18n }}
-          </span>
-        </div>
-        <bit-form-field>
-          <bit-label>2. {{ "twoFactorEmailEnterCode" | i18n }}</bit-label>
-          <input bitInput type="text" formControlName="token" appInputVerbatim />
-        </bit-form-field>
-      </ng-container>
+<form
+  [formGroup]="formGroup"
+  [bitSubmit]="submit"
+  *ngIf="authed"
+  bit-dialog
+  [title]="'twoStepLogin' | i18n"
+  [subtitle]="'emailTitle' | i18n"
+>
+  <ng-container bitDialogContent>
+    <ng-container *ngIf="enabled">
+      <bit-callout type="success" title="{{ 'enabled' | i18n }}" icon="bwi-check-circle">
+        {{ "twoStepLoginProviderEnabled" | i18n }}
+      </bit-callout>
+      <strong>{{ "email" | i18n }}:</strong> {{ email }}
     </ng-container>
-    <ng-container bitDialogFooter>
-      <button bitButton bitFormButton type="submit" buttonType="primary">
-        <span *ngIf="!enabled">{{ "enable" | i18n }}</span>
-        <span *ngIf="enabled">{{ "disable" | i18n }}</span>
-      </button>
-      <button bitButton bitFormButton type="button" buttonType="secondary" bitDialogClose>
-        {{ "close" | i18n }}
-      </button>
+    <ng-container *ngIf="!enabled">
+      <p>{{ "twoFactorEmailDesc" | i18n }}</p>
+      <bit-form-field>
+        <bit-label>1. {{ "twoFactorEmailEnterEmail" | i18n }}</bit-label>
+        <input
+          bitInput
+          type="text"
+          formControlName="email"
+          inputmode="email"
+          appInputVerbatim="false"
+        />
+      </bit-form-field>
+      <div class="tw-mb-3 tw-flex tw-items-center">
+        <button bitButton type="button" buttonType="primary" [bitAction]="sendEmail">
+          {{ "sendEmail" | i18n }}
+        </button>
+        <span class="tw-text-success tw-ml-3" *ngIf="sentEmail">
+          {{ "emailSent" | i18n }}
+        </span>
+      </div>
+      <bit-form-field>
+        <bit-label>2. {{ "twoFactorEmailEnterCode" | i18n }}</bit-label>
+        <input bitInput type="text" formControlName="token" appInputVerbatim />
+      </bit-form-field>
     </ng-container>
-  </bit-dialog>
+  </ng-container>
+  <ng-container bitDialogFooter>
+    <button bitButton bitFormButton type="submit" buttonType="primary">
+      <span *ngIf="!enabled">{{ "enable" | i18n }}</span>
+      <span *ngIf="enabled">{{ "disable" | i18n }}</span>
+    </button>
+    <button bitButton bitFormButton type="button" buttonType="secondary" bitDialogClose>
+      {{ "close" | i18n }}
+    </button>
+  </ng-container>
 </form>

--- a/apps/web/src/app/auth/settings/two-factor/two-factor-setup-webauthn.component.html
+++ b/apps/web/src/app/auth/settings/two-factor/two-factor-setup-webauthn.component.html
@@ -1,120 +1,122 @@
-<form *ngIf="authed" [formGroup]="formGroup" [bitSubmit]="submit">
-  <bit-dialog
-    dialogSize="large"
-    [title]="'twoStepLogin' | i18n"
-    [subtitle]="'webAuthnTitle' | i18n"
-  >
-    <ng-container bitDialogContent>
-      <bit-callout
-        type="success"
-        title="{{ 'enabled' | i18n }}"
-        icon="bwi-check-circle"
-        *ngIf="enabled"
-      >
-        {{ "twoStepLoginProviderEnabled" | i18n }}
-      </bit-callout>
-      <ul class="bwi-ul">
-        <li *ngFor="let k of keys; let i = index" #removeKeyBtn [appApiAction]="k.removePromise">
-          <ng-container *ngIf="k.configured">
-            <bit-icon name="bwi-key" class="bwi-li"></bit-icon>
-            <span *ngIf="k.configured" bitTypography="body1" class="tw-font-medium">
-              {{ k.name || ("unnamedKey" | i18n) }}
-            </span>
-            <ng-container *ngIf="k.configured && !$any(removeKeyBtn).loading">
-              <ng-container *ngIf="k.migrated">
-                <span>{{ "webAuthnMigrated" | i18n }}</span>
-              </ng-container>
-            </ng-container>
-            <ng-container *ngIf="keysConfiguredCount > 1 && k.configured">
-              <bit-icon
-                name="bwi-spinner"
-                class="bwi-spin tw-text-muted bwi-fw"
-                [ariaLabel]="'loading' | i18n"
-                *ngIf="$any(removeKeyBtn).loading"
-              ></bit-icon>
-              -
-              <a bitLink href="#" appStopClick (click)="remove(k)">{{ "remove" | i18n }}</a>
+<form
+  *ngIf="authed"
+  [formGroup]="formGroup"
+  [bitSubmit]="submit"
+  bit-dialog
+  dialogSize="large"
+  [title]="'twoStepLogin' | i18n"
+  [subtitle]="'webAuthnTitle' | i18n"
+>
+  <ng-container bitDialogContent>
+    <bit-callout
+      type="success"
+      title="{{ 'enabled' | i18n }}"
+      icon="bwi-check-circle"
+      *ngIf="enabled"
+    >
+      {{ "twoStepLoginProviderEnabled" | i18n }}
+    </bit-callout>
+    <ul class="bwi-ul">
+      <li *ngFor="let k of keys; let i = index" #removeKeyBtn [appApiAction]="k.removePromise">
+        <ng-container *ngIf="k.configured">
+          <bit-icon name="bwi-key" class="bwi-li"></bit-icon>
+          <span *ngIf="k.configured" bitTypography="body1" class="tw-font-medium">
+            {{ k.name || ("unnamedKey" | i18n) }}
+          </span>
+          <ng-container *ngIf="k.configured && !$any(removeKeyBtn).loading">
+            <ng-container *ngIf="k.migrated">
+              <span>{{ "webAuthnMigrated" | i18n }}</span>
             </ng-container>
           </ng-container>
-        </li>
-      </ul>
-      <hr />
-      <p bitTypography="body1">{{ "twoFactorWebAuthnAdd" | i18n }}:</p>
-      <ol bitTypography="body1">
-        <li>{{ "twoFactorU2fGiveName" | i18n }}</li>
-        <li>{{ "twoFactorU2fPlugInReadKey" | i18n }}</li>
-        <li>{{ "twoFactorU2fTouchButton" | i18n }}</li>
-        <li>{{ "twoFactorU2fSaveForm" | i18n }}</li>
-      </ol>
-      <div class="tw-flex">
-        <bit-form-field class="tw-basis-1/2">
-          <bit-label>{{ "name" | i18n }}</bit-label>
-          <input bitInput type="text" formControlName="name" />
-        </bit-form-field>
-      </div>
-      <button
-        bitButton
-        bitFormButton
-        type="button"
-        [bitAction]="readKey"
-        buttonType="secondary"
-        [disabled]="
-          $any(readKeyBtn).loading() || webAuthnListening || !keyIdAvailable || formGroup.invalid
-        "
-        class="tw-mr-2"
-        #readKeyBtn
-      >
-        {{ "readKey" | i18n }}
-      </button>
-      <ng-container *ngIf="$any(readKeyBtn).loading()">
+          <ng-container *ngIf="keysConfiguredCount > 1 && k.configured">
+            <bit-icon
+              name="bwi-spinner"
+              class="bwi-spin tw-text-muted bwi-fw"
+              [ariaLabel]="'loading' | i18n"
+              *ngIf="$any(removeKeyBtn).loading"
+            ></bit-icon>
+            -
+            <a bitLink href="#" appStopClick (click)="remove(k)">{{ "remove" | i18n }}</a>
+          </ng-container>
+        </ng-container>
+      </li>
+    </ul>
+    <hr />
+    <p bitTypography="body1">{{ "twoFactorWebAuthnAdd" | i18n }}:</p>
+    <ol bitTypography="body1">
+      <li>{{ "twoFactorU2fGiveName" | i18n }}</li>
+      <li>{{ "twoFactorU2fPlugInReadKey" | i18n }}</li>
+      <li>{{ "twoFactorU2fTouchButton" | i18n }}</li>
+      <li>{{ "twoFactorU2fSaveForm" | i18n }}</li>
+    </ol>
+    <div class="tw-flex">
+      <bit-form-field class="tw-basis-1/2">
+        <bit-label>{{ "name" | i18n }}</bit-label>
+        <input bitInput type="text" formControlName="name" />
+      </bit-form-field>
+    </div>
+    <button
+      bitButton
+      bitFormButton
+      type="button"
+      [bitAction]="readKey"
+      buttonType="secondary"
+      [disabled]="
+        $any(readKeyBtn).loading() || webAuthnListening || !keyIdAvailable || formGroup.invalid
+      "
+      class="tw-mr-2"
+      #readKeyBtn
+    >
+      {{ "readKey" | i18n }}
+    </button>
+    <ng-container *ngIf="$any(readKeyBtn).loading()">
+      <bit-icon
+        name="bwi-spinner"
+        class="bwi-spin tw-text-muted"
+        [ariaLabel]="'loading' | i18n"
+      ></bit-icon>
+    </ng-container>
+    <ng-container *ngIf="!$any(readKeyBtn).loading()">
+      <ng-container *ngIf="webAuthnListening">
         <bit-icon
           name="bwi-spinner"
           class="bwi-spin tw-text-muted"
           [ariaLabel]="'loading' | i18n"
         ></bit-icon>
+        {{ "twoFactorU2fWaiting" | i18n }}...
       </ng-container>
-      <ng-container *ngIf="!$any(readKeyBtn).loading()">
-        <ng-container *ngIf="webAuthnListening">
-          <bit-icon
-            name="bwi-spinner"
-            class="bwi-spin tw-text-muted"
-            [ariaLabel]="'loading' | i18n"
-          ></bit-icon>
-          {{ "twoFactorU2fWaiting" | i18n }}...
-        </ng-container>
-        <ng-container *ngIf="webAuthnResponse">
-          <bit-icon name="bwi-check-circle" class="tw-text-success"></bit-icon>
-          {{ "twoFactorU2fClickSave" | i18n }}
-        </ng-container>
-        <ng-container *ngIf="webAuthnError">
-          <bit-icon name="bwi-exclamation-triangle" class="tw-text-danger"></bit-icon>
-          {{ "twoFactorU2fProblemReadingTryAgain" | i18n }}
-        </ng-container>
+      <ng-container *ngIf="webAuthnResponse">
+        <bit-icon name="bwi-check-circle" class="tw-text-success"></bit-icon>
+        {{ "twoFactorU2fClickSave" | i18n }}
+      </ng-container>
+      <ng-container *ngIf="webAuthnError">
+        <bit-icon name="bwi-exclamation-triangle" class="tw-text-danger"></bit-icon>
+        {{ "twoFactorU2fProblemReadingTryAgain" | i18n }}
       </ng-container>
     </ng-container>
-    <ng-container bitDialogFooter>
-      <button
-        bitButton
-        bitFormButton
-        type="submit"
-        buttonType="primary"
-        [disabled]="!webAuthnResponse"
-      >
-        {{ "save" | i18n }}
-      </button>
-      <button
-        bitButton
-        bitFormButton
-        *ngIf="enabled"
-        type="button"
-        buttonType="secondary"
-        [bitAction]="disable"
-      >
-        {{ "disableAllKeys" | i18n }}
-      </button>
-      <button bitButton bitFormButton type="button" buttonType="secondary" bitDialogClose>
-        {{ "close" | i18n }}
-      </button>
-    </ng-container>
-  </bit-dialog>
+  </ng-container>
+  <ng-container bitDialogFooter>
+    <button
+      bitButton
+      bitFormButton
+      type="submit"
+      buttonType="primary"
+      [disabled]="!webAuthnResponse"
+    >
+      {{ "save" | i18n }}
+    </button>
+    <button
+      bitButton
+      bitFormButton
+      *ngIf="enabled"
+      type="button"
+      buttonType="secondary"
+      [bitAction]="disable"
+    >
+      {{ "disableAllKeys" | i18n }}
+    </button>
+    <button bitButton bitFormButton type="button" buttonType="secondary" bitDialogClose>
+      {{ "close" | i18n }}
+    </button>
+  </ng-container>
 </form>

--- a/apps/web/src/app/auth/settings/two-factor/two-factor-setup-yubikey.component.html
+++ b/apps/web/src/app/auth/settings/two-factor/two-factor-setup-yubikey.component.html
@@ -1,77 +1,83 @@
-<form *ngIf="authed" [formGroup]="formGroup" [bitSubmit]="submit">
-  <bit-dialog dialogSize="large" [title]="'twoStepLogin' | i18n" [subtitle]="'YubiKey'">
-    <ng-container bitDialogContent>
-      <bit-callout
-        *ngIf="enabled"
-        type="success"
-        title="{{ 'enabled' | i18n }}"
-        icon="bwi-check-circle"
-      >
-        {{ "twoStepLoginProviderEnabled" | i18n }}
-      </bit-callout>
-      <bit-callout type="warning">
-        <p bitTypography="body1">{{ "twoFactorYubikeyWarning" | i18n }}</p>
-        <ul class="tw-mb-0" bitTypography="body1">
-          <li>{{ "twoFactorYubikeySupportUsb" | i18n }}</li>
-          <li>{{ "twoFactorYubikeySupportMobile" | i18n }}</li>
-        </ul>
-      </bit-callout>
-      <p bitTypography="body1">{{ "twoFactorYubikeyAdd" | i18n }}:</p>
-      <ol bitTypography="body1">
-        <li>{{ "twoFactorYubikeyPlugIn" | i18n }}</li>
-        <li>{{ "twoFactorYubikeySelectKey" | i18n }}</li>
-        <li>{{ "twoFactorYubikeyTouchButton" | i18n }}</li>
-        <li>{{ "twoFactorYubikeySaveForm" | i18n }}</li>
-      </ol>
-      <hr />
-      <div class="tw-flex tw-flex-col tw-mt-4" formArrayName="formKeys">
-        <div *ngFor="let k of keys; let i = index" [formGroupName]="i">
-          <bit-label>{{ "yubikeyX" | i18n: (i + 1).toString() }}</bit-label>
-          <bit-form-field *ngIf="!keys[i].existingKey">
-            <input bitInput type="password" formControlName="key" appInputVerbatim />
-          </bit-form-field>
-          <div class="tw-flex tw-justify-between tw-mb-4" *ngIf="keys[i].existingKey">
-            <span class="tw-mr-2 tw-self-center">{{ keys[i].existingKey }}</span>
-            <button
-              bitIconButton="bwi-minus-circle"
-              type="button"
-              buttonType="dangerGhost"
-              (click)="remove(i)"
-              label="{{ 'remove' | i18n }}"
-            ></button>
-          </div>
+<form
+  *ngIf="authed"
+  [formGroup]="formGroup"
+  [bitSubmit]="submit"
+  bit-dialog
+  dialogSize="large"
+  [title]="'twoStepLogin' | i18n"
+  [subtitle]="'YubiKey'"
+>
+  <ng-container bitDialogContent>
+    <bit-callout
+      *ngIf="enabled"
+      type="success"
+      title="{{ 'enabled' | i18n }}"
+      icon="bwi-check-circle"
+    >
+      {{ "twoStepLoginProviderEnabled" | i18n }}
+    </bit-callout>
+    <bit-callout type="warning">
+      <p bitTypography="body1">{{ "twoFactorYubikeyWarning" | i18n }}</p>
+      <ul class="tw-mb-0" bitTypography="body1">
+        <li>{{ "twoFactorYubikeySupportUsb" | i18n }}</li>
+        <li>{{ "twoFactorYubikeySupportMobile" | i18n }}</li>
+      </ul>
+    </bit-callout>
+    <p bitTypography="body1">{{ "twoFactorYubikeyAdd" | i18n }}:</p>
+    <ol bitTypography="body1">
+      <li>{{ "twoFactorYubikeyPlugIn" | i18n }}</li>
+      <li>{{ "twoFactorYubikeySelectKey" | i18n }}</li>
+      <li>{{ "twoFactorYubikeyTouchButton" | i18n }}</li>
+      <li>{{ "twoFactorYubikeySaveForm" | i18n }}</li>
+    </ol>
+    <hr />
+    <div class="tw-flex tw-flex-col tw-mt-4" formArrayName="formKeys">
+      <div *ngFor="let k of keys; let i = index" [formGroupName]="i">
+        <bit-label>{{ "yubikeyX" | i18n: (i + 1).toString() }}</bit-label>
+        <bit-form-field *ngIf="!keys[i].existingKey">
+          <input bitInput type="password" formControlName="key" appInputVerbatim />
+        </bit-form-field>
+        <div class="tw-flex tw-justify-between tw-mb-4" *ngIf="keys[i].existingKey">
+          <span class="tw-mr-2 tw-self-center">{{ keys[i].existingKey }}</span>
+          <button
+            bitIconButton="bwi-minus-circle"
+            type="button"
+            buttonType="dangerGhost"
+            (click)="remove(i)"
+            label="{{ 'remove' | i18n }}"
+          ></button>
         </div>
       </div>
-      <p bitTypography="body1" class="tw-font-medium tw-mb-2">{{ "nfcSupport" | i18n }}</p>
-      <bit-form-control [disableMargin]="true">
-        <bit-label>{{ "twoFactorYubikeySupportsNfc" | i18n }}</bit-label>
-        <input bitCheckbox type="checkbox" formControlName="anyKeyHasNfc" />
-        <bit-hint class="tw-text-sm">{{ "twoFactorYubikeySupportsNfcDesc" | i18n }}</bit-hint>
-      </bit-form-control>
-    </ng-container>
-    <ng-container bitDialogFooter>
-      <button bitButton bitFormButton type="submit" buttonType="primary">
-        {{ "save" | i18n }}
-      </button>
-      <button
-        *ngIf="enabled"
-        bitButton
-        bitFormButton
-        type="button"
-        buttonType="secondary"
-        [bitAction]="disable"
-      >
-        {{ "disableAllKeys" | i18n }}
-      </button>
-      <button
-        bitButton
-        bitFormButton
-        type="button"
-        buttonType="secondary"
-        [bitDialogClose]="this.enabled"
-      >
-        {{ "close" | i18n }}
-      </button>
-    </ng-container>
-  </bit-dialog>
+    </div>
+    <p bitTypography="body1" class="tw-font-medium tw-mb-2">{{ "nfcSupport" | i18n }}</p>
+    <bit-form-control [disableMargin]="true">
+      <bit-label>{{ "twoFactorYubikeySupportsNfc" | i18n }}</bit-label>
+      <input bitCheckbox type="checkbox" formControlName="anyKeyHasNfc" />
+      <bit-hint class="tw-text-sm">{{ "twoFactorYubikeySupportsNfcDesc" | i18n }}</bit-hint>
+    </bit-form-control>
+  </ng-container>
+  <ng-container bitDialogFooter>
+    <button bitButton bitFormButton type="submit" buttonType="primary">
+      {{ "save" | i18n }}
+    </button>
+    <button
+      *ngIf="enabled"
+      bitButton
+      bitFormButton
+      type="button"
+      buttonType="secondary"
+      [bitAction]="disable"
+    >
+      {{ "disableAllKeys" | i18n }}
+    </button>
+    <button
+      bitButton
+      bitFormButton
+      type="button"
+      buttonType="secondary"
+      [bitDialogClose]="this.enabled"
+    >
+      {{ "close" | i18n }}
+    </button>
+  </ng-container>
 </form>

--- a/apps/web/src/app/auth/settings/two-factor/two-factor-verify.component.html
+++ b/apps/web/src/app/auth/settings/two-factor/two-factor-verify.component.html
@@ -1,19 +1,24 @@
-<form [formGroup]="formGroup" [bitSubmit]="submit">
-  <bit-dialog dialogSize="default" [title]="'twoStepLogin' | i18n" [subtitle]="dialogTitle">
-    <ng-container bitDialogContent>
-      <app-user-verification-form-input
-        formControlName="secret"
-        name="secret"
-        [(invalidSecret)]="invalidSecret"
-      ></app-user-verification-form-input>
-    </ng-container>
-    <ng-container bitDialogFooter>
-      <button bitButton bitFormButton type="submit" buttonType="primary">
-        {{ "continue" | i18n }}
-      </button>
-      <button bitButton type="button" buttonType="secondary" bitDialogClose>
-        {{ "close" | i18n }}
-      </button>
-    </ng-container>
-  </bit-dialog>
+<form
+  [formGroup]="formGroup"
+  [bitSubmit]="submit"
+  bit-dialog
+  dialogSize="default"
+  [title]="'twoStepLogin' | i18n"
+  [subtitle]="dialogTitle"
+>
+  <ng-container bitDialogContent>
+    <app-user-verification-form-input
+      formControlName="secret"
+      name="secret"
+      [(invalidSecret)]="invalidSecret"
+    ></app-user-verification-form-input>
+  </ng-container>
+  <ng-container bitDialogFooter>
+    <button bitButton bitFormButton type="submit" buttonType="primary">
+      {{ "continue" | i18n }}
+    </button>
+    <button bitButton type="button" buttonType="secondary" bitDialogClose>
+      {{ "close" | i18n }}
+    </button>
+  </ng-container>
 </form>

--- a/apps/web/src/app/auth/settings/webauthn-login-settings/create-credential-dialog/create-credential-dialog.component.html
+++ b/apps/web/src/app/auth/settings/webauthn-login-settings/create-credential-dialog/create-credential-dialog.component.html
@@ -1,76 +1,80 @@
-<form [formGroup]="formGroup" [bitSubmit]="submit">
-  <bit-dialog dialogSize="large" [loading]="loading$ | async">
-    <span bitDialogTitle
-      >{{ "logInWithPasskey" | i18n }}
-      <span class="tw-text-sm tw-normal-case tw-text-muted">{{ "newPasskey" | i18n }}</span>
-    </span>
-    <ng-container bitDialogContent>
-      <ng-container *ngIf="currentStep === 'userVerification'">
-        <ng-container formGroupName="userVerification">
-          <app-user-verification
-            formControlName="secret"
-            [(invalidSecret)]="invalidSecret"
-          ></app-user-verification>
-        </ng-container>
+<form
+  [formGroup]="formGroup"
+  [bitSubmit]="submit"
+  bit-dialog
+  dialogSize="large"
+  [loading]="loading$ | async"
+>
+  <span bitDialogTitle
+    >{{ "logInWithPasskey" | i18n }}
+    <span class="tw-text-sm tw-normal-case tw-text-muted">{{ "newPasskey" | i18n }}</span>
+  </span>
+  <ng-container bitDialogContent>
+    <ng-container *ngIf="currentStep === 'userVerification'">
+      <ng-container formGroupName="userVerification">
+        <app-user-verification
+          formControlName="secret"
+          [(invalidSecret)]="invalidSecret"
+        ></app-user-verification>
       </ng-container>
-
-      <div *ngIf="currentStep === 'credentialCreation'" class="tw-flex tw-flex-col tw-items-center">
-        <div class="tw-size-24 tw-content-center tw-mb-6">
-          <bit-svg [content]="Icons.TwoFactorAuthSecurityKeyIcon"></bit-svg>
-        </div>
-        <h3 bitTypography="h3">{{ "creatingPasskeyLoading" | i18n }}</h3>
-        <p bitTypography="body1">{{ "creatingPasskeyLoadingInfo" | i18n }}</p>
-      </div>
-
-      <div
-        *ngIf="currentStep === 'credentialCreationFailed'"
-        class="tw-flex tw-flex-col tw-items-center"
-      >
-        <div class="tw-size-24 tw-content-center tw-mb-6">
-          <bit-svg [content]="Icons.TwoFactorAuthSecurityKeyFailedIcon"></bit-svg>
-        </div>
-        <h3 bitTypography="h3">{{ "errorCreatingPasskey" | i18n }}</h3>
-        <p bitTypography="body1">{{ "errorCreatingPasskeyInfo" | i18n }}</p>
-      </div>
-
-      <div *ngIf="currentStep === 'credentialNaming'" formGroupName="credentialNaming">
-        <h3 bitTypography="h3">{{ "passkeySuccessfullyCreated" | i18n }}</h3>
-        <p bitTypography="body1">
-          {{ "customPasskeyNameInfo" | i18n }}
-        </p>
-        <bit-form-field class="!tw-mb-0">
-          <bit-label>{{ "name" | i18n }}</bit-label>
-          <input type="text" bitInput formControlName="name" appAutofocus />
-          <bit-hint>{{
-            "charactersCurrentAndMaximum"
-              | i18n: formGroup.value.credentialNaming.name.length : NameMaxCharacters
-          }}</bit-hint>
-        </bit-form-field>
-        <bit-form-control *ngIf="pendingCredential?.supportsPrf" class="!tw-mb-0 tw-mt-6">
-          <input type="checkbox" bitCheckbox formControlName="useForEncryption" />
-          <bit-label>{{ "useForVaultEncryption" | i18n }}</bit-label>
-          <bit-hint>{{ "useForVaultEncryptionInfo" | i18n }}</bit-hint>
-        </bit-form-control>
-      </div>
     </ng-container>
-    <ng-container bitDialogFooter>
-      <button type="submit" bitButton bitFormButton buttonType="primary">
-        <ng-container *ngIf="currentStep === 'userVerification'">
-          {{ "continue" | i18n }}
-        </ng-container>
-        <ng-container *ngIf="currentStep === 'credentialCreation'">
-          {{ "continue" | i18n }}
-        </ng-container>
-        <ng-container *ngIf="currentStep === 'credentialCreationFailed'">
-          {{ "tryAgain" | i18n }}
-        </ng-container>
-        <ng-container *ngIf="currentStep === 'credentialNaming'">
-          {{ ((hasPasskeys$ | async) ? "save" : "enable") | i18n }}
-        </ng-container>
-      </button>
-      <button type="button" bitButton bitFormButton buttonType="secondary" bitDialogClose>
-        {{ "cancel" | i18n }}
-      </button>
-    </ng-container>
-  </bit-dialog>
+
+    <div *ngIf="currentStep === 'credentialCreation'" class="tw-flex tw-flex-col tw-items-center">
+      <div class="tw-size-24 tw-content-center tw-mb-6">
+        <bit-svg [content]="Icons.TwoFactorAuthSecurityKeyIcon"></bit-svg>
+      </div>
+      <h3 bitTypography="h3">{{ "creatingPasskeyLoading" | i18n }}</h3>
+      <p bitTypography="body1">{{ "creatingPasskeyLoadingInfo" | i18n }}</p>
+    </div>
+
+    <div
+      *ngIf="currentStep === 'credentialCreationFailed'"
+      class="tw-flex tw-flex-col tw-items-center"
+    >
+      <div class="tw-size-24 tw-content-center tw-mb-6">
+        <bit-svg [content]="Icons.TwoFactorAuthSecurityKeyFailedIcon"></bit-svg>
+      </div>
+      <h3 bitTypography="h3">{{ "errorCreatingPasskey" | i18n }}</h3>
+      <p bitTypography="body1">{{ "errorCreatingPasskeyInfo" | i18n }}</p>
+    </div>
+
+    <div *ngIf="currentStep === 'credentialNaming'" formGroupName="credentialNaming">
+      <h3 bitTypography="h3">{{ "passkeySuccessfullyCreated" | i18n }}</h3>
+      <p bitTypography="body1">
+        {{ "customPasskeyNameInfo" | i18n }}
+      </p>
+      <bit-form-field class="!tw-mb-0">
+        <bit-label>{{ "name" | i18n }}</bit-label>
+        <input type="text" bitInput formControlName="name" appAutofocus />
+        <bit-hint>{{
+          "charactersCurrentAndMaximum"
+            | i18n: formGroup.value.credentialNaming.name.length : NameMaxCharacters
+        }}</bit-hint>
+      </bit-form-field>
+      <bit-form-control *ngIf="pendingCredential?.supportsPrf" class="!tw-mb-0 tw-mt-6">
+        <input type="checkbox" bitCheckbox formControlName="useForEncryption" />
+        <bit-label>{{ "useForVaultEncryption" | i18n }}</bit-label>
+        <bit-hint>{{ "useForVaultEncryptionInfo" | i18n }}</bit-hint>
+      </bit-form-control>
+    </div>
+  </ng-container>
+  <ng-container bitDialogFooter>
+    <button type="submit" bitButton bitFormButton buttonType="primary">
+      <ng-container *ngIf="currentStep === 'userVerification'">
+        {{ "continue" | i18n }}
+      </ng-container>
+      <ng-container *ngIf="currentStep === 'credentialCreation'">
+        {{ "continue" | i18n }}
+      </ng-container>
+      <ng-container *ngIf="currentStep === 'credentialCreationFailed'">
+        {{ "tryAgain" | i18n }}
+      </ng-container>
+      <ng-container *ngIf="currentStep === 'credentialNaming'">
+        {{ ((hasPasskeys$ | async) ? "save" : "enable") | i18n }}
+      </ng-container>
+    </button>
+    <button type="button" bitButton bitFormButton buttonType="secondary" bitDialogClose>
+      {{ "cancel" | i18n }}
+    </button>
+  </ng-container>
 </form>

--- a/apps/web/src/app/auth/settings/webauthn-login-settings/delete-credential-dialog/delete-credential-dialog.component.html
+++ b/apps/web/src/app/auth/settings/webauthn-login-settings/delete-credential-dialog/delete-credential-dialog.component.html
@@ -1,36 +1,40 @@
-<form [formGroup]="formGroup" [bitSubmit]="submit">
-  <bit-dialog dialogSize="large" [loading]="loading$ | async">
-    <span bitDialogTitle
-      >{{ "removePasskey" | i18n }}
-      <span *ngIf="credential" class="tw-text-sm tw-normal-case tw-text-muted">{{
-        credential.name
-      }}</span>
-    </span>
-    <ng-container bitDialogContent>
-      <ng-container *ngIf="!credential">
-        <bit-icon
-          name="bwi-spinner"
-          class="bwi-spin tw-ml-1"
-          [ariaLabel]="'loading' | i18n"
-        ></bit-icon>
-      </ng-container>
-
-      <ng-container *ngIf="credential">
-        <p bitTypography="body1">{{ "removePasskeyInfo" | i18n }}</p>
-
-        <app-user-verification
-          formControlName="secret"
-          [(invalidSecret)]="invalidSecret"
-        ></app-user-verification>
-      </ng-container>
+<form
+  [formGroup]="formGroup"
+  [bitSubmit]="submit"
+  bit-dialog
+  dialogSize="large"
+  [loading]="loading$ | async"
+>
+  <span bitDialogTitle
+    >{{ "removePasskey" | i18n }}
+    <span *ngIf="credential" class="tw-text-sm tw-normal-case tw-text-muted">{{
+      credential.name
+    }}</span>
+  </span>
+  <ng-container bitDialogContent>
+    <ng-container *ngIf="!credential">
+      <bit-icon
+        name="bwi-spinner"
+        class="bwi-spin tw-ml-1"
+        [ariaLabel]="'loading' | i18n"
+      ></bit-icon>
     </ng-container>
-    <ng-container bitDialogFooter>
-      <button type="submit" bitButton bitFormButton buttonType="danger">
-        {{ "remove" | i18n }}
-      </button>
-      <button type="button" bitButton bitFormButton buttonType="secondary" bitDialogClose>
-        {{ "cancel" | i18n }}
-      </button>
+
+    <ng-container *ngIf="credential">
+      <p bitTypography="body1">{{ "removePasskeyInfo" | i18n }}</p>
+
+      <app-user-verification
+        formControlName="secret"
+        [(invalidSecret)]="invalidSecret"
+      ></app-user-verification>
     </ng-container>
-  </bit-dialog>
+  </ng-container>
+  <ng-container bitDialogFooter>
+    <button type="submit" bitButton bitFormButton buttonType="danger">
+      {{ "remove" | i18n }}
+    </button>
+    <button type="button" bitButton bitFormButton buttonType="secondary" bitDialogClose>
+      {{ "cancel" | i18n }}
+    </button>
+  </ng-container>
 </form>

--- a/apps/web/src/app/auth/settings/webauthn-login-settings/enable-encryption-dialog/enable-encryption-dialog.component.html
+++ b/apps/web/src/app/auth/settings/webauthn-login-settings/enable-encryption-dialog/enable-encryption-dialog.component.html
@@ -1,38 +1,42 @@
-<form [formGroup]="formGroup" [bitSubmit]="submit">
-  <bit-dialog dialogSize="large" [loading]="loading$ | async">
-    <span bitDialogTitle
-      >{{ "enablePasskeyEncryption" | i18n }}
-      <span *ngIf="credential" class="tw-text-sm tw-normal-case tw-text-muted">{{
-        credential.name
-      }}</span>
-    </span>
-    <ng-container bitDialogContent>
-      <ng-container *ngIf="!credential">
-        <bit-icon
-          name="bwi-spinner"
-          class="bwi-spin tw-ml-1"
-          [ariaLabel]="'loading' | i18n"
-        ></bit-icon>
-      </ng-container>
+<form
+  [formGroup]="formGroup"
+  [bitSubmit]="submit"
+  bit-dialog
+  dialogSize="large"
+  [loading]="loading$ | async"
+>
+  <span bitDialogTitle
+    >{{ "enablePasskeyEncryption" | i18n }}
+    <span *ngIf="credential" class="tw-text-sm tw-normal-case tw-text-muted">{{
+      credential.name
+    }}</span>
+  </span>
+  <ng-container bitDialogContent>
+    <ng-container *ngIf="!credential">
+      <bit-icon
+        name="bwi-spinner"
+        class="bwi-spin tw-ml-1"
+        [ariaLabel]="'loading' | i18n"
+      ></bit-icon>
+    </ng-container>
 
-      <ng-container *ngIf="credential">
-        <p bitTypography="body1">{{ "useForVaultEncryptionInfo" | i18n }}</p>
+    <ng-container *ngIf="credential">
+      <p bitTypography="body1">{{ "useForVaultEncryptionInfo" | i18n }}</p>
 
-        <ng-container formGroupName="userVerification">
-          <app-user-verification
-            formControlName="secret"
-            [(invalidSecret)]="invalidSecret"
-          ></app-user-verification>
-        </ng-container>
+      <ng-container formGroupName="userVerification">
+        <app-user-verification
+          formControlName="secret"
+          [(invalidSecret)]="invalidSecret"
+        ></app-user-verification>
       </ng-container>
     </ng-container>
-    <ng-container bitDialogFooter>
-      <button type="submit" bitButton bitFormButton buttonType="primary">
-        {{ "submit" | i18n }}
-      </button>
-      <button type="button" bitButton bitFormButton buttonType="secondary" bitDialogClose>
-        {{ "cancel" | i18n }}
-      </button>
-    </ng-container>
-  </bit-dialog>
+  </ng-container>
+  <ng-container bitDialogFooter>
+    <button type="submit" bitButton bitFormButton buttonType="primary">
+      {{ "submit" | i18n }}
+    </button>
+    <button type="button" bitButton bitFormButton buttonType="secondary" bitDialogClose>
+      {{ "cancel" | i18n }}
+    </button>
+  </ng-container>
 </form>

--- a/apps/web/src/app/auth/shared/components/user-verification/user-verification-prompt.component.html
+++ b/apps/web/src/app/auth/shared/components/user-verification/user-verification-prompt.component.html
@@ -1,20 +1,18 @@
-<form [formGroup]="formGroup" [bitSubmit]="submit">
-  <bit-dialog>
-    <span bitDialogTitle>{{ modalTitle | i18n }}</span>
-    <ng-container bitDialogContent>
-      <p bitTypography="body1">{{ confirmDescription | i18n }}</p>
-      <app-user-verification
-        [(invalidSecret)]="invalidSecret"
-        formControlName="secret"
-      ></app-user-verification>
-    </ng-container>
-    <ng-container bitDialogFooter>
-      <button type="submit" bitButton bitFormButton buttonType="primary">
-        {{ confirmButtonText | i18n }}
-      </button>
-      <button type="button" bitButton bitFormButton buttonType="secondary" bitDialogClose>
-        {{ "cancel" | i18n }}
-      </button>
-    </ng-container>
-  </bit-dialog>
+<form [formGroup]="formGroup" [bitSubmit]="submit" bit-dialog>
+  <span bitDialogTitle>{{ modalTitle | i18n }}</span>
+  <ng-container bitDialogContent>
+    <p bitTypography="body1">{{ confirmDescription | i18n }}</p>
+    <app-user-verification
+      [(invalidSecret)]="invalidSecret"
+      formControlName="secret"
+    ></app-user-verification>
+  </ng-container>
+  <ng-container bitDialogFooter>
+    <button type="submit" bitButton bitFormButton buttonType="primary">
+      {{ confirmButtonText | i18n }}
+    </button>
+    <button type="button" bitButton bitFormButton buttonType="secondary" bitDialogClose>
+      {{ "cancel" | i18n }}
+    </button>
+  </ng-container>
 </form>

--- a/apps/web/src/app/billing/individual/subscription/adjust-account-subscription-storage-dialog.component.html
+++ b/apps/web/src/app/billing/individual/subscription/adjust-account-subscription-storage-dialog.component.html
@@ -1,43 +1,41 @@
 @let content = this.content();
-<form [formGroup]="formGroup" [bitSubmit]="submit">
-  <bit-dialog [title]="content.title">
-    <ng-container bitDialogContent>
-      <p bitTypography="body1">{{ content.body }}</p>
-      <div class="tw-grid tw-grid-cols-12">
-        <bit-form-field class="tw-col-span-7">
-          <bit-label>{{ content.label }}</bit-label>
-          <input bitInput type="number" [formControl]="formGroup.controls.amount" />
-          @if (action() === "add") {
-            <bit-hint>
-              <!-- Total: 10 GB × $0.50 = $5.00 /month -->
-              <strong>{{ "total" | i18n }}</strong>
-              {{ formGroup.value.amount }} GB &times; {{ price() | currency: "$" }} =
-              {{ price() * formGroup.value.amount | currency: "$" }} /
-              {{ term() | i18n }}
-            </bit-hint>
-          }
-        </bit-form-field>
-      </div>
-    </ng-container>
-    <ng-container bitDialogFooter>
-      <button
-        type="submit"
-        bitButton
-        bitFormButton
-        buttonType="primary"
-        [disabled]="formGroup.invalid"
-      >
-        {{ "submit" | i18n }}
-      </button>
-      <button
-        type="button"
-        bitButton
-        bitFormButton
-        buttonType="secondary"
-        [bitDialogClose]="'closed'"
-      >
-        {{ "cancel" | i18n }}
-      </button>
-    </ng-container>
-  </bit-dialog>
+<form [formGroup]="formGroup" [bitSubmit]="submit" bit-dialog [title]="content.title">
+  <ng-container bitDialogContent>
+    <p bitTypography="body1">{{ content.body }}</p>
+    <div class="tw-grid tw-grid-cols-12">
+      <bit-form-field class="tw-col-span-7">
+        <bit-label>{{ content.label }}</bit-label>
+        <input bitInput type="number" [formControl]="formGroup.controls.amount" />
+        @if (action() === "add") {
+          <bit-hint>
+            <!-- Total: 10 GB × $0.50 = $5.00 /month -->
+            <strong>{{ "total" | i18n }}</strong>
+            {{ formGroup.value.amount }} GB &times; {{ price() | currency: "$" }} =
+            {{ price() * formGroup.value.amount | currency: "$" }} /
+            {{ term() | i18n }}
+          </bit-hint>
+        }
+      </bit-form-field>
+    </div>
+  </ng-container>
+  <ng-container bitDialogFooter>
+    <button
+      type="submit"
+      bitButton
+      bitFormButton
+      buttonType="primary"
+      [disabled]="formGroup.invalid"
+    >
+      {{ "submit" | i18n }}
+    </button>
+    <button
+      type="button"
+      bitButton
+      bitFormButton
+      buttonType="secondary"
+      [bitDialogClose]="'closed'"
+    >
+      {{ "cancel" | i18n }}
+    </button>
+  </ng-container>
 </form>

--- a/apps/web/src/app/billing/individual/upgrade/premium-org-upgrade-payment/premium-org-upgrade-payment.component.html
+++ b/apps/web/src/app/billing/individual/upgrade/premium-org-upgrade-payment/premium-org-upgrade-payment.component.html
@@ -1,63 +1,67 @@
-<form [formGroup]="formGroup" [bitSubmit]="submit">
-  <bit-dialog dialogSize="large" [loading]="loading()">
-    <span bitDialogTitle class="tw-font-medium">{{ upgradeToMessage() }}</span>
+<form
+  [formGroup]="formGroup"
+  [bitSubmit]="submit"
+  bit-dialog
+  dialogSize="large"
+  [loading]="loading()"
+>
+  <span bitDialogTitle class="tw-font-medium">{{ upgradeToMessage() }}</span>
 
-    <ng-container bitDialogContent>
-      <section>
-        <div class="tw-pb-4">
-          <bit-form-field class="!tw-mb-0">
-            <bit-label>{{ "organizationName" | i18n }}</bit-label>
-            <input bitInput type="text" formControlName="organizationName" required />
-            <bit-hint bitTypography="helper" class="tw-text-muted">
-              {{ "organizationNameDescription" | i18n }}
-            </bit-hint>
-          </bit-form-field>
-        </div>
+  <ng-container bitDialogContent>
+    <section>
+      <div class="tw-pb-4">
+        <bit-form-field class="!tw-mb-0">
+          <bit-label>{{ "organizationName" | i18n }}</bit-label>
+          <input bitInput type="text" formControlName="organizationName" required />
+          <bit-hint bitTypography="helper" class="tw-text-muted">
+            {{ "organizationNameDescription" | i18n }}
+          </bit-hint>
+        </bit-form-field>
+      </div>
 
-        <div class="tw-pb-8 !tw-mx-0">
-          <app-display-payment-method-inline
-            #paymentMethodComponent
-            [subscriber]="subscriber()"
-            [paymentMethod]="paymentMethod()"
-            [externalFormGroup]="formGroup.controls.paymentMethodForm"
-            [showBankAccountOption]="false"
-          >
-          </app-display-payment-method-inline>
-          <h5 bitTypography="h5" class="tw-pt-4 tw-pb-2">{{ "billingAddress" | i18n }}</h5>
-          <app-enter-billing-address
-            [group]="formGroup.controls.billingAddress"
-            [scenario]="{ type: 'checkout', supportsTaxId: showTaxIdField() }"
-          >
-          </app-enter-billing-address>
-        </div>
-      </section>
-      <section>
-        <billing-cart-summary
-          #cartSummaryComponent
-          [cart]="cart()"
-          [hidePricingTerm]="true"
-        ></billing-cart-summary>
-      </section>
-    </ng-container>
-    <ng-container bitDialogFooter>
-      <button
-        bitButton
-        bitFormButton
-        buttonType="primary"
-        [disabled]="loading() || !isFormValid()"
-        type="submit"
-      >
-        {{ "upgrade" | i18n }}
-      </button>
-      <button
-        bitButton
-        type="button"
-        buttonType="secondary"
-        (click)="goBack.emit()"
-        [disabled]="loading()"
-      >
-        {{ "back" | i18n }}
-      </button>
-    </ng-container>
-  </bit-dialog>
+      <div class="tw-pb-8 !tw-mx-0">
+        <app-display-payment-method-inline
+          #paymentMethodComponent
+          [subscriber]="subscriber()"
+          [paymentMethod]="paymentMethod()"
+          [externalFormGroup]="formGroup.controls.paymentMethodForm"
+          [showBankAccountOption]="false"
+        >
+        </app-display-payment-method-inline>
+        <h5 bitTypography="h5" class="tw-pt-4 tw-pb-2">{{ "billingAddress" | i18n }}</h5>
+        <app-enter-billing-address
+          [group]="formGroup.controls.billingAddress"
+          [scenario]="{ type: 'checkout', supportsTaxId: showTaxIdField() }"
+        >
+        </app-enter-billing-address>
+      </div>
+    </section>
+    <section>
+      <billing-cart-summary
+        #cartSummaryComponent
+        [cart]="cart()"
+        [hidePricingTerm]="true"
+      ></billing-cart-summary>
+    </section>
+  </ng-container>
+  <ng-container bitDialogFooter>
+    <button
+      bitButton
+      bitFormButton
+      buttonType="primary"
+      [disabled]="loading() || !isFormValid()"
+      type="submit"
+    >
+      {{ "upgrade" | i18n }}
+    </button>
+    <button
+      bitButton
+      type="button"
+      buttonType="secondary"
+      (click)="goBack.emit()"
+      [disabled]="loading()"
+    >
+      {{ "back" | i18n }}
+    </button>
+  </ng-container>
 </form>

--- a/apps/web/src/app/billing/individual/upgrade/upgrade-payment/upgrade-payment.component.html
+++ b/apps/web/src/app/billing/individual/upgrade/upgrade-payment/upgrade-payment.component.html
@@ -1,87 +1,91 @@
-<form [formGroup]="formGroup" [bitSubmit]="submit">
-  <bit-dialog dialogSize="large" [loading]="loading()">
-    <span bitDialogTitle class="tw-font-medium">{{ upgradeToMessage() }}</span>
-    <ng-container bitDialogContent>
-      <section>
-        @if (isFamiliesPlan()) {
-          @if (userIsOwnerOfFreeOrg$ | async) {
-            <div class="tw-pb-2">
-              <bit-callout type="info">
-                {{ "formWillCreateNewFamiliesOrgMessage" | i18n }}
-                <a
-                  bitLink
-                  bitDialogClose
-                  linkType="primary"
-                  [routerLink]="adminConsoleRouteForOwnedOrganization$ | async"
-                  endIcon="bwi-angle-right"
-                >
-                  {{ "upgradeNow" | i18n }}
-                </a>
-              </bit-callout>
-            </div>
-          }
-          <div class="tw-pb-4">
-            <bit-form-field class="!tw-mb-0">
-              <bit-label>{{ "organizationName" | i18n }}</bit-label>
-              <input bitInput type="text" formControlName="organizationName" required />
-              <bit-hint bitTypography="helper" class="tw-text-muted">
-                {{ "organizationNameDescription" | i18n }}
-              </bit-hint>
-            </bit-form-field>
+<form
+  [formGroup]="formGroup"
+  [bitSubmit]="submit"
+  bit-dialog
+  dialogSize="large"
+  [loading]="loading()"
+>
+  <span bitDialogTitle class="tw-font-medium">{{ upgradeToMessage() }}</span>
+  <ng-container bitDialogContent>
+    <section>
+      @if (isFamiliesPlan()) {
+        @if (userIsOwnerOfFreeOrg$ | async) {
+          <div class="tw-pb-2">
+            <bit-callout type="info">
+              {{ "formWillCreateNewFamiliesOrgMessage" | i18n }}
+              <a
+                bitLink
+                bitDialogClose
+                linkType="primary"
+                [routerLink]="adminConsoleRouteForOwnedOrganization$ | async"
+                endIcon="bwi-angle-right"
+              >
+                {{ "upgradeNow" | i18n }}
+              </a>
+            </bit-callout>
           </div>
         }
-        <div class="tw-pb-8 !tw-mx-0">
-          <h5 bitTypography="h5">{{ "paymentMethod" | i18n }}</h5>
-          <app-enter-payment-method
-            [showBankAccount]="isFamiliesPlan()"
-            [showAccountCredit]="!isFamiliesPlan()"
-            [group]="formGroup.controls.paymentForm"
-            [includeBillingAddress]="false"
-            [hasEnoughAccountCredit]="hasEnoughAccountCredit$ | async"
-            #paymentComponent
-          ></app-enter-payment-method>
-          <h5 bitTypography="h5" class="tw-pt-4 tw-pb-2">{{ "billingAddress" | i18n }}</h5>
-          <app-enter-billing-address
-            [group]="formGroup.controls.billingAddress"
-            [scenario]="{ type: 'checkout', supportsTaxId: false }"
-          >
-          </app-enter-billing-address>
+        <div class="tw-pb-4">
+          <bit-form-field class="!tw-mb-0">
+            <bit-label>{{ "organizationName" | i18n }}</bit-label>
+            <input bitInput type="text" formControlName="organizationName" required />
+            <bit-hint bitTypography="helper" class="tw-text-muted">
+              {{ "organizationNameDescription" | i18n }}
+            </bit-hint>
+          </bit-form-field>
         </div>
-      </section>
+      }
+      <div class="tw-pb-8 !tw-mx-0">
+        <h5 bitTypography="h5">{{ "paymentMethod" | i18n }}</h5>
+        <app-enter-payment-method
+          [showBankAccount]="isFamiliesPlan()"
+          [showAccountCredit]="!isFamiliesPlan()"
+          [group]="formGroup.controls.paymentForm"
+          [includeBillingAddress]="false"
+          [hasEnoughAccountCredit]="hasEnoughAccountCredit$ | async"
+          #paymentComponent
+        ></app-enter-payment-method>
+        <h5 bitTypography="h5" class="tw-pt-4 tw-pb-2">{{ "billingAddress" | i18n }}</h5>
+        <app-enter-billing-address
+          [group]="formGroup.controls.billingAddress"
+          [scenario]="{ type: 'checkout', supportsTaxId: false }"
+        >
+        </app-enter-billing-address>
+      </div>
+    </section>
 
-      <section>
-        <billing-cart-summary
-          #cartSummaryComponent
-          [cart]="cart()"
-          [showDiscountBadges]="true"
-        ></billing-cart-summary>
-        @if (isFamiliesPlan()) {
-          <p bitTypography="helper" class="tw-italic tw-text-muted !tw-mb-0">
-            {{ "paymentChargedWithTrial" | i18n }}
-          </p>
-        }
-      </section>
-    </ng-container>
+    <section>
+      <billing-cart-summary
+        #cartSummaryComponent
+        [cart]="cart()"
+        [showDiscountBadges]="true"
+      ></billing-cart-summary>
+      @if (isFamiliesPlan()) {
+        <p bitTypography="helper" class="tw-italic tw-text-muted !tw-mb-0">
+          {{ "paymentChargedWithTrial" | i18n }}
+        </p>
+      }
+    </section>
+  </ng-container>
 
-    <ng-container bitDialogFooter>
-      <button
-        bitButton
-        bitFormButton
-        buttonType="primary"
-        [disabled]="loading() || !isFormValid() || !(hasEnoughAccountCredit$ | async)"
-        type="submit"
-      >
-        {{ "upgrade" | i18n }}
-      </button>
-      <button
-        bitButton
-        type="button"
-        buttonType="secondary"
-        (click)="goBack.emit()"
-        [disabled]="loading()"
-      >
-        {{ "back" | i18n }}
-      </button>
-    </ng-container>
-  </bit-dialog>
+  <ng-container bitDialogFooter>
+    <button
+      bitButton
+      bitFormButton
+      buttonType="primary"
+      [disabled]="loading() || !isFormValid() || !(hasEnoughAccountCredit$ | async)"
+      type="submit"
+    >
+      {{ "upgrade" | i18n }}
+    </button>
+    <button
+      bitButton
+      type="button"
+      buttonType="secondary"
+      (click)="goBack.emit()"
+      [disabled]="loading()"
+    >
+      {{ "back" | i18n }}
+    </button>
+  </ng-container>
 </form>

--- a/apps/web/src/app/billing/members/add-sponsorship-dialog.component.html
+++ b/apps/web/src/app/billing/members/add-sponsorship-dialog.component.html
@@ -1,52 +1,50 @@
-<form>
-  <bit-dialog>
-    <span bitDialogTitle>{{ "addSponsorship" | i18n }}</span>
+<form bit-dialog>
+  <span bitDialogTitle>{{ "addSponsorship" | i18n }}</span>
 
-    <div bitDialogContent>
-      <form [formGroup]="sponsorshipForm">
-        <div class="tw-grid tw-grid-cols-12 tw-gap-4">
-          <div class="tw-col-span-12">
-            <bit-form-field>
-              <bit-label>{{ "email" | i18n }}</bit-label>
-              <input
-                bitInput
-                inputmode="email"
-                formControlName="sponsorshipEmail"
-                [attr.aria-invalid]="sponsorshipEmailControl.invalid"
-                appInputStripSpaces
-              />
-            </bit-form-field>
-          </div>
-          <div class="tw-col-span-12">
-            <bit-form-field>
-              <bit-label>{{ "notes" | i18n }}</bit-label>
-              <input
-                bitInput
-                inputmode="text"
-                formControlName="sponsorshipNote"
-                [attr.aria-invalid]="sponsorshipNoteControl.invalid"
-              />
-            </bit-form-field>
-          </div>
+  <div bitDialogContent>
+    <form [formGroup]="sponsorshipForm">
+      <div class="tw-grid tw-grid-cols-12 tw-gap-4">
+        <div class="tw-col-span-12">
+          <bit-form-field>
+            <bit-label>{{ "email" | i18n }}</bit-label>
+            <input
+              bitInput
+              inputmode="email"
+              formControlName="sponsorshipEmail"
+              [attr.aria-invalid]="sponsorshipEmailControl.invalid"
+              appInputStripSpaces
+            />
+          </bit-form-field>
         </div>
-      </form>
-    </div>
+        <div class="tw-col-span-12">
+          <bit-form-field>
+            <bit-label>{{ "notes" | i18n }}</bit-label>
+            <input
+              bitInput
+              inputmode="text"
+              formControlName="sponsorshipNote"
+              [attr.aria-invalid]="sponsorshipNoteControl.invalid"
+            />
+          </bit-form-field>
+        </div>
+      </div>
+    </form>
+  </div>
 
-    <ng-container bitDialogFooter>
-      <button
-        bitButton
-        bitFormButton
-        type="button"
-        buttonType="primary"
-        [loading]="loading"
-        [disabled]="loading"
-        (click)="save()"
-      >
-        {{ "save" | i18n }}
-      </button>
-      <button bitButton type="button" buttonType="secondary" [bitDialogClose]="false">
-        {{ "cancel" | i18n }}
-      </button>
-    </ng-container>
-  </bit-dialog>
+  <ng-container bitDialogFooter>
+    <button
+      bitButton
+      bitFormButton
+      type="button"
+      buttonType="primary"
+      [loading]="loading"
+      [disabled]="loading"
+      (click)="save()"
+    >
+      {{ "save" | i18n }}
+    </button>
+    <button bitButton type="button" buttonType="secondary" [bitDialogClose]="false">
+      {{ "cancel" | i18n }}
+    </button>
+  </ng-container>
 </form>

--- a/apps/web/src/app/billing/organizations/billing-sync-api-key.component.html
+++ b/apps/web/src/app/billing/organizations/billing-sync-api-key.component.html
@@ -1,77 +1,75 @@
-<form [formGroup]="formGroup" [bitSubmit]="submit">
-  <bit-dialog>
-    <span bitDialogTitle>
-      {{ (hasBillingToken ? "viewBillingToken" : "generateBillingToken") | i18n }}
-    </span>
-    <div bitDialogContent>
-      <app-user-verification formControlName="verification" *ngIf="!clientSecret">
-      </app-user-verification>
+<form [formGroup]="formGroup" [bitSubmit]="submit" bit-dialog>
+  <span bitDialogTitle>
+    {{ (hasBillingToken ? "viewBillingToken" : "generateBillingToken") | i18n }}
+  </span>
+  <div bitDialogContent>
+    <app-user-verification formControlName="verification" *ngIf="!clientSecret">
+    </app-user-verification>
 
-      <ng-container *ngIf="clientSecret && showRotateScreen">
-        <p>{{ "rotateBillingSyncTokenTitle" | i18n }}</p>
-        <bit-callout type="warning">
-          {{ "rotateBillingSyncTokenWarning" | i18n }}
-        </bit-callout>
-      </ng-container>
+    <ng-container *ngIf="clientSecret && showRotateScreen">
+      <p>{{ "rotateBillingSyncTokenTitle" | i18n }}</p>
+      <bit-callout type="warning">
+        {{ "rotateBillingSyncTokenWarning" | i18n }}
+      </bit-callout>
+    </ng-container>
 
-      <div *ngIf="clientSecret && !showRotateScreen">
-        <p>{{ "copyPasteBillingSync" | i18n }}</p>
-        <bit-form-field>
-          <bit-label>{{ "billingSyncKey" | i18n }}</bit-label>
-          <input
-            bitInput
-            id="clientSecret"
-            type="text"
-            [value]="clientSecret"
-            class="tw-font-mono"
-            disabled
-          />
-          <button
-            bitIconButton="bwi-clone"
-            bitSuffix
-            type="button"
-            showToast
-            [valueLabel]="'billingSyncKey' | i18n"
-            [appCopyClick]="clientSecret"
-            [label]="'copyValue' | i18n"
-          ></button>
-        </bit-form-field>
-        <div class="tw-mt-2 tw-text-sm tw-text-muted" *ngIf="showLastSyncText">
-          <b class="tw-font-medium">{{ "lastSync" | i18n }}:</b>
-          {{ lastSyncDate | date: "medium" }}
-        </div>
-        <div class="tw-mt-2 tw-text-sm tw-text-danger" *ngIf="showAwaitingSyncText">
-          <i class="bwi bwi-error"></i>
-          {{
-            (daysBetween === 1 ? "awaitingSyncSingular" : "awaitingSyncPlural") | i18n: daysBetween
-          }}
-        </div>
+    <div *ngIf="clientSecret && !showRotateScreen">
+      <p>{{ "copyPasteBillingSync" | i18n }}</p>
+      <bit-form-field>
+        <bit-label>{{ "billingSyncKey" | i18n }}</bit-label>
+        <input
+          bitInput
+          id="clientSecret"
+          type="text"
+          [value]="clientSecret"
+          class="tw-font-mono"
+          disabled
+        />
+        <button
+          bitIconButton="bwi-clone"
+          bitSuffix
+          type="button"
+          showToast
+          [valueLabel]="'billingSyncKey' | i18n"
+          [appCopyClick]="clientSecret"
+          [label]="'copyValue' | i18n"
+        ></button>
+      </bit-form-field>
+      <div class="tw-mt-2 tw-text-sm tw-text-muted" *ngIf="showLastSyncText">
+        <b class="tw-font-medium">{{ "lastSync" | i18n }}:</b>
+        {{ lastSyncDate | date: "medium" }}
+      </div>
+      <div class="tw-mt-2 tw-text-sm tw-text-danger" *ngIf="showAwaitingSyncText">
+        <i class="bwi bwi-error"></i>
+        {{
+          (daysBetween === 1 ? "awaitingSyncSingular" : "awaitingSyncPlural") | i18n: daysBetween
+        }}
       </div>
     </div>
-    <ng-container bitDialogFooter>
-      <button
-        type="submit"
-        bitButton
-        bitFormButton
-        buttonType="primary"
-        *ngIf="!clientSecret || showRotateScreen"
-      >
-        {{ submitButtonText }}
-      </button>
-      <button bitButton bitDialogClose type="button" *ngIf="!showRotateScreen">
-        {{ "close" | i18n }}
-      </button>
-      <button bitButton type="button" *ngIf="showRotateScreen" (click)="cancelRotate()">
-        {{ "cancel" | i18n }}
-      </button>
-      <button
-        bitButton
-        type="button"
-        *ngIf="clientSecret && !showRotateScreen"
-        (click)="rotateToken()"
-      >
-        {{ "rotateToken" | i18n }}
-      </button>
-    </ng-container>
-  </bit-dialog>
+  </div>
+  <ng-container bitDialogFooter>
+    <button
+      type="submit"
+      bitButton
+      bitFormButton
+      buttonType="primary"
+      *ngIf="!clientSecret || showRotateScreen"
+    >
+      {{ submitButtonText }}
+    </button>
+    <button bitButton bitDialogClose type="button" *ngIf="!showRotateScreen">
+      {{ "close" | i18n }}
+    </button>
+    <button bitButton type="button" *ngIf="showRotateScreen" (click)="cancelRotate()">
+      {{ "cancel" | i18n }}
+    </button>
+    <button
+      bitButton
+      type="button"
+      *ngIf="clientSecret && !showRotateScreen"
+      (click)="rotateToken()"
+    >
+      {{ "rotateToken" | i18n }}
+    </button>
+  </ng-container>
 </form>

--- a/apps/web/src/app/billing/organizations/billing-sync-key.component.html
+++ b/apps/web/src/app/billing/organizations/billing-sync-key.component.html
@@ -1,40 +1,38 @@
-<form [formGroup]="formGroup" [bitSubmit]="submit">
-  <bit-dialog>
-    <span bitDialogTitle>
-      {{ "manageBillingTokenSync" | i18n }}
-    </span>
-    <div bitDialogContent>
-      <p>{{ "billingSyncKeyDesc" | i18n }}</p>
-      <bit-form-field>
-        <bit-label>
-          {{ "billingSyncKey" | i18n }}
-        </bit-label>
-        <input
-          bitInput
-          id="billingSyncKey"
-          type="text"
-          formControlName="billingSyncKey"
-          appAutofocus
-          appInputVerbatim
-        />
-      </bit-form-field>
-    </div>
-    <ng-container bitDialogFooter>
-      <button type="submit" bitButton bitFormButton buttonType="primary">
-        {{ "save" | i18n }}
-      </button>
-      <button bitButton bitDialogClose type="button">
-        {{ "cancel" | i18n }}
-      </button>
-      <button
-        class="tw-ml-auto"
-        type="button"
-        buttonType="dangerGhost"
-        bitIconButton="bwi-trash"
-        bitFormButton
-        [bitAction]="deleteConnection"
-        label="{{ 'delete' | i18n }}"
-      ></button>
-    </ng-container>
-  </bit-dialog>
+<form [formGroup]="formGroup" [bitSubmit]="submit" bit-dialog>
+  <span bitDialogTitle>
+    {{ "manageBillingTokenSync" | i18n }}
+  </span>
+  <div bitDialogContent>
+    <p>{{ "billingSyncKeyDesc" | i18n }}</p>
+    <bit-form-field>
+      <bit-label>
+        {{ "billingSyncKey" | i18n }}
+      </bit-label>
+      <input
+        bitInput
+        id="billingSyncKey"
+        type="text"
+        formControlName="billingSyncKey"
+        appAutofocus
+        appInputVerbatim
+      />
+    </bit-form-field>
+  </div>
+  <ng-container bitDialogFooter>
+    <button type="submit" bitButton bitFormButton buttonType="primary">
+      {{ "save" | i18n }}
+    </button>
+    <button bitButton bitDialogClose type="button">
+      {{ "cancel" | i18n }}
+    </button>
+    <button
+      class="tw-ml-auto"
+      type="button"
+      buttonType="dangerGhost"
+      bitIconButton="bwi-trash"
+      bitFormButton
+      [bitAction]="deleteConnection"
+      label="{{ 'delete' | i18n }}"
+    ></button>
+  </ng-container>
 </form>

--- a/apps/web/src/app/billing/organizations/change-plan-dialog.component.html
+++ b/apps/web/src/app/billing/organizations/change-plan-dialog.component.html
@@ -1,200 +1,297 @@
-<form [formGroup]="formGroup" [bitSubmit]="submit">
-  <bit-dialog dialogSize="large" [loading]="loading">
-    <span bitDialogTitle class="tw-font-medium">
-      {{ dialogHeaderName }}
-    </span>
-    <div bitDialogContent>
-      <p>{{ "upgradePlans" | i18n }}</p>
-      <div class="tw-mb-3 tw-flex tw-justify-between">
-        <span [hidden]="isSubscriptionCanceled" class="tw-text-lg tw-pr-1 tw-font-medium">{{
-          "selectAPlan" | i18n
-        }}</span>
-        <!-- Discount Badge -->
-        <div class="tw-flex tw-items-center tw-gap-2">
-          <!-- Plan Interval Toggle -->
-          <div class="tw-inline-block" *ngIf="!isSubscriptionCanceled">
-            <bit-toggle-group
-              [selected]="selectedInterval"
-              (selectedChange)="updateInterval($event)"
+<form
+  [formGroup]="formGroup"
+  [bitSubmit]="submit"
+  bit-dialog
+  dialogSize="large"
+  [loading]="loading"
+>
+  <span bitDialogTitle class="tw-font-medium">
+    {{ dialogHeaderName }}
+  </span>
+  <div bitDialogContent>
+    <p>{{ "upgradePlans" | i18n }}</p>
+    <div class="tw-mb-3 tw-flex tw-justify-between">
+      <span [hidden]="isSubscriptionCanceled" class="tw-text-lg tw-pr-1 tw-font-medium">{{
+        "selectAPlan" | i18n
+      }}</span>
+      <!-- Discount Badge -->
+      <div class="tw-flex tw-items-center tw-gap-2">
+        <!-- Plan Interval Toggle -->
+        <div class="tw-inline-block" *ngIf="!isSubscriptionCanceled">
+          <bit-toggle-group [selected]="selectedInterval" (selectedChange)="updateInterval($event)">
+            <bit-toggle
+              *ngFor="
+                let planInterval of getPlanIntervals();
+                trackBy: optimizedNgForRender;
+                let i = index
+              "
+              [value]="planInterval.value"
             >
-              <bit-toggle
-                *ngFor="
-                  let planInterval of getPlanIntervals();
-                  trackBy: optimizedNgForRender;
-                  let i = index
-                "
-                [value]="planInterval.value"
-              >
-                {{ planInterval.name }}
-              </bit-toggle>
-            </bit-toggle-group>
-          </div>
+              {{ planInterval.name }}
+            </bit-toggle>
+          </bit-toggle-group>
         </div>
       </div>
-      <!-- Plan Selection Cards -->
-      <ng-container *ngIf="!loading && !selfHosted && this.passwordManagerPlans">
-        <div
-          class="tw-grid tw-grid-flow-col tw-gap-4 tw-mb-4"
-          [class]="'tw-grid-cols-' + selectableProducts.length"
+    </div>
+    <!-- Plan Selection Cards -->
+    <ng-container *ngIf="!loading && !selfHosted && this.passwordManagerPlans">
+      <div
+        class="tw-grid tw-grid-flow-col tw-gap-4 tw-mb-4"
+        [class]="'tw-grid-cols-' + selectableProducts.length"
+      >
+        <bit-card
+          *ngFor="
+            let selectableProduct of selectableProducts;
+            trackBy: manageSelectableProduct;
+            let i = index
+          "
+          [ngClass]="getPlanCardContainerClasses(selectableProduct, i)"
+          (click)="selectPlan(selectableProduct)"
+          [attr.tabindex]="focusedIndex !== i || isCardDisabled(i) ? '-1' : '0'"
+          (keyup)="onKeydown($event, i)"
+          (focus)="onFocus(i)"
+          [attr.aria-disabled]="isCardDisabled(i)"
+          [id]="i + 'a_plan_card'"
         >
-          <bit-card
-            *ngFor="
-              let selectableProduct of selectableProducts;
-              trackBy: manageSelectableProduct;
-              let i = index
-            "
-            [ngClass]="getPlanCardContainerClasses(selectableProduct, i)"
-            (click)="selectPlan(selectableProduct)"
-            [attr.tabindex]="focusedIndex !== i || isCardDisabled(i) ? '-1' : '0'"
-            (keyup)="onKeydown($event, i)"
-            (focus)="onFocus(i)"
-            [attr.aria-disabled]="isCardDisabled(i)"
-            [id]="i + 'a_plan_card'"
-          >
-            <div class="tw-relative">
-              <div
-                *ngIf="
-                  selectableProduct.productTier === productTypes.Enterprise &&
-                  !isSubscriptionCanceled
-                "
-                class="tw-bg-secondary-100 tw-text-center !tw-border-0 tw-text-sm tw-font-medium tw-py-1"
-                [ngClass]="{
-                  'tw-bg-primary-700 !tw-text-contrast': selectableProduct === selectedPlan,
-                  'tw-bg-secondary-100': !(selectableProduct === selectedPlan),
-                }"
+          <div class="tw-relative">
+            <div
+              *ngIf="
+                selectableProduct.productTier === productTypes.Enterprise && !isSubscriptionCanceled
+              "
+              class="tw-bg-secondary-100 tw-text-center !tw-border-0 tw-text-sm tw-font-medium tw-py-1"
+              [ngClass]="{
+                'tw-bg-primary-700 !tw-text-contrast': selectableProduct === selectedPlan,
+                'tw-bg-secondary-100': !(selectableProduct === selectedPlan),
+              }"
+            >
+              {{ "recommended" | i18n }}
+            </div>
+            <div
+              class="tw-px-2 tw-pb-[4px]"
+              [ngClass]="{
+                'tw-py-1': !(selectableProduct === selectedPlan),
+                'tw-py-0': selectableProduct === selectedPlan,
+              }"
+            >
+              <h3
+                class="tw-text-[1.25rem] tw-mt-[6px] tw-font-medium tw-mb-0 tw-leading-[2rem] tw-flex tw-items-center"
               >
-                {{ "recommended" | i18n }}
-              </div>
-              <div
-                class="tw-px-2 tw-pb-[4px]"
-                [ngClass]="{
-                  'tw-py-1': !(selectableProduct === selectedPlan),
-                  'tw-py-0': selectableProduct === selectedPlan,
-                }"
-              >
-                <h3
-                  class="tw-text-[1.25rem] tw-mt-[6px] tw-font-medium tw-mb-0 tw-leading-[2rem] tw-flex tw-items-center"
-                >
-                  <span class="tw-capitalize tw-whitespace-nowrap">{{
-                    selectableProduct.nameLocalizationKey | i18n
-                  }}</span>
-                  <span
-                    bitBadge
-                    variant="secondary"
-                    *ngIf="selectableProduct === currentPlan"
-                    class="tw-ml-2 tw-align-middle"
-                  >
-                    {{ "current" | i18n }}</span
-                  >
-                </h3>
-                <span *ngIf="selectableProduct.productTier != productTypes.Free">
-                  <ng-container
-                    *ngIf="selectableProduct.PasswordManager.basePrice && !acceptingSponsorship"
-                  >
-                    <b class="tw-text-lg tw-font-medium">
-                      {{
-                        (selectableProduct.isAnnual
-                          ? selectableProduct.PasswordManager.basePrice / 12
-                          : selectableProduct.PasswordManager.basePrice
-                        ) | currency: "$"
-                      }}
-                    </b>
-                    <span class="tw-text-xs tw-px-0">
-                      /{{
-                        selectableProduct.productTier === productTypes.Families
-                          ? "month"
-                          : ("monthPerMember" | i18n)
-                      }}</span
-                    >
-                    <b class="tw-text-sm tw-font-medium">
-                      <ng-container
-                        *ngIf="selectableProduct.PasswordManager.hasAdditionalSeatsOption"
-                      >
-                        {{ ("additionalUsers" | i18n).toLowerCase() }}
-                        {{
-                          (selectableProduct.isAnnual
-                            ? selectableProduct.PasswordManager.seatPrice / 12
-                            : selectableProduct.PasswordManager.seatPrice
-                          ) | currency: "$"
-                        }}
-                        /{{ selectedPlanInterval | i18n }}
-                      </ng-container>
-                    </b>
-                  </ng-container>
-                </span>
+                <span class="tw-capitalize tw-whitespace-nowrap">{{
+                  selectableProduct.nameLocalizationKey | i18n
+                }}</span>
                 <span
-                  *ngIf="
-                    !selectableProduct.PasswordManager.basePrice &&
-                    selectableProduct.PasswordManager.hasAdditionalSeatsOption
-                  "
+                  bitBadge
+                  variant="secondary"
+                  *ngIf="selectableProduct === currentPlan"
+                  class="tw-ml-2 tw-align-middle"
                 >
-                  <b class="tw-text-lg tw-font-medium"
-                    >{{
-                      "costPerMember"
-                        | i18n
-                          : (((this.sub.useSecretsManager
-                              ? selectableProduct.SecretsManager.seatPrice
-                              : 0) +
-                              selectableProduct.PasswordManager.seatPrice) /
-                              (selectableProduct.isAnnual ? 12 : 1)
-                              | currency: "$")
+                  {{ "current" | i18n }}</span
+                >
+              </h3>
+              <span *ngIf="selectableProduct.productTier != productTypes.Free">
+                <ng-container
+                  *ngIf="selectableProduct.PasswordManager.basePrice && !acceptingSponsorship"
+                >
+                  <b class="tw-text-lg tw-font-medium">
+                    {{
+                      (selectableProduct.isAnnual
+                        ? selectableProduct.PasswordManager.basePrice / 12
+                        : selectableProduct.PasswordManager.basePrice
+                      ) | currency: "$"
                     }}
                   </b>
-                  <span class="tw-text-xs tw-px-0"> /{{ "monthPerMember" | i18n }}</span>
-                </span>
-                <span *ngIf="selectableProduct.productTier == productTypes.Free"
-                  >{{ "freeForever" | i18n }}
-                </span>
-              </div>
+                  <span class="tw-text-xs tw-px-0">
+                    /{{
+                      selectableProduct.productTier === productTypes.Families
+                        ? "month"
+                        : ("monthPerMember" | i18n)
+                    }}</span
+                  >
+                  <b class="tw-text-sm tw-font-medium">
+                    <ng-container
+                      *ngIf="selectableProduct.PasswordManager.hasAdditionalSeatsOption"
+                    >
+                      {{ ("additionalUsers" | i18n).toLowerCase() }}
+                      {{
+                        (selectableProduct.isAnnual
+                          ? selectableProduct.PasswordManager.seatPrice / 12
+                          : selectableProduct.PasswordManager.seatPrice
+                        ) | currency: "$"
+                      }}
+                      /{{ selectedPlanInterval | i18n }}
+                    </ng-container>
+                  </b>
+                </ng-container>
+              </span>
+              <span
+                *ngIf="
+                  !selectableProduct.PasswordManager.basePrice &&
+                  selectableProduct.PasswordManager.hasAdditionalSeatsOption
+                "
+              >
+                <b class="tw-text-lg tw-font-medium"
+                  >{{
+                    "costPerMember"
+                      | i18n
+                        : (((this.sub.useSecretsManager
+                            ? selectableProduct.SecretsManager.seatPrice
+                            : 0) +
+                            selectableProduct.PasswordManager.seatPrice) /
+                            (selectableProduct.isAnnual ? 12 : 1)
+                            | currency: "$")
+                  }}
+                </b>
+                <span class="tw-text-xs tw-px-0"> /{{ "monthPerMember" | i18n }}</span>
+              </span>
+              <span *ngIf="selectableProduct.productTier == productTypes.Free"
+                >{{ "freeForever" | i18n }}
+              </span>
             </div>
+          </div>
 
+          <ng-container
+            *ngIf="
+              selectableProduct.productTier === productTypes.Enterprise;
+              else nonEnterprisePlans
+            "
+          >
+            <p
+              class="tw-text-xs tw-px-2 tw-font-medium tw-mb-1"
+              *ngIf="organization.useSecretsManager"
+            >
+              {{ "bitwardenPasswordManager" | i18n }}
+            </p>
+            <p class="tw-text-xs tw-px-2 tw-mb-1">{{ "enterprisePlanUpgradeMessage" | i18n }}</p>
+
+            <ul class="bwi-ul tw-text-xs">
+              <li>
+                <i class="bwi bwi-check tw-text-success bwi-li" aria-hidden="true"></i>
+                {{ "includeEnterprisePolicies" | i18n }}
+              </li>
+              <li>
+                <i class="bwi bwi-check tw-text-success bwi-li" aria-hidden="true"></i>
+                {{ "passwordLessSso" | i18n }}
+              </li>
+              <li>
+                <i class="bwi bwi-check tw-text-success bwi-li" aria-hidden="true"></i>
+                {{ "accountRecovery" | i18n }}
+              </li>
+              <li>
+                <i class="bwi bwi-check tw-text-success bwi-li" aria-hidden="true"></i>
+                {{ "customRoles" | i18n }}
+              </li>
+            </ul>
+
+            <p
+              class="tw-text-xs tw-px-2 tw-font-medium tw-mb-1"
+              *ngIf="organization.useSecretsManager"
+            >
+              {{ "bitwardenSecretsManager" | i18n }}
+            </p>
+            <ul class="bwi-ul tw-text-xs" *ngIf="organization.useSecretsManager">
+              <li>
+                <i class="bwi bwi-check tw-text-success bwi-li" aria-hidden="true"></i>
+                {{ "unlimitedSecretsStorage" | i18n }}
+              </li>
+              <li>
+                <i class="bwi bwi-check tw-text-success bwi-li" aria-hidden="true"></i>
+                {{ "unlimitedUsers" | i18n }}
+              </li>
+              <li>
+                <i class="bwi bwi-check tw-text-success bwi-li" aria-hidden="true"></i>
+                {{ "unlimitedProjects" | i18n }}
+              </li>
+              <li>
+                <i class="bwi bwi-check tw-text-success bwi-li" aria-hidden="true"></i>
+                {{ "UpTo50MachineAccounts" | i18n }}
+              </li>
+            </ul>
+          </ng-container>
+          <ng-template #nonEnterprisePlans>
             <ng-container
               *ngIf="
-                selectableProduct.productTier === productTypes.Enterprise;
-                else nonEnterprisePlans
+                selectableProduct.productTier === productTypes.Teams && teamsStarterPlanIsAvailable;
+                else fullFeatureList
               "
             >
+              <ul class="tw-px-2 tw-pb-2 tw-list-inside tw-mb-0 tw-text-xs">
+                <li>{{ "includeAllTeamsStarterFeatures" | i18n }}</li>
+                <li>{{ "chooseMonthlyOrAnnualBilling" | i18n }}</li>
+                <li>{{ "abilityToAddMoreThanNMembers" | i18n: 10 }}</li>
+              </ul>
+            </ng-container>
+            <ng-template #fullFeatureList>
               <p
                 class="tw-text-xs tw-px-2 tw-font-medium tw-mb-1"
                 *ngIf="organization.useSecretsManager"
               >
                 {{ "bitwardenPasswordManager" | i18n }}
               </p>
-              <p class="tw-text-xs tw-px-2 tw-mb-1">{{ "enterprisePlanUpgradeMessage" | i18n }}</p>
-
-              <ul class="bwi-ul tw-text-xs">
+              <p
+                *ngIf="selectableProduct.productTier === productTypes.Teams"
+                class="tw-text-xs tw-px-2 tw-mb-1"
+              >
+                {{ "teamsPlanUpgradeMessage" | i18n }}
+              </p>
+              <p
+                *ngIf="selectableProduct.productTier === productTypes.Families"
+                class="tw-text-xs tw-px-2 tw-mb-1"
+              >
+                {{ "familyPlanUpgradeMessage" | i18n }}
+              </p>
+              <ul
+                class="bwi-ul tw-text-xs tw-mb-1"
+                *ngIf="selectableProduct.productTier == productTypes.Families"
+              >
                 <li>
                   <i class="bwi bwi-check tw-text-success bwi-li" aria-hidden="true"></i>
-                  {{ "includeEnterprisePolicies" | i18n }}
+                  {{ "premiumAccounts" | i18n }}
                 </li>
                 <li>
                   <i class="bwi bwi-check tw-text-success bwi-li" aria-hidden="true"></i>
-                  {{ "passwordLessSso" | i18n }}
+                  {{ "unlimitedSharing" | i18n }}
                 </li>
                 <li>
                   <i class="bwi bwi-check tw-text-success bwi-li" aria-hidden="true"></i>
-                  {{ "accountRecovery" | i18n }}
-                </li>
-                <li>
-                  <i class="bwi bwi-check tw-text-success bwi-li" aria-hidden="true"></i>
-                  {{ "customRoles" | i18n }}
+                  {{ "unlimitedCollections" | i18n }}
                 </li>
               </ul>
-
+              <ul
+                class="bwi-ul tw-text-xs"
+                *ngIf="selectableProduct.productTier == productTypes.Teams"
+              >
+                <li>
+                  <i class="bwi bwi-check tw-text-success bwi-li" aria-hidden="true"></i>
+                  {{ "secureDataSharing" | i18n }}
+                </li>
+                <li>
+                  <i class="bwi bwi-check tw-text-success bwi-li" aria-hidden="true"></i>
+                  {{ "eventLogMonitoring" | i18n }}
+                </li>
+                <li>
+                  <i class="bwi bwi-check tw-text-success bwi-li" aria-hidden="true"></i>
+                  {{ "directoryIntegration" | i18n }}
+                </li>
+              </ul>
               <p
                 class="tw-text-xs tw-px-2 tw-font-medium tw-mb-1"
-                *ngIf="organization.useSecretsManager"
+                *ngIf="
+                  organization.useSecretsManager &&
+                  selectableProduct.productTier !== productTypes.Families
+                "
               >
                 {{ "bitwardenSecretsManager" | i18n }}
               </p>
-              <ul class="bwi-ul tw-text-xs" *ngIf="organization.useSecretsManager">
+              <ul
+                class="bwi-ul tw-text-xs"
+                *ngIf="
+                  organization.useSecretsManager &&
+                  selectableProduct.productTier == productTypes.Teams
+                "
+              >
                 <li>
                   <i class="bwi bwi-check tw-text-success bwi-li" aria-hidden="true"></i>
                   {{ "unlimitedSecretsStorage" | i18n }}
-                </li>
-                <li>
-                  <i class="bwi bwi-check tw-text-success bwi-li" aria-hidden="true"></i>
-                  {{ "unlimitedUsers" | i18n }}
                 </li>
                 <li>
                   <i class="bwi bwi-check tw-text-success bwi-li" aria-hidden="true"></i>
@@ -202,809 +299,708 @@
                 </li>
                 <li>
                   <i class="bwi bwi-check tw-text-success bwi-li" aria-hidden="true"></i>
-                  {{ "UpTo50MachineAccounts" | i18n }}
+                  {{ "UpTo20MachineAccounts" | i18n }}
                 </li>
               </ul>
-            </ng-container>
-            <ng-template #nonEnterprisePlans>
-              <ng-container
-                *ngIf="
-                  selectableProduct.productTier === productTypes.Teams &&
-                    teamsStarterPlanIsAvailable;
-                  else fullFeatureList
-                "
-              >
-                <ul class="tw-px-2 tw-pb-2 tw-list-inside tw-mb-0 tw-text-xs">
-                  <li>{{ "includeAllTeamsStarterFeatures" | i18n }}</li>
-                  <li>{{ "chooseMonthlyOrAnnualBilling" | i18n }}</li>
-                  <li>{{ "abilityToAddMoreThanNMembers" | i18n: 10 }}</li>
-                </ul>
-              </ng-container>
-              <ng-template #fullFeatureList>
-                <p
-                  class="tw-text-xs tw-px-2 tw-font-medium tw-mb-1"
-                  *ngIf="organization.useSecretsManager"
-                >
-                  {{ "bitwardenPasswordManager" | i18n }}
-                </p>
-                <p
-                  *ngIf="selectableProduct.productTier === productTypes.Teams"
-                  class="tw-text-xs tw-px-2 tw-mb-1"
-                >
-                  {{ "teamsPlanUpgradeMessage" | i18n }}
-                </p>
-                <p
-                  *ngIf="selectableProduct.productTier === productTypes.Families"
-                  class="tw-text-xs tw-px-2 tw-mb-1"
-                >
-                  {{ "familyPlanUpgradeMessage" | i18n }}
-                </p>
-                <ul
-                  class="bwi-ul tw-text-xs tw-mb-1"
-                  *ngIf="selectableProduct.productTier == productTypes.Families"
-                >
-                  <li>
-                    <i class="bwi bwi-check tw-text-success bwi-li" aria-hidden="true"></i>
-                    {{ "premiumAccounts" | i18n }}
-                  </li>
-                  <li>
-                    <i class="bwi bwi-check tw-text-success bwi-li" aria-hidden="true"></i>
-                    {{ "unlimitedSharing" | i18n }}
-                  </li>
-                  <li>
-                    <i class="bwi bwi-check tw-text-success bwi-li" aria-hidden="true"></i>
-                    {{ "unlimitedCollections" | i18n }}
-                  </li>
-                </ul>
-                <ul
-                  class="bwi-ul tw-text-xs"
-                  *ngIf="selectableProduct.productTier == productTypes.Teams"
-                >
-                  <li>
-                    <i class="bwi bwi-check tw-text-success bwi-li" aria-hidden="true"></i>
-                    {{ "secureDataSharing" | i18n }}
-                  </li>
-                  <li>
-                    <i class="bwi bwi-check tw-text-success bwi-li" aria-hidden="true"></i>
-                    {{ "eventLogMonitoring" | i18n }}
-                  </li>
-                  <li>
-                    <i class="bwi bwi-check tw-text-success bwi-li" aria-hidden="true"></i>
-                    {{ "directoryIntegration" | i18n }}
-                  </li>
-                </ul>
-                <p
-                  class="tw-text-xs tw-px-2 tw-font-medium tw-mb-1"
-                  *ngIf="
-                    organization.useSecretsManager &&
-                    selectableProduct.productTier !== productTypes.Families
-                  "
-                >
-                  {{ "bitwardenSecretsManager" | i18n }}
-                </p>
-                <ul
-                  class="bwi-ul tw-text-xs"
-                  *ngIf="
-                    organization.useSecretsManager &&
-                    selectableProduct.productTier == productTypes.Teams
-                  "
-                >
-                  <li>
-                    <i class="bwi bwi-check tw-text-success bwi-li" aria-hidden="true"></i>
-                    {{ "unlimitedSecretsStorage" | i18n }}
-                  </li>
-                  <li>
-                    <i class="bwi bwi-check tw-text-success bwi-li" aria-hidden="true"></i>
-                    {{ "unlimitedProjects" | i18n }}
-                  </li>
-                  <li>
-                    <i class="bwi bwi-check tw-text-success bwi-li" aria-hidden="true"></i>
-                    {{ "UpTo20MachineAccounts" | i18n }}
-                  </li>
-                </ul>
-              </ng-template>
             </ng-template>
-          </bit-card>
-        </div>
-        <br />
-        <bit-callout
-          *ngIf="organization.useSecretsManager && !isSecretsManagerTrial()"
-          type="info"
-          title="SECRETS MANAGER SUBSCRIPTION"
-        >
-          {{ "secretsManagerSubscriptionInfo" | i18n }}
-        </bit-callout>
-        <bit-callout
-          *ngIf="organization.useSecretsManager && isSecretsManagerTrial()"
-          type="info"
-          title="PASSWORD MANAGER SUBSCRIPTION"
-        >
-          {{ "secretsManagerComplimentaryPasswordManager" | i18n }}
-        </bit-callout>
-        <br />
-      </ng-container>
-      <!-- Payment info -->
-      <ng-container
-        *ngIf="formGroup.value.productTier !== productTypes.Free || isSubscriptionCanceled"
+          </ng-template>
+        </bit-card>
+      </div>
+      <br />
+      <bit-callout
+        *ngIf="organization.useSecretsManager && !isSecretsManagerTrial()"
+        type="info"
+        title="SECRETS MANAGER SUBSCRIPTION"
       >
-        <h2 bitTypography="h4">{{ "paymentMethod" | i18n }}</h2>
-        <p *ngIf="!showPayment && !!paymentMethod && !isSubscriptionCanceled">
-          @switch (paymentMethod.type) {
-            @case ("bankAccount") {
-              <i class="bwi bwi-fw bwi-billing"></i>
-              {{ paymentMethod.bankName }}, *{{ paymentMethod.last4 }}
-              @if (paymentMethod.hostedVerificationUrl) {
-                <span>- {{ "unverified" | i18n }}</span>
-              }
-              <span
-                class="tw-ml-2 tw-text-primary-600 tw-cursor-pointer"
-                (click)="toggleShowPayment()"
-              >
-                {{ "changePaymentMethod" | i18n }}
-              </span>
-            }
-            @case ("card") {
-              <p class="tw-flex tw-items-center tw-gap-2">
-                @let cardBrandIcon = getCardBrandIcon();
-                @if (cardBrandIcon !== null) {
-                  <i class="bwi bwi-fw credit-card-icon {{ cardBrandIcon }}"></i>
-                } @else {
-                  <i class="bwi bwi-fw bwi-credit-card"></i>
-                }
-                {{ paymentMethod.brand | titlecase }}, *{{ paymentMethod.last4 }},
-                {{ paymentMethod.expiration }}
-                <span
-                  class="tw-ml-2 tw-text-primary-600 tw-cursor-pointer"
-                  (click)="toggleShowPayment()"
-                >
-                  {{ "changePaymentMethod" | i18n }}
-                </span>
-              </p>
-            }
-            @case ("payPal") {
-              <i class="bwi bwi-fw bwi-paypal tw-text-primary-600"></i>
-              {{ paymentMethod.email }}
-              <span
-                class="tw-ml-2 tw-text-primary-600 tw-cursor-pointer"
-                (click)="toggleShowPayment()"
-              >
-                {{ "changePaymentMethod" | i18n }}
-              </span>
-            }
-          }
-          <a></a>
-        </p>
-        <ng-container *ngIf="canUpdatePaymentInformation()">
-          <app-enter-payment-method [group]="billingFormGroup.controls.paymentMethod">
-          </app-enter-payment-method>
-          <app-enter-billing-address
-            [group]="billingFormGroup.controls.billingAddress"
-            [scenario]="{ type: 'checkout', supportsTaxId }"
-          >
-          </app-enter-billing-address>
-        </ng-container>
-        <div class="tw-mt-4">
-          <p class="tw-text-lg tw-mb-1">
-            <span class="tw-font-medium"
-              >{{ "total" | i18n }}:
-              {{ total - calculateTotalAppliedDiscount(total) | currency: "USD" : "$" }} USD</span
-            >
-            <span class="tw-text-xs tw-font-light"> / {{ selectedPlanInterval | i18n }}</span>
-            <button
-              (click)="toggleTotalOpened()"
-              type="button"
-              [bitIconButton]="totalOpened ? 'bwi-angle-down' : 'bwi-angle-up'"
-              size="small"
-              [label]="totalOpened ? ('hidePricingSummary' | i18n) : ('showPricingSummary' | i18n)"
-            ></button>
-          </p>
-        </div>
-        <!-- SM + PM and PM only cost summary -->
-        <div *ngIf="totalOpened && !isSecretsManagerTrial()" class="tw-flex tw-flex-wrap tw-gap-4">
-          <bit-hint class="tw-w-1/2" *ngIf="selectedInterval == planIntervals.Annually">
-            <p class="tw-font-medium tw-mb-1" *ngIf="organization.useSecretsManager">
-              {{ "passwordManager" | i18n }}
-            </p>
-            <p
-              class="tw-mb-1 tw-flex tw-justify-between"
-              bitTypography="body2"
-              *ngIf="selectedPlan.PasswordManager.basePrice"
-            >
-              <span>
-                {{ passwordManagerSeats }}
-                {{ "members" | i18n }} &times;
-                {{
-                  (selectedPlan.isAnnual
-                    ? selectedPlan.PasswordManager.basePrice / 12
-                    : selectedPlan.PasswordManager.basePrice
-                  ) | currency: "$"
-                }}
-                /{{ selectedPlanInterval | i18n }}
-              </span>
-              <span>
-                <ng-container *ngIf="acceptingSponsorship; else notAcceptingSponsorship">
-                  <span class="tw-line-through">{{
-                    selectedPlan.PasswordManager.basePrice | currency: "$"
-                  }}</span>
-                  {{ "freeWithSponsorship" | i18n }}
-                </ng-container>
-                <ng-template #notAcceptingSponsorship>
-                  {{ selectedPlan.PasswordManager.basePrice | currency: "$" }}
-                </ng-template>
-              </span>
-            </p>
-            <p
-              class="tw-mb-0 tw-flex tw-justify-between"
-              bitTypography="body2"
-              *ngIf="selectedPlan.PasswordManager.hasAdditionalSeatsOption"
-            >
-              <span>
-                <span *ngIf="selectedPlan.PasswordManager.baseSeats"
-                  >{{ "additionalUsers" | i18n }}:</span
-                >
-                {{ passwordManagerSeats || 0 }}&nbsp;
-                <span *ngIf="!selectedPlan.PasswordManager.baseSeats">{{ "members" | i18n }}</span>
-                &times;
-                {{ selectedPlan.PasswordManager.seatPrice | currency: "$" }}
-                /{{ selectedPlanInterval | i18n }}
-              </span>
-
-              <span>
-                {{ passwordManagerSeatTotal(selectedPlan) | currency: "$" }}
-              </span>
-            </p>
-            <p
-              class="tw-mb-0 tw-flex tw-justify-between"
-              bitTypography="body2"
-              *ngIf="selectedPlan.PasswordManager.hasAdditionalStorageOption && storageGb > 0"
-            >
-              <span>
-                {{ storageGb }}
-                {{ "additionalStorageGbMessage" | i18n }}
-                &times;
-                {{ additionalStoragePriceMonthly(selectedPlan) | currency: "$" }}
-                /{{ selectedPlanInterval | i18n }}
-              </span>
-              <span>{{ additionalStorageTotal(selectedPlan) | currency: "$" }}</span>
-            </p>
-            <!--Discount PM Annual-->
-            <p
-              class="tw-mb-0 tw-flex tw-justify-between"
-              bitTypography="body2"
-              *ngIf="organization.useSecretsManager && !isSecretsManagerTrial()"
-            >
-              <ng-container
-                *ngIf="selectedInterval == planIntervals.Annually && discountPercentageFromSub > 0"
-              >
-                <span class="tw-text-xs">
-                  {{ "providerDiscount" | i18n: this.discountPercentageFromSub | lowercase }}
-                </span>
-                <span class="tw-line-through tw-text-xs">{{
-                  calculateTotalAppliedDiscount(
-                    passwordManagerSeatTotal(selectedPlan) + additionalStorageTotal(selectedPlan)
-                  ) | currency: "$"
-                }}</span>
-              </ng-container>
-            </p>
-            <!-- secrets manager summary for annual -->
-            <p class="tw-font-medium tw-mt-3 tw-mb-1" *ngIf="organization.useSecretsManager">
-              {{ "secretsManager" | i18n }}
-            </p>
-            <p
-              class="tw-mb-1 tw-flex tw-justify-between"
-              bitTypography="body2"
-              *ngIf="selectedPlan?.SecretsManager?.basePrice && organization.useSecretsManager"
-            >
-              <span>
-                {{ sub?.smSeats }}
-                {{ "members" | i18n }} &times;
-                {{
-                  (selectedPlan.isAnnual
-                    ? selectedPlan.SecretsManager.basePrice / 12
-                    : selectedPlan.SecretsManager.basePrice
-                  ) | currency: "$"
-                }}
-                /{{ selectedPlanInterval | i18n }}
-              </span>
-            </p>
-            <p
-              class="tw-mb-0 tw-flex tw-justify-between"
-              bitTypography="body2"
-              *ngIf="
-                selectedPlan?.SecretsManager?.hasAdditionalSeatsOption &&
-                organization.useSecretsManager
-              "
-            >
-              <span>
-                <span *ngIf="selectedPlan.SecretsManager.baseSeats"
-                  >{{ "additionalUsers" | i18n }}:</span
-                >
-                {{ sub?.smSeats || 0 }}&nbsp;
-                <span *ngIf="!selectedPlan.SecretsManager.baseSeats">{{ "members" | i18n }}</span>
-                &times;
-                {{ selectedPlan.SecretsManager.seatPrice | currency: "$" }}
-                /{{ selectedPlanInterval | i18n }}
-              </span>
-
-              <span>
-                {{ secretsManagerSeatTotal(selectedPlan, sub.smSeats) | currency: "$" }}
-              </span>
-            </p>
-            <p
-              class="tw-mb-0 tw-flex tw-justify-between"
-              bitTypography="body2"
-              *ngIf="
-                selectedPlan?.SecretsManager?.hasAdditionalServiceAccountOption &&
-                additionalServiceAccount > 0
-              "
-            >
-              <span>
-                {{ additionalServiceAccount }}
-                {{ "serviceAccounts" | i18n | lowercase }}
-                &times;
-                {{ selectedPlan?.SecretsManager?.additionalPricePerServiceAccount | currency: "$" }}
-                /{{ selectedPlanInterval | i18n }}
-              </span>
-              <span>{{ additionalServiceAccountTotal(selectedPlan) | currency: "$" }}</span>
-            </p>
-            <!--Discount SM annual-->
-            <p
-              class="tw-mb-0 tw-flex tw-justify-between"
-              bitTypography="body2"
-              *ngIf="organization.useSecretsManager && !isSecretsManagerTrial()"
-            >
-              <ng-container
-                *ngIf="selectedInterval == planIntervals.Annually && discountPercentageFromSub > 0"
-              >
-                <span class="tw-text-xs">
-                  {{ "providerDiscount" | i18n: this.discountPercentageFromSub | lowercase }}
-                </span>
-                <span class="tw-line-through tw-text-xs">{{
-                  calculateTotalAppliedDiscount(
-                    additionalServiceAccountTotal(selectedPlan) +
-                      secretsManagerSeatTotal(selectedPlan, sub.smSeats)
-                  ) | currency: "$"
-                }}</span>
-              </ng-container>
-            </p>
-          </bit-hint>
-          <bit-hint class="tw-w-1/2" *ngIf="selectedInterval == planIntervals.Monthly">
-            <p class="tw-font-medium tw-mb-1" *ngIf="organization.useSecretsManager">
-              {{ "passwordManager" | i18n }}
-            </p>
-            <p
-              class="tw-mb-0 tw-flex tw-justify-between"
-              bitTypography="body2"
-              *ngIf="selectedPlan.PasswordManager.basePrice"
-            >
-              <span>
-                {{ "basePrice" | i18n }}:
-                {{ selectedPlan.PasswordManager.basePrice | currency: "$" }}
-                {{ "monthAbbr" | i18n }}
-              </span>
-              <span>
-                {{ selectedPlan.PasswordManager.basePrice | currency: "$" }}
-              </span>
-            </p>
-            <p
-              class="tw-mb-0 tw-flex tw-justify-between"
-              bitTypography="body2"
-              *ngIf="selectedPlan.PasswordManager.hasAdditionalSeatsOption"
-            >
-              <span>
-                <span *ngIf="selectedPlan.PasswordManager.baseSeats"
-                  >{{ "additionalUsers" | i18n }}:</span
-                >
-                {{ passwordManagerSeats }}&nbsp;
-                <span *ngIf="!selectedPlan.PasswordManager.baseSeats">{{ "members" | i18n }}</span>
-                &times;
-                {{ selectedPlan.PasswordManager.seatPrice | currency: "$" }}
-                /{{ selectedPlanInterval | i18n }}
-              </span>
-              <span>
-                {{ passwordManagerSeatTotal(selectedPlan) | currency: "$" }}
-              </span>
-            </p>
-            <p
-              class="tw-mb-0 tw-flex tw-justify-between"
-              bitTypography="body2"
-              *ngIf="selectedPlan.PasswordManager.hasAdditionalStorageOption && storageGb > 0"
-            >
-              <span>
-                {{ storageGb }}
-                {{ "additionalStorageGbMessage" | i18n }}
-                &times;
-                {{ additionalStoragePriceMonthly(selectedPlan) | currency: "$" }}
-                /{{ selectedPlanInterval | i18n }}
-              </span>
-              <span>{{
-                storageGb * selectedPlan.PasswordManager.additionalStoragePricePerGb | currency: "$"
-              }}</span>
-            </p>
-            <!--Discount PM Monthly-->
-            <p
-              class="tw-mb-0 tw-flex tw-justify-between"
-              bitTypography="body2"
-              *ngIf="organization.useSecretsManager && !isSecretsManagerTrial()"
-            >
-              <ng-container *ngIf="selectedInterval == planIntervals.Monthly">
-                <span
-                  class="tw-text-xs"
-                  [style.display]="discountPercentageFromSub > 0 ? 'block' : 'none'"
-                >
-                  {{ "providerDiscount" | i18n: this.discountPercentageFromSub | lowercase }}
-                </span>
-                <span
-                  [style.display]="discountPercentageFromSub > 0 ? 'block' : 'none'"
-                  class="tw-line-through tw-text-xs"
-                  >{{ calculateTotalAppliedDiscount(total) | currency: "$" }}</span
-                >
-              </ng-container>
-            </p>
-            <!-- secrets manager summary for monthly -->
-            <p class="tw-font-medium tw-mt-3 tw-mb-1" *ngIf="organization.useSecretsManager">
-              {{ "secretsManager" | i18n }}
-            </p>
-            <p
-              class="tw-mb-0 tw-flex tw-justify-between"
-              bitTypography="body2"
-              *ngIf="selectedPlan.SecretsManager.basePrice && organization.useSecretsManager"
-            >
-              <span>
-                {{ "basePrice" | i18n }}:
-                {{ selectedPlan.SecretsManager.basePrice | currency: "$" }}
-                {{ "monthAbbr" | i18n }}
-              </span>
-              <span>
-                {{ selectedPlan.SecretsManager.basePrice | currency: "$" }}
-              </span>
-            </p>
-            <p
-              class="tw-mb-0 tw-flex tw-justify-between"
-              bitTypography="body2"
-              *ngIf="
-                selectedPlan.SecretsManager.hasAdditionalSeatsOption &&
-                organization.useSecretsManager
-              "
-            >
-              <span>
-                <span *ngIf="selectedPlan.SecretsManager.baseSeats"
-                  >{{ "additionalUsers" | i18n }}:</span
-                >
-                {{ sub?.smSeats }}&nbsp;
-                <span *ngIf="!selectedPlan.SecretsManager.baseSeats">{{ "members" | i18n }}</span>
-                &times;
-                {{ selectedPlan.SecretsManager.seatPrice | currency: "$" }}
-                /{{ selectedPlanInterval | i18n }}
-              </span>
-              <span>
-                {{ secretsManagerSeatTotal(selectedPlan, sub?.smSeats) | currency: "$" }}
-              </span>
-            </p>
-            <p
-              class="tw-mb-0 tw-flex tw-justify-between"
-              bitTypography="body2"
-              *ngIf="
-                selectedPlan.SecretsManager.hasAdditionalServiceAccountOption &&
-                additionalServiceAccount > 0
-              "
-            >
-              <span>
-                {{ additionalServiceAccount }}
-                {{ "serviceAccounts" | i18n | lowercase }}
-                &times;
-                {{ selectedPlan.SecretsManager.additionalPricePerServiceAccount | currency: "$" }}
-                /{{ selectedPlanInterval | i18n }}
-              </span>
-              <span>{{ additionalServiceAccountTotal(selectedPlan) | currency: "$" }}</span>
-            </p>
-            <!--Discount SM Monthly-->
-            <p
-              class="tw-mb-0 tw-flex tw-justify-between"
-              bitTypography="body2"
-              *ngIf="organization.useSecretsManager && !isSecretsManagerTrial()"
-            >
-              <ng-container *ngIf="selectedInterval == planIntervals.Monthly">
-                <span
-                  class="tw-text-xs"
-                  [style.display]="discountPercentageFromSub > 0 ? 'block' : 'none'"
-                >
-                  {{ "providerDiscount" | i18n: this.discountPercentageFromSub | lowercase }}
-                </span>
-                <span
-                  [style.display]="discountPercentageFromSub > 0 ? 'block' : 'none'"
-                  class="tw-line-through tw-text-xs"
-                  >{{
-                    additionalServiceAccountTotal(selectedPlan) +
-                      secretsManagerSeatTotal(selectedPlan, sub?.smSeats) | currency: "$"
-                  }}</span
-                >
-              </ng-container>
-            </p>
-          </bit-hint>
-        </div>
-        <!-- SM + Free PM cost summary -->
-        <div *ngIf="totalOpened && isSecretsManagerTrial()" class="tw-flex tw-flex-wrap tw-gap-4">
-          <bit-hint class="tw-w-1/2" *ngIf="selectedInterval == planIntervals.Annually">
-            <!-- secrets manager summary for annual -->
-            <p class="tw-font-medium tw-mt-2 tw-mb-0" *ngIf="organization.useSecretsManager">
-              {{ "secretsManager" | i18n }}
-            </p>
-            <p
-              class="tw-mb-1 tw-flex tw-justify-between"
-              bitTypography="body2"
-              *ngIf="selectedPlan.SecretsManager.basePrice && organization.useSecretsManager"
-            >
-              <span>
-                {{ sub?.smSeats }}
-                {{ "members" | i18n }} &times;
-                {{
-                  (selectedPlan.isAnnual
-                    ? selectedPlan.SecretsManager.basePrice / 12
-                    : selectedPlan.SecretsManager.basePrice
-                  ) | currency: "$"
-                }}
-                /{{ selectedPlanInterval | i18n }}
-              </span>
-            </p>
-            <p
-              class="tw-mb-0 tw-flex tw-justify-between"
-              bitTypography="body2"
-              *ngIf="
-                selectedPlan.SecretsManager.hasAdditionalSeatsOption &&
-                organization.useSecretsManager
-              "
-            >
-              <span>
-                <span *ngIf="selectedPlan.SecretsManager.baseSeats"
-                  >{{ "additionalUsers" | i18n }}:</span
-                >
-                {{ sub?.smSeats || 0 }}&nbsp;
-                <span *ngIf="!selectedPlan.SecretsManager.baseSeats">{{ "members" | i18n }}</span>
-                &times;
-                {{ selectedPlan.SecretsManager.seatPrice | currency: "$" }}
-                /{{ selectedPlanInterval | i18n }}
-              </span>
-
-              <span>
-                {{ secretsManagerSeatTotal(selectedPlan, sub.smSeats) | currency: "$" }}
-              </span>
-            </p>
-            <p
-              class="tw-mb-0 tw-flex tw-justify-between"
-              bitTypography="body2"
-              *ngIf="
-                selectedPlan.SecretsManager.hasAdditionalServiceAccountOption &&
-                additionalServiceAccount > 0
-              "
-            >
-              <span>
-                {{ additionalServiceAccount }}
-                {{ "serviceAccounts" | i18n }}
-                &times;
-                {{ selectedPlan.SecretsManager.additionalPricePerServiceAccount | currency: "$" }}
-                /{{ selectedPlanInterval | i18n }}
-              </span>
-              <span>{{ additionalServiceAccountTotal(selectedPlan) | currency: "$" }}</span>
-            </p>
-            <!-- password manager summary for annual -->
-            <p class="tw-font-medium tw-mt-3 tw-mb-0" *ngIf="organization.useSecretsManager">
-              {{ "passwordManager" | i18n }}
-            </p>
-            <p
-              class="tw-mb-0 tw-flex tw-justify-between"
-              bitTypography="body2"
-              *ngIf="selectedPlan.PasswordManager.basePrice"
-            >
-              <span>
-                {{ sub?.seats }}
-                {{ "members" | i18n }} &times;
-                {{
-                  (selectedPlan.isAnnual
-                    ? selectedPlan.PasswordManager.basePrice / 12
-                    : selectedPlan.PasswordManager.basePrice
-                  ) | currency: "$"
-                }}
-                /{{ selectedPlanInterval | i18n }}
-              </span>
-              <span>
-                <ng-container *ngIf="acceptingSponsorship; else notAcceptingSponsorship">
-                  <span class="tw-line-through">{{
-                    selectedPlan.PasswordManager.basePrice | currency: "$"
-                  }}</span>
-                  {{ "freeWithSponsorship" | i18n }}
-                </ng-container>
-                <ng-template #notAcceptingSponsorship>
-                  {{ selectedPlan.PasswordManager.basePrice | currency: "$" }}
-                </ng-template>
-              </span>
-            </p>
-            <p
-              class="tw-mb-0 tw-flex tw-justify-between"
-              bitTypography="body2"
-              *ngIf="selectedPlan.PasswordManager.hasAdditionalSeatsOption"
-            >
-              <span>
-                <span *ngIf="selectedPlan.PasswordManager.baseSeats"
-                  >{{ "additionalUsers" | i18n }}:</span
-                >
-                {{ sub?.seats || 0 }}&nbsp;
-                <span *ngIf="!selectedPlan.PasswordManager.baseSeats">{{ "members" | i18n }}</span>
-                &times;
-                {{ selectedPlan.PasswordManager.seatPrice | currency: "$" }}
-                /{{ selectedPlanInterval | i18n }}
-              </span>
-
-              <span *ngIf="isSecretsManagerTrial()">
-                {{ "freeForOneYear" | i18n }}
-              </span>
-
-              <span *ngIf="!isSecretsManagerTrial()">
-                {{ passwordManagerSeatTotal(selectedPlan) | currency: "$" }}
-              </span>
-            </p>
-          </bit-hint>
-          <bit-hint class="tw-w-1/2" *ngIf="selectedInterval == planIntervals.Monthly">
-            <!-- secrets manager summary for monthly -->
-            <p class="tw-font-medium tw-mt-2 tw-mb-0" *ngIf="organization.useSecretsManager">
-              {{ "secretsManager" | i18n }}
-            </p>
-            <p
-              class="tw-mb-0 tw-flex tw-justify-between"
-              bitTypography="body2"
-              *ngIf="selectedPlan.SecretsManager.basePrice && organization.useSecretsManager"
-            >
-              <span>
-                {{ "basePrice" | i18n }}:
-                {{ selectedPlan.SecretsManager.basePrice | currency: "$" }}
-                {{ "monthAbbr" | i18n }}
-              </span>
-              <span>
-                {{ selectedPlan.SecretsManager.basePrice | currency: "$" }}
-              </span>
-            </p>
-            <p
-              class="tw-mb-0 tw-flex tw-justify-between"
-              bitTypography="body2"
-              *ngIf="
-                selectedPlan.SecretsManager.hasAdditionalSeatsOption &&
-                organization.useSecretsManager
-              "
-            >
-              <span>
-                <span *ngIf="selectedPlan.SecretsManager.baseSeats"
-                  >{{ "additionalUsers" | i18n }}:</span
-                >
-                {{ sub?.smSeats }}&nbsp;
-                <span *ngIf="!selectedPlan.SecretsManager.baseSeats">{{ "members" | i18n }}</span>
-                &times;
-                {{ selectedPlan.SecretsManager.seatPrice | currency: "$" }}
-                /{{ selectedPlanInterval | i18n }}
-              </span>
-              <span>
-                {{ secretsManagerSeatTotal(selectedPlan, sub?.smSeats) | currency: "$" }}
-              </span>
-            </p>
-            <p
-              class="tw-mb-0 tw-flex tw-justify-between"
-              bitTypography="body2"
-              *ngIf="
-                selectedPlan.SecretsManager.hasAdditionalServiceAccountOption &&
-                additionalServiceAccount > 0
-              "
-            >
-              <span>
-                {{ additionalServiceAccount }}
-                {{ "serviceAccounts" | i18n }}
-                &times;
-                {{ selectedPlan.SecretsManager.additionalPricePerServiceAccount | currency: "$" }}
-                /{{ selectedPlanInterval | i18n }}
-              </span>
-              <span>{{ additionalServiceAccountTotal(selectedPlan) | currency: "$" }}</span>
-            </p>
-            <!-- password manager summary for monthly -->
-            <p class="tw-font-medium tw-mt-3 tw-mb-0" *ngIf="organization.useSecretsManager">
-              {{ "passwordManager" | i18n }}
-            </p>
-            <p
-              class="tw-mb-0 tw-flex tw-justify-between"
-              bitTypography="body2"
-              *ngIf="selectedPlan.PasswordManager.basePrice"
-            >
-              <span>
-                {{ "basePrice" | i18n }}:
-                {{ selectedPlan.PasswordManager.basePrice | currency: "$" }}
-                {{ "monthAbbr" | i18n }}
-              </span>
-              <span>
-                {{ selectedPlan.PasswordManager.basePrice | currency: "$" }}
-              </span>
-            </p>
-            <p
-              class="tw-mb-0 tw-flex tw-justify-between"
-              bitTypography="body2"
-              *ngIf="selectedPlan.PasswordManager.hasAdditionalSeatsOption"
-            >
-              <span>
-                <span *ngIf="selectedPlan.PasswordManager.baseSeats"
-                  >{{ "additionalUsers" | i18n }}:</span
-                >
-                {{ sub?.seats }}&nbsp;
-                <span *ngIf="!selectedPlan.PasswordManager.baseSeats">{{ "members" | i18n }}</span>
-                &times;
-                {{ selectedPlan.PasswordManager.seatPrice | currency: "$" }}
-                /{{ selectedPlanInterval | i18n }}
-              </span>
-              <span *ngIf="isSecretsManagerTrial()">
-                {{ "freeForOneYear" | i18n }}
-              </span>
-
-              <span *ngIf="!isSecretsManagerTrial()">
-                {{ passwordManagerSeatTotal(selectedPlan) | currency: "$" }}
-              </span>
-            </p>
-          </bit-hint>
-        </div>
-        <!-- discountPercentage to PM Only -->
-        <div
-          *ngIf="totalOpened && !organization.useSecretsManager"
-          class="tw-flex tw-flex-wrap tw-gap-4"
-        >
-          <bit-hint class="tw-w-1/2">
-            <p
-              class="tw-mb-0 tw-flex tw-justify-between"
-              bitTypography="body2"
-              *ngIf="discountPercentageFromSub > 0"
-            >
-              <ng-container>
-                <span class="tw-text-xs">
-                  {{ "providerDiscount" | i18n: this.discountPercentageFromSub | lowercase }}
-                </span>
-                <span class="tw-line-through tw-text-xs">{{
-                  calculateTotalAppliedDiscount(total) | currency: "$"
-                }}</span>
-              </ng-container>
-            </p>
-          </bit-hint>
-        </div>
-        <div *ngIf="totalOpened" class="tw-flex tw-flex-wrap tw-gap-4 tw-mt-4">
-          <bit-hint class="tw-w-1/2">
-            <p
-              class="tw-flex tw-justify-between tw-border-0 tw-border-solid tw-border-t tw-border-secondary-300 tw-pt-2 tw-mb-0"
-            >
-              <span class="tw-font-medium">
-                {{ "estimatedTax" | i18n }}
-              </span>
-              <span>
-                {{ estimatedTax | currency: "USD" : "$" }}
-              </span>
-            </p>
-          </bit-hint>
-        </div>
-        <div *ngIf="totalOpened" class="tw-flex tw-flex-wrap tw-gap-4 tw-mt-4">
-          <bit-hint class="tw-w-1/2">
-            <p
-              class="tw-flex tw-justify-between tw-border-0 tw-border-solid tw-border-t tw-border-secondary-300 tw-pt-2 tw-mb-0"
-            >
-              <span class="tw-font-medium">
-                {{ "total" | i18n }}
-              </span>
-              <span>
-                {{ total - calculateTotalAppliedDiscount(total) | currency: "USD" : "$" }}
-                <span class="tw-text-xs tw-font-medium"> / {{ selectedPlanInterval | i18n }}</span>
-              </span>
-            </p>
-          </bit-hint>
-        </div>
-      </ng-container>
-    </div>
-    <ng-container bitDialogFooter>
-      <button bitButton bitFormButton buttonType="primary" type="submit">
-        {{ submitButtonLabel }}
-      </button>
-      <button bitButton buttonType="secondary" type="button" [bitDialogClose]="ResultType.Closed">
-        {{ "cancel" | i18n }}
-      </button>
+        {{ "secretsManagerSubscriptionInfo" | i18n }}
+      </bit-callout>
+      <bit-callout
+        *ngIf="organization.useSecretsManager && isSecretsManagerTrial()"
+        type="info"
+        title="PASSWORD MANAGER SUBSCRIPTION"
+      >
+        {{ "secretsManagerComplimentaryPasswordManager" | i18n }}
+      </bit-callout>
+      <br />
     </ng-container>
-  </bit-dialog>
+    <!-- Payment info -->
+    <ng-container
+      *ngIf="formGroup.value.productTier !== productTypes.Free || isSubscriptionCanceled"
+    >
+      <h2 bitTypography="h4">{{ "paymentMethod" | i18n }}</h2>
+      <p *ngIf="!showPayment && !!paymentMethod && !isSubscriptionCanceled">
+        @switch (paymentMethod.type) {
+          @case ("bankAccount") {
+            <i class="bwi bwi-fw bwi-billing"></i>
+            {{ paymentMethod.bankName }}, *{{ paymentMethod.last4 }}
+            @if (paymentMethod.hostedVerificationUrl) {
+              <span>- {{ "unverified" | i18n }}</span>
+            }
+            <span
+              class="tw-ml-2 tw-text-primary-600 tw-cursor-pointer"
+              (click)="toggleShowPayment()"
+            >
+              {{ "changePaymentMethod" | i18n }}
+            </span>
+          }
+          @case ("card") {
+            <p class="tw-flex tw-items-center tw-gap-2">
+              @let cardBrandIcon = getCardBrandIcon();
+              @if (cardBrandIcon !== null) {
+                <i class="bwi bwi-fw credit-card-icon {{ cardBrandIcon }}"></i>
+              } @else {
+                <i class="bwi bwi-fw bwi-credit-card"></i>
+              }
+              {{ paymentMethod.brand | titlecase }}, *{{ paymentMethod.last4 }},
+              {{ paymentMethod.expiration }}
+              <span
+                class="tw-ml-2 tw-text-primary-600 tw-cursor-pointer"
+                (click)="toggleShowPayment()"
+              >
+                {{ "changePaymentMethod" | i18n }}
+              </span>
+            </p>
+          }
+          @case ("payPal") {
+            <i class="bwi bwi-fw bwi-paypal tw-text-primary-600"></i>
+            {{ paymentMethod.email }}
+            <span
+              class="tw-ml-2 tw-text-primary-600 tw-cursor-pointer"
+              (click)="toggleShowPayment()"
+            >
+              {{ "changePaymentMethod" | i18n }}
+            </span>
+          }
+        }
+        <a></a>
+      </p>
+      <ng-container *ngIf="canUpdatePaymentInformation()">
+        <app-enter-payment-method [group]="billingFormGroup.controls.paymentMethod">
+        </app-enter-payment-method>
+        <app-enter-billing-address
+          [group]="billingFormGroup.controls.billingAddress"
+          [scenario]="{ type: 'checkout', supportsTaxId }"
+        >
+        </app-enter-billing-address>
+      </ng-container>
+      <div class="tw-mt-4">
+        <p class="tw-text-lg tw-mb-1">
+          <span class="tw-font-medium"
+            >{{ "total" | i18n }}:
+            {{ total - calculateTotalAppliedDiscount(total) | currency: "USD" : "$" }} USD</span
+          >
+          <span class="tw-text-xs tw-font-light"> / {{ selectedPlanInterval | i18n }}</span>
+          <button
+            (click)="toggleTotalOpened()"
+            type="button"
+            [bitIconButton]="totalOpened ? 'bwi-angle-down' : 'bwi-angle-up'"
+            size="small"
+            [label]="totalOpened ? ('hidePricingSummary' | i18n) : ('showPricingSummary' | i18n)"
+          ></button>
+        </p>
+      </div>
+      <!-- SM + PM and PM only cost summary -->
+      <div *ngIf="totalOpened && !isSecretsManagerTrial()" class="tw-flex tw-flex-wrap tw-gap-4">
+        <bit-hint class="tw-w-1/2" *ngIf="selectedInterval == planIntervals.Annually">
+          <p class="tw-font-medium tw-mb-1" *ngIf="organization.useSecretsManager">
+            {{ "passwordManager" | i18n }}
+          </p>
+          <p
+            class="tw-mb-1 tw-flex tw-justify-between"
+            bitTypography="body2"
+            *ngIf="selectedPlan.PasswordManager.basePrice"
+          >
+            <span>
+              {{ passwordManagerSeats }}
+              {{ "members" | i18n }} &times;
+              {{
+                (selectedPlan.isAnnual
+                  ? selectedPlan.PasswordManager.basePrice / 12
+                  : selectedPlan.PasswordManager.basePrice
+                ) | currency: "$"
+              }}
+              /{{ selectedPlanInterval | i18n }}
+            </span>
+            <span>
+              <ng-container *ngIf="acceptingSponsorship; else notAcceptingSponsorship">
+                <span class="tw-line-through">{{
+                  selectedPlan.PasswordManager.basePrice | currency: "$"
+                }}</span>
+                {{ "freeWithSponsorship" | i18n }}
+              </ng-container>
+              <ng-template #notAcceptingSponsorship>
+                {{ selectedPlan.PasswordManager.basePrice | currency: "$" }}
+              </ng-template>
+            </span>
+          </p>
+          <p
+            class="tw-mb-0 tw-flex tw-justify-between"
+            bitTypography="body2"
+            *ngIf="selectedPlan.PasswordManager.hasAdditionalSeatsOption"
+          >
+            <span>
+              <span *ngIf="selectedPlan.PasswordManager.baseSeats"
+                >{{ "additionalUsers" | i18n }}:</span
+              >
+              {{ passwordManagerSeats || 0 }}&nbsp;
+              <span *ngIf="!selectedPlan.PasswordManager.baseSeats">{{ "members" | i18n }}</span>
+              &times;
+              {{ selectedPlan.PasswordManager.seatPrice | currency: "$" }}
+              /{{ selectedPlanInterval | i18n }}
+            </span>
+
+            <span>
+              {{ passwordManagerSeatTotal(selectedPlan) | currency: "$" }}
+            </span>
+          </p>
+          <p
+            class="tw-mb-0 tw-flex tw-justify-between"
+            bitTypography="body2"
+            *ngIf="selectedPlan.PasswordManager.hasAdditionalStorageOption && storageGb > 0"
+          >
+            <span>
+              {{ storageGb }}
+              {{ "additionalStorageGbMessage" | i18n }}
+              &times;
+              {{ additionalStoragePriceMonthly(selectedPlan) | currency: "$" }}
+              /{{ selectedPlanInterval | i18n }}
+            </span>
+            <span>{{ additionalStorageTotal(selectedPlan) | currency: "$" }}</span>
+          </p>
+          <!--Discount PM Annual-->
+          <p
+            class="tw-mb-0 tw-flex tw-justify-between"
+            bitTypography="body2"
+            *ngIf="organization.useSecretsManager && !isSecretsManagerTrial()"
+          >
+            <ng-container
+              *ngIf="selectedInterval == planIntervals.Annually && discountPercentageFromSub > 0"
+            >
+              <span class="tw-text-xs">
+                {{ "providerDiscount" | i18n: this.discountPercentageFromSub | lowercase }}
+              </span>
+              <span class="tw-line-through tw-text-xs">{{
+                calculateTotalAppliedDiscount(
+                  passwordManagerSeatTotal(selectedPlan) + additionalStorageTotal(selectedPlan)
+                ) | currency: "$"
+              }}</span>
+            </ng-container>
+          </p>
+          <!-- secrets manager summary for annual -->
+          <p class="tw-font-medium tw-mt-3 tw-mb-1" *ngIf="organization.useSecretsManager">
+            {{ "secretsManager" | i18n }}
+          </p>
+          <p
+            class="tw-mb-1 tw-flex tw-justify-between"
+            bitTypography="body2"
+            *ngIf="selectedPlan?.SecretsManager?.basePrice && organization.useSecretsManager"
+          >
+            <span>
+              {{ sub?.smSeats }}
+              {{ "members" | i18n }} &times;
+              {{
+                (selectedPlan.isAnnual
+                  ? selectedPlan.SecretsManager.basePrice / 12
+                  : selectedPlan.SecretsManager.basePrice
+                ) | currency: "$"
+              }}
+              /{{ selectedPlanInterval | i18n }}
+            </span>
+          </p>
+          <p
+            class="tw-mb-0 tw-flex tw-justify-between"
+            bitTypography="body2"
+            *ngIf="
+              selectedPlan?.SecretsManager?.hasAdditionalSeatsOption &&
+              organization.useSecretsManager
+            "
+          >
+            <span>
+              <span *ngIf="selectedPlan.SecretsManager.baseSeats"
+                >{{ "additionalUsers" | i18n }}:</span
+              >
+              {{ sub?.smSeats || 0 }}&nbsp;
+              <span *ngIf="!selectedPlan.SecretsManager.baseSeats">{{ "members" | i18n }}</span>
+              &times;
+              {{ selectedPlan.SecretsManager.seatPrice | currency: "$" }}
+              /{{ selectedPlanInterval | i18n }}
+            </span>
+
+            <span>
+              {{ secretsManagerSeatTotal(selectedPlan, sub.smSeats) | currency: "$" }}
+            </span>
+          </p>
+          <p
+            class="tw-mb-0 tw-flex tw-justify-between"
+            bitTypography="body2"
+            *ngIf="
+              selectedPlan?.SecretsManager?.hasAdditionalServiceAccountOption &&
+              additionalServiceAccount > 0
+            "
+          >
+            <span>
+              {{ additionalServiceAccount }}
+              {{ "serviceAccounts" | i18n | lowercase }}
+              &times;
+              {{ selectedPlan?.SecretsManager?.additionalPricePerServiceAccount | currency: "$" }}
+              /{{ selectedPlanInterval | i18n }}
+            </span>
+            <span>{{ additionalServiceAccountTotal(selectedPlan) | currency: "$" }}</span>
+          </p>
+          <!--Discount SM annual-->
+          <p
+            class="tw-mb-0 tw-flex tw-justify-between"
+            bitTypography="body2"
+            *ngIf="organization.useSecretsManager && !isSecretsManagerTrial()"
+          >
+            <ng-container
+              *ngIf="selectedInterval == planIntervals.Annually && discountPercentageFromSub > 0"
+            >
+              <span class="tw-text-xs">
+                {{ "providerDiscount" | i18n: this.discountPercentageFromSub | lowercase }}
+              </span>
+              <span class="tw-line-through tw-text-xs">{{
+                calculateTotalAppliedDiscount(
+                  additionalServiceAccountTotal(selectedPlan) +
+                    secretsManagerSeatTotal(selectedPlan, sub.smSeats)
+                ) | currency: "$"
+              }}</span>
+            </ng-container>
+          </p>
+        </bit-hint>
+        <bit-hint class="tw-w-1/2" *ngIf="selectedInterval == planIntervals.Monthly">
+          <p class="tw-font-medium tw-mb-1" *ngIf="organization.useSecretsManager">
+            {{ "passwordManager" | i18n }}
+          </p>
+          <p
+            class="tw-mb-0 tw-flex tw-justify-between"
+            bitTypography="body2"
+            *ngIf="selectedPlan.PasswordManager.basePrice"
+          >
+            <span>
+              {{ "basePrice" | i18n }}:
+              {{ selectedPlan.PasswordManager.basePrice | currency: "$" }}
+              {{ "monthAbbr" | i18n }}
+            </span>
+            <span>
+              {{ selectedPlan.PasswordManager.basePrice | currency: "$" }}
+            </span>
+          </p>
+          <p
+            class="tw-mb-0 tw-flex tw-justify-between"
+            bitTypography="body2"
+            *ngIf="selectedPlan.PasswordManager.hasAdditionalSeatsOption"
+          >
+            <span>
+              <span *ngIf="selectedPlan.PasswordManager.baseSeats"
+                >{{ "additionalUsers" | i18n }}:</span
+              >
+              {{ passwordManagerSeats }}&nbsp;
+              <span *ngIf="!selectedPlan.PasswordManager.baseSeats">{{ "members" | i18n }}</span>
+              &times;
+              {{ selectedPlan.PasswordManager.seatPrice | currency: "$" }}
+              /{{ selectedPlanInterval | i18n }}
+            </span>
+            <span>
+              {{ passwordManagerSeatTotal(selectedPlan) | currency: "$" }}
+            </span>
+          </p>
+          <p
+            class="tw-mb-0 tw-flex tw-justify-between"
+            bitTypography="body2"
+            *ngIf="selectedPlan.PasswordManager.hasAdditionalStorageOption && storageGb > 0"
+          >
+            <span>
+              {{ storageGb }}
+              {{ "additionalStorageGbMessage" | i18n }}
+              &times;
+              {{ additionalStoragePriceMonthly(selectedPlan) | currency: "$" }}
+              /{{ selectedPlanInterval | i18n }}
+            </span>
+            <span>{{
+              storageGb * selectedPlan.PasswordManager.additionalStoragePricePerGb | currency: "$"
+            }}</span>
+          </p>
+          <!--Discount PM Monthly-->
+          <p
+            class="tw-mb-0 tw-flex tw-justify-between"
+            bitTypography="body2"
+            *ngIf="organization.useSecretsManager && !isSecretsManagerTrial()"
+          >
+            <ng-container *ngIf="selectedInterval == planIntervals.Monthly">
+              <span
+                class="tw-text-xs"
+                [style.display]="discountPercentageFromSub > 0 ? 'block' : 'none'"
+              >
+                {{ "providerDiscount" | i18n: this.discountPercentageFromSub | lowercase }}
+              </span>
+              <span
+                [style.display]="discountPercentageFromSub > 0 ? 'block' : 'none'"
+                class="tw-line-through tw-text-xs"
+                >{{ calculateTotalAppliedDiscount(total) | currency: "$" }}</span
+              >
+            </ng-container>
+          </p>
+          <!-- secrets manager summary for monthly -->
+          <p class="tw-font-medium tw-mt-3 tw-mb-1" *ngIf="organization.useSecretsManager">
+            {{ "secretsManager" | i18n }}
+          </p>
+          <p
+            class="tw-mb-0 tw-flex tw-justify-between"
+            bitTypography="body2"
+            *ngIf="selectedPlan.SecretsManager.basePrice && organization.useSecretsManager"
+          >
+            <span>
+              {{ "basePrice" | i18n }}:
+              {{ selectedPlan.SecretsManager.basePrice | currency: "$" }}
+              {{ "monthAbbr" | i18n }}
+            </span>
+            <span>
+              {{ selectedPlan.SecretsManager.basePrice | currency: "$" }}
+            </span>
+          </p>
+          <p
+            class="tw-mb-0 tw-flex tw-justify-between"
+            bitTypography="body2"
+            *ngIf="
+              selectedPlan.SecretsManager.hasAdditionalSeatsOption && organization.useSecretsManager
+            "
+          >
+            <span>
+              <span *ngIf="selectedPlan.SecretsManager.baseSeats"
+                >{{ "additionalUsers" | i18n }}:</span
+              >
+              {{ sub?.smSeats }}&nbsp;
+              <span *ngIf="!selectedPlan.SecretsManager.baseSeats">{{ "members" | i18n }}</span>
+              &times;
+              {{ selectedPlan.SecretsManager.seatPrice | currency: "$" }}
+              /{{ selectedPlanInterval | i18n }}
+            </span>
+            <span>
+              {{ secretsManagerSeatTotal(selectedPlan, sub?.smSeats) | currency: "$" }}
+            </span>
+          </p>
+          <p
+            class="tw-mb-0 tw-flex tw-justify-between"
+            bitTypography="body2"
+            *ngIf="
+              selectedPlan.SecretsManager.hasAdditionalServiceAccountOption &&
+              additionalServiceAccount > 0
+            "
+          >
+            <span>
+              {{ additionalServiceAccount }}
+              {{ "serviceAccounts" | i18n }}
+              &times;
+              {{ selectedPlan.SecretsManager.additionalPricePerServiceAccount | currency: "$" }}
+              /{{ selectedPlanInterval | i18n }}
+            </span>
+            <span>{{ additionalServiceAccountTotal(selectedPlan) | currency: "$" }}</span>
+          </p>
+          <!--Discount SM Monthly-->
+          <p
+            class="tw-mb-0 tw-flex tw-justify-between"
+            bitTypography="body2"
+            *ngIf="organization.useSecretsManager && !isSecretsManagerTrial()"
+          >
+            <ng-container *ngIf="selectedInterval == planIntervals.Monthly">
+              <span
+                class="tw-text-xs"
+                [style.display]="discountPercentageFromSub > 0 ? 'block' : 'none'"
+              >
+                {{ "providerDiscount" | i18n: this.discountPercentageFromSub | lowercase }}
+              </span>
+              <span
+                [style.display]="discountPercentageFromSub > 0 ? 'block' : 'none'"
+                class="tw-line-through tw-text-xs"
+                >{{
+                  additionalServiceAccountTotal(selectedPlan) +
+                    secretsManagerSeatTotal(selectedPlan, sub?.smSeats) | currency: "$"
+                }}</span
+              >
+            </ng-container>
+          </p>
+        </bit-hint>
+      </div>
+      <!-- SM + Free PM cost summary -->
+      <div *ngIf="totalOpened && isSecretsManagerTrial()" class="tw-flex tw-flex-wrap tw-gap-4">
+        <bit-hint class="tw-w-1/2" *ngIf="selectedInterval == planIntervals.Annually">
+          <!-- secrets manager summary for annual -->
+          <p class="tw-font-medium tw-mt-2 tw-mb-0" *ngIf="organization.useSecretsManager">
+            {{ "secretsManager" | i18n }}
+          </p>
+          <p
+            class="tw-mb-1 tw-flex tw-justify-between"
+            bitTypography="body2"
+            *ngIf="selectedPlan.SecretsManager.basePrice && organization.useSecretsManager"
+          >
+            <span>
+              {{ sub?.smSeats }}
+              {{ "members" | i18n }} &times;
+              {{
+                (selectedPlan.isAnnual
+                  ? selectedPlan.SecretsManager.basePrice / 12
+                  : selectedPlan.SecretsManager.basePrice
+                ) | currency: "$"
+              }}
+              /{{ selectedPlanInterval | i18n }}
+            </span>
+          </p>
+          <p
+            class="tw-mb-0 tw-flex tw-justify-between"
+            bitTypography="body2"
+            *ngIf="
+              selectedPlan.SecretsManager.hasAdditionalSeatsOption && organization.useSecretsManager
+            "
+          >
+            <span>
+              <span *ngIf="selectedPlan.SecretsManager.baseSeats"
+                >{{ "additionalUsers" | i18n }}:</span
+              >
+              {{ sub?.smSeats || 0 }}&nbsp;
+              <span *ngIf="!selectedPlan.SecretsManager.baseSeats">{{ "members" | i18n }}</span>
+              &times;
+              {{ selectedPlan.SecretsManager.seatPrice | currency: "$" }}
+              /{{ selectedPlanInterval | i18n }}
+            </span>
+
+            <span>
+              {{ secretsManagerSeatTotal(selectedPlan, sub.smSeats) | currency: "$" }}
+            </span>
+          </p>
+          <p
+            class="tw-mb-0 tw-flex tw-justify-between"
+            bitTypography="body2"
+            *ngIf="
+              selectedPlan.SecretsManager.hasAdditionalServiceAccountOption &&
+              additionalServiceAccount > 0
+            "
+          >
+            <span>
+              {{ additionalServiceAccount }}
+              {{ "serviceAccounts" | i18n }}
+              &times;
+              {{ selectedPlan.SecretsManager.additionalPricePerServiceAccount | currency: "$" }}
+              /{{ selectedPlanInterval | i18n }}
+            </span>
+            <span>{{ additionalServiceAccountTotal(selectedPlan) | currency: "$" }}</span>
+          </p>
+          <!-- password manager summary for annual -->
+          <p class="tw-font-medium tw-mt-3 tw-mb-0" *ngIf="organization.useSecretsManager">
+            {{ "passwordManager" | i18n }}
+          </p>
+          <p
+            class="tw-mb-0 tw-flex tw-justify-between"
+            bitTypography="body2"
+            *ngIf="selectedPlan.PasswordManager.basePrice"
+          >
+            <span>
+              {{ sub?.seats }}
+              {{ "members" | i18n }} &times;
+              {{
+                (selectedPlan.isAnnual
+                  ? selectedPlan.PasswordManager.basePrice / 12
+                  : selectedPlan.PasswordManager.basePrice
+                ) | currency: "$"
+              }}
+              /{{ selectedPlanInterval | i18n }}
+            </span>
+            <span>
+              <ng-container *ngIf="acceptingSponsorship; else notAcceptingSponsorship">
+                <span class="tw-line-through">{{
+                  selectedPlan.PasswordManager.basePrice | currency: "$"
+                }}</span>
+                {{ "freeWithSponsorship" | i18n }}
+              </ng-container>
+              <ng-template #notAcceptingSponsorship>
+                {{ selectedPlan.PasswordManager.basePrice | currency: "$" }}
+              </ng-template>
+            </span>
+          </p>
+          <p
+            class="tw-mb-0 tw-flex tw-justify-between"
+            bitTypography="body2"
+            *ngIf="selectedPlan.PasswordManager.hasAdditionalSeatsOption"
+          >
+            <span>
+              <span *ngIf="selectedPlan.PasswordManager.baseSeats"
+                >{{ "additionalUsers" | i18n }}:</span
+              >
+              {{ sub?.seats || 0 }}&nbsp;
+              <span *ngIf="!selectedPlan.PasswordManager.baseSeats">{{ "members" | i18n }}</span>
+              &times;
+              {{ selectedPlan.PasswordManager.seatPrice | currency: "$" }}
+              /{{ selectedPlanInterval | i18n }}
+            </span>
+
+            <span *ngIf="isSecretsManagerTrial()">
+              {{ "freeForOneYear" | i18n }}
+            </span>
+
+            <span *ngIf="!isSecretsManagerTrial()">
+              {{ passwordManagerSeatTotal(selectedPlan) | currency: "$" }}
+            </span>
+          </p>
+        </bit-hint>
+        <bit-hint class="tw-w-1/2" *ngIf="selectedInterval == planIntervals.Monthly">
+          <!-- secrets manager summary for monthly -->
+          <p class="tw-font-medium tw-mt-2 tw-mb-0" *ngIf="organization.useSecretsManager">
+            {{ "secretsManager" | i18n }}
+          </p>
+          <p
+            class="tw-mb-0 tw-flex tw-justify-between"
+            bitTypography="body2"
+            *ngIf="selectedPlan.SecretsManager.basePrice && organization.useSecretsManager"
+          >
+            <span>
+              {{ "basePrice" | i18n }}:
+              {{ selectedPlan.SecretsManager.basePrice | currency: "$" }}
+              {{ "monthAbbr" | i18n }}
+            </span>
+            <span>
+              {{ selectedPlan.SecretsManager.basePrice | currency: "$" }}
+            </span>
+          </p>
+          <p
+            class="tw-mb-0 tw-flex tw-justify-between"
+            bitTypography="body2"
+            *ngIf="
+              selectedPlan.SecretsManager.hasAdditionalSeatsOption && organization.useSecretsManager
+            "
+          >
+            <span>
+              <span *ngIf="selectedPlan.SecretsManager.baseSeats"
+                >{{ "additionalUsers" | i18n }}:</span
+              >
+              {{ sub?.smSeats }}&nbsp;
+              <span *ngIf="!selectedPlan.SecretsManager.baseSeats">{{ "members" | i18n }}</span>
+              &times;
+              {{ selectedPlan.SecretsManager.seatPrice | currency: "$" }}
+              /{{ selectedPlanInterval | i18n }}
+            </span>
+            <span>
+              {{ secretsManagerSeatTotal(selectedPlan, sub?.smSeats) | currency: "$" }}
+            </span>
+          </p>
+          <p
+            class="tw-mb-0 tw-flex tw-justify-between"
+            bitTypography="body2"
+            *ngIf="
+              selectedPlan.SecretsManager.hasAdditionalServiceAccountOption &&
+              additionalServiceAccount > 0
+            "
+          >
+            <span>
+              {{ additionalServiceAccount }}
+              {{ "serviceAccounts" | i18n }}
+              &times;
+              {{ selectedPlan.SecretsManager.additionalPricePerServiceAccount | currency: "$" }}
+              /{{ selectedPlanInterval | i18n }}
+            </span>
+            <span>{{ additionalServiceAccountTotal(selectedPlan) | currency: "$" }}</span>
+          </p>
+          <!-- password manager summary for monthly -->
+          <p class="tw-font-medium tw-mt-3 tw-mb-0" *ngIf="organization.useSecretsManager">
+            {{ "passwordManager" | i18n }}
+          </p>
+          <p
+            class="tw-mb-0 tw-flex tw-justify-between"
+            bitTypography="body2"
+            *ngIf="selectedPlan.PasswordManager.basePrice"
+          >
+            <span>
+              {{ "basePrice" | i18n }}:
+              {{ selectedPlan.PasswordManager.basePrice | currency: "$" }}
+              {{ "monthAbbr" | i18n }}
+            </span>
+            <span>
+              {{ selectedPlan.PasswordManager.basePrice | currency: "$" }}
+            </span>
+          </p>
+          <p
+            class="tw-mb-0 tw-flex tw-justify-between"
+            bitTypography="body2"
+            *ngIf="selectedPlan.PasswordManager.hasAdditionalSeatsOption"
+          >
+            <span>
+              <span *ngIf="selectedPlan.PasswordManager.baseSeats"
+                >{{ "additionalUsers" | i18n }}:</span
+              >
+              {{ sub?.seats }}&nbsp;
+              <span *ngIf="!selectedPlan.PasswordManager.baseSeats">{{ "members" | i18n }}</span>
+              &times;
+              {{ selectedPlan.PasswordManager.seatPrice | currency: "$" }}
+              /{{ selectedPlanInterval | i18n }}
+            </span>
+            <span *ngIf="isSecretsManagerTrial()">
+              {{ "freeForOneYear" | i18n }}
+            </span>
+
+            <span *ngIf="!isSecretsManagerTrial()">
+              {{ passwordManagerSeatTotal(selectedPlan) | currency: "$" }}
+            </span>
+          </p>
+        </bit-hint>
+      </div>
+      <!-- discountPercentage to PM Only -->
+      <div
+        *ngIf="totalOpened && !organization.useSecretsManager"
+        class="tw-flex tw-flex-wrap tw-gap-4"
+      >
+        <bit-hint class="tw-w-1/2">
+          <p
+            class="tw-mb-0 tw-flex tw-justify-between"
+            bitTypography="body2"
+            *ngIf="discountPercentageFromSub > 0"
+          >
+            <ng-container>
+              <span class="tw-text-xs">
+                {{ "providerDiscount" | i18n: this.discountPercentageFromSub | lowercase }}
+              </span>
+              <span class="tw-line-through tw-text-xs">{{
+                calculateTotalAppliedDiscount(total) | currency: "$"
+              }}</span>
+            </ng-container>
+          </p>
+        </bit-hint>
+      </div>
+      <div *ngIf="totalOpened" class="tw-flex tw-flex-wrap tw-gap-4 tw-mt-4">
+        <bit-hint class="tw-w-1/2">
+          <p
+            class="tw-flex tw-justify-between tw-border-0 tw-border-solid tw-border-t tw-border-secondary-300 tw-pt-2 tw-mb-0"
+          >
+            <span class="tw-font-medium">
+              {{ "estimatedTax" | i18n }}
+            </span>
+            <span>
+              {{ estimatedTax | currency: "USD" : "$" }}
+            </span>
+          </p>
+        </bit-hint>
+      </div>
+      <div *ngIf="totalOpened" class="tw-flex tw-flex-wrap tw-gap-4 tw-mt-4">
+        <bit-hint class="tw-w-1/2">
+          <p
+            class="tw-flex tw-justify-between tw-border-0 tw-border-solid tw-border-t tw-border-secondary-300 tw-pt-2 tw-mb-0"
+          >
+            <span class="tw-font-medium">
+              {{ "total" | i18n }}
+            </span>
+            <span>
+              {{ total - calculateTotalAppliedDiscount(total) | currency: "USD" : "$" }}
+              <span class="tw-text-xs tw-font-medium"> / {{ selectedPlanInterval | i18n }}</span>
+            </span>
+          </p>
+        </bit-hint>
+      </div>
+    </ng-container>
+  </div>
+  <ng-container bitDialogFooter>
+    <button bitButton bitFormButton buttonType="primary" type="submit">
+      {{ submitButtonLabel }}
+    </button>
+    <button bitButton buttonType="secondary" type="button" [bitDialogClose]="ResultType.Closed">
+      {{ "cancel" | i18n }}
+    </button>
+  </ng-container>
 </form>

--- a/apps/web/src/app/billing/organizations/download-license.component.html
+++ b/apps/web/src/app/billing/organizations/download-license.component.html
@@ -1,35 +1,33 @@
-<form [formGroup]="licenseForm" [bitSubmit]="submit">
-  <bit-dialog>
-    <span bitDialogTitle>{{ "downloadLicense" | i18n }}</span>
-    <ng-container bitDialogContent>
-      <div class="tw-grid tw-grid-cols-12 tw-gap-4">
-        <div class="tw-col-span-8">
-          <bit-form-field>
-            <bit-label
-              >{{ "enterInstallationId" | i18n }}
-              <a
-                bitLink
-                class="tw-ml-auto"
-                target="_blank"
-                rel="noreferrer"
-                appA11yTitle="{{ 'learnMore' | i18n }}"
-                href="https://bitwarden.com/help/licensing-on-premise/#organization-account-sharing"
-                slot="end"
-                startIcon="bwi-question-circle"
-              ></a>
-            </bit-label>
-            <input type="text" bitInput formControlName="installationId" />
-          </bit-form-field>
-        </div>
+<form [formGroup]="licenseForm" [bitSubmit]="submit" bit-dialog>
+  <span bitDialogTitle>{{ "downloadLicense" | i18n }}</span>
+  <ng-container bitDialogContent>
+    <div class="tw-grid tw-grid-cols-12 tw-gap-4">
+      <div class="tw-col-span-8">
+        <bit-form-field>
+          <bit-label
+            >{{ "enterInstallationId" | i18n }}
+            <a
+              bitLink
+              class="tw-ml-auto"
+              target="_blank"
+              rel="noreferrer"
+              appA11yTitle="{{ 'learnMore' | i18n }}"
+              href="https://bitwarden.com/help/licensing-on-premise/#organization-account-sharing"
+              slot="end"
+              startIcon="bwi-question-circle"
+            ></a>
+          </bit-label>
+          <input type="text" bitInput formControlName="installationId" />
+        </bit-form-field>
       </div>
-    </ng-container>
-    <ng-container bitDialogFooter>
-      <button bitButton bitFormButton buttonType="primary" type="submit">
-        {{ "submit" | i18n }}
-      </button>
-      <button bitButton [bitAction]="cancel" bitFormButton buttonType="secondary" type="button">
-        {{ "cancel" | i18n }}
-      </button>
-    </ng-container>
-  </bit-dialog>
+    </div>
+  </ng-container>
+  <ng-container bitDialogFooter>
+    <button bitButton bitFormButton buttonType="primary" type="submit">
+      {{ "submit" | i18n }}
+    </button>
+    <button bitButton [bitAction]="cancel" bitFormButton buttonType="secondary" type="button">
+      {{ "cancel" | i18n }}
+    </button>
+  </ng-container>
 </form>

--- a/apps/web/src/app/billing/payment/components/add-account-credit-dialog.component.ts
+++ b/apps/web/src/app/billing/payment/components/add-account-credit-dialog.component.ts
@@ -56,52 +56,50 @@ const positiveNumberValidator =
 // eslint-disable-next-line @angular-eslint/prefer-on-push-component-change-detection
 @Component({
   template: `
-    <form [formGroup]="formGroup" [bitSubmit]="submit">
-      <bit-dialog>
-        <span bitDialogTitle class="tw-font-medium">
-          {{ "addCredit" | i18n }}
-        </span>
-        <div bitDialogContent>
-          <p bitTypography="body1">{{ "creditDelayed" | i18n }}</p>
-          <div class="tw-grid tw-grid-cols-2">
-            <bit-radio-group [formControl]="formGroup.controls.paymentMethod">
-              <bit-radio-button id="credit-method-paypal" [value]="'payPal'">
-                <bit-label> <i class="bwi bwi-paypal"></i>PayPal</bit-label>
-              </bit-radio-button>
-              <bit-radio-button id="credit-method-bitcoin" [value]="'bitPay'">
-                <bit-label> <i class="bwi bwi-bitcoin"></i>Bitcoin</bit-label>
-              </bit-radio-button>
-            </bit-radio-group>
-          </div>
-          <div class="tw-grid tw-grid-cols-2">
-            <bit-form-field>
-              <bit-label>{{ "amount" | i18n }}</bit-label>
-              <input
-                bitInput
-                [formControl]="formGroup.controls.amount"
-                type="text"
-                (blur)="formatAmount()"
-                required
-              />
-              <span bitPrefix>$USD</span>
-            </bit-form-field>
-          </div>
+    <form [formGroup]="formGroup" [bitSubmit]="submit" bit-dialog>
+      <span bitDialogTitle class="tw-font-medium">
+        {{ "addCredit" | i18n }}
+      </span>
+      <div bitDialogContent>
+        <p bitTypography="body1">{{ "creditDelayed" | i18n }}</p>
+        <div class="tw-grid tw-grid-cols-2">
+          <bit-radio-group [formControl]="formGroup.controls.paymentMethod">
+            <bit-radio-button id="credit-method-paypal" [value]="'payPal'">
+              <bit-label> <i class="bwi bwi-paypal"></i>PayPal</bit-label>
+            </bit-radio-button>
+            <bit-radio-button id="credit-method-bitcoin" [value]="'bitPay'">
+              <bit-label> <i class="bwi bwi-bitcoin"></i>Bitcoin</bit-label>
+            </bit-radio-button>
+          </bit-radio-group>
         </div>
-        <ng-container bitDialogFooter>
-          <button type="submit" bitButton bitFormButton buttonType="primary">
-            {{ "submit" | i18n }}
-          </button>
-          <button
-            type="button"
-            bitButton
-            bitFormButton
-            buttonType="secondary"
-            [bitDialogClose]="'cancelled'"
-          >
-            {{ "cancel" | i18n }}
-          </button>
-        </ng-container>
-      </bit-dialog>
+        <div class="tw-grid tw-grid-cols-2">
+          <bit-form-field>
+            <bit-label>{{ "amount" | i18n }}</bit-label>
+            <input
+              bitInput
+              [formControl]="formGroup.controls.amount"
+              type="text"
+              (blur)="formatAmount()"
+              required
+            />
+            <span bitPrefix>$USD</span>
+          </bit-form-field>
+        </div>
+      </div>
+      <ng-container bitDialogFooter>
+        <button type="submit" bitButton bitFormButton buttonType="primary">
+          {{ "submit" | i18n }}
+        </button>
+        <button
+          type="button"
+          bitButton
+          bitFormButton
+          buttonType="secondary"
+          [bitDialogClose]="'cancelled'"
+        >
+          {{ "cancel" | i18n }}
+        </button>
+      </ng-container>
     </form>
     <form #payPalForm action="{{ payPalConfig.buttonAction }}" method="post" target="_top">
       <input type="hidden" name="cmd" value="_xclick" />

--- a/apps/web/src/app/billing/payment/components/change-payment-method-dialog.component.ts
+++ b/apps/web/src/app/billing/payment/components/change-payment-method-dialog.component.ts
@@ -22,33 +22,31 @@ type DialogParams = {
 // eslint-disable-next-line @angular-eslint/prefer-on-push-component-change-detection
 @Component({
   template: `
-    <form [formGroup]="formGroup" [bitSubmit]="submit">
-      <bit-dialog>
-        <span bitDialogTitle class="tw-font-medium">
-          {{ "changePaymentMethod" | i18n }}
-        </span>
-        <div bitDialogContent>
-          <app-enter-payment-method
-            [group]="formGroup"
-            [showBankAccount]="dialogParams.subscriber.type !== 'account'"
-            [includeBillingAddress]="true"
-          >
-          </app-enter-payment-method>
-        </div>
-        <ng-container bitDialogFooter>
-          <button bitButton bitFormButton buttonType="primary" type="submit">
-            {{ "save" | i18n }}
-          </button>
-          <button
-            bitButton
-            buttonType="secondary"
-            type="button"
-            [bitDialogClose]="{ type: 'cancelled' }"
-          >
-            {{ "cancel" | i18n }}
-          </button>
-        </ng-container>
-      </bit-dialog>
+    <form [formGroup]="formGroup" [bitSubmit]="submit" bit-dialog>
+      <span bitDialogTitle class="tw-font-medium">
+        {{ "changePaymentMethod" | i18n }}
+      </span>
+      <div bitDialogContent>
+        <app-enter-payment-method
+          [group]="formGroup"
+          [showBankAccount]="dialogParams.subscriber.type !== 'account'"
+          [includeBillingAddress]="true"
+        >
+        </app-enter-payment-method>
+      </div>
+      <ng-container bitDialogFooter>
+        <button bitButton bitFormButton buttonType="primary" type="submit">
+          {{ "save" | i18n }}
+        </button>
+        <button
+          bitButton
+          buttonType="secondary"
+          type="button"
+          [bitDialogClose]="{ type: 'cancelled' }"
+        >
+          {{ "cancel" | i18n }}
+        </button>
+      </ng-container>
     </form>
   `,
   standalone: true,

--- a/apps/web/src/app/billing/payment/components/edit-billing-address-dialog.component.ts
+++ b/apps/web/src/app/billing/payment/components/edit-billing-address-dialog.component.ts
@@ -39,42 +39,40 @@ type DialogResult =
 // eslint-disable-next-line @angular-eslint/prefer-on-push-component-change-detection
 @Component({
   template: `
-    <form [formGroup]="formGroup" [bitSubmit]="submit">
-      <bit-dialog>
-        <span bitDialogTitle class="tw-font-medium">
-          {{ "editBillingAddress" | i18n }}
-        </span>
-        <div bitDialogContent>
-          @let callout = taxIdWarningCallout;
-          @if (callout) {
-            <bit-callout [type]="callout.type" [title]="callout.title">
-              {{ callout.message }}
-            </bit-callout>
-          }
-          <app-enter-billing-address
-            [scenario]="{
-              type: 'update',
-              existing: dialogParams.billingAddress,
-              supportsTaxId,
-              taxIdWarning: dialogParams.taxIdWarning,
-            }"
-            [group]="formGroup"
-          ></app-enter-billing-address>
-        </div>
-        <ng-container bitDialogFooter>
-          <button bitButton bitFormButton buttonType="primary" type="submit">
-            {{ "save" | i18n }}
-          </button>
-          <button
-            bitButton
-            buttonType="secondary"
-            type="button"
-            [bitDialogClose]="{ type: 'cancelled' }"
-          >
-            {{ "cancel" | i18n }}
-          </button>
-        </ng-container>
-      </bit-dialog>
+    <form [formGroup]="formGroup" [bitSubmit]="submit" bit-dialog>
+      <span bitDialogTitle class="tw-font-medium">
+        {{ "editBillingAddress" | i18n }}
+      </span>
+      <div bitDialogContent>
+        @let callout = taxIdWarningCallout;
+        @if (callout) {
+          <bit-callout [type]="callout.type" [title]="callout.title">
+            {{ callout.message }}
+          </bit-callout>
+        }
+        <app-enter-billing-address
+          [scenario]="{
+            type: 'update',
+            existing: dialogParams.billingAddress,
+            supportsTaxId,
+            taxIdWarning: dialogParams.taxIdWarning,
+          }"
+          [group]="formGroup"
+        ></app-enter-billing-address>
+      </div>
+      <ng-container bitDialogFooter>
+        <button bitButton bitFormButton buttonType="primary" type="submit">
+          {{ "save" | i18n }}
+        </button>
+        <button
+          bitButton
+          buttonType="secondary"
+          type="button"
+          [bitDialogClose]="{ type: 'cancelled' }"
+        >
+          {{ "cancel" | i18n }}
+        </button>
+      </ng-container>
     </form>
   `,
   standalone: true,

--- a/apps/web/src/app/billing/payment/components/require-payment-method-dialog.component.ts
+++ b/apps/web/src/app/billing/payment/components/require-payment-method-dialog.component.ts
@@ -33,24 +33,22 @@ type DialogParams = {
 // eslint-disable-next-line @angular-eslint/prefer-on-push-component-change-detection
 @Component({
   template: `
-    <form [formGroup]="formGroup" [bitSubmit]="submit">
-      <bit-dialog>
-        <span bitDialogTitle class="tw-font-medium">
-          {{ "addPaymentMethod" | i18n }}
-        </span>
-        <div bitDialogContent>
-          <bit-callout [type]="dialogParams.callout.type" [title]="dialogParams.callout.title">
-            {{ dialogParams.callout.message }}
-          </bit-callout>
-          <app-enter-payment-method [group]="formGroup" [includeBillingAddress]="true">
-          </app-enter-payment-method>
-        </div>
-        <ng-container bitDialogFooter>
-          <button bitButton bitFormButton buttonType="primary" type="submit">
-            {{ "save" | i18n }}
-          </button>
-        </ng-container>
-      </bit-dialog>
+    <form [formGroup]="formGroup" [bitSubmit]="submit" bit-dialog>
+      <span bitDialogTitle class="tw-font-medium">
+        {{ "addPaymentMethod" | i18n }}
+      </span>
+      <div bitDialogContent>
+        <bit-callout [type]="dialogParams.callout.type" [title]="dialogParams.callout.title">
+          {{ dialogParams.callout.message }}
+        </bit-callout>
+        <app-enter-payment-method [group]="formGroup" [includeBillingAddress]="true">
+        </app-enter-payment-method>
+      </div>
+      <ng-container bitDialogFooter>
+        <button bitButton bitFormButton buttonType="primary" type="submit">
+          {{ "save" | i18n }}
+        </button>
+      </ng-container>
     </form>
   `,
   standalone: true,

--- a/apps/web/src/app/billing/shared/adjust-storage-dialog/adjust-storage-dialog.component.html
+++ b/apps/web/src/app/billing/shared/adjust-storage-dialog/adjust-storage-dialog.component.html
@@ -1,34 +1,32 @@
-<form [formGroup]="formGroup" [bitSubmit]="submit">
-  <bit-dialog [title]="title">
-    <ng-container bitDialogContent>
-      <p bitTypography="body1">{{ body }}</p>
-      <div class="tw-grid tw-grid-cols-12">
-        <bit-form-field class="tw-col-span-7">
-          <bit-label>{{ storageFieldLabel }}</bit-label>
-          <input bitInput type="number" formControlName="storage" />
-          <bit-hint *ngIf="dialogParams.type === 'Add'">
-            <!-- Total: 10 GB × $0.50 = $5.00 /month -->
-            <strong>{{ "total" | i18n }}</strong>
-            {{ this.formGroup.value.storage }} GB &times; {{ this.price | currency: "$" }} =
-            {{ this.price * this.formGroup.value.storage | currency: "$" }} /
-            {{ this.cadence | i18n }}
-          </bit-hint>
-        </bit-form-field>
-      </div>
-    </ng-container>
-    <ng-container bitDialogFooter>
-      <button type="submit" bitButton bitFormButton buttonType="primary">
-        {{ "submit" | i18n }}
-      </button>
-      <button
-        type="button"
-        bitButton
-        bitFormButton
-        buttonType="secondary"
-        [bitDialogClose]="ResultType.Closed"
-      >
-        {{ "cancel" | i18n }}
-      </button>
-    </ng-container>
-  </bit-dialog>
+<form [formGroup]="formGroup" [bitSubmit]="submit" bit-dialog [title]="title">
+  <ng-container bitDialogContent>
+    <p bitTypography="body1">{{ body }}</p>
+    <div class="tw-grid tw-grid-cols-12">
+      <bit-form-field class="tw-col-span-7">
+        <bit-label>{{ storageFieldLabel }}</bit-label>
+        <input bitInput type="number" formControlName="storage" />
+        <bit-hint *ngIf="dialogParams.type === 'Add'">
+          <!-- Total: 10 GB × $0.50 = $5.00 /month -->
+          <strong>{{ "total" | i18n }}</strong>
+          {{ this.formGroup.value.storage }} GB &times; {{ this.price | currency: "$" }} =
+          {{ this.price * this.formGroup.value.storage | currency: "$" }} /
+          {{ this.cadence | i18n }}
+        </bit-hint>
+      </bit-form-field>
+    </div>
+  </ng-container>
+  <ng-container bitDialogFooter>
+    <button type="submit" bitButton bitFormButton buttonType="primary">
+      {{ "submit" | i18n }}
+    </button>
+    <button
+      type="button"
+      bitButton
+      bitFormButton
+      buttonType="secondary"
+      [bitDialogClose]="ResultType.Closed"
+    >
+      {{ "cancel" | i18n }}
+    </button>
+  </ng-container>
 </form>

--- a/apps/web/src/app/billing/shared/offboarding-survey.component.html
+++ b/apps/web/src/app/billing/shared/offboarding-survey.component.html
@@ -1,54 +1,52 @@
-<form [formGroup]="formGroup" [bitSubmit]="submit">
-  <bit-dialog>
-    <span bitDialogTitle class="tw-font-medium">
-      {{ "cancelSubscription" | i18n }}
-    </span>
-    <div bitDialogContent>
-      <p>{{ "sorryToSeeYouGo" | i18n }}</p>
-      @if (isBusiness) {
-        <bit-radio-group formControlName="reason" [block]="true">
-          <bit-label>
-            {{ "selectCancellationReason" | i18n }}
-          </bit-label>
-          @for (reason of businessReasons; track reason.value) {
-            <bit-radio-button [value]="reason.value">
-              <bit-label>{{ reason.labelKey | i18n }}</bit-label>
-              @if (reason.hintKey) {
-                <bit-hint>{{ reason.hintKey | i18n }}</bit-hint>
-              }
-            </bit-radio-button>
-          }
-        </bit-radio-group>
-      } @else {
-        <bit-form-field>
-          <bit-label>
-            {{ "selectCancellationReason" | i18n }}
-          </bit-label>
-          <select bitInput formControlName="reason">
-            <option *ngFor="let reason of reasons" [ngValue]="reason.value">
-              {{ reason.text }}
-            </option>
-          </select>
-        </bit-form-field>
-      }
+<form [formGroup]="formGroup" [bitSubmit]="submit" bit-dialog>
+  <span bitDialogTitle class="tw-font-medium">
+    {{ "cancelSubscription" | i18n }}
+  </span>
+  <div bitDialogContent>
+    <p>{{ "sorryToSeeYouGo" | i18n }}</p>
+    @if (isBusiness) {
+      <bit-radio-group formControlName="reason" [block]="true">
+        <bit-label>
+          {{ "selectCancellationReason" | i18n }}
+        </bit-label>
+        @for (reason of businessReasons; track reason.value) {
+          <bit-radio-button [value]="reason.value">
+            <bit-label>{{ reason.labelKey | i18n }}</bit-label>
+            @if (reason.hintKey) {
+              <bit-hint>{{ reason.hintKey | i18n }}</bit-hint>
+            }
+          </bit-radio-button>
+        }
+      </bit-radio-group>
+    } @else {
       <bit-form-field>
         <bit-label>
-          {{ "anyOtherFeedback" | i18n }}
+          {{ "selectCancellationReason" | i18n }}
         </bit-label>
-        <textarea rows="4" bitInput formControlName="feedback"></textarea>
-        <bit-hint>{{
-          "charactersCurrentAndMaximum"
-            | i18n: formGroup.value.feedback?.length ?? 0 : MaxFeedbackLength
-        }}</bit-hint>
+        <select bitInput formControlName="reason">
+          <option *ngFor="let reason of reasons" [ngValue]="reason.value">
+            {{ reason.text }}
+          </option>
+        </select>
       </bit-form-field>
-    </div>
-    <ng-container bitDialogFooter>
-      <button bitButton bitFormButton buttonType="primary" type="submit">
-        {{ "cancelSubscription" | i18n }}
-      </button>
-      <button bitButton buttonType="secondary" type="button" [bitDialogClose]="ResultType.Closed">
-        {{ "close" | i18n }}
-      </button>
-    </ng-container>
-  </bit-dialog>
+    }
+    <bit-form-field>
+      <bit-label>
+        {{ "anyOtherFeedback" | i18n }}
+      </bit-label>
+      <textarea rows="4" bitInput formControlName="feedback"></textarea>
+      <bit-hint>{{
+        "charactersCurrentAndMaximum"
+          | i18n: formGroup.value.feedback?.length ?? 0 : MaxFeedbackLength
+      }}</bit-hint>
+    </bit-form-field>
+  </div>
+  <ng-container bitDialogFooter>
+    <button bitButton bitFormButton buttonType="primary" type="submit">
+      {{ "cancelSubscription" | i18n }}
+    </button>
+    <button bitButton buttonType="secondary" type="button" [bitDialogClose]="ResultType.Closed">
+      {{ "close" | i18n }}
+    </button>
+  </ng-container>
 </form>

--- a/apps/web/src/app/billing/shared/update-license-dialog.component.html
+++ b/apps/web/src/app/billing/shared/update-license-dialog.component.html
@@ -1,55 +1,55 @@
-<form [formGroup]="updateLicenseForm" [bitSubmit]="submitLicenseDialog">
-  <bit-dialog
-    dialogSize="default"
-    [title]="(fromUserSubscriptionPage ? 'uploadLicense' : 'uploadLicenseFile') | i18n"
-  >
-    <ng-container bitDialogContent>
-      <p class="tw-mb-4">{{ "uploadLicenseFileDesc" | i18n: "bitwarden_license.json" }}</p>
-      <div class="tw-mb-4">
-        <label class="tw-block tw-text-sm tw-text-muted tw-mb-2">{{
-          (fromUserSubscriptionPage ? "uploadYourPremiumLicenseFile" : "uploadYourLicenseFile")
-            | i18n
-        }}</label>
-        <div class="tw-mb-2">
-          <button
-            bitButton
-            type="button"
-            buttonType="unstyled"
-            class="tw-text-primary-600 tw-p-0 tw-border-0 tw-bg-transparent hover:tw-underline tw-cursor-pointer"
-            (click)="fileSelector.click()"
-          >
-            {{ "chooseFile" | i18n }}
-          </button>
-          <span class="tw-ml-2 tw-text-muted">{{
-            licenseFile ? licenseFile.name : ("noFileChosen" | i18n)
-          }}</span>
-        </div>
-        <input
-          #fileSelector
-          type="file"
-          formControlName="file"
-          (change)="setSelectedFile($event)"
-          hidden
-          class="tw-hidden"
-        />
-        <p class="tw-text-sm tw-text-muted">{{ "maxFileSizeSansPunctuation" | i18n }}</p>
+<form
+  [formGroup]="updateLicenseForm"
+  [bitSubmit]="submitLicenseDialog"
+  bit-dialog
+  dialogSize="default"
+  [title]="(fromUserSubscriptionPage ? 'uploadLicense' : 'uploadLicenseFile') | i18n"
+>
+  <ng-container bitDialogContent>
+    <p class="tw-mb-4">{{ "uploadLicenseFileDesc" | i18n: "bitwarden_license.json" }}</p>
+    <div class="tw-mb-4">
+      <label class="tw-block tw-text-sm tw-text-muted tw-mb-2">{{
+        (fromUserSubscriptionPage ? "uploadYourPremiumLicenseFile" : "uploadYourLicenseFile") | i18n
+      }}</label>
+      <div class="tw-mb-2">
+        <button
+          bitButton
+          type="button"
+          buttonType="unstyled"
+          class="tw-text-primary-600 tw-p-0 tw-border-0 tw-bg-transparent hover:tw-underline tw-cursor-pointer"
+          (click)="fileSelector.click()"
+        >
+          {{ "chooseFile" | i18n }}
+        </button>
+        <span class="tw-ml-2 tw-text-muted">{{
+          licenseFile ? licenseFile.name : ("noFileChosen" | i18n)
+        }}</span>
       </div>
-    </ng-container>
-    <ng-container bitDialogFooter>
-      <button type="submit" buttonType="primary" bitButton bitFormButton [disabled]="!licenseFile">
-        {{ "upload" | i18n }}
-      </button>
-      <button
-        bitButton
-        *ngIf="showCancel"
-        bitFormButton
-        buttonType="secondary"
-        type="button"
-        bitDialogClose
-        [bitAction]="cancel"
-      >
-        {{ "cancel" | i18n }}
-      </button>
-    </ng-container>
-  </bit-dialog>
+      <input
+        #fileSelector
+        type="file"
+        formControlName="file"
+        (change)="setSelectedFile($event)"
+        hidden
+        class="tw-hidden"
+      />
+      <p class="tw-text-sm tw-text-muted">{{ "maxFileSizeSansPunctuation" | i18n }}</p>
+    </div>
+  </ng-container>
+  <ng-container bitDialogFooter>
+    <button type="submit" buttonType="primary" bitButton bitFormButton [disabled]="!licenseFile">
+      {{ "upload" | i18n }}
+    </button>
+    <button
+      bitButton
+      *ngIf="showCancel"
+      bitFormButton
+      buttonType="secondary"
+      type="button"
+      bitDialogClose
+      [bitAction]="cancel"
+    >
+      {{ "cancel" | i18n }}
+    </button>
+  </ng-container>
 </form>

--- a/apps/web/src/app/key-management/change-kdf/change-kdf-confirmation.component.html
+++ b/apps/web/src/app/key-management/change-kdf/change-kdf-confirmation.component.html
@@ -1,35 +1,33 @@
-<form [formGroup]="form" [bitSubmit]="submit" autocomplete="off">
-  <bit-dialog>
-    <span bitDialogTitle>
-      {{ "updateYourEncryptionSettings" | i18n }}
-    </span>
+<form [formGroup]="form" [bitSubmit]="submit" autocomplete="off" bit-dialog>
+  <span bitDialogTitle>
+    {{ "updateYourEncryptionSettings" | i18n }}
+  </span>
 
-    <span bitDialogContent>
-      @if (!(noLogoutOnKdfChangeFeatureFlag$ | async)) {
-        <bit-callout type="warning">{{ "kdfSettingsChangeLogoutWarning" | i18n }}</bit-callout>
-      }
-      <bit-form-field disableMargin>
-        <bit-label>{{ "masterPass" | i18n }}</bit-label>
-        <input bitInput type="password" formControlName="masterPassword" appAutofocus />
-        <button
-          type="button"
-          bitIconButton
-          bitSuffix
-          bitPasswordInputToggle
-          [(toggled)]="showPassword"
-        ></button>
-        <bit-hint>
-          {{ "confirmIdentity" | i18n }}
-        </bit-hint>
-      </bit-form-field>
-    </span>
-    <ng-container bitDialogFooter>
-      <button bitButton buttonType="primary" type="submit" bitFormButton>
-        <span>{{ "updateSettings" | i18n }}</span>
-      </button>
-      <button bitButton buttonType="secondary" type="button" bitFormButton bitDialogClose>
-        {{ "cancel" | i18n }}
-      </button>
-    </ng-container>
-  </bit-dialog>
+  <span bitDialogContent>
+    @if (!(noLogoutOnKdfChangeFeatureFlag$ | async)) {
+      <bit-callout type="warning">{{ "kdfSettingsChangeLogoutWarning" | i18n }}</bit-callout>
+    }
+    <bit-form-field disableMargin>
+      <bit-label>{{ "masterPass" | i18n }}</bit-label>
+      <input bitInput type="password" formControlName="masterPassword" appAutofocus />
+      <button
+        type="button"
+        bitIconButton
+        bitSuffix
+        bitPasswordInputToggle
+        [(toggled)]="showPassword"
+      ></button>
+      <bit-hint>
+        {{ "confirmIdentity" | i18n }}
+      </bit-hint>
+    </bit-form-field>
+  </span>
+  <ng-container bitDialogFooter>
+    <button bitButton buttonType="primary" type="submit" bitFormButton>
+      <span>{{ "updateSettings" | i18n }}</span>
+    </button>
+    <button bitButton buttonType="secondary" type="button" bitFormButton bitDialogClose>
+      {{ "cancel" | i18n }}
+    </button>
+  </ng-container>
 </form>

--- a/apps/web/src/app/vault/individual-vault/bulk-action-dialogs/bulk-move-dialog/bulk-move-dialog.component.html
+++ b/apps/web/src/app/vault/individual-vault/bulk-action-dialogs/bulk-move-dialog/bulk-move-dialog.component.html
@@ -1,26 +1,24 @@
-<form [formGroup]="formGroup" [bitSubmit]="submit">
-  <bit-dialog dialogSize="small">
-    <span bitDialogTitle>
-      {{ "addToFolder" | i18n }}
-    </span>
-    <span bitDialogContent>
-      <p>{{ "moveSelectedItemsDesc" | i18n: cipherIds.length }}</p>
-      <bit-form-field>
-        <bit-label for="folder">{{ "selectFolder" | i18n }}</bit-label>
-        <bit-select formControlName="folderId">
-          @for (f of folders$ | async; track f.id) {
-            <bit-option [value]="f.id" [label]="f.name"> </bit-option>
-          }
-        </bit-select>
-      </bit-form-field>
-    </span>
-    <ng-container bitDialogFooter>
-      <button bitButton bitFormButton type="submit" buttonType="primary">
-        {{ "save" | i18n }}
-      </button>
-      <button bitButton bitFormButton type="button" buttonType="secondary" (click)="cancel()">
-        {{ "cancel" | i18n }}
-      </button>
-    </ng-container>
-  </bit-dialog>
+<form [formGroup]="formGroup" [bitSubmit]="submit" bit-dialog dialogSize="small">
+  <span bitDialogTitle>
+    {{ "addToFolder" | i18n }}
+  </span>
+  <span bitDialogContent>
+    <p>{{ "moveSelectedItemsDesc" | i18n: cipherIds.length }}</p>
+    <bit-form-field>
+      <bit-label for="folder">{{ "selectFolder" | i18n }}</bit-label>
+      <bit-select formControlName="folderId">
+        @for (f of folders$ | async; track f.id) {
+          <bit-option [value]="f.id" [label]="f.name"> </bit-option>
+        }
+      </bit-select>
+    </bit-form-field>
+  </span>
+  <ng-container bitDialogFooter>
+    <button bitButton bitFormButton type="submit" buttonType="primary">
+      {{ "save" | i18n }}
+    </button>
+    <button bitButton bitFormButton type="button" buttonType="secondary" (click)="cancel()">
+      {{ "cancel" | i18n }}
+    </button>
+  </ng-container>
 </form>

--- a/apps/web/src/app/vault/settings/purge-vault.component.html
+++ b/apps/web/src/app/vault/settings/purge-vault.component.html
@@ -1,19 +1,23 @@
-<form [formGroup]="formGroup" [bitSubmit]="submit">
-  <bit-dialog dialogSize="default" [title]="'purgeVault' | i18n">
-    <ng-container bitDialogContent>
-      <p bitTypography="body1">
-        {{ (organizationId ? "purgeOrgVaultDesc" : "purgeVaultDesc") | i18n }}
-      </p>
-      <bit-callout type="warning">{{ "purgeVaultWarning" | i18n }}</bit-callout>
-      <app-user-verification formControlName="masterPassword"></app-user-verification>
-    </ng-container>
-    <ng-container bitDialogFooter>
-      <button bitButton bitFormButton type="submit" buttonType="danger">
-        {{ "purgeVault" | i18n }}
-      </button>
-      <button bitButton bitFormButton type="button" buttonType="secondary" bitDialogClose>
-        {{ "close" | i18n }}
-      </button>
-    </ng-container>
-  </bit-dialog>
+<form
+  [formGroup]="formGroup"
+  [bitSubmit]="submit"
+  bit-dialog
+  dialogSize="default"
+  [title]="'purgeVault' | i18n"
+>
+  <ng-container bitDialogContent>
+    <p bitTypography="body1">
+      {{ (organizationId ? "purgeOrgVaultDesc" : "purgeVaultDesc") | i18n }}
+    </p>
+    <bit-callout type="warning">{{ "purgeVaultWarning" | i18n }}</bit-callout>
+    <app-user-verification formControlName="masterPassword"></app-user-verification>
+  </ng-container>
+  <ng-container bitDialogFooter>
+    <button bitButton bitFormButton type="submit" buttonType="danger">
+      {{ "purgeVault" | i18n }}
+    </button>
+    <button bitButton bitFormButton type="button" buttonType="secondary" bitDialogClose>
+      {{ "close" | i18n }}
+    </button>
+  </ng-container>
 </form>

--- a/bitwarden_license/bit-web/src/app/admin-console/organizations/manage/domain-verification/domain-add-edit-dialog/domain-add-edit-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/admin-console/organizations/manage/domain-verification/domain-add-edit-dialog/domain-add-edit-dialog.component.html
@@ -2,80 +2,80 @@
   [formGroup]="domainForm"
   [bitSubmit]="data.orgDomain ? verifyDomain : saveDomain"
   [allowDisabledFormSubmit]="true"
+  bit-dialog
+  [dialogSize]="'default'"
 >
-  <bit-dialog [dialogSize]="'default'">
-    <span bitDialogTitle>
-      <span *ngIf="!data.orgDomain">{{ "newDomain" | i18n }}</span>
-      <span *ngIf="data.orgDomain">
-        {{ "claimDomain" | i18n }}
-      </span>
-
-      <span *ngIf="data?.orgDomain && !data.orgDomain?.verifiedDate" bitBadge variant="warning">
-        {{ "domainStatusPending" | i18n }}
-      </span>
-      <span *ngIf="data?.orgDomain && data?.orgDomain?.verifiedDate" bitBadge variant="success">
-        {{ "domainStatusClaimed" | i18n }}
-      </span>
+  <span bitDialogTitle>
+    <span *ngIf="!data.orgDomain">{{ "newDomain" | i18n }}</span>
+    <span *ngIf="data.orgDomain">
+      {{ "claimDomain" | i18n }}
     </span>
-    <div bitDialogContent>
-      <div *ngIf="data?.orgDomain && !data?.orgDomain?.verifiedDate" class="tw-space-y-2 tw-pb-4">
-        <p bitTypography="body1">{{ "automaticDomainClaimProcess1" | i18n }}</p>
-        <p bitTypography="body1">
-          {{ "automaticDomainClaimProcess2" | i18n }}
-          <a
-            bitLink
-            target="_blank"
-            rel="noreferrer"
-            href="https://bitwarden.com/help/claimed-accounts/"
-            class="tw-inline-flex tw-items-center tw-gap-1"
-            endIcon="bwi-external-link"
-          >
-            {{ "accountOwnershipChange" | i18n }}
-          </a>
-          {{ "automaticDomainClaimProcessEnd" | i18n }}
-        </p>
-      </div>
-      <bit-form-field>
-        <bit-label>{{ "domainName" | i18n }}</bit-label>
-        <input bitInput appAutofocus formControlName="domainName" [showErrorsWhenDisabled]="true" />
-      </bit-form-field>
 
-      <bit-form-field *ngIf="data?.orgDomain">
-        <bit-label>{{ "dnsTxtRecord" | i18n }}</bit-label>
-        <input bitInput formControlName="txt" />
-        <bit-hint>{{ "dnsTxtRecordInputHint" | i18n }}</bit-hint>
-        <button
-          type="button"
-          bitSuffix
-          bitIconButton="bwi-clone"
-          label="{{ 'copyDnsTxtRecord' | i18n }}"
-          (click)="copyDnsTxt()"
-        ></button>
-      </bit-form-field>
+    <span *ngIf="data?.orgDomain && !data.orgDomain?.verifiedDate" bitBadge variant="warning">
+      {{ "domainStatusPending" | i18n }}
+    </span>
+    <span *ngIf="data?.orgDomain && data?.orgDomain?.verifiedDate" bitBadge variant="success">
+      {{ "domainStatusClaimed" | i18n }}
+    </span>
+  </span>
+  <div bitDialogContent>
+    <div *ngIf="data?.orgDomain && !data?.orgDomain?.verifiedDate" class="tw-space-y-2 tw-pb-4">
+      <p bitTypography="body1">{{ "automaticDomainClaimProcess1" | i18n }}</p>
+      <p bitTypography="body1">
+        {{ "automaticDomainClaimProcess2" | i18n }}
+        <a
+          bitLink
+          target="_blank"
+          rel="noreferrer"
+          href="https://bitwarden.com/help/claimed-accounts/"
+          class="tw-inline-flex tw-items-center tw-gap-1"
+          endIcon="bwi-external-link"
+        >
+          {{ "accountOwnershipChange" | i18n }}
+        </a>
+        {{ "automaticDomainClaimProcessEnd" | i18n }}
+      </p>
     </div>
-    <ng-container bitDialogFooter>
-      <button type="submit" bitButton bitFormButton buttonType="primary">
-        <span *ngIf="!data?.orgDomain">{{ "next" | i18n }}</span>
-        <span *ngIf="data?.orgDomain && !data?.orgDomain?.verifiedDate">{{
-          "claimDomain" | i18n
-        }}</span>
-        <span *ngIf="data?.orgDomain?.verifiedDate">{{ "reclaimDomain" | i18n }}</span>
-      </button>
-      <button bitButton buttonType="secondary" (click)="dialogRef.close()" type="button">
-        {{ "cancel" | i18n }}
-      </button>
+    <bit-form-field>
+      <bit-label>{{ "domainName" | i18n }}</bit-label>
+      <input bitInput appAutofocus formControlName="domainName" [showErrorsWhenDisabled]="true" />
+    </bit-form-field>
 
+    <bit-form-field *ngIf="data?.orgDomain">
+      <bit-label>{{ "dnsTxtRecord" | i18n }}</bit-label>
+      <input bitInput formControlName="txt" />
+      <bit-hint>{{ "dnsTxtRecordInputHint" | i18n }}</bit-hint>
       <button
-        *ngIf="data.orgDomain"
-        class="tw-ml-auto"
-        bitIconButton="bwi-trash"
-        buttonType="dangerGhost"
-        size="default"
-        label="{{ 'delete' | i18n }}"
-        [bitAction]="deleteDomain"
-        type="submit"
-        bitFormButton
+        type="button"
+        bitSuffix
+        bitIconButton="bwi-clone"
+        label="{{ 'copyDnsTxtRecord' | i18n }}"
+        (click)="copyDnsTxt()"
       ></button>
-    </ng-container>
-  </bit-dialog>
+    </bit-form-field>
+  </div>
+  <ng-container bitDialogFooter>
+    <button type="submit" bitButton bitFormButton buttonType="primary">
+      <span *ngIf="!data?.orgDomain">{{ "next" | i18n }}</span>
+      <span *ngIf="data?.orgDomain && !data?.orgDomain?.verifiedDate">{{
+        "claimDomain" | i18n
+      }}</span>
+      <span *ngIf="data?.orgDomain?.verifiedDate">{{ "reclaimDomain" | i18n }}</span>
+    </button>
+    <button bitButton buttonType="secondary" (click)="dialogRef.close()" type="button">
+      {{ "cancel" | i18n }}
+    </button>
+
+    <button
+      *ngIf="data.orgDomain"
+      class="tw-ml-auto"
+      bitIconButton="bwi-trash"
+      buttonType="dangerGhost"
+      size="default"
+      label="{{ 'delete' | i18n }}"
+      [bitAction]="deleteDomain"
+      type="submit"
+      bitFormButton
+    ></button>
+  </ng-container>
 </form>

--- a/bitwarden_license/bit-web/src/app/admin-console/organizations/manage/scim-api-key-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/admin-console/organizations/manage/scim-api-key-dialog.component.html
@@ -1,30 +1,23 @@
-<form [formGroup]="formGroup" [bitSubmit]="submit">
-  <bit-dialog>
-    <span bitDialogTitle>
-      {{ data.titleKey | i18n }}
-    </span>
-    <div bitDialogContent>
-      @if (isRotation) {
-        <bit-callout type="warning">
-          {{ "rotateScimKeyWarning" | i18n }}
-        </bit-callout>
-      }
+<form [formGroup]="formGroup" [bitSubmit]="submit" bit-dialog>
+  <span bitDialogTitle>
+    {{ data.titleKey | i18n }}
+  </span>
+  <div bitDialogContent>
+    @if (isRotation) {
+      <bit-callout type="warning">
+        {{ "rotateScimKeyWarning" | i18n }}
+      </bit-callout>
+    }
 
-      <app-user-verification-form-input formControlName="verification">
-      </app-user-verification-form-input>
-    </div>
-    <ng-container bitDialogFooter>
-      <button
-        type="submit"
-        bitButton
-        bitFormButton
-        [buttonType]="isRotation ? 'danger' : 'primary'"
-      >
-        {{ (isRotation ? "rotateKey" : "viewApiKey") | i18n }}
-      </button>
-      <button bitButton type="button" (click)="close()">
-        {{ "close" | i18n }}
-      </button>
-    </ng-container>
-  </bit-dialog>
+    <app-user-verification-form-input formControlName="verification">
+    </app-user-verification-form-input>
+  </div>
+  <ng-container bitDialogFooter>
+    <button type="submit" bitButton bitFormButton [buttonType]="isRotation ? 'danger' : 'primary'">
+      {{ (isRotation ? "rotateKey" : "viewApiKey") | i18n }}
+    </button>
+    <button bitButton type="button" (click)="close()">
+      {{ "close" | i18n }}
+    </button>
+  </ng-container>
 </form>

--- a/bitwarden_license/bit-web/src/app/admin-console/providers/clients/create-client-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/admin-console/providers/clients/create-client-dialog.component.html
@@ -1,97 +1,100 @@
-<form [formGroup]="formGroup" [bitSubmit]="submit">
-  <bit-dialog dialogSize="large" [loading]="loading">
-    <span bitDialogTitle class="tw-font-medium">
-      {{ "newClientOrganization" | i18n }}
-    </span>
-    <div bitDialogContent>
-      <p>{{ "createNewClientToManageAsProvider" | i18n }}</p>
-      <div class="tw-mb-3">
-        <span class="tw-text-lg tw-pr-1">{{ "selectAPlan" | i18n }}</span>
-        <span *ngIf="this.discountPercentage" bitBadge variant="success">{{
-          "providerDiscount" | i18n: this.discountPercentage
-        }}</span>
-      </div>
-      <ng-container>
-        <div class="tw-grid tw-grid-flow-col tw-auto-cols-[minmax(0,_2fr)] tw-gap-4 tw-mb-4">
-          <div
-            *ngFor="let planCard of planCards"
-            [ngClass]="planCard.getContainerClasses()"
-            (click)="selectPlan(planCard.name)"
-            tabindex="0"
-          >
-            <div class="tw-relative">
-              <div
-                *ngIf="planCard.selected"
-                class="tw-bg-primary-600 tw-text-center !tw-text-contrast tw-text-sm tw-font-medium tw-py-1 group-hover/plan-card-container:tw-bg-primary-700"
+<form
+  [formGroup]="formGroup"
+  [bitSubmit]="submit"
+  bit-dialog
+  dialogSize="large"
+  [loading]="loading"
+>
+  <span bitDialogTitle class="tw-font-medium">
+    {{ "newClientOrganization" | i18n }}
+  </span>
+  <div bitDialogContent>
+    <p>{{ "createNewClientToManageAsProvider" | i18n }}</p>
+    <div class="tw-mb-3">
+      <span class="tw-text-lg tw-pr-1">{{ "selectAPlan" | i18n }}</span>
+      <span *ngIf="this.discountPercentage" bitBadge variant="success">{{
+        "providerDiscount" | i18n: this.discountPercentage
+      }}</span>
+    </div>
+    <ng-container>
+      <div class="tw-grid tw-grid-flow-col tw-auto-cols-[minmax(0,_2fr)] tw-gap-4 tw-mb-4">
+        <div
+          *ngFor="let planCard of planCards"
+          [ngClass]="planCard.getContainerClasses()"
+          (click)="selectPlan(planCard.name)"
+          tabindex="0"
+        >
+          <div class="tw-relative">
+            <div
+              *ngIf="planCard.selected"
+              class="tw-bg-primary-600 tw-text-center !tw-text-contrast tw-text-sm tw-font-medium tw-py-1 group-hover/plan-card-container:tw-bg-primary-700"
+            >
+              {{ "selected" | i18n }}
+            </div>
+            <div class="tw-pl-5 tw-py-4 tw-pr-4" [ngClass]="{ 'tw-pt-10': !planCard.selected }">
+              <h3 class="tw-text-2xl tw-font-medium tw-uppercase">{{ planCard.name }}</h3>
+              <span class="tw-text-2xl tw-font-medium">{{
+                planCard.getMonthlyCost() | currency: "$"
+              }}</span>
+              <span class="tw-text-sm tw-font-medium"
+                >/ {{ planCard.getTimePerMemberLabel() | i18n }}</span
               >
-                {{ "selected" | i18n }}
-              </div>
-              <div class="tw-pl-5 tw-py-4 tw-pr-4" [ngClass]="{ 'tw-pt-10': !planCard.selected }">
-                <h3 class="tw-text-2xl tw-font-medium tw-uppercase">{{ planCard.name }}</h3>
-                <span class="tw-text-2xl tw-font-medium">{{
-                  planCard.getMonthlyCost() | currency: "$"
-                }}</span>
-                <span class="tw-text-sm tw-font-medium"
-                  >/ {{ planCard.getTimePerMemberLabel() | i18n }}</span
-                >
-              </div>
             </div>
           </div>
         </div>
-      </ng-container>
-      <div class="tw-grid tw-grid-flow-col tw-grid-cols-2 tw-gap-4">
-        <bit-form-field>
-          <bit-label>
-            {{ "organizationName" | i18n }}
-          </bit-label>
-          <input type="text" bitInput formControlName="organizationName" />
-          <bit-error-summary
-            *ngIf="
-              formGroup.controls.organizationName.errors?.['maxLength'] &&
-              formGroup.controls.organizationName.touched
-            "
-          >
-            {{ "organizationNameMaxLength" | i18n }}
-          </bit-error-summary>
-        </bit-form-field>
-        <bit-form-field>
-          <bit-label>
-            {{ "clientOwnerEmail" | i18n }}
-          </bit-label>
-          <input type="text" bitInput formControlName="clientOwnerEmail" />
-        </bit-form-field>
       </div>
-      <div class="tw-grid tw-grid-flow-col tw-grid-cols-2 tw-gap-4">
-        <bit-form-field disableMargin>
-          <bit-label>
-            {{ "seats" | i18n }}
-          </bit-label>
-          <input type="number" bitInput formControlName="seats" min="1" />
-          <bit-hint
-            class="tw-text-muted tw-grid tw-grid-flow-col tw-gap-1 tw-grid-cols-1"
-            [ngClass]="{
-              'tw-grid-rows-1': additionalSeatsPurchased <= 0,
-              'tw-grid-rows-2': additionalSeatsPurchased > 0,
-            }"
-          >
-            <span class="tw-col-span-1"
-              >{{ unassignedSeats }} {{ "unassignedSeatsDescription" | i18n | lowercase }}</span
-            >
-            <span class="tw-col-span-1" *ngIf="additionalSeatsPurchased > 0"
-              >{{ additionalSeatsPurchased }}
-              {{ "purchaseSeatDescription" | i18n | lowercase }}</span
-            >
-          </bit-hint>
-        </bit-form-field>
-      </div>
-    </div>
-    <ng-container bitDialogFooter>
-      <button bitButton bitFormButton buttonType="primary" type="submit">
-        {{ "addOrganization" | i18n }}
-      </button>
-      <button bitButton buttonType="secondary" type="button" [bitDialogClose]="ResultType.Closed">
-        {{ "cancel" | i18n }}
-      </button>
     </ng-container>
-  </bit-dialog>
+    <div class="tw-grid tw-grid-flow-col tw-grid-cols-2 tw-gap-4">
+      <bit-form-field>
+        <bit-label>
+          {{ "organizationName" | i18n }}
+        </bit-label>
+        <input type="text" bitInput formControlName="organizationName" />
+        <bit-error-summary
+          *ngIf="
+            formGroup.controls.organizationName.errors?.['maxLength'] &&
+            formGroup.controls.organizationName.touched
+          "
+        >
+          {{ "organizationNameMaxLength" | i18n }}
+        </bit-error-summary>
+      </bit-form-field>
+      <bit-form-field>
+        <bit-label>
+          {{ "clientOwnerEmail" | i18n }}
+        </bit-label>
+        <input type="text" bitInput formControlName="clientOwnerEmail" />
+      </bit-form-field>
+    </div>
+    <div class="tw-grid tw-grid-flow-col tw-grid-cols-2 tw-gap-4">
+      <bit-form-field disableMargin>
+        <bit-label>
+          {{ "seats" | i18n }}
+        </bit-label>
+        <input type="number" bitInput formControlName="seats" min="1" />
+        <bit-hint
+          class="tw-text-muted tw-grid tw-grid-flow-col tw-gap-1 tw-grid-cols-1"
+          [ngClass]="{
+            'tw-grid-rows-1': additionalSeatsPurchased <= 0,
+            'tw-grid-rows-2': additionalSeatsPurchased > 0,
+          }"
+        >
+          <span class="tw-col-span-1"
+            >{{ unassignedSeats }} {{ "unassignedSeatsDescription" | i18n | lowercase }}</span
+          >
+          <span class="tw-col-span-1" *ngIf="additionalSeatsPurchased > 0"
+            >{{ additionalSeatsPurchased }} {{ "purchaseSeatDescription" | i18n | lowercase }}</span
+          >
+        </bit-hint>
+      </bit-form-field>
+    </div>
+  </div>
+  <ng-container bitDialogFooter>
+    <button bitButton bitFormButton buttonType="primary" type="submit">
+      {{ "addOrganization" | i18n }}
+    </button>
+    <button bitButton buttonType="secondary" type="button" [bitDialogClose]="ResultType.Closed">
+      {{ "cancel" | i18n }}
+    </button>
+  </ng-container>
 </form>

--- a/bitwarden_license/bit-web/src/app/admin-console/providers/clients/manage-client-name-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/admin-console/providers/clients/manage-client-name-dialog.component.html
@@ -1,24 +1,22 @@
-<form [formGroup]="formGroup" [bitSubmit]="submit">
-  <bit-dialog>
-    <span bitDialogTitle class="tw-font-medium">
-      {{ "updateName" | i18n }}
-      <small class="tw-text-muted">{{ dialogParams.organization.name }}</small>
-    </span>
-    <div bitDialogContent>
-      <bit-form-field>
-        <bit-label>
-          {{ "organizationName" | i18n }}
-        </bit-label>
-        <input type="text" bitInput formControlName="name" />
-      </bit-form-field>
-    </div>
-    <ng-container bitDialogFooter>
-      <button bitButton bitFormButton buttonType="primary" type="submit">
-        {{ "save" | i18n }}
-      </button>
-      <button bitButton buttonType="secondary" type="button" [bitDialogClose]="ResultType.Closed">
-        {{ "cancel" | i18n }}
-      </button>
-    </ng-container>
-  </bit-dialog>
+<form [formGroup]="formGroup" [bitSubmit]="submit" bit-dialog>
+  <span bitDialogTitle class="tw-font-medium">
+    {{ "updateName" | i18n }}
+    <small class="tw-text-muted">{{ dialogParams.organization.name }}</small>
+  </span>
+  <div bitDialogContent>
+    <bit-form-field>
+      <bit-label>
+        {{ "organizationName" | i18n }}
+      </bit-label>
+      <input type="text" bitInput formControlName="name" />
+    </bit-form-field>
+  </div>
+  <ng-container bitDialogFooter>
+    <button bitButton bitFormButton buttonType="primary" type="submit">
+      {{ "save" | i18n }}
+    </button>
+    <button bitButton buttonType="secondary" type="button" [bitDialogClose]="ResultType.Closed">
+      {{ "cancel" | i18n }}
+    </button>
+  </ng-container>
 </form>

--- a/bitwarden_license/bit-web/src/app/admin-console/providers/clients/manage-client-subscription-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/admin-console/providers/clients/manage-client-subscription-dialog.component.html
@@ -1,57 +1,60 @@
-<form [formGroup]="formGroup" [bitSubmit]="submit">
-  <bit-dialog dialogSize="large" [loading]="loading">
-    <span bitDialogTitle>
-      {{ "manageSeats" | i18n }}
-      <small class="tw-text-muted">{{ dialogParams.organization.organizationName }}</small>
-    </span>
-    <div bitDialogContent>
-      <p>{{ "manageSeatsDescription" | i18n }}</p>
-      <bit-form-field disableMargin>
-        <bit-label>
-          {{ "assignedSeats" | i18n }}
-        </bit-label>
-        <input
-          type="number"
-          bitInput
-          formControlName="assignedSeats"
-          [min]="dialogParams.organization.occupiedSeats"
-        />
-        <bit-hint class="tw-text-muted" *ngIf="!isServiceUserWithPurchasedSeats">
-          <div
-            class="tw-grid tw-grid-flow-col tw-gap-1 tw-grid-cols-1"
-            [ngClass]="{
-              'tw-grid-rows-1': additionalSeatsPurchased === 0,
-              'tw-grid-rows-2': purchasingSeats || sellingSeats,
-            }"
+<form
+  [formGroup]="formGroup"
+  [bitSubmit]="submit"
+  bit-dialog
+  dialogSize="large"
+  [loading]="loading"
+>
+  <span bitDialogTitle>
+    {{ "manageSeats" | i18n }}
+    <small class="tw-text-muted">{{ dialogParams.organization.organizationName }}</small>
+  </span>
+  <div bitDialogContent>
+    <p>{{ "manageSeatsDescription" | i18n }}</p>
+    <bit-form-field disableMargin>
+      <bit-label>
+        {{ "assignedSeats" | i18n }}
+      </bit-label>
+      <input
+        type="number"
+        bitInput
+        formControlName="assignedSeats"
+        [min]="dialogParams.organization.occupiedSeats"
+      />
+      <bit-hint class="tw-text-muted" *ngIf="!isServiceUserWithPurchasedSeats">
+        <div
+          class="tw-grid tw-grid-flow-col tw-gap-1 tw-grid-cols-1"
+          [ngClass]="{
+            'tw-grid-rows-1': additionalSeatsPurchased === 0,
+            'tw-grid-rows-2': purchasingSeats || sellingSeats,
+          }"
+        >
+          <span class="tw-col-span-1">
+            {{ unassignedSeats }} {{ "unassignedSeatsDescription" | i18n | lowercase }}
+          </span>
+          <span *ngIf="purchasingSeats" class="tw-col-span-1"
+            >{{ additionalSeatsPurchased }} {{ "purchaseSeatDescription" | i18n | lowercase }}</span
           >
-            <span class="tw-col-span-1">
-              {{ unassignedSeats }} {{ "unassignedSeatsDescription" | i18n | lowercase }}
-            </span>
-            <span *ngIf="purchasingSeats" class="tw-col-span-1"
-              >{{ additionalSeatsPurchased }}
-              {{ "purchaseSeatDescription" | i18n | lowercase }}</span
-            >
-            <span *ngIf="sellingSeats" class="tw-col-span-1"
-              >{{ purchasedSeatsRemoved }} {{ "purchasedSeatsRemoved" | i18n | lowercase }}</span
-            >
-          </div>
-        </bit-hint>
-        <bit-hint *ngIf="isServiceUserWithPurchasedSeats"></bit-hint>
-      </bit-form-field>
-    </div>
-    <ng-container bitDialogFooter>
-      <button
-        bitButton
-        bitFormButton
-        buttonType="primary"
-        type="submit"
-        [disabled]="formGroup.invalid"
-      >
-        {{ "save" | i18n }}
-      </button>
-      <button bitButton buttonType="secondary" type="button" [bitDialogClose]="ResultType.Closed">
-        {{ "cancel" | i18n }}
-      </button>
-    </ng-container>
-  </bit-dialog>
+          <span *ngIf="sellingSeats" class="tw-col-span-1"
+            >{{ purchasedSeatsRemoved }} {{ "purchasedSeatsRemoved" | i18n | lowercase }}</span
+          >
+        </div>
+      </bit-hint>
+      <bit-hint *ngIf="isServiceUserWithPurchasedSeats"></bit-hint>
+    </bit-form-field>
+  </div>
+  <ng-container bitDialogFooter>
+    <button
+      bitButton
+      bitFormButton
+      buttonType="primary"
+      type="submit"
+      [disabled]="formGroup.invalid"
+    >
+      {{ "save" | i18n }}
+    </button>
+    <button bitButton buttonType="secondary" type="button" [bitDialogClose]="ResultType.Closed">
+      {{ "cancel" | i18n }}
+    </button>
+  </ng-container>
 </form>

--- a/bitwarden_license/bit-web/src/app/admin-console/providers/manage/dialogs/add-edit-member-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/admin-console/providers/manage/dialogs/add-edit-member-dialog.component.html
@@ -1,68 +1,72 @@
-<form [formGroup]="formGroup" [bitSubmit]="submit">
-  <bit-dialog dialogSize="large" [loading]="loading">
-    <span bitDialogTitle>
-      {{ title | uppercase }}
-      <small class="tw-text-muted" *ngIf="dialogParams.user">{{ dialogParams.user.name }}</small>
-    </span>
-    <div bitDialogContent>
-      <ng-container *ngIf="!editing">
-        <p>{{ "providerInviteUserDesc" | i18n }}</p>
-        <div class="tw-mb-4">
-          <bit-form-field>
-            <bit-label>
-              {{ "email" | i18n }}
-            </bit-label>
-            <input type="text" bitInput formControlName="emails" />
-            <bit-hint>{{ "inviteMultipleEmailsNoSeatLimit" | i18n: 20 }}</bit-hint>
-          </bit-form-field>
-        </div>
-      </ng-container>
-      <ng-container>
-        <h3>
-          {{ "userType" | i18n | uppercase }}
-          <a
-            target="_blank"
-            rel="noreferrer"
-            appA11yTitle="{{ 'learnMore' | i18n }}"
-            href="https://bitwarden.com/help/provider-users/"
-          >
-            <i class="bwi bwi-question-circle" aria-hidden="true"></i>
-          </a>
-        </h3>
-        <bit-radio-group formControlName="type">
-          <bit-radio-button [value]="UserType.ServiceUser">
-            <bit-label>
-              {{ "serviceUser" | i18n }}
-            </bit-label>
-            <bit-hint>{{ "serviceUserDesc" | i18n }}</bit-hint>
-          </bit-radio-button>
-          <bit-radio-button [value]="UserType.ProviderAdmin">
-            <bit-label>
-              {{ "providerAdmin" | i18n }}
-            </bit-label>
-            <bit-hint>{{ "providerAdminDesc" | i18n }}</bit-hint>
-          </bit-radio-button>
-        </bit-radio-group>
-      </ng-container>
-    </div>
-    <ng-container bitDialogFooter>
-      <button type="submit" bitButton bitFormButton buttonType="primary" [disabled]="loading">
-        {{ "save" | i18n }}
-      </button>
-      <button bitButton buttonType="secondary" type="button" [bitDialogClose]="ResultType.Closed">
-        {{ "cancel" | i18n }}
-      </button>
-      <div class="tw-ml-auto" *ngIf="editing">
-        <button
-          type="button"
-          bitIconButton="bwi-trash"
-          buttonType="dangerGhost"
-          bitFormButton
-          [label]="'delete' | i18n"
-          [bitAction]="delete"
-          [disabled]="loading"
-        ></button>
+<form
+  [formGroup]="formGroup"
+  [bitSubmit]="submit"
+  bit-dialog
+  dialogSize="large"
+  [loading]="loading"
+>
+  <span bitDialogTitle>
+    {{ title | uppercase }}
+    <small class="tw-text-muted" *ngIf="dialogParams.user">{{ dialogParams.user.name }}</small>
+  </span>
+  <div bitDialogContent>
+    <ng-container *ngIf="!editing">
+      <p>{{ "providerInviteUserDesc" | i18n }}</p>
+      <div class="tw-mb-4">
+        <bit-form-field>
+          <bit-label>
+            {{ "email" | i18n }}
+          </bit-label>
+          <input type="text" bitInput formControlName="emails" />
+          <bit-hint>{{ "inviteMultipleEmailsNoSeatLimit" | i18n: 20 }}</bit-hint>
+        </bit-form-field>
       </div>
     </ng-container>
-  </bit-dialog>
+    <ng-container>
+      <h3>
+        {{ "userType" | i18n | uppercase }}
+        <a
+          target="_blank"
+          rel="noreferrer"
+          appA11yTitle="{{ 'learnMore' | i18n }}"
+          href="https://bitwarden.com/help/provider-users/"
+        >
+          <i class="bwi bwi-question-circle" aria-hidden="true"></i>
+        </a>
+      </h3>
+      <bit-radio-group formControlName="type">
+        <bit-radio-button [value]="UserType.ServiceUser">
+          <bit-label>
+            {{ "serviceUser" | i18n }}
+          </bit-label>
+          <bit-hint>{{ "serviceUserDesc" | i18n }}</bit-hint>
+        </bit-radio-button>
+        <bit-radio-button [value]="UserType.ProviderAdmin">
+          <bit-label>
+            {{ "providerAdmin" | i18n }}
+          </bit-label>
+          <bit-hint>{{ "providerAdminDesc" | i18n }}</bit-hint>
+        </bit-radio-button>
+      </bit-radio-group>
+    </ng-container>
+  </div>
+  <ng-container bitDialogFooter>
+    <button type="submit" bitButton bitFormButton buttonType="primary" [disabled]="loading">
+      {{ "save" | i18n }}
+    </button>
+    <button bitButton buttonType="secondary" type="button" [bitDialogClose]="ResultType.Closed">
+      {{ "cancel" | i18n }}
+    </button>
+    <div class="tw-ml-auto" *ngIf="editing">
+      <button
+        type="button"
+        bitIconButton="bwi-trash"
+        buttonType="dangerGhost"
+        bitFormButton
+        [label]="'delete' | i18n"
+        [bitAction]="delete"
+        [disabled]="loading"
+      ></button>
+    </div>
+  </ng-container>
 </form>

--- a/bitwarden_license/bit-web/src/app/dirt/organization-integrations/integration-dialog/connect-dialog/connect-dialog-datadog.component.html
+++ b/bitwarden_license/bit-web/src/app/dirt/organization-integrations/integration-dialog/connect-dialog/connect-dialog-datadog.component.html
@@ -1,58 +1,57 @@
-<form [formGroup]="formGroup" [bitSubmit]="submit">
-  <bit-dialog dialogSize="large" [loading]="loading">
-    <span bitDialogTitle>
-      {{ "connectIntegrationButtonDesc" | i18n: connectInfo.settings.name }}
-    </span>
-    <div bitDialogContent class="tw-flex tw-flex-col tw-gap-4">
-      @if (loading) {
-        <ng-container #spinner>
-          <bit-icon name="bwi-spinner" class="bwi-lg bwi-spin" aria-hidden="true"></bit-icon>
-        </ng-container>
-      }
-      @if (!loading) {
-        <ng-container>
-          <bit-form-field>
-            <bit-label>{{ "url" | i18n }}</bit-label>
-            <input
-              bitInput
-              type="text"
-              formControlName="url"
-              placeholder="{{ urlHelperLinkText }}"
-            />
-          </bit-form-field>
+<form
+  [formGroup]="formGroup"
+  [bitSubmit]="submit"
+  bit-dialog
+  dialogSize="large"
+  [loading]="loading"
+>
+  <span bitDialogTitle>
+    {{ "connectIntegrationButtonDesc" | i18n: connectInfo.settings.name }}
+  </span>
+  <div bitDialogContent class="tw-flex tw-flex-col tw-gap-4">
+    @if (loading) {
+      <ng-container #spinner>
+        <bit-icon name="bwi-spinner" class="bwi-lg bwi-spin" aria-hidden="true"></bit-icon>
+      </ng-container>
+    }
+    @if (!loading) {
+      <ng-container>
+        <bit-form-field>
+          <bit-label>{{ "url" | i18n }}</bit-label>
+          <input bitInput type="text" formControlName="url" placeholder="{{ urlHelperLinkText }}" />
+        </bit-form-field>
 
-          <bit-form-field>
-            <bit-label>{{ "apiKey" | i18n }}</bit-label>
-            <input bitInput type="password" formControlName="apiKey" />
-            <bit-hint>{{ "apiKey" | i18n }}</bit-hint>
-          </bit-form-field>
-        </ng-container>
+        <bit-form-field>
+          <bit-label>{{ "apiKey" | i18n }}</bit-label>
+          <input bitInput type="password" formControlName="apiKey" />
+          <bit-hint>{{ "apiKey" | i18n }}</bit-hint>
+        </bit-form-field>
+      </ng-container>
+    }
+  </div>
+  <ng-container bitDialogFooter>
+    <button type="submit" bitButton bitFormButton buttonType="primary" [disabled]="loading">
+      @if (isUpdateAvailable) {
+        {{ "update" | i18n }}
+      } @else {
+        {{ "save" | i18n }}
       }
-    </div>
-    <ng-container bitDialogFooter>
-      <button type="submit" bitButton bitFormButton buttonType="primary" [disabled]="loading">
-        @if (isUpdateAvailable) {
-          {{ "update" | i18n }}
-        } @else {
-          {{ "save" | i18n }}
-        }
-      </button>
-      <button type="button" bitButton bitDialogClose buttonType="secondary" [disabled]="loading">
-        {{ "cancel" | i18n }}
-      </button>
+    </button>
+    <button type="button" bitButton bitDialogClose buttonType="secondary" [disabled]="loading">
+      {{ "cancel" | i18n }}
+    </button>
 
-      @if (canDelete) {
-        <div class="tw-ml-auto">
-          <button
-            bitIconButton="bwi-trash"
-            type="button"
-            buttonType="dangerGhost"
-            label="{{ 'delete' | i18n }}"
-            appA11yTitle="{{ 'delete' | i18n }}"
-            [bitAction]="delete"
-          ></button>
-        </div>
-      }
-    </ng-container>
-  </bit-dialog>
+    @if (canDelete) {
+      <div class="tw-ml-auto">
+        <button
+          bitIconButton="bwi-trash"
+          type="button"
+          buttonType="dangerGhost"
+          label="{{ 'delete' | i18n }}"
+          appA11yTitle="{{ 'delete' | i18n }}"
+          [bitAction]="delete"
+        ></button>
+      </div>
+    }
+  </ng-container>
 </form>

--- a/bitwarden_license/bit-web/src/app/dirt/organization-integrations/integration-dialog/connect-dialog/connect-dialog-hec.component.html
+++ b/bitwarden_license/bit-web/src/app/dirt/organization-integrations/integration-dialog/connect-dialog/connect-dialog-hec.component.html
@@ -1,64 +1,63 @@
-<form [formGroup]="formGroup" [bitSubmit]="submit">
-  <bit-dialog dialogSize="large" [loading]="loading">
-    <span bitDialogTitle>
-      {{ "connectIntegrationButtonDesc" | i18n: connectInfo.settings.name }}
-    </span>
-    <div bitDialogContent class="tw-flex tw-flex-col tw-gap-4">
-      @if (loading) {
-        <ng-container #spinner>
-          <bit-icon name="bwi-spinner" class="bwi-lg bwi-spin" aria-hidden="true"></bit-icon>
-        </ng-container>
-      }
-      @if (!loading) {
-        <ng-container>
-          <bit-form-field>
-            <bit-label>{{ "url" | i18n }}</bit-label>
-            <input
-              bitInput
-              type="text"
-              formControlName="url"
-              placeholder="{{ urlHelperLinkText }}"
-            />
-          </bit-form-field>
+<form
+  [formGroup]="formGroup"
+  [bitSubmit]="submit"
+  bit-dialog
+  dialogSize="large"
+  [loading]="loading"
+>
+  <span bitDialogTitle>
+    {{ "connectIntegrationButtonDesc" | i18n: connectInfo.settings.name }}
+  </span>
+  <div bitDialogContent class="tw-flex tw-flex-col tw-gap-4">
+    @if (loading) {
+      <ng-container #spinner>
+        <bit-icon name="bwi-spinner" class="bwi-lg bwi-spin" aria-hidden="true"></bit-icon>
+      </ng-container>
+    }
+    @if (!loading) {
+      <ng-container>
+        <bit-form-field>
+          <bit-label>{{ "url" | i18n }}</bit-label>
+          <input bitInput type="text" formControlName="url" placeholder="{{ urlHelperLinkText }}" />
+        </bit-form-field>
 
-          <bit-form-field>
-            <bit-label>{{ "bearerToken" | i18n }}</bit-label>
-            <input bitInput type="password" formControlName="bearerToken" />
-            <bit-hint>{{ "apiKey" | i18n }}</bit-hint>
-          </bit-form-field>
+        <bit-form-field>
+          <bit-label>{{ "bearerToken" | i18n }}</bit-label>
+          <input bitInput type="password" formControlName="bearerToken" />
+          <bit-hint>{{ "apiKey" | i18n }}</bit-hint>
+        </bit-form-field>
 
-          <bit-form-field>
-            <bit-label>{{ "index" | i18n }}</bit-label>
-            <input bitInput type="text" formControlName="index" />
-            <bit-hint>{{ "repositoryNameHint" | i18n }}</bit-hint>
-          </bit-form-field>
-        </ng-container>
+        <bit-form-field>
+          <bit-label>{{ "index" | i18n }}</bit-label>
+          <input bitInput type="text" formControlName="index" />
+          <bit-hint>{{ "repositoryNameHint" | i18n }}</bit-hint>
+        </bit-form-field>
+      </ng-container>
+    }
+  </div>
+  <ng-container bitDialogFooter>
+    <button type="submit" bitButton bitFormButton buttonType="primary" [disabled]="loading">
+      @if (isUpdateAvailable) {
+        {{ "update" | i18n }}
+      } @else {
+        {{ "save" | i18n }}
       }
-    </div>
-    <ng-container bitDialogFooter>
-      <button type="submit" bitButton bitFormButton buttonType="primary" [disabled]="loading">
-        @if (isUpdateAvailable) {
-          {{ "update" | i18n }}
-        } @else {
-          {{ "save" | i18n }}
-        }
-      </button>
-      <button type="button" bitButton bitDialogClose buttonType="secondary" [disabled]="loading">
-        {{ "cancel" | i18n }}
-      </button>
+    </button>
+    <button type="button" bitButton bitDialogClose buttonType="secondary" [disabled]="loading">
+      {{ "cancel" | i18n }}
+    </button>
 
-      @if (canDelete) {
-        <div class="tw-ml-auto">
-          <button
-            bitIconButton="bwi-trash"
-            type="button"
-            buttonType="dangerGhost"
-            label="{{ 'delete' | i18n }}"
-            appA11yTitle="{{ 'delete' | i18n }}"
-            [bitAction]="delete"
-          ></button>
-        </div>
-      }
-    </ng-container>
-  </bit-dialog>
+    @if (canDelete) {
+      <div class="tw-ml-auto">
+        <button
+          bitIconButton="bwi-trash"
+          type="button"
+          buttonType="dangerGhost"
+          label="{{ 'delete' | i18n }}"
+          appA11yTitle="{{ 'delete' | i18n }}"
+          [bitAction]="delete"
+        ></button>
+      </div>
+    }
+  </ng-container>
 </form>

--- a/bitwarden_license/bit-web/src/app/dirt/organization-integrations/integration-dialog/connect-dialog/connect-via-hec-token-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/dirt/organization-integrations/integration-dialog/connect-dialog/connect-via-hec-token-dialog.component.html
@@ -1,57 +1,56 @@
-<form [formGroup]="formGroup" [bitSubmit]="submit">
-  <bit-dialog dialogSize="large" [loading]="loading">
-    <span bitDialogTitle>
-      {{ "connectIntegrationButtonDesc" | i18n: connectInfo.settings.name }}
-    </span>
-    <div bitDialogContent class="tw-flex tw-flex-col tw-gap-4">
-      @if (loading) {
-        <ng-container #spinner>
-          <bit-icon name="bwi-spinner" class="bwi-lg bwi-spin" aria-hidden="true"></bit-icon>
-        </ng-container>
-      }
-      @if (!loading) {
-        <ng-container>
-          <bit-form-field>
-            <bit-label>{{ "httpEventCollectorUrl" | i18n }}</bit-label>
-            <input
-              bitInput
-              type="text"
-              formControlName="url"
-              placeholder="{{ urlHelperLinkText }}"
-            />
-          </bit-form-field>
+<form
+  [formGroup]="formGroup"
+  [bitSubmit]="submit"
+  bit-dialog
+  dialogSize="large"
+  [loading]="loading"
+>
+  <span bitDialogTitle>
+    {{ "connectIntegrationButtonDesc" | i18n: connectInfo.settings.name }}
+  </span>
+  <div bitDialogContent class="tw-flex tw-flex-col tw-gap-4">
+    @if (loading) {
+      <ng-container #spinner>
+        <bit-icon name="bwi-spinner" class="bwi-lg bwi-spin" aria-hidden="true"></bit-icon>
+      </ng-container>
+    }
+    @if (!loading) {
+      <ng-container>
+        <bit-form-field>
+          <bit-label>{{ "httpEventCollectorUrl" | i18n }}</bit-label>
+          <input bitInput type="text" formControlName="url" placeholder="{{ urlHelperLinkText }}" />
+        </bit-form-field>
 
-          <bit-form-field>
-            <bit-label>{{ "httpEventCollectorToken" | i18n }}</bit-label>
-            <input bitInput type="password" formControlName="token" />
-          </bit-form-field>
-        </ng-container>
+        <bit-form-field>
+          <bit-label>{{ "httpEventCollectorToken" | i18n }}</bit-label>
+          <input bitInput type="password" formControlName="token" />
+        </bit-form-field>
+      </ng-container>
+    }
+  </div>
+  <ng-container bitDialogFooter>
+    <button type="submit" bitButton bitFormButton buttonType="primary" [disabled]="loading">
+      @if (isUpdateAvailable) {
+        {{ "update" | i18n }}
+      } @else {
+        {{ "save" | i18n }}
       }
-    </div>
-    <ng-container bitDialogFooter>
-      <button type="submit" bitButton bitFormButton buttonType="primary" [disabled]="loading">
-        @if (isUpdateAvailable) {
-          {{ "update" | i18n }}
-        } @else {
-          {{ "save" | i18n }}
-        }
-      </button>
-      <button type="button" bitButton bitDialogClose buttonType="secondary" [disabled]="loading">
-        {{ "cancel" | i18n }}
-      </button>
+    </button>
+    <button type="button" bitButton bitDialogClose buttonType="secondary" [disabled]="loading">
+      {{ "cancel" | i18n }}
+    </button>
 
-      @if (canDelete) {
-        <div class="tw-ml-auto">
-          <button
-            bitIconButton="bwi-trash"
-            type="button"
-            buttonType="dangerGhost"
-            label="{{ 'delete' | i18n }}"
-            appA11yTitle="{{ 'delete' | i18n }}"
-            [bitAction]="delete"
-          ></button>
-        </div>
-      }
-    </ng-container>
-  </bit-dialog>
+    @if (canDelete) {
+      <div class="tw-ml-auto">
+        <button
+          bitIconButton="bwi-trash"
+          type="button"
+          buttonType="dangerGhost"
+          label="{{ 'delete' | i18n }}"
+          appA11yTitle="{{ 'delete' | i18n }}"
+          [bitAction]="delete"
+        ></button>
+      </div>
+    }
+  </ng-container>
 </form>

--- a/bitwarden_license/bit-web/src/app/secrets-manager/projects/dialog/project-delete-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/projects/dialog/project-delete-dialog.component.html
@@ -1,35 +1,33 @@
-<form [formGroup]="formGroup" [bitSubmit]="submit">
-  <bit-dialog dialogSize="default">
-    <ng-container bitDialogTitle>
-      <span>{{ title | i18n }}</span>
-      <span class="tw-text-sm tw-normal-case tw-text-muted">
-        <ng-container *ngIf="data.projects.length == 1">
-          {{ data.projects[0].name }}
-        </ng-container>
-        <ng-container *ngIf="data.projects.length > 1">
-          {{ data.projects.length }}
-          {{ "projects" | i18n }}
-        </ng-container>
-      </span>
-    </ng-container>
+<form [formGroup]="formGroup" [bitSubmit]="submit" bit-dialog dialogSize="default">
+  <ng-container bitDialogTitle>
+    <span>{{ title | i18n }}</span>
+    <span class="tw-text-sm tw-normal-case tw-text-muted">
+      <ng-container *ngIf="data.projects.length == 1">
+        {{ data.projects[0].name }}
+      </ng-container>
+      <ng-container *ngIf="data.projects.length > 1">
+        {{ data.projects.length }}
+        {{ "projects" | i18n }}
+      </ng-container>
+    </span>
+  </ng-container>
 
-    <div bitDialogContent>
-      <bit-callout type="warning" [title]="'warning' | i18n">
-        {{ dialogContent }}
-      </bit-callout>
-      <bit-form-field>
-        <bit-label>{{ dialogConfirmationLabel }}</bit-label>
-        <input bitInput formControlName="confirmDelete" />
-      </bit-form-field>
-    </div>
+  <div bitDialogContent>
+    <bit-callout type="warning" [title]="'warning' | i18n">
+      {{ dialogContent }}
+    </bit-callout>
+    <bit-form-field>
+      <bit-label>{{ dialogConfirmationLabel }}</bit-label>
+      <input bitInput formControlName="confirmDelete" />
+    </bit-form-field>
+  </div>
 
-    <ng-container bitDialogFooter>
-      <button type="submit" bitButton buttonType="danger" bitFormButton>
-        {{ title | i18n }}
-      </button>
-      <button type="button" bitButton buttonType="secondary" bitFormButton bitDialogClose>
-        {{ "cancel" | i18n }}
-      </button>
-    </ng-container>
-  </bit-dialog>
+  <ng-container bitDialogFooter>
+    <button type="submit" bitButton buttonType="danger" bitFormButton>
+      {{ title | i18n }}
+    </button>
+    <button type="button" bitButton buttonType="secondary" bitFormButton bitDialogClose>
+      {{ "cancel" | i18n }}
+    </button>
+  </ng-container>
 </form>

--- a/bitwarden_license/bit-web/src/app/secrets-manager/projects/dialog/project-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/projects/dialog/project-dialog.component.html
@@ -1,22 +1,20 @@
-<form [formGroup]="formGroup" [bitSubmit]="submit">
-  <bit-dialog dialogSize="default">
-    <span bitDialogTitle>{{ title | i18n }}</span>
-    <span bitDialogContent>
-      <div *ngIf="loading" class="tw-text-center">
-        <i class="bwi bwi-spinner bwi-spin bwi-3x"></i>
-      </div>
-      <bit-form-field *ngIf="!loading">
-        <bit-label>{{ "projectName" | i18n }}</bit-label>
-        <input appAutofocus formControlName="name" bitInput />
-      </bit-form-field>
-    </span>
-    <ng-container bitDialogFooter>
-      <button type="submit" bitButton buttonType="primary" bitFormButton>
-        {{ "save" | i18n }}
-      </button>
-      <button type="button" bitButton buttonType="secondary" bitFormButton bitDialogClose>
-        {{ "cancel" | i18n }}
-      </button>
-    </ng-container>
-  </bit-dialog>
+<form [formGroup]="formGroup" [bitSubmit]="submit" bit-dialog dialogSize="default">
+  <span bitDialogTitle>{{ title | i18n }}</span>
+  <span bitDialogContent>
+    <div *ngIf="loading" class="tw-text-center">
+      <i class="bwi bwi-spinner bwi-spin bwi-3x"></i>
+    </div>
+    <bit-form-field *ngIf="!loading">
+      <bit-label>{{ "projectName" | i18n }}</bit-label>
+      <input appAutofocus formControlName="name" bitInput />
+    </bit-form-field>
+  </span>
+  <ng-container bitDialogFooter>
+    <button type="submit" bitButton buttonType="primary" bitFormButton>
+      {{ "save" | i18n }}
+    </button>
+    <button type="button" bitButton buttonType="secondary" bitFormButton bitDialogClose>
+      {{ "cancel" | i18n }}
+    </button>
+  </ng-container>
 </form>

--- a/bitwarden_license/bit-web/src/app/secrets-manager/secrets/dialog/secret-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/secrets/dialog/secret-dialog.component.html
@@ -1,97 +1,103 @@
-<form [formGroup]="formGroup" [bitSubmit]="submit">
-  <bit-dialog dialogSize="large" [loading]="loading" [title]="title | i18n" [subtitle]="subtitle">
-    <div bitDialogContent class="tw-relative">
-      <bit-tab-group [(selectedIndex)]="tabIndex">
-        <bit-tab label="{{ 'nameValuePair' | i18n }}">
-          <div class="tw-flex tw-gap-4 tw-pt-4">
-            <bit-form-field class="tw-w-1/3">
-              <bit-label>{{ "name" | i18n }}</bit-label>
-              <input appAutofocus formControlName="name" bitInput />
-            </bit-form-field>
-            <bit-form-field class="tw-w-full">
-              <bit-label>{{ "value" | i18n }}</bit-label>
-              <textarea bitInput rows="4" formControlName="value"></textarea>
-            </bit-form-field>
-          </div>
-          <bit-form-field>
-            <bit-label>{{ "notes" | i18n }}</bit-label>
-            <textarea bitInput rows="4" formControlName="notes"></textarea>
+<form
+  [formGroup]="formGroup"
+  [bitSubmit]="submit"
+  bit-dialog
+  dialogSize="large"
+  [loading]="loading"
+  [title]="title | i18n"
+  [subtitle]="subtitle"
+>
+  <div bitDialogContent class="tw-relative">
+    <bit-tab-group [(selectedIndex)]="tabIndex">
+      <bit-tab label="{{ 'nameValuePair' | i18n }}">
+        <div class="tw-flex tw-gap-4 tw-pt-4">
+          <bit-form-field class="tw-w-1/3">
+            <bit-label>{{ "name" | i18n }}</bit-label>
+            <input appAutofocus formControlName="name" bitInput />
           </bit-form-field>
-
-          <hr />
-
-          <bit-form-field class="tw-mb-0 tw-mt-3">
-            <bit-label>{{ "project" | i18n }}</bit-label>
-            <bit-select bitInput name="project" formControlName="project">
-              <bit-option value="" [label]="'selectPlaceholder' | i18n"></bit-option>
-              <bit-option
-                *ngFor="let p of projects"
-                [icon]="p.id === this.newProjectGuid ? 'bwi-plus-circle' : ''"
-                [value]="p.id"
-                [label]="p.name"
-              >
-              </bit-option>
-            </bit-select>
+          <bit-form-field class="tw-w-full">
+            <bit-label>{{ "value" | i18n }}</bit-label>
+            <textarea bitInput rows="4" formControlName="value"></textarea>
           </bit-form-field>
+        </div>
+        <bit-form-field>
+          <bit-label>{{ "notes" | i18n }}</bit-label>
+          <textarea bitInput rows="4" formControlName="notes"></textarea>
+        </bit-form-field>
 
-          <bit-form-field *ngIf="addNewProject == true">
-            <bit-label>{{ "projectName" | i18n }}</bit-label>
-            <input formControlName="newProjectName" bitInput />
-          </bit-form-field>
-        </bit-tab>
+        <hr />
 
-        <bit-tab label="{{ 'people' | i18n }}">
-          <p>
-            {{ "secretPeopleDescription" | i18n }}
-          </p>
-          <sm-access-policy-selector
-            formControlName="peopleAccessPolicies"
-            [addButtonMode]="false"
-            [items]="peopleAccessPolicyItems"
-            [label]="'people' | i18n"
-            [hint]="'projectPeopleSelectHint' | i18n"
-            [columnTitle]="'name' | i18n"
-            [emptyMessage]="'secretPeopleEmptyMessage' | i18n"
-          >
-          </sm-access-policy-selector>
-        </bit-tab>
+        <bit-form-field class="tw-mb-0 tw-mt-3">
+          <bit-label>{{ "project" | i18n }}</bit-label>
+          <bit-select bitInput name="project" formControlName="project">
+            <bit-option value="" [label]="'selectPlaceholder' | i18n"></bit-option>
+            <bit-option
+              *ngFor="let p of projects"
+              [icon]="p.id === this.newProjectGuid ? 'bwi-plus-circle' : ''"
+              [value]="p.id"
+              [label]="p.name"
+            >
+            </bit-option>
+          </bit-select>
+        </bit-form-field>
 
-        <bit-tab label="{{ 'machineAccounts' | i18n }}">
-          <p>
-            {{ "secretMachineAccountsDescription" | i18n }}
-          </p>
-          <sm-access-policy-selector
-            formControlName="serviceAccountAccessPolicies"
-            [addButtonMode]="false"
-            [items]="serviceAccountAccessPolicyItems"
-            [label]="'machineAccounts' | i18n"
-            [hint]="'projectMachineAccountsSelectHint' | i18n"
-            [columnTitle]="'machineAccounts' | i18n"
-            [emptyMessage]="'secretMachineAccountsEmptyMessage' | i18n"
-          >
-          </sm-access-policy-selector>
-        </bit-tab>
-      </bit-tab-group>
-    </div>
+        <bit-form-field *ngIf="addNewProject == true">
+          <bit-label>{{ "projectName" | i18n }}</bit-label>
+          <input formControlName="newProjectName" bitInput />
+        </bit-form-field>
+      </bit-tab>
 
-    <ng-container bitDialogFooter>
-      <button [loading]="loading" type="submit" bitButton buttonType="primary" bitFormButton>
-        {{ "save" | i18n }}
-      </button>
-      <button bitButton buttonType="secondary" type="button" bitDialogClose>
-        {{ "cancel" | i18n }}
-      </button>
-      <button
-        *ngIf="deleteButtonIsVisible"
-        class="tw-ml-auto"
-        [disabled]="loading"
-        type="button"
-        buttonType="dangerGhost"
-        bitIconButton="bwi-trash"
-        bitFormButton
-        [label]="'delete' | i18n"
-        [bitAction]="delete"
-      ></button>
-    </ng-container>
-  </bit-dialog>
+      <bit-tab label="{{ 'people' | i18n }}">
+        <p>
+          {{ "secretPeopleDescription" | i18n }}
+        </p>
+        <sm-access-policy-selector
+          formControlName="peopleAccessPolicies"
+          [addButtonMode]="false"
+          [items]="peopleAccessPolicyItems"
+          [label]="'people' | i18n"
+          [hint]="'projectPeopleSelectHint' | i18n"
+          [columnTitle]="'name' | i18n"
+          [emptyMessage]="'secretPeopleEmptyMessage' | i18n"
+        >
+        </sm-access-policy-selector>
+      </bit-tab>
+
+      <bit-tab label="{{ 'machineAccounts' | i18n }}">
+        <p>
+          {{ "secretMachineAccountsDescription" | i18n }}
+        </p>
+        <sm-access-policy-selector
+          formControlName="serviceAccountAccessPolicies"
+          [addButtonMode]="false"
+          [items]="serviceAccountAccessPolicyItems"
+          [label]="'machineAccounts' | i18n"
+          [hint]="'projectMachineAccountsSelectHint' | i18n"
+          [columnTitle]="'machineAccounts' | i18n"
+          [emptyMessage]="'secretMachineAccountsEmptyMessage' | i18n"
+        >
+        </sm-access-policy-selector>
+      </bit-tab>
+    </bit-tab-group>
+  </div>
+
+  <ng-container bitDialogFooter>
+    <button [loading]="loading" type="submit" bitButton buttonType="primary" bitFormButton>
+      {{ "save" | i18n }}
+    </button>
+    <button bitButton buttonType="secondary" type="button" bitDialogClose>
+      {{ "cancel" | i18n }}
+    </button>
+    <button
+      *ngIf="deleteButtonIsVisible"
+      class="tw-ml-auto"
+      [disabled]="loading"
+      type="button"
+      buttonType="dangerGhost"
+      bitIconButton="bwi-trash"
+      bitFormButton
+      [label]="'delete' | i18n"
+      [bitAction]="delete"
+    ></button>
+  </ng-container>
 </form>

--- a/bitwarden_license/bit-web/src/app/secrets-manager/secrets/dialog/secret-view-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/secrets/dialog/secret-view-dialog.component.html
@@ -1,30 +1,30 @@
-<form [formGroup]="formGroup">
-  <bit-dialog
-    dialogSize="large"
-    [loading]="loading"
-    [title]="'viewSecret' | i18n"
-    [subtitle]="formGroup.get('name').value"
-  >
-    <ng-container bitDialogContent class="tw-relative">
-      <div class="tw-flex tw-gap-4 tw-pt-4">
-        <bit-form-field class="tw-w-1/3">
-          <bit-label>{{ "name" | i18n }}</bit-label>
-          <input appAutofocus formControlName="name" bitInput />
-        </bit-form-field>
-        <bit-form-field class="tw-w-full">
-          <bit-label>{{ "value" | i18n }}</bit-label>
-          <textarea bitInput rows="4" formControlName="value"></textarea>
-        </bit-form-field>
-      </div>
-      <bit-form-field>
-        <bit-label>{{ "notes" | i18n }}</bit-label>
-        <textarea bitInput rows="4" formControlName="notes"></textarea>
+<form
+  [formGroup]="formGroup"
+  bit-dialog
+  dialogSize="large"
+  [loading]="loading"
+  [title]="'viewSecret' | i18n"
+  [subtitle]="formGroup.get('name').value"
+>
+  <ng-container bitDialogContent class="tw-relative">
+    <div class="tw-flex tw-gap-4 tw-pt-4">
+      <bit-form-field class="tw-w-1/3">
+        <bit-label>{{ "name" | i18n }}</bit-label>
+        <input appAutofocus formControlName="name" bitInput />
       </bit-form-field>
-    </ng-container>
-    <ng-container bitDialogFooter>
-      <button type="button" bitButton buttonType="primary" bitFormButton bitDialogClose>
-        {{ "close" | i18n }}
-      </button>
-    </ng-container>
-  </bit-dialog>
+      <bit-form-field class="tw-w-full">
+        <bit-label>{{ "value" | i18n }}</bit-label>
+        <textarea bitInput rows="4" formControlName="value"></textarea>
+      </bit-form-field>
+    </div>
+    <bit-form-field>
+      <bit-label>{{ "notes" | i18n }}</bit-label>
+      <textarea bitInput rows="4" formControlName="notes"></textarea>
+    </bit-form-field>
+  </ng-container>
+  <ng-container bitDialogFooter>
+    <button type="button" bitButton buttonType="primary" bitFormButton bitDialogClose>
+      {{ "close" | i18n }}
+    </button>
+  </ng-container>
 </form>

--- a/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/access/dialogs/access-token-create-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/access/dialogs/access-token-create-dialog.component.html
@@ -1,31 +1,29 @@
-<form [formGroup]="formGroup" [bitSubmit]="submit">
-  <bit-dialog dialogSize="default">
-    <ng-container bitDialogTitle>
-      <span>{{ "createAccessToken" | i18n }}</span>
-      <span class="tw-text-sm tw-normal-case tw-text-muted">
-        {{ data.serviceAccountView.name }}
-      </span>
-    </ng-container>
+<form [formGroup]="formGroup" [bitSubmit]="submit" bit-dialog dialogSize="default">
+  <ng-container bitDialogTitle>
+    <span>{{ "createAccessToken" | i18n }}</span>
+    <span class="tw-text-sm tw-normal-case tw-text-muted">
+      {{ data.serviceAccountView.name }}
+    </span>
+  </ng-container>
 
-    <div bitDialogContent>
-      <bit-form-field>
-        <bit-label>{{ "name" | i18n }}</bit-label>
-        <input bitInput appAutofocus formControlName="name" />
-      </bit-form-field>
-      <sm-expiration-options
-        formControlName="expirationDateControl"
-        [expirationDayOptions]="expirationDayOptions"
-        [touched]="formGroup.controls.expirationDateControl.touched"
-      ></sm-expiration-options>
-    </div>
+  <div bitDialogContent>
+    <bit-form-field>
+      <bit-label>{{ "name" | i18n }}</bit-label>
+      <input bitInput appAutofocus formControlName="name" />
+    </bit-form-field>
+    <sm-expiration-options
+      formControlName="expirationDateControl"
+      [expirationDayOptions]="expirationDayOptions"
+      [touched]="formGroup.controls.expirationDateControl.touched"
+    ></sm-expiration-options>
+  </div>
 
-    <ng-container bitDialogFooter>
-      <button class="tw-normal-case" type="submit" bitButton buttonType="primary" bitFormButton>
-        {{ "createAccessToken" | i18n }}
-      </button>
-      <button type="button" bitButton buttonType="secondary" bitFormButton bitDialogClose>
-        {{ "cancel" | i18n }}
-      </button>
-    </ng-container>
-  </bit-dialog>
+  <ng-container bitDialogFooter>
+    <button class="tw-normal-case" type="submit" bitButton buttonType="primary" bitFormButton>
+      {{ "createAccessToken" | i18n }}
+    </button>
+    <button type="button" bitButton buttonType="secondary" bitFormButton bitDialogClose>
+      {{ "cancel" | i18n }}
+    </button>
+  </ng-container>
 </form>

--- a/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/dialog/service-account-delete-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/dialog/service-account-delete-dialog.component.html
@@ -1,35 +1,33 @@
-<form [formGroup]="formGroup" [bitSubmit]="submit">
-  <bit-dialog dialogSize="default">
-    <ng-container bitDialogTitle>
-      <span>{{ title }}</span>
-      <span class="tw-text-sm tw-normal-case tw-text-muted">
-        <ng-container *ngIf="data.serviceAccounts.length == 1">
-          {{ data.serviceAccounts[0].name }}
-        </ng-container>
-        <ng-container *ngIf="data.serviceAccounts.length > 1">
-          {{ data.serviceAccounts.length }}
-          {{ "machineAccounts" | i18n }}
-        </ng-container>
-      </span>
-    </ng-container>
+<form [formGroup]="formGroup" [bitSubmit]="submit" bit-dialog dialogSize="default">
+  <ng-container bitDialogTitle>
+    <span>{{ title }}</span>
+    <span class="tw-text-sm tw-normal-case tw-text-muted">
+      <ng-container *ngIf="data.serviceAccounts.length == 1">
+        {{ data.serviceAccounts[0].name }}
+      </ng-container>
+      <ng-container *ngIf="data.serviceAccounts.length > 1">
+        {{ data.serviceAccounts.length }}
+        {{ "machineAccounts" | i18n }}
+      </ng-container>
+    </span>
+  </ng-container>
 
-    <div bitDialogContent>
-      <bit-callout type="warning" [title]="'warning' | i18n">
-        {{ dialogContent }}
-      </bit-callout>
-      <bit-form-field>
-        <bit-label>{{ dialogConfirmationLabel }}</bit-label>
-        <input bitInput formControlName="confirmDelete" />
-      </bit-form-field>
-    </div>
+  <div bitDialogContent>
+    <bit-callout type="warning" [title]="'warning' | i18n">
+      {{ dialogContent }}
+    </bit-callout>
+    <bit-form-field>
+      <bit-label>{{ dialogConfirmationLabel }}</bit-label>
+      <input bitInput formControlName="confirmDelete" />
+    </bit-form-field>
+  </div>
 
-    <ng-container bitDialogFooter>
-      <button type="submit" bitButton buttonType="danger" bitFormButton>
-        {{ title }}
-      </button>
-      <button type="button" bitButton buttonType="secondary" bitFormButton bitDialogClose>
-        {{ "cancel" | i18n }}
-      </button>
-    </ng-container>
-  </bit-dialog>
+  <ng-container bitDialogFooter>
+    <button type="submit" bitButton buttonType="danger" bitFormButton>
+      {{ title }}
+    </button>
+    <button type="button" bitButton buttonType="secondary" bitFormButton bitDialogClose>
+      {{ "cancel" | i18n }}
+    </button>
+  </ng-container>
 </form>

--- a/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/dialog/service-account-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/dialog/service-account-dialog.component.html
@@ -1,24 +1,22 @@
-<form [formGroup]="formGroup" [bitSubmit]="submit">
-  <bit-dialog dialogSize="default">
-    <ng-container bitDialogTitle>{{ title | i18n }}</ng-container>
-    <div bitDialogContent>
-      <div *ngIf="loading" class="tw-text-center">
-        <i class="bwi bwi-spinner bwi-spin bwi-3x"></i>
-      </div>
-      <div *ngIf="!loading">
-        <bit-form-field>
-          <bit-label>{{ "machineAccountName" | i18n }}</bit-label>
-          <input appAutofocus formControlName="name" bitInput />
-        </bit-form-field>
-      </div>
+<form [formGroup]="formGroup" [bitSubmit]="submit" bit-dialog dialogSize="default">
+  <ng-container bitDialogTitle>{{ title | i18n }}</ng-container>
+  <div bitDialogContent>
+    <div *ngIf="loading" class="tw-text-center">
+      <i class="bwi bwi-spinner bwi-spin bwi-3x"></i>
     </div>
-    <ng-container bitDialogFooter>
-      <button type="submit" bitButton buttonType="primary" bitFormButton>
-        {{ "save" | i18n }}
-      </button>
-      <button type="button" bitButton buttonType="secondary" bitFormButton bitDialogClose>
-        {{ "cancel" | i18n }}
-      </button>
-    </ng-container>
-  </bit-dialog>
+    <div *ngIf="!loading">
+      <bit-form-field>
+        <bit-label>{{ "machineAccountName" | i18n }}</bit-label>
+        <input appAutofocus formControlName="name" bitInput />
+      </bit-form-field>
+    </div>
+  </div>
+  <ng-container bitDialogFooter>
+    <button type="submit" bitButton buttonType="primary" bitFormButton>
+      {{ "save" | i18n }}
+    </button>
+    <button type="button" bitButton buttonType="secondary" bitFormButton bitDialogClose>
+      {{ "cancel" | i18n }}
+    </button>
+  </ng-container>
 </form>

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -221,6 +221,7 @@ export default tseslint.config(
       ],
       "@bitwarden/components/no-bwi-class-usage": "warn",
       "@bitwarden/components/no-icon-children-in-bit-button": "warn",
+      "@bitwarden/components/no-bit-dialog-wrapper": "error",
     },
   },
 

--- a/libs/angular/src/auth/delete-account-dialog/delete-account-dialog.component.html
+++ b/libs/angular/src/auth/delete-account-dialog/delete-account-dialog.component.html
@@ -1,21 +1,25 @@
-<form [formGroup]="deleteForm" [bitSubmit]="submit">
-  <bit-dialog dialogSize="default" [title]="'deleteAccount' | i18n">
-    <ng-container bitDialogContent>
-      <p bitTypography="body1">{{ "deleteAccountDesc" | i18n }}</p>
-      <bit-callout type="warning">{{ "deleteAccountWarning" | i18n }}</bit-callout>
-      <app-user-verification-form-input
-        formControlName="verification"
-        name="verification"
-        [(invalidSecret)]="invalidSecret"
-      ></app-user-verification-form-input>
-    </ng-container>
-    <ng-container bitDialogFooter>
-      <button bitButton bitFormButton type="submit" buttonType="danger">
-        {{ "deleteAccount" | i18n }}
-      </button>
-      <button bitButton bitFormButton type="button" buttonType="secondary" bitDialogClose>
-        {{ "close" | i18n }}
-      </button>
-    </ng-container>
-  </bit-dialog>
+<form
+  [formGroup]="deleteForm"
+  [bitSubmit]="submit"
+  bit-dialog
+  dialogSize="default"
+  [title]="'deleteAccount' | i18n"
+>
+  <ng-container bitDialogContent>
+    <p bitTypography="body1">{{ "deleteAccountDesc" | i18n }}</p>
+    <bit-callout type="warning">{{ "deleteAccountWarning" | i18n }}</bit-callout>
+    <app-user-verification-form-input
+      formControlName="verification"
+      name="verification"
+      [(invalidSecret)]="invalidSecret"
+    ></app-user-verification-form-input>
+  </ng-container>
+  <ng-container bitDialogFooter>
+    <button bitButton bitFormButton type="submit" buttonType="danger">
+      {{ "deleteAccount" | i18n }}
+    </button>
+    <button bitButton bitFormButton type="button" buttonType="secondary" bitDialogClose>
+      {{ "close" | i18n }}
+    </button>
+  </ng-container>
 </form>

--- a/libs/angular/src/key-management/encrypted-migration/prompt-migration-password.component.html
+++ b/libs/angular/src/key-management/encrypted-migration/prompt-migration-password.component.html
@@ -1,55 +1,53 @@
-<form [bitSubmit]="submit" [formGroup]="migrationPasswordForm">
-  <bit-dialog>
-    <div class="tw-font-semibold" bitDialogTitle>
-      {{ "updateEncryptionSettingsTitle" | i18n }}
-    </div>
-    <div bitDialogContent>
-      <p>
-        {{ "updateEncryptionSettingsDesc" | i18n }}
-        <a
-          bitLink
-          href="https://bitwarden.com/help/kdf-algorithms/"
-          target="_blank"
-          rel="noreferrer"
-          aria-label="external link"
-          endIcon="bwi-external-link"
-        >
-          {{ "learnMore" | i18n }}
-        </a>
-      </p>
-      <bit-form-field>
-        <bit-label>{{ "masterPass" | i18n }}</bit-label>
-        <bit-hint>{{ "confirmIdentityToContinue" | i18n }}</bit-hint>
-        <input
-          class="tw-font-mono"
-          bitInput
-          type="password"
-          formControlName="masterPassword"
-          [attr.title]="'masterPass' | i18n"
-        />
-        <button
-          type="button"
-          bitIconButton
-          bitSuffix
-          bitPasswordInputToggle
-          [attr.title]="'toggleVisibility' | i18n"
-          [attr.aria-label]="'toggleVisibility' | i18n"
-        ></button>
-      </bit-form-field>
-    </div>
-    <ng-container bitDialogFooter>
-      <button
-        type="submit"
-        bitButton
-        bitFormButton
-        buttonType="primary"
-        [disabled]="migrationPasswordForm.invalid"
+<form [bitSubmit]="submit" [formGroup]="migrationPasswordForm" bit-dialog>
+  <div class="tw-font-semibold" bitDialogTitle>
+    {{ "updateEncryptionSettingsTitle" | i18n }}
+  </div>
+  <div bitDialogContent>
+    <p>
+      {{ "updateEncryptionSettingsDesc" | i18n }}
+      <a
+        bitLink
+        href="https://bitwarden.com/help/kdf-algorithms/"
+        target="_blank"
+        rel="noreferrer"
+        aria-label="external link"
+        endIcon="bwi-external-link"
       >
-        <span>{{ "updateSettings" | i18n }}</span>
-      </button>
-      <button type="button" bitButton bitFormButton buttonType="secondary" bitDialogClose>
-        {{ "later" | i18n }}
-      </button>
-    </ng-container>
-  </bit-dialog>
+        {{ "learnMore" | i18n }}
+      </a>
+    </p>
+    <bit-form-field>
+      <bit-label>{{ "masterPass" | i18n }}</bit-label>
+      <bit-hint>{{ "confirmIdentityToContinue" | i18n }}</bit-hint>
+      <input
+        class="tw-font-mono"
+        bitInput
+        type="password"
+        formControlName="masterPassword"
+        [attr.title]="'masterPass' | i18n"
+      />
+      <button
+        type="button"
+        bitIconButton
+        bitSuffix
+        bitPasswordInputToggle
+        [attr.title]="'toggleVisibility' | i18n"
+        [attr.aria-label]="'toggleVisibility' | i18n"
+      ></button>
+    </bit-form-field>
+  </div>
+  <ng-container bitDialogFooter>
+    <button
+      type="submit"
+      bitButton
+      bitFormButton
+      buttonType="primary"
+      [disabled]="migrationPasswordForm.invalid"
+    >
+      <span>{{ "updateSettings" | i18n }}</span>
+    </button>
+    <button type="button" bitButton bitFormButton buttonType="secondary" bitDialogClose>
+      {{ "later" | i18n }}
+    </button>
+  </ng-container>
 </form>

--- a/libs/auth/src/angular/self-hosted-env-config-dialog/self-hosted-env-config-dialog.component.html
+++ b/libs/auth/src/angular/self-hosted-env-config-dialog/self-hosted-env-config-dialog.component.html
@@ -1,106 +1,104 @@
-<form [formGroup]="formGroup" [bitSubmit]="submit">
-  <bit-dialog>
-    <span bitDialogTitle> Self-hosted environment</span>
-    <ng-container bitDialogContent>
+<form [formGroup]="formGroup" [bitSubmit]="submit" bit-dialog>
+  <span bitDialogTitle> Self-hosted environment</span>
+  <ng-container bitDialogContent>
+    <bit-form-field>
+      <bit-label>{{ "baseUrl" | i18n }}</bit-label>
+      <input
+        id="self_hosted_env_settings_form_input_base_url"
+        bitInput
+        type="text"
+        formControlName="baseUrl"
+        appAutofocus
+        appInputVerbatim
+      />
+      <bit-hint>{{ "selfHostedBaseUrlHint" | i18n }}</bit-hint>
+    </bit-form-field>
+
+    <button bitLink linkType="primary" type="button" (click)="showCustomEnv = !showCustomEnv">
+      <bit-icon
+        [name]="showCustomEnv ? 'bwi-angle-down' : 'bwi-angle-right'"
+        class="bwi-fw bwi-sm"
+      ></bit-icon>
+      {{ "customEnvironment" | i18n }}
+    </button>
+
+    <ng-container *ngIf="showCustomEnv">
+      <p bitTypography="body1" class="tw-text-muted tw-mt-3">
+        {{ "selfHostedCustomEnvHeader" | i18n }}
+      </p>
+
       <bit-form-field>
-        <bit-label>{{ "baseUrl" | i18n }}</bit-label>
+        <bit-label>{{ "webVaultUrl" | i18n }}</bit-label>
         <input
-          id="self_hosted_env_settings_form_input_base_url"
+          id="self_hosted_env_settings_form_input_web_vault_url"
           bitInput
           type="text"
-          formControlName="baseUrl"
-          appAutofocus
+          formControlName="webVaultUrl"
           appInputVerbatim
         />
-        <bit-hint>{{ "selfHostedBaseUrlHint" | i18n }}</bit-hint>
       </bit-form-field>
 
-      <button bitLink linkType="primary" type="button" (click)="showCustomEnv = !showCustomEnv">
-        <bit-icon
-          [name]="showCustomEnv ? 'bwi-angle-down' : 'bwi-angle-right'"
-          class="bwi-fw bwi-sm"
-        ></bit-icon>
-        {{ "customEnvironment" | i18n }}
-      </button>
+      <bit-form-field>
+        <bit-label>{{ "apiUrl" | i18n }}</bit-label>
+        <input
+          id="self_hosted_env_settings_form_input_api_url"
+          bitInput
+          type="text"
+          formControlName="apiUrl"
+          appInputVerbatim
+        />
+      </bit-form-field>
 
-      <ng-container *ngIf="showCustomEnv">
-        <p bitTypography="body1" class="tw-text-muted tw-mt-3">
-          {{ "selfHostedCustomEnvHeader" | i18n }}
-        </p>
+      <bit-form-field>
+        <bit-label>{{ "identityUrl" | i18n }}</bit-label>
+        <input
+          id="self_hosted_env_settings_form_input_identity_url"
+          bitInput
+          type="text"
+          formControlName="identityUrl"
+          appInputVerbatim
+        />
+      </bit-form-field>
 
-        <bit-form-field>
-          <bit-label>{{ "webVaultUrl" | i18n }}</bit-label>
-          <input
-            id="self_hosted_env_settings_form_input_web_vault_url"
-            bitInput
-            type="text"
-            formControlName="webVaultUrl"
-            appInputVerbatim
-          />
-        </bit-form-field>
+      <bit-form-field>
+        <bit-label>{{ "notificationsUrl" | i18n }}</bit-label>
+        <input
+          id="self_hosted_env_settings_form_input_notifications_url"
+          bitInput
+          type="text"
+          formControlName="notificationsUrl"
+          appInputVerbatim
+        />
+      </bit-form-field>
 
-        <bit-form-field>
-          <bit-label>{{ "apiUrl" | i18n }}</bit-label>
-          <input
-            id="self_hosted_env_settings_form_input_api_url"
-            bitInput
-            type="text"
-            formControlName="apiUrl"
-            appInputVerbatim
-          />
-        </bit-form-field>
-
-        <bit-form-field>
-          <bit-label>{{ "identityUrl" | i18n }}</bit-label>
-          <input
-            id="self_hosted_env_settings_form_input_identity_url"
-            bitInput
-            type="text"
-            formControlName="identityUrl"
-            appInputVerbatim
-          />
-        </bit-form-field>
-
-        <bit-form-field>
-          <bit-label>{{ "notificationsUrl" | i18n }}</bit-label>
-          <input
-            id="self_hosted_env_settings_form_input_notifications_url"
-            bitInput
-            type="text"
-            formControlName="notificationsUrl"
-            appInputVerbatim
-          />
-        </bit-form-field>
-
-        <bit-form-field>
-          <bit-label>{{ "iconsUrl" | i18n }}</bit-label>
-          <input
-            id="self_hosted_env_settings_form_input_icons_url"
-            bitInput
-            type="text"
-            formControlName="iconsUrl"
-            appInputVerbatim
-          />
-        </bit-form-field>
-      </ng-container>
-
-      <span
-        *ngIf="showErrorSummary"
-        class="tw-block tw-text-danger tw-mt-2"
-        aria-live="assertive"
-        role="alert"
-      >
-        <bit-icon name="bwi-error"></bit-icon> {{ "selfHostedEnvFormInvalid" | i18n }}
-      </span>
+      <bit-form-field>
+        <bit-label>{{ "iconsUrl" | i18n }}</bit-label>
+        <input
+          id="self_hosted_env_settings_form_input_icons_url"
+          bitInput
+          type="text"
+          formControlName="iconsUrl"
+          appInputVerbatim
+        />
+      </bit-form-field>
     </ng-container>
-    <ng-container bitDialogFooter>
-      <button type="submit" bitButton bitFormButton buttonType="primary">
-        {{ "save" | i18n }}
-      </button>
 
-      <button type="button" bitButton bitFormButton buttonType="secondary" (click)="cancel()">
-        {{ "cancel" | i18n }}
-      </button>
-    </ng-container>
-  </bit-dialog>
+    <span
+      *ngIf="showErrorSummary"
+      class="tw-block tw-text-danger tw-mt-2"
+      aria-live="assertive"
+      role="alert"
+    >
+      <bit-icon name="bwi-error"></bit-icon> {{ "selfHostedEnvFormInvalid" | i18n }}
+    </span>
+  </ng-container>
+  <ng-container bitDialogFooter>
+    <button type="submit" bitButton bitFormButton buttonType="primary">
+      {{ "save" | i18n }}
+    </button>
+
+    <button type="button" bitButton bitFormButton buttonType="secondary" (click)="cancel()">
+      {{ "cancel" | i18n }}
+    </button>
+  </ng-container>
 </form>

--- a/libs/auth/src/angular/user-verification/user-verification-dialog.component.html
+++ b/libs/auth/src/angular/user-verification/user-verification-dialog.component.html
@@ -1,105 +1,94 @@
-<form [formGroup]="verificationForm" [bitSubmit]="submit">
-  <bit-dialog>
-    <span bitDialogTitle>
-      {{
-        dialogOptions.title ? (dialogOptions.title | i18n) : ("verificationRequired" | i18n)
-      }}</span
+<form [formGroup]="verificationForm" [bitSubmit]="submit" bit-dialog>
+  <span bitDialogTitle>
+    {{ dialogOptions.title ? (dialogOptions.title | i18n) : ("verificationRequired" | i18n) }}</span
+  >
+  <ng-container bitDialogContent>
+    <!-- Show optional content when verification is server side or client side and verification methods were found. -->
+    <ng-container
+      *ngIf="
+        dialogOptions.verificationType !== 'client' ||
+        (dialogOptions.verificationType === 'client' &&
+          activeClientVerificationOption !== ActiveClientVerificationOption.None)
+      "
     >
-    <ng-container bitDialogContent>
-      <!-- Show optional content when verification is server side or client side and verification methods were found. -->
-      <ng-container
-        *ngIf="
-          dialogOptions.verificationType !== 'client' ||
-          (dialogOptions.verificationType === 'client' &&
-            activeClientVerificationOption !== ActiveClientVerificationOption.None)
-        "
-      >
-        <p bitTypography="body1" *ngIf="dialogOptions.bodyText">
-          {{ dialogOptions.bodyText | i18n }}
-        </p>
+      <p bitTypography="body1" *ngIf="dialogOptions.bodyText">
+        {{ dialogOptions.bodyText | i18n }}
+      </p>
 
-        <bit-callout
-          *ngIf="dialogOptions.calloutOptions"
-          [type]="dialogOptions.calloutOptions.type"
-        >
-          {{ dialogOptions.calloutOptions.text | i18n }}
-        </bit-callout>
-      </ng-container>
-
-      <!-- Shown when client side verification methods picked and no verification methods found -->
-      <ng-container
-        *ngIf="
-          dialogOptions.verificationType === 'client' &&
-          activeClientVerificationOption === ActiveClientVerificationOption.None
-        "
-      >
-        <p bitTypography="body1">
-          {{ "verificationRequiredForActionSetPinToContinue" | i18n }}
-        </p>
-      </ng-container>
-
-      <app-user-verification-form-input
-        [(invalidSecret)]="invalidSecret"
-        formControlName="secret"
-        [verificationType]="dialogOptions.verificationType === 'client' ? 'client' : 'server'"
-        (activeClientVerificationOptionChange)="handleActiveClientVerificationOptionChange($event)"
-        (biometricsVerificationResultChange)="handleBiometricsVerificationResultChange($event)"
-      ></app-user-verification-form-input>
+      <bit-callout *ngIf="dialogOptions.calloutOptions" [type]="dialogOptions.calloutOptions.type">
+        {{ dialogOptions.calloutOptions.text | i18n }}
+      </bit-callout>
     </ng-container>
-    <ng-container bitDialogFooter>
-      <!-- Confirm button container - shown for server side validation but hidden if client side validation + biometrics  -->
-      <ng-container
-        *ngIf="
-          dialogOptions.verificationType !== 'client' ||
-          (dialogOptions.verificationType === 'client' &&
-            activeClientVerificationOption !== ActiveClientVerificationOption.Biometrics)
-        "
-      >
-        <!--  Default / custom buttons shown for server verifications or any valid, non biometric client verifications (MP or PIN) -->
-        <ng-container
-          *ngIf="activeClientVerificationOption !== ActiveClientVerificationOption.None"
-        >
-          <!-- Default confirm button -->
-          <button
-            *ngIf="!dialogOptions.confirmButtonOptions"
-            type="submit"
-            bitButton
-            bitFormButton
-            buttonType="primary"
-          >
-            {{ "submit" | i18n }}
-          </button>
 
-          <!-- Custom confirm button -->
-          <button
-            *ngIf="dialogOptions.confirmButtonOptions"
-            type="submit"
-            bitButton
-            bitFormButton
-            [buttonType]="dialogOptions.confirmButtonOptions.type"
-          >
-            {{ dialogOptions.confirmButtonOptions.text | i18n }}
-          </button>
-        </ng-container>
+    <!-- Shown when client side verification methods picked and no verification methods found -->
+    <ng-container
+      *ngIf="
+        dialogOptions.verificationType === 'client' &&
+        activeClientVerificationOption === ActiveClientVerificationOption.None
+      "
+    >
+      <p bitTypography="body1">
+        {{ "verificationRequiredForActionSetPinToContinue" | i18n }}
+      </p>
+    </ng-container>
 
-        <ng-container
-          *ngIf="activeClientVerificationOption === ActiveClientVerificationOption.None"
+    <app-user-verification-form-input
+      [(invalidSecret)]="invalidSecret"
+      formControlName="secret"
+      [verificationType]="dialogOptions.verificationType === 'client' ? 'client' : 'server'"
+      (activeClientVerificationOptionChange)="handleActiveClientVerificationOptionChange($event)"
+      (biometricsVerificationResultChange)="handleBiometricsVerificationResultChange($event)"
+    ></app-user-verification-form-input>
+  </ng-container>
+  <ng-container bitDialogFooter>
+    <!-- Confirm button container - shown for server side validation but hidden if client side validation + biometrics  -->
+    <ng-container
+      *ngIf="
+        dialogOptions.verificationType !== 'client' ||
+        (dialogOptions.verificationType === 'client' &&
+          activeClientVerificationOption !== ActiveClientVerificationOption.Biometrics)
+      "
+    >
+      <!--  Default / custom buttons shown for server verifications or any valid, non biometric client verifications (MP or PIN) -->
+      <ng-container *ngIf="activeClientVerificationOption !== ActiveClientVerificationOption.None">
+        <!-- Default confirm button -->
+        <button
+          *ngIf="!dialogOptions.confirmButtonOptions"
+          type="submit"
+          bitButton
+          bitFormButton
+          buttonType="primary"
         >
-          <!--
-            For no client verifications found, show set a pin confirm button.
-            Note: this doesn't make sense for web as web doesn't support PINs, but this is how we are handling it for now
-            as the expectation is that only browser and desktop will use the new verificationType 'client' flow.
-            We might genericize this in the future to just tell the user they need to configure a valid user verification option like PIN or Biometrics.
-          -->
-          <button type="submit" bitButton bitFormButton buttonType="primary">
-            {{ "setPin" | i18n }}
-          </button>
-        </ng-container>
+          {{ "submit" | i18n }}
+        </button>
+
+        <!-- Custom confirm button -->
+        <button
+          *ngIf="dialogOptions.confirmButtonOptions"
+          type="submit"
+          bitButton
+          bitFormButton
+          [buttonType]="dialogOptions.confirmButtonOptions.type"
+        >
+          {{ dialogOptions.confirmButtonOptions.text | i18n }}
+        </button>
       </ng-container>
 
-      <button type="button" bitButton bitFormButton buttonType="secondary" (click)="cancel()">
-        {{ "cancel" | i18n }}
-      </button>
+      <ng-container *ngIf="activeClientVerificationOption === ActiveClientVerificationOption.None">
+        <!--
+          For no client verifications found, show set a pin confirm button.
+          Note: this doesn't make sense for web as web doesn't support PINs, but this is how we are handling it for now
+          as the expectation is that only browser and desktop will use the new verificationType 'client' flow.
+          We might genericize this in the future to just tell the user they need to configure a valid user verification option like PIN or Biometrics.
+        -->
+        <button type="submit" bitButton bitFormButton buttonType="primary">
+          {{ "setPin" | i18n }}
+        </button>
+      </ng-container>
     </ng-container>
-  </bit-dialog>
+
+    <button type="button" bitButton bitFormButton buttonType="secondary" (click)="cancel()">
+      {{ "cancel" | i18n }}
+    </button>
+  </ng-container>
 </form>

--- a/libs/eslint/components/index.mjs
+++ b/libs/eslint/components/index.mjs
@@ -2,6 +2,7 @@ import requireLabelOnBiticonbutton from "./require-label-on-biticonbutton.mjs";
 import requireThemeColorsInSvg from "./require-theme-colors-in-svg.mjs";
 import noBwiClassUsage from "./no-bwi-class-usage.mjs";
 import noIconChildrenInBitButton from "./no-icon-children-in-bit-button.mjs";
+import noBitDialogWrapper from "./no-bit-dialog-wrapper.mjs";
 import enforceReadonlyAngularProperties from "./enforce-readonly-angular-properties.mjs";
 
 export default {
@@ -10,6 +11,7 @@ export default {
     "require-theme-colors-in-svg": requireThemeColorsInSvg,
     "no-bwi-class-usage": noBwiClassUsage,
     "no-icon-children-in-bit-button": noIconChildrenInBitButton,
+    "no-bit-dialog-wrapper": noBitDialogWrapper,
     "enforce-readonly-angular-properties": enforceReadonlyAngularProperties,
   },
 };

--- a/libs/eslint/components/no-bit-dialog-wrapper.mjs
+++ b/libs/eslint/components/no-bit-dialog-wrapper.mjs
@@ -1,0 +1,40 @@
+const DIALOG_TAGS = new Set(["bit-dialog", "bit-simple-dialog"]);
+
+export const errorMessage =
+  "<bit-dialog> / <bit-simple-dialog> must be the root of its template. " +
+  'Apply the selector as an attribute on the root element instead (e.g. <form bit-dialog dialogSize="large">...</form>).';
+
+export default {
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Disallow placing <bit-dialog> or <bit-simple-dialog> inside a parent element.",
+      category: "Best Practices",
+      recommended: true,
+    },
+    messages: {
+      noWrapper: errorMessage,
+    },
+    schema: [],
+  },
+  create(context) {
+    const sourceCode = context.sourceCode ?? context.getSourceCode();
+
+    return {
+      Element(node) {
+        if (!DIALOG_TAGS.has(node.name)) {
+          return;
+        }
+
+        const ancestors = sourceCode.getAncestors
+          ? sourceCode.getAncestors(node)
+          : context.getAncestors();
+
+        const hasElementAncestor = ancestors.some((a) => a?.constructor?.name === "Element");
+        if (hasElementAncestor) {
+          context.report({ node, messageId: "noWrapper" });
+        }
+      },
+    };
+  },
+};

--- a/libs/eslint/components/no-bit-dialog-wrapper.spec.mjs
+++ b/libs/eslint/components/no-bit-dialog-wrapper.spec.mjs
@@ -1,0 +1,43 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+
+import rule, { errorMessage } from "./no-bit-dialog-wrapper.mjs";
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parser: require("@angular-eslint/template-parser"),
+  },
+});
+
+ruleTester.run("no-bit-dialog-wrapper", rule.default, {
+  valid: [
+    {
+      name: "bit-dialog at the root of the template",
+      code: `<bit-dialog dialogSize="large"></bit-dialog>`,
+    },
+    {
+      name: "bit-simple-dialog at the root of the template",
+      code: `<bit-simple-dialog></bit-simple-dialog>`,
+    },
+    {
+      name: "form using bit-dialog as attribute selector",
+      code: `<form bit-dialog></form>`,
+    },
+  ],
+  invalid: [
+    {
+      name: "bit-dialog wrapped in a form",
+      code: `<form><bit-dialog></bit-dialog></form>`,
+      errors: [{ message: errorMessage }],
+    },
+    {
+      name: "bit-simple-dialog wrapped in a form",
+      code: `<form><bit-simple-dialog></bit-simple-dialog></form>`,
+      errors: [{ message: errorMessage }],
+    },
+    {
+      name: "bit-dialog wrapped in a div",
+      code: `<div><bit-dialog></bit-dialog></div>`,
+      errors: [{ message: errorMessage }],
+    },
+  ],
+});

--- a/libs/importer/src/components/dialog/sshkey-password-prompt.component.html
+++ b/libs/importer/src/components/dialog/sshkey-password-prompt.component.html
@@ -1,31 +1,29 @@
-<form [formGroup]="formGroup" [bitSubmit]="submit">
-  <bit-dialog>
-    <span bitDialogTitle>
-      {{ "enterSshKeyPassword" | i18n }}
-    </span>
+<form [formGroup]="formGroup" [bitSubmit]="submit" bit-dialog>
+  <span bitDialogTitle>
+    {{ "enterSshKeyPassword" | i18n }}
+  </span>
 
-    <div bitDialogContent>
-      {{ "enterSshKeyPasswordDesc" | i18n }}
-      <bit-form-field class="tw-mt-6">
-        <bit-label>{{ "confirmSshKeyPassword" | i18n }}</bit-label>
-        <input
-          bitInput
-          type="password"
-          formControlName="sshKeyPassword"
-          appAutofocus
-          appInputVerbatim
-        />
-        <button type="button" bitSuffix bitIconButton bitPasswordInputToggle></button>
-      </bit-form-field>
-    </div>
+  <div bitDialogContent>
+    {{ "enterSshKeyPasswordDesc" | i18n }}
+    <bit-form-field class="tw-mt-6">
+      <bit-label>{{ "confirmSshKeyPassword" | i18n }}</bit-label>
+      <input
+        bitInput
+        type="password"
+        formControlName="sshKeyPassword"
+        appAutofocus
+        appInputVerbatim
+      />
+      <button type="button" bitSuffix bitIconButton bitPasswordInputToggle></button>
+    </bit-form-field>
+  </div>
 
-    <ng-container bitDialogFooter>
-      <button bitButton buttonType="primary" type="submit">
-        <span>{{ "importSshKey" | i18n }}</span>
-      </button>
-      <button bitButton bitDialogClose buttonType="secondary" type="button">
-        <span>{{ "cancel" | i18n }}</span>
-      </button>
-    </ng-container>
-  </bit-dialog>
+  <ng-container bitDialogFooter>
+    <button bitButton buttonType="primary" type="submit">
+      <span>{{ "importSshKey" | i18n }}</span>
+    </button>
+    <button bitButton bitDialogClose buttonType="secondary" type="button">
+      <span>{{ "cancel" | i18n }}</span>
+    </button>
+  </ng-container>
 </form>

--- a/libs/importer/src/components/lastpass/dialog/lastpass-multifactor-prompt.component.html
+++ b/libs/importer/src/components/lastpass/dialog/lastpass-multifactor-prompt.component.html
@@ -1,25 +1,23 @@
-<form [formGroup]="formGroup" [bitSubmit]="submit">
-  <bit-dialog>
-    <span bitDialogTitle>
-      {{ "lastPassMFARequired" | i18n }}
-    </span>
+<form [formGroup]="formGroup" [bitSubmit]="submit" bit-dialog>
+  <span bitDialogTitle>
+    {{ "lastPassMFARequired" | i18n }}
+  </span>
 
-    <div bitDialogContent>
-      <p>{{ descriptionI18nKey | i18n }}</p>
-      <bit-form-field class="!tw-mb-0">
-        <bit-label>{{ "passcode" | i18n }}</bit-label>
-        <input bitInput type="text" formControlName="passcode" appAutofocus appInputVerbatim />
-        <bit-hint>{{ "confirmIdentity" | i18n }}</bit-hint>
-      </bit-form-field>
-    </div>
+  <div bitDialogContent>
+    <p>{{ descriptionI18nKey | i18n }}</p>
+    <bit-form-field class="!tw-mb-0">
+      <bit-label>{{ "passcode" | i18n }}</bit-label>
+      <input bitInput type="text" formControlName="passcode" appAutofocus appInputVerbatim />
+      <bit-hint>{{ "confirmIdentity" | i18n }}</bit-hint>
+    </bit-form-field>
+  </div>
 
-    <ng-container bitDialogFooter>
-      <button bitButton buttonType="primary" type="submit" bitFormButton>
-        <span>{{ "continue" | i18n }}</span>
-      </button>
-      <button bitButton bitDialogClose="cancel" buttonType="secondary" type="button" bitFormButton>
-        <span>{{ "cancel" | i18n }}</span>
-      </button>
-    </ng-container>
-  </bit-dialog>
+  <ng-container bitDialogFooter>
+    <button bitButton buttonType="primary" type="submit" bitFormButton>
+      <span>{{ "continue" | i18n }}</span>
+    </button>
+    <button bitButton bitDialogClose="cancel" buttonType="secondary" type="button" bitFormButton>
+      <span>{{ "cancel" | i18n }}</span>
+    </button>
+  </ng-container>
 </form>

--- a/libs/importer/src/components/lastpass/dialog/lastpass-password-prompt.component.html
+++ b/libs/importer/src/components/lastpass/dialog/lastpass-password-prompt.component.html
@@ -1,25 +1,23 @@
-<form [formGroup]="formGroup" [bitSubmit]="submit">
-  <bit-dialog>
-    <span bitDialogTitle>
-      {{ "lastPassAuthRequired" | i18n }}
-    </span>
+<form [formGroup]="formGroup" [bitSubmit]="submit" bit-dialog>
+  <span bitDialogTitle>
+    {{ "lastPassAuthRequired" | i18n }}
+  </span>
 
-    <div bitDialogContent>
-      <bit-form-field class="!tw-mb-0">
-        <bit-label>{{ "lastPassMasterPassword" | i18n }}</bit-label>
-        <input bitInput type="password" formControlName="password" appAutofocus appInputVerbatim />
-        <button type="button" bitSuffix bitIconButton bitPasswordInputToggle></button>
-        <bit-hint>{{ "confirmIdentity" | i18n }}</bit-hint>
-      </bit-form-field>
-    </div>
+  <div bitDialogContent>
+    <bit-form-field class="!tw-mb-0">
+      <bit-label>{{ "lastPassMasterPassword" | i18n }}</bit-label>
+      <input bitInput type="password" formControlName="password" appAutofocus appInputVerbatim />
+      <button type="button" bitSuffix bitIconButton bitPasswordInputToggle></button>
+      <bit-hint>{{ "confirmIdentity" | i18n }}</bit-hint>
+    </bit-form-field>
+  </div>
 
-    <ng-container bitDialogFooter>
-      <button bitButton buttonType="primary" type="submit" bitFormButton>
-        <span>{{ "submit" | i18n }}</span>
-      </button>
-      <button bitButton bitDialogClose buttonType="secondary" type="button" bitFormButton>
-        <span>{{ "cancel" | i18n }}</span>
-      </button>
-    </ng-container>
-  </bit-dialog>
+  <ng-container bitDialogFooter>
+    <button bitButton buttonType="primary" type="submit" bitFormButton>
+      <span>{{ "submit" | i18n }}</span>
+    </button>
+    <button bitButton bitDialogClose buttonType="secondary" type="button" bitFormButton>
+      <span>{{ "cancel" | i18n }}</span>
+    </button>
+  </ng-container>
 </form>

--- a/libs/key-management-ui/src/key-rotation/key-rotation-dialog.component.html
+++ b/libs/key-management-ui/src/key-rotation/key-rotation-dialog.component.html
@@ -1,34 +1,32 @@
-<form [formGroup]="form" [bitSubmit]="submit">
-  <bit-dialog>
-    <ng-container bitDialogTitle>
-      {{ "rotateAccountEncryptionKey" | i18n }}
-    </ng-container>
-    <ng-container bitDialogContent>
-      <p bitTypography="body1">
-        {{ "rotateAccountEncryptionDialogDescription" | i18n }}
-      </p>
-      <bit-callout type="info">{{ "rotateAccountEncryptionCallout" | i18n }}</bit-callout>
-      <bit-form-field class="tw-mt-2">
-        <bit-label>{{ "masterPass" | i18n }}</bit-label>
-        <input
-          type="password"
-          formControlName="masterPassword"
-          bitInput
-          name="masterPassword"
-          class="tw-font-mono"
-          required
-          appInputVerbatim
-        />
-        <button type="button" bitIconButton bitSuffix bitPasswordInputToggle></button>
-      </bit-form-field>
-    </ng-container>
-    <ng-container bitDialogFooter>
-      <button type="submit" bitButton bitFormButton buttonType="primary">
-        {{ "rotateKey" | i18n }}
-      </button>
-      <button type="button" bitButton bitFormButton buttonType="secondary" bitDialogClose>
-        {{ "cancel" | i18n }}
-      </button>
-    </ng-container>
-  </bit-dialog>
+<form [formGroup]="form" [bitSubmit]="submit" bit-dialog>
+  <ng-container bitDialogTitle>
+    {{ "rotateAccountEncryptionKey" | i18n }}
+  </ng-container>
+  <ng-container bitDialogContent>
+    <p bitTypography="body1">
+      {{ "rotateAccountEncryptionDialogDescription" | i18n }}
+    </p>
+    <bit-callout type="info">{{ "rotateAccountEncryptionCallout" | i18n }}</bit-callout>
+    <bit-form-field class="tw-mt-2">
+      <bit-label>{{ "masterPass" | i18n }}</bit-label>
+      <input
+        type="password"
+        formControlName="masterPassword"
+        bitInput
+        name="masterPassword"
+        class="tw-font-mono"
+        required
+        appInputVerbatim
+      />
+      <button type="button" bitIconButton bitSuffix bitPasswordInputToggle></button>
+    </bit-form-field>
+  </ng-container>
+  <ng-container bitDialogFooter>
+    <button type="submit" bitButton bitFormButton buttonType="primary">
+      {{ "rotateKey" | i18n }}
+    </button>
+    <button type="button" bitButton bitFormButton buttonType="secondary" bitDialogClose>
+      {{ "cancel" | i18n }}
+    </button>
+  </ng-container>
 </form>

--- a/libs/vault/src/components/password-reprompt.component.html
+++ b/libs/vault/src/components/password-reprompt.component.html
@@ -1,31 +1,29 @@
-<form [formGroup]="formGroup" [bitSubmit]="submit">
-  <bit-dialog>
-    <span bitDialogTitle>
-      {{ "passwordConfirmation" | i18n }}
-    </span>
-    <ng-container bitDialogContent>
-      {{ "passwordConfirmationDesc" | i18n }}
+<form [formGroup]="formGroup" [bitSubmit]="submit" bit-dialog>
+  <span bitDialogTitle>
+    {{ "passwordConfirmation" | i18n }}
+  </span>
+  <ng-container bitDialogContent>
+    {{ "passwordConfirmationDesc" | i18n }}
 
-      <bit-form-field disableMargin class="tw-mt-6">
-        <bit-label>{{ "masterPass" | i18n }}</bit-label>
-        <input
-          bitInput
-          appAutofocus
-          id="masterPassword"
-          type="password"
-          formControlName="masterPassword"
-        />
-        <button type="button" bitSuffix bitIconButton bitPasswordInputToggle></button>
-      </bit-form-field>
-    </ng-container>
+    <bit-form-field disableMargin class="tw-mt-6">
+      <bit-label>{{ "masterPass" | i18n }}</bit-label>
+      <input
+        bitInput
+        appAutofocus
+        id="masterPassword"
+        type="password"
+        formControlName="masterPassword"
+      />
+      <button type="button" bitSuffix bitIconButton bitPasswordInputToggle></button>
+    </bit-form-field>
+  </ng-container>
 
-    <ng-container bitDialogFooter>
-      <button bitButton buttonType="primary" bitFormButton type="submit">
-        <span>{{ "ok" | i18n }}</span>
-      </button>
-      <button bitButton buttonType="secondary" bitDialogClose type="button">
-        {{ "cancel" | i18n }}
-      </button>
-    </ng-container>
-  </bit-dialog>
+  <ng-container bitDialogFooter>
+    <button bitButton buttonType="primary" bitFormButton type="submit">
+      <span>{{ "ok" | i18n }}</span>
+    </button>
+    <button bitButton buttonType="secondary" bitDialogClose type="button">
+      {{ "cancel" | i18n }}
+    </button>
+  </ng-container>
 </form>


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/CL-1046

## 📔 Objective

Adds a custom ESLint rule (`@bitwarden/components/no-bit-dialog-wrapper`) that errors when `<bit-dialog>` or `<bit-simple-dialog>` appears inside any parent HTML element. The selector should be applied as an attribute on the root element instead (e.g. `<form bit-dialog dialogSize="large">…</form>`), so the form receives the dialog's height styling.

Set to `error` severity. Also bundles the previously-separated CL-1046 migration commits (admin console, auth settings, secrets manager) so the rule and its first round of fixes land together. Supersedes and replaces #18933, #18932, #18934.

### Rule scope

- **Errors:** any `<bit-dialog>` / `<bit-simple-dialog>` with an HTML element ancestor (`<form>`, `<div>`, `<ng-container>`, etc.).
- **No auto-fix.** Migration is mechanical but context-dependent; intentionally left manual.

## 📸 Screenshots

n/a

[CL-1046]: https://bitwarden.atlassian.net/browse/CL-1046?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ