### PR TITLE
[PM-37689] [PM-16746] Remove obsolete LockScreen config from AppX manifest

### DIFF
--- a/apps/desktop/custom-appx-manifest.xml
+++ b/apps/desktop/custom-appx-manifest.xml
@@ -96,7 +96,6 @@
                 Square150x150Logo="assets\Square150x150Logo.png"
                 Square44x44Logo="assets\Square44x44Logo.png"
                 Description="A secure and free password manager for all of your devices.">
-                <uap:LockScreen Notification="badgeAndTileText" BadgeLogo="assets\BadgeLogo.png" />
                 <uap:DefaultTile Wide310x150Logo="assets\Wide310x150Logo.png" />
                 <uap:SplashScreen Image="assets\SplashScreen.png" />
             </uap:VisualElements>


### PR DESCRIPTION
This is an independent contribution made in my personal capacity. I am not participating in any organized competition, hackathon, or bounty program related to this contribution.

## 🎟️ Tracking

Fixes #16746

## 📔 Objective

Remove the obsolete `uap:LockScreen` declaration from the AppX manifest. This declaration causes Bitwarden to appear as a selectable lock screen status app in Windows Settings, but the current desktop client no longer supports live tiles on Windows 10/11.

The fix is a single-line removal at `apps/desktop/custom-appx-manifest.xml` line 99, which drops the `<uap:LockScreen Notification="badgeAndTileText" BadgeLogo="assets\BadgeLogo.png" />` element. This matches the behavior expected by users — Bitwarden should not appear under Personalization > Lock screen status.

No functional changes to the app itself — this is purely a manifest metadata cleanup.