### PR TITLE
PM-37554 resolved double cancel issue (#20683)

### DIFF
--- a/libs/tools/send/send-ui/src/add-edit/send-add-edit-dialog.component.ts
+++ b/libs/tools/send/send-ui/src/add-edit/send-add-edit-dialog.component.ts
@@ -256,13 +256,19 @@ export class SendAddEditDialogComponent {
   }
 
   protected async cancelEditSend() {
-    const proceed = await this.sendFormService.promptForUnsavedEdits();
-    if (!proceed) {
-      return;
-    }
     if (this.config.mode === "add") {
+      // For "add" mode, just call close() — the closePredicate wired at open-time
+      // (promptForUnsavedEdits) will handle showing the discard dialog exactly once.
+      // Calling promptForUnsavedEdits manually here AND then close() would cause the
+      // discard dialog to appear twice (once here, once from the closePredicate).
       void this.dialogRef.close();
     } else {
+      // For "edit" mode we are not closing the dialog, just toggling back to view mode,
+      // so the closePredicate never runs — we must check for unsaved edits manually.
+      const proceed = await this.sendFormService.promptForUnsavedEdits();
+      if (!proceed) {
+        return;
+      }
       this.editing.set(false);
     }
   }


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-37554

## 📔 Objective
The discard dialog is displayed twice when clicking cancel while creating a send.

## 📸 Screenshots
https://github.com/user-attachments/assets/2fded75b-0406-4c3c-a801-94ce61f289d4


