### PR TITLE
[CL-1203] Place tab overflow More button next to last visible tab

### DIFF
--- a/libs/components/src/overflow-list/index.ts
+++ b/libs/components/src/overflow-list/index.ts
@@ -1,2 +1,3 @@
 export { OverflowItemDirective } from "./overflow-item.directive";
 export { OverflowListDirective } from "./overflow-list.directive";
+export { OverflowTriggerDirective } from "./overflow-trigger.directive";

--- a/libs/components/src/overflow-list/overflow-list.directive.ts
+++ b/libs/components/src/overflow-list/overflow-list.directive.ts
@@ -101,10 +101,19 @@ export class OverflowListDirective {
         overflow: [] as readonly number[],
       };
     }
+    const containerWidth = this.containerWidth();
+    const gap = this.gap();
+    // First, check whether everything fits without reserving the trigger — when
+    // it does, the trigger will be hidden and won't consume layout, so we'd be
+    // overflowing items just to make room for an affordance we don't need.
+    const totalWidth = widths.reduce((sum, w, i) => sum + w + (i > 0 ? gap : 0), 0);
+    if (totalWidth <= containerWidth) {
+      return pack(widths, containerWidth, gap, this.pinIndex());
+    }
     const triggerWidth = this.triggerWidth();
-    const reserved = triggerWidth > 0 ? triggerWidth + this.gap() : 0;
-    const available = Math.max(0, this.containerWidth() - reserved);
-    return pack(widths, available, this.gap(), this.pinIndex());
+    const reserved = triggerWidth > 0 ? triggerWidth + gap : 0;
+    const available = Math.max(0, containerWidth - reserved);
+    return pack(widths, available, gap, this.pinIndex());
   });
 
   /** Indices of items rendered in the visible row, in DOM order. */
@@ -142,9 +151,10 @@ export class OverflowListDirective {
       this.destroyRef.onDestroy(() => ro.disconnect());
     });
 
-    // Apply [hidden] to overflowed items, flag the lone displayed item (if any)
-    // so consumers can gate truncation styling on it, and tell the trailing
-    // trigger whether to reveal itself.
+    // Apply [hidden] to overflowed items and to the trailing trigger when there's
+    // nothing to surface; flag the lone displayed item (if any) so consumers can
+    // gate truncation styling on it. The trigger update is gated on `ready` so
+    // its first-pass measurement happens while it's still visible.
     effect(() => {
       const overflowList = this.overflow();
       const displayedList = this.displayed();
@@ -155,7 +165,12 @@ export class OverflowListDirective {
         item.elementRef.nativeElement.hidden = overflowSet.has(i);
         item.shouldShrink.set(i === lonelyIndex);
       });
-      this.trigger()?.hasOverflow.set(overflowList.length > 0);
+      if (this.ready()) {
+        const trigger = this.trigger();
+        if (trigger) {
+          trigger.elementRef.nativeElement.hidden = overflowList.length === 0;
+        }
+      }
     });
   }
 }

--- a/libs/components/src/overflow-list/overflow-list.directive.ts
+++ b/libs/components/src/overflow-list/overflow-list.directive.ts
@@ -4,6 +4,7 @@ import {
   ElementRef,
   afterNextRender,
   computed,
+  contentChild,
   contentChildren,
   effect,
   inject,
@@ -12,6 +13,7 @@ import {
 } from "@angular/core";
 
 import { OverflowItemDirective } from "./overflow-item.directive";
+import { OverflowTriggerDirective } from "./overflow-trigger.directive";
 import { pack } from "./pack";
 
 /**
@@ -64,12 +66,20 @@ export class OverflowListDirective {
   readonly itemsInput = input<readonly OverflowItemDirective[] | null>(null, { alias: "items" });
   readonly items = computed(() => this.itemsInput() ?? this.queriedItems());
 
+  /**
+   * Optional trailing affordance (typically a "More" button). When present, its
+   * width is reserved from the space available to items so packing leaves room
+   * for it next to the last visible item.
+   */
+  private readonly trigger = contentChild(OverflowTriggerDirective, { descendants: true });
+
   /** Horizontal gap between items, in pixels. Should match the CSS gap of the host. */
   readonly gap = input(0);
 
   // --- measurement signals (data pipeline inputs) ---
   private readonly containerWidth = signal(0);
   private readonly itemWidths = signal<readonly number[]>([]);
+  private readonly triggerWidth = signal(0);
 
   /** First item with `[pinned]=true`, or null if none. */
   private readonly pinIndex = computed(() => {
@@ -91,7 +101,10 @@ export class OverflowListDirective {
         overflow: [] as readonly number[],
       };
     }
-    return pack(widths, this.containerWidth(), this.gap(), this.pinIndex());
+    const triggerWidth = this.triggerWidth();
+    const reserved = triggerWidth > 0 ? triggerWidth + this.gap() : 0;
+    const available = Math.max(0, this.containerWidth() - reserved);
+    return pack(widths, available, this.gap(), this.pinIndex());
   });
 
   /** Indices of items rendered in the visible row, in DOM order. */
@@ -117,14 +130,21 @@ export class OverflowListDirective {
             Math.ceil(item.elementRef.nativeElement.getBoundingClientRect().width),
           ),
         );
+        const trigger = this.trigger();
+        if (trigger) {
+          this.triggerWidth.set(
+            Math.ceil(trigger.elementRef.nativeElement.getBoundingClientRect().width),
+          );
+        }
         this.ready.set(true);
       });
       ro.observe(this.hostEl);
       this.destroyRef.onDestroy(() => ro.disconnect());
     });
 
-    // Apply [hidden] to overflowed items, and flag the lone displayed item (if any)
-    // so consumers can gate truncation styling on it.
+    // Apply [hidden] to overflowed items, flag the lone displayed item (if any)
+    // so consumers can gate truncation styling on it, and tell the trailing
+    // trigger whether to reveal itself.
     effect(() => {
       const overflowList = this.overflow();
       const displayedList = this.displayed();
@@ -135,6 +155,7 @@ export class OverflowListDirective {
         item.elementRef.nativeElement.hidden = overflowSet.has(i);
         item.shouldShrink.set(i === lonelyIndex);
       });
+      this.trigger()?.hasOverflow.set(overflowList.length > 0);
     });
   }
 }

--- a/libs/components/src/overflow-list/overflow-trigger.directive.ts
+++ b/libs/components/src/overflow-list/overflow-trigger.directive.ts
@@ -1,16 +1,13 @@
-import { Directive, ElementRef, inject, signal } from "@angular/core";
+import { Directive, ElementRef, inject } from "@angular/core";
 
 /**
  * Marks an element as the trailing affordance of a parent `[bitOverflowList]` —
  * typically a "More" button that surfaces overflowed items in a menu. The list
  * measures this element and reserves its width from the space available to items,
- * so packing accounts for the affordance instead of overlapping it.
- *
- * The directive hides itself (via `visibility: hidden` + `aria-hidden`) when the
- * list has no overflowed items, while keeping a stable layout width so the list's
- * one-shot width measurement stays accurate. Using `visibility` rather than the
- * `hidden` attribute is what avoids a feedback loop between the trigger's width
- * and the pack decision.
+ * so packing accounts for the affordance instead of overlapping it. The list also
+ * toggles the trigger's `hidden` property to mirror whether anything has actually
+ * overflowed — the trigger is rendered (and measured) on the first pass, then
+ * hidden if no items overflow.
  *
  * Place the trigger as a child of the `[bitOverflowList]` host so the list can
  * find it via `contentChild`.
@@ -18,14 +15,7 @@ import { Directive, ElementRef, inject, signal } from "@angular/core";
 @Directive({
   selector: "[bitOverflowTrigger]",
   exportAs: "bitOverflowTrigger",
-  host: {
-    "[style.visibility]": "hasOverflow() ? null : 'hidden'",
-    "[attr.aria-hidden]": "hasOverflow() ? null : 'true'",
-  },
 })
 export class OverflowTriggerDirective {
   readonly elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
-
-  /** Set by the parent `bitOverflowList` — true when at least one item is overflowed. */
-  readonly hasOverflow = signal(false);
 }

--- a/libs/components/src/overflow-list/overflow-trigger.directive.ts
+++ b/libs/components/src/overflow-list/overflow-trigger.directive.ts
@@ -1,0 +1,31 @@
+import { Directive, ElementRef, inject, signal } from "@angular/core";
+
+/**
+ * Marks an element as the trailing affordance of a parent `[bitOverflowList]` —
+ * typically a "More" button that surfaces overflowed items in a menu. The list
+ * measures this element and reserves its width from the space available to items,
+ * so packing accounts for the affordance instead of overlapping it.
+ *
+ * The directive hides itself (via `visibility: hidden` + `aria-hidden`) when the
+ * list has no overflowed items, while keeping a stable layout width so the list's
+ * one-shot width measurement stays accurate. Using `visibility` rather than the
+ * `hidden` attribute is what avoids a feedback loop between the trigger's width
+ * and the pack decision.
+ *
+ * Place the trigger as a child of the `[bitOverflowList]` host so the list can
+ * find it via `contentChild`.
+ */
+@Directive({
+  selector: "[bitOverflowTrigger]",
+  exportAs: "bitOverflowTrigger",
+  host: {
+    "[style.visibility]": "hasOverflow() ? null : 'hidden'",
+    "[attr.aria-hidden]": "hasOverflow() ? null : 'true'",
+  },
+})
+export class OverflowTriggerDirective {
+  readonly elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
+
+  /** Set by the parent `bitOverflowList` — true when at least one item is overflowed. */
+  readonly hasOverflow = signal(false);
+}

--- a/libs/components/src/tabs/shared/tab-list-item.directive.ts
+++ b/libs/components/src/tabs/shared/tab-list-item.directive.ts
@@ -60,6 +60,7 @@ export class TabListItemDirective implements FocusableOption {
     "tw-block",
     "tw-relative",
     "tw-h-full",
+    "tw-max-w-fit",
     "tw-whitespace-nowrap",
     "tw-pb-3",
     "tw-text-sm",

--- a/libs/components/src/tabs/tab-group/tab-group.component.html
+++ b/libs/components/src/tabs/tab-group/tab-group.component.html
@@ -47,29 +47,26 @@
         ></ng-container>
       </button>
     }
+    <!--
+      The More button sits inside the overflow list so it lands immediately after
+      the last visible tab in the flex flow. bitOverflowTrigger manages its own
+      visibility and aria-hidden state based on whether anything has overflowed.
+    -->
+    <button
+      bitTabListItem
+      bitOverflowTrigger
+      type="button"
+      class="tw-shrink-0"
+      tabindex="-1"
+      [bitMenuTriggerFor]="overFlowTabsMenu"
+    >
+      <span [class]="tabLabelContentClasses">
+        {{ "more" | i18n }}
+        <bit-berry [value]="ovf.overflow().length"></bit-berry>
+        <bit-icon name="bwi-angle-down" class="tw-text-base" />
+      </span>
+    </button>
   </div>
-  <!--
-    The More button lives outside the bitOverflowList so the directive only manages
-    its own row. It uses tw-invisible (not [hidden]) so its layout space is always
-    reserved — that keeps the directive's measured width stable across the
-    no-overflow / overflow transition and avoids a feedback loop.
-  -->
-  <button
-    bitTabListItem
-    type="button"
-    class="tw-shrink-0"
-    [class.tw-invisible]="ovf.overflow().length === 0"
-    [attr.aria-hidden]="ovf.overflow().length === 0 ? 'true' : null"
-    tabindex="-1"
-    [bitMenuTriggerFor]="overFlowTabsMenu"
-    [style.marginInlineStart.px]="TAB_LIST_CONTAINER_GAP"
-  >
-    <span [class]="tabLabelContentClasses">
-      {{ "more" | i18n }}
-      <bit-berry [value]="ovf.overflow().length"></bit-berry>
-      <bit-icon name="bwi-angle-down" class="tw-text-base" />
-    </span>
-  </button>
 </bit-tab-header>
 <div class="tw-pt-5">
   @for (tab of tabs(); track tab.id; let i = $index) {

--- a/libs/components/src/tabs/tab-group/tab-group.component.html
+++ b/libs/components/src/tabs/tab-group/tab-group.component.html
@@ -54,6 +54,7 @@
       of focus and the accessibility tree.
     -->
     <button
+      #moreButton
       bitTabListItem
       bitOverflowTrigger
       type="button"
@@ -84,7 +85,7 @@
   }
 </div>
 
-<bit-menu #overFlowTabsMenu>
+<bit-menu #overFlowTabsMenu (closed)="onOverflowMenuClosed()">
   @for (i of ovf.overflow(); track i) {
     @let tab = tabs()[i];
     <button bitMenuItem type="button" [disabled]="tab.disabled()" (click)="selectTab(i)">

--- a/libs/components/src/tabs/tab-group/tab-group.component.html
+++ b/libs/components/src/tabs/tab-group/tab-group.component.html
@@ -49,8 +49,9 @@
     }
     <!--
       The More button sits inside the overflow list so it lands immediately after
-      the last visible tab in the flex flow. bitOverflowTrigger manages its own
-      visibility and aria-hidden state based on whether anything has overflowed.
+      the last visible tab in the flex flow. The list hides the trigger via the
+      `hidden` property when there's nothing to surface, which also takes it out
+      of focus and the accessibility tree.
     -->
     <button
       bitTabListItem

--- a/libs/components/src/tabs/tab-group/tab-group.component.spec.ts
+++ b/libs/components/src/tabs/tab-group/tab-group.component.spec.ts
@@ -329,6 +329,11 @@ describe("TabGroupComponent — keyboard navigation", () => {
 
     fixture = TestBed.createComponent(TestAppComponent);
     fixture.detectChanges();
+    // Flush the overflow list's post-render measurement microtask, then run CD
+    // again so the More button's `hidden` property is set and skipPredicate
+    // excludes it from the focus key manager — matching production timing.
+    await fixture.whenStable();
+    fixture.detectChanges();
 
     dispatchKey = (key: string, keyCode: number) => {
       const event = new KeyboardEvent("keydown", { key, keyCode, bubbles: true });

--- a/libs/components/src/tabs/tab-group/tab-group.component.ts
+++ b/libs/components/src/tabs/tab-group/tab-group.component.ts
@@ -10,6 +10,7 @@ import {
   input,
   model,
   output,
+  viewChild,
   viewChildren,
   inject,
   Injector,
@@ -89,6 +90,7 @@ export class TabGroupComponent implements AfterContentChecked, AfterViewInit {
 
   protected readonly tabs = contentChildren(TabComponent);
   readonly tabLabels = viewChildren(TabListItemDirective);
+  private readonly moreButton = viewChild("moreButton", { read: TabListItemDirective });
 
   /** The index of the active tab. Supports two-way binding via `[(selectedIndex)]`. */
   readonly selectedIndex = model(0);
@@ -156,6 +158,19 @@ export class TabGroupComponent implements AfterContentChecked, AfterViewInit {
 
   selectTab(index: number) {
     this.selectedIndex.set(index);
+  }
+
+  /**
+   * When the overflow menu closes, the CDK overlay restores focus to the More
+   * button trigger, but the key manager's active item points at the newly
+   * selected tab (set during `ngAfterContentChecked`). Realign the key manager
+   * to the trigger so the next arrow key behaves relative to where focus is.
+   */
+  protected onOverflowMenuClosed() {
+    const moreButton = this.moreButton();
+    if (moreButton) {
+      this.keyManager()?.updateActiveItem(moreButton);
+    }
   }
 
   /**

--- a/libs/components/src/tabs/tab-group/tab-group.component.ts
+++ b/libs/components/src/tabs/tab-group/tab-group.component.ts
@@ -23,7 +23,11 @@ import { I18nPipe } from "@bitwarden/ui-common";
 import { BerryComponent } from "../../berry";
 import { IconModule } from "../../icon";
 import { MenuModule } from "../../menu";
-import { OverflowItemDirective, OverflowListDirective } from "../../overflow-list";
+import {
+  OverflowItemDirective,
+  OverflowListDirective,
+  OverflowTriggerDirective,
+} from "../../overflow-list";
 import { TabHeaderComponent } from "../shared/tab-header.component";
 import {
   TAB_LIST_CONTAINER_GAP,
@@ -59,6 +63,7 @@ let nextId = 0;
     I18nPipe,
     OverflowListDirective,
     OverflowItemDirective,
+    OverflowTriggerDirective,
   ],
 })
 export class TabGroupComponent implements AfterContentChecked, AfterViewInit {

--- a/libs/components/src/tabs/tab-group/tab-group.component.ts
+++ b/libs/components/src/tabs/tab-group/tab-group.component.ts
@@ -195,14 +195,9 @@ export class TabGroupComponent implements AfterContentChecked, AfterViewInit {
       .withHorizontalOrientation("ltr")
       .withWrap()
       .withHomeAndEnd()
-      // Skip disabled items, items the overflow directive hid via [hidden], and the
-      // visibility-hidden More button (aria-hidden="true" while no overflow exists).
-      .skipPredicate(
-        (item) =>
-          item.disabled ||
-          item.elementRef.nativeElement.hidden ||
-          item.elementRef.nativeElement.getAttribute("aria-hidden") === "true",
-      );
+      // Skip disabled items and anything the overflow directive hid via [hidden]
+      // (overflowed tabs as well as the More button when there's nothing to surface).
+      .skipPredicate((item) => item.disabled || item.elementRef.nativeElement.hidden);
 
     km.updateActiveItem(this._selectedIndex() ?? 0);
 

--- a/libs/components/src/tabs/tab-nav-bar/tab-link.component.ts
+++ b/libs/components/src/tabs/tab-nav-bar/tab-link.component.ts
@@ -33,7 +33,7 @@ import { TabNavBarComponent } from "./tab-nav-bar.component";
   // bitOverflowList can discover this tab-link as one of its items.
   hostDirectives: [OverflowItemDirective],
   host: {
-    class: "tw-block",
+    class: "tw-block tw-max-w-fit",
     "[class]":
       "overflowItem.shouldShrink() ? 'tw-flex-1 tw-min-w-0 tw-overflow-hidden' : 'tw-shrink-0'",
   },

--- a/libs/components/src/tabs/tab-nav-bar/tab-nav-bar.component.html
+++ b/libs/components/src/tabs/tab-nav-bar/tab-nav-bar.component.html
@@ -33,7 +33,7 @@
   </nav>
 </bit-tab-header>
 
-<bit-menu #overflowTabsMenu>
+<bit-menu #overflowTabsMenu (closed)="onOverflowMenuClosed()">
   @for (i of ovf.overflow(); track i) {
     @let tab = tabLabels()[i];
     <a

--- a/libs/components/src/tabs/tab-nav-bar/tab-nav-bar.component.html
+++ b/libs/components/src/tabs/tab-nav-bar/tab-nav-bar.component.html
@@ -9,30 +9,27 @@
     [class.tw-invisible]="!ovf.ready()"
   >
     <ng-content></ng-content>
+    <!--
+      The More button sits inside the overflow list so it lands immediately after
+      the last visible tab in the flex flow. bitOverflowTrigger manages its own
+      visibility and aria-hidden state based on whether anything has overflowed.
+    -->
+    <button
+      #moreButton
+      bitTabListItem
+      bitOverflowTrigger
+      type="button"
+      class="tw-shrink-0"
+      tabindex="-1"
+      [bitMenuTriggerFor]="overflowTabsMenu"
+    >
+      <span [class]="tabLabelContentClasses">
+        {{ "more" | i18n }}
+        <bit-berry [value]="ovf.overflow().length" />
+        <bit-icon name="bwi-angle-down" class="tw-text-base" />
+      </span>
+    </button>
   </nav>
-  <!--
-    The More button lives outside the bitOverflowList so the directive only manages
-    its own row. It uses tw-invisible (not [hidden]) so its layout space is always
-    reserved — that keeps the directive's measured width stable across the
-    no-overflow / overflow transition and avoids a feedback loop.
-  -->
-  <button
-    #moreButton
-    bitTabListItem
-    type="button"
-    class="tw-shrink-0"
-    [class.tw-invisible]="ovf.overflow().length === 0"
-    [attr.aria-hidden]="ovf.overflow().length === 0 ? 'true' : null"
-    tabindex="-1"
-    [bitMenuTriggerFor]="overflowTabsMenu"
-    [style.marginInlineStart.px]="TAB_LIST_CONTAINER_GAP"
-  >
-    <span [class]="tabLabelContentClasses">
-      {{ "more" | i18n }}
-      <bit-berry [value]="ovf.overflow().length" />
-      <bit-icon name="bwi-angle-down" class="tw-text-base" />
-    </span>
-  </button>
 </bit-tab-header>
 
 <bit-menu #overflowTabsMenu>

--- a/libs/components/src/tabs/tab-nav-bar/tab-nav-bar.component.html
+++ b/libs/components/src/tabs/tab-nav-bar/tab-nav-bar.component.html
@@ -11,8 +11,9 @@
     <ng-content></ng-content>
     <!--
       The More button sits inside the overflow list so it lands immediately after
-      the last visible tab in the flex flow. bitOverflowTrigger manages its own
-      visibility and aria-hidden state based on whether anything has overflowed.
+      the last visible tab in the flex flow. The list hides the trigger via the
+      `hidden` property when there's nothing to surface, which also takes it out
+      of focus and the accessibility tree.
     -->
     <button
       #moreButton

--- a/libs/components/src/tabs/tab-nav-bar/tab-nav-bar.component.ts
+++ b/libs/components/src/tabs/tab-nav-bar/tab-nav-bar.component.ts
@@ -82,14 +82,9 @@ export class TabNavBarComponent implements AfterViewInit {
       .withHorizontalOrientation("ltr")
       .withWrap()
       .withHomeAndEnd()
-      // Skip disabled items, items the overflow directive hid via [hidden], and the
-      // visibility-hidden More button (aria-hidden="true" while no overflow exists).
-      .skipPredicate(
-        (item) =>
-          item.disabled ||
-          item.elementRef.nativeElement.hidden ||
-          item.elementRef.nativeElement.getAttribute("aria-hidden") === "true",
-      );
+      // Skip disabled items and anything the overflow directive hid via [hidden]
+      // (overflowed tabs as well as the More button when there's nothing to surface).
+      .skipPredicate((item) => item.disabled || item.elementRef.nativeElement.hidden);
 
     this.keyManager.set(km);
     // Seed roving tabindex now that tab-links have populated their isActive signals.

--- a/libs/components/src/tabs/tab-nav-bar/tab-nav-bar.component.ts
+++ b/libs/components/src/tabs/tab-nav-bar/tab-nav-bar.component.ts
@@ -19,7 +19,7 @@ import { I18nPipe } from "@bitwarden/ui-common";
 import { BerryComponent } from "../../berry";
 import { IconModule } from "../../icon";
 import { MenuModule } from "../../menu";
-import { OverflowListDirective } from "../../overflow-list";
+import { OverflowListDirective, OverflowTriggerDirective } from "../../overflow-list";
 import { TabHeaderComponent } from "../shared/tab-header.component";
 import {
   TAB_LIST_CONTAINER_GAP,
@@ -46,6 +46,7 @@ import { TabLinkComponent } from "./tab-link.component";
     MenuModule,
     I18nPipe,
     OverflowListDirective,
+    OverflowTriggerDirective,
   ],
 })
 export class TabNavBarComponent implements AfterViewInit {

--- a/libs/components/src/tabs/tab-nav-bar/tab-nav-bar.component.ts
+++ b/libs/components/src/tabs/tab-nav-bar/tab-nav-bar.component.ts
@@ -91,6 +91,16 @@ export class TabNavBarComponent implements AfterViewInit {
     this.updateActiveLink();
   }
 
+  /**
+   * When the overflow menu closes, the CDK overlay restores focus to the More
+   * button trigger, but the key manager's active item points at the newly
+   * active route (set during `updateActiveLink`). Realign the key manager to
+   * the trigger so the next arrow key behaves relative to where focus is.
+   */
+  protected onOverflowMenuClosed() {
+    this.keyManager()?.updateActiveItem(this.moreButtonItem());
+  }
+
   updateActiveLink() {
     const items = this.tabLabels();
     if (items.length === 0) {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/CL-1203

## 📔 Objective

In both `bit-tab-group` and `bit-tab-nav-bar`, the "More" overflow button was rendered at the far-right of the tab header, separated from the tabs by a wide gap. This PR places the More button immediately after the last visible tab and tightens a few related behaviors that came out of the design change.

### `bitOverflowTrigger`

A new directive that marks an element as the trailing affordance of a `[bitOverflowList]`. The list discovers it via `contentChild`, measures its width once at first render, and subtracts that (plus a gap) from the space available to items when packing. The directive also exposes its `elementRef` so the list can toggle its `hidden` property — same mechanism it already uses for overflowed items, which means we drop the previous `visibility: hidden` + `aria-hidden` host bindings and the trigger participates in focus and the accessibility tree on identical terms.

### Trigger only consumes space when needed

The pack decision checks total item width against the *full* container width first. If everything fits without the trigger, we return all-displayed — otherwise we'd be hiding an item just to reserve room for the affordance that would summon it back.

### Focus management on overflow menu close

When a user picks an item from the overflow menu, selection logic moves the focus key manager's active item to the newly selected tab. CDK's overlay simultaneously restores DOM focus to the trigger. The next arrow key would jump from the trigger past the just-reintroduced item. Both consumers now realign the key manager to the trigger on menu close, so navigation continues from where focus actually is.

### Tab item width

Tab item host classes pick up `tw-max-w-fit` so each tab caps at its content width rather than stretching.

## 📸 Screenshots

- [ ] Tab group with all tabs visible (no overflow) — More button hidden, tabs left-aligned
- [ ] Tab group with overflow — More button immediately after the last visible tab
- [ ] Tab nav bar equivalent of both states
- [ ] Lone-tab truncation state (single tab visible with many in overflow)
- [ ] Keyboard navigation: arrow keys after selecting an overflow item land on adjacent visible tabs