### PR TITLE
[PM-35196] pass addedElements to checkForNewShadowRoots

### DIFF
--- a/apps/browser/src/autofill/services/abstractions/dom-query.service.ts
+++ b/apps/browser/src/autofill/services/abstractions/dom-query.service.ts
@@ -8,7 +8,7 @@ export interface DomQueryService {
   ): T[];
   updatePageContainsShadowDom(): boolean;
   checkMutationsInShadowRoots(mutations: MutationRecord[]): boolean;
-  checkForNewShadowRoots(): boolean;
+  checkForNewShadowRoots(addedElements?: Element[]): boolean;
   resetObservedShadowRoots(): void;
   queryDeepSelector(selector: string): Element | null;
 }

--- a/apps/browser/src/autofill/services/collect-autofill-content.service.ts
+++ b/apps/browser/src/autofill/services/collect-autofill-content.service.ts
@@ -61,6 +61,7 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
   private readonly overlaySetupDelayMs = 100;
   private shadowDomCheckTimeout: NodeJS.Timeout | number | null = null;
   private pendingShadowDomCheck = false;
+  private pendingMutationAddedElements: Element[] = [];
   private ownedExperienceTagNames: string[] = [];
   private readonly updateAfterMutationTimeout = 1000;
   private readonly shadowDomCheckTimeoutMs = 500;
@@ -1233,6 +1234,17 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
       this.debouncedRequirePageDetailsUpdate();
     }
 
+    // Collect added elements from this mutation batch so that the shadow DOM
+    // check can inspect only the newly-added subtrees instead of rescanning the
+    // entire document (performance fix for large DOMs).
+    for (const mutation of mutations) {
+      for (const node of mutation.addedNodes ?? []) {
+        if (node instanceof Element) {
+          this.pendingMutationAddedElements.push(node);
+        }
+      }
+    }
+
     if (!this.pendingShadowDomCheck) {
       this.pendingShadowDomCheck = true;
 
@@ -1243,6 +1255,7 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
       this.shadowDomCheckTimeout = setTimeout(() => {
         this.handleNewShadowRoots();
         this.pendingShadowDomCheck = false;
+        this.pendingMutationAddedElements = [];
       }, this.shadowDomCheckTimeoutMs);
     }
 
@@ -1337,7 +1350,9 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
    * @private
    */
   private handleNewShadowRoots = () => {
-    const hasNewShadowRoots = this.domQueryService.checkForNewShadowRoots();
+    const hasNewShadowRoots = this.domQueryService.checkForNewShadowRoots(
+      this.pendingMutationAddedElements,
+    );
     if (hasNewShadowRoots) {
       this.debouncedRequirePageDetailsUpdate();
     }

--- a/apps/browser/src/autofill/services/dom-query.service.ts
+++ b/apps/browser/src/autofill/services/dom-query.service.ts
@@ -121,7 +121,7 @@ export class DomQueryService implements DomQueryServiceInterface {
    * This is an expensive operation that should be debounced.
    * @returns True if any new shadow roots are found that aren't being observed
    */
-  checkForNewShadowRoots = (): boolean => {
+  checkForNewShadowRoots = (addedElements?: Element[]): boolean => {
     // Short-circuit: if we have already confirmed the page has no shadow DOM,
     // skip the expensive querySelectorAll(":defined") + getShadowRoot scan entirely.
     // FIXME: this disables all checks after the page initializes; introduce a
@@ -130,6 +130,27 @@ export class DomQueryService implements DomQueryServiceInterface {
       return false;
     }
 
+    // When added elements are provided (from a mutation batch), only check those
+    // elements and their descendants instead of scanning the entire document.
+    // This reduces the number of chrome.dom.openOrClosedShadowRoot() calls from
+    // potentially hundreds of thousands to typically 1–10 per mutation batch.
+    if (addedElements && addedElements.length > 0) {
+      for (const el of addedElements) {
+        const root = this.getShadowRoot(el);
+        if (root && !this.observedShadowRoots.has(root)) {
+          return true;
+        }
+        for (const child of el.querySelectorAll("*")) {
+          const childRoot = this.getShadowRoot(child);
+          if (childRoot && !this.observedShadowRoots.has(childRoot)) {
+            return true;
+          }
+        }
+      }
+      return false;
+    }
+
+    // Full scan fallback when no specific elements are provided.
     let currentRoots: ShadowRoot[];
     try {
       currentRoots = this.recursivelyQueryShadowRoots(globalThis.document.body);


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-37687
https://bitwarden.atlassian.net/browse/PM-35196

## 📔 Objective

`checkForNewShadowRoots()` was scanning the entire DOM every 500ms on pages with shadow DOM, calling `chrome.dom.openOrClosedShadowRoot()` on every candidate element (div, span, section, etc.). This is a cross-process extension API call that consumed 63% of main thread time per invocation. This fix passes only the nodes added in the triggering mutation to the scan, reducing the check from O(all DOM elements) to O(added nodes).

New shadow roots attached to pre-existing elements without   accompanying DOM insertions may not be detected until the next full-scan fallback fires. I am not sure if this is a case we are considering.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
