### PR TITLE
[PM-37725] Fix: CLI asks for master password even when valid session key provided

### DIFF
--- a/apps/cli/src/bw.ts
+++ b/apps/cli/src/bw.ts
@@ -6,46 +6,9 @@ import { OssServeConfigurator } from "./oss-serve-configurator";
 import { registerOssPrograms } from "./register-oss-programs";
 import { ServeProgram } from "./serve.program";
 import { ServiceContainer } from "./service-container/service-container";
+import { applyEarlyProcessEnvFlags } from "./utils";
 
-export function applyEarlyProcessEnvFlags(argv: string[]) {
-  for (let index = 0; index < argv.length; index++) {
-    const arg = argv[index];
-
-    switch (arg) {
-      case "--pretty":
-        process.env.BW_PRETTY = "true";
-        break;
-      case "--raw":
-        process.env.BW_RAW = "true";
-        break;
-      case "--response":
-        process.env.BW_RESPONSE = "true";
-        break;
-      case "--cleanexit":
-        process.env.BW_CLEANEXIT = "true";
-        break;
-      case "--quiet":
-        process.env.BW_QUIET = "true";
-        break;
-      case "--nointeraction":
-        process.env.BW_NOINTERACTION = "true";
-        break;
-      case "--session":
-        if (index + 1 < argv.length) {
-          process.env.BW_SESSION = argv[index + 1];
-          index++;
-        }
-        break;
-      default:
-        if (arg.startsWith("--session=")) {
-          process.env.BW_SESSION = arg.slice("--session=".length);
-        }
-        break;
-    }
-  }
-}
-
-export async function main() {
+async function main() {
   applyEarlyProcessEnvFlags(process.argv.slice(2));
 
   const serviceContainer = new ServiceContainer();

--- a/apps/cli/src/bw.ts
+++ b/apps/cli/src/bw.ts
@@ -7,7 +7,47 @@ import { registerOssPrograms } from "./register-oss-programs";
 import { ServeProgram } from "./serve.program";
 import { ServiceContainer } from "./service-container/service-container";
 
-async function main() {
+export function applyEarlyProcessEnvFlags(argv: string[]) {
+  for (let index = 0; index < argv.length; index++) {
+    const arg = argv[index];
+
+    switch (arg) {
+      case "--pretty":
+        process.env.BW_PRETTY = "true";
+        break;
+      case "--raw":
+        process.env.BW_RAW = "true";
+        break;
+      case "--response":
+        process.env.BW_RESPONSE = "true";
+        break;
+      case "--cleanexit":
+        process.env.BW_CLEANEXIT = "true";
+        break;
+      case "--quiet":
+        process.env.BW_QUIET = "true";
+        break;
+      case "--nointeraction":
+        process.env.BW_NOINTERACTION = "true";
+        break;
+      case "--session":
+        if (index + 1 < argv.length) {
+          process.env.BW_SESSION = argv[index + 1];
+          index++;
+        }
+        break;
+      default:
+        if (arg.startsWith("--session=")) {
+          process.env.BW_SESSION = arg.slice("--session=".length);
+        }
+        break;
+    }
+  }
+}
+
+export async function main() {
+  applyEarlyProcessEnvFlags(process.argv.slice(2));
+
   const serviceContainer = new ServiceContainer();
   await serviceContainer.init();
 

--- a/apps/cli/src/utils.ts
+++ b/apps/cli/src/utils.ts
@@ -290,3 +290,46 @@ export async function firstValueFromOrNull<T>(
 ): Promise<T | null> {
   return firstValueFrom(observable.pipe(timeout({ first: timeoutMs, with: () => of(null) })));
 }
+
+/**
+ * Pre-scans argv and sets process.env flags before Commander parses arguments.
+ * This ensures env-driven features (BW_SESSION, BW_RAW, etc.) are available
+ * during ServiceContainer initialization, which happens before Commander runs.
+ */
+export function applyEarlyProcessEnvFlags(argv: string[]) {
+  for (let index = 0; index < argv.length; index++) {
+    const arg = argv[index];
+
+    switch (arg) {
+      case "--pretty":
+        process.env.BW_PRETTY = "true";
+        break;
+      case "--raw":
+        process.env.BW_RAW = "true";
+        break;
+      case "--response":
+        process.env.BW_RESPONSE = "true";
+        break;
+      case "--cleanexit":
+        process.env.BW_CLEANEXIT = "true";
+        break;
+      case "--quiet":
+        process.env.BW_QUIET = "true";
+        break;
+      case "--nointeraction":
+        process.env.BW_NOINTERACTION = "true";
+        break;
+      case "--session":
+        if (index + 1 < argv.length) {
+          process.env.BW_SESSION = argv[index + 1];
+          index++;
+        }
+        break;
+      default:
+        if (arg.startsWith("--session=")) {
+          process.env.BW_SESSION = arg.slice("--session=".length);
+        }
+        break;
+    }
+  }
+}

--- a/bitwarden_license/bit-cli/src/bw.ts
+++ b/bitwarden_license/bit-cli/src/bw.ts
@@ -2,6 +2,7 @@ import "core-js/proposals/explicit-resource-management";
 
 import { program } from "commander";
 
+import { applyEarlyProcessEnvFlags } from "@bitwarden/cli/bw";
 import { registerOssPrograms } from "@bitwarden/cli/register-oss-programs";
 import { ServeProgram } from "@bitwarden/cli/serve.program";
 
@@ -10,6 +11,8 @@ import { registerBitPrograms } from "./register-bit-programs";
 import { ServiceContainer } from "./service-container";
 
 async function main() {
+  applyEarlyProcessEnvFlags(process.argv.slice(2));
+
   const serviceContainer = new ServiceContainer();
   await serviceContainer.init();
 

--- a/bitwarden_license/bit-cli/src/bw.ts
+++ b/bitwarden_license/bit-cli/src/bw.ts
@@ -2,9 +2,9 @@ import "core-js/proposals/explicit-resource-management";
 
 import { program } from "commander";
 
-import { applyEarlyProcessEnvFlags } from "@bitwarden/cli/bw";
 import { registerOssPrograms } from "@bitwarden/cli/register-oss-programs";
 import { ServeProgram } from "@bitwarden/cli/serve.program";
+import { applyEarlyProcessEnvFlags } from "@bitwarden/cli/utils";
 
 import { BitServeConfigurator } from "./bit-serve-configurator";
 import { registerBitPrograms } from "./register-bit-programs";


### PR DESCRIPTION
## 🎟️ Tracking

Seems related to #9067
Fixes #20703
Fixes #20705

## 📔 Objective

### Problem

The CLI ignores both `$BW_SESSION` and `--session` on `bw` commands. So, it always asks for the master password, even when `--session` has a valid session key or `$BW_SESSION` has a valid session key.

The problem is the CLI attempts to do an unlock restore before evaluating either the session key variables or the `--session` flag. This causes the master password prompt to show before those are even considered.

### Solution

This PR moves those evaluations up earlier in the process, before the unlock restore is attempted. This ensures that any session keys from the shell are now available to the unlock session restore operation.

## Sidenote

This is my first PR on BitWarden, so I'm not super familiar with the project yet. 

**Reviewers:** double-check my CLI string manipulation seems reasonable: `process.argv.slice(2)`

I usually prefer robust libraries like Commander for argument parsing (which `bw` already uses). But, right now the BW CLI is setup such that the initialization of the `ServiceContainer` causes the bug, and Commander only runs as part of the `ServiceContainer` initialization. So, I don't see an obvious way to move the Commander CLI parsing up earlier in the process without more substantial refactoring.

I've not dug into what the exact regression was that caused this bug. So while this provides a working patch, a better alternative may be to pin-point the regression that caused the bug.

#20703 has a hypothesis on what the deeper issue is.

## Testing

I confirmed the bug was still happening for me on the latest source code: `2026.5.0`

I tested both setting setting a `$BW_SESSION` env variable and using `--session` to confirm commands like `bw get` now work with the patch.

### How to reproduce the bug (on `2026.4.1`)

**`$BW_SESSION` variable:**

```bash
export BW_SESSION="$(bw unlock --raw)"
# That command will show the interactive prompt to enter the master password
bw get item <ITEM_ID>
# The `bw get` should NOT show a master password prompt, but on 2026.4.1, it will.
```

**`--session` flag:**

```bash
BWS="$(bw unlock --raw)"
# That command will show the interactive prompt to enter the master password
bw get item <ITEM_ID> --session $BWS
# The `bw get` should NOT show a master password prompt, but on 2026.4.1, it will.
```

### How to test that this PR fixes it

**`$BW_SESSION` variable:**

```bash
export BW_SESSION="$(bw unlock --raw)"
# That command will show the interactive prompt to enter the master password
bw get item <ITEM_ID>
# The `bw get` should NOT show a master password prompt. It should successfully return the item. This confirms that the fix is working.
```

**`--session` flag:**

```bash
BWS="$(bw unlock --raw)"
# That command will show the interactive prompt to enter the master password
bw get item <ITEM_ID> --session $BWS
# The `bw get` should NOT show a master password prompt. It should successfully return the item. This confirms that the fix is working.
```