### PR TITLE
[PM-377730] Refactor unlock service & add decrypted user key method

### DIFF
--- a/libs/unlock/src/default-unlock.service.spec.ts
+++ b/libs/unlock/src/default-unlock.service.spec.ts
@@ -42,6 +42,7 @@ const mockMasterPasswordUnlockData = { some: "unlockData", salt: "salt", kdf: "p
 describe("DefaultUnlockService", () => {
   const registerSdkService = mock<RegisterSdkService>();
   const accountCryptographicStateService = mock<AccountCryptographicStateService>();
+  const pinStateService = mock<PinStateServiceAbstraction>();
   const kdfService = mock<KdfConfigService>();
   const accountService = mock<AccountService>();
   const masterPasswordService = mock<InternalMasterPasswordServiceAbstraction>();
@@ -51,7 +52,6 @@ describe("DefaultUnlockService", () => {
   const biometricsService = mock<BiometricsService>();
   const platformUtilsService = mock<PlatformUtilsService>();
   const biometricStateService = mock<BiometricStateService>();
-  const pinStateService = mock<PinStateServiceAbstraction>();
 
   let service: DefaultUnlockService;
   let mockSdkRef: any;

--- a/libs/unlock/src/default-unlock.service.spec.ts
+++ b/libs/unlock/src/default-unlock.service.spec.ts
@@ -42,7 +42,6 @@ const mockMasterPasswordUnlockData = { some: "unlockData", salt: "salt", kdf: "p
 describe("DefaultUnlockService", () => {
   const registerSdkService = mock<RegisterSdkService>();
   const accountCryptographicStateService = mock<AccountCryptographicStateService>();
-  const pinStateService = mock<PinStateServiceAbstraction>();
   const kdfService = mock<KdfConfigService>();
   const accountService = mock<AccountService>();
   const masterPasswordService = mock<InternalMasterPasswordServiceAbstraction>();
@@ -52,6 +51,7 @@ describe("DefaultUnlockService", () => {
   const biometricsService = mock<BiometricsService>();
   const platformUtilsService = mock<PlatformUtilsService>();
   const biometricStateService = mock<BiometricStateService>();
+  const pinStateService = mock<PinStateServiceAbstraction>();
 
   let service: DefaultUnlockService;
   let mockSdkRef: any;

--- a/libs/unlock/src/default-unlock.service.ts
+++ b/libs/unlock/src/default-unlock.service.ts
@@ -141,7 +141,12 @@ export class DefaultUnlockService implements UnlockService {
         decrypted_user_key: userKey.toSdk(),
       },
     });
-    this.logService.measure(startTime, "Unlock", "DefaultUnlockService", "unlockWithDecryptedUserKey");
+    this.logService.measure(
+      startTime,
+      "Unlock",
+      "DefaultUnlockService",
+      "unlockWithDecryptedUserKey",
+    );
   }
 
   private async unlockWithMethod(userId: UserId, method: InitUserCryptoMethod): Promise<void> {

--- a/libs/unlock/src/default-unlock.service.ts
+++ b/libs/unlock/src/default-unlock.service.ts
@@ -135,14 +135,14 @@ export class DefaultUnlockService implements UnlockService {
     this.logService.measure(startTime, "Unlock", "DefaultUnlockService", "unlockWithKeyConnector");
   }
 
-  async unlockWithDecryptedKey(userId: UserId, key: SymmetricKey): Promise<void> {
+  async unlockWithDecryptedUserKey(userId: UserId, userKey: SymmetricCryptoKey): Promise<void> {
     const startTime = performance.now();
     await this.unlockWithMethod(userId, {
       decryptedKey: {
-        decrypted_user_key: key,
+        decrypted_user_key: userKey.toSdk(),
       },
     });
-    this.logService.measure(startTime, "Unlock", "DefaultUnlockService", "unlockWithDecryptedKey");
+    this.logService.measure(startTime, "Unlock", "DefaultUnlockService", "unlockWithDecryptedUserKey");
   }
 
   private async unlockWithMethod(userId: UserId, method: InitUserCryptoMethod): Promise<void> {

--- a/libs/unlock/src/default-unlock.service.ts
+++ b/libs/unlock/src/default-unlock.service.ts
@@ -28,11 +28,13 @@ import {
 import { LogService } from "@bitwarden/logging";
 import {
   EncString,
+  InitUserCryptoMethod,
   Kdf,
   MasterPasswordUnlockData,
   PasswordManagerClient,
   PasswordProtectedKeyEnvelope,
   PureCrypto,
+  SymmetricKey,
   WrappedAccountCryptographicState,
 } from "@bitwarden/sdk-internal";
 import { StateProvider, StateService } from "@bitwarden/state";
@@ -69,57 +71,23 @@ export class DefaultUnlockService implements UnlockService {
 
   async unlockWithPin(userId: UserId, pin: string): Promise<void> {
     const startTime = performance.now();
-    await firstValueFrom(
-      this.registerSdkService.registerClient$(userId).pipe(
-        map(async (sdk) => {
-          if (!sdk) {
-            throw new Error("SDK not available");
-          }
-          using ref = sdk.take();
-          await ref.value.crypto().initialize_user_crypto({
-            userId: asUuid(userId),
-            kdfParams: await this.getKdfParams(userId),
-            email: await this.getEmail(userId)!,
-            accountCryptographicState: await this.getAccountCryptographicState(userId),
-            method: {
-              pinEnvelope: {
-                pin: pin,
-                pin_protected_user_key_envelope: await this.getPinProtectedUserKeyEnvelope(userId),
-              },
-            },
-          });
-          await this.runOnUnlockSideEffects(userId, ref);
-        }),
-      ),
-    );
+    await this.unlockWithMethod(userId, {
+      pinEnvelope: {
+        pin,
+        pin_protected_user_key_envelope: await this.getPinProtectedUserKeyEnvelope(userId),
+      },
+    });
     this.logService.measure(startTime, "Unlock", "DefaultUnlockService", "unlockWithPin");
   }
 
   async unlockWithMasterPassword(userId: UserId, masterPassword: string): Promise<void> {
     const startTime = performance.now();
-    await firstValueFrom(
-      this.registerSdkService.registerClient$(userId).pipe(
-        map(async (sdk) => {
-          if (!sdk) {
-            throw new Error("SDK not available");
-          }
-          using ref = sdk.take();
-          await ref.value.crypto().initialize_user_crypto({
-            userId: asUuid(userId),
-            kdfParams: await this.getKdfParams(userId),
-            email: await this.getEmail(userId),
-            accountCryptographicState: await this.getAccountCryptographicState(userId),
-            method: {
-              masterPasswordUnlock: {
-                password: masterPassword,
-                master_password_unlock: await this.getMasterPasswordUnlockData(userId),
-              },
-            },
-          });
-          await this.runOnUnlockSideEffects(userId, ref);
-        }),
-      ),
-    );
+    await this.unlockWithMethod(userId, {
+      masterPasswordUnlock: {
+        password: masterPassword,
+        master_password_unlock: await this.getMasterPasswordUnlockData(userId),
+      },
+    });
     await this.setLegacyMasterKeyFromUnlockData(
       masterPassword,
       await this.getMasterPasswordUnlockData(userId),
@@ -142,28 +110,11 @@ export class DefaultUnlockService implements UnlockService {
 
     // Now that we have the biometrics-protected user key, we can initialize the SDK with it to complete the unlock process.
     const startTime = performance.now();
-    await firstValueFrom(
-      this.registerSdkService.registerClient$(userId).pipe(
-        map(async (sdk) => {
-          if (!sdk) {
-            throw new Error("SDK not available");
-          }
-          using ref = sdk.take();
-          await ref.value.crypto().initialize_user_crypto({
-            userId: asUuid(userId),
-            kdfParams: await this.getKdfParams(userId),
-            email: await this.getEmail(userId),
-            accountCryptographicState: await this.getAccountCryptographicState(userId),
-            method: {
-              decryptedKey: {
-                decrypted_user_key: userKey.toBase64(),
-              },
-            },
-          });
-          await this.runOnUnlockSideEffects(userId, ref);
-        }),
-      ),
-    );
+    await this.unlockWithMethod(userId, {
+      decryptedKey: {
+        decrypted_user_key: userKey.toSdk(),
+      },
+    });
     this.logService.measure(startTime, "Unlock", "DefaultUnlockService", "unlockWithBiometrics");
   }
 
@@ -175,30 +126,47 @@ export class DefaultUnlockService implements UnlockService {
     // key-connector-unlock-data. It will unwrap the provided key and set it to state, unlocking
     // the vault.
     const startTime = performance.now();
+    await this.unlockWithMethod(userId, {
+      keyConnectorUrl: {
+        url: keyConnectorUnlockData.url,
+        key_connector_key_wrapped_user_key: keyConnectorUnlockData.keyConnectorKeyWrappedUserKey,
+      },
+    });
+    this.logService.measure(startTime, "Unlock", "DefaultUnlockService", "unlockWithKeyConnector");
+  }
+
+  async unlockWithDecryptedKey(userId: UserId, key: SymmetricKey): Promise<void> {
+    const startTime = performance.now();
+    await this.unlockWithMethod(userId, {
+      decryptedKey: {
+        decrypted_user_key: key,
+      },
+    });
+    this.logService.measure(startTime, "Unlock", "DefaultUnlockService", "unlockWithDecryptedKey");
+  }
+
+  private async unlockWithMethod(userId: UserId, method: InitUserCryptoMethod): Promise<void> {
     await firstValueFrom(
       this.registerSdkService.registerClient$(userId).pipe(
         map(async (sdk) => {
           if (!sdk) {
             throw new Error("SDK not available");
           }
+
           using ref = sdk.take();
-          return ref.value.crypto().initialize_user_crypto({
+
+          await ref.value.crypto().initialize_user_crypto({
             userId: asUuid(userId),
             kdfParams: await this.getKdfParams(userId),
             email: await this.getEmail(userId),
             accountCryptographicState: await this.getAccountCryptographicState(userId),
-            method: {
-              keyConnectorUrl: {
-                url: keyConnectorUnlockData.url,
-                key_connector_key_wrapped_user_key:
-                  keyConnectorUnlockData.keyConnectorKeyWrappedUserKey,
-              },
-            },
+            method,
           });
+
+          await this.runOnUnlockSideEffects(userId, ref);
         }),
       ),
     );
-    this.logService.measure(startTime, "Unlock", "DefaultUnlockService", "unlockWithKeyConnector");
   }
 
   private async getAccountCryptographicState(

--- a/libs/unlock/src/default-unlock.service.ts
+++ b/libs/unlock/src/default-unlock.service.ts
@@ -34,7 +34,6 @@ import {
   PasswordManagerClient,
   PasswordProtectedKeyEnvelope,
   PureCrypto,
-  SymmetricKey,
   WrappedAccountCryptographicState,
 } from "@bitwarden/sdk-internal";
 import { StateProvider, StateService } from "@bitwarden/state";

--- a/libs/unlock/src/unlock.service.ts
+++ b/libs/unlock/src/unlock.service.ts
@@ -1,4 +1,5 @@
 import { UserId } from "@bitwarden/common/types/guid";
+import { SymmetricKey } from "@bitwarden/sdk-internal";
 
 import { KeyConnectorUnlockData } from "./default-unlock.service";
 
@@ -45,4 +46,15 @@ export abstract class UnlockService {
     userId: UserId,
     keyConnectorUnlockData: KeyConnectorUnlockData,
   ): Promise<void>;
+
+  /**
+   * Unlocks the user's account with a decrypted user key
+   * Note: Where possible use other unlock methods.
+   *
+   * @param userId - The user's id
+   * @param userKey - The decrypted user key to unlock with
+   * @throws If the SDK is not available
+   * @throws If decryption fails or the key is invalid
+   */
+  abstract unlockWithDecryptedKey(userId: UserId, userKey: SymmetricKey): Promise<void>;
 }

--- a/libs/unlock/src/unlock.service.ts
+++ b/libs/unlock/src/unlock.service.ts
@@ -1,7 +1,7 @@
+import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
 import { UserId } from "@bitwarden/common/types/guid";
 
 import { KeyConnectorUnlockData } from "./default-unlock.service";
-import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
 
 /**
  * Service for unlocking a user's account with various methods.

--- a/libs/unlock/src/unlock.service.ts
+++ b/libs/unlock/src/unlock.service.ts
@@ -1,5 +1,4 @@
 import { UserId } from "@bitwarden/common/types/guid";
-import { SymmetricKey } from "@bitwarden/sdk-internal";
 
 import { KeyConnectorUnlockData } from "./default-unlock.service";
 import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";

--- a/libs/unlock/src/unlock.service.ts
+++ b/libs/unlock/src/unlock.service.ts
@@ -2,6 +2,7 @@ import { UserId } from "@bitwarden/common/types/guid";
 import { SymmetricKey } from "@bitwarden/sdk-internal";
 
 import { KeyConnectorUnlockData } from "./default-unlock.service";
+import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
 
 /**
  * Service for unlocking a user's account with various methods.
@@ -56,5 +57,5 @@ export abstract class UnlockService {
    * @throws If the SDK is not available
    * @throws If decryption fails or the key is invalid
    */
-  abstract unlockWithDecryptedKey(userId: UserId, userKey: SymmetricKey): Promise<void>;
+  abstract unlockWithDecryptedUserKey(userId: UserId, userKey: SymmetricCryptoKey): Promise<void>;
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-37730

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Mostly a refactor of the unlock service, consolidating the implementations to make them more readable and maintainable.

Non refactor changes:
- Add the decrypted user key unlock method
  - This is temporary until we stop disposing password manager clients and will be used by shared unlock, biometric unlock
- KC now runs the unlock side effects, there is a comment as to why this is okay

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
