### PR TITLE
[PM-37738] fix(cli): mask client_secret prompt during apikey login

### DIFF
--- a/apps/cli/src/auth/commands/login.command.ts
+++ b/apps/cli/src/auth/commands/login.command.ts
@@ -507,7 +507,7 @@ export class LoginCommand {
         const answer: inquirer.Answers = await inquirer.createPromptModule({
           output: process.stderr,
         })({
-          type: "input",
+          type: "password",
           name: "clientSecret",
           message:
             (isAdditionalAuthentication ? additionalAuthenticationMessage : "") + "client_secret:",

--- a/apps/cli/src/auth/commands/login.command.ts
+++ b/apps/cli/src/auth/commands/login.command.ts
@@ -511,7 +511,7 @@ export class LoginCommand {
         const answer: inquirer.Answers = await inquirer.createPromptModule({
           output: process.stderr,
         })({
-          type: "input",
+          type: "password",
           name: "clientSecret",
           message:
             (isAdditionalAuthentication ? additionalAuthenticationMessage : "") + "client_secret:",


### PR DESCRIPTION
## Summary
Fixes #11206. The interactive `client_secret:` prompt in `bw login --apikey` used inquirer's `type: "input"`, which echoes keystrokes to the terminal as the user types. This causes the API key secret to appear in:

- terminal scrollback (visible to anyone attaching to the same `tmux`/`screen` session, or reading `/proc/<pid>/fd/0`)
- screen-share sessions and recorded screencasts (`script(1)`, `asciinema`)
- shoulder-surfing during demos / conferences / pair programming
- tooling that captures stderr (the prompt is written there — see [`apiClientSecret()`](https://github.com/bitwarden/clients/blob/main/apps/cli/src/auth/commands/login.command.ts#L505-L518))

A Bitwarden API key's `client_secret` grants the same vault access as the master password for that user, so it should receive the same protection.

## Change
One-line fix: change `type: "input"` to `type: "password"` in `apiClientSecret()`. This matches the master-password prompt 350 lines above in the same file (`login.command.ts:147`) and the treatment of every other secret prompt in the CLI (`export.command.ts:125`, `import.command.ts:131`, `send/commands/receive.command.ts:292`, `utils.ts:240`).

```diff
- type: "input",
+ type: "password",
  name: "clientSecret",
  message: (isAdditionalAuthentication ? additionalAuthenticationMessage : "") + "client_secret:",
```

## Audit
I checked every remaining `type: "input"` prompt in `apps/cli` to confirm none had the same issue. All prompt for non-secret values:
- `login.command.ts:124` — email address
- `login.command.ts:318` — 2FA TOTP code (short-lived, conventionally echoed)
- `login.command.ts:342` — new-device OTP (short-lived)
- `login.command.ts:485` — `client_id` (not a secret, equivalent to a username per the API key docs)
- `send/commands/receive.command.ts:200` — Send recipient OTP
- `send/commands/receive.command.ts:209` — recipient email

No other prompts need to change.

## Verification
Reproduced the bug and verified the fix using a `pty.fork()` harness that feeds a known marker string as `client_secret` and greps the raw terminal capture:

| | Before | After |
|---|---|---|
| Prompt rendered as | `client_secret: SECRETXYZ999` (char-by-char) | `client_secret: [input is hidden]` |
| Marker visible in capture | `True` | `False` |

The 43 existing tests in `apps/cli/src/auth/commands/login.command.spec.ts` all pass — `apiClientSecret()` isn't exercised interactively in the spec (the suite sets `BW_NOINTERACTION=true`), so this change has no test-suite delta. Happy to add a regression test that mocks `inquirer.createPromptModule` if reviewers prefer.

## Test plan
- [ ] `bw login --apikey` (no `BW_CLIENTSECRET` env var set, in an interactive terminal): typing the secret should render as `[input is hidden]`, not echo the characters.
- [ ] `BW_CLIENTID=user.xxx BW_CLIENTSECRET=yyy bw login --apikey` (env-var path): unaffected, login completes as before.
- [ ] Master-password login path (`bw login email password`): unaffected.