### PR TITLE
[PM-37755] [PM-37694] Persist new session key after bw unlock --raw

### DIFF
--- a/apps/cli/src/base-program.ts
+++ b/apps/cli/src/base-program.ts
@@ -184,6 +184,7 @@ export abstract class BaseProgram {
         this.serviceContainer.masterPasswordUnlockService,
         this.serviceContainer.unlockService,
         this.serviceContainer.configService,
+        this.serviceContainer.userAutoUnlockKeyService,
       );
       const response = await command.run(null, null);
       if (!response.success) {

--- a/apps/cli/src/key-management/commands/unlock.command.spec.ts
+++ b/apps/cli/src/key-management/commands/unlock.command.spec.ts
@@ -11,6 +11,7 @@ import { ConfigService } from "@bitwarden/common/platform/abstractions/config/co
 import { EnvironmentService } from "@bitwarden/common/platform/abstractions/environment.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
+import { UserAutoUnlockKeyService } from "@bitwarden/common/platform/services/user-auto-unlock-key.service";
 import { mockAccountInfoWith } from "@bitwarden/common/spec";
 import { CsprngArray } from "@bitwarden/common/types/csprng";
 import { UserKey } from "@bitwarden/common/types/key";
@@ -41,6 +42,7 @@ describe("UnlockCommand", () => {
   const masterPasswordUnlockService = mock<MasterPasswordUnlockService>();
   const unlockService = mock<UnlockService>();
   const configService = mock<ConfigService>();
+  const userAutoUnlockKeyService = mock<UserAutoUnlockKeyService>();
 
   const mockMasterPassword = "testExample";
   const activeAccount: Account = {
@@ -77,6 +79,7 @@ describe("UnlockCommand", () => {
     keyConnectorService.convertAccountRequired$ = of(false);
     cryptoFunctionService.randomBytes.mockResolvedValue(mockSessionKey);
     configService.getFeatureFlag.mockResolvedValue(false);
+    userAutoUnlockKeyService.setUserKeyInMemoryIfAutoUserKeySet.mockResolvedValue(true);
 
     command = new UnlockCommand(
       accountService,
@@ -92,6 +95,7 @@ describe("UnlockCommand", () => {
       masterPasswordUnlockService,
       unlockService,
       configService,
+      userAutoUnlockKeyService,
     );
   });
 
@@ -139,6 +143,54 @@ describe("UnlockCommand", () => {
         activeAccount.id,
       );
       expect(keyService.setUserKey).toHaveBeenCalledWith(mockUserKey, activeAccount.id);
+    });
+
+    it("verifies the auto-unlock entry decrypts with the returned session key", async () => {
+      masterPasswordUnlockService.unlockWithMasterPassword.mockResolvedValue(mockUserKey);
+
+      const response = await command.run(mockMasterPassword, {});
+
+      expect(response.success).toEqual(true);
+      expect(userAutoUnlockKeyService.setUserKeyInMemoryIfAutoUserKeySet).toHaveBeenCalledWith(
+        activeAccount.id,
+      );
+    });
+
+    it("re-writes the auto-unlock entry when verification fails on legacy path", async () => {
+      masterPasswordUnlockService.unlockWithMasterPassword.mockResolvedValue(mockUserKey);
+      userAutoUnlockKeyService.setUserKeyInMemoryIfAutoUserKeySet
+        .mockResolvedValueOnce(false)
+        .mockResolvedValueOnce(true);
+
+      const response = await command.run(mockMasterPassword, {});
+
+      expect(response.success).toEqual(true);
+      expect(keyService.setUserKey).toHaveBeenCalledTimes(2);
+      expect(keyService.setUserKey).toHaveBeenNthCalledWith(1, mockUserKey, activeAccount.id);
+      expect(keyService.setUserKey).toHaveBeenNthCalledWith(2, mockUserKey, activeAccount.id);
+      expect(userAutoUnlockKeyService.setUserKeyInMemoryIfAutoUserKeySet).toHaveBeenCalledTimes(2);
+    });
+
+    it("returns error when the auto-unlock entry cannot be persisted even after retry", async () => {
+      masterPasswordUnlockService.unlockWithMasterPassword.mockResolvedValue(mockUserKey);
+      userAutoUnlockKeyService.setUserKeyInMemoryIfAutoUserKeySet.mockResolvedValue(false);
+
+      const response = await command.run(mockMasterPassword, {});
+
+      expect(response.success).toEqual(false);
+      expect(response.message).toContain("Failed to persist new session key");
+    });
+
+    it("returns error when SDK unlock path leaves auto-unlock entry undecryptable", async () => {
+      configService.getFeatureFlag.mockResolvedValue(true);
+      unlockService.unlockWithMasterPassword.mockResolvedValue(undefined);
+      userAutoUnlockKeyService.setUserKeyInMemoryIfAutoUserKeySet.mockResolvedValue(false);
+
+      const response = await command.run(mockMasterPassword, {});
+
+      expect(response.success).toEqual(false);
+      expect(response.message).toContain("Failed to persist new session key");
+      expect(keyService.setUserKey).not.toHaveBeenCalled();
     });
 
     it("returns error response if unlockWithMasterPassword fails", async () => {

--- a/apps/cli/src/key-management/commands/unlock.command.ts
+++ b/apps/cli/src/key-management/commands/unlock.command.ts
@@ -13,6 +13,8 @@ import { ConfigService } from "@bitwarden/common/platform/abstractions/config/co
 import { EnvironmentService } from "@bitwarden/common/platform/abstractions/environment.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { ConsoleLogService } from "@bitwarden/common/platform/services/console-log.service";
+import { UserAutoUnlockKeyService } from "@bitwarden/common/platform/services/user-auto-unlock-key.service";
+import { UserKey } from "@bitwarden/common/types/key";
 import { KeyService } from "@bitwarden/key-management";
 import { UnlockService } from "@bitwarden/unlock";
 
@@ -37,6 +39,7 @@ export class UnlockCommand {
     private masterPasswordUnlockService: MasterPasswordUnlockService,
     private unlockService: UnlockService,
     private configService: ConfigService,
+    private userAutoUnlockKeyService: UserAutoUnlockKeyService,
   ) {}
 
   async run(password: string, cmdOptions: Record<string, any>) {
@@ -56,14 +59,12 @@ export class UnlockCommand {
     }
     const userId = activeAccount.id;
 
+    let userKey: UserKey | undefined;
     try {
       if (await this.configService.getFeatureFlag(FeatureFlag.UnlockViaSDK)) {
         await this.unlockService.unlockWithMasterPassword(userId, password);
       } else {
-        const userKey = await this.masterPasswordUnlockService.unlockWithMasterPassword(
-          password,
-          userId,
-        );
+        userKey = await this.masterPasswordUnlockService.unlockWithMasterPassword(password, userId);
 
         await this.keyService.setUserKey(userKey, userId);
       }
@@ -87,6 +88,18 @@ export class UnlockCommand {
     }
 
     await this.encryptedMigrator.runMigrations(userId, password);
+
+    // Verify the returned session key can decrypt the auto-unlock entry, otherwise
+    // subsequent commands will see "locked". Recover by re-writing if possible.
+    if (!(await this.userAutoUnlockKeyService.setUserKeyInMemoryIfAutoUserKeySet(userId))) {
+      if (userKey == null) {
+        return Response.error("Failed to persist new session key. Please try again.");
+      }
+      await this.keyService.setUserKey(userKey, userId);
+      if (!(await this.userAutoUnlockKeyService.setUserKeyInMemoryIfAutoUserKeySet(userId))) {
+        return Response.error("Failed to persist new session key. Please try again.");
+      }
+    }
 
     return this.successResponse();
   }

--- a/apps/cli/src/oss-serve-configurator.ts
+++ b/apps/cli/src/oss-serve-configurator.ts
@@ -177,6 +177,7 @@ export class OssServeConfigurator {
       this.serviceContainer.masterPasswordUnlockService,
       this.serviceContainer.unlockService,
       this.serviceContainer.configService,
+      this.serviceContainer.userAutoUnlockKeyService,
     );
 
     this.sendCreateCommand = new SendCreateCommand(

--- a/apps/cli/src/program.ts
+++ b/apps/cli/src/program.ts
@@ -301,6 +301,7 @@ export class Program extends BaseProgram {
             this.serviceContainer.masterPasswordUnlockService,
             this.serviceContainer.unlockService,
             this.serviceContainer.configService,
+            this.serviceContainer.userAutoUnlockKeyService,
           );
           const response = await command.run(password, cmd);
           this.processResponse(response);


### PR DESCRIPTION
## 🎟️ Tracking

Fixes #20705 (PM-37694)

## 📔 Objective

`bw unlock --raw` returned a session token that subsequent commands could not use: `bw status` reported `"locked"` even though the caller had just exported `BW_SESSION` with the token printed by the command. This is a regression that left non-interactive CLI workflows (CI, scripts, automation) without a working unlock path.

### Root cause

During `bw unlock`, the auto-unlock entry on disk is written more than once:

1. `ServiceContainer.init()` loads the existing auto-unlock entry (encrypted with the previous `BW_SESSION`) and, as a side effect of `keyService.setUserKey()`, re-writes it back to disk with the *previous* session key.
2. `UnlockCommand` then rotates the session key via `setNewSessionKey()` and calls `keyService.setUserKey()` again, which should overwrite the auto-unlock entry with the *new* session key.

In practice, the on-disk state after the second write was not reliably encrypted with the new session key, so the token returned by the command could not decrypt the auto-unlock entry on the next invocation.

### Fix

Verify the round-trip after the unlock paths finish by reading the auto-unlock entry back through `UserAutoUnlockKeyService.setUserKeyInMemoryIfAutoUserKeySet(userId)`, the same path `bw status` uses.

- If the verification call succeeds, it also re-persists the auto-unlock entry with the current `BW_SESSION` as a side effect, so the next command will see the vault as unlocked.
- If it fails on the legacy path, recover by re-running `setUserKey` with the decrypted user key we still have in scope, then verify once more.
- If it fails on the SDK path (where the decrypted user key is not exposed to the CLI layer) or fails again after recovery, return a clear error instead of handing back a session token that cannot be used.

## ⏰ Reminders before review

- [x] Contributor guidelines followed
- [x] All formatters and local linters executed and passed
- [x] Written tests
- [ ] Update documentation as required by this change
- [x] Bug fixes and features have automated tests
- [ ] All UI changes meet accessibility requirements
- [x] No new vulnerabilities introduced
- [x] No new violations of the cryptography, secrets, or PII storage policies introduced
- [x] No new issues in linked Jira tickets / GitHub issues introduced

## 🦮 Reviewer guidelines

<!-- See [CONTRIBUTING.md](https://github.com/bitwarden/clients/blob/main/CONTRIBUTING.md) for more guidance. -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes

## Test plan

- [x] Added `unlock.command.spec.ts` regression tests covering the verify/recover flow, legacy and SDK paths, and the persistent-failure error path. All 13 tests pass locally.
- [ ] Manually verify the original repro from #20705: `bw login`, then `BW_SESSION=$(bw unlock --raw)`, then `bw status` should print `"unlocked"`.