### PR TITLE
[PM-36561] Send edit event logging

### DIFF
--- a/apps/web/src/app/dirt/event-logs/services/event.service.ts
+++ b/apps/web/src/app/dirt/event-logs/services/event.service.ts
@@ -816,6 +816,12 @@ export class EventService {
       case EventType.Send_Created_File_WithPasswordProtection:
         msg = humanReadableMsg = this.i18nService.t("createdFileSendWithPasswordProtection");
         break;
+      case EventType.Send_Updated_Text:
+        msg = humanReadableMsg = this.i18nService.t("editedTextSend");
+        break;
+      case EventType.Send_Updated_File:
+        msg = humanReadableMsg = this.i18nService.t("editedFileSend");
+        break;
 
       default:
         break;

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -4360,6 +4360,14 @@
     "message": "Created file Send with password",
     "description": "'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated."
   },
+  "editedTextSend": {
+    "message": "Edited text Send",
+    "description": "'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated."
+  },
+  "editedFileSend": {
+    "message": "Edited file Send",
+    "description": "'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated."
+  },
   "movedItemIdToOrg": {
     "message": "Moved item $ID$ to an organization.",
     "placeholders": {

--- a/libs/common/src/dirt/event-logs/enums/event-type.enum.ts
+++ b/libs/common/src/dirt/event-logs/enums/event-type.enum.ts
@@ -145,4 +145,6 @@ export enum EventType {
   Send_Created_File = 2503,
   Send_Created_File_WithEmailVerification = 2504,
   Send_Created_File_WithPasswordProtection = 2505,
+  Send_Updated_Text = 2506,
+  Send_Updated_File = 2507,
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-36561

## 📔 Objective

This PR introduces enums, `i18n` translations, and service logic in order to log Send edit events. 

See companion `server` PR: https://github.com/bitwarden/server/pull/7673

## 📸 Screenshots

<img width="1347" height="586" alt="Screenshot 2026-05-19 at 08 03 27" src="https://github.com/user-attachments/assets/e3698e53-07ba-4ff3-a9db-20f62745ab19" />

<img width="1339" height="248" alt="Screenshot 2026-05-19 at 08 08 46" src="https://github.com/user-attachments/assets/43d15845-1d17-4674-9077-d865f4c70cc9" />
