### PR TITLE
Disable Native popover use from Angular 21

### DIFF
--- a/apps/browser/src/popup/app.module.ts
+++ b/apps/browser/src/popup/app.module.ts
@@ -1,7 +1,7 @@
 import { A11yModule } from "@angular/cdk/a11y";
 import { DragDropModule } from "@angular/cdk/drag-drop";
 import { LayoutModule } from "@angular/cdk/layout";
-import { OverlayModule } from "@angular/cdk/overlay";
+import { OverlayModule, OVERLAY_DEFAULT_CONFIG } from "@angular/cdk/overlay";
 import { ScrollingModule } from "@angular/cdk/scrolling";
 import { CurrencyPipe, DatePipe } from "@angular/common";
 import { NgModule } from "@angular/core";
@@ -84,7 +84,11 @@ import "../platform/popup/locales";
   ],
   declarations: [AppComponent, TabsV2Component],
   exports: [CalloutModule],
-  providers: [CurrencyPipe, DatePipe],
+  providers: [
+    CurrencyPipe,
+    DatePipe,
+    { provide: OVERLAY_DEFAULT_CONFIG, useValue: { usePopover: false } },
+  ],
   bootstrap: [AppComponent],
 })
 export class AppModule {}

--- a/apps/desktop/src/app/app.module.ts
+++ b/apps/desktop/src/app/app.module.ts
@@ -3,7 +3,7 @@ import "zone.js";
 // Register the locales for the application
 import "../platform/app/locales";
 
-import { OverlayModule } from "@angular/cdk/overlay";
+import { OverlayModule, OVERLAY_DEFAULT_CONFIG } from "@angular/cdk/overlay";
 import { NgModule } from "@angular/core";
 import { ReactiveFormsModule } from "@angular/forms";
 import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
@@ -55,6 +55,7 @@ import { ServicesModule } from "./services/services.module";
       provide: PremiumUpgradePromptService,
       useClass: DesktopPremiumUpgradePromptService,
     },
+    { provide: OVERLAY_DEFAULT_CONFIG, useValue: { usePopover: false } },
   ],
   bootstrap: [AppComponent],
 })

--- a/apps/web/src/app/oss.module.ts
+++ b/apps/web/src/app/oss.module.ts
@@ -1,3 +1,4 @@
+import { OVERLAY_DEFAULT_CONFIG } from "@angular/cdk/overlay";
 import { NgModule } from "@angular/core";
 
 import { AuthModule } from "./auth";
@@ -30,5 +31,6 @@ import "./shared/locales";
     AccessComponent,
   ],
   bootstrap: [],
+  providers: [{ provide: OVERLAY_DEFAULT_CONFIG, useValue: { usePopover: false } }],
 })
 export class OssModule {}


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-36880
https://bitwarden.atlassian.net/browse/PM-37747

## 📔 Objective

https://github.com/bitwarden/clients/pull/19725 introduced a subtle breaking change that included the angular CDK to defaulting to use the popover api by default. When an element is opened with the popover api it is promoted to the top layer. This disregards the stacking context and z-index. This was causing the select elements within dialogs to open behind the dialog. 

Applying the configuration option globally to disable this and revert back to the implementation that manages z-index. 

Is there a better location for these overrides?

Other threads on this:
- https://github.com/angular/components/issues/32729
- https://github.com/angular/components/pull/32306
- https://github.com/angular/components/issues/32693

## 📸 Screenshots

|Before|After|
|-|-|
|<video src="https://github.com/user-attachments/assets/b4827491-3ef7-4a5c-b3ee-7b43cbb87818"/>|<video src="https://github.com/user-attachments/assets/94b10f7d-d0a0-4c7a-b3b3-5fd3d9d10952"/>|




