### PR TITLE
[PM-36563] Send access event logs

### DIFF
--- a/apps/web/src/app/dirt/event-logs/services/event.service.ts
+++ b/apps/web/src/app/dirt/event-logs/services/event.service.ts
@@ -816,6 +816,12 @@ export class EventService {
       case EventType.Send_Created_File_WithPasswordProtection:
         msg = humanReadableMsg = this.i18nService.t("createdFileSendWithPasswordProtection");
         break;
+      case EventType.Send_Updated_Text:
+        msg = humanReadableMsg = this.i18nService.t("editedTextSend");
+        break;
+      case EventType.Send_Updated_File:
+        msg = humanReadableMsg = this.i18nService.t("editedFileSend");
+        break;
 
       default:
         break;

--- a/apps/web/src/app/dirt/event-logs/services/event.service.ts
+++ b/apps/web/src/app/dirt/event-logs/services/event.service.ts
@@ -816,6 +816,12 @@ export class EventService {
       case EventType.Send_Created_File_WithPasswordProtection:
         msg = humanReadableMsg = this.i18nService.t("createdFileSendWithPasswordProtection");
         break;
+      case EventType.Send_Accessed_Text:
+        msg = humanReadableMsg = this.i18nService.t("accessedTextSend");
+        break;
+      case EventType.Send_Accessed_File:
+        msg = humanReadableMsg = this.i18nService.t("accessedFileSend");
+        break;
 
       default:
         break;

--- a/apps/web/src/app/dirt/event-logs/services/event.service.ts
+++ b/apps/web/src/app/dirt/event-logs/services/event.service.ts
@@ -816,6 +816,12 @@ export class EventService {
       case EventType.Send_Created_File_WithPasswordProtection:
         msg = humanReadableMsg = this.i18nService.t("createdFileSendWithPasswordProtection");
         break;
+      case EventType.Send_Deleted_Text:
+        msg = humanReadableMsg = this.i18nService.t("deletedTextSend");
+        break;
+      case EventType.Send_Deleted_File:
+        msg = humanReadableMsg = this.i18nService.t("deletedFileSend");
+        break;
 
       default:
         break;

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -4377,11 +4377,11 @@
     "description": "'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated."
   },
   "accessedTextSend": {
-    "message": "Text Send accessed",
+    "message": "Accessed text Send",
     "description": "'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated."
   },
   "accessedFileSend": {
-    "message": "File Send accessed",
+    "message": "Accessed file Send",
     "description": "'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated."
   },
   "movedItemIdToOrg": {

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -4360,6 +4360,14 @@
     "message": "Created file Send with password",
     "description": "'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated."
   },
+  "accessedTextSend": {
+    "message": "Text Send accessed",
+    "description": "'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated."
+  },
+  "accessedFileSend": {
+    "message": "File Send accessed",
+    "description": "'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated."
+  },
   "movedItemIdToOrg": {
     "message": "Moved item $ID$ to an organization.",
     "placeholders": {

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -4360,6 +4360,14 @@
     "message": "Created file Send with password",
     "description": "'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated."
   },
+  "deletedTextSend": {
+    "message": "Deleted text Send",
+    "description": "'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated."
+  },
+  "deletedFileSend": {
+    "message": "Deleted file Send",
+    "description": "'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated."
+  },
   "movedItemIdToOrg": {
     "message": "Moved item $ID$ to an organization.",
     "placeholders": {

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -4360,6 +4360,14 @@
     "message": "Created file Send with password",
     "description": "'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated."
   },
+  "editedTextSend": {
+    "message": "Edited text Send",
+    "description": "'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated."
+  },
+  "editedFileSend": {
+    "message": "Edited file Send",
+    "description": "'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated."
+  },
   "movedItemIdToOrg": {
     "message": "Moved item $ID$ to an organization.",
     "placeholders": {

--- a/libs/common/src/dirt/event-logs/enums/event-type.enum.ts
+++ b/libs/common/src/dirt/event-logs/enums/event-type.enum.ts
@@ -145,4 +145,6 @@ export enum EventType {
   Send_Created_File = 2503,
   Send_Created_File_WithEmailVerification = 2504,
   Send_Created_File_WithPasswordProtection = 2505,
+  Send_Accessed_Text = 2510,
+  Send_Accessed_File = 2511,
 }

--- a/libs/common/src/dirt/event-logs/enums/event-type.enum.ts
+++ b/libs/common/src/dirt/event-logs/enums/event-type.enum.ts
@@ -145,4 +145,6 @@ export enum EventType {
   Send_Created_File = 2503,
   Send_Created_File_WithEmailVerification = 2504,
   Send_Created_File_WithPasswordProtection = 2505,
+  Send_Updated_Text = 2506,
+  Send_Updated_File = 2507,
 }

--- a/libs/common/src/dirt/event-logs/enums/event-type.enum.ts
+++ b/libs/common/src/dirt/event-logs/enums/event-type.enum.ts
@@ -145,4 +145,6 @@ export enum EventType {
   Send_Created_File = 2503,
   Send_Created_File_WithEmailVerification = 2504,
   Send_Created_File_WithPasswordProtection = 2505,
+  Send_Deleted_Text = 2508,
+  Send_Deleted_File = 2509,
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-36563

## 📔 Objective

This PR introduces enums, `i18n` translations, and service logic in order to log Send access events. 

Note to reviewers: this PR also de-dupes two `i18n` keys in `messages.json` that were introduced earlier by Tools Team. 

Companion `server` PR: https://github.com/bitwarden/server/pull/7679

## 📸 Screenshots

<img width="1389" height="410" alt="Screenshot 2026-05-20 at 14 22 39" src="https://github.com/user-attachments/assets/5413caf9-4871-45f9-baae-87950c86e6f1" />

<img width="1259" height="207" alt="Screenshot 2026-05-20 at 14 23 14" src="https://github.com/user-attachments/assets/e5de8605-599a-4441-80bf-477804fed6ca" />
