### PR TITLE
Prevents redundant accumulation of `chrome.storage.onChanged`

### DIFF
--- a/apps/browser/src/platform/services/abstractions/abstract-chrome-storage-api.service.ts
+++ b/apps/browser/src/platform/services/abstractions/abstract-chrome-storage-api.service.ts
@@ -1,6 +1,6 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
-import { filter, mergeMap } from "rxjs";
+import { filter, mergeMap, share } from "rxjs";
 
 import {
   AbstractStorageService,
@@ -68,6 +68,10 @@ export default abstract class AbstractChromeStorageService
           };
         });
       }),
+      // Multicast so all subscribers share a single chrome.storage.onChanged listener.
+      // Without share(), every subscriber re-runs fromChromeEvent and registers another
+      // native listener — which accumulates over the service worker's lifetime.
+      share(),
     );
   }
 


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

Addresses unbounded growth of listeners in service worker by limiting the number of `chrome.storage.onChanged` invocations (which were linear per-tab as invoked by `AbstractChromeStorageService`).

Use this temporary instrumentation in `from-chrome-event.ts` to see the listener growth with and without `share()`

```ts
let nextId = 0;
const liveListeners = new Map<number, {
  constructionStack: string;
  subscriptionStack: string;
  createdAt: number;
}>();
(self as any).__fromChromeEventLive = liveListeners;

export function fromChromeEvent<T extends unknown[]>(
  event: chrome.events.Event<(...args: T) => void>,
): Observable<T> {
  // also capture call site 
  const constructionStack = new Error().stack ?? "";

  return new Observable<T>((subscriber) => {
    const id = ++nextId;
    const subscriptionStack = new Error().stack ?? "";
    liveListeners.set(id, { constructionStack, subscriptionStack, createdAt: Date.now() });

    const handler = (...args: readonly unknown[]) => {
      if (chrome.runtime.lastError) {
        subscriber.error(chrome.runtime.lastError);
        return;
      }
      subscriber.next(args as T);
    };
    BrowserApi.addListener(event, handler);

    return () => {
      liveListeners.delete(id);
      BrowserApi.removeListener(event, handler);
    };
  });
}
```

Then, in console, at instantiation:

`__fromChromeEventLive.size; // outputs a constant number`

Open several tabs

`__fromChromeEventLive.size; // number has increased`

Close tabs

`__fromChromeEventLive.size; // number remains large`

After `share()` the number remains constant.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
