### PR TITLE
[CL-1207] Fix missing provideZoneChangeDetection() in bit-browser bootstrap

### DIFF
--- a/bitwarden_license/bit-browser/src/popup/main.ts
+++ b/bitwarden_license/bit-browser/src/popup/main.ts
@@ -1,4 +1,4 @@
-import { enableProdMode } from "@angular/core";
+import { enableProdMode, provideZoneChangeDetection } from "@angular/core";
 import { platformBrowserDynamic } from "@angular/platform-browser-dynamic";
 
 import { PopupSizeService } from "@bitwarden/browser/platform/popup/layout/popup-size.service";
@@ -20,7 +20,9 @@ if (process.env.ENV === "production") {
 }
 
 function init() {
-  void platformBrowserDynamic().bootstrapModule(AppModule);
+  void platformBrowserDynamic().bootstrapModule(AppModule, {
+    applicationProviders: [provideZoneChangeDetection()],
+  });
 }
 
 init();


### PR DESCRIPTION
https://bitwarden.atlassian.net/browse/CL-1207

## Summary

- Adds `provideZoneChangeDetection()` to the commercial browser extension (`bit-browser`) popup bootstrap, matching the pattern already present in all other app entry points (`apps/browser`, `apps/web`, `apps/desktop`, `bit-web`, `libs/components`)

## Root cause

Angular 21 removed the default Zone-based change detection scheduler as a breaking change — applications must now explicitly opt in via `provideZoneChangeDetection()`. An automated migration applied this to all entry points except `bitwarden_license/bit-browser/src/popup/main.ts`, leaving the commercial browser extension without a Zone CD scheduler entirely. Without it, Angular never schedules change detection in response to Zone.js task completion, causing views to not update after async operations.

## Test plan

- [ ] Load the `bit-dev-chrome` build artifact and verify the lock screen renders correctly when opening the extension in a locked state
- [ ] Verify the add-item form renders correctly after selecting an item type
- [ ] Verify general popup navigation and vault display work as expected