### PR TITLE
Stop autofill from doing mutation-driven work in hidden tabs.

### DIFF
--- a/apps/browser/src/autofill/services/collect-autofill-content.service.spec.ts
+++ b/apps/browser/src/autofill/services/collect-autofill-content.service.spec.ts
@@ -58,6 +58,9 @@ describe("CollectAutofillContentService", () => {
       domQueryService,
       autofillOverlayContentService,
     );
+    // The mutation handler gates on an active observation; tests that drive it
+    // directly model the connected-observer precondition.
+    collectAutofillContentService["isObservingActive"] = true;
     window.IntersectionObserver = jest.fn(() => mockIntersectionObserver);
   });
 
@@ -2573,6 +2576,134 @@ describe("CollectAutofillContentService", () => {
 
       expect(collectAutofillContentService["mutationObserver"]).toBeInstanceOf(MutationObserver);
       expect(collectAutofillContentService["mutationObserver"].observe).toHaveBeenCalled();
+    });
+
+    it("registers a visibilitychange listener", () => {
+      const addEventListenerSpy = jest.spyOn(globalThis.document, "addEventListener");
+
+      collectAutofillContentService["setupMutationObserver"]();
+
+      expect(addEventListenerSpy).toHaveBeenCalledWith("visibilitychange", expect.any(Function));
+    });
+  });
+
+  describe("tab visibility handling", () => {
+    const setVisibility = (state: DocumentVisibilityState) => {
+      Object.defineProperty(document, "visibilityState", { configurable: true, get: () => state });
+    };
+
+    afterEach(() => {
+      setVisibility("visible");
+    });
+
+    it("disconnects the observer and drops pending mutation work when the tab becomes hidden", () => {
+      collectAutofillContentService["setupMutationObserver"]();
+      const disconnectSpy = jest.spyOn(
+        collectAutofillContentService["mutationObserver"],
+        "disconnect",
+      );
+      collectAutofillContentService["pendingChildListUpdate"] = true;
+      collectAutofillContentService["pendingAttributeMutations"].set(
+        document.createElement("input"),
+        new Set(["value"]),
+      );
+      collectAutofillContentService["updateAfterMutationIdleCallback"] = setTimeout(jest.fn, 100);
+
+      setVisibility("hidden");
+      collectAutofillContentService["handleVisibilityChange"]();
+
+      expect(disconnectSpy).toHaveBeenCalled();
+      expect(collectAutofillContentService["pendingChildListUpdate"]).toBe(false);
+      expect(collectAutofillContentService["pendingAttributeMutations"].size).toBe(0);
+      expect(collectAutofillContentService["updateAfterMutationIdleCallback"]).toBeNull();
+    });
+
+    it("re-observes the document and runs a reconciliation rebuild when the tab becomes visible", () => {
+      collectAutofillContentService["setupMutationObserver"]();
+      const observeSpy = jest.spyOn(
+        collectAutofillContentService as any,
+        "observeDocumentMutations",
+      );
+      const reconcileSpy = jest.spyOn(
+        collectAutofillContentService as any,
+        "updateAutofillElementsAfterMutation",
+      );
+
+      setVisibility("visible");
+      collectAutofillContentService["handleVisibilityChange"]();
+
+      expect(observeSpy).toHaveBeenCalled();
+      expect(reconcileSpy).toHaveBeenCalled();
+    });
+
+    it("ignores DOM mutations while hidden, then reconciles once visible again", async () => {
+      jest.useFakeTimers();
+      collectAutofillContentService["setupMutationObserver"]();
+      const reconcileSpy = jest.spyOn(
+        collectAutofillContentService as any,
+        "updateAutofillElementsAfterMutation",
+      );
+
+      setVisibility("hidden");
+      collectAutofillContentService["handleVisibilityChange"]();
+      reconcileSpy.mockClear();
+
+      // A disconnected observer delivers no records, so this mutation does no work.
+      document.body.appendChild(document.createElement("input"));
+      await Promise.resolve();
+      jest.advanceTimersByTime(2000);
+      await Promise.resolve();
+
+      expect(reconcileSpy).not.toHaveBeenCalled();
+
+      setVisibility("visible");
+      collectAutofillContentService["handleVisibilityChange"]();
+
+      expect(reconcileSpy).toHaveBeenCalled();
+      jest.runOnlyPendingTimers();
+      jest.useRealTimers();
+    });
+
+    it("removes the visibilitychange listener on destroy", () => {
+      const removeEventListenerSpy = jest.spyOn(globalThis.document, "removeEventListener");
+
+      collectAutofillContentService.destroy();
+
+      expect(removeEventListenerSpy).toHaveBeenCalledWith("visibilitychange", expect.any(Function));
+    });
+
+    it("does no mutation work when the handler is invoked while suspended", () => {
+      collectAutofillContentService["setupMutationObserver"]();
+      setVisibility("hidden");
+      collectAutofillContentService["handleVisibilityChange"]();
+      const scheduleSpy = jest.spyOn(
+        collectAutofillContentService["processMutationsTask"],
+        "schedule",
+      );
+      const mutationRecord = mock<MutationRecord>({ type: "childList" });
+
+      // A callback delivered around the disconnect boundary must be inert.
+      collectAutofillContentService["handleMutationObserverMutation"]([mutationRecord]);
+
+      expect(scheduleSpy).not.toHaveBeenCalled();
+      expect(collectAutofillContentService["pendingChildListUpdate"]).toBe(false);
+    });
+
+    it("cancels in-flight idle mutation work when the tab becomes hidden", () => {
+      collectAutofillContentService["setupMutationObserver"]();
+      const taskCancelSpy = jest.spyOn(
+        collectAutofillContentService["processMutationsTask"],
+        "cancel",
+      );
+      collectAutofillContentService["drainIdleHandle"] = setTimeout(jest.fn, 100);
+      collectAutofillContentService["updateAfterMutationIdleCallback"] = setTimeout(jest.fn, 100);
+
+      setVisibility("hidden");
+      collectAutofillContentService["handleVisibilityChange"]();
+
+      expect(taskCancelSpy).toHaveBeenCalled();
+      expect(collectAutofillContentService["drainIdleHandle"]).toBeNull();
+      expect(collectAutofillContentService["updateAfterMutationIdleCallback"]).toBeNull();
     });
   });
 

--- a/apps/browser/src/autofill/services/collect-autofill-content.service.spec.ts
+++ b/apps/browser/src/autofill/services/collect-autofill-content.service.spec.ts
@@ -2618,7 +2618,7 @@ describe("CollectAutofillContentService", () => {
       expect(collectAutofillContentService["updateAfterMutationIdleCallback"]).toBeNull();
     });
 
-    it("re-observes the document and runs a reconciliation rebuild when the tab becomes visible", () => {
+    it("re-observes the document and forces a live re-derivation when the tab becomes visible", () => {
       collectAutofillContentService["setupMutationObserver"]();
       const observeSpy = jest.spyOn(
         collectAutofillContentService as any,
@@ -2628,12 +2628,18 @@ describe("CollectAutofillContentService", () => {
         collectAutofillContentService as any,
         "updateAutofillElementsAfterMutation",
       );
+      // Simulate the state left by the last rebuild before the tab was hidden:
+      // cached fields and no pending mutation, so getPageDetails would otherwise
+      // short-circuit to cached data.
+      collectAutofillContentService["domRecentlyMutated"] = false;
 
       setVisibility("visible");
       collectAutofillContentService["handleVisibilityChange"]();
 
       expect(observeSpy).toHaveBeenCalled();
       expect(reconcileSpy).toHaveBeenCalled();
+      // Must re-derive from the live DOM, not serve cached field data.
+      expect(collectAutofillContentService["domRecentlyMutated"]).toBe(true);
     });
 
     it("ignores DOM mutations while hidden, then reconciles once visible again", async () => {

--- a/apps/browser/src/autofill/services/collect-autofill-content.service.ts
+++ b/apps/browser/src/autofill/services/collect-autofill-content.service.ts
@@ -1438,6 +1438,11 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
 
   private resumeMutationObservation() {
     this.observeDocumentMutations();
+    // Force a true re-derivation from the live DOM: without this, getPageDetails
+    // short-circuits to cached fields (domRecentlyMutated is false after the last
+    // rebuild and nothing set it while hidden), so changes made while hidden would
+    // be missed.
+    this.requirePageDetailsUpdate();
     this.updateAutofillElementsAfterMutation();
   }
 

--- a/apps/browser/src/autofill/services/collect-autofill-content.service.ts
+++ b/apps/browser/src/autofill/services/collect-autofill-content.service.ts
@@ -1,4 +1,4 @@
-import { AUTOFILL_ATTRIBUTES } from "@bitwarden/common/autofill/constants";
+import { AUTOFILL_ATTRIBUTES, EVENTS } from "@bitwarden/common/autofill/constants";
 import { AutofillTargetingRuleType, FormContent } from "@bitwarden/common/autofill/types";
 
 import AutofillField from "../models/autofill-field";
@@ -23,6 +23,7 @@ import {
   getPropertyOrAttribute,
   requestIdleCallbackPolyfill,
   cancelIdleCallbackPolyfill,
+  CoalescedIdleTask,
   debounce,
 } from "../utils";
 
@@ -64,6 +65,16 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
   private pendingTopLayerTargets: Set<Element> = new Set();
   private pendingChildListUpdate = false;
   private updateAfterMutationIdleCallback: number | NodeJS.Timeout | null = null;
+  // True only while the observer is connected. Mutation-driven work gates on this
+  // so that callbacks delivered around the disconnect boundary (or any path that
+  // outlives disconnect) do no work while the tab is hidden.
+  private isObservingActive = false;
+  // Owned idle handles so suspend can cancel in-flight mutation work, not just the
+  // observer. The drain handle backs the deferred block inside processMutations.
+  private readonly processMutationsTask = new CoalescedIdleTask(() => this.processMutations(), {
+    timeout: 500,
+  });
+  private drainIdleHandle: number | NodeJS.Timeout | null = null;
   private pendingOverlaySetup: Map<Element, NodeJS.Timeout | number> = new Map();
   private readonly overlaySetupDelayMs = 100;
   private shadowDomCheckTimeout: NodeJS.Timeout | number | null = null;
@@ -1359,7 +1370,17 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
   private setupMutationObserver() {
     this.currentLocationHref = globalThis.location.href;
     this.mutationObserver = new MutationObserver(this.handleMutationObserverMutation);
-    this.mutationObserver.observe(document.documentElement, {
+    globalThis.document.addEventListener(EVENTS.VISIBILITYCHANGE, this.handleVisibilityChange);
+    // A tab that initializes hidden (background preload) shouldn't observe until
+    // shown; the visible transition starts observation and runs the first rebuild.
+    if (globalThis.document.visibilityState !== "hidden") {
+      this.observeDocumentMutations();
+    }
+  }
+
+  private observeDocumentMutations() {
+    this.isObservingActive = true;
+    this.mutationObserver?.observe(document.documentElement, {
       attributes: true,
       attributeFilter: Object.values(AUTOFILL_ATTRIBUTES),
       childList: true,
@@ -1367,7 +1388,67 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
     });
   }
 
+  /**
+   * While the tab is hidden, mutation-driven work is pure waste: nothing the
+   * user can see depends on it, yet a churning background page keeps the
+   * observer callback, shadow scans, and full-document rebuilds firing. On the
+   * hidden transition we disconnect the observer and drop in-flight work; on the
+   * visible transition we re-attach and run a single reconciliation rebuild that
+   * re-derives autofill state from the current DOM, so nothing accumulated while
+   * hidden is lost.
+   */
+  private handleVisibilityChange = () => {
+    if (globalThis.document.visibilityState === "hidden") {
+      this.suspendMutationObservation();
+
+      return;
+    }
+
+    this.resumeMutationObservation();
+  };
+
+  private suspendMutationObservation() {
+    this.isObservingActive = false;
+    this.mutationObserver?.disconnect();
+
+    // Cancel every in-flight idle callback so the mutation-rebuild chain cannot
+    // keep re-arming itself (processMutations -> drain -> getPageDetails) while hidden.
+    this.processMutationsTask.cancel();
+    if (this.drainIdleHandle !== null) {
+      cancelIdleCallbackPolyfill(this.drainIdleHandle);
+      this.drainIdleHandle = null;
+    }
+    if (this.updateAfterMutationIdleCallback !== null) {
+      cancelIdleCallbackPolyfill(this.updateAfterMutationIdleCallback);
+      this.updateAfterMutationIdleCallback = null;
+    }
+    if (this.shadowDomCheckTimeout) {
+      clearTimeout(this.shadowDomCheckTimeout);
+      this.shadowDomCheckTimeout = null;
+      this.pendingShadowDomCheck = false;
+    }
+
+    // Pending state is rebuilt from the live DOM on resume, so dropping it is safe.
+    this.pendingAttributeMutations.clear();
+    this.pendingTopLayerTargets.clear();
+    this.pendingChildListUpdate = false;
+    this.pendingMutationAddedElements.clear();
+    this.pendingMutationAddedElementsOverflowed = false;
+  }
+
+  private resumeMutationObservation() {
+    this.observeDocumentMutations();
+    this.updateAutofillElementsAfterMutation();
+  }
+
   private handleMutationObserverMutation = (mutations: MutationRecord[]) => {
+    // Gate on our own state, not just the observer connection: a hidden tab must
+    // do no mutation-driven work even if a callback is delivered around the
+    // disconnect boundary. Resume re-derives state from the live DOM.
+    if (!this.isObservingActive) {
+      return;
+    }
+
     if (this.currentLocationHref !== globalThis.location.href) {
       this.handleWindowLocationMutation();
 
@@ -1442,7 +1523,7 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
     }
 
     if (shouldSchedule) {
-      requestIdleCallbackPolyfill(this.processMutations, { timeout: 500 });
+      this.processMutationsTask.schedule();
     }
   };
 
@@ -1493,8 +1574,9 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
       return;
     }
 
-    requestIdleCallbackPolyfill(
+    this.drainIdleHandle = requestIdleCallbackPolyfill(
       () => {
+        this.drainIdleHandle = null;
         for (const element of drainingTopLayer) {
           this.setupTopLayerCandidateListener(element);
         }
@@ -1998,6 +2080,11 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
    * timeouts and disconnects the mutation observer.
    */
   destroy() {
+    this.processMutationsTask.cancel();
+    if (this.drainIdleHandle !== null) {
+      cancelIdleCallbackPolyfill(this.drainIdleHandle);
+      this.drainIdleHandle = null;
+    }
     if (this.updateAfterMutationIdleCallback !== null) {
       cancelIdleCallbackPolyfill(this.updateAfterMutationIdleCallback);
       this.updateAfterMutationIdleCallback = null;
@@ -2007,6 +2094,7 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
     }
     this.pendingOverlaySetup.forEach((timeout) => globalThis.clearTimeout(timeout));
     this.pendingOverlaySetup.clear();
+    globalThis.document.removeEventListener(EVENTS.VISIBILITYCHANGE, this.handleVisibilityChange);
     if (this.mutationObserver !== null) {
       this.mutationObserver.disconnect();
       this.mutationObserver = null;

--- a/apps/browser/src/autofill/utils/index.spec.ts
+++ b/apps/browser/src/autofill/utils/index.spec.ts
@@ -5,6 +5,7 @@ import { logoIcon, logoLockedIcon } from "./svg-icons";
 
 import {
   buildSvgDomElement,
+  CoalescedIdleTask,
   debounce,
   generateRandomCustomElementName,
   isReadonlyOrDisabledFormFieldElement,
@@ -275,5 +276,90 @@ describe("isReadonlyOrDisabledFormFieldElement", () => {
     const textarea = document.getElementById("field") as HTMLTextAreaElement;
     textarea.readOnly = true;
     expect(isReadonlyOrDisabledFormFieldElement(textarea)).toBe(true);
+  });
+});
+
+describe("CoalescedIdleTask", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    // Exercise the requestIdleCallback branch of the polyfill, backed by timers.
+    globalThis.requestIdleCallback = jest.fn((cb: any) => setTimeout(cb, 1) as any);
+    globalThis.cancelIdleCallback = jest.fn((id: any) => clearTimeout(id));
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    delete (globalThis as any).requestIdleCallback;
+    delete (globalThis as any).cancelIdleCallback;
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  it("runs the callback when the idle period fires", () => {
+    const callback = jest.fn();
+    const task = new CoalescedIdleTask(callback);
+
+    task.schedule();
+    expect(task.pending).toBe(true);
+    expect(callback).not.toHaveBeenCalled();
+
+    jest.runOnlyPendingTimers();
+
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(task.pending).toBe(false);
+  });
+
+  it("coalesces rapid scheduling into a single run, cancelling the prior handle", () => {
+    const callback = jest.fn();
+    const task = new CoalescedIdleTask(callback);
+
+    task.schedule();
+    task.schedule();
+    task.schedule();
+    jest.runOnlyPendingTimers();
+
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(globalThis.cancelIdleCallback).toHaveBeenCalledTimes(2);
+  });
+
+  it("cancel() prevents a pending run", () => {
+    const callback = jest.fn();
+    const task = new CoalescedIdleTask(callback);
+
+    task.schedule();
+    task.cancel();
+    expect(task.pending).toBe(false);
+
+    jest.runOnlyPendingTimers();
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it("cancel() is a no-op when nothing is scheduled", () => {
+    const task = new CoalescedIdleTask(jest.fn());
+    expect(() => task.cancel()).not.toThrow();
+    expect(globalThis.cancelIdleCallback).not.toHaveBeenCalled();
+  });
+
+  it("lets a callback re-schedule itself for a future run", () => {
+    const callback = jest.fn();
+    let scheduledOnce = false;
+    const task: CoalescedIdleTask = new CoalescedIdleTask(() => {
+      callback();
+      if (!scheduledOnce) {
+        scheduledOnce = true;
+        task.schedule();
+      }
+    });
+
+    task.schedule();
+    jest.runOnlyPendingTimers(); // first run re-schedules
+    expect(task.pending).toBe(true);
+    jest.runOnlyPendingTimers(); // second run does not
+
+    expect(callback).toHaveBeenCalledTimes(2);
+    expect(task.pending).toBe(false);
   });
 });

--- a/apps/browser/src/autofill/utils/index.ts
+++ b/apps/browser/src/autofill/utils/index.ts
@@ -55,6 +55,41 @@ export function cancelIdleCallbackPolyfill(id: NodeJS.Timeout | number) {
 }
 
 /**
+ * Owns a single idle-callback handle so callers schedule work without juggling
+ * raw handles: each schedule() cancels any still-pending run first (coalescing),
+ * and cancel() makes the task inert. Centralizing the handle is what lets a
+ * lifecycle owner (e.g. suspend-on-hidden) deterministically stop pending work.
+ */
+export class CoalescedIdleTask {
+  private handle: number | NodeJS.Timeout | null = null;
+
+  constructor(
+    private readonly callback: () => void,
+    private readonly defaultOptions?: Record<string, any>,
+  ) {}
+
+  schedule(options: Record<string, any> | undefined = this.defaultOptions): void {
+    this.cancel();
+    this.handle = requestIdleCallbackPolyfill(() => {
+      // Null before invoking so a callback that re-schedules itself keeps its new handle.
+      this.handle = null;
+      this.callback();
+    }, options);
+  }
+
+  cancel(): void {
+    if (this.handle !== null) {
+      cancelIdleCallbackPolyfill(this.handle);
+      this.handle = null;
+    }
+  }
+
+  get pending(): boolean {
+    return this.handle !== null;
+  }
+}
+
+/**
  * Generates a random string of characters that formatted as a custom element name.
  */
 export function generateRandomCustomElementName(): string {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-39281](https://bitwarden.atlassian.net/browse/PM-39281)

## 📔 Objective

Stop autofill from doing mutation-driven work in **hidden (background) tabs**. A churning
background page keeps the autofill `MutationObserver` callback, shadow-root scans, and
full-document `getPageDetails` rebuilds firing on every DOM change: pure waste, since nothing
the user can see depends on it.

This PR suspends that work while the tab is hidden and reconciles once it's visible again:

- **On hidden:** disconnect the `MutationObserver` and cancel every in-flight idle callback —
  the `processMutations → drain → getPageDetails` chain, via a new `CoalescedIdleTask` that owns
  each handle. The mutation handler also early-returns on an `isObservingActive` flag, so a
  callback delivered around the disconnect boundary does no work.
- **On visible:** re-observe and run a single reconciliation rebuild that re-derives autofill
  state from the live DOM — so anything the page changed while hidden is picked up. A tab that
  initializes hidden defers observation until first shown.

Two commits:
1. `CoalescedIdleTask` — a small primitive that owns one idle-callback handle (coalescing
   `schedule()` + deterministic `cancel()`), so a lifecycle owner can stop pending idle work.
2. The suspend-on-hidden behavior in `CollectAutofillContentService`.

## 📊 Measured result

Bench A/B (heavy shadow-mutation page (Scenario 9), ~24.5s hidden window, build-gated instrumentation that is
**not** part of this PR), counting work that fired *while hidden*: 

| signal (in hidden window) | before | after |
| --- | --- | --- |
| MutationObserver callbacks | 49 | **0** |
| `processMutations` drains | 17 | **0** |
| `getPageDetails` rebuilds | 16 | **1** |

Observer-driven work in the hidden tab drops to zero; the lone `getPageDetails` is a single
straggler at the suspend boundary.

## ⏰ Reminders before review

- No new encryption logic; no vault data leaves the client; no decrypted data/PII logged.
- Content-script rules respected (no Angular/RxJS; direct `chrome.*`/`document` usage is expected here).

## 🦮 Reviewer guidance / QA

See ticket's [QA testing notes](https://bitwarden.atlassian.net/browse/PM-39281).

<details>
<summary>Why the handler gate <em>and</em> the idle cancellation are both needed</summary>

`disconnect()` alone was insufficient in testing: in a backgrounded tab, mutation work kept recurring
~1/s because the `processMutations`/`getPageDetails` idle-callback chain re-armed itself (its handles
weren't owned/cancelable) and observer callbacks were still observed around the disconnect boundary.
Owning the handles (so `suspend` can cancel them) plus gating the handler on our own
`isObservingActive` state closes both paths.
</details>


[PM-39281]: https://bitwarden.atlassian.net/browse/PM-39281?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ