### PR TITLE
[PM-37816] Remove Getting Started tab on extension install (pick)

### DIFF
--- a/apps/browser/src/background/runtime.background.ts
+++ b/apps/browser/src/background/runtime.background.ts
@@ -12,7 +12,6 @@ import { ConfigService } from "@bitwarden/common/platform/abstractions/config/co
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
 import { MessageListener, isExternalMessage } from "@bitwarden/common/platform/messaging";
-import { devFlagEnabled } from "@bitwarden/common/platform/misc/flags";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { CipherType } from "@bitwarden/common/vault/enums";
 import { VaultMessages } from "@bitwarden/common/vault/enums/vault-messages.enum";
@@ -494,10 +493,6 @@ export default class RuntimeBackground {
           this.onInstalledReason === "install" &&
           !(await firstValueFrom(this.browserInitialInstallService.extensionInstalled$))
         ) {
-          if (!devFlagEnabled("skipWelcomeOnInstall")) {
-            void BrowserApi.createNewTab("https://bitwarden.com/browser-start/");
-          }
-
           await this.autofillSettingsService.setInlineMenuVisibility(
             AutofillOverlayVisibility.OnFieldFocus,
           );

--- a/libs/common/src/platform/misc/flags.ts
+++ b/libs/common/src/platform/misc/flags.ts
@@ -9,7 +9,6 @@ export type SharedFlags = {
 // required to avoid linting errors when there are no flags
 export type SharedDevFlags = {
   noopNotifications: boolean;
-  skipWelcomeOnInstall: boolean;
   configRetrievalIntervalMs: number;
   showRiskInsightsDebug: boolean;
   testPhishingUrls: string[];


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-37816

## 📔 Objective

Removes the "Getting Started" browser tab from opening on extension install.  This was already gated to prevent opening in a development environment, and that flag was removed as well.

(cherry picked from commit 7fb6c8ef0a7e911584be705fdcba77f874e08751)

## 📸 Screenshots

https://github.com/user-attachments/assets/36212c89-f8a9-421f-9164-0b3b07dabc99