### PR TITLE
fixed perms in cherry-pick workflow

### DIFF
--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -30,7 +30,8 @@ jobs:
       dest_branch: ${{ inputs.dest_branch }}
       dest_branch_allowed: ''
     permissions:
-      contents: read
+      contents: write
+      pull-requests: write
       id-token: write
     secrets:
       AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}


### PR DESCRIPTION
## 🎟️ Tracking
Failed [run](https://github.com/bitwarden/clients/actions/runs/26184289465)

## 📔 Objective
Corrected permissions for `cherry-pick` job
