### PR TITLE
Tear down `MutationObserver` on hidden tabs

### DIFF
--- a/apps/browser/src/autofill/services/collect-autofill-content.service.spec.ts
+++ b/apps/browser/src/autofill/services/collect-autofill-content.service.spec.ts
@@ -2333,6 +2333,17 @@ describe("CollectAutofillContentService", () => {
       expect(collectAutofillContentService["mutationObserver"]).toBeInstanceOf(MutationObserver);
       expect(collectAutofillContentService["mutationObserver"].observe).toHaveBeenCalled();
     });
+
+    it("registers the visibilitychange listener on the document", () => {
+      const addListenerSpy = jest.spyOn(document, "addEventListener");
+
+      collectAutofillContentService["setupMutationObserver"]();
+
+      expect(addListenerSpy).toHaveBeenCalledWith(
+        "visibilitychange",
+        collectAutofillContentService["handleVisibilityChange"],
+      );
+    });
   });
 
   describe("handleMutationObserverMutation", () => {
@@ -3226,6 +3237,136 @@ describe("CollectAutofillContentService", () => {
       collectAutofillContentService["processMutations"]();
 
       expect(collectAutofillContentService["mutationsQueue"]).toHaveLength(0);
+    });
+  });
+
+  describe("tab visibility handling", () => {
+    const setVisibilityState = (state: DocumentVisibilityState) => {
+      Object.defineProperty(document, "visibilityState", {
+        configurable: true,
+        get: () => state,
+      });
+    };
+
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.runOnlyPendingTimers();
+      jest.useRealTimers();
+      setVisibilityState("visible");
+    });
+
+    it("bails out of processMutations when the tab is hidden and preserves the queue", () => {
+      setVisibilityState("hidden");
+      const mutationRecord = {
+        type: "childList",
+        addedNodes: document.querySelectorAll("div"),
+        removedNodes: document.querySelectorAll("li"),
+        attributeName: null,
+        attributeNamespace: null,
+        nextSibling: null,
+        oldValue: null,
+        previousSibling: null,
+        target: document.body,
+      } as unknown as MutationRecord;
+      collectAutofillContentService["mutationsQueue"] = [[mutationRecord]];
+      const processRecordSpy = jest.spyOn(
+        collectAutofillContentService as any,
+        "processMutationRecord",
+      );
+
+      collectAutofillContentService["processMutations"]();
+
+      expect(processRecordSpy).not.toHaveBeenCalled();
+      expect(collectAutofillContentService["mutationsQueue"]).toHaveLength(1);
+      expect(collectAutofillContentService["hasPendingMutationsOnVisible"]).toBe(true);
+    });
+
+    it("bails out of updateAutofillElementsAfterMutation when the tab is hidden", () => {
+      setVisibilityState("hidden");
+      const requestIdleSpy = jest.spyOn(globalThis, "requestIdleCallback");
+
+      collectAutofillContentService["updateAutofillElementsAfterMutation"]();
+
+      expect(requestIdleSpy).not.toHaveBeenCalled();
+      expect(collectAutofillContentService["updateAfterMutationIdleCallback"]).toBeNull();
+      expect(collectAutofillContentService["hasPendingPageDetailsOnVisible"]).toBe(true);
+    });
+
+    it("reconciles pending mutations and page-details refresh when the tab becomes visible", () => {
+      setVisibilityState("visible");
+      collectAutofillContentService["hasPendingMutationsOnVisible"] = true;
+      collectAutofillContentService["hasPendingPageDetailsOnVisible"] = true;
+      const updateSpy = jest.spyOn(
+        collectAutofillContentService as any,
+        "updateAutofillElementsAfterMutation",
+      );
+      const requestIdleSpy = jest.spyOn(globalThis, "requestIdleCallback");
+
+      collectAutofillContentService["handleVisibilityChange"]();
+
+      expect(collectAutofillContentService["hasPendingMutationsOnVisible"]).toBe(false);
+      expect(collectAutofillContentService["hasPendingPageDetailsOnVisible"]).toBe(false);
+      expect(updateSpy).toHaveBeenCalledTimes(1);
+      expect(requestIdleSpy).toHaveBeenCalled();
+    });
+
+    it("drains a mutation queued while hidden once the tab becomes visible", () => {
+      setVisibilityState("hidden");
+      const mutationRecord = {
+        type: "childList",
+        addedNodes: document.querySelectorAll("div"),
+        removedNodes: document.querySelectorAll("li"),
+        attributeName: null,
+        attributeNamespace: null,
+        nextSibling: null,
+        oldValue: null,
+        previousSibling: null,
+        target: document.body,
+      } as unknown as MutationRecord;
+      collectAutofillContentService["mutationsQueue"] = [[mutationRecord]];
+      const processRecordSpy = jest
+        .spyOn(collectAutofillContentService as any, "processMutationRecord")
+        .mockImplementation(() => undefined);
+
+      collectAutofillContentService["processMutations"]();
+      expect(processRecordSpy).not.toHaveBeenCalled();
+
+      setVisibilityState("visible");
+      collectAutofillContentService["handleVisibilityChange"]();
+      jest.runAllTimers();
+
+      expect(processRecordSpy).toHaveBeenCalledWith(mutationRecord);
+      expect(collectAutofillContentService["mutationsQueue"]).toHaveLength(0);
+    });
+
+    it("does nothing on handleVisibilityChange when the document is still hidden", () => {
+      setVisibilityState("hidden");
+      collectAutofillContentService["hasPendingMutationsOnVisible"] = true;
+      collectAutofillContentService["hasPendingPageDetailsOnVisible"] = true;
+      const updateSpy = jest.spyOn(
+        collectAutofillContentService as any,
+        "updateAutofillElementsAfterMutation",
+      );
+
+      collectAutofillContentService["handleVisibilityChange"]();
+
+      expect(collectAutofillContentService["hasPendingMutationsOnVisible"]).toBe(true);
+      expect(collectAutofillContentService["hasPendingPageDetailsOnVisible"]).toBe(true);
+      expect(updateSpy).not.toHaveBeenCalled();
+    });
+
+    it("removes the visibilitychange listener on destroy", () => {
+      const removeListenerSpy = jest.spyOn(document, "removeEventListener");
+
+      collectAutofillContentService.destroy();
+
+      expect(removeListenerSpy).toHaveBeenCalledWith(
+        "visibilitychange",
+        collectAutofillContentService["handleVisibilityChange"],
+      );
     });
   });
 });

--- a/apps/browser/src/autofill/services/collect-autofill-content.service.spec.ts
+++ b/apps/browser/src/autofill/services/collect-autofill-content.service.spec.ts
@@ -3250,6 +3250,7 @@ describe("CollectAutofillContentService", () => {
 
     beforeEach(() => {
       jest.useFakeTimers();
+      collectAutofillContentService["setupMutationObserver"]();
     });
 
     afterEach(() => {
@@ -3258,104 +3259,43 @@ describe("CollectAutofillContentService", () => {
       setVisibilityState("visible");
     });
 
-    it("bails out of processMutations when the tab is hidden and preserves the queue", () => {
+    it("disconnects the MutationObserver and clears pending mutation work when the tab becomes hidden", () => {
       setVisibilityState("hidden");
-      const mutationRecord = {
-        type: "childList",
-        addedNodes: document.querySelectorAll("div"),
-        removedNodes: document.querySelectorAll("li"),
-        attributeName: null,
-        attributeNamespace: null,
-        nextSibling: null,
-        oldValue: null,
-        previousSibling: null,
-        target: document.body,
-      } as unknown as MutationRecord;
-      collectAutofillContentService["mutationsQueue"] = [[mutationRecord]];
-      const processRecordSpy = jest.spyOn(
-        collectAutofillContentService as any,
-        "processMutationRecord",
+      collectAutofillContentService["mutationsQueue"] = [
+        [{ type: "childList" } as unknown as MutationRecord],
+      ];
+      collectAutofillContentService["updateAfterMutationIdleCallback"] = 42 as any;
+      const disconnectSpy = jest.spyOn(
+        collectAutofillContentService["mutationObserver"]!,
+        "disconnect",
       );
 
-      collectAutofillContentService["processMutations"]();
+      collectAutofillContentService["handleVisibilityChange"]();
 
-      expect(processRecordSpy).not.toHaveBeenCalled();
-      expect(collectAutofillContentService["mutationsQueue"]).toHaveLength(1);
-      expect(collectAutofillContentService["hasPendingMutationsOnVisible"]).toBe(true);
-    });
-
-    it("bails out of updateAutofillElementsAfterMutation when the tab is hidden", () => {
-      setVisibilityState("hidden");
-      const requestIdleSpy = jest.spyOn(globalThis, "requestIdleCallback");
-
-      collectAutofillContentService["updateAutofillElementsAfterMutation"]();
-
-      expect(requestIdleSpy).not.toHaveBeenCalled();
+      expect(disconnectSpy).toHaveBeenCalled();
+      expect(collectAutofillContentService["mutationsQueue"]).toEqual([]);
       expect(collectAutofillContentService["updateAfterMutationIdleCallback"]).toBeNull();
-      expect(collectAutofillContentService["hasPendingPageDetailsOnVisible"]).toBe(true);
     });
 
-    it("reconciles pending mutations and page-details refresh when the tab becomes visible", () => {
+    it("re-observes the document and triggers a page-details rescan when the tab becomes visible", () => {
       setVisibilityState("visible");
-      collectAutofillContentService["hasPendingMutationsOnVisible"] = true;
-      collectAutofillContentService["hasPendingPageDetailsOnVisible"] = true;
+      const observeSpy = jest.spyOn(collectAutofillContentService["mutationObserver"]!, "observe");
       const updateSpy = jest.spyOn(
         collectAutofillContentService as any,
         "updateAutofillElementsAfterMutation",
       );
-      const requestIdleSpy = jest.spyOn(globalThis, "requestIdleCallback");
 
       collectAutofillContentService["handleVisibilityChange"]();
 
-      expect(collectAutofillContentService["hasPendingMutationsOnVisible"]).toBe(false);
-      expect(collectAutofillContentService["hasPendingPageDetailsOnVisible"]).toBe(false);
+      expect(observeSpy).toHaveBeenCalledWith(
+        document.documentElement,
+        expect.objectContaining({
+          attributes: true,
+          childList: true,
+          subtree: true,
+        }),
+      );
       expect(updateSpy).toHaveBeenCalledTimes(1);
-      expect(requestIdleSpy).toHaveBeenCalled();
-    });
-
-    it("drains a mutation queued while hidden once the tab becomes visible", () => {
-      setVisibilityState("hidden");
-      const mutationRecord = {
-        type: "childList",
-        addedNodes: document.querySelectorAll("div"),
-        removedNodes: document.querySelectorAll("li"),
-        attributeName: null,
-        attributeNamespace: null,
-        nextSibling: null,
-        oldValue: null,
-        previousSibling: null,
-        target: document.body,
-      } as unknown as MutationRecord;
-      collectAutofillContentService["mutationsQueue"] = [[mutationRecord]];
-      const processRecordSpy = jest
-        .spyOn(collectAutofillContentService as any, "processMutationRecord")
-        .mockImplementation(() => undefined);
-
-      collectAutofillContentService["processMutations"]();
-      expect(processRecordSpy).not.toHaveBeenCalled();
-
-      setVisibilityState("visible");
-      collectAutofillContentService["handleVisibilityChange"]();
-      jest.runAllTimers();
-
-      expect(processRecordSpy).toHaveBeenCalledWith(mutationRecord);
-      expect(collectAutofillContentService["mutationsQueue"]).toHaveLength(0);
-    });
-
-    it("does nothing on handleVisibilityChange when the document is still hidden", () => {
-      setVisibilityState("hidden");
-      collectAutofillContentService["hasPendingMutationsOnVisible"] = true;
-      collectAutofillContentService["hasPendingPageDetailsOnVisible"] = true;
-      const updateSpy = jest.spyOn(
-        collectAutofillContentService as any,
-        "updateAutofillElementsAfterMutation",
-      );
-
-      collectAutofillContentService["handleVisibilityChange"]();
-
-      expect(collectAutofillContentService["hasPendingMutationsOnVisible"]).toBe(true);
-      expect(collectAutofillContentService["hasPendingPageDetailsOnVisible"]).toBe(true);
-      expect(updateSpy).not.toHaveBeenCalled();
     });
 
     it("removes the visibilitychange listener on destroy", () => {

--- a/apps/browser/src/autofill/services/collect-autofill-content.service.ts
+++ b/apps/browser/src/autofill/services/collect-autofill-content.service.ts
@@ -71,26 +71,24 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
   private readonly maxMutationWaitMs = 5000;
   private readonly formFieldQueryString;
   private readonly debouncedProcessMutations = debounce(() => this.processMutations(), 100);
-  private hasPendingMutationsOnVisible = false;
-  private hasPendingPageDetailsOnVisible = false;
   private handleVisibilityChange = () => {
-    if (globalThis.document.visibilityState !== "visible") {
+    if (globalThis.document.visibilityState === "hidden") {
+      // Tear down all mutation-driven work while the tab is hidden. The rescan
+      // triggered on the visible transition re-derives autofill state from the
+      // current DOM, so we can drop in-flight records without losing signal.
+      // A still-pending debouncedProcessMutations fires harmlessly once the queue
+      // is empty (it early-returns at the length check).
+      this.mutationObserver?.disconnect();
+      this.mutationsQueue = [];
+      if (this.updateAfterMutationIdleCallback !== null) {
+        cancelIdleCallbackPolyfill(this.updateAfterMutationIdleCallback);
+        this.updateAfterMutationIdleCallback = null;
+      }
       return;
     }
 
-    if (this.hasPendingMutationsOnVisible) {
-      this.hasPendingMutationsOnVisible = false;
-      // Debounce coalesces the resume call with any visibility-burst mutations
-      // (lazy hydration, intersection observers) that fire in the next 100ms.
-      requestIdleCallbackPolyfill(this.debouncedProcessMutations, { timeout: 500 });
-    }
-
-    if (this.hasPendingPageDetailsOnVisible) {
-      this.hasPendingPageDetailsOnVisible = false;
-      // updateAutofillElementsAfterMutation schedules through requestIdleCallback itself,
-      // so wrapping this call would double-defer.
-      this.updateAutofillElementsAfterMutation();
-    }
+    this.observeDocumentMutations();
+    this.updateAutofillElementsAfterMutation();
   };
   private readonly nonInputFormFieldTags = new Set(["textarea", "select"]);
   private readonly ignoredInputTypes = new Set([
@@ -1227,13 +1225,17 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
   private setupMutationObserver() {
     this.currentLocationHref = globalThis.location.href;
     this.mutationObserver = new MutationObserver(this.handleMutationObserverMutation);
-    this.mutationObserver.observe(document.documentElement, {
+    this.observeDocumentMutations();
+    globalThis.document.addEventListener(EVENTS.VISIBILITYCHANGE, this.handleVisibilityChange);
+  }
+
+  private observeDocumentMutations() {
+    this.mutationObserver?.observe(document.documentElement, {
       attributes: true,
       attributeFilter: Object.values(AUTOFILL_ATTRIBUTES),
       childList: true,
       subtree: true,
     });
-    globalThis.document.addEventListener(EVENTS.VISIBILITYCHANGE, this.handleVisibilityChange);
   }
 
   /**
@@ -1310,11 +1312,6 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
    * Now all pending work is flattened and processed in a single idle callback.
    */
   private processMutations = () => {
-    if (globalThis.document.visibilityState === "hidden") {
-      this.hasPendingMutationsOnVisible = true;
-      return;
-    }
-
     // Flatten all pending batches into one array and clear the queue immediately
     // so that any new mutations arriving during processing go into a fresh queue.
     const allMutations = this.mutationsQueue.flat();
@@ -1591,11 +1588,6 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
     if (this.updateAfterMutationIdleCallback !== null) {
       cancelIdleCallbackPolyfill(this.updateAfterMutationIdleCallback);
       this.updateAfterMutationIdleCallback = null;
-    }
-
-    if (globalThis.document.visibilityState === "hidden") {
-      this.hasPendingPageDetailsOnVisible = true;
-      return;
     }
 
     const now = Date.now();

--- a/apps/browser/src/autofill/services/collect-autofill-content.service.ts
+++ b/apps/browser/src/autofill/services/collect-autofill-content.service.ts
@@ -1,4 +1,4 @@
-import { AUTOFILL_ATTRIBUTES } from "@bitwarden/common/autofill/constants";
+import { AUTOFILL_ATTRIBUTES, EVENTS } from "@bitwarden/common/autofill/constants";
 import { AutofillTargetingRuleType, FormContent } from "@bitwarden/common/autofill/types";
 
 import AutofillField from "../models/autofill-field";
@@ -71,6 +71,27 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
   private readonly maxMutationWaitMs = 5000;
   private readonly formFieldQueryString;
   private readonly debouncedProcessMutations = debounce(() => this.processMutations(), 100);
+  private hasPendingMutationsOnVisible = false;
+  private hasPendingPageDetailsOnVisible = false;
+  private handleVisibilityChange = () => {
+    if (globalThis.document.visibilityState !== "visible") {
+      return;
+    }
+
+    if (this.hasPendingMutationsOnVisible) {
+      this.hasPendingMutationsOnVisible = false;
+      // Debounce coalesces the resume call with any visibility-burst mutations
+      // (lazy hydration, intersection observers) that fire in the next 100ms.
+      requestIdleCallbackPolyfill(this.debouncedProcessMutations, { timeout: 500 });
+    }
+
+    if (this.hasPendingPageDetailsOnVisible) {
+      this.hasPendingPageDetailsOnVisible = false;
+      // updateAutofillElementsAfterMutation schedules through requestIdleCallback itself,
+      // so wrapping this call would double-defer.
+      this.updateAutofillElementsAfterMutation();
+    }
+  };
   private readonly nonInputFormFieldTags = new Set(["textarea", "select"]);
   private readonly ignoredInputTypes = new Set([
     "hidden",
@@ -1212,6 +1233,7 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
       childList: true,
       subtree: true,
     });
+    globalThis.document.addEventListener(EVENTS.VISIBILITYCHANGE, this.handleVisibilityChange);
   }
 
   /**
@@ -1288,6 +1310,11 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
    * Now all pending work is flattened and processed in a single idle callback.
    */
   private processMutations = () => {
+    if (globalThis.document.visibilityState === "hidden") {
+      this.hasPendingMutationsOnVisible = true;
+      return;
+    }
+
     // Flatten all pending batches into one array and clear the queue immediately
     // so that any new mutations arriving during processing go into a fresh queue.
     const allMutations = this.mutationsQueue.flat();
@@ -1564,6 +1591,11 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
     if (this.updateAfterMutationIdleCallback !== null) {
       cancelIdleCallbackPolyfill(this.updateAfterMutationIdleCallback);
       this.updateAfterMutationIdleCallback = null;
+    }
+
+    if (globalThis.document.visibilityState === "hidden") {
+      this.hasPendingPageDetailsOnVisible = true;
+      return;
     }
 
     const now = Date.now();
@@ -1936,6 +1968,7 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
     }
     this.pendingOverlaySetup.forEach((timeout) => globalThis.clearTimeout(timeout));
     this.pendingOverlaySetup.clear();
+    globalThis.document.removeEventListener(EVENTS.VISIBILITYCHANGE, this.handleVisibilityChange);
     if (this.mutationObserver !== null) {
       this.mutationObserver.disconnect();
       this.mutationObserver = null;


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

Adds a `visibilitychange` handler (on `document`) that disconnects the `MutationObserver` on hide and re-observes + unconditionally rescans on visible. `Mutation` records delivered during the hidden window are dropped — the visibility-return rescan re-derives autofill state from current DOM.

## Changes (relative to `main`)

- Adds `handleVisibilityChange` (arrow property) — on hide: `observer.disconnect()`, clear `mutationsQueue`, cancel `updateAfterMutationIdleCallback`. On visible: re-observe + rescan. (Aside: `chrome-perf-tab-mutation` keeps the observer running and uses two `hasPending*OnVisible` flags drained on the visible-side branch.)
- Adds `observeDocumentMutations()` — single source of truth for the `observe()` options. (Aside: not present on `chrome-perf-tab-mutation` — that branch has no visible-side re-observe, so the original inline call stayed.)
- In `setupMutationObserver`, swaps the inline `observe()` for `observeDocumentMutations()` and registers the `visibilitychange` listener.
- In `destroy`, removes the `visibilitychange` listener — paired teardown for the new registration.
- In imports, adds `EVENTS` alongside the existing `AUTOFILL_ATTRIBUTES` import — uses `EVENTS.VISIBILITYCHANGE` rather than a string literal, matching `autofill-overlay-content.service.ts`.
- Unchanged from `main`: `processMutations` and `updateAutofillElementsAfterMutation`. (Aside: `chrome-perf-tab-mutation` adds `visibilityState === "hidden"` bail-outs in both that set the flags; variant A doesn't need them because the hide-side teardown supersedes them.)