### PR TITLE
[PM-37798] Fix bank account section label to show "Bank account details"

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -2229,6 +2229,9 @@
   "bankAccount": {
     "message": "Bank account"
   },
+  "bankAccountDetails": {
+    "message": "Bank account details"
+  },
   "typeNote": {
     "message": "Note"
   },

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -5099,6 +5099,9 @@
   "bankAccount": {
     "message": "Bank account"
   },
+  "bankAccountDetails": {
+    "message": "Bank account details"
+  },
   "bankName": {
     "message": "Bank name"
   },

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -5338,6 +5338,9 @@
   "bankAccount": {
     "message": "Bank account"
   },
+  "bankAccountDetails": {
+    "message": "Bank account details"
+  },
   "amountX": {
     "message": "Amount $COUNT$",
     "description": "Used in bank account verification of micro-deposits. Amount, as in a currency amount. Ex. Amount 1 is $2.00, Amount 2 is $1.50",

--- a/libs/vault/src/cipher-form/components/bank-account-section/bank-account-section.component.html
+++ b/libs/vault/src/cipher-form/components/bank-account-section/bank-account-section.component.html
@@ -1,7 +1,7 @@
 <section [formGroup]="bankAccountForm" class="tw-mb-5 bit-compact:tw-mb-4">
   <bit-section-header>
     <h2 bitTypography="h6">
-      {{ "bankAccount" | i18n }}
+      {{ "bankAccountDetails" | i18n }}
     </h2>
   </bit-section-header>
   <bit-card>

--- a/libs/vault/src/cipher-view/bank-account-sections/bank-account-view.component.html
+++ b/libs/vault/src/cipher-view/bank-account-sections/bank-account-view.component.html
@@ -1,6 +1,6 @@
 <section class="tw-mb-5 bit-compact:tw-mb-4">
   <bit-section-header>
-    <h2 bitTypography="h6">{{ "bankAccount" | i18n }}</h2>
+    <h2 bitTypography="h6">{{ "bankAccountDetails" | i18n }}</h2>
   </bit-section-header>
   <read-only-cipher-card>
     @if (bankAccount().bankName) {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-37798](https://bitwarden.atlassian.net/browse/PM-37798)

## 📔 Objective

Adds a `bankAccountDetails` i18n key ("Bank account details") and updates the bank account form and view section headers to use it. This makes the bank account section label consistent with other item types (e.g. "Passport details", "License details").

## 📸 Screenshots
|View|Edit|
|-|-|
|<img width="490" height="616" alt="Screenshot 2026-05-21 at 8 51 22 AM" src="https://github.com/user-attachments/assets/e4d56b23-4941-41c2-a28e-66865cb9c23e" />|<img width="494" height="618" alt="Screenshot 2026-05-21 at 8 51 26 AM" src="https://github.com/user-attachments/assets/cb526ad0-c00b-4f3c-872a-a66fd60e9db9" />|


[PM-37798]: https://bitwarden.atlassian.net/browse/PM-37798?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ