### PR TITLE
[PM-37462] `bw get attachment` writes decrypted filename verbatim

### DIFF
--- a/apps/cli/src/commands/get.command.ts
+++ b/apps/cli/src/commands/get.command.ts
@@ -1,5 +1,7 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
+import * as path from "path";
+
 import { filter, firstValueFrom, map, switchMap } from "rxjs";
 
 import { CollectionService } from "@bitwarden/admin-console/common";
@@ -415,7 +417,7 @@ export class GetCommand extends DownloadCommand {
 
     return await this.saveAttachmentToFile(
       url,
-      attachments[0].fileName,
+      path.basename(attachments[0].fileName ?? `BitwardenAttachment-${Date.now()}`),
       decryptBufferFn,
       options.output,
     );


### PR DESCRIPTION
## 🎟️ Tracking

[Jira](https://bitwarden.atlassian.net/browse/PM-37462)

## 📔 Objective

To sanitize the attachment filename when saving the attachment to disk.