### PR TITLE
[bre-1942] improve native module cache busting logic

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -244,7 +244,7 @@ jobs:
             apps/desktop/desktop_native/dist/*
             ${{ env.RUNNER_TEMP }}/.cargo/registry
             ${{ env.RUNNER_TEMP }}/.cargo/git
-          key: rust-${{ runner.os }}-${{ hashFiles('apps/desktop/desktop_native/**/*') }}
+          key: rust-${{ runner.os }}-${{ hashFiles('apps/desktop/desktop_native/**/*', 'package-lock.json') }}
 
       - name: Build Native Module
         if: steps.cache.outputs.cache-hit != 'true'
@@ -407,7 +407,7 @@ jobs:
             apps/desktop/desktop_native/dist/*
             ${{ env.RUNNER_TEMP }}/.cargo/registry
             ${{ env.RUNNER_TEMP }}/.cargo/git
-          key: rust-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('apps/desktop/desktop_native/**/*') }}
+          key: rust-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('apps/desktop/desktop_native/**/*', 'package-lock.json') }}
 
       - name: Build Native Module
         if: steps.cache.outputs.cache-hit != 'true'
@@ -568,7 +568,7 @@ jobs:
           path: |
             apps/desktop/desktop_native/napi/*.node
             apps/desktop/desktop_native/dist/*
-          key: rust-${{ runner.os }}-${{ hashFiles('apps/desktop/desktop_native/**/*') }}
+          key: rust-${{ runner.os }}-${{ hashFiles('apps/desktop/desktop_native/**/*', 'package-lock.json') }}
 
       - name: Build Native Module
         if: steps.cache.outputs.cache-hit != 'true'
@@ -837,7 +837,7 @@ jobs:
           path: |
             apps/desktop/desktop_native/napi/*.node
             apps/desktop/desktop_native/dist/*
-          key: rust-${{ runner.os }}-${{ hashFiles('apps/desktop/desktop_native/**/*') }}
+          key: rust-${{ runner.os }}-${{ hashFiles('apps/desktop/desktop_native/**/*', 'package-lock.json') }}
 
       - name: Build Native Module
         if: steps.cache.outputs.cache-hit != 'true'
@@ -1185,7 +1185,7 @@ jobs:
           path: |
             apps/desktop/desktop_native/napi/*.node
             apps/desktop/desktop_native/dist/*
-          key: rust-${{ runner.os }}-${{ hashFiles('apps/desktop/desktop_native/**/*') }}
+          key: rust-${{ runner.os }}-${{ hashFiles('apps/desktop/desktop_native/**/*', 'package-lock.json') }}
 
       - name: Build Native Module
         if: steps.cache.outputs.cache-hit != 'true'
@@ -1400,7 +1400,7 @@ jobs:
           path: |
             apps/desktop/desktop_native/napi/*.node
             apps/desktop/desktop_native/dist/*
-          key: rust-${{ runner.os }}-${{ hashFiles('apps/desktop/desktop_native/**/*') }}
+          key: rust-${{ runner.os }}-${{ hashFiles('apps/desktop/desktop_native/**/*', 'package-lock.json') }}
 
       - name: Build Native Module
         if: steps.cache.outputs.cache-hit != 'true'
@@ -1677,7 +1677,7 @@ jobs:
           path: |
             apps/desktop/desktop_native/napi/*.node
             apps/desktop/desktop_native/dist/*
-          key: rust-${{ runner.os }}-${{ hashFiles('apps/desktop/desktop_native/**/*') }}
+          key: rust-${{ runner.os }}-${{ hashFiles('apps/desktop/desktop_native/**/*', 'package-lock.json') }}
 
       - name: Build Native Module
         if: steps.cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
## 🎟️ Tracking
[BRE-1942](https://bitwarden.atlassian.net/browse/BRE-1942)

## 📔 Objective

Adds `package-lock.json` to the native module cache key so that lockfile changes always force a fresh build of the desktop native module.

## ⚠️ Note
This PR's desktop builds will fail until #20785 is approved, merged and pulled into this branch

## Problem

The native module cache key previously only hashed files under `apps/desktop/desktop_native/**/*`. This meant changes to `package-lock.json` — the file that controls exactly what npm installs at build time — had no effect on the cache. A stale or broken lockfile could silently pass through CI if a warm cache existed, because the build step is skipped entirely on a cache hit.

This is exactly what happened in #19725 (Angular 21 upgrade): the lockfile was left in a broken state, but every build job got a cache hit and went green without ever running `napi build`. The breakage only surfaced later when the cache expired organically, blocking developers who pulled `main` and tried to build locally. 

## Fix

Added `package-lock.json` as a second input to `hashFiles()` on all 7 native module cache key
definitions in `build-desktop.yml`:

```yaml
# before
key: rust-${{ runner.os }}-${{ hashFiles('apps/desktop/desktop_native/**/*') }}

# after
key: rust-${{ runner.os }}-${{ hashFiles('apps/desktop/desktop_native/**/*', 'package-lock.json') }}
```

Any change to `package-lock.json` — whether from a dependency bump, a Renovate PR, or a lockfile regeneration now busts the native module cache and forces a real build. Broken lockfile states can no longer hide behind a cache hit.

## Tradeoff

`package-lock.json` changes a little under once per day in this repo. This will cause the occasional native module rebuild (~5 min per platform) that would not have happened before. I believe this cost is acceptable: the alternative is broken builds going undetected until a developer hits them locally, which has proven to be significantly time consuming.


[BRE-1942]: https://bitwarden.atlassian.net/browse/BRE-1942?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ