### PR TITLE
[PM-37825] Fix partial date validation blocking save and improve error count accuracy

### DIFF
--- a/libs/vault/src/cipher-form/components/cipher-form.component.ts
+++ b/libs/vault/src/cipher-form/components/cipher-form.component.ts
@@ -361,7 +361,11 @@ export class CipherFormComponent implements AfterViewInit, OnInit, OnChanges, Ci
       if (control instanceof FormGroup) {
         return count + this.countInvalidFields(control);
       }
-      return count + (control.invalid ? 1 : 0);
+
+      // Complex child components may have multiple fields.
+      // They can pass `fieldCount` in the errors object to specify how many fields are invalid.
+      const fieldCount = control.invalid ? ((control.errors?.["fieldCount"] as number) ?? 1) : 0;
+      return count + fieldCount;
     }, 0);
   }
 

--- a/libs/vault/src/cipher-form/components/date-field-group/date-field-group.component.spec.ts
+++ b/libs/vault/src/cipher-form/components/date-field-group/date-field-group.component.spec.ts
@@ -304,6 +304,39 @@ describe("DateFieldGroupComponent", () => {
 
       expect(component.internalForm.valid).toBe(true);
     }));
+
+    it("returns invalidDate with fieldCount 2 when only month is filled (no blur)", fakeAsync(() => {
+      component.internalForm.patchValue({ month: "4", day: "", year: "" });
+      tick();
+      expect(component.validate()).toEqual({ invalidDate: true, fieldCount: 2 });
+    }));
+
+    it("returns invalidDate with fieldCount 1 when month and day are filled but year is missing (no blur)", fakeAsync(() => {
+      component.internalForm.patchValue({ month: "4", day: "15", year: "" });
+      tick();
+      expect(component.validate()).toEqual({ invalidDate: true, fieldCount: 1 });
+    }));
+
+    it("returns null when all fields are empty (no blur)", fakeAsync(() => {
+      component.internalForm.patchValue({ month: "", day: "", year: "" });
+      tick();
+      expect(component.validate()).toBeNull();
+    }));
+
+    it("returns null after filling fields and clearing them all (stale crossFieldRequired errors)", fakeAsync(() => {
+      component.internalForm.patchValue({ month: "4", day: "", year: "" });
+      tick();
+      component.onGroupBlur(new FocusEvent("blur", { relatedTarget: document.body as any }));
+      component.internalForm.patchValue({ month: "", day: "", year: "" });
+      tick();
+      expect(component.validate()).toBeNull();
+    }));
+
+    it("returns null when all fields are filled (no blur)", fakeAsync(() => {
+      component.internalForm.patchValue({ month: "4", day: "15", year: "2025" });
+      tick();
+      expect(component.validate()).toBeNull();
+    }));
   });
 
   describe("onGroupBlur", () => {

--- a/libs/vault/src/cipher-form/components/date-field-group/date-field-group.component.ts
+++ b/libs/vault/src/cipher-form/components/date-field-group/date-field-group.component.ts
@@ -151,7 +151,7 @@ export class DateFieldGroupComponent implements OnInit, ControlValueAccessor, Va
     }
 
     if (!allFilled || this.internalForm.invalid) {
-      const fieldCount = values.filter((v) => !v).length;
+      const fieldCount = values.filter((v) => !v).length || 1;
       return { invalidDate: true, fieldCount };
     }
 

--- a/libs/vault/src/cipher-form/components/date-field-group/date-field-group.component.ts
+++ b/libs/vault/src/cipher-form/components/date-field-group/date-field-group.component.ts
@@ -133,7 +133,29 @@ export class DateFieldGroupComponent implements OnInit, ControlValueAccessor, Va
   }
 
   validate(): ValidationErrors | null {
-    return this.internalForm.invalid ? { invalidDate: true } : null;
+    const monthControl = this.internalForm.get("month")! as AbstractControl<string>;
+    const dayControl = this.internalForm.get("day")! as AbstractControl<string>;
+    const yearControl = this.internalForm.get("year")! as AbstractControl<string>;
+
+    const values = [
+      monthControl.value?.trim(),
+      dayControl.value?.trim(),
+      yearControl.value?.trim(),
+    ];
+
+    const anyFilled = values.some((v) => !!v);
+    const allFilled = values.every((v) => !!v);
+
+    if (!anyFilled) {
+      return null;
+    }
+
+    if (!allFilled || this.internalForm.invalid) {
+      const fieldCount = values.filter((v) => !v).length;
+      return { invalidDate: true, fieldCount };
+    }
+
+    return null;
   }
 
   registerOnValidatorChange(fn: () => void): void {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-37825](https://bitwarden.atlassian.net/browse/PM-37825)

## 📔 Objective

Fixes a bug where entering a partial date in the Passport or Driver's License cipher and clicking Save without blurring the date group would bypass validation and allow saving. Also fixes the submit error toast to accurately report the number of missing date sub-fields (e.g. "2 fields need your attention") rather than always showing "1 field".

## 📸 Screenshots

<video src="https://github.com/user-attachments/assets/8ac25650-2009-4cf2-9340-b23b2c01f819" />

[PM-37825]: https://bitwarden.atlassian.net/browse/PM-37825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ