### PR TITLE
[PM-29615] Replace ClientType usage from LoginViaWebAuthnComponent

### DIFF
--- a/apps/browser/src/auth/popup/login-via-webauthn/extension-login-via-webauthn-component.service.spec.ts
+++ b/apps/browser/src/auth/popup/login-via-webauthn/extension-login-via-webauthn-component.service.spec.ts
@@ -1,0 +1,43 @@
+import { MockProxy, mock } from "jest-mock-extended";
+
+import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
+
+import { ExtensionLoginViaWebAuthnComponentService } from "./extension-login-via-webauthn-component.service";
+
+describe("ExtensionLoginViaWebAuthnComponentService", () => {
+  let service: ExtensionLoginViaWebAuthnComponentService;
+  let messagingService: MockProxy<MessagingService>;
+  let windowCloseSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    messagingService = mock<MessagingService>();
+    windowCloseSpy = jest.spyOn(window, "close").mockImplementation(() => undefined);
+    service = new ExtensionLoginViaWebAuthnComponentService(messagingService);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("sets successRoute to /tabs/vault", () => {
+    expect(service.successRoute).toBe("/tabs/vault");
+  });
+
+  describe("handleSuccessfulAuthentication", () => {
+    it("returns false and does not close the popout when shouldAutoClosePopout is false", async () => {
+      const result = await service.handleSuccessfulAuthentication(false);
+
+      expect(result).toBe(false);
+      expect(messagingService.send).not.toHaveBeenCalled();
+      expect(windowCloseSpy).not.toHaveBeenCalled();
+    });
+
+    it("sends openPopup, closes the window, and returns true when shouldAutoClosePopout is true", async () => {
+      const result = await service.handleSuccessfulAuthentication(true);
+
+      expect(messagingService.send).toHaveBeenCalledWith("openPopup");
+      expect(windowCloseSpy).toHaveBeenCalled();
+      expect(result).toBe(true);
+    });
+  });
+});

--- a/apps/browser/src/auth/popup/login-via-webauthn/extension-login-via-webauthn-component.service.ts
+++ b/apps/browser/src/auth/popup/login-via-webauthn/extension-login-via-webauthn-component.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from "@angular/core";
+
+import { DefaultLoginViaWebAuthnComponentService } from "@bitwarden/angular/auth/login-via-webauthn/default-login-via-webauthn-component.service";
+import { LoginViaWebAuthnComponentService } from "@bitwarden/angular/auth/login-via-webauthn/login-via-webauthn-component.service";
+import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
+
+@Injectable()
+export class ExtensionLoginViaWebAuthnComponentService
+  extends DefaultLoginViaWebAuthnComponentService
+  implements LoginViaWebAuthnComponentService
+{
+  override successRoute = "/tabs/vault";
+
+  constructor(private messagingService: MessagingService) {
+    super();
+  }
+
+  async handleSuccessfulAuthentication(shouldAutoClosePopout: boolean): Promise<boolean> {
+    if (shouldAutoClosePopout) {
+      this.messagingService.send("openPopup");
+      window.close();
+      return true;
+    }
+    return false;
+  }
+}

--- a/apps/browser/src/popup/services/services.module.ts
+++ b/apps/browser/src/popup/services/services.module.ts
@@ -5,6 +5,7 @@ import { merge, of, Subject } from "rxjs";
 
 import { CollectionService } from "@bitwarden/admin-console/common";
 import { DeviceManagementComponentServiceAbstraction } from "@bitwarden/angular/auth/device-management/device-management-component.service.abstraction";
+import { LoginViaWebAuthnComponentService } from "@bitwarden/angular/auth/login-via-webauthn/login-via-webauthn-component.service";
 import { ChangePasswordService } from "@bitwarden/angular/auth/password-management/change-password";
 import { AngularThemingService } from "@bitwarden/angular/platform/services/theming/angular-theming.service";
 import { SafeProvider, safeProvider } from "@bitwarden/angular/platform/utils/safe-provider";
@@ -180,6 +181,7 @@ import { ForegroundLockService } from "../../auth/popup/accounts/foreground-lock
 import { ExtensionChangePasswordService } from "../../auth/popup/change-password/extension-change-password.service";
 import { ExtensionLoginComponentService } from "../../auth/popup/login/extension-login-component.service";
 import { ExtensionSsoComponentService } from "../../auth/popup/login/extension-sso-component.service";
+import { ExtensionLoginViaWebAuthnComponentService } from "../../auth/popup/login-via-webauthn/extension-login-via-webauthn-component.service";
 import { ExtensionLogoutService } from "../../auth/popup/logout/extension-logout.service";
 import { ExtensionDeviceManagementComponentService } from "../../auth/services/extension-device-management-component.service";
 import { ExtensionTwoFactorAuthComponentService } from "../../auth/services/extension-two-factor-auth-component.service";
@@ -708,6 +710,11 @@ const safeProviders: SafeProvider[] = [
       ExtensionAnonLayoutWrapperDataService,
       SsoUrlService,
     ],
+  }),
+  safeProvider({
+    provide: LoginViaWebAuthnComponentService,
+    useClass: ExtensionLoginViaWebAuthnComponentService,
+    deps: [MessagingService],
   }),
   safeProvider({
     provide: LockService,

--- a/apps/web/src/app/core/core.module.ts
+++ b/apps/web/src/app/core/core.module.ts
@@ -12,6 +12,8 @@ import {
   OrganizationUserApiService,
   OrganizationUserService,
 } from "@bitwarden/admin-console/common";
+import { DefaultLoginViaWebAuthnComponentService } from "@bitwarden/angular/auth/login-via-webauthn/default-login-via-webauthn-component.service";
+import { LoginViaWebAuthnComponentService } from "@bitwarden/angular/auth/login-via-webauthn/login-via-webauthn-component.service";
 import { ChangePasswordService } from "@bitwarden/angular/auth/password-management/change-password";
 import { SetInitialPasswordService } from "@bitwarden/angular/auth/password-management/set-initial-password/set-initial-password.service.abstraction";
 import { PremiumInterestStateService } from "@bitwarden/angular/billing/services/premium-interest/premium-interest-state.service.abstraction";
@@ -354,6 +356,11 @@ const safeProviders: SafeProvider[] = [
       AccountService,
       ConfigService,
     ],
+  }),
+  safeProvider({
+    provide: LoginViaWebAuthnComponentService,
+    useClass: DefaultLoginViaWebAuthnComponentService,
+    deps: [],
   }),
   safeProvider({
     provide: CollectionAdminService,

--- a/libs/angular/src/auth/login-via-webauthn/default-login-via-webauthn-component.service.ts
+++ b/libs/angular/src/auth/login-via-webauthn/default-login-via-webauthn-component.service.ts
@@ -1,0 +1,5 @@
+import { LoginViaWebAuthnComponentService } from "./login-via-webauthn-component.service";
+
+export class DefaultLoginViaWebAuthnComponentService implements LoginViaWebAuthnComponentService {
+  successRoute = "/vault";
+}

--- a/libs/angular/src/auth/login-via-webauthn/login-via-webauthn-component.service.ts
+++ b/libs/angular/src/auth/login-via-webauthn/login-via-webauthn-component.service.ts
@@ -1,0 +1,11 @@
+export abstract class LoginViaWebAuthnComponentService {
+  /** The client-specific success route after WebAuthn authentication. */
+  abstract successRoute: string;
+
+  /**
+   * Optionally handles post-authentication logic before route navigation.
+   * Returns true if the service handled navigation (component must not navigate).
+   * Used by: Browser extension (popout auto-close behavior)
+   */
+  handleSuccessfulAuthentication?: (shouldAutoClosePopout: boolean) => Promise<boolean>;
+}

--- a/libs/angular/src/auth/login-via-webauthn/login-via-webauthn.component.ts
+++ b/libs/angular/src/auth/login-via-webauthn/login-via-webauthn.component.ts
@@ -15,12 +15,9 @@ import {
 import { LoginSuccessHandlerService } from "@bitwarden/auth/common";
 import { WebAuthnLoginServiceAbstraction } from "@bitwarden/common/auth/abstractions/webauthn/webauthn-login.service.abstraction";
 import { WebAuthnLoginCredentialAssertionView } from "@bitwarden/common/auth/models/view/webauthn-login/webauthn-login-credential-assertion.view";
-import { ClientType } from "@bitwarden/common/enums";
 import { ErrorResponse } from "@bitwarden/common/models/response/error.response";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
-import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
-import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { ValidationService } from "@bitwarden/common/platform/abstractions/validation.service";
 import {
   AnonLayoutWrapperDataService,
@@ -30,6 +27,8 @@ import {
   TypographyModule,
 } from "@bitwarden/components";
 import { KeyService } from "@bitwarden/key-management";
+
+import { LoginViaWebAuthnComponentService } from "./login-via-webauthn-component.service";
 
 export type State = "assert" | "assertFailed";
 // FIXME(https://bitwarden.atlassian.net/browse/CL-764): Migrate to OnPush
@@ -57,18 +56,6 @@ export class LoginViaWebAuthnComponent implements OnInit {
     TwoFactorAuthSecurityKeyFailedIcon,
   };
 
-  private readonly successRoutes: Record<ClientType, string> = {
-    [ClientType.Web]: "/vault",
-    [ClientType.Browser]: "/tabs/vault",
-    [ClientType.Desktop]: "/vault",
-    [ClientType.Cli]: "/vault",
-  };
-
-  protected get successRoute(): string {
-    const clientType = this.platformUtilsService.getClientType();
-    return this.successRoutes[clientType] || "/vault";
-  }
-
   constructor(
     private webAuthnLoginService: WebAuthnLoginServiceAbstraction,
     private router: Router,
@@ -78,9 +65,8 @@ export class LoginViaWebAuthnComponent implements OnInit {
     private i18nService: I18nService,
     private loginSuccessHandlerService: LoginSuccessHandlerService,
     private keyService: KeyService,
-    private platformUtilsService: PlatformUtilsService,
     private anonLayoutWrapperDataService: AnonLayoutWrapperDataService,
-    private messagingService: MessagingService,
+    private loginViaWebAuthnComponentService: LoginViaWebAuthnComponentService,
   ) {}
 
   ngOnInit(): void {
@@ -131,18 +117,13 @@ export class LoginViaWebAuthnComponent implements OnInit {
         await this.loginSuccessHandlerService.run(authResult.userId, null);
       }
 
-      // If autoClosePopout is enabled and we're in a browser extension,
-      // re-open the regular popup and close this popout window
-      if (
-        this.shouldAutoClosePopout &&
-        this.platformUtilsService.getClientType() === ClientType.Browser
-      ) {
-        this.messagingService.send("openPopup");
-        window.close();
-        return;
+      const handled =
+        (await this.loginViaWebAuthnComponentService.handleSuccessfulAuthentication?.(
+          this.shouldAutoClosePopout,
+        )) ?? false;
+      if (!handled) {
+        await this.router.navigate([this.loginViaWebAuthnComponentService.successRoute]);
       }
-
-      await this.router.navigate([this.successRoute]);
     } catch (error) {
       if (error instanceof ErrorResponse) {
         this.validationService.showError(this.i18nService.t("invalidPasskeyPleaseTryAgain"));


### PR DESCRIPTION
## 🎟️ Tracking

[PM-29615](https://bitwarden.atlassian.net/browse/PM-29615)

## 📔 Objective

Replaces `ClientType` usage in the cross-client `LoginViaWebAuthnComponent` with client-specific services.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->


[PM-29615]: https://bitwarden.atlassian.net/browse/PM-29615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ