### PR TITLE
[PM-24173] Fix credential generator constraint bypass

### DIFF
--- a/libs/tools/generator/components/src/password-settings.component.html
+++ b/libs/tools/generator/components/src/password-settings.component.html
@@ -9,7 +9,14 @@
       <bit-card>
         <bit-form-field disableMargin>
           <bit-label>{{ "length" | i18n }}</bit-label>
-          <input bitInput formControlName="length" type="number" (change)="save('length')" />
+          <input
+            bitInput
+            formControlName="length"
+            type="number"
+            [min]="lengthMin"
+            [max]="lengthMax"
+            (change)="save('length')"
+          />
           <bit-hint>{{ lengthBoundariesHint$ | async }}</bit-hint>
         </bit-form-field>
       </bit-card>
@@ -78,6 +85,8 @@
               bitInput
               type="number"
               formControlName="minNumber"
+              [min]="minNumberMin"
+              [max]="minNumberMax"
               (change)="save('minNumbers')"
             />
           </bit-form-field>
@@ -87,6 +96,8 @@
               bitInput
               type="number"
               formControlName="minSpecial"
+              [min]="minSpecialMin"
+              [max]="minSpecialMax"
               (change)="save('minSpecial')"
             />
           </bit-form-field>

--- a/libs/tools/generator/components/src/password-settings.component.ts
+++ b/libs/tools/generator/components/src/password-settings.component.ts
@@ -10,7 +10,13 @@ import {
   SimpleChanges,
   OnChanges,
 } from "@angular/core";
-import { FormBuilder, ReactiveFormsModule } from "@angular/forms";
+import {
+  AbstractControl,
+  FormBuilder,
+  ReactiveFormsModule,
+  ValidatorFn,
+  Validators,
+} from "@angular/forms";
 import { takeUntil, Subject, map, filter, tap, skip, ReplaySubject, withLatestFrom } from "rxjs";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
@@ -179,6 +185,29 @@ export class PasswordSettingsComponent implements OnInit, OnChanges, OnDestroy {
         }
         this.lengthBoundariesHint.next(boundariesHint);
 
+        this.lengthMin = constraints.length?.min ?? null;
+        this.lengthMax = constraints.length?.max ?? null;
+        this.minNumberMin = constraints.minNumber?.min ?? null;
+        this.minNumberMax = constraints.minNumber?.max ?? null;
+        this.minSpecialMin = constraints.minSpecial?.min ?? null;
+        this.minSpecialMax = constraints.minSpecial?.max ?? null;
+
+        this.applyRangeValidators(
+          this.settings.get(Controls.length)!,
+          this.lengthMin,
+          this.lengthMax,
+        );
+        this.applyRangeValidators(
+          this.settings.get(Controls.minNumber)!,
+          this.minNumberMin,
+          this.minNumberMax,
+        );
+        this.applyRangeValidators(
+          this.settings.get(Controls.minSpecial)!,
+          this.minSpecialMin,
+          this.minSpecialMax,
+        );
+
         // skips reactive event emissions to break a subscription cycle
         this.settings.patchValue(state, { emitEvent: false });
       });
@@ -286,6 +315,26 @@ export class PasswordSettingsComponent implements OnInit, OnChanges, OnDestroy {
 
   /** display binding for min/max constraints of `length` */
   protected lengthBoundariesHint$ = this.lengthBoundariesHint.asObservable();
+
+  /** attribute bindings for the spinbox min/max attributes */
+  protected lengthMin: number | null = null;
+  protected lengthMax: number | null = null;
+  protected minNumberMin: number | null = null;
+  protected minNumberMax: number | null = null;
+  protected minSpecialMin: number | null = null;
+  protected minSpecialMax: number | null = null;
+
+  private applyRangeValidators(control: AbstractControl, min: number | null, max: number | null) {
+    const validators: ValidatorFn[] = [];
+    if (min !== null) {
+      validators.push(Validators.min(min));
+    }
+    if (max !== null) {
+      validators.push(Validators.max(max));
+    }
+    control.setValidators(validators);
+    control.updateValueAndValidity({ emitEvent: false });
+  }
 
   private toggleEnabled(setting: keyof typeof Controls, enabled: boolean) {
     if (enabled) {

--- a/libs/tools/generator/core/src/policies/dynamic-password-policy-constraints.spec.ts
+++ b/libs/tools/generator/core/src/policies/dynamic-password-policy-constraints.spec.ts
@@ -275,5 +275,31 @@ describe("DynamicPasswordPolicyConstraints", () => {
 
       expect(calibrated.constraints.minSpecial).toEqual(Zero);
     });
+
+    it("preserves the minSpecial constraint when the policy sets specialCount and the state's special flag is false", () => {
+      const policy = { ...disabledPolicy, specialCount: 3 };
+      const dynamic = new DynamicPasswordPolicyConstraints(policy, someConstraints);
+      const state = {
+        ...defaultOptions,
+        special: false,
+      };
+
+      const calibrated = dynamic.calibrate(state);
+
+      expect(calibrated.constraints.minSpecial).toEqual({ min: 3, max: 9 });
+    });
+
+    it("preserves the minNumber constraint when the policy sets numberCount and the state's number flag is false", () => {
+      const policy = { ...disabledPolicy, numberCount: 3 };
+      const dynamic = new DynamicPasswordPolicyConstraints(policy, someConstraints);
+      const state = {
+        ...defaultOptions,
+        number: false,
+      };
+
+      const calibrated = dynamic.calibrate(state);
+
+      expect(calibrated.constraints.minNumber).toEqual({ min: 3, max: 9 });
+    });
   });
 });

--- a/libs/tools/generator/core/src/policies/dynamic-password-policy-constraints.ts
+++ b/libs/tools/generator/core/src/policies/dynamic-password-policy-constraints.ts
@@ -59,11 +59,21 @@ export class DynamicPasswordPolicyConstraints implements DynamicStateConstraints
   readonly constraints: PolicyConstraints<PasswordGeneratorSettings>;
 
   calibrate(state: PasswordGeneratorSettings): StateConstraints<PasswordGeneratorSettings> {
-    // decide which constraints are active
+    // decide which constraints are active. A policy-derived minimum for
+    // numbers/special characters must keep its character class enabled even
+    // when the user has unchecked the matching checkbox; otherwise an admin
+    // policy that sets `minSpecial`/`minNumbers` without also enforcing
+    // `useSpecial`/`useNumbers` would be silently bypassed.
     const lowercase = state.lowercase || this.constraints.lowercase?.requiredValue || false;
     const uppercase = state.uppercase || this.constraints.uppercase?.requiredValue || false;
-    const number = state.number || this.constraints.number?.requiredValue || false;
-    const special = state.special || this.constraints.special?.requiredValue || false;
+    const number =
+      state.number ||
+      this.constraints.number?.requiredValue ||
+      (this.constraints.minNumber?.min ?? 0) > 0;
+    const special =
+      state.special ||
+      this.constraints.special?.requiredValue ||
+      (this.constraints.minSpecial?.min ?? 0) > 0;
 
     // minimum constraints cannot `atLeast(state...) because doing so would force
     // the constrained value to only increase


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-24173

## 📔 Objective

This PR introduces adjustments in how generator policies are calibrated, and ensures that constraints are enforced. 

Formerly, min/max values were not always enforced, now, as the screenshot below demonstrates, invalid values will not be allowed. 

## 📸 Screenshots

<img width="690" height="983" alt="Screenshot 2026-05-22 at 07 38 37" src="https://github.com/user-attachments/assets/d24acad3-3c91-4644-be91-886561792282" />