### PR TITLE
[PM-37970] Fix vault list icons for Login and Identity with new item types flag

### DIFF
--- a/apps/browser/src/vault/popup/settings/archive.component.spec.ts
+++ b/apps/browser/src/vault/popup/settings/archive.component.spec.ts
@@ -10,6 +10,7 @@ import { PopupRouterCacheService } from "@bitwarden/browser/platform/popup/view-
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { DomainSettingsService } from "@bitwarden/common/autofill/services/domain-settings.service";
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { EnvironmentService } from "@bitwarden/common/platform/abstractions/environment.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
@@ -96,6 +97,10 @@ describe("ArchiveComponent", () => {
           useValue: {
             canDeleteCipher$: jest.fn().mockReturnValue(of(true)),
           },
+        },
+        {
+          provide: ConfigService,
+          useValue: { getFeatureFlag$: jest.fn().mockReturnValue(of(false)) },
         },
       ],
     })

--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/v2/activity-tab/new-applications-dialog-v2/new-applications-dialog-v2.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/v2/activity-tab/new-applications-dialog-v2/new-applications-dialog-v2.component.spec.ts
@@ -7,6 +7,7 @@ import { AccessIntelligenceDataService } from "@bitwarden/bit-common/dirt/access
 import { createReport } from "@bitwarden/bit-common/dirt/reports/risk-insights/testing/test-helpers";
 import { DomainSettingsService } from "@bitwarden/common/autofill/services/domain-settings.service";
 import { ErrorResponse } from "@bitwarden/common/models/response/error.response";
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { EnvironmentService } from "@bitwarden/common/platform/abstractions/environment.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
@@ -146,6 +147,10 @@ describe("NewApplicationsDialogV2Component", () => {
         { provide: EnvironmentService, useValue: mockEnvironmentService },
         { provide: DomainSettingsService, useValue: mockDomainSettingsService },
         { provide: DIALOG_DATA, useValue: mockDialogData },
+        {
+          provide: ConfigService,
+          useValue: { getFeatureFlag$: jest.fn().mockReturnValue(of(false)) },
+        },
       ],
       schemas: [NO_ERRORS_SCHEMA], // Ignore child component errors for unit testing
     });
@@ -543,6 +548,10 @@ describe("NewApplicationsDialogV2Component", () => {
           },
           { provide: ToastService, useValue: mockToastService },
           { provide: DIALOG_DATA, useValue: emptyDialogData },
+          {
+            provide: ConfigService,
+            useValue: { getFeatureFlag$: jest.fn().mockReturnValue(of(false)) },
+          },
         ],
         schemas: [NO_ERRORS_SCHEMA],
       }).compileComponents();
@@ -575,6 +584,10 @@ describe("NewApplicationsDialogV2Component", () => {
           },
           { provide: ToastService, useValue: mockToastService },
           { provide: DIALOG_DATA, useValue: dialogDataWithCritical },
+          {
+            provide: ConfigService,
+            useValue: { getFeatureFlag$: jest.fn().mockReturnValue(of(false)) },
+          },
         ],
         schemas: [NO_ERRORS_SCHEMA],
       }).compileComponents();

--- a/libs/angular/src/vault/components/icon.component.ts
+++ b/libs/angular/src/vault/components/icon.component.ts
@@ -12,6 +12,8 @@ import {
 } from "rxjs";
 
 import { DomainSettingsService } from "@bitwarden/common/autofill/services/domain-settings.service";
+import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { EnvironmentService } from "@bitwarden/common/platform/abstractions/environment.service";
 import { buildCipherIcon, CipherIconDetails } from "@bitwarden/common/vault/icon/build-cipher-icon";
 import { CipherViewLike } from "@bitwarden/common/vault/utils/cipher-view-like-utils";
@@ -64,6 +66,7 @@ export class IconComponent {
   constructor(
     private readonly environmentService: EnvironmentService,
     private readonly domainSettingsService: DomainSettingsService,
+    private readonly configService: ConfigService,
   ) {
     const iconSettings$ = combineLatest([
       this.environmentService.environment$.pipe(map((e) => e.getIconsUrl())),
@@ -74,8 +77,12 @@ export class IconComponent {
       distinctUntilChanged(),
     );
 
-    this.data$ = combineLatest([iconSettings$, toObservable(this.cipher)]).pipe(
-      map(([{ iconsUrl, showFavicon }, cipher]) => buildCipherIcon(iconsUrl, cipher, showFavicon)),
+    const newItemTypes$ = this.configService.getFeatureFlag$(FeatureFlag.PM32009NewItemTypes);
+
+    this.data$ = combineLatest([iconSettings$, toObservable(this.cipher), newItemTypes$]).pipe(
+      map(([{ iconsUrl, showFavicon }, cipher, newItemTypes]) =>
+        buildCipherIcon(iconsUrl, cipher, showFavicon, newItemTypes),
+      ),
       startWith(null),
       pairwise(),
       tap(([prev, next]) => {

--- a/libs/common/src/vault/icon/build-cipher-icon.spec.ts
+++ b/libs/common/src/vault/icon/build-cipher-icon.spec.ts
@@ -135,9 +135,72 @@ describe("buildCipherIcon", () => {
       });
     });
 
+    it("returns bwi-lock icon when newItemTypes is true and there is no uri", () => {
+      setUri(null as any as string);
+
+      const iconDetails = buildCipherIcon(iconServerUrl, cipher, true, true);
+
+      expect(iconDetails).toEqual({
+        icon: "bwi-lock",
+        image: null,
+        fallbackImage: "",
+        imageEnabled: true,
+      });
+    });
+
+    it("returns bwi-lock icon with favicon resolved when newItemTypes is true", () => {
+      setUri("https://test.example");
+
+      const iconDetails = buildCipherIcon(iconServerUrl, cipher, true, true);
+
+      expect(iconDetails).toEqual({
+        icon: "bwi-lock",
+        image: "https://icons.example/test.example/icon.png",
+        fallbackImage: "images/bwi-globe.png",
+        imageEnabled: true,
+      });
+    });
+
+    it("returns bwi-globe icon when newItemTypes is false", () => {
+      setUri(null as any as string);
+
+      const iconDetails = buildCipherIcon(iconServerUrl, cipher, true, false);
+
+      expect(iconDetails).toEqual({
+        icon: "bwi-globe",
+        image: null,
+        fallbackImage: "",
+        imageEnabled: true,
+      });
+    });
+
     function setUri(uri: string) {
       (cipher.login as { uri: string }).uri = uri;
     }
+  });
+
+  describe("Identity cipher", () => {
+    const cipher = {
+      type: CipherType.Identity,
+    } as any as CipherView;
+
+    it("returns bwi-id-card icon when newItemTypes is false", () => {
+      expect(buildCipherIcon(iconServerUrl, cipher, true, false)).toEqual({
+        icon: "bwi-id-card",
+        image: null,
+        fallbackImage: "",
+        imageEnabled: true,
+      });
+    });
+
+    it("returns bwi-user icon when newItemTypes is true", () => {
+      expect(buildCipherIcon(iconServerUrl, cipher, true, true)).toEqual({
+        icon: "bwi-user",
+        image: null,
+        fallbackImage: "",
+        imageEnabled: true,
+      });
+    });
   });
 
   describe("BankAccount cipher", () => {

--- a/libs/common/src/vault/icon/build-cipher-icon.ts
+++ b/libs/common/src/vault/icon/build-cipher-icon.ts
@@ -16,6 +16,7 @@ export function buildCipherIcon(
   iconsServerUrl: string | null,
   cipher: CipherViewLike,
   showFavicon: boolean,
+  newItemTypes?: boolean,
 ): CipherIconDetails {
   let icon: string = "bwi-globe";
   let image: string | null = null;
@@ -42,7 +43,7 @@ export function buildCipherIcon(
 
   switch (cipherType) {
     case CipherType.Login:
-      icon = "bwi-globe";
+      icon = newItemTypes ? "bwi-lock" : "bwi-globe";
 
       if (uri) {
         let hostnameUri = uri;
@@ -95,7 +96,7 @@ export function buildCipherIcon(
       }
       break;
     case CipherType.Identity:
-      icon = "bwi-id-card";
+      icon = newItemTypes ? "bwi-user" : "bwi-id-card";
       break;
     case CipherType.SshKey:
       icon = "bwi-key";


### PR DESCRIPTION
## 🎟️ Tracking

[PM-37970](https://bitwarden.atlassian.net/browse/PM-37970)

## 📔 Objective

Fixes the vault list icons for `Login` and `Identity` cipher types when the [`PM32009NewItemTypes`](https://bitwarden.atlassian.net/browse/PM-32009) feature flag is enabled. `Identity` now renders `bwi-user` and `Login` renders `bwi-lock` when the flag is on. `DriversLicense` continues to use `bwi-id-card` regardless of the flag.

## 📸 Screenshots

|Before|After|
|-|-|
|<img width="1728" height="965" alt="Screenshot 2026-05-22 at 2 49 10 PM" src="https://github.com/user-attachments/assets/4cf9667f-ed0f-4caf-be2c-35d63e5e3b0b" />|<img width="1728" height="964" alt="Screenshot 2026-05-22 at 2 47 52 PM" src="https://github.com/user-attachments/assets/28164a83-63a1-41df-8959-8e20d01f82c8" />|

[PM-37970]: https://bitwarden.atlassian.net/browse/PM-37970?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ