### PR TITLE
[PM-37479] Assign to collection dialog displays dummy string  `0">`

### DIFF
--- a/libs/vault/src/components/assign-collections.component.html
+++ b/libs/vault/src/components/assign-collections.component.html
@@ -11,7 +11,6 @@
   <ul class="tw-list-disc tw-pl-5 tw-space-y-2 tw-break-words">
     @if (readonlyItemCount > 0) {
       <li>
-        0">
         <p>
           {{ "bulkCollectionAssignmentWarning" | i18n: totalItemCount : readonlyItemCount }}
         </p>
@@ -19,7 +18,6 @@
     }
     @if (personalItemsCount > 0) {
       <li>
-        0">
         <p>
           {{ transferWarningText(orgName, personalItemsCount) }}
         </p>


### PR DESCRIPTION
## 🎟️ Tracking

[Jira](https://bitwarden.atlassian.net/browse/PM-37479)

## 📔 Objective

Removes dummy string from assign to collection dialog.

## 📸 Screenshots

<img width="748" height="374" alt="Screenshot 2026-05-22 at 1 44 30 PM" src="https://github.com/user-attachments/assets/6939929d-dd36-461a-8912-f92753360a8f" />
