### PR TITLE
Shadow dom unified fix

### DIFF
--- a/apps/browser/src/autofill/services/abstractions/dom-query.service.ts
+++ b/apps/browser/src/autofill/services/abstractions/dom-query.service.ts
@@ -8,7 +8,7 @@ export interface DomQueryService {
   ): T[];
   updatePageContainsShadowDom(): boolean;
   checkMutationsInShadowRoots(mutations: MutationRecord[]): boolean;
-  checkForNewShadowRoots(): boolean;
+  checkForNewShadowRoots(addedElements?: Element[]): boolean;
   resetObservedShadowRoots(): void;
   queryDeepSelector(selector: string): Element | null;
 }

--- a/apps/browser/src/autofill/services/collect-autofill-content.service.ts
+++ b/apps/browser/src/autofill/services/collect-autofill-content.service.ts
@@ -61,7 +61,8 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
   private readonly overlaySetupDelayMs = 100;
   private shadowDomCheckTimeout: NodeJS.Timeout | number | null = null;
   private pendingShadowDomCheck = false;
-  private pendingMutationAddedElements: Element[] = [];
+  /** Set, not array: duplicates only cost redundant `getShadowRoot` calls. */
+  private pendingMutationAddedElements: Set<Element> = new Set();
   private ownedExperienceTagNames: string[] = [];
   private readonly updateAfterMutationTimeout = 1000;
   private readonly shadowDomCheckTimeoutMs = 500;
@@ -1240,7 +1241,7 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
     for (const mutation of mutations) {
       for (const node of mutation.addedNodes ?? []) {
         if (node instanceof Element) {
-          this.pendingMutationAddedElements.push(node);
+          this.pendingMutationAddedElements.add(node);
         }
       }
     }
@@ -1255,7 +1256,7 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
       this.shadowDomCheckTimeout = setTimeout(() => {
         this.handleNewShadowRoots();
         this.pendingShadowDomCheck = false;
-        this.pendingMutationAddedElements = [];
+        this.pendingMutationAddedElements.clear();
       }, this.shadowDomCheckTimeoutMs);
     }
 
@@ -1350,9 +1351,14 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
    * @private
    */
   private handleNewShadowRoots = () => {
-    const hasNewShadowRoots = this.domQueryService.checkForNewShadowRoots(
-      this.pendingMutationAddedElements,
-    );
+    // Hosts added by mutation may have been removed during the 500ms debounce.
+    const connected: Element[] = [];
+    for (const el of this.pendingMutationAddedElements) {
+      if (el.isConnected) {
+        connected.push(el);
+      }
+    }
+    const hasNewShadowRoots = this.domQueryService.checkForNewShadowRoots(connected);
     if (hasNewShadowRoots) {
       this.debouncedRequirePageDetailsUpdate();
     }

--- a/apps/browser/src/autofill/services/collect-autofill-content.service.ts
+++ b/apps/browser/src/autofill/services/collect-autofill-content.service.ts
@@ -61,6 +61,7 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
   private readonly overlaySetupDelayMs = 100;
   private shadowDomCheckTimeout: NodeJS.Timeout | number | null = null;
   private pendingShadowDomCheck = false;
+  private pendingMutationAddedElements: Element[] = [];
   private ownedExperienceTagNames: string[] = [];
   private readonly updateAfterMutationTimeout = 1000;
   private readonly shadowDomCheckTimeoutMs = 500;
@@ -1233,6 +1234,17 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
       this.debouncedRequirePageDetailsUpdate();
     }
 
+    // Collect added elements from this mutation batch so that the shadow DOM
+    // check can inspect only the newly-added subtrees instead of rescanning the
+    // entire document (performance fix for large DOMs).
+    for (const mutation of mutations) {
+      for (const node of mutation.addedNodes ?? []) {
+        if (node instanceof Element) {
+          this.pendingMutationAddedElements.push(node);
+        }
+      }
+    }
+
     if (!this.pendingShadowDomCheck) {
       this.pendingShadowDomCheck = true;
 
@@ -1243,6 +1255,7 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
       this.shadowDomCheckTimeout = setTimeout(() => {
         this.handleNewShadowRoots();
         this.pendingShadowDomCheck = false;
+        this.pendingMutationAddedElements = [];
       }, this.shadowDomCheckTimeoutMs);
     }
 
@@ -1337,7 +1350,9 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
    * @private
    */
   private handleNewShadowRoots = () => {
-    const hasNewShadowRoots = this.domQueryService.checkForNewShadowRoots();
+    const hasNewShadowRoots = this.domQueryService.checkForNewShadowRoots(
+      this.pendingMutationAddedElements,
+    );
     if (hasNewShadowRoots) {
       this.debouncedRequirePageDetailsUpdate();
     }

--- a/apps/browser/src/autofill/services/dom-query.service.spec.ts
+++ b/apps/browser/src/autofill/services/dom-query.service.spec.ts
@@ -274,5 +274,142 @@ describe("DomQueryService", () => {
 
       expect(result).toBe(false);
     });
+
+    it("returns true via narrow-scan and does not flip pageContainsShadowDom when latch was already true", () => {
+      domQueryService["pageContainsShadowDom"] = true;
+      const host = document.createElement("custom-element");
+      host.attachShadow({ mode: "open" });
+      document.body.appendChild(host);
+
+      const result = domQueryService.checkForNewShadowRoots([host]);
+
+      expect(result).toBe(true);
+      expect(domQueryService["pageContainsShadowDom"]).toBe(true);
+    });
+
+    it("flips pageContainsShadowDom from false to true when narrow-scan discovers a root", () => {
+      domQueryService["pageContainsShadowDom"] = false;
+      const host = document.createElement("custom-element");
+      host.attachShadow({ mode: "open" });
+      document.body.appendChild(host);
+
+      const result = domQueryService.checkForNewShadowRoots([host]);
+
+      expect(result).toBe(true);
+      expect(domQueryService["pageContainsShadowDom"]).toBe(true);
+    });
+
+    it("preserves the cheap-page short-circuit when latch is false and addedElements is empty", () => {
+      domQueryService["pageContainsShadowDom"] = false;
+
+      const result = domQueryService.checkForNewShadowRoots([]);
+
+      expect(result).toBe(false);
+      expect(domQueryService["pageContainsShadowDom"]).toBe(false);
+    });
+
+    it("returns true when a new root is nested inside a known root (PM-29033)", () => {
+      domQueryService["pageContainsShadowDom"] = true;
+      const outerHost = document.createElement("outer-host");
+      const outerRoot = outerHost.attachShadow({ mode: "open" });
+      // Regression case: a single-level narrow scan would miss this.
+      domQueryService["observedShadowRoots"].add(outerRoot);
+      document.body.appendChild(outerHost);
+
+      const innerHost = document.createElement("inner-host");
+      innerHost.attachShadow({ mode: "open" });
+      outerRoot.appendChild(innerHost);
+
+      const result = domQueryService.checkForNewShadowRoots([outerHost]);
+
+      expect(result).toBe(true);
+    });
+
+    it("bails at MAX_DEEP_QUERY_RECURSION_DEPTH without throwing on pathological nesting", () => {
+      domQueryService["pageContainsShadowDom"] = true;
+      const root0 = document.createElement("host-0");
+      const shadow0 = root0.attachShadow({ mode: "open" });
+      domQueryService["observedShadowRoots"].add(shadow0);
+      document.body.appendChild(root0);
+
+      let parentShadow: ShadowRoot = shadow0;
+      // 6 observed nestings + a final unobserved root past the depth cap (4).
+      for (let i = 1; i <= 6; i++) {
+        const host = document.createElement(`host-${i}`);
+        const shadow = host.attachShadow({ mode: "open" });
+        if (i < 6) {
+          domQueryService["observedShadowRoots"].add(shadow);
+        }
+        parentShadow.appendChild(host);
+        parentShadow = shadow;
+      }
+
+      expect(() => domQueryService.checkForNewShadowRoots([root0])).not.toThrow();
+    });
+
+    it("handles a disconnected element in addedElements without crashing", () => {
+      // External callers may not filter by `isConnected` like
+      // `collect-autofill-content.service.ts` does.
+      domQueryService["pageContainsShadowDom"] = false;
+      const host = document.createElement("disconnected-host");
+      host.attachShadow({ mode: "open" });
+      expect(host.isConnected).toBe(false);
+
+      expect(() => domQueryService.checkForNewShadowRoots([host])).not.toThrow();
+    });
+
+    it("handles duplicate entries in addedElements (defensive — Set-side dedup makes this rare)", () => {
+      domQueryService["pageContainsShadowDom"] = true;
+      const host = document.createElement("dup-host");
+      host.attachShadow({ mode: "open" });
+      document.body.appendChild(host);
+
+      const result = domQueryService.checkForNewShadowRoots([host, host]);
+
+      expect(result).toBe(true);
+    });
+
+    describe("classifyShadowRootScan (pure classifier)", () => {
+      it("returns shortCircuit verdict when latch is false and no added elements", () => {
+        domQueryService["pageContainsShadowDom"] = false;
+
+        const verdict = domQueryService["classifyShadowRootScan"]();
+
+        expect(verdict).toEqual({
+          branch: "shortCircuit",
+          foundNewRoot: false,
+        });
+      });
+
+      it("returns a narrow verdict (not shortCircuit) when addedElements is non-empty even with latch false", () => {
+        domQueryService["pageContainsShadowDom"] = false;
+        const host = document.createElement("custom-element");
+
+        const verdict = domQueryService["classifyShadowRootScan"]([host]);
+
+        expect(verdict.branch).toBe("narrow");
+      });
+
+      it("does not mutate pageContainsShadowDom", () => {
+        domQueryService["pageContainsShadowDom"] = false;
+        const host = document.createElement("custom-element");
+        host.attachShadow({ mode: "open" });
+        document.body.appendChild(host);
+
+        domQueryService["classifyShadowRootScan"]([host]);
+
+        expect(domQueryService["pageContainsShadowDom"]).toBe(false);
+      });
+    });
+
+    describe("markShadowDomPresent (named transition)", () => {
+      it("flips pageContainsShadowDom to true", () => {
+        domQueryService["pageContainsShadowDom"] = false;
+
+        domQueryService["markShadowDomPresent"]();
+
+        expect(domQueryService["pageContainsShadowDom"]).toBe(true);
+      });
+    });
   });
 });

--- a/apps/browser/src/autofill/services/dom-query.service.ts
+++ b/apps/browser/src/autofill/services/dom-query.service.ts
@@ -10,9 +10,15 @@ import { nodeIsElement } from "../utils";
 
 import { DomQueryService as DomQueryServiceInterface } from "./abstractions/dom-query.service";
 
+type ScanVerdict =
+  | { branch: "shortCircuit"; foundNewRoot: false }
+  | { branch: "narrow"; foundNewRoot: boolean }
+  | { branch: "fullScan"; foundNewRoot: boolean };
+
 export class DomQueryService implements DomQueryServiceInterface {
-  /** Non-null asserted. */
+  /** One-way ratchet; reset only by `resetObservedShadowRoots()`. */
   private pageContainsShadowDom!: boolean;
+  // FIXME: merge with `knownShadowRoots` into one registry (needs WeakSet + iteration).
   private observedShadowRoots = new WeakSet<ShadowRoot>();
   /**
    * An iterable mirror of `observedShadowRoots` used by `deepQueryElements`
@@ -116,55 +122,54 @@ export class DomQueryService implements DomQueryServiceInterface {
     });
   };
 
-  /**
-   * Queries the DOM for shadow roots and checks if any are not being observed.
-   * This is an expensive operation that should be debounced.
-   * @returns True if any new shadow roots are found that aren't being observed
-   */
+  /** @returns true if an unobserved root is reachable; flips the latch on first post-init() find. */
   checkForNewShadowRoots = (addedElements?: Element[]): boolean => {
-    // Short-circuit: if we have already confirmed the page has no shadow DOM,
-    // skip the expensive querySelectorAll(":defined") + getShadowRoot scan entirely.
-    // FIXME: this disables all checks after the page initializes; introduce a
-    // less-expensive means to update `pageContainsShadowDom`.
-    if (!this.pageContainsShadowDom) {
-      return false;
+    const verdict = this.classifyShadowRootScan(addedElements);
+    // Only `narrow` can yield foundNewRoot with the latch false: `fullScan` is
+    // unreachable while the latch is false (short-circuit catches it), and
+    // `shortCircuit` always reports false.
+    if (verdict.foundNewRoot && !this.pageContainsShadowDom) {
+      this.markShadowDomPresent();
     }
+    return verdict.foundNewRoot;
+  };
 
-    // When added elements are provided (from a mutation batch), only check those
-    // elements and their descendants instead of scanning the entire document.
-    // This reduces the number of chrome.dom.openOrClosedShadowRoot() calls from
-    // potentially hundreds of thousands to typically 1–10 per mutation batch.
-    if (addedElements && addedElements.length > 0) {
-      for (const el of addedElements) {
-        const root = this.getShadowRoot(el);
-        if (root && !this.observedShadowRoots.has(root)) {
-          return true;
-        }
-        for (const child of el.querySelectorAll("*")) {
-          const childRoot = this.getShadowRoot(child);
-          if (childRoot && !this.observedShadowRoots.has(childRoot)) {
-            return true;
-          }
-        }
+  private classifyShadowRootScan = (addedElements?: Element[]): ScanVerdict => {
+    const hasAddedElements = !!addedElements && addedElements.length > 0;
+    // With a batch present, scan even if the latch is false — shadow DOM may
+    // have attached after init().
+    if (!this.pageContainsShadowDom && !hasAddedElements) {
+      return { branch: "shortCircuit", foundNewRoot: false };
+    }
+    return hasAddedElements
+      ? this.findNewShadowRootInBatch(addedElements!)
+      : this.findNewShadowRootInDocument();
+  };
+
+  private findNewShadowRootInBatch = (elements: Element[]): ScanVerdict => {
+    for (const el of elements) {
+      if (this.scanForNewShadowRootInSubtree(el, 0)) {
+        return { branch: "narrow", foundNewRoot: true };
       }
-      return false;
     }
+    return { branch: "narrow", foundNewRoot: false };
+  };
 
-    // Full scan fallback when no specific elements are provided.
-    let currentRoots: ShadowRoot[];
+  private findNewShadowRootInDocument = (): ScanVerdict => {
+    let roots: ShadowRoot[];
     try {
-      currentRoots = this.recursivelyQueryShadowRoots(globalThis.document.body);
+      roots = this.recursivelyQueryShadowRoots(globalThis.document.body);
     } catch {
-      currentRoots = this.queryShadowRoots(globalThis.document.body);
+      roots = this.queryShadowRoots(globalThis.document.body);
     }
+    return {
+      branch: "fullScan",
+      foundNewRoot: roots.some((r) => !this.observedShadowRoots.has(r)),
+    };
+  };
 
-    for (const root of currentRoots) {
-      if (!this.observedShadowRoots.has(root)) {
-        return true;
-      }
-    }
-
-    return false;
+  private markShadowDomPresent = (): void => {
+    this.pageContainsShadowDom = true;
   };
 
   /**
@@ -289,6 +294,43 @@ export class DomQueryService implements DomQueryServiceInterface {
     // returns an empty NodeList when nothing matches, at no extra cost.
     return Array.from(root.querySelectorAll(queryString)) as T[];
   }
+
+  // No cycle guard — `attachShadow` throws on re-attach, `ShadowRoot.host` is
+  // read-only. See https://dom.spec.whatwg.org/#dom-element-attachshadow.
+  private scanForNewShadowRootInSubtree = (
+    subtree: Element | ShadowRoot,
+    depth: number,
+  ): boolean => {
+    if (depth >= MAX_DEEP_QUERY_RECURSION_DEPTH) {
+      return false;
+    }
+    // Host check — `querySelectorAll("*")` excludes the scope element, so
+    // we'd miss the host's own root without this branch.
+    if (subtree instanceof Element) {
+      const root = this.getShadowRoot(subtree);
+      if (root) {
+        if (!this.observedShadowRoots.has(root)) {
+          return true;
+        }
+        if (this.scanForNewShadowRootInSubtree(root, depth + 1)) {
+          return true;
+        }
+      }
+    }
+    // querySelectorAll doesn't pierce shadow boundaries — recurse per boundary.
+    for (const child of subtree.querySelectorAll("*")) {
+      const childRoot = this.getShadowRoot(child);
+      if (childRoot) {
+        if (!this.observedShadowRoots.has(childRoot)) {
+          return true;
+        }
+        if (this.scanForNewShadowRootInSubtree(childRoot, depth + 1)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  };
 
   /**
    * Recursively queries all shadow roots found within the given root element.

--- a/apps/browser/src/autofill/services/dom-query.service.ts
+++ b/apps/browser/src/autofill/services/dom-query.service.ts
@@ -121,7 +121,7 @@ export class DomQueryService implements DomQueryServiceInterface {
    * This is an expensive operation that should be debounced.
    * @returns True if any new shadow roots are found that aren't being observed
    */
-  checkForNewShadowRoots = (): boolean => {
+  checkForNewShadowRoots = (addedElements?: Element[]): boolean => {
     // Short-circuit: if we have already confirmed the page has no shadow DOM,
     // skip the expensive querySelectorAll(":defined") + getShadowRoot scan entirely.
     // FIXME: this disables all checks after the page initializes; introduce a
@@ -130,6 +130,27 @@ export class DomQueryService implements DomQueryServiceInterface {
       return false;
     }
 
+    // When added elements are provided (from a mutation batch), only check those
+    // elements and their descendants instead of scanning the entire document.
+    // This reduces the number of chrome.dom.openOrClosedShadowRoot() calls from
+    // potentially hundreds of thousands to typically 1–10 per mutation batch.
+    if (addedElements && addedElements.length > 0) {
+      for (const el of addedElements) {
+        const root = this.getShadowRoot(el);
+        if (root && !this.observedShadowRoots.has(root)) {
+          return true;
+        }
+        for (const child of el.querySelectorAll("*")) {
+          const childRoot = this.getShadowRoot(child);
+          if (childRoot && !this.observedShadowRoots.has(childRoot)) {
+            return true;
+          }
+        }
+      }
+      return false;
+    }
+
+    // Full scan fallback when no specific elements are provided.
     let currentRoots: ShadowRoot[];
     try {
       currentRoots = this.recursivelyQueryShadowRoots(globalThis.document.body);


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

Fix `checkForNewShadowRoots` latch and nested-shadow traversal

Two bugs in `checkForNewShadowRoots`, addressed together because they
share the function and the test surface:

1. `pageContainsShadowDom` resolved at `init()` and never re-evaluated.
   On sites that attach shadow DOM after init (i.e. SPAs
   that boot their custom-element renderers post-LOAD), the short-circuit
   blocked all detection for the rest of the session.
2. The narrow scan used `el.querySelectorAll("*")`, which does not pierce
   shadow boundaries. A shadow host nested inside another shadow root was
   invisible to the scan even when the latch was on.

Changes:
- Narrow the latch short-circuit: fires only when both
  `pageContainsShadowDom` is `false` AND `addedElements` is empty.
- `markShadowDomPresent`: a named, one-way sticky-ratchet transition that
  flips the latch when the narrow scan finds a root post-init.
- `scanForNewShadowRootInSubtree`: a depth-bounded recursive helper that
  pierces nested shadow boundaries
  (`MAX_DEEP_QUERY_RECURSION_DEPTH = 4`).
- `pendingMutationAddedElements`: now `Set<Element>`; `isConnected`
  filter at the debounced flush skips dead trees.

Inherits from #20713 (pass addedElements to checkForNewShadowRoots).
