### PR TITLE
[PM-35181] fix(vault): tighten CipherType typing per FIXME (TS 5.9.3)

### DIFF
--- a/libs/common/src/vault/enums/cipher-type.ts
+++ b/libs/common/src/vault/enums/cipher-type.ts
@@ -13,8 +13,7 @@ type _CipherType = typeof _CipherType;
 
 export type CipherType = _CipherType[keyof _CipherType];
 
-// FIXME: Update typing of `CipherType` to be `Record<keyof _CipherType, CipherType>` which is ADR-0025 compliant when the TypeScript version is at least 5.8.
-export const CipherType: typeof _CipherType = _CipherType;
+export const CipherType = _CipherType satisfies Record<keyof _CipherType, CipherType>;
 
 /**
  * Reverse mapping of Cipher Types to their associated names.


### PR DESCRIPTION
## 🎟️ Tracking

Just something I noticed while working on https://bitwarden.atlassian.net/browse/PM-35181

## 📔 Objective

Now that we've upgrade to a new enough typescript version we can remove this FIXME from `CipherType` without effecting anything at all down stream.