### PR TITLE
[PM-37228] - Add price increase callout to organization subscription page

### DIFF
--- a/apps/web/src/app/billing/organizations/organization-subscription-cloud.component.html
+++ b/apps/web/src/app/billing/organizations/organization-subscription-cloud.component.html
@@ -81,13 +81,13 @@
           </ng-template>
         </bit-table>
       </div>
-      <ng-container *ngIf="priceIncreaseCalloutMessage">
-        <div class="tw-mt-6">
+      @if (priceIncreaseCalloutMessage) {
+        <div class="tw-mt-4">
           <bit-callout type="info">
             <span>{{ priceIncreaseCalloutMessage }}</span>
           </bit-callout>
         </div>
-      </ng-container>
+      }
     </ng-container>
 
     <ng-container *ngIf="userOrg.canEditSubscription">

--- a/apps/web/src/app/billing/organizations/organization-subscription-cloud.component.html
+++ b/apps/web/src/app/billing/organizations/organization-subscription-cloud.component.html
@@ -81,6 +81,13 @@
           </ng-template>
         </bit-table>
       </div>
+      <ng-container *ngIf="priceIncreaseCalloutMessage">
+        <div class="tw-mt-6">
+          <bit-callout type="info">
+            <span>{{ priceIncreaseCalloutMessage }}</span>
+          </bit-callout>
+        </div>
+      </ng-container>
     </ng-container>
 
     <ng-container *ngIf="userOrg.canEditSubscription">

--- a/apps/web/src/app/billing/organizations/organization-subscription-cloud.component.ts
+++ b/apps/web/src/app/billing/organizations/organization-subscription-cloud.component.ts
@@ -22,10 +22,7 @@ import { AccountService } from "@bitwarden/common/auth/abstractions/account.serv
 import { getUserId } from "@bitwarden/common/auth/services/account.service";
 import { PlanType, ProductTierType } from "@bitwarden/common/billing/enums";
 import { OrganizationSubscriptionResponse } from "@bitwarden/common/billing/models/response/organization-subscription.response";
-import {
-  BillingSubscriptionItemResponse,
-  ScheduledSubscriptionResponse,
-} from "@bitwarden/common/billing/models/response/subscription.response";
+import { BillingSubscriptionItemResponse } from "@bitwarden/common/billing/models/response/subscription.response";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { DialogService, ToastService } from "@bitwarden/components";
@@ -166,14 +163,6 @@ export class OrganizationSubscriptionCloudComponent implements OnInit, OnDestroy
 
     if (this.showSubscription) {
       this.sub = await this.organizationApiService.getSubscription(this.organizationId);
-
-      // TODO: Remove this mock before merging
-      if (this.sub?.subscription) {
-        this.sub.subscription.scheduledSubscription = new ScheduledSubscriptionResponse({
-          effectiveDate: "2026-07-01",
-          pricePerSeatPerMonth: 7.0,
-        });
-      }
 
       this.lineItems = this.sub?.subscription?.items;
 

--- a/apps/web/src/app/billing/organizations/organization-subscription-cloud.component.ts
+++ b/apps/web/src/app/billing/organizations/organization-subscription-cloud.component.ts
@@ -225,10 +225,7 @@ export class OrganizationSubscriptionCloudComponent implements OnInit, OnDestroy
     }
 
     const formattedPrice = formatCurrency(scheduledSubscription.price, this.locale, "$", "USD");
-    const formattedDate = this.datePipe.transform(
-      scheduledSubscription.effectiveDate,
-      "mediumDate",
-    );
+    const formattedDate = this.datePipe.transform(scheduledSubscription.effectiveDate, "longDate");
 
     const key = this.sub.plan.isAnnual
       ? "subscriptionPriceIncreaseAnnually"

--- a/apps/web/src/app/billing/organizations/organization-subscription-cloud.component.ts
+++ b/apps/web/src/app/billing/organizations/organization-subscription-cloud.component.ts
@@ -224,12 +224,7 @@ export class OrganizationSubscriptionCloudComponent implements OnInit, OnDestroy
       return null;
     }
 
-    const formattedPrice = formatCurrency(
-      scheduledSubscription.pricePerSeatPerMonth,
-      this.locale,
-      "$",
-      "USD",
-    );
+    const formattedPrice = formatCurrency(scheduledSubscription.price, this.locale, "$", "USD");
     const formattedDate = this.datePipe.transform(
       scheduledSubscription.effectiveDate,
       "mediumDate",

--- a/apps/web/src/app/billing/organizations/organization-subscription-cloud.component.ts
+++ b/apps/web/src/app/billing/organizations/organization-subscription-cloud.component.ts
@@ -1,5 +1,6 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
+import { DatePipe, formatCurrency } from "@angular/common";
 import { Component, OnDestroy, OnInit } from "@angular/core";
 import { ActivatedRoute } from "@angular/router";
 import { firstValueFrom, lastValueFrom, Subject } from "rxjs";
@@ -21,7 +22,10 @@ import { AccountService } from "@bitwarden/common/auth/abstractions/account.serv
 import { getUserId } from "@bitwarden/common/auth/services/account.service";
 import { PlanType, ProductTierType } from "@bitwarden/common/billing/enums";
 import { OrganizationSubscriptionResponse } from "@bitwarden/common/billing/models/response/organization-subscription.response";
-import { BillingSubscriptionItemResponse } from "@bitwarden/common/billing/models/response/subscription.response";
+import {
+  BillingSubscriptionItemResponse,
+  ScheduledSubscriptionResponse,
+} from "@bitwarden/common/billing/models/response/subscription.response";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { DialogService, ToastService } from "@bitwarden/components";
@@ -83,6 +87,7 @@ export class OrganizationSubscriptionCloudComponent implements OnInit, OnDestroy
     private dialogService: DialogService,
     private toastService: ToastService,
     private organizationUserApiService: OrganizationUserApiService,
+    private datePipe: DatePipe,
   ) {}
 
   async ngOnInit() {
@@ -161,6 +166,15 @@ export class OrganizationSubscriptionCloudComponent implements OnInit, OnDestroy
 
     if (this.showSubscription) {
       this.sub = await this.organizationApiService.getSubscription(this.organizationId);
+
+      // TODO: Remove this mock before merging
+      if (this.sub?.subscription) {
+        this.sub.subscription.scheduledSubscription = new ScheduledSubscriptionResponse({
+          effectiveDate: "2026-07-01",
+          pricePerSeatPerMonth: 7.0,
+        });
+      }
+
       this.lineItems = this.sub?.subscription?.items;
 
       if (this.lineItems && this.lineItems.length) {
@@ -213,6 +227,30 @@ export class OrganizationSubscriptionCloudComponent implements OnInit, OnDestroy
 
   get subscription() {
     return this.sub != null ? this.sub.subscription : null;
+  }
+
+  get priceIncreaseCalloutMessage(): string | null {
+    const scheduledSubscription = this.subscription?.scheduledSubscription;
+    if (this.subscription?.status !== "active" || !scheduledSubscription) {
+      return null;
+    }
+
+    const formattedPrice = formatCurrency(
+      scheduledSubscription.pricePerSeatPerMonth,
+      this.locale,
+      "$",
+      "USD",
+    );
+    const formattedDate = this.datePipe.transform(
+      scheduledSubscription.effectiveDate,
+      "mediumDate",
+    );
+
+    const key = this.sub.plan.isAnnual
+      ? "subscriptionPriceIncreaseAnnually"
+      : "subscriptionPriceIncreaseMonthly";
+
+    return this.i18nService.t(key, formattedPrice, formattedDate);
   }
 
   get subscriptionLineItems() {

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -3591,6 +3591,34 @@
   "subscriptionPendingCanceled": {
     "message": "The subscription has been marked for cancellation at the end of the current billing period."
   },
+  "subscriptionPriceIncreaseMonthly": {
+    "message": "Your subscription price will increase to $PRICE$ per seat per month on $DATE$. Your plan features and any existing discounts will stay exactly the same.",
+    "placeholders": {
+      "price": {
+        "content": "$1",
+        "example": "$6.00"
+      },
+      "date": {
+        "content": "$2",
+        "example": "January 1, 2025"
+      }
+    },
+    "description": "A message shown when the organization's monthly subscription price will increase on the next renewal date."
+  },
+  "subscriptionPriceIncreaseAnnually": {
+    "message": "Your subscription price will increase to $PRICE$ per seat per month (billed annually) on $DATE$. Your plan features and any existing discounts will stay exactly the same.",
+    "placeholders": {
+      "price": {
+        "content": "$1",
+        "example": "$6.00"
+      },
+      "date": {
+        "content": "$2",
+        "example": "January 1, 2025"
+      }
+    },
+    "description": "A message shown when the organization's annually billed subscription price will increase on the next renewal date."
+  },
   "reinstateSubscription": {
     "message": "Reinstate subscription"
   },

--- a/libs/common/src/billing/models/response/subscription.response.ts
+++ b/libs/common/src/billing/models/response/subscription.response.ts
@@ -111,11 +111,11 @@ export class BillingSubscriptionUpcomingInvoiceResponse extends BaseResponse {
 
 export class ScheduledSubscriptionResponse extends BaseResponse {
   effectiveDate: string;
-  pricePerSeatPerMonth: number;
+  price: number;
 
   constructor(response: any) {
     super(response);
     this.effectiveDate = this.getResponseProperty("EffectiveDate");
-    this.pricePerSeatPerMonth = this.getResponseProperty("PricePerSeatPerMonth");
+    this.price = this.getResponseProperty("Price");
   }
 }

--- a/libs/common/src/billing/models/response/subscription.response.ts
+++ b/libs/common/src/billing/models/response/subscription.response.ts
@@ -48,6 +48,7 @@ export class BillingSubscriptionResponse extends BaseResponse {
   suspensionDate?: string;
   unpaidPeriodEndDate?: string;
   gracePeriod?: number;
+  scheduledSubscription?: ScheduledSubscriptionResponse;
 
   constructor(response: any) {
     super(response);
@@ -67,6 +68,11 @@ export class BillingSubscriptionResponse extends BaseResponse {
     this.suspensionDate = this.getResponseProperty("SuspensionDate");
     this.unpaidPeriodEndDate = this.getResponseProperty("unpaidPeriodEndDate");
     this.gracePeriod = this.getResponseProperty("GracePeriod");
+    const scheduledSubscription = this.getResponseProperty("ScheduledSubscription");
+    this.scheduledSubscription =
+      scheduledSubscription == null
+        ? null
+        : new ScheduledSubscriptionResponse(scheduledSubscription);
   }
 }
 
@@ -100,5 +106,16 @@ export class BillingSubscriptionUpcomingInvoiceResponse extends BaseResponse {
     super(response);
     this.date = this.getResponseProperty("Date");
     this.amount = this.getResponseProperty("Amount");
+  }
+}
+
+export class ScheduledSubscriptionResponse extends BaseResponse {
+  effectiveDate: string;
+  pricePerSeatPerMonth: number;
+
+  constructor(response: any) {
+    super(response);
+    this.effectiveDate = this.getResponseProperty("EffectiveDate");
+    this.pricePerSeatPerMonth = this.getResponseProperty("PricePerSeatPerMonth");
   }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-37228

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Show a price increase callout on the Organization > Subscription (cloud) page when the API returns a scheduled subscription change.

- Added `ScheduledSubscriptionResponse` model class and `scheduledSubscription` field to `BillingSubscriptionResponse` to map the new API property
- Added `priceIncreaseCalloutMessage` getter on `OrganizationSubscriptionCloudComponent` that formats the effective date and per-seat price using `DatePipe` and `formatCurrency`, with separate i18n strings for monthly vs. annually billed plans
- Rendered the message in a `bit-callout type="info"` block in the template, visible only for active subscriptions with a scheduled price change
- Added two new i18n keys: `subscriptionPriceIncreaseMonthly` and `subscriptionPriceIncreaseAnnually`


## Notes

- Assumes the shape of the response will have the following form so this will need adjustment if it differs from the implementation:

```
  ScheduledSubscription: {
    EffectiveDate: 2026-05-22T22:06:50.131Z
    Price:  10.00
}
```


## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

<img width="1127" height="1178" alt="Screenshot 2026-05-28 at 11 41 18 AM" src="https://github.com/user-attachments/assets/bb8e4f8f-50a4-4ca7-bfaa-08929cf06622" />
