### PR TITLE
[PM-38025] Filter inline autofill menu items as the user types

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -4502,6 +4502,16 @@
     "message": "No items to show",
     "description": "Text to show in overlay if there are no matching items"
   },
+  "inlineMenuNoMatches": {
+    "message": "No matches for \"$FILTER$\"",
+    "description": "Text shown in the inline autofill menu when the user has typed in a username/email field and no saved logins match the typed text. $FILTER$ is the user's typed text.",
+    "placeholders": {
+      "filter": {
+        "content": "$1",
+        "example": "exa"
+      }
+    }
+  },
   "newItem": {
     "message": "New item",
     "description": "Button text to display in overlay when there are no matching items"

--- a/apps/browser/src/autofill/background/abstractions/overlay.background.ts
+++ b/apps/browser/src/autofill/background/abstractions/overlay.background.ts
@@ -157,7 +157,7 @@ export type OverlayBackgroundExtensionMessage = {
   isOpeningFullInlineMenu?: boolean;
   styles?: Partial<CSSStyleDeclaration>;
   data?: LockedVaultPendingNotificationsData;
-  filter?: string;
+  filterValue?: string;
 } & OverlayAddNewItemMessage &
   CloseInlineMenuMessage &
   ToggleInlineMenuHiddenMessage &
@@ -278,7 +278,7 @@ export type OverlayBackgroundExtensionMessageHandlers = {
   deletedCipher: () => void;
   bgSaveCipher: () => void;
   updateOverlayCiphers: () => void;
-  updateAutofillInlineMenuFilter: ({
+  filterInlineMenuCiphers: ({
     message,
     sender,
   }: BackgroundOnMessageHandlerParams) => Promise<void>;

--- a/apps/browser/src/autofill/background/abstractions/overlay.background.ts
+++ b/apps/browser/src/autofill/background/abstractions/overlay.background.ts
@@ -157,6 +157,7 @@ export type OverlayBackgroundExtensionMessage = {
   isOpeningFullInlineMenu?: boolean;
   styles?: Partial<CSSStyleDeclaration>;
   data?: LockedVaultPendingNotificationsData;
+  filter?: string;
 } & OverlayAddNewItemMessage &
   CloseInlineMenuMessage &
   ToggleInlineMenuHiddenMessage &
@@ -277,6 +278,10 @@ export type OverlayBackgroundExtensionMessageHandlers = {
   deletedCipher: () => void;
   bgSaveCipher: () => void;
   updateOverlayCiphers: () => void;
+  updateAutofillInlineMenuFilter: ({
+    message,
+    sender,
+  }: BackgroundOnMessageHandlerParams) => Promise<void>;
   fido2AbortRequest: ({ sender }: BackgroundSenderParam) => void;
 };
 

--- a/apps/browser/src/autofill/background/overlay.background.spec.ts
+++ b/apps/browser/src/autofill/background/overlay.background.spec.ts
@@ -961,7 +961,7 @@ describe("OverlayBackground", () => {
 
       expect(listPortSpy.postMessage).toHaveBeenCalledWith({
         command: "updateAutofillInlineMenuListCiphers",
-        filter: "",
+        filterValue: "",
         showInlineMenuAccountCreation: false,
         showPasskeysLabels: false,
         focusedFieldHasValue: false,
@@ -1028,7 +1028,7 @@ describe("OverlayBackground", () => {
         expect(listPortSpy.postMessage).toHaveBeenLastCalledWith(
           expect.objectContaining({
             command: "updateAutofillInlineMenuListCiphers",
-            filter: "",
+            filterValue: "",
             showInlineMenuAccountCreation: expectedShowInlineMenuAccountCreation,
             ciphers: expect.arrayContaining([
               expect.objectContaining({
@@ -1057,7 +1057,7 @@ describe("OverlayBackground", () => {
 
       expect(listPortSpy.postMessage).toHaveBeenCalledWith({
         command: "updateAutofillInlineMenuListCiphers",
-        filter: "",
+        filterValue: "",
         showInlineMenuAccountCreation: false,
         showPasskeysLabels: false,
         focusedFieldHasValue: false,
@@ -1096,7 +1096,7 @@ describe("OverlayBackground", () => {
 
         expect(listPortSpy.postMessage).toHaveBeenCalledWith({
           command: "updateAutofillInlineMenuListCiphers",
-          filter: "",
+          filterValue: "",
           showInlineMenuAccountCreation: true,
           showPasskeysLabels: false,
           focusedFieldHasValue: false,
@@ -1138,7 +1138,7 @@ describe("OverlayBackground", () => {
 
         expect(listPortSpy.postMessage).toHaveBeenCalledWith({
           command: "updateAutofillInlineMenuListCiphers",
-          filter: "",
+          filterValue: "",
           showInlineMenuAccountCreation: true,
           showPasskeysLabels: false,
           focusedFieldHasValue: false,
@@ -1211,7 +1211,7 @@ describe("OverlayBackground", () => {
 
         expect(listPortSpy.postMessage).toHaveBeenCalledWith({
           command: "updateAutofillInlineMenuListCiphers",
-          filter: "",
+          filterValue: "",
           showInlineMenuAccountCreation: true,
           showPasskeysLabels: false,
           focusedFieldHasValue: false,
@@ -1252,7 +1252,7 @@ describe("OverlayBackground", () => {
 
         expect(listPortSpy.postMessage).toHaveBeenCalledWith({
           command: "updateAutofillInlineMenuListCiphers",
-          filter: "",
+          filterValue: "",
           showInlineMenuAccountCreation: true,
           showPasskeysLabels: false,
           focusedFieldHasValue: false,
@@ -1281,7 +1281,7 @@ describe("OverlayBackground", () => {
 
       expect(listPortSpy.postMessage).toHaveBeenCalledWith({
         command: "updateAutofillInlineMenuListCiphers",
-        filter: "",
+        filterValue: "",
         ciphers: [
           {
             id: "inline-menu-cipher-0",
@@ -1371,7 +1371,7 @@ describe("OverlayBackground", () => {
 
       expect(listPortSpy.postMessage).toHaveBeenCalledWith({
         command: "updateAutofillInlineMenuListCiphers",
-        filter: "",
+        filterValue: "",
         ciphers: [
           {
             id: "inline-menu-cipher-0",
@@ -1439,7 +1439,7 @@ describe("OverlayBackground", () => {
 
       expect(listPortSpy.postMessage).toHaveBeenCalledWith({
         command: "updateAutofillInlineMenuListCiphers",
-        filter: "",
+        filterValue: "",
         ciphers: [
           {
             id: "inline-menu-cipher-0",
@@ -2103,7 +2103,7 @@ describe("OverlayBackground", () => {
 
         expect(listPortSpy.postMessage).toHaveBeenCalledWith({
           command: "updateAutofillInlineMenuListCiphers",
-          filter: "",
+          filterValue: "",
           ciphers: [],
           showInlineMenuAccountCreation: true,
           showPasskeysLabels: false,
@@ -2521,7 +2521,7 @@ describe("OverlayBackground", () => {
       });
     });
 
-    describe("updateAutofillInlineMenuFilter message handler", () => {
+    describe("filterInlineMenuCiphers message handler", () => {
       let sender: chrome.runtime.MessageSender;
       let listCipher: CipherView;
       let updateInlineMenuListCiphersSpy: jest.SpyInstance;
@@ -2547,17 +2547,17 @@ describe("OverlayBackground", () => {
 
       it("stores the filter and re-renders the list with the filter forwarded to the iframe", async () => {
         sendMockExtensionMessage(
-          { command: "updateAutofillInlineMenuFilter", filter: "exa" },
+          { command: "filterInlineMenuCiphers", filterValue: "exa" },
           sender,
         );
         await flushPromises();
 
-        expect(overlayBackground["inlineMenuFilter"]).toBe("exa");
+        expect(overlayBackground["inlineMenuFilterValue"]).toBe("exa");
         expect(updateInlineMenuListCiphersSpy).toHaveBeenCalledWith(sender.tab);
         expect(listPortSpy.postMessage).toHaveBeenCalledWith(
           expect.objectContaining({
             command: "updateAutofillInlineMenuListCiphers",
-            filter: "exa",
+            filterValue: "exa",
           }),
         );
       });
@@ -2567,14 +2567,14 @@ describe("OverlayBackground", () => {
         searchService.searchCiphersBasic.mockReturnValue([]);
 
         sendMockExtensionMessage(
-          { command: "updateAutofillInlineMenuFilter", filter: "zzz" },
+          { command: "filterInlineMenuCiphers", filterValue: "zzz" },
           sender,
         );
         await flushPromises();
 
         expect(searchService.searchCiphersBasic).toHaveBeenCalledWith([listCipher], "zzz");
         expect(listPortSpy.postMessage).toHaveBeenCalledWith(
-          expect.objectContaining({ ciphers: [], filter: "zzz" }),
+          expect.objectContaining({ ciphers: [], filterValue: "zzz" }),
         );
       });
 
@@ -2582,7 +2582,7 @@ describe("OverlayBackground", () => {
         searchService.isSearchable.mockResolvedValue(false);
 
         sendMockExtensionMessage(
-          { command: "updateAutofillInlineMenuFilter", filter: "x" },
+          { command: "filterInlineMenuCiphers", filterValue: "x" },
           sender,
         );
         await flushPromises();
@@ -2591,11 +2591,11 @@ describe("OverlayBackground", () => {
       });
 
       it("ignores duplicate filter values without re-rendering", async () => {
-        overlayBackground["inlineMenuFilter"] = "exa";
+        overlayBackground["inlineMenuFilterValue"] = "exa";
         updateInlineMenuListCiphersSpy.mockClear();
 
         sendMockExtensionMessage(
-          { command: "updateAutofillInlineMenuFilter", filter: "exa" },
+          { command: "filterInlineMenuCiphers", filterValue: "exa" },
           sender,
         );
         await flushPromises();
@@ -2606,18 +2606,18 @@ describe("OverlayBackground", () => {
       it("caps the filter at the configured max length to avoid retaining large field values", async () => {
         const longFilter = "a".repeat(1024);
         sendMockExtensionMessage(
-          { command: "updateAutofillInlineMenuFilter", filter: longFilter },
+          { command: "filterInlineMenuCiphers", filterValue: longFilter },
           sender,
         );
         await flushPromises();
 
-        expect(overlayBackground["inlineMenuFilter"].length).toBe(
-          overlayBackground["inlineMenuFilterMaxLength"],
+        expect(overlayBackground["inlineMenuFilterValue"].length).toBe(
+          overlayBackground["inlineMenuFilterValueMaxLength"],
         );
       });
 
       it("resets the filter when the inline menu is closed", async () => {
-        overlayBackground["inlineMenuFilter"] = "exa";
+        overlayBackground["inlineMenuFilterValue"] = "exa";
 
         sendMockExtensionMessage(
           { command: "closeAutofillInlineMenu", forceCloseInlineMenu: true },
@@ -2625,16 +2625,16 @@ describe("OverlayBackground", () => {
         );
         await flushPromises();
 
-        expect(overlayBackground["inlineMenuFilter"]).toBe("");
+        expect(overlayBackground["inlineMenuFilterValue"]).toBe("");
       });
 
       it("resets the filter when updateOverlayCiphers is called", async () => {
-        overlayBackground["inlineMenuFilter"] = "exa";
+        overlayBackground["inlineMenuFilterValue"] = "exa";
         activeAccountStatusMock$.next(AuthenticationStatus.Unlocked);
 
         await overlayBackground.updateOverlayCiphers();
 
-        expect(overlayBackground["inlineMenuFilter"]).toBe("");
+        expect(overlayBackground["inlineMenuFilterValue"]).toBe("");
       });
     });
 

--- a/apps/browser/src/autofill/background/overlay.background.spec.ts
+++ b/apps/browser/src/autofill/background/overlay.background.spec.ts
@@ -36,6 +36,7 @@ import {
 } from "@bitwarden/common/spec";
 import { UserId } from "@bitwarden/common/types/guid";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
+import { SearchService } from "@bitwarden/common/vault/abstractions/search.service";
 import { TotpService } from "@bitwarden/common/vault/abstractions/totp.service";
 import { VaultSettingsService } from "@bitwarden/common/vault/abstractions/vault-settings/vault-settings.service";
 import { CipherRepromptType, CipherType } from "@bitwarden/common/vault/enums";
@@ -119,6 +120,7 @@ describe("OverlayBackground", () => {
   let totpService: MockProxy<TotpService>;
   let generatorService: MockProxy<CredentialGeneratorService>;
   let generatorHistoryService: MockProxy<GeneratorHistoryService>;
+  let searchService: MockProxy<SearchService>;
   let overlayBackground: OverlayBackground;
   let portKeyForTabSpy: Record<number, string>;
   let pageDetailsForTabSpy: PageDetailsForTab;
@@ -231,6 +233,9 @@ describe("OverlayBackground", () => {
     );
     generatorHistoryService = mock<GeneratorHistoryService>();
     generatorHistoryService.track.mockResolvedValue(null);
+    searchService = mock<SearchService>();
+    searchService.isSearchable.mockResolvedValue(true);
+    searchService.searchCiphersBasic.mockImplementation((ciphers) => ciphers);
     overlayBackground = new OverlayBackground(
       logService,
       cipherService,
@@ -249,6 +254,7 @@ describe("OverlayBackground", () => {
       accountService,
       generatorHistoryService,
       generatorService,
+      searchService,
     );
     portKeyForTabSpy = overlayBackground["portKeyForTab"];
     pageDetailsForTabSpy = overlayBackground["pageDetailsForTab"];
@@ -955,6 +961,7 @@ describe("OverlayBackground", () => {
 
       expect(listPortSpy.postMessage).toHaveBeenCalledWith({
         command: "updateAutofillInlineMenuListCiphers",
+        filter: "",
         showInlineMenuAccountCreation: false,
         showPasskeysLabels: false,
         focusedFieldHasValue: false,
@@ -1021,6 +1028,7 @@ describe("OverlayBackground", () => {
         expect(listPortSpy.postMessage).toHaveBeenLastCalledWith(
           expect.objectContaining({
             command: "updateAutofillInlineMenuListCiphers",
+            filter: "",
             showInlineMenuAccountCreation: expectedShowInlineMenuAccountCreation,
             ciphers: expect.arrayContaining([
               expect.objectContaining({
@@ -1049,6 +1057,7 @@ describe("OverlayBackground", () => {
 
       expect(listPortSpy.postMessage).toHaveBeenCalledWith({
         command: "updateAutofillInlineMenuListCiphers",
+        filter: "",
         showInlineMenuAccountCreation: false,
         showPasskeysLabels: false,
         focusedFieldHasValue: false,
@@ -1087,6 +1096,7 @@ describe("OverlayBackground", () => {
 
         expect(listPortSpy.postMessage).toHaveBeenCalledWith({
           command: "updateAutofillInlineMenuListCiphers",
+          filter: "",
           showInlineMenuAccountCreation: true,
           showPasskeysLabels: false,
           focusedFieldHasValue: false,
@@ -1128,6 +1138,7 @@ describe("OverlayBackground", () => {
 
         expect(listPortSpy.postMessage).toHaveBeenCalledWith({
           command: "updateAutofillInlineMenuListCiphers",
+          filter: "",
           showInlineMenuAccountCreation: true,
           showPasskeysLabels: false,
           focusedFieldHasValue: false,
@@ -1200,6 +1211,7 @@ describe("OverlayBackground", () => {
 
         expect(listPortSpy.postMessage).toHaveBeenCalledWith({
           command: "updateAutofillInlineMenuListCiphers",
+          filter: "",
           showInlineMenuAccountCreation: true,
           showPasskeysLabels: false,
           focusedFieldHasValue: false,
@@ -1240,6 +1252,7 @@ describe("OverlayBackground", () => {
 
         expect(listPortSpy.postMessage).toHaveBeenCalledWith({
           command: "updateAutofillInlineMenuListCiphers",
+          filter: "",
           showInlineMenuAccountCreation: true,
           showPasskeysLabels: false,
           focusedFieldHasValue: false,
@@ -1268,6 +1281,7 @@ describe("OverlayBackground", () => {
 
       expect(listPortSpy.postMessage).toHaveBeenCalledWith({
         command: "updateAutofillInlineMenuListCiphers",
+        filter: "",
         ciphers: [
           {
             id: "inline-menu-cipher-0",
@@ -1357,6 +1371,7 @@ describe("OverlayBackground", () => {
 
       expect(listPortSpy.postMessage).toHaveBeenCalledWith({
         command: "updateAutofillInlineMenuListCiphers",
+        filter: "",
         ciphers: [
           {
             id: "inline-menu-cipher-0",
@@ -1424,6 +1439,7 @@ describe("OverlayBackground", () => {
 
       expect(listPortSpy.postMessage).toHaveBeenCalledWith({
         command: "updateAutofillInlineMenuListCiphers",
+        filter: "",
         ciphers: [
           {
             id: "inline-menu-cipher-0",
@@ -2087,6 +2103,7 @@ describe("OverlayBackground", () => {
 
         expect(listPortSpy.postMessage).toHaveBeenCalledWith({
           command: "updateAutofillInlineMenuListCiphers",
+          filter: "",
           ciphers: [],
           showInlineMenuAccountCreation: true,
           showPasskeysLabels: false,
@@ -2501,6 +2518,123 @@ describe("OverlayBackground", () => {
             topFrameSendOptions,
           );
         });
+      });
+    });
+
+    describe("updateAutofillInlineMenuFilter message handler", () => {
+      let sender: chrome.runtime.MessageSender;
+      let listCipher: CipherView;
+      let updateInlineMenuListCiphersSpy: jest.SpyInstance;
+
+      beforeEach(async () => {
+        await initOverlayElementPorts();
+        listCipher = mock<CipherView>({
+          id: "cipher-1",
+          type: CipherType.Login,
+          name: "Example",
+          login: { username: "user@example.com" } as any,
+        });
+        overlayBackground["inlineMenuCiphers"] = new Map([["inline-menu-cipher-0", listCipher]]);
+        overlayBackground["focusedFieldData"] = createFocusedFieldDataMock({
+          inlineMenuFillType: CipherType.Login,
+        });
+        sender = mock<chrome.runtime.MessageSender>({ tab: createChromeTabMock({ id: 1 }) });
+        updateInlineMenuListCiphersSpy = jest.spyOn(
+          overlayBackground as any,
+          "updateInlineMenuListCiphers",
+        );
+      });
+
+      it("stores the filter and re-renders the list with the filter forwarded to the iframe", async () => {
+        sendMockExtensionMessage(
+          { command: "updateAutofillInlineMenuFilter", filter: "exa" },
+          sender,
+        );
+        await flushPromises();
+
+        expect(overlayBackground["inlineMenuFilter"]).toBe("exa");
+        expect(updateInlineMenuListCiphersSpy).toHaveBeenCalledWith(sender.tab);
+        expect(listPortSpy.postMessage).toHaveBeenCalledWith(
+          expect.objectContaining({
+            command: "updateAutofillInlineMenuListCiphers",
+            filter: "exa",
+          }),
+        );
+      });
+
+      it("applies the stored filter to the cipher list via SearchService.searchCiphersBasic", async () => {
+        searchService.isSearchable.mockResolvedValue(true);
+        searchService.searchCiphersBasic.mockReturnValue([]);
+
+        sendMockExtensionMessage(
+          { command: "updateAutofillInlineMenuFilter", filter: "zzz" },
+          sender,
+        );
+        await flushPromises();
+
+        expect(searchService.searchCiphersBasic).toHaveBeenCalledWith([listCipher], "zzz");
+        expect(listPortSpy.postMessage).toHaveBeenCalledWith(
+          expect.objectContaining({ ciphers: [], filter: "zzz" }),
+        );
+      });
+
+      it("short-circuits filtering when the query is not searchable", async () => {
+        searchService.isSearchable.mockResolvedValue(false);
+
+        sendMockExtensionMessage(
+          { command: "updateAutofillInlineMenuFilter", filter: "x" },
+          sender,
+        );
+        await flushPromises();
+
+        expect(searchService.searchCiphersBasic).not.toHaveBeenCalled();
+      });
+
+      it("ignores duplicate filter values without re-rendering", async () => {
+        overlayBackground["inlineMenuFilter"] = "exa";
+        updateInlineMenuListCiphersSpy.mockClear();
+
+        sendMockExtensionMessage(
+          { command: "updateAutofillInlineMenuFilter", filter: "exa" },
+          sender,
+        );
+        await flushPromises();
+
+        expect(updateInlineMenuListCiphersSpy).not.toHaveBeenCalled();
+      });
+
+      it("caps the filter at the configured max length to avoid retaining large field values", async () => {
+        const longFilter = "a".repeat(1024);
+        sendMockExtensionMessage(
+          { command: "updateAutofillInlineMenuFilter", filter: longFilter },
+          sender,
+        );
+        await flushPromises();
+
+        expect(overlayBackground["inlineMenuFilter"].length).toBe(
+          overlayBackground["inlineMenuFilterMaxLength"],
+        );
+      });
+
+      it("resets the filter when the inline menu is closed", async () => {
+        overlayBackground["inlineMenuFilter"] = "exa";
+
+        sendMockExtensionMessage(
+          { command: "closeAutofillInlineMenu", forceCloseInlineMenu: true },
+          sender,
+        );
+        await flushPromises();
+
+        expect(overlayBackground["inlineMenuFilter"]).toBe("");
+      });
+
+      it("resets the filter when updateOverlayCiphers is called", async () => {
+        overlayBackground["inlineMenuFilter"] = "exa";
+        activeAccountStatusMock$.next(AuthenticationStatus.Unlocked);
+
+        await overlayBackground.updateOverlayCiphers();
+
+        expect(overlayBackground["inlineMenuFilter"]).toBe("");
       });
     });
 

--- a/apps/browser/src/autofill/background/overlay.background.ts
+++ b/apps/browser/src/autofill/background/overlay.background.ts
@@ -166,12 +166,12 @@ export class OverlayBackground implements OverlayBackgroundInterface {
    * on inline-menu close, and on full vault refresh. Treated as PII; never
    * logged.
    */
-  private inlineMenuFilter: string = "";
+  private inlineMenuFilterValue: string = "";
   /**
    * Defensive upper bound on the stored filter length. Field values can be
    * arbitrarily long; we don't need more than a short query for matching.
    */
-  private readonly inlineMenuFilterMaxLength = 256;
+  private readonly inlineMenuFilterValueMaxLength = 256;
   private readonly validPortConnections: Set<string> = new Set([
     AutofillOverlayPort.Button,
     AutofillOverlayPort.ButtonMessageConnector,
@@ -228,8 +228,8 @@ export class OverlayBackground implements OverlayBackgroundInterface {
     deletedCipher: () => this.updateOverlayCiphers(),
     bgSaveCipher: () => this.updateOverlayCiphers(),
     updateOverlayCiphers: () => this.updateOverlayCiphers(),
-    updateAutofillInlineMenuFilter: ({ message, sender }) =>
-      this.updateInlineMenuFilter(message, sender),
+    filterInlineMenuCiphers: ({ message, sender }) =>
+      this.filterInlineMenuCiphers(message, sender),
     fido2AbortRequest: ({ sender }) =>
       void this.withSenderTab(sender, (tab) => this.abortFido2ActiveRequest(tab.id)),
   };
@@ -412,7 +412,7 @@ export class OverlayBackground implements OverlayBackgroundInterface {
     const authStatus = await firstValueFrom(this.authService.activeAccountStatus$);
     if (authStatus === AuthenticationStatus.Unlocked) {
       this.inlineMenuCiphers = new Map();
-      this.resetInlineMenuFilter();
+      this.resetInlineMenuFilterValue();
       this.updateOverlayCiphers$.next({ updateAllCipherTypes, refocusField });
     }
   }
@@ -488,7 +488,7 @@ export class OverlayBackground implements OverlayBackgroundInterface {
       showInlineMenuAccountCreation: this.shouldShowInlineMenuAccountCreation(),
       showPasskeysLabels: this.showPasskeysLabelsWithinInlineMenu,
       focusedFieldHasValue: await this.checkFocusedFieldHasValue(tab),
-      filter: this.inlineMenuFilter,
+      filterValue: this.inlineMenuFilterValue,
     });
   }
 
@@ -500,7 +500,7 @@ export class OverlayBackground implements OverlayBackgroundInterface {
    * @param message - The extension message carrying the new filter value
    * @param sender - The sender of the message; tab is used to scope the update
    */
-  private async updateInlineMenuFilter(
+  private async filterInlineMenuCiphers(
     message: OverlayBackgroundExtensionMessage,
     sender: chrome.runtime.MessageSender,
   ) {
@@ -508,14 +508,14 @@ export class OverlayBackground implements OverlayBackgroundInterface {
       return;
     }
 
-    const rawFilter = typeof message.filter === "string" ? message.filter : "";
-    const nextFilter = rawFilter.slice(0, this.inlineMenuFilterMaxLength);
+    const rawFilter = typeof message.filterValue === "string" ? message.filterValue : "";
+    const nextFilter = rawFilter.slice(0, this.inlineMenuFilterValueMaxLength);
 
-    if (nextFilter === this.inlineMenuFilter) {
+    if (nextFilter === this.inlineMenuFilterValue) {
       return;
     }
 
-    this.inlineMenuFilter = nextFilter;
+    this.inlineMenuFilterValue = nextFilter;
     await this.updateInlineMenuListCiphers(sender.tab);
   }
 
@@ -524,8 +524,8 @@ export class OverlayBackground implements OverlayBackgroundInterface {
    * closes, the focused field changes, or the underlying cipher set is
    * refreshed.
    */
-  private resetInlineMenuFilter(): void {
-    this.inlineMenuFilter = "";
+  private resetInlineMenuFilterValue(): void {
+    this.inlineMenuFilterValue = "";
   }
 
   /**
@@ -605,7 +605,7 @@ export class OverlayBackground implements OverlayBackgroundInterface {
    * Strips out unnecessary data from the ciphers and returns an array of
    * objects that contain the cipher data needed for the inline menu list.
    *
-   * Applies the current `inlineMenuFilter` (a user-typed substring) against
+   * Applies the current `inlineMenuFilterValue` (a user-typed substring) against
    * the in-memory cipher set before projection. The filter must always be
    * applied to the raw `CipherView` set so that the existing TOTP/passkey/
    * grouping logic in {@link buildInlineMenuCiphers} continues to operate
@@ -641,24 +641,24 @@ export class OverlayBackground implements OverlayBackgroundInterface {
 
   /**
    * Returns the inline-menu cipher entries, optionally filtered by the current
-   * `inlineMenuFilter` via `SearchService.searchCiphersBasic`. When the filter
+   * `inlineMenuFilterValue` via `SearchService.searchCiphersBasic`. When the filter
    * is empty or too short to be searchable, the full set is returned and all
    * existing behavior is preserved unchanged.
    */
   private async getFilteredInlineMenuCiphers(): Promise<[string, CipherView][]> {
     const entries = Array.from(this.inlineMenuCiphers);
-    const filter = this.inlineMenuFilter;
-    if (!filter) {
+    const filterValue = this.inlineMenuFilterValue;
+    if (!filterValue) {
       return entries;
     }
 
-    const isSearchable = await this.searchService.isSearchable(filter);
+    const isSearchable = await this.searchService.isSearchable(filterValue);
     if (!isSearchable) {
       return entries;
     }
 
     const cipherViews = entries.map(([, cipher]) => cipher);
-    const matched = new Set(this.searchService.searchCiphersBasic(cipherViews, filter));
+    const matched = new Set(this.searchService.searchCiphersBasic(cipherViews, filterValue));
     return entries.filter(([, cipher]) => matched.has(cipher));
   }
 
@@ -1606,7 +1606,7 @@ export class OverlayBackground implements OverlayBackgroundInterface {
     const sendOptions = { frameId: 0 };
     const updateVisibilityDefaults = { overlayElement, isVisible: false, forceUpdate: true };
     this.clearGeneratedPassword$.next();
-    this.resetInlineMenuFilter();
+    this.resetInlineMenuFilterValue();
 
     if (forceCloseInlineMenu) {
       BrowserApi.tabSendMessage(tab, { command, overlayElement }, sendOptions).catch((error) =>
@@ -2032,7 +2032,7 @@ export class OverlayBackground implements OverlayBackgroundInterface {
     this.isFieldCurrentlyFocused = true;
 
     if (previousFocusedFieldData?.focusedFieldOpid !== this.focusedFieldData.focusedFieldOpid) {
-      this.resetInlineMenuFilter();
+      this.resetInlineMenuFilterValue();
     }
 
     if (this.shouldUpdatePasswordGeneratorMenuOnFieldFocus()) {

--- a/apps/browser/src/autofill/background/overlay.background.ts
+++ b/apps/browser/src/autofill/background/overlay.background.ts
@@ -42,6 +42,7 @@ import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { ThemeStateService } from "@bitwarden/common/platform/theming/theme-state.service";
 import { UserId } from "@bitwarden/common/types/guid";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
+import { SearchService } from "@bitwarden/common/vault/abstractions/search.service";
 import { TotpService } from "@bitwarden/common/vault/abstractions/totp.service";
 import { VaultSettingsService } from "@bitwarden/common/vault/abstractions/vault-settings/vault-settings.service";
 import { CipherType } from "@bitwarden/common/vault/enums";
@@ -159,6 +160,18 @@ export class OverlayBackground implements OverlayBackgroundInterface {
   private isInlineMenuListVisible: boolean = false;
   private showPasskeysLabelsWithinInlineMenu: boolean = false;
   private passkeyAuthTabId: number | null = null;
+  /**
+   * Substring filter applied to the inline-menu cipher list, driven by the user
+   * typing into the focused field. Reset on focus-change to a different field,
+   * on inline-menu close, and on full vault refresh. Treated as PII; never
+   * logged.
+   */
+  private inlineMenuFilter: string = "";
+  /**
+   * Defensive upper bound on the stored filter length. Field values can be
+   * arbitrarily long; we don't need more than a short query for matching.
+   */
+  private readonly inlineMenuFilterMaxLength = 256;
   private readonly validPortConnections: Set<string> = new Set([
     AutofillOverlayPort.Button,
     AutofillOverlayPort.ButtonMessageConnector,
@@ -215,6 +228,8 @@ export class OverlayBackground implements OverlayBackgroundInterface {
     deletedCipher: () => this.updateOverlayCiphers(),
     bgSaveCipher: () => this.updateOverlayCiphers(),
     updateOverlayCiphers: () => this.updateOverlayCiphers(),
+    updateAutofillInlineMenuFilter: ({ message, sender }) =>
+      this.updateInlineMenuFilter(message, sender),
     fido2AbortRequest: ({ sender }) =>
       void this.withSenderTab(sender, (tab) => this.abortFido2ActiveRequest(tab.id)),
   };
@@ -260,6 +275,7 @@ export class OverlayBackground implements OverlayBackgroundInterface {
     private accountService: AccountService,
     private generatorHistoryService: GeneratorHistoryService,
     private generatorService: CredentialGeneratorService,
+    private searchService: SearchService,
   ) {
     this.initOverlayEventObservables();
   }
@@ -396,6 +412,7 @@ export class OverlayBackground implements OverlayBackgroundInterface {
     const authStatus = await firstValueFrom(this.authService.activeAccountStatus$);
     if (authStatus === AuthenticationStatus.Unlocked) {
       this.inlineMenuCiphers = new Map();
+      this.resetInlineMenuFilter();
       this.updateOverlayCiphers$.next({ updateAllCipherTypes, refocusField });
     }
   }
@@ -471,7 +488,44 @@ export class OverlayBackground implements OverlayBackgroundInterface {
       showInlineMenuAccountCreation: this.shouldShowInlineMenuAccountCreation(),
       showPasskeysLabels: this.showPasskeysLabelsWithinInlineMenu,
       focusedFieldHasValue: await this.checkFocusedFieldHasValue(tab),
+      filter: this.inlineMenuFilter,
     });
+  }
+
+  /**
+   * Stores the latest filter substring typed into the focused form field and
+   * re-renders the inline-menu list with the filter applied. The filter is
+   * treated as PII (it can be a username or email) and is never logged.
+   *
+   * @param message - The extension message carrying the new filter value
+   * @param sender - The sender of the message; tab is used to scope the update
+   */
+  private async updateInlineMenuFilter(
+    message: OverlayBackgroundExtensionMessage,
+    sender: chrome.runtime.MessageSender,
+  ) {
+    if (sender.tab === null || sender.tab === undefined) {
+      return;
+    }
+
+    const rawFilter = typeof message.filter === "string" ? message.filter : "";
+    const nextFilter = rawFilter.slice(0, this.inlineMenuFilterMaxLength);
+
+    if (nextFilter === this.inlineMenuFilter) {
+      return;
+    }
+
+    this.inlineMenuFilter = nextFilter;
+    await this.updateInlineMenuListCiphers(sender.tab);
+  }
+
+  /**
+   * Resets the inline-menu cipher filter. Called whenever the inline menu
+   * closes, the focused field changes, or the underlying cipher set is
+   * refreshed.
+   */
+  private resetInlineMenuFilter(): void {
+    this.inlineMenuFilter = "";
   }
 
   /**
@@ -550,6 +604,12 @@ export class OverlayBackground implements OverlayBackgroundInterface {
   /**
    * Strips out unnecessary data from the ciphers and returns an array of
    * objects that contain the cipher data needed for the inline menu list.
+   *
+   * Applies the current `inlineMenuFilter` (a user-typed substring) against
+   * the in-memory cipher set before projection. The filter must always be
+   * applied to the raw `CipherView` set so that the existing TOTP/passkey/
+   * grouping logic in {@link buildInlineMenuCiphers} continues to operate
+   * over the same shape it always has.
    */
   private async getInlineMenuCipherData(): Promise<InlineMenuCipherData[]> {
     const [showFavicons, env] = await Promise.all([
@@ -557,7 +617,7 @@ export class OverlayBackground implements OverlayBackgroundInterface {
       firstValueFrom(this.environmentService.environment$),
     ]);
     const iconsServerUrl: string | null = env.getIconsUrl() ?? null;
-    const inlineMenuCiphersArray = Array.from(this.inlineMenuCiphers);
+    const inlineMenuCiphersArray = await this.getFilteredInlineMenuCiphers();
     let inlineMenuCipherData: InlineMenuCipherData[];
     this.showPasskeysLabelsWithinInlineMenu = false;
 
@@ -577,6 +637,29 @@ export class OverlayBackground implements OverlayBackgroundInterface {
 
     this.currentInlineMenuCiphersCount = inlineMenuCipherData.length;
     return inlineMenuCipherData;
+  }
+
+  /**
+   * Returns the inline-menu cipher entries, optionally filtered by the current
+   * `inlineMenuFilter` via `SearchService.searchCiphersBasic`. When the filter
+   * is empty or too short to be searchable, the full set is returned and all
+   * existing behavior is preserved unchanged.
+   */
+  private async getFilteredInlineMenuCiphers(): Promise<[string, CipherView][]> {
+    const entries = Array.from(this.inlineMenuCiphers);
+    const filter = this.inlineMenuFilter;
+    if (!filter) {
+      return entries;
+    }
+
+    const isSearchable = await this.searchService.isSearchable(filter);
+    if (!isSearchable) {
+      return entries;
+    }
+
+    const cipherViews = entries.map(([, cipher]) => cipher);
+    const matched = new Set(this.searchService.searchCiphersBasic(cipherViews, filter));
+    return entries.filter(([, cipher]) => matched.has(cipher));
   }
 
   /**
@@ -1523,6 +1606,7 @@ export class OverlayBackground implements OverlayBackgroundInterface {
     const sendOptions = { frameId: 0 };
     const updateVisibilityDefaults = { overlayElement, isVisible: false, forceUpdate: true };
     this.clearGeneratedPassword$.next();
+    this.resetInlineMenuFilter();
 
     if (forceCloseInlineMenu) {
       BrowserApi.tabSendMessage(tab, { command, overlayElement }, sendOptions).catch((error) =>
@@ -1946,6 +2030,10 @@ export class OverlayBackground implements OverlayBackgroundInterface {
     };
     this.allFieldData = allFieldsRect ?? [];
     this.isFieldCurrentlyFocused = true;
+
+    if (previousFocusedFieldData?.focusedFieldOpid !== this.focusedFieldData.focusedFieldOpid) {
+      this.resetInlineMenuFilter();
+    }
 
     if (this.shouldUpdatePasswordGeneratorMenuOnFieldFocus()) {
       this.updateInlineMenuGeneratedPasswordOnFocus(sender.tab).catch((error) =>
@@ -2494,6 +2582,7 @@ export class OverlayBackground implements OverlayBackgroundInterface {
         "newIdentity",
         "newItem",
         "newLogin",
+        "inlineMenuNoMatches",
         "noItemsToShow",
         "opensInANewWindow",
         "passkeys",

--- a/apps/browser/src/autofill/overlay/inline-menu/abstractions/autofill-inline-menu-list.ts
+++ b/apps/browser/src/autofill/overlay/inline-menu/abstractions/autofill-inline-menu-list.ts
@@ -8,6 +8,12 @@ type AutofillInlineMenuListMessage = { command: string };
 export type UpdateAutofillInlineMenuListCiphersParams = {
   ciphers: InlineMenuCipherData[];
   showInlineMenuAccountCreation?: boolean;
+  /**
+   * The current substring filter being applied to the cipher list. When non-empty
+   * and the resulting `ciphers` array is empty, the list iframe renders a
+   * "no matches" empty-state that includes this string.
+   */
+  filter?: string;
 };
 
 export type UpdateAutofillInlineMenuListCiphersMessage = AutofillInlineMenuListMessage &

--- a/apps/browser/src/autofill/overlay/inline-menu/abstractions/autofill-inline-menu-list.ts
+++ b/apps/browser/src/autofill/overlay/inline-menu/abstractions/autofill-inline-menu-list.ts
@@ -13,7 +13,7 @@ export type UpdateAutofillInlineMenuListCiphersParams = {
    * and the resulting `ciphers` array is empty, the list iframe renders a
    * "no matches" empty-state that includes this string.
    */
-  filter?: string;
+  filterValue?: string;
 };
 
 export type UpdateAutofillInlineMenuListCiphersMessage = AutofillInlineMenuListMessage &

--- a/apps/browser/src/autofill/overlay/inline-menu/pages/list/autofill-inline-menu-list.spec.ts
+++ b/apps/browser/src/autofill/overlay/inline-menu/pages/list/autofill-inline-menu-list.spec.ts
@@ -176,7 +176,7 @@ describe("AutofillInlineMenuList", () => {
           postWindowMessage({
             command: "updateAutofillInlineMenuListCiphers",
             ciphers: [],
-            filter: "exa",
+            filterValue: "exa",
             portKey,
             token: "test-token",
           });
@@ -193,7 +193,7 @@ describe("AutofillInlineMenuList", () => {
           postWindowMessage({
             command: "updateAutofillInlineMenuListCiphers",
             ciphers: [],
-            filter: "<img src=x onerror=alert(1)>",
+            filterValue: "<img src=x onerror=alert(1)>",
             portKey,
             token: "test-token",
           });

--- a/apps/browser/src/autofill/overlay/inline-menu/pages/list/autofill-inline-menu-list.spec.ts
+++ b/apps/browser/src/autofill/overlay/inline-menu/pages/list/autofill-inline-menu-list.spec.ts
@@ -162,6 +162,48 @@ describe("AutofillInlineMenuList", () => {
           expectedOrigin,
         );
       });
+
+      describe("when a filter is applied", () => {
+        beforeEach(async () => {
+          postWindowMessage(
+            createInitAutofillInlineMenuListMessageMock({
+              authStatus: AuthenticationStatus.Unlocked,
+              ciphers: [],
+              portKey,
+            }),
+          );
+          await flushPromises();
+          postWindowMessage({
+            command: "updateAutofillInlineMenuListCiphers",
+            ciphers: [],
+            filter: "exa",
+            portKey,
+            token: "test-token",
+          });
+          await flushPromises();
+        });
+
+        it("renders the localized no-matches message instead of the generic empty-state", () => {
+          const message =
+            autofillInlineMenuList["inlineMenuListContainer"].querySelector(".no-items");
+          expect(message?.textContent).toBe('No matches for "exa"');
+        });
+
+        it("inserts the filter as a text node so it cannot be interpreted as HTML", () => {
+          postWindowMessage({
+            command: "updateAutofillInlineMenuListCiphers",
+            ciphers: [],
+            filter: "<img src=x onerror=alert(1)>",
+            portKey,
+            token: "test-token",
+          });
+
+          const message =
+            autofillInlineMenuList["inlineMenuListContainer"].querySelector(".no-items");
+          expect(message?.querySelector("img")).toBeNull();
+          expect(message?.textContent).toContain("<img src=x onerror=alert(1)>");
+        });
+      });
     });
 
     describe("the list of ciphers for an authenticated user", () => {

--- a/apps/browser/src/autofill/overlay/inline-menu/pages/list/autofill-inline-menu-list.ts
+++ b/apps/browser/src/autofill/overlay/inline-menu/pages/list/autofill-inline-menu-list.ts
@@ -527,14 +527,19 @@ export class AutofillInlineMenuList extends AutofillInlineMenuPageElement {
 
   /**
    * Updates the list items with the passed ciphers.
-   * If no ciphers are passed, the no results inline menu is built.
+   * If no ciphers are passed, the no results inline menu is built. When a non-empty
+   * `filter` is provided (the substring the user has typed into the focused field),
+   * the no-results state surfaces that the empty list is due to the active filter
+   * rather than an empty vault.
    *
    * @param ciphers - The ciphers to display in the inline menu list.
    * @param showInlineMenuAccountCreation - Whether identity ciphers are shown on login fields.
+   * @param filter - The current substring filter applied to the cipher list.
    */
   private updateListItems({
     ciphers = [],
     showInlineMenuAccountCreation = false,
+    filter = "",
   }: UpdateAutofillInlineMenuListCiphersParams) {
     if (this.isPasskeyAuthInProgress) {
       return;
@@ -546,7 +551,7 @@ export class AutofillInlineMenuList extends AutofillInlineMenuPageElement {
     this.resetInlineMenuContainer();
 
     if (!this.ciphers?.length) {
-      this.buildNoResultsInlineMenuList();
+      this.buildNoResultsInlineMenuList(filter);
       return;
     }
 
@@ -584,16 +589,60 @@ export class AutofillInlineMenuList extends AutofillInlineMenuPageElement {
 
   /**
    * Inline menu view that is presented when no ciphers are found for a given page.
-   * Facilitates the ability to add a new vault item from the inline menu.
+   * When a non-empty `filter` is provided the message reflects that the empty list
+   * is the result of the active filter; otherwise the generic "no items" message
+   * is shown. Facilitates the ability to add a new vault item from the inline menu.
+   *
+   * @param filter - The current substring filter applied to the cipher list.
    */
-  private buildNoResultsInlineMenuList() {
+  private buildNoResultsInlineMenuList(filter: string = "") {
     const noItemsMessage = globalThis.document.createElement("div");
     noItemsMessage.classList.add("no-items", "inline-menu-list-message");
-    noItemsMessage.textContent = this.getTranslation("noItemsToShow");
+    if (filter) {
+      this.setNoMatchesMessageContent(noItemsMessage, filter);
+    } else {
+      noItemsMessage.textContent = this.getTranslation("noItemsToShow");
+    }
 
     const newItemButton = this.buildNewItemButton();
 
     this.inlineMenuListContainer.append(noItemsMessage, newItemButton);
+  }
+
+  /**
+   * Renders the localized "no matches for $FILTER$" message into the given
+   * element, inserting the user-typed filter as a text node so it cannot be
+   * interpreted as HTML.
+   *
+   * @param target - The element to receive the message content.
+   * @param filter - The current substring filter applied to the cipher list.
+   */
+  private setNoMatchesMessageContent(target: HTMLElement, filter: string) {
+    const template = this.getTranslation("inlineMenuNoMatches");
+    target.textContent = "";
+
+    if (!template) {
+      // Translation missing — fall back to a plain, escaped representation.
+      target.textContent = filter;
+      return;
+    }
+
+    const placeholder = "$FILTER$";
+    const placeholderIndex = template.indexOf(placeholder);
+    if (placeholderIndex === -1) {
+      target.textContent = template;
+      return;
+    }
+
+    const before = template.slice(0, placeholderIndex);
+    const after = template.slice(placeholderIndex + placeholder.length);
+    if (before) {
+      target.appendChild(globalThis.document.createTextNode(before));
+    }
+    target.appendChild(globalThis.document.createTextNode(filter));
+    if (after) {
+      target.appendChild(globalThis.document.createTextNode(after));
+    }
   }
 
   /**

--- a/apps/browser/src/autofill/overlay/inline-menu/pages/list/autofill-inline-menu-list.ts
+++ b/apps/browser/src/autofill/overlay/inline-menu/pages/list/autofill-inline-menu-list.ts
@@ -534,12 +534,12 @@ export class AutofillInlineMenuList extends AutofillInlineMenuPageElement {
    *
    * @param ciphers - The ciphers to display in the inline menu list.
    * @param showInlineMenuAccountCreation - Whether identity ciphers are shown on login fields.
-   * @param filter - The current substring filter applied to the cipher list.
+   * @param filterValue - The current substring filter applied to the cipher list.
    */
   private updateListItems({
     ciphers = [],
     showInlineMenuAccountCreation = false,
-    filter = "",
+    filterValue = "",
   }: UpdateAutofillInlineMenuListCiphersParams) {
     if (this.isPasskeyAuthInProgress) {
       return;
@@ -551,7 +551,7 @@ export class AutofillInlineMenuList extends AutofillInlineMenuPageElement {
     this.resetInlineMenuContainer();
 
     if (!this.ciphers?.length) {
-      this.buildNoResultsInlineMenuList(filter);
+      this.buildNoResultsInlineMenuList(filterValue);
       return;
     }
 
@@ -589,17 +589,17 @@ export class AutofillInlineMenuList extends AutofillInlineMenuPageElement {
 
   /**
    * Inline menu view that is presented when no ciphers are found for a given page.
-   * When a non-empty `filter` is provided the message reflects that the empty list
+   * When a non-empty `filterValue` is provided the message reflects that the empty list
    * is the result of the active filter; otherwise the generic "no items" message
    * is shown. Facilitates the ability to add a new vault item from the inline menu.
    *
-   * @param filter - The current substring filter applied to the cipher list.
+   * @param filterValue - The current substring filter applied to the cipher list.
    */
-  private buildNoResultsInlineMenuList(filter: string = "") {
+  private buildNoResultsInlineMenuList(filterValue: string = "") {
     const noItemsMessage = globalThis.document.createElement("div");
     noItemsMessage.classList.add("no-items", "inline-menu-list-message");
-    if (filter) {
-      this.setNoMatchesMessageContent(noItemsMessage, filter);
+    if (filterValue) {
+      this.setNoMatchesMessageContent(noItemsMessage, filterValue);
     } else {
       noItemsMessage.textContent = this.getTranslation("noItemsToShow");
     }
@@ -615,15 +615,15 @@ export class AutofillInlineMenuList extends AutofillInlineMenuPageElement {
    * interpreted as HTML.
    *
    * @param target - The element to receive the message content.
-   * @param filter - The current substring filter applied to the cipher list.
+   * @param filterValue - The current substring filter applied to the cipher list.
    */
-  private setNoMatchesMessageContent(target: HTMLElement, filter: string) {
+  private setNoMatchesMessageContent(target: HTMLElement, filterValue: string) {
     const template = this.getTranslation("inlineMenuNoMatches");
     target.textContent = "";
 
     if (!template) {
       // Translation missing — fall back to a plain, escaped representation.
-      target.textContent = filter;
+      target.textContent = filterValue;
       return;
     }
 
@@ -639,7 +639,7 @@ export class AutofillInlineMenuList extends AutofillInlineMenuPageElement {
     if (before) {
       target.appendChild(globalThis.document.createTextNode(before));
     }
-    target.appendChild(globalThis.document.createTextNode(filter));
+    target.appendChild(globalThis.document.createTextNode(filterValue));
     if (after) {
       target.appendChild(globalThis.document.createTextNode(after));
     }

--- a/apps/browser/src/autofill/services/autofill-overlay-content.service.spec.ts
+++ b/apps/browser/src/autofill/services/autofill-overlay-content.service.spec.ts
@@ -497,7 +497,7 @@ describe("AutofillOverlayContentService", () => {
           );
         });
 
-        it("Closes the inline menu list and does not re-open the inline menu if the field has a value", async () => {
+        it("sends the typed value as a filter update on a login username field and does not close the inline menu", async () => {
           (autofillFieldElement as HTMLInputElement).value = "test";
 
           await autofillOverlayContentService.setupOverlayListeners(
@@ -508,14 +508,17 @@ describe("AutofillOverlayContentService", () => {
           autofillFieldElement.dispatchEvent(new Event("input"));
           await flushPromises();
 
-          expect(sendExtensionMessageSpy).toHaveBeenCalledWith("closeAutofillInlineMenu", {
+          expect(sendExtensionMessageSpy).toHaveBeenCalledWith("updateAutofillInlineMenuFilter", {
+            filter: "test",
+          });
+          expect(sendExtensionMessageSpy).not.toHaveBeenCalledWith("closeAutofillInlineMenu", {
             overlayElement: AutofillOverlayElement.List,
             forceCloseInlineMenu: true,
           });
           expect(sendExtensionMessageSpy).not.toHaveBeenCalledWith("openAutofillInlineMenu");
         });
 
-        it("opens the inline menu if the field does not have a value", async () => {
+        it("sends an empty filter update on a login username field when the field is empty", async () => {
           await autofillOverlayContentService.setupOverlayListeners(
             autofillFieldElement,
             autofillFieldData,
@@ -524,7 +527,42 @@ describe("AutofillOverlayContentService", () => {
           autofillFieldElement.dispatchEvent(new Event("input"));
           await flushPromises();
 
-          expect(sendExtensionMessageSpy).toHaveBeenCalledWith("openAutofillInlineMenu");
+          expect(sendExtensionMessageSpy).toHaveBeenCalledWith("updateAutofillInlineMenuFilter", {
+            filter: "",
+          });
+          expect(sendExtensionMessageSpy).not.toHaveBeenCalledWith("openAutofillInlineMenu");
+        });
+
+        it("still closes the inline menu when typing in a password field", async () => {
+          const passwordFieldElement = document.getElementById(
+            "password-field",
+          ) as ElementWithOpId<FillableFormFieldElement>;
+          (passwordFieldElement as HTMLInputElement).value = "secret";
+
+          const passwordFieldData = createAutofillFieldMock({
+            opid: "password-field",
+            form: "validFormId",
+            elementNumber: 2,
+            autoCompleteType: "current-password",
+            type: "password",
+          });
+
+          await autofillOverlayContentService.setupOverlayListeners(
+            passwordFieldElement,
+            passwordFieldData,
+            pageDetailsMock,
+          );
+          passwordFieldElement.dispatchEvent(new Event("input"));
+          await flushPromises();
+
+          expect(sendExtensionMessageSpy).toHaveBeenCalledWith("closeAutofillInlineMenu", {
+            overlayElement: AutofillOverlayElement.List,
+            forceCloseInlineMenu: true,
+          });
+          expect(sendExtensionMessageSpy).not.toHaveBeenCalledWith(
+            "updateAutofillInlineMenuFilter",
+            expect.anything(),
+          );
         });
 
         describe("input changes on a field filled by a card cipher", () => {

--- a/apps/browser/src/autofill/services/autofill-overlay-content.service.spec.ts
+++ b/apps/browser/src/autofill/services/autofill-overlay-content.service.spec.ts
@@ -508,8 +508,8 @@ describe("AutofillOverlayContentService", () => {
           autofillFieldElement.dispatchEvent(new Event("input"));
           await flushPromises();
 
-          expect(sendExtensionMessageSpy).toHaveBeenCalledWith("updateAutofillInlineMenuFilter", {
-            filter: "test",
+          expect(sendExtensionMessageSpy).toHaveBeenCalledWith("filterInlineMenuCiphers", {
+            filterValue: "test",
           });
           expect(sendExtensionMessageSpy).not.toHaveBeenCalledWith("closeAutofillInlineMenu", {
             overlayElement: AutofillOverlayElement.List,
@@ -527,8 +527,8 @@ describe("AutofillOverlayContentService", () => {
           autofillFieldElement.dispatchEvent(new Event("input"));
           await flushPromises();
 
-          expect(sendExtensionMessageSpy).toHaveBeenCalledWith("updateAutofillInlineMenuFilter", {
-            filter: "",
+          expect(sendExtensionMessageSpy).toHaveBeenCalledWith("filterInlineMenuCiphers", {
+            filterValue: "",
           });
           expect(sendExtensionMessageSpy).not.toHaveBeenCalledWith("openAutofillInlineMenu");
         });
@@ -560,7 +560,7 @@ describe("AutofillOverlayContentService", () => {
             forceCloseInlineMenu: true,
           });
           expect(sendExtensionMessageSpy).not.toHaveBeenCalledWith(
-            "updateAutofillInlineMenuFilter",
+            "filterInlineMenuCiphers",
             expect.anything(),
           );
         });

--- a/apps/browser/src/autofill/services/autofill-overlay-content.service.ts
+++ b/apps/browser/src/autofill/services/autofill-overlay-content.service.ts
@@ -817,8 +817,8 @@ export class AutofillOverlayContentService implements AutofillOverlayContentServ
     }
 
     if (this.shouldFilterInlineMenuOnInput(formFieldElement)) {
-      await this.sendExtensionMessage("updateAutofillInlineMenuFilter", {
-        filter: formFieldElement.value ?? "",
+      await this.sendExtensionMessage("filterInlineMenuCiphers", {
+        filterValue: formFieldElement.value ?? "",
       });
       return;
     }

--- a/apps/browser/src/autofill/services/autofill-overlay-content.service.ts
+++ b/apps/browser/src/autofill/services/autofill-overlay-content.service.ts
@@ -796,7 +796,10 @@ export class AutofillOverlayContentService implements AutofillOverlayContentServ
   /**
    * Triggers when the form field element receives an input event. This method will
    * store the modified form element data for use when the user attempts to add a new
-   * vault item. It also acts to remove the inline menu list while the user is typing.
+   * vault item. For username/email/text login-like fields it streams the current
+   * field value to the background so the inline-menu list can filter ciphers as
+   * the user types; for password / TOTP / card / identity fields, the existing
+   * close-on-type behavior is preserved.
    *
    * @param formFieldElement - The form field element that triggered the input event.
    */
@@ -813,6 +816,13 @@ export class AutofillOverlayContentService implements AutofillOverlayContentServ
       return;
     }
 
+    if (this.shouldFilterInlineMenuOnInput(formFieldElement)) {
+      await this.sendExtensionMessage("updateAutofillInlineMenuFilter", {
+        filter: formFieldElement.value ?? "",
+      });
+      return;
+    }
+
     await this.sendExtensionMessage("closeAutofillInlineMenu", {
       overlayElement: AutofillOverlayElement.List,
       forceCloseInlineMenu: true,
@@ -821,6 +831,48 @@ export class AutofillOverlayContentService implements AutofillOverlayContentServ
     if (!formFieldElement?.value) {
       await this.sendExtensionMessage("openAutofillInlineMenu");
     }
+  }
+
+  /**
+   * Whether the focused field should drive a live filter of the inline-menu
+   * cipher list (rather than the legacy close-on-type behavior).
+   *
+   * Limited to login/account-creation **non-password** text-like fields so we
+   * (a) never pipe password keystrokes through the inline-menu plumbing, and
+   * (b) preserve current click-to-fill behavior for card/identity fields.
+   *
+   * @param formFieldElement - The form field element that triggered the input event.
+   */
+  private shouldFilterInlineMenuOnInput(
+    formFieldElement: ElementWithOpId<FormFieldElement>,
+  ): boolean {
+    const autofillFieldData = this.formFieldElements.get(formFieldElement);
+    if (!autofillFieldData) {
+      return false;
+    }
+
+    const fillType = autofillFieldData.inlineMenuFillType;
+    const isLoginUsernameContext =
+      fillType === CipherType.Login ||
+      fillType === InlineMenuFillTypes.AccountCreationUsername;
+    if (!isLoginUsernameContext) {
+      return false;
+    }
+
+    const inputType = (autofillFieldData.type ?? "").toLowerCase();
+    if (inputType === "password" || inputType === "hidden" || inputType === "totp") {
+      return false;
+    }
+
+    if (
+      autofillFieldData.accountCreationFieldType ===
+        InlineMenuAccountCreationFieldType.Password ||
+      autofillFieldData.accountCreationFieldType === InlineMenuAccountCreationFieldType.Totp
+    ) {
+      return false;
+    }
+
+    return true;
   }
 
   /**

--- a/apps/browser/src/autofill/spec/autofill-mocks.ts
+++ b/apps/browser/src/autofill/spec/autofill-mocks.ts
@@ -167,6 +167,7 @@ const overlayPagesTranslations = {
   username: "username",
   view: "view",
   noItemsToShow: "noItemsToShow",
+  inlineMenuNoMatches: 'No matches for "$FILTER$"',
   newItem: "newItem",
   addNewVaultItem: "addNewVaultItem",
 };

--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -2186,6 +2186,7 @@ export default class MainBackground {
       this.accountService,
       this.generatorHistoryService,
       this.credentialGeneratorService,
+      this.searchService,
     );
 
     this.autofillBadgeUpdaterService = new AutofillBadgeUpdaterService(


### PR DESCRIPTION
## 🎟️ Tracking

Community feature request (52 replies, ~1.3k views): https://community.bitwarden.com/t/inline-autofill-menu-ability-to-filter-items-by-typing-searching/63417

## 📔 Objective

When the inline autofill menu is open and the user starts typing in a username/email field, the menu closes today (see `triggerFormFieldInput` -> `closeAutofillInlineMenu`). For users with several saved logins on the same site this means scrolling instead of narrowing. This PR keeps the menu open on login text fields and filters the cipher list using the typed text. The focused input field itself acts as the search box, so no new UI is added.

Behavior on password, TOTP, card, and identity fields is preserved unchanged (still close-on-type). The filter is reset whenever the inline menu closes, focus moves to a different field, or the vault refreshes, and it is treated as PII (never logged, length-capped).

Changes:
- `autofill-overlay-content.service.ts`: `triggerFormFieldInput` branches on `inlineMenuFillType`. For login text-like fields (`CipherType.Login`, `InlineMenuFillTypes.AccountCreationUsername`, excluding password/TOTP) it sends a new `updateAutofillInlineMenuFilter` message and keeps the menu open. All other field types use the existing close path bit-for-bit.
- `overlay.background.ts`: new `inlineMenuFilter` field, new `updateAutofillInlineMenuFilter` extension-message handler, and filter application via the existing `SearchService.searchCiphersBasic` before cipher projection. The filtered set flows through the existing `updateAutofillInlineMenuListCiphers` port message (no new ports).
- `autofill-inline-menu-list.ts`: accepts an optional `filter` and, when the resulting cipher list is empty, renders a localized "No matches for $FILTER$" empty state. The filter value is inserted as a text node so it cannot be interpreted as HTML.
- New i18n key `inlineMenuNoMatches` in `_locales/en/messages.json`.
- `main.background.ts`: passes `SearchService` to `OverlayBackground` (already initialized earlier in the DI graph).

No new permissions, no manifest changes, no new ports, no new event listeners. The implementation reuses existing plumbing that already works on Chrome, Firefox, and Safari. Ten new unit tests were added covering filter apply, reset on close/focus-change/vault refresh, non-searchable short-circuit, dedup, length cap, the iframe empty state, an XSS guard on the filter text-node insertion, and regression guards confirming password/card/identity still close on type. All 1766 autofill tests pass.

## 📸 Screenshots

<!-- UI change is text-driven (menu narrows live as the user types). Happy to attach a GIF if helpful. -->

---

## Consolidation with PR #20543

After this PR was opened, we discovered that PR #20543 (`Add filter-as-you-type to autofill inline menu`, Gamerhund, opened 2026-05-07) already addresses the same feature and has been forwarded to internal teams by `audreyality`. To minimize churn and align with the prior art that is already in front of reviewers, this PR has been updated to:

**Adopted from #20543 (their wire-protocol naming):**
- Message command: `filterInlineMenuCiphers` (was `updateAutofillInlineMenuFilter`)
- Wire payload field: `filterValue` (was `filter`)

**Retained from this PR (engineering differentials worth keeping):**
- **`SearchService.searchCiphersBasic` reuse** instead of duplicating an inline lowercase-substring match. Picks up URI and notes matching for free and centralizes search logic.
- **Field-type guard** in `triggerFormFieldInput`: only login text fields (`CipherType.Login`, `InlineMenuFillTypes.AccountCreationUsername`, excluding password/TOTP) stream the filter. Password keystrokes never traverse the message bus. Card and identity fields keep their existing click-to-fill behavior.
- **PII handling**: filter value is length-capped, never logged, and explicitly documented as PII.
- **Explicit reset hooks**: filter resets on inline-menu close, focus-change to a different field, and full vault refresh.
- **Localized "No matches" empty state** in the iframe (new i18n key `inlineMenuNoMatches`), rendered with text nodes for XSS safety. Preferred over silently closing the menu on zero matches because it tells the user their query simply didn't match — backspacing restores the list without the menu disappearing and re-appearing.
- **Regression-guard tests**: explicit assertions that password / card / identity fields still close-on-type.

**Deliberately not adopted from #20543:**
- *Auto-reopen on filter when the menu is closed.* We treat an explicit close (Escape, blur, etc.) as user intent and do not re-open the menu just because the user typed another character. This may be revisited based on review feedback.
- *Close-on-zero-matches.* The localized empty state is the alternative chosen here.

If the team prefers #20543 as the basis, the wire-protocol naming now matches verbatim, so cherry-picking the differentials above is a small diff.