### PR TITLE
[PM-37932] Recover browser IPC after process reload

### DIFF
--- a/apps/browser/src/platform/ipc/content/ipc-content-script.ts
+++ b/apps/browser/src/platform/ipc/content/ipc-content-script.ts
@@ -1,10 +1,9 @@
-// TODO: This content script should be dynamically reloaded when the extension is updated,
-// to avoid "Extension context invalidated." errors.
-
 import { isIpcMessage } from "@bitwarden/common/platform/ipc/ipc-message";
 
+const IPC_CONTENT_SCRIPT_PORT_NAME = "ipc-content-script-port";
+
 // Web -> Background
-export function sendExtensionMessage(message: unknown) {
+function sendExtensionMessage(message: unknown) {
   if (
     typeof browser !== "undefined" &&
     typeof browser.runtime !== "undefined" &&
@@ -17,7 +16,7 @@ export function sendExtensionMessage(message: unknown) {
   void chrome.runtime.sendMessage(message);
 }
 
-window.addEventListener("message", (event) => {
+function handleWindowMessage(event: MessageEvent) {
   if (event.origin !== window.origin) {
     return;
   }
@@ -25,27 +24,61 @@ window.addEventListener("message", (event) => {
   if (isIpcMessage(event.data)) {
     sendExtensionMessage(event.data);
   }
-});
+}
 
 // Background -> Web
-function setupMessageListener() {
-  function listener(message: unknown) {
-    if (isIpcMessage(message)) {
-      void window.postMessage(message);
-    }
+function handleRuntimeMessage(message: unknown) {
+  if (isIpcMessage(message)) {
+    void window.postMessage(message);
   }
+}
 
+function addRuntimeMessageListener() {
   if (
     typeof browser !== "undefined" &&
     typeof browser.runtime !== "undefined" &&
     typeof browser.runtime.onMessage !== "undefined"
   ) {
-    browser.runtime.onMessage.addListener(listener);
+    browser.runtime.onMessage.addListener(handleRuntimeMessage);
     return;
   }
 
   // eslint-disable-next-line no-restricted-syntax -- This doesn't run in the popup but in the content script
-  chrome.runtime.onMessage.addListener(listener);
+  chrome.runtime.onMessage.addListener(handleRuntimeMessage);
 }
 
-setupMessageListener();
+function removeRuntimeMessageListener() {
+  if (
+    typeof browser !== "undefined" &&
+    typeof browser.runtime !== "undefined" &&
+    typeof browser.runtime.onMessage !== "undefined"
+  ) {
+    browser.runtime.onMessage.removeListener(handleRuntimeMessage);
+    return;
+  }
+
+  chrome.runtime.onMessage.removeListener(handleRuntimeMessage);
+}
+
+/**
+ * Opens a long-lived port whose only purpose is to surface extension-context
+ * teardown via `onDisconnect`. When the extension is reloaded (e.g. via
+ * `chrome.runtime.reload()` on process reload), this fires while the runtime
+ * is still functional, letting us detach our listeners before a freshly
+ * re-injected content script registers its own.
+ */
+function setupExtensionDisconnectAction(callback: (port: chrome.runtime.Port) => void) {
+  const port = chrome.runtime.connect({ name: IPC_CONTENT_SCRIPT_PORT_NAME });
+  const onDisconnect = (disconnectedPort: chrome.runtime.Port) => {
+    callback(disconnectedPort);
+    port.onDisconnect.removeListener(onDisconnect);
+  };
+  port.onDisconnect.addListener(onDisconnect);
+}
+
+window.addEventListener("message", handleWindowMessage);
+addRuntimeMessageListener();
+setupExtensionDisconnectAction(() => {
+  window.removeEventListener("message", handleWindowMessage);
+  removeRuntimeMessageListener();
+});

--- a/apps/browser/src/platform/ipc/ipc-content-script-manager.service.ts
+++ b/apps/browser/src/platform/ipc/ipc-content-script-manager.service.ts
@@ -6,6 +6,8 @@ import { ConfigService } from "@bitwarden/common/platform/abstractions/config/co
 import { BrowserApi } from "../browser/browser-api";
 
 const IPC_CONTENT_SCRIPT_ID = "ipc-content-script";
+const IPC_CONTENT_SCRIPT_FILE = "content/ipc-content-script.js";
+const IPC_CONTENT_SCRIPT_MATCHES = ["https://*/*"];
 
 export class IpcContentScriptManagerService {
   constructor(configService: ConfigService) {
@@ -31,12 +33,39 @@ export class IpcContentScriptManagerService {
           await BrowserApi.registerContentScriptsMv3([
             {
               id: IPC_CONTENT_SCRIPT_ID,
-              matches: ["https://*/*"],
-              js: ["content/ipc-content-script.js"],
+              matches: IPC_CONTENT_SCRIPT_MATCHES,
+              js: [IPC_CONTENT_SCRIPT_FILE],
             },
           ]);
+
+          // Registration only injects on future page loads. Tabs already open
+          // when the (re)started service worker runs this code still hold a
+          // content-script instance bound to the previous extension context
+          // (its chrome.runtime is invalidated after `chrome.runtime.reload()`
+          // on process reload). Re-inject so they get a fresh runtime handle;
+          // the old instance tears itself down via its port's onDisconnect.
+          await this.reinjectIntoOpenTabs();
         }),
       )
       .subscribe();
+  }
+
+  private async reinjectIntoOpenTabs() {
+    const tabs = await BrowserApi.tabsQuery({ url: IPC_CONTENT_SCRIPT_MATCHES });
+    for (const tab of tabs) {
+      if (tab.id === undefined) {
+        continue;
+      }
+
+      try {
+        await BrowserApi.executeScriptInTab(tab.id, {
+          file: IPC_CONTENT_SCRIPT_FILE,
+          runAt: "document_start",
+        });
+      } catch {
+        // Per-tab failures (closed tab, restricted URL, etc.) shouldn't abort
+        // the rest of the re-injection pass.
+      }
+    }
   }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-37932

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Re-inject the IPC content script into already-open tabs when the service worker starts up. After a process reload (`chrome.runtime.reload()`), tabs opened before the reload retain a content script bound to the previous extension context, leaving the IPC bridge dead until a full page reload. The old instance now tears itself down via a long-lived port's onDisconnect so the freshly injected script can register its listeners without duplicating handlers.

