### PR TITLE
[PM-38102] Scale Firefox popup down by 20% on HiDPI displays

### DIFF
--- a/apps/browser/src/platform/popup/layout/popup-size.service.ts
+++ b/apps/browser/src/platform/popup/layout/popup-size.service.ts
@@ -81,7 +81,8 @@ export class PopupSizeService {
 
   private static async setStyle(width: PopupWidthOption) {
     const isInTab = await BrowserPopupUtils.isInTab();
-    const pxWidth = PopupWidthOptions[width] ?? PopupWidthOptions.default;
+    const basePxWidth = PopupWidthOptions[width] ?? PopupWidthOptions.default;
+    const pxWidth = PopupSizeService.scalePxWidth(basePxWidth);
 
     if (BrowserPopupUtils.inPopout(window)) {
       const currentWindow = await BrowserApi.getCurrentWindow();
@@ -96,6 +97,26 @@ export class PopupSizeService {
     }
 
     document.body.style.width = `${pxWidth}px`;
+  }
+
+  /**
+   * Firefox renders the extension popup larger than Chrome, especially on
+   * macOS displays scaled to "More Space". We shrink the popup by 20% on
+   * Firefox to keep parity. The popup's root font-size is scaled by the
+   * corresponding amount in `tailwind.css` under `html.browser_firefox`.
+   */
+  private static readonly FirefoxScale = 0.8;
+
+  private static scalePxWidth(pxWidth: number): number {
+    if (PopupSizeService.isFirefox()) {
+      return Math.round(pxWidth * PopupSizeService.FirefoxScale);
+    }
+    return pxWidth;
+  }
+
+  private static isFirefox(): boolean {
+    const ua = globalThis.navigator?.userAgent ?? "";
+    return ua.indexOf(" Firefox/") !== -1 || ua.indexOf(" Gecko/") !== -1;
   }
 
   /**

--- a/apps/browser/src/platform/popup/layout/popup-size.service.ts
+++ b/apps/browser/src/platform/popup/layout/popup-size.service.ts
@@ -100,23 +100,27 @@ export class PopupSizeService {
   }
 
   /**
-   * Firefox renders the extension popup larger than Chrome, especially on
-   * macOS displays scaled to "More Space". We shrink the popup by 20% on
-   * Firefox to keep parity. The popup's root font-size is scaled by the
-   * corresponding amount in `tailwind.css` under `html.browser_firefox`.
+   * Firefox renders the extension popup larger than Chrome on HiDPI displays
+   * (e.g. macOS "More Space" scaling, Windows 1440p+ at 100% scale). We
+   * shrink the popup by 20% on Firefox in that case to keep parity. The
+   * popup's root font-size is scaled by the corresponding amount in
+   * `tailwind.css` under `html.browser_firefox_hidpi`. Standard-DPI Firefox
+   * users (devicePixelRatio === 1) are not affected.
    */
   private static readonly FirefoxScale = 0.8;
 
   private static scalePxWidth(pxWidth: number): number {
-    if (PopupSizeService.isFirefox()) {
+    if (PopupSizeService.isFirefoxHiDpi()) {
       return Math.round(pxWidth * PopupSizeService.FirefoxScale);
     }
     return pxWidth;
   }
 
-  private static isFirefox(): boolean {
+  private static isFirefoxHiDpi(): boolean {
     const ua = globalThis.navigator?.userAgent ?? "";
-    return ua.indexOf(" Firefox/") !== -1 || ua.indexOf(" Gecko/") !== -1;
+    const isFirefox = ua.indexOf(" Firefox/") !== -1 || ua.indexOf(" Gecko/") !== -1;
+    const dpr = globalThis.devicePixelRatio ?? 1;
+    return isFirefox && dpr > 1;
   }
 
   /**

--- a/apps/browser/src/popup/scss/tailwind.css
+++ b/apps/browser/src/popup/scss/tailwind.css
@@ -34,14 +34,15 @@
   }
 
   /**
-   * Firefox renders the extension popup larger than Chrome — most noticeably
-   * on macOS displays scaled to "More Space" — because page zoom does not
-   * apply to extension popups and Firefox resolves CSS pixels differently
-   * against the backing scale factor. Shrinking the root font-size by 20%
-   * uniformly scales every rem-based dimension throughout the popup.
-   * Width is scaled separately in PopupSizeService.
+   * Firefox renders the extension popup larger than Chrome on HiDPI displays
+   * (e.g. macOS "More Space" scaling, Windows 1440p+ at 100% scale) because
+   * page zoom does not apply to extension popups and Firefox resolves CSS
+   * pixels differently against the backing scale factor. Shrinking the root
+   * font-size by 20% uniformly scales every rem-based dimension throughout
+   * the popup. Width is scaled separately in PopupSizeService. Gated on
+   * `devicePixelRatio > 1` so standard-DPI Firefox users are not affected.
    */
-  html.browser_firefox {
+  html.browser_firefox_hidpi {
     font-size: 12.8px;
     min-height: 480px;
 

--- a/apps/browser/src/popup/scss/tailwind.css
+++ b/apps/browser/src/popup/scss/tailwind.css
@@ -33,6 +33,39 @@
     }
   }
 
+  /**
+   * Firefox renders the extension popup larger than Chrome — most noticeably
+   * on macOS displays scaled to "More Space" — because page zoom does not
+   * apply to extension popups and Firefox resolves CSS pixels differently
+   * against the backing scale factor. Shrinking the root font-size by 20%
+   * uniformly scales every rem-based dimension throughout the popup.
+   * Width is scaled separately in PopupSizeService.
+   */
+  html.browser_firefox {
+    font-size: 12.8px;
+    min-height: 480px;
+
+    &.body-sm {
+      min-height: 400px;
+    }
+
+    &.body-xs {
+      min-height: 320px;
+    }
+
+    &.body-xxs {
+      min-height: 240px;
+    }
+
+    &.body-3xs {
+      min-height: 192px;
+    }
+
+    &.body-full {
+      min-height: unset;
+    }
+  }
+
   html.browser_safari {
     &.safari_height_fix {
       body {

--- a/apps/browser/src/popup/services/init.service.ts
+++ b/apps/browser/src/popup/services/init.service.ts
@@ -43,6 +43,10 @@ export class InitService {
       this.themingService.applyThemeChangesTo(this.document);
       htmlEl.classList.add("locale_" + this.i18nService.translationLocale);
 
+      if (this.platformUtilsService.isFirefox()) {
+        htmlEl.classList.add("browser_firefox");
+      }
+
       // Workaround for slow performance on external monitors on Chrome + MacOS
       // See: https://bugs.chromium.org/p/chromium/issues/detail?id=971701#c64
       if (

--- a/apps/browser/src/popup/services/init.service.ts
+++ b/apps/browser/src/popup/services/init.service.ts
@@ -43,8 +43,8 @@ export class InitService {
       this.themingService.applyThemeChangesTo(this.document);
       htmlEl.classList.add("locale_" + this.i18nService.translationLocale);
 
-      if (this.platformUtilsService.isFirefox()) {
-        htmlEl.classList.add("browser_firefox");
+      if (this.platformUtilsService.isFirefox() && window.devicePixelRatio > 1) {
+        htmlEl.classList.add("browser_firefox_hidpi");
       }
 
       // Workaround for slow performance on external monitors on Chrome + MacOS


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-38102

Reproduced on:

- macOS with the display set to a scaled "More Space" resolution.
- Windows 11 on a 1440p monitor (Firefox vs Chrome side-by-side).

## 📔 Objective

Firefox renders the extension popup at a different effective scale than Chrome on HiDPI displays. Page zoom does not apply to extension popups, so users cannot work around it themselves. The mismatch is not present on standard-DPI displays.

This PR shrinks the popup by 20% on **Firefox + HiDPI only** to bring it closer to Chrome:

- Adds a `browser_firefox_hidpi` class to `<html>` at popup init time when `isFirefox() && window.devicePixelRatio > 1` (mirrors the existing `browser_safari` class pattern).
- Reduces the root `font-size` from `16px` to `12.8px` under `html.browser_firefox_hidpi`, uniformly scaling every `rem`-based dimension throughout the popup.
- Scales the JS-set popup body width by `0.8` in `PopupSizeService` under the same HiDPI gate (covers both the popup and popout paths, and `initBodyWidthFromLocalStorage` to avoid bootstrap flicker).
- Scales the popup `min-height` breakpoints (`body-sm`/`-xs`/`-xxs`/`-3xs`) by `0.8` to match.

Chrome, Safari, and standard-DPI Firefox behavior is unchanged. Autofill in-page overlays / inline menus are out of scope (they live in content scripts, not the popup).

### Why HiDPI-gated rather than all Firefox?

A first pass applied the shrink to every Firefox user, but that would regress standard-DPI installs (1080p laptops, older monitors) where Chrome and Firefox already render at parity. `devicePixelRatio > 1` is the cleanest signal that targets exactly the affected machines.

### Why not `zoom` or `transform: scale`?

CSS `zoom` is now supported in Firefox 126+ and would be a one-liner, but both `zoom` and `transform: scale` interact poorly with CDK overlays (tooltips, dialogs, autofill suggestions) due to coordinate-space differences. Scaling via root `font-size` + explicit width is more predictable and avoids hit-test issues.

### Open questions

- Is `0.8` the right factor? It was tuned visually against a Chrome reference on macOS scaled + Windows 1440p. Open to a different value or a per-display-ratio formula.
- Should this be exposed as a user setting instead of (or in addition to) the automatic gate?

## 📸 Screenshots

UI change — please attach before/after popup screenshots before merging:

- [ ] Firefox popup on HiDPI macOS — before (current main) 
<img width="608" height="266" alt="Screenshot 2026-05-25 at 9 42 26 AM" src="https://github.com/user-attachments/assets/a1ccc325-36b2-4be3-b7ba-554330540066" />

- [ ] Firefox popup on HiDPI macOS — after (this branch) 
<img width="496" height="180" alt="Screenshot 2026-05-25 at 9 40 59 AM" src="https://github.com/user-attachments/assets/7cbb0e3e-44df-4594-a25a-72dd98db5022" />

- [ ] Chrome popup — for parity reference
<img width="408" height="181" alt="Screenshot 2026-05-25 at 9 41 18 AM" src="https://github.com/user-attachments/assets/389a6f2b-a690-4d23-8f20-c6f0aa872d46" />