### PR TITLE
[PM-12039] Remove usage of ActiveUserState from key-connector.service

### DIFF
--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -934,7 +934,6 @@ export default class MainBackground {
     );
 
     this.keyConnectorService = new KeyConnectorService(
-      this.accountService,
       this.masterPasswordService,
       this.keyService,
       this.apiService,

--- a/apps/cli/src/key-management/commands/unlock.command.spec.ts
+++ b/apps/cli/src/key-management/commands/unlock.command.spec.ts
@@ -74,7 +74,7 @@ describe("UnlockCommand", () => {
 
     i18nService.t.mockImplementation((key: string) => key);
     accountService.activeAccount$ = of(activeAccount);
-    keyConnectorService.convertAccountRequired$ = of(false);
+    keyConnectorService.convertAccountRequired$.mockReturnValue(of(false));
     cryptoFunctionService.randomBytes.mockResolvedValue(mockSessionKey);
     configService.getFeatureFlag.mockResolvedValue(false);
 
@@ -161,7 +161,7 @@ describe("UnlockCommand", () => {
     describe("calls convertToKeyConnectorCommand if required", () => {
       let convertToKeyConnectorSpy: jest.SpyInstance;
       beforeEach(() => {
-        keyConnectorService.convertAccountRequired$ = of(true);
+        keyConnectorService.convertAccountRequired$.mockReturnValue(of(true));
         masterPasswordUnlockService.unlockWithMasterPassword.mockResolvedValue(mockUserKey);
       });
 

--- a/apps/cli/src/key-management/commands/unlock.command.ts
+++ b/apps/cli/src/key-management/commands/unlock.command.ts
@@ -71,7 +71,7 @@ export class UnlockCommand {
       return Response.error(e.message);
     }
 
-    if (await firstValueFrom(this.keyConnectorService.convertAccountRequired$)) {
+    if (await firstValueFrom(this.keyConnectorService.convertAccountRequired$(userId))) {
       const convertToKeyConnectorCommand = new ConvertToKeyConnectorCommand(
         userId,
         this.keyConnectorService,

--- a/apps/cli/src/service-container/service-container.ts
+++ b/apps/cli/src/service-container/service-container.ts
@@ -730,7 +730,6 @@ export class ServiceContainer {
     );
 
     this.keyConnectorService = new KeyConnectorService(
-      this.accountService,
       this.masterPasswordService,
       this.keyService,
       this.apiService,

--- a/libs/angular/src/auth/guards/auth.guard.spec.ts
+++ b/libs/angular/src/auth/guards/auth.guard.spec.ts
@@ -30,7 +30,9 @@ describe("AuthGuard", () => {
     authService.getAuthStatus.mockResolvedValue(authStatus);
     const messagingService: MockProxy<MessagingService> = mock<MessagingService>();
     const keyConnectorService: MockProxy<KeyConnectorService> = mock<KeyConnectorService>();
-    keyConnectorService.convertAccountRequired$ = of(keyConnectorServiceRequiresAccountConversion);
+    keyConnectorService.convertAccountRequired$.mockReturnValue(
+      of(keyConnectorServiceRequiresAccountConversion),
+    );
     const configService: MockProxy<ConfigService> = mock<ConfigService>();
     const accountService: MockProxy<AccountService> = mock<AccountService>();
     const activeAccountSubject = new BehaviorSubject<Account | null>(null);

--- a/libs/angular/src/auth/guards/auth.guard.ts
+++ b/libs/angular/src/auth/guards/auth.guard.ts
@@ -103,7 +103,7 @@ export const authGuard: CanActivateFn = async (
   if (
     forceSetPasswordReason == ForceSetPasswordReason.None &&
     !routerState.url.includes("remove-password") &&
-    (await firstValueFrom(keyConnectorService.convertAccountRequired$))
+    (await firstValueFrom(keyConnectorService.convertAccountRequired$(userId)))
   ) {
     return router.createUrlTree(["/remove-password"]);
   }

--- a/libs/angular/src/services/jslib-services.module.ts
+++ b/libs/angular/src/services/jslib-services.module.ts
@@ -1257,7 +1257,6 @@ const safeProviders: SafeProvider[] = [
     provide: KeyConnectorServiceAbstraction,
     useClass: KeyConnectorService,
     deps: [
-      AccountServiceAbstraction,
       InternalMasterPasswordServiceAbstraction,
       KeyService,
       ApiServiceAbstraction,

--- a/libs/common/src/key-management/key-connector/abstractions/key-connector.service.ts
+++ b/libs/common/src/key-management/key-connector/abstractions/key-connector.service.ts
@@ -28,5 +28,5 @@ export abstract class KeyConnectorService {
     userId: UserId,
   ): Observable<KeyConnectorDomainConfirmation | null>;
 
-  abstract convertAccountRequired$: Observable<boolean>;
+  abstract convertAccountRequired$(userId: UserId): Observable<boolean>;
 }

--- a/libs/common/src/key-management/key-connector/services/key-connector.service.spec.ts
+++ b/libs/common/src/key-management/key-connector/services/key-connector.service.spec.ts
@@ -670,7 +670,7 @@ describe("KeyConnectorService", () => {
           const expectedKdfConfig =
             kdfType == KdfType.PBKDF2_SHA256
               ? new PBKDF2KdfConfig(kdfIterations)
-              : new Argon2KdfConfig(kdfIterations, kdfMemory, kdfParallelism);
+              : new Argon2KdfConfig(kdfIterations, kdfMemory!, kdfParallelism!);
 
           const conversion: NewSsoUserKeyConnectorConversion = {
             kdfConfig: expectedKdfConfig,

--- a/libs/common/src/key-management/key-connector/services/key-connector.service.spec.ts
+++ b/libs/common/src/key-management/key-connector/services/key-connector.service.spec.ts
@@ -90,7 +90,6 @@ describe("KeyConnectorService", () => {
     stateProvider = new FakeStateProvider(accountService);
 
     keyConnectorService = new KeyConnectorService(
-      accountService,
       masterPasswordService,
       keyService,
       apiService,
@@ -358,7 +357,7 @@ describe("KeyConnectorService", () => {
 
     it("should return true when user logged in with sso, belong to organization using key connector and user does not use key connector", async () => {
       await expect(
-        firstValueFrom(keyConnectorService.convertAccountRequired$.pipe(timeout(100))),
+        firstValueFrom(keyConnectorService.convertAccountRequired$(mockUserId).pipe(timeout(100))),
       ).resolves.toEqual(true);
     });
 
@@ -366,7 +365,7 @@ describe("KeyConnectorService", () => {
       tokenService.getIsExternal.mockResolvedValue(false);
 
       await expect(
-        firstValueFrom(keyConnectorService.convertAccountRequired$.pipe(timeout(100))),
+        firstValueFrom(keyConnectorService.convertAccountRequired$(mockUserId).pipe(timeout(100))),
       ).resolves.toEqual(false);
     });
 
@@ -381,7 +380,7 @@ describe("KeyConnectorService", () => {
       organizationService.organizations$.mockReturnValue(of([organization]));
 
       await expect(
-        firstValueFrom(keyConnectorService.convertAccountRequired$.pipe(timeout(100))),
+        firstValueFrom(keyConnectorService.convertAccountRequired$(mockUserId).pipe(timeout(100))),
       ).resolves.toEqual(false);
     });
 
@@ -396,7 +395,7 @@ describe("KeyConnectorService", () => {
       organizationService.organizations$.mockReturnValue(of([organization]));
 
       await expect(
-        firstValueFrom(keyConnectorService.convertAccountRequired$.pipe(timeout(100))),
+        firstValueFrom(keyConnectorService.convertAccountRequired$(mockUserId).pipe(timeout(100))),
       ).resolves.toEqual(false);
     });
 
@@ -411,7 +410,7 @@ describe("KeyConnectorService", () => {
       organizationService.organizations$.mockReturnValue(of([organization]));
 
       await expect(
-        firstValueFrom(keyConnectorService.convertAccountRequired$.pipe(timeout(100))),
+        firstValueFrom(keyConnectorService.convertAccountRequired$(mockUserId).pipe(timeout(100))),
       ).resolves.toEqual(false);
     });
 
@@ -426,7 +425,7 @@ describe("KeyConnectorService", () => {
       organizationService.organizations$.mockReturnValue(of([organization]));
 
       await expect(
-        firstValueFrom(keyConnectorService.convertAccountRequired$.pipe(timeout(100))),
+        firstValueFrom(keyConnectorService.convertAccountRequired$(mockUserId).pipe(timeout(100))),
       ).resolves.toEqual(false);
     });
 
@@ -434,23 +433,15 @@ describe("KeyConnectorService", () => {
       await stateProvider.getUser(mockUserId, USES_KEY_CONNECTOR).update(() => true);
 
       await expect(
-        firstValueFrom(keyConnectorService.convertAccountRequired$.pipe(timeout(100))),
+        firstValueFrom(keyConnectorService.convertAccountRequired$(mockUserId).pipe(timeout(100))),
       ).resolves.toEqual(false);
-    });
-
-    it("should not return any value when user not logged in", async () => {
-      await accountService.switchAccount(null as unknown as UserId);
-
-      await expect(
-        firstValueFrom(keyConnectorService.convertAccountRequired$.pipe(timeout(100))),
-      ).rejects.toBeInstanceOf(TimeoutError);
     });
 
     it("should not return any value when organization state is empty", async () => {
       organizationService.organizations$.mockReturnValue(of(null as unknown as Organization[]));
 
       await expect(
-        firstValueFrom(keyConnectorService.convertAccountRequired$.pipe(timeout(100))),
+        firstValueFrom(keyConnectorService.convertAccountRequired$(mockUserId).pipe(timeout(100))),
       ).rejects.toBeInstanceOf(TimeoutError);
     });
 
@@ -458,7 +449,7 @@ describe("KeyConnectorService", () => {
       await stateProvider.getUser(mockUserId, USES_KEY_CONNECTOR).update(() => null);
 
       await expect(
-        firstValueFrom(keyConnectorService.convertAccountRequired$.pipe(timeout(100))),
+        firstValueFrom(keyConnectorService.convertAccountRequired$(mockUserId).pipe(timeout(100))),
       ).rejects.toBeInstanceOf(TimeoutError);
     });
 
@@ -466,7 +457,7 @@ describe("KeyConnectorService", () => {
       tokenService.hasAccessToken$.mockReturnValue(of(false));
 
       await expect(
-        firstValueFrom(keyConnectorService.convertAccountRequired$.pipe(timeout(100))),
+        firstValueFrom(keyConnectorService.convertAccountRequired$(mockUserId).pipe(timeout(100))),
       ).rejects.toBeInstanceOf(TimeoutError);
     });
   });

--- a/libs/common/src/key-management/key-connector/services/key-connector.service.ts
+++ b/libs/common/src/key-management/key-connector/services/key-connector.service.ts
@@ -1,6 +1,6 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
-import { combineLatest, filter, firstValueFrom, map, Observable, of, switchMap } from "rxjs";
+import { combineLatest, filter, firstValueFrom, map, Observable, switchMap } from "rxjs";
 
 // This import has been flagged as unallowed for this class. It may be involved in a circular dependency loop.
 // eslint-disable-next-line no-restricted-imports
@@ -8,7 +8,6 @@ import {
   InternalUserDecryptionOptionsServiceAbstraction,
   LogoutReason,
 } from "@bitwarden/auth/common";
-import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { NewSsoUserKeyConnectorConversion } from "@bitwarden/common/key-management/key-connector/models/new-sso-user-key-connector-conversion";
 import { SdkService } from "@bitwarden/common/platform/abstractions/sdk/sdk.service";
 // This import has been flagged as unallowed for this class. It may be involved in a circular dependency loop.
@@ -77,10 +76,7 @@ export const NEW_SSO_USER_KEY_CONNECTOR_CONVERSION =
   );
 
 export class KeyConnectorService implements KeyConnectorServiceAbstraction {
-  readonly convertAccountRequired$: Observable<boolean>;
-
   constructor(
-    accountService: AccountService,
     private masterPasswordService: InternalMasterPasswordServiceAbstraction,
     private keyService: KeyService,
     private apiService: ApiService,
@@ -95,22 +91,19 @@ export class KeyConnectorService implements KeyConnectorServiceAbstraction {
     private accountCryptographicStateService: AccountCryptographicStateService,
     private sdkService: SdkService,
     private userDecryptionOptionsService: InternalUserDecryptionOptionsServiceAbstraction,
-  ) {
-    this.convertAccountRequired$ = accountService.activeAccount$.pipe(
-      filter((account) => account != null),
-      switchMap((account) =>
-        combineLatest([
-          of(account.id),
-          this.organizationService
-            .organizations$(account.id)
-            .pipe(filter((organizations) => organizations != null)),
-          this.stateProvider
-            .getUserState$(USES_KEY_CONNECTOR, account.id)
-            .pipe(filter((usesKeyConnector) => usesKeyConnector != null)),
-          tokenService.hasAccessToken$(account.id).pipe(filter((hasToken) => hasToken)),
-        ]),
-      ),
-      switchMap(async ([userId, organizations, usesKeyConnector]) => {
+  ) {}
+
+  convertAccountRequired$(userId: UserId): Observable<boolean> {
+    return combineLatest([
+      this.organizationService
+        .organizations$(userId)
+        .pipe(filter((organizations) => organizations != null)),
+      this.stateProvider
+        .getUserState$(USES_KEY_CONNECTOR, userId)
+        .pipe(filter((usesKeyConnector) => usesKeyConnector != null)),
+      this.tokenService.hasAccessToken$(userId).pipe(filter((hasToken) => hasToken)),
+    ]).pipe(
+      switchMap(async ([organizations, usesKeyConnector]) => {
         const loggedInUsingSso = await this.tokenService.getIsExternal(userId);
         const requiredByOrganization = this.findManagingOrganization(organizations) != null;
         const userIsNotUsingKeyConnector = !usesKeyConnector;

--- a/libs/common/src/key-management/key-connector/services/key-connector.service.ts
+++ b/libs/common/src/key-management/key-connector/services/key-connector.service.ts
@@ -8,6 +8,7 @@ import {
   InternalUserDecryptionOptionsServiceAbstraction,
   LogoutReason,
 } from "@bitwarden/auth/common";
+import { assertNonNullish } from "@bitwarden/common/auth/utils";
 import { NewSsoUserKeyConnectorConversion } from "@bitwarden/common/key-management/key-connector/models/new-sso-user-key-connector-conversion";
 import { SdkService } from "@bitwarden/common/platform/abstractions/sdk/sdk.service";
 // This import has been flagged as unallowed for this class. It may be involved in a circular dependency loop.
@@ -94,6 +95,7 @@ export class KeyConnectorService implements KeyConnectorServiceAbstraction {
   ) {}
 
   convertAccountRequired$(userId: UserId): Observable<boolean> {
+    assertNonNullish(userId, "userId");
     return combineLatest([
       this.organizationService
         .organizations$(userId)

--- a/libs/common/src/platform/sync/default-sync.service.spec.ts
+++ b/libs/common/src/platform/sync/default-sync.service.spec.ts
@@ -99,7 +99,7 @@ describe("DefaultSyncService", () => {
     sendService = mock();
     logService = mock();
     keyConnectorService = mock();
-    keyConnectorService.convertAccountRequired$ = of(false);
+    keyConnectorService.convertAccountRequired$.mockReturnValue(of(false));
     providerService = mock();
     folderApiService = mock();
     organizationService = mock();
@@ -481,7 +481,7 @@ describe("DefaultSyncService", () => {
 
       it("uses the current time when a sync is forced", async () => {
         // Mock the value of this observable because it's used in `syncProfile`. Without it, the test breaks.
-        keyConnectorService.convertAccountRequired$ = of(false);
+        keyConnectorService.convertAccountRequired$.mockReturnValue(of(false));
 
         jest.useFakeTimers({ now: Date.now() });
 

--- a/libs/common/src/platform/sync/default-sync.service.ts
+++ b/libs/common/src/platform/sync/default-sync.service.ts
@@ -296,7 +296,7 @@ export class DefaultSyncService extends CoreSyncService {
 
     await this.syncProfileOrganizations(response, response.id);
 
-    if (await firstValueFrom(this.keyConnectorService.convertAccountRequired$)) {
+    if (await firstValueFrom(this.keyConnectorService.convertAccountRequired$(response.id))) {
       this.messageSender.send("convertAccountToKeyConnector");
     }
   }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-12039

## 📔 Objective

Platform is deprecating ActiveUserState. Modifies `key-connector.service.ts` to accept a single userId that is locked in (for services that update data)

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
