### PR TITLE
[PM-12043] Remove usage of ActiveUserState from biometric-state.service

### DIFF
--- a/apps/browser/src/auth/popup/settings/account-security.component.spec.ts
+++ b/apps/browser/src/auth/popup/settings/account-security.component.spec.ts
@@ -161,7 +161,7 @@ describe("AccountSecurityComponent", () => {
       }),
     );
     vaultNudgesService.showNudgeSpotlight$.mockReturnValue(of(false));
-    biometricStateService.promptAutomatically$ = of(false);
+    biometricStateService.promptAutomatically$.mockReturnValue(of(false));
     pinServiceAbstraction.isPinSet.mockResolvedValue(false);
     configService.getFeatureFlag$.mockReturnValue(of(false));
     billingService.hasPremiumPersonally$.mockReturnValue(of(true));
@@ -387,7 +387,10 @@ describe("AccountSecurityComponent", () => {
         await component.ngOnInit();
         await component.updateBiometric(false);
 
-        expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenCalledWith(false);
+        expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenCalledWith(
+          false,
+          mockUserId,
+        );
         expect(biometricStateService.setFingerprintValidated).toHaveBeenCalledWith(false);
       });
     });
@@ -409,6 +412,7 @@ describe("AccountSecurityComponent", () => {
         expect(keyService.refreshAdditionalKeys).toHaveBeenCalledWith(mockUserId);
         expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenCalledWith(
           setupBiometricsResult,
+          mockUserId,
         );
         expect(component.form.controls.biometric.value).toBe(setupBiometricsResult);
       });
@@ -422,6 +426,7 @@ describe("AccountSecurityComponent", () => {
 
         expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenCalledWith(
           setupBiometricsResult,
+          mockUserId,
         );
         expect(biometricStateService.setFingerprintValidated).toHaveBeenCalledWith(
           setupBiometricsResult,

--- a/apps/browser/src/auth/popup/settings/account-security.component.ts
+++ b/apps/browser/src/auth/popup/settings/account-security.component.ts
@@ -210,7 +210,7 @@ export class AccountSecurityComponent implements OnInit, OnDestroy {
         (await this.pinService.getPinLockType(activeAccount.id)) == "AfterFirstUnlock",
       biometric: await this.vaultTimeoutSettingsService.isBiometricLockSet(activeAccount.id),
       enableAutoBiometricsPrompt: await firstValueFrom(
-        this.biometricStateService.promptAutomatically$,
+        this.biometricStateService.promptAutomatically$(activeAccount.id),
       ),
       enablePhishingDetection: await firstValueFrom(this.phishingDetectionSettingsService.enabled$),
       allowSharingUnlockState: await firstValueFrom(
@@ -305,7 +305,7 @@ export class AccountSecurityComponent implements OnInit, OnDestroy {
     this.form.controls.enableAutoBiometricsPrompt.valueChanges
       .pipe(
         concatMap(async (enabled) => {
-          await this.biometricStateService.setPromptAutomatically(enabled);
+          await this.biometricStateService.setPromptAutomatically(enabled, activeAccount.id);
         }),
         takeUntil(this.destroy$),
       )
@@ -370,14 +370,14 @@ export class AccountSecurityComponent implements OnInit, OnDestroy {
   }
 
   async updateBiometric(enabled: boolean) {
+    const userId = await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId));
     if (enabled) {
       try {
-        const userId = await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId));
         await this.keyService.refreshAdditionalKeys(userId);
 
         const successful = await this.trySetupBiometrics();
         this.form.controls.biometric.setValue(successful);
-        await this.biometricStateService.setBiometricUnlockEnabled(successful);
+        await this.biometricStateService.setBiometricUnlockEnabled(successful, userId);
         if (!successful) {
           await this.biometricStateService.setFingerprintValidated(false);
           return;
@@ -392,7 +392,7 @@ export class AccountSecurityComponent implements OnInit, OnDestroy {
         this.validationService.showError(error);
       }
     } else {
-      await this.biometricStateService.setBiometricUnlockEnabled(false);
+      await this.biometricStateService.setBiometricUnlockEnabled(false, userId);
       await this.biometricStateService.setFingerprintValidated(false);
     }
   }
@@ -495,8 +495,10 @@ export class AccountSecurityComponent implements OnInit, OnDestroy {
   }
 
   async updateAutoBiometricsPrompt() {
+    const userId = await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId));
     await this.biometricStateService.setPromptAutomatically(
       this.form.value.enableAutoBiometricsPrompt,
+      userId,
     );
   }
 

--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -290,7 +290,6 @@ import {
   ImportServiceAbstraction,
 } from "@bitwarden/importer-core";
 import {
-  BiometricsService,
   BiometricStateService,
   DefaultBiometricStateService,
   DefaultKdfConfigService,
@@ -513,7 +512,7 @@ export default class MainBackground {
   vaultSettingsService: VaultSettingsServiceAbstraction;
   pendingAuthRequestStateService: PendingAuthRequestsStateService;
   biometricStateService: BiometricStateService;
-  biometricsService: BiometricsService;
+  biometricsService: BackgroundBrowserBiometricsService;
   stateEventRunnerService: StateEventRunnerService;
   ssoLoginService: SsoLoginServiceAbstraction;
   billingAccountProfileStateService: BillingAccountProfileStateService;
@@ -1815,6 +1814,8 @@ export default class MainBackground {
       if (authStatus === AuthenticationStatus.LoggedOut) {
         const nextUpAccount = await firstValueFrom(this.accountService.nextUpAccount$);
         await this.switchAccount(nextUpAccount?.id);
+      } else {
+        this.biometricsService.startPolling(active.id);
       }
     }
 
@@ -1913,12 +1914,14 @@ export default class MainBackground {
       await switchPromise;
 
       if (userId == null) {
+        this.biometricsService.stopPolling();
         await this.refreshMenu();
         await this.updateOverlayCiphers();
         this.messagingService.send("goHome");
         return;
       }
 
+      this.biometricsService.startPolling(userId);
       nextAccountStatus = await this.authService.getAuthStatus(userId);
 
       await this.systemService.clearPendingClipboard();

--- a/apps/browser/src/key-management/biometrics/background-browser-biometrics.service.spec.ts
+++ b/apps/browser/src/key-management/biometrics/background-browser-biometrics.service.spec.ts
@@ -1,9 +1,11 @@
 import { mock } from "jest-mock-extended";
+import { BehaviorSubject } from "rxjs";
 
 import { VaultTimeoutSettingsService } from "@bitwarden/common/key-management/vault-timeout";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
+import { UserId } from "@bitwarden/common/types/guid";
 import { KeyService, BiometricStateService, BiometricsStatus } from "@bitwarden/key-management";
 
 import { NativeMessagingBackground } from "../../background/nativeMessaging.background";
@@ -13,6 +15,7 @@ import { BackgroundBrowserBiometricsService } from "./background-browser-biometr
 describe("background browser biometrics service tests", function () {
   let service: BackgroundBrowserBiometricsService;
 
+  const userId = "userId" as UserId;
   const nativeMessagingBackground = mock<NativeMessagingBackground>();
   const logService = mock<LogService>();
   const keyService = mock<KeyService>();
@@ -24,6 +27,7 @@ describe("background browser biometrics service tests", function () {
 
   beforeEach(() => {
     jest.resetAllMocks();
+    jest.useFakeTimers();
     service = new BackgroundBrowserBiometricsService(
       () => nativeMessagingBackground,
       () => mockConfigService,
@@ -34,6 +38,67 @@ describe("background browser biometrics service tests", function () {
       vaultTimeoutSettingsService,
       () => null as any,
     );
+  });
+
+  afterEach(() => {
+    service.stopPolling();
+    jest.useRealTimers();
+  });
+
+  describe("startPolling", () => {
+    it("connects to native messaging when biometrics are enabled", () => {
+      const biometricEnabled$ = new BehaviorSubject<boolean>(true);
+      biometricStateService.biometricUnlockEnabled$.mockReturnValue(biometricEnabled$);
+      nativeMessagingBackground.connected = false;
+      nativeMessagingBackground.connect.mockResolvedValue();
+
+      service.startPolling(userId);
+      jest.advanceTimersByTime(0);
+
+      expect(biometricStateService.biometricUnlockEnabled$).toHaveBeenCalledWith(userId);
+      expect(nativeMessagingBackground.connect).toHaveBeenCalled();
+    });
+
+    it("does not connect when biometrics are disabled", () => {
+      const biometricEnabled$ = new BehaviorSubject<boolean>(false);
+      biometricStateService.biometricUnlockEnabled$.mockReturnValue(biometricEnabled$);
+      nativeMessagingBackground.connected = false;
+
+      service.startPolling(userId);
+      jest.advanceTimersByTime(0);
+
+      expect(nativeMessagingBackground.connect).not.toHaveBeenCalled();
+    });
+
+    it("does not connect when already connected", () => {
+      const biometricEnabled$ = new BehaviorSubject<boolean>(true);
+      biometricStateService.biometricUnlockEnabled$.mockReturnValue(biometricEnabled$);
+      nativeMessagingBackground.connected = true;
+
+      service.startPolling(userId);
+      jest.advanceTimersByTime(0);
+
+      expect(nativeMessagingBackground.connect).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("stopPolling", () => {
+    it("stops connecting after stopPolling is called", () => {
+      const biometricEnabled$ = new BehaviorSubject<boolean>(true);
+      biometricStateService.biometricUnlockEnabled$.mockReturnValue(biometricEnabled$);
+      nativeMessagingBackground.connected = false;
+      nativeMessagingBackground.connect.mockResolvedValue();
+
+      service.startPolling(userId);
+      jest.advanceTimersByTime(0);
+      expect(nativeMessagingBackground.connect).toHaveBeenCalledTimes(1);
+
+      nativeMessagingBackground.connect.mockClear();
+      service.stopPolling();
+      jest.advanceTimersByTime(service.BACKGROUND_POLLING_INTERVAL);
+
+      expect(nativeMessagingBackground.connect).not.toHaveBeenCalled();
+    });
   });
 
   describe("canEnableBiometricUnlock", () => {

--- a/apps/browser/src/key-management/biometrics/background-browser-biometrics.service.ts
+++ b/apps/browser/src/key-management/biometrics/background-browser-biometrics.service.ts
@@ -1,5 +1,5 @@
-import { combineLatest, timer } from "rxjs";
-import { filter, concatMap } from "rxjs/operators";
+import { BehaviorSubject, combineLatest, EMPTY, timer } from "rxjs";
+import { filter, concatMap, switchMap } from "rxjs/operators";
 
 import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { toTsBiometricsStatus } from "@bitwarden/common/key-management/biometrics-status-mapper";
@@ -31,6 +31,8 @@ import { NativeMessagingBackground } from "../../background/nativeMessaging.back
 export class BackgroundBrowserBiometricsService extends BiometricsService {
   BACKGROUND_POLLING_INTERVAL = 30_000;
 
+  private activePollingUser$ = new BehaviorSubject<UserId | null>(null);
+
   constructor(
     private nativeMessagingBackground: () => NativeMessagingBackground,
     private configService: () => ConfigService,
@@ -44,22 +46,38 @@ export class BackgroundBrowserBiometricsService extends BiometricsService {
     super();
     // Always connect to the native messaging background if biometrics are enabled, not just when it is used
     // so that there is no wait when used.
-    const biometricsEnabled = this.biometricStateService.biometricUnlockEnabled$();
-
-    combineLatest([timer(0, this.BACKGROUND_POLLING_INTERVAL), biometricsEnabled])
+    this.activePollingUser$
       .pipe(
-        filter(([_, enabled]) => enabled),
-        filter(([_]) => !this.nativeMessagingBackground().connected),
-        concatMap(async () => {
-          try {
-            await this.nativeMessagingBackground().connect();
-            await this.getBiometricsStatus();
-          } catch {
-            // Ignore
+        switchMap((userId) => {
+          if (userId == null) {
+            return EMPTY;
           }
+          return combineLatest([
+            timer(0, this.BACKGROUND_POLLING_INTERVAL),
+            this.biometricStateService.biometricUnlockEnabled$(userId),
+          ]).pipe(
+            filter(([_, enabled]) => enabled),
+            filter(() => !this.nativeMessagingBackground().connected),
+            concatMap(async () => {
+              try {
+                await this.nativeMessagingBackground().connect();
+                await this.getBiometricsStatus();
+              } catch {
+                // Ignore
+              }
+            }),
+          );
         }),
       )
       .subscribe();
+  }
+
+  startPolling(userId: UserId): void {
+    this.activePollingUser$.next(userId);
+  }
+
+  stopPolling(): void {
+    this.activePollingUser$.next(null);
   }
 
   async authenticateWithBiometrics(): Promise<boolean> {
@@ -156,7 +174,7 @@ export class BackgroundBrowserBiometricsService extends BiometricsService {
         const userKey = new SymmetricCryptoKey(decodedUserkey) as UserKey;
         try {
           await this.unlockService!.unlockWithDecryptedUserKey(userId, userKey);
-          await this.biometricStateService.setBiometricUnlockEnabled(true);
+          await this.biometricStateService.setBiometricUnlockEnabled(true, userId);
           // to update badge and other things
           this.messagingService.send("switchAccount", { userId });
           return userKey;

--- a/apps/browser/src/key-management/biometrics/background-browser-biometrics.service.ts
+++ b/apps/browser/src/key-management/biometrics/background-browser-biometrics.service.ts
@@ -146,7 +146,7 @@ export class BackgroundBrowserBiometricsService extends BiometricsService {
               return null;
             }
 
-            await this.biometricStateService.setBiometricUnlockEnabled(true);
+            await this.biometricStateService.setBiometricUnlockEnabled(true, userId);
             await this.keyService.setUserKey(userKey, userId);
             // to update badge and other things
             this.messagingService.send("switchAccount", { userId });

--- a/apps/desktop/src/app/accounts/settings-dialog.component.spec.ts
+++ b/apps/desktop/src/app/accounts/settings-dialog.component.spec.ts
@@ -640,7 +640,10 @@ describe("SettingsDialogComponent", () => {
         await (component as any).updateBiometricHandler(true);
 
         expect((component as any).form.controls.biometric.value).toBe(false);
-        expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenLastCalledWith(false, mockUserId);
+        expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenLastCalledWith(
+          false,
+          mockUserId,
+        );
         expect(keyService.refreshAdditionalKeys).toHaveBeenCalled();
         expect(messagingService.send).toHaveBeenCalledWith("redrawMenu");
       });
@@ -680,7 +683,10 @@ describe("SettingsDialogComponent", () => {
         await (component as any).updateBiometricHandler(true);
 
         expect(desktopBiometricsService.setupBiometrics).toHaveBeenCalled();
-        expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenCalledWith(true, mockUserId);
+        expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenCalledWith(
+          true,
+          mockUserId,
+        );
         expect((component as any).form.controls.biometric.value).toBe(true);
         expect(keyService.refreshAdditionalKeys).toHaveBeenCalledWith(mockUserId);
         expect(messagingService.send).toHaveBeenCalledWith("redrawMenu");
@@ -704,9 +710,15 @@ describe("SettingsDialogComponent", () => {
         it("handles windows case", async () => {
           await (component as any).updateBiometricHandler(true);
 
-          expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenCalledWith(true, mockUserId);
+          expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenCalledWith(
+            true,
+            mockUserId,
+          );
           expect((component as any).form.controls.autoPromptBiometrics.value).toBe(false);
-          expect(biometricStateService.setPromptAutomatically).toHaveBeenCalledWith(false, mockUserId);
+          expect(biometricStateService.setPromptAutomatically).toHaveBeenCalledWith(
+            false,
+            mockUserId,
+          );
           expect(keyService.refreshAdditionalKeys).toHaveBeenCalledWith(mockUserId);
           expect((component as any).form.controls.biometric.value).toBe(true);
           expect(messagingService.send).toHaveBeenCalledWith("redrawMenu");
@@ -733,9 +745,15 @@ describe("SettingsDialogComponent", () => {
               false,
             );
 
-            expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenCalledWith(true, mockUserId);
+            expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenCalledWith(
+              true,
+              mockUserId,
+            );
             expect((component as any).form.controls.autoPromptBiometrics.value).toBe(false);
-            expect(biometricStateService.setPromptAutomatically).toHaveBeenCalledWith(false, mockUserId);
+            expect(biometricStateService.setPromptAutomatically).toHaveBeenCalledWith(
+              false,
+              mockUserId,
+            );
             expect(keyService.refreshAdditionalKeys).toHaveBeenCalledWith(mockUserId);
             expect((component as any).form.controls.biometric.value).toBe(true);
             expect(messagingService.send).toHaveBeenCalledWith("redrawMenu");
@@ -764,9 +782,15 @@ describe("SettingsDialogComponent", () => {
                 desktopBiometricsService.setBiometricProtectedUnlockKeyForUser,
               ).toHaveBeenCalledWith(mockUserId, mockUserKey);
 
-              expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenCalledWith(true, mockUserId);
+              expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenCalledWith(
+                true,
+                mockUserId,
+              );
               expect((component as any).form.controls.autoPromptBiometrics.value).toBe(false);
-              expect(biometricStateService.setPromptAutomatically).toHaveBeenCalledWith(false, mockUserId);
+              expect(biometricStateService.setPromptAutomatically).toHaveBeenCalledWith(
+                false,
+                mockUserId,
+              );
               expect(keyService.refreshAdditionalKeys).toHaveBeenCalledWith(mockUserId);
               expect((component as any).form.controls.biometric.value).toBe(true);
               expect(messagingService.send).toHaveBeenCalledWith("redrawMenu");
@@ -785,9 +809,15 @@ describe("SettingsDialogComponent", () => {
         (component as any).isLinux = true;
         await (component as any).updateBiometricHandler(true);
 
-        expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenCalledWith(true, mockUserId);
+        expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenCalledWith(
+          true,
+          mockUserId,
+        );
         expect((component as any).form.controls.autoPromptBiometrics.value).toBe(false);
-        expect(biometricStateService.setPromptAutomatically).toHaveBeenCalledWith(false, mockUserId);
+        expect(biometricStateService.setPromptAutomatically).toHaveBeenCalledWith(
+          false,
+          mockUserId,
+        );
         expect(keyService.refreshAdditionalKeys).toHaveBeenCalledWith(mockUserId);
         expect((component as any).form.controls.biometric.value).toBe(true);
         expect(messagingService.send).toHaveBeenCalledWith("redrawMenu");
@@ -814,9 +844,15 @@ describe("SettingsDialogComponent", () => {
 
           expect(keyService.refreshAdditionalKeys).toHaveBeenCalledWith(mockUserId);
           expect((component as any).form.controls.biometric.value).toBe(false);
-          expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenCalledWith(true, mockUserId);
+          expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenCalledWith(
+            true,
+            mockUserId,
+          );
           expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenCalledTimes(2);
-          expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenLastCalledWith(false, mockUserId);
+          expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenLastCalledWith(
+            false,
+            mockUserId,
+          );
           expect(messagingService.send).toHaveBeenCalledWith("redrawMenu");
         },
       );
@@ -828,7 +864,10 @@ describe("SettingsDialogComponent", () => {
         await (component as any).updateBiometricHandler(false);
 
         expect((component as any).form.controls.biometric.value).toBe(false);
-        expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenLastCalledWith(false, mockUserId);
+        expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenLastCalledWith(
+          false,
+          mockUserId,
+        );
         expect(keyService.refreshAdditionalKeys).toHaveBeenCalled();
         expect(messagingService.send).toHaveBeenCalledWith("redrawMenu");
       });

--- a/apps/desktop/src/app/accounts/settings-dialog.component.spec.ts
+++ b/apps/desktop/src/app/accounts/settings-dialog.component.spec.ts
@@ -49,6 +49,7 @@ import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/sym
 import { ThemeStateService } from "@bitwarden/common/platform/theming/theme-state.service";
 import { FakeAccountService, mockAccountServiceWith } from "@bitwarden/common/spec";
 import { UserId } from "@bitwarden/common/types/guid";
+import { UserKey } from "@bitwarden/common/types/key";
 import { TabsModule, DialogRef, DialogService, ToastService } from "@bitwarden/components";
 import { BiometricStateService, BiometricsStatus, KeyService } from "@bitwarden/key-management";
 import { SessionTimeoutSettingsComponent } from "@bitwarden/key-management-ui";
@@ -102,7 +103,7 @@ describe("SettingsDialogComponent", () => {
   const configService = mock<ConfigService>();
   const userVerificationService = mock<UserVerificationService>();
 
-  const mockUserKey = new SymmetricCryptoKey(new Uint8Array(64));
+  const mockUserKey = new SymmetricCryptoKey(new Uint8Array(64)) as UserKey;
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -187,7 +188,7 @@ describe("SettingsDialogComponent", () => {
     // defined at class level and toSignal() subscribes during construction.
     desktopBiometricsService.hasPersistentKey.mockResolvedValue(false);
     vaultTimeoutSettingsService.isBiometricLockSet.mockResolvedValue(false);
-    biometricStateService.promptAutomatically$ = of(false);
+    biometricStateService.promptAutomatically$.mockReturnValue(of(false));
     autofillSettingsServiceAbstraction.clearClipboardDelay$ = of(null);
     desktopSettingsService.minimizeOnCopy$ = of(false);
     desktopSettingsService.runInBackground$ = of(false);
@@ -469,7 +470,7 @@ describe("SettingsDialogComponent", () => {
 
       describe("when windows biometric v2 feature flag is enabled", () => {
         beforeEach(() => {
-          keyService.userKey$ = jest.fn().mockReturnValue(of(mockUserKey));
+          keyService.userKey$.mockReturnValue(of(mockUserKey));
         });
 
         test.each([false, true])(
@@ -639,7 +640,7 @@ describe("SettingsDialogComponent", () => {
         await (component as any).updateBiometricHandler(true);
 
         expect((component as any).form.controls.biometric.value).toBe(false);
-        expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenLastCalledWith(false);
+        expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenLastCalledWith(false, mockUserId);
         expect(keyService.refreshAdditionalKeys).toHaveBeenCalled();
         expect(messagingService.send).toHaveBeenCalledWith("redrawMenu");
       });
@@ -679,7 +680,7 @@ describe("SettingsDialogComponent", () => {
         await (component as any).updateBiometricHandler(true);
 
         expect(desktopBiometricsService.setupBiometrics).toHaveBeenCalled();
-        expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenCalledWith(true);
+        expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenCalledWith(true, mockUserId);
         expect((component as any).form.controls.biometric.value).toBe(true);
         expect(keyService.refreshAdditionalKeys).toHaveBeenCalledWith(mockUserId);
         expect(messagingService.send).toHaveBeenCalledWith("redrawMenu");
@@ -688,7 +689,7 @@ describe("SettingsDialogComponent", () => {
       describe("windows test cases", () => {
         beforeEach(() => {
           platformUtilsService.getDevice.mockReturnValue(DeviceType.WindowsDesktop);
-          keyService.userKey$ = jest.fn().mockReturnValue(of(mockUserKey));
+          keyService.userKey$.mockReturnValue(of(mockUserKey));
           (component as any).isWindows = true;
           (component as any).isLinux = false;
 
@@ -703,9 +704,9 @@ describe("SettingsDialogComponent", () => {
         it("handles windows case", async () => {
           await (component as any).updateBiometricHandler(true);
 
-          expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenCalledWith(true);
+          expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenCalledWith(true, mockUserId);
           expect((component as any).form.controls.autoPromptBiometrics.value).toBe(false);
-          expect(biometricStateService.setPromptAutomatically).toHaveBeenCalledWith(false);
+          expect(biometricStateService.setPromptAutomatically).toHaveBeenCalledWith(false, mockUserId);
           expect(keyService.refreshAdditionalKeys).toHaveBeenCalledWith(mockUserId);
           expect((component as any).form.controls.biometric.value).toBe(true);
           expect(messagingService.send).toHaveBeenCalledWith("redrawMenu");
@@ -713,7 +714,7 @@ describe("SettingsDialogComponent", () => {
 
         describe("when windows v2 biometrics is enabled", () => {
           beforeEach(() => {
-            keyService.userKey$ = jest.fn().mockReturnValue(of(mockUserKey));
+            keyService.userKey$.mockReturnValue(of(mockUserKey));
           });
 
           it("when the user doesn't have a master password or a PIN set, allows biometric unlock on app restart", async () => {
@@ -732,10 +733,9 @@ describe("SettingsDialogComponent", () => {
               false,
             );
 
-            expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenCalledWith(true);
-            expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenCalledWith(true);
+            expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenCalledWith(true, mockUserId);
             expect((component as any).form.controls.autoPromptBiometrics.value).toBe(false);
-            expect(biometricStateService.setPromptAutomatically).toHaveBeenCalledWith(false);
+            expect(biometricStateService.setPromptAutomatically).toHaveBeenCalledWith(false, mockUserId);
             expect(keyService.refreshAdditionalKeys).toHaveBeenCalledWith(mockUserId);
             expect((component as any).form.controls.biometric.value).toBe(true);
             expect(messagingService.send).toHaveBeenCalledWith("redrawMenu");
@@ -764,10 +764,9 @@ describe("SettingsDialogComponent", () => {
                 desktopBiometricsService.setBiometricProtectedUnlockKeyForUser,
               ).toHaveBeenCalledWith(mockUserId, mockUserKey);
 
-              expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenCalledWith(true);
-              expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenCalledWith(true);
+              expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenCalledWith(true, mockUserId);
               expect((component as any).form.controls.autoPromptBiometrics.value).toBe(false);
-              expect(biometricStateService.setPromptAutomatically).toHaveBeenCalledWith(false);
+              expect(biometricStateService.setPromptAutomatically).toHaveBeenCalledWith(false, mockUserId);
               expect(keyService.refreshAdditionalKeys).toHaveBeenCalledWith(mockUserId);
               expect((component as any).form.controls.biometric.value).toBe(true);
               expect(messagingService.send).toHaveBeenCalledWith("redrawMenu");
@@ -786,15 +785,15 @@ describe("SettingsDialogComponent", () => {
         (component as any).isLinux = true;
         await (component as any).updateBiometricHandler(true);
 
-        expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenCalledWith(true);
+        expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenCalledWith(true, mockUserId);
         expect((component as any).form.controls.autoPromptBiometrics.value).toBe(false);
-        expect(biometricStateService.setPromptAutomatically).toHaveBeenCalledWith(false);
+        expect(biometricStateService.setPromptAutomatically).toHaveBeenCalledWith(false, mockUserId);
         expect(keyService.refreshAdditionalKeys).toHaveBeenCalledWith(mockUserId);
         expect((component as any).form.controls.biometric.value).toBe(true);
         expect(messagingService.send).toHaveBeenCalledWith("redrawMenu");
       });
 
-      test.each([
+      it.each([
         BiometricsStatus.UnlockNeeded,
         BiometricsStatus.HardwareUnavailable,
         BiometricsStatus.AutoSetupNeeded,
@@ -803,7 +802,6 @@ describe("SettingsDialogComponent", () => {
         BiometricsStatus.DesktopDisconnected,
         BiometricsStatus.NotEnabledLocally,
         BiometricsStatus.NotEnabledInConnectedDesktopApp,
-        BiometricsStatus.NativeMessagingPermissionMissing,
       ])(
         `disables biometric when biometrics status check for the user returns %s`,
         async (status) => {
@@ -816,9 +814,9 @@ describe("SettingsDialogComponent", () => {
 
           expect(keyService.refreshAdditionalKeys).toHaveBeenCalledWith(mockUserId);
           expect((component as any).form.controls.biometric.value).toBe(false);
-          expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenCalledWith(true);
+          expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenCalledWith(true, mockUserId);
           expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenCalledTimes(2);
-          expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenLastCalledWith(false);
+          expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenLastCalledWith(false, mockUserId);
           expect(messagingService.send).toHaveBeenCalledWith("redrawMenu");
         },
       );
@@ -830,7 +828,7 @@ describe("SettingsDialogComponent", () => {
         await (component as any).updateBiometricHandler(false);
 
         expect((component as any).form.controls.biometric.value).toBe(false);
-        expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenLastCalledWith(false);
+        expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenLastCalledWith(false, mockUserId);
         expect(keyService.refreshAdditionalKeys).toHaveBeenCalled();
         expect(messagingService.send).toHaveBeenCalledWith("redrawMenu");
       });
@@ -841,7 +839,7 @@ describe("SettingsDialogComponent", () => {
     beforeEach(() => {
       jest.clearAllMocks();
 
-      keyService.userKey$ = jest.fn().mockReturnValue(of(mockUserKey));
+      keyService.userKey$.mockReturnValue(of(mockUserKey));
     });
 
     test.each([true, false])(`handles thrown errors when updated to %s`, async (update) => {
@@ -875,8 +873,6 @@ describe("SettingsDialogComponent", () => {
 
     describe("when updating to false", () => {
       it("doesn't enroll persistent biometric if already enrolled", async () => {
-        biometricStateService.hasPersistentKey.mockResolvedValue(false);
-
         await component.ngOnInit();
         await (component as any).updateRequireMasterPasswordOnAppRestartHandler(false, mockUserId);
 

--- a/apps/desktop/src/app/accounts/settings-dialog.component.ts
+++ b/apps/desktop/src/app/accounts/settings-dialog.component.ts
@@ -268,7 +268,9 @@ export class SettingsDialogComponent implements OnInit {
       requireMasterPasswordOnAppRestart: !(await this.biometricsService.hasPersistentKey(
         this.currentUserId(),
       )),
-      autoPromptBiometrics: await firstValueFrom(this.biometricStateService.promptAutomatically$),
+      autoPromptBiometrics: await firstValueFrom(
+        this.biometricStateService.promptAutomatically$(this.currentUserId()),
+      ),
       clearClipboard: await firstValueFrom(this.autofillSettingsService.clearClipboardDelay$),
       minimizeOnCopyToClipboard: await firstValueFrom(this.desktopSettingsService.minimizeOnCopy$),
       enableFavicons: await firstValueFrom(this.domainSettingsService.showFavicons$),
@@ -436,7 +438,7 @@ export class SettingsDialogComponent implements OnInit {
     const activeUserId = await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId));
     if (!enabled || !this.supportsBiometric()) {
       this.form.controls.biometric.setValue(false, { emitEvent: false });
-      await this.biometricStateService.setBiometricUnlockEnabled(false);
+      await this.biometricStateService.setBiometricUnlockEnabled(false, activeUserId);
       await this.keyService.refreshAdditionalKeys(activeUserId);
       return;
     }
@@ -457,11 +459,11 @@ export class SettingsDialogComponent implements OnInit {
       return;
     }
 
-    await this.biometricStateService.setBiometricUnlockEnabled(true);
+    await this.biometricStateService.setBiometricUnlockEnabled(true, activeUserId);
     if (this.isWindows) {
       // Recommended settings for Windows Hello
       this.form.controls.autoPromptBiometrics.setValue(false);
-      await this.biometricStateService.setPromptAutomatically(false);
+      await this.biometricStateService.setPromptAutomatically(false, activeUserId);
 
       // If the user doesn't have a MP or PIN then they have to use biometrics on app restart.
       if (!this.userHasMasterPassword() && !this.userHasPinSet()) {
@@ -473,7 +475,7 @@ export class SettingsDialogComponent implements OnInit {
     } else if (this.isLinux) {
       // Similar to Windows
       this.form.controls.autoPromptBiometrics.setValue(false);
-      await this.biometricStateService.setPromptAutomatically(false);
+      await this.biometricStateService.setPromptAutomatically(false, activeUserId);
     }
     await this.keyService.refreshAdditionalKeys(activeUserId);
 
@@ -483,7 +485,7 @@ export class SettingsDialogComponent implements OnInit {
       BiometricsStatus.Available;
     this.form.controls.biometric.setValue(biometricSet, { emitEvent: false });
     if (!biometricSet) {
-      await this.biometricStateService.setBiometricUnlockEnabled(false);
+      await this.biometricStateService.setBiometricUnlockEnabled(false, activeUserId);
     }
   }
 
@@ -519,10 +521,11 @@ export class SettingsDialogComponent implements OnInit {
   }
 
   protected async updateAutoPromptBiometrics() {
+    const activeUserId = await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId));
     if (this.form.value.autoPromptBiometrics) {
-      await this.biometricStateService.setPromptAutomatically(true);
+      await this.biometricStateService.setPromptAutomatically(true, activeUserId);
     } else {
-      await this.biometricStateService.setPromptAutomatically(false);
+      await this.biometricStateService.setPromptAutomatically(false, activeUserId);
     }
   }
 

--- a/apps/desktop/src/app/accounts/settings.component.spec.ts
+++ b/apps/desktop/src/app/accounts/settings.component.spec.ts
@@ -29,6 +29,7 @@ import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/sym
 import { ThemeStateService } from "@bitwarden/common/platform/theming/theme-state.service";
 import { FakeAccountService, mockAccountServiceWith } from "@bitwarden/common/spec";
 import { UserId } from "@bitwarden/common/types/guid";
+import { UserKey } from "@bitwarden/common/types/key";
 import { DialogRef, DialogService, ToastService } from "@bitwarden/components";
 import { BiometricStateService, BiometricsStatus, KeyService } from "@bitwarden/key-management";
 import { SessionTimeoutSettingsComponent } from "@bitwarden/key-management-ui";
@@ -82,7 +83,7 @@ describe("SettingsComponent", () => {
   const configService = mock<ConfigService>();
   const userVerificationService = mock<UserVerificationService>();
 
-  const mockUserKey = new SymmetricCryptoKey(new Uint8Array(64));
+  const mockUserKey = new SymmetricCryptoKey(new Uint8Array(64)) as unknown as UserKey;
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -168,7 +169,7 @@ describe("SettingsComponent", () => {
 
     desktopBiometricsService.hasPersistentKey.mockResolvedValue(false);
     vaultTimeoutSettingsService.isBiometricLockSet.mockResolvedValue(false);
-    biometricStateService.promptAutomatically$ = of(false);
+    biometricStateService.promptAutomatically$.mockReturnValue(of(false));
     autofillSettingsServiceAbstraction.clearClipboardDelay$ = of(null);
     desktopSettingsService.minimizeOnCopy$ = of(false);
     desktopSettingsService.runInBackground$ = of(false);
@@ -435,7 +436,7 @@ describe("SettingsComponent", () => {
 
       describe("when windows biometric v2 feature flag is enabled", () => {
         beforeEach(() => {
-          keyService.userKey$ = jest.fn().mockReturnValue(of(mockUserKey));
+          keyService.userKey$.mockReturnValue(of(mockUserKey));
         });
 
         test.each([false, true])(
@@ -603,7 +604,10 @@ describe("SettingsComponent", () => {
         await component.updateBiometricHandler(true);
 
         expect(component.form.controls.biometric.value).toBe(false);
-        expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenLastCalledWith(false);
+        expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenLastCalledWith(
+          false,
+          mockUserId,
+        );
         expect(keyService.refreshAdditionalKeys).toHaveBeenCalled();
         expect(messagingService.send).toHaveBeenCalledWith("redrawMenu");
       });
@@ -643,7 +647,10 @@ describe("SettingsComponent", () => {
         await component.updateBiometricHandler(true);
 
         expect(desktopBiometricsService.setupBiometrics).toHaveBeenCalled();
-        expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenCalledWith(true);
+        expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenCalledWith(
+          true,
+          mockUserId,
+        );
         expect(component.form.controls.biometric.value).toBe(true);
         expect(keyService.refreshAdditionalKeys).toHaveBeenCalledWith(mockUserId);
         expect(messagingService.send).toHaveBeenCalledWith("redrawMenu");
@@ -652,7 +659,7 @@ describe("SettingsComponent", () => {
       describe("windows test cases", () => {
         beforeEach(() => {
           platformUtilsService.getDevice.mockReturnValue(DeviceType.WindowsDesktop);
-          keyService.userKey$ = jest.fn().mockReturnValue(of(mockUserKey));
+          keyService.userKey$.mockReturnValue(of(mockUserKey));
           component.isWindows = true;
           component.isLinux = false;
 
@@ -667,9 +674,15 @@ describe("SettingsComponent", () => {
         it("handles windows case", async () => {
           await component.updateBiometricHandler(true);
 
-          expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenCalledWith(true);
+          expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenCalledWith(
+            true,
+            mockUserId,
+          );
           expect(component.form.controls.autoPromptBiometrics.value).toBe(false);
-          expect(biometricStateService.setPromptAutomatically).toHaveBeenCalledWith(false);
+          expect(biometricStateService.setPromptAutomatically).toHaveBeenCalledWith(
+            false,
+            mockUserId,
+          );
           expect(keyService.refreshAdditionalKeys).toHaveBeenCalledWith(mockUserId);
           expect(component.form.controls.biometric.value).toBe(true);
           expect(messagingService.send).toHaveBeenCalledWith("redrawMenu");
@@ -677,7 +690,7 @@ describe("SettingsComponent", () => {
 
         describe("when windows v2 biometrics is enabled", () => {
           beforeEach(() => {
-            keyService.userKey$ = jest.fn().mockReturnValue(of(mockUserKey));
+            keyService.userKey$.mockReturnValue(of(mockUserKey));
           });
 
           it("when the user doesn't have a master password or a PIN set, allows biometric unlock on app restart", async () => {
@@ -694,10 +707,15 @@ describe("SettingsComponent", () => {
             );
             expect(component.form.controls.requireMasterPasswordOnAppRestart.value).toBe(false);
 
-            expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenCalledWith(true);
-            expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenCalledWith(true);
+            expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenCalledWith(
+              true,
+              mockUserId,
+            );
             expect(component.form.controls.autoPromptBiometrics.value).toBe(false);
-            expect(biometricStateService.setPromptAutomatically).toHaveBeenCalledWith(false);
+            expect(biometricStateService.setPromptAutomatically).toHaveBeenCalledWith(
+              false,
+              mockUserId,
+            );
             expect(keyService.refreshAdditionalKeys).toHaveBeenCalledWith(mockUserId);
             expect(component.form.controls.biometric.value).toBe(true);
             expect(messagingService.send).toHaveBeenCalledWith("redrawMenu");
@@ -724,10 +742,15 @@ describe("SettingsComponent", () => {
                 desktopBiometricsService.setBiometricProtectedUnlockKeyForUser,
               ).toHaveBeenCalledWith(mockUserId, mockUserKey);
 
-              expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenCalledWith(true);
-              expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenCalledWith(true);
+              expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenCalledWith(
+                true,
+                mockUserId,
+              );
               expect(component.form.controls.autoPromptBiometrics.value).toBe(false);
-              expect(biometricStateService.setPromptAutomatically).toHaveBeenCalledWith(false);
+              expect(biometricStateService.setPromptAutomatically).toHaveBeenCalledWith(
+                false,
+                mockUserId,
+              );
               expect(keyService.refreshAdditionalKeys).toHaveBeenCalledWith(mockUserId);
               expect(component.form.controls.biometric.value).toBe(true);
               expect(messagingService.send).toHaveBeenCalledWith("redrawMenu");
@@ -746,9 +769,15 @@ describe("SettingsComponent", () => {
         component.isLinux = true;
         await component.updateBiometricHandler(true);
 
-        expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenCalledWith(true);
+        expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenCalledWith(
+          true,
+          mockUserId,
+        );
         expect(component.form.controls.autoPromptBiometrics.value).toBe(false);
-        expect(biometricStateService.setPromptAutomatically).toHaveBeenCalledWith(false);
+        expect(biometricStateService.setPromptAutomatically).toHaveBeenCalledWith(
+          false,
+          mockUserId,
+        );
         expect(keyService.refreshAdditionalKeys).toHaveBeenCalledWith(mockUserId);
         expect(component.form.controls.biometric.value).toBe(true);
         expect(messagingService.send).toHaveBeenCalledWith("redrawMenu");
@@ -775,9 +804,15 @@ describe("SettingsComponent", () => {
 
           expect(keyService.refreshAdditionalKeys).toHaveBeenCalledWith(mockUserId);
           expect(component.form.controls.biometric.value).toBe(false);
-          expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenCalledWith(true);
+          expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenCalledWith(
+            true,
+            mockUserId,
+          );
           expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenCalledTimes(2);
-          expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenLastCalledWith(false);
+          expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenLastCalledWith(
+            false,
+            mockUserId,
+          );
           expect(messagingService.send).toHaveBeenCalledWith("redrawMenu");
         },
       );
@@ -789,7 +824,10 @@ describe("SettingsComponent", () => {
         await component.updateBiometricHandler(false);
 
         expect(component.form.controls.biometric.value).toBe(false);
-        expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenLastCalledWith(false);
+        expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenLastCalledWith(
+          false,
+          mockUserId,
+        );
         expect(keyService.refreshAdditionalKeys).toHaveBeenCalled();
         expect(messagingService.send).toHaveBeenCalledWith("redrawMenu");
       });
@@ -800,7 +838,7 @@ describe("SettingsComponent", () => {
     beforeEach(() => {
       jest.clearAllMocks();
 
-      keyService.userKey$ = jest.fn().mockReturnValue(of(mockUserKey));
+      keyService.userKey$.mockReturnValue(of(mockUserKey));
     });
 
     test.each([true, false])(`handles thrown errors when updated to %s`, async (update) => {
@@ -832,7 +870,7 @@ describe("SettingsComponent", () => {
 
     describe("when updating to false", () => {
       it("doesn't enroll persistent biometric if already enrolled", async () => {
-        biometricStateService.hasPersistentKey.mockResolvedValue(false);
+        desktopBiometricsService.hasPersistentKey.mockResolvedValue(false);
 
         await component.ngOnInit();
         await component.updateRequireMasterPasswordOnAppRestartHandler(false, mockUserId);

--- a/apps/desktop/src/app/accounts/settings.component.ts
+++ b/apps/desktop/src/app/accounts/settings.component.ts
@@ -278,7 +278,9 @@ export class SettingsComponent implements OnInit, OnDestroy {
       requireMasterPasswordOnAppRestart: !(await this.biometricsService.hasPersistentKey(
         activeAccount.id,
       )),
-      autoPromptBiometrics: await firstValueFrom(this.biometricStateService.promptAutomatically$),
+      autoPromptBiometrics: await firstValueFrom(
+        this.biometricStateService.promptAutomatically$(activeAccount.id),
+      ),
       clearClipboard: await firstValueFrom(this.autofillSettingsService.clearClipboardDelay$),
       minimizeOnCopyToClipboard: await firstValueFrom(this.desktopSettingsService.minimizeOnCopy$),
       enableFavicons: await firstValueFrom(this.domainSettingsService.showFavicons$),
@@ -413,7 +415,7 @@ export class SettingsComponent implements OnInit, OnDestroy {
     const activeUserId = await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId));
     if (!enabled || !this.supportsBiometric) {
       this.form.controls.biometric.setValue(false, { emitEvent: false });
-      await this.biometricStateService.setBiometricUnlockEnabled(false);
+      await this.biometricStateService.setBiometricUnlockEnabled(false, activeUserId);
       await this.keyService.refreshAdditionalKeys(activeUserId);
       return;
     }
@@ -434,11 +436,11 @@ export class SettingsComponent implements OnInit, OnDestroy {
       return;
     }
 
-    await this.biometricStateService.setBiometricUnlockEnabled(true);
+    await this.biometricStateService.setBiometricUnlockEnabled(true, activeUserId);
     if (this.isWindows) {
       // Recommended settings for Windows Hello
       this.form.controls.autoPromptBiometrics.setValue(false);
-      await this.biometricStateService.setPromptAutomatically(false);
+      await this.biometricStateService.setPromptAutomatically(false, activeUserId);
 
       // If the user doesn't have a MP or PIN then they have to use biometrics on app restart.
       if (!this.userHasMasterPassword && !this.userHasPinSet) {
@@ -450,7 +452,7 @@ export class SettingsComponent implements OnInit, OnDestroy {
     } else if (this.isLinux) {
       // Similar to Windows
       this.form.controls.autoPromptBiometrics.setValue(false);
-      await this.biometricStateService.setPromptAutomatically(false);
+      await this.biometricStateService.setPromptAutomatically(false, activeUserId);
     }
     await this.keyService.refreshAdditionalKeys(activeUserId);
 
@@ -460,7 +462,7 @@ export class SettingsComponent implements OnInit, OnDestroy {
       BiometricsStatus.Available;
     this.form.controls.biometric.setValue(biometricSet, { emitEvent: false });
     if (!biometricSet) {
-      await this.biometricStateService.setBiometricUnlockEnabled(false);
+      await this.biometricStateService.setBiometricUnlockEnabled(false, activeUserId);
     }
   }
 
@@ -497,9 +499,9 @@ export class SettingsComponent implements OnInit, OnDestroy {
 
   async updateAutoPromptBiometrics() {
     if (this.form.value.autoPromptBiometrics) {
-      await this.biometricStateService.setPromptAutomatically(true);
+      await this.biometricStateService.setPromptAutomatically(true, this.currentUserId);
     } else {
-      await this.biometricStateService.setPromptAutomatically(false);
+      await this.biometricStateService.setPromptAutomatically(false, this.currentUserId);
     }
   }
 

--- a/libs/key-management-ui/src/lock/components/lock.component.spec.ts
+++ b/libs/key-management-ui/src/lock/components/lock.component.spec.ts
@@ -104,8 +104,8 @@ describe("LockComponent", () => {
     mockI18nService.t.mockImplementation((key: string) => key);
 
     // Mock observables that cause timeouts
-    mockBiometricStateService.promptAutomatically$ = of(false);
-    mockBiometricStateService.promptCancelled$ = of(false);
+    mockBiometricStateService.promptAutomatically$.mockReturnValue(of(false));
+    mockBiometricStateService.promptCancelled$.mockReturnValue(of(false));
     mockBiometricStateService.resetUserPromptCancelled.mockResolvedValue();
     mockLockComponentService.getAvailableUnlockOptions$.mockReturnValue(of(null));
     mockSyncService.fullSync.mockResolvedValue(true);
@@ -268,7 +268,7 @@ describe("LockComponent", () => {
         mockLockComponentService.getPreviousUrl.mockReturnValue(null);
 
         jest.spyOn(component as any, "doContinue").mockImplementation(async () => {
-          await mockBiometricStateService.resetUserPromptCancelled();
+          await mockBiometricStateService.resetUserPromptCancelled(userId);
           mockMessagingService.send("unlocked");
           await mockSyncService.fullSync(false);
           await mockUserAsymmetricKeysRegenerationService.regenerateIfNeeded(userId);
@@ -287,7 +287,7 @@ describe("LockComponent", () => {
       mockPlatformUtilsService.getDevice.mockReturnValue(DeviceType.FirefoxExtension);
 
       jest.spyOn(component as any, "doContinue").mockImplementation(async () => {
-        await mockBiometricStateService.resetUserPromptCancelled();
+        await mockBiometricStateService.resetUserPromptCancelled(userId);
         mockMessagingService.send("unlocked");
         await mockSyncService.fullSync(false);
         await mockUserAsymmetricKeysRegenerationService.regenerateIfNeeded(

--- a/libs/key-management-ui/src/lock/components/lock.component.ts
+++ b/libs/key-management-ui/src/lock/components/lock.component.ts
@@ -32,6 +32,7 @@ import { MessagingService } from "@bitwarden/common/platform/abstractions/messag
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { SyncService } from "@bitwarden/common/platform/sync";
 import { PasswordStrengthServiceAbstraction } from "@bitwarden/common/tools/password-strength";
+import { UserId } from "@bitwarden/common/types/guid";
 import { UserKey } from "@bitwarden/common/types/key";
 import {
   TooltipDirective,
@@ -215,7 +216,7 @@ export class LockComponent implements OnInit, OnDestroy {
             } else if (!prevBiometricsEnabled && this.unlockOptions?.biometrics.enabled) {
               await this.setDefaultActiveUnlockOption(this.unlockOptions);
               if (this.activeUnlockOption === UnlockOption.Biometrics) {
-                await this.handleBiometricsUnlockEnabled();
+                await this.handleBiometricsUnlockEnabled(this.activeAccount.id);
               }
             }
           }
@@ -292,7 +293,7 @@ export class LockComponent implements OnInit, OnDestroy {
     await this.setDefaultActiveUnlockOption(this.unlockOptions);
 
     if (this.unlockOptions?.biometrics.enabled) {
-      await this.handleBiometricsUnlockEnabled();
+      await this.handleBiometricsUnlockEnabled(activeAccount.id);
     }
   }
 
@@ -332,11 +333,11 @@ export class LockComponent implements OnInit, OnDestroy {
     }
   }
 
-  private async handleBiometricsUnlockEnabled() {
+  private async handleBiometricsUnlockEnabled(userId: UserId) {
     this.biometricUnlockBtnText = this.lockComponentService.getBiometricsUnlockBtnText();
 
     const autoPromptBiometrics = await firstValueFrom(
-      this.biometricStateService.promptAutomatically$,
+      this.biometricStateService.promptAutomatically$(userId),
     );
 
     // TODO: PM-12546 - we need to make our biometric autoprompt experience consistent between the
@@ -344,7 +345,7 @@ export class LockComponent implements OnInit, OnDestroy {
     if (this.clientType === "desktop") {
       if (autoPromptBiometrics) {
         this.loading = false;
-        await this.desktopAutoPromptBiometrics();
+        await this.desktopAutoPromptBiometrics(userId);
       }
     }
 
@@ -421,7 +422,7 @@ export class LockComponent implements OnInit, OnDestroy {
         return;
       }
 
-      await this.biometricStateService.setUserPromptCancelled();
+      await this.biometricStateService.setUserPromptCancelled(this.activeAccount.id);
 
       await this.unlockService.unlockWithBiometrics(this.activeAccount.id);
       const userKey = await firstValueFrom(this.keyService.userKey$(this.activeAccount.id));
@@ -570,7 +571,7 @@ export class LockComponent implements OnInit, OnDestroy {
       throw new Error("No active user.");
     }
 
-    await this.biometricStateService.resetUserPromptCancelled();
+    await this.biometricStateService.resetUserPromptCancelled(this.activeAccount.id);
 
     try {
       await this.encryptedMigrator.runMigrations(
@@ -721,7 +722,7 @@ export class LockComponent implements OnInit, OnDestroy {
     this.messagingService.send("getWindowIsFocused");
   }
 
-  private async desktopAutoPromptBiometrics() {
+  private async desktopAutoPromptBiometrics(userId: UserId) {
     if (!this.unlockOptions?.biometrics?.enabled || this.biometricAsked) {
       return;
     }
@@ -731,7 +732,7 @@ export class LockComponent implements OnInit, OnDestroy {
     }
 
     // prevent the biometric prompt from showing if the user has already cancelled it
-    if (await firstValueFrom(this.biometricStateService.promptCancelled$)) {
+    if (await firstValueFrom(this.biometricStateService.promptCancelled$(userId))) {
       return;
     }
 

--- a/libs/key-management/src/biometrics/biometric-state.service.spec.ts
+++ b/libs/key-management/src/biometrics/biometric-state.service.spec.ts
@@ -41,17 +41,19 @@ describe("BiometricStateService", () => {
 
   describe("encryptedClientKeyHalf$", () => {
     it("emits when the encryptedClientKeyHalf state changes", async () => {
-      const state = stateProvider.activeUser.getFake(ENCRYPTED_CLIENT_KEY_HALF);
-      state.nextState(encryptedClientKeyHalf as unknown as EncryptedString);
+      stateProvider.singleUser
+        .getFake(userId, ENCRYPTED_CLIENT_KEY_HALF)
+        .nextState(encryptedClientKeyHalf as unknown as EncryptedString);
 
-      expect(await firstValueFrom(sut.encryptedClientKeyHalf$)).toEqual(encClientKeyHalf);
+      expect(await firstValueFrom(sut.encryptedClientKeyHalf$(userId))).toEqual(encClientKeyHalf);
     });
 
-    it("emits false when the encryptedClientKeyHalf state is undefined", async () => {
-      const state = stateProvider.activeUser.getFake(ENCRYPTED_CLIENT_KEY_HALF);
-      state.nextState(undefined as unknown as EncryptedString);
+    it("emits null when the encryptedClientKeyHalf state is undefined", async () => {
+      stateProvider.singleUser
+        .getFake(userId, ENCRYPTED_CLIENT_KEY_HALF)
+        .nextState(undefined as unknown as EncryptedString);
 
-      expect(await firstValueFrom(sut.encryptedClientKeyHalf$)).toBe(null);
+      expect(await firstValueFrom(sut.encryptedClientKeyHalf$(userId))).toBe(null);
     });
   });
 
@@ -70,9 +72,9 @@ describe("BiometricStateService", () => {
 
   describe("setEncryptedClientKeyHalf", () => {
     it("updates encryptedClientKeyHalf$", async () => {
-      await sut.setEncryptedClientKeyHalf(encClientKeyHalf);
+      await sut.setEncryptedClientKeyHalf(encClientKeyHalf, userId);
 
-      expect(await firstValueFrom(sut.encryptedClientKeyHalf$)).toEqual(encClientKeyHalf);
+      expect(await firstValueFrom(sut.encryptedClientKeyHalf$(userId))).toEqual(encClientKeyHalf);
     });
   });
 
@@ -85,26 +87,17 @@ describe("BiometricStateService", () => {
     });
 
     test("observable is updated", async () => {
-      await sut.setUserPromptCancelled();
+      await sut.setUserPromptCancelled(userId);
 
-      expect(await firstValueFrom(sut.promptCancelled$)).toBe(true);
+      expect(await firstValueFrom(sut.promptCancelled$(userId))).toBe(true);
     });
 
     it("updates state", async () => {
-      await sut.setUserPromptCancelled();
+      await sut.setUserPromptCancelled(userId);
 
       const nextMock = stateProvider.global.getFake(PROMPT_CANCELLED).nextMock;
       expect(nextMock).toHaveBeenCalledWith({ ...existingState, [userId]: true });
       expect(nextMock).toHaveBeenCalledTimes(1);
-    });
-
-    it("throws when called with no active user", async () => {
-      await accountService.switchAccount(null as unknown as UserId);
-      await expect(sut.setUserPromptCancelled()).rejects.toThrow(
-        "Cannot update biometric prompt cancelled state without an active user",
-      );
-      const nextMock = stateProvider.global.getFake(PROMPT_CANCELLED).nextMock;
-      expect(nextMock).not.toHaveBeenCalled();
     });
   });
 
@@ -118,9 +111,9 @@ describe("BiometricStateService", () => {
     });
 
     it("updates observable to false", async () => {
-      const emissions = trackEmissions(sut.promptCancelled$);
+      const emissions = trackEmissions(sut.promptCancelled$(userId));
 
-      await sut.setUserPromptCancelled();
+      await sut.setUserPromptCancelled(userId);
 
       await sut.resetAllPromptCancelled();
 
@@ -133,7 +126,6 @@ describe("BiometricStateService", () => {
     let state: FakeGlobalState<Record<UserId, boolean>>;
 
     beforeEach(async () => {
-      await accountService.switchAccount(userId);
       existingState = { [userId]: true, ["otherUser" as UserId]: false };
       state = stateProvider.global.getFake(PROMPT_CANCELLED);
       state.stateSubject.next(existingState);
@@ -146,17 +138,17 @@ describe("BiometricStateService", () => {
       expect(state.nextMock).toHaveBeenCalledTimes(1);
     });
 
-    it("deletes active user when called with no user", async () => {
-      await sut.resetUserPromptCancelled();
+    it("deletes given user's prompt cancelled state", async () => {
+      await sut.resetUserPromptCancelled(userId);
 
       expect(state.nextMock).toHaveBeenCalledWith({ ["otherUser" as UserId]: false });
       expect(state.nextMock).toHaveBeenCalledTimes(1);
     });
 
     it("updates observable to false", async () => {
-      const emissions = trackEmissions(sut.promptCancelled$);
+      const emissions = trackEmissions(sut.promptCancelled$(userId));
 
-      await sut.resetUserPromptCancelled();
+      await sut.resetUserPromptCancelled(userId);
 
       expect(emissions).toEqual([true, false]);
     });
@@ -164,67 +156,49 @@ describe("BiometricStateService", () => {
 
   describe("setPromptAutomatically", () => {
     test("observable is updated", async () => {
-      await sut.setPromptAutomatically(true);
+      await sut.setPromptAutomatically(true, userId);
 
-      expect(await firstValueFrom(sut.promptAutomatically$)).toBe(true);
+      expect(await firstValueFrom(sut.promptAutomatically$(userId))).toBe(true);
     });
 
     it("updates state", async () => {
-      await sut.setPromptAutomatically(true);
+      await sut.setPromptAutomatically(true, userId);
 
-      const nextMock = stateProvider.activeUser.getFake(PROMPT_AUTOMATICALLY).nextMock;
-      expect(nextMock).toHaveBeenCalledWith([userId, true]);
+      const nextMock = stateProvider.singleUser.getFake(userId, PROMPT_AUTOMATICALLY).nextMock;
+      expect(nextMock).toHaveBeenCalledWith(true);
       expect(nextMock).toHaveBeenCalledTimes(1);
     });
   });
 
   describe("biometricUnlockEnabled$", () => {
-    describe("no user id provided, active user", () => {
-      it("emits when biometricUnlockEnabled state is updated", async () => {
-        const state = stateProvider.activeUser.getFake(BIOMETRIC_UNLOCK_ENABLED);
-        state.nextState(true);
+    it("returns when biometricUnlockEnabled state is updated", async () => {
+      stateProvider.singleUser.getFake(userId, BIOMETRIC_UNLOCK_ENABLED).nextState(true);
 
-        expect(await firstValueFrom(sut.biometricUnlockEnabled$())).toBe(true);
-      });
-
-      it("emits false when biometricUnlockEnabled state is undefined", async () => {
-        const state = stateProvider.activeUser.getFake(BIOMETRIC_UNLOCK_ENABLED);
-        state.nextState(undefined as unknown as boolean);
-
-        expect(await firstValueFrom(sut.biometricUnlockEnabled$())).toBe(false);
-      });
+      expect(await firstValueFrom(sut.biometricUnlockEnabled$(userId))).toBe(true);
     });
 
-    describe("user id provided", () => {
-      it("returns biometricUnlockEnabled state for the given user", async () => {
-        stateProvider.singleUser.getFake(userId, BIOMETRIC_UNLOCK_ENABLED).nextState(true);
+    it("returns false when biometricUnlockEnabled state is undefined", async () => {
+      stateProvider.singleUser
+        .getFake(userId, BIOMETRIC_UNLOCK_ENABLED)
+        .nextState(undefined as unknown as boolean);
 
-        expect(await firstValueFrom(sut.biometricUnlockEnabled$(userId))).toBe(true);
-      });
-
-      it("returns false when the state is not set", async () => {
-        stateProvider.singleUser
-          .getFake(userId, BIOMETRIC_UNLOCK_ENABLED)
-          .nextState(undefined as unknown as boolean);
-
-        expect(await firstValueFrom(sut.biometricUnlockEnabled$(userId))).toBe(false);
-      });
+      expect(await firstValueFrom(sut.biometricUnlockEnabled$(userId))).toBe(false);
     });
   });
 
   describe("setBiometricUnlockEnabled", () => {
     it("updates biometricUnlockEnabled$", async () => {
-      await sut.setBiometricUnlockEnabled(true);
+      await sut.setBiometricUnlockEnabled(true, userId);
 
-      expect(await firstValueFrom(sut.biometricUnlockEnabled$())).toBe(true);
+      expect(await firstValueFrom(sut.biometricUnlockEnabled$(userId))).toBe(true);
     });
 
     it("updates state", async () => {
-      await sut.setBiometricUnlockEnabled(true);
+      await sut.setBiometricUnlockEnabled(true, userId);
 
       expect(
-        stateProvider.activeUser.getFake(BIOMETRIC_UNLOCK_ENABLED).nextMock,
-      ).toHaveBeenCalledWith([userId, true]);
+        stateProvider.singleUser.getFake(userId, BIOMETRIC_UNLOCK_ENABLED).nextMock,
+      ).toHaveBeenCalledWith(true);
     });
   });
 

--- a/libs/key-management/src/biometrics/biometric-state.service.ts
+++ b/libs/key-management/src/biometrics/biometric-state.service.ts
@@ -1,10 +1,11 @@
-import { Observable, firstValueFrom, map, combineLatest } from "rxjs";
+import { Observable, firstValueFrom, map } from "rxjs";
 
+import { assertNonNullish } from "@bitwarden/common/auth/utils";
 import {
   EncryptedString,
   EncString,
 } from "@bitwarden/common/key-management/crypto/models/enc-string";
-import { ActiveUserState, GlobalState, StateProvider } from "@bitwarden/common/platform/state";
+import { GlobalState, StateProvider } from "@bitwarden/common/platform/state";
 import { UserId } from "@bitwarden/common/types/guid";
 
 import {
@@ -20,39 +21,37 @@ import {
 export abstract class BiometricStateService {
   /**
    * Returns whether biometric unlock is enabled for a user.
-   * @param userId The user id to check. If not provided, returns the state for the currently active user.
+   * @param userId The user id to check.
    * @returns An observable that emits `true` if the user has elected to store a biometric key to unlock their vault.
    */
-  abstract biometricUnlockEnabled$(userId?: UserId): Observable<boolean>;
+  abstract biometricUnlockEnabled$(userId: UserId): Observable<boolean>;
   /**
    * If the user has elected to require a password on first unlock of an application instance, this key will store the
    * encrypted client key half used to unlock the vault.
-   *
-   * Tracks the currently active user
+   * @param userId The user id to check.
    */
-  abstract encryptedClientKeyHalf$: Observable<EncString | null>;
+  abstract encryptedClientKeyHalf$(userId: UserId): Observable<EncString | null>;
   /**
    * Whether the user has cancelled the biometric prompt.
-   *
-   * tracks the currently active user
+   * @param userId The user id to check.
    */
-  abstract promptCancelled$: Observable<boolean>;
+  abstract promptCancelled$(userId: UserId): Observable<boolean>;
   /**
    * Whether the user has elected to automatically prompt for biometrics.
-   *
-   * tracks the currently active user
+   * @param userId The user id to check.
    */
-  abstract promptAutomatically$: Observable<boolean>;
+  abstract promptAutomatically$(userId: UserId): Observable<boolean>;
   /**
    * Whether or not IPC fingerprint has been validated by the user this session.
    */
   abstract fingerprintValidated$: Observable<boolean>;
 
   /**
-   * Updates the biometric unlock enabled state for the currently active user.
+   * Updates the biometric unlock enabled state for the given user.
    * @param enabled whether or not to store a biometric key to unlock the vault
+   * @param userId the user to update
    */
-  abstract setBiometricUnlockEnabled(enabled: boolean): Promise<void>;
+  abstract setBiometricUnlockEnabled(enabled: boolean, userId: UserId): Promise<void>;
 
   /**
    * Gets the biometric unlock enabled state for the given user.
@@ -61,20 +60,21 @@ export abstract class BiometricStateService {
    */
   abstract getBiometricUnlockEnabled(userId: UserId): Promise<boolean>;
 
-  abstract setEncryptedClientKeyHalf(encryptedKeyHalf: EncString, userId?: UserId): Promise<void>;
+  abstract setEncryptedClientKeyHalf(encryptedKeyHalf: EncString, userId: UserId): Promise<void>;
 
   abstract getEncryptedClientKeyHalf(userId: UserId): Promise<EncString | null>;
 
   /**
-   * Updates the active user's state to reflect that they've cancelled the biometric prompt.
+   * Updates the given user's state to reflect that they've cancelled the biometric prompt.
+   * @param userId the user to update
    */
-  abstract setUserPromptCancelled(): Promise<void>;
+  abstract setUserPromptCancelled(userId: UserId): Promise<void>;
 
   /**
    * Resets the given user's state to reflect that they haven't cancelled the biometric prompt.
-   * @param userId the user to reset the prompt cancelled state for. If not provided, the currently active user will be used.
+   * @param userId the user to reset the prompt cancelled state for.
    */
-  abstract resetUserPromptCancelled(userId?: UserId): Promise<void>;
+  abstract resetUserPromptCancelled(userId: UserId): Promise<void>;
 
   /**
    * Resets all user's state to reflect that they haven't cancelled the biometric prompt.
@@ -82,10 +82,11 @@ export abstract class BiometricStateService {
   abstract resetAllPromptCancelled(): Promise<void>;
 
   /**
-   * Updates the currently active user's setting for auto prompting for biometrics on application start and lock
+   * Updates the given user's setting for auto prompting for biometrics on application start and lock
    * @param prompt Whether or not to prompt for biometrics on application start.
+   * @param userId the user to update
    */
-  abstract setPromptAutomatically(prompt: boolean): Promise<void>;
+  abstract setPromptAutomatically(prompt: boolean, userId: UserId): Promise<void>;
 
   /**
    * Updates whether or not IPC has been validated by the user this session
@@ -115,37 +116,14 @@ export abstract class BiometricStateService {
 }
 
 export class DefaultBiometricStateService implements BiometricStateService {
-  private biometricUnlockEnabledState: ActiveUserState<boolean>;
-  private encryptedClientKeyHalfState: ActiveUserState<EncryptedString>;
   private promptCancelledState: GlobalState<Record<UserId, boolean>>;
-  private promptAutomaticallyState: ActiveUserState<boolean>;
   private fingerprintValidatedState: GlobalState<boolean>;
   private lastProcessReloadState: GlobalState<Date>;
-  encryptedClientKeyHalf$: Observable<EncString | null>;
-  promptCancelled$: Observable<boolean>;
-  promptAutomatically$: Observable<boolean>;
   fingerprintValidated$: Observable<boolean>;
-  lastProcessReload$: Observable<Date | null>;
+  private lastProcessReload$: Observable<Date | null>;
 
   constructor(private stateProvider: StateProvider) {
-    this.biometricUnlockEnabledState = this.stateProvider.getActive(BIOMETRIC_UNLOCK_ENABLED);
-
-    this.encryptedClientKeyHalfState = this.stateProvider.getActive(ENCRYPTED_CLIENT_KEY_HALF);
-    this.encryptedClientKeyHalf$ = this.encryptedClientKeyHalfState.state$.pipe(
-      map(encryptedClientKeyHalfToEncString),
-    );
-
     this.promptCancelledState = this.stateProvider.getGlobal(PROMPT_CANCELLED);
-    this.promptCancelled$ = combineLatest([
-      this.stateProvider.activeUserId$,
-      this.promptCancelledState.state$,
-    ]).pipe(
-      map(([userId, record]) => {
-        return userId != null ? (record?.[userId] ?? false) : false;
-      }),
-    );
-    this.promptAutomaticallyState = this.stateProvider.getActive(PROMPT_AUTOMATICALLY);
-    this.promptAutomatically$ = this.promptAutomaticallyState.state$.pipe(map(Boolean));
 
     this.fingerprintValidatedState = this.stateProvider.getGlobal(FINGERPRINT_VALIDATED);
     this.fingerprintValidated$ = this.fingerprintValidatedState.state$.pipe(map(Boolean));
@@ -154,43 +132,39 @@ export class DefaultBiometricStateService implements BiometricStateService {
     this.lastProcessReload$ = this.lastProcessReloadState.state$;
   }
 
-  async setBiometricUnlockEnabled(enabled: boolean): Promise<void> {
-    await this.biometricUnlockEnabledState.update(() => enabled);
+  async setBiometricUnlockEnabled(enabled: boolean, userId: UserId): Promise<void> {
+    assertNonNullish(userId, "userId");
+    await this.stateProvider.getUser(userId, BIOMETRIC_UNLOCK_ENABLED).update(() => enabled);
   }
 
-  biometricUnlockEnabled$(userId?: UserId): Observable<boolean> {
-    if (userId != null) {
-      return this.stateProvider.getUser(userId, BIOMETRIC_UNLOCK_ENABLED).state$.pipe(map(Boolean));
-    }
-    // Backwards compatibility for active user state
-    // TODO remove with https://bitwarden.atlassian.net/browse/PM-12043
-    return this.biometricUnlockEnabledState.state$.pipe(map(Boolean));
+  biometricUnlockEnabled$(userId: UserId): Observable<boolean> {
+    assertNonNullish(userId, "userId");
+    return this.stateProvider.getUser(userId, BIOMETRIC_UNLOCK_ENABLED).state$.pipe(map(Boolean));
   }
 
   async getBiometricUnlockEnabled(userId: UserId): Promise<boolean> {
-    return await firstValueFrom(
-      this.stateProvider.getUser(userId, BIOMETRIC_UNLOCK_ENABLED).state$.pipe(map(Boolean)),
-    );
+    return await firstValueFrom(this.biometricUnlockEnabled$(userId));
   }
 
-  async setEncryptedClientKeyHalf(encryptedKeyHalf: EncString, userId?: UserId): Promise<void> {
+  async setEncryptedClientKeyHalf(encryptedKeyHalf: EncString, userId: UserId): Promise<void> {
+    assertNonNullish(userId, "userId");
     const value = encryptedKeyHalf?.encryptedString ?? null;
-    if (userId) {
-      await this.stateProvider.getUser(userId, ENCRYPTED_CLIENT_KEY_HALF).update(() => value);
-    } else {
-      await this.encryptedClientKeyHalfState.update(() => value);
-    }
+    await this.stateProvider.getUser(userId, ENCRYPTED_CLIENT_KEY_HALF).update(() => value);
+  }
+
+  encryptedClientKeyHalf$(userId: UserId): Observable<EncString | null> {
+    assertNonNullish(userId, "userId");
+    return this.stateProvider
+      .getUser(userId, ENCRYPTED_CLIENT_KEY_HALF)
+      .state$.pipe(map(encryptedClientKeyHalfToEncString));
   }
 
   async getEncryptedClientKeyHalf(userId: UserId): Promise<EncString | null> {
-    return await firstValueFrom(
-      this.stateProvider
-        .getUser(userId, ENCRYPTED_CLIENT_KEY_HALF)
-        .state$.pipe(map(encryptedClientKeyHalfToEncString)),
-    );
+    return await firstValueFrom(this.encryptedClientKeyHalf$(userId));
   }
 
   async getBiometricEnrolledKeyId(userId: UserId): Promise<string | null> {
+    assertNonNullish(userId, "userId");
     return await firstValueFrom(
       this.stateProvider
         .getUser(userId, BIOMETRIC_ENROLLED_KEY_ID)
@@ -199,60 +173,57 @@ export class DefaultBiometricStateService implements BiometricStateService {
   }
 
   async setBiometricEnrolledKeyId(userId: UserId, keyId: string | null): Promise<void> {
+    assertNonNullish(userId, "userId");
     await this.stateProvider.getUser(userId, BIOMETRIC_ENROLLED_KEY_ID).update(() => keyId);
   }
 
   async logout(userId: UserId): Promise<void> {
+    assertNonNullish(userId, "userId");
     await this.stateProvider.getUser(userId, ENCRYPTED_CLIENT_KEY_HALF).update(() => null);
     await this.resetUserPromptCancelled(userId);
-    // Persist auto prompt setting through logout
-    // Persist dismissed require password on start callout through logout
+  }
+
+  promptCancelled$(userId: UserId): Observable<boolean> {
+    assertNonNullish(userId, "userId");
+    return this.promptCancelledState.state$.pipe(map((record) => record?.[userId] ?? false));
   }
 
   async resetUserPromptCancelled(userId: UserId): Promise<void> {
-    await this.stateProvider.getGlobal(PROMPT_CANCELLED).update(
-      (data, activeUserId) => {
+    assertNonNullish(userId, "userId");
+    await this.promptCancelledState.update(
+      (data) => {
         if (data != null) {
-          delete data[userId ?? activeUserId];
+          delete data[userId];
         }
         return data;
       },
       {
-        combineLatestWith: this.stateProvider.activeUserId$,
-        shouldUpdate: (data, activeUserId) => data?.[userId ?? activeUserId] != null,
+        shouldUpdate: (data) => data?.[userId] != null,
       },
     );
   }
 
-  async setUserPromptCancelled(): Promise<void> {
-    await this.promptCancelledState.update(
-      (record, userId) => {
-        if (userId != null) {
-          record ??= {};
-          record[userId] = true;
-        }
-        return record;
-      },
-      {
-        combineLatestWith: this.stateProvider.activeUserId$,
-        shouldUpdate: (_, userId) => {
-          if (userId == null) {
-            throw new Error(
-              "Cannot update biometric prompt cancelled state without an active user",
-            );
-          }
-          return true;
-        },
-      },
-    );
+  async setUserPromptCancelled(userId: UserId): Promise<void> {
+    assertNonNullish(userId, "userId");
+    await this.promptCancelledState.update((record) => {
+      record ??= {};
+      record[userId] = true;
+      return record;
+    });
   }
 
   async resetAllPromptCancelled(): Promise<void> {
     await this.promptCancelledState.update(() => null);
   }
 
-  async setPromptAutomatically(prompt: boolean): Promise<void> {
-    await this.promptAutomaticallyState.update(() => prompt);
+  promptAutomatically$(userId: UserId): Observable<boolean> {
+    assertNonNullish(userId, "userId");
+    return this.stateProvider.getUser(userId, PROMPT_AUTOMATICALLY).state$.pipe(map(Boolean));
+  }
+
+  async setPromptAutomatically(prompt: boolean, userId: UserId): Promise<void> {
+    assertNonNullish(userId, "userId");
+    await this.stateProvider.getUser(userId, PROMPT_AUTOMATICALLY).update(() => prompt);
   }
 
   async setFingerprintValidated(validated: boolean): Promise<void> {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-12043

## 📔 Objective

Platform is deprecating ActiveUserState. Modify service to accept either a single userId that is locked in (for services that update data) or an observable UserId and switchMap to a SingleUserState.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
