### PR TITLE
[CL-1172] Improved non-color a11y for selected vs unselected nav items

### DIFF
--- a/libs/components/src/navigation/nav-item.component.html
+++ b/libs/components/src/navigation/nav-item.component.html
@@ -71,9 +71,11 @@
 <ng-template #anchorAndButtonContent>
   <div
     [title]="text()"
-    class="tw-gap-2 tw-py-0 tw-flex tw-items-center tw-font-medium tw-h-full"
+    class="tw-gap-2 tw-py-0 tw-flex tw-items-center tw-h-full"
     [class.tw-text-center]="!open"
     [class.tw-justify-center]="!open"
+    [class.tw-font-medium]="!showActiveStyles()"
+    [class.tw-font-semibold]="showActiveStyles()"
   >
     @if (icon()) {
       <bit-icon

--- a/libs/components/src/navigation/nav-item.component.html
+++ b/libs/components/src/navigation/nav-item.component.html
@@ -74,7 +74,7 @@
     class="tw-gap-2 tw-py-0 tw-flex tw-items-center tw-h-full"
     [class.tw-text-center]="!open"
     [class.tw-justify-center]="!open"
-    [class.tw-font-medium]="!showActiveStyles()"
+    [class.tw-font-normal]="!showActiveStyles()"
     [class.tw-font-semibold]="showActiveStyles()"
   >
     @if (icon()) {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[CL-1172](https://bitwarden.atlassian.net/browse/CL-1172)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Nav items should be medium font weight when inactive, and semibold when active. This provides a distinction other than color for indicating what item is active, which improves accessibility.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

| Before | After |
|--------|--------|
| <img width="692" height="461" alt="Screenshot 2026-05-26 at 11 49 07 AM" src="https://github.com/user-attachments/assets/22852a5d-e869-43e0-b77a-432d5c9fbec6" /> |  <img width="692" height="461" alt="Screenshot 2026-05-26 at 11 48 38 AM" src="https://github.com/user-attachments/assets/297443a0-8f88-4d5b-9433-2184d9fdd5a1" /> |


[CL-1172]: https://bitwarden.atlassian.net/browse/CL-1172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ