### PR TITLE
feat: add support for GlobalClient

### DIFF
--- a/libs/common/src/platform/services/sdk/default-sdk.service.ts
+++ b/libs/common/src/platform/services/sdk/default-sdk.service.ts
@@ -30,6 +30,7 @@ import {
   UnsignedSharedKey,
   WrappedAccountCryptographicState,
   Kdf,
+  GlobalPasswordManagerClient,
 } from "@bitwarden/sdk-internal";
 
 import { ApiService } from "../../../abstractions/api.service";
@@ -76,6 +77,7 @@ class JsTokenProvider implements TokenProvider {
 }
 
 export class DefaultSdkService implements SdkService {
+  private _globalClient?: GlobalPasswordManagerClient;
   private sdkClientOverrides = new BehaviorSubject<{
     [userId: UserId]: Rc<PasswordManagerClient> | typeof UnsetClient;
   }>({});
@@ -113,6 +115,15 @@ export class DefaultSdkService implements SdkService {
     private configService: ConfigService,
     private userAgent: string | null = null,
   ) {}
+
+  async globalClient(): Promise<GlobalPasswordManagerClient> {
+    if (!this._globalClient) {
+      await SdkLoadService.Ready;
+      this._globalClient = new GlobalPasswordManagerClient();
+    }
+
+    return this._globalClient;
+  }
 
   userClient$(userId: UserId): Observable<Rc<PasswordManagerClient>> {
     return this.sdkClientOverrides.pipe(


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

`GlobalClient` was added to the CLI to use as a new way of implementing global operations (non-user context). We never exposed it over WASM which makes it hard to recommend for cross-client functionality. This PR helps in closing that gap

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
