### PR TITLE
chore(platform): add FedRampGovRegion to client feature flag enum

### DIFF
--- a/libs/common/src/enums/feature-flag.enum.ts
+++ b/libs/common/src/enums/feature-flag.enum.ts
@@ -94,6 +94,7 @@ export enum FeatureFlag {
   PM34500_StrictCipherDecryption = "pm-34500-strict-cipher-decryption",
 
   /* Platform */
+  FedRampGovRegion = "fedramp-gov-region",
   ContentScriptIpcChannelFramework = "content-script-ipc-channel-framework",
   WebAuthnRelatedOrigins = "pm-30529-webauthn-related-origins",
   PM34410AttachmentUploadProgress = "pm-34410-attachment-upload-progress",
@@ -204,6 +205,7 @@ export const DefaultFeatureFlagValue = {
   [FeatureFlag.UnlockViaSDK]: FALSE,
 
   /* Platform */
+  [FeatureFlag.FedRampGovRegion]: FALSE,
   [FeatureFlag.ContentScriptIpcChannelFramework]: FALSE,
   [FeatureFlag.WebAuthnRelatedOrigins]: FALSE,
   [FeatureFlag.PM34410AttachmentUploadProgress]: FALSE,


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-35088
https://github.com/bitwarden/server/pull/7726
https://github.com/bitwarden/sdk-internal/pull/1144

## 📔 Objective

Declares FeatureFlag.FedRampGovRegion = "fedramp-gov-region" in the Platform section of the feature flag enum and sets its default to false in DefaultFeatureFlagValue. Aligns with the server-side FeatureFlagKeys.FedRampGovRegion constant added in the companion server task.
