### PR TITLE
fix(cli): harden bw serve origin-protection against DNS rebinding [PM-36600]

### DIFF
--- a/apps/cli/src/commands/serve.command.spec.ts
+++ b/apps/cli/src/commands/serve.command.spec.ts
@@ -1,0 +1,96 @@
+import { mock } from "jest-mock-extended";
+import type { Context, Next } from "koa";
+
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+
+import { buildOriginProtectionMiddleware, buildServeAllowedHosts } from "./serve.command";
+
+describe("buildOriginProtectionMiddleware", () => {
+  const logService = mock<LogService>();
+  const allowedHosts = new Set(["localhost:8087", "127.0.0.1:8087", "[::1]:8087"]);
+  const middleware = buildOriginProtectionMiddleware({
+    protectOrigin: true,
+    allowedHosts,
+    logService,
+  });
+
+  describe("when protectOrigin is true (default)", () => {
+    it("blocks request with a non-empty Origin header (cross-origin fetch)", async () => {
+      const ctx = mock<Context>({
+        headers: { host: "127.0.0.1:8087", origin: "https://evil.example" },
+      });
+      const next = jest.fn<Promise<void>, []>();
+
+      await middleware(ctx, next as unknown as Next);
+
+      expect(ctx.status).toBe(403);
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it("allows request with no Origin header and allowlisted Host", async () => {
+      const ctx = mock<Context>({ headers: { host: "127.0.0.1:8087", origin: undefined } });
+      const next = jest.fn<Promise<void>, []>().mockResolvedValue(undefined);
+
+      await middleware(ctx, next as unknown as Next);
+
+      expect(next).toHaveBeenCalled();
+      expect(ctx.status).not.toBe(403);
+    });
+
+    it("blocks DNS-rebound request with disallowed Host and no Origin (THE FIX)", async () => {
+      const ctx = mock<Context>({ headers: { host: "evil.example:8087", origin: undefined } });
+      const next = jest.fn<Promise<void>, []>();
+
+      await middleware(ctx, next as unknown as Next);
+
+      expect(ctx.status).toBe(403);
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it("performs case-insensitive Host comparison", async () => {
+      const ctx = mock<Context>({ headers: { host: "LOCALHOST:8087", origin: undefined } });
+      const next = jest.fn<Promise<void>, []>().mockResolvedValue(undefined);
+
+      await middleware(ctx, next as unknown as Next);
+
+      expect(next).toHaveBeenCalled();
+      expect(ctx.status).not.toBe(403);
+    });
+
+    it("blocks request with missing Host header (no host key)", async () => {
+      const ctx = mock<Context>({ headers: { host: undefined } });
+      const next = jest.fn<Promise<void>, []>();
+
+      await middleware(ctx, next as unknown as Next);
+
+      expect(ctx.status).toBe(403);
+      expect(next).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when protectOrigin is false (--disable-origin-protection)", () => {
+    it("passes through any request regardless of headers", async () => {
+      const passThrough = buildOriginProtectionMiddleware({
+        protectOrigin: false,
+        allowedHosts,
+        logService,
+      });
+      const ctx = mock<Context>({
+        headers: { host: "evil.example:8087", origin: "https://evil.example" },
+      });
+      const next = jest.fn<Promise<void>, []>().mockResolvedValue(undefined);
+
+      await passThrough(ctx, next as unknown as Next);
+
+      expect(next).toHaveBeenCalled();
+    });
+  });
+});
+
+describe("buildServeAllowedHosts", () => {
+  it("includes the configured hostname in the allowlist, normalized to lowercase", () => {
+    const hosts = buildServeAllowedHosts("BWApi.MyDomain.COM", 80);
+    expect(hosts.has("bwapi.mydomain.com:80")).toBe(true);
+    expect(hosts.has("BWApi.MyDomain.COM:80")).toBe(false);
+  });
+});

--- a/apps/cli/src/commands/serve.command.spec.ts
+++ b/apps/cli/src/commands/serve.command.spec.ts
@@ -85,6 +85,36 @@ describe("buildOriginProtectionMiddleware", () => {
       expect(next).toHaveBeenCalled();
     });
   });
+
+  describe("when allowedHosts is null (--hostname all)", () => {
+    const hostAllowlistDisabled = buildOriginProtectionMiddleware({
+      protectOrigin: true,
+      allowedHosts: null,
+      logService,
+    });
+
+    it("allows request with arbitrary Host and no Origin (Layer 1 disabled)", async () => {
+      const ctx = mock<Context>({ headers: { host: "192.168.1.5:8087", origin: undefined } });
+      const next = jest.fn<Promise<void>, []>().mockResolvedValue(undefined);
+
+      await hostAllowlistDisabled(ctx, next as unknown as Next);
+
+      expect(next).toHaveBeenCalled();
+      expect(ctx.status).not.toBe(403);
+    });
+
+    it("still blocks disallowed Origin (Layer 2 remains active)", async () => {
+      const ctx = mock<Context>({
+        headers: { host: "192.168.1.5:8087", origin: "https://evil.example" },
+      });
+      const next = jest.fn<Promise<void>, []>();
+
+      await hostAllowlistDisabled(ctx, next as unknown as Next);
+
+      expect(ctx.status).toBe(403);
+      expect(next).not.toHaveBeenCalled();
+    });
+  });
 });
 
 describe("buildServeAllowedHosts", () => {
@@ -92,5 +122,37 @@ describe("buildServeAllowedHosts", () => {
     const hosts = buildServeAllowedHosts("BWApi.MyDomain.COM", 80);
     expect(hosts.has("bwapi.mydomain.com:80")).toBe(true);
     expect(hosts.has("BWApi.MyDomain.COM:80")).toBe(false);
+    // Port 80 is the http default; bare-host form must also be present
+    expect(hosts.has("bwapi.mydomain.com")).toBe(true);
+  });
+
+  it("adds bare-host entries when port is 80 (http default)", () => {
+    const hosts = buildServeAllowedHosts("bwapi.example", 80);
+    expect(hosts.has("bwapi.example:80")).toBe(true);
+    expect(hosts.has("bwapi.example")).toBe(true);
+    expect(hosts.has("localhost")).toBe(true);
+    expect(hosts.has("127.0.0.1")).toBe(true);
+    expect(hosts.has("[::1]")).toBe(true);
+  });
+
+  it("adds bare-host entries when port is 443 (https default)", () => {
+    const hosts = buildServeAllowedHosts("bwapi.example", 443);
+    expect(hosts.has("bwapi.example:443")).toBe(true);
+    expect(hosts.has("bwapi.example")).toBe(true);
+    expect(hosts.has("localhost")).toBe(true);
+    expect(hosts.has("127.0.0.1")).toBe(true);
+    expect(hosts.has("[::1]")).toBe(true);
+  });
+
+  it("does NOT add bare-host entries for non-default ports", () => {
+    const hosts = buildServeAllowedHosts("bwapi.example", 8087);
+    expect(hosts.has("bwapi.example:8087")).toBe(true);
+    expect(hosts.has("localhost:8087")).toBe(true);
+    expect(hosts.has("127.0.0.1:8087")).toBe(true);
+    expect(hosts.has("[::1]:8087")).toBe(true);
+    expect(hosts.has("bwapi.example")).toBe(false);
+    expect(hosts.has("localhost")).toBe(false);
+    expect(hosts.has("127.0.0.1")).toBe(false);
+    expect(hosts.has("[::1]")).toBe(false);
   });
 });

--- a/apps/cli/src/commands/serve.command.ts
+++ b/apps/cli/src/commands/serve.command.ts
@@ -83,7 +83,7 @@ export class ServeCommand {
 
   async run(options: OptionValues) {
     const protectOrigin = !options.disableOriginProtection;
-    const port = options.port || 8087;
+    const port = Number(options.port) || 8087;
     const hostname = options.hostname || "localhost";
     this.serviceContainer.logService.info(
       `Starting server on ${hostname}:${port} with ${

--- a/apps/cli/src/commands/serve.command.ts
+++ b/apps/cli/src/commands/serve.command.ts
@@ -15,11 +15,16 @@ import { OssServeConfigurator } from "../oss-serve-configurator";
 import { ServiceContainer } from "../service-container/service-container";
 
 export function buildServeAllowedHosts(hostname: string, port: number): Set<string> {
-  return new Set(
-    [`localhost:${port}`, `127.0.0.1:${port}`, `[::1]:${port}`, `${hostname}:${port}`].map(
-      (entry) => entry.toLowerCase(),
-    ),
-  );
+  const entries = [
+    `localhost:${port}`,
+    `127.0.0.1:${port}`,
+    `[::1]:${port}`,
+    `${hostname}:${port}`,
+  ];
+  if (port === 80 || port === 443) {
+    entries.push("localhost", "127.0.0.1", "[::1]", hostname);
+  }
+  return new Set(entries.map((entry) => entry.toLowerCase()));
 }
 
 function rejectIfHostNotAllowed(
@@ -50,13 +55,16 @@ function rejectIfOriginPresent(ctx: Context, logService: LogService): boolean {
 
 export function buildOriginProtectionMiddleware(opts: {
   protectOrigin: boolean;
-  allowedHosts: ReadonlySet<string>;
+  allowedHosts: ReadonlySet<string> | null;
   logService: LogService;
 }): (ctx: Context, next: Next) => Promise<void> {
   return async (ctx, next) => {
     if (opts.protectOrigin) {
       // Guards are independent; order does not affect correctness.
-      if (rejectIfHostNotAllowed(ctx, opts.allowedHosts, opts.logService)) {
+      if (
+        opts.allowedHosts !== null &&
+        rejectIfHostNotAllowed(ctx, opts.allowedHosts, opts.logService)
+      ) {
         return;
       }
       if (rejectIfOriginPresent(ctx, opts.logService)) {
@@ -83,11 +91,9 @@ export class ServeCommand {
       }`,
     );
 
-    // Allowlist of Host header values that identify legitimate same-origin
-    // requests to the loopback interface. Any other Host value indicates a
-    // DNS-rebinding attack (the browser has rebound an attacker-controlled
-    // name to 127.0.0.1/::1 and is sending the attacker's hostname in Host).
-    const ALLOWED_HOSTS = buildServeAllowedHosts(hostname, port);
+    // `--hostname all` binds every interface, so a LAN client may legitimately
+    // reach the server via any local IP.
+    const ALLOWED_HOSTS = hostname === "all" ? null : buildServeAllowedHosts(hostname, port);
 
     const server = new koa();
     const router = new Router();

--- a/apps/cli/src/commands/serve.command.ts
+++ b/apps/cli/src/commands/serve.command.ts
@@ -4,13 +4,68 @@ import net from "node:net";
 import { Router } from "@koa/router";
 import { OptionValues } from "commander";
 import * as koa from "koa";
+import type { Context, Next } from "koa";
 import * as koaBodyParser from "koa-bodyparser";
 import * as koaJson from "koa-json";
 
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
 
 import { OssServeConfigurator } from "../oss-serve-configurator";
 import { ServiceContainer } from "../service-container/service-container";
+
+export function buildServeAllowedHosts(hostname: string, port: number): Set<string> {
+  return new Set(
+    [`localhost:${port}`, `127.0.0.1:${port}`, `[::1]:${port}`, `${hostname}:${port}`].map(
+      (entry) => entry.toLowerCase(),
+    ),
+  );
+}
+
+function rejectIfHostNotAllowed(
+  ctx: Context,
+  allowedHosts: ReadonlySet<string>,
+  logService: LogService,
+): boolean {
+  if (allowedHosts.has((ctx.headers.host ?? "").toLowerCase())) {
+    return false;
+  }
+  ctx.status = 403;
+  logService.warning(`Blocking request with disallowed Host "${ctx.headers.host ?? "(missing)"}"`);
+  return true;
+}
+
+function rejectIfOriginPresent(ctx: Context, logService: LogService): boolean {
+  if (ctx.headers.origin === undefined) {
+    return false;
+  }
+  ctx.status = 403;
+  logService.warning(
+    `Blocking request from "${
+      Utils.isNullOrEmpty(ctx.headers.origin) ? "(Origin header value missing)" : ctx.headers.origin
+    }"`,
+  );
+  return true;
+}
+
+export function buildOriginProtectionMiddleware(opts: {
+  protectOrigin: boolean;
+  allowedHosts: ReadonlySet<string>;
+  logService: LogService;
+}): (ctx: Context, next: Next) => Promise<void> {
+  return async (ctx, next) => {
+    if (opts.protectOrigin) {
+      // Guards are independent; order does not affect correctness.
+      if (rejectIfHostNotAllowed(ctx, opts.allowedHosts, opts.logService)) {
+        return;
+      }
+      if (rejectIfOriginPresent(ctx, opts.logService)) {
+        return;
+      }
+    }
+    await next();
+  };
+}
 
 export class ServeCommand {
   constructor(
@@ -28,26 +83,25 @@ export class ServeCommand {
       }`,
     );
 
+    // Allowlist of Host header values that identify legitimate same-origin
+    // requests to the loopback interface. Any other Host value indicates a
+    // DNS-rebinding attack (the browser has rebound an attacker-controlled
+    // name to 127.0.0.1/::1 and is sending the attacker's hostname in Host).
+    const ALLOWED_HOSTS = buildServeAllowedHosts(hostname, port);
+
     const server = new koa();
     const router = new Router();
     process.env.BW_SERVE = "true";
     process.env.BW_NOINTERACTION = "true";
 
     server
-      .use(async (ctx, next) => {
-        if (protectOrigin && ctx.headers.origin != undefined) {
-          ctx.status = 403;
-          this.serviceContainer.logService.warning(
-            `Blocking request from "${
-              Utils.isNullOrEmpty(ctx.headers.origin)
-                ? "(Origin header value missing)"
-                : ctx.headers.origin
-            }"`,
-          );
-          return;
-        }
-        await next();
-      })
+      .use(
+        buildOriginProtectionMiddleware({
+          protectOrigin,
+          allowedHosts: ALLOWED_HOSTS,
+          logService: this.serviceContainer.logService,
+        }),
+      )
       .use(koaBodyParser())
       .use(koaJson({ pretty: false, param: "pretty" }));
 


### PR DESCRIPTION
## Tracking

[PM-36600](https://bitwarden.atlassian.net/browse/PM-36600)

## Objective

`bw serve` runs an unauthenticated local HTTP API and was protected only by an `Origin`-header presence check. Browsers omit `Origin` on same-origin GETs, so any DNS-rebinding attack, where a malicious page rebinds its own domain to `127.0.0.1`, sends `Host: evil.example:8087` with no `Origin`, and the original middleware passed those requests through. 

This is fixed over two layers

1. Reject any request whose `Host` header isn't in `{localhost:PORT, 127.0.0.1:PORT, [::1]:PORT, <configured-hostname>:PORT}`. DNS-rebound requests carry the attacker's hostname in `Host`, so this catches them. Bare-host forms are also accepted when PORT is 80 or 443 (clients omit the default port per RFC 7230 §5.4); the allowlist is disabled when `--hostname all` is passed and Layer 2 alone applies.
2. Reject any request that carries an `Origin` header. We are already doing this today.

The allowlist construction (`buildServeAllowedHosts`) and the middleware factory (`buildOriginProtectionMiddleware`) are extracted into pure, exported functions for unit testing.


[PM-36600]: https://bitwarden.atlassian.net/browse/PM-36600?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
