### PR TITLE
[PM-23564] Item view shows removed attachment/does not show added attachment temporarily

### DIFF
--- a/libs/vault/src/vault-item-dialog/vault-item-dialog.component.spec.ts
+++ b/libs/vault/src/vault-item-dialog/vault-item-dialog.component.spec.ts
@@ -449,6 +449,60 @@ describe("VaultItemDialogComponent", () => {
 
       expect(close).toHaveBeenCalledWith(VaultItemDialogResult.Saved);
     });
+
+    describe("from form mode", () => {
+      beforeEach(() => {
+        component.setTestCipher({ id: "cipher-id", collectionIds: [] } as any);
+        component.setTestParams({ mode: "form" });
+        component.setTestFormConfig({ mode: "edit" });
+        jest.spyOn(component as any, "changeMode").mockResolvedValue(undefined);
+      });
+
+      it("refreshes the cipher from local state and switches to view mode", async () => {
+        const latestCipher = { id: "cipher-id" } as any;
+        const refreshedCipherView = { id: "cipher-id", attachments: [] } as any;
+        cipherServiceMock.get.mockResolvedValue(latestCipher);
+        cipherServiceMock.decrypt.mockResolvedValue(refreshedCipherView);
+
+        await component.cancel();
+
+        expect(cipherServiceMock.get).toHaveBeenCalledWith("cipher-id", "test-user-id");
+        expect(cipherServiceMock.decrypt).toHaveBeenCalledWith(latestCipher, "test-user-id");
+        expect(component["cipher"]).toBe(refreshedCipherView);
+        expect((component as any).changeMode).toHaveBeenCalledWith("view");
+      });
+
+      it("leaves the existing cipher in place when local state has no cipher", async () => {
+        const originalCipher = component["cipher"];
+        cipherServiceMock.get.mockResolvedValue(null as any);
+
+        await component.cancel();
+
+        expect(cipherServiceMock.decrypt).not.toHaveBeenCalled();
+        expect(component["cipher"]).toBe(originalCipher);
+        expect((component as any).changeMode).toHaveBeenCalledWith("view");
+      });
+
+      it("does not refresh and closes the dialog when formConfig mode is clone", async () => {
+        component.setTestFormConfig({ mode: "clone" });
+
+        await component.cancel();
+
+        expect(cipherServiceMock.get).not.toHaveBeenCalled();
+        expect((component as any).changeMode).not.toHaveBeenCalled();
+        expect(close).toHaveBeenCalledWith(undefined);
+      });
+    });
+
+    it("does not refresh the cipher when in view mode", async () => {
+      component.setTestCipher({ id: "cipher-id" } as any);
+      component.setTestParams({ mode: "view" });
+
+      await component.cancel();
+
+      expect(cipherServiceMock.get).not.toHaveBeenCalled();
+      expect(close).toHaveBeenCalledWith(undefined);
+    });
   });
 
   describe("static open()", () => {

--- a/libs/vault/src/vault-item-dialog/vault-item-dialog.component.ts
+++ b/libs/vault/src/vault-item-dialog/vault-item-dialog.component.ts
@@ -574,6 +574,13 @@ export class VaultItemDialogComponent implements OnInit, OnDestroy {
       return;
     }
 
+    // Refresh from local state so attachments modified during edit aren't stale in view mode.
+    const activeUserId = await firstValueFrom(this.userId$);
+    const latestCipher = await this.cipherService.get(this.cipher.id, activeUserId);
+    if (latestCipher != null) {
+      this.cipher = await this.cipherService.decrypt(latestCipher, activeUserId);
+    }
+
     // We're in Form mode, and we have a cipher, switch back to View mode.
     await this.changeMode("view");
   };


### PR DESCRIPTION
## 🎟️ Tracking

[Jira](https://bitwarden.atlassian.net/browse/PM-23564)

## 📔 Objective

Make the cipher view include changes to attachments when canceling out of the edit form.

https://github.com/user-attachments/assets/09eed0d6-04ed-4638-94fa-4f2c75ae067f


