### PR TITLE
refactor(platform): migrate Region enum to const object per ADR-0025

### DIFF
--- a/libs/auth/src/angular/registration/registration-env-selector/registration-env-selector.component.ts
+++ b/libs/auth/src/angular/registration/registration-env-selector/registration-env-selector.component.ts
@@ -35,12 +35,14 @@ import { SelfHostedEnvConfigDialogComponent } from "../../self-hosted-env-config
 export class RegistrationEnvSelectorComponent implements OnInit, OnDestroy {
   // FIXME(https://bitwarden.atlassian.net/browse/CL-903): Migrate to Signals
   // eslint-disable-next-line @angular-eslint/prefer-output-emitter-ref
-  @Output() selectedRegionChange = new EventEmitter<RegionConfig | Region.SelfHosted | null>();
+  @Output() selectedRegionChange = new EventEmitter<
+    RegionConfig | typeof Region.SelfHosted | null
+  >();
 
   ServerEnvironmentType = Region;
 
   formGroup = this.formBuilder.group({
-    selectedRegion: [null as RegionConfig | Region.SelfHosted | null, Validators.required],
+    selectedRegion: [null as RegionConfig | typeof Region.SelfHosted | null, Validators.required],
   });
 
   get selectedRegion(): FormControl {
@@ -49,7 +51,7 @@ export class RegistrationEnvSelectorComponent implements OnInit, OnDestroy {
 
   availableRegionConfigs: RegionConfig[] = this.environmentService.availableRegions();
 
-  private selectedRegionFromEnv: RegionConfig | Region.SelfHosted;
+  private selectedRegionFromEnv: RegionConfig | typeof Region.SelfHosted;
 
   hideEnvSelector = false;
   isDesktopOrBrowserExtension = false;
@@ -96,7 +98,7 @@ export class RegistrationEnvSelectorComponent implements OnInit, OnDestroy {
 
           return regionConfig;
         }),
-        tap((selectedRegionFromEnv: RegionConfig | Region.SelfHosted) => {
+        tap((selectedRegionFromEnv: RegionConfig | typeof Region.SelfHosted) => {
           // Only set the value if it is different from the current value.
           if (selectedRegionFromEnv !== this.selectedRegion.value) {
             // Don't emit to avoid triggering the selectedRegion valueChanges subscription
@@ -126,8 +128,8 @@ export class RegistrationEnvSelectorComponent implements OnInit, OnDestroy {
         pairwise(),
         switchMap(
           ([prevSelectedRegion, selectedRegion]: [
-            RegionConfig | Region.SelfHosted | null,
-            RegionConfig | Region.SelfHosted | null,
+            RegionConfig | typeof Region.SelfHosted | null,
+            RegionConfig | typeof Region.SelfHosted | null,
           ]) => {
             if (selectedRegion === null) {
               this.selectedRegionChange.emit(selectedRegion);
@@ -149,7 +151,7 @@ export class RegistrationEnvSelectorComponent implements OnInit, OnDestroy {
 
   private handleSelfHostedEnvConfigDialogResult(
     result: boolean | undefined,
-    prevSelectedRegion: RegionConfig | Region.SelfHosted | null,
+    prevSelectedRegion: RegionConfig | typeof Region.SelfHosted | null,
   ) {
     if (result === true) {
       this.selectedRegionChange.emit(Region.SelfHosted);

--- a/libs/auth/src/angular/registration/registration-start/registration-start.component.ts
+++ b/libs/auth/src/angular/registration/registration-start/registration-start.component.ts
@@ -129,7 +129,7 @@ export class RegistrationStartComponent implements OnInit, OnDestroy {
     });
   }
 
-  setReceiveMarketingEmailsByRegion(region: RegionConfig | Region.SelfHosted) {
+  setReceiveMarketingEmailsByRegion(region: RegionConfig | typeof Region.SelfHosted) {
     let defaultValue;
     if (region === Region.SelfHosted) {
       defaultValue = DEFAULT_MARKETING_EMAILS_PREF_BY_REGION[region];
@@ -179,7 +179,7 @@ export class RegistrationStartComponent implements OnInit, OnDestroy {
     this.registrationStartStateChange.emit(this.state);
   };
 
-  handleSelectedRegionChange(region: RegionConfig | Region.SelfHosted | null) {
+  handleSelectedRegionChange(region: RegionConfig | typeof Region.SelfHosted | null) {
     this.isSelfHost = region === Region.SelfHosted;
 
     if (region !== null) {

--- a/libs/common/src/platform/abstractions/environment.service.ts
+++ b/libs/common/src/platform/abstractions/environment.service.ts
@@ -17,18 +17,22 @@ export type Urls = {
 /**
  * A subset of available regions, additional regions can be loaded through configuration.
  */
-// FIXME: update to use a const object instead of a typescript enum
-// eslint-disable-next-line @bitwarden/platform/no-enums
-export enum Region {
-  US = "US",
-  EU = "EU",
-  SelfHosted = "Self-hosted",
-}
+const _Region = Object.freeze({
+  US: "US",
+  EU: "EU",
+  SelfHosted: "Self-hosted",
+} as const);
+
+type _Region = typeof _Region;
+
+export type Region = _Region[keyof _Region];
+
+export const Region = _Region satisfies Record<keyof _Region, Region>;
 
 /**
  * The possible cloud regions.
  */
-export type CloudRegion = Exclude<Region, Region.SelfHosted>;
+export type CloudRegion = Exclude<Region, typeof Region.SelfHosted>;
 
 export type RegionConfig = {
   // Beware this isn't completely true, it's actually a string for custom environments,


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-35090

## 📔 Objective

Replaces the Region TypeScript enum with a const-object per [ADR-0025](https://contributing.bitwarden.com/contributing/code-style/web/typescript#avoid-typescript-enums). This required dipping in to consumer code to change how the type value of the options are referenced. 
