### PR TITLE
[PM-38165] Limit Send Email character length 

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -4398,6 +4398,9 @@
   "multipleInputEmails": {
     "message": "1 or more emails are invalid"
   },
+  "sendEmailsCharacterLimitReached": {
+    "message": "Email recipient list cannot exceed 2,500 characters. Remove one or more recipients to continue."
+  },
   "inputTrimValidator": {
     "message": "Input must not contain only whitespace.",
     "description": "Notification to inform the user that a form's input can't contain only whitespace."

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -3882,6 +3882,9 @@
   "multipleInputEmails": {
     "message": "1 or more emails are invalid"
   },
+  "sendEmailsCharacterLimitReached": {
+    "message": "Email recipient list cannot exceed 2,500 characters. Remove one or more recipients to continue."
+  },
   "inputTrimValidator": {
     "message": "Input must not contain only whitespace.",
     "description": "Notification to inform the user that a form's input can't contain only whitespace."

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -8927,6 +8927,9 @@
   "multipleInputEmails": {
     "message": "1 or more emails are invalid"
   },
+  "sendEmailsCharacterLimitReached": {
+    "message": "Email recipient list cannot exceed 2,500 characters. Remove one or more recipients to continue."
+  },
   "tooManyEmails": {
     "message": "You can only submit up to $COUNT$ emails at a time",
     "placeholders": {

--- a/libs/tools/send/send-ui/src/send-form/components/send-details/send-details.component.html
+++ b/libs/tools/send/send-ui/src/send-form/components/send-details/send-details.component.html
@@ -131,6 +131,7 @@
           bitInput
           formControlName="emails"
           rows="3"
+          maxlength="2500"
           [placeholder]="'emailPlaceholderMultiple' | i18n"
           [readonly]="!editing()"
         ></textarea>

--- a/libs/tools/send/send-ui/src/send-form/components/send-details/send-details.component.ts
+++ b/libs/tools/send/send-ui/src/send-form/components/send-details/send-details.component.ts
@@ -259,6 +259,17 @@ export class SendDetailsComponent implements OnInit {
         passwordControl.updateValueAndValidity();
       });
 
+    const emailsControl = this.sendDetailsForm.get("emails");
+    emailsControl.valueChanges.pipe(takeUntilDestroyed()).subscribe((value) => {
+      if (typeof value === "string" && value.length >= 2500) {
+        // bitInput's input handler marks the control untouched on every keystroke
+        // (input.directive.ts), which hides bit-error. Defer to the next macrotask
+        // so markAsTouched lands after that, surfacing the cap-reached error while
+        // the user is still in the field.
+        setTimeout(() => emailsControl.markAsTouched(), 0);
+      }
+    });
+
     this.sendFormService.registerChildForm("sendDetailsForm", this.sendDetailsForm);
   }
 

--- a/libs/tools/send/send-ui/src/send-form/components/send-details/send-details.component.ts
+++ b/libs/tools/send/send-ui/src/send-form/components/send-details/send-details.component.ts
@@ -244,7 +244,11 @@ export class SendDetailsComponent implements OnInit {
         } else if (type === AuthType.Email) {
           passwordControl.setValue(null);
           passwordControl.clearValidators();
-          emailsControl.setValidators([Validators.required, this.emailListValidator()]);
+          emailsControl.setValidators([
+            Validators.required,
+            Validators.maxLength(2500),
+            this.emailListValidator(),
+          ]);
         } else {
           emailsControl.setValue(null);
           emailsControl.clearValidators();

--- a/libs/tools/send/send-ui/src/send-form/components/send-details/send-details.component.ts
+++ b/libs/tools/send/send-ui/src/send-form/components/send-details/send-details.component.ts
@@ -246,7 +246,7 @@ export class SendDetailsComponent implements OnInit {
           passwordControl.clearValidators();
           emailsControl.setValidators([
             Validators.required,
-            Validators.maxLength(2500),
+            this.emailsMaxLengthValidator(),
             this.emailListValidator(),
           ]);
         } else {
@@ -353,6 +353,19 @@ export class SendDetailsComponent implements OnInit {
       const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
       const invalidEmails = nonEmptyEmails.filter((e: string) => !emailRegex.test(e));
       return invalidEmails.length > 0 ? { multipleEmails: true } : null;
+    };
+  }
+
+  emailsMaxLengthValidator(): ValidatorFn {
+    return (control: FormControl): ValidationErrors | null => {
+      if (typeof control.value !== "string" || control.value.length < 2500) {
+        return null;
+      }
+      return {
+        emailsMaxLength: {
+          message: this.i18nService.t("sendEmailsCharacterLimitReached"),
+        },
+      };
     };
   }
 


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-38165

## 📔 Objective
This PR introduces a limit on the number of characters a Send owner is able to enter into the `Emails` field on an email verified Send to 2,500 characters or less. 

See companion `server` PR [for additional details and rationale](https://github.com/bitwarden/server/pull/7734). 

## 📷  Screenshots
<img width="514" height="799" alt="Screenshot 2026-05-28 at 07 32 07" src="https://github.com/user-attachments/assets/678654a0-9df3-4ebe-b7ec-b448947860d7" />

