### PR TITLE
[PM-38113] In AC, when item filter is selected and user add new item, it does not default the creation form to selected item type

### DIFF
--- a/apps/web/src/app/admin-console/organizations/collections/services/vault-cipher-actions.service.spec.ts
+++ b/apps/web/src/app/admin-console/organizations/collections/services/vault-cipher-actions.service.spec.ts
@@ -2,7 +2,7 @@ import { EnvironmentInjector, runInInjectionContext } from "@angular/core";
 import { TestBed } from "@angular/core/testing";
 import { Router } from "@angular/router";
 import { mock, MockProxy } from "jest-mock-extended";
-import { of, Subject } from "rxjs";
+import { BehaviorSubject, of, Subject } from "rxjs";
 
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { CollectionAdminView } from "@bitwarden/common/admin-console/models/collections";
@@ -17,6 +17,7 @@ import { mockAccountServiceWith } from "@bitwarden/common/spec";
 import { CipherId, CollectionId, OrganizationId, UserId } from "@bitwarden/common/types/guid";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { TotpService } from "@bitwarden/common/vault/abstractions/totp.service";
+import { CipherType } from "@bitwarden/common/vault/enums";
 import { CipherRepromptType } from "@bitwarden/common/vault/enums/cipher-reprompt-type";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { DialogRef, DialogService, ToastService } from "@bitwarden/components";
@@ -100,6 +101,7 @@ describe("VaultCipherActionsService", () => {
   let refresh: jest.Mock;
   let navigate: jest.Mock;
   let mockFormConfig: CipherFormConfig;
+  let activeFilterSubject: BehaviorSubject<VaultFilter>;
 
   function initService(org = organization) {
     organizationService.organizations$.mockReturnValue(of([org]));
@@ -138,6 +140,9 @@ describe("VaultCipherActionsService", () => {
     organization = buildOrg();
     refresh = jest.fn();
     navigate = jest.fn();
+    activeFilterSubject = new BehaviorSubject({
+      collectionId: "col-1" as CollectionId,
+    } as unknown as VaultFilter);
 
     TestBed.configureTestingModule({
       providers: [
@@ -166,11 +171,7 @@ describe("VaultCipherActionsService", () => {
         },
         {
           provide: RoutedVaultFilterBridgeService,
-          useValue: {
-            activeFilter$: of({
-              collectionId: "col-1" as CollectionId,
-            } as unknown as VaultFilter),
-          },
+          useValue: { activeFilter$: activeFilterSubject.asObservable() },
         },
         {
           provide: VaultCollectionService,
@@ -253,6 +254,63 @@ describe("VaultCipherActionsService", () => {
       await service.editCipherAttachments(cipher);
 
       expect(refresh).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("addCipher", () => {
+    beforeEach(() => {
+      jest.spyOn(VaultItemDialogComponent, "open").mockReturnValue(makeDialogRef(undefined));
+    });
+
+    it("passes the explicit cipherType to buildConfig when one is provided", async () => {
+      await service.addCipher(CipherType.Card);
+
+      expect(cipherFormConfigService.buildConfig).toHaveBeenCalledWith(
+        "add",
+        undefined,
+        CipherType.Card,
+      );
+    });
+
+    it("falls back to activeFilter.cipherType when no cipherType is provided", async () => {
+      activeFilterSubject.next({
+        cipherType: CipherType.Login,
+        collectionId: "col-1" as CollectionId,
+      } as unknown as VaultFilter);
+
+      await service.addCipher();
+
+      expect(cipherFormConfigService.buildConfig).toHaveBeenCalledWith(
+        "add",
+        undefined,
+        CipherType.Login,
+      );
+    });
+
+    it("prefers the explicit cipherType over activeFilter.cipherType when both are set", async () => {
+      activeFilterSubject.next({
+        cipherType: CipherType.Login,
+        collectionId: "col-1" as CollectionId,
+      } as unknown as VaultFilter);
+
+      await service.addCipher(CipherType.SecureNote);
+
+      expect(cipherFormConfigService.buildConfig).toHaveBeenCalledWith(
+        "add",
+        undefined,
+        CipherType.SecureNote,
+      );
+    });
+
+    it("passes the falsy activeFilter.cipherType through when neither source has a type", async () => {
+      activeFilterSubject.next({
+        cipherType: null,
+        collectionId: "col-1" as CollectionId,
+      } as unknown as VaultFilter);
+
+      await service.addCipher();
+
+      expect(cipherFormConfigService.buildConfig).toHaveBeenCalledWith("add", undefined, null);
     });
   });
 

--- a/apps/web/src/app/admin-console/organizations/collections/services/vault-cipher-actions.service.ts
+++ b/apps/web/src/app/admin-console/organizations/collections/services/vault-cipher-actions.service.ts
@@ -144,13 +144,10 @@ export class VaultCipherActionsService {
 
   /** Opens the Add/Edit Dialog */
   async addCipher(cipherType?: CipherType): Promise<void> {
-    const cipherFormConfig = await this.cipherFormConfigService.buildConfig(
-      "add",
-      undefined,
-      cipherType,
-    );
-
     const activeFilter = await firstValueFrom(this.activeFilter$);
+    const type = cipherType ?? activeFilter.cipherType;
+    const cipherFormConfig = await this.cipherFormConfigService.buildConfig("add", undefined, type);
+
     const collectionId: CollectionId | undefined = activeFilter.collectionId as CollectionId;
 
     const organization = await firstValueFrom(this.organization$);

--- a/apps/web/src/app/admin-console/organizations/collections/vault.component.spec.ts
+++ b/apps/web/src/app/admin-console/organizations/collections/vault.component.spec.ts
@@ -23,9 +23,11 @@ import { OrganizationId, UserId } from "@bitwarden/common/types/guid";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { SearchService } from "@bitwarden/common/vault/abstractions/search.service";
 import { TotpService } from "@bitwarden/common/vault/abstractions/totp.service";
+import { CipherType } from "@bitwarden/common/vault/enums";
 import { RestrictedItemTypesService } from "@bitwarden/common/vault/services/restricted-item-types.service";
-import { DialogService, ToastService } from "@bitwarden/components";
+import { DialogRef, DialogService, ToastService } from "@bitwarden/components";
 import {
+  CipherFormConfig,
   CipherFormConfigService,
   PasswordRepromptService,
   RoutedVaultFilterBridgeService,
@@ -33,6 +35,8 @@ import {
   RoutedVaultFilterService,
   VaultFilter,
   VaultFilterServiceAbstraction,
+  VaultItemDialogComponent,
+  VaultItemDialogResult,
 } from "@bitwarden/vault";
 
 import { OrganizationWarningsService } from "../../../billing/organizations/warnings/services";
@@ -67,6 +71,7 @@ describe("VaultComponent (org-vault)", () => {
   /** Controls which organization the routed filter resolves to. */
   let filterSubject: BehaviorSubject<Partial<RoutedVaultFilterModel>>;
   let cipherService: MockProxy<CipherService>;
+  let cipherFormConfigService: MockProxy<CipherFormConfigService>;
 
   beforeEach(async () => {
     filterSubject = new BehaviorSubject<Partial<RoutedVaultFilterModel>>({
@@ -77,6 +82,8 @@ describe("VaultComponent (org-vault)", () => {
 
     cipherService = mock<CipherService>();
     cipherService.getAllFromApiForOrganization.mockResolvedValue([]);
+
+    cipherFormConfigService = mock<CipherFormConfigService>();
 
     const collectionAdminService = mock<CollectionAdminService>();
     // Return an empty array so allCollectionsWithoutUnassigned$ settles immediately.
@@ -156,7 +163,7 @@ describe("VaultComponent (org-vault)", () => {
               provide: RoutedVaultFilterBridgeService,
               useValue: { activeFilter$: of(new VaultFilter()) },
             },
-            { provide: CipherFormConfigService, useValue: mock<CipherFormConfigService>() },
+            { provide: CipherFormConfigService, useValue: cipherFormConfigService },
           ],
         },
       })
@@ -233,6 +240,51 @@ describe("VaultComponent (org-vault)", () => {
         expect(cipherService.getAllFromApiForOrganization.mock.calls.length).toBe(callsBefore);
         expect((component as any).refreshingSubject$.getValue()).toBe(false);
       });
+    });
+  });
+
+  describe("addCipher", () => {
+    beforeEach(() => {
+      cipherFormConfigService.buildConfig.mockResolvedValue({} as CipherFormConfig);
+      jest
+        .spyOn(VaultItemDialogComponent, "open")
+        .mockReturnValue({ closed: of(undefined) } as unknown as DialogRef<
+          VaultItemDialogResult | undefined
+        >);
+    });
+
+    it("passes the explicit cipherType to buildConfig when one is provided", async () => {
+      await component.addCipher(CipherType.Card);
+
+      expect(cipherFormConfigService.buildConfig).toHaveBeenCalledWith(
+        "add",
+        undefined,
+        CipherType.Card,
+      );
+    });
+
+    it("falls back to activeFilter.cipherType when no cipherType is provided", async () => {
+      component.activeFilter = { cipherType: CipherType.Login } as unknown as VaultFilter;
+
+      await component.addCipher();
+
+      expect(cipherFormConfigService.buildConfig).toHaveBeenCalledWith(
+        "add",
+        undefined,
+        CipherType.Login,
+      );
+    });
+
+    it("prefers the explicit cipherType over activeFilter.cipherType when both are set", async () => {
+      component.activeFilter = { cipherType: CipherType.Login } as unknown as VaultFilter;
+
+      await component.addCipher(CipherType.SecureNote);
+
+      expect(cipherFormConfigService.buildConfig).toHaveBeenCalledWith(
+        "add",
+        undefined,
+        CipherType.SecureNote,
+      );
     });
   });
 });

--- a/apps/web/src/app/admin-console/organizations/collections/vault.component.ts
+++ b/apps/web/src/app/admin-console/organizations/collections/vault.component.ts
@@ -886,11 +886,8 @@ export class VaultComponent implements OnInit, OnDestroy {
 
   /** Opens the Add/Edit Dialog */
   async addCipher(cipherType?: CipherType) {
-    const cipherFormConfig = await this.cipherFormConfigService.buildConfig(
-      "add",
-      undefined,
-      cipherType,
-    );
+    const type = cipherType ?? this.activeFilter.cipherType;
+    const cipherFormConfig = await this.cipherFormConfigService.buildConfig("add", undefined, type);
 
     const collectionId: CollectionId | undefined = this.activeFilter.collectionId as CollectionId;
 


### PR DESCRIPTION
## 🎟️ Tracking

[Jira](https://bitwarden.atlassian.net/browse/PM-38113)

## 📔 Objective

When there are no items with a specific filter item type applied, the `+ New Item` button didn't default to the item type filtered for. It always opened a new `Login` form. This changes the behavior to be consistent with the individual vault.