### PR TITLE
[PM-36085] - add autofillVerb and autofillNoun

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -214,8 +214,13 @@
     "message": "Fill",
     "description": "This string is used on the vault page to indicate autofilling. Horizontal space is limited in the interface here so try and keep translations as concise as possible."
   },
-  "autoFill": {
-    "message": "Autofill"
+  "autofillNoun": {
+    "message": "Autofill",
+    "description": "Noun"
+  },
+  "autofillVerb": {
+    "message": "Autofill",
+    "description": "Verb"
   },
   "autoFillLogin": {
     "message": "Autofill login"

--- a/apps/browser/src/autofill/popup/settings/autofill.component.html
+++ b/apps/browser/src/autofill/popup/settings/autofill.component.html
@@ -1,5 +1,5 @@
 <popup-page>
-  <popup-header slot="header" pageTitle="{{ 'autofill' | i18n }}" showBackButton>
+  <popup-header slot="header" pageTitle="{{ 'autofillNoun' | i18n }}" showBackButton>
     <ng-container slot="end">
       <app-pop-out></app-pop-out>
     </ng-container>

--- a/apps/browser/src/tools/popup/settings/settings-v2.component.html
+++ b/apps/browser/src/tools/popup/settings/settings-v2.component.html
@@ -33,7 +33,7 @@
       <a bit-item-content routerLink="/autofill" [truncate]="false">
         <i slot="start" class="bwi bwi-check-circle" aria-hidden="true"></i>
         <div class="tw-flex tw-items-center tw-justify-center">
-          <p class="tw-pr-2">{{ "autofill" | i18n }}</p>
+          <p class="tw-pr-2">{{ "autofillNoun" | i18n }}</p>
           @if (showAutofillBadge$ | async) {
             <bit-berry
               variant="danger"

--- a/apps/browser/src/vault/popup/components/vault/autofill-confirmation-dialog/autofill-confirmation-dialog.component.html
+++ b/apps/browser/src/vault/popup/components/vault/autofill-confirmation-dialog/autofill-confirmation-dialog.component.html
@@ -74,7 +74,7 @@
         </button>
       }
       <button type="button" bitButton buttonType="secondary" (click)="autofillOnly()">
-        {{ (viewOnly() ? "autoFill" : "autofillOnly") | i18n }}
+        {{ (viewOnly() ? "autofillVerb" : "autofillOnly") | i18n }}
       </button>
       <button
         type="button"

--- a/apps/browser/src/vault/popup/components/vault/item-more-options/item-more-options.component.html
+++ b/apps/browser/src/vault/popup/components/vault/item-more-options/item-more-options.component.html
@@ -10,7 +10,7 @@
     @if (!decryptionFailure) {
       @if (canAutofill && showAutofill() && autofillAllowed$ | async) {
         <button type="button" bitMenuItem (click)="doAutofill()">
-          {{ "autofill" | i18n }}
+          {{ "autofillVerb" | i18n }}
         </button>
       }
       @if (showViewOption()) {

--- a/apps/browser/src/vault/popup/components/vault/vault-list-items-container/vault-list-items-container.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/vault-list-items-container/vault-list-items-container.component.ts
@@ -387,7 +387,7 @@ export class VaultListItemsContainerComponent implements AfterViewInit {
     if (autofillShortcut === "") {
       this.autofillShortcutTooltip.set(undefined);
     } else {
-      const autofillTitle = this.i18nService.t("autoFill");
+      const autofillTitle = this.i18nService.t("autofillVerb");
 
       this.autofillShortcutTooltip.set(`${autofillTitle} ${autofillShortcut}`);
     }

--- a/apps/browser/src/vault/popup/components/vault/view/view.component.html
+++ b/apps/browser/src/vault/popup/components/vault/view/view.component.html
@@ -22,7 +22,7 @@
           block
           (click)="doAutofill()"
         >
-          {{ "autofill" | i18n }}
+          {{ "autofillVerb" | i18n }}
         </button>
       }
     </app-cipher-view>


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-36085

Fixes https://github.com/bitwarden/clients/issues/20447

## 📔 Objective

Split the single `autoFill` i18n translation key into separate `autofillNoun` and `autofillVerb` keys to allow translators to provide grammatically correct translations for different contexts (e.g., languages where a noun and verb form of "autofill" differ).

**Noun usage** — page titles and nav labels:
- Autofill settings page title
- Settings nav menu item

**Verb usage** — action buttons and tooltips:
- "Autofill" primary button on the cipher view page
- "Autofill" option in the item more-options menu
- Keyboard shortcut tooltip on vault list items
- "Autofill" button in the autofill confirmation dialog

The `en` locale is updated with the new keys. All other locales will fall back to `en` until they are updated by translators.

## 📸 Screenshots

<!-- No visible UI change — text remains "Autofill" in English. -->
