### PR TITLE
[BRE-1949] Removing duplicate messages keys

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -2161,7 +2161,7 @@
     "message": "National identification number"
   },
   "issuingAuthority": {
-    "message": "Issuing authority / office"
+    "message": "Issuing authority"
   },
   "copyIssuingAuthority": {
     "message": "Copy issuing authority / office"

--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -2280,41 +2280,8 @@
   "driversLicenseDetails": {
     "message": "License details"
   },
-  "dateOfBirth": {
-    "message": "Date of birth"
-  },
-  "birthMonth": {
-    "message": "Birth month"
-  },
-  "birthDay": {
-    "message": "Birth day"
-  },
-  "birthYear": {
-    "message": "Birth year"
-  },
-  "issuingCountry": {
-    "message": "Issuing country"
-  },
   "issuingState": {
     "message": "Issuing state / province"
-  },
-  "issuingAuthority": {
-    "message": "Issuing authority"
-  },
-  "issueDate": {
-    "message": "Issue date"
-  },
-  "issueMonth": {
-    "message": "Issue month"
-  },
-  "issueDay": {
-    "message": "Issue day"
-  },
-  "issueYear": {
-    "message": "Issue year"
-  },
-  "expirationDay": {
-    "message": "Expiration day"
   },
   "licenseClass": {
     "message": "License class"


### PR DESCRIPTION
## 🎟️ Tracking

[BRE-1949](https://bitwarden.atlassian.net/browse/BRE-1949)

## 📔 Objective

Unblock the Firefox AMO upload for the `2026.5.0` browser release by removing duplicate JSON keys from `apps/browser/src/_locales/en/messages.json`.

The [`web-ext sign` step in the deploy workflow](https://github.com/bitwarden/deploy/actions/runs/26645805993) failed with 11 `JSON_DUPLICATE_KEY` validation errors from the AMO validator. Chrome/Edge tolerate duplicate JSON keys (last-wins), which is why this passed CI but Firefox/AMO rejects the build.

## 📋 Root cause

Two recently merged Vault PRs each added the same 11 identity-field locale keys to `messages.json`:

| PR | Merged | Block (current line numbers) |
| --- | --- | --- |
| [#20638 — Add Driver's License to browser](https://github.com/bitwarden/clients/pull/20638) | 2026-05-14 | L2283–L2316 |
| [#20514 — Passport Web](https://github.com/bitwarden/clients/pull/20514) | 2026-05-15 | L2007–L2169 |

Neither set of keys existed in the previous release (`browser-v2026.4.1`).

## 🔧 Changes

- Removed the 11 duplicate keys from the Driver's License block (L2283–L2316):
  `birthDay`, `birthMonth`, `birthYear`, `dateOfBirth`, `issueDate`, `issueDay`, `issueMonth`, `issueYear`, `expirationDay`, `issuingCountry`, `issuingAuthority`
- Kept the 3 genuinely new keys from #20638: `driversLicenseDetails`, `issuingState`, `licenseClass`
- Updated `issuingAuthority` message from `"Issuing authority / office"` to `"Issuing authority"` so the parsed value matches what `main` already resolves to (JSON last-wins), satisfying the Crowdin immutability check (`test:locales`).

## ✅ Validation

- `messages.json` parses as valid JSON (1801 top-level keys)
- 0 remaining duplicate keys
- All 11 affected message IDs resolve to the same value as `main` parses them today — `test:locales` passes

## 🔗 Related

- Deploy run that failed: https://github.com/bitwarden/deploy/actions/runs/26645805993
- CI run that initially failed `test:locales`: https://github.com/bitwarden/clients/actions/runs/26648299137
- Original feature PRs: #20638, #20514

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

[BRE-1949]: https://bitwarden.atlassian.net/browse/BRE-1949?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ