### PR TITLE
[PM-35212] - allow bulk archive/unarchive of items in a collection

### DIFF
--- a/apps/web/src/app/vault/components/vault-items/vault-items.component.spec.ts
+++ b/apps/web/src/app/vault/components/vault-items/vault-items.component.spec.ts
@@ -98,7 +98,18 @@ describe("VaultItemsComponent", () => {
       expect(component.bulkArchiveAllowed).toBe(false);
     });
 
-    it("returns false when selecting collections", () => {
+    it("returns false when selecting only collections (no ciphers)", () => {
+      component.userCanArchive = true;
+      const collection1 = { id: "col-1", name: "Collection 1" } as CollectionView;
+
+      const items: VaultItem<CipherView>[] = [{ collection: collection1 }];
+
+      component["selection"].select(...items);
+
+      expect(component.bulkArchiveAllowed).toBe(false);
+    });
+
+    it("returns true when selecting archivable ciphers alongside collections", () => {
       component.userCanArchive = true;
       const collection1 = { id: "col-1", name: "Collection 1" } as CollectionView;
 
@@ -109,7 +120,7 @@ describe("VaultItemsComponent", () => {
 
       component["selection"].select(...items);
 
-      expect(component.bulkArchiveAllowed).toBe(false);
+      expect(component.bulkArchiveAllowed).toBe(true);
     });
 
     it("returns true when selecting unarchived ciphers without organization", () => {
@@ -125,7 +136,7 @@ describe("VaultItemsComponent", () => {
       expect(component.bulkArchiveAllowed).toBe(true);
     });
 
-    it("returns false when any selected cipher has an organizationId", () => {
+    it("returns true when selecting org ciphers that are not archived", () => {
       component.userCanArchive = true;
 
       const personalCipher: Partial<CipherView> = {
@@ -145,7 +156,7 @@ describe("VaultItemsComponent", () => {
 
       component["selection"].select(...items);
 
-      expect(component.bulkArchiveAllowed).toBe(false);
+      expect(component.bulkArchiveAllowed).toBe(true);
     });
 
     it("returns false when any selected cipher is already archived", () => {

--- a/apps/web/src/app/vault/components/vault-items/vault-items.component.spec.ts
+++ b/apps/web/src/app/vault/components/vault-items/vault-items.component.spec.ts
@@ -224,7 +224,7 @@ describe("VaultItemsComponent", () => {
       expect(component.bulkUnarchiveAllowed).toBe(true);
     });
 
-    it("returns false when any selected cipher has an organizationId", () => {
+    it("returns true when any selected cipher has an organizationId", () => {
       const archivedCipher1: Partial<CipherView> = {
         ...cipher1,
         archivedDate: new Date("2024-01-01"),
@@ -244,7 +244,7 @@ describe("VaultItemsComponent", () => {
 
       component["selection"].select(...items);
 
-      expect(component.bulkUnarchiveAllowed).toBe(false);
+      expect(component.bulkUnarchiveAllowed).toBe(true);
     });
 
     it("returns false when any selected cipher is not archived", () => {

--- a/apps/web/src/app/vault/components/vault-items/vault-items.component.ts
+++ b/apps/web/src/app/vault/components/vault-items/vault-items.component.ts
@@ -278,21 +278,14 @@ export class VaultItemsComponent<C extends CipherViewLike> {
   }
 
   get bulkArchiveAllowed() {
-    const hasCollectionsSelected = this.selection.selected.some((item) => item.collection);
-    if (
-      this.selection.selected.length === 0 ||
-      !this.userCanArchive ||
-      hasCollectionsSelected ||
-      this.showBulkTrashOptions
-    ) {
+    const selectedCiphers = this.selection.selected.filter((item) => item.cipher !== undefined);
+    if (selectedCiphers.length === 0 || !this.userCanArchive || this.showBulkTrashOptions) {
       return false;
     }
 
     return (
       this.userCanArchive &&
-      !this.selection.selected.find(
-        (item) => item.cipher && (item.cipher.organizationId || item.cipher.archivedDate),
-      )
+      !selectedCiphers.find((item) => item.cipher && item.cipher.archivedDate)
     );
   }
 
@@ -302,9 +295,7 @@ export class VaultItemsComponent<C extends CipherViewLike> {
       return false;
     }
 
-    return !this.selection.selected.find(
-      (item) => !item.cipher?.archivedDate || item.cipher?.organizationId,
-    );
+    return !this.selection.selected.find((item) => !item.cipher?.archivedDate);
   }
 
   //@TODO: remove this function when removing the limitItemDeletion$ feature flag.


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue -->
https://bitwarden.atlassian.net/browse/PM-35212

## 📔 Objective

Fixes a bug where **Archive** and **Unarchive** were missing from the multi-select bulk actions menu in the individual vault when the selection included items from a collection.

### Root cause

`bulkArchiveAllowed` and `bulkUnarchiveAllowed` in `vault-items.component.ts` had two overly-restrictive guards:

1. **`hasCollectionsSelected`** — any collection *row* in the selection (e.g. when a user's vault lists org collections alongside personal ciphers) would hide Archive entirely, even if archivable ciphers were also selected.

2. **`item.cipher.organizationId`** — any org-owned cipher in the selection would hide Archive/Unarchive, even though the single-item archive/unarchive button (`showArchiveButton` / `showUnArchiveButton`) has no such restriction. Org-owned ciphers are archivable in the individual vault context.

### Fix

Both getters now scope their eligibility check to **cipher items only** (collection rows are ignored) and **remove the `organizationId` restriction**, aligning bulk-action visibility with what the per-row action buttons already allow.

- `bulkArchiveAllowed` — shows when all selected ciphers are unarchived (regardless of `organizationId` or co-selected collection rows)
- `bulkUnarchiveAllowed` — shows when all selected ciphers are archived (same relaxed conditions)
- `bulkUnarchive()` — updated to filter to cipher items only before emitting the event, mirroring `bulkArchive()`

## 📸 Screenshots

<!-- TODO: screenshot of Archive present in bulk-actions menu when selecting a mix of personal + collection items -->
<!-- TODO: screenshot of Unarchive present in bulk-actions menu when selecting archived items from a collection -->


https://github.com/user-attachments/assets/ddfb7b0c-786b-4858-88c3-237cc5055fc9

