### PR TITLE
[PM-37610] - immediately clear onboarding tasks after completing them

### DIFF
--- a/apps/web/src/app/vault/individual-vault/vault-onboarding/vault-onboarding.component.spec.ts
+++ b/apps/web/src/app/vault/individual-vault/vault-onboarding/vault-onboarding.component.spec.ts
@@ -197,6 +197,31 @@ describe("VaultOnboardingComponent", () => {
 
       expect(saveCompletedTasksSpy).toHaveBeenCalled();
     });
+
+    it("should set showOnboarding to false when extension is detected and all other tasks are complete", async () => {
+      jest
+        .spyOn((component as any).vaultOnboardingService, "setVaultOnboardingTasks")
+        .mockReturnValue(Promise.resolve());
+
+      (component as any).vaultOnboardingService.vaultOnboardingState$ = jest
+        .fn()
+        .mockImplementation(() => {
+          return of({
+            createAccount: true,
+            importData: true,
+            installExtension: false,
+          });
+        });
+
+      (component as any).showOnboarding = true;
+      (component as any).onboardingTasks$ = (
+        component as any
+      ).vaultOnboardingService.vaultOnboardingState$();
+
+      await component.getMessages({ data: { command: VaultMessages.HasBwInstalled } });
+
+      expect((component as any).showOnboarding).toBe(false);
+    });
   });
 
   describe("emitToAddCipher", () => {

--- a/apps/web/src/app/vault/individual-vault/vault-onboarding/vault-onboarding.component.ts
+++ b/apps/web/src/app/vault/individual-vault/vault-onboarding/vault-onboarding.component.ts
@@ -95,6 +95,7 @@ export class VaultOnboardingComponent implements OnInit, OnChanges, OnDestroy {
         installExtension: currentTasks.installExtension,
       };
       await this.vaultOnboardingService.setVaultOnboardingTasks(this.activeId, updatedTasks);
+      this.showOnboarding = Object.values(updatedTasks).includes(false);
     }
   }
 
@@ -124,6 +125,7 @@ export class VaultOnboardingComponent implements OnInit, OnChanges, OnDestroy {
         installExtension: true,
       };
       await this.vaultOnboardingService.setVaultOnboardingTasks(this.activeId, updatedTasks);
+      this.showOnboarding = Object.values(updatedTasks).includes(false);
     }
   }
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue -->
https://bitwarden.atlassian.net/browse/PM-37610

## 📔 Objective

Fixes a bug where the "Get started" onboarding dashboard remained visible on the vault page even after all steps were already completed.

**Root cause:** On first load in a new browser session, `installExtension` is always initialized to `false` because extension presence is determined asynchronously. `checkForBrowserExtension()` posts a message to the extension and, when it responds, `getMessages()` correctly persists `installExtension: true` to state — but never updated the in-memory `showOnboarding` flag. As a result the widget stayed visible until the component was destroyed and recreated on the next navigation.

The same omission existed in `ngOnChanges` for the ciphers-change path.

**Fix:** After saving updated tasks in both `getMessages()` and `ngOnChanges()`, re-evaluate `showOnboarding` against the new task values so the widget hides immediately when all tasks are complete.

## 📸 Screenshots

<!-- TODO: Add before/after screenshots showing the vault landing page immediately after login — before (dashboard still showing with all steps checked) and after (dashboard hidden on load). -->


https://github.com/user-attachments/assets/c141953a-896b-4978-858a-1d823069916c

