### PR TITLE
[PM- 27844] set email on sync and do not logout

### DIFF
--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -1187,6 +1187,7 @@ export default class MainBackground {
       this.securityStateService,
       this.kdfConfigService,
       this.accountCryptographicStateService,
+      this.configService,
     );
 
     this.syncServiceListener = new SyncServiceListener(

--- a/apps/cli/src/service-container/service-container.ts
+++ b/apps/cli/src/service-container/service-container.ts
@@ -1000,6 +1000,7 @@ export class ServiceContainer {
       this.securityStateService,
       this.kdfConfigService,
       this.accountCryptographicStateService,
+      this.configService,
     );
 
     this.totpService = new TotpService(this.sdkService);

--- a/apps/web/src/app/auth/settings/account/change-email.component.ts
+++ b/apps/web/src/app/auth/settings/account/change-email.component.ts
@@ -8,6 +8,8 @@ import { getUserId } from "@bitwarden/common/auth/services/account.service";
 import { ChangeEmailService } from "@bitwarden/common/auth/services/change-email/change-email.service";
 import { TwoFactorService } from "@bitwarden/common/auth/two-factor";
 import { assertNonNullish } from "@bitwarden/common/auth/utils";
+import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
 import { UserId } from "@bitwarden/common/types/guid";
@@ -43,6 +45,7 @@ export class ChangeEmailComponent implements OnInit {
     private formBuilder: FormBuilder,
     private toastService: ToastService,
     private changeEmailService: ChangeEmailService,
+    private configService: ConfigService,
   ) {}
 
   async ngOnInit() {
@@ -95,12 +98,17 @@ export class ChangeEmailComponent implements OnInit {
         this.userId,
       );
       this.reset();
-      this.toastService.showToast({
-        variant: "success",
-        title: this.i18nService.t("emailChanged"),
-        message: this.i18nService.t("logBackIn"),
-      });
-      this.messagingService.send("logout");
+      const selfServiceChangeEmailEnabled = await this.configService.getFeatureFlag(
+        FeatureFlag.PM30806_SelfServiceChangeEmailCommand,
+      );
+      if (!selfServiceChangeEmailEnabled) {
+        this.toastService.showToast({
+          variant: "success",
+          title: this.i18nService.t("emailChanged"),
+          message: this.i18nService.t("logBackIn"),
+        });
+        this.messagingService.send("logout");
+      }
     }
   };
 

--- a/libs/angular/src/services/jslib-services.module.ts
+++ b/libs/angular/src/services/jslib-services.module.ts
@@ -967,6 +967,7 @@ const safeProviders: SafeProvider[] = [
       SecurityStateService,
       KdfConfigService,
       AccountCryptographicStateService,
+      ConfigService,
     ],
   }),
   safeProvider({

--- a/libs/common/src/enums/feature-flag.enum.ts
+++ b/libs/common/src/enums/feature-flag.enum.ts
@@ -22,6 +22,7 @@ export enum FeatureFlag {
   /* Auth */
   SafariAccountSwitching = "pm-5594-safari-account-switching",
   PM30811_ChangeEmailNewAuthenticationApis = "pm-30811-change-email-new-authentication-apis",
+  PM30806_SelfServiceChangeEmailCommand = "pm-30806-self-service-change-email-command",
   PM31088_MasterPasswordServiceEmitSalt = "pm-31088-master-password-service-emit-salt",
   UseUnlockServiceForPasswordLogin = "use-unlock-service-for-password-login",
   PM32413_MultiClientPasswordManagement = "pm-32413-multi-client-password-management",
@@ -172,6 +173,7 @@ export const DefaultFeatureFlagValue = {
   /* Auth */
   [FeatureFlag.SafariAccountSwitching]: FALSE,
   [FeatureFlag.PM30811_ChangeEmailNewAuthenticationApis]: FALSE,
+  [FeatureFlag.PM30806_SelfServiceChangeEmailCommand]: FALSE,
   [FeatureFlag.PM31088_MasterPasswordServiceEmitSalt]: FALSE,
   [FeatureFlag.UseUnlockServiceForPasswordLogin]: FALSE,
   [FeatureFlag.PM32413_MultiClientPasswordManagement]: FALSE,

--- a/libs/common/src/platform/sync/default-sync.service.spec.ts
+++ b/libs/common/src/platform/sync/default-sync.service.spec.ts
@@ -45,6 +45,7 @@ import { UserId } from "../../types/guid";
 import { CipherService } from "../../vault/abstractions/cipher.service";
 import { FolderApiServiceAbstraction } from "../../vault/abstractions/folder/folder-api.service.abstraction";
 import { InternalFolderService } from "../../vault/abstractions/folder/folder.service.abstraction";
+import { ConfigService } from "../abstractions/config/config.service";
 import { LogService } from "../abstractions/log.service";
 import { MessageSender } from "../messaging";
 import { StateProvider } from "../state";
@@ -81,6 +82,7 @@ describe("DefaultSyncService", () => {
   let securityStateService: MockProxy<SecurityStateService>;
   let kdfConfigService: MockProxy<KdfConfigService>;
   let accountCryptographicStateService: MockProxy<AccountCryptographicStateService>;
+  let configService: MockProxy<ConfigService>;
 
   let sut: DefaultSyncService;
 
@@ -114,6 +116,7 @@ describe("DefaultSyncService", () => {
     securityStateService = mock();
     kdfConfigService = mock();
     accountCryptographicStateService = mock();
+    configService = mock();
 
     sut = new DefaultSyncService(
       masterPasswordAbstraction,
@@ -144,6 +147,7 @@ describe("DefaultSyncService", () => {
       securityStateService,
       kdfConfigService,
       accountCryptographicStateService,
+      configService,
     );
   });
 

--- a/libs/common/src/platform/sync/default-sync.service.ts
+++ b/libs/common/src/platform/sync/default-sync.service.ts
@@ -9,6 +9,7 @@ import {
   CollectionData,
   CollectionDetailsResponse,
 } from "@bitwarden/common/admin-console/models/collections";
+import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { AccountCryptographicStateService } from "@bitwarden/common/key-management/account-cryptography/account-cryptographic-state.service";
 import { SecurityStateService } from "@bitwarden/common/key-management/security-state/abstractions/security-state.service";
 // This import has been flagged as unallowed for this class. It may be involved in a circular dependency loop.
@@ -61,6 +62,7 @@ import { CipherData } from "../../vault/models/data/cipher.data";
 import { FolderData } from "../../vault/models/data/folder.data";
 import { CipherResponse } from "../../vault/models/response/cipher.response";
 import { FolderResponse } from "../../vault/models/response/folder.response";
+import { ConfigService } from "../abstractions/config/config.service";
 import { LogService } from "../abstractions/log.service";
 import { MessageSender } from "../messaging";
 import { StateProvider } from "../state";
@@ -110,6 +112,7 @@ export class DefaultSyncService extends CoreSyncService {
     private securityStateService: SecurityStateService,
     private kdfConfigService: KdfConfigService,
     private accountCryptographicStateService: AccountCryptographicStateService,
+    private configService: ConfigService,
   ) {
     super(
       tokenService,
@@ -277,6 +280,12 @@ export class DefaultSyncService extends CoreSyncService {
     await this.accountService.setAccountEmailVerified(response.id, response.emailVerified);
     await this.accountService.setAccountCreationDate(response.id, new Date(response.creationDate));
     await this.accountService.setAccountVerifyNewDeviceLogin(response.id, response.verifyDevices);
+
+    if (
+      await this.configService.getFeatureFlag(FeatureFlag.PM30806_SelfServiceChangeEmailCommand)
+    ) {
+      await this.accountService.setAccountEmail(response.id, response.email);
+    }
 
     await this.billingAccountProfileStateService.setHasPremium(
       response.premiumPersonally,


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-27844](https://bitwarden.atlassian.net/browse/PM-27844)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Once email and salt are separated and this feature flag is enabled there's no longer a need to log a user out. So we will sync on the server push service which will set the sync settings service to fire.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->


[PM-27844]: https://bitwarden.atlassian.net/browse/PM-27844?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ