### PR TITLE
Improve consistency of popout closure

### DIFF
--- a/apps/browser/src/platform/browser/browser-api.spec.ts
+++ b/apps/browser/src/platform/browser/browser-api.spec.ts
@@ -471,6 +471,94 @@ describe("BrowserApi", () => {
     });
   });
 
+  describe("isAnyPopupOrPopoutOpen", () => {
+    describe("when MV3 and chrome.runtime.getContexts is available", () => {
+      beforeEach(() => {
+        (chrome.runtime as any).getContexts = jest.fn();
+        jest.spyOn(BrowserApi, "manifestVersion", "get").mockReturnValue(3);
+      });
+
+      afterEach(() => {
+        delete (chrome.runtime as any).getContexts;
+      });
+
+      it("returns true when a POPUP context exists", async () => {
+        (chrome.runtime as any).getContexts.mockResolvedValue([
+          { contextType: "POPUP", documentUrl: "chrome-extension://id/popup/index.html" },
+        ]);
+
+        expect(await BrowserApi.isAnyPopupOrPopoutOpen()).toBe(true);
+      });
+
+      it("returns true when a TAB context with uilocation=popout exists", async () => {
+        (chrome.runtime as any).getContexts.mockResolvedValue([
+          {
+            contextType: "TAB",
+            documentUrl: "chrome-extension://id/popup/index.html?uilocation=popout",
+          },
+        ]);
+
+        expect(await BrowserApi.isAnyPopupOrPopoutOpen()).toBe(true);
+      });
+
+      it("returns false when only non-popout TAB contexts exist", async () => {
+        (chrome.runtime as any).getContexts.mockResolvedValue([
+          { contextType: "TAB", documentUrl: "chrome-extension://id/popup/index.html" },
+        ]);
+
+        expect(await BrowserApi.isAnyPopupOrPopoutOpen()).toBe(false);
+      });
+
+      it("returns false when no contexts exist", async () => {
+        (chrome.runtime as any).getContexts.mockResolvedValue([]);
+
+        expect(await BrowserApi.isAnyPopupOrPopoutOpen()).toBe(false);
+      });
+    });
+
+    describe("when MV2, falls back to getExtensionViews", () => {
+      beforeEach(() => {
+        jest.spyOn(BrowserApi, "manifestVersion", "get").mockReturnValue(2);
+      });
+
+      it("returns true if the popup is open", async () => {
+        chrome.extension.getViews = jest.fn().mockImplementation((props) => {
+          return props?.type === "popup" ? [window] : [];
+        });
+
+        expect(await BrowserApi.isAnyPopupOrPopoutOpen()).toBe(true);
+      });
+
+      it("returns true if a popout tab is open", async () => {
+        const popoutWindow = {
+          location: { href: "chrome-extension://id/popup/index.html?uilocation=popout" },
+        };
+        chrome.extension.getViews = jest.fn().mockImplementation((props) => {
+          return props?.type === "tab" ? [popoutWindow] : [];
+        });
+
+        expect(await BrowserApi.isAnyPopupOrPopoutOpen()).toBe(true);
+      });
+
+      it("returns false if neither popup nor popout is open", async () => {
+        chrome.extension.getViews = jest.fn().mockReturnValue([]);
+
+        expect(await BrowserApi.isAnyPopupOrPopoutOpen()).toBe(false);
+      });
+
+      it("returns false if only a non-popout tab is open", async () => {
+        const tabWindow = {
+          location: { href: "chrome-extension://id/popup/index.html" },
+        };
+        chrome.extension.getViews = jest.fn().mockImplementation((props) => {
+          return props?.type === "tab" ? [tabWindow] : [];
+        });
+
+        expect(await BrowserApi.isAnyPopupOrPopoutOpen()).toBe(false);
+      });
+    });
+  });
+
   describe("isAnyViewFocused", () => {
     describe("when MV3 and chrome.runtime.getContexts is available", () => {
       beforeEach(() => {

--- a/apps/browser/src/platform/browser/browser-api.ts
+++ b/apps/browser/src/platform/browser/browser-api.ts
@@ -509,6 +509,35 @@ export class BrowserApi {
   }
 
   /**
+   * Returns true if the toolbar popup or any popout window is currently open.
+   *
+   * Used to gate `chrome.runtime.reload()` so it doesn't fire while a popout is mid-teardown.
+   * Popouts are classified as `TAB` contexts (not `POPUP`) by `chrome.runtime.getContexts`,
+   * so they're identified by `uilocation=popout` in their documentUrl.
+   */
+  static async isAnyPopupOrPopoutOpen(): Promise<boolean> {
+    if (
+      typeof (chrome.runtime as any).getContexts === "function" &&
+      BrowserApi.isManifestVersion(3)
+    ) {
+      const contexts = await chrome.runtime.getContexts({});
+      return contexts.some(
+        (context) =>
+          context.contextType === "POPUP" ||
+          (context.contextType === "TAB" && context.documentUrl?.includes("uilocation=popout")),
+      );
+    }
+
+    // MV2/Safari — background page can use getExtensionViews
+    if (BrowserApi.getExtensionViews({ type: "popup" }).length > 0) {
+      return true;
+    }
+    return BrowserApi.getExtensionViews({ type: "tab" }).some((v) =>
+      v.location.href.includes("uilocation=popout"),
+    );
+  }
+
+  /**
    * Returns true if any extension view is currently active/focused.
    *
    * - Main popup: always considered focused (auto-closes on blur).

--- a/apps/browser/src/platform/browser/browser-popup-utils.spec.ts
+++ b/apps/browser/src/platform/browser/browser-popup-utils.spec.ts
@@ -454,6 +454,51 @@ describe("BrowserPopupUtils", () => {
     });
   });
 
+  describe("closeCurrentPopupOrPopout", () => {
+    const win = {} as Window;
+
+    it("closes the browser action popup when the view is a popup", async () => {
+      jest.spyOn(BrowserPopupUtils, "inPopup").mockReturnValue(true);
+      jest.spyOn(BrowserPopupUtils, "inPopout").mockReturnValue(false);
+      jest.spyOn(BrowserApi, "closePopup").mockImplementation();
+      jest.spyOn(BrowserApi, "getWindow");
+      jest.spyOn(BrowserApi, "removeWindow");
+
+      await BrowserPopupUtils.closeCurrentPopupOrPopout(win);
+
+      expect(BrowserApi.closePopup).toHaveBeenCalledWith(win);
+      expect(BrowserApi.getWindow).not.toHaveBeenCalled();
+      expect(BrowserApi.removeWindow).not.toHaveBeenCalled();
+    });
+
+    it("removes the current window when the view is a popout", async () => {
+      jest.spyOn(BrowserPopupUtils, "inPopup").mockReturnValue(false);
+      jest.spyOn(BrowserPopupUtils, "inPopout").mockReturnValue(true);
+      jest.spyOn(BrowserApi, "closePopup").mockImplementation();
+      jest.spyOn(BrowserApi, "getWindow").mockResolvedValue({ id: 42 } as chrome.windows.Window);
+      jest.spyOn(BrowserApi, "removeWindow").mockResolvedValue();
+
+      await BrowserPopupUtils.closeCurrentPopupOrPopout(win);
+
+      expect(BrowserApi.removeWindow).toHaveBeenCalledWith(42);
+      expect(BrowserApi.closePopup).not.toHaveBeenCalled();
+    });
+
+    it("does nothing when the view is neither a popup nor a popout", async () => {
+      jest.spyOn(BrowserPopupUtils, "inPopup").mockReturnValue(false);
+      jest.spyOn(BrowserPopupUtils, "inPopout").mockReturnValue(false);
+      jest.spyOn(BrowserApi, "closePopup").mockImplementation();
+      jest.spyOn(BrowserApi, "getWindow");
+      jest.spyOn(BrowserApi, "removeWindow");
+
+      await BrowserPopupUtils.closeCurrentPopupOrPopout(win);
+
+      expect(BrowserApi.closePopup).not.toHaveBeenCalled();
+      expect(BrowserApi.getWindow).not.toHaveBeenCalled();
+      expect(BrowserApi.removeWindow).not.toHaveBeenCalled();
+    });
+  });
+
   describe("waitForAllPopupsClose", () => {
     beforeEach(() => {
       jest.useFakeTimers();

--- a/apps/browser/src/platform/browser/browser-popup-utils.spec.ts
+++ b/apps/browser/src/platform/browser/browser-popup-utils.spec.ts
@@ -509,17 +509,17 @@ describe("BrowserPopupUtils", () => {
     });
 
     it("should resolve immediately if no popups are open", async () => {
-      jest.spyOn(BrowserApi, "isPopupOpen").mockResolvedValue(false);
+      jest.spyOn(BrowserApi, "isAnyPopupOrPopoutOpen").mockResolvedValue(false);
 
       const promise = BrowserPopupUtils.waitForAllPopupsClose();
       jest.advanceTimersByTime(100);
 
       await expect(promise).resolves.toBeUndefined();
-      expect(BrowserApi.isPopupOpen).toHaveBeenCalledTimes(1);
+      expect(BrowserApi.isAnyPopupOrPopoutOpen).toHaveBeenCalledTimes(1);
     });
 
     it("should resolve after timeout if popup never closes when using custom timeout", async () => {
-      jest.spyOn(BrowserApi, "isPopupOpen").mockResolvedValue(true);
+      jest.spyOn(BrowserApi, "isAnyPopupOrPopoutOpen").mockResolvedValue(true);
 
       const promise = BrowserPopupUtils.waitForAllPopupsClose(500);
 
@@ -530,7 +530,7 @@ describe("BrowserPopupUtils", () => {
     });
 
     it("should resolve after timeout if popup never closes when using default timeout", async () => {
-      jest.spyOn(BrowserApi, "isPopupOpen").mockResolvedValue(true);
+      jest.spyOn(BrowserApi, "isAnyPopupOrPopoutOpen").mockResolvedValue(true);
 
       const promise = BrowserPopupUtils.waitForAllPopupsClose();
 
@@ -542,7 +542,7 @@ describe("BrowserPopupUtils", () => {
 
     it("should stop polling after popup closes before timeout", async () => {
       let callCount = 0;
-      jest.spyOn(BrowserApi, "isPopupOpen").mockImplementation(async () => {
+      jest.spyOn(BrowserApi, "isAnyPopupOrPopoutOpen").mockImplementation(async () => {
         callCount++;
         return callCount <= 2;
       });
@@ -557,7 +557,7 @@ describe("BrowserPopupUtils", () => {
       // Advance further to ensure no more calls are made
       jest.advanceTimersByTime(1000);
 
-      expect(BrowserApi.isPopupOpen).toHaveBeenCalledTimes(3);
+      expect(BrowserApi.isAnyPopupOrPopoutOpen).toHaveBeenCalledTimes(3);
     });
   });
 

--- a/apps/browser/src/platform/browser/browser-popup-utils.ts
+++ b/apps/browser/src/platform/browser/browser-popup-utils.ts
@@ -257,16 +257,16 @@ export default class BrowserPopupUtils {
   }
 
   /**
-   * Waits for all browser action popups to close, polling up to the specified timeout.
-   * Used before extension reload to prevent zombie popups with invalidated contexts.
+   * Waits for the toolbar popup and any popout windows to close, polling up to the specified
+   * timeout. Used before extension reload to prevent zombie views with invalidated contexts.
    *
    * @param timeoutMs - Maximum time to wait in milliseconds. Defaults to 1 second.
-   * @returns Promise that resolves when all popups are closed or timeout is reached.
+   * @returns Promise that resolves when all popup/popout views are closed or timeout is reached.
    */
   static async waitForAllPopupsClose(timeoutMs = 1000): Promise<void> {
     await firstValueFrom(
       interval(100).pipe(
-        switchMap(() => BrowserApi.isPopupOpen()),
+        switchMap(() => BrowserApi.isAnyPopupOrPopoutOpen()),
         takeWhile((isOpen) => isOpen, true),
         filter((isOpen) => !isOpen),
         timeout({

--- a/apps/browser/src/platform/browser/browser-popup-utils.ts
+++ b/apps/browser/src/platform/browser/browser-popup-utils.ts
@@ -238,6 +238,25 @@ export default class BrowserPopupUtils {
   }
 
   /**
+   * Closes the current popup or popout window from inside that window.
+   *
+   * @param win - The passed window object.
+   */
+  static async closeCurrentPopupOrPopout(win: Window): Promise<void> {
+    if (BrowserPopupUtils.inPopup(win)) {
+      BrowserApi.closePopup(win);
+      return;
+    }
+
+    if (BrowserPopupUtils.inPopout(win)) {
+      const currentWindow = await BrowserApi.getWindow();
+      if (currentWindow?.id != null) {
+        await BrowserApi.removeWindow(currentWindow.id);
+      }
+    }
+  }
+
+  /**
    * Waits for all browser action popups to close, polling up to the specified timeout.
    * Used before extension reload to prevent zombie popups with invalidated contexts.
    *

--- a/apps/browser/src/popup/app.component.ts
+++ b/apps/browser/src/popup/app.component.ts
@@ -31,7 +31,6 @@ import {
   LogoutReason,
   UserDecryptionOptionsServiceAbstraction,
 } from "@bitwarden/auth/common";
-import { BrowserApi } from "@bitwarden/browser/platform/browser/browser-api";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { AuthRequestAnsweringService } from "@bitwarden/common/auth/abstractions/auth-request-answering/auth-request-answering.service.abstraction";
 import { AuthService } from "@bitwarden/common/auth/abstractions/auth.service";
@@ -248,12 +247,9 @@ export class AppComponent implements OnInit, OnDestroy {
                 window.location.reload();
               }, 2000);
             } else {
-              // Close browser action popup before extension reload to prevent zombie popup with invalidated context.
-              // This issue occurs in Chromium-based browsers (Chrome, Vivaldi, etc.) where chrome.runtime.reload()
-              // invalidates extension contexts before popup can close naturally
-              if (BrowserPopupUtils.inPopup(window)) {
-                BrowserApi.closePopup(window);
-              }
+              // On Chromium-based browsers (Chrome, Vivaldi, etc.), `chrome.runtime.reload()` invalidates extension contexts before the view can close naturally.
+              // Popouts also need closing because they survive the runtime reload and strand the user on broken states.
+              await BrowserPopupUtils.closeCurrentPopupOrPopout(window);
             }
           } else if (msg.command === "reloadPopup") {
             // FIXME: Verify that this floating promise is intentional. If it is, add an explanatory comment and ensure there is proper error handling.


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-20323
https://bitwarden.atlassian.net/browse/PM-22698

## 📔 Objective

Two bugs share a common root cause where a popout window survives a vault reload with an invalidated extension context, stranding the user:                                                                                          
  - PM-20323: Logout from the popup while a popout is open leaves the popout displaying a   
  New Tab page.                                                                            
  - PM-22698: Locking the vault from a popped-out window in Brave makes subsequent unlock   
  impossible.                                                                                                                                          
  
The results of the bug is the same in each case: after the triggering action, the popout window remains visible but its `chrome.*` APIs are not available.

### Root cause                                                                               

Vault lock / logout flows go through `DefaultProcessReloadService.executeProcessReload()`, which performs a two-step handshake against the runtime reload:                                  
  1. Broadcast `reloadProcess` to every open extension view so each view can close itself.
  2. Run the background's `systemUtilsServiceReloadCallback`, which polls `BrowserPopupUtils.waitForAllPopupsClose()` and then calls `BrowserApi.reloadExtension()`. On Chromium that resolves to `chrome.runtime.reload()`, a full extension restart that invalidates every extension context still alive at the moment it fires.

Both sides of that handshake were popup-only:
  - The view side:
    -  `app.component.ts` handled `reloadProcess` by calling `BrowserApi.closePopup(window)` _only when `BrowserPopupUtils.inPopup(window)` returned true_. `inPopup` returns false for popout windows (their URL is ?uilocation=popout), so popouts ran the handler, did nothing, and stayed open through the runtime reload.
  - The background side:
    - `waitForAllPopupsClose` polled `BrowserApi.isPopupOpen()`, which on MV3 only counts contexts with contextType === "POPUP". Popouts are classified as TAB contexts (the existing `isAnyViewFocused` already identifies them by `documentUrl.includes("uilocation=popout")`). So even if a popout did try to close itself, the background's "wait until views are gone" gate did not actually wait for it.
                                                                                                                                                               
### The change                                                                                 

Two coordinated edits restore the handshake's symmetry for popouts on Chromium.            
                                                         
  1. View-side teardown in `BrowserPopupUtils.closeCurrentPopupOrPopout(win)`. A new helper closes the current view based on its type. Popups go through the existing `BrowserApi.closePopup(win)` path. Popouts go through `BrowserApi.removeWindow(currentWindow.id)`, which is the same primitive `closeSingleActionPopout` already uses for popout cleanup.

`app.component.ts` now calls this single helper inside the `reloadProcess` handler's non-Safari branch.
                                                                                             
  3. Background-side wait in `BrowserApi.isAnyPopupOrPopoutOpen()`. A new predicate checks for both the toolbar popup and popout windows. On MV3 it scans `chrome.runtime.getContexts({})` for either contextType === "POPUP" or contextType === "TAB" with `uilocation=popout` in the `documentUrl`. On MV2/Safari it falls back to `chrome.extension.getViews({ type: "popup" })` and `chrome.extension.getViews({ type: "tab" })` filtered by URL.                                                                        

`waitForAllPopupsClose` now polls this predicate instead of `isPopupOpen`.
                                                         
  ### How this solves the problem                                                                     

  On Chromium, the handshake is now:                                                         
  
  1. `reloadProcess `broadcast → popup closes via closePopup, popout closes via removeWindow.  
  2. Background polls `isAnyPopupOrPopoutOpen` every 100ms; resolves once both view types are
  gone.                                                                                      
  4. `chrome.runtime.reload()` fires only after the OS has torn down both windows.

## 📸 Screenshots

This demonstrates that the popout closes, versus staying open with a New Tab.

https://github.com/user-attachments/assets/ab254122-e6f6-4eaa-bbf4-009c62203ce0