### PR TITLE
[PM-27527] Close 2FA popouts after auth regardless of current view

### DIFF
--- a/apps/browser/src/auth/services/extension-two-factor-auth-component.service.spec.ts
+++ b/apps/browser/src/auth/services/extension-two-factor-auth-component.service.spec.ts
@@ -107,56 +107,41 @@ describe("ExtensionTwoFactorAuthComponentService", () => {
   });
 
   describe("closeSingleActionPopouts", () => {
-    it("should call closeSsoAuthResultPopout if in SSO auth result popout", async () => {
-      const inSingleActionPopoutSpy = jest
-        .spyOn(BrowserPopupUtils, "inSingleActionPopout")
-        .mockImplementation((_, key) => {
-          return key === AuthPopoutType.ssoAuthResult;
-        });
+    it("closes every auth popout unconditionally", async () => {
+      jest.spyOn(BrowserPopupUtils, "inSingleActionPopout").mockReturnValue(false);
 
       await extensionTwoFactorAuthComponentService.closeSingleActionPopouts();
 
-      expect(inSingleActionPopoutSpy).toHaveBeenCalledTimes(1);
       expect(closeSsoAuthResultPopout).toHaveBeenCalled();
-    });
-
-    it("should call closeTwoFactorAuthWebAuthnPopout if in two factor auth webauthn popout", async () => {
-      const inSingleActionPopoutSpy = jest
-        .spyOn(BrowserPopupUtils, "inSingleActionPopout")
-        .mockImplementation((_, key) => {
-          return key === AuthPopoutType.twoFactorAuthWebAuthn;
-        });
-
-      await extensionTwoFactorAuthComponentService.closeSingleActionPopouts();
-
-      expect(inSingleActionPopoutSpy).toHaveBeenCalledTimes(2);
       expect(closeTwoFactorAuthWebAuthnPopout).toHaveBeenCalled();
-    });
-
-    it("should call closeTwoFactorAuthEmailPopout if in two factor auth email popout", async () => {
-      const inSingleActionPopoutSpy = jest
-        .spyOn(BrowserPopupUtils, "inSingleActionPopout")
-        .mockImplementation((_, key) => {
-          return key === AuthPopoutType.twoFactorAuthEmail;
-        });
-
-      await extensionTwoFactorAuthComponentService.closeSingleActionPopouts();
-
-      expect(inSingleActionPopoutSpy).toHaveBeenCalledTimes(3);
       expect(closeTwoFactorAuthEmailPopout).toHaveBeenCalled();
+      expect(closeTwoFactorAuthDuoPopout).toHaveBeenCalled();
     });
 
-    it("should call closeTwoFactorAuthDuoPopout if in two factor auth duo popout", async () => {
-      const inSingleActionPopoutSpy = jest
-        .spyOn(BrowserPopupUtils, "inSingleActionPopout")
-        .mockImplementation((_, key) => {
-          return key === AuthPopoutType.twoFactorAuthDuo;
-        });
+    it.each([
+      ["ssoAuthResult", AuthPopoutType.ssoAuthResult],
+      ["twoFactorAuthWebAuthn", AuthPopoutType.twoFactorAuthWebAuthn],
+      ["twoFactorAuthEmail", AuthPopoutType.twoFactorAuthEmail],
+      ["twoFactorAuthDuo", AuthPopoutType.twoFactorAuthDuo],
+    ])(
+      "returns true when the current view is in the %s popout",
+      async (_name, currentPopoutType) => {
+        jest
+          .spyOn(BrowserPopupUtils, "inSingleActionPopout")
+          .mockImplementation((_, key) => key === currentPopoutType);
 
-      await extensionTwoFactorAuthComponentService.closeSingleActionPopouts();
+        const result = await extensionTwoFactorAuthComponentService.closeSingleActionPopouts();
 
-      expect(inSingleActionPopoutSpy).toHaveBeenCalledTimes(4);
-      expect(closeTwoFactorAuthDuoPopout).toHaveBeenCalled();
+        expect(result).toBe(true);
+      },
+    );
+
+    it("returns false when the current view is not in any auth popout", async () => {
+      jest.spyOn(BrowserPopupUtils, "inSingleActionPopout").mockReturnValue(false);
+
+      const result = await extensionTwoFactorAuthComponentService.closeSingleActionPopouts();
+
+      expect(result).toBe(false);
     });
   });
 

--- a/apps/browser/src/auth/services/extension-two-factor-auth-component.service.ts
+++ b/apps/browser/src/auth/services/extension-two-factor-auth-component.service.ts
@@ -55,19 +55,18 @@ export class ExtensionTwoFactorAuthComponentService
     // we close by key unconditionally; `closeSingleActionPopout` is a no-op if no matching tab
     // exists. The boolean return reports whether the current view itself was one of those
     // popouts, so callers can skip navigating a view that's about to be torn down.
-    const currentViewIsInAuthPopout = [
-      AuthPopoutType.ssoAuthResult,
-      AuthPopoutType.twoFactorAuthWebAuthn,
-      AuthPopoutType.twoFactorAuthEmail,
-      AuthPopoutType.twoFactorAuthDuo,
-    ].some((popoutType) => BrowserPopupUtils.inSingleActionPopout(this.window, popoutType));
+    const authPopouts = [
+      { type: AuthPopoutType.ssoAuthResult, close: closeSsoAuthResultPopout },
+      { type: AuthPopoutType.twoFactorAuthWebAuthn, close: closeTwoFactorAuthWebAuthnPopout },
+      { type: AuthPopoutType.twoFactorAuthEmail, close: closeTwoFactorAuthEmailPopout },
+      { type: AuthPopoutType.twoFactorAuthDuo, close: closeTwoFactorAuthDuoPopout },
+    ];
 
-    await Promise.all([
-      closeSsoAuthResultPopout(),
-      closeTwoFactorAuthWebAuthnPopout(),
-      closeTwoFactorAuthEmailPopout(),
-      closeTwoFactorAuthDuoPopout(),
-    ]);
+    const currentViewIsInAuthPopout = authPopouts.some(({ type }) =>
+      BrowserPopupUtils.inSingleActionPopout(this.window, type),
+    );
+
+    await Promise.all(authPopouts.map(({ close }) => close()));
 
     return currentViewIsInAuthPopout;
   }

--- a/apps/browser/src/auth/services/extension-two-factor-auth-component.service.ts
+++ b/apps/browser/src/auth/services/extension-two-factor-auth-component.service.ts
@@ -29,9 +29,13 @@ export class ExtensionTwoFactorAuthComponentService
     return true;
   }
 
+  /**
+   * Adds a CSS class that widens the popup when needed for the WebAuthn 2FA prompt.
+   *
+   * The WebAuthn prompt appears inside the popup on Linux, and requires a larger popup width
+   * than usual to avoid cutting off the dialog.
+   */
   async extendPopupWidthIfRequired(selected2faProviderType: TwoFactorProviderType): Promise<void> {
-    // WebAuthn prompt appears inside the popup on linux, and requires a larger popup width
-    // than usual to avoid cutting off the dialog.
     const isLinux = await this.isLinux();
     if (selected2faProviderType === TwoFactorProviderType.WebAuthn && isLinux) {
       document.body.classList.add("linux-webauthn");
@@ -42,19 +46,23 @@ export class ExtensionTwoFactorAuthComponentService
     document.body.classList.remove("linux-webauthn");
   }
 
+  /**
+   * Reloads all extension views except the current one.
+   *
+   * Forces sidebars (Firefox and Opera) to reload while exempting the current window, because
+   * we are just going to close the current window if it is in a popout or navigate forward if
+   * it is in the popup.
+   */
   reloadOpenWindows(): void {
-    // Force sidebars (FF && Opera) to reload while exempting current window
-    // because we are just going to close the current window if it is in a popout
-    // or navigate forward if it is in the popup
     BrowserApi.reloadOpenWindows(true);
   }
 
+  /**
+   * Closes any auth-related single-action popouts that are open.
+   * @returns `true` if the current view itself is one of those popouts, so callers can skip
+   *   navigating a view that's about to be torn down.
+   */
   async closeSingleActionPopouts(): Promise<boolean> {
-    // Close any auth-related single-action popouts that are open. The popout may live in a
-    // different window than the current view (e.g., user expanded the extension during 2FA), so
-    // we close by key unconditionally; `closeSingleActionPopout` is a no-op if no matching tab
-    // exists. The boolean return reports whether the current view itself was one of those
-    // popouts, so callers can skip navigating a view that's about to be torn down.
     const authPopouts = [
       { type: AuthPopoutType.ssoAuthResult, close: closeSsoAuthResultPopout },
       { type: AuthPopoutType.twoFactorAuthWebAuthn, close: closeTwoFactorAuthWebAuthnPopout },

--- a/apps/browser/src/auth/services/extension-two-factor-auth-component.service.ts
+++ b/apps/browser/src/auth/services/extension-two-factor-auth-component.service.ts
@@ -50,51 +50,26 @@ export class ExtensionTwoFactorAuthComponentService
   }
 
   async closeSingleActionPopouts(): Promise<boolean> {
-    // If we are in a single action popout, we don't need the popout anymore because the intent
-    // is for the user to be left on the web vault screen which tells them to continue in
-    // the browser extension (sidebar or popup).  We don't want the user to be left with a
-    // floating, popped out extension which could be lost behind another window or minimized.
-    // Currently, the popped out window thinks it is active and wouldn't time out which
-    // leads to the security concern. So, we close the popped out extension to avoid this.
-    const inSsoAuthResultPopout = BrowserPopupUtils.inSingleActionPopout(
-      this.window,
+    // Close any auth-related single-action popouts that are open. The popout may live in a
+    // different window than the current view (e.g., user expanded the extension during 2FA), so
+    // we close by key unconditionally; `closeSingleActionPopout` is a no-op if no matching tab
+    // exists. The boolean return reports whether the current view itself was one of those
+    // popouts, so callers can skip navigating a view that's about to be torn down.
+    const currentViewIsInAuthPopout = [
       AuthPopoutType.ssoAuthResult,
-    );
-    if (inSsoAuthResultPopout) {
-      await closeSsoAuthResultPopout();
-      return true;
-    }
-
-    const inTwoFactorAuthWebAuthnPopout = BrowserPopupUtils.inSingleActionPopout(
-      this.window,
       AuthPopoutType.twoFactorAuthWebAuthn,
-    );
-
-    if (inTwoFactorAuthWebAuthnPopout) {
-      await closeTwoFactorAuthWebAuthnPopout();
-      return true;
-    }
-
-    const inTwoFactorAuthEmailPopout = BrowserPopupUtils.inSingleActionPopout(
-      this.window,
       AuthPopoutType.twoFactorAuthEmail,
-    );
-
-    if (inTwoFactorAuthEmailPopout) {
-      await closeTwoFactorAuthEmailPopout();
-      return true;
-    }
-
-    const inTwoFactorAuthDuoPopout = BrowserPopupUtils.inSingleActionPopout(
-      this.window,
       AuthPopoutType.twoFactorAuthDuo,
-    );
-    if (inTwoFactorAuthDuoPopout) {
-      await closeTwoFactorAuthDuoPopout();
-      return true;
-    }
+    ].some((popoutType) => BrowserPopupUtils.inSingleActionPopout(this.window, popoutType));
 
-    return false;
+    await Promise.all([
+      closeSsoAuthResultPopout(),
+      closeTwoFactorAuthWebAuthnPopout(),
+      closeTwoFactorAuthEmailPopout(),
+      closeTwoFactorAuthDuoPopout(),
+    ]);
+
+    return currentViewIsInAuthPopout;
   }
 
   private async isLinux(): Promise<boolean> {

--- a/apps/browser/src/auth/services/extension-two-factor-auth-component.service.ts
+++ b/apps/browser/src/auth/services/extension-two-factor-auth-component.service.ts
@@ -31,11 +31,10 @@ export class ExtensionTwoFactorAuthComponentService
 
   /**
    * Adds a CSS class that widens the popup when needed for the WebAuthn 2FA prompt.
-   *
-   * The WebAuthn prompt appears inside the popup on Linux, and requires a larger popup width
-   * than usual to avoid cutting off the dialog.
    */
   async extendPopupWidthIfRequired(selected2faProviderType: TwoFactorProviderType): Promise<void> {
+    // The WebAuthn prompt appears inside the popup on Linux, and requires a larger popup width
+    // than usual to avoid cutting off the dialog.
     const isLinux = await this.isLinux();
     if (selected2faProviderType === TwoFactorProviderType.WebAuthn && isLinux) {
       document.body.classList.add("linux-webauthn");
@@ -48,21 +47,22 @@ export class ExtensionTwoFactorAuthComponentService
 
   /**
    * Reloads all extension views except the current one.
-   *
-   * Forces sidebars (Firefox and Opera) to reload while exempting the current window, because
-   * we are just going to close the current window if it is in a popout or navigate forward if
-   * it is in the popup.
    */
   reloadOpenWindows(): void {
+    // Forces sidebars (Firefox and Opera) to reload while exempting the current window, because
+    // we are just going to close the current window if it is in a popout or navigate forward if
+    // it is in the popup.
     BrowserApi.reloadOpenWindows(true);
   }
 
   /**
    * Closes any auth-related single-action popouts that are open.
-   * @returns `true` if the current view itself is one of those popouts, so callers can skip
-   *   navigating a view that's about to be torn down.
+   * @returns `true` if the current view itself is one of those popouts.
    */
   async closeSingleActionPopouts(): Promise<boolean> {
+    // The popout may live in a different window than the current view (e.g., user opened the
+    // extension during 2FA), so we close by key unconditionally; `closeSingleActionPopout` is a
+    // no-op if no matching tab exists.
     const authPopouts = [
       { type: AuthPopoutType.ssoAuthResult, close: closeSsoAuthResultPopout },
       { type: AuthPopoutType.twoFactorAuthWebAuthn, close: closeTwoFactorAuthWebAuthnPopout },


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

`closeSingleActionPopouts` was gated on `inSingleActionPopout(this.window, key)`, so the popout only closed when auth completed inside that same popout view. If the user initiated focus on the extension popup during 2FA, authentication completed in the toolbar popup and the popout was left open with a stale state.

To solve this, we decouple the close from the gating check: close all four auth popouts unconditionally (closeSingleActionPopout is already a no-op when no matching tab exists), and return true only if the current view is inside one of those popouts so callers still skip navigating a view that's about to be torn down.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
