### PR TITLE
[PM-38373] Fix desktop search result keyboard focus

### DIFF
--- a/apps/desktop/src/app/layout/search/search-bar.service.ts
+++ b/apps/desktop/src/app/layout/search/search-bar.service.ts
@@ -6,10 +6,14 @@ export type SearchBarState = {
   placeholderText: string;
 };
 
+type SearchResultFocusTarget = () => boolean;
+
 @Injectable()
 export class SearchBarService {
   private searchTextSubject = new BehaviorSubject<string | null>(null);
   searchText$ = this.searchTextSubject.asObservable();
+
+  private searchResultFocusTarget: SearchResultFocusTarget | null = null;
 
   private _state = {
     enabled: false,
@@ -31,6 +35,14 @@ export class SearchBarService {
 
   setSearchText(value: string) {
     this.searchTextSubject.next(value);
+  }
+
+  setSearchResultFocusTarget(target: SearchResultFocusTarget | null) {
+    this.searchResultFocusTarget = target;
+  }
+
+  focusSearchResults() {
+    return this.searchResultFocusTarget?.() ?? false;
   }
 
   private updateState() {

--- a/apps/desktop/src/app/layout/search/search.component.html
+++ b/apps/desktop/src/app/layout/search/search.component.html
@@ -6,6 +6,8 @@
     autocomplete="off"
     [formControl]="searchText"
     appAutofocus
+    (keydown.tab)="focusSearchResults($event)"
+    (keydown.enter)="focusSearchResults($event)"
   />
   <bit-icon name="bwi-search"></bit-icon>
 </div>

--- a/apps/desktop/src/app/layout/search/search.component.ts
+++ b/apps/desktop/src/app/layout/search/search.component.ts
@@ -47,4 +47,18 @@ export class SearchComponent implements OnInit, OnDestroy {
   ngOnDestroy() {
     this.activeAccountSubscription.unsubscribe();
   }
+
+  focusSearchResults(event: Event) {
+    if (!(event instanceof KeyboardEvent)) {
+      return;
+    }
+
+    if (event.shiftKey || !this.searchText.value) {
+      return;
+    }
+
+    if (this.searchBarService.focusSearchResults()) {
+      event.preventDefault();
+    }
+  }
 }

--- a/apps/desktop/src/vault/app/vault-v3/vault.component.html
+++ b/apps/desktop/src/vault/app/vault-v3/vault.component.html
@@ -15,6 +15,8 @@
     class="tw-mb-4 tw-px-6"
     [ngModel]="currentSearchText$ | async"
     (ngModelChange)="filterSearchText($event)"
+    (keydown.tab)="focusSearchResults($event)"
+    (keydown.enter)="focusSearchResults($event)"
     [placeholder]="searchPlaceholderText"
     appAutofocus
   />

--- a/apps/desktop/src/vault/app/vault-v3/vault.component.ts
+++ b/apps/desktop/src/vault/app/vault-v3/vault.component.ts
@@ -5,6 +5,7 @@ import {
   ChangeDetectorRef,
   Component,
   DestroyRef,
+  ElementRef,
   inject,
   NgZone,
   OnDestroy,
@@ -174,6 +175,7 @@ export class VaultComponent<C extends CipherViewLike> implements OnInit, OnDestr
   private routedVaultFilterService = inject(RoutedVaultFilterService);
   private vaultItemTransferService: VaultItemsTransferService = inject(VaultItemsTransferService);
   private searchBarService = inject(SearchBarService);
+  private elementRef = inject(ElementRef<HTMLElement>);
 
   private destroyRef = inject(DestroyRef);
   private cipherFormConfigService = inject(CipherFormConfigService);
@@ -321,6 +323,7 @@ export class VaultComponent<C extends CipherViewLike> implements OnInit, OnDestr
     this.activeUserId = activeUserId;
 
     this.searchBarService.setEnabled(false);
+    this.searchBarService.setSearchResultFocusTarget(() => this.focusFirstResult());
 
     // Clear cipher selection on page load/reload to prevent flash of content
     const currentParams = await firstValueFrom(this.route.queryParams);
@@ -484,6 +487,7 @@ export class VaultComponent<C extends CipherViewLike> implements OnInit, OnDestr
 
   ngOnDestroy() {
     this.broadcasterService.unsubscribe(BroadcasterSubscriptionId);
+    this.searchBarService.setSearchResultFocusTarget(null);
     this.destroy$.next();
     this.destroy$.complete();
     this.vaultFilterService.clearOrganizationFilter();
@@ -926,5 +930,39 @@ export class VaultComponent<C extends CipherViewLike> implements OnInit, OnDestr
       this.cipherRepromptId = cipher.id;
     }
     return repromptResult;
+  }
+
+  protected focusSearchResults(event: Event) {
+    if (!(event instanceof KeyboardEvent)) {
+      return;
+    }
+
+    if (event.shiftKey || !this.searchInputValue()) {
+      return;
+    }
+
+    if (this.focusFirstResult()) {
+      event.preventDefault();
+    }
+  }
+
+  private focusFirstResult() {
+    const firstResult = this.elementRef.nativeElement.querySelector(
+      "app-vault-list tr[appVaultCipherRow] button[bitLink]:not([disabled]), app-vault-list tr[appVaultCollectionRow] button[bitLink]:not([disabled])",
+    ) as HTMLElement | null;
+
+    if (firstResult == null) {
+      return false;
+    }
+
+    firstResult.focus();
+    return document.activeElement === firstResult;
+  }
+
+  private searchInputValue() {
+    return (
+      (this.elementRef.nativeElement.querySelector("bit-search input") as HTMLInputElement | null)
+        ?.value ?? ""
+    );
   }
 }

--- a/apps/desktop/src/vault/app/vault/vault-items-v2.component.ts
+++ b/apps/desktop/src/vault/app/vault/vault-items-v2.component.ts
@@ -1,6 +1,6 @@
 import { ScrollingModule } from "@angular/cdk/scrolling";
 import { CommonModule } from "@angular/common";
-import { Component, input, output } from "@angular/core";
+import { Component, ElementRef, input, output } from "@angular/core";
 import { takeUntilDestroyed, toSignal } from "@angular/core/rxjs-interop";
 import { distinctUntilChanged, debounceTime } from "rxjs";
 
@@ -62,8 +62,11 @@ export class VaultItemsV2Component<C extends CipherViewLike> extends BaseVaultIt
     restrictedItemTypesService: RestrictedItemTypesService,
     configService: ConfigService,
     private premiumUpgradePromptService: PremiumUpgradePromptService,
+    private elementRef: ElementRef<HTMLElement>,
   ) {
     super(searchService, cipherService, accountService, restrictedItemTypesService, configService);
+
+    this.searchBarService.setSearchResultFocusTarget(() => this.focusFirstResult());
 
     this.searchBarService.searchText$
       .pipe(debounceTime(SearchTextDebounceInterval), distinctUntilChanged(), takeUntilDestroyed())
@@ -72,11 +75,33 @@ export class VaultItemsV2Component<C extends CipherViewLike> extends BaseVaultIt
       });
   }
 
+  override ngOnDestroy(): void {
+    this.searchBarService.setSearchResultFocusTarget(null);
+    super.ngOnDestroy();
+  }
+
   async navigateToGetPremium() {
     await this.premiumUpgradePromptService.promptForPremium();
   }
 
   trackByFn(index: number, c: C): string {
     return uuidAsString(c.id!);
+  }
+
+  private focusFirstResult() {
+    if (!this.loaded || this.ciphers.length === 0) {
+      return false;
+    }
+
+    const firstResult = this.elementRef.nativeElement.querySelector<HTMLElement>(
+      "button.flex-list-item:not([disabled])",
+    );
+
+    if (firstResult == null) {
+      return false;
+    }
+
+    firstResult.focus();
+    return document.activeElement === firstResult;
   }
 }


### PR DESCRIPTION
## Tracking

Closes #20802
Related to #20382

## Objective

Restore the desktop keyboard workflow from vault search into the matching vault results. After entering a search, pressing Tab or Enter should focus the first matching vault item instead of moving focus through the sidebar/account chrome.

This wires the search-result focus handoff into both the shared desktop search component and the active vault-v3 desktop path.

## Testing

Local verification on macOS arm64 desktop dev build:

- Typing a query filters vault items
- Enter from search focuses the first matching vault item
- Tab from search focuses the first matching vault item
- Shift+Tab remains available for reverse tab navigation

Automated checks run locally:

- `npx prettier --write` on changed files
- `git diff --check`
- `npx eslint` on changed TypeScript files
- `npx tsc --noEmit -p apps/desktop/tsconfig.renderer.json`
