### PR TITLE
[PM-38386] PM-37672 Import archived 1Password items as archived ciphers

### DIFF
--- a/libs/importer/src/importers/onepassword/onepassword-1pux-importer.spec.ts
+++ b/libs/importer/src/importers/onepassword/onepassword-1pux-importer.spec.ts
@@ -61,14 +61,16 @@ describe("1Password 1Pux Importer", () => {
   const SecureNoteDataJson = JSON.stringify(SecureNoteData);
   const SanitizedExportJson = JSON.stringify(SanitizedExport);
 
-  it("should not import items with state 'archived'", async () => {
+  it("should import items with state 'archived' as archived ciphers", async () => {
     const importer = new OnePassword1PuxImporter();
-    const archivedLoginData = LoginData;
+    const archivedLoginData = JSON.parse(JSON.stringify(LoginData));
     archivedLoginData["accounts"][0]["vaults"][0]["items"][0]["state"] = "archived";
     const archivedDataJson = JSON.stringify(archivedLoginData);
     const result = await importer.parse(archivedDataJson);
     expect(result != null).toBe(true);
-    expect(result.ciphers.length).toBe(0);
+    expect(result.ciphers.length).toBe(1);
+    expect(result.ciphers[0].name).toBe("eToro");
+    expect(result.ciphers[0].archivedDate).toBeInstanceOf(Date);
   });
 
   it("should parse login data", async () => {

--- a/libs/importer/src/importers/onepassword/onepassword-1pux-importer.ts
+++ b/libs/importer/src/importers/onepassword/onepassword-1pux-importer.ts
@@ -41,11 +41,10 @@ export class OnePassword1PuxImporter extends BaseImporter implements Importer {
     // const personalVaults = account.vaults[0].filter((v) => v.attrs.type === VaultAttributeTypeEnum.Personal);
     account.vaults.forEach((vault: VaultsEntity) => {
       vault.items.forEach((item: Item) => {
-        if (item.state === "archived") {
-          return;
-        }
-
         const cipher = this.initLoginCipher();
+        if (item.state === "archived") {
+          cipher.archivedDate = new Date();
+        }
 
         const category = item.categoryUuid as Category;
         switch (category) {


### PR DESCRIPTION
﻿## Type of change

- [x] Bug fix

## Objective

Fixes #20694 / PM-37672.

The 1Password 1PUX importer was skipping items where `state` is `archived`. That means archived items from 1Password never made it into Bitwarden at all.

This keeps importing those items and marks the resulting cipher as archived instead.

## Code changes

- Remove the early return for `item.state === "archived"`.
- Set `cipher.archivedDate` for archived 1PUX items.
- Update the existing importer test to assert archived items are imported as archived ciphers.

## Testing requirements

Ran locally:

- `npx eslint "libs/importer/src/importers/onepassword/onepassword-1pux-importer.ts" "libs/importer/src/importers/onepassword/onepassword-1pux-importer.spec.ts"`
- `npx jest libs/importer/src/importers/onepassword/onepassword-1pux-importer.spec.ts --runInBand`
