### PR TITLE
[PM-38404] fix(desktop): fix memory leak - IPC listeners + OnPush change detection

### DIFF
--- a/apps/desktop/src/app/app.component.ts
+++ b/apps/desktop/src/app/app.component.ts
@@ -1,6 +1,8 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
 import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
   Component,
   DestroyRef,
   NgZone,
@@ -85,10 +87,9 @@ const BroadcasterSubscriptionId = "AppComponent";
 const IdleTimeout = 60000 * 10; // 10 minutes
 const SyncInterval = 6 * 60 * 60 * 1000; // 6 hours
 
-// FIXME(https://bitwarden.atlassian.net/browse/CL-764): Migrate to OnPush
-// eslint-disable-next-line @angular-eslint/prefer-on-push-component-change-detection
 @Component({
   selector: "app-root",
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styles: [],
   template: `
     <ng-template #settings></ng-template>
@@ -176,6 +177,7 @@ export class AppComponent implements OnInit, OnDestroy {
     private authRequestAnsweringService: AuthRequestAnsweringService,
     private ssoLoginService: SsoLoginServiceAbstraction,
     private accountDeletionService: AccountDeletionService,
+    private readonly cdr: ChangeDetectorRef,
   ) {
     this.deviceTrustToastService.setupListeners$.pipe(takeUntilDestroyed()).subscribe();
 
@@ -237,8 +239,10 @@ export class AppComponent implements OnInit, OnDestroy {
             break;
           case "logout":
             this.loading = message.userId == null || message.userId === this.activeUserId;
+            this.cdr.markForCheck();
             await this.logOut(message.logoutReason, message.userId);
             this.loading = false;
+            this.cdr.markForCheck();
             break;
           case "lockVault":
             await this.lockService.lock(message.userId ?? this.activeUserId);
@@ -485,11 +489,13 @@ export class AppComponent implements OnInit, OnDestroy {
             } else {
               this.messagingService.send("unlocked");
               this.loading = true;
+              this.cdr.markForCheck();
               await this.syncService.fullSync(false);
               // Force reload to ensure route guards are activated
               await this.router.navigate(["vault"], { onSameUrlNavigation: "reload" });
               // Clear loading after navigating to avoid flickering the previous route
               this.loading = false;
+              this.cdr.markForCheck();
             }
             this.messagingService.send("finishSwitchAccount");
             break;
@@ -809,8 +815,7 @@ export class AppComponent implements OnInit, OnDestroy {
 
     [this.modal] = await this.modalService.openViewRef(type, ref);
 
-    // eslint-disable-next-line rxjs-angular/prefer-takeuntil
-    this.modal.onClosed.subscribe(() => {
+    this.modal.onClosed.pipe(takeUntil(this.destroy$)).subscribe(() => {
       this.modal = null;
     });
   }

--- a/apps/desktop/src/platform/preload.ts
+++ b/apps/desktop/src/platform/preload.ts
@@ -140,8 +140,10 @@ export default {
   ): Promise<number> => ipcRenderer.invoke("openContextMenu", { menu }),
 
   getSystemTheme: (): Promise<ThemeType> => ipcRenderer.invoke("systemTheme"),
-  onSystemThemeUpdated: (callback: (theme: ThemeType) => void) => {
-    ipcRenderer.on("systemThemeUpdated", (_event, theme: ThemeType) => callback(theme));
+  onSystemThemeUpdated: (callback: (theme: ThemeType) => void): (() => void) => {
+    const wrapper = (_event: any, theme: ThemeType) => callback(theme);
+    ipcRenderer.on("systemThemeUpdated", wrapper);
+    return () => ipcRenderer.removeListener("systemThemeUpdated", wrapper);
   },
 
   isWindowVisible: (): Promise<boolean> => ipcRenderer.invoke("windowVisible"),
@@ -151,22 +153,27 @@ export default {
 
   sendMessage: (message: { command: string } & any) =>
     ipcRenderer.send("messagingService", message),
-  onMessage: {
-    addListener: (callback: (message: { command: string } & any) => void) => {
-      ipcRenderer.addListener("messagingService", (_event, message: any) => {
-        if (message.command) {
-          callback(message);
+  onMessage: (() => {
+    const listenerMap = new Map<Function, (...args: any[]) => void>();
+    return {
+      addListener: (callback: (message: { command: string } & any) => void) => {
+        const wrapper = (_event: any, message: any) => {
+          if (message.command) {
+            callback(message);
+          }
+        };
+        listenerMap.set(callback, wrapper);
+        ipcRenderer.addListener("messagingService", wrapper);
+      },
+      removeListener: (callback: (message: { command: string } & any) => void) => {
+        const wrapper = listenerMap.get(callback);
+        if (wrapper) {
+          ipcRenderer.removeListener("messagingService", wrapper);
+          listenerMap.delete(callback);
         }
-      });
-    },
-    removeListener: (callback: (message: { command: string } & any) => void) => {
-      ipcRenderer.removeListener("messagingService", (_event, message: any) => {
-        if (message.command) {
-          callback(message);
-        }
-      });
-    },
-  },
+      },
+    };
+  })(),
 
   launchUri: (uri: string) => ipcRenderer.invoke("launchUri", uri),
 

--- a/apps/desktop/src/platform/utils/from-ipc-system-theme.ts
+++ b/apps/desktop/src/platform/utils/from-ipc-system-theme.ts
@@ -1,4 +1,4 @@
-import { defer, fromEventPattern, merge } from "rxjs";
+import { defer, merge, Observable } from "rxjs";
 
 import { ThemeType } from "@bitwarden/common/platform/enums";
 
@@ -8,8 +8,9 @@ import { ThemeType } from "@bitwarden/common/platform/enums";
 export const fromIpcSystemTheme = () => {
   return merge(
     defer(() => ipc.platform.getSystemTheme()),
-    fromEventPattern<ThemeType>((handler) =>
-      ipc.platform.onSystemThemeUpdated((theme) => handler(theme)),
-    ),
+    new Observable<ThemeType>((subscriber) => {
+      const cleanup = ipc.platform.onSystemThemeUpdated((theme) => subscriber.next(theme));
+      return cleanup;
+    }),
   );
 };


### PR DESCRIPTION
## 🎟️ Tracking

Relates to #19054

> Same as the other PR I opened — the issue had a long debate about what language this should be rewritten in but the actual causes of the leak are fixable right now without rewriting anything. This PR goes a bit deeper than the other one.

## 📔 Objective

This PR includes the same three IPC listener leak fixes from my other PR ([fix/ipc-listener-leaks](https://github.com/bitwarden/clients/pull/20945)), plus a migration of `AppComponent` to `ChangeDetectionStrategy.OnPush` that was already tracked as a FIXME in the code.

---

### Bugs 1–3 — IPC listener leaks (same as the other PR)

Quick summary:

- `onMessage.removeListener` was creating a new arrow function instead of reusing the original wrapper, so `ipcRenderer.removeListener` never found a match and listeners accumulated forever
- `onSystemThemeUpdated` registered an `ipcRenderer.on` listener with no way to remove it, and `fromIpcSystemTheme` was using `fromEventPattern` without a `removeHandler`
- `openModal` had an explicit eslint-disable to skip `takeUntil`, leaving the subscription uncleaned

See the other PR for the full explanation of each one.

---

### Bug 4 — `AppComponent` was running change detection on every single async event

There was already a `// FIXME(CL-764): Migrate to OnPush` comment in the code. This is the most impactful change for the memory growth over time.

With `ChangeDetectionStrategy.Default`, every IPC message, every SignalR heartbeat and every timer callback triggers a full change detection cycle across the whole component tree. Over several days running in the background this creates a constant stream of short-lived object allocations and deallocations. Even when the GC collects those objects, V8 does not aggressively release pages back to the OS — the heap keeps growing to accommodate the peak usage, which is exactly the behavior people are reporting in the issue.

Migrating to `OnPush` means Angular only runs change detection when:
- An `async` pipe observable emits a new value
- `markForCheck()` is called explicitly
- An event originates from the component or its children

The only place where the template reads mutable state directly is the `loading` boolean, which is set in two cases inside the broadcaster callback. Added `this.cdr.markForCheck()` right after each assignment so the template still updates correctly when those transitions happen.

---

## 📸 Screenshots

N/A — no UI changes.