### PR TITLE
[PM-37806] Add batch action bar to individual vault

### DIFF
--- a/apps/web/src/app/vault/components/assign-collections/assign-collections-web-dialog.adapter.ts
+++ b/apps/web/src/app/vault/components/assign-collections/assign-collections-web-dialog.adapter.ts
@@ -1,0 +1,25 @@
+import { Injectable, inject } from "@angular/core";
+import { lastValueFrom } from "rxjs";
+
+import { DialogService } from "@bitwarden/components";
+import {
+  AssignCollectionsDialogRef,
+  AssignCollectionsParams,
+  AssignCollectionsResult,
+  CollectionAssignmentResult,
+} from "@bitwarden/vault";
+
+import { AssignCollectionsWebComponent } from "./assign-collections-web.component";
+
+@Injectable()
+export class AssignCollectionsWebDialogAdapter implements AssignCollectionsDialogRef {
+  private readonly dialogService = inject(DialogService);
+
+  async open(params: AssignCollectionsParams): Promise<AssignCollectionsResult> {
+    const dialog = AssignCollectionsWebComponent.open(this.dialogService, { data: params });
+    const result = await lastValueFrom(dialog.closed);
+    return result === CollectionAssignmentResult.Saved
+      ? AssignCollectionsResult.Saved
+      : AssignCollectionsResult.Canceled;
+  }
+}

--- a/apps/web/src/app/vault/components/vault-items/vault-items.component.html
+++ b/apps/web/src/app/vault/components/vault-items/vault-items.component.html
@@ -64,67 +64,77 @@
         }
         <th
           bitCell
-          [class]="((showCopyAndLaunchActions$ | async) ? 'tw-w-28' : 'tw-w-12') + ' tw-text-right'"
+          [ngClass]="
+            ((showCopyAndLaunchActions$ | async)
+              ? 'tw-w-28'
+              : batchBarService && batchBarFlag()
+                ? 'tw-w-24'
+                : 'tw-w-12') + ' tw-text-right'
+          "
         >
-          @let menuDisabled = disableMenu$ | async;
-          <button
-            [disabled]="disabled || isEmpty || menuDisabled"
-            [bitMenuTriggerFor]="headerMenu"
-            [attr.title]="menuDisabled ? ('missingPermissions' | i18n) : ''"
-            bitIconButton="bwi-ellipsis-v"
-            size="small"
-            type="button"
-            label="{{ 'options' | i18n }}"
-          ></button>
-          <bit-menu #headerMenu>
-            @if (bulkMoveAllowed) {
-              <button type="button" bitMenuItem (click)="bulkMoveToFolder()">
-                <i class="bwi bwi-fw bwi-folder" aria-hidden="true"></i>
-                {{ "addToFolder" | i18n }}
-              </button>
-            }
-            @if (showAdminActions && showBulkEditCollectionAccess) {
-              <button type="button" bitMenuItem (click)="bulkEditCollectionAccess()">
-                <i class="bwi bwi-fw bwi-users" aria-hidden="true"></i>
-                {{ "editAccess" | i18n }}
-              </button>
-            }
-            @if (
-              (showAdminActions || showAssignToCollections()) && bulkAssignToCollectionsAllowed
-            ) {
-              <button type="button" bitMenuItem (click)="assignToCollections()">
-                <i class="bwi bwi-fw bwi-collection-shared" aria-hidden="true"></i>
-                {{ "assignToCollections" | i18n }}
-              </button>
-            }
+          @if (!batchBarService || !batchBarFlag()) {
+            @let menuDisabled = disableMenu$ | async;
+            <button
+              [disabled]="disabled || isEmpty || menuDisabled"
+              [bitMenuTriggerFor]="headerMenu"
+              [attr.title]="menuDisabled ? ('missingPermissions' | i18n) : ''"
+              bitIconButton="bwi-ellipsis-v"
+              size="small"
+              type="button"
+              label="{{ 'options' | i18n }}"
+            ></button>
+            <bit-menu #headerMenu>
+              @if (bulkMoveAllowed) {
+                <button type="button" bitMenuItem (click)="bulkMoveToFolder()">
+                  <i class="bwi bwi-fw bwi-folder" aria-hidden="true"></i>
+                  {{ "addToFolder" | i18n }}
+                </button>
+              }
+              @if (showAdminActions && showBulkEditCollectionAccess) {
+                <button type="button" bitMenuItem (click)="bulkEditCollectionAccess()">
+                  <i class="bwi bwi-fw bwi-users" aria-hidden="true"></i>
+                  {{ "editAccess" | i18n }}
+                </button>
+              }
+              @if (
+                (showAdminActions || showAssignToCollections()) && bulkAssignToCollectionsAllowed
+              ) {
+                <button type="button" bitMenuItem (click)="assignToCollections()">
+                  <i class="bwi bwi-fw bwi-collection-shared" aria-hidden="true"></i>
+                  {{ "assignToCollections" | i18n }}
+                </button>
+              }
 
-            @if (bulkArchiveAllowed) {
-              <button type="button" bitMenuItem (click)="bulkArchive()">
-                <i class="bwi bwi-fw bwi-archive" aria-hidden="true"></i>
-                {{ "archiveVerb" | i18n }}
-              </button>
-            }
+              @if (bulkArchiveAllowed) {
+                <button type="button" bitMenuItem (click)="bulkArchive()">
+                  <i class="bwi bwi-fw bwi-archive" aria-hidden="true"></i>
+                  {{ "archiveVerb" | i18n }}
+                </button>
+              }
 
-            @if (bulkUnarchiveAllowed) {
-              <button type="button" bitMenuItem (click)="bulkUnarchive()">
-                <i class="bwi bwi-fw bwi-unarchive" aria-hidden="true"></i>
-                {{ "unArchive" | i18n }}
-              </button>
-            }
+              @if (bulkUnarchiveAllowed) {
+                <button type="button" bitMenuItem (click)="bulkUnarchive()">
+                  <i class="bwi bwi-fw bwi-unarchive" aria-hidden="true"></i>
+                  {{ "unArchive" | i18n }}
+                </button>
+              }
 
-            @if (canRestoreSelected$ | async) {
-              <button type="button" bitMenuItem (click)="bulkRestore()">
-                <i class="bwi bwi-fw bwi-undo" aria-hidden="true"></i>
-                {{ "restoreSelected" | i18n }}
-              </button>
-            }
-            @if (canDeleteSelected$ | async) {
-              <button type="button" variant="danger" bitMenuItem (click)="bulkDelete()">
-                <bit-icon fixedWidth name="bwi-trash" slot="start" />
-                {{ (showBulkTrashOptions ? "permanentlyDeleteSelected" : "delete") | i18n }}
-              </button>
-            }
-          </bit-menu>
+              @if (canRestoreSelected$ | async) {
+                <button type="button" bitMenuItem (click)="bulkRestore()">
+                  <i class="bwi bwi-fw bwi-undo" aria-hidden="true"></i>
+                  {{ "restoreSelected" | i18n }}
+                </button>
+              }
+              @if (canDeleteSelected$ | async) {
+                <button type="button" variant="danger" bitMenuItem (click)="bulkDelete()">
+                  <bit-icon fixedWidth name="bwi-trash" slot="start" />
+                  {{ (showBulkTrashOptions ? "permanentlyDeleteSelected" : "delete") | i18n }}
+                </button>
+              }
+            </bit-menu>
+          } @else {
+            {{ "options" | i18n }}
+          }
         </th>
       </tr>
     </ng-container>

--- a/apps/web/src/app/vault/components/vault-items/vault-items.component.ts
+++ b/apps/web/src/app/vault/components/vault-items/vault-items.component.ts
@@ -1,8 +1,8 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
 import { SelectionModel } from "@angular/cdk/collections";
-import { Component, EventEmitter, Input, Output } from "@angular/core";
-import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
+import { Component, EventEmitter, Input, Output, inject } from "@angular/core";
+import { takeUntilDestroyed, toSignal } from "@angular/core/rxjs-interop";
 import {
   Observable,
   combineLatest,
@@ -32,7 +32,7 @@ import {
 } from "@bitwarden/common/vault/utils/cipher-view-like-utils";
 import { SortDirection, TableDataSource } from "@bitwarden/components";
 import { OrganizationId } from "@bitwarden/sdk-internal";
-import { RoutedVaultFilterService, VaultItem } from "@bitwarden/vault";
+import { RoutedVaultFilterService, VaultBatchBarService, VaultItem } from "@bitwarden/vault";
 
 import { GroupView } from "../../../admin-console/organizations/core";
 
@@ -151,9 +151,20 @@ export class VaultItemsComponent<C extends CipherViewLike> {
   // eslint-disable-next-line @angular-eslint/prefer-output-emitter-ref
   @Output() onEvent = new EventEmitter<VaultItemEvent<C>>();
 
+  protected readonly batchBarService = inject(VaultBatchBarService, {
+    optional: true,
+  }) as VaultBatchBarService<C> | null;
+  protected readonly batchBarFlag = toSignal(
+    this.configService.getFeatureFlag$(FeatureFlag.PM37785_VaultBatchBar),
+    { initialValue: false },
+  );
+
   protected editableItems: VaultItem<C>[] = [];
   protected dataSource = new TableDataSource<VaultItem<C>>();
-  protected selection = new SelectionModel<VaultItem<C>>(true, [], true);
+  private readonly _localSelection = new SelectionModel<VaultItem<C>>(true, [], true);
+  get selection(): SelectionModel<VaultItem<C>> {
+    return this.batchBarService?.selection ?? this._localSelection;
+  }
   protected canDeleteSelected$: Observable<boolean>;
   protected canRestoreSelected$: Observable<boolean>;
   protected disableMenu$: Observable<boolean>;
@@ -236,21 +247,23 @@ export class VaultItemsComponent<C extends CipherViewLike> {
       }),
     );
 
-    this.routedVaultFilterService.filter$
-      .pipe(
-        distinctUntilChanged(
-          (prev, curr) =>
-            prev.organizationId === curr.organizationId &&
-            prev.collectionId === curr.collectionId &&
-            prev.folderId === curr.folderId &&
-            prev.type === curr.type &&
-            prev.organizationIdParamType === curr.organizationIdParamType,
-        ),
-        takeUntilDestroyed(),
-      )
-      .subscribe(() => {
-        this.clearSelection();
-      });
+    if (!this.batchBarService) {
+      this.routedVaultFilterService.filter$
+        .pipe(
+          distinctUntilChanged(
+            (prev, curr) =>
+              prev.organizationId === curr.organizationId &&
+              prev.collectionId === curr.collectionId &&
+              prev.folderId === curr.folderId &&
+              prev.type === curr.type &&
+              prev.organizationIdParamType === curr.organizationIdParamType,
+          ),
+          takeUntilDestroyed(),
+        )
+        .subscribe(() => {
+          this.clearSelection();
+        });
+    }
   }
 
   clearSelection() {

--- a/apps/web/src/app/vault/individual-vault/bulk-action-dialogs/bulk-delete-dialog-web.adapter.ts
+++ b/apps/web/src/app/vault/individual-vault/bulk-action-dialogs/bulk-delete-dialog-web.adapter.ts
@@ -1,0 +1,21 @@
+import { Injectable, inject } from "@angular/core";
+import { lastValueFrom } from "rxjs";
+
+import { DialogService } from "@bitwarden/components";
+import {
+  BulkDeleteDialogParams,
+  BulkDeleteDialogRef,
+  BulkDeleteDialogResult,
+} from "@bitwarden/vault";
+
+import { openBulkDeleteDialog } from "./bulk-delete-dialog/bulk-delete-dialog.component";
+
+@Injectable()
+export class BulkDeleteDialogWebAdapter implements BulkDeleteDialogRef {
+  private readonly dialogService = inject(DialogService);
+
+  async open(params: BulkDeleteDialogParams): Promise<BulkDeleteDialogResult> {
+    const dialog = openBulkDeleteDialog(this.dialogService, { data: params });
+    return lastValueFrom(dialog.closed);
+  }
+}

--- a/apps/web/src/app/vault/individual-vault/bulk-action-dialogs/bulk-delete-dialog-web.adapter.ts
+++ b/apps/web/src/app/vault/individual-vault/bulk-action-dialogs/bulk-delete-dialog-web.adapter.ts
@@ -1,5 +1,6 @@
 import { Injectable, inject } from "@angular/core";
 import { lastValueFrom } from "rxjs";
+import { map } from "rxjs/operators";
 
 import { DialogService } from "@bitwarden/components";
 import {
@@ -16,6 +17,6 @@ export class BulkDeleteDialogWebAdapter implements BulkDeleteDialogRef {
 
   async open(params: BulkDeleteDialogParams): Promise<BulkDeleteDialogResult> {
     const dialog = openBulkDeleteDialog(this.dialogService, { data: params });
-    return lastValueFrom(dialog.closed);
+    return lastValueFrom(dialog.closed.pipe(map((r) => r ?? BulkDeleteDialogResult.Canceled)));
   }
 }

--- a/apps/web/src/app/vault/individual-vault/vault.component.html
+++ b/apps/web/src/app/vault/individual-vault/vault.component.html
@@ -108,3 +108,7 @@
     }
   </div>
 </div>
+
+@if (vaultBatchBarFeatureFlag()) {
+  <bit-vault-batch-action />
+}

--- a/apps/web/src/app/vault/individual-vault/vault.component.spec.ts
+++ b/apps/web/src/app/vault/individual-vault/vault.component.spec.ts
@@ -1,3 +1,4 @@
+import { SelectionModel } from "@angular/cdk/collections";
 import { NO_ERRORS_SCHEMA } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { By } from "@angular/platform-browser";
@@ -50,12 +51,20 @@ import { CipherViewLike } from "@bitwarden/common/vault/utils/cipher-view-like-u
 import { DialogRef, DialogService, ToastService } from "@bitwarden/components";
 import { MessageListener } from "@bitwarden/messaging";
 import {
+  ASSIGN_COLLECTIONS_DIALOG,
+  AssignCollectionsDialogRef,
+  AssignCollectionsResult,
+  BULK_DELETE_DIALOG,
+  BulkDeleteDialogRef,
+  BulkDeleteDialogResult,
   DefaultCipherFormConfigService,
   PasswordRepromptService,
   RoutedVaultFilterBridgeService,
   RoutedVaultFilterService,
+  VaultBatchBarService,
   VaultFilter,
   VaultFilterServiceAbstraction,
+  VaultItem,
   VaultItemDialogComponent,
   VaultItemDialogResult,
   VaultItemEvent,
@@ -291,6 +300,32 @@ describe("VaultComponent", () => {
             {
               provide: VaultItemsTransferService,
               useValue: mock<VaultItemsTransferService>(),
+            },
+            {
+              provide: VaultBatchBarService,
+              useValue: {
+                completed$: EMPTY,
+                selection: new SelectionModel<VaultItem<any>>(true, [], true),
+                setConfig: jest.fn(),
+                bulkArchive: jest.fn(),
+                bulkUnarchive: jest.fn(),
+                bulkRestore: jest.fn(),
+                bulkDelete: jest.fn(),
+                bulkMoveToFolder: jest.fn(),
+                bulkAssignToCollections: jest.fn(),
+              },
+            },
+            {
+              provide: ASSIGN_COLLECTIONS_DIALOG,
+              useValue: {
+                open: jest.fn().mockResolvedValue(AssignCollectionsResult.Canceled),
+              } satisfies AssignCollectionsDialogRef,
+            },
+            {
+              provide: BULK_DELETE_DIALOG,
+              useValue: {
+                open: jest.fn().mockResolvedValue(BulkDeleteDialogResult.Canceled),
+              } satisfies BulkDeleteDialogRef,
             },
           ],
         },

--- a/apps/web/src/app/vault/individual-vault/vault.component.ts
+++ b/apps/web/src/app/vault/individual-vault/vault.component.ts
@@ -1,4 +1,5 @@
 import { ChangeDetectorRef, Component, NgZone, OnDestroy, OnInit, viewChild } from "@angular/core";
+import { toSignal } from "@angular/core/rxjs-interop";
 import { ActivatedRoute, NavigationExtras, Params, Router } from "@angular/router";
 import { combineLatest, firstValueFrom, lastValueFrom, Observable, of, Subject } from "rxjs";
 import {
@@ -49,7 +50,9 @@ import { getUserId } from "@bitwarden/common/auth/services/account.service";
 import { BillingAccountProfileStateService } from "@bitwarden/common/billing/abstractions/account/billing-account-profile-state.service";
 import { BillingApiServiceAbstraction } from "@bitwarden/common/billing/abstractions/billing-api.service.abstraction";
 import { EventCollectionService, EventType } from "@bitwarden/common/dirt/event-logs";
+import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { BroadcasterService } from "@bitwarden/common/platform/abstractions/broadcaster.service";
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
@@ -108,6 +111,10 @@ import {
   BulkDeleteDialogResult,
   BulkMoveDialogResult,
   openBulkMoveDialog,
+  VaultBatchBarService,
+  VaultBatchActionComponent,
+  ASSIGN_COLLECTIONS_DIALOG,
+  BULK_DELETE_DIALOG,
 } from "@bitwarden/vault";
 import { OrganizationWarningsService } from "@bitwarden/web-vault/app/billing/organizations/warnings/services";
 
@@ -118,12 +125,14 @@ import {
 } from "../../admin-console/organizations/shared/components/collection-dialog";
 import { SharedModule } from "../../shared/shared.module";
 import { AssignCollectionsWebComponent } from "../components/assign-collections";
+import { AssignCollectionsWebDialogAdapter } from "../components/assign-collections/assign-collections-web-dialog.adapter";
 import { VaultItemEvent } from "../components/vault-items/vault-item-event";
 import { VaultItemsComponent } from "../components/vault-items/vault-items.component";
 import { VaultItemsModule } from "../components/vault-items/vault-items.module";
 import { WebVaultPromptService } from "../services/web-vault-prompt.service";
 
 import { openBulkDeleteDialog } from "./bulk-action-dialogs/bulk-delete-dialog/bulk-delete-dialog.component";
+import { BulkDeleteDialogWebAdapter } from "./bulk-action-dialogs/bulk-delete-dialog-web.adapter";
 import { VaultBannersComponent } from "./vault-banners/vault-banners.component";
 import { VaultFilterComponent } from "./vault-filter/components/vault-filter.component";
 import { VaultFilterModule } from "./vault-filter/vault-filter.module";
@@ -154,6 +163,7 @@ type EmptyStateMap = Record<EmptyStateType, EmptyStateItem>;
     VaultFilterModule,
     VaultItemsModule,
     SharedModule,
+    VaultBatchActionComponent,
   ],
   providers: [
     RoutedVaultFilterService,
@@ -161,6 +171,9 @@ type EmptyStateMap = Record<EmptyStateType, EmptyStateItem>;
     DefaultCipherFormConfigService,
     WebVaultPromptService,
     { provide: VaultItemsTransferService, useClass: DefaultVaultItemsTransferService },
+    VaultBatchBarService,
+    { provide: ASSIGN_COLLECTIONS_DIALOG, useClass: AssignCollectionsWebDialogAdapter },
+    { provide: BULK_DELETE_DIALOG, useClass: BulkDeleteDialogWebAdapter },
   ],
 })
 export class VaultComponent<C extends CipherViewLike> implements OnInit, OnDestroy {
@@ -198,6 +211,11 @@ export class VaultComponent<C extends CipherViewLike> implements OnInit, OnDestr
   private vaultItemDialogRef?: DialogRef<VaultItemDialogResult> | undefined;
 
   protected showAddCipherBtn: boolean = false;
+
+  protected readonly vaultBatchBarFeatureFlag = toSignal(
+    this.configService.getFeatureFlag$(FeatureFlag.PM37785_VaultBatchBar),
+    { initialValue: false },
+  );
 
   organizations$ = this.accountService.activeAccount$
     .pipe(map((a) => a?.id))
@@ -319,6 +337,8 @@ export class VaultComponent<C extends CipherViewLike> implements OnInit, OnDestr
     private policyService: PolicyService,
     private premiumUpgradePromptService: PremiumUpgradePromptService,
     private webVaultPromptService: WebVaultPromptService,
+    private vaultBatchBarService: VaultBatchBarService<C>,
+    private configService: ConfigService,
   ) {}
 
   async ngOnInit() {
@@ -612,6 +632,16 @@ export class VaultComponent<C extends CipherViewLike> implements OnInit, OnDestr
       );
 
     void this.webVaultPromptService.conditionallyPromptUser();
+
+    this.vaultBatchBarService.completed$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => this.refresh());
+
+    combineLatest([allCollections$, ciphers$.pipe(map((c) => c.length > 0))])
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(([allCollections, hasCiphers]) =>
+        this.vaultBatchBarService.setConfig({ isOrgVault: false, allCollections, hasCiphers }),
+      );
   }
 
   ngOnDestroy() {

--- a/libs/vault/src/components/vault-batch-bar/vault-batch-action.component.html
+++ b/libs/vault/src/components/vault-batch-bar/vault-batch-action.component.html
@@ -1,0 +1,13 @@
+<bit-bulk-actions-bar [selectedCount]="service.selectedCount()" (clear)="service.selection.clear()">
+  @for (action of primaryActions(); track action.label) {
+    <bit-bulk-action [action]="action.action" [icon]="action.icon" [label]="action.label" />
+  }
+
+  @for (action of overflowActions(); track action.label) {
+    <bit-bulk-additional-action
+      [action]="action.action"
+      [icon]="action.icon"
+      [label]="action.label"
+    />
+  }
+</bit-bulk-actions-bar>

--- a/libs/vault/src/components/vault-batch-bar/vault-batch-action.component.spec.ts
+++ b/libs/vault/src/components/vault-batch-bar/vault-batch-action.component.spec.ts
@@ -1,0 +1,248 @@
+import { signal } from "@angular/core";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { NoopAnimationsModule } from "@angular/platform-browser/animations";
+
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+
+import { VaultBatchBarService } from "../../services/vault-batch-bar.service";
+
+import { VaultBatchActionComponent } from "./vault-batch-action.component";
+
+// JSDOM does not implement ResizeObserver — stub so BulkActionsBarComponent can construct.
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+global.ResizeObserver = ResizeObserverStub as unknown as typeof ResizeObserver;
+
+describe("VaultBatchActionComponent", () => {
+  let component: VaultBatchActionComponent;
+  let fixture: ComponentFixture<VaultBatchActionComponent>;
+
+  const canMove = signal(false);
+  const canAssignToCollections = signal(false);
+  const canArchive = signal(false);
+  const canUnarchive = signal(false);
+  const canRestore = signal(false);
+  const canDelete = signal(false);
+  const selectedCount = signal(0);
+
+  const clearSpy = jest.fn();
+  const bulkMoveToFolderSpy = jest.fn();
+  const bulkAssignToCollectionsSpy = jest.fn();
+  const bulkArchiveSpy = jest.fn();
+  const bulkUnarchiveSpy = jest.fn();
+  const bulkRestoreSpy = jest.fn();
+  const bulkDeleteSpy = jest.fn();
+
+  beforeEach(async () => {
+    canMove.set(false);
+    canAssignToCollections.set(false);
+    canArchive.set(false);
+    canUnarchive.set(false);
+    canRestore.set(false);
+    canDelete.set(false);
+    selectedCount.set(0);
+    jest.clearAllMocks();
+
+    await TestBed.configureTestingModule({
+      imports: [VaultBatchActionComponent, NoopAnimationsModule],
+      providers: [
+        {
+          provide: VaultBatchBarService,
+          useValue: {
+            selectedCount,
+            canMove,
+            canAssignToCollections,
+            canArchive,
+            canUnarchive,
+            canRestore,
+            canDelete,
+            selection: { clear: clearSpy },
+            bulkMoveToFolder: bulkMoveToFolderSpy,
+            bulkAssignToCollections: bulkAssignToCollectionsSpy,
+            bulkArchive: bulkArchiveSpy,
+            bulkUnarchive: bulkUnarchiveSpy,
+            bulkRestore: bulkRestoreSpy,
+            bulkDelete: bulkDeleteSpy,
+          },
+        },
+        { provide: I18nService, useValue: { t: (key: string) => `translated-${key}` } },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(VaultBatchActionComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  describe("primaryActions", () => {
+    it("is empty when no signals are true", () => {
+      expect(component["primaryActions"]()).toHaveLength(0);
+    });
+
+    it("includes all actions when total equals threshold (3)", () => {
+      canMove.set(true);
+      canArchive.set(true);
+      canDelete.set(true);
+
+      expect(component["primaryActions"]()).toHaveLength(3);
+      expect(component["overflowActions"]()).toHaveLength(0);
+    });
+
+    it("caps at 2 when total exceeds threshold (3)", () => {
+      canMove.set(true);
+      canAssignToCollections.set(true);
+      canArchive.set(true);
+      canDelete.set(true);
+
+      expect(component["primaryActions"]()).toHaveLength(2);
+    });
+
+    it("contains all actions when exactly 1 is enabled", () => {
+      canDelete.set(true);
+
+      expect(component["primaryActions"]()).toHaveLength(1);
+      expect(component["overflowActions"]()).toHaveLength(0);
+    });
+
+    it("contains all actions when exactly 2 are enabled", () => {
+      canMove.set(true);
+      canDelete.set(true);
+
+      expect(component["primaryActions"]()).toHaveLength(2);
+      expect(component["overflowActions"]()).toHaveLength(0);
+    });
+  });
+
+  describe("overflowActions", () => {
+    it("is empty when total is at or below the threshold (3)", () => {
+      canMove.set(true);
+      canDelete.set(true);
+
+      expect(component["overflowActions"]()).toHaveLength(0);
+    });
+
+    it("contains remaining actions when total is 4", () => {
+      canMove.set(true);
+      canAssignToCollections.set(true);
+      canArchive.set(true);
+      canDelete.set(true);
+
+      expect(component["overflowActions"]()).toHaveLength(2);
+    });
+
+    it("contains remaining actions when all 6 actions are enabled", () => {
+      canMove.set(true);
+      canAssignToCollections.set(true);
+      canArchive.set(true);
+      canUnarchive.set(true);
+      canRestore.set(true);
+      canDelete.set(true);
+
+      expect(component["primaryActions"]()).toHaveLength(2);
+      expect(component["overflowActions"]()).toHaveLength(4);
+    });
+  });
+
+  describe("visibleActions labels and icons", () => {
+    it("assigns the correct icon and translated label for move-to-folder", () => {
+      canMove.set(true);
+
+      const [action] = component["primaryActions"]();
+      expect(action.icon).toBe("bwi-folder");
+      expect(action.label).toBe("translated-addToFolder");
+    });
+
+    it("assigns the correct icon and translated label for assign-to-collections", () => {
+      canAssignToCollections.set(true);
+
+      const [action] = component["primaryActions"]();
+      expect(action.icon).toBe("bwi-collection");
+      expect(action.label).toBe("translated-assignToCollections");
+    });
+
+    it("assigns the correct icon and translated label for archive", () => {
+      canArchive.set(true);
+
+      const [action] = component["primaryActions"]();
+      expect(action.icon).toBe("bwi-archive");
+      expect(action.label).toBe("translated-archiveVerb");
+    });
+
+    it("assigns the correct icon and translated label for unarchive", () => {
+      canUnarchive.set(true);
+
+      const [action] = component["primaryActions"]();
+      expect(action.icon).toBe("bwi-unarchive");
+      expect(action.label).toBe("translated-unArchive");
+    });
+
+    it("assigns the correct icon and translated label for restore", () => {
+      canRestore.set(true);
+
+      const [action] = component["primaryActions"]();
+      expect(action.icon).toBe("bwi-undo");
+      expect(action.label).toBe("translated-restore");
+    });
+
+    it("assigns the correct icon and translated label for delete", () => {
+      canDelete.set(true);
+
+      const [action] = component["primaryActions"]();
+      expect(action.icon).toBe("bwi-trash");
+      expect(action.label).toBe("translated-delete");
+    });
+  });
+
+  describe("action invocation", () => {
+    it("calls service.bulkMoveToFolder when move action is invoked", () => {
+      canMove.set(true);
+
+      component["primaryActions"]()[0].action();
+
+      expect(bulkMoveToFolderSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls service.bulkAssignToCollections when assign action is invoked", () => {
+      canAssignToCollections.set(true);
+
+      component["primaryActions"]()[0].action();
+
+      expect(bulkAssignToCollectionsSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls service.bulkArchive when archive action is invoked", () => {
+      canArchive.set(true);
+
+      component["primaryActions"]()[0].action();
+
+      expect(bulkArchiveSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls service.bulkUnarchive when unarchive action is invoked", () => {
+      canUnarchive.set(true);
+
+      component["primaryActions"]()[0].action();
+
+      expect(bulkUnarchiveSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls service.bulkRestore when restore action is invoked", () => {
+      canRestore.set(true);
+
+      component["primaryActions"]()[0].action();
+
+      expect(bulkRestoreSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls service.bulkDelete when delete action is invoked", () => {
+      canDelete.set(true);
+
+      component["primaryActions"]()[0].action();
+
+      expect(bulkDeleteSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/libs/vault/src/components/vault-batch-bar/vault-batch-action.component.spec.ts
+++ b/libs/vault/src/components/vault-batch-bar/vault-batch-action.component.spec.ts
@@ -20,7 +20,7 @@ describe("VaultBatchActionComponent", () => {
   let component: VaultBatchActionComponent;
   let fixture: ComponentFixture<VaultBatchActionComponent>;
 
-  const canMove = signal(false);
+  const canAddToFolder = signal(false);
   const canAssignToCollections = signal(false);
   const canArchive = signal(false);
   const canUnarchive = signal(false);
@@ -37,7 +37,7 @@ describe("VaultBatchActionComponent", () => {
   const bulkDeleteSpy = jest.fn();
 
   beforeEach(async () => {
-    canMove.set(false);
+    canAddToFolder.set(false);
     canAssignToCollections.set(false);
     canArchive.set(false);
     canUnarchive.set(false);
@@ -53,7 +53,7 @@ describe("VaultBatchActionComponent", () => {
           provide: VaultBatchBarService,
           useValue: {
             selectedCount,
-            canMove,
+            canAddToFolder,
             canAssignToCollections,
             canArchive,
             canUnarchive,
@@ -83,7 +83,7 @@ describe("VaultBatchActionComponent", () => {
     });
 
     it("includes all actions when total equals threshold (3)", () => {
-      canMove.set(true);
+      canAddToFolder.set(true);
       canArchive.set(true);
       canDelete.set(true);
 
@@ -92,7 +92,7 @@ describe("VaultBatchActionComponent", () => {
     });
 
     it("caps at 2 when total exceeds threshold (3)", () => {
-      canMove.set(true);
+      canAddToFolder.set(true);
       canAssignToCollections.set(true);
       canArchive.set(true);
       canDelete.set(true);
@@ -108,7 +108,7 @@ describe("VaultBatchActionComponent", () => {
     });
 
     it("contains all actions when exactly 2 are enabled", () => {
-      canMove.set(true);
+      canAddToFolder.set(true);
       canDelete.set(true);
 
       expect(component["primaryActions"]()).toHaveLength(2);
@@ -118,14 +118,14 @@ describe("VaultBatchActionComponent", () => {
 
   describe("overflowActions", () => {
     it("is empty when total is at or below the threshold (3)", () => {
-      canMove.set(true);
+      canAddToFolder.set(true);
       canDelete.set(true);
 
       expect(component["overflowActions"]()).toHaveLength(0);
     });
 
     it("contains remaining actions when total is 4", () => {
-      canMove.set(true);
+      canAddToFolder.set(true);
       canAssignToCollections.set(true);
       canArchive.set(true);
       canDelete.set(true);
@@ -134,7 +134,7 @@ describe("VaultBatchActionComponent", () => {
     });
 
     it("contains remaining actions when all 6 actions are enabled", () => {
-      canMove.set(true);
+      canAddToFolder.set(true);
       canAssignToCollections.set(true);
       canArchive.set(true);
       canUnarchive.set(true);
@@ -148,7 +148,7 @@ describe("VaultBatchActionComponent", () => {
 
   describe("visibleActions labels and icons", () => {
     it("assigns the correct icon and translated label for move-to-folder", () => {
-      canMove.set(true);
+      canAddToFolder.set(true);
 
       const [action] = component["primaryActions"]();
       expect(action.icon).toBe("bwi-folder");
@@ -198,7 +198,7 @@ describe("VaultBatchActionComponent", () => {
 
   describe("action invocation", () => {
     it("calls service.bulkMoveToFolder when move action is invoked", () => {
-      canMove.set(true);
+      canAddToFolder.set(true);
 
       component["primaryActions"]()[0].action();
 

--- a/libs/vault/src/components/vault-batch-bar/vault-batch-action.component.spec.ts
+++ b/libs/vault/src/components/vault-batch-bar/vault-batch-action.component.spec.ts
@@ -26,6 +26,7 @@ describe("VaultBatchActionComponent", () => {
   const canUnarchive = signal(false);
   const canRestore = signal(false);
   const canDelete = signal(false);
+  const inTrash = signal(false);
   const selectedCount = signal(0);
 
   const clearSpy = jest.fn();
@@ -43,6 +44,7 @@ describe("VaultBatchActionComponent", () => {
     canUnarchive.set(false);
     canRestore.set(false);
     canDelete.set(false);
+    inTrash.set(false);
     selectedCount.set(0);
     jest.clearAllMocks();
 
@@ -59,6 +61,7 @@ describe("VaultBatchActionComponent", () => {
             canUnarchive,
             canRestore,
             canDelete,
+            inTrash,
             selection: { clear: clearSpy },
             bulkMoveToFolder: bulkMoveToFolderSpy,
             bulkAssignToCollections: bulkAssignToCollectionsSpy,

--- a/libs/vault/src/components/vault-batch-bar/vault-batch-action.component.ts
+++ b/libs/vault/src/components/vault-batch-bar/vault-batch-action.component.ts
@@ -14,6 +14,7 @@ type ActionDescriptor = {
   action: () => void;
   icon: BitwardenIcon;
   label: string;
+  color?: string;
 };
 
 /** When the total number of available actions exceeds this, split into primary + overflow. */
@@ -75,7 +76,7 @@ export class VaultBatchActionComponent {
       actions.push({
         action: this.service.bulkDelete.bind(this.service),
         icon: "bwi-trash",
-        label: this.i18nService.t("delete"),
+        label: this.i18nService.t(this.service.inTrash() ? "permanentlyDelete" : "delete"),
       });
     }
 

--- a/libs/vault/src/components/vault-batch-bar/vault-batch-action.component.ts
+++ b/libs/vault/src/components/vault-batch-bar/vault-batch-action.component.ts
@@ -1,0 +1,96 @@
+import { ChangeDetectionStrategy, Component, computed, inject } from "@angular/core";
+
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import {
+  BitwardenIcon,
+  BulkActionsBarComponent,
+  BulkActionComponent,
+  BulkAdditionalActionComponent,
+} from "@bitwarden/components";
+
+import { VaultBatchBarService } from "../../services/vault-batch-bar.service";
+
+type ActionDescriptor = {
+  action: () => void;
+  icon: BitwardenIcon;
+  label: string;
+};
+
+/** When the total number of available actions exceeds this, split into primary + overflow. */
+const PRIMARY_ACTION_THRESHOLD = 3;
+/** Number of actions shown as primary buttons before the rest move to the overflow menu. */
+const PRIMARY_ACTION_COUNT = 2;
+
+@Component({
+  selector: "bit-vault-batch-action",
+  templateUrl: "./vault-batch-action.component.html",
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [BulkActionsBarComponent, BulkActionComponent, BulkAdditionalActionComponent],
+})
+export class VaultBatchActionComponent {
+  protected readonly service = inject(VaultBatchBarService);
+  private readonly i18nService = inject(I18nService);
+
+  /** Builds the ordered list of actions the current selection is permitted to perform. */
+  private readonly visibleActions = computed<ActionDescriptor[]>(() => {
+    const actions: ActionDescriptor[] = [];
+
+    if (this.service.canMove()) {
+      actions.push({
+        action: this.service.bulkMoveToFolder.bind(this.service),
+        icon: "bwi-folder",
+        label: this.i18nService.t("addToFolder"),
+      });
+    }
+    if (this.service.canAssignToCollections()) {
+      actions.push({
+        action: this.service.bulkAssignToCollections.bind(this.service),
+        icon: "bwi-collection",
+        label: this.i18nService.t("assignToCollections"),
+      });
+    }
+    if (this.service.canArchive()) {
+      actions.push({
+        action: this.service.bulkArchive.bind(this.service),
+        icon: "bwi-archive",
+        label: this.i18nService.t("archiveVerb"),
+      });
+    }
+    if (this.service.canUnarchive()) {
+      actions.push({
+        action: this.service.bulkUnarchive.bind(this.service),
+        icon: "bwi-unarchive",
+        label: this.i18nService.t("unArchive"),
+      });
+    }
+    if (this.service.canRestore()) {
+      actions.push({
+        action: this.service.bulkRestore.bind(this.service),
+        icon: "bwi-undo",
+        label: this.i18nService.t("restore"),
+      });
+    }
+    if (this.service.canDelete()) {
+      actions.push({
+        action: this.service.bulkDelete.bind(this.service),
+        icon: "bwi-trash",
+        label: this.i18nService.t("delete"),
+      });
+    }
+
+    return actions;
+  });
+
+  /** Actions rendered as top-level buttons. Capped at PRIMARY_ACTION_COUNT when there are more than PRIMARY_ACTION_THRESHOLD total actions. */
+  protected readonly primaryActions = computed<ActionDescriptor[]>(() => {
+    const all = this.visibleActions();
+    return all.length > PRIMARY_ACTION_THRESHOLD ? all.slice(0, PRIMARY_ACTION_COUNT) : all;
+  });
+
+  /** Actions hidden behind the "more" overflow menu when the total exceeds PRIMARY_ACTION_THRESHOLD. */
+  protected readonly overflowActions = computed<ActionDescriptor[]>(() => {
+    const all = this.visibleActions();
+    return all.length > PRIMARY_ACTION_THRESHOLD ? all.slice(PRIMARY_ACTION_COUNT) : [];
+  });
+}

--- a/libs/vault/src/components/vault-batch-bar/vault-batch-action.component.ts
+++ b/libs/vault/src/components/vault-batch-bar/vault-batch-action.component.ts
@@ -36,7 +36,7 @@ export class VaultBatchActionComponent {
   private readonly visibleActions = computed<ActionDescriptor[]>(() => {
     const actions: ActionDescriptor[] = [];
 
-    if (this.service.canMove()) {
+    if (this.service.canAddToFolder()) {
       actions.push({
         action: this.service.bulkMoveToFolder.bind(this.service),
         icon: "bwi-folder",

--- a/libs/vault/src/index.ts
+++ b/libs/vault/src/index.ts
@@ -87,3 +87,4 @@ export {
 } from "./tokens/bulk-delete-dialog.token";
 
 export { VaultBatchBarService, VaultBatchBarConfig } from "./services/vault-batch-bar.service";
+export { VaultBatchActionComponent } from "./components/vault-batch-bar/vault-batch-action.component";

--- a/libs/vault/src/services/vault-batch-bar.service.ts
+++ b/libs/vault/src/services/vault-batch-bar.service.ts
@@ -105,13 +105,13 @@ export class VaultBatchBarService<C extends CipherViewLike> {
 
   private readonly config = signal<VaultBatchBarConfig>(this.defaultConfig);
 
-  private readonly showBulkTrashOptions = toSignal(
+  readonly inTrash = toSignal(
     this.routedVaultFilterService.filter$.pipe(map((f) => f.type === "trash")),
     { initialValue: false },
   );
 
   private readonly showBulkAddToFolder = computed(
-    () => !this.showBulkTrashOptions() && !this.config().isOrgVault,
+    () => !this.inTrash() && !this.config().isOrgVault,
   );
 
   private readonly allOrganizations = toSignal(
@@ -175,12 +175,7 @@ export class VaultBatchBarService<C extends CipherViewLike> {
   readonly canArchive = computed(() => {
     const selected = this.selected();
     const hasCollections = selected.some((i) => i.collection);
-    if (
-      selected.length === 0 ||
-      !this.userCanArchive() ||
-      hasCollections ||
-      this.showBulkTrashOptions()
-    ) {
+    if (selected.length === 0 || !this.userCanArchive() || hasCollections || this.inTrash()) {
       return false;
     }
     return !selected.find(
@@ -191,7 +186,7 @@ export class VaultBatchBarService<C extends CipherViewLike> {
   /** True when all selected ciphers can be unarchived. */
   readonly canUnarchive = computed(() => {
     const selected = this.selected();
-    if (selected.length === 0 || this.showBulkTrashOptions()) {
+    if (selected.length === 0 || this.inTrash()) {
       return false;
     }
     return !selected.find((i) => !i.cipher?.archivedDate || i.cipher?.organizationId);
@@ -202,9 +197,9 @@ export class VaultBatchBarService<C extends CipherViewLike> {
     combineLatest([
       this.selection.changed.pipe(startWith(null)),
       toObservable(this.config),
-      toObservable(this.showBulkTrashOptions),
+      toObservable(this.inTrash),
     ]).pipe(
-      switchMap(([, config, showBulkTrashOptions]) => {
+      switchMap(([, config, inTrash]) => {
         const selected = this.selection.selected;
         const ciphers = selected.filter((i) => i.cipher).map((i) => i.cipher as C);
 
@@ -221,7 +216,7 @@ export class VaultBatchBarService<C extends CipherViewLike> {
         );
 
         return combineLatest(canRestoreCiphers$).pipe(
-          map((results) => results.every((r) => r) && showBulkTrashOptions),
+          map((results) => results.every((r) => r) && inTrash),
         );
       }),
     ),
@@ -298,7 +293,7 @@ export class VaultBatchBarService<C extends CipherViewLike> {
     // - Cannot assign ciphers when viewing the trash
     // - An org membership is required
     // - At least one cipher must be selected
-    if (this.showBulkTrashOptions() || allOrganizations.length === 0 || selected.length === 0) {
+    if (this.inTrash() || allOrganizations.length === 0 || selected.length === 0) {
       return false;
     }
 
@@ -529,7 +524,7 @@ export class VaultBatchBarService<C extends CipherViewLike> {
       return;
     }
 
-    const permanent = this.showBulkTrashOptions();
+    const permanent = this.inTrash();
 
     const orgIds = collections.map((c) => c.organizationId);
     const organizations = this.allOrganizations().filter((o) => orgIds.includes(o.id));


### PR DESCRIPTION
## 🎟️ Tracking

[PM-37806](https://bitwarden.atlassian.net/browse/PM-37806)
~~Stacked on top of: https://github.com/bitwarden/clients/pull/20885~~

## 📔 Objective

Adds a batch action bar to the individual (password manager) vault, enabling users to select multiple vault items and perform bulk operations including delete, move to folder, restore, archive, and assign to collections.

The batch bar is gated behind feature flags (`PM37785_VaultBatchBar` / `PM37785_DesktopVaultBatchBar`) and uses injection tokens for dialog implementations to keep the shared vault library platform-agnostic.

## 📸 Screenshots


<video src="https://github.com/user-attachments/assets/c7e8dbd2-fa4b-40e5-971d-e8023371e055" />



[PM-37806]: https://bitwarden.atlassian.net/browse/PM-37806?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ