### PR TITLE
Gate childList rebuild on autofill-relevant mutations

### DIFF
--- a/apps/browser/src/autofill/services/collect-autofill-content.service.spec.ts
+++ b/apps/browser/src/autofill/services/collect-autofill-content.service.spec.ts
@@ -3474,4 +3474,291 @@ describe("CollectAutofillContentService", () => {
       expect(Array.from(pending.get(target)!).sort()).toEqual(["id", "value"]);
     });
   });
+
+  describe("childList gate is wired into mutation handling", () => {
+    const childListMutationFor = (...added: Node[]): MutationRecord => {
+      const container = document.createElement("div");
+      document.body.appendChild(container);
+      added.forEach((n) => container.appendChild(n));
+      return {
+        type: "childList",
+        addedNodes: container.childNodes,
+        removedNodes: document.querySelectorAll("nothing-matches-this-selector"),
+        attributeName: null,
+        attributeNamespace: null,
+        nextSibling: null,
+        oldValue: null,
+        previousSibling: null,
+        target: document.body,
+      };
+    };
+
+    beforeEach(() => {
+      collectAutofillContentService["currentLocationHref"] = window.location.href;
+      collectAutofillContentService["pendingChildListUpdate"] = false;
+    });
+
+    it("does not flip pendingChildListUpdate for a cosmetic childList mutation", () => {
+      const cosmetic = childListMutationFor(document.createElement("div"));
+
+      collectAutofillContentService["handleMutationObserverMutation"]([cosmetic]);
+
+      expect(collectAutofillContentService["pendingChildListUpdate"]).toBe(false);
+    });
+
+    it("flips pendingChildListUpdate when the childList mutation contains a form field", () => {
+      const input = Object.assign(document.createElement("input"), { type: "text" });
+      const relevant = childListMutationFor(input);
+
+      collectAutofillContentService["handleMutationObserverMutation"]([relevant]);
+
+      expect(collectAutofillContentService["pendingChildListUpdate"]).toBe(true);
+    });
+  });
+
+  describe("mutationAffectsAutofillTarget (relevance gate)", () => {
+    // Containers we append to body for real NodeList construction; torn down after each test.
+    const createdContainers: HTMLElement[] = [];
+
+    const makeContainer = (): HTMLElement => {
+      const container = document.createElement("div");
+      document.body.appendChild(container);
+      createdContainers.push(container);
+      return container;
+    };
+
+    const buildMutation = (
+      addedNodes: NodeList,
+      removedNodes: NodeList = document.querySelectorAll("nothing-matches-this-selector"),
+    ): MutationRecord => ({
+      type: "childList",
+      addedNodes,
+      removedNodes,
+      attributeName: null,
+      attributeNamespace: null,
+      nextSibling: null,
+      oldValue: null,
+      previousSibling: null,
+      target: document.body,
+    });
+
+    afterEach(() => {
+      while (createdContainers.length) {
+        const container = createdContainers.pop()!;
+        if (container.parentNode) {
+          container.parentNode.removeChild(container);
+        }
+      }
+    });
+
+    const expectGate = (mutation: MutationRecord, admit: boolean) =>
+      expect(collectAutofillContentService["mutationAffectsAutofillTarget"](mutation)).toBe(admit);
+
+    const mutationForChild = (child: Node): MutationRecord => {
+      const container = makeContainer();
+      container.appendChild(child);
+      return buildMutation(container.childNodes);
+    };
+
+    const mutationForInput = (configure: (input: HTMLInputElement) => void): MutationRecord => {
+      const input = document.createElement("input");
+      configure(input);
+      return mutationForChild(input);
+    };
+
+    describe("admits via formFieldQueryString match on the node itself", () => {
+      it("admits <select>", () =>
+        expectGate(mutationForChild(document.createElement("select")), true));
+      it("admits <textarea>", () =>
+        expectGate(mutationForChild(document.createElement("textarea")), true));
+
+      it("admits <span data-bwautofill>", () => {
+        const span = document.createElement("span");
+        span.setAttribute("data-bwautofill", "");
+        expectGate(mutationForChild(span), true);
+      });
+
+      it("admits a type-less <input> (no type attribute satisfies every :not([type=X]) clause)", () => {
+        const input = document.createElement("input");
+        expect(input.getAttribute("type")).toBeNull();
+        expectGate(mutationForChild(input), true);
+      });
+
+      it.each(["text", "email", "password", "number", "tel"])('admits <input type="%s">', (type) =>
+        expectGate(
+          mutationForInput((i) => (i.type = type)),
+          true,
+        ),
+      );
+    });
+
+    describe("rejects bare elements with no autofill descendants", () => {
+      it("rejects <div>", () => expectGate(mutationForChild(document.createElement("div")), false));
+      it("rejects <p>", () => expectGate(mutationForChild(document.createElement("p")), false));
+      it("rejects <span> without data-bwautofill", () =>
+        expectGate(mutationForChild(document.createElement("span")), false));
+
+      // Consolidation deliberately drops the FORM-tag fast-path: empty forms have no fields,
+      // and any later child-append mutation trips the gate via the descendant query.
+      it("rejects an empty <form>", () =>
+        expectGate(mutationForChild(document.createElement("form")), false));
+    });
+
+    describe("rejects inputs whose type is in ignoredInputTypes", () => {
+      // Structural — never autofill targets.
+      it.each(["hidden", "submit", "reset", "button", "image", "file"])(
+        'rejects <input type="%s">',
+        (type) =>
+          expectGate(
+            mutationForInput((i) => (i.type = type)),
+            false,
+          ),
+      );
+
+      // Format-restricted text types. Consolidation widened these from admit to reject:
+      // the gate now uses the same exclusion set as collection, so the rebuild it used to
+      // schedule for these would have produced zero new fields anyway.
+      it.each(["search", "url", "date", "time", "datetime-local", "week", "color", "range"])(
+        'rejects <input type="%s">',
+        (type) =>
+          expectGate(
+            mutationForInput((i) => (i.type = type)),
+            false,
+          ),
+      );
+    });
+
+    describe("rejects nodes carrying data-bwignore", () => {
+      // Consolidating onto formFieldQueryString means data-bwignore-marked elements no longer
+      // trip the gate. Safe because they'd be filtered out during collection anyway.
+      it('rejects <input type="text" data-bwignore>', () =>
+        expectGate(
+          mutationForInput((i) => {
+            i.type = "text";
+            i.setAttribute("data-bwignore", "");
+          }),
+          false,
+        ));
+
+      it("rejects <select data-bwignore>", () => {
+        const select = document.createElement("select");
+        select.setAttribute("data-bwignore", "");
+        expectGate(mutationForChild(select), false);
+      });
+
+      it("rejects <textarea data-bwignore>", () => {
+        const textarea = document.createElement("textarea");
+        textarea.setAttribute("data-bwignore", "");
+        expectGate(mutationForChild(textarea), false);
+      });
+
+      it("rejects a <div> wrapping only a data-bwignore field (descendant inherits exclusion)", () => {
+        const wrapper = document.createElement("div");
+        const input = document.createElement("input");
+        input.type = "text";
+        input.setAttribute("data-bwignore", "");
+        wrapper.appendChild(input);
+        expectGate(mutationForChild(wrapper), false);
+      });
+    });
+
+    describe("admits via descendant match", () => {
+      it("admits a <div> wrapping a text input", () => {
+        const wrapper = document.createElement("div");
+        const input = document.createElement("input");
+        input.type = "text";
+        wrapper.appendChild(input);
+        expectGate(mutationForChild(wrapper), true);
+      });
+
+      it("admits a <div> containing both a hidden and a text input (text input matches)", () => {
+        const wrapper = document.createElement("div");
+        const hidden = document.createElement("input");
+        hidden.type = "hidden";
+        const text = document.createElement("input");
+        text.type = "text";
+        wrapper.append(hidden, text);
+        expectGate(mutationForChild(wrapper), true);
+      });
+
+      it("admits a <div> wrapping a <span data-bwautofill>", () => {
+        const wrapper = document.createElement("div");
+        const span = document.createElement("span");
+        span.setAttribute("data-bwautofill", "");
+        wrapper.appendChild(span);
+        expectGate(mutationForChild(wrapper), true);
+      });
+
+      it("admits a <form> containing a text input (via descendant, not the FORM tag itself)", () => {
+        const form = document.createElement("form");
+        const input = document.createElement("input");
+        input.type = "text";
+        form.appendChild(input);
+        expectGate(mutationForChild(form), true);
+      });
+
+      it("rejects a <form> whose only descendant is an excluded input", () => {
+        const form = document.createElement("form");
+        const hidden = document.createElement("input");
+        hidden.type = "hidden";
+        form.appendChild(hidden);
+        expectGate(mutationForChild(form), false);
+      });
+    });
+
+    describe("processes removedNodes identically to addedNodes", () => {
+      const emptyNodeList = (): NodeList =>
+        document.querySelectorAll("nothing-matches-this-selector");
+
+      it("admits when a text input appears only in removedNodes", () => {
+        const container = makeContainer();
+        const input = document.createElement("input");
+        input.type = "text";
+        container.appendChild(input);
+        expectGate(buildMutation(emptyNodeList(), container.childNodes), true);
+      });
+
+      it("rejects when only an empty <form> appears in removedNodes", () => {
+        const container = makeContainer();
+        container.appendChild(document.createElement("form"));
+        expectGate(buildMutation(emptyNodeList(), container.childNodes), false);
+      });
+    });
+  });
+
+  describe("nodeListIsAutofillRelevant", () => {
+    it("skips non-element nodes (text, comment) and returns false when no element is relevant", () => {
+      const container = document.createElement("div");
+      container.append(
+        document.createTextNode("hello"),
+        document.createComment("a comment"),
+        document.createElement("p"),
+      );
+      document.body.appendChild(container);
+
+      expect(
+        collectAutofillContentService["nodeListIsAutofillRelevant"](container.childNodes),
+      ).toBe(false);
+      document.body.removeChild(container);
+    });
+
+    it("returns false for an empty NodeList", () => {
+      const empty = document.querySelectorAll("nothing-matches-this-selector");
+      expect(collectAutofillContentService["nodeListIsAutofillRelevant"](empty)).toBe(false);
+    });
+
+    it("short-circuits on the first relevant node and returns true", () => {
+      const container = document.createElement("div");
+      const irrelevant = document.createElement("p");
+      const input = document.createElement("input");
+      input.type = "text";
+      container.append(irrelevant, input);
+      document.body.appendChild(container);
+
+      expect(
+        collectAutofillContentService["nodeListIsAutofillRelevant"](container.childNodes),
+      ).toBe(true);
+      document.body.removeChild(container);
+    });
+  });
 });

--- a/apps/browser/src/autofill/services/collect-autofill-content.service.ts
+++ b/apps/browser/src/autofill/services/collect-autofill-content.service.ts
@@ -1355,8 +1355,8 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
 
     for (const mutation of mutations) {
       if (mutation.type === "attributes") {
-        // nodeType === 1 instead of `instanceof Element` — works across realms (adopted-from-iframe).
-        if (mutation.target.nodeType !== 1) {
+        // nodeType === 1 (Node.ELEMENT_NODE) instead of `instanceof Element`; faster & includes iframes
+        if (mutation.target.nodeType !== Node.ELEMENT_NODE) {
           continue;
         }
         const attributeName = mutation.attributeName?.toLowerCase();
@@ -1374,9 +1374,12 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
           this.pendingTopLayerTargets.add(target);
         }
       } else if (mutation.type === "childList") {
-        this.pendingChildListUpdate = true;
+        // Without this gate, cosmetic mutations invalidate the noFieldsFound cache.
+        if (this.mutationAffectsAutofillTarget(mutation)) {
+          this.pendingChildListUpdate = true;
+        }
         for (const node of mutation.addedNodes ?? []) {
-          if (node.nodeType !== 1) {
+          if (node.nodeType !== Node.ELEMENT_NODE) {
             continue;
           }
           const element = node as Element;
@@ -1555,6 +1558,32 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
         }
       }
     }
+  }
+
+  private mutationAffectsAutofillTarget(mutation: MutationRecord): boolean {
+    return (
+      this.nodeListIsAutofillRelevant(mutation.addedNodes) ||
+      this.nodeListIsAutofillRelevant(mutation.removedNodes)
+    );
+  }
+
+  private nodeListIsAutofillRelevant(nodes: NodeList | undefined): boolean {
+    if (!nodes) {
+      return false;
+    }
+    for (const node of nodes) {
+      if (node.nodeType !== Node.ELEMENT_NODE) {
+        continue;
+      }
+      const el = node as Element;
+      if (
+        el.matches(this.formFieldQueryString) ||
+        el.querySelector(this.formFieldQueryString) !== null
+      ) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private isShadowRootCandidate(node: Node): node is Element {


### PR DESCRIPTION
## 🎟️ Tracking

Follow-on to [PM-35196](https://bitwarden.atlassian.net/browse/PM-35196)

## 📔 Objective

Extracted from [shadow-dom-unified-fix-mem-mgmt](https://github.com/bitwarden/clients/pull/20871) so the mutation-filtering optimization can be measured and reviewed independently of the observer lifecycle work it was originally bundled with.

[PM-35196]: https://bitwarden.atlassian.net/browse/PM-35196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ