### PR TITLE
[PM-37611] Add DIRT team CLAUDE.md files

### DIFF
--- a/bitwarden_license/bit-common/src/dirt/CLAUDE.md
+++ b/bitwarden_license/bit-common/src/dirt/CLAUDE.md
@@ -1,0 +1,73 @@
+# CLAUDE.md - DIRT Team (Licensed, Platform-Agnostic)
+
+> Scope: `bitwarden_license/bit-common/src/dirt/` and its children. Claude Code reads
+> CLAUDE.md files hierarchically (repo root + every parent dir), so this supplements the
+> repo-wide `.claude/CLAUDE.md` with DIRT-specific context.
+
+## Project Overview
+
+The DIRT team (Data, Insights, Reporting & Tooling) owns Access Intelligence, Organization
+Integrations, External Reports, and Phishing Detection. This package holds the
+**platform-agnostic** (non-Angular) services and models that work across web, browser, and CLI.
+
+**Start here:** `/bitwarden_license/bit-common/src/dirt/docs/README.md` (team documentation hub). New to the team? See `/bitwarden_license/bit-common/src/dirt/docs/getting-started.md`.
+
+## Tech Stack
+
+- TypeScript (strict), RxJS for service-layer state, Jest for tests.
+- Bitwarden data-model pipeline: Api -> Data -> Domain -> View (follow the Cipher pattern at
+  `/libs/common/src/vault/models/domain/cipher.ts`).
+
+## Architecture & Patterns
+
+- **4-layer data model:** Api (wire) / Data (serializable) / Domain (encrypted, owns
+  encrypt+decrypt) / View (decrypted, smart-model methods). Domain models encrypt and decrypt
+  themselves; services orchestrate, they do not encrypt/decrypt. Canonical reference:
+  `/libs/common/src/vault/models/domain/cipher.ts`.
+- **Smart models, thin services:** business logic lives on view models (like `CipherView`),
+  not in services. Services do `report.mutate()` then persist.
+- **Naming:** Access Intelligence is the current name; "Risk Insights" is the deprecated name
+  for the same feature (legacy paths under `reports/risk-insights/` are being migrated). Use
+  "Access Intelligence" in all new code, comments, and UI.
+- **RxJS in services, Signals in components.** Never mix.
+
+## Common Commands
+
+- `npm run prettier` - format (run after editing, including .md files)
+- `npm run lint` / `npm run lint:fix`
+- `npm run test:types` - catch TypeScript errors after test changes
+
+## Testing Standards
+
+- Jest; deterministic data only (no `Math.random()`, no `new Date()`).
+- Use shared test helpers; avoid `any` (`Partial<DeepJsonify<T>>` for test data).
+- Smart models: follow the CipherView coverage pattern.
+
+## Security & Compliance
+
+- Zero-knowledge invariant: vault data is decrypted only client-side. Never send unencrypted
+  vault data to the server; never log decrypted data, keys, or PII.
+- **Encryption boundary:** domain models own crypto. Do not add field-level EncStrings to new
+  models without confirming the SDK envelope-encryption direction with key management.
+- New encryption logic must not be added to this repo.
+
+## Gotchas & Tips
+
+- `bit-common` is **licensed** code. Licensed code may import from `libs/common`, but
+  `libs/common` must NEVER import from `bitwarden_license/`.
+- Aggregation/filtering happens client-side after decryption (nothing server-side aggregates).
+- When extending an abstraction, check it still serves more than one consumer before adding to it.
+
+## References
+
+- Team docs hub: `/bitwarden_license/bit-common/src/dirt/docs/README.md`
+- Getting started: `/bitwarden_license/bit-common/src/dirt/docs/getting-started.md`
+- Documentation structure: `/bitwarden_license/bit-common/src/dirt/docs/documentation-structure.md`
+- Service / component integration: `/bitwarden_license/bit-common/src/dirt/docs/integration-guide.md`
+- Access Intelligence component context: `/bitwarden_license/bit-web/src/app/dirt/access-intelligence/CLAUDE.md`
+- BW data model: https://contributing.bitwarden.com/architecture/clients/data-model/
+- Repo-wide rules: `/.claude/CLAUDE.md`
+
+<!-- Deferred (follow-up ticket): once the DIRT team standards docs land and their
+     canonical home is decided, add links to docs/standards/* here. Do not reference
+     PR #19049 in the meantime. -->

--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/CLAUDE.md
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/CLAUDE.md
@@ -1,0 +1,69 @@
+# Access Intelligence - Component Context
+
+> Scope: `bitwarden_license/bit-web/src/app/dirt/access-intelligence/` (Angular web components).
+> Supplements the repo-wide `/.claude/CLAUDE.md`. Note: the DIRT team-level file at
+> `bitwarden_license/bit-common/src/dirt/CLAUDE.md` does not auto-load here (different subtree),
+> so the most relevant team context is linked below.
+
+## Quick Navigation
+
+- **Full team context, architecture, services:** [Team CLAUDE.md](/bitwarden_license/bit-common/src/dirt/CLAUDE.md)
+- **Team docs hub / getting started:** [docs/README.md](/bitwarden_license/bit-common/src/dirt/docs/README.md), [getting-started.md](/bitwarden_license/bit-common/src/dirt/docs/getting-started.md)
+
+> Detailed Angular/testing standards docs are tracked for a follow-up. The high-value
+> checklists are inlined below so this file is self-contained today.
+
+## Known Architecture Gaps
+
+### V2 Model Class Names
+
+V2 model families use the final glossary names. V1 names are `@deprecated` in `report-models.ts`
+and will be removed when V1 code is deleted. Use these names in all V2 code and comments.
+
+| V2 Model Name          | Layer classes                                                                                             |
+| ---------------------- | --------------------------------------------------------------------------------------------------------- |
+| `AccessReport`         | `AccessReportApi`, `AccessReportData`, `AccessReport`, `AccessReportView`                                 |
+| `ApplicationHealth`    | `ApplicationHealthApi`, `ApplicationHealthData`, `ApplicationHealth`, `ApplicationHealthView`             |
+| `AccessReportSummary`  | `AccessReportSummaryApi`, `AccessReportSummaryData`, `AccessReportSummary`, `AccessReportSummaryView`     |
+| `AccessReportSettings` | `AccessReportSettingsApi`, `AccessReportSettingsData`, `AccessReportSettings`, `AccessReportSettingsView` |
+| `AccessReportMetrics`  | `AccessReportMetricsApi`, `AccessReportMetricsData`, `AccessReportMetrics`, `AccessReportMetricsView`     |
+
+### 4-Layer Model Mapping Is Not Always 1:1
+
+The 4-layer model (Api -> Data -> Domain -> View) is not strictly 1:1 for all models. Some
+view-layer constructs (e.g., `MemberRegistry`) have no direct domain counterpart; they are
+reconstituted from the decrypted payload rather than lifted from a domain field. Review cross-layer
+`{@link}` references when documenting, since deprecated/repurposed models can make them misleading.
+
+## Standards Compliance Checklist (apply to all modified files)
+
+- [ ] Components use `ChangeDetectionStrategy.OnPush`
+- [ ] New subscriptions use `takeUntilDestroyed(this.destroyRef)` (or convert to `toSignal()`)
+- [ ] Signals follow Angular modernization patterns (`input()`, `output()`, `computed()`)
+- [ ] Tests use deterministic data (no `Math.random()`, no `new Date()`)
+- [ ] Storybook stories use fixtures (e.g. `story-fixtures.ts`)
+- [ ] Follow the Angular Architecture Patterns in [/.claude/CLAUDE.md](/.claude/CLAUDE.md#angular-architecture-patterns)
+
+## Dependency Audit (before implementing)
+
+When a component needs a new observable from a service, the full change chain is:
+
+1. **Abstraction** - add the property to the abstract class
+2. **Default implementation** - add `BehaviorSubject` + emissions
+3. **Mock in spec** - add `BehaviorSubject` to the mock type and `beforeEach`
+
+When using an existing component or service as a dependency, check it for FIXMEs and note them in
+your plan (don't block on them, but track them).
+
+## Pre-commit Checklist
+
+- [ ] No `console.*` statements (use Storybook `action()` for logging in stories)
+- [ ] No exposed `BehaviorSubject`s (expose `.asObservable()` instead)
+- [ ] All subscriptions use `takeUntilDestroyed()` or are converted to `toSignal()`
+- [ ] All promises are awaited or use the `void` operator
+- [ ] No unused imports/variables
+
+---
+
+**For complete project context, architecture, and service documentation:**
+-> [Team CLAUDE.md](/bitwarden_license/bit-common/src/dirt/CLAUDE.md)

--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/CLAUDE.md
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/CLAUDE.md
@@ -15,12 +15,25 @@
 
 ## Known Architecture Gaps
 
-### V2 Model Class Names
+### Model Class Names (current vs. legacy)
 
-V2 model families use the final glossary names. V1 names are `@deprecated` in `report-models.ts`
-and will be removed when V1 code is deleted. Use these names in all V2 code and comments.
+The current Access Intelligence models live under
+`/bitwarden_license/bit-common/src/dirt/access-intelligence/models/` (`api/`, `data/`, `domain/`,
+`view/`) and use the names in the table below. Use these names in all new code and comments.
 
-| V2 Model Name          | Layer classes                                                                                             |
+The legacy ("V1") models still live in
+`/bitwarden_license/bit-common/src/dirt/reports/risk-insights/models/report-models.ts`
+(`RiskInsightsData`, `OrganizationReportSummary`, `OrganizationReportApplication`,
+`ApplicationHealthReportDetail`). They are **not** annotated `@deprecated` in code; treat them as
+legacy regardless. Do not extend them in new work; they are expected to be removed once the V1 code
+path is deleted.
+
+The V2 models are the new architecture, gated behind
+`FeatureFlag.AccessIntelligenceNewArchitecture` (`pm-31936-access-intelligence-new-architecture`,
+currently off by default); V1 remains the active path until that flag is enabled and the V1 cleanup
+lands.
+
+| V2 Model Name          | Layer classes (api / data / domain / view)                                                                |
 | ---------------------- | --------------------------------------------------------------------------------------------------------- |
 | `AccessReport`         | `AccessReportApi`, `AccessReportData`, `AccessReport`, `AccessReportView`                                 |
 | `ApplicationHealth`    | `ApplicationHealthApi`, `ApplicationHealthData`, `ApplicationHealth`, `ApplicationHealthView`             |

--- a/libs/common/src/dirt/CLAUDE.md
+++ b/libs/common/src/dirt/CLAUDE.md
@@ -1,0 +1,18 @@
+# DIRT (libs/common) - Critical Rules
+
+> Scope: `libs/common/src/dirt/` (open-source, platform-agnostic DIRT services and models:
+> event-logs, models, services). Supplements the repo-wide `/.claude/CLAUDE.md`.
+
+- **CRITICAL: import direction.** This is open-source `common` code. It must NEVER import from
+  `bitwarden_license/`. Licensed DIRT code imports from here, not the reverse.
+- **ALWAYS** follow the Api -> Data -> Domain -> View model pipeline. Domain models own
+  encrypt/decrypt; services orchestrate. Canonical reference:
+  `/libs/common/src/vault/models/domain/cipher.ts`.
+- **NEVER** add new encryption logic to this repo. **NEVER** send unencrypted vault data to the
+  server. **NEVER** log decrypted data, keys, or PII.
+- **RxJS** for service state (platform-agnostic). No Angular Signals here (that is component-only,
+  in the web/browser packages).
+- **Naming:** "Access Intelligence" is current; "Risk Insights" is deprecated for the same feature.
+
+For the full DIRT architecture and standards, see the team docs hub:
+`/bitwarden_license/bit-common/src/dirt/docs/README.md`.


### PR DESCRIPTION
## 🎟️ Tracking

[PM-37611](https://bitwarden.atlassian.net/browse/PM-37611) (parent: [PM-34594](https://bitwarden.atlassian.net/browse/PM-34594))

## 📔 Objective

Adds three scoped `CLAUDE.md` files so Claude Code loads accurate DIRT-team context when working in DIRT-owned subtrees, following the org [Documentation Patterns](https://bitwarden.atlassian.net/wiki/spaces/EN/pages/1774977070/Documentation+Patterns) conventions and this repo's `.claude/CONTRIBUTING.md`:

- `bitwarden_license/bit-common/src/dirt/CLAUDE.md` — team-level context anchor for the licensed, platform-agnostic DIRT services/models.
- `bitwarden_license/bit-web/src/app/dirt/access-intelligence/CLAUDE.md` — component-area navigation hub for Access Intelligence UI work (inline standards + pre-commit checklists, V2 model-name gaps).
- `libs/common/src/dirt/CLAUDE.md` — lean critical-rules file for the open-source DIRT code, emphasizing the `common`-never-imports-`bitwarden_license` boundary.

The files are lean and reference-based: they link only to docs that already exist on `main` and do not duplicate them. By team decision, they intentionally do not reference the in-progress standards-docs PR [#19049](https://github.com/bitwarden/clients/pull/19049); linking the `docs/standards/*` files is deferred to a follow-up once their canonical home is settled. CODEOWNERS already covers these directories (`@bitwarden/team-data-insights-and-reporting-dev`) via folder-level inheritance, so no CODEOWNERS change is needed.


[PM-37611]: https://bitwarden.atlassian.net/browse/PM-37611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-34594]: https://bitwarden.atlassian.net/browse/PM-34594?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ