### PR TITLE
[PM-38185] Safari numeric values translations

### DIFF
--- a/apps/browser/src/platform/services/i18n.service.ts
+++ b/apps/browser/src/platform/services/i18n.service.ts
@@ -1,3 +1,5 @@
+// FIXME: Update this file to be type safe and remove this and next line
+// @ts-strict-ignore
 import { I18nService as BaseI18nService } from "@bitwarden/common/platform/services/i18n.service";
 import { GlobalStateProvider } from "@bitwarden/common/platform/state";
 

--- a/apps/browser/src/platform/services/i18n.service.ts
+++ b/apps/browser/src/platform/services/i18n.service.ts
@@ -1,5 +1,3 @@
-// FIXME: Update this file to be type safe and remove this and next line
-// @ts-strict-ignore
 import { I18nService as BaseI18nService } from "@bitwarden/common/platform/services/i18n.service";
 import { GlobalStateProvider } from "@bitwarden/common/platform/state";
 
@@ -101,12 +99,15 @@ export default class I18nService extends BaseI18nService {
       }
 
       if (placeholders.length) {
-        return chrome.i18n.getMessage(id, placeholders);
+        return chrome.i18n.getMessage(
+          id,
+          placeholders.map((placeholder) => placeholder.toString()),
+        );
       } else {
         return chrome.i18n.getMessage(id);
       }
     }
 
-    return super.translate(id, p1, p2, p3);
+    return super.translate(id, p1?.toString(), p2?.toString(), p3?.toString());
   }
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-38185](https://bitwarden.atlassian.net/browse/PM-38185) 

## 📔 Objective

Fixes a Safari-specific bug where the error toast shows ” fields need your attention.” (missing count) instead of e.g. “2 fields need your attention.” when a user partially fills in a MM/DD/YYYY date field on a Passport or License cipher and attempts to save.

Root cause: The browser extension’s I18nService.translate() builds the chrome.i18n.getMessage() substitution array by pushing raw parameter values without converting them to strings first. The caller passes invalidFieldsCount — a number — directly to t(). Chrome’s implementation coerces numeric array elements to strings automatically; Safari’s WebExtension implementation does not, substituting the `$COUNT$` placeholder with an empty string instead.
Safari dev tools of root cause:
<img width="423" height="110" alt="Screenshot 2026-06-01 at 3 48 43 PM" src="https://github.com/user-attachments/assets/c9d0c8aa-b94a-4800-b4b1-5f5822a48570" />

## Screenshots
<img width="489" height="597" alt="Screenshot 2026-06-01 at 3 52 25 PM" src="https://github.com/user-attachments/assets/a87ac374-dea1-4cd6-9c11-55b189e1ad39" />

[PM-38185]: https://bitwarden.atlassian.net/browse/PM-38185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ