### PR TITLE
Bumped client version(s) (#20950)

### DIFF
--- a/apps/browser/package.json
+++ b/apps/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitwarden/browser",
-  "version": "2026.5.0",
+  "version": "2026.5.1",
   "scripts": {
     "build": "npm run build:chrome",
     "build:bit": "npm run build:bit:chrome",

--- a/apps/browser/src/manifest.json
+++ b/apps/browser/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "__MSG_extName__",
   "short_name": "Bitwarden",
-  "version": "2026.5.0",
+  "version": "2026.5.1",
   "description": "__MSG_extDesc__",
   "default_locale": "en",
   "author": "Bitwarden Inc.",

--- a/apps/browser/src/manifest.v3.json
+++ b/apps/browser/src/manifest.v3.json
@@ -3,7 +3,7 @@
   "minimum_chrome_version": "102.0",
   "name": "__MSG_extName__",
   "short_name": "Bitwarden",
-  "version": "2026.5.0",
+  "version": "2026.5.1",
   "description": "__MSG_extDesc__",
   "default_locale": "en",
   "author": "Bitwarden Inc.",

--- a/package-lock.json
+++ b/package-lock.json
@@ -198,7 +198,7 @@
     },
     "apps/browser": {
       "name": "@bitwarden/browser",
-      "version": "2026.5.0"
+      "version": "2026.5.1"
     },
     "apps/cli": {
       "name": "@bitwarden/cli",


### PR DESCRIPTION
## 📔 Objective

Bump browser version to `2026.5.1`
