### PR TITLE
PM-38423 - Fix unsavedSendEditsGuard blocking logout

### DIFF
--- a/apps/desktop/src/app/tools/send/guards/unsaved-send-edits.guard.ts
+++ b/apps/desktop/src/app/tools/send/guards/unsaved-send-edits.guard.ts
@@ -3,5 +3,10 @@ import { CanDeactivateFn } from "@angular/router";
 import { SendComponent } from "../send.component";
 
 export const unsavedSendEditsGuard: CanDeactivateFn<SendComponent> = async (component) => {
+  // Angular passes null when the component has already been destroyed mid-navigation
+  // (e.g. during logout teardown). No edits to save in that case — allow the navigation.
+  if (component == null) {
+    return true;
+  }
   return component.saveUnsavedSendEdits();
 };

--- a/apps/web/src/app/tools/guards/unsaved-send-edits.guard.ts
+++ b/apps/web/src/app/tools/guards/unsaved-send-edits.guard.ts
@@ -3,5 +3,10 @@ import { CanDeactivateFn } from "@angular/router";
 import { SendComponent } from "../send/send.component";
 
 export const unsavedSendEditsGuard: CanDeactivateFn<SendComponent> = async (component) => {
+  // Angular passes null when the component has already been destroyed mid-navigation
+  // (e.g. during logout teardown). No edits to save in that case — allow the navigation.
+  if (component == null) {
+    return true;
+  }
   return component.saveUnsavedSendEdits();
 };


### PR DESCRIPTION
## 🎟️ Tracking
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-38423

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
To resolve an issue w/ the new `unsavedSendEditsGuard` on web where, when the app was logging out, angular would emit null and the guard would attempt to call `null.saveUnsavedSendEdits()` and get a `Cannot read properties of null (reading 'saveUnsavedSendEdits')` error.

Note: I adjusted the logic in the desktop guard, but it doesn't actually seem to work? See below. Logging out sometimes flashes the discard edits dialog but it is quickly and automatically closed without interaction. Regardless, it still seemed safer to add the logic to the desktop guard since Angular itself can emit null for the component in some scenarios. 

## 📸 Screenshots
<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

Web:

https://github.com/user-attachments/assets/e7213920-bcac-488e-b023-73b43ea914e8

Desktop:

https://github.com/user-attachments/assets/cb6ca5d8-069c-490c-9f9f-edb7ccec231a


