### PR TITLE
[PM-34491] Fill Targeting Rules implementation gaps

### DIFF
--- a/apps/browser/src/autofill/background/overlay.background.spec.ts
+++ b/apps/browser/src/autofill/background/overlay.background.spec.ts
@@ -2221,6 +2221,38 @@ describe("OverlayBackground", () => {
             command: "showSaveLoginInlineMenuList",
           });
         });
+
+        it("does not show the save login menu on a password-generation field when only the current-password field has a value", async () => {
+          focusedFieldData.inlineMenuFillType = InlineMenuFillTypes.PasswordGeneration;
+          formData.password = "current-password";
+          formData.newPassword = "";
+
+          sendMockExtensionMessage(
+            { command: "updateFocusedFieldData", focusedFieldData, focusedFieldHasValue: true },
+            sender,
+          );
+          await flushPromises();
+
+          expect(listPortSpy.postMessage).not.toHaveBeenCalledWith({
+            command: "showSaveLoginInlineMenuList",
+          });
+        });
+
+        it("shows the save login menu on a password-generation field once the new-password field has a value", async () => {
+          focusedFieldData.inlineMenuFillType = InlineMenuFillTypes.PasswordGeneration;
+          formData.password = "";
+          formData.newPassword = "generated";
+
+          sendMockExtensionMessage(
+            { command: "updateFocusedFieldData", focusedFieldData, focusedFieldHasValue: true },
+            sender,
+          );
+          await flushPromises();
+
+          expect(listPortSpy.postMessage).toHaveBeenCalledWith({
+            command: "showSaveLoginInlineMenuList",
+          });
+        });
       });
     });
 

--- a/apps/browser/src/autofill/background/overlay.background.spec.ts
+++ b/apps/browser/src/autofill/background/overlay.background.spec.ts
@@ -3901,6 +3901,44 @@ describe("OverlayBackground", () => {
           inlineMenuFillType: InlineMenuFillTypes.PasswordGeneration,
         });
       });
+
+      it("keeps targeted newPassword fields that would fail the heuristic isNewPasswordField check", async () => {
+        const newPasswordField = createAutofillFieldMock({
+          opid: "targeted_field_0_newPassword_0",
+          type: "password",
+          htmlName: "newPassword",
+          targeted: true,
+          fieldQualifier: "newPassword",
+        });
+        // `confirmPassword` is one token, so the keyword "confirm password" (with a space)
+        // misses it via the heuristic; the targeted flag must override that.
+        const confirmPasswordField = createAutofillFieldMock({
+          opid: "targeted_field_0_newPassword_1",
+          type: "password",
+          htmlName: "confirmPassword",
+          targeted: true,
+          fieldQualifier: "newPassword",
+        });
+        const pageDetail = createPageDetailMock({
+          details: createAutofillPageDetailsMock({
+            fields: [newPasswordField, confirmPasswordField],
+          }),
+        });
+        overlayBackground["pageDetailsForTab"][sender.tab!.id!]!.set(sender.frameId!, pageDetail);
+
+        sendPortMessage(listMessageConnectorSpy, { command: "fillGeneratedPassword", portKey });
+        await flushPromises();
+
+        const passedPageDetails = (autofillService.doAutoFill as jest.Mock).mock.calls[0][0]
+          .pageDetails;
+        const filteredOpids = passedPageDetails[0].details.fields
+          .map((f: { opid: string }) => f.opid)
+          .sort();
+        expect(filteredOpids).toEqual([
+          "targeted_field_0_newPassword_0",
+          "targeted_field_0_newPassword_1",
+        ]);
+      });
     });
   });
 

--- a/apps/browser/src/autofill/background/overlay.background.ts
+++ b/apps/browser/src/autofill/background/overlay.background.ts
@@ -2230,10 +2230,16 @@ export class OverlayBackground implements OverlayBackgroundInterface {
       return false;
     }
 
+    // On password-generation fields the save prompt should only fire once a
+    // new password has actually been entered. Gating on `loginData.password`
+    // here would surface the prompt as soon as the *current* password field
+    // on an update form is filled, which isn't a "save new login" signal.
+    const hasAnyPassword = !!(loginData.password || loginData.newPassword);
+    const hasNewPassword = !!loginData.newPassword;
+
     return (
-      (this.shouldShowInlineMenuAccountCreation() ||
-        this.focusedFieldMatchesFillType(InlineMenuFillTypes.PasswordGeneration)) &&
-      !!(loginData.password || loginData.newPassword)
+      (this.shouldShowInlineMenuAccountCreation() && hasAnyPassword) ||
+      (this.focusedFieldMatchesFillType(InlineMenuFillTypes.PasswordGeneration) && hasNewPassword)
     );
   }
 

--- a/apps/browser/src/autofill/background/overlay.background.ts
+++ b/apps/browser/src/autofill/background/overlay.background.ts
@@ -2245,8 +2245,8 @@ export class OverlayBackground implements OverlayBackgroundInterface {
     const hasNewPassword = !!loginData.newPassword;
 
     return (
-      (this.shouldShowInlineMenuAccountCreation() && hasAnyPassword) ||
-      (this.focusedFieldMatchesFillType(InlineMenuFillTypes.PasswordGeneration) && hasNewPassword)
+      (hasAnyPassword && this.shouldShowInlineMenuAccountCreation()) ||
+      (hasNewPassword && this.focusedFieldMatchesFillType(InlineMenuFillTypes.PasswordGeneration))
     );
   }
 

--- a/apps/browser/src/autofill/background/overlay.background.ts
+++ b/apps/browser/src/autofill/background/overlay.background.ts
@@ -23,6 +23,7 @@ import { AuthenticationStatus } from "@bitwarden/common/auth/enums/authenticatio
 import { getOptionalUserId, getUserId } from "@bitwarden/common/auth/services/account.service";
 import {
   AutofillOverlayVisibility,
+  AutofillTargetingRuleTypes,
   SHOW_AUTOFILL_BUTTON,
 } from "@bitwarden/common/autofill/constants";
 import { AutofillSettingsServiceAbstraction } from "@bitwarden/common/autofill/services/autofill-settings.service";
@@ -2172,10 +2173,16 @@ export class OverlayBackground implements OverlayBackgroundInterface {
 
       // If our currently focused field is for a login form, we want to fill the current password field.
       // Otherwise, map over all page details and filter out fields that are not new password fields.
+      // Targeted fields qualified as `newPassword` by targeting rules bypass the heuristic
+      // check; the rules represent an explicit assertion that the field is a new-password
+      // field, and heuristic keyword tokenization can miss compact names like `confirmPassword`.
       if (!this.focusedFieldMatchesFillType(CipherType.Login)) {
         pageDetails = this.getFilteredPageDetails(
           pageDetails,
-          this.inlineMenuFieldQualificationService.isNewPasswordField,
+          (field) =>
+            (field.targeted === true &&
+              field.fieldQualifier === AutofillTargetingRuleTypes.newPassword) ||
+            this.inlineMenuFieldQualificationService.isNewPasswordField(field),
         );
       }
 

--- a/apps/browser/src/autofill/services/autofill-constants.ts
+++ b/apps/browser/src/autofill/services/autofill-constants.ts
@@ -1,6 +1,20 @@
 import { AutofillTargetingRuleTypes } from "@bitwarden/common/autofill/constants";
 import { AutofillTargetingRuleType } from "@bitwarden/common/autofill/types";
 
+const targetingRuleTypeValues: ReadonlySet<string> = new Set(
+  Object.values(AutofillTargetingRuleTypes),
+);
+
+/**
+ * Type guard for `AutofillTargetingRuleType`. Use at boundaries where a value
+ * typed more loosely (e.g. `AutofillField.fieldQualifier`, which can carry
+ * either heuristic or targeting-rule qualifiers) needs to be narrowed before
+ * being compared against targeting-rule-specific groupings.
+ */
+export function isAutofillTargetingRuleType(value: unknown): value is AutofillTargetingRuleType {
+  return typeof value === "string" && targetingRuleTypeValues.has(value);
+}
+
 export const loginQualifiers: AutofillTargetingRuleType[] = [
   AutofillTargetingRuleTypes.username,
   AutofillTargetingRuleTypes.password,

--- a/apps/browser/src/autofill/services/autofill-overlay-content.service.ts
+++ b/apps/browser/src/autofill/services/autofill-overlay-content.service.ts
@@ -9,7 +9,6 @@ import {
   AUTOFILL_TRIGGER_FORM_FIELD_SUBMIT,
   EVENTS,
 } from "@bitwarden/common/autofill/constants";
-import { AutofillTargetingRuleType } from "@bitwarden/common/autofill/types";
 import { CipherType } from "@bitwarden/common/vault/enums";
 
 import { ModifyLoginCipherFormData } from "../background/abstractions/overlay-notifications.background";
@@ -61,6 +60,7 @@ import {
   loginQualifiers,
   cardQualifiers,
   identityQualifiers,
+  isAutofillTargetingRuleType,
 } from "./autofill-constants";
 
 export class AutofillOverlayContentService implements AutofillOverlayContentServiceInterface {
@@ -1173,33 +1173,27 @@ export class AutofillOverlayContentService implements AutofillOverlayContentServ
    * bypassing heuristic qualification.
    */
   private setTargetedFieldFillType(autofillFieldData: AutofillField): void {
-    // Targeted fields use AutofillTargetingRuleType values in fieldQualifier,
-    // which are distinct from the heuristic AutofillFieldQualifierType values.
-    const qualifier = autofillFieldData.fieldQualifier as AutofillTargetingRuleType;
+    // Targeted fields use `AutofillTargetingRuleType` values in `fieldQualifier`,
+    // which are distinct from the heuristic `AutofillFieldQualifierType` values.
+    const qualifier = autofillFieldData.fieldQualifier;
 
-    if (qualifier === AutofillTargetingRuleTypes.newPassword) {
-      autofillFieldData.inlineMenuFillType = InlineMenuFillTypes.PasswordGeneration;
-      return;
-    }
-
-    if (loginQualifiers.includes(qualifier)) {
+    if (!isAutofillTargetingRuleType(qualifier)) {
       autofillFieldData.inlineMenuFillType = CipherType.Login;
-      return;
-    }
-
-    if (cardQualifiers.includes(qualifier)) {
+    } else if (qualifier === AutofillTargetingRuleTypes.newPassword) {
+      autofillFieldData.inlineMenuFillType = InlineMenuFillTypes.PasswordGeneration;
+    } else if (loginQualifiers.includes(qualifier)) {
+      autofillFieldData.inlineMenuFillType = CipherType.Login;
+    } else if (cardQualifiers.includes(qualifier)) {
       autofillFieldData.inlineMenuFillType = CipherType.Card;
-      return;
-    }
-
-    if (identityQualifiers.includes(qualifier)) {
+    } else if (identityQualifiers.includes(qualifier)) {
       autofillFieldData.inlineMenuFillType = CipherType.Identity;
-      return;
+    } else {
+      // The fallback `CipherType.Login` covers both the unrecognized-qualifier
+      // case and qualifier groups that don't have a dedicated fill type yet;
+      // it avoids inline menu re-render churn that occurs when
+      // `inlineMenuFillType` is left undefined.
+      autofillFieldData.inlineMenuFillType = CipherType.Login;
     }
-
-    // Fallback: default to Login to avoid inline menu re-render churn that
-    // occurs when `inlineMenuFillType` is left undefined.
-    autofillFieldData.inlineMenuFillType = CipherType.Login;
   }
 
   /**

--- a/apps/browser/src/autofill/services/autofill-overlay-content.service.ts
+++ b/apps/browser/src/autofill/services/autofill-overlay-content.service.ts
@@ -3,6 +3,7 @@ import "lit/polyfill-support.js";
 import { FocusableElement, tabbable } from "tabbable";
 
 import {
+  AutofillTargetingRuleTypes,
   AUTOFILL_OVERLAY_HANDLE_REPOSITION,
   AUTOFILL_OVERLAY_HANDLE_SCROLL,
   AUTOFILL_TRIGGER_FORM_FIELD_SUBMIT,
@@ -1175,6 +1176,11 @@ export class AutofillOverlayContentService implements AutofillOverlayContentServ
     // Targeted fields use AutofillTargetingRuleType values in fieldQualifier,
     // which are distinct from the heuristic AutofillFieldQualifierType values.
     const qualifier = autofillFieldData.fieldQualifier as AutofillTargetingRuleType;
+
+    if (qualifier === AutofillTargetingRuleTypes.newPassword) {
+      autofillFieldData.inlineMenuFillType = InlineMenuFillTypes.PasswordGeneration;
+      return;
+    }
 
     if (loginQualifiers.includes(qualifier)) {
       autofillFieldData.inlineMenuFillType = CipherType.Login;

--- a/apps/browser/src/autofill/services/autofill.service.spec.ts
+++ b/apps/browser/src/autofill/services/autofill.service.spec.ts
@@ -5,7 +5,10 @@ import { PolicyService } from "@bitwarden/common/admin-console/abstractions/poli
 import { AuthService } from "@bitwarden/common/auth/abstractions/auth.service";
 import { AuthenticationStatus } from "@bitwarden/common/auth/enums/authentication-status";
 import { UserVerificationService } from "@bitwarden/common/auth/services/user-verification/user-verification.service";
-import { AutofillOverlayVisibility } from "@bitwarden/common/autofill/constants";
+import {
+  AutofillOverlayVisibility,
+  AutofillTargetingRuleTypes,
+} from "@bitwarden/common/autofill/constants";
 import { AutofillSettingsServiceAbstraction } from "@bitwarden/common/autofill/services/autofill-settings.service";
 import {
   DefaultDomainSettingsService,
@@ -1799,6 +1802,95 @@ describe("AutofillService", () => {
       );
 
       expect(value).toBeNull();
+    });
+  });
+
+  describe("generateTargetedFillScript", () => {
+    const buildTargetedPageDetails = (fields: AutofillField[]) =>
+      createAutofillPageDetailsMock({ fields });
+
+    const buildTargetedField = (overrides: Partial<AutofillField>) =>
+      createAutofillFieldMock({
+        targeted: true,
+        ...overrides,
+      });
+
+    it("skips newPassword fields for a normal Login cipher fill (avoids leaking current password)", async () => {
+      const newPasswordField = buildTargetedField({
+        opid: "targeted_field_0_newPassword_0",
+        type: "password",
+        fieldQualifier: AutofillTargetingRuleTypes.newPassword,
+      });
+      const options = createGenerateFillScriptOptionsMock();
+      options.cipher.type = CipherType.Login;
+      options.cipher.login = mock<LoginView>({ password: "stored-password", uris: [] });
+      options.inlineMenuFillType = CipherType.Login;
+
+      const result = await autofillService["generateTargetedFillScript"](
+        buildTargetedPageDetails([newPasswordField]),
+        options,
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it("fills newPassword fields with the cipher password when inlineMenuFillType is PasswordGeneration", async () => {
+      const newPasswordField = buildTargetedField({
+        opid: "targeted_field_0_newPassword_0",
+        type: "password",
+        fieldQualifier: AutofillTargetingRuleTypes.newPassword,
+      });
+      const confirmNewPasswordField = buildTargetedField({
+        opid: "targeted_field_0_newPassword_1",
+        type: "password",
+        fieldQualifier: AutofillTargetingRuleTypes.newPassword,
+      });
+      const options = createGenerateFillScriptOptionsMock();
+      options.cipher.type = CipherType.Login;
+      options.cipher.login = mock<LoginView>({ password: "generated-pass", uris: [] });
+      options.inlineMenuFillType = InlineMenuFillTypes.PasswordGeneration;
+      jest.spyOn(AutofillService, "fillByOpid");
+
+      const result = await autofillService["generateTargetedFillScript"](
+        buildTargetedPageDetails([newPasswordField, confirmNewPasswordField]),
+        options,
+      );
+
+      expect(result).not.toBeNull();
+      expect(AutofillService.fillByOpid).toHaveBeenCalledWith(
+        expect.anything(),
+        newPasswordField,
+        "generated-pass",
+      );
+      expect(AutofillService.fillByOpid).toHaveBeenCalledWith(
+        expect.anything(),
+        confirmNewPasswordField,
+        "generated-pass",
+      );
+    });
+
+    it("fills the current-password field via the standard mapping even on a PasswordGeneration fill", async () => {
+      const passwordField = buildTargetedField({
+        opid: "targeted_field_0_password_0",
+        type: "password",
+        fieldQualifier: AutofillTargetingRuleTypes.password,
+      });
+      const options = createGenerateFillScriptOptionsMock();
+      options.cipher.type = CipherType.Login;
+      options.cipher.login = mock<LoginView>({ password: "stored-password", uris: [] });
+      options.inlineMenuFillType = InlineMenuFillTypes.PasswordGeneration;
+      jest.spyOn(AutofillService, "fillByOpid");
+
+      await autofillService["generateTargetedFillScript"](
+        buildTargetedPageDetails([passwordField]),
+        options,
+      );
+
+      expect(AutofillService.fillByOpid).toHaveBeenCalledWith(
+        expect.anything(),
+        passwordField,
+        "stored-password",
+      );
     });
   });
 

--- a/apps/browser/src/autofill/services/autofill.service.ts
+++ b/apps/browser/src/autofill/services/autofill.service.ts
@@ -911,11 +911,11 @@ export default class AutofillService implements AutofillServiceInterface {
     if (fieldType === AutofillTargetingRuleTypes.username) {
       return cipher.login?.username ?? null;
     }
-    if (
-      fieldType === AutofillTargetingRuleTypes.password ||
-      fieldType === AutofillTargetingRuleTypes.newPassword
-    ) {
+    if (fieldType === AutofillTargetingRuleTypes.password) {
       return cipher.login?.password ?? null;
+    }
+    if (fieldType === AutofillTargetingRuleTypes.newPassword) {
+      return null;
     }
 
     // Card fields

--- a/apps/browser/src/autofill/services/autofill.service.ts
+++ b/apps/browser/src/autofill/services/autofill.service.ts
@@ -874,6 +874,8 @@ export default class AutofillService implements AutofillServiceInterface {
   ): Promise<AutofillScript | null> {
     const fillScript = new AutofillScript();
     const cipher = options.cipher;
+    const isPasswordGeneration =
+      options.inlineMenuFillType === InlineMenuFillTypes.PasswordGeneration;
 
     fillScript.savedUrls =
       cipher.login?.uris
@@ -888,7 +890,14 @@ export default class AutofillService implements AutofillServiceInterface {
         continue;
       }
 
-      const value = this.getValueForTargetedFieldType(field.fieldQualifier, cipher);
+      // Password-generation flow synthesizes a Login cipher whose `password`
+      // carries the generated value. The standard newPassword → null policy
+      // would suppress that fill, so override it here.
+      const value =
+        isPasswordGeneration && field.fieldQualifier === AutofillTargetingRuleTypes.newPassword
+          ? (cipher.login?.password ?? null)
+          : this.getValueForTargetedFieldType(field.fieldQualifier, cipher);
+
       if (!value) {
         continue;
       }

--- a/apps/browser/src/autofill/services/collect-autofill-content.service.spec.ts
+++ b/apps/browser/src/autofill/services/collect-autofill-content.service.spec.ts
@@ -1,5 +1,7 @@
 import { mock } from "jest-mock-extended";
 
+import { FormContent } from "@bitwarden/common/autofill/types";
+
 import AutofillField from "../models/autofill-field";
 import AutofillForm from "../models/autofill-form";
 import { createAutofillFieldMock, createAutofillFormMock } from "../spec/autofill-mocks";
@@ -519,6 +521,216 @@ describe("CollectAutofillContentService", () => {
 
       expect(pageDetails.fields).toHaveLength(1);
       expect(pageDetails.fields[0].opid).toBe("targeted_field_0_username");
+    });
+  });
+
+  describe("getTargetedPageDetails (container resolution)", () => {
+    const mockTargetingRules = (rules: FormContent[] | null) => {
+      jest
+        .spyOn(collectAutofillContentService as any, "sendExtensionMessage")
+        .mockImplementation((command: unknown) => {
+          if (command === "getUrlAutofillTargetingRules") {
+            return Promise.resolve({ result: rules });
+          }
+          return Promise.resolve({ result: null });
+        });
+      jest
+        .spyOn(collectAutofillContentService as any, "setupMutationObserver")
+        .mockImplementationOnce(() => {
+          collectAutofillContentService["mutationObserver"] = mock<MutationObserver>();
+        });
+    };
+
+    it("builds an AutofillForm from a <form> container and associates fields with it", async () => {
+      document.body.innerHTML = `
+        <form id="login-form" name="login" action="/sign-in" method="post" class="auth">
+          <input id="user" type="text" />
+          <input id="pw" type="password" />
+        </form>
+      `;
+      mockTargetingRules([
+        {
+          category: "account-login",
+          container: ["form#login-form"],
+          fields: {
+            username: ["input#user"],
+            password: ["input#pw"],
+          },
+        },
+      ]);
+
+      const pageDetails = await collectAutofillContentService.getPageDetails();
+
+      expect(Object.keys(pageDetails.forms)).toEqual(["targeted_form_0"]);
+      const form = pageDetails.forms["targeted_form_0"];
+      expect(form.htmlID).toBe("login-form");
+      expect(form.htmlName).toBe("login");
+      expect(form.htmlClass).toBe("auth");
+      expect(form.htmlMethod).toBe("post");
+      expect(form.htmlAction).toBe(new URL("/sign-in", globalThis.location.href).href);
+      expect(form.htmlAncestorHeadings).toEqual([]);
+      expect(pageDetails.fields).toHaveLength(2);
+      expect(pageDetails.fields.every((f) => f.form === "targeted_form_0")).toBe(true);
+    });
+
+    it("builds an AutofillForm from a role='form' container with empty action/method", async () => {
+      document.body.innerHTML = `
+        <div role="form" id="login-card" class="auth-card">
+          <input id="user" type="text" />
+          <input id="pw" type="password" />
+        </div>
+      `;
+      mockTargetingRules([
+        {
+          category: "account-login",
+          container: ["div[role='form']#login-card"],
+          fields: {
+            username: ["input#user"],
+            password: ["input#pw"],
+          },
+        },
+      ]);
+
+      const pageDetails = await collectAutofillContentService.getPageDetails();
+
+      const form = pageDetails.forms["targeted_form_0"];
+      expect(form.htmlID).toBe("login-card");
+      expect(form.htmlClass).toBe("auth-card");
+      expect(form.htmlAction).toBe("");
+      expect(form.htmlMethod).toBe("");
+      expect(pageDetails.fields.every((f) => f.form === "targeted_form_0")).toBe(true);
+    });
+
+    it("uses the first matching alternative when multiple container selectors are provided", async () => {
+      document.body.innerHTML = `
+        <form id="actual-form">
+          <input id="user" type="text" />
+        </form>
+      `;
+      mockTargetingRules([
+        {
+          category: "account-login",
+          container: ["form#does-not-exist", "form#actual-form"],
+          fields: {
+            username: ["input#user"],
+          },
+        },
+      ]);
+
+      const pageDetails = await collectAutofillContentService.getPageDetails();
+
+      expect(pageDetails.forms["targeted_form_0"].htmlID).toBe("actual-form");
+      expect(pageDetails.fields[0].form).toBe("targeted_form_0");
+    });
+
+    it("creates no form record and leaves fields unassociated when the container does not resolve", async () => {
+      document.body.innerHTML = `
+        <div>
+          <input id="user" type="text" />
+        </div>
+      `;
+      mockTargetingRules([
+        {
+          category: "account-login",
+          container: ["form#missing-container"],
+          fields: {
+            username: ["input#user"],
+          },
+        },
+      ]);
+
+      const pageDetails = await collectAutofillContentService.getPageDetails();
+
+      expect(pageDetails.forms).toEqual({});
+      expect(pageDetails.fields).toHaveLength(1);
+      expect(pageDetails.fields[0].form).toBeNull();
+    });
+
+    it("creates no form record when the container property is omitted", async () => {
+      document.body.innerHTML = `
+        <div>
+          <input id="user" type="text" />
+        </div>
+      `;
+      mockTargetingRules([
+        {
+          category: "account-login",
+          fields: {
+            username: ["input#user"],
+          },
+        },
+      ]);
+
+      const pageDetails = await collectAutofillContentService.getPageDetails();
+
+      expect(pageDetails.forms).toEqual({});
+      expect(pageDetails.fields[0].form).toBeNull();
+    });
+
+    it("skips array (sequence) entries in the container array without throwing", async () => {
+      document.body.innerHTML = `
+        <form id="login-form">
+          <input id="user" type="text" />
+        </form>
+      `;
+      mockTargetingRules([
+        {
+          category: "account-login",
+          container: [["input#never-applies"] as any, "form#login-form"],
+          fields: {
+            username: ["input#user"],
+          },
+        },
+      ]);
+
+      const pageDetails = await collectAutofillContentService.getPageDetails();
+
+      expect(pageDetails.forms["targeted_form_0"].htmlID).toBe("login-form");
+    });
+
+    it("routes fields to their own form when multiple FormContent entries have distinct containers", async () => {
+      document.body.innerHTML = `
+        <form id="login-form">
+          <input id="login-user" type="text" />
+          <input id="login-pw" type="password" />
+        </form>
+        <form id="signup-form">
+          <input id="signup-user" type="text" />
+          <input id="signup-pw" type="password" />
+        </form>
+      `;
+      mockTargetingRules([
+        {
+          category: "account-login",
+          container: ["form#login-form"],
+          fields: {
+            username: ["input#login-user"],
+            password: ["input#login-pw"],
+          },
+        },
+        {
+          category: "account-creation",
+          container: ["form#signup-form"],
+          fields: {
+            username: ["input#signup-user"],
+            newPassword: ["input#signup-pw"],
+          },
+        },
+      ]);
+
+      const pageDetails = await collectAutofillContentService.getPageDetails();
+
+      expect(Object.keys(pageDetails.forms).sort()).toEqual(["targeted_form_0", "targeted_form_1"]);
+      const loginFields = pageDetails.fields.filter((f) => f.form === "targeted_form_0");
+      const signupFields = pageDetails.fields.filter((f) => f.form === "targeted_form_1");
+      expect(loginFields.map((f) => f.opid).sort()).toEqual([
+        "targeted_field_0_password",
+        "targeted_field_0_username",
+      ]);
+      expect(signupFields.map((f) => f.opid).sort()).toEqual([
+        "targeted_field_1_newPassword",
+        "targeted_field_1_username",
+      ]);
     });
   });
 

--- a/apps/browser/src/autofill/services/collect-autofill-content.service.spec.ts
+++ b/apps/browser/src/autofill/services/collect-autofill-content.service.spec.ts
@@ -468,62 +468,6 @@ describe("CollectAutofillContentService", () => {
     });
   });
 
-  describe("getTargetedPageDetails cached-field fallback", () => {
-    beforeEach(() => {
-      jest
-        .spyOn(collectAutofillContentService as any, "sendExtensionMessage")
-        .mockImplementation((command: string) => {
-          if (command === "getUrlAutofillTargetingRules") {
-            return Promise.resolve({
-              result: [
-                {
-                  fields: {
-                    username: ["iframe#nonexistent >>> #username"],
-                  },
-                },
-              ],
-            });
-          }
-          return Promise.resolve(undefined);
-        });
-      jest
-        .spyOn(collectAutofillContentService as any, "setupMutationObserver")
-        .mockImplementationOnce(() => {
-          collectAutofillContentService["mutationObserver"] = mock<MutationObserver>();
-        });
-    });
-
-    it("returns empty page details when no local fields match and autofillFieldElements is empty", async () => {
-      document.body.innerHTML = `<input type="text" id="username" />`;
-
-      const pageDetails = await collectAutofillContentService.getPageDetails();
-
-      expect(pageDetails.fields).toHaveLength(0);
-    });
-
-    it("returns cached page details from applyExternalTargetedFields when no local fields match", async () => {
-      document.body.innerHTML = `<input type="text" id="username" />`;
-
-      const targetedFields = [{ selector: "#username", fieldType: "username" }];
-      jest
-        .spyOn(collectAutofillContentService as any, "sendExtensionMessage")
-        .mockImplementation((command: string) => {
-          if (command === "getUrlAutofillTargetingRules") {
-            return Promise.resolve({
-              result: [{ fields: { username: ["iframe#nonexistent >>> #username"] } }],
-            });
-          }
-          return Promise.resolve(undefined);
-        });
-      await collectAutofillContentService.applyExternalTargetedFields(targetedFields);
-
-      const pageDetails = await collectAutofillContentService.getPageDetails();
-
-      expect(pageDetails.fields).toHaveLength(1);
-      expect(pageDetails.fields[0].opid).toBe("targeted_field_0_username");
-    });
-  });
-
   describe("getTargetedPageDetails (container resolution)", () => {
     const mockTargetingRules = (rules: FormContent[] | null) => {
       jest

--- a/apps/browser/src/autofill/services/collect-autofill-content.service.spec.ts
+++ b/apps/browser/src/autofill/services/collect-autofill-content.service.spec.ts
@@ -724,13 +724,90 @@ describe("CollectAutofillContentService", () => {
       const loginFields = pageDetails.fields.filter((f) => f.form === "targeted_form_0");
       const signupFields = pageDetails.fields.filter((f) => f.form === "targeted_form_1");
       expect(loginFields.map((f) => f.opid).sort()).toEqual([
-        "targeted_field_0_password",
-        "targeted_field_0_username",
+        "targeted_field_0_password_0",
+        "targeted_field_0_username_0",
       ]);
       expect(signupFields.map((f) => f.opid).sort()).toEqual([
-        "targeted_field_1_newPassword",
-        "targeted_field_1_username",
+        "targeted_field_1_newPassword_0",
+        "targeted_field_1_username_0",
       ]);
+    });
+
+    it("collects up to two newPassword matches from a single selector array (re-entry pattern)", async () => {
+      document.body.innerHTML = `
+        <form id="change-password">
+          <input id="new-pw" type="password" name="newPassword" />
+          <input id="confirm-pw" type="password" name="confirmPassword" />
+        </form>
+      `;
+      mockTargetingRules([
+        {
+          category: "account-update",
+          container: ["form#change-password"],
+          fields: {
+            newPassword: ["input[name='newPassword']", "input[name='confirmPassword']"],
+          },
+        },
+      ]);
+
+      const pageDetails = await collectAutofillContentService.getPageDetails();
+
+      const newPasswordFields = pageDetails.fields.filter(
+        (f) => f.fieldQualifier === "newPassword",
+      );
+      expect(newPasswordFields).toHaveLength(2);
+      expect(newPasswordFields.map((f) => f.opid).sort()).toEqual([
+        "targeted_field_0_newPassword_0",
+        "targeted_field_0_newPassword_1",
+      ]);
+    });
+
+    it("stops at the first match for non-newPassword field types", async () => {
+      document.body.innerHTML = `
+        <form id="login-form">
+          <input id="user-1" type="text" name="username" />
+          <input id="user-2" type="text" name="email" />
+        </form>
+      `;
+      mockTargetingRules([
+        {
+          category: "account-login",
+          container: ["form#login-form"],
+          fields: {
+            username: ["input[name='username']", "input[name='email']"],
+          },
+        },
+      ]);
+
+      const pageDetails = await collectAutofillContentService.getPageDetails();
+
+      const usernameFields = pageDetails.fields.filter((f) => f.fieldQualifier === "username");
+      expect(usernameFields).toHaveLength(1);
+      expect(usernameFields[0].opid).toBe("targeted_field_0_username_0");
+    });
+
+    it("dedupes by element identity when two newPassword selectors resolve to the same node", async () => {
+      document.body.innerHTML = `
+        <form id="change-password">
+          <input id="new-pw" type="password" name="newPassword" data-test="new" />
+        </form>
+      `;
+      mockTargetingRules([
+        {
+          category: "account-update",
+          container: ["form#change-password"],
+          fields: {
+            newPassword: ["input[name='newPassword']", "input[data-test='new']"],
+          },
+        },
+      ]);
+
+      const pageDetails = await collectAutofillContentService.getPageDetails();
+
+      const newPasswordFields = pageDetails.fields.filter(
+        (f) => f.fieldQualifier === "newPassword",
+      );
+      expect(newPasswordFields).toHaveLength(1);
     });
   });
 

--- a/apps/browser/src/autofill/services/collect-autofill-content.service.ts
+++ b/apps/browser/src/autofill/services/collect-autofill-content.service.ts
@@ -4,18 +4,6 @@ import {
 } from "@bitwarden/common/autofill/constants";
 import { AutofillTargetingRuleType, FormContent } from "@bitwarden/common/autofill/types";
 
-/**
- * Per-field-type cap on how many DOM matches the targeted-collection pass
- * accepts from a selector array. Selector arrays are alternatives by default
- * (first match wins), but certain field types appear in pairs on the same
- * form — most notably `newPassword`, which is commonly mirrored by a
- * "confirm new password" input on registration and password-update flows.
- */
-const MAX_MATCHES_BY_FIELD_TYPE: Partial<Record<AutofillTargetingRuleType, number>> = {
-  [AutofillTargetingRuleTypes.newPassword]: 2,
-};
-const DEFAULT_MAX_MATCHES = 1;
-
 import AutofillField from "../models/autofill-field";
 import AutofillForm from "../models/autofill-form";
 import AutofillPageDetails from "../models/autofill-page-details";
@@ -51,6 +39,19 @@ import {
 import { DomElementVisibilityService } from "./abstractions/dom-element-visibility.service";
 import { DomQueryService } from "./abstractions/dom-query.service";
 import { AutoFillConstants } from "./autofill-constants";
+
+/**
+ * Per-field-type cap on how many DOM matches the targeted-collection pass
+ * accepts from a selector array. Selector arrays are alternatives by default
+ * (first match wins), but certain field types appear in pairs on the same
+ * form — most notably `newPassword`, which is commonly mirrored by a
+ * "confirm new password" input on registration and password-update flows.
+ */
+const MAX_MATCHES_BY_FIELD_TYPE: Readonly<Partial<Record<AutofillTargetingRuleType, number>>> =
+  Object.freeze({
+    [AutofillTargetingRuleTypes.newPassword]: 2,
+  });
+const DEFAULT_MAX_MATCHES = 1;
 
 export class CollectAutofillContentService implements CollectAutofillContentServiceInterface {
   private readonly sendExtensionMessage = sendExtensionMessage;

--- a/apps/browser/src/autofill/services/collect-autofill-content.service.ts
+++ b/apps/browser/src/autofill/services/collect-autofill-content.service.ts
@@ -260,12 +260,20 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
 
   /**
    * Builds page details using targeting rule selectors instead of heuristic
-   * detection. Iterates through form definitions, resolving each field type's
-   * selector array by trying each `DeepSelector` in order and stopping at the
-   * first DOM match.
+   * detection. Iterates through form definitions, resolving each form's
+   * optional `container` selector and each field type's selector array by
+   * trying each `DeepSelector` in order and stopping at the first DOM match.
+   *
+   * When a `container` resolves locally, fields belonging to that
+   * `FormContent` are associated with the resolved form record via
+   * `field.form`. When it does not resolve (or is absent, or crosses an
+   * iframe boundary), fields are left unassociated — the targeted path is
+   * mutually exclusive with heuristics and does not fall back to native
+   * `<input>.form` ancestry.
    */
   private getTargetedPageDetails(forms: FormContent[]): AutofillPageDetails {
     const fields: AutofillField[] = [];
+    const autofillFormsData: Record<string, AutofillForm> = {};
     // Accumulates targets that live inside iframes, keyed by the iframe's URL.
     // These are routed to the iframe's own content script instead of being
     // collected here, so the existing sub-frame offset infrastructure handles
@@ -277,6 +285,13 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
 
     for (let formIndex = 0; formIndex < forms.length; formIndex++) {
       const form = forms[formIndex];
+
+      const containerElement = this.resolveTargetedContainerElement(form.container);
+      let formOpid: string | null = null;
+      if (containerElement) {
+        formOpid = `targeted_form_${formIndex}`;
+        autofillFormsData[formOpid] = this.buildTargetedAutofillForm(containerElement, formOpid);
+      }
 
       for (const [fieldType, selectorAlternatives] of Object.entries(form.fields)) {
         if (!selectorAlternatives?.length) {
@@ -318,6 +333,7 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
               fieldType as AutofillTargetingRuleType,
               fields.length,
             );
+            autofillField.form = formOpid;
 
             fields.push(autofillField);
             this.cacheAutofillFieldElement(fields.length - 1, formFieldElement, autofillField);
@@ -359,10 +375,61 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
      * @TODO check if need to utilize targeting rules for forms/submits within closed
      * shadow roots as well, in order to detect cipher additions/updates
      */
-    const pageDetails = this.getFormattedPageDetails({}, fields);
+    const pageDetails = this.getFormattedPageDetails(autofillFormsData, fields);
     this.setupOverlayListeners(pageDetails);
 
     return pageDetails;
+  }
+
+  /**
+   * Resolves a targeting rule's `container` selector array to the first DOM
+   * element matched by any string entry. Skips `DeepSelectorSequence`
+   * (string[]) entries (sequences are nonsensical for a single container) and
+   * skips entries that cross an iframe boundary (container routing across
+   * frames is out of scope; the receiving frame has no container metadata).
+   * Returns `null` when no entry resolves, when the array is empty, or when
+   * `container` is undefined.
+   */
+  private resolveTargetedContainerElement(container: FormContent["container"]): HTMLElement | null {
+    if (!container?.length) {
+      return null;
+    }
+    for (const selector of container) {
+      if (typeof selector !== "string") {
+        continue;
+      }
+      if (this.domQueryService.findIframeCrossing(selector)) {
+        continue;
+      }
+      const match = this.domQueryService.queryDeepSelector(selector);
+      if (match instanceof HTMLElement) {
+        return match;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Builds an AutofillForm record for a container element resolved from a
+   * targeting rule. `id`, `name`, and `class` are read from any element type;
+   * `action` and `method` are only populated for actual `<form>` elements
+   * (a `<div role="form">` container, for example, has neither).
+   */
+  private buildTargetedAutofillForm(element: HTMLElement, opid: string): AutofillForm {
+    const isFormElement = element instanceof HTMLFormElement;
+    const form = new AutofillForm();
+    form.opid = opid;
+    form.htmlID = this.getPropertyOrAttribute(element, AUTOFILL_ATTRIBUTES.ID) ?? "";
+    form.htmlName = this.getPropertyOrAttribute(element, AUTOFILL_ATTRIBUTES.NAME) ?? "";
+    form.htmlClass = this.getPropertyOrAttribute(element, "class") ?? "";
+    form.htmlAction = isFormElement
+      ? (this.getFormActionAttribute(element as ElementWithOpId<HTMLFormElement>) ?? "")
+      : "";
+    form.htmlMethod = isFormElement
+      ? (this.getPropertyOrAttribute(element, AUTOFILL_ATTRIBUTES.METHOD) ?? "")
+      : "";
+    form.htmlAncestorHeadings = [];
+    return form;
   }
 
   /**

--- a/apps/browser/src/autofill/services/collect-autofill-content.service.ts
+++ b/apps/browser/src/autofill/services/collect-autofill-content.service.ts
@@ -1,5 +1,20 @@
-import { AUTOFILL_ATTRIBUTES } from "@bitwarden/common/autofill/constants";
+import {
+  AUTOFILL_ATTRIBUTES,
+  AutofillTargetingRuleTypes,
+} from "@bitwarden/common/autofill/constants";
 import { AutofillTargetingRuleType, FormContent } from "@bitwarden/common/autofill/types";
+
+/**
+ * Per-field-type cap on how many DOM matches the targeted-collection pass
+ * accepts from a selector array. Selector arrays are alternatives by default
+ * (first match wins), but certain field types appear in pairs on the same
+ * form — most notably `newPassword`, which is commonly mirrored by a
+ * "confirm new password" input on registration and password-update flows.
+ */
+const MAX_MATCHES_BY_FIELD_TYPE: Partial<Record<AutofillTargetingRuleType, number>> = {
+  [AutofillTargetingRuleTypes.newPassword]: 2,
+};
+const DEFAULT_MAX_MATCHES = 1;
 
 import AutofillField from "../models/autofill-field";
 import AutofillForm from "../models/autofill-form";
@@ -298,7 +313,18 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
           continue;
         }
 
+        const typedFieldType = fieldType as AutofillTargetingRuleType;
+        const maxMatches = MAX_MATCHES_BY_FIELD_TYPE[typedFieldType] ?? DEFAULT_MAX_MATCHES;
+        // Dedupe by element identity in case two selectors in the array
+        // resolve to the same node.
+        const matchedElements = new Set<Element>();
+        let matchCount = 0;
+
         for (const selector of selectorAlternatives) {
+          if (matchCount >= maxMatches) {
+            break;
+          }
+
           if (typeof selector !== "string") {
             continue;
           }
@@ -315,29 +341,35 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
               }
               iframeTargets.get(iframeSrc)!.push({
                 selector: innerSelector,
-                fieldType: fieldType as AutofillTargetingRuleType,
+                fieldType: typedFieldType,
               });
             }
-            break;
+            matchCount++;
+            continue;
           }
 
           // No iframe boundary — resolve locally (direct element or shadow DOM).
           const matchedElement = this.domQueryService.queryDeepSelector(selector);
           if (matchedElement) {
-            const fieldId = `targeted_field_${formIndex}_${fieldType}`;
+            if (matchedElements.has(matchedElement)) {
+              continue;
+            }
+            matchedElements.add(matchedElement);
+
+            const fieldId = `targeted_field_${formIndex}_${fieldType}_${matchCount}`;
             const formFieldElement = matchedElement as ElementWithOpId<FormFieldElement>;
             formFieldElement.opid = fieldId;
 
             const autofillField = this.buildTargetedAutofillField(
               formFieldElement,
-              fieldType as AutofillTargetingRuleType,
+              typedFieldType,
               fields.length,
             );
             autofillField.form = formOpid;
 
             fields.push(autofillField);
             this.cacheAutofillFieldElement(fields.length - 1, formFieldElement, autofillField);
-            break;
+            matchCount++;
           }
         }
       }

--- a/apps/browser/src/autofill/services/collect-autofill-content.service.ts
+++ b/apps/browser/src/autofill/services/collect-autofill-content.service.ts
@@ -44,7 +44,7 @@ import { AutoFillConstants } from "./autofill-constants";
  * Per-field-type cap on how many DOM matches the targeted-collection pass
  * accepts from a selector array. Selector arrays are alternatives by default
  * (first match wins), but certain field types appear in pairs on the same
- * form — most notably `newPassword`, which is commonly mirrored by a
+ * form; most notably `newPassword`, which is commonly mirrored by a
  * "confirm new password" input on registration and password-update flows.
  */
 const MAX_MATCHES_BY_FIELD_TYPE: Readonly<Partial<Record<AutofillTargetingRuleType, number>>> =
@@ -282,16 +282,16 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
    *
    * When a `container` resolves locally, fields belonging to that
    * `FormContent` are associated with the resolved form record via
-   * `field.form`. When it does not resolve (or is absent, or crosses an
-   * iframe boundary), fields are left unassociated — the targeted path is
-   * mutually exclusive with heuristics and does not fall back to native
+   * `field.form`. When it does not resolve (or is absent or crosses an
+   * `iframe` boundary), fields are left unassociated; the targeted path is
+   * mutually-exclusive with heuristics and does not fall back to native
    * `<input>.form` ancestry.
    */
   private getTargetedPageDetails(forms: FormContent[]): AutofillPageDetails {
     const fields: AutofillField[] = [];
     const autofillFormsData: Record<string, AutofillForm> = {};
-    // Accumulates targets that live inside iframes, keyed by the iframe's URL.
-    // These are routed to the iframe's own content script instead of being
+    // Accumulates targets that live inside `iframe`s, indexed by the `iframe`'s `src`.
+    // These are routed to the `iframe`'s own content script instead of being
     // collected here, so the existing sub-frame offset infrastructure handles
     // their positioning correctly.
     const iframeTargets = new Map<
@@ -314,71 +314,20 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
           continue;
         }
 
-        const typedFieldType = fieldType as AutofillTargetingRuleType;
-        const maxMatches = MAX_MATCHES_BY_FIELD_TYPE[typedFieldType] ?? DEFAULT_MAX_MATCHES;
-        // Dedupe by element identity in case two selectors in the array
-        // resolve to the same node.
-        const matchedElements = new Set<Element>();
-        let matchCount = 0;
-
-        for (const selector of selectorAlternatives) {
-          if (matchCount >= maxMatches) {
-            break;
-          }
-
-          if (typeof selector !== "string") {
-            continue;
-          }
-
-          // Check whether this selector crosses an iframe boundary before
-          // trying to resolve it locally.
-          const iframeCrossing = this.domQueryService.findIframeCrossing(selector);
-          if (iframeCrossing) {
-            const { iframeElement, innerSelector } = iframeCrossing;
-            const iframeSrc = iframeElement.contentDocument?.location?.href || iframeElement.src;
-            if (iframeSrc) {
-              if (!iframeTargets.has(iframeSrc)) {
-                iframeTargets.set(iframeSrc, []);
-              }
-              iframeTargets.get(iframeSrc)!.push({
-                selector: innerSelector,
-                fieldType: typedFieldType,
-              });
-            }
-            matchCount++;
-            continue;
-          }
-
-          // No iframe boundary — resolve locally (direct element or shadow DOM).
-          const matchedElement = this.domQueryService.queryDeepSelector(selector);
-          if (matchedElement) {
-            if (matchedElements.has(matchedElement)) {
-              continue;
-            }
-            matchedElements.add(matchedElement);
-
-            const fieldId = `targeted_field_${formIndex}_${fieldType}_${matchCount}`;
-            const formFieldElement = matchedElement as ElementWithOpId<FormFieldElement>;
-            formFieldElement.opid = fieldId;
-
-            const autofillField = this.buildTargetedAutofillField(
-              formFieldElement,
-              typedFieldType,
-              fields.length,
-            );
-            autofillField.form = formOpid;
-
-            fields.push(autofillField);
-            this.cacheAutofillFieldElement(fields.length - 1, formFieldElement, autofillField);
-            matchCount++;
-          }
-        }
+        this.collectTargetedFieldsForType(
+          fieldType as AutofillTargetingRuleType,
+          selectorAlternatives,
+          formIndex,
+          formOpid,
+          fields,
+          iframeTargets,
+        );
       }
     }
 
-    // Route iframe-crossing selectors to their respective frames. Fire-and-
-    // forget: the iframe content scripts apply their fields asynchronously and
-    // re-send collectPageDetailsResponse with their own frameId.
+    // Route `iframe`-crossing selectors to their respective frames. The `iframe`
+    // content scripts apply their fields asynchronously and re-send
+    // "collectPageDetailsResponse" with their own `frameId`; no return here.
     for (const [iframeSrc, iframeTargetedFields] of iframeTargets) {
       void this.sendExtensionMessage("routeTargetedFieldsToFrame", {
         iframeSrc,
@@ -386,32 +335,118 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
       });
     }
 
-    // If this frame resolved no local targeted fields but already has fields cached
-    // from a prior applyExternalTargetedFields call, use those cached fields. This
-    // handles the case where an iframe's own getPageDetails() runs the targeting path
-    // (because targeting rules apply to the whole tab URL) but all selectors in the
-    // rules cross an iframe boundary that doesn't exist inside this frame — so the
-    // results are empty, and we must not overwrite the background's page-details entry
-    // with an empty payload.
-    if (!fields.length && this.autofillFieldElements.size > 0) {
-      this.domRecentlyMutated = false;
-      const cachedPageDetails = this.getFormattedPageDetails(
-        this.getFormattedAutofillFormsData(),
-        this.getFormattedAutofillFieldsData(),
-      );
-      this.setupOverlayListeners(cachedPageDetails);
-      return cachedPageDetails;
-    }
-
     this.domRecentlyMutated = false;
     /**
-     * @TODO check if need to utilize targeting rules for forms/submits within closed
+     * FIXME check if need to utilize targeting rules for forms/submits within closed
      * shadow roots as well, in order to detect cipher additions/updates
      */
     const pageDetails = this.getFormattedPageDetails(autofillFormsData, fields);
     this.setupOverlayListeners(pageDetails);
 
     return pageDetails;
+  }
+
+  /**
+   * Processes a single field type's selector alternatives within a targeted form.
+   */
+  private collectTargetedFieldsForType(
+    fieldType: AutofillTargetingRuleType,
+    selectorAlternatives: NonNullable<FormContent["fields"]>[AutofillTargetingRuleType],
+    formIndex: number,
+    formOpid: string | null,
+    fields: AutofillField[],
+    iframeTargets: Map<string, { selector: string; fieldType: AutofillTargetingRuleType }[]>,
+  ): void {
+    const maxMatches = MAX_MATCHES_BY_FIELD_TYPE[fieldType] ?? DEFAULT_MAX_MATCHES;
+    // Dedupe by element identity in case two selectors in the array
+    // resolve to the same node.
+    const matchedElements = new Set<Element>();
+    let matchCount = 0;
+
+    for (const selector of selectorAlternatives ?? []) {
+      if (matchCount >= maxMatches) {
+        break;
+      }
+
+      if (typeof selector !== "string") {
+        continue;
+      }
+
+      // Check whether this selector crosses an iframe boundary before
+      // trying to resolve it locally.
+      const iframeCrossing = this.domQueryService.findIframeCrossing(selector);
+
+      if (iframeCrossing) {
+        // Treats an outer-hop iframe match as a success signal; the inner
+        // selector's resolution happens asynchronously inside the iframe and
+        // may not actually produce a field. An iframe with no resolvable
+        // source (e.g. constructed but not yet navigated) is NOT counted,
+        // so a later alternative in the same selector array still gets a
+        // chance to resolve.
+        //
+        // FIXME replace with await-per-selector so the inner resolution is
+        // confirmed before the next selector is attempted.
+        if (this.routeSelectorToIframe(iframeCrossing, fieldType, iframeTargets)) {
+          matchCount++;
+        }
+
+        continue;
+      }
+
+      // No `iframe` boundary; resolve locally (direct element or shadow DOM).
+      const matchedElement = this.domQueryService.queryDeepSelector(selector);
+
+      if (!matchedElement || matchedElements.has(matchedElement)) {
+        continue;
+      }
+
+      matchedElements.add(matchedElement);
+
+      const formFieldElement = matchedElement as ElementWithOpId<FormFieldElement>;
+      formFieldElement.opid = `targeted_field_${formIndex}_${fieldType}_${matchCount}`;
+
+      const autofillField = this.buildTargetedAutofillField(
+        formFieldElement,
+        fieldType,
+        fields.length,
+      );
+      autofillField.form = formOpid;
+
+      fields.push(autofillField);
+      this.cacheAutofillFieldElement(fields.length - 1, formFieldElement, autofillField);
+
+      matchCount++;
+    }
+  }
+
+  /**
+   * Records an `iframe`-crossing selector against its target `iframe`'s source URL.
+   * Returns `true` when the routing was recorded; `false` when the `iframe` lacks
+   * a resolvable source (constructed but not yet navigated, etc.) so the caller
+   * can decline to consume a match slot for it.
+   */
+  private routeSelectorToIframe(
+    iframeCrossing: { iframeElement: HTMLIFrameElement; innerSelector: string },
+    fieldType: AutofillTargetingRuleType,
+    iframeTargets: Map<string, { selector: string; fieldType: AutofillTargetingRuleType }[]>,
+  ): boolean {
+    const { iframeElement, innerSelector } = iframeCrossing;
+    const iframeSrc = iframeElement.contentDocument?.location?.href || iframeElement.src;
+
+    if (!iframeSrc) {
+      return false;
+    }
+
+    if (!iframeTargets.has(iframeSrc)) {
+      iframeTargets.set(iframeSrc, []);
+    }
+
+    iframeTargets.get(iframeSrc)!.push({
+      selector: innerSelector,
+      fieldType,
+    });
+
+    return true;
   }
 
   /**


### PR DESCRIPTION
## 🎟️ Tracking

[PM-34491](https://bitwarden.atlassian.net/browse/PM-34491)

## 📔 Objective

Fixed:
- `newPassword` selector arrays match up to two elements (instead of one); instead of stopping on the first new password field, fill will handle up to two new password fields if specified in the targeting rules.

Deferred:
- ~`newPassword` targeted fields no longer fill with the cipher's current password during a normal Login fill.~ 
  (split to https://github.com/bitwarden/clients/pull/21238)
- ~`newPassword` targeted fields now map to `InlineMenuFillTypes.PasswordGeneration` (not `CipherType.Login`), so the inline menu offers the generator instead of the cipher list.~ 
  (split to https://github.com/bitwarden/clients/pull/21238)
- ~`generateTargetedFillScript` honors `PasswordGeneration` by routing `cipher.login.password` into targeted `newPassword` fields, otherwise the menu would appear but fail to fill.~ 
  (split to https://github.com/bitwarden/clients/pull/21239)
- ~Filling a generated password no longer prunes targeted `newPassword` fields through heuristic filter before fill~ 
  (split to https://github.com/bitwarden/clients/pull/21245)
- ~the inline menu save prompt no longer fires on "new password" fields just because the current-password field was filled on an update form.~
  (split to https://github.com/bitwarden/clients/pull/21244)
- ~autofill logic now leverages provided selectors for form "submit" actions (other actions and auto submit support not implemented)~ 
  (split to [PM-38476](https://bitwarden.atlassian.net/browse/PM-38476))

[PM-34491]: https://bitwarden.atlassian.net/browse/PM-34491?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PM-38476]: https://bitwarden.atlassian.net/browse/PM-38476?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ