### PR TITLE
[PM-38448] Feature/desktop quick acces

### DIFF
--- a/apps/desktop/src/app/accounts/settings.component.html
+++ b/apps/desktop/src/app/accounts/settings.component.html
@@ -281,6 +281,37 @@
                   "enableBrowserIntegrationDesc1" | i18n
                 }}</small>
               </div>
+              <div class="form-group">
+                <div class="checkbox">
+                  <label for="enableQuickAccess">
+                    <input
+                      id="enableQuickAccess"
+                      type="checkbox"
+                      aria-describedby="enableQuickAccessHelp"
+                      formControlName="enableQuickAccess"
+                      (change)="saveQuickAccessEnabled()"
+                    />
+                    <div class="tw-flex tw-items-center tw-gap-2">
+                      {{ "enableQuickAccessShortcutPreview" | i18n }}
+                      <div>
+                        <code>{{ form.value.quickAccessShortcut }}</code>
+                      </div>
+                    </div>
+                  </label>
+                </div>
+                <small id="enableQuickAccessHelp" class="help-block">
+                  {{ "enableQuickAccessShortcutDescription" | i18n }}
+                  <a
+                    class="settings-link"
+                    tabindex="0"
+                    *ngIf="form.value.enableQuickAccess"
+                    (click)="saveQuickAccessShortcut()"
+                    (keydown.enter)="saveQuickAccessShortcut(); $event.preventDefault()"
+                  >
+                    {{ "editShortcut" | i18n }}
+                  </a>
+                </small>
+              </div>
               <div class="form-group" *ngIf="showEnableAutotype">
                 <div class="checkbox">
                   <label for="enableAutotype">

--- a/apps/desktop/src/app/accounts/settings.component.spec.ts
+++ b/apps/desktop/src/app/accounts/settings.component.spec.ts
@@ -38,6 +38,7 @@ import { SshAgentPromptType } from "../../autofill/models/ssh-agent-setting";
 import { DesktopAutofillSettingsService } from "../../autofill/services/desktop-autofill-settings.service";
 import { DesktopAutotypeService } from "../../autofill/services/desktop-autotype.service";
 import { DesktopBiometricsService } from "../../key-management/biometrics/desktop.biometrics.service";
+import { DEFAULT_QUICK_ACCESS_SHORTCUT } from "../../platform/models/domain/quick-access-shortcut";
 import { DesktopSettingsService } from "../../platform/services/desktop-settings.service";
 import { NativeMessagingManifestService } from "../services/native-messaging-manifest.service";
 
@@ -177,6 +178,8 @@ describe("SettingsComponent", () => {
     desktopSettingsService.openAtLogin$ = of(false);
     desktopSettingsService.alwaysShowDock$ = of(false);
     desktopSettingsService.browserIntegrationEnabled$ = of(false);
+    desktopSettingsService.quickAccessEnabled$ = of(true);
+    desktopSettingsService.quickAccessShortcut$ = of(DEFAULT_QUICK_ACCESS_SHORTCUT);
     desktopSettingsService.hardwareAcceleration$ = of(false);
     desktopSettingsService.sshAgentEnabled$ = of(false);
     desktopSettingsService.sshAgentPromptBehavior$ = of(SshAgentPromptType.Always);

--- a/apps/desktop/src/app/accounts/settings.component.ts
+++ b/apps/desktop/src/app/accounts/settings.component.ts
@@ -59,7 +59,9 @@ import { DesktopAutofillSettingsService } from "../../autofill/services/desktop-
 import { DesktopAutotypeService } from "../../autofill/services/desktop-autotype.service";
 import { DesktopPremiumUpgradePromptService } from "../../billing/services/desktop-premium-upgrade-prompt.service";
 import { DesktopBiometricsService } from "../../key-management/biometrics/desktop.biometrics.service";
+import { DEFAULT_QUICK_ACCESS_SHORTCUT } from "../../platform/models/domain/quick-access-shortcut";
 import { DesktopSettingsService } from "../../platform/services/desktop-settings.service";
+import { QuickAccessShortcutComponent } from "../quick-access/quick-access-shortcut.component";
 import { NativeMessagingManifestService } from "../services/native-messaging-manifest.service";
 
 // FIXME(https://bitwarden.atlassian.net/browse/CL-764): Migrate to OnPush
@@ -149,6 +151,8 @@ export class SettingsComponent implements OnInit, OnDestroy {
     openAtLogin: false,
     alwaysShowDock: false,
     enableBrowserIntegration: false,
+    enableQuickAccess: true,
+    quickAccessShortcut: [null as string | null],
     enableHardwareAcceleration: true,
     enableSshAgent: false,
     sshAgentPromptBehavior: SshAgentPromptType.Always,
@@ -308,6 +312,8 @@ export class SettingsComponent implements OnInit, OnDestroy {
       enableBrowserIntegration: await firstValueFrom(
         this.desktopSettingsService.browserIntegrationEnabled$,
       ),
+      enableQuickAccess: await firstValueFrom(this.desktopSettingsService.quickAccessEnabled$),
+      quickAccessShortcut: await firstValueFrom(this.desktopSettingsService.quickAccessShortcut$),
       enableDuckDuckGoBrowserIntegration: await firstValueFrom(
         this.desktopAutofillSettingsService.enableDuckDuckGoBrowserIntegration$,
       ),
@@ -650,6 +656,38 @@ export class SettingsComponent implements OnInit, OnDestroy {
         type: "danger",
       });
     }
+  }
+
+  async saveQuickAccessEnabled() {
+    await this.desktopSettingsService.setQuickAccessEnabled(this.form.value.enableQuickAccess);
+    this.messagingService.send("quickAccessSetEnabled", {
+      enabled: this.form.value.enableQuickAccess,
+    });
+  }
+
+  async saveQuickAccessShortcut() {
+    const wasEnabled = this.form.value.enableQuickAccess;
+    if (wasEnabled) {
+      this.messagingService.send("quickAccessSetEnabled", { enabled: false });
+    }
+
+    const dialogRef = QuickAccessShortcutComponent.open(
+      this.dialogService,
+      this.form.value.quickAccessShortcut ?? DEFAULT_QUICK_ACCESS_SHORTCUT,
+    );
+    const shortcut = await firstValueFrom(dialogRef.closed);
+
+    if (wasEnabled) {
+      this.messagingService.send("quickAccessSetEnabled", { enabled: true });
+    }
+
+    if (!shortcut) {
+      return;
+    }
+
+    this.form.controls.quickAccessShortcut.setValue(shortcut);
+    await this.desktopSettingsService.setQuickAccessShortcut(shortcut);
+    this.messagingService.send("quickAccessSetShortcut", { shortcut });
   }
 
   async saveDdgBrowserIntegration() {

--- a/apps/desktop/src/app/app-routing.module.ts
+++ b/apps/desktop/src/app/app-routing.module.ts
@@ -55,6 +55,7 @@ import { Fido2VaultComponent } from "../autofill/modal/credentials/fido2-vault.c
 import { VaultWrapperComponent } from "../vault/app/vault-v3/vault-wrapper.component";
 
 import { DesktopLayoutComponent } from "./layout/desktop-layout.component";
+import { QuickAccessComponent } from "./quick-access/quick-access.component";
 import { unsavedSendEditsGuard } from "./tools/send/guards/unsaved-send-edits.guard";
 import { SendComponent } from "./tools/send/send.component";
 
@@ -128,6 +129,10 @@ const routes: Routes = [
   {
     path: "fido2-excluded",
     component: Fido2ExcludedCiphersComponent,
+  },
+  {
+    path: "quick-access",
+    component: QuickAccessComponent,
   },
   {
     path: "",

--- a/apps/desktop/src/app/app.component.ts
+++ b/apps/desktop/src/app/app.component.ts
@@ -11,8 +11,18 @@ import {
   ViewContainerRef,
 } from "@angular/core";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
-import { Router } from "@angular/router";
-import { filter, firstValueFrom, lastValueFrom, map, Subject, takeUntil, timeout } from "rxjs";
+import { NavigationEnd, Router } from "@angular/router";
+import {
+  combineLatest,
+  filter,
+  firstValueFrom,
+  lastValueFrom,
+  map,
+  startWith,
+  Subject,
+  takeUntil,
+  timeout,
+} from "rxjs";
 
 import { AccountDeletionService } from "@bitwarden/angular/auth/account-deletion/account-deletion.service";
 import { LoginApprovalDialogComponent } from "@bitwarden/angular/auth/login-approval";
@@ -53,6 +63,7 @@ import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.servic
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
+import { uuidAsString } from "@bitwarden/common/platform/abstractions/sdk/sdk.service";
 import { StateService } from "@bitwarden/common/platform/abstractions/state.service";
 import { SystemService } from "@bitwarden/common/platform/abstractions/system.service";
 import { ServerNotificationsService } from "@bitwarden/common/platform/server-notifications";
@@ -62,13 +73,20 @@ import { UserId } from "@bitwarden/common/types/guid";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { InternalFolderService } from "@bitwarden/common/vault/abstractions/folder/folder.service.abstraction";
 import { PremiumUpgradePromptService } from "@bitwarden/common/vault/abstractions/premium-upgrade-prompt.service";
+import { SearchService } from "@bitwarden/common/vault/abstractions/search.service";
 import { CipherType } from "@bitwarden/common/vault/enums";
+import { buildCipherIcon } from "@bitwarden/common/vault/icon/build-cipher-icon";
 import { RestrictedItemTypesService } from "@bitwarden/common/vault/services/restricted-item-types.service";
+import { CipherViewLikeUtils } from "@bitwarden/common/vault/utils/cipher-view-like-utils";
 import { DialogRef, DialogService, ToastOptions, ToastService } from "@bitwarden/components";
 import { CredentialGeneratorHistoryDialogComponent } from "@bitwarden/generator-components";
 import { KeyService, BiometricStateService } from "@bitwarden/key-management";
 import { TroubleshootingDialogComponent } from "@bitwarden/logging-angular";
-import { AddEditFolderDialogComponent, AddEditFolderDialogResult } from "@bitwarden/vault";
+import {
+  AddEditFolderDialogComponent,
+  AddEditFolderDialogResult,
+  CopyCipherFieldService,
+} from "@bitwarden/vault";
 
 import { DeviceManagementDialogComponent } from "../auth/device-management/device-management-dialog.component";
 import { ChangePasswordDialogComponent } from "../auth/password-management/change-password-dialog.component";
@@ -84,6 +102,9 @@ import { ImportDesktopComponent } from "./tools/import/import-desktop.component"
 const BroadcasterSubscriptionId = "AppComponent";
 const IdleTimeout = 60000 * 10; // 10 minutes
 const SyncInterval = 6 * 60 * 60 * 1000; // 6 hours
+const QuickAccessMaxResults = 6;
+
+type QuickAccessCopyAction = "username" | "password";
 
 // FIXME(https://bitwarden.atlassian.net/browse/CL-764): Migrate to OnPush
 // eslint-disable-next-line @angular-eslint/prefer-on-push-component-change-detection
@@ -119,7 +140,14 @@ export class AppComponent implements OnInit, OnDestroy {
   @ViewChild("loginApproval", { read: ViewContainerRef, static: true })
   loginApprovalModalRef: ViewContainerRef;
 
-  showHeader$ = this.accountService.showHeader$;
+  showHeader$ = combineLatest([
+    this.accountService.showHeader$,
+    this.router.events.pipe(
+      filter((event): event is NavigationEnd => event instanceof NavigationEnd),
+      startWith(null),
+      map(() => !this.router.url.includes("/quick-access")),
+    ),
+  ]).pipe(map(([showHeader, showForRoute]) => showHeader && showForRoute));
   loading = false;
 
   private lastActivity: Date = null;
@@ -140,6 +168,8 @@ export class AppComponent implements OnInit, OnDestroy {
     private folderService: InternalFolderService,
     private syncService: SyncService,
     private cipherService: CipherService,
+    private searchService: SearchService,
+    private copyCipherFieldService: CopyCipherFieldService,
     private authService: AuthService,
     private router: Router,
     private toastService: ToastService,
@@ -231,9 +261,9 @@ export class AppComponent implements OnInit, OnDestroy {
             await this.processReloadService.startProcessReload();
             break;
           case "authBlocked":
-            // FIXME: Verify that this floating promise is intentional. If it is, add an explanatory comment and ensure there is proper error handling.
-            // eslint-disable-next-line @typescript-eslint/no-floating-promises
-            this.router.navigate(["login"]);
+            if (!this.isQuickAccessRoute()) {
+              void this.router.navigate(["login"]);
+            }
             break;
           case "logout":
             this.loading = message.userId == null || message.userId === this.activeUserId;
@@ -250,9 +280,12 @@ export class AppComponent implements OnInit, OnDestroy {
           case "locked":
             this.modalService.closeAll();
             if (
-              message.userId == null ||
-              message.userId ===
-                (await firstValueFrom(this.accountService.activeAccount$.pipe(map((a) => a?.id))))
+              !this.isQuickAccessRoute() &&
+              (message.userId == null ||
+                message.userId ===
+                  (await firstValueFrom(
+                    this.accountService.activeAccount$.pipe(map((a) => a?.id)),
+                  )))
             ) {
               await this.router.navigate(["lock"]);
             }
@@ -324,6 +357,35 @@ export class AppComponent implements OnInit, OnDestroy {
             break;
           case "showToast":
             this.toastService._showToast(message);
+            break;
+          case "quickAccessOpenApp":
+            await this.router.navigate(message.route ?? ["/vault"]);
+            break;
+          case "quickAccessOpenCipher":
+            if (message.cipherId != null) {
+              if (this.router.url.includes("/vault")) {
+                break;
+              }
+
+              await this.router.navigate(["/vault"], {
+                queryParams: {
+                  action: "view",
+                  cipherId: message.cipherId,
+                  search: message.searchText || null,
+                },
+                replaceUrl: true,
+              });
+            }
+            break;
+          case "quickAccessSearchRequest":
+            await this.handleQuickAccessSearchRequest(message.requestId, message.query);
+            break;
+          case "quickAccessCopyRequest":
+            await this.handleQuickAccessCopyRequest(
+              message.requestId,
+              message.cipherId,
+              message.action,
+            );
             break;
           case "copiedToClipboard":
             if (!message.clearing) {
@@ -626,6 +688,13 @@ export class AppComponent implements OnInit, OnDestroy {
     this.messagingService.send("updateAppMenu", { updateRequest: updateRequest });
   }
 
+  private isQuickAccessRoute() {
+    return (
+      this.router.url.includes("/quick-access") ||
+      globalThis.location?.href?.includes("redirectUrl=%2Fquick-access")
+    );
+  }
+
   private async displayLogoutReason(logoutReason: LogoutReason) {
     let toastOptions: ToastOptions;
 
@@ -908,6 +977,139 @@ export class AppComponent implements OnInit, OnDestroy {
 
   private async deleteAccount() {
     await this.accountDeletionService.openDeleteAccountFlow();
+  }
+
+  private async handleQuickAccessSearchRequest(requestId: string, query: string) {
+    const activeUserId =
+      this.activeUserId ?? (await firstValueFrom(getUserId(this.accountService.activeAccount$)));
+
+    if (activeUserId == null) {
+      this.messagingService.send("quickAccessSearchResponse", {
+        requestId,
+        authStatus: AuthenticationStatus.LoggedOut,
+        results: [],
+      });
+      return;
+    }
+
+    const authStatus = await this.authService.getAuthStatus(activeUserId);
+    if (authStatus !== AuthenticationStatus.Unlocked) {
+      this.messagingService.send("quickAccessSearchResponse", {
+        requestId,
+        authStatus,
+        results: [],
+      });
+      return;
+    }
+
+    const searchText = (query ?? "").trim();
+    if (searchText === "") {
+      this.messagingService.send("quickAccessSearchResponse", {
+        requestId,
+        authStatus,
+        results: [],
+      });
+      return;
+    }
+
+    const [ciphers, failedCiphers, restrictedTypes] = await Promise.all([
+      firstValueFrom(
+        this.cipherService.cipherListViews$(activeUserId).pipe(filter((c) => c != null)),
+      ),
+      firstValueFrom(this.cipherService.failedToDecryptCiphers$(activeUserId)),
+      firstValueFrom(this.restrictedItemTypesService.restricted$),
+    ]);
+    const allowedCiphers = [...(failedCiphers ?? []), ...(ciphers ?? [])].filter(
+      (cipher) =>
+        !CipherViewLikeUtils.isDeleted(cipher) &&
+        !CipherViewLikeUtils.isArchived(cipher) &&
+        !this.restrictedItemTypesService.isCipherRestricted(cipher, restrictedTypes),
+    );
+    const results = (await this.searchService.isSearchable(searchText))
+      ? await this.searchService.searchCiphers(activeUserId, null, searchText, allowedCiphers)
+      : allowedCiphers;
+
+    this.messagingService.send("quickAccessSearchResponse", {
+      requestId,
+      authStatus,
+      results: results
+        .filter((cipher) => cipher.id != null)
+        .slice(0, QuickAccessMaxResults)
+        .map((cipher) => ({
+          cipherId: uuidAsString(cipher.id),
+          name: cipher.name ?? "",
+          subtitle: CipherViewLikeUtils.subtitle(cipher) || CipherViewLikeUtils.uri(cipher) || "",
+          typeIcon: buildCipherIcon(null, cipher, false).icon,
+          typeI18nKey: this.quickAccessTypeI18nKey(CipherViewLikeUtils.getType(cipher)),
+          canCopyUsername: CipherViewLikeUtils.hasCopyableValue(cipher, "username"),
+          canCopyPassword: CipherViewLikeUtils.hasCopyableValue(cipher, "password"),
+        })),
+    });
+  }
+
+  private async handleQuickAccessCopyRequest(
+    requestId: string,
+    cipherId: string,
+    action: QuickAccessCopyAction,
+  ) {
+    const activeUserId =
+      this.activeUserId ?? (await firstValueFrom(getUserId(this.accountService.activeAccount$)));
+    let copied = false;
+
+    try {
+      if (
+        activeUserId != null &&
+        cipherId != null &&
+        this.isQuickAccessCopyAction(action) &&
+        (await this.authService.getAuthStatus(activeUserId)) === AuthenticationStatus.Unlocked
+      ) {
+        const encryptedCipher = await this.cipherService.get(cipherId, activeUserId);
+        const cipher = await this.cipherService.decrypt(encryptedCipher, activeUserId);
+        const value =
+          action === "username"
+            ? cipher.login?.username || cipher.identity?.username
+            : cipher.login?.password;
+
+        if (value != null && value !== "") {
+          copied = await this.copyCipherFieldService.copy(value, action, cipher);
+        }
+      }
+    } catch (error) {
+      this.logService.error("[AppComponent] Failed to copy Quick Access field", error);
+    }
+
+    this.messagingService.send("quickAccessCopyResponse", {
+      requestId,
+      copied,
+      action,
+    });
+  }
+
+  private isQuickAccessCopyAction(action: string): action is QuickAccessCopyAction {
+    return action === "username" || action === "password";
+  }
+
+  private quickAccessTypeI18nKey(cipherType: CipherType) {
+    switch (cipherType) {
+      case CipherType.Login:
+        return "typeLogin";
+      case CipherType.SecureNote:
+        return "typeSecureNote";
+      case CipherType.Card:
+        return "typeCard";
+      case CipherType.Identity:
+        return "typeIdentity";
+      case CipherType.SshKey:
+        return "typeSshKey";
+      case CipherType.BankAccount:
+        return "bankAccount";
+      case CipherType.DriversLicense:
+        return "typeDriversLicense";
+      case CipherType.Passport:
+        return "typePassport";
+      default:
+        return "item";
+    }
   }
 
   private async processPendingAuthRequests() {

--- a/apps/desktop/src/app/quick-access/quick-access-shortcut.component.html
+++ b/apps/desktop/src/app/quick-access/quick-access-shortcut.component.html
@@ -1,0 +1,31 @@
+<form [bitSubmit]="submit" [formGroup]="setShortcutForm" bit-dialog>
+  <div class="tw-font-medium" bitDialogTitle>
+    {{ "quickAccessShortcut" | i18n }}
+  </div>
+  <div bitDialogContent>
+    <p>
+      {{ "editQuickAccessKeyboardModifiersDescription" | i18n }}
+    </p>
+    <bit-form-field>
+      <bit-label>{{ "typeShortcut" | i18n }}</bit-label>
+      <input
+        class="tw-font-mono"
+        bitInput
+        type="text"
+        formControlName="shortcut"
+        (keydown)="onShortcutKeydown($event)"
+        autocomplete="off"
+        autocorrect="off"
+        autocapitalize="off"
+      />
+    </bit-form-field>
+  </div>
+  <ng-container bitDialogFooter>
+    <button type="submit" bitButton bitFormButton buttonType="primary">
+      <span>{{ "save" | i18n }}</span>
+    </button>
+    <button type="button" bitButton bitFormButton buttonType="secondary" bitDialogClose>
+      {{ "cancel" | i18n }}
+    </button>
+  </ng-container>
+</form>

--- a/apps/desktop/src/app/quick-access/quick-access-shortcut.component.ts
+++ b/apps/desktop/src/app/quick-access/quick-access-shortcut.component.ts
@@ -1,0 +1,151 @@
+import { CommonModule } from "@angular/common";
+import { Component, Inject } from "@angular/core";
+import {
+  AbstractControl,
+  FormBuilder,
+  ReactiveFormsModule,
+  ValidationErrors,
+  ValidatorFn,
+  Validators,
+} from "@angular/forms";
+
+import { Utils } from "@bitwarden/common/platform/misc/utils";
+import {
+  AsyncActionsModule,
+  ButtonModule,
+  DIALOG_DATA,
+  DialogModule,
+  DialogRef,
+  DialogService,
+  FormFieldModule,
+  IconButtonModule,
+} from "@bitwarden/components";
+import { I18nPipe } from "@bitwarden/ui-common";
+
+import {
+  DEFAULT_QUICK_ACCESS_SHORTCUT,
+  isQuickAccessShortcutValid,
+} from "../../platform/models/domain/quick-access-shortcut";
+
+type QuickAccessShortcutDialogData = {
+  currentShortcut?: string | null;
+};
+
+// FIXME(https://bitwarden.atlassian.net/browse/CL-764): Migrate to OnPush
+// eslint-disable-next-line @angular-eslint/prefer-on-push-component-change-detection
+@Component({
+  templateUrl: "quick-access-shortcut.component.html",
+  imports: [
+    AsyncActionsModule,
+    ButtonModule,
+    CommonModule,
+    DialogModule,
+    FormFieldModule,
+    IconButtonModule,
+    I18nPipe,
+    ReactiveFormsModule,
+  ],
+})
+export class QuickAccessShortcutComponent {
+  constructor(
+    @Inject(DIALOG_DATA) private data: QuickAccessShortcutDialogData,
+    private dialogRef: DialogRef<string>,
+    private formBuilder: FormBuilder,
+  ) {
+    this.shortcut = this.data.currentShortcut ?? DEFAULT_QUICK_ACCESS_SHORTCUT;
+  }
+
+  private shortcut = DEFAULT_QUICK_ACCESS_SHORTCUT;
+
+  setShortcutForm = this.formBuilder.group({
+    shortcut: [
+      this.data.currentShortcut ?? DEFAULT_QUICK_ACCESS_SHORTCUT,
+      [Validators.required, this.shortcutCombinationValidator()],
+    ],
+  });
+
+  submit = async () => {
+    const shortcutFormControl = this.setShortcutForm.controls.shortcut;
+
+    if (Utils.isNullOrWhitespace(shortcutFormControl.value) || shortcutFormControl.invalid) {
+      return;
+    }
+
+    await this.dialogRef.close(shortcutFormControl.value);
+  };
+
+  static open(dialogService: DialogService, currentShortcut?: string | null) {
+    return dialogService.open<string, QuickAccessShortcutDialogData>(QuickAccessShortcutComponent, {
+      data: {
+        currentShortcut,
+      },
+    });
+  }
+
+  onShortcutKeydown(event: KeyboardEvent): void {
+    event.preventDefault();
+
+    const shortcut = this.buildShortcutFromEvent(event);
+    if (shortcut == null) {
+      return;
+    }
+
+    this.shortcut = shortcut;
+    this.setShortcutForm.controls.shortcut.setValue(shortcut);
+    this.setShortcutForm.controls.shortcut.markAsDirty();
+    this.setShortcutForm.controls.shortcut.updateValueAndValidity();
+  }
+
+  private buildShortcutFromEvent(event: KeyboardEvent): string | null {
+    const key = event.key;
+    if (key === "Control" || key === "Alt" || key === "Meta" || key === "Shift") {
+      return null;
+    }
+
+    const baseKey = this.getBaseKey(key);
+    if (baseKey == null) {
+      return null;
+    }
+
+    const parts: string[] = [];
+    if (event.ctrlKey) {
+      parts.push("Control");
+    }
+    if (event.altKey) {
+      parts.push("Alt");
+    }
+    if (event.metaKey) {
+      parts.push("CommandOrControl");
+    }
+    if (event.shiftKey) {
+      parts.push("Shift");
+    }
+    parts.push(baseKey);
+
+    const shortcut = parts.join("+");
+    return isQuickAccessShortcutValid(shortcut) ? shortcut : null;
+  }
+
+  private getBaseKey(key: string) {
+    if (key === " " || key === "Spacebar") {
+      return "Space";
+    }
+
+    if (/^[a-z]$/i.test(key)) {
+      return key.toUpperCase();
+    }
+
+    return null;
+  }
+
+  private shortcutCombinationValidator(): ValidatorFn {
+    return (control: AbstractControl): ValidationErrors | null => {
+      const value = (control.value ?? "").toString();
+      if (value.length === 0) {
+        return null;
+      }
+
+      return isQuickAccessShortcutValid(value) ? null : { invalidShortcut: true };
+    };
+  }
+}

--- a/apps/desktop/src/app/quick-access/quick-access.component.html
+++ b/apps/desktop/src/app/quick-access/quick-access.component.html
@@ -1,0 +1,143 @@
+<main
+  role="dialog"
+  aria-modal="true"
+  [attr.aria-label]="'searchVault' | i18n"
+  class="qa-shell"
+  cdkTrapFocus
+  cdkTrapFocusAutoCapture
+  (keydown)="handleKeydown($event)"
+>
+  <section class="qa-card tw-app-region-drag">
+    <header class="qa-top" *ngIf="authStatus === AuthenticationStatus.Unlocked">
+      <div class="qa-search tw-app-region-no-drag">
+        <i class="bwi bwi-search qa-search-icon" aria-hidden="true"></i>
+        <input
+          class="qa-search-input"
+          [(ngModel)]="searchText"
+          (ngModelChange)="search($event)"
+          [placeholder]="'searchVault' | i18n"
+          autocomplete="off"
+          spellcheck="false"
+        />
+        <button
+          *ngIf="searchText !== ''"
+          class="qa-clear"
+          type="button"
+          [attr.aria-label]="'clear' | i18n"
+          [attr.title]="'clear' | i18n"
+          (click)="clearSearch()"
+        >
+          <i class="bwi bwi-close" aria-hidden="true"></i>
+        </button>
+      </div>
+    </header>
+
+    <section class="qa-body tw-app-region-no-drag">
+      <ng-container [ngSwitch]="authStatus">
+        <ng-container *ngSwitchCase="AuthenticationStatus.Unlocked">
+          <div class="qa-results" *ngIf="currentResults.length > 0">
+            <button
+              *ngFor="let result of currentResults; let i = index; trackBy: trackByCipher"
+              class="qa-row"
+              type="button"
+              [class.is-selected]="i === selectedIndex"
+              (mouseenter)="selectedIndex = i"
+              (click)="openSelected()"
+            >
+              <span
+                class="qa-icon"
+                [attr.aria-label]="result.typeI18nKey | i18n"
+                [attr.title]="result.typeI18nKey | i18n"
+              >
+                <i class="bwi" [ngClass]="result.typeIcon" aria-hidden="true"></i>
+              </span>
+              <span class="tw-min-w-0">
+                <span class="qa-title">{{ result.name }}</span>
+                <span class="qa-subtitle">{{ result.subtitle }}</span>
+              </span>
+              <i
+                class="bwi bwi-angle-right qa-hint"
+                [attr.title]="'view' | i18n"
+                aria-hidden="true"
+              ></i>
+            </button>
+          </div>
+        </ng-container>
+
+        <ng-container *ngSwitchCase="AuthenticationStatus.Locked">
+          <div class="qa-panel">
+            <div class="qa-unlock-form">
+              <div class="qa-panel-title">{{ "yourVaultIsLockedV2" | i18n }}</div>
+              <div class="qa-panel-copy">
+                {{ "quickAccessLockedDescription" | i18n }}
+              </div>
+              <div class="qa-unlock-actions">
+                <button class="qa-primary" type="button" (click)="openUnlock()">
+                  {{ "unlock" | i18n }}
+                </button>
+              </div>
+            </div>
+          </div>
+        </ng-container>
+
+        <ng-container *ngSwitchDefault>
+          <div class="qa-panel">
+            <div>
+              <div class="qa-panel-title">{{ "logInToBitwarden" | i18n }}</div>
+              <div class="qa-panel-copy">{{ "quickAccessLoggedOutDescription" | i18n }}</div>
+              <button class="qa-secondary" type="button" (click)="openSignIn()">
+                {{ "logIn" | i18n }}
+              </button>
+            </div>
+          </div>
+        </ng-container>
+      </ng-container>
+
+      <ng-template #noResults>
+        <div class="qa-panel">
+          <div>
+            <div class="qa-panel-title">
+              {{ isSearching ? ("loading" | i18n) : ("noSearchResults" | i18n) }}
+            </div>
+            <div class="qa-panel-copy">{{ "quickAccessNoResultsDescription" | i18n }}</div>
+          </div>
+        </div>
+      </ng-template>
+    </section>
+
+    <footer
+      class="qa-footer tw-app-region-no-drag"
+      *ngIf="authStatus === AuthenticationStatus.Unlocked && currentResults.length > 0"
+    >
+      <button
+        class="qa-action"
+        type="button"
+        [disabled]="selectedResult == null || !selectedResult.canCopyUsername"
+        (click)="copySelected('username', $event)"
+      >
+        <span class="qa-key">Cmd U</span>
+        <span>{{ "copyUsername" | i18n }}</span>
+      </button>
+      <button
+        class="qa-action"
+        type="button"
+        [disabled]="selectedResult == null || !selectedResult.canCopyPassword"
+        (click)="copySelected('password', $event)"
+      >
+        <span class="qa-key">Cmd P</span>
+        <span>{{ "copyPassword" | i18n }}</span>
+      </button>
+      <button
+        class="qa-action"
+        type="button"
+        [disabled]="selectedResult == null"
+        (click)="openSelected()"
+      >
+        <span class="qa-key">Enter</span>
+        <span>{{ "view" | i18n }}</span>
+      </button>
+    </footer>
+
+    <div class="qa-status" *ngIf="statusMessageKey !== ''">{{ statusMessageKey | i18n }}</div>
+  </section>
+</main>

--- a/apps/desktop/src/app/quick-access/quick-access.component.ts
+++ b/apps/desktop/src/app/quick-access/quick-access.component.ts
@@ -1,0 +1,660 @@
+// FIXME: Update this file to be type safe and remove this and next line
+// @ts-strict-ignore
+/* eslint-disable @bitwarden/components/enforce-readonly-angular-properties */
+import { A11yModule } from "@angular/cdk/a11y";
+import { CommonModule } from "@angular/common";
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  ElementRef,
+  NgZone,
+  OnDestroy,
+  OnInit,
+} from "@angular/core";
+import { FormsModule } from "@angular/forms";
+import { Subject, debounceTime, distinctUntilChanged, takeUntil } from "rxjs";
+
+import { AuthenticationStatus } from "@bitwarden/common/auth/enums/authentication-status";
+import { BroadcasterService } from "@bitwarden/common/platform/abstractions/broadcaster.service";
+import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
+import { SearchTextDebounceInterval } from "@bitwarden/common/vault/services/search.service";
+import { I18nPipe } from "@bitwarden/ui-common";
+
+const BroadcasterSubscriptionId = "QuickAccessComponent";
+
+type QuickAccessCopyAction = "username" | "password";
+
+type QuickAccessResult = {
+  cipherId: string;
+  name: string;
+  subtitle: string;
+  typeIcon: string;
+  typeI18nKey: string;
+  canCopyUsername: boolean;
+  canCopyPassword: boolean;
+};
+
+const SearchOnlyHeight = 64;
+const ResultRowHeight = 54;
+const ResultsPaddingHeight = 12;
+const FooterHeight = 40;
+const PanelHeight = 190;
+
+@Component({
+  selector: "app-quick-access",
+  templateUrl: "quick-access.component.html",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [A11yModule, CommonModule, FormsModule, I18nPipe],
+  styles: [
+    `
+      :host {
+        display: block;
+        height: 100vh;
+        color: #f8fafc;
+        font-family: Inter, "Helvetica Neue", Helvetica, Arial, sans-serif;
+      }
+
+      :host * {
+        box-sizing: border-box;
+      }
+
+      .qa-shell {
+        height: 100vh;
+        padding: 0;
+        background: transparent;
+      }
+
+      .qa-card {
+        display: grid;
+        height: 100vh;
+        grid-template-rows: auto minmax(0, 1fr) auto;
+        overflow: hidden;
+        border: 1px solid rgba(219, 229, 246, 0.52);
+        border-radius: 8px;
+        background: #175ddc;
+        background: rgb(var(--color-primary-600));
+        box-shadow:
+          0 12px 32px rgba(23, 93, 220, 0.3),
+          0 2px 8px rgba(16, 24, 40, 0.16);
+      }
+
+      .qa-top {
+        padding: 8px;
+      }
+
+      .qa-search {
+        display: flex;
+        height: 46px;
+        align-items: center;
+        gap: 9px;
+        border: 1px solid rgb(var(--color-primary-600));
+        border-radius: 8px;
+        background: #ffffff;
+        padding: 0 12px;
+        box-shadow:
+          0 0 0 2px rgba(219, 229, 246, 0.52),
+          inset 0 0 0 1px rgba(15, 23, 42, 0.04);
+      }
+
+      .qa-search-icon {
+        color: #1268dc;
+        font-size: 16px;
+      }
+
+      .qa-search input {
+        min-width: 0;
+        flex: 1;
+        border: 0;
+        outline: 0;
+        background: transparent;
+        color: #111827;
+        font-size: 16px;
+        font-weight: 500;
+        letter-spacing: 0;
+        line-height: 1.2;
+      }
+
+      .qa-search input::placeholder {
+        color: #667085;
+        font-weight: 400;
+      }
+
+      .qa-clear {
+        display: grid;
+        width: 24px;
+        height: 24px;
+        flex: 0 0 auto;
+        place-items: center;
+        border: 0;
+        border-radius: 999px;
+        background: transparent;
+        color: #667085;
+        font-size: 14px;
+      }
+
+      .qa-clear:hover {
+        background: #eef2f7;
+        color: #344054;
+      }
+
+      .qa-body {
+        min-height: 0;
+        padding: 0 8px 8px;
+      }
+
+      .qa-results {
+        height: 100%;
+        overflow: hidden auto;
+        padding: 2px 0;
+      }
+
+      .qa-row {
+        display: grid;
+        width: 100%;
+        min-height: 52px;
+        grid-template-columns: 32px minmax(0, 1fr) 24px;
+        align-items: center;
+        gap: 10px;
+        border: 1px solid transparent;
+        border-radius: 8px;
+        background: transparent;
+        padding: 7px 10px;
+        color: #f3f4f6;
+        text-align: left;
+      }
+
+      .qa-row:hover {
+        background: rgba(255, 255, 255, 0.07);
+      }
+
+      .qa-row.is-selected {
+        border-color: rgba(23, 93, 220, 0.45);
+        background: rgba(23, 93, 220, 0.18);
+        color: #ffffff;
+      }
+
+      .qa-icon {
+        display: grid;
+        width: 28px;
+        height: 28px;
+        place-items: center;
+        border-radius: 6px;
+        background: rgba(255, 255, 255, 0.08);
+        color: #9bbcff;
+        font-size: 15px;
+      }
+
+      .qa-row.is-selected .qa-icon {
+        background: rgba(255, 255, 255, 0.16);
+        color: #ffffff;
+      }
+
+      .qa-title,
+      .qa-subtitle {
+        display: block;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      .qa-title {
+        font-size: 14px;
+        font-weight: 600;
+      }
+
+      .qa-subtitle {
+        margin-top: 1px;
+        color: #b6c0cf;
+        font-size: 12px;
+      }
+
+      .qa-row.is-selected .qa-subtitle {
+        color: #c6d8ff;
+      }
+
+      .qa-hint {
+        color: #9ca3af;
+        font-size: 14px;
+      }
+
+      .qa-row.is-selected .qa-hint {
+        color: #ffffff;
+      }
+
+      .qa-panel {
+        display: grid;
+        min-height: 220px;
+        place-items: center;
+        padding: 24px;
+        text-align: center;
+      }
+
+      .qa-panel-title {
+        margin-bottom: 8px;
+        color: #ffffff;
+        font-size: 17px;
+        font-weight: 700;
+      }
+
+      .qa-panel-copy {
+        max-width: 460px;
+        margin: 0 auto 18px;
+        color: #a8b0bf;
+        font-size: 13px;
+        line-height: 1.5;
+      }
+
+      .qa-unlock-form {
+        width: min(420px, 100%);
+      }
+
+      .qa-password {
+        width: 100%;
+        height: 40px;
+        border: 1px solid rgba(148, 163, 184, 0.35);
+        border-radius: 8px;
+        background: rgba(255, 255, 255, 0.1);
+        color: #ffffff;
+        padding: 0 12px;
+        font-size: 14px;
+        outline: 0;
+      }
+
+      .qa-password:focus {
+        border-color: rgba(85, 158, 255, 0.9);
+        box-shadow: 0 0 0 4px rgba(83, 154, 255, 0.16);
+      }
+
+      .qa-row:focus-visible,
+      .qa-clear:focus-visible,
+      .qa-action:focus-visible,
+      .qa-primary:focus-visible,
+      .qa-secondary:focus-visible {
+        outline: 2px solid rgba(85, 158, 255, 0.92);
+        outline-offset: 2px;
+      }
+
+      .qa-unlock-actions {
+        display: flex;
+        margin-top: 12px;
+        gap: 10px;
+      }
+
+      .qa-primary,
+      .qa-secondary {
+        height: 36px;
+        border: 0;
+        border-radius: 8px;
+        padding: 0 14px;
+        font-size: 13px;
+        font-weight: 700;
+      }
+
+      .qa-primary {
+        flex: 1;
+        background: #1268dc;
+        color: #ffffff;
+      }
+
+      .qa-primary:disabled {
+        background: #41506a;
+        color: #a8b0bf;
+      }
+
+      .qa-secondary {
+        background: rgba(255, 255, 255, 0.1);
+        color: #dbeafe;
+      }
+
+      .qa-error {
+        margin-top: 10px;
+        color: #fca5a5;
+        font-size: 13px;
+        font-weight: 700;
+      }
+
+      .qa-footer {
+        display: flex;
+        box-sizing: border-box;
+        height: 40px;
+        align-items: center;
+        justify-content: center;
+        gap: 22px;
+        border-top: 1px solid rgba(255, 255, 255, 0.08);
+        background: rgba(255, 255, 255, 0.04);
+        padding: 6px 16px;
+      }
+
+      .qa-action {
+        display: flex;
+        min-height: 30px;
+        align-items: center;
+        justify-content: center;
+        gap: 6px;
+        border: 0;
+        border-radius: 6px;
+        background: transparent;
+        color: #cbd5e1;
+        font-size: 12px;
+        font-weight: 600;
+      }
+
+      .qa-action:hover:not(:disabled) {
+        color: #ffffff;
+      }
+
+      .qa-action:disabled {
+        color: rgba(255, 255, 255, 0.4);
+      }
+
+      .qa-key {
+        display: inline-flex;
+        min-width: 24px;
+        height: 22px;
+        align-items: center;
+        justify-content: center;
+        border: 1px solid rgba(203, 213, 225, 0.28);
+        border-radius: 4px;
+        background: rgba(255, 255, 255, 0.08);
+        color: inherit;
+        padding: 0 7px;
+        font-size: 11px;
+      }
+
+      .qa-status {
+        position: fixed;
+        left: 50%;
+        bottom: 48px;
+        transform: translateX(-50%);
+        border-radius: 999px;
+        background: rgba(15, 23, 42, 0.92);
+        color: #ffffff;
+        padding: 6px 12px;
+        font-size: 12px;
+        font-weight: 700;
+        box-shadow: 0 12px 32px rgba(0, 0, 0, 0.24);
+      }
+    `,
+  ],
+})
+export class QuickAccessComponent implements OnInit, OnDestroy {
+  protected readonly AuthenticationStatus = AuthenticationStatus;
+  protected authStatus: AuthenticationStatus | null = null;
+  protected currentResults: QuickAccessResult[] = [];
+  protected isSearching = false;
+  protected searchText = "";
+  protected selectedIndex = 0;
+  protected statusMessageKey = "";
+
+  private activeRequestId = "";
+  private activeCopyRequestId = "";
+  private requestSequence = 0;
+  private readonly destroy$ = new Subject<void>();
+  private readonly searchText$ = new Subject<string>();
+
+  constructor(
+    private broadcasterService: BroadcasterService,
+    private changeDetectorRef: ChangeDetectorRef,
+    private elementRef: ElementRef<HTMLElement>,
+    private messagingService: MessagingService,
+    private ngZone: NgZone,
+  ) {}
+
+  ngOnInit() {
+    this.searchText$
+      .pipe(
+        debounceTime(SearchTextDebounceInterval),
+        distinctUntilChanged(),
+        takeUntil(this.destroy$),
+      )
+      .subscribe((query) => this.requestSearch(query));
+
+    this.broadcasterService.subscribe(BroadcasterSubscriptionId, (message: any) => {
+      if (message.command === "quickAccessShown") {
+        this.resetSearch();
+        return;
+      }
+
+      if (message.command === "quickAccessSearchResponse") {
+        this.handleSearchResponse(message);
+        return;
+      }
+
+      if (message.command === "quickAccessCopyResponse") {
+        this.handleCopyResponse(message);
+      }
+    });
+
+    this.resetSearch();
+  }
+
+  ngOnDestroy() {
+    this.destroy$.next();
+    this.destroy$.complete();
+    this.broadcasterService.unsubscribe(BroadcasterSubscriptionId);
+  }
+
+  protected get selectedResult() {
+    return this.currentResults[this.selectedIndex] ?? null;
+  }
+
+  protected search(searchText: string) {
+    this.searchText = searchText ?? "";
+    this.statusMessageKey = "";
+    this.searchText$.next(this.searchText);
+  }
+
+  protected clearSearch() {
+    this.search("");
+    this.focusSearchSoon();
+  }
+
+  protected close() {
+    this.clearLocalState();
+    this.messagingService.send("quickAccessHide");
+  }
+
+  protected openSignIn() {
+    this.messagingService.send("quickAccessOpenApp", {
+      route: ["/login"],
+    });
+  }
+
+  protected openUnlock() {
+    this.messagingService.send("quickAccessOpenApp", {
+      route: ["/lock"],
+    });
+  }
+
+  protected openSelected() {
+    const result = this.selectedResult;
+    if (result == null) {
+      return;
+    }
+
+    this.messagingService.send("quickAccessOpenCipher", {
+      cipherId: result.cipherId,
+      searchText: this.searchText.trim(),
+    });
+  }
+
+  protected copySelected(action: QuickAccessCopyAction, event?: MouseEvent) {
+    event?.stopPropagation();
+
+    const result = this.selectedResult;
+    if (result == null || !this.isQuickAccessCopyAction(action)) {
+      return;
+    }
+
+    const requestId = `quick-access-copy-${Date.now()}-${++this.requestSequence}`;
+    this.activeCopyRequestId = requestId;
+    this.messagingService.send("quickAccessCopyRequest", {
+      requestId,
+      cipherId: result.cipherId,
+      action,
+    });
+    this.changeDetectorRef.markForCheck();
+  }
+
+  protected handleKeydown(event: KeyboardEvent) {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      this.close();
+      return;
+    }
+
+    if (this.authStatus !== AuthenticationStatus.Unlocked) {
+      return;
+    }
+
+    if (event.metaKey || event.ctrlKey) {
+      const key = event.key.toLowerCase();
+
+      if (key === "u") {
+        event.preventDefault();
+        void this.copySelected("username");
+        return;
+      }
+
+      if (key === "p") {
+        event.preventDefault();
+        void this.copySelected("password");
+        return;
+      }
+    }
+
+    if (this.currentResults.length === 0) {
+      return;
+    }
+
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      this.selectedIndex = Math.min(this.selectedIndex + 1, this.currentResults.length - 1);
+      this.changeDetectorRef.markForCheck();
+      return;
+    }
+
+    if (event.key === "ArrowUp") {
+      event.preventDefault();
+      this.selectedIndex = Math.max(this.selectedIndex - 1, 0);
+      this.changeDetectorRef.markForCheck();
+      return;
+    }
+
+    if (event.key === "Enter") {
+      event.preventDefault();
+      this.openSelected();
+    }
+  }
+
+  protected trackByCipher(_index: number, result: QuickAccessResult) {
+    return result.cipherId;
+  }
+
+  private resetSearch() {
+    this.clearLocalState();
+    this.requestSearch("");
+    this.focusSearchSoon();
+  }
+
+  private clearLocalState() {
+    this.searchText = "";
+    this.currentResults = [];
+    this.selectedIndex = 0;
+    this.statusMessageKey = "";
+    this.changeDetectorRef.markForCheck();
+    this.requestResize();
+  }
+
+  private requestSearch(query: string) {
+    const requestId = `quick-access-${Date.now()}-${++this.requestSequence}`;
+    this.activeRequestId = requestId;
+    this.isSearching = true;
+    this.changeDetectorRef.markForCheck();
+    this.requestResize();
+
+    this.messagingService.send("quickAccessSearchRequest", {
+      requestId,
+      query: query ?? "",
+    });
+  }
+
+  private handleSearchResponse(message: {
+    requestId: string;
+    authStatus: AuthenticationStatus;
+    results?: QuickAccessResult[];
+  }) {
+    if (message.requestId !== this.activeRequestId) {
+      return;
+    }
+
+    this.authStatus = message.authStatus;
+    this.currentResults = message.results ?? [];
+    this.selectedIndex = 0;
+    this.isSearching = false;
+    this.changeDetectorRef.markForCheck();
+    this.focusSearchSoon();
+    this.requestResize();
+  }
+
+  private handleCopyResponse(message: {
+    requestId: string;
+    copied: boolean;
+    action: QuickAccessCopyAction;
+  }) {
+    if (message.requestId !== this.activeCopyRequestId) {
+      return;
+    }
+
+    this.statusMessageKey = message.copied
+      ? message.action === "username"
+        ? "usernameCopied"
+        : "passwordCopied"
+      : "";
+    this.changeDetectorRef.markForCheck();
+  }
+
+  private requestResize() {
+    const height = this.calculateHeight();
+
+    this.ngZone.runOutsideAngular(() => {
+      setTimeout(() => {
+        this.messagingService.send("quickAccessResize", { height });
+      });
+    });
+  }
+
+  private calculateHeight() {
+    if (this.authStatus == null) {
+      return SearchOnlyHeight;
+    }
+
+    if (this.authStatus !== AuthenticationStatus.Unlocked) {
+      return PanelHeight;
+    }
+
+    if (this.currentResults.length === 0) {
+      return SearchOnlyHeight;
+    }
+
+    return (
+      SearchOnlyHeight +
+      ResultsPaddingHeight +
+      this.currentResults.length * ResultRowHeight +
+      FooterHeight
+    );
+  }
+
+  private isQuickAccessCopyAction(action: string): action is QuickAccessCopyAction {
+    return action === "username" || action === "password";
+  }
+
+  private focusSearchSoon() {
+    this.ngZone.runOutsideAngular(() => {
+      setTimeout(() =>
+        this.elementRef.nativeElement.querySelector<HTMLInputElement>(".qa-search-input")?.focus(),
+      );
+    });
+  }
+}

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -4769,6 +4769,33 @@
   "enableAutotypeShortcutDescription": {
     "message": "Be sure you are in the correct field before using the shortcut to avoid filling data into the wrong place."
   },
+  "quickAccessShortcut": {
+    "message": "Quick Access shortcut"
+  },
+  "enableQuickAccessShortcutPreview": {
+    "message": "Enable Quick Access"
+  },
+  "enableQuickAccessShortcutDescription": {
+    "message": "Open a standalone vault search window without switching to the main Bitwarden window."
+  },
+  "editQuickAccessKeyboardModifiersDescription": {
+    "message": "Press a shortcut with Command, Control, or Alt. Space and Shift are supported for Spotlight-style shortcuts."
+  },
+  "quickAccessLockedDescription": {
+    "message": "Unlock Bitwarden to search your vault from Quick Access."
+  },
+  "quickAccessLoggedOutDescription": {
+    "message": "Sign in before using Quick Access search."
+  },
+  "quickAccessNoResultsDescription": {
+    "message": "Search by item name, username, or website."
+  },
+  "usernameCopied": {
+    "message": "Copied username"
+  },
+  "passwordCopied": {
+    "message": "Copied password"
+  },
   "editShortcut": {
     "message": "Edit shortcut"
   },

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -44,6 +44,8 @@ import { MenuMain } from "./main/menu/menu.main";
 import { AUTOSTART_FLAG, MessagingMain } from "./main/messaging.main";
 import { NativeMessagingMain } from "./main/native-messaging.main";
 import { PowerMonitorMain } from "./main/power-monitor.main";
+import { QuickAccessWindowMain } from "./main/quick-access-window.main";
+import { QuickAccessMain } from "./main/quick-access.main";
 import { SsoCookieMain } from "./main/sso-cookie.main";
 import { ChromiumImporterService } from "./main/tools/import/chromium-importer.service";
 import { TrayMain } from "./main/tray.main";
@@ -98,6 +100,8 @@ export class Main {
   sdkLoadService: SdkLoadService;
   mainDesktopAutotypeService: MainDesktopAutotypeService;
   ssoCookieMain: SsoCookieMain;
+  quickAccessWindowMain: QuickAccessWindowMain;
+  quickAccessMain: QuickAccessMain;
 
   constructor() {
     // Set paths for portable builds
@@ -287,6 +291,7 @@ export class Main {
       this.desktopSettingsService,
       this.versionMain,
       this.shell,
+      () => void this.quickAccessMain?.toggle(),
     );
 
     this.trayMain = new TrayMain(
@@ -340,7 +345,16 @@ export class Main {
       this.windowMain,
     );
 
+    this.quickAccessWindowMain = new QuickAccessWindowMain(this.logService);
+    this.quickAccessMain = new QuickAccessMain(
+      this.logService,
+      this.windowMain,
+      this.quickAccessWindowMain,
+      this.desktopSettingsService,
+    );
+
     app.on("will-quit", () => {
+      this.quickAccessMain.dispose();
       this.mainDesktopAutotypeService.dispose();
       this.storageService.dispose();
     });
@@ -359,6 +373,7 @@ export class Main {
         this.ssoCookieMain.init(this.windowMain.session);
         await this.i18nService.init();
         await this.messagingMain.init();
+        await this.quickAccessMain.init();
         // FIXME: Verify that this floating promise is intentional. If it is, add an explanatory comment and ensure there is proper error handling.
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
         this.menuMain.init();

--- a/apps/desktop/src/main/menu/menu.main.ts
+++ b/apps/desktop/src/main/menu/menu.main.ts
@@ -26,6 +26,7 @@ export class MenuMain {
     private desktopSettingsService: DesktopSettingsService,
     private versionMain: VersionMain,
     private shell: SafeShell,
+    private toggleQuickAccess?: () => void,
   ) {}
 
   async init() {
@@ -50,6 +51,7 @@ export class MenuMain {
         await firstValueFrom(this.desktopSettingsService.hardwareAcceleration$),
         this.versionMain,
         this.shell,
+        this.toggleQuickAccess,
         updateRequest,
       ).menu,
     );

--- a/apps/desktop/src/main/menu/menu.view.ts
+++ b/apps/desktop/src/main/menu/menu.view.ts
@@ -34,6 +34,9 @@ export class ViewMenu implements IMenubarMenu {
     ];
 
     if (isDev()) {
+      if (this._toggleQuickAccess != null) {
+        items.push(this.separator, this.quickAccess);
+      }
       items.push(this.toggleDevTools);
     }
 
@@ -44,17 +47,20 @@ export class ViewMenu implements IMenubarMenu {
   private readonly _messagingService: MessagingService;
   private readonly _isLocked: boolean;
   private readonly _windowMain: WindowMain;
+  private readonly _toggleQuickAccess?: () => void;
 
   constructor(
     i18nService: I18nService,
     messagingService: MessagingService,
     isLocked: boolean,
     windowMain: WindowMain,
+    toggleQuickAccess?: () => void,
   ) {
     this._i18nService = i18nService;
     this._messagingService = messagingService;
     this._isLocked = isLocked;
     this._windowMain = windowMain;
+    this._toggleQuickAccess = toggleQuickAccess;
   }
 
   private get searchVault(): MenuItemConstructorOptions {
@@ -144,6 +150,14 @@ export class ViewMenu implements IMenubarMenu {
       id: "reload",
       label: this.localize("reload"),
       role: "forceReload",
+    };
+  }
+
+  private get quickAccess(): MenuItemConstructorOptions {
+    return {
+      id: "quickAccess",
+      label: "Toggle Quick Access",
+      click: () => this._toggleQuickAccess?.(),
     };
   }
 

--- a/apps/desktop/src/main/menu/menubar.ts
+++ b/apps/desktop/src/main/menu/menubar.ts
@@ -60,6 +60,7 @@ export class Menubar {
     hardwareAccelerationEnabled: boolean,
     versionMain: VersionMain,
     shell: SafeShell,
+    toggleQuickAccess?: () => void,
     updateRequest?: MenuUpdateRequest,
   ) {
     let isLocked = true;
@@ -94,7 +95,7 @@ export class Menubar {
         updateRequest?.restrictedCipherTypes,
       ),
       new EditMenu(i18nService, messagingService, isLocked),
-      new ViewMenu(i18nService, messagingService, isLocked, windowMain),
+      new ViewMenu(i18nService, messagingService, isLocked, windowMain, toggleQuickAccess),
       new AccountMenu(
         i18nService,
         messagingService,

--- a/apps/desktop/src/main/messaging.main.ts
+++ b/apps/desktop/src/main/messaging.main.ts
@@ -85,11 +85,50 @@ export class MessagingMain {
       case "removeOpenAtLogin":
         this.removeOpenAtLogin();
         break;
+      case "lockVault":
+      case "lockAllVaults":
+      case "locked":
+      case "logout":
+      case "loggedOut":
+        this.main.quickAccessMain.resetWindow();
+        break;
       case "setFocus":
         this.setFocus();
         break;
       case "getWindowIsFocused":
         this.windowIsFocused();
+        break;
+      case "quickAccessHide":
+        this.main.quickAccessMain.hide();
+        break;
+      case "quickAccessOpenCipher":
+        if (message.cipherId != null) {
+          this.main.quickAccessMain.openCipher(message.cipherId, message.searchText);
+        }
+        break;
+      case "quickAccessOpenApp":
+        this.main.quickAccessMain.openApp(message.route);
+        break;
+      case "quickAccessSearchRequest":
+      case "quickAccessCopyRequest":
+        this.main.windowMain.win?.webContents.send("messagingService", message);
+        break;
+      case "quickAccessSearchResponse":
+      case "quickAccessCopyResponse":
+        this.main.quickAccessMain.send(message);
+        break;
+      case "quickAccessResize":
+        if (typeof message.height === "number") {
+          this.main.quickAccessMain.resize(message.height);
+        }
+        break;
+      case "quickAccessSetEnabled":
+        this.main.quickAccessMain.setEnabled(message.enabled === true);
+        break;
+      case "quickAccessSetShortcut":
+        if (typeof message.shortcut === "string") {
+          this.main.quickAccessMain.setShortcut(message.shortcut);
+        }
         break;
       default:
         break;

--- a/apps/desktop/src/main/quick-access-window.main.spec.ts
+++ b/apps/desktop/src/main/quick-access-window.main.spec.ts
@@ -1,0 +1,107 @@
+import { BrowserWindow } from "electron";
+
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+
+import { QuickAccessWindowMain } from "./quick-access-window.main";
+
+jest.mock("electron", () => ({
+  app: {
+    name: "Bitwarden",
+  },
+  BrowserWindow: jest.fn(),
+  screen: {
+    getCursorScreenPoint: jest.fn().mockReturnValue({ x: 0, y: 0 }),
+    getDisplayNearestPoint: jest.fn().mockReturnValue({
+      workArea: {
+        x: 0,
+        y: 0,
+        width: 1440,
+        height: 900,
+      },
+    }),
+  },
+  session: {
+    fromPartition: jest.fn().mockReturnValue({}),
+  },
+}));
+
+describe("QuickAccessWindowMain", () => {
+  let logService: jest.Mocked<LogService>;
+  let webContents: {
+    getURL: jest.Mock;
+    loadURL?: never;
+    send: jest.Mock;
+    setWindowOpenHandler: jest.Mock;
+    userAgent: string;
+  };
+  let browserWindow: {
+    close: jest.Mock;
+    focus: jest.Mock;
+    hide: jest.Mock;
+    isDestroyed: jest.Mock;
+    isFocused: jest.Mock;
+    isVisible: jest.Mock;
+    loadURL: jest.Mock;
+    on: jest.Mock;
+    setBounds: jest.Mock;
+    setWindowButtonVisibility: jest.Mock;
+    show: jest.Mock;
+    webContents: typeof webContents;
+  };
+
+  beforeEach(() => {
+    logService = {
+      debug: jest.fn(),
+    } as any;
+    webContents = {
+      getURL: jest.fn().mockReturnValue("file:///index.html#/quick-access"),
+      send: jest.fn(),
+      setWindowOpenHandler: jest.fn(),
+      userAgent: "Electron",
+    };
+    browserWindow = {
+      close: jest.fn(),
+      focus: jest.fn(),
+      hide: jest.fn(),
+      isDestroyed: jest.fn().mockReturnValue(false),
+      isFocused: jest.fn().mockReturnValue(false),
+      isVisible: jest.fn().mockReturnValue(false),
+      loadURL: jest.fn().mockResolvedValue(undefined),
+      on: jest.fn(),
+      setBounds: jest.fn(),
+      setWindowButtonVisibility: jest.fn(),
+      show: jest.fn(),
+      webContents,
+    };
+
+    (BrowserWindow as unknown as jest.Mock).mockClear();
+    (BrowserWindow as unknown as jest.Mock).mockImplementation(() => browserWindow);
+  });
+
+  it("shows the quick access route without reloading when the window route is clean", async () => {
+    const service = new QuickAccessWindowMain(logService);
+
+    await service.show();
+
+    expect(browserWindow.loadURL).toHaveBeenCalledTimes(1);
+    expect(browserWindow.loadURL).toHaveBeenCalledWith(
+      expect.stringContaining("#/quick-access"),
+      expect.any(Object),
+    );
+    expect(browserWindow.show).toHaveBeenCalled();
+  });
+
+  it("reloads the quick access route before showing a reused window with a stale route", async () => {
+    const service = new QuickAccessWindowMain(logService);
+    await service.show();
+    webContents.getURL.mockReturnValue("file:///index.html#/vault");
+
+    await service.show();
+
+    expect(browserWindow.loadURL).toHaveBeenCalledTimes(2);
+    expect(browserWindow.loadURL).toHaveBeenLastCalledWith(
+      expect.stringContaining("#/quick-access"),
+      expect.any(Object),
+    );
+  });
+});

--- a/apps/desktop/src/main/quick-access-window.main.ts
+++ b/apps/desktop/src/main/quick-access-window.main.ts
@@ -1,0 +1,197 @@
+// FIXME: Update this file to be type safe and remove this and next line
+// @ts-strict-ignore
+import * as path from "path";
+import * as url from "url";
+
+import { app, BrowserWindow, screen, session } from "electron";
+
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+
+import { cleanUserAgent, isLinux } from "../utils";
+
+const quickAccessWidth = 680;
+const quickAccessMinHeight = 64;
+const quickAccessMaxHeight = 472;
+
+export class QuickAccessWindowMain {
+  private win: BrowserWindow | null = null;
+  private height = quickAccessMinHeight;
+  private isHiding = false;
+  private lastShownAt = 0;
+
+  constructor(private logService: LogService) {}
+
+  async show() {
+    await this.ensureWindow();
+
+    if (this.win == null || this.win.isDestroyed()) {
+      return;
+    }
+
+    await this.ensureQuickAccessRoute();
+    this.positionWindow();
+    this.lastShownAt = Date.now();
+    this.win.show();
+    this.win.focus();
+    this.send({ command: "quickAccessShown" });
+  }
+
+  async toggle() {
+    if (this.isVisible()) {
+      this.hide();
+      return;
+    }
+
+    await this.show();
+  }
+
+  hide() {
+    if (this.win == null || this.win.isDestroyed() || this.isHiding) {
+      return;
+    }
+
+    this.isHiding = true;
+    this.win.hide();
+    this.isHiding = false;
+  }
+
+  isVisible() {
+    return this.win != null && !this.win.isDestroyed() && this.win.isVisible();
+  }
+
+  dispose() {
+    if (this.win == null || this.win.isDestroyed()) {
+      return;
+    }
+
+    this.win.close();
+    this.win = null;
+  }
+
+  send(message: Record<string, unknown>) {
+    if (this.win == null || this.win.isDestroyed()) {
+      return;
+    }
+
+    this.win.webContents.send("messagingService", message);
+  }
+
+  resize(height: number) {
+    if (this.win == null || this.win.isDestroyed()) {
+      return;
+    }
+
+    this.height = this.clampHeight(height);
+    this.positionWindow();
+  }
+
+  private async ensureWindow() {
+    if (this.win != null && !this.win.isDestroyed()) {
+      return;
+    }
+
+    this.win = new BrowserWindow({
+      width: quickAccessWidth,
+      height: this.height,
+      minWidth: quickAccessWidth,
+      minHeight: quickAccessMinHeight,
+      maxWidth: quickAccessWidth,
+      maxHeight: quickAccessMaxHeight,
+      show: false,
+      resizable: false,
+      minimizable: false,
+      maximizable: false,
+      fullscreenable: false,
+      skipTaskbar: true,
+      alwaysOnTop: true,
+      frame: false,
+      transparent: true,
+      hasShadow: true,
+      autoHideMenuBar: true,
+      title: `${app.name} Quick Access`,
+      icon: isLinux() ? path.join(__dirname, "/images/icon.png") : undefined,
+      backgroundColor: "#00000000",
+      webPreferences: {
+        preload: path.join(__dirname, "preload.js"),
+        spellcheck: false,
+        nodeIntegration: false,
+        contextIsolation: true,
+        backgroundThrottling: false,
+        session: session.fromPartition("persist:bitwarden", { cache: false }),
+        devTools: false,
+      },
+    });
+
+    // Defensive macOS fallback in case native window controls are exposed.
+    this.win.setWindowButtonVisibility?.(false);
+
+    this.win.on("blur", () => {
+      const settleDelay = Math.max(250, 1000 - (Date.now() - this.lastShownAt));
+
+      setTimeout(() => {
+        if (this.win == null || this.win.isDestroyed() || this.win.isFocused()) {
+          return;
+        }
+
+        this.hide();
+      }, settleDelay);
+    });
+    this.win.on("closed", () => {
+      this.win = null;
+    });
+
+    this.win.webContents.setWindowOpenHandler(() => ({ action: "deny" }));
+
+    await this.win.loadURL(this.quickAccessUrl(), {
+      userAgent: cleanUserAgent(this.win.webContents.userAgent),
+    });
+
+    this.logService.debug("Quick Access window ready.");
+  }
+
+  private async ensureQuickAccessRoute() {
+    if (this.win == null || this.win.isDestroyed()) {
+      return;
+    }
+
+    if (this.win.webContents.getURL().includes("#/quick-access")) {
+      return;
+    }
+
+    await this.win.loadURL(this.quickAccessUrl(), {
+      userAgent: cleanUserAgent(this.win.webContents.userAgent),
+    });
+  }
+
+  private quickAccessUrl() {
+    return url.format({
+      protocol: "file:",
+      pathname: path.join(__dirname, "/index.html"),
+      slashes: true,
+      hash: "/quick-access",
+    });
+  }
+
+  private positionWindow() {
+    if (this.win == null || this.win.isDestroyed()) {
+      return;
+    }
+
+    const point = screen.getCursorScreenPoint();
+    const display = screen.getDisplayNearestPoint(point);
+    const bounds = display.workArea;
+    const x = Math.round(bounds.x + bounds.width / 2 - quickAccessWidth / 2);
+    const y = Math.round(bounds.y + Math.max(bounds.height * 0.22, 120));
+
+    this.win.setBounds({
+      x,
+      y,
+      width: quickAccessWidth,
+      height: this.height,
+    });
+  }
+
+  private clampHeight(height: number) {
+    return Math.min(Math.max(Math.round(height), quickAccessMinHeight), quickAccessMaxHeight);
+  }
+}

--- a/apps/desktop/src/main/quick-access.main.spec.ts
+++ b/apps/desktop/src/main/quick-access.main.spec.ts
@@ -1,0 +1,231 @@
+import { globalShortcut } from "electron";
+import { of } from "rxjs";
+
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+
+import { DesktopSettingsService } from "../platform/services/desktop-settings.service";
+
+import { QuickAccessWindowMain } from "./quick-access-window.main";
+import { DEFAULT_QUICK_ACCESS_SHORTCUT, QuickAccessMain } from "./quick-access.main";
+import { WindowMain } from "./window.main";
+
+jest.mock("electron", () => ({
+  globalShortcut: {
+    isRegistered: jest.fn(),
+    register: jest.fn(),
+    unregister: jest.fn(),
+  },
+}));
+
+describe("QuickAccessMain", () => {
+  let logService: jest.Mocked<LogService>;
+  let windowMain: jest.Mocked<WindowMain>;
+  let quickAccessWindow: jest.Mocked<QuickAccessWindowMain>;
+  let desktopSettingsService: jest.Mocked<DesktopSettingsService>;
+  let service: QuickAccessMain;
+
+  beforeEach(() => {
+    logService = {
+      debug: jest.fn(),
+      error: jest.fn(),
+      info: jest.fn(),
+      warning: jest.fn(),
+    } as any;
+
+    windowMain = {
+      show: jest.fn(),
+      win: {
+        focus: jest.fn(),
+        hide: jest.fn(),
+        isDestroyed: jest.fn().mockReturnValue(false),
+        isVisible: jest.fn().mockReturnValue(true),
+        webContents: {
+          send: jest.fn(),
+        },
+      },
+    } as any;
+
+    quickAccessWindow = {
+      dispose: jest.fn(),
+      hide: jest.fn(),
+      send: jest.fn(),
+      show: jest.fn(),
+      toggle: jest.fn(),
+    } as any;
+
+    desktopSettingsService = {
+      quickAccessEnabled$: of(true),
+      quickAccessShortcut$: of(DEFAULT_QUICK_ACCESS_SHORTCUT),
+    } as any;
+
+    jest.clearAllMocks();
+    (globalShortcut.isRegistered as jest.Mock).mockReturnValue(false);
+    (globalShortcut.register as jest.Mock).mockReturnValue(true);
+
+    service = new QuickAccessMain(
+      logService,
+      windowMain,
+      quickAccessWindow,
+      desktopSettingsService,
+    );
+  });
+
+  it("registers the default global shortcut", async () => {
+    await service.init();
+
+    expect(globalShortcut.register).toHaveBeenCalledWith(
+      DEFAULT_QUICK_ACCESS_SHORTCUT,
+      expect.any(Function),
+    );
+    expect(logService.info).toHaveBeenCalledWith(
+      `Quick Access enabled with shortcut: ${DEFAULT_QUICK_ACCESS_SHORTCUT}`,
+    );
+  });
+
+  it("toggles the quick access window from the shortcut callback", async () => {
+    await service.init();
+    const callback = (globalShortcut.register as jest.Mock).mock.calls[0][1];
+
+    callback();
+
+    expect(quickAccessWindow.toggle).toHaveBeenCalled();
+  });
+
+  it("does not register the shortcut when Quick Access is disabled", async () => {
+    desktopSettingsService.quickAccessEnabled$ = of(false);
+    service = new QuickAccessMain(
+      logService,
+      windowMain,
+      quickAccessWindow,
+      desktopSettingsService,
+    );
+
+    await service.init();
+
+    expect(globalShortcut.register).not.toHaveBeenCalled();
+    expect(quickAccessWindow.hide).toHaveBeenCalled();
+  });
+
+  it("toggles quick access without showing the main window", async () => {
+    await service.toggle();
+
+    expect(quickAccessWindow.toggle).toHaveBeenCalled();
+    expect(windowMain.show).not.toHaveBeenCalled();
+    expect(windowMain.win.focus).not.toHaveBeenCalled();
+  });
+
+  it("keeps the main window hidden when toggling quick access from the background", async () => {
+    windowMain.win.isVisible.mockReturnValueOnce(false).mockReturnValueOnce(true);
+
+    await service.toggle();
+
+    expect(quickAccessWindow.toggle).toHaveBeenCalled();
+    expect(windowMain.win.hide).toHaveBeenCalled();
+  });
+
+  it("ignores toggle when Quick Access is disabled", async () => {
+    desktopSettingsService.quickAccessEnabled$ = of(false);
+    service = new QuickAccessMain(
+      logService,
+      windowMain,
+      quickAccessWindow,
+      desktopSettingsService,
+    );
+    await service.init();
+
+    await service.toggle();
+
+    expect(quickAccessWindow.toggle).not.toHaveBeenCalled();
+  });
+
+  it("does not register when the shortcut is already owned", async () => {
+    (globalShortcut.isRegistered as jest.Mock).mockReturnValue(true);
+
+    await service.init();
+
+    expect(globalShortcut.register).not.toHaveBeenCalled();
+    expect(logService.warning).toHaveBeenCalledWith(
+      `Quick Access shortcut is already registered: ${DEFAULT_QUICK_ACCESS_SHORTCUT}`,
+    );
+  });
+
+  it("re-registers when the shortcut changes", async () => {
+    await service.init();
+    (globalShortcut.isRegistered as jest.Mock).mockImplementation(
+      (shortcut) => shortcut === DEFAULT_QUICK_ACCESS_SHORTCUT,
+    );
+
+    service.setShortcut("Control+Alt+Q");
+
+    expect(globalShortcut.unregister).toHaveBeenCalledWith(DEFAULT_QUICK_ACCESS_SHORTCUT);
+    expect(globalShortcut.register).toHaveBeenLastCalledWith("Control+Alt+Q", expect.any(Function));
+  });
+
+  it("does not re-register invalid shortcuts", async () => {
+    await service.init();
+
+    service.setShortcut("Shift+Q");
+
+    expect(globalShortcut.register).toHaveBeenCalledTimes(1);
+    expect(logService.warning).toHaveBeenCalledWith(
+      "Invalid Quick Access shortcut ignored: Shift+Q",
+    );
+  });
+
+  it("unregisters and hides when Quick Access is disabled", async () => {
+    await service.init();
+    (globalShortcut.isRegistered as jest.Mock).mockReturnValue(true);
+
+    service.setEnabled(false);
+
+    expect(globalShortcut.unregister).toHaveBeenCalledWith(DEFAULT_QUICK_ACCESS_SHORTCUT);
+    expect(quickAccessWindow.hide).toHaveBeenCalled();
+  });
+
+  it("opens a cipher in the main window", () => {
+    service.openCipher("cipher-id", "mail");
+
+    expect(quickAccessWindow.hide).toHaveBeenCalled();
+    expect(windowMain.show).toHaveBeenCalled();
+    expect(windowMain.win.focus).toHaveBeenCalled();
+    expect(windowMain.win.webContents.send).toHaveBeenCalledWith("messagingService", {
+      command: "quickAccessOpenCipher",
+      cipherId: "cipher-id",
+      searchText: "mail",
+    });
+  });
+
+  it("opens an app route in the main window", () => {
+    service.openApp(["/lock"]);
+
+    expect(quickAccessWindow.hide).toHaveBeenCalled();
+    expect(windowMain.show).toHaveBeenCalled();
+    expect(windowMain.win.webContents.send).toHaveBeenCalledWith("messagingService", {
+      command: "quickAccessOpenApp",
+      route: ["/lock"],
+    });
+  });
+
+  it("sends messages to the quick access window", () => {
+    service.send({ command: "quickAccessSearchResponse" });
+
+    expect(quickAccessWindow.send).toHaveBeenCalledWith({ command: "quickAccessSearchResponse" });
+  });
+
+  it("can reset the window without unregistering the shortcut", () => {
+    service.resetWindow();
+
+    expect(quickAccessWindow.dispose).toHaveBeenCalled();
+    expect(globalShortcut.unregister).not.toHaveBeenCalled();
+  });
+
+  it("unregisters the shortcut and disposes the window", async () => {
+    await service.init();
+    (globalShortcut.isRegistered as jest.Mock).mockReturnValue(true);
+
+    service.dispose();
+
+    expect(globalShortcut.unregister).toHaveBeenCalledWith(DEFAULT_QUICK_ACCESS_SHORTCUT);
+    expect(quickAccessWindow.dispose).toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/main/quick-access.main.ts
+++ b/apps/desktop/src/main/quick-access.main.ts
@@ -1,0 +1,170 @@
+import { globalShortcut } from "electron";
+import { firstValueFrom } from "rxjs";
+
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+
+import {
+  DEFAULT_QUICK_ACCESS_SHORTCUT,
+  isQuickAccessShortcutValid,
+} from "../platform/models/domain/quick-access-shortcut";
+import { DesktopSettingsService } from "../platform/services/desktop-settings.service";
+
+import { QuickAccessWindowMain } from "./quick-access-window.main";
+import { WindowMain } from "./window.main";
+
+export { DEFAULT_QUICK_ACCESS_SHORTCUT } from "../platform/models/domain/quick-access-shortcut";
+
+export class QuickAccessMain {
+  private enabled = true;
+  private shortcut = DEFAULT_QUICK_ACCESS_SHORTCUT;
+  private registeredShortcut: string | null = null;
+
+  constructor(
+    private logService: LogService,
+    private windowMain: WindowMain,
+    private quickAccessWindow: QuickAccessWindowMain,
+    private desktopSettingsService: DesktopSettingsService,
+  ) {}
+
+  async init() {
+    this.enabled = await firstValueFrom(this.desktopSettingsService.quickAccessEnabled$);
+    const shortcut = await firstValueFrom(this.desktopSettingsService.quickAccessShortcut$);
+    this.shortcut = isQuickAccessShortcutValid(shortcut) ? shortcut : DEFAULT_QUICK_ACCESS_SHORTCUT;
+    this.applyShortcutRegistration();
+  }
+
+  dispose() {
+    this.unregisterRegisteredShortcut();
+    this.quickAccessWindow.dispose();
+  }
+
+  async toggle() {
+    if (!this.enabled) {
+      return;
+    }
+
+    const wasMainWindowVisible =
+      this.windowMain.win != null &&
+      !this.windowMain.win.isDestroyed() &&
+      this.windowMain.win.isVisible();
+
+    await this.quickAccessWindow.toggle();
+
+    if (
+      !wasMainWindowVisible &&
+      this.windowMain.win != null &&
+      !this.windowMain.win.isDestroyed() &&
+      this.windowMain.win.isVisible()
+    ) {
+      this.windowMain.win.hide();
+    }
+  }
+
+  hide() {
+    this.quickAccessWindow.hide();
+  }
+
+  resetWindow() {
+    this.quickAccessWindow.dispose();
+  }
+
+  send(message: Record<string, unknown>) {
+    this.quickAccessWindow.send(message);
+  }
+
+  resize(height: number) {
+    this.quickAccessWindow.resize(height);
+  }
+
+  setEnabled(enabled: boolean) {
+    this.enabled = enabled;
+    this.applyShortcutRegistration();
+  }
+
+  setShortcut(shortcut: string) {
+    if (!isQuickAccessShortcutValid(shortcut)) {
+      this.logService.warning(`Invalid Quick Access shortcut ignored: ${shortcut}`);
+      return;
+    }
+
+    this.shortcut = shortcut;
+    this.applyShortcutRegistration();
+  }
+
+  openCipher(cipherId: string, searchText?: string) {
+    this.hide();
+
+    if (this.windowMain.win == null || this.windowMain.win.isDestroyed()) {
+      return;
+    }
+
+    this.windowMain.show();
+    this.windowMain.win.focus();
+    this.windowMain.win.webContents.send("messagingService", {
+      command: "quickAccessOpenCipher",
+      cipherId,
+      searchText,
+    });
+  }
+
+  openApp(route: string[] = ["/vault"]) {
+    this.hide();
+
+    if (this.windowMain.win == null || this.windowMain.win.isDestroyed()) {
+      return;
+    }
+
+    this.windowMain.show();
+    this.windowMain.win.focus();
+    this.windowMain.win.webContents.send("messagingService", {
+      command: "quickAccessOpenApp",
+      route,
+    });
+  }
+
+  private applyShortcutRegistration() {
+    if (!this.enabled) {
+      this.unregisterRegisteredShortcut();
+      this.hide();
+      return;
+    }
+
+    const registeredShortcut = this.registeredShortcut;
+    if (registeredShortcut === this.shortcut && globalShortcut.isRegistered(registeredShortcut)) {
+      return;
+    }
+
+    this.unregisterRegisteredShortcut();
+    this.registerShortcut(this.shortcut);
+  }
+
+  private registerShortcut(shortcut: string) {
+    if (globalShortcut.isRegistered(shortcut)) {
+      this.logService.warning(`Quick Access shortcut is already registered: ${shortcut}`);
+      return;
+    }
+
+    const registered = globalShortcut.register(shortcut, () => {
+      void this.toggle();
+    });
+
+    if (registered) {
+      this.registeredShortcut = shortcut;
+      this.logService.info(`Quick Access enabled with shortcut: ${shortcut}`);
+    } else {
+      this.logService.error(`Failed to enable Quick Access shortcut: ${shortcut}`);
+    }
+  }
+
+  private unregisterRegisteredShortcut() {
+    if (this.registeredShortcut == null) {
+      return;
+    }
+
+    if (globalShortcut.isRegistered(this.registeredShortcut)) {
+      globalShortcut.unregister(this.registeredShortcut);
+    }
+
+    this.registeredShortcut = null;
+  }
+}

--- a/apps/desktop/src/platform/models/domain/quick-access-shortcut.ts
+++ b/apps/desktop/src/platform/models/domain/quick-access-shortcut.ts
@@ -1,0 +1,49 @@
+export const DEFAULT_QUICK_ACCESS_SHORTCUT = "CommandOrControl+Shift+Space";
+
+const validShortcutModifiers = new Set([
+  "Alt",
+  "Command",
+  "CommandOrControl",
+  "Control",
+  "Shift",
+  "Super",
+]);
+
+const activationShortcutModifiers = new Set([
+  "Alt",
+  "Command",
+  "CommandOrControl",
+  "Control",
+  "Super",
+]);
+
+export function isQuickAccessShortcutValid(shortcut: string | null | undefined) {
+  if (shortcut == null || shortcut.length === 0) {
+    return false;
+  }
+
+  const parts = shortcut.split("+").filter((part) => part.length > 0);
+  if (parts.length < 2 || parts.length > 5) {
+    return false;
+  }
+
+  const key = parts[parts.length - 1];
+  const modifiers = parts.slice(0, -1);
+  if (key !== "Space" && !/^[A-Z]$/.test(key)) {
+    return false;
+  }
+
+  if (!modifiers.some((modifier) => activationShortcutModifiers.has(modifier))) {
+    return false;
+  }
+
+  const seenModifiers = new Set<string>();
+  return modifiers.every((modifier) => {
+    if (!validShortcutModifiers.has(modifier) || seenModifiers.has(modifier)) {
+      return false;
+    }
+
+    seenModifiers.add(modifier);
+    return true;
+  });
+}

--- a/apps/desktop/src/platform/services/desktop-settings.service.ts
+++ b/apps/desktop/src/platform/services/desktop-settings.service.ts
@@ -20,6 +20,7 @@ import { UserId } from "@bitwarden/common/types/guid";
 
 import { SshAgentPromptType } from "../../autofill/models/ssh-agent-setting";
 import { isDev } from "../../utils";
+import { DEFAULT_QUICK_ACCESS_SHORTCUT } from "../models/domain/quick-access-shortcut";
 import { ModalModeState, WindowState } from "../models/domain/window-state";
 
 export const HARDWARE_ACCELERATION = new KeyDefinition<boolean>(
@@ -63,6 +64,22 @@ const BROWSER_INTEGRATION_ENABLED = new KeyDefinition<boolean>(
   "browserIntegrationEnabled",
   {
     deserializer: (b) => b,
+  },
+);
+
+const QUICK_ACCESS_ENABLED = new KeyDefinition<boolean>(
+  DESKTOP_SETTINGS_DISK,
+  "quickAccessEnabled",
+  {
+    deserializer: (b) => b,
+  },
+);
+
+const QUICK_ACCESS_SHORTCUT = new KeyDefinition<string>(
+  DESKTOP_SETTINGS_DISK,
+  "quickAccessShortcut",
+  {
+    deserializer: (s) => s,
   },
 );
 
@@ -147,6 +164,14 @@ export class DesktopSettingsService {
    * The application setting for whether or not the browser integration is enabled.
    */
   browserIntegrationEnabled$ = this.browserIntegrationEnabledState.state$.pipe(map(Boolean));
+
+  private readonly quickAccessEnabledState = this.stateProvider.getGlobal(QUICK_ACCESS_ENABLED);
+  quickAccessEnabled$ = this.quickAccessEnabledState.state$.pipe(map((v) => v ?? true));
+
+  private readonly quickAccessShortcutState = this.stateProvider.getGlobal(QUICK_ACCESS_SHORTCUT);
+  quickAccessShortcut$ = this.quickAccessShortcutState.state$.pipe(
+    map((v) => v ?? DEFAULT_QUICK_ACCESS_SHORTCUT),
+  );
 
   private readonly sshAgentEnabledState = this.stateProvider.getGlobal(SSH_AGENT_ENABLED);
 
@@ -264,6 +289,14 @@ export class DesktopSettingsService {
    */
   async setBrowserIntegrationEnabled(value: boolean) {
     await this.browserIntegrationEnabledState.update(() => value);
+  }
+
+  async setQuickAccessEnabled(value: boolean) {
+    await this.quickAccessEnabledState.update(() => value);
+  }
+
+  async setQuickAccessShortcut(value: string) {
+    await this.quickAccessShortcutState.update(() => value);
   }
 
   /**

--- a/apps/desktop/src/vault/app/vault-v3/vault-orig.component.ts
+++ b/apps/desktop/src/vault/app/vault-v3/vault-orig.component.ts
@@ -310,6 +310,12 @@ export class VaultComponent implements OnInit, OnDestroy, CopyClickListener {
                   );
                 }
                 break;
+              case "quickAccessOpenCipher": {
+                if (message.cipherId != null) {
+                  await this.viewCipherById(message.cipherId).catch(() => {});
+                }
+                break;
+              }
               case "modalShown":
                 this.showingModal = true;
                 break;
@@ -440,14 +446,16 @@ export class VaultComponent implements OnInit, OnDestroy, CopyClickListener {
     const params = await firstValueFrom(this.route.queryParams).catch();
     const paramCipherAddType = toCipherType(params.addType);
     if (params.cipherId) {
-      const cipherView = new CipherView();
-      cipherView.id = params.cipherId;
       if (params.action === "clone") {
+        const cipherView = new CipherView();
+        cipherView.id = params.cipherId;
         await this.cloneCipher(cipherView).catch(() => {});
       } else if (params.action === "edit") {
+        const cipherView = new CipherView();
+        cipherView.id = params.cipherId;
         await this.editCipher(cipherView).catch(() => {});
       } else {
-        await this.viewCipher(cipherView).catch(() => {});
+        await this.viewCipherById(params.cipherId).catch(() => {});
       }
     } else if (params.action === "add" && paramCipherAddType) {
       this.addType = paramCipherAddType;
@@ -486,6 +494,22 @@ export class VaultComponent implements OnInit, OnDestroy, CopyClickListener {
       false,
       cipher.organizationId,
     );
+  }
+
+  private async viewCipherById(cipherId: string) {
+    if (this.activeUserId == null) {
+      return;
+    }
+
+    const ciphers = await firstValueFrom(
+      this.cipherService.cipherListViews$(this.activeUserId).pipe(filter((c) => c != null)),
+    );
+    const cipher = ciphers.find((cipher) => cipher.id === cipherId);
+    if (cipher == null) {
+      return;
+    }
+
+    await this.viewCipher(cipher);
   }
 
   formStatusChanged(status: "disabled" | "enabled") {

--- a/apps/desktop/src/vault/app/vault-v3/vault.component.ts
+++ b/apps/desktop/src/vault/app/vault-v3/vault.component.ts
@@ -324,7 +324,14 @@ export class VaultComponent<C extends CipherViewLike> implements OnInit, OnDestr
 
     // Clear cipher selection on page load/reload to prevent flash of content
     const currentParams = await firstValueFrom(this.route.queryParams);
-    if (currentParams.itemId || currentParams.cipherId) {
+    if (currentParams.cipherId && currentParams.action === "view") {
+      await this.viewCipherById(currentParams.cipherId).catch((e) => this.logService.error(e));
+      await this.router.navigate([], {
+        queryParams: { itemId: null, cipherId: null, action: null },
+        queryParamsHandling: "merge",
+        replaceUrl: true,
+      });
+    } else if (currentParams.itemId || currentParams.cipherId) {
       await this.router.navigate([], {
         queryParams: { itemId: null, cipherId: null, action: null },
         queryParamsHandling: "merge",
@@ -339,6 +346,9 @@ export class VaultComponent<C extends CipherViewLike> implements OnInit, OnDestr
             void this.vaultItemTransferService.enforceOrganizationDataOwnership(this.activeUserId);
           }
           this.refresh();
+        }
+        if (message.command === "quickAccessOpenCipher" && message.cipherId != null) {
+          await this.viewCipherById(message.cipherId).catch((e) => this.logService.error(e));
         }
       });
     });
@@ -570,6 +580,22 @@ export class VaultComponent<C extends CipherViewLike> implements OnInit, OnDestr
       cipher.type,
     );
     await this.openDialog("view", formConfig);
+  }
+
+  private async viewCipherById(cipherId: string) {
+    if (this.activeUserId == null) {
+      return;
+    }
+
+    const ciphers = await firstValueFrom(
+      this.cipherService.cipherListViews$(this.activeUserId).pipe(filter((c) => c != null)),
+    );
+    const cipher = ciphers.find((cipher) => cipher.id === cipherId);
+    if (cipher == null) {
+      return;
+    }
+
+    await this.viewCipher(cipher);
   }
 
   async openAttachmentsDialog(cipherId: CipherId, canEditCipher: boolean) {
@@ -902,7 +928,7 @@ export class VaultComponent<C extends CipherViewLike> implements OnInit, OnDestr
     this.activeDrawerRef.closed.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((result) => {
       this.activeDrawerRef = undefined;
       void this.router.navigate([], {
-        queryParams: { action: null, itemId: null },
+        queryParams: { action: null, itemId: null, cipherId: null },
         queryParamsHandling: "merge",
         replaceUrl: true,
       });


### PR DESCRIPTION
## 🎟️ Tracking

Adds a desktop Quick Access search workflow for quickly finding and opening vault items from a global shortcut.

## 📔 Objective

This PR adds Quick Access for the desktop client.

Quick Access provides a standalone, keyboard-invoked vault search window that can:
- Search unlocked vault items without bringing the main window forward first.
- Copy usernames and passwords from search results.
- Open the selected item in the main vault window.
- Respect the existing unlocked vault state through main-window IPC delegation.
- Avoid stale Quick Access window routes when the shortcut window is reused.

It also adds desktop settings for enabling Quick Access and configuring the shortcut.

## 📸 Screenshots
<img width="1834" height="692" alt="CleanShot 2026-06-02 at 20 40 42@2x" src="https://github.com/user-attachments/assets/4a42f0cb-632d-4d7c-8683-333ea2c01f77" />
<img width="2348" height="1206" alt="CleanShot 2026-06-02 at 20 42 41@2x" src="https://github.com/user-attachments/assets/6f436076-d930-4760-8ec6-3535ab32aab5" />

