### PR TITLE
[PM-38405] Await unawaited promises

### DIFF
--- a/apps/browser/src/auth/popup/settings/account-security.component.ts
+++ b/apps/browser/src/auth/popup/settings/account-security.component.ts
@@ -512,7 +512,7 @@ export class AccountSecurityComponent implements OnInit, OnDestroy {
       fingerprint,
     });
 
-    return firstValueFrom(dialogRef.closed);
+    return await firstValueFrom(dialogRef.closed);
   }
 
   async lock() {

--- a/apps/cli/src/auth/commands/login.command.ts
+++ b/apps/cli/src/auth/commands/login.command.ts
@@ -558,7 +558,7 @@ export class LoginCommand {
   ): Promise<{ ssoCode: string; orgIdentifier: string }> {
     const env = await firstValueFrom(this.environmentService.environment$);
 
-    return new Promise((resolve, reject) => {
+    return await new Promise((resolve, reject) => {
       const callbackServer = http.createServer((req, res) => {
         const urlString = "http://localhost" + req.url;
         const url = new URL(urlString);

--- a/apps/desktop/src/auth/components/account-switcher/account-switcher-v2.component.ts
+++ b/apps/desktop/src/auth/components/account-switcher/account-switcher-v2.component.ts
@@ -135,7 +135,7 @@ export class AccountSwitcherV2Component implements OnInit {
               accountStatuses[id] !== AuthenticationStatus.LoggedOut || id === activeAccount?.id,
           ),
         );
-        return this.createInactiveAccounts(accounts);
+        return await this.createInactiveAccounts(accounts);
       }),
     );
     this.showSwitcher$ = combineLatest([this.activeAccount$, this.inactiveAccounts$]).pipe(

--- a/apps/web/src/app/auth/core/services/webauthn-login/webauthn-login-admin.service.ts
+++ b/apps/web/src/app/auth/core/services/webauthn-login/webauthn-login-admin.service.ts
@@ -324,7 +324,7 @@ export class WebauthnLoginAdminService implements UserKeyRotationDataProvider<We
       throw new Error("newUserKey is required");
     }
 
-    return Promise.all(
+    return await Promise.all(
       (await this.apiService.getCredentials()).data
         .filter((credential) => credential.hasPrfKeyset())
         .map(async (response) => {

--- a/apps/web/src/app/auth/emergency-access/services/emergency-access.service.ts
+++ b/apps/web/src/app/auth/emergency-access/services/emergency-access.service.ts
@@ -268,7 +268,7 @@ export class EmergencyAccessService implements UserKeyRotationKeyRecoveryProvide
 
     let ciphers: CipherView[] = [];
     const ciphersEncrypted = response.ciphers.map((c) => new Cipher(c));
-    ciphers = await Promise.all(ciphersEncrypted.map(async (c) => c.decrypt(grantorUserKey)));
+    ciphers = await Promise.all(ciphersEncrypted.map(async (c) => await c.decrypt(grantorUserKey)));
     return ciphers.sort(this.cipherService.getLocaleSortingFunction());
   }
 

--- a/apps/web/src/app/auth/guards/deep-link/deep-link.guard.ts
+++ b/apps/web/src/app/auth/guards/deep-link/deep-link.guard.ts
@@ -36,7 +36,7 @@ export function deepLinkGuard(): CanActivateFn {
       // Check if the url is empty or null
       if (!Utils.isNullOrEmpty(persistedPreLoginUrl)) {
         // const urlTree: string | UrlTree = persistedPreLoginUrl;
-        return router.navigateByUrl(persistedPreLoginUrl);
+        return await router.navigateByUrl(persistedPreLoginUrl);
       }
       return true;
     }

--- a/apps/web/src/app/auth/settings/emergency-access/view/emergency-view-dialog.component.ts
+++ b/apps/web/src/app/auth/settings/emergency-access/view/emergency-view-dialog.component.ts
@@ -29,7 +29,7 @@ export interface EmergencyViewDialogParams {
 class PremiumUpgradePromptNoop implements PremiumUpgradePromptService {
   readonly upgradeConfirmed$: Observable<boolean> = EMPTY;
   async promptForPremium() {
-    return Promise.resolve();
+    return await Promise.resolve();
   }
 }
 

--- a/apps/web/src/app/auth/settings/two-factor/two-factor-setup-authenticator.component.ts
+++ b/apps/web/src/app/auth/settings/two-factor/two-factor-setup-authenticator.component.ts
@@ -138,7 +138,7 @@ export class TwoFactorSetupAuthenticatorComponent
 
   async auth(authResponse: AuthResponse<TwoFactorAuthenticatorResponse>) {
     super.auth(authResponse);
-    return this.processResponse(authResponse.response);
+    return await this.processResponse(authResponse.response);
   }
 
   submit = async () => {
@@ -207,10 +207,10 @@ export class TwoFactorSetupAuthenticatorComponent
   private async waitForQRiousToLoadOrError(): Promise<void> {
     // Check if QRious is already loaded or if there was an error loading it either way don't wait for it to try and load again
     if (typeof window.QRious !== "undefined" || this.qrScriptError) {
-      return Promise.resolve();
+      return await Promise.resolve();
     }
 
-    return new Promise((resolve, reject) => {
+    return await new Promise((resolve, reject) => {
       this.qrScript.onload = () => resolve();
       this.qrScript.onerror = () =>
         reject(new Error(this.i18nService.t("twoStepAuthenticatorQRCanvasError")));

--- a/apps/web/src/app/auth/settings/two-factor/two-factor-setup-method-base.component.ts
+++ b/apps/web/src/app/auth/settings/two-factor/two-factor-setup-method-base.component.ts
@@ -83,7 +83,7 @@ export abstract class TwoFactorSetupMethodBaseComponent {
     if (this.secret === undefined || this.verificationType === undefined) {
       throw new Error("User verification data is missing");
     }
-    return this.userVerificationService.buildRequest(
+    return await this.userVerificationService.buildRequest(
       {
         secret: this.secret,
         type: this.verificationType,

--- a/apps/web/src/app/auth/settings/two-factor/two-factor-setup-webauthn.component.ts
+++ b/apps/web/src/app/auth/settings/two-factor/two-factor-setup-webauthn.component.ts
@@ -114,9 +114,9 @@ export class TwoFactorSetupWebAuthnComponent extends TwoFactorSetupMethodBaseCom
   submit = async () => {
     if (this.webAuthnResponse == null || this.keyIdAvailable == null) {
       // Should never happen.
-      return Promise.reject();
+      return await Promise.reject();
     }
-    return this.enable();
+    return await this.enable();
   };
 
   protected async enable() {

--- a/libs/angular/src/auth/guards/unauth.guard.ts
+++ b/libs/angular/src/auth/guards/unauth.guard.ts
@@ -68,5 +68,5 @@ async function unauthGuard(
 }
 
 export function unauthGuardFn(overrides: Partial<UnauthRoutes> = {}): CanActivateFn {
-  return async (route) => unauthGuard(route, { ...defaultRoutes, ...overrides });
+  return async (route) => await unauthGuard(route, { ...defaultRoutes, ...overrides });
 }

--- a/libs/auth/src/common/login-strategies/auth-request-login.strategy.ts
+++ b/libs/auth/src/common/login-strategies/auth-request-login.strategy.ts
@@ -68,7 +68,7 @@ export class AuthRequestLoginStrategy extends LoginStrategy {
     const data = this.cache.value;
     this.cache.next(data);
 
-    return super.logInTwoFactor(twoFactor);
+    return await super.logInTwoFactor(twoFactor);
   }
 
   protected override async setMasterKey(response: IdentityTokenResponse, userId: UserId) {

--- a/libs/auth/src/common/login-strategies/password-login.strategy.ts
+++ b/libs/auth/src/common/login-strategies/password-login.strategy.ts
@@ -177,7 +177,11 @@ export class PasswordLoginStrategy extends LoginStrategy {
   ): Promise<MasterKey> {
     // if we have prefetched prelogin data, use it
     if (preFetchedPreloginData) {
-      return this.keyService.makeMasterKey(masterPassword, email, preFetchedPreloginData.kdfConfig);
+      return await this.keyService.makeMasterKey(
+        masterPassword,
+        email,
+        preFetchedPreloginData.kdfConfig,
+      );
     }
 
     // No prefetched data — fetch now. PasswordPreloginData.fromResponse validates the KDF config.
@@ -187,7 +191,7 @@ export class PasswordLoginStrategy extends LoginStrategy {
       throw new Error("KDF config is required");
     }
 
-    return this.keyService.makeMasterKey(masterPassword, email, preloginData.kdfConfig);
+    return await this.keyService.makeMasterKey(masterPassword, email, preloginData.kdfConfig);
   }
 
   private async evaluateMasterPasswordIfRequired(

--- a/libs/common/src/auth/services/devices/devices.service.implementation.ts
+++ b/libs/common/src/auth/services/devices/devices.service.implementation.ts
@@ -87,7 +87,7 @@ export class DevicesServiceImplementation implements DevicesServiceAbstraction {
   getCurrentDevice$(): Observable<DeviceResponse> {
     return defer(async () => {
       const deviceIdentifier = await this.appIdService.getAppId();
-      return this.devicesApiService.getDeviceByIdentifier(deviceIdentifier);
+      return await this.devicesApiService.getDeviceByIdentifier(deviceIdentifier);
     });
   }
 

--- a/libs/common/src/auth/services/user-verification/user-verification-api.service.ts
+++ b/libs/common/src/auth/services/user-verification/user-verification-api.service.ts
@@ -11,7 +11,7 @@ export class UserVerificationApiService implements UserVerificationApiServiceAbs
     return this.apiService.send("POST", "/accounts/verify-otp", request, true, false);
   }
   async postAccountRequestOTP(): Promise<void> {
-    return this.apiService.send("POST", "/accounts/request-otp", null, true, false);
+    return await this.apiService.send("POST", "/accounts/request-otp", null, true, false);
   }
   postAccountVerifyPassword(
     request: SecretVerificationRequest,

--- a/libs/common/src/auth/services/user-verification/user-verification.service.ts
+++ b/libs/common/src/auth/services/user-verification/user-verification.service.ts
@@ -143,14 +143,14 @@ export class UserVerificationService implements UserVerificationServiceAbstracti
 
     switch (verification.type) {
       case VerificationType.OTP:
-        return this.verifyUserByOTP(verification);
+        return await this.verifyUserByOTP(verification);
       case VerificationType.MasterPassword:
         await this.verifyUserByMasterPassword(verification, userId, email);
         return true;
       case VerificationType.PIN:
-        return this.verifyUserByPIN(verification, userId);
+        return await this.verifyUserByPIN(verification, userId);
       case VerificationType.Biometrics:
-        return this.verifyUserByBiometrics();
+        return await this.verifyUserByBiometrics();
       default: {
         // Compile-time check for exhaustive switch
         const _exhaustiveCheck: never = verification;
@@ -235,7 +235,7 @@ export class UserVerificationService implements UserVerificationServiceAbstracti
   }
 
   private async verifyUserByBiometrics(): Promise<boolean> {
-    return this.biometricsService.authenticateWithBiometrics();
+    return await this.biometricsService.authenticateWithBiometrics();
   }
 
   async requestOTP() {

--- a/libs/common/src/auth/two-factor/services/default-two-factor-api.service.ts
+++ b/libs/common/src/auth/two-factor/services/default-two-factor-api.service.ts
@@ -102,11 +102,17 @@ export class DefaultTwoFactorApiService implements TwoFactorApiService {
   }
 
   async postTwoFactorEmailSetup(request: TwoFactorEmailRequest): Promise<any> {
-    return this.apiService.send("POST", "/two-factor/send-email", request, true, false);
+    return await this.apiService.send("POST", "/two-factor/send-email", request, true, false);
   }
 
   async postTwoFactorEmail(request: TwoFactorEmailRequest): Promise<any> {
-    return this.apiService.send("POST", "/two-factor/send-email-login", request, false, false);
+    return await this.apiService.send(
+      "POST",
+      "/two-factor/send-email-login",
+      request,
+      false,
+      false,
+    );
   }
 
   async putTwoFactorEmail(request: UpdateTwoFactorEmailRequest): Promise<TwoFactorEmailResponse> {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
Jira Bug: https://bitwarden.atlassian.net/browse/PM-38405
Tracking PR: https://github.com/bitwarden/clients/pull/20981

Note: This PR is split per team ownership to keep it reviewable.

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
We want to enable the return-await eslint rule. Currently, there is a pattern of unawaited promises being returned which is causing production bugs as explained in more detail below. To do this, we first migrate all teams. The migration has been performed automatically with eslint --fix. There aren o other changes other than adding await to the unawaited promises.

### Specifically Bugged Behavior

Returning unawaited promises is currently allowing unexpected bugs to appear. Specifically in this example:

```ts
        await firstValueFrom( // Promise on ref.value gets awaited here
          this.sdkService.userClient$(userId).pipe(
            map((sdk) => {
              if (!sdk) {
                throw new Error("SDK not available");
              }

              using ref = sdk.take();

              return ref.value.user_crypto_management().migrate_to_key_connector(keyConnectorUrl); // but created here. also, the return disposes the ref
            }),
          ),
```

the promise is created inside the observable, but passed out and holds an invalid reference and tries to access it. We fix this by completely banning unawaited promises from being returned.

The more subtle benefits, as pointed out by the eslint rule:
> - Returning an awaited promise [improves stack trace information](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await#improving_stack_trace).
> - When the return statement is in try...catch, awaiting the promise allows the promise's rejection to be caught instead of leaving the error to the caller.
> - Contrary to popular belief, return await promise; is [at least as fast as directly returning the promise](https://github.com/tc39/proposal-faster-promise-adoption).

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
