### PR TITLE
[PM-38405] Await unawaited promises

### DIFF
--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -1767,7 +1767,7 @@ export default class MainBackground {
     await this.ipcService.init();
     this.badgeService.startListening();
 
-    return new Promise<void>((resolve) => {
+    return await new Promise<void>((resolve) => {
       setTimeout(async () => {
         await this.fullSync(false);
         this.backgroundSyncService.init();

--- a/apps/browser/src/background/nativeMessaging.background.ts
+++ b/apps/browser/src/background/nativeMessaging.background.ts
@@ -100,7 +100,7 @@ export class NativeMessagingBackground {
     this.appId = appId;
     await this.biometricStateService.setFingerprintValidated(false);
 
-    return new Promise<void>((resolve, reject) => {
+    return await new Promise<void>((resolve, reject) => {
       this.port = BrowserApi.connectNative("com.8bit.bitwarden");
 
       this.connecting = true;
@@ -287,7 +287,7 @@ export class NativeMessagingBackground {
       }
     }, MessageNoResponseTimeout);
 
-    return callback;
+    return await callback;
   }
 
   async send(message: Message) {
@@ -391,7 +391,7 @@ export class NativeMessagingBackground {
       messageId: this.messageId++,
     });
 
-    return new Promise((resolve) => {
+    return await new Promise((resolve) => {
       this.secureChannel = {
         publicKey,
         privateKey,

--- a/apps/browser/src/popup/app.component.ts
+++ b/apps/browser/src/popup/app.component.ts
@@ -334,7 +334,7 @@ export class AppComponent implements OnInit, OnDestroy {
       fingerprint: msg.fingerprint,
     });
 
-    return firstValueFrom(dialogRef.closed);
+    return await firstValueFrom(dialogRef.closed);
   }
 
   // Displaying toasts isn't super useful on the popup due to the reloads we do.

--- a/apps/browser/src/popup/services/debounce-navigation.service.ts
+++ b/apps/browser/src/popup/services/debounce-navigation.service.ts
@@ -15,7 +15,7 @@ import { filter, pairwise } from "rxjs/operators";
 export function debounceNavigationGuard(): CanActivateFn {
   return async () => {
     const debounceNavigationService = inject(DebounceNavigationService);
-    return debounceNavigationService.canActivate();
+    return await debounceNavigationService.canActivate();
   };
 }
 

--- a/apps/cli/src/commands/restore.command.ts
+++ b/apps/cli/src/commands/restore.command.ts
@@ -43,9 +43,9 @@ export class RestoreCommand {
     // Determine if restoring from archive or trash
     // When a cipher is archived and deleted, restore from the trash first
     if (cipher.archivedDate && cipher.deletedDate == null) {
-      return this.restoreArchivedCipher(cipher, activeUserId);
+      return await this.restoreArchivedCipher(cipher, activeUserId);
     } else {
-      return this.restoreDeletedCipher(cipher, activeUserId);
+      return await this.restoreDeletedCipher(cipher, activeUserId);
     }
   }
 

--- a/apps/cli/src/key-management/commands/unlock.command.ts
+++ b/apps/cli/src/key-management/commands/unlock.command.ts
@@ -72,7 +72,7 @@ export class UnlockCommand {
 
     await this.encryptedMigrator.runMigrations(userId, password);
 
-    return this.successResponse();
+    return await this.successResponse();
   }
 
   private async setNewSessionKey() {

--- a/apps/cli/src/utils.ts
+++ b/apps/cli/src/utils.ts
@@ -288,5 +288,5 @@ export async function firstValueFromOrNull<T>(
   observable: Observable<T>,
   timeoutMs = 5000,
 ): Promise<T | null> {
-  return firstValueFrom(observable.pipe(timeout({ first: timeoutMs, with: () => of(null) })));
+  return await firstValueFrom(observable.pipe(timeout({ first: timeoutMs, with: () => of(null) })));
 }

--- a/apps/desktop/src/app/accounts/settings-dialog.component.ts
+++ b/apps/desktop/src/app/accounts/settings-dialog.component.ts
@@ -364,28 +364,28 @@ export class SettingsDialogComponent implements OnInit {
 
     this.form.controls.clearClipboard.valueChanges
       .pipe(
-        concatMap(async () => this.saveClearClipboard()),
+        concatMap(async () => await this.saveClearClipboard()),
         takeUntilDestroyed(this.destroyRef),
       )
       .subscribe();
 
     this.form.controls.sshAgentPromptBehavior.valueChanges
       .pipe(
-        concatMap(async () => this.saveSshAgentPromptBehavior()),
+        concatMap(async () => await this.saveSshAgentPromptBehavior()),
         takeUntilDestroyed(this.destroyRef),
       )
       .subscribe();
 
     this.form.controls.theme.valueChanges
       .pipe(
-        concatMap(async () => this.saveTheme()),
+        concatMap(async () => await this.saveTheme()),
         takeUntilDestroyed(this.destroyRef),
       )
       .subscribe();
 
     this.form.controls.locale.valueChanges
       .pipe(
-        concatMap(async () => this.saveLocale()),
+        concatMap(async () => await this.saveLocale()),
         takeUntilDestroyed(this.destroyRef),
       )
       .subscribe();

--- a/apps/desktop/src/app/app.component.ts
+++ b/apps/desktop/src/app/app.component.ts
@@ -659,7 +659,7 @@ export class AppComponent implements OnInit, OnDestroy {
         // Don't create multiple dialogs if this fires multiple times
         if (this.activeSimpleDialog) {
           // Let the caller of this function listen for the dialog to close
-          return firstValueFrom(this.activeSimpleDialog.closed);
+          return await firstValueFrom(this.activeSimpleDialog.closed);
         }
 
         this.activeSimpleDialog = this.dialogService.openSimpleDialogRef({
@@ -679,7 +679,7 @@ export class AppComponent implements OnInit, OnDestroy {
         // Don't create multiple dialogs if this fires multiple times
         if (this.activeSimpleDialog) {
           // Let the caller of this function listen for the dialog to close
-          return firstValueFrom(this.activeSimpleDialog.closed);
+          return await firstValueFrom(this.activeSimpleDialog.closed);
         }
 
         this.activeSimpleDialog = this.dialogService.openSimpleDialogRef({

--- a/apps/desktop/src/app/services/native-messaging-manifest.service.ts
+++ b/apps/desktop/src/app/services/native-messaging-manifest.service.ts
@@ -5,9 +5,9 @@ export class NativeMessagingManifestService {
   constructor() {}
 
   async generate(create: boolean): Promise<Error | null> {
-    return ipc.platform.nativeMessaging.manifests.generate(create);
+    return await ipc.platform.nativeMessaging.manifests.generate(create);
   }
   async generateDuckDuckGo(create: boolean): Promise<Error | null> {
-    return ipc.platform.nativeMessaging.manifests.generateDuckDuckGo(create);
+    return await ipc.platform.nativeMessaging.manifests.generateDuckDuckGo(create);
   }
 }

--- a/apps/desktop/src/key-management/lock/services/desktop-lock-component.service.ts
+++ b/apps/desktop/src/key-management/lock/services/desktop-lock-component.service.ts
@@ -34,7 +34,7 @@ export class DesktopLockComponentService implements LockComponentService {
   }
 
   async isWindowVisible(): Promise<boolean> {
-    return ipc.platform.isWindowVisible();
+    return await ipc.platform.isWindowVisible();
   }
 
   getBiometricsUnlockBtnText(): string {

--- a/apps/desktop/src/main/tools/import/chromium-importer.service.ts
+++ b/apps/desktop/src/main/tools/import/chromium-importer.service.ts
@@ -7,7 +7,7 @@ import { isMacAppStore } from "../../../utils";
 export class ChromiumImporterService {
   constructor() {
     ipcMain.handle("chromium_importer.getMetadata", async () => {
-      return await chromium_importer.getMetadata(isMacAppStore());
+      return chromium_importer.getMetadata(isMacAppStore());
     });
 
     // Used on Mac OS App Store builds to request permissions to browser entries outside the sandbox

--- a/apps/desktop/src/services/biometric-message-handler.service.ts
+++ b/apps/desktop/src/services/biometric-message-handler.service.ts
@@ -212,7 +212,7 @@ export class BiometricMessageHandlerService {
       }
       case BiometricsCommands.GetBiometricsStatus: {
         const status = await this.biometricsService.getBiometricsStatus();
-        return this.send(
+        return await this.send(
           {
             command: BiometricsCommands.GetBiometricsStatus,
             messageId,
@@ -228,7 +228,7 @@ export class BiometricMessageHandlerService {
         if (status == BiometricsStatus.NotEnabledLocally) {
           status = BiometricsStatus.NotEnabledInConnectedDesktopApp;
         }
-        return this.send(
+        return await this.send(
           {
             command: BiometricsCommands.GetBiometricsStatusForUser,
             messageId,

--- a/apps/web/src/app/key-management/key-rotation/user-key-rotation.service.ts
+++ b/apps/web/src/app/key-management/key-rotation/user-key-rotation.service.ts
@@ -306,14 +306,14 @@ export class UserKeyRotationService {
     cryptographicStateParameters: V1CryptographicStateParameters | V2CryptographicStateParameters,
   ): Promise<V2UserCryptographicState> {
     if (cryptographicStateParameters.version === 1) {
-      return this.upgradeV1UserToV2UserAccountKeys(
+      return await this.upgradeV1UserToV2UserAccountKeys(
         userId,
         masterKeyKdfConfig,
         masterKeySalt,
         cryptographicStateParameters as V1CryptographicStateParameters,
       );
     } else {
-      return this.rotateV2UserAccountKeys(
+      return await this.rotateV2UserAccountKeys(
         userId,
         masterKeyKdfConfig,
         masterKeySalt,
@@ -607,7 +607,7 @@ export class UserKeyRotationService {
       masterKeySalt,
       masterKeyKdfConfig,
     );
-    return this.keyService.hashMasterKey(masterPassword, masterKey);
+    return await this.keyService.hashMasterKey(masterPassword, masterKey);
   }
 
   /**

--- a/bitwarden_license/bit-common/src/admin-console/auth-requests/organization-auth-request.service.ts
+++ b/bitwarden_license/bit-common/src/admin-console/auth-requests/organization-auth-request.service.ts
@@ -35,7 +35,7 @@ export class OrganizationAuthRequestService {
   async listPendingRequestsWithFingerprint(
     organizationId: string,
   ): Promise<PendingAuthRequestWithFingerprintView[]> {
-    return Promise.all(
+    return await Promise.all(
       ((await this.listPendingRequests(organizationId)) ?? []).map(
         async (r) => await PendingAuthRequestWithFingerprintView.fromView(r, this.keyService),
       ),

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -88,6 +88,7 @@ export default tseslint.config(
       "@typescript-eslint/explicit-member-accessibility": ["error", { accessibility: "no-public" }],
       "@typescript-eslint/no-explicit-any": "off", // TODO: This should be re-enabled
       "@typescript-eslint/no-floating-promises": "error",
+      "@typescript-eslint/return-await": ["error", "always"],
       "@typescript-eslint/no-misused-promises": ["error", { checksVoidReturn: false }],
       "@typescript-eslint/no-this-alias": ["error", { allowedNames: ["self"] }],
       "@typescript-eslint/no-unused-expressions": ["error", { allowTernary: true }],

--- a/libs/angular/src/services/jslib-services.module.ts
+++ b/libs/angular/src/services/jslib-services.module.ts
@@ -510,7 +510,7 @@ const safeProviders: SafeProvider[] = [
     useFactory:
       (messagingService: MessagingServiceAbstraction) =>
       async (logoutReason: LogoutReason, userId?: string) => {
-        return Promise.resolve(
+        return await Promise.resolve(
           messagingService.send("logout", { logoutReason: logoutReason, userId: userId }),
         );
       },

--- a/libs/common/src/key-management/encrypted-migrator/default-encrypted-migrator.ts
+++ b/libs/common/src/key-management/encrypted-migrator/default-encrypted-migrator.ts
@@ -121,7 +121,7 @@ export class DefaultEncryptedMigrator implements EncryptedMigrator {
     assertNonNullish(userId, "userId");
 
     const migrationRequirements = await Promise.all(
-      this.migrations.map(async ({ migration }) => migration.needsMigration(userId)),
+      this.migrations.map(async ({ migration }) => await migration.needsMigration(userId)),
     );
 
     if (migrationRequirements.includes("needsMigrationWithMasterPassword")) {

--- a/libs/common/src/key-management/kdf/change-kdf-api.service.ts
+++ b/libs/common/src/key-management/kdf/change-kdf-api.service.ts
@@ -10,6 +10,6 @@ export class DefaultChangeKdfApiService implements ChangeKdfApiService {
   constructor(private apiService: ApiService) {}
 
   async updateUserKdfParams(request: KdfRequest): Promise<void> {
-    return this.apiService.send("POST", "/accounts/kdf", request, true, false);
+    return await this.apiService.send("POST", "/accounts/kdf", request, true, false);
   }
 }

--- a/libs/common/src/key-management/pin/pin.service.implementation.ts
+++ b/libs/common/src/key-management/pin/pin.service.implementation.ts
@@ -64,7 +64,7 @@ export class PinService implements PinServiceAbstraction {
       this.pinStateService.userKeyEncryptedPin$(userId),
       "userKeyEncryptedPin",
     );
-    return this.encryptService.decryptString(userKeyEncryptedPin, userKey);
+    return await this.encryptService.decryptString(userKeyEncryptedPin, userKey);
   }
 
   async setPin(pin: string, pinLockType: PinLockType, userId: UserId): Promise<void> {

--- a/libs/common/src/key-management/shared-unlock/default-shared-unlock-follower.service.ts
+++ b/libs/common/src/key-management/shared-unlock/default-shared-unlock-follower.service.ts
@@ -61,11 +61,13 @@ export class DefaultSharedUnlockFollowerService implements SharedUnlockFollowerS
       });
     });
 
-    this.unlockService.registerOnUnlockAction(async (userId, userKey) =>
-      this.onUnlock(userId, userKey),
+    this.unlockService.registerOnUnlockAction(
+      async (userId, userKey) => await this.onUnlock(userId, userKey),
     );
-    pollForUnlockEvents(this.keyService, this.accountService, async (userId, userKey) =>
-      this.onUnlock(userId, userKey),
+    pollForUnlockEvents(
+      this.keyService,
+      this.accountService,
+      async (userId, userKey) => await this.onUnlock(userId, userKey),
     );
   }
 

--- a/libs/common/src/key-management/shared-unlock/default-shared-unlock-leader.service.ts
+++ b/libs/common/src/key-management/shared-unlock/default-shared-unlock-leader.service.ts
@@ -60,11 +60,13 @@ export class DefaultSharedUnlockLeaderService implements SharedUnlockLeaderServi
       });
     });
 
-    this.unlockService.registerOnUnlockAction(async (userId, userKey) =>
-      this.onUnlock(userId, userKey),
+    this.unlockService.registerOnUnlockAction(
+      async (userId, userKey) => await this.onUnlock(userId, userKey),
     );
-    pollForUnlockEvents(this.keyService, this.accountService, async (userId, userKey) =>
-      this.onUnlock(userId, userKey),
+    pollForUnlockEvents(
+      this.keyService,
+      this.accountService,
+      async (userId, userKey) => await this.onUnlock(userId, userKey),
     );
   }
 

--- a/libs/common/src/key-management/state-bridge.ts
+++ b/libs/common/src/key-management/state-bridge.ts
@@ -44,7 +44,7 @@ async function waitForStateValue<T>(
   keyDefinition: UserKeyDefinition<T>,
   expectedValue: T | null,
 ): Promise<T | null> {
-  return firstValueFrom(
+  return await firstValueFrom(
     race(
       stateProvider
         .getUserState$(keyDefinition, userId)

--- a/libs/common/src/services/api.service.spec.ts
+++ b/libs/common/src/services/api.service.spec.ts
@@ -1274,7 +1274,7 @@ describe("ApiService", () => {
 
     it("executes a registered middleware before sending the request", async () => {
       const middleware = jest.fn<Promise<Response>, [Request, (req: Request) => Promise<Response>]>(
-        async (req, next) => next(req),
+        async (req, next) => await next(req),
       );
       sut.addMiddleware(middleware);
 
@@ -1303,13 +1303,13 @@ describe("ApiService", () => {
         .fn<Promise<Response>, [Request, (req: Request) => Promise<Response>]>()
         .mockImplementation(async (req, next) => {
           callOrder.push(1);
-          return next(req);
+          return await next(req);
         });
       const middleware2 = jest
         .fn<Promise<Response>, [Request, (req: Request) => Promise<Response>]>()
         .mockImplementation(async (req, next) => {
           callOrder.push(2);
-          return next(req);
+          return await next(req);
         });
       sut.addMiddleware(middleware1);
       sut.addMiddleware(middleware2);

--- a/libs/common/src/services/api.service.ts
+++ b/libs/common/src/services/api.service.ts
@@ -224,7 +224,7 @@ export class ApiService implements ApiServiceAbstraction {
       }
     }
 
-    return Promise.reject(new ErrorResponse(responseJson, response.status, true));
+    return await Promise.reject(new ErrorResponse(responseJson, response.status, true));
   }
 
   async refreshIdentityToken(userId: UserId | null = null): Promise<any> {
@@ -341,11 +341,11 @@ export class ApiService implements ApiServiceAbstraction {
   }
 
   async deleteSsoUser(organizationId: string): Promise<void> {
-    return this.send("DELETE", "/accounts/sso/" + organizationId, null, true, false);
+    return await this.send("DELETE", "/accounts/sso/" + organizationId, null, true, false);
   }
 
   async getSsoUserIdentifier(): Promise<string> {
-    return this.send("GET", "/accounts/sso/user-identifier", null, true, true);
+    return await this.send("GET", "/accounts/sso/user-identifier", null, true, true);
   }
 
   async postUserApiKey(id: string, request: SecretVerificationRequest): Promise<ApiKeyResponse> {
@@ -636,10 +636,16 @@ export class ApiService implements ApiServiceAbstraction {
         body: data,
         headers,
       });
-      return this.nativeXMLHttpRequest(request, options.onProgress);
+      return await this.nativeXMLHttpRequest(request, options.onProgress);
     }
 
-    return this.send("POST", "/ciphers/" + id + "/attachment/" + attachmentId, data, true, false);
+    return await this.send(
+      "POST",
+      "/ciphers/" + id + "/attachment/" + attachmentId,
+      data,
+      true,
+      false,
+    );
   }
 
   // Collections APIs
@@ -842,7 +848,7 @@ export class ApiService implements ApiServiceAbstraction {
   }
 
   async deleteOrganizationConnection(id: string): Promise<void> {
-    return this.send("DELETE", "/organizations/connections/" + id, null, true, false);
+    return await this.send("DELETE", "/organizations/connections/" + id, null, true, false);
   }
 
   // Provider User APIs
@@ -1212,7 +1218,7 @@ export class ApiService implements ApiServiceAbstraction {
       }),
     );
     if (response.status !== 200) {
-      return Promise.reject("Event post failed.");
+      return await Promise.reject("Event post failed.");
     }
   }
 
@@ -1259,7 +1265,7 @@ export class ApiService implements ApiServiceAbstraction {
 
     if (response.status !== HttpStatusCode.Ok) {
       const error = await this.handleApiRequestError(response, true);
-      return Promise.reject(error);
+      return await Promise.reject(error);
     }
 
     return new KeyConnectorUserKeyResponse(await response.json());
@@ -1290,7 +1296,7 @@ export class ApiService implements ApiServiceAbstraction {
 
     if (response.status !== HttpStatusCode.Ok) {
       const error = await this.handleApiRequestError(response, true);
-      return Promise.reject(error);
+      return await Promise.reject(error);
     }
   }
 
@@ -1308,7 +1314,7 @@ export class ApiService implements ApiServiceAbstraction {
 
     if (response.status !== HttpStatusCode.Ok) {
       const error = await this.handleApiRequestError(response, true);
-      return Promise.reject(error);
+      return await Promise.reject(error);
     }
   }
 
@@ -1336,7 +1342,7 @@ export class ApiService implements ApiServiceAbstraction {
     await this.applyPlatformHeaders(request.headers);
 
     const pipeline = buildFetchPipeline(this.middlewares, (req) => this.nativeFetch(req));
-    return pipeline(request);
+    return await pipeline(request);
   }
 
   nativeFetch(request: Request): Promise<Response> {
@@ -1423,7 +1429,7 @@ export class ApiService implements ApiServiceAbstraction {
       return new SsoPreValidateResponse(body);
     } else {
       const error = await this.handleApiRequestError(response, false);
-      return Promise.reject(error);
+      return await Promise.reject(error);
     }
   }
 
@@ -1578,7 +1584,7 @@ export class ApiService implements ApiServiceAbstraction {
       return refreshedTokens.accessToken;
     } else {
       const error = await this.handleTokenRefreshRequestError(response);
-      return Promise.reject(error);
+      return await Promise.reject(error);
     }
   }
 
@@ -1700,7 +1706,7 @@ export class ApiService implements ApiServiceAbstraction {
       return { blob, fileName };
     } else if (!responseIsSuccess && response.status !== HttpStatusCode.NoContent) {
       const error = await this.handleApiRequestError(response, userIdMakingRequest != null);
-      return Promise.reject(error);
+      return await Promise.reject(error);
     }
   }
 

--- a/libs/common/src/services/audit.service.ts
+++ b/libs/common/src/services/audit.service.ts
@@ -43,7 +43,7 @@ export class AuditService implements AuditServiceAbstraction {
   }
 
   async passwordLeaked(password: string): Promise<number> {
-    return new Promise<number>((resolve, reject) => {
+    return await new Promise<number>((resolve, reject) => {
       this.passwordLeakedSubject.next({ password, resolve, reject });
     });
   }
@@ -69,6 +69,6 @@ export class AuditService implements AuditServiceAbstraction {
   }
 
   async breachedAccounts(username: string): Promise<BreachAccountResponse[]> {
-    return this.hibpApiService.getHibpBreach(username);
+    return await this.hibpApiService.getHibpBreach(username);
   }
 }

--- a/libs/key-management-ui/src/key-rotation/key-rotation-dialog.component.ts
+++ b/libs/key-management-ui/src/key-rotation/key-rotation-dialog.component.ts
@@ -144,11 +144,14 @@ export class KeyRotationDialogComponent {
   ): Promise<boolean> {
     switch (encryptionType) {
       case "masterPassword":
-        return this.keyRotationDialogService.rotateKeys(this.form.value.masterPassword!, userId);
+        return await this.keyRotationDialogService.rotateKeys(
+          this.form.value.masterPassword!,
+          userId,
+        );
       case "keyConnector":
-        return this.keyRotationDialogService.rotateKeysForKeyConnector(userId);
+        return await this.keyRotationDialogService.rotateKeysForKeyConnector(userId);
       case "TDE":
-        return this.keyRotationDialogService.rotateKeysForTDE(userId);
+        return await this.keyRotationDialogService.rotateKeysForTDE(userId);
     }
   }
 

--- a/libs/key-management/src/key.service.ts
+++ b/libs/key-management/src/key.service.ts
@@ -190,7 +190,7 @@ export class DefaultKeyService implements KeyServiceAbstraction {
     }
 
     const newUserKey = await this.keyGenerationService.createKey(512);
-    return this.buildProtectedSymmetricKey(masterKey, newUserKey);
+    return await this.buildProtectedSymmetricKey(masterKey, newUserKey);
   }
 
   /**
@@ -416,7 +416,7 @@ export class DefaultKeyService implements KeyServiceAbstraction {
       32,
       "sha256",
     );
-    return this.hashPhrase(userFingerprint);
+    return await this.hashPhrase(userFingerprint);
   }
 
   async makeKeyPair(key: SymmetricCryptoKey): Promise<[string, EncString]> {

--- a/libs/node/src/services/node-crypto-function.service.ts
+++ b/libs/node/src/services/node-crypto-function.service.ts
@@ -36,7 +36,7 @@ export class NodeCryptoFunctionService implements CryptoFunctionService {
   ): Promise<Uint8Array> {
     const saltArr = typeof salt === "string" ? Utils.fromUtf8ToArray(salt) : salt;
     const prk = await this.hmac(ikm, saltArr, algorithm);
-    return this.hkdfExpand(prk, info, outputByteSize, algorithm);
+    return await this.hkdfExpand(prk, info, outputByteSize, algorithm);
   }
 
   // ref: https://tools.ietf.org/html/rfc5869

--- a/libs/user-crypto-management/src/user-key-rotation.service.ts
+++ b/libs/user-crypto-management/src/user-key-rotation.service.ts
@@ -131,7 +131,7 @@ export class DefaultUserKeyRotationService implements UserKeyRotationService {
     );
     this.logService.info("result", { emergencyAccessV1Memberships, organizationV1Memberships });
 
-    return this.userCryptoDialogService.verifyTrust(
+    return await this.userCryptoDialogService.verifyTrust(
       organizationV1Memberships,
       emergencyAccessV1Memberships,
     );


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
Jira Bug: https://bitwarden.atlassian.net/browse/PM-38405
Tracking PR: https://github.com/bitwarden/clients/pull/20981

Note: This PR is split per team ownership to keep it reviewable.

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
We want to enable the return-await eslint rule. Currently, there is a pattern of unawaited promises being returned which is causing production bugs as explained in more detail below. To do this, we first migrate all teams. The migration has been performed automatically with eslint --fix. There aren o other changes other than adding await to the unawaited promises.

### Specifically Bugged Behavior

Returning unawaited promises is currently allowing unexpected bugs to appear. Specifically in this example:

```ts
        await firstValueFrom( // Promise on ref.value gets awaited here
          this.sdkService.userClient$(userId).pipe(
            map((sdk) => {
              if (!sdk) {
                throw new Error("SDK not available");
              }

              using ref = sdk.take();

              return ref.value.user_crypto_management().migrate_to_key_connector(keyConnectorUrl); // but created here. also, the return disposes the ref
            }),
          ),
```

the promise is created inside the observable, but passed out and holds an invalid reference and tries to access it. We fix this by completely banning unawaited promises from being returned.

The more subtle benefits, as pointed out by the eslint rule:
> - Returning an awaited promise [improves stack trace information](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await#improving_stack_trace).
> - When the return statement is in try...catch, awaiting the promise allows the promise's rejection to be caught instead of leaving the error to the caller.
> - Contrary to popular belief, return await promise; is [at least as fast as directly returning the promise](https://github.com/tc39/proposal-faster-promise-adoption).

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
