### PR TITLE
[PM-38405] Await unawaited promises

### DIFF
--- a/apps/browser/src/platform/badge/badge-browser-api.ts
+++ b/apps/browser/src/platform/badge/badge-browser-api.ts
@@ -131,7 +131,7 @@ export class DefaultBadgeBrowserApi implements BadgeBrowserApi {
     this.createdOrUpdatedTabEvents$,
     this.createdOrUpdatedTabEvents$.pipe(
       concatMap(async () => {
-        return this.getActiveTabs();
+        return await this.getActiveTabs();
       }),
       pairwise(),
       map(([previousTabs, currentTabs]) => {
@@ -154,7 +154,7 @@ export class DefaultBadgeBrowserApi implements BadgeBrowserApi {
 
   activeTabs$ = this.tabEvents$.pipe(
     concatMap(async () => {
-      return this.getActiveTabs();
+      return await this.getActiveTabs();
     }),
   );
 

--- a/apps/browser/src/platform/browser/browser-api.register-content-scripts-polyfill.ts
+++ b/apps/browser/src/platform/browser/browser-api.register-content-scripts-polyfill.ts
@@ -30,7 +30,7 @@ export async function registerContentScriptsPolyfill(
     registerContentScripts = buildRegisterContentScriptsPolyfill();
   }
 
-  return registerContentScripts(contentScriptOptions, callback);
+  return await registerContentScripts(contentScriptOptions, callback);
 }
 
 function buildRegisterContentScriptsPolyfill() {
@@ -187,19 +187,19 @@ function buildRegisterContentScriptsPolyfill() {
 
         if (gotScripting) {
           if ("file" in content) {
-            return chrome.scripting.insertCSS({
+            return await chrome.scripting.insertCSS({
               target: createTarget(tabId, frameId, allFrames),
               files: [content.file],
             });
           } else {
-            return chrome.scripting.insertCSS({
+            return await chrome.scripting.insertCSS({
               target: createTarget(tabId, frameId, allFrames),
               css: content.code,
             });
           }
         }
 
-        return chromeProxy.tabs.insertCSS(tabId, {
+        return await chromeProxy.tabs.insertCSS(tabId, {
           ...content,
           matchAboutBlank,
           allFrames,
@@ -293,8 +293,9 @@ function buildRegisterContentScriptsPolyfill() {
   ) {
     const targets = castArray(where);
     await Promise.all(
-      targets.map(async (target) =>
-        injectContentScriptInSpecificTarget(castAllFramesTarget(target), scripts, options),
+      targets.map(
+        async (target) =>
+          await injectContentScriptInSpecificTarget(castAllFramesTarget(target), scripts, options),
       ),
     );
   }
@@ -349,7 +350,7 @@ function buildRegisterContentScriptsPolyfill() {
   }
 
   async function isOriginPermitted(url: string) {
-    return chromeProxy.permissions.contains({
+    return await chromeProxy.permissions.contains({
       origins: [new URL(url).origin + "/*"],
     });
   }

--- a/apps/browser/src/platform/browser/browser-api.ts
+++ b/apps/browser/src/platform/browser/browser-api.ts
@@ -113,7 +113,7 @@ export class BrowserApi {
    * @returns A promise that resolves to an array of browser windows.
    */
   static async getWindows(): Promise<chrome.windows.Window[]> {
-    return new Promise((resolve) => chrome.windows.getAll({ populate: true }, resolve));
+    return await new Promise((resolve) => chrome.windows.getAll({ populate: true }, resolve));
   }
 
   /**
@@ -123,7 +123,7 @@ export class BrowserApi {
    */
   static async getWindow(windowId?: number): Promise<chrome.windows.Window> {
     if (!windowId) {
-      return BrowserApi.getCurrentWindow();
+      return await BrowserApi.getCurrentWindow();
     }
 
     return await BrowserApi.getWindowById(windowId);
@@ -133,7 +133,7 @@ export class BrowserApi {
    * Gets the currently active browser window.
    */
   static async getCurrentWindow(): Promise<chrome.windows.Window> {
-    return new Promise((resolve) => chrome.windows.getCurrent({ populate: true }, resolve));
+    return await new Promise((resolve) => chrome.windows.getCurrent({ populate: true }, resolve));
   }
 
   /**
@@ -142,11 +142,13 @@ export class BrowserApi {
    * @param windowId - The id of the window to get.
    */
   static async getWindowById(windowId: number): Promise<chrome.windows.Window> {
-    return new Promise((resolve) => chrome.windows.get(windowId, { populate: true }, resolve));
+    return await new Promise((resolve) =>
+      chrome.windows.get(windowId, { populate: true }, resolve),
+    );
   }
 
   static async createWindow(options: chrome.windows.CreateData): Promise<chrome.windows.Window> {
-    return new Promise((resolve) => {
+    return await new Promise((resolve) => {
       chrome.windows.create(options, async (newWindow) => {
         if (!BrowserApi.isSafariApi) {
           return resolve(newWindow);
@@ -181,7 +183,7 @@ export class BrowserApi {
    * @param windowId - The id of the window to remove.
    */
   static async removeWindow(windowId: number): Promise<void> {
-    return new Promise((resolve) => chrome.windows.remove(windowId, () => resolve()));
+    return await new Promise((resolve) => chrome.windows.remove(windowId, () => resolve()));
   }
 
   /**
@@ -194,7 +196,7 @@ export class BrowserApi {
     windowId: number,
     options: chrome.windows.UpdateInfo,
   ): Promise<void> {
-    return new Promise((resolve) =>
+    return await new Promise((resolve) =>
       chrome.windows.update(windowId, options, () => {
         resolve();
       }),
@@ -252,7 +254,7 @@ export class BrowserApi {
       return await chrome.tabs.get(tabId);
     }
 
-    return new Promise((resolve) =>
+    return await new Promise((resolve) =>
       chrome.tabs.get(tabId, (tab) => {
         resolve(tab);
       }),
@@ -280,7 +282,7 @@ export class BrowserApi {
       return await chrome.tabs.getCurrent();
     }
 
-    return new Promise((resolve) =>
+    return await new Promise((resolve) =>
       chrome.tabs.getCurrent((tab) => {
         resolve(tab);
       }),
@@ -329,7 +331,7 @@ export class BrowserApi {
   }
 
   static async tabsQuery(options: chrome.tabs.QueryInfo): Promise<chrome.tabs.Tab[]> {
-    return new Promise((resolve) => {
+    return await new Promise((resolve) => {
       chrome.tabs.query(options, (tabs) => {
         resolve(tabs);
       });
@@ -416,7 +418,7 @@ export class BrowserApi {
       return;
     }
 
-    return new Promise<TResponse>((resolve, reject) => {
+    return await new Promise<TResponse>((resolve, reject) => {
       chrome.tabs.sendMessage(tab.id, obj, options, (response) => {
         if (chrome.runtime.lastError && rejectOnError) {
           // Some error happened
@@ -572,7 +574,7 @@ export class BrowserApi {
   static async getFrameDetails(
     details: chrome.webNavigation.GetFrameDetails,
   ): Promise<chrome.webNavigation.GetFrameResultDetails> {
-    return new Promise((resolve) => chrome.webNavigation.getFrame(details, resolve));
+    return await new Promise((resolve) => chrome.webNavigation.getFrame(details, resolve));
   }
 
   /**
@@ -583,7 +585,7 @@ export class BrowserApi {
   static async getAllFrameDetails(
     tabId: chrome.tabs.Tab["id"],
   ): Promise<chrome.webNavigation.GetAllFrameResultDetails[]> {
-    return new Promise((resolve) => chrome.webNavigation.getAllFrames({ tabId }, resolve));
+    return await new Promise((resolve) => chrome.webNavigation.getAllFrames({ tabId }, resolve));
   }
 
   // Keep track of all the events registered in a Safari popup so we can remove
@@ -802,7 +804,7 @@ export class BrowserApi {
   static async permissionsGranted(
     permissions: chrome.runtime.ManifestPermissions[],
   ): Promise<boolean> {
-    return new Promise((resolve) =>
+    return await new Promise((resolve) =>
       chrome.permissions.contains({ permissions }, (result) => resolve(result)),
     );
   }

--- a/apps/browser/src/platform/browser/browser-popup-utils.ts
+++ b/apps/browser/src/platform/browser/browser-popup-utils.ts
@@ -114,7 +114,7 @@ export default class BrowserPopupUtils {
     },
   ) {
     const { delay, containerSelector } = options;
-    return new Promise<void>((resolve) =>
+    return await new Promise<void>((resolve) =>
       win.setTimeout(() => {
         const container = win.document.querySelector(containerSelector);
         if (!isNaN(scrollYAmount) && container) {

--- a/apps/browser/src/platform/popup/view-cache/popup-router-cache.service.ts
+++ b/apps/browser/src/platform/popup/view-cache/popup-router-cache.service.ts
@@ -79,7 +79,7 @@ export class PopupRouterCacheService {
   }
 
   async setHistory(state: RouteHistoryCacheState[]): Promise<RouteHistoryCacheState[]> {
-    return this.state.update(() => state);
+    return await this.state.update(() => state);
   }
 
   /** Get the last item from the history stack, or `null` if empty */

--- a/apps/browser/src/platform/services/abstractions/abstract-chrome-storage-api.service.ts
+++ b/apps/browser/src/platform/services/abstractions/abstract-chrome-storage-api.service.ts
@@ -76,7 +76,7 @@ export default abstract class AbstractChromeStorageService
   }
 
   async get<T>(key: string): Promise<T> {
-    return new Promise((resolve, reject) => {
+    return await new Promise((resolve, reject) => {
       this.chromeStorageApi.get(key, (obj) => {
         if (chrome.runtime.lastError) {
           return reject(chrome.runtime.lastError);
@@ -100,11 +100,11 @@ export default abstract class AbstractChromeStorageService
 
     if (obj == null) {
       // Safari does not support set of null values
-      return this.remove(key);
+      return await this.remove(key);
     }
 
     const keyedObj = { [key]: obj };
-    return new Promise<void>((resolve, reject) => {
+    return await new Promise<void>((resolve, reject) => {
       this.chromeStorageApi.set(keyedObj, () => {
         if (chrome.runtime.lastError) {
           return reject(chrome.runtime.lastError);
@@ -116,7 +116,7 @@ export default abstract class AbstractChromeStorageService
   }
 
   async remove(key: string): Promise<void> {
-    return new Promise<void>((resolve, reject) => {
+    return await new Promise<void>((resolve, reject) => {
       this.chromeStorageApi.remove(key, () => {
         if (chrome.runtime.lastError) {
           return reject(chrome.runtime.lastError);

--- a/apps/browser/src/platform/services/browser-local-storage.service.ts
+++ b/apps/browser/src/platform/services/browser-local-storage.service.ts
@@ -26,7 +26,7 @@ export default class BrowserLocalStorageService extends AbstractChromeStorageSer
   async getKeys(): Promise<string[]> {
     // getKeys function is only available since Chrome 130
     if ("getKeys" in this.chromeStorageApi) {
-      return this.chromeStorageApi.getKeys();
+      return await this.chromeStorageApi.getKeys();
     }
     return [];
   }
@@ -61,7 +61,7 @@ export default class BrowserLocalStorageService extends AbstractChromeStorageSer
       return null;
     }
 
-    return new Promise<{ [key: string]: unknown }>((resolve) => {
+    return await new Promise<{ [key: string]: unknown }>((resolve) => {
       this.chromeStorageApi.get(key, (store) => {
         if (chrome.runtime.lastError) {
           this.logService.warning(`Failed to get value for key '${key}'`, chrome.runtime.lastError);

--- a/apps/browser/src/platform/services/platform-utils/browser-platform-utils.service.ts
+++ b/apps/browser/src/platform/services/platform-utils/browser-platform-utils.service.ts
@@ -150,11 +150,11 @@ export abstract class BrowserPlatformUtilsService implements PlatformUtilsServic
   }
 
   async isPopupOpen(): Promise<boolean> {
-    return BrowserApi.isPopupOpen();
+    return await BrowserApi.isPopupOpen();
   }
 
   async isAnyViewFocused(): Promise<boolean> {
-    return BrowserApi.isAnyViewFocused();
+    return await BrowserApi.isAnyViewFocused();
   }
 
   lockTimeout(): number {

--- a/apps/browser/src/platform/services/popup-view-cache-background.service.ts
+++ b/apps/browser/src/platform/services/popup-view-cache-background.service.ts
@@ -109,14 +109,15 @@ export class PopupViewCacheBackgroundService {
     this.messageListener
       .messages$(SAVE_VIEW_CACHE_COMMAND)
       .pipe(
-        concatMap(async ({ key, value, options }) =>
-          this.popupViewCacheState.update((state) => ({
-            ...state,
-            [key]: {
-              value,
-              options,
-            },
-          })),
+        concatMap(
+          async ({ key, value, options }) =>
+            await this.popupViewCacheState.update((state) => ({
+              ...state,
+              [key]: {
+                value,
+                options,
+              },
+            })),
         ),
       )
       .subscribe();
@@ -188,7 +189,7 @@ export class PopupViewCacheBackgroundService {
   }
 
   async clearState() {
-    return Promise.all([
+    return await Promise.all([
       this.popupViewCacheState.update(() => ({}), { shouldUpdate: this.objNotEmpty }),
       this.popupRouteHistoryState.update(() => [], { shouldUpdate: this.objNotEmpty }),
     ]);

--- a/apps/browser/src/platform/services/task-scheduler/browser-task-scheduler.service.ts
+++ b/apps/browser/src/platform/services/task-scheduler/browser-task-scheduler.service.ts
@@ -351,10 +351,10 @@ export class BrowserTaskSchedulerServiceImplementation
    */
   private async clearAlarm(alarmName: string): Promise<boolean> {
     if (this.isNonChromeEnvironment()) {
-      return browser.alarms.clear(alarmName);
+      return await browser.alarms.clear(alarmName);
     }
 
-    return new Promise((resolve) => chrome.alarms.clear(alarmName, resolve));
+    return await new Promise((resolve) => chrome.alarms.clear(alarmName, resolve));
   }
 
   /**
@@ -380,10 +380,10 @@ export class BrowserTaskSchedulerServiceImplementation
     createInfo: chrome.alarms.AlarmCreateInfo,
   ): Promise<void> {
     if (this.isNonChromeEnvironment()) {
-      return browser.alarms.create(alarmName, createInfo);
+      return await browser.alarms.create(alarmName, createInfo);
     }
 
-    return new Promise((resolve) => chrome.alarms.create(alarmName, createInfo, resolve));
+    return await new Promise((resolve) => chrome.alarms.create(alarmName, createInfo, resolve));
   }
 
   /**

--- a/apps/browser/src/platform/system-notifications/browser-system-notification.service.ts
+++ b/apps/browser/src/platform/system-notifications/browser-system-notification.service.ts
@@ -43,7 +43,7 @@ export class BrowserSystemNotificationService implements SystemNotificationsServ
   }
 
   async create(createInfo: SystemNotificationCreateInfo): Promise<string> {
-    return new Promise<string>((resolve) => {
+    return await new Promise<string>((resolve) => {
       const deviceType: DeviceType = this.platformUtilsService.getDevice();
 
       const options: chrome.notifications.NotificationCreateOptions = {

--- a/apps/cli/src/platform/services/lowdb-storage.service.ts
+++ b/apps/cli/src/platform/services/lowdb-storage.service.ts
@@ -117,7 +117,7 @@ export class LowdbStorageService implements AbstractStorageService {
 
   async get<T>(key: string): Promise<T> {
     await this.waitForReady();
-    return this.lockDbFile(() => {
+    return await this.lockDbFile(() => {
       this.readForNoCache();
       const val = this.db.get(key).value();
       this.logService.debug(`Successfully read ${key} from db`);
@@ -134,7 +134,7 @@ export class LowdbStorageService implements AbstractStorageService {
 
   async save(key: string, obj: any): Promise<void> {
     await this.waitForReady();
-    return this.lockDbFile(() => {
+    return await this.lockDbFile(() => {
       this.readForNoCache();
       // FIXME: Verify that this floating promise is intentional. If it is, add an explanatory comment and ensure there is proper error handling.
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
@@ -147,7 +147,7 @@ export class LowdbStorageService implements AbstractStorageService {
 
   async remove(key: string): Promise<void> {
     await this.waitForReady();
-    return this.lockDbFile(() => {
+    return await this.lockDbFile(() => {
       this.readForNoCache();
       // FIXME: Verify that this floating promise is intentional. If it is, add an explanatory comment and ensure there is proper error handling.
       // eslint-disable-next-line @typescript-eslint/no-floating-promises

--- a/apps/cli/src/platform/services/node-api.service.ts
+++ b/apps/cli/src/platform/services/node-api.service.ts
@@ -52,7 +52,7 @@ export class NodeApiService extends ApiService {
       const { HttpsProxyAgent } = await import("https-proxy-agent");
       (request as any).agent = new HttpsProxyAgent(proxy);
     }
-    return fetch(request);
+    return await fetch(request);
   }
 
   /** XMLHttpRequest is not supported in Node.js, fallback to fetch */

--- a/apps/cli/src/platform/services/node-env-secure-storage.service.ts
+++ b/apps/cli/src/platform/services/node-env-secure-storage.service.ts
@@ -41,7 +41,7 @@ export class NodeEnvSecureStorageService implements AbstractStorageService {
 
   async save(key: string, obj: any): Promise<void> {
     if (obj == null) {
-      return this.remove(key);
+      return await this.remove(key);
     }
 
     if (obj !== null && typeof obj !== "string") {

--- a/apps/desktop/src/platform/services/i18n.main.service.ts
+++ b/apps/desktop/src/platform/services/i18n.main.service.ts
@@ -19,8 +19,9 @@ export class I18nMainService extends BaseI18nService {
       globalStateProvider,
     );
 
-    ipcMain.handle("getLanguageFile", async (event, formattedLocale: string) =>
-      this.readLanguageFile(formattedLocale),
+    ipcMain.handle(
+      "getLanguageFile",
+      async (event, formattedLocale: string) => await this.readLanguageFile(formattedLocale),
     );
 
     // Please leave 'en' where it is, as it's our fallback language in case no translation can be found

--- a/apps/desktop/src/platform/services/server-communication-config/default-server-communication-config.service.ts
+++ b/apps/desktop/src/platform/services/server-communication-config/default-server-communication-config.service.ts
@@ -68,7 +68,7 @@ export class DefaultServerCommunicationConfigService implements ServerCommunicat
   }
 
   async getCookies(hostname: string): Promise<Array<[string, string]>> {
-    return this.client.cookies(hostname);
+    return await this.client.cookies(hostname);
   }
 
   async acquireCookie(url: string): Promise<void> {
@@ -103,7 +103,7 @@ export class DefaultServerCommunicationConfigService implements ServerCommunicat
 
       await this.acquireCookie(hostname);
       // Retry with original request (follow redirect mode, cookies now in session)
-      return next(request);
+      return await next(request);
     };
   }
 }

--- a/apps/desktop/src/platform/services/server-communication-config/server-communication-config-platform-api.service.ts
+++ b/apps/desktop/src/platform/services/server-communication-config/server-communication-config-platform-api.service.ts
@@ -64,7 +64,7 @@ export class ServerCommunicationConfigPlatformApiService implements ServerCommun
         this.logService.info(
           "Cookie acquisition already in progress for hostname, returning existing promise",
         );
-        return this.pendingPromise;
+        return await this.pendingPromise;
       }
       // Different hostname - cancel previous and start new
       this.logService.warning("Cancelling previous cookie acquisition for different hostname");
@@ -77,7 +77,7 @@ export class ServerCommunicationConfigPlatformApiService implements ServerCommun
 
     this.pendingHostname = vaultUrl;
     this.pendingPromise = this.runAcquisitionFlow(vaultUrl, url, normalizedVaultUrl);
-    return this.pendingPromise;
+    return await this.pendingPromise;
   }
 
   /**

--- a/apps/desktop/src/platform/services/server-communication-config/server-communication-config.repository.ts
+++ b/apps/desktop/src/platform/services/server-communication-config/server-communication-config.repository.ts
@@ -31,7 +31,7 @@ export class ServerCommunicationConfigRepository implements SdkRepository {
   }
 
   async get(hostname: string): Promise<ServerCommunicationConfig | undefined> {
-    return firstValueFrom(this.get$(hostname));
+    return await firstValueFrom(this.get$(hostname));
   }
 
   /**

--- a/apps/desktop/src/platform/services/sso-localhost-callback.service.ts
+++ b/apps/desktop/src/platform/services/sso-localhost-callback.service.ts
@@ -33,7 +33,7 @@ export class SSOLocalhostCallbackService {
           await this.closeCurrentServer();
         }
 
-        return this.openSsoPrompt(codeChallenge, state, email, orgSsoIdentifier).then(
+        return await this.openSsoPrompt(codeChallenge, state, email, orgSsoIdentifier).then(
           ({ ssoCode, recvState }) => {
             this.messagingService.send("ssoCallback", {
               code: ssoCode,
@@ -51,7 +51,7 @@ export class SSOLocalhostCallbackService {
       return;
     }
 
-    return new Promise<void>((resolve) => {
+    return await new Promise<void>((resolve) => {
       this.currentServer!.close(() => {
         this.currentServer = null;
         resolve();
@@ -67,7 +67,7 @@ export class SSOLocalhostCallbackService {
   ): Promise<{ ssoCode: string; recvState: string }> {
     const env = await firstValueFrom(this.environmentService.environment$);
 
-    return new Promise((resolve, reject) => {
+    return await new Promise((resolve, reject) => {
       const callbackServer = http.createServer((req, res) => {
         const urlString = "http://localhost" + req.url;
         const url = new URL(urlString);

--- a/libs/common/spec/matchers/promise-fulfilled.ts
+++ b/libs/common/spec/matchers/promise-fulfilled.ts
@@ -1,5 +1,5 @@
 async function wait(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+  return await new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 /**

--- a/libs/common/src/platform/misc/fetch-middleware.spec.ts
+++ b/libs/common/src/platform/misc/fetch-middleware.spec.ts
@@ -37,7 +37,7 @@ describe("buildFetchPipeline", () => {
   });
 
   it("passes request through a single pass-through middleware", async () => {
-    const middleware: FetchMiddleware = async (req, next) => next(req);
+    const middleware: FetchMiddleware = async (req, next) => await next(req);
     const pipeline = buildFetchPipeline([middleware], terminal);
     const request = makeRequest();
 
@@ -50,7 +50,7 @@ describe("buildFetchPipeline", () => {
   it("allows middleware to modify the request before next", async () => {
     const middleware: FetchMiddleware = async (req, next) => {
       req.headers.set("X-Custom", "value");
-      return next(req);
+      return await next(req);
     };
     const pipeline = buildFetchPipeline([middleware], terminal);
     const request = makeRequest();
@@ -104,7 +104,7 @@ describe("buildFetchPipeline", () => {
     const retryMiddleware: FetchMiddleware = async (req, next) => {
       const response = await next(req);
       if (response.status === 500) {
-        return next(req);
+        return await next(req);
       }
       return response;
     };
@@ -144,7 +144,7 @@ describe("buildFetchPipeline", () => {
     const error = new Error("network failure");
     terminal.mockRejectedValue(error);
 
-    const middleware: FetchMiddleware = async (req, next) => next(req);
+    const middleware: FetchMiddleware = async (req, next) => await next(req);
     const pipeline = buildFetchPipeline([middleware], terminal);
     const request = makeRequest();
 

--- a/libs/common/src/platform/services/default-environment.service.ts
+++ b/libs/common/src/platform/services/default-environment.service.ts
@@ -308,7 +308,7 @@ export class DefaultEnvironmentService implements EnvironmentService {
     // Add backwards compatibility support for null userId
     const definedUserId = userId ?? (await firstValueFrom(this.activeAccountId$));
 
-    return firstValueFrom(this.getEnvironment$(definedUserId));
+    return await firstValueFrom(this.getEnvironment$(definedUserId));
   }
 
   async seedUserEnvironment(userId: UserId) {

--- a/libs/common/src/platform/services/fido2/fido2-active-request-manager.ts
+++ b/libs/common/src/platform/services/fido2/fido2-active-request-manager.ts
@@ -70,7 +70,7 @@ export class Fido2ActiveRequestManager implements Fido2ActiveRequestManagerAbstr
     const requestResult = firstValueFrom(newRequest.subject);
     abortController.signal.removeEventListener("abort", abortListener);
 
-    return requestResult;
+    return await requestResult;
   }
 
   /**

--- a/libs/common/src/platform/services/fido2/fido2-client.service.ts
+++ b/libs/common/src/platform/services/fido2/fido2-client.service.ts
@@ -324,7 +324,7 @@ export class Fido2ClientService<
     const clientDataJSONBytes = Utils.fromByteStringToArray(clientDataJSON);
 
     if (params.mediation === "conditional") {
-      return this.handleMediatedConditionalRequest(
+      return await this.handleMediatedConditionalRequest(
         params,
         window,
         abortController,

--- a/libs/common/src/platform/services/sdk/default-sdk-client-factory.ts
+++ b/libs/common/src/platform/services/sdk/default-sdk-client-factory.ts
@@ -14,6 +14,6 @@ export class DefaultSdkClientFactory implements SdkClientFactory {
   async createSdkClient(
     ...args: ConstructorParameters<typeof sdk.PasswordManagerClient>
   ): Promise<sdk.PasswordManagerClient> {
-    return Promise.resolve(new sdk.PasswordManagerClient(...args));
+    return await Promise.resolve(new sdk.PasswordManagerClient(...args));
   }
 }

--- a/libs/common/src/platform/sync/default-sync.service.ts
+++ b/libs/common/src/platform/sync/default-sync.service.ts
@@ -418,7 +418,7 @@ export class DefaultSyncService extends CoreSyncService {
       });
     }
 
-    return this.domainSettingsService.setEquivalentDomains(eqDomains, userId);
+    return await this.domainSettingsService.setEquivalentDomains(eqDomains, userId);
   }
 
   private async syncPolicies(response: PolicyResponse[], userId: UserId) {

--- a/libs/state-internal/src/inline-derived-state.spec.ts
+++ b/libs/state-internal/src/inline-derived-state.spec.ts
@@ -18,7 +18,7 @@ describe("InlineDerivedState", () => {
     new StateDefinition("test", "disk"),
     "test",
     {
-      derive: async (value, deps) => Promise.resolve(!value),
+      derive: async (value, deps) => await Promise.resolve(!value),
       deserializer: (value) => value,
     },
   );

--- a/libs/state-test-utils/src/fake-state.ts
+++ b/libs/state-test-utils/src/fake-state.ts
@@ -254,9 +254,9 @@ export class FakeDerivedState<
         concatMap(async (v) => {
           const newState = deriveDefinition.derive(v, dependencies);
           if (newState instanceof Promise) {
-            return newState;
+            return await newState;
           }
-          return Promise.resolve(newState);
+          return await Promise.resolve(newState);
         }),
       )
       .subscribe((newState) => {

--- a/libs/state/src/state-migrations/migrate.ts
+++ b/libs/state/src/state-migrations/migrate.ts
@@ -210,7 +210,7 @@ export async function waitForMigrations(
       // likely to.
       return;
     }
-    return new Promise<void>((resolve) => {
+    return await new Promise<void>((resolve) => {
       setTimeout(async () => {
         if (!(await isReady())) {
           logService.info(`Waiting for migrations to finish, waiting for ${nextTime}ms`);

--- a/libs/state/src/state-migrations/migration-helper.ts
+++ b/libs/state/src/state-migrations/migration-helper.ts
@@ -160,7 +160,7 @@ export class MigrationHelper {
     { userId: string; account: ExpectedAccountType }[]
   > {
     const userIds = await this.getKnownUserIds();
-    return Promise.all(
+    return await Promise.all(
       userIds.map(async (userId) => ({
         userId,
         account: await this.get<ExpectedAccountType>(userId),
@@ -173,9 +173,9 @@ export class MigrationHelper {
    */
   async getKnownUserIds(): Promise<string[]> {
     if (this.currentVersion < 60) {
-      return knownAccountUserIdsBuilderPre60(this.storageService);
+      return await knownAccountUserIdsBuilderPre60(this.storageService);
     } else {
-      return knownAccountUserIdsBuilder(this.storageService);
+      return await knownAccountUserIdsBuilder(this.storageService);
     }
   }
 

--- a/libs/state/src/state-migrations/migrations/4-remove-ever-been-unlocked.ts
+++ b/libs/state/src/state-migrations/migrations/4-remove-ever-been-unlocked.ts
@@ -10,7 +10,7 @@ export class RemoveEverBeenUnlockedMigrator extends Migrator<3, 4> {
     async function removeEverBeenUnlocked(userId: string, account: ExpectedAccountType) {
       if (account?.profile?.everBeenUnlocked != null) {
         delete account.profile.everBeenUnlocked;
-        return helper.set(userId, account);
+        return await helper.set(userId, account);
       }
     }
 

--- a/libs/state/src/state-migrations/migrations/5-add-key-type-to-org-keys.ts
+++ b/libs/state/src/state-migrations/migrations/5-add-key-type-to-org-keys.ts
@@ -59,7 +59,7 @@ export class AddKeyTypeToOrgKeysMigrator extends Migrator<4, 5> {
 
     // FIXME: Verify that this floating promise is intentional. If it is, add an explanatory comment and ensure there is proper error handling.
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    Promise.all(accounts.map(async ({ userId, account }) => updateOrgKey(userId, account)));
+    Promise.all(accounts.map(async ({ userId, account }) => await updateOrgKey(userId, account)));
   }
 
   // Override is necessary because default implementation assumes `stateVersion` at the root, but for this version


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
Jira Bug: https://bitwarden.atlassian.net/browse/PM-38405
Tracking PR: https://github.com/bitwarden/clients/pull/20981

Note: This PR is split per team ownership to keep it reviewable.

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
We want to enable the return-await eslint rule. Currently, there is a pattern of unawaited promises being returned which is causing production bugs as explained in more detail below. To do this, we first migrate all teams. The migration has been performed automatically with eslint --fix. There aren o other changes other than adding await to the unawaited promises.

### Specifically Bugged Behavior

Returning unawaited promises is currently allowing unexpected bugs to appear. Specifically in this example:

```ts
        await firstValueFrom( // Promise on ref.value gets awaited here
          this.sdkService.userClient$(userId).pipe(
            map((sdk) => {
              if (!sdk) {
                throw new Error("SDK not available");
              }

              using ref = sdk.take();

              return ref.value.user_crypto_management().migrate_to_key_connector(keyConnectorUrl); // but created here. also, the return disposes the ref
            }),
          ),
```

the promise is created inside the observable, but passed out and holds an invalid reference and tries to access it. We fix this by completely banning unawaited promises from being returned.

The more subtle benefits, as pointed out by the eslint rule:
> - Returning an awaited promise [improves stack trace information](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await#improving_stack_trace).
> - When the return statement is in try...catch, awaiting the promise allows the promise's rejection to be caught instead of leaving the error to the caller.
> - Contrary to popular belief, return await promise; is [at least as fast as directly returning the promise](https://github.com/tc39/proposal-faster-promise-adoption).

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
