### PR TITLE
[PM-38405] Await unawaited promises

### DIFF
--- a/apps/browser/src/platform/popup/layout/popup-header.component.ts
+++ b/apps/browser/src/platform/popup/layout/popup-header.component.ts
@@ -62,6 +62,6 @@ export class PopupHeaderComponent {
   // eslint-disable-next-line @angular-eslint/prefer-signals
   @Input()
   backAction: FunctionReturningAwaitable = async () => {
-    return this.popupRouterCacheService.back();
+    return await this.popupRouterCacheService.back();
   };
 }

--- a/apps/web/src/app/layouts/product-switcher/navigation-switcher/navigation-switcher.stories.ts
+++ b/apps/web/src/app/layouts/product-switcher/navigation-switcher/navigation-switcher.stories.ts
@@ -77,7 +77,7 @@ class MockProviderService implements Partial<ProviderService> {
 
 class MockSyncService implements Partial<SyncService> {
   async getLastSync() {
-    return Promise.resolve(new Date());
+    return await Promise.resolve(new Date());
   }
 }
 

--- a/apps/web/src/app/layouts/product-switcher/product-switcher.stories.ts
+++ b/apps/web/src/app/layouts/product-switcher/product-switcher.stories.ts
@@ -70,7 +70,7 @@ class MockProviderService implements Partial<ProviderService> {
 
 class MockSyncService implements Partial<SyncService> {
   async getLastSync() {
-    return Promise.resolve(new Date());
+    return await Promise.resolve(new Date());
   }
 }
 

--- a/libs/components/src/dialog/dialog.service.ts
+++ b/libs/components/src/dialog/dialog.service.ts
@@ -423,7 +423,7 @@ export class DialogService {
 
   /** Close the open drawer */
   async closeDrawer(): Promise<DialogCloseRef> {
-    return this.activeDrawer?.close() ?? { closed: true };
+    return await (this.activeDrawer?.close() ?? { closed: true });
   }
 
   /**


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
Jira Bug: https://bitwarden.atlassian.net/browse/PM-38405
Tracking PR: https://github.com/bitwarden/clients/pull/20981

Note: This PR is split per team ownership to keep it reviewable.

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
We want to enable the return-await eslint rule. Currently, there is a pattern of unawaited promises being returned which is causing production bugs as explained in more detail below. To do this, we first migrate all teams. The migration has been performed automatically with eslint --fix. There aren o other changes other than adding await to the unawaited promises.

### Specifically Bugged Behavior

Returning unawaited promises is currently allowing unexpected bugs to appear. Specifically in this example:

```ts
        await firstValueFrom( // Promise on ref.value gets awaited here
          this.sdkService.userClient$(userId).pipe(
            map((sdk) => {
              if (!sdk) {
                throw new Error("SDK not available");
              }

              using ref = sdk.take();

              return ref.value.user_crypto_management().migrate_to_key_connector(keyConnectorUrl); // but created here. also, the return disposes the ref
            }),
          ),
```

the promise is created inside the observable, but passed out and holds an invalid reference and tries to access it. We fix this by completely banning unawaited promises from being returned.

The more subtle benefits, as pointed out by the eslint rule:
> - Returning an awaited promise [improves stack trace information](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await#improving_stack_trace).
> - When the return statement is in try...catch, awaiting the promise allows the promise's rejection to be caught instead of leaving the error to the caller.
> - Contrary to popular belief, return await promise; is [at least as fast as directly returning the promise](https://github.com/tc39/proposal-faster-promise-adoption).

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
