### PR TITLE
[PM-38405] Await unawaited promises @bitwarden/team-tools-dev

### DIFF
--- a/apps/cli/src/tools/send/commands/create.command.ts
+++ b/apps/cli/src/tools/send/commands/create.command.ts
@@ -70,7 +70,7 @@ export class SendCreateCommand {
     }
 
     const normalizedOptions = new Options(cmdOptions);
-    return this.createSend(req, normalizedOptions);
+    return await this.createSend(req, normalizedOptions);
   }
 
   private async createSend(req: SendResponse, options: Options) {

--- a/apps/cli/src/tools/send/commands/get.command.ts
+++ b/apps/cli/src/tools/send/commands/get.command.ts
@@ -65,13 +65,13 @@ export class SendGetCommand extends DownloadCommand {
         return Response.multipleResults(sends.map((s) => s.id));
       }
       if (sends.length > 0) {
-        return selector(sends[0]);
+        return await selector(sends[0]);
       } else {
         return Response.notFound();
       }
     }
 
-    return selector(sends);
+    return await selector(sends);
   }
 
   private async getSendView(id: string): Promise<SendView | SendView[]> {

--- a/apps/cli/src/tools/send/commands/receive.command.ts
+++ b/apps/cli/src/tools/send/commands/receive.command.ts
@@ -358,7 +358,7 @@ export class SendReceiveCommand extends DownloadCommand {
 
           const decryptBufferFn = async (resp: globalThis.Response) => {
             const encBuf = await EncArrayBuffer.fromResponse(resp);
-            return this.encryptService.decryptFileData(encBuf, this.decKey);
+            return await this.encryptService.decryptFileData(encBuf, this.decKey);
           };
 
           return await this.saveAttachmentToFile(

--- a/apps/desktop/src/app/tools/send/guards/unsaved-send-edits.guard.ts
+++ b/apps/desktop/src/app/tools/send/guards/unsaved-send-edits.guard.ts
@@ -8,5 +8,5 @@ export const unsavedSendEditsGuard: CanDeactivateFn<SendComponent> = async (comp
   if (component == null) {
     return true;
   }
-  return component.saveUnsavedSendEdits();
+  return await component.saveUnsavedSendEdits();
 };

--- a/apps/web/src/app/tools/guards/unsaved-send-edits.guard.ts
+++ b/apps/web/src/app/tools/guards/unsaved-send-edits.guard.ts
@@ -8,5 +8,5 @@ export const unsavedSendEditsGuard: CanDeactivateFn<SendComponent> = async (comp
   if (component == null) {
     return true;
   }
-  return component.saveUnsavedSendEdits();
+  return await component.saveUnsavedSendEdits();
 };

--- a/libs/angular/src/tools/send/add-edit.component.ts
+++ b/libs/angular/src/tools/send/add-edit.component.ts
@@ -386,7 +386,7 @@ export class AddEditComponent implements OnInit, OnDestroy {
   }
 
   async copyLinkToClipboard(link: string): Promise<void | boolean> {
-    return Promise.resolve(this.platformUtilsService.copyToClipboard(link));
+    return await Promise.resolve(this.platformUtilsService.copyToClipboard(link));
   }
 
   protected async delete(): Promise<boolean> {

--- a/libs/common/src/tools/send/services/send.service.ts
+++ b/libs/common/src/tools/send/services/send.service.ts
@@ -314,7 +314,7 @@ export class SendService implements InternalSendServiceAbstraction {
 
     const req = await firstValueFrom(
       this.sends$.pipe(
-        concatMap(async (sends) => this.toRotatedKeyRequestMap(sends, originalUserKey, newUserKey)),
+        concatMap(async (sends) => await this.toRotatedKeyRequestMap(sends, originalUserKey, newUserKey)),
       ),
     );
     // separate return for easier debugging

--- a/libs/common/src/tools/state/secret-state.ts
+++ b/libs/common/src/tools/state/secret-state.ts
@@ -118,7 +118,7 @@ export class SecretState<
     }
 
     // decrypt each item
-    const decryptTasks = data.map(async (item) => this.declassifyItem(encryptor, item));
+    const decryptTasks = data.map(async (item) => await this.declassifyItem(encryptor, item));
 
     // reconstruct expected type
     const results = await Promise.all(decryptTasks);
@@ -154,7 +154,7 @@ export class SecretState<
     const desconstructed = this.key.deconstruct(data);
 
     // encrypt each value individually
-    const classifyTasks = desconstructed.map(async (item) => this.classifyItem(encryptor, item));
+    const classifyTasks = desconstructed.map(async (item) => await this.classifyItem(encryptor, item));
     const classified = await Promise.all(classifyTasks);
 
     return classified;

--- a/libs/importer/src/components/lastpass/lastpass-direct-import-ui.service.ts
+++ b/libs/importer/src/components/lastpass/lastpass-direct-import-ui.service.ts
@@ -44,24 +44,24 @@ export class LastPassDirectImportUIService implements Ui {
   }
 
   async provideGoogleAuthPasscode() {
-    return this.getOTPResult("otp");
+    return await this.getOTPResult("otp");
   }
 
   async provideMicrosoftAuthPasscode() {
-    return this.getOTPResult("otp");
+    return await this.getOTPResult("otp");
   }
 
   async provideYubikeyPasscode() {
-    return this.getOTPResult("yubikey");
+    return await this.getOTPResult("yubikey");
   }
 
   async approveLastPassAuth() {
-    return this.getOOBResult("oob");
+    return await this.getOOBResult("oob");
   }
   async approveDuo() {
-    return this.getOOBResult("oob");
+    return await this.getOOBResult("oob");
   }
   async approveSalesforceAuth() {
-    return this.getOOBResult("oob");
+    return await this.getOOBResult("oob");
   }
 }

--- a/libs/importer/src/components/lastpass/lastpass-direct-import.service.ts
+++ b/libs/importer/src/components/lastpass/lastpass-direct-import.service.ts
@@ -114,7 +114,7 @@ export class LastPassDirectImportService {
       throw Error("SSO auth cancelled");
     });
 
-    return Promise.race<{
+    return await Promise.race<{
       oidcCode: string;
       oidcState: string;
     }>([cancelled, ssoCallbackPromise]).finally(() => {

--- a/libs/importer/src/importers/bitwarden/bitwarden-encrypted-json-importer.ts
+++ b/libs/importer/src/importers/bitwarden/bitwarden-encrypted-json-importer.ts
@@ -60,7 +60,7 @@ export class BitwardenEncryptedJsonImporter extends BitwardenJsonImporter implem
     }
 
     if (isUnencrypted(results)) {
-      return super.parse(data);
+      return await super.parse(data);
     }
 
     return await this.parseEncrypted(results);

--- a/libs/importer/src/importers/lastpass/access/services/client.ts
+++ b/libs/importer/src/importers/lastpass/access/services/client.ts
@@ -99,7 +99,7 @@ export class Client {
         privateKey = await this.parser.parseEncryptedPrivateKey(encryptedPrivateKey, key, initVec);
       }
 
-      return this.parseVault(blob, key, privateKey, options);
+      return await this.parseVault(blob, key, privateKey, options);
     } finally {
       await this.logout(session, rest);
     }
@@ -350,7 +350,7 @@ export class Client {
       extraParameters.set("outofbandretry", "1");
       extraParameters.set("outofbandretryid", this.getErrorAttribute(response, "retryid"));
 
-      return attemptLogin(extraParameters);
+      return await attemptLogin(extraParameters);
     };
 
     const pollingLoginSession = () => {
@@ -395,11 +395,11 @@ export class Client {
     }
     switch (method) {
       case "lastpassauth":
-        return ui.approveLastPassAuth();
+        return await ui.approveLastPassAuth();
       case "duo":
-        return this.approveDuo(username, parameters, ui, rest);
+        return await this.approveDuo(username, parameters, ui, rest);
       case "salesforcehash":
-        return ui.approveSalesforceAuth();
+        return await ui.approveSalesforceAuth();
       default:
         throw new Error("Out of band method " + method + " is not supported");
     }
@@ -412,8 +412,8 @@ export class Client {
     rest: RestClient,
   ): Promise<OobResult> {
     return parameters.get("preferduowebsdk") == "1"
-      ? this.approveDuoWebSdk(username, parameters, ui, rest)
-      : ui.approveDuo();
+      ? await this.approveDuoWebSdk(username, parameters, ui, rest)
+      : await ui.approveDuo();
   }
 
   private approveDuoWebSdk(

--- a/libs/importer/src/importers/lastpass/access/services/crypto-utils.ts
+++ b/libs/importer/src/importers/lastpass/access/services/crypto-utils.ts
@@ -43,7 +43,7 @@ export class CryptoUtils {
     defaultValue: string,
   ) {
     try {
-      return this.decryptAes256Plain(data, encryptionKey);
+      return await this.decryptAes256Plain(data, encryptionKey);
     } catch {
       return defaultValue;
     }
@@ -55,7 +55,7 @@ export class CryptoUtils {
     defaultValue: string,
   ) {
     try {
-      return this.decryptAes256Base64(data, encryptionKey);
+      return await this.decryptAes256Base64(data, encryptionKey);
     } catch {
       return defaultValue;
     }
@@ -67,9 +67,9 @@ export class CryptoUtils {
     }
     // Byte 33 == character '!'
     if (data[0] === 33 && data.length % 16 === 1 && data.length > 32) {
-      return this.decryptAes256CbcPlain(data, encryptionKey);
+      return await this.decryptAes256CbcPlain(data, encryptionKey);
     }
-    return this.decryptAes256EcbPlain(data, encryptionKey);
+    return await this.decryptAes256EcbPlain(data, encryptionKey);
   }
 
   async decryptAes256Base64(data: Uint8Array, encryptionKey: Uint8Array) {
@@ -78,9 +78,9 @@ export class CryptoUtils {
     }
     // Byte 33 == character '!'
     if (data[0] === 33) {
-      return this.decryptAes256CbcBase64(data, encryptionKey);
+      return await this.decryptAes256CbcBase64(data, encryptionKey);
     }
-    return this.decryptAes256EcbBase64(data, encryptionKey);
+    return await this.decryptAes256EcbBase64(data, encryptionKey);
   }
 
   async decryptAes256(
@@ -104,23 +104,23 @@ export class CryptoUtils {
   }
 
   private async decryptAes256EcbPlain(data: Uint8Array, encryptionKey: Uint8Array) {
-    return this.decryptAes256(data, encryptionKey, "ecb");
+    return await this.decryptAes256(data, encryptionKey, "ecb");
   }
 
   private async decryptAes256EcbBase64(data: Uint8Array, encryptionKey: Uint8Array) {
     const d = Utils.fromB64ToArray(Utils.fromArrayToUtf8(data)!)!;
-    return this.decryptAes256(d, encryptionKey, "ecb");
+    return await this.decryptAes256(d, encryptionKey, "ecb");
   }
 
   private async decryptAes256CbcPlain(data: Uint8Array, encryptionKey: Uint8Array) {
     const d = data.subarray(17);
     const iv = data.subarray(1, 17);
-    return this.decryptAes256(d, encryptionKey, "cbc", iv);
+    return await this.decryptAes256(d, encryptionKey, "cbc", iv);
   }
 
   private async decryptAes256CbcBase64(data: Uint8Array, encryptionKey: Uint8Array) {
     const d = Utils.fromB64ToArray(Utils.fromArrayToUtf8(data.subarray(26))!)!;
     const iv = Utils.fromB64ToArray(Utils.fromArrayToUtf8(data.subarray(1, 25))!)!;
-    return this.decryptAes256(d, encryptionKey, "cbc", iv);
+    return await this.decryptAes256(d, encryptionKey, "cbc", iv);
   }
 }

--- a/libs/tools/export/vault-export/vault-export-core/src/services/individual-vault-export.service.ts
+++ b/libs/tools/export/vault-export/vault-export-core/src/services/individual-vault-export.service.ts
@@ -61,11 +61,11 @@ export class IndividualVaultExportService
    */
   async getExport(userId: UserId, format: ExportFormat = "csv"): Promise<ExportedVault> {
     if (format === "encrypted_json") {
-      return this.getEncryptedExport(userId);
+      return await this.getEncryptedExport(userId);
     } else if (format === "zip") {
-      return this.getDecryptedExportZip(userId);
+      return await this.getDecryptedExportZip(userId);
     }
-    return this.getDecryptedExport(userId, format);
+    return await this.getDecryptedExport(userId, format);
   }
 
   /** Creates a password protected export of an individual vault (My Vault) as a JSON file

--- a/libs/tools/export/vault-export/vault-export-core/src/services/org-vault-export.service.ts
+++ b/libs/tools/export/vault-export/vault-export-core/src/services/org-vault-export.service.ts
@@ -223,7 +223,7 @@ export class OrganizationVaultExportService
           }
         });
     }
-    return this.BuildEncryptedExport(userId, organizationId, collections, ciphers);
+    return await this.BuildEncryptedExport(userId, organizationId, collections, ciphers);
   }
 
   private async getDecryptedManagedExport(
@@ -303,7 +303,7 @@ export class OrganizationVaultExportService
         !this.restrictedItemTypesService.isCipherRestricted(f, restrictions),
     );
 
-    return this.BuildEncryptedExport(activeUserId, organizationId, encCollections, encCiphers);
+    return await this.BuildEncryptedExport(activeUserId, organizationId, encCollections, encCiphers);
   }
 
   private async BuildEncryptedExport(

--- a/libs/tools/export/vault-export/vault-export-core/src/services/vault-export.service.ts
+++ b/libs/tools/export/vault-export/vault-export-core/src/services/vault-export.service.ts
@@ -42,9 +42,9 @@ export class VaultExportService implements VaultExportServiceAbstraction {
         throw new Error("CSV does not support password protected export");
       }
 
-      return this.individualVaultExportService.getPasswordProtectedExport(userId, password);
+      return await this.individualVaultExportService.getPasswordProtectedExport(userId, password);
     }
-    return this.individualVaultExportService.getExport(userId, format);
+    return await this.individualVaultExportService.getExport(userId, format);
   }
 
   /** Creates an export of an organizational vault. Based on the provided format it will either be unencrypted, encrypted or password protected
@@ -74,7 +74,7 @@ export class VaultExportService implements VaultExportServiceAbstraction {
         throw new Error("CSV does not support password protected export");
       }
 
-      return this.organizationVaultExportService.getPasswordProtectedExport(
+      return await this.organizationVaultExportService.getPasswordProtectedExport(
         userId,
         organizationId,
         password,
@@ -82,7 +82,7 @@ export class VaultExportService implements VaultExportServiceAbstraction {
       );
     }
 
-    return this.organizationVaultExportService.getOrganizationExport(
+    return await this.organizationVaultExportService.getOrganizationExport(
       userId,
       organizationId,
       format,

--- a/libs/tools/export/vault-export/vault-export-ui/src/components/export.component.ts
+++ b/libs/tools/export/vault-export/vault-export-ui/src/components/export.component.ts
@@ -640,8 +640,8 @@ export class ExportComponent implements OnInit, OnDestroy, AfterViewInit {
   protected async getExportData(): Promise<ExportedVault> {
     const userId = await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId));
     return Utils.isNullOrWhitespace(this.organizationId)
-      ? this.exportService.getExport(userId, this.format, this.filePassword)
-      : this.exportService.getOrganizationExport(
+      ? await this.exportService.getExport(userId, this.format, this.filePassword)
+      : await this.exportService.getOrganizationExport(
           userId,
           this.organizationId,
           this.format,

--- a/libs/tools/generator/core/src/strategies/catchall-generator-strategy.ts
+++ b/libs/tools/generator/core/src/strategies/catchall-generator-strategy.ts
@@ -40,9 +40,9 @@ export class CatchallGeneratorStrategy implements GeneratorStrategy<
     }
 
     if (options.catchallType === "website-name") {
-      return await this.emailCalculator.concatenate(options.website, options.catchallDomain);
+      return this.emailCalculator.concatenate(options.website, options.catchallDomain);
     }
 
-    return this.emailRandomizer.randomAsciiCatchall(options.catchallDomain);
+    return await this.emailRandomizer.randomAsciiCatchall(options.catchallDomain);
   }
 }

--- a/libs/tools/generator/core/src/strategies/passphrase-generator-strategy.ts
+++ b/libs/tools/generator/core/src/strategies/passphrase-generator-strategy.ts
@@ -48,6 +48,6 @@ export class PassphraseGeneratorStrategy implements GeneratorStrategy<
   async generate(options: PassphraseGenerationOptions): Promise<string> {
     const request = optionsToEffWordListRequest(options);
 
-    return this.randomizer.randomEffLongWords(request);
+    return await this.randomizer.randomEffLongWords(request);
   }
 }

--- a/libs/tools/generator/core/src/strategies/subaddress-generator-strategy.ts
+++ b/libs/tools/generator/core/src/strategies/subaddress-generator-strategy.ts
@@ -47,6 +47,6 @@ export class SubaddressGeneratorStrategy implements GeneratorStrategy<
       return this.emailCalculator.appendToSubaddress(options.website, options.subaddressEmail);
     }
 
-    return this.emailRandomizer.randomAsciiSubaddress(options.subaddressEmail);
+    return await this.emailRandomizer.randomAsciiSubaddress(options.subaddressEmail);
   }
 }

--- a/libs/tools/generator/extensions/history/src/legacy-password-history-decryptor.ts
+++ b/libs/tools/generator/extensions/history/src/legacy-password-history-decryptor.ts
@@ -29,6 +29,6 @@ export class LegacyPasswordHistoryDecryptor {
       return new GeneratedPasswordHistory(decrypted, item.date);
     });
 
-    return Promise.all(promises);
+    return await Promise.all(promises);
   }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
Jira Bug: https://bitwarden.atlassian.net/browse/PM-38405
Tracking PR: https://github.com/bitwarden/clients/pull/20981

Note: This PR is split per team ownership to keep it reviewable.

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
We want to enable the return-await eslint rule. Currently, there is a pattern of unawaited promises being returned which is causing production bugs as explained in more detail below. To do this, we first migrate all teams. The migration has been performed automatically with eslint --fix. There aren o other changes other than adding await to the unawaited promises.

### Specifically Bugged Behavior

Returning unawaited promises is currently allowing unexpected bugs to appear. Specifically in this example:

```ts
        await firstValueFrom( // Promise on ref.value gets awaited here
          this.sdkService.userClient$(userId).pipe(
            map((sdk) => {
              if (!sdk) {
                throw new Error("SDK not available");
              }

              using ref = sdk.take();

              return ref.value.user_crypto_management().migrate_to_key_connector(keyConnectorUrl); // but created here. also, the return disposes the ref
            }),
          ),
```

the promise is created inside the observable, but passed out and holds an invalid reference and tries to access it. We fix this by completely banning unawaited promises from being returned.

The more subtle benefits, as pointed out by the eslint rule:
> - Returning an awaited promise [improves stack trace information](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await#improving_stack_trace).
> - When the return statement is in try...catch, awaiting the promise allows the promise's rejection to be caught instead of leaving the error to the caller.
> - Contrary to popular belief, return await promise; is [at least as fast as directly returning the promise](https://github.com/tc39/proposal-faster-promise-adoption).

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

