### PR TITLE
[PM-38405] Await unawaited promises @bitwarden/team-desktop-native-dev

### DIFF
--- a/apps/desktop/native-messaging-test-runner/src/ipc.service.ts
+++ b/apps/desktop/native-messaging-test-runner/src/ipc.service.ts
@@ -65,7 +65,7 @@ export default class IPCService {
       this._connect();
     }
 
-    return deferredConnections.getPromise();
+    return await deferredConnections.getPromise();
   }
 
   private _connect() {
@@ -137,7 +137,7 @@ export default class IPCService {
     try {
       // Since we can not guarantee that a response message will ever be sent, we put a timeout
       // on messages
-      return race({
+      return await race({
         promise: deferred.getPromise(),
         timeout: options?.overrideTimeout ?? DEFAULT_MESSAGE_TIMEOUT,
         error: new Error(`Message: ${message.messageId} timed out`),
@@ -198,7 +198,7 @@ export default class IPCService {
         continue;
       }
 
-      this.processMessage(message);
+      await this.processMessage(message);
     }
   }
 

--- a/apps/desktop/native-messaging-test-runner/src/native-message.service.ts
+++ b/apps/desktop/native-messaging-test-runner/src/native-message.service.ts
@@ -87,7 +87,7 @@ export default class NativeMessageService {
       encryptedCommand,
     });
 
-    return this.decryptResponsePayload(response.encryptedPayload, key);
+    return await this.decryptResponsePayload(response.encryptedPayload, key);
   }
 
   async credentialRetrieval(key: string, uri: string): Promise<DecryptedCommandData> {
@@ -104,7 +104,7 @@ export default class NativeMessageService {
       encryptedCommand,
     });
 
-    return this.decryptResponsePayload(response.encryptedPayload, key);
+    return await this.decryptResponsePayload(response.encryptedPayload, key);
   }
 
   async credentialCreation(
@@ -122,7 +122,7 @@ export default class NativeMessageService {
       encryptedCommand,
     });
 
-    return this.decryptResponsePayload(response.encryptedPayload, key);
+    return await this.decryptResponsePayload(response.encryptedPayload, key);
   }
 
   async credentialUpdate(
@@ -140,7 +140,7 @@ export default class NativeMessageService {
       encryptedCommand,
     });
 
-    return this.decryptResponsePayload(response.encryptedPayload, key);
+    return await this.decryptResponsePayload(response.encryptedPayload, key);
   }
 
   async generatePassword(key: string, userId: string): Promise<DecryptedCommandData> {
@@ -157,7 +157,7 @@ export default class NativeMessageService {
       encryptedCommand,
     });
 
-    return this.decryptResponsePayload(response.encryptedPayload, key);
+    return await this.decryptResponsePayload(response.encryptedPayload, key);
   }
 
   // Private message sending
@@ -220,7 +220,7 @@ export default class NativeMessageService {
 
     const sharedKey = await this.getSharedKeyForKey(key);
 
-    return this.encryptService.encryptString(commandDataString, sharedKey);
+    return await this.encryptService.encryptString(commandDataString, sharedKey);
   }
 
   private async decryptResponsePayload(

--- a/apps/desktop/src/autofill/modal/credentials/fido2-create.component.ts
+++ b/apps/desktop/src/autofill/modal/credentials/fido2-create.component.ts
@@ -210,7 +210,7 @@ export class Fido2CreateComponent implements OnInit, OnDestroy {
     }
 
     if (cipher.reprompt) {
-      return this.passwordRepromptService.showPasswordPrompt();
+      return await this.passwordRepromptService.showPasswordPrompt();
     }
 
     return true;

--- a/apps/desktop/src/autofill/modal/credentials/fido2-vault.component.ts
+++ b/apps/desktop/src/autofill/modal/credentials/fido2-vault.component.ts
@@ -159,7 +159,7 @@ export class Fido2VaultComponent implements OnInit, OnDestroy {
 
   private async validateCipherAccess(cipher: CipherView): Promise<boolean> {
     if (cipher.reprompt !== CipherRepromptType.None) {
-      return this.passwordRepromptService.showPasswordPrompt();
+      return await this.passwordRepromptService.showPasswordPrompt();
     }
 
     return true;

--- a/apps/desktop/src/autofill/preload.ts
+++ b/apps/desktop/src/autofill/preload.ts
@@ -30,7 +30,7 @@ const sshAgent = {
   isLoaded(): Promise<boolean> {
     return ipcRenderer.invoke(SSH_AGENT_IPC_CHANNELS.IS_LOADED);
   },
-  stop: async () => ipcRenderer.invoke(SSH_AGENT_IPC_CHANNELS.STOP),
+  stop: async () => await ipcRenderer.invoke(SSH_AGENT_IPC_CHANNELS.STOP),
 };
 
 export default {

--- a/apps/desktop/src/autofill/services/desktop-fido2-user-interface.service.ts
+++ b/apps/desktop/src/autofill/services/desktop-fido2-user-interface.service.ts
@@ -157,7 +157,7 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
   }
 
   async getRpId(): Promise<string> {
-    return firstValueFrom(this.rpId.pipe(filter((id) => id != null)));
+    return await firstValueFrom(this.rpId.pipe(filter((id) => id != null)));
   }
 
   confirmChosenCipher(cipherId: string, userVerified: boolean = false): void {
@@ -195,7 +195,7 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
    * @returns
    */
   private async waitForUiNewCredentialConfirmation(): Promise<boolean> {
-    return lastValueFrom(this.confirmCredentialSubject);
+    return await lastValueFrom(this.confirmCredentialSubject);
   }
 
   /**

--- a/apps/desktop/src/autofill/services/ssh-agent.service.ts
+++ b/apps/desktop/src/autofill/services/ssh-agent.service.ts
@@ -195,12 +195,12 @@ export class SshAgentService implements OnDestroy {
 
             if (await firstValueFrom(dialogRef.closed)) {
               await this.rememberAuthorization(cipherId);
-              return ipc.autofill.sshAgent.signRequestResponse(requestId, true);
+              return await ipc.autofill.sshAgent.signRequestResponse(requestId, true);
             } else {
-              return ipc.autofill.sshAgent.signRequestResponse(requestId, false);
+              return await ipc.autofill.sshAgent.signRequestResponse(requestId, false);
             }
           } else {
-            return ipc.autofill.sshAgent.signRequestResponse(requestId, true);
+            return await ipc.autofill.sshAgent.signRequestResponse(requestId, true);
           }
         }),
         catchError((error: unknown, source) => {

--- a/apps/desktop/src/services/encrypted-message-handler.service.ts
+++ b/apps/desktop/src/services/encrypted-message-handler.service.ts
@@ -88,7 +88,7 @@ export class EncryptedMessageHandlerService {
       return [];
     }
 
-    return Promise.all(
+    return await Promise.all(
       Object.keys(accounts).map(async (userId: UserId) => {
         const authStatus = await this.authService.getAuthStatus(userId);
         const email = accounts[userId].email;


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
Jira Bug: https://bitwarden.atlassian.net/browse/PM-38405
Tracking PR: https://github.com/bitwarden/clients/pull/20981

Note: This PR is split per team ownership to keep it reviewable.

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
We want to enable the return-await eslint rule. Currently, there is a pattern of unawaited promises being returned which is causing production bugs as explained in more detail below. To do this, we first migrate all teams. The migration has been performed automatically with eslint --fix. There aren o other changes other than adding await to the unawaited promises.

### Specifically Bugged Behavior

Returning unawaited promises is currently allowing unexpected bugs to appear. Specifically in this example:

```ts
        await firstValueFrom( // Promise on ref.value gets awaited here
          this.sdkService.userClient$(userId).pipe(
            map((sdk) => {
              if (!sdk) {
                throw new Error("SDK not available");
              }

              using ref = sdk.take();

              return ref.value.user_crypto_management().migrate_to_key_connector(keyConnectorUrl); // but created here. also, the return disposes the ref
            }),
          ),
```

the promise is created inside the observable, but passed out and holds an invalid reference and tries to access it. We fix this by completely banning unawaited promises from being returned.

The more subtle benefits, as pointed out by the eslint rule:
> - Returning an awaited promise [improves stack trace information](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await#improving_stack_trace).
> - When the return statement is in try...catch, awaiting the promise allows the promise's rejection to be caught instead of leaving the error to the caller.
> - Contrary to popular belief, return await promise; is [at least as fast as directly returning the promise](https://github.com/tc39/proposal-faster-promise-adoption).

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

