### PR TITLE
[PM-38405] Await unawaited promises @bitwarden/team-billing-dev

### DIFF
--- a/apps/web/src/app/billing/clients/account-billing.client.ts
+++ b/apps/web/src/app/billing/clients/account-billing.client.ts
@@ -37,7 +37,7 @@ export class AccountBillingClient {
 
   getLicense = async (): Promise<string> => {
     const path = `${this.endpoint}/license`;
-    return this.apiService.send("GET", path, null, true, true);
+    return await this.apiService.send("GET", path, null, true, true);
   };
 
   getSubscription = async (): Promise<Maybe<BitwardenSubscription>> => {

--- a/apps/web/src/app/billing/individual/premium/self-hosted-premium.component.ts
+++ b/apps/web/src/app/billing/individual/premium/self-hosted-premium.component.ts
@@ -122,7 +122,7 @@ export class SelfHostedPremiumComponent {
   };
 
   protected navigateToSubscription = async (): Promise<boolean> =>
-    this.router.navigate(["../user-subscription"], { relativeTo: this.activatedRoute });
+    await this.router.navigate(["../user-subscription"], { relativeTo: this.activatedRoute });
 
   protected onPremiumUpgradeClick = async () => {
     const url = await firstValueFrom(this.cloudPremiumPageUrl$);

--- a/apps/web/src/app/billing/individual/upgrade/services/unified-upgrade-prompt.service.ts
+++ b/apps/web/src/app/billing/individual/upgrade/services/unified-upgrade-prompt.service.ts
@@ -77,7 +77,7 @@ export class UnifiedUpgradePromptService {
     const shouldShow = await firstValueFrom(this.shouldShowPrompt$);
 
     if (shouldShow) {
-      return this.launchUpgradeDialog();
+      return await this.launchUpgradeDialog();
     }
 
     return null;

--- a/apps/web/src/app/billing/individual/upgrade/upgrade-payment/upgrade-payment.component.ts
+++ b/apps/web/src/app/billing/individual/upgrade/upgrade-payment/upgrade-payment.component.ts
@@ -354,12 +354,12 @@ export class UpgradePaymentComponent implements OnInit, AfterViewInit {
     }
 
     return this.isFamiliesPlan()
-      ? this.processFamiliesUpgrade(
+      ? await this.processFamiliesUpgrade(
           organizationName!,
           billingAddress,
           paymentMethod as TokenizedPaymentMethod,
         )
-      : this.processPremiumUpgrade(paymentMethod, billingAddress);
+      : await this.processPremiumUpgrade(paymentMethod, billingAddress);
   }
 
   private async processFamiliesUpgrade(

--- a/apps/web/src/app/billing/payment/components/enter-payment-method.component.ts
+++ b/apps/web/src/app/billing/payment/components/enter-payment-method.component.ts
@@ -360,14 +360,14 @@ export class EnterPaymentMethodComponent implements OnInit, OnDestroy {
           const billingDetails = this.group().controls.billingAddress.enabled
             ? this.group().controls.billingAddress.getRawValue()
             : undefined;
-          return this.stripeService.setupCardPaymentMethod(
+          return await this.stripeService.setupCardPaymentMethod(
             this.instanceId,
             clientSecret,
             billingDetails,
           );
         }
         case "payPal": {
-          return this.braintreeService.requestPaymentMethod();
+          return await this.braintreeService.requestPaymentMethod();
         }
       }
     };

--- a/apps/web/src/app/billing/shared/update-license.component.ts
+++ b/apps/web/src/app/billing/shared/update-license.component.ts
@@ -97,7 +97,7 @@ export class UpdateLicenseComponent implements OnInit {
       message: this.i18nService.t("licenseUploadSuccess"),
     });
     this.onUpdated.emit();
-    return new Promise((resolve) => resolve(UpdateLicenseDialogResult.Updated));
+    return await new Promise((resolve) => resolve(UpdateLicenseDialogResult.Updated));
   };
 
   cancel = () => {

--- a/apps/web/src/app/billing/trial-initiation/complete-trial-initiation/complete-trial-initiation.component.ts
+++ b/apps/web/src/app/billing/trial-initiation/complete-trial-initiation/complete-trial-initiation.component.ts
@@ -415,7 +415,7 @@ export class CompleteTrialInitiationComponent implements OnInit, OnDestroy {
 
   async finishRegistration(passwordInputResult: PasswordInputResult) {
     this.submitting = true;
-    return this.registrationFinishService
+    return await this.registrationFinishService
       .finishRegistration(this.email, passwordInputResult, this.emailVerificationToken)
       .catch((e: unknown): null => {
         this.validationService.showError(e);

--- a/bitwarden_license/bit-web/src/app/billing/providers/warnings/services/provider-warnings.service.ts
+++ b/bitwarden_license/bit-web/src/app/billing/providers/warnings/services/provider-warnings.service.ts
@@ -119,7 +119,7 @@ export class ProviderWarningsService {
               cancelButtonText: null,
               acceptAction: async () => {
                 window.open("https://bitwarden.com/contact/", "_blank");
-                return Promise.resolve();
+                return await Promise.resolve();
               },
             });
           }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
Jira Bug: https://bitwarden.atlassian.net/browse/PM-38405
Tracking PR: https://github.com/bitwarden/clients/pull/20981

Note: This PR is split per team ownership to keep it reviewable.

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
We want to enable the return-await eslint rule. Currently, there is a pattern of unawaited promises being returned which is causing production bugs as explained in more detail below. To do this, we first migrate all teams. The migration has been performed automatically with eslint --fix. There aren o other changes other than adding await to the unawaited promises.

### Specifically Bugged Behavior

Returning unawaited promises is currently allowing unexpected bugs to appear. Specifically in this example:

```ts
        await firstValueFrom( // Promise on ref.value gets awaited here
          this.sdkService.userClient$(userId).pipe(
            map((sdk) => {
              if (!sdk) {
                throw new Error("SDK not available");
              }

              using ref = sdk.take();

              return ref.value.user_crypto_management().migrate_to_key_connector(keyConnectorUrl); // but created here. also, the return disposes the ref
            }),
          ),
```

the promise is created inside the observable, but passed out and holds an invalid reference and tries to access it. We fix this by completely banning unawaited promises from being returned.

The more subtle benefits, as pointed out by the eslint rule:
> - Returning an awaited promise [improves stack trace information](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await#improving_stack_trace).
> - When the return statement is in try...catch, awaiting the promise allows the promise's rejection to be caught instead of leaving the error to the caller.
> - Contrary to popular belief, return await promise; is [at least as fast as directly returning the promise](https://github.com/tc39/proposal-faster-promise-adoption).

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

