### PR TITLE
[PM-38405] Await unawaited promises @bitwarden/team-autofill-dev

### DIFF
--- a/apps/browser/src/autofill/background/auto-submit-login.background.ts
+++ b/apps/browser/src/autofill/background/auto-submit-login.background.ts
@@ -289,7 +289,7 @@ export class AutoSubmitLoginBackground implements AutoSubmitLoginBackgroundAbstr
    * Retrieves the authentication status of the active user.
    */
   private getAuthStatus = async () => {
-    return firstValueFrom(this.authService.activeAccountStatus$);
+    return await firstValueFrom(this.authService.activeAccountStatus$);
   };
 
   /**

--- a/apps/browser/src/autofill/background/overlay.background.ts
+++ b/apps/browser/src/autofill/background/overlay.background.ts
@@ -494,7 +494,7 @@ export class OverlayBackground implements OverlayBackgroundInterface {
     }
 
     if (updateAllCipherTypes || !this.cardAndIdentityCiphers) {
-      return this.getAllCipherTypeViews(currentTab, activeUserId);
+      return await this.getAllCipherTypeViews(currentTab, activeUserId);
     }
 
     const cipherViews = (

--- a/apps/browser/src/autofill/browser/context-menu-clicked-handler.ts
+++ b/apps/browser/src/autofill/browser/context-menu-clicked-handler.ts
@@ -391,7 +391,7 @@ export class ContextMenuClickedHandler {
 
   private async getIdentifier(tab: chrome.tabs.Tab, info: chrome.contextMenus.OnClickData) {
     const tabId = tab.id!;
-    return new Promise<string>((resolve, reject) => {
+    return await new Promise<string>((resolve, reject) => {
       BrowserApi.sendTabsMessage(
         tabId,
         { command: "getClickedElement" },

--- a/apps/browser/src/autofill/browser/main-context-menu-handler.ts
+++ b/apps/browser/src/autofill/browser/main-context-menu-handler.ts
@@ -267,7 +267,7 @@ export class MainContextMenuHandler {
       return;
     }
 
-    return new Promise<void>((resolve, reject) => {
+    return await new Promise<void>((resolve, reject) => {
       const itemId = chrome.contextMenus.create(options, () => {
         if (chrome.runtime.lastError) {
           return reject(chrome.runtime.lastError);
@@ -282,7 +282,7 @@ export class MainContextMenuHandler {
   };
 
   static async removeAll() {
-    return new Promise<void>((resolve, reject) => {
+    return await new Promise<void>((resolve, reject) => {
       chrome.contextMenus.removeAll(() => {
         if (chrome.runtime.lastError) {
           reject(chrome.runtime.lastError);

--- a/apps/browser/src/autofill/fido2/background/fido2.background.spec.ts
+++ b/apps/browser/src/autofill/fido2/background/fido2.background.spec.ts
@@ -269,7 +269,7 @@ describe("Fido2Background", () => {
       let duringRequestResult: boolean;
       fido2ClientService.createCredential.mockImplementation(async () => {
         duringRequestResult = fido2Background.isCredentialRequestInProgress(tabMock.id);
-        return mock();
+        return await mock();
       });
 
       const message = mock<Fido2ExtensionMessage>({
@@ -288,7 +288,7 @@ describe("Fido2Background", () => {
       let duringRequestResult: boolean;
       fido2ClientService.assertCredential.mockImplementation(async () => {
         duringRequestResult = fido2Background.isCredentialRequestInProgress(tabMock.id);
-        return mock();
+        return await mock();
       });
 
       const message = mock<Fido2ExtensionMessage>({

--- a/apps/browser/src/autofill/fido2/content/fido2-content-script.ts
+++ b/apps/browser/src/autofill/fido2/content/fido2-content-script.ts
@@ -52,21 +52,21 @@ import { MessageWithMetadata, Messenger } from "./messaging/messenger";
 
     try {
       if (message.type === MessageTypes.CredentialCreationRequest) {
-        return handleCredentialCreationRequestMessage(
+        return await handleCredentialCreationRequestMessage(
           requestId,
           message.data as InsecureCreateCredentialParams,
         );
       }
 
       if (message.type === MessageTypes.CredentialGetRequest) {
-        return handleCredentialGetRequestMessage(
+        return await handleCredentialGetRequestMessage(
           requestId,
           message.data as InsecureAssertCredentialParams,
         );
       }
 
       if (message.type === MessageTypes.AbortRequest) {
-        return sendExtensionMessage("fido2AbortRequest", { abortedRequestId: requestId });
+        return await sendExtensionMessage("fido2AbortRequest", { abortedRequestId: requestId });
       }
     } finally {
       abortController?.signal.removeEventListener("abort", abortHandler);
@@ -83,7 +83,7 @@ import { MessageWithMetadata, Messenger } from "./messaging/messenger";
     requestId: string,
     data: InsecureCreateCredentialParams,
   ): Promise<Message | undefined> {
-    return respondToCredentialRequest(
+    return await respondToCredentialRequest(
       "fido2RegisterCredentialRequest",
       MessageTypes.CredentialCreationResponse,
       requestId,
@@ -101,7 +101,7 @@ import { MessageWithMetadata, Messenger } from "./messaging/messenger";
     requestId: string,
     data: InsecureAssertCredentialParams,
   ): Promise<Message | undefined> {
-    return respondToCredentialRequest(
+    return await respondToCredentialRequest(
       "fido2GetCredentialRequest",
       MessageTypes.CredentialGetResponse,
       requestId,
@@ -135,10 +135,10 @@ import { MessageWithMetadata, Messenger } from "./messaging/messenger";
     const result = await sendExtensionMessage(command, { data, requestId });
 
     if (result && result.error !== undefined) {
-      return Promise.reject(result.error);
+      return await Promise.reject(result.error);
     }
 
-    return Promise.resolve({ type, result });
+    return await Promise.resolve({ type, result });
   }
 
   /**

--- a/apps/browser/src/autofill/overlay/inline-menu/content/autofill-inline-menu-content.service.ts
+++ b/apps/browser/src/autofill/overlay/inline-menu/content/autofill-inline-menu-content.service.ts
@@ -185,10 +185,10 @@ export class AutofillInlineMenuContentService implements AutofillInlineMenuConte
     }
 
     if (overlayElement === AutofillOverlayElement.Button) {
-      return this.appendButtonElement();
+      return await this.appendButtonElement();
     }
 
-    return this.appendListElement();
+    return await this.appendListElement();
   }
 
   /**

--- a/apps/browser/src/autofill/popup/autofill-triage/autofill-triage.component.ts
+++ b/apps/browser/src/autofill/popup/autofill-triage/autofill-triage.component.ts
@@ -191,7 +191,7 @@ export class AutofillTriageComponent implements OnInit, OnDestroy {
   }
 
   private async promptExportWarning(): Promise<boolean> {
-    return this.dialogService.openSimpleDialog({
+    return await this.dialogService.openSimpleDialog({
       title: "Export Report Data",
       content:
         "Carefully review all data before copying. The report may contain form field details, labels, and partial field values — ensure no sensitive information is included before sharing.",

--- a/apps/browser/src/autofill/popup/fido2/fido2.component.ts
+++ b/apps/browser/src/autofill/popup/fido2/fido2.component.ts
@@ -218,7 +218,7 @@ export class Fido2Component implements OnInit, OnDestroy {
             this.ciphers = await Promise.all(
               message.cipherIds.map(async (cipherId) => {
                 const cipher = await this.cipherService.get(cipherId, activeUserId);
-                return this.cipherService.decrypt(cipher, activeUserId);
+                return await this.cipherService.decrypt(cipher, activeUserId);
               }),
             );
 
@@ -237,7 +237,7 @@ export class Fido2Component implements OnInit, OnDestroy {
             this.ciphers = await Promise.all(
               message.existingCipherIds.map(async (cipherId) => {
                 const cipher = await this.cipherService.get(cipherId, activeUserId);
-                return this.cipherService.decrypt(cipher, activeUserId);
+                return await this.cipherService.decrypt(cipher, activeUserId);
               }),
             );
 

--- a/apps/browser/src/autofill/services/autofill-overlay-content.service.ts
+++ b/apps/browser/src/autofill/services/autofill-overlay-content.service.ts
@@ -1075,7 +1075,7 @@ export class AutofillOverlayContentService implements AutofillOverlayContentServ
       return null;
     }
 
-    return new Promise((resolve) => {
+    return await new Promise((resolve) => {
       const intersectionObserver = new IntersectionObserver(
         (entries) => {
           let fieldBoundingClientRects: DOMRectReadOnly | null =

--- a/apps/browser/src/autofill/services/autofill.service.ts
+++ b/apps/browser/src/autofill/services/autofill.service.ts
@@ -777,7 +777,7 @@ export default class AutofillService implements AutofillServiceInterface {
     // This operation is mutually-exclusive from heuristic data-gathering
     const hasTargetedFields = pageDetails.fields.some((f) => f.targeted === true);
     if (hasTargetedFields) {
-      return this.generateTargetedFillScript(pageDetails, options);
+      return await this.generateTargetedFillScript(pageDetails, options);
     }
 
     const fillScript = new AutofillScript();

--- a/apps/browser/src/autofill/utils/index.ts
+++ b/apps/browser/src/autofill/utils/index.ts
@@ -114,10 +114,10 @@ export async function sendExtensionMessage(
     typeof browser.runtime !== "undefined" &&
     typeof browser.runtime.sendMessage !== "undefined"
   ) {
-    return browser.runtime.sendMessage({ command, ...options });
+    return await browser.runtime.sendMessage({ command, ...options });
   }
 
-  return new Promise((resolve) =>
+  return await new Promise((resolve) =>
     chrome.runtime.sendMessage(Object.assign({ command }, options), (response) => {
       if (chrome.runtime.lastError) {
         resolve(null);


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
Jira Bug: https://bitwarden.atlassian.net/browse/PM-38405
Tracking PR: https://github.com/bitwarden/clients/pull/20981

Note: This PR is split per team ownership to keep it reviewable.

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
We want to enable the return-await eslint rule. Currently, there is a pattern of unawaited promises being returned which is causing production bugs as explained in more detail below. To do this, we first migrate all teams. The migration has been performed automatically with eslint --fix. There aren o other changes other than adding await to the unawaited promises.

### Specifically Bugged Behavior

Returning unawaited promises is currently allowing unexpected bugs to appear. Specifically in this example:

```ts
        await firstValueFrom( // Promise on ref.value gets awaited here
          this.sdkService.userClient$(userId).pipe(
            map((sdk) => {
              if (!sdk) {
                throw new Error("SDK not available");
              }

              using ref = sdk.take();

              return ref.value.user_crypto_management().migrate_to_key_connector(keyConnectorUrl); // but created here. also, the return disposes the ref
            }),
          ),
```

the promise is created inside the observable, but passed out and holds an invalid reference and tries to access it. We fix this by completely banning unawaited promises from being returned.

The more subtle benefits, as pointed out by the eslint rule:
> - Returning an awaited promise [improves stack trace information](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await#improving_stack_trace).
> - When the return statement is in try...catch, awaiting the promise allows the promise's rejection to be caught instead of leaving the error to the caller.
> - Contrary to popular belief, return await promise; is [at least as fast as directly returning the promise](https://github.com/tc39/proposal-faster-promise-adoption).

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

