### PR TITLE
[PM-38405] Await unawaited promises @bitwarden/team-data-insights-and-reporting-dev

### DIFF
--- a/apps/browser/src/dirt/phishing-detection/popup/phishing-warning.component.ts
+++ b/apps/browser/src/dirt/phishing-detection/popup/phishing-warning.component.ts
@@ -69,6 +69,6 @@ export class PhishingWarningComponent {
   }
 
   private async getTabId() {
-    return BrowserApi.getCurrentTab()?.then((tab) => tab.id);
+    return await BrowserApi.getCurrentTab()?.then((tab) => tab.id);
   }
 }

--- a/apps/browser/src/dirt/phishing-detection/services/phishing-data.service.ts
+++ b/apps/browser/src/dirt/phishing-detection/services/phishing-data.service.ts
@@ -448,7 +448,7 @@ export class PhishingDataService {
 
     if (applicationVersion !== previous?.applicationVersion) {
       this.logService.info("[PhishingDataService] App version changed — performing full update");
-      return this._performFullUpdate(applicationVersion);
+      return await this._performFullUpdate(applicationVersion);
     }
 
     let manifest: PhishingManifest;
@@ -459,14 +459,14 @@ export class PhishingDataService {
         "[PhishingDataService] Failed to fetch manifest — falling back to legacy sync",
         e,
       );
-      return this._performLegacySync(previous, applicationVersion);
+      return await this._performLegacySync(previous, applicationVersion);
     }
 
     const localSha256 = previous?.sha256;
 
     if (!localSha256) {
       this.logService.info("[PhishingDataService] No local sha256 — performing full update");
-      return this._performFullUpdate(applicationVersion, manifest);
+      return await this._performFullUpdate(applicationVersion, manifest);
     }
 
     if (localSha256 === manifest.full_list.sha256) {
@@ -480,7 +480,7 @@ export class PhishingDataService {
     const resultSha256 = await this.applyPatchChain(manifest, localSha256);
 
     if (resultSha256 === null) {
-      return this._performFullUpdate(applicationVersion, manifest);
+      return await this._performFullUpdate(applicationVersion, manifest);
     }
 
     // Patch chain structure guarantees integrity via from_sha256 -> to_sha256 chaining.

--- a/apps/web/src/app/dirt/reports/pages/organizations/exposed-passwords-report.component.ts
+++ b/apps/web/src/app/dirt/reports/pages/organizations/exposed-passwords-report.component.ts
@@ -114,7 +114,7 @@ export class ExposedPasswordsReportComponent
 
   async getAllCiphers(): Promise<CipherView[]> {
     if (this.organization) {
-      return this.cipherService.getAllFromApiForOrganization(this.organization.id, true);
+      return await this.cipherService.getAllFromApiForOrganization(this.organization.id, true);
     }
     return [];
   }

--- a/apps/web/src/app/dirt/reports/pages/organizations/inactive-two-factor-report.component.ts
+++ b/apps/web/src/app/dirt/reports/pages/organizations/inactive-two-factor-report.component.ts
@@ -125,7 +125,7 @@ export class InactiveTwoFactorReportComponent
 
   async getAllCiphers(): Promise<CipherView[]> {
     if (this.organization) {
-      return this.cipherService.getAllFromApiForOrganization(this.organization.id, true);
+      return await this.cipherService.getAllFromApiForOrganization(this.organization.id, true);
     }
     return [];
   }

--- a/apps/web/src/app/dirt/reports/pages/organizations/reused-passwords-report.component.ts
+++ b/apps/web/src/app/dirt/reports/pages/organizations/reused-passwords-report.component.ts
@@ -112,7 +112,7 @@ export class ReusedPasswordsReportComponent
 
   async getAllCiphers(): Promise<CipherView[]> {
     if (this.organization) {
-      return this.cipherService.getAllFromApiForOrganization(this.organization.id, true);
+      return await this.cipherService.getAllFromApiForOrganization(this.organization.id, true);
     }
     return [];
   }

--- a/apps/web/src/app/dirt/reports/pages/organizations/unsecured-websites-report.component.ts
+++ b/apps/web/src/app/dirt/reports/pages/organizations/unsecured-websites-report.component.ts
@@ -112,7 +112,7 @@ export class UnsecuredWebsitesReportComponent
 
   async getAllCiphers(): Promise<CipherView[]> {
     if (this.organization) {
-      return this.cipherService.getAllFromApiForOrganization(this.organization.id, true);
+      return await this.cipherService.getAllFromApiForOrganization(this.organization.id, true);
     }
     return [];
   }

--- a/apps/web/src/app/dirt/reports/pages/organizations/weak-passwords-report.component.ts
+++ b/apps/web/src/app/dirt/reports/pages/organizations/weak-passwords-report.component.ts
@@ -114,7 +114,7 @@ export class WeakPasswordsReportComponent
 
   async getAllCiphers(): Promise<CipherView[]> {
     if (this.organization) {
-      return this.cipherService.getAllFromApiForOrganization(this.organization.id, true);
+      return await this.cipherService.getAllFromApiForOrganization(this.organization.id, true);
     }
     return [];
   }

--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/onboarding/new-admin-welcome-dialog.component.ts
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/onboarding/new-admin-welcome-dialog.component.ts
@@ -69,7 +69,7 @@ export class NewAdminWelcomeDialogComponent {
     dialogService: DialogService,
     organizationId: OrganizationId,
   ): Promise<DialogRef<unknown, NewAdminWelcomeDialogComponent> | undefined> {
-    return runInInjectionContext(injector, async () => {
+    return await runInInjectionContext(injector, async () => {
       const logger = inject(LogService);
       const onboardingService = inject(OnboardingService);
       const acknowledged = await onboardingService.isNewAdminWelcomeDialogAcknowledged();

--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/onboarding/post-import-modal-dialog.component.ts
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/onboarding/post-import-modal-dialog.component.ts
@@ -57,7 +57,7 @@ export class PostImportModalDialogComponent {
     dialogService: DialogService,
     organizationId: OrganizationId,
   ): Promise<DialogRef<unknown, PostImportModalDialogComponent> | undefined> {
-    return runInInjectionContext(injector, async () => {
+    return await runInInjectionContext(injector, async () => {
       const logger = inject(LogService);
       const onboardingService = inject(OnboardingService);
       const acknowledged = await onboardingService.isPostImportDialogAcknowledged();

--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/onboarding/services/onboarding.service.ts
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/onboarding/services/onboarding.service.ts
@@ -32,7 +32,7 @@ export class OnboardingService {
   private stateProvider = inject(StateProvider);
 
   async isPostImportDialogAcknowledged(): Promise<boolean> {
-    return this.isAcknowledged(ACCESS_INTELLIGENCE_POST_IMPORT_DIALOG_ACKNOWLEDGED_KEY);
+    return await this.isAcknowledged(ACCESS_INTELLIGENCE_POST_IMPORT_DIALOG_ACKNOWLEDGED_KEY);
   }
 
   async setPostImportDialogAcknowledged(value = true) {
@@ -40,7 +40,7 @@ export class OnboardingService {
   }
 
   async isNewAdminWelcomeDialogAcknowledged(): Promise<boolean> {
-    return this.isAcknowledged(ACCESS_INTELLIGENCE_NEW_ADMIN_WELCOME_ACKNOWLEDGED_KEY);
+    return await this.isAcknowledged(ACCESS_INTELLIGENCE_NEW_ADMIN_WELCOME_ACKNOWLEDGED_KEY);
   }
 
   async setNewAdminWelcomeDialogAcknowledged(value = true) {

--- a/bitwarden_license/bit-web/src/app/dirt/reports/member-access-report/services/member-access-report.service.ts
+++ b/bitwarden_license/bit-web/src/app/dirt/reports/member-access-report/services/member-access-report.service.ts
@@ -519,7 +519,7 @@ export class MemberAccessReportService {
 
     const fetchPromise = this.cipherService.getAllFromApiForOrganization(organizationId);
 
-    return Promise.race([fetchPromise, timeoutPromise]).finally(() => {
+    return await Promise.race([fetchPromise, timeoutPromise]).finally(() => {
       clearTimeout(timeoutId);
     });
   }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
Jira Bug: https://bitwarden.atlassian.net/browse/PM-38405
Tracking PR: https://github.com/bitwarden/clients/pull/20981

Note: This PR is split per team ownership to keep it reviewable.

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
We want to enable the return-await eslint rule. Currently, there is a pattern of unawaited promises being returned which is causing production bugs as explained in more detail below. To do this, we first migrate all teams. The migration has been performed automatically with eslint --fix. There aren o other changes other than adding await to the unawaited promises.

### Specifically Bugged Behavior

Returning unawaited promises is currently allowing unexpected bugs to appear. Specifically in this example:

```ts
        await firstValueFrom( // Promise on ref.value gets awaited here
          this.sdkService.userClient$(userId).pipe(
            map((sdk) => {
              if (!sdk) {
                throw new Error("SDK not available");
              }

              using ref = sdk.take();

              return ref.value.user_crypto_management().migrate_to_key_connector(keyConnectorUrl); // but created here. also, the return disposes the ref
            }),
          ),
```

the promise is created inside the observable, but passed out and holds an invalid reference and tries to access it. We fix this by completely banning unawaited promises from being returned.

The more subtle benefits, as pointed out by the eslint rule:
> - Returning an awaited promise [improves stack trace information](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await#improving_stack_trace).
> - When the return statement is in try...catch, awaiting the promise allows the promise's rejection to be caught instead of leaving the error to the caller.
> - Contrary to popular belief, return await promise; is [at least as fast as directly returning the promise](https://github.com/tc39/proposal-faster-promise-adoption).

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

