### PR TITLE
[PM-38405] Await unawaited promises @bitwarden/team-admin-console-dev

### DIFF
--- a/apps/web/src/app/admin-console/organizations/collections/services/vault-cipher-actions.service.ts
+++ b/apps/web/src/app/admin-console/organizations/collections/services/vault-cipher-actions.service.ts
@@ -573,8 +573,8 @@ export class VaultCipherActionsService {
     const organization = await firstValueFrom(this.organization$);
     const asAdmin = organization.canEditAllCiphers || isUnassigned;
     return permanent
-      ? this.cipherService.deleteWithServer(id, userId, asAdmin)
-      : this.cipherService.softDeleteWithServer(id, userId, asAdmin);
+      ? await this.cipherService.deleteWithServer(id, userId, asAdmin)
+      : await this.cipherService.softDeleteWithServer(id, userId, asAdmin);
   }
 
   private async repromptCipher(ciphers: CipherViewLike[]): Promise<boolean> {

--- a/apps/web/src/app/admin-console/organizations/collections/vault-filter/vault-filter.component.spec.ts
+++ b/apps/web/src/app/admin-console/organizations/collections/vault-filter/vault-filter.component.spec.ts
@@ -215,7 +215,7 @@ describe("OrganizationVaultFilterComponent", () => {
         );
 
         const getIds = async () =>
-          firstValueFrom(section.data$).then((tree) => tree.children.map((c) => c.node.id));
+          await firstValueFrom(section.data$).then((tree) => tree.children.map((c) => c.node.id));
 
         // Initially no card ciphers — card should be hidden
         expect(await getIds()).not.toContain("card");

--- a/apps/web/src/app/admin-console/organizations/collections/vault.component.ts
+++ b/apps/web/src/app/admin-console/organizations/collections/vault.component.ts
@@ -1458,8 +1458,8 @@ export class VaultComponent implements OnInit, OnDestroy {
     const organization = await firstValueFrom(this.organization$);
     const asAdmin = organization.canEditAllCiphers || isUnassigned;
     return permanent
-      ? this.cipherService.deleteWithServer(id, userId, asAdmin)
-      : this.cipherService.softDeleteWithServer(id, userId, asAdmin);
+      ? await this.cipherService.deleteWithServer(id, userId, asAdmin)
+      : await this.cipherService.softDeleteWithServer(id, userId, asAdmin);
   }
 
   protected async repromptCipher(ciphers: CipherViewLike[]) {

--- a/apps/web/src/app/admin-console/organizations/guards/org-permissions.guard.spec.ts
+++ b/apps/web/src/app/admin-console/organizations/guards/org-permissions.guard.spec.ts
@@ -91,8 +91,8 @@ describe("Organization Permissions Guard", () => {
     });
 
     it("permits navigation if no permissions are specified", async () => {
-      const actual = await TestBed.runInInjectionContext(async () =>
-        organizationPermissionsGuard()(route, state),
+      const actual = await TestBed.runInInjectionContext(
+        async () => await organizationPermissionsGuard()(route, state),
       );
 
       expect(actual).toBe(true);

--- a/apps/web/src/app/admin-console/organizations/members/services/member-dialog-manager/member-dialog-manager.service.ts
+++ b/apps/web/src/app/admin-console/organizations/members/services/member-dialog-manager/member-dialog-manager.service.ts
@@ -353,7 +353,7 @@ export class MemberDialogManagerService {
   private async openNoMasterPasswordConfirmationDialog(
     user: OrganizationUserView,
   ): Promise<boolean> {
-    return this.dialogService.openSimpleDialog({
+    return await this.dialogService.openSimpleDialog({
       title: {
         key: "removeOrgUserNoMasterPasswordTitle",
       },

--- a/apps/web/src/app/admin-console/organizations/members/services/organization-user-reset-password/organization-user-reset-password.service.ts
+++ b/apps/web/src/app/admin-console/organizations/members/services/organization-user-reset-password/organization-user-reset-password.service.ts
@@ -158,7 +158,7 @@ export class OrganizationUserResetPasswordService implements UserKeyRotationKeyR
     orgUserId: string,
     orgId: OrganizationId,
   ): Promise<void> {
-    return this.recoverAccount({
+    return await this.recoverAccount({
       organizationUserId: orgUserId,
       organizationId: orgId,
       resetMasterPassword: true,

--- a/apps/web/src/app/admin-console/organizations/policies/policies-deactivate.guard.ts
+++ b/apps/web/src/app/admin-console/organizations/policies/policies-deactivate.guard.ts
@@ -30,6 +30,6 @@ export class PoliciesDeactivateGuard implements CanDeactivate<PoliciesComponent>
     if (status !== AuthenticationStatus.Unlocked) {
       return true;
     }
-    return component.canDeactivate();
+    return await component.canDeactivate();
   }
 }

--- a/apps/web/src/app/admin-console/organizations/policies/policy-edit-definitions/auto-confirm-policy.component.spec.ts
+++ b/apps/web/src/app/admin-console/organizations/policies/policy-edit-definitions/auto-confirm-policy.component.spec.ts
@@ -95,7 +95,7 @@ describe("AutoConfirmPolicyEditComponent — policySteps[0].sideEffect", () => {
   });
 
   async function runSideEffect() {
-    return component.policySteps[0].sideEffect!();
+    return await component.policySteps[0].sideEffect!();
   }
 
   describe("SingleOrg prerequisite enablement", () => {

--- a/bitwarden_license/bit-web/src/app/admin-console/providers/manage/members.component.ts
+++ b/bitwarden_license/bit-web/src/app/admin-console/providers/manage/members.component.ts
@@ -270,7 +270,7 @@ export class MembersComponent {
   }
 
   private async removeUserConfirmationDialog(user: ProviderUser) {
-    return this.dialogService.openSimpleDialog({
+    return await this.dialogService.openSimpleDialog({
       title: this.userNamePipe.transform(user),
       content: { key: "removeUserConfirmation" },
       type: "warning",

--- a/libs/admin-console/src/common/collections/services/default-collection-admin.service.ts
+++ b/libs/admin-console/src/common/collections/services/default-collection-admin.service.ts
@@ -136,7 +136,7 @@ export class DefaultCollectionAdminService implements CollectionAdminService {
   ): Promise<CollectionAdminView[]> {
     const promises = collections.map(async (c) => {
       if (isCollectionAccessDetailsResponse(c)) {
-        return CollectionAdminView.fromCollectionAccessDetails(
+        return await CollectionAdminView.fromCollectionAccessDetails(
           c,
           this.encryptService,
           orgKeys[organizationId as OrganizationId],

--- a/libs/admin-console/src/common/collections/services/default-collection-encryption.service.ts
+++ b/libs/admin-console/src/common/collections/services/default-collection-encryption.service.ts
@@ -29,7 +29,7 @@ export class DefaultCollectionEncryptionService implements CollectionEncryptionS
       return [];
     }
 
-    return firstValueFrom(
+    return await firstValueFrom(
       this.sdkService.userClient$(userId).pipe(
         concatMap(async (sdk) => {
           if (!sdk) {

--- a/libs/common/src/admin-console/services/organization/organization-api.service.ts
+++ b/libs/common/src/admin-console/services/organization/organization-api.service.ts
@@ -79,7 +79,7 @@ export class OrganizationApiService implements OrganizationApiServiceAbstraction
   }
 
   async getLicense(id: string, installationId: string): Promise<unknown> {
-    return this.apiService.send(
+    return await this.apiService.send(
       "GET",
       "/organizations/" + id + "/license?installationId=" + installationId,
       null,
@@ -201,7 +201,13 @@ export class OrganizationApiService implements OrganizationApiServiceAbstraction
   }
 
   async reinstate(id: string): Promise<void> {
-    return this.apiService.send("POST", "/organizations/" + id + "/reinstate", null, true, false);
+    return await this.apiService.send(
+      "POST",
+      "/organizations/" + id + "/reinstate",
+      null,
+      true,
+      false,
+    );
   }
 
   async leave(id: string): Promise<void> {
@@ -238,7 +244,7 @@ export class OrganizationApiService implements OrganizationApiServiceAbstraction
   }
 
   async importDirectory(organizationId: string, request: ImportDirectoryRequest): Promise<void> {
-    return this.apiService.send(
+    return await this.apiService.send(
       "POST",
       "/organizations/" + organizationId + "/import",
       request,

--- a/libs/common/src/admin-console/services/policy/policy-api.service.ts
+++ b/libs/common/src/admin-console/services/policy/policy-api.service.ts
@@ -99,7 +99,7 @@ export class PolicyApiService implements PolicyApiServiceAbstraction {
         return null;
       }
 
-      return firstValueFrom(
+      return await firstValueFrom(
         this.accountService.activeAccount$.pipe(
           getUserId,
           switchMap((userId) =>


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
Jira Bug: https://bitwarden.atlassian.net/browse/PM-38405
Tracking PR: https://github.com/bitwarden/clients/pull/20981

Note: This PR is split per team ownership to keep it reviewable.

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
We want to enable the return-await eslint rule. Currently, there is a pattern of unawaited promises being returned which is causing production bugs as explained in more detail below. To do this, we first migrate all teams. The migration has been performed automatically with eslint --fix. There aren o other changes other than adding await to the unawaited promises.

### Specifically Bugged Behavior

Returning unawaited promises is currently allowing unexpected bugs to appear. Specifically in this example:

```ts
        await firstValueFrom( // Promise on ref.value gets awaited here
          this.sdkService.userClient$(userId).pipe(
            map((sdk) => {
              if (!sdk) {
                throw new Error("SDK not available");
              }

              using ref = sdk.take();

              return ref.value.user_crypto_management().migrate_to_key_connector(keyConnectorUrl); // but created here. also, the return disposes the ref
            }),
          ),
```

the promise is created inside the observable, but passed out and holds an invalid reference and tries to access it. We fix this by completely banning unawaited promises from being returned.

The more subtle benefits, as pointed out by the eslint rule:
> - Returning an awaited promise [improves stack trace information](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await#improving_stack_trace).
> - When the return statement is in try...catch, awaiting the promise allows the promise's rejection to be caught instead of leaving the error to the caller.
> - Contrary to popular belief, return await promise; is [at least as fast as directly returning the promise](https://github.com/tc39/proposal-faster-promise-adoption).

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

