### PR TITLE
[PM-38405] Await unawaited promises @bitwarden/team-vault-dev

### DIFF
--- a/apps/browser/src/vault/popup/components/vault/vault.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/vault.component.ts
@@ -343,7 +343,7 @@ export class VaultComponent implements OnInit, OnDestroy {
             }
           }
 
-          return this.autoConfirmService.upsert(userId, newState);
+          return await this.autoConfirmService.upsert(userId, newState);
         }),
         takeUntilDestroyed(this.destroyRef),
       )

--- a/apps/cli/src/vault/archive.command.ts
+++ b/apps/cli/src/vault/archive.command.ts
@@ -28,7 +28,7 @@ export class ArchiveCommand {
     const normalizedObject = object.toLowerCase();
 
     if (normalizedObject === "item") {
-      return this.archiveCipher(id);
+      return await this.archiveCipher(id);
     }
 
     return Response.badRequest("Unknown object.");

--- a/apps/cli/src/vault/services/cli-restricted-item-types.service.ts
+++ b/apps/cli/src/vault/services/cli-restricted-item-types.service.ts
@@ -16,7 +16,7 @@ export class CliRestrictedItemTypesService {
    * @returns Promise resolving to array of restricted cipher types with allowed organization IDs
    */
   async getRestrictedTypes(): Promise<RestrictedCipherType[]> {
-    return firstValueFrom(this.restrictedItemTypesService.restricted$);
+    return await firstValueFrom(this.restrictedItemTypesService.restricted$);
   }
 
   /**
@@ -40,6 +40,6 @@ export class CliRestrictedItemTypesService {
    * @returns Promise resolving to true if the cipher type is restricted, false otherwise
    */
   async isCipherRestricted(cipher: Cipher | CipherView): Promise<boolean> {
-    return firstValueFrom(this.restrictedItemTypesService.isCipherRestricted$(cipher));
+    return await firstValueFrom(this.restrictedItemTypesService.isCipherRestricted$(cipher));
   }
 }

--- a/apps/web/src/app/vault/guards/premium-interest-redirect/premium-interest-redirect.guard.spec.ts
+++ b/apps/web/src/app/vault/guards/premium-interest-redirect/premium-interest-redirect.guard.spec.ts
@@ -43,8 +43,8 @@ describe("premiumInterestRedirectGuard", () => {
   function runPremiumInterestGuard(route?: ActivatedRouteSnapshot) {
     // Run the guard within injection context so `inject` works as you'd expect
     // Pass state object to make TypeScript happy
-    return TestBed.runInInjectionContext(async () =>
-      premiumInterestRedirectGuard(route ?? emptyRoute, _state),
+    return TestBed.runInInjectionContext(
+      async () => await premiumInterestRedirectGuard(route ?? emptyRoute, _state),
     );
   }
 

--- a/apps/web/src/app/vault/guards/setup-extension-redirect.guard.spec.ts
+++ b/apps/web/src/app/vault/guards/setup-extension-redirect.guard.spec.ts
@@ -50,8 +50,8 @@ describe("setupExtensionRedirectGuard", () => {
   function setupExtensionGuard(route?: ActivatedRouteSnapshot) {
     // Run the guard within injection context so `inject` works as you'd expect
     // Pass state object to make TypeScript happy
-    return TestBed.runInInjectionContext(async () =>
-      setupExtensionRedirectGuard(route ?? emptyRoute, _state),
+    return TestBed.runInInjectionContext(
+      async () => await setupExtensionRedirectGuard(route ?? emptyRoute, _state),
     );
   }
 

--- a/apps/web/src/app/vault/individual-vault/vault.component.ts
+++ b/apps/web/src/app/vault/individual-vault/vault.component.ts
@@ -1009,7 +1009,7 @@ export class VaultComponent<C extends CipherViewLike> implements OnInit, OnDestr
   }
 
   async editCipher(cipher: CipherView | CipherListView, cloneMode?: boolean) {
-    return this.editCipherId(uuidAsString(cipher.id), cloneMode);
+    return await this.editCipherId(uuidAsString(cipher.id), cloneMode);
   }
 
   /**
@@ -1631,7 +1631,7 @@ export class VaultComponent<C extends CipherViewLike> implements OnInit, OnDestr
    */
   private async getPasswordFromCipherViewLike(cipher: C): Promise<string | undefined> {
     if (!CipherViewLikeUtils.isCipherListView(cipher)) {
-      return Promise.resolve(cipher?.login?.password);
+      return await Promise.resolve(cipher?.login?.password);
     }
 
     const activeUserId = await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId));

--- a/libs/angular/src/vault/services/vault-profile.service.ts
+++ b/libs/angular/src/vault/services/vault-profile.service.ts
@@ -27,7 +27,7 @@ export class VaultProfileService {
    */
   async getProfileCreationDate(userId: string): Promise<Date> {
     if (this.profileCreatedDate && userId === this.userId) {
-      return Promise.resolve(new Date(this.profileCreatedDate));
+      return await Promise.resolve(new Date(this.profileCreatedDate));
     }
 
     const profile = await this.fetchAndCacheProfile();

--- a/libs/common/src/vault/models/domain/card.ts
+++ b/libs/common/src/vault/models/domain/card.ts
@@ -32,7 +32,7 @@ export class Card extends Domain {
   }
 
   async decrypt(encKey: SymmetricCryptoKey, context = "No Cipher Context"): Promise<CardView> {
-    return this.decryptObj<Card, CardView>(
+    return await this.decryptObj<Card, CardView>(
       this,
       new CardView(),
       ["cardholderName", "brand", "number", "expMonth", "expYear", "code"],

--- a/libs/common/src/vault/notifications/services/default-end-user-notification.service.ts
+++ b/libs/common/src/vault/notifications/services/default-end-user-notification.service.ts
@@ -187,7 +187,7 @@ export class DefaultEndUserNotificationService implements EndUserNotificationSer
     userId: UserId,
     notification: NotificationViewData,
   ): Promise<NotificationViewData[] | null> {
-    return this.notificationState(userId).update((current) => {
+    return await this.notificationState(userId).update((current) => {
       current ??= [];
 
       const existingIndex = current.findIndex((n) => n.id === notification.id);

--- a/libs/common/src/vault/services/cipher.service.spec.ts
+++ b/libs/common/src/vault/services/cipher.service.spec.ts
@@ -1568,7 +1568,7 @@ describe("Cipher Service", () => {
         name: `Enc ${id}`,
       }) as CipherData;
 
-    const tick = async () => new Promise((r) => setTimeout(r, 0));
+    const tick = async () => await new Promise((r) => setTimeout(r, 0));
 
     const setEncryptedState = async (data: Record<CipherId, CipherData>, uid = userId) => {
       // Directly set the encrypted state, this will result in a single emission

--- a/libs/common/src/vault/services/cipher.service.ts
+++ b/libs/common/src/vault/services/cipher.service.ts
@@ -429,7 +429,7 @@ export class CipherService implements CipherServiceAbstraction {
   async getAllDecrypted(userId: UserId): Promise<CipherView[]> {
     const useSdk = await firstValueFrom(this.sdkCipherCrudEnabled$);
     if (useSdk) {
-      return this.getAllDecryptedUsingSdk(userId);
+      return await this.getAllDecryptedUsingSdk(userId);
     }
 
     const decCiphers = await this.getDecryptedCiphers(userId);
@@ -560,7 +560,7 @@ export class CipherService implements CipherServiceAbstraction {
   }
 
   async getAllDecryptedForIds(userId: UserId, ids: string[]): Promise<CipherView[]> {
-    return firstValueFrom(
+    return await firstValueFrom(
       this.cipherViews$(userId).pipe(
         filter((ciphers) => ciphers != null),
         map((ciphers) => ciphers.filter((cipher) => ids.includes(cipher.id))),
@@ -635,7 +635,10 @@ export class CipherService implements CipherServiceAbstraction {
   ): Promise<CipherView[]> {
     const useSdk = await firstValueFrom(this.sdkCipherCrudEnabled$);
     if (useSdk) {
-      return this.getAllFromApiForOrganizationUsingSdk(organizationId, includeMemberItems ?? false);
+      return await this.getAllFromApiForOrganizationUsingSdk(
+        organizationId,
+        includeMemberItems ?? false,
+      );
     }
 
     const response = await this.apiService.getCiphersOrganization(
@@ -676,7 +679,7 @@ export class CipherService implements CipherServiceAbstraction {
   async getManyFromApiForOrganization(organizationId: string): Promise<CipherView[]> {
     const useSdk = await firstValueFrom(this.sdkCipherAdminOpsEnabled$);
     if (useSdk) {
-      return this.getManyFromApiForOrganizationUsingSdk(organizationId);
+      return await this.getManyFromApiForOrganizationUsingSdk(organizationId);
     }
 
     const r = await this.apiService.send(
@@ -687,7 +690,7 @@ export class CipherService implements CipherServiceAbstraction {
       true,
     );
     const response = new ListResponse(r, CipherResponse);
-    return this.decryptOrganizationCiphersResponse(response, organizationId);
+    return await this.decryptOrganizationCiphersResponse(response, organizationId);
   }
 
   private async getManyFromApiForOrganizationUsingSdk(
@@ -739,7 +742,7 @@ export class CipherService implements CipherServiceAbstraction {
     userId: UserId,
     autofillOnPageLoad = false,
   ): Promise<CipherView> {
-    return this.getCipherForUrl(url, userId, true, false, autofillOnPageLoad);
+    return await this.getCipherForUrl(url, userId, true, false, autofillOnPageLoad);
   }
 
   async getLastLaunchedForUrl(
@@ -747,11 +750,11 @@ export class CipherService implements CipherServiceAbstraction {
     userId: UserId,
     autofillOnPageLoad = false,
   ): Promise<CipherView> {
-    return this.getCipherForUrl(url, userId, false, true, autofillOnPageLoad);
+    return await this.getCipherForUrl(url, userId, false, true, autofillOnPageLoad);
   }
 
   async getNextCipherForUrl(url: string, userId: UserId): Promise<CipherView> {
-    return this.getCipherForUrl(url, userId, false, false, false);
+    return await this.getCipherForUrl(url, userId, false, false, false);
   }
 
   async getNextCardCipher(userId: UserId): Promise<CipherView> {
@@ -994,7 +997,7 @@ export class CipherService implements CipherServiceAbstraction {
   ): Promise<Cipher> {
     const useSdkShare = await firstValueFrom(this.sdkCipherShareEnabled$);
     if (useSdkShare) {
-      return this.shareWithServerUsingSdk(
+      return await this.shareWithServerUsingSdk(
         cipher,
         organizationId,
         collectionIds,
@@ -1041,7 +1044,7 @@ export class CipherService implements CipherServiceAbstraction {
   ) {
     const useSdkShare = await firstValueFrom(this.sdkCipherShareEnabled$);
     if (useSdkShare) {
-      return this.shareManyWithServerUsingSdk(ciphers, organizationId, collectionIds, userId);
+      return await this.shareManyWithServerUsingSdk(ciphers, organizationId, collectionIds, userId);
     }
 
     const promises: Promise<any>[] = [];
@@ -1522,7 +1525,7 @@ export class CipherService implements CipherServiceAbstraction {
         ? await this.apiService.deleteCipherAttachmentAdmin(id, attachmentId)
         : await this.apiService.deleteCipherAttachment(id, attachmentId);
     } catch (e) {
-      return Promise.reject((e as ErrorResponse).getSingleMessage());
+      return await Promise.reject((e as ErrorResponse).getSingleMessage());
     }
 
     const cipherData = new CipherData(response.cipher);
@@ -1829,7 +1832,7 @@ export class CipherService implements CipherServiceAbstraction {
 
     if (!useLegacyDecryption) {
       const encryptedContent = await response.arrayBuffer();
-      return this.cipherEncryptionService.decryptAttachmentContent(
+      return await this.cipherEncryptionService.decryptAttachmentContent(
         cipherDomain,
         attachment,
         new Uint8Array(encryptedContent),
@@ -2386,7 +2389,7 @@ export class CipherService implements CipherServiceAbstraction {
     );
 
     // Finally, we can encrypt the cipher with the decrypted cipher key.
-    return this.encryptCipher(model, cipher, decryptedCipherKey);
+    return await this.encryptCipher(model, cipher, decryptedCipherKey);
   }
 
   private async getCipherKeyEncryptionEnabled(): Promise<boolean> {
@@ -2469,9 +2472,9 @@ export class CipherService implements CipherServiceAbstraction {
         this.accountService.activeAccount$.pipe(map((a) => a?.id)),
       );
       const cipher = await this.get(uuidAsString(c.id!), activeUserId);
-      return this.decrypt(cipher, activeUserId);
+      return await this.decrypt(cipher, activeUserId);
     }
 
-    return Promise.resolve(c);
+    return await Promise.resolve(c);
   }
 }

--- a/libs/common/src/vault/services/default-cipher-encryption.service.ts
+++ b/libs/common/src/vault/services/default-cipher-encryption.service.ts
@@ -21,7 +21,7 @@ export class DefaultCipherEncryptionService implements CipherEncryptionService {
   ) {}
 
   async encrypt(model: CipherView, userId: UserId): Promise<EncryptionContext | undefined> {
-    return firstValueFrom(
+    return await firstValueFrom(
       this.sdkService.userClient$(userId).pipe(
         concatMap(async (sdk) => {
           if (!sdk) {
@@ -51,7 +51,7 @@ export class DefaultCipherEncryptionService implements CipherEncryptionService {
       return [];
     }
 
-    return firstValueFrom(
+    return await firstValueFrom(
       this.sdkService.userClient$(userId).pipe(
         concatMap(async (sdk) => {
           if (!sdk) {
@@ -84,7 +84,7 @@ export class DefaultCipherEncryptionService implements CipherEncryptionService {
     organizationId: OrganizationId,
     userId: UserId,
   ): Promise<EncryptionContext | undefined> {
-    return firstValueFrom(
+    return await firstValueFrom(
       this.sdkService.userClient$(userId).pipe(
         concatMap(async (sdk) => {
           if (!sdk) {
@@ -119,7 +119,7 @@ export class DefaultCipherEncryptionService implements CipherEncryptionService {
     userId: UserId,
     newKey: UserKey,
   ): Promise<EncryptionContext | undefined> {
-    return firstValueFrom(
+    return await firstValueFrom(
       this.sdkService.userClient$(userId).pipe(
         concatMap(async (sdk) => {
           if (!sdk) {
@@ -148,7 +148,7 @@ export class DefaultCipherEncryptionService implements CipherEncryptionService {
   }
 
   async decrypt(cipher: Cipher, userId: UserId): Promise<CipherView> {
-    return firstValueFrom(
+    return await firstValueFrom(
       this.sdkService.userClient$(userId).pipe(
         concatMap(async (sdk) => {
           if (!sdk) {
@@ -262,7 +262,7 @@ export class DefaultCipherEncryptionService implements CipherEncryptionService {
     ciphers: Cipher[],
     userId: UserId,
   ): Promise<[CipherListView[], Cipher[]]> {
-    return firstValueFrom(
+    return await firstValueFrom(
       this.sdkService.userClient$(userId).pipe(
         concatMap(async (sdk) => {
           if (!sdk) {
@@ -303,7 +303,7 @@ export class DefaultCipherEncryptionService implements CipherEncryptionService {
     encryptedContent: Uint8Array,
     userId: UserId,
   ): Promise<Uint8Array> {
-    return firstValueFrom(
+    return await firstValueFrom(
       this.sdkService.userClient$(userId).pipe(
         map((sdk) => {
           if (!sdk) {

--- a/libs/vault/src/services/default-vault-items-transfer.service.ts
+++ b/libs/vault/src/services/default-vault-items-transfer.service.ts
@@ -138,7 +138,7 @@ export class DefaultVaultItemsTransferService implements VaultItemsTransferServi
     const leaveResult = await firstValueFrom(leaveDialogRef.closed);
 
     if (leaveResult === LeaveConfirmationDialogResult.Back) {
-      return this.promptUserForTransfer(organizationName);
+      return await this.promptUserForTransfer(organizationName);
     }
 
     return false;


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
Jira Bug: https://bitwarden.atlassian.net/browse/PM-38405
Tracking PR: https://github.com/bitwarden/clients/pull/20981

Note: This PR is split per team ownership to keep it reviewable.

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
We want to enable the return-await eslint rule. Currently, there is a pattern of unawaited promises being returned which is causing production bugs as explained in more detail below. To do this, we first migrate all teams. The migration has been performed automatically with eslint --fix. There aren o other changes other than adding await to the unawaited promises.

### Specifically Bugged Behavior

Returning unawaited promises is currently allowing unexpected bugs to appear. Specifically in this example:

```ts
        await firstValueFrom( // Promise on ref.value gets awaited here
          this.sdkService.userClient$(userId).pipe(
            map((sdk) => {
              if (!sdk) {
                throw new Error("SDK not available");
              }

              using ref = sdk.take();

              return ref.value.user_crypto_management().migrate_to_key_connector(keyConnectorUrl); // but created here. also, the return disposes the ref
            }),
          ),
```

the promise is created inside the observable, but passed out and holds an invalid reference and tries to access it. We fix this by completely banning unawaited promises from being returned.

The more subtle benefits, as pointed out by the eslint rule:
> - Returning an awaited promise [improves stack trace information](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await#improving_stack_trace).
> - When the return statement is in try...catch, awaiting the promise allows the promise's rejection to be caught instead of leaving the error to the caller.
> - Contrary to popular belief, return await promise; is [at least as fast as directly returning the promise](https://github.com/tc39/proposal-faster-promise-adoption).

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

