### PR TITLE
[PM-38405] Fix SDK ref leaking out of scope and add eslint rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -83,6 +83,7 @@ export default tseslint.config(
       "@bitwarden/platform/required-using": "error",
       "@bitwarden/platform/no-enums": "error",
       "@bitwarden/platform/no-page-script-url-leakage": "error",
+      "@bitwarden/platform/no-unawaited-using-return": "error",
       "@bitwarden/components/require-theme-colors-in-svg": "error",
 
       "@typescript-eslint/explicit-member-accessibility": ["error", { accessibility: "no-public" }],

--- a/libs/common/src/key-management/kdf/change-kdf.service.ts
+++ b/libs/common/src/key-management/kdf/change-kdf.service.ts
@@ -33,7 +33,7 @@ export class DefaultChangeKdfService implements ChangeKdfService {
     assertNonNullish(userId, "userId");
     const updateKdfResult = await firstValueFrom(
       this.sdkService.userClient$(userId).pipe(
-        map((sdk) => {
+        map(async (sdk) => {
           if (!sdk) {
             throw new Error("SDK not available");
           }
@@ -43,7 +43,7 @@ export class DefaultChangeKdfService implements ChangeKdfService {
           const updateKdfResponse = ref.value
             .crypto()
             .make_update_kdf(masterPassword, kdf.toSdkConfig());
-          return updateKdfResponse;
+          return await updateKdfResponse;
         }),
       ),
     );

--- a/libs/common/src/key-management/key-connector/services/key-connector.service.ts
+++ b/libs/common/src/key-management/key-connector/services/key-connector.service.ts
@@ -145,7 +145,9 @@ export class KeyConnectorService implements KeyConnectorServiceAbstraction {
 
               using ref = sdk.take();
 
-              return await ref.value.user_crypto_management().migrate_to_key_connector(keyConnectorUrl);
+              return await ref.value
+                .user_crypto_management()
+                .migrate_to_key_connector(keyConnectorUrl);
             }),
           ),
         );

--- a/libs/common/src/key-management/key-connector/services/key-connector.service.ts
+++ b/libs/common/src/key-management/key-connector/services/key-connector.service.ts
@@ -138,14 +138,14 @@ export class KeyConnectorService implements KeyConnectorServiceAbstraction {
       try {
         await firstValueFrom(
           this.sdkService.userClient$(userId).pipe(
-            map((sdk) => {
+            map(async (sdk) => {
               if (!sdk) {
                 throw new Error("SDK not available");
               }
 
               using ref = sdk.take();
 
-              return ref.value.user_crypto_management().migrate_to_key_connector(keyConnectorUrl);
+              return await ref.value.user_crypto_management().migrate_to_key_connector(keyConnectorUrl);
             }),
           ),
         );
@@ -245,14 +245,14 @@ export class KeyConnectorService implements KeyConnectorServiceAbstraction {
   ) {
     const result = await firstValueFrom(
       this.registerSdkService.registerClient$(userId).pipe(
-        map((sdk) => {
+        map(async (sdk) => {
           if (!sdk) {
             throw new Error("SDK not available");
           }
 
           using ref = sdk.take();
 
-          return ref.value
+          return await ref.value
             .auth()
             .registration()
             .post_keys_for_key_connector_registration(keyConnectorUrl, ssoOrganizationIdentifier);

--- a/libs/eslint/platform/index.mjs
+++ b/libs/eslint/platform/index.mjs
@@ -1,11 +1,13 @@
 import requiredUsing from "./required-using.mjs";
 import noEnums from "./no-enums.mjs";
 import noPageScriptUrlLeakage from "./no-page-script-url-leakage.mjs";
+import noUnawaitedUsingReturn from "./no-unawaited-using-return.mjs";
 
 export default {
   rules: {
     "required-using": requiredUsing,
     "no-enums": noEnums,
     "no-page-script-url-leakage": noPageScriptUrlLeakage,
+    "no-unawaited-using-return": noUnawaitedUsingReturn,
   },
 };

--- a/libs/eslint/platform/no-unawaited-using-return.mjs
+++ b/libs/eslint/platform/no-unawaited-using-return.mjs
@@ -1,0 +1,145 @@
+import { ESLintUtils } from "@typescript-eslint/utils";
+
+export const errorMessage =
+  "Returning an unawaited Promise from a scope with a `using` declaration disposes the resource before the Promise settles. Await the value before returning.";
+
+const FUNCTION_TYPES = new Set([
+  "FunctionDeclaration",
+  "FunctionExpression",
+  "ArrowFunctionExpression",
+]);
+
+const USING_KINDS = new Set(["using", "await using"]);
+
+export default {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow returning an unawaited Promise from a scope that holds a `using` resource",
+      category: "Possible Errors",
+      recommended: false,
+    },
+    fixable: "code",
+    schema: [],
+  },
+  create(context) {
+    const parserServices = ESLintUtils.getParserServices(context);
+    const checker = parserServices.program.getTypeChecker();
+
+    function isThenable(node) {
+      const tsNode = parserServices.esTreeNodeToTSNodeMap.get(node);
+      if (!tsNode) {
+        return false;
+      }
+
+      const type = checker.getTypeAtLocation(tsNode);
+      const constituents = type.isUnion() ? type.types : [type];
+
+      return constituents.some((constituent) => {
+        const thenSymbol = constituent.getProperty("then");
+        if (!thenSymbol) {
+          return false;
+        }
+
+        const thenType = checker.getTypeOfSymbolAtLocation(thenSymbol, tsNode);
+        return thenType.getCallSignatures().length > 0;
+      });
+    }
+
+    function nearestFunction(node) {
+      let current = node.parent;
+      while (current) {
+        if (FUNCTION_TYPES.has(current.type)) {
+          return current;
+        }
+        current = current.parent;
+      }
+      return null;
+    }
+
+    // Walks up from the return to the enclosing function, looking for a `using`/`await using`
+    // declaration in any enclosing block that appears lexically before the return. Such a
+    // resource is live at the return and will be disposed when the return exits its block.
+    function hasLiveUsingInScope(returnNode, fn) {
+      let child = returnNode;
+      let parent = returnNode.parent;
+
+      while (parent) {
+        let body = null;
+        if (parent.type === "BlockStatement" || parent.type === "StaticBlock") {
+          body = parent.body;
+        } else if (parent.type === "SwitchCase") {
+          body = parent.consequent;
+        }
+
+        if (body) {
+          const idx = body.indexOf(child);
+          const limit = idx === -1 ? body.length : idx;
+          for (let i = 0; i < limit; i++) {
+            const stmt = body[i];
+            if (stmt.type === "VariableDeclaration" && USING_KINDS.has(stmt.kind)) {
+              return true;
+            }
+          }
+        }
+
+        if (parent === fn) {
+          break;
+        }
+
+        child = parent;
+        parent = parent.parent;
+      }
+
+      return false;
+    }
+
+    function asyncInsertTarget(fn) {
+      const parent = fn.parent;
+      if (
+        parent &&
+        (parent.type === "MethodDefinition" ||
+          (parent.type === "Property" && parent.method) ||
+          parent.type === "PropertyDefinition")
+      ) {
+        return parent.key;
+      }
+      return fn;
+    }
+
+    return {
+      ReturnStatement(node) {
+        const argument = node.argument;
+        if (!argument || argument.type === "AwaitExpression") {
+          return;
+        }
+
+        const fn = nearestFunction(node);
+        if (!fn) {
+          return;
+        }
+
+        if (!hasLiveUsingInScope(node, fn)) {
+          return;
+        }
+
+        if (!isThenable(argument)) {
+          return;
+        }
+
+        context.report({
+          node: argument,
+          message: errorMessage,
+          fix(fixer) {
+            const fixes = [fixer.insertTextBefore(argument, "await ")];
+            if (!fn.async) {
+              fixes.push(fixer.insertTextBefore(asyncInsertTarget(fn), "async "));
+            }
+            return fixes;
+          },
+        });
+      },
+    };
+  },
+};

--- a/libs/eslint/platform/no-unawaited-using-return.spec.mjs
+++ b/libs/eslint/platform/no-unawaited-using-return.spec.mjs
@@ -1,0 +1,118 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+
+import rule, { errorMessage } from "./no-unawaited-using-return.mjs";
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parserOptions: {
+      projectService: {
+        allowDefaultProject: ["*.ts*"],
+      },
+      tsconfigRootDir: __dirname + "/..",
+    },
+  },
+});
+
+const decl = `declare function take(): { value: { foo(): Promise<string>; name: string } };`;
+
+ruleTester.run("no-unawaited-using-return", rule.default, {
+  valid: [
+    {
+      name: "Awaited return inside using scope",
+      code: `
+${decl}
+async function f() {
+  using ref = take();
+  return await ref.value.foo();
+}
+`,
+    },
+    {
+      name: "Returning a non-Promise value from a using scope",
+      code: `
+${decl}
+function f(): string {
+  using ref = take();
+  return ref.value.name;
+}
+`,
+    },
+    {
+      name: "Promise return with no using in scope",
+      code: `
+${decl}
+function f() {
+  return take().value.foo();
+}
+`,
+    },
+    {
+      name: "Side effect with no return",
+      code: `
+${decl}
+async function f() {
+  using ref = take();
+  await ref.value.foo();
+}
+`,
+    },
+  ],
+  invalid: [
+    {
+      name: "Sync arrow returns unawaited Promise built from using resource",
+      code: `
+${decl}
+const cb = (x: number) => {
+  using ref = take();
+  return ref.value.foo();
+};
+`,
+      output: `
+${decl}
+const cb = async (x: number) => {
+  using ref = take();
+  return await ref.value.foo();
+};
+`,
+      errors: [{ message: errorMessage }],
+    },
+    {
+      name: "Aliased Promise returned without await",
+      code: `
+${decl}
+function f() {
+  using ref = take();
+  const p = ref.value.foo();
+  return p;
+}
+`,
+      output: `
+${decl}
+async function f() {
+  using ref = take();
+  const p = ref.value.foo();
+  return await p;
+}
+`,
+      errors: [{ message: errorMessage }],
+    },
+    {
+      name: "Async function returns unawaited Promise from using scope",
+      code: `
+${decl}
+async function g() {
+  using ref = take();
+  return ref.value.foo();
+}
+`,
+      output: `
+${decl}
+async function g() {
+  using ref = take();
+  return await ref.value.foo();
+}
+`,
+      errors: [{ message: errorMessage }],
+    },
+  ],
+});


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
Jira Bug: https://bitwarden.atlassian.net/browse/PM-38405

## 📔 Objective

```ts
        await firstValueFrom( // Promise on ref.value gets awaited here
          this.sdkService.userClient$(userId).pipe(
            map((sdk) => {
              if (!sdk) {
                throw new Error("SDK not available");
              }

              using ref = sdk.take();

              return ref.value.user_crypto_management().migrate_to_key_connector(keyConnectorUrl); // but created here. also, the return disposes the ref
            }),
          ),
```

the promise is created inside the observable, but passed out and holds an invalid reference and tries to access it. It should be awaited.

This PR fixes existing cases and adds an eslint rule that enforces correct behavior. It is no longer allowed to return unawaited promised if a using lives in the scope. This is not possible with existing eslint rules.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

