### PR TITLE
Remove cargo-deny check from the pre-commit hooks

### DIFF
--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -13,6 +13,5 @@ export default {
   "apps/desktop/desktop_native/**/Cargo.toml": () => [
     "node scripts/run-cargo-tool.mjs sort --workspace --check",
     "node scripts/run-cargo-tool.mjs +nightly udeps --workspace --all-features --all-targets",
-    "node scripts/run-cargo-tool.mjs deny --log-level error --all-features check all",
   ],
 };


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-38465

## 📔 Objective

The pre-commit hooks are intended to check local changes before pushing to a remote. The rust checks in the pre commit hooks are there to save devs time and to save CI cycles.

The cargo-deny check can fail if a new advisory is released, and devs shouldn’t be blocked from committing changes due to things outside their control.

We should be alerted by automation when cargo deny is failing in CI on main.