### PR TITLE
[PM-38192] Collection Check for CLI Move

### DIFF
--- a/apps/cli/src/admin-console/commands/share.command.spec.ts
+++ b/apps/cli/src/admin-console/commands/share.command.spec.ts
@@ -1,0 +1,128 @@
+// @ts-strict-ignore
+import { mock } from "jest-mock-extended";
+import { of } from "rxjs";
+
+import { CollectionService } from "@bitwarden/admin-console/common";
+import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
+import { CollectionView } from "@bitwarden/common/admin-console/models/collections";
+import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { mockAccountInfoWith } from "@bitwarden/common/spec";
+import { OrganizationId } from "@bitwarden/common/types/guid";
+import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
+import { Cipher } from "@bitwarden/common/vault/models/domain/cipher";
+import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+import { UserId } from "@bitwarden/user-core";
+
+import { ShareCommand } from "./share.command";
+
+describe("ShareCommand", () => {
+  const cipherService = mock<CipherService>();
+  const accountService = mock<AccountService>();
+  const collectionService = mock<CollectionService>();
+  const organizationService = mock<OrganizationService>();
+
+  const userId = "user-id" as UserId;
+  const orgId = "aaaa0000-0000-0000-0000-000000000000" as OrganizationId;
+  const cipherId = "cipher-id";
+  const writableCollectionId = "bbbb0000-0000-0000-0000-000000000000";
+  const viewOnlyCollectionId = "cccc0000-0000-0000-0000-000000000000";
+  const unknownCollectionId = "dddd0000-0000-0000-0000-000000000000";
+
+  const activeAccount = {
+    id: userId,
+    ...mockAccountInfoWith({ email: "user@example.com", name: "Test User" }),
+  };
+
+  const mockOrg = { id: orgId } as Organization;
+  const mockCipher = {
+    id: cipherId,
+    organizationId: null,
+  } as unknown as Cipher;
+  const mockCipherView = { id: cipherId } as CipherView;
+
+  const writableCollection = {
+    id: writableCollectionId,
+    organizationId: orgId,
+    canEditItems: () => true,
+  } as unknown as CollectionView;
+
+  const viewOnlyCollection = {
+    id: viewOnlyCollectionId,
+    organizationId: orgId,
+    readOnly: true,
+    manage: false,
+    canEditItems: () => false,
+  } as unknown as CollectionView;
+
+  let command: ShareCommand;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    accountService.activeAccount$ = of(activeAccount as any);
+    cipherService.get.mockResolvedValue(mockCipher);
+    collectionService.decryptedCollections$.mockReturnValue(
+      of([writableCollection, viewOnlyCollection]),
+    );
+    organizationService.organizations$.mockReturnValue(of([mockOrg]));
+
+    command = new ShareCommand(
+      cipherService,
+      accountService,
+      collectionService,
+      organizationService,
+    );
+  });
+
+  const encode = (ids: string[]) => Buffer.from(JSON.stringify(ids)).toString("base64");
+
+  it("returns notFound when cipher does not exist", async () => {
+    cipherService.get.mockResolvedValue(null);
+
+    const result = await command.run(cipherId, orgId, encode([writableCollectionId]));
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain("Not found");
+  });
+
+  it("returns badRequest when cipher already belongs to an organization", async () => {
+    cipherService.get.mockResolvedValue({
+      ...mockCipher,
+      organizationId: orgId,
+    } as unknown as Cipher);
+
+    const result = await command.run(cipherId, orgId, encode([writableCollectionId]));
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain("already belongs to an organization");
+  });
+
+  it("returns badRequest when a collection ID is not in the org's collections", async () => {
+    const result = await command.run(cipherId, orgId, encode([unknownCollectionId]));
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain("You do not have permission to add items to this collection.");
+    expect(cipherService.shareWithServer).not.toHaveBeenCalled();
+  });
+
+  it("returns badRequest when the collection exists but canEditItems returns false", async () => {
+    const result = await command.run(cipherId, orgId, encode([viewOnlyCollectionId]));
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain("You do not have permission to add items to this collection.");
+    expect(cipherService.shareWithServer).not.toHaveBeenCalled();
+  });
+
+  it("proceeds successfully when all collections pass canEditItems", async () => {
+    cipherService.decrypt.mockResolvedValue(mockCipherView);
+    cipherService.shareWithServer.mockResolvedValue(undefined);
+    cipherService.get.mockResolvedValueOnce(mockCipher).mockResolvedValueOnce(mockCipher);
+    cipherService.decrypt.mockResolvedValue(mockCipherView);
+
+    const result = await command.run(cipherId, orgId, encode([writableCollectionId]));
+
+    expect(result.success).toBe(true);
+    expect(cipherService.shareWithServer).toHaveBeenCalled();
+  });
+});

--- a/apps/cli/src/admin-console/commands/share.command.ts
+++ b/apps/cli/src/admin-console/commands/share.command.ts
@@ -1,7 +1,9 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
-import { firstValueFrom } from "rxjs";
+import { firstValueFrom, map } from "rxjs";
 
+import { CollectionService } from "@bitwarden/admin-console/common";
+import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { getUserId } from "@bitwarden/common/auth/services/account.service";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
@@ -14,6 +16,8 @@ export class ShareCommand {
   constructor(
     private cipherService: CipherService,
     private accountService: AccountService,
+    private collectionService: CollectionService,
+    private organizationService: OrganizationService,
   ) {}
 
   async run(id: string, organizationId: string, requestJson: string): Promise<Response> {
@@ -57,6 +61,24 @@ export class ShareCommand {
     }
     if (cipher.organizationId != null) {
       return Response.badRequest("This item already belongs to an organization.");
+    }
+
+    const allCollections = await firstValueFrom(
+      this.collectionService.decryptedCollections$(activeUserId),
+    );
+    const orgCollections = allCollections.filter((c) => c.organizationId === organizationId);
+
+    const org = await firstValueFrom(
+      this.organizationService
+        .organizations$(activeUserId)
+        .pipe(map((orgs) => orgs.find((o) => o.id === organizationId))),
+    );
+
+    for (const collectionId of req) {
+      const collection = orgCollections.find((c) => c.id === collectionId);
+      if (collection == null || !collection.canEditItems(org)) {
+        return Response.badRequest("You do not have permission to add items to this collection.");
+      }
     }
 
     const cipherView = await this.cipherService.decrypt(cipher, activeUserId);

--- a/apps/cli/src/oss-serve-configurator.ts
+++ b/apps/cli/src/oss-serve-configurator.ts
@@ -158,6 +158,8 @@ export class OssServeConfigurator {
     this.shareCommand = new ShareCommand(
       this.serviceContainer.cipherService,
       this.serviceContainer.accountService,
+      this.serviceContainer.collectionService,
+      this.serviceContainer.organizationService,
     );
     this.lockCommand = new LockCommand(
       serviceContainer.lockService,

--- a/apps/cli/src/vault.program.ts
+++ b/apps/cli/src/vault.program.ts
@@ -441,6 +441,8 @@ export class VaultProgram extends BaseProgram {
         const command = new ShareCommand(
           this.serviceContainer.cipherService,
           this.serviceContainer.accountService,
+          this.serviceContainer.collectionService,
+          this.serviceContainer.organizationService,
         );
         const response = await command.run(id, organizationId, encodedJson);
         this.processResponse(response);


### PR DESCRIPTION
## 🎟️ Tracking

[PM-38192](https://bitwarden.atlassian.net/browse/PM-38192)

## 📔 Objective

Adds human readable error for the CLI when a user attempts to move an item into an organization and assign to a collection they cannot edit. 

## 📸 Screenshots

<img width="937" height="106" alt="Screenshot 2026-06-02 at 2 40 59 PM" src="https://github.com/user-attachments/assets/17744895-43c5-486e-b76b-bb34933f9784" />


[PM-38192]: https://bitwarden.atlassian.net/browse/PM-38192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ