### PR TITLE
[PM-35573]  - Refocus login input on Desktop restore

### DIFF
--- a/libs/auth/src/angular/login/login.component.html
+++ b/libs/auth/src/angular/login/login.component.html
@@ -16,6 +16,7 @@
     <bit-form-field>
       <bit-label>{{ "emailAddress" | i18n }}</bit-label>
       <input
+        id="email"
         type="email"
         formControlName="email"
         bitInput
@@ -89,6 +90,7 @@
     <bit-form-field class="!tw-mb-1">
       <bit-label>{{ "masterPass" | i18n }}</bit-label>
       <input
+        id="masterPassword"
         type="password"
         autocomplete="current-password"
         formControlName="masterPassword"

--- a/libs/auth/src/angular/login/login.component.ts
+++ b/libs/auth/src/angular/login/login.component.ts
@@ -239,6 +239,9 @@ export class LoginComponent implements OnInit, OnDestroy {
     this.broadcasterService.subscribe(BroadcasterSubscriptionId, async (message: any) => {
       this.ngZone.run(() => {
         switch (message.command) {
+          case "windowHidden":
+            this.onWindowHidden();
+            break;
           case "windowIsFocused":
             if (this.deferFocus === null) {
               this.deferFocus = !message.windowIsFocused;
@@ -675,6 +678,10 @@ export class LoginComponent implements OnInit, OnDestroy {
           : "masterPassword",
       )
       ?.focus();
+  }
+
+  private onWindowHidden() {
+    this.deferFocus = true;
   }
 
   /**


### PR DESCRIPTION
## 🎟️ Tracking

[PM-35573](https://bitwarden.atlassian.net/browse/PM-35573)

## 📔 Objective

Fix an issue where the Bitwarden logo could show a focus outline after reopening the Desktop app from the tray/header flow.

The login component already listens for Desktop window focus events, but once initial focus handling completed it did not reset its deferred focus state when the window was hidden. This caused focus to remain on the first focusable element in the landing layout when the app was shown again.

This change:
- Handles the existing `windowHidden` Desktop message in the login component
- Marks login input focus as deferred while the window is hidden
- Allows the next `windowIsFocused` message to focus the login input again
- Adds explicit `id` attributes to the email and master password inputs so the existing focus routine has stable targets

## 📸 Screenshots


https://github.com/user-attachments/assets/fee3b442-5fa0-43a2-8809-4ac92e33873e



[PM-35573]: https://bitwarden.atlassian.net/browse/PM-35573?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ