### PR TITLE
[PM-34926] Allow single-character CJK vault searches

### DIFF
--- a/libs/common/src/vault/services/search.service.spec.ts
+++ b/libs/common/src/vault/services/search.service.spec.ts
@@ -30,6 +30,7 @@ describe("SearchService", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockLocale$.next("en");
     service = new SearchService(
       mockLogService as unknown as LogService,
       mockI18nService as unknown as I18nService,
@@ -58,6 +59,18 @@ describe("SearchService", () => {
       const result = await service.isSearchable("test");
       expect(result).toBe(false);
     });
+
+    it("returns true if a single-character query contains a CJK character", async () => {
+      const result = await service.isSearchable("密");
+
+      expect(result).toBe(true);
+    });
+
+    it("returns false if a single-character query does not contain a CJK character", async () => {
+      const result = await service.isSearchable("p");
+
+      expect(result).toBe(false);
+    });
   });
 
   describe("searchCiphers", () => {
@@ -77,6 +90,14 @@ describe("SearchService", () => {
       const result = await service.searchCiphers(userId, null, "", ciphers);
 
       expect(result).toEqual(ciphers);
+    });
+
+    it("finds ciphers with single-character CJK queries", async () => {
+      const ciphers = [createCipherView("cipher-1", "密碼"), createCipherView("cipher-2", "Login")];
+
+      const result = await service.searchCiphers(userId, null, "密", ciphers);
+
+      expect(result).toEqual([ciphers[0]]);
     });
   });
 });

--- a/libs/common/src/vault/services/search.service.ts
+++ b/libs/common/src/vault/services/search.service.ts
@@ -15,6 +15,9 @@ export const SearchTextDebounceInterval = 100; // milliseconds
 
 export class SearchService implements SearchServiceAbstraction {
   private readonly immediateSearchLocales: string[] = ["zh-CN", "zh-TW", "ja", "ko", "vi"];
+  // Immediately search for CJK characters as they can represent complete search terms, regardless of the active locale.
+  private readonly immediateSearchQueryRegex =
+    /[\u3040-\u30ff\u3400-\u4dbf\u4e00-\u9fff\uf900-\ufaff\uac00-\ud7af\u{20000}-\u{2ebef}]/u;
   private readonly defaultSearchableMinLength: number = 2;
   private searchableMinLength: number = this.defaultSearchableMinLength;
 
@@ -46,6 +49,10 @@ export class SearchService implements SearchServiceAbstraction {
     }
 
     query = normalizeSearchQuery(query);
+
+    if (this.immediateSearchQueryRegex.test(query)) {
+      return true;
+    }
 
     // Regular queries only require a minimum length
     return query.length >= this.searchableMinLength;

--- a/libs/common/src/vault/services/search.service.ts
+++ b/libs/common/src/vault/services/search.service.ts
@@ -17,7 +17,7 @@ export class SearchService implements SearchServiceAbstraction {
   private readonly immediateSearchLocales: string[] = ["zh-CN", "zh-TW", "ja", "ko", "vi"];
   // Immediately search for CJK characters as they can represent complete search terms, regardless of the active locale.
   private readonly immediateSearchQueryRegex =
-    /[\u3040-\u30ff\u3400-\u4dbf\u4e00-\u9fff\uf900-\ufaff\uac00-\ud7af\u{20000}-\u{2ebef}]/u;
+    /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/u;
   private readonly defaultSearchableMinLength: number = 2;
   private searchableMinLength: number = this.defaultSearchableMinLength;
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-34926](https://bitwarden.atlassian.net/browse/PM-34926)

## 📔 Objective

Allow single-character CJK vault search queries to return matching vault entries regardless of the active UI language.

Previously, the minimum searchable query length was based only on the active locale. This meant users running the app in English needed at least two characters before search would run, even when the query was a valid one-character CJK term such as `密`.

This updates `SearchService` to detect CJK characters in the query itself and allow immediate search for those queries, while preserving the existing minimum length behavior for non-CJK one-character searches.

This also adds regression coverage for:

- Single-character CJK queries being searchable under the default English locale
- Single-character non-CJK queries remaining non-searchable
- Searching ciphers by a single CJK character, such as finding `密碼` with `密`

## 📸 Screenshots


https://github.com/user-attachments/assets/fa13fdb0-e527-489f-acae-dfbc9544a54e



[PM-34926]: https://bitwarden.atlassian.net/browse/PM-34926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ