### PR TITLE
[BEEEP] [PM-38497] Dev-ex: Add attach VSCode debugger to desktop, web configs

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -26,6 +26,43 @@
       "windows": {
         "program": "${workspaceFolder}/node_modules/jest/bin/jest"
       }
+    },
+    {
+      "type": "node",
+      "request": "attach",
+      "name": "Desktop: Main (attach)",
+      "port": 5858,
+      "restart": true,
+      "continueOnAttach": true,
+      "sourceMaps": true,
+      "outFiles": ["${workspaceFolder}/apps/desktop/build/**/*.js"],
+      "skipFiles": ["<node_internals>/**"],
+      "presentation": { "hidden": true }
+    },
+    {
+      "type": "chrome",
+      "request": "attach",
+      "name": "Desktop: Renderer (attach)",
+      "port": 9222,
+      "webRoot": "${workspaceFolder}/apps/desktop",
+      "sourceMaps": true,
+      "timeout": 60000,
+      "presentation": { "hidden": true }
+    },
+    {
+      "type": "chrome",
+      "request": "attach",
+      "name": "Web: Renderer (attach)",
+      "port": 9223,
+      "webRoot": "${workspaceFolder}/apps/web",
+      "sourceMaps": true,
+      "timeout": 60000
+    }
+  ],
+  "compounds": [
+    {
+      "name": "Desktop: Attach Debugger (main + renderer)",
+      "configurations": ["Desktop: Main (attach)", "Desktop: Renderer (attach)"]
     }
   ]
 }

--- a/apps/desktop/scripts/start.js
+++ b/apps/desktop/scripts/start.js
@@ -25,7 +25,7 @@ concurrently(
     },
     {
       name: "Elec",
-      command: `npx wait-on ./build/main.js && npx electron --no-sandbox --inspect=5858 ${args.join(
+      command: `npx wait-on ./build/main.js && npx electron --no-sandbox --inspect=5858 --remote-debugging-port=9222 ${args.join(
         " ",
       )} ./build --watch`,
       prefixColor: "green",

--- a/apps/desktop/scripts/start.js
+++ b/apps/desktop/scripts/start.js
@@ -25,7 +25,7 @@ concurrently(
     },
     {
       name: "Elec",
-      command: `npx wait-on ./build/main.js && npx electron --no-sandbox --inspect=5858 --remote-debugging-port=9222 ${args.join(
+      command: `npx wait-on ./build/main.js ./build/index.html ./build/app/main.js && npx electron --no-sandbox --inspect=5858 --remote-debugging-port=9222 ${args.join(
         " ",
       )} ./build --watch`,
       prefixColor: "green",


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-38497
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Add configs to attach the vs-code debugger to chrome / electron. For electron, we auto-start with the correct ports enabled. The debugger automatically attaches to both main and renderer.

For chrome, you need to start chrome with the following parameters: `--remote-debugging-port=9223 --user-data-dir=remote-debug-profile`. We can later make this automatic too, by launching a chrome browser with those parameters as part of the VSCode config.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/5ec6cba4-2c17-47fc-a642-c0390a067076


https://github.com/user-attachments/assets/f7a05384-308c-499c-b742-b82fe13499a8

