### PR TITLE
[PM-32089] Sync after collection deletion

### DIFF
--- a/apps/web/src/app/vault/individual-vault/bulk-action-dialogs/bulk-delete-dialog/bulk-delete-dialog.component.ts
+++ b/apps/web/src/app/vault/individual-vault/bulk-action-dialogs/bulk-delete-dialog/bulk-delete-dialog.component.ts
@@ -10,6 +10,7 @@ import { Organization } from "@bitwarden/common/admin-console/models/domain/orga
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { getUserId } from "@bitwarden/common/auth/services/account.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { SyncService } from "@bitwarden/common/platform/sync";
 import { CollectionId } from "@bitwarden/common/types/guid";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { UnionOfValues } from "@bitwarden/common/vault/types/union-of-values";
@@ -79,6 +80,7 @@ export class BulkDeleteDialogComponent {
     private collectionService: CollectionService,
     private toastService: ToastService,
     private accountService: AccountService,
+    private syncService: SyncService,
   ) {
     this.cipherIds = params.cipherIds ?? [];
     this.permanent = params.permanent;
@@ -160,7 +162,13 @@ export class BulkDeleteDialogComponent {
     }
   }
 
-  private async deleteCollections(): Promise<any> {
+  private async deleteCollections(): Promise<void> {
+    // Deleting collections will alter the underlying ciphers, perform a full sync
+    // to ensure the vault has the most up to date cipher data.
+    const fullSync = async () => {
+      await this.syncService.fullSync(true);
+    };
+
     // From org vault
     if (this.organization) {
       if (this.collections.some((c) => !c.canDelete(this.organization))) {
@@ -171,10 +179,12 @@ export class BulkDeleteDialogComponent {
         });
         return;
       }
-      return await this.apiService.deleteManyCollections(
+      await this.apiService.deleteManyCollections(
         this.organization.id,
         this.collections.map((c) => c.id),
       );
+      await fullSync();
+      return;
       // From individual vault, so there can be multiple organizations
     } else if (this.organizations && this.collections) {
       const deletePromises: Promise<any>[] = [];
@@ -193,7 +203,9 @@ export class BulkDeleteDialogComponent {
           this.apiService.deleteManyCollections(organization.id, orgCollectionIds),
         );
       }
-      return await Promise.all(deletePromises);
+      await Promise.all(deletePromises);
+      await fullSync();
+      return;
     }
   }
 

--- a/apps/web/src/app/vault/individual-vault/vault.component.ts
+++ b/apps/web/src/app/vault/individual-vault/vault.component.ts
@@ -1187,6 +1187,9 @@ export class VaultComponent<C extends CipherViewLike> implements OnInit, OnDestr
       await this.apiService.deleteCollection(collection.organizationId, collection.id);
       const activeUserId = await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId));
       await this.collectionService.delete([collection.id as CollectionId], activeUserId);
+      // Deleting collections will alter the underlying ciphers, perform a full sync
+      // to ensure the vault has the most up to date cipher data.
+      await this.syncService.fullSync(true);
 
       this.toastService.showToast({
         variant: "success",


### PR DESCRIPTION
## 🎟️ Tracking

[PM-32089](https://bitwarden.atlassian.net/browse/PM-32089)

## 📔 Objective

When a collection is deleted the underlying ciphers are disassociated with that collection, this can cause unexpected behavior and stale data for those ciphers until a sync as occurred. In the context of this bug that presented itself in an item still appearing in the users trash when it should be in the organization's trash.

Notes: 
- A full sync is a heavy call to make. I didn't see a smoother way to ensuring that the client had fresh data without it because:
  -  There currently isn't any dependency between the `CollectionService` and `CipherService`.
  - Updating only the cipher state client side would open up for differences to creep in between the server state and client state if not maintained. 
- I double checked the server side logic and the ciphers are properly getting unassigned when a collection is deleted regardless of their soft delete status.

## 📸 Screenshots

|Cipher only in a single collection|Cipher in multiple collections|
|-|-|
|<video src="https://github.com/user-attachments/assets/3474764d-0a70-4b0b-aef3-409f22d583b4" />|<video src="https://github.com/user-attachments/assets/ce9c5539-cd24-4c8d-bb27-c562062d225a" />|





[PM-32089]: https://bitwarden.atlassian.net/browse/PM-32089?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ