### PR TITLE
[BEEEP] [PM-38497] Dev-ex: Add debugger attach rust desktop-native support

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -28,6 +28,12 @@
       }
     },
     {
+      "type": "lldb",
+      "request": "attach",
+      "program": "${workspaceFolder}/node_modules/electron/dist/Electron.app/Contents/MacOS/Electron",
+      "name": "Desktop: Main desktop-native rust debugger (attach)",
+    },
+    {
       "type": "node",
       "request": "attach",
       "name": "Desktop: Main (attach)",
@@ -62,7 +68,7 @@
   "compounds": [
     {
       "name": "Desktop: Attach Debugger (main + renderer)",
-      "configurations": ["Desktop: Main (attach)", "Desktop: Renderer (attach)"]
+      "configurations": ["Desktop: Main (attach)", "Desktop: Renderer (attach)", "Desktop: Main desktop-native rust debugger (attach)"]
     }
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -31,7 +31,7 @@
       "type": "lldb",
       "request": "attach",
       "program": "${workspaceFolder}/node_modules/electron/dist/Electron.app/Contents/MacOS/Electron",
-      "name": "Desktop: Main desktop-native rust debugger (attach)",
+      "name": "Desktop: Main desktop-native rust debugger (attach)"
     },
     {
       "type": "node",
@@ -68,7 +68,11 @@
   "compounds": [
     {
       "name": "Desktop: Attach Debugger (main + renderer)",
-      "configurations": ["Desktop: Main (attach)", "Desktop: Renderer (attach)", "Desktop: Main desktop-native rust debugger (attach)"]
+      "configurations": [
+        "Desktop: Main (attach)",
+        "Desktop: Renderer (attach)",
+        "Desktop: Main desktop-native rust debugger (attach)"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-38497
https://github.com/bitwarden/clients/pull/21016

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
https://github.com/bitwarden/clients/pull/21016 adds configs to attach to the desktop app for debugging. This left out wasm, desktop-native. This PR adds debugger support for desktop-native, so you can put break-points in rust.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
