### PR TITLE
[PM-38544] Fix flatpak auto-start

### DIFF
--- a/apps/desktop/src/main/messaging.main.ts
+++ b/apps/desktop/src/main/messaging.main.ts
@@ -131,7 +131,7 @@ export class MessagingMain {
   private addOpenAtLogin() {
     if (process.platform === "linux") {
       if (isFlatpak()) {
-        autostart.setAutostart(true, [AUTOSTART_FLAG]).catch((e) => {});
+        autostart.setAutostart(true, ["bitwarden.sh", AUTOSTART_FLAG, "%U"]).catch((e) => {});
       } else if (isSnapStore()) {
         this.updateSnapAutostartExec();
       } else {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-38544
Found in https://bitwarden.atlassian.net/browse/PM-38543

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

For new flatpak installations, autostart doesn't work. For existing flatpak installations, flatpak fails to add the --autostart flag to the configuration, thus always auto-starting to the foreground.

The flatpak path in addOpenAtLogin passed only the autostart flag to setAutostart, so the XDG Background portal wrote an invalid Exec command. This passes the full launch command (bitwarden.sh), the autostart flag, and the %U URI placeholder so a valid Exec line is generated.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
