### PR TITLE
[PM-38026] Fix desktop client saturates gpu usage at 99% after start when using fallapart effect in KDE/KWIN

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -352,10 +352,17 @@ export class Main {
     // Run migrations first, then other things
     this.migrationRunner.run().then(
       async () => {
+        const isAutostart = process.argv.some((val) => val === AUTOSTART_FLAG);
+
         await this.toggleHardwareAcceleration();
         // Reset modal mode to make sure main window is displayed correctly
         await this.desktopSettingsService.resetModalMode();
-        await this.windowMain.init();
+
+        // Autostart should start to tray. However showing it then hiding it quickly triggers a bug in Kwin
+        // https://bugs.kde.org/show_bug.cgi?id=520724. Until it is fixed we must never call show when
+        // autostart is enabled.
+        const showWindow = !isAutostart;
+        await this.windowMain.init(showWindow);
         this.ssoCookieMain.init(this.windowMain.session);
         await this.i18nService.init();
         await this.messagingMain.init();
@@ -372,7 +379,6 @@ export class Main {
         ]);
 
         // Autostart should always start to tray. Any auto-start mechanism must provide this flag.
-        const isAutostart = process.argv.some((val) => val === AUTOSTART_FLAG);
         if (isAutostart) {
           await this.trayMain.hideToTray();
         }

--- a/apps/desktop/src/main/window.main.ts
+++ b/apps/desktop/src/main/window.main.ts
@@ -54,7 +54,7 @@ export class WindowMain {
     private createWindowCallback: (win: BrowserWindow) => void,
   ) {}
 
-  init(): Promise<any> {
+  init(show: boolean = true): Promise<any> {
     // Perform a hard reload of the render process by crashing it. This is suboptimal but ensures that all memory gets
     // cleared, as the process itself will be completely garbage collected.
     ipcMain.on("reload-process", async () => {
@@ -191,7 +191,7 @@ export class WindowMain {
             }
           }
 
-          await this.createWindow();
+          await this.createWindow("full-app", show);
           resolve();
 
           if (this.argvCallback != null) {
@@ -268,7 +268,10 @@ export class WindowMain {
    * When the template is "modal-app", the window will be styled as a modal and the passkeys page will be loaded.
    * TODO: We might want to refactor the template argument to accomodate more target pages, e.g. ssh-agent.
    */
-  async createWindow(template: "full-app" | "modal-app" = "full-app"): Promise<void> {
+  async createWindow(
+    template: "full-app" | "modal-app" = "full-app",
+    show: boolean = true,
+  ): Promise<void> {
     this.windowStates[mainWindowSizeKey] = await this.getWindowState(
       this.defaultWidth,
       this.defaultHeight,
@@ -327,7 +330,9 @@ export class WindowMain {
       this.win.maximize();
     }
 
-    this.win.show();
+    if (show) {
+      this.win.show();
+    }
 
     if (template === "full-app") {
       void this.win


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-38026

## 📔 Objective

On KDE/KWin, autostarting the desktop client briefly showed the main window and then hid it to tray. Showing then quickly hiding the window triggers KWin bug https://bugs.kde.org/show_bug.cgi?id=520724, which saturates GPU usage at ~99%.

This threads a `show` flag through `WindowMain.init()` and `createWindow()`. When the autostart flag is present the window is created but never shown, so it goes straight to the tray and the KWin bug is avoided.

I verified this to fix the behavior on an AMD system on KDE 6.6.
