### PR TITLE
Add form validation documentation to component library

### DIFF
--- a/libs/components/src/form-field/validation.mdx
+++ b/libs/components/src/form-field/validation.mdx
@@ -1,0 +1,222 @@
+import { Meta, Canvas } from "@storybook/addon-docs/blocks";
+
+import * as stories from "./validation.stories";
+
+<Meta title="Component Library/Form/Validation" />
+
+# Form Validation
+
+This page covers how form validation works across our Angular clients: how an error becomes visible,
+how to express a rule, when it runs, and what happens when the server has the final say.
+
+## Principles
+
+**Validation happens on both the client and the server.** Some checks can only run on one side: the
+server can't inspect end-to-end-encrypted Vault Data, while a check like "is this value already
+taken?" can only be answered by the server. Expect both — and expect
+[server errors at submit](#server-reconciliation-at-submit) as a normal case, not a gap.
+
+**Most errors share one path.** Built-in validators, custom async checks, and field-attributable
+server errors all end up as a [`ValidationErrors`][validation-errors] object on a control and render
+inline the same way. Only errors that can't be tied to a field fall back to a toast.
+
+## Rendering errors
+
+Errors are shown two ways. **Inline, contextual errors are preferred** — they sit next to the field
+they describe. **Toasts** are the fallback for errors that can't be tied to a specific field.
+
+Inline errors come from a control's `ValidationErrors` — a map of error key to value. `bit-error`
+renders the first error on the control:
+
+- known keys (`required`, `email`, `minlength`, `forbiddenCharacters`, `trim`, …) get a translated,
+  interpolated message;
+- anything else falls back to the error value's `message` property:
+
+```ts
+return { emailTaken: { message: "This email address is already in use." } };
+```
+
+Two components render control errors:
+
+- **`bit-error`** — the message beneath the field; `bit-form-field` includes it automatically.
+- **[`bit-error-summary`][bit-error-summary]** — a count ("3 fields above need your attention") for
+  a `formGroup`, near the submit button. Counts dirty/touched errors only; renders no text.
+
+Toasts are shown via `ValidationService.showError`, usually for errors the server returns at submit.
+Use them only when the error can't be attributed to a field — see
+[server reconciliation](#server-reconciliation-at-submit).
+
+> **i18n is the validator's responsibility.** Because the fallback renders `message` verbatim,
+> resolve the string through `I18nService` in the component or factory that builds the validator,
+> and pass the translated text in. Don't hand `bit-error` an untranslated key it doesn't know.
+
+## Synchronous validators
+
+Use these when the answer is available immediately — from the field's own value, sibling fields, or
+data already loaded into memory.
+
+### Provided validators
+
+Angular's [`Validators`][validators] (`required`, `email`, `minLength`, `min`/`max`, …) and our
+shared validators in `libs/components/src/form-field/bit-validators` (`forbiddenCharacters`,
+`trimValidator`) come ready to use, with messages already wired up. Reach for these before writing
+your own.
+
+<Canvas of={stories.Validations} />
+
+### Your own validator
+
+A `ValidatorFn` is just a function from a control to errors-or-null. Write a factory when the rule
+needs configuration, and close over it. The example below validates against a list of claimed
+domains that was fetched once when the dialog opened — the data lives on the client, so the check
+stays synchronous:
+
+```ts
+// `message` is resolved via I18nService by the caller and passed in (see the i18n note above).
+function claimedDomainValidator(claimedDomains: string[], message: string): ValidatorFn {
+  return (control: AbstractControl): ValidationErrors | null => {
+    const domain = (control.value ?? "").split("@")[1]?.toLowerCase();
+    if (!domain || claimedDomains.includes(domain)) {
+      return null;
+    }
+    return { unclaimedDomain: { message } };
+  };
+}
+```
+
+<Canvas of={stories.PreFetchedData} />
+
+### Cross-field validators
+
+These validate the relationship between controls, so they go on the `FormGroup`, not a single
+control, and set the error on the control that should display it:
+
+```ts
+// "Passwords must match" — added to the FormGroup, error shown on the confirm field.
+function passwordsMatchValidator(message: string): ValidatorFn {
+  return (group: AbstractControl): ValidationErrors | null => {
+    const password = group.get("password");
+    const confirm = group.get("confirmPassword");
+    if (!password || !confirm || password.value === confirm.value) {
+      return null;
+    }
+    confirm.setErrors({ passwordMismatch: { message } });
+    return { passwordMismatch: { message } };
+  };
+}
+```
+
+For a configurable version, see the `compareInputs` validator in `libs/auth`.
+
+## Asynchronous validators
+
+Use an [`AsyncValidatorFn`][async-validators] when getting the answer requires awaiting something.
+Often that's a server lookup — "is this email already taken?" — but not always: much of our service
+layer (vault, state, crypto) is Promise/Observable-based, so client-side checks that read decrypted
+data or query a store are async too. (A server-side check usually needs a dedicated endpoint just
+for validation, separate from our reusable GETs.)
+
+```ts
+// Returns an Observable so Angular can cancel a superseded check (see below).
+function emailNotTakenValidator(api: AccountApi, message: string): AsyncValidatorFn {
+  return (control: AbstractControl): Observable<ValidationErrors | null> =>
+    api
+      .isEmailTaken(control.value)
+      .pipe(map((taken) => (taken ? { emailTaken: { message } } : null)));
+}
+```
+
+<Canvas of={stories.AsyncValidation} />
+
+Three things to get right:
+
+**Return an Observable to get cancellation for free.** When a control re-runs its async validators,
+Angular unsubscribes from the previous run before starting the new one. Returning an `Observable`
+(e.g. `this.api.checkEmail(value)`) gives you `switchMap`-style cancellation automatically — you do
+not debounce or `switchMap` yourself. A `Promise` still has its superseded result ignored, but the
+in-flight request can't be cancelled, so prefer an Observable when the check is expensive.
+
+**Surface the in-progress state.** While async validation runs, the control's `pending` flag is
+`true`. `bit-form-field` has no built-in spinner for this yet, so show it yourself — the example
+above swaps its hint for a "Checking availability…" message keyed off `control.pending`.
+
+**Pair it with the right timing** — almost always `blur` (see below).
+
+## Validation timing
+
+`updateOn` controls when a control runs its validators, and it matters most for async and expensive
+checks. Set it per control (or per group):
+
+```ts
+email: [
+  "",
+  {
+    updateOn: "blur", // run when the user leaves the field, not on every keystroke
+    validators: [Validators.required, Validators.email],
+    asyncValidators: [emailNotTakenValidator()],
+  },
+],
+```
+
+- `"change"` (default) — every keystroke. Fine for cheap sync checks; wrong for async or expensive
+  ones.
+- `"blur"` — when the field loses focus. The right default for async/expensive validation.
+- `"submit"` — only on submit. Used by `trimValidator`, which mutates the value.
+
+Validation must also run on submit, because the user can submit without ever blurring a field. Call
+`formGroup.markAllAsTouched()` in your submit handler so untouched-but-invalid fields reveal their
+errors — and so `bit-error-summary` counts them.
+
+## Server reconciliation at submit
+
+Some checks can only be settled by the server, so even with everything above in place a submit can
+still come back invalid: a value that was free at blur got taken before submit, or the request
+failed outright. These split into two cases that are handled differently.
+
+**Attributable failures** — the server rejects for a reason you can tie to a specific field. Map it
+onto the control with the same `message` contract as any other error, and `markAsTouched()` so it
+renders. No toast. This is the pattern already used in auth flows (new-device verification, login):
+
+<Canvas of={stories.ServerErrorInline} />
+
+```ts
+submit = async () => {
+  if (this.formGroup.invalid) {
+    return;
+  }
+  try {
+    await this.api.createMember(this.formGroup.value);
+  } catch (e) {
+    // Attributable to a field → render inline like any other error.
+    if (isEmailTakenError(e)) {
+      const email = this.formGroup.controls.email;
+      email.setErrors({ serverError: { message: this.i18n.t("emailAlreadyTaken") } });
+      email.markAsTouched();
+      return;
+    }
+    // Unattributable (infra, bug) → rethrow; bitSubmit shows the danger toast.
+    throw e;
+  }
+};
+```
+
+**Unattributable failures** — infrastructure errors, bugs, anything you can't pin to a field. There
+is nothing to render inline, so the danger toast is the honest fallback. By default
+[`bitSubmit`][async-forms] routes any uncaught error to `ValidationService.showError`, which shows
+that toast — so rethrowing (or simply not catching) already gives you the right behavior.
+
+This is the answer to "no toasts ever": attributable failures move inline, and the toast shrinks to
+the genuinely-unexpected tail it was always meant for.
+
+## Accessibility
+
+Inline errors, required-field labelling, and the announce-on-blur behavior are covered in the
+[Forms guide](?path=/docs/component-library-form--docs#accessibility). The same rules apply to every
+validator on this page regardless of where its verdict comes from.
+
+[validation-errors]: https://angular.io/api/forms/ValidationErrors
+[validators]: https://angular.io/api/forms/Validators
+[async-validators]: https://angular.io/api/forms/AsyncValidator
+[bit-error]: ?path=/docs/component-library-form--docs
+[bit-error-summary]: ?path=/docs/component-library-form--docs
+[async-forms]: ?path=/docs/component-library-async-actions-in-forms-documentation--docs

--- a/libs/components/src/form-field/validation.stories.ts
+++ b/libs/components/src/form-field/validation.stories.ts
@@ -1,0 +1,383 @@
+import { Component, OnInit, input } from "@angular/core";
+import {
+  AbstractControl,
+  AsyncValidatorFn,
+  FormBuilder,
+  FormsModule,
+  ReactiveFormsModule,
+  ValidationErrors,
+  ValidatorFn,
+  Validators,
+} from "@angular/forms";
+import { Meta, StoryObj, moduleMetadata } from "@storybook/angular";
+import { action } from "storybook/actions";
+import { userEvent, getByText } from "storybook/test";
+
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { ValidationService } from "@bitwarden/common/platform/abstractions/validation.service";
+
+import { AsyncActionsModule } from "../async-actions";
+import { ButtonModule } from "../button";
+import { InputModule } from "../input/input.module";
+import { I18nMockService } from "../utils/i18n-mock.service";
+
+import { trimValidator, forbiddenCharacters } from "./bit-validators";
+import { FormFieldModule } from "./form-field.module";
+
+// --- Example validators ---------------------------------------------------
+// These live in the story file because they exist to illustrate the docs.
+// Real validators belong next to the form/feature that uses them, or in
+// `libs/components/src/form-field/bit-validators` when broadly reusable.
+
+/**
+ * Synchronous validator against pre-fetched data.
+ *
+ * The list of claimed domains is loaded once (e.g. when the dialog opens) and
+ * closed over by the validator, so validation itself stays synchronous.
+ */
+function claimedDomainValidator(claimedDomains: string[]): ValidatorFn {
+  return (control: AbstractControl): ValidationErrors | null => {
+    const value: string = control.value ?? "";
+    const domain = value.split("@")[1]?.toLowerCase();
+    if (!domain) {
+      return null;
+    }
+    if (!claimedDomains.includes(domain)) {
+      return {
+        unclaimedDomain: {
+          message: `Email must belong to a claimed domain: ${claimedDomains.join(", ")}`,
+        },
+      };
+    }
+    return null;
+  };
+}
+
+/**
+ * Asynchronous validator (here, a server lookup).
+ *
+ * Returning a Promise lets Angular set the control to `pending` while the
+ * lookup runs. Angular discards the result of a superseded run automatically,
+ * so a fast-clicking user never sees a stale answer.
+ */
+function emailNotTakenValidator(): AsyncValidatorFn {
+  // Stands in for an HTTP call to a dedicated validation endpoint.
+  const lookupTakenEmail = (email: string): Promise<boolean> =>
+    new Promise((resolve) => {
+      const taken = ["taken@example.com", "admin@example.com"];
+      setTimeout(() => resolve(taken.includes(email.toLowerCase())), 1000);
+    });
+
+  return async (control: AbstractControl): Promise<ValidationErrors | null> => {
+    const value: string = control.value ?? "";
+    if (value === "") {
+      return null;
+    }
+    const taken = await lookupTakenEmail(value);
+    return taken ? { emailTaken: { message: "This email address is already in use." } } : null;
+  };
+}
+
+/**
+ * A failure the server reports at submit time.
+ *
+ * The handler maps a known, field-attributable failure onto the control inline
+ * (no toast), and rethrows anything it can't attribute so `bitSubmit` falls back
+ * to the danger toast.
+ */
+class EmailTakenError extends Error {}
+
+// Stands in for a POST whose server-side validation can fail after the client validated.
+const createMember = (email: string): Promise<void> =>
+  new Promise((resolve, reject) => {
+    setTimeout(() => {
+      const value = email.toLowerCase();
+      if (value === "taken@example.com") {
+        reject(new EmailTakenError());
+      } else if (value === "error@example.com") {
+        reject(new Error("Simulated unexpected server error"));
+      } else {
+        resolve();
+      }
+    }, 1000);
+  });
+
+// FIXME(https://bitwarden.atlassian.net/browse/CL-764): Migrate to OnPush
+// eslint-disable-next-line @angular-eslint/prefer-on-push-component-change-detection
+@Component({
+  selector: "app-server-error-example",
+  imports: [AsyncActionsModule, ButtonModule, FormFieldModule, InputModule, ReactiveFormsModule],
+  template: /*html*/ `
+    <form [formGroup]="formObj" [bitSubmit]="submit">
+      <bit-form-field>
+        <bit-label>Email</bit-label>
+        <input bitInput type="email" formControlName="email" />
+        <bit-hint>
+          "taken@example.com" fails inline; "error@example.com" triggers the toast fallback (see the
+          Actions panel); anything else succeeds.
+        </bit-hint>
+      </bit-form-field>
+
+      <button type="submit" bitButton bitFormButton buttonType="primary">Submit</button>
+      <bit-error-summary [formGroup]="formObj"></bit-error-summary>
+    </form>
+  `,
+})
+class ServerErrorExampleComponent implements OnInit {
+  readonly initialEmail = input("");
+
+  formObj = this.formBuilder.group({
+    email: ["", [Validators.required, Validators.email]],
+  });
+
+  constructor(private formBuilder: FormBuilder) {}
+
+  ngOnInit() {
+    this.formObj.controls.email.setValue(this.initialEmail());
+  }
+
+  submit = async () => {
+    this.formObj.markAllAsTouched();
+    if (!this.formObj.valid) {
+      return;
+    }
+
+    const email = this.formObj.controls.email;
+    try {
+      await createMember(email.value ?? "");
+    } catch (e) {
+      // Known, field-attributable failure → render it inline like any other error.
+      if (e instanceof EmailTakenError) {
+        email.setErrors({ serverError: { message: "This email address is already in use." } });
+        email.markAsTouched();
+        return;
+      }
+      // Truly unexpected (infra, bug) → rethrow and let bitSubmit show the danger toast.
+      throw e;
+    }
+  };
+}
+
+export default {
+  title: "Component Library/Form/Validation",
+  decorators: [
+    moduleMetadata({
+      imports: [
+        FormsModule,
+        ReactiveFormsModule,
+        FormFieldModule,
+        InputModule,
+        ButtonModule,
+        AsyncActionsModule,
+        ServerErrorExampleComponent,
+      ],
+      providers: [
+        {
+          provide: I18nService,
+          useFactory: () => {
+            return new I18nMockService({
+              required: "required",
+              loading: "Loading",
+              inputRequired: "Input is required.",
+              inputEmail: "Input is not an email address.",
+              inputForbiddenCharacters: (char) =>
+                `The following characters are not allowed: ${char}`,
+              inputMinValue: (min) => `Input value must be at least ${min}.`,
+              inputMaxValue: (max) => `Input value must not exceed ${max}.`,
+              inputMinLength: (min) => `Input value must be at least ${min} characters long.`,
+              inputMaxLength: (max) => `Input value must not exceed ${max} characters in length.`,
+              inputTrimValidator: "Input must not contain only whitespace.",
+              fieldsNeedAttention: "__$1__ field(s) above need your attention.",
+            });
+          },
+        },
+        {
+          // bitSubmit routes any uncaught error here; in the app this shows the danger toast.
+          provide: ValidationService,
+          useValue: {
+            showError: action("ValidationService.showError (danger toast fallback)"),
+          } as Partial<ValidationService>,
+        },
+      ],
+    }),
+  ],
+  parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/Zt3YSeb6E6lebAffrNLa0h/Tailwind-Component-Library?node-id=13213-55392&t=b5tDKylm5sWm2yKo-4",
+    },
+  },
+} as Meta;
+
+const fb = new FormBuilder();
+
+type Story = StoryObj;
+
+// --- Built-in and shared validators ---------------------------------------
+
+const showValidationsFormObj = fb.group({
+  required: ["", [Validators.required]],
+  whitespace: ["    ", trimValidator],
+  email: ["example?bad-email", [Validators.email]],
+  minLength: ["Hello", [Validators.minLength(8)]],
+  maxLength: ["Hello there", [Validators.maxLength(8)]],
+  minValue: [9, [Validators.min(10)]],
+  maxValue: [15, [Validators.max(10)]],
+  forbiddenChars: ["Th!$ value cont#in$ forbidden char$", forbiddenCharacters(["#", "!", "$"])],
+});
+
+export const Validations: Story = {
+  render: (args) => ({
+    props: {
+      formObj: showValidationsFormObj,
+      submit: () => showValidationsFormObj.markAllAsTouched(),
+      ...args,
+    },
+    template: /*html*/ `
+      <form [formGroup]="formObj" (ngSubmit)="submit()">
+        <bit-form-field>
+          <bit-label>Required validation</bit-label>
+          <input bitInput formControlName="required" />
+          <bit-hint>This field is required. Submit form or blur input to see error</bit-hint>
+        </bit-form-field>
+
+        <bit-form-field>
+          <bit-label>Email validation</bit-label>
+          <input bitInput type="email" formControlName="email" />
+          <bit-hint>This field contains a malformed email address. Submit form or blur input to see error</bit-hint>
+        </bit-form-field>
+
+        <bit-form-field>
+          <bit-label>Min length validation</bit-label>
+          <input bitInput formControlName="minLength" />
+          <bit-hint>Value must be at least 8 characters. Submit form or blur input to see error</bit-hint>
+        </bit-form-field>
+
+        <bit-form-field>
+          <bit-label>Max length validation</bit-label>
+          <input bitInput formControlName="maxLength" />
+          <bit-hint>Value must be less then 8 characters. Submit form or blur input to see error</bit-hint>
+        </bit-form-field>
+
+        <bit-form-field>
+          <bit-label>Min number value validation</bit-label>
+          <input
+            bitInput
+            type="number"
+            formControlName="minValue"
+          />
+          <bit-hint>Value must be greater than 10. Submit form or blur input to see error</bit-hint>
+        </bit-form-field>
+
+        <bit-form-field>
+          <bit-label>Max number value validation</bit-label>
+          <input
+            bitInput
+            type="number"
+            formControlName="maxValue"
+          />
+          <bit-hint>Value must be less than than 10. Submit form or blur input to see error</bit-hint>
+        </bit-form-field>
+
+        <bit-form-field>
+          <bit-label>Forbidden characters validation</bit-label>
+          <input
+            bitInput
+            formControlName="forbiddenChars"
+          />
+          <bit-hint>Value must not contain '#', '!' or '$'. Submit form or blur input to see error</bit-hint>
+        </bit-form-field>
+
+        <bit-form-field>
+          <bit-label>White space validation</bit-label>
+          <input bitInput formControlName="whitespace" />
+          <bit-hint>This input contains only white space. Submit form or blur input to see error</bit-hint>
+        </bit-form-field>
+
+        <button type="submit" bitButton buttonType="primary">Submit</button>
+        <bit-error-summary [formGroup]="formObj"></bit-error-summary>
+      </form>
+    `,
+  }),
+  play: async (context) => {
+    const canvas = context.canvasElement;
+    const submitButton = getByText(canvas, "Submit");
+
+    await userEvent.click(submitButton);
+  },
+};
+
+// --- Custom synchronous validator (validates against pre-fetched data) ----
+
+const preFetchedFormObj = fb.group({
+  email: ["member@unclaimed.com", [Validators.required, claimedDomainValidator(["example.com"])]],
+});
+
+export const PreFetchedData: Story = {
+  render: () => ({
+    props: {
+      formObj: preFetchedFormObj,
+      submit: () => preFetchedFormObj.markAllAsTouched(),
+    },
+    template: /*html*/ `
+      <form [formGroup]="formObj" (ngSubmit)="submit()">
+        <bit-form-field>
+          <bit-label>Member email</bit-label>
+          <input bitInput type="email" formControlName="email" />
+          <bit-hint>Only the claimed domain "example.com" is allowed. Blur the field or submit to see the error.</bit-hint>
+        </bit-form-field>
+
+        <button type="submit" bitButton buttonType="primary">Submit</button>
+        <bit-error-summary [formGroup]="formObj"></bit-error-summary>
+      </form>
+    `,
+  }),
+};
+
+// --- Asynchronous validator -----------------------------------------------
+
+const asyncFormObj = fb.group({
+  email: [
+    "",
+    {
+      // Run the (potentially expensive) async check on blur, not on every keystroke.
+      updateOn: "blur",
+      validators: [Validators.required, Validators.email],
+      asyncValidators: [emailNotTakenValidator()],
+    },
+  ],
+});
+
+export const AsyncValidation: Story = {
+  render: () => ({
+    props: {
+      formObj: asyncFormObj,
+      submit: () => asyncFormObj.markAllAsTouched(),
+    },
+    template: /*html*/ `
+      <form [formGroup]="formObj" (ngSubmit)="submit()">
+        <bit-form-field>
+          <bit-label>Email</bit-label>
+          <input bitInput type="email" formControlName="email" />
+          @if (formObj.controls.email.pending) {
+            <bit-hint><i class="bwi bwi-spinner bwi-spin" aria-hidden="true"></i> Checking availability&hellip;</bit-hint>
+          } @else {
+            <bit-hint>Try "taken@example.com" or "admin@example.com". Blur the field to run the check.</bit-hint>
+          }
+        </bit-form-field>
+
+        <button type="submit" bitButton buttonType="primary">Submit</button>
+        <bit-error-summary [formGroup]="formObj"></bit-error-summary>
+      </form>
+    `,
+  }),
+};
+
+// --- Server error mapped inline at submit ---------------------------------
+
+// Attributable failure → mapped onto the control inline. Submit to see it.
+export const ServerErrorInline: Story = {
+  render: () => ({
+    template: `<app-server-error-example initialEmail="taken@example.com"></app-server-error-example>`,
+  }),
+};

--- a/libs/components/src/form/form.stories.ts
+++ b/libs/components/src/form/form.stories.ts
@@ -1,6 +1,5 @@
 import { FormBuilder, FormsModule, ReactiveFormsModule, Validators } from "@angular/forms";
 import { Meta, StoryObj, moduleMetadata } from "@storybook/angular";
-import { userEvent, getByText } from "storybook/test";
 
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 
@@ -8,7 +7,7 @@ import { ButtonModule } from "../button";
 import { CheckboxModule } from "../checkbox";
 import { FormControlModule } from "../form-control";
 import { FormFieldModule } from "../form-field";
-import { trimValidator, forbiddenCharacters } from "../form-field/bit-validators";
+import { forbiddenCharacters } from "../form-field/bit-validators";
 import { InputModule } from "../input/input.module";
 import { MultiSelectModule } from "../multi-select";
 import { RadioButtonModule } from "../radio-button";
@@ -167,97 +166,5 @@ export const FullExample: Story = {
       { id: "6", listName: "Group 6", labelName: "Group 6", icon: "bwi-family" },
       { id: "7", listName: "Group 7", labelName: "Group 7", icon: "bwi-family" },
     ],
-  },
-};
-
-const showValidationsFormObj = fb.group({
-  required: ["", [Validators.required]],
-  whitespace: ["    ", trimValidator],
-  email: ["example?bad-email", [Validators.email]],
-  minLength: ["Hello", [Validators.minLength(8)]],
-  maxLength: ["Hello there", [Validators.maxLength(8)]],
-  minValue: [9, [Validators.min(10)]],
-  maxValue: [15, [Validators.max(10)]],
-  forbiddenChars: ["Th!$ value cont#in$ forbidden char$", forbiddenCharacters(["#", "!", "$"])],
-});
-
-export const Validations: Story = {
-  render: (args) => ({
-    props: {
-      formObj: showValidationsFormObj,
-      submit: () => showValidationsFormObj.markAllAsTouched(),
-      ...args,
-    },
-    template: /*html*/ `
-      <form [formGroup]="formObj" (ngSubmit)="submit()">
-        <bit-form-field>
-          <bit-label>Required validation</bit-label>
-          <input bitInput formControlName="required" />
-          <bit-hint>This field is required. Submit form or blur input to see error</bit-hint>
-        </bit-form-field>
-
-        <bit-form-field>
-          <bit-label>Email validation</bit-label>
-          <input bitInput type="email" formControlName="email" />
-          <bit-hint>This field contains a malformed email address. Submit form or blur input to see error</bit-hint>
-        </bit-form-field>
-
-        <bit-form-field>
-          <bit-label>Min length validation</bit-label>
-          <input bitInput formControlName="minLength" />
-          <bit-hint>Value must be at least 8 characters. Submit form or blur input to see error</bit-hint>
-        </bit-form-field>
-
-        <bit-form-field>
-          <bit-label>Max length validation</bit-label>
-          <input bitInput formControlName="maxLength" />
-          <bit-hint>Value must be less then 8 characters. Submit form or blur input to see error</bit-hint>
-        </bit-form-field>
-
-        <bit-form-field>
-          <bit-label>Min number value validation</bit-label>
-          <input
-            bitInput
-            type="number"
-            formControlName="minValue"
-          />
-          <bit-hint>Value must be greater than 10. Submit form or blur input to see error</bit-hint>
-        </bit-form-field>
-
-        <bit-form-field>
-          <bit-label>Max number value validation</bit-label>
-          <input
-            bitInput
-            type="number"
-            formControlName="maxValue"
-          />
-          <bit-hint>Value must be less than than 10. Submit form or blur input to see error</bit-hint>
-        </bit-form-field>
-
-        <bit-form-field>
-          <bit-label>Forbidden characters validation</bit-label>
-          <input
-            bitInput
-            formControlName="forbiddenChars"
-          />
-          <bit-hint>Value must not contain '#', '!' or '$'. Submit form or blur input to see error</bit-hint>
-        </bit-form-field>
-
-        <bit-form-field>
-          <bit-label>White space validation</bit-label>
-          <input bitInput formControlName="whitespace" />
-          <bit-hint>This input contains only white space. Submit form or blur input to see error</bit-hint>
-        </bit-form-field>
-
-        <button type="submit" bitButton buttonType="primary">Submit</button>
-        <bit-error-summary [formGroup]="formObj"></bit-error-summary>
-      </form>
-    `,
-  }),
-  play: async (context) => {
-    const canvas = context.canvasElement;
-    const submitButton = getByText(canvas, "Submit");
-
-    await userEvent.click(submitButton);
   },
 };

--- a/libs/components/src/form/forms.mdx
+++ b/libs/components/src/form/forms.mdx
@@ -6,6 +6,7 @@ import * as passwordToggleStories from "../form-field/password-input-toggle.stor
 import * as searchStories from "../search/search.stories";
 import * as selectStories from "../select/select.stories";
 import * as multiSelectStories from "../form-field/multi-select.stories";
+import * as validationStories from "../form-field/validation.stories";
 import * as radioStories from "../radio-button/radio-button.stories";
 import * as checkboxStories from "../checkbox/checkbox.stories";
 
@@ -146,7 +147,7 @@ If a checkbox group has more than 4 options a
 
 These are examples of our default validation error messages:
 
-<Canvas of={formStories.Validations} />
+<Canvas of={validationStories.Validations} />
 
 ## Accessibility
 


### PR DESCRIPTION
## 🎟️ Tracking

N/A — documentation for the component library's form validation patterns.

## 📔 Objective

Adds a new **Component Library → Form → Validation** Storybook page (`validation.mdx`) documenting how form validation works across our Angular clients, with a runnable example per section:

- **Rendering errors** — how a `ValidationErrors` object reaches the user via `bit-error` (inline) and `bit-error-summary` (count), the `{ key: { message } }` fallback contract, and where toasts fit.
- **Synchronous validators** — built-in/shared validators, custom `ValidatorFn` factories, and cross-field validators.
- **Asynchronous validators** — `AsyncValidatorFn` for any awaited check (server *or* client-side Promise/Observable services), Observable cancellation, and the `pending` state.
- **Validation timing** — `updateOn` and submit-time validation.
- **Server reconciliation at submit** — mapping attributable failures inline via `setErrors`, with the danger toast as the fallback for unattributable errors.

Supporting changes:

- Adds `validation.stories.ts` with the examples backing the page.
- Moves the shared `Validations` story out of `form.stories.ts` into `validation.stories.ts` (single definition) and repoints `forms.mdx` at its new location.

No production code changes — docs and Storybook stories only.

## 📸 Screenshots

<!-- TODO: capture the Form/Validation page and its four canvases (Validations, PreFetchedData, AsyncValidation, ServerErrorInline). -->