### PR TITLE
Expand .claude/rules to cover i18n, Tailwind, testing, and Angular DI

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -14,8 +14,6 @@
 - **CRITICAL**: new encryption logic should not be added to this repo.
 - **NEVER** send unencrypted vault data to API services
 - **NEVER** commit secrets, credentials, or sensitive information.
-- **CRITICAL**: Tailwind CSS classes MUST use the `tw-` prefix (e.g., `tw-flex`, `tw-p-4`).
-  - Missing prefix breaks styling completely.
 - **NEVER** log decrypted data, encryption keys, or PII
   - No vault data in error messages or console logs
 - **ALWAYS** Respect configuration files at the root and within each app/library (e.g., `eslint.config.mjs`, `jest.config.js`, `tsconfig.json`).
@@ -25,10 +23,12 @@
 This repository is organized as a **monorepo** containing multiple applications and libraries. The
 main directories are:
 
-- `apps/` – Contains all application projects (e.g., browser, cli, desktop, web). Each app is
-  self-contained with its own configuration, source code, and tests.
-- `libs/` – Contains shared libraries and modules used across multiple apps. Libraries are organized
-  by team name, domain, functionality (e.g., common, ui, platform, key-management).
+- `apps/<client>/` — single-client code (browser, cli, desktop, web). Each app is self-contained.
+- `libs/common/` — code shared across **all** clients, including non-Angular (CLI). No Angular APIs here: no `@Injectable`, no `inject()`, no decorators, no template references.
+- `libs/angular/` — code shared across Angular clients (browser/desktop/web). Angular APIs allowed.
+- Other `libs/*` (e.g. `ui`, `platform`, `key-management`, `vault`) — domain-scoped, follow the same Angular / non-Angular split based on which clients consume them.
+
+When adding new code, place it as deep and as narrow as possible. Promote to a shared `libs/` only when a second client needs it.
 
 **Strict boundaries** must be maintained between apps and libraries. Do not introduce
 cross-dependencies that violate the intended modular structure. Always consult and respect the

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -17,6 +17,7 @@
 - **NEVER** log decrypted data, encryption keys, or PII
   - No vault data in error messages or console logs
 - **ALWAYS** Respect configuration files at the root and within each app/library (e.g., `eslint.config.mjs`, `jest.config.js`, `tsconfig.json`).
+- **CRITICAL**: Tailwind CSS classes MUST use the `tw-` prefix (e.g., `tw-flex`, `tw-p-4`). Missing prefix means the class is ignored and styling silently breaks. See [.claude/rules/tailwind.md](./rules/tailwind.md) for additional Tailwind rules.
 
 ## Mono-Repo Architecture
 

--- a/.claude/rules/angular-components.md
+++ b/.claude/rules/angular-components.md
@@ -6,12 +6,12 @@ paths:
 
 # Angular Component Patterns
 
-Distilled from [Web Code Style](https://contributing.bitwarden.com/contributing/code-style/web/). TypeScript-wide rules (enum-likes, observable services) live in [typescript.md](./typescript.md); the Tailwind `tw-` prefix rule lives in [CLAUDE.md](../CLAUDE.md).
+Distilled from [Web Code Style](https://contributing.bitwarden.com/contributing/code-style/web/). Angular patterns that span beyond components (DI, observable subscriptions) live in [angular.md](./angular.md); TypeScript-wide rules (enum-likes, file/class naming, imports) live in [typescript.md](./typescript.md); Tailwind rules live in [tailwind.md](./tailwind.md).
 
 ## Component Configuration
 
-- **Standalone**: Components must be standalone. Declare imports on the component decorator; do not register in `NgModule.declarations`.
-- **OnPush**: Set `changeDetection: ChangeDetectionStrategy.OnPush`. Re-render fires when an input signal/`@Input()` reference changes, an event handler runs, a signal in the template updates, an Observable with `async` pipe emits, or `markForCheck()` is called.
+- **Standalone**: Components must be standalone. NgModules may still be used to group components, but the inner components must be standalone. Declare imports on the component decorator; do not register in `NgModule.declarations`.
+- **OnPush**: Set `changeDetection: ChangeDetectionStrategy.OnPush`. With OnPush, mutating arrays/objects in place does **not** trigger change detection — create new references (`[...arr]`, `{...obj}`) or use signals.
 - **Host bindings**: Use the `host` property — not `@HostBinding` / `@HostListener`.
 
 ```typescript
@@ -24,14 +24,6 @@ Distilled from [Web Code Style](https://contributing.bitwarden.com/contributing/
     "(click)": "onClick()",
   },
 })
-```
-
-## Dependency Injection
-
-Use `inject()` — not constructor injection. (Constructor injection stays only in code shared with non-Angular clients; that code lives in services, see [typescript.md](./typescript.md).)
-
-```typescript
-private folderService = inject(FolderService);
 ```
 
 ## Signals (ADR-0027)

--- a/.claude/rules/angular-components.md
+++ b/.claude/rules/angular-components.md
@@ -6,7 +6,7 @@ paths:
 
 # Angular Component Patterns
 
-Distilled from [Web Code Style](https://contributing.bitwarden.com/contributing/code-style/web/). Angular patterns that span beyond components (DI, observable subscriptions) live in [angular.md](./angular.md); TypeScript-wide rules (enum-likes, file/class naming, imports) live in [typescript.md](./typescript.md); Tailwind rules live in [tailwind.md](./tailwind.md).
+Distilled from [Web Code Style](https://contributing.bitwarden.com/contributing/code-style/web/). Angular patterns that span beyond components (DI) live in [angular.md](./angular.md); TypeScript-wide rules (enum-likes, file/class naming) live in [typescript.md](./typescript.md); Tailwind rules live in [tailwind.md](./tailwind.md).
 
 ## Component Configuration
 

--- a/.claude/rules/angular.md
+++ b/.claude/rules/angular.md
@@ -1,0 +1,32 @@
+---
+paths:
+  - "**/*.ts"
+---
+
+# Angular Patterns
+
+> **Scope:** these rules apply **only to Angular code** — files in `apps/browser`, `apps/desktop`, `apps/web`, `libs/angular`, and any other library consumed by Angular clients. **Skip them in non-Angular TypeScript**: `libs/common`, `apps/cli`, SDK code, and anywhere `@Injectable` and Angular APIs are forbidden by the monorepo rules in the root [CLAUDE.md](../CLAUDE.md).
+
+Distilled from [Web Code Style — Angular](https://contributing.bitwarden.com/contributing/code-style/web/angular). Component-only patterns (templates, OnPush, signals, observable subscriptions, etc.) live in [angular-components.md](./angular-components.md); TypeScript-wide patterns live in [typescript.md](./typescript.md).
+
+## Dependency Injection
+
+Use `inject()` — not constructor injection. Constructor injection stays only in code shared with non-Angular clients (CLI).
+
+```typescript
+private folderService = inject(FolderService);
+```
+
+When declaring providers (component decorator, route config, module), wrap them in `safeProvider()` from `@bitwarden/ui-common`. It adds compile-time checks that the implementation matches the abstraction and that the `deps` array matches the constructor — raw Angular provider objects don't.
+
+```typescript
+import { safeProvider } from "@bitwarden/ui-common";
+
+providers: [
+  safeProvider({
+    provide: FolderService,
+    useClass: DefaultFolderService,
+    deps: [CipherService, I18nService],
+  }),
+],
+```

--- a/.claude/rules/autofill-content-scripts.md
+++ b/.claude/rules/autofill-content-scripts.md
@@ -11,7 +11,7 @@ Code in this directory runs as **injected content scripts**, not within the Angu
 
 - **DO NOT** use Angular patterns (components, services, dependency injection, RxJS Observable Data Services, Signals, `takeUntilDestroyed()`, `async` pipe, etc.)
 - **DO NOT** import Angular modules or dependencies
-- The Angular patterns defined in [angular-components.md](./angular-components.md) and the Observable Data Services pattern in [typescript.md](./typescript.md) do not apply here
+- The Angular patterns defined in [angular.md](./angular.md) and [angular-components.md](./angular-components.md), and the Observable Data Services pattern in [typescript.md](./typescript.md), do not apply here
 
 ## Lit Components
 

--- a/.claude/rules/i18n.md
+++ b/.claude/rules/i18n.md
@@ -1,0 +1,20 @@
+---
+paths:
+  - "apps/**/*.html"
+  - "apps/**/*.ts"
+  - "libs/**/*.html"
+  - "libs/**/*.ts"
+---
+
+# Localization
+
+User-visible strings (templates, toasts, dialogs, ARIA labels, validation messages) must be localized via `I18nPipe` in templates or `I18nService.t()` in TypeScript.
+
+When adding a new key:
+
+- **Only edit the `en` locale** — Crowdin handles every other language.
+- **Add it to every app that uses it.** Shared library strings need the key in each consuming app's `messages.json`:
+  - browser — `apps/browser/src/_locales/en/messages.json`
+  - web — `apps/web/src/locales/en/messages.json`
+  - desktop — `apps/desktop/src/locales/en/messages.json`
+  - cli — `apps/cli/src/locales/en/messages.json`

--- a/.claude/rules/tailwind.md
+++ b/.claude/rules/tailwind.md
@@ -7,11 +7,7 @@ paths:
 
 # Tailwind
 
-Distilled from [Web Code Style — Tailwind](https://contributing.bitwarden.com/contributing/code-style/web/tailwind).
-
-## `tw-` Prefix
-
-All Tailwind classes **must** use the `tw-` prefix (e.g. `tw-flex`, `tw-p-4`). The prefix is required by the Tailwind config — missing it means the class is ignored and styling silently breaks.
+Distilled from [Web Code Style — Tailwind](https://contributing.bitwarden.com/contributing/code-style/web/tailwind). The `tw-` prefix rule lives in the root [CLAUDE.md](../CLAUDE.md) so it loads on every session.
 
 ## No Arbitrary Values
 

--- a/.claude/rules/tailwind.md
+++ b/.claude/rules/tailwind.md
@@ -2,6 +2,7 @@
 paths:
   - "**/*.html"
   - "**/*.component.ts"
+  - "**/*.directive.ts"
 ---
 
 # Tailwind

--- a/.claude/rules/tailwind.md
+++ b/.claude/rules/tailwind.md
@@ -1,0 +1,23 @@
+---
+paths:
+  - "**/*.html"
+  - "**/*.component.ts"
+---
+
+# Tailwind
+
+Distilled from [Web Code Style — Tailwind](https://contributing.bitwarden.com/contributing/code-style/web/tailwind).
+
+## `tw-` Prefix
+
+All Tailwind classes **must** use the `tw-` prefix (e.g. `tw-flex`, `tw-p-4`). The prefix is required by the Tailwind config — missing it means the class is ignored and styling silently breaks.
+
+## No Arbitrary Values
+
+Do not use Tailwind's arbitrary-value syntax (e.g. `tw-[12px]`, `tw-text-[#ff0000]`). The only exception is preserving an existing Bootstrap style during migration — in that case, document it inline and add a tech-debt note for follow-up.
+
+## Theme Tokens Only
+
+Colors are restricted to the project's theme tokens (CSS variables wired into the Tailwind config) so multiple themes work. Use semantic tokens like `tw-bg-background-alt2`, not raw Tailwind colors (`tw-bg-gray-100`, `tw-text-red-500`).
+
+The canonical theme is defined in [libs/components/tailwind.config.base.js](../../libs/components/tailwind.config.base.js); check it for available tokens before adding new color or spacing values. App-specific configs (`apps/<app>/tailwind.config.js`) extend the base.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,0 +1,24 @@
+---
+paths:
+  - "**/*.spec.ts"
+---
+
+# Testing
+
+Distilled from [ADR-0010 — Clients Use Jest Mocks](https://contributing.bitwarden.com/architecture/adr/clients-use-jest-mocks).
+
+## Mocking Interfaces and Classes
+
+Use `mock<T>()` from `jest-mock-extended` to mock interfaces, abstract classes, and services. It gives a fully-typed mock with every method auto-stubbed.
+
+```typescript
+import { mock } from "jest-mock-extended";
+
+const cipherService = mock<CipherService>();
+const i18nService = mock<I18nService>();
+
+cipherService.get.mockResolvedValue(cipher);
+expect(i18nService.t).toHaveBeenCalledWith("itemDeleted");
+```
+
+`jest.fn()` is still appropriate for ad-hoc callbacks and spies — but reach for `mock<T>()` whenever you'd otherwise be hand-rolling a partial implementation of a typed interface.

--- a/.claude/rules/typescript.md
+++ b/.claude/rules/typescript.md
@@ -9,7 +9,7 @@ Distilled from [Web Code Style — TypeScript](https://contributing.bitwarden.co
 
 ## Boolean Naming
 
-Use the base word. Add `is` / `has` / `can` prefixes only when the unprefixed name would collide with another property.
+Use the base word. Add `is` / `has` / `can` prefixes only when meaning cannot be conveyed without them — for example, when the unprefixed name would collide with another property.
 
 ```typescript
 // Prefer
@@ -23,6 +23,8 @@ isEnabled = signal(true); // because `enabled` is already an input
 ## No TypeScript Enums (ADR-0025)
 
 Use const objects with derived type aliases. Don't add new enums; legacy ones remain.
+
+`Object.freeze` is recommended to prevent member injection at runtime.
 
 ```typescript
 // Numeric
@@ -71,3 +73,21 @@ Use **RxJS** (not Signals) in services for:
 - Code shared with non-Angular clients (CLI)
 - Complex reactive workflows
 - Interop with existing Observable-based code
+
+## File and Class Naming
+
+File names use suffixes to indicate role:
+
+- Conventional: `.service`, `.component`, `.pipe`, `.module`, `.directive`
+- Less conventional: `.api`, `.data`, `.view`, `.export`, `.request`, `.response`, `.type`, `.enum`
+
+Class names include the same suffix: `folder.service.ts` → `FolderService`, `folder.request.ts` → `FolderRequest`.
+
+### Implementation Prefixes
+
+When an abstract class has multiple implementations, prefix the class name:
+
+- `Default` — the default implementation
+- `Web`, `Browser`, `Desktop`, `Cli` — platform-specific implementations
+
+Example: `DefaultFolderService`, `BrowserPlatformUtilsService`.


### PR DESCRIPTION


## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Cross-references typescript.md and angular-components.md against the canonical code-style docs, fixes inaccuracies, and adds rule files for gaps where Claude was making the same mistakes repeatedly.