### PR TITLE
[PM-38529] Fix virtual scroll after Angular 21 update

### DIFF
--- a/apps/desktop/src/vault/app/vault-v3/vault-items/vault-cipher-row.component.ts
+++ b/apps/desktop/src/vault/app/vault-v3/vault-items/vault-cipher-row.component.ts
@@ -55,7 +55,7 @@ interface CopyFieldConfig {
   ],
 })
 export class VaultCipherRowComponent<C extends CipherViewLike> {
-  protected RowHeightClass = `tw-h-[75px]`;
+  protected RowHeightClass = `tw-h-[76.5px]`;
 
   protected readonly menuTrigger = viewChild<MenuTriggerForDirective>("optionsMenuTrigger");
 

--- a/apps/desktop/src/vault/app/vault-v3/vault-items/vault-collection-row.component.ts
+++ b/apps/desktop/src/vault/app/vault-v3/vault-items/vault-collection-row.component.ts
@@ -29,7 +29,7 @@ import { GetOrgNameFromIdPipe, OrganizationNameBadgeComponent } from "@bitwarden
   ],
 })
 export class VaultCollectionRowComponent {
-  protected RowHeightClass = `tw-h-[75px]`;
+  protected RowHeightClass = `tw-h-[76.5px]`;
   protected DefaultCollectionType = CollectionTypes.DefaultUserCollection;
 
   protected readonly disabled = input<boolean>();

--- a/apps/desktop/src/vault/app/vault-v3/vault-list.component.ts
+++ b/apps/desktop/src/vault/app/vault-v3/vault-list.component.ts
@@ -38,8 +38,8 @@ import { VaultCollectionRowComponent } from "./vault-items/vault-collection-row.
 import { VaultItemEvent } from "./vault-items/vault-item-event";
 
 // Fixed manual row height required due to how cdk-virtual-scroll works
-export const RowHeight = 75;
-export const RowHeightClass = `tw-h-[75px]`;
+export const RowHeight = 76.5;
+export const RowHeightClass = `tw-h-[76.5px]`;
 type EmptyStateItem = {
   title: string;
   description: string;

--- a/apps/web/src/app/vault/components/vault-items/vault-items.component.ts
+++ b/apps/web/src/app/vault/components/vault-items/vault-items.component.ts
@@ -43,8 +43,8 @@ import {
 import { VaultItemEvent } from "./vault-item-event";
 
 // Fixed manual row height required due to how cdk-virtual-scroll works
-export const RowHeight = 75;
-export const RowHeightClass = `tw-h-[75px]`;
+export const RowHeight = 76.5;
+export const RowHeightClass = `tw-h-[76.5px]`;
 
 const MaxSelectionCount = 500;
 

--- a/apps/web/webpack.base.js
+++ b/apps/web/webpack.base.js
@@ -300,8 +300,9 @@ module.exports.buildConfig = function buildConfig(params) {
                     ${"'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='" /* date input polyfill */}
                     ${"'sha256-JVRXyYPueLWdwGwY9m/7u4QlZ1xeQdqUj2t8OVIzZE4='" /* date input polyfill */}
                     ${"'sha256-EnIJNDxVnh0++RytXJOkU0sqtLDFt1nYUDOfeJ5SKxg='" /* ng-select */}
-                    ${"'sha256-dbBsIsz2pJ5loaLjhE6xWlmhYdjl6ghbwnGSCr4YObs='" /* cdk-virtual-scroll */}
                     ${"'sha256-S+uMh1G1SNQDAMG3seBmknQ26Wh+KSEoKdsNiy0joEE='" /* cdk-visually-hidden */}
+                    ${"'sha256-NioKnUhAWIPG1FfdlXRRJiUMWVaO2lqsAA83ioDrbRs='" /* cdk-virtual-scroll */}
+                    ${"'sha256-5Aa95/ZO6hntqOK1ZYDkfF0M76NFmrG+N39v6gp+12k='" /* related to angular */}
                     ;img-src
                     'self'
                     data:


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[PM-38529](https://bitwarden.atlassian.net/browse/PM-38529)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR adds missing CSP hashes from the Angular 21 upgrade, and also updates the vault row height which was a little off.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

Before

https://github.com/user-attachments/assets/2c957e8c-7a15-41ea-a367-861b6855ac47



After

https://github.com/user-attachments/assets/4819ca27-c0b2-4724-a05b-0322ec96c8ca



[PM-38529]: https://bitwarden.atlassian.net/browse/PM-38529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ