### PR TITLE
[PM-33813] Wrap danger zone buttons in a conditional to prevent rendering

### DIFF
--- a/apps/web/src/app/admin-console/organizations/settings/account.component.html
+++ b/apps/web/src/app/admin-console/organizations/settings/account.component.html
@@ -89,12 +89,14 @@
     </button>
   </form>
 
-  <app-danger-zone>
-    <button type="button" bitButton buttonType="danger" (click)="deleteOrganization()">
-      {{ "deleteOrganization" | i18n }}
-    </button>
-    <button type="button" bitButton buttonType="danger" [bitAction]="purgeVault">
-      {{ "purgeVault" | i18n }}
-    </button>
-  </app-danger-zone>
+  @if (!loading) {
+    <app-danger-zone>
+      <button type="button" bitButton buttonType="danger" (click)="deleteOrganization()">
+        {{ "deleteOrganization" | i18n }}
+      </button>
+      <button type="button" bitButton buttonType="danger" [bitAction]="purgeVault">
+        {{ "purgeVault" | i18n }}
+      </button>
+    </app-danger-zone>
+  }
 </bit-container>


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-33813

## 📔 Objective

Prevents danger zone area from rendering until organization details have properly loaded.

## 📸 Screenshots

<img width="1351" height="873" alt="image" src="https://github.com/user-attachments/assets/2fec9d1e-bed0-444e-bc24-8e81d6a347ec" />
