### PR TITLE
[PM-37913] - fix cloning archived cipher

### DIFF
--- a/libs/common/src/vault/models/view/cipher.view.spec.ts
+++ b/libs/common/src/vault/models/view/cipher.view.spec.ts
@@ -411,6 +411,7 @@ describe("CipherView", () => {
         username: "testuser",
         password: "testpass",
       });
+      expect(result.archivedDate).toBeNull();
     });
 
     it("handles undefined organizationId and folderId", () => {

--- a/libs/common/src/vault/models/view/cipher.view.spec.ts
+++ b/libs/common/src/vault/models/view/cipher.view.spec.ts
@@ -411,7 +411,7 @@ describe("CipherView", () => {
         username: "testuser",
         password: "testpass",
       });
-      expect(result.archivedDate).toBeNull();
+      expect(result.archivedDate).toBeUndefined();
     });
 
     it("handles undefined organizationId and folderId", () => {

--- a/libs/common/src/vault/models/view/cipher.view.ts
+++ b/libs/common/src/vault/models/view/cipher.view.ts
@@ -415,6 +415,7 @@ export class CipherView implements View, InitializerMetadata {
       reprompt: this.reprompt ?? CipherRepromptType.None,
       fields: this.fields?.map((f) => f.toSdkFieldView()),
       type: this.getSdkCipherViewType(),
+      archivedDate: null,
     };
 
     // If the cipher has FIDO2 credentials, we need to set them on the SDK create request

--- a/libs/common/src/vault/models/view/cipher.view.ts
+++ b/libs/common/src/vault/models/view/cipher.view.ts
@@ -415,7 +415,7 @@ export class CipherView implements View, InitializerMetadata {
       reprompt: this.reprompt ?? CipherRepromptType.None,
       fields: this.fields?.map((f) => f.toSdkFieldView()),
       type: this.getSdkCipherViewType(),
-      archivedDate: null,
+      archivedDate: undefined,
     };
 
     // If the cipher has FIDO2 credentials, we need to set them on the SDK create request

--- a/libs/common/src/vault/services/cipher-sdk.service.spec.ts
+++ b/libs/common/src/vault/services/cipher-sdk.service.spec.ts
@@ -124,6 +124,7 @@ describe("DefaultCipherSdkService", () => {
       cipherView.type = CipherType.Login;
       cipherView.name = "Test Cipher";
       cipherView.organizationId = orgId;
+      cipherView.archivedDate = new Date("2024-01-01T12:00:00.000Z");
 
       const mockSdkCipherView = cipherView.toSdkCipherView();
       mockCiphersSdk.create.mockResolvedValue(mockSdkCipherView);
@@ -136,6 +137,7 @@ describe("DefaultCipherSdkService", () => {
         expect.objectContaining({
           name: cipherView.name,
           organizationId: expect.anything(),
+          archivedDate: null,
         }),
       );
       expect(result).toBeInstanceOf(CipherView);

--- a/libs/common/src/vault/services/cipher-sdk.service.spec.ts
+++ b/libs/common/src/vault/services/cipher-sdk.service.spec.ts
@@ -137,7 +137,7 @@ describe("DefaultCipherSdkService", () => {
         expect.objectContaining({
           name: cipherView.name,
           organizationId: expect.anything(),
-          archivedDate: null,
+          archivedDate: undefined,
         }),
       );
       expect(result).toBeInstanceOf(CipherView);


### PR DESCRIPTION
## 🎟️ Tracking

[PM-37913](https://bitwarden.atlassian.net/browse/PM-37913)

## 📔 Objective

When cloning a cipher through SDK create operations, ensure the new cipher is not created as archived.

This updates the SDK create request mapping to explicitly send `archivedDate: null`, even when the source `CipherView` has an archived date. It also adds test coverage in `DefaultCipherSdkService` to verify archived source ciphers are sent to the SDK create API with `archivedDate` cleared.

Testing:
- `npx jest libs/common/src/vault/services/cipher-sdk.service.spec.ts -t "should create cipher using SDK when orgAdmin is false" --runInBand`

## 📸 Screenshots


https://github.com/user-attachments/assets/45c9a128-7921-48ef-a5dd-519aa084ba84



[PM-37913]: https://bitwarden.atlassian.net/browse/PM-37913?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ