### PR TITLE
Gate import of SSH key ECDSA type on FF

### DIFF
--- a/apps/browser/src/popup/services/services.module.ts
+++ b/apps/browser/src/popup/services/services.module.ts
@@ -754,7 +754,14 @@ const safeProviders: SafeProvider[] = [
   safeProvider({
     provide: SshImportPromptService,
     useClass: DefaultSshImportPromptService,
-    deps: [DialogService, ToastService, PlatformUtilsService, I18nServiceAbstraction],
+    deps: [
+      DialogService,
+      ToastService,
+      PlatformUtilsService,
+      I18nServiceAbstraction,
+      ConfigService,
+      LogService,
+    ],
   }),
   safeProvider({
     provide: ChangePasswordService,

--- a/apps/desktop/src/app/services/services.module.ts
+++ b/apps/desktop/src/app/services/services.module.ts
@@ -532,7 +532,14 @@ const safeProviders: SafeProvider[] = [
   safeProvider({
     provide: SshImportPromptService,
     useClass: DefaultSshImportPromptService,
-    deps: [DialogService, ToastService, PlatformUtilsServiceAbstraction, I18nServiceAbstraction],
+    deps: [
+      DialogService,
+      ToastService,
+      PlatformUtilsServiceAbstraction,
+      I18nServiceAbstraction,
+      ConfigService,
+      LogService,
+    ],
   }),
   safeProvider({
     provide: DesktopAutotypeService,

--- a/apps/web/src/app/core/core.module.ts
+++ b/apps/web/src/app/core/core.module.ts
@@ -432,7 +432,14 @@ const safeProviders: SafeProvider[] = [
   safeProvider({
     provide: SshImportPromptService,
     useClass: DefaultSshImportPromptService,
-    deps: [DialogService, ToastService, PlatformUtilsService, I18nServiceAbstraction],
+    deps: [
+      DialogService,
+      ToastService,
+      PlatformUtilsService,
+      I18nServiceAbstraction,
+      ConfigService,
+      LogService,
+    ],
   }),
   safeProvider({
     provide: ChangePasswordService,

--- a/libs/vault/src/services/default-ssh-import-prompt.service.ts
+++ b/libs/vault/src/services/default-ssh-import-prompt.service.ts
@@ -1,7 +1,10 @@
 import { Injectable } from "@angular/core";
 import { firstValueFrom } from "rxjs";
 
+import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { SshKeyApi } from "@bitwarden/common/vault/models/api/ssh-key.api";
 import { SshKeyData } from "@bitwarden/common/vault/models/data/ssh-key.data";
@@ -16,11 +19,19 @@ import { SshImportPromptService } from "./ssh-import-prompt.service";
  */
 @Injectable()
 export class DefaultSshImportPromptService implements SshImportPromptService {
+  private static readonly ECDSA_KEY_TYPES = [
+    "ecdsa-sha2-nistp256",
+    "ecdsa-sha2-nistp384",
+    "ecdsa-sha2-nistp521",
+  ];
+
   constructor(
     private dialogService: DialogService,
     private toastService: ToastService,
     private platformUtilsService: PlatformUtilsService,
     private i18nService: I18nService,
+    private configService: ConfigService,
+    private logService: LogService,
   ) {}
 
   async importSshKeyFromClipboard(): Promise<SshKeyData | null> {
@@ -67,6 +78,17 @@ export class DefaultSshImportPromptService implements SshImportPromptService {
             return null;
           }
         }
+      }
+    }
+
+    const isEcdsaKey = DefaultSshImportPromptService.ECDSA_KEY_TYPES.some((type) =>
+      parsedKey!.publicKey.startsWith(type),
+    );
+    if (isEcdsaKey) {
+      const ecdsaEnabled = await this.configService.getFeatureFlag(FeatureFlag.SSHecdsa);
+      if (!ecdsaEnabled) {
+        this.logService.error("ECDSA SSH key import blocked: SSHecdsa feature flag is not enabled");
+        return null;
       }
     }
 

--- a/libs/vault/src/services/default-ssh-import-prompt.service.ts
+++ b/libs/vault/src/services/default-ssh-import-prompt.service.ts
@@ -88,6 +88,14 @@ export class DefaultSshImportPromptService implements SshImportPromptService {
       const ecdsaEnabled = await this.configService.getFeatureFlag(FeatureFlag.SSHecdsa);
       if (!ecdsaEnabled) {
         this.logService.error("ECDSA SSH key import blocked: SSHecdsa feature flag is not enabled");
+
+        const variant = "UnsupportedKeyType";
+        this.toastService.showToast({
+          variant: "error",
+          title: "",
+          message: this.i18nService.t(this.sshImportErrorVariantToI18nKey(variant)),
+        });
+
         return null;
       }
     }

--- a/libs/vault/src/services/ssh-import-prompt.service.spec.ts
+++ b/libs/vault/src/services/ssh-import-prompt.service.spec.ts
@@ -133,7 +133,10 @@ describe("SshImportPromptService", () => {
       expect(await sshImportPromptService.importSshKeyFromClipboard()).toBeNull();
       expect(configService.getFeatureFlag).toHaveBeenCalledWith(FeatureFlag.SSHecdsa);
       expect(logService.error).toHaveBeenCalled();
-      expect(toastService.showToast).not.toHaveBeenCalled();
+      expect(toastService.showToast).toHaveBeenCalledWith(
+        expect.objectContaining({ variant: "error" }),
+      );
+      expect(i18nService.t).toHaveBeenCalledWith("sshKeyTypeUnsupported");
     });
 
     it("allows ECDSA key import when SSHecdsa flag is enabled", async () => {
@@ -144,6 +147,10 @@ describe("SshImportPromptService", () => {
       expect(await sshImportPromptService.importSshKeyFromClipboard()).not.toBeNull();
       expect(configService.getFeatureFlag).toHaveBeenCalledWith(FeatureFlag.SSHecdsa);
       expect(logService.error).not.toHaveBeenCalled();
+      expect(toastService.showToast).toHaveBeenCalledWith(
+        expect.objectContaining({ variant: "success" }),
+      );
+      expect(i18nService.t).not.toHaveBeenCalledWith("sshKeyTypeUnsupported");
     });
 
     it("does not check SSHecdsa flag for non-ECDSA keys", async () => {

--- a/libs/vault/src/services/ssh-import-prompt.service.spec.ts
+++ b/libs/vault/src/services/ssh-import-prompt.service.spec.ts
@@ -1,7 +1,10 @@
 import { MockProxy, mock } from "jest-mock-extended";
 import { BehaviorSubject } from "rxjs";
 
+import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { SshKeyApi } from "@bitwarden/common/vault/models/api/ssh-key.api";
 import { SshKeyData } from "@bitwarden/common/vault/models/data/ssh-key.data";
@@ -16,6 +19,12 @@ const exampleSshKey = {
   privateKey: "private_key",
   publicKey: "public_key",
   fingerprint: "key_fingerprint",
+} as sdkInternal.SshKeyView;
+
+const exampleEcdsaKey = {
+  privateKey: "ecdsa_private_key",
+  publicKey: "ecdsa-sha2-nistp256 AAAA...",
+  fingerprint: "ecdsa_fingerprint",
 } as sdkInternal.SshKeyView;
 
 const exampleSshKeyData = new SshKeyData(
@@ -33,18 +42,26 @@ describe("SshImportPromptService", () => {
   let toastService: MockProxy<ToastService>;
   let platformUtilsService: MockProxy<PlatformUtilsService>;
   let i18nService: MockProxy<I18nService>;
+  let configService: MockProxy<ConfigService>;
+  let logService: MockProxy<LogService>;
 
   beforeEach(() => {
     dialogService = mock<DialogService>();
     toastService = mock<ToastService>();
     platformUtilsService = mock<PlatformUtilsService>();
     i18nService = mock<I18nService>();
+    configService = mock<ConfigService>();
+    logService = mock<LogService>();
+
+    configService.getFeatureFlag.mockResolvedValue(false);
 
     sshImportPromptService = new DefaultSshImportPromptService(
       dialogService,
       toastService,
       platformUtilsService,
       i18nService,
+      configService,
+      logService,
     );
     jest.clearAllMocks();
   });
@@ -106,6 +123,35 @@ describe("SshImportPromptService", () => {
 
       expect(await sshImportPromptService.importSshKeyFromClipboard()).toEqual(null);
       expect(i18nService.t).toHaveBeenCalledWith("sshKeyTypeUnsupported");
+    });
+
+    it("blocks ECDSA key import when SSHecdsa flag is disabled", async () => {
+      jest.spyOn(sdkInternal, "import_ssh_key").mockReturnValue(exampleEcdsaKey);
+      platformUtilsService.readFromClipboard.mockResolvedValue("ecdsa_key");
+      configService.getFeatureFlag.mockResolvedValue(false);
+
+      expect(await sshImportPromptService.importSshKeyFromClipboard()).toBeNull();
+      expect(configService.getFeatureFlag).toHaveBeenCalledWith(FeatureFlag.SSHecdsa);
+      expect(logService.error).toHaveBeenCalled();
+      expect(toastService.showToast).not.toHaveBeenCalled();
+    });
+
+    it("allows ECDSA key import when SSHecdsa flag is enabled", async () => {
+      jest.spyOn(sdkInternal, "import_ssh_key").mockReturnValue(exampleEcdsaKey);
+      platformUtilsService.readFromClipboard.mockResolvedValue("ecdsa_key");
+      configService.getFeatureFlag.mockResolvedValue(true);
+
+      expect(await sshImportPromptService.importSshKeyFromClipboard()).not.toBeNull();
+      expect(configService.getFeatureFlag).toHaveBeenCalledWith(FeatureFlag.SSHecdsa);
+      expect(logService.error).not.toHaveBeenCalled();
+    });
+
+    it("does not check SSHecdsa flag for non-ECDSA keys", async () => {
+      jest.spyOn(sdkInternal, "import_ssh_key").mockReturnValue(exampleSshKey);
+      platformUtilsService.readFromClipboard.mockResolvedValue("ssh_key");
+
+      expect(await sshImportPromptService.importSshKeyFromClipboard()).toEqual(exampleSshKeyData);
+      expect(configService.getFeatureFlag).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-37918

## 📔 Objective

Import of ECDSA keys is not yet enabled in the SDK. When it is, we want to ensure that we only attempt to add keys to the vault if the ECDSA is supported in the client. We do this by checking that the ECDSA FF is enabled before importing to the vault.
After some releases have passed that the ECDSA support is available in the agent, we will remove this logic as part of the removal of the ECDSA FF.

## 📸 Manual testing

- validated with a local build of the SDK with ecdsa key type support, that when the FF is off, each curve is rejected with the toast message, and when it's enabled, they are correctly imported. 
