### PR TITLE
[PM-38583] chore: remove incompatible special character for passwords

### DIFF
--- a/libs/tools/generator/core/src/engine/data.ts
+++ b/libs/tools/generator/core/src/engine/data.ts
@@ -6,7 +6,7 @@ function toCharacterSet(characters: string) {
   return Object.freeze(set as CharacterSet);
 }
 
-const SpecialCharacters = toCharacterSet("!@#$%^&*");
+const SpecialCharacters = toCharacterSet("!@#$%&*");
 
 /** Sets of Ascii characters used for password generation */
 export const Ascii = Object.freeze({

--- a/libs/tools/generator/core/src/engine/data.ts
+++ b/libs/tools/generator/core/src/engine/data.ts
@@ -6,7 +6,7 @@ function toCharacterSet(characters: string) {
   return Object.freeze(set as CharacterSet);
 }
 
-const SpecialCharacters = toCharacterSet("!@#$%&*");
+const SpecialCharacters = toCharacterSet("!@#$%?&*");
 
 /** Sets of Ascii characters used for password generation */
 export const Ascii = Object.freeze({


### PR DESCRIPTION
This special character "^" is often not accepted (I would say in 40% of cases) by websites as a valid character for a password.  As a user, I always click "generate again" when it appears in my new generated passwords.

## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-38583

## 📔 Objective

<!-- This special character "^" is often not accepted by websites as a valid character for a password. -->