### PR TITLE
Perf/incremental shadow overflow

### DIFF
--- a/apps/browser/src/autofill/services/collect-autofill-content.service.spec.ts
+++ b/apps/browser/src/autofill/services/collect-autofill-content.service.spec.ts
@@ -2875,15 +2875,14 @@ describe("CollectAutofillContentService", () => {
         expect(collectAutofillContentService["pendingMutationAddedElements"].size).toBe(0);
       });
 
-      it("trips the overflow flag at the cap and releases element refs", () => {
+      it("trips the overflow flag at the cap and keeps the capped set for incremental scan", () => {
         const cap = collectAutofillContentService["pendingMutationAddedElementsCap"];
         const widgets = Array.from({ length: cap + 50 }, () => document.createElement("my-widget"));
 
         collectAutofillContentService["collectAddedShadowRootCandidates"]([buildMutation(widgets)]);
 
         expect(collectAutofillContentService["pendingMutationAddedElementsOverflowed"]).toBe(true);
-        // Overflow path clears the Set immediately so refs don't linger until the debounce fires.
-        expect(collectAutofillContentService["pendingMutationAddedElements"].size).toBe(0);
+        expect(collectAutofillContentService["pendingMutationAddedElements"].size).toBe(cap);
       });
 
       it("is a no-op once overflow has been tripped (later batches are ignored)", () => {

--- a/apps/browser/src/autofill/services/collect-autofill-content.service.ts
+++ b/apps/browser/src/autofill/services/collect-autofill-content.service.ts
@@ -66,7 +66,7 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
   private pendingShadowDomCheck = false;
   private pendingMutationAddedElements: Set<Element> = new Set();
   private pendingMutationAddedElementsOverflowed = false;
-  // Caps the batch handed to suppressDescendantsInBatch; overflow → full-document scan fallback.
+  // Caps the batch handed to suppressDescendantsInBatch; on cap the kept set is scanned incrementally.
   private readonly pendingMutationAddedElementsCap = 256;
   private ownedExperienceTagNames: string[] = [];
   private readonly updateAfterMutationTimeout = 1000;
@@ -1594,10 +1594,8 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
         this.pendingMutationAddedElements.add(node);
         if (this.pendingMutationAddedElements.size >= this.pendingMutationAddedElementsCap) {
           this.pendingMutationAddedElementsOverflowed = true;
-          // Overflow → next shadow check escalates to a full-document scan.
           this.monitorCandidateOverflow();
-          // Release element refs immediately; we won't process them this window.
-          this.pendingMutationAddedElements.clear();
+          // Keep the capped set so the debounced check scans it incrementally, not a re-walk.
           return;
         }
       }

--- a/apps/browser/src/autofill/services/collect-autofill-content.service.ts
+++ b/apps/browser/src/autofill/services/collect-autofill-content.service.ts
@@ -1,6 +1,7 @@
 import { AUTOFILL_ATTRIBUTES } from "@bitwarden/common/autofill/constants";
 import { AutofillTargetingRuleType, FormContent } from "@bitwarden/common/autofill/types";
 
+import { createMeter, measure, stopwatch } from "../content/performance";
 import AutofillField from "../models/autofill-field";
 import AutofillForm from "../models/autofill-form";
 import AutofillPageDetails from "../models/autofill-page-details";
@@ -76,6 +77,24 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
   private readonly mutationCooldownMs = 500;
   private readonly maxMutationWaitMs = 5000;
   private readonly formFieldQueryString;
+
+  private readonly monitorMapSizes = createMeter("mapSizes", "fields", "byOpid", "forms", "heap");
+  // Larger ring than default: fires per MO callback; churn-heavy pages can outrun 256 slots before flush.
+  private readonly monitorMutationBatch = createMeter(
+    { name: "mutationBatch", bits: 10 },
+    "records",
+    "inShadow",
+  );
+  private readonly monitorRequireUpdateLocation = createMeter("requireUpdateLocation");
+  private readonly monitorRequireUpdateShadow = createMeter("requireUpdateShadow");
+  private readonly monitorRequireUpdateNewShadowRoot = createMeter("requireUpdateNewShadowRoot");
+  private readonly monitorProcessMutations = createMeter("processMutations");
+  private readonly monitorUpdateCachedVisibility = createMeter("updateCachedVisibility");
+  private readonly monitorSetupOverlayOnField = createMeter("setupOverlayOnField");
+  // Gate-branch-architecture meters (main's queue-swap path): adaptive backoff + 256-cap overflow.
+  private readonly monitorBackoff = createMeter("mutationBackoff", "burst", "adaptiveMs");
+  private readonly monitorCandidateOverflow = createMeter("shadowCandidateOverflow");
+
   private readonly nonInputFormFieldTags = new Set(["textarea", "select"]);
   private readonly ignoredInputTypes = new Set([
     "hidden",
@@ -105,6 +124,16 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
       inputQuery += `:not([type="${type}"])`;
     }
     this.formFieldQueryString = `${inputQuery}, textarea:not([data-bwignore]), select:not([data-bwignore]), span[data-bwautofill]`;
+
+    this.handleMutationObserverMutation = stopwatch(
+      "handleMutationObserverMutation",
+      this.handleMutationObserverMutation,
+    );
+    this.handleNewShadowRoots = stopwatch("handleNewShadowRoots", this.handleNewShadowRoots);
+    this.queryAutofillFormAndFieldElements = stopwatch(
+      "queryAutofillFormAndFieldElements",
+      this.queryAutofillFormAndFieldElements,
+    );
   }
 
   get autofillFormElements(): AutofillFormElements {
@@ -448,6 +477,7 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
    * @private
    */
   private updateCachedAutofillFieldVisibility() {
+    this.monitorUpdateCachedVisibility();
     this.autofillFieldElements.forEach(async (autofillField, element) => {
       const previouslyViewable = autofillField.viewable;
       autofillField.viewable = await this.domElementVisibilityService.isElementViewable(element);
@@ -1320,9 +1350,14 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
       return;
     }
 
-    const hasMutationsInShadowRoot = this.domQueryService.checkMutationsInShadowRoots(mutations);
+    const hasMutationsInShadowRoot = measure("shadowMutationCheck", () =>
+      this.domQueryService.checkMutationsInShadowRoots(mutations),
+    );
+
+    this.monitorMutationBatch(mutations.length, hasMutationsInShadowRoot);
 
     if (hasMutationsInShadowRoot) {
+      this.monitorRequireUpdateShadow();
       this.debouncedRequirePageDetailsUpdate();
     }
 
@@ -1398,6 +1433,7 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
    * @private
    */
   private handleWindowLocationMutation() {
+    this.monitorRequireUpdateLocation();
     this.currentLocationHref = globalThis.location.href;
 
     this.domRecentlyMutated = true;
@@ -1419,6 +1455,7 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
   }
 
   private processMutations = () => {
+    this.monitorProcessMutations();
     // Swap first so reentrant mutations during processing land in fresh structures
     // and drain on the next cycle, mirroring the queue-swap the previous design relied on.
     const drainingAttributeMutations = this.pendingAttributeMutations;
@@ -1454,6 +1491,13 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
         if (this.domRecentlyMutated) {
           this.updateAutofillElementsAfterMutation();
         }
+        this.monitorMapSizes(
+          this.autofillFieldElements.size,
+          this.autofillFieldsByOpid.size,
+          this._autofillFormElements.size,
+          (performance as unknown as { memory?: { usedJSHeapSize: number } }).memory
+            ?.usedJSHeapSize ?? 0,
+        );
       },
       { timeout: 500 },
     );
@@ -1530,6 +1574,7 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
     }
     const hasNewShadowRoots = this.domQueryService.checkForNewShadowRoots(connected);
     if (hasNewShadowRoots) {
+      this.monitorRequireUpdateNewShadowRoot();
       this.debouncedRequirePageDetailsUpdate();
     }
   };
@@ -1549,6 +1594,8 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
         this.pendingMutationAddedElements.add(node);
         if (this.pendingMutationAddedElements.size >= this.pendingMutationAddedElementsCap) {
           this.pendingMutationAddedElementsOverflowed = true;
+          // Overflow → next shadow check escalates to a full-document scan.
+          this.monitorCandidateOverflow();
           // Release element refs immediately; we won't process them this window.
           this.pendingMutationAddedElements.clear();
           return;
@@ -1644,6 +1691,9 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
       );
       adaptiveTimeout = this.updateAfterMutationTimeout + extensionMs;
     }
+
+    // Rising burst with adaptiveMs pinned at max = perpetually-hot page.
+    this.monitorBackoff(this.mutationBurstCount, adaptiveTimeout);
 
     this.updateAfterMutationIdleCallback = requestIdleCallbackPolyfill(
       this.getPageDetails.bind(this),
@@ -1860,6 +1910,7 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
     autofillField: AutofillField,
     pageDetails?: AutofillPageDetails,
   ) {
+    this.monitorSetupOverlayOnField();
     if (!this.autofillOverlayContentService) {
       return;
     }

--- a/apps/browser/src/autofill/services/dom-query.service.spec.ts
+++ b/apps/browser/src/autofill/services/dom-query.service.spec.ts
@@ -322,18 +322,18 @@ describe("DomQueryService", () => {
       domQueryService["knownShadowRoots"].clear();
     });
 
-    it("returns true when a shadow root is not in the observed set", () => {
+    it("returns true when a batched element hosts a root not in the observed set", () => {
       domQueryService["pageContainsShadowDom"] = true;
       const customElement = document.createElement("custom-element");
       customElement.attachShadow({ mode: "open" });
       document.body.appendChild(customElement);
 
-      const result = domQueryService.checkForNewShadowRoots();
+      const result = domQueryService.checkForNewShadowRoots([customElement]);
 
       expect(result).toBe(true);
     });
 
-    it("returns false when all shadow roots are already observed", () => {
+    it("returns false when the batched element's root is already observed", () => {
       domQueryService["pageContainsShadowDom"] = true;
       const customElement = document.createElement("custom-element");
       const shadowRoot = customElement.attachShadow({ mode: "open" });
@@ -342,18 +342,28 @@ describe("DomQueryService", () => {
       // Simulate the shadow root being observed by adding it to the tracked set
       domQueryService["knownShadowRoots"].add(shadowRoot);
 
-      const result = domQueryService.checkForNewShadowRoots();
+      const result = domQueryService.checkForNewShadowRoots([customElement]);
 
       expect(result).toBe(false);
     });
 
-    it("returns false when there are no shadow roots on the page", () => {
+    it("returns false when a batched element hosts no shadow root", () => {
       const div = document.createElement("div");
       document.body.appendChild(div);
 
-      const result = domQueryService.checkForNewShadowRoots();
+      const result = domQueryService.checkForNewShadowRoots([div]);
 
       expect(result).toBe(false);
+    });
+
+    it("short-circuits to false on an empty batch even with an unobserved root present", () => {
+      domQueryService["pageContainsShadowDom"] = true;
+      const customElement = document.createElement("custom-element");
+      customElement.attachShadow({ mode: "open" });
+      document.body.appendChild(customElement);
+
+      expect(domQueryService.checkForNewShadowRoots()).toBe(false);
+      expect(domQueryService.checkForNewShadowRoots([])).toBe(false);
     });
 
     it("returns true via narrow-scan and does not flip pageContainsShadowDom when latch was already true", () => {
@@ -468,6 +478,14 @@ describe("DomQueryService", () => {
         const verdict = domQueryService["classifyShadowRootScan"]([host]);
 
         expect(verdict.branch).toBe("narrow");
+      });
+
+      it("returns shortCircuit on an empty batch even with the latch true (no full-document walk)", () => {
+        domQueryService["pageContainsShadowDom"] = true;
+
+        const verdict = domQueryService["classifyShadowRootScan"]([]);
+
+        expect(verdict).toEqual({ branch: "shortCircuit", foundNewRoot: false });
       });
 
       it("does not mutate pageContainsShadowDom", () => {

--- a/apps/browser/src/autofill/services/dom-query.service.spec.ts
+++ b/apps/browser/src/autofill/services/dom-query.service.spec.ts
@@ -366,6 +366,21 @@ describe("DomQueryService", () => {
       expect(domQueryService.checkForNewShadowRoots([])).toBe(false);
     });
 
+    // Characterizes the known gap (no full-document fallback); flip when fixed.
+    it("finds an in-place attachShadow root only via the candidate batch, not absent the host", () => {
+      domQueryService["pageContainsShadowDom"] = true;
+      const host = document.createElement("div");
+      document.body.appendChild(host);
+      const root = host.attachShadow({ mode: "open" });
+      root.appendChild(Object.assign(document.createElement("input"), { type: "text" }));
+
+      const unrelated = document.createElement("span");
+      document.body.appendChild(unrelated);
+
+      expect(domQueryService.checkForNewShadowRoots([unrelated])).toBe(false);
+      expect(domQueryService.checkForNewShadowRoots([host])).toBe(true);
+    });
+
     it("returns true via narrow-scan and does not flip pageContainsShadowDom when latch was already true", () => {
       domQueryService["pageContainsShadowDom"] = true;
       const host = document.createElement("custom-element");

--- a/apps/browser/src/autofill/services/dom-query.service.ts
+++ b/apps/browser/src/autofill/services/dom-query.service.ts
@@ -12,8 +12,7 @@ import { DomQueryService as DomQueryServiceInterface } from "./abstractions/dom-
 
 type ScanVerdict =
   | { branch: "shortCircuit"; foundNewRoot: false }
-  | { branch: "narrow"; foundNewRoot: boolean }
-  | { branch: "fullScan"; foundNewRoot: boolean };
+  | { branch: "narrow"; foundNewRoot: boolean };
 
 export class DomQueryService implements DomQueryServiceInterface {
   /** One-way ratchet; reset only by `resetObservedShadowRoots()`. */
@@ -130,13 +129,12 @@ export class DomQueryService implements DomQueryServiceInterface {
 
   private classifyShadowRootScan = (addedElements?: Element[]): ScanVerdict => {
     const hasAddedElements = !!addedElements && addedElements.length > 0;
-    // Batch present: scan even with latch false (shadow DOM may attach post-init).
-    if (!this.pageContainsShadowDom && !hasAddedElements) {
+    // No added elements ⇒ nothing to discover; never escalate to a full-document walk
+    // (re-pierces known roots, O(document)). A batch is scanned even with latch false.
+    if (!hasAddedElements) {
       return { branch: "shortCircuit", foundNewRoot: false };
     }
-    return hasAddedElements
-      ? this.findNewShadowRootInBatch(addedElements!)
-      : this.findNewShadowRootInDocument();
+    return this.findNewShadowRootInBatch(addedElements!);
   };
 
   private findNewShadowRootInBatch = (elements: Element[]): ScanVerdict => {
@@ -169,19 +167,6 @@ export class DomQueryService implements DomQueryServiceInterface {
       }
     }
     return roots;
-  };
-
-  private findNewShadowRootInDocument = (): ScanVerdict => {
-    let roots: ShadowRoot[];
-    try {
-      roots = this.recursivelyQueryShadowRoots(globalThis.document.body);
-    } catch {
-      roots = this.queryShadowRoots(globalThis.document.body);
-    }
-    return {
-      branch: "fullScan",
-      foundNewRoot: roots.some((r) => !this.knownShadowRoots.has(r)),
-    };
   };
 
   private markShadowDomPresent = (): void => {


### PR DESCRIPTION
## 🎟️ Tracking

PM-35196 (follow-on)

# PR 3 — perf/incremental-shadow-overflow

PR 1: #21083
PR 2: #21084

(Note: applies last, biggest caveats)

**Net objective:** Remove the worst-case latency spike: on candidate-cap overflow,
scan the kept set incrementally instead of re-walking the whole document.
Touches both files → must rebase onto PRs 1 (#21083) & 2 (#21084).

- **Expected:** Eliminates the full-document-walk spike; freed time may be
  reclaimed by more rebuilds; coverage risk for roots only the full scan found.
- **Result (headline — per-call spike):** S10 `handleNewShadowRoots`: the 
  worst-case freeze in shadow-root discovery went from ~166ms to instant, 
  ~11.7 seconds of total blocking over the minute vanished; not coincidence 
  because overflow kept happening just as often (only its cost changed).

### ⚠️ Tradeoff 1 — work shift, not CPU saving
S10 `queryAutofillForm` 225→415 calls, +11668ms: the ~11.7s freed is almost
exactly reabsorbed by more rebuilds on the clean baseline. On the integrated
stack (PRs 1+2 present) those rebuilds are gated, net win but
measured alone it redistributes (rather than reduces).

### ⚠️ Tradeoff 2 — narrow coverage gap
In-place `attachShadow` on an already-present element (field, no node-addition)
is no longer swept up. Documented by a committed characterization test;
decision was to document and ship.

### ⚠️ Caveat 3 — 1.A subsumes most of its S10 effect
With PR 1 (#21083) landed, 1.A prevents the deep-churn delivery that causes S10 overflow,
so this lever's unique remaining value is light-DOM node floods (e.g. Google Maps tiles), which 1.A can't mask.

## Coverage

S10 fields/forms max held 5/2; late attach via node-addition still discovered.

<details>
<summary><b>Benchmark scenario legend</b></summary>

| Label | Fixture | What it exercises |
|-------|---------|-------------------|
| **S1** | `1-cosmetic-feed-scroll` | Light-DOM cosmetic childList churn (feed scrolling) — no fillable change. |
| **S2** | `2-form-with-mutations` | A real form mutating; fields should plateau at the page's true count. |
| **S3** | `3-late-attached-shadow-form` | A shadow-hosted form attached *after* load — late discovery / coverage. |
| **S4** | `4-detach-reattach-churn` | Elements detaching and reattaching — reaper / leak behavior. |
| **S5** | `5-attribute-toggle-storm` | High-rate attribute toggling across many fields. |
| **S6** | `6-rerender-burst` | Bursty full re-renders (large mutation batches). |
| **S7** | `7-attr-relevance-transition` | A node becoming autofill-relevant via attribute change. _(retired)_ |
| **S8** | `8-shadow-attribute-storm` | Style/transform churn at frame rate *inside a field-bearing shadow root*. |
| **S9** | `9-shadow-tile-churn` | Field-less shadow roots doing deep childList churn (map-tile pattern). |
| **S10** | `10-shadow-scale-stress` | ~90k nodes: 300 field-less tiles + a nested-root chain + sparse forms (scale, overflow, nesting). |

</details>