### PR TITLE
[PM-38571] Fix shareReplay memory leaks

### DIFF
--- a/libs/angular/src/vault/services/nudges.service.ts
+++ b/libs/angular/src/vault/services/nudges.service.ts
@@ -1,5 +1,5 @@
 import { inject, Injectable } from "@angular/core";
-import { combineLatest, map, Observable, shareReplay } from "rxjs";
+import { combineLatest, map, Observable } from "rxjs";
 
 import { UserKeyDefinition, NUDGES_DISK } from "@bitwarden/common/platform/state";
 import { UserId } from "@bitwarden/common/types/guid";
@@ -165,10 +165,7 @@ export class NudgesService {
     const nudgeTypesWithBadge$ = nudgeTypes.map((nudge) => {
       return this.getNudgeService(nudge)
         .nudgeStatus$(nudge, userId)
-        .pipe(
-          map((status) => !status?.hasBadgeDismissed),
-          shareReplay({ refCount: false, bufferSize: 1 }),
-        );
+        .pipe(map((status) => !status?.hasBadgeDismissed));
     });
 
     return combineLatest(nudgeTypesWithBadge$).pipe(

--- a/libs/common/src/vault/services/cipher-authorization.service.ts
+++ b/libs/common/src/vault/services/cipher-authorization.service.ts
@@ -1,4 +1,4 @@
-import { combineLatest, map, Observable, of, shareReplay, switchMap } from "rxjs";
+import { combineLatest, map, Observable, of, switchMap } from "rxjs";
 
 // This import has been flagged as unallowed for this class. It may be involved in a circular dependency loop.
 // eslint-disable-next-line no-restricted-imports
@@ -181,7 +181,6 @@ export class DefaultCipherAuthorizationService implements CipherAuthorizationSer
           map((allCollections) => allCollections.some((collection) => collection.manage)),
         );
       }),
-      shareReplay({ bufferSize: 1, refCount: false }),
     );
   }
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-38571](https://bitwarden.atlassian.net/browse/PM-38571)

## 📔 Objective

Fixes memory leaks caused by `shareReplay({ refCount: false })` inside per-call observable factory methods.

When `refCount: false` is set, RxJS keeps an internal subscription to the upstream source alive indefinitely — even after all external subscribers unsubscribe. In a method that returns a new observable on each invocation, each call accumulates a persistent subscription that is never cleaned up.

Fix: remove `shareReplay` from both methods entirely.

[PM-38571]: https://bitwarden.atlassian.net/browse/PM-38571?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ