### PR TITLE
BRE-1965 feat(web): add usqa2 environment build and artifact

### DIFF
--- a/.github/workflows/build-web.yml
+++ b/.github/workflows/build-web.yml
@@ -128,6 +128,11 @@ jobs:
             image_name: web-qa-cloud
             npm_command: build:bit:qa
             git_metadata: true
+          - artifact_name: cloud-usqa2
+            license_type: "commercial"
+            image_name: web-qa2-cloud
+            npm_command: build:bit:usqa2
+            git_metadata: true
           - artifact_name: ee
             license_type: "commercial"
             image_name: web-ee

--- a/apps/web/config/euqa.json
+++ b/apps/web/config/euqa.json
@@ -13,6 +13,13 @@
       }
     },
     {
+      "key": "USQA2",
+      "domain": "qa2.bitwarden.pw",
+      "urls": {
+        "webVault": "https://vault.qa2.bitwarden.pw"
+      }
+    },
+    {
       "key": "EUQA",
       "domain": "euqa.bitwarden.pw",
       "urls": {

--- a/apps/web/config/qa.json
+++ b/apps/web/config/qa.json
@@ -19,6 +19,13 @@
       }
     },
     {
+      "key": "USQA2",
+      "domain": "qa2.bitwarden.pw",
+      "urls": {
+        "webVault": "https://vault.qa2.bitwarden.pw"
+      }
+    },
+    {
       "key": "EUQA",
       "domain": "euqa.bitwarden.pw",
       "urls": {

--- a/apps/web/config/usqa2.json
+++ b/apps/web/config/usqa2.json
@@ -1,0 +1,31 @@
+{
+  "urls": {
+    "icons": "https://icons.qa2.bitwarden.pw",
+    "notifications": "https://notifications.qa2.bitwarden.pw",
+    "scim": "https://scim.qa2.bitwarden.pw"
+  },
+  "additionalRegions": [
+    {
+      "key": "USQA2",
+      "domain": "qa2.bitwarden.pw",
+      "urls": {
+        "webVault": "https://vault.qa2.bitwarden.pw"
+      }
+    },
+    {
+      "key": "USQA",
+      "domain": "qa.bitwarden.pw",
+      "urls": {
+        "webVault": "https://vault.qa.bitwarden.pw"
+      }
+    },
+    {
+      "key": "EUQA",
+      "domain": "euqa.bitwarden.pw",
+      "urls": {
+        "webVault": "https://vault.euqa.bitwarden.pw"
+      }
+    }
+  ],
+  "flags": {}
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,6 +10,7 @@
     "build:bit:dev:analyze": "cross-env LOGGING=false webpack -c ../../bitwarden_license/bit-web/webpack.config.js --profile --json > stats.json && npx webpack-bundle-analyzer stats.json build/",
     "build:bit:dev:watch": "cross-env ENV=development NODE_OPTIONS=\"--max-old-space-size=8192\" npm run build:bit:watch",
     "build:bit:qa": "cross-env NODE_ENV=production ENV=qa npm run build:bit",
+    "build:bit:usqa2": "cross-env NODE_ENV=production ENV=usqa2 npm run build:bit",
     "build:bit:euprd": "cross-env NODE_ENV=production ENV=euprd npm run build:bit",
     "build:bit:euqa": "cross-env NODE_ENV=production ENV=euqa npm run build:bit",
     "build:bit:usdev": "cross-env NODE_ENV=production ENV=usdev npm run build:bit",


### PR DESCRIPTION




## 🎟️ Tracking

[BRE-1965](https://bitwarden.atlassian.net/browse/BRE-1965)

## 📔 Objective

Add a dedicated build target for the new US QA2 cloud environment so the web vault can be built and deployed independently to its isolated us-qa2 namespace. The build emits a web-short-sha-cloud-usqa2.zip runner artifact that the downstream deploy workflows consume.
* Add cloud-usqa2 matrix entry to build-web.yml emitting web-*-cloud-usqa2.zip
* Add build:bit:usqa2 script targeting ENV=usqa2
* Add usqa2.json env config pointing at *.qa2.bitwarden.pw
* Register the USQA2 region in the qa and euqa region selectors

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->


[BRE-1965]: https://bitwarden.atlassian.net/browse/BRE-1965?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ