### PR TITLE
[CL-1216] Add optional hint text support to the select component

### DIFF
--- a/libs/components/src/select/option.component.ts
+++ b/libs/components/src/select/option.component.ts
@@ -15,5 +15,7 @@ export class OptionComponent<T = unknown> implements MappedOptionComponent<T> {
 
   readonly label = input.required<string>();
 
+  readonly description = input<string>();
+
   readonly disabled = input(undefined, { transform: booleanAttribute });
 }

--- a/libs/components/src/select/option.ts
+++ b/libs/components/src/select/option.ts
@@ -4,6 +4,7 @@ export interface Option<T> {
   icon?: string;
   value: T | null;
   label?: string;
+  description?: string;
   disabled?: boolean;
 }
 

--- a/libs/components/src/select/select.component.html
+++ b/libs/components/src/select/select.component.html
@@ -20,11 +20,11 @@
           <bit-icon [name]="item.icon" fixedWidth />
         }
       </div>
-      <div class="tw-flex tw-flex-col">
+      <div class="tw-flex tw-flex-col tw-min-w-0">
         <div class="tw-flex-1 tw-text-ellipsis tw-overflow-hidden">
           {{ item.label }}
         </div>
-        <div bitTypography="helper" class="tw-text-fg-body tw-font-normal">
+        <div bitTypography="helper" class="tw-text-fg-body tw-font-normal tw-truncate">
           {{ item.description }}
         </div>
       </div>

--- a/libs/components/src/select/select.component.html
+++ b/libs/components/src/select/select.component.html
@@ -14,14 +14,19 @@
   [attr.aria-label]="selectedOption()?.label ?? placeholder()"
 >
   <ng-template ng-option-tmp let-item="item">
-    <div class="tw-flex" [title]="item.label">
-      <div class="tw-me-2 tw-flex-initial">
-        @if (item.icon != null) {
-          <i class="bwi bwi-fw {{ item.icon }}" aria-hidden="true"></i>
-        }
+    <div class="tw-flex-col" [title]="item.label">
+      <div class="tw-flex">
+        <div class="tw-me-2 tw-flex-initial">
+          @if (item.icon != null) {
+            <i class="bwi bwi-fw {{ item.icon }}" aria-hidden="true"></i>
+          }
+        </div>
+        <div class="tw-flex-1 tw-text-ellipsis tw-overflow-hidden">
+          {{ item.label }}
+        </div>
       </div>
-      <div class="tw-flex-1 tw-text-ellipsis tw-overflow-hidden">
-        {{ item.label }}
+      <div bitTypography="helper" class="tw-text-fg-body tw-font-normal">
+        {{ item.description }}
       </div>
     </div>
   </ng-template>

--- a/libs/components/src/select/select.component.html
+++ b/libs/components/src/select/select.component.html
@@ -14,19 +14,19 @@
   [attr.aria-label]="selectedOption()?.label ?? placeholder()"
 >
   <ng-template ng-option-tmp let-item="item">
-    <div class="tw-flex-col" [title]="item.label">
-      <div class="tw-flex">
-        <div class="tw-me-2 tw-flex-initial">
-          @if (item.icon != null) {
-            <i class="bwi bwi-fw {{ item.icon }}" aria-hidden="true"></i>
-          }
-        </div>
+    <div class="tw-flex" [title]="item.label">
+      <div class="tw-me-2 tw-flex-initial tw-self-center">
+        @if (item.icon != null) {
+          <bit-icon [name]="item.icon" fixedWidth />
+        }
+      </div>
+      <div class="tw-flex tw-flex-col">
         <div class="tw-flex-1 tw-text-ellipsis tw-overflow-hidden">
           {{ item.label }}
         </div>
-      </div>
-      <div bitTypography="helper" class="tw-text-fg-body tw-font-normal">
-        {{ item.description }}
+        <div bitTypography="helper" class="tw-text-fg-body tw-font-normal">
+          {{ item.description }}
+        </div>
       </div>
     </div>
   </ng-template>

--- a/libs/components/src/select/select.component.ts
+++ b/libs/components/src/select/select.component.ts
@@ -21,6 +21,7 @@ import { NgSelectComponent, NgSelectModule } from "@ng-select/ng-select";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 
 import { BitFormFieldControlDirective } from "../form-field";
+import { IconComponent } from "../icon";
 import { TypographyDirective } from "../typography/typography.directive";
 
 import { Option } from "./option";
@@ -37,7 +38,7 @@ import { OptionComponent } from "./option.component";
       inputs: ["required", "id"],
     },
   ],
-  imports: [NgSelectModule, ReactiveFormsModule, FormsModule, TypographyDirective],
+  imports: [NgSelectModule, ReactiveFormsModule, FormsModule, TypographyDirective, IconComponent],
   host: {
     class: "tw-block tw-w-full tw-h-full",
     "[id]": "formFieldControl.id()",

--- a/libs/components/src/select/select.component.ts
+++ b/libs/components/src/select/select.component.ts
@@ -21,6 +21,7 @@ import { NgSelectComponent, NgSelectModule } from "@ng-select/ng-select";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 
 import { BitFormFieldControlDirective } from "../form-field";
+import { TypographyDirective } from "../typography/typography.directive";
 
 import { Option } from "./option";
 import { OptionComponent } from "./option.component";
@@ -36,7 +37,7 @@ import { OptionComponent } from "./option.component";
       inputs: ["required", "id"],
     },
   ],
-  imports: [NgSelectModule, ReactiveFormsModule, FormsModule],
+  imports: [NgSelectModule, ReactiveFormsModule, FormsModule, TypographyDirective],
   host: {
     class: "tw-block tw-w-full tw-h-full",
     "[id]": "formFieldControl.id()",
@@ -89,6 +90,7 @@ export class SelectComponent<T> implements ControlValueAccessor {
             icon: option.icon(),
             value: option.value(),
             label: option.label(),
+            description: option.description(),
             disabled: option.disabled(),
           })),
         );

--- a/libs/components/src/select/select.stories.ts
+++ b/libs/components/src/select/select.stories.ts
@@ -49,7 +49,7 @@ export const Default: Story = {
       <bit-form-field>
         <bit-label>Choose a value</bit-label>
         <bit-select [disabled]="disabled">
-          <bit-option value="value1" label="Value 1" icon="bwi-collection-shared"></bit-option>
+          <bit-option value="value1" label="Value 1" icon="bwi-collection-shared" description="Very cool hint text"></bit-option>
           <bit-option value="value2" label="Value 2" icon="bwi-collection-shared"></bit-option>
           <bit-option value="value3" label="Value 3" icon="bwi-collection-shared"></bit-option>
           <bit-option value="value4" label="Value 4" icon="bwi-collection-shared" disabled></bit-option>

--- a/libs/components/src/select/select.stories.ts
+++ b/libs/components/src/select/select.stories.ts
@@ -49,8 +49,8 @@ export const Default: Story = {
       <bit-form-field>
         <bit-label>Choose a value</bit-label>
         <bit-select [disabled]="disabled">
-          <bit-option value="value1" label="Value 1" icon="bwi-collection-shared" description="Very cool hint text"></bit-option>
-          <bit-option value="value2" label="Value 2" icon="bwi-collection-shared"></bit-option>
+          <bit-option value="value1" label="Value 1" icon="bwi-collection-shared" description="Very cool hint text that is also incredibly long, so helpful that it will need to truncate if you shrink the window width"></bit-option>
+          <bit-option value="value2" label="Value 2 very long label though so it will truncate on small screen" icon="bwi-collection-shared"></bit-option>
           <bit-option value="value3" label="Value 3" icon="bwi-collection-shared"></bit-option>
           <bit-option value="value4" label="Value 4" icon="bwi-collection-shared" disabled></bit-option>
         </bit-select>


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[CL-1216](https://bitwarden.atlassian.net/browse/CL-1216)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR adds support for optional hint text to the options of the select component.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

<img width="1399" height="514" alt="Screenshot 2026-06-08 at 4 34 17 PM" src="https://github.com/user-attachments/assets/9cb75e15-8b30-40e6-bb0c-a2fa9d886a24" />


[CL-1216]: https://bitwarden.atlassian.net/browse/CL-1216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ