### PR TITLE
[PM-38530] Fix marking critical applications in Access Intelligence reports stored as files

### DIFF
--- a/bitwarden_license/bit-common/src/dirt/access-intelligence/services/abstractions/access-intelligence-api.service.ts
+++ b/bitwarden_license/bit-common/src/dirt/access-intelligence/services/abstractions/access-intelligence-api.service.ts
@@ -28,7 +28,8 @@ export interface AccessReportLegacyCreateRequest {
 export interface AccessReportSettingsUpdateRequest {
   summaryData: string;
   applicationData: string;
-  metrics: AccessReportMetricsApi;
+  reportMetrics: AccessReportMetricsApi;
+  contentEncryptionKey: string;
 }
 
 /**

--- a/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/api/default-access-intelligence-api.service.spec.ts
+++ b/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/api/default-access-intelligence-api.service.spec.ts
@@ -515,13 +515,17 @@ describe("DefaultAccessIntelligenceApiService", () => {
         organizationId: orgId,
         creationDate: "2024-01-01T00:00:00Z",
         summaryData: "encrypted-summary",
+        applicationData: "encrypted-apps",
+        reportMetrics: mockMetrics,
+        contentEncryptionKey: "encryption-key",
       };
       mockApiService.send.mockResolvedValue(rawResponse);
 
       const request: AccessReportSettingsUpdateRequest = {
         summaryData: "encrypted-summary",
         applicationData: "encrypted-apps",
-        metrics: mockMetrics,
+        reportMetrics: mockMetrics,
+        contentEncryptionKey: "encryption-key",
       };
 
       const result = await firstValueFrom(service.updateReportSettings$(orgId, reportId, request));

--- a/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/persistence/file-report-persistence.service.spec.ts
+++ b/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/persistence/file-report-persistence.service.spec.ts
@@ -297,7 +297,8 @@ describe("FileReportPersistenceService", () => {
         expect.objectContaining({
           applicationData: expect.any(String),
           summaryData: expect.any(String),
-          metrics: expect.any(Object),
+          reportMetrics: expect.any(Object),
+          contentEncryptionKey: expect.any(String),
         }),
       );
     });

--- a/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/persistence/file-report-persistence.service.ts
+++ b/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/persistence/file-report-persistence.service.ts
@@ -142,7 +142,8 @@ export class FileReportPersistenceService extends ReportPersistenceService {
             const request: AccessReportSettingsUpdateRequest = {
               applicationData: data.applications,
               summaryData: data.summary,
-              metrics: metrics,
+              reportMetrics: metrics,
+              contentEncryptionKey: data.contentEncryptionKey,
             };
 
             return this.accessIntelligenceApiService.updateReportSettings$(


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-38530

## 📔 Objective
The PATCH request to update applications marked as critical was being created incorrectly when storing reports as files (i.e. `pm-31920-access-intelligence-azure-file-storage` flag on), leaving out the `contentEncryptionKey` and using the wrong property for metrics data. This change updates the request body for the requests succeed as expected.

### References

- Related server endpoint: [UpdateOrganizationReportAsync](https://github.com/bitwarden/server/blob/bb5516e4aa9046df83652036b82992a706af5e9d/src/Api/Dirt/Controllers/OrganizationReportsController.cs#L206)

## 📸 Screenshots
**Request completes successfully**
<img width="1105" height="187" alt="image" src="https://github.com/user-attachments/assets/abae0afd-6905-401a-94d0-57bb2af899f9" />

