### PR TITLE
[PM-38635] [PM-37790] fix(fido2): consult vault before transport-only fallback

### DIFF
--- a/libs/common/src/platform/services/fido2/fido2-client.service.spec.ts
+++ b/libs/common/src/platform/services/fido2/fido2-client.service.spec.ts
@@ -654,6 +654,24 @@ describe("FidoAuthenticatorService", () => {
         expect(authenticator.getAssertion).toHaveBeenCalled();
       });
 
+      it("matches vault credentials stored in b64.<base64url> form", async () => {
+        const rawBytes = randomBytes(16);
+        const allowedId = Fido2Utils.arrayToString(rawBytes);
+        const credentialId = "b64." + allowedId;
+        const params = createParams({
+          allowedCredentials: [{ id: allowedId, transports: ["usb"] }],
+          fallbackSupported: true,
+        });
+        authenticator.silentCredentialDiscovery.mockResolvedValue([
+          { credentialId } as Fido2CredentialView,
+        ]);
+        authenticator.getAssertion.mockResolvedValue(createAuthenticatorAssertResult());
+
+        await client.assertCredential(params, windowReference);
+
+        expect(authenticator.getAssertion).toHaveBeenCalled();
+      });
+
       it("falls back when allowCredentials are non-internal and the vault holds different credentials", async () => {
         const params = createParams({
           allowedCredentials: [{ id: "requestedCredId", transports: ["hybrid"] }],
@@ -662,6 +680,19 @@ describe("FidoAuthenticatorService", () => {
         authenticator.silentCredentialDiscovery.mockResolvedValue([
           { credentialId: Utils.newGuid() } as Fido2CredentialView,
         ]);
+
+        await expect(client.assertCredential(params, windowReference)).rejects.toMatchObject({
+          fallbackRequested: true,
+        });
+        expect(authenticator.getAssertion).not.toHaveBeenCalled();
+      });
+
+      it("falls back when silentCredentialDiscovery throws", async () => {
+        const params = createParams({
+          allowedCredentials: [{ id: "requestedCredId", transports: ["hybrid"] }],
+          fallbackSupported: true,
+        });
+        authenticator.silentCredentialDiscovery.mockRejectedValue(new Error("vault unavailable"));
 
         await expect(client.assertCredential(params, windowReference)).rejects.toMatchObject({
           fallbackRequested: true,

--- a/libs/common/src/platform/services/fido2/fido2-client.service.spec.ts
+++ b/libs/common/src/platform/services/fido2/fido2-client.service.spec.ts
@@ -6,6 +6,7 @@ import { AuthenticationStatus } from "../../../auth/enums/authentication-status"
 import { DomainSettingsService } from "../../../autofill/services/domain-settings.service";
 import { Utils } from "../../../platform/misc/utils";
 import { VaultSettingsService } from "../../../vault/abstractions/vault-settings/vault-settings.service";
+import { Fido2CredentialView } from "../../../vault/models/view/fido2-credential.view";
 import { ConfigService } from "../../abstractions/config/config.service";
 import {
   ActiveRequest,
@@ -618,7 +619,7 @@ describe("FidoAuthenticatorService", () => {
     });
 
     describe("fallback for hardware/roaming keys", () => {
-      it("throws FallbackRequestedError when all allowCredentials have non-internal transports only", async () => {
+      it("throws FallbackRequestedError when all allowCredentials have non-internal transports only and none are in the vault", async () => {
         const params = createParams({
           allowedCredentials: [
             { id: "credId1", transports: ["usb"] },
@@ -626,6 +627,41 @@ describe("FidoAuthenticatorService", () => {
           ],
           fallbackSupported: true,
         });
+        authenticator.silentCredentialDiscovery.mockResolvedValue([]);
+
+        await expect(client.assertCredential(params, windowReference)).rejects.toMatchObject({
+          fallbackRequested: true,
+        });
+        expect(authenticator.silentCredentialDiscovery).toHaveBeenCalledWith(RpId);
+        expect(authenticator.getAssertion).not.toHaveBeenCalled();
+      });
+
+      it("does not fall back when at least one non-internal allowCredential matches a vault credential", async () => {
+        const credentialId = Utils.newGuid();
+        const allowedId = Fido2Utils.arrayToString(guidToRawFormat(credentialId));
+        const params = createParams({
+          allowedCredentials: [{ id: allowedId, transports: ["hybrid"] }],
+          fallbackSupported: true,
+        });
+        authenticator.silentCredentialDiscovery.mockResolvedValue([
+          { credentialId } as Fido2CredentialView,
+        ]);
+        authenticator.getAssertion.mockResolvedValue(createAuthenticatorAssertResult());
+
+        await client.assertCredential(params, windowReference);
+
+        expect(authenticator.silentCredentialDiscovery).toHaveBeenCalledWith(RpId);
+        expect(authenticator.getAssertion).toHaveBeenCalled();
+      });
+
+      it("falls back when allowCredentials are non-internal and the vault holds different credentials", async () => {
+        const params = createParams({
+          allowedCredentials: [{ id: "requestedCredId", transports: ["hybrid"] }],
+          fallbackSupported: true,
+        });
+        authenticator.silentCredentialDiscovery.mockResolvedValue([
+          { credentialId: Utils.newGuid() } as Fido2CredentialView,
+        ]);
 
         await expect(client.assertCredential(params, windowReference)).rejects.toMatchObject({
           fallbackRequested: true,
@@ -642,6 +678,7 @@ describe("FidoAuthenticatorService", () => {
 
         await client.assertCredential(params, windowReference);
 
+        expect(authenticator.silentCredentialDiscovery).not.toHaveBeenCalled();
         expect(authenticator.getAssertion).toHaveBeenCalled();
       });
 
@@ -654,6 +691,7 @@ describe("FidoAuthenticatorService", () => {
 
         await client.assertCredential(params, windowReference);
 
+        expect(authenticator.silentCredentialDiscovery).not.toHaveBeenCalled();
         expect(authenticator.getAssertion).toHaveBeenCalled();
       });
     });

--- a/libs/common/src/platform/services/fido2/fido2-client.service.ts
+++ b/libs/common/src/platform/services/fido2/fido2-client.service.ts
@@ -342,32 +342,16 @@ export class Fido2ClientService<
       )
     ) {
       // Spec reference: https://www.w3.org/TR/webauthn-3/#sctn-discover-from-external-source step 20.
-      // The spec says the client should determine if "no authenticator will become available" by
-      // examining transports. Since Bitwarden is an internal-only authenticator, if all
-      // allowCredentials entries specify only non-internal transports we generally cannot satisfy
-      // the request, and we throw FallbackRequestedError (instead of the spec's NotAllowedError)
-      // so the browser's native WebAuthn handler can contact the hardware authenticator.
-      //
-      // However, an RP may echo the original `transports` recorded at registration time for a
-      // credential that has since been synced into the Bitwarden vault (for example a passkey
-      // originally registered via cross-device hybrid flow and now backed up in the vault as an
-      // internal credential). Falling back unconditionally in that case routes the request to the
-      // browser's native picker, which on Chrome 146+ may surface a different attached provider
-      // (e.g. 1Password, iCloud Keychain) even though Bitwarden holds the credential. See
-      // https://github.com/bitwarden/clients/issues/20973.
-      //
-      // To preserve the original intent (PM-33781) without breaking vault-resident passkeys, we
-      // consult the vault first and only fall back when none of the requested credential ids are
-      // present. Vault credential ids may be stored in either UUID or "b64.<base64url>" form, so
-      // we normalize via `parseCredentialId` rather than assuming UUID format.
+      // Bitwarden is an internal-only authenticator, so a request that allows only non-internal
+      // transports normally cannot be satisfied and we fall back to the browser. RPs may however
+      // echo the transports recorded at registration time even for credentials that are now
+      // synced into the vault, so we consult the vault first and only fall back when no requested
+      // credential id is present.
       let vaultCredentials: { credentialId: string }[];
       try {
         vaultCredentials = await this.authenticator.silentCredentialDiscovery(params.rpId);
       } catch (error) {
-        // Treat discovery failures (e.g. transient sync / decryption / no active account) as
-        // "no vault match" so the original PM-33781 fallback fires. Surfacing the raw error here
-        // would convert what was previously a deterministic FallbackRequestedError into an
-        // unhandled exception in the calling page-script.
+        // Treat discovery failures as "no vault match" so the fallback still fires deterministically.
         this.logService?.warning(
           `[Fido2Client] silentCredentialDiscovery failed during transport-only fallback check; falling back to browser. ${error}`,
         );

--- a/libs/common/src/platform/services/fido2/fido2-client.service.ts
+++ b/libs/common/src/platform/services/fido2/fido2-client.service.ts
@@ -38,6 +38,7 @@ import { Utils } from "../../misc/utils";
 import { ScheduledTaskNames } from "../../scheduling/scheduled-task-name.enum";
 import { TaskSchedulerService } from "../../scheduling/task-scheduler.service";
 
+import { parseCredentialId } from "./credential-id-utils";
 import { isValidRpId } from "./domain-utils";
 import { Fido2Utils } from "./fido2-utils";
 import { guidToRawFormat } from "./guid-utils";
@@ -357,15 +358,29 @@ export class Fido2ClientService<
       //
       // To preserve the original intent (PM-33781) without breaking vault-resident passkeys, we
       // consult the vault first and only fall back when none of the requested credential ids are
-      // present.
-      const vaultCredentials = await this.authenticator.silentCredentialDiscovery(params.rpId);
+      // present. Vault credential ids may be stored in either UUID or "b64.<base64url>" form, so
+      // we normalize via `parseCredentialId` rather than assuming UUID format.
+      let vaultCredentials: { credentialId: string }[];
+      try {
+        vaultCredentials = await this.authenticator.silentCredentialDiscovery(params.rpId);
+      } catch (error) {
+        // Treat discovery failures (e.g. transient sync / decryption / no active account) as
+        // "no vault match" so the original PM-33781 fallback fires. Surfacing the raw error here
+        // would convert what was previously a deterministic FallbackRequestedError into an
+        // unhandled exception in the calling page-script.
+        this.logService?.warning(
+          `[Fido2Client] silentCredentialDiscovery failed during transport-only fallback check; falling back to browser. ${error}`,
+        );
+        throw new FallbackRequestedError();
+      }
+
       const requestedIds = new Set(params.allowedCredentials.map((c) => c.id));
       const vaultHasMatch = vaultCredentials.some((vc) => {
-        try {
-          return requestedIds.has(Fido2Utils.arrayToString(guidToRawFormat(vc.credentialId)));
-        } catch {
+        const raw = parseCredentialId(vc.credentialId);
+        if (raw == null) {
           return false;
         }
+        return requestedIds.has(Fido2Utils.arrayToString(raw));
       });
 
       if (!vaultHasMatch) {

--- a/libs/common/src/platform/services/fido2/fido2-client.service.ts
+++ b/libs/common/src/platform/services/fido2/fido2-client.service.ts
@@ -343,13 +343,41 @@ export class Fido2ClientService<
       // Spec reference: https://www.w3.org/TR/webauthn-3/#sctn-discover-from-external-source step 20.
       // The spec says the client should determine if "no authenticator will become available" by
       // examining transports. Since Bitwarden is an internal-only authenticator, if all
-      // allowCredentials entries specify only non-internal transports, we cannot satisfy the
-      // request. We throw FallbackRequestedError (instead of the spec's NotAllowedError) to let
-      // the browser's native WebAuthn handler contact the hardware authenticator.
+      // allowCredentials entries specify only non-internal transports we generally cannot satisfy
+      // the request, and we throw FallbackRequestedError (instead of the spec's NotAllowedError)
+      // so the browser's native WebAuthn handler can contact the hardware authenticator.
+      //
+      // However, an RP may echo the original `transports` recorded at registration time for a
+      // credential that has since been synced into the Bitwarden vault (for example a passkey
+      // originally registered via cross-device hybrid flow and now backed up in the vault as an
+      // internal credential). Falling back unconditionally in that case routes the request to the
+      // browser's native picker, which on Chrome 146+ may surface a different attached provider
+      // (e.g. 1Password, iCloud Keychain) even though Bitwarden holds the credential. See
+      // https://github.com/bitwarden/clients/issues/20973.
+      //
+      // To preserve the original intent (PM-33781) without breaking vault-resident passkeys, we
+      // consult the vault first and only fall back when none of the requested credential ids are
+      // present.
+      const vaultCredentials = await this.authenticator.silentCredentialDiscovery(params.rpId);
+      const requestedIds = new Set(params.allowedCredentials.map((c) => c.id));
+      const vaultHasMatch = vaultCredentials.some((vc) => {
+        try {
+          return requestedIds.has(Fido2Utils.arrayToString(guidToRawFormat(vc.credentialId)));
+        } catch {
+          return false;
+        }
+      });
+
+      if (!vaultHasMatch) {
+        this.logService?.info(
+          `[Fido2Client] All allowCredentials entries specify non-internal transports only and none match the vault — falling back to browser.`,
+        );
+        throw new FallbackRequestedError();
+      }
+
       this.logService?.info(
-        `[Fido2Client] All allowCredentials entries specify non-internal transports only — falling back to browser.`,
+        `[Fido2Client] All allowCredentials entries specify non-internal transports only but at least one matches a vault credential — proceeding with Bitwarden.`,
       );
-      throw new FallbackRequestedError();
     }
 
     const getAssertionParams = mapToGetAssertionParams({ params, clientDataHash });


### PR DESCRIPTION
## 🎟️ Tracking

[PM-37790](https://bitwarden.atlassian.net/browse/PM-37790)

Fixes #20973, related to #20743.

## 📔 Objective

Vault-resident passkeys are unusable in Chrome 146+ when another passkey provider (1Password, iCloud Keychain) is also attached, because Bitwarden hands the request off to the browser before checking whether the credential is in the vault.

[PM-33781](https://bitwarden.atlassian.net/browse/PM-33781) added a fallback at the top of `Fido2ClientService.assertCredential` that throws `FallbackRequestedError` whenever every entry in `allowCredentials` advertises only non-internal transports (`usb` / `nfc` / `ble` / `hybrid`). The intent was correct: a request that only allows roaming-key transports cannot be served by an internal-only authenticator, so the browser should handle it. The check, however, does not consult the vault. Relying parties commonly echo the transports recorded at registration time, so a passkey that was originally registered via cross-device hybrid flow and is now synced into the vault arrives with transports such as `["hybrid"]` and trips the fallback. Chrome 146+ then routes the request to its native picker, which surfaces whichever other provider is attached.

Fix: consult the vault first via `silentCredentialDiscovery(rpId)` and only throw `FallbackRequestedError` when none of the requested credential ids match a vault credential. Behavior for credentials that are genuinely not in the vault is unchanged. Vault credential ids are normalized via `parseCredentialId` so both UUID and `b64.<base64url>` forms are handled. Discovery failures are caught and surfaced as `FallbackRequestedError` to keep the page-script flow deterministic.

Coverage in `fido2-client.service.spec.ts` (`fallback for hardware/roaming keys`):
- vault match in UUID form proceeds with Bitwarden
- vault match in `b64.<base64url>` form proceeds with Bitwarden
- no vault match falls back
- `silentCredentialDiscovery` rejection falls back
- existing tests for internal transports and empty transport lists are unchanged in intent and now also assert that discovery is not invoked

## 📸 Screenshots

N/A.


[PM-37790]: https://bitwarden.atlassian.net/browse/PM-37790?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-33781]: https://bitwarden.atlassian.net/browse/PM-33781?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ