### PR TITLE
[PM-38719] Add env var to override access token location

### DIFF
--- a/apps/desktop/src/app/services/services.module.ts
+++ b/apps/desktop/src/app/services/services.module.ts
@@ -257,8 +257,15 @@ const safeProviders: SafeProvider[] = [
     //
     // Note: Portable mode does not use secure storage for read/write/clear operations,
     // preventing any collision with tokens from a regular desktop installation.
+    //
+    // Setting the ACCESS_TOKEN_LOCATION=DISK environment variable forces the same disk-backed
+    // behavior on any platform, for environments where the OS keyring is unavailable or
+    // undesirable (see `accessTokenLocation` in apps/desktop/src/utils.ts).
     provide: SUPPORTS_SECURE_STORAGE,
-    useValue: ELECTRON_SUPPORTS_SECURE_STORAGE && !ipc.platform.isWindowsPortable,
+    useValue:
+      ELECTRON_SUPPORTS_SECURE_STORAGE &&
+      !ipc.platform.isWindowsPortable &&
+      !ipc.platform.forceDiskAccessTokenStorage,
   }),
   safeProvider({
     provide: DEFAULT_VAULT_TIMEOUT,

--- a/apps/desktop/src/platform/preload.ts
+++ b/apps/desktop/src/platform/preload.ts
@@ -11,6 +11,8 @@ import {
   UnencryptedMessageResponse,
 } from "../models/native-messaging";
 import {
+  EnvAccessTokenLocation,
+  accessTokenLocation,
   allowBrowserintegrationOverride,
   isAppImage,
   isDev,
@@ -115,6 +117,7 @@ export default {
   isMacAppStore: isMacAppStore(),
   isWindowsStore: isWindowsStore(),
   isWindowsPortable: isWindowsPortable(),
+  forceDiskAccessTokenStorage: accessTokenLocation() === EnvAccessTokenLocation.Disk,
   isFlatpak: isFlatpak(),
   isSnapStore: isSnapStore(),
   isAppImage: isAppImage(),

--- a/apps/desktop/src/utils.spec.ts
+++ b/apps/desktop/src/utils.spec.ts
@@ -1,4 +1,4 @@
-import { cleanUserAgent } from "./utils";
+import { EnvAccessTokenLocation, accessTokenLocation, cleanUserAgent } from "./utils";
 
 const expectedUserAgent = `Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/${process.versions.chrome} Safari/537.36`;
 
@@ -23,5 +23,42 @@ describe("cleanUserAgent", () => {
     const initialAgent = `Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Bitwarden/1.28.3 Chrome/87.0.4280.141 Electron/11.4.5 Safari/537.36`;
 
     expect(cleanUserAgent(initialAgent)).toEqual(expected);
+  });
+});
+
+describe("accessTokenLocation", () => {
+  const original = process.env.ACCESS_TOKEN_LOCATION;
+
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env.ACCESS_TOKEN_LOCATION;
+    } else {
+      process.env.ACCESS_TOKEN_LOCATION = original;
+    }
+  });
+
+  it("defaults to Keyring when unset", () => {
+    delete process.env.ACCESS_TOKEN_LOCATION;
+    expect(accessTokenLocation()).toEqual(EnvAccessTokenLocation.Default);
+  });
+
+  it("returns Disk for DISK", () => {
+    process.env.ACCESS_TOKEN_LOCATION = "DISK";
+    expect(accessTokenLocation()).toEqual(EnvAccessTokenLocation.Disk);
+  });
+
+  it("parses case-insensitively", () => {
+    process.env.ACCESS_TOKEN_LOCATION = "disk";
+    expect(accessTokenLocation()).toEqual(EnvAccessTokenLocation.Disk);
+  });
+
+  it("returns Keyring for DEFAULT", () => {
+    process.env.ACCESS_TOKEN_LOCATION = "DEFAULT";
+    expect(accessTokenLocation()).toEqual(EnvAccessTokenLocation.Default);
+  });
+
+  it("falls back to Keyring for unrecognized values", () => {
+    process.env.ACCESS_TOKEN_LOCATION = "somewhere-else";
+    expect(accessTokenLocation()).toEqual(EnvAccessTokenLocation.Default);
   });
 });

--- a/apps/desktop/src/utils.ts
+++ b/apps/desktop/src/utils.ts
@@ -76,13 +76,14 @@ export const EnvAccessTokenLocation = Object.freeze({
   Disk: "DISK",
   Default: "DEFAULT",
 } as const);
-export type EnvAccessTokenLocation = (typeof EnvAccessTokenLocation)[keyof typeof EnvAccessTokenLocation];
+export type EnvAccessTokenLocation =
+  (typeof EnvAccessTokenLocation)[keyof typeof EnvAccessTokenLocation];
 
 /**
  * Reads the `ACCESS_TOKEN_LOCATION` env var. `DISK` forces the access token to be stored
  * unencrypted on disk (bypassing the OS keyring); anything else (including unset) keeps the
  * default keyring-backed secure storage.
- * 
+ *
  * This is useful on systems where the keyring is unreliable (KDE/Kwallet) where the user
  * otherwise experiences periodic logouts.
  */

--- a/apps/desktop/src/utils.ts
+++ b/apps/desktop/src/utils.ts
@@ -82,6 +82,9 @@ export type EnvAccessTokenLocation = (typeof EnvAccessTokenLocation)[keyof typeo
  * Reads the `ACCESS_TOKEN_LOCATION` env var. `DISK` forces the access token to be stored
  * unencrypted on disk (bypassing the OS keyring); anything else (including unset) keeps the
  * default keyring-backed secure storage.
+ * 
+ * This is useful on systems where the keyring is unreliable (KDE/Kwallet) where the user
+ * otherwise experiences periodic logouts.
  */
 export function accessTokenLocation(): EnvAccessTokenLocation {
   return process.env.ACCESS_TOKEN_LOCATION?.toUpperCase() === EnvAccessTokenLocation.Disk

--- a/apps/desktop/src/utils.ts
+++ b/apps/desktop/src/utils.ts
@@ -70,6 +70,26 @@ export function isWindowsPortable() {
 }
 
 /**
+ * Overrides the access token location
+ */
+export const EnvAccessTokenLocation = Object.freeze({
+  Disk: "DISK",
+  Default: "DEFAULT",
+} as const);
+export type EnvAccessTokenLocation = (typeof EnvAccessTokenLocation)[keyof typeof EnvAccessTokenLocation];
+
+/**
+ * Reads the `ACCESS_TOKEN_LOCATION` env var. `DISK` forces the access token to be stored
+ * unencrypted on disk (bypassing the OS keyring); anything else (including unset) keeps the
+ * default keyring-backed secure storage.
+ */
+export function accessTokenLocation(): EnvAccessTokenLocation {
+  return process.env.ACCESS_TOKEN_LOCATION?.toUpperCase() === EnvAccessTokenLocation.Disk
+    ? EnvAccessTokenLocation.Disk
+    : EnvAccessTokenLocation.Default;
+}
+
+/**
  * We block the browser integration on some unsupported platforms prevents
  * experimenting with the feature for QA. So this env var allows overriding
  * the block.


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-38719

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

On some systems - KDE/KWallet - the key ring is not a reliable location to store tokens. This currently results in random logouts based on f.e race conditions during login when autostart is enabled, or based on other conditions.

The solution for now is to give an environment variable that can be used to force the token location to be on disk. This is opt in, so a user is aware that the token is now on disk instead of in the "protected key ring". Further, this is not different from how the extension stores the token, which is also just on disk.

This is not a setting generally exposed to users because most users should just use the keyring.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
