### PR TITLE
[PM-38723] [PM-37790] fix(fido2): consult vault by rpId before transport-only fallback

### DIFF
--- a/libs/common/src/platform/services/fido2/fido2-client.service.spec.ts
+++ b/libs/common/src/platform/services/fido2/fido2-client.service.spec.ts
@@ -6,6 +6,7 @@ import { AuthenticationStatus } from "../../../auth/enums/authentication-status"
 import { DomainSettingsService } from "../../../autofill/services/domain-settings.service";
 import { Utils } from "../../../platform/misc/utils";
 import { VaultSettingsService } from "../../../vault/abstractions/vault-settings/vault-settings.service";
+import { Fido2CredentialView } from "../../../vault/models/view/fido2-credential.view";
 import { ConfigService } from "../../abstractions/config/config.service";
 import {
   ActiveRequest,
@@ -618,7 +619,7 @@ describe("FidoAuthenticatorService", () => {
     });
 
     describe("fallback for hardware/roaming keys", () => {
-      it("throws FallbackRequestedError when all allowCredentials have non-internal transports only", async () => {
+      it("throws FallbackRequestedError when all allowCredentials have non-internal transports only and vault has no credentials for rpId", async () => {
         const params = createParams({
           allowedCredentials: [
             { id: "credId1", transports: ["usb"] },
@@ -626,6 +627,54 @@ describe("FidoAuthenticatorService", () => {
           ],
           fallbackSupported: true,
         });
+        authenticator.silentCredentialDiscovery.mockResolvedValue([]);
+
+        await expect(client.assertCredential(params, windowReference)).rejects.toMatchObject({
+          fallbackRequested: true,
+        });
+        expect(authenticator.silentCredentialDiscovery).toHaveBeenCalledWith(RpId);
+        expect(authenticator.getAssertion).not.toHaveBeenCalled();
+      });
+
+      it("proceeds with Bitwarden when transports are non-internal but the vault has a credential for rpId", async () => {
+        const params = createParams({
+          allowedCredentials: [
+            { id: "credId1", transports: ["hybrid"] },
+            { id: "credId2", transports: ["usb"] },
+          ],
+          fallbackSupported: true,
+        });
+        authenticator.silentCredentialDiscovery.mockResolvedValue([
+          { credentialId: Utils.newGuid() } as Fido2CredentialView,
+        ]);
+        authenticator.getAssertion.mockResolvedValue(createAuthenticatorAssertResult());
+
+        await client.assertCredential(params, windowReference);
+
+        expect(authenticator.silentCredentialDiscovery).toHaveBeenCalledWith(RpId);
+        expect(authenticator.getAssertion).toHaveBeenCalled();
+      });
+
+      it("falls back when the vault is locked, without invoking silentCredentialDiscovery", async () => {
+        authService.activeAccountStatus$ = of(AuthenticationStatus.Locked);
+        const params = createParams({
+          allowedCredentials: [{ id: "credId1", transports: ["hybrid"] }],
+          fallbackSupported: true,
+        });
+
+        await expect(client.assertCredential(params, windowReference)).rejects.toMatchObject({
+          fallbackRequested: true,
+        });
+        expect(authenticator.silentCredentialDiscovery).not.toHaveBeenCalled();
+        expect(authenticator.getAssertion).not.toHaveBeenCalled();
+      });
+
+      it("falls back when silentCredentialDiscovery throws", async () => {
+        const params = createParams({
+          allowedCredentials: [{ id: "credId1", transports: ["hybrid"] }],
+          fallbackSupported: true,
+        });
+        authenticator.silentCredentialDiscovery.mockRejectedValue(new Error("boom"));
 
         await expect(client.assertCredential(params, windowReference)).rejects.toMatchObject({
           fallbackRequested: true,
@@ -642,6 +691,7 @@ describe("FidoAuthenticatorService", () => {
 
         await client.assertCredential(params, windowReference);
 
+        expect(authenticator.silentCredentialDiscovery).not.toHaveBeenCalled();
         expect(authenticator.getAssertion).toHaveBeenCalled();
       });
 
@@ -654,6 +704,7 @@ describe("FidoAuthenticatorService", () => {
 
         await client.assertCredential(params, windowReference);
 
+        expect(authenticator.silentCredentialDiscovery).not.toHaveBeenCalled();
         expect(authenticator.getAssertion).toHaveBeenCalled();
       });
     });

--- a/libs/common/src/platform/services/fido2/fido2-client.service.spec.ts
+++ b/libs/common/src/platform/services/fido2/fido2-client.service.spec.ts
@@ -619,11 +619,11 @@ describe("FidoAuthenticatorService", () => {
     });
 
     describe("fallback for hardware/roaming keys", () => {
-      it("throws FallbackRequestedError when all allowCredentials have non-internal transports only and vault has no credentials for rpId", async () => {
+      it("falls back when transports are non-internal and the vault has no credential for rpId", async () => {
         const params = createParams({
           allowedCredentials: [
-            { id: "credId1", transports: ["usb"] },
-            { id: "credId2", transports: ["nfc"] },
+            { id: Fido2Utils.arrayToString(guidToRawFormat(Utils.newGuid())), transports: ["usb"] },
+            { id: Fido2Utils.arrayToString(guidToRawFormat(Utils.newGuid())), transports: ["nfc"] },
           ],
           fallbackSupported: true,
         });
@@ -636,22 +636,56 @@ describe("FidoAuthenticatorService", () => {
         expect(authenticator.getAssertion).not.toHaveBeenCalled();
       });
 
-      it("proceeds with Bitwarden when transports are non-internal but the vault has a credential for rpId", async () => {
+      it("falls back when vault has credentials for rpId but none match the requested ids", async () => {
+        const requestedId = Fido2Utils.arrayToString(guidToRawFormat(Utils.newGuid()));
         const params = createParams({
-          allowedCredentials: [
-            { id: "credId1", transports: ["hybrid"] },
-            { id: "credId2", transports: ["usb"] },
-          ],
+          allowedCredentials: [{ id: requestedId, transports: ["usb"] }],
           fallbackSupported: true,
         });
         authenticator.silentCredentialDiscovery.mockResolvedValue([
           { credentialId: Utils.newGuid() } as Fido2CredentialView,
+        ]);
+
+        await expect(client.assertCredential(params, windowReference)).rejects.toMatchObject({
+          fallbackRequested: true,
+        });
+        expect(authenticator.getAssertion).not.toHaveBeenCalled();
+      });
+
+      it("proceeds when a vault credential matches a requested id (uuid form)", async () => {
+        const credentialId = Utils.newGuid();
+        const params = createParams({
+          allowedCredentials: [
+            { id: Fido2Utils.arrayToString(guidToRawFormat(credentialId)), transports: ["hybrid"] },
+          ],
+          fallbackSupported: true,
+        });
+        authenticator.silentCredentialDiscovery.mockResolvedValue([
+          { credentialId } as Fido2CredentialView,
         ]);
         authenticator.getAssertion.mockResolvedValue(createAuthenticatorAssertResult());
 
         await client.assertCredential(params, windowReference);
 
         expect(authenticator.silentCredentialDiscovery).toHaveBeenCalledWith(RpId);
+        expect(authenticator.getAssertion).toHaveBeenCalled();
+      });
+
+      it("proceeds when a vault credential matches a requested id (b64 form)", async () => {
+        const raw = randomBytes(32);
+        const requestedId = Fido2Utils.arrayToString(raw);
+        const credentialId = "b64." + requestedId;
+        const params = createParams({
+          allowedCredentials: [{ id: requestedId, transports: ["hybrid"] }],
+          fallbackSupported: true,
+        });
+        authenticator.silentCredentialDiscovery.mockResolvedValue([
+          { credentialId } as Fido2CredentialView,
+        ]);
+        authenticator.getAssertion.mockResolvedValue(createAuthenticatorAssertResult());
+
+        await client.assertCredential(params, windowReference);
+
         expect(authenticator.getAssertion).toHaveBeenCalled();
       });
 

--- a/libs/common/src/platform/services/fido2/fido2-client.service.ts
+++ b/libs/common/src/platform/services/fido2/fido2-client.service.ts
@@ -342,14 +342,43 @@ export class Fido2ClientService<
     ) {
       // Spec reference: https://www.w3.org/TR/webauthn-3/#sctn-discover-from-external-source step 20.
       // The spec says the client should determine if "no authenticator will become available" by
-      // examining transports. Since Bitwarden is an internal-only authenticator, if all
-      // allowCredentials entries specify only non-internal transports, we cannot satisfy the
-      // request. We throw FallbackRequestedError (instead of the spec's NotAllowedError) to let
-      // the browser's native WebAuthn handler contact the hardware authenticator.
+      // examining transports. Since Bitwarden is an internal-only authenticator, allowCredentials
+      // entries that specify only non-internal transports normally cannot be satisfied here.
+      //
+      // However, vault-synced passkeys originally registered via the cross-device hybrid flow are
+      // commonly echoed back by the RP with transports such as ["hybrid"]. Bailing purely on
+      // transports causes those credentials to be unreachable on Chrome 146+ when another passkey
+      // provider is installed alongside Bitwarden (see #20973). Before falling back, consult the
+      // vault for the requesting rpId so a Bitwarden-resident credential gets a chance to handle
+      // the request. The lookup intentionally only checks "does the vault have any credential for
+      // this rpId" rather than matching individual credential ids, so the RP cannot use this code
+      // path to enumerate specific vault credentials beyond what it already knows about its own
+      // registrations.
+      const rpId = params.rpId;
+      const authStatus = await firstValueFrom(this.authService.activeAccountStatus$);
+      let vaultHasCredentialForRp = false;
+      if (authStatus === AuthenticationStatus.Unlocked) {
+        try {
+          const vaultCredentials = await this.authenticator.silentCredentialDiscovery(rpId);
+          vaultHasCredentialForRp = vaultCredentials.length > 0;
+        } catch (error) {
+          this.logService?.warning(
+            `[Fido2Client] silentCredentialDiscovery failed during transport-only fallback check; falling back to browser. ${error}`,
+          );
+          throw new FallbackRequestedError();
+        }
+      }
+
+      if (!vaultHasCredentialForRp) {
+        this.logService?.info(
+          `[Fido2Client] All allowCredentials entries specify non-internal transports only and vault has no credentials for rpId — falling back to browser.`,
+        );
+        throw new FallbackRequestedError();
+      }
+
       this.logService?.info(
-        `[Fido2Client] All allowCredentials entries specify non-internal transports only — falling back to browser.`,
+        `[Fido2Client] All allowCredentials entries specify non-internal transports only but vault has credentials for rpId — proceeding with Bitwarden.`,
       );
-      throw new FallbackRequestedError();
     }
 
     const getAssertionParams = mapToGetAssertionParams({ params, clientDataHash });

--- a/libs/common/src/platform/services/fido2/fido2-client.service.ts
+++ b/libs/common/src/platform/services/fido2/fido2-client.service.ts
@@ -38,6 +38,7 @@ import { Utils } from "../../misc/utils";
 import { ScheduledTaskNames } from "../../scheduling/scheduled-task-name.enum";
 import { TaskSchedulerService } from "../../scheduling/task-scheduler.service";
 
+import { compareCredentialIds, parseCredentialId } from "./credential-id-utils";
 import { isValidRpId } from "./domain-utils";
 import { Fido2Utils } from "./fido2-utils";
 import { guidToRawFormat } from "./guid-utils";
@@ -341,44 +342,37 @@ export class Fido2ClientService<
       )
     ) {
       // Spec reference: https://www.w3.org/TR/webauthn-3/#sctn-discover-from-external-source step 20.
-      // The spec says the client should determine if "no authenticator will become available" by
-      // examining transports. Since Bitwarden is an internal-only authenticator, allowCredentials
-      // entries that specify only non-internal transports normally cannot be satisfied here.
-      //
-      // However, vault-synced passkeys originally registered via the cross-device hybrid flow are
-      // commonly echoed back by the RP with transports such as ["hybrid"]. Bailing purely on
-      // transports causes those credentials to be unreachable on Chrome 146+ when another passkey
-      // provider is installed alongside Bitwarden (see #20973). Before falling back, consult the
-      // vault for the requesting rpId so a Bitwarden-resident credential gets a chance to handle
-      // the request. The lookup intentionally only checks "does the vault have any credential for
-      // this rpId" rather than matching individual credential ids, so the RP cannot use this code
-      // path to enumerate specific vault credentials beyond what it already knows about its own
-      // registrations.
-      const rpId = params.rpId;
+      // Bitwarden is an internal authenticator, but vault-synced passkeys originally registered via
+      // the cross-device hybrid flow are commonly echoed back by the RP with transports such as
+      // ["hybrid"], so the transport check alone is not enough to know we can't serve the request
+      // (see #20973). Consult the vault for the requesting rpId and only fall back when none of
+      // the requested credential ids matches a vault credential. The RP could already probe vault
+      // ids by sending the same allowCredentials with transports:["internal"], so this check adds
+      // no enumeration capability beyond what the existing internal-transport path exposes.
+      let matchedVaultCredential = false;
       const authStatus = await firstValueFrom(this.authService.activeAccountStatus$);
-      let vaultHasCredentialForRp = false;
       if (authStatus === AuthenticationStatus.Unlocked) {
         try {
-          const vaultCredentials = await this.authenticator.silentCredentialDiscovery(rpId);
-          vaultHasCredentialForRp = vaultCredentials.length > 0;
+          const vaultCredentials = await this.authenticator.silentCredentialDiscovery(params.rpId);
+          const requestedIds = params.allowedCredentials.map((c) => Fido2Utils.stringToArray(c.id));
+          matchedVaultCredential = vaultCredentials.some((vc) => {
+            const parsed = parseCredentialId(vc.credentialId);
+            return parsed != null && requestedIds.some((id) => compareCredentialIds(parsed, id));
+          });
         } catch (error) {
           this.logService?.warning(
-            `[Fido2Client] silentCredentialDiscovery failed during transport-only fallback check; falling back to browser. ${error}`,
+            `[Fido2Client] silentCredentialDiscovery failed; falling back to browser. ${error}`,
           );
           throw new FallbackRequestedError();
         }
       }
 
-      if (!vaultHasCredentialForRp) {
+      if (!matchedVaultCredential) {
         this.logService?.info(
-          `[Fido2Client] All allowCredentials entries specify non-internal transports only and vault has no credentials for rpId — falling back to browser.`,
+          `[Fido2Client] No vault credential matches allowCredentials; falling back to browser.`,
         );
         throw new FallbackRequestedError();
       }
-
-      this.logService?.info(
-        `[Fido2Client] All allowCredentials entries specify non-internal transports only but vault has credentials for rpId — proceeding with Bitwarden.`,
-      );
     }
 
     const getAssertionParams = mapToGetAssertionParams({ params, clientDataHash });

--- a/libs/common/src/platform/services/fido2/fido2-client.service.ts
+++ b/libs/common/src/platform/services/fido2/fido2-client.service.ts
@@ -342,13 +342,9 @@ export class Fido2ClientService<
       )
     ) {
       // Spec reference: https://www.w3.org/TR/webauthn-3/#sctn-discover-from-external-source step 20.
-      // Bitwarden is an internal authenticator, but vault-synced passkeys originally registered via
-      // the cross-device hybrid flow are commonly echoed back by the RP with transports such as
-      // ["hybrid"], so the transport check alone is not enough to know we can't serve the request
-      // (see #20973). Consult the vault for the requesting rpId and only fall back when none of
-      // the requested credential ids matches a vault credential. The RP could already probe vault
-      // ids by sending the same allowCredentials with transports:["internal"], so this check adds
-      // no enumeration capability beyond what the existing internal-transport path exposes.
+      // Hybrid-registered vault passkeys are echoed back by RPs with non-internal transports, so
+      // check the vault for a matching credential id before falling back. The same id probe is
+      // already available via transports:["internal"], so matching here adds no enumeration surface.
       let matchedVaultCredential = false;
       const authStatus = await firstValueFrom(this.authService.activeAccountStatus$);
       if (authStatus === AuthenticationStatus.Unlocked) {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-37790](https://bitwarden.atlassian.net/browse/PM-37790)

Fixes #20973, related to #20743.

## 📔 Objective

Vault-resident passkeys are unusable in Chrome 146+ when another passkey provider (1Password, iCloud Keychain) is also attached, because Bitwarden hands the request to the browser before checking whether the credential is in the vault.

[PM-33781](https://bitwarden.atlassian.net/browse/PM-33781) (#19606) added a fallback at the top of `Fido2ClientService.assertCredential` that throws `FallbackRequestedError` whenever every `allowCredentials` entry advertises only non-internal transports. RPs commonly echo the transports recorded at registration, so a passkey originally registered via cross-device hybrid flow arrives with transports such as `["hybrid"]` and trips the fallback even when the vault holds the credential.

Inside the existing non-internal-transports branch, call `silentCredentialDiscovery(rpId)` and only fall back when no requested credential id matches a vault credential. Vault credential ids are normalized via `parseCredentialId` so both UUID and `b64.<base64url>` forms match.

Follow-up to closed PR #21098. The previous attempt was rejected because the id-matching path appeared to enable vault enumeration. The same probe is already available via `transports:["internal"]`, so matching ids inside this branch adds no enumeration surface beyond what already exists. Happy to discuss further in review.

## 📸 Screenshots

N/A.


[PM-37790]: https://bitwarden.atlassian.net/browse/PM-37790?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-33781]: https://bitwarden.atlassian.net/browse/PM-33781?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
