### PR TITLE
[PM-38744] Bugfix - Do not trigger Targeting Rules sync on scheduled vault syncs

### DIFF
--- a/apps/browser/src/autofill/services/targeting-rules-data.service.ts
+++ b/apps/browser/src/autofill/services/targeting-rules-data.service.ts
@@ -37,6 +37,9 @@ const MANIFEST_FILENAME = "manifest.json";
 /** Manifest key for the forms map version this client targets */
 const TARGET_FORMS_VERSION = "v1";
 
+/** Message command that triggers an immediate manifest check from the background context */
+export const FORCE_TARGETING_RULES_UPDATE_COMMAND = "bgForceTargetingRulesUpdate";
+
 type TargetingRulesDataMeta = {
   /** The last time the data source was checked */
   timestamp: number;

--- a/apps/browser/src/background/runtime.background.ts
+++ b/apps/browser/src/background/runtime.background.ts
@@ -26,6 +26,7 @@ import {
 } from "../auth/popup/utils/auth-popout-window";
 import { LockedVaultPendingNotificationsData } from "../autofill/background/abstractions/notification.background";
 import { AutofillService } from "../autofill/services/abstractions/autofill.service";
+import { FORCE_TARGETING_RULES_UPDATE_COMMAND } from "../autofill/services/targeting-rules-data.service";
 import { BrowserApi } from "../platform/browser/browser-api";
 import { BrowserEnvironmentService } from "../platform/services/browser-environment.service";
 import BrowserInitialInstallService from "../platform/services/browser-initial-install.service";
@@ -324,7 +325,7 @@ export default class RuntimeBackground {
           await this.autofillService.setAutoFillOnPageLoadOrgPolicy();
         }
         break;
-      case "bgForceTargetingRulesUpdate":
+      case FORCE_TARGETING_RULES_UPDATE_COMMAND:
         this.main.targetingRulesDataService.forceUpdate();
         break;
       case "openPopup":

--- a/apps/browser/src/background/runtime.background.ts
+++ b/apps/browser/src/background/runtime.background.ts
@@ -322,8 +322,10 @@ export default class RuntimeBackground {
           await this.main.updateOverlayCiphers();
 
           await this.autofillService.setAutoFillOnPageLoadOrgPolicy();
-          void this.main.targetingRulesDataService.forceUpdate();
         }
+        break;
+      case "bgForceTargetingRulesUpdate":
+        this.main.targetingRulesDataService.forceUpdate();
         break;
       case "openPopup":
         await this.executeMessageActionOrOpenPopup(msg, this.openPopup.bind(this));

--- a/apps/browser/src/vault/popup/settings/vault-settings.component.spec.ts
+++ b/apps/browser/src/vault/popup/settings/vault-settings.component.spec.ts
@@ -10,6 +10,7 @@ import { AccountService } from "@bitwarden/common/auth/abstractions/account.serv
 import { BillingAccountProfileStateService } from "@bitwarden/common/billing/abstractions/account/billing-account-profile-state.service";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
 import { CipherArchiveService } from "@bitwarden/common/vault/abstractions/cipher-archive.service";
 import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.service.abstraction";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
@@ -89,6 +90,7 @@ describe("VaultSettingsComponent", () => {
           { path: "premium", component: VaultSettingsComponent },
         ]),
         { provide: SyncService, useValue: mock<SyncService>() },
+        { provide: MessagingService, useValue: mock<MessagingService>() },
         { provide: ToastService, useValue: mock<ToastService>() },
         { provide: ConfigService, useValue: mock<ConfigService>() },
         { provide: DialogService, useValue: mock<DialogService>() },

--- a/apps/browser/src/vault/popup/settings/vault-settings.component.ts
+++ b/apps/browser/src/vault/popup/settings/vault-settings.component.ts
@@ -23,6 +23,7 @@ import {
   ToastService,
 } from "@bitwarden/components";
 
+import { FORCE_TARGETING_RULES_UPDATE_COMMAND } from "../../../autofill/services/targeting-rules-data.service";
 import { PopOutComponent } from "../../../platform/popup/components/pop-out.component";
 import { PopupHeaderComponent } from "../../../platform/popup/layout/popup-header.component";
 import { PopupPageComponent } from "../../../platform/popup/layout/popup-page.component";
@@ -106,7 +107,7 @@ export class VaultSettingsComponent implements OnInit, OnDestroy {
       const success = await this.syncService.fullSync(true);
       if (success) {
         await this.setLastSync();
-        this.messagingService.send("bgForceTargetingRulesUpdate");
+        this.messagingService.send(FORCE_TARGETING_RULES_UPDATE_COMMAND);
         toastConfig = {
           variant: "success",
           title: "",

--- a/apps/browser/src/vault/popup/settings/vault-settings.component.ts
+++ b/apps/browser/src/vault/popup/settings/vault-settings.component.ts
@@ -11,6 +11,7 @@ import { BrowserPremiumUpgradePromptService } from "@bitwarden/browser/billing/p
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { getUserId } from "@bitwarden/common/auth/services/account.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
 import { CipherArchiveService } from "@bitwarden/common/vault/abstractions/cipher-archive.service";
 import { PremiumUpgradePromptService } from "@bitwarden/common/vault/abstractions/premium-upgrade-prompt.service";
 import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.service.abstraction";
@@ -80,6 +81,7 @@ export class VaultSettingsComponent implements OnInit, OnDestroy {
     private nudgeService: NudgesService,
     private accountService: AccountService,
     private cipherArchiveService: CipherArchiveService,
+    private messagingService: MessagingService,
   ) {}
 
   async ngOnInit() {
@@ -104,6 +106,7 @@ export class VaultSettingsComponent implements OnInit, OnDestroy {
       const success = await this.syncService.fullSync(true);
       if (success) {
         await this.setLastSync();
+        this.messagingService.send("bgForceTargetingRulesUpdate");
         toastConfig = {
           variant: "success",
           title: "",


### PR DESCRIPTION
## 🎟️ Tracking

[PM-38744](https://bitwarden.atlassian.net/browse/PM-38744)

## 📔 Objective

Targeting rules presently syncs on every vault sync; not just manual user-initiated syncs.

Because the vault auto-syncs on a regular interval shorter than the scheduled sync for targeting rules, this effectively negates the targeting rules sync schedule.

This task represents making targeting rules only sync on:
- the regular targeting rules sync schedule (right now, 6 hour interval)
- vault syncs which were manually triggered

[PM-38744]: https://bitwarden.atlassian.net/browse/PM-38744?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ