### PR TITLE
Uif/m3/visual regression fixes

### DIFF
--- a/apps/web/src/app/admin-console/organizations/members/components/invite-members-dialog/by-link-tab.component.html
+++ b/apps/web/src/app/admin-console/organizations/members/components/invite-members-dialog/by-link-tab.component.html
@@ -46,7 +46,7 @@
       <input
         bitInput
         type="text"
-        disabled="true"
+        readonly
         [value]="inviteLinkUrl"
         [class.tw-select-none]="domainsEmpty()"
         data-testid="inviteLink"

--- a/apps/web/src/app/admin-console/organizations/members/components/invite-members-dialog/by-link-tab.component.html
+++ b/apps/web/src/app/admin-console/organizations/members/components/invite-members-dialog/by-link-tab.component.html
@@ -11,18 +11,10 @@
   </a>
 </p>
 
-<div class="tw-flex tw-items-start tw-gap-2">
-  <bit-form-field class="tw-flex-1">
-    <bit-label> {{ "allowedDomains" | i18n }} </bit-label>
-    <input
-      bitInput
-      type="text"
-      [formControl]="form.controls.domains"
-      data-testid="allowedDomains"
-    />
-    <bit-hint>{{ "allowedDomainsHint" | i18n }}</bit-hint>
-  </bit-form-field>
-
+<bit-form-field class="tw-flex-1">
+  <bit-label> {{ "allowedDomains" | i18n }} </bit-label>
+  <input bitInput type="text" [formControl]="form.controls.domains" data-testid="allowedDomains" />
+  <bit-hint>{{ "allowedDomainsHint" | i18n }}</bit-hint>
   <button
     type="button"
     bitButton
@@ -32,12 +24,12 @@
     [disabled]="domainsEmpty()"
     [bitTooltip]="domainsEmpty() ? ('mustEnterAtLeastOneDomain' | i18n) : ''"
     tooltipPosition="left-center"
-    class="tw-mt-[10px]"
+    slot="inline-end"
     data-testid="saveDomains"
   >
     {{ "save" | i18n }}
   </button>
-</div>
+</bit-form-field>
 
 @let inviteLink = inviteLink$ | async;
 @if (inviteLink == null) {

--- a/apps/web/src/app/admin-console/organizations/policies/policy-edit-definitions/simple-toggle-policy.component.ts
+++ b/apps/web/src/app/admin-console/organizations/policies/policy-edit-definitions/simple-toggle-policy.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component } from "@angular/core";
 import { ReactiveFormsModule } from "@angular/forms";
 
-import { CalloutComponent, FormFieldModule, SwitchComponent } from "@bitwarden/components";
+import { CalloutComponent, FormControlModule, SwitchComponent } from "@bitwarden/components";
 import { I18nPipe } from "@bitwarden/ui-common";
 
 import { BasePolicyEditComponent } from "../base-policy-edit.component";
@@ -12,11 +12,12 @@ import { BasePolicyEditComponent } from "../base-policy-edit.component";
     @if (policy()?.warningKey) {
       <bit-callout type="warning">{{ policy()!.warningKey! | i18n }}</bit-callout>
     }
-    <bit-switch [formControl]="enabled">
+    <bit-form-control>
+      <bit-switch [formControl]="enabled"></bit-switch>
       <bit-label>{{ "turnOn" | i18n }}</bit-label>
-    </bit-switch>
+    </bit-form-control>
   `,
-  imports: [ReactiveFormsModule, CalloutComponent, FormFieldModule, SwitchComponent, I18nPipe],
+  imports: [ReactiveFormsModule, CalloutComponent, FormControlModule, SwitchComponent, I18nPipe],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class SimpleTogglePolicyComponent extends BasePolicyEditComponent {}

--- a/bitwarden_license/bit-web/src/app/admin-console/organizations/manage/scim-v2.component.html
+++ b/bitwarden_license/bit-web/src/app/admin-console/organizations/manage/scim-v2.component.html
@@ -1,72 +1,71 @@
 <app-header></app-header>
 
 <form [formGroup]="formData">
-  <bit-card>
-    <div [hidden]="!loading()">
-      <bit-spinner />
-      <span class="tw-sr-only">{{ "loading" | i18n }}</span>
-    </div>
-    <div [hidden]="loading()">
-      <div class="tw-flex tw-items-start tw-justify-between tw-gap-6">
-        <div>
-          <h2 bitTypography="h2" class="tw-mb-3">{{ "scim" | i18n }}</h2>
-          <p bitTypography="body1" class="tw-mb-0">
-            {{ "scimDescriptionV2" | i18n }}
-            <a bitLink target="_blank" href="https://bitwarden.com/help/about-scim/">
-              {{ "scimLearnMore" | i18n }}
-              <bit-icon name="bwi-external-link" slot="end"></bit-icon>
-            </a>
-          </p>
-        </div>
-        <bit-switch [formControl]="enabled" (change)="submit()" class="tw-shrink-0 tw-mt-1">
-          <bit-label class="tw-sr-only">{{ "scim" | i18n }}</bit-label>
-        </bit-switch>
-      </div>
+  <div [hidden]="!loading()">
+    <bit-spinner />
+    <span class="tw-sr-only">{{ "loading" | i18n }}</span>
+  </div>
+  <div [hidden]="loading()">
+    <bit-form-control-card>
+      <bit-switch [formControl]="enabled" (change)="submit()"></bit-switch>
+      <bit-label>{{ "scim" | i18n }}</bit-label>
+      <bit-hint>
+        {{ "scimDescriptionV2" | i18n }}
+        <a
+          bitLink
+          target="_blank"
+          href="https://bitwarden.com/help/about-scim/"
+          endIcon="bwi-external-link"
+        >
+          {{ "scimLearnMore" | i18n }}
+        </a>
+      </bit-hint>
+    </bit-form-control-card>
 
-      <div class="tw-mt-6" [hidden]="!showScimSettings()">
-        <bit-form-field>
-          <bit-label>{{ "scimUrl" | i18n }}</bit-label>
-          <input bitInput type="text" formControlName="endpointUrl" />
-          <button
-            type="button"
-            bitSuffix
-            bitIconButton="bwi-clone"
-            [bitAction]="copyScimUrl"
-            [label]="'copyScimUrl' | i18n"
-          ></button>
-        </bit-form-field>
-        <bit-form-field>
-          <bit-label>{{ "scimApiKey" | i18n }}</bit-label>
-          <input
-            bitInput
-            [type]="showScimKey() ? 'text' : 'password'"
-            formControlName="clientSecret"
-            id="clientSecret"
-          />
-          <button
-            type="button"
-            bitSuffix
-            [bitIconButton]="showScimKey() ? 'bwi-eye-slash' : 'bwi-eye'"
-            [bitAction]="loadApiKey"
-            [label]="'toggleVisibility' | i18n"
-          ></button>
-          <button
-            type="button"
-            bitSuffix
-            bitIconButton="bwi-clone"
-            [bitAction]="copyScimKey"
-            [label]="'copyScimKey' | i18n"
-          ></button>
-          <button
-            type="button"
-            bitSuffix
-            bitIconButton="bwi-generate"
-            [bitAction]="rotateScimKey"
-            [label]="'rotateScimKey' | i18n"
-          ></button>
-          <bit-hint>{{ "scimApiKeyHelperText" | i18n }}</bit-hint>
-        </bit-form-field>
-      </div>
+    <div class="tw-mt-6" [hidden]="!showScimSettings()">
+      <bit-form-field>
+        <bit-label>{{ "scimUrl" | i18n }}</bit-label>
+        <input bitInput type="text" formControlName="endpointUrl" readonly />
+        <button
+          type="button"
+          bitSuffix
+          bitIconButton="bwi-clone"
+          [bitAction]="copyScimUrl"
+          [label]="'copyScimUrl' | i18n"
+        ></button>
+      </bit-form-field>
+      <bit-form-field>
+        <bit-label>{{ "scimApiKey" | i18n }}</bit-label>
+        <input
+          bitInput
+          [type]="showScimKey() ? 'text' : 'password'"
+          formControlName="clientSecret"
+          id="clientSecret"
+          readonly
+        />
+        <button
+          type="button"
+          bitSuffix
+          [bitIconButton]="showScimKey() ? 'bwi-eye-slash' : 'bwi-eye'"
+          [bitAction]="loadApiKey"
+          [label]="'toggleVisibility' | i18n"
+        ></button>
+        <button
+          type="button"
+          bitSuffix
+          bitIconButton="bwi-clone"
+          [bitAction]="copyScimKey"
+          [label]="'copyScimKey' | i18n"
+        ></button>
+        <button
+          type="button"
+          bitSuffix
+          bitIconButton="bwi-generate"
+          [bitAction]="rotateScimKey"
+          [label]="'rotateScimKey' | i18n"
+        ></button>
+        <bit-hint>{{ "scimApiKeyHelperText" | i18n }}</bit-hint>
+      </bit-form-field>
     </div>
-  </bit-card>
+  </div>
 </form>

--- a/bitwarden_license/bit-web/src/app/admin-console/organizations/manage/scim-v2.component.html
+++ b/bitwarden_license/bit-web/src/app/admin-console/organizations/manage/scim-v2.component.html
@@ -22,9 +22,14 @@
             </a>
           </p>
         </div>
-        <label>
+        <label [for]="switchInputId">
           <span [id]="labelId" class="tw-sr-only">{{ "scim" | i18n }}</span>
-          <bit-switch [formControl]="enabled" (change)="submit()" class="tw-shrink-0 tw-mt-1">
+          <bit-switch
+            [id]="switchId"
+            [formControl]="enabled"
+            (change)="submit()"
+            class="tw-shrink-0 tw-mt-1"
+          >
           </bit-switch>
         </label>
       </div>

--- a/bitwarden_license/bit-web/src/app/admin-console/organizations/manage/scim-v2.component.html
+++ b/bitwarden_license/bit-web/src/app/admin-console/organizations/manage/scim-v2.component.html
@@ -1,71 +1,79 @@
 <app-header></app-header>
 
 <form [formGroup]="formData">
-  <div [hidden]="!loading()">
-    <bit-spinner />
-    <span class="tw-sr-only">{{ "loading" | i18n }}</span>
-  </div>
-  <div [hidden]="loading()">
-    <bit-form-control-card>
-      <bit-switch [formControl]="enabled" (change)="submit()"></bit-switch>
-      <bit-label>{{ "scim" | i18n }}</bit-label>
-      <bit-hint>
-        {{ "scimDescriptionV2" | i18n }}
-        <a
-          bitLink
-          target="_blank"
-          href="https://bitwarden.com/help/about-scim/"
-          endIcon="bwi-external-link"
-        >
-          {{ "scimLearnMore" | i18n }}
-        </a>
-      </bit-hint>
-    </bit-form-control-card>
-
-    <div class="tw-mt-6" [hidden]="!showScimSettings()">
-      <bit-form-field>
-        <bit-label>{{ "scimUrl" | i18n }}</bit-label>
-        <input bitInput type="text" formControlName="endpointUrl" readonly />
-        <button
-          type="button"
-          bitSuffix
-          bitIconButton="bwi-clone"
-          [bitAction]="copyScimUrl"
-          [label]="'copyScimUrl' | i18n"
-        ></button>
-      </bit-form-field>
-      <bit-form-field>
-        <bit-label>{{ "scimApiKey" | i18n }}</bit-label>
-        <input
-          bitInput
-          [type]="showScimKey() ? 'text' : 'password'"
-          formControlName="clientSecret"
-          id="clientSecret"
-          readonly
-        />
-        <button
-          type="button"
-          bitSuffix
-          [bitIconButton]="showScimKey() ? 'bwi-eye-slash' : 'bwi-eye'"
-          [bitAction]="loadApiKey"
-          [label]="'toggleVisibility' | i18n"
-        ></button>
-        <button
-          type="button"
-          bitSuffix
-          bitIconButton="bwi-clone"
-          [bitAction]="copyScimKey"
-          [label]="'copyScimKey' | i18n"
-        ></button>
-        <button
-          type="button"
-          bitSuffix
-          bitIconButton="bwi-generate"
-          [bitAction]="rotateScimKey"
-          [label]="'rotateScimKey' | i18n"
-        ></button>
-        <bit-hint>{{ "scimApiKeyHelperText" | i18n }}</bit-hint>
-      </bit-form-field>
+  <bit-card>
+    <div [hidden]="!loading()">
+      <bit-spinner />
+      <span class="tw-sr-only">{{ "loading" | i18n }}</span>
     </div>
-  </div>
+    <div [hidden]="loading()">
+      <div class="tw-flex tw-items-start tw-justify-between tw-gap-6">
+        <div>
+          <h2 bitTypography="h2" class="tw-mb-3">{{ "scim" | i18n }}</h2>
+          <p [id]="descriptionId" bitTypography="body1" class="tw-mb-0">
+            {{ "scimDescriptionV2" | i18n }}
+            <a
+              bitLink
+              target="_blank"
+              endIcon="bwi-external-link"
+              href="https://bitwarden.com/help/about-scim/"
+            >
+              {{ "scimLearnMore" | i18n }}
+            </a>
+          </p>
+        </div>
+        <label>
+          <span [id]="labelId" class="tw-sr-only">{{ "scim" | i18n }}</span>
+          <bit-switch [formControl]="enabled" (change)="submit()" class="tw-shrink-0 tw-mt-1">
+          </bit-switch>
+        </label>
+      </div>
+
+      <div class="tw-mt-6" [hidden]="!showScimSettings()">
+        <bit-form-field>
+          <bit-label>{{ "scimUrl" | i18n }}</bit-label>
+          <input bitInput type="text" formControlName="endpointUrl" readonly />
+          <button
+            type="button"
+            bitSuffix
+            bitIconButton="bwi-clone"
+            [bitAction]="copyScimUrl"
+            [label]="'copyScimUrl' | i18n"
+          ></button>
+        </bit-form-field>
+        <bit-form-field>
+          <bit-label>{{ "scimApiKey" | i18n }}</bit-label>
+          <input
+            bitInput
+            [type]="showScimKey() ? 'text' : 'password'"
+            formControlName="clientSecret"
+            id="clientSecret"
+            readonly
+          />
+          <button
+            type="button"
+            bitSuffix
+            [bitIconButton]="showScimKey() ? 'bwi-eye-slash' : 'bwi-eye'"
+            [bitAction]="loadApiKey"
+            [label]="'toggleVisibility' | i18n"
+          ></button>
+          <button
+            type="button"
+            bitSuffix
+            bitIconButton="bwi-clone"
+            [bitAction]="copyScimKey"
+            [label]="'copyScimKey' | i18n"
+          ></button>
+          <button
+            type="button"
+            bitSuffix
+            bitIconButton="bwi-generate"
+            [bitAction]="rotateScimKey"
+            [label]="'rotateScimKey' | i18n"
+          ></button>
+          <bit-hint>{{ "scimApiKeyHelperText" | i18n }}</bit-hint>
+        </bit-form-field>
+      </div>
+    </div>
+  </bit-card>
 </form>

--- a/bitwarden_license/bit-web/src/app/admin-console/organizations/manage/scim-v2.component.ts
+++ b/bitwarden_license/bit-web/src/app/admin-console/organizations/manage/scim-v2.component.ts
@@ -16,18 +16,14 @@ import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/pl
 import { OrganizationId } from "@bitwarden/common/types/guid";
 import {
   AriaDisableDirective,
-  BaseCardDirective,
   BitActionDirective,
   BitIconButtonComponent,
-  CardComponent,
   DialogService,
   FormFieldModule,
-  IconComponent,
   LinkComponent,
   SpinnerComponent,
   SwitchComponent,
   ToastService,
-  TypographyModule,
 } from "@bitwarden/components";
 import { I18nPipe } from "@bitwarden/ui-common";
 import { WebHeaderComponent } from "@bitwarden/web-vault/app/layouts/header/web-header.component";
@@ -41,16 +37,12 @@ import { ScimApiKeyDialogComponent } from "./scim-api-key-dialog.component";
   imports: [
     WebHeaderComponent,
     ReactiveFormsModule,
-    BaseCardDirective,
-    CardComponent,
-    TypographyModule,
     LinkComponent,
     AriaDisableDirective,
     SwitchComponent,
     FormFieldModule,
     BitIconButtonComponent,
     BitActionDirective,
-    IconComponent,
     I18nPipe,
     SpinnerComponent,
   ],
@@ -70,8 +62,8 @@ export class ScimV2Component {
 
   protected readonly enabled = new FormControl(false);
   protected readonly formData = new FormGroup({
-    endpointUrl: new FormControl({ value: "", disabled: true }),
-    clientSecret: new FormControl({ value: "", disabled: true }),
+    endpointUrl: new FormControl({ value: "", disabled: false }),
+    clientSecret: new FormControl({ value: "", disabled: false }),
   });
 
   private readonly organizationId: Signal<OrganizationId>;

--- a/bitwarden_license/bit-web/src/app/admin-console/organizations/manage/scim-v2.component.ts
+++ b/bitwarden_license/bit-web/src/app/admin-console/organizations/manage/scim-v2.component.ts
@@ -1,4 +1,12 @@
-import { ChangeDetectionStrategy, Component, effect, inject, Signal, signal } from "@angular/core";
+import {
+  ChangeDetectionStrategy,
+  Component,
+  effect,
+  inject,
+  Signal,
+  signal,
+  viewChild,
+} from "@angular/core";
 import { toSignal } from "@angular/core/rxjs-interop";
 import { FormControl, FormGroup, ReactiveFormsModule } from "@angular/forms";
 import { ActivatedRoute } from "@angular/router";
@@ -16,19 +24,24 @@ import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/pl
 import { OrganizationId } from "@bitwarden/common/types/guid";
 import {
   AriaDisableDirective,
+  BaseCardDirective,
   BitActionDirective,
   BitIconButtonComponent,
+  CardComponent,
   DialogService,
   FormFieldModule,
   LinkComponent,
   SpinnerComponent,
   SwitchComponent,
   ToastService,
+  TypographyModule,
 } from "@bitwarden/components";
 import { I18nPipe } from "@bitwarden/ui-common";
 import { WebHeaderComponent } from "@bitwarden/web-vault/app/layouts/header/web-header.component";
 
 import { ScimApiKeyDialogComponent } from "./scim-api-key-dialog.component";
+
+let nextId = 0;
 
 @Component({
   selector: "app-org-manage-scim-v2",
@@ -37,6 +50,9 @@ import { ScimApiKeyDialogComponent } from "./scim-api-key-dialog.component";
   imports: [
     WebHeaderComponent,
     ReactiveFormsModule,
+    BaseCardDirective,
+    CardComponent,
+    TypographyModule,
     LinkComponent,
     AriaDisableDirective,
     SwitchComponent,
@@ -60,6 +76,10 @@ export class ScimV2Component {
   protected readonly showScimSettings = signal(false);
   protected readonly showScimKey = signal(false);
 
+  protected readonly descriptionId = `scim-description-${nextId++}`;
+  protected readonly labelId = `scim-label-${nextId++}`;
+  private readonly switchRef = viewChild.required(SwitchComponent);
+
   protected readonly enabled = new FormControl(false);
   protected readonly formData = new FormGroup({
     endpointUrl: new FormControl(""),
@@ -77,6 +97,12 @@ export class ScimV2Component {
       if (this.organizationId()) {
         void this.load();
       }
+    });
+
+    effect(() => {
+      this.switchRef().ariaDescribedBy.set(this.descriptionId);
+      this.switchRef().ariaLabelledBy.set(this.labelId);
+      this.switchRef().size.set("large");
     });
   }
 

--- a/bitwarden_license/bit-web/src/app/admin-console/organizations/manage/scim-v2.component.ts
+++ b/bitwarden_license/bit-web/src/app/admin-console/organizations/manage/scim-v2.component.ts
@@ -78,6 +78,8 @@ export class ScimV2Component {
 
   protected readonly descriptionId = `scim-description-${nextId++}`;
   protected readonly labelId = `scim-label-${nextId++}`;
+  protected readonly switchId = `scim-switch-${nextId++}`;
+  protected readonly switchInputId = `${this.switchId}-input`;
   private readonly switchRef = viewChild.required(SwitchComponent);
 
   protected readonly enabled = new FormControl(false);

--- a/bitwarden_license/bit-web/src/app/admin-console/organizations/manage/scim-v2.component.ts
+++ b/bitwarden_license/bit-web/src/app/admin-console/organizations/manage/scim-v2.component.ts
@@ -62,8 +62,8 @@ export class ScimV2Component {
 
   protected readonly enabled = new FormControl(false);
   protected readonly formData = new FormGroup({
-    endpointUrl: new FormControl({ value: "", disabled: false }),
-    clientSecret: new FormControl({ value: "", disabled: false }),
+    endpointUrl: new FormControl(""),
+    clientSecret: new FormControl(""),
   });
 
   private readonly organizationId: Signal<OrganizationId>;

--- a/bitwarden_license/bit-web/src/app/admin-console/organizations/manage/scim.component.html
+++ b/bitwarden_license/bit-web/src/app/admin-console/organizations/manage/scim.component.html
@@ -27,7 +27,7 @@
   </bit-form-control>
   <bit-form-field *ngIf="showScimSettings">
     <bit-label>{{ "scimUrl" | i18n }}</bit-label>
-    <input bitInput type="text" formControlName="endpointUrl" />
+    <input bitInput type="text" formControlName="endpointUrl" readonly />
     <button
       type="button"
       bitSuffix
@@ -44,6 +44,7 @@
       [type]="showScimKey ? 'text' : 'password'"
       formControlName="clientSecret"
       id="clientSecret"
+      readonly
     />
     <button
       type="button"

--- a/bitwarden_license/bit-web/src/app/admin-console/organizations/manage/scim.component.ts
+++ b/bitwarden_license/bit-web/src/app/admin-console/organizations/manage/scim.component.ts
@@ -35,8 +35,8 @@ export class ScimComponent implements OnInit {
   private cachedApiKey: string | undefined;
 
   formData = this.formBuilder.group({
-    endpointUrl: new FormControl({ value: "", disabled: false }),
-    clientSecret: new FormControl({ value: "", disabled: false }),
+    endpointUrl: new FormControl(""),
+    clientSecret: new FormControl(""),
   });
 
   constructor(

--- a/bitwarden_license/bit-web/src/app/admin-console/organizations/manage/scim.component.ts
+++ b/bitwarden_license/bit-web/src/app/admin-console/organizations/manage/scim.component.ts
@@ -35,8 +35,8 @@ export class ScimComponent implements OnInit {
   private cachedApiKey: string | undefined;
 
   formData = this.formBuilder.group({
-    endpointUrl: new FormControl({ value: "", disabled: true }),
-    clientSecret: new FormControl({ value: "", disabled: true }),
+    endpointUrl: new FormControl({ value: "", disabled: false }),
+    clientSecret: new FormControl({ value: "", disabled: false }),
   });
 
   constructor(

--- a/libs/components/src/form-control/form-control-card.component.html
+++ b/libs/components/src/form-control/form-control-card.component.html
@@ -41,7 +41,11 @@
         <ng-content select="bit-hint"></ng-content>
       </span>
     </div>
-    <ng-content></ng-content>
+    <div
+      class="tw-relative tw-pointer-events-none [&_a]:tw-pointer-events-auto [&_button]:tw-pointer-events-auto"
+    >
+      <ng-content></ng-content>
+    </div>
   </div>
   <div [id]="errorId" class="tw-text-fg-danger tw-text-xs tw-ms-0.5" [hidden]="!control.hasError">
     @if (control.hasError) {

--- a/libs/components/src/form-control/form-control-card.component.html
+++ b/libs/components/src/form-control/form-control-card.component.html
@@ -1,48 +1,51 @@
 @let control = base.formControl();
-<div
-  class="tw-flex tw-items-center tw-relative tw-p-4 tw-border tw-border-border-base tw-rounded-xl tw-justify-between tw-gap-4 has-[label:hover]:tw-border-border-brand-soft has-[input:focus-visible]:tw-ring-2 has-[input:focus-visible]:tw-ring-border-focus has-[input:focus-visible]:tw-border-transparent has-[input:checked]:tw-bg-bg-brand-soft"
->
-  <!-- label z-index to ensure label sits on top of switch thumb control(z-index: 2) -->
-  <label
-    [for]="base.inputId()"
-    class="tw-absolute tw-top-0 tw-left-0 tw-size-full tw-z-[3]"
-    [class]="control.disabled ? 'tw-cursor-default' : 'tw-cursor-pointer'"
-  ></label>
+<div class="tw-flex tw-flex-col tw-gap-2">
+  <div
+    class="tw-flex tw-items-center tw-relative tw-isolate tw-p-4 tw-border tw-border-border-base tw-rounded-xl tw-justify-between tw-gap-4 has-[label:hover]:tw-border-border-brand-soft has-[input:focus-visible]:tw-ring-2 has-[input:focus-visible]:tw-ring-border-focus has-[input:focus-visible]:tw-border-transparent has-[input:checked]:tw-bg-bg-brand-softer"
+  >
+    <label
+      [for]="base.inputId()"
+      class="tw-absolute tw-inset-0 tw-rounded-xl"
+      [class]="control.disabled ? 'tw-cursor-default' : 'tw-cursor-pointer'"
+    ></label>
 
-  <div class="tw-flex tw-items-center tw-gap-4">
-    @if (icon(); as icon) {
-      <!-- this positioning style to account for tile staying top aligned when text wraps -->
-      <bit-icon-tile
-        [variant]="control.disabled ? 'subtle' : 'primary'"
-        class="tw-self-start tw-relative tw-top-[1px]"
-        [icon]="icon"
-      ></bit-icon-tile>
-    }
-
-    <span
-      class="tw-inline-flex tw-flex-col"
-      [class.tw-text-fg-inactive]="control.disabled"
-      [class]="control.disabled ? '[&_bit-hint]:!tw-text-fg-inactive' : ''"
-      [class.tw-text-fg-heading]="!control.disabled"
+    <div
+      class="tw-flex tw-items-center tw-gap-4 tw-relative tw-pointer-events-none [&_a]:tw-pointer-events-auto [&_button]:tw-pointer-events-auto"
     >
+      @if (icon(); as icon) {
+        <!-- this positioning style to account for tile staying top aligned when text wraps -->
+        <bit-icon-tile
+          [variant]="control.disabled ? 'subtle' : 'primary'"
+          class="tw-self-start tw-relative tw-top-[1px]"
+          [icon]="icon"
+        ></bit-icon-tile>
+      }
+
       <span
-        [id]="labelId"
-        bitTypography="body2"
-        class="tw-flex tw-gap-0.5 tw-items-center tw-leading-5 tw-font-medium"
+        class="tw-inline-flex tw-flex-col"
+        [class.tw-text-fg-inactive]="control.disabled"
+        [class]="control.disabled ? '[&_bit-hint]:!tw-text-fg-inactive' : ''"
+        [class.tw-text-fg-heading]="!control.disabled"
       >
-        <ng-content select="bit-label"></ng-content>
-        @if (control.required) {
-          <sup aria-hidden class="tw-text-sm tw-text-fg-danger tw-relative tw-top-[-1px]">*</sup>
-          <span class="tw-sr-only"> ({{ "required" | i18n }})</span>
-        }
+        <span
+          [id]="labelId"
+          bitTypography="body2"
+          class="tw-flex tw-gap-0.5 tw-items-center tw-leading-5 tw-font-medium"
+        >
+          <ng-content select="bit-label"></ng-content>
+          @if (control.required) {
+            <sup aria-hidden class="tw-text-sm tw-text-fg-danger tw-relative tw-top-[-1px]">*</sup>
+            <span class="tw-sr-only"> ({{ "required" | i18n }})</span>
+          }
+        </span>
+        <ng-content select="bit-hint"></ng-content>
       </span>
-      <ng-content select="bit-hint"></ng-content>
-    </span>
+    </div>
+    <ng-content></ng-content>
   </div>
-  <ng-content></ng-content>
+  <div [id]="errorId" class="tw-text-fg-danger tw-text-xs tw-ms-0.5" [hidden]="!control.hasError">
+    @if (control.hasError) {
+      <bit-icon name="bwi-error"></bit-icon> {{ base.displayError }}
+    }
+  </div>
 </div>
-@if (control.hasError) {
-  <div [id]="errorId" class="tw-mt-1 tw-text-fg-danger tw-text-xs tw-ms-0.5">
-    <bit-icon name="bwi-error"></bit-icon> {{ base.displayError }}
-  </div>
-}

--- a/libs/components/src/form-control/form-control-card.component.html
+++ b/libs/components/src/form-control/form-control-card.component.html
@@ -43,7 +43,7 @@
       </span>
     </div>
     <div
-      class="tw-relative tw-pointer-events-none [&_a]:tw-pointer-events-auto [&_button]:tw-pointer-events-auto"
+      class="tw-relative tw-pointer-events-none tw-flex [&_a]:tw-pointer-events-auto [&_button]:tw-pointer-events-auto"
     >
       <ng-content></ng-content>
     </div>

--- a/libs/components/src/form-control/form-control-card.component.html
+++ b/libs/components/src/form-control/form-control-card.component.html
@@ -5,6 +5,7 @@
   >
     <label
       [for]="base.inputId()"
+      [attr.aria-labelledby]="labelId"
       class="tw-absolute tw-inset-0 tw-rounded-xl"
       [class]="control.disabled ? 'tw-cursor-default' : 'tw-cursor-pointer'"
     ></label>

--- a/libs/components/src/form-control/form-control-group.component.html
+++ b/libs/components/src/form-control/form-control-group.component.html
@@ -23,7 +23,7 @@
       <ng-content></ng-content>
     </div>
     @if (hasError()) {
-      <div [id]="errorId" class="tw-mt-1 tw-text-fg-danger tw-text-xs tw-ms-0.5">
+      <div [id]="errorId" class="tw-text-fg-danger tw-text-xs tw-ms-0.5">
         <bit-icon name="bwi-error"></bit-icon> {{ displayError() }}
       </div>
     } @else {

--- a/libs/components/src/form-field/field-container.directive.ts
+++ b/libs/components/src/form-field/field-container.directive.ts
@@ -19,6 +19,7 @@ export class BitFieldContainerDirective {
     return [
       "tw-group/form-field",
       "tw-flex",
+      "tw-w-full",
       "tw-border",
       "tw-rounded-xl",
       "tw-border-solid",

--- a/libs/components/src/form-field/form-field.component.html
+++ b/libs/components/src/form-field/form-field.component.html
@@ -9,28 +9,31 @@
       <span class="tw-sr-only"> ({{ "required" | i18n }})</span>
     }
   </label>
-  <div bitFieldContainer [size]="size()" [hasError]="input().hasError()" [readOnly]="readOnly">
-    <div
-      #prefixContainer
-      [hidden]="!prefixHasChildren()"
-      class="tw-flex tw-items-center tw-border-e tw-border-border-base tw-px-3 tw-bg-bg-quaternary tw-rounded-s-[11px]"
-    >
-      <ng-content select="[bitPrefix]"></ng-content>
-    </div>
-    <div
-      class="tw-flex tw-w-full tw-items-center tw-pe-3 has-[[biticonbutton]:last-child]:tw-pe-1 has-[bit-select]:tw-pe-0 has-[bit-multi-select]:tw-pe-0 has-[textarea]:!tw-items-start"
-    >
-      <div [class]="contentContainerClasses" data-default-content>
-        <ng-content></ng-content>
+  <div class="tw-flex tw-gap-2 tw-items-center">
+    <div bitFieldContainer [size]="size()" [hasError]="input().hasError()" [readOnly]="readOnly">
+      <div
+        #prefixContainer
+        [hidden]="!prefixHasChildren()"
+        class="tw-flex tw-items-center tw-border-e tw-border-border-base tw-px-3 tw-bg-bg-quaternary tw-rounded-s-[11px]"
+      >
+        <ng-content select="[bitPrefix]"></ng-content>
       </div>
       <div
-        #suffixContainer
-        [hidden]="!suffixHasChildren()"
-        class="tw-flex tw-items-center group-has-[textarea]/form-field:tw-pt-1"
+        class="tw-flex tw-w-full tw-items-center tw-pe-3 has-[[biticonbutton]:last-child]:tw-pe-1 has-[bit-select]:tw-pe-0 has-[bit-multi-select]:tw-pe-0 has-[textarea]:!tw-items-start"
       >
-        <ng-content select="[bitSuffix]"></ng-content>
+        <div [class]="contentContainerClasses" data-default-content>
+          <ng-content></ng-content>
+        </div>
+        <div
+          #suffixContainer
+          [hidden]="!suffixHasChildren()"
+          class="tw-flex tw-items-center group-has-[textarea]/form-field:tw-pt-1"
+        >
+          <ng-content select="[bitSuffix]"></ng-content>
+        </div>
       </div>
     </div>
+    <ng-content select="[slot='inline-end']"></ng-content>
   </div>
   @switch (input().hasError()) {
     @case (false) {

--- a/libs/components/src/form-field/form-field.stories.ts
+++ b/libs/components/src/form-field/form-field.stories.ts
@@ -361,6 +361,26 @@ export const InputGroup: Story = {
   args: {},
 };
 
+export const InlineEndButton: Story = {
+  render: (args) => ({
+    props: {
+      formObj: formObj,
+      ...args,
+    },
+    template: /*html*/ `
+      <bit-form-field [formGroup]="formObj">
+        <bit-label>Allowed domains</bit-label>
+        <input bitInput formControlName="test" placeholder="example.com" />
+        <bit-hint>Comma-separated list of email domains.</bit-hint>
+        <button type="button" bitButton buttonType="primary" slot="inline-end">
+          Save
+        </button>
+      </bit-form-field>
+    `,
+  }),
+  args: {},
+};
+
 export const ButtonInputGroup: Story = {
   render: (args) => ({
     props: args,


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

- Fix some minor visual regressions introduced with new field designs

@bitwarden/team-admin-console-dev As a heads up: I've updated a couple of the fields in the scim components to be readonly rather than disabled. I've aligned with design on this change. Readonly fields in this scenario are a better experience for both screen reader and keyboard users.

Also, made some minor changes to the scim v2 component to be able to use the switch in this manor. Support for switch for use like this is not built into the component. It's meant to be rendered with a label currently

## 📸 Screenshots
