### PR TITLE
[PM-38581] - disable drag for single custom fields

### DIFF
--- a/libs/vault/src/cipher-form/components/custom-fields/custom-fields.component.html
+++ b/libs/vault/src/cipher-form/components/custom-fields/custom-fields.component.html
@@ -19,7 +19,7 @@
             }"
             [attr.data-testid]="field.value.name + '-entry'"
             cdkDrag
-            [cdkDragDisabled]="!canEdit(field.value.type)"
+            [cdkDragDisabled]="!canEdit(field.value.type) || fields.controls.length <= 1"
             #customFieldRow
           >
             <!-- Text Field -->

--- a/libs/vault/src/cipher-form/components/custom-fields/custom-fields.component.html
+++ b/libs/vault/src/cipher-form/components/custom-fields/custom-fields.component.html
@@ -19,7 +19,7 @@
             }"
             [attr.data-testid]="field.value.name + '-entry'"
             cdkDrag
-            [cdkDragDisabled]="!canEdit(field.value.type) || fields.controls.length <= 1"
+            [cdkDragDisabled]="dragDisabled(field.value.type)"
             #customFieldRow
           >
             <!-- Text Field -->

--- a/libs/vault/src/cipher-form/components/custom-fields/custom-fields.component.ts
+++ b/libs/vault/src/cipher-form/components/custom-fields/custom-fields.component.ts
@@ -163,6 +163,10 @@ export class CustomFieldsComponent implements OnInit, AfterViewInit {
     );
   }
 
+  dragDisabled(type: FieldType): boolean {
+    return !this.canEdit(type) || this.fields.length <= 1;
+  }
+
   ngOnInit() {
     const linkedFieldsOptionsForCipher = this.getLinkedFieldsOptionsForCipher();
     const optionsArray = Array.from(linkedFieldsOptionsForCipher?.entries() ?? []);


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-38581

Fixes https://github.com/bitwarden/clients/issues/21060

## 📔 Objective

Fixes an issue where an individual custom field could be dragged by clicking and
holding anywhere on its text input when only a single custom field existed.

The drag handle button (`cdkDragHandle`) is only rendered when there are two or
more fields. With a single field, no handle was present, so Angular CDK fell back
to making the entire row draggable — including the text input — which interfered
with normal text entry/selection.

The fix disables `cdkDrag` on the row when there is only one field by adding
`fields.controls.length <= 1` to the `cdkDragDisabled` condition. When multiple
fields are present, behavior is unchanged: the drag-and-drop handle on the far
right works as expected, and the inputs remain fully interactive.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/9ac47a00-e9ea-4709-9834-16568a900fa8