### PR TITLE
[PM-38409] - update custom field value on reorder

### DIFF
--- a/libs/vault/src/cipher-form/components/custom-fields/custom-fields.component.html
+++ b/libs/vault/src/cipher-form/components/custom-fields/custom-fields.component.html
@@ -10,7 +10,7 @@
         (cdkDropListDropped)="drop($event)"
         data-testid="custom-fields"
       >
-        @for (field of fields.controls; track $index; let i = $index) {
+        @for (field of fields.controls; track field; let i = $index) {
           <div
             [formGroupName]="i"
             class="tw-flex tw-p-3 -tw-mx-3 tw-gap-4 tw-bg-background tw-rounded-lg first:-tw-mt-3 last-of-type:tw-mb-0"


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-38409

## 📔 Objective

Fixes a visual desync when reordering custom fields on the cipher edit form.

When a custom field was moved (via the drag handle or arrow keys), the field
**labels** would reorder correctly but the field **input contents** would not —
an input could appear to take on the value of another field, and sometimes the
order looked unchanged. Saving persisted the correct order, confirming the
underlying data was always right; only the UI was out of sync.

**Root cause:** the `@for` loop rendering the fields used `track $index`. On a
reorder, `drop()` calls `moveItemInArray()` on the `FormArray` controls, but
because each row was tracked by its index, Angular kept every DOM row pinned to
its original index instead of moving it. The `[formGroupName]="i"` binding
therefore stayed attached to the original control, so `formControlName` inputs
kept rendering the old control's value. Labels updated only because they use
`{{ field.value.name }}` interpolation, which is re-evaluated on every change
detection cycle.

**Fix:** track the loop by the control identity (`track field`) instead of the
index. Angular now moves the DOM rows to match the reordered controls and
re-binds `formGroupName`, so both the label and the input content reorder
together and stay consistent with the saved data.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/e6208920-4246-436f-9cb1-21be37bb29a2


