### PR TITLE
[DRAFT] Scripts for release notes generation

### DIFF
--- a/.github/label-pr.json
+++ b/.github/label-pr.json
@@ -1,0 +1,73 @@
+{
+  "title_patterns": {
+    "t:feature": ["feat", "feature", "tool"],
+    "t:bugfix": ["fix", "bug", "bugfix"],
+    "t:tech-debt": ["refactor", "chore", "cleanup", "revert", "debt", "test", "perf"],
+    "t:docs": ["docs"],
+    "t:ci": ["ci", "build", "chore(ci)"],
+    "t:deps": ["deps", "[deps]"],
+    "t:breaking-change": ["breaking", "breaking-change"],
+    "t:misc": ["misc"],
+    "t:llm": ["llm"]
+  },
+  "path_patterns": {
+    "web": [
+      "apps/web",
+      "bitwarden_license/bit-web",
+      "bitwarden_license/bit-common",
+      "libs/",
+      "!libs/common/src/autofill"
+    ],
+    "browser": [
+      "apps/browser",
+      "bitwarden_license/bit-browser",
+      "bitwarden_license/bit-common",
+      "libs/"
+    ],
+    "desktop": [
+      "apps/desktop",
+      "bitwarden_license/bit-desktop",
+      "bitwarden_license/bit-common",
+      "libs/",
+      "!libs/common/src/autofill"
+    ],
+    "cli": [
+      "apps/cli",
+      "bitwarden_license/bit-cli",
+      "bitwarden_license/bit-common",
+      "libs/",
+      "!libs/angular",
+      "!libs/auth/src/angular",
+      "!libs/auto-confirm/src/angular",
+      "!libs/assets",
+      "!libs/common/src/autofill",
+      "!libs/components",
+      "!libs/dirt/card/",
+      "!libs/importer/src/components",
+      "!libs/key-management-ui",
+      "!libs/pricing/src/components",
+      "!libs/subscription/src/components",
+      "!libs/tools/export/vault-export/vault-export-ui",
+      "!libs/tools/generator/components",
+      "!libs/tools/send/send-ui",
+      "!libs/vault/src/cipher-form",
+      "!libs/vault/src/cipher-view",
+      "!libs/vault/src/components"
+    ],
+    "feature-flag": ["libs/common/src/enums/feature-flag.enum.ts"],
+    "t:feature": ["libs/common/src/enums/feature-flag.enum.ts"],
+    "t:tech-debt": [],
+    "t:ci": [
+      ".checkmarx/",
+      ".github/",
+      "scripts/",
+      "apps/desktop/electron-builder.json",
+      "apps/desktop/electron-builder-beta.json",
+      "apps/desktop/scripts",
+      "apps/desktop/stores"
+    ],
+    "t:docs": ["docs/", "README.md", "CONTRIBUTING.md", "SECURITY.md"],
+    "t:deps": [],
+    "t:llm": [".claude/"]
+  }
+}

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,31 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+  categories:
+    - title: "💙 Community Highlight"
+      labels:
+        - community-pr
+    - title: ":shipit: Feature Development"
+      labels:
+        - t:feature
+        - feature-flag
+    - title: "❗ Breaking Changes"
+      labels:
+        - t:breaking-change
+    - title: "🐛 Bug fixes"
+      labels:
+        - t:bugfix
+    - title: "⚙️ Maintenance"
+      labels:
+        - t:tech-debt
+        - t:ci
+        - t:docs
+        - t:misc
+    - title: "📦 Dependency Updates"
+      labels:
+        - major-updates
+        - t:deps
+    - title: "🔧 Other"
+      labels:
+        - "*"

--- a/.github/scripts/batch-label-prs.sh
+++ b/.github/scripts/batch-label-prs.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Runs label-pr.py in dry-run/add mode for each PR found in a JSON inpit file.
+# #Usage: ./batch-label-prs.sh <input-file> [output-file]
+# #Example: ./batch-label-prs.sh prs-web.json label-results.txt
+#
+# The input file should be a JSON array of objects with "number" and "labels" fields,
+# e.g. [{"number": 123, "title": "...", "labels": [{"name": "web"}], ...}, ...]
+# Requirements: python3, jq, gh (authenticated)
+
+set -euo pipefail
+
+INPUT_FILE="${1:?Usage: $0 <input-json> [output-file]}"
+OUTPUT_FILE="${2:-label-results.txt}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+if [ ! -f "$INPUT_FILE" ]; then
+  echo "Error: Input file '$INPUT_FILE' not found" >&2
+  exit 1
+fi
+
+if ! command -v jq &>/dev/null; then
+  echo "Error: jq is required but not installed" >&2
+  exit 1
+fi
+
+> "$OUTPUT_FILE"
+
+TOTAL=$(jq 'length' "$INPUT_FILE")
+COUNT=0
+
+jq -c '.[]' "$INPUT_FILE" | while IFS= read -r PR_JSON; do
+  PR_NUMBER=$(echo "$PR_JSON" | jq -r '.number')
+  LABELS=$(echo "$PR_JSON" | jq -c '[.labels[].name]')
+
+  COUNT=$((COUNT + 1))
+  echo "[$COUNT/$TOTAL] Processing PR #${PR_NUMBER} (existing labels: $LABELS)..." >&2
+
+  {
+    echo "======================================"
+    echo "PR #${PR_NUMBER}"
+    echo "======================================"
+    # python3 "$SCRIPT_DIR/label-pr.py" "$PR_NUMBER" "$LABELS" -d 2>&1 || echo "ERROR: Failed to process PR #${PR_NUMBER}"
+    python3 "$SCRIPT_DIR/label-pr.py" "$PR_NUMBER" "$LABELS" 2>&1 || echo "ERROR: Failed to process PR #${PR_NUMBER}"
+    echo ""
+  } >> "$OUTPUT_FILE"
+
+done
+
+echo "Done. Results written to $OUTPUT_FILE" >&2

--- a/.github/scripts/fetch-release-prs.sh
+++ b/.github/scripts/fetch-release-prs.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Fetches PR details for commits between the last release tag and HEAD, writes to JSON.
+# Usage: ./fetch-release-prs.sh <client> [output-file]
+# Example: ./fetch-release-prs.sh web prs-web.json
+#
+# Requirements: gh (authenticated), jq, git (with tags fetched)
+
+set -euo pipefail
+
+CLIENT="${1:?Usage: $0 <client> (web, browser, desktop, cli)}"
+OUTPUT_FILE="${2:-prs-${CLIENT}.json}"
+GH_REPO="${GH_REPO:-bitwarden/clients}"
+TARGET_TAG="HEAD"
+
+# Override for testing - comment out for normal use
+PREV_TAG="${CLIENT}-v2026.4.2"
+TARGET_TAG="${CLIENT}-v2026.5.0"
+
+# Find the most recent tag for this client (skip if already set)
+if [ -z "${PREV_TAG:-}" ]; then
+  PREV_TAG=$(git tag -l --sort=-authordate | grep "^${CLIENT}-v" | head -n 1)
+fi
+
+if [ -z "$PREV_TAG" ]; then
+  echo "Error: No previous tag found for client '${CLIENT}'" >&2
+  exit 1
+fi
+
+echo "Previous tag: $PREV_TAG" >&2
+
+# Extract PR numbers from commit messages between the previous tag and HEAD.
+# This ensures we only capture PRs whose commits are actually on this branch,
+# rather than all PRs merged after a date (which could include other branches).
+PR_NUMBERS=$(git log "${PREV_TAG}..${TARGET_TAG}" --oneline | grep -oE '\(#[0-9]+\)' | grep -oE '[0-9]+' | sort -u)
+
+if [ -z "$PR_NUMBERS" ]; then
+  echo "No PRs found in commit history since $PREV_TAG" >&2
+  echo "[]" > "$OUTPUT_FILE"
+  echo "Wrote 0 PRs to $OUTPUT_FILE" >&2
+  exit 0
+fi
+
+PR_COUNT=$(echo "$PR_NUMBERS" | wc -l | tr -d ' ')
+echo "Found $PR_COUNT PRs in commit history since $PREV_TAG" >&2
+
+# Fetch PR details via GitHub GraphQL API in batches of 100
+fetch_prs_batch() {
+  local numbers=("$@")
+  local query="query {"
+  for n in "${numbers[@]}"; do
+    query+=" pr_${n}: repository(owner: \"bitwarden\", name: \"clients\") { pullRequest(number: ${n}) { number title labels(first: 20) { nodes { name } } author { login } } }"
+  done
+  query+=" }"
+
+  local result
+  result=$(gh api graphql -f query="$query" 2>&1) || {
+    echo "Error: Failed to fetch PR details from GitHub: $result" >&2
+    exit 1
+  }
+
+  echo "$result" | jq '[.data | to_entries[].value.pullRequest | { number, title, labels: [.labels.nodes[] | {name}], author }]'
+}
+
+PRS="[]"
+BATCH=()
+while IFS= read -r num; do
+  BATCH+=("$num")
+  if [ "${#BATCH[@]}" -ge 100 ]; then
+    BATCH_RESULT=$(fetch_prs_batch "${BATCH[@]}")
+    PRS=$(jq -s '.[0] + .[1]' <(echo "$PRS") <(echo "$BATCH_RESULT"))
+    BATCH=()
+  fi
+done <<< "$PR_NUMBERS"
+
+# Flush remaining batch
+if [ "${#BATCH[@]}" -gt 0 ]; then
+  BATCH_RESULT=$(fetch_prs_batch "${BATCH[@]}")
+  PRS=$(jq -s '.[0] + .[1]' <(echo "$PRS") <(echo "$BATCH_RESULT"))
+fi
+
+echo "$PRS" > "$OUTPUT_FILE"
+echo "Wrote $(echo "$PRS" | jq 'length') PRs to $OUTPUT_FILE" >&2

--- a/.github/scripts/generate-release-notes.sh
+++ b/.github/scripts/generate-release-notes.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# Generates per-client release notes by filtering merged PRs by client label.
+# Usage: ./generate-release-notes.sh <client> <release_config>
+# Example: ./generate-release-notes.sh web ../release.yml
+#
+# Requirements: gh (authenticated), jq, yq, git (with tags fetched)
+
+set -euo pipefail
+
+CLIENT="${1:?Usage: $0 <client> (web, browser, desktop, cli)}"
+
+# Internal variables that can be overridden for testing
+GH_REPO="bitwarden/clients"
+RELEASE_CONFIG_PATH=".github/release.yml"
+TARGET_TAG="HEAD"
+
+# Override for testing — comment out for normal use
+PREV_TAG="${CLIENT}-v2026.4.0"
+TARGET_TAG="${CLIENT}-v2026.5.0"
+
+# Parse .github/release.yml into JSON for use by jq
+RELEASE_CONFIG=$(yq -o=json '.changelog' "$RELEASE_CONFIG_PATH") || {
+  echo "Error: Failed to parse release config from $RELEASE_CONFIG_PATH" >&2
+  exit 1
+}
+
+# Find the most recent tag for this client
+if [ -z "${PREV_TAG:-}" ]; then
+  PREV_TAG=$(git tag -l --sort=-authordate | grep "^${CLIENT}-v" | head -n 1)
+fi
+
+if [ -z "$PREV_TAG" ]; then
+  echo "No previous tag found for client '${CLIENT}'" >&2
+  exit 1
+fi
+
+echo "Previous tag: $PREV_TAG" >&2
+
+# Extract PR numbers from commit messages between the previous tag and HEAD.
+# This ensures we only capture PRs whose commits are actually on this branch,
+# rather than all PRs merged after a date (which could include other branches).
+PR_NUMBERS=$(git log "${PREV_TAG}..${TARGET_TAG}" --oneline | grep -oE '\(#[0-9]+\)' | grep -oE '[0-9]+' | sort -u)
+
+if [ -z "$PR_NUMBERS" ]; then
+  echo "No PRs found in commit history since $PREV_TAG" >&2
+  echo "No changes for this release."
+  exit 0
+fi
+
+PR_COUNT=$(echo "$PR_NUMBERS" | wc -l | tr -d ' ')
+echo "Found $PR_COUNT PRs in commit history since $PREV_TAG" >&2
+
+# Fetch PR details via GitHub GraphQL API in batches
+# (GitHub GraphQL queries have a complexity limit, so we batch by 100)
+fetch_prs_batch() {
+  local numbers=("$@")
+  local query="query {"
+  for n in "${numbers[@]}"; do
+    query+=" pr_${n}: repository(owner: \"bitwarden\", name: \"clients\") { pullRequest(number: ${n}) { number title labels(first: 20) { nodes { name } } author { login } } }"
+  done
+  query+=" }"
+
+  local result
+  result=$(gh api graphql -f query="$query" 2>&1) || {
+    echo "Error: Failed to fetch PR details from GitHub: $result" >&2
+    exit 1
+  }
+
+  # Normalize GraphQL response to match the previous JSON structure:
+  # [ { number, title, labels: [{name}], author: {login} } ]
+  echo "$result" | jq '[.data | to_entries[].value.pullRequest | { number, title, labels: [.labels.nodes[] | {name}], author }]'
+}
+
+PRS="[]"
+BATCH=()
+while IFS= read -r num; do
+  BATCH+=("$num")
+  if [ "${#BATCH[@]}" -ge 100 ]; then
+    BATCH_RESULT=$(fetch_prs_batch "${BATCH[@]}")
+    PRS=$(jq -s '.[0] + .[1]' <(echo "$PRS") <(echo "$BATCH_RESULT"))
+    BATCH=()
+  fi
+done <<< "$PR_NUMBERS"
+
+# Flush remaining batch
+if [ "${#BATCH[@]}" -gt 0 ]; then
+  BATCH_RESULT=$(fetch_prs_batch "${BATCH[@]}")
+  PRS=$(jq -s '.[0] + .[1]' <(echo "$PRS") <(echo "$BATCH_RESULT"))
+fi
+
+echo "Fetched details for $(echo "$PRS" | jq 'length') PRs" >&2
+
+# Filter and categorize PRs using the release.yml config
+MARKDOWN=$(jq -r -n \
+  --arg client "$CLIENT" \
+  --argjson config "$RELEASE_CONFIG" \
+  --argjson prs "$PRS" '
+
+  ($config.exclude.labels // []) as $exclude_labels |
+  ($config.categories // []) as $categories |
+
+  # Filter out PRs with excluded labels
+  [ $prs[] | select(.labels | map(.name) | any(. as $l | $exclude_labels | index($l)) | not) ] |
+
+  # Filter by client label: if a PR has any client label, it must match the current client
+  ["web", "browser", "desktop", "cli"] as $client_labels |
+  [ .[] | select(
+    (.labels | map(.name)) as $pr_labels |
+    ($pr_labels | any(. as $l | $client_labels | index($l))) as $has_client_label |
+    if $has_client_label then ($pr_labels | index($client) != null)
+    else true
+    end
+  ) ] |
+
+  # Iterate categories in order, assign each PR to first matching category
+  . as $filtered_prs |
+  reduce ($categories | to_entries[]) as $entry (
+    { used: [], sections: [] };
+    .used as $used_numbers |
+    $entry.value as $cat |
+    [
+      $filtered_prs[] |
+      select(.number as $n | $used_numbers | index($n) | not) |
+      select(
+        ($cat.labels | index("*")) or
+        (.labels | map(.name) | any(. as $l | $cat.labels | index($l)))
+      )
+    ] as $matched |
+    .sections += [{ title: $cat.title, prs: $matched }] |
+    .used += [ $matched[].number ]
+  ) |
+
+  # Render markdown, skip empty sections
+  [ .sections[] | select(.prs | length > 0) |
+    "### \(.title)\n" + (
+    [ .prs[] | "- \(.title) by @\(.author.login) in [#\(.number)](https://github.com/bitwarden/clients/pull/\(.number))" ] | join("\n")
+    )
+  ] | join("\n\n")
+  ')
+
+OUTPUT_FILE="${CLIENT}-release-notes.md"
+
+if [ -z "$MARKDOWN" ]; then
+  echo "No changes for this release."
+else
+  echo "$MARKDOWN" | tee "$OUTPUT_FILE"
+fi
+
+echo "Release notes written to $OUTPUT_FILE" >&2

--- a/.github/scripts/label-pr.py
+++ b/.github/scripts/label-pr.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+# Requires Python 3.9+
+"""
+Label pull requests based on changed file paths and PR title patterns (conventional commit format).
+
+Usage:
+    python label-pr.py <pr-number> <pr-labels> [-a|--add|-r|--replace] [-d|--dry-run] [-c|--config CONFIG]
+
+Arguments:
+    pr-number: The pull request number
+    pr-labels: Current PR labels as JSON array string
+    -a, --add: Add labels without removing existing ones (default)
+    -r, --replace: Replace all existing labels
+    -d, --dry-run: Run without actually applying labels
+    -c, --config: Path to JSON config file (default: .github/label-pr.json)
+
+Examples:
+    python label-pr.py 1234 '[]'
+    python label-pr.py 1234 '[{"name":"label1"}]' -a
+    python label-pr.py 1234 '[{"name":"label1"}]' --replace
+    python label-pr.py 1234 '[{"name":"label1"}]' -r -d
+    python label-pr.py 1234 '[]' --config custom-config.json
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+
+DEFAULT_MODE = "add"
+DEFAULT_CONFIG_PATH = ".github/label-pr.json"
+
+def load_config_json(config_file: str) -> dict:
+    """Load configuration from JSON file."""
+    if not os.path.exists(config_file):
+        print(f"\u274c Config file not found: {config_file}")
+        sys.exit(1)
+
+    try:
+        with open(config_file, "r") as f:
+            config = json.load(f)
+            print(f"\u2705 Loaded config from: {config_file}")
+
+            valid_config = True
+            if not config.get("title_patterns"):
+                print("\u274c Missing 'title_patterns' in config file")
+                valid_config = False
+            if not config.get("path_patterns"):
+                print("\u274c Missing 'path_patterns' in config file")
+                valid_config = False
+
+            if not valid_config:
+                print("::error::Invalid label-pr.json config file, exiting...")
+                sys.exit(1)
+
+            return config
+    except json.JSONDecodeError as e:
+        print(f"\u274c JSON deserialization error in label-pr.json config: {e}")
+        sys.exit(1)
+    except Exception as e:
+        print(f"\u274c Unexpected error loading label-pr.json config: {e}")
+        sys.exit(1)
+
+def gh_get_changed_files(pr_number: str) -> list[str]:
+    """Get list of changed files in a pull request."""
+    try:
+        result = subprocess.run(
+            ["gh", "pr", "diff", pr_number, "--name-only"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        changed_files = result.stdout.strip().split("\n")
+        return list(filter(None, changed_files))
+    except subprocess.CalledProcessError as e:
+        print(f"::error::Error getting changed files: {e}")
+        return []
+
+def gh_get_pr_title(pr_number: str) -> str:
+    """Get the title of a pull request."""
+    try:
+        result = subprocess.run(
+            ["gh", "pr", "view", pr_number, "--json", "title", "--jq", ".title"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return result.stdout.strip()
+    except subprocess.CalledProcessError as e:
+        print(f"::error::Error getting PR title: {e}")
+        return ""
+
+def gh_add_labels(pr_number: str, labels: list[str]) -> None:
+    """Add labels to a pull request (doesn't remove existing labels)."""
+    gh_labels = ",".join(labels)
+    subprocess.run(
+        ["gh", "pr", "edit", pr_number, "--add-label", gh_labels],
+        check=True,
+    )
+
+def gh_replace_labels(pr_number: str, labels: list[str]) -> None:
+    """Replace all labels on a pull request with the specified labels."""
+    payload = json.dumps({"labels": labels})
+    subprocess.run(
+        ["gh", "api", "repos/{owner}/{repo}/issues/" + pr_number, "-X", "PATCH", "--silent", "--input", "-"],
+        input=payload,
+        text=True,
+        check=True,
+    )
+
+def file_matches_patterns(file: str, patterns: list[str]) -> bool:
+    """Check if a file matches the pattern list using .gitignore-style negation.
+
+    Patterns are evaluated in order:
+    - Regular patterns (e.g. "libs/") include files starting with that prefix.
+    - Negation patterns (e.g. "!libs/angular/") exclude previously matched files.
+
+    The last matching pattern wins, just like .gitignore.
+    """
+    matched = False
+    for pattern in patterns:
+        if pattern.startswith("!"):
+            if file.startswith(pattern[1:]):
+                matched = False
+        else:
+            if file.startswith(pattern):
+                matched = True
+    return matched
+
+def label_filepaths(changed_files: list[str], path_patterns: dict) -> list[str]:
+    """Check changed files against path patterns and return labels to apply."""
+    if not changed_files:
+        return []
+
+    labels_to_apply = set()  # Use set to avoid duplicates
+
+    for label, patterns in path_patterns.items():
+        for file in changed_files:
+            if file_matches_patterns(file, patterns):
+                print(f"\U0001f436 File '{file}' matches pattern for label '{label}'")
+                labels_to_apply.add(label)
+                break
+
+    if "app:shared" in labels_to_apply:
+        labels_to_apply.add("app:password-manager")
+        labels_to_apply.add("app:authenticator")
+        labels_to_apply.remove("app:shared")
+
+    if not labels_to_apply:
+        print("::notice::No matching file paths found.")
+
+    return list(labels_to_apply)
+
+def label_title(pr_title: str, title_patterns: dict) -> list[str]:
+    """Check PR title against patterns and return labels to apply."""
+    if not pr_title:
+        return []
+
+    labels_to_apply = set()
+    title_lower = pr_title.lower()
+    for label, patterns in title_patterns.items():
+        for pattern in patterns:
+            # Check for pattern with : or ( suffix (conventional commits format)
+            if f"{pattern}:" in title_lower or f"{pattern}(" in title_lower:
+                print(f"\U0001f4cb Title matches pattern '{pattern}' for label '{label}'")
+                labels_to_apply.add(label)
+                break
+
+    if not labels_to_apply:
+        print("::notice::No matching title patterns found.")
+
+    return list(labels_to_apply)
+
+def parse_pr_labels(pr_labels_str: str) -> list[str]:
+    """Parse PR labels from JSON array string."""
+    try:
+        labels = json.loads(pr_labels_str)
+        if not isinstance(labels, list):
+            print("::warning::Failed to parse PR labels: not a list")
+            return []
+        return [item.get("name") for item in labels if item.get("name")]
+    except (json.JSONDecodeError, TypeError) as e:
+        print(f"::error::Error parsing PR labels: {e}")
+        return []
+
+def get_preserved_labels(pr_labels_str: str) -> list[str]:
+    """Get existing PR labels that should be preserved (exclude app: and t: labels)."""
+    existing_labels = parse_pr_labels(pr_labels_str)
+    print(f"\U0001f50d Parsed PR labels: {existing_labels}")
+    preserved_labels = [label for label in existing_labels if not (label.startswith("app:") or label.startswith("t:"))]
+    if preserved_labels:
+        print(f"\U0001f50d Preserving existing labels: {', '.join(preserved_labels)}")
+    return preserved_labels
+
+def parse_args():
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Label pull requests based on changed file paths and PR title patterns."
+    )
+
+    parser.add_argument(
+        "pr_number",
+        help="The pull request number",
+    )
+
+    parser.add_argument(
+        "pr_labels",
+        help="Current PR labels (JSON array)",
+    )
+    
+    mode_group = parser.add_mutually_exclusive_group()
+    mode_group.add_argument(
+        "-a",
+        "--add",
+        action="store_true",
+        help="Add labels without removing existing ones (default)",
+    )
+    mode_group.add_argument(
+        "-r",
+        "--replace",
+        action="store_true",
+        help="Replace all existing labels",
+    )
+
+    parser.add_argument(
+        "-d",
+        "--dry-run",
+        action="store_true",
+        help="Run without actually applying labels",
+    )
+
+    parser.add_argument(
+        "-c",
+        "--config",
+        default=DEFAULT_CONFIG_PATH,
+        help=f"Path to JSON config file (default: {DEFAULT_CONFIG_PATH})",
+    )
+
+    args, unknown = parser.parse_known_args()  # required to handle --dry-run passed as an empty string ("") by the workflow
+    return args
+
+def main():
+    args = parse_args()
+    config = load_config_json(args.config)
+    LABEL_TITLE_PATTERNS = config["title_patterns"]
+    LABEL_PATH_PATTERNS = config["path_patterns"]
+
+    pr_number = args.pr_number
+    mode = "replace" if args.replace else "add"
+
+    if args.dry_run:
+        print("\U0001f50d DRY RUN MODE \u2013 Labels will not be applied")
+    print(f"\U0001f680 Labeling mode: {mode}")
+    print(f"\U0001f50d Checking PR #{pr_number}...")
+
+    pr_title = gh_get_pr_title(pr_number)
+    print(f"\U0001f4cb PR Title: {pr_title}\n")
+
+    changed_files = gh_get_changed_files(pr_number)
+    print("\U0001f436 Changed files:\n" + "\n".join(changed_files) + "\n")
+
+    filepath_labels = label_filepaths(changed_files, LABEL_PATH_PATTERNS)
+    title_labels = label_title(pr_title, LABEL_TITLE_PATTERNS)
+    all_labels = set(filepath_labels + title_labels)
+
+    if all_labels:
+        print("----------------------------------------")
+        labels_str = ", ".join(sorted(all_labels))
+        if mode == "add":
+            print(f"::notice::\U0001f4cb Adding labels: {labels_str}")
+            if not args.dry_run:
+                gh_add_labels(pr_number, list(all_labels))
+        else:
+            preserved_labels = get_preserved_labels(args.pr_labels)
+            if preserved_labels:
+                all_labels.update(preserved_labels)
+            labels_str = ", ".join(sorted(all_labels))
+            print(f"::notice::\U0001f4cb Replacing labels with: {labels_str}")
+            if not args.dry_run:
+                gh_replace_labels(pr_number, list(all_labels))
+    else:
+        print("::warning::No matching patterns found, no labels applied.")
+
+    print("\u2705 Done")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Scripts to support labeling PRs and generating release notes for the clients (browser, cli, desktop, web)
- `fetch-release-prs.sh`
  - Retrieves all PRs between two tags and saves them in a json file
- `batch-label-prs.sh`
  - Takes the output from fetch-release-prs.sh and passes it to label-pr.py
- `label-pr.py`
  - Retrieves PRs with title and changed files and applies labels based on label-pr.json
- `generate-release-notes.sh`
  - Retrieves all PR between two tags and based on the labels on the PRs categorizes them based on release.yml and generates the release notes for the requested client (browser, cli, desktop, web)
 