### PR TITLE
[PM-38621] Fix desktop settings dialog saving stale form values

### DIFF
--- a/apps/desktop/src/app/accounts/settings-dialog.component.spec.ts
+++ b/apps/desktop/src/app/accounts/settings-dialog.component.spec.ts
@@ -30,6 +30,7 @@ import { AccountService } from "@bitwarden/common/auth/abstractions/account.serv
 import { UserVerificationService } from "@bitwarden/common/auth/abstractions/user-verification/user-verification.service.abstraction";
 import { AutofillSettingsServiceAbstraction } from "@bitwarden/common/autofill/services/autofill-settings.service";
 import { DomainSettingsService } from "@bitwarden/common/autofill/services/domain-settings.service";
+import { ClearClipboardDelaySetting } from "@bitwarden/common/autofill/types";
 import { BillingAccountProfileStateService } from "@bitwarden/common/billing/abstractions";
 import { DeviceType } from "@bitwarden/common/enums";
 import { PinServiceAbstraction } from "@bitwarden/common/key-management/pin/pin.service.abstraction";
@@ -914,6 +915,50 @@ describe("SettingsDialogComponent", () => {
 
       // `showEnableAutotype` signal should be false
       expect((component as any).showEnableAutotype()).toBe(false);
+    });
+  });
+
+  describe("clearClipboard valueChanges", () => {
+    it("saves the new clear clipboard value when changed", async () => {
+      await component.ngOnInit();
+
+      component["form"].controls.clearClipboard.setValue(ClearClipboardDelaySetting.ThirtySeconds);
+
+      expect(autofillSettingsServiceAbstraction.setClearClipboardDelay).toHaveBeenLastCalledWith(
+        ClearClipboardDelaySetting.ThirtySeconds,
+      );
+    });
+  });
+
+  describe("sshAgentPromptBehavior valueChanges", () => {
+    it("saves the new ssh agent prompt behavior value when changed", async () => {
+      await component.ngOnInit();
+
+      component["form"].controls.sshAgentPromptBehavior.setValue(SshAgentPromptType.Never);
+
+      expect(desktopSettingsService.setSshAgentPromptBehavior).toHaveBeenLastCalledWith(
+        SshAgentPromptType.Never,
+      );
+    });
+  });
+
+  describe("theme valueChanges", () => {
+    it("saves the new theme value when changed", async () => {
+      await component.ngOnInit();
+
+      component["form"].controls.theme.setValue(ThemeType.Dark);
+
+      expect(themeStateService.setSelectedTheme).toHaveBeenLastCalledWith(ThemeType.Dark);
+    });
+  });
+
+  describe("locale valueChanges", () => {
+    it("saves the new locale value when changed", async () => {
+      await component.ngOnInit();
+
+      component["form"].controls.locale.setValue("fr");
+
+      expect(i18nService.setLocale).toHaveBeenLastCalledWith("fr");
     });
   });
 });

--- a/apps/desktop/src/app/accounts/settings-dialog.component.spec.ts
+++ b/apps/desktop/src/app/accounts/settings-dialog.component.spec.ts
@@ -28,9 +28,9 @@ import { PolicyType } from "@bitwarden/common/admin-console/enums";
 import { Policy } from "@bitwarden/common/admin-console/models/domain/policy";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { UserVerificationService } from "@bitwarden/common/auth/abstractions/user-verification/user-verification.service.abstraction";
+import { ClearClipboardDelay } from "@bitwarden/common/autofill/constants";
 import { AutofillSettingsServiceAbstraction } from "@bitwarden/common/autofill/services/autofill-settings.service";
 import { DomainSettingsService } from "@bitwarden/common/autofill/services/domain-settings.service";
-import { ClearClipboardDelaySetting } from "@bitwarden/common/autofill/types";
 import { BillingAccountProfileStateService } from "@bitwarden/common/billing/abstractions";
 import { DeviceType } from "@bitwarden/common/enums";
 import { PinServiceAbstraction } from "@bitwarden/common/key-management/pin/pin.service.abstraction";
@@ -922,10 +922,10 @@ describe("SettingsDialogComponent", () => {
     it("saves the new clear clipboard value when changed", async () => {
       await component.ngOnInit();
 
-      component["form"].controls.clearClipboard.setValue(ClearClipboardDelaySetting.ThirtySeconds);
+      component["form"].controls.clearClipboard.setValue(ClearClipboardDelay.ThirtySeconds);
 
       expect(autofillSettingsServiceAbstraction.setClearClipboardDelay).toHaveBeenLastCalledWith(
-        ClearClipboardDelaySetting.ThirtySeconds,
+        ClearClipboardDelay.ThirtySeconds,
       );
     });
   });

--- a/apps/desktop/src/app/accounts/settings-dialog.component.ts
+++ b/apps/desktop/src/app/accounts/settings-dialog.component.ts
@@ -17,6 +17,7 @@ import { getUserId } from "@bitwarden/common/auth/services/account.service";
 import { ClearClipboardDelay } from "@bitwarden/common/autofill/constants";
 import { AutofillSettingsServiceAbstraction } from "@bitwarden/common/autofill/services/autofill-settings.service";
 import { DomainSettingsService } from "@bitwarden/common/autofill/services/domain-settings.service";
+import { ClearClipboardDelaySetting } from "@bitwarden/common/autofill/types";
 import { BillingAccountProfileStateService } from "@bitwarden/common/billing/abstractions";
 import { DeviceType } from "@bitwarden/common/enums";
 import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
@@ -364,28 +365,28 @@ export class SettingsDialogComponent implements OnInit {
 
     this.form.controls.clearClipboard.valueChanges
       .pipe(
-        concatMap(async () => this.saveClearClipboard()),
+        concatMap(async (value: ClearClipboardDelaySetting) => this.saveClearClipboard(value)),
         takeUntilDestroyed(this.destroyRef),
       )
       .subscribe();
 
     this.form.controls.sshAgentPromptBehavior.valueChanges
       .pipe(
-        concatMap(async () => this.saveSshAgentPromptBehavior()),
+        concatMap(async (value: SshAgentPromptType) => this.saveSshAgentPromptBehavior(value)),
         takeUntilDestroyed(this.destroyRef),
       )
       .subscribe();
 
     this.form.controls.theme.valueChanges
       .pipe(
-        concatMap(async () => this.saveTheme()),
+        concatMap(async (value: Theme) => this.saveTheme(value)),
         takeUntilDestroyed(this.destroyRef),
       )
       .subscribe();
 
     this.form.controls.locale.valueChanges
       .pipe(
-        concatMap(async () => this.saveLocale()),
+        concatMap(async (value: string) => this.saveLocale(value)),
         takeUntilDestroyed(this.destroyRef),
       )
       .subscribe();
@@ -595,12 +596,12 @@ export class SettingsDialogComponent implements OnInit {
     this.messagingService.send(this.form.value.enableTray ? "showTray" : "removeTray");
   }
 
-  protected async saveLocale() {
-    await this.i18nService.setLocale(this.form.value.locale);
+  private async saveLocale(newValue: string) {
+    await this.i18nService.setLocale(newValue);
   }
 
-  protected async saveTheme() {
-    await this.themeStateService.setSelectedTheme(this.form.value.theme);
+  private async saveTheme(newValue: Theme) {
+    await this.themeStateService.setSelectedTheme(newValue);
   }
 
   protected async saveMinOnCopyToClipboard() {
@@ -610,8 +611,8 @@ export class SettingsDialogComponent implements OnInit {
     );
   }
 
-  protected async saveClearClipboard() {
-    await this.autofillSettingsService.setClearClipboardDelay(this.form.value.clearClipboard);
+  private async saveClearClipboard(newValue: ClearClipboardDelaySetting) {
+    await this.autofillSettingsService.setClearClipboardDelay(newValue);
   }
 
   protected async saveAlwaysShowDock() {
@@ -703,10 +704,8 @@ export class SettingsDialogComponent implements OnInit {
     await this.desktopSettingsService.setSshAgentEnabled(this.form.value.enableSshAgent);
   }
 
-  protected async saveSshAgentPromptBehavior() {
-    await this.desktopSettingsService.setSshAgentPromptBehavior(
-      this.form.value.sshAgentPromptBehavior,
-    );
+  private async saveSshAgentPromptBehavior(newValue: SshAgentPromptType) {
+    await this.desktopSettingsService.setSshAgentPromptBehavior(newValue);
   }
 
   protected async savePreventScreenshots() {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-38621](https://bitwarden.atlassian.net/browse/PM-38621)

## 📔 Objective

Fixes a bug in the desktop settings dialog where form control `valueChanges` subscriptions were using `this.form.value.<control>` to get the current value instead of receiving the new value directly from the observable stream.

When a `valueChanges` observable emits, accessing `this.form.value` may not yet reflect the updated value due to Angular's change detection timing. This could cause settings to be saved with stale values.

## 📸 Screenshots

<video src="https://github.com/user-attachments/assets/b6c6b8ed-5453-4374-bcb1-e5f785445996" />

[PM-38621]: https://bitwarden.atlassian.net/browse/PM-38621?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ