### PR TITLE
[PM-38787] Pin vault bulk-actions bar to the viewport on scroll

### DIFF
--- a/libs/components/src/layout/index.ts
+++ b/libs/components/src/layout/index.ts
@@ -1,2 +1,3 @@
 export * from "./layout.component";
+export * from "./layout-footer.service";
 export * from "./scroll-layout.directive";

--- a/libs/components/src/layout/layout-footer.service.ts
+++ b/libs/components/src/layout/layout-footer.service.ts
@@ -1,0 +1,27 @@
+import { Portal } from "@angular/cdk/portal";
+import { Injectable, signal } from "@angular/core";
+
+/**
+ * Hosts content pinned to the bottom of the layout's main content area — e.g. a
+ * bulk-actions bar.
+ *
+ * The layout renders this portal in a region that overlaps `<main>` but sits outside its
+ * scroll container, so the content stays pinned to the viewport while `<main>` scrolls and is
+ * horizontally aligned to the main content column. Consumers attach a `TemplatePortal` /
+ * `ComponentPortal` and detach it on destroy.
+ */
+@Injectable({ providedIn: "root" })
+export class LayoutFooterService {
+  /** The portal to display in the layout footer region. */
+  readonly portal = signal<Portal<unknown> | undefined>(undefined);
+
+  attach(portal: Portal<unknown>) {
+    this.portal.set(portal);
+  }
+
+  detach(portal: Portal<unknown>) {
+    if (portal === this.portal()) {
+      this.portal.set(undefined);
+    }
+  }
+}

--- a/libs/components/src/layout/layout.component.html
+++ b/libs/components/src/layout/layout.component.html
@@ -55,6 +55,16 @@
     <ng-content></ng-content>
   </main>
 
+  <!-- Footer region (always col 2): overlaps <main> but is a sibling of it — outside the
+       `cdk-virtual-scrollable` scroll container — so pinned content (e.g. a bulk-actions bar)
+       stays fixed to the viewport while <main> scrolls. `tw-contain-layout` makes this the
+       containing block for `position: fixed` content; unlike <main> this element never scrolls,
+       so it doesn't re-introduce scroll-with-content. Grid keeps it aligned to the main column,
+       and `pointer-events-none` lets clicks through to <main> (projected content opts back in). -->
+  <div class="tw-col-start-2 tw-row-start-1 tw-z-50 tw-contain-layout tw-pointer-events-none">
+    <ng-template [cdkPortalOutlet]="footerPortal()"></ng-template>
+  </div>
+
   <!-- Overlay backdrop for side-nav (fixed, z-40 — below nav overlay z-50) -->
   <div
     class="tw-pointer-events-none tw-fixed tw-inset-0 tw-z-40 tw-bg-black tw-bg-opacity-0 motion-safe:tw-transition-colors"

--- a/libs/components/src/layout/layout.component.ts
+++ b/libs/components/src/layout/layout.component.ts
@@ -23,6 +23,7 @@ import { LinkComponent, LinkModule } from "../link";
 import { SideNavService } from "../navigation/side-nav.service";
 import { getRootFontSizePx } from "../shared";
 
+import { LayoutFooterService } from "./layout-footer.service";
 import { ScrollLayoutHostDirective } from "./scroll-layout.directive";
 
 /** Matches tw-min-w-96 on <main>. */
@@ -56,6 +57,7 @@ export class LayoutComponent {
   protected sideNavService = inject(SideNavService);
   private readonly drawerService = inject(DrawerService);
   protected drawerPortal = this.drawerService.portal;
+  protected footerPortal = inject(LayoutFooterService).portal;
 
   /** Rendered only when nothing is projected into the side-nav slot (ng-content fallback). */
   private readonly sideNavSlotFallback = viewChild<ElementRef>("sideNavSlotFallback");

--- a/libs/vault/src/components/vault-batch-bar/vault-batch-action.component.html
+++ b/libs/vault/src/components/vault-batch-bar/vault-batch-action.component.html
@@ -1,13 +1,23 @@
-<bit-bulk-actions-bar [selectedCount]="service.selectedCount()" (clear)="service.selection.clear()">
-  @for (action of primaryActions(); track action.label) {
-    <bit-bulk-action [action]="action.action" [icon]="action.icon" [label]="action.label" />
-  }
+<!--
+  Rendered through a CDK overlay (see the component) so the fixed-position bar pins to
+  the viewport. Hosting it inline would place it inside the layout's `cdk-virtual-scrollable`
+  <main>, whose `contain: strict` establishes a containing block that traps `position: fixed`.
+-->
+<ng-template #barPortal>
+  <bit-bulk-actions-bar
+    [selectedCount]="service.selectedCount()"
+    (clear)="service.selection.clear()"
+  >
+    @for (action of primaryActions(); track action.label) {
+      <bit-bulk-action [action]="action.action" [icon]="action.icon" [label]="action.label" />
+    }
 
-  @for (action of overflowActions(); track action.label) {
-    <bit-bulk-additional-action
-      [action]="action.action"
-      [icon]="action.icon"
-      [label]="action.label"
-    />
-  }
-</bit-bulk-actions-bar>
+    @for (action of overflowActions(); track action.label) {
+      <bit-bulk-additional-action
+        [action]="action.action"
+        [icon]="action.icon"
+        [label]="action.label"
+      />
+    }
+  </bit-bulk-actions-bar>
+</ng-template>

--- a/libs/vault/src/components/vault-batch-bar/vault-batch-action.component.ts
+++ b/libs/vault/src/components/vault-batch-bar/vault-batch-action.component.ts
@@ -1,4 +1,16 @@
-import { ChangeDetectionStrategy, Component, computed, inject } from "@angular/core";
+import { TemplatePortal } from "@angular/cdk/portal";
+import {
+  ChangeDetectionStrategy,
+  Component,
+  OnDestroy,
+  TemplateRef,
+  ViewContainerRef,
+  afterNextRender,
+  computed,
+  inject,
+  signal,
+  viewChild,
+} from "@angular/core";
 
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import {
@@ -6,6 +18,7 @@ import {
   BulkActionsBarComponent,
   BulkActionComponent,
   BulkAdditionalActionComponent,
+  LayoutFooterService,
 } from "@bitwarden/components";
 
 import { VaultBatchBarService } from "../../services/vault-batch-bar.service";
@@ -29,9 +42,35 @@ const PRIMARY_ACTION_COUNT = 2;
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [BulkActionsBarComponent, BulkActionComponent, BulkAdditionalActionComponent],
 })
-export class VaultBatchActionComponent {
+export class VaultBatchActionComponent implements OnDestroy {
   protected readonly service = inject(VaultBatchBarService);
   private readonly i18nService = inject(I18nService);
+  private readonly viewContainerRef = inject(ViewContainerRef);
+  private readonly layoutFooter = inject(LayoutFooterService);
+
+  private readonly barPortal = viewChild.required<TemplateRef<unknown>>("barPortal");
+  private readonly portal = signal<TemplatePortal | null>(null);
+
+  constructor() {
+    // The bar is `position: fixed`, but it's used within the layout's `cdk-virtual-scrollable`
+    // <main>, whose `contain: strict` establishes a containing block — so `fixed` would resolve
+    // against <main> and scroll with its content instead of pinning to the viewport. Rendering
+    // it into the layout's footer region (a sibling of <main>, outside the scroll container)
+    // escapes that containing block while keeping the bar aligned to the main content column.
+    afterNextRender(() => {
+      const portal = new TemplatePortal(this.barPortal(), this.viewContainerRef);
+      this.portal.set(portal);
+      this.layoutFooter.attach(portal);
+    });
+  }
+
+  ngOnDestroy(): void {
+    const portal = this.portal();
+    if (portal != null) {
+      this.layoutFooter.detach(portal);
+      this.portal.set(null);
+    }
+  }
 
   /** Builds the ordered list of actions the current selection is permitted to perform. */
   private readonly visibleActions = computed<ActionDescriptor[]>(() => {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-38787](https://bitwarden.atlassian.net/browse/PM-38787)

## 📔 Objective

The bulk-actions bar (`bit-vault-batch-action`) didn't stay pinned to the bottom of the viewport — it scrolled away with the vault list.

**Root cause:** the bar is `position: fixed`, but the layout's `<main>` carries `cdk-virtual-scrollable`, whose `contain: strict` makes it a containing block for fixed descendants. So the bar resolved against `<main>` (the scroll container) instead of the viewport and scrolled with the content.

**Fix:** render the bar in a new `bit-layout` footer region — a sibling of `<main>` in the same grid cell but outside the scroll container — mirroring the existing `drawerPortal` pattern:
- `LayoutFooterService` holds a `Portal` signal that `LayoutComponent` renders via `cdkPortalOutlet`, this closely follows how the drawer service here but I'd appreciate any feedback of course!

## 📸 Screenshots

|Before|After|
|-|-|
|<video src="https://github.com/user-attachments/assets/c6b19145-6aba-4103-bc02-a2eb30f757d7" />|<video src="https://github.com/user-attachments/assets/7546d2cc-7064-47be-88be-eb0494d86706" />|

[PM-38787]: https://bitwarden.atlassian.net/browse/PM-38787?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ