### PR TITLE
[PM-38274] Fix help text in At-Risk drawers not appearing in Access Intelligence V2 path

### DIFF
--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/v2/shared/access-intelligence-drawer-v2/access-intelligence-drawer-v2.component.html
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/v2/shared/access-intelligence-drawer-v2/access-intelligence-drawer-v2.component.html
@@ -120,10 +120,8 @@
     </ng-container>
     <ng-container bitDialogContent>
       <span bitTypography="body1" class="tw-text-muted tw-text-sm">{{
-        (data.members?.length > 0
-          ? "criticalAtRiskMembersDescription"
-          : "criticalAtRiskMembersDescriptionNone"
-        ) | i18n
+        (data.members?.length > 0 ? "atRiskMemberDescription" : "atRiskMembersDescriptionNone")
+          | i18n
       }}</span>
 
       @if (data.members?.length > 0) {
@@ -166,8 +164,8 @@
     <ng-container bitDialogContent>
       <span bitTypography="body1" class="tw-text-muted tw-text-sm">{{
         (data.applications?.length > 0
-          ? "criticalAtRiskApplicationsDescription"
-          : "criticalAtRiskApplicationsDescriptionNone"
+          ? "atRiskApplicationsDescription"
+          : "atRiskApplicationsDescriptionNone"
         ) | i18n
       }}</span>
       @if (data.applications?.length > 0) {

--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/v2/shared/access-intelligence-drawer-v2/access-intelligence-drawer-v2.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/v2/shared/access-intelligence-drawer-v2/access-intelligence-drawer-v2.component.stories.ts
@@ -92,15 +92,6 @@ export default {
               atRiskApplicationsWithCount: "At-Risk Applications (__$1__)",
               atRiskApplicationsDescription: "Applications with at-risk passwords.",
               atRiskApplicationsDescriptionNone: "No at-risk applications found.",
-              criticalAtRiskMembersWithCount: "Critical At-Risk Members (__$1__)",
-              criticalAtRiskMembersDescription:
-                "Members with at-risk passwords in critical applications.",
-              criticalAtRiskMembersDescriptionNone:
-                "No at-risk members found in critical applications.",
-              criticalAtRiskApplicationsWithCount: "Critical At-Risk Applications (__$1__)",
-              criticalAtRiskApplicationsDescription:
-                "Critical applications with at-risk passwords.",
-              criticalAtRiskApplicationsDescriptionNone: "No at-risk critical applications found.",
               downloadCSV: "Download CSV",
               email: "Email",
               atRiskPasswords: "At-Risk Passwords",

--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/v2/shared/access-intelligence-drawer-v2/access-intelligence-drawer-v2.component.ts
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/v2/shared/access-intelligence-drawer-v2/access-intelligence-drawer-v2.component.ts
@@ -3,11 +3,11 @@ import { Component, ChangeDetectionStrategy, inject } from "@angular/core";
 import { DrawerType } from "@bitwarden/bit-common/dirt/access-intelligence/services";
 import { FileDownloadService } from "@bitwarden/common/platform/abstractions/file-download/file-download.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
-import { DIALOG_DATA } from "@bitwarden/components";
+import { DIALOG_DATA, DialogModule, LinkModule, TypographyModule } from "@bitwarden/components";
 import { LogService } from "@bitwarden/logging";
+import { I18nPipe } from "@bitwarden/ui-common";
 import { ExportHelper } from "@bitwarden/vault-export-core";
 import { exportToCSV } from "@bitwarden/web-vault/app/dirt/reports/report-utils";
-import { SharedModule } from "@bitwarden/web-vault/app/shared";
 
 import { DrawerContentData } from "../../models/drawer-content-data.types";
 
@@ -20,7 +20,7 @@ import { DrawerContentData } from "../../models/drawer-content-data.types";
  */
 @Component({
   selector: "dirt-access-intelligence-drawer-v2",
-  imports: [SharedModule],
+  imports: [DialogModule, TypographyModule, LinkModule, I18nPipe],
   templateUrl: "./access-intelligence-drawer-v2.component.html",
   changeDetection: ChangeDetectionStrategy.OnPush,
 })


### PR DESCRIPTION
## 🎟️ Tracking

[PM-38274](https://bitwarden.atlassian.net/browse/PM-38274)

## 📔 Objective

This pull request fixes the help text in **At-Risk drawers** in Access Intelligence not appearing while the feature flag `pm-31936-access-intelligence-new-architecture` is enabled. The fix was to correct the i18n keys to match the v1 version of the drawer.

**Changes**
- Corrected i18n keys in `AccessIntelligenceDrawerV2Component` template
- Removed obsolete keys from storybook
- ♻️ Removed `SharedModule` usage from `AccessIntelligenceDrawerV2Component`

## 📸 Screenshots

Drawers with help text:

<img width="386" height="203" alt="Screenshot 2026-06-09 at 1 51 24 PM" src="https://github.com/user-attachments/assets/552be19b-408e-40a7-a1cf-799b8d2959ec" />

<img width="413" height="171" alt="Screenshot 2026-06-09 at 1 51 15 PM" src="https://github.com/user-attachments/assets/ce254997-8ad2-4c7a-85a4-f2ca17cd56dc" />


[PM-38274]: https://bitwarden.atlassian.net/browse/PM-38274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ