### PR TITLE
[PM-38393] feat: Add feature flag to disable self-host premium check

### DIFF
--- a/libs/angular/src/billing/components/premium-upgrade-dialog/premium-upgrade-dialog.component.spec.ts
+++ b/libs/angular/src/billing/components/premium-upgrade-dialog/premium-upgrade-dialog.component.spec.ts
@@ -103,6 +103,7 @@ describe("PremiumUpgradeDialogComponent", () => {
 
     mockConfigService = {
       getFeatureFlag: jest.fn().mockResolvedValue(false),
+      getFeatureFlag$: jest.fn().mockReturnValue(of(false)),
     } as any;
 
     mockBillingApiService = {
@@ -195,7 +196,7 @@ describe("PremiumUpgradeDialogComponent", () => {
         expect(mockDialogRef.close).toHaveBeenCalled();
       });
 
-      it("should launch web vault URL on self-host even when flag is enabled", async () => {
+      it("should launch web vault URL on self-host when the checkout flag is enabled and the bypass flag is at its default", async () => {
         mockConfigService.getFeatureFlag.mockResolvedValue(true);
         mockEnvironmentService.environment$ = of({
           getWebVaultUrl: () => "https://self-hosted.example.com",
@@ -208,6 +209,62 @@ describe("PremiumUpgradeDialogComponent", () => {
         expect(mockBillingApiService.createPremiumCheckoutSession).not.toHaveBeenCalled();
         expect(mockPlatformUtilsService.launchUri).toHaveBeenCalledWith(
           "https://self-hosted.example.com/#/settings/subscription/premium?callToAction=upgradeToPremium",
+        );
+        expect(mockDialogRef.close).toHaveBeenCalled();
+      });
+    });
+
+    describe("QA self-host check bypass (PM38393_DisableSelfHostPremiumCheck)", () => {
+      beforeEach(() => {
+        mockConfigService.getFeatureFlag.mockResolvedValue(true);
+        mockEnvironmentService.environment$ = of({
+          getWebVaultUrl: () => "https://vault.qa.example.com",
+          getRegion: () => Region.SelfHosted,
+          isCloud: () => false,
+        }) as any;
+        mockBillingApiService.createPremiumCheckoutSession.mockResolvedValue({
+          checkoutSessionUrl: "https://checkout.stripe.com/c/pay/cs_123",
+        } as any);
+      });
+
+      it("should use the Stripe checkout flow on self-host when the bypass flag is enabled", async () => {
+        mockConfigService.getFeatureFlag$.mockReturnValue(of(true));
+
+        await component["upgrade"]();
+
+        expect(mockConfigService.getFeatureFlag$).toHaveBeenCalledWith(
+          FeatureFlag.PM38393_DisableSelfHostPremiumCheck,
+        );
+        expect(mockBillingApiService.createPremiumCheckoutSession).toHaveBeenCalledWith({
+          platform: "browser",
+        });
+        expect(mockPlatformUtilsService.launchUri).toHaveBeenCalledWith(
+          "https://checkout.stripe.com/c/pay/cs_123",
+        );
+        expect(mockDialogRef.close).toHaveBeenCalled();
+      });
+
+      it("should keep the web vault flow on self-host when the bypass flag is disabled", async () => {
+        mockConfigService.getFeatureFlag$.mockReturnValue(of(false));
+
+        await component["upgrade"]();
+
+        expect(mockBillingApiService.createPremiumCheckoutSession).not.toHaveBeenCalled();
+        expect(mockPlatformUtilsService.launchUri).toHaveBeenCalledWith(
+          "https://vault.qa.example.com/#/settings/subscription/premium?callToAction=upgradeToPremium",
+        );
+        expect(mockDialogRef.close).toHaveBeenCalled();
+      });
+
+      it("should not use the checkout flow when the bypass flag is enabled but the checkout flag is disabled", async () => {
+        mockConfigService.getFeatureFlag.mockResolvedValue(false);
+        mockConfigService.getFeatureFlag$.mockReturnValue(of(true));
+
+        await component["upgrade"]();
+
+        expect(mockBillingApiService.createPremiumCheckoutSession).not.toHaveBeenCalled();
+        expect(mockPlatformUtilsService.launchUri).toHaveBeenCalledWith(
+          "https://vault.qa.example.com/#/settings/subscription/premium?callToAction=upgradeToPremium",
         );
         expect(mockDialogRef.close).toHaveBeenCalled();
       });

--- a/libs/angular/src/billing/components/premium-upgrade-dialog/premium-upgrade-dialog.component.stories.ts
+++ b/libs/angular/src/billing/components/premium-upgrade-dialog/premium-upgrade-dialog.component.stories.ts
@@ -108,6 +108,7 @@ export default {
           provide: ConfigService,
           useValue: {
             getFeatureFlag: () => Promise.resolve(false),
+            getFeatureFlag$: () => of(false),
           },
         },
         {

--- a/libs/angular/src/billing/components/premium-upgrade-dialog/premium-upgrade-dialog.component.ts
+++ b/libs/angular/src/billing/components/premium-upgrade-dialog/premium-upgrade-dialog.component.ts
@@ -1,7 +1,7 @@
 import { CdkTrapFocus } from "@angular/cdk/a11y";
 import { CommonModule } from "@angular/common";
 import { ChangeDetectionStrategy, Component, signal } from "@angular/core";
-import { catchError, EMPTY, firstValueFrom, map, Observable } from "rxjs";
+import { catchError, EMPTY, firstValueFrom, map, Observable, of } from "rxjs";
 
 import { SubscriptionPricingCardDetails } from "@bitwarden/angular/billing/types/subscription-pricing-card-details";
 import { JslibModule } from "@bitwarden/angular/jslib.module";
@@ -14,6 +14,7 @@ import {
   PersonalSubscriptionPricingTierIds,
   SubscriptionCadenceIds,
 } from "@bitwarden/common/billing/types/subscription-pricing-tier";
+import { isPremiumCloudEnvironment$ } from "@bitwarden/common/billing/utils/premium-environment-utils";
 import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { EnvironmentService } from "@bitwarden/common/platform/abstractions/environment.service";
@@ -88,9 +89,12 @@ export class PremiumUpgradeDialogComponent {
       const checkoutFlagEnabled = await this.configService.getFeatureFlag(
         FeatureFlag.PM34515_BrowserDesktopCheckout,
       );
+      const isPremiumCloudEnvironment = await firstValueFrom(
+        isPremiumCloudEnvironment$(of(environment), this.configService),
+      );
       const platform = this.resolveCheckoutPlatform();
 
-      if (checkoutFlagEnabled && environment.isCloud() && platform != null) {
+      if (checkoutFlagEnabled && isPremiumCloudEnvironment && platform != null) {
         const { checkoutSessionUrl } = await this.billingApiService.createPremiumCheckoutSession({
           platform,
         });

--- a/libs/common/src/billing/services/subscription-pricing.service.spec.ts
+++ b/libs/common/src/billing/services/subscription-pricing.service.spec.ts
@@ -5,6 +5,7 @@ import { BillingApiServiceAbstraction } from "@bitwarden/common/billing/abstract
 import { PlanType, ProductTierType } from "@bitwarden/common/billing/enums";
 import { PlanResponse } from "@bitwarden/common/billing/models/response/plan.response";
 import { PremiumPlanResponse } from "@bitwarden/common/billing/models/response/premium-plan.response";
+import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import {
   EnvironmentService,
@@ -1034,6 +1035,71 @@ describe("DefaultSubscriptionPricingService", () => {
         expect(premiumTier?.passwordManager.features.length).toBeGreaterThan(0);
 
         done();
+      });
+    });
+
+    it("should call API and return prices for self-hosted when the QA self-host check bypass flag is enabled", (done) => {
+      const selfHostedBillingApiService = mock<BillingApiServiceAbstraction>();
+      const selfHostedConfigService = mock<ConfigService>();
+      const selfHostedEnvironmentService = mock<EnvironmentService>();
+
+      selfHostedBillingApiService.getPlans.mockResolvedValue(mockPlansResponse);
+      selfHostedBillingApiService.getPremiumPlan.mockResolvedValue(mockPremiumPlanResponse);
+      selfHostedConfigService.getFeatureFlag$.mockReturnValue(of(true));
+      setupEnvironmentService(selfHostedEnvironmentService, Region.SelfHosted);
+
+      const selfHostedService = new DefaultSubscriptionPricingService(
+        selfHostedBillingApiService,
+        selfHostedConfigService,
+        i18nService,
+        logService,
+        selfHostedEnvironmentService,
+      );
+
+      selfHostedService.getPersonalSubscriptionPricingTiers$().subscribe((tiers) => {
+        expect(selfHostedConfigService.getFeatureFlag$).toHaveBeenCalledWith(
+          FeatureFlag.PM38393_DisableSelfHostPremiumCheck,
+        );
+        expect(selfHostedBillingApiService.getPlans).toHaveBeenCalled();
+        expect(selfHostedBillingApiService.getPremiumPlan).toHaveBeenCalled();
+
+        const premiumTier = tiers.find((t) => t.id === PersonalSubscriptionPricingTierIds.Premium);
+        expect(premiumTier?.passwordManager.annualPrice).toBe(10);
+
+        done();
+      });
+    });
+
+    it("should fetch prices for self-hosted when the QA self-host check bypass flag turns on after initially being off", (done) => {
+      const selfHostedBillingApiService = mock<BillingApiServiceAbstraction>();
+      const selfHostedConfigService = mock<ConfigService>();
+      const selfHostedEnvironmentService = mock<EnvironmentService>();
+
+      selfHostedBillingApiService.getPlans.mockResolvedValue(mockPlansResponse);
+      selfHostedBillingApiService.getPremiumPlan.mockResolvedValue(mockPremiumPlanResponse);
+      // Simulates the flag resolving to its FALSE default before the server config arrives,
+      // then flipping to true once the QA-served config lands.
+      selfHostedConfigService.getFeatureFlag$.mockReturnValue(of(false, true));
+      setupEnvironmentService(selfHostedEnvironmentService, Region.SelfHosted);
+
+      const selfHostedService = new DefaultSubscriptionPricingService(
+        selfHostedBillingApiService,
+        selfHostedConfigService,
+        i18nService,
+        logService,
+        selfHostedEnvironmentService,
+      );
+
+      selfHostedService.getPersonalSubscriptionPricingTiers$().subscribe((tiers) => {
+        const premiumTier = tiers.find((t) => t.id === PersonalSubscriptionPricingTierIds.Premium);
+
+        // Earlier emissions reflect the flag-off stub values; the stream recovers once the
+        // flag turns on instead of caching the initial default forever.
+        if (premiumTier?.passwordManager.annualPrice === 10) {
+          expect(selfHostedBillingApiService.getPlans).toHaveBeenCalled();
+          expect(selfHostedBillingApiService.getPremiumPlan).toHaveBeenCalled();
+          done();
+        }
       });
     });
   });

--- a/libs/common/src/billing/services/subscription-pricing.service.ts
+++ b/libs/common/src/billing/services/subscription-pricing.service.ts
@@ -1,12 +1,12 @@
 import {
   combineLatest,
+  distinctUntilChanged,
   from,
   map,
   Observable,
   of,
   shareReplay,
   switchMap,
-  take,
   throwError,
 } from "rxjs";
 import { catchError } from "rxjs/operators";
@@ -29,6 +29,7 @@ import {
   PersonalSubscriptionPricingTierIds,
   SubscriptionCadenceIds,
 } from "../types/subscription-pricing-tier";
+import { isPremiumCloudEnvironment$ } from "../utils/premium-environment-utils";
 
 export class DefaultSubscriptionPricingService implements SubscriptionPricingServiceAbstraction {
   constructor(
@@ -42,7 +43,8 @@ export class DefaultSubscriptionPricingService implements SubscriptionPricingSer
   /**
    * Gets personal subscription pricing tiers (Premium and Families).
    * Throws any errors that occur during api request so callers must handle errors.
-   * Pricing information will be undefined if current environment is self-hosted.
+   * Pricing information will be undefined if the current environment is self-hosted, unless
+   * the internal QA self-host bypass flag is enabled — see {@link isPremiumCloudEnvironment$}.
    * @returns An observable of an array of personal subscription pricing tiers.
    * @throws Error if any errors occur during api request.
    */
@@ -57,7 +59,8 @@ export class DefaultSubscriptionPricingService implements SubscriptionPricingSer
   /**
    * Gets business subscription pricing tiers (Teams, Enterprise, and Custom).
    * Throws any errors that occur during api request so callers must handle errors.
-   * Pricing information will be undefined if current environment is self-hosted.
+   * Pricing information will be undefined if the current environment is self-hosted, unless
+   * the internal QA self-host bypass flag is enabled — see {@link isPremiumCloudEnvironment$}.
    * @returns An observable of an array of business subscription pricing tiers.
    * @throws Error if any errors occur during api request.
    */
@@ -72,7 +75,8 @@ export class DefaultSubscriptionPricingService implements SubscriptionPricingSer
   /**
    * Gets developer subscription pricing tiers (Free, Teams, and Enterprise).
    * Throws any errors that occur during api request so callers must handle errors.
-   * Pricing information will be undefined if current environment is self-hosted.
+   * Pricing information will be undefined if the current environment is self-hosted, unless
+   * the internal QA self-host bypass flag is enabled — see {@link isPremiumCloudEnvironment$}.
    * @returns An observable of an array of business subscription pricing tiers for developers.
    * @throws Error if any errors occur during api request.
    */
@@ -84,32 +88,37 @@ export class DefaultSubscriptionPricingService implements SubscriptionPricingSer
       }),
     );
 
+  // Shared and live (no take(1)): if the QA self-host bypass flag arrives after the first
+  // emission (e.g. the initial config fetch was slow), the pricing streams re-evaluate
+  // instead of caching the flag's default value for the lifetime of the service.
+  private isCloudEnvironment$: Observable<boolean> = isPremiumCloudEnvironment$(
+    this.environmentService.environment$,
+    this.configService,
+  ).pipe(distinctUntilChanged(), shareReplay({ bufferSize: 1, refCount: false }));
+
   private organizationPlansResponse$: Observable<ListResponse<PlanResponse>> =
-    this.environmentService.environment$.pipe(
-      take(1),
-      switchMap((environment) =>
-        !environment.isCloud()
+    this.isCloudEnvironment$.pipe(
+      switchMap((isCloudEnvironment) =>
+        !isCloudEnvironment
           ? of({ data: [] } as unknown as ListResponse<PlanResponse>)
           : from(this.billingApiService.getPlans()),
       ),
       shareReplay({ bufferSize: 1, refCount: false }),
     );
 
-  private premiumPlanResponse$: Observable<PremiumPlanResponse> =
-    this.environmentService.environment$.pipe(
-      take(1),
-      switchMap((environment) =>
-        !environment.isCloud()
-          ? of({ seat: undefined, storage: undefined } as unknown as PremiumPlanResponse)
-          : from(this.billingApiService.getPremiumPlan()).pipe(
-              catchError((error: unknown) => {
-                this.logService.error("Failed to fetch premium plan from API", error);
-                return throwError(() => error); // Re-throw to propagate to higher-level error handler
-              }),
-            ),
-      ),
-      shareReplay({ bufferSize: 1, refCount: false }),
-    );
+  private premiumPlanResponse$: Observable<PremiumPlanResponse> = this.isCloudEnvironment$.pipe(
+    switchMap((isCloudEnvironment) =>
+      !isCloudEnvironment
+        ? of({ seat: undefined, storage: undefined } as unknown as PremiumPlanResponse)
+        : from(this.billingApiService.getPremiumPlan()).pipe(
+            catchError((error: unknown) => {
+              this.logService.error("Failed to fetch premium plan from API", error);
+              return throwError(() => error); // Re-throw to propagate to higher-level error handler
+            }),
+          ),
+    ),
+    shareReplay({ bufferSize: 1, refCount: false }),
+  );
 
   private premium$: Observable<PersonalSubscriptionPricingTier> = this.premiumPlanResponse$.pipe(
     map((premiumPlan) => ({

--- a/libs/common/src/billing/utils/premium-environment-utils.spec.ts
+++ b/libs/common/src/billing/utils/premium-environment-utils.spec.ts
@@ -1,0 +1,83 @@
+import { mock, MockProxy } from "jest-mock-extended";
+import { firstValueFrom, Observable, of } from "rxjs";
+
+import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
+import { Environment } from "@bitwarden/common/platform/abstractions/environment.service";
+
+import { isPremiumCloudEnvironment$ } from "./premium-environment-utils";
+
+describe("isPremiumCloudEnvironment$", () => {
+  let environment$: Observable<Environment>;
+  let configService: MockProxy<ConfigService>;
+
+  const setup = (isCloud: boolean, disableSelfHostCheck: boolean) => {
+    configService = mock<ConfigService>();
+
+    environment$ = of({ isCloud: () => isCloud } as Environment);
+    configService.getFeatureFlag$.mockReturnValue(of(disableSelfHostCheck));
+  };
+
+  it("emits true for a cloud environment when the flag is disabled", async () => {
+    setup(true, false);
+
+    await expect(
+      firstValueFrom(isPremiumCloudEnvironment$(environment$, configService)),
+    ).resolves.toBe(true);
+  });
+
+  it("emits true for a cloud environment when the flag is enabled", async () => {
+    setup(true, true);
+
+    await expect(
+      firstValueFrom(isPremiumCloudEnvironment$(environment$, configService)),
+    ).resolves.toBe(true);
+  });
+
+  it("emits false for a self-hosted environment when the flag is disabled", async () => {
+    setup(false, false);
+
+    await expect(
+      firstValueFrom(isPremiumCloudEnvironment$(environment$, configService)),
+    ).resolves.toBe(false);
+  });
+
+  it("emits true for a self-hosted environment when the flag is enabled", async () => {
+    setup(false, true);
+
+    await expect(
+      firstValueFrom(isPremiumCloudEnvironment$(environment$, configService)),
+    ).resolves.toBe(true);
+  });
+
+  it("does not consult the feature flag for a cloud environment", async () => {
+    setup(true, false);
+
+    await firstValueFrom(isPremiumCloudEnvironment$(environment$, configService));
+
+    expect(configService.getFeatureFlag$).not.toHaveBeenCalled();
+  });
+
+  it("reads the PM38393_DisableSelfHostPremiumCheck feature flag for a self-hosted environment", async () => {
+    setup(false, false);
+
+    await firstValueFrom(isPremiumCloudEnvironment$(environment$, configService));
+
+    expect(configService.getFeatureFlag$).toHaveBeenCalledWith(
+      FeatureFlag.PM38393_DisableSelfHostPremiumCheck,
+    );
+  });
+
+  it("re-emits when the flag value changes on a self-hosted environment", async () => {
+    configService = mock<ConfigService>();
+    environment$ = of({ isCloud: () => false } as Environment);
+    configService.getFeatureFlag$.mockReturnValue(of(false, true));
+
+    const emissions: boolean[] = [];
+    isPremiumCloudEnvironment$(environment$, configService).subscribe((value) =>
+      emissions.push(value),
+    );
+
+    expect(emissions).toEqual([false, true]);
+  });
+});

--- a/libs/common/src/billing/utils/premium-environment-utils.ts
+++ b/libs/common/src/billing/utils/premium-environment-utils.ts
@@ -1,0 +1,35 @@
+import { Observable, of, switchMap } from "rxjs";
+
+import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
+import { Environment } from "@bitwarden/common/platform/abstractions/environment.service";
+
+/**
+ * Emits whether the current environment should be treated as cloud for subscription pricing
+ * and premium purchase purposes.
+ *
+ * Premium purchases are intentionally unavailable on self-hosted environments, where users
+ * subscribe through the web app so they can download and apply their license file. However,
+ * Bitwarden-owned QA and dev cloud environments are also classified as self-hosted because
+ * their URLs are not production cloud regions, which blocks QA from testing the premium
+ * upgrade flows. The PM38393_DisableSelfHostPremiumCheck feature flag — only ever served by
+ * internal QA environments — bypasses the self-host check so those environments behave as
+ * cloud.
+ *
+ * The bypass is one-directional: a cloud environment is always treated as cloud — and never
+ * consults the feature flag — regardless of the flag's value. Self-hosted-classified
+ * environments re-emit when the resolved flag value changes, so a flag served after the
+ * initial config fetch still takes effect.
+ */
+export function isPremiumCloudEnvironment$(
+  environment$: Observable<Environment>,
+  configService: ConfigService,
+): Observable<boolean> {
+  return environment$.pipe(
+    switchMap((environment) =>
+      environment.isCloud()
+        ? of(true)
+        : configService.getFeatureFlag$(FeatureFlag.PM38393_DisableSelfHostPremiumCheck),
+    ),
+  );
+}

--- a/libs/common/src/enums/feature-flag.enum.ts
+++ b/libs/common/src/enums/feature-flag.enum.ts
@@ -43,6 +43,7 @@ export enum FeatureFlag {
   PM24032_NewNavigationPremiumUpgradeButton = "pm-24032-new-navigation-premium-upgrade-button",
   PM23713_PremiumBadgeOpensNewPremiumUpgradeDialog = "pm-23713-premium-badge-opens-new-premium-upgrade-dialog",
   PM34515_BrowserDesktopCheckout = "pm-34515-browser-desktop-checkout",
+  PM38393_DisableSelfHostPremiumCheck = "pm-38393-disable-self-host-premium-check",
 
   PM29593_PremiumToOrganizationUpgrade = "pm-29593-premium-to-organization-upgrade",
 
@@ -182,6 +183,7 @@ export const DefaultFeatureFlagValue = {
   [FeatureFlag.PM24032_NewNavigationPremiumUpgradeButton]: FALSE,
   [FeatureFlag.PM23713_PremiumBadgeOpensNewPremiumUpgradeDialog]: FALSE,
   [FeatureFlag.PM34515_BrowserDesktopCheckout]: FALSE,
+  [FeatureFlag.PM38393_DisableSelfHostPremiumCheck]: FALSE,
 
   [FeatureFlag.PM29593_PremiumToOrganizationUpgrade]: FALSE,
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-38393

## 📔 Objective

Some of the Bitwarden-owned QA cloud environments are classified as self-hosted by the clients (their URLs are not in `PRODUCTION_REGIONS`), which blocks QA from testing the browser/desktop Stripe checkout flow (PM-35229) and the premium pricing fetches — both intentionally cloud-only. This PR adds the `pm-38393-disable-self-host-premium-check` feature flag (served only by internal QA environments; client default `false`) and a shared `isPremiumCloudEnvironment$` helper that treats self-hosted-classified environments as cloud for subscription pricing and premium purchase purposes while the flag is enabled. Mirrors the mobile precedent (bitwarden/android#6954).

Key properties:

- **One-directional**: cloud environments short-circuit to `true` and never consult the flag; with the flag absent or `false`, self-host behavior is identical to today.
- **Live recovery**: the pricing gates in `DefaultSubscriptionPricingService` re-evaluate when the resolved flag value changes (no `take(1)`), so a flag value arriving after the initial `/config` fetch takes effect without an app restart.
- **Server-enforced boundary**: even if a self-hosted server served this flag as `true`, the checkout endpoint is `[SelfHosted(NotSelfHostedOnly = true)]` and rejects with 400.

Targets the PM-35229 branch because it modifies the checkout gate introduced there. Companion server PR (flag key registration): https://github.com/bitwarden/server/pull/7794.

Dev-tested locally against a cloud-mode server: flag off → legacy web-vault redirect and no pricing fetch; flag on → pricing renders and "Upgrade Now" opens Stripe test checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)