### PR TITLE
[PM-38012] Initialize feature flag overrides state to empty object

### DIFF
--- a/libs/state/src/state-migrations/migrate.ts
+++ b/libs/state/src/state-migrations/migrate.ts
@@ -75,12 +75,13 @@ import { RemoveUserEncryptedPrivateKey } from "./migrations/75-remove-user-encry
 import { MigratePopupWidthOptions } from "./migrations/76-migrate-popup-width-options";
 import { ClearClipboardDelayToStringMigrator } from "./migrations/77-clear-clipboard-delay-to-string";
 import { MigrateSsoRequiredCache } from "./migrations/78-migrate-sso-required-cache";
+import { InitializeFeatureFlagOverridesMigrator } from "./migrations/79-initialize-feature-flag-overrides";
 import { MoveStateVersionMigrator } from "./migrations/8-move-state-version";
 import { MoveBrowserSettingsToGlobal } from "./migrations/9-move-browser-settings-to-global";
 import { MinVersionMigrator } from "./migrations/min-version";
 
 export const MIN_VERSION = 3;
-export const CURRENT_VERSION = 78;
+export const CURRENT_VERSION = 79;
 export type MinVersion = typeof MIN_VERSION;
 
 export function createMigrationBuilder() {
@@ -160,7 +161,8 @@ export function createMigrationBuilder() {
     .with(RemoveUserEncryptedPrivateKey, 74, 75)
     .with(MigratePopupWidthOptions, 75, 76)
     .with(ClearClipboardDelayToStringMigrator, 76, 77)
-    .with(MigrateSsoRequiredCache, 77, CURRENT_VERSION);
+    .with(MigrateSsoRequiredCache, 77, 78)
+    .with(InitializeFeatureFlagOverridesMigrator, 78, CURRENT_VERSION);
 }
 
 export async function currentVersion(

--- a/libs/state/src/state-migrations/migrations/79-initialize-feature-flag-overrides.spec.ts
+++ b/libs/state/src/state-migrations/migrations/79-initialize-feature-flag-overrides.spec.ts
@@ -1,0 +1,57 @@
+import { runMigrator } from "../migration-helper.spec";
+
+import { InitializeFeatureFlagOverridesMigrator } from "./79-initialize-feature-flag-overrides";
+
+describe("InitializeFeatureFlagOverridesMigrator", () => {
+  const sut = new InitializeFeatureFlagOverridesMigrator(78, 79);
+
+  describe("migrate", () => {
+    it("initializes to an empty object when the key is absent", async () => {
+      const output = await runMigrator(sut, {});
+
+      expect(output).toEqual({
+        global_config_featureFlagOverrides: {},
+      });
+    });
+
+    it("initializes to an empty object when the value is null", async () => {
+      const output = await runMigrator(sut, {
+        global_config_featureFlagOverrides: null,
+      });
+
+      expect(output).toEqual({
+        global_config_featureFlagOverrides: {},
+      });
+    });
+
+    it("leaves an existing override map unchanged", async () => {
+      const overrides = { "some-flag": true, "another-flag": 99 };
+
+      const output = await runMigrator(sut, {
+        global_config_featureFlagOverrides: overrides,
+      });
+
+      expect(output).toEqual({
+        global_config_featureFlagOverrides: overrides,
+      });
+    });
+  });
+
+  describe("rollback", () => {
+    it("leaves the overrides unchanged", async () => {
+      const overrides = { "some-flag": true };
+
+      const output = await runMigrator(
+        sut,
+        {
+          global_config_featureFlagOverrides: overrides,
+        },
+        "rollback",
+      );
+
+      expect(output).toEqual({
+        global_config_featureFlagOverrides: overrides,
+      });
+    });
+  });
+});

--- a/libs/state/src/state-migrations/migrations/79-initialize-feature-flag-overrides.ts
+++ b/libs/state/src/state-migrations/migrations/79-initialize-feature-flag-overrides.ts
@@ -1,0 +1,27 @@
+import { KeyDefinitionLike, MigrationHelper } from "../migration-helper";
+import { Migrator } from "../migrator";
+
+export const FEATURE_FLAG_OVERRIDES_KEY: KeyDefinitionLike = {
+  key: "featureFlagOverrides",
+  stateDefinition: { name: "config" },
+};
+
+/**
+ * Initializes the global feature flag overrides state to an empty object when it has never
+ * been set. The overrides are a record of flag name -> override value; an empty object means
+ * "no overrides". Existing override maps are left unchanged.
+ */
+export class InitializeFeatureFlagOverridesMigrator extends Migrator<78, 79> {
+  async migrate(helper: MigrationHelper): Promise<void> {
+    const overrides = await helper.getFromGlobal<object>(FEATURE_FLAG_OVERRIDES_KEY);
+    if (overrides == null) {
+      await helper.setToGlobal(FEATURE_FLAG_OVERRIDES_KEY, {});
+    }
+  }
+
+  async rollback(): Promise<void> {
+    // No-op: an empty overrides object and an unset value are equivalent to every reader
+    // (resolveFlag treats both as "no overrides"), and we cannot distinguish an override map
+    // we initialized from one a user populated. Leaving the value as-is is safe.
+  }
+}


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-38012

## 📔 Objective

Initialize the global feature flag overrides state (`global_config_featureFlagOverrides`) to an empty object via a state migration (78 -> 79). This state is read by `DefaultConfigService` but was never written by production code, so on disk it was null/absent until something set it.

This makes it easier to set the values in the config since the correct value does not have to be created.

## 📸 Screenshots

n/a

