### PR TITLE
[PM-38821] Fix vault search not finding entries with umlauts/diacritics

### DIFF
--- a/libs/common/src/vault/services/lunr-search.service.ts
+++ b/libs/common/src/vault/services/lunr-search.service.ts
@@ -13,8 +13,6 @@ import { CipherType } from "../enums/cipher-type";
 import { FieldType } from "../enums/field-type.enum";
 import { CipherViewLike, CipherViewLikeUtils } from "../utils/cipher-view-like-utils";
 
-import { normalizeSearchQuery } from "./search.service";
-
 export type IndexId = Opaque<string, "IndexId">;
 
 type IndexState = {
@@ -165,15 +163,18 @@ function makeIndexId(userId: UserId, organizationId: OrganizationId | null): Ind
 
 /// Helper functions and extractors
 
-function normalizeAccentsPipelineFunction(token: lunr.Token): any {
+function normalizeAccentsPipelineFunction(token: lunr.Token): lunr.Token {
   const searchableFields = ["name", "login.username", "subtitle", "notes"];
   const metadata = (token as unknown as { metadata?: { fields?: unknown[] } }).metadata;
   const fields = metadata?.fields;
-  const checkFields =
-    Array.isArray(fields) && fields.every((i) => searchableFields.includes(String(i)));
 
-  if (checkFields) {
-    return normalizeSearchQuery(token.toString());
+  // When fields is present (indexing): only normalize the searchable fields.
+  // When fields is absent (search pipeline): always normalize.
+  const shouldNormalize =
+    !Array.isArray(fields) || fields.every((f) => searchableFields.includes(String(f)));
+
+  if (shouldNormalize) {
+    return token.update((s) => s.normalize("NFD").replace(/[̀-ͯ]/g, ""));
   }
 
   return token;
@@ -185,6 +186,7 @@ function normalizeAccentsPipelineFunction(token: lunr.Token): any {
 async function buildCipherIndex(ciphers: CipherViewLike[]): Promise<lunr.Index> {
   const builder = new lunr.Builder();
   builder.pipeline.add(normalizeAccentsPipelineFunction);
+  builder.searchPipeline.add(normalizeAccentsPipelineFunction);
   builder.ref("id");
   builder.field("shortid", {
     boost: 100,

--- a/libs/common/src/vault/services/search.service.ts
+++ b/libs/common/src/vault/services/search.service.ts
@@ -97,14 +97,19 @@ export class SearchService implements SearchServiceAbstraction {
   searchCiphersBasic<C extends CipherViewLike>(ciphers: C[], query: string) {
     query = normalizeSearchQuery(query.trim().toLowerCase());
     return ciphers.filter((c) => {
-      if (c.name != null && c.name.toLowerCase().indexOf(query) > -1) {
+      if (c.name != null && normalizeSearchQuery(c.name.toLowerCase()).indexOf(query) > -1) {
         return true;
       }
       if (query.length >= 8 && uuidAsString(c.id).startsWith(query)) {
         return true;
       }
       const subtitle = CipherViewLikeUtils.subtitle(c);
-      if (subtitle != null && subtitle.toLowerCase().indexOf(query) > -1) {
+      if (subtitle != null && normalizeSearchQuery(subtitle.toLowerCase()).indexOf(query) > -1) {
+        return true;
+      }
+
+      const notes = CipherViewLikeUtils.getNotes(c);
+      if (notes != null && normalizeSearchQuery(notes.toLowerCase()).indexOf(query) > -1) {
         return true;
       }
 
@@ -114,7 +119,8 @@ export class SearchService implements SearchServiceAbstraction {
         login &&
         login.uris?.length &&
         login.uris?.some(
-          (loginUri) => loginUri?.uri && loginUri.uri.toLowerCase().indexOf(query) > -1,
+          (loginUri) =>
+            loginUri?.uri && normalizeSearchQuery(loginUri.uri.toLowerCase()).indexOf(query) > -1,
         )
       ) {
         return true;
@@ -133,7 +139,7 @@ export class SearchService implements SearchServiceAbstraction {
     const sendsMatched: SendView[] = [];
     const lowPriorityMatched: SendView[] = [];
     sends.forEach((s) => {
-      if (s.name != null && s.name.toLowerCase().indexOf(query) > -1) {
+      if (s.name != null && normalizeSearchQuery(s.name.toLowerCase()).indexOf(query) > -1) {
         sendsMatched.push(s);
       } else if (
         query.length >= 8 &&
@@ -142,11 +148,20 @@ export class SearchService implements SearchServiceAbstraction {
           (s.file?.id != null && s.file.id.startsWith(query)))
       ) {
         lowPriorityMatched.push(s);
-      } else if (s.notes != null && s.notes.toLowerCase().indexOf(query) > -1) {
+      } else if (
+        s.notes != null &&
+        normalizeSearchQuery(s.notes.toLowerCase()).indexOf(query) > -1
+      ) {
         lowPriorityMatched.push(s);
-      } else if (s.text?.text != null && s.text.text.toLowerCase().indexOf(query) > -1) {
+      } else if (
+        s.text?.text != null &&
+        normalizeSearchQuery(s.text.text.toLowerCase()).indexOf(query) > -1
+      ) {
         lowPriorityMatched.push(s);
-      } else if (s.file?.fileName != null && s.file.fileName.toLowerCase().indexOf(query) > -1) {
+      } else if (
+        s.file?.fileName != null &&
+        normalizeSearchQuery(s.file.fileName.toLowerCase()).indexOf(query) > -1
+      ) {
         lowPriorityMatched.push(s);
       }
     });


### PR DESCRIPTION
## 🎟️ Tracking

Fixes #10738 

## 📔 Objective

Vault search failed to find entries when the search query or the entry fields contained umlaut/diacritic characters (ö, ü, ä, é, …).

**Root cause:** `normalizeSearchQuery` was applied to the query, stripping diacritics (e.g. `ö → o`), but the field values compared against were left un-normalized. This caused mismatches like `"muller".indexOf("müller") === -1`.

A second issue existed in the lunr pipeline: `normalizeAccentsPipelineFunction` only ran during indexing, not during search. Adding it to `builder.searchPipeline` was a no-op because the original function's field-metadata check always returned `false` in search context (no field metadata present).

**Changes:**

- `searchCiphersBasic`: normalize `name`, `subtitle`, `notes` and login URIs before `indexOf` comparison, so searches with or without umlauts both match
- `normalizeAccentsPipelineFunction`: preserve field-specific indexing behaviour, but normalize unconditionally when no field metadata is present (search pipeline context)
- `buildCipherIndex`: add `builder.searchPipeline.add(normalizeAccentsPipelineFunction)` so lunr queries with umlauts are normalized before lookup

## 📸 Screenshots

<!-- Not applicable – no UI changes -->