### PR TITLE
[PM-36510] Remove dead "SDK not available" guards from SDK-backed services

### DIFF
--- a/libs/common/src/vault/services/cipher-sdk.service.spec.ts
+++ b/libs/common/src/vault/services/cipher-sdk.service.spec.ts
@@ -203,17 +203,6 @@ describe("DefaultCipherSdkService", () => {
       expect(result?.login?.fido2Credentials?.[0].keyValue).toBe("decrypted-key-value");
     });
 
-    it("should throw error and log when SDK client is not available", async () => {
-      sdkService.userClient$.mockReturnValue(of(null));
-      const cipherView = new CipherView();
-      cipherView.name = "Test Cipher";
-
-      await expect(cipherSdkService.createWithServer(cipherView, userId)).rejects.toThrow();
-      expect(logService.error).toHaveBeenCalledWith(
-        expect.stringContaining("Failed to create cipher"),
-      );
-    });
-
     it("should throw error and log when SDK throws an error", async () => {
       const cipherView = new CipherView();
       cipherView.name = "Test Cipher";
@@ -396,19 +385,6 @@ describe("DefaultCipherSdkService", () => {
       expect(result?.login?.fido2Credentials?.[0].keyValue).toBe("decrypted-key-value");
     });
 
-    it("should throw error and log when SDK client is not available", async () => {
-      sdkService.userClient$.mockReturnValue(of(null));
-      const cipherView = new CipherView();
-      cipherView.name = "Test Cipher";
-
-      await expect(
-        cipherSdkService.updateWithServer(cipherView, userId, undefined, false),
-      ).rejects.toThrow();
-      expect(logService.error).toHaveBeenCalledWith(
-        expect.stringContaining("Failed to update cipher"),
-      );
-    });
-
     it("should throw error and log when SDK throws an error", async () => {
       const cipherView = new CipherView();
       cipherView.name = "Test Cipher";
@@ -462,17 +438,6 @@ describe("DefaultCipherSdkService", () => {
       expect(mockAdminSdk.delete).toHaveBeenCalledWith(testCipherId);
     });
 
-    it("should throw error and log when SDK client is not available", async () => {
-      sdkService.userClient$.mockReturnValue(of(null));
-
-      await expect(cipherSdkService.deleteWithServer(testCipherId, userId)).rejects.toThrow(
-        "SDK not available",
-      );
-      expect(logService.error).toHaveBeenCalledWith(
-        expect.stringContaining("Failed to delete cipher"),
-      );
-    });
-
     it("should throw error and log when SDK throws an error", async () => {
       mockCiphersSdk.delete.mockRejectedValue(new Error("SDK error"));
 
@@ -513,17 +478,6 @@ describe("DefaultCipherSdkService", () => {
       ).rejects.toThrow("Organization ID is required for admin delete.");
     });
 
-    it("should throw error and log when SDK client is not available", async () => {
-      sdkService.userClient$.mockReturnValue(of(null));
-
-      await expect(cipherSdkService.deleteManyWithServer(testCipherIds, userId)).rejects.toThrow(
-        "SDK not available",
-      );
-      expect(logService.error).toHaveBeenCalledWith(
-        expect.stringContaining("Failed to delete multiple ciphers"),
-      );
-    });
-
     it("should throw error and log when SDK throws an error", async () => {
       mockCiphersSdk.delete_many.mockRejectedValue(new Error("SDK error"));
 
@@ -553,17 +507,6 @@ describe("DefaultCipherSdkService", () => {
       expect(mockVaultSdk.ciphers).toHaveBeenCalled();
       expect(mockCiphersSdk.admin).toHaveBeenCalled();
       expect(mockAdminSdk.soft_delete).toHaveBeenCalledWith(testCipherId);
-    });
-
-    it("should throw error and log when SDK client is not available", async () => {
-      sdkService.userClient$.mockReturnValue(of(null));
-
-      await expect(cipherSdkService.softDeleteWithServer(testCipherId, userId)).rejects.toThrow(
-        "SDK not available",
-      );
-      expect(logService.error).toHaveBeenCalledWith(
-        expect.stringContaining("Failed to soft delete cipher"),
-      );
     });
 
     it("should throw error and log when SDK throws an error", async () => {
@@ -606,17 +549,6 @@ describe("DefaultCipherSdkService", () => {
       ).rejects.toThrow("Organization ID is required for admin soft delete.");
     });
 
-    it("should throw error and log when SDK client is not available", async () => {
-      sdkService.userClient$.mockReturnValue(of(null));
-
-      await expect(
-        cipherSdkService.softDeleteManyWithServer(testCipherIds, userId),
-      ).rejects.toThrow("SDK not available");
-      expect(logService.error).toHaveBeenCalledWith(
-        expect.stringContaining("Failed to soft delete multiple ciphers"),
-      );
-    });
-
     it("should throw error and log when SDK throws an error", async () => {
       mockCiphersSdk.soft_delete_many.mockRejectedValue(new Error("SDK error"));
 
@@ -648,17 +580,6 @@ describe("DefaultCipherSdkService", () => {
       expect(mockVaultSdk.ciphers).toHaveBeenCalled();
       expect(mockCiphersSdk.admin).toHaveBeenCalled();
       expect(mockAdminSdk.restore).toHaveBeenCalledWith(testCipherId);
-    });
-
-    it("should throw error and log when SDK client is not available", async () => {
-      sdkService.userClient$.mockReturnValue(of(null));
-
-      await expect(cipherSdkService.restoreWithServer(testCipherId, userId)).rejects.toThrow(
-        "SDK not available",
-      );
-      expect(logService.error).toHaveBeenCalledWith(
-        expect.stringContaining("Failed to restore cipher"),
-      );
     });
 
     it("should throw error and log when SDK throws an error", async () => {
@@ -694,17 +615,6 @@ describe("DefaultCipherSdkService", () => {
       expect(mockVaultSdk.ciphers).toHaveBeenCalled();
       expect(mockCiphersSdk.admin).toHaveBeenCalled();
       expect(mockAdminSdk.restore_many).toHaveBeenCalledWith(testCipherIds, orgIdString);
-    });
-
-    it("should throw error and log when SDK client is not available", async () => {
-      sdkService.userClient$.mockReturnValue(of(null));
-
-      await expect(cipherSdkService.restoreManyWithServer(testCipherIds, userId)).rejects.toThrow(
-        "SDK not available",
-      );
-      expect(logService.error).toHaveBeenCalledWith(
-        expect.stringContaining("Failed to restore multiple ciphers"),
-      );
     });
 
     it("should throw error and log when SDK throws an error", async () => {
@@ -779,19 +689,6 @@ describe("DefaultCipherSdkService", () => {
       );
     });
 
-    it("should throw error and log when SDK client is not available", async () => {
-      sdkService.userClient$.mockReturnValue(of(null));
-      const cipherView = new CipherView();
-      cipherView.name = "Test Cipher";
-
-      await expect(
-        cipherSdkService.shareWithServer(cipherView, orgId, [collectionId1], userId),
-      ).rejects.toThrow("SDK not available");
-      expect(logService.error).toHaveBeenCalledWith(
-        expect.stringContaining("Failed to share cipher"),
-      );
-    });
-
     it("should throw error and log when SDK throws an error", async () => {
       const cipherView = new CipherView();
       cipherView.name = "Test Cipher";
@@ -848,19 +745,6 @@ describe("DefaultCipherSdkService", () => {
       expect(result).toHaveLength(2);
       expect(result[0]).toBeInstanceOf(CipherView);
       expect(result[1]).toBeInstanceOf(CipherView);
-    });
-
-    it("should throw error and log when SDK client is not available", async () => {
-      sdkService.userClient$.mockReturnValue(of(null));
-      const cipherView = new CipherView();
-      cipherView.name = "Test Cipher";
-
-      await expect(
-        cipherSdkService.shareManyWithServer([cipherView], orgId, [collectionId1], userId),
-      ).rejects.toThrow("SDK not available");
-      expect(logService.error).toHaveBeenCalledWith(
-        expect.stringContaining("Failed to share multiple ciphers"),
-      );
     });
 
     it("should throw error and log when SDK throws an error", async () => {
@@ -1032,15 +916,6 @@ describe("DefaultCipherSdkService", () => {
       expect(result.failures[0].decryptionFailure).toBe(true);
     });
 
-    it("should throw error and log when SDK client is not available", async () => {
-      sdkService.userClient$.mockReturnValue(of(null));
-
-      await expect(cipherSdkService.getAllDecrypted(userId)).rejects.toThrow("SDK not available");
-      expect(logService.error).toHaveBeenCalledWith(
-        expect.stringContaining("Failed to list and decrypt ciphers"),
-      );
-    });
-
     it("should throw error and log when SDK throws an error", async () => {
       mockCiphersSdk.get_all.mockRejectedValue(new Error("SDK error"));
 
@@ -1111,17 +986,6 @@ describe("DefaultCipherSdkService", () => {
       expect(mockAdminSdk.list_org_ciphers).toHaveBeenCalledWith(orgId, true);
     });
 
-    it("should throw error and log when SDK client is not available", async () => {
-      sdkService.userClient$.mockReturnValue(of(null));
-
-      await expect(
-        cipherSdkService.getAllFromApiForOrganization(orgId, userId, false),
-      ).rejects.toThrow("SDK not available");
-      expect(logService.error).toHaveBeenCalledWith(
-        expect.stringContaining("Failed to list organization ciphers"),
-      );
-    });
-
     it("should throw error and log when SDK throws an error", async () => {
       mockAdminSdk.list_org_ciphers.mockRejectedValue(new Error("SDK error"));
 
@@ -1156,17 +1020,6 @@ describe("DefaultCipherSdkService", () => {
       expect(result).toBeInstanceOf(CipherView);
     });
 
-    it("should throw error and log when SDK client is not available", async () => {
-      sdkService.userClient$.mockReturnValue(of(null));
-
-      await expect(
-        cipherSdkService.saveCollectionsWithServerAdmin(cipherId, [collectionId1], userId),
-      ).rejects.toThrow("SDK not available");
-      expect(logService.error).toHaveBeenCalledWith(
-        expect.stringContaining("Failed to update cipher collections as admin"),
-      );
-    });
-
     it("should throw error and log when SDK throws an error", async () => {
       mockAdminSdk.update_collection.mockRejectedValue(new Error("SDK error"));
 
@@ -1199,17 +1052,6 @@ describe("DefaultCipherSdkService", () => {
       expect(mockCiphersSdk.update_collection).toHaveBeenCalledWith(cipherId, collectionIds, false);
       expect(mockCiphersSdk.admin).not.toHaveBeenCalled();
       expect(result).toBeInstanceOf(CipherView);
-    });
-
-    it("should throw error and log when SDK client is not available", async () => {
-      sdkService.userClient$.mockReturnValue(of(null));
-
-      await expect(
-        cipherSdkService.saveCollectionsWithServer(cipherId, [collectionId1], userId),
-      ).rejects.toThrow("SDK not available");
-      expect(logService.error).toHaveBeenCalledWith(
-        expect.stringContaining("Failed to update cipher collections"),
-      );
     });
 
     it("should throw error and log when SDK throws an error", async () => {

--- a/libs/common/src/vault/services/cipher-sdk.service.ts
+++ b/libs/common/src/vault/services/cipher-sdk.service.ts
@@ -24,9 +24,6 @@ export class DefaultCipherSdkService implements CipherSdkService {
     return await firstValueFrom(
       this.sdkService.userClient$(userId).pipe(
         switchMap(async (sdk) => {
-          if (!sdk) {
-            throw new Error("SDK not available");
-          }
           using ref = sdk.take();
           const sdkCiphersClient = ref.value.vault().ciphers();
 
@@ -58,9 +55,6 @@ export class DefaultCipherSdkService implements CipherSdkService {
     return await firstValueFrom(
       this.sdkService.userClient$(userId).pipe(
         switchMap(async (sdk) => {
-          if (!sdk) {
-            throw new Error("SDK not available");
-          }
           using ref = sdk.take();
           const sdkCiphersClient = ref.value.vault().ciphers();
 
@@ -96,9 +90,6 @@ export class DefaultCipherSdkService implements CipherSdkService {
     return await firstValueFrom(
       this.sdkService.userClient$(userId).pipe(
         switchMap(async (sdk) => {
-          if (!sdk) {
-            throw new Error("SDK not available");
-          }
           using ref = sdk.take();
           if (asAdmin) {
             await ref.value.vault().ciphers().admin().delete(asUuid(id));
@@ -123,9 +114,6 @@ export class DefaultCipherSdkService implements CipherSdkService {
     return await firstValueFrom(
       this.sdkService.userClient$(userId).pipe(
         switchMap(async (sdk) => {
-          if (!sdk) {
-            throw new Error("SDK not available");
-          }
           using ref = sdk.take();
           if (asAdmin) {
             if (orgId == null) {
@@ -158,9 +146,6 @@ export class DefaultCipherSdkService implements CipherSdkService {
     return await firstValueFrom(
       this.sdkService.userClient$(userId).pipe(
         switchMap(async (sdk) => {
-          if (!sdk) {
-            throw new Error("SDK not available");
-          }
           using ref = sdk.take();
           if (asAdmin) {
             await ref.value.vault().ciphers().admin().soft_delete(asUuid(id));
@@ -185,9 +170,6 @@ export class DefaultCipherSdkService implements CipherSdkService {
     return await firstValueFrom(
       this.sdkService.userClient$(userId).pipe(
         switchMap(async (sdk) => {
-          if (!sdk) {
-            throw new Error("SDK not available");
-          }
           using ref = sdk.take();
           if (asAdmin) {
             if (orgId == null) {
@@ -220,9 +202,6 @@ export class DefaultCipherSdkService implements CipherSdkService {
     return await firstValueFrom(
       this.sdkService.userClient$(userId).pipe(
         switchMap(async (sdk) => {
-          if (!sdk) {
-            throw new Error("SDK not available");
-          }
           using ref = sdk.take();
           if (asAdmin) {
             await ref.value.vault().ciphers().admin().restore(asUuid(id));
@@ -242,9 +221,6 @@ export class DefaultCipherSdkService implements CipherSdkService {
     return await firstValueFrom(
       this.sdkService.userClient$(userId).pipe(
         switchMap(async (sdk) => {
-          if (!sdk) {
-            throw new Error("SDK not available");
-          }
           using ref = sdk.take();
 
           // No longer using an asAdmin Param. Org Vault bulkRestore will assess if an item is unassigned or editable
@@ -283,9 +259,6 @@ export class DefaultCipherSdkService implements CipherSdkService {
     return await firstValueFrom(
       this.sdkService.userClient$(userId).pipe(
         switchMap(async (sdk) => {
-          if (!sdk) {
-            throw new Error("SDK not available");
-          }
           using ref = sdk.take();
           const sdkCiphersClient = ref.value.vault().ciphers();
 
@@ -317,9 +290,6 @@ export class DefaultCipherSdkService implements CipherSdkService {
     return await firstValueFrom(
       this.sdkService.userClient$(userId).pipe(
         switchMap(async (sdk) => {
-          if (!sdk) {
-            throw new Error("SDK not available");
-          }
           using ref = sdk.take();
           const sdkCiphersClient = ref.value.vault().ciphers();
 
@@ -376,9 +346,6 @@ export class DefaultCipherSdkService implements CipherSdkService {
     return await firstValueFrom(
       this.sdkService.userClient$(userId).pipe(
         switchMap(async (sdk) => {
-          if (!sdk) {
-            throw new Error("SDK not available");
-          }
           using ref = sdk.take();
           const sdkCiphersClient = ref.value.vault().ciphers();
 
@@ -415,9 +382,6 @@ export class DefaultCipherSdkService implements CipherSdkService {
     return await firstValueFrom(
       this.sdkService.userClient$(userId).pipe(
         switchMap(async (sdk) => {
-          if (!sdk) {
-            throw new Error("SDK not available");
-          }
           using ref = sdk.take();
 
           const result = await ref.value
@@ -527,9 +491,6 @@ export class DefaultCipherSdkService implements CipherSdkService {
     return await firstValueFrom(
       this.sdkService.userClient$(userId).pipe(
         switchMap(async (sdk) => {
-          if (!sdk) {
-            throw new Error("SDK not available");
-          }
           using ref = sdk.take();
           const sdkCiphersClient = ref.value.vault().ciphers();
           const result = await sdkCiphersClient.admin().update_collection(
@@ -554,9 +515,6 @@ export class DefaultCipherSdkService implements CipherSdkService {
     return await firstValueFrom(
       this.sdkService.userClient$(userId).pipe(
         switchMap(async (sdk) => {
-          if (!sdk) {
-            throw new Error("SDK not available");
-          }
           using ref = sdk.take();
           const sdkCiphersClient = ref.value.vault().ciphers();
           const result = await sdkCiphersClient.update_collection(

--- a/libs/common/src/vault/services/default-cipher-encryption.service.spec.ts
+++ b/libs/common/src/vault/services/default-cipher-encryption.service.spec.ts
@@ -566,18 +566,6 @@ describe("DefaultCipherEncryptionService", () => {
       expect(mockSdkClient.vault().ciphers().decrypt).toHaveBeenCalledTimes(2);
       expect(CipherView.fromSdkCipherView).toHaveBeenCalledTimes(2);
     });
-
-    it("should throw EmptyError when SDK is not available", async () => {
-      sdkService.userClient$ = jest.fn().mockReturnValue(of(null)) as any;
-
-      await expect(
-        cipherEncryptionService.decryptManyLegacy([cipherObj], userId),
-      ).rejects.toThrow();
-
-      expect(logService.error).toHaveBeenCalledWith(
-        expect.stringContaining("Failed to decrypt ciphers"),
-      );
-    });
   });
 
   describe("decryptManyWithFailures", () => {

--- a/libs/common/src/vault/services/default-cipher-encryption.service.ts
+++ b/libs/common/src/vault/services/default-cipher-encryption.service.ts
@@ -24,10 +24,6 @@ export class DefaultCipherEncryptionService implements CipherEncryptionService {
     return firstValueFrom(
       this.sdkService.userClient$(userId).pipe(
         concatMap(async (sdk) => {
-          if (!sdk) {
-            throw new Error("SDK not available");
-          }
-
           using ref = sdk.take();
           const sdkCipherView = model.toSdkCipherView(ref.value.vault().ciphers());
 
@@ -54,10 +50,6 @@ export class DefaultCipherEncryptionService implements CipherEncryptionService {
     return firstValueFrom(
       this.sdkService.userClient$(userId).pipe(
         concatMap(async (sdk) => {
-          if (!sdk) {
-            throw new Error("SDK not available");
-          }
-
           using ref = sdk.take();
 
           const results = await ref.value
@@ -87,10 +79,6 @@ export class DefaultCipherEncryptionService implements CipherEncryptionService {
     return firstValueFrom(
       this.sdkService.userClient$(userId).pipe(
         concatMap(async (sdk) => {
-          if (!sdk) {
-            throw new Error("SDK not available");
-          }
-
           using ref = sdk.take();
           const sdkCipherView = model.toSdkCipherView(ref.value.vault().ciphers());
 
@@ -122,10 +110,6 @@ export class DefaultCipherEncryptionService implements CipherEncryptionService {
     return firstValueFrom(
       this.sdkService.userClient$(userId).pipe(
         concatMap(async (sdk) => {
-          if (!sdk) {
-            throw new Error("SDK not available");
-          }
-
           using ref = sdk.take();
           const sdkCipherView = model.toSdkCipherView(ref.value.vault().ciphers());
 
@@ -151,10 +135,6 @@ export class DefaultCipherEncryptionService implements CipherEncryptionService {
     return firstValueFrom(
       this.sdkService.userClient$(userId).pipe(
         concatMap(async (sdk) => {
-          if (!sdk) {
-            throw new Error("SDK not available");
-          }
-
           using ref = sdk.take();
           const sdkCipherView = await ref.value.vault().ciphers().decrypt(cipher.toSdkCipher());
 
@@ -200,10 +180,6 @@ export class DefaultCipherEncryptionService implements CipherEncryptionService {
     return firstValueFrom(
       this.sdkService.userClient$(userId).pipe(
         concatMap(async (sdk) => {
-          if (!sdk) {
-            throw new Error("SDK not available");
-          }
-
           using ref = sdk.take();
 
           const successful: CipherView[] = [];
@@ -265,10 +241,6 @@ export class DefaultCipherEncryptionService implements CipherEncryptionService {
     return firstValueFrom(
       this.sdkService.userClient$(userId).pipe(
         concatMap(async (sdk) => {
-          if (!sdk) {
-            throw new Error("SDK is undefined");
-          }
-
           using ref = sdk.take();
 
           const result: DecryptCipherListResult = await ref.value
@@ -306,10 +278,6 @@ export class DefaultCipherEncryptionService implements CipherEncryptionService {
     return firstValueFrom(
       this.sdkService.userClient$(userId).pipe(
         map((sdk) => {
-          if (!sdk) {
-            throw new Error("SDK is undefined");
-          }
-
           using ref = sdk.take();
 
           return ref.value


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-36510
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
SdkService.userClient$(userId) is typed as Observable<Rc<PasswordManagerClient>> (non-nullable) and its implementation in DefaultSdkService either emits a valid client or throws UserNotLoggedInError via throwIfEmpty, it never emits null/undefined. The if (!sdk) throw new Error("SDK not available") guard that several SDK-backed services place inside switchMap(async (sdk) => { ... }) is therefore dead code, and the matching unit tests (sdkService.userClient$.mockReturnValue(of(null))) test an impossible scenario.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
