### PR TITLE
[PM-38856] Match targeting rules against frame over tab URI

### DIFF
--- a/apps/browser/src/background/runtime.background.ts
+++ b/apps/browser/src/background/runtime.background.ts
@@ -222,7 +222,12 @@ export default class RuntimeBackground {
         return result;
       }
       case "getUrlAutofillTargetingRules": {
-        return await this.main.domainSettingsService.getTargetingRulesForUrl(sender.tab?.url);
+        return await this.main.domainSettingsService.getTargetingRulesForUrl(
+          // Because content scripts are injected into all _frames_, we give precedence
+          // to targeting rules matching by frame URI (`sender.url`) over tab URI, to avoid
+          // selector collision with coincidentally-matching in-frame structures.
+          sender.url ?? sender.tab?.url,
+        );
       }
     }
   }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-38856](https://bitwarden.atlassian.net/browse/PM-38856)

## 📔 Objective

Because content scripts are injected into all frames, we give precedence to targeting rules matching by frame URI (`sender.url`) over tab URI, to avoid selector collision with coincidentally-matching in-frame structures.

[PM-38856]: https://bitwarden.atlassian.net/browse/PM-38856?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ