### PR TITLE
[PM-38863] [PM-17952] - Defer autofocus until the window has focus

### DIFF
--- a/libs/components/src/input/autofocus.directive.spec.ts
+++ b/libs/components/src/input/autofocus.directive.spec.ts
@@ -1,0 +1,131 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Injectable,
+  NgZone,
+} from "@angular/core";
+import { ComponentFixture, fakeAsync, TestBed, tick } from "@angular/core/testing";
+
+import { Utils } from "@bitwarden/common/platform/misc/utils";
+
+import { AutofocusDirective } from "./autofocus.directive";
+
+@Injectable()
+class MockNgZone extends NgZone {
+  override onStable: EventEmitter<any> = new EventEmitter(false);
+  isStable = true;
+
+  constructor() {
+    super({ enableLongStackTrace: false });
+  }
+
+  override run(fn: any): any {
+    return fn();
+  }
+
+  override runOutsideAngular(fn: any): any {
+    return fn();
+  }
+}
+
+@Component({
+  template: `<input appAutofocus />`,
+  imports: [AutofocusDirective],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class TestHostComponent {}
+
+describe("AutofocusDirective", () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [{ provide: NgZone, useClass: MockNgZone }],
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    TestBed.resetTestingModule();
+  });
+
+  function createFixture(): {
+    fixture: ComponentFixture<TestHostComponent>;
+    focusSpy: jest.SpyInstance;
+  } {
+    // Spy before the first change detection, since the directive focuses as soon as the element
+    // becomes visible (in AfterContentChecked).
+    const focusSpy = jest.spyOn(HTMLElement.prototype, "focus");
+    const fixture = TestBed.createComponent(TestHostComponent);
+    fixture.detectChanges();
+    return { fixture, focusSpy };
+  }
+
+  it("focuses the element when the window has focus", fakeAsync(() => {
+    jest.spyOn(document, "hasFocus").mockReturnValue(true);
+
+    const { focusSpy } = createFixture();
+
+    TestBed.tick();
+    tick(0);
+
+    expect(focusSpy).toHaveBeenCalled();
+  }));
+
+  it("does not focus the element while the window is not focused", fakeAsync(() => {
+    jest.spyOn(document, "hasFocus").mockReturnValue(false);
+
+    const { focusSpy } = createFixture();
+
+    TestBed.tick();
+    tick(0);
+
+    expect(focusSpy).not.toHaveBeenCalled();
+  }));
+
+  it("focuses the element once the window regains focus", fakeAsync(() => {
+    const hasFocusSpy = jest.spyOn(document, "hasFocus").mockReturnValue(false);
+
+    const { focusSpy } = createFixture();
+
+    TestBed.tick();
+    tick(0);
+
+    expect(focusSpy).not.toHaveBeenCalled();
+
+    // Simulate the user bringing the window back to the foreground.
+    hasFocusSpy.mockReturnValue(true);
+    window.dispatchEvent(new Event("focus"));
+    tick(0);
+
+    expect(focusSpy).toHaveBeenCalled();
+  }));
+
+  it("does not focus a deferred element after the directive is destroyed", fakeAsync(() => {
+    const hasFocusSpy = jest.spyOn(document, "hasFocus").mockReturnValue(false);
+
+    const { fixture, focusSpy } = createFixture();
+
+    TestBed.tick();
+    tick(0);
+
+    fixture.destroy();
+
+    hasFocusSpy.mockReturnValue(true);
+    window.dispatchEvent(new Event("focus"));
+    tick(0);
+
+    expect(focusSpy).not.toHaveBeenCalled();
+  }));
+
+  it("does not focus the element on a mobile browser", fakeAsync(() => {
+    jest.replaceProperty(Utils, "isMobileBrowser", true);
+    jest.spyOn(document, "hasFocus").mockReturnValue(true);
+
+    const { focusSpy } = createFixture();
+
+    TestBed.tick();
+    tick(0);
+
+    expect(focusSpy).not.toHaveBeenCalled();
+  }));
+});

--- a/libs/components/src/input/autofocus.directive.ts
+++ b/libs/components/src/input/autofocus.directive.ts
@@ -5,6 +5,7 @@ import {
   ElementRef,
   input,
   NgZone,
+  OnDestroy,
   Optional,
 } from "@angular/core";
 import { take } from "rxjs/operators";
@@ -38,11 +39,14 @@ export function queryForAutofocusDescendents(el: Document | Element) {
 @Directive({
   selector: "[appAutofocus], [bitAutofocus]",
 })
-export class AutofocusDirective implements AfterContentChecked {
+export class AutofocusDirective implements AfterContentChecked, OnDestroy {
   readonly appAutofocus = input(undefined, { transform: booleanAttribute });
 
   // Track if we have already focused the element.
   private focused = false;
+
+  // Defers focusing until the window regains focus.
+  private deferredFocusListener?: () => void;
 
   constructor(
     private el: ElementRef,
@@ -69,10 +73,53 @@ export class AutofocusDirective implements AfterContentChecked {
       return;
     }
 
+    this.focusWhenWindowFocused();
+  }
+
+  ngOnDestroy() {
+    this.removeDeferredFocusListener();
+  }
+
+  /**
+   * Focus the element, but only while the window has focus.
+   *
+   * Focusing an input in a backgrounded window can enable macOS Secure Keyboard Input, which
+   * blocks global hotkeys in other applications until Bitwarden is closed. When the window isn't
+   * focused, defer until it regains focus.
+   *
+   * @see https://github.com/bitwarden/clients/issues/13241
+   */
+  private focusWhenWindowFocused() {
+    if (!document.hasFocus()) {
+      if (this.deferredFocusListener == null) {
+        this.deferredFocusListener = () => {
+          this.removeDeferredFocusListener();
+          this.focusOnceStable();
+        };
+        window.addEventListener("focus", this.deferredFocusListener);
+      }
+      return;
+    }
+
+    this.focusOnceStable();
+  }
+
+  private focusOnceStable() {
+    if (this.focused) {
+      return;
+    }
+
     if (this.ngZone.isStable) {
       this.focus();
     } else {
       this.ngZone.onStable.pipe(take(1)).subscribe(this.focus.bind(this));
+    }
+  }
+
+  private removeDeferredFocusListener() {
+    if (this.deferredFocusListener != null) {
+      window.removeEventListener("focus", this.deferredFocusListener);
+      this.deferredFocusListener = undefined;
     }
   }
 

--- a/libs/key-management-ui/src/lock/components/lock.component.ts
+++ b/libs/key-management-ui/src/lock/components/lock.component.ts
@@ -142,7 +142,6 @@ export class LockComponent implements OnInit, OnDestroy {
   shouldClosePopout = false;
 
   // Desktop properties:
-  private deferFocus: boolean | null = null;
   private biometricAsked = false;
 
   defaultUnlockOptionSetForUser = false;
@@ -703,22 +702,10 @@ export class LockComponent implements OnInit, OnDestroy {
           case "windowHidden":
             this.onWindowHidden();
             break;
-          case "windowIsFocused":
-            if (this.deferFocus === null) {
-              this.deferFocus = !message.windowIsFocused;
-              if (!this.deferFocus) {
-                this.focusInput();
-              }
-            } else if (this.deferFocus && message.windowIsFocused) {
-              this.focusInput();
-              this.deferFocus = false;
-            }
-            break;
           default:
         }
       });
     });
-    this.messagingService.send("getWindowIsFocused");
   }
 
   private async desktopAutoPromptBiometrics() {
@@ -745,12 +732,6 @@ export class LockComponent implements OnInit, OnDestroy {
 
   onWindowHidden() {
     this.showPassword = false;
-  }
-
-  private focusInput() {
-    if (this.unlockOptions) {
-      document.getElementById(this.unlockOptions.pin.enabled ? "pin" : "masterPassword")?.focus();
-    }
   }
 
   // -----------------------------------------------------------------------------------------------


### PR DESCRIPTION
## 🎟️ Tracking

  - Fixes https://github.com/bitwarden/clients/issues/13241
  - PM-17952

## 📔 Objective

On macOS, when the vault auto-locks on timeout while Bitwarden is in the background, global hotkeys / keyboard monitoring in other applications (e.g. iTerm2, BetterTouchTool, Hammerspoon, skhd, Keyboard Maestro, etc.) stop working.

**Root cause:** the lock screen's master password field is autofocused when the lock route renders even if the Bitwarden application is not focused at the OS level.

**Regression Source:** The desktop lock component already had a `deferFocus` mechanism meant to prevent this, but it was dead: it focused via `document.getElementById("masterPassword" / "pin")`, and those inputs now render through `bitInput` with auto-generated ids.  This meant the lookup in the original location always returned `null`, and the only thing focusing the field was the `appAutofocus` directive, which had no window-focus guard.

**Fix:** `AutofocusDirective` now only focuses when `document.hasFocus()` is true. When the window isn't focused, it defers focusing until the window regains focus (one-shot `window` `focus` listener, cleaned up on destroy).

This matches expected behavior: the cursor only enters the field once Bitwarden is brought to the foreground.  It also fixes every unlock method, not just master password.

In the common case (window already focused) behavior should be unchanged.

This PR has two commits:

  1. The fix in `AutofocusDirective`, with tests.
  2. Removal of the now-redundant, dead `deferFocus`/`focusInput` code in the lock component.

## 📸 Screenshots

N/A