### PR TITLE
[PM-38274] Fix help text size in At-Risk drawer views in Access Intelligence v2

### DIFF
--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/v2/shared/access-intelligence-drawer-v2/access-intelligence-drawer-v2.component.html
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/v2/shared/access-intelligence-drawer-v2/access-intelligence-drawer-v2.component.html
@@ -5,7 +5,7 @@
       <span>{{ "atRiskMembersWithCount" | i18n: data.members?.length ?? 0 }}</span>
     </ng-container>
     <ng-container bitDialogContent>
-      <span bitTypography="body1" class="tw-text-muted tw-text-sm">{{
+      <span bitTypography="body2" class="tw-text-muted">{{
         (data.members?.length > 0 ? "atRiskMemberDescription" : "atRiskMembersDescriptionNone")
           | i18n
       }}</span>
@@ -22,10 +22,10 @@
         </button>
         <ng-container>
           <div class="tw-flex tw-justify-between tw-mt-2 tw-text-muted">
-            <div bitTypography="body2" class="tw-text-sm tw-font-bold">
+            <div bitTypography="body2" class="tw-font-bold">
               {{ "email" | i18n }}
             </div>
-            <div bitTypography="body2" class="tw-text-sm tw-font-bold">
+            <div bitTypography="body2" class="tw-font-bold">
               {{ "atRiskApplications" | i18n }}
             </div>
           </div>
@@ -51,7 +51,7 @@
       <div bitTypography="body1" class="tw-mb-2">
         {{ "atRiskMembersWithCount" | i18n: data.members?.length ?? 0 }}
       </div>
-      <div bitTypography="body1" class="tw-text-muted tw-text-sm tw-mb-2">
+      <div bitTypography="body2" class="tw-text-muted tw-mb-2">
         {{
           (data.members?.length > 0
             ? "atRiskMembersDescriptionWithApp"
@@ -75,7 +75,7 @@
       <span>{{ "atRiskApplicationsWithCount" | i18n: data.applications?.length ?? 0 }}</span>
     </ng-container>
     <ng-container bitDialogContent>
-      <span bitTypography="body1" class="tw-text-muted tw-text-sm">{{
+      <span bitTypography="body2" class="tw-text-muted">{{
         (data.applications?.length > 0
           ? "atRiskApplicationsDescription"
           : "atRiskApplicationsDescriptionNone"
@@ -93,10 +93,10 @@
             {{ "downloadCSV" | i18n }}
           </button>
           <div class="tw-flex tw-justify-between tw-mt-2 tw-text-muted">
-            <div bitTypography="body2" class="tw-text-sm tw-font-bold">
+            <div bitTypography="body2" class="tw-font-bold">
               {{ "application" | i18n }}
             </div>
-            <div bitTypography="body2" class="tw-text-sm tw-font-bold">
+            <div bitTypography="body2" class="tw-font-bold">
               {{ "atRiskPasswords" | i18n }}
             </div>
           </div>
@@ -119,7 +119,7 @@
       <span>{{ "atRiskMembersWithCount" | i18n: data.members?.length ?? 0 }}</span>
     </ng-container>
     <ng-container bitDialogContent>
-      <span bitTypography="body1" class="tw-text-muted tw-text-sm">{{
+      <span bitTypography="body2" class="tw-text-muted">{{
         (data.members?.length > 0 ? "atRiskMemberDescription" : "atRiskMembersDescriptionNone")
           | i18n
       }}</span>
@@ -136,10 +136,10 @@
         </button>
         <ng-container>
           <div class="tw-flex tw-justify-between tw-mt-2 tw-text-muted">
-            <div bitTypography="body2" class="tw-text-sm tw-font-bold">
+            <div bitTypography="body2" class="tw-font-bold">
               {{ "email" | i18n }}
             </div>
-            <div bitTypography="body2" class="tw-text-sm tw-font-bold">
+            <div bitTypography="body2" class="tw-font-bold">
               {{ "atRiskApplications" | i18n }}
             </div>
           </div>
@@ -162,7 +162,7 @@
       <span>{{ "atRiskApplicationsWithCount" | i18n: data.applications?.length ?? 0 }}</span>
     </ng-container>
     <ng-container bitDialogContent>
-      <span bitTypography="body1" class="tw-text-muted tw-text-sm">{{
+      <span bitTypography="body2" class="tw-text-muted">{{
         (data.applications?.length > 0
           ? "atRiskApplicationsDescription"
           : "atRiskApplicationsDescriptionNone"
@@ -180,10 +180,10 @@
             {{ "downloadCSV" | i18n }}
           </button>
           <div class="tw-flex tw-justify-between tw-mt-2 tw-text-muted">
-            <div bitTypography="body2" class="tw-text-sm tw-font-bold">
+            <div bitTypography="body2" class="tw-font-bold">
               {{ "application" | i18n }}
             </div>
-            <div bitTypography="body2" class="tw-text-sm tw-font-bold">
+            <div bitTypography="body2" class="tw-font-bold">
               {{ "atRiskPasswords" | i18n }}
             </div>
           </div>


### PR DESCRIPTION
## 🎟️ Tracking

[PM-38274](https://bitwarden.atlassian.net/browse/PM-38274)

## 📔 Objective

This pull request fixes font size for the helper text in **At-Risk drawer** views in Access Intelligence v2. The v1 drawer does not import the `TypographyModule` for an unknown reason while v2 does. Due to the missing import, there were slight differences in the font size. 

**Changes:**
- Update `bitTypography` for help text on all five views
- Removed redundant font size styling when `bitTypography` is applied across the file

**Note:**
- I am leaving the v1 version of the drawer since it is working and will be deleted after v2 migration is complete

## 📸 Screenshots

Helper text size after fix:

<img width="379" height="201" alt="Screenshot 2026-06-10 at 4 31 34 PM" src="https://github.com/user-attachments/assets/9546f104-cc9c-49e4-8987-967c8b8aa243" />


[PM-38274]: https://bitwarden.atlassian.net/browse/PM-38274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ