### PR TITLE
[PM-38831] fix: defective SyncPolicy push notification parsing

### DIFF
--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -1412,8 +1412,6 @@ export default class MainBackground {
       this.webPushConnectionService,
       this.authRequestAnsweringService,
       this.configService,
-      this.policyService,
-      this.newPolicyService,
       this.autoConfirmService,
       this.billingAccountProfileStateService,
     );

--- a/libs/angular/src/services/jslib-services.module.ts
+++ b/libs/angular/src/services/jslib-services.module.ts
@@ -1190,8 +1190,6 @@ const safeProviders: SafeProvider[] = [
       WebPushConnectionService,
       AuthRequestAnsweringService,
       ConfigService,
-      InternalPolicyService,
-      InternalNewPolicyService,
       AutomaticUserConfirmationService,
       BillingAccountProfileStateService,
     ],

--- a/libs/common/src/models/response/notification.response.ts
+++ b/libs/common/src/models/response/notification.response.ts
@@ -1,4 +1,3 @@
-import { Policy } from "@bitwarden/common/admin-console/models/domain/policy";
 import { NotificationViewResponse as EndUserNotificationResponse } from "@bitwarden/common/vault/notifications/models";
 
 import { NotificationType, PushNotificationLogOutReasonType } from "../../enums";
@@ -71,9 +70,6 @@ export class NotificationResponse extends BaseResponse {
         break;
       case NotificationType.ProviderBankAccountVerified:
         this.payload = new ProviderBankAccountVerifiedPushNotification(payload);
-        break;
-      case NotificationType.SyncPolicy:
-        this.payload = new SyncPolicyNotification(payload);
         break;
       case NotificationType.AutoConfirmMember:
         this.payload = new AutoConfirmMemberNotification(payload);
@@ -194,15 +190,6 @@ export class ProviderBankAccountVerifiedPushNotification extends BaseResponse {
     super(response);
     this.providerId = this.getResponseProperty("ProviderId");
     this.adminId = this.getResponseProperty("AdminId");
-  }
-}
-
-export class SyncPolicyNotification extends BaseResponse {
-  policy: Policy;
-
-  constructor(response: any) {
-    super(response);
-    this.policy = this.getResponseProperty("Policy");
   }
 }
 

--- a/libs/common/src/platform/server-notifications/internal/default-server-notifications.multiuser.spec.ts
+++ b/libs/common/src/platform/server-notifications/internal/default-server-notifications.multiuser.spec.ts
@@ -4,8 +4,6 @@ import { BehaviorSubject, bufferCount, firstValueFrom, Subject, ObservedValueOf 
 // eslint-disable-next-line no-restricted-imports
 import { LogoutReason } from "@bitwarden/auth/common";
 import { AutomaticUserConfirmationService } from "@bitwarden/auto-confirm";
-import { InternalNewPolicyService } from "@bitwarden/common/admin-console/abstractions/policy/new-policy.service.abstraction";
-import { InternalPolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
 import { AuthRequestAnsweringService } from "@bitwarden/common/auth/abstractions/auth-request-answering/auth-request-answering.service.abstraction";
 import { BillingAccountProfileStateService } from "@bitwarden/common/billing/abstractions/account/billing-account-profile-state.service";
 
@@ -38,8 +36,6 @@ describe("DefaultServerNotificationsService (multi-user)", () => {
   let webPushNotificationConnectionService: MockProxy<WebPushConnectionService>;
   let authRequestAnsweringService: MockProxy<AuthRequestAnsweringService>;
   let configService: MockProxy<ConfigService>;
-  let policyService: MockProxy<InternalPolicyService>;
-  let newPolicyService: MockProxy<InternalNewPolicyService>;
   let autoConfirmService: MockProxy<AutomaticUserConfirmationService>;
   let billingAccountProfileStateService: MockProxy<BillingAccountProfileStateService>;
 
@@ -135,8 +131,6 @@ describe("DefaultServerNotificationsService (multi-user)", () => {
 
     authRequestAnsweringService = mock<AuthRequestAnsweringService>();
 
-    policyService = mock<InternalPolicyService>();
-    newPolicyService = mock<InternalNewPolicyService>();
     autoConfirmService = mock<AutomaticUserConfirmationService>();
     billingAccountProfileStateService = mock<BillingAccountProfileStateService>();
 
@@ -153,8 +147,6 @@ describe("DefaultServerNotificationsService (multi-user)", () => {
       webPushNotificationConnectionService,
       authRequestAnsweringService,
       configService,
-      policyService,
-      newPolicyService,
       autoConfirmService,
       billingAccountProfileStateService,
     );

--- a/libs/common/src/platform/server-notifications/internal/default-server-notifications.service.spec.ts
+++ b/libs/common/src/platform/server-notifications/internal/default-server-notifications.service.spec.ts
@@ -5,9 +5,6 @@ import { BehaviorSubject, bufferCount, firstValueFrom, ObservedValueOf, of, Subj
 // eslint-disable-next-line no-restricted-imports
 import { LogoutReason } from "@bitwarden/auth/common";
 import { AutomaticUserConfirmationService } from "@bitwarden/auto-confirm";
-import { InternalNewPolicyService } from "@bitwarden/common/admin-console/abstractions/policy/new-policy.service.abstraction";
-import { InternalPolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
-import { PolicyType } from "@bitwarden/common/admin-console/enums";
 import { AuthRequestAnsweringService } from "@bitwarden/common/auth/abstractions/auth-request-answering/auth-request-answering.service.abstraction";
 import { BillingAccountProfileStateService } from "@bitwarden/common/billing/abstractions/account/billing-account-profile-state.service";
 
@@ -47,8 +44,6 @@ describe("NotificationsService", () => {
   let webPushNotificationConnectionService: MockProxy<WebPushConnectionService>;
   let authRequestAnsweringService: MockProxy<AuthRequestAnsweringService>;
   let configService: MockProxy<ConfigService>;
-  let policyService: MockProxy<InternalPolicyService>;
-  let newPolicyService: MockProxy<InternalNewPolicyService>;
   let autoConfirmService: MockProxy<AutomaticUserConfirmationService>;
   let billingAccountProfileStateService: MockProxy<BillingAccountProfileStateService>;
 
@@ -80,8 +75,6 @@ describe("NotificationsService", () => {
     webPushNotificationConnectionService = mock<WorkerWebPushConnectionService>();
     authRequestAnsweringService = mock<AuthRequestAnsweringService>();
     configService = mock<ConfigService>();
-    policyService = mock<InternalPolicyService>();
-    newPolicyService = mock<InternalNewPolicyService>();
     autoConfirmService = mock<AutomaticUserConfirmationService>();
     billingAccountProfileStateService = mock<BillingAccountProfileStateService>();
 
@@ -136,8 +129,6 @@ describe("NotificationsService", () => {
       webPushNotificationConnectionService,
       authRequestAnsweringService,
       configService,
-      policyService,
-      newPolicyService,
       autoConfirmService,
       billingAccountProfileStateService,
     );
@@ -466,64 +457,17 @@ describe("NotificationsService", () => {
     });
 
     describe("NotificationType.SyncPolicy", () => {
-      it("should call policyService.syncPolicy with the policy from the notification", async () => {
-        const mockPolicy = {
-          id: "policy-id",
-          organizationId: "org-id",
-          type: PolicyType.TwoFactorAuthentication,
-          enabled: true,
-          data: { test: "data" },
-        };
-
-        policyService.syncPolicy.mockResolvedValue();
-
+      it("forces a full sync so the API path can deserialize the policy", async () => {
         const notification = new NotificationResponse({
           type: NotificationType.SyncPolicy,
-          payload: { policy: mockPolicy },
+          payload: {},
           contextId: "different-app-id",
         });
 
         await sut["processNotification"](notification, mockUser1);
 
-        expect(policyService.syncPolicy).toHaveBeenCalledTimes(1);
-        expect(policyService.syncPolicy).toHaveBeenCalledWith(
-          expect.objectContaining({
-            id: mockPolicy.id,
-            organizationId: mockPolicy.organizationId,
-            type: mockPolicy.type,
-            enabled: mockPolicy.enabled,
-            data: mockPolicy.data,
-          }),
-        );
-      });
-
-      it("should handle SyncPolicy notification with minimal policy data", async () => {
-        const mockPolicy = {
-          id: "policy-id-2",
-          organizationId: "org-id-2",
-          type: PolicyType.RequireSso,
-          enabled: false,
-        };
-
-        policyService.syncPolicy.mockResolvedValue();
-
-        const notification = new NotificationResponse({
-          type: NotificationType.SyncPolicy,
-          payload: { policy: mockPolicy },
-          contextId: "different-app-id",
-        });
-
-        await sut["processNotification"](notification, mockUser1);
-
-        expect(policyService.syncPolicy).toHaveBeenCalledTimes(1);
-        expect(policyService.syncPolicy).toHaveBeenCalledWith(
-          expect.objectContaining({
-            id: mockPolicy.id,
-            organizationId: mockPolicy.organizationId,
-            type: mockPolicy.type,
-            enabled: mockPolicy.enabled,
-          }),
-        );
+        expect(syncService.fullSync).toHaveBeenCalledTimes(1);
+        expect(syncService.fullSync).toHaveBeenCalledWith(true);
       });
     });
 

--- a/libs/common/src/platform/server-notifications/internal/default-server-notifications.service.ts
+++ b/libs/common/src/platform/server-notifications/internal/default-server-notifications.service.ts
@@ -16,9 +16,6 @@ import {
 // eslint-disable-next-line no-restricted-imports
 import { LogoutReason } from "@bitwarden/auth/common";
 import { AutomaticUserConfirmationService } from "@bitwarden/auto-confirm";
-import { InternalNewPolicyService } from "@bitwarden/common/admin-console/abstractions/policy/new-policy.service.abstraction";
-import { InternalPolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
-import { PolicyData } from "@bitwarden/common/admin-console/models/data/policy.data";
 import { AuthRequestAnsweringService } from "@bitwarden/common/auth/abstractions/auth-request-answering/auth-request-answering.service.abstraction";
 import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { trackedMerge } from "@bitwarden/common/platform/misc";
@@ -74,8 +71,6 @@ export class DefaultServerNotificationsService implements ServerNotificationsSer
     private readonly webPushConnectionService: WebPushConnectionService,
     private readonly authRequestAnsweringService: AuthRequestAnsweringService,
     private readonly configService: ConfigService,
-    private readonly policyService: InternalPolicyService,
-    private readonly newPolicyService: InternalNewPolicyService,
     private autoConfirmService: AutomaticUserConfirmationService,
     private readonly billingAccountProfileStateService: BillingAccountProfileStateService,
   ) {
@@ -307,12 +302,11 @@ export class DefaultServerNotificationsService implements ServerNotificationsSer
           adminId: notification.payload.adminId,
         });
         break;
-      case NotificationType.SyncPolicy: {
-        const policyData = PolicyData.fromPolicy(notification.payload.policy);
-        await this.policyService.syncPolicy(policyData);
-        await this.newPolicyService.upsert(policyData, userId);
+      case NotificationType.SyncPolicy:
+        // TODO (PM-38875): this should compare against local data and only fetch the specific
+        // policy if required. For now just force a sync.
+        await this.syncService.fullSync(true);
         break;
-      }
       case NotificationType.AutoConfirmMember:
         await this.autoConfirmService.autoConfirmUser(
           notification.payload.userId,


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-38831

## 📔 Objective

After an org admin edited a policy, the next import/export attempt threw `Invalid UUID: undefined`from `Policy.toSdkPolicyView()`, breaking unrelated functionality across the org.

**Root cause:**

1. Server-side `SyncPolicyPushNotification` was sent in a push notification using the raw `Policy` entity — PascalCase keys and `Data` as the JSON string from storage — not the proper API `PolicyResponseModel`.
2. The handler called `PolicyData.fromPolicy(notification.payload.policy)`, which `Object.assign`s an untyped payload onto a `PolicyData`. The case mismatch left `policyData.id` `undefined`.
3. The bad entry was persisted into `POLICIES_NEW` state under the key `"undefined"`.
4. The old policy service silently tolerated this, but once `DefaultNewPolicyService` started routing policies through the SDK (PM-34157) — which strictly validates UUIDs — a single bad row took down the entire `policiesByType$` stream.

**Fix:** stop trying to deserialize the notification payload at all. The `SyncPolicy` handler now just triggers `syncService.fullSync(true)`, mirroring how `SyncOrganizations` already works. The sync path's existing `PolicyResponse` / `PolicyData` deserialization stays the single source of truth.

This is a quick fix for the next `rc` cut. Note:
- Mobile already handles `SyncPolicy` this way (full sync on receipt), so this aligns the clients.
- Policies don't change frequently, so the extra full-sync load is expected to be negligible.
- We'll revisit a more targeted update path under PM-38875. I think the proper handling is not to embed the policy object at all, but to send an `Id` + `RevisionDate` for the client to evaluate, and then fetch the updated policy from the server if required. That is out of scope for now.