### PR TITLE
[PM-38892] Remove unused methods invokeMenu and openContextMenu

### DIFF
--- a/apps/desktop/src/platform/preload.ts
+++ b/apps/desktop/src/platform/preload.ts
@@ -132,13 +132,6 @@ export default {
   log: (level: LogLevelType, message?: any, ...optionalParams: any[]) =>
     ipcRenderer.invoke("ipc.log", { level, message, optionalParams }),
 
-  openContextMenu: (
-    menu: {
-      label?: string;
-      type?: "normal" | "separator" | "submenu" | "checkbox" | "radio";
-    }[],
-  ): Promise<number> => ipcRenderer.invoke("openContextMenu", { menu }),
-
   getSystemTheme: (): Promise<ThemeType> => ipcRenderer.invoke("systemTheme"),
   onSystemThemeUpdated: (callback: (theme: ThemeType) => void) => {
     ipcRenderer.on("systemThemeUpdated", (_event, theme: ThemeType) => callback(theme));

--- a/apps/desktop/src/services/electron-main-messaging.service.ts
+++ b/apps/desktop/src/services/electron-main-messaging.service.ts
@@ -1,6 +1,6 @@
 import * as path from "path";
 
-import { app, dialog, ipcMain, Menu, MenuItem, nativeTheme, Notification } from "electron";
+import { app, dialog, ipcMain, nativeTheme, Notification } from "electron";
 
 import { ThemeType } from "@bitwarden/common/platform/enums";
 import { MessageSender, CommandDefinition } from "@bitwarden/common/platform/messaging";
@@ -10,7 +10,6 @@ import { UrlType } from "@bitwarden/common/platform/misc/safe-urls";
 
 import { WindowMain } from "../main/window.main";
 import { SafeShell } from "../platform/main/safe-shell.main";
-import { RendererMenuItem } from "../utils";
 
 export class ElectronMainMessagingService implements MessageSender {
   constructor(
@@ -27,29 +26,6 @@ export class ElectronMainMessagingService implements MessageSender {
 
     ipcMain.handle("showMessageBox", (event, options) => {
       return dialog.showMessageBox(this.windowMain.win, options);
-    });
-
-    ipcMain.handle("openContextMenu", (event, options: { menu: RendererMenuItem[] }) => {
-      return new Promise((resolve) => {
-        const menu = new Menu();
-        options.menu.forEach((m, index) => {
-          menu.append(
-            new MenuItem({
-              label: m.label,
-              type: m.type,
-              click: () => {
-                resolve(index);
-              },
-            }),
-          );
-        });
-        menu.popup({
-          window: windowMain.win,
-          callback: () => {
-            resolve(-1);
-          },
-        });
-      });
     });
 
     ipcMain.handle("windowVisible", () => {

--- a/apps/desktop/src/utils.ts
+++ b/apps/desktop/src/utils.ts
@@ -1,24 +1,5 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
-export type RendererMenuItem = {
-  label?: string;
-  type?: "normal" | "separator" | "submenu" | "checkbox" | "radio";
-  click?: () => any;
-};
-
-export function invokeMenu(menu: RendererMenuItem[]) {
-  const menuWithoutClick = menu.map((m) => {
-    return { label: m.label, type: m.type };
-  });
-  // FIXME: Verify that this floating promise is intentional. If it is, add an explanatory comment and ensure there is proper error handling.
-  // eslint-disable-next-line @typescript-eslint/no-floating-promises
-  ipc.platform.openContextMenu(menuWithoutClick).then((i: number) => {
-    if (i !== -1) {
-      menu[i].click();
-    }
-  });
-}
-
 export function isDev() {
   return BIT_ENVIRONMENT === "development";
 }


### PR DESCRIPTION
## 🎟️ Tracking
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-38892

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
While working on https://github.com/bitwarden/clients/pull/21195 I noticed the invokeMenu method and was curious if it was still being used. A right click context menu was present on desktop looking at:
- https://github.com/search?q=repo%3Abitwarden%2Fdesktop%20invokeMenu&type=code
- https://github.com/search?q=repo%3Abitwarden%2Fjslib+openContextMenu&type=code
but has since been removed/replace by a web-based right click menu with https://github.com/bitwarden/clients/pull/10954

Removing this code should be save as no calling references to invokeMenu or openContextMenu can be found on current main.