### PR TITLE
fix(nx): clear build dependsOn workspace default

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -33,7 +33,7 @@
   "parallel": 4,
   "targetDefaults": {
     "build": {
-      "dependsOn": ["^build"],
+      "dependsOn": [],
       "inputs": ["production", "^production"],
       "outputs": ["{options.outputPath}"],
       "cache": true


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-38889

## 📔 Objective

Current `clients` apps bundle libs via @bitwarden/* path aliases in tsconfig.base.json that resolve to sibling lib source, not dist artifacts.

The workspace default targetDefaults.build.dependsOn: ["^build"] is an artifact-based declaration that does not match the codebase. Combined with @nx/js plugin auto-inference of build targets on every lib with a tsconfig.lib.json, it forces nx build <app> to walk into leaf libs that cannot compile standalone with tsc. This causes failed builds.

This commit changes the workspace default to [], making the declaration match the actual bundling pattern. Apps no longer pull broken leaf libs through their build chain, instead using their dependencies with their aliases.

This isn't ideal. Once circular dependencies are addressed across the monorepo, we'll want to swap the build pattern such that apps build from dist copies of depended upon libs.

## 📸 Screenshots

On the left: `main` failing to build web. On the right: this branch building web successfully.

<img width="1728" height="1084" alt="Screenshot 2026-06-11 at 10 03 39 AM" src="https://github.com/user-attachments/assets/2c85f213-a73c-4a83-80b0-8bab39fc6d43" />
