### PR TITLE
[PM-38891] fix: Bind subscription strikethrough price to actual billing interval

### DIFF
--- a/apps/web/src/app/billing/organizations/organization-subscription-cloud.component.html
+++ b/apps/web/src/app/billing/organizations/organization-subscription-cloud.component.html
@@ -61,7 +61,7 @@
                         "
                         class="tw-line-through !tw-text-muted"
                         >{{ i.quantity * i.originalAmount | currency: "$" }} /
-                        {{ "year" | i18n }}</span
+                        {{ i.interval | i18n }}</span
                       >
                     </div>
                   </ng-template>


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-38891

## 📔 Objective

The struck-through "original" price on the **Organization → Billing → Subscription** details line hardcoded its billing-cadence label to the `"year"` i18n key. Monthly plans therefore rendered the strikethrough as "$35.00 / **year**" while the active discounted price on the same line correctly read "$28.00 / month". The amount was always correct (5 seats × $7 = $35 monthly subtotal); only the unit label was wrong.

The strikethrough only renders when a percent-off customer discount is applied, so the legacy Enterprise/Teams 2020 Monthly migration cohort (parent PM-37228) surfaced this previously-latent bug. Annual plans were unaffected because their interval is already `"year"`.

This binds the strikethrough's cadence label to the line item's actual interval (`i.interval`), mirroring the active-price span directly above it. One-line template change, no new i18n keys (the `"month"` key is already consumed by the active-price span).