### PR TITLE
[PM-25277] SSH Key desktop translations

### DIFF
--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -882,6 +882,15 @@
       }
     }
   },
+  "copyPrivateKey": {
+    "message": "Copy private key"
+  },
+  "copyPublicKey": {
+    "message": "Copy public key"
+  },
+  "copyFingerprint": {
+    "message": "Copy fingerprint"
+  },
   "length": {
     "message": "Length"
   },


### PR DESCRIPTION
## 🎟️ Tracking

[PM-25277](https://bitwarden.atlassian.net/browse/PM-25277)

## 📔 Objective

The copy translations for SSH Keys were missing on the desktop. Added them here! 

## 📸 Screenshots

<video src="https://github.com/user-attachments/assets/e2c24add-0454-4ead-a55f-927dfa7e2efd"/>




[PM-25277]: https://bitwarden.atlassian.net/browse/PM-25277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ