### PR TITLE
[BRE-2017] Pin snapcraft to 8.x/stable to fix Linux builds

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -202,7 +202,7 @@ jobs:
           sudo apt-get -y install pkg-config libxss-dev rpm flatpak flatpak-builder
 
       - name: Set up Snap
-        run: sudo snap install snapcraft --classic
+        run: sudo snap install snapcraft --classic --channel=8.x/stable
 
       - name: Print environment
         run: |
@@ -359,7 +359,7 @@ jobs:
           sudo gem install --no-document fpm
 
       - name: Set up Snap
-        run: sudo snap install snapcraft --classic
+        run: sudo snap install snapcraft --classic --channel=8.x/stable
 
       - name: Install snaps required by snapcraft in destructive mode
         run: |


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/BRE-2017

## 📔 Objective

Snapcraft `9.0.0` removed the deprecated `snap` command. electron-builder `26.x` still uses this command for core22 builds. Pinning to `8.x/stable` as temporary fix until electron-builder [v27](https://github.com/electron-userland/electron-builder/pull/9517) is released.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
