### PR TITLE
[PM-38867] Fix: add error toast if no owner for a new item 

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -6681,5 +6681,8 @@
   },
   "errorImportingMyItemsMultiCollection": {
     "message": "You cannot import items into My Items that are part of multiple collections"
+  },
+  "cannotSaveItemNoConfirmedOrgs": {
+    "message": "Unable to save item. You must be confirmed to the organization to save items."
   }
 }

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -5345,5 +5345,8 @@
   },
   "licenseClass": {
     "message": "License class"
+  },
+  "cannotSaveItemNoConfirmedOrgs": {
+    "message": "Unable to save item. You must be confirmed to the organization to save items."
   }
 }

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -14429,5 +14429,8 @@
   },
   "copy": {
     "message": "Copy"
+  },
+  "cannotSaveItemNoConfirmedOrgs": {
+    "message": "Unable to save item. You must be confirmed to the organization to save items."
   }
 }

--- a/libs/vault/src/cipher-form/components/cipher-form.component.spec.ts
+++ b/libs/vault/src/cipher-form/components/cipher-form.component.spec.ts
@@ -74,7 +74,10 @@ describe("CipherFormComponent", () => {
 
   describe("submit", () => {
     beforeEach(() => {
-      component.config = { mode: "edit" } as CipherFormConfig;
+      component.config = {
+        mode: "edit",
+        organizationDataOwnershipDisabled: true,
+      } as CipherFormConfig;
 
       component["updatedCipherView"] = new CipherView();
       component["updatedCipherView"].archivedDate = new Date();
@@ -92,6 +95,29 @@ describe("CipherFormComponent", () => {
 
       expect(component["updatedCipherView"]?.archivedDate).toBeNull();
       expect(mockCipherArchiveService.userCanArchive$).toHaveBeenCalledWith("user-id");
+    });
+
+    it("shows an error toast and aborts when the policy applies but there are no eligible orgs", async () => {
+      component.config = {
+        mode: "add",
+        organizationDataOwnershipDisabled: false,
+        organizations: [],
+      } as unknown as CipherFormConfig;
+
+      const toastService = TestBed.inject(ToastService);
+      const showToast = jest.spyOn(toastService, "showToast");
+      mockAddEditFormService.saveCipher = jest.fn();
+      const cipherSavedSpy = jest.fn();
+      component.cipherSaved.subscribe(cipherSavedSpy);
+
+      await component.submit();
+
+      expect(showToast).toHaveBeenCalledWith({
+        variant: "error",
+        message: "cannotSaveItemNoConfirmedOrgs",
+      });
+      expect(mockAddEditFormService.saveCipher).not.toHaveBeenCalled();
+      expect(cipherSavedSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/libs/vault/src/cipher-form/components/cipher-form.component.ts
+++ b/libs/vault/src/cipher-form/components/cipher-form.component.ts
@@ -370,6 +370,14 @@ export class CipherFormComponent implements AfterViewInit, OnInit, OnChanges, Ci
   }
 
   submit = async () => {
+    if (!this.config.organizationDataOwnershipDisabled && this.config.organizations.length === 0) {
+      this.toastService.showToast({
+        variant: "error",
+        message: this.i18nService.t("cannotSaveItemNoConfirmedOrgs"),
+      });
+      return;
+    }
+
     let successToast: string = "editedItem";
     if (this.cipherForm.invalid) {
       this.cipherForm.markAllAsTouched();

--- a/libs/vault/src/cipher-form/components/item-details/item-details-section.component.spec.ts
+++ b/libs/vault/src/cipher-form/components/item-details/item-details-section.component.spec.ts
@@ -131,12 +131,13 @@ describe("ItemDetailsSectionComponent", () => {
   });
 
   describe("ngOnInit", () => {
-    it("should throw an error if no organizations are available for ownership and organization data ownership is enabled", async () => {
+    it("should initialize with a null organizationId when no organizations are available for ownership and organization data ownership is enabled", async () => {
       component.config.organizationDataOwnershipDisabled = false;
       component.config.organizations = [];
-      await expect(component.ngOnInit()).rejects.toThrow(
-        "No organizations available for ownership.",
-      );
+
+      await expect(component.ngOnInit()).resolves.not.toThrow();
+
+      expect(component.itemDetailsForm.controls.organizationId.value).toBeNull();
     });
 
     it("should initialize form with default values if no originalCipher is provided", fakeAsync(async () => {

--- a/libs/vault/src/cipher-form/components/item-details/item-details-section.component.ts
+++ b/libs/vault/src/cipher-form/components/item-details/item-details-section.component.ts
@@ -219,10 +219,6 @@ export class ItemDetailsSectionComponent implements OnInit {
 
     this.userId = await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId));
 
-    if (!this.allowPersonalOwnership && this.organizations.length === 0) {
-      throw new Error("No organizations available for ownership.");
-    }
-
     const prefillCipher = this.cipherFormContainer.getInitialCipherView();
 
     if (prefillCipher) {

--- a/libs/vault/src/cipher-form/components/item-details/item-details-section.component.ts
+++ b/libs/vault/src/cipher-form/components/item-details/item-details-section.component.ts
@@ -209,7 +209,12 @@ export class ItemDetailsSectionComponent implements OnInit {
   }
 
   get defaultOwner() {
-    return this.allowPersonalOwnership ? null : this.organizations[0].id;
+    // Default to personal ownership if permitted or if there are no other alternatives
+    // (in which case the top level component will show an error toast on submit)
+    if (this.allowPersonalOwnership || this.organizations.length === 0) {
+      return null;
+    }
+    return this.organizations[0].id;
   }
 
   async ngOnInit() {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-38867

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
With #20377, we are enforcing policies as soon as a user accepts their invite. However, this causes the following problem:

> A user in the accepted state has the Centralize Org Policy enforced against them, so they can’t create personal items, but they also can’t create organization items until they’re confirmed. This is an in-between state we didn’t have previously.

Current behavior:
- `ItemDetailsSectionComponent` does check for this state, but it [throws an error](https://github.com/bitwarden/clients/blob/main/libs/vault/src/cipher-form/components/item-details/item-details-section.component.ts#L223) that is unhandled and leaves the form partially initialized (particularly noticeable when editing an existing item - the load logic never gets executed)
- when the save button is clicked, it shows a `1 field needs attention` error, but with no inline error message.

New behavior:
- remove the unhandled throw - instead default to `null` (personal ownership) in this case. This allows the form to load properly even though it's invalid, and this will be caught on submit below.
- move the check to the submit method and show a toast: "Unable to save item. You must be confirmed to the organization to save items."

This is a quick fix for the `rc` cut on Monday. Product & Design will refine a nicer solution as follow-up work.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/440563c5-7e70-4add-a75b-acf0de87a336

