### PR TITLE
[PM-38985] Fix CipherResponse/CipherData type confusion in archive and emergency access services

### DIFF
--- a/apps/web/src/app/auth/emergency-access/services/emergency-access.service.ts
+++ b/apps/web/src/app/auth/emergency-access/services/emergency-access.service.ts
@@ -20,6 +20,7 @@ import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { UserId } from "@bitwarden/common/types/guid";
 import { UserKey } from "@bitwarden/common/types/key";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
+import { CipherData } from "@bitwarden/common/vault/models/data/cipher.data";
 import { Cipher } from "@bitwarden/common/vault/models/domain/cipher";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import {
@@ -267,7 +268,7 @@ export class EmergencyAccessService implements UserKeyRotationKeyRecoveryProvide
     )) as UserKey;
 
     let ciphers: CipherView[] = [];
-    const ciphersEncrypted = response.ciphers.map((c) => new Cipher(c));
+    const ciphersEncrypted = response.ciphers.map((c) => new Cipher(new CipherData(c)));
     ciphers = await Promise.all(ciphersEncrypted.map(async (c) => c.decrypt(grantorUserKey)));
     return ciphers.sort(this.cipherService.getLocaleSortingFunction());
   }

--- a/libs/common/src/vault/services/default-cipher-archive.service.ts
+++ b/libs/common/src/vault/services/default-cipher-archive.service.ts
@@ -76,7 +76,7 @@ export class DefaultCipherArchiveService implements CipherArchiveService {
     );
 
     await this.cipherService.upsert(responseDataArray, userId);
-    return response.data[0];
+    return responseDataArray[0];
   }
 
   async unarchiveWithServer(ids: CipherId | CipherId[], userId: UserId): Promise<CipherData> {
@@ -90,6 +90,6 @@ export class DefaultCipherArchiveService implements CipherArchiveService {
     );
 
     await this.cipherService.upsert(responseDataArray, userId);
-    return response.data[0];
+    return responseDataArray[0];
   }
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-38985](https://bitwarden.atlassian.net/browse/PM-38985)

## 📔 Objective

Fixes two places where a `CipherResponse` was silently passed where a `CipherData` was expected. No user facing changes. 

- In `default-cipher-archive.service.ts`, `archiveWithServer` and `unarchiveWithServer` were returning `response.data[0]` (a `CipherResponse`) instead of `responseDataArray[0]` (the already-constructed `CipherData`). 
- In `emergency-access.service.ts`, each `CipherResponse` was passed directly to `new Cipher()` without first being wrapped in `new CipherData()`, which skips the field normalization that `Cipher` relies on.

[PM-38985]: https://bitwarden.atlassian.net/browse/PM-38985?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ