### PR TITLE
[PM-38992] Fix Targeting Rules autofilling new password inputs with current password values

### DIFF
--- a/apps/browser/src/autofill/services/autofill-overlay-content.service.ts
+++ b/apps/browser/src/autofill/services/autofill-overlay-content.service.ts
@@ -3,6 +3,7 @@ import "lit/polyfill-support.js";
 import { FocusableElement, tabbable } from "tabbable";
 
 import {
+  AutofillTargetingRuleTypes,
   AUTOFILL_OVERLAY_HANDLE_REPOSITION,
   AUTOFILL_OVERLAY_HANDLE_SCROLL,
   AUTOFILL_TRIGGER_FORM_FIELD_SUBMIT,
@@ -1176,6 +1177,11 @@ export class AutofillOverlayContentService implements AutofillOverlayContentServ
     // Targeted fields use AutofillTargetingRuleType values in fieldQualifier,
     // which are distinct from the heuristic AutofillFieldQualifierType values.
     const qualifier = autofillFieldData.fieldQualifier as AutofillTargetingRuleType;
+
+    if (qualifier === AutofillTargetingRuleTypes.newPassword) {
+      autofillFieldData.inlineMenuFillType = InlineMenuFillTypes.PasswordGeneration;
+      return;
+    }
 
     if (loginQualifiers.includes(qualifier)) {
       autofillFieldData.inlineMenuFillType = CipherType.Login;

--- a/apps/browser/src/autofill/services/autofill.service.ts
+++ b/apps/browser/src/autofill/services/autofill.service.ts
@@ -921,11 +921,11 @@ export default class AutofillService implements AutofillServiceInterface {
     if (fieldType === AutofillTargetingRuleTypes.username) {
       return cipher.login?.username ?? null;
     }
-    if (
-      fieldType === AutofillTargetingRuleTypes.password ||
-      fieldType === AutofillTargetingRuleTypes.newPassword
-    ) {
+    if (fieldType === AutofillTargetingRuleTypes.password) {
       return cipher.login?.password ?? null;
+    }
+    if (fieldType === AutofillTargetingRuleTypes.newPassword) {
+      return null;
     }
 
     // Card fields


### PR DESCRIPTION
## 🎟️ Tracking

[PM-38992](https://bitwarden.atlassian.net/browse/PM-38992)

## 📔 Objective

> Note: split from https://github.com/bitwarden/clients/pull/20970

Fixed:

- `newPassword` targeted fields no longer fill with the cipher's current password during a normal Login fill.
- `newPassword` targeted fields now map to `InlineMenuFillTypes.PasswordGeneration` (not `CipherType.Login`), so the inline menu offers the generator instead of the cipher list.

[PM-38992]: https://bitwarden.atlassian.net/browse/PM-38992?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ