### PR TITLE
[PM-39000] Fix targeted new password field not filling upon click on generate password inline menu

### DIFF
--- a/apps/browser/src/autofill/services/autofill.service.spec.ts
+++ b/apps/browser/src/autofill/services/autofill.service.spec.ts
@@ -5,7 +5,10 @@ import { PolicyService } from "@bitwarden/common/admin-console/abstractions/poli
 import { AuthService } from "@bitwarden/common/auth/abstractions/auth.service";
 import { AuthenticationStatus } from "@bitwarden/common/auth/enums/authentication-status";
 import { UserVerificationService } from "@bitwarden/common/auth/services/user-verification/user-verification.service";
-import { AutofillOverlayVisibility } from "@bitwarden/common/autofill/constants";
+import {
+  AutofillOverlayVisibility,
+  AutofillTargetingRuleTypes,
+} from "@bitwarden/common/autofill/constants";
 import { AutofillSettingsServiceAbstraction } from "@bitwarden/common/autofill/services/autofill-settings.service";
 import {
   DefaultDomainSettingsService,
@@ -1863,6 +1866,95 @@ describe("AutofillService", () => {
         expect(generateTargetedFillScriptSpy).not.toHaveBeenCalled();
         expect(generateLoginFillScriptSpy).not.toHaveBeenCalled();
       });
+    });
+  });
+
+  describe("generateTargetedFillScript", () => {
+    const buildTargetedPageDetails = (fields: AutofillField[]) =>
+      createAutofillPageDetailsMock({ fields });
+
+    const buildTargetedField = (overrides: Partial<AutofillField>) =>
+      createAutofillFieldMock({
+        targeted: true,
+        ...overrides,
+      });
+
+    it("skips newPassword fields for a normal Login cipher fill (avoids leaking current password)", async () => {
+      const newPasswordField = buildTargetedField({
+        opid: "targeted_field_0_newPassword_0",
+        type: "password",
+        fieldQualifier: AutofillTargetingRuleTypes.newPassword,
+      });
+      const options = createGenerateFillScriptOptionsMock();
+      options.cipher.type = CipherType.Login;
+      options.cipher.login = mock<LoginView>({ password: "stored-password", uris: [] });
+      options.inlineMenuFillType = CipherType.Login;
+
+      const result = await autofillService["generateTargetedFillScript"](
+        buildTargetedPageDetails([newPasswordField]),
+        options,
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it("fills newPassword fields with the cipher password when inlineMenuFillType is PasswordGeneration", async () => {
+      const newPasswordField = buildTargetedField({
+        opid: "targeted_field_0_newPassword_0",
+        type: "password",
+        fieldQualifier: AutofillTargetingRuleTypes.newPassword,
+      });
+      const confirmNewPasswordField = buildTargetedField({
+        opid: "targeted_field_0_newPassword_1",
+        type: "password",
+        fieldQualifier: AutofillTargetingRuleTypes.newPassword,
+      });
+      const options = createGenerateFillScriptOptionsMock();
+      options.cipher.type = CipherType.Login;
+      options.cipher.login = mock<LoginView>({ password: "generated-pass", uris: [] });
+      options.inlineMenuFillType = InlineMenuFillTypes.PasswordGeneration;
+      jest.spyOn(AutofillService, "fillByOpid");
+
+      const result = await autofillService["generateTargetedFillScript"](
+        buildTargetedPageDetails([newPasswordField, confirmNewPasswordField]),
+        options,
+      );
+
+      expect(result).not.toBeNull();
+      expect(AutofillService.fillByOpid).toHaveBeenCalledWith(
+        expect.anything(),
+        newPasswordField,
+        "generated-pass",
+      );
+      expect(AutofillService.fillByOpid).toHaveBeenCalledWith(
+        expect.anything(),
+        confirmNewPasswordField,
+        "generated-pass",
+      );
+    });
+
+    it("fills the current-password field via the standard mapping even on a PasswordGeneration fill", async () => {
+      const passwordField = buildTargetedField({
+        opid: "targeted_field_0_password_0",
+        type: "password",
+        fieldQualifier: AutofillTargetingRuleTypes.password,
+      });
+      const options = createGenerateFillScriptOptionsMock();
+      options.cipher.type = CipherType.Login;
+      options.cipher.login = mock<LoginView>({ password: "stored-password", uris: [] });
+      options.inlineMenuFillType = InlineMenuFillTypes.PasswordGeneration;
+      jest.spyOn(AutofillService, "fillByOpid");
+
+      await autofillService["generateTargetedFillScript"](
+        buildTargetedPageDetails([passwordField]),
+        options,
+      );
+
+      expect(AutofillService.fillByOpid).toHaveBeenCalledWith(
+        expect.anything(),
+        passwordField,
+        "stored-password",
+      );
     });
   });
 

--- a/apps/browser/src/autofill/services/autofill.service.ts
+++ b/apps/browser/src/autofill/services/autofill.service.ts
@@ -884,6 +884,8 @@ export default class AutofillService implements AutofillServiceInterface {
   ): Promise<AutofillScript | null> {
     const fillScript = new AutofillScript();
     const cipher = options.cipher;
+    const isPasswordGeneration =
+      options.inlineMenuFillType === InlineMenuFillTypes.PasswordGeneration;
 
     fillScript.savedUrls =
       cipher.login?.uris
@@ -898,7 +900,14 @@ export default class AutofillService implements AutofillServiceInterface {
         continue;
       }
 
-      const value = this.getValueForTargetedFieldType(field.fieldQualifier, cipher);
+      // Password-generation flow synthesizes a Login cipher whose `password`
+      // carries the generated value. The standard newPassword → null policy
+      // would suppress that fill, so override it here.
+      const value =
+        isPasswordGeneration && field.fieldQualifier === AutofillTargetingRuleTypes.newPassword
+          ? (cipher.login?.password ?? null)
+          : this.getValueForTargetedFieldType(field.fieldQualifier, cipher);
+
       if (!value) {
         continue;
       }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-39000](https://bitwarden.atlassian.net/browse/PM-39000)

## 📔 Objective

> Note: split from https://github.com/bitwarden/clients/pull/20970

Fix targeted new password field not filling upon click on generate password inline menu


[PM-39000]: https://bitwarden.atlassian.net/browse/PM-39000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ