### PR TITLE
[PM- 38988] Fix Trial Dialog Dismissal Caching

### DIFF
--- a/apps/web/src/app/billing/organizations/warnings/services/organization-warnings.service.spec.ts
+++ b/apps/web/src/app/billing/organizations/warnings/services/organization-warnings.service.spec.ts
@@ -89,7 +89,9 @@ describe("OrganizationWarningsService", () => {
     platformUtilsService.isSelfHost.mockReturnValue(false);
     accountService.activeAccount$ = of(activeAccount);
     stateProvider.getUserState$.mockReturnValue(of(null));
-    stateProvider.getUser.mockReturnValue({ update: jest.fn().mockResolvedValue(undefined) } as any);
+    stateProvider.getUser.mockReturnValue({
+      update: jest.fn().mockResolvedValue(undefined),
+    } as any);
 
     i18nService.t.mockImplementation((key: string, ...args: any[]) => {
       switch (key) {

--- a/apps/web/src/app/billing/organizations/warnings/services/organization-warnings.service.spec.ts
+++ b/apps/web/src/app/billing/organizations/warnings/services/organization-warnings.service.spec.ts
@@ -89,7 +89,7 @@ describe("OrganizationWarningsService", () => {
     platformUtilsService.isSelfHost.mockReturnValue(false);
     accountService.activeAccount$ = of(activeAccount);
     stateProvider.getUserState$.mockReturnValue(of(null));
-    stateProvider.setUserState.mockResolvedValue([activeAccount.id, null]);
+    stateProvider.getUser.mockReturnValue({ update: jest.fn().mockResolvedValue(undefined) } as any);
 
     i18nService.t.mockImplementation((key: string, ...args: any[]) => {
       switch (key) {
@@ -825,10 +825,9 @@ describe("OrganizationWarningsService", () => {
 
       service.showSubscribeBeforeFreeTrialEndsDialog$(organization).subscribe({
         complete: () => {
-          expect(stateProvider.setUserState).toHaveBeenCalledWith(
-            TRIAL_PAYMENT_MODAL_DISMISSED_ORGS_KEY,
-            expect.objectContaining({ [organization.id]: true }),
+          expect(stateProvider.getUser).toHaveBeenCalledWith(
             activeAccount.id,
+            TRIAL_PAYMENT_MODAL_DISMISSED_ORGS_KEY,
           );
           done();
         },
@@ -850,10 +849,9 @@ describe("OrganizationWarningsService", () => {
 
       service.showSubscribeBeforeFreeTrialEndsDialog$(organization).subscribe({
         complete: () => {
-          expect(stateProvider.setUserState).toHaveBeenCalledWith(
-            TRIAL_PAYMENT_MODAL_DISMISSED_ORGS_KEY,
-            expect.objectContaining({ [organization.id]: true }),
+          expect(stateProvider.getUser).toHaveBeenCalledWith(
             activeAccount.id,
+            TRIAL_PAYMENT_MODAL_DISMISSED_ORGS_KEY,
           );
           done();
         },
@@ -875,7 +873,7 @@ describe("OrganizationWarningsService", () => {
 
       service.showSubscribeBeforeFreeTrialEndsDialog$(organization).subscribe({
         complete: () => {
-          expect(stateProvider.setUserState).not.toHaveBeenCalled();
+          expect(stateProvider.getUser).not.toHaveBeenCalled();
           done();
         },
       });

--- a/apps/web/src/app/billing/organizations/warnings/services/organization-warnings.service.spec.ts
+++ b/apps/web/src/app/billing/organizations/warnings/services/organization-warnings.service.spec.ts
@@ -65,17 +65,31 @@ describe("OrganizationWarningsService", () => {
       year: "numeric",
     });
 
+  const activeAccount: Account = {
+    id: "user-id-123" as UserId,
+    email: "test@example.com",
+    emailVerified: true,
+    name: undefined,
+    creationDate: undefined,
+  };
+
   beforeEach(() => {
+    accountService = mock<AccountService>();
     dialogService = mock<DialogService>();
     i18nService = mock<I18nService>();
+    logService = mock<LogService>();
     organizationApiService = mock<OrganizationApiServiceAbstraction>();
     organizationBillingClient = mock<OrganizationBillingClient>();
     platformUtilsService = mock<PlatformUtilsService>();
     router = mock<Router>();
+    stateProvider = mock<StateProvider>();
 
     (openChangePlanDialog as jest.Mock).mockReset();
 
     platformUtilsService.isSelfHost.mockReturnValue(false);
+    accountService.activeAccount$ = of(activeAccount);
+    stateProvider.getUserState$.mockReturnValue(of(null));
+    stateProvider.setUserState.mockResolvedValue([activeAccount.id, null]);
 
     i18nService.t.mockImplementation((key: string, ...args: any[]) => {
       switch (key) {

--- a/apps/web/src/app/billing/organizations/warnings/services/organization-warnings.service.spec.ts
+++ b/apps/web/src/app/billing/organizations/warnings/services/organization-warnings.service.spec.ts
@@ -815,9 +815,9 @@ describe("OrganizationWarningsService", () => {
         freeTrial: { remainingTrialDays: 2 },
       } as OrganizationWarningsResponse);
 
-      organizationApiService.getSubscription.mockResolvedValue(
-        { id: "sub-123" } as OrganizationSubscriptionResponse,
-      );
+      organizationApiService.getSubscription.mockResolvedValue({
+        id: "sub-123",
+      } as OrganizationSubscriptionResponse);
 
       jest.spyOn(TrialPaymentDialogComponent, "open").mockReturnValue({
         closed: of(TRIAL_PAYMENT_METHOD_DIALOG_RESULT_TYPE.CLOSED),
@@ -840,9 +840,9 @@ describe("OrganizationWarningsService", () => {
         freeTrial: { remainingTrialDays: 2 },
       } as OrganizationWarningsResponse);
 
-      organizationApiService.getSubscription.mockResolvedValue(
-        { id: "sub-123" } as OrganizationSubscriptionResponse,
-      );
+      organizationApiService.getSubscription.mockResolvedValue({
+        id: "sub-123",
+      } as OrganizationSubscriptionResponse);
 
       jest.spyOn(TrialPaymentDialogComponent, "open").mockReturnValue({
         closed: of(undefined),
@@ -865,9 +865,9 @@ describe("OrganizationWarningsService", () => {
         freeTrial: { remainingTrialDays: 2 },
       } as OrganizationWarningsResponse);
 
-      organizationApiService.getSubscription.mockResolvedValue(
-        { id: "sub-123" } as OrganizationSubscriptionResponse,
-      );
+      organizationApiService.getSubscription.mockResolvedValue({
+        id: "sub-123",
+      } as OrganizationSubscriptionResponse);
 
       jest.spyOn(TrialPaymentDialogComponent, "open").mockReturnValue({
         closed: of(TRIAL_PAYMENT_METHOD_DIALOG_RESULT_TYPE.SUBMITTED),

--- a/apps/web/src/app/billing/organizations/warnings/services/organization-warnings.service.spec.ts
+++ b/apps/web/src/app/billing/organizations/warnings/services/organization-warnings.service.spec.ts
@@ -791,5 +791,94 @@ describe("OrganizationWarningsService", () => {
         },
       });
     });
+
+    it("should not open dialog when already dismissed for the organization", (done) => {
+      organizationBillingClient.getWarnings.mockResolvedValue({
+        freeTrial: { remainingTrialDays: 2 },
+      } as OrganizationWarningsResponse);
+
+      stateProvider.getUserState$.mockReturnValue(of({ [organization.id]: true }));
+
+      const openSpy = jest.spyOn(TrialPaymentDialogComponent, "open");
+      openSpy.mockClear();
+
+      service.showSubscribeBeforeFreeTrialEndsDialog$(organization).subscribe({
+        complete: () => {
+          expect(openSpy).not.toHaveBeenCalled();
+          done();
+        },
+      });
+    });
+
+    it("should persist dismissal when dialog is closed without submitting", (done) => {
+      organizationBillingClient.getWarnings.mockResolvedValue({
+        freeTrial: { remainingTrialDays: 2 },
+      } as OrganizationWarningsResponse);
+
+      organizationApiService.getSubscription.mockResolvedValue(
+        { id: "sub-123" } as OrganizationSubscriptionResponse,
+      );
+
+      jest.spyOn(TrialPaymentDialogComponent, "open").mockReturnValue({
+        closed: of(TRIAL_PAYMENT_METHOD_DIALOG_RESULT_TYPE.CLOSED),
+      } as DialogRef<TrialPaymentDialogResultType>);
+
+      service.showSubscribeBeforeFreeTrialEndsDialog$(organization).subscribe({
+        complete: () => {
+          expect(stateProvider.setUserState).toHaveBeenCalledWith(
+            TRIAL_PAYMENT_MODAL_DISMISSED_ORGS_KEY,
+            expect.objectContaining({ [organization.id]: true }),
+            activeAccount.id,
+          );
+          done();
+        },
+      });
+    });
+
+    it("should persist dismissal when dialog is dismissed via X button or outside click", (done) => {
+      organizationBillingClient.getWarnings.mockResolvedValue({
+        freeTrial: { remainingTrialDays: 2 },
+      } as OrganizationWarningsResponse);
+
+      organizationApiService.getSubscription.mockResolvedValue(
+        { id: "sub-123" } as OrganizationSubscriptionResponse,
+      );
+
+      jest.spyOn(TrialPaymentDialogComponent, "open").mockReturnValue({
+        closed: of(undefined),
+      } as DialogRef<TrialPaymentDialogResultType>);
+
+      service.showSubscribeBeforeFreeTrialEndsDialog$(organization).subscribe({
+        complete: () => {
+          expect(stateProvider.setUserState).toHaveBeenCalledWith(
+            TRIAL_PAYMENT_MODAL_DISMISSED_ORGS_KEY,
+            expect.objectContaining({ [organization.id]: true }),
+            activeAccount.id,
+          );
+          done();
+        },
+      });
+    });
+
+    it("should not persist dismissal when dialog is submitted", (done) => {
+      organizationBillingClient.getWarnings.mockResolvedValue({
+        freeTrial: { remainingTrialDays: 2 },
+      } as OrganizationWarningsResponse);
+
+      organizationApiService.getSubscription.mockResolvedValue(
+        { id: "sub-123" } as OrganizationSubscriptionResponse,
+      );
+
+      jest.spyOn(TrialPaymentDialogComponent, "open").mockReturnValue({
+        closed: of(TRIAL_PAYMENT_METHOD_DIALOG_RESULT_TYPE.SUBMITTED),
+      } as DialogRef<TrialPaymentDialogResultType>);
+
+      service.showSubscribeBeforeFreeTrialEndsDialog$(organization).subscribe({
+        complete: () => {
+          expect(stateProvider.setUserState).not.toHaveBeenCalled();
+          done();
+        },
+      });
+    });
   });
 });

--- a/apps/web/src/app/billing/organizations/warnings/services/organization-warnings.service.spec.ts
+++ b/apps/web/src/app/billing/organizations/warnings/services/organization-warnings.service.spec.ts
@@ -13,17 +13,24 @@ import { of } from "rxjs";
 
 import { OrganizationApiServiceAbstraction } from "@bitwarden/common/admin-console/abstractions/organization/organization-api.service.abstraction";
 import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
+import { Account, AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { ProductTierType } from "@bitwarden/common/billing/enums";
 import { OrganizationSubscriptionResponse } from "@bitwarden/common/billing/models/response/organization-subscription.response";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
+import { UserId } from "@bitwarden/common/types/guid";
 import { DialogRef, DialogService } from "@bitwarden/components";
+import { StateProvider } from "@bitwarden/state";
 import { OrganizationBillingClient } from "@bitwarden/web-vault/app/billing/clients";
 import {
   ChangePlanDialogResultType,
   openChangePlanDialog,
 } from "@bitwarden/web-vault/app/billing/organizations/change-plan-dialog.component";
-import { OrganizationWarningsService } from "@bitwarden/web-vault/app/billing/organizations/warnings/services/organization-warnings.service";
+import {
+  OrganizationWarningsService,
+  TRIAL_PAYMENT_MODAL_DISMISSED_ORGS_KEY,
+} from "@bitwarden/web-vault/app/billing/organizations/warnings/services/organization-warnings.service";
 import { OrganizationWarningsResponse } from "@bitwarden/web-vault/app/billing/organizations/warnings/types";
 import {
   TRIAL_PAYMENT_METHOD_DIALOG_RESULT_TYPE,
@@ -34,12 +41,15 @@ import { TaxIdWarningTypes } from "@bitwarden/web-vault/app/billing/warnings/typ
 
 describe("OrganizationWarningsService", () => {
   let service: OrganizationWarningsService;
+  let accountService: MockProxy<AccountService>;
   let dialogService: MockProxy<DialogService>;
   let i18nService: MockProxy<I18nService>;
+  let logService: MockProxy<LogService>;
   let organizationApiService: MockProxy<OrganizationApiServiceAbstraction>;
   let organizationBillingClient: MockProxy<OrganizationBillingClient>;
   let platformUtilsService: MockProxy<PlatformUtilsService>;
   let router: MockProxy<Router>;
+  let stateProvider: MockProxy<StateProvider>;
 
   const organization = {
     id: "org-id-123",
@@ -99,12 +109,15 @@ describe("OrganizationWarningsService", () => {
     TestBed.configureTestingModule({
       providers: [
         OrganizationWarningsService,
+        { provide: AccountService, useValue: accountService },
         { provide: DialogService, useValue: dialogService },
         { provide: I18nService, useValue: i18nService },
+        { provide: LogService, useValue: logService },
         { provide: OrganizationApiServiceAbstraction, useValue: organizationApiService },
         { provide: OrganizationBillingClient, useValue: organizationBillingClient },
         { provide: PlatformUtilsService, useValue: platformUtilsService },
         { provide: Router, useValue: router },
+        { provide: StateProvider, useValue: stateProvider },
       ],
     });
 

--- a/apps/web/src/app/billing/organizations/warnings/services/organization-warnings.service.ts
+++ b/apps/web/src/app/billing/organizations/warnings/services/organization-warnings.service.ts
@@ -296,13 +296,13 @@ export class OrganizationWarningsService {
             break;
           }
           default: {
-            // Covers CLOSED, X button, ESC, and clicking outside (all emit undefined)
+            // Covers CLOSED, X button, ESC, and clicking outside (all emit undefined).
+            // Uses .update() to read current state at write time, preventing stale overwrites
+            // if multiple tabs dismiss different orgs concurrently.
             try {
-              await this.stateProvider.setUserState(
-                TRIAL_PAYMENT_MODAL_DISMISSED_ORGS_KEY,
-                { ...(dismissedOrgs ?? {}), [organization.id]: true },
-                account.id,
-              );
+              await this.stateProvider
+                .getUser(account.id, TRIAL_PAYMENT_MODAL_DISMISSED_ORGS_KEY)
+                .update((current) => ({ ...(current ?? {}), [organization.id]: true }));
             } catch (error) {
               this.logService.error("Failed to save trial payment modal dismissal state:", error);
             }

--- a/apps/web/src/app/billing/organizations/warnings/services/organization-warnings.service.ts
+++ b/apps/web/src/app/billing/organizations/warnings/services/organization-warnings.service.ts
@@ -46,6 +46,18 @@ const format = (date: Date) =>
     year: "numeric",
   });
 
+type TrialPaymentModalDismissedOrgs = Partial<Record<OrganizationId, boolean>>;
+
+export const TRIAL_PAYMENT_MODAL_DISMISSED_ORGS_KEY =
+  new UserKeyDefinition<TrialPaymentModalDismissedOrgs>(
+    BILLING_DISK_LOCAL,
+    "trialPaymentModalDismissedOrgs",
+    {
+      deserializer: (value) => value,
+      clearOn: [], // Do not clear dismissed modals
+    },
+  );
+
 @Injectable({ providedIn: "root" })
 export class OrganizationWarningsService {
   private cache$ = new Map<OrganizationId, Observable<OrganizationWarningsResponse>>();

--- a/apps/web/src/app/billing/organizations/warnings/services/organization-warnings.service.ts
+++ b/apps/web/src/app/billing/organizations/warnings/services/organization-warnings.service.ts
@@ -3,6 +3,7 @@ import { Router } from "@angular/router";
 import {
   BehaviorSubject,
   filter,
+  firstValueFrom,
   from,
   lastValueFrom,
   map,
@@ -262,6 +263,19 @@ export class OrganizationWarningsService {
     this.getWarning$(organization, (response) => response.freeTrial).pipe(
       filter((warning) => warning !== null),
       switchMap(async () => {
+        const account = await firstValueFrom(this.accountService.activeAccount$);
+        if (!account) {
+          return;
+        }
+
+        const dismissedOrgs = await firstValueFrom(
+          this.stateProvider.getUserState$(TRIAL_PAYMENT_MODAL_DISMISSED_ORGS_KEY, account.id),
+        );
+        // dismissedOrgs is null when no dismissals have been stored yet
+        if (dismissedOrgs?.[organization.id]) {
+          return;
+        }
+
         const organizationSubscriptionResponse = await this.organizationApiService.getSubscription(
           organization.id,
         );
@@ -273,9 +287,27 @@ export class OrganizationWarningsService {
             productTierType: organization?.productTierType,
           },
         });
+
         const result = await lastValueFrom(dialogRef.closed);
-        if (result === TRIAL_PAYMENT_METHOD_DIALOG_RESULT_TYPE.SUBMITTED) {
-          this.refreshFreeTrialWarningTrigger.next();
+
+        switch (result) {
+          case TRIAL_PAYMENT_METHOD_DIALOG_RESULT_TYPE.SUBMITTED: {
+            this.refreshFreeTrialWarningTrigger.next();
+            break;
+          }
+          default: {
+            // Covers CLOSED, X button, ESC, and clicking outside (all emit undefined)
+            try {
+              await this.stateProvider.setUserState(
+                TRIAL_PAYMENT_MODAL_DISMISSED_ORGS_KEY,
+                { ...(dismissedOrgs ?? {}), [organization.id]: true },
+                account.id,
+              );
+            } catch (error) {
+              this.logService.error("Failed to save trial payment modal dismissal state:", error);
+            }
+            break;
+          }
         }
       }),
     );

--- a/apps/web/src/app/billing/organizations/warnings/services/organization-warnings.service.ts
+++ b/apps/web/src/app/billing/organizations/warnings/services/organization-warnings.service.ts
@@ -17,10 +17,13 @@ import { take } from "rxjs/operators";
 
 import { OrganizationApiServiceAbstraction } from "@bitwarden/common/admin-console/abstractions/organization/organization-api.service.abstraction";
 import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { OrganizationId } from "@bitwarden/common/types/guid";
 import { DialogService } from "@bitwarden/components";
+import { BILLING_DISK_LOCAL, StateProvider, UserKeyDefinition } from "@bitwarden/state";
 import { OrganizationBillingClient } from "@bitwarden/web-vault/app/billing/clients";
 import { TaxIdWarningType } from "@bitwarden/web-vault/app/billing/warnings/types";
 
@@ -61,6 +64,9 @@ export class OrganizationWarningsService {
     private organizationBillingClient: OrganizationBillingClient,
     private platformUtilsService: PlatformUtilsService,
     private router: Router,
+    private accountService: AccountService,
+    private logService: LogService,
+    private stateProvider: StateProvider,
   ) {}
 
   getFreeTrialWarning$ = (


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-38988

## 📔 Objective
During a payment-optional free trial, the trial payment modal was re-appearing every time the user navigated between pages in the admin console (e.g. Members → Collections). Dismissing via the "Later" button, the X button, or clicking outside the modal had no effect on subsequent page navigations.

**Root cause:** `OrganizationWarningsService.showSubscribeBeforeFreeTrialEndsDialog$` had no dismissal tracking. Both `members.component.ts` and `vault.component.ts` subscribe to this method via `switchMap` on `organization$`, so each navigation created a new
      subscription that re-opened the dialog.

**Fix:** Persist per-organization dismissal state using `StateProvider` with a `UserKeyDefinition` stored in `BILLING_DISK_LOCAL` (localStorage). Once a user dismisses the modal for an org — via "Later", the X button, ESC, or clicking outside — it will not appear again. Dismissal is permanent but does not exist if client changes.

## 📸 Screenshots

### Initial Dismiss of Modal Able to Navigate without Dialog
https://github.com/user-attachments/assets/357ddf2d-09ed-4b9d-810f-edfeb04973ff

### New Client (Incognito) without Session Storage Dialog Opens but Close Persists
https://github.com/user-attachments/assets/489804e1-b6b7-492f-9b48-41270f91fc12



