### PR TITLE
fix(auto-enroll-status): [PM-39004] POC pass SSO identifier as query param for auto-enroll-status

### DIFF
--- a/libs/angular/src/auth/password-management/set-initial-password/set-initial-password.component.html
+++ b/libs/angular/src/auth/password-management/set-initial-password/set-initial-password.component.html
@@ -2,6 +2,14 @@
   <div class="tw-flex tw-items-center tw-justify-center">
     <bit-icon name="bwi-spinner" class="bwi-spin bwi-3x" [ariaLabel]="'loading' | i18n"></bit-icon>
   </div>
+} @else if (loadError) {
+  <div class="tw-mt-4"></div>
+  <bit-callout type="danger">
+    {{ "errorOccurred" | i18n }}
+  </bit-callout>
+  <button type="button" bitButton block buttonType="secondary" (click)="logout()">
+    {{ "logOut" | i18n }}
+  </button>
 } @else {
   @if (userType === SetInitialPasswordUserType.OFFBOARDED_TDE_ORG_USER_UNTRUSTED_DEVICE) {
     <div class="tw-mt-4"></div>

--- a/libs/angular/src/auth/password-management/set-initial-password/set-initial-password.component.ts
+++ b/libs/angular/src/auth/password-management/set-initial-password/set-initial-password.component.ts
@@ -71,6 +71,7 @@ export class SetInitialPasswordComponent implements OnInit {
   protected email?: string;
   protected forceSetPasswordReason?: ForceSetPasswordReason;
   protected initializing = true;
+  protected loadError = false;
   protected masterPasswordPolicyOptions: MasterPasswordPolicyOptions | null = null;
   protected orgId?: string;
   protected orgSsoIdentifier?: string;
@@ -111,7 +112,19 @@ export class SetInitialPasswordComponent implements OnInit {
     this.email = activeAccount?.email;
 
     await this.establishUserType();
-    await this.getOrgInfo();
+
+    try {
+      await this.getOrgInfo();
+    } catch (e) {
+      // Org info (orgId / reset-password policy) is required to set the initial password for org
+      // users. If it can't be loaded, surface an error state instead of rendering a form that would
+      // later fail with an opaque "orgId is falsy" assertion at submit time. See ticket #870106.
+      this.loadError = true;
+      this.logService.error(
+        "Failed to load organization info for the set initial password flow.",
+        e,
+      );
+    }
 
     this.initializing = false;
   }
@@ -264,12 +277,15 @@ export class SetInitialPasswordComponent implements OnInit {
         this.resetPasswordAutoEnroll = autoEnrollStatus.resetPasswordEnabled;
         this.masterPasswordPolicyOptions =
           await this.policyApiService.getMasterPasswordPolicyOptsForOrgUser(this.orgId);
-      } catch {
+      } catch (e) {
         this.toastService.showToast({
           variant: "error",
           title: "",
           message: this.i18nService.t("errorOccurred"),
         });
+        // Re-throw so ngOnInit puts the page into an error state rather than rendering a form
+        // that cannot succeed without orgId. See ticket #870106.
+        throw e;
       }
     }
   }

--- a/libs/auth/src/angular/login-decryption-options/login-decryption-options.component.spec.ts
+++ b/libs/auth/src/angular/login-decryption-options/login-decryption-options.component.spec.ts
@@ -241,6 +241,17 @@ describe("LoginDecryptionOptionsComponent", () => {
       await component.ngOnInit();
     });
 
+    it("does not throw when getAutoEnrollStatus fails while loading new user data", async () => {
+      // Regression: the failure previously resolved to undefined and the component dereferenced
+      // `.id`, throwing a TypeError. The error must be surfaced and ngOnInit must not reject.
+      // See ticket #870106.
+      organizationApiService.getAutoEnrollStatus.mockRejectedValue(new Error("Request failed"));
+
+      await expect(component.ngOnInit()).resolves.toBeUndefined();
+
+      expect(validationService.showError).toHaveBeenCalled();
+    });
+
     it("should use SDK v2 registration when feature flag is enabled", async () => {
       // Arrange
       configService.getFeatureFlag.mockResolvedValue(true);

--- a/libs/auth/src/angular/login-decryption-options/login-decryption-options.component.ts
+++ b/libs/auth/src/angular/login-decryption-options/login-decryption-options.component.ts
@@ -250,6 +250,12 @@ export class LoginDecryptionOptionsComponent implements OnInit {
 
     const autoEnrollStatus = await firstValueFrom(autoEnrollStatus$);
 
+    if (autoEnrollStatus == undefined) {
+      // getAutoEnrollStatus failed (the error was surfaced via validationService.showError above).
+      // Do not dereference undefined; leave newUserOrgId unset and stop here.
+      return;
+    }
+
     this.newUserOrgId = autoEnrollStatus.id;
   }
 

--- a/libs/common/src/admin-console/services/organization/organization-api.service.spec.ts
+++ b/libs/common/src/admin-console/services/organization/organization-api.service.spec.ts
@@ -1,0 +1,58 @@
+import { mock, MockProxy } from "jest-mock-extended";
+
+import { ApiService } from "../../../abstractions/api.service";
+import { SyncService } from "../../../vault/abstractions/sync/sync.service.abstraction";
+
+import { OrganizationApiService } from "./organization-api.service";
+
+describe("OrganizationApiService", () => {
+  let apiService: MockProxy<ApiService>;
+  let syncService: MockProxy<SyncService>;
+  let sut: OrganizationApiService;
+
+  beforeEach(() => {
+    apiService = mock<ApiService>();
+    syncService = mock<SyncService>();
+    sut = new OrganizationApiService(apiService, syncService);
+  });
+
+  describe("getAutoEnrollStatus", () => {
+    beforeEach(() => {
+      apiService.send.mockResolvedValue({ Id: "org-id", ResetPasswordEnabled: true });
+    });
+
+    it("passes the identifier as an encoded query parameter, not a path segment", async () => {
+      // An admin-chosen SSO identifier can contain reserved URL characters (e.g. "/"). It must be
+      // sent in the query string so it survives Utils.normalizePath (which decodes %2F in the path).
+      // See ticket #870106.
+      await sut.getAutoEnrollStatus("DQS/bitwarden");
+
+      expect(apiService.send).toHaveBeenCalledWith(
+        "GET",
+        "/organizations/auto-enroll-status?identifier=DQS%2Fbitwarden",
+        null,
+        true,
+        true,
+      );
+    });
+
+    it("encodes other reserved characters in the identifier", async () => {
+      await sut.getAutoEnrollStatus("a b&c");
+
+      expect(apiService.send).toHaveBeenCalledWith(
+        "GET",
+        "/organizations/auto-enroll-status?identifier=a%20b%26c",
+        null,
+        true,
+        true,
+      );
+    });
+
+    it("maps the response", async () => {
+      const result = await sut.getAutoEnrollStatus("DQS/bitwarden");
+
+      expect(result.id).toBe("org-id");
+      expect(result.resetPasswordEnabled).toBe(true);
+    });
+  });
+});

--- a/libs/common/src/admin-console/services/organization/organization-api.service.ts
+++ b/libs/common/src/admin-console/services/organization/organization-api.service.ts
@@ -89,9 +89,13 @@ export class OrganizationApiService implements OrganizationApiServiceAbstraction
   }
 
   async getAutoEnrollStatus(identifier: string): Promise<OrganizationAutoEnrollStatusResponse> {
+    // The identifier is an admin-chosen SSO identifier that may contain reserved URL characters
+    // (e.g. "/"). It must be passed as a query parameter, not a path segment: the path is run
+    // through Utils.normalizePath which decodes %2F back to "/", so a path-encoded identifier
+    // would re-split the path and 404. The query string is sent verbatim. See ticket #870106.
     const r = await this.apiService.send(
       "GET",
-      "/organizations/" + identifier + "/auto-enroll-status",
+      "/organizations/auto-enroll-status?identifier=" + encodeURIComponent(identifier),
       null,
       true,
       true,


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-39004

## 📔 Objective

1. Moves the sso identifier to a query param instead of in the path and sanitizes the input
2. Adjusts error handling of a failure to not just spin

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
