### PR TITLE
[Beeep] [PM-39039] Fix basic search matching

### DIFF
--- a/libs/common/src/vault/services/search.service.spec.ts
+++ b/libs/common/src/vault/services/search.service.spec.ts
@@ -4,13 +4,49 @@ import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.servic
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { UserId } from "@bitwarden/common/types/guid";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+import { FieldView } from "@bitwarden/common/vault/models/view/field.view";
+import { LoginUriView } from "@bitwarden/common/vault/models/view/login-uri.view";
 
 import { SearchService } from "./search.service";
 
-function createCipherView(id: string, name: string): CipherView {
+interface CipherViewOptions {
+  username?: string;
+  notes?: string;
+  uris?: string[];
+  fields?: { name?: string; value?: string }[];
+}
+
+function createCipherView(id: string, name: string, options: CipherViewOptions = {}): CipherView {
   const cipher = new CipherView();
   cipher.id = id;
   cipher.name = name;
+
+  // For a Login cipher the subtitle is driven by the username.
+  if (options.username != null) {
+    cipher.login.username = options.username;
+  }
+
+  if (options.notes != null) {
+    cipher.notes = options.notes;
+  }
+
+  if (options.uris != null) {
+    cipher.login.uris = options.uris.map((uri) => {
+      const loginUri = new LoginUriView();
+      loginUri.uri = uri;
+      return loginUri;
+    });
+  }
+
+  if (options.fields != null) {
+    cipher.fields = options.fields.map((f) => {
+      const field = new FieldView();
+      field.name = f.name;
+      field.value = f.value;
+      return field;
+    });
+  }
+
   return cipher;
 }
 
@@ -77,6 +113,179 @@ describe("SearchService", () => {
       const result = await service.searchCiphers(userId, null, "", ciphers);
 
       expect(result).toEqual(ciphers);
+    });
+  });
+
+  describe("searchCiphersBasic", () => {
+    describe("single-target matching", () => {
+      it("matches on the name", () => {
+        const cipher = createCipherView("cipher-1", "Personal Login");
+
+        const result = service.searchCiphersBasic([cipher], "personal");
+
+        expect(result).toEqual([cipher]);
+      });
+
+      it("matches on the subtitle (username)", () => {
+        const cipher = createCipherView("cipher-1", "Work", { username: "alice@example.com" });
+
+        const result = service.searchCiphersBasic([cipher], "alice");
+
+        expect(result).toEqual([cipher]);
+      });
+
+      it("matches on the UUID when the query is at least 8 characters", () => {
+        const cipher = createCipherView("abcdef12-3456-7890", "Some Item");
+
+        const result = service.searchCiphersBasic([cipher], "abcdef12");
+
+        expect(result).toEqual([cipher]);
+      });
+
+      it("does not match on the UUID when the query is shorter than 8 characters", () => {
+        const cipher = createCipherView("abcdef12-3456-7890", "Some Item");
+
+        const result = service.searchCiphersBasic([cipher], "abcdef1");
+
+        expect(result).toEqual([]);
+      });
+
+      it("matches on a login URI hostname", () => {
+        const cipher = createCipherView("cipher-1", "Work", {
+          uris: ["https://mycompany.com/login"],
+        });
+
+        const result = service.searchCiphersBasic([cipher], "mycompany");
+
+        expect(result).toEqual([cipher]);
+      });
+
+      it("does not match on a login URI path", () => {
+        const cipher = createCipherView("cipher-1", "Work", {
+          uris: ["https://example.com/secret-path"],
+        });
+
+        const result = service.searchCiphersBasic([cipher], "secret-path");
+
+        expect(result).toEqual([]);
+      });
+
+      it("skips invalid login URIs without throwing", () => {
+        const cipher = createCipherView("cipher-1", "Work", {
+          uris: ["not a valid uri"],
+        });
+
+        expect(() => service.searchCiphersBasic([cipher], "valid")).not.toThrow();
+        expect(service.searchCiphersBasic([cipher], "valid")).toEqual([]);
+      });
+
+      it("matches on a custom field name", () => {
+        const cipher = createCipherView("cipher-1", "Work", {
+          fields: [{ name: "Security Question", value: "blue" }],
+        });
+
+        const result = service.searchCiphersBasic([cipher], "security");
+
+        expect(result).toEqual([cipher]);
+      });
+
+      it("matches on a custom field value", () => {
+        const cipher = createCipherView("cipher-1", "Work", {
+          fields: [{ name: "Security Question", value: "azure" }],
+        });
+
+        const result = service.searchCiphersBasic([cipher], "azure");
+
+        expect(result).toEqual([cipher]);
+      });
+
+      it("matches on the notes", () => {
+        const cipher = createCipherView("cipher-1", "Work", { notes: "Archived account" });
+
+        const result = service.searchCiphersBasic([cipher], "archived");
+
+        expect(result).toEqual([cipher]);
+      });
+    });
+
+    describe("multi-token semantics", () => {
+      it("matches when all parts are found in the same target", () => {
+        const cipher = createCipherView("cipher-1", "Email Work MyCompany");
+
+        const result = service.searchCiphersBasic([cipher], "email work");
+
+        expect(result).toEqual([cipher]);
+      });
+
+      it("matches when parts are spread across different targets", () => {
+        const cipher = createCipherView("cipher-1", "Work", {
+          username: "alice@mycompany.com",
+          notes: "Archived",
+        });
+
+        const result = service.searchCiphersBasic([cipher], "alice archived");
+
+        expect(result).toEqual([cipher]);
+      });
+
+      it("matches regardless of the order of the parts", () => {
+        const cipher = createCipherView("cipher-1", "Email Work MyCompany");
+
+        const result = service.searchCiphersBasic([cipher], "work email");
+
+        expect(result).toEqual([cipher]);
+      });
+
+      it("matches on partial tokens across multiple targets", () => {
+        const cipher = createCipherView("cipher-1", "Email Work MyCompany");
+
+        const result = service.searchCiphersBasic([cipher], "mycomp mail");
+
+        expect(result).toEqual([cipher]);
+      });
+
+      it("returns no results when one of the parts has no matching target", () => {
+        const cipher = createCipherView("cipher-1", "Email Work MyCompany");
+
+        const result = service.searchCiphersBasic([cipher], "email missing");
+
+        expect(result).toEqual([]);
+      });
+    });
+
+    describe("query normalization", () => {
+      it("matches ignoring case", () => {
+        const cipher = createCipherView("cipher-1", "Personal Login");
+
+        const result = service.searchCiphersBasic([cipher], "PERSONAL");
+
+        expect(result).toEqual([cipher]);
+      });
+
+      it("matches ignoring diacritics", () => {
+        const cipher = createCipherView("cipher-1", "Cafe Account");
+
+        const result = service.searchCiphersBasic([cipher], "café");
+
+        expect(result).toEqual([cipher]);
+      });
+
+      it("trims surrounding whitespace", () => {
+        const cipher = createCipherView("cipher-1", "Personal Login");
+
+        const result = service.searchCiphersBasic([cipher], "  personal  ");
+
+        expect(result).toEqual([cipher]);
+      });
+    });
+
+    it("returns only the matching subset across multiple ciphers", () => {
+      const match = createCipherView("cipher-1", "Personal Login");
+      const other = createCipherView("cipher-2", "Bank Account");
+
+      const result = service.searchCiphersBasic([match, other], "personal");
+
+      expect(result).toEqual([match]);
     });
   });
 });

--- a/libs/common/src/vault/services/search.service.ts
+++ b/libs/common/src/vault/services/search.service.ts
@@ -96,30 +96,87 @@ export class SearchService implements SearchServiceAbstraction {
 
   searchCiphersBasic<C extends CipherViewLike>(ciphers: C[], query: string) {
     query = normalizeSearchQuery(query.trim().toLowerCase());
+
+    // Basic search works by splitting the query into parts. Each part must occur somewhere in the vault item.
+    // A vault item consists of targets. A target is extracted from the various information in the vault item, such as name, notes.
+    //
+    // For each part in the query, at least on target must contain the part. If all query parts are found in the vault item target,
+    // then the vault item matches the search.
+    //
+    // Example:
+    // {
+    //    name: "Email Work MyCompany",
+    //    username: "alice@mycompany.com",
+    //    notes: "Archived"
+    // }
+    //
+    // Valid queries:
+    // - "email work"
+    // - "alice mycompany"
+    // - "alice archived"
+    // - "work email"
+    // - "mycomp mail" (matches on MyCompany and Email)
+    //
+    // This allows a user to not have to remember the exact order they used when creating the item,
+    // leading to a more consistent search experience.
+    const queryParts = query.split(" ");
+
     return ciphers.filter((c) => {
-      if (c.name != null && c.name.toLowerCase().indexOf(query) > -1) {
-        return true;
+      const targets = [];
+
+      // Match on vault item name
+      if (c.name != null && c.name.toLowerCase()) {
+        targets.push(c.name.toLowerCase());
       }
-      if (query.length >= 8 && uuidAsString(c.id).startsWith(query)) {
-        return true;
+
+      // Match on vault item UUID
+      if (query.length >= 8) {
+        targets.push(uuidAsString(c.id));
       }
+
+      // Match on vault item subtitle
       const subtitle = CipherViewLikeUtils.subtitle(c);
-      if (subtitle != null && subtitle.toLowerCase().indexOf(query) > -1) {
-        return true;
+      if (subtitle != null) {
+        targets.push(subtitle.toLowerCase());
       }
 
+      // Match on hostname of any login URIs
+      // We do not match on the full URI because parts of the URI such as the query are hidden.
       const login = CipherViewLikeUtils.getLogin(c);
-
-      if (
-        login &&
-        login.uris?.length &&
-        login.uris?.some(
-          (loginUri) => loginUri?.uri && loginUri.uri.toLowerCase().indexOf(query) > -1,
-        )
-      ) {
-        return true;
+      if (login) {
+        login.uris.forEach((u) => {
+          if (u.uri) {
+            try {
+              const url = new URL(u.uri);
+              targets.push(url.hostname.toLowerCase());
+            } catch {
+              // Not a valid URI, skip it
+            }
+          }
+        });
       }
-      return false;
+
+      // Match on any custom fields (both name and value)
+      c.fields.forEach((f) => {
+        if (f.value != null) {
+          targets.push(f.name.toLowerCase());
+          targets.push(f.value.toLowerCase());
+        }
+      });
+
+      // Match on any notes
+      if (c.notes != null) {
+        targets.push(c.notes.toLowerCase());
+      }
+
+      // Match parts to targets
+      for (const part of queryParts) {
+        if (!targets.some((t) => t.indexOf(part) > -1)) {
+          return false;
+        }
+      }
+
+      return true;
     });
   }
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-39039

## 📔 Objective

Rework basic vault search to split the query into parts and match each part against a set of targets extracted from the item (name, UUID, subtitle, login URI hostnames, custom field names/values, and notes). An item matches when every query part is found in at least one target.

Fixes the following bugs:

- Order independent matching no longer works.
- Search does not match on custom fields.
- Search does not match on notes.
- Search delivers unexpected (too many) results, due to matching on invisible URI paths (now matches only on URI hostname).

This adds tests for all of these regressions.

## 📸 Screenshots

n/a
