### PR TITLE
[PM-34779] Add accept method to OrganizationInviteLinkApiService

### DIFF
--- a/libs/organization-invite-link/src/abstractions/organization-invite-link-api.service.ts
+++ b/libs/organization-invite-link/src/abstractions/organization-invite-link-api.service.ts
@@ -1,3 +1,4 @@
+import { OrganizationInviteLinkAcceptRequest } from "../models/requests/organization-invite-link-accept.request";
 import { OrganizationInviteLinkCreateRequest } from "../models/requests/organization-invite-link-create.request";
 import { OrganizationInviteLinkRefreshRequest } from "../models/requests/organization-invite-link-refresh.request";
 import { OrganizationInviteLinkUpdateRequest } from "../models/requests/organization-invite-link-update.request";
@@ -38,4 +39,7 @@ export abstract class OrganizationInviteLinkApiService {
 
   /** Get the public status of an invite link by its code (anonymous) */
   abstract getStatus(code: string): Promise<OrganizationInviteLinkStatusResponseModel>;
+
+  /** Accept an invite link, joining the authenticated user to the organization */
+  abstract accept(request: OrganizationInviteLinkAcceptRequest): Promise<void>;
 }

--- a/libs/organization-invite-link/src/models/requests/index.ts
+++ b/libs/organization-invite-link/src/models/requests/index.ts
@@ -1,3 +1,4 @@
+export * from "./organization-invite-link-accept.request";
 export * from "./organization-invite-link-create.request";
 export * from "./organization-invite-link-refresh.request";
 export * from "./organization-invite-link-update.request";

--- a/libs/organization-invite-link/src/models/requests/organization-invite-link-accept.request.ts
+++ b/libs/organization-invite-link/src/models/requests/organization-invite-link-accept.request.ts
@@ -1,0 +1,9 @@
+export class OrganizationInviteLinkAcceptRequest {
+  code: string;
+  resetPasswordKey?: string;
+
+  constructor(c: { code: string; resetPasswordKey?: string }) {
+    this.code = c.code;
+    this.resetPasswordKey = c.resetPasswordKey;
+  }
+}

--- a/libs/organization-invite-link/src/services/default-organization-invite-link-api.service.ts
+++ b/libs/organization-invite-link/src/services/default-organization-invite-link-api.service.ts
@@ -1,6 +1,7 @@
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
 
 import { OrganizationInviteLinkApiService } from "../abstractions/organization-invite-link-api.service";
+import { OrganizationInviteLinkAcceptRequest } from "../models/requests/organization-invite-link-accept.request";
 import { OrganizationInviteLinkCreateRequest } from "../models/requests/organization-invite-link-create.request";
 import { OrganizationInviteLinkRefreshRequest } from "../models/requests/organization-invite-link-refresh.request";
 import { OrganizationInviteLinkUpdateRequest } from "../models/requests/organization-invite-link-update.request";
@@ -97,5 +98,15 @@ export class DefaultOrganizationInviteLinkApiService implements OrganizationInvi
       true,
     );
     return new OrganizationInviteLinkStatusResponseModel(r);
+  }
+
+  async accept(request: OrganizationInviteLinkAcceptRequest): Promise<void> {
+    await this.apiService.send(
+      "POST",
+      "/organizations/users/invite-link/accept",
+      request,
+      true,
+      false,
+    );
   }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-34779

## 📔 Objective

Add an `accept(request: OrganizationInviteLinkAcceptRequest)` method to `OrganizationInviteLinkApiService`.

[Server PR](https://github.com/bitwarden/server/pull/7812).
