### PR TITLE
[BRE-2013] Fix repo name in PR description link

### DIFF
--- a/.github/workflows/sdk-update.yml
+++ b/.github/workflows/sdk-update.yml
@@ -332,7 +332,7 @@ jobs:
             echo "### Links"
             echo "- [Workflow Run]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)"
             if [ -n "$_TRIGGERING_RUN_ID" ]; then
-              echo "- [Triggering SDK Publish Run](https://github.com/bitwarden/sdk-internal/actions/runs/$_TRIGGERING_RUN_ID)"
+              echo "- [Triggering SDK Publish Run](https://github.com/bitwarden/deploy/actions/runs/$_TRIGGERING_RUN_ID)"
             fi
             echo "- [SDK Releases](https://github.com/bitwarden/sdk-internal/releases)"
           } > /tmp/pr-body.md


### PR DESCRIPTION
## 🎟️ Tracking

[BRE-2013](https://bitwarden.atlassian.net/browse/BRE-2013)

## 📔 Objective

This PR fixes the repository name in the `Triggering SDK Publish Run` link URL in the PR description.

[BRE-2013]: https://bitwarden.atlassian.net/browse/BRE-2013?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ