### PR TITLE
[PM-36835] added logging to weak-password-report and its parent

### DIFF
--- a/apps/web/src/app/dirt/reports/pages/cipher-report.component.spec.ts
+++ b/apps/web/src/app/dirt/reports/pages/cipher-report.component.spec.ts
@@ -4,6 +4,7 @@ import { of } from "rxjs";
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.service.abstraction";
 import { CipherType } from "@bitwarden/common/vault/enums/cipher-type";
@@ -20,10 +21,15 @@ import { AdminConsoleCipherFormConfigService } from "../../../vault/org-vault/se
 
 import { CipherReportComponent } from "./cipher-report.component";
 
+// CipherReportComponent is an abstract class, so we create a concrete subclass for testing
+class TestCipherReportComponent extends CipherReportComponent {}
+
 describe("CipherReportComponent", () => {
-  let component: CipherReportComponent;
+  let component: TestCipherReportComponent;
   let mockAccountService: MockProxy<AccountService>;
   let mockAdminConsoleCipherFormConfigService: MockProxy<AdminConsoleCipherFormConfigService>;
+  let mockSyncService: MockProxy<SyncService>;
+  let mockLogService: MockProxy<LogService>;
   const mockCipher = {
     id: "122-333-444",
     type: CipherType.Login,
@@ -45,20 +51,76 @@ describe("CipherReportComponent", () => {
     mockAccountService = mock<AccountService>();
     mockAccountService.activeAccount$ = of({ id: "user1" } as any);
     mockAdminConsoleCipherFormConfigService = mock<AdminConsoleCipherFormConfigService>();
+    mockSyncService = mock<SyncService>();
+    mockLogService = mock<LogService>();
 
-    component = new CipherReportComponent(
+    // CipherReportComponent is an abstract class, so we create a concrete subclass for testing
+    component = new TestCipherReportComponent(
       mockCipherService,
       mock<DialogService>(),
       mock<PasswordRepromptService>(),
       mock<OrganizationService>(),
       mockAccountService,
       mock<I18nService>(),
-      mock<SyncService>(),
+      mockSyncService,
       mock<CipherFormConfigService>(),
       mockAdminConsoleCipherFormConfigService,
+      mockLogService,
     );
     component.ciphers = [];
     component.allCiphers = [];
+  });
+
+  it("should log an error and rethrow when fullSync fails during load", async () => {
+    const syncError = new Error("sync failed");
+    mockSyncService.fullSync.mockRejectedValue(syncError);
+
+    await expect(component.load()).rejects.toThrow(syncError);
+
+    expect(mockLogService.error).toHaveBeenCalledWith(expect.any(String), syncError);
+    // Spinner state must still settle so the UI does not hang.
+    expect(component.loading).toBe(false);
+    // hasLoaded must remain false and loadFailed must be set on failure so the template renders
+    // an error state instead of a misleading "success" (e.g. "no exposed passwords found") state.
+    expect(component.hasLoaded).toBe(false);
+    expect(component.loadFailed).toBe(true);
+  });
+
+  it("should log a completion info message that includes a count on a successful load", async () => {
+    mockSyncService.fullSync.mockResolvedValue(true);
+
+    await component.load();
+
+    expect(mockLogService.error).not.toHaveBeenCalled();
+    expect(mockLogService.info).toHaveBeenCalled();
+    expect(component.loadFailed).toBe(false);
+  });
+
+  it("should log entry into setCiphers during load", async () => {
+    mockSyncService.fullSync.mockResolvedValue(true);
+
+    await component.load();
+
+    expect(mockLogService.info).toHaveBeenCalledWith(expect.stringContaining("Setting ciphers"));
+  });
+
+  it("should log an error and rethrow when setCiphers fails during load", async () => {
+    mockSyncService.fullSync.mockResolvedValue(true);
+    const setCiphersError = new Error("setCiphers failed");
+    jest.spyOn(component as any, "setCiphers").mockRejectedValue(setCiphersError);
+
+    await expect(component.load()).rejects.toThrow(setCiphersError);
+
+    expect(mockLogService.error).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to load report"),
+      setCiphersError,
+    );
+    // Spinner state must still settle so the UI does not hang.
+    expect(component.loading).toBe(false);
+    // hasLoaded must remain false and loadFailed must be set on failure so the template renders
+    // an error state instead of a misleading "success" (e.g. "no exposed passwords found") state.
+    expect(component.hasLoaded).toBe(false);
+    expect(component.loadFailed).toBe(true);
   });
 
   it("should remove the cipher from the report if it was deleted", async () => {

--- a/apps/web/src/app/dirt/reports/pages/cipher-report.component.ts
+++ b/apps/web/src/app/dirt/reports/pages/cipher-report.component.ts
@@ -14,6 +14,7 @@ import { Organization } from "@bitwarden/common/admin-console/models/domain/orga
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { getUserId } from "@bitwarden/common/auth/services/account.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { CipherId, CollectionId, OrganizationId } from "@bitwarden/common/types/guid";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.service.abstraction";
@@ -37,6 +38,7 @@ export abstract class CipherReportComponent implements OnDestroy {
 
   loading = false;
   hasLoaded = false;
+  loadFailed = false;
   ciphers: CipherView[] = [];
   allCiphers: CipherView[] = [];
   dataSource = new TableDataSource<CipherView>();
@@ -65,6 +67,7 @@ export abstract class CipherReportComponent implements OnDestroy {
     private syncService: SyncService,
     private cipherFormConfigService: CipherFormConfigService,
     protected adminConsoleCipherFormConfigService: AdminConsoleCipherFormConfigService,
+    protected logService: LogService,
   ) {
     this.organizations$ = this.accountService.activeAccount$.pipe(
       getUserId,
@@ -79,6 +82,10 @@ export abstract class CipherReportComponent implements OnDestroy {
   ngOnDestroy(): void {
     this.destroyed$.next();
     this.destroyed$.complete();
+  }
+
+  protected get reportScope(): string {
+    return this.organization ? "Enterprise" : "Individual";
   }
 
   getName(filterId: string | number) {
@@ -132,22 +139,34 @@ export abstract class CipherReportComponent implements OnDestroy {
 
   async load() {
     this.loading = true;
-    await this.syncService.fullSync(false);
-    // when a user fixes an item in a report we want to persist the filter they had
-    // if they fix the last item of that filter we will go back to the "All" filter
-    if (this.currentFilterStatus) {
-      if (this.ciphers.length > 2) {
-        this.filterOrgStatus$.next(this.currentFilterStatus);
-        await this.filterOrgToggle(this.currentFilterStatus);
+    this.loadFailed = false;
+    try {
+      this.logService.info(`[CipherReport] [${this.reportScope}] Starting full sync`);
+      await this.syncService.fullSync(false);
+      this.logService.info(`[CipherReport] [${this.reportScope}] Full sync complete`);
+
+      // when a user fixes an item in a report we want to persist the filter they had
+      // if they fix the last item of that filter we will go back to the "All" filter
+      if (this.currentFilterStatus) {
+        if (this.ciphers.length > 2) {
+          this.filterOrgStatus$.next(this.currentFilterStatus);
+          await this.filterOrgToggle(this.currentFilterStatus);
+        } else {
+          this.filterOrgStatus$.next(0);
+          await this.filterOrgToggle(0);
+        }
       } else {
-        this.filterOrgStatus$.next(0);
-        await this.filterOrgToggle(0);
+        this.logService.info(`[CipherReport] [${this.reportScope}] Setting ciphers`);
+        await this.setCiphers();
       }
-    } else {
-      await this.setCiphers();
+      this.hasLoaded = true;
+    } catch (e) {
+      this.loadFailed = true;
+      this.logService.error(`[CipherReport] [${this.reportScope}] Failed to load report`, e);
+      throw e;
+    } finally {
+      this.loading = false;
     }
-    this.loading = false;
-    this.hasLoaded = true;
   }
   async selectCipher(cipher: CipherView) {
     if (!(await this.repromptCipher(cipher))) {

--- a/apps/web/src/app/dirt/reports/pages/exposed-passwords-report.component.spec.ts
+++ b/apps/web/src/app/dirt/reports/pages/exposed-passwords-report.component.spec.ts
@@ -18,6 +18,7 @@ import {
   ButtonModule,
   FormFieldModule,
 } from "@bitwarden/components";
+import { LogService } from "@bitwarden/logging";
 import { I18nPipe } from "@bitwarden/ui-common";
 import { CipherFormConfigService, PasswordRepromptService } from "@bitwarden/vault";
 
@@ -106,6 +107,7 @@ describe("ExposedPasswordsReportComponent", () => {
           provide: AdminConsoleCipherFormConfigService,
           useValue: adminConsoleCipherFormConfigServiceMock,
         },
+        { provide: LogService, useValue: mock<LogService>() },
       ],
       schemas: [],
     }).compileComponents();

--- a/apps/web/src/app/dirt/reports/pages/exposed-passwords-report.component.ts
+++ b/apps/web/src/app/dirt/reports/pages/exposed-passwords-report.component.ts
@@ -9,6 +9,7 @@ import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.serv
 import { CipherType } from "@bitwarden/common/vault/enums";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { DialogService } from "@bitwarden/components";
+import { LogService } from "@bitwarden/logging";
 import {
   CipherFormConfigService,
   PasswordRepromptService,
@@ -42,6 +43,7 @@ export class ExposedPasswordsReportComponent extends CipherReportComponent imple
     syncService: SyncService,
     cipherFormConfigService: CipherFormConfigService,
     adminConsoleCipherFormConfigService: AdminConsoleCipherFormConfigService,
+    protected logService: LogService,
   ) {
     super(
       cipherService,
@@ -53,6 +55,7 @@ export class ExposedPasswordsReportComponent extends CipherReportComponent imple
       syncService,
       cipherFormConfigService,
       adminConsoleCipherFormConfigService,
+      logService,
     );
   }
 

--- a/apps/web/src/app/dirt/reports/pages/inactive-two-factor-report.component.ts
+++ b/apps/web/src/app/dirt/reports/pages/inactive-two-factor-report.component.ts
@@ -38,7 +38,7 @@ export class InactiveTwoFactorReportComponent extends CipherReportComponent impl
     protected organizationService: OrganizationService,
     dialogService: DialogService,
     accountService: AccountService,
-    private logService: LogService,
+    protected logService: LogService,
     passwordRepromptService: PasswordRepromptService,
     i18nService: I18nService,
     syncService: SyncService,
@@ -56,6 +56,7 @@ export class InactiveTwoFactorReportComponent extends CipherReportComponent impl
       syncService,
       cipherFormConfigService,
       adminConsoleCipherFormConfigService,
+      logService,
     );
   }
 

--- a/apps/web/src/app/dirt/reports/pages/organizations/exposed-passwords-report.component.ts
+++ b/apps/web/src/app/dirt/reports/pages/organizations/exposed-passwords-report.component.ts
@@ -14,6 +14,7 @@ import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.serv
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { CipherViewLikeUtils } from "@bitwarden/common/vault/utils/cipher-view-like-utils";
 import { BerryComponent, ChipFilterComponent, DialogService } from "@bitwarden/components";
+import { LogService } from "@bitwarden/logging";
 import {
   PasswordRepromptService,
   CipherFormConfigService,
@@ -71,6 +72,7 @@ export class ExposedPasswordsReportComponent
     cipherFormService: CipherFormConfigService,
     adminConsoleCipherFormConfigService: AdminConsoleCipherFormConfigService,
     private collectionService: CollectionService,
+    logService: LogService,
   ) {
     super(
       cipherService,
@@ -83,6 +85,7 @@ export class ExposedPasswordsReportComponent
       syncService,
       cipherFormService,
       adminConsoleCipherFormConfigService,
+      logService,
     );
   }
 

--- a/apps/web/src/app/dirt/reports/pages/organizations/reused-passwords-report.component.ts
+++ b/apps/web/src/app/dirt/reports/pages/organizations/reused-passwords-report.component.ts
@@ -13,6 +13,7 @@ import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.serv
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { CipherViewLikeUtils } from "@bitwarden/common/vault/utils/cipher-view-like-utils";
 import { BerryComponent, ChipFilterComponent, DialogService } from "@bitwarden/components";
+import { LogService } from "@bitwarden/logging";
 import {
   CipherFormConfigService,
   PasswordRepromptService,
@@ -69,6 +70,7 @@ export class ReusedPasswordsReportComponent
     cipherFormConfigService: CipherFormConfigService,
     adminConsoleCipherFormConfigService: AdminConsoleCipherFormConfigService,
     private collectionService: CollectionService,
+    protected logService: LogService,
   ) {
     super(
       cipherService,
@@ -80,6 +82,7 @@ export class ReusedPasswordsReportComponent
       syncService,
       cipherFormConfigService,
       adminConsoleCipherFormConfigService,
+      logService,
     );
   }
 

--- a/apps/web/src/app/dirt/reports/pages/organizations/unsecured-websites-report.component.ts
+++ b/apps/web/src/app/dirt/reports/pages/organizations/unsecured-websites-report.component.ts
@@ -13,6 +13,7 @@ import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.serv
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { CipherViewLikeUtils } from "@bitwarden/common/vault/utils/cipher-view-like-utils";
 import { BerryComponent, ChipFilterComponent, DialogService } from "@bitwarden/components";
+import { LogService } from "@bitwarden/logging";
 import {
   CipherFormConfigService,
   PasswordRepromptService,
@@ -69,6 +70,7 @@ export class UnsecuredWebsitesReportComponent
     collectionService: CollectionService,
     cipherFormConfigService: CipherFormConfigService,
     adminConsoleCipherFormConfigService: AdminConsoleCipherFormConfigService,
+    protected logService: LogService,
   ) {
     super(
       cipherService,
@@ -81,6 +83,7 @@ export class UnsecuredWebsitesReportComponent
       collectionService,
       cipherFormConfigService,
       adminConsoleCipherFormConfigService,
+      logService,
     );
   }
 

--- a/apps/web/src/app/dirt/reports/pages/organizations/weak-passwords-report.component.ts
+++ b/apps/web/src/app/dirt/reports/pages/organizations/weak-passwords-report.component.ts
@@ -1,13 +1,11 @@
-import { Component, OnInit } from "@angular/core";
+import { Component, inject, OnInit } from "@angular/core";
 import { ActivatedRoute } from "@angular/router";
-import { firstValueFrom, takeUntil, tap } from "rxjs";
+import { takeUntil, tap } from "rxjs";
 
-import { CollectionService } from "@bitwarden/admin-console/common";
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
-import { getUserId } from "@bitwarden/common/auth/services/account.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
-import { getById } from "@bitwarden/common/platform/misc";
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { PasswordStrengthServiceAbstraction } from "@bitwarden/common/tools/password-strength";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.service.abstraction";
@@ -26,6 +24,7 @@ import { SharedModule } from "../../../../shared";
 import { OrganizationBadgeModule } from "../../../../vault/individual-vault/organization-badge/organization-badge.module";
 import { PipesModule } from "../../../../vault/individual-vault/pipes/pipes.module";
 import { AdminConsoleCipherFormConfigService } from "../../../../vault/org-vault/services/admin-console-cipher-form-config.service";
+import { OrgReportContextService } from "../../services/org-report-context.service";
 import { WeakPasswordsReportComponent as BaseWeakPasswordsReportComponent } from "../weak-passwords-report.component";
 
 // FIXME(https://bitwarden.atlassian.net/browse/CL-764): Migrate to OnPush
@@ -57,6 +56,7 @@ export class WeakPasswordsReportComponent
 {
   private manageableCipherIds = new Set<string>();
   private sharedCollectionIds = new Set<string>();
+  private readonly orgReportContext = inject(OrgReportContextService);
 
   constructor(
     cipherService: CipherService,
@@ -70,7 +70,7 @@ export class WeakPasswordsReportComponent
     cipherFormConfigService: CipherFormConfigService,
     protected accountService: AccountService,
     adminConsoleCipherFormConfigService: AdminConsoleCipherFormConfigService,
-    private collectionService: CollectionService,
+    logService: LogService,
   ) {
     super(
       cipherService,
@@ -83,29 +83,33 @@ export class WeakPasswordsReportComponent
       syncService,
       cipherFormConfigService,
       adminConsoleCipherFormConfigService,
+      logService,
     );
   }
 
   async ngOnInit() {
     this.isAdminConsoleActive = true;
+    const logContext = "[WeakPasswordsReport] [Enterprise]";
     this.route.parent?.parent?.params
       .pipe(
         tap(async (params) => {
-          const userId = await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId));
-          this.organization = await firstValueFrom(
-            this.organizationService.organizations$(userId).pipe(getById(params.organizationId)),
-          );
-          const manageableCiphers = await this.cipherService.getAll(userId);
-          this.manageableCipherIds = new Set(manageableCiphers.map((c) => c.id));
-          const collections = await firstValueFrom(
-            this.collectionService.decryptedCollections$(userId),
-          );
-          this.sharedCollectionIds = new Set(
-            collections
-              .filter((c) => !c.isDefaultCollection && c.organizationId === this.organization?.id)
-              .map((c) => c.id as string),
-          );
-          await super.ngOnInit();
+          try {
+            const ctx = await this.orgReportContext.load(params.organizationId, logContext);
+            this.organization = ctx.organization;
+            this.manageableCipherIds = ctx.manageableCipherIds;
+            this.sharedCollectionIds = ctx.sharedCollectionIds;
+
+            // Runs after this.organization is assigned — the overridden getAllCiphers() reads it.
+            await super.ngOnInit();
+
+            this.logService.info(
+              `${logContext} Initialized report for organization ${this.organization?.id} ` +
+                `with ${this.manageableCipherIds.size} manageable ciphers`,
+            );
+          } catch (e) {
+            this.logService.error(`${logContext} Failed to load report`, e);
+            this.loadFailed = true;
+          }
         }),
         takeUntil(this.destroyed$),
       )

--- a/apps/web/src/app/dirt/reports/pages/reused-passwords-report.component.spec.ts
+++ b/apps/web/src/app/dirt/reports/pages/reused-passwords-report.component.spec.ts
@@ -12,6 +12,7 @@ import { UserId } from "@bitwarden/common/types/guid";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.service.abstraction";
 import { DialogService } from "@bitwarden/components";
+import { LogService } from "@bitwarden/logging";
 import { I18nPipe } from "@bitwarden/ui-common";
 import { CipherFormConfigService, PasswordRepromptService } from "@bitwarden/vault";
 
@@ -94,6 +95,7 @@ describe("ReusedPasswordsReportComponent", () => {
           provide: AdminConsoleCipherFormConfigService,
           useValue: adminConsoleCipherFormConfigServiceMock,
         },
+        { provide: LogService, useValue: mock<LogService>() },
       ],
       schemas: [CUSTOM_ELEMENTS_SCHEMA],
     }).compileComponents();

--- a/apps/web/src/app/dirt/reports/pages/reused-passwords-report.component.ts
+++ b/apps/web/src/app/dirt/reports/pages/reused-passwords-report.component.ts
@@ -10,6 +10,7 @@ import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.serv
 import { CipherType } from "@bitwarden/common/vault/enums";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { DialogService } from "@bitwarden/components";
+import { LogService } from "@bitwarden/logging";
 import {
   CipherFormConfigService,
   PasswordRepromptService,
@@ -42,6 +43,7 @@ export class ReusedPasswordsReportComponent extends CipherReportComponent implem
     syncService: SyncService,
     cipherFormConfigService: CipherFormConfigService,
     adminConsoleCipherFormConfigService: AdminConsoleCipherFormConfigService,
+    protected logService: LogService,
   ) {
     super(
       cipherService,
@@ -53,6 +55,7 @@ export class ReusedPasswordsReportComponent extends CipherReportComponent implem
       syncService,
       cipherFormConfigService,
       adminConsoleCipherFormConfigService,
+      logService,
     );
   }
 

--- a/apps/web/src/app/dirt/reports/pages/unsecured-websites-report.component.spec.ts
+++ b/apps/web/src/app/dirt/reports/pages/unsecured-websites-report.component.spec.ts
@@ -13,6 +13,7 @@ import { UserId } from "@bitwarden/common/types/guid";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.service.abstraction";
 import { DialogService } from "@bitwarden/components";
+import { LogService } from "@bitwarden/logging";
 import { I18nPipe } from "@bitwarden/ui-common";
 import { CipherFormConfigService, PasswordRepromptService } from "@bitwarden/vault";
 
@@ -103,6 +104,7 @@ describe("UnsecuredWebsitesReportComponent", () => {
           provide: AdminConsoleCipherFormConfigService,
           useValue: adminConsoleCipherFormConfigService,
         },
+        { provide: LogService, useValue: mock<LogService>() },
       ],
       schemas: [CUSTOM_ELEMENTS_SCHEMA],
     }).compileComponents();

--- a/apps/web/src/app/dirt/reports/pages/unsecured-websites-report.component.ts
+++ b/apps/web/src/app/dirt/reports/pages/unsecured-websites-report.component.ts
@@ -9,6 +9,7 @@ import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.serv
 import { CipherType } from "@bitwarden/common/vault/enums";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { DialogService } from "@bitwarden/components";
+import { LogService } from "@bitwarden/logging";
 import {
   CipherFormConfigService,
   PasswordRepromptService,
@@ -40,6 +41,7 @@ export class UnsecuredWebsitesReportComponent extends CipherReportComponent impl
     protected collectionService: CollectionService,
     cipherFormConfigService: CipherFormConfigService,
     adminConsoleCipherFormConfigService: AdminConsoleCipherFormConfigService,
+    protected logService: LogService,
   ) {
     super(
       cipherService,
@@ -51,6 +53,7 @@ export class UnsecuredWebsitesReportComponent extends CipherReportComponent impl
       syncService,
       cipherFormConfigService,
       adminConsoleCipherFormConfigService,
+      logService,
     );
   }
 

--- a/apps/web/src/app/dirt/reports/pages/weak-passwords-report.component.html
+++ b/apps/web/src/app/dirt/reports/pages/weak-passwords-report.component.html
@@ -12,6 +12,10 @@
       ></bit-icon>
       <span class="tw-sr-only">{{ "loading" | i18n }}</span>
     </div>
+  } @else if (loadFailed) {
+    <bit-callout type="danger" title="{{ 'error' | i18n }}">
+      {{ "unexpectedError" | i18n }}
+    </bit-callout>
   } @else {
     <div class="tw-mt-4">
       @if (!ciphers.length) {

--- a/apps/web/src/app/dirt/reports/pages/weak-passwords-report.component.spec.ts
+++ b/apps/web/src/app/dirt/reports/pages/weak-passwords-report.component.spec.ts
@@ -6,6 +6,7 @@ import { of } from "rxjs";
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { FakeAccountService, mockAccountServiceWith } from "@bitwarden/common/spec";
 import { PasswordStrengthServiceAbstraction } from "@bitwarden/common/tools/password-strength";
@@ -98,6 +99,10 @@ describe("WeakPasswordsReportComponent", () => {
         {
           provide: AdminConsoleCipherFormConfigService,
           useValue: adminConsoleCipherFormConfigServiceMock,
+        },
+        {
+          provide: LogService,
+          useValue: mock<LogService>(),
         },
       ],
       schemas: [CUSTOM_ELEMENTS_SCHEMA],

--- a/apps/web/src/app/dirt/reports/pages/weak-passwords-report.component.ts
+++ b/apps/web/src/app/dirt/reports/pages/weak-passwords-report.component.ts
@@ -5,6 +5,7 @@ import { Component, OnInit } from "@angular/core";
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { PasswordStrengthServiceAbstraction } from "@bitwarden/common/tools/password-strength";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
@@ -48,6 +49,7 @@ export class WeakPasswordsReportComponent extends CipherReportComponent implemen
     syncService: SyncService,
     cipherFormConfigService: CipherFormConfigService,
     protected adminConsoleCipherFormConfigService: AdminConsoleCipherFormConfigService,
+    protected logService: LogService,
   ) {
     super(
       cipherService,
@@ -59,6 +61,7 @@ export class WeakPasswordsReportComponent extends CipherReportComponent implemen
       syncService,
       cipherFormConfigService,
       adminConsoleCipherFormConfigService,
+      logService,
     );
   }
 
@@ -100,12 +103,19 @@ export class WeakPasswordsReportComponent extends CipherReportComponent implemen
   }
 
   protected findWeakPasswords(ciphers: CipherView[]): void {
+    const loginCiphers = ciphers.filter((c) => c.type === CipherType.Login);
+    this.logService.info(
+      `[WeakPasswordsReport] [${this.reportScope}] Analyzing ${loginCiphers.length} logins`,
+    );
     ciphers.forEach((ciph) => {
       const row = this.determineWeakPasswordScore(ciph);
       if (row != null) {
         this.weakPasswordCiphers.push(row);
       }
     });
+    this.logService.info(
+      `[WeakPasswordsReport] [${this.reportScope}] Found ${this.weakPasswordCiphers.length} weak passwords`,
+    );
     this.filterCiphersByOrg(this.weakPasswordCiphers);
   }
 

--- a/apps/web/src/app/dirt/reports/services/org-report-context.service.spec.ts
+++ b/apps/web/src/app/dirt/reports/services/org-report-context.service.spec.ts
@@ -1,0 +1,99 @@
+import { TestBed } from "@angular/core/testing";
+import { MockProxy, mock } from "jest-mock-extended";
+import { of, throwError } from "rxjs";
+
+import { CollectionService } from "@bitwarden/admin-console/common";
+import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
+
+import { OrgReportContextService } from "./org-report-context.service";
+
+describe("OrgReportContextService", () => {
+  let service: OrgReportContextService;
+  let accountService: MockProxy<AccountService>;
+  let organizationService: MockProxy<OrganizationService>;
+  let cipherService: MockProxy<CipherService>;
+  let collectionService: MockProxy<CollectionService>;
+  let logService: MockProxy<LogService>;
+
+  const logContext = "[TestReport] [Enterprise]";
+  const organization = { id: "org1" } as any;
+
+  beforeEach(() => {
+    accountService = mock<AccountService>();
+    accountService.activeAccount$ = of({ id: "user1" } as any);
+    organizationService = mock<OrganizationService>();
+    organizationService.organizations$.mockReturnValue(of([organization]));
+    cipherService = mock<CipherService>();
+    cipherService.getAll.mockResolvedValue([]);
+    collectionService = mock<CollectionService>();
+    collectionService.decryptedCollections$.mockReturnValue(of([]));
+    logService = mock<LogService>();
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: AccountService, useValue: accountService },
+        { provide: OrganizationService, useValue: organizationService },
+        { provide: CipherService, useValue: cipherService },
+        { provide: CollectionService, useValue: collectionService },
+        { provide: LogService, useValue: logService },
+      ],
+    });
+    service = TestBed.inject(OrgReportContextService);
+  });
+
+  it("returns the organization, manageable cipher IDs, and shared collection IDs", async () => {
+    cipherService.getAll.mockResolvedValue([{ id: "c1" } as any, { id: "c2" } as any]);
+    collectionService.decryptedCollections$.mockReturnValue(
+      of([
+        { id: "col1", isDefaultCollection: false, organizationId: "org1" } as any,
+        { id: "col2", isDefaultCollection: true, organizationId: "org1" } as any,
+        { id: "col3", isDefaultCollection: false, organizationId: "other" } as any,
+      ]),
+    );
+
+    const ctx = await service.load("org1", logContext);
+
+    expect(ctx.organization).toBe(organization);
+    expect([...ctx.manageableCipherIds]).toEqual(["c1", "c2"]);
+    // Only the non-default collection belonging to this organization is shared.
+    expect([...ctx.sharedCollectionIds]).toEqual(["col1"]);
+    expect(logService.error).not.toHaveBeenCalled();
+  });
+
+  it("logs and rethrows when loading the organization fails", async () => {
+    organizationService.organizations$.mockReturnValue(
+      throwError(() => new Error("org load failed")),
+    );
+
+    await expect(service.load("org1", logContext)).rejects.toThrow("org load failed");
+    expect(logService.error).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to load organization"),
+      expect.any(Error),
+    );
+  });
+
+  it("logs and rethrows when loading manageable ciphers fails", async () => {
+    cipherService.getAll.mockRejectedValue(new Error("ciphers load failed"));
+
+    await expect(service.load("org1", logContext)).rejects.toThrow("ciphers load failed");
+    expect(logService.error).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to load manageable ciphers"),
+      expect.any(Error),
+    );
+  });
+
+  it("logs and rethrows when loading collections fails", async () => {
+    collectionService.decryptedCollections$.mockReturnValue(
+      throwError(() => new Error("collection load failed")),
+    );
+
+    await expect(service.load("org1", logContext)).rejects.toThrow("collection load failed");
+    expect(logService.error).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to load collections"),
+      expect.any(Error),
+    );
+  });
+});

--- a/apps/web/src/app/dirt/reports/services/org-report-context.service.ts
+++ b/apps/web/src/app/dirt/reports/services/org-report-context.service.ts
@@ -1,0 +1,84 @@
+import { Injectable, inject } from "@angular/core";
+import { firstValueFrom } from "rxjs";
+
+import { CollectionService } from "@bitwarden/admin-console/common";
+import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
+import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { getUserId } from "@bitwarden/common/auth/services/account.service";
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+import { getById } from "@bitwarden/common/platform/misc";
+import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
+
+/** The organization-scoped data an organization report page needs before loading its ciphers. */
+export interface OrgReportContext {
+  organization: Organization;
+  manageableCipherIds: Set<string>;
+  sharedCollectionIds: Set<string>;
+}
+
+/**
+ * Loads the shared organization context (organization, the user's manageable cipher IDs, and the
+ * org's shared non-default collection IDs) used by every organization report page. Extracting this
+ * keeps the report components thin and removes the per-step error-logging that was previously
+ * duplicated across each org report, in line with composition-over-inheritance (ADR-0009).
+ *
+ * This is observability/structure only — it performs the same loads, in the same order, that the
+ * report components did inline.
+ */
+@Injectable({ providedIn: "root" })
+export class OrgReportContextService {
+  private readonly accountService = inject(AccountService);
+  private readonly organizationService = inject(OrganizationService);
+  private readonly cipherService = inject(CipherService);
+  private readonly collectionService = inject(CollectionService);
+  private readonly logService = inject(LogService);
+
+  /**
+   * Loads the organization report context. Each step logs its failure (with the error object) under
+   * `logContext` and re-throws, so failures still surface to the caller rather than being swallowed.
+   *
+   * @param organizationId Organization whose report context to load.
+   * @param logContext Bracketed log prefix, e.g. `"[ExposedPasswordsReport] [Enterprise]"`.
+   */
+  async load(organizationId: string, logContext: string): Promise<OrgReportContext> {
+    const userId = await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId));
+
+    const organization = await this.step(logContext, "load organization", async () => {
+      const org = await firstValueFrom(
+        this.organizationService.organizations$(userId).pipe(getById(organizationId)),
+      );
+      if (org == null) {
+        throw new Error(`Organization ${organizationId} not found`);
+      }
+      return org;
+    });
+
+    const manageableCipherIds = await this.step(logContext, "load manageable ciphers", async () => {
+      const ciphers = await this.cipherService.getAll(userId);
+      return new Set(ciphers.map((c) => c.id));
+    });
+
+    const sharedCollectionIds = await this.step(logContext, "load collections", async () => {
+      const collections = await firstValueFrom(
+        this.collectionService.decryptedCollections$(userId),
+      );
+      return new Set(
+        collections
+          .filter((c) => !c.isDefaultCollection && c.organizationId === organization.id)
+          .map((c) => c.id as string),
+      );
+    });
+
+    return { organization, manageableCipherIds, sharedCollectionIds };
+  }
+
+  private async step<T>(logContext: string, action: string, fn: () => Promise<T>): Promise<T> {
+    try {
+      return await fn();
+    } catch (e) {
+      this.logService.error(`${logContext} Failed to ${action}`, e);
+      throw e;
+    }
+  }
+}


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-36835

## 📔 Objective

To facilitate logging in weak-passwords report.
Since the weak-passwords-report inherits from cipher-report - we had to modify other reports - just to include logging

## 📸 Screenshots

<img width="2029" height="1078" alt="image" src="https://github.com/user-attachments/assets/afc54cbb-5ea8-47f4-8789-0a76339e7520" />
