### PR TITLE
feat(browser): Add autofill for SSH keys

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -1944,7 +1944,7 @@
   "showInlineMenuCardsLabel": {
     "message": "Display cards as suggestions"
   },
-  "showInlineMenuSshKeysLabel": {
+  "showInlineMenuSSHKeysLabel": {
     "message": "Display SSH keys as suggestions"
   },
   "showInlineMenuOnIconSelectionLabel": {

--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -1944,6 +1944,9 @@
   "showInlineMenuCardsLabel": {
     "message": "Display cards as suggestions"
   },
+  "showInlineMenuSshKeysLabel": {
+    "message": "Display SSH keys as suggestions"
+  },
   "showInlineMenuOnIconSelectionLabel": {
     "message": "Display suggestions when icon is selected"
   },

--- a/apps/browser/src/autofill/background/abstractions/overlay.background.ts
+++ b/apps/browser/src/autofill/background/abstractions/overlay.background.ts
@@ -213,6 +213,7 @@ export type InlineMenuCipherData = {
     fullName: string;
     username?: string;
   };
+  sshKey?: string;
 };
 
 export type BuildCipherDataParams = {
@@ -253,6 +254,7 @@ export type OverlayBackgroundExtensionMessageHandlers = {
   openAutofillInlineMenu: ({ message, sender }: BackgroundOnMessageHandlerParams) => Promise<void>;
   getInlineMenuCardsVisibility: () => void;
   getInlineMenuIdentitiesVisibility: () => void;
+  getInlineMenuSshKeysVisibility: () => void;
   closeAutofillInlineMenu: ({ message, sender }: BackgroundOnMessageHandlerParams) => void;
   checkAutofillInlineMenuFocused: ({ sender }: BackgroundSenderParam) => void;
   focusAutofillInlineMenuList: () => void;

--- a/apps/browser/src/autofill/background/abstractions/overlay.background.ts
+++ b/apps/browser/src/autofill/background/abstractions/overlay.background.ts
@@ -213,7 +213,6 @@ export type InlineMenuCipherData = {
     fullName: string;
     username?: string;
   };
-  sshKey?: string;
 };
 
 export type BuildCipherDataParams = {

--- a/apps/browser/src/autofill/background/overlay.background.spec.ts
+++ b/apps/browser/src/autofill/background/overlay.background.spec.ts
@@ -1020,6 +1020,7 @@ describe("OverlayBackground", () => {
       expect(cipherService.getAllDecryptedForUrl).toHaveBeenCalledWith(url, mockUserId, [
         CipherType.Card,
         CipherType.Identity,
+        CipherType.SshKey,
       ]);
       expect(cipherService.sortCiphersByLastUsedThenName).toHaveBeenCalled();
       expect(overlayBackground["inlineMenuCiphers"]).toStrictEqual(
@@ -1062,6 +1063,7 @@ describe("OverlayBackground", () => {
       expect(cipherService.getAllDecryptedForUrl).toHaveBeenCalledWith(url, mockUserId, [
         CipherType.Card,
         CipherType.Identity,
+        CipherType.SshKey,
       ]);
       expect(cipherService.sortCiphersByLastUsedThenName).toHaveBeenCalled();
       expect(overlayBackground["inlineMenuCiphers"]).toStrictEqual(

--- a/apps/browser/src/autofill/background/overlay.background.spec.ts
+++ b/apps/browser/src/autofill/background/overlay.background.spec.ts
@@ -1801,6 +1801,23 @@ describe("OverlayBackground", () => {
         expect(openAddEditVaultItemPopoutSpy).toHaveBeenCalled();
       });
 
+      it("creates a blank SSH key cipher without captured page data", async () => {
+        overlayBackground["currentAddNewItemData"].addNewCipherType = CipherType.SshKey;
+
+        sendMockExtensionMessage(
+          {
+            command: "autofillOverlayAddNewVaultItem",
+            addNewCipherType: CipherType.SshKey,
+          },
+          sender,
+        );
+        jest.advanceTimersByTime(100);
+        await flushPromises();
+
+        expect(cipherService.setAddEditCipherInfo).toHaveBeenCalled();
+        expect(openAddEditVaultItemPopoutSpy).toHaveBeenCalled();
+      });
+
       describe("creating a new identity cipher", () => {
         beforeEach(() => {
           overlayBackground["currentAddNewItemData"].addNewCipherType = CipherType.Identity;
@@ -3351,10 +3368,10 @@ describe("OverlayBackground", () => {
           left: "1271px",
         });
         expect(buttonPosition).toEqual({
-          width: "34px",
-          height: "34px",
-          top: "317px",
-          left: "1271px",
+          width: "23px",
+          height: "23px",
+          top: "311px",
+          left: "1289px",
         });
       });
       it("sets button and menu width and position when multi-input totp field is focused", async () => {
@@ -3435,10 +3452,10 @@ describe("OverlayBackground", () => {
           left: "1042px",
         });
         expect(buttonPosition).toEqual({
-          width: "34px",
-          height: "34px",
-          top: "292px",
-          left: "2187px",
+          width: "23px",
+          height: "23px",
+          top: "286px",
+          left: "2204px",
         });
       });
     });

--- a/apps/browser/src/autofill/background/overlay.background.ts
+++ b/apps/browser/src/autofill/background/overlay.background.ts
@@ -117,7 +117,12 @@ import {
   PasswordGenerateRequestSource,
 } from "./abstractions/overlay.background";
 
-const cardAndIdentityCipherType: CipherType[] = [CipherType.Card, CipherType.Identity];
+// Non-login cipher types that are fetched and cached for the inline menu regardless of URL match.
+const cardAndIdentityCipherType: CipherType[] = [
+  CipherType.Card,
+  CipherType.Identity,
+  CipherType.SshKey,
+];
 
 export class OverlayBackground implements OverlayBackgroundInterface {
   // Assigned as members so jest.spyOn can intercept them in tests
@@ -189,6 +194,7 @@ export class OverlayBackground implements OverlayBackgroundInterface {
       ),
     getInlineMenuCardsVisibility: () => this.getInlineMenuCardsVisibility(),
     getInlineMenuIdentitiesVisibility: () => this.getInlineMenuIdentitiesVisibility(),
+    getInlineMenuSshKeysVisibility: () => this.getInlineMenuSshKeysVisibility(),
     closeAutofillInlineMenu: ({ message, sender }) =>
       void this.withSenderTab(sender, () => this.closeInlineMenu(sender, message)),
     checkAutofillInlineMenuFocused: ({ sender }) =>
@@ -580,6 +586,7 @@ export class OverlayBackground implements OverlayBackgroundInterface {
       await this.cipherService.getAllDecryptedForUrl(currentTab.url || "", userId, [
         CipherType.Card,
         CipherType.Identity,
+        CipherType.SshKey,
       ])
     ).sort((a, b) => this.cipherService.sortCiphersByLastUsedThenName(a, b));
 
@@ -737,6 +744,12 @@ export class OverlayBackground implements OverlayBackgroundInterface {
             continue;
           }
           break;
+
+        case CipherType.SshKey:
+          if (areKeyValuesNull(cipher.sshKey, ["publicKey"])) {
+            continue;
+          }
+          break;
       }
       if (!this.focusedFieldMatchesFillType(cipher.type)) {
         continue;
@@ -885,6 +898,11 @@ export class OverlayBackground implements OverlayBackgroundInterface {
 
     if (cipher.type === CipherType.Card) {
       inlineMenuData.card = cipher.card.subTitle;
+      return inlineMenuData;
+    }
+
+    if (cipher.type === CipherType.SshKey) {
+      inlineMenuData.sshKey = cipher.sshKey?.keyFingerprint;
       return inlineMenuData;
     }
 
@@ -1941,20 +1959,24 @@ export class OverlayBackground implements OverlayBackgroundInterface {
       return {};
     }
 
-    let elementOffset = height * 0.37;
-    if (height >= 35) {
-      elementOffset = height >= 50 ? height * 0.47 : height * 0.42;
+    // Cap the height used for sizing the button so tall fields (e.g. textareas for SSH public
+    // keys) don't scale the icon up. Single-line inputs are at or under this cap and unaffected.
+    const sizingHeight = Math.min(height, 64);
+
+    let elementOffset = sizingHeight * 0.37;
+    if (sizingHeight >= 35) {
+      elementOffset = sizingHeight >= 50 ? sizingHeight * 0.47 : sizingHeight * 0.42;
     }
 
     const fieldPaddingRight = parseInt(paddingRight ?? "", 10);
     const fieldPaddingLeft = parseInt(paddingLeft ?? "", 10);
-    const elementHeight = height - elementOffset;
+    const elementHeight = sizingHeight - elementOffset;
 
     const elementTopPosition = subFrameTopOffset + top + elementOffset / 2;
     const elementLeftPosition =
       fieldPaddingRight > fieldPaddingLeft
-        ? subFrameLeftOffset + left + width - height - (fieldPaddingRight - elementOffset + 2)
-        : subFrameLeftOffset + left + width - height + elementOffset / 2;
+        ? subFrameLeftOffset + left + width - sizingHeight - (fieldPaddingRight - elementOffset + 2)
+        : subFrameLeftOffset + left + width - sizingHeight + elementOffset / 2;
 
     const button = {
       top: Math.round(elementTopPosition),
@@ -2485,6 +2507,13 @@ export class OverlayBackground implements OverlayBackgroundInterface {
    */
   private async getInlineMenuIdentitiesVisibility(): Promise<boolean> {
     return await firstValueFrom(this.autofillSettingsService.showInlineMenuIdentities$);
+  }
+
+  /**
+   * Gets the inline menu's visibility setting for SSH keys from the settings service.
+   */
+  private async getInlineMenuSshKeysVisibility(): Promise<boolean> {
+    return await firstValueFrom(this.autofillSettingsService.showInlineMenuSshKeys$);
   }
 
   /**

--- a/apps/browser/src/autofill/background/overlay.background.ts
+++ b/apps/browser/src/autofill/background/overlay.background.ts
@@ -54,6 +54,7 @@ import { Fido2CredentialView } from "@bitwarden/common/vault/models/view/fido2-c
 import { IdentityView } from "@bitwarden/common/vault/models/view/identity.view";
 import { LoginUriView } from "@bitwarden/common/vault/models/view/login-uri.view";
 import { LoginView } from "@bitwarden/common/vault/models/view/login.view";
+import { SshKeyView } from "@bitwarden/common/vault/models/view/ssh-key.view";
 import { CredentialGeneratorService, GenerateRequest, Type } from "@bitwarden/generator-core";
 import { GeneratorHistoryService } from "@bitwarden/generator-history";
 
@@ -118,7 +119,7 @@ import {
 } from "./abstractions/overlay.background";
 
 // Non-login cipher types that are fetched and cached for the inline menu regardless of URL match.
-const cardAndIdentityCipherType: CipherType[] = [
+const nonLoginInlineCipherType: CipherType[] = [
   CipherType.Card,
   CipherType.Identity,
   CipherType.SshKey,
@@ -598,7 +599,7 @@ export class OverlayBackground implements OverlayBackgroundInterface {
       const cipherView = cipherViews[cipherIndex];
       if (
         !this.cardAndIdentityCiphers.has(cipherView) &&
-        cardAndIdentityCipherType.includes(cipherView.type)
+        nonLoginInlineCipherType.includes(cipherView.type)
       ) {
         this.cardAndIdentityCiphers.add(cipherView);
       }
@@ -902,7 +903,6 @@ export class OverlayBackground implements OverlayBackgroundInterface {
     }
 
     if (cipher.type === CipherType.SshKey) {
-      inlineMenuData.sshKey = cipher.sshKey?.keyFingerprint;
       return inlineMenuData;
     }
 
@@ -1960,8 +1960,9 @@ export class OverlayBackground implements OverlayBackgroundInterface {
     }
 
     // Cap the height used for sizing the button so tall fields (e.g. textareas for SSH public
-    // keys) don't scale the icon up. Single-line inputs are at or under this cap and unaffected.
-    const sizingHeight = Math.min(height, 64);
+    // keys) produce a button comparable to a normal single-line input rather than scaling the
+    // icon up. Typical single-line inputs are under this cap and unaffected.
+    const sizingHeight = Math.min(height, 40);
 
     let elementOffset = sizingHeight * 0.37;
     if (sizingHeight >= 35) {
@@ -2785,6 +2786,13 @@ export class OverlayBackground implements OverlayBackgroundInterface {
   }
 
   /**
+   * Identifies if the current add new item data is for adding a new identity.
+   */
+  private isAddingNewSshKey() {
+    return this.currentAddNewItemData?.addNewCipherType === CipherType.SshKey;
+  }
+
+  /**
    * Updates the current add new item data with the provided login data. If the
    * login data is already present, the data will be merged with the existing data.
    *
@@ -2923,6 +2931,7 @@ export class OverlayBackground implements OverlayBackgroundInterface {
       login,
       card,
       identity,
+      addNewCipherType,
     });
 
     if (!cipherView) {
@@ -2966,6 +2975,7 @@ export class OverlayBackground implements OverlayBackgroundInterface {
     login,
     card,
     identity,
+    addNewCipherType,
   }: OverlayAddNewItemMessage): CipherView | undefined {
     if (login && this.isAddingNewLogin()) {
       return this.buildLoginCipherView(login);
@@ -2978,6 +2988,24 @@ export class OverlayBackground implements OverlayBackgroundInterface {
     if (identity && this.isAddingNewIdentity()) {
       return this.buildIdentityCipherView(identity);
     }
+
+    if (this.isAddingNewSshKey()) {
+      return this.buildSshKeyCipherView();
+    }
+  }
+
+  /**
+   * Builds a new, empty SSH key cipher view. SSH keys cannot be captured from the page, so
+   * the add/edit popout is opened with a blank item for the user to fill in.
+   */
+  private buildSshKeyCipherView() {
+    const cipherView = new CipherView();
+    cipherView.name = "";
+    cipherView.folderId = undefined;
+    cipherView.type = CipherType.SshKey;
+    cipherView.sshKey = new SshKeyView();
+
+    return cipherView;
   }
 
   /**

--- a/apps/browser/src/autofill/browser/cipher-context-menu-handler.ts
+++ b/apps/browser/src/autofill/browser/cipher-context-menu-handler.ts
@@ -70,6 +70,9 @@ export class CipherContextMenuHandler {
         [CipherType.Login]: [],
         [CipherType.Card]: [],
         [CipherType.Identity]: [],
+        // SSH keys are not surfaced in the right-click context menu yet, but the grouping
+        // record must cover every AutofillCipherTypeId.
+        [CipherType.SshKey]: [],
       },
     );
 

--- a/apps/browser/src/autofill/enums/autofill-overlay.enum.ts
+++ b/apps/browser/src/autofill/enums/autofill-overlay.enum.ts
@@ -21,10 +21,12 @@ export const RedirectFocusDirection = {
   Next: "next",
 } as const;
 
+// These values must not collide with any `CipherType` (1-8), since `InlineMenuFillType`
+// is a union of these and `CipherType` and the two are compared with `===`.
 export const InlineMenuFillTypes = {
-  AccountCreationUsername: 5,
-  PasswordGeneration: 6,
-  CurrentPasswordUpdate: 7,
+  AccountCreationUsername: 100,
+  PasswordGeneration: 101,
+  CurrentPasswordUpdate: 102,
 } as const;
 
 export type InlineMenuFillTypeValue =

--- a/apps/browser/src/autofill/overlay/inline-menu/abstractions/autofill-inline-menu-button.ts
+++ b/apps/browser/src/autofill/overlay/inline-menu/abstractions/autofill-inline-menu-button.ts
@@ -26,9 +26,4 @@ export type AutofillInlineMenuButtonWindowMessageHandlers = {
   }: {
     message: UpdateAuthStatusMessage;
   }) => void;
-  updateAutofillInlineMenuColorScheme: ({
-    message,
-  }: {
-    message: AutofillInlineMenuButtonMessage;
-  }) => void;
 };

--- a/apps/browser/src/autofill/overlay/inline-menu/iframe-content/autofill-inline-menu-button-iframe.ts
+++ b/apps/browser/src/autofill/overlay/inline-menu/iframe-content/autofill-inline-menu-button-iframe.ts
@@ -10,6 +10,7 @@ export class AutofillInlineMenuButtonIframe extends AutofillInlineMenuIframeElem
       {
         background: "transparent",
         border: "none",
+        colorScheme: "auto",
       },
       chrome.i18n.getMessage("bitwardenOverlayButton"),
       chrome.i18n.getMessage("bitwardenOverlayMenuAvailable"),

--- a/apps/browser/src/autofill/overlay/inline-menu/pages/button/autofill-inline-menu-button.spec.ts
+++ b/apps/browser/src/autofill/overlay/inline-menu/pages/button/autofill-inline-menu-button.spec.ts
@@ -136,10 +136,10 @@ describe("AutofillInlineMenuButton", () => {
       expect(autofillInlineMenuButton["authStatus"]).toBe(AuthenticationStatus.Unlocked);
     });
 
-    it("updates the page color scheme meta tag", async () => {
+    it("does not adopt the host page color scheme so the button canvas stays transparent", async () => {
       const colorSchemeMetaTag = globalThis.document.createElement("meta");
       colorSchemeMetaTag.setAttribute("name", "color-scheme");
-      colorSchemeMetaTag.setAttribute("content", "light");
+      colorSchemeMetaTag.setAttribute("content", "normal");
       globalThis.document.head.append(colorSchemeMetaTag);
 
       postWindowMessage({
@@ -149,7 +149,7 @@ describe("AutofillInlineMenuButton", () => {
       });
       await flushPromises();
 
-      expect(colorSchemeMetaTag.getAttribute("content")).toBe("dark");
+      expect(colorSchemeMetaTag.getAttribute("content")).toBe("normal");
     });
   });
 });

--- a/apps/browser/src/autofill/overlay/inline-menu/pages/button/autofill-inline-menu-button.ts
+++ b/apps/browser/src/autofill/overlay/inline-menu/pages/button/autofill-inline-menu-button.ts
@@ -7,7 +7,6 @@ import { buildSvgDomElement } from "../../../../utils";
 import { logoIcon, logoLockedIcon } from "../../../../utils/svg-icons";
 import {
   InitAutofillInlineMenuButtonMessage,
-  AutofillInlineMenuButtonMessage,
   AutofillInlineMenuButtonWindowMessageHandlers,
 } from "../../abstractions/autofill-inline-menu-button";
 import { AutofillInlineMenuPageElement } from "../shared/autofill-inline-menu-page-element";
@@ -23,7 +22,6 @@ export class AutofillInlineMenuButton extends AutofillInlineMenuPageElement {
       checkAutofillInlineMenuButtonFocused: () => this.checkButtonFocused(),
       updateAutofillInlineMenuButtonAuthStatus: ({ message }) =>
         this.updateAuthStatus(message.authStatus),
-      updateAutofillInlineMenuColorScheme: ({ message }) => this.updatePageColorScheme(message),
     };
 
   constructor() {
@@ -69,7 +67,6 @@ export class AutofillInlineMenuButton extends AutofillInlineMenuPageElement {
       this.getTranslation("toggleBitwardenVaultOverlay"),
     );
     this.buttonElement.addEventListener(EVENTS.CLICK, this.handleButtonElementClick);
-    this.postMessageToParent({ command: "updateAutofillInlineMenuColorScheme" });
 
     this.updateAuthStatus(authStatus);
 
@@ -91,20 +88,6 @@ export class AutofillInlineMenuButton extends AutofillInlineMenuPageElement {
         ? this.logoIconElement
         : this.logoLockedIconElement;
     this.buttonElement.append(iconElement);
-  }
-
-  /**
-   * Handles updating the page color scheme meta tag. Ensures that the button
-   * does not present with a non-transparent background on dark mode pages.
-   *
-   * @param colorScheme - The color scheme of the iframe's parent page
-   */
-  private updatePageColorScheme({ colorScheme }: AutofillInlineMenuButtonMessage) {
-    const colorSchemeMetaTag = globalThis.document.querySelector("meta[name='color-scheme']");
-
-    if (colorSchemeMetaTag && colorScheme) {
-      colorSchemeMetaTag.setAttribute("content", colorScheme);
-    }
   }
 
   /**

--- a/apps/browser/src/autofill/overlay/inline-menu/pages/button/button.html
+++ b/apps/browser/src/autofill/overlay/inline-menu/pages/button/button.html
@@ -4,7 +4,6 @@
     <title>Bitwarden inline menu button</title>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
-    <meta name="color-scheme" content="normal" />
   </head>
   <body>
     <autofill-inline-menu-button></autofill-inline-menu-button>

--- a/apps/browser/src/autofill/overlay/inline-menu/pages/list/autofill-inline-menu-list.ts
+++ b/apps/browser/src/autofill/overlay/inline-menu/pages/list/autofill-inline-menu-list.ts
@@ -1521,6 +1521,10 @@ export class AutofillInlineMenuList extends AutofillInlineMenuPageElement {
       return cipher.card;
     }
 
+    if (cipher.sshKey) {
+      return cipher.sshKey;
+    }
+
     return "";
   }
 

--- a/apps/browser/src/autofill/overlay/inline-menu/pages/list/autofill-inline-menu-list.ts
+++ b/apps/browser/src/autofill/overlay/inline-menu/pages/list/autofill-inline-menu-list.ts
@@ -1301,6 +1301,11 @@ export class AutofillInlineMenuList extends AutofillInlineMenuPageElement {
       return cipherIcon;
     }
 
+    if (cipher.icon.icon.includes("bwi-key")) {
+      cipherIcon.append(buildSvgDomElement(keyIcon));
+      return cipherIcon;
+    }
+
     const iconClasses = cipher.icon.icon.split(" ");
     cipherIcon.classList.add("cipher-icon", "bwi", ...iconClasses);
     return cipherIcon;

--- a/apps/browser/src/autofill/overlay/inline-menu/pages/list/autofill-inline-menu-list.ts
+++ b/apps/browser/src/autofill/overlay/inline-menu/pages/list/autofill-inline-menu-list.ts
@@ -1526,10 +1526,6 @@ export class AutofillInlineMenuList extends AutofillInlineMenuPageElement {
       return cipher.card;
     }
 
-    if (cipher.sshKey) {
-      return cipher.sshKey;
-    }
-
     return "";
   }
 

--- a/apps/browser/src/autofill/overlay/inline-menu/pages/menu-container/autofill-inline-menu-container.ts
+++ b/apps/browser/src/autofill/overlay/inline-menu/pages/menu-container/autofill-inline-menu-container.ts
@@ -56,7 +56,7 @@ export class AutofillInlineMenuContainer {
     pointerEvents: "auto",
     margin: "0",
     padding: "0",
-    colorScheme: "normal",
+    colorScheme: "auto",
   };
   private readonly defaultIframeAttributes: Record<string, string> = {
     src: "",

--- a/apps/browser/src/autofill/overlay/inline-menu/pages/menu-container/menu-container.html
+++ b/apps/browser/src/autofill/overlay/inline-menu/pages/menu-container/menu-container.html
@@ -4,7 +4,6 @@
     <title>Bitwarden inline menu</title>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
-    <meta name="color-scheme" content="normal" />
   </head>
   <body></body>
 </html>

--- a/apps/browser/src/autofill/popup/settings/autofill.component.html
+++ b/apps/browser/src/autofill/popup/settings/autofill.component.html
@@ -157,6 +157,18 @@
         <bit-form-control *ngIf="enableInlineMenu" class="tw-ml-5">
           <input
             bitCheckbox
+            id="show-inline-menu-ssh-keys"
+            type="checkbox"
+            (change)="updateShowInlineMenuSshKeys()"
+            [(ngModel)]="showInlineMenuSshKeys"
+          />
+          <bit-label for="show-inline-menu-ssh-keys">
+            {{ "showInlineMenuSshKeysLabel" | i18n }}
+          </bit-label>
+        </bit-form-control>
+        <bit-form-control *ngIf="enableInlineMenu" class="tw-ml-5">
+          <input
+            bitCheckbox
             id="show-autofill-suggestions-on-icon"
             type="checkbox"
             (change)="updateInlineMenuVisibility()"

--- a/apps/browser/src/autofill/popup/settings/autofill.component.html
+++ b/apps/browser/src/autofill/popup/settings/autofill.component.html
@@ -163,7 +163,7 @@
             [(ngModel)]="showInlineMenuSshKeys"
           />
           <bit-label for="show-inline-menu-ssh-keys">
-            {{ "showInlineMenuSshKeysLabel" | i18n }}
+            {{ "showInlineMenuSSHKeysLabel" | i18n }}
           </bit-label>
         </bit-form-control>
         <bit-form-control *ngIf="enableInlineMenu" class="tw-ml-5">

--- a/apps/browser/src/autofill/popup/settings/autofill.component.ts
+++ b/apps/browser/src/autofill/popup/settings/autofill.component.ts
@@ -156,6 +156,7 @@ export class AutofillComponent implements OnInit {
   enableInlineMenuOnIconSelect: boolean = false;
   showInlineMenuIdentities: boolean = true;
   showInlineMenuCards: boolean = true;
+  showInlineMenuSshKeys: boolean = true;
   autofillOnPageLoadDefault: boolean = false;
   autofillOnPageLoadOptions: { name: string; value: boolean }[];
   enableContextMenuItem: boolean = false;
@@ -252,6 +253,10 @@ export class AutofillComponent implements OnInit {
 
     this.showInlineMenuCards = await firstValueFrom(
       this.autofillSettingsService.showInlineMenuCards$,
+    );
+
+    this.showInlineMenuSshKeys = await firstValueFrom(
+      this.autofillSettingsService.showInlineMenuSshKeys$,
     );
 
     this.enableInlineMenuOnIconSelect =
@@ -644,6 +649,10 @@ export class AutofillComponent implements OnInit {
 
   async updateShowInlineMenuIdentities() {
     await this.autofillSettingsService.setShowInlineMenuIdentities(this.showInlineMenuIdentities);
+  }
+
+  async updateShowInlineMenuSshKeys() {
+    await this.autofillSettingsService.setShowInlineMenuSshKeys(this.showInlineMenuSshKeys);
   }
 
   getMatchHints() {

--- a/apps/browser/src/autofill/services/abstractions/inline-menu-field-qualifications.service.ts
+++ b/apps/browser/src/autofill/services/abstractions/inline-menu-field-qualifications.service.ts
@@ -13,6 +13,7 @@ export interface InlineMenuFieldQualificationService {
   isFieldForCreditCardForm(field: AutofillField, pageDetails: AutofillPageDetails): boolean;
   isFieldForAccountCreationForm(field: AutofillField, pageDetails: AutofillPageDetails): boolean;
   isFieldForIdentityForm(field: AutofillField, pageDetails: AutofillPageDetails): boolean;
+  isFieldForSshKeyForm(field: AutofillField, pageDetails: AutofillPageDetails): boolean;
   isFieldForCardholderName(field: AutofillField): boolean;
   isFieldForCardNumber(field: AutofillField): boolean;
   isFieldForCardExpirationDate(field: AutofillField): boolean;

--- a/apps/browser/src/autofill/services/autofill-constants.ts
+++ b/apps/browser/src/autofill/services/autofill-constants.ts
@@ -1026,7 +1026,6 @@ export class IdentityAutoFillConstants {
 export class SshKeyAutoFillConstants {
   /** Field attributes scanned to gather matching keywords. */
   static readonly SshKeyAttributes: string[] = [
-    "autoCompleteType",
     "htmlName",
     "htmlID",
     "htmlClass",

--- a/apps/browser/src/autofill/services/autofill-constants.ts
+++ b/apps/browser/src/autofill/services/autofill-constants.ts
@@ -1051,13 +1051,7 @@ export class SshKeyAutoFillConstants {
     "sk-ecdsa-sha2-",
   ];
 
-  static readonly PublicKeyFieldNames: string[] = [
-    "key",
-    "public-key",
-    "publickey",
-    "ssh-key",
-    "sshkey",
-  ];
+  static readonly PublicKeyFieldNames: string[] = ["public-key", "publickey", "ssh-key", "sshkey"];
 
   static readonly TitleFieldNames: string[] = ["title", "label", "name", "description"];
 

--- a/apps/browser/src/autofill/services/autofill-constants.ts
+++ b/apps/browser/src/autofill/services/autofill-constants.ts
@@ -1023,6 +1023,48 @@ export class IdentityAutoFillConstants {
   };
 }
 
+export class SshKeyAutoFillConstants {
+  /** Field attributes scanned to gather matching keywords. */
+  static readonly SshKeyAttributes: string[] = [
+    "autoCompleteType",
+    "htmlName",
+    "htmlID",
+    "htmlClass",
+    "label-tag",
+    "label-left",
+    "label-top",
+    "placeholder",
+    "title",
+  ];
+
+  /**
+   * Algorithm prefixes that appear in the public key value or the field placeholder
+   * (e.g. GitHub/GitLab "Begins with 'ssh-rsa', 'ecdsa-sha2-nistp256'..."). This is the
+   * strongest signal that a field is an SSH public key field.
+   */
+  static readonly PublicKeyAlgorithmPrefixes: string[] = [
+    "ssh-rsa",
+    "ssh-ed25519",
+    "ssh-dss",
+    "ecdsa-sha2-",
+    "sk-ssh-ed25519",
+    "sk-ecdsa-sha2-",
+  ];
+
+  static readonly PublicKeyFieldNames: string[] = [
+    "key",
+    "public-key",
+    "publickey",
+    "ssh-key",
+    "sshkey",
+  ];
+
+  static readonly TitleFieldNames: string[] = ["title", "label", "name", "description"];
+
+  /** Data attribute GitLab places on its public key textarea. */
+  static readonly SupportedAlgorithmsAttribute = "data-supported-algorithms";
+}
+
 export const SubmitLoginButtonNames: string[] = [
   "login",
   "signin",

--- a/apps/browser/src/autofill/services/autofill-overlay-content.service.spec.ts
+++ b/apps/browser/src/autofill/services/autofill-overlay-content.service.spec.ts
@@ -2275,6 +2275,22 @@ describe("AutofillOverlayContentService", () => {
           },
         });
       });
+
+      it("sends a message that facilitates adding an SSH key cipher vault item without captured page data", async () => {
+        jest
+          .spyOn(autofillOverlayContentService as any, "isInlineMenuListVisible")
+          .mockResolvedValue(true);
+
+        sendMockExtensionMessage({
+          command: "addNewVaultItemFromOverlay",
+          addNewCipherType: CipherType.SshKey,
+        });
+        await flushPromises();
+
+        expect(sendExtensionMessageSpy).toHaveBeenCalledWith("autofillOverlayAddNewVaultItem", {
+          addNewCipherType: CipherType.SshKey,
+        });
+      });
     });
 
     describe("unsetMostRecentlyFocusedField message handler", () => {

--- a/apps/browser/src/autofill/services/autofill-overlay-content.service.ts
+++ b/apps/browser/src/autofill/services/autofill-overlay-content.service.ts
@@ -373,6 +373,13 @@ export class AutofillOverlayContentService implements AutofillOverlayContentServ
       };
 
       await this.sendExtensionMessage(command, { addNewCipherType, identity });
+
+      return;
+    }
+
+    if (addNewCipherType === CipherType.SshKey) {
+      // SSH keys cannot be captured from the page, so open a blank add/edit item.
+      await this.sendExtensionMessage(command, { addNewCipherType });
     }
   }
 

--- a/apps/browser/src/autofill/services/autofill-overlay-content.service.ts
+++ b/apps/browser/src/autofill/services/autofill-overlay-content.service.ts
@@ -70,6 +70,7 @@ export class AutofillOverlayContentService implements AutofillOverlayContentServ
   pageDetailsUpdateRequired = false;
   private showInlineMenuIdentities: boolean = false;
   private showInlineMenuCards: boolean = false;
+  private showInlineMenuSshKeys: boolean = false;
   private readonly findTabs = tabbable;
   private readonly sendExtensionMessage = sendExtensionMessage;
   private formFieldElements: Map<ElementWithOpId<FormFieldElement>, AutofillField> = new Map();
@@ -186,6 +187,7 @@ export class AutofillOverlayContentService implements AutofillOverlayContentServ
     this.isMonitoring = true;
     void this.getInlineMenuCardsVisibility();
     void this.getInlineMenuIdentitiesVisibility();
+    void this.getInlineMenuSshKeysVisibility();
 
     if (globalThis.document.readyState === "loading") {
       globalThis.document.addEventListener(EVENTS.DOMCONTENTLOADED, this.setupGlobalEventListeners);
@@ -1182,6 +1184,16 @@ export class AutofillOverlayContentService implements AutofillOverlayContentServ
       return false;
     }
 
+    // SSH key fields must be checked before the ignored-types early return, since the SSH
+    // public key field is a textarea (which is otherwise an ignored inline menu field type).
+    if (
+      this.showInlineMenuSshKeys &&
+      this.inlineMenuFieldQualificationService.isFieldForSshKeyForm(autofillFieldData, pageDetails)
+    ) {
+      autofillFieldData.inlineMenuFillType = CipherType.SshKey;
+      return false;
+    }
+
     if (autofillFieldData.type != null && this.ignoredFieldTypes.has(autofillFieldData.type)) {
       return true;
     }
@@ -1511,6 +1523,18 @@ export class AutofillOverlayContentService implements AutofillOverlayContentServ
       "getInlineMenuIdentitiesVisibility",
     );
     this.showInlineMenuIdentities = inlineMenuIdentitiesVisibility ?? true;
+  }
+
+  /**
+   * Queries the background script for the autofill inline menu's SSH keys visibility setting.
+   * If the setting is not found, a default value of true will be used
+   * @private
+   */
+  private async getInlineMenuSshKeysVisibility() {
+    const inlineMenuSshKeysVisibility = await this.sendExtensionMessage(
+      "getInlineMenuSshKeysVisibility",
+    );
+    this.showInlineMenuSshKeys = inlineMenuSshKeysVisibility ?? true;
   }
 
   /**

--- a/apps/browser/src/autofill/services/autofill.service.spec.ts
+++ b/apps/browser/src/autofill/services/autofill.service.spec.ts
@@ -48,6 +48,7 @@ import { FieldView } from "@bitwarden/common/vault/models/view/field.view";
 import { IdentityView } from "@bitwarden/common/vault/models/view/identity.view";
 import { LoginUriView } from "@bitwarden/common/vault/models/view/login-uri.view";
 import { LoginView } from "@bitwarden/common/vault/models/view/login.view";
+import { SshKeyView } from "@bitwarden/common/vault/models/view/ssh-key.view";
 import { TotpService } from "@bitwarden/common/vault/services/totp.service";
 
 import { BrowserApi } from "../../platform/browser/browser-api";
@@ -953,6 +954,33 @@ describe("AutofillService", () => {
       await autofillService.doAutoFill(autofillOptions);
 
       expect(autofillService["generateIdentityFillScript"]).toHaveBeenCalled();
+      expect(chrome.tabs.sendMessage).toHaveBeenCalled();
+      expect(eventCollectionService.collect).toHaveBeenCalledWith(
+        EventType.Cipher_ClientAutofilled,
+        autofillOptions.cipher.id,
+      );
+    });
+
+    it("will autofill SSH key data for a page", async () => {
+      autofillOptions.cipher.type = CipherType.SshKey;
+      autofillOptions.cipher.sshKey = mock<SshKeyView>({
+        publicKey: "ssh-ed25519 AAAApublickey",
+      });
+      autofillOptions.pageDetails[0].details.fields = [
+        createAutofillFieldMock({
+          opid: "ssh-public-key",
+          form: "validFormId",
+          elementNumber: 2,
+          tagName: "textarea",
+          placeholder: "Begins with 'ssh-rsa', 'ssh-ed25519'",
+        }),
+      ];
+      jest.spyOn(autofillService as any, "generateSshKeyFillScript");
+      jest.spyOn(eventCollectionService, "collect");
+
+      await autofillService.doAutoFill(autofillOptions);
+
+      expect(autofillService["generateSshKeyFillScript"]).toHaveBeenCalled();
       expect(chrome.tabs.sendMessage).toHaveBeenCalled();
       expect(eventCollectionService.collect).toHaveBeenCalledWith(
         EventType.Cipher_ClientAutofilled,
@@ -4404,6 +4432,149 @@ describe("AutofillService", () => {
           });
         });
       }
+    });
+  });
+
+  describe("generateSshKeyFillScript", () => {
+    let fillScript: AutofillScript;
+    let pageDetails: AutofillPageDetails;
+    let filledFields: { [id: string]: AutofillField };
+    let options: GenerateFillScriptOptions;
+
+    beforeEach(() => {
+      fillScript = createAutofillScriptMock({ script: [] });
+      pageDetails = createAutofillPageDetailsMock();
+      pageDetails.fields = [];
+      filledFields = {};
+      options = createGenerateFillScriptOptionsMock();
+      options.cipher.name = "My SSH key";
+      options.cipher.sshKey = mock<SshKeyView>({
+        publicKey: "ssh-ed25519 AAAApublickey comment",
+        privateKey: "private",
+        keyFingerprint: "SHA256:fingerprint",
+      });
+    });
+
+    it("returns null if an SSH key is not found within the cipher", () => {
+      options.cipher.sshKey = null;
+
+      const value = autofillService["generateSshKeyFillScript"](
+        fillScript,
+        pageDetails,
+        filledFields,
+        options,
+      );
+
+      expect(value).toBeNull();
+    });
+
+    it("fills the public key into a GitHub-shaped key textarea and the name into the title", () => {
+      const publicKeyField = createAutofillFieldMock({
+        opid: "public-key",
+        htmlName: "ssh_key[key]",
+        htmlID: "ssh_key_key",
+        tagName: "textarea",
+        placeholder: "Begins with 'ssh-rsa', 'ssh-ed25519'",
+        "label-tag": "Key",
+      });
+      const titleField = createAutofillFieldMock({
+        opid: "title",
+        htmlName: "ssh_key[title]",
+        htmlID: "ssh_key_title",
+        tagName: "input",
+        type: "text",
+        placeholder: "",
+        "label-tag": "Title",
+      });
+      pageDetails.fields = [publicKeyField, titleField];
+
+      const value = autofillService["generateSshKeyFillScript"](
+        fillScript,
+        pageDetails,
+        filledFields,
+        options,
+      );
+
+      expect(value.script).toContainEqual([
+        "fill_by_opid",
+        publicKeyField.opid,
+        "ssh-ed25519 AAAApublickey comment",
+      ]);
+      expect(value.script).toContainEqual(["fill_by_opid", titleField.opid, "My SSH key"]);
+    });
+
+    it("matches a GitLab-shaped textarea via the data-supported-algorithms attribute", () => {
+      const publicKeyField = createAutofillFieldMock({
+        opid: "public-key",
+        htmlName: "key[key]",
+        htmlID: "key_key",
+        tagName: "textarea",
+        placeholder: "",
+        "label-tag": "Key",
+        dataSetValues: 'supportedAlgorithms: ["ssh-rsa","ssh-ed25519"]',
+      });
+      pageDetails.fields = [publicKeyField];
+
+      const value = autofillService["generateSshKeyFillScript"](
+        fillScript,
+        pageDetails,
+        filledFields,
+        options,
+      );
+
+      expect(value.script).toContainEqual([
+        "fill_by_opid",
+        publicKeyField.opid,
+        "ssh-ed25519 AAAApublickey comment",
+      ]);
+    });
+
+    it("does not fill the title when no public key field is present on the page", () => {
+      const titleField = createAutofillFieldMock({
+        opid: "title",
+        htmlName: "ssh_key[title]",
+        tagName: "input",
+        type: "text",
+        placeholder: "",
+        "label-tag": "Title",
+      });
+      pageDetails.fields = [titleField];
+
+      const value = autofillService["generateSshKeyFillScript"](
+        fillScript,
+        pageDetails,
+        filledFields,
+        options,
+      );
+
+      expect(value.script).toStrictEqual([]);
+    });
+
+    it("does not fill single-line key inputs such as api_key", () => {
+      const apiKeyField = createAutofillFieldMock({
+        opid: "api-key",
+        htmlName: "api_key",
+        htmlID: "api_key",
+        tagName: "input",
+        type: "text",
+        placeholder: "",
+        "label-tag": "API key",
+        "label-left": "",
+        "label-right": "",
+        "label-top": "",
+        "label-aria": "",
+        title: "",
+      });
+      pageDetails.fields = [apiKeyField];
+
+      const value = autofillService["generateSshKeyFillScript"](
+        fillScript,
+        pageDetails,
+        filledFields,
+        options,
+      );
+
+      expect(value.script).toStrictEqual([]);
     });
   });
 

--- a/apps/browser/src/autofill/services/autofill.service.ts
+++ b/apps/browser/src/autofill/services/autofill.service.ts
@@ -72,6 +72,7 @@ import {
   CardExpiryDateFormat,
   CreditCardAutoFillConstants,
   IdentityAutoFillConstants,
+  SshKeyAutoFillConstants,
 } from "./autofill-constants";
 
 /**
@@ -879,6 +880,9 @@ export default class AutofillService implements AutofillServiceInterface {
           filledFields,
           options,
         );
+        break;
+      case CipherType.SshKey:
+        result = this.generateSshKeyFillScript(fillScript, pageDetails, filledFields, options);
         break;
       default:
         return null;
@@ -1943,6 +1947,163 @@ export default class AutofillService implements AutofillServiceInterface {
     }
 
     return fillScript;
+  }
+
+  /**
+   * Generates the autofill script for an SSH key cipher. Fills the SSH public key into the
+   * key field (a textarea on "add SSH key" forms such as GitHub and GitLab) and the cipher
+   * name into the title field. The title is only filled when a public key field is present on
+   * the page, to avoid matching generic "title"/"name" inputs on unrelated forms.
+   *
+   * @param fillScript - The autofill script to add to
+   * @param pageDetails - The collected page details
+   * @param filledFields - The fields that have already been filled
+   * @param options - The fill script generation options
+   */
+  private generateSshKeyFillScript(
+    fillScript: AutofillScript,
+    pageDetails: AutofillPageDetails,
+    filledFields: { [id: string]: AutofillField },
+    options: GenerateFillScriptOptions,
+  ): AutofillScript | null {
+    const sshKey = options.cipher.sshKey;
+    if (!sshKey) {
+      return null;
+    }
+
+    const hasPublicKeyField = pageDetails.fields.some((field) => this.isSshPublicKeyField(field));
+
+    let publicKeyFilled = false;
+    let titleFilled = false;
+    for (let fieldsIndex = 0; fieldsIndex < pageDetails.fields.length; fieldsIndex++) {
+      const field = pageDetails.fields[fieldsIndex];
+      if (this.excludeFieldFromSshKeyFill(field)) {
+        continue;
+      }
+
+      if (!publicKeyFilled && this.isSshPublicKeyField(field)) {
+        publicKeyFilled = true;
+        this.makeScriptActionWithValue(fillScript, sshKey.publicKey, field, filledFields);
+        continue;
+      }
+
+      if (hasPublicKeyField && !titleFilled && this.isSshTitleField(field)) {
+        titleFilled = true;
+        this.makeScriptActionWithValue(fillScript, options.cipher.name, field, filledFields);
+        continue;
+      }
+    }
+
+    return fillScript;
+  }
+
+  /**
+   * Identifies if the current field should be excluded from triggering autofill of the SSH
+   * key cipher. Unlike the identity check, textareas are NOT excluded since the SSH public
+   * key field is itself a textarea.
+   *
+   * @param field - The field to check
+   */
+  private excludeFieldFromSshKeyFill(field: AutofillField): boolean {
+    return (
+      AutofillService.isExcludedFieldType(field, [
+        "password",
+        ...AutoFillConstants.ExcludedAutofillTypes,
+      ]) || !field.viewable
+    );
+  }
+
+  /**
+   * Gathers all unique keyword identifiers from a field that can be used to determine which
+   * SSH key value should be filled.
+   *
+   * @param field - The field to gather keywords from
+   */
+  private getSshKeyAutofillFieldKeywords(field: AutofillField): string[] {
+    const keywords: Set<string> = new Set();
+    for (let index = 0; index < SshKeyAutoFillConstants.SshKeyAttributes.length; index++) {
+      const attribute = SshKeyAutoFillConstants.SshKeyAttributes[index];
+      const value = field[attribute];
+      if (value != null && typeof value === "string") {
+        keywords.add(
+          value
+            .trim()
+            .toLowerCase()
+            .replace(/[^a-zA-Z0-9]+/g, ""),
+        );
+      }
+    }
+
+    return Array.from(keywords);
+  }
+
+  /**
+   * Identifies if a field is the SSH public key field. Requires a textarea (the shape used by
+   * GitHub/GitLab) combined with a strong SSH signal: an algorithm prefix in the placeholder
+   * or value (e.g. "ssh-rsa"), GitLab's `data-supported-algorithms` attribute, or a "key"
+   * keyword. Requiring the textarea avoids matching single-line inputs such as `api_key`.
+   *
+   * @param field - The field to check
+   */
+  private isSshPublicKeyField(field: AutofillField): boolean {
+    if (field.tagName !== "textarea") {
+      return false;
+    }
+
+    if (this.sshFieldHasAlgorithmSignal(field)) {
+      return true;
+    }
+
+    const keywords = this.getSshKeyAutofillFieldKeywords(field);
+    return keywords.some((keyword) =>
+      AutofillService.isFieldMatch(keyword, SshKeyAutoFillConstants.PublicKeyFieldNames),
+    );
+  }
+
+  /**
+   * Identifies if a field exposes an SSH algorithm signal, either an algorithm prefix in the
+   * placeholder/value/labels or the `data-supported-algorithms` attribute.
+   *
+   * @param field - The field to check
+   */
+  private sshFieldHasAlgorithmSignal(field: AutofillField): boolean {
+    const haystack = [
+      field.placeholder,
+      field.value,
+      field.dataSetValues,
+      field["label-tag"],
+      field["label-top"],
+      field["label-left"],
+    ]
+      .filter((value): value is string => typeof value === "string")
+      .join(" ")
+      .toLowerCase();
+
+    if (haystack.includes(SshKeyAutoFillConstants.SupportedAlgorithmsAttribute)) {
+      return true;
+    }
+
+    return SshKeyAutoFillConstants.PublicKeyAlgorithmPrefixes.some((prefix) =>
+      haystack.includes(prefix),
+    );
+  }
+
+  /**
+   * Identifies if a field is the SSH key title field. Limited to non-textarea inputs whose
+   * keywords match a title field name. Callers should additionally confirm a public key field
+   * is present before filling.
+   *
+   * @param field - The field to check
+   */
+  private isSshTitleField(field: AutofillField): boolean {
+    if (field.tagName === "textarea" || this.isSshPublicKeyField(field)) {
+      return false;
+    }
+
+    const keywords = this.getSshKeyAutofillFieldKeywords(field);
+    return keywords.some((keyword) =>
+      AutofillService.isFieldMatch(keyword, SshKeyAutoFillConstants.TitleFieldNames),
+    );
   }
 
   /**

--- a/apps/browser/src/autofill/services/autofill.service.ts
+++ b/apps/browser/src/autofill/services/autofill.service.ts
@@ -2029,7 +2029,7 @@ export default class AutofillService implements AutofillServiceInterface {
           value
             .trim()
             .toLowerCase()
-            .replace(/[^a-zA-Z0-9]+/g, ""),
+            .replace(/[^a-z0-9]+/gi, ""),
         );
       }
     }

--- a/apps/browser/src/autofill/services/inline-menu-field-qualification.service.spec.ts
+++ b/apps/browser/src/autofill/services/inline-menu-field-qualification.service.spec.ts
@@ -1149,6 +1149,98 @@ describe("InlineMenuFieldQualificationService", () => {
     });
   });
 
+  describe("isFieldForSshKeyForm", () => {
+    it("qualifies a GitHub-shaped public key textarea via algorithm placeholder", () => {
+      const field = mock<AutofillField>({
+        tagName: "textarea",
+        htmlName: "ssh_key[key]",
+        htmlID: "ssh_key_key",
+        placeholder: "Begins with 'ssh-rsa', 'ssh-ed25519'",
+      });
+      pageDetails.fields = [field];
+
+      expect(inlineMenuFieldQualificationService.isFieldForSshKeyForm(field, pageDetails)).toBe(
+        true,
+      );
+    });
+
+    it("qualifies a GitLab-shaped public key textarea via data-supported-algorithms", () => {
+      const field = mock<AutofillField>({
+        tagName: "textarea",
+        htmlName: "key[key]",
+        htmlID: "key_key",
+        dataSetValues: 'supportedAlgorithms: ["ssh-rsa","ssh-ed25519"]',
+      });
+      pageDetails.fields = [field];
+
+      expect(inlineMenuFieldQualificationService.isFieldForSshKeyForm(field, pageDetails)).toBe(
+        true,
+      );
+    });
+
+    it("qualifies a title input when a public key field is present on the page", () => {
+      const publicKeyField = mock<AutofillField>({
+        tagName: "textarea",
+        htmlName: "ssh_key[key]",
+        placeholder: "Begins with 'ssh-rsa'",
+        form: "validFormId",
+      });
+      const titleField = mock<AutofillField>({
+        tagName: "input",
+        type: "text",
+        htmlName: "ssh_key[title]",
+        form: "validFormId",
+      });
+      pageDetails.fields = [publicKeyField, titleField];
+
+      expect(
+        inlineMenuFieldQualificationService.isFieldForSshKeyForm(titleField, pageDetails),
+      ).toBe(true);
+    });
+
+    it("does not qualify a title input when no public key field is present", () => {
+      const titleField = mock<AutofillField>({
+        tagName: "input",
+        type: "text",
+        htmlName: "ssh_key[title]",
+        form: "validFormId",
+      });
+      pageDetails.fields = [titleField];
+
+      expect(
+        inlineMenuFieldQualificationService.isFieldForSshKeyForm(titleField, pageDetails),
+      ).toBe(false);
+    });
+
+    it("does not qualify a single-line api_key input", () => {
+      const field = mock<AutofillField>({
+        tagName: "input",
+        type: "text",
+        htmlName: "api_key",
+        htmlID: "api_key",
+      });
+      pageDetails.fields = [field];
+
+      expect(inlineMenuFieldQualificationService.isFieldForSshKeyForm(field, pageDetails)).toBe(
+        false,
+      );
+    });
+
+    it("does not qualify a generic comment textarea", () => {
+      const field = mock<AutofillField>({
+        tagName: "textarea",
+        htmlName: "comment",
+        htmlID: "comment",
+        placeholder: "Leave a comment",
+      });
+      pageDetails.fields = [field];
+
+      expect(inlineMenuFieldQualificationService.isFieldForSshKeyForm(field, pageDetails)).toBe(
+        false,
+      );
+    });
+  });
+
   describe("isFieldForAccountCreationForm", () => {
     it("validates a field for an account creation if the field is formless but at least one new password field exists in the page details", () => {
       const field = mock<AutofillField>({

--- a/apps/browser/src/autofill/services/inline-menu-field-qualification.service.ts
+++ b/apps/browser/src/autofill/services/inline-menu-field-qualification.service.ts
@@ -17,6 +17,7 @@ import {
   AutoFillConstants,
   CreditCardAutoFillConstants,
   IdentityAutoFillConstants,
+  SshKeyAutoFillConstants,
   SubmitChangePasswordButtonNames,
   SubmitLoginButtonNames,
 } from "./autofill-constants";
@@ -50,6 +51,9 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
       ...CreditCardAutoFillConstants.CardBrandFieldNames,
     ]),
   ];
+  private sshKeyPublicKeyFieldKeywords = [...SshKeyAutoFillConstants.PublicKeyFieldNames];
+  private sshKeyAlgorithmKeywords = [...SshKeyAutoFillConstants.PublicKeyAlgorithmPrefixes];
+  private sshKeyTitleFieldKeywords = [...SshKeyAutoFillConstants.TitleFieldNames];
   private creditCardNameAutocompleteValues = new Set([
     "cc-name",
     "cc-given-name,",
@@ -312,6 +316,72 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
       // Recognize explicit identity email fields (like id="new-email")
       this.isFieldForIdentityEmail(field) ||
       this.fieldContainsAutocompleteValues(field, this.identityAutocompleteValues)
+    );
+  }
+
+  /**
+   * Validates the provided field as a field for an SSH key form (e.g. GitHub/GitLab "add SSH
+   * key" forms). Qualifies the public key textarea directly, and the title input only when a
+   * public key field is co-present on the same form/page (to avoid matching generic title
+   * inputs on unrelated forms).
+   *
+   * @param field - The field to validate
+   * @param pageDetails - The details of the page that the field is on.
+   */
+  isFieldForSshKeyForm(field: AutofillField, pageDetails: AutofillPageDetails): boolean {
+    if (this.isFieldForSshPublicKey(field)) {
+      return true;
+    }
+
+    if (this.isFieldForSshKeyTitle(field)) {
+      const fieldsToCheck = field.form
+        ? pageDetails.fields.filter((pageField) => pageField.form === field.form)
+        : pageDetails.fields;
+
+      return fieldsToCheck.some((pageField) => this.isFieldForSshPublicKey(pageField));
+    }
+
+    return false;
+  }
+
+  /**
+   * Validates the provided field as an SSH public key field. Requires a textarea (the shape
+   * used by SSH key forms) combined with an algorithm signal (e.g. "ssh-rsa") or a key
+   * keyword. Requiring the textarea avoids matching single-line inputs such as `api_key`.
+   *
+   * @param field - The field to validate
+   */
+  private isFieldForSshPublicKey(field: AutofillField): boolean {
+    if (field.tagName !== "textarea") {
+      return false;
+    }
+
+    if (fieldContainsKeyword(field, this.sshKeyAlgorithmKeywords)) {
+      return true;
+    }
+
+    return fieldContainsKeyword(
+      field,
+      this.sshKeyPublicKeyFieldKeywords,
+      KeywordMatchMode.MatchesToken,
+    );
+  }
+
+  /**
+   * Validates the provided field as an SSH key title field. Limited to non-textarea inputs
+   * whose keywords match a title field name.
+   *
+   * @param field - The field to validate
+   */
+  private isFieldForSshKeyTitle(field: AutofillField): boolean {
+    if (field.tagName === "textarea") {
+      return false;
+    }
+
+    return fieldContainsKeyword(
+      field,
+      this.sshKeyTitleFieldKeywords,
+      KeywordMatchMode.MatchesToken,
     );
   }
 

--- a/apps/browser/src/autofill/types/index.ts
+++ b/apps/browser/src/autofill/types/index.ts
@@ -55,4 +55,7 @@ export type FormFieldElement = FillableFormFieldElement | HTMLSpanElement;
 export type FormElementWithAttribute = FormFieldElement & Record<string, string | null | undefined>;
 
 export type AutofillCipherTypeId =
-  typeof CipherType.Login | typeof CipherType.Card | typeof CipherType.Identity;
+  | typeof CipherType.Login
+  | typeof CipherType.Card
+  | typeof CipherType.Identity
+  | typeof CipherType.SshKey;

--- a/apps/browser/src/vault/popup/components/vault/item-more-options/item-more-options.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/item-more-options/item-more-options.component.ts
@@ -170,9 +170,9 @@ export class ItemMoreOptionsComponent {
    * Determines if the cipher can be autofilled.
    */
   get canAutofill() {
-    return ([CipherType.Login, CipherType.Card, CipherType.Identity] as CipherType[]).includes(
-      CipherViewLikeUtils.getType(this.cipher),
-    );
+    return (
+      [CipherType.Login, CipherType.Card, CipherType.Identity, CipherType.SshKey] as CipherType[]
+    ).includes(CipherViewLikeUtils.getType(this.cipher));
   }
 
   get isLogin() {

--- a/apps/browser/src/vault/popup/components/vault/view/view.component.spec.ts
+++ b/apps/browser/src/vault/popup/components/vault/view/view.component.spec.ts
@@ -847,7 +847,7 @@ describe("ViewComponent", () => {
       expect(result).toBe(false);
     }));
 
-    it("returns false for SshKey type", fakeAsync(() => {
+    it("returns true for SshKey type", fakeAsync(() => {
       autofillAllowed$.next(true);
 
       // Recreate component to pick up the signal values
@@ -866,7 +866,7 @@ describe("ViewComponent", () => {
 
       const result = component.showAutofillButton();
 
-      expect(result).toBe(false);
+      expect(result).toBe(true);
     }));
 
     it("returns false when cipher is archived", fakeAsync(() => {

--- a/apps/browser/src/vault/popup/components/vault/view/view.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/view/view.component.ts
@@ -358,7 +358,7 @@ export class ViewComponent {
     }
 
     const validAutofillType = (
-      [CipherType.Login, CipherType.Card, CipherType.Identity] as CipherType[]
+      [CipherType.Login, CipherType.Card, CipherType.Identity, CipherType.SshKey] as CipherType[]
     ).includes(CipherViewLikeUtils.getType(this.cipher));
 
     return validAutofillType && !(this.cipher.isArchived || this.cipher.isDeleted);

--- a/libs/common/src/autofill/services/autofill-settings.service.ts
+++ b/libs/common/src/autofill/services/autofill-settings.service.ts
@@ -83,6 +83,15 @@ const SHOW_INLINE_MENU_CARDS = new UserKeyDefinition(
   },
 );
 
+const SHOW_INLINE_MENU_SSH_KEYS = new UserKeyDefinition(
+  AUTOFILL_SETTINGS_DISK,
+  "showInlineMenuSshKeys",
+  {
+    deserializer: (value: boolean) => value ?? true,
+    clearOn: [],
+  },
+);
+
 const ENABLE_CONTEXT_MENU = new KeyDefinition(AUTOFILL_SETTINGS_DISK, "enableContextMenu", {
   deserializer: (value: boolean) => value ?? true,
 });
@@ -132,6 +141,8 @@ export abstract class AutofillSettingsServiceAbstraction {
   setShowInlineMenuIdentities: (newValue: boolean) => Promise<void>;
   showInlineMenuCards$: Observable<boolean>;
   setShowInlineMenuCards: (newValue: boolean) => Promise<void>;
+  showInlineMenuSshKeys$: Observable<boolean>;
+  setShowInlineMenuSshKeys: (newValue: boolean) => Promise<void>;
   enableContextMenu$: Observable<boolean>;
   setEnableContextMenu: (newValue: boolean) => Promise<void>;
   clearClipboardDelay$: Observable<ClearClipboardDelaySetting>;
@@ -168,6 +179,9 @@ export class AutofillSettingsService implements AutofillSettingsServiceAbstracti
 
   private showInlineMenuCardsState: ActiveUserState<boolean>;
   readonly showInlineMenuCards$: Observable<boolean>;
+
+  private showInlineMenuSshKeysState: ActiveUserState<boolean>;
+  readonly showInlineMenuSshKeys$: Observable<boolean>;
 
   private enableContextMenuState: GlobalState<boolean>;
   readonly enableContextMenu$: Observable<boolean>;
@@ -243,6 +257,18 @@ export class AutofillSettingsService implements AutofillSettingsServiceAbstracti
       ),
     );
 
+    this.showInlineMenuSshKeysState = this.stateProvider.getActive(SHOW_INLINE_MENU_SSH_KEYS);
+    this.showInlineMenuSshKeys$ = combineLatest([
+      this.showInlineMenuSshKeysState.state$.pipe(map((x) => x ?? true)),
+      this.restrictedItemTypesService.restricted$,
+    ]).pipe(
+      map(
+        ([enabled, restrictions]) =>
+          // If enabled, show SSH keys inline menu unless the SSH key type is restricted
+          enabled && !restrictions.some((r) => r.cipherType === CipherType.SshKey),
+      ),
+    );
+
     this.enableContextMenuState = this.stateProvider.getGlobal(ENABLE_CONTEXT_MENU);
     this.enableContextMenu$ = this.enableContextMenuState.state$.pipe(map((x) => x ?? true));
 
@@ -308,6 +334,10 @@ export class AutofillSettingsService implements AutofillSettingsServiceAbstracti
 
   async setShowInlineMenuCards(newValue: boolean): Promise<void> {
     await this.showInlineMenuCardsState.update(() => newValue);
+  }
+
+  async setShowInlineMenuSshKeys(newValue: boolean): Promise<void> {
+    await this.showInlineMenuSshKeysState.update(() => newValue);
   }
 
   async setEnableContextMenu(newValue: boolean): Promise<void> {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-39609
https://bitwarden.slack.com/archives/C09CE6NSPHC/p1782462926838819

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Adds autofill (inline and regular) for SSH-keys. Recorded and tested are GitHub and GitLab, Hetzner, BorgBase, DigitalOcean.

## 📸 Screenshots

<img width="2016" height="1330" alt="image" src="https://github.com/user-attachments/assets/918c7d8e-c055-4197-82bb-be2949a2956f" />

(Please note, below did not have a fix for the icon missing applied yet, so they are missing the key icon).
https://github.com/user-attachments/assets/251554e6-96a1-4d12-a45a-7764f89a7274


https://github.com/user-attachments/assets/2e002dd1-2bba-4ffb-9b3e-c92dc8539128

<img width="3176" height="1824" alt="borgbase" src="https://github.com/user-attachments/assets/c3f5ae3d-37e8-4f19-89b6-a088a24955dd" />

Note: On hetzner autofill was not available, and the page showed a popup that bitwarden inline autofill disabled itself because the page was interfering.
<img width="3176" height="1884" alt="hetzner" src="https://github.com/user-attachments/assets/8ecead5e-c332-46aa-8b86-2f1f61bb6d87" />

<img width="3158" height="1810" alt="digitialocean" src="https://github.com/user-attachments/assets/c7ada5b6-277d-4304-a623-036c5c1a2f6e" />

