### PR TITLE
[PM-27041] - CLI - respect passphrase param in /generate

### DIFF
--- a/apps/cli/src/tools/generate.command.spec.ts
+++ b/apps/cli/src/tools/generate.command.spec.ts
@@ -1,0 +1,54 @@
+// FIXME: Update this file to be type safe and remove this and next line
+// @ts-strict-ignore
+import { mock } from "jest-mock-extended";
+import { of } from "rxjs";
+
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { TokenService } from "@bitwarden/common/auth/abstractions/token.service";
+import { PasswordGenerationServiceAbstraction } from "@bitwarden/generator-legacy";
+
+import { GenerateCommand } from "./generate.command";
+
+describe("GenerateCommand", () => {
+  let command: GenerateCommand;
+
+  const passwordGenerationService = mock<PasswordGenerationServiceAbstraction>();
+  const tokenService = mock<TokenService>();
+  const accountService = mock<AccountService>();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    accountService.activeAccount$ = of(null);
+    passwordGenerationService.generatePassword.mockResolvedValue("generated-value");
+
+    command = new GenerateCommand(passwordGenerationService, tokenService, accountService);
+  });
+
+  it("uses password type when passphrase is the string false", async () => {
+    const response = await command.run({
+      password: "true",
+      passphrase: "false",
+      length: "40",
+      lowercase: "true",
+      uppercase: "true",
+      number: "true",
+    });
+
+    expect(response.success).toBe(true);
+    expect(passwordGenerationService.generatePassword).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "password" }),
+    );
+  });
+
+  it("uses passphrase type when passphrase is the string true", async () => {
+    const response = await command.run({
+      passphrase: "true",
+    });
+
+    expect(response.success).toBe(true);
+    expect(passwordGenerationService.generatePassword).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "passphrase" }),
+    );
+  });
+});

--- a/apps/cli/src/tools/generate.command.spec.ts
+++ b/apps/cli/src/tools/generate.command.spec.ts
@@ -1,5 +1,3 @@
-// FIXME: Update this file to be type safe and remove this and next line
-// @ts-strict-ignore
 import { mock } from "jest-mock-extended";
 import { of } from "rxjs";
 

--- a/apps/cli/src/tools/generate.command.ts
+++ b/apps/cli/src/tools/generate.command.ts
@@ -90,7 +90,9 @@ class Options {
       passedOptions?.length,
       DefaultPasswordGenerationOptions.length,
     );
-    this.type = passedOptions?.passphrase ? "passphrase" : "password";
+    this.type = CliUtils.convertBooleanOption(passedOptions?.passphrase)
+      ? "passphrase"
+      : "password";
     this.separator = CliUtils.convertStringOption(
       passedOptions?.separator,
       DefaultPassphraseGenerationOptions.wordSeparator,


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-27041

## 📔 Objective

Fix a bug in the CLI serve `/generate` route where query-string boolean values were handled by truthiness instead of boolean parsing.

Previously, when `passphrase` was present as a query parameter, `"false"` was treated as truthy, so the command generated a passphrase even for:

`/generate?password=true&...&passphrase=false`

This PR updates option normalization to parse `passphrase` via `CliUtils.convertBooleanOption(...)` before selecting generation type, so:
- `passphrase=true` => passphrase
- `passphrase=false` => password

Also adds regression tests in `GenerateCommand` to lock this behavior.

## 📸 Screenshots

N/A (no UI changes)