### PR TITLE
[PM-39125] fix: import 1Password archived items with archivedDate set

### DIFF
--- a/libs/importer/src/importers/onepassword/onepassword-1pux-importer.spec.ts
+++ b/libs/importer/src/importers/onepassword/onepassword-1pux-importer.spec.ts
@@ -61,14 +61,15 @@ describe("1Password 1Pux Importer", () => {
   const SecureNoteDataJson = JSON.stringify(SecureNoteData);
   const SanitizedExportJson = JSON.stringify(SanitizedExport);
 
-  it("should not import items with state 'archived'", async () => {
+  it("should import items with state 'archived' and set archivedDate", async () => {
     const importer = new OnePassword1PuxImporter();
-    const archivedLoginData = LoginData;
+    const archivedLoginData = structuredClone(LoginData);
     archivedLoginData["accounts"][0]["vaults"][0]["items"][0]["state"] = "archived";
     const archivedDataJson = JSON.stringify(archivedLoginData);
     const result = await importer.parse(archivedDataJson);
     expect(result != null).toBe(true);
-    expect(result.ciphers.length).toBe(0);
+    expect(result.ciphers.length).toBe(1);
+    expect(result.ciphers[0].archivedDate).toBeDefined();
   });
 
   it("should parse login data", async () => {

--- a/libs/importer/src/importers/onepassword/onepassword-1pux-importer.ts
+++ b/libs/importer/src/importers/onepassword/onepassword-1pux-importer.ts
@@ -41,11 +41,11 @@ export class OnePassword1PuxImporter extends BaseImporter implements Importer {
     // const personalVaults = account.vaults[0].filter((v) => v.attrs.type === VaultAttributeTypeEnum.Personal);
     account.vaults.forEach((vault: VaultsEntity) => {
       vault.items.forEach((item: Item) => {
-        if (item.state === "archived") {
-          return;
-        }
-
         const cipher = this.initLoginCipher();
+
+        if (item.state === "archived") {
+          cipher.archivedDate = new Date();
+        }
 
         const category = item.categoryUuid as Category;
         switch (category) {


### PR DESCRIPTION
## Problem

Items with `"state": "archived"` in a 1Password `.1pux` export are silently skipped during import (#20694). This means archived items are completely lost when migrating from 1Password to Bitwarden.

## Solution

Instead of returning early for archived items, import them normally and set `cipher.archivedDate` to mark them as archived in Bitwarden.

## Changes

- `libs/importer/src/importers/onepassword/onepassword-1pux-importer.ts` - removed early `return` for archived state; set `cipher.archivedDate = new Date()` instead
- `libs/importer/src/importers/onepassword/onepassword-1pux-importer.spec.ts` - updated test to assert archived items ARE imported with `archivedDate` set

## How to Test

1. Create a `.1pux` export from 1Password containing some archived items
2. Import to Bitwarden
3. Archived items should now appear in the archive instead of being missing

Fixes #20694