### PR TITLE
[PM-39131] [Shared Unlock] Safari - Desktop IPC Implementation

### DIFF
--- a/apps/browser/src/platform/ipc/ipc-background.service.ts
+++ b/apps/browser/src/platform/ipc/ipc-background.service.ts
@@ -1,32 +1,28 @@
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { SdkLoadService } from "@bitwarden/common/platform/abstractions/sdk/sdk-load.service";
-import {
-  IpcMessage,
-  isIpcMessage,
-  IpcService,
-  isForwardedIpcMessage,
-} from "@bitwarden/common/platform/ipc";
+import { IpcService } from "@bitwarden/common/platform/ipc";
 import {
   IpcCommunicationBackend,
-  IncomingMessage,
   OutgoingMessage,
   ipcRegisterDiscoverHandler,
   IpcClient,
-  ipcRequestDiscover,
 } from "@bitwarden/sdk-internal";
 
 import { BrowserApi } from "../browser/browser-api";
 
-// The interval at which the browser extension in the background tries to reconnect to the desktop app.
-const RECONNECTION_INTERVAL_MS = 10_000;
-// The timeout for the discover message sent to the desktop app when trying to connect. If the desktop app does not respond to the discover message within this time, the connection attempt is considered failed and will be retried after the reconnection interval.
-const DISCOVER_MESSAGE_TIMEOUT_MS = 5_000;
+import { NativeMessagingTransport, SafariTransport, WebIpcTransport } from "./transports";
+
+/** A transport responsible for communicating with the desktop app. */
+interface DesktopTransport {
+  connectToDesktop(): Promise<void> | void;
+  send(message: OutgoingMessage): Promise<void>;
+}
 
 export class IpcBackgroundService extends IpcService {
   private communicationBackend?: IpcCommunicationBackend;
-  private nativeMessagingPort?: browser.runtime.Port | chrome.runtime.Port;
-  private reconnectTimer?: ReturnType<typeof setTimeout>;
+  private webTransport?: WebIpcTransport;
+  private desktopTransport?: DesktopTransport;
 
   constructor(
     private platformUtilsService: PlatformUtilsService,
@@ -39,56 +35,26 @@ export class IpcBackgroundService extends IpcService {
     try {
       // This function uses classes and functions defined in the SDK, so we need to wait for the SDK to load.
       await SdkLoadService.Ready;
+
+      this.webTransport = new WebIpcTransport(() => this.communicationBackend, this.logService);
+      this.desktopTransport = BrowserApi.isSafariApi
+        ? new SafariTransport(() => this.communicationBackend, this.logService)
+        : new NativeMessagingTransport(
+            () => this.communicationBackend,
+            () => this.client,
+            this.logService,
+          );
+
       this.communicationBackend = new IpcCommunicationBackend({
         send: async (message: OutgoingMessage): Promise<void> => {
           if (typeof message.destination === "object" && "Web" in message.destination) {
-            // Verify the document hasn't changed (e.g., user navigated away) before delivering.
-            // If the browser doesn't support documentId on getFrame, skip the check and send anyway.
-            try {
-              const frame = await chrome.webNavigation.getFrame({
-                tabId: message.destination.Web.tab_id,
-                frameId: 0,
-              });
-              if (
-                frame?.documentId != null &&
-                frame.documentId !== message.destination.Web.document_id
-              ) {
-                this.logService.warning("[IPC] Dropping message to Web tab: document has changed");
-                return;
-              }
-            } catch {
-              // Tab may have been closed, or API not available. Drop the message.
-              this.logService.warning(
-                "[IPC] Dropping message to Web tab: tab no longer accessible",
-              );
-              return;
-            }
-
-            await BrowserApi.tabSendMessage(
-              { id: message.destination.Web.tab_id } as chrome.tabs.Tab,
-              {
-                type: "bitwarden-ipc-message",
-                message: {
-                  destination: message.destination,
-                  payload: [...message.payload],
-                  topic: message.topic,
-                },
-              } satisfies IpcMessage,
-              { frameId: 0 },
-            );
+            await this.webTransport!.send(message);
             return;
           }
 
           if (message.destination === "DesktopMain" || message.destination === "DesktopRenderer") {
             try {
-              this.nativeMessagingPort?.postMessage({
-                type: "bitwarden-ipc-message",
-                message: {
-                  destination: message.destination,
-                  payload: [...message.payload],
-                  topic: message.topic,
-                },
-              } satisfies IpcMessage);
+              await this.desktopTransport!.send(message);
             } catch (e) {
               this.logService.error("[IPC] Failed to send message via native messaging", e);
             }
@@ -99,45 +65,9 @@ export class IpcBackgroundService extends IpcService {
         },
       });
 
-      BrowserApi.messageListener("platform.ipc", (message, sender) => {
-        if (
-          !isIpcMessage(message) ||
-          typeof message.message.destination !== "object" ||
-          !("BrowserBackground" in message.message.destination)
-        ) {
-          return;
-        }
-
-        if (sender.tab?.id === undefined || sender.tab.id === chrome.tabs.TAB_ID_NONE) {
-          // Ignore messages from non-tab sources
-          return;
-        }
-
-        if (sender.documentId === undefined) {
-          this.logService.warning(
-            "[IPC] Received message from tab without documentId (unsupported browser version)",
-          );
-          return;
-        }
-
-        this.communicationBackend?.receive(
-          new IncomingMessage(
-            new Uint8Array(message.message.payload),
-            message.message.destination,
-            {
-              Web: {
-                tab_id: sender.tab.id,
-                document_id: sender.documentId,
-                origin: sender.origin ?? "",
-              },
-            },
-            message.message.topic,
-          ),
-        );
-      });
+      this.webTransport.registerListener();
 
       await super.initWithClient(IpcClient.newWithSdkInMemorySessions(this.communicationBackend));
-
       await ipcRegisterDiscoverHandler(this.client, {
         version: await this.platformUtilsService.getApplicationVersion(),
       });
@@ -148,65 +78,8 @@ export class IpcBackgroundService extends IpcService {
     }
   }
 
-  /**
-   * Starts a connection to the desktop app. This function attempts to establish a connection with the desktop application
-   * using native messaging. It will automaticall retry and reconnect if the connection fails or is lost.
-   */
-  private async connectToDesktop() {
-    let port: browser.runtime.Port | chrome.runtime.Port | undefined;
-    try {
-      port = BrowserApi.connectNative("com.8bit.bitwarden");
-      this.nativeMessagingPort = port;
-
-      port.onMessage.addListener((ipcMessage) => {
-        if (!isIpcMessage(ipcMessage) && !isForwardedIpcMessage(ipcMessage)) {
-          return;
-        }
-
-        this.communicationBackend?.receive(
-          new IncomingMessage(
-            new Uint8Array(ipcMessage.message.payload),
-            ipcMessage.message.destination,
-            isForwardedIpcMessage(ipcMessage) ? ipcMessage.originalSource : "DesktopMain",
-            ipcMessage.message.topic,
-          ),
-        );
-      });
-
-      // Register the disconnect handler before awaiting the discover handshake so that a
-      // disconnect during the handshake window (e.g. the desktop app closing) is still handled.
-      port.onDisconnect.addListener(() => {
-        this.logService.warning("[IPC] Disconnected from Bitwarden Desktop App");
-        this.nativeMessagingPort = undefined;
-        this.scheduleReconnect();
-      });
-
-      // Ensure the desktop app is properly connected
-      const version = await ipcRequestDiscover(
-        this.client,
-        "DesktopRenderer",
-        AbortSignal.timeout(DISCOVER_MESSAGE_TIMEOUT_MS),
-      );
-      this.logService.info(
-        `[IPC] Connected to Bitwarden Desktop App with version ${version.version}`,
-      );
-    } catch (e) {
-      this.logService.error("[IPC] Failed to connect to Bitwarden Desktop App", e);
-      // Explicitly disconnect the port to avoid leaking the native port and its spawned
-      // desktop_proxy process when the handshake fails (e.g. the desktop app is unreachable).
-      port?.disconnect();
-      this.nativeMessagingPort = undefined;
-      this.scheduleReconnect();
-    }
-  }
-
-  private scheduleReconnect() {
-    if (this.reconnectTimer != null) {
-      return;
-    }
-    this.reconnectTimer = setTimeout(() => {
-      this.reconnectTimer = undefined;
-      void this.connectToDesktop();
-    }, RECONNECTION_INTERVAL_MS);
+  /** Establishes the connection to the desktop app using the platform-appropriate transport. */
+  private async connectToDesktop(): Promise<void> {
+    await this.desktopTransport?.connectToDesktop();
   }
 }

--- a/apps/browser/src/platform/ipc/transports/index.ts
+++ b/apps/browser/src/platform/ipc/transports/index.ts
@@ -1,0 +1,3 @@
+export { WebIpcTransport } from "./web";
+export { SafariTransport } from "./safari";
+export { NativeMessagingTransport } from "./native-messaging";

--- a/apps/browser/src/platform/ipc/transports/native-messaging.ts
+++ b/apps/browser/src/platform/ipc/transports/native-messaging.ts
@@ -1,0 +1,107 @@
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+import { IpcMessage, isIpcMessage, isForwardedIpcMessage } from "@bitwarden/common/platform/ipc";
+import {
+  IpcCommunicationBackend,
+  IncomingMessage,
+  OutgoingMessage,
+  IpcClient,
+  ipcRequestDiscover,
+} from "@bitwarden/sdk-internal";
+
+import { BrowserApi } from "../../browser/browser-api";
+
+// The interval at which the browser extension in the background tries to reconnect to the desktop app.
+const RECONNECTION_INTERVAL_MS = 10_000;
+// The timeout for the discover message sent to the desktop app when trying to connect. If the desktop app does not respond to the discover message within this time, the connection attempt is considered failed and will be retried after the reconnection interval.
+const DISCOVER_MESSAGE_TIMEOUT_MS = 5_000;
+
+/**
+ * Transport for communicating with the desktop app over a persistent native messaging connection.
+ *
+ * Establishes a native messaging port to the desktop app, performs the discover handshake, and
+ * automatically reconnects if the connection fails or is lost.
+ */
+export class NativeMessagingTransport {
+  private port?: browser.runtime.Port | chrome.runtime.Port;
+  private reconnectTimer?: ReturnType<typeof setTimeout>;
+
+  constructor(
+    private getCommunicationBackend: () => IpcCommunicationBackend | undefined,
+    private getClient: () => IpcClient,
+    private logService: LogService,
+  ) {}
+
+  /** Sends a message to the desktop app over the native messaging port. */
+  async send(message: OutgoingMessage): Promise<void> {
+    this.port?.postMessage({
+      type: "bitwarden-ipc-message",
+      message: {
+        destination: message.destination,
+        payload: [...message.payload],
+        topic: message.topic,
+      },
+    } satisfies IpcMessage);
+  }
+
+  /**
+   * Starts a connection to the desktop app. This function attempts to establish a connection with the desktop application
+   * using native messaging. It will automaticall retry and reconnect if the connection fails or is lost.
+   */
+  async connectToDesktop(): Promise<void> {
+    let port: browser.runtime.Port | chrome.runtime.Port | undefined;
+    try {
+      port = BrowserApi.connectNative("com.8bit.bitwarden");
+      this.port = port;
+
+      port.onMessage.addListener((ipcMessage) => {
+        if (!isIpcMessage(ipcMessage) && !isForwardedIpcMessage(ipcMessage)) {
+          return;
+        }
+
+        this.getCommunicationBackend()?.receive(
+          new IncomingMessage(
+            new Uint8Array(ipcMessage.message.payload),
+            ipcMessage.message.destination,
+            isForwardedIpcMessage(ipcMessage) ? ipcMessage.originalSource : "DesktopMain",
+            ipcMessage.message.topic,
+          ),
+        );
+      });
+
+      // Register the disconnect handler before awaiting the discover handshake so that a
+      // disconnect during the handshake window (e.g. the desktop app closing) is still handled.
+      port.onDisconnect.addListener(() => {
+        this.logService.warning("[IPC] Disconnected from Bitwarden Desktop App");
+        this.port = undefined;
+        this.scheduleReconnect();
+      });
+
+      // Ensure the desktop app is properly connected
+      const version = await ipcRequestDiscover(
+        this.getClient(),
+        "DesktopRenderer",
+        AbortSignal.timeout(DISCOVER_MESSAGE_TIMEOUT_MS),
+      );
+      this.logService.info(
+        `[IPC] Connected to Bitwarden Desktop App with version ${version.version}`,
+      );
+    } catch (e) {
+      this.logService.error("[IPC] Failed to connect to Bitwarden Desktop App", e);
+      // Explicitly disconnect the port to avoid leaking the native port and its spawned
+      // desktop_proxy process when the handshake fails (e.g. the desktop app is unreachable).
+      port?.disconnect();
+      this.port = undefined;
+      this.scheduleReconnect();
+    }
+  }
+
+  private scheduleReconnect(): void {
+    if (this.reconnectTimer != null) {
+      return;
+    }
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = undefined;
+      void this.connectToDesktop();
+    }, RECONNECTION_INTERVAL_MS);
+  }
+}

--- a/apps/browser/src/platform/ipc/transports/native-messaging.ts
+++ b/apps/browser/src/platform/ipc/transports/native-messaging.ts
@@ -45,7 +45,7 @@ export class NativeMessagingTransport {
 
   /**
    * Starts a connection to the desktop app. This function attempts to establish a connection with the desktop application
-   * using native messaging. It will automaticall retry and reconnect if the connection fails or is lost.
+   * using native messaging. It will automatically retry and reconnect if the connection fails or is lost.
    */
   async connectToDesktop(): Promise<void> {
     let port: browser.runtime.Port | chrome.runtime.Port | undefined;

--- a/apps/browser/src/platform/ipc/transports/safari.ts
+++ b/apps/browser/src/platform/ipc/transports/safari.ts
@@ -1,0 +1,115 @@
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+import { IpcCommunicationBackend, IncomingMessage, OutgoingMessage } from "@bitwarden/sdk-internal";
+
+import { SafariApp } from "../../../browser/safariApp";
+
+/** Poll interval while the channel is active (a recent send, or messages just arrived). */
+const SAFARI_FAST_POLL_MS = 200;
+/** Idle heartbeat so desktop-initiated pushes (e.g. shared unlock) arrive promptly. */
+const SAFARI_IDLE_POLL_MS = 1000;
+/** How long after activity to keep polling fast. */
+const SAFARI_ACTIVE_WINDOW_MS = 5000;
+
+/** Envelope serialized over the buffered Safari socket. Payloads are opaque (SDK-encrypted). */
+interface SafariIpcEnvelope {
+  destination: unknown;
+  source?: unknown;
+  payload: number[];
+  topic?: string;
+}
+
+/**
+ * Transport for communicating with the desktop app on Safari.
+ *
+ * Safari cannot maintain a persistent native messaging connection to the desktop, so messages are
+ * sent through the Safari Swift module and desktop -> extension messages are received by polling a
+ * buffered socket.
+ */
+export class SafariTransport {
+  private pollTimeout?: ReturnType<typeof setTimeout>;
+  private lastActivity = 0;
+
+  constructor(
+    private getCommunicationBackend: () => IpcCommunicationBackend | undefined,
+    private logService: LogService,
+  ) {}
+
+  /** Starts polling the buffered socket for desktop -> extension messages. */
+  connectToDesktop(): void {
+    this.startPolling();
+  }
+
+  /** Sends a message to the desktop app via the Safari Swift module. */
+  async send(message: OutgoingMessage): Promise<void> {
+    this.lastActivity = Date.now();
+    const envelope: SafariIpcEnvelope = {
+      destination: message.destination,
+      payload: [...message.payload],
+      topic: message.topic,
+    };
+    await SafariApp.sendMessageToApp("sendMessage", JSON.stringify(envelope));
+  }
+
+  /**
+   * Repeatedly drain the buffered socket. Polls fast while the channel is active and falls back to
+   * an idle heartbeat otherwise. Each poll spawns Safari's native handler, so the idle cadence is a
+   * deliberate trade-off between latency and overhead / power-consumption.
+   */
+  private startPolling(): void {
+    if (this.pollTimeout != null) {
+      return;
+    }
+
+    const poll = async () => {
+      let received = false;
+      try {
+        received = await this.drainDesktopMessages();
+      } catch (e) {
+        this.logService.warning("[IPC] Safari desktop poll failed", e);
+      }
+
+      const active = received || Date.now() - this.lastActivity < SAFARI_ACTIVE_WINDOW_MS;
+      this.pollTimeout = setTimeout(
+        () => void poll(),
+        active ? SAFARI_FAST_POLL_MS : SAFARI_IDLE_POLL_MS,
+      );
+    };
+
+    void poll();
+  }
+
+  /** Drain and pipe to the SDK ipc framework the desktop -> extension messages. Returns whether any were received. */
+  private async drainDesktopMessages(): Promise<boolean> {
+    const response = await SafariApp.sendMessageToApp("receiveMessage");
+    const messages: string[] = response?.messages ?? [];
+    if (messages.length > 0) {
+      this.lastActivity = Date.now();
+      this.logService.info(`[IPC] Safari drained ${messages.length} message(s):`, messages);
+    }
+
+    for (const raw of messages) {
+      let envelope: SafariIpcEnvelope;
+      try {
+        envelope = JSON.parse(raw) as SafariIpcEnvelope;
+      } catch (e) {
+        this.logService.warning("[IPC] Dropping malformed desktop message", e);
+        continue;
+      }
+
+      try {
+        this.getCommunicationBackend()?.receive(
+          new IncomingMessage(
+            new Uint8Array(envelope.payload),
+            envelope.destination as IncomingMessage["destination"],
+            "DesktopMain",
+            envelope.topic,
+          ),
+        );
+      } catch (e) {
+        this.logService.warning("[IPC] Failed to dispatch desktop message", e);
+      }
+    }
+
+    return messages.length > 0;
+  }
+}

--- a/apps/browser/src/platform/ipc/transports/web.ts
+++ b/apps/browser/src/platform/ipc/transports/web.ts
@@ -1,0 +1,95 @@
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+import { IpcMessage, isIpcMessage } from "@bitwarden/common/platform/ipc";
+import { IpcCommunicationBackend, IncomingMessage, OutgoingMessage } from "@bitwarden/sdk-internal";
+
+import { BrowserApi } from "../../browser/browser-api";
+
+/**
+ * Transport for communicating with web pages (content scripts) running in browser tabs.
+ *
+ * Sends extension -> tab messages via {@link BrowserApi.tabSendMessage} and receives tab ->
+ * extension messages through a runtime message listener.
+ */
+export class WebIpcTransport {
+  constructor(
+    private getCommunicationBackend: () => IpcCommunicationBackend | undefined,
+    private logService: LogService,
+  ) {}
+
+  /** Registers the runtime listener that pipes tab -> extension messages into the SDK. */
+  registerListener(): void {
+    BrowserApi.messageListener("platform.ipc", (message, sender) => {
+      if (
+        !isIpcMessage(message) ||
+        typeof message.message.destination !== "object" ||
+        !("BrowserBackground" in message.message.destination)
+      ) {
+        return;
+      }
+
+      if (sender.tab?.id === undefined || sender.tab.id === chrome.tabs.TAB_ID_NONE) {
+        // Ignore messages from non-tab sources
+        return;
+      }
+
+      if (sender.documentId === undefined) {
+        this.logService.warning(
+          "[IPC] Received message from tab without documentId (unsupported browser version)",
+        );
+        return;
+      }
+
+      this.getCommunicationBackend()?.receive(
+        new IncomingMessage(
+          new Uint8Array(message.message.payload),
+          message.message.destination,
+          {
+            Web: {
+              tab_id: sender.tab.id,
+              document_id: sender.documentId,
+              origin: sender.origin ?? "",
+            },
+          },
+          message.message.topic,
+        ),
+      );
+    });
+  }
+
+  /** Sends an extension -> tab message, dropping it if the target document has changed. */
+  async send(message: OutgoingMessage): Promise<void> {
+    if (typeof message.destination !== "object" || !("Web" in message.destination)) {
+      throw new Error("Destination not supported.");
+    }
+
+    // Verify the document hasn't changed (e.g., user navigated away) before delivering.
+    // If the browser doesn't support documentId on getFrame, skip the check and send anyway.
+    try {
+      const frame = await chrome.webNavigation.getFrame({
+        tabId: message.destination.Web.tab_id,
+        frameId: 0,
+      });
+      if (frame?.documentId != null && frame.documentId !== message.destination.Web.document_id) {
+        this.logService.warning("[IPC] Dropping message to Web tab: document has changed");
+        return;
+      }
+    } catch {
+      // Tab may have been closed, or API not available. Drop the message.
+      this.logService.warning("[IPC] Dropping message to Web tab: tab no longer accessible");
+      return;
+    }
+
+    await BrowserApi.tabSendMessage(
+      { id: message.destination.Web.tab_id } as chrome.tabs.Tab,
+      {
+        type: "bitwarden-ipc-message",
+        message: {
+          destination: message.destination,
+          payload: [...message.payload],
+          topic: message.topic,
+        },
+      } satisfies IpcMessage,
+      { frameId: 0 },
+    );
+  }
+}

--- a/apps/browser/src/safari/safari/SafariWebExtensionHandler.swift
+++ b/apps/browser/src/safari/safari/SafariWebExtensionHandler.swift
@@ -513,44 +513,52 @@ enum BufferedSocketClient {
         os_log(.default, "[BufferedSocketClient] Connected successfully")
 
         // Write the 4-byte little-endian length prefix followed by the payload.
-        var lengthLE = UInt32(payload.count).littleEndian
-        let header = Data(bytes: &lengthLE, count: 4)
+        let length = UInt32(payload.count)
+        let header = Data([
+            UInt8(length & 0xff),
+            UInt8((length >> 8) & 0xff),
+            UInt8((length >> 16) & 0xff),
+            UInt8((length >> 24) & 0xff),
+        ])
         if !writeAll(fd, header) || !writeAll(fd, payload) { return nil }
 
         // Read the response length prefix, then exactly that many bytes.
         guard let lengthData = readExactly(fd, 4) else { return nil }
-        let responseLength = lengthData.withUnsafeBytes { UInt32(littleEndian: $0.load(as: UInt32.self)) }
+        let lengthBytes = [UInt8](lengthData)
+        let responseLength = UInt32(lengthBytes[0])
+            | (UInt32(lengthBytes[1]) << 8)
+            | (UInt32(lengthBytes[2]) << 16)
+            | (UInt32(lengthBytes[3]) << 24)
         if responseLength > UInt32(maxFrameLength) { return nil }
         return readExactly(fd, Int(responseLength))
     }
 
     private static func writeAll(_ fd: Int32, _ data: Data) -> Bool {
-        data.withUnsafeBytes { (raw: UnsafeRawBufferPointer) -> Bool in
-            guard let base = raw.baseAddress else { return data.isEmpty }
-            var total = 0
-            while total < data.count {
-                let n = write(fd, base + total, data.count - total)
-                if n <= 0 { return false }
-                total += n
-            }
+        // closeOnDealloc: false — the caller owns `fd` and closes it via `defer`.
+        let handle = FileHandle(fileDescriptor: fd, closeOnDealloc: false)
+        do {
+            // write(contentsOf:) handles partial writes internally.
+            try handle.write(contentsOf: data)
             return true
+        } catch {
+            return false
         }
     }
 
     private static func readExactly(_ fd: Int32, _ count: Int) -> Data? {
         if count == 0 { return Data() }
-        var buffer = Data(count: count)
-        let ok = buffer.withUnsafeMutableBytes { (raw: UnsafeMutableRawBufferPointer) -> Bool in
-            guard let base = raw.baseAddress else { return false }
-            var total = 0
-            while total < count {
-                let n = read(fd, base + total, count - total)
-                if n <= 0 { return false }
-                total += n
+        // closeOnDealloc: false — the caller owns `fd` and closes it via `defer`.
+        let handle = FileHandle(fileDescriptor: fd, closeOnDealloc: false)
+        var buffer = Data()
+        while buffer.count < count {
+            // read(upToCount:) may return fewer bytes than requested; loop until we have `count`.
+            guard let chunk = try? handle.read(upToCount: count - buffer.count),
+                  !chunk.isEmpty else {
+                return nil
             }
-            return true
+            buffer.append(chunk)
         }
-        return ok ? buffer : nil
+        return buffer
     }
 }
 

--- a/apps/browser/src/safari/safari/SafariWebExtensionHandler.swift
+++ b/apps/browser/src/safari/safari/SafariWebExtensionHandler.swift
@@ -86,6 +86,7 @@ class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
                 context.completeRequest(returningItems: [response], completionHandler: nil)
             }
             return
+        // Deprecated
         case "authenticateWithBiometrics":
             let messageId = message?["messageId"] as? Int
             let laContext = LAContext()
@@ -126,6 +127,7 @@ class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
                 context.completeRequest(returningItems: [response], completionHandler: nil)
             }
             return
+        // Deprecated
         case "getBiometricsStatus":
             let messageId = message?["messageId"] as? Int
             response.userInfo = [
@@ -141,6 +143,7 @@ class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
 
             context.completeRequest(returningItems: [response], completionHandler: nil);
             break
+        // Deprecated
         case "unlockWithBiometricsForUser":
             let messageId = message?["messageId"] as? Int
             var error: NSError?
@@ -233,6 +236,7 @@ class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
                 context.completeRequest(returningItems: [response], completionHandler: nil)
             }
             return
+        // Deprecated
         case "getBiometricsStatusForUser":
             let messageId = message?["messageId"] as? Int
             let laContext = LAContext()
@@ -289,6 +293,7 @@ class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
                 ]
             }
             break
+        // Deprecated
         case "biometricUnlock":
             var error: NSError?
             let laContext = LAContext()
@@ -361,6 +366,7 @@ class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
                 context.completeRequest(returningItems: [response], completionHandler: nil)
             }
             return
+        // Deprecated
         case "biometricUnlockAvailable":
             let laContext = LAContext()
             var isAvailable = laContext.isBiometricsAvailable();
@@ -375,6 +381,39 @@ class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
                 ],
             ]
             break
+        // IPC to safari works via two primitives, send message, receive messages.
+        // The desktop app buffers messages to receive, and accepts messages the safari extension sends it.
+        case "sendMessage":
+            // Transport verb: forward an extension -> desktop payload to the buffered desktop
+            // socket.
+            let payloadString = message?["data"] as? String ?? ""
+            DispatchQueue.global(qos: .userInitiated).async {
+                var ok = false
+                let request: [String: Any] = ["op": "send", "payload": payloadString]
+                if let requestData = try? JSONSerialization.data(withJSONObject: request),
+                   let responseData = BufferedSocketClient.sendRequest(requestData),
+                   let parsed = try? JSONSerialization.jsonObject(with: responseData) as? [String: Any] {
+                    ok = parsed["ok"] as? Bool ?? false
+                }
+                response.userInfo = [ SFExtensionMessageKey: [ "ok": ok ] ]
+                context.completeRequest(returningItems: [response], completionHandler: nil)
+            }
+            return
+        case "receiveMessage":
+            // Transport verb: drain buffered desktop -> extension messages by polling.
+            DispatchQueue.global(qos: .userInitiated).async {
+                var messages: [String] = []
+                let request: [String: Any] = ["op": "receive"]
+                if let requestData = try? JSONSerialization.data(withJSONObject: request),
+                   let responseData = BufferedSocketClient.sendRequest(requestData),
+                   let parsed = try? JSONSerialization.jsonObject(with: responseData) as? [String: Any],
+                   let msgs = parsed["messages"] as? [String] {
+                    messages = msgs
+                }
+                response.userInfo = [ SFExtensionMessageKey: [ "messages": messages ] ]
+                context.completeRequest(returningItems: [response], completionHandler: nil)
+            }
+            return
         default:
             return
         }
@@ -404,6 +443,114 @@ func jsonDeserialize<T: Decodable>(json: String?) -> T? {
         return obj
     } catch _ {
         return nil
+    }
+}
+
+/// Client for the desktop app's buffered Safari IPC socket.
+///
+/// The socket lives in the shared App Group container so this sandboxed extension can reach it.
+/// Frames are length-delimited with a 4-byte little-endian length prefix, matching the desktop's
+/// `LengthDelimitedCodec`.
+enum BufferedSocketClient {
+    /// Shared App Group identifier; must match the desktop app, the desktop proxy, and the Rust
+    /// `app_group_path` helper.
+    static let appGroupId = "LTZ2PFU5D6.com.bitwarden.desktop"
+    /// Socket endpoint name; must match the desktop's `NativeBufferedIpcServer.listen` name.
+    static let socketName = "s.bw-safari"
+    /// Maximum frame size, matching the desktop's `NATIVE_MESSAGING_BUFFER_SIZE`.
+    static let maxFrameLength = 1024 * 1024
+
+    /// Resolve the socket path inside the shared App Group container.
+    static func socketPath() -> String? {
+        guard let container = FileManager.default
+            .containerURL(forSecurityApplicationGroupIdentifier: appGroupId) else {
+            os_log(.error, "[BufferedSocketClient] App Group container URL is nil for group %{public}@ — is the app group entitlement provisioned for the extension?", appGroupId)
+            return nil
+        }
+        return container.appendingPathComponent(socketName).path
+    }
+
+    /// Send one length-delimited request and return the response payload. Blocking; call off the
+    /// main thread. Returns `nil` on any connection or protocol error.
+    static func sendRequest(_ payload: Data) -> Data? {
+        guard let path = socketPath() else { return nil }
+        guard payload.count <= maxFrameLength else {
+            return nil
+        }
+
+        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        if fd < 0 {
+            return nil
+        }
+        defer { close(fd) }
+
+        var addr = sockaddr_un()
+        addr.sun_family = sa_family_t(AF_UNIX)
+        let pathBytes = path.utf8CString
+        // sun_path is a fixed-size buffer (104 bytes on Darwin); the path must fit including its
+        // null terminator.
+        if pathBytes.count > MemoryLayout.size(ofValue: addr.sun_path) {
+            os_log(.error, "[BufferedSocketClient] Socket path too long (%d bytes, max %d)", pathBytes.count, MemoryLayout.size(ofValue: addr.sun_path))
+            return nil
+        }
+        withUnsafeMutablePointer(to: &addr.sun_path) { rawPtr in
+            rawPtr.withMemoryRebound(to: CChar.self, capacity: pathBytes.count) { dst in
+                pathBytes.withUnsafeBufferPointer { src in
+                    dst.update(from: src.baseAddress!, count: pathBytes.count)
+                }
+            }
+        }
+
+        let connected = withUnsafePointer(to: &addr) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                connect(fd, $0, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        if connected < 0 {
+            os_log(.error, "[BufferedSocketClient] connect() failed: errno %d (%{public}@) — is the desktop app running and listening at this path?", errno, String(cString: strerror(errno)))
+            return nil
+        }
+        os_log(.default, "[BufferedSocketClient] Connected successfully")
+
+        // Write the 4-byte little-endian length prefix followed by the payload.
+        var lengthLE = UInt32(payload.count).littleEndian
+        let header = Data(bytes: &lengthLE, count: 4)
+        if !writeAll(fd, header) || !writeAll(fd, payload) { return nil }
+
+        // Read the response length prefix, then exactly that many bytes.
+        guard let lengthData = readExactly(fd, 4) else { return nil }
+        let responseLength = lengthData.withUnsafeBytes { UInt32(littleEndian: $0.load(as: UInt32.self)) }
+        if responseLength > UInt32(maxFrameLength) { return nil }
+        return readExactly(fd, Int(responseLength))
+    }
+
+    private static func writeAll(_ fd: Int32, _ data: Data) -> Bool {
+        data.withUnsafeBytes { (raw: UnsafeRawBufferPointer) -> Bool in
+            guard let base = raw.baseAddress else { return data.isEmpty }
+            var total = 0
+            while total < data.count {
+                let n = write(fd, base + total, data.count - total)
+                if n <= 0 { return false }
+                total += n
+            }
+            return true
+        }
+    }
+
+    private static func readExactly(_ fd: Int32, _ count: Int) -> Data? {
+        if count == 0 { return Data() }
+        var buffer = Data(count: count)
+        let ok = buffer.withUnsafeMutableBytes { (raw: UnsafeMutableRawBufferPointer) -> Bool in
+            guard let base = raw.baseAddress else { return false }
+            var total = 0
+            while total < count {
+                let n = read(fd, base + total, count - total)
+                if n <= 0 { return false }
+                total += n
+            }
+            return true
+        }
+        return ok ? buffer : nil
     }
 }
 

--- a/apps/browser/src/safari/safari/safari.entitlements
+++ b/apps/browser/src/safari/safari/safari.entitlements
@@ -4,6 +4,10 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>LTZ2PFU5D6.com.bitwarden.desktop</string>
+	</array>
 	<key>com.apple.security.files.user-selected.read-write</key>
 	<true/>
 	<key>com.apple.security.network.client</key>

--- a/apps/desktop/desktop_native/core/Cargo.toml
+++ b/apps/desktop/desktop_native/core/Cargo.toml
@@ -32,6 +32,7 @@ interprocess = { workspace = true, features = ["tokio"] }
 memsec = { workspace = true, features = ["alloc_ext"] }
 rand = { workspace = true }
 rsa = "=0.9.6"
+serde = { workspace = true, features = ["derive"] }
 sha2 = "=0.10.9"
 ssh-key = { version = "=0.6.7", features = [
     "encryption",
@@ -63,12 +64,12 @@ homedir = { workspace = true }
 secmem-proc = { workspace = true }
 security-framework = { workspace = true, optional = true }
 security-framework-sys = { workspace = true, optional = true }
+serde_json = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
 pin-project = { workspace = true }
 scopeguard = { workspace = true }
 secmem-proc = { workspace = true }
-serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 widestring = { workspace = true, optional = true }
 windows = { workspace = true, features = [

--- a/apps/desktop/desktop_native/core/src/ipc/mod.rs
+++ b/apps/desktop/desktop_native/core/src/ipc/mod.rs
@@ -6,6 +6,8 @@ use tokio::io::{AsyncRead, AsyncWrite};
 use tokio_util::codec::{Framed, LengthDelimitedCodec};
 
 pub mod client;
+#[cfg(target_os = "macos")]
+pub mod safari_ipc_server;
 pub mod server;
 
 /// The maximum size of a message that can be sent over IPC.

--- a/apps/desktop/desktop_native/core/src/ipc/safari_ipc_server.rs
+++ b/apps/desktop/desktop_native/core/src/ipc/safari_ipc_server.rs
@@ -1,0 +1,381 @@
+//! Buffered IPC server for the Safari web extension.
+//!
+//! Safari's native component (`SafariWebExtensionHandler`) is a stateless, per-request handler with
+//! no long-lived process, so the desktop app cannot push messages to it. Instead, this server
+//! buffers messages destined for the extension and lets the extension drain them by polling.
+//!
+//! Connections are short-lived. Each frame is a JSON [`Request`]:
+//! - `{"op":"send","payload":"..."}` forwards an extension -> desktop payload to the consumer
+//!   channel and replies `{"ok":true}`.
+//! - `{"op":"receive"}` drains the outbound (desktop -> extension) queue and replies
+//!   `{"messages":[...]}`.
+
+use std::{
+    collections::VecDeque,
+    error::Error,
+    path::PathBuf,
+    sync::{Arc, Mutex},
+    time::{Duration, Instant},
+};
+
+use anyhow::Result;
+use futures::{SinkExt, StreamExt, TryFutureExt};
+use interprocess::local_socket::{tokio::prelude::*, GenericFilePath, ListenerOptions};
+use serde::{Deserialize, Serialize};
+use tokio::{
+    io::{AsyncRead, AsyncWrite},
+    sync::mpsc,
+};
+use tokio_util::sync::CancellationToken;
+use tracing::{error, info};
+
+/// The application group identifier shared between the desktop app, the `desktop_proxy`, and the
+/// Safari web extension. Used to locate sockets in a shared container that a sandboxed Safari
+/// extension can reach.
+pub const APP_GROUP_ID: &str = "LTZ2PFU5D6.com.bitwarden.desktop";
+
+/// Endpoint name for the buffered Safari IPC socket. Must match the Safari extension's
+/// `BufferedSocketClient.socketName` (`s.bw-safari`).
+const SOCKET_NAME: &str = "bw-safari";
+
+/// Path to an IPC socket inside the shared App Group container.
+///
+/// Unlike [`crate::ipc::path`], this always resolves to the App Group container on macOS regardless
+/// of whether the current process is sandboxed. This is required for the Safari buffered socket: a
+/// sandboxed Safari web extension can only reach the shared Group Container, while the (potentially
+/// unsandboxed, non-MAS) desktop app must agree on the same location.
+fn app_group_path(name: &str) -> PathBuf {
+    let mut home = dirs::home_dir().expect("Could not find user home directory");
+
+    // If the process is sandboxed, the home dir points inside Library/Containers/...; strip
+    // back to the user's home so we can reach the shared Group Containers directory.
+    if let Some(position) = home
+        .components()
+        .position(|c| c.as_os_str() == "Containers")
+    {
+        while home.components().count() > position - 1 {
+            home.pop();
+        }
+    }
+
+    let dir = home.join(format!("Library/Group Containers/{APP_GROUP_ID}"));
+
+    // The directory might not exist, so create it
+    let _ = std::fs::create_dir_all(&dir);
+    dir.join(format!("s.{name}"))
+}
+
+/// The maximum number of outbound (desktop → extension) messages buffered while the extension is
+/// not polling (e.g. its service worker has been terminated). Past this, the oldest messages are
+/// dropped. The SDK IPC layer provides its own retry/timeout semantics, so occasional loss of a
+/// stale message is tolerable.
+const OUTBOUND_QUEUE_CAPACITY: usize = 128;
+
+/// How long an outbound message stays in the buffer before it is considered stale and evicted.
+const OUTBOUND_TTL: Duration = Duration::from_secs(60);
+
+/// A request issued by the Safari extension over a buffered-server connection.
+#[derive(Debug, Deserialize)]
+#[serde(tag = "op", rename_all = "lowercase")]
+enum Request {
+    /// Forward an extension → desktop payload to the desktop.
+    Send { payload: String },
+    /// Drain and return all currently buffered desktop → extension messages.
+    Receive,
+}
+
+/// Reply to a [`Request::Send`].
+#[derive(Debug, Serialize)]
+struct SendResponse {
+    ok: bool,
+}
+
+/// Reply to a [`Request::Receive`].
+#[derive(Debug, Serialize)]
+struct ReceiveResponse {
+    messages: Vec<String>,
+}
+
+/// A bounded, TTL-evicting FIFO queue of outbound payloads.
+struct OutboundQueue {
+    messages: VecDeque<(Instant, String)>,
+    capacity: usize,
+    ttl: Duration,
+}
+
+impl OutboundQueue {
+    fn new(capacity: usize, ttl: Duration) -> Self {
+        Self {
+            messages: VecDeque::new(),
+            capacity,
+            ttl,
+        }
+    }
+
+    /// Evict messages older than the TTL. Messages are stored in FIFO order, so the oldest are at
+    /// the front.
+    fn evict_expired(&mut self, now: Instant) {
+        while let Some((enqueued_at, _)) = self.messages.front() {
+            if now.duration_since(*enqueued_at) >= self.ttl {
+                self.messages.pop_front();
+            } else {
+                break;
+            }
+        }
+    }
+
+    fn push(&mut self, payload: String, now: Instant) {
+        self.evict_expired(now);
+        // Bounded queue: drop the oldest message to make room.
+        if self.messages.len() >= self.capacity {
+            self.messages.pop_front();
+        }
+        self.messages.push_back((now, payload));
+    }
+
+    fn drain(&mut self, now: Instant) -> Vec<String> {
+        self.evict_expired(now);
+        self.messages
+            .drain(..)
+            .map(|(_, payload)| payload)
+            .collect()
+    }
+}
+
+type Outbound = Arc<Mutex<OutboundQueue>>;
+
+/// Buffered IPC server that the Safari web extension polls.
+pub struct SafariIpcServer {
+    /// The path that the server is listening on.
+    pub path: PathBuf,
+    cancel_token: CancellationToken,
+    outbound: Outbound,
+}
+
+impl SafariIpcServer {
+    /// Create and start the buffered IPC server without blocking.
+    ///
+    /// The socket is always created inside the shared App Group container so that the sandboxed
+    /// Safari web extension can reach it.
+    pub fn start(inbound_send: mpsc::Sender<String>) -> Result<Self, Box<dyn Error>> {
+        let path = app_group_path(SOCKET_NAME);
+        let cancel_token = CancellationToken::new();
+        let outbound: Outbound = Arc::new(Mutex::new(OutboundQueue::new(
+            OUTBOUND_QUEUE_CAPACITY,
+            OUTBOUND_TTL,
+        )));
+
+        // If the unix socket file already exists, we get an error when trying to bind to it, so
+        // we remove it first.
+        if path.exists() {
+            info!(
+                "Removing existing buffered IPC socket at: {}",
+                path.display()
+            );
+            std::fs::remove_file(path.clone())?;
+        }
+
+        let name = path.as_os_str().to_fs_name::<GenericFilePath>()?;
+        let opts = ListenerOptions::new().name(name);
+        let Ok(listener) = opts.create_tokio() else {
+            info!(
+                "Failed to create buffered IPC listener for path: {}",
+                path.display()
+            );
+            return Err(format!(
+                "Failed to create buffered IPC listener for path: {}",
+                path.display()
+            )
+            .into());
+        };
+        info!(
+            "Safari IPC server bound and listening at: {}",
+            path.display()
+        );
+
+        tokio::spawn(listen_incoming(
+            listener,
+            inbound_send.clone(),
+            outbound.clone(),
+            cancel_token.clone(),
+        ));
+
+        Ok(SafariIpcServer {
+            path,
+            cancel_token,
+            outbound,
+        })
+    }
+
+    /// Buffer a desktop → extension message to be delivered on the next `receive` poll.
+    pub fn enqueue(&self, message: String) {
+        let mut queue = self.outbound.lock().expect("outbound mutex poisoned");
+        queue.push(message, Instant::now());
+    }
+
+    /// Stop the buffered IPC server.
+    pub fn stop(&self) {
+        self.cancel_token.cancel();
+    }
+}
+
+impl Drop for SafariIpcServer {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}
+
+async fn listen_incoming(
+    listener: LocalSocketListener,
+    inbound_send: mpsc::Sender<String>,
+    outbound: Outbound,
+    cancel_token: CancellationToken,
+) {
+    loop {
+        tokio::select! {
+            _ = cancel_token.cancelled() => {
+                info!("Buffered IPC server cancelled.");
+                break;
+            },
+
+            msg = listener.accept() => {
+                match msg {
+                    Ok(client_stream) => {
+                        let future = handle_connection(
+                            client_stream,
+                            inbound_send.clone(),
+                            outbound.clone(),
+                            cancel_token.clone(),
+                        );
+                        tokio::spawn(future.map_err(|e| {
+                            error!(error = %e, "Error handling buffered connection")
+                        }));
+                    },
+                    Err(e) => {
+                        error!(error = %e, "Error accepting buffered connection");
+                        break;
+                    },
+                }
+            }
+        }
+    }
+}
+
+async fn handle_connection(
+    client_stream: impl AsyncRead + AsyncWrite + Unpin,
+    inbound_send: mpsc::Sender<String>,
+    outbound: Outbound,
+    cancel_token: CancellationToken,
+) -> Result<(), Box<dyn Error>> {
+    let mut framed = crate::ipc::internal_ipc_codec(client_stream);
+
+    loop {
+        tokio::select! {
+            _ = cancel_token.cancelled() => break,
+
+            result = framed.next() => {
+                match result {
+                    None => break, // Client disconnected.
+                    Some(Err(e)) => {
+                        error!(error = %e, "Error reading from Safari client");
+                        break;
+                    },
+                    Some(Ok(bytes)) => {
+                        let response = handle_request(&bytes, &inbound_send, &outbound).await;
+                        framed.send(response.into()).await?;
+                    },
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+async fn handle_request(
+    bytes: &[u8],
+    inbound_send: &mpsc::Sender<String>,
+    outbound: &Outbound,
+) -> Vec<u8> {
+    match serde_json::from_slice::<Request>(bytes) {
+        Ok(Request::Send { payload }) => {
+            // Best-effort forward to the desktop. Failure means the consumer is gone.
+            let ok = inbound_send.send(payload).await.is_ok();
+            serde_json::to_vec(&SendResponse { ok }).unwrap_or_default()
+        }
+        Ok(Request::Receive) => {
+            let messages = {
+                let mut queue = outbound.lock().expect("outbound mutex poisoned");
+                queue.drain(Instant::now())
+            };
+            serde_json::to_vec(&ReceiveResponse { messages }).unwrap_or_default()
+        }
+        Err(e) => {
+            error!(error = %e, "Invalid Safari IPC request");
+            serde_json::to_vec(&SendResponse { ok: false }).unwrap_or_default()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn queue() -> OutboundQueue {
+        OutboundQueue::new(3, Duration::from_secs(60))
+    }
+
+    #[test]
+    fn drain_returns_messages_in_fifo_order_and_empties_the_queue() {
+        let mut q = queue();
+        let now = Instant::now();
+        q.push("a".into(), now);
+        q.push("b".into(), now);
+
+        assert_eq!(q.drain(now), vec!["a".to_string(), "b".to_string()]);
+        // Draining empties the queue.
+        assert!(q.drain(now).is_empty());
+    }
+
+    #[test]
+    fn push_beyond_capacity_drops_the_oldest_message() {
+        let mut q = queue();
+        let now = Instant::now();
+        q.push("a".into(), now);
+        q.push("b".into(), now);
+        q.push("c".into(), now);
+        q.push("d".into(), now); // Capacity is 3, so "a" is dropped.
+
+        assert_eq!(
+            q.drain(now),
+            vec!["b".to_string(), "c".to_string(), "d".to_string()]
+        );
+    }
+
+    #[test]
+    fn drain_evicts_messages_older_than_the_ttl() {
+        let mut q = OutboundQueue::new(10, Duration::from_secs(60));
+        let start = Instant::now();
+        q.push("stale".into(), start);
+
+        let later = start + Duration::from_secs(61);
+        q.push("fresh".into(), later);
+
+        // "stale" is evicted on access; only "fresh" remains.
+        assert_eq!(q.drain(later), vec!["fresh".to_string()]);
+    }
+
+    #[test]
+    fn push_evicts_expired_before_enforcing_capacity() {
+        let mut q = OutboundQueue::new(2, Duration::from_secs(60));
+        let start = Instant::now();
+        q.push("old".into(), start);
+
+        let later = start + Duration::from_secs(61);
+        q.push("a".into(), later);
+        q.push("b".into(), later);
+
+        // "old" expired and was evicted, so "a" and "b" both fit without dropping.
+        assert_eq!(q.drain(later), vec!["a".to_string(), "b".to_string()]);
+    }
+}

--- a/apps/desktop/desktop_native/napi/index.d.ts
+++ b/apps/desktop/desktop_native/napi/index.d.ts
@@ -197,6 +197,18 @@ export declare namespace ipc {
     /** Send a message to a specific connected client by ID. */
     sendTo(clientId: number, message: string): void
   }
+  /** Ipc server for talking to the safari extension */
+  export class SafariIpcServer {
+    /** Create and start the buffered IPC server without blocking. */
+    static listen(callback: (error: null | Error, message: string) => void): Promise<SafariIpcServer>
+    /** Stop the buffered IPC server. */
+    stop(): void
+    /**
+     * Buffer a message to send to the Safari extension. The safari extension will poll the
+     * desktop app to collect the message.
+     */
+    enqueue(message: string): void
+  }
   export interface IpcMessage {
     clientId: number
     kind: IpcMessageType

--- a/apps/desktop/desktop_native/napi/src/ipc.rs
+++ b/apps/desktop/desktop_native/napi/src/ipc.rs
@@ -114,4 +114,76 @@ pub mod ipc {
             })
         }
     }
+
+    /// Ipc server for talking to the safari extension
+    #[napi]
+    pub struct SafariIpcServer {
+        #[cfg(target_os = "macos")]
+        server: desktop_core::ipc::safari_ipc_server::SafariIpcServer,
+    }
+
+    #[napi]
+    impl SafariIpcServer {
+        /// Create and start the buffered IPC server without blocking.
+        #[napi(factory)]
+        #[allow(clippy::unused_async)]
+        pub async fn listen(
+            #[napi(ts_arg_type = "(error: null | Error, message: string) => void")]
+            callback: ThreadsafeFunction<String>,
+        ) -> napi::Result<Self> {
+            #[cfg(target_os = "macos")]
+            {
+                let (send, mut recv) = tokio::sync::mpsc::channel::<String>(32);
+                tokio::spawn(async move {
+                    while let Some(message) = recv.recv().await {
+                        callback.call(Ok(message), ThreadsafeFunctionCallMode::NonBlocking);
+                    }
+                });
+
+                let server = desktop_core::ipc::safari_ipc_server::SafariIpcServer::start(send)
+                    .map_err(|e| {
+                        napi::Error::from_reason(format!(
+                            "Error listening to buffered server - Error: {e:?}"
+                        ))
+                    })?;
+
+                Ok(SafariIpcServer { server })
+            }
+            #[cfg(not(target_os = "macos"))]
+            {
+                let _ = callback;
+                Err(napi::Error::from_reason(
+                    "Safari IPC server is only supported on macOS",
+                ))
+            }
+        }
+
+        /// Stop the buffered IPC server.
+        #[napi]
+        pub fn stop(&self) -> napi::Result<()> {
+            #[cfg(target_os = "macos")]
+            {
+                self.server.stop();
+            }
+            Ok(())
+        }
+
+        /// Buffer a message to send to the Safari extension. The safari extension will poll the
+        /// desktop app to collect the message.
+        #[napi]
+        pub fn enqueue(&self, message: String) -> napi::Result<()> {
+            #[cfg(target_os = "macos")]
+            {
+                self.server.enqueue(message);
+                Ok(())
+            }
+            #[cfg(not(target_os = "macos"))]
+            {
+                let _ = message;
+                Err(napi::Error::from_reason(
+                    "Safari IPC server is only supported on macOS",
+                ))
+            }
+        }
+    }
 }

--- a/apps/desktop/resources/entitlements.mac.plist
+++ b/apps/desktop/resources/entitlements.mac.plist
@@ -6,6 +6,10 @@
 	<string>LTZ2PFU5D6.com.bitwarden.desktop</string>
 	<key>com.apple.developer.team-identifier</key>
 	<string>LTZ2PFU5D6</string>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>LTZ2PFU5D6.com.bitwarden.desktop</string>
+	</array>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
 </dict>

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -49,6 +49,7 @@ import { MenuMain } from "./main/menu/menu.main";
 import { AUTOSTART_FLAG, MessagingMain } from "./main/messaging.main";
 import { NativeMessagingMain } from "./main/native-messaging.main";
 import { PowerMonitorMain } from "./main/power-monitor.main";
+import { SafariIpcMain } from "./main/safari-ipc.main";
 import { SsoCookieMain } from "./main/sso-cookie.main";
 import { ChromiumImporterService } from "./main/tools/import/chromium-importer.service";
 import { TrayMain } from "./main/tray.main";
@@ -95,6 +96,7 @@ export class Main {
   trayMain: TrayMain;
   biometricsService: DesktopBiometricsService;
   nativeMessagingMain: NativeMessagingMain;
+  safariIpcMain: SafariIpcMain;
   clipboardMain: ClipboardMain;
   nativeAutofillMain: NativeAutofillMain;
   desktopAutofillSettingsService: DesktopAutofillSettingsService;
@@ -325,10 +327,12 @@ export class Main {
       app.getAppPath(),
     );
 
+    this.safariIpcMain = new SafariIpcMain(this.logService);
     this.ipcService = new IpcMainService(
       this.logService,
       app,
       this.nativeMessagingMain,
+      this.safariIpcMain,
       this.windowMain,
     );
 
@@ -359,6 +363,7 @@ export class Main {
     );
 
     app.on("will-quit", () => {
+      this.safariIpcMain.stop();
       this.mainDesktopAutotypeService.dispose();
       this.storageService.dispose();
     });
@@ -418,6 +423,12 @@ export class Main {
 
           await this.nativeMessagingMain.generateManifests();
           await this.nativeMessagingMain.listen();
+
+          // Safari cannot use native messaging hosts; it talks to the desktop over a buffered
+          // socket in the shared App Group container (macOS only).
+          if (process.platform === "darwin") {
+            await this.safariIpcMain.listen();
+          }
         } catch (err) {
           this.logService.error("Error while setting up native messaging:", err);
         }

--- a/apps/desktop/src/main/safari-ipc.main.ts
+++ b/apps/desktop/src/main/safari-ipc.main.ts
@@ -1,0 +1,41 @@
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+import { ipc } from "@bitwarden/desktop-napi";
+
+/**
+ * Ipc service for communicating with the safari extension. This is implemented in `desktop_native`.
+ */
+export class SafariIpcMain {
+  private ipcServer: ipc.SafariIpcServer | null = null;
+  private messageHandler?: (message: string) => void;
+
+  constructor(private logService: LogService) {}
+
+  /** Buffer a desktop -> safari extension message for delivery on the extension's next poll. */
+  enqueue(message: string) {
+    this.ipcServer?.enqueue(message);
+  }
+
+  /** Sets a handler to process incoming messages */
+  setMessageHandler(handler: (message: string) => void) {
+    this.messageHandler = handler;
+  }
+
+  async listen() {
+    if (this.ipcServer) {
+      this.ipcServer.stop();
+    }
+
+    this.ipcServer = await ipc.SafariIpcServer.listen((error, message) => {
+      if (error != null) {
+        this.logService.warning("[SafariIPC] error:", error);
+        return;
+      }
+      this.messageHandler?.(message);
+    });
+  }
+
+  stop() {
+    this.ipcServer?.stop();
+    this.ipcServer = null;
+  }
+}

--- a/apps/desktop/src/platform/services/ipc.main.service.ts
+++ b/apps/desktop/src/platform/services/ipc.main.service.ts
@@ -19,9 +19,22 @@ import {
 } from "@bitwarden/sdk-internal";
 
 import { NativeMessagingMain } from "../../main/native-messaging.main";
+import { SafariIpcMain } from "../../main/safari-ipc.main";
 import { WindowMain } from "../../main/window.main";
 import { isDev } from "../../utils";
 
+/** Envelope serialized over the buffered Safari socket. Payloads are opaque (SDK-encrypted). */
+interface SafariIpcEnvelope {
+  destination: unknown;
+  source?: unknown;
+  payload: number[];
+  topic?: string;
+}
+
+/**
+ * Desktop main-process {@link IpcService}. Handles both Safari (buffered socket) and non-Safari
+ * (firefox/chromium/CLI native messaging, plus the desktop renderer) clients.
+ */
 export class IpcMainService extends IpcService {
   private communicationBackend?: IpcCommunicationBackend;
 
@@ -29,6 +42,7 @@ export class IpcMainService extends IpcService {
     private logService: LogService,
     private app: Electron.App,
     private nativeMessaging: NativeMessagingMain,
+    private safariIpcMain: SafariIpcMain,
     private windowMain: WindowMain,
   ) {
     super();
@@ -51,6 +65,18 @@ export class IpcMainService extends IpcService {
             typeof message.destination === "object" &&
             "BrowserBackground" in message.destination
           ) {
+            // Safari has no persistent native-messaging connection; route through the buffered
+            // socket instead. Safari backgrounds are addressed by the string id "Own".
+            if (isSafariBackground(message.destination.BrowserBackground)) {
+              const envelope: SafariIpcEnvelope = {
+                destination: message.destination,
+                payload: [...message.payload],
+                topic: message.topic,
+              };
+              this.safariIpcMain.enqueue(JSON.stringify(envelope));
+              return;
+            }
+
             const ipcMessage = {
               type: "bitwarden-ipc-message",
               message: {
@@ -130,6 +156,9 @@ export class IpcMainService extends IpcService {
         }
       });
 
+      // Handle messages from the Safari extension, received over the buffered socket.
+      this.safariIpcMain.setMessageHandler((raw) => this.receiveFromSafari(raw));
+
       // Handle messages from renderer process
       ipcMain.on("ipc.send", async (_event, message: IpcMessage) => {
         try {
@@ -182,6 +211,37 @@ export class IpcMainService extends IpcService {
       this.logService.error("[IPC] Initialization failed", e);
     }
   }
+
+  private receiveFromSafari(raw: string): void {
+    let envelope: SafariIpcEnvelope;
+    try {
+      envelope = JSON.parse(raw) as SafariIpcEnvelope;
+    } catch (e) {
+      this.logService.warning("[IPC] Dropping malformed Safari message", e);
+      return;
+    }
+
+    try {
+      this.communicationBackend?.receive(
+        new IncomingMessage(
+          new Uint8Array(envelope.payload),
+          envelope.destination as IncomingMessage["destination"],
+          (envelope.source ?? { BrowserBackground: { id: "Own" } }) as IncomingMessage["source"],
+          envelope.topic,
+        ),
+      );
+    } catch (e) {
+      this.logService.warning("[IPC] Failed to dispatch Safari message", e);
+    }
+  }
+}
+
+/**
+ * A {@link BrowserBackground} host with the string id `"Own"` is the Safari extension, which is
+ * reached over the buffered socket rather than a native-messaging connection.
+ */
+function isSafariBackground(host: { id: string | { Id: number } }): boolean {
+  return host.id === "Own";
 }
 
 /**


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-39131

## 📔 Objective

Implements IPC transport for Safari. This enables biometric unlock via the desktop app, and shared unlock for Safari.

Safari extensions cannot hold a persistent connection to the desktop, so the desktop hosts a buffered IPC server over the shared App Group socket (native Rust implementation in `desktop_native`, exposed via NAPI). The extension background sends messages through the Safari native handler and polls the buffered socket to receive desktop-initiated messages.

Please note, eventually we should switch this to XPC, which should be a reasonably sized lift. However, I've moved that out of scope for this PR because:
- We should migrate it together with `desktop_proxy`
- This approach was easier to implement and easier to debug
- The complexity introduced here is limited to two files and can be easily replaced
  - It is reasonably easy to replace with XPC later on. MAS is distributed together with Safari, so we don't even need to do any compatibility checking. We can just have one PR replacing (parts of) the swift module, the one rust file. The rest of the code stays the same.
- (My signing setup didn't work and it would be a scope increase to set up proper signing)
- (There is a prototype for XPC here https://github.com/bitwarden/clients/pull/21297/changes, but I don't see a need to shepherd it through here. Please feel free to take it over)

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
