### PR TITLE
[PM-36835] implement logging in the weak-passwords component

### DIFF
--- a/apps/web/src/app/dirt/reports/pages/cipher-report.component.ts
+++ b/apps/web/src/app/dirt/reports/pages/cipher-report.component.ts
@@ -1,4 +1,4 @@
-import { Directive, OnDestroy } from "@angular/core";
+import { Directive, OnDestroy, Optional } from "@angular/core";
 import {
   BehaviorSubject,
   lastValueFrom,
@@ -20,6 +20,7 @@ import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.serv
 import { CipherRepromptType } from "@bitwarden/common/vault/enums/cipher-reprompt-type";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { DialogRef, TableDataSource, DialogService } from "@bitwarden/components";
+import { LogService } from "@bitwarden/logging";
 import {
   CipherFormConfig,
   CipherFormConfigService,
@@ -65,6 +66,7 @@ export abstract class CipherReportComponent implements OnDestroy {
     private syncService: SyncService,
     private cipherFormConfigService: CipherFormConfigService,
     protected adminConsoleCipherFormConfigService: AdminConsoleCipherFormConfigService,
+    @Optional() protected logService?: LogService,
   ) {
     this.organizations$ = this.accountService.activeAccount$.pipe(
       getUserId,
@@ -131,15 +133,22 @@ export abstract class CipherReportComponent implements OnDestroy {
   }
 
   async load() {
+    this.logService?.info(
+      `[CipherReport] load() — filterStatus="${this.currentFilterStatus}", cipherCount=${this.ciphers.length}`,
+    );
     this.loading = true;
     await this.syncService.fullSync(false);
     // when a user fixes an item in a report we want to persist the filter they had
     // if they fix the last item of that filter we will go back to the "All" filter
     if (this.currentFilterStatus) {
       if (this.ciphers.length > 2) {
+        this.logService?.info(`[CipherReport] Restoring filter "${this.currentFilterStatus}"`);
         this.filterOrgStatus$.next(this.currentFilterStatus);
         await this.filterOrgToggle(this.currentFilterStatus);
       } else {
+        this.logService?.info(
+          `[CipherReport] Too few items (${this.ciphers.length}), resetting filter to All`,
+        );
         this.filterOrgStatus$.next(0);
         await this.filterOrgToggle(0);
       }
@@ -283,8 +292,15 @@ export abstract class CipherReportComponent implements OnDestroy {
   }
 
   protected async getAllCiphers(): Promise<CipherView[]> {
-    const activeUserId = await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId));
-    return await this.cipherService.getAllDecrypted(activeUserId);
+    this.logService?.info(`[CipherReport] Fetching all ciphers for user`);
+
+    try {
+      const activeUserId = await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId));
+      return await this.cipherService.getAllDecrypted(activeUserId);
+    } catch (e) {
+      this.logService?.error(`[CipherReport] Failed to fetch ciphers for user`, e);
+      throw e;
+    }
   }
 
   protected canDisplayToggleGroup(): boolean {

--- a/apps/web/src/app/dirt/reports/pages/cipher-report.component.ts
+++ b/apps/web/src/app/dirt/reports/pages/cipher-report.component.ts
@@ -137,7 +137,9 @@ export abstract class CipherReportComponent implements OnDestroy {
       `[CipherReport] load() — filterStatus="${this.currentFilterStatus}", cipherCount=${this.ciphers.length}`,
     );
     this.loading = true;
+    this.logService?.info(`[CipherReport] Starting full sync`);
     await this.syncService.fullSync(false);
+    this.logService?.info(`[CipherReport] Full sync complete`);
     // when a user fixes an item in a report we want to persist the filter they had
     // if they fix the last item of that filter we will go back to the "All" filter
     if (this.currentFilterStatus) {
@@ -153,6 +155,7 @@ export abstract class CipherReportComponent implements OnDestroy {
         await this.filterOrgToggle(0);
       }
     } else {
+      this.logService?.info(`[CipherReport] No active filter, calling setCiphers()`);
       await this.setCiphers();
     }
     this.loading = false;
@@ -220,12 +223,15 @@ export abstract class CipherReportComponent implements OnDestroy {
   }
 
   async refresh(result: VaultItemDialogResult, cipher: CipherView) {
+    this.logService?.info(`[CipherReport] refresh() — result="${result}", cipherId="${cipher.id}"`);
+
     if (result === VaultItemDialogResult.Deleted) {
       // update downstream report status if the cipher was deleted
       await this.determinedUpdatedCipherReportStatus(result, cipher);
 
       // the cipher was deleted, filter it out from the report.
       this.ciphers = this.ciphers.filter((ciph) => ciph.id !== cipher.id);
+      this.logService?.info(`[CipherReport] Cipher deleted, ${this.ciphers.length} remaining`);
       this.filterCiphersByOrg(this.ciphers);
       return;
     }
@@ -236,6 +242,7 @@ export abstract class CipherReportComponent implements OnDestroy {
       let updatedCipher = await this.cipherService.get(cipher.id, activeUserId);
 
       if (this.isAdminConsoleActive) {
+        this.logService?.info(`[CipherReport] Fetching cipher via admin console path`);
         updatedCipher =
           (await this.adminConsoleCipherFormConfigService.getCipher(
             cipher.id as CipherId,
@@ -258,13 +265,19 @@ export abstract class CipherReportComponent implements OnDestroy {
       // determine the index of the updated cipher in the report
       const index = this.ciphers.findIndex((c) => c.id === updatedCipherView.id);
 
+      if (index === -1) {
+        this.logService?.warning(`[CipherReport] Saved cipher not found in report list`);
+      }
+
       // the updated cipher does not meet the criteria for the report, it returns a null
       if (updatedReportResult === null && index > -1) {
+        this.logService?.info(`[CipherReport] Cipher no longer meets report criteria, removing`);
         this.ciphers.splice(index, 1);
       }
 
       // the cipher is already in the report, update it.
       if (updatedReportResult !== null && index > -1) {
+        this.logService?.info(`[CipherReport] Cipher still meets report criteria, updating`);
         this.ciphers[index] = updatedReportResult;
       }
 
@@ -296,7 +309,9 @@ export abstract class CipherReportComponent implements OnDestroy {
 
     try {
       const activeUserId = await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId));
-      return await this.cipherService.getAllDecrypted(activeUserId);
+      const ciphers = await this.cipherService.getAllDecrypted(activeUserId);
+      this.logService?.info(`[CipherReport] Fetched ${ciphers.length} decrypted ciphers for user`);
+      return ciphers;
     } catch (e) {
       this.logService?.error(`[CipherReport] Failed to fetch ciphers for user`, e);
       throw e;

--- a/apps/web/src/app/dirt/reports/pages/inactive-two-factor-report.component.ts
+++ b/apps/web/src/app/dirt/reports/pages/inactive-two-factor-report.component.ts
@@ -38,7 +38,7 @@ export class InactiveTwoFactorReportComponent extends CipherReportComponent impl
     protected organizationService: OrganizationService,
     dialogService: DialogService,
     accountService: AccountService,
-    private logService: LogService,
+    protected logService: LogService,
     passwordRepromptService: PasswordRepromptService,
     i18nService: I18nService,
     syncService: SyncService,

--- a/apps/web/src/app/dirt/reports/pages/organizations/weak-passwords-report.component.ts
+++ b/apps/web/src/app/dirt/reports/pages/organizations/weak-passwords-report.component.ts
@@ -102,7 +102,12 @@ export class WeakPasswordsReportComponent
             this.logService.info(
               `[WeakPasswordsReport] Initializing for organization "${this.organization?.id ?? params.organizationId}"`,
             );
+
             const manageableCiphers = await this.cipherService.getAll(userId);
+            this.logService.info(
+              `[WeakPasswordsReport] User has access to ${manageableCiphers.length} ciphers in organization"`,
+            );
+            this.logService.info(`[WeakPasswordsReport] Fetching collections for organization}"`);
             this.manageableCipherIds = new Set(manageableCiphers.map((c) => c.id));
             const collections = await firstValueFrom(
               this.collectionService.decryptedCollections$(userId),
@@ -111,6 +116,9 @@ export class WeakPasswordsReportComponent
               collections
                 .filter((c) => !c.isDefaultCollection && c.organizationId === this.organization?.id)
                 .map((c) => c.id as string),
+            );
+            this.logService.info(
+              `[WeakPasswordsReport] User has access to ${this.sharedCollectionIds.size} shared collections in organization"`,
             );
             await super.ngOnInit();
           } catch (e) {

--- a/apps/web/src/app/dirt/reports/pages/organizations/weak-passwords-report.component.ts
+++ b/apps/web/src/app/dirt/reports/pages/organizations/weak-passwords-report.component.ts
@@ -107,7 +107,7 @@ export class WeakPasswordsReportComponent
             this.logService.info(
               `[WeakPasswordsReport] User has access to ${manageableCiphers.length} ciphers in organization"`,
             );
-            this.logService.info(`[WeakPasswordsReport] Fetching collections for organization}"`);
+            this.logService.info(`[WeakPasswordsReport] Fetching collections for organization"`);
             this.manageableCipherIds = new Set(manageableCiphers.map((c) => c.id));
             const collections = await firstValueFrom(
               this.collectionService.decryptedCollections$(userId),

--- a/apps/web/src/app/dirt/reports/pages/organizations/weak-passwords-report.component.ts
+++ b/apps/web/src/app/dirt/reports/pages/organizations/weak-passwords-report.component.ts
@@ -14,6 +14,7 @@ import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.serv
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { CipherViewLikeUtils } from "@bitwarden/common/vault/utils/cipher-view-like-utils";
 import { BerryComponent, ChipFilterComponent, DialogService } from "@bitwarden/components";
+import { LogService } from "@bitwarden/logging";
 import {
   CipherFormConfigService,
   PasswordRepromptService,
@@ -71,6 +72,7 @@ export class WeakPasswordsReportComponent
     protected accountService: AccountService,
     adminConsoleCipherFormConfigService: AdminConsoleCipherFormConfigService,
     private collectionService: CollectionService,
+    protected logService: LogService,
   ) {
     super(
       cipherService,
@@ -83,6 +85,7 @@ export class WeakPasswordsReportComponent
       syncService,
       cipherFormConfigService,
       adminConsoleCipherFormConfigService,
+      logService,
     );
   }
 
@@ -113,6 +116,9 @@ export class WeakPasswordsReportComponent
   }
 
   async getAllCiphers(): Promise<CipherView[]> {
+    this.logService.info(
+      `[WeakPasswordsReport] Fetching ciphers for organization ${this.organization?.id ?? "N/A"}`,
+    );
     if (this.organization) {
       return this.cipherService.getAllFromApiForOrganization(this.organization.id, true);
     }

--- a/apps/web/src/app/dirt/reports/pages/organizations/weak-passwords-report.component.ts
+++ b/apps/web/src/app/dirt/reports/pages/organizations/weak-passwords-report.component.ts
@@ -94,21 +94,33 @@ export class WeakPasswordsReportComponent
     this.route.parent?.parent?.params
       .pipe(
         tap(async (params) => {
-          const userId = await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId));
-          this.organization = await firstValueFrom(
-            this.organizationService.organizations$(userId).pipe(getById(params.organizationId)),
-          );
-          const manageableCiphers = await this.cipherService.getAll(userId);
-          this.manageableCipherIds = new Set(manageableCiphers.map((c) => c.id));
-          const collections = await firstValueFrom(
-            this.collectionService.decryptedCollections$(userId),
-          );
-          this.sharedCollectionIds = new Set(
-            collections
-              .filter((c) => !c.isDefaultCollection && c.organizationId === this.organization?.id)
-              .map((c) => c.id as string),
-          );
-          await super.ngOnInit();
+          try {
+            const userId = await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId));
+            this.organization = await firstValueFrom(
+              this.organizationService.organizations$(userId).pipe(getById(params.organizationId)),
+            );
+            this.logService.info(
+              `[WeakPasswordsReport] Initializing for organization "${this.organization?.id ?? params.organizationId}"`,
+            );
+            const manageableCiphers = await this.cipherService.getAll(userId);
+            this.manageableCipherIds = new Set(manageableCiphers.map((c) => c.id));
+            const collections = await firstValueFrom(
+              this.collectionService.decryptedCollections$(userId),
+            );
+            this.sharedCollectionIds = new Set(
+              collections
+                .filter((c) => !c.isDefaultCollection && c.organizationId === this.organization?.id)
+                .map((c) => c.id as string),
+            );
+            await super.ngOnInit();
+          } catch (e) {
+            // Re-throwing here would surface an unhandled promise rejection rather than
+            // propagating through the observable stream, so we log and swallow instead.
+            this.logService.error(
+              `[WeakPasswordsReport] Failed to initialize for organization "${params.organizationId}"`,
+              e,
+            );
+          }
         }),
         takeUntil(this.destroyed$),
       )
@@ -120,7 +132,22 @@ export class WeakPasswordsReportComponent
       `[WeakPasswordsReport] Fetching ciphers for organization ${this.organization?.id ?? "N/A"}`,
     );
     if (this.organization) {
-      return this.cipherService.getAllFromApiForOrganization(this.organization.id, true);
+      try {
+        const ciphers = await this.cipherService.getAllFromApiForOrganization(
+          this.organization.id,
+          true,
+        );
+        this.logService.info(
+          `[WeakPasswordsReport] Fetched ${ciphers.length} ciphers for organization "${this.organization.id}"`,
+        );
+        return ciphers;
+      } catch (e) {
+        this.logService.error(
+          `[WeakPasswordsReport] Failed to fetch ciphers for organization "${this.organization?.id ?? "N/A"}"`,
+          e,
+        );
+        throw e;
+      }
     }
     return [];
   }

--- a/apps/web/src/app/dirt/reports/pages/weak-passwords-report.component.spec.ts
+++ b/apps/web/src/app/dirt/reports/pages/weak-passwords-report.component.spec.ts
@@ -13,6 +13,7 @@ import { UserId } from "@bitwarden/common/types/guid";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.service.abstraction";
 import { DialogService } from "@bitwarden/components";
+import { LogService } from "@bitwarden/logging";
 import { I18nPipe } from "@bitwarden/ui-common";
 import { CipherFormConfigService, PasswordRepromptService } from "@bitwarden/vault";
 
@@ -98,6 +99,10 @@ describe("WeakPasswordsReportComponent", () => {
         {
           provide: AdminConsoleCipherFormConfigService,
           useValue: adminConsoleCipherFormConfigServiceMock,
+        },
+        {
+          provide: LogService,
+          useValue: mock<LogService>(),
         },
       ],
       schemas: [CUSTOM_ELEMENTS_SCHEMA],

--- a/apps/web/src/app/dirt/reports/pages/weak-passwords-report.component.ts
+++ b/apps/web/src/app/dirt/reports/pages/weak-passwords-report.component.ts
@@ -69,6 +69,7 @@ export class WeakPasswordsReportComponent extends CipherReportComponent implemen
       await super.load();
     } catch (e) {
       this.logService.error("[WeakPasswordsReport] Failed to load report", e);
+      throw e;
     }
   }
 
@@ -82,6 +83,7 @@ export class WeakPasswordsReportComponent extends CipherReportComponent implemen
       this.findWeakPasswords(allCiphers);
     } catch (e) {
       this.logService.error("[WeakPasswordsReport] Failed to fetch ciphers", e);
+      throw e;
     }
   }
 

--- a/apps/web/src/app/dirt/reports/pages/weak-passwords-report.component.ts
+++ b/apps/web/src/app/dirt/reports/pages/weak-passwords-report.component.ts
@@ -65,27 +65,40 @@ export class WeakPasswordsReportComponent extends CipherReportComponent implemen
   }
 
   async ngOnInit() {
-    await super.load();
+    try {
+      await super.load();
+    } catch (e) {
+      this.logService.error("[WeakPasswordsReport] Failed to load report", e);
+    }
   }
 
   async setCiphers() {
     this.logService.info(`[WeakPasswordsReport] Loading ciphers for report`);
-
-    const allCiphers = await this.getAllCiphers();
-    this.logService.info(`[WeakPasswordsReport] Loaded ${allCiphers.length} ciphers for report`);
-
-    this.weakPasswordCiphers = [];
-    this.filterStatus = [0];
-    this.findWeakPasswords(allCiphers);
+    try {
+      const allCiphers = await this.getAllCiphers();
+      this.logService.info(`[WeakPasswordsReport] Loaded ${allCiphers.length} ciphers for report`);
+      this.weakPasswordCiphers = [];
+      this.filterStatus = [0];
+      this.findWeakPasswords(allCiphers);
+    } catch (e) {
+      this.logService.error("[WeakPasswordsReport] Failed to fetch ciphers", e);
+    }
   }
 
   async determinedUpdatedCipherReportStatus(
     result: VaultItemDialogResult,
     updatedCipherView: CipherView,
   ): Promise<CipherView | null> {
+    this.logService.info(
+      `[WeakPasswordsReport] Updating cipher ${updatedCipherView.id}, result: ${result}`,
+    );
+
     if (result === VaultItemDialogResult.Deleted) {
       this.weakPasswordCiphers = this.weakPasswordCiphers.filter(
         (c) => c.id !== updatedCipherView.id,
+      );
+      this.logService.info(
+        `[WeakPasswordsReport] Cipher deleted, ${this.weakPasswordCiphers.length} remaining`,
       );
       return null;
     }
@@ -94,7 +107,11 @@ export class WeakPasswordsReportComponent extends CipherReportComponent implemen
 
     const index = this.weakPasswordCiphers.findIndex((c) => c.id === updatedCipherView.id);
 
-    if (index !== -1) {
+    if (index === -1) {
+      this.logService.warning(
+        `[WeakPasswordsReport] Edited cipher not found in report list: ${updatedCipherView.id}`,
+      );
+    } else {
       if (updatedReportStatus !== null) {
         this.weakPasswordCiphers[index] = updatedReportStatus;
       } else {
@@ -107,7 +124,9 @@ export class WeakPasswordsReportComponent extends CipherReportComponent implemen
 
   protected findWeakPasswords(ciphers: CipherView[]): void {
     const loginCiphers = ciphers.filter((c) => c.type === CipherType.Login);
-    this.logService.info(`[WeakPasswordsReport] Analyzing ${loginCiphers.length} logins`);
+    this.logService.info(
+      `[WeakPasswordsReport] Analyzing ${ciphers.length} ciphers (${loginCiphers.length} logins)`,
+    );
 
     this.logService.info(
       `[WeakPasswordsReport] Checking passwords against user inputs and common patterns`,
@@ -173,7 +192,14 @@ export class WeakPasswordsReportComponent extends CipherReportComponent implemen
       userInput.length > 0 ? userInput : null,
     );
 
-    if (result.score != null && result.score <= 2) {
+    if (result.score == null) {
+      this.logService.warning(
+        `[WeakPasswordsReport] Password strength returned null score for cipher ${ciph.id}`,
+      );
+      return null;
+    }
+
+    if (result.score <= 2) {
       const scoreValue = this.scoreKey(result.score);
       return {
         ...ciph,

--- a/apps/web/src/app/dirt/reports/pages/weak-passwords-report.component.ts
+++ b/apps/web/src/app/dirt/reports/pages/weak-passwords-report.component.ts
@@ -12,6 +12,7 @@ import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.serv
 import { CipherType } from "@bitwarden/common/vault/enums";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { BadgeVariant, DialogService } from "@bitwarden/components";
+import { LogService } from "@bitwarden/logging";
 import {
   CipherFormConfigService,
   PasswordRepromptService,
@@ -48,6 +49,7 @@ export class WeakPasswordsReportComponent extends CipherReportComponent implemen
     syncService: SyncService,
     cipherFormConfigService: CipherFormConfigService,
     protected adminConsoleCipherFormConfigService: AdminConsoleCipherFormConfigService,
+    protected logService: LogService,
   ) {
     super(
       cipherService,
@@ -67,7 +69,11 @@ export class WeakPasswordsReportComponent extends CipherReportComponent implemen
   }
 
   async setCiphers() {
+    this.logService.info(`[WeakPasswordsReport] Loading ciphers for report`);
+
     const allCiphers = await this.getAllCiphers();
+    this.logService.info(`[WeakPasswordsReport] Loaded ${allCiphers.length} ciphers for report`);
+
     this.weakPasswordCiphers = [];
     this.filterStatus = [0];
     this.findWeakPasswords(allCiphers);
@@ -100,13 +106,29 @@ export class WeakPasswordsReportComponent extends CipherReportComponent implemen
   }
 
   protected findWeakPasswords(ciphers: CipherView[]): void {
+    const loginCiphers = ciphers.filter((c) => c.type === CipherType.Login);
+    this.logService.info(`[WeakPasswordsReport] Analyzing ${loginCiphers.length} logins`);
+
+    this.logService.info(
+      `[WeakPasswordsReport] Checking passwords against user inputs and common patterns`,
+    );
     ciphers.forEach((ciph) => {
       const row = this.determineWeakPasswordScore(ciph);
       if (row != null) {
         this.weakPasswordCiphers.push(row);
       }
     });
+
+    this.logService.info(
+      `[WeakPasswordsReport] Found ${this.weakPasswordCiphers.length} weak passwords`,
+    );
+
+    this.logService.info(`[WeakPasswordsReport] Filtering ciphers by organization`);
     this.filterCiphersByOrg(this.weakPasswordCiphers);
+
+    this.logService.info(
+      `[WeakPasswordsReport] Finished loading report with ${this.ciphers.length} ciphers to display`,
+    );
   }
 
   protected determineWeakPasswordScore(ciph: CipherView): ReportResult | null {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-36835

## 📔 Objective

Introduce logging only in the weak-passwords report
This is for diagnostics only - to determine a potential failure point within the weak-passwords report.

## 📸 Screenshots

None at this time.
