### PR TITLE
[PM-39182] Migrate to relative imports - @bitwarden/team-data-insights-and-reporting-dev

### DIFF
--- a/libs/common/src/dirt/event-logs/services/event-collection.service.ts
+++ b/libs/common/src/dirt/event-logs/services/event-collection.service.ts
@@ -2,15 +2,14 @@
 // @ts-strict-ignore
 import { firstValueFrom, map, from, zip } from "rxjs";
 
-import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
-import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
-import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
-import { getUserId } from "@bitwarden/common/auth/services/account.service";
-import { UserId } from "@bitwarden/common/types/guid";
-
+import { OrganizationService } from "../../../admin-console/abstractions/organization/organization.service.abstraction";
+import { Organization } from "../../../admin-console/models/domain/organization";
+import { AccountService } from "../../../auth/abstractions/account.service";
 import { AuthService } from "../../../auth/abstractions/auth.service";
 import { AuthenticationStatus } from "../../../auth/enums/authentication-status";
+import { getUserId } from "../../../auth/services/account.service";
 import { StateProvider } from "../../../platform/state";
+import { UserId } from "../../../types/guid";
 import { CipherService } from "../../../vault/abstractions/cipher.service";
 import { CipherView } from "../../../vault/models/view/cipher.view";
 import { EventCollectionService as EventCollectionServiceAbstraction } from "../abstractions/event-collection.service";

--- a/libs/common/src/dirt/services/phishing-detection/phishing-detection-settings.service.spec.ts
+++ b/libs/common/src/dirt/services/phishing-detection/phishing-detection-settings.service.spec.ts
@@ -1,16 +1,16 @@
 import { mock, MockProxy } from "jest-mock-extended";
 import { BehaviorSubject, firstValueFrom, Subject } from "rxjs";
 
-import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
-import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
-import { Account, AccountService } from "@bitwarden/common/auth/abstractions/account.service";
-import { BillingAccountProfileStateService } from "@bitwarden/common/billing/abstractions";
-import { ProductTierType } from "@bitwarden/common/billing/enums";
-import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
-import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { LogService } from "@bitwarden/logging";
 
 import { FakeAccountService, FakeStateProvider, mockAccountServiceWith } from "../../../../spec";
+import { OrganizationService } from "../../../admin-console/abstractions/organization/organization.service.abstraction";
+import { Organization } from "../../../admin-console/models/domain/organization";
+import { Account, AccountService } from "../../../auth/abstractions/account.service";
+import { BillingAccountProfileStateService } from "../../../billing/abstractions";
+import { ProductTierType } from "../../../billing/enums";
+import { ConfigService } from "../../../platform/abstractions/config/config.service";
+import { PlatformUtilsService } from "../../../platform/abstractions/platform-utils.service";
 import { UserId } from "../../../types/guid";
 
 import { PhishingDetectionSettingsService } from "./phishing-detection-settings.service";

--- a/libs/common/src/dirt/services/phishing-detection/phishing-detection-settings.service.ts
+++ b/libs/common/src/dirt/services/phishing-detection/phishing-detection-settings.service.ts
@@ -1,17 +1,17 @@
 import { combineLatest, Observable, of, switchMap } from "rxjs";
 import { catchError, distinctUntilChanged, map, shareReplay, tap } from "rxjs/operators";
 
-import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
-import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
-import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
-import { BillingAccountProfileStateService } from "@bitwarden/common/billing/abstractions";
-import { ProductTierType } from "@bitwarden/common/billing/enums";
-import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
-import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
-import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { LogService } from "@bitwarden/logging";
 import { UserId } from "@bitwarden/user-core";
 
+import { OrganizationService } from "../../../admin-console/abstractions/organization/organization.service.abstraction";
+import { Organization } from "../../../admin-console/models/domain/organization";
+import { AccountService } from "../../../auth/abstractions/account.service";
+import { BillingAccountProfileStateService } from "../../../billing/abstractions";
+import { ProductTierType } from "../../../billing/enums";
+import { FeatureFlag } from "../../../enums/feature-flag.enum";
+import { ConfigService } from "../../../platform/abstractions/config/config.service";
+import { PlatformUtilsService } from "../../../platform/abstractions/platform-utils.service";
 import { PHISHING_DETECTION_DISK, StateProvider, UserKeyDefinition } from "../../../platform/state";
 import { PhishingDetectionSettingsServiceAbstraction } from "../abstractions/phishing-detection-settings.service.abstraction";
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-39182

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Imports within the same package must be relative imports. This is documented here: https://contributing.bitwarden.com/contributing/code-style/web/typescript#imports-within-the-same-package . To enforce this requirement, an eslint rule has been added in https://github.com/bitwarden/clients/pull/21198 . This PR set is, per team, introducing relative self imports. These are for the most part auto-generated by the eslint rule, with some manual tweaks for e.g. import order issues after the autofix was applied.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
