### PR TITLE
[PM-39182] Migrate to relative imports - @bitwarden/team-autofill-dev

### DIFF
--- a/libs/common/src/autofill/services/autofill-settings.service.ts
+++ b/libs/common/src/autofill/services/autofill-settings.service.ts
@@ -2,9 +2,6 @@
 // @ts-strict-ignore
 import { combineLatest, map, Observable, switchMap } from "rxjs";
 
-import { CipherType } from "@bitwarden/common/vault/enums";
-import { RestrictedItemTypesService } from "@bitwarden/common/vault/services/restricted-item-types.service";
-
 import { PolicyService } from "../../admin-console/abstractions/policy/policy.service.abstraction";
 import { PolicyType } from "../../admin-console/enums";
 import { AccountService } from "../../auth/abstractions/account.service";
@@ -18,6 +15,8 @@ import {
   StateProvider,
   UserKeyDefinition,
 } from "../../platform/state";
+import { CipherType } from "../../vault/enums";
+import { RestrictedItemTypesService } from "../../vault/services/restricted-item-types.service";
 import { ClearClipboardDelay, AutofillOverlayVisibility } from "../constants";
 import { ClearClipboardDelaySetting, InlineMenuVisibilitySetting } from "../types";
 

--- a/libs/common/src/autofill/services/domain-settings.service.spec.ts
+++ b/libs/common/src/autofill/services/domain-settings.service.spec.ts
@@ -1,17 +1,13 @@
 import { mock, MockProxy } from "jest-mock-extended";
 import { BehaviorSubject, firstValueFrom, of } from "rxjs";
 
-import { PolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
-import { AuthService } from "@bitwarden/common/auth/abstractions/auth.service";
-import { AuthenticationStatus } from "@bitwarden/common/auth/enums/authentication-status";
-import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
-import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
-import {
-  Environment,
-  EnvironmentService,
-} from "@bitwarden/common/platform/abstractions/environment.service";
-
 import { FakeStateProvider, FakeAccountService, mockAccountServiceWith } from "../../../spec";
+import { PolicyService } from "../../admin-console/abstractions/policy/policy.service.abstraction";
+import { AuthService } from "../../auth/abstractions/auth.service";
+import { AuthenticationStatus } from "../../auth/enums/authentication-status";
+import { FeatureFlag } from "../../enums/feature-flag.enum";
+import { ConfigService } from "../../platform/abstractions/config/config.service";
+import { Environment, EnvironmentService } from "../../platform/abstractions/environment.service";
 import { Utils } from "../../platform/misc/utils";
 import { UserId } from "../../types/guid";
 import { FormPurposeCategories } from "../constants";

--- a/libs/common/src/autofill/services/domain-settings.service.ts
+++ b/libs/common/src/autofill/services/domain-settings.service.ts
@@ -10,23 +10,22 @@ import {
   shareReplay,
 } from "rxjs";
 
-import { PolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
-import { PolicyType } from "@bitwarden/common/admin-console/enums/policy-type.enum";
-import { getFirstPolicy } from "@bitwarden/common/admin-console/services/policy/default-policy.service";
-import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
-import { AuthService } from "@bitwarden/common/auth/abstractions/auth.service";
-import { AuthenticationStatus } from "@bitwarden/common/auth/enums/authentication-status";
-import { getUserId } from "@bitwarden/common/auth/services/account.service";
-import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
-import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
-import { EnvironmentService } from "@bitwarden/common/platform/abstractions/environment.service";
-
+import { PolicyService } from "../../admin-console/abstractions/policy/policy.service.abstraction";
+import { PolicyType } from "../../admin-console/enums/policy-type.enum";
+import { getFirstPolicy } from "../../admin-console/services/policy/default-policy.service";
+import { AccountService } from "../../auth/abstractions/account.service";
+import { AuthService } from "../../auth/abstractions/auth.service";
+import { AuthenticationStatus } from "../../auth/enums/authentication-status";
+import { getUserId } from "../../auth/services/account.service";
+import { FeatureFlag } from "../../enums/feature-flag.enum";
 import {
   NeverDomains,
   EquivalentDomains,
   UriMatchStrategySetting,
   UriMatchStrategy,
 } from "../../models/domain/domain-service";
+import { ConfigService } from "../../platform/abstractions/config/config.service";
+import { EnvironmentService } from "../../platform/abstractions/environment.service";
 import { Utils } from "../../platform/misc/utils";
 import {
   DOMAIN_SETTINGS_DISK,

--- a/libs/common/src/autofill/utils/index.spec.ts
+++ b/libs/common/src/autofill/utils/index.spec.ts
@@ -1,5 +1,4 @@
-import { NeverDomains } from "@bitwarden/common/models/domain/domain-service";
-
+import { NeverDomains } from "../../models/domain/domain-service";
 import { CardView } from "../../vault/models/view/card.view";
 import {
   isCardExpired,

--- a/libs/common/src/autofill/utils/index.ts
+++ b/libs/common/src/autofill/utils/index.ts
@@ -1,6 +1,5 @@
-import { NeverDomains } from "@bitwarden/common/models/domain/domain-service";
-import { Utils } from "@bitwarden/common/platform/misc/utils";
-
+import { NeverDomains } from "../../models/domain/domain-service";
+import { Utils } from "../../platform/misc/utils";
 import { CardView } from "../../vault/models/view/card.view";
 import {
   DelimiterPatternExpression,


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-39182

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Imports within the same package must be relative imports. This is documented here: https://contributing.bitwarden.com/contributing/code-style/web/typescript#imports-within-the-same-package . To enforce this requirement, an eslint rule has been added in https://github.com/bitwarden/clients/pull/21198 . This PR set is, per team, introducing relative self imports. These are for the most part auto-generated by the eslint rule, with some manual tweaks for e.g. import order issues after the autofix was applied.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
