### PR TITLE
Change to global environment for all pre-auth uses

### DIFF
--- a/apps/browser/src/auth/popup/account-switching/services/account-switcher.service.spec.ts
+++ b/apps/browser/src/auth/popup/account-switching/services/account-switcher.service.spec.ts
@@ -54,7 +54,7 @@ describe("AccountSwitcherService", () => {
     authService.authStatuses$ = authStatusSubject;
 
     envBSubject = new BehaviorSubject<Environment | undefined>(mockEnv as Environment);
-    environmentService.getEnvironment$.mockReturnValue(envBSubject);
+    environmentService.userEnvironment$.mockReturnValue(envBSubject);
 
     accountSwitcherService = new AccountSwitcherService(
       accountService,

--- a/apps/browser/src/auth/popup/account-switching/services/account-switcher.service.ts
+++ b/apps/browser/src/auth/popup/account-switching/services/account-switcher.service.ts
@@ -72,7 +72,7 @@ export class AccountSwitcherService {
         const hasMaxAccounts = loggedInIds.length >= this.ACCOUNT_LIMIT;
         const options: AvailableAccount[] = await Promise.all(
           loggedInIds.map(async (id: UserId) => {
-            const userEnv = await firstValueFrom(this.environmentService.getEnvironment$(id));
+            const userEnv = await firstValueFrom(this.environmentService.userEnvironment$(id));
             return {
               name: accounts[id].name ?? accounts[id].email,
               email: accounts[id].email,

--- a/apps/browser/src/auth/popup/login/extension-login-component.service.spec.ts
+++ b/apps/browser/src/auth/popup/login/extension-login-component.service.spec.ts
@@ -45,6 +45,9 @@ describe("ExtensionLoginComponentService", () => {
     environmentService.environment$ = new BehaviorSubject<Environment>({
       getWebVaultUrl: () => baseUrl,
     } as Environment);
+    environmentService.globalEnvironment$ = new BehaviorSubject<Environment>({
+      getWebVaultUrl: () => baseUrl,
+    } as Environment);
     platformUtilsService.getClientType.mockReturnValue(ClientType.Browser);
 
     TestBed.configureTestingModule({

--- a/apps/browser/src/auth/popup/login/extension-login-component.service.ts
+++ b/apps/browser/src/auth/popup/login/extension-login-component.service.ts
@@ -49,7 +49,8 @@ export class ExtensionLoginComponentService
     codeChallenge: string,
     orgSsoIdentifier?: string,
   ): Promise<void> {
-    const env = await firstValueFrom(this.environmentService.environment$);
+    // Use the global environment because the user-scoped environment is not set until authentication is complete.
+    const env = await firstValueFrom(this.environmentService.globalEnvironment$);
     const webVaultUrl = env.getWebVaultUrl();
 
     const redirectUri = webVaultUrl + "/sso-connector.html";

--- a/apps/browser/src/auth/services/extension-two-factor-auth-duo-component.service.spec.ts
+++ b/apps/browser/src/auth/services/extension-two-factor-auth-duo-component.service.spec.ts
@@ -82,6 +82,7 @@ describe("ExtensionTwoFactorAuthDuoComponentService", () => {
 
       const environmentBSubject = new BehaviorSubject(mockEnvironment);
       environmentService.environment$ = environmentBSubject.asObservable();
+      environmentService.globalEnvironment$ = environmentBSubject.asObservable();
 
       // Act
       await extensionTwoFactorAuthDuoComponentService.launchDuoFrameless(duoFramelessUrl);

--- a/apps/browser/src/auth/services/extension-two-factor-auth-duo-component.service.ts
+++ b/apps/browser/src/auth/services/extension-two-factor-auth-duo-component.service.ts
@@ -46,8 +46,9 @@ export class ExtensionTwoFactorAuthDuoComponentService implements TwoFactorAuthD
     };
 
     // we're using the connector here as a way to set a cookie with translations
-    // before continuing to the duo frameless url
-    const env = await firstValueFrom(this.environmentService.environment$);
+    // before continuing to the duo frameless url.
+    // Use the global environment because the user-scoped environment is not set until authentication is complete.
+    const env = await firstValueFrom(this.environmentService.globalEnvironment$);
     const launchUrl =
       env.getWebVaultUrl() +
       "/duo-redirect-connector.html" +

--- a/apps/browser/src/platform/services/browser-environment.service.ts
+++ b/apps/browser/src/platform/services/browser-environment.service.ts
@@ -70,7 +70,7 @@ export class BrowserEnvironmentService extends DefaultEnvironmentService {
 
   async setUrlsToManagedEnvironment() {
     const env = await this.getManagedEnvironment();
-    await this.setEnvironment(Region.SelfHosted, {
+    await this.setGlobalEnvironment(Region.SelfHosted, {
       base: env.base,
       webVault: env.webVault,
       api: env.api,

--- a/apps/cli/src/auth/commands/login.command.spec.ts
+++ b/apps/cli/src/auth/commands/login.command.spec.ts
@@ -151,6 +151,9 @@ describe("LoginCommand", () => {
     environmentService.environment$ = of({
       getWebVaultUrl: () => "https://vault.bitwarden.com",
     } as any);
+    environmentService.globalEnvironment$ = of({
+      getWebVaultUrl: () => "https://vault.bitwarden.com",
+    } as any);
 
     command = new LoginCommand(
       loginStrategyService,

--- a/apps/cli/src/auth/commands/login.command.ts
+++ b/apps/cli/src/auth/commands/login.command.ts
@@ -426,7 +426,8 @@ export class LoginCommand {
         e instanceof ErrorResponse &&
         e.message === "Username or password is incorrect. Try again."
       ) {
-        const env = await firstValueFrom(this.environmentService.environment$);
+        // Use the global environment because the user-scoped environment is not set until authentication is complete.
+        const env = await firstValueFrom(this.environmentService.globalEnvironment$);
         const host = Utils.getHost(env.getWebVaultUrl());
         return Response.error(this.i18nService.t("invalidMasterPasswordConfirmEmailAndHost", host));
       }
@@ -556,7 +557,8 @@ export class LoginCommand {
     state: string,
     orgSsoIdentifier: string,
   ): Promise<{ ssoCode: string; orgIdentifier: string }> {
-    const env = await firstValueFrom(this.environmentService.environment$);
+    // Use the global environment because the user-scoped environment is not set until authentication is complete.
+    const env = await firstValueFrom(this.environmentService.globalEnvironment$);
 
     return new Promise((resolve, reject) => {
       const callbackServer = http.createServer((req, res) => {

--- a/apps/cli/src/key-management/convert-to-key-connector.command.spec.ts
+++ b/apps/cli/src/key-management/convert-to-key-connector.command.spec.ts
@@ -134,7 +134,7 @@ describe("ConvertToKeyConnectorCommand", () => {
         organization.keyConnectorUrl,
         userId,
       );
-      expect(environmentService.setEnvironment).toHaveBeenCalledWith(Region.SelfHosted, {
+      expect(environmentService.setGlobalEnvironment).toHaveBeenCalledWith(Region.SelfHosted, {
         keyConnector: organization.keyConnectorUrl,
       } as Urls);
     });

--- a/apps/cli/src/key-management/convert-to-key-connector.command.ts
+++ b/apps/cli/src/key-management/convert-to-key-connector.command.ts
@@ -74,7 +74,7 @@ export class ConvertToKeyConnectorCommand {
       const env = await firstValueFrom(this.environmentService.environment$);
       const urls = env.getUrls();
       urls.keyConnector = organization.keyConnectorUrl;
-      await this.environmentService.setEnvironment(Region.SelfHosted, urls);
+      await this.environmentService.setGlobalEnvironment(Region.SelfHosted, urls);
 
       return Response.success();
     } else if (answer.convert === "leave") {

--- a/apps/cli/src/platform/commands/config.command.ts
+++ b/apps/cli/src/platform/commands/config.command.ts
@@ -53,7 +53,7 @@ export class ConfigCommand {
     }
 
     url = url === "null" || url === "bitwarden.com" || url === "https://bitwarden.com" ? null : url;
-    await this.environmentService.setEnvironment(Region.SelfHosted, {
+    await this.environmentService.setGlobalEnvironment(Region.SelfHosted, {
       base: url,
       webVault: options.webVault || null,
       api: options.api || null,

--- a/apps/desktop/src/app/tools/send/send.component.spec.ts
+++ b/apps/desktop/src/app/tools/send/send.component.spec.ts
@@ -81,9 +81,11 @@ describe("SendComponent", () => {
     configService.getFeatureFlag$.mockReturnValue(of(true));
 
     // Setup environmentService mock
-    environmentService.getEnvironment.mockResolvedValue({
-      getSendUrl: () => "https://send.bitwarden.com/#/",
-    } as any);
+    environmentService.userEnvironment$.mockReturnValue(
+      of({
+        getSendUrl: () => "https://send.bitwarden.com/#/",
+      } as any),
+    );
 
     // Setup i18nService mock
     i18nService.t.mockImplementation((key: string) => key);
@@ -265,7 +267,7 @@ describe("SendComponent", () => {
 
       await component["onCopySend"](mockSend);
 
-      expect(environmentService.getEnvironment).toHaveBeenCalled();
+      expect(environmentService.userEnvironment$).toHaveBeenCalled();
       expect(platformUtilsService.copyToClipboard).toHaveBeenCalledWith(
         "https://send.bitwarden.com/#/test-access-id/test-key",
       );

--- a/apps/desktop/src/app/tools/send/send.component.ts
+++ b/apps/desktop/src/app/tools/send/send.component.ts
@@ -2,8 +2,10 @@
 // @ts-strict-ignore
 import { Component, DestroyRef, inject } from "@angular/core";
 import { toSignal } from "@angular/core/rxjs-interop";
-import { combineLatest, lastValueFrom, map } from "rxjs";
+import { combineLatest, firstValueFrom, lastValueFrom, map } from "rxjs";
 
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { getUserId } from "@bitwarden/common/auth/services/account.service";
 import { EnvironmentService } from "@bitwarden/common/platform/abstractions/environment.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
@@ -58,6 +60,7 @@ export class SendComponent {
   private i18nService = inject(I18nService);
   private platformUtilsService = inject(PlatformUtilsService);
   private environmentService = inject(EnvironmentService);
+  private accountService = inject(AccountService);
   private sendApiService = inject(SendApiService);
   private dialogService = inject(DialogService);
   private toastService = inject(ToastService);
@@ -142,7 +145,8 @@ export class SendComponent {
   }
 
   protected async onCopySend(send: SendView): Promise<void> {
-    const env = await this.environmentService.getEnvironment();
+    const userId = await firstValueFrom(getUserId(this.accountService.activeAccount$));
+    const env = await firstValueFrom(this.environmentService.userEnvironment$(userId));
     const link = env.getSendUrl() + send.accessId + "/" + send.urlB64Key;
     this.platformUtilsService.copyToClipboard(link);
     this.toastService.showToast({

--- a/apps/desktop/src/auth/components/account-switcher/account-switcher-v2.component.ts
+++ b/apps/desktop/src/auth/components/account-switcher/account-switcher-v2.component.ts
@@ -117,7 +117,7 @@ export class AccountSwitcherV2Component implements OnInit {
           email: active.email,
           avatarColor,
           server: (
-            await firstValueFrom(this.environmentService.getEnvironment$(active.id))
+            await firstValueFrom(this.environmentService.userEnvironment$(active.id))
           )?.getHostname(),
         };
       }),
@@ -230,7 +230,7 @@ export class AccountSwitcherV2Component implements OnInit {
         authenticationStatus: await this.authService.getAuthStatus(userId),
         avatarColor: await firstValueFrom(this.avatarService.getUserAvatarColor$(userId as UserId)),
         server: (
-          await firstValueFrom(this.environmentService.getEnvironment$(userId as UserId))
+          await firstValueFrom(this.environmentService.userEnvironment$(userId as UserId))
         )?.getHostname(),
       };
     }

--- a/apps/desktop/src/auth/login/desktop-login-component.service.spec.ts
+++ b/apps/desktop/src/auth/login/desktop-login-component.service.spec.ts
@@ -55,6 +55,13 @@ describe("DesktopLoginComponentService", () => {
       isCloud: () => true,
       getApiUrl: () => "https://api.bitwarden.com",
     } as Environment);
+    environmentService.globalEnvironment$ = of({
+      getWebVaultUrl: () => "https://webvault.bitwarden.com",
+      getRegion: () => "US",
+      getUrls: () => ({}),
+      isCloud: () => true,
+      getApiUrl: () => "https://api.bitwarden.com",
+    } as Environment);
 
     passwordGenerationService = mock<PasswordGenerationServiceAbstraction>();
     platformUtilsService = mock<ElectronPlatformUtilsService>();

--- a/apps/desktop/src/auth/login/desktop-login-component.service.ts
+++ b/apps/desktop/src/auth/login/desktop-login-component.service.ts
@@ -55,7 +55,8 @@ export class DesktopLoginComponentService
     if (ipc.platform.isAppImage || ipc.platform.isDev) {
       await this.initiateSsoThroughLocalhostCallback(email, state, codeChallenge, orgSsoIdentifier);
     } else {
-      const env = await firstValueFrom(this.environmentService.environment$);
+      // Use the global environment because the user-scoped environment is not set until authentication is complete.
+      const env = await firstValueFrom(this.environmentService.globalEnvironment$);
       const webVaultUrl = env.getWebVaultUrl();
 
       const redirectUri = DESKTOP_SSO_CALLBACK;

--- a/apps/desktop/src/auth/services/desktop-two-factor-auth-duo-component.service.spec.ts
+++ b/apps/desktop/src/auth/services/desktop-two-factor-auth-duo-component.service.spec.ts
@@ -75,6 +75,7 @@ describe("DesktopTwoFactorAuthDuoComponentService", () => {
       } as unknown as Environment;
       const environmentBSubject = new BehaviorSubject(mockEnvironment);
       environmentService.environment$ = environmentBSubject.asObservable();
+      environmentService.globalEnvironment$ = environmentBSubject.asObservable();
 
       // Act
       await desktopTwoFactorAuthDuoComponentService.launchDuoFrameless(duoFramelessUrl);

--- a/apps/desktop/src/auth/services/desktop-two-factor-auth-duo-component.service.ts
+++ b/apps/desktop/src/auth/services/desktop-two-factor-auth-duo-component.service.ts
@@ -42,8 +42,9 @@ export class DesktopTwoFactorAuthDuoComponentService implements TwoFactorAuthDuo
     };
 
     // we're using the connector here as a way to set a cookie with translations
-    // before continuing to the duo frameless url
-    const env = await firstValueFrom(this.environmentService.environment$);
+    // before continuing to the duo frameless url.
+    // Use the global environment because the user-scoped environment is not set until authentication is complete.
+    const env = await firstValueFrom(this.environmentService.globalEnvironment$);
     const launchUrl =
       env.getWebVaultUrl() +
       "/duo-redirect-connector.html" +

--- a/apps/desktop/src/platform/services/sso-localhost-callback.service.ts
+++ b/apps/desktop/src/platform/services/sso-localhost-callback.service.ts
@@ -65,7 +65,8 @@ export class SSOLocalhostCallbackService {
     email: string,
     orgSsoIdentifier?: string,
   ): Promise<{ ssoCode: string; recvState: string }> {
-    const env = await firstValueFrom(this.environmentService.environment$);
+    // Use the global environment because the user-scoped environment is not set until authentication is complete.
+    const env = await firstValueFrom(this.environmentService.globalEnvironment$);
 
     return new Promise((resolve, reject) => {
       const callbackServer = http.createServer((req, res) => {

--- a/apps/web/src/app/platform/web-environment.service.spec.ts
+++ b/apps/web/src/app/platform/web-environment.service.spec.ts
@@ -109,20 +109,20 @@ describe("WebEnvironmentService", () => {
         expect(env.getHostname()).toEqual(PROD_US_REGION.domain);
       });
 
-      describe("setEnvironment", () => {
+      describe("setGlobalEnvironment", () => {
         it("throws an error when trying to set the environment to self-hosted", async () => {
-          await expect(service.setEnvironment(Region.SelfHosted)).rejects.toThrow(
-            "setEnvironment does not work in web for self-hosted.",
+          await expect(service.setGlobalEnvironment(Region.SelfHosted)).rejects.toThrow(
+            "setGlobalEnvironment does not work in web for self-hosted.",
           );
         });
 
         it("only returns the current env's urls when trying to set the environment to the current region", async () => {
-          const urls = await service.setEnvironment(Region.US);
+          const urls = await service.setGlobalEnvironment(Region.US);
           expect(urls).toEqual(expectedProdUSUrls);
         });
 
         it("errors if the selected region is unknown", async () => {
-          await expect(service.setEnvironment("unknown" as Region)).rejects.toThrow(
+          await expect(service.setGlobalEnvironment("unknown" as Region)).rejects.toThrow(
             "The selected region is not known as an available region.",
           );
         });
@@ -134,7 +134,7 @@ describe("WebEnvironmentService", () => {
           const newRegion = Region.EU;
           const newRegionConfig = PRODUCTION_REGIONS.find((r) => r.key === newRegion);
 
-          await service.setEnvironment(newRegion);
+          await service.setGlobalEnvironment(newRegion);
 
           expect(window.location.href).toEqual(
             newRegionConfig.urls.webVault + "/#" + routeAndQueryParams,
@@ -226,20 +226,20 @@ describe("WebEnvironmentService", () => {
         expect(env.getHostname()).toEqual(prodEURegionConfig.domain);
       });
 
-      describe("setEnvironment", () => {
+      describe("setGlobalEnvironment", () => {
         it("throws an error when trying to set the environment to self-hosted", async () => {
-          await expect(service.setEnvironment(Region.SelfHosted)).rejects.toThrow(
-            "setEnvironment does not work in web for self-hosted.",
+          await expect(service.setGlobalEnvironment(Region.SelfHosted)).rejects.toThrow(
+            "setGlobalEnvironment does not work in web for self-hosted.",
           );
         });
 
         it("only returns the current env's urls when trying to set the environment to the current region", async () => {
-          const urls = await service.setEnvironment(Region.EU);
+          const urls = await service.setGlobalEnvironment(Region.EU);
           expect(urls).toEqual(expectedProdEUUrls);
         });
 
         it("errors if the selected region is unknown", async () => {
-          await expect(service.setEnvironment("unknown" as Region)).rejects.toThrow(
+          await expect(service.setGlobalEnvironment("unknown" as Region)).rejects.toThrow(
             "The selected region is not known as an available region.",
           );
         });
@@ -251,7 +251,7 @@ describe("WebEnvironmentService", () => {
           const newRegion = Region.US;
           const newRegionConfig = PRODUCTION_REGIONS.find((r) => r.key === newRegion);
 
-          await service.setEnvironment(newRegion);
+          await service.setGlobalEnvironment(newRegion);
 
           expect(window.location.href).toEqual(
             newRegionConfig.urls.webVault + "/#" + routeAndQueryParams,
@@ -349,20 +349,20 @@ describe("WebEnvironmentService", () => {
         expect(env.getHostname()).toEqual(QA_US_WEB_REGION_CONFIG.domain);
       });
 
-      describe("setEnvironment", () => {
+      describe("setGlobalEnvironment", () => {
         it("throws an error when trying to set the environment to self-hosted", async () => {
-          await expect(service.setEnvironment(Region.SelfHosted)).rejects.toThrow(
-            "setEnvironment does not work in web for self-hosted.",
+          await expect(service.setGlobalEnvironment(Region.SelfHosted)).rejects.toThrow(
+            "setGlobalEnvironment does not work in web for self-hosted.",
           );
         });
 
         it("only returns the current env's urls when trying to set the environment to the current region", async () => {
-          const urls = await service.setEnvironment(QA_US_REGION_KEY);
+          const urls = await service.setGlobalEnvironment(QA_US_REGION_KEY);
           expect(urls).toEqual(expected_QA_US_Urls);
         });
 
         it("errors if the selected region is unknown", async () => {
-          await expect(service.setEnvironment("unknown" as Region)).rejects.toThrow(
+          await expect(service.setGlobalEnvironment("unknown" as Region)).rejects.toThrow(
             "The selected region is not known as an available region.",
           );
         });
@@ -371,7 +371,7 @@ describe("WebEnvironmentService", () => {
           const routeAndQueryParams = "/signup?example=1&another=2";
           (router as any).url = routeAndQueryParams;
 
-          await service.setEnvironment(QA_EU_REGION_KEY);
+          await service.setGlobalEnvironment(QA_EU_REGION_KEY);
 
           expect(window.location.href).toEqual(
             QA_EU_WEB_REGION_CONFIG.urls.webVault + "/#" + routeAndQueryParams,
@@ -444,20 +444,20 @@ describe("WebEnvironmentService", () => {
         expect(env.getHostname()).toEqual(QA_EU_WEB_REGION_CONFIG.domain);
       });
 
-      describe("setEnvironment", () => {
+      describe("setGlobalEnvironment", () => {
         it("throws an error when trying to set the environment to self-hosted", async () => {
-          await expect(service.setEnvironment(Region.SelfHosted)).rejects.toThrow(
-            "setEnvironment does not work in web for self-hosted.",
+          await expect(service.setGlobalEnvironment(Region.SelfHosted)).rejects.toThrow(
+            "setGlobalEnvironment does not work in web for self-hosted.",
           );
         });
 
         it("only returns the current env's urls when trying to set the environment to the current region", async () => {
-          const urls = await service.setEnvironment(QA_EU_REGION_KEY);
+          const urls = await service.setGlobalEnvironment(QA_EU_REGION_KEY);
           expect(urls).toEqual(expected_QA_EU_Urls);
         });
 
         it("errors if the selected region is unknown", async () => {
-          await expect(service.setEnvironment("unknown" as Region)).rejects.toThrow(
+          await expect(service.setGlobalEnvironment("unknown" as Region)).rejects.toThrow(
             "The selected region is not known as an available region.",
           );
         });
@@ -466,7 +466,7 @@ describe("WebEnvironmentService", () => {
           const routeAndQueryParams = "/signup?example=1&another=2";
           (router as any).url = routeAndQueryParams;
 
-          await service.setEnvironment(QA_US_REGION_KEY);
+          await service.setGlobalEnvironment(QA_US_REGION_KEY);
 
           expect(window.location.href).toEqual(
             QA_US_WEB_REGION_CONFIG.urls.webVault + "/#" + routeAndQueryParams,

--- a/apps/web/src/app/platform/web-environment.service.ts
+++ b/apps/web/src/app/platform/web-environment.service.ts
@@ -72,9 +72,9 @@ export class WebEnvironmentService extends DefaultEnvironmentService {
   }
 
   // Web setting env means navigating to a new location
-  async setEnvironment(region: Region | string, urls?: Urls): Promise<Urls> {
+  async setGlobalEnvironment(region: Region | string, urls?: Urls): Promise<Urls> {
     if (region === Region.SelfHosted) {
-      throw new Error("setEnvironment does not work in web for self-hosted.");
+      throw new Error("setGlobalEnvironment does not work in web for self-hosted.");
     }
 
     // Find the region
@@ -109,7 +109,7 @@ export class WebEnvironmentService extends DefaultEnvironmentService {
     return chosenRegionConfig.urls;
   }
 
-  getEnvironment$(userId: UserId): Observable<Environment> {
+  userEnvironment$(userId: UserId): Observable<Environment> {
     // Web does not support account switching, and even if it did, you'd be required to be the environment of where the application
     // is running.
     return this._environmentSubject.asObservable();

--- a/apps/web/src/app/tools/send/send.component.ts
+++ b/apps/web/src/app/tools/send/send.component.ts
@@ -361,7 +361,7 @@ export class SendComponent implements OnDestroy {
 
   protected async onCopySend(send: SendView): Promise<void> {
     const userId = await firstValueFrom(this.accountService.activeAccount$.pipe(map((a) => a?.id)));
-    const env = await firstValueFrom(this.environmentService.getEnvironment$(userId));
+    const env = await firstValueFrom(this.environmentService.userEnvironment$(userId));
     const link = env.getSendUrl() + send.accessId + "/" + send.urlB64Key;
     this.platformUtilsService.copyToClipboard(link);
     this.toastService.showToast({

--- a/libs/angular/src/auth/environment-selector/environment-selector.component.ts
+++ b/libs/angular/src/auth/environment-selector/environment-selector.component.ts
@@ -72,6 +72,6 @@ export class EnvironmentSelectorComponent implements OnDestroy {
       return;
     }
 
-    await this.environmentService.setEnvironment(option);
+    await this.environmentService.setGlobalEnvironment(option);
   }
 }

--- a/libs/angular/src/auth/self-hosted-env-config-dialog/self-hosted-env-config-dialog.component.ts
+++ b/libs/angular/src/auth/self-hosted-env-config-dialog/self-hosted-env-config-dialog.component.ts
@@ -171,10 +171,9 @@ export class SelfHostedEnvConfigDialogComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit() {
-    /**
-     * Populate the form with the current self-hosted environment settings.
-     */
-    this.environmentService.environment$
+    // Populate the form with the current self-hosted environment settings.
+    // Use the global environment because the user-scoped environment is not set until authentication is complete.
+    this.environmentService.globalEnvironment$
       .pipe(
         take(1),
         filter((env) => {

--- a/libs/angular/src/auth/self-hosted-env-config-dialog/self-hosted-env-config-dialog.component.ts
+++ b/libs/angular/src/auth/self-hosted-env-config-dialog/self-hosted-env-config-dialog.component.ts
@@ -207,7 +207,7 @@ export class SelfHostedEnvConfigDialogComponent implements OnInit, OnDestroy {
       return;
     }
 
-    await this.environmentService.setEnvironment(Region.SelfHosted, {
+    await this.environmentService.setGlobalEnvironment(Region.SelfHosted, {
       base: this.baseUrl.value,
       api: this.apiUrl.value,
       identity: this.identityUrl.value,

--- a/libs/auth/src/angular/login-via-auth-request/login-via-auth-request.component.ts
+++ b/libs/auth/src/angular/login-via-auth-request/login-via-auth-request.component.ts
@@ -124,8 +124,9 @@ export class LoginViaAuthRequestComponent implements OnInit, OnDestroy {
         });
       });
 
-    // Get the web vault URL from the environment service
-    this.environmentService.environment$.pipe(takeUntilDestroyed()).subscribe((env) => {
+    // Get the web vault URL from the environment service.
+    // Use the global environment because the user-scoped environment is not set until authentication is complete.
+    this.environmentService.globalEnvironment$.pipe(takeUntilDestroyed()).subscribe((env) => {
       this.webVaultUrl = env.getWebVaultUrl();
       this.deviceManagementUrl = `${this.webVaultUrl}/#/settings/security/device-management`;
     });

--- a/libs/auth/src/angular/login/login.component.ts
+++ b/libs/auth/src/angular/login/login.component.ts
@@ -210,7 +210,8 @@ export class LoginComponent implements OnInit, OnDestroy {
     // If the user switches region while on the password entry screen, we need to clear
     // any stale authentication errors from the previous region and refresh the prelogin
     // data (KDF settings) for the new environment.
-    this.environmentService.environment$
+    // Use the global environment because the user-scoped environment is not set until authentication is complete.
+    this.environmentService.globalEnvironment$
       .pipe(
         skip(1), // Skip the initial emission, only react to subsequent changes
         takeUntil(this.destroy$),
@@ -361,7 +362,8 @@ export class LoginComponent implements OnInit, OnDestroy {
       switch (error.statusCode) {
         case HttpStatusCode.BadRequest: {
           if (error.message?.toLowerCase().includes("username or password is incorrect")) {
-            const env = await firstValueFrom(this.environmentService.environment$);
+            // Use the global environment because the user-scoped environment is not set until authentication is complete.
+            const env = await firstValueFrom(this.environmentService.globalEnvironment$);
             const host = Utils.getHost(env.getWebVaultUrl());
 
             this.formGroup.controls.masterPassword.setErrors({

--- a/libs/auth/src/angular/registration/registration-env-selector/registration-env-selector.component.ts
+++ b/libs/auth/src/angular/registration/registration-env-selector/registration-env-selector.component.ts
@@ -82,7 +82,8 @@ export class RegistrationEnvSelectorComponent implements OnInit, OnDestroy {
   }
 
   private async initSelectedRegionAndListenForEnvChanges() {
-    this.environmentService.environment$
+    // Use the global environment because the user-scoped environment is not set until authentication is complete.
+    this.environmentService.globalEnvironment$
       .pipe(
         map((env: Environment) => {
           const region: Region = env.getRegion();

--- a/libs/auth/src/angular/registration/registration-env-selector/registration-env-selector.component.ts
+++ b/libs/auth/src/angular/registration/registration-env-selector/registration-env-selector.component.ts
@@ -137,7 +137,7 @@ export class RegistrationEnvSelectorComponent implements OnInit, OnDestroy {
 
             if (selectedRegion !== Region.SelfHosted) {
               this.selectedRegionChange.emit(selectedRegion);
-              return from(this.environmentService.setEnvironment(selectedRegion.key));
+              return from(this.environmentService.setGlobalEnvironment(selectedRegion.key));
             }
 
             return of(null);

--- a/libs/auth/src/angular/registration/registration-start/registration-start.stories.ts
+++ b/libs/auth/src/angular/registration/registration-start/registration-start.stories.ts
@@ -85,7 +85,7 @@ const decorators = (options: {
               { key: Region.US, domain: "bitwarden.com", urls: {} },
               { key: Region.EU, domain: "bitwarden.eu", urls: {} },
             ],
-            setEnvironment: (region: Region, urls?: Urls) => Promise.resolve({}),
+            setGlobalEnvironment: (region: Region, urls?: Urls) => Promise.resolve({}),
           } as Partial<EnvironmentService>,
         },
         {

--- a/libs/auth/src/angular/sso/sso.component.ts
+++ b/libs/auth/src/angular/sso/sso.component.ts
@@ -123,7 +123,8 @@ export class SsoComponent implements OnInit {
     private loginSuccessHandlerService: LoginSuccessHandlerService,
     private keyConnectorService: KeyConnectorService,
   ) {
-    environmentService.environment$.pipe(takeUntilDestroyed()).subscribe((env) => {
+    // Use the global environment because the user-scoped environment is not set until authentication is complete.
+    environmentService.globalEnvironment$.pipe(takeUntilDestroyed()).subscribe((env) => {
       this.redirectUri = env.getWebVaultUrl() + "/sso-connector.html";
     });
 
@@ -381,7 +382,8 @@ export class SsoComponent implements OnInit {
     // we need it on the web client to verify after the user authenticates with the identity provider and is redirected back.
     await this.ssoLoginService.setSsoState(state);
 
-    const env = await firstValueFrom(this.environmentService.environment$);
+    // Use the global environment because the user-scoped environment is not set until authentication is complete.
+    const env = await firstValueFrom(this.environmentService.globalEnvironment$);
 
     let authorizeUrl =
       env.getIdentityUrl() +

--- a/libs/auth/src/angular/two-factor-auth/child-components/two-factor-auth-webauthn/two-factor-auth-webauthn.component.ts
+++ b/libs/auth/src/angular/two-factor-auth/child-components/two-factor-auth-webauthn/two-factor-auth-webauthn.component.ts
@@ -105,7 +105,8 @@ export class TwoFactorAuthWebAuthnComponent implements OnInit, OnDestroy {
 
   private async buildWebAuthnIFrame() {
     if (this.win != null && this.webAuthnSupported) {
-      const env = await firstValueFrom(this.environmentService.environment$);
+      // Use the global environment because the user-scoped environment is not set until authentication is complete.
+      const env = await firstValueFrom(this.environmentService.globalEnvironment$);
       const webVaultUrl = env.getWebVaultUrl();
       this.webAuthnIframe = new WebAuthnIFrame(
         this.win,

--- a/libs/auth/src/angular/two-factor-auth/two-factor-auth.component.ts
+++ b/libs/auth/src/angular/two-factor-auth/two-factor-auth.component.ts
@@ -612,7 +612,8 @@ export class TwoFactorAuthComponent implements OnInit, OnDestroy {
   async use2faRecoveryCode() {
     // TODO: PM-17696 eventually we should have a consolidated recover-2fa component as a follow up
     // so that we don't have to always open a new tab for non-web clients.
-    const env = await firstValueFrom(this.environmentService.environment$);
+    // Use the global environment because the user-scoped environment is not set until authentication is complete.
+    const env = await firstValueFrom(this.environmentService.globalEnvironment$);
     const webVault = env.getWebVaultUrl();
     this.platformUtilsService.launchUri(webVault + "/#/recover-2fa");
   }

--- a/libs/auth/src/common/login-strategies/user-api-login.strategy.spec.ts
+++ b/libs/auth/src/common/login-strategies/user-api-login.strategy.spec.ts
@@ -209,6 +209,7 @@ describe("UserApiLoginStrategy", () => {
     const env = mock<Environment>();
     env.getKeyConnectorUrl.mockReturnValue(keyConnectorUrl);
     environmentService.environment$ = new BehaviorSubject(env);
+    environmentService.globalEnvironment$ = new BehaviorSubject(env);
 
     apiService.postIdentityToken.mockResolvedValue(tokenResponse);
 
@@ -225,6 +226,7 @@ describe("UserApiLoginStrategy", () => {
     const env = mock<Environment>();
     env.getKeyConnectorUrl.mockReturnValue(keyConnectorUrl);
     environmentService.environment$ = new BehaviorSubject(env);
+    environmentService.globalEnvironment$ = new BehaviorSubject(env);
 
     apiService.postIdentityToken.mockResolvedValue(tokenResponse);
 
@@ -243,6 +245,7 @@ describe("UserApiLoginStrategy", () => {
     const env = mock<Environment>();
     env.getKeyConnectorUrl.mockReturnValue(keyConnectorUrl);
     environmentService.environment$ = new BehaviorSubject(env);
+    environmentService.globalEnvironment$ = new BehaviorSubject(env);
     configService.getFeatureFlag
       .calledWith(FeatureFlag.UnlockKeyConnectorWithSdk)
       .mockResolvedValue(true);
@@ -268,6 +271,7 @@ describe("UserApiLoginStrategy", () => {
     const env = mock<Environment>();
     env.getKeyConnectorUrl.mockReturnValue(keyConnectorUrl);
     environmentService.environment$ = new BehaviorSubject(env);
+    environmentService.globalEnvironment$ = new BehaviorSubject(env);
 
     apiService.postIdentityToken.mockResolvedValue(tokenResponse);
     masterPasswordService.masterKeySubject.next(masterKey);
@@ -294,6 +298,7 @@ describe("UserApiLoginStrategy", () => {
     const env = mock<Environment>();
     env.getKeyConnectorUrl.mockReturnValue(keyConnectorUrl);
     environmentService.environment$ = new BehaviorSubject(env);
+    environmentService.globalEnvironment$ = new BehaviorSubject(env);
 
     apiService.postIdentityToken.mockResolvedValue(tokenResponse);
     masterPasswordService.masterKeySubject.next(masterKey);

--- a/libs/auth/src/common/login-strategies/user-api-login.strategy.ts
+++ b/libs/auth/src/common/login-strategies/user-api-login.strategy.ts
@@ -60,7 +60,8 @@ export class UserApiLoginStrategy extends LoginStrategy {
       (await this.configService.getFeatureFlag(FeatureFlag.UnlockKeyConnectorWithSdk));
 
     if (!sdkHandledKeyConnector && response.apiUseKeyConnector) {
-      const env = await firstValueFrom(this.environmentService.environment$);
+      // Use the global environment because the user-scoped environment is not set until authentication is complete.
+      const env = await firstValueFrom(this.environmentService.globalEnvironment$);
       const keyConnectorUrl = env.getKeyConnectorUrl();
       await this.keyConnectorService.setMasterKeyFromUrl(keyConnectorUrl, userId);
     }

--- a/libs/common/src/auth/password-prelogin/password-prelogin-api.service.spec.ts
+++ b/libs/common/src/auth/password-prelogin/password-prelogin-api.service.spec.ts
@@ -26,6 +26,9 @@ describe("PasswordPreloginApiService", () => {
     environmentService.environment$ = of({
       getIdentityUrl: () => identityUrl,
     } satisfies Partial<Environment> as Environment);
+    environmentService.globalEnvironment$ = of({
+      getIdentityUrl: () => identityUrl,
+    } satisfies Partial<Environment> as Environment);
 
     sut = new PasswordPreloginApiService(apiService, environmentService);
   });
@@ -83,6 +86,9 @@ describe("PasswordPreloginApiService", () => {
     it("uses the identity url from the environment", async () => {
       const customIdentityUrl = "https://custom.identity.bitwarden.com";
       environmentService.environment$ = of({
+        getIdentityUrl: () => customIdentityUrl,
+      } satisfies Partial<Environment> as Environment);
+      environmentService.globalEnvironment$ = of({
         getIdentityUrl: () => customIdentityUrl,
       } satisfies Partial<Environment> as Environment);
 

--- a/libs/common/src/auth/password-prelogin/password-prelogin-api.service.ts
+++ b/libs/common/src/auth/password-prelogin/password-prelogin-api.service.ts
@@ -13,7 +13,8 @@ export class PasswordPreloginApiService {
   ) {}
 
   async getPreloginData(request: PasswordPreloginRequest): Promise<PasswordPreloginResponse> {
-    const env = await firstValueFrom(this.environmentService.environment$);
+    // Use the global environment because the user-scoped environment is not set until authentication is complete.
+    const env = await firstValueFrom(this.environmentService.globalEnvironment$);
     const r = await this.apiService.send(
       "POST",
       "/accounts/prelogin/password",

--- a/libs/common/src/auth/services/account-api.service.ts
+++ b/libs/common/src/auth/services/account-api.service.ts
@@ -36,7 +36,8 @@ export class AccountApiServiceImplementation implements AccountApiService {
   async registerSendVerificationEmail(
     request: RegisterSendVerificationEmailRequest,
   ): Promise<null | string> {
-    const env = await firstValueFrom(this.environmentService.environment$);
+    // Use the global environment because the user-scoped environment is not set until authentication is complete.
+    const env = await firstValueFrom(this.environmentService.globalEnvironment$);
 
     try {
       const response = await this.apiService.send(
@@ -65,7 +66,8 @@ export class AccountApiServiceImplementation implements AccountApiService {
   async registerVerificationEmailClicked(
     request: RegisterVerificationEmailClickedRequest,
   ): Promise<void> {
-    const env = await firstValueFrom(this.environmentService.environment$);
+    // Use the global environment because the user-scoped environment is not set until authentication is complete.
+    const env = await firstValueFrom(this.environmentService.globalEnvironment$);
 
     try {
       const response = await this.apiService.send(
@@ -85,7 +87,8 @@ export class AccountApiServiceImplementation implements AccountApiService {
   }
 
   async registerFinish(request: RegisterFinishRequest): Promise<void> {
-    const env = await firstValueFrom(this.environmentService.environment$);
+    // Use the global environment because the user-scoped environment is not set until authentication is complete.
+    const env = await firstValueFrom(this.environmentService.globalEnvironment$);
 
     try {
       const response = await this.apiService.send(

--- a/libs/common/src/auth/services/anonymous-hub.service.ts
+++ b/libs/common/src/auth/services/anonymous-hub.service.ts
@@ -33,7 +33,10 @@ export class AnonymousHubService implements AnonymousHubServiceAbstraction {
   ) {}
 
   async createHubConnection(token: string) {
-    this.url = (await firstValueFrom(this.environmentService.environment$)).getNotificationsUrl();
+    // Use the global environment because the user-scoped environment is not set until authentication is complete.
+    this.url = (
+      await firstValueFrom(this.environmentService.globalEnvironment$)
+    ).getNotificationsUrl();
     if (!this.url.startsWith("https://") && !this.platformUtilsService.isDev()) {
       throw new InsecureUrlNotAllowedError();
     }

--- a/libs/common/src/auth/services/sso-login/sso-login.service.spec.ts
+++ b/libs/common/src/auth/services/sso-login/sso-login.service.spec.ts
@@ -51,7 +51,7 @@ describe("SSOLoginService ", () => {
     mockPolicyService = mock<PolicyService>();
     mockEnvironmentService = mock<EnvironmentService>();
 
-    mockEnvironmentService.getEnvironment$.mockReturnValue(
+    mockEnvironmentService.userEnvironment$.mockReturnValue(
       of({ getWebVaultUrl: () => webVaultUrl } as Environment),
     );
 
@@ -220,7 +220,7 @@ describe("SSOLoginService ", () => {
         await sut.updateSsoRequiredCache(email, userId);
 
         // Assert
-        expect(mockEnvironmentService.getEnvironment$).toHaveBeenCalledWith(userId);
+        expect(mockEnvironmentService.userEnvironment$).toHaveBeenCalledWith(userId);
       });
     });
 
@@ -265,7 +265,7 @@ describe("SSOLoginService ", () => {
         await sut.updateSsoRequiredCache(email, userId);
 
         // Assert
-        expect(mockEnvironmentService.getEnvironment$).toHaveBeenCalledWith(userId);
+        expect(mockEnvironmentService.userEnvironment$).toHaveBeenCalledWith(userId);
       });
     });
 
@@ -361,13 +361,13 @@ describe("SSOLoginService ", () => {
       await sut.removeFromSsoRequiredCacheIfPresent(email, userId);
 
       // Assert
-      expect(mockEnvironmentService.getEnvironment$).toHaveBeenCalledWith(userId);
+      expect(mockEnvironmentService.userEnvironment$).toHaveBeenCalledWith(userId);
     });
 
     it("should NOT remove an entry when the email matches but the resolved webVaultUrl differs", async () => {
       // Arrange
       const euUrl = "https://vault.bitwarden.eu";
-      mockEnvironmentService.getEnvironment$.mockReturnValue(
+      mockEnvironmentService.userEnvironment$.mockReturnValue(
         of({ getWebVaultUrl: () => euUrl } as Environment),
       );
       mockStateProvider.global

--- a/libs/common/src/auth/services/sso-login/sso-login.service.ts
+++ b/libs/common/src/auth/services/sso-login/sso-login.service.ts
@@ -164,7 +164,7 @@ export class SsoLoginService implements SsoLoginServiceAbstraction {
    * Makes an `SsoRequiredCacheEntry` object based on the user's email and resolved webVaultUrl
    */
   private async makeEntry(email: string, userId: UserId): Promise<SsoRequiredCacheEntry> {
-    const env = await firstValueFrom(this.environmentService.getEnvironment$(userId));
+    const env = await firstValueFrom(this.environmentService.userEnvironment$(userId));
     const webVaultUrl = env.getWebVaultUrl();
 
     return { email: email.toLowerCase(), webVaultUrl };

--- a/libs/common/src/auth/services/webauthn-login/webauthn-login-api.service.ts
+++ b/libs/common/src/auth/services/webauthn-login/webauthn-login-api.service.ts
@@ -13,7 +13,8 @@ export class WebAuthnLoginApiService implements WebAuthnLoginApiServiceAbstracti
   ) {}
 
   async getCredentialAssertionOptions(): Promise<CredentialAssertionOptionsResponse> {
-    const env = await firstValueFrom(this.environmentService.environment$);
+    // Use the global environment because the user-scoped environment is not set until authentication is complete.
+    const env = await firstValueFrom(this.environmentService.globalEnvironment$);
     const response = await this.apiService.send(
       "GET",
       `/accounts/webauthn/assertion-options`,

--- a/libs/common/src/key-management/shared-unlock/shared-unlock-driver.ts
+++ b/libs/common/src/key-management/shared-unlock/shared-unlock-driver.ts
@@ -83,7 +83,7 @@ export class JsSharedUnlockDriver implements SharedUnlockDriver {
 
   async get_vault_url(user_id: UserId): Promise<string> {
     const environment = await firstValueFrom(
-      this.environmentService.getEnvironment$(fromSdkUserId(user_id)),
+      this.environmentService.userEnvironment$(fromSdkUserId(user_id)),
     );
     return environment.getWebVaultUrl();
   }

--- a/libs/common/src/platform/abstractions/environment.service.ts
+++ b/libs/common/src/platform/abstractions/environment.service.ts
@@ -99,6 +99,9 @@ export interface Environment {
  * The environment service. Provides access to set the current environment urls and region.
  */
 export abstract class EnvironmentService {
+  /**
+   * @deprecated Use {@link globalEnvironment$} or {@link userEnvironment$} instead.
+   */
   abstract environment$: Observable<Environment>;
 
   /**
@@ -121,7 +124,7 @@ export abstract class EnvironmentService {
   /**
    * Set the global environment.
    */
-  abstract setEnvironment(region: Region, urls?: Urls): Promise<Urls>;
+  abstract setGlobalEnvironment(region: Region, urls?: Urls): Promise<Urls>;
 
   /**
    * Seed the environment state for a given user based on the global environment.
@@ -140,12 +143,7 @@ export abstract class EnvironmentService {
   abstract setCloudRegion(userId: UserId | null, region: Region): Promise<void>;
 
   /**
-   * Get the environment from state. Useful if you need to get the environment for another user.
+   * Get the environment from state for a user.
    */
-  abstract getEnvironment$(userId: UserId): Observable<Environment>;
-
-  /**
-   * @deprecated Use {@link getEnvironment$} instead.
-   */
-  abstract getEnvironment(userId?: string): Promise<Environment | undefined>;
+  abstract userEnvironment$(userId: UserId): Observable<Environment>;
 }

--- a/libs/common/src/platform/server-notifications/internal/default-server-notifications.multiuser.spec.ts
+++ b/libs/common/src/platform/server-notifications/internal/default-server-notifications.multiuser.spec.ts
@@ -78,7 +78,7 @@ describe("DefaultServerNotificationsService (multi-user)", () => {
     } as Environment);
     environmentConfigurationService.environment$ = environmentConfiguration$ as any;
     // Ensure user-scoped environment lookups return the same test environment stream
-    environmentConfigurationService.getEnvironment$.mockImplementation(
+    environmentConfigurationService.userEnvironment$.mockImplementation(
       (_userId: UserId) => environmentConfiguration$.asObservable() as any,
     );
 

--- a/libs/common/src/platform/server-notifications/internal/default-server-notifications.service.spec.ts
+++ b/libs/common/src/platform/server-notifications/internal/default-server-notifications.service.spec.ts
@@ -93,7 +93,7 @@ describe("NotificationsService", () => {
 
     environmentService.environment$ = environment;
     // Ensure user-scoped environment lookups return the same test environment stream
-    environmentService.getEnvironment$.mockImplementation(
+    environmentService.userEnvironment$.mockImplementation(
       (_userId: UserId) => environment.asObservable() as any,
     );
 

--- a/libs/common/src/platform/server-notifications/internal/default-server-notifications.service.ts
+++ b/libs/common/src/platform/server-notifications/internal/default-server-notifications.service.ts
@@ -95,7 +95,7 @@ export class DefaultServerNotificationsService implements ServerNotificationsSer
    * @param userId The user id of the user to get the push server notifications for.
    */
   private userNotifications$(userId: UserId) {
-    return this.environmentService.getEnvironment$(userId).pipe(
+    return this.environmentService.userEnvironment$(userId).pipe(
       map((env) => env.getNotificationsUrl()),
       distinctUntilChanged(),
       switchMap((notificationsUrl) => {

--- a/libs/common/src/platform/services/config/config.service.spec.ts
+++ b/libs/common/src/platform/services/config/config.service.spec.ts
@@ -75,7 +75,7 @@ describe("ConfigService", () => {
     });
 
     beforeEach(() => {
-      Matrix.autoMockMethod(environmentService.getEnvironment$, () => environmentSubject);
+      Matrix.autoMockMethod(environmentService.userEnvironment$, () => environmentSubject);
       environmentService.globalEnvironment$ = environmentSubject;
       sut = new DefaultConfigService(
         configApiService,
@@ -231,7 +231,7 @@ describe("ConfigService", () => {
         beforeEach(() => {
           globalState.stateSubject.next(globalStored);
           userState.nextState(userStored);
-          Matrix.autoMockMethod(environmentService.getEnvironment$, () => environmentSubject);
+          Matrix.autoMockMethod(environmentService.userEnvironment$, () => environmentSubject);
         });
         it("does not fetch from server", async () => {
           await firstValueFrom(sut.serverConfig$);
@@ -283,7 +283,7 @@ describe("ConfigService", () => {
     beforeEach(() => {
       environmentSubject = new Subject<Environment>();
       environmentService.globalEnvironment$ = environmentSubject;
-      Matrix.autoMockMethod(environmentService.getEnvironment$, () => environmentSubject);
+      Matrix.autoMockMethod(environmentService.userEnvironment$, () => environmentSubject);
       sut = new DefaultConfigService(
         configApiService,
         environmentService,
@@ -377,7 +377,7 @@ describe("ConfigService", () => {
     });
 
     beforeEach(() => {
-      Matrix.autoMockMethod(environmentService.getEnvironment$, () => environmentSubject);
+      Matrix.autoMockMethod(environmentService.userEnvironment$, () => environmentSubject);
       environmentService.globalEnvironment$ = environmentSubject;
 
       // Provide a fresh server config so serverConfig$ resolves without fetching
@@ -462,7 +462,7 @@ describe("ConfigService", () => {
     beforeEach(async () => {
       const config = serverConfigFactory("existing-data", tooOld);
       environmentService.globalEnvironment$ = environmentSubject;
-      Matrix.autoMockMethod(environmentService.getEnvironment$, () => environmentSubject);
+      Matrix.autoMockMethod(environmentService.userEnvironment$, () => environmentSubject);
 
       globalState.stateSubject.next({ [apiUrl(0)]: config });
       userState.stateSubject.next({

--- a/libs/common/src/platform/services/config/default-config.service.ts
+++ b/libs/common/src/platform/services/config/default-config.service.ts
@@ -122,7 +122,7 @@ export class DefaultConfigService implements ConfigService {
 
             return combineLatest([
               this.environmentService
-                .getEnvironment$(userId)
+                .userEnvironment$(userId)
                 .pipe(distinctUntilChanged(environmentComparer)),
               this.userConfigFor$(userId),
             ]).pipe(

--- a/libs/common/src/platform/services/default-environment.service.spec.ts
+++ b/libs/common/src/platform/services/default-environment.service.spec.ts
@@ -176,7 +176,7 @@ describe("EnvironmentService", () => {
         // User clicks EU in the environment selector → setEnvironment(EU) → writes GLOBAL
         // Without fix: environment$ watches USER state (which is null and defaults to US) and ignores GLOBAL write and the value stays US
         // With fix: environment$ falls back to GLOBAL, so setEnvironment(EU) updates GLOBAL and emits EU
-        await sut.setEnvironment(Region.EU);
+        await sut.setGlobalEnvironment(Region.EU);
         await awaitAsync();
 
         const env = await firstValueFrom(sut.environment$);
@@ -345,9 +345,9 @@ describe("EnvironmentService", () => {
     });
   });
 
-  describe("setEnvironment", () => {
+  describe("setGlobalEnvironment", () => {
     it("self-hosted with base-url", async () => {
-      await sut.setEnvironment(Region.SelfHosted, {
+      await sut.setGlobalEnvironment(Region.SelfHosted, {
         base: "base.example.com",
       });
       await awaitAsync();
@@ -373,7 +373,7 @@ describe("EnvironmentService", () => {
       let env = await firstValueFrom(sut.environment$);
       expect(env.getScimUrl()).toBe("https://scim.bitwarden.com/v2");
 
-      await sut.setEnvironment(Region.SelfHosted, {
+      await sut.setGlobalEnvironment(Region.SelfHosted, {
         base: "base.example.com",
         api: "api.example.com",
         identity: "identity.example.com",
@@ -402,7 +402,7 @@ describe("EnvironmentService", () => {
     });
 
     it("sets the region", async () => {
-      await sut.setEnvironment(Region.US);
+      await sut.setGlobalEnvironment(Region.US);
 
       const data = await firstValueFrom(sut.environment$);
 
@@ -410,7 +410,7 @@ describe("EnvironmentService", () => {
     });
 
     it("normalizes a blank send url to null", async () => {
-      await sut.setEnvironment(Region.SelfHosted, {
+      await sut.setGlobalEnvironment(Region.SelfHosted, {
         base: "base.example.com",
         send: "", // empty string from the dialog — should be normalized to null
       });
@@ -423,7 +423,7 @@ describe("EnvironmentService", () => {
     });
   });
 
-  describe("getEnvironment$", () => {
+  describe("userEnvironment$", () => {
     it.each([
       { region: Region.US, expectedHost: "bitwarden.com" },
       { region: Region.EU, expectedHost: "bitwarden.eu" },
@@ -433,7 +433,7 @@ describe("EnvironmentService", () => {
 
       await switchUser(testUser);
 
-      const env = await firstValueFrom(sut.getEnvironment$(alternateTestUser));
+      const env = await firstValueFrom(sut.userEnvironment$(alternateTestUser));
       expect(env?.getHostname()).toBe(expectedHost);
     });
 
@@ -446,31 +446,7 @@ describe("EnvironmentService", () => {
 
       await switchUser(testUser);
 
-      const env = await firstValueFrom(sut.getEnvironment$(alternateTestUser));
-      expect(env?.getHostname()).toBe("base.example.com");
-    });
-  });
-
-  describe("getEnvironment (deprecated)", () => {
-    it("gets self hosted env from active user when no user passed in", async () => {
-      const selfHostUserUrls = new EnvironmentUrls();
-      selfHostUserUrls.base = "https://base.example.com";
-      setUserData(Region.SelfHosted, selfHostUserUrls);
-
-      await switchUser(testUser);
-
-      const env = await sut.getEnvironment();
-      expect(env?.getHostname()).toBe("base.example.com");
-    });
-
-    it("gets self hosted env from passed in user", async () => {
-      const selfHostUserUrls = new EnvironmentUrls();
-      selfHostUserUrls.base = "https://base.example.com";
-      setUserData(Region.SelfHosted, selfHostUserUrls);
-
-      await switchUser(testUser);
-
-      const env = await sut.getEnvironment(testUser);
+      const env = await firstValueFrom(sut.userEnvironment$(alternateTestUser));
       expect(env?.getHostname()).toBe("base.example.com");
     });
   });

--- a/libs/common/src/platform/services/default-environment.service.ts
+++ b/libs/common/src/platform/services/default-environment.service.ts
@@ -215,7 +215,7 @@ export class DefaultEnvironmentService implements EnvironmentService {
     return this.availableRegions().find((r) => r.key === region);
   }
 
-  async setEnvironment(region: Region, urls?: Urls): Promise<Urls> {
+  async setGlobalEnvironment(region: Region, urls?: Urls): Promise<Urls> {
     // Unknown regions are treated as self-hosted
     if (this.getRegionConfig(region) == null) {
       region = Region.SelfHosted;
@@ -298,22 +298,12 @@ export class DefaultEnvironmentService implements EnvironmentService {
     }
   }
 
-  getEnvironment$(userId: UserId): Observable<Environment> {
+  userEnvironment$(userId: UserId): Observable<Environment> {
     return this.stateProvider.getUser(userId, USER_ENVIRONMENT_KEY).state$.pipe(
       map((state) => {
         return this.buildEnvironment(state?.region, state?.urls);
       }),
     );
-  }
-
-  /**
-   * @deprecated Use getEnvironment$ instead.
-   */
-  async getEnvironment(userId?: UserId): Promise<Environment | undefined> {
-    // Add backwards compatibility support for null userId
-    const definedUserId = userId ?? (await firstValueFrom(this.activeAccountId$));
-
-    return firstValueFrom(this.getEnvironment$(definedUserId));
   }
 
   async seedUserEnvironment(userId: UserId) {

--- a/libs/common/src/platform/services/sdk/default-sdk.service.spec.ts
+++ b/libs/common/src/platform/services/sdk/default-sdk.service.spec.ts
@@ -92,7 +92,7 @@ describe("DefaultSdkService", () => {
     describe("given the user is logged in", () => {
       const userId = "0da62ebd-98bb-4f42-a846-64e8555087d7" as UserId;
       beforeEach(() => {
-        environmentService.getEnvironment$
+        environmentService.userEnvironment$
           .calledWith(userId)
           .mockReturnValue(new BehaviorSubject(mock<Environment>()));
         accountService.accounts$ = of({
@@ -210,7 +210,7 @@ describe("DefaultSdkService", () => {
 
         it("completes the subscription and frees the internal SDK client when the environment is unset (logout)", async () => {
           const env$ = new BehaviorSubject<Environment | undefined>(mock<Environment>());
-          environmentService.getEnvironment$
+          environmentService.userEnvironment$
             .calledWith(userId)
             .mockReturnValue(env$ as BehaviorSubject<Environment>);
 

--- a/libs/common/src/platform/services/sdk/default-sdk.service.ts
+++ b/libs/common/src/platform/services/sdk/default-sdk.service.ts
@@ -192,7 +192,7 @@ export class DefaultSdkService implements SdkService {
       .pipe(distinctUntilChanged());
 
     const client$ = combineLatest([
-      this.environmentService.getEnvironment$(userId),
+      this.environmentService.userEnvironment$(userId),
       account$,
       kdfParams$,
       accountCryptographicState$,

--- a/libs/common/src/platform/services/sdk/register-sdk.service.spec.ts
+++ b/libs/common/src/platform/services/sdk/register-sdk.service.spec.ts
@@ -72,7 +72,7 @@ describe("DefaultRegisterSdkService", () => {
     describe("given the user is logged in", () => {
       const userId = "0da62ebd-98bb-4f42-a846-64e8555087d7" as UserId;
       beforeEach(() => {
-        environmentService.getEnvironment$
+        environmentService.userEnvironment$
           .calledWith(userId)
           .mockReturnValue(new BehaviorSubject(mock<Environment>()));
         accountService.accounts$ = of({
@@ -149,7 +149,7 @@ describe("DefaultRegisterSdkService", () => {
       const userId = "0da62ebd-98bb-4f42-a846-64e8555087d7" as UserId;
 
       beforeEach(() => {
-        environmentService.getEnvironment$
+        environmentService.userEnvironment$
           .calledWith(userId)
           .mockReturnValue(new BehaviorSubject(mock<Environment>()));
         accountService.accounts$ = of({});

--- a/libs/common/src/platform/services/sdk/register-sdk.service.ts
+++ b/libs/common/src/platform/services/sdk/register-sdk.service.ts
@@ -125,7 +125,7 @@ export class DefaultRegisterSdkService implements RegisterSdkService {
     );
 
     const client$ = combineLatest([
-      this.environmentService.getEnvironment$(userId),
+      this.environmentService.userEnvironment$(userId),
       account$,
       SdkLoadService.Ready, // Makes sure we wait (once) for the SDK to be loaded
     ]).pipe(

--- a/libs/common/src/services/api.service.spec.ts
+++ b/libs/common/src/services/api.service.spec.ts
@@ -86,7 +86,7 @@ describe("ApiService", () => {
         getApiUrl: () => "https://example.com",
       } satisfies Partial<Environment> as Environment);
 
-      environmentService.getEnvironment$.mockReturnValue(
+      environmentService.userEnvironment$.mockReturnValue(
         of({
           getApiUrl: () => "https://authed.example.com",
         } satisfies Partial<Environment> as Environment),
@@ -146,7 +146,7 @@ describe("ApiService", () => {
         getApiUrl: () => "https://example.com",
       } satisfies Partial<Environment> as Environment);
 
-      environmentService.getEnvironment$.calledWith(testInactiveUser).mockReturnValueOnce(
+      environmentService.userEnvironment$.calledWith(testInactiveUser).mockReturnValueOnce(
         of({
           getApiUrl: () => "https://inactive.example.com",
         } satisfies Partial<Environment> as Environment),
@@ -235,7 +235,7 @@ describe("ApiService", () => {
     ];
 
     it.each(cases)("$name does", async ({ authedOrUserId, expectedEffectiveUser }) => {
-      environmentService.getEnvironment$.calledWith(expectedEffectiveUser).mockReturnValue(
+      environmentService.userEnvironment$.calledWith(expectedEffectiveUser).mockReturnValue(
         of({
           getApiUrl: () => `https://${expectedEffectiveUser}.example.com`,
           getIdentityUrl: () => `https://${expectedEffectiveUser}.identity.example.com`,
@@ -381,7 +381,7 @@ describe("ApiService", () => {
   it.each(errorData)(
     "throws error-like response when not ok response with $name",
     async ({ input, error }) => {
-      environmentService.getEnvironment$.calledWith(testActiveUser).mockReturnValue(
+      environmentService.userEnvironment$.calledWith(testActiveUser).mockReturnValue(
         of({
           getApiUrl: () => "https://example.com",
         } satisfies Partial<Environment> as Environment),
@@ -418,7 +418,7 @@ describe("ApiService", () => {
   );
 
   it("throws error when trying to fetch an insecure URL", async () => {
-    environmentService.getEnvironment$.calledWith(testActiveUser).mockReturnValue(
+    environmentService.userEnvironment$.calledWith(testActiveUser).mockReturnValue(
       of({
         getApiUrl: () => "http://example.com",
       } satisfies Partial<Environment> as Environment),
@@ -461,7 +461,7 @@ describe("ApiService", () => {
       // 4. refreshToken makes an HTTP call to /connect/token to get new tokens
       // 5. setTokens is called to store the new tokens, returning the refreshed access token
       // 6. Request is retried with the refreshed token and succeeds
-      environmentService.getEnvironment$.calledWith(testActiveUser).mockReturnValue(
+      environmentService.userEnvironment$.calledWith(testActiveUser).mockReturnValue(
         of({
           getApiUrl: () => "https://example.com",
           getIdentityUrl: () => "https://identity.example.com",
@@ -612,7 +612,7 @@ describe("ApiService", () => {
     });
 
     it("does not retry when request returns non-401 error", async () => {
-      environmentService.getEnvironment$.calledWith(testActiveUser).mockReturnValue(
+      environmentService.userEnvironment$.calledWith(testActiveUser).mockReturnValue(
         of({
           getApiUrl: () => "https://example.com",
           getIdentityUrl: () => "https://identity.example.com",
@@ -701,7 +701,7 @@ describe("ApiService", () => {
         getApiUrl: () => "https://example.com",
       } satisfies Partial<Environment> as Environment);
 
-      environmentService.getEnvironment$.calledWith(testActiveUser).mockReturnValue(
+      environmentService.userEnvironment$.calledWith(testActiveUser).mockReturnValue(
         of({
           getApiUrl: () => "https://example.com",
           getIdentityUrl: () => "https://identity.example.com",
@@ -762,14 +762,14 @@ describe("ApiService", () => {
         }),
       } satisfies ObservedValueOf<AccountService["activeAccount$"]>);
 
-      environmentService.getEnvironment$.calledWith(testActiveUser).mockReturnValue(
+      environmentService.userEnvironment$.calledWith(testActiveUser).mockReturnValue(
         of({
           getApiUrl: () => "https://example.com",
           getIdentityUrl: () => "https://identity.example.com",
         } satisfies Partial<Environment> as Environment),
       );
 
-      environmentService.getEnvironment$.calledWith(testInactiveUser).mockReturnValue(
+      environmentService.userEnvironment$.calledWith(testInactiveUser).mockReturnValue(
         of({
           getApiUrl: () => "https://inactive.example.com",
           getIdentityUrl: () => "https://identity.inactive.example.com",
@@ -909,7 +909,7 @@ describe("ApiService", () => {
     });
 
     it("throws error when retry also returns 401", async () => {
-      environmentService.getEnvironment$.calledWith(testActiveUser).mockReturnValue(
+      environmentService.userEnvironment$.calledWith(testActiveUser).mockReturnValue(
         of({
           getApiUrl: () => "https://example.com",
           getIdentityUrl: () => "https://identity.example.com",
@@ -1030,7 +1030,7 @@ describe("ApiService", () => {
       // 5. Request B should wait for A's refresh to complete (via refreshTokenPromise cache)
       // 6. Both requests retry with the new token
 
-      environmentService.getEnvironment$.calledWith(testActiveUser).mockReturnValue(
+      environmentService.userEnvironment$.calledWith(testActiveUser).mockReturnValue(
         of({
           getApiUrl: () => "https://example.com",
           getIdentityUrl: () => "https://identity.example.com",
@@ -1170,7 +1170,7 @@ describe("ApiService", () => {
 
   describe("When 403 Forbidden response is received from API request", () => {
     it("logs out the authenticated user", async () => {
-      environmentService.getEnvironment$.calledWith(testActiveUser).mockReturnValue(
+      environmentService.userEnvironment$.calledWith(testActiveUser).mockReturnValue(
         of({
           getApiUrl: () => "https://example.com",
         } satisfies Partial<Environment> as Environment),
@@ -1342,7 +1342,7 @@ describe("ApiService", () => {
     const refreshedAccessToken = "refreshed_access_token";
 
     beforeEach(() => {
-      environmentService.getEnvironment$.calledWith(userId).mockReturnValue(
+      environmentService.userEnvironment$.calledWith(userId).mockReturnValue(
         of({
           getIdentityUrl: () => "https://identity.example.com",
         } satisfies Partial<Environment> as Environment),

--- a/libs/common/src/services/api.service.spec.ts
+++ b/libs/common/src/services/api.service.spec.ts
@@ -83,7 +83,10 @@ describe("ApiService", () => {
   describe("send", () => {
     it("handles ok GET", async () => {
       environmentService.environment$ = of({
-        getApiUrl: () => "https://example.com",
+        getApiUrl: () => "https://user-scoped.example.com",
+      } satisfies Partial<Environment> as Environment);
+      environmentService.globalEnvironment$ = of({
+        getApiUrl: () => "https://global.example.com",
       } satisfies Partial<Environment> as Environment);
 
       environmentService.userEnvironment$.mockReturnValue(
@@ -143,7 +146,10 @@ describe("ApiService", () => {
 
     it("authenticates with non-active user when user is passed in", async () => {
       environmentService.environment$ = of({
-        getApiUrl: () => "https://example.com",
+        getApiUrl: () => "https://user-scoped.example.com",
+      } satisfies Partial<Environment> as Environment);
+      environmentService.globalEnvironment$ = of({
+        getApiUrl: () => "https://global.example.com",
       } satisfies Partial<Environment> as Environment);
 
       environmentService.userEnvironment$.calledWith(testInactiveUser).mockReturnValueOnce(
@@ -573,7 +579,10 @@ describe("ApiService", () => {
 
     it("does not retry when request has no access token and returns 401", async () => {
       environmentService.environment$ = of({
-        getApiUrl: () => "https://example.com",
+        getApiUrl: () => "https://user-scoped.example.com",
+      } satisfies Partial<Environment> as Environment);
+      environmentService.globalEnvironment$ = of({
+        getApiUrl: () => "https://global.example.com",
       } satisfies Partial<Environment> as Environment);
 
       httpOperations.createRequest.mockImplementation((url, request) => {
@@ -609,6 +618,8 @@ describe("ApiService", () => {
 
       // Should only be called once (no retry)
       expect(nativeFetch).toHaveBeenCalledTimes(1);
+      // Unauthenticated requests must resolve their URL via the global environment.
+      expect(nativeFetch.mock.calls[0][0].url).toBe("https://global.example.com/something");
     });
 
     it("does not retry when request returns non-401 error", async () => {
@@ -659,7 +670,10 @@ describe("ApiService", () => {
 
     it("does not attempt to log out unauthenticated user", async () => {
       environmentService.environment$ = of({
-        getApiUrl: () => "https://example.com",
+        getApiUrl: () => "https://user-scoped.example.com",
+      } satisfies Partial<Environment> as Environment);
+      environmentService.globalEnvironment$ = of({
+        getApiUrl: () => "https://global.example.com",
       } satisfies Partial<Environment> as Environment);
 
       httpOperations.createRequest.mockImplementation((url, request) => {
@@ -694,11 +708,16 @@ describe("ApiService", () => {
       ).rejects.toMatchObject({ message: "Unauthorized" });
 
       expect(logoutCallback).not.toHaveBeenCalled();
+      // Unauthenticated requests must resolve their URL via the global environment.
+      expect(nativeFetch.mock.calls[0][0].url).toBe("https://global.example.com/something");
     });
 
     it("does not retry when hasResponse is false", async () => {
       environmentService.environment$ = of({
-        getApiUrl: () => "https://example.com",
+        getApiUrl: () => "https://user-scoped.example.com",
+      } satisfies Partial<Environment> as Environment);
+      environmentService.globalEnvironment$ = of({
+        getApiUrl: () => "https://global.example.com",
       } satisfies Partial<Environment> as Environment);
 
       environmentService.userEnvironment$.calledWith(testActiveUser).mockReturnValue(
@@ -1215,7 +1234,10 @@ describe("ApiService", () => {
 
     it("does not attempt to log out unauthenticated user", async () => {
       environmentService.environment$ = of({
-        getApiUrl: () => "https://example.com",
+        getApiUrl: () => "https://user-scoped.example.com",
+      } satisfies Partial<Environment> as Environment);
+      environmentService.globalEnvironment$ = of({
+        getApiUrl: () => "https://global.example.com",
       } satisfies Partial<Environment> as Environment);
 
       httpOperations.createRequest.mockImplementation((url, request) => {
@@ -1250,6 +1272,8 @@ describe("ApiService", () => {
       ).rejects.toMatchObject({ message: "Forbidden" });
 
       expect(logoutCallback).not.toHaveBeenCalled();
+      // Unauthenticated requests must resolve their URL via the global environment.
+      expect(nativeFetch.mock.calls[0][0].url).toBe("https://global.example.com/something");
     });
   });
 

--- a/libs/common/src/services/api.service.ts
+++ b/libs/common/src/services/api.service.ts
@@ -188,7 +188,8 @@ export class ApiService implements ApiServiceAbstraction {
         ? request.toIdentityToken()
         : request.toIdentityToken(this.platformUtilsService.getClientType());
 
-    const env = await firstValueFrom(this.environmentService.environment$);
+    // Use the global environment because the user-scoped environment is not set until authentication is complete.
+    const env = await firstValueFrom(this.environmentService.globalEnvironment$);
 
     const response = await this.fetch(
       this.httpOperations.createRequest(env.getIdentityUrl() + "/connect/token", {
@@ -1199,7 +1200,7 @@ export class ApiService implements ApiServiceAbstraction {
 
     const env = await firstValueFrom(
       userId == null
-        ? this.environmentService.environment$
+        ? this.environmentService.globalEnvironment$
         : this.environmentService.userEnvironment$(userId),
     );
     const response = await this.fetch(
@@ -1407,7 +1408,8 @@ export class ApiService implements ApiServiceAbstraction {
       headers.set("User-Agent", this.customUserAgent);
     }
 
-    const env = await firstValueFrom(this.environmentService.environment$);
+    // Use the global environment because the user-scoped environment is not set until authentication is complete.
+    const env = await firstValueFrom(this.environmentService.globalEnvironment$);
     const path = `/sso/prevalidate?domainHint=${encodeURIComponent(identifier)}`;
     const response = await this.fetch(
       this.httpOperations.createRequest(env.getIdentityUrl() + path, {
@@ -1638,7 +1640,7 @@ export class ApiService implements ApiServiceAbstraction {
 
     const environment = await firstValueFrom(
       userIdMakingRequest == null
-        ? this.environmentService.environment$
+        ? this.environmentService.globalEnvironment$
         : this.environmentService.userEnvironment$(userIdMakingRequest),
     );
     apiUrl = Utils.isNullOrWhitespace(apiUrl) ? environment.getApiUrl() : apiUrl;

--- a/libs/common/src/services/api.service.ts
+++ b/libs/common/src/services/api.service.ts
@@ -628,7 +628,7 @@ export class ApiService implements ApiServiceAbstraction {
   ): Promise<any> {
     if (typeof XMLHttpRequest !== "undefined" && options?.onProgress) {
       const userId = await this.getActiveUser();
-      const environment = await firstValueFrom(this.environmentService.getEnvironment$(userId));
+      const environment = await firstValueFrom(this.environmentService.userEnvironment$(userId));
       const apiUrl = environment.getApiUrl();
       const headers = await this.buildRequestHeaders();
       const request = new Request(`${apiUrl}/ciphers/${id}/attachment/${attachmentId}`, {
@@ -1200,7 +1200,7 @@ export class ApiService implements ApiServiceAbstraction {
     const env = await firstValueFrom(
       userId == null
         ? this.environmentService.environment$
-        : this.environmentService.getEnvironment$(userId),
+        : this.environmentService.userEnvironment$(userId),
     );
     const response = await this.fetch(
       this.httpOperations.createRequest(env.getEventsUrl() + "/collect", {
@@ -1537,7 +1537,7 @@ export class ApiService implements ApiServiceAbstraction {
       headers.set("User-Agent", this.customUserAgent);
     }
 
-    const env = await firstValueFrom(this.environmentService.getEnvironment$(userId));
+    const env = await firstValueFrom(this.environmentService.userEnvironment$(userId));
     const decodedToken = await this.tokenService.decodeAccessToken(userId);
     const response = await this.fetch(
       this.httpOperations.createRequest(env.getIdentityUrl() + "/connect/token", {
@@ -1639,7 +1639,7 @@ export class ApiService implements ApiServiceAbstraction {
     const environment = await firstValueFrom(
       userIdMakingRequest == null
         ? this.environmentService.environment$
-        : this.environmentService.getEnvironment$(userIdMakingRequest),
+        : this.environmentService.userEnvironment$(userIdMakingRequest),
     );
     apiUrl = Utils.isNullOrWhitespace(apiUrl) ? environment.getApiUrl() : apiUrl;
 

--- a/libs/key-management-ui/src/lock/services/default-webauthn-prf-unlock.service.ts
+++ b/libs/key-management-ui/src/lock/services/default-webauthn-prf-unlock.service.ts
@@ -255,7 +255,7 @@ export class DefaultWebAuthnPrfUnlockService implements WebAuthnPrfUnlockService
    */
   private async getRpIdForUser(userId: UserId): Promise<string | undefined> {
     try {
-      const environment = await firstValueFrom(this.environmentService.getEnvironment$(userId));
+      const environment = await firstValueFrom(this.environmentService.userEnvironment$(userId));
       const hostname = Utils.getHost(environment.getWebVaultUrl());
 
       // The navigator.credentials.get call will fail if rpId is set but is null/empty. Undefined uses the current host.


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-39218

## 📔 Objective

In https://github.com/bitwarden/clients/pull/20495, we moved to use the non-user-scoped globalEnvironment$ on the environment selector, to address a race condition on logout that was preventing the correct environment from being used.

We have observed in subsequent tickets that the same issue is now occurring elsewhere in a pre-authenticated state - components and services that execute before the user has authenticated still rely on environment$, and when that is not present (due to the same race condition as #20495) other downstream issues occur.

This PR makes the change to `globalEnvironment$` in the following places:
1. WebAuthn and Duo 2FA - to get the correct web vault URL for the connector URL.
2. Login with Device - to get the URL for device management web app link.
3. 2FA component - to get the URL for the 2FA recovery web app link.
4. Registration - to determine the correct URL for registration requests.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
