### PR TITLE
[PM-39200] - fix notification bar behavior with save and fill

### DIFF
--- a/apps/browser/src/vault/popup/components/vault/add-edit/add-edit.component.html
+++ b/apps/browser/src/vault/popup/components/vault/add-edit/add-edit.component.html
@@ -31,7 +31,7 @@
   }
 
   <popup-footer slot="footer">
-    @if (showSaveAndFill) {
+    @if (saveAndFillEnabled) {
       <button [bitAction]="submitAndFill" type="button" bitButton buttonType="primary">
         {{ "saveAndFill" | i18n }}
       </button>
@@ -40,12 +40,12 @@
       bitButton
       type="submit"
       form="cipherForm"
-      [buttonType]="showSaveAndFill ? 'secondary' : 'primary'"
+      [buttonType]="saveAndFillEnabled ? 'secondary' : 'primary'"
       #submitBtn
     >
       {{ (previouslyCouldArchive ? "unarchiveAndSave" : "save") | i18n }}
     </button>
-    @if (showSaveAndFill) {
+    @if (saveAndFillEnabled) {
       <button
         (click)="handleBackButton()"
         bitButton

--- a/apps/browser/src/vault/popup/components/vault/add-edit/add-edit.component.spec.ts
+++ b/apps/browser/src/vault/popup/components/vault/add-edit/add-edit.component.spec.ts
@@ -336,19 +336,22 @@ describe("AddEditComponent", () => {
       expect(navigate).not.toHaveBeenCalled();
     });
 
-    it("closes single action popout", async () => {
+    it("closes single action popout without notification when save and fill is disabled", async () => {
       jest.spyOn(BrowserPopupUtils, "inSingleActionPopout").mockReturnValueOnce(true);
       jest.spyOn(BrowserPopupUtils, "closeSingleActionPopout").mockResolvedValue();
       const sendMessageSpy = jest.spyOn(BrowserApi, "sendMessage").mockResolvedValue(undefined);
+      (component as any).saveAndFillEnabled = false;
 
       await component.onCipherSaved({ id: "123-456-789", name: "Test Cipher" } as CipherView);
 
-      expect(sendMessageSpy).toHaveBeenCalledWith("showLoginSavedNotification", {
-        cipherId: "123-456-789",
-        itemName: "Test Cipher",
-        senderTabId: 1,
-      });
-      expect(BrowserPopupUtils.closeSingleActionPopout).toHaveBeenCalled();
+      expect(sendMessageSpy).not.toHaveBeenCalledWith(
+        "showLoginSavedNotification",
+        expect.anything(),
+      );
+      expect(BrowserPopupUtils.closeSingleActionPopout).toHaveBeenCalledWith(
+        "vault_AddEditVaultItem",
+        1000,
+      );
       expect(navigate).not.toHaveBeenCalled();
     });
 
@@ -358,6 +361,7 @@ describe("AddEditComponent", () => {
       const sendMessageSpy = jest.spyOn(BrowserApi, "sendMessage").mockResolvedValue(undefined);
       vaultPopupAutofillService.doAutofill.mockResolvedValue(true);
       (component as any).fillOnSuccessfulSave = true;
+      (component as any).saveAndFillEnabled = true;
 
       await component.onCipherSaved({ id: "123-456-789", name: "Test Cipher" } as CipherView);
 

--- a/apps/browser/src/vault/popup/components/vault/add-edit/add-edit.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/add-edit/add-edit.component.ts
@@ -198,7 +198,7 @@ export class AddEditComponent implements OnInit, OnDestroy {
   config: CipherFormConfig;
   canDeleteCipher$: Observable<boolean>;
   routeAfterDeletion: ROUTES_AFTER_EDIT_DELETION = "/tabs/vault";
-  protected showSaveAndFill = false;
+  protected saveAndFillEnabled = false;
   private fillOnSuccessfulSave = false;
 
   get loading() {
@@ -355,8 +355,12 @@ export class AddEditComponent implements OnInit, OnDestroy {
       if (this.fillOnSuccessfulSave) {
         await this.vaultPopupAutofillService.doAutofill(cipher, false, true);
       }
-      await this.showLoginSavedNotification(cipher);
-      await BrowserPopupUtils.closeSingleActionPopout(VaultPopoutType.addEditVaultItem);
+      if (this.saveAndFillEnabled) {
+        await this.showLoginSavedNotification(cipher);
+        await BrowserPopupUtils.closeSingleActionPopout(VaultPopoutType.addEditVaultItem);
+      } else {
+        await BrowserPopupUtils.closeSingleActionPopout(VaultPopoutType.addEditVaultItem, 1000);
+      }
       return;
     }
 
@@ -413,12 +417,9 @@ export class AddEditComponent implements OnInit, OnDestroy {
           }
 
           if (params.fillAfterSave) {
-            const saveAndFillEnabled = await this.configService.getFeatureFlag(
+            this.saveAndFillEnabled = await this.configService.getFeatureFlag(
               FeatureFlag.PM29968_FillAfterSave,
             );
-            this.showSaveAndFill = saveAndFillEnabled;
-          } else {
-            this.showSaveAndFill = false;
           }
           const config = await this.addEditFormConfigService.buildConfig(
             mode,


### PR DESCRIPTION
## 🎟️ Tracking

[PM-39200](https://bitwarden.atlassian.net/browse/PM-39200)

## 📔 Objective

Fixes the post-save behavior in the browser add/edit vault item flow when the Save and Fill feature (`PM29968_FillAfterSave`) is disabled.

Previously, `AddEditComponent.onCipherSaved()` always sent the `showLoginSavedNotification` message and closed the single-action popout immediately, regardless of the feature flag. This surfaced the save-and-fill notification flow in contexts where the feature is off and removed the brief delay that gives users visual confirmation of the save.

Changes:
- Gate the saved-notification flow behind the feature flag: only call `showLoginSavedNotification` and close the popout immediately when `saveAndFillEnabled` is true; otherwise close the popout with a 1000ms delay and skip the notification.
- Consolidated `showSaveAndFill` and the locally-scoped `saveAndFillEnabled` into a single `saveAndFillEnabled` field so the template (Save and Fill button visibility) and the save flow are driven by the same source of truth.
- Updated the `onCipherSaved` unit tests to cover both the enabled and disabled paths.


[PM-39200]: https://bitwarden.atlassian.net/browse/PM-39200?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ