### PR TITLE
fix(extension-scrollbar): Auth [PM-32445] Extension Scrollbar Fix (#2…

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -37,8 +37,8 @@
   "yourOrganizationRequiresSingleSignOn": {
     "message": "Your organization requires single sign-on."
   },
-  "welcomeBack": {
-    "message": "Welcome back"
+  "loginPageMasterPasswordEntryScreenTitle": {
+    "message": "Log in"
   },
   "setAStrongPassword": {
     "message": "Set a strong password"
@@ -289,8 +289,8 @@
   "enterYourAccountEmailAddressAndYourPasswordHintWillBeSentToYou": {
     "message": "Enter your account email address and your password hint will be sent to you"
   },
-  "getMasterPasswordHint": {
-    "message": "Get master password hint"
+  "hint": {
+    "message": "Hint"
   },
   "continue": {
     "message": "Continue"
@@ -978,8 +978,8 @@
   "logIn": {
     "message": "Log in"
   },
-  "logInToBitwarden": {
-    "message": "Log in to Bitwarden"
+  "loginPageEmailEntryScreenTitle": {
+    "message": "Log in"
   },
   "enterTheCodeSentToYourEmail": {
     "message": "Enter the code sent to your email"
@@ -1714,8 +1714,8 @@
   "passkeyAuthenticationFailed": {
     "message": "Passkey authentication failed"
   },
-  "useADifferentLogInMethod": {
-    "message": "Use a different log in method"
+  "useDifferentLoginMethod": {
+    "message": "Use different login method"
   },
   "awaitingSecurityKeyInteraction": {
     "message": "Awaiting security key interaction..."
@@ -2891,8 +2891,8 @@
   "masterPasswordPolicyRequirementsNotMet": {
     "message": "Your new master password does not meet the policy requirements."
   },
-  "receiveMarketingEmailsV2": {
-    "message": "Get advice, announcements, and research opportunities from Bitwarden in your inbox."
+  "receiveMarketingEmails": {
+    "message": "Receive updates from Bitwarden in your inbox."
   },
   "unsubscribe": {
     "message": "Unsubscribe"
@@ -3950,9 +3950,6 @@
         "example": "Jun 15, 2015"
       }
     }
-  },
-  "loginWithMasterPassword": {
-    "message": "Log in with master password"
   },
   "newAroundHere": {
     "message": "New around here?"

--- a/apps/browser/src/auth/popup/login/extension-login-via-webauthn-component.service.ts
+++ b/apps/browser/src/auth/popup/login/extension-login-via-webauthn-component.service.ts
@@ -1,0 +1,13 @@
+import { Injectable } from "@angular/core";
+
+import { DefaultLoginViaWebAuthnComponentService } from "@bitwarden/angular/auth/login-via-webauthn/default-login-via-webauthn-component.service";
+import { LoginViaWebAuthnComponentService } from "@bitwarden/angular/auth/login-via-webauthn/login-via-webauthn-component.service";
+
+@Injectable()
+export class ExtensionLoginViaWebAuthnComponentService
+  extends DefaultLoginViaWebAuthnComponentService
+  implements LoginViaWebAuthnComponentService
+{
+  showTroubleLoggingInText = false;
+  leftAlignDescription = true;
+}

--- a/apps/browser/src/popup/app-routing.module.ts
+++ b/apps/browser/src/popup/app-routing.module.ts
@@ -20,14 +20,12 @@ import { SetInitialPasswordComponent } from "@bitwarden/angular/auth/password-ma
 import { canAccessFeature } from "@bitwarden/angular/platform/guard/feature-flag.guard";
 import {
   DevicesIcon,
-  RegistrationUserAddIcon,
   TwoFactorTimeoutIcon,
   TwoFactorAuthEmailIcon,
   UserLockIcon,
   VaultIcon,
   LockIcon,
   DomainIcon,
-  TwoFactorAuthSecurityKeyIcon,
 } from "@bitwarden/assets/svg";
 import {
   LoginComponent,
@@ -406,11 +404,15 @@ const routes: Routes = [
         canActivate: [unauthGuardFn()],
         data: {
           elevation: 1,
-          pageIcon: RegistrationUserAddIcon,
           pageTitle: {
             key: "createAccount",
           },
           showBackButton: true,
+          hidePageIcon: true,
+          contentVerticalPadding: "compact",
+          footerVerticalPadding: "compact",
+          heroTextAlignment: "left",
+          hideFooter: true,
         } satisfies RouteDataProperties & ExtensionAnonLayoutWrapperData,
         children: [
           {
@@ -454,12 +456,16 @@ const routes: Routes = [
         path: AuthRoute.Login,
         canActivate: [unauthGuardFn(unauthRouteOverrides), IntroCarouselGuard],
         data: {
-          pageIcon: VaultIcon,
           pageTitle: {
-            key: "logInToBitwarden",
+            key: "loginPageEmailEntryScreenTitle",
           },
           elevation: 1,
           showAcctSwitcher: true,
+          hidePageIcon: true,
+          contentVerticalPadding: "compact",
+          footerVerticalPadding: "compact",
+          heroTextAlignment: "left",
+          secondaryContentLocation: "footer",
         } satisfies RouteDataProperties & ExtensionAnonLayoutWrapperData,
         children: [
           { path: "", component: LoginComponent },
@@ -475,15 +481,16 @@ const routes: Routes = [
         path: AuthRoute.LoginWithPasskey,
         canActivate: [unauthGuardFn(unauthRouteOverrides), platformPopoutGuard(["linux"])],
         data: {
-          pageIcon: TwoFactorAuthSecurityKeyIcon,
           pageTitle: {
             key: "logInWithPasskey",
           },
-          pageSubtitle: {
-            key: "readingPasskeyLoadingInfo",
-          },
           elevation: 1,
           showBackButton: true,
+          hidePageIcon: true,
+          contentVerticalPadding: "compact",
+          footerVerticalPadding: "compact",
+          heroTextAlignment: "left",
+          secondaryContentLocation: "footer",
         } satisfies RouteDataProperties & ExtensionAnonLayoutWrapperData,
         children: [
           { path: "", component: LoginViaWebAuthnComponent },
@@ -598,6 +605,8 @@ const routes: Routes = [
           },
           showReadonlyHostname: true,
           showAcctSwitcher: true,
+          contentVerticalPadding: "compact",
+          footerVerticalPadding: "compact",
           elevation: 1,
           /**
            * This ensures that in a passkey flow the `/fido2?<queryParams>` URL does not get

--- a/apps/browser/src/popup/components/extension-anon-layout-wrapper/extension-anon-layout-defaults.ts
+++ b/apps/browser/src/popup/components/extension-anon-layout-wrapper/extension-anon-layout-defaults.ts
@@ -1,0 +1,24 @@
+import type { AnonLayoutWrapperData } from "@bitwarden/components";
+
+import type { ExtensionAnonLayoutWrapperData } from "./extension-anon-layout-wrapper.component";
+
+/**
+ * Default values for the fields {@link ExtensionAnonLayoutWrapperData} adds on top of
+ * {@link AnonLayoutWrapperData}.
+ *
+ * Used together with `ANON_LAYOUT_DEFAULTS` in `ExtensionAnonLayoutWrapperDataService`'s
+ * `resetToCachedRouteData()` override so the reset emits a complete payload across both
+ * the base and the extension-only fields.
+ *
+ * Typed as `Required<Omit<...>>` against the extension delta so adding a new extension-only
+ * field to {@link ExtensionAnonLayoutWrapperData} forces a defaults entry here at compile
+ * time, mirroring the base-side guarantee in `ANON_LAYOUT_DEFAULTS`.
+ */
+export const EXTENSION_ANON_LAYOUT_DEFAULTS: Required<
+  Omit<ExtensionAnonLayoutWrapperData, keyof AnonLayoutWrapperData>
+> = {
+  showAcctSwitcher: false,
+  showBackButton: false,
+  showLogo: true,
+  hideFooter: false,
+};

--- a/apps/browser/src/popup/components/extension-anon-layout-wrapper/extension-anon-layout-wrapper-data.service.spec.ts
+++ b/apps/browser/src/popup/components/extension-anon-layout-wrapper/extension-anon-layout-wrapper-data.service.spec.ts
@@ -1,0 +1,99 @@
+import { ANON_LAYOUT_DEFAULTS, AnonLayoutWrapperData } from "@bitwarden/components";
+
+import { EXTENSION_ANON_LAYOUT_DEFAULTS } from "./extension-anon-layout-defaults";
+import { ExtensionAnonLayoutWrapperDataService } from "./extension-anon-layout-wrapper-data.service";
+import { ExtensionAnonLayoutWrapperData } from "./extension-anon-layout-wrapper.component";
+
+describe("ExtensionAnonLayoutWrapperDataService", () => {
+  let service: ExtensionAnonLayoutWrapperDataService;
+  let emissions: Partial<ExtensionAnonLayoutWrapperData>[];
+
+  beforeEach(() => {
+    service = new ExtensionAnonLayoutWrapperDataService();
+    emissions = [];
+    service.anonLayoutWrapperData$().subscribe((data) => emissions.push(data));
+  });
+
+  // Behaviors inherited from DefaultAnonLayoutWrapperDataService (basic emission, caching
+  // silently, cache replacement) are covered by the parent's spec. These tests focus on
+  // the extension-specific overrides: support for extension-only fields in the emission
+  // stream, and the dual-spread reset behavior.
+
+  describe("setAnonLayoutWrapperData", () => {
+    it("emits extension-only fields to subscribers", () => {
+      const data: Partial<ExtensionAnonLayoutWrapperData> = {
+        showLogo: true,
+        showBackButton: true,
+      };
+
+      service.setAnonLayoutWrapperData(data);
+
+      expect(emissions).toEqual([data]);
+    });
+  });
+
+  describe("resetToCachedRouteData", () => {
+    it("emits both ANON_LAYOUT_DEFAULTS and EXTENSION_ANON_LAYOUT_DEFAULTS when no cache has been set", () => {
+      service.resetToCachedRouteData();
+
+      expect(emissions[0]).toEqual({
+        ...ANON_LAYOUT_DEFAULTS,
+        ...EXTENSION_ANON_LAYOUT_DEFAULTS,
+      });
+    });
+
+    it("spreads cached values over both default consts", () => {
+      // cacheRouteData is inherited with a `Partial<AnonLayoutWrapperData>` signature, so
+      // extension-only fields trigger an excess-property check on object literals. Typing
+      // the variable as the extension partial sidesteps the check while still satisfying
+      // the parameter via structural assignability.
+      const cacheData: Partial<ExtensionAnonLayoutWrapperData> = {
+        pageTitle: "Cached title",
+        showLogo: false,
+      };
+      service.cacheRouteData(cacheData);
+      service.resetToCachedRouteData();
+
+      expect(emissions[0]).toEqual({
+        ...ANON_LAYOUT_DEFAULTS,
+        ...EXTENSION_ANON_LAYOUT_DEFAULTS,
+        pageTitle: "Cached title",
+        showLogo: false,
+      });
+    });
+
+    it("cached values win over extension-only default values where keys overlap", () => {
+      // EXTENSION_ANON_LAYOUT_DEFAULTS.showLogo is true; cache it as false.
+      const cacheData: Partial<ExtensionAnonLayoutWrapperData> = { showLogo: false };
+      service.cacheRouteData(cacheData);
+      service.resetToCachedRouteData();
+
+      expect(emissions[0].showLogo).toBe(false);
+    });
+
+    it("emits extension-only default values for keys the cache doesn't declare", () => {
+      service.cacheRouteData({ pageTitle: "Only title" });
+      service.resetToCachedRouteData();
+
+      // Extension-only fields fall back to EXTENSION_ANON_LAYOUT_DEFAULTS.
+      expect(emissions[0].showAcctSwitcher).toBe(EXTENSION_ANON_LAYOUT_DEFAULTS.showAcctSwitcher);
+      expect(emissions[0].showBackButton).toBe(EXTENSION_ANON_LAYOUT_DEFAULTS.showBackButton);
+      expect(emissions[0].showLogo).toBe(EXTENSION_ANON_LAYOUT_DEFAULTS.showLogo);
+      expect(emissions[0].hideFooter).toBe(EXTENSION_ANON_LAYOUT_DEFAULTS.hideFooter);
+    });
+
+    it("emits a complete payload containing every key from both default consts", () => {
+      service.cacheRouteData({ pageTitle: "Some title" });
+      service.resetToCachedRouteData();
+
+      for (const key of Object.keys(ANON_LAYOUT_DEFAULTS) as (keyof AnonLayoutWrapperData)[]) {
+        expect(emissions[0]).toHaveProperty(key);
+      }
+      for (const key of Object.keys(
+        EXTENSION_ANON_LAYOUT_DEFAULTS,
+      ) as (keyof ExtensionAnonLayoutWrapperData)[]) {
+        expect(emissions[0]).toHaveProperty(key);
+      }
+    });
+  });
+});

--- a/apps/browser/src/popup/components/extension-anon-layout-wrapper/extension-anon-layout-wrapper-data.service.ts
+++ b/apps/browser/src/popup/components/extension-anon-layout-wrapper/extension-anon-layout-wrapper-data.service.ts
@@ -2,9 +2,11 @@ import { Observable, Subject } from "rxjs";
 
 import {
   AnonLayoutWrapperDataService,
+  ANON_LAYOUT_DEFAULTS,
   DefaultAnonLayoutWrapperDataService,
 } from "@bitwarden/components";
 
+import { EXTENSION_ANON_LAYOUT_DEFAULTS } from "./extension-anon-layout-defaults";
 import { ExtensionAnonLayoutWrapperData } from "./extension-anon-layout-wrapper.component";
 
 export class ExtensionAnonLayoutWrapperDataService
@@ -21,5 +23,17 @@ export class ExtensionAnonLayoutWrapperDataService
 
   override anonLayoutWrapperData$(): Observable<Partial<ExtensionAnonLayoutWrapperData>> {
     return this.anonLayoutWrapperDataSubject.asObservable();
+  }
+
+  override resetToCachedRouteData(): void {
+    // Spread defaults before the cached payload so the emitted object is complete across
+    // both base and extension-only fields. Route-declared fields win where present; unset
+    // fields fall back to the defaults, which clears stale imperative overrides for fields
+    // the route didn't declare.
+    this.anonLayoutWrapperDataSubject.next({
+      ...ANON_LAYOUT_DEFAULTS,
+      ...EXTENSION_ANON_LAYOUT_DEFAULTS,
+      ...this.cachedRouteData,
+    });
   }
 }

--- a/apps/browser/src/popup/components/extension-anon-layout-wrapper/extension-anon-layout-wrapper.component.html
+++ b/apps/browser/src/popup/components/extension-anon-layout-wrapper/extension-anon-layout-wrapper.component.html
@@ -14,6 +14,7 @@
       <app-current-account *ngIf="showAcctSwitcher && hasLoggedInAccount"></app-current-account>
     </ng-container>
   </popup-header>
+
   <auth-anon-layout
     [title]="pageTitle"
     [subtitle]="pageSubtitle"
@@ -23,9 +24,20 @@
     [maxWidth]="maxWidth"
     [hideFooter]="hideFooter"
     [hideCardWrapper]="hideCardWrapper"
+    [hidePageIcon]="hidePageIcon"
+    [contentVerticalPadding]="contentVerticalPadding"
+    [footerVerticalPadding]="footerVerticalPadding"
+    [heroTextAlignment]="heroTextAlignment"
+    [secondaryContentLocation]="secondaryContentLocation"
   >
     <router-outlet></router-outlet>
-    <router-outlet slot="secondary" name="secondary"></router-outlet>
+    <!-- The shared layout exposes two distinct slot selectors. We pick which one -->
+    <!-- to project into based on the route-level secondaryContentLocation flag. -->
+    @if (secondaryContentLocation === "footer") {
+      <router-outlet slot="footer-secondary" name="secondary"></router-outlet>
+    } @else {
+      <router-outlet slot="secondary" name="secondary"></router-outlet>
+    }
     <router-outlet slot="environment-selector" name="environment-selector"></router-outlet>
   </auth-anon-layout>
 </popup-page>

--- a/apps/browser/src/popup/components/extension-anon-layout-wrapper/extension-anon-layout-wrapper.component.ts
+++ b/apps/browser/src/popup/components/extension-anon-layout-wrapper/extension-anon-layout-wrapper.component.ts
@@ -13,6 +13,11 @@ import {
   AnonLayoutComponent,
   AnonLayoutWrapperData,
   AnonLayoutWrapperDataService,
+  ANON_LAYOUT_DEFAULTS,
+  ContentVerticalPaddingType,
+  FooterVerticalPaddingType,
+  HeroTextAlignmentType,
+  SecondaryContentLocationType,
 } from "@bitwarden/components";
 import { I18nPipe } from "@bitwarden/ui-common";
 
@@ -21,6 +26,8 @@ import { AccountSwitcherService } from "../../../auth/popup/account-switching/se
 import { PopOutComponent } from "../../../platform/popup/components/pop-out.component";
 import { PopupHeaderComponent } from "../../../platform/popup/layout/popup-header.component";
 import { PopupPageComponent } from "../../../platform/popup/layout/popup-page.component";
+
+import { EXTENSION_ANON_LAYOUT_DEFAULTS } from "./extension-anon-layout-defaults";
 
 export interface ExtensionAnonLayoutWrapperData extends AnonLayoutWrapperData {
   showAcctSwitcher?: boolean;
@@ -60,6 +67,11 @@ export class ExtensionAnonLayoutWrapperComponent implements OnInit, OnDestroy {
   protected hasLoggedInAccount: boolean = false;
   protected hideFooter: boolean;
   protected hideCardWrapper: boolean = false;
+  protected hidePageIcon?: boolean;
+  protected contentVerticalPadding?: ContentVerticalPaddingType;
+  protected footerVerticalPadding?: FooterVerticalPaddingType;
+  protected heroTextAlignment?: HeroTextAlignmentType;
+  protected secondaryContentLocation?: SecondaryContentLocationType;
 
   protected theme: string;
   protected logo = BitwardenLogo;
@@ -118,25 +130,37 @@ export class ExtensionAnonLayoutWrapperComponent implements OnInit, OnDestroy {
       this.pageIcon = firstChildRouteData["pageIcon"];
     }
 
-    this.hideFooter = Boolean(firstChildRouteData["hideFooter"]);
-    this.showReadonlyHostname = Boolean(firstChildRouteData["showReadonlyHostname"]);
-    this.maxWidth = firstChildRouteData["maxWidth"];
+    // When undefined, fall back to ANON_LAYOUT_DEFAULTS / EXTENSION_ANON_LAYOUT_DEFAULTS — single
+    // source of truth for route-init defaults, the reset emission, and the component-level
+    // input defaults.
+    this.showReadonlyHostname =
+      firstChildRouteData["showReadonlyHostname"] ?? ANON_LAYOUT_DEFAULTS.showReadonlyHostname;
+    this.maxWidth = firstChildRouteData["maxWidth"] ?? ANON_LAYOUT_DEFAULTS.maxWidth;
+    this.hideCardWrapper =
+      firstChildRouteData["hideCardWrapper"] ?? ANON_LAYOUT_DEFAULTS.hideCardWrapper;
+    this.hidePageIcon = firstChildRouteData["hidePageIcon"] ?? ANON_LAYOUT_DEFAULTS.hidePageIcon;
+    this.contentVerticalPadding =
+      firstChildRouteData["contentVerticalPadding"] ?? ANON_LAYOUT_DEFAULTS.contentVerticalPadding;
+    this.footerVerticalPadding =
+      firstChildRouteData["footerVerticalPadding"] ?? ANON_LAYOUT_DEFAULTS.footerVerticalPadding;
+    this.heroTextAlignment =
+      firstChildRouteData["heroTextAlignment"] ?? ANON_LAYOUT_DEFAULTS.heroTextAlignment;
 
-    if (firstChildRouteData["showAcctSwitcher"] !== undefined) {
-      this.showAcctSwitcher = Boolean(firstChildRouteData["showAcctSwitcher"]);
-    }
+    this.showAcctSwitcher =
+      firstChildRouteData["showAcctSwitcher"] ?? EXTENSION_ANON_LAYOUT_DEFAULTS.showAcctSwitcher;
+    this.showBackButton =
+      firstChildRouteData["showBackButton"] ?? EXTENSION_ANON_LAYOUT_DEFAULTS.showBackButton;
+    this.showLogo = firstChildRouteData["showLogo"] ?? EXTENSION_ANON_LAYOUT_DEFAULTS.showLogo;
+    this.hideFooter =
+      firstChildRouteData["hideFooter"] ?? EXTENSION_ANON_LAYOUT_DEFAULTS.hideFooter;
+    this.secondaryContentLocation =
+      firstChildRouteData["secondaryContentLocation"] ??
+      ANON_LAYOUT_DEFAULTS.secondaryContentLocation;
 
-    if (firstChildRouteData["showBackButton"] !== undefined) {
-      this.showBackButton = Boolean(firstChildRouteData["showBackButton"]);
-    }
-
-    if (firstChildRouteData["showLogo"] !== undefined) {
-      this.showLogo = Boolean(firstChildRouteData["showLogo"]);
-    }
-
-    if (firstChildRouteData["hideCardWrapper"] !== undefined) {
-      this.hideCardWrapper = Boolean(firstChildRouteData["hideCardWrapper"]);
-    }
+    // Cache the route-data payload so resetToCachedRouteData() can later restore it.
+    this.extensionAnonLayoutWrapperDataService.cacheRouteData(
+      firstChildRouteData as Partial<AnonLayoutWrapperData>,
+    );
   }
 
   private listenForServiceDataChanges() {
@@ -144,11 +168,11 @@ export class ExtensionAnonLayoutWrapperComponent implements OnInit, OnDestroy {
       .anonLayoutWrapperData$()
       .pipe(takeUntil(this.destroy$))
       .subscribe((data: ExtensionAnonLayoutWrapperData) => {
-        this.setAnonLayoutWrapperData(data);
+        this.setAnonLayoutWrapperDataFromService(data);
       });
   }
 
-  private setAnonLayoutWrapperData(data: ExtensionAnonLayoutWrapperData) {
+  private setAnonLayoutWrapperDataFromService(data: ExtensionAnonLayoutWrapperData) {
     if (!data) {
       return;
     }
@@ -192,6 +216,22 @@ export class ExtensionAnonLayoutWrapperComponent implements OnInit, OnDestroy {
     if (data.showLogo !== undefined) {
       this.showLogo = data.showLogo;
     }
+
+    if (data.hidePageIcon !== undefined) {
+      this.hidePageIcon = data.hidePageIcon;
+    }
+    if (data.contentVerticalPadding !== undefined) {
+      this.contentVerticalPadding = data.contentVerticalPadding;
+    }
+    if (data.footerVerticalPadding !== undefined) {
+      this.footerVerticalPadding = data.footerVerticalPadding;
+    }
+    if (data.heroTextAlignment !== undefined) {
+      this.heroTextAlignment = data.heroTextAlignment;
+    }
+    if (data.secondaryContentLocation !== undefined) {
+      this.secondaryContentLocation = data.secondaryContentLocation;
+    }
   }
 
   private handleStringOrTranslation(value: string | Translation): string {
@@ -215,6 +255,11 @@ export class ExtensionAnonLayoutWrapperComponent implements OnInit, OnDestroy {
     this.maxWidth = null;
     this.hideFooter = null;
     this.hideCardWrapper = null;
+    this.hidePageIcon = undefined;
+    this.contentVerticalPadding = undefined;
+    this.footerVerticalPadding = undefined;
+    this.heroTextAlignment = undefined;
+    this.secondaryContentLocation = undefined;
   }
 
   ngOnDestroy() {

--- a/apps/browser/src/popup/services/services.module.ts
+++ b/apps/browser/src/popup/services/services.module.ts
@@ -5,6 +5,7 @@ import { merge, of, Subject } from "rxjs";
 
 import { CollectionService } from "@bitwarden/admin-console/common";
 import { DeviceManagementComponentServiceAbstraction } from "@bitwarden/angular/auth/device-management/device-management-component.service.abstraction";
+import { LoginViaWebAuthnComponentService } from "@bitwarden/angular/auth/login-via-webauthn/login-via-webauthn-component.service";
 import { ChangePasswordService } from "@bitwarden/angular/auth/password-management/change-password";
 import { AngularThemingService } from "@bitwarden/angular/platform/services/theming/angular-theming.service";
 import { SafeProvider, safeProvider } from "@bitwarden/angular/platform/utils/safe-provider";
@@ -184,6 +185,7 @@ import { AccountSwitcherService } from "../../auth/popup/account-switching/servi
 import { ForegroundLockService } from "../../auth/popup/accounts/foreground-lock.service";
 import { ExtensionChangePasswordService } from "../../auth/popup/change-password/extension-change-password.service";
 import { ExtensionLoginComponentService } from "../../auth/popup/login/extension-login-component.service";
+import { ExtensionLoginViaWebAuthnComponentService } from "../../auth/popup/login/extension-login-via-webauthn-component.service";
 import { ExtensionSsoComponentService } from "../../auth/popup/login/extension-sso-component.service";
 import { ExtensionLogoutService } from "../../auth/popup/logout/extension-logout.service";
 import { ExtensionDeviceManagementComponentService } from "../../auth/services/extension-device-management-component.service";
@@ -719,6 +721,11 @@ const safeProviders: SafeProvider[] = [
       ExtensionAnonLayoutWrapperDataService,
       SsoUrlService,
     ],
+  }),
+  safeProvider({
+    provide: LoginViaWebAuthnComponentService,
+    useClass: ExtensionLoginViaWebAuthnComponentService,
+    deps: [],
   }),
   safeProvider({
     provide: LockService,

--- a/apps/desktop/src/app/app-routing.module.ts
+++ b/apps/desktop/src/app/app-routing.module.ts
@@ -185,7 +185,7 @@ const routes: Routes = [
         canActivate: [maxAccountsGuardFn()],
         data: {
           pageTitle: {
-            key: "logInToBitwarden",
+            key: "loginPageEmailEntryScreenTitle",
           },
           pageIcon: VaultIcon,
         },

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -126,7 +126,7 @@
   "noEditPermissions": {
     "message": "You don't have permission to edit this item"
   },
-  "welcomeBack": {
+  "loginPageMasterPasswordEntryScreenTitle": {
     "message": "Welcome back"
   },
   "moveToOrgDesc": {
@@ -1055,7 +1055,7 @@
   "logIn": {
     "message": "Log in"
   },
-  "logInToBitwarden": {
+  "loginPageEmailEntryScreenTitle": {
     "message": "Log in to Bitwarden"
   },
   "enterTheCodeSentToYourEmail": {
@@ -1163,9 +1163,6 @@
   },
   "enterYourAccountEmailAddressAndYourPasswordHintWillBeSentToYou": {
     "message": "Enter your account email address and your password hint will be sent to you"
-  },
-  "getMasterPasswordHint": {
-    "message": "Get master password hint"
   },
   "emailRequired": {
     "message": "Email address is required."
@@ -2585,8 +2582,8 @@
   "changePasswordDelegationMasterPasswordPolicyInEffect": {
     "message": "One or more organization policies require the master password to meet the following requirements:"
   },
-  "receiveMarketingEmailsV2": {
-    "message": "Get advice, announcements, and research opportunities from Bitwarden in your inbox."
+  "receiveMarketingEmails": {
+    "message": "Receive updates from Bitwarden in your inbox."
   },
   "unsubscribe": {
     "message": "Unsubscribe"
@@ -2671,6 +2668,9 @@
   },
   "yourNewPasswordCannotBeTheSameAsYourCurrentPassword": {
     "message": "Your new password cannot be the same as your current password."
+  },
+  "hint": {
+    "message": "Hint"
   },
   "hintEqualsPassword": {
     "message": "Your password hint cannot be the same as your password."
@@ -3445,9 +3445,6 @@
   "vault": {
     "message": "Vault",
     "description": "'Vault' is a noun and refers to the Bitwarden Vault feature."
-  },
-  "loginWithMasterPassword": {
-    "message": "Log in with master password"
   },
   "rememberEmail": {
     "message": "Remember email"

--- a/apps/web/src/app/core/core.module.ts
+++ b/apps/web/src/app/core/core.module.ts
@@ -12,6 +12,8 @@ import {
   OrganizationUserApiService,
   OrganizationUserService,
 } from "@bitwarden/admin-console/common";
+import { DefaultLoginViaWebAuthnComponentService } from "@bitwarden/angular/auth/login-via-webauthn/default-login-via-webauthn-component.service";
+import { LoginViaWebAuthnComponentService } from "@bitwarden/angular/auth/login-via-webauthn/login-via-webauthn-component.service";
 import { ChangePasswordService } from "@bitwarden/angular/auth/password-management/change-password";
 import { SetInitialPasswordService } from "@bitwarden/angular/auth/password-management/set-initial-password/set-initial-password.service.abstraction";
 import { PremiumInterestStateService } from "@bitwarden/angular/billing/services/premium-interest/premium-interest-state.service.abstraction";
@@ -344,6 +346,11 @@ const safeProviders: SafeProvider[] = [
     provide: AppIdService,
     useClass: DefaultAppIdService,
     deps: [OBSERVABLE_DISK_LOCAL_STORAGE, LogService],
+  }),
+  safeProvider({
+    provide: LoginViaWebAuthnComponentService,
+    useClass: DefaultLoginViaWebAuthnComponentService,
+    deps: [],
   }),
   safeProvider({
     provide: LoginComponentService,

--- a/apps/web/src/app/oss-routing.module.ts
+++ b/apps/web/src/app/oss-routing.module.ts
@@ -216,7 +216,7 @@ const routes: Routes = [
         canActivate: [unauthGuardFn()],
         data: {
           pageTitle: {
-            key: "logInToBitwarden",
+            key: "loginPageEmailEntryScreenTitle",
           },
           pageIcon: VaultIcon,
         } satisfies RouteDataProperties & AnonLayoutWrapperData,

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -1739,9 +1739,6 @@
   "needAnotherOptionV1": {
     "message": "Need another option?"
   },
-  "loginWithMasterPassword": {
-    "message": "Log in with master password"
-  },
   "readingPasskeyLoading": {
     "message": "Reading passkey..."
   },
@@ -1751,8 +1748,8 @@
   "passkeyAuthenticationFailed": {
     "message": "Passkey authentication failed. Please try again."
   },
-  "useADifferentLogInMethod": {
-    "message": "Use a different log in method"
+  "useDifferentLoginMethod": {
+    "message": "Use different login method"
   },
   "logInWithPasskey": {
     "message": "Log in with passkey"
@@ -1763,7 +1760,7 @@
   "yourOrganizationRequiresSingleSignOn": {
     "message": "Your organization requires single sign-on."
   },
-  "welcomeBack": {
+  "loginPageMasterPasswordEntryScreenTitle": {
     "message": "Welcome back"
   },
   "invalidPasskeyPleaseTryAgain": {
@@ -1865,7 +1862,7 @@
   "logIn": {
     "message": "Log in"
   },
-  "logInToBitwarden": {
+  "loginPageEmailEntryScreenTitle": {
     "message": "Log in to Bitwarden"
   },
   "enterTheCodeSentToYourEmail": {
@@ -1967,9 +1964,6 @@
   },
   "enterYourAccountEmailAddressAndYourPasswordHintWillBeSentToYou": {
     "message": "Enter your account email address and your password hint will be sent to you"
-  },
-  "getMasterPasswordHint": {
-    "message": "Get master password hint"
   },
   "emailRequired": {
     "message": "Email address is required."
@@ -5820,8 +5814,8 @@
   "nothingSelected": {
     "message": "You have not selected anything."
   },
-  "receiveMarketingEmailsV2": {
-    "message": "Get advice, announcements, and research opportunities from Bitwarden in your inbox."
+  "receiveMarketingEmails": {
+    "message": "Receive updates from Bitwarden in your inbox."
   },
   "subscribe": {
     "message": "Subscribe"
@@ -7277,6 +7271,9 @@
   },
   "yourNewPasswordCannotBeTheSameAsYourCurrentPassword": {
     "message": "Your new password cannot be the same as your current password."
+  },
+  "hint": {
+    "message": "Hint"
   },
   "hintEqualsPassword": {
     "message": "Your password hint cannot be the same as your password."

--- a/libs/angular/src/auth/login-via-webauthn/default-login-via-webauthn-component.service.ts
+++ b/libs/angular/src/auth/login-via-webauthn/default-login-via-webauthn-component.service.ts
@@ -1,0 +1,6 @@
+import { LoginViaWebAuthnComponentService } from "./login-via-webauthn-component.service";
+
+export class DefaultLoginViaWebAuthnComponentService implements LoginViaWebAuthnComponentService {
+  showTroubleLoggingInText = true;
+  leftAlignDescription = false;
+}

--- a/libs/angular/src/auth/login-via-webauthn/login-via-webauthn-component.service.ts
+++ b/libs/angular/src/auth/login-via-webauthn/login-via-webauthn-component.service.ts
@@ -1,0 +1,7 @@
+export abstract class LoginViaWebAuthnComponentService {
+  /** Whether to show the "Trouble logging in?" text. */
+  abstract showTroubleLoggingInText: boolean;
+
+  /** Whether to left-align the descriptive text. */
+  abstract leftAlignDescription: boolean;
+}

--- a/libs/angular/src/auth/login-via-webauthn/login-via-webauthn.component.html
+++ b/libs/angular/src/auth/login-via-webauthn/login-via-webauthn.component.html
@@ -1,20 +1,34 @@
 <div class="tw-flex tw-flex-col tw-items-center">
   <ng-container *ngIf="currentState === 'assert'">
-    <p bitTypography="body1" class="tw-text-center">{{ "readingPasskeyLoading" | i18n }}</p>
+    <p
+      bitTypography="body1"
+      [class.tw-self-start]="leftAlignDescription"
+      [class.tw-text-center]="!leftAlignDescription"
+    >
+      {{ "readingPasskeyLoading" | i18n }}
+    </p>
     <button type="button" bitButton block [loading]="true" buttonType="primary" class="tw-mb-4">
       {{ "loading" | i18n }}
     </button>
   </ng-container>
 
   <ng-container *ngIf="currentState === 'assertFailed'">
-    <p bitTypography="body1" class="tw-text-center">{{ "passkeyAuthenticationFailed" | i18n }}</p>
+    <p
+      bitTypography="body1"
+      [class.tw-self-start]="leftAlignDescription"
+      [class.tw-text-center]="!leftAlignDescription"
+    >
+      {{ "passkeyAuthenticationFailed" | i18n }}
+    </p>
     <button type="button" bitButton block buttonType="primary" class="tw-mb-4" (click)="retry()">
       {{ "tryAgain" | i18n }}
     </button>
   </ng-container>
 
   <p bitTypography="body1" class="tw-mb-0 tw-text-center">
-    {{ "troubleLoggingIn" | i18n }}<br />
-    <a bitLink routerLink="/login">{{ "useADifferentLogInMethod" | i18n }}</a>
+    @if (showTroubleLoggingInText) {
+      {{ "troubleLoggingIn" | i18n }}<br />
+    }
+    <a bitLink routerLink="/login">{{ "useDifferentLoginMethod" | i18n }}</a>
   </p>
 </div>

--- a/libs/angular/src/auth/login-via-webauthn/login-via-webauthn.component.ts
+++ b/libs/angular/src/auth/login-via-webauthn/login-via-webauthn.component.ts
@@ -31,6 +31,8 @@ import {
 } from "@bitwarden/components";
 import { KeyService } from "@bitwarden/key-management";
 
+import { LoginViaWebAuthnComponentService } from "./login-via-webauthn-component.service";
+
 export type State = "assert" | "assertFailed";
 // FIXME(https://bitwarden.atlassian.net/browse/CL-764): Migrate to OnPush
 // eslint-disable-next-line @angular-eslint/prefer-on-push-component-change-detection
@@ -50,6 +52,8 @@ export type State = "assert" | "assertFailed";
 })
 export class LoginViaWebAuthnComponent implements OnInit {
   protected currentState: State = "assert";
+  protected showTroubleLoggingInText: boolean;
+  protected leftAlignDescription: boolean;
   private shouldAutoClosePopout = false;
 
   protected readonly Icons = {
@@ -81,7 +85,11 @@ export class LoginViaWebAuthnComponent implements OnInit {
     private platformUtilsService: PlatformUtilsService,
     private anonLayoutWrapperDataService: AnonLayoutWrapperDataService,
     private messagingService: MessagingService,
-  ) {}
+    private loginViaWebAuthnComponentService: LoginViaWebAuthnComponentService,
+  ) {
+    this.showTroubleLoggingInText = this.loginViaWebAuthnComponentService.showTroubleLoggingInText;
+    this.leftAlignDescription = this.loginViaWebAuthnComponentService.leftAlignDescription;
+  }
 
   ngOnInit(): void {
     // Check if we should auto-close the popout after successful authentication
@@ -155,13 +163,13 @@ export class LoginViaWebAuthnComponent implements OnInit {
 
   private setDefaultIcon(): void {
     this.anonLayoutWrapperDataService.setAnonLayoutWrapperData({
-      pageIcon: this.Icons.TwoFactorAuthSecurityKeyIcon,
+      pageIcon: this.Icons.TwoFactorAuthSecurityKeyIcon, // layout decides whether to render it via hidePageIcon
     });
   }
 
   private setFailureIcon(): void {
     this.anonLayoutWrapperDataService.setAnonLayoutWrapperData({
-      pageIcon: this.Icons.TwoFactorAuthSecurityKeyFailedIcon,
+      pageIcon: this.Icons.TwoFactorAuthSecurityKeyFailedIcon, // layout decides whether to render it via hidePageIcon
     });
   }
 }

--- a/libs/auth/src/angular/login/login.component.html
+++ b/libs/auth/src/angular/login/login.component.html
@@ -1,15 +1,3 @@
-<!--
-  # Table of Contents
-
-    This file contains a single consolidated template for all visual clients.
-
-  # UI States
-
-    The template has two UI states, defined by the `LoginUiState` enum:
-      EMAIL_ENTRY: displays the email input field + continue button
-      MASTER_PASSWORD_ENTRY: displays the master password input field + login button
--->
-
 <form [bitSubmit]="submit" [formGroup]="formGroup">
   <div [ngClass]="{ 'tw-hidden': loginUiState !== LoginUiState.EMAIL_ENTRY }">
     <!-- Email Address input -->
@@ -102,13 +90,13 @@
 
     <!-- Link to Password Hint page - doesn't use bit-hint so that it doesn't get hidden on input validation errors -->
     <a bitLink routerLink="/hint" (click)="goToHint()" class="tw-inline-block tw-mb-4">
-      {{ "getMasterPasswordHint" | i18n }}
+      {{ "hint" | i18n }}
     </a>
 
     <div class="tw-grid tw-gap-3">
       <!-- Submit button to Login with Master Password -->
       <button type="submit" bitButton bitFormButton block buttonType="primary">
-        {{ "loginWithMasterPassword" | i18n }}
+        {{ "logIn" | i18n }}
       </button>
 
       <!-- Button to Login with Device -->

--- a/libs/auth/src/angular/login/login.component.ts
+++ b/libs/auth/src/angular/login/login.component.ts
@@ -66,7 +66,9 @@ const BroadcasterSubscriptionId = "LoginComponent";
 // FIXME: update to use a const object instead of a typescript enum
 // eslint-disable-next-line @bitwarden/platform/no-enums
 export enum LoginUiState {
+  /** Display the email input field + continue button */
   EMAIL_ENTRY = "EmailEntry",
+  /** Display the master password input field + login submit button */
   MASTER_PASSWORD_ENTRY = "MasterPasswordEntry",
 }
 
@@ -530,8 +532,8 @@ export class LoginComponent implements OnInit, OnDestroy {
       this.loginComponentService.showBackButton(false);
 
       this.anonLayoutWrapperDataService.setAnonLayoutWrapperData({
-        pageTitle: { key: "logInToBitwarden" },
-        pageIcon: this.Icons.VaultIcon,
+        pageTitle: { key: "loginPageEmailEntryScreenTitle" },
+        pageIcon: this.Icons.VaultIcon, // layout decides whether to render it via hidePageIcon
         pageSubtitle: null, // remove subtitle when going back to email entry
       });
 
@@ -542,10 +544,11 @@ export class LoginComponent implements OnInit, OnDestroy {
       this.isKnownDevice = false;
     } else if (this.loginUiState === LoginUiState.MASTER_PASSWORD_ENTRY) {
       this.loginComponentService.showBackButton(true);
+
       this.anonLayoutWrapperDataService.setAnonLayoutWrapperData({
-        pageTitle: { key: "welcomeBack" },
+        pageTitle: { key: "loginPageMasterPasswordEntryScreenTitle" },
         pageSubtitle: this.emailFormControl.value,
-        pageIcon: this.Icons.WaveIcon,
+        pageIcon: this.Icons.WaveIcon, // layout decides whether to render it via hidePageIcon
       });
 
       // Mark MP as untouched so that, when users enter email and hit enter, the MP field doesn't load with validation errors

--- a/libs/auth/src/angular/registration/registration-start/registration-start.component.html
+++ b/libs/auth/src/angular/registration/registration-start/registration-start.component.html
@@ -28,7 +28,7 @@
         formControlName="receiveMarketingEmails"
       />
       <bit-label for="register-start-form-input-receive-marketing-emails">
-        {{ "receiveMarketingEmailsV2" | i18n }}
+        {{ "receiveMarketingEmails" | i18n }}
         <a
           bitLink
           linkType="primary"
@@ -71,7 +71,7 @@
         target="_blank"
         rel="noreferrer"
         >{{ "privacyPolicy" | i18n }}</a
-      >
+      >.
     </p>
 
     <bit-error-summary *ngIf="showErrorSummary" [formGroup]="formGroup"></bit-error-summary></form

--- a/libs/auth/src/angular/registration/registration-start/registration-start.component.ts
+++ b/libs/auth/src/angular/registration/registration-start/registration-start.component.ts
@@ -7,7 +7,7 @@ import { ActivatedRoute, Router } from "@angular/router";
 import { Subject, takeUntil } from "rxjs";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
-import { RegistrationCheckEmailIcon, RegistrationUserAddIcon } from "@bitwarden/assets/svg";
+import { RegistrationCheckEmailIcon } from "@bitwarden/assets/svg";
 import { AccountApiService } from "@bitwarden/common/auth/abstractions/account-api.service";
 import { RegisterSendVerificationEmailRequest } from "@bitwarden/common/auth/models/request/registration/register-send-verification-email.request";
 import { RegionConfig, Region } from "@bitwarden/common/platform/abstractions/environment.service";
@@ -15,6 +15,7 @@ import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/pl
 // This import has been flagged as unallowed for this class. It may be involved in a circular dependency loop.
 // eslint-disable-next-line no-restricted-imports
 import {
+  ANON_LAYOUT_DEFAULTS,
   AnonLayoutWrapperDataService,
   AsyncActionsModule,
   ButtonModule,
@@ -175,6 +176,16 @@ export class RegistrationStartComponent implements OnInit, OnDestroy {
         key: "checkYourEmail",
       },
       pageIcon: RegistrationCheckEmailIcon,
+      // These four fields undo the extension SignUp route's compact/left/no-icon styling for
+      // the CHECK_EMAIL screen specifically. On web/desktop these values already match the
+      // wrapper defaults, so these overrides are visual no-ops. `goBack()`'s reset is
+      // symmetric across all clients: in resetToCachedRouteData(), ANON_LAYOUT_DEFAULTS is
+      // spread before the cached route data, so route-omitted fields get set to defaults,
+      // while route-declared fields get re-applied from the cached route data.
+      hidePageIcon: ANON_LAYOUT_DEFAULTS.hidePageIcon,
+      heroTextAlignment: ANON_LAYOUT_DEFAULTS.heroTextAlignment,
+      contentVerticalPadding: ANON_LAYOUT_DEFAULTS.contentVerticalPadding,
+      footerVerticalPadding: ANON_LAYOUT_DEFAULTS.footerVerticalPadding,
     });
     this.registrationStartStateChange.emit(this.state);
   };
@@ -199,12 +210,7 @@ export class RegistrationStartComponent implements OnInit, OnDestroy {
 
   goBack() {
     this.state = RegistrationStartState.USER_DATA_ENTRY;
-    this.anonLayoutWrapperDataService.setAnonLayoutWrapperData({
-      pageIcon: RegistrationUserAddIcon,
-      pageTitle: {
-        key: "createAccount",
-      },
-    });
+    this.anonLayoutWrapperDataService.resetToCachedRouteData();
     this.registrationStartStateChange.emit(this.state);
   }
 

--- a/libs/auth/src/angular/registration/registration-start/registration-start.stories.ts
+++ b/libs/auth/src/angular/registration/registration-start/registration-start.stories.ts
@@ -107,6 +107,9 @@ const decorators = (options: {
             setAnonLayoutWrapperData: (data: AnonLayoutWrapperData) => {
               return;
             },
+            resetToCachedRouteData: () => {
+              return;
+            },
           } as Partial<AnonLayoutWrapperDataService>,
         },
         {

--- a/libs/components/src/anon-layout/anon-layout-defaults.ts
+++ b/libs/components/src/anon-layout/anon-layout-defaults.ts
@@ -1,0 +1,34 @@
+import {
+  LANDING_CONTENT_VERTICAL_PADDING_DEFAULT,
+  LANDING_FOOTER_VERTICAL_PADDING_DEFAULT,
+  LANDING_HERO_TEXT_ALIGNMENT_DEFAULT,
+} from "../landing-layout";
+
+import type { AnonLayoutWrapperData } from "./anon-layout-wrapper.component";
+
+/**
+ * Default values for every field on {@link AnonLayoutWrapperData}.
+ *
+ * Spread under the cached route payload in `resetToCachedRouteData()` so the reset
+ * emits a complete payload — route-declared values win where present, defaults clear
+ * any imperative overrides for fields the route didn't declare.
+ *
+ * Also referenced from `AnonLayoutComponent`'s `input<>()` declarations to keep the
+ * component-level default and the reset-time default in lockstep. Landing-layout
+ * primitives source their defaults from {@link ../landing-layout/landing-defaults}
+ * so the dependency stays one-way (`anon-layout → landing-layout`).
+ */
+export const ANON_LAYOUT_DEFAULTS: Required<AnonLayoutWrapperData> = {
+  pageTitle: null,
+  pageSubtitle: null,
+  pageIcon: null,
+  hidePageIcon: false,
+  contentVerticalPadding: LANDING_CONTENT_VERTICAL_PADDING_DEFAULT,
+  footerVerticalPadding: LANDING_FOOTER_VERTICAL_PADDING_DEFAULT,
+  heroTextAlignment: LANDING_HERO_TEXT_ALIGNMENT_DEFAULT,
+  showReadonlyHostname: false,
+  maxWidth: "md",
+  hideCardWrapper: false,
+  hideBackgroundIllustration: false,
+  secondaryContentLocation: "main",
+};

--- a/libs/components/src/anon-layout/anon-layout-wrapper-data.service.ts
+++ b/libs/components/src/anon-layout/anon-layout-wrapper-data.service.ts
@@ -17,4 +17,21 @@ export abstract class AnonLayoutWrapperDataService {
    * Reactively gets the current AnonLayoutWrapperData.
    */
   abstract anonLayoutWrapperData$(): Observable<Partial<AnonLayoutWrapperData>>;
+
+  /**
+   * Caches the route-data payload so that `resetToCachedRouteData()` can later restore it.
+   * Called by the wrapper components (`AnonLayoutWrapperComponent`,
+   * `ExtensionAnonLayoutWrapperComponent`) when they apply route data. Does not emit.
+   */
+  abstract cacheRouteData(data: Partial<AnonLayoutWrapperData>): void;
+
+  /**
+   * Re-emits the most recently cached route-data payload through `anonLayoutWrapperData$()`,
+   * undoing any subsequent imperative overrides applied via `setAnonLayoutWrapperData()`.
+   *
+   * Components with intra-route state transitions that imperatively override layout state
+   * can call this to roll back to the original route-declared fields (while spreading
+   * defaults for any fields the route omitted).
+   */
+  abstract resetToCachedRouteData(): void;
 }

--- a/libs/components/src/anon-layout/anon-layout-wrapper.component.html
+++ b/libs/components/src/anon-layout/anon-layout-wrapper.component.html
@@ -6,9 +6,20 @@
   [maxWidth]="maxWidth"
   [hideCardWrapper]="hideCardWrapper"
   [hideBackgroundIllustration]="hideBackgroundIllustration"
+  [hidePageIcon]="hidePageIcon"
+  [contentVerticalPadding]="contentVerticalPadding"
+  [footerVerticalPadding]="footerVerticalPadding"
+  [heroTextAlignment]="heroTextAlignment"
+  [secondaryContentLocation]="secondaryContentLocation"
 >
   <router-outlet slot="header-actions" name="header-actions"></router-outlet>
   <router-outlet></router-outlet>
-  <router-outlet slot="secondary" name="secondary"></router-outlet>
+  <!-- The shared layout exposes two distinct slot selectors. We pick which one -->
+  <!-- to project into based on the route-level secondaryContentLocation flag. -->
+  @if (secondaryContentLocation === "footer") {
+    <router-outlet slot="footer-secondary" name="secondary"></router-outlet>
+  } @else {
+    <router-outlet slot="secondary" name="secondary"></router-outlet>
+  }
   <router-outlet slot="environment-selector" name="environment-selector"></router-outlet>
 </auth-anon-layout>

--- a/libs/components/src/anon-layout/anon-layout-wrapper.component.ts
+++ b/libs/components/src/anon-layout/anon-layout-wrapper.component.ts
@@ -7,10 +7,16 @@ import { BitSvg } from "@bitwarden/assets/svg";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 
 import { Translation } from "../dialog";
-import { LandingContentMaxWidthType } from "../landing-layout";
+import {
+  ContentVerticalPaddingType,
+  FooterVerticalPaddingType,
+  HeroTextAlignmentType,
+  LandingContentMaxWidthType,
+} from "../landing-layout";
 
+import { ANON_LAYOUT_DEFAULTS } from "./anon-layout-defaults";
 import { AnonLayoutWrapperDataService } from "./anon-layout-wrapper-data.service";
-import { AnonLayoutComponent } from "./anon-layout.component";
+import { AnonLayoutComponent, SecondaryContentLocationType } from "./anon-layout.component";
 export interface AnonLayoutWrapperData {
   /**
    * The optional title of the page.
@@ -26,8 +32,35 @@ export interface AnonLayoutWrapperData {
   pageSubtitle?: string | Translation | null;
   /**
    * The icon to display on the page. Pass null to hide the icon.
+   *
+   * Optional. The layout itself decides whether to render the icon based on `hidePageIcon`;
+   * this field just supplies which icon to render when it is shown.
    */
-  pageIcon: BitSvg | null;
+  pageIcon?: BitSvg | null;
+  /**
+   * Whether to hide the page icon. Defaults to false (icon is shown).
+   *
+   * When true, the layout suppresses the icon even if `pageIcon` is set.
+   */
+  hidePageIcon?: boolean;
+  /**
+   * Vertical padding of the content area. Defaults to "default".
+   *
+   * "compact" reduces the vertical padding so more content fits. Use in scenarios where vertical space is at a premium.
+   */
+  contentVerticalPadding?: ContentVerticalPaddingType;
+  /**
+   * Vertical padding of the footer. Defaults to "default".
+   *
+   * "compact" reduces the vertical padding so more content fits. Use in scenarios where vertical space is at a premium.
+   */
+  footerVerticalPadding?: FooterVerticalPaddingType;
+  /**
+   * Horizontal alignment of the hero's title and subtitle. Defaults to "center".
+   * (The icon is always centered. Pair with `hidePageIcon: true` for a fully
+   * left-aligned hero block.)
+   */
+  heroTextAlignment?: HeroTextAlignmentType;
   /**
    * Optional flag to either show the optional environment selector (false) or just a readonly hostname (true).
    */
@@ -44,6 +77,13 @@ export interface AnonLayoutWrapperData {
    * Hides the background illustration. Defaults to false.
    */
   hideBackgroundIllustration?: boolean;
+  /**
+   * Where to render content from the route's `outlet: "secondary"` router outlet. Defaults to "main".
+   *
+   * "main" places the secondary content beneath the main card.
+   * "footer" places it inside the footer.
+   */
+  secondaryContentLocation?: SecondaryContentLocationType;
 }
 
 // FIXME(https://bitwarden.atlassian.net/browse/CL-764): Migrate to OnPush
@@ -62,6 +102,11 @@ export class AnonLayoutWrapperComponent implements OnInit {
   protected maxWidth?: LandingContentMaxWidthType | null;
   protected hideCardWrapper?: boolean | null;
   protected hideBackgroundIllustration?: boolean | null;
+  protected hidePageIcon?: boolean;
+  protected contentVerticalPadding?: ContentVerticalPaddingType;
+  protected footerVerticalPadding?: FooterVerticalPaddingType;
+  protected heroTextAlignment?: HeroTextAlignmentType;
+  protected secondaryContentLocation?: SecondaryContentLocationType;
 
   constructor(
     private router: Router,
@@ -112,10 +157,31 @@ export class AnonLayoutWrapperComponent implements OnInit {
       this.pageIcon = firstChildRouteData["pageIcon"];
     }
 
-    this.showReadonlyHostname = Boolean(firstChildRouteData["showReadonlyHostname"]);
-    this.maxWidth = firstChildRouteData["maxWidth"];
-    this.hideCardWrapper = Boolean(firstChildRouteData["hideCardWrapper"]);
-    this.hideBackgroundIllustration = Boolean(firstChildRouteData["hideBackgroundIllustration"]);
+    // When undefined, fall back to ANON_LAYOUT_DEFAULTS — single source of truth for
+    // route-init defaults, the reset emission, and the component-level input defaults.
+    this.showReadonlyHostname =
+      firstChildRouteData["showReadonlyHostname"] ?? ANON_LAYOUT_DEFAULTS.showReadonlyHostname;
+    this.maxWidth = firstChildRouteData["maxWidth"] ?? ANON_LAYOUT_DEFAULTS.maxWidth;
+    this.hideCardWrapper =
+      firstChildRouteData["hideCardWrapper"] ?? ANON_LAYOUT_DEFAULTS.hideCardWrapper;
+    this.hideBackgroundIllustration =
+      firstChildRouteData["hideBackgroundIllustration"] ??
+      ANON_LAYOUT_DEFAULTS.hideBackgroundIllustration;
+    this.hidePageIcon = firstChildRouteData["hidePageIcon"] ?? ANON_LAYOUT_DEFAULTS.hidePageIcon;
+    this.contentVerticalPadding =
+      firstChildRouteData["contentVerticalPadding"] ?? ANON_LAYOUT_DEFAULTS.contentVerticalPadding;
+    this.footerVerticalPadding =
+      firstChildRouteData["footerVerticalPadding"] ?? ANON_LAYOUT_DEFAULTS.footerVerticalPadding;
+    this.heroTextAlignment =
+      firstChildRouteData["heroTextAlignment"] ?? ANON_LAYOUT_DEFAULTS.heroTextAlignment;
+    this.secondaryContentLocation =
+      firstChildRouteData["secondaryContentLocation"] ??
+      ANON_LAYOUT_DEFAULTS.secondaryContentLocation;
+
+    // Cache the route-data payload so resetToCachedRouteData() can later restore it.
+    this.anonLayoutWrapperDataService.cacheRouteData(
+      firstChildRouteData as Partial<AnonLayoutWrapperData>,
+    );
   }
 
   private listenForServiceDataChanges() {
@@ -123,11 +189,11 @@ export class AnonLayoutWrapperComponent implements OnInit {
       .anonLayoutWrapperData$()
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((data: Partial<AnonLayoutWrapperData>) => {
-        this.setAnonLayoutWrapperData(data);
+        this.setAnonLayoutWrapperDataFromService(data);
       });
   }
 
-  private setAnonLayoutWrapperData(data: Partial<AnonLayoutWrapperData>) {
+  private setAnonLayoutWrapperDataFromService(data: Partial<AnonLayoutWrapperData>) {
     if (!data) {
       return;
     }
@@ -163,6 +229,22 @@ export class AnonLayoutWrapperComponent implements OnInit {
       this.maxWidth = data.maxWidth;
     }
 
+    if (data.hidePageIcon !== undefined) {
+      this.hidePageIcon = data.hidePageIcon;
+    }
+    if (data.contentVerticalPadding !== undefined) {
+      this.contentVerticalPadding = data.contentVerticalPadding;
+    }
+    if (data.footerVerticalPadding !== undefined) {
+      this.footerVerticalPadding = data.footerVerticalPadding;
+    }
+    if (data.heroTextAlignment !== undefined) {
+      this.heroTextAlignment = data.heroTextAlignment;
+    }
+    if (data.secondaryContentLocation !== undefined) {
+      this.secondaryContentLocation = data.secondaryContentLocation;
+    }
+
     // Manually fire change detection to avoid ExpressionChangedAfterItHasBeenCheckedError
     // when setting the page data from a service
     this.changeDetectorRef.detectChanges();
@@ -186,5 +268,10 @@ export class AnonLayoutWrapperComponent implements OnInit {
     this.maxWidth = null;
     this.hideCardWrapper = null;
     this.hideBackgroundIllustration = null;
+    this.hidePageIcon = undefined;
+    this.contentVerticalPadding = undefined;
+    this.footerVerticalPadding = undefined;
+    this.heroTextAlignment = undefined;
+    this.secondaryContentLocation = undefined;
   }
 }

--- a/libs/components/src/anon-layout/anon-layout.component.html
+++ b/libs/components/src/anon-layout/anon-layout.component.html
@@ -3,8 +3,13 @@
     <ng-content select="[slot=header-actions]"></ng-content>
   </bit-landing-header>
 
-  <bit-landing-content [maxWidth]="maxWidth()">
-    <bit-landing-hero [icon]="icon()" [title]="title()" [subtitle]="subtitle()"></bit-landing-hero>
+  <bit-landing-content [maxWidth]="maxWidth()" [contentVerticalPadding]="contentVerticalPadding()">
+    <bit-landing-hero
+      [icon]="hidePageIcon() ? null : icon()"
+      [title]="title()"
+      [subtitle]="subtitle()"
+      [heroTextAlignment]="heroTextAlignment()"
+    ></bit-landing-hero>
     @if (hideCardWrapper()) {
       <div class="tw-mb-6 sm:tw-mb-10">
         <ng-container *ngTemplateOutlet="defaultContent"></ng-container>
@@ -20,12 +25,19 @@
   </bit-landing-content>
 
   @if (!hideFooter()) {
-    <bit-landing-footer>
-      @if (showReadonlyHostname()) {
-        <div bitTypography="body2">{{ "accessing" | i18n }} {{ hostname }}</div>
-      } @else {
-        <ng-content select="[slot=environment-selector]"></ng-content>
-      }
+    <bit-landing-footer [footerVerticalPadding]="footerVerticalPadding()">
+      <div [class]="footerLayoutClasses()">
+        <!-- Wrappers project here when secondaryContentLocation === "footer". Two -->
+        <!-- distinct slot names are required because Angular projects to the first -->
+        <!-- matching <ng-content>, so @if-guarded duplicate selectors won't switch. -->
+        <ng-content select="[slot=footer-secondary]"></ng-content>
+
+        @if (showReadonlyHostname()) {
+          <div bitTypography="body2">{{ "accessing" | i18n }} {{ hostname }}</div>
+        } @else {
+          <ng-content select="[slot=environment-selector]"></ng-content>
+        }
+      </div>
 
       @if (!hideYearAndVersion) {
         <div bitTypography="body2">&copy; {{ year }} Bitwarden Inc.</div>

--- a/libs/components/src/anon-layout/anon-layout.component.ts
+++ b/libs/components/src/anon-layout/anon-layout.component.ts
@@ -5,6 +5,7 @@ import {
   OnChanges,
   OnInit,
   SimpleChanges,
+  computed,
   input,
   model,
 } from "@angular/core";
@@ -17,10 +18,19 @@ import { EnvironmentService } from "@bitwarden/common/platform/abstractions/envi
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { I18nPipe } from "@bitwarden/ui-common";
 
-import { LandingContentMaxWidthType } from "../landing-layout";
+import {
+  ContentVerticalPaddingType,
+  FooterVerticalPaddingType,
+  HeroTextAlignmentType,
+  LandingContentMaxWidthType,
+} from "../landing-layout";
 import { LandingLayoutModule } from "../landing-layout/landing-layout.module";
 import { SvgModule } from "../svg";
 import { TypographyModule } from "../typography";
+
+import { ANON_LAYOUT_DEFAULTS } from "./anon-layout-defaults";
+
+export type SecondaryContentLocationType = "main" | "footer";
 
 // FIXME(https://bitwarden.atlassian.net/browse/CL-764): Migrate to OnPush
 // eslint-disable-next-line @angular-eslint/prefer-on-push-component-change-detection
@@ -39,18 +49,36 @@ export class AnonLayoutComponent implements OnInit, OnChanges {
   readonly title = input<string>();
   readonly subtitle = input<string>();
   readonly icon = model.required<BitSvg | null>();
-  readonly showReadonlyHostname = input<boolean>(false);
+  readonly showReadonlyHostname = input<boolean>(ANON_LAYOUT_DEFAULTS.showReadonlyHostname);
   readonly hideLogo = input<boolean>(false);
   readonly hideFooter = input<boolean>(false);
-  readonly hideCardWrapper = input<boolean>(false);
-  readonly hideBackgroundIllustration = input<boolean>(false);
+  readonly hideCardWrapper = input<boolean>(ANON_LAYOUT_DEFAULTS.hideCardWrapper);
+  readonly hideBackgroundIllustration = input<boolean>(
+    ANON_LAYOUT_DEFAULTS.hideBackgroundIllustration,
+  );
+
+  readonly hidePageIcon = input<boolean>(ANON_LAYOUT_DEFAULTS.hidePageIcon);
+  readonly contentVerticalPadding = input<ContentVerticalPaddingType>(
+    ANON_LAYOUT_DEFAULTS.contentVerticalPadding,
+  );
+  readonly footerVerticalPadding = input<FooterVerticalPaddingType>(
+    ANON_LAYOUT_DEFAULTS.footerVerticalPadding,
+  );
+  readonly heroTextAlignment = input<HeroTextAlignmentType>(ANON_LAYOUT_DEFAULTS.heroTextAlignment);
+  readonly secondaryContentLocation = input<SecondaryContentLocationType>(
+    ANON_LAYOUT_DEFAULTS.secondaryContentLocation,
+  );
+
+  protected readonly footerLayoutClasses = computed(() =>
+    this.secondaryContentLocation() === "footer" ? "tw-grid tw-gap-6" : "",
+  );
 
   /**
    * Max width of the anon layout title, subtitle, and content areas.
    *
    * @default 'md'
    */
-  readonly maxWidth = model<LandingContentMaxWidthType>("md");
+  readonly maxWidth = model<LandingContentMaxWidthType>(ANON_LAYOUT_DEFAULTS.maxWidth);
 
   protected logo = BitwardenLogo;
   protected year: string;
@@ -70,14 +98,14 @@ export class AnonLayoutComponent implements OnInit, OnChanges {
   }
 
   async ngOnInit() {
-    this.maxWidth.set(this.maxWidth() ?? "md");
+    this.maxWidth.set(this.maxWidth() ?? ANON_LAYOUT_DEFAULTS.maxWidth);
     this.hostname = (await firstValueFrom(this.environmentService.environment$)).getHostname();
     this.version = await this.platformUtilsService.getApplicationVersion();
   }
 
   async ngOnChanges(changes: SimpleChanges) {
     if (changes.maxWidth) {
-      this.maxWidth.set(changes.maxWidth.currentValue ?? "md");
+      this.maxWidth.set(changes.maxWidth.currentValue ?? ANON_LAYOUT_DEFAULTS.maxWidth);
     }
   }
 }

--- a/libs/components/src/anon-layout/default-anon-layout-wrapper-data.service.spec.ts
+++ b/libs/components/src/anon-layout/default-anon-layout-wrapper-data.service.spec.ts
@@ -1,0 +1,108 @@
+import { ANON_LAYOUT_DEFAULTS } from "./anon-layout-defaults";
+import { AnonLayoutWrapperData } from "./anon-layout-wrapper.component";
+import { DefaultAnonLayoutWrapperDataService } from "./default-anon-layout-wrapper-data.service";
+
+describe("DefaultAnonLayoutWrapperDataService", () => {
+  let service: DefaultAnonLayoutWrapperDataService;
+  let emissions: Partial<AnonLayoutWrapperData>[];
+
+  beforeEach(() => {
+    service = new DefaultAnonLayoutWrapperDataService();
+    emissions = [];
+    service.anonLayoutWrapperData$().subscribe((data) => emissions.push(data));
+  });
+
+  describe("setAnonLayoutWrapperData", () => {
+    it("emits the data to subscribers of anonLayoutWrapperData$", () => {
+      const data: Partial<AnonLayoutWrapperData> = { pageTitle: "Welcome" };
+
+      service.setAnonLayoutWrapperData(data);
+
+      expect(emissions).toEqual([data]);
+    });
+
+    it("emits sequentially for multiple calls", () => {
+      service.setAnonLayoutWrapperData({ pageTitle: "First" });
+      service.setAnonLayoutWrapperData({ pageTitle: "Second" });
+
+      expect(emissions).toEqual([{ pageTitle: "First" }, { pageTitle: "Second" }]);
+    });
+  });
+
+  describe("anonLayoutWrapperData$", () => {
+    it("uses a non-replaying Subject (late subscribers don't see past emissions)", () => {
+      service.setAnonLayoutWrapperData({ pageTitle: "Before subscribe" });
+
+      const lateEmissions: Partial<AnonLayoutWrapperData>[] = [];
+      service.anonLayoutWrapperData$().subscribe((data) => lateEmissions.push(data));
+
+      expect(lateEmissions).toEqual([]);
+    });
+  });
+
+  describe("cacheRouteData", () => {
+    it("does not emit through anonLayoutWrapperData$", () => {
+      service.cacheRouteData({ pageTitle: "Cached" });
+
+      expect(emissions).toEqual([]);
+    });
+
+    it("overwrites prior cached data on subsequent calls", () => {
+      service.cacheRouteData({ pageTitle: "First" });
+      service.cacheRouteData({ pageSubtitle: "Second" });
+      service.resetToCachedRouteData();
+
+      // Second cache's value wins.
+      expect(emissions[0].pageSubtitle).toBe("Second");
+      // First cache's value is gone (cache is replaced, not merged); falls back to default.
+      expect(emissions[0].pageTitle).toBe(ANON_LAYOUT_DEFAULTS.pageTitle);
+    });
+  });
+
+  describe("resetToCachedRouteData", () => {
+    it("emits ANON_LAYOUT_DEFAULTS when no cache has been set", () => {
+      service.resetToCachedRouteData();
+
+      expect(emissions[0]).toEqual(ANON_LAYOUT_DEFAULTS);
+    });
+
+    it("spreads cached values over ANON_LAYOUT_DEFAULTS", () => {
+      service.cacheRouteData({ pageTitle: "Cached title", hidePageIcon: true });
+      service.resetToCachedRouteData();
+
+      expect(emissions[0]).toEqual({
+        ...ANON_LAYOUT_DEFAULTS,
+        pageTitle: "Cached title",
+        hidePageIcon: true,
+      });
+    });
+
+    it("cached values win over default values where keys overlap", () => {
+      // ANON_LAYOUT_DEFAULTS.hidePageIcon is false; cache it as true.
+      service.cacheRouteData({ hidePageIcon: true });
+      service.resetToCachedRouteData();
+
+      expect(emissions[0].hidePageIcon).toBe(true);
+    });
+
+    it("emits default values for keys the cache doesn't declare", () => {
+      service.cacheRouteData({ pageTitle: "Only title" });
+      service.resetToCachedRouteData();
+
+      // pageIcon wasn't cached, so it should fall back to the default (null).
+      expect(emissions[0].pageIcon).toBe(ANON_LAYOUT_DEFAULTS.pageIcon);
+      expect(emissions[0].hidePageIcon).toBe(ANON_LAYOUT_DEFAULTS.hidePageIcon);
+      expect(emissions[0].contentVerticalPadding).toBe(ANON_LAYOUT_DEFAULTS.contentVerticalPadding);
+    });
+
+    it("emits a complete payload containing every ANON_LAYOUT_DEFAULTS key", () => {
+      service.cacheRouteData({ pageTitle: "Some title" });
+      service.resetToCachedRouteData();
+
+      // Every key in ANON_LAYOUT_DEFAULTS should appear in the emission.
+      for (const key of Object.keys(ANON_LAYOUT_DEFAULTS) as (keyof AnonLayoutWrapperData)[]) {
+        expect(emissions[0]).toHaveProperty(key);
+      }
+    });
+  });
+});

--- a/libs/components/src/anon-layout/default-anon-layout-wrapper-data.service.ts
+++ b/libs/components/src/anon-layout/default-anon-layout-wrapper-data.service.ts
@@ -1,10 +1,12 @@
 import { Observable, Subject } from "rxjs";
 
+import { ANON_LAYOUT_DEFAULTS } from "./anon-layout-defaults";
 import { AnonLayoutWrapperDataService } from "./anon-layout-wrapper-data.service";
 import { AnonLayoutWrapperData } from "./anon-layout-wrapper.component";
 
 export class DefaultAnonLayoutWrapperDataService implements AnonLayoutWrapperDataService {
   protected anonLayoutWrapperDataSubject = new Subject<Partial<AnonLayoutWrapperData>>();
+  protected cachedRouteData: Partial<AnonLayoutWrapperData> = {};
 
   setAnonLayoutWrapperData(data: Partial<AnonLayoutWrapperData>): void {
     this.anonLayoutWrapperDataSubject.next(data);
@@ -12,5 +14,19 @@ export class DefaultAnonLayoutWrapperDataService implements AnonLayoutWrapperDat
 
   anonLayoutWrapperData$(): Observable<Partial<AnonLayoutWrapperData>> {
     return this.anonLayoutWrapperDataSubject.asObservable();
+  }
+
+  cacheRouteData(data: Partial<AnonLayoutWrapperData>): void {
+    this.cachedRouteData = data;
+  }
+
+  resetToCachedRouteData(): void {
+    // Spread defaults before the cached payload so the emitted object is complete:
+    // route-declared fields win where present; unset fields fall back to ANON_LAYOUT_DEFAULTS,
+    // which clears stale imperative overrides for fields the route didn't declare.
+    this.anonLayoutWrapperDataSubject.next({
+      ...ANON_LAYOUT_DEFAULTS,
+      ...this.cachedRouteData,
+    });
   }
 }

--- a/libs/components/src/anon-layout/index.ts
+++ b/libs/components/src/anon-layout/index.ts
@@ -1,3 +1,4 @@
+export * from "./anon-layout-defaults";
 export * from "./anon-layout-wrapper-data.service";
 export * from "./anon-layout-wrapper.component";
 export * from "./anon-layout.component";

--- a/libs/components/src/landing-layout/index.ts
+++ b/libs/components/src/landing-layout/index.ts
@@ -1,3 +1,4 @@
+export * from "./landing-defaults";
 export * from "./landing-layout.component";
 export * from "./landing-layout.module";
 export * from "./landing-card.component";

--- a/libs/components/src/landing-layout/landing-content.component.html
+++ b/libs/components/src/landing-layout/landing-content.component.html
@@ -1,5 +1,7 @@
 <div
-  class="tw-flex tw-flex-col tw-flex-1 tw-items-center tw-bg-background-alt tw-p-5 tw-pt-12 tw-text-main"
+  class="tw-flex tw-flex-col tw-flex-1 tw-items-center tw-bg-background-alt tw-p-5 tw-text-main"
+  [class.tw-py-3]="contentVerticalPadding() === 'compact'"
+  [class.tw-pt-12]="contentVerticalPadding() === 'default'"
 >
   <div [class]="maxWidthClasses()">
     <ng-content select="bit-landing-hero"></ng-content>

--- a/libs/components/src/landing-layout/landing-content.component.ts
+++ b/libs/components/src/landing-layout/landing-content.component.ts
@@ -1,8 +1,12 @@
 import { ChangeDetectionStrategy, Component, computed, input } from "@angular/core";
 
+import { LANDING_CONTENT_VERTICAL_PADDING_DEFAULT } from "./landing-defaults";
+
 export const LandingContentMaxWidth = ["md", "lg", "xl", "2xl", "3xl", "4xl"] as const;
 
 export type LandingContentMaxWidthType = (typeof LandingContentMaxWidth)[number];
+
+export type ContentVerticalPaddingType = "compact" | "default";
 
 /**
  * Main content container for landing pages with configurable max-width constraints.
@@ -46,6 +50,15 @@ export class LandingContentComponent {
    * @default "md"
    */
   readonly maxWidth = input<LandingContentMaxWidthType>("md");
+
+  /**
+   * Vertical padding of the content area. Defaults to "default".
+   *
+   * "compact" reduces the vertical padding.
+   */
+  readonly contentVerticalPadding = input<ContentVerticalPaddingType>(
+    LANDING_CONTENT_VERTICAL_PADDING_DEFAULT,
+  );
 
   private readonly maxWidthClassMap: Record<LandingContentMaxWidthType, string> = {
     md: "tw-max-w-md",

--- a/libs/components/src/landing-layout/landing-defaults.ts
+++ b/libs/components/src/landing-layout/landing-defaults.ts
@@ -1,0 +1,11 @@
+/**
+ * Default values for the landing-layout primitive components.
+ *
+ * These are referenced from each landing-* component's `input<>()` declaration *and* from
+ * `ANON_LAYOUT_DEFAULTS` in the `anon-layout` folder, so the standalone-component default and
+ * the reset-time default in `resetToCachedRouteData()` cannot drift. Co-locating them here
+ * also keeps the dependency one-way: `anon-layout → landing-layout`.
+ */
+export const LANDING_CONTENT_VERTICAL_PADDING_DEFAULT = "default" as const;
+export const LANDING_FOOTER_VERTICAL_PADDING_DEFAULT = "default" as const;
+export const LANDING_HERO_TEXT_ALIGNMENT_DEFAULT = "center" as const;

--- a/libs/components/src/landing-layout/landing-footer.component.html
+++ b/libs/components/src/landing-layout/landing-footer.component.html
@@ -1,3 +1,3 @@
-<footer class="tw-bg-background-alt tw-text-center tw-p-5 tw-pt-4 sm:tw-pt-6">
+<footer class="tw-bg-background-alt tw-text-center tw-px-5" [class]="paddingClasses()">
   <ng-content></ng-content>
 </footer>

--- a/libs/components/src/landing-layout/landing-footer.component.ts
+++ b/libs/components/src/landing-layout/landing-footer.component.ts
@@ -1,4 +1,8 @@
-import { ChangeDetectionStrategy, Component } from "@angular/core";
+import { ChangeDetectionStrategy, Component, computed, input } from "@angular/core";
+
+import { LANDING_FOOTER_VERTICAL_PADDING_DEFAULT } from "./landing-defaults";
+
+export type FooterVerticalPaddingType = "compact" | "default";
 
 /**
  * Footer component for landing pages.
@@ -26,4 +30,17 @@ import { ChangeDetectionStrategy, Component } from "@angular/core";
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: "./landing-footer.component.html",
 })
-export class LandingFooterComponent {}
+export class LandingFooterComponent {
+  /**
+   * Vertical padding of the footer. Defaults to "default".
+   *
+   * "compact" reduces the vertical padding.
+   */
+  readonly footerVerticalPadding = input<FooterVerticalPaddingType>(
+    LANDING_FOOTER_VERTICAL_PADDING_DEFAULT,
+  );
+
+  protected readonly paddingClasses = computed(() =>
+    this.footerVerticalPadding() === "compact" ? "tw-py-3" : "tw-pb-5 tw-pt-4 sm:tw-pt-6",
+  );
+}

--- a/libs/components/src/landing-layout/landing-hero.component.html
+++ b/libs/components/src/landing-layout/landing-hero.component.html
@@ -1,5 +1,5 @@
 @if (icon() || title() || subtitle()) {
-  <div class="tw-text-center tw-mb-4 sm:tw-mb-6 tw-mx-auto">
+  <div class="tw-mb-4 sm:tw-mb-6" [class]="alignmentClasses()">
     @if (icon()) {
       <!-- In some scenarios this icon's size is not limited by container width correctly -->
       <!-- Targeting the SVG here to try and ensure it never grows too large in even the media queries are not working as expected -->
@@ -22,7 +22,9 @@
     }
 
     @if (subtitle()) {
-      <div class="tw-text-sm sm:tw-text-base">{{ subtitle() }}</div>
+      <div class="tw-text-sm tw-mt-4 sm:tw-mt-0 sm:tw-text-base">
+        {{ subtitle() }}
+      </div>
     }
   </div>
 }

--- a/libs/components/src/landing-layout/landing-hero.component.ts
+++ b/libs/components/src/landing-layout/landing-hero.component.ts
@@ -1,9 +1,13 @@
-import { ChangeDetectionStrategy, Component, input } from "@angular/core";
+import { ChangeDetectionStrategy, Component, computed, input } from "@angular/core";
 
 import { BitSvg } from "@bitwarden/assets/svg";
 
 import { SvgModule } from "../svg";
 import { TypographyModule } from "../typography";
+
+import { LANDING_HERO_TEXT_ALIGNMENT_DEFAULT } from "./landing-defaults";
+
+export type HeroTextAlignmentType = "left" | "center";
 
 /**
  * Hero section component for landing pages featuring an optional icon, title, and subtitle.
@@ -37,4 +41,15 @@ export class LandingHeroComponent {
   readonly icon = input<BitSvg | null>(null);
   readonly title = input<string | undefined>();
   readonly subtitle = input<string | undefined>();
+
+  /**
+   * Horizontal alignment of the hero's title and subtitle. Defaults to "center".
+   * (The icon is always centered. Pair with `hidePageIcon: true` for a fully
+   * left-aligned hero block.)
+   */
+  readonly heroTextAlignment = input<HeroTextAlignmentType>(LANDING_HERO_TEXT_ALIGNMENT_DEFAULT);
+
+  protected readonly alignmentClasses = computed(() =>
+    this.heroTextAlignment() === "left" ? "tw-text-left" : "tw-text-center tw-mx-auto",
+  );
 }


### PR DESCRIPTION
## 🎟️ Tracking

Cherry-pick to `rc`. Original PR here: https://github.com/bitwarden/clients/pull/20478 ([PM-32445](https://bitwarden.atlassian.net/browse/PM-32445))

## 📔 Objective

Makes design adjustments so that a scrollbar does not appear on particular Extension pages:
- /login
- /login-with-passkey
- /signup
- /lock

(cherry picked from commit 9fc071c65ebe248b8a31bb57c9f7251ab905a8a6)

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->


[PM-32445]: https://bitwarden.atlassian.net/browse/PM-32445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ