### PR TITLE
[PM-39206] use block input to ensure radios are displayed stacked

### DIFF
--- a/apps/web/src/app/admin-console/organizations/members/components/edit-member-dialog/edit-member-dialog.component.html
+++ b/apps/web/src/app/admin-console/organizations/members/components/edit-member-dialog/edit-member-dialog.component.html
@@ -20,7 +20,7 @@
     @if (!loading() && organization$ | async; as organization) {
       <bit-tab-group [selectedIndex]="tabIndex()" (selectedIndexChange)="tabIndex.set($event)">
         <bit-tab [label]="'role' | i18n">
-          <bit-radio-group formControlName="type">
+          <bit-radio-group formControlName="type" [block]="true">
             <bit-label>
               {{ "memberRole" | i18n }}
               <a

--- a/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.html
+++ b/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.html
@@ -53,7 +53,7 @@
               </bit-form-field>
             }
           }
-          <bit-radio-group formControlName="type">
+          <bit-radio-group formControlName="type" [block]="true">
             <bit-label>
               {{ "memberRole" | i18n }}
               <a

--- a/bitwarden_license/bit-web/src/app/auth/sso/sso-manage.component.html
+++ b/bitwarden_license/bit-web/src/app/auth/sso/sso-manage.component.html
@@ -35,7 +35,7 @@
         </bit-hint>
       </bit-form-field>
 
-      <bit-radio-group formControlName="memberDecryptionType">
+      <bit-radio-group formControlName="memberDecryptionType" [block]="true">
         <bit-label>{{ "memberDecryptionOption" | i18n }}</bit-label>
 
         <bit-radio-button


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-39206

## 📔 Objective
Recent changes to radio group 'broke' group rendering. Previously, even if `block="true"` was not explicitly passed to the group, sometimes, depending on label/hint text length the browser would still render them stacked due to how inline elements naturally wrap. We updated the group component to use flex recently, with that change, exposed this previously invisible bug. 

- Add `block="true"` to radio groups to mirror previous behavior

## 📸 Screenshots
<img width="790" height="820" alt="image" src="https://github.com/user-attachments/assets/a0cb85fc-b475-46d7-b55d-3aa17644bba8" />

<img width="1048" height="629" alt="image" src="https://github.com/user-attachments/assets/623e94e2-67f7-4605-962f-2c07af965a0a" />

<img width="831" height="649" alt="image" src="https://github.com/user-attachments/assets/89f5e539-4f52-4ec6-9e97-812c64d78ef1" />

