### PR TITLE
[PM-39195] Add banner to scimv2 component for invite link

### DIFF
--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -9059,6 +9059,10 @@
     "message": "SCIM settings saved",
     "description": "the text, 'SCIM', is an acronym and should not be translated."
   },
+  "scimProvisioningBannerInfo": {
+    "message": "Configuring this setting will automatically send invitations to all assigned users and groups in your identity provider (IdP).",
+    "description": "Informational banner on the SCIM settings page when SCIM is not yet enabled. 'IdP' is an abbreviation for 'identity provider' and should not be translated."
+  },
   "onlyOneIntegrationOfTypeAllowed": {
     "message": "Only one integration of this type ($TYPE$) is allowed. The conflicting integration is: $NAME$",
     "placeholders": {

--- a/bitwarden_license/bit-web/src/app/admin-console/organizations/manage/scim-banner.service.ts
+++ b/bitwarden_license/bit-web/src/app/admin-console/organizations/manage/scim-banner.service.ts
@@ -1,0 +1,35 @@
+import { inject, Injectable } from "@angular/core";
+import { map } from "rxjs";
+
+import { SCIM_BANNER, StateProvider, UserKeyDefinition } from "@bitwarden/common/platform/state";
+import { OrganizationId } from "@bitwarden/common/types/guid";
+
+export const SCIM_BANNER_SEEN_KEY = new UserKeyDefinition<OrganizationId[]>(
+  SCIM_BANNER,
+  "scimBannerSeen",
+  {
+    deserializer: (b) => b,
+    clearOn: [],
+  },
+);
+
+@Injectable({ providedIn: "root" })
+export class ScimBannerService {
+  private readonly _seen = inject(StateProvider).getActive(SCIM_BANNER_SEEN_KEY);
+
+  bannerSeen$(organizationId: OrganizationId) {
+    return this._seen.state$.pipe(map((ids) => ids?.includes(organizationId) ?? false));
+  }
+
+  async markBannerSeen(organizationId: OrganizationId): Promise<void> {
+    await this._seen.update((state) => {
+      if (!state) {
+        return [organizationId];
+      }
+      if (!state.includes(organizationId)) {
+        return [...state, organizationId];
+      }
+      return state;
+    });
+  }
+}

--- a/bitwarden_license/bit-web/src/app/admin-console/organizations/manage/scim-v2.component.html
+++ b/bitwarden_license/bit-web/src/app/admin-console/organizations/manage/scim-v2.component.html
@@ -1,5 +1,11 @@
 <app-header></app-header>
 
+@if (showProvisioningBanner()) {
+  <bit-callout type="info">
+    {{ "scimProvisioningBannerInfo" | i18n }}
+  </bit-callout>
+}
+
 <form [formGroup]="formData">
   <bit-card>
     <div [hidden]="!loading()">

--- a/bitwarden_license/bit-web/src/app/admin-console/organizations/manage/scim-v2.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/admin-console/organizations/manage/scim-v2.component.spec.ts
@@ -8,6 +8,7 @@ import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import { OrganizationConnectionType } from "@bitwarden/common/admin-console/enums";
 import { ScimConfigApi } from "@bitwarden/common/admin-console/models/api/scim-config.api";
 import { OrganizationConnectionResponse } from "@bitwarden/common/admin-console/models/response/organization-connection.response";
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import {
   Environment,
   EnvironmentService,
@@ -17,6 +18,7 @@ import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/pl
 import { DialogService, ToastService } from "@bitwarden/components";
 
 import { ScimApiKeyDialogComponent } from "./scim-api-key-dialog.component";
+import { ScimBannerService } from "./scim-banner.service";
 import { ScimV2Component } from "./scim-v2.component";
 
 describe("ScimV2Component", () => {
@@ -31,6 +33,8 @@ describe("ScimV2Component", () => {
   let environmentService: MockProxy<EnvironmentService>;
   let dialogService: MockProxy<DialogService>;
   let toastService: MockProxy<ToastService>;
+  let configService: MockProxy<ConfigService>;
+  let scimBannerService: MockProxy<ScimBannerService>;
   let mockEnv: MockProxy<Environment>;
   let environment$: BehaviorSubject<Environment>;
 
@@ -59,11 +63,17 @@ describe("ScimV2Component", () => {
     environmentService = mock<EnvironmentService>();
     dialogService = mock<DialogService>();
     toastService = mock<ToastService>();
+    configService = mock<ConfigService>();
+    scimBannerService = mock<ScimBannerService>();
 
     mockEnv = mock<Environment>();
     mockEnv.getScimUrl.mockReturnValue(scimUrl);
     environment$ = new BehaviorSubject<Environment>(mockEnv);
     environmentService.environment$ = environment$;
+
+    configService.getFeatureFlag$.mockReturnValue(of(false));
+    scimBannerService.bannerSeen$.mockReturnValue(of(false));
+    scimBannerService.markBannerSeen.mockResolvedValue();
 
     i18nService.t.mockImplementation((key: string) => key);
 
@@ -85,6 +95,8 @@ describe("ScimV2Component", () => {
         { provide: EnvironmentService, useValue: environmentService },
         { provide: DialogService, useValue: dialogService },
         { provide: ToastService, useValue: toastService },
+        { provide: ConfigService, useValue: configService },
+        { provide: ScimBannerService, useValue: scimBannerService },
       ],
       schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();

--- a/bitwarden_license/bit-web/src/app/admin-console/organizations/manage/scim-v2.component.ts
+++ b/bitwarden_license/bit-web/src/app/admin-console/organizations/manage/scim-v2.component.ts
@@ -253,6 +253,7 @@ export class ScimV2Component {
     this.cachedApiKey.set(undefined);
     this.showScimKey.set(false);
     if (connection !== null && connection.config?.enabled) {
+      await this.scimBannerService.markBannerSeen(this.organizationId());
       this.showScimSettings.set(true);
       this.enabled.setValue(true);
       this.formData.setValue({

--- a/bitwarden_license/bit-web/src/app/admin-console/organizations/manage/scim-v2.component.ts
+++ b/bitwarden_license/bit-web/src/app/admin-console/organizations/manage/scim-v2.component.ts
@@ -1,16 +1,17 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  computed,
   effect,
   inject,
   Signal,
   signal,
   viewChild,
 } from "@angular/core";
-import { toSignal } from "@angular/core/rxjs-interop";
+import { toObservable, toSignal } from "@angular/core/rxjs-interop";
 import { FormControl, FormGroup, ReactiveFormsModule } from "@angular/forms";
 import { ActivatedRoute } from "@angular/router";
-import { firstValueFrom, map } from "rxjs";
+import { firstValueFrom, map, of, switchMap } from "rxjs";
 
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import { OrganizationConnectionType } from "@bitwarden/common/admin-console/enums";
@@ -27,6 +28,7 @@ import {
   BaseCardDirective,
   BitActionDirective,
   BitIconButtonComponent,
+  CalloutComponent,
   CardComponent,
   DialogService,
   FormFieldModule,
@@ -40,6 +42,7 @@ import { I18nPipe } from "@bitwarden/ui-common";
 import { WebHeaderComponent } from "@bitwarden/web-vault/app/layouts/header/web-header.component";
 
 import { ScimApiKeyDialogComponent } from "./scim-api-key-dialog.component";
+import { ScimBannerService } from "./scim-banner.service";
 
 let nextId = 0;
 
@@ -51,6 +54,7 @@ let nextId = 0;
     WebHeaderComponent,
     ReactiveFormsModule,
     BaseCardDirective,
+    CalloutComponent,
     CardComponent,
     TypographyModule,
     LinkComponent,
@@ -71,6 +75,7 @@ export class ScimV2Component {
   private readonly environmentService = inject(EnvironmentService);
   private readonly dialogService = inject(DialogService);
   private readonly toastService = inject(ToastService);
+  private readonly scimBannerService = inject(ScimBannerService);
 
   protected readonly loading = signal(true);
   protected readonly showScimSettings = signal(false);
@@ -88,12 +93,24 @@ export class ScimV2Component {
     clientSecret: new FormControl(""),
   });
 
+  private readonly bannerSeen: Signal<boolean>;
+  protected readonly showProvisioningBanner: Signal<boolean>;
+
   private readonly organizationId: Signal<OrganizationId>;
   private readonly existingConnectionId = signal<string | undefined>(undefined);
   private readonly cachedApiKey = signal<string | undefined>(undefined);
 
   constructor() {
     this.organizationId = toSignal(this.route.params.pipe(map((params) => params.organizationId)));
+
+    this.bannerSeen = toSignal(
+      toObservable(this.organizationId).pipe(
+        switchMap((orgId) => (orgId ? this.scimBannerService.bannerSeen$(orgId) : of(false))),
+      ),
+      { initialValue: false },
+    );
+
+    this.showProvisioningBanner = computed(() => !this.showScimSettings() && !this.bannerSeen());
 
     effect(() => {
       if (this.organizationId()) {
@@ -176,6 +193,10 @@ export class ScimV2Component {
   };
 
   protected readonly submit = async () => {
+    if (this.enabled.value === true && !this.showScimSettings()) {
+      await this.scimBannerService.markBannerSeen(this.organizationId());
+    }
+
     const request = new OrganizationConnectionRequest(
       this.organizationId(),
       OrganizationConnectionType.Scim,

--- a/libs/state/src/core/state-definitions.ts
+++ b/libs/state/src/core/state-definitions.ts
@@ -38,6 +38,9 @@ export const DELETE_MANAGED_USER_WARNING = new StateDefinition(
 );
 export const AUTO_CONFIRM = new StateDefinition("autoConfirm", "disk", { web: "disk-local" });
 export const ORGANIZATION_INVITE_LINK_DISK = new StateDefinition("organizationInviteLink", "disk");
+export const SCIM_BANNER = new StateDefinition("scimBanner", "disk", {
+  web: "disk-local",
+});
 
 // Billing
 export const BILLING_DISK = new StateDefinition("billing", "disk");


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-39195?actionerId=6179d0553e3753006f1c7bb6&sourceType=assign
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
Adds a banner to the SCIM v2 page notifying admins of the automatic emails that will be sent by turning on SCIM
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots
<img width="934" height="839" alt="Screenshot 2026-06-18 at 11 50 39 AM" src="https://github.com/user-attachments/assets/e181c562-24eb-4a0a-99b0-71e6394e8c3d" />
<img width="947" height="794" alt="Screenshot 2026-06-18 at 11 56 22 AM" src="https://github.com/user-attachments/assets/7e8430e5-2ebf-412d-b2eb-2978edf3ac6c" />

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
