### PR TITLE
feat(platform): introduce GovModeService for FedRAMP region gating

### DIFF
--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -165,6 +165,7 @@ import { Fido2AuthenticatorService as Fido2AuthenticatorServiceAbstraction } fro
 import { Fido2ClientService as Fido2ClientServiceAbstraction } from "@bitwarden/common/platform/abstractions/fido2/fido2-client.service.abstraction";
 import { Fido2UserInterfaceService as Fido2UserInterfaceServiceAbstraction } from "@bitwarden/common/platform/abstractions/fido2/fido2-user-interface.service.abstraction";
 import { FileUploadService as FileUploadServiceAbstraction } from "@bitwarden/common/platform/abstractions/file-upload/file-upload.service";
+import { GovModeService } from "@bitwarden/common/platform/abstractions/gov-mode.service";
 import { I18nService as I18nServiceAbstraction } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService as LogServiceAbstraction } from "@bitwarden/common/platform/abstractions/log.service";
 import { PlatformUtilsService as PlatformUtilsServiceAbstraction } from "@bitwarden/common/platform/abstractions/platform-utils.service";
@@ -197,6 +198,7 @@ import { DefaultConfigService } from "@bitwarden/common/platform/services/config
 import { ConsoleLogService } from "@bitwarden/common/platform/services/console-log.service";
 import { ContainerService } from "@bitwarden/common/platform/services/container.service";
 import { DefaultAvailableRegionsService } from "@bitwarden/common/platform/services/default-available-regions.service";
+import { DefaultGovModeService } from "@bitwarden/common/platform/services/default-gov-mode.service";
 import { Fido2ActiveRequestManager } from "@bitwarden/common/platform/services/fido2/fido2-active-request-manager";
 import { Fido2AuthenticatorService } from "@bitwarden/common/platform/services/fido2/fido2-authenticator.service";
 import { Fido2ClientService } from "@bitwarden/common/platform/services/fido2/fido2-client.service";
@@ -499,6 +501,7 @@ export default class MainBackground {
   cipherContextMenuHandler: CipherContextMenuHandler;
   configService: ConfigService;
   availableRegionsService: AvailableRegionsService;
+  govModeService: GovModeService;
   configApiService: ConfigApiServiceAbstraction;
   devicesApiService: DevicesApiServiceAbstraction;
   devicesService: DevicesServiceAbstraction;
@@ -916,6 +919,8 @@ export default class MainBackground {
       this.environmentService,
       this.configService,
     );
+
+    this.govModeService = new DefaultGovModeService(this.environmentService);
 
     this.autoConfirmService = new DefaultAutomaticUserConfirmationService(
       this.apiService,

--- a/apps/cli/src/service-container/service-container.ts
+++ b/apps/cli/src/service-container/service-container.ts
@@ -123,6 +123,7 @@ import {
   EnvironmentService,
   RegionConfig,
 } from "@bitwarden/common/platform/abstractions/environment.service";
+import { GovModeService } from "@bitwarden/common/platform/abstractions/gov-mode.service";
 import { RegisterSdkService } from "@bitwarden/common/platform/abstractions/sdk/register-sdk.service";
 import { SdkLoadService } from "@bitwarden/common/platform/abstractions/sdk/sdk-load.service";
 import { SdkService } from "@bitwarden/common/platform/abstractions/sdk/sdk.service";
@@ -138,6 +139,7 @@ import { DefaultConfigService } from "@bitwarden/common/platform/services/config
 import { ContainerService } from "@bitwarden/common/platform/services/container.service";
 import { DefaultAvailableRegionsService } from "@bitwarden/common/platform/services/default-available-regions.service";
 import { DefaultEnvironmentService } from "@bitwarden/common/platform/services/default-environment.service";
+import { DefaultGovModeService } from "@bitwarden/common/platform/services/default-gov-mode.service";
 import { FileUploadService } from "@bitwarden/common/platform/services/file-upload/file-upload.service";
 import { MemoryStorageService } from "@bitwarden/common/platform/services/memory-storage.service";
 import { MigrationBuilderService } from "@bitwarden/common/platform/services/migration-builder.service";
@@ -335,6 +337,7 @@ export class ServiceContainer {
   configApiService: ConfigApiServiceAbstraction;
   configService: ConfigService;
   availableRegionsService: AvailableRegionsService;
+  govModeService: GovModeService;
   accountService: AccountService;
   globalStateProvider: GlobalStateProvider;
   singleUserStateProvider: SingleUserStateProvider;
@@ -629,6 +632,8 @@ export class ServiceContainer {
       this.environmentService,
       this.configService,
     );
+
+    this.govModeService = new DefaultGovModeService(this.environmentService);
 
     this.domainSettingsService = new DefaultDomainSettingsService(
       this.stateProvider,

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -23,6 +23,7 @@ import { Message, MessageSender } from "@bitwarden/common/platform/messaging";
 // eslint-disable-next-line no-restricted-imports -- For dependency creation
 import { SubjectMessageSender } from "@bitwarden/common/platform/messaging/internal";
 import { DefaultEnvironmentService } from "@bitwarden/common/platform/services/default-environment.service";
+import { DefaultGovModeService } from "@bitwarden/common/platform/services/default-gov-mode.service";
 import { MemoryStorageService } from "@bitwarden/common/platform/services/memory-storage.service";
 import { MigrationBuilderService } from "@bitwarden/common/platform/services/migration-builder.service";
 import { MigrationRunner } from "@bitwarden/common/platform/services/migration-runner";
@@ -79,6 +80,7 @@ export class Main {
   memoryStorageForStateProviders: SerializedMemoryStorageService;
   messagingService: MessageSender;
   environmentService: DefaultEnvironmentService;
+  govModeService: DefaultGovModeService;
   desktopCredentialStorageListener: DesktopCredentialStorageListener;
   mainBiometricsIpcListener: MainBiometricsIPCListener;
   desktopSettingsService: DesktopSettingsService;
@@ -212,6 +214,8 @@ export class Main {
       accountService,
       process.env.ADDITIONAL_REGIONS as unknown as RegionConfig[],
     );
+
+    this.govModeService = new DefaultGovModeService(this.environmentService);
 
     this.migrationRunner = new MigrationRunner(
       this.storageService,

--- a/libs/angular/src/services/jslib-services.module.ts
+++ b/libs/angular/src/services/jslib-services.module.ts
@@ -245,6 +245,7 @@ import {
   RegionConfig,
 } from "@bitwarden/common/platform/abstractions/environment.service";
 import { FileUploadService as FileUploadServiceAbstraction } from "@bitwarden/common/platform/abstractions/file-upload/file-upload.service";
+import { GovModeService } from "@bitwarden/common/platform/abstractions/gov-mode.service";
 import { I18nService as I18nServiceAbstraction } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { MessagingService as MessagingServiceAbstraction } from "@bitwarden/common/platform/abstractions/messaging.service";
@@ -279,6 +280,7 @@ import { ConsoleLogService } from "@bitwarden/common/platform/services/console-l
 import { DefaultAvailableRegionsService } from "@bitwarden/common/platform/services/default-available-regions.service";
 import { DefaultBroadcasterService } from "@bitwarden/common/platform/services/default-broadcaster.service";
 import { DefaultEnvironmentService } from "@bitwarden/common/platform/services/default-environment.service";
+import { DefaultGovModeService } from "@bitwarden/common/platform/services/default-gov-mode.service";
 import { DefaultServerSettingsService } from "@bitwarden/common/platform/services/default-server-settings.service";
 import { FileUploadService } from "@bitwarden/common/platform/services/file-upload/file-upload.service";
 import { MigrationBuilderService } from "@bitwarden/common/platform/services/migration-builder.service";
@@ -802,6 +804,11 @@ const safeProviders: SafeProvider[] = [
     provide: AvailableRegionsService,
     useClass: DefaultAvailableRegionsService,
     deps: [EnvironmentService, ConfigService],
+  }),
+  safeProvider({
+    provide: GovModeService,
+    useClass: DefaultGovModeService,
+    deps: [EnvironmentService],
   }),
   safeProvider({
     provide: InternalUserDecryptionOptionsServiceAbstraction,

--- a/libs/common/src/platform/abstractions/gov-mode.service.ts
+++ b/libs/common/src/platform/abstractions/gov-mode.service.ts
@@ -1,0 +1,17 @@
+import { Observable } from "rxjs";
+
+import { UserId } from "../../types/guid";
+
+/**
+ * Detects whether the current environment is the Gov cloud.
+ *
+ * Use globalIsGovMode$ pre-login.
+ * Use isGovMode$(userId) when a UserId is in scope.
+ * Bridge with firstValueFrom at the call-site if you need a snapshot.
+ *
+ * MVP infers from client-side region; PM-36520 will swap to a server check.
+ */
+export abstract class GovModeService {
+  abstract globalIsGovMode$: Observable<boolean>;
+  abstract isGovMode$(userId: UserId): Observable<boolean>;
+}

--- a/libs/common/src/platform/services/default-gov-mode.service.spec.ts
+++ b/libs/common/src/platform/services/default-gov-mode.service.spec.ts
@@ -1,0 +1,60 @@
+import { firstValueFrom, of } from "rxjs";
+
+import { UserId } from "../../types/guid";
+import { Region } from "../abstractions/environment.service";
+
+import { DefaultGovModeService } from "./default-gov-mode.service";
+
+describe("DefaultGovModeService", () => {
+  const mockUserId = "00000000-0000-0000-0000-000000000001" as UserId;
+
+  const createMockEnvironmentService = (region: Region) => ({
+    globalEnvironment$: of({
+      getRegion: () => region,
+    }),
+    getEnvironment$: (_userId: UserId) =>
+      of({
+        getRegion: () => region,
+      }),
+  });
+
+  describe("globalIsGovMode$", () => {
+    it("emits true for Gov", async () => {
+      const envService = createMockEnvironmentService(Region.Gov);
+      const sut = new DefaultGovModeService(envService as any);
+
+      const result = await firstValueFrom(sut.globalIsGovMode$);
+
+      expect(result).toBe(true);
+    });
+
+    it.each([Region.US, Region.EU, Region.SelfHosted])("emits false for %s", async (region) => {
+      const envService = createMockEnvironmentService(region);
+      const sut = new DefaultGovModeService(envService as any);
+
+      const result = await firstValueFrom(sut.globalIsGovMode$);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("isGovMode$", () => {
+    it("emits true for Gov", async () => {
+      const envService = createMockEnvironmentService(Region.Gov);
+      const sut = new DefaultGovModeService(envService as any);
+
+      const result = await firstValueFrom(sut.isGovMode$(mockUserId));
+
+      expect(result).toBe(true);
+    });
+
+    it.each([Region.US, Region.EU, Region.SelfHosted])("emits false for %s", async (region) => {
+      const envService = createMockEnvironmentService(region);
+      const sut = new DefaultGovModeService(envService as any);
+
+      const result = await firstValueFrom(sut.isGovMode$(mockUserId));
+
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/libs/common/src/platform/services/default-gov-mode.service.ts
+++ b/libs/common/src/platform/services/default-gov-mode.service.ts
@@ -1,0 +1,21 @@
+import { Observable, map } from "rxjs";
+
+import { UserId } from "../../types/guid";
+import { EnvironmentService, Region } from "../abstractions/environment.service";
+import { GovModeService } from "../abstractions/gov-mode.service";
+
+export class DefaultGovModeService implements GovModeService {
+  readonly globalIsGovMode$: Observable<boolean>;
+
+  constructor(private environmentService: EnvironmentService) {
+    this.globalIsGovMode$ = this.environmentService.globalEnvironment$.pipe(
+      map((env) => env.getRegion() === Region.Gov),
+    );
+  }
+
+  isGovMode$(userId: UserId): Observable<boolean> {
+    return this.environmentService
+      .getEnvironment$(userId)
+      .pipe(map((env) => env.getRegion() === Region.Gov));
+  }
+}


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-38020

## 📔 Objective

GovModeService is a shared Platform service that downstream teams consume to gate FedRAMP-specific behavior.

The MVP implementation infers the gov-mode signal from the client-side Region (true when `env.getRegion() === Region.Gov`). A redundant implementation of this same kind of check will be introduced to the SDK by [PM-38266](https://bitwarden.atlassian.net/browse/PM-38266). Later [PM-36520](https://bitwarden.atlassian.net/browse/PM-36520) will replace both implementations with a single server-backed check propagated by the SDK, while keeping this contract stable. 

The service exposes two Observable surfaces: `globalIsGovMode$` (pre-login) and `isGovMode$(userId)` (when a UserId is in scope).

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->


[PM-38266]: https://bitwarden.atlassian.net/browse/PM-38266?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-36520]: https://bitwarden.atlassian.net/browse/PM-36520?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ