### PR TITLE
[PM-38751] Update Chromium importer hash

### DIFF
--- a/apps/desktop/desktop_native/chromium_importer/src/chromium/platform/windows/signature.rs
+++ b/apps/desktop/desktop_native/chromium_importer/src/chromium/platform/windows/signature.rs
@@ -7,7 +7,7 @@ use verifysign::CodeSignVerifier;
 use crate::config::ENABLE_SIGNATURE_VALIDATION;
 
 pub const EXPECTED_SIGNATURE_SHA256_THUMBPRINT: &str =
-    "e8496f9940c5ee64c60ff1a87235af3760dedae6b067e027c61e2862a73f61b2";
+    "9D368B4C95F9794880ED5FC3A6ABD99232EBE04473FC6267B5479B4FE6104DF6";
 
 pub fn verify_signature(path: &Path) -> Result<bool> {
     if !ENABLE_SIGNATURE_VALIDATION {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-38751

## 📔 Objective

The Windows App Signing certificate has been rotated, and the `bitwarden_chromium_importer_helper.exe` is now failing signature verification. This PR updates the expected hash to match the current signed assets. 
