### PR TITLE
fix(platform): remove hardcoded vault.bitwarden.com checks in getSendUrl and getScimUrl

### DIFF
--- a/libs/common/src/platform/services/default-environment.service.spec.ts
+++ b/libs/common/src/platform/services/default-environment.service.spec.ts
@@ -232,6 +232,22 @@ describe("EnvironmentService", () => {
       // Must NOT return "https://send.bitwarden.com/#/" (cloud fallback)
       expect(env.getSendUrl()).toBe("https://vault.myserver.com/#/send/");
     });
+
+    it("getScimUrl falls back to webVault when only webVault is configured (regression)", async () => {
+      // Regression: self-hosted user sets only webVault (no base, no scim).
+      // getScimUrl() must use the self-hosted webVault, not the Bitwarden cloud scim URL.
+      const userEnvironmentUrls = new EnvironmentUrls();
+      userEnvironmentUrls.webVault = "https://vault.myserver.com";
+      setUserData(Region.SelfHosted, userEnvironmentUrls);
+
+      await switchUser(testUser);
+
+      const env = await firstValueFrom(sut.environment$);
+
+      expect(env.getWebVaultUrl()).toBe("https://vault.myserver.com");
+      // Must NOT return "https://scim.bitwarden.com/v2" (cloud fallback)
+      expect(env.getScimUrl()).toBe("https://vault.myserver.com/scim/v2");
+    });
   });
 
   describe("without user", () => {

--- a/libs/common/src/platform/services/default-environment.service.ts
+++ b/libs/common/src/platform/services/default-environment.service.ts
@@ -420,9 +420,7 @@ abstract class UrlEnvironment implements Environment {
       return this.urls.scim + "/v2";
     }
 
-    return this.getWebVaultUrl() === "https://vault.bitwarden.com"
-      ? "https://scim.bitwarden.com/v2"
-      : this.getWebVaultUrl() + "/scim/v2";
+    return this.getWebVaultUrl() + "/scim/v2";
   }
 
   getSendUrl() {
@@ -430,11 +428,7 @@ abstract class UrlEnvironment implements Environment {
       return this.urls.send + "/#/";
     }
 
-    const webVaultUrl = this.getWebVaultUrl();
-    if (webVaultUrl === "https://vault.bitwarden.com") {
-      return "https://send.bitwarden.com/#/";
-    }
-    return webVaultUrl + "/#/send/";
+    return this.getWebVaultUrl() + "/#/send/";
   }
 
   /**


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-38021

## 📔 Objective

Hardcoded '=== "https://vault.bitwarden.com"' string comparisons in getScimUrl() and getSendUrl() produced confusing URLs for non-US cloud regions. This is a dead condition anyway, only self hosted environments can fall through to this path. 

This commit simplifies these paths to just say "if there is no configured send/scim url, use webVault + a suffix". I also added a test for SCIM that asserts the same thing already tested for send.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
