### PR TITLE
[PM-39295] Fix SDK IPC messages being parsed by legacy IPC, resetting the connection

### DIFF
--- a/apps/desktop/src/services/native-messaging.service.ts
+++ b/apps/desktop/src/services/native-messaging.service.ts
@@ -1,11 +1,12 @@
 import { Injectable } from "@angular/core";
 
+import { isForwardedIpcMessage, isIpcMessage } from "@bitwarden/common/platform/ipc";
+
 import { LegacyMessageWrapper } from "../models/native-messaging/legacy-message-wrapper";
 import { Message } from "../models/native-messaging/message";
 
 import { BiometricMessageHandlerService } from "./biometric-message-handler.service";
 import { DuckDuckGoMessageHandlerService } from "./duckduckgo-message-handler.service";
-import { isForwardedIpcMessage, isIpcMessage } from "@bitwarden/common/platform/ipc";
 
 @Injectable()
 export class NativeMessagingService {

--- a/apps/desktop/src/services/native-messaging.service.ts
+++ b/apps/desktop/src/services/native-messaging.service.ts
@@ -5,6 +5,7 @@ import { Message } from "../models/native-messaging/message";
 
 import { BiometricMessageHandlerService } from "./biometric-message-handler.service";
 import { DuckDuckGoMessageHandlerService } from "./duckduckgo-message-handler.service";
+import { isForwardedIpcMessage, isIpcMessage } from "@bitwarden/common/platform/ipc";
 
 @Injectable()
 export class NativeMessagingService {
@@ -19,6 +20,12 @@ export class NativeMessagingService {
 
   private async messageHandler(msg: LegacyMessageWrapper | Message) {
     const outerMessage = msg as Message;
+
+    // Ignore SDK IPC messages here
+    if (isIpcMessage(msg) || isForwardedIpcMessage(msg)) {
+      return;
+    }
+
     if (outerMessage.version) {
       // If there is a version, it is a using the protocol created for the DuckDuckGo integration
       await this.duckduckgoMessageHandler.handleMessage(outerMessage);


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-39295

## 📔 Objective

SDK IPC (and thus shared unlock, new biometric ipc) has a different message type, and is handled separately. Currently, the new IPC messages are making it into the legacy IPC services, and because those services don't understand the message type, this leads to an encryption reset loop where the service sees the message, and does not find an existing encryption set up for the connection, and resets the connection.

This PR fixes this by filtering out SDK ipc messages from making it to these services.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
