### PR TITLE
[PM-39204] Add extra spacing to vault items when batch bar is visible

### DIFF
--- a/apps/web/src/app/vault/components/vault-items/vault-items.component.html
+++ b/apps/web/src/app/vault/components/vault-items/vault-items.component.html
@@ -1,4 +1,9 @@
-<cdk-virtual-scroll-viewport [itemSize]="RowHeight" bitScrollLayout class="tw-pb-8">
+<cdk-virtual-scroll-viewport
+  [itemSize]="RowHeight"
+  bitScrollLayout
+  class="tw-transition-[padding-bottom] tw-duration-300 tw-ease-in-out"
+  [ngClass]="batchBarService?.barVisible() ? 'tw-pb-[7.5rem]' : 'tw-pb-8'"
+>
   <bit-table [dataSource]="dataSource" layout="fixed">
     <ng-container header>
       <tr>
@@ -63,12 +68,12 @@
           [ngClass]="
             ((showCopyAndLaunchActions$ | async)
               ? 'tw-w-28'
-              : batchBarService && batchBarFlag()
+              : batchBarService?.enabled()
                 ? 'tw-w-24'
                 : 'tw-w-12') + ' tw-text-right'
           "
         >
-          @if (!batchBarService || !batchBarFlag()) {
+          @if (!batchBarService?.enabled()) {
             @let menuDisabled = disableMenu$ | async;
             <button
               [disabled]="disabled || isEmpty || menuDisabled"

--- a/apps/web/src/app/vault/components/vault-items/vault-items.component.ts
+++ b/apps/web/src/app/vault/components/vault-items/vault-items.component.ts
@@ -2,7 +2,7 @@
 // @ts-strict-ignore
 import { SelectionModel } from "@angular/cdk/collections";
 import { Component, EventEmitter, Input, Output, inject } from "@angular/core";
-import { takeUntilDestroyed, toSignal } from "@angular/core/rxjs-interop";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import {
   Observable,
   combineLatest,
@@ -154,10 +154,6 @@ export class VaultItemsComponent<C extends CipherViewLike> {
   protected readonly batchBarService = inject(VaultBatchBarService, {
     optional: true,
   }) as VaultBatchBarService<C> | null;
-  protected readonly batchBarFlag = toSignal(
-    this.configService.getFeatureFlag$(FeatureFlag.PM37785_VaultBatchBar),
-    { initialValue: false },
-  );
 
   protected editableItems: VaultItem<C>[] = [];
   protected dataSource = new TableDataSource<VaultItem<C>>();

--- a/apps/web/src/app/vault/individual-vault/vault.component.spec.ts
+++ b/apps/web/src/app/vault/individual-vault/vault.component.spec.ts
@@ -1,5 +1,5 @@
 import { SelectionModel } from "@angular/cdk/collections";
-import { NO_ERRORS_SCHEMA } from "@angular/core";
+import { NO_ERRORS_SCHEMA, signal } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { By } from "@angular/platform-browser";
 import { ActivatedRoute, convertToParamMap, Params, provideRouter, Router } from "@angular/router";
@@ -313,6 +313,8 @@ describe("VaultComponent", () => {
                 bulkDelete: jest.fn(),
                 bulkMoveToFolder: jest.fn(),
                 bulkAssignToCollections: jest.fn(),
+                enabled: signal(false),
+                barVisible: signal(false),
               },
             },
             {

--- a/libs/vault/src/services/vault-batch-bar.service.spec.ts
+++ b/libs/vault/src/services/vault-batch-bar.service.spec.ts
@@ -6,6 +6,8 @@ import { OrganizationService } from "@bitwarden/common/admin-console/abstraction
 import { CollectionView, Unassigned } from "@bitwarden/common/admin-console/models/collections";
 import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
 import { Account, AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { CipherId, OrganizationId, UserId } from "@bitwarden/common/types/guid";
@@ -99,12 +101,14 @@ describe("VaultBatchBarService", () => {
   let mockAssignCollectionsDialogOpen: jest.Mock;
   let mockBulkDeleteDialogOpen: jest.Mock;
   let activeFilterSubject: BehaviorSubject<RoutedVaultFilterModel>;
+  let featureFlagSubject: BehaviorSubject<boolean>;
 
   beforeEach(() => {
     filterSubject = new BehaviorSubject<RoutedVaultFilterModel>({});
     organizationsSubject = new BehaviorSubject<Organization[]>([]);
     userCanArchiveSubject = new BehaviorSubject<boolean>(false);
     activeFilterSubject = new BehaviorSubject<RoutedVaultFilterModel>({});
+    featureFlagSubject = new BehaviorSubject<boolean>(false);
 
     mockCipherService = mock<CipherService>();
     mockCipherArchiveService = mock<CipherArchiveService>();
@@ -140,6 +144,16 @@ describe("VaultBatchBarService", () => {
         {
           provide: RoutedVaultFilterBridgeService,
           useValue: { activeFilter$: activeFilterSubject },
+        },
+        {
+          provide: ConfigService,
+          useValue: {
+            getFeatureFlag$: jest
+              .fn()
+              .mockImplementation((flag: FeatureFlag) =>
+                flag === FeatureFlag.PM37785_VaultBatchBar ? featureFlagSubject : of(false),
+              ),
+          },
         },
         { provide: I18nService, useValue: { t: (key: string) => key } },
         { provide: LogService, useValue: mock<LogService>() },
@@ -201,6 +215,38 @@ describe("VaultBatchBarService", () => {
 
       expect(service.selectedCollections()).toHaveLength(1);
       expect(service.selectedCollections()[0]).toBe(collectionItem.collection);
+    });
+  });
+
+  describe("barVisible()", () => {
+    it("returns false when flag is off and nothing is selected", () => {
+      featureFlagSubject.next(false);
+
+      expect(service.barVisible()).toBe(false);
+    });
+
+    it("returns false when flag is on but nothing is selected", () => {
+      featureFlagSubject.next(true);
+
+      expect(service.barVisible()).toBe(false);
+    });
+
+    it("returns true when flag is on and at least one item is selected", () => {
+      featureFlagSubject.next(true);
+      service.selection.select(makeCipherItem());
+
+      expect(service.barVisible()).toBe(true);
+    });
+
+    it("returns false after selection is cleared", () => {
+      featureFlagSubject.next(true);
+      service.selection.select(makeCipherItem());
+
+      expect(service.barVisible()).toBe(true);
+
+      service.selection.clear();
+
+      expect(service.barVisible()).toBe(false);
     });
   });
 

--- a/libs/vault/src/services/vault-batch-bar.service.ts
+++ b/libs/vault/src/services/vault-batch-bar.service.ts
@@ -18,6 +18,8 @@ import { CollectionView, Unassigned } from "@bitwarden/common/admin-console/mode
 import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { getUserId } from "@bitwarden/common/auth/services/account.service";
+import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { uuidAsString } from "@bitwarden/common/platform/abstractions/sdk/sdk.service";
@@ -93,6 +95,7 @@ export class VaultBatchBarService<C extends CipherViewLike> {
   private readonly routedVaultFilterService = inject(RoutedVaultFilterService);
   private readonly i18nService = inject(I18nService);
   private readonly logService = inject(LogService);
+  private readonly configService = inject(ConfigService);
   private readonly assignCollectionsDialog =
     inject<AssignCollectionsDialogRef>(ASSIGN_COLLECTIONS_DIALOG);
   private readonly bulkDeleteDialog = inject<BulkDeleteDialogRef>(BULK_DELETE_DIALOG);
@@ -146,6 +149,17 @@ export class VaultBatchBarService<C extends CipherViewLike> {
   });
 
   readonly selectedCount = computed(() => this.selected().length);
+
+  private readonly batchBarFlag = toSignal(
+    this.configService.getFeatureFlag$(FeatureFlag.PM37785_VaultBatchBar),
+    { initialValue: false },
+  );
+
+  /** True when the batch bar feature flag is enabled. */
+  readonly enabled = computed(() => this.batchBarFlag());
+
+  /** True when the batch bar is actively visible: feature flag on and at least one item selected. */
+  readonly barVisible = computed(() => this.batchBarFlag() && this.selectedCount() > 0);
 
   /** Selected items that are ciphers. */
   readonly selectedCiphers = computed(() =>


### PR DESCRIPTION
## 🎟️ Tracking

[PM-39204](https://bitwarden.atlassian.net/browse/PM-39204)

## 📔 Objective

When the vault batch action bar is visible, vault items near the bottom of the list can be obscured by the floating bar. This PR adds dynamic bottom padding to the virtual scroll viewport so items remain accessible while the bar is shown.

**Changes:**

- Moves the `PM37785_VaultBatchBar` feature flag signal from `VaultItemsComponent` into `VaultBatchBarService`
  - Added `barVisible()` signal which is true when the flag is on and at least one item is selected (i.e., the bar is actually rendered)
- Applies `tw-pb-[7.5rem]` (120px) to the scroll viewport when `barVisible()` is true, transitioning back to `tw-pb-8` when the bar is dismissed.

> Note: The designs specify 96px of bottom padding when the batch bar is visible. 120px (`7.5rem`) is used here because it produces the same visual clearance as the designs intend.

## 📸 Screenshots

<video src="https://github.com/user-attachments/assets/759bd092-23c1-453c-b064-64d3bf29b109" />

[PM-39204]: https://bitwarden.atlassian.net/browse/PM-39204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ