### PR TITLE
added inline rename for projects and machine accounts

### DIFF
--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -6050,6 +6050,9 @@
   "projectsCannotCreate": {
     "message": "Projects cannot be created in suspended organizations. Please contact your organization owner for assistance."
   },
+  "projectsCannotEdit": {
+    "message": "Projects cannot be edited in suspended organizations. Please contact your organization owner for assistance."
+  },
   "serviceAccountsCannotCreate": {
     "message": "Service accounts cannot be created in suspended organizations. Please contact your organization owner for assistance."
   },
@@ -11433,6 +11436,9 @@
   },
   "machineAccountsCannotCreate": {
     "message": "Machine accounts cannot be created in suspended organizations. Please contact your organization owner for assistance."
+  },
+  "machineAccountsCannotEdit": {
+    "message": "Machine accounts cannot be edited in suspended organizations. Please contact your organization owner for assistance."
   },
   "machineAccount": {
     "message": "Machine account",

--- a/bitwarden_license/bit-web/src/app/secrets-manager/projects/dialog/project-dialog.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/projects/dialog/project-dialog.component.ts
@@ -10,6 +10,7 @@ import { DialogRef, DIALOG_DATA, BitValidators, ToastService } from "@bitwarden/
 
 import { ProjectView } from "../../models/view/project.view";
 import { ProjectService } from "../../projects/project.service";
+import { SM_NAME_MAX_LENGTH } from "../../shared/sm-constants";
 
 // FIXME: update to use a const object instead of a typescript enum
 // eslint-disable-next-line @bitwarden/platform/no-enums
@@ -34,7 +35,11 @@ export interface ProjectOperation {
 export class ProjectDialogComponent implements OnInit {
   protected formGroup = new FormGroup({
     name: new FormControl("", {
-      validators: [Validators.required, Validators.maxLength(500), BitValidators.trimValidator],
+      validators: [
+        Validators.required,
+        Validators.maxLength(SM_NAME_MAX_LENGTH),
+        BitValidators.trimValidator,
+      ],
       updateOn: "submit",
     }),
   });

--- a/bitwarden_license/bit-web/src/app/secrets-manager/projects/project/project.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/projects/project/project.component.html
@@ -1,4 +1,19 @@
-<app-header *ngIf="project$ | async as project" [title]="project.name" icon="bwi-collection">
+<app-header
+  *ngIf="project$ | async as project"
+  [title]="renaming ? rename.titlePlaceholder : project.name"
+  icon="bwi-collection"
+>
+  <sm-inline-rename
+    #rename
+    slot="title-suffix"
+    [(editing)]="renaming"
+    [name]="project.name"
+    [label]="'projectName' | i18n"
+    [editLabel]="'editProject' | i18n"
+    [canEdit]="project.write"
+    [save]="saveRename"
+    idPrefix="project-header"
+  ></sm-inline-rename>
   <bit-breadcrumbs slot="breadcrumbs">
     <bit-breadcrumb [route]="['..']" icon="bwi-angle-left">{{ "projects" | i18n }}</bit-breadcrumb>
   </bit-breadcrumbs>
@@ -25,15 +40,5 @@
     </ng-container>
   </bit-tab-nav-bar>
   <sm-new-menu></sm-new-menu>
-  <button
-    type="button"
-    slot="secondary"
-    bitButton
-    buttonType="secondary"
-    (click)="openEditDialog()"
-    *ngIf="project.write"
-  >
-    {{ "editProject" | i18n }}
-  </button>
 </app-header>
 <router-outlet></router-outlet>

--- a/bitwarden_license/bit-web/src/app/secrets-manager/projects/project/project.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/projects/project/project.component.ts
@@ -4,6 +4,7 @@ import { Component, OnDestroy, OnInit } from "@angular/core";
 import { ActivatedRoute } from "@angular/router";
 import {
   combineLatest,
+  distinctUntilChanged,
   filter,
   Observable,
   startWith,
@@ -11,27 +12,19 @@ import {
   switchMap,
   takeUntil,
   map,
-  concatMap,
 } from "rxjs";
 
-import {
-  getOrganizationById,
-  OrganizationService,
-} from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
+import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
-import { getUserId } from "@bitwarden/common/auth/services/account.service";
-import { DialogService } from "@bitwarden/components";
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { ToastService } from "@bitwarden/components";
 
 import { ProjectCounts } from "../../models/view/counts.view";
 import { ProjectView } from "../../models/view/project.view";
 import { SecretService } from "../../secrets/secret.service";
 import { AccessPolicyService } from "../../shared/access-policies/access-policy.service";
 import { CountService } from "../../shared/counts/count.service";
-import {
-  OperationType,
-  ProjectDialogComponent,
-  ProjectOperation,
-} from "../dialog/project-dialog.component";
+import { organizationForRoute$ } from "../../shared/sm-organization";
 import { ProjectService } from "../project.service";
 
 // FIXME(https://bitwarden.atlassian.net/browse/CL-764): Migrate to OnPush
@@ -45,6 +38,8 @@ export class ProjectComponent implements OnInit, OnDestroy {
   protected project$: Observable<ProjectView>;
   protected projectCounts: ProjectCounts;
 
+  protected renaming = false;
+
   private organizationId: string;
   private projectId: string;
   private organizationEnabled: boolean;
@@ -55,10 +50,11 @@ export class ProjectComponent implements OnInit, OnDestroy {
     private projectService: ProjectService,
     private secretService: SecretService,
     private accessPolicyService: AccessPolicyService,
-    private dialogService: DialogService,
     private organizationService: OrganizationService,
     private accountService: AccountService,
     private countService: CountService,
+    private i18nService: I18nService,
+    private toastService: ToastService,
   ) {}
 
   ngOnInit(): void {
@@ -74,35 +70,34 @@ export class ProjectComponent implements OnInit, OnDestroy {
       ),
     );
     const projectId$ = this.route.params.pipe(map((p) => p.projectId));
-    const organization$ = this.route.params.pipe(
-      concatMap((params) =>
-        getUserId(this.accountService.activeAccount$).pipe(
-          switchMap((userId) =>
-            this.organizationService
-              .organizations$(userId)
-              .pipe(getOrganizationById(params.organizationId)),
-          ),
-        ),
-      ),
-    );
+
+    // Close the editor when switching projects.
+    projectId$.pipe(distinctUntilChanged(), takeUntil(this.destroy$)).subscribe((projectId) => {
+      this.projectId = projectId;
+      this.renaming = false;
+    });
+
+    // Separate from the counts fetch so the rename guard isn't blocked on it.
+    organizationForRoute$(this.route.params, this.accountService, this.organizationService)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((organization) => {
+        this.organizationId = organization?.id;
+        this.organizationEnabled = organization?.enabled;
+      });
+
     const projectCounts$ = combineLatest([
       this.route.params,
       this.secretService.secret$.pipe(startWith(null)),
       this.accessPolicyService.accessPolicy$.pipe(startWith(null)),
     ]).pipe(switchMap(([params]) => this.countService.getProjectCounts(params.projectId)));
 
-    combineLatest([projectId$, organization$, projectCounts$])
-      .pipe(takeUntil(this.destroy$))
-      .subscribe(([projectId, organization, projectCounts]) => {
-        this.organizationId = organization.id;
-        this.projectId = projectId;
-        this.organizationEnabled = organization.enabled;
-        this.projectCounts = {
-          secrets: projectCounts.secrets,
-          people: projectCounts.people,
-          serviceAccounts: projectCounts.serviceAccounts,
-        };
-      });
+    projectCounts$.pipe(takeUntil(this.destroy$)).subscribe((projectCounts) => {
+      this.projectCounts = {
+        secrets: projectCounts.secrets,
+        people: projectCounts.people,
+        serviceAccounts: projectCounts.serviceAccounts,
+      };
+    });
   }
 
   ngOnDestroy(): void {
@@ -110,14 +105,27 @@ export class ProjectComponent implements OnInit, OnDestroy {
     this.destroy$.complete();
   }
 
-  async openEditDialog() {
-    this.dialogService.open<unknown, ProjectOperation>(ProjectDialogComponent, {
-      data: {
-        organizationId: this.organizationId,
-        operation: OperationType.Edit,
-        organizationEnabled: this.organizationEnabled,
-        projectId: this.projectId,
-      },
+  saveRename = async (name: string): Promise<boolean> => {
+    if (this.organizationEnabled === false) {
+      this.toastService.showToast({
+        variant: "error",
+        title: null,
+        message: this.i18nService.t("projectsCannotEdit"),
+      });
+      return false;
+    }
+
+    const projectView = new ProjectView();
+    projectView.id = this.projectId;
+    projectView.organizationId = this.organizationId;
+    projectView.name = name;
+
+    await this.projectService.update(this.organizationId, projectView);
+    this.toastService.showToast({
+      variant: "success",
+      title: null,
+      message: this.i18nService.t("projectSaved"),
     });
-  }
+    return true;
+  };
 }

--- a/bitwarden_license/bit-web/src/app/secrets-manager/secrets/dialog/secret-dialog.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/secrets/dialog/secret-dialog.component.ts
@@ -41,6 +41,7 @@ import {
 } from "../../shared/access-policies/access-policy-selector/models/ap-item-view.type";
 import { ApItemEnum } from "../../shared/access-policies/access-policy-selector/models/enums/ap-item.enum";
 import { AccessPolicyService } from "../../shared/access-policies/access-policy.service";
+import { SM_NAME_MAX_LENGTH } from "../../shared/sm-constants";
 import { SecretService } from "../secret.service";
 
 import { SecretDeleteDialogComponent, SecretDeleteOperation } from "./secret-delete.component";
@@ -83,7 +84,11 @@ export class SecretDialogComponent implements OnInit, OnDestroy {
 
   protected formGroup = new FormGroup({
     name: new FormControl("", {
-      validators: [Validators.required, Validators.maxLength(500), BitValidators.trimValidator],
+      validators: [
+        Validators.required,
+        Validators.maxLength(SM_NAME_MAX_LENGTH),
+        BitValidators.trimValidator,
+      ],
       updateOn: "submit",
     }),
     value: new FormControl("", [Validators.required, Validators.maxLength(25000)]),
@@ -93,7 +98,7 @@ export class SecretDialogComponent implements OnInit, OnDestroy {
     }),
     project: new FormControl("", [Validators.required]),
     newProjectName: new FormControl("", {
-      validators: [Validators.maxLength(500), BitValidators.trimValidator],
+      validators: [Validators.maxLength(SM_NAME_MAX_LENGTH), BitValidators.trimValidator],
       updateOn: "submit",
     }),
     peopleAccessPolicies: new FormControl([] as ApItemValueType[]),

--- a/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/dialog/service-account-dialog.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/dialog/service-account-dialog.component.ts
@@ -8,6 +8,7 @@ import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.servic
 import { DialogRef, DIALOG_DATA, BitValidators, ToastService } from "@bitwarden/components";
 
 import { ServiceAccountView } from "../../models/view/service-account.view";
+import { SM_NAME_MAX_LENGTH } from "../../shared/sm-constants";
 import { ServiceAccountService } from "../service-account.service";
 
 // FIXME: update to use a const object instead of a typescript enum
@@ -34,7 +35,11 @@ export class ServiceAccountDialogComponent implements OnInit {
   protected formGroup = new FormGroup(
     {
       name: new FormControl("", {
-        validators: [Validators.required, Validators.maxLength(500), BitValidators.trimValidator],
+        validators: [
+          Validators.required,
+          Validators.maxLength(SM_NAME_MAX_LENGTH),
+          BitValidators.trimValidator,
+        ],
         updateOn: "submit",
       }),
     },

--- a/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/service-account.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/service-account.component.html
@@ -1,8 +1,18 @@
 <app-header
   *ngIf="serviceAccount$ | async as serviceAccount"
-  [title]="serviceAccount.name"
+  [title]="renaming ? rename.titlePlaceholder : serviceAccount.name"
   icon="bwi-wrench"
 >
+  <sm-inline-rename
+    #rename
+    slot="title-suffix"
+    [(editing)]="renaming"
+    [name]="serviceAccount.name"
+    [label]="'machineAccountName' | i18n"
+    [editLabel]="'editMachineAccount' | i18n"
+    [save]="saveName"
+    idPrefix="machine-account-header"
+  ></sm-inline-rename>
   <bit-breadcrumbs slot="breadcrumbs">
     <bit-breadcrumb [route]="['..']" icon="bwi-angle-left">{{
       "machineAccounts" | i18n

--- a/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/service-account.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/service-account.component.ts
@@ -2,14 +2,27 @@
 // @ts-strict-ignore
 import { Component, OnDestroy, OnInit } from "@angular/core";
 import { ActivatedRoute } from "@angular/router";
-import { Subject, combineLatest, filter, startWith, switchMap, takeUntil } from "rxjs";
+import {
+  Subject,
+  combineLatest,
+  distinctUntilChanged,
+  filter,
+  map,
+  startWith,
+  switchMap,
+  takeUntil,
+} from "rxjs";
 
-import { DialogService } from "@bitwarden/components";
+import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { DialogService, ToastService } from "@bitwarden/components";
 
 import { ServiceAccountCounts } from "../models/view/counts.view";
 import { ServiceAccountView } from "../models/view/service-account.view";
 import { AccessPolicyService } from "../shared/access-policies/access-policy.service";
 import { CountService } from "../shared/counts/count.service";
+import { organizationForRoute$ } from "../shared/sm-organization";
 
 import { AccessService } from "./access/access.service";
 import { AccessTokenCreateDialogComponent } from "./access/dialogs/access-token-create-dialog.component";
@@ -42,6 +55,10 @@ export class ServiceAccountComponent implements OnInit, OnDestroy {
   );
   protected serviceAccountCounts: ServiceAccountCounts;
 
+  private organizationEnabled: boolean;
+
+  protected renaming = false;
+
   constructor(
     private route: ActivatedRoute,
     private serviceAccountService: ServiceAccountService,
@@ -49,9 +66,31 @@ export class ServiceAccountComponent implements OnInit, OnDestroy {
     private accessService: AccessService,
     private dialogService: DialogService,
     private countService: CountService,
+    private organizationService: OrganizationService,
+    private accountService: AccountService,
+    private i18nService: I18nService,
+    private toastService: ToastService,
   ) {}
 
   ngOnInit(): void {
+    this.route.params
+      .pipe(
+        map((p) => p.serviceAccountId),
+        distinctUntilChanged(),
+        takeUntil(this.destroy$),
+      )
+      .subscribe((serviceAccountId) => {
+        // Close the editor when switching accounts.
+        this.serviceAccountId = serviceAccountId;
+        this.renaming = false;
+      });
+
+    organizationForRoute$(this.route.params, this.accountService, this.organizationService)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((organization) => {
+        this.organizationEnabled = organization?.enabled;
+      });
+
     const serviceAccountCounts$ = combineLatest([
       this.route.params,
       this.accessPolicyService.accessPolicy$.pipe(startWith(null)),
@@ -86,4 +125,30 @@ export class ServiceAccountComponent implements OnInit, OnDestroy {
       this.serviceAccountView,
     );
   }
+
+  protected saveName = async (name: string): Promise<boolean> => {
+    if (this.organizationEnabled === false) {
+      this.toastService.showToast({
+        variant: "error",
+        title: null,
+        message: this.i18nService.t("machineAccountsCannotEdit"),
+      });
+      return false;
+    }
+
+    // serviceAccountView may not be set yet (separate subscription), so read ids from the route.
+    const { serviceAccountId, organizationId } = this.route.snapshot.params;
+
+    const serviceAccountView = new ServiceAccountView();
+    serviceAccountView.organizationId = organizationId;
+    serviceAccountView.name = name;
+
+    await this.serviceAccountService.update(serviceAccountId, organizationId, serviceAccountView);
+    this.toastService.showToast({
+      variant: "success",
+      title: null,
+      message: this.i18nService.t("machineAccountUpdated"),
+    });
+    return true;
+  };
 }

--- a/bitwarden_license/bit-web/src/app/secrets-manager/shared/inline-rename.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/shared/inline-rename.component.html
@@ -1,0 +1,45 @@
+@if (canEdit()) {
+  @if (editing()) {
+    <form class="tw-flex tw-items-center tw-gap-2" [formGroup]="form" [bitSubmit]="submit">
+      <div class="tw-w-64 tw-max-w-full">
+        <input
+          appAutofocus
+          bitInput
+          formControlName="name"
+          (keydown.escape)="cancel()"
+          [attr.aria-label]="label()"
+          class="tw-text-base tw-font-normal tw-leading-normal"
+          [id]="idPrefix() + '_input_name'"
+        />
+      </div>
+      <button
+        type="submit"
+        bitIconButton="bwi-check"
+        buttonType="primary"
+        size="small"
+        bitFormButton
+        [label]="'save' | i18n"
+        [id]="idPrefix() + '_button_save-name'"
+      ></button>
+      <button
+        type="button"
+        bitIconButton="bwi-close"
+        buttonType="secondary"
+        size="small"
+        (click)="cancel()"
+        [label]="'cancel' | i18n"
+        [id]="idPrefix() + '_button_cancel-name'"
+      ></button>
+    </form>
+  } @else {
+    <button
+      type="button"
+      bitIconButton="bwi-pencil"
+      buttonType="subtleGhost"
+      size="small"
+      (click)="start()"
+      [label]="editLabel()"
+      [id]="idPrefix() + '_button_edit-name'"
+    ></button>
+  }
+}

--- a/bitwarden_license/bit-web/src/app/secrets-manager/shared/inline-rename.component.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/shared/inline-rename.component.ts
@@ -1,0 +1,78 @@
+import { ChangeDetectionStrategy, Component, input, model } from "@angular/core";
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from "@angular/forms";
+
+import { JslibModule } from "@bitwarden/angular/jslib.module";
+import {
+  AsyncActionsModule,
+  BitValidators,
+  IconButtonModule,
+  InputModule,
+} from "@bitwarden/components";
+
+import { SM_NAME_MAX_LENGTH } from "./sm-constants";
+
+// Non-breaking space: app-header falls back to the route title when [title] is empty.
+const TITLE_PLACEHOLDER = "\u00A0";
+
+/** Inline rename affordance for an `app-header` title; lives in the `title-suffix` slot. */
+@Component({
+  selector: "sm-inline-rename",
+  templateUrl: "./inline-rename.component.html",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    class: "tw-contents",
+  },
+  imports: [JslibModule, ReactiveFormsModule, AsyncActionsModule, IconButtonModule, InputModule],
+})
+export class InlineRenameComponent {
+  readonly name = input.required<string>();
+  /** aria-label for the text field. */
+  readonly label = input.required<string>();
+  /** aria-label for the pencil button. */
+  readonly editLabel = input.required<string>();
+  readonly canEdit = input(true);
+  readonly idPrefix = input("inline-rename");
+
+  /** Persists the name. Resolve `false` to keep the editor open. */
+  readonly save = input.required<(name: string) => Promise<boolean>>();
+
+  readonly editing = model(false);
+
+  /** Host binds this to app-header's `[title]` while editing. */
+  readonly titlePlaceholder = TITLE_PLACEHOLDER;
+
+  protected readonly form = new FormGroup({
+    name: new FormControl("", {
+      nonNullable: true,
+      validators: [
+        Validators.required,
+        Validators.maxLength(SM_NAME_MAX_LENGTH),
+        BitValidators.trimValidator,
+      ],
+      // trimValidator rewrites the value, so only run it on submit.
+      updateOn: "submit",
+    }),
+  });
+
+  protected start() {
+    this.form.setValue({ name: this.name() });
+    this.editing.set(true);
+  }
+
+  protected cancel() {
+    this.editing.set(false);
+  }
+
+  protected readonly submit = async () => {
+    this.form.markAllAsTouched();
+
+    if (this.form.invalid) {
+      return;
+    }
+
+    const saved = await this.save()(this.form.controls.name.value);
+    if (saved) {
+      this.editing.set(false);
+    }
+  };
+}

--- a/bitwarden_license/bit-web/src/app/secrets-manager/shared/sm-constants.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/shared/sm-constants.ts
@@ -1,0 +1,2 @@
+/** Maximum length for Secrets Manager entity names (projects, machine accounts, secrets). */
+export const SM_NAME_MAX_LENGTH = 500;

--- a/bitwarden_license/bit-web/src/app/secrets-manager/shared/sm-organization.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/shared/sm-organization.ts
@@ -1,0 +1,30 @@
+import { Params } from "@angular/router";
+import { Observable, concatMap, distinctUntilChanged, switchMap } from "rxjs";
+
+import {
+  getOrganizationById,
+  OrganizationService,
+} from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
+import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { getUserId } from "@bitwarden/common/auth/services/account.service";
+
+/** Organization for the route's `organizationId`, de-duped by id + enabled. `undefined` if not found. */
+export function organizationForRoute$(
+  params$: Observable<Params>,
+  accountService: AccountService,
+  organizationService: OrganizationService,
+): Observable<Organization | undefined> {
+  return params$.pipe(
+    concatMap((params) =>
+      getUserId(accountService.activeAccount$).pipe(
+        switchMap((userId) =>
+          organizationService
+            .organizations$(userId)
+            .pipe(getOrganizationById(params.organizationId)),
+        ),
+      ),
+    ),
+    distinctUntilChanged((a, b) => a?.id === b?.id && a?.enabled === b?.enabled),
+  );
+}

--- a/bitwarden_license/bit-web/src/app/secrets-manager/shared/sm-shared.module.ts
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/shared/sm-shared.module.ts
@@ -18,6 +18,7 @@ import { SharedModule } from "@bitwarden/web-vault/app/shared";
 import { AccessPolicySelectorComponent } from "./access-policies/access-policy-selector/access-policy-selector.component";
 import { BulkConfirmationDialogComponent } from "./dialogs/bulk-confirmation-dialog.component";
 import { BulkStatusDialogComponent } from "./dialogs/bulk-status-dialog.component";
+import { InlineRenameComponent } from "./inline-rename.component";
 import { NewMenuComponent } from "./new-menu.component";
 import { OrgSuspendedComponent } from "./org-suspended.component";
 import { ProjectsListComponent } from "./projects-list.component";
@@ -37,6 +38,7 @@ import { SecretsListComponent } from "./secrets-list.component";
     CardComponent,
     FormFieldModule,
     IconModule,
+    InlineRenameComponent,
   ],
   exports: [
     AccessPolicySelectorComponent,
@@ -44,6 +46,7 @@ import { SecretsListComponent } from "./secrets-list.component";
     BulkStatusDialogComponent,
     FormFieldModule,
     HeaderModule,
+    InlineRenameComponent,
     NewMenuComponent,
     NoItemsModule,
     ProjectsListComponent,


### PR DESCRIPTION
## 🎟️ Tracking

[https://bitwarden.atlassian.net/browse/SM-1990](https://bitwarden.atlassian.net/browse/SM-1990)

## 📔 Objective

Replaces the separate "Edit" dialog with inline renaming directly in the page header for Projects and Machine accounts in Secrets Manager. Clicking the pencil next to the title swaps it for a text field with save/cancel; the title is restored on success or cancel.

Changes:

- New shared sm-inline-rename component in the header's title-suffix slot; hosts supply a save callback. Removes the old "Edit project" button.
- Saving is blocked with a toast when the organization is suspended (new strings projectsCannotEdit / machineAccountsCannotEdit).
- Adds SM_NAME_MAX_LENGTH (replaces hard-coded 500 across the dialogs) and an organizationForRoute$ helper shared by both pages.

## 📸 Screenshots

https://github.com/user-attachments/assets/40ffa2b9-71b7-49b5-947c-8d42391d34de

