### PR TITLE
Add automation driver service for UI test automation

### DIFF
--- a/.claude/skills/interact-client-run-steps/SKILL.md
+++ b/.claude/skills/interact-client-run-steps/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: interact-client-run-steps
+description: >
+  Run a flow against the running Bitwarden app (desktop, browser extension, or web) against a set
+  of changes. Reads relevant files and the git diff, builds a short run plan, saves it to
+  .debug/automated-run/, then drives the app via the interact-client skill, taking and saving a
+  screenshot after each step.
+---
+
+# interact-client-run-steps skill
+
+Invoke this skill when you want to run a flow against changes to a Bitwarden client. The skill
+reads the relevant code and git diff, generates a concise run plan focused on user-visible
+behavior, then executes each step against the running app while capturing screenshots.
+
+## Workflow
+
+### Step 1: Determine target, generate run ID, and gather context
+
+Identify the target client from the user's description or the diff:
+
+- `apps/desktop/` changes → **Desktop** (Electron, `electron-devtools`, port 9222)
+- `apps/browser/` changes → **Browser extension** (`chrome-devtools`, port 9200)
+- `apps/web/` changes → **Web** (`chrome-devtools`, port 9200)
+- `libs/` changes → use whichever client the user specifies, or ask
+
+Generate a unique run ID in `YYYYMMDD-HHMMSS` format (e.g. `20260622-143022`).
+
+Run `git diff --stat HEAD` to see what changed. Read the files that appear in the diff. Identify
+the 3-5 most important user-visible behaviors or flows that the changes should affect.
+
+### Step 2: Write the run plan
+
+Create `.debug/automated-run/<run-id>/` and write `.debug/automated-run/<run-id>/run-plan.md`:
+
+- One-line title describing what is being run
+- Numbered steps, one sentence per step
+- No em dashes, no bullet sub-lists
+- Direct, plain language focused on observable UI behavior
+
+Example:
+
+```markdown
+# Run: unlock with biometrics after flag change
+
+1. Open the app and verify the login screen is shown.
+2. Enable the biometrics feature flag.
+3. Reload the app and confirm the biometric prompt appears.
+4. Approve the biometric request and verify the vault unlocks.
+```
+
+### Step 3: Load the interact-client skill, connect, and start screencast
+
+Invoke the `interact-client` skill now by calling the Skill tool with `skill: "interact-client"`.
+This loads MCP tool conventions, automation driver patterns, and platform-specific workflows into
+context.
+
+Follow the loaded skill's Step 1 for the target client:
+
+- **Desktop**: `mcp__electron-devtools__list_pages` — confirm app is running on port 9222.
+- **Browser / Web**: `mcp__chrome-devtools__list_pages` — confirm Chrome is reachable on port 9200.
+
+If not reachable, tell the user which command to run (see the `interact-client` skill's Step 1) and
+wait for it to be ready before continuing.
+
+Once connected, start recording:
+
+- **Desktop**: `mcp__electron-devtools__screencast_start` with
+  `filePath: ".debug/automated-run/<run-id>/screencast.mp4"`
+- **Browser / Web**: `mcp__chrome-devtools__screencast_start` with the same path
+
+### Step 4: Execute the plan with screenshots
+
+For each numbered step in the run plan:
+
+1. Perform the action using the `interact-client` skill's MCP tool conventions — refer to the
+   loaded skill for driver method signatures, feature flag patterns, and biometrics flows.
+2. Call `take_screenshot` (with the appropriate MCP prefix) after each action.
+3. Save to `.debug/automated-run/<run-id>/step-N-<slug>.png` where N is the step number and slug is a
+   2-3 word kebab-case description (e.g. `step-1-login-screen`, `step-2-flag-enabled`).
+4. If a step fails, note it in the plan file and continue with remaining steps.
+
+### Step 5: Dump log buffer, then stop screencast
+
+**Log buffer** — read the automation driver's in-memory log buffer using the pattern from
+`interact-client` references/log-buffer.md. Serialize the returned array to JSON and write it to
+`.debug/automated-run/<run-id>/log-buffer.json` using the Write tool.
+
+Then call `screencast_stop` to end the recording.
+
+### Step 6: Report
+
+Summarize pass/fail status for each step. List all artifact paths under
+`.debug/automated-run/<run-id>/` (screenshots, screencast, log buffer). If any steps failed,
+explain why and suggest next steps. Include the run ID so the user can reference the artifacts.
+
+## References
+
+- `interact-client` skill: MCP tool conventions, automation driver, feature flags, biometrics, platform routing
+- `interact-client` references/log-buffer.md: reading and serializing the automation driver log buffer
+- `interact-client-lock` skill: lock and unlock flows
+- `libs/common/src/platform/services/automation-driver.service.ts`: automation driver definition
+- `apps/desktop/src/app/services/init.service.ts`: desktop driver attachment point

--- a/.claude/skills/interact-client/SKILL.md
+++ b/.claude/skills/interact-client/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: interact-client
+description: >
+  Drive and interact with the running Bitwarden app — desktop (Electron), browser extension, or
+  web — via the Chrome DevTools protocol. Use when asked to navigate, click, fill UI, screenshot,
+  lock/unlock the vault, toggle feature flags, mock biometrics, or automate flows. Requires the
+  target app to already be running.
+---
+
+# Interact Client
+
+Drive the **already-running** Bitwarden app for debugging and automation.
+
+Two MCP servers are wired in `.mcp.json` — pick the right one for your target:
+
+| MCP server          | Port | Targets                                                       |
+| ------------------- | ---- | ------------------------------------------------------------- |
+| `electron-devtools` | 9222 | Desktop (Electron renderer) — use `mcp__electron-devtools__*` |
+| `chrome-devtools`   | 9200 | Browser extension, Web app — use `mcp__chrome-devtools__*`    |
+
+This skill may read vault states. **Only use it with test accounts.**
+
+## Detailed references
+
+Load these on demand for the specific sub-task:
+
+- **[references/screenshot.md](references/screenshot.md)** — DOM snapshots vs. screenshots and when
+  to use each.
+- **[references/lock.md](references/lock.md)** — lock the vault and unlock via biometrics, PIN, or
+  master password (credentials from `.debug/credentials.txt`).
+- **[references/biometrics.md](references/biometrics.md)** — desktop mock biometrics: set status,
+  approve/deny prompts.
+- **[references/feature-flags.md](references/feature-flags.md)** — override feature flags via the
+  desktop automation driver and reload the process.
+- **[references/flight-recorder.md](references/flight-recorder.md)** — read SDK flight recorder
+  events from the running app.
+- **[references/log-buffer.md](references/log-buffer.md)** — read buffered log entries captured
+  from the app's `LogService` since startup.
+
+## Step 1 — Determine target and connect
+
+Identify which client you are working with, then confirm the DevTools endpoint is reachable.
+
+**Desktop:**
+
+```bash
+curl -s http://localhost:9222/json/version
+```
+
+Call `mcp__electron-devtools__list_pages`. Select the renderer page (URL contains `index.html`) with
+`mcp__electron-devtools__select_page` if there are multiple pages.
+
+**Browser extension or Web:**
+
+```bash
+curl -s http://localhost:9200/json/version
+```
+
+Call `mcp__chrome-devtools__list_pages`. For the browser extension the popup appears as an
+**Extension Page** entry; for the web app find the tab at the dev-server URL.
+
+**If the endpoint is not reachable, do NOT try to launch the app yourself.** Ask the user to start
+it in dev mode:
+
+```bash
+# Desktop — exposes remote debugging on port 9222 (from apps/desktop)
+npm run electron
+
+# Desktop with mock biometrics (skips the native OS prompt) — see references/biometrics.md:
+USE_AUTOMATION_BIOMETRICS=1 npm run electron
+
+# Web — start the dev server, then open it in Chrome (from apps/web)
+npm run build:watch
+
+# Browser extension — build then load the unpacked extension in Chrome (from apps/browser)
+npm run build:watch
+```
+
+> The automation driver and mock biometrics are **dev-mode only** (`PlatformUtilsService.isDev()`).
+> Packaged builds do not expose them.
+
+## Step 2 — Navigate and interact
+
+Standard MCP operations — use the correct tool prefix for the active target:
+
+- **Snapshot / screenshot**: see [references/screenshot.md](references/screenshot.md). Snapshot to
+  locate elements (`uid`s), screenshot to show state.
+- **Click / fill**: `click`, `fill`, `fill_form` using `uid`s from the snapshot.
+- **Wait**: `wait_for` for text to appear after navigation or transitions.
+- **Console / network**: `list_console_messages`, `list_network_requests` for debugging.
+
+The Bitwarden clients are single-page Angular apps — navigate by interacting with UI elements, not
+by changing the URL directly.
+
+For lock/unlock flows, see [references/lock.md](references/lock.md).
+
+## Desktop
+
+### Automation driver
+
+A dev-only object, `window.bitwardenAutomationDriver`, is attached to the renderer global. Call its
+methods via `mcp__electron-devtools__evaluate_script` to override feature flags, send app messages,
+reload the process, control biometrics, and read flight recorder events.
+
+Defined in `libs/automation-driver/src/automation-driver.service.ts`; attached in
+`apps/desktop/src/app/services/init.service.ts`.
+
+Always guard for its presence:
+
+```js
+() => {
+  const d = window.bitwardenAutomationDriver;
+  if (!d) return "automation driver unavailable — app is not running in dev mode";
+  // call driver methods...
+};
+```
+
+Driver capabilities are documented in the references:
+
+- **Feature flags** → [references/feature-flags.md](references/feature-flags.md)
+- **Biometrics** → [references/biometrics.md](references/biometrics.md)
+- **Flight recorder** → [references/flight-recorder.md](references/flight-recorder.md)
+- **Log buffer** → [references/log-buffer.md](references/log-buffer.md)
+
+### Messaging / menubar
+
+`sendMessage(command, data?)` dispatches an app message — the same commands the native menubar
+sends. `openSettings()` is a convenience wrapper:
+
+```js
+() => {
+  window.bitwardenAutomationDriver.openSettings();
+};
+() => {
+  window.bitwardenAutomationDriver.sendMessage("openSettings");
+};
+```
+
+## Browser extension
+
+The browser extension exposes pages under `chrome-extension://` in
+`mcp__chrome-devtools__list_pages`. The popup appears as an **Extension Page** entry; the
+background service worker appears as an **Extension Service Workers** entry.
+
+To open the popup when it is not yet visible:
+
+1. If no tabs are open, call `mcp__chrome-devtools__new_page` with `url: "about:blank"`.
+2. Use `mcp__chrome-devtools__trigger_extension_action` with the extension ID (read from the
+   `chrome-extension://` URL in the service worker entry).
+3. Call `list_pages` again to find the new extension page, then `select_page` to focus it.
+
+## Web
+
+Navigate Chrome to the web app dev-server URL (check `apps/web` package scripts for the port —
+typically `localhost:8080`). The page will appear in `mcp__chrome-devtools__list_pages` as a
+regular page. Select it and interact via `mcp__chrome-devtools__*` tools.
+
+## Notes
+
+- Prefer `take_snapshot` over `take_screenshot` for locating elements; use screenshots to report
+  visual state.
+- After `reloadProcess` (desktop), re-establish the page with `list_pages` → `select_page`.
+- If `bitwardenAutomationDriver` is undefined, the build is not in dev mode.
+- If `.biometrics` is undefined on the driver, relaunch the desktop app with
+  `USE_AUTOMATION_BIOMETRICS=1`.

--- a/.claude/skills/interact-client/references/biometrics.md
+++ b/.claude/skills/interact-client/references/biometrics.md
@@ -1,0 +1,64 @@
+# Desktop mock biometrics
+
+Desktop-only. Only present when the app was launched with `USE_AUTOMATION_BIOMETRICS=1`. Replaces
+the OS biometric prompt with a fake service so prompts can be approved or denied deterministically.
+Access via `window.bitwardenAutomationDriver.biometrics` (undefined if the env var was not set).
+
+> The automation driver and mock biometrics are **dev-mode only** (`PlatformUtilsService.isDev()`).
+> Packaged builds do not expose them.
+
+Launch the desktop app with mock biometrics (from `apps/desktop`):
+
+```bash
+USE_AUTOMATION_BIOMETRICS=1 npm run electron
+```
+
+## Set the reported status
+
+From `BiometricsStatus` in `libs/key-management/src/biometrics/biometrics-status.ts`:
+
+| Value | Status                | Meaning                             |
+| ----- | --------------------- | ----------------------------------- |
+| 0     | `Available`           | Biometric unlock available          |
+| 1     | `UnlockNeeded`        | Password must unlock user key first |
+| 2     | `HardwareUnavailable` | No biometric hardware               |
+| 5     | `PlatformUnsupported` | Not implemented for this platform   |
+
+```js
+async () => {
+  await window.bitwardenAutomationDriver.biometrics.setStatus(0);
+};
+```
+
+## Approve / deny prompts
+
+```js
+// list queued requests — [{ id, type: "authenticate" | "unlock", userId? }, ...]
+async () => window.bitwardenAutomationDriver.biometrics.listPending();
+
+// approve / deny by id, or omit id to resolve the oldest pending request
+async () => {
+  await window.bitwardenAutomationDriver.biometrics.approve("1");
+};
+async () => {
+  await window.bitwardenAutomationDriver.biometrics.deny();
+};
+```
+
+## Typical biometric-unlock flow
+
+1. `setStatus(0)` — report biometrics as available.
+2. Click the biometric unlock button via `mcp__electron-devtools__click`.
+3. `listPending()` — confirm a request is queued.
+4. `approve(id)` or `deny(id)` — simulate the user's response.
+5. Screenshot to verify the result.
+
+> Mock biometrics keys are held in memory only — they do not survive a process reload.
+> If `.biometrics` is undefined on the driver, relaunch the desktop app with
+> `USE_AUTOMATION_BIOMETRICS=1`.
+
+## Source
+
+- `apps/desktop/src/key-management/biometrics/automation-biometrics.service.ts`: mock biometrics
+  implementation
+- `libs/key-management/src/biometrics/biometrics-status.ts`: `BiometricsStatus` values

--- a/.claude/skills/interact-client/references/feature-flags.md
+++ b/.claude/skills/interact-client/references/feature-flags.md
@@ -1,0 +1,41 @@
+# Override feature flags (desktop)
+
+Use the dev-only automation driver to override feature flags on the running desktop app. Call its
+methods via `mcp__electron-devtools__evaluate_script`. Always guard for the driver's presence — if
+`window.bitwardenAutomationDriver` is undefined, the build is not in dev mode.
+
+Flag keys are the string **values** of the `FeatureFlag` enum in
+`libs/common/src/enums/feature-flag.enum.ts` — **not** the enum member name. Read the enum to get
+the exact key before toggling.
+
+```js
+async () => {
+  await window.bitwardenAutomationDriver.setFeatureFlag("windows-desktop-autotype", true);
+};
+async () => window.bitwardenAutomationDriver.getFeatureFlag("windows-desktop-autotype");
+async () => {
+  await window.bitwardenAutomationDriver.clearFeatureFlag("windows-desktop-autotype");
+};
+async () => {
+  await window.bitwardenAutomationDriver.clearAllFeatureFlagOverrides();
+};
+```
+
+## Reload after changing a flag
+
+Overrides persist in global state. Many flags are only read at startup — after changing a flag,
+reload the process:
+
+```js
+async () => {
+  await window.bitwardenAutomationDriver.reloadProcess();
+};
+```
+
+After `reloadProcess`, call `mcp__electron-devtools__list_pages` → `select_page` before further
+interaction.
+
+## Source
+
+- `libs/common/src/enums/feature-flag.enum.ts`: `FeatureFlag` enum — read this for exact flag keys
+- `libs/automation-driver/src/automation-driver.service.ts`: `AutomationDriver` implementation

--- a/.claude/skills/interact-client/references/flight-recorder.md
+++ b/.claude/skills/interact-client/references/flight-recorder.md
@@ -1,0 +1,49 @@
+# Flight recorder
+
+Read SDK flight recorder events from the running desktop app via the automation driver. Only
+available on clients that load the WASM SDK (desktop, browser extension, web — not CLI).
+
+Access via `window.bitwardenAutomationDriver.flightRecorder` (undefined if the client does not wire
+it in). Call methods via `mcp__electron-devtools__evaluate_script`.
+
+## Read events
+
+```js
+// Read all events currently in the buffer
+async () => window.bitwardenAutomationDriver.flightRecorder.read();
+
+// Get the current event count without reading contents
+async () => window.bitwardenAutomationDriver.flightRecorder.count();
+```
+
+`read()` returns an array of `FlightRecorderEvent` objects from `@bitwarden/sdk-internal`.
+
+## Typical debugging flow
+
+1. Guard for the driver and the flight recorder capability:
+
+   ```js
+   () => {
+     const d = window.bitwardenAutomationDriver;
+     if (!d) return "automation driver unavailable";
+     if (!d.flightRecorder) return "flight recorder not wired on this client";
+   };
+   ```
+
+2. Reproduce the operation under investigation.
+
+3. Read the event buffer:
+
+   ```js
+   async () => window.bitwardenAutomationDriver.flightRecorder.read();
+   ```
+
+4. Inspect the returned events for timing, ordering, or error signals.
+
+## Source
+
+- `libs/automation-driver/src/automation-driver.service.ts`: `AutomationDriver.flightRecorder`
+  getter and `AutomationDriverCapabilities.flightRecorder`
+- `libs/logging/src/flight-recorder.ts`: `FlightRecorder` — `read()` and `count()` implementation
+- `libs/logging-angular/src/flight-recorder.service.ts`: Angular injectable that wires
+  `FlightRecorder` to `SdkLoadService.Ready`

--- a/.claude/skills/interact-client/references/lock.md
+++ b/.claude/skills/interact-client/references/lock.md
@@ -1,0 +1,120 @@
+# Lock / Unlock
+
+Lock or unlock the vault in a running Bitwarden client. Assumes a DevTools session is already
+active (see the main `interact-client` SKILL.md for connecting).
+
+## Credentials
+
+Read credentials from `.debug/credentials.txt` before any unlock flow. The file uses `KEY=VALUE`
+format:
+
+```
+PIN=1234
+PASSWORD=yourpassword
+```
+
+- **PIN**: default is `1234`; always read the actual value from `credentials.txt`.
+- **Password**: always read from `credentials.txt`; no hardcoded default.
+
+## Locking
+
+To lock the vault from within the app, dispatch the `lockVault` message via the automation driver
+(desktop only):
+
+```js
+async () => {
+  await window.bitwardenAutomationDriver.sendMessage("lockVault");
+};
+```
+
+For browser extension or web, click the **Lock** option in the account menu. Use `take_snapshot` to
+locate the account/profile button, click it, then click the Lock item.
+
+After locking, `wait_for` the lock screen to confirm the transition, then take a screenshot to
+confirm the vault is locked before proceeding.
+
+## Unlocking
+
+The lock screen is implemented in
+`libs/key-management-ui/src/lock/components/lock.component.ts`. It presents one active unlock
+method at a time — biometrics, PIN, or master password — with tab-style controls to switch between
+them.
+
+### Unlock via biometrics
+
+Biometric unlock uses the automation driver and is **desktop-only**. The app must have been
+launched with `USE_AUTOMATION_BIOMETRICS=1`. See `references/biometrics.md` for the full driver
+API.
+
+1. Ensure the biometrics status is reported as available:
+
+   ```js
+   async () => {
+     await window.bitwardenAutomationDriver.biometrics.setStatus(0);
+   };
+   ```
+
+2. On the lock screen, locate and click the biometric unlock button (labeled "Use biometrics" or
+   similar — use `take_snapshot` to find it by accessible name).
+
+3. Confirm a request is queued:
+
+   ```js
+   async () => window.bitwardenAutomationDriver.biometrics.listPending();
+   // returns [{ id, type: "authenticate" | "unlock", userId? }, ...]
+   ```
+
+4. Approve or deny the request:
+
+   ```js
+   // approve the oldest pending request
+   async () => {
+     await window.bitwardenAutomationDriver.biometrics.approve();
+   };
+
+   // or approve/deny by id
+   async () => {
+     await window.bitwardenAutomationDriver.biometrics.approve("1");
+   };
+   async () => {
+     await window.bitwardenAutomationDriver.biometrics.deny("1");
+   };
+   ```
+
+5. Screenshot to verify the vault unlocked.
+
+> If `.biometrics` is undefined on the driver, the app was not launched with
+> `USE_AUTOMATION_BIOMETRICS=1`. Ask the user to relaunch with that env var set.
+
+> Mock biometric keys are held in memory only — they do not survive a `reloadProcess()` call.
+
+### Unlock via PIN
+
+1. Read the PIN from `.debug/credentials.txt` (default: `1234`).
+2. On the lock screen, switch to the PIN tab if it is not already active — use `take_snapshot` to
+   find the "Use PIN" or equivalent tab control and click it.
+3. Fill the PIN input field with the value from `credentials.txt`.
+4. Submit the form (click the Unlock button or press Enter).
+5. Screenshot to verify the vault unlocked.
+
+The PIN input field is a password-type input. The lock component calls
+`unlockService.unlockWithPin(userId, pin)` on submission.
+
+### Unlock via master password
+
+1. Read the password from `.debug/credentials.txt`.
+2. On the lock screen, switch to the master password tab if needed — use `take_snapshot` to find
+   the "Use master password" tab and click it.
+3. Fill the password input field with the value from `credentials.txt`.
+4. Submit the form (click Unlock or press Enter).
+5. Screenshot to verify the vault unlocked.
+
+The lock component delegates master password entry to `MasterPasswordLockComponent`, which calls
+`unlockService.unlockWithMasterPassword(userId, password)`.
+
+## Source
+
+- `libs/key-management-ui/src/lock/components/lock.component.ts`: lock screen component
+- `libs/unlock/src/default-unlock.service.ts`: unlock service (PIN, password, biometrics)
+- `apps/desktop/src/key-management/biometrics/automation-biometrics.service.ts`: mock biometrics
+- `libs/automation-driver/src/automation-driver.service.ts`: automation driver

--- a/.claude/skills/interact-client/references/log-buffer.md
+++ b/.claude/skills/interact-client/references/log-buffer.md
@@ -1,0 +1,48 @@
+# Log buffer
+
+The automation driver hooks the app's `LogService` at startup and accumulates every log write in
+an in-memory buffer. Use this to inspect log output without attaching a debugger.
+
+Available via `window.bitwardenAutomationDriver` on any client running in dev mode. Call methods
+via the appropriate `evaluate_script` tool for the target client.
+
+## Read the buffer
+
+```js
+// Returns a snapshot: [{ level: 0|1|2|3, message: any, params: any[] }, ...]
+async () => window.bitwardenAutomationDriver.readLogBuffer();
+```
+
+`level` maps to `LogLevel` from `@bitwarden/logging`:
+
+| Value | Name      |
+| ----- | --------- |
+| 0     | `Debug`   |
+| 1     | `Info`    |
+| 2     | `Warning` |
+| 3     | `Error`   |
+
+## Clear the buffer
+
+```js
+async () => {
+  window.bitwardenAutomationDriver.clearLogBuffer();
+};
+```
+
+Call this before the operation under test so the buffer only contains messages from that run.
+
+## Typical debugging flow
+
+1. Clear the buffer.
+2. Trigger the operation (click, send message, call an API, etc.).
+3. Read the buffer and inspect for unexpected warnings or errors.
+
+## Notes
+
+- The hook is added once, at driver construction. Calling the driver's `hookLogService` method
+  a second time on the same service stacks wrappers — avoid double-hooking.
+- The buffer is never automatically cleared; it grows until you call `clearLogBuffer()` or the
+  page/process reloads.
+- `readLogBuffer()` returns a snapshot (a copy) — entries added after the call are not visible in
+  the returned array.

--- a/.claude/skills/interact-client/references/screenshot.md
+++ b/.claude/skills/interact-client/references/screenshot.md
@@ -1,0 +1,36 @@
+# Screenshots & DOM snapshots
+
+Two ways to observe the running app. Pick by intent: **snapshot to locate**, **screenshot to
+show**. Use the correct MCP tool prefix for the active target (`mcp__electron-devtools__*` for
+desktop, `mcp__chrome-devtools__*` for browser extension / web).
+
+## DOM snapshot (preferred for locating elements)
+
+`take_snapshot` returns an accessibility tree with element `uid`s. Those `uid`s are what the
+interaction tools (`click`, `fill`, `fill_form`) operate on, so snapshot first whenever you need to
+act on the UI.
+
+```
+take_snapshot          # accessibility tree + uids
+```
+
+The Bitwarden clients are single-page Angular apps — locate elements by their accessible name in
+the snapshot, not by URL.
+
+## Screenshot (for reporting visual state)
+
+Use `take_screenshot` whenever the user asks to "see" or "show" the current state, or to verify the
+result of a flow.
+
+```
+take_screenshot                  # current viewport
+take_screenshot fullPage: true   # full window / page
+```
+
+## Guidance
+
+- Prefer `take_snapshot` over `take_screenshot` for finding things to click; screenshots are for
+  human-visible confirmation.
+- After navigation or a transition, `wait_for` the expected text before snapshotting/screenshotting
+  so you capture the settled state.
+- In flows, take a screenshot after each meaningful step to document progress.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -239,6 +239,9 @@ apps/desktop/src/services/biometric-message-handler.service.ts @bitwarden/team-k
 apps/web/src/app/pam @bitwarden/team-pam-dev
 libs/pam @bitwarden/team-pam-dev
 
+## Automation driver ##
+libs/automation-driver @bitwarden/team-ai-sme @bitwarden/team-key-management-dev @bitwarden/team-platform-dev
+
 ## Locales ##
 apps/browser/src/_locales/en/messages.json
 apps/browser/store/locales/en

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,40 @@
+{
+  "mcpServers": {
+    "electron-devtools-attach": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "chrome-devtools-mcp@1.2.0",
+        "--browserUrl=http://localhost:9222",
+        "--experimental-screencast"
+      ],
+      "env": {},
+      "__comment": "This server is used to attach to a running electron app"
+    },
+    "chrome-devtools-attach": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "chrome-devtools-mcp@1.2.0",
+        "--browserUrl=http://localhost:9200",
+        "--experimental-screencast",
+        "--categoryExtensions"
+      ],
+      "env": {},
+      "__comment": "This server is used to attach to a running chrome instance"
+    },
+    "chrome-devtools-headless": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "chrome-devtools-mcp@1.2.0",
+        "--experimental-screencast",
+        "--headless",
+        "--isolated",
+        "--categoryExtensions"
+      ],
+      "env": {},
+      "__comment": "This server is used for headless Chrome debugging. It can be launched concurrently"
+    }
+  }
+}

--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -47,6 +47,7 @@ import {
   AutomaticUserConfirmationService,
   DefaultAutomaticUserConfirmationService,
 } from "@bitwarden/auto-confirm";
+import { AutomationDriver } from "@bitwarden/automation-driver";
 import { ApiService as ApiServiceAbstraction } from "@bitwarden/common/abstractions/api.service";
 import { AuditService as AuditServiceAbstraction } from "@bitwarden/common/abstractions/audit.service";
 import { InternalOrganizationServiceAbstraction } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
@@ -1758,6 +1759,15 @@ export default class MainBackground {
 
   async bootstrap() {
     this.containerService.attachToGlobal(self);
+
+    AutomationDriver.attachToGlobalIfDev(
+      self,
+      this.platformUtilsService,
+      this.configService,
+      this.stateProvider,
+      this.messagingService,
+      { logService: this.logService },
+    );
 
     await this.sdkLoadService.loadAndInit();
     // Only the "true" background should run migrations

--- a/apps/browser/src/popup/services/init.service.ts
+++ b/apps/browser/src/popup/services/init.service.ts
@@ -1,13 +1,17 @@
 import { inject, Inject, Injectable, DOCUMENT } from "@angular/core";
 
 import { AbstractThemingService } from "@bitwarden/angular/platform/services/theming/theming.service.abstraction";
+import { AutomationDriver } from "@bitwarden/automation-driver";
 import { TwoFactorService } from "@bitwarden/common/auth/two-factor";
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService as LogServiceAbstraction } from "@bitwarden/common/platform/abstractions/log.service";
+import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { SdkLoadService } from "@bitwarden/common/platform/abstractions/sdk/sdk-load.service";
 import { StateService } from "@bitwarden/common/platform/abstractions/state.service";
 import { MigrationRunner } from "@bitwarden/common/platform/services/migration-runner";
+import { StateProvider } from "@bitwarden/common/platform/state";
 
 import BrowserPopupUtils from "../../platform/browser/browser-popup-utils";
 import { PopupSizeService } from "../../platform/popup/layout/popup-size.service";
@@ -16,6 +20,9 @@ import { PopupViewCacheService } from "../../platform/popup/view-cache/popup-vie
 @Injectable()
 export class InitService {
   private sizeService = inject(PopupSizeService);
+  private configService = inject(ConfigService);
+  private stateProvider = inject(StateProvider);
+  private messagingService = inject(MessagingService);
 
   constructor(
     private platformUtilsService: PlatformUtilsService,
@@ -38,6 +45,15 @@ export class InitService {
       this.twoFactorService.init();
       await this.viewCacheService.init();
       await this.sizeService.init();
+
+      AutomationDriver.attachToGlobalIfDev(
+        self,
+        this.platformUtilsService,
+        this.configService,
+        this.stateProvider,
+        this.messagingService,
+        { logService: this.logService },
+      );
 
       const htmlEl = window.document.documentElement;
       this.themingService.applyThemeChangesTo(this.document);

--- a/apps/cli/src/service-container/service-container.ts
+++ b/apps/cli/src/service-container/service-container.ts
@@ -27,6 +27,7 @@ import {
   DefaultLogoutService,
   LockService,
 } from "@bitwarden/auth/common";
+import { AutomationDriver } from "@bitwarden/automation-driver";
 import { OrganizationApiServiceAbstraction } from "@bitwarden/common/admin-console/abstractions/organization/organization-api.service.abstraction";
 import { InternalNewPolicyService } from "@bitwarden/common/admin-console/abstractions/policy/new-policy.service.abstraction";
 import { PolicyApiServiceAbstraction } from "@bitwarden/common/admin-console/abstractions/policy/policy-api.service.abstraction";
@@ -1176,6 +1177,16 @@ export class ServiceContainer {
 
     await this.migrationRunner.run();
     this.containerService.attachToGlobal(global);
+
+    AutomationDriver.attachToGlobalIfDev(
+      global,
+      this.platformUtilsService,
+      this.configService,
+      this.stateProvider,
+      this.messagingService,
+      { logService: this.logService },
+    );
+
     await this.i18nService.init();
     this.twoFactorService.init();
 

--- a/apps/desktop/src/app/services/init.service.ts
+++ b/apps/desktop/src/app/services/init.service.ts
@@ -3,6 +3,7 @@ import { firstValueFrom } from "rxjs";
 
 import { AbstractThemingService } from "@bitwarden/angular/platform/services/theming/theming.service.abstraction";
 import { WINDOW } from "@bitwarden/angular/services/injection-tokens";
+import { AutomationDriver } from "@bitwarden/automation-driver";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { TokenService } from "@bitwarden/common/auth/abstractions/token.service";
 import { TwoFactorService } from "@bitwarden/common/auth/two-factor";
@@ -14,6 +15,8 @@ import { SharedUnlockLeaderService } from "@bitwarden/common/key-management/shar
 import { DefaultVaultTimeoutService } from "@bitwarden/common/key-management/vault-timeout";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { I18nService as I18nServiceAbstraction } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
 import { PlatformUtilsService as PlatformUtilsServiceAbstraction } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { SdkLoadService } from "@bitwarden/common/platform/abstractions/sdk/sdk-load.service";
 import { IpcService } from "@bitwarden/common/platform/ipc";
@@ -21,6 +24,7 @@ import { ServerNotificationsService } from "@bitwarden/common/platform/server-no
 import { ContainerService } from "@bitwarden/common/platform/services/container.service";
 import { MigrationRunner } from "@bitwarden/common/platform/services/migration-runner";
 import { UserAutoUnlockKeyService } from "@bitwarden/common/platform/services/user-auto-unlock-key.service";
+import { StateProvider } from "@bitwarden/common/platform/state";
 import { SyncService as SyncServiceAbstraction } from "@bitwarden/common/platform/sync";
 import { UserId } from "@bitwarden/common/types/guid";
 import { BiometricsService, KeyService as KeyServiceAbstraction } from "@bitwarden/key-management";
@@ -70,6 +74,9 @@ export class InitService {
     private readonly migrationRunner: MigrationRunner,
     private serverCommunicationConfigService: ServerCommunicationConfigService,
     private updateRestartService: UpdateRestartService,
+    private stateProvider: StateProvider,
+    private messagingService: MessagingService,
+    private logService: LogService,
   ) {}
 
   init() {
@@ -114,6 +121,24 @@ export class InitService {
 
       const containerService = new ContainerService(this.keyService, this.encryptService);
       containerService.attachToGlobal(this.win);
+
+      AutomationDriver.attachToGlobalIfDev(
+        this.win,
+        this.platformUtilsService,
+        this.configService,
+        this.stateProvider,
+        this.messagingService,
+        {
+          reloadProcess: () => ipc.platform.reloadProcess(),
+          biometrics: {
+            setStatus: (status) => ipc.platform.automation.biometrics.setStatus(status),
+            listPending: () => ipc.platform.automation.biometrics.listPending(),
+            approve: (id) => ipc.platform.automation.biometrics.approve(id),
+            deny: (id) => ipc.platform.automation.biometrics.deny(id),
+          },
+          logService: this.logService,
+        },
+      );
 
       if (await this.configService.getFeatureFlag(FeatureFlag.SharedUnlockPart1)) {
         await this.sharedUnlockLeaderService.start();

--- a/apps/desktop/src/key-management/biometrics/automation-biometrics-ipc.listener.ts
+++ b/apps/desktop/src/key-management/biometrics/automation-biometrics-ipc.listener.ts
@@ -1,0 +1,66 @@
+import { ipcMain } from "electron";
+
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+import { BiometricsStatus } from "@bitwarden/key-management";
+
+import { AutomationBiometricsService } from "./automation-biometrics.service";
+
+export const AutomationBiometricAction = Object.freeze({
+  SetStatus: "setStatus",
+  ListPending: "listPending",
+  Approve: "approve",
+  Deny: "deny",
+} as const);
+export type AutomationBiometricAction =
+  (typeof AutomationBiometricAction)[keyof typeof AutomationBiometricAction];
+
+export type AutomationBiometricMessage = {
+  action: AutomationBiometricAction;
+  status?: BiometricsStatus;
+  id?: string;
+};
+
+export const AUTOMATION_BIOMETRIC_CHANNEL = "automation.biometric";
+
+/**
+ * Registers the IPC channel that lets the renderer-side automation driver control the
+ * {@link AutomationBiometricsService} running in the main process. Only wired up when automation
+ * biometrics are active (dev mode + `USE_AUTOMATION_BIOMETRICS`).
+ */
+export class AutomationBiometricsIPCListener {
+  constructor(
+    private biometricsService: AutomationBiometricsService,
+    private logService: LogService,
+  ) {}
+
+  init() {
+    ipcMain.handle(
+      AUTOMATION_BIOMETRIC_CHANNEL,
+      async (event: any, message: AutomationBiometricMessage) => {
+        try {
+          switch (message.action) {
+            case AutomationBiometricAction.SetStatus:
+              this.biometricsService.setMockStatus(message.status as BiometricsStatus);
+              return;
+            case AutomationBiometricAction.ListPending:
+              return this.biometricsService.listPendingRequests();
+            case AutomationBiometricAction.Approve:
+              this.biometricsService.approveRequest(message.id);
+              return;
+            case AutomationBiometricAction.Deny:
+              this.biometricsService.denyRequest(message.id);
+              return;
+            default:
+              return;
+          }
+        } catch (e) {
+          this.logService.error(
+            "[Automation Biometrics IPC Listener] %s failed",
+            message.action,
+            e,
+          );
+        }
+      },
+    );
+  }
+}

--- a/apps/desktop/src/key-management/biometrics/automation-biometrics.service.spec.ts
+++ b/apps/desktop/src/key-management/biometrics/automation-biometrics.service.spec.ts
@@ -1,0 +1,133 @@
+import { mock } from "jest-mock-extended";
+
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
+import { UserId } from "@bitwarden/common/types/guid";
+import { BiometricsStatus } from "@bitwarden/key-management";
+
+import { AutomationBiometricsService } from "./automation-biometrics.service";
+
+describe("AutomationBiometricsService", () => {
+  const userId = "user-id" as UserId;
+  const key = new SymmetricCryptoKey(new Uint8Array(64)) as SymmetricCryptoKey;
+
+  let sut: AutomationBiometricsService;
+
+  beforeEach(() => {
+    sut = new AutomationBiometricsService(mock<LogService>());
+  });
+
+  describe("mock status", () => {
+    it("defaults to Available at the platform level", async () => {
+      await expect(sut.supportsBiometrics()).resolves.toBe(true);
+    });
+
+    it("reports the configured status", async () => {
+      sut.setMockStatus(BiometricsStatus.HardwareUnavailable);
+
+      await expect(sut.supportsBiometrics()).resolves.toBe(false);
+      await expect(sut.getBiometricsFirstUnlockStatusForUser(userId)).resolves.toBe(
+        BiometricsStatus.HardwareUnavailable,
+      );
+    });
+  });
+
+  describe("getBiometricsFirstUnlockStatusForUser", () => {
+    it("returns the platform status when biometrics are not available", async () => {
+      sut.setMockStatus(BiometricsStatus.HardwareUnavailable);
+
+      await expect(sut.getBiometricsFirstUnlockStatusForUser(userId)).resolves.toBe(
+        BiometricsStatus.HardwareUnavailable,
+      );
+    });
+
+    it("returns UnlockNeeded when available but no key is held for the user", async () => {
+      await expect(sut.getBiometricsFirstUnlockStatusForUser(userId)).resolves.toBe(
+        BiometricsStatus.UnlockNeeded,
+      );
+    });
+
+    it("returns Available when available and a key is held for the user", async () => {
+      await sut.setBiometricKey(userId, key);
+
+      await expect(sut.getBiometricsFirstUnlockStatusForUser(userId)).resolves.toBe(
+        BiometricsStatus.Available,
+      );
+    });
+  });
+
+  describe("pending authentication requests", () => {
+    it("lists a pending request and resolves true on approval", async () => {
+      const result = sut.authenticateBiometric();
+
+      const pending = sut.listPendingRequests();
+      expect(pending).toHaveLength(1);
+      expect(pending[0].type).toBe("authenticate");
+
+      sut.approveRequest();
+
+      await expect(result).resolves.toBe(true);
+      expect(sut.listPendingRequests()).toHaveLength(0);
+    });
+
+    it("resolves false on denial", async () => {
+      const result = sut.authenticateBiometric();
+
+      sut.denyRequest();
+
+      await expect(result).resolves.toBe(false);
+    });
+
+    it("resolves a specific request by id", async () => {
+      const first = sut.authenticateBiometric();
+      const second = sut.authenticateBiometric();
+
+      const [, secondPending] = sut.listPendingRequests();
+      sut.approveRequest(secondPending.id);
+
+      await expect(second).resolves.toBe(true);
+      expect(sut.listPendingRequests()).toHaveLength(1);
+
+      sut.denyRequest();
+      await expect(first).resolves.toBe(false);
+    });
+  });
+
+  describe("biometric keys", () => {
+    it("returns the stored key after unlock approval", async () => {
+      await sut.setBiometricKey(userId, key);
+
+      const result = sut.getBiometricKey(userId);
+      sut.approveRequest();
+
+      await expect(result).resolves.toBe(key);
+    });
+
+    it("returns null after unlock denial", async () => {
+      await sut.setBiometricKey(userId, key);
+
+      const result = sut.getBiometricKey(userId);
+      sut.denyRequest();
+
+      await expect(result).resolves.toBeNull();
+    });
+
+    it("tracks persistent keys", async () => {
+      await expect(sut.hasPersistentKey(userId)).resolves.toBe(false);
+
+      await sut.enrollPersistent(userId, key);
+
+      await expect(sut.hasPersistentKey(userId)).resolves.toBe(true);
+    });
+
+    it("deletes keys", async () => {
+      await sut.setBiometricKey(userId, key);
+
+      await sut.deleteBiometricKey(userId);
+
+      const result = sut.getBiometricKey(userId);
+      sut.approveRequest();
+      await expect(result).resolves.toBeNull();
+    });
+  });
+});

--- a/apps/desktop/src/key-management/biometrics/automation-biometrics.service.ts
+++ b/apps/desktop/src/key-management/biometrics/automation-biometrics.service.ts
@@ -1,0 +1,135 @@
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
+import { UserId } from "@bitwarden/common/types/guid";
+import { BiometricsStatus } from "@bitwarden/key-management";
+
+import { OsBiometricService } from "./os-biometrics.service";
+
+export type AutomationBiometricRequestType = "authenticate" | "unlock";
+
+export interface AutomationBiometricRequest {
+  id: string;
+  type: AutomationBiometricRequestType;
+  userId?: UserId;
+}
+
+interface PendingRequest extends AutomationBiometricRequest {
+  resolve: (approved: boolean) => void;
+}
+
+/**
+ * A fake {@link OsBiometricService} used for automation (E2E tests, manual automation). It replaces
+ * the real OS biometric service on the desktop main process when running in dev mode with the
+ * `USE_AUTOMATION_BIOMETRICS` environment variable set, so the native OS prompt never fires.
+ *
+ * Biometric requests are queued and block until automation approves or denies them, allowing tests
+ * to deterministically simulate the user accepting or rejecting the native prompt. The reported
+ * biometric status is settable. Biometric keys are held in memory only (no OS keychain), so they do
+ * not persist across restarts.
+ */
+export class AutomationBiometricsService implements OsBiometricService {
+  private mockStatus = BiometricsStatus.Available;
+  private keys = new Map<UserId, SymmetricCryptoKey>();
+  private pendingRequests: PendingRequest[] = [];
+  private nextRequestId = 1;
+
+  constructor(private logService: LogService) {}
+
+  // --- Automation control surface (driven over IPC) ---
+
+  setMockStatus(status: BiometricsStatus): void {
+    this.mockStatus = status;
+  }
+
+  listPendingRequests(): AutomationBiometricRequest[] {
+    return this.pendingRequests.map(({ id, type, userId }) => ({ id, type, userId }));
+  }
+
+  approveRequest(id?: string): void {
+    this.resolveRequests(id, true);
+  }
+
+  denyRequest(id?: string): void {
+    this.resolveRequests(id, false);
+  }
+
+  private resolveRequests(id: string | undefined, approved: boolean): void {
+    const matches =
+      id == null
+        ? this.pendingRequests.splice(0, this.pendingRequests.length)
+        : this.pendingRequests
+            .filter((r) => r.id === id)
+            .map((r) => {
+              this.pendingRequests.splice(this.pendingRequests.indexOf(r), 1);
+              return r;
+            });
+    for (const request of matches) {
+      request.resolve(approved);
+    }
+  }
+
+  private awaitApproval(type: AutomationBiometricRequestType, userId?: UserId): Promise<boolean> {
+    const id = (this.nextRequestId++).toString();
+    this.logService.info(
+      "[AutomationBiometrics] Pending %s request %s awaiting approval",
+      type,
+      id,
+    );
+    return new Promise<boolean>((resolve) => {
+      this.pendingRequests.push({ id, type, userId, resolve });
+    });
+  }
+
+  // --- OsBiometricService implementation ---
+
+  async supportsBiometrics(): Promise<boolean> {
+    return this.mockStatus !== BiometricsStatus.HardwareUnavailable;
+  }
+
+  async needsSetup(): Promise<boolean> {
+    return false;
+  }
+
+  async canAutoSetup(): Promise<boolean> {
+    return false;
+  }
+
+  async runSetup(): Promise<void> {
+    return;
+  }
+
+  async authenticateBiometric(): Promise<boolean> {
+    return await this.awaitApproval("authenticate");
+  }
+
+  async getBiometricKey(userId: UserId): Promise<SymmetricCryptoKey | null> {
+    const approved = await this.awaitApproval("unlock", userId);
+    if (!approved) {
+      return null;
+    }
+    return this.keys.get(userId) ?? null;
+  }
+
+  async setBiometricKey(userId: UserId, key: SymmetricCryptoKey): Promise<void> {
+    this.keys.set(userId, key);
+  }
+
+  async deleteBiometricKey(userId: UserId): Promise<void> {
+    this.keys.delete(userId);
+  }
+
+  async getBiometricsFirstUnlockStatusForUser(userId: UserId): Promise<BiometricsStatus> {
+    if (this.mockStatus !== BiometricsStatus.Available) {
+      return this.mockStatus;
+    }
+    return this.keys.has(userId) ? BiometricsStatus.Available : BiometricsStatus.UnlockNeeded;
+  }
+
+  async enrollPersistent(userId: UserId, key: SymmetricCryptoKey): Promise<void> {
+    this.keys.set(userId, key);
+  }
+
+  async hasPersistentKey(userId: UserId): Promise<boolean> {
+    return this.keys.has(userId);
+  }
+}

--- a/apps/desktop/src/key-management/biometrics/main-biometrics.service.ts
+++ b/apps/desktop/src/key-management/biometrics/main-biometrics.service.ts
@@ -8,7 +8,10 @@ import { UserKey } from "@bitwarden/common/types/key";
 import { BiometricsStatus, BiometricStateService } from "@bitwarden/key-management";
 
 import { WindowMain } from "../../main/window.main";
+import { isDev } from "../../utils";
 
+import { AutomationBiometricsIPCListener } from "./automation-biometrics-ipc.listener";
+import { AutomationBiometricsService } from "./automation-biometrics.service";
 import { DesktopBiometricsService } from "./desktop.biometrics.service";
 import { LinuxBiometricsSystem, WindowsBiometricsSystem } from "./native-v2";
 import { OsBiometricService } from "./os-biometrics.service";
@@ -28,7 +31,16 @@ export class MainBiometricsService extends DesktopBiometricsService {
     private cryptoFunctionService: CryptoFunctionService,
   ) {
     super();
-    if (platform === "win32") {
+    if (process.env.USE_AUTOMATION_BIOMETRICS && isDev()) {
+      // Replace the OS biometric service with a fake, automation-controlled one so the native OS
+      // prompt never fires. Only ever active in dev mode with the env var set.
+      this.logService.warning(
+        "[BiometricsMain] USE_AUTOMATION_BIOMETRICS is set; using automation biometrics service",
+      );
+      const automationBiometricsService = new AutomationBiometricsService(this.logService);
+      this.osBiometricsService = automationBiometricsService;
+      new AutomationBiometricsIPCListener(automationBiometricsService, this.logService).init();
+    } else if (platform === "win32") {
       this.osBiometricsService = new WindowsBiometricsSystem(
         this.i18nService,
         this.windowMain,

--- a/apps/desktop/src/platform/preload.ts
+++ b/apps/desktop/src/platform/preload.ts
@@ -136,6 +136,19 @@ export default {
   isAppImage: isAppImage(),
   allowBrowserintegrationOverride: allowBrowserintegrationOverride(),
   reloadProcess: () => ipcRenderer.send("reload-process"),
+  // Automation-only surface, controlled by the renderer automation driver (dev mode only).
+  automation: {
+    biometrics: {
+      setStatus: (status: number): Promise<void> =>
+        ipcRenderer.invoke("automation.biometric", { action: "setStatus", status }),
+      listPending: (): Promise<unknown[]> =>
+        ipcRenderer.invoke("automation.biometric", { action: "listPending" }),
+      approve: (id?: string): Promise<void> =>
+        ipcRenderer.invoke("automation.biometric", { action: "approve", id }),
+      deny: (id?: string): Promise<void> =>
+        ipcRenderer.invoke("automation.biometric", { action: "deny", id }),
+    },
+  },
   registerUpdateRestartHandler: (provide: (resolve: (canRestart: boolean) => void) => void) => {
     const resolve = (canRestart: boolean) => ipcRenderer.send("confirmUpdateRestart", canRestart);
 

--- a/apps/web/src/app/core/init.service.ts
+++ b/apps/web/src/app/core/init.service.ts
@@ -3,6 +3,7 @@ import { firstValueFrom } from "rxjs";
 
 import { AbstractThemingService } from "@bitwarden/angular/platform/services/theming/theming.service.abstraction";
 import { WINDOW } from "@bitwarden/angular/services/injection-tokens";
+import { AutomationDriver } from "@bitwarden/automation-driver";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { TokenService } from "@bitwarden/common/auth/abstractions/token.service";
 import { TwoFactorService } from "@bitwarden/common/auth/two-factor";
@@ -14,12 +15,16 @@ import { SharedUnlockFollowerService } from "@bitwarden/common/key-management/sh
 import { DefaultVaultTimeoutService } from "@bitwarden/common/key-management/vault-timeout";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { I18nService as I18nServiceAbstraction } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
+import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { SdkLoadService } from "@bitwarden/common/platform/abstractions/sdk/sdk-load.service";
 import { IpcService } from "@bitwarden/common/platform/ipc";
 import { ServerNotificationsService } from "@bitwarden/common/platform/server-notifications";
 import { ContainerService } from "@bitwarden/common/platform/services/container.service";
 import { MigrationRunner } from "@bitwarden/common/platform/services/migration-runner";
 import { UserAutoUnlockKeyService } from "@bitwarden/common/platform/services/user-auto-unlock-key.service";
+import { StateProvider } from "@bitwarden/common/platform/state";
 import { UserId } from "@bitwarden/common/types/guid";
 import { TaskService } from "@bitwarden/common/vault/tasks";
 import { KeyService as KeyServiceAbstraction } from "@bitwarden/key-management";
@@ -49,6 +54,10 @@ export class InitService {
     @Inject(DOCUMENT) private document: Document,
     private configService: ConfigService,
     private sharedUnlockFollowerService: SharedUnlockFollowerService,
+    private platformUtilsService: PlatformUtilsService,
+    private stateProvider: StateProvider,
+    private messagingService: MessagingService,
+    private logService: LogService,
   ) {}
 
   init() {
@@ -83,6 +92,18 @@ export class InitService {
 
       const containerService = new ContainerService(this.keyService, this.encryptService);
       containerService.attachToGlobal(this.win);
+
+      AutomationDriver.attachToGlobalIfDev(
+        this.win,
+        this.platformUtilsService,
+        this.configService,
+        this.stateProvider,
+        this.messagingService,
+        {
+          reloadProcess: () => this.win.location.reload(),
+          logService: this.logService,
+        },
+      );
     };
   }
 }

--- a/libs/automation-driver/README.md
+++ b/libs/automation-driver/README.md
@@ -1,0 +1,3 @@
+# Automation-driver
+
+Library exposing `AutomationDriver` — a dev-only hook into the client for E2E test automation of Bitwarden clients.

--- a/libs/automation-driver/eslint.config.mjs
+++ b/libs/automation-driver/eslint.config.mjs
@@ -1,0 +1,3 @@
+import baseConfig from "../../eslint.config.mjs";
+
+export default [...baseConfig];

--- a/libs/automation-driver/jest.config.js
+++ b/libs/automation-driver/jest.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  displayName: "automation-driver",
+  preset: "../../jest.preset.js",
+  testEnvironment: "node",
+  transform: {
+    "^.+\\.[tj]s$": ["ts-jest", { tsconfig: "<rootDir>/tsconfig.spec.json" }],
+  },
+  moduleFileExtensions: ["ts", "js", "html"],
+  coverageDirectory: "../../coverage/libs/automation-driver",
+};

--- a/libs/automation-driver/package.json
+++ b/libs/automation-driver/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@bitwarden/automation-driver",
+  "version": "0.0.1",
+  "description": "Automation driver library for E2E test automation of Bitwarden clients",
+  "private": true,
+  "type": "commonjs",
+  "main": "index.js",
+  "types": "index.d.ts",
+  "license": "GPL-3.0",
+  "author": "automation-driver"
+}

--- a/libs/automation-driver/project.json
+++ b/libs/automation-driver/project.json
@@ -1,0 +1,34 @@
+{
+  "name": "automation-driver",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/automation-driver/src",
+  "projectType": "library",
+  "tags": ["scope:automation-driver", "type:lib"],
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "dist/libs/automation-driver",
+        "main": "libs/automation-driver/src/index.ts",
+        "tsConfig": "libs/automation-driver/tsconfig.lib.json",
+        "assets": ["libs/automation-driver/*.md"],
+        "rootDir": "libs/automation-driver/src"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": ["libs/automation-driver/**/*.ts"]
+      }
+    },
+    "test": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "libs/automation-driver/jest.config.js"
+      }
+    }
+  }
+}

--- a/libs/automation-driver/src/automation-driver.service.spec.ts
+++ b/libs/automation-driver/src/automation-driver.service.spec.ts
@@ -1,0 +1,217 @@
+import { mock } from "jest-mock-extended";
+import { firstValueFrom } from "rxjs";
+
+import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
+import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
+import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
+import { GLOBAL_FEATURE_FLAG_OVERRIDES } from "@bitwarden/common/platform/services/config/default-config.service";
+import { FakeStateProvider, mockAccountServiceWith } from "@bitwarden/common/spec";
+import { UserId } from "@bitwarden/common/types/guid";
+import { ConsoleLogService, FlightRecorder, LogLevel } from "@bitwarden/logging";
+
+import { AutomationBiometricsController, AutomationDriver } from "./automation-driver.service";
+
+describe("AutomationDriver", () => {
+  const flag = FeatureFlag.GenerateInviteLink;
+  const userId = "user-id" as UserId;
+
+  let configService: ReturnType<typeof mock<ConfigService>>;
+  let messagingService: ReturnType<typeof mock<MessagingService>>;
+  let stateProvider: FakeStateProvider;
+  let sut: AutomationDriver;
+
+  const currentOverrides = () =>
+    firstValueFrom(stateProvider.getGlobal(GLOBAL_FEATURE_FLAG_OVERRIDES).state$);
+
+  beforeEach(() => {
+    configService = mock<ConfigService>();
+    messagingService = mock<MessagingService>();
+    stateProvider = new FakeStateProvider(mockAccountServiceWith(userId));
+    sut = new AutomationDriver(configService, stateProvider, messagingService);
+  });
+
+  describe("feature flags", () => {
+    it("sets an override", async () => {
+      await sut.setFeatureFlag(flag, true);
+
+      expect(await currentOverrides()).toEqual({ [flag]: true });
+    });
+
+    it("clears a single override", async () => {
+      await sut.setFeatureFlag(flag, true);
+
+      await sut.clearFeatureFlag(flag);
+
+      expect(await currentOverrides()).toEqual({});
+    });
+
+    it("clears all overrides", async () => {
+      await sut.setFeatureFlag(flag, true);
+
+      await sut.clearAllFeatureFlagOverrides();
+
+      expect(await currentOverrides()).toEqual({});
+    });
+
+    it("reads the effective value from the config service", async () => {
+      configService.getFeatureFlag.mockResolvedValue(true as never);
+
+      await expect(sut.getFeatureFlag(flag)).resolves.toBe(true);
+      expect(configService.getFeatureFlag).toHaveBeenCalledWith(flag);
+    });
+  });
+
+  describe("messaging", () => {
+    it("sends a message command", () => {
+      sut.sendMessage("foo", { bar: 1 });
+
+      expect(messagingService.send).toHaveBeenCalledWith("foo", { bar: 1 });
+    });
+
+    it("opens settings", () => {
+      sut.openSettings();
+
+      expect(messagingService.send).toHaveBeenCalledWith("openSettings", undefined);
+    });
+  });
+
+  describe("process reload", () => {
+    it("delegates to the supplied capability", async () => {
+      const reloadProcess = jest.fn();
+      sut = new AutomationDriver(configService, stateProvider, messagingService, {
+        reloadProcess,
+      });
+
+      await sut.reloadProcess();
+
+      expect(reloadProcess).toHaveBeenCalled();
+    });
+
+    it("throws when not supported", async () => {
+      await expect(sut.reloadProcess()).rejects.toThrow();
+    });
+  });
+
+  describe("biometrics", () => {
+    it("exposes the supplied biometrics controller", () => {
+      const biometrics = mock<AutomationBiometricsController>();
+      sut = new AutomationDriver(configService, stateProvider, messagingService, { biometrics });
+
+      expect(sut.biometrics).toBe(biometrics);
+    });
+
+    it("is undefined when not supplied", () => {
+      expect(sut.biometrics).toBeUndefined();
+    });
+  });
+
+  describe("flight recorder", () => {
+    it("exposes the supplied flight recorder", () => {
+      const flightRecorder = mock<FlightRecorder>();
+      sut = new AutomationDriver(configService, stateProvider, messagingService, {
+        flightRecorder,
+      });
+
+      expect(sut.flightRecorder).toBe(flightRecorder);
+    });
+
+    it("is undefined when not supplied", () => {
+      expect(sut.flightRecorder).toBeUndefined();
+    });
+  });
+
+  describe("log service hook", () => {
+    let logService: ConsoleLogService;
+
+    beforeEach(() => {
+      logService = new ConsoleLogService(false);
+    });
+
+    it("hooks automatically when logService is in capabilities", () => {
+      sut = new AutomationDriver(configService, stateProvider, messagingService, { logService });
+
+      logService.write(LogLevel.Info, "auto");
+
+      expect(sut.readLogBuffer()).toEqual([{ level: LogLevel.Info, message: "auto", params: [] }]);
+    });
+
+    it("buffers entries written after hooking", () => {
+      sut.hookLogService(logService);
+
+      logService.write(LogLevel.Info, "hello");
+
+      expect(sut.readLogBuffer()).toEqual([{ level: LogLevel.Info, message: "hello", params: [] }]);
+    });
+
+    it("captures extra params", () => {
+      sut.hookLogService(logService);
+
+      logService.write(LogLevel.Warning, "msg", "a", "b");
+
+      expect(sut.readLogBuffer()[0].params).toEqual(["a", "b"]);
+    });
+
+    it("still calls the original write", () => {
+      const writeSpy = jest.spyOn(logService, "write");
+      sut.hookLogService(logService);
+
+      logService.write(LogLevel.Error, "boom");
+
+      expect(writeSpy).toHaveBeenCalledWith(LogLevel.Error, "boom");
+    });
+
+    it("readLogBuffer returns a snapshot, not the live array", () => {
+      sut.hookLogService(logService);
+      logService.write(LogLevel.Debug, "first");
+      const snapshot = sut.readLogBuffer();
+
+      logService.write(LogLevel.Debug, "second");
+
+      expect(snapshot).toHaveLength(1);
+    });
+
+    it("clearLogBuffer empties the buffer", () => {
+      sut.hookLogService(logService);
+      logService.write(LogLevel.Info, "x");
+
+      sut.clearLogBuffer();
+
+      expect(sut.readLogBuffer()).toHaveLength(0);
+    });
+  });
+
+  describe("attachToGlobalIfDev", () => {
+    it("attaches in dev mode", () => {
+      const platformUtilsService = mock<PlatformUtilsService>();
+      platformUtilsService.isDev.mockReturnValue(true);
+      const global: any = {};
+
+      AutomationDriver.attachToGlobalIfDev(
+        global,
+        platformUtilsService,
+        configService,
+        stateProvider,
+        messagingService,
+      );
+
+      expect(global.bitwardenAutomationDriver).toBeInstanceOf(AutomationDriver);
+    });
+
+    it("does not attach outside dev mode", () => {
+      const platformUtilsService = mock<PlatformUtilsService>();
+      platformUtilsService.isDev.mockReturnValue(false);
+      const global: any = {};
+
+      AutomationDriver.attachToGlobalIfDev(
+        global,
+        platformUtilsService,
+        configService,
+        stateProvider,
+        messagingService,
+      );
+
+      expect(global.bitwardenAutomationDriver).toBeUndefined();
+    });
+  });
+});

--- a/libs/automation-driver/src/automation-driver.service.ts
+++ b/libs/automation-driver/src/automation-driver.service.ts
@@ -1,0 +1,189 @@
+import { AllowedFeatureFlagTypes, FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
+import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
+import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
+import { GLOBAL_FEATURE_FLAG_OVERRIDES } from "@bitwarden/common/platform/services/config/default-config.service";
+import { StateProvider } from "@bitwarden/common/platform/state";
+import { FlightRecorder, LogLevel, LogService } from "@bitwarden/logging";
+
+type FeatureFlagOverrides = Record<FeatureFlag, AllowedFeatureFlagTypes>;
+
+export interface LogEntry {
+  level: LogLevel;
+  message: any;
+  params: any[];
+}
+
+/**
+ * Controls the desktop main-process automation biometrics service from the renderer. Kept generic
+ * so this (common) file has no dependency on desktop code; the desktop client supplies an
+ * implementation that forwards to the main process over IPC.
+ */
+export interface AutomationBiometricsController {
+  /** Set the mocked {@link BiometricsStatus} the automation biometrics service reports. */
+  setStatus(status: number): Promise<void>;
+  /** List the biometric requests currently awaiting approval. */
+  listPending(): Promise<unknown[]>;
+  /** Approve a pending request by id, or the oldest pending request when no id is given. */
+  approve(id?: string): Promise<void>;
+  /** Deny a pending request by id, or the oldest pending request when no id is given. */
+  deny(id?: string): Promise<void>;
+}
+
+/**
+ * Optional, client-specific capabilities. Each client wires only what it supports; the universal
+ * capabilities (feature flags, messaging) are constructor dependencies that every client has.
+ */
+export interface AutomationDriverCapabilities {
+  /** Trigger a process reload. */
+  reloadProcess?: () => Promise<void> | void;
+  /** Control biometrics (desktop only). */
+  biometrics?: AutomationBiometricsController;
+  /** Read SDK flight recorder events (clients with WASM SDK only). */
+  flightRecorder?: FlightRecorder;
+  /** Log service to hook at startup; every write will also be appended to the log buffer. */
+  logService?: LogService;
+}
+
+/**
+ * A small surface attached to the global object for external automation (E2E tests, manual
+ * automation). Mirrors {@link ContainerService.attachToGlobal}, but is only attached when the app
+ * is running in dev mode.
+ *
+ * This does not handle Vault Data: feature flag overrides are non-secret developer settings, and
+ * the messaging / reload / biometrics capabilities delegate to existing services.
+ */
+export class AutomationDriver {
+  private logBuffer: LogEntry[] = [];
+
+  constructor(
+    private configService: ConfigService,
+    private stateProvider: StateProvider,
+    private messagingService: MessagingService,
+    private capabilities: AutomationDriverCapabilities = {},
+  ) {
+    if (capabilities.logService != null) {
+      this.hookLogService(capabilities.logService);
+    }
+  }
+
+  /**
+   * Construct and attach an {@link AutomationDriver} to the global object, but only when the app is
+   * running in dev mode. Centralizes the dev gate so each client's attach site is a single call.
+   */
+  static attachToGlobalIfDev(
+    global: any,
+    platformUtilsService: PlatformUtilsService,
+    configService: ConfigService,
+    stateProvider: StateProvider,
+    messagingService: MessagingService,
+    capabilities: AutomationDriverCapabilities = {},
+  ): void {
+    if (!platformUtilsService.isDev()) {
+      return;
+    }
+    new AutomationDriver(
+      configService,
+      stateProvider,
+      messagingService,
+      capabilities,
+    ).attachToGlobal(global);
+  }
+
+  attachToGlobal(global: any) {
+    if (!global.bitwardenAutomationDriver) {
+      global.bitwardenAutomationDriver = this;
+    }
+  }
+
+  // --- Feature flags ---
+
+  /** Override a feature flag to the given value. */
+  async setFeatureFlag(flag: FeatureFlag, value: AllowedFeatureFlagTypes): Promise<void> {
+    await this.stateProvider
+      .getGlobal(GLOBAL_FEATURE_FLAG_OVERRIDES)
+      // The override record is a partial map keyed by flag, despite its full-Record type.
+      .update((overrides) => ({ ...overrides, [flag]: value }) as FeatureFlagOverrides);
+  }
+
+  /** Remove a single feature flag override, restoring server/default resolution. */
+  async clearFeatureFlag(flag: FeatureFlag): Promise<void> {
+    await this.stateProvider.getGlobal(GLOBAL_FEATURE_FLAG_OVERRIDES).update((overrides) => {
+      const updated = { ...overrides };
+      delete updated[flag];
+      return updated as FeatureFlagOverrides;
+    });
+  }
+
+  /** Remove all feature flag overrides. */
+  async clearAllFeatureFlagOverrides(): Promise<void> {
+    await this.stateProvider
+      .getGlobal(GLOBAL_FEATURE_FLAG_OVERRIDES)
+      .update(() => ({}) as FeatureFlagOverrides);
+  }
+
+  /** Read the current effective value of a feature flag (override > server config > default). */
+  async getFeatureFlag(flag: FeatureFlag): Promise<AllowedFeatureFlagTypes> {
+    return await this.configService.getFeatureFlag(flag);
+  }
+
+  // --- Messaging / menubar ---
+
+  /** Send a message command, e.g. menubar actions handled by the app. */
+  sendMessage(command: string, data?: Record<string, unknown>): void {
+    this.messagingService.send(command, data);
+  }
+
+  /** Desktop only — opens the settings page via the menubar message handler. */
+  openSettings(): void {
+    this.sendMessage("openSettings");
+  }
+
+  // --- Process reload ---
+
+  async reloadProcess(): Promise<void> {
+    if (this.capabilities.reloadProcess == null) {
+      throw new Error("reloadProcess is not supported on this client.");
+    }
+    await this.capabilities.reloadProcess();
+  }
+
+  // --- Biometrics (desktop) ---
+
+  get biometrics(): AutomationBiometricsController | undefined {
+    return this.capabilities.biometrics;
+  }
+
+  // --- Flight recorder ---
+
+  get flightRecorder(): FlightRecorder | undefined {
+    return this.capabilities.flightRecorder;
+  }
+
+  // --- Log service hook ---
+
+  /**
+   * Patches `logService.write` so every log call is also appended to an internal buffer.
+   * The original `write` still fires — this is additive. Calling this more than once on the
+   * same service stacks wrappers; call it once at startup.
+   */
+  hookLogService(logService: LogService): void {
+    const original = logService.write.bind(logService);
+    const buffer = this.logBuffer;
+
+    (logService as any).write = (level: LogLevel, message?: any, ...optionalParams: any[]) => {
+      buffer.push({ level, message, params: optionalParams });
+      original(level, message, ...optionalParams);
+    };
+  }
+
+  /** Return a snapshot of buffered log entries since the last {@link clearLogBuffer} call. */
+  readLogBuffer(): LogEntry[] {
+    return [...this.logBuffer];
+  }
+
+  /** Empty the log buffer. */
+  clearLogBuffer(): void {
+    this.logBuffer = [];
+  }
+}

--- a/libs/automation-driver/src/index.ts
+++ b/libs/automation-driver/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./automation-driver.service";

--- a/libs/automation-driver/tsconfig.eslint.json
+++ b/libs/automation-driver/tsconfig.eslint.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [],
+  "include": ["src/**/*.ts", "src/**/*.js"],
+  "exclude": ["**/build", "**/dist"]
+}

--- a/libs/automation-driver/tsconfig.json
+++ b/libs/automation-driver/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/libs/automation-driver/tsconfig.lib.json
+++ b/libs/automation-driver/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["jest.config.js", "src/**/*.spec.ts"]
+}

--- a/libs/automation-driver/tsconfig.spec.json
+++ b/libs/automation-driver/tsconfig.spec.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "moduleResolution": "node10",
+    "types": ["jest", "node"]
+  },
+  "include": ["jest.config.ts", "src/**/*.test.ts", "src/**/*.spec.ts", "src/**/*.d.ts"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -284,6 +284,11 @@
       "version": "0.0.1",
       "license": "GPL-3.0"
     },
+    "libs/automation-driver": {
+      "name": "@bitwarden/automation-driver",
+      "version": "0.0.1",
+      "license": "GPL-3.0"
+    },
     "libs/billing": {
       "name": "@bitwarden/billing",
       "version": "0.0.0",
@@ -4811,6 +4816,10 @@
     },
     "node_modules/@bitwarden/auto-confirm": {
       "resolved": "libs/auto-confirm",
+      "link": true
+    },
+    "node_modules/@bitwarden/automation-driver": {
+      "resolved": "libs/automation-driver",
       "link": true
     },
     "node_modules/@bitwarden/billing": {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -26,6 +26,7 @@
       "@bitwarden/auth/common": ["./libs/auth/src/common"],
       "@bitwarden/auto-confirm": ["./libs/auto-confirm/src/index.ts"],
       "@bitwarden/auto-confirm/angular": ["./libs/auto-confirm/src/angular"],
+      "@bitwarden/automation-driver": ["./libs/automation-driver/src/index.ts"],
       "@bitwarden/billing": ["./libs/billing/src"],
       "@bitwarden/bit-common/*": ["./bitwarden_license/bit-common/src/*"],
       "@bitwarden/browser/*": ["./apps/browser/src/*"],


### PR DESCRIPTION
## Reference

https://bitwarden.atlassian.net/browse/PM-39560

## Goal

We want to make automated navigation and testing of the desktop app (and other apps) easier. Currently, some features are hard to test. 

- Biometrics cannot be tested in an automated fashion
- Feature flags cannot be set locally by automation. This is problematic if we want to test a specific feature state
- (desktop) open the settings menu
- Lock / Unlock

We want to make these automateable, so we can test them, either with selenium-style frameworks, or even claude. Specifically, we have other work in flight to make the desktop app, and the other apps available to claude via devtools-mcp, and have a set of skills to control it via the automation driver and the UI.

In combination, this allows fully automated testing and debugging of certain feature types or combinations.