### PR TITLE
[SM-1993][CL-1227] Fix textarea height and fix SM button spacing (#21417)

### DIFF
--- a/bitwarden_license/bit-web/src/app/secrets-manager/shared/access-policies/access-policy-selector/access-policy-selector.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/shared/access-policies/access-policy-selector/access-policy-selector.component.html
@@ -94,20 +94,19 @@
       (blur)="handleBlur()"
     ></bit-multi-select>
     <bit-hint>{{ hint }}</bit-hint>
+    <div class="tw-shrink-0" slot="inline-end">
+      <button
+        type="button"
+        bitButton
+        buttonType="secondary"
+        [loading]="loading"
+        [disabled]="disabled"
+        (click)="addButton()"
+      >
+        {{ "add" | i18n }}
+      </button>
+    </div>
   </bit-form-field>
-
-  <div class="tw-shrink-0 tw-mt-[0.6rem]">
-    <button
-      type="button"
-      bitButton
-      buttonType="secondary"
-      [loading]="loading"
-      [disabled]="disabled"
-      (click)="addButton()"
-    >
-      {{ "add" | i18n }}
-    </button>
-  </div>
 </ng-template>
 
 <ng-template #spinner>

--- a/libs/components/src/form-field/form-field.stories.ts
+++ b/libs/components/src/form-field/form-field.stories.ts
@@ -308,6 +308,11 @@ export const Readonly: Story = {
         <textarea bitInput rows="4" readonly>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</textarea>
       </bit-form-field>
 
+       <bit-form-field>
+        <bit-label>Textarea short</bit-label>
+        <textarea bitInput rows="1" readonly>Lorem ipsum dolor sit ametroident</textarea>
+      </bit-form-field>
+
       <div class="tw-p-4 tw-mt-10 tw-border-2 tw-border-solid tw-border-black tw-bg-background-alt">
         <h2 bitTypography="h2">Inside card</h2>
         <bit-section>

--- a/libs/components/src/input/input.directive.ts
+++ b/libs/components/src/input/input.directive.ts
@@ -48,7 +48,7 @@ export class BitInputDirective implements AfterViewInit {
       "tw-w-full",
       "[&:is(input,select)]:tw-h-full",
       "[&:is(textarea)]:tw-h-auto",
-      "[&:is(textarea)]:tw-min-h-[80px]",
+      "[&:is(textarea)]:tw-min-h-[30px]",
       ...(isReadonlyTextarea ? [] : ["tw-max-h-[50vh]", "tw-overflow-y-auto"]),
       "[&:is(textarea)]:tw-resize-none",
       "tw-px-1",


### PR DESCRIPTION
# Cherry pick of #21417 into rc

## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[SM-1993](https://bitwarden.atlassian.net/browse/SM-1993)
[CL-1227](https://bitwarden.atlassian.net/browse/CL-1227)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
- Fix misaligned buttons/form fields in Secrets Manager
- Fix textarea component minimum height to reduce whitespace in readonly view when there is only 1 line of text

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

Secrets Manager

| Before | After |
|--------|--------|
| <img width="1326" height="938" alt="Screenshot 2026-06-22 at 10 21 26 AM" src="https://github.com/user-attachments/assets/46f1f40a-3451-46d3-901c-5b8b9191b680" /> | <img width="1692" height="868" alt="Screenshot 2026-06-22 at 11 43 00 AM" src="https://github.com/user-attachments/assets/cc2977dd-d4ad-49de-bbeb-6f3cd292a3fc" /> | 


Vault

| Before | After |
|--------|--------|
| <img width="1678" height="1560" alt="c284c880-a4f9-4da5-ba23-123f7644de8a" src="https://github.com/user-attachments/assets/ce68f4ff-ece8-46c4-934c-32704da622e6" /> | <img width="1908" height="957" alt="Screenshot 2026-06-22 at 11 10 59 AM" src="https://github.com/user-attachments/assets/98c73f06-2c64-4f0a-bdf8-f105aeaa3bbc" /> |




[SM-1993]: https://bitwarden.atlassian.net/browse/SM-1993?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CL-1227]: https://bitwarden.atlassian.net/browse/CL-1227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ