### PR TITLE
Bumped client version(s) (#21420)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitwarden/web-vault",
-  "version": "2026.6.1",
+  "version": "2026.6.2",
   "scripts": {
     "build:oss": "webpack",
     "build:bit": "webpack -c ../../bitwarden_license/bit-web/webpack.config.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -257,7 +257,7 @@
     },
     "apps/web": {
       "name": "@bitwarden/web-vault",
-      "version": "2026.6.1"
+      "version": "2026.6.2"
     },
     "libs/admin-console": {
       "name": "@bitwarden/admin-console",


### PR DESCRIPTION
bump the upcoming web release to 2026.6.2, 2026.6.1 was released as a hotfix
