### PR TITLE
[PM-34580] Rename "Note" to "Secure note" for SecureNote cipher type

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -2337,6 +2337,10 @@
     "message": "New Note",
     "description": "Header for new note item type"
   },
+  "newItemHeaderSecureNote": {
+    "message": "New secure note",
+    "description": "Header for new secure note item type"
+  },
   "newItemHeaderSshKey": {
     "message": "New SSH key",
     "description": "Header for new SSH key item type"
@@ -2377,6 +2381,10 @@
     "message": "Edit Note",
     "description": "Header for edit note item type"
   },
+  "editItemHeaderSecureNote": {
+    "message": "Edit secure note",
+    "description": "Header for edit secure note item type"
+  },
   "editItemHeaderSshKey": {
     "message": "Edit SSH key",
     "description": "Header for edit SSH key item type"
@@ -2416,6 +2424,10 @@
   "viewItemHeaderNote": {
     "message": "View Note",
     "description": "Header for view note item type"
+  },
+  "viewItemHeaderSecureNote": {
+    "message": "View secure note",
+    "description": "Header for view secure note item type"
   },
   "viewItemHeaderSshKey": {
     "message": "View SSH key",

--- a/apps/desktop/src/app/app.component.ts
+++ b/apps/desktop/src/app/app.component.ts
@@ -623,6 +623,10 @@ export class AppComponent implements OnInit, OnDestroy {
             desktopAddDevices: await firstValueFrom(
               this.configService.getFeatureFlag$(FeatureFlag.PM34210_DesktopAddDevices),
             ),
+            // TODO: PM-34580 - remove pm32009NewItemTypes flag read and MenuAccount field population
+            pm32009NewItemTypes: await firstValueFrom(
+              this.configService.getFeatureFlag$(FeatureFlag.PM32009NewItemTypes),
+            ),
           };
         }
       }

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -154,6 +154,10 @@
     "message": "View Note",
     "description": "Header for view note item type"
   },
+  "viewItemHeaderSecureNote": {
+    "message": "View secure note",
+    "description": "Header for view secure note item type"
+  },
   "viewItemHeaderSshKey": {
     "message": "View SSH key",
     "description": "Header for view SSH key item type"
@@ -186,6 +190,10 @@
     "message": "New Note",
     "description": "Header for new note item type"
   },
+  "newItemHeaderSecureNote": {
+    "message": "New secure note",
+    "description": "Header for new secure note item type"
+  },
   "newItemHeaderSshKey": {
     "message": "New SSH key",
     "description": "Header for new SSH key item type"
@@ -217,6 +225,10 @@
   "editItemHeaderNote": {
     "message": "Edit Note",
     "description": "Header for edit note item type"
+  },
+  "editItemHeaderSecureNote": {
+    "message": "Edit secure note",
+    "description": "Header for edit secure note item type"
   },
   "editItemHeaderSshKey": {
     "message": "Edit SSH key",

--- a/apps/desktop/src/main/menu/menu.file.ts
+++ b/apps/desktop/src/main/menu/menu.file.ts
@@ -56,6 +56,7 @@ export class FileMenu extends FirstMenu implements IMenubarMenu {
     isLocked: boolean,
     isLockable: boolean,
     private restrictedCipherTypes: CipherType[],
+    private pm32009NewItemTypes: boolean = false,
   ) {
     super(i18nService, messagingService, updater, window, accounts, isLocked, isLockable);
   }
@@ -118,7 +119,7 @@ export class FileMenu extends FirstMenu implements IMenubarMenu {
       },
       {
         id: "typeSecureNote",
-        label: this.localize("typeNote"),
+        label: this.localize(this.pm32009NewItemTypes ? "typeSecureNote" : "typeNote"),
         click: () => this.sendMessage("newSecureNote"),
         accelerator: "CmdOrCtrl+Shift+S",
       },

--- a/apps/desktop/src/main/menu/menu.updater.ts
+++ b/apps/desktop/src/main/menu/menu.updater.ts
@@ -18,4 +18,6 @@ export class MenuAccount {
   multiClientPasswordManagement: boolean;
   // TODO: PM-34438 - remove desktopAddDevices from MenuAccount
   desktopAddDevices: boolean;
+  // TODO: PM-34580 - remove pm32009NewItemTypes from MenuAccount once fully rolled out
+  pm32009NewItemTypes: boolean;
 }

--- a/apps/desktop/src/main/menu/menubar.ts
+++ b/apps/desktop/src/main/menu/menubar.ts
@@ -81,6 +81,9 @@ export class Menubar {
     // TODO: PM-34438 - remove desktopAddDevices variable and the parameter passed to AccountMenu
     const desktopAddDevices =
       updateRequest?.accounts?.[updateRequest.activeUserId]?.desktopAddDevices ?? false;
+    // TODO: PM-34580 - remove pm32009NewItemTypes variable and the parameter passed to FileMenu
+    const pm32009NewItemTypes =
+      updateRequest?.accounts?.[updateRequest.activeUserId]?.pm32009NewItemTypes ?? false;
 
     this.items = [
       new FileMenu(
@@ -92,6 +95,7 @@ export class Menubar {
         isLocked,
         isLockable,
         updateRequest?.restrictedCipherTypes,
+        pm32009NewItemTypes,
       ),
       new EditMenu(i18nService, messagingService, isLocked),
       new ViewMenu(i18nService, messagingService, isLocked, windowMain),

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -1203,6 +1203,10 @@
     "message": "New Note",
     "description": "Header for new note item type"
   },
+  "newItemHeaderSecureNote": {
+    "message": "New secure note",
+    "description": "Header for new secure note item type"
+  },
   "newItemHeaderSshKey": {
     "message": "New SSH key",
     "description": "Header for new SSH key item type"
@@ -1243,6 +1247,10 @@
     "message": "Edit Note",
     "description": "Header for edit note item type"
   },
+  "editItemHeaderSecureNote": {
+    "message": "Edit secure note",
+    "description": "Header for edit secure note item type"
+  },
   "editItemHeaderSshKey": {
     "message": "Edit SSH key",
     "description": "Header for edit SSH key item type"
@@ -1282,6 +1290,10 @@
   "viewItemHeaderNote": {
     "message": "View Note",
     "description": "Header for view note item type"
+  },
+  "viewItemHeaderSecureNote": {
+    "message": "View secure note",
+    "description": "Header for view secure note item type"
   },
   "viewItemHeaderSshKey": {
     "message": "View SSH key",

--- a/libs/common/src/vault/types/cipher-menu-items.ts
+++ b/libs/common/src/vault/types/cipher-menu-items.ts
@@ -97,5 +97,13 @@ export const DIALOG_CIPHER_MENU_ITEMS = [
       icon: "bwi-user",
     };
   }
+
+  if (item.type === CipherType.SecureNote) {
+    return {
+      ...item,
+      labelKey: "typeSecureNote",
+    };
+  }
+
   return item;
 });

--- a/libs/vault/src/components/add-item-grid/add-item-grid.component.spec.ts
+++ b/libs/vault/src/components/add-item-grid/add-item-grid.component.spec.ts
@@ -59,7 +59,7 @@ describe("AddItemGridComponent", () => {
         "typeIdentity",
         "typeDriversLicense",
         "typePassport",
-        "typeNote",
+        "typeSecureNote",
         "typeSshKey",
       ]),
     );

--- a/libs/vault/src/vault-item-dialog/vault-item-dialog.component.spec.ts
+++ b/libs/vault/src/vault-item-dialog/vault-item-dialog.component.spec.ts
@@ -19,6 +19,7 @@ import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { BillingAccountProfileStateService } from "@bitwarden/common/billing/abstractions";
 import { EventCollectionService } from "@bitwarden/common/dirt/event-logs/abstractions/event-collection.service";
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
@@ -144,6 +145,10 @@ describe("VaultItemDialogComponent", () => {
         { provide: ApiService, useValue: mock<ApiService>() },
         { provide: EventCollectionService, useValue: mock<EventCollectionService>() },
         { provide: CipherArchiveService, useValue: mockArchiveService },
+        {
+          provide: ConfigService,
+          useValue: { getFeatureFlag$: jest.fn().mockReturnValue(of(false)) },
+        },
       ],
     })
       .overrideProvider(DialogService, { useValue: mockDialogService })

--- a/libs/vault/src/vault-item-dialog/vault-item-dialog.component.ts
+++ b/libs/vault/src/vault-item-dialog/vault-item-dialog.component.ts
@@ -17,6 +17,8 @@ import { getUserId } from "@bitwarden/common/auth/services/account.service";
 import { BillingAccountProfileStateService } from "@bitwarden/common/billing/abstractions";
 import { EventCollectionService, EventType } from "@bitwarden/common/dirt/event-logs";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
 import { CipherId, CollectionId, OrganizationId, UserId } from "@bitwarden/common/types/guid";
@@ -219,6 +221,11 @@ export class VaultItemDialogComponent implements OnInit, OnDestroy {
 
   private readonly userCanArchive = toSignal(this.userCanArchive$, { initialValue: false });
 
+  private readonly pm32009NewItemTypes = toSignal(
+    this.configService.getFeatureFlag$(FeatureFlag.PM32009NewItemTypes),
+    { initialValue: false },
+  );
+
   protected get isTrashFilter() {
     return !!this.cipher?.isDeleted;
   }
@@ -324,6 +331,7 @@ export class VaultItemDialogComponent implements OnInit, OnDestroy {
     private apiService: ApiService,
     private eventCollectionService: EventCollectionService,
     private archiveService: CipherArchiveService,
+    private configService: ConfigService,
   ) {
     this.updateTitle();
     this.premiumUpgradeService.upgradeConfirmed$
@@ -664,7 +672,9 @@ export class VaultItemDialogComponent implements OnInit, OnDestroy {
         [CipherType.Login]: "viewItemHeaderLogin",
         [CipherType.Card]: "viewItemHeaderCard",
         [CipherType.Identity]: "viewItemHeaderIdentity",
-        [CipherType.SecureNote]: "viewItemHeaderNote",
+        [CipherType.SecureNote]: this.pm32009NewItemTypes()
+          ? "viewItemHeaderSecureNote"
+          : "viewItemHeaderNote",
         [CipherType.SshKey]: "viewItemHeaderSshKey",
         [CipherType.BankAccount]: "viewItemHeaderBankAccount",
         [CipherType.DriversLicense]: "viewItemHeaderLicense",
@@ -674,7 +684,9 @@ export class VaultItemDialogComponent implements OnInit, OnDestroy {
         [CipherType.Login]: "newItemHeaderLogin",
         [CipherType.Card]: "newItemHeaderCard",
         [CipherType.Identity]: "newItemHeaderIdentity",
-        [CipherType.SecureNote]: "newItemHeaderNote",
+        [CipherType.SecureNote]: this.pm32009NewItemTypes()
+          ? "newItemHeaderSecureNote"
+          : "newItemHeaderNote",
         [CipherType.SshKey]: "newItemHeaderSshKey",
         [CipherType.BankAccount]: "newItemHeaderBankAccount",
         [CipherType.DriversLicense]: "newItemHeaderDriversLicense",
@@ -684,7 +696,9 @@ export class VaultItemDialogComponent implements OnInit, OnDestroy {
         [CipherType.Login]: "editItemHeaderLogin",
         [CipherType.Card]: "editItemHeaderCard",
         [CipherType.Identity]: "editItemHeaderIdentity",
-        [CipherType.SecureNote]: "editItemHeaderNote",
+        [CipherType.SecureNote]: this.pm32009NewItemTypes()
+          ? "editItemHeaderSecureNote"
+          : "editItemHeaderNote",
         [CipherType.SshKey]: "editItemHeaderSshKey",
         [CipherType.BankAccount]: "editItemHeaderBankAccount",
         [CipherType.DriversLicense]: "editItemHeaderLicense",

--- a/libs/vault/src/vault-item-dialog/vault-item-dialog.component.ts
+++ b/libs/vault/src/vault-item-dialog/vault-item-dialog.component.ts
@@ -16,9 +16,9 @@ import { AccountService } from "@bitwarden/common/auth/abstractions/account.serv
 import { getUserId } from "@bitwarden/common/auth/services/account.service";
 import { BillingAccountProfileStateService } from "@bitwarden/common/billing/abstractions";
 import { EventCollectionService, EventType } from "@bitwarden/common/dirt/event-logs";
-import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
 import { CipherId, CollectionId, OrganizationId, UserId } from "@bitwarden/common/types/guid";


### PR DESCRIPTION
## 🎟️ Tracking

[PM-34580](https://bitwarden.atlassian.net/browse/PM-34580)

## 📔 Objective

Renames the SecureNote cipher type display label from "Note" to "Secure note" across web, browser, and desktop clients, gated behind `FeatureFlag.PM32009NewItemTypes`.

## 📸 Screenshots
|Desktop|Web|Browser|
|-|-|-|
|<video src="https://github.com/user-attachments/assets/da68536d-bb71-4748-961b-dd8a7845217e"/>|<video src="https://github.com/user-attachments/assets/80cc8426-99b1-453a-a01d-9c9f444ada97"/>|<video src="https://github.com/user-attachments/assets/c7cb9129-3b2a-4b85-9b11-6c979a7d4999"/>|

[PM-34580]: https://bitwarden.atlassian.net/browse/PM-34580?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
