### PR TITLE
[PM-39392] Use readonly styles for fields intended to be readonly

### DIFF
--- a/apps/web/src/app/admin-console/organizations/manage/group-add-edit.component.html
+++ b/apps/web/src/app/admin-console/organizations/manage/group-add-edit.component.html
@@ -22,7 +22,7 @@
         </bit-form-field>
         <bit-form-field *ngIf="isExternalIdVisible">
           <bit-label>{{ "externalId" | i18n }}</bit-label>
-          <input bitInput type="text" formControlName="externalId" />
+          <input bitInput type="text" formControlName="externalId" readonly />
           <bit-hint>{{ "externalIdDesc" | i18n }}</bit-hint>
         </bit-form-field>
       </bit-tab>

--- a/apps/web/src/app/admin-console/organizations/manage/group-add-edit.component.ts
+++ b/apps/web/src/app/admin-console/organizations/manage/group-add-edit.component.ts
@@ -136,7 +136,8 @@ export class GroupAddEditComponent implements OnInit, OnDestroy {
 
   groupForm = this.formBuilder.group({
     name: ["", [Validators.required, Validators.maxLength(100)]],
-    externalId: this.formBuilder.control({ value: "", disabled: true }),
+    // set to readonly in the template
+    externalId: this.formBuilder.control({ value: "", disabled: false }),
     members: [[] as AccessItemValue[]],
     collections: [[] as AccessItemValue[]],
   });

--- a/apps/web/src/app/admin-console/organizations/members/components/edit-member-dialog/edit-member-dialog.component.html
+++ b/apps/web/src/app/admin-console/organizations/members/components/edit-member-dialog/edit-member-dialog.component.html
@@ -153,14 +153,14 @@
           @if (externalId() != null) {
             <bit-form-field>
               <bit-label>{{ "externalId" | i18n }}</bit-label>
-              <input bitInput type="text" formControlName="externalId" />
+              <input bitInput type="text" formControlName="externalId" readonly />
               <bit-hint>{{ "externalIdDesc" | i18n }}</bit-hint>
             </bit-form-field>
           }
           @if (ssoExternalId() != null) {
             <bit-form-field>
               <bit-label>{{ "ssoExternalId" | i18n }}</bit-label>
-              <input bitInput type="text" formControlName="ssoExternalId" />
+              <input bitInput type="text" formControlName="ssoExternalId" readonly />
               <bit-hint>{{ "ssoExternalIdDesc" | i18n }}</bit-hint>
             </bit-form-field>
           }

--- a/apps/web/src/app/admin-console/organizations/members/components/edit-member-dialog/edit-member-dialog.component.ts
+++ b/apps/web/src/app/admin-console/organizations/members/components/edit-member-dialog/edit-member-dialog.component.ts
@@ -126,8 +126,10 @@ export class EditMemberDialogComponent {
 
   protected readonly formGroup = this.formBuilder.group({
     type: this.formBuilder.nonNullable.control(OrganizationUserType.User),
-    externalId: this.formBuilder.control({ value: "", disabled: true }),
-    ssoExternalId: this.formBuilder.control({ value: "", disabled: true }),
+    // set to readonly in the template
+    externalId: this.formBuilder.control({ value: "", disabled: false }),
+    // set to readonly in the template
+    ssoExternalId: this.formBuilder.control({ value: "", disabled: false }),
     accessSecretsManager: false,
     access: [[] as AccessItemValue[]],
     groups: [[] as AccessItemValue[]],

--- a/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.html
+++ b/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.html
@@ -186,14 +186,14 @@
           @if (isExternalIdVisible) {
             <bit-form-field>
               <bit-label>{{ "externalId" | i18n }}</bit-label>
-              <input bitInput type="text" formControlName="externalId" />
+              <input bitInput type="text" formControlName="externalId" readonly />
               <bit-hint>{{ "externalIdDesc" | i18n }}</bit-hint>
             </bit-form-field>
           }
           @if (isSsoExternalIdVisible) {
             <bit-form-field>
               <bit-label>{{ "ssoExternalId" | i18n }}</bit-label>
-              <input bitInput type="text" formControlName="ssoExternalId" />
+              <input bitInput type="text" formControlName="ssoExternalId" readonly />
               <bit-hint>{{ "ssoExternalIdDesc" | i18n }}</bit-hint>
             </bit-form-field>
           }

--- a/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.ts
+++ b/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.ts
@@ -144,8 +144,10 @@ export class MemberDialogComponent implements OnDestroy {
   protected formGroup = this.formBuilder.group({
     emails: [""],
     type: OrganizationUserType.User,
-    externalId: this.formBuilder.control({ value: "", disabled: true }),
-    ssoExternalId: this.formBuilder.control({ value: "", disabled: true }),
+    // set to readonly in the template
+    externalId: this.formBuilder.control({ value: "", disabled: false }),
+    // set to readonly in the template
+    ssoExternalId: this.formBuilder.control({ value: "", disabled: false }),
     accessSecretsManager: false,
     access: [[] as AccessItemValue[]],
     groups: [[] as AccessItemValue[]],

--- a/apps/web/src/app/admin-console/organizations/shared/components/collection-dialog/collection-dialog.component.html
+++ b/apps/web/src/app/admin-console/organizations/shared/components/collection-dialog/collection-dialog.component.html
@@ -36,7 +36,7 @@
 
         <bit-form-field *ngIf="isExternalIdVisible">
           <bit-label>{{ "externalId" | i18n }}</bit-label>
-          <input bitInput formControlName="externalId" />
+          <input bitInput formControlName="externalId" readonly />
           <bit-hint>{{ "externalIdDesc" | i18n }}</bit-hint>
         </bit-form-field>
 

--- a/apps/web/src/app/admin-console/organizations/shared/components/collection-dialog/collection-dialog.component.ts
+++ b/apps/web/src/app/admin-console/organizations/shared/components/collection-dialog/collection-dialog.component.ts
@@ -138,7 +138,8 @@ export class CollectionDialogComponent implements OnInit, OnDestroy {
   protected showOrgSelector = false;
   protected formGroup = this.formBuilder.group({
     name: ["", [Validators.required, BitValidators.forbiddenCharacters(["/"])]],
-    externalId: { value: "", disabled: true },
+    // set to readonly in the template
+    externalId: { value: "", disabled: false },
     parent: undefined as string | undefined,
     access: [[] as AccessItemValue[]],
     selectedOrg: "" as OrganizationId,

--- a/apps/web/src/app/billing/organizations/billing-sync-api-key.component.html
+++ b/apps/web/src/app/billing/organizations/billing-sync-api-key.component.html
@@ -23,7 +23,7 @@
           type="text"
           [value]="clientSecret"
           class="tw-font-mono"
-          disabled
+          readonly
         />
         <button
           bitIconButton="bwi-clone"

--- a/apps/web/src/app/tools/send/shared/send-success-drawer-dialog.component.html
+++ b/apps/web/src/app/tools/send/shared/send-success-drawer-dialog.component.html
@@ -28,7 +28,7 @@
 
       <bit-form-field class="tw-w-full tw-max-w-sm tw-mb-4">
         <bit-label>{{ "sendLink" | i18n }}</bit-label>
-        <input bitInput disabled type="text" [value]="sendLink()" />
+        <input bitInput readonly type="text" [value]="sendLink()" />
         <button
           type="button"
           bitIconButton="bwi-clone"

--- a/bitwarden_license/bit-web/src/app/auth/sso/sso-manage.component.html
+++ b/bitwarden_license/bit-web/src/app/auth/sso/sso-manage.component.html
@@ -174,7 +174,7 @@
 
         <bit-form-field>
           <bit-label>{{ "callbackPath" | i18n }}</bit-label>
-          <input bitInput disabled [value]="callbackPath" />
+          <input bitInput readonly [value]="callbackPath" />
           <button
             bitIconButton="bwi-clone"
             bitSuffix
@@ -186,7 +186,7 @@
 
         <bit-form-field>
           <bit-label>{{ "signedOutCallbackPath" | i18n }}</bit-label>
-          <input bitInput disabled [value]="signedOutCallbackPath" />
+          <input bitInput readonly [value]="signedOutCallbackPath" />
           <button
             bitIconButton="bwi-clone"
             bitSuffix
@@ -328,7 +328,7 @@
 
         <bit-form-field *ngIf="ssoConfigForm.value.saml.spUniqueEntityId">
           <bit-label>{{ "spEntityId" | i18n }}</bit-label>
-          <input bitInput disabled [value]="spEntityId" />
+          <input bitInput readonly [value]="spEntityId" />
           <button
             bitIconButton="bwi-clone"
             bitSuffix
@@ -340,7 +340,7 @@
 
         <bit-form-field *ngIf="!ssoConfigForm.value.saml.spUniqueEntityId">
           <bit-label>{{ "spEntityId" | i18n }}</bit-label>
-          <input bitInput disabled [value]="spEntityIdStatic" />
+          <input bitInput readonly [value]="spEntityIdStatic" />
           <button
             bitIconButton="bwi-clone"
             bitSuffix
@@ -352,7 +352,7 @@
 
         <bit-form-field>
           <bit-label>{{ "spMetadataUrl" | i18n }}</bit-label>
-          <input bitInput disabled [value]="spMetadataUrl" />
+          <input bitInput readonly [value]="spMetadataUrl" />
           <button
             bitIconButton="bwi-external-link"
             bitSuffix
@@ -371,7 +371,7 @@
 
         <bit-form-field>
           <bit-label>{{ "spAcsUrl" | i18n }}</bit-label>
-          <input bitInput disabled [value]="spAcsUrl" />
+          <input bitInput readonly [value]="spAcsUrl" />
           <button
             bitIconButton="bwi-clone"
             bitSuffix

--- a/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/access/dialogs/access-token-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/access/dialogs/access-token-dialog.component.html
@@ -8,7 +8,7 @@
 
     <bit-form-field class="tw-mb-0">
       <bit-label>{{ "accessToken" | i18n }}</bit-label>
-      <textarea bitInput disabled rows="4">{{ data.accessToken }}</textarea>
+      <textarea bitInput readonly rows="4">{{ data.accessToken }}</textarea>
     </bit-form-field>
     {{ "expiresOnAccessToken" | i18n }}
     {{ data.expirationDate === null ? ("never" | i18n) : (data.expirationDate | date: "medium") }}

--- a/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/config/config.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/config/config.component.html
@@ -4,7 +4,7 @@
     <div class="tw-flex tw-gap-6 tw-pt-4">
       <bit-form-field class="tw-w-2/5 tw-min-w-80" tw>
         <bit-label>{{ "identityUrl" | i18n }}</bit-label>
-        <input bitInput type="text" [(ngModel)]="identityUrl" [disabled]="true" />
+        <input bitInput type="text" [(ngModel)]="identityUrl" readonly />
         <button
           bitSuffix
           type="button"
@@ -16,7 +16,7 @@
       </bit-form-field>
       <bit-form-field class="tw-w-2/5 tw-min-w-80">
         <bit-label>{{ "apiUrl" | i18n }}</bit-label>
-        <input bitInput type="text" [(ngModel)]="apiUrl" [disabled]="true" />
+        <input bitInput type="text" [(ngModel)]="apiUrl" readonly />
         <button
           bitSuffix
           type="button"
@@ -28,7 +28,7 @@
     </div>
     <bit-form-field class="tw-w-2/5 tw-min-w-80">
       <bit-label>{{ "organizationId" | i18n }}</bit-label>
-      <input bitInput type="text" [(ngModel)]="organizationId" [disabled]="true" />
+      <input bitInput type="text" [(ngModel)]="organizationId" readonly />
       <button
         bitSuffix
         type="button"

--- a/libs/vault/src/cipher-form/components/login-details-section/login-details-section.component.html
+++ b/libs/vault/src/cipher-form/components/login-details-section/login-details-section.component.html
@@ -85,7 +85,7 @@
         <bit-label>{{ "typePasskey" | i18n }}</bit-label>
         <input
           bitInput
-          disabled
+          readonly
           [value]="fido2CredentialCreationDateValue"
           data-testid="passkey-field"
         />


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[PM-39392](https://bitwarden.atlassian.net/browse/PM-39392)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Disabled fields do not need to meet the same contrast requirements as interactive fields.

We were using disabled fields in a number of places that should actually be readonly fields, as the intent is not to show that a field is **currently** disabled, but simply that it is not editable at all. Readonly is the appropriate style here.

This PR migrates the existing instances to use readonly to improve readability and accessibility.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

Examples:

| Before | After |
|--------|--------|
| <img width="1608" height="1164" alt="Screenshot 2026-06-22 at 11 15 04" src="https://github.com/user-attachments/assets/02db7def-8f76-4814-b718-2d0f15ed9a6c" /> | <img width="1728" height="923" alt="Screenshot 2026-06-22 at 3 28 12 PM" src="https://github.com/user-attachments/assets/536a2e84-7b8c-4e7c-8f58-b7a4fe48ee27" /> | 
| <img width="1608" height="1164" alt="Screenshot 2026-06-22 at 11 09 45" src="https://github.com/user-attachments/assets/1b52a240-2e86-4451-8f2b-2864cbadb21a" />  | <img width="1728" height="923" alt="Screenshot 2026-06-22 at 3 28 02 PM" src="https://github.com/user-attachments/assets/b2335182-1fba-4459-9925-dfc7907d7250" /> |
| <img width="1608" height="1164" alt="Screenshot 2026-06-22 at 11 14 55" src="https://github.com/user-attachments/assets/f0da9378-eeda-4573-b497-1db4aa2473dc" /> | <img width="1728" height="923" alt="Screenshot 2026-06-22 at 3 28 21 PM" src="https://github.com/user-attachments/assets/df258a1e-15f0-48e8-8c5c-e787f17fc8ac" /> | 



[PM-39392]: https://bitwarden.atlassian.net/browse/PM-39392?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ