### PR TITLE
Use readonly instead of disabled for display-only form fields

### DIFF
--- a/apps/web/src/app/admin-console/organizations/members/components/edit-member-dialog/edit-member-dialog.component.html
+++ b/apps/web/src/app/admin-console/organizations/members/components/edit-member-dialog/edit-member-dialog.component.html
@@ -153,14 +153,14 @@
           @if (externalId() != null) {
             <bit-form-field>
               <bit-label>{{ "externalId" | i18n }}</bit-label>
-              <input bitInput type="text" formControlName="externalId" />
+              <input bitInput type="text" formControlName="externalId" readonly />
               <bit-hint>{{ "externalIdDesc" | i18n }}</bit-hint>
             </bit-form-field>
           }
           @if (ssoExternalId() != null) {
             <bit-form-field>
               <bit-label>{{ "ssoExternalId" | i18n }}</bit-label>
-              <input bitInput type="text" formControlName="ssoExternalId" />
+              <input bitInput type="text" formControlName="ssoExternalId" readonly />
               <bit-hint>{{ "ssoExternalIdDesc" | i18n }}</bit-hint>
             </bit-form-field>
           }

--- a/apps/web/src/app/admin-console/organizations/members/components/edit-member-dialog/edit-member-dialog.component.ts
+++ b/apps/web/src/app/admin-console/organizations/members/components/edit-member-dialog/edit-member-dialog.component.ts
@@ -126,8 +126,8 @@ export class EditMemberDialogComponent {
 
   protected readonly formGroup = this.formBuilder.group({
     type: this.formBuilder.nonNullable.control(OrganizationUserType.User),
-    externalId: this.formBuilder.control({ value: "", disabled: true }),
-    ssoExternalId: this.formBuilder.control({ value: "", disabled: true }),
+    externalId: this.formBuilder.control(""),
+    ssoExternalId: this.formBuilder.control(""),
     accessSecretsManager: false,
     access: [[] as AccessItemValue[]],
     groups: [[] as AccessItemValue[]],

--- a/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.html
+++ b/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.html
@@ -186,14 +186,14 @@
           @if (isExternalIdVisible) {
             <bit-form-field>
               <bit-label>{{ "externalId" | i18n }}</bit-label>
-              <input bitInput type="text" formControlName="externalId" />
+              <input bitInput type="text" formControlName="externalId" readonly />
               <bit-hint>{{ "externalIdDesc" | i18n }}</bit-hint>
             </bit-form-field>
           }
           @if (isSsoExternalIdVisible) {
             <bit-form-field>
               <bit-label>{{ "ssoExternalId" | i18n }}</bit-label>
-              <input bitInput type="text" formControlName="ssoExternalId" />
+              <input bitInput type="text" formControlName="ssoExternalId" readonly />
               <bit-hint>{{ "ssoExternalIdDesc" | i18n }}</bit-hint>
             </bit-form-field>
           }

--- a/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.ts
+++ b/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.ts
@@ -144,8 +144,8 @@ export class MemberDialogComponent implements OnDestroy {
   protected formGroup = this.formBuilder.group({
     emails: [""],
     type: OrganizationUserType.User,
-    externalId: this.formBuilder.control({ value: "", disabled: true }),
-    ssoExternalId: this.formBuilder.control({ value: "", disabled: true }),
+    externalId: this.formBuilder.control(""),
+    ssoExternalId: this.formBuilder.control(""),
     accessSecretsManager: false,
     access: [[] as AccessItemValue[]],
     groups: [[] as AccessItemValue[]],

--- a/apps/web/src/app/billing/organizations/billing-sync-api-key.component.html
+++ b/apps/web/src/app/billing/organizations/billing-sync-api-key.component.html
@@ -23,7 +23,7 @@
           type="text"
           [value]="clientSecret"
           class="tw-font-mono"
-          disabled
+          readonly
         />
         <button
           bitIconButton="bwi-clone"

--- a/apps/web/src/app/tools/send/shared/send-success-drawer-dialog.component.html
+++ b/apps/web/src/app/tools/send/shared/send-success-drawer-dialog.component.html
@@ -28,7 +28,7 @@
 
       <bit-form-field class="tw-w-full tw-max-w-sm tw-mb-4">
         <bit-label>{{ "sendLink" | i18n }}</bit-label>
-        <input bitInput disabled type="text" [value]="sendLink()" />
+        <input bitInput readonly type="text" [value]="sendLink()" />
         <button
           type="button"
           bitIconButton="bwi-clone"

--- a/bitwarden_license/bit-web/src/app/auth/sso/sso-manage.component.html
+++ b/bitwarden_license/bit-web/src/app/auth/sso/sso-manage.component.html
@@ -174,7 +174,7 @@
 
         <bit-form-field>
           <bit-label>{{ "callbackPath" | i18n }}</bit-label>
-          <input bitInput disabled [value]="callbackPath" />
+          <input bitInput readonly [value]="callbackPath" />
           <button
             bitIconButton="bwi-clone"
             bitSuffix
@@ -186,7 +186,7 @@
 
         <bit-form-field>
           <bit-label>{{ "signedOutCallbackPath" | i18n }}</bit-label>
-          <input bitInput disabled [value]="signedOutCallbackPath" />
+          <input bitInput readonly [value]="signedOutCallbackPath" />
           <button
             bitIconButton="bwi-clone"
             bitSuffix
@@ -328,7 +328,7 @@
 
         <bit-form-field *ngIf="ssoConfigForm.value.saml.spUniqueEntityId">
           <bit-label>{{ "spEntityId" | i18n }}</bit-label>
-          <input bitInput disabled [value]="spEntityId" />
+          <input bitInput readonly [value]="spEntityId" />
           <button
             bitIconButton="bwi-clone"
             bitSuffix
@@ -340,7 +340,7 @@
 
         <bit-form-field *ngIf="!ssoConfigForm.value.saml.spUniqueEntityId">
           <bit-label>{{ "spEntityId" | i18n }}</bit-label>
-          <input bitInput disabled [value]="spEntityIdStatic" />
+          <input bitInput readonly [value]="spEntityIdStatic" />
           <button
             bitIconButton="bwi-clone"
             bitSuffix
@@ -352,7 +352,7 @@
 
         <bit-form-field>
           <bit-label>{{ "spMetadataUrl" | i18n }}</bit-label>
-          <input bitInput disabled [value]="spMetadataUrl" />
+          <input bitInput readonly [value]="spMetadataUrl" />
           <button
             bitIconButton="bwi-external-link"
             bitSuffix
@@ -371,7 +371,7 @@
 
         <bit-form-field>
           <bit-label>{{ "spAcsUrl" | i18n }}</bit-label>
-          <input bitInput disabled [value]="spAcsUrl" />
+          <input bitInput readonly [value]="spAcsUrl" />
           <button
             bitIconButton="bwi-clone"
             bitSuffix

--- a/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/access/dialogs/access-token-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/access/dialogs/access-token-dialog.component.html
@@ -8,7 +8,7 @@
 
     <bit-form-field class="tw-mb-0">
       <bit-label>{{ "accessToken" | i18n }}</bit-label>
-      <textarea bitInput disabled rows="4">{{ data.accessToken }}</textarea>
+      <textarea bitInput readonly rows="4">{{ data.accessToken }}</textarea>
     </bit-form-field>
     {{ "expiresOnAccessToken" | i18n }}
     {{ data.expirationDate === null ? ("never" | i18n) : (data.expirationDate | date: "medium") }}

--- a/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/config/config.component.html
+++ b/bitwarden_license/bit-web/src/app/secrets-manager/service-accounts/config/config.component.html
@@ -4,7 +4,7 @@
     <div class="tw-flex tw-gap-6 tw-pt-4">
       <bit-form-field class="tw-w-2/5 tw-min-w-80" tw>
         <bit-label>{{ "identityUrl" | i18n }}</bit-label>
-        <input bitInput type="text" [(ngModel)]="identityUrl" [disabled]="true" />
+        <input bitInput type="text" [(ngModel)]="identityUrl" readonly />
         <button
           bitSuffix
           type="button"
@@ -16,7 +16,7 @@
       </bit-form-field>
       <bit-form-field class="tw-w-2/5 tw-min-w-80">
         <bit-label>{{ "apiUrl" | i18n }}</bit-label>
-        <input bitInput type="text" [(ngModel)]="apiUrl" [disabled]="true" />
+        <input bitInput type="text" [(ngModel)]="apiUrl" readonly />
         <button
           bitSuffix
           type="button"
@@ -28,7 +28,7 @@
     </div>
     <bit-form-field class="tw-w-2/5 tw-min-w-80">
       <bit-label>{{ "organizationId" | i18n }}</bit-label>
-      <input bitInput type="text" [(ngModel)]="organizationId" [disabled]="true" />
+      <input bitInput type="text" [(ngModel)]="organizationId" readonly />
       <button
         bitSuffix
         type="button"

--- a/libs/vault/src/cipher-form/components/login-details-section/login-details-section.component.html
+++ b/libs/vault/src/cipher-form/components/login-details-section/login-details-section.component.html
@@ -85,7 +85,7 @@
         <bit-label>{{ "typePasskey" | i18n }}</bit-label>
         <input
           bitInput
-          disabled
+          readonly
           [value]="fido2CredentialCreationDateValue"
           data-testid="passkey-field"
         />


### PR DESCRIPTION
## 🎟️ Tracking

No associated Jira ticket — proactive accessibility/semantics cleanup of form fields.

## 📔 Objective

Several `bit-form-field` inputs exist only to **display** a value for the user to read and copy, but were using `disabled`. `disabled` makes the field unfocusable, blocks text selection/copy, dims it, and weakens screen-reader announcement. For read-only display values, `readonly` is the correct semantic — the value stays focusable, selectable, and copyable.

This audit covered `apps/web`, `apps/browser`, `apps/desktop`, all `libs/*`, and `bitwarden_license/bit-web`.

### Tier 1 — `disabled` → `readonly` on display/copy fields (template-only)

All are `[value]`/`[(ngModel)]`-bound inputs with an adjacent copy button:

- `apps/web` — Send link (`send-success-drawer-dialog`), billing sync key (`billing-sync-api-key`)
- `bitwarden_license/bit-web` — SSO/SAML config values (callback paths, SP entity IDs, metadata/ACS URLs in `sso-manage`), Secrets Manager environment variables + access token (`config`, `access-token-dialog`)
- `libs/vault` — passkey creation date (`login-details-section`)

### Tier 2 — reactive identifier fields enabled + marked `readonly`

`member-dialog` and `edit-member-dialog`: `externalId` / `ssoExternalId`. A `disabled` reactive control renders disabled regardless of the `readonly` attribute, so the control is enabled and the input marked `readonly`. **Verified safe:** both submit paths hardcode these to `null` / omit them from the request, so the API payload is unchanged.

### Intentionally left as `disabled` (out of scope)

Two `externalId` fields were **deliberately not changed** because, unlike the Tier-2 fields above, their submit handlers read the control value directly into the save object. Enabling them (required for `readonly` to take effect) would start sending a field that is currently excluded from the request:

- `group-add-edit.component.ts` — saved via `groupForm.value.externalId`
- `collection-dialog.component.ts` — `collectionView.externalId = controls.externalId.value`

These are read-only directory-sync identifiers, so re-sending the unchanged value is very likely a server no-op — but that can't be confirmed from the client, so they were left `disabled` to avoid any behavior change to the create/update API calls. Worth a follow-up once the server behavior is confirmed.

Also excluded: the boolean custom-field checkbox in `custom-fields-v2` (HTML checkboxes ignore `readonly`; `disabled` + `aria-readonly="true"` is the correct pattern), permission-gated buttons (not inputs), and whole-form view-mode toggles (intentionally non-submitting).

### Verification

- `prettier` — clean
- `eslint` — 0 errors on changed files
- `jest` — 45/45 member-dialog tests pass
- Type-check — changed files clean (the only failures are a pre-existing, unrelated SDK type drift in `cipher-sdk.service.ts`)

## 📸 Screenshots

UI change is that the listed read-only fields are now selectable/copyable rather than dimmed-and-inert. TODO before marking ready:

- [ ] Send success drawer — Send link field
- [ ] Org billing — billing sync key field
- [ ] SSO config (SAML/OIDC) — callback paths, SP entity IDs, metadata/ACS URLs
- [ ] Secrets Manager — service account config (identity/API URL, org ID) and access token dialog
- [ ] Vault item — passkey creation date field
- [ ] Member / edit-member dialogs — external ID and SSO external ID fields