### PR TITLE
[PM-33740] Remove unlock service for password flagged logic

### DIFF
--- a/libs/auth/src/common/login-strategies/password-login.strategy.spec.ts
+++ b/libs/auth/src/common/login-strategies/password-login.strategy.spec.ts
@@ -17,7 +17,6 @@ import {
 } from "@bitwarden/common/auth/password-prelogin";
 import { TwoFactorService } from "@bitwarden/common/auth/two-factor";
 import { BillingAccountProfileStateService } from "@bitwarden/common/billing/abstractions/account/billing-account-profile-state.service";
-import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { AccountCryptographicStateService } from "@bitwarden/common/key-management/account-cryptography/account-cryptographic-state.service";
 import { EncryptService } from "@bitwarden/common/key-management/crypto/abstractions/encrypt.service";
 import { FakeMasterPasswordService } from "@bitwarden/common/key-management/master-password/services/fake-master-password.service";
@@ -117,9 +116,6 @@ describe("PasswordLoginStrategy", () => {
     environmentService = mock<EnvironmentService>();
     configService = mock<ConfigService>();
     accountCryptographicStateService = mock<AccountCryptographicStateService>();
-    configService.getFeatureFlag
-      .calledWith(FeatureFlag.UseUnlockServiceForPasswordLogin)
-      .mockResolvedValue(false);
 
     appIdService.getAppId.mockResolvedValue(deviceId);
     tokenService.decodeAccessToken.mockResolvedValue({
@@ -202,73 +198,23 @@ describe("PasswordLoginStrategy", () => {
     );
   });
 
-  it("sets keys after a successful authentication", async () => {
-    const userKey = new SymmetricCryptoKey(new Uint8Array(64)) as UserKey;
-
-    masterPasswordService.masterKeySubject.next(masterKey);
-    masterPasswordService.mock.decryptUserKeyWithMasterKey.mockResolvedValue(userKey);
-    tokenService.decodeAccessToken.mockResolvedValue({ sub: userId });
-
-    await passwordLoginStrategy.logIn(credentials);
-
-    expect(masterPasswordService.mock.setMasterKey).toHaveBeenCalledWith(masterKey, userId);
-    expect(masterPasswordService.mock.setMasterKeyEncryptedUserKey).toHaveBeenCalledWith(
-      tokenResponse.key,
-      userId,
-    );
-    expect(keyService.setUserKey).toHaveBeenCalledWith(userKey, userId);
-    expect(accountCryptographicStateService.setAccountCryptographicState).toHaveBeenCalledWith(
-      { V1: { private_key: tokenResponse.privateKey } },
-      userId,
-    );
-  });
-
-  it("uses master password unlock service when feature flag is enabled", async () => {
-    configService.getFeatureFlag
-      .calledWith(FeatureFlag.UseUnlockServiceForPasswordLogin)
-      .mockResolvedValue(true);
-
-    // Re-create he strategy and wait a bit to settle the feature flag
-    passwordLoginStrategy = new PasswordLoginStrategy(
-      new PasswordLoginStrategyData(),
-      passwordStrengthService,
-      policyService,
-      passwordPreloginService,
-      unlockService,
-      accountService,
-      masterPasswordService,
-      keyService,
-      encryptService,
-      apiService,
-      tokenService,
-      appIdService,
-      platformUtilsService,
-      messagingService,
-      logService,
-      stateService,
-      twoFactorService,
-      userDecryptionOptionsService,
-      billingAccountProfileStateService,
-      vaultTimeoutSettingsService,
-      kdfConfigService,
-      environmentService,
-      configService,
-      accountCryptographicStateService,
-    );
-
+  it("uses the unlock service to set keys after a successful authentication", async () => {
     unlockService.unlockWithMasterPassword.mockResolvedValue(undefined);
     tokenService.decodeAccessToken.mockResolvedValue({ sub: userId });
 
     await passwordLoginStrategy.logIn(credentials);
 
-    expect(configService.getFeatureFlag).toHaveBeenCalledWith(
-      FeatureFlag.UseUnlockServiceForPasswordLogin,
-    );
-    expect(masterPasswordService.mock.setMasterKey).not.toHaveBeenCalled();
     expect(unlockService.unlockWithMasterPassword).toHaveBeenCalledWith(userId, masterPassword);
+    expect(accountCryptographicStateService.setAccountCryptographicState).toHaveBeenCalledWith(
+      { V1: { private_key: tokenResponse.privateKey } },
+      userId,
+    );
+
+    // The unlock service owns key setup, so the strategy must not set keys directly.
+    expect(masterPasswordService.mock.setMasterKey).not.toHaveBeenCalled();
+    expect(masterPasswordService.mock.setMasterKeyEncryptedUserKey).not.toHaveBeenCalled();
     expect(masterPasswordService.mock.decryptUserKeyWithMasterKey).not.toHaveBeenCalled();
     expect(keyService.setUserKey).not.toHaveBeenCalled();
-    expect(passwordLoginStrategy.exportCache().password.unlockServiceForPasswordLogin).toBe(true);
   });
 
   describe("makePasswordPreloginMasterKey", () => {
@@ -548,7 +494,7 @@ describe("PasswordLoginStrategy", () => {
       const result = await passwordLoginStrategy.logIn(credentials);
 
       expect(result.requiresEncryptionKeyMigration).toBe(true);
-      expect(keyService.setUserKey).not.toHaveBeenCalled();
+      expect(unlockService.unlockWithMasterPassword).not.toHaveBeenCalled();
     });
   });
 

--- a/libs/auth/src/common/login-strategies/password-login.strategy.ts
+++ b/libs/auth/src/common/login-strategies/password-login.strategy.ts
@@ -17,7 +17,6 @@ import {
   PasswordPreloginData,
   PasswordPreloginService,
 } from "@bitwarden/common/auth/password-prelogin";
-import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
 import { PasswordStrengthServiceAbstraction } from "@bitwarden/common/tools/password-strength";
 import { UserId } from "@bitwarden/common/types/guid";
@@ -38,8 +37,6 @@ export class PasswordLoginStrategyData implements LoginStrategyData {
   masterKey: MasterKey;
   /** The user's master password */
   masterPassword: string;
-  /** Whether unlock service should be used for this login flow. */
-  unlockServiceForPasswordLogin = false;
   /**
    * Tracks if the user needs to update their password due to
    * a password that does not meet an organization's master password policy.
@@ -81,10 +78,6 @@ export class PasswordLoginStrategy extends LoginStrategy {
   }
 
   override async logIn(credentials: PasswordLoginCredentials): Promise<AuthResult> {
-    const unlockServiceForPasswordLogin = await this.configService.getFeatureFlag(
-      FeatureFlag.UseUnlockServiceForPasswordLogin,
-    );
-
     const { email, masterPassword, twoFactor, preFetchedPreloginData } = credentials;
 
     const data = new PasswordLoginStrategyData();
@@ -95,7 +88,6 @@ export class PasswordLoginStrategy extends LoginStrategy {
     );
     this.passwordPreloginService.clearCache();
     data.masterPassword = masterPassword;
-    data.unlockServiceForPasswordLogin = unlockServiceForPasswordLogin;
     data.userEnteredEmail = email;
 
     // Hash the password early (before authentication) so we don't persist it in memory in plaintext
@@ -123,37 +115,13 @@ export class PasswordLoginStrategy extends LoginStrategy {
     return result;
   }
 
-  protected override async setMasterKey(response: IdentityTokenResponse, userId: UserId) {
-    if (!this.cache.value.unlockServiceForPasswordLogin) {
-      const { masterKey } = this.cache.value;
-      await this.masterPasswordService.setMasterKey(masterKey, userId);
-    }
-  }
+  protected override async setMasterKey(response: IdentityTokenResponse, userId: UserId) {}
 
   protected override async setUserKey(
     response: IdentityTokenResponse,
     userId: UserId,
   ): Promise<void> {
-    if (this.cache.value.unlockServiceForPasswordLogin) {
-      await this.unlockService.unlockWithMasterPassword(userId, this.cache.value.masterPassword);
-    } else {
-      // If migration is required, we won't have a user key to set yet.
-      if (this.encryptionKeyMigrationRequired(response)) {
-        return;
-      }
-      await this.masterPasswordService.setMasterKeyEncryptedUserKey(response.key, userId);
-      // Warning: State is accessed right after state is set. This could lead to a race condition
-      // in some cases where decryptUserKeyWithMasterKey will get a null encrypted user-key!!
-      // https://github.com/bitwarden/clients/tree/afc45ee0c8fc823301bb361b0dcac581eb0aff0c/libs/state#updating-state-with-update
-      const masterKey = await firstValueFrom(this.masterPasswordService.masterKey$(userId));
-      if (masterKey) {
-        const userKey = await this.masterPasswordService.decryptUserKeyWithMasterKey(
-          masterKey,
-          userId,
-        );
-        await this.keyService.setUserKey(userKey, userId);
-      }
-    }
+    await this.unlockService.unlockWithMasterPassword(userId, this.cache.value.masterPassword);
   }
 
   protected override async setAccountCryptographicState(

--- a/libs/common/src/enums/feature-flag.enum.ts
+++ b/libs/common/src/enums/feature-flag.enum.ts
@@ -22,7 +22,6 @@ export enum FeatureFlag {
   SafariAccountSwitching = "pm-5594-safari-account-switching",
   PM30811_ChangeEmailNewAuthenticationApis = "pm-30811-change-email-new-authentication-apis",
   PM31088_MasterPasswordServiceEmitSalt = "pm-31088-master-password-service-emit-salt",
-  UseUnlockServiceForPasswordLogin = "use-unlock-service-for-password-login",
   PM32413_MultiClientPasswordManagement = "pm-32413-multi-client-password-management",
   PM34210_DesktopAddDevices = "pm-34210-desktop-add-devices",
   // TODO: PM-34091 - Remove this flag and its DefaultFeatureFlagValue entry below.
@@ -191,7 +190,6 @@ export const DefaultFeatureFlagValue = {
   [FeatureFlag.SafariAccountSwitching]: FALSE,
   [FeatureFlag.PM30811_ChangeEmailNewAuthenticationApis]: FALSE,
   [FeatureFlag.PM31088_MasterPasswordServiceEmitSalt]: FALSE,
-  [FeatureFlag.UseUnlockServiceForPasswordLogin]: FALSE,
   [FeatureFlag.PM32413_MultiClientPasswordManagement]: FALSE,
   [FeatureFlag.PM34210_DesktopAddDevices]: FALSE,
   // TODO: PM-34091 - Remove this default value entry.


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-33740

## 📔 Objective

Unlock service for password feature flag has been enabled in prod and the feature flagged code can now be removed from clients.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
