### PR TITLE
feat(biometrics): add windows biometrics format based on sdk cryptography

### DIFF
--- a/apps/desktop/desktop_native/Cargo.lock
+++ b/apps/desktop/desktop_native/Cargo.lock
@@ -13,14 +13,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "aead"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
+dependencies = [
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
+]
+
+[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.4.4",
  "cpufeatures 0.2.17",
+ "zeroize",
+]
+
+[[package]]
+name = "aes"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
+dependencies = [
+ "cipher 0.5.2",
+ "cpubits",
+ "cpufeatures 0.3.0",
  "zeroize",
 ]
 
@@ -30,12 +52,27 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
 dependencies = [
- "aead",
- "aes",
- "cipher",
- "ctr",
- "ghash",
+ "aead 0.5.2",
+ "aes 0.8.4",
+ "cipher 0.4.4",
+ "ctr 0.9.2",
+ "ghash 0.5.1",
  "subtle",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdf011db2e21ce0d575593d749db5554b47fed37aff429e4dc50bc91ac93a028"
+dependencies = [
+ "aead 0.6.1",
+ "aes 0.9.1",
+ "cipher 0.5.2",
+ "ctr 0.10.1",
+ "ghash 0.6.0",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -128,6 +165,20 @@ dependencies = [
  "windows-sys 0.60.2",
  "wl-clipboard-rs",
  "x11rb",
+]
+
+[[package]]
+name = "argon2"
+version = "0.6.0-rc.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7af50940b73bf4e16c15c448a2b121c63f2d68e3e54b6a8731673cb4aa0cdff5"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures 0.3.0",
+ "kdf",
+ "password-hash",
+ "zeroize",
 ]
 
 [[package]]
@@ -371,7 +422,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "itertools",
- "mockall",
+ "mockall 0.15.0",
  "serial_test",
  "tracing",
  "windows 0.62.2",
@@ -383,6 +434,12 @@ name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
+name = "base16ct"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
 
 [[package]]
 name = "base64"
@@ -413,7 +470,7 @@ checksum = "6aeac2e1fe888769f34f05ac343bbef98b14d1ffb292ab69d4608b3abc86f2a2"
 dependencies = [
  "blowfish",
  "pbkdf2 0.12.2",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -429,16 +486,19 @@ dependencies = [
 name = "biometric"
 version = "0.0.0"
 dependencies = [
- "aes",
+ "aes 0.8.4",
  "anyhow",
- "chacha20poly1305",
+ "bitwarden-crypto",
+ "bitwarden-random",
+ "bitwarden-sensitive-value",
+ "chacha20poly1305 0.10.1",
  "desktop_core",
- "rand 0.9.3",
+ "rand_core 0.10.1",
  "scopeguard",
  "secure_memory",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tokio",
  "tracing",
  "windows 0.62.2",
@@ -454,6 +514,146 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
+name = "bitwarden-api-base"
+version = "3.0.0"
+source = "git+https://github.com/bitwarden/sdk-internal?rev=f76b51450582cff9be767c9d9f454c42a84a56c1#f76b51450582cff9be767c9d9f454c42a84a56c1"
+dependencies = [
+ "http",
+ "reqwest",
+ "reqwest-middleware",
+ "rustls",
+ "rustls-platform-verifier 0.6.2",
+ "serde",
+ "serde_json",
+ "url",
+]
+
+[[package]]
+name = "bitwarden-api-key-connector"
+version = "3.0.0"
+source = "git+https://github.com/bitwarden/sdk-internal?rev=f76b51450582cff9be767c9d9f454c42a84a56c1#f76b51450582cff9be767c9d9f454c42a84a56c1"
+dependencies = [
+ "async-trait",
+ "bitwarden-api-base",
+ "mockall 0.14.0",
+ "reqwest",
+ "reqwest-middleware",
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
+name = "bitwarden-crypto"
+version = "3.0.0"
+source = "git+https://github.com/bitwarden/sdk-internal?rev=f76b51450582cff9be767c9d9f454c42a84a56c1#f76b51450582cff9be767c9d9f454c42a84a56c1"
+dependencies = [
+ "aes 0.9.1",
+ "aes-gcm 0.11.0",
+ "argon2",
+ "bitwarden-api-key-connector",
+ "bitwarden-encoding",
+ "bitwarden-error",
+ "bitwarden-logging",
+ "bitwarden-random",
+ "bitwarden-sensitive-value",
+ "cbc 0.2.1",
+ "chacha20poly1305 0.11.0-rc.3",
+ "ciborium",
+ "coset",
+ "ed25519-dalek 3.0.0-rc.1",
+ "hex",
+ "hkdf 0.13.0",
+ "hmac 0.13.0",
+ "hybrid-array",
+ "ml-dsa",
+ "num-bigint",
+ "num-traits",
+ "pbkdf2 0.13.0",
+ "rand 0.10.2",
+ "rayon",
+ "rsa 0.10.0-rc.18",
+ "schemars 1.2.1",
+ "serde",
+ "serde_bytes",
+ "serde_repr",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
+ "subtle",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
+ "typenum",
+ "uuid",
+ "zeroize",
+ "zeroizing-alloc",
+]
+
+[[package]]
+name = "bitwarden-encoding"
+version = "3.0.0"
+source = "git+https://github.com/bitwarden/sdk-internal?rev=f76b51450582cff9be767c9d9f454c42a84a56c1#f76b51450582cff9be767c9d9f454c42a84a56c1"
+dependencies = [
+ "data-encoding",
+ "data-encoding-macro",
+ "serde",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "bitwarden-error"
+version = "3.0.0"
+source = "git+https://github.com/bitwarden/sdk-internal?rev=f76b51450582cff9be767c9d9f454c42a84a56c1#f76b51450582cff9be767c9d9f454c42a84a56c1"
+dependencies = [
+ "bitwarden-error-macro",
+]
+
+[[package]]
+name = "bitwarden-error-macro"
+version = "3.0.0"
+source = "git+https://github.com/bitwarden/sdk-internal?rev=f76b51450582cff9be767c9d9f454c42a84a56c1#f76b51450582cff9be767c9d9f454c42a84a56c1"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "bitwarden-logging"
+version = "3.0.0"
+source = "git+https://github.com/bitwarden/sdk-internal?rev=f76b51450582cff9be767c9d9f454c42a84a56c1#f76b51450582cff9be767c9d9f454c42a84a56c1"
+dependencies = [
+ "bitwarden-logging-macro",
+ "chrono",
+ "serde",
+ "serde_json",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "bitwarden-logging-macro"
+version = "3.0.0"
+source = "git+https://github.com/bitwarden/sdk-internal?rev=f76b51450582cff9be767c9d9f454c42a84a56c1#f76b51450582cff9be767c9d9f454c42a84a56c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "bitwarden-random"
+version = "3.0.0"
+source = "git+https://github.com/bitwarden/sdk-internal?rev=f76b51450582cff9be767c9d9f454c42a84a56c1#f76b51450582cff9be767c9d9f454c42a84a56c1"
+dependencies = [
+ "bitwarden-error",
+ "rand 0.10.2",
+ "thiserror 2.0.17",
+ "uuid",
+]
+
+[[package]]
 name = "bitwarden-russh"
 version = "0.1.0"
 source = "git+https://github.com/bitwarden/bitwarden-russh.git?rev=a641316227227f8777fdf56ac9fa2d6b5f7fe662#a641316227227f8777fdf56ac9fa2d6b5f7fe662"
@@ -461,12 +661,12 @@ dependencies = [
  "anyhow",
  "byteorder",
  "ecdsa",
- "ed25519-dalek",
+ "ed25519-dalek 2.2.0",
  "futures",
  "p256",
  "p384",
  "p521",
- "rsa",
+ "rsa 0.9.6",
  "russh-cryptovec",
  "ssh-encoding",
  "ssh-key",
@@ -476,13 +676,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitwarden-sensitive-value"
+version = "3.0.0"
+source = "git+https://github.com/bitwarden/sdk-internal?rev=f76b51450582cff9be767c9d9f454c42a84a56c1#f76b51450582cff9be767c9d9f454c42a84a56c1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitwarden_chromium_import_helper"
 version = "0.0.0"
 dependencies = [
- "aes-gcm",
+ "aes-gcm 0.10.3",
  "anyhow",
  "base64",
- "chacha20poly1305",
+ "chacha20poly1305 0.10.1",
  "chromium_importer",
  "clap",
  "embed-resource",
@@ -492,6 +700,15 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "windows 0.62.2",
+]
+
+[[package]]
+name = "blake2"
+version = "0.11.0-rc.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "061f1a09225e328e1ffbb378d2d49923c0ca5fee19fb5ac1cc9c1e9d52b93690"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -510,6 +727,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
  "hybrid-array",
+ "zeroize",
 ]
 
 [[package]]
@@ -519,6 +737,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "710f1dd022ef4e93f8a438b4ba958de7f64308434fa6a87104481645cc30068b"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -541,7 +768,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e412e2cd0f2b2d93e02543ceae7917b3c70331573df19ee046bcbc35e45e87d7"
 dependencies = [
  "byteorder",
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -632,7 +859,16 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
+]
+
+[[package]]
+name = "cbc"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2dc9ee5f88d11e0beb842c88b33c8a5cf0d1329c4b19494af42b07dbfe8896"
+dependencies = [
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -644,6 +880,12 @@ dependencies = [
  "find-msvc-tools",
  "shlex",
 ]
+
+[[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
@@ -664,8 +906,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.4.4",
  "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cipher 0.5.2",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+ "zeroize",
 ]
 
 [[package]]
@@ -674,10 +929,23 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
- "aead",
- "chacha20",
- "cipher",
- "poly1305",
+ "aead 0.5.2",
+ "chacha20 0.9.1",
+ "cipher 0.4.4",
+ "poly1305 0.8.0",
+ "zeroize",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.11.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c9ed179664f12fd6f155f6dd632edf5f3806d48c228c67ff78366f2a0eb6b5e"
+dependencies = [
+ "aead 0.6.1",
+ "chacha20 0.10.1",
+ "cipher 0.5.2",
+ "poly1305 0.9.0",
  "zeroize",
 ]
 
@@ -685,12 +953,12 @@ dependencies = [
 name = "chromium_importer"
 version = "0.0.0"
 dependencies = [
- "aes",
- "aes-gcm",
+ "aes 0.8.4",
+ "aes-gcm 0.10.3",
  "anyhow",
  "async-trait",
  "base64",
- "cbc",
+ "cbc 0.1.2",
  "desktop_objc",
  "dirs",
  "hex",
@@ -721,13 +989,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common 0.1.7",
- "inout",
+ "inout 0.1.4",
+ "zeroize",
+]
+
+[[package]]
+name = "cipher"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
+dependencies = [
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
  "zeroize",
 ]
 
@@ -793,6 +1100,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -839,6 +1156,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "coset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1eb98d5e9155e2cf7cd942c8b3033097d4563b6fb0a00b9caecb74669555c058"
+dependencies = [
+ "ciborium",
+ "ciborium-io",
+]
+
+[[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -857,10 +1190,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
@@ -871,6 +1229,20 @@ dependencies = [
  "generic-array",
  "rand_core 0.6.4",
  "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto-bigint"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a52aa3fcda4e6302a9f48734f234d35d4721b96f8fe07d073f07ce9df4f0271"
+dependencies = [
+ "cpubits",
+ "ctutils",
+ "num-traits",
+ "rand_core 0.10.1",
+ "serdect",
  "zeroize",
 ]
 
@@ -891,7 +1263,19 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
+ "getrandom 0.4.3",
  "hybrid-array",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "crypto-primes"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3633a51a39c69ebbaa4feaa694bd83d241e4093901c84a0963b19d9bb3f0cf8f"
+dependencies = [
+ "crypto-bigint 0.7.5",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -932,7 +1316,16 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
+]
+
+[[package]]
+name = "ctr"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaca1c4b237092596f64d571e9db6ce4109c4ef9742e27590f1709594461f21"
+dependencies = [
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -954,7 +1347,23 @@ dependencies = [
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest 0.10.7",
- "fiat-crypto",
+ "fiat-crypto 0.2.9",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "5.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c906a87e53a36ff795d72e06e8162a83c5436e3ea89e942a9cb9fc083f0a384f"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "curve25519-dalek-derive",
+ "digest 0.11.3",
+ "fiat-crypto 0.3.0",
  "rustc_version",
  "subtle",
  "zeroize",
@@ -973,12 +1382,36 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
 ]
 
 [[package]]
@@ -996,12 +1429,49 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core",
+ "darling_core 0.23.0",
  "quote",
+ "syn",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
+name = "data-encoding-macro"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3259c913752a86488b501ed8680446a5ed2d5aeac6e596cb23ba3800768ea32c"
+dependencies = [
+ "data-encoding",
+ "data-encoding-macro-internal",
+]
+
+[[package]]
+name = "data-encoding-macro-internal"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
+dependencies = [
+ "data-encoding",
  "syn",
 ]
 
@@ -1012,7 +1482,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid 0.9.6",
- "pem-rfc7468",
+ "pem-rfc7468 0.7.0",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
+dependencies = [
+ "const-oid 0.10.2",
+ "pem-rfc7468 1.0.0",
  "zeroize",
 ]
 
@@ -1029,15 +1510,15 @@ dependencies = [
 name = "desktop_core"
 version = "0.0.0"
 dependencies = [
- "aes",
- "aes-gcm",
+ "aes 0.8.4",
+ "aes-gcm 0.10.3",
  "anyhow",
  "arboard",
  "ashpd 0.13.11",
  "base64",
  "bitwarden-russh",
  "bytes",
- "cbc",
+ "cbc 0.1.2",
  "core-foundation",
  "desktop_objc",
  "dirs",
@@ -1048,12 +1529,12 @@ dependencies = [
  "oo7",
  "pin-project",
  "rand 0.9.3",
- "rsa",
+ "rsa 0.9.6",
  "scopeguard",
  "secmem-proc",
  "security-framework",
  "security-framework-sys",
- "sha2",
+ "sha2 0.10.9",
  "ssh-key",
  "sysinfo",
  "thiserror 2.0.17",
@@ -1137,6 +1618,7 @@ dependencies = [
  "const-oid 0.10.2",
  "crypto-common 0.2.2",
  "ctutils",
+ "zeroize",
 ]
 
 [[package]]
@@ -1241,12 +1723,12 @@ version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
- "der",
+ "der 0.7.10",
  "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
- "signature",
- "spki",
+ "signature 2.2.0",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -1255,8 +1737,17 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "pkcs8",
- "signature",
+ "pkcs8 0.10.2",
+ "signature 2.2.0",
+]
+
+[[package]]
+name = "ed25519"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a"
+dependencies = [
+ "signature 3.0.0",
 ]
 
 [[package]]
@@ -1265,11 +1756,25 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
- "curve25519-dalek",
- "ed25519",
+ "curve25519-dalek 4.1.3",
+ "ed25519 2.2.3",
  "serde",
- "sha2",
- "signature",
+ "sha2 0.10.9",
+ "signature 2.2.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "3.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1685663e23882cd8517dcbcb1c23a6ebff4433c22dfb681d760219b62cd1b849"
+dependencies = [
+ "curve25519-dalek 5.0.0-rc.1",
+ "ed25519 3.0.0",
+ "rand_core 0.10.1",
+ "sha2 0.11.0",
  "subtle",
  "zeroize",
 ]
@@ -1286,15 +1791,15 @@ version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
- "base16ct",
- "crypto-bigint",
+ "base16ct 0.2.0",
+ "crypto-bigint 0.5.5",
  "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
- "hkdf",
- "pem-rfc7468",
- "pkcs8",
+ "hkdf 0.12.4",
+ "pem-rfc7468 0.7.0",
+ "pkcs8 0.10.2",
  "rand_core 0.6.4",
  "sec1",
  "subtle",
@@ -1426,6 +1931,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
+name = "fiat-crypto"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1436,6 +1947,12 @@ name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -1630,6 +2147,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1639,7 +2157,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
 dependencies = [
  "opaque-debug",
- "polyval",
+ "polyval 0.6.2",
+]
+
+[[package]]
+name = "ghash"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eecf2d5dc9b66b732b97707a0210906b1d30523eb773193ab777c0c84b3e8d5"
+dependencies = [
+ "polyval 0.7.1",
 ]
 
 [[package]]
@@ -1668,6 +2195,36 @@ dependencies = [
  "ff",
  "rand_core 0.6.4",
  "subtle",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.14.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1737,6 +2294,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hkdf"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
+dependencies = [
+ "hmac 0.13.0",
+]
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1767,12 +2333,113 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
 name = "hybrid-array"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
 dependencies = [
+ "ctutils",
+ "serde",
  "typenum",
+ "zeroize",
+]
+
+[[package]]
+name = "hyper"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1937,8 +2604,18 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
- "block-padding",
+ "block-padding 0.3.3",
  "generic-array",
+]
+
+[[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "block-padding 0.4.2",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1955,6 +2632,12 @@ dependencies = [
  "widestring",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -1978,6 +2661,80 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.17",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1986,6 +2743,22 @@ dependencies = [
  "cfg-if",
  "futures-util",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "kdf"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb9652713a34bd7a2f539adcab233163943bed9c685970db62eb3cb264d625a1"
+
+[[package]]
+name = "keccak"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -2155,6 +2928,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "ml-dsa"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "add6b9d92e496f16f4526d68ff29da1483aba4b119baeab8bed3b9e3544a6f3d"
+dependencies = [
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
+ "ctutils",
+ "hybrid-array",
+ "module-lattice",
+ "pkcs8 0.11.0",
+ "shake",
+ "signature 3.0.0",
+ "zeroize",
+]
+
+[[package]]
+name = "mockall"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f58d964098a5f9c6b63d0798e5372fd04708193510a7af313c22e9f29b7b620b"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "mockall_derive 0.14.0",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
 name = "mockall"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2163,9 +2967,21 @@ dependencies = [
  "cfg-if",
  "downcast",
  "fragile",
- "mockall_derive",
+ "mockall_derive 0.15.0",
  "predicates",
  "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca41ce716dda6a9be188b385aa78ee5260fc25cd3802cb2a8afdc6afbe6b6dbf"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2178,6 +2994,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "module-lattice"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c61b87c9683ab7cb1c6871d261ad5479b6b10ceb52c4352aaca3b5d35a8febe"
+dependencies = [
+ "ctutils",
+ "hybrid-array",
+ "num-traits",
+ "zeroize",
 ]
 
 [[package]]
@@ -2511,15 +3339,15 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3299dd401feaf1d45afd8fd1c0586f10fcfb22f244bb9afa942cec73503b89d"
 dependencies = [
- "aes",
+ "aes 0.8.4",
  "ashpd 0.12.3",
- "cbc",
- "cipher",
+ "cbc 0.1.2",
+ "cipher 0.4.4",
  "digest 0.10.7",
  "endi",
  "futures-util",
  "getrandom 0.3.4",
- "hkdf",
+ "hkdf 0.12.4",
  "hmac 0.12.1",
  "md-5",
  "num",
@@ -2527,7 +3355,7 @@ dependencies = [
  "pbkdf2 0.12.2",
  "rand 0.9.3",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "tokio",
  "zbus",
@@ -2541,6 +3369,12 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "option-ext"
@@ -2577,7 +3411,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -2589,7 +3423,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -2598,12 +3432,12 @@ version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fc9e2161f1f215afdfce23677034ae137bbd45016a880c2eb3ba8eb95f085b2"
 dependencies = [
- "base16ct",
+ "base16ct 0.2.0",
  "ecdsa",
  "elliptic-curve",
  "primeorder",
  "rand_core 0.6.4",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -2633,6 +3467,15 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "password-hash"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aab41826031698d6ffcd9cff78ef56ef998e39dc7e5067cdfebe373842d4723b"
+dependencies = [
+ "phc",
 ]
 
 [[package]]
@@ -2671,6 +3514,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem-rfc7468"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2685,6 +3537,16 @@ dependencies = [
  "fixedbitset",
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
+]
+
+[[package]]
+name = "phc"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44dc769b75f93afdddd8c7fa12d685292ddeff1e66f7f0f3a234cf1818afe892"
+dependencies = [
+ "base64ct",
+ "ctutils",
 ]
 
 [[package]]
@@ -2730,9 +3592,19 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
 dependencies = [
- "der",
- "pkcs8",
- "spki",
+ "der 0.7.10",
+ "pkcs8 0.10.2",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs1"
+version = "0.8.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "986d2e952779af96ea048f160fd9194e1751b4faea78bcf3ceb456efe008088e"
+dependencies = [
+ "der 0.8.0",
+ "spki 0.8.0",
 ]
 
 [[package]]
@@ -2741,8 +3613,18 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
- "spki",
+ "der 0.7.10",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
+dependencies = [
+ "der 0.8.0",
+ "spki 0.8.0",
 ]
 
 [[package]]
@@ -2779,7 +3661,17 @@ checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
  "cpufeatures 0.2.17",
  "opaque-debug",
- "universal-hash",
+ "universal-hash 0.5.1",
+]
+
+[[package]]
+name = "poly1305"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00baa632505d05512f48a963e16051c54fda9a95cc9acea1a4e3c90991c4a2e"
+dependencies = [
+ "cpufeatures 0.3.0",
+ "universal-hash 0.6.1",
 ]
 
 [[package]]
@@ -2791,7 +3683,18 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "opaque-debug",
- "universal-hash",
+ "universal-hash 0.5.1",
+]
+
+[[package]]
+name = "polyval"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dfc63250416fea14f5749b90725916a6c903f599d51cb635aa7a52bfd03eede"
+dependencies = [
+ "cpubits",
+ "cpufeatures 0.3.0",
+ "universal-hash 0.6.1",
 ]
 
 [[package]]
@@ -2962,6 +3865,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20 0.10.1",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2997,6 +3911,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -3072,6 +4012,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime_guess",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier 0.7.0",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "reqwest-middleware"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bc3f1384cffa4f274dad2d4ddd73aed32fed8f786d96c6be8aa4e5fd3c3b58"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "http",
+ "reqwest",
+ "serde",
+ "thiserror 2.0.17",
+ "tower-service",
+]
+
+[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3079,6 +4074,20 @@ checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
  "hmac 0.12.1",
  "subtle",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3122,13 +4131,31 @@ dependencies = [
  "num-bigint-dig",
  "num-integer",
  "num-traits",
- "pkcs1",
- "pkcs8",
+ "pkcs1 0.7.5",
+ "pkcs8 0.10.2",
  "rand_core 0.6.4",
- "sha2",
- "signature",
- "spki",
+ "sha2 0.10.9",
+ "signature 2.2.0",
+ "spki 0.7.3",
  "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rsa"
+version = "0.10.0-rc.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b2aa4ba0d89f73d1e332df05be0eeab8840351c36ca5654341dfdb57bb3caf"
+dependencies = [
+ "const-oid 0.10.2",
+ "crypto-bigint 0.7.5",
+ "crypto-primes",
+ "digest 0.11.3",
+ "pkcs1 0.8.0-rc.4",
+ "pkcs8 0.11.0",
+ "rand_core 0.10.1",
+ "signature 3.0.0",
+ "spki 0.8.0",
  "zeroize",
 ]
 
@@ -3206,10 +4233,129 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni 0.21.1",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni 0.22.4",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "schemars"
@@ -3229,10 +4375,25 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
+ "chrono",
  "dyn-clone",
  "ref-cast",
+ "schemars_derive",
  "serde",
  "serde_json",
+ "uuid",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
 ]
 
 [[package]]
@@ -3267,10 +4428,10 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
- "base16ct",
- "der",
+ "base16ct 0.2.0",
+ "der 0.7.10",
  "generic-array",
- "pkcs8",
+ "pkcs8 0.10.2",
  "subtle",
  "zeroize",
 ]
@@ -3294,7 +4455,7 @@ dependencies = [
 name = "secure_memory"
 version = "0.0.0"
 dependencies = [
- "aes-gcm",
+ "aes-gcm 0.10.3",
  "linux-keyutils",
  "memsec",
  "rand 0.9.3",
@@ -3346,6 +4507,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3359,6 +4530,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3399,6 +4581,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_with"
 version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3424,10 +4618,20 @@ version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serdect"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66cf8fedced2fcf12406bcb34223dffb92eaf34908ede12fed414c82b7f00b3e"
+dependencies = [
+ "base16ct 1.0.0",
+ "serde",
 ]
 
 [[package]]
@@ -3489,6 +4693,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
+]
+
+[[package]]
+name = "shake"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09057cb2149ad4cbd2da1e26b351f9a4c354219421229c69c3063e6f61947c4a"
+dependencies = [
+ "digest 0.11.3",
+ "keccak",
+ "sponge-cursor",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3521,6 +4747,26 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "signature"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
+dependencies = [
+ "digest 0.11.3",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
 ]
 
 [[package]]
@@ -3576,8 +4822,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.10",
 ]
+
+[[package]]
+name = "spki"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
+dependencies = [
+ "base64ct",
+ "der 0.8.0",
+]
+
+[[package]]
+name = "sponge-cursor"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a0219bd7d979d58245a4f41f695e1ac9f8befdffadd7f61f1bae9e39abc6620"
 
 [[package]]
 name = "sqlite-wasm-rs"
@@ -3597,13 +4859,13 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caac132742f0d33c3af65bfcde7f6aa8f62f0e991d80db99149eb9d44708784f"
 dependencies = [
- "aes",
- "aes-gcm",
- "cbc",
- "chacha20",
- "cipher",
- "ctr",
- "poly1305",
+ "aes 0.8.4",
+ "aes-gcm 0.10.3",
+ "cbc 0.1.2",
+ "chacha20 0.9.1",
+ "cipher 0.4.4",
+ "ctr 0.9.2",
+ "poly1305 0.8.0",
  "ssh-encoding",
  "subtle",
 ]
@@ -3615,8 +4877,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9242b9ef4108a78e8cd1a2c98e193ef372437f8c22be363075233321dd4a15"
 dependencies = [
  "base64ct",
- "pem-rfc7468",
- "sha2",
+ "pem-rfc7468 0.7.0",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3626,16 +4888,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b86f5297f0f04d08cabaa0f6bff7cb6aec4d9c3b49d87990d63da9d9156a8c3"
 dependencies = [
  "bcrypt-pbkdf",
- "ed25519-dalek",
+ "ed25519-dalek 2.2.0",
  "num-bigint-dig",
  "p256",
  "p384",
  "p521",
  "rand_core 0.6.4",
- "rsa",
+ "rsa 0.9.6",
  "sec1",
- "sha2",
- "signature",
+ "sha2 0.10.9",
+ "signature 2.2.0",
  "ssh-cipher",
  "ssh-encoding",
  "subtle",
@@ -3651,14 +4913,14 @@ dependencies = [
  "base64",
  "homedir",
  "libc",
- "mockall",
+ "mockall 0.15.0",
  "rand 0.9.3",
  "rkyv",
- "rsa",
+ "rsa 0.9.6",
  "secure_memory",
  "serial_test",
- "sha2",
- "signature",
+ "sha2 0.10.9",
+ "signature 2.2.0",
  "ssh-key",
  "sysinfo",
  "thiserror 2.0.17",
@@ -3702,6 +4964,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
 ]
 
 [[package]]
@@ -3891,6 +5162,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3971,6 +5252,51 @@ name = "toml_writer"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -4055,6 +5381,12 @@ dependencies = [
  "nom 8.0.0",
  "petgraph",
 ]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
@@ -4232,6 +5564,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "universal-hash"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
+dependencies = [
+ "crypto-common 0.2.2",
+ "ctutils",
+]
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4262,6 +5610,7 @@ version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
+ "getrandom 0.4.3",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -4287,7 +5636,7 @@ checksum = "2ebfe12e38930c3b851aea35e93fab1a6c29279cad7e8e273f29a21678fee8c0"
 dependencies = [
  "core-foundation",
  "sha1 0.10.7",
- "sha2",
+ "sha2 0.10.9",
  "windows-sys 0.61.2",
 ]
 
@@ -4318,6 +5667,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4343,6 +5711,16 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -4448,6 +5826,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-sys"
+version = "0.3.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "weedle2"
 version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4488,6 +5885,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/apps/desktop/desktop_native/Cargo.toml
+++ b/apps/desktop/desktop_native/Cargo.toml
@@ -30,6 +30,9 @@ arboard = { version = "=3.6.1", default-features = false }
 ashpd = "=0.13.11"
 async-trait = "=0.1.89"
 base64 = "=0.22.1"
+bitwarden-crypto = { git = "https://github.com/bitwarden/sdk-internal", rev = "f76b51450582cff9be767c9d9f454c42a84a56c1" }
+bitwarden-random = { git = "https://github.com/bitwarden/sdk-internal", rev = "f76b51450582cff9be767c9d9f454c42a84a56c1" }
+bitwarden-sensitive-value = { git = "https://github.com/bitwarden/sdk-internal", rev = "f76b51450582cff9be767c9d9f454c42a84a56c1" }
 byteorder = "=1.5.0"
 bytes = "=1.11.1"
 cbc = "=0.1.2"
@@ -53,6 +56,9 @@ napi-derive = "=3.5.4"
 oo7 = "=0.5.0"
 pin-project = "=1.1.10"
 rand = "=0.9.3"
+# rand_core 0.10 (a distinct major from `rand` 0.9) provides the `Rng` trait needed to draw bytes
+# from `bitwarden_random::rng()`, whose RNG type is built on the 0.10 rand-core traits.
+rand_core = "=0.10.1"
 scopeguard = "=1.2.0"
 secmem-proc = "=0.3.7"
 security-framework = "=3.7.0"

--- a/apps/desktop/desktop_native/biometric/Cargo.toml
+++ b/apps/desktop/desktop_native/biometric/Cargo.toml
@@ -17,9 +17,12 @@ zbus_polkit = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 aes = { workspace = true }
+bitwarden-crypto = { workspace = true }
+bitwarden-random = { workspace = true }
+bitwarden-sensitive-value = { workspace = true }
 chacha20poly1305 = { workspace = true }
 desktop_core = { path = "../core" }
-rand = { workspace = true }
+rand_core = { workspace = true }
 scopeguard = { workspace = true }
 secure_memory = { path = "../secure_memory" }
 serde = { workspace = true, features = ["derive"] }

--- a/apps/desktop/desktop_native/biometric/src/encryption.rs
+++ b/apps/desktop/desktop_native/biometric/src/encryption.rs
@@ -1,0 +1,400 @@
+//! Cryptographic core of the Windows Hello biometric unlock.
+//!
+//! Everything here is platform-independent cryptography built on top of a Windows Hello signature.
+//! A [`Challenge`] is signed by Windows Hello to produce a deterministic signature, which is hashed
+//! into a high-entropy [`WindowsHelloPrf`]. That PRF is then used as the high-entropy secret that
+//! seals and unseals the vault user key ([`SymmetricCryptoKey`]) in a keychain entry.
+//!
+//! The Windows Hello API calls that produce the signature, and the keychain persistence of the
+//! entries defined here, live in the parent module (`windows.rs`).
+
+use aes::cipher::KeyInit;
+use anyhow::{anyhow, Result};
+use bitwarden_crypto::{
+    key_slot_ids,
+    safe::{
+        HighEntropySecret, HighEntropySecretSource, SecretProtectedKeyEnvelope,
+        SecretProtectedKeyEnvelopeNamespace,
+    },
+    BitwardenLegacyKeyBytes, KeyStore, SymmetricCryptoKey,
+};
+use bitwarden_sensitive_value::{Sensitive, SensitiveSlice};
+use chacha20poly1305::{aead::Aead, XChaCha20Poly1305, XNonce};
+use rand_core::Rng;
+use sha2::{Digest, Sha256};
+
+pub(crate) const CHALLENGE_LENGTH: usize = 16;
+pub(crate) const PSEUDORANDOM_WINDOWS_HELLO_OUTPUT_LENGTH: usize = 32;
+pub(super) const XCHACHA20POLY1305_NONCE_LENGTH: usize = 24;
+
+/// Unique content-layer namespace for biometric-protected keys.
+pub(super) const BIOMETRIC_NAMESPACE: SecretProtectedKeyEnvelopeNamespace =
+    SecretProtectedKeyEnvelopeNamespace::DesktopBiometricUnlock;
+
+// The key slots for the biometric module. Only local symmetric keys are used (the user key is
+// added via `add_local_symmetric_key`); the private and signing slots exist solely to satisfy the
+// `KeySlotIds` contract that `KeyStore` requires.
+key_slot_ids! {
+    #[symmetric]
+    pub enum BiometricSymmetricKey {
+        #[local]
+        Local(LocalId),
+    }
+
+    #[private]
+    pub enum BiometricPrivateKey {
+        #[local]
+        Local(LocalId),
+    }
+
+    #[signing]
+    pub enum BiometricSigningKey {
+        #[local]
+        Local(LocalId),
+    }
+
+    pub BiometricIds => BiometricSymmetricKey, BiometricPrivateKey, BiometricSigningKey;
+}
+
+/// A per-enrollment random challenge that is signed by Windows Hello to derive the
+/// [`WindowsHelloPrf`].
+///
+/// The challenge is stored alongside the protected key so the same PRF output can be re-derived on
+/// unlock. Because the challenge is stored in the (userspace-readable) keychain, it is not secret;
+/// the security comes from requiring a Windows Hello prompt to produce the signature.
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
+pub(super) struct Challenge([u8; CHALLENGE_LENGTH]);
+
+impl Challenge {
+    /// Generates a new random challenge.
+    pub(super) fn make() -> Self {
+        let mut bytes = [0u8; CHALLENGE_LENGTH];
+        bitwarden_random::rng().fill_bytes(&mut bytes);
+        Self(bytes)
+    }
+
+    pub(super) fn as_bytes(&self) -> &[u8; CHALLENGE_LENGTH] {
+        &self.0
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_bytes(bytes: [u8; CHALLENGE_LENGTH]) -> Self {
+        Self(bytes)
+    }
+}
+
+/// The pseudorandom output derived from Windows Hello for a given [`Challenge`]. This is used as
+/// the high-entropy secret to protect the vault unlock key.
+///
+/// The prf is a SHA-256 digest of a Windows Hello signature.
+#[derive(Clone)]
+pub(super) struct WindowsHelloPrf([u8; PSEUDORANDOM_WINDOWS_HELLO_OUTPUT_LENGTH]);
+
+impl WindowsHelloPrf {
+    pub(crate) fn as_bytes(&self) -> &[u8; PSEUDORANDOM_WINDOWS_HELLO_OUTPUT_LENGTH] {
+        &self.0
+    }
+
+    /// Derive the PRF output from a raw Windows Hello signature
+    ///
+    /// The signature is deterministic based on the challenge and keychain key, so hashing it yields
+    /// a stable key. It is unclear what entropy this key provides.
+    pub(super) fn derive_from_signature(signature: &[u8]) -> Self {
+        Self(Sha256::digest(signature).into())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_bytes(bytes: [u8; PSEUDORANDOM_WINDOWS_HELLO_OUTPUT_LENGTH]) -> Self {
+        Self(bytes)
+    }
+}
+
+impl HighEntropySecretSource for WindowsHelloPrf {
+    fn provide_high_entropy_bytes(&self) -> SensitiveSlice<'_> {
+        Sensitive::from(self.0.as_slice())
+    }
+}
+
+/// V1 keychain entry: the user key is wrapped directly with XChaCha20Poly1305 using the
+/// Windows Hello-derived PRF as a key.
+#[derive(serde::Serialize, serde::Deserialize)]
+pub(super) struct WindowsHelloKeychainEntryV1 {
+    pub(super) nonce: [u8; XCHACHA20POLY1305_NONCE_LENGTH],
+    pub(super) challenge: Challenge,
+    pub(super) wrapped_key: Vec<u8>,
+}
+
+/// V2 keychain entry: the user key is sealed in a [`SecretProtectedKeyEnvelope`]. The `challenge`
+/// is still stored because it is the input used to re-derive the Windows Hello PRF.
+#[derive(serde::Serialize, serde::Deserialize)]
+pub(super) struct WindowsHelloKeychainEntryV2 {
+    pub(super) challenge: Challenge,
+    pub(super) envelope: SecretProtectedKeyEnvelope,
+}
+
+#[derive(serde::Deserialize)]
+#[serde(untagged)]
+#[allow(clippy::large_enum_variant)]
+pub(super) enum WindowsHelloKeychainEntry {
+    // The two formats have disjoint required fields (`envelope` vs `nonce` + `wrapped_key`), so
+    // untagged deserialization unambiguously deserializes to the correct variant.
+    V2(WindowsHelloKeychainEntryV2),
+    V1(WindowsHelloKeychainEntryV1),
+}
+
+impl WindowsHelloKeychainEntryV2 {
+    /// Seal `user_key` into a new keychain entry with `challenge`.
+    pub(super) fn seal(
+        challenge: Challenge,
+        windows_hello_key: &WindowsHelloPrf,
+        user_key: &SymmetricCryptoKey,
+    ) -> Result<Self> {
+        let secret = HighEntropySecret::from(windows_hello_key.clone());
+
+        let store = KeyStore::<BiometricIds>::default();
+        let mut ctx = store.context_mut();
+        let key_id = ctx.add_local_symmetric_key(user_key.clone());
+        let envelope = SecretProtectedKeyEnvelope::seal(key_id, &secret, BIOMETRIC_NAMESPACE, &ctx)
+            .map_err(|e| anyhow!("Failed to seal user key: {e}"))?;
+
+        Ok(Self {
+            challenge,
+            envelope,
+        })
+    }
+
+    /// Unseal the user key from the entry
+    pub(super) fn unseal(&self, windows_hello_key: &WindowsHelloPrf) -> Result<SymmetricCryptoKey> {
+        let secret = HighEntropySecret::from(windows_hello_key.clone());
+
+        let store = KeyStore::<BiometricIds>::default();
+        let mut ctx = store.context_mut();
+        let key_id = self
+            .envelope
+            .unseal(&secret, BIOMETRIC_NAMESPACE, &mut ctx)
+            .map_err(|e| anyhow!("Failed to unseal user key: {e}"))?;
+        #[allow(deprecated)]
+        let user_key = ctx
+            .dangerous_get_symmetric_key(key_id)
+            .map_err(|e| anyhow!("Failed to read unsealed user key: {e}"))?;
+        Ok(user_key.clone())
+    }
+}
+
+impl WindowsHelloKeychainEntryV1 {
+    /// Seal `user_key` by wrapping its encoded bytes with XChaCha20Poly1305 under the Windows
+    /// Hello-derived key. Only used by tests to produce legacy entries; the production code path
+    /// seals into the [`WindowsHelloKeychainEntryV2`] envelope format.
+    #[cfg(test)]
+    pub(super) fn seal(
+        challenge: Challenge,
+        windows_hello_key: &WindowsHelloPrf,
+        user_key: &SymmetricCryptoKey,
+    ) -> Result<Self> {
+        let cipher = XChaCha20Poly1305::new(windows_hello_key.as_bytes().into());
+        let mut nonce = [0u8; XCHACHA20POLY1305_NONCE_LENGTH];
+        bitwarden_random::rng().fill_bytes(&mut nonce);
+        let wrapped_key = cipher
+            .encrypt(
+                XNonce::from_slice(&nonce),
+                user_key.to_encoded().to_vec().as_slice(),
+            )
+            .map_err(|e| anyhow!(e))?;
+        Ok(Self {
+            nonce,
+            challenge,
+            wrapped_key,
+        })
+    }
+
+    /// Unseal the user key
+    pub(super) fn unseal(&self, windows_hello_key: &WindowsHelloPrf) -> Result<SymmetricCryptoKey> {
+        let cipher = XChaCha20Poly1305::new(windows_hello_key.as_bytes().into());
+        let decrypted = cipher
+            .decrypt(XNonce::from_slice(&self.nonce), self.wrapped_key.as_slice())
+            .map_err(|e| anyhow!(e))?;
+        SymmetricCryptoKey::try_from(&BitwardenLegacyKeyBytes::from(decrypted))
+            .map_err(|e| anyhow!("Failed to parse user key: {e}"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use aes::cipher::KeyInit;
+    use bitwarden_crypto::{BitwardenLegacyKeyBytes, SymmetricCryptoKey, SymmetricKeyAlgorithm};
+    use chacha20poly1305::{aead::Aead, XChaCha20Poly1305, XNonce};
+
+    use super::{
+        Challenge, WindowsHelloKeychainEntry, WindowsHelloKeychainEntryV1,
+        WindowsHelloKeychainEntryV2, WindowsHelloPrf, CHALLENGE_LENGTH,
+        PSEUDORANDOM_WINDOWS_HELLO_OUTPUT_LENGTH, XCHACHA20POLY1305_NONCE_LENGTH,
+    };
+
+    fn user_key(encoded: &[u8]) -> SymmetricCryptoKey {
+        SymmetricCryptoKey::try_from(&BitwardenLegacyKeyBytes::from(encoded.to_vec())).unwrap()
+    }
+
+    // Fixed, deterministic inputs used to produce and verify the test vector below. The Windows
+    // Hello key stands in for the PRF that Windows Hello would derive from the challenge; the test
+    // never calls Windows, it re-derives the sealing secret directly from these bytes.
+    const TEST_VECTOR_WINDOWS_HELLO_KEY: [u8; PSEUDORANDOM_WINDOWS_HELLO_OUTPUT_LENGTH] =
+        [42u8; PSEUDORANDOM_WINDOWS_HELLO_OUTPUT_LENGTH];
+    const TEST_VECTOR_CHALLENGE: [u8; CHALLENGE_LENGTH] =
+        [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
+    // A valid 64-byte (AES-CBC-HMAC) encoded user key
+    const TEST_VECTOR_USER_KEY: &[u8] = &[9u8; 64];
+
+    // A `WindowsHelloKeychainEntryV2` (challenge + `SecretProtectedKeyEnvelope`), serialized
+    // exactly as it is persisted to the OS keychain. Sealing with
+    // `TEST_VECTOR_WINDOWS_HELLO_KEY` must keep unsealing to `TEST_VECTOR_USER_KEY`; if this
+    // stops decoding, the persisted format broke.
+    const TEST_VECTOR_ENTRY_V2_JSON: &str = r#"{"challenge":[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15],"envelope":"hFg0pAEDA3giYXBwbGljYXRpb24veC5iaXR3YXJkZW4ubGVnYWN5LWtleToAATiBBjoAATiAAqEFTJX+FbmsYy42SWrfHFhQI16UOuY0GTZtLbTetv+Wqj6lVecK8DtCRcyn/e1ULGKaf13Q9tXSrg4rJl4v8GKIJv361FCsgOZ8kxzN7qUDFAUIGYEEW2hDG7kWOVkD56GBg0CiASkzWCAqKJNBFc+VbkGF4V0sv5HXgCn4CcMpw8/UGHyrvP95v/Y="}"#;
+
+    // Fixed nonce used to wrap the V1 test vector below. V1 seals with a random nonce, but the
+    // recorded vector pins one so the ciphertext is reproducible.
+    const TEST_VECTOR_NONCE: [u8; XCHACHA20POLY1305_NONCE_LENGTH] = [
+        100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117,
+        118, 119, 120, 121, 122, 123,
+    ];
+
+    // A `WindowsHelloKeychainEntryV1` (nonce + challenge + XChaCha20Poly1305-wrapped user key),
+    // serialized exactly as legacy enrollments are persisted to the OS keychain. Unsealing with
+    // `TEST_VECTOR_WINDOWS_HELLO_KEY` must keep yielding `TEST_VECTOR_USER_KEY`; if this stops
+    // decoding, backward compatibility for pre-envelope enrollments broke.
+    const TEST_VECTOR_ENTRY_V1_JSON: &str = r#"{"nonce":[100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123],"challenge":[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15],"wrapped_key":[81,218,92,229,12,119,8,54,163,227,74,91,121,250,150,67,17,18,87,203,171,52,240,148,22,32,186,221,13,62,88,100,76,134,2,161,8,214,206,255,148,98,112,209,165,238,212,69,206,211,254,102,160,138,69,28,192,20,15,244,244,187,68,159,162,81,235,10,88,16,242,93,161,225,231,48,172,242,125,176]}"#;
+
+    /// Regenerates the constants above. Ignored so it never runs in CI; run manually with
+    /// `--ignored --nocapture` and paste the printed constant back into the source.
+    #[test]
+    #[ignore = "Generates test vectors; run manually"]
+    #[allow(clippy::print_stdout)]
+    fn generate_test_vectors() {
+        let windows_hello_key = WindowsHelloPrf::from_bytes(TEST_VECTOR_WINDOWS_HELLO_KEY);
+
+        let v2 = WindowsHelloKeychainEntryV2::seal(
+            Challenge::from_bytes(TEST_VECTOR_CHALLENGE),
+            &windows_hello_key,
+            &user_key(TEST_VECTOR_USER_KEY),
+        )
+        .unwrap();
+
+        // Round-trip once here to confirm the generated vector is itself valid.
+        let unsealed = v2.unseal(&windows_hello_key).unwrap();
+        assert_eq!(unsealed.to_encoded().to_vec(), TEST_VECTOR_USER_KEY);
+
+        println!(
+            "const TEST_VECTOR_ENTRY_V2_JSON: &str = r#\"{}\"#;",
+            serde_json::to_string(&v2).unwrap()
+        );
+
+        // V1 wraps the user key directly with XChaCha20Poly1305. `seal` picks a random nonce, so
+        // build the entry with the pinned `TEST_VECTOR_NONCE` to keep the recorded vector stable.
+        let cipher = XChaCha20Poly1305::new(windows_hello_key.as_bytes().into());
+        let wrapped_key = cipher
+            .encrypt(
+                XNonce::from_slice(&TEST_VECTOR_NONCE),
+                user_key(TEST_VECTOR_USER_KEY)
+                    .to_encoded()
+                    .to_vec()
+                    .as_slice(),
+            )
+            .unwrap();
+        let v1 = WindowsHelloKeychainEntryV1 {
+            nonce: TEST_VECTOR_NONCE,
+            challenge: Challenge::from_bytes(TEST_VECTOR_CHALLENGE),
+            wrapped_key,
+        };
+
+        let unsealed = v1.unseal(&windows_hello_key).unwrap();
+        assert_eq!(unsealed.to_encoded().to_vec(), TEST_VECTOR_USER_KEY);
+
+        println!(
+            "const TEST_VECTOR_ENTRY_V1_JSON: &str = r#\"{}\"#;",
+            serde_json::to_string(&v1).unwrap()
+        );
+    }
+
+    /// Never regenerate the test vector, it would be a breaking change
+    #[test]
+    fn test_keychain_entry_v2_test_vector() {
+        let windows_hello_key = WindowsHelloPrf::from_bytes(TEST_VECTOR_WINDOWS_HELLO_KEY);
+
+        let entry: WindowsHelloKeychainEntry =
+            serde_json::from_str(TEST_VECTOR_ENTRY_V2_JSON).unwrap();
+        let WindowsHelloKeychainEntry::V2(entry) = entry else {
+            panic!("Test vector must decode as a V2 keychain entry");
+        };
+
+        let unsealed = entry.unseal(&windows_hello_key).unwrap();
+        assert_eq!(unsealed.to_encoded().to_vec(), TEST_VECTOR_USER_KEY);
+    }
+
+    /// Never regenerate the test vector, it would be a breaking change
+    #[test]
+    fn test_keychain_entry_v1_test_vector() {
+        let windows_hello_key = WindowsHelloPrf::from_bytes(TEST_VECTOR_WINDOWS_HELLO_KEY);
+
+        let entry: WindowsHelloKeychainEntry =
+            serde_json::from_str(TEST_VECTOR_ENTRY_V1_JSON).unwrap();
+        let WindowsHelloKeychainEntry::V1(entry) = entry else {
+            panic!("Test vector must decode as a V1 keychain entry");
+        };
+
+        let unsealed = entry.unseal(&windows_hello_key).unwrap();
+        assert_eq!(unsealed.to_encoded().to_vec(), TEST_VECTOR_USER_KEY);
+    }
+
+    #[test]
+    fn test_v2_seal_unseal_roundtrip() {
+        let windows_hello_key =
+            WindowsHelloPrf::from_bytes([42u8; PSEUDORANDOM_WINDOWS_HELLO_OUTPUT_LENGTH]);
+
+        // Cover both a legacy AES-CBC-HMAC user key and a modern (COSE) XChaCha20Poly1305 key.
+        for key in [
+            SymmetricCryptoKey::make(SymmetricKeyAlgorithm::Aes256CbcHmac),
+            SymmetricCryptoKey::make(SymmetricKeyAlgorithm::Aes256Gcm),
+        ] {
+            let entry = WindowsHelloKeychainEntryV2::seal(
+                Challenge::from_bytes([0u8; CHALLENGE_LENGTH]),
+                &windows_hello_key,
+                &key,
+            )
+            .unwrap();
+            let unsealed = entry.unseal(&windows_hello_key).unwrap();
+            assert_eq!(unsealed.to_encoded().to_vec(), key.to_encoded().to_vec());
+        }
+    }
+
+    #[test]
+    fn test_v1_seal_unseal_roundtrip() {
+        let windows_hello_key =
+            WindowsHelloPrf::from_bytes([42u8; PSEUDORANDOM_WINDOWS_HELLO_OUTPUT_LENGTH]);
+
+        for encoded in [vec![7u8; 32], vec![9u8; 64]] {
+            let entry = WindowsHelloKeychainEntryV1::seal(
+                Challenge::from_bytes([0u8; CHALLENGE_LENGTH]),
+                &windows_hello_key,
+                &user_key(&encoded),
+            )
+            .unwrap();
+            let unsealed = entry.unseal(&windows_hello_key).unwrap();
+            assert_eq!(unsealed.to_encoded().to_vec(), encoded);
+        }
+    }
+
+    #[test]
+    fn test_unseal_with_wrong_secret_fails() {
+        let entry = WindowsHelloKeychainEntryV2::seal(
+            Challenge::from_bytes([0u8; CHALLENGE_LENGTH]),
+            &WindowsHelloPrf::from_bytes([42u8; PSEUDORANDOM_WINDOWS_HELLO_OUTPUT_LENGTH]),
+            &user_key(&[9u8; 64]),
+        )
+        .unwrap();
+        // A different Windows Hello key must not unseal the envelope.
+        assert!(entry
+            .unseal(&WindowsHelloPrf::from_bytes(
+                [7u8; PSEUDORANDOM_WINDOWS_HELLO_OUTPUT_LENGTH]
+            ))
+            .is_err());
+    }
+}

--- a/apps/desktop/desktop_native/biometric/src/windows.rs
+++ b/apps/desktop/desktop_native/biometric/src/windows.rs
@@ -186,12 +186,13 @@ impl super::BiometricTrait for BiometricLockSystem {
             }
         });
 
-        let mut secure_memory = self.secure_memory.lock().await;
         // If the key is held ephemerally, always use UV API. Only use signing API if the key is not
         // held ephemerally but the keychain holds it persistently.
-        if secure_memory.has(user_id) {
+        if self.secure_memory.lock().await.has(user_id) {
             if windows_hello_authenticate("Unlock your vault".to_string()).await? {
-                secure_memory
+                self.secure_memory
+                    .lock()
+                    .await
                     .get(user_id)?
                     .ok_or_else(|| anyhow!("No key found for user"))
             } else {
@@ -239,15 +240,17 @@ impl super::BiometricTrait for BiometricLockSystem {
             let decrypted_key = user_key.to_encoded().to_vec();
             // The first unlock already sets the key for subsequent unlocks. The key may again be
             // set externally after unlock finishes.
-            secure_memory.put(user_id.to_string(), &decrypted_key);
+            self.secure_memory
+                .lock()
+                .await
+                .put(user_id.to_string(), &decrypted_key);
             Ok(decrypted_key)
         }
     }
 
     async fn unlock_available(&self, user_id: &String) -> Result<bool> {
-        let secure_memory = self.secure_memory.lock().await;
-        let has_key =
-            secure_memory.has(user_id) || self.has_persistent(user_id).await.unwrap_or(false);
+        let has_key = self.secure_memory.lock().await.has(user_id)
+            || self.has_persistent(user_id).await.unwrap_or(false);
         Ok(has_key && self.authenticate_available().await.unwrap_or(false))
     }
 

--- a/apps/desktop/desktop_native/biometric/src/windows.rs
+++ b/apps/desktop/desktop_native/biometric/src/windows.rs
@@ -34,12 +34,12 @@ use std::{
     time::{Duration, Instant},
 };
 
-use aes::cipher::KeyInit;
+mod encryption;
+
 use anyhow::{anyhow, Result};
-use chacha20poly1305::{aead::Aead, XChaCha20Poly1305, XNonce};
+use bitwarden_crypto::{BitwardenLegacyKeyBytes, SymmetricCryptoKey};
 use desktop_core::password::{self, PASSWORD_NOT_FOUND};
 use secure_memory::*;
-use sha2::{Digest, Sha256};
 use tokio::sync::Mutex;
 use tracing::{debug, warn};
 use windows::{
@@ -61,21 +61,14 @@ use windows::{
 };
 use windows_future::IAsyncOperation;
 
+use self::encryption::{
+    Challenge, WindowsHelloKeychainEntry, WindowsHelloKeychainEntryV2, WindowsHelloPrf,
+};
 use super::windows_focus::{focus_security_prompt, restore_focus};
 
 const AUTHENTICATE_AVAILABLE_CACHE_TTL: Duration = Duration::from_secs(30);
 const KEYCHAIN_SERVICE_NAME: &str = "BitwardenBiometricsV2";
 const CREDENTIAL_NAME: &HSTRING = h!("BitwardenBiometricsV2");
-const CHALLENGE_LENGTH: usize = 16;
-const XCHACHA20POLY1305_NONCE_LENGTH: usize = 24;
-const XCHACHA20POLY1305_KEY_LENGTH: usize = 32;
-
-#[derive(serde::Serialize, serde::Deserialize)]
-struct WindowsHelloKeychainEntry {
-    nonce: [u8; XCHACHA20POLY1305_NONCE_LENGTH],
-    challenge: [u8; CHALLENGE_LENGTH],
-    wrapped_key: Vec<u8>,
-}
 
 /// The Windows OS implementation of the biometric trait.
 pub struct BiometricLockSystem {
@@ -151,28 +144,23 @@ impl super::BiometricTrait for BiometricLockSystem {
 
     async fn enroll_persistent(&self, user_id: &str, key: &[u8]) -> Result<()> {
         // Enrollment works by first generating a random challenge unique to the user / enrollment.
-        // Then, with the challenge and a Windows-Hello prompt, the "windows hello key" is
-        // derived. The windows hello key is used to encrypt the key to store with
-        // XChaCha20Poly1305. The bundle of nonce, challenge and wrapped-key are stored to
-        // the keychain
+        // Then, with the challenge and a Windows-Hello prompt, the "windows hello prf" is derived.
+        // The windows hello prf is used as the high-entropy secret to seal the user key into a
+        // `SecretProtectedKeyEnvelope`. The bundle of challenge and serialized envelope are stored
+        // to the keychain.
 
-        // Each enrollment (per user) has a unique challenge, so that the windows-hello key is
+        let user_key = SymmetricCryptoKey::try_from(&BitwardenLegacyKeyBytes::from(key.to_vec()))
+            .map_err(|e| anyhow!("Failed to parse user key: {e}"))?;
+
+        // Each enrollment (per user) has a unique challenge, so that the windows-hello prf is
         // unique
-        let challenge: [u8; CHALLENGE_LENGTH] = rand::random();
+        let challenge = Challenge::make();
 
-        // This key is unique to the challenge
+        // This prf is unique to the challenge
         let windows_hello_key = windows_hello_authenticate_with_crypto(&challenge).await?;
-        let (wrapped_key, nonce) = encrypt_data(&windows_hello_key, key)?;
+        let entry = WindowsHelloKeychainEntryV2::seal(challenge, &windows_hello_key, &user_key)?;
 
-        set_keychain_entry(
-            user_id,
-            &WindowsHelloKeychainEntry {
-                nonce,
-                challenge,
-                wrapped_key,
-            },
-        )
-        .await?;
+        set_keychain_entry(user_id, &entry).await?;
 
         self.has_keychain_entry_cache
             .lock()
@@ -210,17 +198,48 @@ impl super::BiometricTrait for BiometricLockSystem {
                 Err(anyhow!("Authentication failed"))
             }
         } else {
-            let keychain_entry = get_keychain_entry(user_id).await?;
-            let windows_hello_key =
-                windows_hello_authenticate_with_crypto(&keychain_entry.challenge).await?;
-            let decrypted_key = decrypt_data(
-                &windows_hello_key,
-                &keychain_entry.wrapped_key,
-                &keychain_entry.nonce,
-            )?;
+            // Re-derive the PRF via Windows Hello and unseal the persisted user key. Legacy (V1)
+            // entries are migrated on unlock to the V2 format.
+            let user_key = match get_keychain_entry(user_id).await? {
+                WindowsHelloKeychainEntry::V2(entry) => {
+                    let windows_hello_key =
+                        windows_hello_authenticate_with_crypto(&entry.challenge).await?;
+                    entry.unseal(&windows_hello_key)?
+                }
+                WindowsHelloKeychainEntry::V1(entry) => {
+                    let windows_hello_key =
+                        windows_hello_authenticate_with_crypto(&entry.challenge).await?;
+                    let user_key = entry.unseal(&windows_hello_key)?;
+
+                    // Lazily migrate the legacy entry to the envelope format. The same challenge is
+                    // reused, so no additional Windows Hello prompt is required. A migration
+                    // failure must not fail the unlock - the key was already
+                    // recovered above.
+                    match WindowsHelloKeychainEntryV2::seal(
+                        entry.challenge,
+                        &windows_hello_key,
+                        &user_key,
+                    ) {
+                        Ok(migrated_entry) => {
+                            if let Err(e) = set_keychain_entry(user_id, &migrated_entry).await {
+                                warn!(
+                                    "[Windows Hello] Failed to persist migrated keychain entry: {e}"
+                                );
+                            }
+                        }
+                        Err(e) => {
+                            warn!("[Windows Hello] Failed to re-seal keychain entry during migration: {e}");
+                        }
+                    }
+
+                    user_key
+                }
+            };
+
+            let decrypted_key = user_key.to_encoded().to_vec();
             // The first unlock already sets the key for subsequent unlocks. The key may again be
             // set externally after unlock finishes.
-            secure_memory.put(user_id.to_string(), &decrypted_key.clone());
+            secure_memory.put(user_id.to_string(), &decrypted_key);
             Ok(decrypted_key)
         }
     }
@@ -269,19 +288,17 @@ async fn windows_hello_authenticate(message: String) -> Result<bool> {
     }
 }
 
-/// Derive the symmetric encryption key from the Windows Hello signature.
+/// Derive the [`WindowsHelloPrf`] from the Windows Hello signature.
 ///
-/// This works by signing a static challenge string with Windows Hello protected key store. The
-/// signed challenge is then hashed using SHA-256 and used as the symmetric encryption key for the
-/// Windows Hello protected keys.
+/// This works by signing the challenge with the Windows Hello protected key store. The signed
+/// challenge is then hashed into a high-entropy PRF that seals/unseals the Windows Hello protected
+/// keys.
 ///
 /// Windows will only sign the challenge if the user has successfully authenticated with Windows,
 /// ensuring user presence.
 ///
 /// Note: This API has inconsistent focusing behavior when called from another window
-async fn windows_hello_authenticate_with_crypto(
-    challenge: &[u8; CHALLENGE_LENGTH],
-) -> Result<[u8; XCHACHA20POLY1305_KEY_LENGTH]> {
+async fn windows_hello_authenticate_with_crypto(challenge: &Challenge) -> Result<WindowsHelloPrf> {
     debug!("[Windows Hello] Authenticating to sign challenge");
 
     // Ugly hack: We need to focus the window via window focusing APIs until Microsoft releases a
@@ -321,7 +338,7 @@ async fn windows_hello_authenticate_with_crypto(
 
     let signature = {
         let sign_operation = credential.RequestSignAsync(
-            &CryptographicBuffer::CreateFromByteArray(challenge.as_slice())?,
+            &CryptographicBuffer::CreateFromByteArray(challenge.as_bytes().as_slice())?,
         )?;
 
         // We need to drop the credential here to avoid holding it across an await point.
@@ -336,13 +353,10 @@ async fn windows_hello_authenticate_with_crypto(
     let mut signature_buffer = signature.Result()?;
     let signature_value = unsafe { as_mut_bytes(&mut signature_buffer)? };
 
-    // The signature is deterministic based on the challenge and keychain key. Thus, it can be
-    // hashed to a key. It is unclear what entropy this key provides.
-    let windows_hello_key = Sha256::digest(signature_value).into();
-    Ok(windows_hello_key)
+    Ok(WindowsHelloPrf::derive_from_signature(signature_value))
 }
 
-async fn set_keychain_entry(user_id: &str, entry: &WindowsHelloKeychainEntry) -> Result<()> {
+async fn set_keychain_entry(user_id: &str, entry: &WindowsHelloKeychainEntryV2) -> Result<()> {
     password::set_password(
         KEYCHAIN_SERVICE_NAME,
         user_id,
@@ -389,33 +403,6 @@ async fn has_keychain_entry(user_id: &str) -> Result<bool> {
         })
 }
 
-/// Encrypt data with XChaCha20Poly1305
-fn encrypt_data(
-    key: &[u8; XCHACHA20POLY1305_KEY_LENGTH],
-    plaintext: &[u8],
-) -> Result<(Vec<u8>, [u8; XCHACHA20POLY1305_NONCE_LENGTH])> {
-    let cipher = XChaCha20Poly1305::new(key.into());
-    let mut nonce = [0u8; XCHACHA20POLY1305_NONCE_LENGTH];
-    rand::fill(&mut nonce);
-    let ciphertext = cipher
-        .encrypt(XNonce::from_slice(&nonce), plaintext)
-        .map_err(|e| anyhow!(e))?;
-    Ok((ciphertext, nonce))
-}
-
-/// Decrypt data with XChaCha20Poly1305
-fn decrypt_data(
-    key: &[u8; XCHACHA20POLY1305_KEY_LENGTH],
-    ciphertext: &[u8],
-    nonce: &[u8; XCHACHA20POLY1305_NONCE_LENGTH],
-) -> Result<Vec<u8>> {
-    let cipher = XChaCha20Poly1305::new(key.into());
-    let plaintext = cipher
-        .decrypt(XNonce::from_slice(nonce), ciphertext)
-        .map_err(|e| anyhow!(e))?;
-    Ok(plaintext)
-}
-
 unsafe fn as_mut_bytes(buffer: &mut IBuffer) -> Result<&mut [u8]> {
     let interop = buffer.cast::<IBufferByteAccess>()?;
 
@@ -431,22 +418,18 @@ unsafe fn as_mut_bytes(buffer: &mut IBuffer) -> Result<&mut [u8]> {
 #[cfg(test)]
 #[allow(clippy::print_stdout)]
 mod tests {
-    use crate::{
-        biometric::{
-            decrypt_data, encrypt_data, has_keychain_entry, windows_hello_authenticate,
-            windows_hello_authenticate_with_crypto, CHALLENGE_LENGTH, XCHACHA20POLY1305_KEY_LENGTH,
-        },
-        BiometricLockSystem, BiometricTrait,
-    };
+    use bitwarden_crypto::{BitwardenLegacyKeyBytes, SymmetricCryptoKey};
+    use rand_core::Rng;
 
-    #[test]
-    fn test_encrypt_decrypt() {
-        let key = [0u8; 32];
-        let plaintext = b"Test data";
-        let (ciphertext, nonce) = encrypt_data(&key, plaintext).unwrap();
-        let decrypted = decrypt_data(&key, &ciphertext, &nonce).unwrap();
-        assert_eq!(plaintext.to_vec(), decrypted);
-    }
+    use super::{
+        encryption::{
+            Challenge, WindowsHelloKeychainEntry, WindowsHelloKeychainEntryV1, CHALLENGE_LENGTH,
+            PSEUDORANDOM_WINDOWS_HELLO_OUTPUT_LENGTH,
+        },
+        get_keychain_entry, has_keychain_entry, windows_hello_authenticate,
+        windows_hello_authenticate_with_crypto, BiometricLockSystem, KEYCHAIN_SERVICE_NAME,
+    };
+    use crate::BiometricTrait;
 
     #[tokio::test]
     async fn test_has_keychain_entry_no_entry() {
@@ -460,13 +443,13 @@ mod tests {
     #[tokio::test]
     #[ignore]
     async fn test_windows_hello_authenticate_with_crypto_manual() {
-        let challenge = [0u8; CHALLENGE_LENGTH];
+        let challenge = Challenge::from_bytes([0u8; CHALLENGE_LENGTH]);
         let windows_hello_key = windows_hello_authenticate_with_crypto(&challenge)
             .await
             .unwrap();
         println!(
-            "Windows hello key {:?} for challenge {:?}",
-            windows_hello_key, challenge
+            "Windows hello key {:?} for challenge",
+            windows_hello_key.as_bytes()
         );
     }
 
@@ -484,8 +467,8 @@ mod tests {
     #[ignore]
     async fn test_double_unenroll() {
         let user_id = String::from("test_user");
-        let mut key = [0u8; XCHACHA20POLY1305_KEY_LENGTH];
-        rand::fill(&mut key);
+        let mut key = [0u8; PSEUDORANDOM_WINDOWS_HELLO_OUTPUT_LENGTH];
+        bitwarden_random::rng().fill_bytes(&mut key);
 
         let windows_hello_lock_system = BiometricLockSystem::new();
 
@@ -527,8 +510,8 @@ mod tests {
     #[ignore]
     async fn test_enroll_unlock_unenroll() {
         let user_id = String::from("test_user");
-        let mut key = [0u8; XCHACHA20POLY1305_KEY_LENGTH];
-        rand::fill(&mut key);
+        let mut key = [0u8; PSEUDORANDOM_WINDOWS_HELLO_OUTPUT_LENGTH];
+        bitwarden_random::rng().fill_bytes(&mut key);
 
         let windows_hello_lock_system = BiometricLockSystem::new();
 
@@ -555,5 +538,48 @@ mod tests {
             .has_persistent(&user_id)
             .await
             .unwrap());
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn test_legacy_entry_migrates_on_unlock() {
+        let user_id = String::from("test_user");
+        let mut key = [0u8; PSEUDORANDOM_WINDOWS_HELLO_OUTPUT_LENGTH];
+        bitwarden_random::rng().fill_bytes(&mut key);
+
+        let windows_hello_lock_system = BiometricLockSystem::new();
+
+        // Write a legacy (pre-envelope) keychain entry directly, simulating a user enrolled with an
+        // older build.
+        let mut challenge_bytes = [0u8; CHALLENGE_LENGTH];
+        bitwarden_random::rng().fill_bytes(&mut challenge_bytes);
+        let challenge = Challenge::from_bytes(challenge_bytes);
+        let windows_hello_key = windows_hello_authenticate_with_crypto(&challenge)
+            .await
+            .unwrap();
+        let user_key =
+            SymmetricCryptoKey::try_from(&BitwardenLegacyKeyBytes::from(key.to_vec())).unwrap();
+        let legacy =
+            WindowsHelloKeychainEntryV1::seal(challenge, &windows_hello_key, &user_key).unwrap();
+        desktop_core::password::set_password(
+            KEYCHAIN_SERVICE_NAME,
+            &user_id,
+            &serde_json::to_string(&legacy).unwrap(),
+        )
+        .await
+        .unwrap();
+
+        println!("Unlocking user (should decrypt legacy entry and migrate)");
+        let key_after_unlock = windows_hello_lock_system
+            .unlock(&user_id, Vec::new())
+            .await
+            .unwrap();
+        assert_eq!(key_after_unlock, key);
+
+        // The entry should now be stored in the envelope (V2) format.
+        let migrated = get_keychain_entry(&user_id).await.unwrap();
+        assert!(matches!(migrated, WindowsHelloKeychainEntry::V2(_)));
+
+        windows_hello_lock_system.unenroll(&user_id).await.unwrap();
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://github.com/bitwarden/sdk-internal/pull/1204
https://bitwarden.atlassian.net/browse/PM-35105

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Splits up the windows-hello biometric unlock.

Most of the diff here is cargo lock. Moves the encryption into a separate file and adds a new format based on SDK cryptography. 

Overview of crypto: We store a per-enrollement challenge. This is used via keycredentialmanager to sign the challenge deterministically. The signature is hashed to produce a high-entropy-secret "PRF". This is fed into the secretkeyenvelope seal / unseal. The secretkeyenvelope directly contains the user's user key.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. 

## QA
Tested in a windows VM, but needs QA testing before merge.
