### PR TITLE
Restructure environment$ to be resilient to logout race condition

### DIFF
--- a/libs/common/src/platform/services/default-environment.service.spec.ts
+++ b/libs/common/src/platform/services/default-environment.service.spec.ts
@@ -136,47 +136,171 @@ describe("EnvironmentService", () => {
       },
     );
 
-    describe("logout race condition: USER_ENVIRONMENT_KEY cleared before activeAccountId$ switches to null", () => {
-      // The race: background clears USER_ENVIRONMENT_KEY ("logout" state event) before
-      // the popup's activeAccountId$ receives the null emission from accountService.clean().
-      // If the USER_ENVIRONMENT_KEY clear propagates first, environment$ watches USER state while
-      // setEnvironment() writes only to GLOBAL, causing the selector to fall back to the default (US) immediately.
+    describe("strict source-of-truth invariants", () => {
+      // Invariant 1: while a user is logged in (activeAccount$ has an id), environment$ MUST
+      // emit only from USER_ENVIRONMENT_KEY for that user. Global state must never be served.
+      //
+      // Invariant 2: while no user is logged in (activeAccount$ is null), environment$ MUST
+      // emit only from GLOBAL_ENVIRONMENT_KEY. A previously-active user's environment must
+      // never leak across the logout boundary.
 
-      it("falls back to global when user environment state is cleared mid-logout", async () => {
-        setGlobalData(Region.EU, new EnvironmentUrls());
-        setUserData(Region.EU, new EnvironmentUrls());
-        await switchUser(testUser);
-
-        // Storage event arrives: USER_ENVIRONMENT_KEY = null (logout cleared it)
-        // but activeAccountId$ still emits testUser (account not yet cleaned up)
-        stateProvider.singleUser.getFake(testUser, USER_ENVIRONMENT_KEY).nextState(null);
-        await awaitAsync();
-
-        const env = await firstValueFrom(sut.environment$);
-        // Without fix: null USER state → buildEnvironment(null, null) → US (default)
-        // With fix: falls back to GLOBAL → EU
-        expect(env.getRegion()).toBe(Region.EU);
-      });
-
-      it("reflects setEnvironment call when user environment state is null mid-logout", async () => {
-        // GLOBAL is US (never explicitly set to EU on this context)
-        // USER was EU (seeded at login time)
+      it("does not serve global environment while a user is logged in", async () => {
+        // user state = EU, global state = US. While logged in, must serve EU regardless of global.
         setGlobalData(Region.US, new EnvironmentUrls());
         setUserData(Region.EU, new EnvironmentUrls());
         await switchUser(testUser);
 
-        // Race: USER_ENVIRONMENT_KEY clear arrives before activeAccountId$ → null
-        stateProvider.singleUser.getFake(testUser, USER_ENVIRONMENT_KEY).nextState(null);
-        await awaitAsync();
+        const env = await firstValueFrom(sut.environment$);
+        expect(env.getRegion()).toBe(Region.EU);
+      });
 
-        // User clicks EU in the environment selector → setEnvironment(EU) → writes GLOBAL
-        // Without fix: environment$ watches USER state (which is null and defaults to US) and ignores GLOBAL write and the value stays US
-        // With fix: environment$ falls back to GLOBAL, so setEnvironment(EU) updates GLOBAL and emits EU
-        await sut.setEnvironment(Region.EU);
+      it("ignores changes to global state while a user is logged in", async () => {
+        setGlobalData(Region.US, new EnvironmentUrls());
+        setUserData(Region.EU, new EnvironmentUrls());
+        await switchUser(testUser);
+
+        // While logged in, mutate global to SelfHosted. environment$ must NOT emit SelfHosted.
+        const selfHostedUrls = new EnvironmentUrls();
+        selfHostedUrls.base = "https://self-hosted.example.com";
+        setGlobalData(Region.SelfHosted, selfHostedUrls);
         await awaitAsync();
 
         const env = await firstValueFrom(sut.environment$);
         expect(env.getRegion()).toBe(Region.EU);
+      });
+
+      it("holds the last user environment when user state is cleared mid-logout", async () => {
+        // Distinguishes the new behavior from the old "fall back to global" behavior:
+        // setting global to US and user to EU, then clearing user state — old code would
+        // emit US (global fallback); new code holds EU (last buffered user value).
+        setGlobalData(Region.US, new EnvironmentUrls());
+        setUserData(Region.EU, new EnvironmentUrls());
+        await switchUser(testUser);
+
+        const before = await firstValueFrom(sut.environment$);
+        expect(before.getRegion()).toBe(Region.EU);
+
+        // USER_ENVIRONMENT_KEY is asynchronously cleared by the logout event handler,
+        // but activeAccount$ has not yet transitioned to null.
+        stateProvider.singleUser.getFake(testUser, USER_ENVIRONMENT_KEY).nextState(null);
+        await awaitAsync();
+
+        // Strict invariant: still logged in, so global must not be served. Last user value
+        // (EU) is held by shareReplay; the null state is filtered out before mapping.
+        const after = await firstValueFrom(sut.environment$);
+        expect(after.getRegion()).toBe(Region.EU);
+      });
+
+      it("does not leak a prior user's environment after logout", async () => {
+        // User logged in with EU, global is US. After logout, environment$ must emit US.
+        setGlobalData(Region.US, new EnvironmentUrls());
+        setUserData(Region.EU, new EnvironmentUrls());
+        await switchUser(testUser);
+
+        const loggedIn = await firstValueFrom(sut.environment$);
+        expect(loggedIn.getRegion()).toBe(Region.EU);
+
+        // Logout: activeAccount$ → null. (clearOn handles user state on its own track.)
+        accountService.activeAccountSubject.next(null);
+        await awaitAsync();
+
+        const loggedOut = await firstValueFrom(sut.environment$);
+        expect(loggedOut.getRegion()).toBe(Region.US);
+      });
+
+      it("does not leak a prior user's environment after logout even if user state survives", async () => {
+        // Defense in depth: even if USER_ENVIRONMENT_KEY were NOT cleared by clearOn (e.g.,
+        // race where activeAccount$ → null arrives first), environment$ must still read
+        // from global once activeAccount$ is null.
+        setGlobalData(Region.US, new EnvironmentUrls());
+        setUserData(Region.EU, new EnvironmentUrls());
+        await switchUser(testUser);
+
+        accountService.activeAccountSubject.next(null);
+        // Intentionally do NOT clear USER_ENVIRONMENT_KEY here.
+        await awaitAsync();
+
+        const env = await firstValueFrom(sut.environment$);
+        expect(env.getRegion()).toBe(Region.US);
+      });
+
+      it("serves the buffered user environment to a late subscriber mid-logout", async () => {
+        // Reproduces the PM-39218 self-hosted dialog pattern: take(1) + filter for SelfHosted.
+        // The dialog subscribes after a logout-clear has fired but before activeAccount$ → null.
+        // Without shareReplay, take(1) could capture a null/default emission; with shareReplay,
+        // the late subscriber receives the last buffered user value immediately.
+        const userUrls = new EnvironmentUrls();
+        userUrls.base = "https://self-hosted.example.com";
+        setGlobalData(Region.US, new EnvironmentUrls());
+        setUserData(Region.SelfHosted, userUrls);
+        await switchUser(testUser);
+
+        // Prime shareReplay by ensuring environment$ has emitted at least once.
+        const primed = await firstValueFrom(sut.environment$);
+        expect(primed.getRegion()).toBe(Region.SelfHosted);
+
+        // Logout-clear arrives but activeAccount$ has not yet transitioned.
+        stateProvider.singleUser.getFake(testUser, USER_ENVIRONMENT_KEY).nextState(null);
+        await awaitAsync();
+
+        // Late subscriber simulating the self-hosted dialog ngOnInit pattern.
+        const env = await firstValueFrom(sut.environment$);
+        expect(env.getRegion()).toBe(Region.SelfHosted);
+      });
+
+      it("switches cleanly between users without emitting global in between", async () => {
+        // User A: EU, User B: US, Global: SelfHosted. Switching A → B must never expose
+        // the global SelfHosted value to a downstream subscriber.
+        const globalUrls = new EnvironmentUrls();
+        globalUrls.base = "https://self-hosted.example.com";
+        setGlobalData(Region.SelfHosted, globalUrls);
+        setUserData(Region.EU, new EnvironmentUrls(), testUser);
+        setUserData(Region.US, new EnvironmentUrls(), alternateTestUser);
+
+        await switchUser(testUser);
+        const a = await firstValueFrom(sut.environment$);
+        expect(a.getRegion()).toBe(Region.EU);
+
+        await switchUser(alternateTestUser);
+        const b = await firstValueFrom(sut.environment$);
+        expect(b.getRegion()).toBe(Region.US);
+      });
+
+      it("ignores user state changes after logout", async () => {
+        setGlobalData(Region.US, new EnvironmentUrls());
+        setUserData(Region.EU, new EnvironmentUrls());
+        await switchUser(testUser);
+
+        accountService.activeAccountSubject.next(null);
+        await awaitAsync();
+
+        const loggedOut = await firstValueFrom(sut.environment$);
+        expect(loggedOut.getRegion()).toBe(Region.US);
+
+        // Some background process resurrects user state. environment$ must not pick it up.
+        setUserData(Region.EU, new EnvironmentUrls());
+        await awaitAsync();
+
+        const stillLoggedOut = await firstValueFrom(sut.environment$);
+        expect(stillLoggedOut.getRegion()).toBe(Region.US);
+      });
+
+      it("emits the new user environment on login, not the prior global", async () => {
+        // Pre-auth global is US. User has SelfHosted in their user state.
+        // On login, environment$ must transition from global US to user SelfHosted —
+        // it must not stay on global.
+        const userUrls = new EnvironmentUrls();
+        userUrls.base = "https://self-hosted.example.com";
+        setGlobalData(Region.US, new EnvironmentUrls());
+        setUserData(Region.SelfHosted, userUrls);
+
+        const preLogin = await firstValueFrom(sut.environment$);
+        expect(preLogin.getRegion()).toBe(Region.US);
+
+        await switchUser(testUser);
+
+        const postLogin = await firstValueFrom(sut.environment$);
+        expect(postLogin.getRegion()).toBe(Region.SelfHosted);
       });
     });
 

--- a/libs/common/src/platform/services/default-environment.service.ts
+++ b/libs/common/src/platform/services/default-environment.service.ts
@@ -1,6 +1,14 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
-import { distinctUntilChanged, firstValueFrom, map, Observable, of, switchMap } from "rxjs";
+import {
+  distinctUntilChanged,
+  filter,
+  firstValueFrom,
+  map,
+  Observable,
+  shareReplay,
+  switchMap,
+} from "rxjs";
 import { Jsonify } from "type-fest";
 
 import { AccountService } from "../../auth/abstractions/account.service";
@@ -156,40 +164,33 @@ export class DefaultEnvironmentService implements EnvironmentService {
       .getGlobal(GLOBAL_ENVIRONMENT_KEY)
       .state$.pipe(map((state) => this.buildEnvironment(state?.region, state?.urls)));
 
-    // The current environment emitted by environment$ can come from two sources: the "global" environment,
-    // which represents the environment used by the application before a user authenticates, and the "user" environment,
-    // which represents the environment of an authenticated account using the application.
-    // We preference the user environment, only falling back to the global environment if a user is not logged in.
-    // However, there does exist the possibility that - due to timing of state updates - the active userId state may
-    // be cleared after the user environment state.
-    // To handle this, we fall back to the global state as a last resort, if the user state is not set.
-    const globalEnvState$ = this.stateProvider.getGlobal(GLOBAL_ENVIRONMENT_KEY).state$;
+    // Strict source-of-truth invariants:
+    //   - While account$ has a userId, environment$ emits ONLY from USER_ENVIRONMENT_KEY.
+    //   - While account$ is null, environment$ emits ONLY from GLOBAL_ENVIRONMENT_KEY.
+    // The logged-in branch filters out null state so a transient clear (clearOn: ["logout"])
+    // cannot cause global state to be served while the user is still logged in. shareReplay
+    // holds the last good value across the transition window so late subscribers receive the
+    // correct environment immediately rather than a stale or default emission.
     this.environment$ = account$.pipe(
       switchMap((userId) => {
         if (!userId) {
-          return globalEnvState$;
+          return this.stateProvider.getGlobal(GLOBAL_ENVIRONMENT_KEY).state$;
         }
         return this.stateProvider
           .getUser(userId, USER_ENVIRONMENT_KEY)
-          .state$.pipe(
-            switchMap((userState) => (userState != null ? of(userState) : globalEnvState$)),
-          );
+          .state$.pipe(filter((state) => state != null));
       }),
-      map((state) => {
-        return this.buildEnvironment(state?.region, state?.urls);
-      }),
+      map((state) => this.buildEnvironment(state?.region, state?.urls)),
+      shareReplay({ bufferSize: 1, refCount: false }),
     );
-    const globalCloudRegionState$ = this.stateProvider.getGlobal(GLOBAL_CLOUD_REGION_KEY).state$;
     this.cloudWebVaultUrl$ = account$.pipe(
       switchMap((userId) => {
         if (!userId) {
-          return globalCloudRegionState$;
+          return this.stateProvider.getGlobal(GLOBAL_CLOUD_REGION_KEY).state$;
         }
         return this.stateProvider
           .getUser(userId, USER_CLOUD_REGION_KEY)
-          .state$.pipe(
-            switchMap((userState) => (userState != null ? of(userState) : globalCloudRegionState$)),
-          );
+          .state$.pipe(filter((region) => region != null));
       }),
       map((region) => {
         if (region != null) {
@@ -201,6 +202,7 @@ export class DefaultEnvironmentService implements EnvironmentService {
         }
         return DEFAULT_REGION_CONFIG.urls.webVault;
       }),
+      shareReplay({ bufferSize: 1, refCount: false }),
     );
   }
 

--- a/libs/common/src/platform/services/default-environment.service.ts
+++ b/libs/common/src/platform/services/default-environment.service.ts
@@ -204,6 +204,15 @@ export class DefaultEnvironmentService implements EnvironmentService {
       }),
       shareReplay({ bufferSize: 1, refCount: false }),
     );
+
+    // Keep the global state observables warm. StateProvider's internal
+    // ReplaySubject resets after `cleanupDelayMs` of zero subscribers; if that
+    // happens, a switchMap transition into the global branch (e.g. on logout)
+    // would trigger an async disk read while shareReplay's buffer still holds
+    // the prior user's environment. Pinning refCount >= 1 for the service's
+    // lifetime guarantees synchronous replay on every transition into global.
+    this.stateProvider.getGlobal(GLOBAL_ENVIRONMENT_KEY).state$.subscribe();
+    this.stateProvider.getGlobal(GLOBAL_CLOUD_REGION_KEY).state$.subscribe();
   }
 
   availableRegions(): RegionConfig[] {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-39218

## 📔 Objective

Restructures `environment$` to enforce two strict source-of-truth invariants and to be resilient to the `activeAccount$` ↔ `USER_ENVIRONMENT_KEY` transition race. Closes PM-39218; subsumes PM-30715. Supersedes the consumer-side migration approach in #21350.

### The problem

`environment$` resolves from one of two state keys depending on auth state:

- `USER_ENVIRONMENT_KEY` while a user is active (cleared on logout via `clearOn: ["logout"]`)
- `GLOBAL_ENVIRONMENT_KEY` otherwise

The previous topology was a nested `switchMap` with an `of(userState)` fast path and a `globalEnvState$` fallback inside the authenticated branch:

```ts
account$.pipe(
  switchMap((userId) => {
    if (!userId) return globalEnvState$;
    return getUser(userId, USER_ENVIRONMENT_KEY).state$.pipe(
      switchMap((userState) => (userState != null ? of(userState) : globalEnvState$)),
    );
  }),
  map(buildEnvironment),
);
```

Three failure modes followed.

**The fallback was the leak.** `activeAccount$` and the `clearOn: ["logout"]` clear of `USER_ENVIRONMENT_KEY` are not atomically ordered. When user-state cleared first, the inner `switchMap` evaluated `userState ?? globalEnvState$` to global *while `activeAccount$` still held the userId*. The pipeline emitted a global value during what was, by `activeAccount$`'s definition, an authenticated session. This is the mechanism behind PM-30715.

**No `shareReplay` plus a downstream `take(1)` trap.** Bitwarden's state observable (`libs/state-internal/src/state-base.ts:42-78`) is `merge(defer(getStoredValue), storageUpdate$)` wrapped in `share({ connector: ReplaySubject(1), resetOnRefCountZero: timer(cleanupDelayMs) })`. When cold, the `defer` triggers an async disk read; the first emission to a new subscription can be `undefined`, and `buildEnvironment(undefined, undefined)` resolves to the US Cloud default. The self-hosted dialog uses `environment$.pipe(take(1), filter(env => env.getRegion() === Region.SelfHosted))`. `take(1)` captures the default emission, `filter` drops it, the form is never patched. The real SelfHosted value lands microseconds later but `take(1)` has already completed. This is PM-39218.

**Resubscription cascading.** Three nested `switchMap`s meant every `account$` transition tore down the entire authenticated branch and rebuilt subscriptions, multiplying the moments where downstream consumers could observe a stale or default emission.

### The fix

```ts
this.environment$ = account$.pipe(
  switchMap((userId) => {
    if (!userId) {
      return this.stateProvider.getGlobal(GLOBAL_ENVIRONMENT_KEY).state$;
    }
    return this.stateProvider
      .getUser(userId, USER_ENVIRONMENT_KEY)
      .state$.pipe(filter((state) => state != null));
  }),
  map((state) => this.buildEnvironment(state?.region, state?.urls)),
  shareReplay({ bufferSize: 1, refCount: false }),
);

// Warm-cache pin: keep the global ReplaySubject's refcount >= 1 so transitions
// into the global branch replay synchronously rather than triggering an async
// disk read (which would let shareReplay serve the prior user's value during
// the cold window).
this.stateProvider.getGlobal(GLOBAL_ENVIRONMENT_KEY).state$.subscribe();
this.stateProvider.getGlobal(GLOBAL_CLOUD_REGION_KEY).state$.subscribe();
```

Four changes:

1. **`filter((state) => state != null)` replaces the fallback.** While `activeAccount$` holds a userId, the only path from the user state observable to `map` is through non-null values. Null emissions (from `clearOn: ["logout"]`) are dropped on the floor; the pipeline produces no new emission. There is no syntactic path to `globalEnvState$` while logged in.
2. **`shareReplay({ bufferSize: 1, refCount: false })` multicasts the pipeline output.** The buffer holds the last value that passed through `filter` and `map`, which is always source-appropriate. Late subscribers receive the buffered value synchronously on subscribe, closing the `take(1)` trap. `refCount: false` keeps the upstream subscription warm for the lifetime of the service.
3. **Single `switchMap`, no nested branches.** `account$` is now the only signal that can change which source is read. Fewer teardown/resubscribe events, simpler reasoning, fewer transition windows.
4. **Warm-cache pin on the global state observables.** StateProvider's internal `share({ connector: ReplaySubject(1), resetOnRefCountZero: timer(cleanupDelayMs) })` resets after `cleanupDelayMs` of zero subscribers. If that happened mid-session (long logged-in stretch with no pre-auth components mounted), a `switchMap` transition into the global branch on logout would trigger a fresh `defer(getStoredValue)` — an async disk read during which `shareReplay`'s buffer still holds the prior user's Environment. A no-op subscription per global key pins `refCount >= 1` for the service's lifetime, guaranteeing the `ReplaySubject` replays synchronously in the same RxJS tick that the transition happens.

`cloudWebVaultUrl$` receives the same treatment for the same reasons.

### The invariants enforced

1. **While `activeAccount$` has a userId**, `environment$` emits only from `USER_ENVIRONMENT_KEY` for that user. The filter ensures global never reaches the buffer during this window.
2. **While `activeAccount$` is null**, `environment$` emits only from `GLOBAL_ENVIRONMENT_KEY`. The `switchMap` re-subscribes to global; the warm-cache pin guarantees synchronous replay; the buffer updates in the same tick.

The buffer is source-appropriate at all times because each emission that updates it came through the branch matching the current `activeAccount$` value, and the source emits synchronously thanks to the pin.

### Why this is correct under transitions

- **Logout-clear race (user state cleared while `activeAccount$` still holds userId):** `filter` drops the null; the buffer retains the last user value. Invariant 1 holds.
- **Logout completion (`activeAccount$` → null):** `switchMap` unsubscribes user, subscribes global. The warm-cache pin means global replays synchronously; buffer updates in the same tick. Invariant 2 holds with zero transition window.
- **Account switch (A → B):** `switchMap` drops A's user state and subscribes B's. Global is never touched. Invariant 1 holds across the swap.
- **Login (`activeAccount$` null → userId):** `seedUserEnvironment(userId)` is called before `switchAccount(userId)` in `login.strategy.ts:195-199` (existing intentional ordering), so by the time the `switchMap` moves to the user branch, `USER_ENVIRONMENT_KEY` is populated. Filter passes immediately, buffer updates.

### Supersedes

[#21350](https://github.com/bitwarden/clients/pull/21350) — the consumer-side `environment$` → `globalEnvironment$` migration across 25 files. That approach treated each call site as the unit of fix; this PR treats the EnvironmentService's contract as the unit of fix. Once this lands, #21350's migration becomes unnecessary and the PR can be closed.

## 📸 Screenshots

