### PR TITLE
[PM-37932] Make IPC content script re-injection idempotent

### DIFF
--- a/apps/browser/src/platform/ipc/content/ipc-content-script.ts
+++ b/apps/browser/src/platform/ipc/content/ipc-content-script.ts
@@ -76,9 +76,28 @@ function setupExtensionDisconnectAction(callback: (port: chrome.runtime.Port) =>
   port.onDisconnect.addListener(onDisconnect);
 }
 
-window.addEventListener("message", handleWindowMessage);
-addRuntimeMessageListener();
-setupExtensionDisconnectAction(() => {
+function teardown() {
   window.removeEventListener("message", handleWindowMessage);
   removeRuntimeMessageListener();
-});
+}
+
+// The background service worker re-injects this script into already-open tabs
+// whenever it (re)starts (see ipc-content-script-manager.service.ts). A plain
+// service-worker restart does not invalidate the extension context, so a tab
+// can still hold a live instance when the re-injection runs. All injections in
+// a frame share one isolated world, so each instance exposes its teardown here
+// and the next injection replaces (rather than stacks on top of) its
+// predecessor.
+// This keeps exactly one set of listeners and one port alive, avoiding the
+// duplicate IPC message delivery that stacked listeners would cause.
+const ipcWindow = window as Window & {
+  __bitwardenIpcContentScript?: { teardown: () => void };
+};
+
+ipcWindow.__bitwardenIpcContentScript?.teardown();
+
+window.addEventListener("message", handleWindowMessage);
+addRuntimeMessageListener();
+setupExtensionDisconnectAction(teardown);
+
+ipcWindow.__bitwardenIpcContentScript = { teardown };


### PR DESCRIPTION
## 🎟️ Tracking

Follow-up to review feedback on #20848: https://github.com/bitwarden/clients/pull/20848#discussion_r3465533853

## 📔 Objective

Makes re-injection of the IPC content script idempotent so it can never stack duplicate listeners/ports onto a tab.

`IpcContentScriptManagerService.init()` re-injects `ipc-content-script.js` into already-open tabs every time the background service worker (re)starts. The injected script previously ran its setup side-effects (`window` message listener, `chrome.runtime.onMessage` listener, long-lived port) unconditionally on every execution, with teardown wired only through the port's `onDisconnect`.

Because an MV3 service-worker restart does **not** invalidate the extension context, a tab can still hold a live content-script instance when the re-injection runs. The re-injection and the old instance's `onDisconnect` teardown race, so a tab can transiently end up with two live listener sets, causing duplicate IPC message delivery.

This is the still-valid part of the review comment. The comment's other concern (re-injection firing on every `serverConfig$`/`getFeatureFlag$` emission) no longer applies: `init()` is now a one-time call from `bootstrap()` using the Promise-based `getFeatureFlag`, not a `mergeMap` over the config stream.

### Approach

The reviewer suggested a "skip setup if already loaded" guard. A naive boolean guard is unsafe here: after a genuine `chrome.runtime.reload()`, the isolated-world globals persist, so a never-reset flag would block the legitimate post-reload re-setup, and resetting it from `onDisconnect` reintroduces the same race against re-injection.

Instead, re-injection is made **authoritative**. All injections in a frame share one isolated world, so each instance records its `teardown` on the isolated-world `window`. The next injection tears down its predecessor before registering, guaranteeing exactly one set of listeners and one port at all times. This eliminates the transient overlap in both orderings (re-inject-before-disconnect and disconnect-before-re-inject) and is safe across reloads, since re-injection happens after a reload too.

## 📸 Screenshots

N/A — no UI changes.
