### PR TITLE
[PM-39290] Coachmark navigation in v2

### DIFF
--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/risk-insights.component.ts
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/risk-insights.component.ts
@@ -197,9 +197,11 @@ export class RiskInsightsComponent implements OnInit, OnDestroy {
         const activeStepId = untracked(() => this.coachmarkService.activeStepId());
         this.coachmarkService.activeStepId.set(null); // close all popovers now
 
-        // setTimeout defers re-activation to after Angular's CD + rendering completes,
+        // afterNextRender defers re-activation to after Angular's CD + rendering completes,
         // so the tab button is un-hidden before the popover measures its position.
-        setTimeout(() => this.coachmarkService.activeStepId.set(activeStepId));
+        afterNextRender(() => this.coachmarkService.activeStepId.set(activeStepId), {
+          injector: this.injector,
+        });
       }
     });
 

--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/v2/access-intelligence-page/access-intelligence-page.component.ts
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/v2/access-intelligence-page/access-intelligence-page.component.ts
@@ -272,9 +272,11 @@ export class AccessIntelligencePageComponent implements OnInit, OnDestroy {
         const activeStepId = untracked(() => this.coachmarkService.activeStepId());
         this.coachmarkService.activeStepId.set(null); // close all popovers now
 
-        // setTimeout defers re-activation to after Angular's CD + rendering completes,
+        // afterNextRender defers re-activation to after Angular's CD + rendering completes,
         // so the tab button is un-hidden before the popover measures its position.
-        setTimeout(() => this.coachmarkService.activeStepId.set(activeStepId));
+        afterNextRender(() => this.coachmarkService.activeStepId.set(activeStepId), {
+          injector: this.injector,
+        });
       }
     });
 

--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/v2/access-intelligence-page/access-intelligence-page.component.ts
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/v2/access-intelligence-page/access-intelligence-page.component.ts
@@ -13,6 +13,7 @@ import {
   isDevMode,
   effect,
   afterNextRender,
+  untracked,
 } from "@angular/core";
 import { toObservable, toSignal, takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { ActivatedRoute, Router } from "@angular/router";
@@ -261,10 +262,19 @@ export class AccessIntelligencePageComponent implements OnInit, OnDestroy {
     });
 
     effect(() => {
-      // coachmarks are running, so set tab index to the coachmark's required tab
-      const tabIndex = this.coachmarkService.requiredTabIndex();
-      if (tabIndex !== null && tabIndex !== this.tabIndex()) {
-        this.tabIndex.set(tabIndex);
+      const requiredTabIndex = this.coachmarkService.requiredTabIndex();
+      if (requiredTabIndex !== null && requiredTabIndex !== this.tabIndex()) {
+        this.tabIndex.set(requiredTabIndex);
+
+        // Reset drawer state and close drawer when tabs are changed
+        // we need to ensure that the popover is closed before the tab is changed,
+        // otherwise the popover will be hidden behind the new tab content
+        const activeStepId = untracked(() => this.coachmarkService.activeStepId());
+        this.coachmarkService.activeStepId.set(null); // close all popovers now
+
+        // setTimeout defers re-activation to after Angular's CD + rendering completes,
+        // so the tab button is un-hidden before the popover measures its position.
+        setTimeout(() => this.coachmarkService.activeStepId.set(activeStepId));
       }
     });
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-39290

## 📔 Objective

Fix the coachmark navigation in v2 of Access Intelligence
When coachmark renders, the parent elements that it renders must be present in the view port.
In tab components, the tab button is not visible when the coach mark renders.
Therefore delay the rendering of the coach mark using `setTimeout` - which waits till the render is complete.

## 📸 Screenshots

None at this time.
