### PR TITLE
[deps] Fix Rust nightly toolchain reference in lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -106,6 +106,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: Install Rust nightly
+        id: rust-nightly
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: nightly-2026-06-23
@@ -119,7 +120,10 @@ jobs:
 
       - name: Run cargo fmt
         working-directory: ./apps/desktop/desktop_native
-        run: cargo +nightly fmt --check
+        # Use the exact toolchain installed above (Renovate manages the version
+        # via the `with: toolchain:` input) so the invoked toolchain can never
+        # drift from the installed one.
+        run: cargo +${{ steps.rust-nightly.outputs.name }} fmt --check
 
       - name: Run Clippy
         working-directory: ./apps/desktop/desktop_native
@@ -136,7 +140,7 @@ jobs:
 
       - name: Cargo udeps
         working-directory: ./apps/desktop/desktop_native
-        run: cargo +nightly udeps --workspace --all-features --all-targets
+        run: cargo +${{ steps.rust-nightly.outputs.name }} udeps --workspace --all-features --all-targets
 
       - name: Run cargo deny
         working-directory: ./apps/desktop/desktop_native

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -122,8 +122,11 @@ jobs:
         working-directory: ./apps/desktop/desktop_native
         # Use the exact toolchain installed above (Renovate manages the version
         # via the `with: toolchain:` input) so the invoked toolchain can never
-        # drift from the installed one.
-        run: cargo +${{ steps.rust-nightly.outputs.name }} fmt --check
+        # drift from the installed one. Passed through env rather than
+        # interpolated into the run script to satisfy the template-injection rule.
+        env:
+          RUST_NIGHTLY: ${{ steps.rust-nightly.outputs.name }}
+        run: cargo +"$RUST_NIGHTLY" fmt --check
 
       - name: Run Clippy
         working-directory: ./apps/desktop/desktop_native
@@ -140,7 +143,9 @@ jobs:
 
       - name: Cargo udeps
         working-directory: ./apps/desktop/desktop_native
-        run: cargo +${{ steps.rust-nightly.outputs.name }} udeps --workspace --all-features --all-targets
+        env:
+          RUST_NIGHTLY: ${{ steps.rust-nightly.outputs.name }}
+        run: cargo +"$RUST_NIGHTLY" udeps --workspace --all-features --all-targets
 
       - name: Run cargo deny
         working-directory: ./apps/desktop/desktop_native


### PR DESCRIPTION
## 🎟️ Tracking

Fixes the repo-wide `Run Rust lint` CI failure (`'cargo-fmt' is not installed for the toolchain 'nightly-...'`), red on every PR and recent `main` push.

## 📔 Objective

The `rust` lint job referenced the nightly toolchain in two places that could disagree:

- **Install:** `with: toolchain: nightly-2026-06-23` (+ `components: rustfmt`)
- **Invoke:** `cargo +nightly fmt` / `cargo +nightly udeps`

`#21406` ([deps]: Pin dependencies) pinned the install input from `nightly` to `nightly-2026-06-23` (Renovate's github-actions manager understands the `dtolnay/rust-toolchain` `toolchain:` input via the `rust-version` datasource). It could not touch the `cargo +nightly` shell strings, so the two desynced: `rustfmt` was installed onto `nightly-2026-06-23`, while `cargo +nightly` resolved to the *floating* latest nightly, which rustup auto-installed fresh. The break surfaced on 2026-06-24, the first day the floating nightly shipped without the `rustfmt` component.

## Fix

Keep a single Renovate-managed version literal in `with: toolchain:`, and derive the invoked toolchain from the install step's `name` output (which `dtolnay/rust-toolchain` documents as "suitable for use with `cargo +${{ steps.toolchain.outputs.name }}`"):

```yaml
- name: Install Rust nightly
  id: rust-nightly
  uses: dtolnay/rust-toolchain@...
  with:
    toolchain: nightly-2026-06-23   # Renovate keeps this current
    components: rustfmt
...
run: cargo +${{ steps.rust-nightly.outputs.name }} fmt --check
run: cargo +${{ steps.rust-nightly.outputs.name }} udeps --workspace --all-features --all-targets
```

There is now exactly one toolchain reference, so the install and the invocation can never drift again.

### Why no Renovate config change

Renovate's built-in `github-actions` manager already auto-updates the `with: toolchain:` value (including dated nightlies, via the `rust-version` datasource) — that is exactly what pinned it in `#21406` and will keep it current going forward. Moving the value into an `env:` var or a custom manager would only *break* that built-in detection, so the right move is to keep the value in the field Renovate already manages. A bonus safety property: because the date is pinned with `components: rustfmt`, a future Renovate bump to a nightly missing `rustfmt` fails on the Renovate PR's own CI rather than landing on `main`.

## 📸 Screenshots

N/A — CI workflow only.
