### PR TITLE
fix(environment): remove trailing slash from getSendUrl 

### DIFF
--- a/apps/web/src/app/platform/web-environment.service.spec.ts
+++ b/apps/web/src/app/platform/web-environment.service.spec.ts
@@ -56,7 +56,7 @@ describe("WebEnvironmentService", () => {
       };
 
       const expectedModifiedScimUrl = expectedProdUSUrls.scim + "/v2";
-      const expectedSendUrl = PROD_US_REGION.urls.send + "/#/";
+      const expectedSendUrl = PROD_US_REGION.urls.send + "/#";
 
       const prodUSEnv = new WebCloudEnvironment(PROD_US_REGION, {
         ...expectedProdUSUrls,
@@ -148,7 +148,7 @@ describe("WebEnvironmentService", () => {
           ...expectedProdUSUrls,
           send: customSendUrl,
         });
-        expect(env.getSendUrl()).toEqual(customSendUrl + "/#/");
+        expect(env.getSendUrl()).toEqual(customSendUrl + "/#");
       });
     });
 
@@ -176,7 +176,7 @@ describe("WebEnvironmentService", () => {
       };
 
       const expectedModifiedScimUrl = expectedProdEUUrls.scim + "/v2";
-      const expectedSendUrl = prodEURegionConfig.urls.send + "/#/";
+      const expectedSendUrl = prodEURegionConfig.urls.send + "/#";
 
       const prodEUEnv = new WebCloudEnvironment(prodEURegionConfig, {
         ...expectedProdEUUrls,

--- a/libs/common/src/platform/services/default-environment.service.spec.ts
+++ b/libs/common/src/platform/services/default-environment.service.spec.ts
@@ -117,7 +117,7 @@ describe("EnvironmentService", () => {
         expect(env.getNotificationsUrl()).toBe(expectedUrls.notifications);
         expect(env.getEventsUrl()).toBe(expectedUrls.events);
         expect(env.getScimUrl()).toBe(expectedUrls.scim);
-        expect(env.getSendUrl()).toBe(expectedUrls.send + "/#/");
+        expect(env.getSendUrl()).toBe(expectedUrls.send + "/#");
         expect(env.getKeyConnectorUrl()).toBe(undefined);
         expect(env.isCloud()).toBe(true);
         expect(env.getUrls()).toEqual({
@@ -250,6 +250,20 @@ describe("EnvironmentService", () => {
     });
   });
 
+  describe("getSendUrl URL format", () => {
+    it("returns the dedicated send domain with no trailing slash when urls.send is set", async () => {
+      const userEnvironmentUrls = new EnvironmentUrls();
+      userEnvironmentUrls.send = "https://send.bitwarden.com";
+      setUserData(Region.SelfHosted, userEnvironmentUrls);
+
+      await switchUser(testUser);
+
+      const env = await firstValueFrom(sut.environment$);
+
+      expect(env.getSendUrl()).toBe("https://send.bitwarden.com/#");
+    });
+  });
+
   describe("without user", () => {
     it.each(REGION_SETUP)("gets default urls %s", async ({ region, expectedUrls }) => {
       setGlobalData(region, new EnvironmentUrls());
@@ -263,7 +277,7 @@ describe("EnvironmentService", () => {
       expect(env.getNotificationsUrl()).toBe(expectedUrls.notifications);
       expect(env.getEventsUrl()).toBe(expectedUrls.events);
       expect(env.getScimUrl()).toBe(expectedUrls.scim);
-      expect(env.getSendUrl()).toBe(expectedUrls.send + "/#/");
+      expect(env.getSendUrl()).toBe(expectedUrls.send + "/#");
       expect(env.getKeyConnectorUrl()).toBe(undefined);
       expect(env.isCloud()).toBe(true);
       expect(env.getUrls()).toEqual({

--- a/libs/common/src/platform/services/default-environment.service.ts
+++ b/libs/common/src/platform/services/default-environment.service.ts
@@ -425,7 +425,7 @@ abstract class UrlEnvironment implements Environment {
 
   getSendUrl() {
     if (this.urls.send != null) {
-      return this.urls.send + "/#/";
+      return this.urls.send + "/#";
     }
 
     return this.getWebVaultUrl() + "/#/send/";


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-39449

## 📔 Objective

Send links generated by web app are broken. This PR fixes the issue on main. A separate PR (https://github.com/bitwarden/clients/pull/21472) fixes the issue on a hotfix-rc branch for release. The reason for the drift is that this code has changed since the release of `web-v2026.6.2`, and we don't want to include any changes in a hotfix release other than what is necessary to fix production. 

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
