### PR TITLE
[PM-39472] Note -> Secure Note 

### DIFF
--- a/apps/browser/src/vault/popup/components/vault/add-edit/add-edit.component.spec.ts
+++ b/apps/browser/src/vault/popup/components/vault/add-edit/add-edit.component.spec.ts
@@ -91,7 +91,12 @@ describe("AddEditComponent", () => {
       providers: [
         provideNoopAnimations(),
         { provide: PlatformUtilsService, useValue: mock<PlatformUtilsService>() },
-        { provide: ConfigService, useValue: mock<ConfigService>() },
+        {
+          provide: ConfigService,
+          useValue: mock<ConfigService>({
+            getFeatureFlag$: jest.fn().mockReturnValue(of(false)),
+          }),
+        },
         { provide: PopupRouterCacheService, useValue: { back, setHistory } },
         { provide: PopupCloseWarningService, useValue: { disable } },
         { provide: Router, useValue: { navigate } },

--- a/apps/browser/src/vault/popup/components/vault/add-edit/add-edit.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/add-edit/add-edit.component.ts
@@ -231,6 +231,7 @@ export class AddEditComponent implements OnInit, OnDestroy {
 
   private readonly pm32009NewItemTypesEnabled = toSignal(
     this.configService.getFeatureFlag$(FeatureFlag.PM32009NewItemTypes),
+    { initialValue: false },
   );
 
   constructor(

--- a/apps/browser/src/vault/popup/components/vault/add-edit/add-edit.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/add-edit/add-edit.component.ts
@@ -2,7 +2,7 @@
 // @ts-strict-ignore
 import { CommonModule } from "@angular/common";
 import { Component, OnInit, OnDestroy, viewChild } from "@angular/core";
-import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
+import { takeUntilDestroyed, toSignal } from "@angular/core/rxjs-interop";
 import { FormsModule } from "@angular/forms";
 import { ActivatedRoute, Params, Router } from "@angular/router";
 import { firstValueFrom, map, Observable, switchMap } from "rxjs";
@@ -229,6 +229,10 @@ export class AddEditComponent implements OnInit, OnDestroy {
     return BrowserPopupUtils.inSingleActionPopout(window, VaultPopoutType.addEditVaultItem);
   }
 
+  private readonly pm32009NewItemTypesEnabled = toSignal(
+    this.configService.getFeatureFlag$(FeatureFlag.PM32009NewItemTypes),
+  );
+
   constructor(
     private route: ActivatedRoute,
     private i18nService: I18nService,
@@ -421,6 +425,7 @@ export class AddEditComponent implements OnInit, OnDestroy {
               FeatureFlag.PM29968_FillAfterSave,
             );
           }
+
           const config = await this.addEditFormConfigService.buildConfig(
             mode,
             params.cipherId,
@@ -512,11 +517,18 @@ export class AddEditComponent implements OnInit, OnDestroy {
 
   setHeader(mode: CipherFormMode, type: CipherType) {
     const isEditMode = mode === "edit" || mode === "partial-edit";
+    const newItemTypesEnabled = this.pm32009NewItemTypesEnabled();
     const translation = {
       [CipherType.Login]: isEditMode ? "editItemHeaderLogin" : "newItemHeaderLogin",
       [CipherType.Card]: isEditMode ? "editItemHeaderCard" : "newItemHeaderCard",
       [CipherType.Identity]: isEditMode ? "editItemHeaderIdentity" : "newItemHeaderIdentity",
-      [CipherType.SecureNote]: isEditMode ? "editItemHeaderNote" : "newItemHeaderNote",
+      [CipherType.SecureNote]: newItemTypesEnabled
+        ? isEditMode
+          ? "editItemHeaderSecureNote"
+          : "newItemHeaderSecureNote"
+        : isEditMode
+          ? "editItemHeaderNote"
+          : "newItemHeaderNote",
       [CipherType.SshKey]: isEditMode ? "editItemHeaderSshKey" : "newItemHeaderSshKey",
       [CipherType.BankAccount]: isEditMode
         ? "editItemHeaderBankAccount"

--- a/apps/browser/src/vault/popup/components/vault/view/view.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/view/view.component.ts
@@ -127,6 +127,7 @@ export class ViewComponent {
   private readonly autofillAllowed = toSignal(this.vaultPopupAutofillService.autofillAllowed$);
   private readonly pm32009NewItemTypesEnabled = toSignal(
     this.configService.getFeatureFlag$(FeatureFlag.PM32009NewItemTypes),
+    { initialValue: false },
   );
   private uriMatchStrategy$ = this.domainSettingsService.resolvedDefaultUriMatchStrategy$;
   protected showFooter$: Observable<boolean>;

--- a/apps/browser/src/vault/popup/components/vault/view/view.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/view/view.component.ts
@@ -23,6 +23,8 @@ import {
 } from "@bitwarden/common/autofill/constants";
 import { DomainSettingsService } from "@bitwarden/common/autofill/services/domain-settings.service";
 import { EventCollectionService, EventType } from "@bitwarden/common/dirt/event-logs";
+import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { UserId } from "@bitwarden/common/types/guid";
@@ -123,6 +125,9 @@ export class ViewComponent {
   routeAfterDeletion?: ROUTES_AFTER_EDIT_DELETION;
 
   private readonly autofillAllowed = toSignal(this.vaultPopupAutofillService.autofillAllowed$);
+  private readonly pm32009NewItemTypesEnabled = toSignal(
+    this.configService.getFeatureFlag$(FeatureFlag.PM32009NewItemTypes),
+  );
   private uriMatchStrategy$ = this.domainSettingsService.resolvedDefaultUriMatchStrategy$;
   protected showFooter$: Observable<boolean>;
   protected userCanArchive$ = this.accountService.activeAccount$
@@ -147,6 +152,7 @@ export class ViewComponent {
     private archiveCipherUtilsService: ArchiveCipherUtilitiesService,
     private domainSettingsService: DomainSettingsService,
     private afterDeletionNavigationService: VaultPopupAfterDeletionNavigationService,
+    private configService: ConfigService,
   ) {
     this.subscribeToParams();
   }
@@ -215,11 +221,14 @@ export class ViewComponent {
   }
 
   setHeader(type: CipherType) {
+    const newItemTypesEnabled = this.pm32009NewItemTypesEnabled();
     const translation = {
       [CipherType.Login]: "viewItemHeaderLogin",
       [CipherType.Card]: "viewItemHeaderCard",
       [CipherType.Identity]: "viewItemHeaderIdentity",
-      [CipherType.SecureNote]: "viewItemHeaderNote",
+      [CipherType.SecureNote]: newItemTypesEnabled
+        ? "viewItemHeaderSecureNote"
+        : "viewItemHeaderNote",
       [CipherType.SshKey]: "viewItemHeaderSshKey",
       [CipherType.BankAccount]: "viewItemHeaderBankAccount",
       [CipherType.DriversLicense]: "viewItemHeaderLicense",

--- a/apps/web/src/app/auth/settings/emergency-access/view/emergency-view-dialog.component.ts
+++ b/apps/web/src/app/auth/settings/emergency-access/view/emergency-view-dialog.component.ts
@@ -1,9 +1,12 @@
 import { CommonModule } from "@angular/common";
 import { Component, Inject } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { EMPTY, Observable } from "rxjs";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { VaultViewPasswordHistoryService } from "@bitwarden/angular/services/view-password-history.service";
+import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { EmergencyAccessId } from "@bitwarden/common/types/guid";
 import { PremiumUpgradePromptService } from "@bitwarden/common/vault/abstractions/premium-upgrade-prompt.service";
@@ -55,8 +58,16 @@ export class EmergencyViewDialogComponent {
     @Inject(DIALOG_DATA) protected params: EmergencyViewDialogParams,
     private dialogRef: DialogRef,
     private i18nService: I18nService,
+    private configService: ConfigService,
   ) {
     this.updateTitle();
+
+    this.configService
+      .getFeatureFlag$(FeatureFlag.PM32009NewItemTypes)
+      .pipe(takeUntilDestroyed())
+      .subscribe((newItemTypesEnabled) => {
+        this.updateTitle(newItemTypesEnabled);
+      });
   }
 
   get cipher(): CipherView {
@@ -71,7 +82,7 @@ export class EmergencyViewDialogComponent {
     void this.dialogRef.close();
   };
 
-  private updateTitle() {
+  private updateTitle(newItemTypesEnabled?: boolean) {
     const type = this.cipher.type;
 
     switch (type) {
@@ -85,7 +96,9 @@ export class EmergencyViewDialogComponent {
         this.title = this.i18nService.t("viewItemHeaderIdentity");
         break;
       case CipherType.SecureNote:
-        this.title = this.i18nService.t("viewItemHeaderNote");
+        this.title = this.i18nService.t(
+          newItemTypesEnabled ? "viewItemHeaderSecureNote" : "viewItemHeaderNote",
+        );
         break;
       case CipherType.SshKey:
         this.title = this.i18nService.t("viewItemHeaderSshKey");


### PR DESCRIPTION
## 🎟️ Tracking

[PM-39472](https://bitwarden.atlassian.net/browse/PM-39472)

## 📔 Objective

Additional changes for "Note" to "Secure Note" transition. I have a video on https://github.com/bitwarden/clients/pull/21423 of the extension but I must have not pushed a commit because the extension was missed. This addresses the extension and the emergency access which I also found.

## 📸 Screenshots

|Add|Edit|View|Emergency Access|
|-|-|-|-|
|<img width="484" height="604" alt="Screenshot 2026-06-24 at 12 33 58 PM" src="https://github.com/user-attachments/assets/6571d694-28cb-4362-97e7-cbfdddb364fa" />|<img width="484" height="603" alt="Screenshot 2026-06-24 at 12 34 19 PM" src="https://github.com/user-attachments/assets/db05dace-6544-416f-a218-7b1efb535688" />|<img width="485" height="606" alt="Screenshot 2026-06-24 at 12 34 10 PM" src="https://github.com/user-attachments/assets/6f811ef7-df40-49ef-a099-93c0e202d96b" />|<img width="741" height="692" alt="Screenshot 2026-06-24 at 12 35 02 PM" src="https://github.com/user-attachments/assets/a33286e0-c647-405b-8d01-31c3daa6f4a9" />|


[PM-39472]: https://bitwarden.atlassian.net/browse/PM-39472