### PR TITLE
fix:hotfix(environment): remove trailing slash from getSendUrl 

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitwarden/web-vault",
-  "version": "2026.6.2",
+  "version": "2026.6.3",
   "scripts": {
     "build:oss": "webpack",
     "build:bit": "webpack -c ../../bitwarden_license/bit-web/webpack.config.js",

--- a/apps/web/src/app/platform/web-environment.service.spec.ts
+++ b/apps/web/src/app/platform/web-environment.service.spec.ts
@@ -56,7 +56,7 @@ describe("WebEnvironmentService", () => {
       };
 
       const expectedModifiedScimUrl = expectedProdUSUrls.scim + "/v2";
-      const expectedSendUrl = PROD_US_REGION.urls.send + "/#/";
+      const expectedSendUrl = PROD_US_REGION.urls.send + "/#";
 
       const prodUSEnv = new WebCloudEnvironment(PROD_US_REGION, {
         ...expectedProdUSUrls,
@@ -148,7 +148,7 @@ describe("WebEnvironmentService", () => {
           ...expectedProdUSUrls,
           send: customSendUrl,
         });
-        expect(env.getSendUrl()).toEqual(customSendUrl + "/#/");
+        expect(env.getSendUrl()).toEqual(customSendUrl + "/#");
       });
     });
 
@@ -176,7 +176,7 @@ describe("WebEnvironmentService", () => {
       };
 
       const expectedModifiedScimUrl = expectedProdEUUrls.scim + "/v2";
-      const expectedSendUrl = prodEURegionConfig.urls.send + "/#/";
+      const expectedSendUrl = prodEURegionConfig.urls.send + "/#";
 
       const prodEUEnv = new WebCloudEnvironment(prodEURegionConfig, {
         ...expectedProdEUUrls,

--- a/libs/common/src/platform/services/default-environment.service.spec.ts
+++ b/libs/common/src/platform/services/default-environment.service.spec.ts
@@ -117,7 +117,7 @@ describe("EnvironmentService", () => {
         expect(env.getNotificationsUrl()).toBe(expectedUrls.notifications);
         expect(env.getEventsUrl()).toBe(expectedUrls.events);
         expect(env.getScimUrl()).toBe(expectedUrls.scim);
-        expect(env.getSendUrl()).toBe(expectedUrls.send + "/#/");
+        expect(env.getSendUrl()).toBe(expectedUrls.send + "/#");
         expect(env.getKeyConnectorUrl()).toBe(undefined);
         expect(env.isCloud()).toBe(true);
         expect(env.getUrls()).toEqual({
@@ -234,6 +234,32 @@ describe("EnvironmentService", () => {
     });
   });
 
+  describe("getSendUrl URL format", () => {
+    it("returns the dedicated send domain with no trailing slash when urls.send is set", async () => {
+      const userEnvironmentUrls = new EnvironmentUrls();
+      userEnvironmentUrls.send = "https://send.bitwarden.com";
+      setUserData(Region.SelfHosted, userEnvironmentUrls);
+
+      await switchUser(testUser);
+
+      const env = await firstValueFrom(sut.environment$);
+
+      expect(env.getSendUrl()).toBe("https://send.bitwarden.com/#");
+    });
+
+    it("returns the dedicated send domain with no trailing slash via the hardcoded cloud webVault fallback", async () => {
+      const userEnvironmentUrls = new EnvironmentUrls();
+      userEnvironmentUrls.webVault = "https://vault.bitwarden.com";
+      setUserData(Region.SelfHosted, userEnvironmentUrls);
+
+      await switchUser(testUser);
+
+      const env = await firstValueFrom(sut.environment$);
+
+      expect(env.getSendUrl()).toBe("https://send.bitwarden.com/#");
+    });
+  });
+
   describe("without user", () => {
     it.each(REGION_SETUP)("gets default urls %s", async ({ region, expectedUrls }) => {
       setGlobalData(region, new EnvironmentUrls());
@@ -247,7 +273,7 @@ describe("EnvironmentService", () => {
       expect(env.getNotificationsUrl()).toBe(expectedUrls.notifications);
       expect(env.getEventsUrl()).toBe(expectedUrls.events);
       expect(env.getScimUrl()).toBe(expectedUrls.scim);
-      expect(env.getSendUrl()).toBe(expectedUrls.send + "/#/");
+      expect(env.getSendUrl()).toBe(expectedUrls.send + "/#");
       expect(env.getKeyConnectorUrl()).toBe(undefined);
       expect(env.isCloud()).toBe(true);
       expect(env.getUrls()).toEqual({

--- a/libs/common/src/platform/services/default-environment.service.ts
+++ b/libs/common/src/platform/services/default-environment.service.ts
@@ -427,12 +427,12 @@ abstract class UrlEnvironment implements Environment {
 
   getSendUrl() {
     if (this.urls.send != null) {
-      return this.urls.send + "/#/";
+      return this.urls.send + "/#";
     }
 
     const webVaultUrl = this.getWebVaultUrl();
     if (webVaultUrl === "https://vault.bitwarden.com") {
-      return "https://send.bitwarden.com/#/";
+      return "https://send.bitwarden.com/#";
     }
     return webVaultUrl + "/#/send/";
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -257,7 +257,7 @@
     },
     "apps/web": {
       "name": "@bitwarden/web-vault",
-      "version": "2026.6.2"
+      "version": "2026.6.3"
     },
     "libs/admin-console": {
       "name": "@bitwarden/admin-console",


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-39449

## 📔 Objective

Send links generated by web app are broken. This PR fixes the issue on `hotfix-rc`. A separate PR (https://github.com/bitwarden/clients/pull/21467) fixes the issue on a main. The reason for the drift is that this code has changed since the release of web-v2026.6.2, and we don't want to include any changes in a hotfix release other than what is necessary to fix production. This branch was based off the last web tag, and the fix applied on top of that. The main PR fixed on top of the state the code is in on main.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
