### PR TITLE
[PM-7036] Add support for latest LogMeOnce CSV import format, add folder mapping

### DIFF
--- a/libs/importer/src/importers/logmeonce-csv-importer.spec.ts
+++ b/libs/importer/src/importers/logmeonce-csv-importer.spec.ts
@@ -1,0 +1,36 @@
+import { LogMeOnceCsvImporter } from "./logmeonce-csv-importer";
+
+const oldFormatCSV = `"name","url","username","password","group","extra"
+"Facebook (auser)","https://www.facebook.com/","auser","123456","Favorites",""`;
+
+const newFormatCSV = `"name","url","note","group","username","password","passkey","extra"
+"Facebook (auser)","https://www.facebook.com/","","Favorites","auser","123456","",""`;
+
+describe("LogMeOnce CSV Importer", () => {
+  let importer: LogMeOnceCsvImporter;
+
+  beforeEach(() => {
+    importer = new LogMeOnceCsvImporter();
+  });
+
+  it.each([oldFormatCSV, newFormatCSV])(
+    "should parse login data when provided valid CSV in old or new formats",
+    async (csv) => {
+      const result = await importer.parse(csv);
+      expect(result != null).toBe(true);
+
+      expect(result.ciphers.length).toEqual(1);
+      const cipher = result.ciphers[0];
+      expect(cipher.name).toEqual("Facebook (auser)");
+      expect(cipher.login.uris.length).toEqual(1);
+      expect(cipher.login.uris[0].uri).toEqual("https://www.facebook.com/");
+      expect(cipher.login.username).toEqual("auser");
+      expect(cipher.login.password).toEqual("123456");
+
+      expect(result.folders.length).toEqual(1);
+      expect(result.folders[0].name).toEqual("Favorites");
+      expect(result.folderRelationships.length).toEqual(1);
+      expect(result.folderRelationships[0]).toEqual([0, 0]);
+    },
+  );
+});

--- a/libs/importer/src/importers/logmeonce-csv-importer.ts
+++ b/libs/importer/src/importers/logmeonce-csv-importer.ts
@@ -1,3 +1,5 @@
+import { FolderView } from "@bitwarden/common/vault/models/view/folder.view";
+
 import { ImportResult } from "../models/import-result";
 
 import { BaseImporter } from "./base-importer";
@@ -6,7 +8,7 @@ import { Importer } from "./importer";
 export class LogMeOnceCsvImporter extends BaseImporter implements Importer {
   parse(data: string): Promise<ImportResult> {
     const result = new ImportResult();
-    const results = this.parseCsv(data, false);
+    const results = this.parseCsv(data, true);
     if (results == null) {
       result.success = false;
       return Promise.resolve(result);
@@ -17,12 +19,25 @@ export class LogMeOnceCsvImporter extends BaseImporter implements Importer {
         return;
       }
       const cipher = this.initLoginCipher();
-      cipher.name = this.getValueOrDefault(value[0], "--");
-      cipher.login.username = this.getValueOrDefault(value[2]);
-      cipher.login.password = this.getValueOrDefault(value[3]);
-      cipher.login.uris = this.makeUriArray(value[1]);
+      cipher.name = this.getValueOrDefault(value.name, "--");
+      cipher.login.username = this.getValueOrDefault(value.username);
+      cipher.login.password = this.getValueOrDefault(value.password);
+      cipher.login.uris = this.makeUriArray(value.url);
+
       this.cleanupCipher(cipher);
       result.ciphers.push(cipher);
+
+      // Map groups to folders
+      if (value.group) {
+        let folderIdx = result.folders.findIndex((f) => f.name === value.group);
+        if (folderIdx === -1) {
+          const folder = new FolderView();
+          folder.name = value.group;
+          result.folders.push(folder);
+          folderIdx = result.folders.length - 1;
+        }
+        result.folderRelationships.push([result.ciphers.length - 1, folderIdx]);
+      }
     });
 
     result.success = true;

--- a/libs/importer/src/importers/logmeonce-csv-importer.ts
+++ b/libs/importer/src/importers/logmeonce-csv-importer.ts
@@ -15,9 +15,10 @@ export class LogMeOnceCsvImporter extends BaseImporter implements Importer {
     }
 
     results.forEach((value) => {
-      if (value.length < 4) {
+      if (!value.name) {
         return;
       }
+
       const cipher = this.initLoginCipher();
       cipher.name = this.getValueOrDefault(value.name, "--");
       cipher.login.username = this.getValueOrDefault(value.username);


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-7036

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
LogMeOnce has changed the format of their CSV export file. This PR makes the importer support both old and new formats, adds folder mapping, and adds simple tests.