### PR TITLE
[PM-39269] Fix At-Risk Members CSV export including extra columns

### DIFF
--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/v2/access-intelligence-page/access-intelligence-page.component.ts
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/v2/access-intelligence-page/access-intelligence-page.component.ts
@@ -492,8 +492,6 @@ export class AccessIntelligencePageComponent implements OnInit, OnDestroy {
       type: DrawerType.CriticalAtRiskMembers,
       members: members.map((member) => ({
         email: member.email,
-        userName: member.userName ?? "",
-        userGuid: member.id,
         atRiskApplicationCount: report.getAtRiskApplicationCountForMember(member.id, {
           criticalOnly: true,
         }),
@@ -523,8 +521,6 @@ export class AccessIntelligencePageComponent implements OnInit, OnDestroy {
   ): DrawerMemberData[] {
     return members.map((member) => ({
       email: member.email,
-      userName: member.userName ?? "",
-      userGuid: member.id,
       atRiskApplicationCount: report.getAtRiskApplicationCountForMember(member.id),
     }));
   }

--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/v2/models/drawer-content-data.types.ts
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/v2/models/drawer-content-data.types.ts
@@ -7,10 +7,6 @@ import { DrawerType } from "@bitwarden/bit-common/dirt/access-intelligence/servi
 export interface DrawerMemberData {
   /** Member's email address */
   email: string;
-  /** Member's display name */
-  userName: string;
-  /** Organization user ID (userGuid) */
-  userGuid: string;
   /** Number of at-risk applications this member is in */
   atRiskApplicationCount: number;
 }

--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/v2/shared/access-intelligence-drawer-v2/access-intelligence-drawer-v2.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/v2/shared/access-intelligence-drawer-v2/access-intelligence-drawer-v2.component.spec.ts
@@ -29,13 +29,8 @@ describe("AccessIntelligenceDrawerV2Component", () => {
 
   /** Sample members used in drawer data */
   const sampleMembers: DrawerMemberData[] = [
-    {
-      email: "alice@example.com",
-      userName: "Alice Smith",
-      userGuid: "u1",
-      atRiskApplicationCount: 5,
-    },
-    { email: "bob@example.com", userName: "Bob Jones", userGuid: "u2", atRiskApplicationCount: 3 },
+    { email: "alice@example.com", atRiskApplicationCount: 5 },
+    { email: "bob@example.com", atRiskApplicationCount: 3 },
   ];
 
   /** Sample applications used in drawer data */
@@ -122,7 +117,22 @@ describe("AccessIntelligenceDrawerV2Component", () => {
 
       const callArg = mockFileDownloadService.download.mock.calls[0][0];
       const firstLine = (callArg.blobData as string).split("\n")[0].trim();
-      expect(firstLine).toBe("email,userName,userGuid,atRiskApplications");
+      // Only email + at-risk application count must be exported (PM-39269).
+      expect(firstLine).toBe("email,atRiskApplications");
+    });
+
+    it("should NOT include userName or userGuid columns in the CSV (PM-39269)", () => {
+      testAccess(component).data = {
+        type: DrawerType.OrgAtRiskMembers,
+        members: sampleMembers,
+      };
+
+      component.downloadAtRiskMembers();
+
+      const callArg = mockFileDownloadService.download.mock.calls[0][0];
+      const header = (callArg.blobData as string).split("\n")[0];
+      expect(header).not.toContain("userName");
+      expect(header).not.toContain("userGuid");
     });
 
     it("should call FileDownloadService.download for CriticalAtRiskMembers drawer type", () => {

--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/v2/shared/access-intelligence-drawer-v2/access-intelligence-drawer-v2.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/v2/shared/access-intelligence-drawer-v2/access-intelligence-drawer-v2.component.spec.ts
@@ -117,22 +117,9 @@ describe("AccessIntelligenceDrawerV2Component", () => {
 
       const callArg = mockFileDownloadService.download.mock.calls[0][0];
       const firstLine = (callArg.blobData as string).split("\n")[0].trim();
-      // Only email + at-risk application count must be exported (PM-39269).
+      // Only email + at-risk application count must be exported (PM-39269);
+      // this exact-match assertion proves no extra columns (e.g. userName, userGuid) leak through.
       expect(firstLine).toBe("email,atRiskApplications");
-    });
-
-    it("should NOT include userName or userGuid columns in the CSV (PM-39269)", () => {
-      testAccess(component).data = {
-        type: DrawerType.OrgAtRiskMembers,
-        members: sampleMembers,
-      };
-
-      component.downloadAtRiskMembers();
-
-      const callArg = mockFileDownloadService.download.mock.calls[0][0];
-      const header = (callArg.blobData as string).split("\n")[0];
-      expect(header).not.toContain("userName");
-      expect(header).not.toContain("userGuid");
     });
 
     it("should call FileDownloadService.download for CriticalAtRiskMembers drawer type", () => {

--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/v2/shared/access-intelligence-drawer-v2/access-intelligence-drawer-v2.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/v2/shared/access-intelligence-drawer-v2/access-intelligence-drawer-v2.component.stories.ts
@@ -23,32 +23,22 @@ import { AccessIntelligenceDrawerV2Component } from "./access-intelligence-drawe
 const sampleMembers: DrawerMemberData[] = [
   {
     email: "alice@example.com",
-    userName: "Alice Smith",
-    userGuid: "user-1",
     atRiskApplicationCount: 15,
   },
   {
     email: "bob@example.com",
-    userName: "Bob Johnson",
-    userGuid: "user-2",
     atRiskApplicationCount: 8,
   },
   {
     email: "charlie@example.com",
-    userName: "Charlie Davis",
-    userGuid: "user-3",
     atRiskApplicationCount: 12,
   },
   {
     email: "diana@example.com",
-    userName: "Diana Wilson",
-    userGuid: "user-4",
     atRiskApplicationCount: 5,
   },
   {
     email: "eve@example.com",
-    userName: "Eve Martinez",
-    userGuid: "user-5",
     atRiskApplicationCount: 20,
   },
 ];
@@ -277,8 +267,6 @@ export const LargeDataset: Story = {
             type: DrawerType.OrgAtRiskMembers,
             members: Array.from({ length: 50 }, (_, i) => ({
               email: `user${i}@example.com`,
-              userName: `User ${i}`,
-              userGuid: `user-${i}`,
               atRiskApplicationCount: (i % 25) + 1,
             })),
           } as OrgAtRiskMembersData,

--- a/bitwarden_license/bit-web/src/app/dirt/access-intelligence/v2/testing/story-fixtures.ts
+++ b/bitwarden_license/bit-web/src/app/dirt/access-intelligence/v2/testing/story-fixtures.ts
@@ -85,7 +85,6 @@ export function createSampleApplications(count: number = 7): ApplicationHealthVi
  * @param count - Number of members to create (defaults to 5)
  */
 export function createSampleMembers(count: number = 5): DrawerMemberData[] {
-  const names = ["Alice Smith", "Bob Johnson", "Charlie Davis", "Diana Wilson", "Eve Martinez"];
   const emails = [
     "alice@example.com",
     "bob@example.com",
@@ -95,10 +94,8 @@ export function createSampleMembers(count: number = 5): DrawerMemberData[] {
   ];
   const atRiskCounts = [15, 8, 12, 5, 20];
 
-  return Array.from({ length: Math.min(count, names.length) }, (_, i) => ({
+  return Array.from({ length: Math.min(count, emails.length) }, (_, i) => ({
     email: emails[i],
-    userName: names[i],
-    userGuid: `user-${i + 1}`,
     atRiskApplicationCount: atRiskCounts[i],
   }));
 }
@@ -123,8 +120,6 @@ export function createMockCiphersWithIcons(): CipherView[] {
 export function createLargeDataset(count: number): DrawerMemberData[] {
   return Array.from({ length: count }, (_, i) => ({
     email: `user${i}@example.com`,
-    userName: `User ${i}`,
-    userGuid: `user-${i}`,
     // Use deterministic pattern instead of random: cycles through 1-25
     atRiskApplicationCount: (i % 25) + 1,
   }));


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-39269

## 📔 Objective

The V2 Access Intelligence "At-Risk Members" CSV export (behind the `pm-31936-access-intelligence-new-architecture` flag) incorrectly included `userName` and `userGuid` columns. The export should contain only the member email and the at-risk application count.

Root cause: `DrawerMemberData` carried `userName`/`userGuid` fields that were written by the page-component content builders but never read by the drawer template or any logic. Because the shared `exportToCSV` helper emits every key present on each row object, these unused fields leaked into the CSV as extra columns.

This change removes the two dead fields from `DrawerMemberData` and stops populating them in `mapMembersToDrawerData` and `getCriticalAtRiskMembersContent`, so the export now contains only `email` and `atRiskApplicationCount`. The shared `exportToCSV` helper is intentionally left untouched (it backs several other exports), keeping the change scoped to the at-risk-members path. The member registry and report serialization are unaffected. The drawer download spec assertion is tightened to the two-column header and a regression test guards against the fields reappearing.
