### PR TITLE
[PM-24097] - [Vault] Remove getOrgKey from the key service

### DIFF
--- a/apps/cli/src/vault/create.command.spec.ts
+++ b/apps/cli/src/vault/create.command.spec.ts
@@ -71,7 +71,7 @@ describe("CreateCommand", () => {
     organizationService.organizations$.mockReturnValue(
       of([{ id: validOrgId, organizationUserId: orgUserId }] as any),
     );
-    keyService.getOrgKey.mockResolvedValue(mockOrgKey);
+    keyService.orgKeys$.mockReturnValue(of({ [validOrgId]: mockOrgKey } as any));
     encryptService.encryptString.mockResolvedValue(mockEncString);
     apiService.postCollection.mockResolvedValue({ id: "new-collection-id" } as any);
 
@@ -156,7 +156,7 @@ describe("CreateCommand", () => {
     });
 
     it("returns error when no org encryption key is found", async () => {
-      keyService.getOrgKey.mockResolvedValue(null);
+      keyService.orgKeys$.mockReturnValue(of(null));
       const result = await command["createOrganizationCollection"](makeRequest(), makeOptions());
       expect(result.success).toBe(false);
       expect(result.message).toContain("No encryption key for this organization");
@@ -166,7 +166,7 @@ describe("CreateCommand", () => {
       accountService.activeAccount$ = of(null);
       const result = await command["createOrganizationCollection"](makeRequest(), makeOptions());
       expect(result.success).toBe(false);
-      expect(result.message).toContain("No user found");
+      expect(result.message).toContain("Null or undefined account");
     });
 
     it("creates collection successfully with groups and users provided", async () => {

--- a/apps/cli/src/vault/create.command.ts
+++ b/apps/cli/src/vault/create.command.ts
@@ -19,6 +19,7 @@ import { CollectionExport } from "@bitwarden/common/models/export/collection.exp
 import { FolderExport } from "@bitwarden/common/models/export/folder.export";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
+import { OrganizationId } from "@bitwarden/common/types/guid";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { FolderApiServiceAbstraction } from "@bitwarden/common/vault/abstractions/folder/folder-api.service.abstraction";
 import { FolderService } from "@bitwarden/common/vault/abstractions/folder/folder.service.abstraction";
@@ -227,15 +228,11 @@ export class CreateCommand {
       return Response.badRequest("Collection name is required.");
     }
     try {
-      const orgKey = await this.keyService.getOrgKey(req.organizationId);
+      const userId = await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId));
+      const orgKeys = await firstValueFrom(this.keyService.orgKeys$(userId));
+      const orgKey = orgKeys?.[req.organizationId as OrganizationId] ?? null;
       if (orgKey == null) {
         throw new Error("No encryption key for this organization.");
-      }
-      const userId = await firstValueFrom(
-        this.accountService.activeAccount$.pipe(map((a) => a?.id)),
-      );
-      if (!userId) {
-        return Response.badRequest("No user found.");
       }
       const organization = await firstValueFrom(
         this.organizationService

--- a/libs/common/src/vault/services/cipher.service.ts
+++ b/libs/common/src/vault/services/cipher.service.ts
@@ -723,8 +723,13 @@ export class CipherService implements CipherServiceAbstraction {
       return [];
     }
 
+    const userId = await firstValueFrom(this.accountService.activeAccount$.pipe(map((a) => a?.id)));
+    if (!userId) {
+      throw new Error("User ID is required");
+    }
+    const orgKeys = await firstValueFrom(this.keyService.orgKeys$(userId));
+    const key = orgKeys?.[organizationId as OrganizationId] ?? null;
     const ciphers = response.data.map((cr) => new Cipher(new CipherData(cr)));
-    const key = await this.keyService.getOrgKey(organizationId);
     const decCiphers: CipherView[] = await Promise.all(
       ciphers.map(async (cipher) => {
         return await cipher.decrypt(key);


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Jira ticket link -->
https://bitwarden.atlassian.net/browse/PM-24097

## 📔 Objective

Replaces deprecated `keyService.getOrgKey(orgId)` calls with `keyService.orgKeys$(userId)` mapped to the desired `OrgKey`, as recommended by the deprecation notice on that method.

**Changed files:**

- `apps/cli/src/vault/create.command.ts` — `createOrganizationCollection`: fetches the active `userId` first (via `getUserId` pipe), then calls `orgKeys$(userId)` once and indexes into the result. Removes the now-redundant manual `userId` null-check since `getUserId` throws on missing account.
- `libs/common/src/vault/services/cipher.service.ts` — `decryptOrganizationCiphersResponse`: resolves the active `userId`, then fetches `orgKeys$(userId)` once before the `Promise.all` decrypt loop, avoiding repeated RSA decryption per cipher.


