### PR TITLE
[PM-39560] [BEEEP] Add MCP server configuration for Chrome and Electron DevTools

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,25 @@
+{
+  "mcpServers": {
+    "electron-devtools": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "chrome-devtools-mcp@1.2.0",
+        "--browserUrl=http://localhost:9222",
+        "--experimental-screencast"
+      ],
+      "env": {}
+    },
+    "chrome-devtools": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "chrome-devtools-mcp@1.2.0",
+        "--browserUrl=http://localhost:9200",
+        "--experimental-screencast",
+        "--categoryExtensions"
+      ],
+      "env": {}
+    }
+  }
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,6 +1,6 @@
 {
   "mcpServers": {
-    "electron-devtools": {
+    "electron-devtools-attach": {
       "type": "stdio",
       "command": "npx",
       "args": [
@@ -8,9 +8,10 @@
         "--browserUrl=http://localhost:9222",
         "--experimental-screencast"
       ],
-      "env": {}
+      "env": {},
+      "__comment": "This server is used to attach to a running electron app"
     },
-    "chrome-devtools": {
+    "chrome-devtools-attach": {
       "type": "stdio",
       "command": "npx",
       "args": [
@@ -19,7 +20,21 @@
         "--experimental-screencast",
         "--categoryExtensions"
       ],
-      "env": {}
+      "env": {},
+      "__comment": "This server is used to attach to a running chrome instance"
+    },
+    "chrome-devtools-headless": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "chrome-devtools-mcp@1.2.0",
+        "--experimental-screencast",
+        "--headless",
+        "--isolated",
+        "--categoryExtensions"
+      ],
+      "env": {},
+      "__comment": "This server is used for headless Chrome debugging. It can be launched concurrently"
     }
   }
 }


### PR DESCRIPTION
## Tracking
https://bitwarden.atlassian.net/browse/PM-39560

## Summary

Adds `.mcp.json` so Claude Code can drive the browser extension (port 9200) and Electron desktop app (port 9222) directly via Chrome DevTools protocol. Useful for hands-on testing and inspection without leaving the Claude Code session.

Appsec Dependency Review: https://bitwarden.atlassian.net/browse/VULN-657 -- dependency is approved for *dev only*, but `.mcp.json` is a dev only construct. We also pin to the 1.2.0 version.

