### PR TITLE
[PM-39608] [Shared Unlock] Snap Browser Extension Native Messaging Support

### DIFF
--- a/apps/desktop/desktop_native/core/src/ipc/mod.rs
+++ b/apps/desktop/desktop_native/core/src/ipc/mod.rs
@@ -42,6 +42,17 @@ pub const UNSANDBOXED_PATHS: [&str; 4] = [
     ".mozilla/native-messaging-hosts",
 ];
 
+/// The paths, relative to the host home directory, to where the native messaging files live for
+/// snap-packaged browsers. Snap-confined browsers can only reach a socket inside their own
+/// `~/snap/<browser>/` directory, so the server mounts a socket per snap browser here. 
+#[cfg(target_os = "linux")]
+pub const SNAP_PATHS: [&str; 4] = [
+    "snap/firefox/common/.mozilla/native-messaging-hosts",
+    "snap/chromium/common/chromium/NativeMessagingHosts",
+    "snap/brave/current/.config/BraveSoftware/Brave-Browser/NativeMessagingHosts",
+    "snap/microsoft-edge-dev/current/.config/microsoft-edge-dev/NativeMessagingHosts",
+];
+
 /// This is the codec used for communication through the UNIX socket / Windows named pipe.
 /// It's an internal implementation detail, but we want to make sure that both the client
 ///  and the server use the same one.
@@ -136,6 +147,14 @@ pub fn all_paths(name: &str) -> Vec<std::path::PathBuf> {
                 .iter()
                 .map(|path| host_home.join(path).join(format!(".app.{name}.socket")));
             paths.extend(unsandboxed_paths);
+
+            // Add the snap browser paths. These live under the real host home (`~/snap/<browser>/`),
+            // which a snap-confined browser's proxy can reach via its absolute path, so we build them
+            // from the host home rather than the (potentially sandbox-mapped) `dirs::home_dir()`.
+            let snap_paths = SNAP_PATHS
+                .iter()
+                .map(|path| host_home.join(path).join(format!(".app.{name}.socket")));
+            paths.extend(snap_paths);
         }
 
         paths

--- a/apps/desktop/desktop_native/core/src/ipc/mod.rs
+++ b/apps/desktop/desktop_native/core/src/ipc/mod.rs
@@ -44,7 +44,7 @@ pub const UNSANDBOXED_PATHS: [&str; 4] = [
 
 /// The paths, relative to the host home directory, to where the native messaging files live for
 /// snap-packaged browsers. Snap-confined browsers can only reach a socket inside their own
-/// `~/snap/<browser>/` directory, so the server mounts a socket per snap browser here. 
+/// `~/snap/<browser>/` directory, so the server mounts a socket per snap browser here.
 #[cfg(target_os = "linux")]
 pub const SNAP_PATHS: [&str; 4] = [
     "snap/firefox/common/.mozilla/native-messaging-hosts",
@@ -148,9 +148,10 @@ pub fn all_paths(name: &str) -> Vec<std::path::PathBuf> {
                 .map(|path| host_home.join(path).join(format!(".app.{name}.socket")));
             paths.extend(unsandboxed_paths);
 
-            // Add the snap browser paths. These live under the real host home (`~/snap/<browser>/`),
-            // which a snap-confined browser's proxy can reach via its absolute path, so we build them
-            // from the host home rather than the (potentially sandbox-mapped) `dirs::home_dir()`.
+            // Add the snap browser paths. These live under the real host home
+            // (`~/snap/<browser>/`), which a snap-confined browser's proxy can reach
+            // via its absolute path, so we build them from the host home rather than
+            // the (potentially sandbox-mapped) `dirs::home_dir()`.
             let snap_paths = SNAP_PATHS
                 .iter()
                 .map(|path| host_home.join(path).join(format!(".app.{name}.socket")));

--- a/apps/desktop/desktop_native/core/src/ipc/mod.rs
+++ b/apps/desktop/desktop_native/core/src/ipc/mod.rs
@@ -46,11 +46,10 @@ pub const UNSANDBOXED_PATHS: [&str; 4] = [
 /// snap-packaged browsers. Snap-confined browsers can only reach a socket inside their own
 /// `~/snap/<browser>/` directory, so the server mounts a socket per snap browser here.
 #[cfg(target_os = "linux")]
-pub const SNAP_PATHS: [&str; 4] = [
+pub const SNAP_PATHS: [&str; 3] = [
     "snap/firefox/common/.mozilla/native-messaging-hosts",
     "snap/chromium/common/chromium/NativeMessagingHosts",
     "snap/brave/current/.config/BraveSoftware/Brave-Browser/NativeMessagingHosts",
-    "snap/microsoft-edge-dev/current/.config/microsoft-edge-dev/NativeMessagingHosts",
 ];
 
 /// This is the codec used for communication through the UNIX socket / Windows named pipe.

--- a/apps/desktop/desktop_native/proxy/src/main.rs
+++ b/apps/desktop/desktop_native/proxy/src/main.rs
@@ -61,7 +61,22 @@ fn init_logging(log_path: &Path, console_level: LevelFilter, file_level: LevelFi
 #[allow(clippy::unwrap_used)]
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
-    let sock_paths = desktop_core::ipc::all_paths("bw");
+    #[cfg_attr(not(target_os = "linux"), allow(unused_mut))]
+    let mut sock_paths = desktop_core::ipc::all_paths("bw");
+
+    // When running inside a snap sandbox, the browser's proxy can only reach sockets that live
+    // under its own snap directory (`~/snap/<name>/`). The unsandboxed (`~/.config/...`) and other
+    // snaps' sockets may appear to exist via `stat`, but connecting to them is blocked by the
+    // snap's AppArmor confinement (yielding "Permission denied"). Restrict the candidates to the
+    // current snap's directory so we connect to the socket the desktop app mounted for this snap.
+    #[cfg(target_os = "linux")]
+    if let Ok(snap_user_common) = std::env::var("SNAP_USER_COMMON") {
+        // `SNAP_USER_COMMON` is `~/snap/<name>/common`; its parent is the snap root `~/snap/<name>`.
+        if let Some(snap_root) = Path::new(&snap_user_common).parent().map(Path::to_path_buf) {
+            sock_paths.retain(|p| p.starts_with(&snap_root));
+        }
+    }
+
     let sock_path = sock_paths
         .into_iter()
         .find(|p| p.exists())

--- a/apps/desktop/desktop_native/proxy/src/main.rs
+++ b/apps/desktop/desktop_native/proxy/src/main.rs
@@ -71,7 +71,8 @@ async fn main() {
     // current snap's directory so we connect to the socket the desktop app mounted for this snap.
     #[cfg(target_os = "linux")]
     if let Ok(snap_user_common) = std::env::var("SNAP_USER_COMMON") {
-        // `SNAP_USER_COMMON` is `~/snap/<name>/common`; its parent is the snap root `~/snap/<name>`.
+        // `SNAP_USER_COMMON` is `~/snap/<name>/common`; its parent is the snap root
+        // `~/snap/<name>`.
         if let Some(snap_root) = Path::new(&snap_user_common).parent().map(Path::to_path_buf) {
             sock_paths.retain(|p| p.starts_with(&snap_root));
         }

--- a/apps/desktop/electron-builder.json
+++ b/apps/desktop/electron-builder.json
@@ -283,7 +283,11 @@
             "$HOME/.config/chromium/NativeMessagingHosts",
             "$HOME/.config/microsoft-edge/NativeMessagingHosts",
             "$HOME/.config/google-chrome/NativeMessagingHosts",
-            "$HOME/.mozilla"
+            "$HOME/.mozilla",
+            "$HOME/snap/firefox/common/.mozilla",
+            "$HOME/snap/chromium/common/chromium/NativeMessagingHosts",
+            "$HOME/snap/google-chrome/common/google-chrome/NativeMessagingHosts",
+            "$HOME/snap/microsoft-edge/common/microsoft-edge/NativeMessagingHosts"
           ]
         }
       },

--- a/apps/desktop/electron-builder.json
+++ b/apps/desktop/electron-builder.json
@@ -286,8 +286,7 @@
             "$HOME/.mozilla",
             "$HOME/snap/firefox/common/.mozilla",
             "$HOME/snap/chromium/common/chromium/NativeMessagingHosts",
-            "$HOME/snap/google-chrome/common/google-chrome/NativeMessagingHosts",
-            "$HOME/snap/microsoft-edge/common/microsoft-edge/NativeMessagingHosts"
+            "$HOME/snap/brave/current/.config/BraveSoftware/Brave-Browser/NativeMessagingHosts"
           ]
         }
       },

--- a/apps/desktop/src/main/native-messaging.main.ts
+++ b/apps/desktop/src/main/native-messaging.main.ts
@@ -166,6 +166,15 @@ export class NativeMessagingMain {
       throw new Error(`Unable to find proxy binary: ${binaryPath}`);
     }
 
+    // Firefox-based browsers may not have created their native messaging host directory yet.
+    // Create it when the browser is installed so the manifest below can be written.
+    for (const { installDir, nmhsDir } of this.getFirefoxNMHSDirsToCreate()) {
+      if (existsSync(installDir) && !existsSync(nmhsDir)) {
+        await fs.mkdir(nmhsDir, { recursive: true });
+        this.logService.info(`[Native messaging] Created missing manifest directory ${nmhsDir}`);
+      }
+    }
+
     switch (process.platform) {
       case "win32": {
         const destination = path.join(this.userPath, "browsers");
@@ -256,13 +265,45 @@ export class NativeMessagingMain {
                 path.join(value, "com.8bit.bitwarden.json"),
                 await this.generateFirefoxJson(sandboxedProxyBinaryPath),
               );
-            } else if (key === "Chrome" || key === "Chromium" || key === "Microsoft Edge") {
+            } else if (
+              key === "Chrome" ||
+              key === "Chromium" ||
+              key === "Microsoft Edge" ||
+              key === "Brave"
+            ) {
               await this.writeManifest(
                 path.join(value, "com.8bit.bitwarden.json"),
                 await this.generateChromeJson(sandboxedProxyBinaryPath),
               );
             } else {
               this.logService.warning(`Flatpak ${key} not supported, skipping.`);
+            }
+          } else {
+            this.logService.warning(`${key} not found, skipping.`);
+          }
+        }
+
+        // Snap browser
+        for (const [key, value] of Object.entries(this.getSnapNMHS())) {
+          if (existsSync(value)) {
+            const sandboxedProxyBinaryPath = path.join(value, ".bitwarden_desktop_proxy");
+            await this.linkOrCopy(binaryPath, sandboxedProxyBinaryPath);
+            this.logService.info(
+              `[Native messaging] Hard-linked ${binaryPath} to ${sandboxedProxyBinaryPath}`,
+            );
+
+            if (key === "Firefox") {
+              await this.writeManifest(
+                path.join(value, "com.8bit.bitwarden.json"),
+                await this.generateFirefoxJson(sandboxedProxyBinaryPath),
+              );
+            } else if (key === "Chromium" || key === "Brave" || key === "Microsoft Edge") {
+              await this.writeManifest(
+                path.join(value, "com.8bit.bitwarden.json"),
+                await this.generateChromeJson(sandboxedProxyBinaryPath),
+              );
+            } else {
+              this.logService.warning(`Snap ${key} not supported, skipping.`);
             }
           } else {
             this.logService.warning(`${key} not found, skipping.`);
@@ -339,6 +380,11 @@ export class NativeMessagingMain {
           await this.removeIfExists(path.join(value, ".bitwarden_desktop_proxy"));
         }
 
+        for (const [, value] of Object.entries(this.getSnapNMHS())) {
+          await this.removeIfExists(path.join(value, "com.8bit.bitwarden.json"));
+          await this.removeIfExists(path.join(value, ".bitwarden_desktop_proxy"));
+        }
+
         break;
       }
       default:
@@ -381,11 +427,12 @@ export class NativeMessagingMain {
         "HKCU",
         "SOFTWARE\\Microsoft\\Edge\\NativeMessagingHosts\\com.8bit.bitwarden",
       ],
-      Vivaldi: ["HKCU", "SOFTWARE\\Vivaldi\\NativeMessagingHosts\\com.8bit.bitwarden"],
       Brave: [
         "HKCU",
         "SOFTWARE\\BraveSoftware\\Brave-Browser\\NativeMessagingHosts\\com.8bit.bitwarden",
       ],
+      // Community Maintained. No official support provided
+      Vivaldi: ["HKCU", "SOFTWARE\\Vivaldi\\NativeMessagingHosts\\com.8bit.bitwarden"],
     };
   }
 
@@ -402,6 +449,7 @@ export class NativeMessagingMain {
       "Microsoft Edge Beta": `${this.homedir()}/Library/Application\ Support/Microsoft\ Edge\ Beta/`,
       "Microsoft Edge Dev": `${this.homedir()}/Library/Application\ Support/Microsoft\ Edge\ Dev/`,
       "Microsoft Edge Canary": `${this.homedir()}/Library/Application\ Support/Microsoft\ Edge\ Canary/`,
+      // Community Maintained. No official support provided
       Vivaldi: `${this.homedir()}/Library/Application\ Support/Vivaldi/`,
       Zen: `${this.homedir()}/Library/Application\ Support/Zen/`,
       Helium: `${this.homedir()}/Library/Application\ Support/net.imput.helium/`,
@@ -415,8 +463,9 @@ export class NativeMessagingMain {
       Chrome: `${this.homedir()}/.config/google-chrome/`,
       Chromium: `${this.homedir()}/.config/chromium/`,
       "Microsoft Edge": `${this.homedir()}/.config/microsoft-edge/`,
-      Vivaldi: `${this.homedir()}/.config/vivaldi/`,
       Brave: `${this.homedir()}/.config/BraveSoftware/Brave-Browser/`,
+      // Community Maintained. No official support provided
+      Vivaldi: `${this.homedir()}/.config/vivaldi/`,
     };
   }
 
@@ -426,7 +475,56 @@ export class NativeMessagingMain {
       Chrome: `${this.homedir()}/.var/app/com.google.Chrome/config/google-chrome/NativeMessagingHosts/`,
       Chromium: `${this.homedir()}/.var/app/org.chromium.Chromium/config/chromium/NativeMessagingHosts/`,
       "Microsoft Edge": `${this.homedir()}/.var/app/com.microsoft.Edge/config/microsoft-edge/NativeMessagingHosts/`,
+      Brave: `${this.homedir()}/.var/app/com.brave.Browser/config/BraveSoftware/Brave-Browser/NativeMessagingHosts/`,
     };
+  }
+
+  private getSnapNMHS() {
+    return {
+      Firefox: `${this.homedir()}/snap/firefox/common/.mozilla/native-messaging-hosts/`,
+      Chromium: `${this.homedir()}/snap/chromium/common/chromium/NativeMessagingHosts/`,
+      Brave: `${this.homedir()}/snap/brave/current/.config/BraveSoftware/Brave-Browser/NativeMessagingHosts/`,
+      "Microsoft Edge": `${this.homedir()}/snap/microsoft-edge-dev/current/.config/microsoft-edge-dev/NativeMessagingHosts/`,
+    };
+  }
+
+  /*
+    Firefox-based browsers create their native messaging host directory lazily and, unlike the
+    chromium-based browsers, have no fallback to another browser's path. So when the browser is
+    installed (its parent/app directory exists) but the manifest directory has not been created
+    yet, we create it up front so the manifest can be installed.
+  */
+  private getFirefoxNMHSDirsToCreate(): { installDir: string; nmhsDir: string }[] {
+    const home = this.homedir();
+    switch (process.platform) {
+      case "darwin": {
+        const appSupport = `${home}/Library/Application Support`;
+        return [
+          {
+            installDir: `${appSupport}/Firefox/`,
+            nmhsDir: `${appSupport}/Mozilla/NativeMessagingHosts/`,
+          },
+          { installDir: `${appSupport}/Zen/`, nmhsDir: `${appSupport}/Zen/NativeMessagingHosts/` },
+        ];
+      }
+      case "linux":
+        return [
+          // Unsandboxed
+          { installDir: `${home}/.mozilla/`, nmhsDir: `${home}/.mozilla/native-messaging-hosts/` },
+          // Snap
+          {
+            installDir: `${home}/snap/firefox/`,
+            nmhsDir: `${home}/snap/firefox/common/.mozilla/native-messaging-hosts/`,
+          },
+          // Flatpak
+          {
+            installDir: `${home}/.var/app/org.mozilla.firefox/`,
+            nmhsDir: `${home}/.var/app/org.mozilla.firefox/.mozilla/native-messaging-hosts/`,
+          },
+        ];
+      default:
+        return [];
+    }
   }
 
   private async writeManifest(destination: string, manifest: object) {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-39608
https://forum.snapcraft.io/t/auto-connection-for-personal-files-for-bitwarden-desktop/51959

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Implement support for snap-sandboxed browsers, to communicate with the desktop app.
This means that on Linux, all combinations are now supported 🎉

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

<img width="2498" height="1562" alt="image" src="https://github.com/user-attachments/assets/5bef2bc7-7524-4087-94bb-09d456355f31" />
