### PR TITLE
[CL-1225] Berry should hide when count is 0 in toggle group

### DIFF
--- a/libs/components/src/berry/berry.component.ts
+++ b/libs/components/src/berry/berry.component.ts
@@ -24,7 +24,7 @@ export type BerryVariant =
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     "[class]": "containerClasses()",
-    "[class.tw-hidden]": "!content() && type() === 'count'",
+    "[class.!tw-hidden]": "!content() && type() === 'count'",
   },
 })
 export class BerryComponent {

--- a/libs/components/src/toggle-group/toggle-group.stories.ts
+++ b/libs/components/src/toggle-group/toggle-group.stories.ts
@@ -41,7 +41,9 @@ export const Default: Story = {
           Accepted <bit-berry [value]="2" variant="danger"></bit-berry>
         </bit-toggle>
 
-        <bit-toggle value="deactivated"> Deactivated </bit-toggle>
+        <bit-toggle value="deactivated">
+          Deactivated <bit-berry [value]="0" variant="danger"></bit-berry>
+        </bit-toggle>
       </bit-toggle-group>
     `,
   }),


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[CL-1225](https://bitwarden.atlassian.net/browse/CL-1225)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Fix issue where berries showed up blank in toggle groups when the count is 0, when they should hide themselves instead.

Added to the existing story to catch regressions in the future.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

| Before | After |
|--------|--------|
| <img width="1296" height="839" alt="Screenshot 2026-06-25 at 10 13 29 AM" src="https://github.com/user-attachments/assets/ac846332-a61e-4f0f-b683-e3ec873b0f6f" /> | <img width="1296" height="839" alt="Screenshot 2026-06-25 at 10 14 54 AM" src="https://github.com/user-attachments/assets/388daed5-c454-4b3c-9886-2a96284ff6f1" /> |


[CL-1225]: https://bitwarden.atlassian.net/browse/CL-1225?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ