### PR TITLE
[PM-23485] Use a staticlib for UniFFI

### DIFF
--- a/apps/desktop/desktop_native/autofill_provider/Cargo.toml
+++ b/apps/desktop/desktop_native/autofill_provider/Cargo.toml
@@ -6,7 +6,7 @@ version = { workspace = true }
 publish = { workspace = true }
 
 [lib]
-crate-type = ["lib", "staticlib", "cdylib"]
+crate-type = ["lib", "staticlib"]
 bench = false
 
 [[bin]]

--- a/apps/desktop/desktop_native/autofill_provider/build.sh
+++ b/apps/desktop/desktop_native/autofill_provider/build.sh
@@ -25,7 +25,7 @@ lipo -create ../target/aarch64-apple-darwin/release/libautofill_provider.a \
 
 # Generate swift bindings
 cargo run --bin uniffi-bindgen --features uniffi/cli generate \
-  ../target/aarch64-apple-darwin/release/libautofill_provider.dylib \
+  ../target/aarch64-apple-darwin/release/libautofill_provider.a \
   --library \
   --language swift \
   --no-format \


### PR DESCRIPTION
## 🎟️ Tracking
[PM-23485](https://bitwarden.atlassian.net/browse/PM-23485)

## 📔 Objective

This is required to have NAPI and UniFFI to coexist in the autofill_provider crate. NAPI references symbols that are only available when building the NAPI crate. Using cdylib causes cargo to try to link to those missing symbols. Using a staticlib, the linker does not resolve until the NAPI crate is built, which works fine.



[PM-23485]: https://bitwarden.atlassian.net/browse/PM-23485?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ