### PR TITLE
[PM-38480] Add Staged Event Message

### DIFF
--- a/apps/web/src/app/dirt/event-logs/services/event.service.ts
+++ b/apps/web/src/app/dirt/event-logs/services/event.service.ts
@@ -442,6 +442,13 @@ export class EventService {
           this.getShortId(ev.organizationUserId),
         );
         break;
+      case EventType.OrganizationUser_Staged:
+        msg = this.i18nService.t("stagedUserId", this.formatOrgUserId(ev));
+        humanReadableMsg = this.i18nService.t(
+          "stagedUserId",
+          this.getShortId(ev.organizationUserId),
+        );
+        break;
       case EventType.OrganizationUser_ApprovedAuthRequest:
         msg = this.i18nService.t("approvedAuthRequest", this.formatOrgUserId(ev));
         humanReadableMsg = this.i18nService.t(

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -5040,6 +5040,15 @@
       }
     }
   },
+  "stagedUserId": {
+    "message": "Staged user $ID$ added.",
+    "placeholders": {
+      "id": {
+        "content": "$1",
+        "example": "John Smith"
+      }
+    }
+  },
   "revokedEmailError": {
     "message": "1 or more emails belong to revoked members. Restore their access to reinvite."
   },

--- a/libs/common/src/dirt/event-logs/enums/event-type.enum.ts
+++ b/libs/common/src/dirt/event-logs/enums/event-type.enum.ts
@@ -80,6 +80,7 @@ export enum EventType {
   OrganizationUser_Revoked_TwoFactorNonCompliance = 1520,
   OrganizationUser_Revoked_SingleOrganizationNonCompliance = 1521,
   OrganizationUser_NotificationBannerActionClicked = 1522,
+  OrganizationUser_Staged = 1523,
 
   Organization_Updated = 1600,
   Organization_PurgedVault = 1601,


### PR DESCRIPTION
## 🎟️ Tracking
[PM-38480](https://bitwarden.atlassian.net/browse/PM-38480)

## 📔 Objective
Adding messages when users are staged via SCIM/BWDC. No screenshots yet - staged command (which handles the event) is not up and running.

[PM-38480]: https://bitwarden.atlassian.net/browse/PM-38480?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ