### PR TITLE
[PM-33362] Autotype Edit Cipher Initial Changes

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -5483,11 +5483,30 @@
       }
     }
   },
+  "appUri": {
+    "message": "App (URI)"
+  },
+  "appUriCount": {
+    "message": "App (URI) $COUNT$",
+    "description": "Label for an input field that contains an app URI. The input field is part of a list of fields, and the count indicates the position of the field in the list.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      }
+    }
+  },
   "websiteAdded": {
     "message": "Website added"
   },
   "addWebsite": {
     "message": "Add website"
+  },
+  "addWebsiteOrApp": {
+    "message": "Add website or app"
+  },
+  "app": {
+    "message": "App"
   },
   "deleteWebsite": {
     "message": "Delete website"

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -711,11 +711,30 @@
       }
     }
   },
+  "appUri": {
+    "message": "App (URI)"
+  },
+  "appUriCount": {
+    "message": "App (URI) $COUNT$",
+    "description": "Label for an input field that contains an app URI. The input field is part of a list of fields, and the count indicates the position of the field in the list.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      }
+    }
+  },
   "websiteAdded": {
     "message": "Website added"
   },
   "addWebsite": {
     "message": "Add website"
+  },
+  "addWebsiteOrApp": {
+    "message": "Add website or app"
+  },
+  "app": {
+    "message": "App"
   },
   "deleteWebsite": {
     "message": "Delete website"

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -646,11 +646,30 @@
       }
     }
   },
+  "appUri": {
+    "message": "App (URI)"
+  },
+  "appUriCount": {
+    "message": "App (URI) $COUNT$",
+    "description": "Label for an input field that contains an app URI. The input field is part of a list of fields, and the count indicates the position of the field in the list.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      }
+    }
+  },
   "websiteAdded": {
     "message": "Website added"
   },
   "addWebsite": {
     "message": "Add website"
+  },
+  "addWebsiteOrApp": {
+    "message": "Add website or app"
+  },
+  "app": {
+    "message": "App"
   },
   "deleteWebsite": {
     "message": "Delete website"

--- a/libs/vault/src/cipher-form/cipher-form.stories.ts
+++ b/libs/vault/src/cipher-form/cipher-form.stories.ts
@@ -22,7 +22,7 @@ import { AccountService } from "@bitwarden/common/auth/abstractions/account.serv
 import { AutofillSettingsServiceAbstraction } from "@bitwarden/common/autofill/services/autofill-settings.service";
 import { DomainSettingsService } from "@bitwarden/common/autofill/services/domain-settings.service";
 import { EventCollectionService } from "@bitwarden/common/dirt/event-logs";
-import { ClientType } from "@bitwarden/common/enums";
+import { ClientType, DeviceType } from "@bitwarden/common/enums";
 import { UriMatchStrategy } from "@bitwarden/common/models/domain/domain-service";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
@@ -231,6 +231,7 @@ export default {
           provide: PlatformUtilsService,
           useValue: {
             getClientType: () => ClientType.Browser,
+            getDevice: () => DeviceType.ChromeExtension,
           },
         },
         {

--- a/libs/vault/src/cipher-form/components/autofill-options/autofill-options.component.html
+++ b/libs/vault/src/cipher-form/components/autofill-options/autofill-options.component.html
@@ -18,6 +18,7 @@
           [canRemove]="uriControls.length > 1 && autofillOptionsForm.enabled"
           [defaultMatchDetection]="defaultMatchDetection$ | async"
           [index]="i"
+          [showAppLabel]="showAddAppDropdown()"
         ></vault-autofill-uri-option>
       }
     </ng-container>

--- a/libs/vault/src/cipher-form/components/autofill-options/autofill-options.component.html
+++ b/libs/vault/src/cipher-form/components/autofill-options/autofill-options.component.html
@@ -23,16 +23,45 @@
     </ng-container>
 
     @if (autofillOptionsForm.enabled) {
-      <button
-        type="button"
-        bitLink
-        linkType="primary"
-        [class.tw-mb-6]="autofillOnPageLoadEnabled$ | async"
-        (click)="addUri({ uri: null, matchDetection: null }, true)"
-        startIcon="bwi-plus"
-      >
-        {{ "addWebsite" | i18n }}
-      </button>
+      @if (showAddAppDropdown()) {
+        <button
+          type="button"
+          bitLink
+          linkType="primary"
+          [class.tw-mb-6]="autofillOnPageLoadEnabled$ | async"
+          startIcon="bwi-plus"
+          [bitMenuTriggerFor]="addUriMenu"
+        >
+          {{ "addWebsiteOrApp" | i18n }}
+        </button>
+        <bit-menu #addUriMenu>
+          <button
+            type="button"
+            bitMenuItem
+            (click)="addUri({ uri: null, matchDetection: null }, true)"
+          >
+            {{ "website" | i18n }}
+          </button>
+          <button
+            type="button"
+            bitMenuItem
+            (click)="addUri({ uri: desktopAppUriPrefix, matchDetection: null }, true)"
+          >
+            {{ "app" | i18n }}
+          </button>
+        </bit-menu>
+      } @else {
+        <button
+          type="button"
+          bitLink
+          linkType="primary"
+          [class.tw-mb-6]="autofillOnPageLoadEnabled$ | async"
+          (click)="addUri({ uri: null, matchDetection: null }, true)"
+          startIcon="bwi-plus"
+        >
+          {{ "addWebsite" | i18n }}
+        </button>
+      }
     }
 
     @if (autofillOnPageLoadEnabled$ | async) {

--- a/libs/vault/src/cipher-form/components/autofill-options/autofill-options.component.spec.ts
+++ b/libs/vault/src/cipher-form/components/autofill-options/autofill-options.component.spec.ts
@@ -6,13 +6,16 @@ import { BehaviorSubject } from "rxjs";
 
 import { AutofillSettingsServiceAbstraction } from "@bitwarden/common/autofill/services/autofill-settings.service";
 import { DomainSettingsService } from "@bitwarden/common/autofill/services/domain-settings.service";
+import { DeviceType } from "@bitwarden/common/enums";
 import { UriMatchStrategy } from "@bitwarden/common/models/domain/domain-service";
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { LoginUriView } from "@bitwarden/common/vault/models/view/login-uri.view";
 import { LoginView } from "@bitwarden/common/vault/models/view/login.view";
 
+import { DESKTOP_APP_URI_PREFIX } from "../../../models/desktop-app-uri.constants";
 import { CipherFormContainer } from "../../cipher-form-container";
 
 import { AutofillOptionsComponent } from "./autofill-options.component";
@@ -34,6 +37,8 @@ describe("AutofillOptionsComponent", () => {
   let domainSettingsService: MockProxy<DomainSettingsService>;
   let autofillSettingsService: MockProxy<AutofillSettingsServiceAbstraction>;
   let platformUtilsService: MockProxy<PlatformUtilsService>;
+  let configService: MockProxy<ConfigService>;
+  let featureFlagSubject: BehaviorSubject<boolean>;
   const getInitialCipherView = jest.fn((): any => null);
   const formStatusChange$ = new BehaviorSubject<"enabled" | "disabled">("enabled");
 
@@ -43,6 +48,8 @@ describe("AutofillOptionsComponent", () => {
     cipherFormContainer.formStatusChange$ = formStatusChange$.asObservable();
     liveAnnouncer = mock<LiveAnnouncer>();
     platformUtilsService = mock<PlatformUtilsService>();
+    featureFlagSubject = new BehaviorSubject<boolean>(false);
+    configService = mock<ConfigService>();
     domainSettingsService = mock<DomainSettingsService>();
     domainSettingsService.resolvedDefaultUriMatchStrategy$ = new BehaviorSubject(null);
 
@@ -62,6 +69,7 @@ describe("AutofillOptionsComponent", () => {
         { provide: DomainSettingsService, useValue: domainSettingsService },
         { provide: AutofillSettingsServiceAbstraction, useValue: autofillSettingsService },
         { provide: PlatformUtilsService, useValue: platformUtilsService },
+        { provide: ConfigService, useValue: configService },
       ],
     }).compileComponents();
 
@@ -282,6 +290,116 @@ describe("AutofillOptionsComponent", () => {
     fixture.detectChanges();
 
     expect(enable).toHaveBeenCalledWith({ emitEvent: false });
+  });
+
+  // Autotype App Tests
+  describe("showAddAppDropdown", () => {
+    it("is false when device type is not Windows Desktop", () => {
+      fixture.detectChanges();
+
+      expect(component["showAddAppDropdown"]()).toBe(false);
+    });
+
+    it("is false when device type is Windows Desktop but windows-desktop-autotype-ga feature flag is off", () => {
+      platformUtilsService.getDevice.mockReturnValue(DeviceType.WindowsDesktop);
+      configService.getFeatureFlag$.mockReturnValue(featureFlagSubject);
+
+      const localFixture = TestBed.createComponent(AutofillOptionsComponent);
+      localFixture.detectChanges();
+
+      expect(localFixture.componentInstance["showAddAppDropdown"]()).toBe(false);
+    });
+
+    it("is true when device is Windows Desktop and windows-desktop-autotype-ga feature flag is on", () => {
+      platformUtilsService.getDevice.mockReturnValue(DeviceType.WindowsDesktop);
+      configService.getFeatureFlag$.mockReturnValue(featureFlagSubject);
+
+      featureFlagSubject.next(true);
+
+      const localFixture = TestBed.createComponent(AutofillOptionsComponent);
+      localFixture.detectChanges();
+
+      expect(localFixture.componentInstance["showAddAppDropdown"]()).toBe(true);
+    });
+  });
+
+  // Autotype App Tests
+  describe("Add URI button", () => {
+    it("renders a plain 'Add website' button when showAddAppDropdown is false", () => {
+      fixture.detectChanges();
+
+      const buttons = Array.from(
+        fixture.nativeElement.querySelectorAll("button"),
+      ) as HTMLButtonElement[];
+      const addWebsiteBtn = buttons.find((btn) => btn.textContent?.trim() === "addWebsite");
+      const menu = fixture.nativeElement.querySelector("bit-menu");
+
+      expect(addWebsiteBtn).toBeTruthy();
+      expect(menu).toBeFalsy();
+    });
+
+    it("renders an 'Add website or app' dropdown button with 'Website' and 'App' options when showAddAppDropdown is true", () => {
+      platformUtilsService.getDevice.mockReturnValue(DeviceType.WindowsDesktop);
+      configService.getFeatureFlag$.mockReturnValue(featureFlagSubject);
+
+      featureFlagSubject.next(true);
+
+      const localFixture = TestBed.createComponent(AutofillOptionsComponent);
+      localFixture.detectChanges();
+
+      // Verify the trigger button is present
+      const triggerBtn = Array.from(localFixture.nativeElement.querySelectorAll("button")).find(
+        (btn: HTMLButtonElement) => btn.textContent?.trim() === "addWebsiteOrApp",
+      ) as HTMLButtonElement;
+      expect(triggerBtn).toBeTruthy();
+
+      // Open the menu
+      triggerBtn.click();
+      localFixture.detectChanges();
+
+      // Verify both options are present in the dropdown
+      const menuButtons = Array.from(
+        document.querySelectorAll(".cdk-overlay-container button"),
+      ) as HTMLButtonElement[];
+      const websiteBtn = menuButtons.find((btn) => btn.textContent?.trim() === "website");
+      const appBtn = menuButtons.find((btn) => btn.textContent?.trim() === "app");
+
+      expect(websiteBtn).toBeTruthy();
+      expect(appBtn).toBeTruthy();
+    });
+
+    it("clicking 'App' menu item calls addUri with the desktopapp:// prefix", () => {
+      platformUtilsService.getDevice.mockReturnValue(DeviceType.WindowsDesktop);
+      configService.getFeatureFlag$.mockReturnValue(featureFlagSubject);
+      featureFlagSubject.next(true);
+
+      const localFixture = TestBed.createComponent(AutofillOptionsComponent);
+      const localComponent = localFixture.componentInstance;
+      localFixture.detectChanges();
+
+      jest.spyOn(localComponent, "addUri");
+
+      // Open the menu by clicking the trigger button
+      const triggerBtn = Array.from(localFixture.nativeElement.querySelectorAll("button")).find(
+        (btn: HTMLButtonElement) => btn.textContent?.trim() === "addWebsiteOrApp",
+      ) as HTMLButtonElement;
+      expect(triggerBtn).toBeTruthy();
+      triggerBtn.click();
+      localFixture.detectChanges();
+
+      // Menu content is rendered in the CDK overlay portal, not in the component's DOM
+      const menuButtons = Array.from(
+        document.querySelectorAll(".cdk-overlay-container button"),
+      ) as HTMLButtonElement[];
+      const appBtn = menuButtons.find((btn) => btn.textContent?.trim() === "app");
+      expect(appBtn).toBeTruthy();
+      appBtn.click();
+
+      expect(localComponent.addUri).toHaveBeenCalledWith(
+        { uri: DESKTOP_APP_URI_PREFIX, matchDetection: null },
+        true,
+      );
+    });
   });
 
   describe("Drag & Drop Functionality", () => {

--- a/libs/vault/src/cipher-form/components/autofill-options/autofill-options.component.ts
+++ b/libs/vault/src/cipher-form/components/autofill-options/autofill-options.component.ts
@@ -4,15 +4,17 @@ import { LiveAnnouncer } from "@angular/cdk/a11y";
 import { CdkDragDrop, DragDropModule, moveItemInArray } from "@angular/cdk/drag-drop";
 import { AsyncPipe } from "@angular/common";
 import { Component, OnInit, QueryList, ViewChildren } from "@angular/core";
-import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
+import { takeUntilDestroyed, toSignal } from "@angular/core/rxjs-interop";
 import { FormBuilder, ReactiveFormsModule } from "@angular/forms";
-import { filter, Subject, switchMap, take } from "rxjs";
+import { filter, of, Subject, switchMap, take } from "rxjs";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { AutofillSettingsServiceAbstraction } from "@bitwarden/common/autofill/services/autofill-settings.service";
 import { DomainSettingsService } from "@bitwarden/common/autofill/services/domain-settings.service";
-import { ClientType } from "@bitwarden/common/enums";
+import { ClientType, DeviceType } from "@bitwarden/common/enums";
+import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { UriMatchStrategySetting } from "@bitwarden/common/models/domain/domain-service";
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { LoginUriView } from "@bitwarden/common/vault/models/view/login-uri.view";
@@ -22,11 +24,13 @@ import {
   FormFieldModule,
   IconButtonModule,
   LinkModule,
+  MenuModule,
   SectionHeaderComponent,
   SelectModule,
   TypographyModule,
 } from "@bitwarden/components";
 
+import { DESKTOP_APP_URI_PREFIX } from "../../../models/desktop-app-uri.constants";
 import { CipherFormContainer } from "../../cipher-form-container";
 
 import { UriOptionComponent } from "./uri-option.component";
@@ -53,6 +57,7 @@ interface UriField {
     IconButtonModule,
     UriOptionComponent,
     LinkModule,
+    MenuModule,
     AsyncPipe,
   ],
 })
@@ -97,6 +102,18 @@ export class AutofillOptionsComponent implements OnInit {
    */
   private focusOnNewInput$ = new Subject<void>();
 
+  private readonly isWindowsDesktop =
+    this.platformUtilsService.getDevice() === DeviceType.WindowsDesktop;
+
+  protected readonly showAddAppDropdown = toSignal(
+    this.isWindowsDesktop
+      ? this.configService.getFeatureFlag$(FeatureFlag.WindowsDesktopAutotypeGA)
+      : of(false),
+    { initialValue: false },
+  );
+
+  protected readonly desktopAppUriPrefix = DESKTOP_APP_URI_PREFIX;
+
   constructor(
     private cipherFormContainer: CipherFormContainer,
     private formBuilder: FormBuilder,
@@ -105,6 +122,7 @@ export class AutofillOptionsComponent implements OnInit {
     private domainSettingsService: DomainSettingsService,
     private autofillSettingsService: AutofillSettingsServiceAbstraction,
     private platformUtilsService: PlatformUtilsService,
+    private configService: ConfigService,
   ) {
     this.cipherFormContainer.registerChildForm("autoFillOptions", this.autofillOptionsForm);
 

--- a/libs/vault/src/cipher-form/components/autofill-options/uri-option.component.spec.ts
+++ b/libs/vault/src/cipher-form/components/autofill-options/uri-option.component.spec.ts
@@ -203,16 +203,34 @@ describe("UriOptionComponent", () => {
       expect(component["uriLabel"]).toBe("websiteUriCount 2");
     });
 
-    it("returns 'appUri' for a desktopapp:// URI at index 0", () => {
+    it("returns 'websiteUri' for a desktopapp:// URI at index 0 when showAppLabel is false", () => {
       component.writeValue({ uri: DESKTOP_APP_URI_PREFIX, matchDetection: null });
       component.index = 0;
+      component.showAppLabel = false;
+
+      expect(component["uriLabel"]).toBe("websiteUri");
+    });
+
+    it("returns 'websiteUriCount' for a desktopapp:// URI at index greater than 0 when showAppLabel is false", () => {
+      component.writeValue({ uri: DESKTOP_APP_URI_PREFIX, matchDetection: null });
+      component.index = 1;
+      component.showAppLabel = false;
+
+      expect(component["uriLabel"]).toBe("websiteUriCount 2");
+    });
+
+    it("returns 'appUri' for a desktopapp:// URI at index 0 when showAppLabel is true", () => {
+      component.writeValue({ uri: DESKTOP_APP_URI_PREFIX, matchDetection: null });
+      component.index = 0;
+      component.showAppLabel = true;
 
       expect(component["uriLabel"]).toBe("appUri");
     });
 
-    it("returns 'appUriCount' for a desktopapp:// URI at index greater than 0", () => {
+    it("returns 'appUriCount' for a desktopapp:// URI at index greater than 0 when showAppLabel is true", () => {
       component.writeValue({ uri: DESKTOP_APP_URI_PREFIX, matchDetection: null });
       component.index = 1;
+      component.showAppLabel = true;
 
       expect(component["uriLabel"]).toBe("appUriCount 2");
     });

--- a/libs/vault/src/cipher-form/components/autofill-options/uri-option.component.spec.ts
+++ b/libs/vault/src/cipher-form/components/autofill-options/uri-option.component.spec.ts
@@ -6,6 +6,8 @@ import { UriMatchStrategy } from "@bitwarden/common/models/domain/domain-service
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { DialogRef, DialogService } from "@bitwarden/components";
 
+import { DESKTOP_APP_URI_PREFIX } from "../../../models/desktop-app-uri.constants";
+
 import { AdvancedUriOptionDialogComponent } from "./advanced-uri-option-dialog.component";
 import { UriOptionComponent } from "./uri-option.component";
 
@@ -182,6 +184,37 @@ describe("UriOptionComponent", () => {
       fixture.detectChanges();
       getRemoveButton().click();
       expect(component.remove.emit).toHaveBeenCalled();
+    });
+  });
+
+  // Autotype App Tests
+  describe("uriLabel", () => {
+    it("returns 'websiteUri' for a normal URL at index 0", () => {
+      component.writeValue({ uri: "https://example.com", matchDetection: null });
+      component.index = 0;
+
+      expect(component["uriLabel"]).toBe("websiteUri");
+    });
+
+    it("returns 'websiteUriCount' for a normal URL at index greater than 0", () => {
+      component.writeValue({ uri: "https://example.com", matchDetection: null });
+      component.index = 1;
+
+      expect(component["uriLabel"]).toBe("websiteUriCount 2");
+    });
+
+    it("returns 'appUri' for a desktopapp:// URI at index 0", () => {
+      component.writeValue({ uri: DESKTOP_APP_URI_PREFIX, matchDetection: null });
+      component.index = 0;
+
+      expect(component["uriLabel"]).toBe("appUri");
+    });
+
+    it("returns 'appUriCount' for a desktopapp:// URI at index greater than 0", () => {
+      component.writeValue({ uri: DESKTOP_APP_URI_PREFIX, matchDetection: null });
+      component.index = 1;
+
+      expect(component["uriLabel"]).toBe("appUriCount 2");
     });
   });
 

--- a/libs/vault/src/cipher-form/components/autofill-options/uri-option.component.ts
+++ b/libs/vault/src/cipher-form/components/autofill-options/uri-option.component.ts
@@ -135,6 +135,15 @@ export class UriOptionComponent implements ControlValueAccessor {
   // eslint-disable-next-line @angular-eslint/prefer-signals
   @Input({ required: true }) index: number;
 
+  /**
+   * When true, URIs prefixed with the desktop app scheme will display the "App (URI)" label
+   * instead of "Website (URI)". Should only be true when the WindowsDesktopAutotypeGA feature
+   * flag is enabled.
+   */
+  // FIXME(https://bitwarden.atlassian.net/browse/CL-903): Migrate to Signals
+  // eslint-disable-next-line @angular-eslint/prefer-signals
+  @Input() showAppLabel: boolean = false;
+
   // FIXME(https://bitwarden.atlassian.net/browse/CL-903): Migrate to Signals
   // eslint-disable-next-line @angular-eslint/prefer-output-emitter-ref
   @Output()
@@ -158,7 +167,9 @@ export class UriOptionComponent implements ControlValueAccessor {
   }
 
   protected get uriLabel() {
-    const isAppUri = this.uriForm.controls.uri.value?.startsWith(DESKTOP_APP_URI_PREFIX) ?? false;
+    const isAppUri =
+      this.showAppLabel &&
+      (this.uriForm.controls.uri.value?.startsWith(DESKTOP_APP_URI_PREFIX) ?? false);
 
     if (isAppUri) {
       return this.index === 0

--- a/libs/vault/src/cipher-form/components/autofill-options/uri-option.component.ts
+++ b/libs/vault/src/cipher-form/components/autofill-options/uri-option.component.ts
@@ -33,6 +33,8 @@ import {
   SelectModule,
 } from "@bitwarden/components";
 
+import { DESKTOP_APP_URI_PREFIX } from "../../../models/desktop-app-uri.constants";
+
 import { AdvancedUriOptionDialogComponent } from "./advanced-uri-option-dialog.component";
 
 // FIXME(https://bitwarden.atlassian.net/browse/CL-764): Migrate to OnPush
@@ -156,6 +158,14 @@ export class UriOptionComponent implements ControlValueAccessor {
   }
 
   protected get uriLabel() {
+    const isAppUri = this.uriForm.controls.uri.value?.startsWith(DESKTOP_APP_URI_PREFIX) ?? false;
+
+    if (isAppUri) {
+      return this.index === 0
+        ? this.i18nService.t("appUri")
+        : this.i18nService.t("appUriCount", this.index + 1);
+    }
+
     return this.index === 0
       ? this.i18nService.t("websiteUri")
       : this.i18nService.t("websiteUriCount", this.index + 1);

--- a/libs/vault/src/models/desktop-app-uri.constants.ts
+++ b/libs/vault/src/models/desktop-app-uri.constants.ts
@@ -1,0 +1,1 @@
+export const DESKTOP_APP_URI_PREFIX = "desktopapp://";


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-33362

## 📔 Objective

This PR implements the following initial changes for editing a cipher to pair an application for use with Autotype:
- `+ website` becomes `+ website or app`
- When clicking the above changed button, a dropdown appears, allowing the user to select `website` or `app`
  - If `website` is selected, everything works as is
  - If `app` is selected, the text `desktopapp://` is appended which identifies this uri as a desktop app. This will be expanded on in future pr's (and changed to become a select instead of a text input field), and the schema is subject to change while the v1 is still being ironed out.
- Change the title text for the field based on if it's a website or an app
- Feature flag the change, and make sure it is only for windows desktop (initially)
- UI tests added with the `// Autotype App Tests` comment so they can easily be identified and updated later

There will be more PR's for this ticket, the PR's are being broken up into logical chunks to avoid having one massive PR that accomplishes many things.

## 📸 Screenshots

The dropdown:

<img width="413" height="304" alt="Dropdown" src="https://github.com/user-attachments/assets/825838ce-2e6d-46f8-8073-8cd40415329e" />

The "App" label working, retaining the incrementing numbers:

<img width="415" height="307" alt="New App" src="https://github.com/user-attachments/assets/f71ea9d9-14f8-4f95-978a-e4ed78052bef" />

## 🧪 Testing

Locally I have verified:
- In the dev environment these changes are active and working, only on Windows (not active on macOS)
- In the prod environment these changes are not active, as they are behind the autotype GA FF

Discussed with QA- no QA required for each PR until all PR's for this ticket are in, as the changes are behind a FF.
