### PR TITLE
Fix/badge storage chrome listener leak

### DIFF
--- a/apps/browser/src/platform/badge/badge-browser-api.ts
+++ b/apps/browser/src/platform/badge/badge-browser-api.ts
@@ -127,8 +127,15 @@ export class DefaultBadgeBrowserApi implements BadgeBrowserApi {
     ).pipe(shareReplay({ bufferSize: 1, refCount: true })),
   );
 
+  // Removal maps to a "deactivated" event so the per-tab badge group tears down
+  // even for tabs that were never activated (and so never otherwise deactivated).
+  private onTabRemoved$ = fromChromeEvent(chrome.tabs.onRemoved).pipe(
+    map(([tabId]) => ({ type: "deactivated", tabId }) satisfies TabEvent),
+  );
+
   tabEvents$ = merge(
     this.createdOrUpdatedTabEvents$,
+    this.onTabRemoved$,
     this.createdOrUpdatedTabEvents$.pipe(
       concatMap(async () => {
         return this.getActiveTabs();

--- a/apps/browser/src/platform/services/abstractions/abstract-chrome-storage-api.service.ts
+++ b/apps/browser/src/platform/services/abstractions/abstract-chrome-storage-api.service.ts
@@ -1,6 +1,6 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
-import { filter, mergeMap } from "rxjs";
+import { filter, mergeMap, share } from "rxjs";
 
 import {
   AbstractStorageService,
@@ -68,6 +68,7 @@ export default abstract class AbstractChromeStorageService
           };
         });
       }),
+      share(),
     );
   }
 


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

**AbstractChromeStorageService.updates$** wraps a cold fromChromeEvent, so every subscriber registered its own chrome.storage.onChanged listener that was never torn down — they accumulated per tab/interaction and grew background/SW memory. Use `share()` to keep a single upstream listener regardless of subscriber count.

**The badge `groupBy`** completed a tab's group only on a derived 'deactivated' event (active-set departure). A background tab that loaded but was never activated never deactivated, so its group and every subscription beneath it leaked for the life of the background. Observe `chrome.tabs.onRemoved` and map it to a deactivated event so any closed tab finalizes its group.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
