### PR TITLE
[PM-35107] Remove Argon2Id option from UI in gov environment

### DIFF
--- a/apps/web/src/app/key-management/change-kdf/change-kdf.component.html
+++ b/apps/web/src/app/key-management/change-kdf/change-kdf.component.html
@@ -26,16 +26,14 @@
           ></button>
         </bit-label>
         <bit-select formControlName="kdf">
-          <bit-option
-            *ngFor="let option of kdfOptions"
-            [value]="option.value"
-            [label]="option.name"
-          ></bit-option>
+          @for (option of kdfOptions(); track option.value) {
+            <bit-option [value]="option.value" [label]="option.name"></bit-option>
+          }
         </bit-select>
       </bit-form-field>
     </div>
     <div class="tw-col-span-6">
-      @if (isPBKDF2(kdfConfig)) {
+      @if (isPBKDF2()) {
         <bit-form-field formGroupName="kdfConfig">
           <bit-label>
             {{ "kdfIterations" | i18n }}
@@ -49,7 +47,7 @@
           />
           <bit-hint>{{ "kdfIterationRecommends" | i18n }}</bit-hint>
         </bit-form-field>
-      } @else if (isArgon2(kdfConfig)) {
+      } @else if (isArgon2()) {
         <bit-form-field formGroupName="kdfConfig">
           <bit-label>{{ "kdfMemory" | i18n }}</bit-label>
           <input
@@ -62,7 +60,7 @@
         </bit-form-field>
       }
     </div>
-    @if (isArgon2(kdfConfig)) {
+    @if (isArgon2()) {
       <div class="tw-col-span-6">
         <bit-form-field formGroupName="kdfConfig">
           <bit-label>
@@ -108,7 +106,9 @@
 <bit-popover [title]="'encryptionKeySettingsAlgorithmPopoverTitle' | i18n" #algorithmPopover>
   <ul class="tw-mt-2 tw-mb-0 tw-ps-4">
     <li class="tw-mb-2">{{ "encryptionKeySettingsAlgorithmPopoverPBKDF2" | i18n }}</li>
-    <li>{{ "encryptionKeySettingsAlgorithmPopoverArgon2Id" | i18n }}</li>
+    @if (argon2Available()) {
+      <li>{{ "encryptionKeySettingsAlgorithmPopoverArgon2Id" | i18n }}</li>
+    }
   </ul>
   <div class="tw-mt-4 tw-mb-1">
     <a

--- a/apps/web/src/app/key-management/change-kdf/change-kdf.component.spec.ts
+++ b/apps/web/src/app/key-management/change-kdf/change-kdf.component.spec.ts
@@ -1,22 +1,33 @@
 import { ComponentFixture, TestBed } from "@angular/core/testing";
-import { FormBuilder, FormControl } from "@angular/forms";
+import { FormBuilder, FormControl, ReactiveFormsModule } from "@angular/forms";
 import { mock, MockProxy } from "jest-mock-extended";
 import { of } from "rxjs";
 
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { SdkService } from "@bitwarden/common/platform/abstractions/sdk/sdk.service";
 import { FakeAccountService, mockAccountServiceWith } from "@bitwarden/common/spec";
 import { UserId } from "@bitwarden/common/types/guid";
-import { DialogService, PopoverModule, CalloutModule } from "@bitwarden/components";
+import {
+  A11yTitleDirective,
+  ButtonModule,
+  CalloutModule,
+  DialogService,
+  FormFieldModule,
+  LinkModule,
+  PopoverModule,
+  SelectModule,
+  TypographyModule,
+} from "@bitwarden/components";
 import {
   KdfConfigService,
   Argon2KdfConfig,
   PBKDF2KdfConfig,
   KdfType,
 } from "@bitwarden/key-management";
-
-import { SharedModule } from "../../shared";
+import { Kdf, PasswordManagerClient } from "@bitwarden/sdk-internal";
+import { I18nPipe } from "@bitwarden/ui-common";
 
 import { ChangeKdfComponent } from "./change-kdf.component";
 
@@ -30,6 +41,8 @@ describe("ChangeKdfComponent", () => {
   let mockConfigService: MockProxy<ConfigService>;
   let mockI18nService: MockProxy<I18nService>;
   let accountService: FakeAccountService;
+  let mockSdkService: MockProxy<SdkService>;
+  let isKdfCompliant: jest.Mock<boolean, [Kdf]>;
   let formBuilder: FormBuilder;
 
   const mockUserId = "user-id" as UserId;
@@ -98,9 +111,27 @@ describe("ChangeKdfComponent", () => {
 
     mockI18nService.t.mockImplementation((key) => `${key}-used-i18n`);
 
+    // Default to the standard cipher suite where every KDF is compliant.
+    isKdfCompliant = jest.fn<boolean, [Kdf]>().mockReturnValue(true);
+    mockSdkService = mock<SdkService>();
+    mockSdkService.client$ = of({
+      crypto_cipher_suite: () => ({ is_kdf_compliant: isKdfCompliant }),
+    } as unknown as PasswordManagerClient);
+
     TestBed.configureTestingModule({
       declarations: [ChangeKdfComponent],
-      imports: [SharedModule, PopoverModule, CalloutModule],
+      imports: [
+        ReactiveFormsModule,
+        A11yTitleDirective,
+        ButtonModule,
+        CalloutModule,
+        FormFieldModule,
+        I18nPipe,
+        LinkModule,
+        PopoverModule,
+        SelectModule,
+        TypographyModule,
+      ],
       providers: [
         { provide: DialogService, useValue: mockDialogService },
         { provide: KdfConfigService, useValue: mockKdfConfigService },
@@ -108,6 +139,7 @@ describe("ChangeKdfComponent", () => {
         { provide: FormBuilder, useValue: formBuilder },
         { provide: ConfigService, useValue: mockConfigService },
         { provide: I18nService, useValue: mockI18nService },
+        { provide: SdkService, useValue: mockSdkService },
       ],
     });
   });
@@ -133,7 +165,7 @@ describe("ChangeKdfComponent", () => {
         expect(kdfConfigFormGroup.controls.iterations.value).toBe(600_000);
         expect(kdfConfigFormGroup.controls.memory.value).toBeNull();
         expect(kdfConfigFormGroup.controls.parallelism.value).toBeNull();
-        expect(component.kdfConfig).toEqual(mockPBKDF2Config);
+        expect(component["kdfConfig"]()).toEqual(mockPBKDF2Config);
 
         // Assert validators
         expectPBKDF2Validation(
@@ -164,7 +196,7 @@ describe("ChangeKdfComponent", () => {
         expect(kdfConfigFormGroup.controls.iterations.value).toBe(3);
         expect(kdfConfigFormGroup.controls.memory.value).toBe(64);
         expect(kdfConfigFormGroup.controls.parallelism.value).toBe(4);
-        expect(component.kdfConfig).toEqual(mockArgon2Config);
+        expect(component["kdfConfig"]()).toEqual(mockArgon2Config);
 
         // Assert validators
         expectArgon2Validation(
@@ -360,6 +392,40 @@ describe("ChangeKdfComponent", () => {
         // Assert
         expect(mockDialogService.open).not.toHaveBeenCalled();
       });
+    });
+  });
+
+  describe("KDF options by cipher suite", () => {
+    it("offers PBKDF2 and Argon2id in the standard cipher suite", async () => {
+      // Arrange - standard cipher suite: every KDF is compliant.
+      isKdfCompliant.mockReturnValue(true);
+      mockKdfConfigService.getKdfConfig.mockResolvedValue(new PBKDF2KdfConfig(600_000));
+
+      // Act
+      fixture = TestBed.createComponent(ChangeKdfComponent);
+      component = fixture.componentInstance;
+      await component.ngOnInit();
+
+      // Assert
+      const optionValues = component["kdfOptions"]().map((option) => option.value);
+      expect(optionValues).toEqual([KdfType.PBKDF2_SHA256, KdfType.Argon2id]);
+      expect(component["argon2Available"]()).toBe(true);
+    });
+
+    it("offers only PBKDF2 in the FIPS cipher suite", async () => {
+      // Arrange - FIPS cipher suite: only PBKDF2 is compliant.
+      isKdfCompliant.mockImplementation((kdf) => "pBKDF2" in kdf);
+      mockKdfConfigService.getKdfConfig.mockResolvedValue(new PBKDF2KdfConfig(600_000));
+
+      // Act
+      fixture = TestBed.createComponent(ChangeKdfComponent);
+      component = fixture.componentInstance;
+      await component.ngOnInit();
+
+      // Assert
+      const optionValues = component["kdfOptions"]().map((option) => option.value);
+      expect(optionValues).toEqual([KdfType.PBKDF2_SHA256]);
+      expect(component["argon2Available"]()).toBe(false);
     });
   });
 });

--- a/apps/web/src/app/key-management/change-kdf/change-kdf.component.ts
+++ b/apps/web/src/app/key-management/change-kdf/change-kdf.component.ts
@@ -1,11 +1,21 @@
-import { Component, OnDestroy, OnInit } from "@angular/core";
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  OnInit,
+  computed,
+  inject,
+  signal,
+} from "@angular/core";
+import { takeUntilDestroyed, toSignal } from "@angular/core/rxjs-interop";
 import { FormBuilder, FormControl, Validators } from "@angular/forms";
-import { Subject, firstValueFrom, takeUntil, Observable } from "rxjs";
+import { firstValueFrom, map } from "rxjs";
 
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { getUserId } from "@bitwarden/common/auth/services/account.service";
 import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
+import { SdkService } from "@bitwarden/common/platform/abstractions/sdk/sdk.service";
 import { DialogService } from "@bitwarden/components";
 import {
   KdfConfigService,
@@ -17,19 +27,64 @@ import {
 
 import { ChangeKdfConfirmationComponent } from "./change-kdf-confirmation.component";
 
-// FIXME(https://bitwarden.atlassian.net/browse/CL-764): Migrate to OnPush
-// eslint-disable-next-line @angular-eslint/prefer-on-push-component-change-detection
+type KdfOption = { name: string; value: KdfType };
+
+const ALL_KDF_OPTIONS: KdfOption[] = [
+  { name: "PBKDF2 SHA-256", value: KdfType.PBKDF2_SHA256 },
+  { name: "Argon2id", value: KdfType.Argon2id },
+];
+
+function defaultKdfConfig(kdfType: KdfType): KdfConfig {
+  switch (kdfType) {
+    case KdfType.PBKDF2_SHA256:
+      return PBKDF2KdfConfig.createDefault();
+    case KdfType.Argon2id:
+      return Argon2KdfConfig.createDefault();
+    default:
+      throw new Error("Unknown KDF type.");
+  }
+}
+
 @Component({
   selector: "app-change-kdf",
   templateUrl: "change-kdf.component.html",
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class ChangeKdfComponent implements OnInit, OnDestroy {
-  kdfConfig: KdfConfig = PBKDF2KdfConfig.createDefault();
-  kdfOptions: any[] = [];
-  private destroy$ = new Subject<void>();
+export class ChangeKdfComponent implements OnInit {
+  private readonly dialogService = inject(DialogService);
+  private readonly kdfConfigService = inject(KdfConfigService);
+  private readonly accountService = inject(AccountService);
+  private readonly formBuilder = inject(FormBuilder);
+  private readonly configService = inject(ConfigService);
+  private readonly sdkService = inject(SdkService);
+  private readonly destroyRef = inject(DestroyRef);
 
-  protected formGroup = this.formBuilder.group({
+  protected readonly kdfConfig = signal<KdfConfig>(PBKDF2KdfConfig.createDefault());
+  protected readonly isPBKDF2 = computed(() => this.kdfConfig() instanceof PBKDF2KdfConfig);
+  protected readonly isArgon2 = computed(() => this.kdfConfig() instanceof Argon2KdfConfig);
+
+  /**
+   * The KDF algorithms the user is allowed to select, filtered by the SDK's environment-aware
+   * compliance check. In a FIPS (gov) environment only PBKDF2 is compliant, so Argon2id is removed.
+   */
+  protected readonly kdfOptions = toSignal(
+    this.sdkService.client$.pipe(
+      map((client) => {
+        const cipherSuite = client.crypto_cipher_suite();
+        return ALL_KDF_OPTIONS.filter((option) =>
+          cipherSuite.is_kdf_compliant(defaultKdfConfig(option.value).toSdkConfig()),
+        );
+      }),
+    ),
+    { initialValue: [] as KdfOption[] },
+  );
+
+  protected readonly argon2Available = computed(() =>
+    this.kdfOptions().some((option) => option.value === KdfType.Argon2id),
+  );
+
+  protected readonly formGroup = this.formBuilder.group({
     kdf: new FormControl<KdfType>(KdfType.PBKDF2_SHA256, [Validators.required]),
     kdfConfig: this.formBuilder.group({
       iterations: new FormControl<number | null>(null),
@@ -39,59 +94,35 @@ export class ChangeKdfComponent implements OnInit, OnDestroy {
   });
 
   // Default values for template
-  protected PBKDF2_ITERATIONS = PBKDF2KdfConfig.ITERATIONS;
-  protected ARGON2_ITERATIONS = Argon2KdfConfig.ITERATIONS;
-  protected ARGON2_MEMORY = Argon2KdfConfig.MEMORY;
-  protected ARGON2_PARALLELISM = Argon2KdfConfig.PARALLELISM;
+  protected readonly PBKDF2_ITERATIONS = PBKDF2KdfConfig.ITERATIONS;
+  protected readonly ARGON2_ITERATIONS = Argon2KdfConfig.ITERATIONS;
+  protected readonly ARGON2_MEMORY = Argon2KdfConfig.MEMORY;
+  protected readonly ARGON2_PARALLELISM = Argon2KdfConfig.PARALLELISM;
 
-  noLogoutOnKdfChangeFeatureFlag$: Observable<boolean>;
-
-  constructor(
-    private dialogService: DialogService,
-    private kdfConfigService: KdfConfigService,
-    private accountService: AccountService,
-    private formBuilder: FormBuilder,
-    configService: ConfigService,
-  ) {
-    this.kdfOptions = [
-      { name: "PBKDF2 SHA-256", value: KdfType.PBKDF2_SHA256 },
-      { name: "Argon2id", value: KdfType.Argon2id },
-    ];
-    this.noLogoutOnKdfChangeFeatureFlag$ = configService.getFeatureFlag$(
-      FeatureFlag.NoLogoutOnKdfChange,
-    );
-  }
+  protected readonly noLogoutOnKdfChangeFeatureFlag$ = this.configService.getFeatureFlag$(
+    FeatureFlag.NoLogoutOnKdfChange,
+  );
 
   async ngOnInit() {
     const userId = await firstValueFrom(getUserId(this.accountService.activeAccount$));
-    this.kdfConfig = await this.kdfConfigService.getKdfConfig(userId);
-    this.formGroup.controls.kdf.setValue(this.kdfConfig.kdfType);
-    this.setFormControlValues(this.kdfConfig);
-    this.setFormValidators(this.kdfConfig.kdfType);
+    const kdfConfig = await this.kdfConfigService.getKdfConfig(userId);
+    this.kdfConfig.set(kdfConfig);
+    this.formGroup.controls.kdf.setValue(kdfConfig.kdfType);
+    this.setFormControlValues(kdfConfig);
+    this.setFormValidators(kdfConfig.kdfType);
 
     this.formGroup.controls.kdf.valueChanges
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((newValue) => {
         this.updateKdfConfig(newValue!);
       });
   }
+
   private updateKdfConfig(newValue: KdfType) {
-    let config: KdfConfig;
-
-    switch (newValue) {
-      case KdfType.PBKDF2_SHA256:
-        config = PBKDF2KdfConfig.createDefault();
-        break;
-      case KdfType.Argon2id:
-        config = Argon2KdfConfig.createDefault();
-        break;
-      default:
-        throw new Error("Unknown KDF type.");
-    }
-
-    this.kdfConfig = config;
+    const config = defaultKdfConfig(newValue);
+    this.kdfConfig.set(config);
     this.setFormValidators(newValue);
-    this.setFormControlValues(this.kdfConfig);
+    this.setFormControlValues(config);
   }
 
   private setFormValidators(kdfType: KdfType) {
@@ -143,19 +174,6 @@ export class ChangeKdfComponent implements OnInit, OnDestroy {
     }
   }
 
-  ngOnDestroy() {
-    this.destroy$.next();
-    this.destroy$.complete();
-  }
-
-  isPBKDF2(t: KdfConfig): t is PBKDF2KdfConfig {
-    return t instanceof PBKDF2KdfConfig;
-  }
-
-  isArgon2(t: KdfConfig): t is Argon2KdfConfig {
-    return t instanceof Argon2KdfConfig;
-  }
-
   async openConfirmationModal() {
     this.formGroup.markAllAsTouched();
     if (this.formGroup.invalid) {
@@ -163,18 +181,21 @@ export class ChangeKdfComponent implements OnInit, OnDestroy {
     }
 
     const kdfConfigFormGroup = this.formGroup.controls.kdfConfig;
-    if (this.kdfConfig.kdfType === KdfType.PBKDF2_SHA256) {
-      this.kdfConfig = new PBKDF2KdfConfig(kdfConfigFormGroup.controls.iterations.value!);
-    } else if (this.kdfConfig.kdfType === KdfType.Argon2id) {
-      this.kdfConfig = new Argon2KdfConfig(
+    const currentKdfConfig = this.kdfConfig();
+    let kdfConfig: KdfConfig;
+    if (currentKdfConfig.kdfType === KdfType.PBKDF2_SHA256) {
+      kdfConfig = new PBKDF2KdfConfig(kdfConfigFormGroup.controls.iterations.value!);
+    } else {
+      kdfConfig = new Argon2KdfConfig(
         kdfConfigFormGroup.controls.iterations.value!,
         kdfConfigFormGroup.controls.memory.value!,
         kdfConfigFormGroup.controls.parallelism.value!,
       );
     }
+    this.kdfConfig.set(kdfConfig);
     this.dialogService.open(ChangeKdfConfirmationComponent, {
       data: {
-        kdfConfig: this.kdfConfig,
+        kdfConfig,
       },
     });
   }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-35107

## 📔 Objective

Remove Argon2Id option from UI in gov environment using the SDK crypto cipher suite.
Modernised the component to newest angular.
Used `client$` instead of `userClient$`, since the cipher suite / gov mode does not depend on the user.

## 📸 Screenshots

Standard cipher suite (non-gov):

https://github.com/user-attachments/assets/cc714c9f-75fc-41be-8589-4eca4bf6c216

FIPS cipher suite (gov):

https://github.com/user-attachments/assets/6138698f-3157-4725-bb3b-a0628e3a0b31


