### PR TITLE
[PM-39349]] - make ssh key cipher fields readonly

### DIFF
--- a/libs/vault/src/cipher-form/components/cipher-form.component.html
+++ b/libs/vault/src/cipher-form/components/cipher-form.component.html
@@ -28,10 +28,7 @@
     }
 
     @if (config.cipherType === CipherType.SshKey) {
-      <vault-sshkey-section
-        [disabled]="config.mode === 'partial-edit'"
-        [originalCipherView]="originalCipherView"
-      ></vault-sshkey-section>
+      <vault-sshkey-section [originalCipherView]="originalCipherView"></vault-sshkey-section>
     }
 
     @if (config.cipherType === CipherType.BankAccount) {

--- a/libs/vault/src/cipher-form/components/sshkey-section/sshkey-section.component.html
+++ b/libs/vault/src/cipher-form/components/sshkey-section/sshkey-section.component.html
@@ -7,7 +7,7 @@
   <bit-card>
     <bit-form-field>
       <bit-label>{{ "sshPrivateKey" | i18n }}</bit-label>
-      <input id="privateKey" bitInput formControlName="privateKey" type="password" />
+      <input id="privateKey" bitInput formControlName="privateKey" type="password" readonly />
       <button
         type="button"
         bitIconButton
@@ -29,12 +29,12 @@
 
     <bit-form-field>
       <bit-label>{{ "sshPublicKey" | i18n }}</bit-label>
-      <input id="publicKey" bitInput formControlName="publicKey" />
+      <input id="publicKey" bitInput formControlName="publicKey" readonly />
     </bit-form-field>
 
     <bit-form-field>
       <bit-label>{{ "sshFingerprint" | i18n }}</bit-label>
-      <input id="keyFingerprint" bitInput formControlName="keyFingerprint" />
+      <input id="keyFingerprint" bitInput formControlName="keyFingerprint" readonly />
     </bit-form-field>
   </bit-card>
 </section>

--- a/libs/vault/src/cipher-form/components/sshkey-section/sshkey-section.component.spec.ts
+++ b/libs/vault/src/cipher-form/components/sshkey-section/sshkey-section.component.spec.ts
@@ -81,7 +81,6 @@ describe("SshKeySectionComponent", () => {
 
     // minimal required inputs
     fixture.componentRef.setInput("originalCipherView", { edit: true, sshKey: null });
-    fixture.componentRef.setInput("disabled", false);
 
     (generate_ssh_key as unknown as jest.Mock).mockReset();
   });
@@ -166,17 +165,6 @@ describe("SshKeySectionComponent", () => {
     expect(component.sshKeyForm.get("keyFingerprint")?.value).toBe("genFp");
   });
 
-  it("ngOnInit disables the form", async () => {
-    cipherFormContainer.getInitialCipherView.mockReturnValue({
-      sshKey: { privateKey: "p1", publicKey: "p2", keyFingerprint: "p3" },
-    });
-    platformUtilsService.getClientType.mockReturnValue(ClientType.Desktop);
-
-    await component.ngOnInit();
-
-    expect(component.sshKeyForm.disabled).toBe(true);
-  });
-
   it("sets showImport true when not Web and originalCipherView.edit is true", async () => {
     cipherFormContainer.getInitialCipherView.mockReturnValue({
       sshKey: { privateKey: "p1", publicKey: "p2", keyFingerprint: "p3" },
@@ -201,22 +189,6 @@ describe("SshKeySectionComponent", () => {
     await component.ngOnInit();
 
     expect(component.showImport()).toBe(false);
-  });
-
-  it("disables the ssh key form when formStatusChange emits enabled", async () => {
-    cipherFormContainer.getInitialCipherView.mockReturnValue({
-      sshKey: { privateKey: "p1", publicKey: "p2", keyFingerprint: "p3" },
-    });
-
-    platformUtilsService.getClientType.mockReturnValue(ClientType.Desktop);
-
-    await component.ngOnInit();
-
-    component.sshKeyForm.enable();
-    expect(component.sshKeyForm.disabled).toBe(false);
-
-    formStatusChange$.next("enabled");
-    expect(component.sshKeyForm.disabled).toBe(true);
   });
 
   it("renders the import button only when showImport is true", async () => {

--- a/libs/vault/src/cipher-form/components/sshkey-section/sshkey-section.component.ts
+++ b/libs/vault/src/cipher-form/components/sshkey-section/sshkey-section.component.ts
@@ -1,7 +1,7 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
 import { CommonModule } from "@angular/common";
-import { Component, computed, DestroyRef, inject, input, OnInit } from "@angular/core";
+import { Component, computed, input, OnInit } from "@angular/core";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { FormBuilder, ReactiveFormsModule } from "@angular/forms";
 import { firstValueFrom } from "rxjs";
@@ -45,8 +45,6 @@ import { CipherFormContainer } from "../../cipher-form-container";
 export class SshKeySectionComponent implements OnInit {
   readonly originalCipherView = input<CipherView | null>(null);
 
-  readonly disabled = input(false);
-
   /**
    * All form fields associated with the ssh key
    *
@@ -67,8 +65,6 @@ export class SshKeySectionComponent implements OnInit {
       (this.originalCipherView() == null || this.originalCipherView()!.edit)
     );
   });
-
-  private destroyRef = inject(DestroyRef);
 
   constructor(
     private cipherFormContainer: CipherFormContainer,
@@ -99,18 +95,6 @@ export class SshKeySectionComponent implements OnInit {
     } else {
       await this.generateSshKey();
     }
-
-    this.sshKeyForm.disable();
-
-    // Disable the form if the cipher form container is enabled
-    // to prevent user interaction
-    this.cipherFormContainer.formStatusChange$
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe((status) => {
-        if (status === "enabled") {
-          this.sshKeyForm.disable();
-        }
-      });
   }
 
   /** Set form initial form values from the current cipher */


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-39439

## 📔 Objective

SSH key cipher fields were using Angular's `FormGroup.disable()` to prevent user input. Disabled form controls render with low-contrast text in dark mode, making the field values nearly unreadable.

This PR changes the SSH key fields (`privateKey`, `publicKey`, `keyFingerprint`) from disabled to `readonly`. The `readonly` HTML attribute prevents user input without altering the field's visual styling, so the values remain legible in both light and dark mode.

**Changes:**
- Removed `sshKeyForm.disable()` and the `formStatusChange$` re-disable subscription from `ngOnInit` — the form stays enabled so values flow correctly through `valueChanges` and programmatic updates (e.g. import from clipboard) continue to work
- Added `readonly` attribute to all three SSH key inputs in the template
- Removed the now-unused `disabled` input, `DestroyRef`, and `inject` from the component
- Removed the `[disabled]` binding from the parent `cipher-form.component.html`
- Updated tests to remove assertions on the (now-removed) disabled behavior

## 📸 Screenshots

<!-- TODO: Screenshot of SSH key cipher fields in dark mode — before (illegible disabled text) and after (readable readonly text) -->
<img width="486" height="598" alt="Screenshot 2026-06-25 at 5 14 03 PM" src="https://github.com/user-attachments/assets/1786280f-88ef-4dd6-9eff-6d6ea4b3692f" />
