### PR TITLE
[PM-38771] - add missing i18n strings for button labels

### DIFF
--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -363,6 +363,18 @@
     "message": "Copy value",
     "description": "Copy value to clipboard"
   },
+  "copyWebsite": {
+    "message": "Copy website"
+  },
+  "copyCustomField": {
+    "message": "Copy $FIELD$",
+    "placeholders": {
+      "field": {
+        "content": "$1",
+        "example": "Custom field label"
+      }
+    }
+  },
   "minimizeOnCopyToClipboard": {
     "message": "Minimize when copying to clipboard"
   },
@@ -720,6 +732,15 @@
   "deleteWebsite": {
     "message": "Delete website"
   },
+  "deleteCustomField": {
+    "message": "Delete $LABEL$",
+    "placeholders": {
+      "label": {
+        "content": "$1",
+        "example": "Custom field"
+      }
+    }
+  },
   "owner": {
     "message": "Owner"
   },
@@ -728,6 +749,15 @@
   },
   "editField": {
     "message": "Edit field"
+  },
+  "editFieldLabel": {
+    "message": "Edit $LABEL$",
+    "placeholders": {
+      "label": {
+        "content": "$1",
+        "example": "Custom field"
+      }
+    }
   },
   "permanentlyDeleteAttachmentConfirmation": {
     "message": "Are you sure you want to permanently delete this attachment?"

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -5897,6 +5897,15 @@
       }
     }
   },
+  "deleteCustomField": {
+    "message": "Delete $LABEL$",
+    "placeholders": {
+      "label": {
+        "content": "$1",
+        "example": "Custom field"
+      }
+    }
+  },
   "reorderToggleButton": {
     "message": "Reorder $LABEL$. Use arrow key to move item up or down.",
     "placeholders": {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-38771

Fixes #21146 

## 📔 Objective

Several icon buttons in the vault item view and edit flows were missing accessible labels on
desktop (and one on web), because the i18n keys they relied on were not present in those apps'
`messages.json` files. Screen-reader users had no way to identify the buttons' purpose without
activating them.

Keys added to `apps/desktop/src/locales/en/messages.json`:

- `copyWebsite` — "Copy website" — copy button next to the URI field in login view
- `copyCustomField` — "Copy $FIELD$" — copy button next to a custom field value (including hidden fields) in view mode
- `editFieldLabel` — "Edit $LABEL$" — pencil button next to each custom field in edit mode
- `deleteCustomField` — "Delete $LABEL$" — trash button inside the add/edit custom field dialog

Key added to `apps/web/src/locales/en/messages.json`:

- `deleteCustomField` — "Delete $LABEL$" — same dialog button was also unlabelled on web

All five keys were already present and correctly used in `apps/browser`. This change brings
desktop and web into parity.

## 📸 Screenshots

<!-- TODO: Screenshot of each button with a screen reader announcing its label:
  - Copy button on URI field (desktop)
  - Copy button on hidden custom field (desktop)
  - Edit (pencil) button next to a custom field (desktop)
  - Delete (trash) button inside the custom field dialog (desktop + web)
-->

| Copy button — URI field | Copy button — hidden custom field |
|---|---|
| <img width="569" height="1067" alt="Screenshot 2026-06-25 at 5 44 42 PM" src="https://github.com/user-attachments/assets/5275a1ff-475c-4048-987e-2311fc45e536" /> | <img width="579" height="1036" alt="Screenshot 2026-06-25 at 5 44 59 PM" src="https://github.com/user-attachments/assets/1dde7686-b3ed-4678-8aa0-ee2454cdef66" /> |

| Edit button — custom field | Delete button — custom field dialog |
|---|---|
| <img width="582" height="973" alt="Screenshot 2026-06-25 at 5 45 35 PM" src="https://github.com/user-attachments/assets/24680fdd-799f-43a4-bdbc-95b29971eca1" /> | <img width="616" height="369" alt="Screenshot 2026-06-25 at 5 45 56 PM" src="https://github.com/user-attachments/assets/53b14e88-b614-475d-9bb8-22c08799fc82" /> |



