### PR TITLE
[PM-39607] fix(browser): warn when legacy paste fails

### DIFF
--- a/apps/browser/src/platform/services/browser-clipboard.service.spec.ts
+++ b/apps/browser/src/platform/services/browser-clipboard.service.spec.ts
@@ -116,5 +116,16 @@ describe("BrowserClipboardService", () => {
 
       await BrowserClipboardService.read(windowMock as Window);
     });
+
+    it("prints a warning message when execCommand('paste') returns false", async () => {
+      windowMock.document.queryCommandSupported.mockReturnValue(true);
+      windowMock.navigator.clipboard.readText.mockRejectedValue(new Error("test"));
+      windowMock.document.execCommand.mockReturnValue(false);
+
+      const returnValue = await BrowserClipboardService.read(windowMock as Window);
+
+      expect(returnValue).toBe("");
+      expect(consoleWarnSpy).toHaveBeenCalledWith("execCommand('paste') returned false");
+    });
   });
 });

--- a/apps/browser/src/platform/services/browser-clipboard.service.ts
+++ b/apps/browser/src/platform/services/browser-clipboard.service.ts
@@ -96,7 +96,12 @@ class BrowserClipboardService {
     textareaElement.focus();
 
     try {
-      return globalContext.document.execCommand("paste") ? textareaElement.value : "";
+      const success = globalContext.document.execCommand("paste");
+      if (!success) {
+        BrowserClipboardService.consoleLogService.warning("execCommand('paste') returned false");
+      }
+
+      return success ? textareaElement.value : "";
     } catch (error) {
       BrowserClipboardService.consoleLogService.warning(`Error reading from clipboard: ${error}`);
     } finally {


### PR DESCRIPTION
## Summary

Adds the same false-return warning to `useLegacyReadMethod()` that copy already has for `execCommand("copy")`. When the legacy paste command returns `false`, the method still returns an empty string as before, but now records a warning for debugging.

This follows up on the review note in #20859. The read path is also used by clipboard auto-clear, so a silent failed read can make the clear step skip without any useful diagnostic.

## Testing

- `npx jest --config apps/browser/jest.config.js --testPathPatterns="browser-clipboard.service.spec" --runInBand`
