### PR TITLE
[PM-39610] Keyboard shortcuts only work once

### DIFF
--- a/apps/desktop/src/vault/app/vault-v3/vault.component.ts
+++ b/apps/desktop/src/vault/app/vault-v3/vault.component.ts
@@ -649,13 +649,14 @@ export class VaultComponent<C extends CipherViewLike> implements OnInit, OnDestr
     if (await this.shouldReprompt(cipher)) {
       return;
     }
-    this.cipher.set(cipher);
     const formConfig = await this.cipherFormConfigService.buildConfig(
       cipher.edit ? "edit" : "partial-edit",
       cipher.id as CipherId,
       cipher.type,
     );
-    await this.openDialog("view", formConfig);
+    if (await this.openDialog("view", formConfig)) {
+      this.cipher.set(cipher);
+    }
   }
 
   async openAttachmentsDialog(cipherId: CipherId, canEditCipher: boolean) {
@@ -680,26 +681,28 @@ export class VaultComponent<C extends CipherViewLike> implements OnInit, OnDestr
     if (await this.shouldReprompt(cipher)) {
       return;
     }
-    this.cipher.set(cipher);
     const formConfig = await this.cipherFormConfigService.buildConfig(
       cipher.edit ? "edit" : "partial-edit",
       cipher.id as CipherId,
       cipher.type,
     );
-    await this.openDialog("form", formConfig);
+    if (await this.openDialog("form", formConfig)) {
+      this.cipher.set(cipher);
+    }
   }
 
   async cloneCipher(cipher: CipherView) {
     if (await this.shouldReprompt(cipher)) {
       return;
     }
-    this.cipher.set(cipher);
     const formConfig = await this.cipherFormConfigService.buildConfig(
       "clone",
       cipher.id as CipherId,
       cipher.type,
     );
-    await this.openDialog("form", formConfig);
+    if (await this.openDialog("form", formConfig)) {
+      this.cipher.set(cipher);
+    }
   }
 
   async shareCipher(cipher: CipherView) {
@@ -974,22 +977,31 @@ export class VaultComponent<C extends CipherViewLike> implements OnInit, OnDestr
     return !confirmed;
   }
 
-  private async openDialog(mode: VaultItemDialogMode, formConfig: CipherFormConfig) {
+  private async openDialog(
+    mode: VaultItemDialogMode,
+    formConfig: CipherFormConfig,
+  ): Promise<boolean> {
     if (this.activeDrawerRef != null && this.dirtyInput()) {
       const keepChanges = await this.wantsToSaveChanges();
       if (keepChanges) {
-        return;
+        return false;
       }
       await this.activeDrawerRef.close();
     }
-    this.activeDrawerRef = await VaultItemDialogComponent.openDrawer(this.dialogService, {
+    const drawerRef = await VaultItemDialogComponent.openDrawer(this.dialogService, {
       mode,
       formConfig,
       restore: this.restore,
     });
-    this.activeDrawerRef.closed.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((result) => {
-      this.activeDrawerRef = undefined;
-      this.cipher.set(null);
+    this.activeDrawerRef = drawerRef;
+    drawerRef?.closed.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((result) => {
+      // Opening a new drawer closes the previous one, which emits `closed` after the new
+      // drawer is already active. Only clear state if this drawer is still the active one,
+      // so switching items doesn't wipe the newly-selected cipher used by copy shortcuts.
+      if (this.activeDrawerRef === drawerRef) {
+        this.activeDrawerRef = undefined;
+        this.cipher.set(null);
+      }
       void this.router.navigate([], {
         queryParams: { action: null, itemId: null },
         queryParamsHandling: "merge",
@@ -999,6 +1011,7 @@ export class VaultComponent<C extends CipherViewLike> implements OnInit, OnDestr
         this.refresh();
       }
     });
+    return drawerRef != null;
   }
 
   private copyValue(cipher: CipherView, value: string, labelI18nKey: string, aType: string) {


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-39610
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
Restore copy-to-clipboard keyboard shortcuts (Ctrl/Cmd + U/P/T) in the desktop vault so they copy the username, password, or TOTP of whichever item is currently open, not just the first item opened.

### Root cause
The shortcut handlers read the open item from a cipher signal. Opening a new item makes `DialogService.openDrawer` close the previous drawer first, and that drawer's closed subscription runs `cipher.set(null)`. Because that null write executes after the new item has already been set, it overwrites the new value and leaves the signal empty, so the handlers find nothing to copy.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

https://github.com/user-attachments/assets/fe786621-cf16-4ff4-904f-4ae3ceed5216


<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
