### PR TITLE
[PM-39731] Revert default enablement of native messaging permission

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -3096,6 +3096,18 @@
   "biometricsFailedDesc": {
     "message": "Biometrics cannot be completed, consider using a master password or logging out. If this persists, please contact Bitwarden support."
   },
+  "nativeMessaginPermissionErrorTitle": {
+    "message": "Permission not provided"
+  },
+  "nativeMessaginPermissionErrorDesc": {
+    "message": "Without permission to communicate with the Bitwarden Desktop Application we cannot provide biometrics in the browser extension. Please try again."
+  },
+  "nativeMessaginPermissionSidebarTitle": {
+    "message": "Permission request error"
+  },
+  "nativeMessaginPermissionSidebarDesc": {
+    "message": "This action cannot be done in the sidebar, please retry the action in the popup or popout."
+  },
   "personalOwnershipSubmitError": {
     "message": "Due to an Enterprise Policy, you are restricted from saving items to your personal vault. Change the Ownership option to an organization and choose from available collections."
   },

--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -6036,9 +6036,6 @@
   "unlockPinSet": {
     "message": "Unlock PIN set"
   },
-  "unlockWithBiometricSet": {
-    "message": "Unlock with biometrics set"
-  },
   "authenticating": {
     "message": "Authenticating"
   },
@@ -6725,6 +6722,30 @@
   },
   "sharedUnlockDescriptionFirefox": {
     "message": "Keep your Bitwarden apps in sync. When enabled, unlock state will be shared with the Bitwarden desktop app."
+  },
+  "sharedUnlockWithDesktop": {
+    "message": "Share unlock with Desktop"
+  },
+  "sharedUnlockWithDesktopDescription": {
+    "message": "When enabled, unlock state will be shared with the Bitwarden Desktop app."
+  },
+  "sharedUnlockWithWeb": {
+    "message": "Share unlock with web vault"
+  },
+  "sharedUnlockWithWebDescription": {
+    "message": "When enabled, unlock state will be shared with Bitwarden web vaults."
+  },
+  "newPermissionNeeded": {
+    "message": "New permission needed"
+  },
+  "sharedUnlockDesktopPermissionDesc": {
+    "message": "To use shared unlock, Bitwarden needs permission to communicate with the desktop app. When you continue, your browser will ask you to approve it."
+  },
+  "sharedUnlockDesktopPermissionWarning": {
+    "message": "Bitwarden will lock and reload. After you approve, the extension reloads and will lock your vault."
+  },
+  "biometricPermissionDesc": {
+    "message": "To use biometric unlock, Bitwarden needs permission to communicate with the desktop app. When you continue, your browser will ask you to approve it."
   },
   "enterMonth": {
     "message": "Enter month."

--- a/apps/browser/src/auth/popup/settings/account-security.component.html
+++ b/apps/browser/src/auth/popup/settings/account-security.component.html
@@ -83,20 +83,38 @@
             </bit-form-control>
           }
           @if (sharedUnlockFeatureEnabled$ | async) {
-            <bit-form-control [disableMargin]="true">
-              <input
-                bitCheckbox
-                id="allowSharingUnlockState"
-                type="checkbox"
-                formControlName="allowSharingUnlockState"
-              />
-              <bit-label for="allowSharingUnlockState" class="tw-whitespace-normal">
-                {{ "sharedUnlock" | i18n }}
-              </bit-label>
-              <bit-hint class="tw-text-sm">
-                {{ sharedUnlockDescriptionKey | i18n }}
-              </bit-hint>
-            </bit-form-control>
+            @if (showSharedUnlockWithDesktop) {
+              <bit-form-control>
+                <input
+                  bitCheckbox
+                  id="allowSharingUnlockStateWithDesktop"
+                  type="checkbox"
+                  formControlName="allowSharingUnlockStateWithDesktop"
+                />
+                <bit-label for="allowSharingUnlockStateWithDesktop" class="tw-whitespace-normal">
+                  {{ "sharedUnlockWithDesktop" | i18n }}
+                </bit-label>
+                <bit-hint class="tw-text-sm">
+                  {{ "sharedUnlockWithDesktopDescription" | i18n }}
+                </bit-hint>
+              </bit-form-control>
+            }
+            @if (showSharedUnlockWithWeb) {
+              <bit-form-control [disableMargin]="true">
+                <input
+                  bitCheckbox
+                  id="allowSharingUnlockStateWithWeb"
+                  type="checkbox"
+                  formControlName="allowSharingUnlockStateWithWeb"
+                />
+                <bit-label for="allowSharingUnlockStateWithWeb" class="tw-whitespace-normal">
+                  {{ "sharedUnlockWithWeb" | i18n }}
+                </bit-label>
+                <bit-hint class="tw-text-sm">
+                  {{ "sharedUnlockWithWebDescription" | i18n }}
+                </bit-hint>
+              </bit-form-control>
+            }
           }
         </bit-card>
       </bit-section>

--- a/apps/browser/src/auth/popup/settings/account-security.component.spec.ts
+++ b/apps/browser/src/auth/popup/settings/account-security.component.spec.ts
@@ -43,6 +43,8 @@ import {
 } from "@bitwarden/key-management";
 import { SessionTimeoutSettingsComponent } from "@bitwarden/key-management-ui";
 
+import { BrowserApi } from "../../../platform/browser/browser-api";
+import BrowserPopupUtils from "../../../platform/browser/browser-popup-utils";
 import { PopOutComponent } from "../../../platform/popup/components/pop-out.component";
 import { PopupRouterCacheService } from "../../../platform/popup/view-cache/popup-router-cache.service";
 
@@ -378,8 +380,12 @@ describe("AccountSecurityComponent", () => {
   });
 
   describe("updateBiometric", () => {
+    let browserApiSpy: jest.SpyInstance;
+
     beforeEach(() => {
       policyService.policiesByType$.mockReturnValue(of([null]));
+      browserApiSpy = jest.spyOn(BrowserApi, "requestPermission");
+      browserApiSpy.mockResolvedValue(true);
     });
 
     describe("updating to false", () => {
@@ -402,7 +408,69 @@ describe("AccountSecurityComponent", () => {
         trySetupBiometricsSpy = jest.spyOn(component, "trySetupBiometrics");
       });
 
-      it("refreshes additional keys and attempts to setup biometrics", async () => {
+      it("displays permission error dialog when nativeMessaging permission is not granted", async () => {
+        browserApiSpy.mockResolvedValue(false);
+
+        await component.ngOnInit();
+        await component.updateBiometric(true);
+
+        expect(dialogService.openSimpleDialog).toHaveBeenCalledWith({
+          title: { key: "nativeMessaginPermissionErrorTitle" },
+          content: { key: "nativeMessaginPermissionErrorDesc" },
+          acceptButtonText: { key: "ok" },
+          cancelButtonText: null,
+          type: "danger",
+        });
+        expect(component.form.controls.biometric.value).toBe(false);
+        expect(trySetupBiometricsSpy).not.toHaveBeenCalled();
+      });
+
+      it("displays a specific sidebar dialog when nativeMessaging permissions throws an error on firefox + sidebar", async () => {
+        browserApiSpy.mockRejectedValue(new Error("Permission denied"));
+        platformUtilsService.isFirefox.mockReturnValue(true);
+        jest.spyOn(BrowserPopupUtils, "inSidebar").mockReturnValue(true);
+
+        await component.ngOnInit();
+        await component.updateBiometric(true);
+
+        expect(dialogService.openSimpleDialog).toHaveBeenCalledWith({
+          title: { key: "nativeMessaginPermissionSidebarTitle" },
+          content: { key: "nativeMessaginPermissionSidebarDesc" },
+          acceptButtonText: { key: "ok" },
+          cancelButtonText: null,
+          type: "info",
+        });
+        expect(component.form.controls.biometric.value).toBe(false);
+        expect(trySetupBiometricsSpy).not.toHaveBeenCalled();
+      });
+
+      test.each([
+        [false, false],
+        [false, true],
+        [true, false],
+      ])(
+        "displays a generic dialog when nativeMessaging permissions throws an error and isFirefox is %s and onSidebar is %s",
+        async (isFirefox, inSidebar) => {
+          browserApiSpy.mockRejectedValue(new Error("Permission denied"));
+          platformUtilsService.isFirefox.mockReturnValue(isFirefox);
+          jest.spyOn(BrowserPopupUtils, "inSidebar").mockReturnValue(inSidebar);
+
+          await component.ngOnInit();
+          await component.updateBiometric(true);
+
+          expect(dialogService.openSimpleDialog).toHaveBeenCalledWith({
+            title: { key: "nativeMessaginPermissionErrorTitle" },
+            content: { key: "nativeMessaginPermissionErrorDesc" },
+            acceptButtonText: { key: "ok" },
+            cancelButtonText: null,
+            type: "danger",
+          });
+          expect(component.form.controls.biometric.value).toBe(false);
+          expect(trySetupBiometricsSpy).not.toHaveBeenCalled();
+        },
+      );
+
+      it("refreshes additional keys and attempts to setup biometrics when enabled with nativeMessaging permission", async () => {
         const setupBiometricsResult = true;
         trySetupBiometricsSpy.mockResolvedValue(setupBiometricsResult);
 
@@ -449,6 +517,12 @@ describe("AccountSecurityComponent", () => {
   });
 
   describe("biometrics polling timer", () => {
+    let browserApiSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      browserApiSpy = jest.spyOn(BrowserApi, "permissionsGranted");
+    });
+
     afterEach(() => {
       component.ngOnDestroy();
     });
@@ -471,8 +545,35 @@ describe("AccountSecurityComponent", () => {
       expect(component.form.controls.biometric.disabled).toBe(false);
     }));
 
+    it("skips status check when nativeMessaging permission is not granted and not Safari", fakeAsync(async () => {
+      biometricsService.canEnableBiometricUnlock.mockResolvedValue(true);
+      browserApiSpy.mockResolvedValue(false);
+      platformUtilsService.isSafari.mockReturnValue(false);
+
+      await component.ngOnInit();
+      tick();
+
+      expect(biometricsService.getBiometricsStatusForUser).not.toHaveBeenCalled();
+      expect(component.biometricUnavailabilityReason).toBeUndefined();
+    }));
+
+    it("checks biometrics status when nativeMessaging permission is granted", fakeAsync(async () => {
+      biometricsService.canEnableBiometricUnlock.mockResolvedValue(true);
+      browserApiSpy.mockResolvedValue(true);
+      platformUtilsService.isSafari.mockReturnValue(false);
+      biometricsService.getBiometricsStatusForUser.mockResolvedValue(
+        BiometricsStatus.DesktopDisconnected,
+      );
+
+      await component.ngOnInit();
+      tick();
+
+      expect(biometricsService.getBiometricsStatusForUser).toHaveBeenCalledWith(mockUserId);
+    }));
+
     it("should check status on Safari", fakeAsync(async () => {
       biometricsService.canEnableBiometricUnlock.mockResolvedValue(true);
+      browserApiSpy.mockResolvedValue(false);
       platformUtilsService.isSafari.mockReturnValue(true);
       biometricsService.getBiometricsStatusForUser.mockResolvedValue(
         BiometricsStatus.DesktopDisconnected,
@@ -501,6 +602,7 @@ describe("AccountSecurityComponent", () => {
       "sets expected unavailability reason for %s status when biometric not available",
       fakeAsync(async (biometricStatus: BiometricsStatus, expected: string) => {
         biometricsService.canEnableBiometricUnlock.mockResolvedValue(false);
+        browserApiSpy.mockResolvedValue(true);
         platformUtilsService.isSafari.mockReturnValue(false);
         biometricsService.getBiometricsStatusForUser.mockResolvedValue(biometricStatus);
 
@@ -513,6 +615,7 @@ describe("AccountSecurityComponent", () => {
 
     it("should not set unavailability reason for error statuses when biometric is available", fakeAsync(async () => {
       biometricsService.canEnableBiometricUnlock.mockResolvedValue(true);
+      browserApiSpy.mockResolvedValue(true);
       platformUtilsService.isSafari.mockReturnValue(false);
       biometricsService.getBiometricsStatusForUser.mockResolvedValue(
         BiometricsStatus.DesktopDisconnected,

--- a/apps/browser/src/auth/popup/settings/account-security.component.spec.ts
+++ b/apps/browser/src/auth/popup/settings/account-security.component.spec.ts
@@ -27,7 +27,6 @@ import { EnvironmentService } from "@bitwarden/common/platform/abstractions/envi
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
-import { ValidationService } from "@bitwarden/common/platform/abstractions/validation.service";
 import { MessageSender } from "@bitwarden/common/platform/messaging";
 import { StateProvider } from "@bitwarden/common/platform/state";
 import { FakeAccountService, mockAccountServiceWith } from "@bitwarden/common/spec";
@@ -87,10 +86,10 @@ describe("AccountSecurityComponent", () => {
   const phishingDetectionSettingsService = mock<PhishingDetectionSettingsServiceAbstraction>();
   const pinServiceAbstraction = mock<PinServiceAbstraction>();
   const platformUtilsService = mock<PlatformUtilsService>();
-  const validationService = mock<ValidationService>();
   const vaultNudgesService = mock<NudgesService>();
   const vaultTimeoutSettingsService = mock<VaultTimeoutSettingsService>();
   const sharedUnlockSettingsService = mock<SharedUnlockSettingsService>();
+  const messagingService = mock<MessageSender>();
   const mockI18nService = mock<I18nService>();
 
   // Mock subjects to control the phishing detection observables
@@ -119,7 +118,7 @@ describe("AccountSecurityComponent", () => {
         { provide: KeyService, useValue: keyService },
         { provide: LockService, useValue: lockService },
         { provide: LogService, useValue: mock<LogService>() },
-        { provide: MessageSender, useValue: mock<MessageSender>() },
+        { provide: MessageSender, useValue: messagingService },
         { provide: NudgesService, useValue: vaultNudgesService },
         { provide: OrganizationService, useValue: mock<OrganizationService>() },
         { provide: PinServiceAbstraction, useValue: pinServiceAbstraction },
@@ -133,7 +132,6 @@ describe("AccountSecurityComponent", () => {
         { provide: StateProvider, useValue: mock<StateProvider>() },
         { provide: ToastService, useValue: mock<ToastService>() },
         { provide: UserVerificationService, useValue: mock<UserVerificationService>() },
-        { provide: ValidationService, useValue: validationService },
         { provide: LockService, useValue: lockService },
         {
           provide: AutomaticUserConfirmationService,
@@ -170,8 +168,10 @@ describe("AccountSecurityComponent", () => {
     mockI18nService.t.mockImplementation((key) => `${key}-used-i18n`);
     platformUtilsService.isSafari.mockReturnValue(false);
     platformUtilsService.isFirefox.mockReturnValue(false);
-    sharedUnlockSettingsService.allowSharingUnlockState$.mockReturnValue(of(true));
-    sharedUnlockSettingsService.setAllowSharingUnlockState.mockResolvedValue(undefined);
+    sharedUnlockSettingsService.allowSharingUnlockStateWithDesktop$.mockReturnValue(of(false));
+    sharedUnlockSettingsService.allowSharingUnlockStateWithWeb$.mockReturnValue(of(false));
+    sharedUnlockSettingsService.setAllowSharingUnlockStateWithDesktop.mockResolvedValue(undefined);
+    sharedUnlockSettingsService.setAllowSharingUnlockStateWithWeb.mockResolvedValue(undefined);
 
     policyService.policiesByType$.mockReturnValue(of([null]));
 
@@ -199,38 +199,6 @@ describe("AccountSecurityComponent", () => {
     await component.ngOnInit();
 
     await expect(firstValueFrom(component.pinEnabled$)).resolves.toBe(true);
-  });
-
-  describe("shared unlock description", () => {
-    it("uses the Safari-specific description key on Safari", () => {
-      platformUtilsService.isSafari.mockReturnValue(true);
-      platformUtilsService.isFirefox.mockReturnValue(false);
-
-      const safariFixture = TestBed.createComponent(AccountSecurityComponent);
-      const safariComponent = safariFixture.componentInstance;
-
-      expect(safariComponent.sharedUnlockDescriptionKey).toBe("sharedUnlockDescriptionSafari");
-    });
-
-    it("uses the Firefox-specific description key on Firefox", () => {
-      platformUtilsService.isSafari.mockReturnValue(false);
-      platformUtilsService.isFirefox.mockReturnValue(true);
-
-      const firefoxFixture = TestBed.createComponent(AccountSecurityComponent);
-      const firefoxComponent = firefoxFixture.componentInstance;
-
-      expect(firefoxComponent.sharedUnlockDescriptionKey).toBe("sharedUnlockDescriptionFirefox");
-    });
-
-    it("uses the generic description key on non-Safari and non-Firefox browsers", () => {
-      platformUtilsService.isSafari.mockReturnValue(false);
-      platformUtilsService.isFirefox.mockReturnValue(false);
-
-      const defaultFixture = TestBed.createComponent(AccountSecurityComponent);
-      const defaultComponent = defaultFixture.componentInstance;
-
-      expect(defaultComponent.sharedUnlockDescriptionKey).toBe("sharedUnlockDescription");
-    });
   });
 
   it("pin enabled when RemoveUnlockWithPin policy is disabled", async () => {
@@ -380,12 +348,15 @@ describe("AccountSecurityComponent", () => {
   });
 
   describe("updateBiometric", () => {
-    let browserApiSpy: jest.SpyInstance;
+    let permissionsGrantedSpy: jest.SpyInstance;
+    let requestPermissionSpy: jest.SpyInstance;
 
     beforeEach(() => {
       policyService.policiesByType$.mockReturnValue(of([null]));
-      browserApiSpy = jest.spyOn(BrowserApi, "requestPermission");
-      browserApiSpy.mockResolvedValue(true);
+      permissionsGrantedSpy = jest.spyOn(BrowserApi, "permissionsGranted");
+      permissionsGrantedSpy.mockResolvedValue(true);
+      requestPermissionSpy = jest.spyOn(BrowserApi, "requestPermission");
+      requestPermissionSpy.mockResolvedValue(true);
     });
 
     describe("updating to false", () => {
@@ -402,31 +373,39 @@ describe("AccountSecurityComponent", () => {
     });
 
     describe("updating to true", () => {
-      let trySetupBiometricsSpy: jest.SpyInstance;
-
       beforeEach(() => {
-        trySetupBiometricsSpy = jest.spyOn(component, "trySetupBiometrics");
+        // Default to popout context so the permission dialog shows rather than triggering
+        // the popup-to-popout redirect.
+        jest.spyOn(BrowserPopupUtils, "inPopup").mockReturnValue(false);
+        // Default: user proceeds through the informational dialog.
+        dialogService.open.mockReturnValue({ closed: of(true) } as any);
       });
 
-      it("displays permission error dialog when nativeMessaging permission is not granted", async () => {
-        browserApiSpy.mockResolvedValue(false);
+      it("enables biometric unlock when nativeMessaging permission is granted", async () => {
+        await component.ngOnInit();
+        await component.updateBiometric(true);
+
+        expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenCalledWith(
+          true,
+          mockUserId,
+        );
+      });
+
+      it("reverts the biometric toggle without a dialog when nativeMessaging permission is denied", async () => {
+        permissionsGrantedSpy.mockResolvedValue(false);
+        requestPermissionSpy.mockResolvedValue(false);
 
         await component.ngOnInit();
         await component.updateBiometric(true);
 
-        expect(dialogService.openSimpleDialog).toHaveBeenCalledWith({
-          title: { key: "nativeMessaginPermissionErrorTitle" },
-          content: { key: "nativeMessaginPermissionErrorDesc" },
-          acceptButtonText: { key: "ok" },
-          cancelButtonText: null,
-          type: "danger",
-        });
+        expect(dialogService.openSimpleDialog).not.toHaveBeenCalled();
         expect(component.form.controls.biometric.value).toBe(false);
-        expect(trySetupBiometricsSpy).not.toHaveBeenCalled();
+        expect(biometricStateService.setBiometricUnlockEnabled).not.toHaveBeenCalled();
       });
 
       it("displays a specific sidebar dialog when nativeMessaging permissions throws an error on firefox + sidebar", async () => {
-        browserApiSpy.mockRejectedValue(new Error("Permission denied"));
+        permissionsGrantedSpy.mockResolvedValue(false);
+        requestPermissionSpy.mockRejectedValue(new Error("permission request failed"));
         platformUtilsService.isFirefox.mockReturnValue(true);
         jest.spyOn(BrowserPopupUtils, "inSidebar").mockReturnValue(true);
 
@@ -441,7 +420,7 @@ describe("AccountSecurityComponent", () => {
           type: "info",
         });
         expect(component.form.controls.biometric.value).toBe(false);
-        expect(trySetupBiometricsSpy).not.toHaveBeenCalled();
+        expect(biometricStateService.setBiometricUnlockEnabled).not.toHaveBeenCalled();
       });
 
       test.each([
@@ -449,70 +428,185 @@ describe("AccountSecurityComponent", () => {
         [false, true],
         [true, false],
       ])(
-        "displays a generic dialog when nativeMessaging permissions throws an error and isFirefox is %s and onSidebar is %s",
+        "reverts biometric toggle without a dialog when permission request throws and isFirefox is %s and inSidebar is %s",
         async (isFirefox, inSidebar) => {
-          browserApiSpy.mockRejectedValue(new Error("Permission denied"));
+          permissionsGrantedSpy.mockResolvedValue(false);
+          requestPermissionSpy.mockRejectedValue(new Error("permission request failed"));
           platformUtilsService.isFirefox.mockReturnValue(isFirefox);
           jest.spyOn(BrowserPopupUtils, "inSidebar").mockReturnValue(inSidebar);
 
           await component.ngOnInit();
           await component.updateBiometric(true);
 
-          expect(dialogService.openSimpleDialog).toHaveBeenCalledWith({
-            title: { key: "nativeMessaginPermissionErrorTitle" },
-            content: { key: "nativeMessaginPermissionErrorDesc" },
-            acceptButtonText: { key: "ok" },
-            cancelButtonText: null,
-            type: "danger",
-          });
+          expect(dialogService.openSimpleDialog).not.toHaveBeenCalled();
           expect(component.form.controls.biometric.value).toBe(false);
-          expect(trySetupBiometricsSpy).not.toHaveBeenCalled();
+          expect(biometricStateService.setBiometricUnlockEnabled).not.toHaveBeenCalled();
         },
       );
 
-      it("refreshes additional keys and attempts to setup biometrics when enabled with nativeMessaging permission", async () => {
-        const setupBiometricsResult = true;
-        trySetupBiometricsSpy.mockResolvedValue(setupBiometricsResult);
+      it("pops out without showing the dialog or requesting the permission when in the popup", async () => {
+        jest.spyOn(BrowserPopupUtils, "inPopup").mockReturnValue(true);
+        jest.spyOn(BrowserApi, "permissionsGranted").mockResolvedValue(false);
+        const openPopoutSpy = jest
+          .spyOn(BrowserPopupUtils, "openCurrentPagePopout")
+          .mockResolvedValue(undefined as any);
 
         await component.ngOnInit();
         await component.updateBiometric(true);
 
-        expect(keyService.refreshAdditionalKeys).toHaveBeenCalledWith(mockUserId);
-        expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenCalledWith(
-          setupBiometricsResult,
-          mockUserId,
-        );
-        expect(component.form.controls.biometric.value).toBe(setupBiometricsResult);
+        expect(openPopoutSpy).toHaveBeenCalled();
+        expect(dialogService.open).not.toHaveBeenCalled();
+        expect(requestPermissionSpy).not.toHaveBeenCalled();
+        expect(biometricStateService.setBiometricUnlockEnabled).not.toHaveBeenCalled();
       });
 
-      it("handles failed biometrics setup", async () => {
-        const setupBiometricsResult = false;
-        trySetupBiometricsSpy.mockResolvedValue(setupBiometricsResult);
+      it("shows the informational dialog before requesting the permission", async () => {
+        jest.spyOn(BrowserApi, "permissionsGranted").mockResolvedValue(false);
+        requestPermissionSpy.mockResolvedValue(true);
 
         await component.ngOnInit();
         await component.updateBiometric(true);
 
-        expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenCalledWith(
-          setupBiometricsResult,
-          mockUserId,
-        );
-        expect(biometricStateService.setFingerprintValidated).toHaveBeenCalledWith(
-          setupBiometricsResult,
-        );
-        expect(component.form.controls.biometric.value).toBe(setupBiometricsResult);
+        expect(dialogService.open).toHaveBeenCalled();
       });
 
-      it("handles error during biometrics setup", async () => {
-        // Simulate an error during biometrics setup
-        keyService.refreshAdditionalKeys.mockRejectedValue(new Error("UserId is required"));
+      it("saves state then reloads when permission is just granted", async () => {
+        jest.spyOn(BrowserApi, "permissionsGranted").mockResolvedValue(false);
+        requestPermissionSpy.mockResolvedValue(true);
 
         await component.ngOnInit();
         await component.updateBiometric(true);
 
-        expect(validationService.showError).toHaveBeenCalledWith(new Error("UserId is required"));
+        const setBiometricOrder = biometricStateService.setBiometricUnlockEnabled.mock.invocationCallOrder[0];
+        const sendOrder = messagingService.send.mock.invocationCallOrder[0];
+        expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenCalledWith(true, mockUserId);
+        expect(messagingService.send).toHaveBeenCalledWith("reloadExtension");
+        expect(setBiometricOrder).toBeLessThan(sendOrder);
+      });
+
+      it("reverts the toggle and does not request the permission when the user closes the dialog", async () => {
+        jest.spyOn(BrowserApi, "permissionsGranted").mockResolvedValue(false);
+        dialogService.open.mockReturnValue({ closed: of(undefined) } as any);
+
+        await component.ngOnInit();
+        await component.updateBiometric(true);
+
+        expect(requestPermissionSpy).not.toHaveBeenCalled();
         expect(component.form.controls.biometric.value).toBe(false);
-        expect(trySetupBiometricsSpy).not.toHaveBeenCalled();
+        expect(biometricStateService.setBiometricUnlockEnabled).not.toHaveBeenCalled();
       });
+
+      it("shows the dialog again on subsequent enable attempts after the user cancels", async () => {
+        jest.spyOn(BrowserApi, "permissionsGranted").mockResolvedValue(false);
+        dialogService.open.mockReturnValue({ closed: of(undefined) } as any);
+
+        await component.ngOnInit();
+
+        // First attempt: user cancels, toggle reverts to false.
+        await component.updateBiometric(true);
+        expect(dialogService.open).toHaveBeenCalledTimes(1);
+        expect(component.form.controls.biometric.value).toBe(false);
+
+        // Second attempt: dialog must appear again, not be silently skipped.
+        dialogService.open.mockClear();
+        await component.updateBiometric(true);
+        expect(dialogService.open).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+
+  describe("updateAllowSharingUnlockStateWithDesktop", () => {
+    let requestPermissionSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      policyService.policiesByType$.mockReturnValue(of([null]));
+      // Simulate the popout context so the permission is requested directly rather than
+      // re-opening the page in a popout.
+      jest.spyOn(BrowserPopupUtils, "inPopup").mockReturnValue(false);
+      jest.spyOn(BrowserApi, "permissionsGranted").mockResolvedValue(false);
+      requestPermissionSpy = jest.spyOn(BrowserApi, "requestPermission");
+      // The informational dialog is shown every time; default to the user continuing.
+      dialogService.open.mockReturnValue({ closed: of(true) } as any);
+    });
+
+    it("shows the informational dialog before requesting the permission", async () => {
+      requestPermissionSpy.mockResolvedValue(true);
+
+      await component.ngOnInit();
+      await component.updateAllowSharingUnlockStateWithDesktop(true);
+
+      expect(dialogService.open).toHaveBeenCalled();
+    });
+
+    it("pops out without showing the dialog or requesting the permission when in the popup", async () => {
+      jest.spyOn(BrowserPopupUtils, "inPopup").mockReturnValue(true);
+      const openPopoutSpy = jest
+        .spyOn(BrowserPopupUtils, "openCurrentPagePopout")
+        .mockResolvedValue(undefined as any);
+
+      await component.ngOnInit();
+      await component.updateAllowSharingUnlockStateWithDesktop(true);
+
+      expect(openPopoutSpy).toHaveBeenCalled();
+      expect(dialogService.open).not.toHaveBeenCalled();
+      expect(requestPermissionSpy).not.toHaveBeenCalled();
+      expect(
+        sharedUnlockSettingsService.setAllowSharingUnlockStateWithDesktop,
+      ).not.toHaveBeenCalled();
+    });
+
+    it("reverts the toggle and does not request the permission when the user closes the dialog", async () => {
+      dialogService.open.mockReturnValue({ closed: of(undefined) } as any);
+
+      await component.ngOnInit();
+      await component.updateAllowSharingUnlockStateWithDesktop(true);
+
+      expect(requestPermissionSpy).not.toHaveBeenCalled();
+      expect(component.form.controls.allowSharingUnlockStateWithDesktop.value).toBe(false);
+      expect(
+        sharedUnlockSettingsService.setAllowSharingUnlockStateWithDesktop,
+      ).not.toHaveBeenCalled();
+    });
+
+    it("does not show an error dialog and reverts the toggle when the permission is denied", async () => {
+      requestPermissionSpy.mockResolvedValue(false);
+
+      await component.ngOnInit();
+      await component.updateAllowSharingUnlockStateWithDesktop(true);
+
+      expect(dialogService.openSimpleDialog).not.toHaveBeenCalled();
+      expect(component.form.controls.allowSharingUnlockStateWithDesktop.value).toBe(false);
+      expect(
+        sharedUnlockSettingsService.setAllowSharingUnlockStateWithDesktop,
+      ).not.toHaveBeenCalled();
+    });
+
+    it("persists the setting when the permission is granted", async () => {
+      requestPermissionSpy.mockResolvedValue(true);
+
+      await component.ngOnInit();
+      await component.updateAllowSharingUnlockStateWithDesktop(true);
+
+      expect(
+        sharedUnlockSettingsService.setAllowSharingUnlockStateWithDesktop,
+      ).toHaveBeenCalledWith(true, mockUserId);
+    });
+
+    it("saves state then reloads when permission is just granted", async () => {
+      requestPermissionSpy.mockResolvedValue(true);
+
+      await component.ngOnInit();
+      await component.updateAllowSharingUnlockStateWithDesktop(true);
+
+      const saveOrder =
+        sharedUnlockSettingsService.setAllowSharingUnlockStateWithDesktop.mock.invocationCallOrder[0];
+      const sendOrder = messagingService.send.mock.invocationCallOrder[0];
+      expect(sharedUnlockSettingsService.setAllowSharingUnlockStateWithDesktop).toHaveBeenCalledWith(
+        true,
+        mockUserId,
+      );
+      expect(messagingService.send).toHaveBeenCalledWith("reloadExtension");
+      expect(saveOrder).toBeLessThan(sendOrder);
     });
   });
 
@@ -628,5 +722,111 @@ describe("AccountSecurityComponent", () => {
       expect(component.biometricUnavailabilityReason).toBe("");
       component.ngOnDestroy();
     }));
+  });
+
+  describe("desktop sharing permission request on popout", () => {
+    let inPopoutSpy: jest.SpyInstance;
+    let permissionsGrantedSpy: jest.SpyInstance;
+    let updateDesktopSharingSpy: jest.SpyInstance;
+    let queryParamGet: jest.Mock;
+
+    beforeEach(() => {
+      policyService.policiesByType$.mockReturnValue(of([null]));
+      inPopoutSpy = jest.spyOn(BrowserPopupUtils, "inPopout").mockReturnValue(true);
+      permissionsGrantedSpy = jest.spyOn(BrowserApi, "permissionsGranted").mockResolvedValue(false);
+      queryParamGet = jest.fn().mockImplementation((key: string) =>
+        key === "autoRequestDesktopSharing" ? "true" : null,
+      );
+      const route = TestBed.inject(ActivatedRoute);
+      (route as any).snapshot = { queryParamMap: { get: queryParamGet } };
+      updateDesktopSharingSpy = jest
+        .spyOn(component, "updateAllowSharingUnlockStateWithDesktop")
+        .mockResolvedValue(undefined);
+    });
+
+    it("enables the setting to trigger the permission flow", async () => {
+      await component.ngOnInit();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(component.form.controls.allowSharingUnlockStateWithDesktop.value).toBe(true);
+      expect(updateDesktopSharingSpy).toHaveBeenCalledWith(true);
+    });
+
+    it("does not trigger the flow when the autoRequestDesktopSharing query param is absent", async () => {
+      queryParamGet.mockReturnValue(null);
+
+      await component.ngOnInit();
+
+      expect(updateDesktopSharingSpy).not.toHaveBeenCalled();
+    });
+
+    it("does not trigger the flow when not in a popout", async () => {
+      inPopoutSpy.mockReturnValue(false);
+
+      await component.ngOnInit();
+
+      expect(updateDesktopSharingSpy).not.toHaveBeenCalled();
+    });
+
+    it("does not trigger the flow when the nativeMessaging permission is already granted", async () => {
+      permissionsGrantedSpy.mockResolvedValue(true);
+
+      await component.ngOnInit();
+
+      expect(updateDesktopSharingSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("biometric permission request on popout", () => {
+    let inPopoutSpy: jest.SpyInstance;
+    let permissionsGrantedSpy: jest.SpyInstance;
+    let updateBiometricSpy: jest.SpyInstance;
+    let queryParamGet: jest.Mock;
+
+    beforeEach(() => {
+      policyService.policiesByType$.mockReturnValue(of([null]));
+      inPopoutSpy = jest.spyOn(BrowserPopupUtils, "inPopout").mockReturnValue(true);
+      permissionsGrantedSpy = jest.spyOn(BrowserApi, "permissionsGranted").mockResolvedValue(false);
+      queryParamGet = jest.fn().mockImplementation((key: string) =>
+        key === "autoRequestBiometrics" ? "true" : null,
+      );
+      const route = TestBed.inject(ActivatedRoute);
+      (route as any).snapshot = { queryParamMap: { get: queryParamGet } };
+      updateBiometricSpy = jest
+        .spyOn(component, "updateBiometric")
+        .mockResolvedValue(undefined);
+    });
+
+    it("enables the biometric setting to trigger the permission flow", async () => {
+      await component.ngOnInit();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(component.form.controls.biometric.value).toBe(true);
+      expect(updateBiometricSpy).toHaveBeenCalledWith(true);
+    });
+
+    it("does not trigger the flow when the autoRequestBiometrics query param is absent", async () => {
+      queryParamGet.mockImplementation(() => null);
+
+      await component.ngOnInit();
+
+      expect(updateBiometricSpy).not.toHaveBeenCalled();
+    });
+
+    it("does not trigger the flow when not in a popout", async () => {
+      inPopoutSpy.mockReturnValue(false);
+
+      await component.ngOnInit();
+
+      expect(updateBiometricSpy).not.toHaveBeenCalled();
+    });
+
+    it("does not trigger the flow when the nativeMessaging permission is already granted", async () => {
+      permissionsGrantedSpy.mockResolvedValue(true);
+
+      await component.ngOnInit();
+
+      expect(updateBiometricSpy).not.toHaveBeenCalled();
+    });
   });
 });

--- a/apps/browser/src/auth/popup/settings/account-security.component.ts
+++ b/apps/browser/src/auth/popup/settings/account-security.component.ts
@@ -69,6 +69,7 @@ import { SessionTimeoutSettingsComponent } from "@bitwarden/key-management-ui";
 
 import { BiometricErrors, BiometricErrorTypes } from "../../../models/biometricErrors";
 import { BrowserApi } from "../../../platform/browser/browser-api";
+import BrowserPopupUtils from "../../../platform/browser/browser-popup-utils";
 import { PopOutComponent } from "../../../platform/popup/components/pop-out.component";
 import { PopupHeaderComponent } from "../../../platform/popup/layout/popup-header.component";
 import { PopupPageComponent } from "../../../platform/popup/layout/popup-page.component";
@@ -230,6 +231,14 @@ export class AccountSecurityComponent implements OnInit, OnDestroy {
             this.form.controls.biometric.enable({ emitEvent: false });
           }
 
+          // Biometrics status shouldn't be checked if permissions are needed.
+          const needsPermissionPrompt =
+            !(await BrowserApi.permissionsGranted(["nativeMessaging"])) &&
+            !this.platformUtilsService.isSafari();
+          if (needsPermissionPrompt) {
+            return;
+          }
+
           const status = await this.biometricsService.getBiometricsStatusForUser(activeAccount.id);
           if (status === BiometricsStatus.DesktopDisconnected && !biometricSettingAvailable) {
             this.biometricUnavailabilityReason = this.i18nService.t(
@@ -372,6 +381,40 @@ export class AccountSecurityComponent implements OnInit, OnDestroy {
   async updateBiometric(enabled: boolean) {
     const userId = await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId));
     if (enabled) {
+      let granted;
+      try {
+        granted = await BrowserApi.requestPermission({ permissions: ["nativeMessaging"] });
+      } catch (e) {
+        // eslint-disable-next-line
+        console.error(e);
+
+        if (this.platformUtilsService.isFirefox() && BrowserPopupUtils.inSidebar(window)) {
+          await this.dialogService.openSimpleDialog({
+            title: { key: "nativeMessaginPermissionSidebarTitle" },
+            content: { key: "nativeMessaginPermissionSidebarDesc" },
+            acceptButtonText: { key: "ok" },
+            cancelButtonText: null,
+            type: "info",
+          });
+
+          this.form.controls.biometric.setValue(false);
+          return;
+        }
+      }
+
+      if (!granted) {
+        await this.dialogService.openSimpleDialog({
+          title: { key: "nativeMessaginPermissionErrorTitle" },
+          content: { key: "nativeMessaginPermissionErrorDesc" },
+          acceptButtonText: { key: "ok" },
+          cancelButtonText: null,
+          type: "danger",
+        });
+
+        this.form.controls.biometric.setValue(false);
+        return;
+      }
+
       try {
         await this.keyService.refreshAdditionalKeys(userId);
 

--- a/apps/browser/src/auth/popup/settings/account-security.component.ts
+++ b/apps/browser/src/auth/popup/settings/account-security.component.ts
@@ -3,11 +3,10 @@
 import { CommonModule } from "@angular/common";
 import { Component, OnDestroy, OnInit, signal } from "@angular/core";
 import { FormBuilder, FormsModule, ReactiveFormsModule } from "@angular/forms";
-import { Router, RouterModule } from "@angular/router";
+import { ActivatedRoute, Router, RouterModule } from "@angular/router";
 import {
   BehaviorSubject,
   concatMap,
-  distinctUntilChanged,
   firstValueFrom,
   map,
   Observable,
@@ -39,9 +38,7 @@ import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.servic
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
-import { ValidationService } from "@bitwarden/common/platform/abstractions/validation.service";
 import {
-  DialogRef,
   CardComponent,
   CheckboxModule,
   DialogService,
@@ -67,7 +64,7 @@ import {
 } from "@bitwarden/key-management";
 import { SessionTimeoutSettingsComponent } from "@bitwarden/key-management-ui";
 
-import { BiometricErrors, BiometricErrorTypes } from "../../../models/biometricErrors";
+import { NativeMessagingPermissionDialogComponent } from "../../../key-management/shared-unlock/popup/native-messaging-permission-dialog.component";
 import { BrowserApi } from "../../../platform/browser/browser-api";
 import BrowserPopupUtils from "../../../platform/browser/browser-popup-utils";
 import { PopOutComponent } from "../../../platform/popup/components/pop-out.component";
@@ -76,7 +73,6 @@ import { PopupPageComponent } from "../../../platform/popup/layout/popup-page.co
 import { SetPinComponent } from "../components/set-pin.component";
 import { AuthExtensionRoute } from "../constants/auth-extension-route.constant";
 
-import { AwaitDesktopDialogComponent } from "./await-desktop-dialog.component";
 
 // FIXME(https://bitwarden.atlassian.net/browse/CL-764): Migrate to OnPush
 // eslint-disable-next-line @angular-eslint/prefer-on-push-component-change-detection
@@ -121,7 +117,8 @@ export class AccountSecurityComponent implements OnInit, OnDestroy {
     biometric: false,
     enableAutoBiometricsPrompt: true,
     enablePhishingDetection: true,
-    allowSharingUnlockState: true,
+    allowSharingUnlockStateWithDesktop: false,
+    allowSharingUnlockStateWithWeb: false,
   });
 
   protected showAccountSecurityNudge$: Observable<boolean> =
@@ -136,6 +133,11 @@ export class AccountSecurityComponent implements OnInit, OnDestroy {
   protected readonly sharedUnlockFeatureEnabled$: Observable<boolean>;
   protected readonly multiClientPasswordManagement$: Observable<boolean>;
 
+  // Native messaging with the desktop app is unavailable on Safari.
+  protected readonly showSharedUnlockWithDesktop: boolean;
+  // Firefox does not support sharing unlock state with the web vault.
+  protected readonly showSharedUnlockWithWeb: boolean;
+
   protected refreshTimeoutSettings$ = new BehaviorSubject<void>(undefined);
   private destroy$ = new Subject<void>();
   private readonly BIOMETRICS_POLLING_INTERVAL = 2000;
@@ -145,6 +147,7 @@ export class AccountSecurityComponent implements OnInit, OnDestroy {
     private pinService: PinServiceAbstraction,
     private configService: ConfigService,
     private router: Router,
+    private route: ActivatedRoute,
     private policyService: PolicyService,
     private formBuilder: FormBuilder,
     private platformUtilsService: PlatformUtilsService,
@@ -160,7 +163,6 @@ export class AccountSecurityComponent implements OnInit, OnDestroy {
     private toastService: ToastService,
     private biometricsService: BiometricsService,
     private vaultNudgesService: NudgesService,
-    private validationService: ValidationService,
     private logService: LogService,
     private phishingDetectionSettingsService: PhishingDetectionSettingsServiceAbstraction,
     private sharedUnlockSettingsService: SharedUnlockSettingsService,
@@ -174,18 +176,9 @@ export class AccountSecurityComponent implements OnInit, OnDestroy {
     this.sharedUnlockFeatureEnabled$ = this.configService.getFeatureFlag$(
       FeatureFlag.SharedUnlockPart2,
     );
-  }
 
-  get sharedUnlockDescriptionKey(): string {
-    if (this.platformUtilsService.isSafari()) {
-      return "sharedUnlockDescriptionSafari";
-    }
-
-    if (this.platformUtilsService.isFirefox()) {
-      return "sharedUnlockDescriptionFirefox";
-    }
-
-    return "sharedUnlockDescription";
+    this.showSharedUnlockWithDesktop = !this.platformUtilsService.isSafari();
+    this.showSharedUnlockWithWeb = !this.platformUtilsService.isFirefox();
   }
 
   async ngOnInit() {
@@ -214,8 +207,11 @@ export class AccountSecurityComponent implements OnInit, OnDestroy {
         this.biometricStateService.promptAutomatically$(activeAccount.id),
       ),
       enablePhishingDetection: await firstValueFrom(this.phishingDetectionSettingsService.enabled$),
-      allowSharingUnlockState: await firstValueFrom(
-        this.sharedUnlockSettingsService.allowSharingUnlockState$(activeAccount.id),
+      allowSharingUnlockStateWithDesktop: await firstValueFrom(
+        this.sharedUnlockSettingsService.allowSharingUnlockStateWithDesktop$(activeAccount.id),
+      ),
+      allowSharingUnlockStateWithWeb: await firstValueFrom(
+        this.sharedUnlockSettingsService.allowSharingUnlockStateWithWeb$(activeAccount.id),
       ),
     };
     this.form.patchValue(initialValues, { emitEvent: false });
@@ -297,7 +293,6 @@ export class AccountSecurityComponent implements OnInit, OnDestroy {
 
     this.form.controls.biometric.valueChanges
       .pipe(
-        distinctUntilChanged(),
         concatMap(async (enabled) => {
           await this.updateBiometric(enabled);
           if (enabled) {
@@ -330,14 +325,63 @@ export class AccountSecurityComponent implements OnInit, OnDestroy {
       )
       .subscribe();
 
-    this.form.controls.allowSharingUnlockState.valueChanges
+    this.form.controls.allowSharingUnlockStateWithDesktop.valueChanges
       .pipe(
         concatMap(async (enabled) => {
-          await this.updateAllowSharingUnlockState(enabled);
+          await this.updateAllowSharingUnlockStateWithDesktop(enabled);
         }),
         takeUntil(this.destroy$),
       )
       .subscribe();
+
+    this.form.controls.allowSharingUnlockStateWithWeb.valueChanges
+      .pipe(
+        concatMap(async (enabled) => {
+          await this.updateAllowSharingUnlockStateWithWeb(enabled);
+        }),
+        takeUntil(this.destroy$),
+      )
+      .subscribe();
+
+    await this.promptForDesktopSharingPermissionIfNeeded();
+    await this.promptForBiometricPermissionIfNeeded();
+  }
+
+  /**
+   * When the Account Security page was popped out specifically to enable desktop unlock sharing
+   * (signalled by the `autoRequestDesktopSharing` query param), continue the flow that was started
+   * in the popup. Enabling the form control triggers `updateAllowSharingUnlockStateWithDesktop`,
+   * which — now running in the popout — presents the permission dialog and requests the
+   * `nativeMessaging` permission.
+   */
+  private async promptForDesktopSharingPermissionIfNeeded() {
+    if (
+      !BrowserPopupUtils.inPopout(window) ||
+      this.route.snapshot.queryParamMap.get("autoRequestDesktopSharing") !== "true" ||
+      (await BrowserApi.permissionsGranted(["nativeMessaging"]))
+    ) {
+      return;
+    }
+
+    this.form.controls.allowSharingUnlockStateWithDesktop.setValue(true);
+  }
+
+  /**
+   * When the Account Security page was popped out specifically to enable biometric unlock
+   * (signalled by the `autoRequestBiometrics` query param), continue the flow that was started
+   * in the popup. Enabling the form control triggers `updateBiometric`, which — now running in
+   * the popout — presents the permission dialog and requests the `nativeMessaging` permission.
+   */
+  private async promptForBiometricPermissionIfNeeded() {
+    if (
+      !BrowserPopupUtils.inPopout(window) ||
+      this.route.snapshot.queryParamMap.get("autoRequestBiometrics") !== "true" ||
+      (await BrowserApi.permissionsGranted(["nativeMessaging"]))
+    ) {
+      return;
+    }
+
+    this.form.controls.biometric.setValue(true);
   }
 
   protected async dismissAccountSecurityNudge() {
@@ -378,61 +422,74 @@ export class AccountSecurityComponent implements OnInit, OnDestroy {
     }
   }
 
+  private async requestNativeMessagingPermission(): Promise<boolean> {
+    if (await BrowserApi.permissionsGranted(["nativeMessaging"])) {
+      return true;
+    }
+
+    let granted = false;
+
+    try {
+      granted = (await BrowserApi.requestPermission({
+        permissions: ["nativeMessaging"],
+      })) as boolean;
+    } catch {
+      if (this.platformUtilsService.isFirefox() && BrowserPopupUtils.inSidebar(window)) {
+        await this.dialogService.openSimpleDialog({
+          title: { key: "nativeMessaginPermissionSidebarTitle" },
+          content: { key: "nativeMessaginPermissionSidebarDesc" },
+          acceptButtonText: { key: "ok" },
+          cancelButtonText: null,
+          type: "info",
+        });
+      }
+      return false;
+    }
+
+    return granted;
+  }
+
   async updateBiometric(enabled: boolean) {
     const userId = await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId));
     if (enabled) {
-      let granted;
-      try {
-        granted = await BrowserApi.requestPermission({ permissions: ["nativeMessaging"] });
-      } catch (e) {
-        // eslint-disable-next-line
-        console.error(e);
+      const hadPermission = await BrowserApi.permissionsGranted(["nativeMessaging"]);
+      if (!hadPermission) {
+        if (BrowserPopupUtils.inPopup(window)) {
+          // Requesting the permission in the popup would close the window (granting reloads
+          // the extension), so pop out to a stable window. With hash routing, Angular reads
+          // query params from after the hash route.
+          const url = new URL(window.location.href);
+          url.hash += (url.hash.includes("?") ? "&" : "?") + "autoRequestBiometrics=true";
+          await BrowserPopupUtils.openCurrentPagePopout(window, url.href);
+          return;
+        }
 
-        if (this.platformUtilsService.isFirefox() && BrowserPopupUtils.inSidebar(window)) {
-          await this.dialogService.openSimpleDialog({
-            title: { key: "nativeMessaginPermissionSidebarTitle" },
-            content: { key: "nativeMessaginPermissionSidebarDesc" },
-            acceptButtonText: { key: "ok" },
-            cancelButtonText: null,
-            type: "info",
-          });
-
-          this.form.controls.biometric.setValue(false);
+        // In the popout, always explain what enabling biometric unlock entails before
+        // requesting the permission.
+        const proceed = await firstValueFrom(
+          NativeMessagingPermissionDialogComponent.open(this.dialogService, {
+            descriptionKey: "biometricPermissionDesc",
+          }).closed,
+        );
+        if (!proceed) {
+          this.form.controls.biometric.setValue(false, { emitEvent: false });
           return;
         }
       }
 
+      const granted = await this.requestNativeMessagingPermission();
       if (!granted) {
-        await this.dialogService.openSimpleDialog({
-          title: { key: "nativeMessaginPermissionErrorTitle" },
-          content: { key: "nativeMessaginPermissionErrorDesc" },
-          acceptButtonText: { key: "ok" },
-          cancelButtonText: null,
-          type: "danger",
-        });
-
-        this.form.controls.biometric.setValue(false);
+        this.form.controls.biometric.setValue(false, { emitEvent: false });
         return;
       }
 
-      try {
-        await this.keyService.refreshAdditionalKeys(userId);
+      await this.biometricStateService.setBiometricUnlockEnabled(true, userId);
 
-        const successful = await this.trySetupBiometrics();
-        this.form.controls.biometric.setValue(successful);
-        await this.biometricStateService.setBiometricUnlockEnabled(successful, userId);
-        if (!successful) {
-          await this.biometricStateService.setFingerprintValidated(false);
-          return;
-        }
-        this.toastService.showToast({
-          variant: "success",
-          title: null,
-          message: this.i18nService.t("unlockWithBiometricSet"),
-        });
-      } catch (error) {
-        this.form.controls.biometric.setValue(false);
-        this.validationService.showError(error);
+      if (!hadPermission) {
+        // The nativeMessaging permission was just granted. The extension must reload to
+        // register the native messaging host. State is saved above so it survives the reload.
+        this.messagingService.send("reloadExtension");
+        return;
       }
     } else {
       await this.biometricStateService.setBiometricUnlockEnabled(false, userId);
@@ -440,99 +497,54 @@ export class AccountSecurityComponent implements OnInit, OnDestroy {
     }
   }
 
-  async trySetupBiometrics(): Promise<boolean> {
-    let awaitDesktopDialogRef: DialogRef<boolean, unknown> | undefined;
-    let biometricsResponseReceived = false;
-    let setupResult = false;
-
-    const waitForUserDialogPromise = async () => {
-      // only show waiting dialog if we have waited for 500 msec to prevent double dialog
-      // the os will respond instantly if the dialog shows successfully, and the desktop app will respond instantly if something is wrong
-      await new Promise((resolve) => setTimeout(resolve, 500));
-      if (biometricsResponseReceived) {
+  async updateAllowSharingUnlockStateWithDesktop(enabled: boolean) {
+    const hadPermission = await BrowserApi.permissionsGranted(["nativeMessaging"]);
+    if (enabled && !hadPermission) {
+      if (BrowserPopupUtils.inPopup(window)) {
+        // Requesting the permission in the popup would close the window (granting reloads the
+        // extension), so pop out to a stable window. The popped-out window presents the dialog and
+        // requests the permission. With hash routing, Angular reads query params from after the
+        // hash route.
+        const url = new URL(window.location.href);
+        url.hash += (url.hash.includes("?") ? "&" : "?") + "autoRequestDesktopSharing=true";
+        await BrowserPopupUtils.openCurrentPagePopout(window, url.href);
         return;
       }
 
-      awaitDesktopDialogRef = AwaitDesktopDialogComponent.open(this.dialogService);
-      await firstValueFrom(awaitDesktopDialogRef.closed);
-      if (!biometricsResponseReceived) {
-        setupResult = false;
+      // In the popout, always explain what enabling desktop sharing entails before requesting the
+      // permission.
+      const proceed = await firstValueFrom(
+        NativeMessagingPermissionDialogComponent.open(this.dialogService).closed,
+      );
+      if (!proceed) {
+        this.form.controls.allowSharingUnlockStateWithDesktop.setValue(false, { emitEvent: false });
+        return;
       }
-      return;
-    };
 
-    const biometricsPromise = async () => {
-      try {
-        const userId = await firstValueFrom(
-          this.accountService.activeAccount$.pipe(map((a) => a.id)),
-        );
-        let result = false;
-        try {
-          const userKey = await this.biometricsService.unlockWithBiometricsForUser(userId);
-          result = await this.keyService.validateUserKey(userKey, userId);
-          // FIXME: Remove when updating file. Eslint update
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        } catch (e) {
-          result = false;
-        }
-
-        // prevent duplicate dialog
-        biometricsResponseReceived = true;
-        if (awaitDesktopDialogRef) {
-          await awaitDesktopDialogRef.close(result);
-        }
-
-        if (!result) {
-          this.platformUtilsService.showToast(
-            "error",
-            this.i18nService.t("errorEnableBiometricTitle"),
-            this.i18nService.t("errorEnableBiometricDesc"),
-          );
-          setupResult = false;
-          return;
-        }
-        setupResult = true;
-      } catch (e) {
-        // prevent duplicate dialog
-        biometricsResponseReceived = true;
-        if (awaitDesktopDialogRef) {
-          await awaitDesktopDialogRef.close(true);
-        }
-
-        if (e.message == "canceled") {
-          setupResult = false;
-          return;
-        }
-
-        const error = BiometricErrors[e.message as BiometricErrorTypes];
-        const shouldRetry = await this.dialogService.openSimpleDialog({
-          title: { key: error.title },
-          content: { key: error.description },
-          acceptButtonText: { key: "retry" },
-          cancelButtonText: null,
-          type: "danger",
-        });
-        if (shouldRetry) {
-          setupResult = await this.trySetupBiometrics();
-        } else {
-          setupResult = false;
-          return;
-        }
-      } finally {
-        if (awaitDesktopDialogRef) {
-          await awaitDesktopDialogRef.close(true);
-        }
+      const granted = await this.requestNativeMessagingPermission();
+      if (!granted) {
+        this.form.controls.allowSharingUnlockStateWithDesktop.setValue(false, { emitEvent: false });
+        return;
       }
-    };
+    }
 
-    await Promise.all([waitForUserDialogPromise(), biometricsPromise()]);
-    return setupResult;
+    const userId = await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId));
+    await this.sharedUnlockSettingsService.setAllowSharingUnlockStateWithDesktop(enabled, userId);
+    if (!enabled && !this.form.controls.allowSharingUnlockStateWithWeb.value) {
+      await this.vaultTimeoutSettingsService.clearVaultTimeoutSuppression(userId);
+    }
+
+    if (enabled && !hadPermission) {
+      // The nativeMessaging permission was just granted. The extension must reload to register
+      // the native messaging host. State is saved above so it survives the reload.
+      this.messagingService.send("reloadExtension");
+    }
   }
 
-  async updateAllowSharingUnlockState(enabled: boolean) {
+  async updateAllowSharingUnlockStateWithWeb(enabled: boolean) {
     const userId = await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId));
-    await this.sharedUnlockSettingsService.setAllowSharingUnlockState(enabled, userId);
-    if (!enabled) {
+    await this.sharedUnlockSettingsService.setAllowSharingUnlockStateWithWeb(enabled, userId);
+    if (!enabled && !this.form.controls.allowSharingUnlockStateWithDesktop.value) {
       await this.vaultTimeoutSettingsService.clearVaultTimeoutSuppression(userId);
     }
   }

--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -1452,7 +1452,7 @@ export default class MainBackground {
       // and popups will close themselves upon receiving it. Poll to verify popup is actually closed.
       await BrowserPopupUtils.waitForAllPopupsClose();
 
-      BrowserApi.reloadExtension();
+      await BrowserApi.reloadExtension();
     };
 
     this.systemService = new SystemService(

--- a/apps/browser/src/background/native-messaging.background.spec.ts
+++ b/apps/browser/src/background/native-messaging.background.spec.ts
@@ -74,6 +74,7 @@ describe("NativeMessagingBackground", () => {
     accountService.activeAccount$ = of(mockAccount);
     platformUtilsService.isSafari.mockReturnValue(false);
 
+    (BrowserApi.permissionsGranted as jest.Mock).mockResolvedValue(true);
     (BrowserApi.connectNative as jest.Mock).mockReturnValue({
       onMessage: {
         addListener: jest.fn(),
@@ -107,6 +108,17 @@ describe("NativeMessagingBackground", () => {
   });
 
   describe("connect", () => {
+    it("logs warning and returns if native messaging permission is missing", async () => {
+      (BrowserApi.permissionsGranted as jest.Mock).mockResolvedValue(false);
+
+      await sut.connect();
+
+      expect(logService.warning).toHaveBeenCalledWith(
+        "[Native Messaging IPC] Native messaging permission is missing for biometrics",
+      );
+      expect(sut.connected).toBe(false);
+    });
+
     it("connects immediately for Safari", async () => {
       platformUtilsService.isSafari.mockReturnValue(true);
 

--- a/apps/browser/src/background/native-messaging.background.spec.ts
+++ b/apps/browser/src/background/native-messaging.background.spec.ts
@@ -73,6 +73,7 @@ describe("NativeMessagingBackground", () => {
     appIdService.getAppId.mockResolvedValue(mockAppId);
     accountService.activeAccount$ = of(mockAccount);
     platformUtilsService.isSafari.mockReturnValue(false);
+    (BrowserApi.permissionsGranted as jest.Mock).mockResolvedValue(true);
 
     (BrowserApi.permissionsGranted as jest.Mock).mockResolvedValue(true);
     (BrowserApi.connectNative as jest.Mock).mockReturnValue({
@@ -161,6 +162,11 @@ describe("NativeMessagingBackground", () => {
       platformUtilsService.isSafari.mockReturnValue(false);
 
       connectPromise = sut.connect() as Promise<void>;
+      // connect() has 3 awaits before synchronously registering port listeners;
+      // flush them so listeners are captured before each test body runs.
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
     });
 
     afterEach(() => {

--- a/apps/browser/src/background/nativeMessaging.background.ts
+++ b/apps/browser/src/background/nativeMessaging.background.ts
@@ -88,9 +88,24 @@ export class NativeMessagingBackground {
     private logService: LogService,
     private biometricStateService: BiometricStateService,
     private accountService: AccountService,
-  ) {}
+  ) {
+    if (chrome?.permissions?.onAdded) {
+      // Reload extension to activate nativeMessaging
+      chrome.permissions.onAdded.addListener((permissions) => {
+        if (permissions.permissions?.includes("nativeMessaging")) {
+          BrowserApi.reloadExtension();
+        }
+      });
+    }
+  }
 
   async connect() {
+    if (!(await BrowserApi.permissionsGranted(["nativeMessaging"]))) {
+      this.logService.warning(
+        "[Native Messaging IPC] Native messaging permission is missing for biometrics",
+      );
+      return;
+    }
     if (this.connected || this.connecting) {
       return;
     }

--- a/apps/browser/src/background/nativeMessaging.background.ts
+++ b/apps/browser/src/background/nativeMessaging.background.ts
@@ -89,14 +89,6 @@ export class NativeMessagingBackground {
     private biometricStateService: BiometricStateService,
     private accountService: AccountService,
   ) {
-    if (chrome?.permissions?.onAdded) {
-      // Reload extension to activate nativeMessaging
-      chrome.permissions.onAdded.addListener((permissions) => {
-        if (permissions.permissions?.includes("nativeMessaging")) {
-          BrowserApi.reloadExtension();
-        }
-      });
-    }
   }
 
   async connect() {

--- a/apps/browser/src/background/runtime.background.ts
+++ b/apps/browser/src/background/runtime.background.ts
@@ -433,6 +433,9 @@ export default class RuntimeBackground {
         await this.main.clearClipboard(msg.clipboardValue, msg.timeoutMs);
         break;
       }
+      case "reloadExtension":
+        await BrowserApi.reloadExtension();
+        break;
     }
   }
 

--- a/apps/browser/src/key-management/biometrics/background-browser-biometrics.service.ts
+++ b/apps/browser/src/key-management/biometrics/background-browser-biometrics.service.ts
@@ -27,6 +27,7 @@ import {
 } from "@bitwarden/sdk-internal";
 
 import { NativeMessagingBackground } from "../../background/nativeMessaging.background";
+import { BrowserApi } from "../../platform/browser/browser-api";
 
 export class BackgroundBrowserBiometricsService extends BiometricsService {
   BACKGROUND_POLLING_INTERVAL = 30_000;
@@ -103,6 +104,10 @@ export class BackgroundBrowserBiometricsService extends BiometricsService {
   }
 
   async getBiometricsStatus(): Promise<BiometricsStatus> {
+    if (!(await BrowserApi.permissionsGranted(["nativeMessaging"]))) {
+      return BiometricsStatus.NativeMessagingPermissionMissing;
+    }
+
     if (await this.configService().getFeatureFlag(FeatureFlag.BiometricsSDKIPC)) {
       if (!this.nativeMessagingBackground().connected) {
         return BiometricsStatus.DesktopDisconnected;

--- a/apps/browser/src/key-management/biometrics/foreground-browser-biometrics.spec.ts
+++ b/apps/browser/src/key-management/biometrics/foreground-browser-biometrics.spec.ts
@@ -1,3 +1,7 @@
+import { mock } from "jest-mock-extended";
+
+import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
+
 import { BrowserApi } from "../../platform/browser/browser-api";
 
 import { ForegroundBrowserBiometricsService } from "./foreground-browser-biometrics";
@@ -5,27 +9,47 @@ import { ForegroundBrowserBiometricsService } from "./foreground-browser-biometr
 jest.mock("../../platform/browser/browser-api", () => ({
   BrowserApi: {
     sendMessageWithResponse: jest.fn(),
+    permissionsGranted: jest.fn(),
   },
 }));
 
 describe("foreground browser biometrics service tests", function () {
+  const platformUtilsService = mock<PlatformUtilsService>();
+
   beforeEach(() => {
     jest.resetAllMocks();
   });
 
   describe("canEnableBiometricUnlock", () => {
-    const table: [boolean, boolean][] = [
-      [false, false],
-      [true, true],
+    const table: [boolean, boolean, boolean, boolean][] = [
+      // canEnableBiometricUnlock from background, native permission granted, isSafari, expected
+
+      // needs permission prompt; always allowed
+      [true, false, false, true],
+      [false, false, false, true],
+
+      // is safari; depends on the status that the background service reports
+      [false, false, true, false],
+      [true, false, true, true],
+
+      // native permissions granted; depends on the status that the background service reports
+      [false, true, false, false],
+      [true, true, false, true],
+
+      // should never happen since safari does not use the permissions
+      [false, true, true, false],
+      [true, true, true, true],
     ];
     test.each(table)(
-      "canEnableBiometric: %s, expected: %s",
-      async (canEnableBiometricUnlockBackground, expected) => {
-        const service = new ForegroundBrowserBiometricsService();
+      "canEnableBiometric: %s, native permission granted: %s, isSafari: %s, expected: %s",
+      async (canEnableBiometricUnlockBackground, granted, isSafari, expected) => {
+        const service = new ForegroundBrowserBiometricsService(platformUtilsService);
 
+        (BrowserApi.permissionsGranted as jest.Mock).mockResolvedValue(granted);
         (BrowserApi.sendMessageWithResponse as jest.Mock).mockResolvedValue({
           result: canEnableBiometricUnlockBackground,
         });
+        platformUtilsService.isSafari.mockReturnValue(isSafari);
 
         const result = await service.canEnableBiometricUnlock();
 

--- a/apps/browser/src/key-management/biometrics/foreground-browser-biometrics.ts
+++ b/apps/browser/src/key-management/biometrics/foreground-browser-biometrics.ts
@@ -1,3 +1,4 @@
+import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
 import { UserId } from "@bitwarden/common/types/guid";
 import { UserKey } from "@bitwarden/common/types/key";
@@ -8,7 +9,7 @@ import { BrowserApi } from "../../platform/browser/browser-api";
 export class ForegroundBrowserBiometricsService extends BiometricsService {
   shouldAutopromptNow = true;
 
-  constructor() {
+  constructor(private platformUtilsService: PlatformUtilsService) {
     super();
   }
 
@@ -62,12 +63,18 @@ export class ForegroundBrowserBiometricsService extends BiometricsService {
   }
 
   async canEnableBiometricUnlock(): Promise<boolean> {
+    const needsPermissionPrompt =
+      !(await BrowserApi.permissionsGranted(["nativeMessaging"])) &&
+      !this.platformUtilsService.isSafari();
     return (
-      await BrowserApi.sendMessageWithResponse<{
-        result: boolean;
-        error: string;
-      }>(BiometricsCommands.CanEnableBiometricUnlock)
-    ).result;
+      needsPermissionPrompt ||
+      (
+        await BrowserApi.sendMessageWithResponse<{
+          result: boolean;
+          error: string;
+        }>(BiometricsCommands.CanEnableBiometricUnlock)
+      ).result
+    );
   }
   async setBiometricProtectedUnlockKeyForUser(
     userId: UserId,

--- a/apps/browser/src/key-management/lock/services/extension-lock-component.service.spec.ts
+++ b/apps/browser/src/key-management/lock/services/extension-lock-component.service.spec.ts
@@ -424,7 +424,8 @@ describe("ExtensionLockComponentService", () => {
 
       // Shared unlock
       configService.getFeatureFlag$.mockReturnValue(of(false));
-      sharedUnlockSettingsService.allowSharingUnlockState$.mockReturnValue(of(false));
+      sharedUnlockSettingsService.allowSharingUnlockStateWithDesktop$.mockReturnValue(of(false));
+      sharedUnlockSettingsService.allowSharingUnlockStateWithWeb$.mockReturnValue(of(false));
 
       const unlockOptions = await firstValueFrom(service.getAvailableUnlockOptions$(userId));
 

--- a/apps/browser/src/key-management/lock/services/extension-lock-component.service.ts
+++ b/apps/browser/src/key-management/lock/services/extension-lock-component.service.ts
@@ -84,13 +84,13 @@ export class ExtensionLockComponentService implements LockComponentService {
     return combineLatest([
       combineLatest([
         this.configService.getFeatureFlag$(FeatureFlag.SharedUnlockPart2),
-        this.sharedUnlockSettingsService.allowSharingUnlockState$(userId),
+        this.sharedUnlockSettingsService.allowSharingUnlockStateWithDesktop$(userId),
         // Check biometricUnlockEnabled$ first to avoid background native messaging & IPC calls when biometrics is disabled.
         this.biometricStateService.biometricUnlockEnabled$(userId),
       ]).pipe(
         switchMap(
-          async ([sharedUnlockFeatureFlag, allowSharingUnlockState, biometricUnlockEnabled]) =>
-            biometricUnlockEnabled || (sharedUnlockFeatureFlag && allowSharingUnlockState)
+          async ([sharedUnlockFeatureFlag, allowSharingWithDesktop, biometricUnlockEnabled]) =>
+            biometricUnlockEnabled || (sharedUnlockFeatureFlag && allowSharingWithDesktop)
               ? await this.biometricsService.getBiometricsStatusForUser(userId)
               : BiometricsStatus.NotEnabledLocally,
         ),

--- a/apps/browser/src/key-management/shared-unlock/popup/native-messaging-permission-dialog.component.html
+++ b/apps/browser/src/key-management/shared-unlock/popup/native-messaging-permission-dialog.component.html
@@ -1,0 +1,28 @@
+<bit-dialog [title]="'newPermissionNeeded' | i18n">
+  <div bitDialogContent>
+    <p bitTypography="body1">{{ descriptionKey | i18n }}</p>
+    <bit-callout type="warning">{{ "sharedUnlockDesktopPermissionWarning" | i18n }}</bit-callout>
+  </div>
+  <ng-container bitDialogFooter>
+    <button
+      type="button"
+      class="tw-flex-1"
+      bitButton
+      buttonType="secondary"
+      bitDialogClose
+      id="native-messaging-permission_button_close"
+    >
+      {{ "close" | i18n }}
+    </button>
+    <button
+      type="button"
+      class="tw-flex-1"
+      bitButton
+      buttonType="primary"
+      (click)="continue()"
+      id="native-messaging-permission_button_continue"
+    >
+      {{ "continue" | i18n }}
+    </button>
+  </ng-container>
+</bit-dialog>

--- a/apps/browser/src/key-management/shared-unlock/popup/native-messaging-permission-dialog.component.spec.ts
+++ b/apps/browser/src/key-management/shared-unlock/popup/native-messaging-permission-dialog.component.spec.ts
@@ -1,0 +1,69 @@
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { mock } from "jest-mock-extended";
+
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { DialogRef, DialogService } from "@bitwarden/components";
+
+import {
+  NativeMessagingPermissionDialogComponent,
+  NativeMessagingPermissionDialogParams,
+} from "./native-messaging-permission-dialog.component";
+
+describe("NativeMessagingPermissionDialogComponent", () => {
+  let component: NativeMessagingPermissionDialogComponent;
+  let fixture: ComponentFixture<NativeMessagingPermissionDialogComponent>;
+
+  const dialogRef = mock<DialogRef<boolean>>();
+  const i18nService = mock<I18nService>();
+
+  beforeEach(async () => {
+    i18nService.t.mockImplementation((key) => key);
+
+    await TestBed.configureTestingModule({
+      imports: [NativeMessagingPermissionDialogComponent],
+      providers: [
+        { provide: DialogRef, useValue: dialogRef },
+        { provide: I18nService, useValue: i18nService },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(NativeMessagingPermissionDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("closes with true when the user continues", () => {
+    component.continue();
+
+    expect(dialogRef.close).toHaveBeenCalledWith(true);
+  });
+
+  it("open() opens the dialog via the DialogService", () => {
+    const dialogService = mock<DialogService>();
+
+    NativeMessagingPermissionDialogComponent.open(dialogService);
+
+    expect(dialogService.open).toHaveBeenCalledWith(
+      NativeMessagingPermissionDialogComponent,
+      expect.objectContaining({ positionStrategy: expect.anything() }),
+    );
+  });
+
+  it("open() passes params as dialog data when provided", () => {
+    const dialogService = mock<DialogService>();
+    const params: NativeMessagingPermissionDialogParams = {
+      descriptionKey: "biometricPermissionDesc",
+    };
+
+    NativeMessagingPermissionDialogComponent.open(dialogService, params);
+
+    expect(dialogService.open).toHaveBeenCalledWith(
+      NativeMessagingPermissionDialogComponent,
+      expect.objectContaining({ data: params }),
+    );
+  });
+});

--- a/apps/browser/src/key-management/shared-unlock/popup/native-messaging-permission-dialog.component.ts
+++ b/apps/browser/src/key-management/shared-unlock/popup/native-messaging-permission-dialog.component.ts
@@ -1,0 +1,53 @@
+import { DIALOG_DATA } from "@angular/cdk/dialog";
+import { ChangeDetectionStrategy, Component, inject } from "@angular/core";
+
+import { JslibModule } from "@bitwarden/angular/jslib.module";
+import {
+  ButtonModule,
+  CalloutComponent,
+  CenterPositionStrategy,
+  DialogModule,
+  DialogRef,
+  DialogService,
+  TypographyModule,
+} from "@bitwarden/components";
+
+/**
+ * Informational dialog shown in the popped-out Account Security page when the user enables
+ * a feature requiring the `nativeMessaging` permission. It explains that the browser will
+ * prompt for the optional permission and that granting it reloads the extension and locks the vault.
+ *
+ * Closes with `true` when the user chooses to continue, and `undefined` (via `bitDialogClose`)
+ * when the user closes without proceeding.
+ */
+export type NativeMessagingPermissionDialogParams = {
+  descriptionKey?: string;
+};
+
+@Component({
+  templateUrl: "./native-messaging-permission-dialog.component.html",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [ButtonModule, CalloutComponent, DialogModule, TypographyModule, JslibModule],
+})
+export class NativeMessagingPermissionDialogComponent {
+  private readonly dialogRef = inject(DialogRef<boolean>);
+  private readonly params = inject<NativeMessagingPermissionDialogParams | null>(DIALOG_DATA, {
+    optional: true,
+  });
+  protected readonly descriptionKey =
+    this.params?.descriptionKey ?? "sharedUnlockDesktopPermissionDesc";
+
+  continue() {
+    void this.dialogRef.close(true);
+  }
+
+  static open(
+    dialogService: DialogService,
+    params?: NativeMessagingPermissionDialogParams,
+  ): DialogRef<boolean> {
+    return dialogService.open<boolean>(NativeMessagingPermissionDialogComponent, {
+      positionStrategy: new CenterPositionStrategy(),
+      data: params,
+    });
+  }
+}

--- a/apps/browser/src/manifest.json
+++ b/apps/browser/src/manifest.json
@@ -51,7 +51,6 @@
     "clipboardWrite",
     "contextMenus",
     "idle",
-    "nativeMessaging",
     "storage",
     "tabs",
     "unlimitedStorage",
@@ -76,8 +75,8 @@
     "webRequest",
     "webRequestBlocking"
   ],
-  "optional_permissions": ["privacy"],
-  "__firefox__optional_permissions": ["privacy"],
+  "optional_permissions": ["nativeMessaging", "privacy"],
+  "__firefox__optional_permissions": ["nativeMessaging", "privacy"],
   "__safari__optional_permissions": null,
   "content_security_policy": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'",
   "sandbox": {

--- a/apps/browser/src/manifest.v3.json
+++ b/apps/browser/src/manifest.v3.json
@@ -53,7 +53,6 @@
     "clipboardWrite",
     "contextMenus",
     "idle",
-    "nativeMessaging",
     "offscreen",
     "scripting",
     "sidePanel",
@@ -72,7 +71,6 @@
     "clipboardWrite",
     "contextMenus",
     "idle",
-    "nativeMessaging",
     "scripting",
     "storage",
     "tabs",
@@ -99,8 +97,8 @@
     "webRequest",
     "webRequestAuthProvider"
   ],
-  "optional_permissions": ["privacy"],
-  "__firefox__optional_permissions": ["privacy"],
+  "optional_permissions": ["nativeMessaging", "privacy"],
+  "__firefox__optional_permissions": ["nativeMessaging", "privacy"],
   "__safari__optional_permissions": null,
   "host_permissions": ["https://*/*", "http://*/*"],
   "content_security_policy": {

--- a/apps/browser/src/platform/browser/browser-api.spec.ts
+++ b/apps/browser/src/platform/browser/browser-api.spec.ts
@@ -765,8 +765,9 @@ describe("BrowserApi", () => {
   });
 
   describe("reloadExtension", () => {
-    it("forwards call to extension runtime", () => {
-      BrowserApi.reloadExtension();
+    it("forwards call to extension runtime", async () => {
+      jest.spyOn(BrowserApi, "tabsQuery").mockResolvedValue([]);
+      await BrowserApi.reloadExtension();
       expect(chrome.runtime.reload).toHaveBeenCalled();
     });
   });

--- a/apps/browser/src/platform/browser/browser-api.ts
+++ b/apps/browser/src/platform/browser/browser-api.ts
@@ -779,15 +779,29 @@ export class BrowserApi {
   }
 
   /**
+   * Closes all open extension windows (popouts, sidepanel, etc.).
+   */
+  static async closeAllExtensionWindows(): Promise<void> {
+    const extensionUrl = chrome.runtime.getURL("popup/index.html");
+    const tabs = await BrowserApi.tabsQuery({ url: `${extensionUrl}*` });
+    await Promise.all(tabs.map((tab) => BrowserApi.removeWindow(tab.windowId)));
+  }
+
+  /**
    * Handles reloading the extension using the underlying functionality exposed by the browser API.
    */
-  static reloadExtension() {
+  static async reloadExtension() {
     // If we do `chrome.runtime.reload` on safari they will send an onInstalled reason of install
     // and that prompts us to show a new tab, this apparently doesn't happen on sideloaded
     // extensions and only shows itself production scenarios. See: https://bitwarden.atlassian.net/browse/PM-12298
     if (this.isSafariApi) {
       return self.location.reload();
     }
+
+    // Reloading the extension while popouts and popups are open will close all popups and popouts on firefox.
+    // On chrome, only the popups will be closed, but popouts remain and navigate to an empty page. This is
+    // undesired behavior. To prevent this, an extension reload will first close all popups and popouts.
+    await BrowserApi.closeAllExtensionWindows();
     return chrome.runtime.reload();
   }
 

--- a/apps/browser/src/platform/ipc/ipc-background.service.ts
+++ b/apps/browser/src/platform/ipc/ipc-background.service.ts
@@ -150,9 +150,13 @@ export class IpcBackgroundService extends IpcService {
 
   /**
    * Starts a connection to the desktop app. This function attempts to establish a connection with the desktop application
-   * using native messaging. It will automaticall retry and reconnect if the connection fails or is lost.
+   * using native messaging. It will automatically retry and reconnect if the connection fails or is lost.
    */
   private async connectToDesktop() {
+    if (!(await BrowserApi.permissionsGranted(["nativeMessaging"]))) {
+      return;
+    }
+
     let port: browser.runtime.Port | chrome.runtime.Port | undefined;
     try {
       port = BrowserApi.connectNative("com.8bit.bitwarden");

--- a/apps/browser/src/popup/services/services.module.ts
+++ b/apps/browser/src/popup/services/services.module.ts
@@ -383,7 +383,7 @@ const safeProviders: SafeProvider[] = [
   safeProvider({
     provide: BiometricsService,
     useClass: ForegroundBrowserBiometricsService,
-    deps: [],
+    deps: [PlatformUtilsService],
   }),
   safeProvider({
     provide: SyncService,

--- a/apps/desktop/src/app/accounts/settings.component.spec.ts
+++ b/apps/desktop/src/app/accounts/settings.component.spec.ts
@@ -792,6 +792,7 @@ describe("SettingsComponent", () => {
         BiometricsStatus.DesktopDisconnected,
         BiometricsStatus.NotEnabledLocally,
         BiometricsStatus.NotEnabledInConnectedDesktopApp,
+        BiometricsStatus.NativeMessagingPermissionMissing,
       ])(
         `disables biometric when biometrics status check for the user returns %s`,
         async (status) => {

--- a/libs/common/src/key-management/shared-unlock/default-shared-unlock-follower.service.ts
+++ b/libs/common/src/key-management/shared-unlock/default-shared-unlock-follower.service.ts
@@ -1,7 +1,8 @@
-import { Observable, Subject } from "rxjs";
+import { firstValueFrom, Observable, Subject } from "rxjs";
 
 // eslint-disable-next-line no-restricted-imports
 import { LockService } from "@bitwarden/auth/common";
+import { ClientType } from "@bitwarden/client-type";
 // eslint-disable-next-line no-restricted-imports
 import { KeyService } from "@bitwarden/key-management";
 import { SharedUnlockFollower } from "@bitwarden/sdk-internal";
@@ -47,7 +48,7 @@ export class DefaultSharedUnlockFollowerService implements SharedUnlockFollowerS
       this.platformUtilsService,
       this.vaultTimeoutSettingsService,
       this.environmentService,
-      this.sharedUnlockSettingsService,
+      (userId) => this.enabled(userId),
       (userId) => this._externalUnlock$.next(userId),
     );
 
@@ -75,7 +76,13 @@ export class DefaultSharedUnlockFollowerService implements SharedUnlockFollowerS
   }
 
   private async enabled(userId: UserId): Promise<boolean> {
-    return await this.sharedUnlockSettingsService.allowSharingUnlockState(userId);
+    if (this.platformUtilsService.getClientType() === ClientType.Browser) {
+      return await firstValueFrom(
+        this.sharedUnlockSettingsService.allowSharingUnlockStateWithDesktop$(userId),
+      );
+    } else {
+      return true;
+    }
   }
 
   private async onUnlock(userId: UserId, userKey: SymmetricCryptoKey): Promise<void> {

--- a/libs/common/src/key-management/shared-unlock/default-shared-unlock-leader.service.ts
+++ b/libs/common/src/key-management/shared-unlock/default-shared-unlock-leader.service.ts
@@ -1,7 +1,8 @@
-import { Observable, Subject } from "rxjs";
+import { firstValueFrom, Observable, Subject } from "rxjs";
 
 // eslint-disable-next-line no-restricted-imports
 import { LockService } from "@bitwarden/auth/common";
+import { ClientType } from "@bitwarden/client-type";
 // eslint-disable-next-line no-restricted-imports
 import { KeyService } from "@bitwarden/key-management";
 import { SharedUnlockLeader } from "@bitwarden/sdk-internal";
@@ -47,7 +48,7 @@ export class DefaultSharedUnlockLeaderService implements SharedUnlockLeaderServi
       this.platformUtilsService,
       this.vaultTimeoutSettingsService,
       this.environmentService,
-      this.sharedUnlockSettingsService,
+      (userId) => this.enabled(userId),
       (userId) => this._externalUnlock$.next(userId),
     );
 
@@ -74,7 +75,13 @@ export class DefaultSharedUnlockLeaderService implements SharedUnlockLeaderServi
   }
 
   private async enabled(userId: UserId): Promise<boolean> {
-    return await this.sharedUnlockSettingsService.allowSharingUnlockState(userId);
+    if (this.platformUtilsService.getClientType() === ClientType.Browser) {
+      return await firstValueFrom(
+        this.sharedUnlockSettingsService.allowSharingUnlockStateWithWeb$(userId),
+      );
+    } else {
+      return true;
+    }
   }
 
   private async onUnlock(userId: UserId, userKey: SymmetricCryptoKey): Promise<void> {

--- a/libs/common/src/key-management/shared-unlock/default-shared-unlock-settings.service.ts
+++ b/libs/common/src/key-management/shared-unlock/default-shared-unlock-settings.service.ts
@@ -1,4 +1,4 @@
-import { firstValueFrom, map, Observable } from "rxjs";
+import { map, Observable } from "rxjs";
 
 import {
   SHARED_UNLOCK_SETTINGS_DISK,
@@ -9,35 +9,54 @@ import { UserId } from "../../types/guid";
 
 import { SharedUnlockSettingsService } from "./shared-unlock-settings.service";
 
-const ALLOW_SHARING_UNLOCK_STATE = new UserKeyDefinition<boolean>(
+const ALLOW_SHARING_UNLOCK_STATE_WITH_DESKTOP = new UserKeyDefinition<boolean>(
   SHARED_UNLOCK_SETTINGS_DISK,
-  "allowSharingUnlockState",
+  "allowSharingUnlockStateWithDesktop",
   {
     deserializer: (b) => b,
     clearOn: ["logout"],
   },
 );
 
+const ALLOW_SHARING_UNLOCK_STATE_WITH_WEB = new UserKeyDefinition<boolean>(
+  SHARED_UNLOCK_SETTINGS_DISK,
+  "allowSharingUnlockStateWithWeb",
+  {
+    deserializer: (b) => b,
+    clearOn: ["logout"],
+  },
+);
+
+// Default off because of native messaging permission
+const DEFAULT_ALLOW_SHARING_UNLOCK_STATE_WITH_DESKTOP = false;
+const DEFAULT_ALLOW_SHARING_UNLOCK_STATE_WITH_WEB = true;
+
 export class DefaultSharedUnlockSettingsService extends SharedUnlockSettingsService {
   constructor(private stateProvider: StateProvider) {
     super();
   }
 
-  async setAllowSharingUnlockState(value: boolean, userId: UserId) {
-    await this.stateProvider.getUser(userId, ALLOW_SHARING_UNLOCK_STATE).update(() => value);
-  }
-
-  allowSharingUnlockState$(userId: UserId): Observable<boolean> {
+  allowSharingUnlockStateWithDesktop$(userId: UserId): Observable<boolean> {
     return this.stateProvider
-      .getUserState$(ALLOW_SHARING_UNLOCK_STATE, userId)
-      .pipe(map((v) => v ?? true));
+      .getUserState$(ALLOW_SHARING_UNLOCK_STATE_WITH_DESKTOP, userId)
+      .pipe(map((v) => v ?? DEFAULT_ALLOW_SHARING_UNLOCK_STATE_WITH_DESKTOP));
   }
 
-  async allowSharingUnlockState(userId: UserId): Promise<boolean> {
-    return (
-      (await firstValueFrom(
-        this.stateProvider.getUserState$(ALLOW_SHARING_UNLOCK_STATE, userId),
-      )) ?? true
-    );
+  async setAllowSharingUnlockStateWithDesktop(value: boolean, userId: UserId): Promise<void> {
+    await this.stateProvider
+      .getUser(userId, ALLOW_SHARING_UNLOCK_STATE_WITH_DESKTOP)
+      .update(() => value);
+  }
+
+  allowSharingUnlockStateWithWeb$(userId: UserId): Observable<boolean> {
+    return this.stateProvider
+      .getUserState$(ALLOW_SHARING_UNLOCK_STATE_WITH_WEB, userId)
+      .pipe(map((v) => v ?? DEFAULT_ALLOW_SHARING_UNLOCK_STATE_WITH_WEB));
+  }
+
+  async setAllowSharingUnlockStateWithWeb(value: boolean, userId: UserId): Promise<void> {
+    await this.stateProvider
+      .getUser(userId, ALLOW_SHARING_UNLOCK_STATE_WITH_WEB)
+      .update(() => value);
   }
 }

--- a/libs/common/src/key-management/shared-unlock/shared-unlock-driver.ts
+++ b/libs/common/src/key-management/shared-unlock/shared-unlock-driver.ts
@@ -16,8 +16,6 @@ import { SymmetricCryptoKey } from "../../platform/models/domain/symmetric-crypt
 import { UserKey } from "../../types/key";
 import { VaultTimeoutSettingsService } from "../vault-timeout/abstractions/vault-timeout-settings.service";
 
-import { SharedUnlockSettingsService } from "./shared-unlock-settings.service";
-
 function fromSdkUserId(userId: UserId): TSUserId {
   return uuidAsString(userId) as TSUserId;
 }
@@ -35,12 +33,12 @@ export class JsSharedUnlockDriver implements SharedUnlockDriver {
     private platformUtilsService: PlatformUtilsService,
     private vaultTimeoutSettingsService: VaultTimeoutSettingsService,
     private environmentService: EnvironmentService,
-    private sharedUnlockSettingsService: SharedUnlockSettingsService,
+    private isEnabled: (userId: TSUserId) => Promise<boolean>,
     private onExternalUnlock?: (userId: TSUserId) => void,
   ) {}
 
   async lock_user(user_id: UserId): Promise<void> {
-    if (!(await this.sharedUnlockSettingsService.allowSharingUnlockState(fromSdkUserId(user_id)))) {
+    if (!(await this.isEnabled(fromSdkUserId(user_id)))) {
       return;
     }
 
@@ -48,7 +46,7 @@ export class JsSharedUnlockDriver implements SharedUnlockDriver {
   }
 
   async unlock_user(user_id: UserId, user_key: SymmetricKey): Promise<void> {
-    if (!(await this.sharedUnlockSettingsService.allowSharingUnlockState(fromSdkUserId(user_id)))) {
+    if (!(await this.isEnabled(fromSdkUserId(user_id)))) {
       return;
     }
 

--- a/libs/common/src/key-management/shared-unlock/shared-unlock-settings.service.ts
+++ b/libs/common/src/key-management/shared-unlock/shared-unlock-settings.service.ts
@@ -3,7 +3,9 @@ import { Observable } from "rxjs";
 import { UserId } from "../../types/guid";
 
 export abstract class SharedUnlockSettingsService {
-  abstract allowSharingUnlockState$(userId: UserId): Observable<boolean>;
-  abstract setAllowSharingUnlockState(value: boolean, userId: UserId): Promise<void>;
-  abstract allowSharingUnlockState(userId: UserId): Promise<boolean>;
+  abstract allowSharingUnlockStateWithDesktop$(userId: UserId): Observable<boolean>;
+  abstract setAllowSharingUnlockStateWithDesktop(value: boolean, userId: UserId): Promise<void>;
+
+  abstract allowSharingUnlockStateWithWeb$(userId: UserId): Observable<boolean>;
+  abstract setAllowSharingUnlockStateWithWeb(value: boolean, userId: UserId): Promise<void>;
 }

--- a/libs/common/src/platform/services/config/default-config.service.ts
+++ b/libs/common/src/platform/services/config/default-config.service.ts
@@ -176,6 +176,9 @@ export class DefaultConfigService implements ConfigService {
   }
 
   getFeatureFlag$<Flag extends FeatureFlag>(key: Flag) {
+    if ([FeatureFlag.BiometricsSDKIPC, FeatureFlag.SharedUnlockPart1, FeatureFlag.SharedUnlockPart2].includes(key)) {
+      return of(false as FeatureFlagValueType<Flag>);
+    }
     return combineLatest([this.serverConfig$, this.featureFlagOverrides$]).pipe(
       map(([serverConfig, overrides]) => this.resolveFlag(serverConfig, overrides, key)),
     );

--- a/libs/key-management/src/biometrics/biometrics-status.ts
+++ b/libs/key-management/src/biometrics/biometrics-status.ts
@@ -19,4 +19,6 @@ export enum BiometricsStatus {
   NotEnabledLocally,
   /** Only on browser extension; Biometrics is not enabled in the desktop app */
   NotEnabledInConnectedDesktopApp,
+  /** Browser extension does not have the permission to talk to the desktop app */
+  NativeMessagingPermissionMissing,
 }

--- a/libs/state/src/state-migrations/migrate.ts
+++ b/libs/state/src/state-migrations/migrate.ts
@@ -78,11 +78,12 @@ import { MigrateSsoRequiredCache } from "./migrations/78-migrate-sso-required-ca
 import { InitializeFeatureFlagOverridesMigrator } from "./migrations/79-initialize-feature-flag-overrides";
 import { MoveStateVersionMigrator } from "./migrations/8-move-state-version";
 import { ConsolidateTrayToRunInBackground } from "./migrations/80-consolidate-tray-to-run-in-background";
+import { EnableDesktopSharingIfBiometricsEnabled } from "./migrations/81-enable-desktop-sharing-if-biometrics-enabled";
 import { MoveBrowserSettingsToGlobal } from "./migrations/9-move-browser-settings-to-global";
 import { MinVersionMigrator } from "./migrations/min-version";
 
 export const MIN_VERSION = 3;
-export const CURRENT_VERSION = 80;
+export const CURRENT_VERSION = 81;
 export type MinVersion = typeof MIN_VERSION;
 
 export function createMigrationBuilder() {
@@ -164,7 +165,8 @@ export function createMigrationBuilder() {
     .with(ClearClipboardDelayToStringMigrator, 76, 77)
     .with(MigrateSsoRequiredCache, 77, 78)
     .with(InitializeFeatureFlagOverridesMigrator, 78, 79)
-    .with(ConsolidateTrayToRunInBackground, 79, CURRENT_VERSION);
+    .with(ConsolidateTrayToRunInBackground, 79, 80)
+    .with(EnableDesktopSharingIfBiometricsEnabled, 80, CURRENT_VERSION);
 }
 
 export async function currentVersion(

--- a/libs/state/src/state-migrations/migrations/81-enable-desktop-sharing-if-biometrics-enabled.spec.ts
+++ b/libs/state/src/state-migrations/migrations/81-enable-desktop-sharing-if-biometrics-enabled.spec.ts
@@ -1,0 +1,82 @@
+import { runMigrator } from "../migration-helper.spec";
+
+import { EnableDesktopSharingIfBiometricsEnabled } from "./81-enable-desktop-sharing-if-biometrics-enabled";
+
+describe("EnableDesktopSharingIfBiometricsEnabled", () => {
+  const sut = new EnableDesktopSharingIfBiometricsEnabled(80, 81);
+
+  describe("migrate", () => {
+    it("enables desktop sharing for users with biometric unlock enabled", async () => {
+      const output = await runMigrator(sut, {
+        global_account_accounts: {
+          user1: {},
+          user2: {},
+          user3: {},
+        },
+        user_user1_biometricSettings_biometricUnlockEnabled: true,
+        user_user2_biometricSettings_biometricUnlockEnabled: false,
+        // user3 has no biometric setting
+      });
+
+      expect(output).toEqual({
+        global_account_accounts: {
+          user1: {},
+          user2: {},
+          user3: {},
+        },
+        user_user1_biometricSettings_biometricUnlockEnabled: true,
+        user_user1_sharedUnlockSettings_allowSharingUnlockStateWithDesktop: true,
+        user_user2_biometricSettings_biometricUnlockEnabled: false,
+      });
+    });
+
+    it("does not overwrite desktop sharing when it is already set", async () => {
+      const output = await runMigrator(sut, {
+        global_account_accounts: { user1: {} },
+        user_user1_biometricSettings_biometricUnlockEnabled: true,
+        user_user1_sharedUnlockSettings_allowSharingUnlockStateWithDesktop: false,
+      });
+
+      expect(output).toEqual({
+        global_account_accounts: { user1: {} },
+        user_user1_biometricSettings_biometricUnlockEnabled: true,
+        user_user1_sharedUnlockSettings_allowSharingUnlockStateWithDesktop: false,
+      });
+    });
+
+    it("does nothing when there are no accounts", async () => {
+      const output = await runMigrator(sut, {});
+
+      expect(output).toEqual({});
+    });
+  });
+
+  describe("rollback", () => {
+    it("removes desktop sharing for users with biometric unlock enabled", async () => {
+      const output = await runMigrator(
+        sut,
+        {
+          global_account_accounts: {
+            user1: {},
+            user2: {},
+          },
+          user_user1_biometricSettings_biometricUnlockEnabled: true,
+          user_user1_sharedUnlockSettings_allowSharingUnlockStateWithDesktop: true,
+          user_user2_biometricSettings_biometricUnlockEnabled: false,
+          user_user2_sharedUnlockSettings_allowSharingUnlockStateWithDesktop: true,
+        },
+        "rollback",
+      );
+
+      expect(output).toEqual({
+        global_account_accounts: {
+          user1: {},
+          user2: {},
+        },
+        user_user1_biometricSettings_biometricUnlockEnabled: true,
+        user_user2_biometricSettings_biometricUnlockEnabled: false,
+        user_user2_sharedUnlockSettings_allowSharingUnlockStateWithDesktop: true,
+      });
+    });
+  });
+});

--- a/libs/state/src/state-migrations/migrations/81-enable-desktop-sharing-if-biometrics-enabled.ts
+++ b/libs/state/src/state-migrations/migrations/81-enable-desktop-sharing-if-biometrics-enabled.ts
@@ -1,0 +1,48 @@
+import { KeyDefinitionLike, MigrationHelper } from "../migration-helper";
+import { Migrator } from "../migrator";
+
+const BIOMETRIC_UNLOCK_ENABLED: KeyDefinitionLike = {
+  key: "biometricUnlockEnabled",
+  stateDefinition: { name: "biometricSettings" },
+};
+
+const ALLOW_SHARING_UNLOCK_STATE_WITH_DESKTOP: KeyDefinitionLike = {
+  key: "allowSharingUnlockStateWithDesktop",
+  stateDefinition: { name: "sharedUnlockSettings" },
+};
+
+/**
+ * For each user that already has biometric unlock enabled, enables sharing unlock state
+ * with the desktop app. Previously this setting defaulted to off even when biometrics were
+ * configured, so existing users had to manually enable it.
+ */
+export class EnableDesktopSharingIfBiometricsEnabled extends Migrator<80, 81> {
+  async migrate(helper: MigrationHelper): Promise<void> {
+    async function migrateUser(userId: string) {
+      const biometricUnlock = await helper.getFromUser<boolean>(userId, BIOMETRIC_UNLOCK_ENABLED);
+
+      if (
+        biometricUnlock === true &&
+        (await helper.getFromUser(userId, ALLOW_SHARING_UNLOCK_STATE_WITH_DESKTOP)) == null
+      ) {
+        await helper.setToUser(userId, ALLOW_SHARING_UNLOCK_STATE_WITH_DESKTOP, true);
+      }
+    }
+
+    const accounts = await helper.getAccounts();
+    await Promise.all(accounts.map(({ userId }) => migrateUser(userId)));
+  }
+
+  async rollback(helper: MigrationHelper): Promise<void> {
+    async function rollbackUser(userId: string) {
+      const biometricUnlock = await helper.getFromUser<boolean>(userId, BIOMETRIC_UNLOCK_ENABLED);
+
+      if (biometricUnlock === true) {
+        await helper.removeFromUser(userId, ALLOW_SHARING_UNLOCK_STATE_WITH_DESKTOP);
+      }
+    }
+
+    const accounts = await helper.getAccounts();
+    await Promise.all(accounts.map(({ userId }) => rollbackUser(userId)));
+  }
+}


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.slack.com/archives/C012NRQS4LX/p1782609561888649
https://github.com/bitwarden/clients/pull/19907
https://bitwarden.atlassian.net/browse/PM-39731

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
https://github.com/bitwarden/clients/pull/19907 introduced the native messaging permission as default on and removed the optional permission prompt. The experience of upgrading existing users was deemed as to disruptive for now. We have to revert and re-iterate.

A clean revert is not possible because of follow-up changes. This PR reverts it as best as possible, making the permission optional once more, with a migration for shared unlock for users that have the biometric unlock permission enabled.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
