### PR TITLE
[PM-35106] Make AES-GCM the default algorithm in crypto.rs for secure memory

### DIFF
--- a/apps/desktop/desktop_native/Cargo.lock
+++ b/apps/desktop/desktop_native/Cargo.lock
@@ -1017,6 +1017,7 @@ dependencies = [
  "bitwarden-russh",
  "bytes",
  "cbc",
+ "chacha20poly1305",
  "core-foundation",
  "desktop_objc",
  "dirs",

--- a/apps/desktop/desktop_native/Cargo.lock
+++ b/apps/desktop/desktop_native/Cargo.lock
@@ -1009,6 +1009,7 @@ name = "desktop_core"
 version = "0.0.0"
 dependencies = [
  "aes",
+ "aes-gcm",
  "anyhow",
  "arboard",
  "ashpd 0.13.11",
@@ -1016,7 +1017,6 @@ dependencies = [
  "bitwarden-russh",
  "bytes",
  "cbc",
- "chacha20poly1305",
  "core-foundation",
  "desktop_objc",
  "dirs",

--- a/apps/desktop/desktop_native/core/Cargo.toml
+++ b/apps/desktop/desktop_native/core/Cargo.toml
@@ -65,6 +65,7 @@ security-framework = { workspace = true, optional = true }
 security-framework-sys = { workspace = true, optional = true }
 
 [target.'cfg(windows)'.dependencies]
+chacha20poly1305 = { workspace = true }
 pin-project = { workspace = true }
 scopeguard = { workspace = true }
 secmem-proc = { workspace = true }

--- a/apps/desktop/desktop_native/core/Cargo.toml
+++ b/apps/desktop/desktop_native/core/Cargo.toml
@@ -19,13 +19,13 @@ manual_test = []
 
 [dependencies]
 aes = { workspace = true }
+aes-gcm = { workspace = true }
 anyhow = { workspace = true }
 arboard = { workspace = true, features = ["wayland-data-control"] }
 base64 = { workspace = true }
 bitwarden-russh = { git = "https://github.com/bitwarden/bitwarden-russh.git", rev = "a641316227227f8777fdf56ac9fa2d6b5f7fe662" }
 bytes = { workspace = true }
 cbc = { workspace = true, features = ["alloc"] }
-chacha20poly1305 = { workspace = true }
 dirs = { workspace = true }
 futures = { workspace = true }
 interprocess = { workspace = true, features = ["tokio"] }

--- a/apps/desktop/desktop_native/core/src/secure_memory/secure_key/crypto.rs
+++ b/apps/desktop/desktop_native/core/src/secure_memory/secure_key/crypto.rs
@@ -1,12 +1,12 @@
 use std::ptr::NonNull;
 
-use chacha20poly1305::{aead::Aead, Key, KeyInit};
+use aes_gcm::{aead::Aead, Aes256Gcm, Key, KeyInit, Nonce};
 use rand::{rng, Rng};
 
 pub(super) const KEY_SIZE: usize = 32;
-pub(super) const NONCE_SIZE: usize = 24;
+pub(super) const NONCE_SIZE: usize = 12;
 
-/// The encryption performed here is xchacha-poly1305. Any tampering with the key or the ciphertexts
+/// The encryption performed here is AES-256-GCM. Any tampering with the key or the ciphertexts
 /// will result in a decryption failure and panic. The key's memory contents are protected from
 /// being swapped to disk via mlock.
 pub(super) struct MemoryEncryptionKey(NonNull<[u8]>);
@@ -27,11 +27,11 @@ impl MemoryEncryptionKey {
     /// Encrypts the given plaintext using the key.
     #[allow(unused)]
     pub(super) fn encrypt(&self, plaintext: &[u8]) -> EncryptedMemory {
-        let cipher = chacha20poly1305::XChaCha20Poly1305::new(Key::from_slice(self.as_ref()));
+        let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(self.as_ref()));
         let mut nonce = [0u8; NONCE_SIZE];
         rng().fill(&mut nonce);
         let ciphertext = cipher
-            .encrypt(chacha20poly1305::XNonce::from_slice(&nonce), plaintext)
+            .encrypt(Nonce::from_slice(&nonce), plaintext)
             .expect("encryption should not fail");
         EncryptedMemory { nonce, ciphertext }
     }
@@ -41,10 +41,10 @@ impl MemoryEncryptionKey {
     /// indicates that the process memory was tampered with.
     #[allow(unused)]
     pub(super) fn decrypt(&self, encrypted: &EncryptedMemory) -> Result<Vec<u8>, DecryptionError> {
-        let cipher = chacha20poly1305::XChaCha20Poly1305::new(Key::from_slice(self.as_ref()));
+        let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(self.as_ref()));
         cipher
             .decrypt(
-                chacha20poly1305::XNonce::from_slice(&encrypted.nonce),
+                Nonce::from_slice(&encrypted.nonce),
                 encrypted.ciphertext.as_ref(),
             )
             .map_err(|_| DecryptionError::CouldNotDecrypt)
@@ -102,5 +102,14 @@ mod tests {
         let encrypted = key.encrypt(data);
         let decrypted = key.decrypt(&encrypted).unwrap();
         assert_eq!(data.as_ref(), decrypted.as_slice());
+    }
+
+    #[test]
+    fn test_tampered_ciphertext_fails_to_decrypt() {
+        let key = MemoryEncryptionKey::new();
+        let mut encrypted = key.encrypt(b"Hello, world!");
+        encrypted.ciphertext[0] ^= 0xff;
+        let result = key.decrypt(&encrypted);
+        assert!(matches!(result, Err(DecryptionError::CouldNotDecrypt)));
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-35106

## 📔 Objective

Make AES-GCM the default algorithm in crypto.rs for secure memory in desktop native.
None is now 96 bits length (12 bytes).

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
