### PR TITLE
Bumped client version(s) (#21554)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitwarden/web-vault",
-  "version": "2026.6.2",
+  "version": "2026.6.4",
   "scripts": {
     "build:oss": "webpack",
     "build:bit": "webpack -c ../../bitwarden_license/bit-web/webpack.config.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -257,7 +257,7 @@
     },
     "apps/web": {
       "name": "@bitwarden/web-vault",
-      "version": "2026.6.2"
+      "version": "2026.6.4"
     },
     "libs/admin-console": {
       "name": "@bitwarden/admin-console",


### PR DESCRIPTION
pick the next web version to rc.

2026.6.3 was released as a hotfix, but didn't ever land on main, so this commit bumps by 2.
