### PR TITLE
[PM-39746] Exclude search and select components from legacy global desktop css

### DIFF
--- a/apps/desktop/src/scss/base.scss
+++ b/apps/desktop/src/scss/base.scss
@@ -66,8 +66,8 @@ a:not([bitlink], [bitbutton]) {
   }
 }
 
-input:not(bit-form-field input, input[bitcheckbox]),
-select,
+input:not(bit-form-field input, input[bitcheckbox], bit-search input),
+select:not(select[bitinput]),
 textarea:not(bit-form-field textarea) {
   @include themify($themes) {
     color: themed("textColor");


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[PM-39746](https://bitwarden.atlassian.net/browse/PM-39746)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Legacy desktop css is overriding some of our form field components' css. We plan to clean up the old css, but in the meantime we can exclude our affected components.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
| Before | After |
|--------|--------|
| <img width="1033" height="170" alt="image (26)" src="https://github.com/user-attachments/assets/157acaef-2eb7-476f-a4b2-d9683d5bb24e" /> | <img width="942" height="422" alt="Screenshot 2026-06-29 at 9 50 08 AM" src="https://github.com/user-attachments/assets/53eb91f4-2b0f-4355-b601-71edfe3e8863" /> |


[PM-39746]: https://bitwarden.atlassian.net/browse/PM-39746?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ