### PR TITLE
Address RUSTSEC-2026-0190

### DIFF
--- a/apps/desktop/desktop_native/Cargo.lock
+++ b/apps/desktop/desktop_native/Cargo.lock
@@ -108,9 +108,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arboard"

--- a/apps/desktop/desktop_native/Cargo.toml
+++ b/apps/desktop/desktop_native/Cargo.toml
@@ -23,7 +23,7 @@ publish = false
 [workspace.dependencies]
 aes = "=0.8.4"
 aes-gcm = "=0.10.3"
-anyhow = "=1.0.100"
+anyhow = "=1.0.103"
 arboard = { version = "=3.6.1", default-features = false }
 ashpd = "=0.13.11"
 async-trait = "=0.1.89"


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-39751

## 📔 Objective

Fix the vulnerability by updating anyhow.

https://rustsec.org/advisories/RUSTSEC-2026-0190

before:

```
  ├ Announcement: https://github.com/dtolnay/anyhow/issues/451
  ├ Solution: Upgrade to >=1.0.103 (try `cargo update -p anyhow`)
  ├ anyhow v1.0.100
    ├── autotype v0.0.0
    │   └── desktop_napi v0.0.0
    ├── bitwarden-russh v0.1.0
    │   └── desktop_core v0.0.0
    │       ├── autofill_provider v0.0.0
    │       ├── desktop_napi v0.0.0 (*)
    │       ├── desktop_proxy v0.0.0
    │       ├── process_isolation v0.0.0
    │       └── ssh_agent v0.0.0
    │           └── desktop_napi v0.0.0 (*)
    ├── bitwarden_chromium_import_helper v0.0.0
    ├── chromium_importer v0.0.0
    │   ├── bitwarden_chromium_import_helper v0.0.0 (*)
    │   └── desktop_napi v0.0.0 (*)
    ├── desktop_core v0.0.0 (*)
    ├── desktop_napi v0.0.0 (*)
    ├── desktop_objc v0.0.0
    │   ├── chromium_importer v0.0.0 (*)
    │   └── desktop_core v0.0.0 (*)
    ├── napi v3.8.5
    │   └── desktop_napi v0.0.0 (*)
    ├── secmem-proc v0.3.7
    │   └── desktop_core v0.0.0 (*)
    ├── ssh_agent v0.0.0 (*)
    ├── uniffi v0.28.3
    │   └── (build) autofill_provider v0.0.0 (*)
    ├── uniffi_bindgen v0.28.3
    │   ├── uniffi v0.28.3 (*)
    │   └── uniffi_build v0.28.3
    │       └── uniffi v0.28.3 (*)
    ├── uniffi_build v0.28.3 (*)
    ├── uniffi_core v0.28.3
    │   └── uniffi v0.28.3 (*)
    ├── uniffi_meta v0.28.3
    │   ├── uniffi_bindgen v0.28.3 (*)
    │   ├── uniffi_macros v0.28.3
    │   │   └── uniffi v0.28.3 (*)
    │   └── uniffi_udl v0.28.3
    │       └── uniffi_bindgen v0.28.3 (*)
    ├── uniffi_testing v0.28.3
    │   └── uniffi_udl v0.28.3 (*)
    └── uniffi_udl v0.28.3 (*)

advisories FAILED, bans ok, licenses ok, sources ok
```