### PR TITLE
[PM-39787] Promote exact hostname-match cipher to top of autofill list

### DIFF
--- a/apps/browser/src/autofill/background/overlay.background.spec.ts
+++ b/apps/browser/src/autofill/background/overlay.background.spec.ts
@@ -41,6 +41,7 @@ import { VaultSettingsService } from "@bitwarden/common/vault/abstractions/vault
 import { CipherRepromptType, CipherType } from "@bitwarden/common/vault/enums";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { Fido2CredentialView } from "@bitwarden/common/vault/models/view/fido2-credential.view";
+import { CipherViewLikeUtils } from "@bitwarden/common/vault/utils/cipher-view-like-utils";
 import { CredentialGeneratorService } from "@bitwarden/generator-core";
 import { GeneratedCredential, GeneratorHistoryService } from "@bitwarden/generator-history";
 
@@ -187,6 +188,8 @@ describe("OverlayBackground", () => {
     cipherService = mock<CipherService>({
       getAllDecryptedForUrl: jest.fn().mockResolvedValue([]),
     });
+
+    jest.spyOn(CipherViewLikeUtils, "sortCiphersForUrl").mockImplementation((ciphers) => ciphers);
     enableNotificationAnimationMock$ = new BehaviorSubject(true);
     enableInlineMenuAnimationMock$ = new BehaviorSubject(true);
     autofillService = mock<AutofillService>();

--- a/apps/browser/src/autofill/background/overlay.background.ts
+++ b/apps/browser/src/autofill/background/overlay.background.ts
@@ -48,6 +48,7 @@ import { TotpService } from "@bitwarden/common/vault/abstractions/totp.service";
 import { VaultSettingsService } from "@bitwarden/common/vault/abstractions/vault-settings/vault-settings.service";
 import { CipherType } from "@bitwarden/common/vault/enums";
 import { buildCipherIcon } from "@bitwarden/common/vault/icon/build-cipher-icon";
+import { CipherViewLikeUtils } from "@bitwarden/common/vault/utils/cipher-view-like-utils";
 import { CardView } from "@bitwarden/common/vault/models/view/card.view";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { Fido2CredentialView } from "@bitwarden/common/vault/models/view/fido2-credential.view";
@@ -552,9 +553,13 @@ export class OverlayBackground implements OverlayBackgroundInterface {
       return this.getAllCipherTypeViews(currentTab, activeUserId);
     }
 
-    const cipherViews = (
-      await this.cipherService.getAllDecryptedForUrl(currentTab.url || "", activeUserId)
-    ).sort((a, b) => this.cipherService.sortCiphersByLastUsedThenName(a, b));
+    const url = currentTab.url || "";
+    const cipherViews = CipherViewLikeUtils.sortCiphersForUrl(
+      (await this.cipherService.getAllDecryptedForUrl(url, activeUserId)).sort((a, b) =>
+        this.cipherService.sortCiphersByLastUsedThenName(a, b),
+      ),
+      url,
+    );
 
     return this.cardAndIdentityCiphers
       ? cipherViews.concat(...this.cardAndIdentityCiphers)
@@ -576,12 +581,16 @@ export class OverlayBackground implements OverlayBackgroundInterface {
     }
 
     this.cardAndIdentityCiphers.clear();
-    const cipherViews = (
-      await this.cipherService.getAllDecryptedForUrl(currentTab.url || "", userId, [
-        CipherType.Card,
-        CipherType.Identity,
-      ])
-    ).sort((a, b) => this.cipherService.sortCiphersByLastUsedThenName(a, b));
+    const url = currentTab.url || "";
+    const cipherViews = CipherViewLikeUtils.sortCiphersForUrl(
+      (
+        await this.cipherService.getAllDecryptedForUrl(url, userId, [
+          CipherType.Card,
+          CipherType.Identity,
+        ])
+      ).sort((a, b) => this.cipherService.sortCiphersByLastUsedThenName(a, b)),
+      url,
+    );
 
     if (!this.cardAndIdentityCiphers) {
       return cipherViews;

--- a/apps/browser/src/autofill/browser/cipher-context-menu-handler.spec.ts
+++ b/apps/browser/src/autofill/browser/cipher-context-menu-handler.spec.ts
@@ -7,6 +7,7 @@ import { UserId } from "@bitwarden/common/types/guid";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { CipherType } from "@bitwarden/common/vault/enums";
 import { CipherRepromptType } from "@bitwarden/common/vault/enums/cipher-reprompt-type";
+import { CipherViewLikeUtils } from "@bitwarden/common/vault/utils/cipher-view-like-utils";
 
 import { CipherContextMenuHandler } from "./cipher-context-menu-handler";
 import { MainContextMenuHandler } from "./main-context-menu-handler";
@@ -27,6 +28,7 @@ describe("CipherContextMenuHandler", () => {
     authService = mock();
     cipherService = mock();
 
+    jest.spyOn(CipherViewLikeUtils, "sortCiphersForUrl").mockImplementation((ciphers) => ciphers);
     jest.spyOn(MainContextMenuHandler, "removeAll").mockResolvedValue();
 
     sut = new CipherContextMenuHandler(

--- a/apps/browser/src/autofill/browser/cipher-context-menu-handler.ts
+++ b/apps/browser/src/autofill/browser/cipher-context-menu-handler.ts
@@ -8,6 +8,7 @@ import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { CipherType } from "@bitwarden/common/vault/enums";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+import { CipherViewLikeUtils } from "@bitwarden/common/vault/utils/cipher-view-like-utils";
 
 import { AutofillCipherTypeId } from "../types";
 
@@ -47,11 +48,15 @@ export class CipherContextMenuHandler {
       return;
     }
 
-    const ciphers = await this.cipherService.getAllDecryptedForUrl(url, activeUserId, [
-      CipherType.Card,
-      CipherType.Identity,
-    ]);
-    ciphers.sort((a, b) => this.cipherService.sortCiphersByLastUsedThenName(a, b));
+    const ciphers = CipherViewLikeUtils.sortCiphersForUrl(
+      (
+        await this.cipherService.getAllDecryptedForUrl(url, activeUserId, [
+          CipherType.Card,
+          CipherType.Identity,
+        ])
+      ).sort((a, b) => this.cipherService.sortCiphersByLastUsedThenName(a, b)),
+      url,
+    );
 
     const groupedCiphers: Record<AutofillCipherTypeId, CipherView[]> = ciphers.reduce(
       (ciphersByType, cipher) => {

--- a/libs/common/src/vault/utils/cipher-view-like-utils.spec.ts
+++ b/libs/common/src/vault/utils/cipher-view-like-utils.spec.ts
@@ -1110,4 +1110,67 @@ describe("CipherViewLikeUtils", () => {
       });
     });
   });
+
+  describe("sortCiphersForUrl", () => {
+    it("returns ciphers unchanged when url has no hostname", () => {
+      const ciphers = [new CipherView(), new CipherView()];
+
+      const result = CipherViewLikeUtils.sortCiphersForUrl(ciphers, "");
+
+      expect(result).toEqual(ciphers);
+    });
+
+    it("moves exact hostname match to position 0", () => {
+      const match = createCipherView();
+      match.login = { uris: [{ uri: "https://example.com/app", match: 1 }] } as any;
+      const other = new CipherView();
+
+      const result = CipherViewLikeUtils.sortCiphersForUrl(
+        [other, match],
+        "https://example.com/dashboard",
+      );
+
+      expect(result[0]).toEqual(match);
+      expect(result[1]).toEqual(other);
+    });
+
+    it("keeps match at position 0 when already first", () => {
+      const match = createCipherView();
+      match.login = { uris: [{ uri: "https://example.com/app", match: 1 }] } as any;
+      const other = new CipherView();
+
+      const result = CipherViewLikeUtils.sortCiphersForUrl(
+        [match, other],
+        "https://example.com/dashboard",
+      );
+
+      expect(result[0]).toEqual(match);
+      expect(result[1]).toEqual(other);
+    });
+
+    it("preserves order when no hostname matches", () => {
+      const a = createCipherView();
+      a.login = { uris: [{ uri: "https://other.com", match: 1 }] } as any;
+      const b = new CipherView();
+
+      const result = CipherViewLikeUtils.sortCiphersForUrl([a, b], "https://example.com/dashboard");
+
+      expect(result[0]).toEqual(a);
+      expect(result[1]).toEqual(b);
+    });
+
+    it("handles cipher with no login gracefully", () => {
+      const loginCipher = createCipherView();
+      loginCipher.login = { uris: [{ uri: "https://example.com/app", match: 1 }] } as any;
+      const nonLoginCipher = new CipherView();
+
+      const result = CipherViewLikeUtils.sortCiphersForUrl(
+        [loginCipher, nonLoginCipher],
+        "https://example.com/dashboard",
+      );
+
+      expect(result[0]).toEqual(loginCipher);
+      expect(result[1]).toEqual(nonLoginCipher);
+    });
+  });
 });

--- a/libs/common/src/vault/utils/cipher-view-like-utils.ts
+++ b/libs/common/src/vault/utils/cipher-view-like-utils.ts
@@ -465,6 +465,35 @@ export class CipherViewLikeUtils {
 
     return undefined;
   };
+
+  /**
+   * Sorts ciphers so that a cipher with an exact hostname match to the
+   * given URL is moved to the front of the array. All other ciphers remain
+   * in their existing relative order. When no match is found or the match
+   * is already at position 0, the array is returned unchanged.
+   *
+   * @param ciphers - Array of ciphers to reorder. Mutated in place.
+   * @param url - The URL whose hostname is used for matching.
+   * @returns The same array reference with the best match at position 0.
+   */
+  static sortCiphersForUrl = <T extends CipherViewLike>(ciphers: T[], url: string): T[] => {
+    const hostname = Utils.getHostname(url);
+    if (!hostname) {
+      return ciphers;
+    }
+
+    const exactIdx = ciphers.findIndex((c) => {
+      const login = CipherViewLikeUtils.getLogin(c);
+      return login?.uris?.some((u) => u.uri && Utils.getHostname(u.uri) === hostname);
+    });
+
+    if (exactIdx > 0) {
+      const [match] = ciphers.splice(exactIdx, 1);
+      ciphers.unshift(match);
+    }
+
+    return ciphers;
+  };
 }
 
 /**


### PR DESCRIPTION
## 📔 Objective

Before this change, the browser extension's inline autofill menu and
context menu ordered matching ciphers purely by last-used recency. This
means a cipher saved for a specific subdomain — e.g.
`https://admin.example.com` — would almost always appear at the bottom of
the list when visiting that subdomain, because it is used less frequently
than the main domain's cipher. The user has to scroll past unrelated
entries to find the most relevant match.

This adds a hostname-awareness step: after the initial last-used sort,
`CipherViewLikeUtils.sortCiphersForUrl()` finds the first cipher whose
login URI matches the current page's exact hostname and moves it to
position 0. So the subdomain-specific cipher now appears first, and all
other matches follow in their last-used order.

### What changed

- **`libs/common/src/vault/utils/cipher-view-like-utils.ts`**: New static
  `sortCiphersForUrl<T>(ciphers, url)` — pure utility that promotes the
  exact-hostname match cipher to the front of the array.

- **3 call sites updated**:
  - `overlay.background.ts` — `getCipherViews` (login-only inline menu update)
    and `getAllCipherTypeViews` (full card/identity refresh)
  - `cipher-context-menu-handler.ts` — right-click context menu cipher list

- **Tests**: 5 unit tests in `cipher-view-like-utils.spec.ts` covering
  no-hostname, match-at-front, match-promoted, no-match, and no-login.

### Design notes

- Placed on `CipherViewLikeUtils` (not `CipherService`) because the method
  is a pure function with zero service-state dependencies — it only uses
  `Utils.getHostname` and `CipherViewLikeUtils.getLogin`, both already
  available in that module. This follows the existing pattern of static
  cipher utilities (`matchesUri`, `canLaunch`, `getUriHostname`).
- Mutates the array in place and returns it. Safe for current callers
  (all pass a fresh `.filter()`-ed array from `getAllDecryptedForUrl`).

### Behavior change

Before: autofill list ordered purely by last-used-then-name — a
subdomain-specific cipher typically appears at the bottom.

After: exact-hostname match promoted to position 0, then last-used-then-name
for the rest.

## 📸 Screenshots

No UI changes — ordering only.