### PR TITLE
Bump Desktop client to 2026.6.1

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bitwarden/desktop",
   "description": "A secure and free password manager for all of your devices.",
-  "version": "2026.6.0",
+  "version": "2026.6.1",
   "keywords": [
     "bitwarden",
     "password",

--- a/apps/desktop/src/package-lock.json
+++ b/apps/desktop/src/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bitwarden/desktop",
-  "version": "2026.6.0",
+  "version": "2026.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bitwarden/desktop",
-      "version": "2026.6.0",
+      "version": "2026.6.1",
       "license": "GPL-3.0",
       "dependencies": {
         "@bitwarden/desktop-napi": "file:../desktop_native/napi"

--- a/apps/desktop/src/package.json
+++ b/apps/desktop/src/package.json
@@ -2,7 +2,7 @@
   "name": "@bitwarden/desktop",
   "productName": "Bitwarden",
   "description": "A secure and free password manager for all of your devices.",
-  "version": "2026.6.0",
+  "version": "2026.6.1",
   "author": "Bitwarden Inc. <hello@bitwarden.com> (https://bitwarden.com)",
   "homepage": "https://bitwarden.com",
   "license": "GPL-3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -240,7 +240,7 @@
     },
     "apps/desktop": {
       "name": "@bitwarden/desktop",
-      "version": "2026.6.0",
+      "version": "2026.6.1",
       "hasInstallScript": true,
       "license": "GPL-3.0",
       "dependencies": {


### PR DESCRIPTION
## Objective

Bump the Desktop client version to `2026.6.1` on `hotfix-rc-desktop` for the desktop emergency release.
