### PR TITLE
build: Add arm64-only MacOS pack step

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -50,6 +50,7 @@
     "pack:mac:arm64": "npm run clean:dist && electron-builder --mac --arm64 -p never",
     "pack:mac:mas": "npm run clean:dist && npm run build:macos-extension:mas && electron-builder --mac mas --universal -p never -c.mac.identity=null",
     "pack:mac:masdev": "npm run clean:dist && electron-builder --mac mas-dev --universal -p never -c.mac.identity=null -c.mas.identity=$CSC_NAME -c.mas.provisioningProfile=bitwarden_desktop_developer_id.provisionprofile -c.mas.entitlements=resources/entitlements.mas.autofill-enabled.plist",
+    "pack:mac:masdev:arm64": "npm run clean:dist && electron-builder --mac mas-dev --arm64 -p never -c.mac.identity=null -c.mas.identity=$CSC_NAME -c.mas.provisioningProfile=bitwarden_desktop_developer_id.provisionprofile -c.mas.entitlements=resources/entitlements.mas.autofill-enabled.plist",
     "pack:local:mac": "npm run clean:dist && npm run build:macos-extension:masdev && electron-builder --mac mas-dev --universal -p never -c.mac.provisioningProfile=\"\" -c.mas.provisioningProfile=\"\"",
     "pack:win": "npm run clean:dist && electron-builder --win --x64 --arm64 --ia32 -p never",
     "pack:win:beta": "npm run clean:dist && electron-builder --config electron-builder.beta.json --win --x64 --arm64 --ia32 -p never",


### PR DESCRIPTION
## 📔 Objective

Adds a build step to compile just the arm64 version of the MAS-development profile of the desktop app. This makes it faster for local compilations on macOS with Apple Silicon.