### PR TITLE
add bit-inline-edit component

### DIFF
--- a/libs/components/src/index.ts
+++ b/libs/components/src/index.ts
@@ -28,6 +28,7 @@ export * from "./icon-button";
 export * from "./icon";
 export * from "./svg";
 export * from "./icon-tile";
+export * from "./inline-edit";
 export * from "./input";
 export * from "./item";
 export * from "./landing-layout";

--- a/libs/components/src/inline-edit/index.ts
+++ b/libs/components/src/inline-edit/index.ts
@@ -1,0 +1,2 @@
+export * from "./inline-edit.module";
+export * from "./inline-edit.component";

--- a/libs/components/src/inline-edit/inline-edit.component.html
+++ b/libs/components/src/inline-edit/inline-edit.component.html
@@ -1,0 +1,56 @@
+@if (editing()) {
+  <form
+    class="tw-flex tw-w-64 tw-max-w-full tw-flex-col tw-gap-1"
+    [formGroup]="form"
+    [bitSubmit]="submit"
+  >
+    <div class="tw-flex tw-items-center tw-gap-2">
+      <input
+        bitAutofocus
+        bitInput
+        formControlName="value"
+        (keydown.escape)="cancel()"
+        [attr.aria-label]="label()"
+        class="tw-min-w-0 tw-flex-1 tw-text-base tw-font-normal tw-leading-normal"
+        [id]="idPrefix() + '_input_value'"
+      />
+      <button
+        type="submit"
+        bitIconButton="bwi-check"
+        buttonType="primary"
+        size="small"
+        bitFormButton
+        [label]="saveLabel()"
+        [id]="idPrefix() + '_button_save'"
+      ></button>
+      <button
+        type="button"
+        bitIconButton="bwi-close"
+        buttonType="secondary"
+        size="small"
+        (click)="cancel()"
+        [label]="cancelLabel()"
+        [id]="idPrefix() + '_button_cancel'"
+      ></button>
+    </div>
+    @if (valueError(); as error) {
+      <bit-error [error]="error"></bit-error>
+    }
+  </form>
+} @else {
+  <!-- Value always shows; canEdit only gates the edit affordance. -->
+  <span class="tw-inline-flex tw-items-center tw-gap-1">
+    {{ displayValue() }}
+    @if (canEdit()) {
+      <button
+        type="button"
+        bitIconButton="bwi-pencil"
+        buttonType="subtleGhost"
+        size="small"
+        (click)="start()"
+        [label]="editLabel()"
+        [id]="idPrefix() + '_button_edit'"
+      ></button>
+    }
+  </span>
+}

--- a/libs/components/src/inline-edit/inline-edit.component.spec.ts
+++ b/libs/components/src/inline-edit/inline-edit.component.spec.ts
@@ -1,0 +1,165 @@
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+
+import { I18nMockService } from "../utils";
+
+import { InlineEditComponent } from "./inline-edit.component";
+
+describe("InlineEditComponent", () => {
+  let component: InlineEditComponent;
+  let fixture: ComponentFixture<InlineEditComponent>;
+  let save: jest.Mock<Promise<boolean>, [string]>;
+
+  // `start`, `submit`, `cancel` and `form` are protected; cast for testing.
+  const internals = () =>
+    component as unknown as {
+      start: () => void;
+      cancel: () => void;
+      submit: () => Promise<void>;
+      form: InlineEditComponent["form"];
+    };
+
+  // Open the editor and flush the effect that seeds the value and installs validators.
+  const startEditing = () => {
+    internals().start();
+    fixture.detectChanges();
+  };
+
+  beforeEach(async () => {
+    save = jest.fn().mockResolvedValue(true);
+
+    await TestBed.configureTestingModule({
+      imports: [InlineEditComponent],
+      providers: [
+        {
+          provide: I18nService,
+          useValue: new I18nMockService({
+            inputRequired: "required",
+            inputMaxLength: "too long",
+            inputTrimValidator: "whitespace",
+          }),
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(InlineEditComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput("value", "Initial");
+    fixture.componentRef.setInput("label", "Name");
+    fixture.componentRef.setInput("editLabel", "Edit");
+    fixture.componentRef.setInput("saveLabel", "Save");
+    fixture.componentRef.setInput("cancelLabel", "Cancel");
+    fixture.componentRef.setInput("save", save);
+    fixture.detectChanges();
+  });
+
+  it("shows the value but no edit affordance when canEdit is false", () => {
+    fixture.componentRef.setInput("canEdit", false);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain("Initial");
+    expect(fixture.nativeElement.querySelector("button")).toBeNull();
+  });
+
+  it("closes the editor if edit permission is revoked mid-edit", () => {
+    internals().start();
+    expect(component.editing()).toBe(true);
+
+    fixture.componentRef.setInput("canEdit", false);
+    fixture.detectChanges();
+
+    expect(component.editing()).toBe(false);
+    expect(fixture.nativeElement.textContent).toContain("Initial");
+  });
+
+  it("populates the form with the current value when editing starts", () => {
+    startEditing();
+
+    expect(component.editing()).toBe(true);
+    expect(internals().form.controls.value.value).toBe("Initial");
+  });
+
+  it("does not save when the value is empty", async () => {
+    startEditing();
+    internals().form.controls.value.setValue("");
+
+    await internals().submit();
+
+    expect(save).not.toHaveBeenCalled();
+    expect(component.editing()).toBe(true);
+  });
+
+  it("does not save when the value is only whitespace", async () => {
+    startEditing();
+    internals().form.controls.value.setValue("   ");
+
+    await internals().submit();
+
+    expect(save).not.toHaveBeenCalled();
+    expect(component.editing()).toBe(true);
+  });
+
+  it("does not save when the value exceeds maxLength", async () => {
+    fixture.componentRef.setInput("maxLength", 5);
+    fixture.detectChanges();
+
+    startEditing();
+    internals().form.controls.value.setValue("too long");
+
+    await internals().submit();
+
+    expect(save).not.toHaveBeenCalled();
+  });
+
+  it("calls save with the entered value and closes the editor on success", async () => {
+    startEditing();
+    internals().form.controls.value.setValue("Renamed");
+
+    await internals().submit();
+
+    expect(save).toHaveBeenCalledWith("Renamed");
+    expect(component.editing()).toBe(false);
+  });
+
+  it("keeps the editor open when save resolves false", async () => {
+    save.mockResolvedValue(false);
+
+    startEditing();
+    internals().form.controls.value.setValue("Renamed");
+
+    await internals().submit();
+
+    expect(save).toHaveBeenCalledWith("Renamed");
+    expect(component.editing()).toBe(true);
+  });
+
+  it("closes the editor on cancel", () => {
+    startEditing();
+    internals().cancel();
+
+    expect(component.editing()).toBe(false);
+  });
+
+  it("seeds and validates the form when a parent opens the editor via the editing model", async () => {
+    component.editing.set(true);
+    fixture.detectChanges();
+
+    expect(internals().form.controls.value.value).toBe("Initial");
+
+    internals().form.controls.value.setValue("");
+    await internals().submit();
+
+    expect(save).not.toHaveBeenCalled();
+  });
+
+  it("shows the saved value in the display state after a successful save", async () => {
+    startEditing();
+    internals().form.controls.value.setValue("Renamed");
+
+    await internals().submit();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain("Renamed");
+  });
+});

--- a/libs/components/src/inline-edit/inline-edit.component.ts
+++ b/libs/components/src/inline-edit/inline-edit.component.ts
@@ -1,0 +1,146 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  effect,
+  input,
+  linkedSignal,
+  model,
+  untracked,
+} from "@angular/core";
+import { toSignal } from "@angular/core/rxjs-interop";
+import {
+  FormControl,
+  FormGroup,
+  ReactiveFormsModule,
+  ValidatorFn,
+  Validators,
+} from "@angular/forms";
+
+import { AsyncActionsModule } from "../async-actions";
+import { FormFieldModule } from "../form-field";
+import { trimValidator } from "../form-field/bit-validators";
+import { IconButtonModule } from "../icon-button";
+import { AutofocusDirective } from "../input/autofocus.directive";
+import { InputModule } from "../input/input.module";
+
+/**
+ * Edit-in-place affordance for a single text value: shows the value with a pencil button, swapping
+ * to an input with save/cancel while editing. Display text inherits the host's typography.
+ */
+@Component({
+  selector: "bit-inline-edit",
+  templateUrl: "./inline-edit.component.html",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    class: "tw-contents",
+  },
+  imports: [
+    ReactiveFormsModule,
+    AsyncActionsModule,
+    IconButtonModule,
+    FormFieldModule,
+    InputModule,
+    AutofocusDirective,
+  ],
+})
+export class InlineEditComponent {
+  readonly value = input.required<string>();
+  /** Label for the text field, used as its `aria-label`. */
+  readonly label = input.required<string>();
+  /** `aria-label` for the pencil (edit) button. */
+  readonly editLabel = input.required<string>();
+  /** `aria-label` for the save button. */
+  readonly saveLabel = input.required<string>();
+  /** `aria-label` for the cancel button. */
+  readonly cancelLabel = input.required<string>();
+  readonly canEdit = input(true);
+  readonly idPrefix = input("bit-inline-edit");
+
+  /** When set, adds a `maxLength` validator. */
+  readonly maxLength = input<number>();
+  /** Extra validators appended to the built-in `required` and trim validators. */
+  readonly validators = input<ValidatorFn[]>([]);
+
+  /** Persists the value. Resolve `false` to keep the editor open. */
+  readonly save = input.required<(value: string) => Promise<boolean>>();
+
+  readonly editing = model(false);
+
+  protected readonly form = new FormGroup({
+    value: new FormControl("", {
+      nonNullable: true,
+      // trimValidator rewrites the value, so only run validation on submit.
+      updateOn: "submit",
+    }),
+  });
+
+  /** Tracks `value`, but also updates locally on save so the saved text shows before the consumer
+   * pushes it back through `[value]`. */
+  protected readonly displayValue = linkedSignal(() => this.value());
+
+  private readonly formEvents = toSignal(this.form.controls.value.events);
+
+  constructor() {
+    // Seed the form when the editor opens, however it was opened. untracked: inputs changing
+    // mid-edit must not clobber what the user typed.
+    effect(() => {
+      if (this.editing()) {
+        untracked(() => this.prepareForm());
+      }
+    });
+
+    // Close the editor if edit permission is revoked mid-edit.
+    effect(() => {
+      if (!this.canEdit()) {
+        this.editing.set(false);
+      }
+    });
+  }
+
+  /** First validation error on the value control, as a `[key, value]` tuple for `bit-error`. */
+  protected readonly valueError = computed<[string, unknown] | undefined>(() => {
+    this.formEvents(); // recompute on value/status/touched changes
+    const control = this.form.controls.value;
+    if (control.valid || !control.touched || !control.errors) {
+      return undefined;
+    }
+    return Object.entries(control.errors)[0];
+  });
+
+  protected start() {
+    this.editing.set(true);
+  }
+
+  protected cancel() {
+    this.editing.set(false);
+  }
+
+  private prepareForm() {
+    const validators: ValidatorFn[] = [Validators.required, trimValidator];
+    const maxLength = this.maxLength();
+    if (maxLength != null) {
+      validators.push(Validators.maxLength(maxLength));
+    }
+    validators.push(...this.validators());
+
+    this.form.controls.value.setValidators(validators);
+    this.form.setValue({ value: this.value() });
+  }
+
+  protected readonly submit = async () => {
+    this.form.markAllAsTouched();
+
+    if (this.form.invalid) {
+      return;
+    }
+
+    // trimValidator may rewrite the value on submit; persist the final text.
+    const value = this.form.controls.value.value;
+    const saved = await this.save()(value);
+    if (saved) {
+      this.displayValue.set(value);
+      this.editing.set(false);
+    }
+  };
+}

--- a/libs/components/src/inline-edit/inline-edit.mdx
+++ b/libs/components/src/inline-edit/inline-edit.mdx
@@ -1,0 +1,50 @@
+import { Meta, Canvas, Primary, Controls, Title, Description } from "@storybook/addon-docs/blocks";
+
+import * as stories from "./inline-edit.stories";
+
+<Meta of={stories} />
+
+```ts
+import { InlineEditModule } from "@bitwarden/components";
+```
+
+<Title />
+<Description />
+
+<Primary />
+<Controls />
+
+## Usage
+
+Inline edit provides an edit-in-place affordance for a single text value. In its display state it
+renders the value followed by a pencil button; activating it swaps to a text input with save and
+cancel controls. The value text inherits typography from the host context, so the component can be
+placed inside a heading (for example, an `app-header` title) and match its surroundings.
+
+The `save` input is a function returning `Promise<boolean>`. Resolve `true` to close the editor on a
+successful save, or `false` to keep it open (for example, when a server-side validation fails). The
+consuming code is responsible for any toasts or side effects.
+
+## Validation
+
+The control always enforces `required` and a trim validator. Set `maxLength` to add a maximum-length
+validator, and pass additional `ValidatorFn`s through `validators`. Validation runs on submit so the
+trim validator can normalize the value first.
+
+<Canvas of={stories.WithMaxLength} />
+
+## Read-only
+
+The value is always displayed. When `canEdit` is `false`, only the edit affordance is hidden — the
+value remains visible. This suits a value that everyone can see but only some users may change (for
+example, a header title gated on a `write` permission: `[canEdit]="entity.write"`). If editing is
+open when permission is revoked, the editor closes and the value is shown again.
+
+<Canvas of={stories.ReadOnly} />
+
+## Accessibility
+
+The `label`, `editLabel`, `saveLabel`, and `cancelLabel` inputs are required and provide the
+`aria-label`s for the input and the edit, save, and cancel buttons respectively. Provide localized
+strings — the component does not localize text itself. The editor autofocuses the input on open and
+closes on <kbd>Escape</kbd>.

--- a/libs/components/src/inline-edit/inline-edit.module.ts
+++ b/libs/components/src/inline-edit/inline-edit.module.ts
@@ -1,0 +1,9 @@
+import { NgModule } from "@angular/core";
+
+import { InlineEditComponent } from "./inline-edit.component";
+
+@NgModule({
+  imports: [InlineEditComponent],
+  exports: [InlineEditComponent],
+})
+export class InlineEditModule {}

--- a/libs/components/src/inline-edit/inline-edit.stories.ts
+++ b/libs/components/src/inline-edit/inline-edit.stories.ts
@@ -1,0 +1,88 @@
+import { Meta, moduleMetadata, StoryObj } from "@storybook/angular";
+
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+
+import { I18nMockService } from "../utils";
+
+import { InlineEditComponent } from "./inline-edit.component";
+
+export default {
+  title: "Component Library/Inline Edit",
+  component: InlineEditComponent,
+  decorators: [
+    moduleMetadata({
+      providers: [
+        {
+          provide: I18nService,
+          useFactory: () => {
+            return new I18nMockService({
+              inputRequired: "Input is required.",
+              inputMaxLength: (max) => `Input cannot exceed ${max} characters.`,
+              inputTrimValidator: "Input must not contain only whitespace.",
+            });
+          },
+        },
+      ],
+    }),
+  ],
+  args: {
+    value: "My project",
+    label: "Name",
+    editLabel: "Edit name",
+    saveLabel: "Save",
+    cancelLabel: "Cancel",
+    canEdit: true,
+    save: () => Promise.resolve(true),
+  },
+  argTypes: {
+    save: { table: { disable: true } },
+    editing: { table: { disable: true } },
+  },
+} as Meta<InlineEditComponent>;
+
+type Story = StoryObj<InlineEditComponent>;
+
+export const Default: Story = {
+  render: (args) => ({
+    props: args,
+    template: /*html*/ `
+      <bit-inline-edit
+        [value]="value"
+        [label]="label"
+        [editLabel]="editLabel"
+        [saveLabel]="saveLabel"
+        [cancelLabel]="cancelLabel"
+        [canEdit]="canEdit"
+        [save]="save"
+      ></bit-inline-edit>
+    `,
+  }),
+};
+
+export const ReadOnly: Story = {
+  ...Default,
+  args: {
+    canEdit: false,
+  },
+};
+
+export const WithMaxLength: Story = {
+  render: (args) => ({
+    props: args,
+    template: /*html*/ `
+      <bit-inline-edit
+        [value]="value"
+        [label]="label"
+        [editLabel]="editLabel"
+        [saveLabel]="saveLabel"
+        [cancelLabel]="cancelLabel"
+        [canEdit]="canEdit"
+        [maxLength]="maxLength"
+        [save]="save"
+      ></bit-inline-edit>
+    `,
+  }),
+  args: {
+    maxLength: 10,
+  },
+};


### PR DESCRIPTION
 ## 🎟️ Tracking

  [CL-1253](https://bitwarden.atlassian.net/browse/CL-1253)

  ## 📔 Objective

  Add a reusable `bit-inline-edit` (edit in place) component to `libs/components`.

  Display state shows the value with a pencil button; activating it swaps to an input with save and
  cancel. The value is always visible and `canEdit` gates only the edit affordance, so it works as a
  permission-gated header title (everyone sees the title, only editors see the pencil).

  - Inputs: `value`, `label`, `editLabel`, `saveLabel`, `cancelLabel`, `canEdit`, `idPrefix`,
    `maxLength`, `validators`, `save`, plus a two-way `editing` model.
  - Async `save` returns `Promise<boolean>`; resolve `false` to keep the editor open. Toasts and side

  ## 📸 Screenshots

<img width="177" height="101" alt="image" src="https://github.com/user-attachments/assets/39a269f6-b698-4eb3-b2cf-27aac2865c99" />
<img width="309" height="96" alt="image" src="https://github.com/user-attachments/assets/524c6b9c-dae5-4860-910d-69c125b17fe6" />
<img width="345" height="121" alt="image" src="https://github.com/user-attachments/assets/880af125-e95b-458d-b8e7-faac1282d9a4" />


[CL-1253]: https://bitwarden.atlassian.net/browse/CL-1253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ