### PR TITLE
[PM-39814] Firefox passkey login using WebAuthn fallback relay

### DIFF
--- a/apps/browser/src/auth/popup/guards/platform-popout.guard.ts
+++ b/apps/browser/src/auth/popup/guards/platform-popout.guard.ts
@@ -16,6 +16,15 @@ export function platformPopoutGuard(
   forcePopout: boolean = false,
 ): CanActivateFn {
   return async (route: ActivatedRouteSnapshot, state: RouterStateSnapshot) => {
+    // Skip popout for Firefox — WebAuthn is handled via a relay tab (not in-popup),
+    // so the popout window is unnecessary and would be left orphaned.
+    const isFirefox =
+      navigator.userAgent.indexOf(" Firefox/") !== -1 ||
+      navigator.userAgent.indexOf(" Gecko/") !== -1;
+    if (isFirefox && !forcePopout) {
+      return true;
+    }
+
     // Check if current platform matches
     const platformInfo = await BrowserApi.getPlatformInfo();
     const isPlatformMatch = platforms.includes(platformInfo.os);

--- a/apps/browser/src/auth/popup/login-with-passkey-result/login-with-passkey-result.component.html
+++ b/apps/browser/src/auth/popup/login-with-passkey-result/login-with-passkey-result.component.html
@@ -1,0 +1,27 @@
+<div class="tw-flex tw-flex-col tw-items-center tw-justify-center tw-min-h-[300px]">
+  @if (currentState() === "loggingIn") {
+    <div class="tw-text-center">
+      <div class="tw-mb-4">
+        <bit-icon name="bwi-spinner" class="tw-text-3xl tw-animate-spin"></bit-icon>
+      </div>
+      <p class="tw-text-lg">{{ "loggingIn" | i18n }}</p>
+      <p class="tw-text-sm tw-text-muted">{{ "completingPasskeyLogin" | i18n }}</p>
+    </div>
+  }
+
+  @if (currentState() === "loginFailed") {
+    <div class="tw-text-center tw-max-w-md">
+      <div class="tw-mb-4">
+        <bit-icon name="bwi-exclamation-triangle" class="tw-text-2xl tw-text-danger"></bit-icon>
+      </div>
+      <h2 class="tw-text-xl tw-font-semibold tw-mb-2">{{ "loginFailed" | i18n }}</h2>
+      <p class="tw-text-sm tw-text-muted tw-mb-6">{{ "passkeyLoginFailedDesc" | i18n }}</p>
+      <button type="button" bitButton buttonType="primary" (click)="retry()" class="tw-w-full">
+        {{ "tryAgain" | i18n }}
+      </button>
+      <a bitButton buttonType="secondary" routerLink="/login" class="tw-w-full tw-mt-2">
+        {{ "backToLogin" | i18n }}
+      </a>
+    </div>
+  }
+</div>

--- a/apps/browser/src/auth/popup/login-with-passkey-result/login-with-passkey-result.component.spec.ts
+++ b/apps/browser/src/auth/popup/login-with-passkey-result/login-with-passkey-result.component.spec.ts
@@ -1,0 +1,122 @@
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { RouterTestingModule } from "@angular/router/testing";
+import { mock } from "jest-mock-extended";
+
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { ValidationService } from "@bitwarden/common/platform/abstractions/validation.service";
+import { AnonLayoutWrapperDataService } from "@bitwarden/components";
+
+import { BrowserApi } from "../../../platform/browser/browser-api";
+import * as popoutWindow from "../../popup/utils/auth-popout-window";
+import { LoginWithPasskeyResultService } from "../../services/login-with-passkey-result.service";
+
+import { LoginWithPasskeyResultComponent } from "./login-with-passkey-result.component";
+
+describe("LoginWithPasskeyResultComponent", () => {
+  let component: LoginWithPasskeyResultComponent;
+  let fixture: ComponentFixture<LoginWithPasskeyResultComponent>;
+  let loginWithPasskeyResultService: LoginWithPasskeyResultService;
+  let validationService: ValidationService;
+  let anonLayoutWrapperDataService: AnonLayoutWrapperDataService;
+
+  let reloadOpenWindowsSpy: jest.SpyInstance;
+  let closePasskeyResultPopoutSpy: jest.SpyInstance;
+
+  const getStateText = () => fixture.nativeElement.textContent;
+  const getComponentState = () => (component as any).currentState();
+  const retry = () => (component as any).retry();
+
+  beforeEach(async () => {
+    loginWithPasskeyResultService = mock<LoginWithPasskeyResultService>();
+    validationService = mock<ValidationService>();
+    anonLayoutWrapperDataService = mock<AnonLayoutWrapperDataService>();
+
+    reloadOpenWindowsSpy = jest.spyOn(BrowserApi, "reloadOpenWindows").mockImplementation();
+    closePasskeyResultPopoutSpy = jest
+      .spyOn(popoutWindow, "closePasskeyResultPopout")
+      .mockResolvedValue(undefined);
+
+    await TestBed.configureTestingModule({
+      imports: [LoginWithPasskeyResultComponent, RouterTestingModule],
+      providers: [
+        { provide: LoginWithPasskeyResultService, useValue: loginWithPasskeyResultService },
+        { provide: ValidationService, useValue: validationService },
+        { provide: AnonLayoutWrapperDataService, useValue: anonLayoutWrapperDataService },
+        { provide: I18nService, useValue: { t: (key: string) => key } },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(LoginWithPasskeyResultComponent);
+    component = fixture.componentInstance;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("starts in the loggingIn state", () => {
+    expect(getComponentState()).toBe("loggingIn");
+  });
+
+  it("calls completeLogin on init", async () => {
+    (loginWithPasskeyResultService.completeLogin as jest.Mock).mockResolvedValue({
+      success: true,
+      userId: "user-id",
+    });
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(loginWithPasskeyResultService.completeLogin).toHaveBeenCalledTimes(1);
+    expect(reloadOpenWindowsSpy).toHaveBeenCalledWith(true);
+    expect(closePasskeyResultPopoutSpy).toHaveBeenCalled();
+  });
+
+  it("shows the failure UI and reports the error when login fails", async () => {
+    (loginWithPasskeyResultService.completeLogin as jest.Mock).mockResolvedValue({
+      success: false,
+      errorMessage: "login-failed-message",
+    });
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(getComponentState()).toBe("loginFailed");
+    expect(validationService.showError).toHaveBeenCalledWith("login-failed-message");
+    expect(getStateText()).toContain("loginFailed");
+    expect(getStateText()).toContain("passkeyLoginFailedDesc");
+    expect(anonLayoutWrapperDataService.setAnonLayoutWrapperData).toHaveBeenCalled();
+  });
+
+  it("shows the failure UI for an unexpected error", async () => {
+    (loginWithPasskeyResultService.completeLogin as jest.Mock).mockRejectedValue(new Error("boom"));
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(getComponentState()).toBe("loginFailed");
+    expect(validationService.showError).toHaveBeenCalledWith("invalidPasskeyPleaseTryAgain");
+    expect(anonLayoutWrapperDataService.setAnonLayoutWrapperData).toHaveBeenCalled();
+  });
+
+  it("retries login when the user clicks try again", async () => {
+    (loginWithPasskeyResultService.completeLogin as jest.Mock)
+      .mockRejectedValueOnce(new Error("boom"))
+      .mockResolvedValueOnce({ success: true, userId: "user-id" });
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(getComponentState()).toBe("loginFailed");
+
+    retry();
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(getComponentState()).toBe("loggingIn");
+    expect(loginWithPasskeyResultService.completeLogin).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/browser/src/auth/popup/login-with-passkey-result/login-with-passkey-result.component.ts
+++ b/apps/browser/src/auth/popup/login-with-passkey-result/login-with-passkey-result.component.ts
@@ -1,0 +1,82 @@
+import { CommonModule } from "@angular/common";
+import { ChangeDetectionStrategy, Component, inject, OnInit, signal } from "@angular/core";
+import { RouterModule } from "@angular/router";
+
+import { JslibModule } from "@bitwarden/angular/jslib.module";
+import { TwoFactorAuthSecurityKeyIcon } from "@bitwarden/assets/svg";
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { ValidationService } from "@bitwarden/common/platform/abstractions/validation.service";
+import {
+  AnonLayoutWrapperDataService,
+  ButtonModule,
+  IconModule,
+  TypographyModule,
+} from "@bitwarden/components";
+
+import { BrowserApi } from "../../../platform/browser/browser-api";
+import { LoginWithPasskeyResultService } from "../../services/login-with-passkey-result.service";
+import { closePasskeyResultPopout } from "../utils/auth-popout-window";
+
+export type PasskeyLoginState = "loggingIn" | "loginFailed";
+
+@Component({
+  selector: "app-login-with-passkey-result",
+  templateUrl: "login-with-passkey-result.component.html",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  standalone: true,
+  imports: [CommonModule, RouterModule, JslibModule, ButtonModule, IconModule, TypographyModule],
+})
+export class LoginWithPasskeyResultComponent implements OnInit {
+  protected readonly currentState = signal<PasskeyLoginState>("loggingIn");
+
+  protected readonly Icons = {
+    TwoFactorAuthSecurityKeyIcon,
+  };
+
+  private readonly loginWithPasskeyResultService = inject(LoginWithPasskeyResultService);
+  private readonly i18nService = inject(I18nService);
+  private readonly validationService = inject(ValidationService);
+  private readonly anonLayoutWrapperDataService = inject(AnonLayoutWrapperDataService);
+
+  ngOnInit(): void {
+    void this.completeLogin();
+  }
+
+  protected retry(): void {
+    this.currentState.set("loggingIn");
+    void this.completeLogin();
+  }
+
+  private async completeLogin(): Promise<void> {
+    try {
+      const outcome = await this.loginWithPasskeyResultService.completeLogin();
+
+      if (outcome.success === false) {
+        this.validationService.showError(outcome.errorMessage);
+        this.currentState.set("loginFailed");
+        this.setFailureIcon();
+        return;
+      }
+
+      // Reload other open extension windows so they re-evaluate auth guards
+      // and navigate to the vault. Then close this popout.
+      BrowserApi.reloadOpenWindows(true); // true = exclude current window
+      await closePasskeyResultPopout();
+    } catch {
+      this.validationService.showError(this.i18nService.t("invalidPasskeyPleaseTryAgain"));
+      this.currentState.set("loginFailed");
+      this.setFailureIcon();
+    }
+  }
+
+  private setDefaultIcon(): void {
+    this.anonLayoutWrapperDataService.setAnonLayoutWrapperData({
+      pageIcon: this.Icons.TwoFactorAuthSecurityKeyIcon,
+    });
+  }
+
+  private setFailureIcon(): void {
+    // For now, use the same icon, but the component could show a different one.
+    this.setDefaultIcon();
+  }
+}

--- a/apps/browser/src/auth/popup/login/extension-login-component.service.ts
+++ b/apps/browser/src/auth/popup/login/extension-login-component.service.ts
@@ -72,8 +72,9 @@ export class ExtensionLoginComponentService
   }
 
   /**
-   * Enable passkey login support for chromium-based browsers only.
-   * Neither Firefox nor safari support overriding the relying party ID in an extension.
+   * Enable passkey login support for chromium-based browsers and Firefox.
+   * Firefox is now supported via the web vault relay mechanism.
+   * Safari remains unsupported (different restrictions, no passkey support in extension context).
    *
    * https://github.com/w3c/webextensions/issues/238
    *
@@ -82,6 +83,8 @@ export class ExtensionLoginComponentService
    * https://developer.apple.com/forums/thread/774351
    */
   isLoginWithPasskeySupported(): boolean {
-    return this.platformUtilsService.isChromium();
+    // Firefox is now supported via the web vault relay mechanism.
+    // Safari remains unsupported (different restrictions, no passkey support in extension context).
+    return this.platformUtilsService.isChromium() || this.platformUtilsService.isFirefox();
   }
 }

--- a/apps/browser/src/auth/popup/unlock-with-passkey-result/unlock-with-passkey-result.component.html
+++ b/apps/browser/src/auth/popup/unlock-with-passkey-result/unlock-with-passkey-result.component.html
@@ -1,0 +1,27 @@
+<div class="tw-flex tw-flex-col tw-items-center tw-justify-center tw-min-h-[300px]">
+  @if (currentState() === "unlocking") {
+    <div class="tw-text-center">
+      <div class="tw-mb-4">
+        <bit-icon name="bwi-spinner" class="tw-text-3xl tw-animate-spin"></bit-icon>
+      </div>
+      <p class="tw-text-lg">{{ "unlocking" | i18n }}</p>
+      <p class="tw-text-sm tw-text-muted">{{ "completingPasskeyUnlock" | i18n }}</p>
+    </div>
+  }
+
+  @if (currentState() === "unlockFailed") {
+    <div class="tw-text-center tw-max-w-md">
+      <div class="tw-mb-4">
+        <bit-icon name="bwi-exclamation-triangle" class="tw-text-2xl tw-text-danger"></bit-icon>
+      </div>
+      <h2 class="tw-text-xl tw-font-semibold tw-mb-2">{{ "unlockFailed" | i18n }}</h2>
+      <p class="tw-text-sm tw-text-muted tw-mb-6">{{ "passkeyUnlockFailedDesc" | i18n }}</p>
+      <button type="button" bitButton buttonType="primary" (click)="retry()" class="tw-w-full">
+        {{ "tryAgain" | i18n }}
+      </button>
+      <a bitButton buttonType="secondary" routerLink="/lock" class="tw-w-full tw-mt-2">
+        {{ "backToLock" | i18n }}
+      </a>
+    </div>
+  }
+</div>

--- a/apps/browser/src/auth/popup/unlock-with-passkey-result/unlock-with-passkey-result.component.spec.ts
+++ b/apps/browser/src/auth/popup/unlock-with-passkey-result/unlock-with-passkey-result.component.spec.ts
@@ -1,0 +1,147 @@
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { Router } from "@angular/router";
+import { RouterTestingModule } from "@angular/router/testing";
+import { mock } from "jest-mock-extended";
+
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { ValidationService } from "@bitwarden/common/platform/abstractions/validation.service";
+import { AnonLayoutWrapperDataService } from "@bitwarden/components";
+
+import { BrowserApi } from "../../../platform/browser/browser-api";
+import * as popoutWindow from "../../popup/utils/auth-popout-window";
+import { UnlockWithPasskeyResultService } from "../../services/unlock-with-passkey-result.service";
+
+import { UnlockWithPasskeyResultComponent } from "./unlock-with-passkey-result.component";
+
+describe("UnlockWithPasskeyResultComponent", () => {
+  let component: UnlockWithPasskeyResultComponent;
+  let fixture: ComponentFixture<UnlockWithPasskeyResultComponent>;
+  let unlockWithPasskeyResultService: UnlockWithPasskeyResultService;
+  let validationService: ValidationService;
+  let anonLayoutWrapperDataService: AnonLayoutWrapperDataService;
+  let router: Router;
+
+  let reloadOpenWindowsSpy: jest.SpyInstance;
+  let closePasskeyResultPopoutSpy: jest.SpyInstance;
+  let routerNavigateSpy: jest.SpyInstance;
+
+  const getStateText = () => fixture.nativeElement.textContent;
+  const getComponentState = () => (component as any).currentState();
+  const retry = () => (component as any).retry();
+
+  beforeEach(async () => {
+    unlockWithPasskeyResultService = mock<UnlockWithPasskeyResultService>();
+    validationService = mock<ValidationService>();
+    anonLayoutWrapperDataService = mock<AnonLayoutWrapperDataService>();
+
+    reloadOpenWindowsSpy = jest.spyOn(BrowserApi, "reloadOpenWindows").mockImplementation();
+    closePasskeyResultPopoutSpy = jest
+      .spyOn(popoutWindow, "closePasskeyResultPopout")
+      .mockResolvedValue(undefined);
+
+    await TestBed.configureTestingModule({
+      imports: [UnlockWithPasskeyResultComponent, RouterTestingModule],
+      providers: [
+        { provide: UnlockWithPasskeyResultService, useValue: unlockWithPasskeyResultService },
+        { provide: ValidationService, useValue: validationService },
+        { provide: AnonLayoutWrapperDataService, useValue: anonLayoutWrapperDataService },
+        { provide: I18nService, useValue: { t: (key: string) => key } },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(UnlockWithPasskeyResultComponent);
+    component = fixture.componentInstance;
+    router = TestBed.inject(Router);
+    routerNavigateSpy = jest.spyOn(router, "navigate").mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("starts in the unlocking state", () => {
+    expect(getComponentState()).toBe("unlocking");
+  });
+
+  it("calls completeUnlock on init and navigates to the vault on success", async () => {
+    (unlockWithPasskeyResultService.completeUnlock as jest.Mock).mockResolvedValue({
+      success: true,
+    });
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(unlockWithPasskeyResultService.completeUnlock).toHaveBeenCalledTimes(1);
+    expect(reloadOpenWindowsSpy).toHaveBeenCalledWith(true);
+    expect(closePasskeyResultPopoutSpy).toHaveBeenCalled();
+    expect(routerNavigateSpy).toHaveBeenCalledWith(["/tabs/vault"]);
+  });
+
+  it("closes the popout without showing an error when unlock is canceled", async () => {
+    (unlockWithPasskeyResultService.completeUnlock as jest.Mock).mockResolvedValue({
+      success: false,
+      errorMessage: "",
+      canceled: true,
+    });
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(getComponentState()).toBe("unlocking");
+    expect(validationService.showError).not.toHaveBeenCalled();
+    expect(closePasskeyResultPopoutSpy).toHaveBeenCalled();
+    expect(reloadOpenWindowsSpy).not.toHaveBeenCalled();
+    expect(routerNavigateSpy).not.toHaveBeenCalled();
+  });
+
+  it("shows the failure UI and reports the error when unlock fails", async () => {
+    (unlockWithPasskeyResultService.completeUnlock as jest.Mock).mockResolvedValue({
+      success: false,
+      errorMessage: "unlock-failed-message",
+      canceled: false,
+    });
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(getComponentState()).toBe("unlockFailed");
+    expect(validationService.showError).toHaveBeenCalledWith("unlock-failed-message");
+    expect(getStateText()).toContain("unlockFailed");
+    expect(getStateText()).toContain("passkeyUnlockFailedDesc");
+    expect(anonLayoutWrapperDataService.setAnonLayoutWrapperData).toHaveBeenCalled();
+  });
+
+  it("shows the failure UI for an unexpected error", async () => {
+    (unlockWithPasskeyResultService.completeUnlock as jest.Mock).mockRejectedValue(
+      new Error("boom"),
+    );
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(getComponentState()).toBe("unlockFailed");
+    expect(validationService.showError).toHaveBeenCalledWith("invalidPasskeyPleaseTryAgain");
+  });
+
+  it("retries unlock when the user clicks try again", async () => {
+    (unlockWithPasskeyResultService.completeUnlock as jest.Mock)
+      .mockRejectedValueOnce(new Error("boom"))
+      .mockResolvedValueOnce({ success: true });
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(getComponentState()).toBe("unlockFailed");
+
+    retry();
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(getComponentState()).toBe("unlocking");
+    expect(unlockWithPasskeyResultService.completeUnlock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/browser/src/auth/popup/unlock-with-passkey-result/unlock-with-passkey-result.component.ts
+++ b/apps/browser/src/auth/popup/unlock-with-passkey-result/unlock-with-passkey-result.component.ts
@@ -1,0 +1,89 @@
+import { CommonModule } from "@angular/common";
+import { ChangeDetectionStrategy, Component, inject, OnInit, signal } from "@angular/core";
+import { Router, RouterModule } from "@angular/router";
+
+import { JslibModule } from "@bitwarden/angular/jslib.module";
+import { TwoFactorAuthSecurityKeyIcon } from "@bitwarden/assets/svg";
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { ValidationService } from "@bitwarden/common/platform/abstractions/validation.service";
+import {
+  AnonLayoutWrapperDataService,
+  ButtonModule,
+  IconModule,
+  TypographyModule,
+} from "@bitwarden/components";
+
+import { BrowserApi } from "../../../platform/browser/browser-api";
+import { UnlockWithPasskeyResultService } from "../../services/unlock-with-passkey-result.service";
+import { closePasskeyResultPopout } from "../utils/auth-popout-window";
+
+export type PasskeyUnlockState = "unlocking" | "unlockFailed";
+
+@Component({
+  selector: "app-unlock-with-passkey-result",
+  templateUrl: "unlock-with-passkey-result.component.html",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  standalone: true,
+  imports: [CommonModule, RouterModule, JslibModule, ButtonModule, IconModule, TypographyModule],
+})
+export class UnlockWithPasskeyResultComponent implements OnInit {
+  protected readonly currentState = signal<PasskeyUnlockState>("unlocking");
+
+  protected readonly Icons = {
+    TwoFactorAuthSecurityKeyIcon,
+  };
+
+  private readonly unlockWithPasskeyResultService = inject(UnlockWithPasskeyResultService);
+  private readonly validationService = inject(ValidationService);
+  private readonly i18nService = inject(I18nService);
+  private readonly router = inject(Router);
+  private readonly anonLayoutWrapperDataService = inject(AnonLayoutWrapperDataService);
+
+  ngOnInit(): void {
+    void this.completeUnlock();
+  }
+
+  protected retry(): void {
+    this.currentState.set("unlocking");
+    void this.completeUnlock();
+  }
+
+  private async completeUnlock(): Promise<void> {
+    try {
+      const outcome = await this.unlockWithPasskeyResultService.completeUnlock();
+
+      if (outcome.success === false) {
+        if (outcome.canceled) {
+          await closePasskeyResultPopout();
+          return;
+        }
+
+        this.validationService.showError(outcome.errorMessage);
+        this.currentState.set("unlockFailed");
+        this.setFailureIcon();
+        return;
+      }
+
+      // Reload other open extension windows so they re-evaluate auth guards
+      // and navigate to the vault. Then close this popout.
+      BrowserApi.reloadOpenWindows(true); // true = exclude current window
+      await closePasskeyResultPopout();
+      await this.router.navigate(["/tabs/vault"]);
+    } catch {
+      this.validationService.showError(this.i18nService.t("invalidPasskeyPleaseTryAgain"));
+      this.currentState.set("unlockFailed");
+      this.setFailureIcon();
+    }
+  }
+
+  private setDefaultIcon(): void {
+    this.anonLayoutWrapperDataService.setAnonLayoutWrapperData({
+      pageIcon: this.Icons.TwoFactorAuthSecurityKeyIcon,
+    });
+  }
+
+  private setFailureIcon(): void {
+    // For now, use the same icon, but the component could show a different one.
+    this.setDefaultIcon();
+  }
+}

--- a/apps/browser/src/auth/popup/utils/auth-popout-window.ts
+++ b/apps/browser/src/auth/popup/utils/auth-popout-window.ts
@@ -10,6 +10,7 @@ const AuthPopoutType = {
   twoFactorAuthWebAuthn: "auth_twoFactorAuthWebAuthn",
   twoFactorAuthEmail: "auth_twoFactorAuthEmail",
   twoFactorAuthDuo: "auth_twoFactorAuthDuo",
+  passkeyResult: "auth_passkeyResult",
 } as const;
 
 const extensionUnlockUrls = new Set([
@@ -144,6 +145,23 @@ async function closeTwoFactorAuthDuoPopout() {
   await BrowserPopupUtils.closeSingleActionPopout(AuthPopoutType.twoFactorAuthDuo);
 }
 
+/**
+ * Opens a popout that facilitates completing passkey result (login or unlock) with PRF.
+ */
+async function openPasskeyResultPopout(type: "login" | "unlock") {
+  const route = type === "login" ? "login-with-passkey-result" : "unlock-with-passkey-result";
+  await BrowserPopupUtils.openPopout(`popup/index.html#/${route}`, {
+    singleActionKey: AuthPopoutType.passkeyResult,
+  });
+}
+
+/**
+ * Closes the passkey result popout.
+ */
+async function closePasskeyResultPopout() {
+  await BrowserPopupUtils.closeSingleActionPopout(AuthPopoutType.passkeyResult);
+}
+
 export {
   AuthPopoutType,
   openUnlockPopout,
@@ -156,4 +174,6 @@ export {
   closeTwoFactorAuthEmailPopout,
   openTwoFactorAuthDuoPopout,
   closeTwoFactorAuthDuoPopout,
+  openPasskeyResultPopout,
+  closePasskeyResultPopout,
 };

--- a/apps/browser/src/auth/services/extension-login-via-webauthn-component.service.spec.ts
+++ b/apps/browser/src/auth/services/extension-login-via-webauthn-component.service.spec.ts
@@ -1,0 +1,83 @@
+import { mock } from "jest-mock-extended";
+import { of } from "rxjs";
+
+import {
+  Environment,
+  EnvironmentService,
+} from "@bitwarden/common/platform/abstractions/environment.service";
+import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
+
+import { ExtensionLoginViaWebAuthnComponentService } from "./extension-login-via-webauthn-component.service";
+
+describe("ExtensionLoginViaWebAuthnComponentService", () => {
+  let service: ExtensionLoginViaWebAuthnComponentService;
+  let platformUtilsService: PlatformUtilsService;
+  let environmentService: EnvironmentService;
+
+  const webVaultUrl = "https://vault.bitwarden.com";
+  const extensionPublicKey = "extension-public-key";
+
+  beforeEach(() => {
+    platformUtilsService = mock<PlatformUtilsService>();
+    environmentService = mock<EnvironmentService>();
+    (environmentService.environment$ as any) = of({
+      getWebVaultUrl: () => webVaultUrl,
+    } as Environment);
+
+    service = new ExtensionLoginViaWebAuthnComponentService(
+      platformUtilsService,
+      environmentService,
+    );
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("shouldUseWebVaultRelay", () => {
+    it("returns true for Firefox", () => {
+      platformUtilsService.isFirefox = jest.fn().mockReturnValue(true);
+
+      expect(service.shouldUseWebVaultRelay()).toBe(true);
+    });
+
+    it("returns false for non-Firefox browsers", () => {
+      platformUtilsService.isFirefox = jest.fn().mockReturnValue(false);
+
+      expect(service.shouldUseWebVaultRelay()).toBe(false);
+    });
+  });
+
+  describe("openWebVaultRelayTab", () => {
+    beforeEach(() => {
+      (chrome.runtime.sendMessage as jest.Mock).mockResolvedValue({ result: extensionPublicKey });
+    });
+
+    it("requests an ephemeral ECDH public key and opens the connector tab in the URL fragment", async () => {
+      platformUtilsService.isFirefox = jest.fn().mockReturnValue(true);
+
+      await service.openWebVaultRelayTab();
+
+      expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({ command: "initiatePasskeyRelay" });
+      expect(platformUtilsService.launchUri).toHaveBeenCalledWith(
+        expect.stringContaining(`${webVaultUrl}/passkey-connector.html#`),
+      );
+      expect(platformUtilsService.launchUri).toHaveBeenCalledWith(
+        expect.stringContaining(`extensionPublicKey=${encodeURIComponent(extensionPublicKey)}`),
+      );
+    });
+
+    it("throws when the background does not return a public key", async () => {
+      (chrome.runtime.sendMessage as jest.Mock).mockResolvedValue({});
+
+      await expect(service.openWebVaultRelayTab()).rejects.toThrow(
+        "Failed to initiate passkey login relay",
+      );
+    });
+
+    it("exposes layout flags used by the login via WebAuthn component", () => {
+      expect(service.showTroubleLoggingInText).toBe(false);
+      expect(service.leftAlignDescription).toBe(true);
+    });
+  });
+});

--- a/apps/browser/src/auth/services/extension-login-via-webauthn-component.service.ts
+++ b/apps/browser/src/auth/services/extension-login-via-webauthn-component.service.ts
@@ -1,0 +1,57 @@
+// eslint-disable-next-line no-restricted-imports -- This is an Angular component service
+import { Injectable } from "@angular/core";
+import { firstValueFrom } from "rxjs";
+
+import { LoginViaWebAuthnComponentService } from "@bitwarden/auth/angular";
+import { EnvironmentService } from "@bitwarden/common/platform/abstractions/environment.service";
+import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
+
+/**
+ * Browser extension implementation of LoginViaWebAuthnComponentService.
+ * Handles Firefox passkey login via the web vault connector relay mechanism.
+ */
+@Injectable()
+export class ExtensionLoginViaWebAuthnComponentService implements LoginViaWebAuthnComponentService {
+  showTroubleLoggingInText = false;
+  leftAlignDescription = true;
+
+  constructor(
+    private platformUtilsService: PlatformUtilsService,
+    private environmentService: EnvironmentService,
+  ) {}
+
+  /**
+   * Returns true for Firefox, which requires the web vault relay mechanism
+   * because it cannot call credentials.get() with a custom RP ID from an extension.
+   */
+  shouldUseWebVaultRelay(): boolean {
+    return this.platformUtilsService.isFirefox();
+  }
+
+  /**
+   * Opens the web vault connector tab for relay-based passkey login.
+   * 1. Sends message to background to generate ephemeral ECDH key pair
+   * 2. Opens connector page with public key in URL fragment
+   */
+  async openWebVaultRelayTab(): Promise<void> {
+    // 1. Ask the background to generate the ephemeral ECDH key pair
+    const response = await chrome.runtime.sendMessage({
+      command: "initiatePasskeyRelay",
+    });
+
+    if (!response?.result) {
+      throw new Error("Failed to initiate passkey login relay");
+    }
+
+    const extensionPublicKey = response.result;
+
+    // 2. Open the connector page with public key in fragment (not sent to server)
+    const env = await firstValueFrom(this.environmentService.environment$);
+    const webVaultUrl = env.getWebVaultUrl();
+
+    // Use URL fragment to avoid sending the key to the server
+    const connectorUrl = `${webVaultUrl}/passkey-connector.html#extensionPublicKey=${encodeURIComponent(extensionPublicKey)}`;
+
+    this.platformUtilsService.launchUri(connectorUrl);
+  }
+}

--- a/apps/browser/src/auth/services/extension-unlock-via-webauthn-component.service.spec.ts
+++ b/apps/browser/src/auth/services/extension-unlock-via-webauthn-component.service.spec.ts
@@ -1,0 +1,127 @@
+import { mock } from "jest-mock-extended";
+import { of } from "rxjs";
+
+import { UserDecryptionOptionsServiceAbstraction } from "@bitwarden/auth/common";
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import {
+  Environment,
+  EnvironmentService,
+} from "@bitwarden/common/platform/abstractions/environment.service";
+import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
+import { UserId } from "@bitwarden/common/types/guid";
+
+import { ExtensionUnlockViaWebAuthnComponentService } from "./extension-unlock-via-webauthn-component.service";
+
+describe("ExtensionUnlockViaWebAuthnComponentService", () => {
+  let service: ExtensionUnlockViaWebAuthnComponentService;
+  let platformUtilsService: PlatformUtilsService;
+  let environmentService: EnvironmentService;
+  let accountService: AccountService;
+  let userDecryptionOptionsService: UserDecryptionOptionsServiceAbstraction;
+
+  const webVaultUrl = "https://vault.bitwarden.com";
+  const extensionPublicKey = "extension-public-key";
+  const userId = "00000000-0000-0000-0000-000000000003" as UserId;
+  const credentialId = "credential-id";
+  const transports = ["usb", "nfc"];
+
+  beforeEach(() => {
+    platformUtilsService = mock<PlatformUtilsService>();
+    environmentService = mock<EnvironmentService>();
+    accountService = mock<AccountService>();
+    userDecryptionOptionsService = mock<UserDecryptionOptionsServiceAbstraction>();
+
+    (environmentService.environment$ as any) = of({
+      getWebVaultUrl: () => webVaultUrl,
+    } as Environment);
+    (accountService.activeAccount$ as any) = of({ id: userId, email: "test@example.com" });
+    (userDecryptionOptionsService.userDecryptionOptionsById$ as jest.Mock).mockReturnValue(
+      of({
+        webAuthnPrfOptions: [
+          {
+            credentialId,
+            encryptedPrivateKey: "encrypted-private-key",
+            encryptedUserKey: "encrypted-user-key",
+            transports,
+          },
+        ],
+      }),
+    );
+
+    service = new ExtensionUnlockViaWebAuthnComponentService(
+      platformUtilsService,
+      environmentService,
+      accountService,
+      userDecryptionOptionsService,
+    );
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("shouldUseWebVaultRelay", () => {
+    it("returns true for Firefox", () => {
+      platformUtilsService.isFirefox = jest.fn().mockReturnValue(true);
+
+      expect(service.shouldUseWebVaultRelay()).toBe(true);
+    });
+
+    it("returns false for non-Firefox browsers", () => {
+      platformUtilsService.isFirefox = jest.fn().mockReturnValue(false);
+
+      expect(service.shouldUseWebVaultRelay()).toBe(false);
+    });
+  });
+
+  describe("openWebVaultRelayTab", () => {
+    beforeEach(() => {
+      (chrome.runtime.sendMessage as jest.Mock).mockResolvedValue({ result: extensionPublicKey });
+    });
+
+    it("requests an ephemeral ECDH public key and opens the unlock connector tab with credentials", async () => {
+      await service.openWebVaultRelayTab();
+
+      expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({ command: "initiatePasskeyRelay" });
+      expect(userDecryptionOptionsService.userDecryptionOptionsById$).toHaveBeenCalledWith(userId);
+      expect(platformUtilsService.launchUri).toHaveBeenCalledWith(
+        expect.stringContaining(`${webVaultUrl}/passkey-connector.html#`),
+      );
+      expect(platformUtilsService.launchUri).toHaveBeenCalledWith(
+        expect.stringContaining(`mode=unlock`),
+      );
+      expect(platformUtilsService.launchUri).toHaveBeenCalledWith(
+        expect.stringContaining(
+          `credentials=${encodeURIComponent(JSON.stringify([{ id: credentialId, transports }]))}`,
+        ),
+      );
+      expect(platformUtilsService.launchUri).toHaveBeenCalledWith(
+        expect.stringContaining(`extensionPublicKey=${encodeURIComponent(extensionPublicKey)}`),
+      );
+    });
+
+    it("throws when the background does not return a public key", async () => {
+      (chrome.runtime.sendMessage as jest.Mock).mockResolvedValue({});
+
+      await expect(service.openWebVaultRelayTab()).rejects.toThrow(
+        "Failed to initiate passkey unlock relay",
+      );
+    });
+
+    it("throws when there is no active account", async () => {
+      (accountService.activeAccount$ as any) = of({ id: null });
+
+      await expect(service.openWebVaultRelayTab()).rejects.toThrow("No active account found");
+    });
+
+    it("throws when there are no PRF credentials available", async () => {
+      (userDecryptionOptionsService.userDecryptionOptionsById$ as jest.Mock).mockReturnValue(
+        of({ webAuthnPrfOptions: [] }),
+      );
+
+      await expect(service.openWebVaultRelayTab()).rejects.toThrow(
+        "No PRF credentials available for unlock",
+      );
+    });
+  });
+});

--- a/apps/browser/src/auth/services/extension-unlock-via-webauthn-component.service.ts
+++ b/apps/browser/src/auth/services/extension-unlock-via-webauthn-component.service.ts
@@ -1,0 +1,83 @@
+// eslint-disable-next-line no-restricted-imports -- This is an Angular component service
+import { Injectable } from "@angular/core";
+import { firstValueFrom } from "rxjs";
+
+import { UserDecryptionOptionsServiceAbstraction } from "@bitwarden/auth/common";
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { EnvironmentService } from "@bitwarden/common/platform/abstractions/environment.service";
+import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
+import { UserId } from "@bitwarden/common/types/guid";
+
+/**
+ * Browser extension implementation for unlock via WebAuthn/PRF.
+ * Handles Firefox passkey unlock via the web vault connector relay mechanism.
+ */
+@Injectable()
+export class ExtensionUnlockViaWebAuthnComponentService {
+  constructor(
+    private platformUtilsService: PlatformUtilsService,
+    private environmentService: EnvironmentService,
+    private accountService: AccountService,
+    private userDecryptionOptionsService: UserDecryptionOptionsServiceAbstraction,
+  ) {}
+
+  /**
+   * Returns true for Firefox, which requires the web vault relay mechanism
+   * because it cannot call credentials.get() with a custom RP ID from an extension.
+   */
+  shouldUseWebVaultRelay(): boolean {
+    return this.platformUtilsService.isFirefox();
+  }
+
+  /**
+   * Opens the web vault connector tab for relay-based passkey unlock.
+   * 1. Sends message to background to generate ephemeral ECDH key pair
+   * 2. Opens connector page with public key and credential IDs in URL fragment
+   */
+  async openWebVaultRelayTab(): Promise<void> {
+    // 1. Ask the background to generate the ephemeral ECDH key pair
+    const response = await chrome.runtime.sendMessage({
+      command: "initiatePasskeyRelay",
+    });
+
+    if (!response?.result) {
+      throw new Error("Failed to initiate passkey unlock relay");
+    }
+
+    const extensionPublicKey = response.result;
+
+    // 2. Get the active user and their PRF credentials
+    const activeAccount = await firstValueFrom(this.accountService.activeAccount$);
+    if (!activeAccount?.id) {
+      throw new Error("No active account found");
+    }
+    const userId = activeAccount.id as UserId;
+
+    // 3. Get the user's PRF credentials
+    const userDecryptionOptions = await firstValueFrom(
+      this.userDecryptionOptionsService.userDecryptionOptionsById$(userId),
+    );
+
+    if (!userDecryptionOptions?.webAuthnPrfOptions?.length) {
+      throw new Error("No PRF credentials available for unlock");
+    }
+
+    // Serialize credential IDs for the URL
+    const credentials = userDecryptionOptions.webAuthnPrfOptions.map(
+      (option: { credentialId: string; transports: string[] }) => ({
+        id: option.credentialId,
+        transports: option.transports || [],
+      }),
+    );
+    const credentialsParam = encodeURIComponent(JSON.stringify(credentials));
+
+    // 4. Open the connector page with public key and credentials in fragment
+    const env = await firstValueFrom(this.environmentService.environment$);
+    const webVaultUrl = env.getWebVaultUrl();
+
+    // Use URL fragment to avoid sending sensitive data to the server
+    const connectorUrl = `${webVaultUrl}/passkey-connector.html#extensionPublicKey=${encodeURIComponent(extensionPublicKey)}&mode=unlock&credentials=${credentialsParam}`;
+
+    this.platformUtilsService.launchUri(connectorUrl);
+  }
+}

--- a/apps/browser/src/auth/services/login-with-passkey-result.service.spec.ts
+++ b/apps/browser/src/auth/services/login-with-passkey-result.service.spec.ts
@@ -1,0 +1,244 @@
+// eslint-disable-next-line no-restricted-imports
+import { TestBed } from "@angular/core/testing";
+import { mock } from "jest-mock-extended";
+import { BehaviorSubject, of } from "rxjs";
+
+import { LoginSuccessHandlerService } from "@bitwarden/auth/common";
+import { WebAuthnLoginPrfKeyServiceAbstraction } from "@bitwarden/common/auth/abstractions/webauthn/webauthn-login-prf-key.service.abstraction";
+import { WebAuthnLoginServiceAbstraction } from "@bitwarden/common/auth/abstractions/webauthn/webauthn-login.service.abstraction";
+import { TwoFactorProviderType } from "@bitwarden/common/auth/enums/two-factor-provider-type";
+import { AuthResult } from "@bitwarden/common/auth/models/domain/auth-result";
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+import { UserId } from "@bitwarden/common/types/guid";
+import { PrfKey } from "@bitwarden/common/types/key";
+import { KeyService } from "@bitwarden/key-management";
+
+import { LoginWithPasskeyResultService } from "./login-with-passkey-result.service";
+import { PasskeyLoginRelayResult, PasskeyRelayService } from "./passkey-relay.service";
+
+describe("LoginWithPasskeyResultService", () => {
+  let service: LoginWithPasskeyResultService;
+  let passkeyRelayService: PasskeyRelayService;
+  let webAuthnLoginService: WebAuthnLoginServiceAbstraction;
+  let webAuthnLoginPrfKeyService: WebAuthnLoginPrfKeyServiceAbstraction;
+  let loginSuccessHandlerService: LoginSuccessHandlerService;
+  let keyService: KeyService;
+  let i18nService: I18nService;
+  let logService: LogService;
+
+  const testUserId = "00000000-0000-0000-0000-000000000001" as UserId;
+  const token = "login-token";
+  const assertionData = JSON.stringify({ id: "assertion-id", rawId: "raw-id" });
+
+  const setupDependencies = (overrides?: {
+    relayResult?: PasskeyLoginRelayResult | null;
+    relayType?: "login" | "unlock";
+  }) => {
+    const relayResult =
+      overrides?.relayResult === undefined
+        ? ({
+            type: "login",
+            token,
+            assertionData,
+            prfOutput: null,
+          } as PasskeyLoginRelayResult)
+        : overrides?.relayResult;
+
+    (passkeyRelayService.consumeResult as jest.Mock).mockResolvedValue(relayResult);
+  };
+
+  beforeEach(() => {
+    passkeyRelayService = mock<PasskeyRelayService>();
+    webAuthnLoginService = mock<WebAuthnLoginServiceAbstraction>();
+    webAuthnLoginPrfKeyService = mock<WebAuthnLoginPrfKeyServiceAbstraction>();
+    loginSuccessHandlerService = mock<LoginSuccessHandlerService>();
+    keyService = mock<KeyService>();
+    i18nService = mock<I18nService>();
+    logService = mock<LogService>();
+
+    i18nService.t = jest.fn((key: string) => key) as any;
+    (keyService.userKey$ as jest.Mock).mockReturnValue(of(null));
+
+    TestBed.configureTestingModule({
+      providers: [
+        LoginWithPasskeyResultService,
+        { provide: PasskeyRelayService, useValue: passkeyRelayService },
+        { provide: WebAuthnLoginServiceAbstraction, useValue: webAuthnLoginService },
+        { provide: WebAuthnLoginPrfKeyServiceAbstraction, useValue: webAuthnLoginPrfKeyService },
+        { provide: LoginSuccessHandlerService, useValue: loginSuccessHandlerService },
+        { provide: KeyService, useValue: keyService },
+        { provide: I18nService, useValue: i18nService },
+        { provide: LogService, useValue: logService },
+      ],
+    });
+
+    service = TestBed.inject(LoginWithPasskeyResultService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("creates the service", () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe("completeLogin", () => {
+    it("returns a timeout error when there is no relay result", async () => {
+      setupDependencies({ relayResult: null });
+
+      const result = await service.completeLogin();
+
+      expect(result).toEqual({
+        success: false,
+        errorMessage: "passkeyLoginTimeout",
+      });
+      expect(logService.error).toHaveBeenCalledWith("[PasskeyLogin] No relay result available");
+      expect(webAuthnLoginService.logIn).not.toHaveBeenCalled();
+    });
+
+    it("returns a timeout error when the relay result has the wrong type", async () => {
+      setupDependencies({
+        relayResult: {
+          type: "unlock",
+          credentialId: "credential-id",
+          prfOutput: new Uint8Array([1]).buffer,
+        } as any,
+      });
+
+      const result = await service.completeLogin();
+
+      expect(result).toEqual({
+        success: false,
+        errorMessage: "passkeyLoginTimeout",
+      });
+    });
+
+    it("returns an invalid passkey error when assertion data is not valid JSON", async () => {
+      setupDependencies({
+        relayResult: {
+          type: "login",
+          token,
+          assertionData: "not-json",
+          prfOutput: null,
+        },
+      });
+
+      const result = await service.completeLogin();
+
+      expect(result).toEqual({
+        success: false,
+        errorMessage: "invalidPasskeyPleaseTryAgain",
+      });
+      expect(webAuthnLoginService.logIn).not.toHaveBeenCalled();
+    });
+
+    it("submits the assertion and returns success when no PRF output is present", async () => {
+      setupDependencies();
+      (webAuthnLoginService.logIn as jest.Mock).mockResolvedValue({
+        userId: testUserId,
+        twoFactorProviders: null,
+      });
+
+      const result = await service.completeLogin();
+
+      expect(result).toEqual({ success: true, userId: testUserId });
+      expect(webAuthnLoginService.logIn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          token,
+          prfKey: null,
+        }),
+      );
+      expect(loginSuccessHandlerService.run).not.toHaveBeenCalled();
+    });
+
+    it("derives the PRF key, zeroes the PRF output, and submits the assertion", async () => {
+      const prfOutput = new Uint8Array([1, 2, 3, 4]).buffer;
+      const prfKey = mock<PrfKey>();
+      (webAuthnLoginPrfKeyService.createSymmetricKeyFromPrf as jest.Mock).mockResolvedValue(prfKey);
+      setupDependencies({
+        relayResult: {
+          type: "login",
+          token,
+          assertionData,
+          prfOutput,
+        },
+      });
+      (webAuthnLoginService.logIn as jest.Mock).mockResolvedValue({
+        userId: testUserId,
+        twoFactorProviders: null,
+      });
+
+      const result = await service.completeLogin();
+
+      expect(result).toEqual({ success: true, userId: testUserId });
+      expect(webAuthnLoginPrfKeyService.createSymmetricKeyFromPrf).toHaveBeenCalledWith(prfOutput);
+      expect(new Uint8Array(prfOutput).every((byte) => byte === 0)).toBe(true);
+      expect(webAuthnLoginService.logIn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          token,
+          prfKey,
+        }),
+      );
+    });
+
+    it("runs the login success handler when a user key is present", async () => {
+      const userKey = new BehaviorSubject<unknown>({ key: [1, 2, 3] });
+      (keyService.userKey$ as jest.Mock).mockReturnValue(userKey.asObservable());
+      setupDependencies();
+      (webAuthnLoginService.logIn as jest.Mock).mockResolvedValue({
+        userId: testUserId,
+        twoFactorProviders: null,
+      });
+
+      await service.completeLogin();
+
+      expect(loginSuccessHandlerService.run).toHaveBeenCalledWith(testUserId, null);
+    });
+
+    it("does not run the login success handler when no user key is present", async () => {
+      setupDependencies();
+      (webAuthnLoginService.logIn as jest.Mock).mockResolvedValue({
+        userId: testUserId,
+        twoFactorProviders: null,
+      });
+
+      await service.completeLogin();
+
+      expect(loginSuccessHandlerService.run).not.toHaveBeenCalled();
+    });
+
+    it("returns a two-factor error when the server requires two-factor authentication", async () => {
+      setupDependencies();
+      const authResult = Object.assign(new AuthResult(), {
+        userId: testUserId,
+        twoFactorProviders: { [TwoFactorProviderType.WebAuthn]: { some: "data" } },
+      });
+      (webAuthnLoginService.logIn as jest.Mock).mockResolvedValue(authResult);
+
+      const result = await service.completeLogin();
+
+      expect(result).toEqual({
+        success: false,
+        errorMessage: "twoFactorForPasskeysNotSupportedOnClientUpdateToLogIn",
+      });
+      expect(loginSuccessHandlerService.run).not.toHaveBeenCalled();
+    });
+
+    it("returns an invalid passkey error when the auth result has no userId", async () => {
+      setupDependencies();
+      (webAuthnLoginService.logIn as jest.Mock).mockResolvedValue({
+        userId: null,
+        twoFactorProviders: null,
+      });
+
+      const result = await service.completeLogin();
+
+      expect(result).toEqual({
+        success: false,
+        errorMessage: "invalidPasskeyPleaseTryAgain",
+      });
+    });
+  });
+});

--- a/apps/browser/src/auth/services/login-with-passkey-result.service.ts
+++ b/apps/browser/src/auth/services/login-with-passkey-result.service.ts
@@ -1,0 +1,128 @@
+// eslint-disable-next-line no-restricted-imports -- This is an Angular service
+import { inject, Injectable } from "@angular/core";
+import { firstValueFrom } from "rxjs";
+
+import { LoginSuccessHandlerService } from "@bitwarden/auth/common";
+import { WebAuthnLoginPrfKeyServiceAbstraction } from "@bitwarden/common/auth/abstractions/webauthn/webauthn-login-prf-key.service.abstraction";
+import { WebAuthnLoginServiceAbstraction } from "@bitwarden/common/auth/abstractions/webauthn/webauthn-login.service.abstraction";
+import { WebAuthnLoginCredentialAssertionView } from "@bitwarden/common/auth/models/view/webauthn-login/webauthn-login-credential-assertion.view";
+import { WebAuthnLoginAssertionResponseRequest } from "@bitwarden/common/auth/services/webauthn-login/request/webauthn-login-assertion-response.request";
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+import { UserId } from "@bitwarden/common/types/guid";
+import { KeyService } from "@bitwarden/key-management";
+
+import { PasskeyRelayService, PasskeyLoginRelayResult } from "./passkey-relay.service";
+
+/** Outcome of completing a passkey login via the relay result popout. */
+export type PasskeyLoginOutcome =
+  | { success: true; userId: UserId }
+  | { success: false; errorMessage: string };
+
+/**
+ * Completes a passkey login that was relayed from the web-vault connector page.
+ */
+@Injectable({
+  providedIn: "root",
+})
+export class LoginWithPasskeyResultService {
+  private readonly passkeyRelayService = inject(PasskeyRelayService);
+  private readonly webAuthnLoginService = inject(WebAuthnLoginServiceAbstraction);
+  private readonly webAuthnLoginPrfKeyService = inject(WebAuthnLoginPrfKeyServiceAbstraction);
+  private readonly loginSuccessHandlerService = inject(LoginSuccessHandlerService);
+  private readonly keyService = inject(KeyService);
+  private readonly i18nService = inject(I18nService);
+  private readonly logService = inject(LogService);
+
+  /**
+   * Consumes the relayed passkey result, derives the PRF key, submits the assertion
+   * to the server, and runs post-login setup when vault decryption is available.
+   */
+  async completeLogin(): Promise<PasskeyLoginOutcome> {
+    this.logService.info("[PasskeyLogin] Starting completeLogin");
+
+    const relayResult = await this.passkeyRelayService.consumeResult();
+
+    if (!relayResult) {
+      this.logService.error("[PasskeyLogin] No relay result available");
+      return { success: false, errorMessage: this.i18nService.t("passkeyLoginTimeout") };
+    }
+
+    if (relayResult.type !== "login") {
+      this.logService.error("[PasskeyLogin] Unexpected result type:", relayResult.type);
+      return { success: false, errorMessage: this.i18nService.t("passkeyLoginTimeout") };
+    }
+
+    return this.processLogin(relayResult);
+  }
+
+  private async processLogin(relayResult: PasskeyLoginRelayResult): Promise<PasskeyLoginOutcome> {
+    const { token, assertionData, prfOutput } = relayResult;
+
+    this.logService.info("[PasskeyLogin] Parsing assertion data");
+
+    let parsedAssertion: Record<string, unknown>;
+    try {
+      parsedAssertion = JSON.parse(assertionData) as Record<string, unknown>;
+    } catch {
+      this.logService.error("[PasskeyLogin] Failed to parse assertionData");
+      return {
+        success: false,
+        errorMessage: this.i18nService.t("invalidPasskeyPleaseTryAgain"),
+      };
+    }
+
+    const deviceResponse = Object.assign(
+      Object.create(WebAuthnLoginAssertionResponseRequest.prototype),
+      parsedAssertion,
+    ) as WebAuthnLoginAssertionResponseRequest;
+
+    let prfKey = null;
+    if (prfOutput) {
+      this.logService.info("[PasskeyLogin] Deriving PRF key...");
+      try {
+        prfKey = await this.webAuthnLoginPrfKeyService.createSymmetricKeyFromPrf(prfOutput);
+      } finally {
+        // Zero the raw PRF bytes immediately after use
+        new Uint8Array(prfOutput).fill(0);
+      }
+      this.logService.info("[PasskeyLogin] PRF key derived successfully");
+    } else {
+      this.logService.info("[PasskeyLogin] No PRF output, continuing without vault decryption key");
+    }
+
+    const assertion = new WebAuthnLoginCredentialAssertionView(token, deviceResponse, prfKey);
+
+    this.logService.info("[PasskeyLogin] Calling webAuthnLoginService.logIn...");
+    const authResult = await this.webAuthnLoginService.logIn(assertion);
+    this.logService.info("[PasskeyLogin] Login result:", {
+      requiresTwoFactor: authResult.requiresTwoFactor,
+      userId: authResult.userId,
+    });
+
+    if (authResult.requiresTwoFactor) {
+      return {
+        success: false,
+        errorMessage: this.i18nService.t("twoFactorForPasskeysNotSupportedOnClientUpdateToLogIn"),
+      };
+    }
+
+    if (!authResult.userId) {
+      return {
+        success: false,
+        errorMessage: this.i18nService.t("invalidPasskeyPleaseTryAgain"),
+      };
+    }
+
+    // Only run the login success handler if the user has a decrypted user key.
+    this.logService.info("[PasskeyLogin] Checking user key...");
+    const userKey = await firstValueFrom(this.keyService.userKey$(authResult.userId));
+    this.logService.info("[PasskeyLogin] User key exists:", !!userKey);
+    if (userKey) {
+      this.logService.info("[PasskeyLogin] Running login success handler...");
+      await this.loginSuccessHandlerService.run(authResult.userId, null);
+    }
+
+    return { success: true, userId: authResult.userId };
+  }
+}

--- a/apps/browser/src/auth/services/passkey-relay.service.spec.ts
+++ b/apps/browser/src/auth/services/passkey-relay.service.spec.ts
@@ -1,0 +1,246 @@
+import { mock } from "jest-mock-extended";
+
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+
+import { PasskeyRelayService, PasskeyLoginRelayResult } from "./passkey-relay.service";
+
+describe("PasskeyRelayService", () => {
+  let service: PasskeyRelayService;
+  let logService: LogService;
+  let storageChangeListener: (changes: any, areaName: string) => void;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (chrome.storage as any).session = {
+      get: jest.fn(),
+      set: jest.fn(),
+      remove: jest.fn(),
+    };
+    (chrome.storage as any).onChanged = {
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+    };
+
+    logService = mock<LogService>();
+    service = new PasskeyRelayService(logService);
+    storageChangeListener = (chrome.storage.onChanged.addListener as jest.Mock).mock.calls[0][0];
+
+    // Clear construction-time calls but keep the captured listener
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("registers a chrome storage change listener on construction", () => {
+    expect(storageChangeListener).toBeDefined();
+  });
+
+  describe("storeResult", () => {
+    it("stores a login result with a serialized prfOutput", async () => {
+      const prfOutput = new Uint8Array([1, 2, 3]).buffer;
+      const result: PasskeyLoginRelayResult = {
+        type: "login",
+        token: "token",
+        assertionData: "assertion",
+        prfOutput,
+      };
+
+      await service.storeResult(result);
+
+      expect(chrome.storage.session.set).toHaveBeenCalledWith({
+        passkeyRelayResult: expect.objectContaining({
+          type: "login",
+          token: "token",
+          assertionData: "assertion",
+          prfOutput: [1, 2, 3],
+          timestamp: expect.any(Number),
+        }),
+      });
+    });
+
+    it("stores a result with a null prfOutput", async () => {
+      const result: PasskeyLoginRelayResult = {
+        type: "login",
+        token: "token",
+        assertionData: "assertion",
+        prfOutput: null,
+      };
+
+      await service.storeResult(result);
+
+      expect(chrome.storage.session.set).toHaveBeenCalledWith({
+        passkeyRelayResult: expect.objectContaining({
+          prfOutput: null,
+        }),
+      });
+    });
+  });
+
+  describe("consumeResult", () => {
+    it("returns the stored login result and clears it from storage", async () => {
+      const prfOutput = new Uint8Array([4, 5, 6]).buffer;
+      const stored = {
+        type: "login",
+        token: "token",
+        assertionData: "assertion",
+        prfOutput: Array.from(new Uint8Array(prfOutput)),
+        timestamp: Date.now(),
+      };
+      (chrome.storage.session.get as jest.Mock).mockResolvedValueOnce({
+        passkeyRelayResult: stored,
+      });
+
+      const result = await service.consumeResult();
+
+      expect(result).toEqual({
+        type: "login",
+        token: "token",
+        assertionData: "assertion",
+        prfOutput,
+      });
+      expect(chrome.storage.session.remove).toHaveBeenCalledWith("passkeyRelayResult");
+    });
+
+    it("returns the stored unlock result and clears it from storage", async () => {
+      const prfOutput = new Uint8Array([7, 8, 9]).buffer;
+      const stored = {
+        type: "unlock",
+        credentialId: "credential-id",
+        prfOutput: Array.from(new Uint8Array(prfOutput)),
+        timestamp: Date.now(),
+      };
+      (chrome.storage.session.get as jest.Mock).mockResolvedValueOnce({
+        passkeyRelayResult: stored,
+      });
+
+      const result = await service.consumeResult();
+
+      expect(result).toEqual({
+        type: "unlock",
+        credentialId: "credential-id",
+        prfOutput,
+      });
+      expect(chrome.storage.session.remove).toHaveBeenCalledWith("passkeyRelayResult");
+    });
+
+    it("waits for a storage change when no result is present initially", async () => {
+      const prfOutput = new Uint8Array([1, 2, 3]).buffer;
+      const stored = {
+        type: "login",
+        token: "token",
+        assertionData: "assertion",
+        prfOutput: Array.from(new Uint8Array(prfOutput)),
+        timestamp: Date.now(),
+      };
+      (chrome.storage.session.get as jest.Mock)
+        .mockResolvedValueOnce({})
+        .mockResolvedValueOnce({ passkeyRelayResult: stored });
+
+      const listener = storageChangeListener;
+      const consumePromise = service.consumeResult();
+
+      // Allow the service to start waiting for the storage change event
+      await Promise.resolve();
+
+      listener({ passkeyRelayResult: { newValue: stored } }, "session");
+
+      const result = await consumePromise;
+
+      expect(result).toEqual({
+        type: "login",
+        token: "token",
+        assertionData: "assertion",
+        prfOutput,
+      });
+    });
+
+    it("returns null when the storage change does not contain the relay key", async () => {
+      (chrome.storage.session.get as jest.Mock).mockResolvedValueOnce({});
+      jest.useFakeTimers();
+
+      const consumePromise = service.consumeResult();
+
+      await Promise.resolve();
+
+      storageChangeListener({ someOtherKey: { newValue: "value" } }, "session");
+
+      await jest.advanceTimersByTimeAsync(5000);
+
+      const result = await consumePromise;
+
+      expect(result).toBeNull();
+      expect(logService.error).toHaveBeenCalledWith("[PasskeyRelay] Timeout waiting for result");
+    });
+
+    it("returns null when the wait for a storage change times out", async () => {
+      (chrome.storage.session.get as jest.Mock).mockResolvedValueOnce({});
+      jest.useFakeTimers();
+
+      const consumePromise = service.consumeResult();
+
+      await jest.advanceTimersByTimeAsync(5000);
+
+      const result = await consumePromise;
+
+      expect(result).toBeNull();
+      expect(logService.error).toHaveBeenCalledWith("[PasskeyRelay] Timeout waiting for result");
+    });
+
+    it("returns null when there is no stored result after the change event", async () => {
+      (chrome.storage.session.get as jest.Mock).mockResolvedValueOnce({}).mockResolvedValueOnce({});
+
+      const consumePromise = service.consumeResult();
+
+      await Promise.resolve();
+
+      // A change event for the relay key resolves the wait even if storage is then empty
+      storageChangeListener({ passkeyRelayResult: { newValue: {} } }, "session");
+
+      const result = await consumePromise;
+
+      expect(result).toBeNull();
+      expect(logService.error).toHaveBeenCalledWith("[PasskeyRelay] No result found in storage");
+    });
+  });
+
+  describe("hasPendingResult", () => {
+    it("returns false when no result is stored", async () => {
+      (chrome.storage.session.get as jest.Mock).mockResolvedValueOnce({});
+
+      const result = await service.hasPendingResult();
+
+      expect(result).toBe(false);
+    });
+
+    it("returns true when a recently stored result exists", async () => {
+      (chrome.storage.session.get as jest.Mock).mockResolvedValueOnce({
+        passkeyRelayResult: { timestamp: Date.now() },
+      });
+
+      const result = await service.hasPendingResult();
+
+      expect(result).toBe(true);
+    });
+
+    it("clears an expired result and returns false", async () => {
+      (chrome.storage.session.get as jest.Mock).mockResolvedValueOnce({
+        passkeyRelayResult: { timestamp: Date.now() - 6 * 60 * 1000 },
+      });
+
+      const result = await service.hasPendingResult();
+
+      expect(result).toBe(false);
+      expect(chrome.storage.session.remove).toHaveBeenCalledWith("passkeyRelayResult");
+    });
+  });
+
+  describe("clearResult", () => {
+    it("removes the stored result", async () => {
+      await service.clearResult();
+
+      expect(chrome.storage.session.remove).toHaveBeenCalledWith("passkeyRelayResult");
+    });
+  });
+});

--- a/apps/browser/src/auth/services/passkey-relay.service.ts
+++ b/apps/browser/src/auth/services/passkey-relay.service.ts
@@ -1,0 +1,182 @@
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+
+import { BrowserApi } from "../../platform/browser/browser-api";
+
+/**
+ * Result type for passkey login relay.
+ */
+export interface PasskeyLoginRelayResult {
+  type: "login";
+  token: string;
+  assertionData: string;
+  prfOutput: ArrayBuffer | null;
+}
+
+/**
+ * Result type for passkey unlock relay.
+ */
+export interface PasskeyUnlockRelayResult {
+  type: "unlock";
+  credentialId: string;
+  prfOutput: ArrayBuffer;
+}
+
+/**
+ * Union type for all passkey relay results.
+ */
+export type PasskeyRelayResult = PasskeyLoginRelayResult | PasskeyUnlockRelayResult;
+
+/**
+ * Service for relaying passkey results between the background script
+ * and the popup. Uses chrome.storage.session for cross-context communication.
+ * Handles both login and unlock flows.
+ */
+export class PasskeyRelayService {
+  private readonly STORAGE_KEY = "passkeyRelayResult";
+  private storageChangeListener: ((changes: any, areaName: string) => void) | null = null;
+  private resolveStorageChange: (() => void) | null = null;
+
+  constructor(private logService: LogService) {
+    this.setupStorageListener();
+  }
+
+  private setupStorageListener(): void {
+    if (typeof chrome !== "undefined" && chrome.storage && chrome.storage.onChanged) {
+      this.storageChangeListener = (changes, areaName) => {
+        if (areaName === "session" && changes[this.STORAGE_KEY]) {
+          this.logService.info("[PasskeyRelay] Storage change detected");
+          this.resolveStorageChange?.();
+        }
+      };
+      BrowserApi.addListener(chrome.storage.onChanged, this.storageChangeListener);
+    }
+  }
+
+  /**
+   * Stores the relay result in chrome.storage.session.
+   * Called from the background after processing the passkey result.
+   */
+  async storeResult(result: PasskeyRelayResult): Promise<void> {
+    this.logService.info("[PasskeyRelay] Storing result in storage");
+
+    // Convert ArrayBuffer to array for JSON serialization
+    const storableResult = {
+      ...result,
+      prfOutput: result.prfOutput ? Array.from(new Uint8Array(result.prfOutput)) : null,
+      timestamp: Date.now(),
+    };
+
+    await chrome.storage.session.set({ [this.STORAGE_KEY]: storableResult });
+    this.logService.info("[PasskeyRelay] Result stored successfully");
+  }
+
+  /**
+   * Retrieves and clears the relay result.
+   * Called once from the result popout.
+   * @returns The stored result or null if none exists
+   */
+  async consumeResult(): Promise<PasskeyRelayResult | null> {
+    this.logService.info("[PasskeyRelay] Attempting to consume result");
+
+    // Check storage immediately first - the result may already be there
+    // because the background stores it before opening the popup
+    const data = await chrome.storage.session.get(this.STORAGE_KEY);
+    let storedResult = data[this.STORAGE_KEY];
+
+    if (!storedResult) {
+      // Result not yet in storage, wait for it with a short timeout
+      this.logService.info(
+        "[PasskeyRelay] Result not in storage yet, waiting for storage change...",
+      );
+      try {
+        await this.waitForStorageChange(5000); // 5 seconds timeout
+
+        // Try again after receiving the event
+        const dataAfterEvent = await chrome.storage.session.get(this.STORAGE_KEY);
+        storedResult = dataAfterEvent[this.STORAGE_KEY];
+      } catch {
+        this.logService.error("[PasskeyRelay] Timeout waiting for result");
+        return null;
+      }
+    }
+
+    if (!storedResult) {
+      this.logService.error("[PasskeyRelay] No result found in storage");
+      return null;
+    }
+
+    this.logService.info("[PasskeyRelay] Result found, converting format");
+
+    // Clear the result from storage
+    await chrome.storage.session.remove(this.STORAGE_KEY);
+
+    // Convert array back to ArrayBuffer
+    const prfOutput = storedResult.prfOutput ? new Uint8Array(storedResult.prfOutput).buffer : null;
+
+    // Reconstruct the result based on type
+    const result: PasskeyRelayResult =
+      storedResult.type === "login"
+        ? {
+            type: "login",
+            token: storedResult.token,
+            assertionData: storedResult.assertionData,
+            prfOutput,
+          }
+        : {
+            type: "unlock",
+            credentialId: storedResult.credentialId,
+            prfOutput: prfOutput as ArrayBuffer, // unlock always has prfOutput
+          };
+
+    this.logService.info("[PasskeyRelay] Result consumed successfully");
+    return result;
+  }
+
+  /**
+   * Waits for the storage change event with a timeout.
+   */
+  private waitForStorageChange(timeoutMs: number): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const timeoutId = setTimeout(() => {
+        this.resolveStorageChange = null;
+        reject(new Error("Timeout"));
+      }, timeoutMs);
+
+      this.resolveStorageChange = () => {
+        clearTimeout(timeoutId);
+        this.resolveStorageChange = null;
+        resolve();
+      };
+    });
+  }
+
+  /**
+   * Checks if there's a pending result available.
+   */
+  async hasPendingResult(): Promise<boolean> {
+    const data = await chrome.storage.session.get(this.STORAGE_KEY);
+    const storedResult = data[this.STORAGE_KEY];
+
+    if (!storedResult) {
+      return false;
+    }
+
+    // Check if result is expired (older than 5 minutes)
+    const maxAge = 5 * 60 * 1000; // 5 minutes
+    if (Date.now() - storedResult.timestamp > maxAge) {
+      await chrome.storage.session.remove(this.STORAGE_KEY);
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * Clears any pending result without consuming it.
+   * Used for cleanup (e.g., on timeout).
+   */
+  async clearResult(): Promise<void> {
+    this.logService.info("[PasskeyRelay] Clearing result from storage");
+    await chrome.storage.session.remove(this.STORAGE_KEY);
+  }
+}

--- a/apps/browser/src/auth/services/unlock-with-passkey-result.service.spec.ts
+++ b/apps/browser/src/auth/services/unlock-with-passkey-result.service.spec.ts
@@ -1,0 +1,250 @@
+// eslint-disable-next-line no-restricted-imports
+import { TestBed } from "@angular/core/testing";
+import { mock } from "jest-mock-extended";
+import { BehaviorSubject, of } from "rxjs";
+
+import { UserDecryptionOptionsServiceAbstraction } from "@bitwarden/auth/common";
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { WebAuthnLoginPrfKeyServiceAbstraction } from "@bitwarden/common/auth/abstractions/webauthn/webauthn-login-prf-key.service.abstraction";
+import { EncryptService } from "@bitwarden/common/key-management/crypto/abstractions/encrypt.service";
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+import { UserId } from "@bitwarden/common/types/guid";
+import { UserKey } from "@bitwarden/common/types/key";
+import { KeyService } from "@bitwarden/key-management";
+
+import { PasskeyRelayService, PasskeyUnlockRelayResult } from "./passkey-relay.service";
+import { UnlockWithPasskeyResultService } from "./unlock-with-passkey-result.service";
+
+describe("UnlockWithPasskeyResultService", () => {
+  let service: UnlockWithPasskeyResultService;
+  let passkeyRelayService: PasskeyRelayService;
+  let webAuthnLoginPrfKeyService: WebAuthnLoginPrfKeyServiceAbstraction;
+  let userDecryptionOptionsService: UserDecryptionOptionsServiceAbstraction;
+  let accountService: AccountService;
+  let encryptService: EncryptService;
+  let keyService: KeyService;
+  let i18nService: I18nService;
+  let logService: LogService;
+
+  const testUserId = "00000000-0000-0000-0000-000000000002" as UserId;
+  const credentialId = "credential-id";
+  const encryptedPrivateKey = "encrypted-private-key";
+  const encryptedUserKey = "encrypted-user-key";
+
+  const activeAccount$ = new BehaviorSubject<{ id: string | null; name: string }>({
+    id: testUserId,
+    name: "Test Account",
+  });
+
+  const decryptionOptions = {
+    webAuthnPrfOptions: [
+      {
+        credentialId,
+        encryptedPrivateKey,
+        encryptedUserKey,
+        transports: ["usb"],
+      },
+    ],
+  };
+
+  const prfKey = mock<UserKey>();
+  const privateKey = new Uint8Array([9, 8, 7]);
+  const userKey = mock<UserKey>();
+
+  beforeEach(() => {
+    passkeyRelayService = mock<PasskeyRelayService>();
+    webAuthnLoginPrfKeyService = mock<WebAuthnLoginPrfKeyServiceAbstraction>();
+    userDecryptionOptionsService = mock<UserDecryptionOptionsServiceAbstraction>();
+    accountService = mock<AccountService>();
+    encryptService = mock<EncryptService>();
+    keyService = mock<KeyService>();
+    i18nService = mock<I18nService>();
+    logService = mock<LogService>();
+
+    (accountService as any).activeAccount$ = activeAccount$;
+    (userDecryptionOptionsService.userDecryptionOptionsById$ as jest.Mock).mockReturnValue(
+      of(decryptionOptions),
+    );
+    (webAuthnLoginPrfKeyService.createSymmetricKeyFromPrf as jest.Mock).mockResolvedValue(prfKey);
+    (encryptService.unwrapDecapsulationKey as jest.Mock).mockResolvedValue(privateKey);
+    (encryptService.decapsulateKeyUnsigned as jest.Mock).mockResolvedValue(userKey);
+    i18nService.t = jest.fn((key: string) => key) as any;
+
+    TestBed.configureTestingModule({
+      providers: [
+        UnlockWithPasskeyResultService,
+        { provide: PasskeyRelayService, useValue: passkeyRelayService },
+        { provide: WebAuthnLoginPrfKeyServiceAbstraction, useValue: webAuthnLoginPrfKeyService },
+        {
+          provide: UserDecryptionOptionsServiceAbstraction,
+          useValue: userDecryptionOptionsService,
+        },
+        { provide: AccountService, useValue: accountService },
+        { provide: EncryptService, useValue: encryptService },
+        { provide: KeyService, useValue: keyService },
+        { provide: I18nService, useValue: i18nService },
+        { provide: LogService, useValue: logService },
+      ],
+    });
+
+    service = TestBed.inject(UnlockWithPasskeyResultService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    activeAccount$.next({ id: testUserId, name: "Test Account" });
+  });
+
+  it("creates the service", () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe("completeUnlock", () => {
+    const buildRelayResult = (prfOutput: ArrayBuffer): PasskeyUnlockRelayResult => ({
+      type: "unlock",
+      credentialId,
+      prfOutput,
+    });
+
+    it("returns a timeout error when there is no relay result", async () => {
+      (passkeyRelayService.consumeResult as jest.Mock).mockResolvedValue(null);
+
+      const result = await service.completeUnlock();
+
+      expect(result).toEqual({
+        success: false,
+        errorMessage: "passkeyUnlockTimeout",
+        canceled: false,
+      });
+    });
+
+    it("returns a timeout error when the relay result has the wrong type", async () => {
+      (passkeyRelayService.consumeResult as jest.Mock).mockResolvedValue({
+        type: "login",
+        token: "token",
+        assertionData: "data",
+        prfOutput: null,
+      } as any);
+
+      const result = await service.completeUnlock();
+
+      expect(result).toEqual({
+        success: false,
+        errorMessage: "passkeyUnlockTimeout",
+        canceled: false,
+      });
+    });
+
+    it("derives the PRF key, decrypts the user key, sets it, and zeros raw PRF bytes", async () => {
+      const prfOutput = new Uint8Array([1, 2, 3, 4]).buffer;
+      (passkeyRelayService.consumeResult as jest.Mock).mockResolvedValue(
+        buildRelayResult(prfOutput),
+      );
+
+      const result = await service.completeUnlock();
+
+      expect(result).toEqual({ success: true });
+      expect(webAuthnLoginPrfKeyService.createSymmetricKeyFromPrf).toHaveBeenCalledWith(prfOutput);
+      expect(new Uint8Array(prfOutput).every((byte) => byte === 0)).toBe(true);
+      expect(encryptService.unwrapDecapsulationKey).toHaveBeenCalled();
+      expect(encryptService.decapsulateKeyUnsigned).toHaveBeenCalled();
+      expect(keyService.setUserKey).toHaveBeenCalledWith(userKey, testUserId);
+    });
+
+    it("returns a canceled result when the unlock is canceled", async () => {
+      (passkeyRelayService.consumeResult as jest.Mock).mockResolvedValue(
+        buildRelayResult(new Uint8Array([1]).buffer),
+      );
+      (webAuthnLoginPrfKeyService.createSymmetricKeyFromPrf as jest.Mock).mockRejectedValue(
+        new Error("User canceled"),
+      );
+
+      const result = await service.completeUnlock();
+
+      expect(result).toEqual({ success: false, errorMessage: "", canceled: true });
+    });
+
+    it("returns the active account error when no active account exists", async () => {
+      activeAccount$.next({ id: null, name: "No active account" });
+      (passkeyRelayService.consumeResult as jest.Mock).mockResolvedValue(
+        buildRelayResult(new Uint8Array([1]).buffer),
+      );
+
+      const result = await service.completeUnlock();
+
+      expect(result).toEqual({
+        success: false,
+        errorMessage: "No active account found",
+        canceled: false,
+      });
+    });
+
+    it("returns an error when the user has no WebAuthn PRF options", async () => {
+      (passkeyRelayService.consumeResult as jest.Mock).mockResolvedValue(
+        buildRelayResult(new Uint8Array([1]).buffer),
+      );
+      (userDecryptionOptionsService.userDecryptionOptionsById$ as jest.Mock).mockReturnValue(
+        of({ webAuthnPrfOptions: undefined }),
+      );
+
+      const result = await service.completeUnlock();
+
+      expect(result).toEqual({
+        success: false,
+        errorMessage: "No WebAuthn PRF options available for user",
+        canceled: false,
+      });
+    });
+
+    it("returns an error when no matching credential is found", async () => {
+      (passkeyRelayService.consumeResult as jest.Mock).mockResolvedValue({
+        type: "unlock",
+        credentialId: "unknown-credential-id",
+        prfOutput: new Uint8Array([1]).buffer,
+      } as any);
+
+      const result = await service.completeUnlock();
+
+      expect(result).toEqual({
+        success: false,
+        errorMessage: "No matching WebAuthn PRF option found for this credential",
+        canceled: false,
+      });
+    });
+
+    it("returns a generic error message for unexpected failures", async () => {
+      (passkeyRelayService.consumeResult as jest.Mock).mockResolvedValue(
+        buildRelayResult(new Uint8Array([1]).buffer),
+      );
+      (encryptService.unwrapDecapsulationKey as jest.Mock).mockRejectedValue(
+        new Error("Decryption failed"),
+      );
+
+      const result = await service.completeUnlock();
+
+      expect(result).toEqual({
+        success: false,
+        errorMessage: "Decryption failed",
+        canceled: false,
+      });
+    });
+
+    it("falls back to the unexpectedError translation for non-Error throws", async () => {
+      (passkeyRelayService.consumeResult as jest.Mock).mockResolvedValue(
+        buildRelayResult(new Uint8Array([1]).buffer),
+      );
+      (encryptService.unwrapDecapsulationKey as jest.Mock).mockImplementation(() => {
+        throw "string-error";
+      });
+
+      const result = await service.completeUnlock();
+
+      expect(result).toEqual({
+        success: false,
+        errorMessage: "unexpectedError",
+        canceled: false,
+      });
+    });
+  });
+});

--- a/apps/browser/src/auth/services/unlock-with-passkey-result.service.ts
+++ b/apps/browser/src/auth/services/unlock-with-passkey-result.service.ts
@@ -1,0 +1,134 @@
+// eslint-disable-next-line no-restricted-imports -- This is an Angular service
+import { inject, Injectable } from "@angular/core";
+import { firstValueFrom } from "rxjs";
+
+import { UserDecryptionOptionsServiceAbstraction } from "@bitwarden/auth/common";
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { WebAuthnLoginPrfKeyServiceAbstraction } from "@bitwarden/common/auth/abstractions/webauthn/webauthn-login-prf-key.service.abstraction";
+import { EncryptService } from "@bitwarden/common/key-management/crypto/abstractions/encrypt.service";
+import { EncString } from "@bitwarden/common/key-management/crypto/models/enc-string";
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+import { UserId } from "@bitwarden/common/types/guid";
+import { UserKey } from "@bitwarden/common/types/key";
+import { KeyService } from "@bitwarden/key-management";
+
+import { PasskeyRelayService, PasskeyUnlockRelayResult } from "./passkey-relay.service";
+
+/** Outcome of completing a passkey unlock via the relay result popout. */
+export type PasskeyUnlockOutcome =
+  | { success: true }
+  | { success: false; errorMessage: string; canceled: boolean };
+
+/**
+ * Completes a passkey vault unlock that was relayed from the web-vault connector page.
+ */
+@Injectable({
+  providedIn: "root",
+})
+export class UnlockWithPasskeyResultService {
+  private readonly passkeyRelayService = inject(PasskeyRelayService);
+  private readonly webAuthnLoginPrfKeyService = inject(WebAuthnLoginPrfKeyServiceAbstraction);
+  private readonly userDecryptionOptionsService = inject(UserDecryptionOptionsServiceAbstraction);
+  private readonly accountService = inject(AccountService);
+  private readonly encryptService = inject(EncryptService);
+  private readonly keyService = inject(KeyService);
+  private readonly i18nService = inject(I18nService);
+  private readonly logService = inject(LogService);
+
+  /**
+   * Consumes the relayed unlock result, derives the PRF key, decrypts the user's
+   * private key and user key, and stores the user key.
+   */
+  async completeUnlock(): Promise<PasskeyUnlockOutcome> {
+    this.logService.info("[PasskeyUnlock] Starting completeUnlock");
+
+    const relayResult = await this.passkeyRelayService.consumeResult();
+
+    if (!relayResult) {
+      this.logService.error("[PasskeyUnlock] No relay result available");
+      return {
+        success: false,
+        errorMessage: this.i18nService.t("passkeyUnlockTimeout"),
+        canceled: false,
+      };
+    }
+
+    if (relayResult.type !== "unlock") {
+      this.logService.error("[PasskeyUnlock] Unexpected result type:", relayResult.type);
+      return {
+        success: false,
+        errorMessage: this.i18nService.t("passkeyUnlockTimeout"),
+        canceled: false,
+      };
+    }
+
+    try {
+      await this.processUnlock(relayResult);
+      this.logService.info("[PasskeyUnlock] Unlock complete");
+      return { success: true };
+    } catch (error) {
+      this.logService.error("[PasskeyUnlock] Error in completeUnlock:", error);
+
+      if (error instanceof Error && error.message.includes("canceled")) {
+        return { success: false, errorMessage: "", canceled: true };
+      }
+
+      return {
+        success: false,
+        errorMessage:
+          error instanceof Error ? error.message : this.i18nService.t("unexpectedError"),
+        canceled: false,
+      };
+    }
+  }
+
+  private async processUnlock(relayResult: PasskeyUnlockRelayResult): Promise<void> {
+    const { credentialId, prfOutput } = relayResult;
+
+    this.logService.info("[PasskeyUnlock] Deriving PRF key...");
+    const prfKey = await this.webAuthnLoginPrfKeyService.createSymmetricKeyFromPrf(prfOutput);
+    // Zero the raw PRF bytes immediately after use
+    new Uint8Array(prfOutput).fill(0);
+    this.logService.info("[PasskeyUnlock] PRF key derived successfully");
+
+    const activeAccount = await firstValueFrom(this.accountService.activeAccount$);
+    if (!activeAccount?.id) {
+      throw new Error("No active account found");
+    }
+    const userId = activeAccount.id as UserId;
+
+    this.logService.info("[PasskeyUnlock] Getting user decryption options...");
+    const userDecryptionOptions = await firstValueFrom(
+      this.userDecryptionOptionsService.userDecryptionOptionsById$(userId),
+    );
+
+    if (!userDecryptionOptions?.webAuthnPrfOptions) {
+      throw new Error("No WebAuthn PRF options available for user");
+    }
+
+    const prfOption = userDecryptionOptions.webAuthnPrfOptions.find(
+      (option: { credentialId: string }) => option.credentialId === credentialId,
+    );
+
+    if (!prfOption) {
+      throw new Error("No matching WebAuthn PRF option found for this credential");
+    }
+
+    const privateKey = await this.encryptService.unwrapDecapsulationKey(
+      new EncString(prfOption.encryptedPrivateKey),
+      prfKey,
+    );
+
+    const userKey = await this.encryptService.decapsulateKeyUnsigned(
+      new EncString(prfOption.encryptedUserKey),
+      privateKey,
+    );
+
+    if (!userKey) {
+      throw new Error("Failed to decrypt user key from private key");
+    }
+
+    await this.keyService.setUserKey(userKey as UserKey, userId);
+  }
+}

--- a/apps/browser/src/autofill/content/abstractions/content-message-handler.ts
+++ b/apps/browser/src/autofill/content/abstractions/content-message-handler.ts
@@ -8,6 +8,11 @@ type ContentMessageWindowData = {
   data?: string;
   remember?: boolean;
   url?: ExtensionPageUrls;
+  token?: string;
+  assertionData?: string;
+  encryptedPrfOutput?: { ciphertext: string; iv: string } | null;
+  connectorPublicKey?: string | null;
+  credentialId?: string;
 };
 type ContentMessageWindowEventParams = {
   data: ContentMessageWindowData;

--- a/apps/browser/src/autofill/content/content-message-handler.spec.ts
+++ b/apps/browser/src/autofill/content/content-message-handler.spec.ts
@@ -100,6 +100,52 @@ describe("ContentMessageHandler", () => {
         referrer: "localhost",
       });
     });
+
+    it("sends a passkeyLoginResult message", () => {
+      postWindowMessage(
+        {
+          command: "passkeyLoginResult",
+          token: "token",
+          assertionData: "assertionData",
+          encryptedPrfOutput: { ciphertext: "ciphertext", iv: "iv" },
+          connectorPublicKey: "connectorPublicKey",
+        },
+        "https://localhost/",
+        window,
+      );
+
+      expect(sendMessageSpy).toHaveBeenCalledWith({
+        command: "passkeyLoginResult",
+        token: "token",
+        assertionData: "assertionData",
+        encryptedPrfOutput: { ciphertext: "ciphertext", iv: "iv" },
+        connectorPublicKey: "connectorPublicKey",
+        referrer: "localhost",
+        type: "login",
+      });
+    });
+
+    it("sends a passkeyUnlockResult message", () => {
+      postWindowMessage(
+        {
+          command: "passkeyUnlockResult",
+          credentialId: "credentialId",
+          encryptedPrfOutput: { ciphertext: "ciphertext", iv: "iv" },
+          connectorPublicKey: "connectorPublicKey",
+        },
+        "https://localhost/",
+        window,
+      );
+
+      expect(sendMessageSpy).toHaveBeenCalledWith({
+        command: "passkeyUnlockResult",
+        credentialId: "credentialId",
+        encryptedPrfOutput: { ciphertext: "ciphertext", iv: "iv" },
+        connectorPublicKey: "connectorPublicKey",
+        referrer: "localhost",
+        type: "unlock",
+      });
+    });
   });
 
   describe("handled extension messages", () => {

--- a/apps/browser/src/autofill/content/content-message-handler.ts
+++ b/apps/browser/src/autofill/content/content-message-handler.ts
@@ -17,6 +17,10 @@ const windowMessageHandlers: ContentMessageWindowEventHandlers = {
     handleAuthResultMessage(data, referrer),
   webAuthnResult: ({ data, referrer }: { data: any; referrer: string }) =>
     handleWebAuthnResultMessage(data, referrer),
+  passkeyLoginResult: ({ data, referrer }: { data: any; referrer: string }) =>
+    handlePasskeyResultMessage(data, referrer, "login"),
+  passkeyUnlockResult: ({ data, referrer }: { data: any; referrer: string }) =>
+    handlePasskeyResultMessage(data, referrer, "unlock"),
   [VaultMessages.checkBwInstalled]: () => handleExtensionInstallCheck(),
   duoResult: ({ data, referrer }: { data: any; referrer: string }) =>
     handleDuoResultMessage(data, referrer),
@@ -76,6 +80,36 @@ async function handleDuoResultMessage(data: ContentMessageWindowData, referrer: 
 function handleWebAuthnResultMessage(data: ContentMessageWindowData, referrer: string) {
   const { command, remember } = data;
   sendExtensionRuntimeMessage({ command, data: data.data, remember, referrer });
+}
+
+/**
+ * Handles passkey result messages (login or unlock) from the window.
+ *
+ * @param data - Data from the window message
+ * @param referrer - The referrer of the window
+ * @param type - The type of passkey result ('login' or 'unlock')
+ */
+function handlePasskeyResultMessage(
+  data: ContentMessageWindowData,
+  referrer: string,
+  type: "login" | "unlock",
+) {
+  const { command, encryptedPrfOutput, connectorPublicKey } = data;
+
+  const basePayload = {
+    command,
+    encryptedPrfOutput,
+    connectorPublicKey,
+    referrer,
+    type,
+  };
+
+  const typeSpecificData =
+    type === "login"
+      ? { token: data.token, assertionData: data.assertionData }
+      : { credentialId: data.credentialId };
+
+  sendExtensionRuntimeMessage({ ...basePayload, ...typeSpecificData });
 }
 
 /** @deprecated use {@link handleOpenBrowserExtensionToUrlMessage} */

--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -331,6 +331,7 @@ import {
 import { ExtensionAuthRequestAnsweringService } from "../auth/services/auth-request-answering/extension-auth-request-answering.service";
 import { AuthStatusBadgeUpdaterService } from "../auth/services/auth-status-badge-updater.service";
 import { ExtensionLockService } from "../auth/services/extension-lock.service";
+import { PasskeyRelayService } from "../auth/services/passkey-relay.service";
 import { OverlayNotificationsBackground as OverlayNotificationsBackgroundInterface } from "../autofill/background/abstractions/overlay-notifications.background";
 import {
   OverlayBackground as OverlayBackgroundInterface,
@@ -1500,6 +1501,8 @@ export default class MainBackground {
       logoutService,
     );
 
+    const passkeyRelayService = new PasskeyRelayService(this.logService);
+
     this.runtimeBackground = new RuntimeBackground(
       this,
       this.autofillService,
@@ -1515,6 +1518,7 @@ export default class MainBackground {
       this.lockService,
       this.billingAccountProfileStateService,
       this.browserInitialInstallService,
+      passkeyRelayService,
     );
     this.nativeMessagingBackground = new NativeMessagingBackground(
       this.keyService,

--- a/apps/browser/src/background/runtime.background.spec.ts
+++ b/apps/browser/src/background/runtime.background.spec.ts
@@ -1,0 +1,243 @@
+import { webcrypto } from "crypto";
+
+import { mock } from "jest-mock-extended";
+
+import { LockService } from "@bitwarden/auth/common";
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { AutofillSettingsServiceAbstraction } from "@bitwarden/common/autofill/services/autofill-settings.service";
+import { BillingAccountProfileStateService } from "@bitwarden/common/billing/abstractions/account/billing-account-profile-state.service";
+import { ProcessReloadServiceAbstraction } from "@bitwarden/common/key-management/abstractions/process-reload.service";
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
+import { MessageListener } from "@bitwarden/common/platform/messaging";
+
+import { PasskeyRelayService } from "../auth/services/passkey-relay.service";
+import { AutofillService } from "../autofill/services/abstractions/autofill.service";
+import BrowserPopupUtils from "../platform/browser/browser-popup-utils";
+import { BrowserEnvironmentService } from "../platform/services/browser-environment.service";
+import BrowserInitialInstallService from "../platform/services/browser-initial-install.service";
+import { BrowserPlatformUtilsService } from "../platform/services/platform-utils/browser-platform-utils.service";
+
+import MainBackground from "./main.background";
+import RuntimeBackground from "./runtime.background";
+
+describe("RuntimeBackground passkey relay support", () => {
+  let runtimeBackground: RuntimeBackground;
+  let passkeyRelayService: PasskeyRelayService;
+  let logService: LogService;
+
+  const buildRuntimeBackground = () => {
+    return new RuntimeBackground(
+      mock<MainBackground>() as unknown as MainBackground,
+      mock<AutofillService>(),
+      mock<BrowserPlatformUtilsService>(),
+      mock<AutofillSettingsServiceAbstraction>(),
+      mock<ProcessReloadServiceAbstraction>(),
+      mock<BrowserEnvironmentService>(),
+      mock<MessagingService>(),
+      logService,
+      mock<ConfigService>(),
+      mock<MessageListener>(),
+      mock<AccountService>(),
+      mock<LockService>(),
+      mock<BillingAccountProfileStateService>(),
+      mock<BrowserInitialInstallService>(),
+      passkeyRelayService,
+    );
+  };
+
+  beforeAll(() => {
+    // Make Web Crypto available to RuntimeBackground, which uses the global crypto object.
+    Object.defineProperty(globalThis, "crypto", { value: webcrypto });
+    Object.defineProperty(globalThis, "CryptoKey", { value: webcrypto.CryptoKey });
+
+    // RuntimeBackground wires up several extension event listeners in its constructor.
+    const chromeRuntime = (global as any).chrome.runtime;
+    chromeRuntime.onInstalled = { addListener: jest.fn() };
+    (global as any).chrome.permissions = {
+      ...((global as any).chrome.permissions ?? {}),
+      onAdded: { addListener: jest.fn() },
+    };
+  });
+
+  beforeEach(() => {
+    passkeyRelayService = mock<PasskeyRelayService>();
+    logService = mock<LogService>();
+    runtimeBackground = buildRuntimeBackground();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("initiatePasskeyRelay", () => {
+    it("generates an ECDH key pair and returns the base64url-encoded public key", async () => {
+      const publicKey = await runtimeBackground.initiatePasskeyRelay();
+
+      expect(publicKey).toBeTruthy();
+      expect(publicKey).not.toContain("+");
+      expect(publicKey).not.toContain("/");
+      expect(publicKey).not.toContain("=");
+    });
+
+    it("stores a pending session with a private key and a future expiry", async () => {
+      const now = Date.now();
+      jest.spyOn(Date, "now").mockReturnValue(now);
+
+      await runtimeBackground.initiatePasskeyRelay();
+
+      const session = (runtimeBackground as any).pendingPasskeyLoginEcdhSession;
+      expect(session).toBeTruthy();
+      expect(session.privateKey.type).toBe("private");
+      expect(session.expiresAt).toBeGreaterThan(now);
+      expect(session.expiresAt).toBeLessThanOrEqual(now + 5 * 60 * 1000);
+    });
+
+    it("replaces any existing pending session", async () => {
+      const originalPrivateKey = {} as CryptoKey;
+      (runtimeBackground as any).pendingPasskeyLoginEcdhSession = {
+        privateKey: originalPrivateKey,
+        expiresAt: Date.now() + 1000,
+      };
+
+      await runtimeBackground.initiatePasskeyRelay();
+      const session2 = (runtimeBackground as any).pendingPasskeyLoginEcdhSession;
+
+      expect(session2.privateKey).not.toBe(originalPrivateKey);
+      expect(session2.privateKey.type).toBe("private");
+    });
+  });
+
+  describe("handlePasskeyResult", () => {
+    const validLoginMsg = {
+      type: "login" as const,
+      token: "login-token",
+      assertionData: "{}",
+      referrer: "https://vault.bitwarden.com",
+    };
+
+    const validUnlockMsg = {
+      type: "unlock" as const,
+      credentialId: "credential-id",
+      referrer: "https://vault.bitwarden.com",
+    };
+
+    const setValidSession = () => {
+      (runtimeBackground as any).pendingPasskeyLoginEcdhSession = {
+        privateKey: {} as CryptoKey,
+        expiresAt: Date.now() + 60 * 1000,
+      };
+    };
+
+    beforeEach(() => {
+      (passkeyRelayService.storeResult as jest.Mock).mockResolvedValue(undefined);
+      jest.spyOn(BrowserPopupUtils as any, "openPopout").mockResolvedValue(undefined);
+    });
+
+    it("stores a login result and opens the login result popout", async () => {
+      setValidSession();
+
+      await (runtimeBackground as any).handlePasskeyResult(validLoginMsg);
+
+      expect(passkeyRelayService.storeResult).toHaveBeenCalledWith({
+        type: "login",
+        token: validLoginMsg.token,
+        assertionData: validLoginMsg.assertionData,
+        prfOutput: null,
+      });
+      expect(BrowserPopupUtils.openPopout).toHaveBeenCalledWith(
+        "popup/index.html#/login-with-passkey-result",
+        { singleActionKey: "auth_passkeyResult" },
+      );
+    });
+
+    it("stores an unlock result and opens the unlock result popout", async () => {
+      setValidSession();
+
+      await (runtimeBackground as any).handlePasskeyResult(validUnlockMsg);
+
+      expect(passkeyRelayService.storeResult).toHaveBeenCalledWith({
+        type: "unlock",
+        credentialId: validUnlockMsg.credentialId,
+        prfOutput: null,
+      });
+      expect(BrowserPopupUtils.openPopout).toHaveBeenCalledWith(
+        "popup/index.html#/unlock-with-passkey-result",
+        { singleActionKey: "auth_passkeyResult" },
+      );
+    });
+
+    it("passes decrypted PRF output through to the unlock result", async () => {
+      setValidSession();
+      const decryptedPrf = new Uint8Array([1, 2, 3]).buffer;
+      jest.spyOn(runtimeBackground as any, "decryptPrfOutput").mockResolvedValue(decryptedPrf);
+
+      await (runtimeBackground as any).handlePasskeyResult({
+        ...validUnlockMsg,
+        encryptedPrfOutput: { ciphertext: "cipher", iv: "iv" },
+        connectorPublicKey: "connector-key",
+      });
+
+      expect(passkeyRelayService.storeResult).toHaveBeenCalledWith({
+        type: "unlock",
+        credentialId: validUnlockMsg.credentialId,
+        prfOutput: decryptedPrf,
+      });
+    });
+
+    it("does nothing when no passkey session is pending", async () => {
+      await (runtimeBackground as any).handlePasskeyResult(validLoginMsg);
+
+      expect(passkeyRelayService.storeResult).not.toHaveBeenCalled();
+      expect(BrowserPopupUtils.openPopout).not.toHaveBeenCalled();
+      expect(logService.error).toHaveBeenCalledWith(
+        "[PasskeyLogin] No pending passkey session or session expired",
+      );
+    });
+
+    it("does nothing when the pending passkey session is expired", async () => {
+      (runtimeBackground as any).pendingPasskeyLoginEcdhSession = {
+        privateKey: {} as CryptoKey,
+        expiresAt: Date.now() - 1000,
+      };
+
+      await (runtimeBackground as any).handlePasskeyResult(validLoginMsg);
+
+      expect(passkeyRelayService.storeResult).not.toHaveBeenCalled();
+      expect(BrowserPopupUtils.openPopout).not.toHaveBeenCalled();
+    });
+
+    it("decrypts encrypted PRF output and passes it to the relay service", async () => {
+      setValidSession();
+      const decryptedPrf = new Uint8Array([1, 2, 3]).buffer;
+      const decryptSpy = jest
+        .spyOn(runtimeBackground as any, "decryptPrfOutput")
+        .mockResolvedValue(decryptedPrf);
+
+      await (runtimeBackground as any).handlePasskeyResult({
+        ...validLoginMsg,
+        encryptedPrfOutput: { ciphertext: "cipher", iv: "iv" },
+        connectorPublicKey: "connector-key",
+      });
+
+      expect(decryptSpy).toHaveBeenCalledWith("cipher", "iv", "connector-key");
+      expect(passkeyRelayService.storeResult).toHaveBeenCalledWith({
+        type: "login",
+        token: validLoginMsg.token,
+        assertionData: validLoginMsg.assertionData,
+        prfOutput: decryptedPrf,
+      });
+    });
+
+    it("clears the pending session even when an error occurs", async () => {
+      setValidSession();
+      (passkeyRelayService.storeResult as jest.Mock).mockRejectedValue(new Error("storage error"));
+
+      await (runtimeBackground as any).handlePasskeyResult(validLoginMsg);
+
+      expect((runtimeBackground as any).pendingPasskeyLoginEcdhSession).toBeNull();
+      expect(logService.error).toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/browser/src/background/runtime.background.ts
+++ b/apps/browser/src/background/runtime.background.ts
@@ -21,9 +21,11 @@ import { BiometricsCommands } from "@bitwarden/key-management";
 // eslint-disable-next-line no-restricted-imports
 import {
   closeUnlockPopout,
+  openPasskeyResultPopout,
   openSsoAuthResultPopout,
   openTwoFactorAuthWebAuthnPopout,
 } from "../auth/popup/utils/auth-popout-window";
+import { PasskeyRelayService } from "../auth/services/passkey-relay.service";
 import { LockedVaultPendingNotificationsData } from "../autofill/background/abstractions/notification.background";
 import { AutofillService } from "../autofill/services/abstractions/autofill.service";
 import { FORCE_TARGETING_RULES_UPDATE_COMMAND } from "../autofill/services/targeting-rules-data.service";
@@ -43,6 +45,10 @@ export default class RuntimeBackground {
   private pageDetailsToAutoFill: any[] = [];
   private onInstalledReason: string = null;
   private lockedVaultPendingNotifications: LockedVaultPendingNotificationsData[] = [];
+  private pendingPasskeyLoginEcdhSession: {
+    privateKey: CryptoKey;
+    expiresAt: number;
+  } | null = null;
 
   constructor(
     private main: MainBackground,
@@ -59,6 +65,7 @@ export default class RuntimeBackground {
     private readonly lockService: LockService,
     private billingAccountProfileStateService: BillingAccountProfileStateService,
     private browserInitialInstallService: BrowserInitialInstallService,
+    private passkeyRelayService: PasskeyRelayService,
   ) {
     // onInstalled listener must be wired up before anything else, so we do it in the ctor
     chrome.runtime.onInstalled.addListener((details: any) => {
@@ -98,6 +105,7 @@ export default class RuntimeBackground {
         BiometricsCommands.CanEnableBiometricUnlock,
         "getUserPremiumStatus",
         "getUrlAutofillTargetingRules",
+        "initiatePasskeyRelay",
       ];
 
       if (messagesWithResponse.includes(msg.command)) {
@@ -264,6 +272,9 @@ export default class RuntimeBackground {
         }
         break;
       }
+      case "initiatePasskeyRelay": {
+        return await this.initiatePasskeyRelay();
+      }
     }
   }
 
@@ -398,6 +409,16 @@ export default class RuntimeBackground {
         }
 
         await openTwoFactorAuthWebAuthnPopout(msg);
+        break;
+      }
+      case "passkeyLoginResult":
+      case "passkeyUnlockResult": {
+        if (!(await this.isValidVaultReferrer(msg.referrer))) {
+          return;
+        }
+
+        const type = msg.command === "passkeyLoginResult" ? "login" : "unlock";
+        await this.handlePasskeyResult({ ...msg, type });
         break;
       }
       case "reloadPopup":
@@ -590,5 +611,224 @@ export default class RuntimeBackground {
         clearInterval(interval);
       }
     }, 200);
+  }
+
+  /**
+   * Handles passkey result messages (login or unlock) from the connector page.
+   * Decrypts the PRF output using ECDH and opens the appropriate result popout.
+   */
+  private async handlePasskeyResult(msg: {
+    type: "login" | "unlock";
+    token?: string;
+    assertionData?: string;
+    credentialId?: string;
+    encryptedPrfOutput?: { ciphertext: string; iv: string } | null;
+    connectorPublicKey?: string | null;
+    referrer: string;
+  }): Promise<void> {
+    const login = msg.type === "login";
+    const logPrefix = login ? "[PasskeyLogin]" : "[PasskeyUnlock]";
+
+    // Use unified popout function
+    const popoutType = login ? "login" : "unlock";
+
+    try {
+      this.logService.info(`${logPrefix} handlePasskeyResult called`);
+
+      // Check if there's a pending ECDH session and it's not expired
+      if (
+        !this.pendingPasskeyLoginEcdhSession ||
+        Date.now() > this.pendingPasskeyLoginEcdhSession.expiresAt
+      ) {
+        this.logService.error(`${logPrefix} No pending passkey session or session expired`);
+        return;
+      }
+
+      this.logService.info(`${logPrefix} ECDH session valid, processing result...`);
+
+      let prfOutput: ArrayBuffer | null = null;
+
+      // Decrypt PRF output if present
+      if (msg.encryptedPrfOutput && msg.connectorPublicKey) {
+        this.logService.info(`${logPrefix} Decrypting PRF output...`);
+        prfOutput = await this.decryptPrfOutput(
+          msg.encryptedPrfOutput.ciphertext,
+          msg.encryptedPrfOutput.iv,
+          msg.connectorPublicKey,
+        );
+        this.logService.info(`${logPrefix} PRF output decrypted successfully`);
+      } else {
+        this.logService.info(`${logPrefix} No encrypted PRF output to decrypt`);
+      }
+
+      this.logService.info(`${logPrefix} Storing result in relay service...`);
+
+      // Store the result in the relay service for the popout to consume
+      if (login) {
+        await this.passkeyRelayService.storeResult({
+          type: "login",
+          token: msg.token!,
+          assertionData: msg.assertionData!,
+          prfOutput,
+        });
+      } else {
+        await this.passkeyRelayService.storeResult({
+          type: "unlock",
+          credentialId: msg.credentialId!,
+          prfOutput: prfOutput as ArrayBuffer, // unlock always requires PRF output
+        });
+      }
+
+      this.logService.info(`${logPrefix} Opening result popout...`);
+      // Open the result popout
+      await openPasskeyResultPopout(popoutType);
+      this.logService.info(`${logPrefix} Result popout opened successfully`);
+    } catch (error) {
+      this.logService.error(`${logPrefix} Error handling passkey result`, error);
+    } finally {
+      // Always discard the ephemeral ECDH private key, even on failure. CryptoKey objects
+      // cannot be explicitly zeroed in JavaScript; removing the only reference is the best
+      // available mitigation.
+      this.pendingPasskeyLoginEcdhSession = null;
+    }
+  }
+
+  /**
+   * Decrypts the PRF output using ECDH key exchange.
+   */
+  private async decryptPrfOutput(
+    ciphertextB64: string,
+    ivB64: string,
+    connectorPublicKeyB64: string,
+  ): Promise<ArrayBuffer> {
+    if (!this.pendingPasskeyLoginEcdhSession) {
+      throw new Error("No pending ECDH session");
+    }
+
+    // Convert base64url to ArrayBuffer
+    const ciphertext = this.base64urlToBuffer(ciphertextB64);
+    const iv = this.base64urlToBuffer(ivB64);
+    const connectorPublicKeyBuffer = this.base64urlToBuffer(connectorPublicKeyB64);
+
+    // Import connector's public key
+    const connectorPublicKey = await crypto.subtle.importKey(
+      "raw",
+      connectorPublicKeyBuffer,
+      {
+        name: "ECDH",
+        namedCurve: "P-256",
+      },
+      false,
+      [],
+    );
+
+    // Derive shared secret using ECDH
+    const sharedSecret = await crypto.subtle.deriveBits(
+      {
+        name: "ECDH",
+        public: connectorPublicKey,
+      },
+      this.pendingPasskeyLoginEcdhSession.privateKey,
+      256,
+    );
+
+    // Derive AES-GCM key from shared secret using HKDF
+    const aesKey = await this.deriveAesKeyFromSharedSecret(sharedSecret);
+
+    // Decrypt the PRF output
+    const decrypted = await crypto.subtle.decrypt(
+      {
+        name: "AES-GCM",
+        iv: new Uint8Array(iv),
+      },
+      aesKey,
+      ciphertext,
+    );
+
+    return decrypted;
+  }
+
+  /**
+   * Derive AES-GCM key from shared secret using HKDF.
+   */
+  private async deriveAesKeyFromSharedSecret(sharedSecret: ArrayBuffer): Promise<CryptoKey> {
+    const keyMaterial = await crypto.subtle.importKey("raw", sharedSecret, "HKDF", false, [
+      "deriveKey",
+    ]);
+
+    return await crypto.subtle.deriveKey(
+      {
+        name: "HKDF",
+        salt: new Uint8Array(0), // Empty salt - the shared secret is already random
+        info: new TextEncoder().encode("passkey-login-prf"),
+        hash: "SHA-256",
+      },
+      keyMaterial,
+      {
+        name: "AES-GCM",
+        length: 256,
+      },
+      false,
+      ["decrypt"],
+    );
+  }
+
+  /**
+   * Convert base64url string to ArrayBuffer.
+   */
+  private base64urlToBuffer(base64url: string): ArrayBuffer {
+    const base64 = base64url.replace(/-/g, "+").replace(/_/g, "/");
+    const padding = "=".repeat((4 - (base64.length % 4)) % 4);
+    const padded = base64 + padding;
+    const binary = atob(padded);
+    const buffer = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) {
+      buffer[i] = binary.charCodeAt(i);
+    }
+    return buffer.buffer;
+  }
+
+  /**
+   * Initiates a passkey relay session by generating an ephemeral ECDH key pair.
+   * Called when the user clicks "Log in with passkey" or "Unlock with passkey" on Firefox.
+   *
+   * @returns The base64url-encoded public key to pass to the connector page
+   */
+  async initiatePasskeyRelay(): Promise<string> {
+    // Discard any previous session private key to avoid retaining stale key material.
+    this.pendingPasskeyLoginEcdhSession = null;
+
+    // Generate ephemeral ECDH key pair (P-256)
+    const keyPair = await crypto.subtle.generateKey(
+      {
+        name: "ECDH",
+        namedCurve: "P-256",
+      },
+      true, // extractable - we need to export the public key
+      ["deriveBits"],
+    );
+
+    // Store the private key with 5-minute expiry
+    this.pendingPasskeyLoginEcdhSession = {
+      privateKey: keyPair.privateKey,
+      expiresAt: Date.now() + 5 * 60 * 1000, // 5 minutes
+    };
+
+    // Export and return the public key
+    const publicKeyBuffer = await crypto.subtle.exportKey("raw", keyPair.publicKey);
+    return this.bufferToBase64url(publicKeyBuffer);
+  }
+
+  /**
+   * Convert ArrayBuffer to base64url string.
+   */
+  private bufferToBase64url(buffer: ArrayBuffer): string {
+    const bytes = new Uint8Array(buffer);
+    let binary = "";
+    for (let i = 0; i < bytes.byteLength; i++) {
+      binary += String.fromCharCode(bytes[i]);
+    }
+    const base64 = btoa(binary);
+    return base64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
   }
 }

--- a/apps/browser/src/popup/app-routing.module.ts
+++ b/apps/browser/src/popup/app-routing.module.ts
@@ -22,6 +22,7 @@ import {
   DevicesIcon,
   TwoFactorTimeoutIcon,
   TwoFactorAuthEmailIcon,
+  TwoFactorAuthSecurityKeyIcon,
   UserLockIcon,
   VaultIcon,
   LockIcon,
@@ -55,9 +56,11 @@ import { AccountSwitcherComponent } from "../auth/popup/account-switching/accoun
 import { AuthExtensionRoute } from "../auth/popup/constants/auth-extension-route.constant";
 import { fido2AuthGuard } from "../auth/popup/guards/fido2-auth.guard";
 import { platformPopoutGuard } from "../auth/popup/guards/platform-popout.guard";
+import { LoginWithPasskeyResultComponent } from "../auth/popup/login-with-passkey-result/login-with-passkey-result.component";
 import { AccountSecurityComponent } from "../auth/popup/settings/account-security.component";
 import { ChangePasswordPageComponent } from "../auth/popup/settings/change-password-page.component";
 import { ExtensionDeviceManagementComponent } from "../auth/popup/settings/extension-device-management.component";
+import { UnlockWithPasskeyResultComponent } from "../auth/popup/unlock-with-passkey-result/unlock-with-passkey-result.component";
 import { AutofillTriageComponent } from "../autofill/popup/autofill-triage/autofill-triage.component";
 import { Fido2Component } from "../autofill/popup/fido2/fido2.component";
 import { AutofillComponent } from "../autofill/popup/settings/autofill.component";
@@ -659,6 +662,30 @@ const routes: Routes = [
           },
         ],
         canActivate: [authGuard],
+      },
+      {
+        path: "login-with-passkey-result",
+        canActivate: [unauthGuardFn(unauthRouteOverrides)],
+        data: {
+          pageIcon: TwoFactorAuthSecurityKeyIcon,
+          pageTitle: {
+            key: "loggingIn",
+          },
+          elevation: 1,
+        } satisfies RouteDataProperties & ExtensionAnonLayoutWrapperData,
+        children: [{ path: "", component: LoginWithPasskeyResultComponent }],
+      },
+      {
+        path: "unlock-with-passkey-result",
+        canActivate: [lockGuard()],
+        data: {
+          pageIcon: TwoFactorAuthSecurityKeyIcon,
+          pageTitle: {
+            key: "unlocking",
+          },
+          elevation: 1,
+        } satisfies RouteDataProperties & ExtensionAnonLayoutWrapperData,
+        children: [{ path: "", component: UnlockWithPasskeyResultComponent }],
       },
     ],
   },

--- a/apps/browser/src/popup/services/services.module.ts
+++ b/apps/browser/src/popup/services/services.module.ts
@@ -5,7 +5,6 @@ import { merge, of, Subject } from "rxjs";
 
 import { CollectionService } from "@bitwarden/admin-console/common";
 import { DeviceManagementComponentServiceAbstraction } from "@bitwarden/angular/auth/device-management/device-management-component.service.abstraction";
-import { LoginViaWebAuthnComponentService } from "@bitwarden/angular/auth/login-via-webauthn/login-via-webauthn-component.service";
 import { ChangePasswordService } from "@bitwarden/angular/auth/password-management/change-password";
 import { AngularThemingService } from "@bitwarden/angular/platform/services/theming/angular-theming.service";
 import { SafeProvider, safeProvider } from "@bitwarden/angular/platform/utils/safe-provider";
@@ -37,6 +36,7 @@ import {
   TwoFactorAuthWebAuthnComponentService,
   SsoComponentService,
   NewDeviceVerificationComponentService,
+  LoginViaWebAuthnComponentService,
 } from "@bitwarden/auth/angular";
 import {
   LockService,
@@ -176,6 +176,7 @@ import {
   DefaultWebAuthnPrfUnlockService,
   SessionTimeoutSettingsComponentService,
   KeyManagementUiModule,
+  UnlockViaWebAuthnComponentService,
 } from "@bitwarden/key-management-ui";
 import { DerivedStateProvider, GlobalStateProvider, StateProvider } from "@bitwarden/state";
 import { InlineDerivedStateProvider } from "@bitwarden/state-internal";
@@ -189,13 +190,15 @@ import { AccountSwitcherService } from "../../auth/popup/account-switching/servi
 import { ForegroundLockService } from "../../auth/popup/accounts/foreground-lock.service";
 import { ExtensionChangePasswordService } from "../../auth/popup/change-password/extension-change-password.service";
 import { ExtensionLoginComponentService } from "../../auth/popup/login/extension-login-component.service";
-import { ExtensionLoginViaWebAuthnComponentService } from "../../auth/popup/login/extension-login-via-webauthn-component.service";
 import { ExtensionSsoComponentService } from "../../auth/popup/login/extension-sso-component.service";
 import { ExtensionLogoutService } from "../../auth/popup/logout/extension-logout.service";
 import { ExtensionDeviceManagementComponentService } from "../../auth/services/extension-device-management-component.service";
+import { ExtensionLoginViaWebAuthnComponentService } from "../../auth/services/extension-login-via-webauthn-component.service";
 import { ExtensionTwoFactorAuthComponentService } from "../../auth/services/extension-two-factor-auth-component.service";
 import { ExtensionTwoFactorAuthDuoComponentService } from "../../auth/services/extension-two-factor-auth-duo-component.service";
 import { ExtensionTwoFactorAuthWebAuthnComponentService } from "../../auth/services/extension-two-factor-auth-webauthn-component.service";
+import { ExtensionUnlockViaWebAuthnComponentService } from "../../auth/services/extension-unlock-via-webauthn-component.service";
+import { PasskeyRelayService } from "../../auth/services/passkey-relay.service";
 import { AutofillService as AutofillServiceAbstraction } from "../../autofill/services/abstractions/autofill.service";
 import AutofillService from "../../autofill/services/autofill.service";
 import { InlineMenuFieldQualificationService } from "../../autofill/services/inline-menu-field-qualification.service";
@@ -636,6 +639,11 @@ const safeProviders: SafeProvider[] = [
     deps: [],
   }),
   safeProvider({
+    provide: LoginViaWebAuthnComponentService,
+    useClass: ExtensionLoginViaWebAuthnComponentService,
+    deps: [PlatformUtilsService, EnvironmentService],
+  }),
+  safeProvider({
     provide: TwoFactorAuthDuoComponentService,
     useClass: ExtensionTwoFactorAuthDuoComponentService,
     deps: [
@@ -682,6 +690,18 @@ const safeProviders: SafeProvider[] = [
       PlatformUtilsService,
       WINDOW,
       LogService,
+      ConfigService,
+      UnlockViaWebAuthnComponentService,
+    ],
+  }),
+  safeProvider({
+    provide: UnlockViaWebAuthnComponentService,
+    useClass: ExtensionUnlockViaWebAuthnComponentService,
+    deps: [
+      PlatformUtilsService,
+      EnvironmentService,
+      AccountService,
+      UserDecryptionOptionsServiceAbstraction,
     ],
   }),
   safeProvider({
@@ -729,7 +749,7 @@ const safeProviders: SafeProvider[] = [
   safeProvider({
     provide: LoginViaWebAuthnComponentService,
     useClass: ExtensionLoginViaWebAuthnComponentService,
-    deps: [],
+    deps: [PlatformUtilsService, EnvironmentService],
   }),
   safeProvider({
     provide: LockService,
@@ -841,6 +861,11 @@ const safeProviders: SafeProvider[] = [
     provide: AUTO_CONFIRM_NUDGE_SERVICE as SafeInjectionToken<AutoConfirmNudgeService>,
     useClass: AutoConfirmNudgeService,
     deps: [StateProvider, AutomaticUserConfirmationService],
+  }),
+  safeProvider({
+    provide: PasskeyRelayService,
+    useFactory: (logService: LogService) => new PasskeyRelayService(logService),
+    deps: [LogService],
   }),
 ];
 

--- a/apps/web/src/app/core/core.module.ts
+++ b/apps/web/src/app/core/core.module.ts
@@ -12,8 +12,6 @@ import {
   OrganizationUserApiService,
   OrganizationUserService,
 } from "@bitwarden/admin-console/common";
-import { DefaultLoginViaWebAuthnComponentService } from "@bitwarden/angular/auth/login-via-webauthn/default-login-via-webauthn-component.service";
-import { LoginViaWebAuthnComponentService } from "@bitwarden/angular/auth/login-via-webauthn/login-via-webauthn-component.service";
 import { ChangePasswordService } from "@bitwarden/angular/auth/password-management/change-password";
 import { SetInitialPasswordService } from "@bitwarden/angular/auth/password-management/set-initial-password/set-initial-password.service.abstraction";
 import { PremiumInterestStateService } from "@bitwarden/angular/billing/services/premium-interest/premium-interest-state.service.abstraction";
@@ -34,8 +32,10 @@ import {
 } from "@bitwarden/angular/services/injection-tokens";
 import { JslibServicesModule } from "@bitwarden/angular/services/jslib-services.module";
 import {
+  DefaultLoginViaWebAuthnComponentService,
   LoginComponentService,
   LoginDecryptionOptionsService,
+  LoginViaWebAuthnComponentService,
   RegistrationFinishService as RegistrationFinishServiceAbstraction,
   SsoComponentService,
   TwoFactorAuthDuoComponentService,
@@ -139,6 +139,8 @@ import {
   DefaultWebAuthnPrfUnlockService,
   SessionTimeoutSettingsComponentService,
   KeyManagementUiModule,
+  UnlockViaWebAuthnComponentService,
+  DefaultUnlockViaWebAuthnComponentService,
 } from "@bitwarden/key-management-ui";
 import { SerializedMemoryStorageService } from "@bitwarden/storage-core";
 import { UnlockService } from "@bitwarden/unlock";
@@ -540,7 +542,14 @@ const safeProviders: SafeProvider[] = [
       PlatformUtilsService,
       WINDOW,
       LogService,
+      ConfigService,
+      UnlockViaWebAuthnComponentService,
     ],
+  }),
+  safeProvider({
+    provide: UnlockViaWebAuthnComponentService,
+    useClass: DefaultUnlockViaWebAuthnComponentService,
+    deps: [],
   }),
   safeProvider({
     provide: ChangeEmailService,
@@ -552,6 +561,11 @@ const safeProviders: SafeProvider[] = [
       ApiService,
       KeyServiceAbstraction,
     ],
+  }),
+  safeProvider({
+    provide: LoginViaWebAuthnComponentService,
+    useClass: DefaultLoginViaWebAuthnComponentService,
+    deps: [],
   }),
 ];
 

--- a/apps/web/src/connectors/passkey-connector.html
+++ b/apps/web/src/connectors/passkey-connector.html
@@ -1,0 +1,124 @@
+<!doctype html>
+<html class="theme_light tw-h-full" lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+
+    <title>Bitwarden Passkey Login Connector</title>
+  </head>
+
+  <body class="tw-min-h-full !tw-min-w-0 tw-text-center !tw-bg-background-alt">
+    <main class="tw-flex tw-w-full tw-mx-auto tw-flex-col tw-px-6 tw-pt-6 tw-pb-4 tw-text-main">
+      <a href="#" class="tw-w-[128px] tw-block tw-mb-12 [&>*]:tw-align-top" aria-label="Bitwarden">
+        <img class="new-logo-themed" alt="Bitwarden" />
+      </a>
+
+      <div class="tw-text-center tw-mb-6 tw-max-w-md tw-mx-auto">
+        <div class="tw-mx-auto tw-max-w-20 sm:tw-max-w-24">
+          <!-- Matches TwoFactorAuthSecurityKeyIcon -->
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="3.33 3.33 76.49 75.83"
+            aria-hidden="true"
+          >
+            <path
+              class="tw-fill-illustration-bg-primary"
+              d="M3.333 8.334a5 5 0 0 1 5-5H35a5 5 0 0 1 5 5v56.667a5 5 0 0 1-5 5H8.333a5 5 0 0 1-5-5V8.334Z"
+            />
+            <path
+              class="tw-fill-illustration-outline"
+              fill-rule="evenodd"
+              d="M35 5H8.333A3.333 3.333 0 0 0 5 8.335v56.667a3.333 3.333 0 0 0 3.333 3.333H35a3.333 3.333 0 0 0 3.333-3.333V8.334A3.333 3.333 0 0 0 35 5.001ZM8.333 3.335a5 5 0 0 0-5 5v56.667a5 5 0 0 0 5 5H35a5 5 0 0 0 5-5V8.334a5 5 0 0 0-5-5H8.333Z"
+              clip-rule="evenodd"
+            />
+            <path
+              class="tw-fill-illustration-outline"
+              fill-rule="evenodd"
+              d="M18.333 9.167c0-.46.373-.833.834-.833h5a.833.833 0 0 1 0 1.667h-5a.833.833 0 0 1-.834-.834Z"
+              clip-rule="evenodd"
+            />
+            <path
+              class="tw-fill-illustration-tertiary"
+              d="M36.667 38.333c0 10.126-6.716 18.334-15 18.334-8.285 0-15-8.208-15-18.334 0-10.125 6.715-18.333 15-18.333 8.284 0 15 8.208 15 18.333Z"
+            />
+            <path
+              class="tw-fill-illustration-outline"
+              fill-rule="evenodd"
+              d="M21.667 55C28.733 55 35 47.866 35 38.333c0-9.533-6.267-16.666-13.333-16.666-7.067 0-13.334 7.133-13.334 16.666C8.333 47.866 14.6 55 21.667 55Zm0 1.667c8.284 0 15-8.208 15-18.334 0-10.125-6.716-18.333-15-18.333-8.285 0-15 8.208-15 18.333 0 10.126 6.715 18.334 15 18.334Z"
+              clip-rule="evenodd"
+            />
+            <path
+              class="tw-fill-illustration-bg-tertiary"
+              d="M68.333 35c0 6.444-5.223 11.667-11.666 11.667C50.223 46.667 45 41.444 45 35.001c0-6.444 5.223-11.667 11.667-11.667 6.443 0 11.666 5.223 11.666 11.667Z"
+            />
+            <path
+              class="tw-fill-illustration-outline"
+              fill-rule="evenodd"
+              d="M56.667 45c5.523 0 10-4.477 10-10 0-5.522-4.477-10-10-10s-10 4.478-10 10c0 5.523 4.477 10 10 10Zm0 1.667c6.443 0 11.666-5.223 11.666-11.666 0-6.444-5.223-11.667-11.666-11.667C50.223 23.334 45 28.557 45 35.001c0 6.443 5.223 11.666 11.667 11.666Z"
+              clip-rule="evenodd"
+            />
+            <path
+              class="tw-fill-illustration-bg-tertiary"
+              fill-rule="evenodd"
+              d="M78.255 59.98a22.918 22.918 0 0 1 1.559 5.854H41.667v-8.333h-4.549a22.916 22.916 0 0 1 41.137 2.48Z"
+              clip-rule="evenodd"
+            />
+            <path
+              class="tw-fill-illustration-outline"
+              fill-rule="evenodd"
+              d="M43.333 55.834v8.333h34.5a21.238 21.238 0 0 0-5.724-10.442 21.25 21.25 0 0 0-31.9 2.109h3.124Zm-5.18 0c-.368.54-.714 1.096-1.035 1.667h4.549v8.333h38.147a22.875 22.875 0 0 0-1.558-5.853 22.915 22.915 0 0 0-40.102-4.147Z"
+              clip-rule="evenodd"
+            />
+            <path
+              class="tw-fill-illustration-bg-secondary"
+              fill-rule="evenodd"
+              d="M39.167 79.167c5.272 0 9.829-3.06 11.993-7.5h5.65c.442 0 .866-.176 1.178-.489L60 69.168l1.91 1.91a.833.833 0 0 0 1.18 0l.66-.66.66.66a.833.833 0 0 0 1.18 0l1.91-1.91 2.012 2.011c.312.313.736.489 1.178.489h2.786c.442 0 .866-.176 1.179-.489l5.05-5.05a.417.417 0 0 0 0-.59l-5.05-5.05A1.667 1.667 0 0 0 73.476 60H51.16c-2.164-4.44-6.721-7.5-11.993-7.5-7.364 0-13.334 5.97-13.334 13.333 0 7.364 5.97 13.334 13.334 13.334Zm-5-10.834a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5Z"
+              clip-rule="evenodd"
+            />
+            <path
+              class="tw-fill-illustration-outline"
+              fill-rule="evenodd"
+              d="M50.118 70h6.692L60 66.81l2.5 2.5 1.25-1.25L65 69.31l2.5-2.5L70.69 70h2.786l4.167-4.167-4.167-4.166H50.118l-.457-.937a11.667 11.667 0 0 0-10.494-6.563c-6.444 0-11.667 5.223-11.667 11.666 0 6.444 5.223 11.667 11.667 11.667 4.61 0 8.6-2.674 10.494-6.563l.457-.937Zm29.587-3.872a.417.417 0 0 0 0-.59l-5.05-5.05A1.667 1.667 0 0 0 73.476 60H51.16c-2.164-4.44-6.721-7.5-11.993-7.5-7.364 0-13.334 5.97-13.334 13.333 0 7.364 5.97 13.334 13.334 13.334 5.272 0 9.829-3.06 11.993-7.5h5.65c.442 0 .866-.176 1.178-.489L60 69.168l1.91 1.91a.833.833 0 0 0 1.179.001l.661-.661.66.66.002.001a.833.833 0 0 0 1.177 0l1.911-1.911 2.012 2.011c.312.313.736.489 1.178.489h2.786c.442 0 .866-.176 1.179-.489l5.05-5.05Zm-41.372-.295a4.167 4.167 0 1 1-8.333 0 4.167 4.167 0 0 1 8.333 0Zm-1.666 0a2.5 2.5 0 1 1-5 0 2.5 2.5 0 0 1 5 0ZM16.126 28.497a15.793 15.793 0 0 1 5.542-.996c1.95 0 3.818.352 5.541.996a.833.833 0 0 0 .584-1.56 17.462 17.462 0 0 0-6.125-1.103c-2.154 0-4.218.39-6.125 1.102a.833.833 0 1 0 .583 1.561Zm5.542 2.337a11.648 11.648 0 0 0-9.335 4.667.833.833 0 1 1-1.332-1 13.314 13.314 0 0 1 10.667-5.334c4.331 0 7.947 1.77 10.59 4.41a.833.833 0 1 1-1.179 1.18c-2.36-2.36-5.564-3.923-9.411-3.923Zm-.117 1.667c-5.377 0-9.63 4.555-9.26 9.92l.075 1.081c.097 1.4.428 2.772.98 4.061l.47 1.099a.833.833 0 1 0 1.532-.656l-.47-1.1a10.835 10.835 0 0 1-.85-3.519l-.074-1.08a7.615 7.615 0 1 1 15.212-.524v.718a.833.833 0 0 1-1.666 0v-.834a5.848 5.848 0 0 0-1.522-3.927c-1.054-1.146-2.637-1.906-4.728-1.906-2.173 0-3.575.99-4.397 2.254-.79 1.216-1.02 2.639-1.02 3.58 0 2.326.209 4.02.794 5.424.593 1.425 1.54 2.465 2.84 3.549a.833.833 0 1 0 1.067-1.28c-1.2-1-1.921-1.835-2.369-2.91-.457-1.097-.665-2.527-.665-4.784 0-.726.187-1.803.75-2.67.533-.82 1.423-1.496 3-1.496 1.659 0 2.785.589 3.501 1.368a4.181 4.181 0 0 1 1.082 2.798v.834a2.5 2.5 0 0 0 5 0v-.718a9.282 9.282 0 0 0-9.282-9.282Zm-.754 9.116c0-.42.347-.783.823-.783a.88.88 0 0 1 .88.88v1.364a4.68 4.68 0 0 0 1.872 3.743l.684.513a5 5 0 0 0 3 1h.277a.833.833 0 0 0 0-1.667h-.277a3.334 3.334 0 0 1-2-.666l-.684-.513a3.013 3.013 0 0 1-1.205-2.41v-1.364a2.547 2.547 0 0 0-2.547-2.547c-1.342 0-2.492 1.056-2.49 2.453.001.82.033 1.85.148 2.804.125 1.035.627 1.848 1.163 2.526.244.31.509.608.757.887l.066.074c.274.308.526.597.752.895.553.729.7 1.326.544 1.719a.833.833 0 0 0 1.547.619c.504-1.26-.137-2.52-.763-3.345-.27-.356-.562-.688-.834-.994l-.06-.069a18.78 18.78 0 0 1-.701-.819c-.456-.577-.745-1.1-.817-1.693a23.012 23.012 0 0 1-.135-2.607Z"
+              clip-rule="evenodd"
+            />
+          </svg>
+        </div>
+
+        <div>
+          <!-- Content is set dynamically via JavaScript at runtime -->
+          <!-- eslint-disable-next-line @angular-eslint/template/elements-content -->
+          <h1 class="tw-mt-2 tw-text-2xl sm:tw-text-3xl tw-font-semibold" id="title"></h1>
+        </div>
+
+        <div class="tw-text-sm sm:tw-text-base" id="subtitle"></div>
+      </div>
+
+      <div
+        class="tw-grow tw-w-full tw-max-w-md tw-mx-auto tw-flex tw-flex-col tw-items-center sm:tw-min-w-[28rem]"
+      >
+        <div
+          class="tw-rounded-2xl tw-mb-10 tw-mx-auto tw-w-full sm:tw-bg-background sm:tw-border sm:tw-border-solid sm:tw-border-secondary-300 sm:tw-p-8"
+        >
+          <p
+            id="msg"
+            class="tw-hidden"
+            role="status"
+            aria-live="polite"
+            aria-atomic="true"
+            tabindex="-1"
+          ></p>
+
+          <!-- Content is set dynamically via JavaScript at runtime -->
+          <!-- eslint-disable-next-line @angular-eslint/template/elements-content -->
+          <button
+            type="button"
+            id="passkey-button"
+            class="!tw-text-contrast disabled:!tw-text-muted disabled:hover:!tw-text-muted disabled:hover:tw-bg-secondary-300 disabled:hover:tw-border-secondary-300 disabled:hover:tw-no-underline disabled:tw-bg-secondary-300 disabled:tw-border-secondary-300 disabled:tw-cursor-not-allowed focus-visible:tw-ring-2 focus-visible:tw-ring-offset-2 focus-visible:tw-ring-primary-600 focus-visible:tw-z-10 focus:tw-outline-none hover:tw-bg-primary-700 hover:tw-border-primary-700 hover:tw-no-underline tw-bg-primary-600 tw-block tw-border-2 tw-border-primary-600 tw-border-solid tw-font-medium tw-no-underline tw-px-3 tw-py-1.5 tw-rounded-full tw-text-center tw-transition tw-w-full"
+          ></button>
+        </div>
+      </div>
+    </main>
+  </body>
+</html>

--- a/apps/web/src/connectors/passkey-connector.ts
+++ b/apps/web/src/connectors/passkey-connector.ts
@@ -1,0 +1,493 @@
+// FIXME: Update this file to be type safe and remove this and next line
+// @ts-strict-ignore
+import { getQsParam } from "./common";
+import { TranslationService } from "./translation.service";
+
+let parametersParsed = false;
+let locale: string = null;
+let localeService: TranslationService = null;
+let extensionPublicKeyB64: string = null;
+let resultSent = false;
+let mode: "login" | "unlock" = "login";
+let unlockCredentials: { id: string; transports: string[] }[] | null = null;
+
+// PRF salt for login - must match WebAuthnLoginPrfKeyService.getLoginWithPrfSalt()
+// The salt is the string "passwordless-login" hashed with SHA-256
+const LOGIN_WITH_PRF_SALT_STRING = "passwordless-login";
+let prfSaltCache: Uint8Array | null = null;
+
+/**
+ * Get the PRF salt by hashing the salt string with SHA-256.
+ * This must match WebAuthnLoginPrfKeyService.getLoginWithPrfSalt()
+ */
+async function getLoginWithPrfSalt(): Promise<Uint8Array> {
+  if (prfSaltCache) {
+    return prfSaltCache;
+  }
+
+  const encoder = new TextEncoder();
+  const data = encoder.encode(LOGIN_WITH_PRF_SALT_STRING);
+  const hashBuffer = await crypto.subtle.digest("SHA-256", data);
+  prfSaltCache = new Uint8Array(hashBuffer);
+  return prfSaltCache;
+}
+
+function parseParameters() {
+  if (parametersParsed) {
+    return;
+  }
+
+  // Parse URL fragment (avoids sending key to server)
+  const fragment = window.location.hash.slice(1); // remove leading #
+  const params = new URLSearchParams(fragment);
+  extensionPublicKeyB64 = params.get("extensionPublicKey");
+  if (!extensionPublicKeyB64) {
+    error("No extension public key provided.");
+    return;
+  }
+
+  // Parse mode (login or unlock)
+  const modeParam = params.get("mode");
+  if (modeParam === "unlock") {
+    mode = "unlock";
+    const credentialsParam = params.get("credentials");
+    if (credentialsParam) {
+      try {
+        unlockCredentials = JSON.parse(decodeURIComponent(credentialsParam));
+      } catch {
+        error("Invalid credentials format.");
+        return;
+      }
+    } else {
+      error("No credentials provided for unlock mode.");
+      return;
+    }
+  }
+
+  locale = getQsParam("locale") ?? "en";
+  parametersParsed = true;
+}
+
+document.addEventListener("DOMContentLoaded", async () => {
+  parseParameters();
+  try {
+    localeService = new TranslationService(locale, "locales");
+  } catch {
+    error("Failed to load the provided locale " + locale);
+    localeService = new TranslationService("en", "locales");
+  }
+
+  await localeService.init();
+
+  document.documentElement.lang = locale;
+
+  const button = document.getElementById("passkey-button");
+  button.innerText = localeService.t("authenticateWithPasskey");
+  button.onclick = () => void start();
+
+  const title = document.getElementById("title");
+
+  if (mode === "unlock") {
+    title.innerText = localeService.t("unlockWithPasskey");
+  } else {
+    title.innerText = localeService.t("logInWithPasskey");
+  }
+
+  const subtitle = document.getElementById("subtitle");
+  if (mode === "unlock") {
+    subtitle.innerText = localeService.t("followTheStepsBelowToFinishUnlockingWithPasskey");
+  } else {
+    subtitle.innerText = localeService.t("followTheStepsBelowToFinishLoggingInWithPasskey");
+  }
+
+  // Auto-start if user has already clicked the button previously
+  const autoStart = getQsParam("autoStart");
+  if (autoStart === "true") {
+    void start();
+  }
+});
+
+function start() {
+  if (resultSent) {
+    return;
+  }
+
+  if (!("credentials" in navigator)) {
+    error(localeService.t("webAuthnNotSupported"));
+    return;
+  }
+
+  parseParameters();
+  if (!extensionPublicKeyB64) {
+    error("No extension public key provided.");
+    return;
+  }
+
+  void initPasskeyLogin();
+}
+
+async function initPasskeyLogin() {
+  try {
+    let credential: PublicKeyCredential;
+    let token: string | null = null;
+    let prfOutput: ArrayBuffer | null = null;
+
+    if (mode === "unlock") {
+      // Unlock mode: Use provided credentials directly
+      credential = await performUnlockWebAuthn();
+      if (!credential) {
+        error(localeService.t("passkeyAuthenticationFailed"));
+        return;
+      }
+      prfOutput = (credential.getClientExtensionResults() as any)?.prf?.results?.first ?? null;
+    } else {
+      // Login mode: Fetch assertion options from the server
+      const apiOrigin = window.location.origin;
+      const response = await fetch(`${apiOrigin}/identity/accounts/webauthn/assertion-options`, {
+        method: "GET",
+      });
+
+      if (!response.ok) {
+        throw new Error(`Failed to fetch assertion options: ${response.status}`);
+      }
+
+      const { options, token: serverToken } = await response.json();
+      token = serverToken;
+
+      // Parse the assertion options and perform WebAuthn
+      const publicKeyOptions = parseAssertionOptions(options);
+      credential = await performLoginWebAuthn(publicKeyOptions);
+
+      if (!credential) {
+        error(localeService.t("passkeyAuthenticationFailed"));
+        return;
+      }
+
+      prfOutput = (credential.getClientExtensionResults() as any)?.prf?.results?.first ?? null;
+    }
+
+    if (resultSent) {
+      return;
+    }
+
+    // Encrypt the PRF output with the extension's ECDH public key if present
+    let encryptedPrfOutput = null;
+    let connectorPublicKeyB64 = null;
+    if (prfOutput && extensionPublicKeyB64) {
+      const encryptionResult = await encryptPrfWithEcdh(prfOutput, extensionPublicKeyB64);
+      encryptedPrfOutput = {
+        ciphertext: encryptionResult.ciphertext,
+        iv: encryptionResult.iv,
+      };
+      connectorPublicKeyB64 = encryptionResult.connectorPublicKey;
+    }
+
+    // Post result back to extension via content script
+    if (mode === "unlock") {
+      // Unlock mode: Send credentialId and encrypted PRF output
+      window.postMessage(
+        {
+          command: "passkeyUnlockResult",
+          credentialId: credential.id,
+          encryptedPrfOutput,
+          connectorPublicKey: connectorPublicKeyB64,
+        },
+        "*",
+      );
+      resultSent = true;
+      success(localeService.t("passkeyUnlockSuccess"));
+    } else {
+      // Login mode: Send full assertion data
+      const assertionData = serializeAssertionData(credential);
+      window.postMessage(
+        {
+          command: "passkeyLoginResult",
+          token,
+          assertionData,
+          encryptedPrfOutput,
+          connectorPublicKey: connectorPublicKeyB64,
+        },
+        "*",
+      );
+      resultSent = true;
+      success(localeService.t("passkeyLoginSuccess"));
+    }
+  } catch (err) {
+    error(err.message || err);
+  }
+}
+
+/**
+ * Perform WebAuthn authentication for unlock mode.
+ * Uses the provided credentials directly.
+ */
+async function performUnlockWebAuthn(): Promise<PublicKeyCredential> {
+  if (!unlockCredentials || unlockCredentials.length === 0) {
+    throw new Error("No credentials available for unlock");
+  }
+
+  // Build allowCredentials from the provided credentials
+  const allowCredentials = unlockCredentials.map((cred) => ({
+    type: "public-key" as const,
+    id: base64urlToBuffer(cred.id),
+    transports: cred.transports as AuthenticatorTransport[],
+  }));
+
+  // Get the PRF salt (same as login)
+  const prfSalt = await getLoginWithPrfSalt();
+
+  // Call credentials.get() with PRF extension
+  const credential = (await navigator.credentials.get({
+    publicKey: {
+      challenge: crypto.getRandomValues(new Uint8Array(32)),
+      allowCredentials,
+      userVerification: "preferred",
+      extensions: {
+        prf: { eval: { first: prfSalt.buffer as ArrayBuffer } },
+      },
+    },
+  })) as PublicKeyCredential;
+
+  return credential;
+}
+
+/**
+ * Perform WebAuthn authentication for login mode.
+ * Uses the server's assertion options.
+ */
+async function performLoginWebAuthn(
+  publicKeyOptions: PublicKeyCredentialRequestOptions,
+): Promise<PublicKeyCredential> {
+  // Get the PRF salt (must match WebAuthnLoginPrfKeyService.getLoginWithPrfSalt)
+  const prfSalt = await getLoginWithPrfSalt();
+
+  // Call credentials.get() with PRF extension
+  const credential = (await navigator.credentials.get({
+    publicKey: {
+      ...publicKeyOptions,
+      extensions: {
+        prf: { eval: { first: prfSalt.buffer as ArrayBuffer } },
+      },
+    },
+  })) as PublicKeyCredential;
+
+  return credential;
+}
+
+/**
+ * Parse assertion options from server response
+ */
+function parseAssertionOptions(options: any): PublicKeyCredentialRequestOptions {
+  const challenge = options.challenge.replace(/-/g, "+").replace(/_/g, "/");
+  const challengeBuffer = Uint8Array.from(atob(challenge), (c) => c.charCodeAt(0));
+
+  const allowCredentials =
+    options.allowCredentials?.map((cred: any) => {
+      const id = cred.id.replace(/_/g, "/").replace(/-/g, "+");
+      return {
+        ...cred,
+        id: Uint8Array.from(atob(id), (c) => c.charCodeAt(0)),
+      };
+    }) || [];
+
+  return {
+    ...options,
+    challenge: challengeBuffer,
+    allowCredentials,
+  };
+}
+
+/**
+ * Serialize assertion data to match WebAuthnLoginAssertionResponseRequest format.
+ * This is critical because the extension uses Object.assign() with the prototype,
+ * and the field names must match exactly (case-sensitive).
+ *
+ * Differences from buildDataString():
+ * - Uses 'clientDataJSON' (uppercase) instead of 'clientDataJson' (lowercase)
+ * - Includes 'userHandle' field which is required by WebAuthnLoginAssertionResponseRequest
+ */
+function serializeAssertionData(credential: PublicKeyCredential): string {
+  const response = credential.response as AuthenticatorAssertionResponse;
+
+  const data = {
+    id: credential.id,
+    rawId: bufferToBase64url(credential.rawId),
+    type: credential.type,
+    extensions: {}, // Empty - PRF must not go to server
+    response: {
+      authenticatorData: bufferToBase64url(response.authenticatorData),
+      clientDataJSON: bufferToBase64url(response.clientDataJSON), // Note: uppercase JSON
+      signature: bufferToBase64url(response.signature),
+      userHandle: response.userHandle ? bufferToBase64url(response.userHandle) : null,
+    },
+  };
+
+  return JSON.stringify(data);
+}
+
+/**
+ * Encrypt PRF output using ECDH key exchange
+ *
+ * @param prfOutput - The raw PRF output bytes (ArrayBuffer)
+ * @param extensionPublicKeyB64 - Base64url-encoded extension ECDH public key
+ * @returns Object containing ciphertext, IV, and connector's public key
+ */
+async function encryptPrfWithEcdh(
+  prfOutput: ArrayBuffer,
+  extensionPublicKeyB64: string,
+): Promise<{
+  ciphertext: string;
+  iv: string;
+  connectorPublicKey: string;
+}> {
+  // Import the extension's public key
+  const extensionPublicKeyBuffer = base64urlToBuffer(extensionPublicKeyB64);
+
+  // Generate ephemeral ECDH key pair for the connector (P-256)
+  const connectorKeyPair = await window.crypto.subtle.generateKey(
+    {
+      name: "ECDH",
+      namedCurve: "P-256",
+    },
+    true, // extractable
+    ["deriveBits"],
+  );
+
+  // Import extension public key
+  const extensionPublicKey = await window.crypto.subtle.importKey(
+    "raw",
+    extensionPublicKeyBuffer,
+    {
+      name: "ECDH",
+      namedCurve: "P-256",
+    },
+    false,
+    [],
+  );
+
+  // Derive shared secret using ECDH
+  const sharedSecret = await window.crypto.subtle.deriveBits(
+    {
+      name: "ECDH",
+      public: extensionPublicKey,
+    },
+    connectorKeyPair.privateKey,
+    256,
+  );
+
+  // Derive AES-GCM key from shared secret using HKDF-like approach
+  // We'll use the raw shared secret to derive an AES key
+  const aesKey = await deriveAesKeyFromSharedSecret(sharedSecret);
+
+  // Generate random IV for AES-GCM
+  const iv = window.crypto.getRandomValues(new Uint8Array(12));
+
+  // Encrypt the PRF output
+  const ciphertext = await window.crypto.subtle.encrypt(
+    {
+      name: "AES-GCM",
+      iv: iv,
+    },
+    aesKey,
+    prfOutput,
+  );
+
+  // Export connector's public key to send back
+  const connectorPublicKeyBuffer = await window.crypto.subtle.exportKey(
+    "raw",
+    connectorKeyPair.publicKey,
+  );
+
+  return {
+    ciphertext: bufferToBase64url(ciphertext),
+    iv: bufferToBase64url(iv.buffer as ArrayBuffer),
+    connectorPublicKey: bufferToBase64url(connectorPublicKeyBuffer),
+  };
+}
+
+/**
+ * Derive AES-GCM key from shared secret
+ */
+async function deriveAesKeyFromSharedSecret(sharedSecret: ArrayBuffer): Promise<CryptoKey> {
+  // Use the shared secret directly as key material
+  // In production, you might want to use HKDF for better key separation
+  const keyMaterial = await window.crypto.subtle.importKey("raw", sharedSecret, "HKDF", false, [
+    "deriveKey",
+  ]);
+
+  return await window.crypto.subtle.deriveKey(
+    {
+      name: "HKDF",
+      salt: new Uint8Array(0), // Empty salt - the shared secret is already random
+      info: new TextEncoder().encode("passkey-login-prf"),
+      hash: "SHA-256",
+    },
+    keyMaterial,
+    {
+      name: "AES-GCM",
+      length: 256,
+    },
+    false,
+    ["encrypt"],
+  );
+}
+
+/**
+ * Convert base64url string to ArrayBuffer
+ */
+function base64urlToBuffer(base64url: string): ArrayBuffer {
+  const base64 = base64url.replace(/-/g, "+").replace(/_/g, "/");
+  const padding = "=".repeat((4 - (base64.length % 4)) % 4);
+  const padded = base64 + padding;
+  const binary = atob(padded);
+  const buffer = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    buffer[i] = binary.charCodeAt(i);
+  }
+  return buffer.buffer;
+}
+
+/**
+ * Convert ArrayBuffer to base64url string
+ */
+function bufferToBase64url(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  let binary = "";
+  for (let i = 0; i < bytes.byteLength; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  const base64 = btoa(binary);
+  return base64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
+}
+
+function error(message: string) {
+  const el = document.getElementById("msg");
+  resetMsgBox(el);
+  el.textContent = message;
+  el.classList.add("alert");
+  el.classList.add("alert-danger");
+  el.classList.remove("tw-hidden");
+}
+
+function success(message: string) {
+  (document.getElementById("passkey-button") as HTMLButtonElement).disabled = true;
+
+  const msgEl = document.getElementById("msg");
+  resetMsgBox(msgEl);
+  msgEl.textContent = message;
+  msgEl.classList.add("alert");
+  msgEl.classList.add("alert-success");
+  msgEl.classList.remove("tw-hidden");
+
+  // Delay closing to allow async messages (postMessage) to be processed
+  setTimeout(() => {
+    window.close();
+  }, 2000);
+}
+
+function resetMsgBox(el: HTMLElement) {
+  el.classList.remove("alert");
+  el.classList.remove("alert-danger");
+  el.classList.remove("alert-success");
+  el.classList.add("tw-hidden");
+}

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -1877,6 +1877,21 @@
   "useDifferentLoginMethod": {
     "message": "Use different login method"
   },
+  "followTheStepsBelowToFinishLoggingInWithPasskey": {
+    "message": "Follow the steps below to finish logging in with passkey"
+  },
+  "passkeyLoginSuccess": {
+    "message": "Passkey login successful"
+  },
+  "passkeyUnlockSuccess": {
+    "message": "Passkey unlock successful"
+  },
+  "useADifferentLogInMethod": {
+    "message": "Use a different log in method"
+  },
+  "authenticateWithPasskey": {
+    "message": "Authenticate with passkey"
+  },
   "logInWithPasskey": {
     "message": "Log in with passkey"
   },

--- a/apps/web/webpack.base.js
+++ b/apps/web/webpack.base.js
@@ -137,6 +137,11 @@ module.exports.buildConfig = function buildConfig(params) {
       chunks: ["connectors/webauthn-fallback", "styles"],
     }),
     new HtmlWebpackPlugin({
+      template: path.resolve(__dirname, "src/connectors/passkey-connector.html"),
+      filename: "passkey-connector.html",
+      chunks: ["connectors/passkey-connector", "styles"],
+    }),
+    new HtmlWebpackPlugin({
       template: path.resolve(__dirname, "src/connectors/sso.html"),
       filename: "sso-connector.html",
       chunks: ["connectors/sso", "styles"],
@@ -224,16 +229,30 @@ module.exports.buildConfig = function buildConfig(params) {
   let certSuffix = fs.existsSync(path.resolve(__dirname, "dev-server.local.pem"))
     ? ".local"
     : ".shared";
+
+  // Use custom certificates if configured, otherwise use default dev-server certs
+  const httpsKey = envConfig.dev?.httpsKey;
+  const httpsCert = envConfig.dev?.httpsCert;
+  const useCustomCerts =
+    httpsKey && httpsCert && fs.existsSync(httpsKey) && fs.existsSync(httpsCert);
+
   const devServer =
     NODE_ENV !== "development"
       ? {}
       : {
           server: {
             type: "https",
-            options: {
-              key: fs.readFileSync(path.resolve(__dirname, "dev-server" + certSuffix + ".pem")),
-              cert: fs.readFileSync(path.resolve(__dirname, "dev-server" + certSuffix + ".pem")),
-            },
+            options: useCustomCerts
+              ? {
+                  key: fs.readFileSync(httpsKey),
+                  cert: fs.readFileSync(httpsCert),
+                }
+              : {
+                  key: fs.readFileSync(path.resolve(__dirname, "dev-server" + certSuffix + ".pem")),
+                  cert: fs.readFileSync(
+                    path.resolve(__dirname, "dev-server" + certSuffix + ".pem"),
+                  ),
+                },
           },
           // host: '192.168.1.9',
           proxy: [
@@ -390,6 +409,10 @@ module.exports.buildConfig = function buildConfig(params) {
       "connectors/webauthn-fallback": path.resolve(
         __dirname,
         "src/connectors/webauthn-fallback.ts",
+      ),
+      "connectors/passkey-connector": path.resolve(
+        __dirname,
+        "src/connectors/passkey-connector.ts",
       ),
       "connectors/sso": path.resolve(__dirname, "src/connectors/sso.ts"),
       "connectors/duo-redirect": path.resolve(__dirname, "src/connectors/duo-redirect.ts"),

--- a/libs/angular/src/auth/login-via-webauthn/login-via-webauthn.component.ts
+++ b/libs/angular/src/auth/login-via-webauthn/login-via-webauthn.component.ts
@@ -9,7 +9,9 @@ import {
   TwoFactorAuthSecurityKeyIcon,
   TwoFactorAuthSecurityKeyFailedIcon,
 } from "@bitwarden/assets/svg";
-// This import has been flagged as unallowed for this class. It may be involved in a circular dependency loop.
+// These imports have been flagged as unallowed for this class. They may be involved in a circular dependency loop.
+// eslint-disable-next-line no-restricted-imports
+import { LoginViaWebAuthnComponentService } from "@bitwarden/auth/angular";
 // eslint-disable-next-line no-restricted-imports
 import { LoginSuccessHandlerService } from "@bitwarden/auth/common";
 import { WebAuthnLoginServiceAbstraction } from "@bitwarden/common/auth/abstractions/webauthn/webauthn-login.service.abstraction";
@@ -31,8 +33,6 @@ import {
 import { KeyService } from "@bitwarden/key-management";
 
 import { JslibModule } from "../../jslib.module";
-
-import { LoginViaWebAuthnComponentService } from "./login-via-webauthn-component.service";
 
 export type State = "assert" | "assertFailed";
 // FIXME(https://bitwarden.atlassian.net/browse/CL-764): Migrate to OnPush
@@ -76,6 +76,7 @@ export class LoginViaWebAuthnComponent implements OnInit {
 
   constructor(
     private webAuthnLoginService: WebAuthnLoginServiceAbstraction,
+    private loginViaWebAuthnComponentService: LoginViaWebAuthnComponentService,
     private router: Router,
     private route: ActivatedRoute,
     private logService: LogService,
@@ -86,7 +87,6 @@ export class LoginViaWebAuthnComponent implements OnInit {
     private platformUtilsService: PlatformUtilsService,
     private anonLayoutWrapperDataService: AnonLayoutWrapperDataService,
     private messagingService: MessagingService,
-    private loginViaWebAuthnComponentService: LoginViaWebAuthnComponentService,
   ) {
     this.showTroubleLoggingInText = this.loginViaWebAuthnComponentService.showTroubleLoggingInText;
     this.leftAlignDescription = this.loginViaWebAuthnComponentService.leftAlignDescription;
@@ -112,6 +112,26 @@ export class LoginViaWebAuthnComponent implements OnInit {
   }
 
   private async authenticate() {
+    // Check if we should use the web vault relay mechanism (Firefox)
+    if (this.loginViaWebAuthnComponentService.shouldUseWebVaultRelay()) {
+      // Firefox path: hand off to the web vault connector page.
+      // The result comes back asynchronously via the background message handler,
+      // which will open the /login-with-passkey-result popout to complete login.
+      try {
+        await this.loginViaWebAuthnComponentService.openWebVaultRelayTab();
+        // Show "waiting" state - the actual login will happen in the result popout
+        this.currentState = "assert";
+        // The current popup window will be replaced by the result popout when done.
+        return;
+      } catch (error) {
+        this.validationService.showError(error);
+        this.currentState = "assertFailed";
+        this.setFailureIcon();
+        return;
+      }
+    }
+
+    // Chromium/Desktop path: call credentials.get() directly
     let assertion: WebAuthnLoginCredentialAssertionView;
     try {
       const options = await this.webAuthnLoginService.getCredentialAssertionOptions();

--- a/libs/auth/src/angular/index.ts
+++ b/libs/auth/src/angular/index.ts
@@ -23,6 +23,9 @@ export * from "./login-decryption-options/default-login-decryption-options.servi
 // login via auth request
 export * from "./login-via-auth-request/login-via-auth-request.component";
 
+// login via webauthn
+export * from "./login-via-webauthn/login-via-webauthn-component.service";
+
 // password callout
 export * from "./password-callout/password-callout.component";
 

--- a/libs/auth/src/angular/login-via-webauthn/login-via-webauthn-component.service.ts
+++ b/libs/auth/src/angular/login-via-webauthn/login-via-webauthn-component.service.ts
@@ -1,0 +1,43 @@
+/**
+ * Service abstraction for LoginViaWebAuthnComponent.
+ * Allows platform-specific implementations to handle passkey login differently.
+ */
+export abstract class LoginViaWebAuthnComponentService {
+  /**
+   * Whether to show the "Trouble logging in?" text.
+   */
+  abstract showTroubleLoggingInText: boolean;
+
+  /**
+   * Whether to left-align the descriptive text.
+   */
+  abstract leftAlignDescription: boolean;
+
+  /**
+   * Returns true when credentials.get() cannot be called directly in the current context
+   * and must be relayed via the web vault connector page.
+   */
+  abstract shouldUseWebVaultRelay(): boolean;
+
+  /**
+   * Opens the web vault connector tab for relay-based passkey login.
+   * Returns when the tab has been launched.
+   */
+  abstract openWebVaultRelayTab(): Promise<void>;
+}
+
+/**
+ * Default implementation for platforms that support direct WebAuthn API calls.
+ */
+export class DefaultLoginViaWebAuthnComponentService implements LoginViaWebAuthnComponentService {
+  showTroubleLoggingInText = true;
+  leftAlignDescription = false;
+
+  shouldUseWebVaultRelay(): boolean {
+    return false;
+  }
+
+  async openWebVaultRelayTab(): Promise<void> {
+    throw new Error("Web vault relay is not supported on this platform.");
+  }
+}

--- a/libs/key-management-ui/src/index.ts
+++ b/libs/key-management-ui/src/index.ts
@@ -6,6 +6,10 @@ export { LockComponent } from "./lock/components/lock.component";
 export { LockComponentService, UnlockOptions } from "./lock/services/lock-component.service";
 export { WebAuthnPrfUnlockService } from "./lock/services/webauthn-prf-unlock.service";
 export { DefaultWebAuthnPrfUnlockService } from "./lock/services/default-webauthn-prf-unlock.service";
+export {
+  UnlockViaWebAuthnComponentService,
+  DefaultUnlockViaWebAuthnComponentService,
+} from "./lock/services/unlock-via-webauthn-component.service";
 export { KeyRotationTrustInfoComponent } from "./key-rotation/key-rotation-trust-info.component";
 export { AccountRecoveryTrustComponent } from "./trust/account-recovery-trust.component";
 export { EmergencyAccessTrustComponent } from "./trust/emergency-access-trust.component";

--- a/libs/key-management-ui/src/lock/components/unlock-via-prf.component.ts
+++ b/libs/key-management-ui/src/lock/components/unlock-via-prf.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from "@angular/common";
-import { Component, OnInit, input, output } from "@angular/core";
+import { Component, Inject, OnInit, Optional, input, output } from "@angular/core";
 import { firstValueFrom } from "rxjs";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
@@ -10,6 +10,7 @@ import { UserId } from "@bitwarden/common/types/guid";
 import { UserKey } from "@bitwarden/common/types/key";
 import { AsyncActionsModule, ButtonModule, DialogService } from "@bitwarden/components";
 
+import { UnlockViaWebAuthnComponentService } from "../services/unlock-via-webauthn-component.service";
 import { WebAuthnPrfUnlockService } from "../services/webauthn-prf-unlock.service";
 
 // eslint-disable-next-line @angular-eslint/prefer-on-push-component-change-detection
@@ -65,6 +66,9 @@ export class UnlockViaPrfComponent implements OnInit {
     private dialogService: DialogService,
     private i18nService: I18nService,
     private logService: LogService,
+    @Optional()
+    @Inject(UnlockViaWebAuthnComponentService)
+    private unlockViaWebAuthnComponentService?: UnlockViaWebAuthnComponentService,
   ) {}
 
   async ngOnInit(): Promise<void> {
@@ -81,12 +85,23 @@ export class UnlockViaPrfComponent implements OnInit {
     }
 
     this.unlocking = true;
+    let isRelayFlowInitiated = false;
 
     try {
       const userKey = await this.webAuthnPrfUnlockService.unlockVaultWithPrf(this.userId);
       this.unlockSuccess.emit(userKey);
     } catch (error) {
       this.logService.error("[UnlockViaPrfComponent] Failed to unlock via PRF:", error);
+
+      // Handle relay flow initiated - this is expected for Firefox
+      if (error instanceof Error && error.message === "RelayFlowInitiated") {
+        this.logService.info(
+          "[UnlockViaPrfComponent] Relay flow initiated, waiting for completion",
+        );
+        isRelayFlowInitiated = true;
+        // Don't reset unlocking state - the popup may be replaced by result popout
+        return;
+      }
 
       let errorMessage = this.i18nService.t("unexpectedError");
 
@@ -108,7 +123,46 @@ export class UnlockViaPrfComponent implements OnInit {
         type: "danger",
       });
     } finally {
+      // Only reset unlocking if relay flow was NOT initiated
+      if (!isRelayFlowInitiated) {
+        this.unlocking = false;
+      }
+    }
+  }
+
+  /**
+   * Handles PRF unlock via the web vault relay mechanism (Firefox).
+   * Opens the relay tab and waits for the result popout to complete the unlock.
+   */
+  private async unlockViaPrfWithRelay(): Promise<void> {
+    if (!this.unlockViaWebAuthnComponentService) {
+      return;
+    }
+
+    this.unlocking = true;
+
+    try {
+      this.logService.info("[UnlockViaPrfComponent] Starting relay-based PRF unlock");
+      await this.unlockViaWebAuthnComponentService.openWebVaultRelayTab();
+
+      // The relay tab has been opened. The actual unlock will happen in the
+      // unlock result popout component when the user completes the WebAuthn flow.
+      // We keep the button in a loading state to indicate something is happening.
+      this.logService.info("[UnlockViaPrfComponent] Relay tab opened, waiting for completion");
+
+      // Note: We don't reset unlocking state here because:
+      // 1. The popup may be closed/replaced by the result popout
+      // 2. If the user cancels, they'll navigate back and the component will re-initialize
+    } catch (error) {
+      this.logService.error("[UnlockViaPrfComponent] Failed to open relay tab:", error);
       this.unlocking = false;
+
+      await this.dialogService.openSimpleDialog({
+        title: { key: "error" },
+        content: this.i18nService.t("unexpectedError"),
+        acceptButtonText: { key: "ok" },
+        type: "danger",
+      });
     }
   }
 }

--- a/libs/key-management-ui/src/lock/services/default-webauthn-prf-unlock.service.ts
+++ b/libs/key-management-ui/src/lock/services/default-webauthn-prf-unlock.service.ts
@@ -9,6 +9,7 @@ import { WebAuthnLoginPrfKeyServiceAbstraction } from "@bitwarden/common/auth/ab
 import { ClientType } from "@bitwarden/common/enums";
 import { EncryptService } from "@bitwarden/common/key-management/crypto/abstractions/encrypt.service";
 import { EncString } from "@bitwarden/common/key-management/crypto/models/enc-string";
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { EnvironmentService } from "@bitwarden/common/platform/abstractions/environment.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
@@ -17,6 +18,7 @@ import { Fido2Utils } from "@bitwarden/common/platform/services/fido2/fido2-util
 import { UserId } from "@bitwarden/common/types/guid";
 import { PrfKey, UserKey } from "@bitwarden/common/types/key";
 
+import { UnlockViaWebAuthnComponentService } from "./unlock-via-webauthn-component.service";
 import { WebAuthnPrfUnlockService } from "./webauthn-prf-unlock.service";
 
 export class DefaultWebAuthnPrfUnlockService implements WebAuthnPrfUnlockService {
@@ -30,6 +32,8 @@ export class DefaultWebAuthnPrfUnlockService implements WebAuthnPrfUnlockService
     private platformUtilsService: PlatformUtilsService,
     private window: Window,
     private logService: LogService,
+    private configService: ConfigService,
+    private unlockViaWebAuthnComponentService?: UnlockViaWebAuthnComponentService,
   ) {
     this.navigatorCredentials = this.window.navigator.credentials;
   }
@@ -41,11 +45,8 @@ export class DefaultWebAuthnPrfUnlockService implements WebAuthnPrfUnlockService
         return false;
       }
 
-      // PRF unlock is only supported on Web and Chromium-based browser extensions
+      // PRF unlock is supported on Web and browser extensions (including Firefox via relay)
       const clientType = this.platformUtilsService.getClientType();
-      if (clientType === ClientType.Browser && !this.platformUtilsService.isChromium()) {
-        return false;
-      }
       if (clientType !== ClientType.Web && clientType !== ClientType.Browser) {
         return false;
       }
@@ -95,6 +96,11 @@ export class DefaultWebAuthnPrfUnlockService implements WebAuthnPrfUnlockService
       throw new Error("No PRF credentials available for unlock");
     }
 
+    // Check if we should use the web vault relay mechanism (Firefox)
+    if (this.unlockViaWebAuthnComponentService?.shouldUseWebVaultRelay()) {
+      return this.unlockVaultWithPrfViaRelay(userId, credentials);
+    }
+
     const response = await this.performWebAuthnGetWithPrf(credentials, userId);
     const prfKey = await this.createPrfKeyFromResponse(response);
     const prfOption = await this.getPrfOptionForCredential(response.id, userId);
@@ -119,6 +125,38 @@ export class DefaultWebAuthnPrfUnlockService implements WebAuthnPrfUnlockService
     }
 
     return userKey as UserKey;
+  }
+
+  /**
+   * Unlocks the vault using WebAuthn PRF via the web vault relay mechanism.
+   * Used for Firefox which cannot call credentials.get() with a custom RP ID from an extension.
+   *
+   * Note: This method opens the relay tab and returns. The actual unlock is completed
+   * by the unlock result popout component. This method never returns successfully - it
+   * either throws immediately on error, or the relay flow handles the unlock separately.
+   *
+   * @param userId The user ID to unlock vault for
+   * @param credentials Available PRF credentials for the user
+   * @throws Error always throws since the unlock is handled by the result popout
+   */
+  private async unlockVaultWithPrfViaRelay(
+    userId: UserId,
+    credentials: { credentialId: string; transports: string[] }[],
+  ): Promise<UserKey> {
+    this.logService.info("[PasskeyUnlockRelay] Starting relay-based PRF unlock");
+
+    if (!this.unlockViaWebAuthnComponentService) {
+      throw new Error("UnlockViaWebAuthnComponentService is required for relay-based unlock");
+    }
+
+    // Open the web vault relay tab
+    await this.unlockViaWebAuthnComponentService.openWebVaultRelayTab();
+
+    // The relay tab has been opened. The actual unlock will happen in the
+    // unlock result popout component when the user completes the WebAuthn flow.
+    // We throw a specific error that the caller can recognize to know the
+    // relay flow has been initiated.
+    throw new Error("RelayFlowInitiated");
   }
 
   /**

--- a/libs/key-management-ui/src/lock/services/unlock-via-webauthn-component.service.ts
+++ b/libs/key-management-ui/src/lock/services/unlock-via-webauthn-component.service.ts
@@ -1,0 +1,30 @@
+/**
+ * Service abstraction for unlock via WebAuthn/PRF.
+ * Allows platform-specific implementations to handle passkey unlock differently.
+ */
+export abstract class UnlockViaWebAuthnComponentService {
+  /**
+   * Returns true when credentials.get() cannot be called directly in the current context
+   * and must be relayed via the web vault connector page.
+   */
+  abstract shouldUseWebVaultRelay(): boolean;
+
+  /**
+   * Opens the web vault connector tab for relay-based passkey unlock.
+   * Returns when the tab has been launched.
+   */
+  abstract openWebVaultRelayTab(): Promise<void>;
+}
+
+/**
+ * Default implementation for platforms that support direct WebAuthn API calls.
+ */
+export class DefaultUnlockViaWebAuthnComponentService implements UnlockViaWebAuthnComponentService {
+  shouldUseWebVaultRelay(): boolean {
+    return false;
+  }
+
+  async openWebVaultRelayTab(): Promise<void> {
+    throw new Error("Web vault relay is not supported on this platform.");
+  }
+}


### PR DESCRIPTION
## 📔 Objective

We want to enable passkey (WebAuthn/FIDO2) login and PRF-based vault unlock for the Firefox browser extension.

Firefox extensions cannot call `navigator.credentials.get()` with a custom RP ID, so we reused the same relay pattern that our existing **WebAuthn 2FA fallback connector** already uses. A web-vault connector page hosted on the vault domain performs the WebAuthn ceremony that we cannot run inside the extension, then returns the result to us through the existing content-script bridge. We extended that flow so it also fetches the assertion options, evaluates PRF, and encrypts the raw PRF output with an ephemeral ECDH key exchange before it crosses the extension boundary.

### Key changes
- New `passkey-connector.html` / `passkey-connector.ts` page for login and unlock.
- Extension background ECDH session management and `passkeyLoginResult`/`passkeyUnlockResult` handling.
- New `PasskeyRelayService` bridging background and popup contexts.
- New `LoginWithPasskeyResultComponent` and `UnlockWithPasskeyResultComponent` result popouts.
- `LoginViaWebAuthnComponentService` and `UnlockViaWebAuthnComponentService` abstractions.
- Firefox passkey login enabled in `extension-login-component.service.ts`.

### Security
- ECDH P-256 + HKDF/AES-GCM encryption for PRF bytes in transit.
- Referrer validated against known vault hostnames from `event.origin`.
- 5-minute expiry and immediate discard of the ephemeral ECDH private key.
- Raw PRF bytes are zeroed after key derivation.

### Security

- **ECDH encryption:** The raw PRF output is encrypted under a one-time P-256 ECDH shared secret (AES-GCM via HKDF) before crossing `window.postMessage` or the content script.
- **Referrer validation:** The background validates the result came from a known vault hostname via `isValidVaultReferrer(referrer)`, where `referrer` is taken from `event.origin`, not the message payload.
- **Single-use keys:** The ECDH private key is discarded immediately after decryption; pending sessions expire after 5 minutes.
- **Buffer zeroing:** Raw PRF bytes are zeroed after `createSymmetricKeyFromPrf()`/`decrypt` operations.
- **Token/session note:** This flow relies on `/webauthn/assertion-options` returning a stateless bearer token usable by the extension context. 

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
Firefox extension login screen with "Log in with passkey" enabled
<img width="480" height="660" alt="image" src="https://github.com/user-attachments/assets/cba15cf2-2c29-4dcf-b034-39929d80cd54" />

Firefox extension unlock screen with "Log in with passkey" enabled
<img width="483" height="660" alt="image" src="https://github.com/user-attachments/assets/96ce0b8a-fcf4-4311-8361-accc1d39571c" />

Web vault connector page prompting for passkey authentication
<img width="802" height="617" alt="image" src="https://github.com/user-attachments/assets/98064bde-2672-499b-95e5-d767cfd311bb" />

Extension result popout showing "Logging in..." / "Unlocking..." state
<img width="481" height="659" alt="image" src="https://github.com/user-attachments/assets/40e263e7-2282-463f-ab27-593db1fd7ee0" />