### PR TITLE
[PM-39060] Fix new org button not showing up

### DIFF
--- a/apps/web/src/app/vault/individual-vault/vault-filter/shared/components/vault-filter-section.component.html
+++ b/apps/web/src/app/vault/individual-vault/vault-filter/shared/components/vault-filter-section.component.html
@@ -1,5 +1,5 @@
 <!-- eslint-disable tailwindcss/no-custom-classname -->
-@if (filters && filters.length) {
+@if (filters() && filters()!.length) {
   <!-- Collections coachmark (only active for the collections filter section) -->
   <app-coachmark #collectionsCoachmark stepId="shareWithCollections" />
 
@@ -8,7 +8,7 @@
     but is runtime safe. Ideally the directive would be conditionally applied, but Angular doesn't support conditional
     directive bindings.
   -->
-  @if (headerInfo.showHeader) {
+  @if (headerInfo().showHeader) {
     <div
       class="filter-heading"
       [bitPopoverAnchorFor]="isCollectionFilter ? collectionsCoachmark.popover() : null"
@@ -20,41 +20,41 @@
       <button
         type="button"
         class="toggle-button"
-        (click)="toggleCollapse(headerNode.node)"
-        [attr.aria-expanded]="!isCollapsed(headerNode.node)"
-        appA11yTitle="{{ 'toggleCollapse' | i18n }}: {{ headerNode.node.name | i18n }}"
+        (click)="toggleCollapse(headerNode().node)"
+        [attr.aria-expanded]="!isCollapsed(headerNode().node)"
+        appA11yTitle="{{ 'toggleCollapse' | i18n }}: {{ headerNode().node.name | i18n }}"
         aria-controls="sub-filters"
       >
         <i
           class="bwi bwi-fw"
           aria-hidden="true"
-          [ngClass]="isCollapsed(headerNode.node) ? 'bwi-angle-right' : 'bwi-angle-down'"
+          [ngClass]="isCollapsed(headerNode().node) ? 'bwi-angle-right' : 'bwi-angle-down'"
         ></i>
       </button>
-      @if (headerInfo.isSelectable) {
+      @if (headerInfo().isSelectable) {
         <button
           type="button"
-          appA11yTitle="{{ (isOrganizationFilter ? 'vault' : 'filter') | i18n }}: {{
-            headerNode.node.name | i18n
+          appA11yTitle="{{ (isOrganizationFilter() ? 'vault' : 'filter') | i18n }}: {{
+            headerNode().node.name | i18n
           }}"
           class="filter-button"
-          (click)="onFilterSelect(headerNode)"
+          (click)="onFilterSelect(headerNode())"
         >
           <h3
             [ngClass]="{
-              active: isAllVaultsSelected || isNodeSelected(headerNode),
+              active: isAllVaultsSelected() || isNodeSelected(headerNode()),
             }"
           >
-            &nbsp;{{ headerNode.node.name | i18n }}
+            &nbsp;{{ headerNode().node.name | i18n }}
           </h3>
         </button>
       } @else {
-        <h3 class="filter-title">&nbsp;{{ headerNode.node.name | i18n }}</h3>
+        <h3 class="filter-title">&nbsp;{{ headerNode().node.name | i18n }}</h3>
       }
     </div>
   }
-  @if (!isCollapsed(headerNode.node)) {
-    <ul id="{{ headerNode.node.name }}-filters" class="filter-options">
+  @if (!isCollapsed(headerNode().node)) {
+    <ul id="{{ headerNode().node.name }}-filters" class="filter-options">
       <ng-template #recursiveFilters let-filters>
         @for (f of filters; track f) {
           <li
@@ -86,10 +86,10 @@
               <button
                 type="button"
                 class="filter-button"
-                appA11yTitle="{{ isOrganizationFilter ? 'vault' : ('filter' | i18n) }}: {{
+                appA11yTitle="{{ isOrganizationFilter() ? 'vault' : ('filter' | i18n) }}: {{
                   f.node.name
                 }}"
-                [ngClass]="{ 'disabled-organization': isOrganizationFilter && !f.node.enabled }"
+                [ngClass]="{ 'disabled-organization': isOrganizationFilter() && !f.node.enabled }"
                 (click)="onFilterSelect(f)"
               >
                 @if (f.children.length === 0) {
@@ -98,29 +98,29 @@
                 &nbsp;{{ f.node.name }}
               </button>
               <span class="tw-ml-auto tw-flex tw-items-center">
-                @if (editInfo && f.node.id) {
+                @if (editInfo() && f.node.id) {
                   <button
                     type="button"
                     class="edit-button"
                     (click)="onEdit(f)"
-                    appA11yTitle="{{ 'editWithName' | i18n: editInfo.filterName : f.node.name }}"
+                    appA11yTitle="{{ 'editWithName' | i18n: editInfo()!.filterName : f.node.name }}"
                   >
                     <i class="bwi bwi-pencil bwi-fw" aria-hidden="true"></i>
                   </button>
                 }
-                @if (isOrganizationFilter && !f.node.enabled) {
+                @if (isOrganizationFilter() && !f.node.enabled) {
                   <i
                     class="org-options bwi bwi-fw bwi-exclamation-triangle text-danger"
                     [attr.aria-label]="'organizationIsDisabled' | i18n"
                     appA11yTitle="{{ 'organizationIsDisabled' | i18n }}"
                   ></i>
                 }
-                @if (optionsInfo && !f.node.hideOptions) {
+                @if (optionsInfo() && !f.node.hideOptions) {
                   <ng-container
-                    *ngComponentOutlet="optionsInfo.component; injector: createInjector(f.node)"
+                    *ngComponentOutlet="optionsInfo()!.component; injector: createInjector(f.node)"
                   ></ng-container>
                 }
-                @if (premiumFeature) {
+                @if (premiumFeature()) {
                   <app-premium-badge></app-premium-badge>
                 }
               </span>
@@ -137,21 +137,35 @@
         }
       </ng-template>
       <ng-container
-        *ngTemplateOutlet="recursiveFilters; context: { $implicit: filters }"
+        *ngTemplateOutlet="recursiveFilters; context: { $implicit: filters() }"
       ></ng-container>
-      @if (showAddLink) {
+      @if (showAddLink()) {
         <li class="filter-option">
           <span class="filter-buttons">
-            <a href="#" routerLink="{{ addInfo.route }}" class="filter-button tw-truncate">
+            <a href="#" routerLink="{{ addInfo()!.route }}" class="filter-button tw-truncate">
               <i class="bwi bwi-plus bwi-fw" aria-hidden="true"></i>
-              &nbsp;{{ addInfo.text | i18n }}
+              &nbsp;{{ addInfo()!.text | i18n }}
             </a>
           </span>
         </li>
       }
     </ul>
   }
-  @if (divider) {
+  @if (divider()) {
+    <hr />
+  }
+} @else if (showAddLink()) {
+  <ul id="{{ headerNode().node.name }}-filters" class="filter-options">
+    <li class="filter-option">
+      <span class="filter-buttons">
+        <a href="#" routerLink="{{ addInfo()!.route }}" class="filter-button tw-truncate">
+          <i class="bwi bwi-plus bwi-fw" aria-hidden="true"></i>
+          &nbsp;{{ addInfo()!.text | i18n }}
+        </a>
+      </span>
+    </li>
+  </ul>
+  @if (divider()) {
     <hr />
   }
 }

--- a/apps/web/src/app/vault/individual-vault/vault-filter/shared/components/vault-filter-section.component.html
+++ b/apps/web/src/app/vault/individual-vault/vault-filter/shared/components/vault-filter-section.component.html
@@ -140,32 +140,29 @@
         *ngTemplateOutlet="recursiveFilters; context: { $implicit: filters() }"
       ></ng-container>
       @if (showAddLink()) {
-        <li class="filter-option">
-          <span class="filter-buttons">
-            <a href="#" routerLink="{{ addInfo()!.route }}" class="filter-button tw-truncate">
-              <i class="bwi bwi-plus bwi-fw" aria-hidden="true"></i>
-              &nbsp;{{ addInfo()!.text | i18n }}
-            </a>
-          </span>
-        </li>
+        <ng-container *ngTemplateOutlet="addLink"></ng-container>
       }
     </ul>
   }
   @if (divider()) {
     <hr />
   }
-} @else if (showAddLink()) {
+} @else if (showAddLink() && data()) {
   <ul id="{{ headerNode().node.name }}-filters" class="filter-options">
-    <li class="filter-option">
-      <span class="filter-buttons">
-        <a href="#" routerLink="{{ addInfo()!.route }}" class="filter-button tw-truncate">
-          <i class="bwi bwi-plus bwi-fw" aria-hidden="true"></i>
-          &nbsp;{{ addInfo()!.text | i18n }}
-        </a>
-      </span>
-    </li>
+    <ng-container *ngTemplateOutlet="addLink"></ng-container>
   </ul>
   @if (divider()) {
     <hr />
   }
 }
+
+<ng-template #addLink>
+  <li class="filter-option">
+    <span class="filter-buttons">
+      <a href="#" routerLink="{{ addInfo()!.route }}" class="filter-button tw-truncate">
+        <i class="bwi bwi-plus bwi-fw" aria-hidden="true"></i>
+        &nbsp;{{ addInfo()!.text | i18n }}
+      </a>
+    </span>
+  </li>
+</ng-template>

--- a/apps/web/src/app/vault/individual-vault/vault-filter/shared/components/vault-filter-section.component.ts
+++ b/apps/web/src/app/vault/individual-vault/vault-filter/shared/components/vault-filter-section.component.ts
@@ -51,6 +51,24 @@ export class VaultFilterSectionComponent {
     initialValue: new Set<string>(),
   });
 
+  protected readonly headerNode = computed(() => this.data()!);
+  protected readonly headerInfo = computed(() => this.section().header);
+  protected readonly filters = computed(() => this.data()?.children);
+  protected readonly isOrganizationFilter = computed(
+    () => this.data()?.node instanceof Organization,
+  );
+  protected readonly isAllVaultsSelected = computed(
+    () => this.isOrganizationFilter() && !this.activeFilter.selectedOrganizationNode,
+  );
+  protected readonly editInfo = computed(() => this.section().edit);
+  protected readonly addInfo = computed(() => this.section().add);
+  protected readonly showAddLink = computed(() => !!this.section().add?.route);
+  protected readonly optionsInfo = computed(() => this.section().options);
+  protected readonly premiumFeature = computed(
+    () => this.section().premiumOptions?.showBadgeForNonPremium,
+  );
+  protected readonly divider = computed(() => this.section().divider);
+
   private injectors = new Map<string, Injector>();
 
   constructor(
@@ -58,26 +76,6 @@ export class VaultFilterSectionComponent {
     private injector: Injector,
     private accountService: AccountService,
   ) {}
-
-  get headerNode() {
-    return this.data()!;
-  }
-
-  get headerInfo() {
-    return this.section().header;
-  }
-
-  get filters() {
-    return this.data()?.children;
-  }
-
-  get isOrganizationFilter() {
-    return this.data()?.node instanceof Organization;
-  }
-
-  get isAllVaultsSelected() {
-    return this.isOrganizationFilter && !this.activeFilter.selectedOrganizationNode;
-  }
 
   isNodeSelected(filterNode: TreeNode<VaultFilterType>) {
     const { organizationId, cipherTypeId, folderId, collectionId, isCollectionSelected } =
@@ -104,36 +102,12 @@ export class VaultFilterSectionComponent {
     await this.section().action(filterNode);
   }
 
-  get editInfo() {
-    return this.section().edit;
-  }
-
   onEdit(filterNode: TreeNode<VaultFilterType>) {
     this.section().edit?.action(filterNode.node);
   }
 
-  get addInfo() {
-    return this.section().add;
-  }
-
-  get showAddLink() {
-    return this.section().add && this.section().add.route;
-  }
-
   async onAdd() {
     this.section().add?.action();
-  }
-
-  get optionsInfo() {
-    return this.section().options;
-  }
-
-  get premiumFeature() {
-    return this.section().premiumOptions?.showBadgeForNonPremium;
-  }
-
-  get divider() {
-    return this.section().divider;
   }
 
   isCollapsed(node: ITreeNodeObject) {

--- a/libs/vault/src/services/vault-filter.service.ts
+++ b/libs/vault/src/services/vault-filter.service.ts
@@ -79,7 +79,7 @@ export class VaultFilterService implements VaultFilterServiceAbstraction {
       ),
     ),
   ]).pipe(
-    switchMap(([orgs, singleOrgPolicy, organizationDataOwnershipPolicy]) =>
+    map(([orgs, singleOrgPolicy, organizationDataOwnershipPolicy]) =>
       this.buildOrganizationTree(orgs, singleOrgPolicy, organizationDataOwnershipPolicy),
     ),
   );
@@ -251,11 +251,11 @@ export class VaultFilterService implements VaultFilterServiceAbstraction {
     await this.setCollapsedFilterNodes(collapsedFilterNodes, userId);
   }
 
-  protected async buildOrganizationTree(
+  protected buildOrganizationTree(
     orgs: Organization[],
     singleOrgPolicy: boolean,
     organizationDataOwnershipPolicy: boolean,
-  ): Promise<TreeNode<OrganizationFilter>> {
+  ): TreeNode<OrganizationFilter> {
     const headNode = this.getOrganizationFilterHead();
     if (!organizationDataOwnershipPolicy) {
       const myVaultNode = this.getOrganizationFilterMyVault();


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-39060
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
The change to enforce policies on accepted users caused an edge case here. Rendering these filter nodes is gated by there being at least one child filter node, which normally was always the "My Vault" node. However, with organizationDataOwnership policy enabled, individual vault node is removed. Since the user is accepted they don’t have an organization node. The end result is the whole section is hidden because there are no nodes, even though the new org button node should be allowed to appear.

also refactors some class members and getters into readonly signals.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
