### PR TITLE
[PM-39780] Toast text is incorrect when editing collection access

### DIFF
--- a/apps/web/src/app/admin-console/organizations/collections/bulk-collections-dialog/bulk-collections-dialog.component.ts
+++ b/apps/web/src/app/admin-console/organizations/collections/bulk-collections-dialog/bulk-collections-dialog.component.ts
@@ -147,7 +147,7 @@ export class BulkCollectionsDialogComponent implements OnDestroy {
     );
     const editedMessage = batchBarEnabled
       ? this.i18nService.t(
-          this.params.collections.length === 1 ? "editedCollection" : "editedCollections",
+          this.params.collections.length === 1 ? "collectionEdited" : "collectionsEdited",
         )
       : this.i18nService.t("editedCollections");
 

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -11193,6 +11193,12 @@
   "editedCollection": {
     "message": "Edited collection"
   },
+  "collectionEdited": {
+    "message": "Collection edited"
+  },
+  "collectionsEdited": {
+    "message": "Collections edited"
+  },
   "baseUrl": {
     "message": "Server URL"
   },


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-39780
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
Add the new toast translation for the batch bar when editing a collection.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
