### PR TITLE
[PM-39147] Batch bar copy fixes — singular/plural toasts and dialog title

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -624,15 +624,9 @@
       }
     }
   },
-  "archiveItemsSingular": {
-    "message": "Archive $NUM$ item",
-    "description": "Title of the archive items dialog when a single item is selected",
-    "placeholders": {
-      "num": {
-        "content": "$1",
-        "example": "1"
-      }
-    }
+  "archiveItemTitle": {
+    "message": "Archive item",
+    "description": "Title of the archive items dialog when a single item is selected"
   },
   "archiveItemsPluralDescription": {
     "message": "Once archived, these items will be excluded from search results and autofill suggestions."
@@ -5832,6 +5826,18 @@
   },
   "successfullyAssignedCollections": {
     "message": "Successfully assigned collections"
+  },
+  "itemMovedToCollection": {
+    "message": "Item moved to collection"
+  },
+  "itemMovedToCollections": {
+    "message": "Item moved to collections"
+  },
+  "itemsMovedToCollection": {
+    "message": "Items moved to collection"
+  },
+  "itemsMovedToCollections": {
+    "message": "Items moved to collections"
   },
   "itemAssignedToCollections": {
     "message": "Item assigned to collections"

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -2573,6 +2573,9 @@
   "collectionsDeleted": {
     "message": "Collections deleted"
   },
+  "movedItem": {
+    "message": "Item moved"
+  },
   "movedItems": {
     "message": "Items moved"
   },
@@ -4841,6 +4844,18 @@
   "successfullyAssignedCollections": {
     "message": "Successfully assigned collections"
   },
+  "itemMovedToCollection": {
+    "message": "Item moved to collection"
+  },
+  "itemMovedToCollections": {
+    "message": "Item moved to collections"
+  },
+  "itemsMovedToCollection": {
+    "message": "Items moved to collection"
+  },
+  "itemsMovedToCollections": {
+    "message": "Items moved to collections"
+  },
   "itemAssignedToCollections": {
     "message": "Item assigned to collections"
   },
@@ -5000,15 +5015,9 @@
       }
     }
   },
-  "archiveItemsSingular": {
-    "message": "Archive $NUM$ item",
-    "description": "Title of the archive items dialog when a single item is selected",
-    "placeholders": {
-      "num": {
-        "content": "$1",
-        "example": "1"
-      }
-    }
+  "archiveItemTitle": {
+    "message": "Archive item",
+    "description": "Title of the archive items dialog when a single item is selected"
   },
   "archiveItemsPluralDescription": {
     "message": "Once archived, these items will be excluded from search results and autofill suggestions."

--- a/apps/desktop/src/vault/app/vault-v3/bulk-action-dialogs/bulk-delete-dialog-desktop.adapter.ts
+++ b/apps/desktop/src/vault/app/vault-v3/bulk-action-dialogs/bulk-delete-dialog-desktop.adapter.ts
@@ -66,7 +66,15 @@ export class BulkDeleteDialogDesktopAdapter implements BulkDeleteDialogRef {
 
     this.toastService.showToast({
       variant: "success",
-      message: this.i18nService.t(permanent ? "permanentlyDeletedItems" : "deletedItems"),
+      message: this.i18nService.t(
+        permanent
+          ? count === 1
+            ? "permanentlyDeletedItem"
+            : "permanentlyDeletedItems"
+          : count === 1
+            ? "deletedItem"
+            : "deletedItems",
+      ),
     });
 
     return BulkDeleteDialogResult.Deleted;
@@ -122,6 +130,8 @@ export class BulkDeleteDialogDesktopAdapter implements BulkDeleteDialogRef {
       return BulkDeleteDialogResult.Canceled;
     }
 
+    const cipherCount = cipherIds.length + unassignedCiphers.length;
+
     await Promise.all([
       this.bulkDelete.deleteCiphers({
         cipherIds,
@@ -134,7 +144,7 @@ export class BulkDeleteDialogDesktopAdapter implements BulkDeleteDialogRef {
 
     this.toastService.showToast({
       variant: "success",
-      message: this.i18nService.t("deletedItems"),
+      message: this.i18nService.t(cipherCount === 1 ? "deletedItem" : "deletedItems"),
     });
     this.toastService.showToast({
       variant: "success",

--- a/apps/web/src/app/admin-console/organizations/collections/bulk-collections-dialog/bulk-collections-dialog.component.ts
+++ b/apps/web/src/app/admin-console/organizations/collections/bulk-collections-dialog/bulk-collections-dialog.component.ts
@@ -147,9 +147,9 @@ export class BulkCollectionsDialogComponent implements OnDestroy {
     );
     const editedMessage = batchBarEnabled
       ? this.i18nService.t(
-          this.params.collections.length === 1 ? "editedCollection" : "editedCollections",
+          this.params.collections.length === 1 ? "collectionEdited" : "collectionsEdited",
         )
-      : this.i18nService.t("editedCollections");
+      : this.i18nService.t("collectionsEdited");
 
     this.toastService.showToast({
       variant: "success",

--- a/apps/web/src/app/vault/individual-vault/bulk-action-dialogs/bulk-delete-dialog-web.adapter.ts
+++ b/apps/web/src/app/vault/individual-vault/bulk-action-dialogs/bulk-delete-dialog-web.adapter.ts
@@ -85,7 +85,15 @@ export class BulkDeleteDialogWebAdapter implements BulkDeleteDialogRef {
 
     this.toastService.showToast({
       variant: "success",
-      message: this.i18nService.t(permanent ? "permanentlyDeletedItems" : "deletedItems"),
+      message: this.i18nService.t(
+        permanent
+          ? count === 1
+            ? "permanentlyDeletedItem"
+            : "permanentlyDeletedItems"
+          : count === 1
+            ? "deletedItem"
+            : "deletedItems",
+      ),
     });
 
     return BulkDeleteDialogResult.Deleted;
@@ -150,6 +158,8 @@ export class BulkDeleteDialogWebAdapter implements BulkDeleteDialogRef {
       return BulkDeleteDialogResult.Canceled;
     }
 
+    const cipherCount = cipherIds.length + unassignedCiphers.length;
+
     await Promise.all([
       this.bulkDelete.deleteCiphers({
         cipherIds,
@@ -162,7 +172,7 @@ export class BulkDeleteDialogWebAdapter implements BulkDeleteDialogRef {
 
     this.toastService.showToast({
       variant: "success",
-      message: this.i18nService.t("deletedItems"),
+      message: this.i18nService.t(cipherCount === 1 ? "deletedItem" : "deletedItems"),
     });
     this.toastService.showToast({
       variant: "success",

--- a/apps/web/src/app/vault/individual-vault/bulk-action-dialogs/bulk-delete-dialog/bulk-delete-dialog.component.ts
+++ b/apps/web/src/app/vault/individual-vault/bulk-action-dialogs/bulk-delete-dialog/bulk-delete-dialog.component.ts
@@ -92,10 +92,19 @@ export class BulkDeleteDialogComponent {
     await Promise.all(deletePromises);
 
     if (this.cipherIds.length || this.unassignedCiphers.length) {
+      const cipherCount = this.cipherIds.length + this.unassignedCiphers.length;
       this.toastService.showToast({
         variant: "success",
         title: null,
-        message: this.i18nService.t(this.permanent ? "permanentlyDeletedItems" : "deletedItems"),
+        message: this.i18nService.t(
+          this.permanent
+            ? cipherCount === 1
+              ? "permanentlyDeletedItem"
+              : "permanentlyDeletedItems"
+            : cipherCount === 1
+              ? "deletedItem"
+              : "deletedItems",
+        ),
       });
     }
     if (this.collections.length) {

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -1778,6 +1778,9 @@
   "deletedItems": {
     "message": "Items sent to trash"
   },
+  "movedItem": {
+    "message": "Item moved"
+  },
   "movedItems": {
     "message": "Items moved"
   },
@@ -11187,8 +11190,14 @@
   "assignCollectionAccess": {
     "message": "Assign collection access"
   },
+  "collectionsEdited": {
+    "message": "Collections edited"
+  },
   "editedCollections": {
     "message": "Edited collections"
+  },
+  "collectionEdited": {
+    "message": "Collection edited"
   },
   "editedCollection": {
     "message": "Edited collection"
@@ -11571,6 +11580,18 @@
   },
   "successfullyAssignedCollections": {
     "message": "Successfully assigned collections"
+  },
+  "itemMovedToCollection": {
+    "message": "Item moved to collection"
+  },
+  "itemMovedToCollections": {
+    "message": "Item moved to collections"
+  },
+  "itemsMovedToCollection": {
+    "message": "Items moved to collection"
+  },
+  "itemsMovedToCollections": {
+    "message": "Items moved to collections"
   },
   "itemAssignedToCollections": {
     "message": "Item assigned to collections"
@@ -13389,6 +13410,10 @@
         "example": "5"
       }
     }
+  },
+  "archiveItemTitle": {
+    "message": "Archive item",
+    "description": "Title of the archive items dialog when a single item is selected"
   },
   "archiveItemsSingular": {
     "message": "Archive $NUM$ item",

--- a/libs/vault/src/components/assign-collections.component.ts
+++ b/libs/vault/src/components/assign-collections.component.ts
@@ -218,7 +218,7 @@ export class AssignCollectionsComponent implements OnInit, OnDestroy, AfterViewI
     private toastService: ToastService,
     private accountService: AccountService,
     private configService: ConfigService,
-  ) {}
+  ) { }
 
   async ngOnInit() {
     const onlyPersonalItems = this.params.ciphers.every((c) => c.organizationId == null);
@@ -300,13 +300,16 @@ export class AssignCollectionsComponent implements OnInit, OnDestroy, AfterViewI
       const batchBarEnabled = await this.configService.getFeatureFlag(
         FeatureFlag.PM37785_VaultBatchBar,
       );
-      const assignedMessage = batchBarEnabled
-        ? this.i18nService.t(
-            this.params.ciphers.length === 1
-              ? "itemAssignedToCollections"
-              : "itemsAssignedToCollections",
-          )
-        : this.i18nService.t("successfullyAssignedCollections");
+      const selectedCollectionsCount = this.formGroup.controls.collections.value.length;
+      const ciphersCount = this.params.ciphers.length;
+      let assignedMessageKey: string;
+
+      if (batchBarEnabled) {
+        assignedMessageKey = this.collectionAssignmentToastKey(ciphersCount, selectedCollectionsCount);
+      } else {
+        assignedMessageKey = "successfullyAssignedCollections";
+      }
+      const assignedMessage = this.i18nService.t(assignedMessageKey);
 
       this.toastService.showToast({
         variant: "success",
@@ -505,6 +508,13 @@ export class AssignCollectionsComponent implements OnInit, OnDestroy, AfterViewI
     );
   }
 
+  private collectionAssignmentToastKey(ciphersCount: number, collectionsCount: number): string {
+    if (ciphersCount === 1) {
+      return collectionsCount === 1 ? "itemMovedToCollection" : "itemMovedToCollections";
+    }
+    return collectionsCount === 1 ? "itemsMovedToCollection" : "itemsMovedToCollections";
+  }
+
   private async moveToOrganization(
     organizationId: OrganizationId,
     shareableCiphers: CipherView[],
@@ -518,14 +528,28 @@ export class AssignCollectionsComponent implements OnInit, OnDestroy, AfterViewI
       userId,
     );
 
-    this.toastService.showToast({
-      variant: "success",
-      title: null,
-      message: this.i18nService.t(
-        shareableCiphers.length === 1 ? "itemMovedToOrg" : "itemsMovedToOrg",
-        this.orgName ?? this.i18nService.t("organization"),
-      ),
-    });
+    const batchBarEnabled = await this.configService.getFeatureFlag(
+      FeatureFlag.PM37785_VaultBatchBar,
+    );
+
+    if (batchBarEnabled) {
+      this.toastService.showToast({
+        variant: "success",
+        title: null,
+        message: this.i18nService.t(
+          this.collectionAssignmentToastKey(shareableCiphers.length, selectedCollectionIds.length),
+        ),
+      });
+    } else {
+      this.toastService.showToast({
+        variant: "success",
+        title: null,
+        message: this.i18nService.t(
+          shareableCiphers.length === 1 ? "itemMovedToOrg" : "itemsMovedToOrg",
+          this.orgName ?? this.i18nService.t("organization"),
+        ),
+      });
+    }
   }
 
   private async bulkUpdateCollections(cipherIds: CipherId[], userId: UserId) {

--- a/libs/vault/src/components/assign-collections.component.ts
+++ b/libs/vault/src/components/assign-collections.component.ts
@@ -218,7 +218,7 @@ export class AssignCollectionsComponent implements OnInit, OnDestroy, AfterViewI
     private toastService: ToastService,
     private accountService: AccountService,
     private configService: ConfigService,
-  ) { }
+  ) {}
 
   async ngOnInit() {
     const onlyPersonalItems = this.params.ciphers.every((c) => c.organizationId == null);
@@ -305,7 +305,10 @@ export class AssignCollectionsComponent implements OnInit, OnDestroy, AfterViewI
       let assignedMessageKey: string;
 
       if (batchBarEnabled) {
-        assignedMessageKey = this.collectionAssignmentToastKey(ciphersCount, selectedCollectionsCount);
+        assignedMessageKey = this.collectionAssignmentToastKey(
+          ciphersCount,
+          selectedCollectionsCount,
+        );
       } else {
         assignedMessageKey = "successfullyAssignedCollections";
       }

--- a/libs/vault/src/components/bulk-action-dialogs/bulk-move-dialog/bulk-move-dialog.component.ts
+++ b/libs/vault/src/components/bulk-action-dialogs/bulk-move-dialog/bulk-move-dialog.component.ts
@@ -100,7 +100,7 @@ export class BulkMoveDialogComponent implements OnInit {
     this.toastService.showToast({
       variant: "success",
       title: null,
-      message: this.i18nService.t("movedItems"),
+      message: this.i18nService.t(this.cipherIds.length === 1 ? "movedItem" : "movedItems"),
     });
     this.close(BulkMoveDialogResult.Moved);
   };

--- a/libs/vault/src/services/vault-batch-bar.service.spec.ts
+++ b/libs/vault/src/services/vault-batch-bar.service.spec.ts
@@ -792,23 +792,23 @@ describe("VaultBatchBarService", () => {
       expect(mockCipherService.restoreManyWithServer).toHaveBeenCalledWith([cipher.id], userId);
     });
 
-    it("shows 'restoredItems' toast when ciphers are not archived", async () => {
+    it("shows 'restoredItem' toast when a single cipher is not archived", async () => {
       service.selection.select(makeCipherItem());
 
       await service.bulkRestore();
 
       expect(mockToastService.showToast).toHaveBeenCalledWith(
-        expect.objectContaining({ message: "restoredItems" }),
+        expect.objectContaining({ message: "restoredItem" }),
       );
     });
 
-    it("shows 'archivedItemsRestored' toast when all ciphers are archived", async () => {
+    it("shows 'archivedItemRestored' toast when a single archived cipher is restored", async () => {
       service.selection.select(makeCipherItem({ archivedDate: new Date() }));
 
       await service.bulkRestore();
 
       expect(mockToastService.showToast).toHaveBeenCalledWith(
-        expect.objectContaining({ message: "archivedItemsRestored" }),
+        expect.objectContaining({ message: "archivedItemRestored" }),
       );
     });
 

--- a/libs/vault/src/services/vault-batch-bar.service.ts
+++ b/libs/vault/src/services/vault-batch-bar.service.ts
@@ -391,7 +391,7 @@ export class VaultBatchBarService<C extends CipherViewLike> {
       return;
     }
 
-    const titleKey = ciphers.length === 1 ? "archiveItemsSingular" : "archiveItemsPlural";
+    const titleKey = ciphers.length === 1 ? "archiveItemTitle" : "archiveItemsPlural";
     const contentKey =
       ciphers.length === 1 ? "archiveItemDialogContent" : "archiveItemsPluralDescription";
     const successKey = ciphers.length === 1 ? "itemArchiveToast" : "bulkArchiveItems";
@@ -440,7 +440,7 @@ export class VaultBatchBarService<C extends CipherViewLike> {
       await this.cipherArchiveService.unarchiveWithServer(cipherIds, userId);
       this.toastService.showToast({
         variant: "success",
-        message: this.i18nService.t("bulkUnarchiveItems"),
+        message: this.i18nService.t(ciphers.length === 1 ? "itemUnarchivedToast" : "bulkUnarchiveItems"),
       });
       this.selection.clear();
       this._completed$.next();
@@ -475,8 +475,8 @@ export class VaultBatchBarService<C extends CipherViewLike> {
     }
 
     const toastMessage = ciphers.some((c) => !CipherViewLikeUtils.isArchived(c))
-      ? this.i18nService.t("restoredItems")
-      : this.i18nService.t("archivedItemsRestored");
+      ? this.i18nService.t(ciphers.length === 1 ? "restoredItem" : "restoredItems")
+      : this.i18nService.t(ciphers.length === 1 ? "archivedItemRestored" : "archivedItemsRestored");
 
     if (!(await this.reprompt(ciphers))) {
       return;

--- a/libs/vault/src/services/vault-batch-bar.service.ts
+++ b/libs/vault/src/services/vault-batch-bar.service.ts
@@ -440,7 +440,9 @@ export class VaultBatchBarService<C extends CipherViewLike> {
       await this.cipherArchiveService.unarchiveWithServer(cipherIds, userId);
       this.toastService.showToast({
         variant: "success",
-        message: this.i18nService.t(ciphers.length === 1 ? "itemUnarchivedToast" : "bulkUnarchiveItems"),
+        message: this.i18nService.t(
+          ciphers.length === 1 ? "itemUnarchivedToast" : "bulkUnarchiveItems",
+        ),
       });
       this.selection.clear();
       this._completed$.next();


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-39147

## 📔 Objective

Copy-only fixes from the PM-39147 design review. No existing translation values were changed — new strings use new keys.

- **Archive dialog**: single-item title is now "Archive item" (no count)
- **Toasts**: singular/plural for folder move, delete, unarchive, and restore
- **Collection edit toast** *(behind flag)*: "Collection edited" / "Collections edited"
- **Collection assignment toast** *(behind flag)*: four variants based on item × collection count ("Item/Items moved to collection/collections")

## 📸 Screenshots

### Archive toast

| Scenario | Screenshot |
|---|---|
| 1 item |<img width="365" height="159" alt="Screenshot 2026-06-30 at 3 40 52 PM" src="https://github.com/user-attachments/assets/178722e3-abd8-413c-90ff-032261206ce4" />|
| 2+ items | <img width="343" height="140" alt="Screenshot 2026-06-30 at 3 40 59 PM" src="https://github.com/user-attachments/assets/0f4c9c12-bf28-49de-a439-2ccaa1766d6f" /> |

### Folder move toast

| Scenario | Screenshot |
|---|---|
| 1 item | <img width="336" height="73" alt="Screenshot 2026-06-30 at 8 29 31 PM" src="https://github.com/user-attachments/assets/c0ba59e8-8c29-43c5-8d82-38484aa116c2" />|
| 2+ items | <img width="335" height="101" alt="Screenshot 2026-06-30 at 8 29 23 PM" src="https://github.com/user-attachments/assets/f7d06c1a-34d2-4f89-836d-b89483cd4197" />|

### Collection edit toast

| Scenario | Screenshot |
|---|---|
| 1 collection  | <img width="349" height="108" alt="Screenshot 2026-06-30 at 8 30 59 PM" src="https://github.com/user-attachments/assets/1c0e0776-8bbd-4ec6-b164-716bb42cdd36" />|
| 2+ collections | <img width="332" height="91" alt="Screenshot 2026-06-30 at 8 31 07 PM" src="https://github.com/user-attachments/assets/d0e75ae7-fe51-48fd-9b53-e9955c0ab44c" />|

### Delete toast

| Scenario | Screenshot |
|---|---|
| 1 item  | <img width="336" height="171" alt="Screenshot 2026-06-30 at 3 41 37 PM" src="https://github.com/user-attachments/assets/eb9842eb-1776-48ad-89fe-283f61ea7b59" />|
| 2+ items  | <img width="322" height="136" alt="Screenshot 2026-06-30 at 3 41 30 PM" src="https://github.com/user-attachments/assets/f69b7591-43e9-44be-b7f8-7e8d67991b06" />|
| 1 item permanent  | <img width="373" height="144" alt="Screenshot 2026-06-30 at 3 42 33 PM" src="https://github.com/user-attachments/assets/f6a30816-ec60-44de-9ce2-629d6fbdc7a0" />|
| 2+ items permanent  | <img width="343" height="136" alt="Screenshot 2026-06-30 at 3 42 40 PM" src="https://github.com/user-attachments/assets/b727c513-a8ab-46fe-b687-9e7e9cfe85c8" />|

### Unarchive toast

| Scenario | Screenshot |
|---|---|
| 1 item | <img width="354" height="130" alt="Screenshot 2026-06-30 at 3 41 07 PM" src="https://github.com/user-attachments/assets/d11508bc-2a10-40df-9c81-cf19a2a58be7" />|
| 2+ items — "Items unarchived" |<img width="378" height="150" alt="Screenshot 2026-06-30 at 3 41 17 PM" src="https://github.com/user-attachments/assets/e11e7188-0c88-4d76-937a-34da521fc745" />|


### Restore toast

| Scenario | Screenshot |
|---|---|
| 1 item  |<img width="357" height="140" alt="Screenshot 2026-06-30 at 3 42 21 PM" src="https://github.com/user-attachments/assets/480e39b9-fa69-46b5-bbbf-9b6ccb81bb96" /> |
| 2+ items  |<img width="378" height="139" alt="Screenshot 2026-06-30 at 3 42 27 PM" src="https://github.com/user-attachments/assets/35153a18-8810-415d-b695-0221ec63eda6" />|
| 1 archived item | <img width="366" height="139" alt="Screenshot 2026-06-30 at 3 41 45 PM" src="https://github.com/user-attachments/assets/b03c0eb6-899d-48df-b686-ecc9f0d46cb7" />|
| 2+ archived items | <img width="341" height="105" alt="Screenshot 2026-06-30 at 8 34 10 PM" src="https://github.com/user-attachments/assets/6cc90413-d598-4d84-a3b3-c87c33af7430" />|


### Collection assignment toast

| Scenario | Screenshot |
|---|---|
| 1 item → 1 collection | <img width="504" height="181" alt="Screenshot 2026-06-30 at 3 40 12 PM" src="https://github.com/user-attachments/assets/eda368b0-1f01-40b5-bf4f-a7cc315d760b" />|
| 1 item → 2+ collections |<img width="334" height="127" alt="Screenshot 2026-06-30 at 3 40 45 PM" src="https://github.com/user-attachments/assets/1c06e0db-a4bc-41cb-be12-50df29dd4160" /> |
| 2+ items → 1 collection |<img width="438" height="148" alt="Screenshot 2026-06-30 at 3 40 24 PM" src="https://github.com/user-attachments/assets/a18ba554-28c8-42a0-b07e-50740d35cafd" /> |
| 2+ items → 2+ collections |<img width="400" height="140" alt="Screenshot 2026-06-30 at 3 40 35 PM" src="https://github.com/user-attachments/assets/6cc75ca9-4694-4fa9-909d-745cafbfabf1" /> |
