### PR TITLE
[BRE-1533] Trigger Bitwarden Lite from web vault build

### DIFF
--- a/.github/workflows/build-web.yml
+++ b/.github/workflows/build-web.yml
@@ -476,3 +476,73 @@ jobs:
           azure_client_id: ${{ secrets.AZURE_CLIENT_ID }}
           task: deploy-webvault-dev
           description: "Triggered by build-web on main"
+
+  bitwarden-lite-build:
+    name: Trigger Bitwarden lite build
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-24.04
+    needs: build-containers
+    permissions:
+      id-token: write
+    steps:
+      - name: Compute Bitwarden lite web tag
+        id: web-tag
+        uses: bitwarden/gh-actions/sanitize-image-tag@main
+        with:
+          ref: ${{ github.head_ref || github.ref }}
+          fork_repo: ${{ github.event.pull_request.head.repo.fork == true && github.event.pull_request.head.repo.full_name || '' }}
+
+      - name: Compute Bitwarden lite override tag
+        id: override-tag
+        uses: bitwarden/gh-actions/sanitize-image-tag@main
+        with:
+          ref: ${{ github.head_ref || github.ref }}
+          fork_repo: ${{ github.event.pull_request.head.repo.fork == true && github.event.pull_request.head.repo.full_name || '' }}
+          prefix: "web-"
+
+      - name: Log in to Azure
+        uses: bitwarden/gh-actions/azure-login@main
+        with:
+          subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          tenant_id: ${{ secrets.AZURE_TENANT_ID }}
+          client_id: ${{ secrets.AZURE_CLIENT_ID }}
+
+      - name: Get Azure Key Vault secrets
+        id: get-kv-secrets
+        uses: bitwarden/gh-actions/get-keyvault-secrets@main
+        with:
+          keyvault: gh-org-bitwarden
+          secrets: "BW-GHAPP-ID,BW-GHAPP-KEY"
+
+      - name: Log out from Azure
+        uses: bitwarden/gh-actions/azure-logout@main
+
+      - name: Generate GH App token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        id: app-token
+        with:
+          app-id: ${{ steps.get-kv-secrets.outputs.BW-GHAPP-ID }}
+          private-key: ${{ steps.get-kv-secrets.outputs.BW-GHAPP-KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: self-host
+
+      - name: Trigger Bitwarden lite build
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          WEB_BRANCH: ${{ github.head_ref || github.ref_name }}
+          WEB_TAG: ${{ steps.web-tag.outputs.tag }}
+          OVERRIDE_TAG: ${{ steps.override-tag.outputs.tag }}
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: 'bitwarden',
+              repo: 'self-host',
+              workflow_id: 'build-bitwarden-lite.yml',
+              ref: 'main',
+              inputs: {
+                web_branch: process.env.WEB_BRANCH,
+                web_tag: process.env.WEB_TAG,
+                override_tag: process.env.OVERRIDE_TAG
+              }
+            });


### PR DESCRIPTION
## 🎟️ Tracking

[BRE-1533](https://bitwarden.atlassian.net/browse/BRE-1533)

## 📔 Objective

Mirror the server-side trigger in `build-web.yml`: every web vault build now dispatches a matching Bitwarden Lite build with a `web-` prefixed `override_tag`.

## Changes

- New `bitwarden-lite-build` job in `build-web.yml`, running after `build-containers`, and fork-PR guarded.
- Tag derivation uses `bitwarden/gh-actions/sanitize-image-tag@main` - one call for `web_tag`, one for the `web-` prefixed `override_tag`.
- Dispatches `build-bitwarden-lite.yml` via `createWorkflowDispatch` using a GH App token.

## Dependencies

Requires the [self-host PR](https://github.com/bitwarden/self-host/pull/530) to merge first; the new self-host inputs (`override_tag`, `web_tag`) aren't accepted until then.

[BRE-1533]: https://bitwarden.atlassian.net/browse/BRE-1533?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ