### PR TITLE
[PM-39841] Fix unlocking crashing the desktop app

### DIFF
--- a/libs/common/src/platform/services/sdk/default-sdk.service.ts
+++ b/libs/common/src/platform/services/sdk/default-sdk.service.ts
@@ -16,8 +16,8 @@ import {
   takeWhile,
   throwIfEmpty,
   firstValueFrom,
-  debounceTime,
   filter,
+  throttleTime,
 } from "rxjs";
 
 // This import has been flagged as unallowed for this class. It may be involved in a circular dependency loop.
@@ -201,7 +201,7 @@ export class DefaultSdkService implements SdkService {
       SdkLoadService.Ready, // Makes sure we wait (once) for the SDK to be loaded
     ]).pipe(
       // Do not emit when multiple state values are written in quick succession
-      debounceTime(20),
+      throttleTime(20),
       // switchMap is required to allow the clean-up logic to be executed when `combineLatest` emits a new value.
       switchMap(
         ([

--- a/libs/common/src/platform/services/sdk/default-sdk.service.ts
+++ b/libs/common/src/platform/services/sdk/default-sdk.service.ts
@@ -1,4 +1,5 @@
 import {
+  asyncScheduler,
   combineLatest,
   concatMap,
   Observable,
@@ -200,8 +201,9 @@ export class DefaultSdkService implements SdkService {
       v2UpgradeToken$,
       SdkLoadService.Ready, // Makes sure we wait (once) for the SDK to be loaded
     ]).pipe(
-      // Do not emit when multiple state values are written in quick succession
-      throttleTime(20),
+      // Do not emit when multiple state values are written in quick succession.
+      // leading: emit immediately on first change; trailing: always process the final state in a burst.
+      throttleTime(20, asyncScheduler, { leading: true, trailing: true }),
       // switchMap is required to allow the clean-up logic to be executed when `combineLatest` emits a new value.
       switchMap(
         ([


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-39841
https://bitwarden.slack.com/archives/C07KT8VK3UG/p1782812931638739

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
We introduced debounceTime as a means to prevent frequent state writes (e.g. several writes during a sync) from causing multiple SDK re-inits. However, this leads to a case where setting the userkey to state leads to the clients counting as unlocked, and the cipher observables already starting the decryption process, while the SDK is not actually replaced by an SDK instance that is initialized. This leads to all decrypts failing.

Further, this failure in some cases leads to re-attempts, which blows up memory usage. On electron, the memory usage was up to 10 gigabytes in the renderer before it died.

The temporary fix is to use throttleTime instead of debounceTime which allows through the first emission and then blocks. The long-term fix is to get rid of the observable pattern and to have a single unlocked/locked sdk instance.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
