### PR TITLE
[PM-36888] Do auto confirm when setting is enabled

### DIFF
--- a/apps/browser/src/vault/popup/components/vault/vault.component.spec.ts
+++ b/apps/browser/src/vault/popup/components/vault/vault.component.spec.ts
@@ -253,6 +253,7 @@ describe("VaultComponent", () => {
     canManageAutoConfirm$: jest.fn().mockReturnValue(of(false)),
     upsert: jest.fn().mockResolvedValue(undefined),
     autoConfirmUser: jest.fn().mockResolvedValue(undefined),
+    bulkAutoConfirmPendingUsers: jest.fn().mockResolvedValue(undefined),
   };
 
   beforeEach(async () => {
@@ -821,6 +822,46 @@ describe("VaultComponent", () => {
       tick();
 
       expect(autoConfirmDialogSpy).not.toHaveBeenCalled();
+    }));
+
+    it("calls bulkAutoConfirmPendingUsers when user enables auto-confirm via setup dialog", fakeAsync(() => {
+      autoConfirmSvc.canManageAutoConfirm$.mockReturnValue(of(true));
+      autoConfirmSvc.configuration$.mockReturnValue(
+        of({
+          enabled: false,
+          showSetupDialog: true,
+          showBrowserNotification: undefined,
+        }),
+      );
+      autoConfirmDialogSpy.mockImplementation((_: DialogService) => ({ closed: of(true) }) as any);
+
+      const fixture = TestBed.createComponent(VaultComponent);
+      const component = fixture.componentInstance;
+
+      void component.ngOnInit();
+      tick();
+
+      expect(autoConfirmSvc.bulkAutoConfirmPendingUsers).toHaveBeenCalledWith(expect.any(String));
+    }));
+
+    it("does not call bulkAutoConfirmPendingUsers when user dismisses setup dialog", fakeAsync(() => {
+      autoConfirmSvc.canManageAutoConfirm$.mockReturnValue(of(true));
+      autoConfirmSvc.configuration$.mockReturnValue(
+        of({
+          enabled: false,
+          showSetupDialog: true,
+          showBrowserNotification: undefined,
+        }),
+      );
+      autoConfirmDialogSpy.mockImplementation((_: DialogService) => ({ closed: of(false) }) as any);
+
+      const fixture = TestBed.createComponent(VaultComponent);
+      const component = fixture.componentInstance;
+
+      void component.ngOnInit();
+      tick();
+
+      expect(autoConfirmSvc.bulkAutoConfirmPendingUsers).not.toHaveBeenCalled();
     }));
   });
 });

--- a/apps/browser/src/vault/popup/components/vault/vault.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/vault.component.ts
@@ -345,7 +345,11 @@ export class VaultComponent implements OnInit, OnDestroy {
             }
           }
 
-          return this.autoConfirmService.upsert(userId, newState);
+          await this.autoConfirmService.upsert(userId, newState);
+
+          if (result) {
+            await this.autoConfirmService.bulkAutoConfirmPendingUsers(userId);
+          }
         }),
         takeUntilDestroyed(this.destroyRef),
       )

--- a/apps/browser/src/vault/popup/settings/admin-settings.component.spec.ts
+++ b/apps/browser/src/vault/popup/settings/admin-settings.component.spec.ts
@@ -1,11 +1,12 @@
 import { ChangeDetectionStrategy, Component, input } from "@angular/core";
-import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { ComponentFixture, fakeAsync, TestBed, tick } from "@angular/core/testing";
 import { provideNoopAnimations } from "@angular/platform-browser/animations";
 import { mock, MockProxy } from "jest-mock-extended";
 import { of } from "rxjs";
 
 import { NudgesService, NudgeType } from "@bitwarden/angular/vault";
 import { AutoConfirmState, AutomaticUserConfirmationService } from "@bitwarden/auto-confirm";
+import { AutoConfirmWarningDialogComponent } from "@bitwarden/auto-confirm/angular";
 import { PopOutComponent } from "@bitwarden/browser/platform/popup/components/pop-out.component";
 import { InternalOrganizationServiceAbstraction } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
@@ -208,5 +209,55 @@ describe("AdminSettingsComponent", () => {
     it("should have autoConfirm control", () => {
       expect(component["adminForm"].controls.autoConfirm).toBeDefined();
     });
+  });
+
+  describe("autoConfirm toggle", () => {
+    let warningDialogSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      warningDialogSpy = jest
+        .spyOn(AutoConfirmWarningDialogComponent, "open")
+        .mockImplementation((_: DialogService) => ({ closed: of(true) }) as any);
+    });
+
+    afterEach(() => {
+      warningDialogSpy.mockRestore();
+    });
+
+    it("calls bulkAutoConfirmPendingUsers when toggle is enabled and warning confirmed", fakeAsync(async () => {
+      await component.ngOnInit();
+      fixture.detectChanges();
+
+      component["adminForm"].controls.autoConfirm.setValue(true);
+      tick();
+
+      expect(autoConfirmService.bulkAutoConfirmPendingUsers).toHaveBeenCalledWith(userId);
+    }));
+
+    it("does not call bulkAutoConfirmPendingUsers when toggle is disabled", fakeAsync(async () => {
+      autoConfirmService.configuration$.mockReturnValue(
+        of({ ...mockAutoConfirmState, enabled: true }),
+      );
+
+      await component.ngOnInit();
+      fixture.detectChanges();
+
+      component["adminForm"].controls.autoConfirm.setValue(false);
+      tick();
+
+      expect(autoConfirmService.bulkAutoConfirmPendingUsers).not.toHaveBeenCalled();
+    }));
+
+    it("does not call bulkAutoConfirmPendingUsers when warning dialog is cancelled", fakeAsync(async () => {
+      warningDialogSpy.mockImplementation((_: DialogService) => ({ closed: of(false) }) as any);
+
+      await component.ngOnInit();
+      fixture.detectChanges();
+
+      component["adminForm"].controls.autoConfirm.setValue(true);
+      tick();
+
+      expect(autoConfirmService.bulkAutoConfirmPendingUsers).not.toHaveBeenCalled();
+    }));
   });
 });

--- a/apps/browser/src/vault/popup/settings/admin-settings.component.spec.ts
+++ b/apps/browser/src/vault/popup/settings/admin-settings.component.spec.ts
@@ -74,7 +74,7 @@ describe("AdminSettingsComponent", () => {
 
     autoConfirmService.configuration$.mockReturnValue(of(mockAutoConfirmState));
     autoConfirmService.upsert.mockResolvedValue(undefined);
-    autoConfirmService.bulkAutoConfirmPendingUsers.mockReturnValue(of(undefined));
+    autoConfirmService.bulkAutoConfirmPendingUsers.mockResolvedValue(undefined);
     nudgesService.showNudgeSpotlight$.mockReturnValue(of(false));
     eventCollectionService.collect.mockResolvedValue(undefined);
     organizationService.organizations$.mockReturnValue(of([]));

--- a/apps/browser/src/vault/popup/settings/admin-settings.component.spec.ts
+++ b/apps/browser/src/vault/popup/settings/admin-settings.component.spec.ts
@@ -74,6 +74,7 @@ describe("AdminSettingsComponent", () => {
 
     autoConfirmService.configuration$.mockReturnValue(of(mockAutoConfirmState));
     autoConfirmService.upsert.mockResolvedValue(undefined);
+    autoConfirmService.bulkAutoConfirmPendingUsers.mockReturnValue(of(undefined));
     nudgesService.showNudgeSpotlight$.mockReturnValue(of(false));
     eventCollectionService.collect.mockResolvedValue(undefined);
     organizationService.organizations$.mockReturnValue(of([]));
@@ -224,37 +225,31 @@ describe("AdminSettingsComponent", () => {
       warningDialogSpy.mockRestore();
     });
 
-    it("calls bulkAutoConfirmPendingUsers when toggle is enabled and warning confirmed", fakeAsync(async () => {
-      await component.ngOnInit();
-      fixture.detectChanges();
-
-      component["adminForm"].controls.autoConfirm.setValue(true);
-      tick();
-
-      expect(autoConfirmService.bulkAutoConfirmPendingUsers).toHaveBeenCalledWith(userId);
-    }));
-
-    it("does not call bulkAutoConfirmPendingUsers when toggle is disabled", fakeAsync(async () => {
+    it("calls bulkAutoConfirmPendingUsers when auto-confirm is enabled", fakeAsync(async () => {
       autoConfirmService.configuration$.mockReturnValue(
         of({ ...mockAutoConfirmState, enabled: true }),
       );
 
       await component.ngOnInit();
       fixture.detectChanges();
+      tick();
 
-      component["adminForm"].controls.autoConfirm.setValue(false);
+      expect(autoConfirmService.bulkAutoConfirmPendingUsers).toHaveBeenCalledWith(userId);
+    }));
+
+    it("does not call bulkAutoConfirmPendingUsers when auto-confirm is disabled", fakeAsync(async () => {
+      await component.ngOnInit();
+      fixture.detectChanges();
       tick();
 
       expect(autoConfirmService.bulkAutoConfirmPendingUsers).not.toHaveBeenCalled();
     }));
 
-    it("does not call bulkAutoConfirmPendingUsers when warning dialog is cancelled", fakeAsync(async () => {
+    it("does not call bulkAutoConfirmPendingUsers when auto-confirm configuration is never enabled", fakeAsync(async () => {
       warningDialogSpy.mockImplementation((_: DialogService) => ({ closed: of(false) }) as any);
 
       await component.ngOnInit();
       fixture.detectChanges();
-
-      component["adminForm"].controls.autoConfirm.setValue(true);
       tick();
 
       expect(autoConfirmService.bulkAutoConfirmPendingUsers).not.toHaveBeenCalled();

--- a/apps/browser/src/vault/popup/settings/admin-settings.component.ts
+++ b/apps/browser/src/vault/popup/settings/admin-settings.component.ts
@@ -78,7 +78,7 @@ export class AdminSettingsComponent implements OnInit {
     const autoConfirmEnabled = (
       await firstValueFrom(this.autoConfirmService.configuration$(userId))
     ).enabled;
-    this.adminForm.setValue({ autoConfirm: autoConfirmEnabled });
+    this.adminForm.setValue({ autoConfirm: autoConfirmEnabled }, { emitEvent: false });
 
     this.formLoading.set(false);
 

--- a/apps/browser/src/vault/popup/settings/admin-settings.component.ts
+++ b/apps/browser/src/vault/popup/settings/admin-settings.component.ts
@@ -101,6 +101,10 @@ export class AdminSettingsComponent implements OnInit {
             showBrowserNotification: false,
           });
 
+          if (newValue) {
+            await this.autoConfirmService.bulkAutoConfirmPendingUsers(userId);
+          }
+
           // Auto-confirm users can only belong to one organization
           const organization = organizations[0];
           if (organization?.id) {

--- a/apps/browser/src/vault/popup/settings/admin-settings.component.ts
+++ b/apps/browser/src/vault/popup/settings/admin-settings.component.ts
@@ -20,6 +20,7 @@ import { PopOutComponent } from "@bitwarden/browser/platform/popup/components/po
 import { PopupHeaderComponent } from "@bitwarden/browser/platform/popup/layout/popup-header.component";
 import { PopupPageComponent } from "@bitwarden/browser/platform/popup/layout/popup-page.component";
 import { InternalOrganizationServiceAbstraction } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
+import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { getUserId } from "@bitwarden/common/auth/services/account.service";
 import { EventCollectionService, EventType } from "@bitwarden/common/dirt/event-logs";
@@ -51,6 +52,9 @@ import { UserId } from "@bitwarden/user-core";
 })
 export class AdminSettingsComponent implements OnInit {
   private readonly userId$: Observable<UserId> = this.accountService.activeAccount$.pipe(getUserId);
+  private readonly organizations$: Observable<Organization[]> = this.userId$.pipe(
+    switchMap((userId) => this.organizationService.organizations$(userId)),
+  );
 
   protected readonly formLoading: WritableSignal<boolean> = signal(true);
   protected readonly adminForm = this.formBuilder.group({
@@ -82,6 +86,7 @@ export class AdminSettingsComponent implements OnInit {
 
     this.formLoading.set(false);
 
+    // Update State
     this.adminForm.controls.autoConfirm.valueChanges
       .pipe(
         switchMap((newValue) => {
@@ -90,30 +95,42 @@ export class AdminSettingsComponent implements OnInit {
           }
           return of(false);
         }),
-        withLatestFrom(
-          this.autoConfirmService.configuration$(userId),
-          this.organizationService.organizations$(userId),
-        ),
-        switchMap(async ([newValue, existingState, organizations]) => {
-          await this.autoConfirmService.upsert(userId, {
+        withLatestFrom(this.autoConfirmService.configuration$(userId)),
+        switchMap(([newValue, existingState]) =>
+          this.autoConfirmService.upsert(userId, {
             ...existingState,
             enabled: newValue,
             showBrowserNotification: false,
-          });
+          }),
+        ),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe();
 
-          if (newValue) {
-            await this.autoConfirmService.bulkAutoConfirmPendingUsers(userId);
-          }
+    // Event Logging
+    this.autoConfirmService
+      .configuration$(userId)
+      .pipe(
+        map((state) =>
+          state.enabled
+            ? EventType.Organization_AutoConfirmEnabled_Admin
+            : EventType.Organization_AutoConfirmDisabled_Admin,
+        ),
+        withLatestFrom(this.organizations$.pipe(map((organizations) => organizations[0]))),
+        switchMap(([event, organization]) =>
+          this.eventCollectionService.collect(event, undefined, true, organization.id),
+        ),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe();
 
-          // Auto-confirm users can only belong to one organization
-          const organization = organizations[0];
-          if (organization?.id) {
-            const eventType = newValue
-              ? EventType.Organization_AutoConfirmEnabled_Admin
-              : EventType.Organization_AutoConfirmDisabled_Admin;
-            await this.eventCollectionService.collect(eventType, undefined, true, organization.id);
-          }
-        }),
+    // Fire confirm on initial event
+    this.autoConfirmService
+      .configuration$(userId)
+      .pipe(
+        switchMap((state) =>
+          state.enabled ? this.autoConfirmService.bulkAutoConfirmPendingUsers(userId) : of(),
+        ),
         takeUntilDestroyed(this.destroyRef),
       )
       .subscribe();

--- a/apps/browser/src/vault/popup/settings/admin-settings.component.ts
+++ b/apps/browser/src/vault/popup/settings/admin-settings.component.ts
@@ -117,9 +117,12 @@ export class AdminSettingsComponent implements OnInit {
             : EventType.Organization_AutoConfirmDisabled_Admin,
         ),
         withLatestFrom(this.organizations$.pipe(map((organizations) => organizations[0]))),
-        switchMap(([event, organization]) =>
-          this.eventCollectionService.collect(event, undefined, true, organization.id),
-        ),
+        switchMap(([event, organization]) => {
+          if (!organization) {
+            return of(undefined);
+          }
+          return this.eventCollectionService.collect(event, undefined, true, organization.id);
+        }),
         takeUntilDestroyed(this.destroyRef),
       )
       .subscribe();

--- a/libs/auto-confirm/src/services/default-auto-confirm.service.ts
+++ b/libs/auto-confirm/src/services/default-auto-confirm.service.ts
@@ -65,12 +65,10 @@ export class DefaultAutomaticUserConfirmationService implements AutomaticUserCon
             catchError(() => EMPTY),
           ),
         ),
+        switchMap((userId) => this.bulkAutoConfirmPendingUsers(userId)),
+        catchError(() => EMPTY),
       )
-      .subscribe((userId) => {
-        this.bulkAutoConfirmPendingUsers(userId).catch(() => {
-          // intentionally swallowed — errors are transient (network, etc.)
-        });
-      });
+      .subscribe();
   }
 
   private async resolveAutoConfirmOrg(userId: UserId): Promise<Organization | null> {

--- a/libs/auto-confirm/src/services/default-auto-confirm.service.ts
+++ b/libs/auto-confirm/src/services/default-auto-confirm.service.ts
@@ -65,8 +65,9 @@ export class DefaultAutomaticUserConfirmationService implements AutomaticUserCon
             catchError(() => EMPTY),
           ),
         ),
-        switchMap((userId) => this.bulkAutoConfirmPendingUsers(userId)),
-        catchError(() => EMPTY),
+        mergeMap((userId) =>
+          from(this.bulkAutoConfirmPendingUsers(userId)).pipe(catchError(() => EMPTY)),
+        ),
       )
       .subscribe();
   }


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-36888
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
Auto-confirm functionality only works for users who move into an accepted state after the auto-confirm feature has been turned on in the browser. Users who were in that state prior to auto-confirm being turned on are not auto-confirmed, and must be manually confirmed. This fixes that.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
