### PR TITLE
[PM-29790] Add credential request processing for Windows passkey plugin

### DIFF
--- a/apps/desktop/desktop_native/Cargo.lock
+++ b/apps/desktop/desktop_native/Cargo.lock
@@ -4990,6 +4990,7 @@ checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
 name = "windows_plugin_authenticator"
 version = "0.0.0"
 dependencies = [
+ "autofill_provider",
  "base64",
  "serde",
  "serde_json",

--- a/apps/desktop/desktop_native/windows_plugin_authenticator/Cargo.toml
+++ b/apps/desktop/desktop_native/windows_plugin_authenticator/Cargo.toml
@@ -6,7 +6,7 @@ license = { workspace = true }
 publish = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
-# autofill_provider = { path = "../autofill_provider" }
+autofill_provider = { path = "../autofill_provider" }
 base64 = { workspace = true }
 # desktop_core = { path = "../core" }
 serde = { workspace = true, features = ["derive"] }

--- a/apps/desktop/desktop_native/windows_plugin_authenticator/src/assert.rs
+++ b/apps/desktop/desktop_native/windows_plugin_authenticator/src/assert.rs
@@ -1,0 +1,271 @@
+use std::{
+    sync::{mpsc::Receiver, Arc},
+    time::Duration,
+};
+
+use autofill_provider::{
+    AutofillProviderClient, CallbackError, PasskeyAssertionRequest, PasskeyAssertionResponse,
+    PasskeyAssertionWithoutUserInterfaceRequest, Position, TimedCallback, UserVerification,
+    WindowDetails,
+};
+use win_webauthn::{plugin::PluginGetAssertionRequest, CborWriter};
+
+use crate::util::{create_context_string, HwndExt};
+
+pub fn get_assertion(
+    ipc_client: &AutofillProviderClient,
+    request: PluginGetAssertionRequest,
+    cancellation_token: Receiver<()>,
+) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+    // Extract RP information
+    let rp_id = request.rp_id().to_string();
+
+    // Extract client data hash
+    let client_data_hash = request.client_data_hash().to_vec();
+
+    // Extract user verification requirement from authenticator options
+    let user_verification = match request
+        .authenticator_options()
+        .and_then(|opts| opts.user_verification())
+    {
+        Some(true) => UserVerification::Required,
+        Some(false) => UserVerification::Discouraged,
+        None => UserVerification::Preferred,
+    };
+
+    // Extract allowed credentials from credential list
+    let allowed_credential_ids: Vec<Vec<u8>> = request
+        .allow_credentials()
+        .filter_map(|cred| cred.credential_id().map(|id| id.to_vec()))
+        .collect();
+
+    let client_pos = request
+        .window_handle
+        .center_position()
+        .unwrap_or((640, 480));
+    let client_window = WindowDetails {
+        position: Position {
+            x: client_pos.0,
+            y: client_pos.1,
+        },
+        handle: Some(request.window_handle.0.addr().to_le_bytes().to_vec()),
+    };
+
+    tracing::debug!(
+        "Get assertion request - RP: {}, Allowed credentials: {:?}",
+        rp_id,
+        allowed_credential_ids
+    );
+    let context = create_context_string(request.transaction_id, request.operation_request_hash());
+
+    // Send assertion request
+    let assertion_request = PasskeyAssertionRequest {
+        rp_id,
+        client_data_hash,
+        allowed_credentials: allowed_credential_ids,
+        user_verification,
+        client_window,
+        context: Some(context),
+    };
+    let passkey_response =
+        send_assertion_request(ipc_client, assertion_request, cancellation_token)
+            .map_err(|err| format!("Failed to get assertion response from IPC channel: {err}"))?;
+    tracing::debug!("Assertion response received: {:?}", passkey_response);
+
+    // Create proper WebAuthn response from passkey_response
+    tracing::debug!("Creating WebAuthn get assertion response");
+
+    let response = create_get_assertion_response(
+        passkey_response.credential_id,
+        passkey_response.authenticator_data,
+        passkey_response.signature,
+        passkey_response.user_handle,
+    )?;
+    Ok(response)
+}
+
+/// Helper for assertion requests
+fn send_assertion_request(
+    ipc_client: &AutofillProviderClient,
+    request: PasskeyAssertionRequest,
+    cancellation_token: Receiver<()>,
+) -> Result<PasskeyAssertionResponse, String> {
+    tracing::debug!(
+        "Assertion request data - RP ID: {}, Client data hash: {} bytes, Allowed credentials: {:?}",
+        request.rp_id,
+        request.client_data_hash.len(),
+        request.allowed_credentials,
+    );
+
+    let callback = Arc::new(TimedCallback::new());
+    if request.allowed_credentials.len() == 1 {
+        // Copy details into without user interface. On Windows, we don't
+        // require any extra fields, but we use a separate method/type to signal
+        // to the desktop app to try resolving this without the UI.
+        let request = PasskeyAssertionWithoutUserInterfaceRequest {
+            rp_id: request.rp_id,
+            credential_id: request.allowed_credentials[0].clone(),
+            client_data_hash: request.client_data_hash,
+            user_verification: request.user_verification,
+            client_window: request.client_window,
+            context: request.context,
+            // These are currently only used on macOS
+            record_identifier: None,
+            user_name: None,
+            user_handle: None,
+        };
+        ipc_client.prepare_passkey_assertion_without_user_interface(request, callback.clone());
+    } else {
+        ipc_client.prepare_passkey_assertion(request, callback.clone());
+    }
+    let wait_time = Duration::from_secs(600);
+    callback
+        .wait_for_response(wait_time, Some(cancellation_token))
+        .map_err(|err| match err {
+            CallbackError::Timeout => "Assertion request timed out".to_string(),
+            CallbackError::Cancelled => "Assertion request cancelled".to_string(),
+        })?
+        .map_err(|err| err.to_string())
+}
+
+/// Creates a WebAuthn get assertion response from Bitwarden's assertion response
+fn create_get_assertion_response(
+    credential_id: Vec<u8>,
+    authenticator_data: Vec<u8>,
+    signature: Vec<u8>,
+    user_handle: Vec<u8>,
+) -> std::result::Result<Vec<u8>, Box<dyn std::error::Error>> {
+    const CTAP2_OK: u8 = 0x00;
+    // Construct a CTAP2 response with the proper structure
+
+    // Create CTAP2 GetAssertion response map according to CTAP2 specification
+    let mut cbor_data = vec![CTAP2_OK];
+    let mut writer = CborWriter::new(&mut cbor_data);
+
+    let mut num_elements = 4;
+    if !user_handle.is_empty() {
+        num_elements += 1;
+    }
+    writer.write_map_start(num_elements)?;
+
+    // [1] credential (optional) - Always include credential descriptor
+    writer.write_number(1)?;
+    writer.write_map_start(2)?;
+    writer.write_text("id")?;
+    writer.write_bytes(&credential_id)?;
+    writer.write_text("type")?;
+    writer.write_text("public-key")?;
+
+    // [2] authenticatorData (required)
+    writer.write_number(2)?;
+    writer.write_bytes(&authenticator_data)?;
+
+    // [3] signature (required)
+    writer.write_number(3)?;
+    writer.write_bytes(&signature)?;
+
+    // [4] user (optional) - include if user handle is provided
+    if !user_handle.is_empty() {
+        writer.write_number(4)?;
+        writer.write_map_start(1)?;
+        writer.write_text("id")?;
+        writer.write_bytes(&user_handle)?;
+    }
+
+    // [5] numberOfCredentials (optional), but we'll always send it
+    writer.write_number(5)?;
+    writer.write_number(1)?;
+
+    // Encode to CBOR with error handling
+    tracing::debug!("Formatted CBOR assertion response: {:?}", cbor_data);
+    Ok(cbor_data)
+}
+
+#[cfg(test)]
+mod tests {
+    use win_webauthn::{CborParser, CborValue};
+
+    use super::create_get_assertion_response;
+
+    #[test]
+    fn test_create_native_assertion_response() {
+        let credential_id = vec![1, 2, 3, 4];
+        let authenticator_data = vec![5, 6, 7, 8];
+        let signature = vec![9, 10, 11, 12];
+        let user_handle = vec![13, 14, 15, 16];
+        let cbor = create_get_assertion_response(
+            credential_id,
+            authenticator_data,
+            signature,
+            user_handle,
+        )
+        .unwrap();
+        // CTAP2_OK, Map(5 elements)
+        assert_eq!([0x00, 0xa5], cbor[..2]);
+    }
+
+    #[test]
+    fn response_has_five_map_entries_with_non_empty_user_handle() {
+        let cbor = create_get_assertion_response(
+            vec![1, 2, 3, 4],
+            vec![5, 6, 7, 8],
+            vec![9, 10, 11, 12],
+            vec![13, 14, 15, 16],
+        )
+        .unwrap();
+
+        assert_eq!(cbor[0], 0x00); // CTAP2_OK
+        let map = CborParser::parse(&cbor[1..]).unwrap().into_map().unwrap();
+        assert_eq!(map.len(), 5);
+    }
+
+    #[test]
+    fn response_omits_user_entry_when_user_handle_is_empty() {
+        let cbor = create_get_assertion_response(
+            vec![1, 2, 3, 4],
+            vec![5, 6, 7, 8],
+            vec![9, 10, 11, 12],
+            vec![], // empty → no [4] user entry
+        )
+        .unwrap();
+
+        assert_eq!(cbor[0], 0x00);
+        let map = CborParser::parse(&cbor[1..]).unwrap().into_map().unwrap();
+        assert_eq!(map.len(), 4);
+        assert!(!map.iter().any(|(k, _)| *k == CborValue::PositiveInteger(4)));
+    }
+
+    #[test]
+    fn credential_descriptor_contains_id_and_public_key_type() {
+        let credential_id = vec![0xaa, 0xbb, 0xcc, 0xdd];
+        let cbor = create_get_assertion_response(
+            credential_id.clone(),
+            vec![1, 2],
+            vec![3, 4],
+            vec![5, 6],
+        )
+        .unwrap();
+
+        let map = CborParser::parse(&cbor[1..]).unwrap().into_map().unwrap();
+        let (_, cred_descriptor) = map
+            .iter()
+            .find(|(k, _)| *k == CborValue::PositiveInteger(1))
+            .expect("key [1] (credential) must be present");
+        let cred_map = match cred_descriptor {
+            CborValue::Map(m) => m,
+            _ => panic!("credential descriptor must be a CBOR map"),
+        };
+
+        let type_entry = cred_map
+            .iter()
+            .find(|(k, _)| k.as_text() == Some("type"))
+            .expect("type key must be present");
+        assert_eq!(type_entry.1.as_text(), Some("public-key"));
+
+        let id_entry = cred_map
+            .iter()
+            .find(|(k, _)| k.as_text() == Some("id"))
+            .expect("id key must be present");
+        assert_eq!(id_entry.1.as_bytes(), Some(credential_id.as_slice()));
+    }
+}

--- a/apps/desktop/desktop_native/windows_plugin_authenticator/src/main.rs
+++ b/apps/desktop/desktop_native/windows_plugin_authenticator/src/main.rs
@@ -1,1 +1,9 @@
+#![cfg_attr(target_os = "windows", expect(unused))]
+#[cfg(target_os = "windows")]
+mod assert;
+#[cfg(target_os = "windows")]
+mod make_credential;
+#[cfg(target_os = "windows")]
+mod util;
+
 fn main() {}

--- a/apps/desktop/desktop_native/windows_plugin_authenticator/src/make_credential.rs
+++ b/apps/desktop/desktop_native/windows_plugin_authenticator/src/make_credential.rs
@@ -1,0 +1,260 @@
+use std::{
+    collections::HashMap,
+    sync::{mpsc::Receiver, Arc},
+    time::Duration,
+};
+
+use autofill_provider::{
+    AutofillProviderClient, CallbackError, PasskeyRegistrationRequest, PasskeyRegistrationResponse,
+    Position, TimedCallback, UserVerification, WindowDetails,
+};
+use win_webauthn::{
+    plugin::{PluginMakeCredentialRequest, PluginMakeCredentialResponse},
+    CborParser, CborValue, CtapTransport,
+};
+
+use crate::util::{create_context_string, HwndExt};
+
+pub fn make_credential(
+    ipc_client: &AutofillProviderClient,
+    request: PluginMakeCredentialRequest,
+    cancellation_token: Receiver<()>,
+) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+    tracing::debug!("=== PluginMakeCredential() called ===");
+    // Extract RP information
+    let rp_info = request.rp_information();
+
+    let rp_id = rp_info.id();
+
+    // Extract user information
+    let user = request.user_information();
+
+    let user_handle = user.id().to_vec();
+
+    let user_name = user.name();
+
+    // Extract client data hash
+    let client_data_hash = request.client_data_hash().to_vec();
+
+    // Extract supported algorithms
+    let supported_algorithms: Vec<i32> = request
+        .pub_key_cred_params()
+        .map(|params| params.alg())
+        .collect();
+
+    // Extract user verification requirement from authenticator options
+    let user_verification = match request
+        .authenticator_options()
+        .and_then(|opts| opts.user_verification())
+    {
+        Some(true) => UserVerification::Required,
+        Some(false) => UserVerification::Discouraged,
+        None => UserVerification::Preferred,
+    };
+
+    // Extract excluded credentials from credential list
+    let excluded_credentials: Vec<Vec<u8>> = request
+        .exclude_credentials()
+        .filter_map(|cred| cred.credential_id().map(|id| id.to_vec()))
+        .collect();
+    if !excluded_credentials.is_empty() {
+        tracing::debug!(
+            "Found {} excluded credentials for make credential",
+            excluded_credentials.len()
+        );
+    }
+
+    let client_pos = request
+        .window_handle
+        .center_position()
+        .unwrap_or((640, 480));
+    let client_window = WindowDetails {
+        position: Position {
+            x: client_pos.0,
+            y: client_pos.1,
+        },
+        handle: Some(request.window_handle.0.addr().to_le_bytes().to_vec()),
+    };
+
+    let context = create_context_string(request.transaction_id, request.operation_request_hash());
+
+    // Create Windows registration request
+    let registration_request = PasskeyRegistrationRequest {
+        rp_id: rp_id.clone(),
+        user_handle,
+        user_name,
+        client_data_hash,
+        excluded_credentials,
+        user_verification,
+        supported_algorithms,
+        client_window,
+        context: Some(context),
+    };
+
+    tracing::debug!("Make credential request - RP: {rp_id}");
+
+    if let Ok(()) = cancellation_token.try_recv() {
+        Err(format!("Request {:?} cancelled", request.transaction_id))?;
+    }
+
+    // Send registration request
+    let passkey_response =
+        send_registration_request(ipc_client, registration_request, cancellation_token)
+            .map_err(|err| format!("Registration request failed: {err}"))?;
+    tracing::debug!("Registration response received: {:?}", passkey_response);
+
+    // Create proper WebAuthn response from passkey_response
+    tracing::debug!("Creating WebAuthn make credential response");
+    let webauthn_response = create_make_credential_response(passkey_response.attestation_object)
+        .map_err(|err| format!("Failed to create WebAuthn response: {err}"))?;
+    tracing::debug!("Successfully created WebAuthn response: {webauthn_response:?}");
+    Ok(webauthn_response)
+}
+
+/// Helper for registration requests
+fn send_registration_request(
+    ipc_client: &AutofillProviderClient,
+    request: PasskeyRegistrationRequest,
+    cancellation_token: Receiver<()>,
+) -> Result<PasskeyRegistrationResponse, String> {
+    tracing::debug!("Registration request data - RP ID: {}, User ID: {} bytes, Client data hash: {} bytes, Algorithms: {:?}, Excluded credentials: {}",
+        request.rp_id, request.user_handle.len(), request.client_data_hash.len(), request.supported_algorithms, request.excluded_credentials.len());
+
+    let callback = Arc::new(TimedCallback::new());
+    ipc_client.prepare_passkey_registration(request, callback.clone());
+    // Corresponds to maximum recommended timeout for WebAuthn.
+    // https://www.w3.org/TR/webauthn-3/#recommended-range-and-default-for-a-webauthn-ceremony-timeout
+    let wait_time = Duration::from_secs(600);
+    let response = callback
+        .wait_for_response(wait_time, Some(cancellation_token))
+        .map_err(|err| match err {
+            CallbackError::Timeout => "Registration request timed out".to_string(),
+            CallbackError::Cancelled => "Registration request cancelled".to_string(),
+        })?
+        .map_err(|err| err.to_string());
+    if response.is_ok() {
+        tracing::debug!("Requesting credential sync after registering a new credential.");
+        ipc_client.send_native_status("request-sync".to_string(), "".to_string());
+    }
+    response
+}
+
+/// Creates a CTAP2 authenticatorMakeCredential response from Bitwarden's
+/// WebAuthn registration response.
+fn create_make_credential_response(
+    attestation_object: Vec<u8>,
+) -> std::result::Result<Vec<u8>, Box<dyn std::error::Error>> {
+    // Use the attestation object directly as the encoded response
+    let att_obj_items = CborParser::parse(&attestation_object)
+        .map_err(|err| format!("Failed to deserialize WebAuthn attestation object: {err}"))?
+        .into_map()
+        .map_err(|_| "object is not a CBOR map".to_string())?;
+
+    let webauthn_att_obj: HashMap<&str, &CborValue> = att_obj_items
+        .iter()
+        .filter_map(|(k, v)| k.as_text().map(|s| (s, v)))
+        .collect();
+
+    let att_fmt = webauthn_att_obj
+        .get("fmt")
+        .and_then(|s| s.as_text())
+        .ok_or("could not read `fmt` key as a string".to_string())?
+        .to_string();
+    let authenticator_data = webauthn_att_obj
+        .get("authData")
+        .and_then(|d| d.as_bytes())
+        .ok_or("could not read `authData` key as bytes".to_string())?
+        .to_vec();
+    let attestation = PluginMakeCredentialResponse {
+        format_type: att_fmt,
+        authenticator_data,
+        attestation_statement: None,
+        attestation_object: None,
+        credential_id: None,
+        extensions: None,
+        used_transport: CtapTransport::Internal,
+        ep_att: false,
+        large_blob_supported: false,
+        resident_key: true,
+        prf_enabled: false,
+        unsigned_extension_outputs: None,
+        hmac_secret: None,
+        third_party_payment: false,
+        transports: Some(vec![CtapTransport::Internal, CtapTransport::Hybrid]),
+        client_data_json: None,
+        registration_response_json: None,
+    };
+    Ok(attestation.to_ctap_response()?)
+}
+
+#[cfg(test)]
+mod tests {
+    use win_webauthn::CborWriter;
+
+    use super::create_make_credential_response;
+
+    fn build_attestation_object(fmt: &str, auth_data: &[u8]) -> Vec<u8> {
+        let mut buf = Vec::new();
+        let mut writer = CborWriter::new(&mut buf);
+        writer.write_map_start(3).unwrap();
+        writer.write_text("fmt").unwrap();
+        writer.write_text(fmt).unwrap();
+        writer.write_text("attStmt").unwrap();
+        writer.write_map_start(0).unwrap();
+        writer.write_text("authData").unwrap();
+        writer.write_bytes(auth_data).unwrap();
+        buf
+    }
+
+    #[test]
+    fn returns_error_for_non_map_cbor() {
+        // CBOR positive integer 1 — not a map
+        let not_a_map = vec![0x01u8];
+        assert!(create_make_credential_response(not_a_map).is_err());
+    }
+
+    #[test]
+    fn returns_error_for_empty_input() {
+        assert!(create_make_credential_response(vec![]).is_err());
+    }
+
+    #[test]
+    fn returns_error_when_fmt_key_is_missing() {
+        let mut buf = Vec::new();
+        let mut writer = CborWriter::new(&mut buf);
+        writer.write_map_start(1).unwrap();
+        writer.write_text("authData").unwrap();
+        writer.write_bytes([1, 2, 3, 4]).unwrap();
+        assert!(create_make_credential_response(buf).is_err());
+    }
+
+    #[test]
+    fn returns_error_when_auth_data_key_is_missing() {
+        let mut buf = Vec::new();
+        let mut writer = CborWriter::new(&mut buf);
+        writer.write_map_start(1).unwrap();
+        writer.write_text("fmt").unwrap();
+        writer.write_text("none").unwrap();
+        assert!(create_make_credential_response(buf).is_err());
+    }
+
+    #[test]
+    fn parses_fmt_and_auth_data_from_attestation_object() {
+        // Build a minimal valid attestation object and verify it is parsed without
+        // error up to the Windows API call. The call to to_ctap_response() invokes
+        // webauthn.dll, so we only assert that CBOR parsing succeeds by checking
+        // that errors from the parser are distinct from Windows API errors.
+        let att_obj = build_attestation_object("none", &[0x01, 0x02, 0x03, 0x04]);
+        let result = create_make_credential_response(att_obj);
+        // Either succeeds (Windows with webauthn.dll) or fails at the Windows API
+        // layer — the important thing is it does not fail during CBOR parsing, which
+        // would produce a string containing "Failed to deserialize" or "CBOR map".
+        if let Err(e) = &result {
+            let msg = e.to_string();
+            assert!(
+                !msg.contains("Failed to deserialize") && !msg.contains("CBOR map"),
+                "unexpected CBOR parse error: {msg}"
+            );
+        }
+    }
+}

--- a/apps/desktop/desktop_native/windows_plugin_authenticator/src/util.rs
+++ b/apps/desktop/desktop_native/windows_plugin_authenticator/src/util.rs
@@ -1,0 +1,60 @@
+use base64::engine::{general_purpose::STANDARD, Engine as _};
+use windows::{
+    core::GUID,
+    Win32::{Foundation::*, UI::WindowsAndMessaging::GetWindowRect},
+};
+
+pub trait HwndExt {
+    fn center_position(&self) -> windows::core::Result<(i32, i32)>;
+}
+
+impl HwndExt for HWND {
+    fn center_position(&self) -> windows::core::Result<(i32, i32)> {
+        let mut window: RECT = RECT::default();
+        unsafe {
+            GetWindowRect(*self, &mut window)?;
+
+            // when running as a separate process, we're not DPI aware, so the pixels are logical
+            // pixels and we can return them directly.
+            let center = (
+                (window.right + window.left) / 2,
+                (window.bottom + window.top) / 2,
+            );
+
+            tracing::debug!("Coordinates for {:?}: {center:?}", *self);
+            Ok(center)
+        }
+    }
+}
+
+pub fn create_context_string(transaction_id: GUID, request_hash: &[u8]) -> String {
+    let context = &[&transaction_id.to_u128().to_le_bytes(), request_hash].concat();
+    STANDARD.encode(context)
+}
+
+#[cfg(test)]
+mod tests {
+    use base64::engine::{general_purpose::STANDARD, Engine as _};
+    use windows::core::GUID;
+
+    use super::create_context_string;
+
+    #[test]
+    fn context_string_guid_round_trips() {
+        let guid1 = GUID {
+            data1: 1,
+            data2: 2,
+            data3: 3,
+            data4: [4; 8],
+        };
+        let hash1 = b"abcd";
+        let result = create_context_string(guid1, hash1);
+
+        let decoded = STANDARD.decode(&result).unwrap();
+        let (guid_bytes, hash2) = decoded.split_at(16);
+        let guid2 = GUID::from_u128(u128::from_le_bytes(guid_bytes.try_into().unwrap()));
+
+        assert_eq!(guid1, guid2);
+        assert_eq!(hash1, hash2);
+    }
+}


### PR DESCRIPTION
## 🎟️ Tracking

[PM-29790](https://bitwarden.atlassian.net/browse/PM-29790)

## 📔 Objective

Translate and forward Windows Hello credential requests and Bitwarden internal passkey request types over `AutofillIpcClient`.

[PM-29790]: https://bitwarden.atlassian.net/browse/PM-29790?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ