### PR TITLE
[PM-39270] - [Safari][Browser] Settings icons and title pages are misaligned 

### DIFF
--- a/libs/components/src/item/item-content.component.html
+++ b/libs/components/src/item/item-content.component.html
@@ -9,7 +9,7 @@
       <div
         [ngClass]="{
           'tw-truncate': truncate(),
-          'tw-text-wrap tw-overflow-auto tw-break-words': !truncate(),
+          'tw-text-wrap tw-break-words': !truncate(),
         }"
       >
         <ng-content></ng-content>
@@ -23,7 +23,7 @@
       class="tw-text-muted tw-w-full"
       [ngClass]="{
         'tw-truncate': truncate(),
-        'tw-text-wrap tw-overflow-auto tw-break-words': !truncate(),
+        'tw-text-wrap tw-break-words': !truncate(),
       }"
     >
       <ng-content select="[slot=secondary]"></ng-content>


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-39270

## 📔 Objective

Fix item content rows rendering with extra vertical height when macOS scrollbars are visible.

`bit-item-content` was applying `tw-overflow-auto` to non-truncated text content. When persistent scrollbars are enabled, that can reserve scrollbar space inside the text wrapper, causing affected item rows to become taller even when the text itself does not need scrolling.

This removes `tw-overflow-auto` from wrapped item content while preserving text wrapping and word breaking behavior.

Verified with:
- macOS scrollbar setting set to `Always`
- Browser extension settings popup in non-compact mode
- Tailwind CSS build check

## 📸 Screenshots

Before: affected settings rows showed extra vertical height when scrollbars were always visible.

After: settings rows render at the expected height without the extra space.

<img width="524" height="666" alt="Screenshot 2026-07-01 at 3 40 43 PM" src="https://github.com/user-attachments/assets/008bbb83-49f5-41cf-9352-330cc11a668b" />
