### PR TITLE
Allow toggling PIN unlock type on desktop

### DIFF
--- a/apps/desktop/src/app/accounts/settings-dialog.component.html
+++ b/apps/desktop/src/app/accounts/settings-dialog.component.html
@@ -15,17 +15,10 @@
           <bit-session-timeout-settings [refreshTimeoutActionSettings]="refreshTimeoutSettings$" />
         </bit-section>
 
-        @if (pinEnabled() || form.value.pin) {
-          <bit-form-control class="tw-mt-4">
-            <input type="checkbox" bitCheckbox formControlName="pin" />
-            <bit-label>{{ "unlockWithPin" | i18n }}</bit-label>
-          </bit-form-control>
-        }
-
         @if (supportsBiometric()) {
-          <bit-form-control>
+          <bit-form-control class="tw-mt-4">
             <input type="checkbox" bitCheckbox formControlName="biometric" />
-            <bit-label>{{ biometricText | i18n }}</bit-label>
+            <bit-label>{{ "unlockWithBiometrics" | i18n }}</bit-label>
             @if (form.value.biometric && isMac) {
               <bit-hint>{{ "additionalTouchIdSettings" | i18n }}</bit-hint>
             }
@@ -63,6 +56,20 @@
               (change)="updateAutoPromptBiometrics()"
             />
             <bit-label>{{ "autoPromptTouchId" | i18n }}</bit-label>
+          </bit-form-control>
+        }
+
+        @if (pinEnabled() || form.value.pin) {
+          <bit-form-control>
+            <input type="checkbox" bitCheckbox formControlName="pin" />
+            <bit-label>{{ "unlockWithPin" | i18n }}</bit-label>
+          </bit-form-control>
+        }
+
+        @if (form.value.pin && userHasMasterPassword()) {
+          <bit-form-control class="tw-ms-5">
+            <input type="checkbox" bitCheckbox formControlName="pinLockWithMasterPassword" />
+            <bit-label>{{ "requireMasterPasswordOnAppRestart" | i18n }}</bit-label>
           </bit-form-control>
         }
       </bit-tab>

--- a/apps/desktop/src/app/accounts/settings-dialog.component.ts
+++ b/apps/desktop/src/app/accounts/settings-dialog.component.ts
@@ -167,6 +167,7 @@ export class SettingsDialogComponent implements OnInit {
   protected readonly form = this.formBuilder.group({
     // Security
     pin: [null as boolean | null],
+    pinLockWithMasterPassword: false,
     biometric: false,
     requireMasterPasswordOnAppRestart: true,
     autoPromptBiometrics: false,
@@ -264,6 +265,8 @@ export class SettingsDialogComponent implements OnInit {
 
     const initialValues = {
       pin: this.userHasPinSet(),
+      pinLockWithMasterPassword:
+        (await this.pinService.getPinLockType(this.currentUserId())) == "AfterFirstUnlock",
       biometric: await this.vaultTimeoutSettingsService.isBiometricLockSet(this.currentUserId()),
       requireMasterPasswordOnAppRestart: !(await this.biometricsService.hasPersistentKey(
         this.currentUserId(),
@@ -315,6 +318,16 @@ export class SettingsDialogComponent implements OnInit {
       .pipe(
         concatMap(async (value) => {
           await this.updatePinHandler(value);
+          this.refreshTimeoutSettings$.next();
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe();
+
+    this.form.controls.pinLockWithMasterPassword.valueChanges
+      .pipe(
+        concatMap(async (value) => {
+          await this.updatePinLockWithMasterPasswordHandler(value);
           this.refreshTimeoutSettings$.next();
         }),
         takeUntilDestroyed(this.destroyRef),
@@ -399,6 +412,13 @@ export class SettingsDialogComponent implements OnInit {
       const pinSet = await firstValueFrom(dialogRef.closed);
       this.userHasPinSet.set(pinSet);
       this.form.controls.pin.setValue(this.userHasPinSet(), { emitEvent: false });
+
+      const userId = await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId));
+      const requireMasterPasswordOnClientRestart =
+        (await this.pinService.getPinLockType(userId)) == "AfterFirstUnlock";
+      this.form.controls.pinLockWithMasterPassword.setValue(requireMasterPasswordOnClientRestart, {
+        emitEvent: false,
+      });
     } else {
       const userId = await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId));
 
@@ -414,6 +434,18 @@ export class SettingsDialogComponent implements OnInit {
         await this.enrollPersistentBiometricIfNeeded(userId);
       }
       await this.pinService.unsetPin(userId);
+    }
+  }
+
+  private async updatePinLockWithMasterPasswordHandler(value: boolean) {
+    try {
+      const userId = await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId));
+      const pin = await this.pinService.getPin(userId);
+      await this.pinService.setPin(pin, value ? "AfterFirstUnlock" : "BeforeFirstUnlock", userId);
+    } catch (error) {
+      this.logService.error("Error updating PIN lock type: ", error);
+      this.form.controls.pinLockWithMasterPassword.setValue(!value, { emitEvent: false });
+      this.validationService.showError(error);
     }
   }
 
@@ -707,19 +739,6 @@ export class SettingsDialogComponent implements OnInit {
       this.getFormattedAutotypeShortcutText(newShortcutArray),
     );
     await this.desktopAutotypeService.setAutotypeKeyboardShortcutState(newShortcutArray);
-  }
-
-  protected get biometricText() {
-    switch (this.platformUtilsService.getDevice()) {
-      case DeviceType.MacOsDesktop:
-        return "unlockWithTouchId";
-      case DeviceType.WindowsDesktop:
-        return "unlockWithWindowsHello";
-      case DeviceType.LinuxDesktop:
-        return "unlockWithPolkit";
-      default:
-        throw new Error("Unsupported platform");
-    }
   }
 
   private getFormattedAutotypeShortcutText(shortcut: string[]) {


### PR DESCRIPTION
## 🎟️ Tracking

n/a

## 📔 Objective

Add a "Require master password on app restart" checkbox indented under "Unlock with PIN" in desktop settings. Toggling it switches the PIN lock type between `AfterFirstUnlock` (persistent, no master password on restart) and `BeforeFirstUnlock` (require master password on restart), reusing the stored PIN so no re-entry is prompted. Matches the browser extension behavior. Also relabels the biometric checkbox to "Unlock with biometrics" and reorders biometric options above PIN options.

## 📸 Screenshots

<img width="1848" height="1732" alt="step-3-checkbox-visible" src="https://github.com/user-attachments/assets/784cb823-59fd-416b-9932-169db09dc8f5" />

