### PR TITLE
[PM-39554] Create default collection when admin is demoted to user

### DIFF
--- a/apps/web/src/app/admin-console/organizations/core/services/user-admin.service.ts
+++ b/apps/web/src/app/admin-console/organizations/core/services/user-admin.service.ts
@@ -1,10 +1,16 @@
 import { Injectable } from "@angular/core";
+import { firstValueFrom, switchMap } from "rxjs";
 
 import {
   OrganizationUserApiService,
   OrganizationUserInviteRequest,
+  OrganizationUserService,
   OrganizationUserUpdateRequest,
 } from "@bitwarden/admin-console/common";
+import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { getUserId } from "@bitwarden/common/auth/services/account.service";
+import { getById } from "@bitwarden/common/platform/misc";
 import { Guid, OrganizationId } from "@bitwarden/common/types/guid";
 
 import { CoreOrganizationModule } from "../core-organization.module";
@@ -12,7 +18,12 @@ import { OrganizationUserAdminView } from "../views/organization-user-admin-view
 
 @Injectable({ providedIn: CoreOrganizationModule })
 export class UserAdminService {
-  constructor(private organizationUserApiService: OrganizationUserApiService) {}
+  constructor(
+    private organizationUserApiService: OrganizationUserApiService,
+    private organizationUserService: OrganizationUserService,
+    private organizationService: OrganizationService,
+    private accountService: AccountService,
+  ) {}
 
   async get(
     organizationId: OrganizationId,
@@ -52,7 +63,20 @@ export class UserAdminService {
     userId: Guid,
     organizationId: OrganizationId,
   ): Promise<void> {
-    await this.organizationUserApiService.putOrganizationUser(organizationId, userId, request);
+    await firstValueFrom(
+      this.accountService.activeAccount$.pipe(
+        getUserId,
+        switchMap((activeUserId) => this.organizationService.organizations$(activeUserId)),
+        getById(organizationId),
+        switchMap((organization) => {
+          if (organization == null) {
+            throw new Error("Organization not found");
+          }
+
+          return this.organizationUserService.updateUser(organization, userId, request);
+        }),
+      ),
+    );
   }
 
   async invite(emails: string[], user: OrganizationUserAdminView): Promise<void> {

--- a/apps/web/src/app/admin-console/organizations/core/services/user-admin.service.ts
+++ b/apps/web/src/app/admin-console/organizations/core/services/user-admin.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from "@angular/core";
-import { firstValueFrom, switchMap } from "rxjs";
+import { firstValueFrom } from "rxjs";
 
 import {
   OrganizationUserApiService,
@@ -7,10 +7,7 @@ import {
   OrganizationUserService,
   OrganizationUserUpdateRequest,
 } from "@bitwarden/admin-console/common";
-import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
-import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
-import { getUserId } from "@bitwarden/common/auth/services/account.service";
-import { getById } from "@bitwarden/common/platform/misc";
+import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
 import { Guid, OrganizationId } from "@bitwarden/common/types/guid";
 
 import { CoreOrganizationModule } from "../core-organization.module";
@@ -21,8 +18,6 @@ export class UserAdminService {
   constructor(
     private organizationUserApiService: OrganizationUserApiService,
     private organizationUserService: OrganizationUserService,
-    private organizationService: OrganizationService,
-    private accountService: AccountService,
   ) {}
 
   async get(
@@ -46,7 +41,7 @@ export class UserAdminService {
 
   // TODO: Remove this wrapper once MemberDialogComponent (the old dialog) is deleted.
   // Callers should use saveV2() directly with an OrganizationUserUpdateRequest.
-  async save(userView: OrganizationUserAdminView): Promise<void> {
+  async save(userView: OrganizationUserAdminView, organization: Organization): Promise<void> {
     const request = new OrganizationUserUpdateRequest({
       type: userView.type,
       permissions: userView.permissions,
@@ -55,27 +50,16 @@ export class UserAdminService {
       accessSecretsManager: userView.accessSecretsManager,
     });
 
-    await this.saveV2(request, userView.id, userView.organizationId);
+    await this.saveV2(request, userView.id, organization);
   }
 
   async saveV2(
     request: OrganizationUserUpdateRequest,
-    userId: Guid,
-    organizationId: OrganizationId,
+    organizationUserId: Guid,
+    organization: Organization,
   ): Promise<void> {
     await firstValueFrom(
-      this.accountService.activeAccount$.pipe(
-        getUserId,
-        switchMap((activeUserId) => this.organizationService.organizations$(activeUserId)),
-        getById(organizationId),
-        switchMap((organization) => {
-          if (organization == null) {
-            throw new Error("Organization not found");
-          }
-
-          return this.organizationUserService.updateUser(organization, userId, request);
-        }),
-      ),
+      this.organizationUserService.updateUser(organization, organizationUserId, request),
     );
   }
 

--- a/apps/web/src/app/admin-console/organizations/members/components/edit-member-dialog/edit-member-dialog.component.ts
+++ b/apps/web/src/app/admin-console/organizations/members/components/edit-member-dialog/edit-member-dialog.component.ts
@@ -373,7 +373,7 @@ export class EditMemberDialogComponent {
     return Object.assign(p, partialPermissions);
   }
 
-  private async handleEditUser() {
+  private async handleEditUser(organization: Organization) {
     const userId = this.params.organizationUserId;
     const type = this.formGroup.getRawValue().type;
     const permissions = this.setRequestPermissions(
@@ -399,7 +399,7 @@ export class EditMemberDialogComponent {
       accessSecretsManager,
     });
 
-    await this.userService.saveV2(request, userId, this.params.organizationId);
+    await this.userService.saveV2(request, userId, organization);
 
     this.toastService.showToast({
       variant: "success",
@@ -432,7 +432,7 @@ export class EditMemberDialogComponent {
       return;
     }
 
-    await this.handleEditUser();
+    await this.handleEditUser(organization);
   };
 
   readonly revoke = async () => {

--- a/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.ts
+++ b/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.ts
@@ -521,7 +521,7 @@ export class MemberDialogComponent implements OnDestroy {
     const userView = await this.getUserView();
 
     if (this.isEditDialogParams(this.params)) {
-      await this.handleEditUser(userView, this.params);
+      await this.handleEditUser(userView, this.params, organization);
     } else {
       await this.handleInviteUsers(userView);
     }
@@ -565,9 +565,10 @@ export class MemberDialogComponent implements OnDestroy {
   private async handleEditUser(
     userView: OrganizationUserAdminView,
     params: EditMemberDialogParams,
+    organization: Organization,
   ) {
     userView.id = params.organizationUserId;
-    await this.userService.save(userView);
+    await this.userService.save(userView, organization);
 
     this.toastService.showToast({
       variant: "success",

--- a/libs/admin-console/src/common/organization-user/abstractions/organization-user.service.ts
+++ b/libs/admin-console/src/common/organization-user/abstractions/organization-user.service.ts
@@ -4,6 +4,7 @@ import { Organization } from "@bitwarden/common/admin-console/models/domain/orga
 import { ListResponse } from "@bitwarden/common/models/response/list.response";
 
 import { OrganizationUserConfirmRequest, OrganizationUserBulkResponse } from "../..";
+import { OrganizationUserUpdateRequest } from "../models/requests";
 
 export abstract class OrganizationUserService {
   /**
@@ -47,4 +48,15 @@ export abstract class OrganizationUserService {
     organization: Organization,
     userIds: string[],
   ): Observable<ListResponse<OrganizationUserBulkResponse>>;
+
+  /**
+   * Updates a user's role and settings in an organization. When the target role is subject to the
+   * Centralize Organization Ownership policy (i.e. User or Custom), an encrypted default collection
+   * name is included so the server can create the "My Items" collection if it is missing.
+   */
+  abstract updateUser(
+    organization: Organization,
+    userId: string,
+    request: OrganizationUserUpdateRequest,
+  ): Observable<void>;
 }

--- a/libs/admin-console/src/common/organization-user/models/requests/organization-user-update.request.ts
+++ b/libs/admin-console/src/common/organization-user/models/requests/organization-user-update.request.ts
@@ -1,6 +1,7 @@
 import { OrganizationUserType } from "@bitwarden/common/admin-console/enums";
 import { PermissionsApi } from "@bitwarden/common/admin-console/models/api/permissions.api";
 import { SelectionReadOnlyRequest } from "@bitwarden/common/admin-console/models/request/selection-read-only.request";
+import { EncryptedString } from "@bitwarden/common/key-management/crypto/models/enc-string";
 
 export class OrganizationUserUpdateRequest {
   type: OrganizationUserType;
@@ -8,6 +9,7 @@ export class OrganizationUserUpdateRequest {
   collections: SelectionReadOnlyRequest[];
   groups: string[] | undefined;
   permissions: PermissionsApi;
+  defaultUserCollectionName: EncryptedString | undefined;
 
   constructor(c: {
     type: OrganizationUserType;
@@ -15,11 +17,13 @@ export class OrganizationUserUpdateRequest {
     accessSecretsManager?: boolean;
     collections?: SelectionReadOnlyRequest[];
     groups?: string[];
+    defaultUserCollectionName?: EncryptedString;
   }) {
     this.type = c.type;
     this.accessSecretsManager = c.accessSecretsManager ?? false;
     this.collections = c.collections ?? [];
     this.groups = c.groups;
     this.permissions = c.permissions;
+    this.defaultUserCollectionName = c.defaultUserCollectionName;
   }
 }

--- a/libs/admin-console/src/common/organization-user/services/default-organization-user.service.spec.ts
+++ b/libs/admin-console/src/common/organization-user/services/default-organization-user.service.spec.ts
@@ -1,6 +1,8 @@
 import { TestBed } from "@angular/core/testing";
 import { of } from "rxjs";
 
+import { OrganizationUserType } from "@bitwarden/common/admin-console/enums";
+import { PermissionsApi } from "@bitwarden/common/admin-console/models/api/permissions.api";
 import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { EncryptService } from "@bitwarden/common/key-management/crypto/abstractions/encrypt.service";
@@ -18,6 +20,7 @@ import {
   OrganizationUserBulkConfirmRequest,
   OrganizationUserApiService,
   OrganizationUserBulkResponse,
+  OrganizationUserUpdateRequest,
 } from "../..";
 
 import { DefaultOrganizationUserService } from "./default-organization-user.service";
@@ -64,6 +67,7 @@ describe("DefaultOrganizationUserService", () => {
       postOrganizationUserBulkConfirm: jest.fn(),
       restoreOrganizationUser: jest.fn(),
       restoreManyOrganizationUsers: jest.fn(),
+      putOrganizationUser: jest.fn(),
     } as any;
 
     accountService = {
@@ -267,5 +271,68 @@ describe("DefaultOrganizationUserService", () => {
         error: done,
       });
     });
+  });
+
+  describe("updateUser", () => {
+    const mockPermissions = new PermissionsApi();
+
+    beforeEach(() => {
+      organizationUserApiService.putOrganizationUser.mockReturnValue(Promise.resolve());
+    });
+
+    it.each([OrganizationUserType.Owner, OrganizationUserType.Admin])(
+      "should call putOrganizationUser without encrypting a collection name for exempt type %s",
+      (userType, done: jest.DoneCallback) => {
+        const request = new OrganizationUserUpdateRequest({
+          type: userType,
+          permissions: mockPermissions,
+        });
+
+        service.updateUser(mockOrganization, mockUserId, request).subscribe({
+          next: () => {
+            expect(encryptService.encryptString).not.toHaveBeenCalled();
+            expect(request.defaultUserCollectionName).toBeUndefined();
+            expect(organizationUserApiService.putOrganizationUser).toHaveBeenCalledWith(
+              mockOrganization.id,
+              mockUserId,
+              request,
+            );
+            done();
+          },
+          error: done,
+        });
+      },
+    );
+
+    it.each([OrganizationUserType.User, OrganizationUserType.Custom])(
+      "should encrypt the default collection name and include it in the request for non-exempt type %s",
+      (userType, done: jest.DoneCallback) => {
+        setupCommonMocks();
+        const request = new OrganizationUserUpdateRequest({
+          type: userType,
+          permissions: mockPermissions,
+        });
+
+        service.updateUser(mockOrganization, mockUserId, request).subscribe({
+          next: () => {
+            expect(i18nService.t).toHaveBeenCalledWith("myItems");
+            expect(encryptService.encryptString).toHaveBeenCalledWith(
+              mockDefaultCollectionName,
+              mockOrgKey,
+            );
+            expect(request.defaultUserCollectionName).toBe(
+              mockEncryptedCollectionName.encryptedString,
+            );
+            expect(organizationUserApiService.putOrganizationUser).toHaveBeenCalledWith(
+              mockOrganization.id,
+              mockUserId,
+              request,
+            );
+            done();
+          },
+          error: done,
+        });
+      },
+    );
   });
 });

--- a/libs/admin-console/src/common/organization-user/services/default-organization-user.service.spec.ts
+++ b/libs/admin-console/src/common/organization-user/services/default-organization-user.service.spec.ts
@@ -288,12 +288,17 @@ describe("DefaultOrganizationUserService", () => {
           permissions: mockPermissions,
         });
 
-        service.updateUser(mockOrganization, mockUserId, request).subscribe({
+        const org = new Organization();
+        org.id = mockOrganization.id;
+        org.useMyItems = true;
+        org.usePolicies = true;
+
+        service.updateUser(org, mockUserId, request).subscribe({
           next: () => {
             expect(encryptService.encryptString).not.toHaveBeenCalled();
             expect(request.defaultUserCollectionName).toBeUndefined();
             expect(organizationUserApiService.putOrganizationUser).toHaveBeenCalledWith(
-              mockOrganization.id,
+              org.id,
               mockUserId,
               request,
             );
@@ -305,7 +310,7 @@ describe("DefaultOrganizationUserService", () => {
     );
 
     it.each([OrganizationUserType.User, OrganizationUserType.Custom])(
-      "should encrypt the default collection name and include it in the request for non-exempt type %s",
+      "should encrypt the default collection name and include it in the request for non-exempt type %s when useMyItems and usePolicies are enabled",
       (userType, done: jest.DoneCallback) => {
         setupCommonMocks();
         const request = new OrganizationUserUpdateRequest({
@@ -313,7 +318,12 @@ describe("DefaultOrganizationUserService", () => {
           permissions: mockPermissions,
         });
 
-        service.updateUser(mockOrganization, mockUserId, request).subscribe({
+        const org = new Organization();
+        org.id = mockOrganization.id;
+        org.useMyItems = true;
+        org.usePolicies = true;
+
+        service.updateUser(org, mockUserId, request).subscribe({
           next: () => {
             expect(i18nService.t).toHaveBeenCalledWith("myItems");
             expect(encryptService.encryptString).toHaveBeenCalledWith(
@@ -324,7 +334,36 @@ describe("DefaultOrganizationUserService", () => {
               mockEncryptedCollectionName.encryptedString,
             );
             expect(organizationUserApiService.putOrganizationUser).toHaveBeenCalledWith(
-              mockOrganization.id,
+              org.id,
+              mockUserId,
+              request,
+            );
+            done();
+          },
+          error: done,
+        });
+      },
+    );
+
+    it.each([OrganizationUserType.User, OrganizationUserType.Custom])(
+      "should not encrypt the default collection name for non-exempt type %s when useMyItems or usePolicies is disabled",
+      (userType, done: jest.DoneCallback) => {
+        const request = new OrganizationUserUpdateRequest({
+          type: userType,
+          permissions: mockPermissions,
+        });
+
+        const org = new Organization();
+        org.id = mockOrganization.id;
+        org.useMyItems = false;
+        org.usePolicies = true;
+
+        service.updateUser(org, mockUserId, request).subscribe({
+          next: () => {
+            expect(encryptService.encryptString).not.toHaveBeenCalled();
+            expect(request.defaultUserCollectionName).toBeUndefined();
+            expect(organizationUserApiService.putOrganizationUser).toHaveBeenCalledWith(
+              org.id,
               mockUserId,
               request,
             );

--- a/libs/admin-console/src/common/organization-user/services/default-organization-user.service.ts
+++ b/libs/admin-console/src/common/organization-user/services/default-organization-user.service.ts
@@ -1,5 +1,6 @@
-import { combineLatest, filter, map, Observable, switchMap } from "rxjs";
+import { combineLatest, filter, from, map, Observable, switchMap } from "rxjs";
 
+import { OrganizationUserType } from "@bitwarden/common/admin-console/enums";
 import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { getUserId } from "@bitwarden/common/auth/services/account.service";
@@ -16,6 +17,7 @@ import {
   OrganizationUserConfirmRequest,
   OrganizationUserService,
 } from "../..";
+import { OrganizationUserUpdateRequest } from "../models/requests";
 import { OrganizationUserBulkRestoreRequest } from "../models/requests/organization-user-bulk-restore.request";
 import { OrganizationUserRestoreRequest } from "../models/requests/organization-user-restore.request";
 
@@ -114,6 +116,30 @@ export class DefaultOrganizationUserService implements OrganizationUserService {
         return this.organizationUserApiService.restoreManyOrganizationUsers(
           organization.id,
           request,
+        );
+      }),
+    );
+  }
+
+  updateUser(
+    organization: Organization,
+    userId: string,
+    request: OrganizationUserUpdateRequest,
+  ): Observable<void> {
+    const exempt =
+      request.type === OrganizationUserType.Owner || request.type === OrganizationUserType.Admin;
+
+    if (exempt) {
+      return from(
+        this.organizationUserApiService.putOrganizationUser(organization.id, userId, request),
+      );
+    }
+
+    return this.getEncryptedDefaultCollectionName$(organization).pipe(
+      switchMap((collectionName) => {
+        request.defaultUserCollectionName = collectionName.encryptedString;
+        return from(
+          this.organizationUserApiService.putOrganizationUser(organization.id, userId, request),
         );
       }),
     );

--- a/libs/admin-console/src/common/organization-user/services/default-organization-user.service.ts
+++ b/libs/admin-console/src/common/organization-user/services/default-organization-user.service.ts
@@ -129,7 +129,10 @@ export class DefaultOrganizationUserService implements OrganizationUserService {
     const exempt =
       request.type === OrganizationUserType.Owner || request.type === OrganizationUserType.Admin;
 
-    if (exempt) {
+    const shouldSetDefaultCollection =
+      !exempt && organization.useMyItems && organization.usePolicies;
+
+    if (!shouldSetDefaultCollection) {
       return from(
         this.organizationUserApiService.putOrganizationUser(organization.id, userId, request),
       );


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-39554
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
This PR fixes an issue when an admin's role is demoted to a user, no "My Items" collection is created for them.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
