### PR TITLE
[PM-29790] Windows passkey plugin: unify signature verification 

### DIFF
--- a/apps/desktop/desktop_native/win_webauthn/src/api/plugin/com.rs
+++ b/apps/desktop/desktop_native/win_webauthn/src/api/plugin/com.rs
@@ -5,6 +5,7 @@
 use std::{
     alloc,
     mem::{size_of, ManuallyDrop, MaybeUninit},
+    ops::DerefMut,
     ptr::{self, NonNull},
     sync::{Arc, Mutex, OnceLock},
 };
@@ -27,7 +28,7 @@ use super::{
 };
 use crate::{
     api::{
-        plugin::{get_request_hash, get_request_signature},
+        plugin::{crypto::RequestHash, get_request_hash, SignedRequest},
         sys::plugin::{
             WEBAUTHN_PLUGIN_CANCEL_OPERATION_REQUEST, WEBAUTHN_PLUGIN_OPERATION_REQUEST,
             WEBAUTHN_PLUGIN_OPERATION_RESPONSE,
@@ -271,44 +272,34 @@ impl PluginAuthenticatorComObject {
         }
     }
 
-    fn cancel_operation(&self, request: PluginCancelOperationRequest) -> windows::core::Result<()> {
-        let mut guard = self.in_flight_request.lock().expect("not poisoned");
-
-        let Some(ctx) = guard.as_ref() else {
-            tracing::warn!("Received a request to cancel an operation, but no context was found");
-            return Err(E_FAIL.into());
-        };
-        let incoming_id = request.transaction_id();
-        if ctx.transaction_id != incoming_id {
-            tracing::warn!(
-                "Attempting to cancel operation with mismatched transaction ID. Expected {:?}, received {:?}",
-                ctx.transaction_id,
-                incoming_id
-            );
-            return Err(E_FAIL.into());
+    fn cancel_operation(
+        &self,
+        ctx: &mut Option<RequestContext>,
+        request: PluginCancelOperationRequest,
+    ) -> windows::core::Result<()> {
+        match ctx.as_ref() {
+            Some(ctx) => {
+                let incoming_id = request.transaction_id();
+                if ctx.transaction_id != incoming_id {
+                    tracing::warn!(
+                        "Attempting to cancel operation with mismatched transaction ID. Expected {:?}, received {:?}",
+                        ctx.transaction_id,
+                        incoming_id
+                    );
+                    return Err(E_FAIL.into());
+                }
+            }
+            None => {
+                tracing::warn!(
+                    "Received a request to cancel an operation, but no context was found"
+                );
+                return Err(E_FAIL.into());
+            }
         }
-        let signature = request.request_signature().map_err(|err| {
-            tracing::error!(%err, "Invalid request signature buffer in CancelOperation");
-            E_INVALIDARG
-        })?;
-
-        tracing::debug!("Retrieving signing key");
-        let op_pub_key = get_operation_signing_public_key(&self.clsid).map_err(|err| {
-            tracing::error!(%err, "Failed to get signing key for operation");
-            E_FAIL
-        })?;
-        tracing::debug!("Verifying signature");
-        op_pub_key
-            .verify_signature((&ctx.request_hash).into(), signature)
-            .map_err(|err| {
-                tracing::error!("Failed to verify request signature: {err}");
-                E_INVALIDARG
-            })?;
-        tracing::debug!("Signature verified");
 
         // Clean up request context here; regardless of whether the handler
         // succeeds or fails, we're ready for the next request.
-        _ = guard.take();
+        _ = ctx.take();
 
         // Pass to handler
         self.handler.cancel_operation(request).map_err(|err| {
@@ -368,24 +359,11 @@ impl PluginAuthenticatorComObject {
             "Method called with null request pointer from Windows. Aborting request.",
         ))?;
 
-        // Verify that the request came from the OS.
-        tracing::debug!("Verifying request");
         // SAFETY: WEBAUTHN_PLUGIN_OPERATION_REQUEST::request_hash() has the same safety
         // requirements as this function: the encoded request must be valid.
         let request_hash = unsafe { get_request_hash(request)? };
-        // SAFETY: WEBAUTHN_PLUGIN_OPERATION_REQUEST::signature() has the same safety requirements
-        // as this function: the encoded request must be valid.
-        let signature = unsafe { get_request_signature(request)? };
-        tracing::debug!("Retrieving signing key");
-        let op_pub_key = get_operation_signing_public_key(&self.clsid).map_err(|err| {
-            WinWebAuthnError::with_cause(
-                ErrorKind::WindowsInternal,
-                "Failed to get signing key for operation",
-                err,
-            )
-        })?;
-        tracing::debug!("Verifying signature");
-        op_pub_key.verify_signature((&request_hash).into(), signature)?;
+        self.verify_request_signature(&request, (&request_hash).into())?;
+
         // SAFETY: We verified the request came from the operating system, so
         // trust that it is well-formed.
         let request: T =
@@ -415,6 +393,62 @@ impl PluginAuthenticatorComObject {
         Ok(request)
     }
 
+    /// Reads a pointer as a cancel operation request and verifies its signature
+    /// as coming from the OS.
+    ///
+    /// # Safety: The `request_ptr` must be convertible to a reference.
+    unsafe fn initialize_cancel_request<'a>(
+        &self,
+        ctx: Option<&RequestContext>,
+        request_ptr: *const WEBAUTHN_PLUGIN_CANCEL_OPERATION_REQUEST,
+    ) -> Result<PluginCancelOperationRequest<'a>, WinWebAuthnError> {
+        if !request_ptr.is_aligned() {
+            return Err(WinWebAuthnError::new(
+                ErrorKind::InvalidArguments,
+                "cancel request pointer is unaligned",
+            ));
+        }
+
+        let request = unsafe { request_ptr.as_ref() }.ok_or(WinWebAuthnError::new(
+            ErrorKind::WindowsInternal,
+            "CancelOperation called with null request pointer from Windows. Aborting request.",
+        ))?;
+
+        let ctx = ctx.ok_or(WinWebAuthnError::new(
+            ErrorKind::WindowsInternal,
+            "No in-flight request found to cancel.",
+        ))?;
+
+        let request_hash = ctx.request_hash.clone();
+
+        self.verify_request_signature(&request, (&request_hash).into())?;
+
+        Ok(PluginCancelOperationRequest::from_ref(
+            request,
+            request_hash,
+        ))
+    }
+
+    /// Verifies a request signature.
+    fn verify_request_signature<T: SignedRequest>(
+        &self,
+        request: &T,
+        request_hash: RequestHash<'_>,
+    ) -> Result<(), WinWebAuthnError> {
+        // SAFETY: We're about to verify the signature, which will implicitly validate the length.
+        let signature = unsafe { request.get_request_signature()? };
+        tracing::debug!("Retrieving signing key");
+        let op_pub_key = get_operation_signing_public_key(&self.clsid).map_err(|err| {
+            WinWebAuthnError::with_cause(
+                ErrorKind::WindowsInternal,
+                "Failed to get signing key for operation",
+                err,
+            )
+        })?;
+        tracing::debug!("Verifying signature");
+        op_pub_key.verify_signature(request_hash, signature)?;
+        Ok(())
+    }
     fn complete_request(
         &self,
         request_transaction_id: GUID,
@@ -503,11 +537,19 @@ impl IPluginAuthenticator_Impl for PluginAuthenticatorComObject_Impl {
         request_ptr: *const WEBAUTHN_PLUGIN_CANCEL_OPERATION_REQUEST,
     ) -> HRESULT {
         tracing::debug!("CancelOperation called");
-        let request = match request_ptr.try_into() {
+        let mut ctx = self.in_flight_request.lock().expect("not poisoned");
+        // SAFETY: We assume that the request from the OS is convertible to a
+        // reference. The method will verify that the request comes from the OS.
+        let init_result = unsafe { self.initialize_cancel_request(ctx.as_ref(), request_ptr) };
+        let request = match init_result {
             Ok(request) => request,
-            Err(err) => return err,
+            Err(err) => {
+                tracing::error!(%err, "Invalid request passed to CancelOperation");
+                return E_INVALIDARG;
+            }
         };
-        let result = self.cancel_operation(request);
+
+        let result = self.cancel_operation(ctx.deref_mut(), request);
         result.into()
     }
 

--- a/apps/desktop/desktop_native/win_webauthn/src/api/plugin/mod.rs
+++ b/apps/desktop/desktop_native/win_webauthn/src/api/plugin/mod.rs
@@ -83,6 +83,10 @@ pub trait PluginAuthenticator {
     fn get_assertion(&self, request: PluginGetAssertionRequest) -> Result<Vec<u8>, Box<dyn Error>>;
 
     /// Cancel an ongoing operation.
+    ///
+    /// `request_hash` refers the hash of the original credential operation
+    /// request that is being cancelled, not the hash of the cancel operation
+    /// request.
     fn cancel_operation(&self, request: PluginCancelOperationRequest)
         -> Result<(), Box<dyn Error>>;
 

--- a/apps/desktop/desktop_native/win_webauthn/src/api/plugin/types/cancel_operation.rs
+++ b/apps/desktop/desktop_native/win_webauthn/src/api/plugin/types/cancel_operation.rs
@@ -1,90 +1,45 @@
-use std::{marker::PhantomData, ptr::NonNull};
-
-use windows::{
-    core::{GUID, HRESULT},
-    Win32::Foundation::E_INVALIDARG,
-};
+use windows::core::GUID;
 
 use crate::{
-    api::{plugin::crypto::Signature, sys::plugin::WEBAUTHN_PLUGIN_CANCEL_OPERATION_REQUEST},
+    api::{
+        plugin::{crypto::OwnedRequestHash, SignedRequest},
+        sys::plugin::WEBAUTHN_PLUGIN_CANCEL_OPERATION_REQUEST,
+    },
     ErrorKind, WinWebAuthnError,
 };
 
 pub struct PluginCancelOperationRequest<'a> {
-    inner: NonNull<WEBAUTHN_PLUGIN_CANCEL_OPERATION_REQUEST>,
-    _phantom: PhantomData<&'a WEBAUTHN_PLUGIN_CANCEL_OPERATION_REQUEST>,
+    inner: &'a WEBAUTHN_PLUGIN_CANCEL_OPERATION_REQUEST,
+    /// Request hash of the _original_ operation this cancel request is referring to.
+    request_hash: OwnedRequestHash,
 }
 
-impl PluginCancelOperationRequest<'_> {
+impl<'a> PluginCancelOperationRequest<'a> {
     /// Request transaction ID
     pub fn transaction_id(&self) -> GUID {
-        self.as_ref().transactionId
+        // SAFETY: The pointer is received from Windows, so we assume it's correct.
+        unsafe { self.inner.transactionId }
     }
 
-    /// Request signature.
-    pub(in crate::api::plugin) fn request_signature(
-        &self,
-    ) -> Result<Signature<'_>, WinWebAuthnError> {
-        let inner = self.as_ref();
-        if inner.pbRequestSignature.is_null() {
-            return Err(WinWebAuthnError::new(
-                ErrorKind::InvalidArguments,
-                "cancel request signature buffer pointer is null",
-            ));
-        } else if !inner.pbRequestSignature.is_aligned() {
-            return Err(WinWebAuthnError::new(
-                ErrorKind::InvalidArguments,
-                "cancel request signature buffer pointer is not aligned",
-            ));
-        }
-
-        // SAFETY: The signature buffer pointer is non-null and aligned, and Windows provides a
-        // buffer of length cbRequestSignature.
-        let slice = unsafe {
-            std::slice::from_raw_parts(inner.pbRequestSignature, inner.cbRequestSignature as usize)
-        };
-        Ok(Signature::new(slice))
+    /// The SHA-256 hash of the original plugin operation request.
+    /// Can be used along with the transaction ID to correlate the original cancellation request.
+    pub fn operation_request_hash(&self) -> &[u8] {
+        &self.request_hash.0
     }
-}
 
-impl AsRef<WEBAUTHN_PLUGIN_CANCEL_OPERATION_REQUEST> for PluginCancelOperationRequest<'_> {
-    fn as_ref(&self) -> &WEBAUTHN_PLUGIN_CANCEL_OPERATION_REQUEST {
-        // SAFETY: Pointer is received from Windows so we assume it is correct.
-        unsafe { self.inner.as_ref() }
-    }
-}
-
-#[doc(hidden)]
-impl From<NonNull<WEBAUTHN_PLUGIN_CANCEL_OPERATION_REQUEST>> for PluginCancelOperationRequest<'_> {
-    fn from(value: NonNull<WEBAUTHN_PLUGIN_CANCEL_OPERATION_REQUEST>) -> Self {
+    pub(in crate::api::plugin) fn from_ref(
+        value: &'a WEBAUTHN_PLUGIN_CANCEL_OPERATION_REQUEST,
+        request_hash: OwnedRequestHash,
+    ) -> Self {
         Self {
             inner: value,
-            _phantom: PhantomData,
+            request_hash,
         }
     }
 }
 
-#[doc(hidden)]
-impl TryFrom<*const WEBAUTHN_PLUGIN_CANCEL_OPERATION_REQUEST> for PluginCancelOperationRequest<'_> {
-    type Error = HRESULT;
-    fn try_from(
-        value: *const WEBAUTHN_PLUGIN_CANCEL_OPERATION_REQUEST,
-    ) -> Result<Self, Self::Error> {
-        let op_request_ptr = match NonNull::new(value.cast_mut()) {
-            Some(p) => p,
-            None => {
-                tracing::warn!(
-                    "CancelOperation called with null request pointer from Windows. Aborting request."
-                );
-                return Err(E_INVALIDARG);
-            }
-        };
-        if !op_request_ptr.is_aligned() {
-            return Err(E_INVALIDARG);
-        }
-        Ok(Self {
-            inner: op_request_ptr,
-            _phantom: PhantomData,
-        })
+impl SignedRequest for &WEBAUTHN_PLUGIN_CANCEL_OPERATION_REQUEST {
+    fn get_signature_parts(&self) -> (u32, *const u8) {
+        (self.cbRequestSignature, self.pbRequestSignature)
     }
 }

--- a/apps/desktop/desktop_native/win_webauthn/src/api/plugin/types/operation.rs
+++ b/apps/desktop/desktop_native/win_webauthn/src/api/plugin/types/operation.rs
@@ -22,41 +22,6 @@ use crate::{
 
 // Generic Operation types
 
-/// Extract the signature from an operation request.
-///
-/// The signature is made by the OS over the SHA-256 hash of the operation
-/// request buffer using the signing key created during authenticator
-/// registration and retrievable via
-/// [webauthn_plugin_get_operation_signing_public_key](crate::plugin::crypto::webauthn_plugin_get_operation_signing_public_key).
-///
-/// # Safety
-/// The caller must ensure that `request.pbRequestSignature` points to a valid non-null byte
-/// string of length `request.cbRequestSignature`.
-pub(in crate::api::plugin) unsafe fn get_request_signature(
-    request: &WEBAUTHN_PLUGIN_OPERATION_REQUEST,
-) -> Result<Signature<'_>, WinWebAuthnError> {
-    if request.pbRequestSignature.is_null() {
-        return Err(WinWebAuthnError::new(
-            ErrorKind::InvalidArguments,
-            "request signature buffer pointer is null",
-        ));
-    } else if !request.pbRequestSignature.is_aligned() {
-        return Err(WinWebAuthnError::new(
-            ErrorKind::InvalidArguments,
-            "request signature buffer pointer is not aligned",
-        ));
-    }
-
-    // SAFETY: The caller must make sure that the encoded request is valid.
-    let signature = unsafe {
-        std::slice::from_raw_parts(
-            request.pbRequestSignature,
-            request.cbRequestSignature as usize,
-        )
-    };
-    Ok(Signature::new(signature))
-}
-
 /// Calculate a SHA-256 hash over the request.
 ///
 /// # Safety
@@ -230,5 +195,44 @@ pub(crate) fn get_operation_signing_public_key(
             ErrorKind::WindowsInternal,
             "Windows returned null pointer when requesting operation signing public key",
         )),
+    }
+}
+
+pub(in crate::api::plugin) trait SignedRequest {
+    fn get_signature_parts(&self) -> (u32, *const u8);
+
+    /// Extract the signature from an operation request.
+    ///
+    /// The signature is made by the OS over the SHA-256 hash of the operation
+    /// request buffer using the signing key created during authenticator
+    /// registration and retrievable via
+    /// [webauthn_plugin_get_operation_signing_public_key](crate::plugin::crypto::webauthn_plugin_get_operation_signing_public_key).
+    ///
+    /// # Safety
+    /// The caller must ensure that `request.pbRequestSignature` points to a valid non-null byte
+    /// string of length `request.cbRequestSignature`.
+    unsafe fn get_request_signature(&self) -> Result<Signature<'_>, WinWebAuthnError> {
+        let (count, ptr) = self.get_signature_parts();
+        if ptr.is_null() {
+            return Err(WinWebAuthnError::new(
+                ErrorKind::InvalidArguments,
+                "request signature buffer pointer is null",
+            ));
+        } else if !ptr.is_aligned() {
+            return Err(WinWebAuthnError::new(
+                ErrorKind::InvalidArguments,
+                "request signature buffer pointer is not aligned",
+            ));
+        }
+
+        // SAFETY: The caller must make sure that the encoded request is valid.
+        let signature = unsafe { std::slice::from_raw_parts(ptr, count as usize) };
+        Ok(Signature::new(signature))
+    }
+}
+
+impl SignedRequest for &WEBAUTHN_PLUGIN_OPERATION_REQUEST {
+    fn get_signature_parts(&self) -> (u32, *const u8) {
+        (self.cbRequestSignature, self.pbRequestSignature)
     }
 }

--- a/apps/desktop/desktop_native/windows_plugin_authenticator/src/authenticator.rs
+++ b/apps/desktop/desktop_native/windows_plugin_authenticator/src/authenticator.rs
@@ -26,7 +26,10 @@ use windows::{
     },
 };
 
-use crate::ipc::{IpcClient, IpcConnector, RealIpcConnector};
+use crate::{
+    ipc::{IpcClient, IpcConnector, RealIpcConnector},
+    util::create_context_string,
+};
 
 pub(super) fn run_server(clsid: Clsid) -> Result<WebAuthnPlugin, String> {
     tracing::debug!("Setting up COM server");
@@ -194,11 +197,11 @@ impl<C: IpcConnector> PluginAuthenticator for BitwardenPluginAuthenticator<C> {
             .callbacks
             .lock()
             .expect("not poisoned")
-            .get(&request.transaction_id())
+            .get(&transaction_id)
         {
             _ = cancellation_token.send(());
             let client = self.get_client()?;
-            let context = STANDARD.encode(transaction_id.to_u128().to_le_bytes());
+            let context = create_context_string(transaction_id, request.operation_request_hash());
             tracing::debug!("Sending cancel operation for context: {context}");
             client.send_native_status("cancel-operation".to_string(), context);
         }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-29790](https://bitwarden.atlassian.net/browse/PM-29790)

## 📔 Objective

Following up from a [previous review comment](https://github.com/bitwarden/clients/pull/21622#discussion_r3513676812), the context strings between get/create requests and cancel requests are different. That requires the desktop app to parse the transaction ID instead of just storing the context string opaquely for cancellation. (The user verification request still does need to parse the request context.)

This unifies this by adding the request hash to the context string.

To get there though, we have to add the request hash to the context, causing extra plumbing during the initial verification. To simplify that, we also use a single function to verify an operation request, whether it is a get/create/cancel.

This makes cancel operation behave much more like get/create.

[PM-29790]: https://bitwarden.atlassian.net/browse/PM-29790?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ