### PR TITLE
[PM-39900] Enhance PoliciesComponent to clear drawer reference after closing

### DIFF
--- a/apps/web/src/app/admin-console/organizations/policies/policies.component.spec.ts
+++ b/apps/web/src/app/admin-console/organizations/policies/policies.component.spec.ts
@@ -624,5 +624,46 @@ describe("PoliciesComponent", () => {
       });
       expect(mockDrawerDialog.open).not.toHaveBeenCalled();
     });
+
+    it("clears the drawer ref once it closes, so canDeactivate doesn't re-close a stale ref", async () => {
+      mockConfigService.getFeatureFlag$.mockReturnValue(of(true));
+
+      fixture = TestBed.createComponent(PoliciesComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+
+      // Simulate the real DrawerRef behavior: calling close() on an already-closed ref
+      // short-circuits to `{ closed: false }`. If the component failed to clear its
+      // `drawerRef` signal after the drawer closed, canDeactivate() would call this again
+      // and incorrectly block navigation.
+      const closeSpy = jest.fn().mockResolvedValue({ closed: false });
+      const mockDrawerRef = { close: closeSpy, closed: of(undefined) };
+      const mockDrawerDialog = {
+        open: jest.fn(),
+        openDrawer: jest.fn().mockReturnValue(mockDrawerRef),
+      };
+
+      const mockPolicy: BasePolicyEditDefinition = {
+        name: "Drawer Policy",
+        description: "Drawer Description",
+        type: PolicyType.TwoFactorAuthentication,
+        category: PolicyCategory.Authentication,
+        priority: 10,
+        component: {} as any,
+        editDialogComponent: mockDrawerDialog as any,
+        showDescription: true,
+        showEnabledBadge: false,
+        display$: () => of(true),
+      };
+
+      // The drawer's `closed` observable (of(undefined)) completes synchronously once
+      // subscribed, simulating a save/cancel that already closed the drawer.
+      await component.edit(mockPolicy, mockOrg);
+
+      const canLeave = await component.canDeactivate();
+
+      expect(canLeave).toBe(true);
+      expect(closeSpy).not.toHaveBeenCalled();
+    });
   });
 });

--- a/apps/web/src/app/admin-console/organizations/policies/policies.component.ts
+++ b/apps/web/src/app/admin-console/organizations/policies/policies.component.ts
@@ -199,7 +199,15 @@ export class PoliciesComponent {
       });
       if (ref !== undefined) {
         this.drawerRef.set(ref);
-        await lastValueFrom(ref.closed);
+        try {
+          await lastValueFrom(ref.closed);
+        } finally {
+          // Once closed, this ref is permanently spent (DrawerRef.close() short-circuits to
+          // `{ closed: false }` on a ref that's already closed). Clear it so canDeactivate()
+          // doesn't try to re-close a stale ref and incorrectly block navigation away from
+          // this page after a save/cancel.
+          this.drawerRef.set(undefined);
+        }
         if (triggerEl?.isConnected) {
           triggerEl.focus();
         }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-39900

## 📔 Objective

Fixes bug with drawers where enable/disable policy then prevents navigation because drawer ref still believes it is open and should block navigation...
