### PR TITLE
[PM-39556] Fix access selector not saving changes when the dialog field is modified

### DIFF
--- a/apps/web/src/app/admin-console/organizations/members/components/edit-member-dialog/edit-member-dialog.component.ts
+++ b/apps/web/src/app/admin-console/organizations/members/components/edit-member-dialog/edit-member-dialog.component.ts
@@ -240,6 +240,8 @@ export class EditMemberDialogComponent {
       ),
     );
 
+    let formInitialized = false;
+
     combineLatest({
       organization: this.organization$,
       collections: collections$,
@@ -277,8 +279,13 @@ export class EditMemberDialogComponent {
           return;
         }
 
-        this.loadOrganizationUser(userDetails, groups, collections, organization);
-        this.loading.set(false);
+        // Only patch the form on first load — subsequent emissions update the item list
+        // (collectionAccessItems) but must not overwrite user-made permission changes.
+        if (!formInitialized) {
+          formInitialized = true;
+          this.loadOrganizationUser(userDetails, groups, collections, organization);
+          this.loading.set(false);
+        }
       });
   }
 

--- a/apps/web/src/app/admin-console/organizations/shared/components/access-selector/access-selector.component.spec.ts
+++ b/apps/web/src/app/admin-console/organizations/shared/components/access-selector/access-selector.component.spec.ts
@@ -123,6 +123,76 @@ describe("AccessSelectorComponent", () => {
       );
     });
 
+    it("should preserve permission changes when items input re-emits", () => {
+      // Arrange — set up item with an initial writeValue, then change permission in the table
+      const collectionItem = {
+        id: "123",
+        type: AccessItemType.Group,
+        labelName: "Group 1",
+        listName: "Group 1",
+      };
+      component.writeValue([
+        { id: "123", type: AccessItemType.Group, permission: CollectionPermission.View },
+      ]);
+      fixture.componentRef.setInput("permissionMode", PermissionMode.Edit);
+      fixture.detectChanges();
+
+      component.changeSelectedItemPerm(0, CollectionPermission.Edit);
+
+      const mockChange = jest.fn();
+      component.registerOnChange(mockChange);
+
+      // Act — items input re-emits (simulating async stream re-emission)
+      fixture.componentRef.setInput("items", [collectionItem]);
+      fixture.detectChanges();
+
+      // Assert — re-emission must not revert the user's permission change
+      expect(mockChange.mock.lastCall?.[0]).toHaveProperty(
+        "[0].permission",
+        CollectionPermission.Edit,
+      );
+    });
+
+    it("should preserve table permission changes when writeValue is called again before items re-emit", () => {
+      // Arrange — simulate: permission dropdown changes → writeValue called → items re-emit
+      const collectionItem = {
+        id: "123",
+        type: AccessItemType.Group,
+        labelName: "Group 1",
+        listName: "Group 1",
+      };
+      fixture.componentRef.setInput("permissionMode", PermissionMode.Edit);
+      fixture.detectChanges();
+
+      // First writeValue (initial load)
+      component.writeValue([
+        { id: "123", type: AccessItemType.Group, permission: CollectionPermission.View },
+      ]);
+      fixture.detectChanges();
+
+      // User changes permission in the table
+      component.changeSelectedItemPerm(0, CollectionPermission.Manage);
+
+      // writeValue called again (simulating form patchValue from parent re-emission)
+      component.writeValue([
+        { id: "123", type: AccessItemType.Group, permission: CollectionPermission.Edit },
+      ]);
+      fixture.detectChanges();
+
+      const mockChange = jest.fn();
+      component.registerOnChange(mockChange);
+
+      // Act — items re-emit after the second writeValue
+      fixture.componentRef.setInput("items", [collectionItem]);
+      fixture.detectChanges();
+
+      // Assert — second writeValue value applies (Edit), not the stale first one (View)
+      expect(mockChange.mock.lastCall?.[0]).toHaveProperty(
+        "[0].permission",
+        CollectionPermission.Edit,
+      );
+    });
+
     it("should emit value change when a row is removed", () => {
       // Arrange
       const mockChange = jest.fn();

--- a/apps/web/src/app/admin-console/organizations/shared/components/access-selector/access-selector.component.ts
+++ b/apps/web/src/app/admin-console/organizations/shared/components/access-selector/access-selector.component.ts
@@ -250,11 +250,10 @@ export class AccessSelectorComponent implements ControlValueAccessor {
 
     effect(() => {
       const val = this.items();
-      const selected = (
-        this.pendingValue() ??
-        this.selectionList.formArray.getRawValue() ??
-        []
-      ).concat(val.filter((m) => m.readonly));
+      const pending = this.pendingValue();
+      const selected = (pending ?? this.selectionList.formArray.getRawValue() ?? []).concat(
+        val.filter((m) => m.readonly),
+      );
       this.selectionList.populateItems(
         val.map((m) => {
           m.icon = m.icon ?? this.itemIcon(m); // Ensure an icon is set
@@ -263,6 +262,11 @@ export class AccessSelectorComponent implements ControlValueAccessor {
         selected,
       );
       this.selectedItems.set([...this.selectionList.selectedItems]);
+      // Clear after applying so subsequent items reloads use live form state,
+      // not the original writeValue — otherwise user permission changes get overwritten.
+      if (pending !== null) {
+        this.pendingValue.set(null);
+      }
     });
 
     effect(() => {

--- a/apps/web/src/app/admin-console/organizations/shared/components/access-selector/access-selector.component.ts
+++ b/apps/web/src/app/admin-console/organizations/shared/components/access-selector/access-selector.component.ts
@@ -7,6 +7,7 @@ import {
   inject,
   input,
   signal,
+  untracked,
 } from "@angular/core";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import {
@@ -254,6 +255,9 @@ export class AccessSelectorComponent implements ControlValueAccessor {
       const selected = (pending ?? this.selectionList.formArray.getRawValue() ?? []).concat(
         val.filter((m) => m.readonly),
       );
+      if (pending != null) {
+        untracked(() => this.pendingValue.set(null));
+      }
       this.selectionList.populateItems(
         val.map((m) => {
           m.icon = m.icon ?? this.itemIcon(m); // Ensure an icon is set
@@ -262,11 +266,6 @@ export class AccessSelectorComponent implements ControlValueAccessor {
         selected,
       );
       this.selectedItems.set([...this.selectionList.selectedItems]);
-      // Clear after applying so subsequent items reloads use live form state,
-      // not the original writeValue — otherwise user permission changes get overwritten.
-      if (pending !== null) {
-        this.pendingValue.set(null);
-      }
     });
 
     effect(() => {


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-39556
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
When changes are made to collection permission when editing a member with the access selector table, if the collection permission field above is modified the access selector changes are lost. This PR fixes this and decouples pending changes to the field from the access selector
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
