### PR TITLE
[BRE-2044] Migrate Auto Bump Desktop Version workflow logic to the deploy repo

### DIFF
--- a/.github/workflows/version-auto-bump.yml
+++ b/.github/workflows/version-auto-bump.yml
@@ -5,80 +5,19 @@ on:
     tags:
       - desktop-v**
 
+permissions: {}
+
 jobs:
-  bump-version:
-    name: Bump Desktop Version
+  trigger:
+    name: Trigger version-auto-bump-desktop
     runs-on: ubuntu-24.04
     permissions:
       id-token: write
-      contents: write
     steps:
-      - name: Log in to Azure
-        uses: bitwarden/gh-actions/azure-login@main
+      - name: Trigger deployment
+        uses: bitwarden/gh-actions/trigger-actions@main
         with:
-          subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-          tenant_id: ${{ secrets.AZURE_TENANT_ID }}
-          client_id: ${{ secrets.AZURE_CLIENT_ID }}
-
-      - name: Get Azure Key Vault secrets
-        id: get-kv-secrets
-        uses: bitwarden/gh-actions/get-keyvault-secrets@main
-        with:
-          keyvault: gh-org-bitwarden
-          secrets: "BW-GHAPP-ID,BW-GHAPP-KEY"
-
-      - name: Log out from Azure
-        uses: bitwarden/gh-actions/azure-logout@main
-
-      - name: Generate GH App token
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
-        id: app-token
-        with:
-          app-id: ${{ steps.get-kv-secrets.outputs.BW-GHAPP-ID }}
-          private-key: ${{ steps.get-kv-secrets.outputs.BW-GHAPP-KEY }}
-          permission-contents: write # for committing and pushing to the current branch
-
-      - name: Check out target ref
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: main
-          token: ${{ steps.app-token.outputs.token }}
-          persist-credentials: true
-
-      - name: Configure Git
-        run: |
-          git config --local user.email "actions@github.com"
-          git config --local user.name "Github Actions"
-
-      - name: Get current Desktop version
-        id: current-desktop-version
-        run: |
-          CURRENT_VERSION=$(cat package.json | jq -r '.version')
-          echo "version=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
-        working-directory: apps/desktop
-
-      - name: Calculate next Desktop release version
-        id: calculate-next-desktop-version
-        uses: bitwarden/gh-actions/version-next@main
-        with:
-          version: ${{ steps.current-desktop-version.outputs.version }}
-
-      - name: Bump Desktop Version - Root - Automatic Calculation
-        id: bump-desktop-version-automatic
-        env:
-          VERSION: ${{ steps.calculate-next-desktop-version.outputs.version }}
-        run: npm version --workspace=@bitwarden/desktop "$VERSION"
-
-      - name: Bump Desktop Version - App - Automatic Calculation
-        env:
-          VERSION: ${{ steps.calculate-next-desktop-version.outputs.version }}
-        run: npm version "$VERSION"
-        working-directory: "apps/desktop/src"
-
-      - name: Commit files
-        env:
-          VERSION: ${{ steps.calculate-next-desktop-version.outputs.version }}
-        run: git commit -m "Bumped Desktop client to $VERSION" -a
-
-      - name: Push changes
-        run: git push
+          azure_subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          azure_tenant_id: ${{ secrets.AZURE_TENANT_ID }}
+          azure_client_id: ${{ secrets.AZURE_CLIENT_ID }}
+          task: version-auto-bump-desktop


### PR DESCRIPTION
## 🎟️ Tracking

[BRE-2044](https://bitwarden.atlassian.net/browse/BRE-2044)

## 📔 Objective

The logic for bumping the Desktop client to the next version automatically has been moved to the deploy repository. The Auto Bump Desktop Version workflow has been updated to act as a trigger to send a task to the deploy repo to initiate the version bump.

[BRE-2044]: https://bitwarden.atlassian.net/browse/BRE-2044?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ