### PR TITLE
[BRE-2044] Bump Desktop client to v2026.6.2

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bitwarden/desktop",
   "description": "A secure and free password manager for all of your devices.",
-  "version": "2026.6.1",
+  "version": "2026.6.2",
   "keywords": [
     "bitwarden",
     "password",

--- a/apps/desktop/src/package-lock.json
+++ b/apps/desktop/src/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bitwarden/desktop",
-  "version": "2026.6.1",
+  "version": "2026.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bitwarden/desktop",
-      "version": "2026.6.1",
+      "version": "2026.6.2",
       "license": "GPL-3.0",
       "dependencies": {
         "@bitwarden/desktop-napi": "file:../desktop_native/napi"

--- a/apps/desktop/src/package.json
+++ b/apps/desktop/src/package.json
@@ -2,7 +2,7 @@
   "name": "@bitwarden/desktop",
   "productName": "Bitwarden",
   "description": "A secure and free password manager for all of your devices.",
-  "version": "2026.6.1",
+  "version": "2026.6.2",
   "author": "Bitwarden Inc. <hello@bitwarden.com> (https://bitwarden.com)",
   "homepage": "https://bitwarden.com",
   "license": "GPL-3.0",


### PR DESCRIPTION
## 🎟️ Tracking

[BRE-2044](https://bitwarden.atlassian.net/browse/BRE-2044)

## 📔 Objective

This PR bumps the Desktop client to v2026.6.2.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

[BRE-2044]: https://bitwarden.atlassian.net/browse/BRE-2044?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ