### PR TITLE
[PM-37196] Tooltip expand max-width

### DIFF
--- a/libs/components/src/tooltip/tooltip.component.css
+++ b/libs/components/src/tooltip/tooltip.component.css
@@ -8,7 +8,7 @@
 
 .bit-tooltip-container {
   position: relative;
-  max-width: 12rem;
+  max-width: 12.25rem;
   opacity: 0;
   width: max-content;
   box-shadow:
@@ -121,7 +121,7 @@
 
 .bit-tooltip {
   width: max-content;
-  max-width: 12rem;
+  max-width: 13rem;
   background-color: rgb(var(--color-text-main));
   color: rgb(var(--color-text-contrast));
   padding: 0.5rem 0.75rem;


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-37196

## 📔 Objective

Expands the max-width from `12rem` for tooltips to `12.25rem` so the tooltip for revocation reasons is 2 liner instead of 3 liner...

## 📸 Screenshots

Old:
<img width="1920" height="786" alt="image" src="https://github.com/user-attachments/assets/282cdebe-c0e8-4968-9a95-13d0623ec7a0" />

New:
<img width="390" height="197" alt="image" src="https://github.com/user-attachments/assets/dc3e3d56-4b9f-4bec-839f-8295275b3acd" />

