### PR TITLE
Add Early Access option on desktop, extension, and web clients

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -6889,19 +6889,19 @@
   "cannotSaveItemNoConfirmedOrgs": {
     "message": "Unable to save item. You must be confirmed to the organization to save items."
   },
-  "betaMode": {
-    "message": "Beta mode"
+  "earlyAccess": {
+    "message": "Early access"
   },
-  "betaModeDesc": {
+  "earlyAccessDesc": {
     "message": "Enable early access to features currently in prerelease testing"
   },
-  "enableBetaModeConfirmTitle": {
-    "message": "Enable beta mode?"
+  "enableEarlyAccessConfirmTitle": {
+    "message": "Enable early access?"
   },
-  "enableBetaModeConfirmContent": {
-    "message": "Beta features are still in testing and may be unstable or change without notice."
+  "enableEarlyAccessConfirmContent": {
+    "message": "Early access features are still in testing and may be unstable or change without notice."
   },
-  "betaModeEnabledToast": {
-    "message": "Beta mode enabled. Reopen the app to make sure all features refresh."
+  "earlyAccessEnabledToast": {
+    "message": "Early access enabled."
   }
 }

--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -6888,5 +6888,20 @@
   },
   "cannotSaveItemNoConfirmedOrgs": {
     "message": "Unable to save item. You must be confirmed to the organization to save items."
+  },
+  "betaMode": {
+    "message": "Beta mode"
+  },
+  "betaModeDesc": {
+    "message": "Enable early access to features currently in prerelease testing"
+  },
+  "enableBetaModeConfirmTitle": {
+    "message": "Enable beta mode?"
+  },
+  "enableBetaModeConfirmContent": {
+    "message": "Beta features are still in testing and may be unstable or change without notice."
+  },
+  "betaModeEnabledToast": {
+    "message": "Beta mode enabled. Reopen the app to make sure all features refresh."
   }
 }

--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -6900,8 +6900,5 @@
   },
   "enableEarlyAccessConfirmContent": {
     "message": "Early access features are still in testing and may be unstable or change without notice."
-  },
-  "earlyAccessEnabledToast": {
-    "message": "Early access enabled."
   }
 }

--- a/apps/browser/src/tools/popup/settings/about-page/about-page-v2.component.html
+++ b/apps/browser/src/tools/popup/settings/about-page/about-page-v2.component.html
@@ -37,20 +37,12 @@
   </bit-item-group>
 
   @if (showEarlyAccessToggle()) {
-    <h2 bitTypography="h6" class="tw-font-medium tw-mt-4">{{ "earlyAccess" | i18n }}</h2>
-    <bit-card>
-      <form [formGroup]="earlyAccessForm">
-        <bit-form-control disableMargin>
-          <input
-            bitCheckbox
-            id="about-page_input_early-access"
-            formControlName="earlyAccess"
-            type="checkbox"
-          />
-          <bit-label>{{ "earlyAccess" | i18n }}</bit-label>
-          <bit-hint>{{ "earlyAccessDesc" | i18n }}</bit-hint>
-        </bit-form-control>
-      </form>
-    </bit-card>
+    <form [formGroup]="earlyAccessForm" class="tw-mt-4">
+      <bit-form-control-card>
+        <bit-switch id="about-page_input_early-access" formControlName="earlyAccess"></bit-switch>
+        <bit-label>{{ "earlyAccess" | i18n }}</bit-label>
+        <bit-hint>{{ "earlyAccessDesc" | i18n }}</bit-hint>
+      </bit-form-control-card>
+    </form>
   }
 </popup-page>

--- a/apps/browser/src/tools/popup/settings/about-page/about-page-v2.component.html
+++ b/apps/browser/src/tools/popup/settings/about-page/about-page-v2.component.html
@@ -35,4 +35,22 @@
       </button>
     </bit-item>
   </bit-item-group>
+
+  @if (showBetaToggle()) {
+    <h2 bitTypography="h6" class="tw-font-medium tw-mt-4">{{ "betaMode" | i18n }}</h2>
+    <bit-card>
+      <form [formGroup]="betaModeForm">
+        <bit-form-control disableMargin>
+          <input
+            bitCheckbox
+            id="about-page_input_beta-mode"
+            formControlName="betaMode"
+            type="checkbox"
+          />
+          <bit-label>{{ "betaMode" | i18n }}</bit-label>
+          <bit-hint>{{ "betaModeDesc" | i18n }}</bit-hint>
+        </bit-form-control>
+      </form>
+    </bit-card>
+  }
 </popup-page>

--- a/apps/browser/src/tools/popup/settings/about-page/about-page-v2.component.html
+++ b/apps/browser/src/tools/popup/settings/about-page/about-page-v2.component.html
@@ -36,19 +36,19 @@
     </bit-item>
   </bit-item-group>
 
-  @if (showBetaToggle()) {
-    <h2 bitTypography="h6" class="tw-font-medium tw-mt-4">{{ "betaMode" | i18n }}</h2>
+  @if (showEarlyAccessToggle()) {
+    <h2 bitTypography="h6" class="tw-font-medium tw-mt-4">{{ "earlyAccess" | i18n }}</h2>
     <bit-card>
-      <form [formGroup]="betaModeForm">
+      <form [formGroup]="earlyAccessForm">
         <bit-form-control disableMargin>
           <input
             bitCheckbox
-            id="about-page_input_beta-mode"
-            formControlName="betaMode"
+            id="about-page_input_early-access"
+            formControlName="earlyAccess"
             type="checkbox"
           />
-          <bit-label>{{ "betaMode" | i18n }}</bit-label>
-          <bit-hint>{{ "betaModeDesc" | i18n }}</bit-hint>
+          <bit-label>{{ "earlyAccess" | i18n }}</bit-label>
+          <bit-hint>{{ "earlyAccessDesc" | i18n }}</bit-hint>
         </bit-form-control>
       </form>
     </bit-card>

--- a/apps/browser/src/tools/popup/settings/about-page/about-page-v2.component.ts
+++ b/apps/browser/src/tools/popup/settings/about-page/about-page-v2.component.ts
@@ -17,12 +17,11 @@ import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/pl
 import { ValidationService } from "@bitwarden/common/platform/abstractions/validation.service";
 import { EarlyAccessService } from "@bitwarden/common/platform/services/early-access/early-access.service";
 import {
-  CardComponent,
   CenterPositionStrategy,
-  CheckboxModule,
   DialogService,
-  FormFieldModule,
+  FormControlModule,
   ItemModule,
+  SwitchComponent,
 } from "@bitwarden/components";
 import { TroubleshootingDialogComponent } from "@bitwarden/logging-angular";
 import { I18nPipe } from "@bitwarden/ui-common";
@@ -60,9 +59,8 @@ const RateUrls = {
     PopupHeaderComponent,
     PopOutComponent,
     ItemModule,
-    CardComponent,
-    CheckboxModule,
-    FormFieldModule,
+    FormControlModule,
+    SwitchComponent,
     I18nPipe,
   ],
 })

--- a/apps/browser/src/tools/popup/settings/about-page/about-page-v2.component.ts
+++ b/apps/browser/src/tools/popup/settings/about-page/about-page-v2.component.ts
@@ -1,12 +1,26 @@
 import { CommonModule } from "@angular/common";
-import { Component } from "@angular/core";
+import { Component, DestroyRef, OnInit, inject } from "@angular/core";
+import { takeUntilDestroyed, toSignal } from "@angular/core/rxjs-interop";
+import { FormBuilder, ReactiveFormsModule } from "@angular/forms";
 import { RouterModule } from "@angular/router";
 import { firstValueFrom } from "rxjs";
 
+import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { DeviceType } from "@bitwarden/common/enums";
+import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { EnvironmentService } from "@bitwarden/common/platform/abstractions/environment.service";
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
-import { CenterPositionStrategy, DialogService, ItemModule } from "@bitwarden/components";
+import {
+  CardComponent,
+  CenterPositionStrategy,
+  CheckboxModule,
+  DialogService,
+  FormFieldModule,
+  ItemModule,
+  ToastService,
+} from "@bitwarden/components";
 import { TroubleshootingDialogComponent } from "@bitwarden/logging-angular";
 import { I18nPipe } from "@bitwarden/ui-common";
 
@@ -37,19 +51,72 @@ const RateUrls = {
   imports: [
     CommonModule,
     RouterModule,
+    ReactiveFormsModule,
+    JslibModule,
     PopupPageComponent,
     PopupHeaderComponent,
     PopOutComponent,
     ItemModule,
+    CardComponent,
+    CheckboxModule,
+    FormFieldModule,
     I18nPipe,
   ],
 })
-export class AboutPageV2Component {
+export class AboutPageV2Component implements OnInit {
+  private configService = inject(ConfigService);
+  private toastService = inject(ToastService);
+  private i18nService = inject(I18nService);
+  private formBuilder = inject(FormBuilder);
+  private destroyRef = inject(DestroyRef);
+
+  protected betaModeForm = this.formBuilder.group({ betaMode: false });
+
+  protected readonly showBetaToggle = toSignal(
+    this.configService.getFeatureFlag$(FeatureFlag.PM39893BetaMode),
+    { initialValue: false },
+  );
+
   constructor(
     private dialogService: DialogService,
     private environmentService: EnvironmentService,
     private platformUtilsService: PlatformUtilsService,
   ) {}
+
+  async ngOnInit(): Promise<void> {
+    const current = await firstValueFrom(this.configService.betaMode$);
+    this.betaModeForm.controls.betaMode.setValue(current, { emitEvent: false });
+
+    this.betaModeForm.controls.betaMode.valueChanges
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((enabled) => {
+        void this.onBetaModeChange(enabled ?? false);
+      });
+  }
+
+  private async onBetaModeChange(enabled: boolean): Promise<void> {
+    if (enabled) {
+      const confirmed = await this.dialogService.openSimpleDialog({
+        title: { key: "enableBetaModeConfirmTitle" },
+        content: { key: "enableBetaModeConfirmContent" },
+        type: "warning",
+      });
+
+      if (!confirmed) {
+        this.betaModeForm.controls.betaMode.setValue(false, { emitEvent: false });
+        return;
+      }
+
+      await this.configService.setBetaMode(true);
+      this.toastService.showToast({
+        variant: "info",
+        message: this.i18nService.t("betaModeEnabledToast"),
+      });
+      return;
+    }
+
+    await this.configService.setBetaMode(false);
+  }
 
   about() {
     this.dialogService.open(AboutDialogComponent, {

--- a/apps/browser/src/tools/popup/settings/about-page/about-page-v2.component.ts
+++ b/apps/browser/src/tools/popup/settings/about-page/about-page-v2.component.ts
@@ -3,7 +3,7 @@ import { Component, DestroyRef, OnInit, inject } from "@angular/core";
 import { takeUntilDestroyed, toSignal } from "@angular/core/rxjs-interop";
 import { FormBuilder, ReactiveFormsModule } from "@angular/forms";
 import { RouterModule } from "@angular/router";
-import { firstValueFrom } from "rxjs";
+import { concatMap, firstValueFrom } from "rxjs";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
@@ -13,7 +13,10 @@ import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { EnvironmentService } from "@bitwarden/common/platform/abstractions/environment.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
+import { ValidationService } from "@bitwarden/common/platform/abstractions/validation.service";
+import { EarlyAccessService } from "@bitwarden/common/platform/services/early-access/early-access.service";
 import {
   CardComponent,
   CenterPositionStrategy,
@@ -68,8 +71,11 @@ const RateUrls = {
 export class AboutPageV2Component implements OnInit {
   private accountService = inject(AccountService);
   private configService = inject(ConfigService);
+  private earlyAccessService = inject(EarlyAccessService);
   private toastService = inject(ToastService);
   private i18nService = inject(I18nService);
+  private logService = inject(LogService);
+  private validationService = inject(ValidationService);
   private formBuilder = inject(FormBuilder);
   private destroyRef = inject(DestroyRef);
 
@@ -88,40 +94,46 @@ export class AboutPageV2Component implements OnInit {
 
   async ngOnInit(): Promise<void> {
     const userId = await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId));
-    const current = await firstValueFrom(this.configService.earlyAccess$(userId));
+    const current = await firstValueFrom(this.earlyAccessService.earlyAccess$(userId));
     this.earlyAccessForm.controls.earlyAccess.setValue(current, { emitEvent: false });
 
     this.earlyAccessForm.controls.earlyAccess.valueChanges
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe((enabled) => {
-        void this.onEarlyAccessChange(enabled ?? false);
-      });
+      .pipe(
+        concatMap(async (enabled) => this.onEarlyAccessChange(enabled ?? false)),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe();
   }
 
   private async onEarlyAccessChange(enabled: boolean): Promise<void> {
     const userId = await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId));
 
-    if (enabled) {
+    try {
+      if (!enabled) {
+        await this.earlyAccessService.setEarlyAccess(userId, false);
+        return;
+      }
+
       const confirmed = await this.dialogService.openSimpleDialog({
         title: { key: "enableEarlyAccessConfirmTitle" },
         content: { key: "enableEarlyAccessConfirmContent" },
         type: "warning",
       });
-
       if (!confirmed) {
         this.earlyAccessForm.controls.earlyAccess.setValue(false, { emitEvent: false });
         return;
       }
 
-      await this.configService.setEarlyAccess(userId, true);
+      await this.earlyAccessService.setEarlyAccess(userId, true);
       this.toastService.showToast({
         variant: "info",
         message: this.i18nService.t("earlyAccessEnabledToast"),
       });
-      return;
+    } catch (error) {
+      this.logService.error("Error updating Early Access preference: ", error);
+      this.earlyAccessForm.controls.earlyAccess.setValue(!enabled, { emitEvent: false });
+      this.validationService.showError(error);
     }
-
-    await this.configService.setEarlyAccess(userId, false);
   }
 
   about() {

--- a/apps/browser/src/tools/popup/settings/about-page/about-page-v2.component.ts
+++ b/apps/browser/src/tools/popup/settings/about-page/about-page-v2.component.ts
@@ -70,10 +70,10 @@ export class AboutPageV2Component implements OnInit {
   private formBuilder = inject(FormBuilder);
   private destroyRef = inject(DestroyRef);
 
-  protected betaModeForm = this.formBuilder.group({ betaMode: false });
+  protected earlyAccessForm = this.formBuilder.group({ earlyAccess: false });
 
-  protected readonly showBetaToggle = toSignal(
-    this.configService.getFeatureFlag$(FeatureFlag.PM39893BetaMode),
+  protected readonly showEarlyAccessToggle = toSignal(
+    this.configService.getFeatureFlag$(FeatureFlag.EarlyAccess),
     { initialValue: false },
   );
 
@@ -84,38 +84,38 @@ export class AboutPageV2Component implements OnInit {
   ) {}
 
   async ngOnInit(): Promise<void> {
-    const current = await firstValueFrom(this.configService.betaMode$);
-    this.betaModeForm.controls.betaMode.setValue(current, { emitEvent: false });
+    const current = await firstValueFrom(this.configService.earlyAccess$);
+    this.earlyAccessForm.controls.earlyAccess.setValue(current, { emitEvent: false });
 
-    this.betaModeForm.controls.betaMode.valueChanges
+    this.earlyAccessForm.controls.earlyAccess.valueChanges
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((enabled) => {
-        void this.onBetaModeChange(enabled ?? false);
+        void this.onEarlyAccessChange(enabled ?? false);
       });
   }
 
-  private async onBetaModeChange(enabled: boolean): Promise<void> {
+  private async onEarlyAccessChange(enabled: boolean): Promise<void> {
     if (enabled) {
       const confirmed = await this.dialogService.openSimpleDialog({
-        title: { key: "enableBetaModeConfirmTitle" },
-        content: { key: "enableBetaModeConfirmContent" },
+        title: { key: "enableEarlyAccessConfirmTitle" },
+        content: { key: "enableEarlyAccessConfirmContent" },
         type: "warning",
       });
 
       if (!confirmed) {
-        this.betaModeForm.controls.betaMode.setValue(false, { emitEvent: false });
+        this.earlyAccessForm.controls.earlyAccess.setValue(false, { emitEvent: false });
         return;
       }
 
-      await this.configService.setBetaMode(true);
+      await this.configService.setEarlyAccess(true);
       this.toastService.showToast({
         variant: "info",
-        message: this.i18nService.t("betaModeEnabledToast"),
+        message: this.i18nService.t("earlyAccessEnabledToast"),
       });
       return;
     }
 
-    await this.configService.setBetaMode(false);
+    await this.configService.setEarlyAccess(false);
   }
 
   about() {

--- a/apps/browser/src/tools/popup/settings/about-page/about-page-v2.component.ts
+++ b/apps/browser/src/tools/popup/settings/about-page/about-page-v2.component.ts
@@ -6,6 +6,8 @@ import { RouterModule } from "@angular/router";
 import { firstValueFrom } from "rxjs";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { getUserId } from "@bitwarden/common/auth/services/account.service";
 import { DeviceType } from "@bitwarden/common/enums";
 import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
@@ -64,6 +66,7 @@ const RateUrls = {
   ],
 })
 export class AboutPageV2Component implements OnInit {
+  private accountService = inject(AccountService);
   private configService = inject(ConfigService);
   private toastService = inject(ToastService);
   private i18nService = inject(I18nService);
@@ -84,7 +87,8 @@ export class AboutPageV2Component implements OnInit {
   ) {}
 
   async ngOnInit(): Promise<void> {
-    const current = await firstValueFrom(this.configService.earlyAccess$);
+    const userId = await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId));
+    const current = await firstValueFrom(this.configService.earlyAccess$(userId));
     this.earlyAccessForm.controls.earlyAccess.setValue(current, { emitEvent: false });
 
     this.earlyAccessForm.controls.earlyAccess.valueChanges
@@ -95,6 +99,8 @@ export class AboutPageV2Component implements OnInit {
   }
 
   private async onEarlyAccessChange(enabled: boolean): Promise<void> {
+    const userId = await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId));
+
     if (enabled) {
       const confirmed = await this.dialogService.openSimpleDialog({
         title: { key: "enableEarlyAccessConfirmTitle" },
@@ -107,7 +113,7 @@ export class AboutPageV2Component implements OnInit {
         return;
       }
 
-      await this.configService.setEarlyAccess(true);
+      await this.configService.setEarlyAccess(userId, true);
       this.toastService.showToast({
         variant: "info",
         message: this.i18nService.t("earlyAccessEnabledToast"),
@@ -115,7 +121,7 @@ export class AboutPageV2Component implements OnInit {
       return;
     }
 
-    await this.configService.setEarlyAccess(false);
+    await this.configService.setEarlyAccess(userId, false);
   }
 
   about() {

--- a/apps/browser/src/tools/popup/settings/about-page/about-page-v2.component.ts
+++ b/apps/browser/src/tools/popup/settings/about-page/about-page-v2.component.ts
@@ -12,7 +12,6 @@ import { DeviceType } from "@bitwarden/common/enums";
 import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { EnvironmentService } from "@bitwarden/common/platform/abstractions/environment.service";
-import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { ValidationService } from "@bitwarden/common/platform/abstractions/validation.service";
@@ -24,7 +23,6 @@ import {
   DialogService,
   FormFieldModule,
   ItemModule,
-  ToastService,
 } from "@bitwarden/components";
 import { TroubleshootingDialogComponent } from "@bitwarden/logging-angular";
 import { I18nPipe } from "@bitwarden/ui-common";
@@ -72,8 +70,6 @@ export class AboutPageV2Component implements OnInit {
   private accountService = inject(AccountService);
   private configService = inject(ConfigService);
   private earlyAccessService = inject(EarlyAccessService);
-  private toastService = inject(ToastService);
-  private i18nService = inject(I18nService);
   private logService = inject(LogService);
   private validationService = inject(ValidationService);
   private formBuilder = inject(FormBuilder);
@@ -125,10 +121,6 @@ export class AboutPageV2Component implements OnInit {
       }
 
       await this.earlyAccessService.setEarlyAccess(userId, true);
-      this.toastService.showToast({
-        variant: "info",
-        message: this.i18nService.t("earlyAccessEnabledToast"),
-      });
     } catch (error) {
       this.logService.error("Error updating Early Access preference: ", error);
       this.earlyAccessForm.controls.earlyAccess.setValue(!enabled, { emitEvent: false });

--- a/apps/desktop/src/app/accounts/settings-dialog.component.html
+++ b/apps/desktop/src/app/accounts/settings-dialog.component.html
@@ -98,17 +98,17 @@
           </bit-label>
         </bit-form-control>
 
-        @if (showBetaToggle()) {
+        @if (showEarlyAccessToggle()) {
           <bit-form-control>
             <input
               type="checkbox"
               bitCheckbox
-              id="settings-dialog_input_beta-mode"
-              formControlName="betaMode"
-              (change)="saveBetaMode()"
+              id="settings-dialog_input_early-access"
+              formControlName="earlyAccess"
+              (change)="saveEarlyAccess()"
             />
-            <bit-label>{{ "betaMode" | i18n }}</bit-label>
-            <bit-hint>{{ "betaModeDesc" | i18n }}</bit-hint>
+            <bit-label>{{ "earlyAccess" | i18n }}</bit-label>
+            <bit-hint>{{ "earlyAccessDesc" | i18n }}</bit-hint>
           </bit-form-control>
         }
       </bit-tab>

--- a/apps/desktop/src/app/accounts/settings-dialog.component.html
+++ b/apps/desktop/src/app/accounts/settings-dialog.component.html
@@ -97,6 +97,20 @@
             <vault-permit-cipher-details-popover slot="end" />
           </bit-label>
         </bit-form-control>
+
+        @if (showBetaToggle()) {
+          <bit-form-control>
+            <input
+              type="checkbox"
+              bitCheckbox
+              id="settings-dialog_input_beta-mode"
+              formControlName="betaMode"
+              (change)="saveBetaMode()"
+            />
+            <bit-label>{{ "betaMode" | i18n }}</bit-label>
+            <bit-hint>{{ "betaModeDesc" | i18n }}</bit-hint>
+          </bit-form-control>
+        }
       </bit-tab>
 
       <bit-tab [label]="'appPreferences' | i18n">

--- a/apps/desktop/src/app/accounts/settings-dialog.component.html
+++ b/apps/desktop/src/app/accounts/settings-dialog.component.html
@@ -99,17 +99,14 @@
         </bit-form-control>
 
         @if (showEarlyAccessToggle()) {
-          <bit-form-control>
-            <input
-              type="checkbox"
-              bitCheckbox
+          <bit-form-control-card>
+            <bit-switch
               id="settings-dialog_input_early-access"
               formControlName="earlyAccess"
-              (change)="saveEarlyAccess()"
-            />
+            ></bit-switch>
             <bit-label>{{ "earlyAccess" | i18n }}</bit-label>
             <bit-hint>{{ "earlyAccessDesc" | i18n }}</bit-hint>
-          </bit-form-control>
+          </bit-form-control-card>
         }
       </bit-tab>
 

--- a/apps/desktop/src/app/accounts/settings-dialog.component.spec.ts
+++ b/apps/desktop/src/app/accounts/settings-dialog.component.spec.ts
@@ -208,7 +208,7 @@ describe("SettingsDialogComponent", () => {
     desktopAutotypeService.autotypeKeyboardShortcut$ = of(["Control", "Alt", "B"]);
     billingAccountProfileStateService.hasPremiumFromAnySource$.mockReturnValue(of(false));
     configService.getFeatureFlag$.mockReturnValue(of(false));
-    configService.betaMode$ = of(false);
+    configService.earlyAccess$ = of(false);
 
     fixture = TestBed.createComponent(SettingsDialogComponent);
     component = fixture.componentInstance;

--- a/apps/desktop/src/app/accounts/settings-dialog.component.spec.ts
+++ b/apps/desktop/src/app/accounts/settings-dialog.component.spec.ts
@@ -46,6 +46,7 @@ import { ThemeType } from "@bitwarden/common/platform/enums";
 import { MessageSender } from "@bitwarden/common/platform/messaging";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
+import { EarlyAccessService } from "@bitwarden/common/platform/services/early-access/early-access.service";
 import { ThemeStateService } from "@bitwarden/common/platform/theming/theme-state.service";
 import { FakeAccountService, mockAccountServiceWith } from "@bitwarden/common/spec";
 import { UserId } from "@bitwarden/common/types/guid";
@@ -101,6 +102,7 @@ describe("SettingsDialogComponent", () => {
   const desktopAutotypeService = mock<DesktopAutotypeService>();
   const billingAccountProfileStateService = mock<BillingAccountProfileStateService>();
   const configService = mock<ConfigService>();
+  const earlyAccessService = mock<EarlyAccessService>();
   const userVerificationService = mock<UserVerificationService>();
 
   const mockUserKey = new SymmetricCryptoKey(new Uint8Array(64)) as UserKey;
@@ -136,6 +138,7 @@ describe("SettingsDialogComponent", () => {
         { provide: AccountService, useValue: accountService },
         { provide: BiometricStateService, useValue: biometricStateService },
         { provide: ConfigService, useValue: configService },
+        { provide: EarlyAccessService, useValue: earlyAccessService },
         {
           provide: DesktopAutofillSettingsService,
           useValue: desktopAutofillSettingsService,
@@ -208,7 +211,8 @@ describe("SettingsDialogComponent", () => {
     desktopAutotypeService.autotypeKeyboardShortcut$ = of(["Control", "Alt", "B"]);
     billingAccountProfileStateService.hasPremiumFromAnySource$.mockReturnValue(of(false));
     configService.getFeatureFlag$.mockReturnValue(of(false));
-    configService.earlyAccess$.mockReturnValue(of(false));
+    earlyAccessService.earlyAccess$.mockReturnValue(of(false));
+    earlyAccessService.setEarlyAccess.mockResolvedValue(undefined);
 
     fixture = TestBed.createComponent(SettingsDialogComponent);
     component = fixture.componentInstance;

--- a/apps/desktop/src/app/accounts/settings-dialog.component.spec.ts
+++ b/apps/desktop/src/app/accounts/settings-dialog.component.spec.ts
@@ -208,7 +208,7 @@ describe("SettingsDialogComponent", () => {
     desktopAutotypeService.autotypeKeyboardShortcut$ = of(["Control", "Alt", "B"]);
     billingAccountProfileStateService.hasPremiumFromAnySource$.mockReturnValue(of(false));
     configService.getFeatureFlag$.mockReturnValue(of(false));
-    configService.earlyAccess$ = of(false);
+    configService.earlyAccess$.mockReturnValue(of(false));
 
     fixture = TestBed.createComponent(SettingsDialogComponent);
     component = fixture.componentInstance;

--- a/apps/desktop/src/app/accounts/settings-dialog.component.spec.ts
+++ b/apps/desktop/src/app/accounts/settings-dialog.component.spec.ts
@@ -208,6 +208,7 @@ describe("SettingsDialogComponent", () => {
     desktopAutotypeService.autotypeKeyboardShortcut$ = of(["Control", "Alt", "B"]);
     billingAccountProfileStateService.hasPremiumFromAnySource$.mockReturnValue(of(false));
     configService.getFeatureFlag$.mockReturnValue(of(false));
+    configService.betaMode$ = of(false);
 
     fixture = TestBed.createComponent(SettingsDialogComponent);
     component = fixture.componentInstance;

--- a/apps/desktop/src/app/accounts/settings-dialog.component.ts
+++ b/apps/desktop/src/app/accounts/settings-dialog.component.ts
@@ -32,6 +32,7 @@ import { StateService } from "@bitwarden/common/platform/abstractions/state.serv
 import { ValidationService } from "@bitwarden/common/platform/abstractions/validation.service";
 import { Theme, ThemeTypes } from "@bitwarden/common/platform/enums/theme-type.enum";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
+import { EarlyAccessService } from "@bitwarden/common/platform/services/early-access/early-access.service";
 import { ThemeStateService } from "@bitwarden/common/platform/theming/theme-state.service";
 import { UserId } from "@bitwarden/common/types/guid";
 import { PremiumUpgradePromptService } from "@bitwarden/common/vault/abstractions/premium-upgrade-prompt.service";
@@ -125,6 +126,7 @@ export class SettingsDialogComponent implements OnInit {
   private readonly logService = inject(LogService);
   private readonly nativeMessagingManifestService = inject(NativeMessagingManifestService);
   private readonly configService = inject(ConfigService);
+  private readonly earlyAccessService = inject(EarlyAccessService);
   private readonly validationService = inject(ValidationService);
   private readonly billingAccountProfileStateService = inject(BillingAccountProfileStateService);
   private readonly toastService = inject(ToastService);
@@ -303,7 +305,7 @@ export class SettingsDialogComponent implements OnInit {
       ),
       theme: await firstValueFrom(this.themeStateService.selectedTheme$),
       locale: await firstValueFrom(this.i18nService.userSetLocale$),
-      earlyAccess: await firstValueFrom(this.configService.earlyAccess$(this.currentUserId())),
+      earlyAccess: await firstValueFrom(this.earlyAccessService.earlyAccess$(this.currentUserId())),
     };
     this.form.setValue(initialValues, { emitEvent: false });
 
@@ -543,29 +545,37 @@ export class SettingsDialogComponent implements OnInit {
   }
 
   protected async saveEarlyAccess() {
+    // Capture userId once — an account switch mid-dialog must not redirect the write to a
+    // different user than the one whose UI initiated the change.
+    const userId = this.currentUserId();
     const enabled = this.form.value.earlyAccess ?? false;
 
-    if (enabled) {
+    try {
+      if (!enabled) {
+        await this.earlyAccessService.setEarlyAccess(userId, false);
+        return;
+      }
+
       const confirmed = await this.dialogService.openSimpleDialog({
         title: { key: "enableEarlyAccessConfirmTitle" },
         content: { key: "enableEarlyAccessConfirmContent" },
         type: "warning",
       });
-
       if (!confirmed) {
         this.form.controls.earlyAccess.setValue(false, { emitEvent: false });
         return;
       }
 
-      await this.configService.setEarlyAccess(this.currentUserId(), true);
+      await this.earlyAccessService.setEarlyAccess(userId, true);
       this.toastService.showToast({
         variant: "info",
         message: this.i18nService.t("earlyAccessEnabledToast"),
       });
-      return;
+    } catch (error) {
+      this.logService.error("Error updating Early Access preference: ", error);
+      this.form.controls.earlyAccess.setValue(!enabled, { emitEvent: false });
+      this.validationService.showError(error);
     }
-
-    await this.configService.setEarlyAccess(this.currentUserId(), false);
   }
 
   protected async saveRunInBackground() {

--- a/apps/desktop/src/app/accounts/settings-dialog.component.ts
+++ b/apps/desktop/src/app/accounts/settings-dialog.component.ts
@@ -50,6 +50,7 @@ import {
   SectionHeaderComponent,
   SelectModule,
   TabsModule,
+  ToastService,
   TypographyModule,
 } from "@bitwarden/components";
 import { KeyService, BiometricStateService, BiometricsStatus } from "@bitwarden/key-management";
@@ -126,6 +127,7 @@ export class SettingsDialogComponent implements OnInit {
   private readonly configService = inject(ConfigService);
   private readonly validationService = inject(ValidationService);
   private readonly billingAccountProfileStateService = inject(BillingAccountProfileStateService);
+  private readonly toastService = inject(ToastService);
   private readonly destroyRef = inject(DestroyRef);
 
   protected readonly localeOptions: Option<string>[];
@@ -143,6 +145,10 @@ export class SettingsDialogComponent implements OnInit {
 
   protected readonly supportsBiometric = signal(false);
   protected readonly showEnableAutotype = signal(false);
+  protected readonly showBetaToggle = toSignal(
+    this.configService.getFeatureFlag$(FeatureFlag.PM39893BetaMode),
+    { initialValue: false },
+  );
   private readonly activeAccount = toSignal(this.accountService.activeAccount$, {
     requireSync: true,
   });
@@ -190,6 +196,7 @@ export class SettingsDialogComponent implements OnInit {
     autotypeShortcut: [null as string | null],
     theme: [null as Theme | null],
     locale: [null as string | null],
+    betaMode: false,
   });
 
   constructor() {
@@ -296,6 +303,7 @@ export class SettingsDialogComponent implements OnInit {
       ),
       theme: await firstValueFrom(this.themeStateService.selectedTheme$),
       locale: await firstValueFrom(this.i18nService.userSetLocale$),
+      betaMode: await firstValueFrom(this.configService.betaMode$),
     };
     this.form.setValue(initialValues, { emitEvent: false });
 
@@ -532,6 +540,32 @@ export class SettingsDialogComponent implements OnInit {
   protected async saveFavicons() {
     await this.domainSettingsService.setShowFavicons(this.form.value.enableFavicons);
     this.messagingService.send("refreshCiphers");
+  }
+
+  protected async saveBetaMode() {
+    const enabled = this.form.value.betaMode ?? false;
+
+    if (enabled) {
+      const confirmed = await this.dialogService.openSimpleDialog({
+        title: { key: "enableBetaModeConfirmTitle" },
+        content: { key: "enableBetaModeConfirmContent" },
+        type: "warning",
+      });
+
+      if (!confirmed) {
+        this.form.controls.betaMode.setValue(false, { emitEvent: false });
+        return;
+      }
+
+      await this.configService.setBetaMode(true);
+      this.toastService.showToast({
+        variant: "info",
+        message: this.i18nService.t("betaModeEnabledToast"),
+      });
+      return;
+    }
+
+    await this.configService.setBetaMode(false);
   }
 
   protected async saveRunInBackground() {

--- a/apps/desktop/src/app/accounts/settings-dialog.component.ts
+++ b/apps/desktop/src/app/accounts/settings-dialog.component.ts
@@ -145,8 +145,8 @@ export class SettingsDialogComponent implements OnInit {
 
   protected readonly supportsBiometric = signal(false);
   protected readonly showEnableAutotype = signal(false);
-  protected readonly showBetaToggle = toSignal(
-    this.configService.getFeatureFlag$(FeatureFlag.PM39893BetaMode),
+  protected readonly showEarlyAccessToggle = toSignal(
+    this.configService.getFeatureFlag$(FeatureFlag.EarlyAccess),
     { initialValue: false },
   );
   private readonly activeAccount = toSignal(this.accountService.activeAccount$, {
@@ -196,7 +196,7 @@ export class SettingsDialogComponent implements OnInit {
     autotypeShortcut: [null as string | null],
     theme: [null as Theme | null],
     locale: [null as string | null],
-    betaMode: false,
+    earlyAccess: false,
   });
 
   constructor() {
@@ -303,7 +303,7 @@ export class SettingsDialogComponent implements OnInit {
       ),
       theme: await firstValueFrom(this.themeStateService.selectedTheme$),
       locale: await firstValueFrom(this.i18nService.userSetLocale$),
-      betaMode: await firstValueFrom(this.configService.betaMode$),
+      earlyAccess: await firstValueFrom(this.configService.earlyAccess$),
     };
     this.form.setValue(initialValues, { emitEvent: false });
 
@@ -542,30 +542,30 @@ export class SettingsDialogComponent implements OnInit {
     this.messagingService.send("refreshCiphers");
   }
 
-  protected async saveBetaMode() {
-    const enabled = this.form.value.betaMode ?? false;
+  protected async saveEarlyAccess() {
+    const enabled = this.form.value.earlyAccess ?? false;
 
     if (enabled) {
       const confirmed = await this.dialogService.openSimpleDialog({
-        title: { key: "enableBetaModeConfirmTitle" },
-        content: { key: "enableBetaModeConfirmContent" },
+        title: { key: "enableEarlyAccessConfirmTitle" },
+        content: { key: "enableEarlyAccessConfirmContent" },
         type: "warning",
       });
 
       if (!confirmed) {
-        this.form.controls.betaMode.setValue(false, { emitEvent: false });
+        this.form.controls.earlyAccess.setValue(false, { emitEvent: false });
         return;
       }
 
-      await this.configService.setBetaMode(true);
+      await this.configService.setEarlyAccess(true);
       this.toastService.showToast({
         variant: "info",
-        message: this.i18nService.t("betaModeEnabledToast"),
+        message: this.i18nService.t("earlyAccessEnabledToast"),
       });
       return;
     }
 
-    await this.configService.setBetaMode(false);
+    await this.configService.setEarlyAccess(false);
   }
 
   protected async saveRunInBackground() {

--- a/apps/desktop/src/app/accounts/settings-dialog.component.ts
+++ b/apps/desktop/src/app/accounts/settings-dialog.component.ts
@@ -51,7 +51,6 @@ import {
   SectionHeaderComponent,
   SelectModule,
   TabsModule,
-  ToastService,
   TypographyModule,
 } from "@bitwarden/components";
 import { KeyService, BiometricStateService, BiometricsStatus } from "@bitwarden/key-management";
@@ -129,7 +128,6 @@ export class SettingsDialogComponent implements OnInit {
   private readonly earlyAccessService = inject(EarlyAccessService);
   private readonly validationService = inject(ValidationService);
   private readonly billingAccountProfileStateService = inject(BillingAccountProfileStateService);
-  private readonly toastService = inject(ToastService);
   private readonly destroyRef = inject(DestroyRef);
 
   protected readonly localeOptions: Option<string>[];
@@ -567,10 +565,6 @@ export class SettingsDialogComponent implements OnInit {
       }
 
       await this.earlyAccessService.setEarlyAccess(userId, true);
-      this.toastService.showToast({
-        variant: "info",
-        message: this.i18nService.t("earlyAccessEnabledToast"),
-      });
     } catch (error) {
       this.logService.error("Error updating Early Access preference: ", error);
       this.form.controls.earlyAccess.setValue(!enabled, { emitEvent: false });

--- a/apps/desktop/src/app/accounts/settings-dialog.component.ts
+++ b/apps/desktop/src/app/accounts/settings-dialog.component.ts
@@ -303,7 +303,7 @@ export class SettingsDialogComponent implements OnInit {
       ),
       theme: await firstValueFrom(this.themeStateService.selectedTheme$),
       locale: await firstValueFrom(this.i18nService.userSetLocale$),
-      earlyAccess: await firstValueFrom(this.configService.earlyAccess$),
+      earlyAccess: await firstValueFrom(this.configService.earlyAccess$(this.currentUserId())),
     };
     this.form.setValue(initialValues, { emitEvent: false });
 
@@ -557,7 +557,7 @@ export class SettingsDialogComponent implements OnInit {
         return;
       }
 
-      await this.configService.setEarlyAccess(true);
+      await this.configService.setEarlyAccess(this.currentUserId(), true);
       this.toastService.showToast({
         variant: "info",
         message: this.i18nService.t("earlyAccessEnabledToast"),
@@ -565,7 +565,7 @@ export class SettingsDialogComponent implements OnInit {
       return;
     }
 
-    await this.configService.setEarlyAccess(false);
+    await this.configService.setEarlyAccess(this.currentUserId(), false);
   }
 
   protected async saveRunInBackground() {

--- a/apps/desktop/src/app/accounts/settings-dialog.component.ts
+++ b/apps/desktop/src/app/accounts/settings-dialog.component.ts
@@ -41,6 +41,7 @@ import {
   CheckboxModule,
   DialogModule,
   DialogService,
+  FormControlModule,
   FormFieldModule,
   IconButtonModule,
   IconModule,
@@ -50,6 +51,7 @@ import {
   SectionComponent,
   SectionHeaderComponent,
   SelectModule,
+  SwitchComponent,
   TabsModule,
   TypographyModule,
 } from "@bitwarden/components";
@@ -82,6 +84,7 @@ import { NativeMessagingManifestService } from "../services/native-messaging-man
     ButtonModule,
     CheckboxModule,
     DialogModule,
+    FormControlModule,
     FormFieldModule,
     FormsModule,
     ReactiveFormsModule,
@@ -94,6 +97,7 @@ import { NativeMessagingManifestService } from "../services/native-messaging-man
     SectionComponent,
     SectionHeaderComponent,
     SelectModule,
+    SwitchComponent,
     TabsModule,
     TypographyModule,
     SessionTimeoutSettingsComponent,
@@ -372,6 +376,13 @@ export class SettingsDialogComponent implements OnInit {
     this.form.controls.locale.valueChanges
       .pipe(
         concatMap(async (value: string) => this.saveLocale(value)),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe();
+
+    this.form.controls.earlyAccess.valueChanges
+      .pipe(
+        concatMap(async () => this.saveEarlyAccess()),
         takeUntilDestroyed(this.destroyRef),
       )
       .subscribe();

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -5605,19 +5605,19 @@
   "deleteCollectionsDesc": {
     "message": "These collections will be permanently deleted."
   },
-  "betaMode": {
-    "message": "Beta mode"
+  "earlyAccess": {
+    "message": "Early access"
   },
-  "betaModeDesc": {
+  "earlyAccessDesc": {
     "message": "Enable early access to features currently in prerelease testing"
   },
-  "enableBetaModeConfirmTitle": {
-    "message": "Enable beta mode?"
+  "enableEarlyAccessConfirmTitle": {
+    "message": "Enable early access?"
   },
-  "enableBetaModeConfirmContent": {
-    "message": "Beta features are still in testing and may be unstable or change without notice."
+  "enableEarlyAccessConfirmContent": {
+    "message": "Early access features are still in testing and may be unstable or change without notice."
   },
-  "betaModeEnabledToast": {
-    "message": "Beta mode enabled. Reopen to make sure all features refresh."
+  "earlyAccessEnabledToast": {
+    "message": "Early access enabled. Reopen to make sure all features refresh."
   }
 }

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -5604,5 +5604,20 @@
   },
   "deleteCollectionsDesc": {
     "message": "These collections will be permanently deleted."
+  },
+  "betaMode": {
+    "message": "Beta mode"
+  },
+  "betaModeDesc": {
+    "message": "Enable early access to features currently in prerelease testing"
+  },
+  "enableBetaModeConfirmTitle": {
+    "message": "Enable beta mode?"
+  },
+  "enableBetaModeConfirmContent": {
+    "message": "Beta features are still in testing and may be unstable or change without notice."
+  },
+  "betaModeEnabledToast": {
+    "message": "Beta mode enabled. Reopen to make sure all features refresh."
   }
 }

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -5618,6 +5618,6 @@
     "message": "Early access features are still in testing and may be unstable or change without notice."
   },
   "earlyAccessEnabledToast": {
-    "message": "Early access enabled. Reopen to make sure all features refresh."
+    "message": "Early access enabled."
   }
 }

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -5616,8 +5616,5 @@
   },
   "enableEarlyAccessConfirmContent": {
     "message": "Early access features are still in testing and may be unstable or change without notice."
-  },
-  "earlyAccessEnabledToast": {
-    "message": "Early access enabled."
   }
 }

--- a/apps/web/src/app/settings/appearance.component.html
+++ b/apps/web/src/app/settings/appearance.component.html
@@ -44,16 +44,11 @@
       </div>
     </div>
     @if (showEarlyAccessToggle()) {
-      <bit-form-control>
-        <input
-          type="checkbox"
-          bitCheckbox
-          id="appearance_input_early-access"
-          formControlName="earlyAccess"
-        />
+      <bit-form-control-card>
+        <bit-switch id="appearance_input_early-access" formControlName="earlyAccess"></bit-switch>
         <bit-label>{{ "earlyAccess" | i18n }}</bit-label>
         <bit-hint>{{ "earlyAccessDesc" | i18n }}</bit-hint>
-      </bit-form-control>
+      </bit-form-control-card>
     }
   </form>
 </bit-container>

--- a/apps/web/src/app/settings/appearance.component.html
+++ b/apps/web/src/app/settings/appearance.component.html
@@ -43,16 +43,16 @@
         <vault-permit-cipher-details-popover></vault-permit-cipher-details-popover>
       </div>
     </div>
-    @if (showBetaToggle()) {
+    @if (showEarlyAccessToggle()) {
       <bit-form-control>
         <input
           type="checkbox"
           bitCheckbox
-          id="appearance_input_beta-mode"
-          formControlName="betaMode"
+          id="appearance_input_early-access"
+          formControlName="earlyAccess"
         />
-        <bit-label>{{ "betaMode" | i18n }}</bit-label>
-        <bit-hint>{{ "betaModeDesc" | i18n }}</bit-hint>
+        <bit-label>{{ "earlyAccess" | i18n }}</bit-label>
+        <bit-hint>{{ "earlyAccessDesc" | i18n }}</bit-hint>
       </bit-form-control>
     }
   </form>

--- a/apps/web/src/app/settings/appearance.component.html
+++ b/apps/web/src/app/settings/appearance.component.html
@@ -43,5 +43,17 @@
         <vault-permit-cipher-details-popover></vault-permit-cipher-details-popover>
       </div>
     </div>
+    @if (showBetaToggle()) {
+      <bit-form-control>
+        <input
+          type="checkbox"
+          bitCheckbox
+          id="appearance_input_beta-mode"
+          formControlName="betaMode"
+        />
+        <bit-label>{{ "betaMode" | i18n }}</bit-label>
+        <bit-hint>{{ "betaModeDesc" | i18n }}</bit-hint>
+      </bit-form-control>
+    }
   </form>
 </bit-container>

--- a/apps/web/src/app/settings/appearance.component.spec.ts
+++ b/apps/web/src/app/settings/appearance.component.spec.ts
@@ -8,7 +8,10 @@ import { AccountService } from "@bitwarden/common/auth/abstractions/account.serv
 import { DomainSettingsService } from "@bitwarden/common/autofill/services/domain-settings.service";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+import { ValidationService } from "@bitwarden/common/platform/abstractions/validation.service";
 import { Theme, ThemeTypes } from "@bitwarden/common/platform/enums";
+import { EarlyAccessService } from "@bitwarden/common/platform/services/early-access/early-access.service";
 import { ThemeStateService } from "@bitwarden/common/platform/theming/theme-state.service";
 import { UserId } from "@bitwarden/common/types/guid";
 import { DialogService, ToastService } from "@bitwarden/components";
@@ -22,8 +25,11 @@ describe("AppearanceComponent", () => {
   let mockThemeStateService: MockProxy<ThemeStateService>;
   let mockDomainSettingsService: MockProxy<DomainSettingsService>;
   let mockConfigService: MockProxy<ConfigService>;
+  let mockEarlyAccessService: MockProxy<EarlyAccessService>;
   let mockDialogService: MockProxy<DialogService>;
   let mockToastService: MockProxy<ToastService>;
+  let mockLogService: MockProxy<LogService>;
+  let mockValidationService: MockProxy<ValidationService>;
   let mockAccountService: MockProxy<AccountService>;
 
   const mockUserId = "test-user" as UserId;
@@ -46,8 +52,11 @@ describe("AppearanceComponent", () => {
     mockThemeStateService = mock<ThemeStateService>();
     mockDomainSettingsService = mock<DomainSettingsService>();
     mockConfigService = mock<ConfigService>();
+    mockEarlyAccessService = mock<EarlyAccessService>();
     mockDialogService = mock<DialogService>();
     mockToastService = mock<ToastService>();
+    mockLogService = mock<LogService>();
+    mockValidationService = mock<ValidationService>();
     mockAccountService = mock<AccountService>();
     mockAccountService.activeAccount$ = of({ id: mockUserId } as any);
 
@@ -61,8 +70,8 @@ describe("AppearanceComponent", () => {
 
     mockThemeStateService.selectedTheme$ = mockSelectedTheme$;
     mockDomainSettingsService.showFavicons$ = mockShowFavicons$;
-    mockConfigService.earlyAccess$.mockReturnValue(mockEarlyAccess$);
-    mockConfigService.setEarlyAccess.mockResolvedValue(undefined);
+    mockEarlyAccessService.earlyAccess$.mockReturnValue(mockEarlyAccess$);
+    mockEarlyAccessService.setEarlyAccess.mockResolvedValue(undefined);
     mockConfigService.getFeatureFlag$.mockReturnValue(of(false));
 
     mockDomainSettingsService.setShowFavicons.mockResolvedValue(undefined);
@@ -77,8 +86,11 @@ describe("AppearanceComponent", () => {
         { provide: DomainSettingsService, useValue: mockDomainSettingsService },
         { provide: AccountService, useValue: mockAccountService },
         { provide: ConfigService, useValue: mockConfigService },
+        { provide: EarlyAccessService, useValue: mockEarlyAccessService },
         { provide: DialogService, useValue: mockDialogService },
         { provide: ToastService, useValue: mockToastService },
+        { provide: LogService, useValue: mockLogService },
+        { provide: ValidationService, useValue: mockValidationService },
       ],
     })
       .overrideComponent(AppearanceComponent, {
@@ -202,6 +214,57 @@ describe("AppearanceComponent", () => {
       flush();
 
       expect(mockThemeStateService.setSelectedTheme).not.toHaveBeenCalled();
+    }));
+  });
+
+  describe("earlyAccess value changes", () => {
+    beforeEach(fakeAsync(() => {
+      fixture.detectChanges();
+      flush();
+      jest.clearAllMocks();
+    }));
+
+    it("persists straight through when disabling (no confirmation)", fakeAsync(() => {
+      component.form.controls.earlyAccess.setValue(false);
+      flush();
+
+      expect(mockDialogService.openSimpleDialog).not.toHaveBeenCalled();
+      expect(mockEarlyAccessService.setEarlyAccess).toHaveBeenCalledWith(mockUserId, false);
+    }));
+
+    it("confirms then persists and toasts when enabling", fakeAsync(() => {
+      mockDialogService.openSimpleDialog.mockResolvedValue(true);
+
+      component.form.controls.earlyAccess.setValue(true);
+      flush();
+
+      expect(mockDialogService.openSimpleDialog).toHaveBeenCalledWith(
+        expect.objectContaining({ type: "warning" }),
+      );
+      expect(mockEarlyAccessService.setEarlyAccess).toHaveBeenCalledWith(mockUserId, true);
+      expect(mockToastService.showToast).toHaveBeenCalled();
+    }));
+
+    it("reverts the form control when the confirm dialog is cancelled", fakeAsync(() => {
+      mockDialogService.openSimpleDialog.mockResolvedValue(false);
+
+      component.form.controls.earlyAccess.setValue(true);
+      flush();
+
+      expect(mockEarlyAccessService.setEarlyAccess).not.toHaveBeenCalled();
+      expect(component.form.value.earlyAccess).toBe(false);
+    }));
+
+    it("reverts and surfaces the error when setEarlyAccess rejects", fakeAsync(() => {
+      mockDialogService.openSimpleDialog.mockResolvedValue(true);
+      const error = new Error("write failed");
+      mockEarlyAccessService.setEarlyAccess.mockRejectedValueOnce(error);
+
+      component.form.controls.earlyAccess.setValue(true);
+      flush();
+
+      expect(component.form.value.earlyAccess).toBe(false);
+      expect(mockValidationService.showError).toHaveBeenCalledWith(error);
     }));
   });
 

--- a/apps/web/src/app/settings/appearance.component.spec.ts
+++ b/apps/web/src/app/settings/appearance.component.spec.ts
@@ -14,7 +14,7 @@ import { Theme, ThemeTypes } from "@bitwarden/common/platform/enums";
 import { EarlyAccessService } from "@bitwarden/common/platform/services/early-access/early-access.service";
 import { ThemeStateService } from "@bitwarden/common/platform/theming/theme-state.service";
 import { UserId } from "@bitwarden/common/types/guid";
-import { DialogService, ToastService } from "@bitwarden/components";
+import { DialogService } from "@bitwarden/components";
 
 import { AppearanceComponent } from "./appearance.component";
 
@@ -27,7 +27,6 @@ describe("AppearanceComponent", () => {
   let mockConfigService: MockProxy<ConfigService>;
   let mockEarlyAccessService: MockProxy<EarlyAccessService>;
   let mockDialogService: MockProxy<DialogService>;
-  let mockToastService: MockProxy<ToastService>;
   let mockLogService: MockProxy<LogService>;
   let mockValidationService: MockProxy<ValidationService>;
   let mockAccountService: MockProxy<AccountService>;
@@ -54,7 +53,6 @@ describe("AppearanceComponent", () => {
     mockConfigService = mock<ConfigService>();
     mockEarlyAccessService = mock<EarlyAccessService>();
     mockDialogService = mock<DialogService>();
-    mockToastService = mock<ToastService>();
     mockLogService = mock<LogService>();
     mockValidationService = mock<ValidationService>();
     mockAccountService = mock<AccountService>();
@@ -88,7 +86,6 @@ describe("AppearanceComponent", () => {
         { provide: ConfigService, useValue: mockConfigService },
         { provide: EarlyAccessService, useValue: mockEarlyAccessService },
         { provide: DialogService, useValue: mockDialogService },
-        { provide: ToastService, useValue: mockToastService },
         { provide: LogService, useValue: mockLogService },
         { provide: ValidationService, useValue: mockValidationService },
       ],
@@ -232,7 +229,7 @@ describe("AppearanceComponent", () => {
       expect(mockEarlyAccessService.setEarlyAccess).toHaveBeenCalledWith(mockUserId, false);
     }));
 
-    it("confirms then persists and toasts when enabling", fakeAsync(() => {
+    it("confirms then persists when enabling", fakeAsync(() => {
       mockDialogService.openSimpleDialog.mockResolvedValue(true);
 
       component.form.controls.earlyAccess.setValue(true);
@@ -242,7 +239,6 @@ describe("AppearanceComponent", () => {
         expect.objectContaining({ type: "warning" }),
       );
       expect(mockEarlyAccessService.setEarlyAccess).toHaveBeenCalledWith(mockUserId, true);
-      expect(mockToastService.showToast).toHaveBeenCalled();
     }));
 
     it("reverts the form control when the confirm dialog is cancelled", fakeAsync(() => {

--- a/apps/web/src/app/settings/appearance.component.spec.ts
+++ b/apps/web/src/app/settings/appearance.component.spec.ts
@@ -4,11 +4,13 @@ import { NoopAnimationsModule } from "@angular/platform-browser/animations";
 import { mock, MockProxy } from "jest-mock-extended";
 import { BehaviorSubject, of } from "rxjs";
 
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { DomainSettingsService } from "@bitwarden/common/autofill/services/domain-settings.service";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { Theme, ThemeTypes } from "@bitwarden/common/platform/enums";
 import { ThemeStateService } from "@bitwarden/common/platform/theming/theme-state.service";
+import { UserId } from "@bitwarden/common/types/guid";
 import { DialogService, ToastService } from "@bitwarden/components";
 
 import { AppearanceComponent } from "./appearance.component";
@@ -22,6 +24,9 @@ describe("AppearanceComponent", () => {
   let mockConfigService: MockProxy<ConfigService>;
   let mockDialogService: MockProxy<DialogService>;
   let mockToastService: MockProxy<ToastService>;
+  let mockAccountService: MockProxy<AccountService>;
+
+  const mockUserId = "test-user" as UserId;
 
   const mockShowFavicons$ = new BehaviorSubject<boolean>(true);
   const mockSelectedTheme$ = new BehaviorSubject<Theme>(ThemeTypes.Light);
@@ -43,6 +48,8 @@ describe("AppearanceComponent", () => {
     mockConfigService = mock<ConfigService>();
     mockDialogService = mock<DialogService>();
     mockToastService = mock<ToastService>();
+    mockAccountService = mock<AccountService>();
+    mockAccountService.activeAccount$ = of({ id: mockUserId } as any);
 
     mockI18nService.supportedTranslationLocales = mockSupportedLocales;
     mockI18nService.localeNames = mockLocaleNames;
@@ -54,7 +61,7 @@ describe("AppearanceComponent", () => {
 
     mockThemeStateService.selectedTheme$ = mockSelectedTheme$;
     mockDomainSettingsService.showFavicons$ = mockShowFavicons$;
-    mockConfigService.earlyAccess$ = mockEarlyAccess$;
+    mockConfigService.earlyAccess$.mockReturnValue(mockEarlyAccess$);
     mockConfigService.setEarlyAccess.mockResolvedValue(undefined);
     mockConfigService.getFeatureFlag$.mockReturnValue(of(false));
 
@@ -68,6 +75,7 @@ describe("AppearanceComponent", () => {
         { provide: I18nService, useValue: mockI18nService },
         { provide: ThemeStateService, useValue: mockThemeStateService },
         { provide: DomainSettingsService, useValue: mockDomainSettingsService },
+        { provide: AccountService, useValue: mockAccountService },
         { provide: ConfigService, useValue: mockConfigService },
         { provide: DialogService, useValue: mockDialogService },
         { provide: ToastService, useValue: mockToastService },

--- a/apps/web/src/app/settings/appearance.component.spec.ts
+++ b/apps/web/src/app/settings/appearance.component.spec.ts
@@ -26,7 +26,7 @@ describe("AppearanceComponent", () => {
   const mockShowFavicons$ = new BehaviorSubject<boolean>(true);
   const mockSelectedTheme$ = new BehaviorSubject<Theme>(ThemeTypes.Light);
   const mockUserSetLocale$ = new BehaviorSubject<string | undefined>("en");
-  const mockBetaMode$ = new BehaviorSubject<boolean>(false);
+  const mockEarlyAccess$ = new BehaviorSubject<boolean>(false);
 
   const mockSupportedLocales = ["en", "es", "fr", "de"];
   const mockLocaleNames = new Map([
@@ -54,8 +54,8 @@ describe("AppearanceComponent", () => {
 
     mockThemeStateService.selectedTheme$ = mockSelectedTheme$;
     mockDomainSettingsService.showFavicons$ = mockShowFavicons$;
-    mockConfigService.betaMode$ = mockBetaMode$;
-    mockConfigService.setBetaMode.mockResolvedValue(undefined);
+    mockConfigService.earlyAccess$ = mockEarlyAccess$;
+    mockConfigService.setEarlyAccess.mockResolvedValue(undefined);
     mockConfigService.getFeatureFlag$.mockReturnValue(of(false));
 
     mockDomainSettingsService.setShowFavicons.mockResolvedValue(undefined);
@@ -129,7 +129,7 @@ describe("AppearanceComponent", () => {
         enableFavicons: false,
         theme: ThemeTypes.Dark,
         locale: "es",
-        betaMode: false,
+        earlyAccess: false,
       });
     }));
 

--- a/apps/web/src/app/settings/appearance.component.spec.ts
+++ b/apps/web/src/app/settings/appearance.component.spec.ts
@@ -2,12 +2,14 @@ import { ComponentFixture, fakeAsync, flush, TestBed } from "@angular/core/testi
 import { ReactiveFormsModule } from "@angular/forms";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
 import { mock, MockProxy } from "jest-mock-extended";
-import { BehaviorSubject } from "rxjs";
+import { BehaviorSubject, of } from "rxjs";
 
 import { DomainSettingsService } from "@bitwarden/common/autofill/services/domain-settings.service";
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { Theme, ThemeTypes } from "@bitwarden/common/platform/enums";
 import { ThemeStateService } from "@bitwarden/common/platform/theming/theme-state.service";
+import { DialogService, ToastService } from "@bitwarden/components";
 
 import { AppearanceComponent } from "./appearance.component";
 
@@ -17,10 +19,14 @@ describe("AppearanceComponent", () => {
   let mockI18nService: MockProxy<I18nService>;
   let mockThemeStateService: MockProxy<ThemeStateService>;
   let mockDomainSettingsService: MockProxy<DomainSettingsService>;
+  let mockConfigService: MockProxy<ConfigService>;
+  let mockDialogService: MockProxy<DialogService>;
+  let mockToastService: MockProxy<ToastService>;
 
   const mockShowFavicons$ = new BehaviorSubject<boolean>(true);
   const mockSelectedTheme$ = new BehaviorSubject<Theme>(ThemeTypes.Light);
   const mockUserSetLocale$ = new BehaviorSubject<string | undefined>("en");
+  const mockBetaMode$ = new BehaviorSubject<boolean>(false);
 
   const mockSupportedLocales = ["en", "es", "fr", "de"];
   const mockLocaleNames = new Map([
@@ -34,6 +40,9 @@ describe("AppearanceComponent", () => {
     mockI18nService = mock<I18nService>();
     mockThemeStateService = mock<ThemeStateService>();
     mockDomainSettingsService = mock<DomainSettingsService>();
+    mockConfigService = mock<ConfigService>();
+    mockDialogService = mock<DialogService>();
+    mockToastService = mock<ToastService>();
 
     mockI18nService.supportedTranslationLocales = mockSupportedLocales;
     mockI18nService.localeNames = mockLocaleNames;
@@ -45,6 +54,9 @@ describe("AppearanceComponent", () => {
 
     mockThemeStateService.selectedTheme$ = mockSelectedTheme$;
     mockDomainSettingsService.showFavicons$ = mockShowFavicons$;
+    mockConfigService.betaMode$ = mockBetaMode$;
+    mockConfigService.setBetaMode.mockResolvedValue(undefined);
+    mockConfigService.getFeatureFlag$.mockReturnValue(of(false));
 
     mockDomainSettingsService.setShowFavicons.mockResolvedValue(undefined);
     mockThemeStateService.setSelectedTheme.mockResolvedValue(undefined);
@@ -56,6 +68,9 @@ describe("AppearanceComponent", () => {
         { provide: I18nService, useValue: mockI18nService },
         { provide: ThemeStateService, useValue: mockThemeStateService },
         { provide: DomainSettingsService, useValue: mockDomainSettingsService },
+        { provide: ConfigService, useValue: mockConfigService },
+        { provide: DialogService, useValue: mockDialogService },
+        { provide: ToastService, useValue: mockToastService },
       ],
     })
       .overrideComponent(AppearanceComponent, {
@@ -114,6 +129,7 @@ describe("AppearanceComponent", () => {
         enableFavicons: false,
         theme: ThemeTypes.Dark,
         locale: "es",
+        betaMode: false,
       });
     }));
 

--- a/apps/web/src/app/settings/appearance.component.ts
+++ b/apps/web/src/app/settings/appearance.component.ts
@@ -40,11 +40,11 @@ export class AppearanceComponent implements OnInit {
     enableFavicons: true,
     theme: [ThemeTypes.Light as Theme],
     locale: [null as string | null],
-    betaMode: false,
+    earlyAccess: false,
   });
 
-  protected readonly showBetaToggle = toSignal(
-    this.configService.getFeatureFlag$(FeatureFlag.PM39893BetaMode),
+  protected readonly showEarlyAccessToggle = toSignal(
+    this.configService.getFeatureFlag$(FeatureFlag.EarlyAccess),
     { initialValue: false },
   );
 
@@ -82,15 +82,15 @@ export class AppearanceComponent implements OnInit {
         enableFavicons: await firstValueFrom(this.domainSettingsService.showFavicons$),
         theme: await firstValueFrom(this.themeStateService.selectedTheme$),
         locale: (await firstValueFrom(this.i18nService.userSetLocale$)) ?? null,
-        betaMode: await firstValueFrom(this.configService.betaMode$),
+        earlyAccess: await firstValueFrom(this.configService.earlyAccess$),
       },
       { emitEvent: false },
     );
 
-    this.form.controls.betaMode.valueChanges
+    this.form.controls.earlyAccess.valueChanges
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((enabled) => {
-        void this.onBetaModeChange(enabled ?? false);
+        void this.onEarlyAccessChange(enabled ?? false);
       });
 
     this.form.controls.enableFavicons.valueChanges
@@ -124,27 +124,27 @@ export class AppearanceComponent implements OnInit {
       .subscribe();
   }
 
-  private async onBetaModeChange(enabled: boolean): Promise<void> {
+  private async onEarlyAccessChange(enabled: boolean): Promise<void> {
     if (enabled) {
       const confirmed = await this.dialogService.openSimpleDialog({
-        title: { key: "enableBetaModeConfirmTitle" },
-        content: { key: "enableBetaModeConfirmContent" },
+        title: { key: "enableEarlyAccessConfirmTitle" },
+        content: { key: "enableEarlyAccessConfirmContent" },
         type: "warning",
       });
 
       if (!confirmed) {
-        this.form.controls.betaMode.setValue(false, { emitEvent: false });
+        this.form.controls.earlyAccess.setValue(false, { emitEvent: false });
         return;
       }
 
-      await this.configService.setBetaMode(true);
+      await this.configService.setEarlyAccess(true);
       this.toastService.showToast({
         variant: "info",
-        message: this.i18nService.t("betaModeEnabledToast"),
+        message: this.i18nService.t("earlyAccessEnabledToast"),
       });
       return;
     }
 
-    await this.configService.setBetaMode(false);
+    await this.configService.setEarlyAccess(false);
   }
 }

--- a/apps/web/src/app/settings/appearance.component.ts
+++ b/apps/web/src/app/settings/appearance.component.ts
@@ -3,6 +3,8 @@ import { takeUntilDestroyed, toSignal } from "@angular/core/rxjs-interop";
 import { FormBuilder } from "@angular/forms";
 import { filter, firstValueFrom, switchMap } from "rxjs";
 
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { getUserId } from "@bitwarden/common/auth/services/account.service";
 import { DomainSettingsService } from "@bitwarden/common/autofill/services/domain-settings.service";
 import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
@@ -53,6 +55,7 @@ export class AppearanceComponent implements OnInit {
     private readonly i18nService: I18nService,
     private readonly themeStateService: ThemeStateService,
     private readonly domainSettingsService: DomainSettingsService,
+    private readonly accountService: AccountService,
     private readonly configService: ConfigService,
     private readonly dialogService: DialogService,
     private readonly toastService: ToastService,
@@ -77,12 +80,13 @@ export class AppearanceComponent implements OnInit {
   }
 
   async ngOnInit() {
+    const userId = await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId));
     this.form.setValue(
       {
         enableFavicons: await firstValueFrom(this.domainSettingsService.showFavicons$),
         theme: await firstValueFrom(this.themeStateService.selectedTheme$),
         locale: (await firstValueFrom(this.i18nService.userSetLocale$)) ?? null,
-        earlyAccess: await firstValueFrom(this.configService.earlyAccess$),
+        earlyAccess: await firstValueFrom(this.configService.earlyAccess$(userId)),
       },
       { emitEvent: false },
     );
@@ -125,6 +129,8 @@ export class AppearanceComponent implements OnInit {
   }
 
   private async onEarlyAccessChange(enabled: boolean): Promise<void> {
+    const userId = await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId));
+
     if (enabled) {
       const confirmed = await this.dialogService.openSimpleDialog({
         title: { key: "enableEarlyAccessConfirmTitle" },
@@ -137,7 +143,7 @@ export class AppearanceComponent implements OnInit {
         return;
       }
 
-      await this.configService.setEarlyAccess(true);
+      await this.configService.setEarlyAccess(userId, true);
       this.toastService.showToast({
         variant: "info",
         message: this.i18nService.t("earlyAccessEnabledToast"),
@@ -145,6 +151,6 @@ export class AppearanceComponent implements OnInit {
       return;
     }
 
-    await this.configService.setEarlyAccess(false);
+    await this.configService.setEarlyAccess(userId, false);
   }
 }

--- a/apps/web/src/app/settings/appearance.component.ts
+++ b/apps/web/src/app/settings/appearance.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, DestroyRef, OnInit } from "@angular/core";
 import { takeUntilDestroyed, toSignal } from "@angular/core/rxjs-interop";
 import { FormBuilder } from "@angular/forms";
-import { filter, firstValueFrom, switchMap } from "rxjs";
+import { concatMap, filter, firstValueFrom, switchMap } from "rxjs";
 
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { getUserId } from "@bitwarden/common/auth/services/account.service";
@@ -9,8 +9,11 @@ import { DomainSettingsService } from "@bitwarden/common/autofill/services/domai
 import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+import { ValidationService } from "@bitwarden/common/platform/abstractions/validation.service";
 import { Theme, ThemeTypes } from "@bitwarden/common/platform/enums";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
+import { EarlyAccessService } from "@bitwarden/common/platform/services/early-access/early-access.service";
 import { ThemeStateService } from "@bitwarden/common/platform/theming/theme-state.service";
 import { DialogService, ToastService } from "@bitwarden/components";
 import { PermitCipherDetailsPopoverComponent } from "@bitwarden/vault";
@@ -57,8 +60,11 @@ export class AppearanceComponent implements OnInit {
     private readonly domainSettingsService: DomainSettingsService,
     private readonly accountService: AccountService,
     private readonly configService: ConfigService,
+    private readonly earlyAccessService: EarlyAccessService,
     private readonly dialogService: DialogService,
     private readonly toastService: ToastService,
+    private readonly logService: LogService,
+    private readonly validationService: ValidationService,
     private readonly destroyRef: DestroyRef,
   ) {
     const localeOptions: LocaleOption[] = [];
@@ -86,16 +92,17 @@ export class AppearanceComponent implements OnInit {
         enableFavicons: await firstValueFrom(this.domainSettingsService.showFavicons$),
         theme: await firstValueFrom(this.themeStateService.selectedTheme$),
         locale: (await firstValueFrom(this.i18nService.userSetLocale$)) ?? null,
-        earlyAccess: await firstValueFrom(this.configService.earlyAccess$(userId)),
+        earlyAccess: await firstValueFrom(this.earlyAccessService.earlyAccess$(userId)),
       },
       { emitEvent: false },
     );
 
     this.form.controls.earlyAccess.valueChanges
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe((enabled) => {
-        void this.onEarlyAccessChange(enabled ?? false);
-      });
+      .pipe(
+        concatMap(async (enabled) => this.onEarlyAccessChange(enabled ?? false)),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe();
 
     this.form.controls.enableFavicons.valueChanges
       .pipe(
@@ -131,26 +138,31 @@ export class AppearanceComponent implements OnInit {
   private async onEarlyAccessChange(enabled: boolean): Promise<void> {
     const userId = await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId));
 
-    if (enabled) {
+    try {
+      if (!enabled) {
+        await this.earlyAccessService.setEarlyAccess(userId, false);
+        return;
+      }
+
       const confirmed = await this.dialogService.openSimpleDialog({
         title: { key: "enableEarlyAccessConfirmTitle" },
         content: { key: "enableEarlyAccessConfirmContent" },
         type: "warning",
       });
-
       if (!confirmed) {
         this.form.controls.earlyAccess.setValue(false, { emitEvent: false });
         return;
       }
 
-      await this.configService.setEarlyAccess(userId, true);
+      await this.earlyAccessService.setEarlyAccess(userId, true);
       this.toastService.showToast({
         variant: "info",
         message: this.i18nService.t("earlyAccessEnabledToast"),
       });
-      return;
+    } catch (error) {
+      this.logService.error("Error updating Early Access preference: ", error);
+      this.form.controls.earlyAccess.setValue(!enabled, { emitEvent: false });
+      this.validationService.showError(error);
     }
-
-    await this.configService.setEarlyAccess(userId, false);
   }
 }

--- a/apps/web/src/app/settings/appearance.component.ts
+++ b/apps/web/src/app/settings/appearance.component.ts
@@ -15,7 +15,7 @@ import { Theme, ThemeTypes } from "@bitwarden/common/platform/enums";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { EarlyAccessService } from "@bitwarden/common/platform/services/early-access/early-access.service";
 import { ThemeStateService } from "@bitwarden/common/platform/theming/theme-state.service";
-import { DialogService, ToastService } from "@bitwarden/components";
+import { DialogService } from "@bitwarden/components";
 import { PermitCipherDetailsPopoverComponent } from "@bitwarden/vault";
 
 import { HeaderModule } from "../layouts/header/header.module";
@@ -62,7 +62,6 @@ export class AppearanceComponent implements OnInit {
     private readonly configService: ConfigService,
     private readonly earlyAccessService: EarlyAccessService,
     private readonly dialogService: DialogService,
-    private readonly toastService: ToastService,
     private readonly logService: LogService,
     private readonly validationService: ValidationService,
     private readonly destroyRef: DestroyRef,
@@ -155,10 +154,6 @@ export class AppearanceComponent implements OnInit {
       }
 
       await this.earlyAccessService.setEarlyAccess(userId, true);
-      this.toastService.showToast({
-        variant: "info",
-        message: this.i18nService.t("earlyAccessEnabledToast"),
-      });
     } catch (error) {
       this.logService.error("Error updating Early Access preference: ", error);
       this.form.controls.earlyAccess.setValue(!enabled, { emitEvent: false });

--- a/apps/web/src/app/settings/appearance.component.ts
+++ b/apps/web/src/app/settings/appearance.component.ts
@@ -1,13 +1,16 @@
 import { ChangeDetectionStrategy, Component, DestroyRef, OnInit } from "@angular/core";
-import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
+import { takeUntilDestroyed, toSignal } from "@angular/core/rxjs-interop";
 import { FormBuilder } from "@angular/forms";
 import { filter, firstValueFrom, switchMap } from "rxjs";
 
 import { DomainSettingsService } from "@bitwarden/common/autofill/services/domain-settings.service";
+import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { Theme, ThemeTypes } from "@bitwarden/common/platform/enums";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { ThemeStateService } from "@bitwarden/common/platform/theming/theme-state.service";
+import { DialogService, ToastService } from "@bitwarden/components";
 import { PermitCipherDetailsPopoverComponent } from "@bitwarden/vault";
 
 import { HeaderModule } from "../layouts/header/header.module";
@@ -37,13 +40,22 @@ export class AppearanceComponent implements OnInit {
     enableFavicons: true,
     theme: [ThemeTypes.Light as Theme],
     locale: [null as string | null],
+    betaMode: false,
   });
+
+  protected readonly showBetaToggle = toSignal(
+    this.configService.getFeatureFlag$(FeatureFlag.PM39893BetaMode),
+    { initialValue: false },
+  );
 
   constructor(
     private readonly formBuilder: FormBuilder,
     private readonly i18nService: I18nService,
     private readonly themeStateService: ThemeStateService,
     private readonly domainSettingsService: DomainSettingsService,
+    private readonly configService: ConfigService,
+    private readonly dialogService: DialogService,
+    private readonly toastService: ToastService,
     private readonly destroyRef: DestroyRef,
   ) {
     const localeOptions: LocaleOption[] = [];
@@ -70,9 +82,16 @@ export class AppearanceComponent implements OnInit {
         enableFavicons: await firstValueFrom(this.domainSettingsService.showFavicons$),
         theme: await firstValueFrom(this.themeStateService.selectedTheme$),
         locale: (await firstValueFrom(this.i18nService.userSetLocale$)) ?? null,
+        betaMode: await firstValueFrom(this.configService.betaMode$),
       },
       { emitEvent: false },
     );
+
+    this.form.controls.betaMode.valueChanges
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((enabled) => {
+        void this.onBetaModeChange(enabled ?? false);
+      });
 
     this.form.controls.enableFavicons.valueChanges
       .pipe(
@@ -103,5 +122,29 @@ export class AppearanceComponent implements OnInit {
         takeUntilDestroyed(this.destroyRef),
       )
       .subscribe();
+  }
+
+  private async onBetaModeChange(enabled: boolean): Promise<void> {
+    if (enabled) {
+      const confirmed = await this.dialogService.openSimpleDialog({
+        title: { key: "enableBetaModeConfirmTitle" },
+        content: { key: "enableBetaModeConfirmContent" },
+        type: "warning",
+      });
+
+      if (!confirmed) {
+        this.form.controls.betaMode.setValue(false, { emitEvent: false });
+        return;
+      }
+
+      await this.configService.setBetaMode(true);
+      this.toastService.showToast({
+        variant: "info",
+        message: this.i18nService.t("betaModeEnabledToast"),
+      });
+      return;
+    }
+
+    await this.configService.setBetaMode(false);
   }
 }

--- a/apps/web/src/app/settings/appearance.component.ts
+++ b/apps/web/src/app/settings/appearance.component.ts
@@ -15,7 +15,7 @@ import { Theme, ThemeTypes } from "@bitwarden/common/platform/enums";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { EarlyAccessService } from "@bitwarden/common/platform/services/early-access/early-access.service";
 import { ThemeStateService } from "@bitwarden/common/platform/theming/theme-state.service";
-import { DialogService } from "@bitwarden/components";
+import { DialogService, SwitchComponent } from "@bitwarden/components";
 import { PermitCipherDetailsPopoverComponent } from "@bitwarden/vault";
 
 import { HeaderModule } from "../layouts/header/header.module";
@@ -34,7 +34,7 @@ type ThemeOption = {
 @Component({
   selector: "app-appearance",
   templateUrl: "appearance.component.html",
-  imports: [SharedModule, HeaderModule, PermitCipherDetailsPopoverComponent],
+  imports: [SharedModule, HeaderModule, PermitCipherDetailsPopoverComponent, SwitchComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class AppearanceComponent implements OnInit {

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -14985,19 +14985,19 @@
   "cannotSaveItemNoConfirmedOrgs": {
     "message": "Unable to save item. You must be confirmed to the organization to save items."
   },
-  "betaMode": {
-    "message": "Beta mode"
+  "earlyAccess": {
+    "message": "Early access"
   },
-  "betaModeDesc": {
+  "earlyAccessDesc": {
     "message": "Enable early access to features currently in prerelease testing"
   },
-  "enableBetaModeConfirmTitle": {
-    "message": "Enable beta mode?"
+  "enableEarlyAccessConfirmTitle": {
+    "message": "Enable early access?"
   },
-  "enableBetaModeConfirmContent": {
-    "message": "Beta features are still in testing and may be unstable or change without notice."
+  "enableEarlyAccessConfirmContent": {
+    "message": "Early access features are still in testing and may be unstable or change without notice."
   },
-  "betaModeEnabledToast": {
-    "message": "Beta mode enabled. Reopen the app to make sure all features refresh."
+  "earlyAccessEnabledToast": {
+    "message": "Early access enabled. Reopen the app to make sure all features refresh."
   }
 }

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -14996,8 +14996,5 @@
   },
   "enableEarlyAccessConfirmContent": {
     "message": "Early access features are still in testing and may be unstable or change without notice."
-  },
-  "earlyAccessEnabledToast": {
-    "message": "Early access enabled."
   }
 }

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -14998,6 +14998,6 @@
     "message": "Early access features are still in testing and may be unstable or change without notice."
   },
   "earlyAccessEnabledToast": {
-    "message": "Early access enabled. Reopen the app to make sure all features refresh."
+    "message": "Early access enabled."
   }
 }

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -14984,5 +14984,20 @@
   },
   "cannotSaveItemNoConfirmedOrgs": {
     "message": "Unable to save item. You must be confirmed to the organization to save items."
+  },
+  "betaMode": {
+    "message": "Beta mode"
+  },
+  "betaModeDesc": {
+    "message": "Enable early access to features currently in prerelease testing"
+  },
+  "enableBetaModeConfirmTitle": {
+    "message": "Enable beta mode?"
+  },
+  "enableBetaModeConfirmContent": {
+    "message": "Beta features are still in testing and may be unstable or change without notice."
+  },
+  "betaModeEnabledToast": {
+    "message": "Beta mode enabled. Reopen the app to make sure all features refresh."
   }
 }

--- a/libs/angular/src/services/jslib-services.module.ts
+++ b/libs/angular/src/services/jslib-services.module.ts
@@ -274,6 +274,7 @@ import {
 import { AppIdService } from "@bitwarden/common/platform/services/app-id.service";
 import { ConfigApiService } from "@bitwarden/common/platform/services/config/config-api.service";
 import { DefaultConfigService } from "@bitwarden/common/platform/services/config/default-config.service";
+import { prereleaseHeaderMiddleware } from "@bitwarden/common/platform/services/config/prerelease-header.middleware";
 import { ConsoleLogService } from "@bitwarden/common/platform/services/console-log.service";
 import { DefaultBroadcasterService } from "@bitwarden/common/platform/services/default-broadcaster.service";
 import { DefaultEnvironmentService } from "@bitwarden/common/platform/services/default-environment.service";
@@ -2020,6 +2021,15 @@ const safeProviders: SafeProvider[] = [
     provide: APP_INITIALIZER as SafeInjectionToken<() => Promise<void>>,
     useFactory: (encryptedMigrationsScheduler: EncryptedMigrationsSchedulerService) => () => {},
     deps: [EncryptedMigrationsSchedulerService],
+    multi: true,
+  }),
+  safeProvider({
+    provide: APP_INITIALIZER as SafeInjectionToken<() => Promise<void>>,
+    useFactory: (apiService: ApiServiceAbstraction, configService: ConfigService) => {
+      apiService.addMiddleware(prereleaseHeaderMiddleware(configService));
+      return () => Promise.resolve();
+    },
+    deps: [ApiServiceAbstraction, ConfigService],
     multi: true,
   }),
   safeProvider({

--- a/libs/angular/src/services/jslib-services.module.ts
+++ b/libs/angular/src/services/jslib-services.module.ts
@@ -279,6 +279,8 @@ import { ConsoleLogService } from "@bitwarden/common/platform/services/console-l
 import { DefaultBroadcasterService } from "@bitwarden/common/platform/services/default-broadcaster.service";
 import { DefaultEnvironmentService } from "@bitwarden/common/platform/services/default-environment.service";
 import { DefaultServerSettingsService } from "@bitwarden/common/platform/services/default-server-settings.service";
+import { DefaultEarlyAccessService } from "@bitwarden/common/platform/services/early-access/default-early-access.service";
+import { EarlyAccessService } from "@bitwarden/common/platform/services/early-access/early-access.service";
 import { FileUploadService } from "@bitwarden/common/platform/services/file-upload/file-upload.service";
 import { MigrationBuilderService } from "@bitwarden/common/platform/services/migration-builder.service";
 import { MigrationRunner } from "@bitwarden/common/platform/services/migration-runner";
@@ -2024,16 +2026,21 @@ const safeProviders: SafeProvider[] = [
     multi: true,
   }),
   safeProvider({
+    provide: EarlyAccessService,
+    useClass: DefaultEarlyAccessService,
+    deps: [StateProvider, ConfigService],
+  }),
+  safeProvider({
     provide: APP_INITIALIZER as SafeInjectionToken<() => Promise<void>>,
     useFactory: (
       apiService: ApiServiceAbstraction,
-      configService: ConfigService,
+      earlyAccessService: EarlyAccessService,
       accountService: AccountServiceAbstraction,
     ) => {
-      apiService.addMiddleware(prereleaseHeaderMiddleware(configService, accountService));
+      apiService.addMiddleware(prereleaseHeaderMiddleware(earlyAccessService, accountService));
       return () => Promise.resolve();
     },
-    deps: [ApiServiceAbstraction, ConfigService, AccountServiceAbstraction],
+    deps: [ApiServiceAbstraction, EarlyAccessService, AccountServiceAbstraction],
     multi: true,
   }),
   safeProvider({

--- a/libs/angular/src/services/jslib-services.module.ts
+++ b/libs/angular/src/services/jslib-services.module.ts
@@ -2025,11 +2025,15 @@ const safeProviders: SafeProvider[] = [
   }),
   safeProvider({
     provide: APP_INITIALIZER as SafeInjectionToken<() => Promise<void>>,
-    useFactory: (apiService: ApiServiceAbstraction, configService: ConfigService) => {
-      apiService.addMiddleware(prereleaseHeaderMiddleware(configService));
+    useFactory: (
+      apiService: ApiServiceAbstraction,
+      configService: ConfigService,
+      accountService: AccountServiceAbstraction,
+    ) => {
+      apiService.addMiddleware(prereleaseHeaderMiddleware(configService, accountService));
       return () => Promise.resolve();
     },
-    deps: [ApiServiceAbstraction, ConfigService],
+    deps: [ApiServiceAbstraction, ConfigService, AccountServiceAbstraction],
     multi: true,
   }),
   safeProvider({

--- a/libs/common/src/enums/feature-flag.enum.ts
+++ b/libs/common/src/enums/feature-flag.enum.ts
@@ -230,7 +230,7 @@ export const DefaultFeatureFlagValue = {
   [FeatureFlag.ContentScriptIpcChannelFramework]: FALSE,
   [FeatureFlag.WebAuthnRelatedOrigins]: FALSE,
   [FeatureFlag.PM34410AttachmentUploadProgress]: FALSE,
-  [FeatureFlag.EarlyAccess]: true as boolean,
+  [FeatureFlag.EarlyAccess]: FALSE,
 
   /* Innovation */
   [FeatureFlag.ElectronStorageCache]: FALSE,

--- a/libs/common/src/enums/feature-flag.enum.ts
+++ b/libs/common/src/enums/feature-flag.enum.ts
@@ -110,6 +110,7 @@ export enum FeatureFlag {
   ContentScriptIpcChannelFramework = "content-script-ipc-channel-framework",
   WebAuthnRelatedOrigins = "pm-30529-webauthn-related-origins",
   PM34410AttachmentUploadProgress = "pm-34410-attachment-upload-progress",
+  PM39893BetaMode = "pm-39893-beta-mode",
 
   /* Innovation */
   ElectronStorageCache = "pm-32783-electron-storage-cache",
@@ -229,6 +230,7 @@ export const DefaultFeatureFlagValue = {
   [FeatureFlag.ContentScriptIpcChannelFramework]: FALSE,
   [FeatureFlag.WebAuthnRelatedOrigins]: FALSE,
   [FeatureFlag.PM34410AttachmentUploadProgress]: FALSE,
+  [FeatureFlag.PM39893BetaMode]: FALSE,
 
   /* Innovation */
   [FeatureFlag.ElectronStorageCache]: FALSE,

--- a/libs/common/src/enums/feature-flag.enum.ts
+++ b/libs/common/src/enums/feature-flag.enum.ts
@@ -110,7 +110,7 @@ export enum FeatureFlag {
   ContentScriptIpcChannelFramework = "content-script-ipc-channel-framework",
   WebAuthnRelatedOrigins = "pm-30529-webauthn-related-origins",
   PM34410AttachmentUploadProgress = "pm-34410-attachment-upload-progress",
-  PM39893BetaMode = "pm-39893-beta-mode",
+  EarlyAccess = "early-access",
 
   /* Innovation */
   ElectronStorageCache = "pm-32783-electron-storage-cache",
@@ -230,7 +230,7 @@ export const DefaultFeatureFlagValue = {
   [FeatureFlag.ContentScriptIpcChannelFramework]: FALSE,
   [FeatureFlag.WebAuthnRelatedOrigins]: FALSE,
   [FeatureFlag.PM34410AttachmentUploadProgress]: FALSE,
-  [FeatureFlag.PM39893BetaMode]: FALSE,
+  [FeatureFlag.EarlyAccess]: true as boolean,
 
   /* Innovation */
   [FeatureFlag.ElectronStorageCache]: FALSE,

--- a/libs/common/src/platform/abstractions/config/config.service.ts
+++ b/libs/common/src/platform/abstractions/config/config.service.ts
@@ -64,15 +64,15 @@ export abstract class ConfigService {
   abstract ensureConfigFetched(): Promise<void>;
 
   /**
-   * Device-level Beta Mode state. When enabled, the client sends the `Is-Prerelease` header on
-   * API requests so that feature flags evaluate with prerelease context. Applies to the entire
-   * installation regardless of which user is signed in.
+   * Device-level Early Access state. When enabled, the client sends the `Is-Prerelease` header
+   * on API requests so that feature flags evaluate with prerelease context. Applies to the
+   * entire installation regardless of which user is signed in.
    */
-  abstract betaMode$: Observable<boolean>;
+  abstract earlyAccess$: Observable<boolean>;
 
   /**
-   * Sets the device-level Beta Mode state. Takes effect on subsequent API requests; feature
+   * Sets the device-level Early Access state. Takes effect on subsequent API requests; feature
    * flags re-evaluate on the next scheduled config fetch.
    */
-  abstract setBetaMode(enabled: boolean): Promise<void>;
+  abstract setEarlyAccess(enabled: boolean): Promise<void>;
 }

--- a/libs/common/src/platform/abstractions/config/config.service.ts
+++ b/libs/common/src/platform/abstractions/config/config.service.ts
@@ -64,16 +64,10 @@ export abstract class ConfigService {
   abstract ensureConfigFetched(): Promise<void>;
 
   /**
-   * Per-user Early Access preference. When enabled, the client sends the `Is-Prerelease` header
-   * on API requests for this user so that feature flags evaluate with prerelease context.
-   * Persists across logout for the account.
+   * Invalidates the cached server config for the given user so the next `serverConfig$` read is
+   * forced to refetch — instead of waiting up to `RETRIEVAL_INTERVAL` (1 hour) for the natural
+   * refresh cycle. Backdates the cached config's `utcDate` rather than clearing to null so
+   * consumers keep seeing the current flag values while the refresh is in flight.
    */
-  abstract earlyAccess$(userId: UserId): Observable<boolean>;
-
-  /**
-   * Sets the Early Access preference for the given user. Takes effect on subsequent API
-   * requests; the user's cached config is invalidated immediately so feature flags re-evaluate
-   * on the next read rather than waiting for the natural refresh interval.
-   */
-  abstract setEarlyAccess(userId: UserId, enabled: boolean): Promise<void>;
+  abstract invalidateUserConfig(userId: UserId): Promise<void>;
 }

--- a/libs/common/src/platform/abstractions/config/config.service.ts
+++ b/libs/common/src/platform/abstractions/config/config.service.ts
@@ -62,4 +62,17 @@ export abstract class ConfigService {
    * Triggers a check that the config for the currently active user is up-to-date. If it is not, it will be fetched from the server and stored.
    */
   abstract ensureConfigFetched(): Promise<void>;
+
+  /**
+   * Device-level Beta Mode state. When enabled, the client sends the `Is-Prerelease` header on
+   * API requests so that feature flags evaluate with prerelease context. Applies to the entire
+   * installation regardless of which user is signed in.
+   */
+  abstract betaMode$: Observable<boolean>;
+
+  /**
+   * Sets the device-level Beta Mode state. Takes effect on subsequent API requests; feature
+   * flags re-evaluate on the next scheduled config fetch.
+   */
+  abstract setBetaMode(enabled: boolean): Promise<void>;
 }

--- a/libs/common/src/platform/abstractions/config/config.service.ts
+++ b/libs/common/src/platform/abstractions/config/config.service.ts
@@ -64,15 +64,16 @@ export abstract class ConfigService {
   abstract ensureConfigFetched(): Promise<void>;
 
   /**
-   * Device-level Early Access state. When enabled, the client sends the `Is-Prerelease` header
-   * on API requests so that feature flags evaluate with prerelease context. Applies to the
-   * entire installation regardless of which user is signed in.
+   * Per-user Early Access preference. When enabled, the client sends the `Is-Prerelease` header
+   * on API requests for this user so that feature flags evaluate with prerelease context.
+   * Persists across logout for the account.
    */
-  abstract earlyAccess$: Observable<boolean>;
+  abstract earlyAccess$(userId: UserId): Observable<boolean>;
 
   /**
-   * Sets the device-level Early Access state. Takes effect on subsequent API requests; feature
-   * flags re-evaluate on the next scheduled config fetch.
+   * Sets the Early Access preference for the given user. Takes effect on subsequent API
+   * requests; the user's cached config is invalidated immediately so feature flags re-evaluate
+   * on the next read rather than waiting for the natural refresh interval.
    */
-  abstract setEarlyAccess(enabled: boolean): Promise<void>;
+  abstract setEarlyAccess(userId: UserId, enabled: boolean): Promise<void>;
 }

--- a/libs/common/src/platform/services/config/config.service.spec.ts
+++ b/libs/common/src/platform/services/config/config.service.spec.ts
@@ -519,24 +519,24 @@ describe("ConfigService", () => {
     });
 
     it("defaults to disabled when the app has never been opted in", async () => {
-      expect(await firstValueFrom(sut.earlyAccess$)).toBe(false);
+      expect(await firstValueFrom(sut.earlyAccess$(userId))).toBe(false);
     });
 
     it("setEarlyAccess toggles what earlyAccess$ emits", async () => {
-      await sut.setEarlyAccess(true);
-      expect(await firstValueFrom(sut.earlyAccess$)).toBe(true);
+      await sut.setEarlyAccess(userId, true);
+      expect(await firstValueFrom(sut.earlyAccess$(userId))).toBe(true);
 
-      await sut.setEarlyAccess(false);
-      expect(await firstValueFrom(sut.earlyAccess$)).toBe(false);
+      await sut.setEarlyAccess(userId, false);
+      expect(await firstValueFrom(sut.earlyAccess$(userId))).toBe(false);
     });
 
     it("delivers live updates so middleware and UI subscribers see toggle flips without re-subscribing", async () => {
       const emissions: boolean[] = [];
-      const subscription = sut.earlyAccess$.subscribe((v) => emissions.push(v));
+      const subscription = sut.earlyAccess$(userId).subscribe((v) => emissions.push(v));
 
-      await sut.setEarlyAccess(true);
-      await sut.setEarlyAccess(false);
-      await sut.setEarlyAccess(true);
+      await sut.setEarlyAccess(userId, true);
+      await sut.setEarlyAccess(userId, false);
+      await sut.setEarlyAccess(userId, true);
       subscription.unsubscribe();
 
       // Initial `false`, then each setEarlyAccess change; guards against a stale ReplaySubject or
@@ -544,15 +544,31 @@ describe("ConfigService", () => {
       expect(emissions).toEqual([false, true, false, true]);
     });
 
-    it("is not user-scoped: switching the active user does not change earlyAccess$", async () => {
-      // The design decision behind this is that Early Access targets the install/build, not the user.
-      await sut.setEarlyAccess(true);
+    it("is user-scoped: each user's preference is independent", async () => {
+      const otherUserId = "other-user" as UserId;
 
-      await accountService.switchAccount(null);
-      expect(await firstValueFrom(sut.earlyAccess$)).toBe(true);
+      await sut.setEarlyAccess(userId, true);
+      await sut.setEarlyAccess(otherUserId, false);
 
-      await accountService.switchAccount(userId);
-      expect(await firstValueFrom(sut.earlyAccess$)).toBe(true);
+      expect(await firstValueFrom(sut.earlyAccess$(userId))).toBe(true);
+      expect(await firstValueFrom(sut.earlyAccess$(otherUserId))).toBe(false);
+    });
+
+    it("persists across logout — clearOn is [] so re-authenticating keeps the preference", async () => {
+      // Simulate the "user preference survives logout" invariant by writing directly to state:
+      // clearOn: [] means logout events do not clear this key. We assert the state key definition
+      // reflects that intent by ensuring toggling on -> logout-like reset -> re-read still shows on.
+      await sut.setEarlyAccess(userId, true);
+
+      // A fresh service instance (as if the app relaunched) reads the same persisted value.
+      const nextLaunch = new DefaultConfigService(
+        configApiService,
+        environmentService,
+        logService,
+        stateProvider,
+        authService,
+      );
+      expect(await firstValueFrom(nextLaunch.earlyAccess$(userId))).toBe(true);
     });
 
     describe("cache invalidation on toggle", () => {
@@ -568,7 +584,7 @@ describe("ConfigService", () => {
       });
 
       it("backdates the cached config so the pipeline's staleness check will force a refetch on the next read", async () => {
-        await sut.setEarlyAccess(true);
+        await sut.setEarlyAccess(userId, true);
 
         const cached = await firstValueFrom(userState.state$);
         // olderThanRetrievalInterval treats utcDate < (now - RETRIEVAL_INTERVAL) as stale.
@@ -577,7 +593,7 @@ describe("ConfigService", () => {
       });
 
       it("preserves the cached feature flag data during the refresh window (backdate, not clear)", async () => {
-        await sut.setEarlyAccess(true);
+        await sut.setEarlyAccess(userId, true);
 
         const cached = await firstValueFrom(userState.state$);
         // Consumers reading getFeatureFlag$ during the refresh window see the original flag data
@@ -589,8 +605,8 @@ describe("ConfigService", () => {
       it("no-ops safely when there is no cached config to invalidate", async () => {
         userState.nextState(null);
 
-        await expect(sut.setEarlyAccess(true)).resolves.not.toThrow();
-        expect(await firstValueFrom(sut.earlyAccess$)).toBe(true);
+        await expect(sut.setEarlyAccess(userId, true)).resolves.not.toThrow();
+        expect(await firstValueFrom(sut.earlyAccess$(userId))).toBe(true);
       });
     });
   });

--- a/libs/common/src/platform/services/config/config.service.spec.ts
+++ b/libs/common/src/platform/services/config/config.service.spec.ts
@@ -36,6 +36,7 @@ import {
   RETRIEVAL_INTERVAL,
   GLOBAL_FEATURE_FLAG_OVERRIDES,
   GLOBAL_SERVER_CONFIGURATIONS,
+  USER_EARLY_ACCESS_ENABLED,
   USER_SERVER_CONFIG,
   SLOW_EMISSION_GUARD,
 } from "./default-config.service";
@@ -519,6 +520,27 @@ describe("ConfigService", () => {
     });
 
     it("defaults to disabled when the app has never been opted in", async () => {
+      expect(await firstValueFrom(sut.earlyAccess$(userId))).toBe(false);
+    });
+
+    it("returns false when the EarlyAccess feature flag is disabled, even if state has been opted in", async () => {
+      // Seed a cached config that explicitly disables the EarlyAccess flag server-side.
+      const config = new ServerConfig(
+        new ServerConfigData(
+          new ServerConfigResponse({
+            version: "myConfigVersion",
+            gitHash: "flag-off",
+            server: new ThirdPartyServerConfigResponse({ name: "n", url: "u" }),
+            environment: new EnvironmentServerConfigResponse({ vault: "vault.example.com" }),
+            featureStates: { [FeatureFlag.EarlyAccess]: false },
+          }),
+        ),
+      );
+      userState.nextState(config);
+
+      // User previously opted in — but the server-side flag is now off.
+      await stateProvider.setUserState(USER_EARLY_ACCESS_ENABLED, true, userId);
+
       expect(await firstValueFrom(sut.earlyAccess$(userId))).toBe(false);
     });
 

--- a/libs/common/src/platform/services/config/config.service.spec.ts
+++ b/libs/common/src/platform/services/config/config.service.spec.ts
@@ -501,7 +501,7 @@ describe("ConfigService", () => {
     });
   });
 
-  describe("beta mode", () => {
+  describe("early access", () => {
     let sut: DefaultConfigService;
 
     const buildService = () =>
@@ -519,45 +519,45 @@ describe("ConfigService", () => {
     });
 
     it("defaults to disabled when the app has never been opted in", async () => {
-      expect(await firstValueFrom(sut.betaMode$)).toBe(false);
+      expect(await firstValueFrom(sut.earlyAccess$)).toBe(false);
     });
 
-    it("setBetaMode toggles what betaMode$ emits", async () => {
-      await sut.setBetaMode(true);
-      expect(await firstValueFrom(sut.betaMode$)).toBe(true);
+    it("setEarlyAccess toggles what earlyAccess$ emits", async () => {
+      await sut.setEarlyAccess(true);
+      expect(await firstValueFrom(sut.earlyAccess$)).toBe(true);
 
-      await sut.setBetaMode(false);
-      expect(await firstValueFrom(sut.betaMode$)).toBe(false);
+      await sut.setEarlyAccess(false);
+      expect(await firstValueFrom(sut.earlyAccess$)).toBe(false);
     });
 
     it("delivers live updates so middleware and UI subscribers see toggle flips without re-subscribing", async () => {
       const emissions: boolean[] = [];
-      const subscription = sut.betaMode$.subscribe((v) => emissions.push(v));
+      const subscription = sut.earlyAccess$.subscribe((v) => emissions.push(v));
 
-      await sut.setBetaMode(true);
-      await sut.setBetaMode(false);
-      await sut.setBetaMode(true);
+      await sut.setEarlyAccess(true);
+      await sut.setEarlyAccess(false);
+      await sut.setEarlyAccess(true);
       subscription.unsubscribe();
 
-      // Initial `false`, then each setBetaMode change; guards against a stale ReplaySubject or
+      // Initial `false`, then each setEarlyAccess change; guards against a stale ReplaySubject or
       // detached observable pipeline in a future refactor.
       expect(emissions).toEqual([false, true, false, true]);
     });
 
-    it("is not user-scoped: switching the active user does not change betaMode$", async () => {
-      // The design decision behind this is that Beta Mode targets the install/build, not the user.
-      await sut.setBetaMode(true);
+    it("is not user-scoped: switching the active user does not change earlyAccess$", async () => {
+      // The design decision behind this is that Early Access targets the install/build, not the user.
+      await sut.setEarlyAccess(true);
 
       await accountService.switchAccount(null);
-      expect(await firstValueFrom(sut.betaMode$)).toBe(true);
+      expect(await firstValueFrom(sut.earlyAccess$)).toBe(true);
 
       await accountService.switchAccount(userId);
-      expect(await firstValueFrom(sut.betaMode$)).toBe(true);
+      expect(await firstValueFrom(sut.earlyAccess$)).toBe(true);
     });
 
     describe("cache invalidation on toggle", () => {
-      // A user who toggles beta mode expects flag values to update on the very next read — not
-      // to wait up to RETRIEVAL_INTERVAL (1 hour) for the natural refresh cycle. setBetaMode
+      // A user who toggles early access expects flag values to update on the very next read — not
+      // to wait up to RETRIEVAL_INTERVAL (1 hour) for the natural refresh cycle. setEarlyAccess
       // invalidates the cached config by backdating its utcDate so that the next serverConfig$
       // subscription treats it as stale and refetches. Backdating (rather than clearing to null)
       // keeps the current flag values available to consumers during the refresh window instead of
@@ -568,7 +568,7 @@ describe("ConfigService", () => {
       });
 
       it("backdates the cached config so the pipeline's staleness check will force a refetch on the next read", async () => {
-        await sut.setBetaMode(true);
+        await sut.setEarlyAccess(true);
 
         const cached = await firstValueFrom(userState.state$);
         // olderThanRetrievalInterval treats utcDate < (now - RETRIEVAL_INTERVAL) as stale.
@@ -577,7 +577,7 @@ describe("ConfigService", () => {
       });
 
       it("preserves the cached feature flag data during the refresh window (backdate, not clear)", async () => {
-        await sut.setBetaMode(true);
+        await sut.setEarlyAccess(true);
 
         const cached = await firstValueFrom(userState.state$);
         // Consumers reading getFeatureFlag$ during the refresh window see the original flag data
@@ -589,8 +589,8 @@ describe("ConfigService", () => {
       it("no-ops safely when there is no cached config to invalidate", async () => {
         userState.nextState(null);
 
-        await expect(sut.setBetaMode(true)).resolves.not.toThrow();
-        expect(await firstValueFrom(sut.betaMode$)).toBe(true);
+        await expect(sut.setEarlyAccess(true)).resolves.not.toThrow();
+        expect(await firstValueFrom(sut.earlyAccess$)).toBe(true);
       });
     });
   });

--- a/libs/common/src/platform/services/config/config.service.spec.ts
+++ b/libs/common/src/platform/services/config/config.service.spec.ts
@@ -36,7 +36,6 @@ import {
   RETRIEVAL_INTERVAL,
   GLOBAL_FEATURE_FLAG_OVERRIDES,
   GLOBAL_SERVER_CONFIGURATIONS,
-  USER_EARLY_ACCESS_ENABLED,
   USER_SERVER_CONFIG,
   SLOW_EMISSION_GUARD,
 } from "./default-config.service";
@@ -502,134 +501,62 @@ describe("ConfigService", () => {
     });
   });
 
-  describe("early access", () => {
+  describe("invalidateUserConfig", () => {
+    // A caller (typically EarlyAccessService.setEarlyAccess) expects flag values to update on the
+    // very next read — not to wait up to RETRIEVAL_INTERVAL (1 hour) for the natural refresh
+    // cycle. `invalidateUserConfig` backdates the cached config's utcDate so the next
+    // serverConfig$ subscription treats it as stale and refetches. Backdating (rather than
+    // clearing to null) keeps the current flag values available to consumers during the refresh
+    // window instead of briefly falling through to defaults.
     let sut: DefaultConfigService;
-
-    const buildService = () =>
-      new DefaultConfigService(
-        configApiService,
-        environmentService,
-        logService,
-        stateProvider,
-        authService,
-      );
 
     beforeEach(async () => {
       await accountService.switchAccount(userId);
-      sut = buildService();
-    });
-
-    it("defaults to disabled when the app has never been opted in", async () => {
-      expect(await firstValueFrom(sut.earlyAccess$(userId))).toBe(false);
-    });
-
-    it("returns false when the EarlyAccess feature flag is disabled, even if state has been opted in", async () => {
-      // Seed a cached config that explicitly disables the EarlyAccess flag server-side.
-      const config = new ServerConfig(
-        new ServerConfigData(
-          new ServerConfigResponse({
-            version: "myConfigVersion",
-            gitHash: "flag-off",
-            server: new ThirdPartyServerConfigResponse({ name: "n", url: "u" }),
-            environment: new EnvironmentServerConfigResponse({ vault: "vault.example.com" }),
-            featureStates: { [FeatureFlag.EarlyAccess]: false },
-          }),
-        ),
-      );
-      userState.nextState(config);
-
-      // User previously opted in — but the server-side flag is now off.
-      await stateProvider.setUserState(USER_EARLY_ACCESS_ENABLED, true, userId);
-
-      expect(await firstValueFrom(sut.earlyAccess$(userId))).toBe(false);
-    });
-
-    it("setEarlyAccess toggles what earlyAccess$ emits", async () => {
-      await sut.setEarlyAccess(userId, true);
-      expect(await firstValueFrom(sut.earlyAccess$(userId))).toBe(true);
-
-      await sut.setEarlyAccess(userId, false);
-      expect(await firstValueFrom(sut.earlyAccess$(userId))).toBe(false);
-    });
-
-    it("delivers live updates so middleware and UI subscribers see toggle flips without re-subscribing", async () => {
-      const emissions: boolean[] = [];
-      const subscription = sut.earlyAccess$(userId).subscribe((v) => emissions.push(v));
-
-      await sut.setEarlyAccess(userId, true);
-      await sut.setEarlyAccess(userId, false);
-      await sut.setEarlyAccess(userId, true);
-      subscription.unsubscribe();
-
-      // Initial `false`, then each setEarlyAccess change; guards against a stale ReplaySubject or
-      // detached observable pipeline in a future refactor.
-      expect(emissions).toEqual([false, true, false, true]);
-    });
-
-    it("is user-scoped: each user's preference is independent", async () => {
-      const otherUserId = "other-user" as UserId;
-
-      await sut.setEarlyAccess(userId, true);
-      await sut.setEarlyAccess(otherUserId, false);
-
-      expect(await firstValueFrom(sut.earlyAccess$(userId))).toBe(true);
-      expect(await firstValueFrom(sut.earlyAccess$(otherUserId))).toBe(false);
-    });
-
-    it("persists across logout — clearOn is [] so re-authenticating keeps the preference", async () => {
-      // Simulate the "user preference survives logout" invariant by writing directly to state:
-      // clearOn: [] means logout events do not clear this key. We assert the state key definition
-      // reflects that intent by ensuring toggling on -> logout-like reset -> re-read still shows on.
-      await sut.setEarlyAccess(userId, true);
-
-      // A fresh service instance (as if the app relaunched) reads the same persisted value.
-      const nextLaunch = new DefaultConfigService(
+      sut = new DefaultConfigService(
         configApiService,
         environmentService,
         logService,
         stateProvider,
         authService,
       );
-      expect(await firstValueFrom(nextLaunch.earlyAccess$(userId))).toBe(true);
+      // Seed a fresh cached config so we can observe the invalidation.
+      userState.nextState(serverConfigFactory("cached-hash"));
     });
 
-    describe("cache invalidation on toggle", () => {
-      // A user who toggles early access expects flag values to update on the very next read — not
-      // to wait up to RETRIEVAL_INTERVAL (1 hour) for the natural refresh cycle. setEarlyAccess
-      // invalidates the cached config by backdating its utcDate so that the next serverConfig$
-      // subscription treats it as stale and refetches. Backdating (rather than clearing to null)
-      // keeps the current flag values available to consumers during the refresh window instead of
-      // briefly falling through to defaults.
-      beforeEach(() => {
-        // Seed a fresh cached config so we can observe the invalidation.
-        userState.nextState(serverConfigFactory("cached-hash"));
-      });
+    it("backdates the cached config so the pipeline's staleness check will force a refetch on the next read", async () => {
+      await sut.invalidateUserConfig(userId);
 
-      it("backdates the cached config so the pipeline's staleness check will force a refetch on the next read", async () => {
-        await sut.setEarlyAccess(userId, true);
+      const cached = await firstValueFrom(userState.state$);
+      // olderThanRetrievalInterval treats utcDate < (now - RETRIEVAL_INTERVAL) as stale.
+      // new Date(0) (epoch) is definitively past that boundary.
+      expect(cached.utcDate.getTime()).toBe(0);
+    });
 
-        const cached = await firstValueFrom(userState.state$);
-        // olderThanRetrievalInterval treats utcDate < (now - RETRIEVAL_INTERVAL) as stale.
-        // new Date(0) (epoch) is definitively past that boundary.
-        expect(cached.utcDate.getTime()).toBe(0);
-      });
+    it("preserves the cached feature flag data during the refresh window (backdate, not clear)", async () => {
+      await sut.invalidateUserConfig(userId);
 
-      it("preserves the cached feature flag data during the refresh window (backdate, not clear)", async () => {
-        await sut.setEarlyAccess(userId, true);
+      const cached = await firstValueFrom(userState.state$);
+      // Consumers reading getFeatureFlag$ during the refresh window see the original flag data
+      // — not defaults — because the data wasn't cleared, just marked stale.
+      expect(cached).not.toBeNull();
+      expect(cached.gitHash).toBe("cached-hash");
+    });
 
-        const cached = await firstValueFrom(userState.state$);
-        // Consumers reading getFeatureFlag$ during the refresh window see the original flag data
-        // — not defaults — because the data wasn't cleared, just marked stale.
-        expect(cached).not.toBeNull();
-        expect(cached.gitHash).toBe("cached-hash");
-      });
+    it("no-ops safely when there is no cached config to invalidate", async () => {
+      userState.nextState(null);
 
-      it("no-ops safely when there is no cached config to invalidate", async () => {
-        userState.nextState(null);
+      await expect(sut.invalidateUserConfig(userId)).resolves.not.toThrow();
+    });
 
-        await expect(sut.setEarlyAccess(userId, true)).resolves.not.toThrow();
-        expect(await firstValueFrom(sut.earlyAccess$(userId))).toBe(true);
-      });
+    it("returns a fresh instance instead of mutating the cached ServerConfig in place", async () => {
+      const before = await firstValueFrom(userState.state$);
+      const originalUtcDate = before.utcDate;
+
+      await sut.invalidateUserConfig(userId);
+
+      // The pre-invalidation reference must not have been mutated — otherwise concurrent
+      // subscribers holding that reference would see the backdated utcDate before the write.
+      expect(before.utcDate).toBe(originalUtcDate);
     });
   });
 });

--- a/libs/common/src/platform/services/config/config.service.spec.ts
+++ b/libs/common/src/platform/services/config/config.service.spec.ts
@@ -500,6 +500,100 @@ describe("ConfigService", () => {
       expect(configs[1].gitHash).toBe("slow-response");
     });
   });
+
+  describe("beta mode", () => {
+    let sut: DefaultConfigService;
+
+    const buildService = () =>
+      new DefaultConfigService(
+        configApiService,
+        environmentService,
+        logService,
+        stateProvider,
+        authService,
+      );
+
+    beforeEach(async () => {
+      await accountService.switchAccount(userId);
+      sut = buildService();
+    });
+
+    it("defaults to disabled when the app has never been opted in", async () => {
+      expect(await firstValueFrom(sut.betaMode$)).toBe(false);
+    });
+
+    it("setBetaMode toggles what betaMode$ emits", async () => {
+      await sut.setBetaMode(true);
+      expect(await firstValueFrom(sut.betaMode$)).toBe(true);
+
+      await sut.setBetaMode(false);
+      expect(await firstValueFrom(sut.betaMode$)).toBe(false);
+    });
+
+    it("delivers live updates so middleware and UI subscribers see toggle flips without re-subscribing", async () => {
+      const emissions: boolean[] = [];
+      const subscription = sut.betaMode$.subscribe((v) => emissions.push(v));
+
+      await sut.setBetaMode(true);
+      await sut.setBetaMode(false);
+      await sut.setBetaMode(true);
+      subscription.unsubscribe();
+
+      // Initial `false`, then each setBetaMode change; guards against a stale ReplaySubject or
+      // detached observable pipeline in a future refactor.
+      expect(emissions).toEqual([false, true, false, true]);
+    });
+
+    it("is not user-scoped: switching the active user does not change betaMode$", async () => {
+      // The design decision behind this is that Beta Mode targets the install/build, not the user.
+      await sut.setBetaMode(true);
+
+      await accountService.switchAccount(null);
+      expect(await firstValueFrom(sut.betaMode$)).toBe(true);
+
+      await accountService.switchAccount(userId);
+      expect(await firstValueFrom(sut.betaMode$)).toBe(true);
+    });
+
+    describe("cache invalidation on toggle", () => {
+      // A user who toggles beta mode expects flag values to update on the very next read — not
+      // to wait up to RETRIEVAL_INTERVAL (1 hour) for the natural refresh cycle. setBetaMode
+      // invalidates the cached config by backdating its utcDate so that the next serverConfig$
+      // subscription treats it as stale and refetches. Backdating (rather than clearing to null)
+      // keeps the current flag values available to consumers during the refresh window instead of
+      // briefly falling through to defaults.
+      beforeEach(() => {
+        // Seed a fresh cached config so we can observe the invalidation.
+        userState.nextState(serverConfigFactory("cached-hash"));
+      });
+
+      it("backdates the cached config so the pipeline's staleness check will force a refetch on the next read", async () => {
+        await sut.setBetaMode(true);
+
+        const cached = await firstValueFrom(userState.state$);
+        // olderThanRetrievalInterval treats utcDate < (now - RETRIEVAL_INTERVAL) as stale.
+        // new Date(0) (epoch) is definitively past that boundary.
+        expect(cached.utcDate.getTime()).toBe(0);
+      });
+
+      it("preserves the cached feature flag data during the refresh window (backdate, not clear)", async () => {
+        await sut.setBetaMode(true);
+
+        const cached = await firstValueFrom(userState.state$);
+        // Consumers reading getFeatureFlag$ during the refresh window see the original flag data
+        // — not defaults — because the data wasn't cleared, just marked stale.
+        expect(cached).not.toBeNull();
+        expect(cached.gitHash).toBe("cached-hash");
+      });
+
+      it("no-ops safely when there is no cached config to invalidate", async () => {
+        userState.nextState(null);
+
+        await expect(sut.setBetaMode(true)).resolves.not.toThrow();
+        expect(await firstValueFrom(sut.betaMode$)).toBe(true);
+      });
+    });
+  });
 });
 
 function apiUrl(count: number) {

--- a/libs/common/src/platform/services/config/default-config.service.ts
+++ b/libs/common/src/platform/services/config/default-config.service.ts
@@ -51,9 +51,13 @@ export const USER_SERVER_CONFIG = new UserKeyDefinition<ServerConfig>(CONFIG_DIS
   clearOn: ["logout"],
 });
 
-export const GLOBAL_BETA_MODE_ENABLED = new KeyDefinition<boolean>(CONFIG_DISK, "betaModeEnabled", {
-  deserializer: (v) => v ?? false,
-});
+export const GLOBAL_EARLY_ACCESS_ENABLED = new KeyDefinition<boolean>(
+  CONFIG_DISK,
+  "earlyAccessEnabled",
+  {
+    deserializer: (v) => v ?? false,
+  },
+);
 
 export const GLOBAL_SERVER_CONFIGURATIONS = KeyDefinition.record<ServerConfig, ApiUrl>(
   CONFIG_DISK,
@@ -86,7 +90,7 @@ export class DefaultConfigService implements ConfigService {
 
   cloudRegion$: Observable<Region>;
 
-  betaMode$: Observable<boolean>;
+  earlyAccess$: Observable<boolean>;
 
   private featureFlagOverrides$: Observable<Partial<
     Record<FeatureFlag, AllowedFeatureFlagTypes>
@@ -180,13 +184,13 @@ export class DefaultConfigService implements ConfigService {
 
     this.featureFlagOverrides$ = this.stateProvider.getGlobal(GLOBAL_FEATURE_FLAG_OVERRIDES).state$;
 
-    this.betaMode$ = this.stateProvider
-      .getGlobal(GLOBAL_BETA_MODE_ENABLED)
+    this.earlyAccess$ = this.stateProvider
+      .getGlobal(GLOBAL_EARLY_ACCESS_ENABLED)
       .state$.pipe(map((v) => v ?? false));
   }
 
-  async setBetaMode(enabled: boolean): Promise<void> {
-    await this.stateProvider.getGlobal(GLOBAL_BETA_MODE_ENABLED).update(() => enabled);
+  async setEarlyAccess(enabled: boolean): Promise<void> {
+    await this.stateProvider.getGlobal(GLOBAL_EARLY_ACCESS_ENABLED).update(() => enabled);
     await this.invalidateConfig();
   }
 

--- a/libs/common/src/platform/services/config/default-config.service.ts
+++ b/libs/common/src/platform/services/config/default-config.service.ts
@@ -51,11 +51,13 @@ export const USER_SERVER_CONFIG = new UserKeyDefinition<ServerConfig>(CONFIG_DIS
   clearOn: ["logout"],
 });
 
-export const GLOBAL_EARLY_ACCESS_ENABLED = new KeyDefinition<boolean>(
+export const USER_EARLY_ACCESS_ENABLED = new UserKeyDefinition<boolean>(
   CONFIG_DISK,
   "earlyAccessEnabled",
   {
     deserializer: (v) => v ?? false,
+    // Persist across logout so a user who re-authenticates keeps their preference.
+    clearOn: [],
   },
 );
 
@@ -89,8 +91,6 @@ export class DefaultConfigService implements ConfigService {
   serverSettings$: Observable<ServerSettings>;
 
   cloudRegion$: Observable<Region>;
-
-  earlyAccess$: Observable<boolean>;
 
   private featureFlagOverrides$: Observable<Partial<
     Record<FeatureFlag, AllowedFeatureFlagTypes>
@@ -183,28 +183,26 @@ export class DefaultConfigService implements ConfigService {
     );
 
     this.featureFlagOverrides$ = this.stateProvider.getGlobal(GLOBAL_FEATURE_FLAG_OVERRIDES).state$;
+  }
 
-    this.earlyAccess$ = this.stateProvider
-      .getGlobal(GLOBAL_EARLY_ACCESS_ENABLED)
+  earlyAccess$(userId: UserId): Observable<boolean> {
+    return this.stateProvider
+      .getUser(userId, USER_EARLY_ACCESS_ENABLED)
       .state$.pipe(map((v) => v ?? false));
   }
 
-  async setEarlyAccess(enabled: boolean): Promise<void> {
-    await this.stateProvider.getGlobal(GLOBAL_EARLY_ACCESS_ENABLED).update(() => enabled);
-    await this.invalidateConfig();
+  async setEarlyAccess(userId: UserId, enabled: boolean): Promise<void> {
+    await this.stateProvider.setUserState(USER_EARLY_ACCESS_ENABLED, enabled, userId);
+    await this.invalidateConfig(userId);
   }
 
   /**
-   * Invalidates the cached server config so the next `serverConfig$` read is forced to refetch —
-   * instead of waiting up to `RETRIEVAL_INTERVAL` (1 hour) for the natural refresh cycle.
-   * Backdates the cached config's `utcDate` rather than clearing to null so consumers keep
-   * seeing the current flag values while the refresh is in flight.
+   * Invalidates the cached server config for the given user so the next `serverConfig$` read is
+   * forced to refetch — instead of waiting up to `RETRIEVAL_INTERVAL` (1 hour) for the natural
+   * refresh cycle. Backdates the cached config's `utcDate` rather than clearing to null so
+   * consumers keep seeing the current flag values while the refresh is in flight.
    */
-  private async invalidateConfig(): Promise<void> {
-    const userId = await firstValueFrom(this.stateProvider.activeUserId$);
-    if (userId == null) {
-      return;
-    }
+  private async invalidateConfig(userId: UserId): Promise<void> {
     const existing = await firstValueFrom(this.userConfigFor$(userId));
     if (existing == null) {
       return;

--- a/libs/common/src/platform/services/config/default-config.service.ts
+++ b/libs/common/src/platform/services/config/default-config.service.ts
@@ -186,9 +186,10 @@ export class DefaultConfigService implements ConfigService {
   }
 
   earlyAccess$(userId: UserId): Observable<boolean> {
-    return this.stateProvider
-      .getUser(userId, USER_EARLY_ACCESS_ENABLED)
-      .state$.pipe(map((v) => v ?? false));
+    return combineLatest([
+      this.userCachedFeatureFlag$(FeatureFlag.EarlyAccess, userId),
+      this.stateProvider.getUser(userId, USER_EARLY_ACCESS_ENABLED).state$,
+    ]).pipe(map(([flagEnabled, stored]) => flagEnabled === true && (stored ?? false)));
   }
 
   async setEarlyAccess(userId: UserId, enabled: boolean): Promise<void> {

--- a/libs/common/src/platform/services/config/default-config.service.ts
+++ b/libs/common/src/platform/services/config/default-config.service.ts
@@ -51,16 +51,6 @@ export const USER_SERVER_CONFIG = new UserKeyDefinition<ServerConfig>(CONFIG_DIS
   clearOn: ["logout"],
 });
 
-export const USER_EARLY_ACCESS_ENABLED = new UserKeyDefinition<boolean>(
-  CONFIG_DISK,
-  "earlyAccessEnabled",
-  {
-    deserializer: (v) => v ?? false,
-    // Persist across logout so a user who re-authenticates keeps their preference.
-    clearOn: [],
-  },
-);
-
 export const GLOBAL_SERVER_CONFIGURATIONS = KeyDefinition.record<ServerConfig, ApiUrl>(
   CONFIG_DISK,
   "byServer",
@@ -185,31 +175,21 @@ export class DefaultConfigService implements ConfigService {
     this.featureFlagOverrides$ = this.stateProvider.getGlobal(GLOBAL_FEATURE_FLAG_OVERRIDES).state$;
   }
 
-  earlyAccess$(userId: UserId): Observable<boolean> {
-    return combineLatest([
-      this.userCachedFeatureFlag$(FeatureFlag.EarlyAccess, userId),
-      this.stateProvider.getUser(userId, USER_EARLY_ACCESS_ENABLED).state$,
-    ]).pipe(map(([flagEnabled, stored]) => flagEnabled === true && (stored ?? false)));
-  }
-
-  async setEarlyAccess(userId: UserId, enabled: boolean): Promise<void> {
-    await this.stateProvider.setUserState(USER_EARLY_ACCESS_ENABLED, enabled, userId);
-    await this.invalidateConfig(userId);
-  }
-
-  /**
-   * Invalidates the cached server config for the given user so the next `serverConfig$` read is
-   * forced to refetch — instead of waiting up to `RETRIEVAL_INTERVAL` (1 hour) for the natural
-   * refresh cycle. Backdates the cached config's `utcDate` rather than clearing to null so
-   * consumers keep seeing the current flag values while the refresh is in flight.
-   */
-  private async invalidateConfig(userId: UserId): Promise<void> {
-    const existing = await firstValueFrom(this.userConfigFor$(userId));
-    if (existing == null) {
-      return;
-    }
-    existing.utcDate = new Date(0);
-    await this.stateProvider.setUserState(USER_SERVER_CONFIG, existing, userId);
+  async invalidateUserConfig(userId: UserId): Promise<void> {
+    // Atomic, non-mutating update: cloning through the update callback avoids read-modify-write
+    // races with `renewConfig`, and the fresh instance keeps any live subscribers from observing
+    // a mid-mutation `utcDate`.
+    await this.stateProvider.getUser(userId, USER_SERVER_CONFIG).update((existing) => {
+      if (existing == null) {
+        return existing;
+      }
+      const invalidated: ServerConfig = Object.assign(
+        Object.create(ServerConfig.prototype),
+        existing,
+      );
+      invalidated.utcDate = new Date(0);
+      return invalidated;
+    });
   }
 
   getFeatureFlag$<Flag extends FeatureFlag>(key: Flag) {

--- a/libs/common/src/platform/services/config/default-config.service.ts
+++ b/libs/common/src/platform/services/config/default-config.service.ts
@@ -51,6 +51,10 @@ export const USER_SERVER_CONFIG = new UserKeyDefinition<ServerConfig>(CONFIG_DIS
   clearOn: ["logout"],
 });
 
+export const GLOBAL_BETA_MODE_ENABLED = new KeyDefinition<boolean>(CONFIG_DISK, "betaModeEnabled", {
+  deserializer: (v) => v ?? false,
+});
+
 export const GLOBAL_SERVER_CONFIGURATIONS = KeyDefinition.record<ServerConfig, ApiUrl>(
   CONFIG_DISK,
   "byServer",
@@ -81,6 +85,8 @@ export class DefaultConfigService implements ConfigService {
   serverSettings$: Observable<ServerSettings>;
 
   cloudRegion$: Observable<Region>;
+
+  betaMode$: Observable<boolean>;
 
   private featureFlagOverrides$: Observable<Partial<
     Record<FeatureFlag, AllowedFeatureFlagTypes>
@@ -173,6 +179,34 @@ export class DefaultConfigService implements ConfigService {
     );
 
     this.featureFlagOverrides$ = this.stateProvider.getGlobal(GLOBAL_FEATURE_FLAG_OVERRIDES).state$;
+
+    this.betaMode$ = this.stateProvider
+      .getGlobal(GLOBAL_BETA_MODE_ENABLED)
+      .state$.pipe(map((v) => v ?? false));
+  }
+
+  async setBetaMode(enabled: boolean): Promise<void> {
+    await this.stateProvider.getGlobal(GLOBAL_BETA_MODE_ENABLED).update(() => enabled);
+    await this.invalidateConfig();
+  }
+
+  /**
+   * Invalidates the cached server config so the next `serverConfig$` read is forced to refetch —
+   * instead of waiting up to `RETRIEVAL_INTERVAL` (1 hour) for the natural refresh cycle.
+   * Backdates the cached config's `utcDate` rather than clearing to null so consumers keep
+   * seeing the current flag values while the refresh is in flight.
+   */
+  private async invalidateConfig(): Promise<void> {
+    const userId = await firstValueFrom(this.stateProvider.activeUserId$);
+    if (userId == null) {
+      return;
+    }
+    const existing = await firstValueFrom(this.userConfigFor$(userId));
+    if (existing == null) {
+      return;
+    }
+    existing.utcDate = new Date(0);
+    await this.stateProvider.setUserState(USER_SERVER_CONFIG, existing, userId);
   }
 
   getFeatureFlag$<Flag extends FeatureFlag>(key: Flag) {

--- a/libs/common/src/platform/services/config/prerelease-header.middleware.spec.ts
+++ b/libs/common/src/platform/services/config/prerelease-header.middleware.spec.ts
@@ -1,0 +1,55 @@
+import { mock } from "jest-mock-extended";
+import { of } from "rxjs";
+
+import { ConfigService } from "../../abstractions/config/config.service";
+import { FetchFn } from "../../misc/fetch-middleware";
+
+import { prereleaseHeaderMiddleware } from "./prerelease-header.middleware";
+
+describe("prereleaseHeaderMiddleware", () => {
+  let configService: ReturnType<typeof mock<ConfigService>>;
+  let next: jest.Mock<Promise<Response>, [Request]>;
+  let response: Response;
+
+  beforeEach(() => {
+    configService = mock<ConfigService>();
+    response = { ok: true, status: 200 } as unknown as Response;
+    next = jest.fn<Promise<Response>, [Request]>().mockResolvedValue(response);
+  });
+
+  function makeRequest(): Request {
+    return { headers: new Headers() } as unknown as Request;
+  }
+
+  it("sets Is-Prerelease header when beta mode is enabled", async () => {
+    configService.betaMode$ = of(true);
+    const middleware = prereleaseHeaderMiddleware(configService);
+    const request = makeRequest();
+
+    await middleware(request, next as FetchFn);
+
+    expect(request.headers.get("Is-Prerelease")).toBe("1");
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith(request);
+  });
+
+  it("does not set the header when beta mode is disabled", async () => {
+    configService.betaMode$ = of(false);
+    const middleware = prereleaseHeaderMiddleware(configService);
+    const request = makeRequest();
+
+    await middleware(request, next as FetchFn);
+
+    expect(request.headers.has("Is-Prerelease")).toBe(false);
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns the response produced by next", async () => {
+    configService.betaMode$ = of(true);
+    const middleware = prereleaseHeaderMiddleware(configService);
+
+    const result = await middleware(makeRequest(), next as FetchFn);
+
+    expect(result).toBe(response);
+  });
+});

--- a/libs/common/src/platform/services/config/prerelease-header.middleware.spec.ts
+++ b/libs/common/src/platform/services/config/prerelease-header.middleware.spec.ts
@@ -1,18 +1,24 @@
 import { mock } from "jest-mock-extended";
 import { of } from "rxjs";
 
+import { AccountService } from "../../../auth/abstractions/account.service";
+import { UserId } from "../../../types/guid";
 import { ConfigService } from "../../abstractions/config/config.service";
 import { FetchFn } from "../../misc/fetch-middleware";
 
 import { prereleaseHeaderMiddleware } from "./prerelease-header.middleware";
 
 describe("prereleaseHeaderMiddleware", () => {
+  const userId = "user-1" as UserId;
   let configService: ReturnType<typeof mock<ConfigService>>;
+  let accountService: ReturnType<typeof mock<AccountService>>;
   let next: jest.Mock<Promise<Response>, [Request]>;
   let response: Response;
 
   beforeEach(() => {
     configService = mock<ConfigService>();
+    accountService = mock<AccountService>();
+    accountService.activeAccount$ = of({ id: userId } as any);
     response = { ok: true, status: 200 } as unknown as Response;
     next = jest.fn<Promise<Response>, [Request]>().mockResolvedValue(response);
   });
@@ -21,21 +27,22 @@ describe("prereleaseHeaderMiddleware", () => {
     return { headers: new Headers() } as unknown as Request;
   }
 
-  it("sets Is-Prerelease header when early access is enabled", async () => {
-    configService.earlyAccess$ = of(true);
-    const middleware = prereleaseHeaderMiddleware(configService);
+  it("sets Is-Prerelease header when early access is enabled for the active user", async () => {
+    configService.earlyAccess$.mockReturnValue(of(true));
+    const middleware = prereleaseHeaderMiddleware(configService, accountService);
     const request = makeRequest();
 
     await middleware(request, next as FetchFn);
 
+    expect(configService.earlyAccess$).toHaveBeenCalledWith(userId);
     expect(request.headers.get("Is-Prerelease")).toBe("1");
     expect(next).toHaveBeenCalledTimes(1);
     expect(next).toHaveBeenCalledWith(request);
   });
 
-  it("does not set the header when early access is disabled", async () => {
-    configService.earlyAccess$ = of(false);
-    const middleware = prereleaseHeaderMiddleware(configService);
+  it("does not set the header when early access is disabled for the active user", async () => {
+    configService.earlyAccess$.mockReturnValue(of(false));
+    const middleware = prereleaseHeaderMiddleware(configService, accountService);
     const request = makeRequest();
 
     await middleware(request, next as FetchFn);
@@ -44,9 +51,19 @@ describe("prereleaseHeaderMiddleware", () => {
     expect(next).toHaveBeenCalledTimes(1);
   });
 
+  it("skips the check when there is no active user", async () => {
+    accountService.activeAccount$ = of(null);
+    const middleware = prereleaseHeaderMiddleware(configService, accountService);
+
+    await middleware(makeRequest(), next as FetchFn);
+
+    expect(configService.earlyAccess$).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
   it("returns the response produced by next", async () => {
-    configService.earlyAccess$ = of(true);
-    const middleware = prereleaseHeaderMiddleware(configService);
+    configService.earlyAccess$.mockReturnValue(of(true));
+    const middleware = prereleaseHeaderMiddleware(configService, accountService);
 
     const result = await middleware(makeRequest(), next as FetchFn);
 

--- a/libs/common/src/platform/services/config/prerelease-header.middleware.spec.ts
+++ b/libs/common/src/platform/services/config/prerelease-header.middleware.spec.ts
@@ -21,8 +21,8 @@ describe("prereleaseHeaderMiddleware", () => {
     return { headers: new Headers() } as unknown as Request;
   }
 
-  it("sets Is-Prerelease header when beta mode is enabled", async () => {
-    configService.betaMode$ = of(true);
+  it("sets Is-Prerelease header when early access is enabled", async () => {
+    configService.earlyAccess$ = of(true);
     const middleware = prereleaseHeaderMiddleware(configService);
     const request = makeRequest();
 
@@ -33,8 +33,8 @@ describe("prereleaseHeaderMiddleware", () => {
     expect(next).toHaveBeenCalledWith(request);
   });
 
-  it("does not set the header when beta mode is disabled", async () => {
-    configService.betaMode$ = of(false);
+  it("does not set the header when early access is disabled", async () => {
+    configService.earlyAccess$ = of(false);
     const middleware = prereleaseHeaderMiddleware(configService);
     const request = makeRequest();
 
@@ -45,7 +45,7 @@ describe("prereleaseHeaderMiddleware", () => {
   });
 
   it("returns the response produced by next", async () => {
-    configService.betaMode$ = of(true);
+    configService.earlyAccess$ = of(true);
     const middleware = prereleaseHeaderMiddleware(configService);
 
     const result = await middleware(makeRequest(), next as FetchFn);

--- a/libs/common/src/platform/services/config/prerelease-header.middleware.spec.ts
+++ b/libs/common/src/platform/services/config/prerelease-header.middleware.spec.ts
@@ -3,20 +3,20 @@ import { of } from "rxjs";
 
 import { AccountService } from "../../../auth/abstractions/account.service";
 import { UserId } from "../../../types/guid";
-import { ConfigService } from "../../abstractions/config/config.service";
 import { FetchFn } from "../../misc/fetch-middleware";
+import { EarlyAccessService } from "../early-access/early-access.service";
 
 import { prereleaseHeaderMiddleware } from "./prerelease-header.middleware";
 
 describe("prereleaseHeaderMiddleware", () => {
   const userId = "user-1" as UserId;
-  let configService: ReturnType<typeof mock<ConfigService>>;
+  let earlyAccessService: ReturnType<typeof mock<EarlyAccessService>>;
   let accountService: ReturnType<typeof mock<AccountService>>;
   let next: jest.Mock<Promise<Response>, [Request]>;
   let response: Response;
 
   beforeEach(() => {
-    configService = mock<ConfigService>();
+    earlyAccessService = mock<EarlyAccessService>();
     accountService = mock<AccountService>();
     accountService.activeAccount$ = of({ id: userId } as any);
     response = { ok: true, status: 200 } as unknown as Response;
@@ -28,21 +28,21 @@ describe("prereleaseHeaderMiddleware", () => {
   }
 
   it("sets Is-Prerelease header when early access is enabled for the active user", async () => {
-    configService.earlyAccess$.mockReturnValue(of(true));
-    const middleware = prereleaseHeaderMiddleware(configService, accountService);
+    earlyAccessService.earlyAccess$.mockReturnValue(of(true));
+    const middleware = prereleaseHeaderMiddleware(earlyAccessService, accountService);
     const request = makeRequest();
 
     await middleware(request, next as FetchFn);
 
-    expect(configService.earlyAccess$).toHaveBeenCalledWith(userId);
+    expect(earlyAccessService.earlyAccess$).toHaveBeenCalledWith(userId);
     expect(request.headers.get("Is-Prerelease")).toBe("1");
     expect(next).toHaveBeenCalledTimes(1);
     expect(next).toHaveBeenCalledWith(request);
   });
 
   it("does not set the header when early access is disabled for the active user", async () => {
-    configService.earlyAccess$.mockReturnValue(of(false));
-    const middleware = prereleaseHeaderMiddleware(configService, accountService);
+    earlyAccessService.earlyAccess$.mockReturnValue(of(false));
+    const middleware = prereleaseHeaderMiddleware(earlyAccessService, accountService);
     const request = makeRequest();
 
     await middleware(request, next as FetchFn);
@@ -53,17 +53,17 @@ describe("prereleaseHeaderMiddleware", () => {
 
   it("skips the check when there is no active user", async () => {
     accountService.activeAccount$ = of(null);
-    const middleware = prereleaseHeaderMiddleware(configService, accountService);
+    const middleware = prereleaseHeaderMiddleware(earlyAccessService, accountService);
 
     await middleware(makeRequest(), next as FetchFn);
 
-    expect(configService.earlyAccess$).not.toHaveBeenCalled();
+    expect(earlyAccessService.earlyAccess$).not.toHaveBeenCalled();
     expect(next).toHaveBeenCalledTimes(1);
   });
 
   it("returns the response produced by next", async () => {
-    configService.earlyAccess$.mockReturnValue(of(true));
-    const middleware = prereleaseHeaderMiddleware(configService, accountService);
+    earlyAccessService.earlyAccess$.mockReturnValue(of(true));
+    const middleware = prereleaseHeaderMiddleware(earlyAccessService, accountService);
 
     const result = await middleware(makeRequest(), next as FetchFn);
 

--- a/libs/common/src/platform/services/config/prerelease-header.middleware.ts
+++ b/libs/common/src/platform/services/config/prerelease-header.middleware.ts
@@ -5,7 +5,7 @@ import { FetchFn, FetchMiddleware } from "../../misc/fetch-middleware";
 
 export function prereleaseHeaderMiddleware(configService: ConfigService): FetchMiddleware {
   return async (request: Request, next: FetchFn): Promise<Response> => {
-    const enabled = await firstValueFrom(configService.betaMode$);
+    const enabled = await firstValueFrom(configService.earlyAccess$);
     if (enabled) {
       request.headers.set("Is-Prerelease", "1");
     }

--- a/libs/common/src/platform/services/config/prerelease-header.middleware.ts
+++ b/libs/common/src/platform/services/config/prerelease-header.middleware.ts
@@ -1,0 +1,14 @@
+import { firstValueFrom } from "rxjs";
+
+import { ConfigService } from "../../abstractions/config/config.service";
+import { FetchFn, FetchMiddleware } from "../../misc/fetch-middleware";
+
+export function prereleaseHeaderMiddleware(configService: ConfigService): FetchMiddleware {
+  return async (request: Request, next: FetchFn): Promise<Response> => {
+    const enabled = await firstValueFrom(configService.betaMode$);
+    if (enabled) {
+      request.headers.set("Is-Prerelease", "1");
+    }
+    return next(request);
+  };
+}

--- a/libs/common/src/platform/services/config/prerelease-header.middleware.ts
+++ b/libs/common/src/platform/services/config/prerelease-header.middleware.ts
@@ -1,11 +1,11 @@
 import { firstValueFrom } from "rxjs";
 
 import { AccountService } from "../../../auth/abstractions/account.service";
-import { ConfigService } from "../../abstractions/config/config.service";
 import { FetchFn, FetchMiddleware } from "../../misc/fetch-middleware";
+import { EarlyAccessService } from "../early-access/early-access.service";
 
 export function prereleaseHeaderMiddleware(
-  configService: ConfigService,
+  earlyAccessService: EarlyAccessService,
   accountService: AccountService,
 ): FetchMiddleware {
   return async (request: Request, next: FetchFn): Promise<Response> => {
@@ -13,7 +13,7 @@ export function prereleaseHeaderMiddleware(
     if (activeAccount == null) {
       return next(request);
     }
-    const enabled = await firstValueFrom(configService.earlyAccess$(activeAccount.id));
+    const enabled = await firstValueFrom(earlyAccessService.earlyAccess$(activeAccount.id));
     if (enabled) {
       request.headers.set("Is-Prerelease", "1");
     }

--- a/libs/common/src/platform/services/config/prerelease-header.middleware.ts
+++ b/libs/common/src/platform/services/config/prerelease-header.middleware.ts
@@ -1,11 +1,19 @@
 import { firstValueFrom } from "rxjs";
 
+import { AccountService } from "../../../auth/abstractions/account.service";
 import { ConfigService } from "../../abstractions/config/config.service";
 import { FetchFn, FetchMiddleware } from "../../misc/fetch-middleware";
 
-export function prereleaseHeaderMiddleware(configService: ConfigService): FetchMiddleware {
+export function prereleaseHeaderMiddleware(
+  configService: ConfigService,
+  accountService: AccountService,
+): FetchMiddleware {
   return async (request: Request, next: FetchFn): Promise<Response> => {
-    const enabled = await firstValueFrom(configService.earlyAccess$);
+    const activeAccount = await firstValueFrom(accountService.activeAccount$);
+    if (activeAccount == null) {
+      return next(request);
+    }
+    const enabled = await firstValueFrom(configService.earlyAccess$(activeAccount.id));
     if (enabled) {
       request.headers.set("Is-Prerelease", "1");
     }

--- a/libs/common/src/platform/services/early-access/default-early-access.service.spec.ts
+++ b/libs/common/src/platform/services/early-access/default-early-access.service.spec.ts
@@ -1,0 +1,108 @@
+import { mock } from "jest-mock-extended";
+import { BehaviorSubject, firstValueFrom, of } from "rxjs";
+
+import { FakeStateProvider, mockAccountServiceWith } from "../../../../spec";
+import { FeatureFlag } from "../../../enums/feature-flag.enum";
+import { UserId } from "../../../types/guid";
+import { ConfigService } from "../../abstractions/config/config.service";
+
+import {
+  DefaultEarlyAccessService,
+  USER_EARLY_ACCESS_ENABLED,
+} from "./default-early-access.service";
+
+describe("DefaultEarlyAccessService", () => {
+  const userId = "userId" as UserId;
+  const accountService = mockAccountServiceWith(userId);
+  let stateProvider: FakeStateProvider;
+  let configService: ReturnType<typeof mock<ConfigService>>;
+  let flagValue$: BehaviorSubject<boolean>;
+  let sut: DefaultEarlyAccessService;
+
+  beforeEach(async () => {
+    stateProvider = new FakeStateProvider(accountService);
+    configService = mock<ConfigService>();
+    flagValue$ = new BehaviorSubject<boolean>(true);
+    configService.userCachedFeatureFlag$.mockReturnValue(flagValue$);
+    configService.invalidateUserConfig.mockResolvedValue(undefined);
+
+    await accountService.switchAccount(userId);
+    sut = new DefaultEarlyAccessService(stateProvider, configService);
+  });
+
+  it("defaults to disabled when the app has never been opted in", async () => {
+    expect(await firstValueFrom(sut.earlyAccess$(userId))).toBe(false);
+  });
+
+  it("returns false when the EarlyAccess feature flag is disabled, even if state has been opted in", async () => {
+    await stateProvider.setUserState(USER_EARLY_ACCESS_ENABLED, true, userId);
+    flagValue$.next(false);
+
+    expect(await firstValueFrom(sut.earlyAccess$(userId))).toBe(false);
+  });
+
+  it("gates on the EarlyAccess feature flag for the specific userId", async () => {
+    await sut.setEarlyAccess(userId, true);
+    await firstValueFrom(sut.earlyAccess$(userId));
+
+    expect(configService.userCachedFeatureFlag$).toHaveBeenCalledWith(
+      FeatureFlag.EarlyAccess,
+      userId,
+    );
+  });
+
+  it("setEarlyAccess toggles what earlyAccess$ emits when the flag is on", async () => {
+    await sut.setEarlyAccess(userId, true);
+    expect(await firstValueFrom(sut.earlyAccess$(userId))).toBe(true);
+
+    await sut.setEarlyAccess(userId, false);
+    expect(await firstValueFrom(sut.earlyAccess$(userId))).toBe(false);
+  });
+
+  it("delivers live updates to subscribers without re-subscribing", async () => {
+    const emissions: boolean[] = [];
+    const subscription = sut.earlyAccess$(userId).subscribe((v) => emissions.push(v));
+
+    await sut.setEarlyAccess(userId, true);
+    await sut.setEarlyAccess(userId, false);
+    await sut.setEarlyAccess(userId, true);
+    subscription.unsubscribe();
+
+    expect(emissions).toEqual([false, true, false, true]);
+  });
+
+  it("is user-scoped: each user's preference is independent", async () => {
+    const otherUserId = "other-user" as UserId;
+
+    await sut.setEarlyAccess(userId, true);
+    await sut.setEarlyAccess(otherUserId, false);
+
+    expect(await firstValueFrom(sut.earlyAccess$(userId))).toBe(true);
+    expect(await firstValueFrom(sut.earlyAccess$(otherUserId))).toBe(false);
+  });
+
+  it("persists across logout — clearOn is [] so re-authenticating keeps the preference", async () => {
+    // A fresh service instance (as if the app relaunched) reads the same persisted value.
+    await sut.setEarlyAccess(userId, true);
+
+    const nextLaunch = new DefaultEarlyAccessService(stateProvider, configService);
+    expect(await firstValueFrom(nextLaunch.earlyAccess$(userId))).toBe(true);
+  });
+
+  it("invalidates the user's cached server config so flag values refresh on the next read", async () => {
+    await sut.setEarlyAccess(userId, true);
+
+    expect(configService.invalidateUserConfig).toHaveBeenCalledWith(userId);
+  });
+
+  it("does not consult ConfigService for a null feature-flag stream", async () => {
+    // Guard against a regression where a caller passes null-tolerating patterns and the pipeline
+    // silently emits `true` because null was coerced. earlyAccess$ must resolve to a strict
+    // boolean AND — anything non-true from the flag side yields false.
+    configService.userCachedFeatureFlag$.mockReturnValue(of(null as unknown as boolean));
+    await stateProvider.setUserState(USER_EARLY_ACCESS_ENABLED, true, userId);
+
+    const fresh = new DefaultEarlyAccessService(stateProvider, configService);
+    expect(await firstValueFrom(fresh.earlyAccess$(userId))).toBe(false);
+  });
+});

--- a/libs/common/src/platform/services/early-access/default-early-access.service.ts
+++ b/libs/common/src/platform/services/early-access/default-early-access.service.ts
@@ -1,0 +1,37 @@
+import { Observable, combineLatest, map } from "rxjs";
+
+import { FeatureFlag } from "../../../enums/feature-flag.enum";
+import { UserId } from "../../../types/guid";
+import { ConfigService } from "../../abstractions/config/config.service";
+import { CONFIG_DISK, StateProvider, UserKeyDefinition } from "../../state";
+
+import { EarlyAccessService } from "./early-access.service";
+
+export const USER_EARLY_ACCESS_ENABLED = new UserKeyDefinition<boolean>(
+  CONFIG_DISK,
+  "earlyAccessEnabled",
+  {
+    deserializer: (v) => v ?? false,
+    // Persist across logout so a user who re-authenticates keeps their preference.
+    clearOn: [],
+  },
+);
+
+export class DefaultEarlyAccessService implements EarlyAccessService {
+  constructor(
+    private stateProvider: StateProvider,
+    private configService: ConfigService,
+  ) {}
+
+  earlyAccess$(userId: UserId): Observable<boolean> {
+    return combineLatest([
+      this.configService.userCachedFeatureFlag$(FeatureFlag.EarlyAccess, userId),
+      this.stateProvider.getUser(userId, USER_EARLY_ACCESS_ENABLED).state$,
+    ]).pipe(map(([flagEnabled, stored]) => flagEnabled === true && (stored ?? false)));
+  }
+
+  async setEarlyAccess(userId: UserId, enabled: boolean): Promise<void> {
+    await this.stateProvider.setUserState(USER_EARLY_ACCESS_ENABLED, enabled, userId);
+    await this.configService.invalidateUserConfig(userId);
+  }
+}

--- a/libs/common/src/platform/services/early-access/early-access.service.ts
+++ b/libs/common/src/platform/services/early-access/early-access.service.ts
@@ -1,0 +1,23 @@
+import { Observable } from "rxjs";
+
+import { UserId } from "../../../types/guid";
+
+export abstract class EarlyAccessService {
+  /**
+   * Per-user Early Access preference. Gates on the `EarlyAccess` feature flag so this returns
+   * false whenever the flag is disabled server-side, regardless of what is stored — the user's
+   * opt-in is only honored while the feature flag is on.
+   *
+   * When enabled, the client sends the `Is-Prerelease` header on API requests for this user so
+   * that feature flags evaluate with prerelease context. The stored preference persists across
+   * logout for the account.
+   */
+  abstract earlyAccess$(userId: UserId): Observable<boolean>;
+
+  /**
+   * Sets the Early Access preference for the given user. Takes effect on subsequent API
+   * requests; the user's cached server config is invalidated immediately so feature flags
+   * re-evaluate on the next read rather than waiting for the natural refresh interval.
+   */
+  abstract setEarlyAccess(userId: UserId, enabled: boolean): Promise<void>;
+}


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-39893

## 📔 Objective

Adds an option in the desktop, extension, and web clients to allow "early access" to features not yet ready for production release, by setting the `Is-Prerelease` header on requests if the user chooses to do so.

This header is passed up on:
1. Authenticated `/api/config` requests, which is important for client-flagged changes
2. All authenticated API requests, which is important if any Early Access features are flagged server-side.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
