### PR TITLE
[PM-39992] Add support for SDK IPC unreachability

### DIFF
--- a/apps/browser/src/platform/ipc/ipc-background.service.ts
+++ b/apps/browser/src/platform/ipc/ipc-background.service.ts
@@ -18,6 +18,8 @@ import {
 
 import { BrowserApi } from "../browser/browser-api";
 
+import { WebIpcTransport } from "./transports";
+
 // The interval at which the browser extension in the background tries to reconnect to the desktop app.
 const RECONNECTION_INTERVAL_MS = 10_000;
 // The timeout for the discover message sent to the desktop app when trying to connect. If the desktop app does not respond to the discover message within this time, the connection attempt is considered failed and will be retried after the reconnection interval.
@@ -27,6 +29,7 @@ export class IpcBackgroundService extends IpcService {
   private communicationBackend?: IpcCommunicationBackend;
   private nativeMessagingPort?: browser.runtime.Port | chrome.runtime.Port;
   private reconnectTimer?: ReturnType<typeof setTimeout>;
+  private webTransport?: WebIpcTransport;
 
   constructor(
     private platformUtilsService: PlatformUtilsService,
@@ -39,43 +42,17 @@ export class IpcBackgroundService extends IpcService {
     try {
       // This function uses classes and functions defined in the SDK, so we need to wait for the SDK to load.
       await SdkLoadService.Ready;
+
+      const receive = (message: IncomingMessage) => this.communicationBackend?.receive(message);
+
       this.communicationBackend = new IpcCommunicationBackend({
         send: async (message: OutgoingMessage): Promise<void> => {
-          if (typeof message.destination === "object" && "Web" in message.destination) {
-            // Verify the document hasn't changed (e.g., user navigated away) before delivering.
-            // If the browser doesn't support documentId on getFrame, skip the check and send anyway.
-            try {
-              const frame = await chrome.webNavigation.getFrame({
-                tabId: message.destination.Web.tab_id,
-                frameId: 0,
-              });
-              if (
-                frame?.documentId != null &&
-                frame.documentId !== message.destination.Web.document_id
-              ) {
-                this.logService.warning("[IPC] Dropping message to Web tab: document has changed");
-                return;
-              }
-            } catch {
-              // Tab may have been closed, or API not available. Drop the message.
-              this.logService.warning(
-                "[IPC] Dropping message to Web tab: tab no longer accessible",
-              );
-              return;
-            }
-
-            await BrowserApi.tabSendMessage(
-              { id: message.destination.Web.tab_id } as chrome.tabs.Tab,
-              {
-                type: "bitwarden-ipc-message",
-                message: {
-                  destination: message.destination,
-                  payload: [...message.payload],
-                  topic: message.topic,
-                },
-              } satisfies IpcMessage,
-              { frameId: 0 },
-            );
+          if (
+            typeof message.destination === "object" &&
+            "Web" in message.destination &&
+            this.webTransport != null
+          ) {
+            await this.webTransport!.send(message);
             return;
           }
 
@@ -99,42 +76,10 @@ export class IpcBackgroundService extends IpcService {
         },
       });
 
-      BrowserApi.messageListener("platform.ipc", (message, sender) => {
-        if (
-          !isIpcMessage(message) ||
-          typeof message.message.destination !== "object" ||
-          !("BrowserBackground" in message.message.destination)
-        ) {
-          return;
-        }
-
-        if (sender.tab?.id === undefined || sender.tab.id === chrome.tabs.TAB_ID_NONE) {
-          // Ignore messages from non-tab sources
-          return;
-        }
-
-        if (sender.documentId === undefined) {
-          this.logService.warning(
-            "[IPC] Received message from tab without documentId (unsupported browser version)",
-          );
-          return;
-        }
-
-        this.communicationBackend?.receive(
-          new IncomingMessage(
-            new Uint8Array(message.message.payload),
-            message.message.destination,
-            {
-              Web: {
-                tab_id: sender.tab.id,
-                document_id: sender.documentId,
-                origin: sender.origin ?? "",
-              },
-            },
-            message.message.topic,
-          ),
-        );
-      });
+      if (!this.platformUtilsService.isFirefox()) {
+        this.webTransport = new WebIpcTransport(this.logService, receive);
+        this.webTransport.init();
+      }
 
       await super.initWithClient(IpcClient.newWithSdkInMemorySessions(this.communicationBackend));
 

--- a/apps/browser/src/platform/ipc/ipc-background.service.ts
+++ b/apps/browser/src/platform/ipc/ipc-background.service.ts
@@ -1,35 +1,21 @@
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { SdkLoadService } from "@bitwarden/common/platform/abstractions/sdk/sdk-load.service";
-import {
-  IpcMessage,
-  isIpcMessage,
-  IpcService,
-  isForwardedIpcMessage,
-} from "@bitwarden/common/platform/ipc";
+import { IpcService } from "@bitwarden/common/platform/ipc";
 import {
   IpcCommunicationBackend,
   IncomingMessage,
   OutgoingMessage,
   ipcRegisterDiscoverHandler,
   IpcClient,
-  ipcRequestDiscover,
 } from "@bitwarden/sdk-internal";
 
-import { BrowserApi } from "../browser/browser-api";
-
-import { WebIpcTransport } from "./transports";
-
-// The interval at which the browser extension in the background tries to reconnect to the desktop app.
-const RECONNECTION_INTERVAL_MS = 10_000;
-// The timeout for the discover message sent to the desktop app when trying to connect. If the desktop app does not respond to the discover message within this time, the connection attempt is considered failed and will be retried after the reconnection interval.
-const DISCOVER_MESSAGE_TIMEOUT_MS = 5_000;
+import { DesktopIpcTransport, WebIpcTransport } from "./transports";
 
 export class IpcBackgroundService extends IpcService {
   private communicationBackend?: IpcCommunicationBackend;
-  private nativeMessagingPort?: browser.runtime.Port | chrome.runtime.Port;
-  private reconnectTimer?: ReturnType<typeof setTimeout>;
   private webTransport?: WebIpcTransport;
+  private desktopTransport?: DesktopIpcTransport;
 
   constructor(
     private platformUtilsService: PlatformUtilsService,
@@ -56,19 +42,11 @@ export class IpcBackgroundService extends IpcService {
             return;
           }
 
-          if (message.destination === "DesktopMain" || message.destination === "DesktopRenderer") {
-            try {
-              this.nativeMessagingPort?.postMessage({
-                type: "bitwarden-ipc-message",
-                message: {
-                  destination: message.destination,
-                  payload: [...message.payload],
-                  topic: message.topic,
-                },
-              } satisfies IpcMessage);
-            } catch (e) {
-              this.logService.error("[IPC] Failed to send message via native messaging", e);
-            }
+          if (
+            (message.destination === "DesktopMain" || message.destination === "DesktopRenderer") &&
+            this.desktopTransport != null
+          ) {
+            await this.desktopTransport!.send(message);
             return;
           }
 
@@ -87,79 +65,12 @@ export class IpcBackgroundService extends IpcService {
         version: await this.platformUtilsService.getApplicationVersion(),
       });
 
-      await this.connectToDesktop();
+      if (!this.platformUtilsService.isSafari()) {
+        this.desktopTransport = new DesktopIpcTransport(this.client, this.logService, receive);
+        this.desktopTransport.init();
+      }
     } catch (e) {
       this.logService.error("[IPC] Initialization failed", e);
     }
-  }
-
-  /**
-   * Starts a connection to the desktop app. This function attempts to establish a connection with the desktop application
-   * using native messaging. It will automatically retry and reconnect if the connection fails or is lost.
-   */
-  private async connectToDesktop() {
-    if (!(await BrowserApi.permissionsGranted(["nativeMessaging"]))) {
-      return;
-    }
-
-    let port: browser.runtime.Port | chrome.runtime.Port | undefined;
-    try {
-      port = BrowserApi.connectNative("com.8bit.bitwarden");
-      this.nativeMessagingPort = port;
-
-      port.onMessage.addListener((ipcMessage) => {
-        if (!isIpcMessage(ipcMessage) && !isForwardedIpcMessage(ipcMessage)) {
-          return;
-        }
-
-        this.communicationBackend?.receive(
-          new IncomingMessage(
-            new Uint8Array(ipcMessage.message.payload),
-            ipcMessage.message.destination,
-            isForwardedIpcMessage(ipcMessage) ? ipcMessage.originalSource : "DesktopMain",
-            ipcMessage.message.topic,
-          ),
-        );
-      });
-
-      // Register the disconnect handler before awaiting the discover handshake so that a
-      // disconnect during the handshake window (e.g. the desktop app closing) is still handled.
-      port.onDisconnect.addListener(() => {
-        this.logService.warning("[IPC] Disconnected from Bitwarden Desktop App");
-        this.nativeMessagingPort = undefined;
-        this.scheduleReconnect();
-      });
-
-      try {
-        // Ensure the desktop app is properly connected
-        const version = await ipcRequestDiscover(
-          this.client,
-          "DesktopRenderer",
-          AbortSignal.timeout(DISCOVER_MESSAGE_TIMEOUT_MS),
-        );
-        this.logService.info(
-          `[IPC] Connected to Bitwarden Desktop App with version ${version.version}`,
-        );
-      } catch (e) {
-        this.logService.error("[IPC] Failed to handshake with Bitwarden Desktop App", e);
-      }
-    } catch (e) {
-      this.logService.error("[IPC] Failed to connect to Bitwarden Desktop App", e);
-      // Explicitly disconnect the port to avoid leaking the native port and its spawned
-      // desktop_proxy process when the handshake fails (e.g. the desktop app is unreachable).
-      port?.disconnect();
-      this.nativeMessagingPort = undefined;
-      this.scheduleReconnect();
-    }
-  }
-
-  private scheduleReconnect() {
-    if (this.reconnectTimer != null) {
-      return;
-    }
-    this.reconnectTimer = setTimeout(() => {
-      this.reconnectTimer = undefined;
-      void this.connectToDesktop();
-    }, RECONNECTION_INTERVAL_MS);
   }
 }

--- a/apps/browser/src/platform/ipc/transports/desktop-ipc.transport.ts
+++ b/apps/browser/src/platform/ipc/transports/desktop-ipc.transport.ts
@@ -1,5 +1,10 @@
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
-import { IpcMessage, isIpcMessage, isForwardedIpcMessage } from "@bitwarden/common/platform/ipc";
+import {
+  IpcMessage,
+  isIpcMessage,
+  isForwardedIpcMessage,
+  isProxyConnectedMessage,
+} from "@bitwarden/common/platform/ipc";
 import {
   IncomingMessage,
   OutgoingMessage,
@@ -9,10 +14,31 @@ import {
 
 import { BrowserApi } from "../../browser/browser-api";
 
+import { DESTINATION_UNREACHABLE_ERROR } from "./errors";
+
 // The interval at which the browser extension in the background tries to reconnect to the desktop app.
 const RECONNECTION_INTERVAL_MS = 10_000;
+// How long to wait for the native messaging proxy to report a connection after the port is opened.
+// If it does not connect within this time, the attempt is aborted and retried after the reconnection interval.
+const CONNECTION_TIMEOUT_MS = 5_000;
 // The timeout for the discover message sent to the desktop app when trying to connect. If the desktop app does not respond to the discover message within this time, the connection attempt is considered failed and will be retried after the reconnection interval.
 const DISCOVER_MESSAGE_TIMEOUT_MS = 5_000;
+
+type NativePort = browser.runtime.Port | chrome.runtime.Port;
+
+/**
+ * The lifecycle of the native messaging connection, modelled as a state machine
+ *
+ * - `disconnected` — no live port. The initial state and the state after any failure/disconnect.
+ * - `connecting`   — the port is open but the proxy has not reported a connection yet. `ready`
+ *                    resolves once the outcome is known (either the proxy connects, or the port
+ *                    disconnects), so callers can await it without risking a permanent hang.
+ * - `connected`    — the proxy has reported a connection and the port is ready to send messages.
+ */
+type ConnectionState =
+  | { kind: "disconnected" }
+  | { kind: "connecting"; port: NativePort; ready: Promise<void> }
+  | { kind: "connected"; port: NativePort };
 
 /**
  * Transport for communicating with the Bitwarden Desktop App over native messaging.
@@ -22,8 +48,8 @@ const DISCOVER_MESSAGE_TIMEOUT_MS = 5_000;
  * `DesktopRenderer` destinations.
  */
 export class DesktopIpcTransport {
-  private nativeMessagingPort?: browser.runtime.Port | chrome.runtime.Port;
-  private reconnectTimer?: ReturnType<typeof setTimeout>;
+  private _state: ConnectionState = { kind: "disconnected" };
+  private reconnectTimer?: ReturnType<typeof setInterval>;
 
   constructor(
     private client: IpcClient,
@@ -32,43 +58,68 @@ export class DesktopIpcTransport {
   ) {}
 
   async send(message: OutgoingMessage): Promise<void> {
-    try {
-      this.nativeMessagingPort?.postMessage({
-        type: "bitwarden-ipc-message",
-        message: {
-          destination: message.destination,
-          payload: [...message.payload],
-          topic: message.topic,
-        },
-      } satisfies IpcMessage);
-    } catch (e) {
-      this.logService.error("[IPC] Failed to send message via native messaging", e);
+    // Wait out an in-flight connection attempt before deciding reachability.
+    const state = this.currentState();
+    if (state.kind === "connecting") {
+      await state.ready;
     }
+
+    const connected = this.currentState();
+    if (connected.kind !== "connected") {
+      throw new Error(DESTINATION_UNREACHABLE_ERROR);
+    }
+
+    connected.port.postMessage({
+      type: "bitwarden-ipc-message",
+      message: {
+        destination: message.destination,
+        payload: [...message.payload],
+        topic: message.topic,
+      },
+    } satisfies IpcMessage);
   }
 
   /**
-   * Starts the transport, establishing the connection to the desktop app and automatically
-   * retrying whenever the connection fails or is lost.
+   * Starts the transport. Kicks off the periodic reconnect timer, which establishes the connection
+   * to the desktop app and automatically retries whenever the connection fails or is lost.
    */
   init() {
-    void this.connect();
+    this.startReconnectTimer();
   }
 
   /**
-   * Starts a connection to the desktop app. This function attempts to establish a connection with the desktop application
-   * using native messaging. It will automatically retry and reconnect if the connection fails or is lost.
+   * Attempts to establish a connection with the desktop application using native messaging. Invoked
+   * by the reconnect timer whenever the connection is down; no-ops unless currently disconnected.
    */
   private async connect() {
+    // Only start from a clean slate; guards against overwriting a live port (which would leak the
+    // previous native port and its spawned desktop_proxy process).
+    if (this.currentState().kind !== "disconnected") {
+      return;
+    }
+
     if (!(await BrowserApi.permissionsGranted(["nativeMessaging"]))) {
       return;
     }
 
-    let port: browser.runtime.Port | chrome.runtime.Port | undefined;
+    let activePort: NativePort | undefined;
     try {
-      port = BrowserApi.connectNative("com.8bit.bitwarden");
-      this.nativeMessagingPort = port;
+      const port = BrowserApi.connectNative("com.8bit.bitwarden");
+      activePort = port;
 
-      port.onMessage.addListener((ipcMessage) => {
+      let resolveReady: () => void;
+      const ready = new Promise<void>((resolve) => {
+        resolveReady = resolve;
+      });
+      this.setState({ kind: "connecting", port, ready });
+
+      port.onMessage.addListener((ipcMessage: any) => {
+        if (isProxyConnectedMessage(ipcMessage)) {
+          this.setState({ kind: "connected", port });
+          resolveReady();
+          this.logService.info("[IPC] Connected to Bitwarden Desktop App Transport");
+        }
+
         if (!isIpcMessage(ipcMessage) && !isForwardedIpcMessage(ipcMessage)) {
           return;
         }
@@ -86,10 +137,32 @@ export class DesktopIpcTransport {
       // Register the disconnect handler before awaiting the discover handshake so that a
       // disconnect during the handshake window (e.g. the desktop app closing) is still handled.
       port.onDisconnect.addListener(() => {
-        this.logService.warning("[IPC] Disconnected from Bitwarden Desktop App");
-        this.nativeMessagingPort = undefined;
-        this.scheduleReconnect();
+        if (this.currentState().kind === "connected") {
+          this.logService.warning("[IPC] Disconnected from Bitwarden Desktop App Transport");
+        }
+
+        this.setState({ kind: "disconnected" });
+        // Unblock anyone waiting on the connection attempt (both connect() and send()).
+        resolveReady();
+
+        // Suppress error message
+        void chrome.runtime.lastError;
       });
+
+      // Wait for the proxy to report a connection, bounded by a timeout so a proxy that opens the
+      // port but never reports a connection (and never disconnects) can't leave us stuck here forever.
+      await Promise.race([
+        ready,
+        new Promise<void>((resolve) => setTimeout(resolve, CONNECTION_TIMEOUT_MS)),
+      ]);
+
+      if (this.currentState().kind !== "connected") {
+        // Either we timed out waiting for the proxy, or the port disconnected mid-attempt.
+        // Explicitly tear down the port
+        port.disconnect();
+        this.setState({ kind: "disconnected" });
+        return;
+      }
 
       try {
         // Ensure the desktop app is properly connected
@@ -108,19 +181,32 @@ export class DesktopIpcTransport {
       this.logService.error("[IPC] Failed to connect to Bitwarden Desktop App", e);
       // Explicitly disconnect the port to avoid leaking the native port and its spawned
       // desktop_proxy process when the handshake fails (e.g. the desktop app is unreachable).
-      port?.disconnect();
-      this.nativeMessagingPort = undefined;
-      this.scheduleReconnect();
+      activePort?.disconnect();
+      this.setState({ kind: "disconnected" });
     }
   }
 
-  private scheduleReconnect() {
+  private currentState(): ConnectionState {
+    return this._state;
+  }
+
+  private setState(state: ConnectionState) {
+    this._state = state;
+  }
+
+  // Runs a single long-lived timer that re-invokes connect() while the connection is down, plus one
+  // immediate attempt so the first connection isn't delayed by a full interval. connect() itself
+  // no-ops unless the state is `disconnected`, so ticks during an active/in-flight connection are
+  // harmless. Idempotent: repeated calls keep the one existing timer.
+  private startReconnectTimer() {
     if (this.reconnectTimer != null) {
       return;
     }
-    this.reconnectTimer = setTimeout(() => {
-      this.reconnectTimer = undefined;
-      void this.connect();
+    void this.connect();
+    this.reconnectTimer = setInterval(() => {
+      if (this.currentState().kind === "disconnected") {
+        void this.connect();
+      }
     }, RECONNECTION_INTERVAL_MS);
   }
 }

--- a/apps/browser/src/platform/ipc/transports/desktop-ipc.transport.ts
+++ b/apps/browser/src/platform/ipc/transports/desktop-ipc.transport.ts
@@ -1,0 +1,126 @@
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+import { IpcMessage, isIpcMessage, isForwardedIpcMessage } from "@bitwarden/common/platform/ipc";
+import {
+  IncomingMessage,
+  OutgoingMessage,
+  IpcClient,
+  ipcRequestDiscover,
+} from "@bitwarden/sdk-internal";
+
+import { BrowserApi } from "../../browser/browser-api";
+
+// The interval at which the browser extension in the background tries to reconnect to the desktop app.
+const RECONNECTION_INTERVAL_MS = 10_000;
+// The timeout for the discover message sent to the desktop app when trying to connect. If the desktop app does not respond to the discover message within this time, the connection attempt is considered failed and will be retried after the reconnection interval.
+const DISCOVER_MESSAGE_TIMEOUT_MS = 5_000;
+
+/**
+ * Transport for communicating with the Bitwarden Desktop App over native messaging.
+ *
+ * Owns the native messaging port lifecycle, including the discover handshake and automatic
+ * reconnection when the connection fails or is lost. Handles the `DesktopMain` and
+ * `DesktopRenderer` destinations.
+ */
+export class DesktopIpcTransport {
+  private nativeMessagingPort?: browser.runtime.Port | chrome.runtime.Port;
+  private reconnectTimer?: ReturnType<typeof setTimeout>;
+
+  constructor(
+    private client: IpcClient,
+    private logService: LogService,
+    private receive: (message: IncomingMessage) => void,
+  ) {}
+
+  async send(message: OutgoingMessage): Promise<void> {
+    try {
+      this.nativeMessagingPort?.postMessage({
+        type: "bitwarden-ipc-message",
+        message: {
+          destination: message.destination,
+          payload: [...message.payload],
+          topic: message.topic,
+        },
+      } satisfies IpcMessage);
+    } catch (e) {
+      this.logService.error("[IPC] Failed to send message via native messaging", e);
+    }
+  }
+
+  /**
+   * Starts the transport, establishing the connection to the desktop app and automatically
+   * retrying whenever the connection fails or is lost.
+   */
+  init() {
+    void this.connect();
+  }
+
+  /**
+   * Starts a connection to the desktop app. This function attempts to establish a connection with the desktop application
+   * using native messaging. It will automatically retry and reconnect if the connection fails or is lost.
+   */
+  private async connect() {
+    if (!(await BrowserApi.permissionsGranted(["nativeMessaging"]))) {
+      return;
+    }
+
+    let port: browser.runtime.Port | chrome.runtime.Port | undefined;
+    try {
+      port = BrowserApi.connectNative("com.8bit.bitwarden");
+      this.nativeMessagingPort = port;
+
+      port.onMessage.addListener((ipcMessage) => {
+        if (!isIpcMessage(ipcMessage) && !isForwardedIpcMessage(ipcMessage)) {
+          return;
+        }
+
+        this.receive(
+          new IncomingMessage(
+            new Uint8Array(ipcMessage.message.payload),
+            ipcMessage.message.destination,
+            isForwardedIpcMessage(ipcMessage) ? ipcMessage.originalSource : "DesktopMain",
+            ipcMessage.message.topic,
+          ),
+        );
+      });
+
+      // Register the disconnect handler before awaiting the discover handshake so that a
+      // disconnect during the handshake window (e.g. the desktop app closing) is still handled.
+      port.onDisconnect.addListener(() => {
+        this.logService.warning("[IPC] Disconnected from Bitwarden Desktop App");
+        this.nativeMessagingPort = undefined;
+        this.scheduleReconnect();
+      });
+
+      try {
+        // Ensure the desktop app is properly connected
+        const version = await ipcRequestDiscover(
+          this.client,
+          "DesktopRenderer",
+          AbortSignal.timeout(DISCOVER_MESSAGE_TIMEOUT_MS),
+        );
+        this.logService.info(
+          `[IPC] Connected to Bitwarden Desktop App with version ${version.version}`,
+        );
+      } catch (e) {
+        this.logService.error("[IPC] Failed to handshake with Bitwarden Desktop App", e);
+      }
+    } catch (e) {
+      this.logService.error("[IPC] Failed to connect to Bitwarden Desktop App", e);
+      // Explicitly disconnect the port to avoid leaking the native port and its spawned
+      // desktop_proxy process when the handshake fails (e.g. the desktop app is unreachable).
+      port?.disconnect();
+      this.nativeMessagingPort = undefined;
+      this.scheduleReconnect();
+    }
+  }
+
+  private scheduleReconnect() {
+    if (this.reconnectTimer != null) {
+      return;
+    }
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = undefined;
+      void this.connect();
+    }, RECONNECTION_INTERVAL_MS);
+  }
+}

--- a/apps/browser/src/platform/ipc/transports/errors.ts
+++ b/apps/browser/src/platform/ipc/transports/errors.ts
@@ -1,0 +1,3 @@
+// Thrown by a transport's `send` when the target destination cannot be reached (e.g. the desktop
+// app is not connected, or the web tab/document is gone). The sdk looks for this specific error.
+export const DESTINATION_UNREACHABLE_ERROR = "Destination unreachable";

--- a/apps/browser/src/platform/ipc/transports/index.ts
+++ b/apps/browser/src/platform/ipc/transports/index.ts
@@ -1,1 +1,2 @@
 export { WebIpcTransport } from "./web-ipc.transport";
+export { DesktopIpcTransport } from "./desktop-ipc.transport";

--- a/apps/browser/src/platform/ipc/transports/index.ts
+++ b/apps/browser/src/platform/ipc/transports/index.ts
@@ -1,0 +1,1 @@
+export { WebIpcTransport } from "./web-ipc.transport";

--- a/apps/browser/src/platform/ipc/transports/web-ipc.transport.ts
+++ b/apps/browser/src/platform/ipc/transports/web-ipc.transport.ts
@@ -1,0 +1,94 @@
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+import { IpcMessage, isIpcMessage } from "@bitwarden/common/platform/ipc";
+import { IncomingMessage, OutgoingMessage } from "@bitwarden/sdk-internal";
+
+import { BrowserApi } from "../../browser/browser-api";
+
+import { DESTINATION_UNREACHABLE_ERROR } from "./errors";
+
+/**
+ * Transport for communicating with web vaults via content scripts for Manifest V3.
+ *
+ * Sends messages to tabs via {@link BrowserApi.tabSendMessage} and receives messages from tabs
+ * through a {@link BrowserApi.messageListener}. Handles the `Web` destination.
+ */
+export class WebIpcTransport {
+  constructor(
+    private logService: LogService,
+    private receive: (message: IncomingMessage) => void,
+  ) {}
+
+  init() {
+    BrowserApi.messageListener("platform.ipc", (message, sender) => {
+      if (
+        !isIpcMessage(message) ||
+        typeof message.message.destination !== "object" ||
+        !("BrowserBackground" in message.message.destination)
+      ) {
+        return;
+      }
+
+      if (sender.tab?.id === undefined || sender.tab.id === chrome.tabs.TAB_ID_NONE) {
+        // Ignore messages from non-tab sources
+        return;
+      }
+
+      if (sender.documentId === undefined) {
+        this.logService.warning(
+          "[IPC] Received message from tab without documentId (unsupported browser version)",
+        );
+        return;
+      }
+
+      this.receive(
+        new IncomingMessage(
+          new Uint8Array(message.message.payload),
+          message.message.destination,
+          {
+            Web: {
+              tab_id: sender.tab.id,
+              document_id: sender.documentId,
+              origin: sender.origin ?? "",
+            },
+          },
+          message.message.topic,
+        ),
+      );
+    });
+  }
+
+  async send(message: OutgoingMessage): Promise<void> {
+    if (typeof message.destination !== "object" || !("Web" in message.destination)) {
+      throw new Error("Destination not supported.");
+    }
+
+    // Verify the document hasn't changed (e.g., user navigated away) before delivering.
+    // If the browser doesn't support documentId on getFrame, skip the check and send anyway.
+    try {
+      const frame = await chrome.webNavigation.getFrame({
+        tabId: message.destination.Web.tab_id,
+        frameId: 0,
+      });
+      if (frame?.documentId != null && frame.documentId !== message.destination.Web.document_id) {
+        this.logService.warning("[IPC] Dropping message to Web tab: document has changed");
+        return;
+      }
+    } catch {
+      // Tab may have been closed, or API not available.
+      throw new Error(DESTINATION_UNREACHABLE_ERROR);
+    }
+
+    await BrowserApi.tabSendMessage(
+      { id: message.destination.Web.tab_id } as chrome.tabs.Tab,
+      {
+        type: "bitwarden-ipc-message",
+        message: {
+          destination: message.destination,
+          payload: [...message.payload],
+          topic: message.topic,
+        },
+      } satisfies IpcMessage,
+      { frameId: 0 },
+    );
+  }
+}

--- a/libs/common/src/platform/ipc/ipc-message.ts
+++ b/libs/common/src/platform/ipc/ipc-message.ts
@@ -25,3 +25,11 @@ export function isIpcMessage(message: any): message is IpcMessage {
 export function isForwardedIpcMessage(message: any): message is ForwardedIpcMessage {
   return message != null && message.type === "forwarded-bitwarden-ipc-message";
 }
+
+/**
+ * Detects the `{ command: "connected" }` message emitted by the `desktop_proxy` native-messaging
+ * binary after connecting to the desktop app.
+ */
+export function isProxyConnectedMessage(message: any): boolean {
+  return message != null && message.command === "connected";
+}


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-39992
Related SDK PR:
https://github.com/bitwarden/sdk-internal/pull/1229

## 📔 Objective

https://github.com/bitwarden/sdk-internal/pull/1229 added handling for a destination unreachable error type. If a destination is unreachable, then the ipc transport should throw, so that the SDK can properly react to this (clear crypto state).

This PR adds support for throwing in the unreachable case.  For the desktop, we have to add tracking for the connection state, based on the proxy's connected message.

Because the code got complex, I took the opportunity to refactor out (in a separate commit) the web transport and desktop transport into separate files.
