### PR TITLE
[PM-39123] Fix members page filters flicker

### DIFF
--- a/apps/web/src/app/admin-console/organizations/members/members.component.ts
+++ b/apps/web/src/app/admin-console/organizations/members/members.component.ts
@@ -14,6 +14,7 @@ import {
   merge,
   Observable,
   shareReplay,
+  startWith,
   switchMap,
   take,
 } from "rxjs";
@@ -153,7 +154,10 @@ export class MembersComponent {
   protected rowHeightClass = `tw-h-[66px]`;
 
   constructor() {
-    combineLatest([this.searchControl.valueChanges.pipe(debounceTime(200)), this.statusToggle])
+    combineLatest([
+      this.searchControl.valueChanges.pipe(startWith(this.searchControl.value), debounceTime(200)),
+      this.statusToggle,
+    ])
       .pipe(takeUntilDestroyed())
       .subscribe(
         ([searchText, status]) => (this.dataSource().filter = peopleFilter(searchText, status)),
@@ -195,9 +199,9 @@ export class MembersComponent {
     combineLatest([this.route.queryParams, organization$])
       .pipe(
         concatMap(async ([qParams, organization]) => {
-          await this.load(organization!);
+          this.searchControl.setValue(qParams.search, { emitEvent: false });
 
-          this.searchControl.setValue(qParams.search);
+          await this.load(organization!);
 
           if (qParams.viewEvents != null) {
             const user = this.dataSource().data.filter((u) => u.id === qParams.viewEvents);
@@ -237,6 +241,10 @@ export class MembersComponent {
   async load(organization: Organization) {
     const response = await this.memberService.loadUsers(organization);
     this.dataSource().data = response;
+    // Apply the current filter synchronously alongside the data so the table never renders
+    // an unfiltered frame (e.g. showing a just-revoked member) while waiting for the debounced
+    // searchControl/statusToggle subscription to catch up.
+    this.dataSource().filter = peopleFilter(this.searchControl.value, this.statusToggle.value);
     this.firstLoaded.set(true);
   }
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-39123

## 📔 Objective

Fixes the members page filters flicker caused by the debounce of the search filter value coming in 200ms and more behind.
