### PR TITLE
[PM-39949] Fix Bitwarden Browser Extension interfering with ASPEED H5Viewer

### DIFF
--- a/apps/browser/src/autofill/services/autofill-constants.ts
+++ b/apps/browser/src/autofill/services/autofill-constants.ts
@@ -181,7 +181,14 @@ export class AutoFillConstants {
     "logon",
   ] as const;
 
-  static readonly FieldIgnoreList: string[] = ["captcha", "findanything", "forgot"];
+  static readonly FieldIgnoreList: string[] = [
+    "captcha",
+    "findanything",
+    "forgot",
+    // Used by ASPEED H5Viewer KVM/BMC consoles to capture keyboard input; autofill
+    // binding to it breaks remote console input. The element id is "kvm_textbox".
+    "kvmtextbox",
+  ];
 
   static readonly PasswordFieldExcludeList: string[] = [
     "hint",

--- a/apps/browser/src/autofill/services/autofill.service.spec.ts
+++ b/apps/browser/src/autofill/services/autofill.service.spec.ts
@@ -4704,6 +4704,16 @@ describe("AutofillService", () => {
 
         expect(result).toStrictEqual([]);
       });
+
+      it("returns an empty array for an ASPEED H5Viewer KVM console text capture field", () => {
+        passwordField.htmlID = "kvm_textbox";
+        passwordField.htmlName = "password";
+        pageDetails.fields = [passwordField];
+
+        const result = AutofillService.loadPasswordFields(pageDetails, false, false, false, false);
+
+        expect(result).toStrictEqual([]);
+      });
     });
 
     describe("given a field that is not viewable", () => {

--- a/apps/browser/src/autofill/services/inline-menu-field-qualification.service.spec.ts
+++ b/apps/browser/src/autofill/services/inline-menu-field-qualification.service.spec.ts
@@ -110,6 +110,36 @@ describe("InlineMenuFieldQualificationService", () => {
           });
         });
 
+        it("disqualifies an ASPEED H5Viewer KVM console text capture field", () => {
+          const field = mock<AutofillField>({
+            type: "text",
+            htmlID: "kvm_textbox",
+            htmlName: "password",
+            placeholder: "",
+            autoCompleteType: "",
+          });
+
+          expect(inlineMenuFieldQualificationService.isFieldForLoginForm(field, pageDetails)).toBe(
+            false,
+          );
+        });
+
+        it("does not disqualify fields whose attribute is only a substring of a FieldIgnoreList entry", () => {
+          // Regression guard: "textbox" is a substring of the "kvmtextbox"
+          // ignore-list entry but must not itself trigger disqualification.
+          const field = mock<AutofillField>({
+            type: "text",
+            htmlID: "textbox",
+            htmlName: "",
+            placeholder: "",
+            autoCompleteType: "",
+          });
+
+          expect(
+            inlineMenuFieldQualificationService["fieldHasDisqualifyingAttributeValue"](field),
+          ).toBe(false);
+        });
+
         it("has a type other than `password` or `text`", () => {
           const field = mock<AutofillField>({
             type: "number",

--- a/apps/browser/src/autofill/services/inline-menu-field-qualification.service.ts
+++ b/apps/browser/src/autofill/services/inline-menu-field-qualification.service.ts
@@ -34,7 +34,6 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
     this.emailAutocompleteValue,
     this.webAuthnAutocompleteValue,
   ]);
-  private fieldIgnoreListString = AutoFillConstants.FieldIgnoreList.join(",");
   private currentPasswordAutocompleteValue = "current-password";
   private newPasswordAutoCompleteValue = "new-password";
   private submitButtonKeywordsMap: SubmitButtonKeywordsMap = new WeakMap();
@@ -1104,7 +1103,10 @@ export class InlineMenuFieldQualificationService implements InlineMenuFieldQuali
       const checkedAttributeValue = checkedAttributeValues[i];
       const cleanedValue = checkedAttributeValue?.toLowerCase().replace(/[\s_-]/g, "");
 
-      if (cleanedValue && this.fieldIgnoreListString.indexOf(cleanedValue) > -1) {
+      if (
+        cleanedValue &&
+        AutoFillConstants.FieldIgnoreList.some((i) => cleanedValue.indexOf(i) > -1)
+      ) {
         return true;
       }
     }


### PR DESCRIPTION
## 🎟️ Tracking

https://github.com/bitwarden/clients/issues/17835

## 📔 Objective

The ASPEED H5Viewer uses a dirty trick to capture keyboard inputs, specifically an element `<input id="kvm_textbox" name="password...` to which the Bitwarden Browser Extension tries to bind. This interferes with the KVM operation.

## Disclaimer
I have no idea what I'm doing, but the tests pass and a quick local test appears to be working fine.