### PR TITLE
[PM-39974] Remove Biometric Integration Setting Fully

### DIFF
--- a/apps/desktop/src/app/accounts/settings-dialog.component.html
+++ b/apps/desktop/src/app/accounts/settings-dialog.component.html
@@ -124,17 +124,6 @@
           </bit-form-control>
         }
 
-        <bit-form-control>
-          <input
-            type="checkbox"
-            bitCheckbox
-            formControlName="enableBrowserIntegration"
-            (change)="saveBrowserIntegration()"
-          />
-          <bit-label>{{ "enableBrowserIntegration" | i18n }}</bit-label>
-          <bit-hint>{{ "enableBrowserIntegrationDesc1" | i18n }}</bit-hint>
-        </bit-form-control>
-
         @if (showEnableAutotype()) {
           <bit-form-control>
             <input

--- a/apps/desktop/src/app/accounts/settings-dialog.component.spec.ts
+++ b/apps/desktop/src/app/accounts/settings-dialog.component.spec.ts
@@ -193,7 +193,6 @@ describe("SettingsDialogComponent", () => {
     desktopSettingsService.minimizeOnCopy$ = of(false);
     desktopSettingsService.runInBackground$ = of(false);
     desktopSettingsService.openAtLogin$ = of(false);
-    desktopSettingsService.browserIntegrationEnabled$ = of(false);
     desktopSettingsService.hardwareAcceleration$ = of(false);
     desktopSettingsService.sshAgentEnabled$ = of(false);
     desktopSettingsService.sshAgentPromptBehavior$ = of(SshAgentPromptType.Always);

--- a/apps/desktop/src/app/accounts/settings-dialog.component.ts
+++ b/apps/desktop/src/app/accounts/settings-dialog.component.ts
@@ -177,7 +177,6 @@ export class SettingsDialogComponent implements OnInit {
     // App Settings
     runInBackground: false,
     openAtLogin: false,
-    enableBrowserIntegration: false,
     enableHardwareAcceleration: true,
     enableSshAgent: false,
     sshAgentPromptBehavior: SshAgentPromptType.Always,
@@ -276,9 +275,6 @@ export class SettingsDialogComponent implements OnInit {
       enableFavicons: await firstValueFrom(this.domainSettingsService.showFavicons$),
       runInBackground: await firstValueFrom(this.desktopSettingsService.runInBackground$),
       openAtLogin: await firstValueFrom(this.desktopSettingsService.openAtLogin$),
-      enableBrowserIntegration: await firstValueFrom(
-        this.desktopSettingsService.browserIntegrationEnabled$,
-      ),
       enableDuckDuckGoBrowserIntegration: await firstValueFrom(
         this.desktopAutofillSettingsService.enableDuckDuckGoBrowserIntegration$,
       ),
@@ -571,44 +567,6 @@ export class SettingsDialogComponent implements OnInit {
     );
   }
 
-  protected async saveBrowserIntegration() {
-    const skipSupportedPlatformCheck =
-      ipc.platform.allowBrowserintegrationOverride || ipc.platform.isDev;
-
-    if (!skipSupportedPlatformCheck) {
-      if (ipc.platform.isWindowsStore) {
-        await this.dialogService.openSimpleDialog({
-          title: { key: "browserIntegrationUnsupportedTitle" },
-          content: { key: "browserIntegrationWindowsStoreDesc" },
-          acceptButtonText: { key: "ok" },
-          cancelButtonText: null,
-          type: "warning",
-        });
-
-        this.form.controls.enableBrowserIntegration.setValue(false);
-        return;
-      }
-    }
-
-    await this.desktopSettingsService.setBrowserIntegrationEnabled(
-      this.form.value.enableBrowserIntegration,
-    );
-
-    const errorResult = await this.nativeMessagingManifestService.generate(
-      this.form.value.enableBrowserIntegration,
-    );
-    if (errorResult !== null) {
-      this.logService.error("Error in browser integration: " + errorResult);
-      await this.dialogService.openSimpleDialog({
-        title: { key: "browserIntegrationErrorTitle" },
-        content: { key: "browserIntegrationErrorDesc" },
-        acceptButtonText: { key: "ok" },
-        cancelButtonText: null,
-        type: "danger",
-      });
-    }
-  }
-
   protected async saveDdgBrowserIntegration() {
     await this.desktopAutofillSettingsService.setEnableDuckDuckGoBrowserIntegration(
       this.form.value.enableDuckDuckGoBrowserIntegration,
@@ -618,10 +576,6 @@ export class SettingsDialogComponent implements OnInit {
     await this.stateService.setEnableDuckDuckGoBrowserIntegration(
       this.form.value.enableDuckDuckGoBrowserIntegration,
     );
-
-    if (!this.form.value.enableBrowserIntegration) {
-      await this.stateService.setDuckDuckGoSharedKey(null);
-    }
 
     const errorResult = await this.nativeMessagingManifestService.generateDuckDuckGo(
       this.form.value.enableDuckDuckGoBrowserIntegration,

--- a/apps/desktop/src/app/accounts/settings.component.spec.ts
+++ b/apps/desktop/src/app/accounts/settings.component.spec.ts
@@ -174,7 +174,6 @@ describe("SettingsComponent", () => {
     desktopSettingsService.minimizeOnCopy$ = of(false);
     desktopSettingsService.runInBackground$ = of(false);
     desktopSettingsService.openAtLogin$ = of(false);
-    desktopSettingsService.browserIntegrationEnabled$ = of(false);
     desktopSettingsService.hardwareAcceleration$ = of(false);
     desktopSettingsService.sshAgentEnabled$ = of(false);
     desktopSettingsService.sshAgentPromptBehavior$ = of(SshAgentPromptType.Always);

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -2761,29 +2761,11 @@
   "acceptPoliciesRequired": {
     "message": "Terms of Service and Privacy Policy have not been acknowledged."
   },
-  "enableBrowserIntegration": {
-    "message": "Allow browser integration"
-  },
-  "enableBrowserIntegrationDesc1": {
-    "message": "Used to allow biometric unlock in browsers that are not Safari."
-  },
   "enableDuckDuckGoBrowserIntegration": {
     "message": "Allow DuckDuckGo browser integration"
   },
   "enableDuckDuckGoBrowserIntegrationDesc": {
     "message": "Use your Bitwarden vault when browsing with DuckDuckGo."
-  },
-  "browserIntegrationUnsupportedTitle": {
-    "message": "Browser integration not supported"
-  },
-  "browserIntegrationErrorTitle": {
-    "message": "Error enabling browser integration"
-  },
-  "browserIntegrationErrorDesc": {
-    "message": "An error has occurred while enabling browser integration."
-  },
-  "browserIntegrationWindowsStoreDesc": {
-    "message": "Unfortunately browser integration is currently not supported in the Microsoft Store version."
   },
   "enableHardwareAcceleration": {
     "message": "Use hardware acceleration"

--- a/apps/desktop/src/platform/services/desktop-settings.service.ts
+++ b/apps/desktop/src/platform/services/desktop-settings.service.ts
@@ -46,14 +46,6 @@ const ALWAYS_ON_TOP_KEY = new KeyDefinition<boolean>(DESKTOP_SETTINGS_DISK, "alw
   deserializer: (b) => b,
 });
 
-const BROWSER_INTEGRATION_ENABLED = new KeyDefinition<boolean>(
-  DESKTOP_SETTINGS_DISK,
-  "browserIntegrationEnabled",
-  {
-    deserializer: (b) => b,
-  },
-);
-
 const SSH_AGENT_ENABLED = new KeyDefinition<boolean>(DESKTOP_SETTINGS_DISK, "sshAgentEnabled", {
   deserializer: (b) => b,
 });
@@ -113,15 +105,6 @@ export class DesktopSettingsService {
   private readonly alwaysOnTopState = this.stateProvider.getGlobal(ALWAYS_ON_TOP_KEY);
 
   alwaysOnTop$ = this.alwaysOnTopState.state$.pipe(map(Boolean));
-
-  private readonly browserIntegrationEnabledState = this.stateProvider.getGlobal(
-    BROWSER_INTEGRATION_ENABLED,
-  );
-
-  /**
-   * The application setting for whether or not the browser integration is enabled.
-   */
-  browserIntegrationEnabled$ = this.browserIntegrationEnabledState.state$.pipe(map(Boolean));
 
   private readonly sshAgentEnabledState = this.stateProvider.getGlobal(SSH_AGENT_ENABLED);
 
@@ -207,15 +190,6 @@ export class DesktopSettingsService {
    */
   async setAlwaysOnTop(value: boolean) {
     await this.alwaysOnTopState.update(() => value);
-  }
-
-  /**
-   * Sets a setting for whether or not the browser integration has been enabled.
-   * @param value `true` if the integration with the browser extension is enabled,
-   * `false` if it is not.
-   */
-  async setBrowserIntegrationEnabled(value: boolean) {
-    await this.browserIntegrationEnabledState.update(() => value);
   }
 
   /**

--- a/apps/desktop/src/services/biometric-message-handler.service.spec.ts
+++ b/apps/desktop/src/services/biometric-message-handler.service.spec.ts
@@ -1,5 +1,5 @@
 import { mock, MockProxy } from "jest-mock-extended";
-import { BehaviorSubject, filter, firstValueFrom, of, take, timeout, timer } from "rxjs";
+import { of } from "rxjs";
 
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { AuthService } from "@bitwarden/common/auth/abstractions/auth.service";
@@ -12,8 +12,6 @@ import { mockAccountInfoWith, FakeAccountService } from "@bitwarden/common/spec"
 import { CsprngArray } from "@bitwarden/common/types/csprng";
 import { UserId } from "@bitwarden/common/types/guid";
 import { BiometricsService, BiometricsCommands } from "@bitwarden/key-management";
-
-import { DesktopSettingsService } from "../platform/services/desktop-settings.service";
 
 import { BiometricMessageHandlerService } from "./biometric-message-handler.service";
 
@@ -49,7 +47,6 @@ describe("BiometricMessageHandlerService", () => {
   let cryptoFunctionService: MockProxy<CryptoFunctionService>;
   let encryptService: MockProxy<EncryptService>;
   let logService: MockProxy<LogService>;
-  let desktopSettingsService: DesktopSettingsService;
   let biometricsService: MockProxy<BiometricsService>;
   let accountService: AccountService;
   let authService: MockProxy<AuthService>;
@@ -58,12 +55,9 @@ describe("BiometricMessageHandlerService", () => {
     cryptoFunctionService = mock<CryptoFunctionService>();
     encryptService = mock<EncryptService>();
     logService = mock<LogService>();
-    desktopSettingsService = mock<DesktopSettingsService>();
     biometricsService = mock<BiometricsService>();
     accountService = new FakeAccountService(accounts);
     authService = mock<AuthService>();
-
-    desktopSettingsService.browserIntegrationEnabled$ = of(false);
 
     (global as any).ipc = {
       platform: {
@@ -88,90 +82,10 @@ describe("BiometricMessageHandlerService", () => {
       cryptoFunctionService,
       encryptService,
       logService,
-      desktopSettingsService,
       biometricsService,
       accountService,
       authService,
     );
-  });
-
-  describe("constructor", () => {
-    let browserIntegrationEnabled = new BehaviorSubject<boolean>(true);
-
-    beforeEach(async () => {
-      (global as any).ipc = {
-        platform: {
-          ephemeralStore: {
-            listEphemeralValueKeys: jest.fn(() =>
-              Promise.resolve(["connectedApp_appId1", "connectedApp_appId2"]),
-            ),
-            getEphemeralValue: jest.fn((key) => {
-              if (key === "connectedApp_appId1") {
-                return Promise.resolve(
-                  JSON.stringify({
-                    publicKey: Utils.fromUtf8ToB64("publicKeyApp1"),
-                    sessionSecret: Utils.fromUtf8ToB64("sessionSecretApp1"),
-                    trusted: true,
-                  }),
-                );
-              } else if (key === "connectedApp_appId2") {
-                return Promise.resolve(
-                  JSON.stringify({
-                    publicKey: Utils.fromUtf8ToB64("publicKeyApp2"),
-                    sessionSecret: Utils.fromUtf8ToB64("sessionSecretApp2"),
-                    trusted: false,
-                  }),
-                );
-              }
-              return Promise.resolve(null);
-            }),
-            removeEphemeralValue: jest.fn(),
-            setEphemeralValue: jest.fn(),
-          },
-        },
-      };
-
-      desktopSettingsService.browserIntegrationEnabled$ = browserIntegrationEnabled.asObservable();
-
-      service = new BiometricMessageHandlerService(
-        cryptoFunctionService,
-        encryptService,
-        logService,
-        desktopSettingsService,
-        biometricsService,
-        accountService,
-        authService,
-      );
-    });
-
-    afterEach(() => {
-      browserIntegrationEnabled = new BehaviorSubject<boolean>(true);
-
-      desktopSettingsService.browserIntegrationEnabled$ = browserIntegrationEnabled.asObservable();
-    });
-
-    it("should clear connected apps when browser integration disabled", async () => {
-      browserIntegrationEnabled.next(false);
-
-      await firstValueFrom(
-        timer(0, 100).pipe(
-          filter(
-            () =>
-              (global as any).ipc.platform.ephemeralStore.removeEphemeralValue.mock.calls.length ==
-              2,
-          ),
-          take(1),
-          timeout(1000),
-        ),
-      );
-
-      expect((global as any).ipc.platform.ephemeralStore.removeEphemeralValue).toHaveBeenCalledWith(
-        "connectedApp_appId1",
-      );
-      expect((global as any).ipc.platform.ephemeralStore.removeEphemeralValue).toHaveBeenCalledWith(
-        "connectedApp_appId2",
-      );
-    });
   });
 
   describe("setup encryption", () => {

--- a/apps/desktop/src/services/biometric-message-handler.service.ts
+++ b/apps/desktop/src/services/biometric-message-handler.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from "@angular/core";
-import { concatMap, firstValueFrom } from "rxjs";
+import { firstValueFrom } from "rxjs";
 
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { AuthService } from "@bitwarden/common/auth/abstractions/auth.service";
@@ -17,7 +17,6 @@ import { PureCrypto } from "@bitwarden/sdk-internal";
 
 import { DesktopBiometricsService } from "../key-management/biometrics/desktop.biometrics.service";
 import { LegacyMessage, LegacyMessageWrapper } from "../models/native-messaging";
-import { DesktopSettingsService } from "../platform/services/desktop-settings.service";
 
 const MessageValidTimeout = 10 * 1000;
 const HashAlgorithmForAsymmetricEncryption = "sha1";
@@ -71,22 +70,10 @@ export class BiometricMessageHandlerService {
     private cryptoFunctionService: CryptoFunctionService,
     private encryptService: EncryptService,
     private logService: LogService,
-    private desktopSettingService: DesktopSettingsService,
     private biometricsService: DesktopBiometricsService,
     private accountService: AccountService,
     private authService: AuthService,
-  ) {
-    this.desktopSettingService.browserIntegrationEnabled$
-      .pipe(
-        concatMap(async (browserIntegrationEnabled) => {
-          if (!browserIntegrationEnabled) {
-            this.logService.info("[Native Messaging IPC] Clearing connected apps");
-            await this.connectedApps.clear();
-          }
-        }),
-      )
-      .subscribe();
-  }
+  ) {}
 
   private connectedApps: ConnectedApps = new ConnectedApps();
 

--- a/libs/state/src/state-migrations/migrate.ts
+++ b/libs/state/src/state-migrations/migrate.ts
@@ -79,11 +79,12 @@ import { InitializeFeatureFlagOverridesMigrator } from "./migrations/79-initiali
 import { MoveStateVersionMigrator } from "./migrations/8-move-state-version";
 import { ConsolidateTrayToRunInBackground } from "./migrations/80-consolidate-tray-to-run-in-background";
 import { EnableDesktopSharingIfBiometricsEnabled } from "./migrations/81-enable-desktop-sharing-if-biometrics-enabled";
+import { RemoveBrowserIntegrationEnabled } from "./migrations/82-remove-browser-integration-enabled";
 import { MoveBrowserSettingsToGlobal } from "./migrations/9-move-browser-settings-to-global";
 import { MinVersionMigrator } from "./migrations/min-version";
 
 export const MIN_VERSION = 3;
-export const CURRENT_VERSION = 81;
+export const CURRENT_VERSION = 82;
 export type MinVersion = typeof MIN_VERSION;
 
 export function createMigrationBuilder() {
@@ -166,7 +167,8 @@ export function createMigrationBuilder() {
     .with(MigrateSsoRequiredCache, 77, 78)
     .with(InitializeFeatureFlagOverridesMigrator, 78, 79)
     .with(ConsolidateTrayToRunInBackground, 79, 80)
-    .with(EnableDesktopSharingIfBiometricsEnabled, 80, CURRENT_VERSION);
+    .with(EnableDesktopSharingIfBiometricsEnabled, 80, 81)
+    .with(RemoveBrowserIntegrationEnabled, 81, CURRENT_VERSION);
 }
 
 export async function currentVersion(

--- a/libs/state/src/state-migrations/migrations/82-remove-browser-integration-enabled.spec.ts
+++ b/libs/state/src/state-migrations/migrations/82-remove-browser-integration-enabled.spec.ts
@@ -1,0 +1,38 @@
+import { runMigrator } from "../migration-helper.spec";
+import { IRREVERSIBLE } from "../migrator";
+
+import { RemoveBrowserIntegrationEnabled } from "./82-remove-browser-integration-enabled";
+
+describe("RemoveBrowserIntegrationEnabled", () => {
+  const sut = new RemoveBrowserIntegrationEnabled(81, 82);
+
+  describe("migrate", () => {
+    it("removes the browserIntegrationEnabled key when present and enabled", async () => {
+      const output = await runMigrator(sut, {
+        global_desktopSettings_browserIntegrationEnabled: true,
+      });
+
+      expect(output).toEqual({});
+    });
+
+    it("removes the browserIntegrationEnabled key when present and disabled", async () => {
+      const output = await runMigrator(sut, {
+        global_desktopSettings_browserIntegrationEnabled: false,
+      });
+
+      expect(output).toEqual({});
+    });
+
+    it("does nothing when the key is not present", async () => {
+      const output = await runMigrator(sut, {});
+
+      expect(output).toEqual({});
+    });
+  });
+
+  describe("rollback", () => {
+    it("is irreversible", async () => {
+      await expect(runMigrator(sut, {}, "rollback")).rejects.toThrow(IRREVERSIBLE);
+    });
+  });
+});

--- a/libs/state/src/state-migrations/migrations/82-remove-browser-integration-enabled.ts
+++ b/libs/state/src/state-migrations/migrations/82-remove-browser-integration-enabled.ts
@@ -1,0 +1,25 @@
+import { KeyDefinitionLike, MigrationHelper, StateDefinitionLike } from "../migration-helper";
+import { IRREVERSIBLE, Migrator } from "../migrator";
+
+const DESKTOP_SETTINGS_STATE: StateDefinitionLike = { name: "desktopSettings" };
+
+const BROWSER_INTEGRATION_ENABLED_KEY: KeyDefinitionLike = {
+  key: "browserIntegrationEnabled",
+  stateDefinition: DESKTOP_SETTINGS_STATE,
+};
+
+/**
+ * Removes the now-unused `browserIntegrationEnabled` desktop setting. Browser integration is always
+ * enabled, so the persisted value is orphaned and is removed here.
+ */
+export class RemoveBrowserIntegrationEnabled extends Migrator<81, 82> {
+  async migrate(helper: MigrationHelper): Promise<void> {
+    if ((await helper.getFromGlobal<boolean>(BROWSER_INTEGRATION_ENABLED_KEY)) != null) {
+      await helper.removeFromGlobal(BROWSER_INTEGRATION_ENABLED_KEY);
+    }
+  }
+
+  rollback(helper: MigrationHelper): Promise<void> {
+    throw IRREVERSIBLE;
+  }
+}


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-39974

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

The introduction of shared unlock removed the browser integration setting, but not the state (incorrectly). Further, it conflicted with the addition of the new desktop settings dialog. This leads to a situation, where currently only the new desktop settings dialog component did not regress, and correctly allows enabling biometric unlock.

This PR fully removes the setting in UI and in state and enables the setting always.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
