### PR TITLE
Revert "[Shared Unlock] [PM-34508] Default enable native messaging pe…

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -3096,6 +3096,18 @@
   "biometricsFailedDesc": {
     "message": "Biometrics cannot be completed, consider using a master password or logging out. If this persists, please contact Bitwarden support."
   },
+  "nativeMessaginPermissionErrorTitle": {
+    "message": "Permission not provided"
+  },
+  "nativeMessaginPermissionErrorDesc": {
+    "message": "Without permission to communicate with the Bitwarden Desktop Application we cannot provide biometrics in the browser extension. Please try again."
+  },
+  "nativeMessaginPermissionSidebarTitle": {
+    "message": "Permission request error"
+  },
+  "nativeMessaginPermissionSidebarDesc": {
+    "message": "This action cannot be done in the sidebar, please retry the action in the popup or popout."
+  },
   "personalOwnershipSubmitError": {
     "message": "Due to an Enterprise Policy, you are restricted from saving items to your personal vault. Change the Ownership option to an organization and choose from available collections."
   },

--- a/apps/browser/src/auth/popup/settings/account-security.component.spec.ts
+++ b/apps/browser/src/auth/popup/settings/account-security.component.spec.ts
@@ -43,6 +43,8 @@ import {
 } from "@bitwarden/key-management";
 import { SessionTimeoutSettingsComponent } from "@bitwarden/key-management-ui";
 
+import { BrowserApi } from "../../../platform/browser/browser-api";
+import BrowserPopupUtils from "../../../platform/browser/browser-popup-utils";
 import { PopOutComponent } from "../../../platform/popup/components/pop-out.component";
 import { PopupRouterCacheService } from "../../../platform/popup/view-cache/popup-router-cache.service";
 
@@ -378,8 +380,12 @@ describe("AccountSecurityComponent", () => {
   });
 
   describe("updateBiometric", () => {
+    let browserApiSpy: jest.SpyInstance;
+
     beforeEach(() => {
       policyService.policiesByType$.mockReturnValue(of([null]));
+      browserApiSpy = jest.spyOn(BrowserApi, "requestPermission");
+      browserApiSpy.mockResolvedValue(true);
     });
 
     describe("updating to false", () => {
@@ -402,7 +408,69 @@ describe("AccountSecurityComponent", () => {
         trySetupBiometricsSpy = jest.spyOn(component, "trySetupBiometrics");
       });
 
-      it("refreshes additional keys and attempts to setup biometrics", async () => {
+      it("displays permission error dialog when nativeMessaging permission is not granted", async () => {
+        browserApiSpy.mockResolvedValue(false);
+
+        await component.ngOnInit();
+        await component.updateBiometric(true);
+
+        expect(dialogService.openSimpleDialog).toHaveBeenCalledWith({
+          title: { key: "nativeMessaginPermissionErrorTitle" },
+          content: { key: "nativeMessaginPermissionErrorDesc" },
+          acceptButtonText: { key: "ok" },
+          cancelButtonText: null,
+          type: "danger",
+        });
+        expect(component.form.controls.biometric.value).toBe(false);
+        expect(trySetupBiometricsSpy).not.toHaveBeenCalled();
+      });
+
+      it("displays a specific sidebar dialog when nativeMessaging permissions throws an error on firefox + sidebar", async () => {
+        browserApiSpy.mockRejectedValue(new Error("Permission denied"));
+        platformUtilsService.isFirefox.mockReturnValue(true);
+        jest.spyOn(BrowserPopupUtils, "inSidebar").mockReturnValue(true);
+
+        await component.ngOnInit();
+        await component.updateBiometric(true);
+
+        expect(dialogService.openSimpleDialog).toHaveBeenCalledWith({
+          title: { key: "nativeMessaginPermissionSidebarTitle" },
+          content: { key: "nativeMessaginPermissionSidebarDesc" },
+          acceptButtonText: { key: "ok" },
+          cancelButtonText: null,
+          type: "info",
+        });
+        expect(component.form.controls.biometric.value).toBe(false);
+        expect(trySetupBiometricsSpy).not.toHaveBeenCalled();
+      });
+
+      test.each([
+        [false, false],
+        [false, true],
+        [true, false],
+      ])(
+        "displays a generic dialog when nativeMessaging permissions throws an error and isFirefox is %s and onSidebar is %s",
+        async (isFirefox, inSidebar) => {
+          browserApiSpy.mockRejectedValue(new Error("Permission denied"));
+          platformUtilsService.isFirefox.mockReturnValue(isFirefox);
+          jest.spyOn(BrowserPopupUtils, "inSidebar").mockReturnValue(inSidebar);
+
+          await component.ngOnInit();
+          await component.updateBiometric(true);
+
+          expect(dialogService.openSimpleDialog).toHaveBeenCalledWith({
+            title: { key: "nativeMessaginPermissionErrorTitle" },
+            content: { key: "nativeMessaginPermissionErrorDesc" },
+            acceptButtonText: { key: "ok" },
+            cancelButtonText: null,
+            type: "danger",
+          });
+          expect(component.form.controls.biometric.value).toBe(false);
+          expect(trySetupBiometricsSpy).not.toHaveBeenCalled();
+        },
+      );
+
+      it("refreshes additional keys and attempts to setup biometrics when enabled with nativeMessaging permission", async () => {
         const setupBiometricsResult = true;
         trySetupBiometricsSpy.mockResolvedValue(setupBiometricsResult);
 
@@ -449,6 +517,12 @@ describe("AccountSecurityComponent", () => {
   });
 
   describe("biometrics polling timer", () => {
+    let browserApiSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      browserApiSpy = jest.spyOn(BrowserApi, "permissionsGranted");
+    });
+
     afterEach(() => {
       component.ngOnDestroy();
     });
@@ -471,8 +545,35 @@ describe("AccountSecurityComponent", () => {
       expect(component.form.controls.biometric.disabled).toBe(false);
     }));
 
+    it("skips status check when nativeMessaging permission is not granted and not Safari", fakeAsync(async () => {
+      biometricsService.canEnableBiometricUnlock.mockResolvedValue(true);
+      browserApiSpy.mockResolvedValue(false);
+      platformUtilsService.isSafari.mockReturnValue(false);
+
+      await component.ngOnInit();
+      tick();
+
+      expect(biometricsService.getBiometricsStatusForUser).not.toHaveBeenCalled();
+      expect(component.biometricUnavailabilityReason).toBeUndefined();
+    }));
+
+    it("checks biometrics status when nativeMessaging permission is granted", fakeAsync(async () => {
+      biometricsService.canEnableBiometricUnlock.mockResolvedValue(true);
+      browserApiSpy.mockResolvedValue(true);
+      platformUtilsService.isSafari.mockReturnValue(false);
+      biometricsService.getBiometricsStatusForUser.mockResolvedValue(
+        BiometricsStatus.DesktopDisconnected,
+      );
+
+      await component.ngOnInit();
+      tick();
+
+      expect(biometricsService.getBiometricsStatusForUser).toHaveBeenCalledWith(mockUserId);
+    }));
+
     it("should check status on Safari", fakeAsync(async () => {
       biometricsService.canEnableBiometricUnlock.mockResolvedValue(true);
+      browserApiSpy.mockResolvedValue(false);
       platformUtilsService.isSafari.mockReturnValue(true);
       biometricsService.getBiometricsStatusForUser.mockResolvedValue(
         BiometricsStatus.DesktopDisconnected,
@@ -501,6 +602,7 @@ describe("AccountSecurityComponent", () => {
       "sets expected unavailability reason for %s status when biometric not available",
       fakeAsync(async (biometricStatus: BiometricsStatus, expected: string) => {
         biometricsService.canEnableBiometricUnlock.mockResolvedValue(false);
+        browserApiSpy.mockResolvedValue(true);
         platformUtilsService.isSafari.mockReturnValue(false);
         biometricsService.getBiometricsStatusForUser.mockResolvedValue(biometricStatus);
 
@@ -513,6 +615,7 @@ describe("AccountSecurityComponent", () => {
 
     it("should not set unavailability reason for error statuses when biometric is available", fakeAsync(async () => {
       biometricsService.canEnableBiometricUnlock.mockResolvedValue(true);
+      browserApiSpy.mockResolvedValue(true);
       platformUtilsService.isSafari.mockReturnValue(false);
       biometricsService.getBiometricsStatusForUser.mockResolvedValue(
         BiometricsStatus.DesktopDisconnected,

--- a/apps/browser/src/auth/popup/settings/account-security.component.ts
+++ b/apps/browser/src/auth/popup/settings/account-security.component.ts
@@ -69,6 +69,7 @@ import { SessionTimeoutSettingsComponent } from "@bitwarden/key-management-ui";
 
 import { BiometricErrors, BiometricErrorTypes } from "../../../models/biometricErrors";
 import { BrowserApi } from "../../../platform/browser/browser-api";
+import BrowserPopupUtils from "../../../platform/browser/browser-popup-utils";
 import { PopOutComponent } from "../../../platform/popup/components/pop-out.component";
 import { PopupHeaderComponent } from "../../../platform/popup/layout/popup-header.component";
 import { PopupPageComponent } from "../../../platform/popup/layout/popup-page.component";
@@ -230,6 +231,14 @@ export class AccountSecurityComponent implements OnInit, OnDestroy {
             this.form.controls.biometric.enable({ emitEvent: false });
           }
 
+          // Biometrics status shouldn't be checked if permissions are needed.
+          const needsPermissionPrompt =
+            !(await BrowserApi.permissionsGranted(["nativeMessaging"])) &&
+            !this.platformUtilsService.isSafari();
+          if (needsPermissionPrompt) {
+            return;
+          }
+
           const status = await this.biometricsService.getBiometricsStatusForUser(activeAccount.id);
           if (status === BiometricsStatus.DesktopDisconnected && !biometricSettingAvailable) {
             this.biometricUnavailabilityReason = this.i18nService.t(
@@ -372,6 +381,40 @@ export class AccountSecurityComponent implements OnInit, OnDestroy {
   async updateBiometric(enabled: boolean) {
     const userId = await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId));
     if (enabled) {
+      let granted;
+      try {
+        granted = await BrowserApi.requestPermission({ permissions: ["nativeMessaging"] });
+      } catch (e) {
+        // eslint-disable-next-line
+        console.error(e);
+
+        if (this.platformUtilsService.isFirefox() && BrowserPopupUtils.inSidebar(window)) {
+          await this.dialogService.openSimpleDialog({
+            title: { key: "nativeMessaginPermissionSidebarTitle" },
+            content: { key: "nativeMessaginPermissionSidebarDesc" },
+            acceptButtonText: { key: "ok" },
+            cancelButtonText: null,
+            type: "info",
+          });
+
+          this.form.controls.biometric.setValue(false);
+          return;
+        }
+      }
+
+      if (!granted) {
+        await this.dialogService.openSimpleDialog({
+          title: { key: "nativeMessaginPermissionErrorTitle" },
+          content: { key: "nativeMessaginPermissionErrorDesc" },
+          acceptButtonText: { key: "ok" },
+          cancelButtonText: null,
+          type: "danger",
+        });
+
+        this.form.controls.biometric.setValue(false);
+        return;
+      }
+
       try {
         await this.keyService.refreshAdditionalKeys(userId);
 

--- a/apps/browser/src/background/native-messaging.background.spec.ts
+++ b/apps/browser/src/background/native-messaging.background.spec.ts
@@ -74,6 +74,7 @@ describe("NativeMessagingBackground", () => {
     accountService.activeAccount$ = of(mockAccount);
     platformUtilsService.isSafari.mockReturnValue(false);
 
+    (BrowserApi.permissionsGranted as jest.Mock).mockResolvedValue(true);
     (BrowserApi.connectNative as jest.Mock).mockReturnValue({
       onMessage: {
         addListener: jest.fn(),
@@ -107,6 +108,17 @@ describe("NativeMessagingBackground", () => {
   });
 
   describe("connect", () => {
+    it("logs warning and returns if native messaging permission is missing", async () => {
+      (BrowserApi.permissionsGranted as jest.Mock).mockResolvedValue(false);
+
+      await sut.connect();
+
+      expect(logService.warning).toHaveBeenCalledWith(
+        "[Native Messaging IPC] Native messaging permission is missing for biometrics",
+      );
+      expect(sut.connected).toBe(false);
+    });
+
     it("connects immediately for Safari", async () => {
       platformUtilsService.isSafari.mockReturnValue(true);
 

--- a/apps/browser/src/background/nativeMessaging.background.ts
+++ b/apps/browser/src/background/nativeMessaging.background.ts
@@ -88,9 +88,24 @@ export class NativeMessagingBackground {
     private logService: LogService,
     private biometricStateService: BiometricStateService,
     private accountService: AccountService,
-  ) {}
+  ) {
+    if (chrome?.permissions?.onAdded) {
+      // Reload extension to activate nativeMessaging
+      chrome.permissions.onAdded.addListener((permissions) => {
+        if (permissions.permissions?.includes("nativeMessaging")) {
+          BrowserApi.reloadExtension();
+        }
+      });
+    }
+  }
 
   async connect() {
+    if (!(await BrowserApi.permissionsGranted(["nativeMessaging"]))) {
+      this.logService.warning(
+        "[Native Messaging IPC] Native messaging permission is missing for biometrics",
+      );
+      return;
+    }
     if (this.connected || this.connecting) {
       return;
     }

--- a/apps/browser/src/key-management/biometrics/background-browser-biometrics.service.ts
+++ b/apps/browser/src/key-management/biometrics/background-browser-biometrics.service.ts
@@ -27,6 +27,7 @@ import {
 } from "@bitwarden/sdk-internal";
 
 import { NativeMessagingBackground } from "../../background/nativeMessaging.background";
+import { BrowserApi } from "../../platform/browser/browser-api";
 
 export class BackgroundBrowserBiometricsService extends BiometricsService {
   BACKGROUND_POLLING_INTERVAL = 30_000;
@@ -103,6 +104,10 @@ export class BackgroundBrowserBiometricsService extends BiometricsService {
   }
 
   async getBiometricsStatus(): Promise<BiometricsStatus> {
+    if (!(await BrowserApi.permissionsGranted(["nativeMessaging"]))) {
+      return BiometricsStatus.NativeMessagingPermissionMissing;
+    }
+
     if (await this.configService().getFeatureFlag(FeatureFlag.BiometricsSDKIPC)) {
       if (!this.nativeMessagingBackground().connected) {
         return BiometricsStatus.DesktopDisconnected;

--- a/apps/browser/src/key-management/biometrics/foreground-browser-biometrics.spec.ts
+++ b/apps/browser/src/key-management/biometrics/foreground-browser-biometrics.spec.ts
@@ -1,3 +1,7 @@
+import { mock } from "jest-mock-extended";
+
+import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
+
 import { BrowserApi } from "../../platform/browser/browser-api";
 
 import { ForegroundBrowserBiometricsService } from "./foreground-browser-biometrics";
@@ -5,27 +9,47 @@ import { ForegroundBrowserBiometricsService } from "./foreground-browser-biometr
 jest.mock("../../platform/browser/browser-api", () => ({
   BrowserApi: {
     sendMessageWithResponse: jest.fn(),
+    permissionsGranted: jest.fn(),
   },
 }));
 
 describe("foreground browser biometrics service tests", function () {
+  const platformUtilsService = mock<PlatformUtilsService>();
+
   beforeEach(() => {
     jest.resetAllMocks();
   });
 
   describe("canEnableBiometricUnlock", () => {
-    const table: [boolean, boolean][] = [
-      [false, false],
-      [true, true],
+    const table: [boolean, boolean, boolean, boolean][] = [
+      // canEnableBiometricUnlock from background, native permission granted, isSafari, expected
+
+      // needs permission prompt; always allowed
+      [true, false, false, true],
+      [false, false, false, true],
+
+      // is safari; depends on the status that the background service reports
+      [false, false, true, false],
+      [true, false, true, true],
+
+      // native permissions granted; depends on the status that the background service reports
+      [false, true, false, false],
+      [true, true, false, true],
+
+      // should never happen since safari does not use the permissions
+      [false, true, true, false],
+      [true, true, true, true],
     ];
     test.each(table)(
-      "canEnableBiometric: %s, expected: %s",
-      async (canEnableBiometricUnlockBackground, expected) => {
-        const service = new ForegroundBrowserBiometricsService();
+      "canEnableBiometric: %s, native permission granted: %s, isSafari: %s, expected: %s",
+      async (canEnableBiometricUnlockBackground, granted, isSafari, expected) => {
+        const service = new ForegroundBrowserBiometricsService(platformUtilsService);
 
+        (BrowserApi.permissionsGranted as jest.Mock).mockResolvedValue(granted);
         (BrowserApi.sendMessageWithResponse as jest.Mock).mockResolvedValue({
           result: canEnableBiometricUnlockBackground,
         });
+        platformUtilsService.isSafari.mockReturnValue(isSafari);
 
         const result = await service.canEnableBiometricUnlock();
 

--- a/apps/browser/src/key-management/biometrics/foreground-browser-biometrics.ts
+++ b/apps/browser/src/key-management/biometrics/foreground-browser-biometrics.ts
@@ -1,3 +1,4 @@
+import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
 import { UserId } from "@bitwarden/common/types/guid";
 import { UserKey } from "@bitwarden/common/types/key";
@@ -8,7 +9,7 @@ import { BrowserApi } from "../../platform/browser/browser-api";
 export class ForegroundBrowserBiometricsService extends BiometricsService {
   shouldAutopromptNow = true;
 
-  constructor() {
+  constructor(private platformUtilsService: PlatformUtilsService) {
     super();
   }
 
@@ -62,12 +63,18 @@ export class ForegroundBrowserBiometricsService extends BiometricsService {
   }
 
   async canEnableBiometricUnlock(): Promise<boolean> {
+    const needsPermissionPrompt =
+      !(await BrowserApi.permissionsGranted(["nativeMessaging"])) &&
+      !this.platformUtilsService.isSafari();
     return (
-      await BrowserApi.sendMessageWithResponse<{
-        result: boolean;
-        error: string;
-      }>(BiometricsCommands.CanEnableBiometricUnlock)
-    ).result;
+      needsPermissionPrompt ||
+      (
+        await BrowserApi.sendMessageWithResponse<{
+          result: boolean;
+          error: string;
+        }>(BiometricsCommands.CanEnableBiometricUnlock)
+      ).result
+    );
   }
   async setBiometricProtectedUnlockKeyForUser(
     userId: UserId,

--- a/apps/browser/src/manifest.json
+++ b/apps/browser/src/manifest.json
@@ -51,7 +51,6 @@
     "clipboardWrite",
     "contextMenus",
     "idle",
-    "nativeMessaging",
     "storage",
     "tabs",
     "unlimitedStorage",
@@ -76,8 +75,8 @@
     "webRequest",
     "webRequestBlocking"
   ],
-  "optional_permissions": ["privacy"],
-  "__firefox__optional_permissions": ["privacy"],
+  "optional_permissions": ["nativeMessaging", "privacy"],
+  "__firefox__optional_permissions": ["nativeMessaging", "privacy"],
   "__safari__optional_permissions": null,
   "content_security_policy": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'",
   "sandbox": {

--- a/apps/browser/src/manifest.v3.json
+++ b/apps/browser/src/manifest.v3.json
@@ -53,7 +53,6 @@
     "clipboardWrite",
     "contextMenus",
     "idle",
-    "nativeMessaging",
     "offscreen",
     "scripting",
     "sidePanel",
@@ -72,7 +71,6 @@
     "clipboardWrite",
     "contextMenus",
     "idle",
-    "nativeMessaging",
     "scripting",
     "storage",
     "tabs",
@@ -99,8 +97,8 @@
     "webRequest",
     "webRequestAuthProvider"
   ],
-  "optional_permissions": ["privacy"],
-  "__firefox__optional_permissions": ["privacy"],
+  "optional_permissions": ["nativeMessaging", "privacy"],
+  "__firefox__optional_permissions": ["nativeMessaging", "privacy"],
   "__safari__optional_permissions": null,
   "host_permissions": ["https://*/*", "http://*/*"],
   "content_security_policy": {

--- a/apps/browser/src/popup/services/services.module.ts
+++ b/apps/browser/src/popup/services/services.module.ts
@@ -383,7 +383,7 @@ const safeProviders: SafeProvider[] = [
   safeProvider({
     provide: BiometricsService,
     useClass: ForegroundBrowserBiometricsService,
-    deps: [],
+    deps: [PlatformUtilsService],
   }),
   safeProvider({
     provide: SyncService,

--- a/apps/desktop/src/app/accounts/settings.component.spec.ts
+++ b/apps/desktop/src/app/accounts/settings.component.spec.ts
@@ -792,6 +792,7 @@ describe("SettingsComponent", () => {
         BiometricsStatus.DesktopDisconnected,
         BiometricsStatus.NotEnabledLocally,
         BiometricsStatus.NotEnabledInConnectedDesktopApp,
+        BiometricsStatus.NativeMessagingPermissionMissing,
       ])(
         `disables biometric when biometrics status check for the user returns %s`,
         async (status) => {

--- a/libs/key-management/src/biometrics/biometrics-status.ts
+++ b/libs/key-management/src/biometrics/biometrics-status.ts
@@ -19,4 +19,6 @@ export enum BiometricsStatus {
   NotEnabledLocally,
   /** Only on browser extension; Biometrics is not enabled in the desktop app */
   NotEnabledInConnectedDesktopApp,
+  /** Browser extension does not have the permission to talk to the desktop app */
+  NativeMessagingPermissionMissing,
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://github.com/bitwarden/clients/pull/21559

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Reverts the changes on main for the native messaging permission, just like we did in the hotfix.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
