### PR TITLE
[PM-39977] Fix broken shared unlock for browser-desktop in non-dev mode

### DIFF
--- a/apps/browser/src/platform/ipc/ipc-background.service.ts
+++ b/apps/browser/src/platform/ipc/ipc-background.service.ts
@@ -17,6 +17,7 @@ import {
 } from "@bitwarden/sdk-internal";
 
 import { BrowserApi } from "../browser/browser-api";
+import { version } from "os";
 
 // The interval at which the browser extension in the background tries to reconnect to the desktop app.
 const RECONNECTION_INTERVAL_MS = 10_000;
@@ -181,15 +182,19 @@ export class IpcBackgroundService extends IpcService {
         this.scheduleReconnect();
       });
 
-      // Ensure the desktop app is properly connected
-      const version = await ipcRequestDiscover(
-        this.client,
-        "DesktopRenderer",
-        AbortSignal.timeout(DISCOVER_MESSAGE_TIMEOUT_MS),
-      );
-      this.logService.info(
-        `[IPC] Connected to Bitwarden Desktop App with version ${version.version}`,
-      );
+      try {
+        // Ensure the desktop app is properly connected
+        const version = await ipcRequestDiscover(
+          this.client,
+          "DesktopRenderer",
+          AbortSignal.timeout(DISCOVER_MESSAGE_TIMEOUT_MS),
+        );
+        this.logService.info(
+          `[IPC] Connected to Bitwarden Desktop App with version ${version.version}`,
+        );
+      } catch (e) {
+        this.logService.error("[IPC] Failed to handshake with Bitwarden Desktop App", e);
+      }
     } catch (e) {
       this.logService.error("[IPC] Failed to connect to Bitwarden Desktop App", e);
       // Explicitly disconnect the port to avoid leaking the native port and its spawned

--- a/apps/browser/src/platform/ipc/ipc-background.service.ts
+++ b/apps/browser/src/platform/ipc/ipc-background.service.ts
@@ -17,7 +17,6 @@ import {
 } from "@bitwarden/sdk-internal";
 
 import { BrowserApi } from "../browser/browser-api";
-import { version } from "os";
 
 // The interval at which the browser extension in the background tries to reconnect to the desktop app.
 const RECONNECTION_INTERVAL_MS = 10_000;

--- a/apps/desktop/src/platform/services/ipc-renderer.service.ts
+++ b/apps/desktop/src/platform/services/ipc-renderer.service.ts
@@ -74,11 +74,9 @@ export class IpcRendererService extends IpcService {
 
       await super.initWithClient(IpcClient.newWithSdkInMemorySessions(this.communicationBackend));
 
-      if (this.platformUtilsService.isDev()) {
-        await ipcRegisterDiscoverHandler(this.client, {
-          version: await this.platformUtilsService.getApplicationVersion(),
-        });
-      }
+      await ipcRegisterDiscoverHandler(this.client, {
+        version: await this.platformUtilsService.getApplicationVersion(),
+      });
     } catch (e) {
       this.logService.error("[IPC] Initialization failed", e);
     }

--- a/apps/desktop/src/platform/services/ipc.main.service.ts
+++ b/apps/desktop/src/platform/services/ipc.main.service.ts
@@ -20,7 +20,6 @@ import {
 
 import { NativeMessagingMain } from "../../main/native-messaging.main";
 import { WindowMain } from "../../main/window.main";
-import { isDev } from "../../utils";
 
 export class IpcMainService extends IpcService {
   private communicationBackend?: IpcCommunicationBackend;
@@ -173,11 +172,9 @@ export class IpcMainService extends IpcService {
 
       await super.initWithClient(IpcClient.newWithSdkInMemorySessions(this.communicationBackend));
 
-      if (isDev()) {
-        await ipcRegisterDiscoverHandler(this.client, {
-          version: await this.app.getVersion(),
-        });
-      }
+      await ipcRegisterDiscoverHandler(this.client, {
+        version: this.app.getVersion(),
+      });
     } catch (e) {
       this.logService.error("[IPC] Initialization failed", e);
     }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-39977

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Shared unlock, when connecting to from browser to desktop, confirms that the connection works correctly by doing a version discovery. If it does not work, then the ipc connection gets torn down. In non-dev mode this currently leads to shared unlock being unusable.

This fixes it by both default enabling the version discovery handler. This is already the case for web, and it is useful to have in the logs. Secondly, it makes the discovery request non-breaking for the connection. There are still other unresolved cases in which the discovery request may fail, such as when the browser connected to the desktop app, and the desktop app restarts, the browser may have an old crypto state that only gets wiped *after* the new version discovery request is sent. There is a separate PR set for this.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
