### PR TITLE
[CL-1258] Add NumberInput story to bit-form-field

### DIFF
--- a/libs/components/src/form-field/form-field.stories.ts
+++ b/libs/components/src/form-field/form-field.stories.ts
@@ -84,6 +84,7 @@ const fb = new UntypedFormBuilder();
 const formObj = fb.group({
   test: [""],
   required: ["", [Validators.required]],
+  amount: [null],
 });
 
 const defaultFormObj = fb.group({
@@ -538,6 +539,24 @@ export const FileInput: Story = {
       </form>
     `,
   }),
+};
+
+export const NumberInput: Story = {
+  render: (args) => ({
+    props: {
+      formObj: formObj,
+      ...args,
+    },
+    template: /*html*/ `
+      <bit-form-field [formGroup]="formObj">
+        <bit-label>Amount</bit-label>
+        <input bitInput type="number" formControlName="amount" placeholder="0" />
+        <span bitSuffix>USD</span>
+        <bit-hint>Enter a numeric value.</bit-hint>
+      </bit-form-field>
+    `,
+  }),
+  args: {},
 };
 
 export const Textarea: Story = {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/CL-1258

## 📔 Objective

Adds a `NumberInput` Storybook story to the `bit-form-field` component library. There was no existing story demonstrating a numeric (`type="number"`) input within a form field, so this fills that gap.

The story renders a `bit-form-field` with a `type="number"` input bound to a reactive form control, a `bitSuffix` unit label, and a hint.

## 📸 Screenshots

<!-- Storybook: Component Library / Form / Field / Number Input -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!--
Please use the following emojis to indicate the priority of comments in the review.
- :+1: (`:+1:`) or no emoji: Non-blocking comment.
- :question: (`:question:`): Blocking question — must be resolved before approval.
- :framed_picture: (`:framed_picture:`): Blocking (framework/architecture) — must be resolved before approval.
-->