### PR TITLE
[PM-39825] Fix URI reordering, drag handle alignment

### DIFF
--- a/libs/components/src/tw-theme.css
+++ b/libs/components/src/tw-theme.css
@@ -709,3 +709,16 @@
     display: none;
   }
 }
+
+/**
+* The CDK drag preview is rendered as a native popover attached to <body>, outside the
+* app content that normally provides the themed text color and background. Without these
+* overrides it picks up the popover UA styles (Canvas/CanvasText and overflow: auto),
+* which render as a white box with black text and scrollbars in dark mode.
+* Kept outside @layer components so Tailwind does not tree-shake the selector.
+*/
+.cdk-drag-preview {
+  background-color: rgb(var(--color-background));
+  color: rgb(var(--color-text-main));
+  overflow: hidden;
+}

--- a/libs/components/src/tw-theme.css
+++ b/libs/components/src/tw-theme.css
@@ -718,7 +718,7 @@
 * Kept outside @layer components so Tailwind does not tree-shake the selector.
 */
 .cdk-drag-preview {
-  background-color: rgb(var(--color-background));
+  background-color: rgb(var(--color-bg-primary));
   color: rgb(var(--color-text-main));
   overflow: hidden;
 }

--- a/libs/components/src/tw-theme.css
+++ b/libs/components/src/tw-theme.css
@@ -709,16 +709,3 @@
     display: none;
   }
 }
-
-/**
-* The CDK drag preview is rendered as a native popover attached to <body>, outside the
-* app content that normally provides the themed text color and background. Without these
-* overrides it picks up the popover UA styles (Canvas/CanvasText and overflow: auto),
-* which render as a white box with black text and scrollbars in dark mode.
-* Kept outside @layer components so Tailwind does not tree-shake the selector.
-*/
-.cdk-drag-preview {
-  background-color: rgb(var(--color-bg-primary));
-  color: rgb(var(--color-text-main));
-  overflow: hidden;
-}

--- a/libs/vault/src/cipher-form/components/autofill-options/autofill-options.component.html
+++ b/libs/vault/src/cipher-form/components/autofill-options/autofill-options.component.html
@@ -7,7 +7,7 @@
 
   <bit-card cdkDropList (cdkDropListDropped)="onUriItemDrop($event)">
     <ng-container formArrayName="uris">
-      @for (uri of uriControls; track $index; let i = $index) {
+      @for (uri of uriControls; track uri; let i = $index) {
         <vault-autofill-uri-option
           cdkDrag
           [cdkDragDisabled]="uriControls.length <= 1 || autofillOptionsForm.disabled"

--- a/libs/vault/src/cipher-form/components/autofill-options/uri-option.component.html
+++ b/libs/vault/src/cipher-form/components/autofill-options/uri-option.component.html
@@ -1,62 +1,60 @@
 <ng-container [formGroup]="uriForm">
-  <div class="tw-mb-4 tw-pt-1">
-    <div class="tw-flex tw-pt-2" [class.!tw-mb-1]="showMatchDetection">
-      <bit-form-field disableMargin class="tw-flex-1 !tw-pt-0">
-        <bit-label>{{ uriLabel }}</bit-label>
-        <input bitInput formControlName="uri" #uriInput />
+  <div class="tw-flex tw-flex-1" [class.!tw-mb-1]="showMatchDetection">
+    <bit-form-field disableMargin class="tw-flex-1 !tw-pt-0">
+      <bit-label>{{ uriLabel }}</bit-label>
+      <input bitInput formControlName="uri" #uriInput />
+      <button
+        type="button"
+        [bitIconButton]="showMatchDetection ? 'bwi-cog-f' : 'bwi-cog'"
+        bitSuffix
+        [label]="toggleTitle"
+        (click)="toggleMatchDetection()"
+        data-testid="toggle-match-detection-button"
+      ></button>
+      @if (canRemove) {
         <button
           type="button"
-          [bitIconButton]="showMatchDetection ? 'bwi-cog-f' : 'bwi-cog'"
+          bitIconButton="bwi-minus-circle"
+          buttonType="dangerGhost"
           bitSuffix
-          [label]="toggleTitle"
-          (click)="toggleMatchDetection()"
-          data-testid="toggle-match-detection-button"
+          [label]="'deleteWebsite' | i18n"
+          (click)="removeUri()"
+          data-testid="remove-uri-button"
         ></button>
-        @if (canRemove) {
-          <button
-            type="button"
-            bitIconButton="bwi-minus-circle"
-            buttonType="dangerGhost"
-            bitSuffix
-            [label]="'deleteWebsite' | i18n"
-            (click)="removeUri()"
-            data-testid="remove-uri-button"
-          ></button>
-        }
-      </bit-form-field>
-      @if (canReorder) {
-        <div class="tw-flex tw-items-center tw-ml-1.5 tw-self-end tw-min-h-10">
-          <button
-            role="application"
-            type="button"
-            bitIconButton="bwi-drag-and-drop"
-            class="!tw-py-0 !tw-px-1"
-            cdkDragHandle
-            [label]="'reorderToggleButton' | i18n: uriLabel"
-            (keydown)="handleKeydown($event)"
-            data-testid="reorder-toggle-button"
-          ></button>
-        </div>
       }
-    </div>
-    @if (showMatchDetection) {
-      <bit-form-field class="!tw-mb-5">
-        <bit-label>{{ "matchDetection" | i18n }}</bit-label>
-        <bit-select formControlName="matchDetection" #matchDetectionSelect>
-          @for (o of uriMatchOptions; track o.value) {
-            <bit-option [label]="o.label" [value]="o.value" [disabled]="o.disabled"></bit-option>
-          }
-        </bit-select>
-        @if (getMatchHints(); as hints) {
-          <bit-hint>
-            {{ hints[0] | i18n }}
-            @if (hints.length > 1) {
-              <b>{{ "warningCapitalized" | i18n }}:</b>
-              {{ hints[1] | i18n }}
-            }
-          </bit-hint>
-        }
-      </bit-form-field>
+    </bit-form-field>
+    @if (canReorder) {
+      <div class="tw-flex tw-items-center tw-ml-1.5 tw-self-end tw-min-h-10">
+        <button
+          role="application"
+          type="button"
+          bitIconButton="bwi-drag-and-drop"
+          class="!tw-py-0 !tw-px-1"
+          cdkDragHandle
+          [label]="'reorderToggleButton' | i18n: uriLabel"
+          (keydown)="handleKeydown($event)"
+          data-testid="reorder-toggle-button"
+        ></button>
+      </div>
     }
   </div>
+  @if (showMatchDetection) {
+    <bit-form-field class="!tw-mb-0">
+      <bit-label>{{ "matchDetection" | i18n }}</bit-label>
+      <bit-select formControlName="matchDetection" #matchDetectionSelect>
+        @for (o of uriMatchOptions; track o.value) {
+          <bit-option [label]="o.label" [value]="o.value" [disabled]="o.disabled"></bit-option>
+        }
+      </bit-select>
+      @if (getMatchHints(); as hints) {
+        <bit-hint>
+          {{ hints[0] | i18n }}
+          @if (hints.length > 1) {
+            <b>{{ "warningCapitalized" | i18n }}:</b>
+            {{ hints[1] | i18n }}
+          }
+        </bit-hint>
+      }
+    </bit-form-field>
+  }
 </ng-container>

--- a/libs/vault/src/cipher-form/components/autofill-options/uri-option.component.html
+++ b/libs/vault/src/cipher-form/components/autofill-options/uri-option.component.html
@@ -25,7 +25,7 @@
         }
       </bit-form-field>
       @if (canReorder) {
-        <div class="tw-flex tw-items-center tw-ml-1.5">
+        <div class="tw-flex tw-items-center tw-ml-1.5 tw-self-end tw-min-h-10">
           <button
             role="application"
             type="button"

--- a/libs/vault/src/cipher-form/components/autofill-options/uri-option.component.ts
+++ b/libs/vault/src/cipher-form/components/autofill-options/uri-option.component.ts
@@ -43,6 +43,10 @@ import { AdvancedUriOptionDialogComponent } from "./advanced-uri-option-dialog.c
 @Component({
   selector: "vault-autofill-uri-option",
   templateUrl: "./uri-option.component.html",
+  host: {
+    class:
+      "tw-flex tw-flex-col tw-p-3 -tw-mx-3 tw-gap-4 tw-bg-background tw-text-main tw-rounded-lg first:-tw-mt-3 last-of-type:tw-mb-0",
+  },
   providers: [
     {
       provide: NG_VALUE_ACCESSOR,


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-39825
https://bitwarden.atlassian.net/browse/PM-38377

## 📔 Objective

Fixes several issues with the URI list in the cipher form's autofill options section:

1. **Reordering didn't take effect on drop.** The `@for` loop tracked `$index`, so Angular never re-rendered rows when the `FormArray` controls moved and the saved order silently diverged from the UI. Tracking by control instance (`track uri`) fixes drag reorder and keyboard reorder.

2. **Removing a URI removed the wrong row.** Same `$index` tracking cause — Angular reused rows by position instead of following controls. The `track uri` change fixes it.

3. **The drag handle wasn't aligned with its row.** It now anchors to the input's centerline (`tw-self-end tw-min-h-10`).

4. **The drag preview showed light-mode colors in dark mode.** The preview is a clone of the row attached to `<body>`, so its inherited colors fell back to UA defaults. The row host now carries its own theme tokens (`tw-bg-background tw-text-main`), so the clone themes itself — no global CSS needed. Row markup was also flattened, with layout moved onto the host.

Verified in Storybook (`Vault/Cipher Form → Edit`): rows reorder in both directions and persist, removing the first of several URIs removes the right one, the handle is centered, and the dark-mode preview renders correct theme tokens.

## 📸 Screenshots

Before

https://github.com/user-attachments/assets/22b88c42-af53-469a-a579-47ffdee00ab2

After


https://github.com/user-attachments/assets/a3eb8bff-5187-4311-8a67-a9646c41380d



