### PR TITLE
Split shared unlock setting into desktop and web, gate on native mess…

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -6742,6 +6742,18 @@
   "sharedUnlockDescriptionFirefox": {
     "message": "Keep your Bitwarden apps in sync. When enabled, unlock state will be shared with the Bitwarden desktop app."
   },
+  "sharedUnlockWithDesktop": {
+    "message": "Share unlock with Desktop"
+  },
+  "sharedUnlockWithDesktopDescription": {
+    "message": "When enabled, unlock state will be shared with the Bitwarden Desktop app."
+  },
+  "sharedUnlockWithWeb": {
+    "message": "Share unlock with web vault"
+  },
+  "sharedUnlockWithWebDescription": {
+    "message": "When enabled, unlock state will be shared with Bitwarden web vaults."
+  },
   "newPermissionNeeded": {
     "message": "New permission needed"
   },

--- a/apps/browser/src/auth/popup/settings/account-security.component.html
+++ b/apps/browser/src/auth/popup/settings/account-security.component.html
@@ -83,20 +83,38 @@
             </bit-form-control>
           }
           @if (sharedUnlockFeatureEnabled$ | async) {
-            <bit-form-control [disableMargin]="true">
-              <input
-                bitCheckbox
-                id="allowSharingUnlockState"
-                type="checkbox"
-                formControlName="allowSharingUnlockState"
-              />
-              <bit-label for="allowSharingUnlockState" class="tw-whitespace-normal">
-                {{ "sharedUnlock" | i18n }}
-              </bit-label>
-              <bit-hint class="tw-text-sm">
-                {{ sharedUnlockDescriptionKey | i18n }}
-              </bit-hint>
-            </bit-form-control>
+            @if (showSharedUnlockWithDesktop) {
+              <bit-form-control>
+                <input
+                  bitCheckbox
+                  id="allowSharingUnlockStateWithDesktop"
+                  type="checkbox"
+                  formControlName="allowSharingUnlockStateWithDesktop"
+                />
+                <bit-label for="allowSharingUnlockStateWithDesktop" class="tw-whitespace-normal">
+                  {{ "sharedUnlockWithDesktop" | i18n }}
+                </bit-label>
+                <bit-hint class="tw-text-sm">
+                  {{ "sharedUnlockWithDesktopDescription" | i18n }}
+                </bit-hint>
+              </bit-form-control>
+            }
+            @if (showSharedUnlockWithWeb) {
+              <bit-form-control [disableMargin]="true">
+                <input
+                  bitCheckbox
+                  id="allowSharingUnlockStateWithWeb"
+                  type="checkbox"
+                  formControlName="allowSharingUnlockStateWithWeb"
+                />
+                <bit-label for="allowSharingUnlockStateWithWeb" class="tw-whitespace-normal">
+                  {{ "sharedUnlockWithWeb" | i18n }}
+                </bit-label>
+                <bit-hint class="tw-text-sm">
+                  {{ "sharedUnlockWithWebDescription" | i18n }}
+                </bit-hint>
+              </bit-form-control>
+            }
           }
         </bit-card>
       </bit-section>

--- a/apps/browser/src/auth/popup/settings/account-security.component.spec.ts
+++ b/apps/browser/src/auth/popup/settings/account-security.component.spec.ts
@@ -168,8 +168,10 @@ describe("AccountSecurityComponent", () => {
     mockI18nService.t.mockImplementation((key) => `${key}-used-i18n`);
     platformUtilsService.isSafari.mockReturnValue(false);
     platformUtilsService.isFirefox.mockReturnValue(false);
-    sharedUnlockSettingsService.allowSharingUnlockState$.mockReturnValue(of(true));
-    sharedUnlockSettingsService.setAllowSharingUnlockState.mockResolvedValue(undefined);
+    sharedUnlockSettingsService.allowSharingUnlockStateWithDesktop$.mockReturnValue(of(false));
+    sharedUnlockSettingsService.allowSharingUnlockStateWithWeb$.mockReturnValue(of(false));
+    sharedUnlockSettingsService.setAllowSharingUnlockStateWithDesktop.mockResolvedValue(undefined);
+    sharedUnlockSettingsService.setAllowSharingUnlockStateWithWeb.mockResolvedValue(undefined);
 
     policyService.policiesByType$.mockReturnValue(of([null]));
 
@@ -197,38 +199,6 @@ describe("AccountSecurityComponent", () => {
     await component.ngOnInit();
 
     await expect(firstValueFrom(component.pinEnabled$)).resolves.toBe(true);
-  });
-
-  describe("shared unlock description", () => {
-    it("uses the Safari-specific description key on Safari", () => {
-      platformUtilsService.isSafari.mockReturnValue(true);
-      platformUtilsService.isFirefox.mockReturnValue(false);
-
-      const safariFixture = TestBed.createComponent(AccountSecurityComponent);
-      const safariComponent = safariFixture.componentInstance;
-
-      expect(safariComponent.sharedUnlockDescriptionKey).toBe("sharedUnlockDescriptionSafari");
-    });
-
-    it("uses the Firefox-specific description key on Firefox", () => {
-      platformUtilsService.isSafari.mockReturnValue(false);
-      platformUtilsService.isFirefox.mockReturnValue(true);
-
-      const firefoxFixture = TestBed.createComponent(AccountSecurityComponent);
-      const firefoxComponent = firefoxFixture.componentInstance;
-
-      expect(firefoxComponent.sharedUnlockDescriptionKey).toBe("sharedUnlockDescriptionFirefox");
-    });
-
-    it("uses the generic description key on non-Safari and non-Firefox browsers", () => {
-      platformUtilsService.isSafari.mockReturnValue(false);
-      platformUtilsService.isFirefox.mockReturnValue(false);
-
-      const defaultFixture = TestBed.createComponent(AccountSecurityComponent);
-      const defaultComponent = defaultFixture.componentInstance;
-
-      expect(defaultComponent.sharedUnlockDescriptionKey).toBe("sharedUnlockDescription");
-    });
   });
 
   it("pin enabled when RemoveUnlockWithPin policy is disabled", async () => {
@@ -549,6 +519,101 @@ describe("AccountSecurityComponent", () => {
     });
   });
 
+  describe("updateAllowSharingUnlockStateWithDesktop", () => {
+    let requestPermissionSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      policyService.policiesByType$.mockReturnValue(of([null]));
+      // Simulate the popout context so the permission is requested directly rather than
+      // re-opening the page in a popout.
+      jest.spyOn(BrowserPopupUtils, "inPopup").mockReturnValue(false);
+      jest.spyOn(BrowserApi, "permissionsGranted").mockResolvedValue(false);
+      requestPermissionSpy = jest.spyOn(BrowserApi, "requestPermission");
+      // The informational dialog is shown every time; default to the user continuing.
+      dialogService.open.mockReturnValue({ closed: of(true) } as any);
+    });
+
+    it("shows the informational dialog before requesting the permission", async () => {
+      requestPermissionSpy.mockResolvedValue(true);
+
+      await component.ngOnInit();
+      await component.updateAllowSharingUnlockStateWithDesktop(true);
+
+      expect(dialogService.open).toHaveBeenCalled();
+    });
+
+    it("pops out without showing the dialog or requesting the permission when in the popup", async () => {
+      jest.spyOn(BrowserPopupUtils, "inPopup").mockReturnValue(true);
+      const openPopoutSpy = jest
+        .spyOn(BrowserPopupUtils, "openCurrentPagePopout")
+        .mockResolvedValue(undefined as any);
+
+      await component.ngOnInit();
+      await component.updateAllowSharingUnlockStateWithDesktop(true);
+
+      expect(openPopoutSpy).toHaveBeenCalled();
+      expect(dialogService.open).not.toHaveBeenCalled();
+      expect(requestPermissionSpy).not.toHaveBeenCalled();
+      expect(
+        sharedUnlockSettingsService.setAllowSharingUnlockStateWithDesktop,
+      ).not.toHaveBeenCalled();
+    });
+
+    it("reverts the toggle and does not request the permission when the user closes the dialog", async () => {
+      dialogService.open.mockReturnValue({ closed: of(undefined) } as any);
+
+      await component.ngOnInit();
+      await component.updateAllowSharingUnlockStateWithDesktop(true);
+
+      expect(requestPermissionSpy).not.toHaveBeenCalled();
+      expect(component.form.controls.allowSharingUnlockStateWithDesktop.value).toBe(false);
+      expect(
+        sharedUnlockSettingsService.setAllowSharingUnlockStateWithDesktop,
+      ).not.toHaveBeenCalled();
+    });
+
+    it("does not show an error dialog and reverts the toggle when the permission is denied", async () => {
+      requestPermissionSpy.mockResolvedValue(false);
+
+      await component.ngOnInit();
+      await component.updateAllowSharingUnlockStateWithDesktop(true);
+
+      expect(dialogService.openSimpleDialog).not.toHaveBeenCalled();
+      expect(component.form.controls.allowSharingUnlockStateWithDesktop.value).toBe(false);
+      expect(
+        sharedUnlockSettingsService.setAllowSharingUnlockStateWithDesktop,
+      ).not.toHaveBeenCalled();
+    });
+
+    it("persists the setting when the permission is granted", async () => {
+      requestPermissionSpy.mockResolvedValue(true);
+
+      await component.ngOnInit();
+      await component.updateAllowSharingUnlockStateWithDesktop(true);
+
+      expect(
+        sharedUnlockSettingsService.setAllowSharingUnlockStateWithDesktop,
+      ).toHaveBeenCalledWith(true, mockUserId);
+    });
+
+    it("saves state then reloads when permission is just granted", async () => {
+      requestPermissionSpy.mockResolvedValue(true);
+
+      await component.ngOnInit();
+      await component.updateAllowSharingUnlockStateWithDesktop(true);
+
+      const saveOrder =
+        sharedUnlockSettingsService.setAllowSharingUnlockStateWithDesktop.mock
+          .invocationCallOrder[0];
+      const sendOrder = messagingService.send.mock.invocationCallOrder[0];
+      expect(
+        sharedUnlockSettingsService.setAllowSharingUnlockStateWithDesktop,
+      ).toHaveBeenCalledWith(true, mockUserId);
+      expect(messagingService.send).toHaveBeenCalledWith("reloadExtension");
+      expect(saveOrder).toBeLessThan(sendOrder);
+    });
+  });
+
   describe("biometrics polling timer", () => {
     let browserApiSpy: jest.SpyInstance;
 
@@ -661,6 +726,59 @@ describe("AccountSecurityComponent", () => {
       expect(component.biometricUnavailabilityReason).toBe("");
       component.ngOnDestroy();
     }));
+  });
+
+  describe("desktop sharing permission request on popout", () => {
+    let inPopoutSpy: jest.SpyInstance;
+    let permissionsGrantedSpy: jest.SpyInstance;
+    let updateDesktopSharingSpy: jest.SpyInstance;
+    let queryParamGet: jest.Mock;
+
+    beforeEach(() => {
+      policyService.policiesByType$.mockReturnValue(of([null]));
+      inPopoutSpy = jest.spyOn(BrowserPopupUtils, "inPopout").mockReturnValue(true);
+      permissionsGrantedSpy = jest.spyOn(BrowserApi, "permissionsGranted").mockResolvedValue(false);
+      queryParamGet = jest
+        .fn()
+        .mockImplementation((key: string) => (key === "autoRequestDesktopSharing" ? "true" : null));
+      const route = TestBed.inject(ActivatedRoute);
+      (route as any).snapshot = { queryParamMap: { get: queryParamGet } };
+      updateDesktopSharingSpy = jest
+        .spyOn(component, "updateAllowSharingUnlockStateWithDesktop")
+        .mockResolvedValue(undefined);
+    });
+
+    it("enables the setting to trigger the permission flow", async () => {
+      await component.ngOnInit();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(component.form.controls.allowSharingUnlockStateWithDesktop.value).toBe(true);
+      expect(updateDesktopSharingSpy).toHaveBeenCalledWith(true);
+    });
+
+    it("does not trigger the flow when the autoRequestDesktopSharing query param is absent", async () => {
+      queryParamGet.mockReturnValue(null);
+
+      await component.ngOnInit();
+
+      expect(updateDesktopSharingSpy).not.toHaveBeenCalled();
+    });
+
+    it("does not trigger the flow when not in a popout", async () => {
+      inPopoutSpy.mockReturnValue(false);
+
+      await component.ngOnInit();
+
+      expect(updateDesktopSharingSpy).not.toHaveBeenCalled();
+    });
+
+    it("does not trigger the flow when the nativeMessaging permission is already granted", async () => {
+      permissionsGrantedSpy.mockResolvedValue(true);
+
+      await component.ngOnInit();
+
+      expect(updateDesktopSharingSpy).not.toHaveBeenCalled();
+    });
   });
 
   describe("biometric permission request on popout", () => {

--- a/apps/browser/src/auth/popup/settings/account-security.component.ts
+++ b/apps/browser/src/auth/popup/settings/account-security.component.ts
@@ -116,7 +116,8 @@ export class AccountSecurityComponent implements OnInit, OnDestroy {
     biometric: false,
     enableAutoBiometricsPrompt: true,
     enablePhishingDetection: true,
-    allowSharingUnlockState: true,
+    allowSharingUnlockStateWithDesktop: false,
+    allowSharingUnlockStateWithWeb: false,
   });
 
   protected showAccountSecurityNudge$: Observable<boolean> =
@@ -130,6 +131,11 @@ export class AccountSecurityComponent implements OnInit, OnDestroy {
   protected readonly phishingDetectionAvailable$: Observable<boolean>;
   protected readonly sharedUnlockFeatureEnabled$: Observable<boolean>;
   protected readonly multiClientPasswordManagement$: Observable<boolean>;
+
+  // Native messaging with the desktop app is unavailable on Safari.
+  protected readonly showSharedUnlockWithDesktop: boolean;
+  // Firefox does not support sharing unlock state with the web vault.
+  protected readonly showSharedUnlockWithWeb: boolean;
 
   protected refreshTimeoutSettings$ = new BehaviorSubject<void>(undefined);
   private destroy$ = new Subject<void>();
@@ -169,18 +175,9 @@ export class AccountSecurityComponent implements OnInit, OnDestroy {
     this.sharedUnlockFeatureEnabled$ = this.configService.getFeatureFlag$(
       FeatureFlag.SharedUnlockPart2,
     );
-  }
 
-  get sharedUnlockDescriptionKey(): string {
-    if (this.platformUtilsService.isSafari()) {
-      return "sharedUnlockDescriptionSafari";
-    }
-
-    if (this.platformUtilsService.isFirefox()) {
-      return "sharedUnlockDescriptionFirefox";
-    }
-
-    return "sharedUnlockDescription";
+    this.showSharedUnlockWithDesktop = !this.platformUtilsService.isSafari();
+    this.showSharedUnlockWithWeb = !this.platformUtilsService.isFirefox();
   }
 
   async ngOnInit() {
@@ -209,8 +206,11 @@ export class AccountSecurityComponent implements OnInit, OnDestroy {
         this.biometricStateService.promptAutomatically$(activeAccount.id),
       ),
       enablePhishingDetection: await firstValueFrom(this.phishingDetectionSettingsService.enabled$),
-      allowSharingUnlockState: await firstValueFrom(
-        this.sharedUnlockSettingsService.allowSharingUnlockState$(activeAccount.id),
+      allowSharingUnlockStateWithDesktop: await firstValueFrom(
+        this.sharedUnlockSettingsService.allowSharingUnlockStateWithDesktop$(activeAccount.id),
+      ),
+      allowSharingUnlockStateWithWeb: await firstValueFrom(
+        this.sharedUnlockSettingsService.allowSharingUnlockStateWithWeb$(activeAccount.id),
       ),
     };
     this.form.patchValue(initialValues, { emitEvent: false });
@@ -324,17 +324,46 @@ export class AccountSecurityComponent implements OnInit, OnDestroy {
       )
       .subscribe();
 
-    this.form.controls.allowSharingUnlockState.valueChanges
+    this.form.controls.allowSharingUnlockStateWithDesktop.valueChanges
       .pipe(
         concatMap(async (enabled) => {
-          await this.updateAllowSharingUnlockState(enabled);
+          await this.updateAllowSharingUnlockStateWithDesktop(enabled);
         }),
         takeUntil(this.destroy$),
       )
       .subscribe();
 
+    this.form.controls.allowSharingUnlockStateWithWeb.valueChanges
+      .pipe(
+        concatMap(async (enabled) => {
+          await this.updateAllowSharingUnlockStateWithWeb(enabled);
+        }),
+        takeUntil(this.destroy$),
+      )
+      .subscribe();
+
+    await this.promptForDesktopSharingPermissionIfNeeded();
     // Note: This will be removed after shared unlock is rolled out
     await this.promptForBiometricPermissionIfNeeded();
+  }
+
+  /**
+   * When the Account Security page was popped out specifically to enable desktop unlock sharing
+   * (signalled by the `autoRequestDesktopSharing` query param), continue the flow that was started
+   * in the popup. Enabling the form control triggers `updateAllowSharingUnlockStateWithDesktop`,
+   * which — now running in the popout — presents the permission dialog and requests the
+   * `nativeMessaging` permission.
+   */
+  private async promptForDesktopSharingPermissionIfNeeded() {
+    if (
+      !BrowserPopupUtils.inPopout(window) ||
+      this.route.snapshot.queryParamMap.get("autoRequestDesktopSharing") !== "true" ||
+      (await BrowserApi.permissionsGranted(["nativeMessaging"]))
+    ) {
+      return;
+    }
+
+    this.form.controls.allowSharingUnlockStateWithDesktop.setValue(true);
   }
 
   /**
@@ -472,10 +501,54 @@ export class AccountSecurityComponent implements OnInit, OnDestroy {
     }
   }
 
-  async updateAllowSharingUnlockState(enabled: boolean) {
+  async updateAllowSharingUnlockStateWithDesktop(enabled: boolean) {
+    const hadPermission = await BrowserApi.permissionsGranted(["nativeMessaging"]);
+    if (enabled && !hadPermission) {
+      if (BrowserPopupUtils.inPopup(window)) {
+        // Requesting the permission in the popup would close the window (granting reloads the
+        // extension), so pop out to a stable window. The popped-out window presents the dialog and
+        // requests the permission. With hash routing, Angular reads query params from after the
+        // hash route.
+        const url = new URL(window.location.href);
+        url.hash += (url.hash.includes("?") ? "&" : "?") + "autoRequestDesktopSharing=true";
+        await BrowserPopupUtils.openCurrentPagePopout(window, url.href);
+        return;
+      }
+
+      // In the popout, always explain what enabling desktop sharing entails before requesting the
+      // permission.
+      const proceed = await firstValueFrom(
+        NativeMessagingPermissionDialogComponent.open(this.dialogService).closed,
+      );
+      if (!proceed) {
+        this.form.controls.allowSharingUnlockStateWithDesktop.setValue(false, { emitEvent: false });
+        return;
+      }
+
+      const granted = await this.requestNativeMessagingPermission();
+      if (!granted) {
+        this.form.controls.allowSharingUnlockStateWithDesktop.setValue(false, { emitEvent: false });
+        return;
+      }
+    }
+
     const userId = await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId));
-    await this.sharedUnlockSettingsService.setAllowSharingUnlockState(enabled, userId);
-    if (!enabled) {
+    await this.sharedUnlockSettingsService.setAllowSharingUnlockStateWithDesktop(enabled, userId);
+    if (!enabled && !this.form.controls.allowSharingUnlockStateWithWeb.value) {
+      await this.vaultTimeoutSettingsService.clearVaultTimeoutSuppression(userId);
+    }
+
+    if (enabled && !hadPermission) {
+      // The nativeMessaging permission was just granted. The extension must reload to register
+      // the native messaging host. State is saved above so it survives the reload.
+      this.messagingService.send("reloadExtension");
+    }
+  }
+
+  async updateAllowSharingUnlockStateWithWeb(enabled: boolean) {
+    const userId = await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId));
+    await this.sharedUnlockSettingsService.setAllowSharingUnlockStateWithWeb(enabled, userId);
+    if (!enabled && !this.form.controls.allowSharingUnlockStateWithDesktop.value) {
       await this.vaultTimeoutSettingsService.clearVaultTimeoutSuppression(userId);
     }
   }

--- a/apps/browser/src/key-management/lock/services/extension-lock-component.service.spec.ts
+++ b/apps/browser/src/key-management/lock/services/extension-lock-component.service.spec.ts
@@ -424,7 +424,8 @@ describe("ExtensionLockComponentService", () => {
 
       // Shared unlock
       configService.getFeatureFlag$.mockReturnValue(of(false));
-      sharedUnlockSettingsService.allowSharingUnlockState$.mockReturnValue(of(false));
+      sharedUnlockSettingsService.allowSharingUnlockStateWithDesktop$.mockReturnValue(of(false));
+      sharedUnlockSettingsService.allowSharingUnlockStateWithWeb$.mockReturnValue(of(false));
 
       const unlockOptions = await firstValueFrom(service.getAvailableUnlockOptions$(userId));
 

--- a/apps/browser/src/key-management/lock/services/extension-lock-component.service.ts
+++ b/apps/browser/src/key-management/lock/services/extension-lock-component.service.ts
@@ -84,13 +84,13 @@ export class ExtensionLockComponentService implements LockComponentService {
     return combineLatest([
       combineLatest([
         this.configService.getFeatureFlag$(FeatureFlag.SharedUnlockPart2),
-        this.sharedUnlockSettingsService.allowSharingUnlockState$(userId),
+        this.sharedUnlockSettingsService.allowSharingUnlockStateWithDesktop$(userId),
         // Check biometricUnlockEnabled$ first to avoid background native messaging & IPC calls when biometrics is disabled.
         this.biometricStateService.biometricUnlockEnabled$(userId),
       ]).pipe(
         switchMap(
-          async ([sharedUnlockFeatureFlag, allowSharingUnlockState, biometricUnlockEnabled]) =>
-            biometricUnlockEnabled || (sharedUnlockFeatureFlag && allowSharingUnlockState)
+          async ([sharedUnlockFeatureFlag, allowSharingWithDesktop, biometricUnlockEnabled]) =>
+            biometricUnlockEnabled || (sharedUnlockFeatureFlag && allowSharingWithDesktop)
               ? await this.biometricsService.getBiometricsStatusForUser(userId)
               : BiometricsStatus.NotEnabledLocally,
         ),

--- a/libs/common/src/key-management/shared-unlock/default-shared-unlock-follower.service.ts
+++ b/libs/common/src/key-management/shared-unlock/default-shared-unlock-follower.service.ts
@@ -1,7 +1,8 @@
-import { Observable, Subject } from "rxjs";
+import { firstValueFrom, Observable, Subject } from "rxjs";
 
 // eslint-disable-next-line no-restricted-imports
 import { LockService } from "@bitwarden/auth/common";
+import { ClientType } from "@bitwarden/client-type";
 // eslint-disable-next-line no-restricted-imports
 import { KeyService } from "@bitwarden/key-management";
 import { SharedUnlockFollower } from "@bitwarden/sdk-internal";
@@ -47,7 +48,7 @@ export class DefaultSharedUnlockFollowerService implements SharedUnlockFollowerS
       this.platformUtilsService,
       this.vaultTimeoutSettingsService,
       this.environmentService,
-      this.sharedUnlockSettingsService,
+      (userId) => this.enabled(userId),
       (userId) => this._externalUnlock$.next(userId),
     );
 
@@ -75,7 +76,13 @@ export class DefaultSharedUnlockFollowerService implements SharedUnlockFollowerS
   }
 
   private async enabled(userId: UserId): Promise<boolean> {
-    return await this.sharedUnlockSettingsService.allowSharingUnlockState(userId);
+    if (this.platformUtilsService.getClientType() === ClientType.Browser) {
+      return await firstValueFrom(
+        this.sharedUnlockSettingsService.allowSharingUnlockStateWithDesktop$(userId),
+      );
+    } else {
+      return true;
+    }
   }
 
   private async onUnlock(userId: UserId, userKey: SymmetricCryptoKey): Promise<void> {

--- a/libs/common/src/key-management/shared-unlock/default-shared-unlock-leader.service.ts
+++ b/libs/common/src/key-management/shared-unlock/default-shared-unlock-leader.service.ts
@@ -1,7 +1,8 @@
-import { Observable, Subject } from "rxjs";
+import { firstValueFrom, Observable, Subject } from "rxjs";
 
 // eslint-disable-next-line no-restricted-imports
 import { LockService } from "@bitwarden/auth/common";
+import { ClientType } from "@bitwarden/client-type";
 // eslint-disable-next-line no-restricted-imports
 import { KeyService } from "@bitwarden/key-management";
 import { SharedUnlockLeader } from "@bitwarden/sdk-internal";
@@ -47,7 +48,7 @@ export class DefaultSharedUnlockLeaderService implements SharedUnlockLeaderServi
       this.platformUtilsService,
       this.vaultTimeoutSettingsService,
       this.environmentService,
-      this.sharedUnlockSettingsService,
+      (userId) => this.enabled(userId),
       (userId) => this._externalUnlock$.next(userId),
     );
 
@@ -74,7 +75,13 @@ export class DefaultSharedUnlockLeaderService implements SharedUnlockLeaderServi
   }
 
   private async enabled(userId: UserId): Promise<boolean> {
-    return await this.sharedUnlockSettingsService.allowSharingUnlockState(userId);
+    if (this.platformUtilsService.getClientType() === ClientType.Browser) {
+      return await firstValueFrom(
+        this.sharedUnlockSettingsService.allowSharingUnlockStateWithWeb$(userId),
+      );
+    } else {
+      return true;
+    }
   }
 
   private async onUnlock(userId: UserId, userKey: SymmetricCryptoKey): Promise<void> {

--- a/libs/common/src/key-management/shared-unlock/default-shared-unlock-settings.service.ts
+++ b/libs/common/src/key-management/shared-unlock/default-shared-unlock-settings.service.ts
@@ -1,4 +1,4 @@
-import { firstValueFrom, map, Observable } from "rxjs";
+import { map, Observable } from "rxjs";
 
 import {
   SHARED_UNLOCK_SETTINGS_DISK,
@@ -9,35 +9,54 @@ import { UserId } from "../../types/guid";
 
 import { SharedUnlockSettingsService } from "./shared-unlock-settings.service";
 
-const ALLOW_SHARING_UNLOCK_STATE = new UserKeyDefinition<boolean>(
+const ALLOW_SHARING_UNLOCK_STATE_WITH_DESKTOP = new UserKeyDefinition<boolean>(
   SHARED_UNLOCK_SETTINGS_DISK,
-  "allowSharingUnlockState",
+  "allowSharingUnlockStateWithDesktop",
   {
     deserializer: (b) => b,
     clearOn: ["logout"],
   },
 );
 
+const ALLOW_SHARING_UNLOCK_STATE_WITH_WEB = new UserKeyDefinition<boolean>(
+  SHARED_UNLOCK_SETTINGS_DISK,
+  "allowSharingUnlockStateWithWeb",
+  {
+    deserializer: (b) => b,
+    clearOn: ["logout"],
+  },
+);
+
+// Default off because of native messaging permission
+const DEFAULT_ALLOW_SHARING_UNLOCK_STATE_WITH_DESKTOP = false;
+const DEFAULT_ALLOW_SHARING_UNLOCK_STATE_WITH_WEB = true;
+
 export class DefaultSharedUnlockSettingsService extends SharedUnlockSettingsService {
   constructor(private stateProvider: StateProvider) {
     super();
   }
 
-  async setAllowSharingUnlockState(value: boolean, userId: UserId) {
-    await this.stateProvider.getUser(userId, ALLOW_SHARING_UNLOCK_STATE).update(() => value);
-  }
-
-  allowSharingUnlockState$(userId: UserId): Observable<boolean> {
+  allowSharingUnlockStateWithDesktop$(userId: UserId): Observable<boolean> {
     return this.stateProvider
-      .getUserState$(ALLOW_SHARING_UNLOCK_STATE, userId)
-      .pipe(map((v) => v ?? true));
+      .getUserState$(ALLOW_SHARING_UNLOCK_STATE_WITH_DESKTOP, userId)
+      .pipe(map((v) => v ?? DEFAULT_ALLOW_SHARING_UNLOCK_STATE_WITH_DESKTOP));
   }
 
-  async allowSharingUnlockState(userId: UserId): Promise<boolean> {
-    return (
-      (await firstValueFrom(
-        this.stateProvider.getUserState$(ALLOW_SHARING_UNLOCK_STATE, userId),
-      )) ?? true
-    );
+  async setAllowSharingUnlockStateWithDesktop(value: boolean, userId: UserId): Promise<void> {
+    await this.stateProvider
+      .getUser(userId, ALLOW_SHARING_UNLOCK_STATE_WITH_DESKTOP)
+      .update(() => value);
+  }
+
+  allowSharingUnlockStateWithWeb$(userId: UserId): Observable<boolean> {
+    return this.stateProvider
+      .getUserState$(ALLOW_SHARING_UNLOCK_STATE_WITH_WEB, userId)
+      .pipe(map((v) => v ?? DEFAULT_ALLOW_SHARING_UNLOCK_STATE_WITH_WEB));
+  }
+
+  async setAllowSharingUnlockStateWithWeb(value: boolean, userId: UserId): Promise<void> {
+    await this.stateProvider
+      .getUser(userId, ALLOW_SHARING_UNLOCK_STATE_WITH_WEB)
+      .update(() => value);
   }
 }

--- a/libs/common/src/key-management/shared-unlock/shared-unlock-driver.ts
+++ b/libs/common/src/key-management/shared-unlock/shared-unlock-driver.ts
@@ -16,8 +16,6 @@ import { SymmetricCryptoKey } from "../../platform/models/domain/symmetric-crypt
 import { UserKey } from "../../types/key";
 import { VaultTimeoutSettingsService } from "../vault-timeout/abstractions/vault-timeout-settings.service";
 
-import { SharedUnlockSettingsService } from "./shared-unlock-settings.service";
-
 function fromSdkUserId(userId: UserId): TSUserId {
   return uuidAsString(userId) as TSUserId;
 }
@@ -35,12 +33,12 @@ export class JsSharedUnlockDriver implements SharedUnlockDriver {
     private platformUtilsService: PlatformUtilsService,
     private vaultTimeoutSettingsService: VaultTimeoutSettingsService,
     private environmentService: EnvironmentService,
-    private sharedUnlockSettingsService: SharedUnlockSettingsService,
+    private isEnabled: (userId: TSUserId) => Promise<boolean>,
     private onExternalUnlock?: (userId: TSUserId) => void,
   ) {}
 
   async lock_user(user_id: UserId): Promise<void> {
-    if (!(await this.sharedUnlockSettingsService.allowSharingUnlockState(fromSdkUserId(user_id)))) {
+    if (!(await this.isEnabled(fromSdkUserId(user_id)))) {
       return;
     }
 
@@ -48,7 +46,7 @@ export class JsSharedUnlockDriver implements SharedUnlockDriver {
   }
 
   async unlock_user(user_id: UserId, user_key: SymmetricKey): Promise<void> {
-    if (!(await this.sharedUnlockSettingsService.allowSharingUnlockState(fromSdkUserId(user_id)))) {
+    if (!(await this.isEnabled(fromSdkUserId(user_id)))) {
       return;
     }
 

--- a/libs/common/src/key-management/shared-unlock/shared-unlock-settings.service.ts
+++ b/libs/common/src/key-management/shared-unlock/shared-unlock-settings.service.ts
@@ -3,7 +3,9 @@ import { Observable } from "rxjs";
 import { UserId } from "../../types/guid";
 
 export abstract class SharedUnlockSettingsService {
-  abstract allowSharingUnlockState$(userId: UserId): Observable<boolean>;
-  abstract setAllowSharingUnlockState(value: boolean, userId: UserId): Promise<void>;
-  abstract allowSharingUnlockState(userId: UserId): Promise<boolean>;
+  abstract allowSharingUnlockStateWithDesktop$(userId: UserId): Observable<boolean>;
+  abstract setAllowSharingUnlockStateWithDesktop(value: boolean, userId: UserId): Promise<void>;
+
+  abstract allowSharingUnlockStateWithWeb$(userId: UserId): Observable<boolean>;
+  abstract setAllowSharingUnlockStateWithWeb(value: boolean, userId: UserId): Promise<void>;
 }

--- a/libs/state/src/state-migrations/migrate.ts
+++ b/libs/state/src/state-migrations/migrate.ts
@@ -78,11 +78,12 @@ import { MigrateSsoRequiredCache } from "./migrations/78-migrate-sso-required-ca
 import { InitializeFeatureFlagOverridesMigrator } from "./migrations/79-initialize-feature-flag-overrides";
 import { MoveStateVersionMigrator } from "./migrations/8-move-state-version";
 import { ConsolidateTrayToRunInBackground } from "./migrations/80-consolidate-tray-to-run-in-background";
+import { EnableDesktopSharingIfBiometricsEnabled } from "./migrations/81-enable-desktop-sharing-if-biometrics-enabled";
 import { MoveBrowserSettingsToGlobal } from "./migrations/9-move-browser-settings-to-global";
 import { MinVersionMigrator } from "./migrations/min-version";
 
 export const MIN_VERSION = 3;
-export const CURRENT_VERSION = 80;
+export const CURRENT_VERSION = 81;
 export type MinVersion = typeof MIN_VERSION;
 
 export function createMigrationBuilder() {
@@ -164,7 +165,8 @@ export function createMigrationBuilder() {
     .with(ClearClipboardDelayToStringMigrator, 76, 77)
     .with(MigrateSsoRequiredCache, 77, 78)
     .with(InitializeFeatureFlagOverridesMigrator, 78, 79)
-    .with(ConsolidateTrayToRunInBackground, 79, CURRENT_VERSION);
+    .with(ConsolidateTrayToRunInBackground, 79, 80)
+    .with(EnableDesktopSharingIfBiometricsEnabled, 80, CURRENT_VERSION);
 }
 
 export async function currentVersion(

--- a/libs/state/src/state-migrations/migrations/81-enable-desktop-sharing-if-biometrics-enabled.spec.ts
+++ b/libs/state/src/state-migrations/migrations/81-enable-desktop-sharing-if-biometrics-enabled.spec.ts
@@ -1,0 +1,82 @@
+import { runMigrator } from "../migration-helper.spec";
+
+import { EnableDesktopSharingIfBiometricsEnabled } from "./81-enable-desktop-sharing-if-biometrics-enabled";
+
+describe("EnableDesktopSharingIfBiometricsEnabled", () => {
+  const sut = new EnableDesktopSharingIfBiometricsEnabled(80, 81);
+
+  describe("migrate", () => {
+    it("enables desktop sharing for users with biometric unlock enabled", async () => {
+      const output = await runMigrator(sut, {
+        global_account_accounts: {
+          user1: {},
+          user2: {},
+          user3: {},
+        },
+        user_user1_biometricSettings_biometricUnlockEnabled: true,
+        user_user2_biometricSettings_biometricUnlockEnabled: false,
+        // user3 has no biometric setting
+      });
+
+      expect(output).toEqual({
+        global_account_accounts: {
+          user1: {},
+          user2: {},
+          user3: {},
+        },
+        user_user1_biometricSettings_biometricUnlockEnabled: true,
+        user_user1_sharedUnlockSettings_allowSharingUnlockStateWithDesktop: true,
+        user_user2_biometricSettings_biometricUnlockEnabled: false,
+      });
+    });
+
+    it("does not overwrite desktop sharing when it is already set", async () => {
+      const output = await runMigrator(sut, {
+        global_account_accounts: { user1: {} },
+        user_user1_biometricSettings_biometricUnlockEnabled: true,
+        user_user1_sharedUnlockSettings_allowSharingUnlockStateWithDesktop: false,
+      });
+
+      expect(output).toEqual({
+        global_account_accounts: { user1: {} },
+        user_user1_biometricSettings_biometricUnlockEnabled: true,
+        user_user1_sharedUnlockSettings_allowSharingUnlockStateWithDesktop: false,
+      });
+    });
+
+    it("does nothing when there are no accounts", async () => {
+      const output = await runMigrator(sut, {});
+
+      expect(output).toEqual({});
+    });
+  });
+
+  describe("rollback", () => {
+    it("removes desktop sharing for users with biometric unlock enabled", async () => {
+      const output = await runMigrator(
+        sut,
+        {
+          global_account_accounts: {
+            user1: {},
+            user2: {},
+          },
+          user_user1_biometricSettings_biometricUnlockEnabled: true,
+          user_user1_sharedUnlockSettings_allowSharingUnlockStateWithDesktop: true,
+          user_user2_biometricSettings_biometricUnlockEnabled: false,
+          user_user2_sharedUnlockSettings_allowSharingUnlockStateWithDesktop: true,
+        },
+        "rollback",
+      );
+
+      expect(output).toEqual({
+        global_account_accounts: {
+          user1: {},
+          user2: {},
+        },
+        user_user1_biometricSettings_biometricUnlockEnabled: true,
+        user_user2_biometricSettings_biometricUnlockEnabled: false,
+        user_user2_sharedUnlockSettings_allowSharingUnlockStateWithDesktop: true,
+      });
+    });
+  });
+});

--- a/libs/state/src/state-migrations/migrations/81-enable-desktop-sharing-if-biometrics-enabled.ts
+++ b/libs/state/src/state-migrations/migrations/81-enable-desktop-sharing-if-biometrics-enabled.ts
@@ -1,0 +1,48 @@
+import { KeyDefinitionLike, MigrationHelper } from "../migration-helper";
+import { Migrator } from "../migrator";
+
+const BIOMETRIC_UNLOCK_ENABLED: KeyDefinitionLike = {
+  key: "biometricUnlockEnabled",
+  stateDefinition: { name: "biometricSettings" },
+};
+
+const ALLOW_SHARING_UNLOCK_STATE_WITH_DESKTOP: KeyDefinitionLike = {
+  key: "allowSharingUnlockStateWithDesktop",
+  stateDefinition: { name: "sharedUnlockSettings" },
+};
+
+/**
+ * For each user that already has biometric unlock enabled, enables sharing unlock state
+ * with the desktop app. Previously this setting defaulted to off even when biometrics were
+ * configured, so existing users had to manually enable it.
+ */
+export class EnableDesktopSharingIfBiometricsEnabled extends Migrator<80, 81> {
+  async migrate(helper: MigrationHelper): Promise<void> {
+    async function migrateUser(userId: string) {
+      const biometricUnlock = await helper.getFromUser<boolean>(userId, BIOMETRIC_UNLOCK_ENABLED);
+
+      if (
+        biometricUnlock === true &&
+        (await helper.getFromUser(userId, ALLOW_SHARING_UNLOCK_STATE_WITH_DESKTOP)) == null
+      ) {
+        await helper.setToUser(userId, ALLOW_SHARING_UNLOCK_STATE_WITH_DESKTOP, true);
+      }
+    }
+
+    const accounts = await helper.getAccounts();
+    await Promise.all(accounts.map(({ userId }) => migrateUser(userId)));
+  }
+
+  async rollback(helper: MigrationHelper): Promise<void> {
+    async function rollbackUser(userId: string) {
+      const biometricUnlock = await helper.getFromUser<boolean>(userId, BIOMETRIC_UNLOCK_ENABLED);
+
+      if (biometricUnlock === true) {
+        await helper.removeFromUser(userId, ALLOW_SHARING_UNLOCK_STATE_WITH_DESKTOP);
+      }
+    }
+
+    const accounts = await helper.getAccounts();
+    await Promise.all(accounts.map(({ userId }) => rollbackUser(userId)));
+  }
+}


### PR DESCRIPTION
…aging permission

Splits the single allowSharingUnlockState into allowSharingUnlockStateWithDesktop and allowSharingUnlockStateWithWeb, each with its own toggle in Account Security. Enabling desktop sharing now requires the nativeMessaging permission and uses the NativeMessagingPermissionDialogComponent flow (pop out, explain, request, reload). The leader/follower services and shared-unlock driver are gated on the relevant per-direction setting, and migration 81 enables desktop sharing for users who already had biometric unlock configured.

## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
