### PR TITLE
[PM-39783] Add override for policy enabled state

### DIFF
--- a/apps/web/src/app/admin-console/organizations/policies/base-policy-edit.component.ts
+++ b/apps/web/src/app/admin-console/organizations/policies/base-policy-edit.component.ts
@@ -9,6 +9,7 @@ import { PolicyType } from "@bitwarden/common/admin-console/enums";
 import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
 import { SavePolicyRequest } from "@bitwarden/common/admin-console/models/request/save-policy.request";
 import { PolicyStatusResponse } from "@bitwarden/common/admin-console/models/response/policy-status.response";
+import { PolicyResponse } from "@bitwarden/common/admin-console/models/response/policy.response";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { getUserId } from "@bitwarden/common/auth/services/account.service";
 import { assertNonNullish } from "@bitwarden/common/auth/utils";
@@ -132,6 +133,19 @@ export abstract class BasePolicyEditDefinition {
    */
   display$(organization: Organization, configService: ConfigService): Observable<boolean> {
     return of(true);
+  }
+
+  /**
+   * Logic for displaying the policy status in the Admin Console.
+   * If this returns true, the policy is shown as enabled. If false, it is shown as disabled.
+   * This uses the `policy.enabled` value by default, which is appropriate for most cases.
+   * You may wish to override this if the UI does not perfectly match the data model, e.g.
+   * you wish to determine policy status based on a `policy.data` value.
+
+   * Note: this only affects policy editing in Admin Console, it does not affect its enforcement.
+   */
+  enabled(policy: PolicyResponse): boolean {
+    return policy.enabled;
   }
 }
 

--- a/apps/web/src/app/admin-console/organizations/policies/policies.component.ts
+++ b/apps/web/src/app/admin-console/organizations/policies/policies.component.ts
@@ -91,12 +91,17 @@ export class PoliciesComponent {
       shareReplay({ bufferSize: 1, refCount: true }),
     );
 
+  private readonly policyEditDefinitionsDict = Object.fromEntries(
+    this.policyListService.getPolicies().map((p) => [p.type, p]),
+  ) as Record<PolicyType, BasePolicyEditDefinition>;
+
   protected readonly policiesEnabledMap$: Observable<Map<PolicyType, boolean>> =
     this.orgPolicies$.pipe(
       map((orgPolicies) => {
         const policiesEnabledMap: Map<PolicyType, boolean> = new Map<PolicyType, boolean>();
         orgPolicies.forEach((op) => {
-          policiesEnabledMap.set(op.type, op.enabled);
+          const showEnabled = this.policyEditDefinitionsDict[op.type]?.enabled(op) ?? op.enabled;
+          policiesEnabledMap.set(op.type, showEnabled);
         });
         return policiesEnabledMap;
       }),

--- a/apps/web/src/app/admin-console/organizations/policies/policy-edit-definitions/send-controls.component.ts
+++ b/apps/web/src/app/admin-console/organizations/policies/policy-edit-definitions/send-controls.component.ts
@@ -25,12 +25,15 @@ import { ControlsOf } from "@bitwarden/angular/types/controls-of";
 import { OrgDomainApiServiceAbstraction } from "@bitwarden/common/admin-console/abstractions/organization-domain/org-domain-api.service.abstraction";
 import { PolicyType } from "@bitwarden/common/admin-console/enums";
 import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
+import { SavePolicyRequest } from "@bitwarden/common/admin-console/models/request/save-policy.request";
+import { PolicyResponse } from "@bitwarden/common/admin-console/models/response/policy.response";
 import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { SendControlsPolicyData } from "@bitwarden/common/tools/models/send-controls-policy-data";
 import { WhoCanAccessType } from "@bitwarden/common/tools/models/send-who-can-access-type";
 import { SendType } from "@bitwarden/common/tools/send/types/send-type";
+import { OrgKey } from "@bitwarden/common/types/key";
 import {
   FormFieldModule,
   Option,
@@ -56,6 +59,19 @@ export class SendControlsPolicy extends BasePolicyEditDefinition {
 
   override display$(organization: Organization, configService: ConfigService): Observable<boolean> {
     return configService.getFeatureFlag$(FeatureFlag.SendControls);
+  }
+
+  override enabled(policy: PolicyResponse): boolean {
+    // This policy is always enabled, and is driven entirely through its `policy.data` configuration.
+    // The 'enabled' UI reflects whether the Send feature is enabled, rather than whether the policy is enabled.
+
+    // It is enabled by default:
+    if (policy == null || policy.data == null) {
+      return true;
+    }
+
+    // Or enabled if the Send feature is enabled:
+    return !policy.data.disableSend;
   }
 }
 
@@ -235,5 +251,16 @@ export class SendControlsPolicyComponent extends BasePolicyEditComponent impleme
       }
       return null;
     };
+  }
+
+  override buildRequest(orgKey?: OrgKey): Promise<SavePolicyRequest> {
+    return Promise.resolve({
+      policy: {
+        enabled: true, // note: you could technically set this to false if all `data` properties are set to their defaults (because that would be a no-op anyway)
+        // but that seems cumbersome to maintain - easier to just always set it to on and pivot from the data configuration
+        data: this.data.value, // assuming this maps 1:1 to the request/data model
+      },
+      metadata: null,
+    });
   }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-39783

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Example code for how we can support the proposed behavior of the new Send Controls policy.

Expected behavior:
- the policy toggle turns the Send _feature_ on or off
- toggle off -> Send is disabled
- toggle on -> Send is enabled, and the additional controls apply (e.g. allowed send types)
- default state: toggle is on

This doesn't match usual behavior, because usually the toggle being off means that the policy is disabled and has no effect. But here, it has effects in both states.

The approach in this PR: we treat the policy as always-enabled behind the scenes (so that it always has some effect), and the `policy.data.disableSend` value maps to the toggle state. This avoids additional data migrations and means we don't have to make adjustments to policy enforcement logic to support disabled policies doing something. It preserves the mental model of "enabled = potentially enforced".

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
