### PR TITLE
Prevent connect to desktop in ipc background if native messaging permission is missing

### DIFF
--- a/apps/browser/src/platform/ipc/ipc-background.service.ts
+++ b/apps/browser/src/platform/ipc/ipc-background.service.ts
@@ -150,9 +150,13 @@ export class IpcBackgroundService extends IpcService {
 
   /**
    * Starts a connection to the desktop app. This function attempts to establish a connection with the desktop application
-   * using native messaging. It will automaticall retry and reconnect if the connection fails or is lost.
+   * using native messaging. It will automatically retry and reconnect if the connection fails or is lost.
    */
   private async connectToDesktop() {
+    if (!(await BrowserApi.permissionsGranted(["nativeMessaging"]))) {
+      return;
+    }
+
     let port: browser.runtime.Port | chrome.runtime.Port | undefined;
     try {
       port = BrowserApi.connectNative("com.8bit.bitwarden");


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[no ticket]

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

connectToDesktop should not attempt to send if the native messaging permission is missing. If it is not grated, it should just do nothing, as to prevent error spam.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
