### PR TITLE
[PM-40060] Add native messaging permission dialog

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -6751,6 +6751,18 @@
   "sharedUnlockDescriptionFirefox": {
     "message": "Keep your Bitwarden apps in sync. When enabled, unlock state will be shared with the Bitwarden desktop app."
   },
+  "newPermissionNeeded": {
+    "message": "New permission needed"
+  },
+  "sharedUnlockDesktopPermissionDesc": {
+    "message": "To use shared unlock, Bitwarden needs permission to communicate with the desktop app. When you continue, your browser will ask you to approve it."
+  },
+  "sharedUnlockDesktopPermissionWarning": {
+    "message": "Bitwarden will lock and reload. After you approve, the extension reloads and will lock your vault."
+  },
+  "biometricPermissionDesc": {
+    "message": "To use biometric unlock, Bitwarden needs permission to communicate with the desktop app. When you continue, your browser will ask you to approve it."
+  },
   "enterMonth": {
     "message": "Enter month."
   },

--- a/apps/browser/src/key-management/shared-unlock/popup/native-messaging-permission-dialog.component.html
+++ b/apps/browser/src/key-management/shared-unlock/popup/native-messaging-permission-dialog.component.html
@@ -1,0 +1,28 @@
+<bit-dialog [title]="'newPermissionNeeded' | i18n">
+  <div bitDialogContent>
+    <p bitTypography="body1">{{ descriptionKey | i18n }}</p>
+    <bit-callout type="warning">{{ "sharedUnlockDesktopPermissionWarning" | i18n }}</bit-callout>
+  </div>
+  <ng-container bitDialogFooter>
+    <button
+      type="button"
+      class="tw-flex-1"
+      bitButton
+      buttonType="secondary"
+      bitDialogClose
+      id="native-messaging-permission_button_close"
+    >
+      {{ "close" | i18n }}
+    </button>
+    <button
+      type="button"
+      class="tw-flex-1"
+      bitButton
+      buttonType="primary"
+      (click)="continue()"
+      id="native-messaging-permission_button_continue"
+    >
+      {{ "continue" | i18n }}
+    </button>
+  </ng-container>
+</bit-dialog>

--- a/apps/browser/src/key-management/shared-unlock/popup/native-messaging-permission-dialog.component.spec.ts
+++ b/apps/browser/src/key-management/shared-unlock/popup/native-messaging-permission-dialog.component.spec.ts
@@ -1,0 +1,178 @@
+import { DIALOG_DATA } from "@angular/cdk/dialog";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { By } from "@angular/platform-browser";
+import { mock } from "jest-mock-extended";
+
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
+import { DialogRef, DialogService } from "@bitwarden/components";
+
+import { BrowserApi } from "../../../platform/browser/browser-api";
+import BrowserPopupUtils from "../../../platform/browser/browser-popup-utils";
+
+import {
+  NativeMessagingPermissionDialogComponent,
+  NativeMessagingPermissionDialogParams,
+  NativeMessagingPermissionDialogType,
+} from "./native-messaging-permission-dialog.component";
+
+describe("NativeMessagingPermissionDialogComponent", () => {
+  let component: NativeMessagingPermissionDialogComponent;
+  let fixture: ComponentFixture<NativeMessagingPermissionDialogComponent>;
+
+  const dialogRef = mock<DialogRef<boolean>>();
+  const dialogService = mock<DialogService>();
+  const i18nService = mock<I18nService>();
+  const platformUtilsService = mock<PlatformUtilsService>();
+
+  let requestPermissionSpy: jest.SpyInstance;
+
+  async function createComponent(params?: NativeMessagingPermissionDialogParams) {
+    await TestBed.configureTestingModule({
+      imports: [NativeMessagingPermissionDialogComponent],
+      providers: [
+        { provide: DialogRef, useValue: dialogRef },
+        { provide: I18nService, useValue: i18nService },
+        { provide: PlatformUtilsService, useValue: platformUtilsService },
+        {
+          provide: DIALOG_DATA,
+          useValue: params ?? null,
+        },
+      ],
+    })
+      // DialogModule (imported by the component) provides a real DialogService; override it
+      // with the mock at the component's element injector so it shadows the module provider.
+      .overrideComponent(NativeMessagingPermissionDialogComponent, {
+        add: { providers: [{ provide: DialogService, useValue: dialogService }] },
+      })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(NativeMessagingPermissionDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }
+
+  beforeEach(() => {
+    i18nService.t.mockImplementation((key) => key);
+    platformUtilsService.isFirefox.mockReturnValue(false);
+    requestPermissionSpy = jest.spyOn(BrowserApi, "requestPermission");
+    requestPermissionSpy.mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+    TestBed.resetTestingModule();
+  });
+
+  describe("continue()", () => {
+    it("closes with true when the nativeMessaging permission is granted", async () => {
+      requestPermissionSpy.mockResolvedValue(true);
+      await createComponent({ type: NativeMessagingPermissionDialogType.Biometrics });
+
+      await component.continue();
+
+      expect(requestPermissionSpy).toHaveBeenCalledWith({ permissions: ["nativeMessaging"] });
+      expect(dialogRef.close).toHaveBeenCalledWith(true);
+    });
+
+    it("closes with false when the nativeMessaging permission is denied", async () => {
+      requestPermissionSpy.mockResolvedValue(false);
+      await createComponent({ type: NativeMessagingPermissionDialogType.Biometrics });
+
+      await component.continue();
+
+      expect(dialogRef.close).toHaveBeenCalledWith(false);
+    });
+
+    it("closes with false and shows the sidebar dialog when the request throws on Firefox + sidebar", async () => {
+      requestPermissionSpy.mockRejectedValue(new Error("permission request failed"));
+      platformUtilsService.isFirefox.mockReturnValue(true);
+      jest.spyOn(BrowserPopupUtils, "inSidebar").mockReturnValue(true);
+      await createComponent({ type: NativeMessagingPermissionDialogType.Biometrics });
+
+      await component.continue();
+
+      expect(dialogService.openSimpleDialog).toHaveBeenCalledWith({
+        title: { key: "nativeMessaginPermissionSidebarTitle" },
+        content: { key: "nativeMessaginPermissionSidebarDesc" },
+        acceptButtonText: { key: "ok" },
+        cancelButtonText: null,
+        type: "info",
+      });
+      expect(dialogRef.close).toHaveBeenCalledWith(false);
+    });
+
+    it("closes with false without the sidebar dialog when the request throws elsewhere", async () => {
+      requestPermissionSpy.mockRejectedValue(new Error("permission request failed"));
+      platformUtilsService.isFirefox.mockReturnValue(false);
+      jest.spyOn(BrowserPopupUtils, "inSidebar").mockReturnValue(false);
+      await createComponent({ type: NativeMessagingPermissionDialogType.Biometrics });
+
+      await component.continue();
+
+      expect(dialogService.openSimpleDialog).not.toHaveBeenCalled();
+      expect(dialogRef.close).toHaveBeenCalledWith(false);
+    });
+  });
+
+  describe("description copy", () => {
+    it("renders the biometrics description key for the biometrics type", async () => {
+      await createComponent({ type: NativeMessagingPermissionDialogType.Biometrics });
+
+      const description = fixture.debugElement.query(By.css("p")).nativeElement as HTMLElement;
+      expect(description.textContent).toContain("biometricPermissionDesc");
+    });
+
+    it("renders the shared unlock description key for the shared unlock type", async () => {
+      await createComponent({ type: NativeMessagingPermissionDialogType.SharedUnlock });
+
+      const description = fixture.debugElement.query(By.css("p")).nativeElement as HTMLElement;
+      expect(description.textContent).toContain("sharedUnlockDesktopPermissionDesc");
+    });
+  });
+
+  describe("open()", () => {
+    beforeEach(() => {
+      jest.spyOn(BrowserPopupUtils, "inPopout").mockReturnValue(true);
+    });
+
+    it("opens the dialog via the DialogService", async () => {
+      const service = mock<DialogService>();
+
+      NativeMessagingPermissionDialogComponent.open(service, {
+        type: NativeMessagingPermissionDialogType.Biometrics,
+      });
+
+      expect(service.open).toHaveBeenCalledWith(
+        NativeMessagingPermissionDialogComponent,
+        expect.objectContaining({ positionStrategy: expect.anything() }),
+      );
+    });
+
+    it("passes params as dialog data", () => {
+      const service = mock<DialogService>();
+      const params: NativeMessagingPermissionDialogParams = {
+        type: NativeMessagingPermissionDialogType.SharedUnlock,
+      };
+
+      NativeMessagingPermissionDialogComponent.open(service, params);
+
+      expect(service.open).toHaveBeenCalledWith(
+        NativeMessagingPermissionDialogComponent,
+        expect.objectContaining({ data: params }),
+      );
+    });
+
+    it("throws and does not open the dialog when not in a popout", () => {
+      jest.spyOn(BrowserPopupUtils, "inPopout").mockReturnValue(false);
+      const service = mock<DialogService>();
+
+      expect(() =>
+        NativeMessagingPermissionDialogComponent.open(service, {
+          type: NativeMessagingPermissionDialogType.Biometrics,
+        }),
+      ).toThrow();
+      expect(service.open).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/browser/src/key-management/shared-unlock/popup/native-messaging-permission-dialog.component.ts
+++ b/apps/browser/src/key-management/shared-unlock/popup/native-messaging-permission-dialog.component.ts
@@ -63,7 +63,9 @@ export class NativeMessagingPermissionDialogComponent {
     optional: true,
   });
   protected readonly descriptionKey =
-    DESCRIPTION_KEY_BY_TYPE[this.params?.type ?? NativeMessagingPermissionDialogType.Biometrics];
+    DESCRIPTION_KEY_BY_TYPE[
+      (this.params?.type as NativeMessagingPermissionDialogType | undefined) ?? NativeMessagingPermissionDialogType.Biometrics
+    ];
 
   async continue() {
     let granted = false;
@@ -81,7 +83,6 @@ export class NativeMessagingPermissionDialogComponent {
           type: "info",
         });
       }
-      granted = false;
     }
     await this.dialogRef.close(granted);
   }

--- a/apps/browser/src/key-management/shared-unlock/popup/native-messaging-permission-dialog.component.ts
+++ b/apps/browser/src/key-management/shared-unlock/popup/native-messaging-permission-dialog.component.ts
@@ -83,7 +83,7 @@ export class NativeMessagingPermissionDialogComponent {
       }
       granted = false;
     }
-    void this.dialogRef.close(granted);
+    await this.dialogRef.close(granted);
   }
 
   /**

--- a/apps/browser/src/key-management/shared-unlock/popup/native-messaging-permission-dialog.component.ts
+++ b/apps/browser/src/key-management/shared-unlock/popup/native-messaging-permission-dialog.component.ts
@@ -64,7 +64,8 @@ export class NativeMessagingPermissionDialogComponent {
   });
   protected readonly descriptionKey =
     DESCRIPTION_KEY_BY_TYPE[
-      (this.params?.type as NativeMessagingPermissionDialogType | undefined) ?? NativeMessagingPermissionDialogType.Biometrics
+      (this.params?.type as NativeMessagingPermissionDialogType | undefined) ??
+        NativeMessagingPermissionDialogType.Biometrics
     ];
 
   async continue() {

--- a/apps/browser/src/key-management/shared-unlock/popup/native-messaging-permission-dialog.component.ts
+++ b/apps/browser/src/key-management/shared-unlock/popup/native-messaging-permission-dialog.component.ts
@@ -1,0 +1,110 @@
+import { DIALOG_DATA } from "@angular/cdk/dialog";
+import { ChangeDetectionStrategy, Component, inject } from "@angular/core";
+
+import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
+import {
+  ButtonModule,
+  CalloutComponent,
+  CenterPositionStrategy,
+  DialogModule,
+  DialogRef,
+  DialogService,
+  TypographyModule,
+} from "@bitwarden/components";
+import { I18nPipe } from "@bitwarden/ui-common";
+
+import { BrowserApi } from "../../../platform/browser/browser-api";
+import BrowserPopupUtils from "../../../platform/browser/browser-popup-utils";
+
+/**
+ * The feature that requires the `nativeMessaging` permission. Determines the description copy
+ * shown in the dialog.
+ */
+export const NativeMessagingPermissionDialogType = Object.freeze({
+  Biometrics: "biometrics",
+  SharedUnlock: "sharedUnlock",
+} as const);
+export type NativeMessagingPermissionDialogType =
+  (typeof NativeMessagingPermissionDialogType)[keyof typeof NativeMessagingPermissionDialogType];
+
+const DESCRIPTION_KEY_BY_TYPE: Record<NativeMessagingPermissionDialogType, string> = {
+  [NativeMessagingPermissionDialogType.Biometrics]: "biometricPermissionDesc",
+  [NativeMessagingPermissionDialogType.SharedUnlock]: "sharedUnlockDesktopPermissionDesc",
+};
+
+/**
+ * Informational dialog shown in the popped-out Account Security page when the user enables
+ * a feature requiring the `nativeMessaging` permission. It explains that the browser will
+ * prompt for the optional permission and that granting it reloads the extension and locks the vault.
+ *
+ * When the user continues, the dialog requests the `nativeMessaging` permission and closes with
+ * `true` when it was granted and `false` when it was not. Closing without proceeding (via
+ * `bitDialogClose`) closes with `undefined`.
+ *
+ * When the dialog emits `true`, the newly granted `nativeMessaging` permission is not usable until
+ * the extension reloads to register the native messaging host. The caller is therefore responsible
+ * for reloading the extension (e.g. `messagingService.send("reloadExtension")`) after persisting
+ * any state that must survive the reload.
+ */
+export type NativeMessagingPermissionDialogParams = {
+  type: NativeMessagingPermissionDialogType;
+};
+
+@Component({
+  templateUrl: "./native-messaging-permission-dialog.component.html",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [ButtonModule, CalloutComponent, DialogModule, TypographyModule, I18nPipe],
+})
+export class NativeMessagingPermissionDialogComponent {
+  private readonly dialogRef = inject(DialogRef<boolean>);
+  private readonly dialogService = inject(DialogService);
+  private readonly platformUtilsService = inject(PlatformUtilsService);
+  private readonly params = inject<NativeMessagingPermissionDialogParams | null>(DIALOG_DATA, {
+    optional: true,
+  });
+  protected readonly descriptionKey =
+    DESCRIPTION_KEY_BY_TYPE[this.params?.type ?? NativeMessagingPermissionDialogType.Biometrics];
+
+  async continue() {
+    let granted = false;
+    try {
+      granted = (await BrowserApi.requestPermission({
+        permissions: ["nativeMessaging"],
+      })) as boolean;
+    } catch {
+      if (this.platformUtilsService.isFirefox() && BrowserPopupUtils.inSidebar(window)) {
+        await this.dialogService.openSimpleDialog({
+          title: { key: "nativeMessaginPermissionSidebarTitle" },
+          content: { key: "nativeMessaginPermissionSidebarDesc" },
+          acceptButtonText: { key: "ok" },
+          cancelButtonText: null,
+          type: "info",
+        });
+      }
+      granted = false;
+    }
+    void this.dialogRef.close(granted);
+  }
+
+  /**
+   * @throws if not called from a popout. Requesting the `nativeMessaging` permission reloads the
+   * extension on grant, which would close a popup or sidebar; the flow must be popped out to a
+   * stable window first.
+   */
+  static open(
+    dialogService: DialogService,
+    params: NativeMessagingPermissionDialogParams,
+  ): DialogRef<boolean> {
+    if (!BrowserPopupUtils.inPopout(window)) {
+      throw new Error(
+        "NativeMessagingPermissionDialogComponent must be opened from a popout, so the extension " +
+          "can reload after the permission is granted without closing the window.",
+      );
+    }
+
+    return dialogService.open<boolean>(NativeMessagingPermissionDialogComponent, {
+      positionStrategy: new CenterPositionStrategy(),
+      data: params,
+    });
+  }
+}


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-40060

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Adds a new dialog. This will be responsible for asking for the native messaging permission. The design is confirmed by product.

The flow will be:
1. User clicks on feature that needs permission
2. If popup -> convert to popout and show dialog
3. If popout -> show dialog
4. -> The dialog primes the user.
5. After the user clicks continue, ask for permission
6. After permission is granted, return true
7. -> The caller is expected to set / unset the setting in the UI thread it was called from. If the result was true, they must also do an extension reload for the permission to become active.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

<img width="766" height="1016" alt="image" src="https://github.com/user-attachments/assets/e1f243b3-7aa6-48b4-b548-ad217fceb6d6" />

