### PR TITLE
[PM-39259] Migrate auth token key generation to SDK

### DIFF
--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -750,7 +750,6 @@ export default class MainBackground {
       this.globalStateProvider,
       this.platformUtilsService.supportsSecureStorage(),
       this.secureStorageService,
-      this.keyGenerationService,
       this.encryptService,
       this.logService,
       logoutCallback,

--- a/apps/cli/src/auth/commands/login.command.spec.ts
+++ b/apps/cli/src/auth/commands/login.command.spec.ts
@@ -29,12 +29,15 @@ import { ErrorResponse } from "@bitwarden/common/models/response/error.response"
 import { EnvironmentService } from "@bitwarden/common/platform/abstractions/environment.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
+import { SdkLoadService } from "@bitwarden/common/platform/abstractions/sdk/sdk-load.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
+import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
 import { CsprngArray } from "@bitwarden/common/types/csprng";
 import { UserId } from "@bitwarden/common/types/guid";
 import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.service.abstraction";
 import { PasswordGenerationServiceAbstraction } from "@bitwarden/generator-legacy";
 import { NodeUtils } from "@bitwarden/node/node-utils";
+import { PureCrypto } from "@bitwarden/sdk-internal";
 
 import { ConfirmKeyConnectorDomainCommand } from "../../key-management/confirm-key-connector-domain.command";
 import { Response } from "../../models/response";
@@ -136,6 +139,17 @@ describe("LoginCommand", () => {
     masterPasswordService = mock<MasterPasswordServiceAbstraction>();
     userDecryptionOptionsService = mock<UserDecryptionOptionsServiceAbstraction>();
     encryptedMigrator = mock<EncryptedMigrator>();
+
+    // Session key is generated via the SDK: SymmetricCryptoKey.fromSdk(PureCrypto.make_aes256_cbc_hmac_key()).
+    // Stub the SDK load gate and key generation so validatedParams() produces a deterministic session key.
+    Object.defineProperty(SdkLoadService, "Ready", {
+      value: Promise.resolve(),
+      configurable: true,
+    });
+    jest.spyOn(PureCrypto, "make_aes256_cbc_hmac_key").mockReturnValue({} as any);
+    jest
+      .spyOn(SymmetricCryptoKey, "fromSdk")
+      .mockReturnValue({ toBase64: () => B64_SESSION_KEY } as SymmetricCryptoKey);
 
     // Default mock behaviors for a successful password login
     i18nService.t.mockImplementation((key: string) => key);

--- a/apps/cli/src/auth/commands/login.command.ts
+++ b/apps/cli/src/auth/commands/login.command.ts
@@ -36,11 +36,14 @@ import { ErrorResponse } from "@bitwarden/common/models/response/error.response"
 import { EnvironmentService } from "@bitwarden/common/platform/abstractions/environment.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
+import { SdkLoadService } from "@bitwarden/common/platform/abstractions/sdk/sdk-load.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
+import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
 import { UserId } from "@bitwarden/common/types/guid";
 import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.service.abstraction";
 import { PasswordGenerationServiceAbstraction } from "@bitwarden/generator-legacy";
 import { NodeUtils } from "@bitwarden/node/node-utils";
+import { PureCrypto } from "@bitwarden/sdk-internal";
 
 import { ConfirmKeyConnectorDomainCommand } from "../../key-management/confirm-key-connector-domain.command";
 import { Response } from "../../models/response";
@@ -436,8 +439,9 @@ export class LoginCommand {
   }
 
   private async validatedParams() {
-    const key = await this.cryptoFunctionService.randomBytes(64);
-    process.env.BW_SESSION = Utils.fromBufferToB64(key);
+    await SdkLoadService.Ready;
+    const key = SymmetricCryptoKey.fromSdk(PureCrypto.make_aes256_cbc_hmac_key());
+    process.env.BW_SESSION = key.toBase64();
   }
 
   private async handleSuccessResponse(response: AuthResult): Promise<Response> {

--- a/apps/cli/src/service-container/service-container.ts
+++ b/apps/cli/src/service-container/service-container.ts
@@ -489,7 +489,6 @@ export class ServiceContainer {
       this.globalStateProvider,
       this.platformUtilsService.supportsSecureStorage(),
       this.secureStorageService,
-      this.keyGenerationService,
       this.encryptService,
       this.logService,
       logoutCallback,

--- a/libs/angular/src/services/jslib-services.module.ts
+++ b/libs/angular/src/services/jslib-services.module.ts
@@ -818,7 +818,6 @@ const safeProviders: SafeProvider[] = [
       GlobalStateProvider,
       SUPPORTS_SECURE_STORAGE,
       SECURE_STORAGE,
-      KeyGenerationService,
       EncryptService,
       LogService,
       LOGOUT_CALLBACK,

--- a/libs/common/src/auth/services/token.service.spec.ts
+++ b/libs/common/src/auth/services/token.service.spec.ts
@@ -6,9 +6,9 @@ import { firstValueFrom } from "rxjs";
 // This import has been flagged as unallowed for this class. It may be involved in a circular dependency loop.
 // eslint-disable-next-line no-restricted-imports
 import { LogoutReason } from "@bitwarden/auth/common";
+import { PureCrypto } from "@bitwarden/sdk-internal";
 
 import { FakeSingleUserStateProvider, FakeGlobalStateProvider } from "../../../spec";
-import { KeyGenerationService } from "../../key-management/crypto";
 import { EncryptService } from "../../key-management/crypto/abstractions/encrypt.service";
 import {
   VaultTimeout,
@@ -16,6 +16,7 @@ import {
   VaultTimeoutStringType,
 } from "../../key-management/vault-timeout";
 import { LogService } from "../../platform/abstractions/log.service";
+import { SdkLoadService } from "../../platform/abstractions/sdk/sdk-load.service";
 import { AbstractStorageService } from "../../platform/abstractions/storage.service";
 import { StorageLocation } from "../../platform/enums";
 import { StorageOptions } from "../../platform/models/domain/storage-options";
@@ -50,7 +51,6 @@ describe("TokenService", () => {
   let globalStateProvider: FakeGlobalStateProvider;
 
   let secureStorageService: MockProxy<AbstractStorageService>;
-  let keyGenerationService: MockProxy<KeyGenerationService>;
   let encryptService: MockProxy<EncryptService>;
   let logService: MockProxy<LogService>;
   let logoutCallback: jest.Mock<Promise<void>, [logoutReason: LogoutReason, userId?: string]>;
@@ -111,10 +111,15 @@ describe("TokenService", () => {
     globalStateProvider = new FakeGlobalStateProvider();
 
     secureStorageService = mock<AbstractStorageService>();
-    keyGenerationService = mock<KeyGenerationService>();
     encryptService = mock<EncryptService>();
     logService = mock<LogService>();
     logoutCallback = jest.fn();
+
+    Object.defineProperty(SdkLoadService, "Ready", {
+      value: Promise.resolve(),
+      configurable: true,
+    });
+    jest.spyOn(PureCrypto, "make_aes256_cbc_hmac_key").mockReturnValue({} as any);
 
     const supportsSecureStorage = false; // default to false; tests will override as needed
     tokenService = createTokenService(supportsSecureStorage);
@@ -291,7 +296,7 @@ describe("TokenService", () => {
             .getFake(userIdFromAccessToken, ACCESS_TOKEN_MEMORY)
             .nextState(accessTokenJwt);
 
-          keyGenerationService.createKey.mockResolvedValue(accessTokenKey);
+          jest.spyOn(SymmetricCryptoKey, "fromSdk").mockReturnValue(accessTokenKey);
 
           const mockEncryptedAccessToken = "encryptedAccessToken";
 
@@ -337,7 +342,7 @@ describe("TokenService", () => {
           // This tests the scenario where the access token key silently fails to be set in secure storage
 
           // Arrange:
-          keyGenerationService.createKey.mockResolvedValue(accessTokenKey);
+          jest.spyOn(SymmetricCryptoKey, "fromSdk").mockReturnValue(accessTokenKey);
 
           // First call resolves to null to simulate no key in secure storage
           // and then resolves to no key after it should have been set
@@ -377,7 +382,7 @@ describe("TokenService", () => {
           // This tests the scenario for linux users who don't have secure storage configured.
 
           // Arrange:
-          keyGenerationService.createKey.mockResolvedValue(accessTokenKey);
+          jest.spyOn(SymmetricCryptoKey, "fromSdk").mockReturnValue(accessTokenKey);
 
           // Mock linux secure storage error
           const secureStorageError = "Secure storage error";
@@ -466,7 +471,7 @@ describe("TokenService", () => {
               .getFake(userIdFromAccessToken, ACCESS_TOKEN_MEMORY)
               .nextState(accessTokenJwt);
 
-            keyGenerationService.createKey.mockResolvedValue(accessTokenKey);
+            jest.spyOn(SymmetricCryptoKey, "fromSdk").mockReturnValue(accessTokenKey);
             encryptService.encryptString.mockResolvedValue({
               encryptedString: "encryptedAccessToken",
             } as any);
@@ -493,7 +498,7 @@ describe("TokenService", () => {
               .getFake(userIdFromAccessToken, ACCESS_TOKEN_MEMORY)
               .nextState(accessTokenJwt);
 
-            keyGenerationService.createKey.mockResolvedValue(accessTokenKey);
+            jest.spyOn(SymmetricCryptoKey, "fromSdk").mockReturnValue(accessTokenKey);
             // Both get calls return null: first (before save) → null key, second (after save) → null
             // key, which causes the "key unable to be retrieved" error and falls into the catch block.
             secureStorageService.get.mockResolvedValue(null);
@@ -517,7 +522,7 @@ describe("TokenService", () => {
               .getFake(userIdFromAccessToken, ACCESS_TOKEN_MEMORY)
               .nextState(accessTokenJwt);
 
-            keyGenerationService.createKey.mockResolvedValue(accessTokenKey);
+            jest.spyOn(SymmetricCryptoKey, "fromSdk").mockReturnValue(accessTokenKey);
             secureStorageService.get.mockRejectedValue(new Error("Secure storage error"));
 
             // Act
@@ -3218,7 +3223,6 @@ describe("TokenService", () => {
       globalStateProvider,
       supportsSecureStorage,
       secureStorageService,
-      keyGenerationService,
       encryptService,
       logService,
       logoutCallback,

--- a/libs/common/src/auth/services/token.service.ts
+++ b/libs/common/src/auth/services/token.service.ts
@@ -6,8 +6,8 @@ import { Opaque } from "type-fest";
 // This import has been flagged as unallowed for this class. It may be involved in a circular dependency loop.
 // eslint-disable-next-line no-restricted-imports
 import { LogoutReason, decodeJwtTokenToJson } from "@bitwarden/auth/common";
+import { PureCrypto } from "@bitwarden/sdk-internal";
 
-import { KeyGenerationService } from "../../key-management/crypto";
 import { EncryptService } from "../../key-management/crypto/abstractions/encrypt.service";
 import { EncString, EncryptedString } from "../../key-management/crypto/models/enc-string";
 import {
@@ -16,6 +16,7 @@ import {
   VaultTimeoutStringType,
 } from "../../key-management/vault-timeout";
 import { LogService } from "../../platform/abstractions/log.service";
+import { SdkLoadService } from "../../platform/abstractions/sdk/sdk-load.service";
 import { AbstractStorageService } from "../../platform/abstractions/storage.service";
 import { StorageLocation } from "../../platform/enums";
 import { Utils } from "../../platform/misc/utils";
@@ -140,7 +141,6 @@ export class TokenService implements TokenServiceAbstraction {
     private globalStateProvider: GlobalStateProvider,
     private readonly platformSupportsSecureStorage: boolean,
     private secureStorageService: AbstractStorageService,
-    private keyGenerationService: KeyGenerationService,
     private encryptService: EncryptService,
     private logService: LogService,
     private logoutCallback: (logoutReason: LogoutReason, userId?: string) => Promise<void>,
@@ -242,7 +242,10 @@ export class TokenService implements TokenServiceAbstraction {
   }
 
   private async createAndSaveAccessTokenKey(userId: UserId): Promise<AccessTokenKey> {
-    const newAccessTokenKey = (await this.keyGenerationService.createKey(512)) as AccessTokenKey;
+    await SdkLoadService.Ready;
+    const newAccessTokenKey = SymmetricCryptoKey.fromSdk(
+      PureCrypto.make_aes256_cbc_hmac_key(),
+    ) as AccessTokenKey;
 
     await this.secureStorageService.save<AccessTokenKey>(
       `${userId}${this.accessTokenKeySecureStorageKey}`,


### PR DESCRIPTION
https://bitwarden.atlassian.net/browse/PM-39259

Migrates auth callers to use SDK key-generation (and transitively SDK randomness), since we are removing the typescript random implementation and keygen code.