### PR TITLE
[PM-39259] Migrate key-management consumers to SDK key generation

### DIFF
--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -970,7 +970,6 @@ export default class MainBackground {
       this.tokenService,
       this.logService,
       this.organizationService,
-      this.keyGenerationService,
       logoutCallback,
       this.stateProvider,
       this.configService,
@@ -1024,7 +1023,6 @@ export default class MainBackground {
 
     this.devicesApiService = new DevicesApiServiceImplementation(this.apiService);
     this.deviceTrustService = new DeviceTrustService(
-      this.keyGenerationService,
       this.cryptoFunctionService,
       this.keyService,
       this.encryptService,

--- a/apps/cli/src/base-program.ts
+++ b/apps/cli/src/base-program.ts
@@ -172,7 +172,6 @@ export abstract class BaseProgram {
     } else {
       const command = new UnlockCommand(
         this.serviceContainer.accountService,
-        this.serviceContainer.cryptoFunctionService,
         this.serviceContainer.logService,
         this.serviceContainer.keyConnectorService,
         this.serviceContainer.environmentService,

--- a/apps/cli/src/key-management/commands/unlock.command.spec.ts
+++ b/apps/cli/src/key-management/commands/unlock.command.spec.ts
@@ -3,14 +3,15 @@ import { of } from "rxjs";
 
 import { OrganizationApiServiceAbstraction } from "@bitwarden/common/admin-console/abstractions/organization/organization-api.service.abstraction";
 import { Account, AccountService } from "@bitwarden/common/auth/abstractions/account.service";
-import { CryptoFunctionService } from "@bitwarden/common/key-management/crypto/abstractions/crypto-function.service";
 import { EncryptedMigrator } from "@bitwarden/common/key-management/encrypted-migrator/encrypted-migrator.abstraction";
 import { KeyConnectorService } from "@bitwarden/common/key-management/key-connector/abstractions/key-connector.service";
 import { EnvironmentService } from "@bitwarden/common/platform/abstractions/environment.service";
+import { SdkLoadService } from "@bitwarden/common/platform/abstractions/sdk/sdk-load.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { mockAccountInfoWith } from "@bitwarden/common/spec";
 import { CsprngArray } from "@bitwarden/common/types/csprng";
 import { ConsoleLogService } from "@bitwarden/logging";
+import { PureCrypto, SymmetricKey } from "@bitwarden/sdk-internal";
 import { UnlockService } from "@bitwarden/unlock";
 import { UserId } from "@bitwarden/user-core";
 
@@ -24,7 +25,6 @@ describe("UnlockCommand", () => {
   let command: UnlockCommand;
 
   const accountService = mock<AccountService>();
-  const cryptoFunctionService = mock<CryptoFunctionService>();
   const logService = mock<ConsoleLogService>();
   const keyConnectorService = mock<KeyConnectorService>();
   const environmentService = mock<EnvironmentService>();
@@ -66,11 +66,18 @@ describe("UnlockCommand", () => {
     i18nService.t.mockImplementation((key: string) => key);
     accountService.activeAccount$ = of(activeAccount);
     keyConnectorService.convertAccountRequired$ = of(false);
-    cryptoFunctionService.randomBytes.mockResolvedValue(mockSessionKey);
+
+    Object.defineProperty(SdkLoadService, "Ready", {
+      value: Promise.resolve(),
+      writable: true,
+      configurable: true,
+    });
+    jest
+      .spyOn(PureCrypto, "make_aes256_cbc_hmac_key")
+      .mockReturnValue(b64sessionKey as SymmetricKey);
 
     command = new UnlockCommand(
       accountService,
-      cryptoFunctionService,
       logService,
       keyConnectorService,
       environmentService,

--- a/apps/cli/src/key-management/commands/unlock.command.ts
+++ b/apps/cli/src/key-management/commands/unlock.command.ts
@@ -4,12 +4,13 @@ import { firstValueFrom } from "rxjs";
 
 import { OrganizationApiServiceAbstraction } from "@bitwarden/common/admin-console/abstractions/organization/organization-api.service.abstraction";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
-import { CryptoFunctionService } from "@bitwarden/common/key-management/crypto/abstractions/crypto-function.service";
 import { EncryptedMigrator } from "@bitwarden/common/key-management/encrypted-migrator/encrypted-migrator.abstraction";
 import { KeyConnectorService } from "@bitwarden/common/key-management/key-connector/abstractions/key-connector.service";
 import { EnvironmentService } from "@bitwarden/common/platform/abstractions/environment.service";
-import { Utils } from "@bitwarden/common/platform/misc/utils";
+import { SdkLoadService } from "@bitwarden/common/platform/abstractions/sdk/sdk-load.service";
+import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
 import { ConsoleLogService } from "@bitwarden/common/platform/services/console-log.service";
+import { PureCrypto } from "@bitwarden/sdk-internal";
 import { UnlockService } from "@bitwarden/unlock";
 
 import { Response } from "../../models/response";
@@ -21,7 +22,6 @@ import { ConvertToKeyConnectorCommand } from "../convert-to-key-connector.comman
 export class UnlockCommand {
   constructor(
     private accountService: AccountService,
-    private cryptoFunctionService: CryptoFunctionService,
     private logService: ConsoleLogService,
     private keyConnectorService: KeyConnectorService,
     private environmentService: EnvironmentService,
@@ -76,8 +76,9 @@ export class UnlockCommand {
   }
 
   private async setNewSessionKey() {
-    const key = await this.cryptoFunctionService.randomBytes(64);
-    process.env.BW_SESSION = Utils.fromBufferToB64(key);
+    await SdkLoadService.Ready;
+    const key = SymmetricCryptoKey.fromSdk(PureCrypto.make_aes256_cbc_hmac_key());
+    process.env.BW_SESSION = key.toBase64();
   }
 
   private async successResponse() {

--- a/apps/cli/src/oss-serve-configurator.ts
+++ b/apps/cli/src/oss-serve-configurator.ts
@@ -167,7 +167,6 @@ export class OssServeConfigurator {
     );
     this.unlockCommand = new UnlockCommand(
       this.serviceContainer.accountService,
-      this.serviceContainer.cryptoFunctionService,
       this.serviceContainer.logService,
       this.serviceContainer.keyConnectorService,
       this.serviceContainer.environmentService,

--- a/apps/cli/src/program.ts
+++ b/apps/cli/src/program.ts
@@ -289,7 +289,6 @@ export class Program extends BaseProgram {
           await this.exitIfNotAuthed();
           const command = new UnlockCommand(
             this.serviceContainer.accountService,
-            this.serviceContainer.cryptoFunctionService,
             this.serviceContainer.logService,
             this.serviceContainer.keyConnectorService,
             this.serviceContainer.environmentService,

--- a/apps/cli/src/service-container/service-container.ts
+++ b/apps/cli/src/service-container/service-container.ts
@@ -754,7 +754,6 @@ export class ServiceContainer {
       this.tokenService,
       this.logService,
       this.organizationService,
-      this.keyGenerationService,
       logoutCallback,
       this.stateProvider,
       this.configService,
@@ -801,7 +800,6 @@ export class ServiceContainer {
 
     this.devicesApiService = new DevicesApiServiceImplementation(this.apiService);
     this.deviceTrustService = new DeviceTrustService(
-      this.keyGenerationService,
       this.cryptoFunctionService,
       this.keyService,
       this.encryptService,

--- a/apps/desktop/src/services/biometric-message-handler.service.spec.ts
+++ b/apps/desktop/src/services/biometric-message-handler.service.spec.ts
@@ -17,6 +17,19 @@ import { DesktopSettingsService } from "../platform/services/desktop-settings.se
 
 import { BiometricMessageHandlerService } from "./biometric-message-handler.service";
 
+jest.mock("@bitwarden/sdk-internal", () => ({
+  PureCrypto: {
+    make_aes256_cbc_hmac_key: jest.fn(),
+  },
+}));
+
+jest.mock("@bitwarden/common/platform/abstractions/sdk/sdk-load.service", () => ({
+  SdkLoadService: { Ready: Promise.resolve() },
+}));
+
+const makeAes256CbcHmacKey = jest.requireMock("@bitwarden/sdk-internal").PureCrypto
+  .make_aes256_cbc_hmac_key as jest.Mock;
+
 const SomeUser = "SomeUser" as UserId;
 const AnotherUser = "SomeOtherUser" as UserId;
 const accounts = {
@@ -67,6 +80,7 @@ describe("BiometricMessageHandlerService", () => {
       },
     };
     cryptoFunctionService.randomBytes.mockResolvedValue(new Uint8Array(64) as CsprngArray);
+    makeAes256CbcHmacKey.mockReturnValue(Utils.fromBufferToB64(new Uint8Array(64)));
     cryptoFunctionService.rsaEncrypt.mockResolvedValue(
       Utils.fromUtf8ToArray("encrypted") as CsprngArray,
     );

--- a/apps/desktop/src/services/biometric-message-handler.service.ts
+++ b/apps/desktop/src/services/biometric-message-handler.service.ts
@@ -8,10 +8,12 @@ import { CryptoFunctionService } from "@bitwarden/common/key-management/crypto/a
 import { EncryptService } from "@bitwarden/common/key-management/crypto/abstractions/encrypt.service";
 import { EncString } from "@bitwarden/common/key-management/crypto/models/enc-string";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+import { SdkLoadService } from "@bitwarden/common/platform/abstractions/sdk/sdk-load.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
 import { UserId } from "@bitwarden/common/types/guid";
 import { BiometricsCommands, BiometricsStatus } from "@bitwarden/key-management";
+import { PureCrypto } from "@bitwarden/sdk-internal";
 
 import { DesktopBiometricsService } from "../key-management/biometrics/desktop.biometrics.service";
 import { LegacyMessage, LegacyMessageWrapper } from "../models/native-messaging";
@@ -260,14 +262,15 @@ export class BiometricMessageHandlerService {
     remotePublicKey: Uint8Array,
     appId: string,
   ) {
-    const secret = await this.cryptoFunctionService.randomBytes(64);
+    await SdkLoadService.Ready;
+    const secret = SymmetricCryptoKey.fromSdk(PureCrypto.make_aes256_cbc_hmac_key());
 
-    connectedApp.sessionSecret = new SymmetricCryptoKey(secret).keyB64;
+    connectedApp.sessionSecret = secret.keyB64;
     await this.connectedApps.set(appId, connectedApp);
 
     this.logService.info("[Native Messaging IPC] Setting up secure channel");
     const encryptedSecret = await this.cryptoFunctionService.rsaEncrypt(
-      secret,
+      secret.toEncoded(),
       remotePublicKey,
       HashAlgorithmForAsymmetricEncryption,
     );

--- a/libs/angular/src/services/jslib-services.module.ts
+++ b/libs/angular/src/services/jslib-services.module.ts
@@ -1312,7 +1312,6 @@ const safeProviders: SafeProvider[] = [
       TokenServiceAbstraction,
       LogService,
       OrganizationServiceAbstraction,
-      KeyGenerationService,
       LOGOUT_CALLBACK,
       StateProvider,
       ConfigService,
@@ -1510,7 +1509,6 @@ const safeProviders: SafeProvider[] = [
     provide: DeviceTrustServiceAbstraction,
     useClass: DeviceTrustService,
     deps: [
-      KeyGenerationService,
       CryptoFunctionServiceAbstraction,
       KeyService,
       EncryptService,

--- a/libs/common/src/key-management/device-trust/services/device-trust.service.implementation.ts
+++ b/libs/common/src/key-management/device-trust/services/device-trust.service.implementation.ts
@@ -8,6 +8,7 @@ import { UserDecryptionOptionsServiceAbstraction } from "@bitwarden/auth/common"
 // This import has been flagged as unallowed for this class. It may be involved in a circular dependency loop.
 // eslint-disable-next-line no-restricted-imports
 import { KeyService } from "@bitwarden/key-management";
+import { PureCrypto } from "@bitwarden/sdk-internal";
 
 import { AccountService } from "../../../auth/abstractions/account.service";
 import { DeviceResponse } from "../../../auth/abstractions/devices/responses/device.response";
@@ -23,6 +24,7 @@ import { ConfigService } from "../../../platform/abstractions/config/config.serv
 import { I18nService } from "../../../platform/abstractions/i18n.service";
 import { LogService } from "../../../platform/abstractions/log.service";
 import { PlatformUtilsService } from "../../../platform/abstractions/platform-utils.service";
+import { SdkLoadService } from "../../../platform/abstractions/sdk/sdk-load.service";
 import { AbstractStorageService } from "../../../platform/abstractions/storage.service";
 import { StorageLocation } from "../../../platform/enums";
 import { StorageOptions } from "../../../platform/models/domain/storage-options";
@@ -30,7 +32,6 @@ import { SymmetricCryptoKey } from "../../../platform/models/domain/symmetric-cr
 import { DEVICE_TRUST_DISK_LOCAL, StateProvider, UserKeyDefinition } from "../../../platform/state";
 import { UserId } from "../../../types/guid";
 import { UserKey, DeviceKey } from "../../../types/key";
-import { KeyGenerationService } from "../../crypto";
 import { CryptoFunctionService } from "../../crypto/abstractions/crypto-function.service";
 import { EncryptService } from "../../crypto/abstractions/encrypt.service";
 import { EncString } from "../../crypto/models/enc-string";
@@ -75,7 +76,6 @@ export class DeviceTrustService implements DeviceTrustServiceAbstraction {
   deviceTrusted$ = this.deviceTrustedSubject.asObservable();
 
   constructor(
-    private keyGenerationService: KeyGenerationService,
     private cryptoFunctionService: CryptoFunctionService,
     private keyService: KeyService,
     private encryptService: EncryptService,
@@ -379,7 +379,10 @@ export class DeviceTrustService implements DeviceTrustServiceAbstraction {
 
   private async makeDeviceKey(): Promise<DeviceKey> {
     // Create 512-bit device key
-    const deviceKey = (await this.keyGenerationService.createKey(512)) as DeviceKey;
+    await SdkLoadService.Ready;
+    const deviceKey = SymmetricCryptoKey.fromSdk(
+      PureCrypto.make_aes256_cbc_hmac_key(),
+    ) as DeviceKey;
 
     return deviceKey;
   }

--- a/libs/common/src/key-management/device-trust/services/device-trust.service.spec.ts
+++ b/libs/common/src/key-management/device-trust/services/device-trust.service.spec.ts
@@ -12,6 +12,7 @@ import {
 // This import has been flagged as unallowed for this class. It may be involved in a circular dependency loop.
 // eslint-disable-next-line no-restricted-imports
 import { KeyService } from "@bitwarden/key-management";
+import { PureCrypto } from "@bitwarden/sdk-internal";
 
 import { FakeAccountService, mockAccountServiceWith } from "../../../../spec/fake-account-service";
 import { FakeActiveUserState } from "../../../../spec/fake-state";
@@ -27,6 +28,7 @@ import { ConfigService } from "../../../platform/abstractions/config/config.serv
 import { I18nService } from "../../../platform/abstractions/i18n.service";
 import { LogService } from "../../../platform/abstractions/log.service";
 import { PlatformUtilsService } from "../../../platform/abstractions/platform-utils.service";
+import { SdkLoadService } from "../../../platform/abstractions/sdk/sdk-load.service";
 import { AbstractStorageService } from "../../../platform/abstractions/storage.service";
 import { StorageLocation } from "../../../platform/enums";
 import { EncryptionType } from "../../../platform/enums/encryption-type.enum";
@@ -36,7 +38,6 @@ import { SymmetricCryptoKey } from "../../../platform/models/domain/symmetric-cr
 import { CsprngArray } from "../../../types/csprng";
 import { UserId } from "../../../types/guid";
 import { DeviceKey, UserKey } from "../../../types/key";
-import { KeyGenerationService } from "../../crypto";
 import { CryptoFunctionService } from "../../crypto/abstractions/crypto-function.service";
 import { EncryptService } from "../../crypto/abstractions/encrypt.service";
 import { EncString } from "../../crypto/models/enc-string";
@@ -50,7 +51,6 @@ import {
 describe("deviceTrustService", () => {
   let deviceTrustService: DeviceTrustService;
 
-  const keyGenerationService = mock<KeyGenerationService>();
   const cryptoFunctionService = mock<CryptoFunctionService>();
   const keyService = mock<KeyService>();
   const encryptService = mock<EncryptService>();
@@ -325,16 +325,18 @@ describe("deviceTrustService", () => {
         const mockRandomBytes = new Uint8Array(deviceKeyBytesLength) as CsprngArray;
         const mockDeviceKey = new SymmetricCryptoKey(mockRandomBytes) as DeviceKey;
 
-        const keyGenSvcGenerateKeySpy = jest
-          .spyOn(keyGenerationService, "createKey")
-          .mockResolvedValue(mockDeviceKey);
+        Object.defineProperty(SdkLoadService, "Ready", {
+          value: Promise.resolve(),
+          configurable: true,
+        });
+        jest.spyOn(PureCrypto, "make_aes256_cbc_hmac_key").mockReturnValue({} as any);
+        jest.spyOn(SymmetricCryptoKey, "fromSdk").mockReturnValue(mockDeviceKey);
 
         // TypeScript will allow calling private methods if the object is of type 'any'
         // This is a hacky workaround, but it allows for cleaner tests
         const deviceKey = await (deviceTrustService as any).makeDeviceKey();
 
-        expect(keyGenSvcGenerateKeySpy).toHaveBeenCalledTimes(1);
-        expect(keyGenSvcGenerateKeySpy).toHaveBeenCalledWith(deviceKeyBytesLength * 8);
+        expect(PureCrypto.make_aes256_cbc_hmac_key).toHaveBeenCalledTimes(1);
 
         expect(deviceKey).not.toBeNull();
         expect(deviceKey).toBeInstanceOf(SymmetricCryptoKey);
@@ -917,7 +919,6 @@ describe("deviceTrustService", () => {
     userDecryptionOptionsService.userDecryptionOptionsById$.mockReturnValue(decryptionOptions);
 
     return new DeviceTrustService(
-      keyGenerationService,
       cryptoFunctionService,
       keyService,
       encryptService,

--- a/libs/common/src/key-management/key-connector/services/key-connector.service.spec.ts
+++ b/libs/common/src/key-management/key-connector/services/key-connector.service.spec.ts
@@ -10,7 +10,7 @@ import {
 // This import has been flagged as unallowed for this class. It may be involved in a circular dependency loop.
 // eslint-disable-next-line no-restricted-imports
 import { Argon2KdfConfig, KdfType, KeyService, PBKDF2KdfConfig } from "@bitwarden/key-management";
-import { BitwardenClient } from "@bitwarden/sdk-internal";
+import { BitwardenClient, PureCrypto } from "@bitwarden/sdk-internal";
 
 import { FakeAccountService, FakeStateProvider, mockAccountServiceWith } from "../../../../spec";
 import { ApiService } from "../../../abstractions/api.service";
@@ -25,6 +25,7 @@ import { KeysRequest } from "../../../models/request/keys.request";
 import { ConfigService } from "../../../platform/abstractions/config/config.service";
 import { LogService } from "../../../platform/abstractions/log.service";
 import { RegisterSdkService } from "../../../platform/abstractions/sdk/register-sdk.service";
+import { SdkLoadService } from "../../../platform/abstractions/sdk/sdk-load.service";
 import { SdkService } from "../../../platform/abstractions/sdk/sdk.service";
 import { Rc } from "../../../platform/misc/reference-counting/rc";
 import { Utils } from "../../../platform/misc/utils";
@@ -32,7 +33,6 @@ import { SymmetricCryptoKey } from "../../../platform/models/domain/symmetric-cr
 import { OrganizationId, UserId } from "../../../types/guid";
 import { MasterKey, UserKey } from "../../../types/key";
 import { AccountCryptographicStateService } from "../../account-cryptography/account-cryptographic-state.service";
-import { KeyGenerationService } from "../../crypto";
 import { EncString } from "../../crypto/models/enc-string";
 import { FakeMasterPasswordService } from "../../master-password/services/fake-master-password.service";
 import { KeyConnectorUserKeyRequest } from "../models/key-connector-user-key.request";
@@ -53,7 +53,6 @@ describe("KeyConnectorService", () => {
   const tokenService = mock<TokenService>();
   const logService = mock<LogService>();
   const organizationService = mock<OrganizationService>();
-  const keyGenerationService = mock<KeyGenerationService>();
   const logoutCallback = jest.fn();
   const configService = mock<ConfigService>();
   const registerSdkService = mock<RegisterSdkService>();
@@ -97,7 +96,6 @@ describe("KeyConnectorService", () => {
       tokenService,
       logService,
       organizationService,
-      keyGenerationService,
       logoutCallback,
       stateProvider,
       configService,
@@ -662,7 +660,12 @@ describe("KeyConnectorService", () => {
         const encString = new EncString("mockEncryptedString");
         mockMakeUserKeyResult = [mockUserKey, encString] as [UserKey, EncString];
 
-        keyGenerationService.createKey.mockResolvedValue(passwordKey);
+        Object.defineProperty(SdkLoadService, "Ready", {
+          value: Promise.resolve(),
+          configurable: true,
+        });
+        jest.spyOn(PureCrypto, "make_aes256_cbc_hmac_key").mockReturnValue({} as any);
+        jest.spyOn(SymmetricCryptoKey, "fromSdk").mockReturnValue(passwordKey);
         keyService.makeMasterKey.mockResolvedValue(mockMasterKey);
         keyService.makeUserKey.mockResolvedValue(mockMakeUserKeyResult);
         keyService.makeKeyPair.mockResolvedValue(mockKeyPair);
@@ -694,7 +697,7 @@ describe("KeyConnectorService", () => {
 
           await keyConnectorService.convertNewSsoUserToKeyConnector(mockUserId);
 
-          expect(keyGenerationService.createKey).toHaveBeenCalledWith(512);
+          expect(PureCrypto.make_aes256_cbc_hmac_key).toHaveBeenCalled();
           expect(keyService.makeMasterKey).toHaveBeenCalledWith(
             passwordKey.keyB64,
             mockEmail,
@@ -744,7 +747,7 @@ describe("KeyConnectorService", () => {
           keyConnectorService.convertNewSsoUserToKeyConnector(mockUserId),
         ).rejects.toThrow(new Error("Key Connector error"));
 
-        expect(keyGenerationService.createKey).toHaveBeenCalledWith(512);
+        expect(PureCrypto.make_aes256_cbc_hmac_key).toHaveBeenCalled();
         expect(keyService.makeMasterKey).toHaveBeenCalledWith(
           passwordKey.keyB64,
           mockEmail,
@@ -785,7 +788,7 @@ describe("KeyConnectorService", () => {
         ).rejects.toThrow(new Error("Key Connector conversion not found"));
 
         // Verify that no key generation or API calls were made
-        expect(keyGenerationService.createKey).not.toHaveBeenCalled();
+        expect(PureCrypto.make_aes256_cbc_hmac_key).not.toHaveBeenCalled();
         expect(keyService.makeMasterKey).not.toHaveBeenCalled();
         expect(apiService.postUserKeyToKeyConnector).not.toHaveBeenCalled();
         expect(apiService.postSetKeyConnectorKey).not.toHaveBeenCalled();

--- a/libs/common/src/key-management/key-connector/services/key-connector.service.ts
+++ b/libs/common/src/key-management/key-connector/services/key-connector.service.ts
@@ -18,6 +18,7 @@ import {
   PBKDF2KdfConfig,
 } from "@bitwarden/key-management";
 import { LogService } from "@bitwarden/logging";
+import { PureCrypto } from "@bitwarden/sdk-internal";
 
 import { ApiService } from "../../../abstractions/api.service";
 import { OrganizationService } from "../../../admin-console/abstractions/organization/organization.service.abstraction";
@@ -29,6 +30,7 @@ import { FeatureFlag } from "../../../enums/feature-flag.enum";
 import { KeysRequest } from "../../../models/request/keys.request";
 import { ConfigService } from "../../../platform/abstractions/config/config.service";
 import { RegisterSdkService } from "../../../platform/abstractions/sdk/register-sdk.service";
+import { SdkLoadService } from "../../../platform/abstractions/sdk/sdk-load.service";
 import { SdkService } from "../../../platform/abstractions/sdk/sdk.service";
 import { Utils } from "../../../platform/misc/utils";
 import { SymmetricCryptoKey } from "../../../platform/models/domain/symmetric-crypto-key";
@@ -36,7 +38,6 @@ import { KEY_CONNECTOR_DISK, StateProvider, UserKeyDefinition } from "../../../p
 import { UserId } from "../../../types/guid";
 import { MasterKey, UserKey } from "../../../types/key";
 import { AccountCryptographicStateService } from "../../account-cryptography/account-cryptographic-state.service";
-import { KeyGenerationService } from "../../crypto";
 import { EncString } from "../../crypto/models/enc-string";
 import { InternalMasterPasswordServiceAbstraction } from "../../master-password/abstractions/master-password.service.abstraction";
 import { KeyConnectorService as KeyConnectorServiceAbstraction } from "../abstractions/key-connector.service";
@@ -87,7 +88,6 @@ export class KeyConnectorService implements KeyConnectorServiceAbstraction {
     private tokenService: TokenService,
     private logService: LogService,
     private organizationService: OrganizationService,
-    private keyGenerationService: KeyGenerationService,
     private logoutCallback: (logoutReason: LogoutReason, userId?: string) => Promise<void>,
     private stateProvider: StateProvider,
     private configService: ConfigService,
@@ -292,7 +292,8 @@ export class KeyConnectorService implements KeyConnectorServiceAbstraction {
     keyConnectorUrl: string,
     ssoOrganizationIdentifier: string,
   ) {
-    const password = await this.keyGenerationService.createKey(512);
+    await SdkLoadService.Ready;
+    const password = SymmetricCryptoKey.fromSdk(PureCrypto.make_aes256_cbc_hmac_key());
 
     const masterKey = await this.keyService.makeMasterKey(
       password.keyB64,

--- a/libs/key-management/src/key.service.spec.ts
+++ b/libs/key-management/src/key.service.spec.ts
@@ -17,6 +17,7 @@ import { VaultTimeoutStringType } from "@bitwarden/common/key-management/vault-t
 import { VAULT_TIMEOUT } from "@bitwarden/common/key-management/vault-timeout/services/vault-timeout-settings.state";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
+import { SdkLoadService } from "@bitwarden/common/platform/abstractions/sdk/sdk-load.service";
 import { StateService } from "@bitwarden/common/platform/abstractions/state.service";
 import { KeySuffixOptions } from "@bitwarden/common/platform/enums";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
@@ -47,6 +48,7 @@ import {
   OrgKey,
   ProviderKey,
 } from "@bitwarden/common/types/key";
+import { PureCrypto } from "@bitwarden/sdk-internal";
 
 import { KdfConfigService } from "./abstractions/kdf-config.service";
 import { DefaultKeyService } from "./key.service";
@@ -75,6 +77,11 @@ describe("keyService", () => {
     stateProvider = new FakeStateProvider(accountService);
 
     await stateProvider.setUserState(VAULT_TIMEOUT, VaultTimeoutStringType.Never, mockUserId);
+
+    Object.defineProperty(SdkLoadService, "Ready", {
+      value: Promise.resolve(),
+      configurable: true,
+    });
 
     keyService = new DefaultKeyService(
       masterPasswordService,
@@ -196,7 +203,8 @@ describe("keyService", () => {
       const mockUserKey = makeSymmetricCryptoKey<UserKey>(64);
       const mockEncryptedUserKey = makeEncString("encryptedUserKey");
 
-      keyGenerationService.createKey.mockResolvedValue(mockUserKey);
+      jest.spyOn(PureCrypto, "make_aes256_cbc_hmac_key").mockReturnValue({} as any);
+      jest.spyOn(SymmetricCryptoKey, "fromSdk").mockReturnValue(mockUserKey);
       encryptService.wrapSymmetricKey.mockResolvedValue(mockEncryptedUserKey);
       const stretchedMasterKey = new SymmetricCryptoKey(new Uint8Array(64));
       keyGenerationService.stretchKey.mockResolvedValue(stretchedMasterKey);
@@ -204,7 +212,7 @@ describe("keyService", () => {
       const result = await keyService.makeUserKey(makeSymmetricCryptoKey<MasterKey>(32));
 
       expect(encryptService.wrapSymmetricKey).toHaveBeenCalledWith(mockUserKey, stretchedMasterKey);
-      expect(keyGenerationService.createKey).toHaveBeenCalledWith(512);
+      expect(PureCrypto.make_aes256_cbc_hmac_key).toHaveBeenCalled();
       expect(result[0]).toBe(mockUserKey);
       expect(result[1]).toBe(mockEncryptedUserKey);
     });
@@ -836,7 +844,8 @@ describe("keyService", () => {
       keyService.userPublicKey$ = jest
         .fn()
         .mockReturnValueOnce(new BehaviorSubject(mockUserPublicKey));
-      keyGenerationService.createKey.mockResolvedValue(shareKey);
+      jest.spyOn(PureCrypto, "make_aes256_cbc_hmac_key").mockReturnValue({} as any);
+      jest.spyOn(SymmetricCryptoKey, "fromSdk").mockReturnValue(shareKey);
       encryptService.encapsulateKeyUnsigned.mockResolvedValue(mockEncapsulatedKey);
     });
 
@@ -845,7 +854,7 @@ describe("keyService", () => {
 
       expect(result).toEqual([mockEncapsulatedKey, shareKey as OrgKey]);
       expect(keyService.userPublicKey$).toHaveBeenCalledWith(mockUserId);
-      expect(keyGenerationService.createKey).toHaveBeenCalledWith(512);
+      expect(PureCrypto.make_aes256_cbc_hmac_key).toHaveBeenCalled();
       expect(encryptService.encapsulateKeyUnsigned).toHaveBeenCalledWith(
         shareKey,
         mockUserPublicKey,
@@ -857,7 +866,7 @@ describe("keyService", () => {
 
       expect(result).toEqual([mockEncapsulatedKey, shareKey as ProviderKey]);
       expect(keyService.userPublicKey$).toHaveBeenCalledWith(mockUserId);
-      expect(keyGenerationService.createKey).toHaveBeenCalledWith(512);
+      expect(PureCrypto.make_aes256_cbc_hmac_key).toHaveBeenCalled();
       expect(encryptService.encapsulateKeyUnsigned).toHaveBeenCalledWith(
         shareKey,
         mockUserPublicKey,
@@ -870,7 +879,7 @@ describe("keyService", () => {
         await expect(keyService.makeOrgKey(userId)).rejects.toThrow("UserId is required");
 
         expect(keyService.userPublicKey$).not.toHaveBeenCalled();
-        expect(keyGenerationService.createKey).not.toHaveBeenCalled();
+        expect(PureCrypto.make_aes256_cbc_hmac_key).not.toHaveBeenCalled();
         expect(encryptService.encapsulateKeyUnsigned).not.toHaveBeenCalled();
       },
     );
@@ -882,7 +891,7 @@ describe("keyService", () => {
         "No public key found for user " + mockUserId,
       );
 
-      expect(keyGenerationService.createKey).not.toHaveBeenCalled();
+      expect(PureCrypto.make_aes256_cbc_hmac_key).not.toHaveBeenCalled();
       expect(encryptService.encapsulateKeyUnsigned).not.toHaveBeenCalled();
     });
   });
@@ -1025,7 +1034,8 @@ describe("keyService", () => {
       mockPublicKey = "mockPublicKey";
       mockPrivateKey = makeEncString("mockPrivateKey");
 
-      keyGenerationService.createKey.mockResolvedValue(userKey);
+      jest.spyOn(PureCrypto, "make_aes256_cbc_hmac_key").mockReturnValue({} as any);
+      jest.spyOn(SymmetricCryptoKey, "fromSdk").mockReturnValue(userKey);
       jest.spyOn(keyService, "makeKeyPair").mockResolvedValue([mockPublicKey, mockPrivateKey]);
       jest.spyOn(keyService, "setUserKey").mockResolvedValue();
     });
@@ -1066,11 +1076,9 @@ describe("keyService", () => {
     });
 
     it("successfully initializes account with new keys", async () => {
-      const keyCreationSize = 512;
-
       const result = await keyService.initAccount(mockUserId);
 
-      expect(keyGenerationService.createKey).toHaveBeenCalledWith(keyCreationSize);
+      expect(PureCrypto.make_aes256_cbc_hmac_key).toHaveBeenCalled();
       expect(keyService.makeKeyPair).toHaveBeenCalledWith(userKey);
       expect(keyService.setUserKey).toHaveBeenCalledWith(userKey, mockUserId);
       expect(accountCryptographicStateService.setAccountCryptographicState).toHaveBeenCalledWith(

--- a/libs/key-management/src/key.service.ts
+++ b/libs/key-management/src/key.service.ts
@@ -35,6 +35,7 @@ import { VaultTimeoutStringType } from "@bitwarden/common/key-management/vault-t
 import { VAULT_TIMEOUT } from "@bitwarden/common/key-management/vault-timeout/services/vault-timeout-settings.state";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
+import { SdkLoadService } from "@bitwarden/common/platform/abstractions/sdk/sdk-load.service";
 import { StateService } from "@bitwarden/common/platform/abstractions/state.service";
 import { KeySuffixOptions, EncryptionType } from "@bitwarden/common/platform/enums";
 import { convertValues } from "@bitwarden/common/platform/misc/convert-values";
@@ -59,7 +60,7 @@ import {
   UserPrivateKey,
   UserPublicKey,
 } from "@bitwarden/common/types/key";
-import { WrappedAccountCryptographicState } from "@bitwarden/sdk-internal";
+import { PureCrypto, WrappedAccountCryptographicState } from "@bitwarden/sdk-internal";
 
 import { KdfConfigService } from "./abstractions/kdf-config.service";
 import {
@@ -189,7 +190,8 @@ export class DefaultKeyService implements KeyServiceAbstraction {
       throw new Error("MasterKey is required");
     }
 
-    const newUserKey = await this.keyGenerationService.createKey(512);
+    await SdkLoadService.Ready;
+    const newUserKey = SymmetricCryptoKey.fromSdk(PureCrypto.make_aes256_cbc_hmac_key());
     return this.buildProtectedSymmetricKey(masterKey, newUserKey);
   }
 
@@ -344,7 +346,8 @@ export class DefaultKeyService implements KeyServiceAbstraction {
     }
 
     // Content encryption key is AES256_CBC_HMAC
-    const cek = await this.keyGenerationService.createKey(512);
+    await SdkLoadService.Ready;
+    const cek = SymmetricCryptoKey.fromSdk(PureCrypto.make_aes256_cbc_hmac_key());
     const wrappedCek = await this.encryptService.wrapSymmetricKey(cek, key);
     return [cek, wrappedCek];
   }
@@ -399,7 +402,8 @@ export class DefaultKeyService implements KeyServiceAbstraction {
       throw new Error("No public key found for user " + userId);
     }
 
-    const shareKey = await this.keyGenerationService.createKey(512);
+    await SdkLoadService.Ready;
+    const shareKey = SymmetricCryptoKey.fromSdk(PureCrypto.make_aes256_cbc_hmac_key());
     const encShareKey = await this.encryptService.encapsulateKeyUnsigned(shareKey, publicKey);
     return [encShareKey, shareKey as T];
   }
@@ -512,7 +516,8 @@ export class DefaultKeyService implements KeyServiceAbstraction {
       throw new Error("Cannot initialize account, keys already exist.");
     }
 
-    const userKey = (await this.keyGenerationService.createKey(512)) as UserKey;
+    await SdkLoadService.Ready;
+    const userKey = SymmetricCryptoKey.fromSdk(PureCrypto.make_aes256_cbc_hmac_key()) as UserKey;
     const [publicKey, privateKey] = await this.makeKeyPair(userKey);
     if (privateKey.encryptedString == null) {
       throw new Error("Failed to create valid private key.");


### PR DESCRIPTION
https://bitwarden.atlassian.net/browse/PM-39259

Migrate KM consumers to use SDK-sourced keys via PureCrypto, in order to be able to drop SDK randomness. Eventually we will move all of these to SDK at a higher level, this is a bridge until then.