### PR TITLE
[PM-39259] Migrate risk-insights encryption to SDK key generation

### DIFF
--- a/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/legacy/legacy-risk-insights-encryption.service.spec.ts
+++ b/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/legacy/legacy-risk-insights-encryption.service.spec.ts
@@ -4,12 +4,14 @@ import { BehaviorSubject } from "rxjs";
 import { KeyGenerationService } from "@bitwarden/common/key-management/crypto";
 import { EncryptService } from "@bitwarden/common/key-management/crypto/abstractions/encrypt.service";
 import { EncString } from "@bitwarden/common/key-management/crypto/models/enc-string";
+import { SdkLoadService } from "@bitwarden/common/platform/abstractions/sdk/sdk-load.service";
 import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
 import { makeSymmetricCryptoKey } from "@bitwarden/common/spec";
 import { OrganizationId, UserId } from "@bitwarden/common/types/guid";
 import { OrgKey } from "@bitwarden/common/types/key";
 import { KeyService } from "@bitwarden/key-management";
 import { LogService } from "@bitwarden/logging";
+import { PureCrypto } from "@bitwarden/sdk-internal";
 
 import {
   MemberRegistryEntryData,
@@ -59,8 +61,12 @@ describe("LegacyRiskInsightsEncryptionService", () => {
 
     jest.clearAllMocks();
 
-    // Always use the same contentEncryptionKey for both encrypt and decrypt tests
-    mockKeyGenerationService.createKey.mockResolvedValue(contentEncryptionKey);
+    Object.defineProperty(SdkLoadService, "Ready", {
+      value: Promise.resolve(),
+      configurable: true,
+    });
+    jest.spyOn(PureCrypto, "make_aes256_cbc_hmac_key").mockReturnValue({} as any);
+    jest.spyOn(SymmetricCryptoKey, "fromSdk").mockReturnValue(contentEncryptionKey);
     mockEncryptService.wrapSymmetricKey.mockResolvedValue(new EncString(ENCRYPTED_KEY));
     mockEncryptService.encryptString.mockResolvedValue(new EncString(ENCRYPTED_TEXT));
     mockEncryptService.unwrapSymmetricKey.mockResolvedValue(contentEncryptionKey);
@@ -93,7 +99,7 @@ describe("LegacyRiskInsightsEncryptionService", () => {
 
       // Assert: ensure that the methods were called with the expected parameters
       expect(mockKeyService.orgKeys$).toHaveBeenCalledWith(userId);
-      expect(mockKeyGenerationService.createKey).toHaveBeenCalledWith(512);
+      expect(PureCrypto.make_aes256_cbc_hmac_key).toHaveBeenCalled();
 
       // Assert all variables were encrypted
       expect(mockEncryptService.encryptString).toHaveBeenCalledWith(

--- a/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/legacy/legacy-risk-insights-encryption.service.ts
+++ b/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/legacy/legacy-risk-insights-encryption.service.ts
@@ -3,10 +3,12 @@ import { firstValueFrom, map } from "rxjs";
 import { KeyGenerationService } from "@bitwarden/common/key-management/crypto";
 import { EncryptService } from "@bitwarden/common/key-management/crypto/abstractions/encrypt.service";
 import { EncString } from "@bitwarden/common/key-management/crypto/models/enc-string";
+import { SdkLoadService } from "@bitwarden/common/platform/abstractions/sdk/sdk-load.service";
 import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
 import { CipherId, OrganizationId, UserId } from "@bitwarden/common/types/guid";
 import { KeyService } from "@bitwarden/key-management";
 import { LogService } from "@bitwarden/logging";
+import { PureCrypto } from "@bitwarden/sdk-internal";
 
 import {
   createNewSummaryData,
@@ -81,7 +83,8 @@ export class LegacyRiskInsightsEncryptionService {
     try {
       if (!wrappedKey) {
         // Generate a new key
-        contentEncryptionKey = await this.keyGeneratorService.createKey(512);
+        await SdkLoadService.Ready;
+        contentEncryptionKey = SymmetricCryptoKey.fromSdk(PureCrypto.make_aes256_cbc_hmac_key());
       } else {
         // Unwrap the existing key
         contentEncryptionKey = await this.encryptService.unwrapSymmetricKey(wrappedKey, orgKey);

--- a/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/persistence/default-access-report-encryption.service.spec.ts
+++ b/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/persistence/default-access-report-encryption.service.spec.ts
@@ -4,6 +4,7 @@ import { BehaviorSubject, firstValueFrom } from "rxjs";
 import { KeyGenerationService } from "@bitwarden/common/key-management/crypto";
 import { EncryptService } from "@bitwarden/common/key-management/crypto/abstractions/encrypt.service";
 import { EncString } from "@bitwarden/common/key-management/crypto/models/enc-string";
+import { SdkLoadService } from "@bitwarden/common/platform/abstractions/sdk/sdk-load.service";
 import { EncryptionType } from "@bitwarden/common/platform/enums";
 import { EncArrayBuffer } from "@bitwarden/common/platform/models/domain/enc-array-buffer";
 import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
@@ -12,6 +13,7 @@ import { OrganizationId, UserId } from "@bitwarden/common/types/guid";
 import { OrgKey } from "@bitwarden/common/types/key";
 import { KeyService } from "@bitwarden/key-management";
 import { LogService } from "@bitwarden/logging";
+import { PureCrypto } from "@bitwarden/sdk-internal";
 
 import {
   AccessReportSettingsData,
@@ -105,7 +107,12 @@ describe("DefaultAccessReportEncryptionService", () => {
 
     jest.clearAllMocks();
 
-    mockKeyGenerationService.createKey.mockResolvedValue(contentEncryptionKey);
+    Object.defineProperty(SdkLoadService, "Ready", {
+      value: Promise.resolve(),
+      configurable: true,
+    });
+    jest.spyOn(PureCrypto, "make_aes256_cbc_hmac_key").mockReturnValue({} as any);
+    jest.spyOn(SymmetricCryptoKey, "fromSdk").mockReturnValue(contentEncryptionKey);
     mockEncryptService.wrapSymmetricKey.mockResolvedValue(new EncString(ENCRYPTED_KEY));
     mockEncryptService.encryptString.mockResolvedValue(new EncString(ENCRYPTED_TEXT));
     mockEncryptService.unwrapSymmetricKey.mockResolvedValue(contentEncryptionKey);
@@ -157,7 +164,7 @@ describe("DefaultAccessReportEncryptionService", () => {
       );
 
       expect(mockKeyService.orgKeys$).toHaveBeenCalledWith(userId);
-      expect(mockKeyGenerationService.createKey).toHaveBeenCalledWith(512);
+      expect(PureCrypto.make_aes256_cbc_hmac_key).toHaveBeenCalled();
       expect(mockReportVersioningService.serialize).toHaveBeenCalledWith(mockV2Input.reportData);
       expect(mockSummaryVersioningService.serialize).toHaveBeenCalledWith(mockV2Input.summaryData);
       expect(mockApplicationVersioningService.serialize).toHaveBeenCalledWith(
@@ -194,7 +201,7 @@ describe("DefaultAccessReportEncryptionService", () => {
         service.encryptReport$({ organizationId: orgId, userId }, mockV2Input, mockKey),
       );
 
-      expect(mockKeyGenerationService.createKey).not.toHaveBeenCalled();
+      expect(PureCrypto.make_aes256_cbc_hmac_key).not.toHaveBeenCalled();
       expect(mockEncryptService.unwrapSymmetricKey).toHaveBeenCalledWith(mockKey, orgKey);
     });
 
@@ -207,7 +214,9 @@ describe("DefaultAccessReportEncryptionService", () => {
     });
 
     it("should throw if key operation fails", async () => {
-      mockKeyGenerationService.createKey.mockRejectedValue(new Error("Key generation failed"));
+      jest.spyOn(PureCrypto, "make_aes256_cbc_hmac_key").mockImplementation(() => {
+        throw new Error("Key generation failed");
+      });
 
       await expect(
         firstValueFrom(service.encryptReport$({ organizationId: orgId, userId }, mockV2Input)),
@@ -468,7 +477,7 @@ describe("DefaultAccessReportEncryptionService", () => {
       );
 
       expect(mockKeyService.orgKeys$).toHaveBeenCalledWith(userId);
-      expect(mockKeyGenerationService.createKey).toHaveBeenCalledWith(512);
+      expect(PureCrypto.make_aes256_cbc_hmac_key).toHaveBeenCalled();
       expect(mockReportVersioningService.serialize).toHaveBeenCalledWith(mockV2Input.reportData);
       expect(mockEncryptService.encryptFileData).toHaveBeenCalledWith(
         expect.anything(),
@@ -515,7 +524,7 @@ describe("DefaultAccessReportEncryptionService", () => {
         service.encryptReportFile$({ organizationId: orgId, userId }, mockV2Input, mockKey),
       );
 
-      expect(mockKeyGenerationService.createKey).not.toHaveBeenCalled();
+      expect(PureCrypto.make_aes256_cbc_hmac_key).not.toHaveBeenCalled();
       expect(mockEncryptService.unwrapSymmetricKey).toHaveBeenCalledWith(mockKey, orgKey);
     });
 
@@ -528,7 +537,9 @@ describe("DefaultAccessReportEncryptionService", () => {
     });
 
     it("should throw if key operation fails", async () => {
-      mockKeyGenerationService.createKey.mockRejectedValue(new Error("Key generation failed"));
+      jest.spyOn(PureCrypto, "make_aes256_cbc_hmac_key").mockImplementation(() => {
+        throw new Error("Key generation failed");
+      });
 
       await expect(
         firstValueFrom(service.encryptReportFile$({ organizationId: orgId, userId }, mockV2Input)),

--- a/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/persistence/default-access-report-encryption.service.ts
+++ b/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/persistence/default-access-report-encryption.service.ts
@@ -3,11 +3,13 @@ import { Observable, catchError, forkJoin, from, map, switchMap, take } from "rx
 import { KeyGenerationService } from "@bitwarden/common/key-management/crypto";
 import { EncryptService } from "@bitwarden/common/key-management/crypto/abstractions/encrypt.service";
 import { EncString } from "@bitwarden/common/key-management/crypto/models/enc-string";
+import { SdkLoadService } from "@bitwarden/common/platform/abstractions/sdk/sdk-load.service";
 import { EncArrayBuffer } from "@bitwarden/common/platform/models/domain/enc-array-buffer";
 import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
 import { OrganizationId, UserId } from "@bitwarden/common/types/guid";
 import { KeyService } from "@bitwarden/key-management";
 import { LogService } from "@bitwarden/logging";
+import { PureCrypto } from "@bitwarden/sdk-internal";
 
 import { AccessReportSummaryView } from "../../../models";
 import {
@@ -57,7 +59,12 @@ export class DefaultAccessReportEncryptionService extends AccessReportEncryption
         const contentKey$ = (
           wrappedKey
             ? from(this.encryptService.unwrapSymmetricKey(wrappedKey, orgKey))
-            : from(this.keyGeneratorService.createKey(512))
+            : from(
+                (async () => {
+                  await SdkLoadService.Ready;
+                  return SymmetricCryptoKey.fromSdk(PureCrypto.make_aes256_cbc_hmac_key());
+                })(),
+              )
         ).pipe(
           catchError((error: unknown) => {
             this.logService.error(
@@ -250,7 +257,12 @@ export class DefaultAccessReportEncryptionService extends AccessReportEncryption
         const contentKey$ = (
           wrappedKey
             ? from(this.encryptService.unwrapSymmetricKey(wrappedKey, orgKey))
-            : from(this.keyGeneratorService.createKey(512))
+            : from(
+                (async () => {
+                  await SdkLoadService.Ready;
+                  return SymmetricCryptoKey.fromSdk(PureCrypto.make_aes256_cbc_hmac_key());
+                })(),
+              )
         ).pipe(
           catchError((error: unknown) => {
             this.logService.error(

--- a/bitwarden_license/bit-common/src/dirt/reports/risk-insights/services/domain/risk-insights-encryption.service.spec.ts
+++ b/bitwarden_license/bit-common/src/dirt/reports/risk-insights/services/domain/risk-insights-encryption.service.spec.ts
@@ -4,12 +4,14 @@ import { BehaviorSubject } from "rxjs";
 import { KeyGenerationService } from "@bitwarden/common/key-management/crypto";
 import { EncryptService } from "@bitwarden/common/key-management/crypto/abstractions/encrypt.service";
 import { EncString } from "@bitwarden/common/key-management/crypto/models/enc-string";
+import { SdkLoadService } from "@bitwarden/common/platform/abstractions/sdk/sdk-load.service";
 import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
 import { makeSymmetricCryptoKey } from "@bitwarden/common/spec";
 import { OrganizationId, UserId } from "@bitwarden/common/types/guid";
 import { OrgKey } from "@bitwarden/common/types/key";
 import { KeyService } from "@bitwarden/key-management";
 import { LogService } from "@bitwarden/logging";
+import { PureCrypto } from "@bitwarden/sdk-internal";
 
 import { EncryptedReportData, DecryptedReportData } from "../../models";
 import { mockApplicationData, mockReportData, mockSummaryData } from "../../models/mocks/mock-data";
@@ -50,8 +52,12 @@ describe("RiskInsightsEncryptionService", () => {
 
     jest.clearAllMocks();
 
-    // Always use the same contentEncryptionKey for both encrypt and decrypt tests
-    mockKeyGenerationService.createKey.mockResolvedValue(contentEncryptionKey);
+    Object.defineProperty(SdkLoadService, "Ready", {
+      value: Promise.resolve(),
+      configurable: true,
+    });
+    jest.spyOn(PureCrypto, "make_aes256_cbc_hmac_key").mockReturnValue({} as any);
+    jest.spyOn(SymmetricCryptoKey, "fromSdk").mockReturnValue(contentEncryptionKey);
     mockEncryptService.wrapSymmetricKey.mockResolvedValue(new EncString(ENCRYPTED_KEY));
     mockEncryptService.encryptString.mockResolvedValue(new EncString(ENCRYPTED_TEXT));
     mockEncryptService.unwrapSymmetricKey.mockResolvedValue(contentEncryptionKey);
@@ -84,7 +90,7 @@ describe("RiskInsightsEncryptionService", () => {
 
       // Assert: ensure that the methods were called with the expected parameters
       expect(mockKeyService.orgKeys$).toHaveBeenCalledWith(userId);
-      expect(mockKeyGenerationService.createKey).toHaveBeenCalledWith(512);
+      expect(PureCrypto.make_aes256_cbc_hmac_key).toHaveBeenCalled();
 
       // Assert all variables were encrypted
       expect(mockEncryptService.encryptString).toHaveBeenCalledWith(

--- a/bitwarden_license/bit-common/src/dirt/reports/risk-insights/services/domain/risk-insights-encryption.service.ts
+++ b/bitwarden_license/bit-common/src/dirt/reports/risk-insights/services/domain/risk-insights-encryption.service.ts
@@ -3,10 +3,12 @@ import { firstValueFrom, map } from "rxjs";
 import { KeyGenerationService } from "@bitwarden/common/key-management/crypto";
 import { EncryptService } from "@bitwarden/common/key-management/crypto/abstractions/encrypt.service";
 import { EncString } from "@bitwarden/common/key-management/crypto/models/enc-string";
+import { SdkLoadService } from "@bitwarden/common/platform/abstractions/sdk/sdk-load.service";
 import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
 import { OrganizationId, UserId } from "@bitwarden/common/types/guid";
 import { KeyService } from "@bitwarden/key-management";
 import { LogService } from "@bitwarden/logging";
+import { PureCrypto } from "@bitwarden/sdk-internal";
 
 import { createNewSummaryData } from "../../helpers";
 import {
@@ -62,7 +64,8 @@ export class RiskInsightsEncryptionService {
     try {
       if (!wrappedKey) {
         // Generate a new key
-        contentEncryptionKey = await this.keyGeneratorService.createKey(512);
+        await SdkLoadService.Ready;
+        contentEncryptionKey = SymmetricCryptoKey.fromSdk(PureCrypto.make_aes256_cbc_hmac_key());
       } else {
         // Unwrap the existing key
         contentEncryptionKey = await this.encryptService.unwrapSymmetricKey(wrappedKey, orgKey);


### PR DESCRIPTION
https://bitwarden.atlassian.net/browse/PM-39259

Migrates risk insights to use SDK generated keys. We will drop the key generation service imminently to only use SDK sourced randomness.