### PR TITLE
[PM-39259] Migrate FIDO2 credential id to SDK random

### DIFF
--- a/libs/common/src/platform/services/fido2/fido2-authenticator.service.spec.ts
+++ b/libs/common/src/platform/services/fido2/fido2-authenticator.service.spec.ts
@@ -3,7 +3,7 @@ import { TextEncoder } from "util";
 import { mock, MockProxy } from "jest-mock-extended";
 import { BehaviorSubject, of } from "rxjs";
 
-import { PureCrypto } from "@bitwarden/sdk-internal";
+import { SdkRandomNumberClient } from "@bitwarden/sdk-internal";
 
 import { mockAccountServiceWith, mockAccountInfoWith } from "../../../../spec";
 import { Account } from "../../../auth/abstractions/account.service";
@@ -74,10 +74,12 @@ describe("FidoAuthenticatorService", () => {
     windowReference = Utils.newGuid();
     accountService.activeAccount$ = activeAccountSubject;
 
-    // PureCrypto is backed by WASM and is not initialized in jest. stub the
+    // SdkRandomNumberClient is backed by WASM and is not initialized in jest. stub the
     // GUID generator so createKeyView() can run without loading the module.
     (SdkLoadService as any).Ready = jest.fn().mockResolvedValue(true);
-    jest.spyOn(PureCrypto, "new_guid").mockImplementation(() => Utils.newGuid());
+    jest
+      .spyOn(SdkRandomNumberClient.prototype, "gen_uuid")
+      .mockImplementation(() => Utils.newGuid());
   });
 
   describe("makeCredential", () => {

--- a/libs/common/src/platform/services/fido2/fido2-authenticator.service.ts
+++ b/libs/common/src/platform/services/fido2/fido2-authenticator.service.ts
@@ -2,7 +2,7 @@
 // @ts-strict-ignore
 import { filter, firstValueFrom, map, timeout } from "rxjs";
 
-import { PureCrypto } from "@bitwarden/sdk-internal";
+import { SdkRandomNumberClient } from "@bitwarden/sdk-internal";
 
 import { AccountService } from "../../../auth/abstractions/account.service";
 import { getUserId } from "../../../auth/services/account.service";
@@ -488,11 +488,11 @@ async function createKeyView(
     throw new Fido2AuthenticatorError(Fido2AuthenticatorErrorCode.Unknown);
   }
 
-  await SdkLoadService.Ready; // Required for PureCrypto.new_guid()
+  await SdkLoadService.Ready; // Required for SdkRandomNumberClient
 
   const pkcs8Key = new Uint8Array(await crypto.subtle.exportKey("pkcs8", keyValue));
   const fido2Credential = new Fido2CredentialView();
-  fido2Credential.credentialId = PureCrypto.new_guid();
+  fido2Credential.credentialId = new SdkRandomNumberClient().gen_uuid();
   fido2Credential.keyType = "public-key";
   fido2Credential.keyAlgorithm = "ECDSA";
   fido2Credential.keyCurve = "P-256";


### PR DESCRIPTION
https://bitwarden.atlassian.net/browse/PM-39259

Migrates off of the temporary PureCrypto shim to the long-term random number client which will be the only way to get randomness.

Ideally, teams move entire features into the sdk, however for the cases that this has not happened the random number client is how to get randomness.