### PR TITLE
[PM-39876] Implement targeting rules form category

### DIFF
--- a/apps/browser/src/autofill/background/abstractions/overlay.background.ts
+++ b/apps/browser/src/autofill/background/abstractions/overlay.background.ts
@@ -158,7 +158,7 @@ export type OverlayBackgroundExtensionMessage = {
   styles?: Partial<CSSStyleDeclaration>;
   data?: LockedVaultPendingNotificationsData;
   iframeSrc?: string;
-  iframeTargetedFields?: { selector: string; fieldType: string }[];
+  iframeTargetedFields?: { selector: string; fieldType: string; formCategory?: string }[];
 } & OverlayAddNewItemMessage &
   CloseInlineMenuMessage &
   ToggleInlineMenuHiddenMessage &

--- a/apps/browser/src/autofill/content/abstractions/autofill-init.ts
+++ b/apps/browser/src/autofill/content/abstractions/autofill-init.ts
@@ -24,7 +24,7 @@ export type AutofillExtensionMessage = {
   isOpeningFullInlineMenu?: boolean;
   addNewCipherType?: CipherType;
   ignoreFieldFocus?: boolean;
-  iframeTargetedFields?: { selector: string; fieldType: string }[];
+  iframeTargetedFields?: { selector: string; fieldType: string; formCategory?: string }[];
   data?: {
     direction?: "previous" | "next" | "current";
     forceCloseInlineMenu?: boolean;

--- a/apps/browser/src/autofill/models/autofill-field.ts
+++ b/apps/browser/src/autofill/models/autofill-field.ts
@@ -1,3 +1,5 @@
+import { AutofillTargetingRuleType, FormPurposeCategory } from "@bitwarden/common/autofill/types";
+
 import { FieldRect } from "../background/abstractions/overlay.background";
 import { AutofillFieldQualifierType } from "../enums/autofill-field.enums";
 import {
@@ -124,12 +126,19 @@ export default class AutofillField {
 
   showPasskeys?: boolean;
 
-  fieldQualifier?: AutofillFieldQualifierType;
+  fieldQualifier?: AutofillFieldQualifierType | AutofillTargetingRuleType;
 
   /**
    * Indicates this field was qualified by targeting rules rather than heuristics
    */
   targeted?: boolean;
+
+  /**
+   * The `category` of the targeting-rule form this field was resolved from
+   * (e.g. `account-login`). Only set for targeted fields; undefined for
+   * heuristic fields and for targeted fields routed across an iframe boundary.
+   */
+  formCategory?: FormPurposeCategory;
 
   accountCreationFieldType?: InlineMenuAccountCreationFieldTypes;
 

--- a/apps/browser/src/autofill/models/autofill-field.ts
+++ b/apps/browser/src/autofill/models/autofill-field.ts
@@ -136,7 +136,7 @@ export default class AutofillField {
   /**
    * The `category` of the targeting-rule form this field was resolved from
    * (e.g. `account-login`). Only set for targeted fields; undefined for
-   * heuristic fields and for targeted fields routed across an iframe boundary.
+   * heuristically-gathered fields.
    */
   formCategory?: FormPurposeCategory;
 

--- a/apps/browser/src/autofill/services/autofill-constants.ts
+++ b/apps/browser/src/autofill/services/autofill-constants.ts
@@ -1,5 +1,20 @@
-import { AutofillTargetingRuleTypes } from "@bitwarden/common/autofill/constants";
-import { AutofillTargetingRuleType } from "@bitwarden/common/autofill/types";
+import {
+  AutofillTargetingRuleTypes,
+  FormPurposeCategories,
+} from "@bitwarden/common/autofill/constants";
+import { AutofillTargetingRuleType, FormPurposeCategory } from "@bitwarden/common/autofill/types";
+import { CipherType } from "@bitwarden/common/vault/enums";
+
+/**
+ * Authoritative cipher-type mapping for targeting-rule form categories whose
+ * fields all belong to a single cipher type.
+ */
+export const targetedFormCategoryFillTypes: Partial<Record<FormPurposeCategory, CipherType>> = {
+  [FormPurposeCategories.AccountLogin]: CipherType.Login,
+  [FormPurposeCategories.PaymentCard]: CipherType.Card,
+  [FormPurposeCategories.Identity]: CipherType.Identity,
+  [FormPurposeCategories.Address]: CipherType.Identity,
+};
 
 export const loginQualifiers: AutofillTargetingRuleType[] = [
   AutofillTargetingRuleTypes.username,

--- a/apps/browser/src/autofill/services/autofill-overlay-content.service.spec.ts
+++ b/apps/browser/src/autofill/services/autofill-overlay-content.service.spec.ts
@@ -1,10 +1,15 @@
 import { mock, MockProxy } from "jest-mock-extended";
 
-import { EVENTS } from "@bitwarden/common/autofill/constants";
+import {
+  AutofillTargetingRuleTypes,
+  EVENTS,
+  FormPurposeCategories,
+} from "@bitwarden/common/autofill/constants";
 import { CipherType } from "@bitwarden/common/vault/enums";
 
 import { ModifyLoginCipherFormData } from "../background/abstractions/overlay-notifications.background";
 import AutofillInit from "../content/autofill-init";
+import { AutofillFieldQualifier } from "../enums/autofill-field.enums";
 import {
   AutofillOverlayElement,
   InlineMenuFillTypes,
@@ -1531,6 +1536,135 @@ describe("AutofillOverlayContentService", () => {
             InlineMenuFillTypes.CurrentPasswordUpdate,
           );
         });
+      });
+    });
+
+    describe("setTargetedFieldFillType", () => {
+      const setFillType = (overrides: Partial<AutofillField>) => {
+        const field = createAutofillFieldMock({ targeted: true, ...overrides });
+        autofillOverlayContentService["setTargetedFieldFillType"](field);
+        return field.inlineMenuFillType;
+      };
+
+      it("resolves an account-login form's email field to a Login fill type (not Identity)", () => {
+        expect(
+          setFillType({
+            fieldQualifier: AutofillTargetingRuleTypes.email,
+            formCategory: FormPurposeCategories.AccountLogin,
+          }),
+        ).toEqual(CipherType.Login);
+      });
+
+      it("resolves an account-login form's phone field to a Login fill type (not Identity)", () => {
+        expect(
+          setFillType({
+            fieldQualifier: AutofillTargetingRuleTypes.phone,
+            formCategory: FormPurposeCategories.AccountLogin,
+          }),
+        ).toEqual(CipherType.Login);
+      });
+
+      it("resolves an account-login form's password field to a Login fill type (not password generation)", () => {
+        expect(
+          setFillType({
+            fieldQualifier: AutofillTargetingRuleTypes.password,
+            formCategory: FormPurposeCategories.AccountLogin,
+          }),
+        ).toEqual(CipherType.Login);
+      });
+
+      it("resolves a payment-card form's cardholderName field to a Card fill type", () => {
+        expect(
+          setFillType({
+            fieldQualifier: AutofillTargetingRuleTypes.cardholderName,
+            formCategory: FormPurposeCategories.PaymentCard,
+          }),
+        ).toEqual(CipherType.Card);
+      });
+
+      it("resolves identity and address form fields to an Identity fill type", () => {
+        expect(
+          setFillType({
+            fieldQualifier: AutofillTargetingRuleTypes.firstName,
+            formCategory: FormPurposeCategories.Identity,
+          }),
+        ).toEqual(CipherType.Identity);
+        expect(
+          setFillType({
+            fieldQualifier: AutofillTargetingRuleTypes.postalCode,
+            formCategory: FormPurposeCategories.Address,
+          }),
+        ).toEqual(CipherType.Identity);
+      });
+
+      it("routes a username field on an identity form to Identity via category (overriding the login qualifier inference)", () => {
+        expect(
+          setFillType({
+            fieldQualifier: AutofillTargetingRuleTypes.username,
+            formCategory: FormPurposeCategories.Identity,
+          }),
+        ).toEqual(CipherType.Identity);
+      });
+
+      it("falls back to qualifier inference when the category is not a single-cipher-type category", () => {
+        expect(
+          setFillType({
+            fieldQualifier: AutofillTargetingRuleTypes.email,
+            formCategory: FormPurposeCategories.AccountCreation,
+          }),
+        ).toEqual(CipherType.Identity);
+      });
+
+      it("falls back to qualifier inference when no category is present (e.g. iframe-routed targeted field)", () => {
+        expect(
+          setFillType({
+            fieldQualifier: AutofillTargetingRuleTypes.email,
+            formCategory: undefined,
+          }),
+        ).toEqual(CipherType.Identity);
+      });
+
+      it("keeps newPassword mapped to password generation regardless of category", () => {
+        expect(
+          setFillType({
+            fieldQualifier: AutofillTargetingRuleTypes.newPassword,
+            formCategory: FormPurposeCategories.AccountLogin,
+          }),
+        ).toEqual(InlineMenuFillTypes.PasswordGeneration);
+      });
+    });
+
+    describe("storeQualifiedUserFilledField login-identifier capture", () => {
+      const captureUsernameFor = (qualifier: string) => {
+        autofillOverlayContentService["userFilledFields"] = {};
+        const element = document.createElement(
+          "input",
+        ) as ElementWithOpId<FillableFormFieldElement>;
+        const field = createAutofillFieldMock({ fieldQualifier: qualifier });
+        autofillOverlayContentService["storeQualifiedUserFilledField"](element, field);
+        return autofillOverlayContentService["userFilledFields"].username;
+      };
+
+      it("captures a targeted email field as the login username", () => {
+        expect(captureUsernameFor(AutofillTargetingRuleTypes.email)).toBeInstanceOf(
+          HTMLInputElement,
+        );
+      });
+
+      it("captures a targeted phone field as the login username", () => {
+        expect(captureUsernameFor(AutofillTargetingRuleTypes.phone)).toBeInstanceOf(
+          HTMLInputElement,
+        );
+      });
+
+      it("captures a heuristic identity phone field as the login username", () => {
+        expect(captureUsernameFor(AutofillFieldQualifier.identityPhone)).toBeInstanceOf(
+          HTMLInputElement,
+        );
+      });
+
+      it("does not capture an unrelated field (e.g. postal code) as the login username", () => {
+        expect(captureUsernameFor(AutofillTargetingRuleTypes.postalCode)).toBeUndefined();
       });
     });
 

--- a/apps/browser/src/autofill/services/autofill-overlay-content.service.ts
+++ b/apps/browser/src/autofill/services/autofill-overlay-content.service.ts
@@ -63,6 +63,7 @@ import {
   loginQualifiers,
   cardQualifiers,
   identityQualifiers,
+  targetedFormCategoryFillTypes,
 } from "./autofill-constants";
 
 export class AutofillOverlayContentService implements AutofillOverlayContentServiceInterface {
@@ -946,9 +947,16 @@ export class AutofillOverlayContentService implements AutofillOverlayContentServ
     }
 
     const clonedNode = formFieldElement.cloneNode(true) as FillableFormFieldElement;
-    const identityLoginFields: AutofillFieldQualifierType[] = [
+    // Identifier fields that double as the login username when saving a login.
+    // Heuristic (identity) and targeting-rule (email/phone) qualifiers both flow
+    // through here, so both namespaces are listed; targeting `username` already
+    // stores directly under the username key below.
+    const identityLoginFields: (AutofillFieldQualifierType | AutofillTargetingRuleType)[] = [
       AutofillFieldQualifier.identityUsername,
       AutofillFieldQualifier.identityEmail,
+      AutofillFieldQualifier.identityPhone,
+      AutofillTargetingRuleTypes.email,
+      AutofillTargetingRuleTypes.phone,
     ];
     if (!this.userFilledFields) {
       return;
@@ -1228,6 +1236,21 @@ export class AutofillOverlayContentService implements AutofillOverlayContentServ
 
     if (qualifier === AutofillTargetingRuleTypes.newPassword) {
       autofillFieldData.inlineMenuFillType = InlineMenuFillTypes.PasswordGeneration;
+      return;
+    }
+
+    // The form category is authoritative for single-cipher-type forms, so it
+    // takes precedence over inferring the cipher type from the individual field
+    // qualifier. This is what routes an account-login form's email/phone field
+    // to Login rather than Identity. Categories needing qualifier-level fill
+    // sub-types fall through to the qualifier checks below.
+    const categoryFillType =
+      autofillFieldData.formCategory != null
+        ? targetedFormCategoryFillTypes[autofillFieldData.formCategory]
+        : undefined;
+
+    if (categoryFillType != null) {
+      autofillFieldData.inlineMenuFillType = categoryFillType;
       return;
     }
 

--- a/apps/browser/src/autofill/services/autofill.service.spec.ts
+++ b/apps/browser/src/autofill/services/autofill.service.spec.ts
@@ -8,6 +8,7 @@ import { UserVerificationService } from "@bitwarden/common/auth/services/user-ve
 import {
   AutofillOverlayVisibility,
   AutofillTargetingRuleTypes,
+  FormPurposeCategories,
 } from "@bitwarden/common/autofill/constants";
 import { AutofillSettingsServiceAbstraction } from "@bitwarden/common/autofill/services/autofill-settings.service";
 import {
@@ -1953,6 +1954,156 @@ describe("AutofillService", () => {
         passwordField,
         "stored-password",
       );
+    });
+
+    it("fills an email-only account-login form's email field with the Login cipher username", async () => {
+      const emailField = buildTargetedField({
+        opid: "targeted_field_0_email",
+        type: "email",
+        fieldQualifier: AutofillTargetingRuleTypes.email,
+        formCategory: FormPurposeCategories.AccountLogin,
+      });
+      const options = createGenerateFillScriptOptionsMock();
+      options.cipher.type = CipherType.Login;
+      options.cipher.login = mock<LoginView>({ username: "m.moss@example.com", uris: [] });
+      jest.spyOn(AutofillService, "fillByOpid");
+
+      await autofillService["generateTargetedFillScript"](
+        buildTargetedPageDetails([emailField]),
+        options,
+      );
+
+      expect(AutofillService.fillByOpid).toHaveBeenCalledWith(
+        expect.anything(),
+        emailField,
+        "m.moss@example.com",
+      );
+    });
+
+    it("fills a phone-only account-login form's phone field with the Login cipher username", async () => {
+      const phoneField = buildTargetedField({
+        opid: "targeted_field_0_phone",
+        type: "tel",
+        fieldQualifier: AutofillTargetingRuleTypes.phone,
+        formCategory: FormPurposeCategories.AccountLogin,
+      });
+      const options = createGenerateFillScriptOptionsMock();
+      options.cipher.type = CipherType.Login;
+      options.cipher.login = mock<LoginView>({ username: "0118 999 881 999 119 7253", uris: [] });
+      jest.spyOn(AutofillService, "fillByOpid");
+
+      await autofillService["generateTargetedFillScript"](
+        buildTargetedPageDetails([phoneField]),
+        options,
+      );
+
+      expect(AutofillService.fillByOpid).toHaveBeenCalledWith(
+        expect.anything(),
+        phoneField,
+        "0118 999 881 999 119 7253",
+      );
+    });
+
+    it("prefers the username field over email/phone when multiple identifier fields are present in a login form", async () => {
+      const usernameField = buildTargetedField({
+        opid: "targeted_field_0_username",
+        fieldQualifier: AutofillTargetingRuleTypes.username,
+        formCategory: FormPurposeCategories.AccountLogin,
+      });
+      const emailField = buildTargetedField({
+        opid: "targeted_field_1_email",
+        type: "email",
+        fieldQualifier: AutofillTargetingRuleTypes.email,
+        formCategory: FormPurposeCategories.AccountLogin,
+      });
+      const phoneField = buildTargetedField({
+        opid: "targeted_field_2_phone",
+        type: "tel",
+        fieldQualifier: AutofillTargetingRuleTypes.phone,
+        formCategory: FormPurposeCategories.AccountLogin,
+      });
+      const options = createGenerateFillScriptOptionsMock();
+      options.cipher.type = CipherType.Login;
+      options.cipher.login = mock<LoginView>({ username: "dreynholm", uris: [] });
+      jest.spyOn(AutofillService, "fillByOpid");
+
+      await autofillService["generateTargetedFillScript"](
+        buildTargetedPageDetails([usernameField, emailField, phoneField]),
+        options,
+      );
+
+      expect(AutofillService.fillByOpid).toHaveBeenCalledWith(
+        expect.anything(),
+        usernameField,
+        "dreynholm",
+      );
+      expect(AutofillService.fillByOpid).not.toHaveBeenCalledWith(
+        expect.anything(),
+        emailField,
+        expect.anything(),
+      );
+      expect(AutofillService.fillByOpid).not.toHaveBeenCalledWith(
+        expect.anything(),
+        phoneField,
+        expect.anything(),
+      );
+    });
+
+    it("does not collapse identifier fields for an Identity cipher (email/phone map to their identity values)", async () => {
+      const emailField = buildTargetedField({
+        opid: "targeted_field_0_email",
+        type: "email",
+        fieldQualifier: AutofillTargetingRuleTypes.email,
+        formCategory: FormPurposeCategories.AccountLogin,
+      });
+      const phoneField = buildTargetedField({
+        opid: "targeted_field_1_phone",
+        type: "tel",
+        fieldQualifier: AutofillTargetingRuleTypes.phone,
+        formCategory: FormPurposeCategories.AccountLogin,
+      });
+      const options = createGenerateFillScriptOptionsMock();
+      options.cipher.type = CipherType.Identity;
+      options.cipher.identity = mock<IdentityView>({
+        email: "r.trenneman@example.com",
+        phone: "55 55 5555 5555",
+      });
+      jest.spyOn(AutofillService, "fillByOpid");
+
+      await autofillService["generateTargetedFillScript"](
+        buildTargetedPageDetails([emailField, phoneField]),
+        options,
+      );
+
+      expect(AutofillService.fillByOpid).toHaveBeenCalledWith(
+        expect.anything(),
+        emailField,
+        "r.trenneman@example.com",
+      );
+      expect(AutofillService.fillByOpid).toHaveBeenCalledWith(
+        expect.anything(),
+        phoneField,
+        "55 55 5555 5555",
+      );
+    });
+
+    it("does not route the Login cipher username to email/phone fields outside an account-login form", async () => {
+      const emailField = buildTargetedField({
+        opid: "targeted_field_0_email",
+        type: "email",
+        fieldQualifier: AutofillTargetingRuleTypes.email,
+        formCategory: FormPurposeCategories.AccountCreation,
+      });
+      const options = createGenerateFillScriptOptionsMock();
+      options.cipher.type = CipherType.Login;
+      options.cipher.login = mock<LoginView>({ username: "j.barber@example.com", uris: [] });
+
+      const result = await autofillService["generateTargetedFillScript"](
+        buildTargetedPageDetails([emailField]),
+        options,
+      );
+
+      expect(result).toBeNull();
     });
   });
 

--- a/apps/browser/src/autofill/services/autofill.service.ts
+++ b/apps/browser/src/autofill/services/autofill.service.ts
@@ -19,6 +19,7 @@ import {
   AutofillOverlayVisibility,
   AutofillTargetingRuleTypes,
   CardExpiryDateDelimiters,
+  FormPurposeCategories,
 } from "@bitwarden/common/autofill/constants";
 import { AutofillSettingsServiceAbstraction } from "@bitwarden/common/autofill/services/autofill-settings.service";
 import { DomainSettingsService } from "@bitwarden/common/autofill/services/domain-settings.service";
@@ -71,6 +72,20 @@ import {
   CreditCardAutoFillConstants,
   IdentityAutoFillConstants,
 } from "./autofill-constants";
+
+/**
+ * A Login cipher stores a single `login.username` that represents whatever the
+ * primary login identifier is (an actual username, an email, or a phone number).
+ * A targeting-rule `account-login` form may expose that identifier under any of
+ * these field types (and often has no `username` field at all). When filling a
+ * Login cipher, route `login.username` to the highest-priority identifier field
+ * present in the form, in this order, and skip the others.
+ */
+const loginIdentifierQualifierPriority: string[] = [
+  AutofillTargetingRuleTypes.username,
+  AutofillTargetingRuleTypes.email,
+  AutofillTargetingRuleTypes.phone,
+];
 
 export default class AutofillService implements AutofillServiceInterface {
   private openVaultItemPasswordRepromptPopout = openVaultItemPasswordRepromptPopout;
@@ -891,21 +906,42 @@ export default class AutofillService implements AutofillServiceInterface {
         ?.filter((u) => u.match != UriMatchStrategy.Never && u.uri != null)
         .map((u) => u.uri!) ?? [];
 
-    // Note; targeted fields intentionally skip the untrusted iframe check. The
+    // Note, targeted fields intentionally skip the untrusted iframe check. The
     // presence of targeting rules represents explicit expectations of the target
+
+    // For a Login cipher, `login.username` fills only the single highest-priority
+    // identifier field present in an `account-login` form (see the priority list).
+    const isLoginCipher = cipher.type === CipherType.Login;
+    const loginIdentifierQualifier = isLoginCipher
+      ? this.resolveLoginIdentifierQualifier(pageDetails)
+      : null;
 
     for (const field of pageDetails.fields) {
       if (!field.targeted || !field.fieldQualifier) {
         continue;
       }
 
-      // Password-generation flow synthesizes a Login cipher whose `password`
-      // carries the generated value. The standard newPassword → null policy
-      // would suppress that fill, so override it here.
-      const value =
-        isPasswordGeneration && field.fieldQualifier === AutofillTargetingRuleTypes.newPassword
-          ? (cipher.login?.password ?? null)
-          : this.getValueForTargetedFieldType(field.fieldQualifier, cipher);
+      let value: string | null;
+      if (isPasswordGeneration && field.fieldQualifier === AutofillTargetingRuleTypes.newPassword) {
+        // The Login cipher is a transient representation of the generated password
+        // value, so the usual logic skipping new password fills does not apply here
+        value = cipher.login?.password ?? null;
+      } else if (
+        isLoginCipher &&
+        field.formCategory === FormPurposeCategories.AccountLogin &&
+        loginIdentifierQualifierPriority.includes(field.fieldQualifier)
+      ) {
+        // The login identifier fills the winning identifier field only; sibling
+        // identifier fields are skipped. This presumes a _login_ form will not require
+        // more than one of a `loginIdentifierQualifierPriority` (e.g. only one of
+        // username, email, or phone number).
+        value =
+          field.fieldQualifier === loginIdentifierQualifier
+            ? (cipher.login?.username ?? null)
+            : null;
+      } else {
+        value = this.getValueForTargetedFieldType(field.fieldQualifier, cipher);
+      }
 
       if (!value) {
         continue;
@@ -919,6 +955,31 @@ export default class AutofillService implements AutofillServiceInterface {
     }
 
     return fillScript;
+  }
+
+  /**
+   * Determines which identifier field a Login cipher's `login.username` should
+   * fill, given the targeted fields present on `account-login` forms. Returns
+   * the highest-priority present qualifier (username > email > phone), or null
+   * when none are present.
+   */
+  private resolveLoginIdentifierQualifier(pageDetails: AutofillPageDetails): string | null {
+    const presentIdentifierQualifiers = new Set(
+      pageDetails.fields
+        .filter(
+          (field) =>
+            field.targeted &&
+            field.formCategory === FormPurposeCategories.AccountLogin &&
+            field.fieldQualifier != null,
+        )
+        .map((field) => field.fieldQualifier as string),
+    );
+
+    return (
+      loginIdentifierQualifierPriority.find((qualifier) =>
+        presentIdentifierQualifiers.has(qualifier),
+      ) ?? null
+    );
   }
 
   /**

--- a/apps/browser/src/autofill/services/collect-autofill-content.service.spec.ts
+++ b/apps/browser/src/autofill/services/collect-autofill-content.service.spec.ts
@@ -1,5 +1,7 @@
 import { mock } from "jest-mock-extended";
 
+import { FormPurposeCategories } from "@bitwarden/common/autofill/constants";
+
 import AutofillField from "../models/autofill-field";
 import AutofillForm from "../models/autofill-form";
 import { createAutofillFieldMock, createAutofillFormMock } from "../spec/autofill-mocks";
@@ -504,6 +506,33 @@ describe("CollectAutofillContentService", () => {
 
       expect(pageDetails.fields).toHaveLength(1);
       expect(pageDetails.fields[0].opid).toBe("targeted_field_0_username");
+    });
+  });
+
+  describe("getTargetedPageDetails category threading", () => {
+    it("carries the source form category onto locally-resolved targeted fields", async () => {
+      document.body.innerHTML = `<input type="text" id="username" />`;
+      jest
+        .spyOn(collectAutofillContentService as any, "sendExtensionMessage")
+        .mockImplementation((command: string) => {
+          if (command === "getUrlAutofillTargetingRules") {
+            return Promise.resolve({
+              result: [
+                {
+                  category: FormPurposeCategories.AccountLogin,
+                  fields: { email: ["#username"] },
+                },
+              ],
+            });
+          }
+          return Promise.resolve(undefined);
+        });
+
+      const pageDetails = await collectAutofillContentService.getPageDetails();
+
+      expect(pageDetails.fields).toHaveLength(1);
+      expect(pageDetails.fields[0].fieldQualifier).toBe("email");
+      expect(pageDetails.fields[0].formCategory).toBe(FormPurposeCategories.AccountLogin);
     });
   });
 

--- a/apps/browser/src/autofill/services/collect-autofill-content.service.spec.ts
+++ b/apps/browser/src/autofill/services/collect-autofill-content.service.spec.ts
@@ -612,6 +612,46 @@ describe("CollectAutofillContentService", () => {
         }),
       );
     });
+
+    it("includes the source form category in the routed iframe payload", async () => {
+      document.body.innerHTML = `<iframe id="login-form-container"></iframe>`;
+      const iframe = document.getElementById("login-form-container") as HTMLIFrameElement;
+      Object.defineProperty(iframe, "src", {
+        value: "https://other.example.com/login",
+        configurable: true,
+      });
+      Object.defineProperty(iframe, "contentDocument", { value: null, configurable: true });
+
+      const sendMessageSpy = jest
+        .spyOn(collectAutofillContentService as any, "sendExtensionMessage")
+        .mockImplementation((command: string) => {
+          if (command === "getUrlAutofillTargetingRules") {
+            return Promise.resolve({
+              result: [
+                {
+                  category: FormPurposeCategories.AccountLogin,
+                  fields: { username: ["iframe#login-form-container >>> #username"] },
+                },
+              ],
+            });
+          }
+          return Promise.resolve(undefined);
+        });
+
+      await collectAutofillContentService.getPageDetails();
+
+      expect(sendMessageSpy).toHaveBeenCalledWith(
+        "routeTargetedFieldsToFrame",
+        expect.objectContaining({
+          iframeTargetedFields: expect.arrayContaining([
+            expect.objectContaining({
+              fieldType: "username",
+              formCategory: FormPurposeCategories.AccountLogin,
+            }),
+          ]),
+        }),
+      );
+    });
   });
 
   describe("applyExternalTargetedFields recursion", () => {
@@ -644,6 +684,26 @@ describe("CollectAutofillContentService", () => {
           ]),
         }),
       );
+    });
+
+    it("retains the routed form category on a locally-resolved field", async () => {
+      document.body.innerHTML = `<input type="text" id="username" />`;
+
+      await collectAutofillContentService.applyExternalTargetedFields([
+        {
+          selector: "#username",
+          fieldType: "username",
+          formCategory: FormPurposeCategories.AccountLogin,
+        },
+      ]);
+
+      const fields = Array.from(
+        (
+          collectAutofillContentService as any
+        ).autofillFieldElements.values() as Iterable<AutofillField>,
+      );
+      expect(fields).toHaveLength(1);
+      expect(fields[0].formCategory).toBe(FormPurposeCategories.AccountLogin);
     });
 
     it("does not send collectPageDetailsResponse when all selectors route onward and no fields are cached", async () => {

--- a/apps/browser/src/autofill/services/collect-autofill-content.service.ts
+++ b/apps/browser/src/autofill/services/collect-autofill-content.service.ts
@@ -47,6 +47,16 @@ type ResolveFieldTarget = {
   formCategory?: FormPurposeCategory;
 };
 
+/**
+ * A single targeting-rule field whose selector crosses an iframe boundary and
+ * is routed to the sub-frame for local resolution. (mirrors {@link ResolveFieldTarget}).
+ */
+type IframeTargetedField = {
+  selector: string;
+  fieldType: AutofillTargetingRuleType;
+  formCategory?: FormPurposeCategory;
+};
+
 export class CollectAutofillContentService implements CollectAutofillContentServiceInterface {
   private readonly sendExtensionMessage = sendExtensionMessage;
   private readonly getAttributeBoolean = getAttributeBoolean;
@@ -375,11 +385,12 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
    * @param targetedFields - Selector/fieldType pairs resolved to this frame
    */
   async applyExternalTargetedFields(
-    targetedFields: { selector: string; fieldType: string }[],
+    targetedFields: { selector: string; fieldType: string; formCategory?: string }[],
   ): Promise<void> {
     const targets: ResolveFieldTarget[] = targetedFields.map((t) => ({
       selectorAlternatives: [t.selector],
       fieldType: t.fieldType as AutofillTargetingRuleType,
+      formCategory: t.formCategory as FormPurposeCategory,
     }));
 
     const { localFields, iframeTargets } = this.resolveTargetedFields(targets);
@@ -428,17 +439,14 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
    */
   private resolveTargetedFields(targets: ResolveFieldTarget[]): {
     localFields: AutofillField[];
-    iframeTargets: Map<string, { selector: string; fieldType: AutofillTargetingRuleType }[]>;
+    iframeTargets: Map<string, IframeTargetedField[]>;
   } {
     const localFields: AutofillField[] = [];
     // Accumulates targets that live inside iframes, keyed by the iframe's URL.
     // These are routed to the iframe's own content script instead of being
     // collected here, so the existing sub-frame offset infrastructure handles
     // their positioning correctly.
-    const iframeTargets = new Map<
-      string,
-      { selector: string; fieldType: AutofillTargetingRuleType }[]
-    >();
+    const iframeTargets = new Map<string, IframeTargetedField[]>();
 
     for (let targetIndex = 0; targetIndex < targets.length; targetIndex++) {
       const { selectorAlternatives, fieldType, formCategory } = targets[targetIndex];
@@ -465,6 +473,7 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
             iframeTargets.get(iframeSrc)!.push({
               selector: innerSelector,
               fieldType,
+              formCategory,
             });
           }
           break;
@@ -507,9 +516,7 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
    * The receiving frame's `applyExternalTargetedFields` will resolve locally
    * or re-route onward, enabling multi-hop chains.
    */
-  private routeIframeTargets(
-    iframeTargets: Map<string, { selector: string; fieldType: AutofillTargetingRuleType }[]>,
-  ): void {
+  private routeIframeTargets(iframeTargets: Map<string, IframeTargetedField[]>): void {
     for (const [iframeSrc, iframeTargetedFields] of iframeTargets) {
       void this.sendExtensionMessage("routeTargetedFieldsToFrame", {
         iframeSrc,

--- a/apps/browser/src/autofill/services/collect-autofill-content.service.ts
+++ b/apps/browser/src/autofill/services/collect-autofill-content.service.ts
@@ -1,5 +1,9 @@
 import { AUTOFILL_ATTRIBUTES } from "@bitwarden/common/autofill/constants";
-import { AutofillTargetingRuleType, FormContent } from "@bitwarden/common/autofill/types";
+import {
+  AutofillTargetingRuleType,
+  FormContent,
+  FormPurposeCategory,
+} from "@bitwarden/common/autofill/types";
 
 import AutofillField from "../models/autofill-field";
 import AutofillForm from "../models/autofill-form";
@@ -40,6 +44,7 @@ import { AutoFillConstants } from "./autofill-constants";
 type ResolveFieldTarget = {
   selectorAlternatives: string[];
   fieldType: AutofillTargetingRuleType;
+  formCategory?: FormPurposeCategory;
 };
 
 export class CollectAutofillContentService implements CollectAutofillContentServiceInterface {
@@ -320,7 +325,11 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
     const targets: ResolveFieldTarget[] = forms.flatMap((form) =>
       (Object.entries(form.fields) as Array<[AutofillTargetingRuleType, string[]]>)
         .filter(([, alternatives]) => alternatives?.length)
-        .map(([fieldType, selectorAlternatives]) => ({ fieldType, selectorAlternatives })),
+        .map(([fieldType, selectorAlternatives]) => ({
+          fieldType,
+          selectorAlternatives,
+          formCategory: form.category,
+        })),
     );
 
     const { localFields, iframeTargets } = this.resolveTargetedFields(targets);
@@ -432,7 +441,7 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
     >();
 
     for (let targetIndex = 0; targetIndex < targets.length; targetIndex++) {
-      const { selectorAlternatives, fieldType } = targets[targetIndex];
+      const { selectorAlternatives, fieldType, formCategory } = targets[targetIndex];
       if (!selectorAlternatives?.length) {
         continue;
       }
@@ -472,6 +481,7 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
             formFieldElement,
             fieldType,
             localFields.length,
+            formCategory,
           );
           localFields.push(autofillField);
           this.cacheAutofillFieldElement(localFields.length - 1, formFieldElement, autofillField);
@@ -522,6 +532,7 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
     element: ElementWithOpId<FormFieldElement>,
     fieldType: AutofillTargetingRuleType,
     index: number,
+    formCategory?: FormPurposeCategory,
   ): AutofillField {
     const field = new AutofillField();
     field.opid = element.opid;
@@ -537,8 +548,9 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
     field.title = element.getAttribute("title");
     field.tagName = element.tagName?.toLowerCase();
     field.type = (element as HTMLInputElement).type?.toLowerCase() || undefined;
-    field.fieldQualifier = fieldType as AutofillField["fieldQualifier"];
+    field.fieldQualifier = fieldType;
     field.targeted = true;
+    field.formCategory = formCategory;
     return field;
   }
 

--- a/apps/browser/src/background/runtime.background.ts
+++ b/apps/browser/src/background/runtime.background.ts
@@ -241,12 +241,14 @@ export default class RuntimeBackground {
         return result;
       }
       case "getUrlAutofillTargetingRules": {
-        return await this.main.domainSettingsService.getTargetingRulesForUrl(
-          // Because content scripts are injected into all _frames_, we give precedence
-          // to targeting rules matching by frame URI (`sender.url`) over tab URI, to avoid
-          // selector collision with coincidentally-matching in-frame structures.
-          sender.url ?? sender.tab?.url,
-        );
+        // Because content scripts are injected into all _frames_, we give precedence
+        // to targeting rules matching by frame URI (`sender.url`) over tab URI, to avoid
+        // selector collision with coincidentally-matching in-frame structures.
+        const senderURL = sender.url ?? sender.tab?.url;
+        const targetingRulesForUrl =
+          await this.main.domainSettingsService.getTargetingRulesForUrl(senderURL);
+
+        return targetingRulesForUrl;
       }
       case "authResult": {
         if (!(await this.isValidVaultReferrer(msg.referrer))) {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-39876](https://bitwarden.atlassian.net/browse/PM-39876)

## 📔 Objective

The extension treats username as a shared data concept (email/username), but map-the-web treats concepts semantically, expecting consumers to implement concerns like autofill on the contextual basis of the form category. In our case, we can have login forms that have email and/or phone number fields and no username field.

Using the Forms map category context, we are now able to map discrete fields to a shared username concept for stored login ciphers.


[PM-39876]: https://bitwarden.atlassian.net/browse/PM-39876?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ