### PR TITLE
Add per-device UseNewUi toggle gated by NewUiBetaSwitch flag

### DIFF
--- a/apps/web/src/app/settings/appearance.component.html
+++ b/apps/web/src/app/settings/appearance.component.html
@@ -43,5 +43,14 @@
         <vault-permit-cipher-details-popover></vault-permit-cipher-details-popover>
       </div>
     </div>
+    @if (newUiBetaEnabled$ | async) {
+      <bit-form-control>
+        <input type="checkbox" bitCheckbox formControlName="useNewUi" />
+        <bit-label>
+          {{ "useNewUi" | i18n }}
+        </bit-label>
+        <bit-hint>{{ "useNewUiDesc" | i18n }}</bit-hint>
+      </bit-form-control>
+    }
   </form>
 </bit-container>

--- a/apps/web/src/app/settings/appearance.component.spec.ts
+++ b/apps/web/src/app/settings/appearance.component.spec.ts
@@ -4,6 +4,7 @@ import { NoopAnimationsModule } from "@angular/platform-browser/animations";
 import { mock, MockProxy } from "jest-mock-extended";
 import { BehaviorSubject } from "rxjs";
 
+import { DeviceSettingsServiceAbstraction } from "@bitwarden/common/auth/abstractions/device-settings.service.abstraction";
 import { DomainSettingsService } from "@bitwarden/common/autofill/services/domain-settings.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { Theme, ThemeTypes } from "@bitwarden/common/platform/enums";
@@ -17,10 +18,13 @@ describe("AppearanceComponent", () => {
   let mockI18nService: MockProxy<I18nService>;
   let mockThemeStateService: MockProxy<ThemeStateService>;
   let mockDomainSettingsService: MockProxy<DomainSettingsService>;
+  let mockDeviceSettingsService: MockProxy<DeviceSettingsServiceAbstraction>;
 
   const mockShowFavicons$ = new BehaviorSubject<boolean>(true);
   const mockSelectedTheme$ = new BehaviorSubject<Theme>(ThemeTypes.Light);
   const mockUserSetLocale$ = new BehaviorSubject<string | undefined>("en");
+  const mockUseNewUi$ = new BehaviorSubject<boolean>(false);
+  const mockNewUiBetaEnabled$ = new BehaviorSubject<boolean>(true);
 
   const mockSupportedLocales = ["en", "es", "fr", "de"];
   const mockLocaleNames = new Map([
@@ -34,6 +38,14 @@ describe("AppearanceComponent", () => {
     mockI18nService = mock<I18nService>();
     mockThemeStateService = mock<ThemeStateService>();
     mockDomainSettingsService = mock<DomainSettingsService>();
+    mockDeviceSettingsService = mock<DeviceSettingsServiceAbstraction>();
+
+    mockUseNewUi$.next(false);
+    mockNewUiBetaEnabled$.next(true);
+    mockDeviceSettingsService.useNewUi$ = mockUseNewUi$;
+    mockDeviceSettingsService.newUiBetaEnabled$ = mockNewUiBetaEnabled$;
+    mockDeviceSettingsService.refreshFromServer.mockResolvedValue(undefined);
+    mockDeviceSettingsService.setUseNewUi.mockResolvedValue(undefined);
 
     mockI18nService.supportedTranslationLocales = mockSupportedLocales;
     mockI18nService.localeNames = mockLocaleNames;
@@ -56,6 +68,7 @@ describe("AppearanceComponent", () => {
         { provide: I18nService, useValue: mockI18nService },
         { provide: ThemeStateService, useValue: mockThemeStateService },
         { provide: DomainSettingsService, useValue: mockDomainSettingsService },
+        { provide: DeviceSettingsServiceAbstraction, useValue: mockDeviceSettingsService },
       ],
     })
       .overrideComponent(AppearanceComponent, {
@@ -114,7 +127,27 @@ describe("AppearanceComponent", () => {
         enableFavicons: false,
         theme: ThemeTypes.Dark,
         locale: "es",
+        useNewUi: false,
       });
+    }));
+
+    it("should refresh from the server and seed useNewUi from the cached value", fakeAsync(() => {
+      mockUseNewUi$.next(true);
+
+      fixture.detectChanges();
+      flush();
+
+      expect(mockDeviceSettingsService.refreshFromServer).toHaveBeenCalled();
+      expect(component.form.value.useNewUi).toBe(true);
+    }));
+
+    it("should not refresh from the server when the beta flag is off", fakeAsync(() => {
+      mockNewUiBetaEnabled$.next(false);
+
+      fixture.detectChanges();
+      flush();
+
+      expect(mockDeviceSettingsService.refreshFromServer).not.toHaveBeenCalled();
     }));
 
     it("should set locale to null when user locale not set", fakeAsync(() => {
@@ -178,6 +211,28 @@ describe("AppearanceComponent", () => {
       flush();
 
       expect(mockThemeStateService.setSelectedTheme).not.toHaveBeenCalled();
+    }));
+  });
+
+  describe("useNewUi value changes", () => {
+    beforeEach(fakeAsync(() => {
+      fixture.detectChanges();
+      flush();
+      jest.clearAllMocks();
+    }));
+
+    it("should persist the preference for the current device when toggled on", fakeAsync(() => {
+      component.form.controls.useNewUi.setValue(true);
+      flush();
+
+      expect(mockDeviceSettingsService.setUseNewUi).toHaveBeenCalledWith(true);
+    }));
+
+    it("should persist the preference for the current device when toggled off", fakeAsync(() => {
+      component.form.controls.useNewUi.setValue(false);
+      flush();
+
+      expect(mockDeviceSettingsService.setUseNewUi).toHaveBeenCalledWith(false);
     }));
   });
 

--- a/apps/web/src/app/settings/appearance.component.ts
+++ b/apps/web/src/app/settings/appearance.component.ts
@@ -3,6 +3,7 @@ import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { FormBuilder } from "@angular/forms";
 import { filter, firstValueFrom, switchMap } from "rxjs";
 
+import { DeviceSettingsServiceAbstraction } from "@bitwarden/common/auth/abstractions/device-settings.service.abstraction";
 import { DomainSettingsService } from "@bitwarden/common/autofill/services/domain-settings.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { Theme, ThemeTypes } from "@bitwarden/common/platform/enums";
@@ -37,13 +38,18 @@ export class AppearanceComponent implements OnInit {
     enableFavicons: true,
     theme: [ThemeTypes.Light as Theme],
     locale: [null as string | null],
+    useNewUi: false,
   });
+
+  /** Drives visibility of the new-UI toggle; hidden when the beta flag is off. */
+  protected readonly newUiBetaEnabled$ = this.deviceSettingsService.newUiBetaEnabled$;
 
   constructor(
     private readonly formBuilder: FormBuilder,
     private readonly i18nService: I18nService,
     private readonly themeStateService: ThemeStateService,
     private readonly domainSettingsService: DomainSettingsService,
+    private readonly deviceSettingsService: DeviceSettingsServiceAbstraction,
     private readonly destroyRef: DestroyRef,
   ) {
     const localeOptions: LocaleOption[] = [];
@@ -65,11 +71,18 @@ export class AppearanceComponent implements OnInit {
   }
 
   async ngOnInit() {
+    // Only pull the per-device value from the server when the beta is available; otherwise the
+    // toggle is hidden and useNewUi$ is forced to false anyway.
+    if (await firstValueFrom(this.deviceSettingsService.newUiBetaEnabled$)) {
+      await this.deviceSettingsService.refreshFromServer();
+    }
+
     this.form.setValue(
       {
         enableFavicons: await firstValueFrom(this.domainSettingsService.showFavicons$),
         theme: await firstValueFrom(this.themeStateService.selectedTheme$),
         locale: (await firstValueFrom(this.i18nService.userSetLocale$)) ?? null,
+        useNewUi: await firstValueFrom(this.deviceSettingsService.useNewUi$),
       },
       { emitEvent: false },
     );
@@ -99,6 +112,16 @@ export class AppearanceComponent implements OnInit {
         switchMap(async (locale) => {
           await this.i18nService.setLocale(locale);
           window.location.reload();
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe();
+
+    this.form.controls.useNewUi.valueChanges
+      .pipe(
+        filter((useNewUi) => useNewUi != null),
+        switchMap(async (useNewUi) => {
+          await this.deviceSettingsService.setUseNewUi(useNewUi);
         }),
         takeUntilDestroyed(this.destroyRef),
       )

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -2952,6 +2952,12 @@
   "showIconsChangePasswordUrls": {
     "message": "Show website icons and retrieve change password URLs"
   },
+  "useNewUi": {
+    "message": "Use the new UI"
+  },
+  "useNewUiDesc": {
+    "message": "Switch this device to the redesigned interface. This preference applies only to the current device."
+  },
   "default": {
     "message": "Default"
   },

--- a/libs/angular/src/services/jslib-services.module.ts
+++ b/libs/angular/src/services/jslib-services.module.ts
@@ -103,6 +103,7 @@ import { AnonymousHubService as AnonymousHubServiceAbstraction } from "@bitwarde
 import { AuthRequestAnsweringService } from "@bitwarden/common/auth/abstractions/auth-request-answering/auth-request-answering.service.abstraction";
 import { AuthService as AuthServiceAbstraction } from "@bitwarden/common/auth/abstractions/auth.service";
 import { AvatarService as AvatarServiceAbstraction } from "@bitwarden/common/auth/abstractions/avatar.service";
+import { DeviceSettingsServiceAbstraction } from "@bitwarden/common/auth/abstractions/device-settings.service.abstraction";
 import { DevicesServiceAbstraction } from "@bitwarden/common/auth/abstractions/devices/devices.service.abstraction";
 import { DevicesApiServiceAbstraction } from "@bitwarden/common/auth/abstractions/devices-api.service.abstraction";
 import { MasterPasswordApiService as MasterPasswordApiServiceAbstraction } from "@bitwarden/common/auth/abstractions/master-password-api.service.abstraction";
@@ -130,6 +131,7 @@ import { PendingAuthRequestsStateService } from "@bitwarden/common/auth/services
 import { AuthService } from "@bitwarden/common/auth/services/auth.service";
 import { AvatarService } from "@bitwarden/common/auth/services/avatar.service";
 import { DefaultActiveUserAccessor } from "@bitwarden/common/auth/services/default-active-user.accessor";
+import { DeviceSettingsServiceImplementation } from "@bitwarden/common/auth/services/device-settings.service.implementation";
 import { DevicesServiceImplementation } from "@bitwarden/common/auth/services/devices/devices.service.implementation";
 import { DevicesApiServiceImplementation } from "@bitwarden/common/auth/services/devices-api.service.implementation";
 import { MasterPasswordApiService } from "@bitwarden/common/auth/services/master-password/master-password-api.service.implementation";
@@ -1500,6 +1502,11 @@ const safeProviders: SafeProvider[] = [
     provide: DevicesServiceAbstraction,
     useClass: DevicesServiceImplementation,
     deps: [AppIdServiceAbstraction, DevicesApiServiceAbstraction, I18nServiceAbstraction],
+  }),
+  safeProvider({
+    provide: DeviceSettingsServiceAbstraction,
+    useClass: DeviceSettingsServiceImplementation,
+    deps: [StateProvider, DevicesApiServiceAbstraction, AppIdServiceAbstraction, ConfigService],
   }),
   safeProvider({
     provide: AuthRequestApiServiceAbstraction,

--- a/libs/common/src/auth/abstractions/device-settings.service.abstraction.ts
+++ b/libs/common/src/auth/abstractions/device-settings.service.abstraction.ts
@@ -1,0 +1,37 @@
+import { Observable } from "rxjs";
+
+/**
+ * Reads and writes per-device settings for the current device. Values are scoped to a single
+ * device and are not shared across the user's other clients. Holds the new/legacy UI preference
+ * today; add a typed accessor here as each new per-device setting is introduced.
+ *
+ * Reads are served from cached local (per-account) state, so they are cheap and safe to consume
+ * anywhere in the authenticated app — including offline. Call {@link refreshFromServer} to pull
+ * the latest value from the server (e.g. on login/sync or when opening a settings screen).
+ */
+export abstract class DeviceSettingsServiceAbstraction {
+  /**
+   * Whether the new-UI beta is available at all (gated by the NewUiBetaSwitch feature flag). When
+   * false, the new UI is unavailable regardless of the per-device setting, and the toggle should
+   * be hidden.
+   */
+  abstract newUiBetaEnabled$: Observable<boolean>;
+
+  /**
+   * Whether the current device has opted into the new UI. Backed by local state (no network per
+   * read). Forced to false when {@link newUiBetaEnabled$} is false; otherwise defaults to false
+   * (legacy UI) until refreshed from the server.
+   */
+  abstract useNewUi$: Observable<boolean>;
+
+  /**
+   * Persists the new/legacy UI preference for the current device to the server and updates the
+   * cached local state.
+   */
+  abstract setUseNewUi(useNewUi: boolean): Promise<void>;
+
+  /**
+   * Fetches the current device from the server and updates the cached local state.
+   */
+  abstract refreshFromServer(): Promise<void>;
+}

--- a/libs/common/src/auth/abstractions/devices-api.service.abstraction.ts
+++ b/libs/common/src/auth/abstractions/devices-api.service.abstraction.ts
@@ -2,6 +2,7 @@ import { ListResponse } from "../../models/response/list.response";
 import { DeviceResponse } from "../abstractions/devices/responses/device.response";
 import { UpdateDevicesTrustRequest } from "../models/request/update-devices-trust.request";
 import { ProtectedDeviceResponse } from "../models/response/protected-device.response";
+import { DeviceSettingsRequest } from "../services/devices/requests/device-settings.request";
 
 export abstract class DevicesApiServiceAbstraction {
   abstract getKnownDevice(email: string, deviceIdentifier: string): Promise<boolean>;
@@ -21,6 +22,17 @@ export abstract class DevicesApiServiceAbstraction {
     updateDevicesTrustRequestModel: UpdateDevicesTrustRequest,
     deviceIdentifier: string,
   ): Promise<void>;
+
+  /**
+   * Applies a partial update of per-device settings for the given device. Settings are scoped to a
+   * single device and are not shared across the user's other clients.
+   * @param deviceIdentifier - client generated id (not device id in DB)
+   * @param request - the settings to change; omitted settings are left as-is
+   */
+  abstract updateDeviceSettings(
+    deviceIdentifier: string,
+    request: DeviceSettingsRequest,
+  ): Promise<DeviceResponse>;
 
   abstract getDeviceKeys(deviceIdentifier: string): Promise<ProtectedDeviceResponse>;
 

--- a/libs/common/src/auth/abstractions/devices/responses/device.response.ts
+++ b/libs/common/src/auth/abstractions/devices/responses/device.response.ts
@@ -20,6 +20,7 @@ export class DeviceResponse extends BaseResponse {
 
   devicePendingAuthRequest: DevicePendingAuthRequest | null;
   lastActivityDate: string | null;
+  useNewUi: boolean;
 
   constructor(response: any) {
     super(response);
@@ -35,5 +36,6 @@ export class DeviceResponse extends BaseResponse {
     this.encryptedPublicKey = this.getResponseProperty("EncryptedPublicKey");
     this.devicePendingAuthRequest = this.getResponseProperty("DevicePendingAuthRequest");
     this.lastActivityDate = this.getResponseProperty("LastActivityDate");
+    this.useNewUi = this.getResponseProperty("UseNewUi") ?? false;
   }
 }

--- a/libs/common/src/auth/services/device-settings.service.implementation.spec.ts
+++ b/libs/common/src/auth/services/device-settings.service.implementation.spec.ts
@@ -1,0 +1,106 @@
+import { mock, MockProxy } from "jest-mock-extended";
+import { BehaviorSubject, firstValueFrom } from "rxjs";
+
+import { AppIdService } from "../../platform/abstractions/app-id.service";
+import { ConfigService } from "../../platform/abstractions/config/config.service";
+import { ActiveUserState, StateProvider } from "../../platform/state";
+import { DevicesApiServiceAbstraction } from "../abstractions/devices-api.service.abstraction";
+
+import { DeviceSettingsServiceImplementation } from "./device-settings.service.implementation";
+
+describe("DeviceSettingsServiceImplementation", () => {
+  let service: DeviceSettingsServiceImplementation;
+  let stateProvider: MockProxy<StateProvider>;
+  let devicesApiService: MockProxy<DevicesApiServiceAbstraction>;
+  let appIdService: MockProxy<AppIdService>;
+  let configService: MockProxy<ConfigService>;
+
+  let stateSubject: BehaviorSubject<boolean | null>;
+  let betaFlag$: BehaviorSubject<boolean>;
+  let updateMock: jest.Mock;
+
+  beforeEach(() => {
+    stateProvider = mock<StateProvider>();
+    devicesApiService = mock<DevicesApiServiceAbstraction>();
+    appIdService = mock<AppIdService>();
+    configService = mock<ConfigService>();
+    appIdService.getAppId.mockResolvedValue("app-id-123");
+
+    betaFlag$ = new BehaviorSubject<boolean>(true);
+    configService.getFeatureFlag$.mockReturnValue(betaFlag$ as any);
+
+    stateSubject = new BehaviorSubject<boolean | null>(null);
+    updateMock = jest.fn(async (configureState: (current: boolean | null) => boolean) => {
+      const next = configureState(stateSubject.value);
+      stateSubject.next(next);
+      return next;
+    });
+    stateProvider.getActive.mockReturnValue({
+      state$: stateSubject,
+      update: updateMock,
+    } as unknown as ActiveUserState<boolean>);
+
+    service = new DeviceSettingsServiceImplementation(
+      stateProvider,
+      devicesApiService,
+      appIdService,
+      configService,
+    );
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe("newUiBetaEnabled$", () => {
+    it("reflects the feature flag", async () => {
+      expect(await firstValueFrom(service.newUiBetaEnabled$)).toBe(true);
+
+      betaFlag$.next(false);
+      expect(await firstValueFrom(service.newUiBetaEnabled$)).toBe(false);
+    });
+  });
+
+  describe("useNewUi$", () => {
+    it("defaults to false when state is unset", async () => {
+      expect(await firstValueFrom(service.useNewUi$)).toBe(false);
+    });
+
+    it("reflects the cached state value when the beta flag is on", async () => {
+      stateSubject.next(true);
+      expect(await firstValueFrom(service.useNewUi$)).toBe(true);
+    });
+
+    it("is forced to false when the beta flag is off, even if the device opted in", async () => {
+      stateSubject.next(true);
+      betaFlag$.next(false);
+
+      expect(await firstValueFrom(service.useNewUi$)).toBe(false);
+    });
+  });
+
+  describe("setUseNewUi", () => {
+    it("persists to the server and updates cached state", async () => {
+      devicesApiService.updateDeviceSettings.mockResolvedValue({ useNewUi: true } as any);
+
+      await service.setUseNewUi(true);
+
+      expect(devicesApiService.updateDeviceSettings).toHaveBeenCalledWith(
+        "app-id-123",
+        expect.objectContaining({ useNewUi: true }),
+      );
+      expect(await firstValueFrom(service.useNewUi$)).toBe(true);
+    });
+  });
+
+  describe("refreshFromServer", () => {
+    it("loads the current device value into cached state", async () => {
+      devicesApiService.getDeviceByIdentifier.mockResolvedValue({ useNewUi: true } as any);
+
+      await service.refreshFromServer();
+
+      expect(devicesApiService.getDeviceByIdentifier).toHaveBeenCalledWith("app-id-123");
+      expect(await firstValueFrom(service.useNewUi$)).toBe(true);
+    });
+  });
+});

--- a/libs/common/src/auth/services/device-settings.service.implementation.ts
+++ b/libs/common/src/auth/services/device-settings.service.implementation.ts
@@ -1,0 +1,57 @@
+import { combineLatest, map, Observable } from "rxjs";
+
+import { FeatureFlag } from "../../enums/feature-flag.enum";
+import { AppIdService } from "../../platform/abstractions/app-id.service";
+import { ConfigService } from "../../platform/abstractions/config/config.service";
+import {
+  ActiveUserState,
+  DEVICE_SETTINGS_DISK,
+  StateProvider,
+  UserKeyDefinition,
+} from "../../platform/state";
+import { DeviceSettingsServiceAbstraction } from "../abstractions/device-settings.service.abstraction";
+import { DevicesApiServiceAbstraction } from "../abstractions/devices-api.service.abstraction";
+
+import { DeviceSettingsRequest } from "./devices/requests/device-settings.request";
+
+const USE_NEW_UI = new UserKeyDefinition<boolean>(DEVICE_SETTINGS_DISK, "useNewUi", {
+  deserializer: (value) => value ?? false,
+  clearOn: ["logout"],
+});
+
+export class DeviceSettingsServiceImplementation implements DeviceSettingsServiceAbstraction {
+  private useNewUiState: ActiveUserState<boolean>;
+  newUiBetaEnabled$: Observable<boolean>;
+  useNewUi$: Observable<boolean>;
+
+  constructor(
+    private stateProvider: StateProvider,
+    private devicesApiService: DevicesApiServiceAbstraction,
+    private appIdService: AppIdService,
+    private configService: ConfigService,
+  ) {
+    this.useNewUiState = this.stateProvider.getActive(USE_NEW_UI);
+    this.newUiBetaEnabled$ = this.configService.getFeatureFlag$(FeatureFlag.NewUiBetaSwitch);
+
+    // The new UI is gated behind the beta flag: when it is off, useNewUi$ is forced to false
+    // regardless of the stored per-device value (which is preserved for when the flag flips on).
+    this.useNewUi$ = combineLatest([this.newUiBetaEnabled$, this.useNewUiState.state$]).pipe(
+      map(([betaEnabled, useNewUi]) => (betaEnabled ? (useNewUi ?? false) : false)),
+    );
+  }
+
+  async setUseNewUi(useNewUi: boolean): Promise<void> {
+    const deviceIdentifier = await this.appIdService.getAppId();
+    await this.devicesApiService.updateDeviceSettings(
+      deviceIdentifier,
+      new DeviceSettingsRequest(useNewUi),
+    );
+    await this.useNewUiState.update(() => useNewUi);
+  }
+
+  async refreshFromServer(): Promise<void> {
+    const deviceIdentifier = await this.appIdService.getAppId();
+    const device = await this.devicesApiService.getDeviceByIdentifier(deviceIdentifier);
+    await this.useNewUiState.update(() => device.useNewUi);
+  }
+}

--- a/libs/common/src/auth/services/devices-api.service.implementation.spec.ts
+++ b/libs/common/src/auth/services/devices-api.service.implementation.spec.ts
@@ -3,6 +3,7 @@ import { mock, MockProxy } from "jest-mock-extended";
 import { ApiService } from "../../abstractions/api.service";
 import { DeviceResponse } from "../abstractions/devices/responses/device.response";
 
+import { DeviceSettingsRequest } from "./devices/requests/device-settings.request";
 import { DevicesApiServiceImplementation } from "./devices-api.service.implementation";
 
 describe("DevicesApiServiceImplementation", () => {
@@ -83,6 +84,28 @@ describe("DevicesApiServiceImplementation", () => {
           encryptedPublicKey: userKeyEncrypted,
           encryptedUserKey: publicKeyEncrypted,
         },
+        true,
+        true,
+      );
+    });
+  });
+
+  describe("updateDeviceSettings", () => {
+    it("updates device settings and returns device response", async () => {
+      const deviceIdentifier = "device123";
+      const mockResponse = { id: "123", name: "Test Device", UseNewUi: true };
+      apiService.send.mockResolvedValue(mockResponse);
+
+      const result = await devicesApiService.updateDeviceSettings(
+        deviceIdentifier,
+        new DeviceSettingsRequest(true),
+      );
+
+      expect(result).toBeInstanceOf(DeviceResponse);
+      expect(apiService.send).toHaveBeenCalledWith(
+        "PUT",
+        `/devices/${deviceIdentifier}/settings`,
+        { useNewUi: true },
         true,
         true,
       );

--- a/libs/common/src/auth/services/devices-api.service.implementation.ts
+++ b/libs/common/src/auth/services/devices-api.service.implementation.ts
@@ -9,6 +9,7 @@ import { UntrustDevicesRequestModel } from "../models/request/untrust-devices.re
 import { UpdateDevicesTrustRequest } from "../models/request/update-devices-trust.request";
 import { ProtectedDeviceResponse } from "../models/response/protected-device.response";
 
+import { DeviceSettingsRequest } from "./devices/requests/device-settings.request";
 import { TrustedDeviceKeysRequest } from "./devices/requests/trusted-device-keys.request";
 
 export class DevicesApiServiceImplementation implements DevicesApiServiceAbstraction {
@@ -88,6 +89,21 @@ export class DevicesApiServiceImplementation implements DevicesApiServiceAbstrac
         headers.set("Device-Identifier", deviceIdentifier);
       },
     );
+  }
+
+  async updateDeviceSettings(
+    deviceIdentifier: string,
+    request: DeviceSettingsRequest,
+  ): Promise<DeviceResponse> {
+    const result = await this.apiService.send(
+      "PUT",
+      `/devices/${deviceIdentifier}/settings`,
+      request,
+      true,
+      true,
+    );
+
+    return new DeviceResponse(result);
   }
 
   async getDeviceKeys(deviceIdentifier: string): Promise<ProtectedDeviceResponse> {

--- a/libs/common/src/auth/services/devices/requests/device-settings.request.ts
+++ b/libs/common/src/auth/services/devices/requests/device-settings.request.ts
@@ -1,0 +1,11 @@
+/**
+ * Partial update of per-device settings. Only properties that are set are changed on the server;
+ * omitted properties are left as-is.
+ */
+export class DeviceSettingsRequest {
+  useNewUi?: boolean;
+
+  constructor(useNewUi?: boolean) {
+    this.useNewUi = useNewUi;
+  }
+}

--- a/libs/common/src/enums/feature-flag.enum.ts
+++ b/libs/common/src/enums/feature-flag.enum.ts
@@ -115,6 +115,9 @@ export enum FeatureFlag {
 
   /* Desktop */
   DesktopSettingsDialog = "desktop-ui-settings-dialog",
+
+  /* UIF */
+  NewUiBetaSwitch = "new-ui-beta-switch",
 }
 
 export type AllowedFeatureFlagTypes = boolean | number | string;
@@ -233,6 +236,9 @@ export const DefaultFeatureFlagValue = {
 
   /* Desktop */
   [FeatureFlag.DesktopSettingsDialog]: FALSE,
+
+  /* UIF */
+  [FeatureFlag.NewUiBetaSwitch]: FALSE,
 } satisfies Record<FeatureFlag, AllowedFeatureFlagTypes>;
 
 export type DefaultFeatureFlagValueType = typeof DefaultFeatureFlagValue;

--- a/libs/state/src/core/state-definitions.ts
+++ b/libs/state/src/core/state-definitions.ts
@@ -98,6 +98,7 @@ export const USER_NOTIFICATION_SETTINGS_DISK = new StateDefinition(
   "disk",
 );
 
+export const DEVICE_SETTINGS_DISK = new StateDefinition("deviceSettings", "disk");
 export const DOMAIN_SETTINGS_DISK = new StateDefinition("domainSettings", "disk");
 export const AUTOFILL_SETTINGS_DISK = new StateDefinition("autofillSettings", "disk");
 export const AUTOFILL_SETTINGS_DISK_LOCAL = new StateDefinition("autofillSettingsLocal", "disk", {


### PR DESCRIPTION
## 🎟️ Tracking

No Jira ticket (internal spike). Companion **server** PR: bitwarden/server#7940

## 📔 Objective

Client side of the per-device **"Use new UI"** setting: lets a user switch a single client between the old and new UI independently of their other devices, gated behind the `NewUiBetaSwitch` feature flag.

- **`DeviceSettingsService`** (`libs/common`, `StateProvider`-backed, registered in `jslib-services.module` for all Angular clients): exposes `useNewUi$` (cached, per-account, offline-safe) and `newUiBetaEnabled$`, plus `setUseNewUi()` and `refreshFromServer()`. `useNewUi$` is forced to `false` when the beta flag is off.
- **Transport:** `DevicesApiService.updateDeviceSettings()` → `PUT /devices/{identifier}/settings` (patch), `DeviceSettingsRequest`; `DeviceResponse.useNewUi`.
- **Feature flag:** adds `NewUiBetaSwitch` to `FeatureFlag` (+ default value).
- **UI:** "Use the new UI" toggle on the web **Appearance** settings page, hidden when the beta flag is off.
- **Tests:** unit tests for the service (flag gating, state round-trip), the API service, and the appearance component.

Depends on the server endpoint/flag in bitwarden/server#7940.

## 📸 Screenshots

_Toggle appears on Settings → Appearance when `new-ui-beta-switch` is enabled; hidden otherwise._
