### PR TITLE
[PM-34458] Add release.yml to bitwarden/clients

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,34 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+  categories:
+    - title: "💙 Community Highlight"
+      labels:
+        - community-pr
+    - title: ":shipit: Feature Development"
+      labels:
+        - t:feature
+        - t:feature-app
+        - t:feature-tool
+        - t:new-feature
+        - t:enhancement
+    - title: "❗ Breaking Changes"
+      labels:
+        - t:breaking-change
+    - title: "🐛 Bug fixes"
+      labels:
+        - t:bugfix
+    - title: "⚙️ Maintenance"
+      labels:
+        - t:tech-debt
+        - t:ci
+        - t:docs
+        - t:misc
+    - title: "📦 Dependency Updates"
+      labels:
+        - major-updates
+        - t:deps
+    - title: "🎨 Other"
+      labels:
+        - "*"


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-34458

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Adds the release.yml template file for release notes generation

Same as on [bitwarden/server](https://github.com/bitwarden/server/blob/main/.github/release.yml)