### PR TITLE
[BRE-2018] Add snapcraft compatibility note to electron-builder PRs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -492,8 +492,8 @@
         "- OR migrate to core24 in `apps/desktop/electron-builder.json` (requires ubuntu-24.04 runners)",
         "- If compatible, remove `--channel=8.x/stable` pin from workflow",
         "",
-        "Related: BRE-2018"
-      ]
+        "Related: BRE-2018",
+      ],
     },
 
     // ==================== Dashboard Rules ====================

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -478,6 +478,23 @@
         "electron-updater",
       ],
     },
+    {
+      // Add snapcraft compatibility note to electron-builder PRs
+      matchPackageNames: ["electron-builder"],
+      prBodyNotes: [
+        "⚠️ **Snapcraft Compatibility Check Required**",
+        "",
+        "electron-builder 26.x + core22 requires snapcraft ≤8.x due to deprecated 'snap pack' command.",
+        "Currently pinned to `8.x/stable` in `.github/workflows/build-desktop.yml` (lines 205, 362)",
+        "",
+        "**If upgrading to electron-builder ≥27.0.0:**",
+        "- Test if electron-builder v27 + core22 works with snapcraft 9.x",
+        "- OR migrate to core24 in `apps/desktop/electron-builder.json` (requires ubuntu-24.04 runners)",
+        "- If compatible, remove `--channel=8.x/stable` pin from workflow",
+        "",
+        "Related: BRE-2018"
+      ]
+    },
 
     // ==================== Dashboard Rules ====================
     {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/BRE-2018

## 📔 Objective

When Renovate creates PRs to update electron-builder, add a note prompting reviewers to verify snapcraft compatibility.

electron-builder 26.x + core22 requires snapcraft ≤8.x due to the deprecated 'snap pack' command. When v27 is released, we need to test if it works with snapcraft 9.x before removing the pin.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
