### PR TITLE
[PM-36505] Finalize Send Controls policy design, adjust base policy component enabled display logic

### DIFF
--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -5559,10 +5559,6 @@
     "message": "Progress bar",
     "description": "This is the name of a page component that displays progress to the user. This string will be used to label the progress bar for a screenreader when multiple progress bars are on a page, like 'Progress bar 1' and 'Progress bar 2'."
   },
-  "sendControlsPolicyDescV2": {
-    "message": "Configure what members can do using Send. Admins and owners are exempt from this policy.",
-    "description": "'Send' is the name of a Bitwarden feature (used in the plural here) and should not be translated."
-  },
   "sendNotCompliantWithYourOrgsPolicy": {
     "message": "Not compliant with your organization's Send policy",
     "description": "'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated."

--- a/apps/web/src/app/admin-console/organizations/policies/base-policy-edit.component.ts
+++ b/apps/web/src/app/admin-console/organizations/policies/base-policy-edit.component.ts
@@ -9,6 +9,7 @@ import { PolicyType } from "@bitwarden/common/admin-console/enums";
 import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
 import { SavePolicyRequest } from "@bitwarden/common/admin-console/models/request/save-policy.request";
 import { PolicyStatusResponse } from "@bitwarden/common/admin-console/models/response/policy-status.response";
+import { PolicyResponse } from "@bitwarden/common/admin-console/models/response/policy.response";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { getUserId } from "@bitwarden/common/auth/services/account.service";
 import { assertNonNullish } from "@bitwarden/common/auth/utils";
@@ -132,6 +133,19 @@ export abstract class BasePolicyEditDefinition {
    */
   display$(organization: Organization, configService: ConfigService): Observable<boolean> {
     return of(true);
+  }
+
+  /**
+   * Logic for displaying the policy status in the Admin Console.
+   * If this returns true, the policy is shown as enabled. If false, it is shown as disabled.
+   * This uses the `policy.enabled` value by default, which is appropriate for most cases.
+   * You may wish to override this if the UI does not perfectly match the data model, e.g.
+   * you wish to determine policy status based on a `policy.data` value.
+
+   * Note: this only affects policy editing in Admin Console, it does not affect its enforcement.
+   */
+  enabled(policy: PolicyResponse): boolean {
+    return policy.enabled;
   }
 }
 

--- a/apps/web/src/app/admin-console/organizations/policies/policies.component.ts
+++ b/apps/web/src/app/admin-console/organizations/policies/policies.component.ts
@@ -91,12 +91,17 @@ export class PoliciesComponent {
       shareReplay({ bufferSize: 1, refCount: true }),
     );
 
+  private readonly policyEditDefinitionsDict = Object.fromEntries(
+    this.policyListService.getPolicies().map((p) => [p.type, p]),
+  ) as Record<PolicyType, BasePolicyEditDefinition>;
+
   protected readonly policiesEnabledMap$: Observable<Map<PolicyType, boolean>> =
     this.orgPolicies$.pipe(
       map((orgPolicies) => {
         const policiesEnabledMap: Map<PolicyType, boolean> = new Map<PolicyType, boolean>();
         orgPolicies.forEach((op) => {
-          policiesEnabledMap.set(op.type, op.enabled);
+          const showEnabled = this.policyEditDefinitionsDict[op.type]?.enabled(op) ?? op.enabled;
+          policiesEnabledMap.set(op.type, showEnabled);
         });
         return policiesEnabledMap;
       }),

--- a/apps/web/src/app/admin-console/organizations/policies/policy-edit-definitions/send-controls.component.html
+++ b/apps/web/src/app/admin-console/organizations/policies/policy-edit-definitions/send-controls.component.html
@@ -1,18 +1,8 @@
-<bit-form-control class="tw-mt-4">
-  <bit-switch [formControl]="enabled" id="enableSendControlsPolicySwitch"></bit-switch>
-  <bit-label class="tw-text-sm">{{ "sendControlsPolicySwitchLabel" | i18n }}</bit-label>
-</bit-form-control>
-
 <div [formGroup]="data">
-  <bit-hint class="tw-mb-2">{{ "sendControlsEnableDescription" | i18n }}</bit-hint>
-  <bit-radio-group formControlName="disableSend" [block]="true">
-    <bit-radio-button [value]="false">
-      <bit-label>{{ "allow" | i18n }}</bit-label>
-    </bit-radio-button>
-    <bit-radio-button [value]="true">
-      <bit-label>{{ "block" | i18n }}</bit-label>
-    </bit-radio-button>
-  </bit-radio-group>
+  <bit-form-control class="tw-mt-4">
+    <bit-switch [formControl]="enableSendControl" id="enableSendControlsPolicySwitch"></bit-switch>
+    <bit-label class="tw-text-sm">{{ "sendControlsPolicySwitchLabelV2" | i18n }}</bit-label>
+  </bit-form-control>
   <div [hidden]="!sendFeatureAllowed()">
     <bit-form-field>
       <bit-label>{{ "sendTypes" | i18n }}</bit-label>

--- a/apps/web/src/app/admin-console/organizations/policies/policy-edit-definitions/send-controls.component.ts
+++ b/apps/web/src/app/admin-console/organizations/policies/policy-edit-definitions/send-controls.component.ts
@@ -25,6 +25,8 @@ import { ControlsOf } from "@bitwarden/angular/types/controls-of";
 import { OrgDomainApiServiceAbstraction } from "@bitwarden/common/admin-console/abstractions/organization-domain/org-domain-api.service.abstraction";
 import { PolicyType } from "@bitwarden/common/admin-console/enums";
 import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
+import { SavePolicyRequest } from "@bitwarden/common/admin-console/models/request/save-policy.request";
+import { PolicyResponse } from "@bitwarden/common/admin-console/models/response/policy.response";
 import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
@@ -32,6 +34,7 @@ import { SendControlsPolicyData } from "@bitwarden/common/tools/models/send-cont
 import { SendDeletionDatePreset } from "@bitwarden/common/tools/models/send-deletion-date-preset";
 import { WhoCanAccessType } from "@bitwarden/common/tools/models/send-who-can-access-type";
 import { SendType } from "@bitwarden/common/tools/send/types/send-type";
+import { OrgKey } from "@bitwarden/common/types/key";
 import {
   FormFieldModule,
   Option,
@@ -48,8 +51,8 @@ import { BasePolicyEditDefinition, BasePolicyEditComponent } from "../base-polic
 import { PolicyCategory } from "../pipes/policy-category";
 
 export class SendControlsPolicy extends BasePolicyEditDefinition {
-  name = "sendControls";
-  description = "sendControlsPolicyDescV2";
+  name = "manageSend";
+  description = "sendControlsPolicyDescV3";
   type = PolicyType.SendControls;
   category = PolicyCategory.DataControl;
   priority = 30;
@@ -57,6 +60,19 @@ export class SendControlsPolicy extends BasePolicyEditDefinition {
 
   override display$(organization: Organization, configService: ConfigService): Observable<boolean> {
     return configService.getFeatureFlag$(FeatureFlag.SendControls);
+  }
+
+  override enabled(policy: PolicyResponse): boolean {
+    // This policy is always enabled, and is driven entirely through its `policy.data` configuration.
+    // The 'enabled' UI reflects whether the Send feature is enabled, rather than whether the policy is enabled.
+
+    // It is enabled by default:
+    if (policy == null || policy.data == null) {
+      return true;
+    }
+
+    // Or enabled if the Send feature is enabled:
+    return !policy.data.disableSend;
   }
 }
 
@@ -89,6 +105,7 @@ export class SendControlsPolicyComponent extends BasePolicyEditComponent impleme
     allowedSendTypes: [[SendType.Text, SendType.File], [Validators.required]],
     deletionHours: null,
   });
+  readonly enableSendControl = new FormControl<boolean>(false);
   readonly allowedSendTypesMultiSelectControl = new FormControl<
     (SelectItemView & { value: SendType })[]
   >([], { validators: [Validators.required] });
@@ -180,17 +197,12 @@ export class SendControlsPolicyComponent extends BasePolicyEditComponent impleme
           this.showDomains.set(false);
         }
       });
-    this.enabled.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((enabled) => {
-      if (!enabled) {
-        this.data.disable();
-        this.showDeletionHours.disable();
-        this.allowedSendTypesMultiSelectControl.disable();
-      } else {
-        this.data.enable();
-        this.showDeletionHours.enable();
-        this.allowedSendTypesMultiSelectControl.enable();
-      }
-    });
+    // The actual boolean field in the policy is the opposite of its toggle
+    this.enableSendControl.valueChanges
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((enableSend) => {
+        this.data.get("disableSend")?.patchValue(!enableSend);
+      });
     this.data
       .get("deletionHours")
       ?.valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
@@ -213,13 +225,26 @@ export class SendControlsPolicyComponent extends BasePolicyEditComponent impleme
         this.data.get("allowedSendTypes")?.patchValue((values ?? []).map<SendType>((v) => v.value));
       });
     super.ngOnInit();
-    // The separate multi-select form control must be initialized after we've loaded the policy data
-    const currentSendTypes = this.data.get("allowedSendTypes")?.value ?? [];
+  }
+
+  protected override loadData(): void {
+    const policyResponseData =
+      (this.policyResponse()?.data as SendControlsPolicyData) ?? new SendControlsPolicyData();
+    if (policyResponseData.allowedSendTypes == null) {
+      policyResponseData.allowedSendTypes = [SendType.Text, SendType.File];
+    }
+    if (policyResponseData.whoCanAccess == null) {
+      policyResponseData.whoCanAccess = WhoCanAccessType.Any;
+    }
+
+    this.data.patchValue(policyResponseData);
+
+    // The two separate form controls (enabled toggle and Send Types multi-select) must be initialized separately
+    this.enableSendControl.patchValue(!(policyResponseData.disableSend ?? false));
     this.allowedSendTypesMultiSelectControl.patchValue(
       this.allSendTypeOptions().filter((asto) =>
-        currentSendTypes.some((st) => st.toString() === asto.id),
+        policyResponseData.allowedSendTypes.some((st) => st.toString() === asto.id),
       ),
-      { emitEvent: false },
     );
   }
 
@@ -265,5 +290,18 @@ export class SendControlsPolicyComponent extends BasePolicyEditComponent impleme
       }
       return null;
     };
+  }
+
+  override buildRequest(orgKey?: OrgKey): Promise<SavePolicyRequest> {
+    // This policy is always enabled, but unlike other policies whether it shows as such on the
+    // policy admin screen is determined by whether or not the 'Enable Send' toggle is on or off.
+    // Therefore when saving the policy we set both enabled and data fields directly
+    return Promise.resolve({
+      policy: {
+        enabled: true,
+        data: this.data.value,
+      },
+      metadata: null,
+    });
   }
 }

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -7364,12 +7364,16 @@
   "sendControls": {
     "message": "Send controls"
   },
+  "manageSend": {
+    "message": "Manage Send",
+    "description": "'Send' is the name of a Bitwarden feature (used in the plural here) and should not be translated."
+  },
   "sendControlsPolicyDesc": {
     "message": "Set options for creating and editing Sends, including the ability to remove Sends.",
     "description": "'Send' is the name of a Bitwarden feature (used in the plural here) and should not be translated."
   },
-  "sendControlsPolicyDescV2": {
-    "message": "Configure what members can do using Send. Admins and owners are exempt from this policy.",
+  "sendControlsPolicyDescV3": {
+    "message": "Manage how members use Send. Admins and owners are exempt from this policy.",
     "description": "'Send' is the name of a Bitwarden feature (used in the plural here) and should not be translated."
   },
   "sendOptions": {
@@ -14913,8 +14917,8 @@
     "message": "Send has unsaved edits. Are you sure you want to leave?",
     "description": "'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated."
   },
-  "sendControlsPolicySwitchLabel": {
-    "message": "Enable Send controls",
+  "sendControlsPolicySwitchLabelV2": {
+    "message": "Enable Send",
     "description": "'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated."
   },
   "allow": {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-36505

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR finalizes the look of the Send Controls policy, part of which necessitates changing the base logic for when policies display "On" or "Off" in the editor (these changes were discussed with @eliykat) to allow us to have it depend not on `policy.enabled`, but on a field in `policy.data`. This is necessary because we want the On/Off display for this policy to depend on whether the Send feature is On/Off, not whether the policy is enabled or not.

This is an expansion of (and replacement for) [this PR](https://github.com/bitwarden/clients/pull/21127), many thanks to @bmbitwarden for taking the first crack at this

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/f6e956aa-a989-4626-be27-a5a581ea31f8

