### PR TITLE
fix(vault): archive and unarchive missing from bulk bar for org items

### DIFF
--- a/libs/vault/src/services/vault-batch-bar.service.spec.ts
+++ b/libs/vault/src/services/vault-batch-bar.service.spec.ts
@@ -325,12 +325,12 @@ describe("VaultBatchBarService", () => {
       expect(service.canArchive()).toBe(false);
     });
 
-    it("returns false when any cipher has an organizationId", () => {
+    it("returns true when an org cipher is selected and userCanArchive is true", () => {
       userCanArchiveSubject.next(true);
 
       service.selection.select(makeCipherItem({ organizationId: orgId }));
 
-      expect(service.canArchive()).toBe(false);
+      expect(service.canArchive()).toBe(true);
     });
 
     it("returns false when any cipher has an archivedDate", () => {
@@ -369,10 +369,10 @@ describe("VaultBatchBarService", () => {
       expect(service.canUnarchive()).toBe(false);
     });
 
-    it("returns false when any cipher has an organizationId", () => {
+    it("returns true when an archived org cipher is selected", () => {
       service.selection.select(makeCipherItem({ archivedDate: new Date(), organizationId: orgId }));
 
-      expect(service.canUnarchive()).toBe(false);
+      expect(service.canUnarchive()).toBe(true);
     });
 
     it("returns true when all selected ciphers are archived personal items", () => {

--- a/libs/vault/src/services/vault-batch-bar.service.ts
+++ b/libs/vault/src/services/vault-batch-bar.service.ts
@@ -201,9 +201,7 @@ export class VaultBatchBarService<C extends CipherViewLike> {
     if (selected.length === 0 || !this.userCanArchive() || hasCollections || this.inTrash()) {
       return false;
     }
-    return !selected.find(
-      (item) => item.cipher && (item.cipher.organizationId || item.cipher.archivedDate),
-    );
+    return !selected.find((item) => item.cipher && item.cipher.archivedDate);
   });
 
   /** True when all selected ciphers can be unarchived. */
@@ -212,7 +210,7 @@ export class VaultBatchBarService<C extends CipherViewLike> {
     if (selected.length === 0 || this.inTrash()) {
       return false;
     }
-    return !selected.find((i) => !i.cipher?.archivedDate || i.cipher?.organizationId);
+    return !selected.find((i) => !i.cipher?.archivedDate);
   });
 
   /** True when all selected ciphers can be restored from trash. */


### PR DESCRIPTION
## 🎟️ Tracking

[PM-40105](https://bitwarden.atlassian.net/browse/PM-40105)

## 📔 Objective

The new `VaultBatchBarService` incorrectly blocked **Archive** and **Unarchive** in the bulk action bar whenever an org-owned cipher was selected, due to an `organizationId` guard that never existed in the legacy bulk menu or the per-item context menu. Removed the guard from `canArchive` and `canUnarchive` so bulk archive behavior is consistent with those surfaces.

## 📸 Screenshots


https://github.com/user-attachments/assets/90952665-4e2e-431b-b6ec-7006106d6ed1


[PM-40105]: https://bitwarden.atlassian.net/browse/PM-40105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ