### PR TITLE
[PM-38595] Update local collections from server response

### DIFF
--- a/apps/cli/src/commands/edit.command.spec.ts
+++ b/apps/cli/src/commands/edit.command.spec.ts
@@ -70,7 +70,11 @@ describe("EditCommand", () => {
     accountService.activeAccount$ = of(activeAccount as any);
     keyService.orgKeys$.mockReturnValue(of({ [validOrgId]: mockOrgKey }));
     encryptService.encryptString.mockResolvedValue(mockEncString);
-    apiService.putCollection.mockResolvedValue({ id: validCollectionId } as any);
+    apiService.putCollection.mockResolvedValue({
+      id: validCollectionId,
+      groups: [],
+      users: [],
+    } as any);
     billingAccountProfileStateService.hasPremiumFromAnySource$.mockReturnValue(of(true));
 
     command = new EditCommand(
@@ -256,6 +260,26 @@ describe("EditCommand", () => {
       );
       expect(result.success).toBe(false);
       expect(result.message).toContain("API error");
+    });
+
+    it("response groups/users reflect server values, not request values", async () => {
+      const requestGroups = [
+        { id: "fake-group-id", readOnly: false, hidePasswords: false, manage: true },
+      ];
+      apiService.putCollection.mockResolvedValue({
+        id: validCollectionId,
+        groups: [],
+        users: [],
+      } as any);
+      const result = await command["editOrganizationCollection"](
+        validCollectionId,
+        makeRequest({ groups: requestGroups }),
+        makeOptions(),
+      );
+      expect(result.success).toBe(true);
+      const data = result.data as any;
+      expect(data.groups).toEqual([]);
+      expect(data.users).toEqual([]);
     });
   });
 });

--- a/apps/cli/src/commands/edit.command.ts
+++ b/apps/cli/src/commands/edit.command.ts
@@ -26,6 +26,7 @@ import { KeyService } from "@bitwarden/key-management";
 
 import { OrganizationCollectionRequest } from "../admin-console/models/request/organization-collection.request";
 import { OrganizationCollectionResponse } from "../admin-console/models/response/organization-collection.response";
+import { SelectionReadOnly } from "../admin-console/models/selection-read-only";
 import { Response } from "../models/response";
 import { CliUtils } from "../utils";
 import { CipherResponse } from "../vault/models/cipher.response";
@@ -262,7 +263,13 @@ export class EditCommand {
 
       const response = await this.apiService.putCollection(req.organizationId, id, request);
       const view = CollectionExport.toView(req, response.id);
-      const res = new OrganizationCollectionResponse(view, groups, users);
+      const serverGroups = response.groups.map(
+        (g) => new SelectionReadOnly(g.id, g.readOnly, g.hidePasswords, g.manage),
+      );
+      const serverUsers = response.users.map(
+        (u) => new SelectionReadOnly(u.id, u.readOnly, u.hidePasswords, u.manage),
+      );
+      const res = new OrganizationCollectionResponse(view, serverGroups, serverUsers);
       return Response.success(res);
     } catch (e) {
       return Response.error(e);

--- a/apps/cli/src/vault/create.command.spec.ts
+++ b/apps/cli/src/vault/create.command.spec.ts
@@ -73,7 +73,11 @@ describe("CreateCommand", () => {
     );
     keyService.getOrgKey.mockResolvedValue(mockOrgKey);
     encryptService.encryptString.mockResolvedValue(mockEncString);
-    apiService.postCollection.mockResolvedValue({ id: "new-collection-id" } as any);
+    apiService.postCollection.mockResolvedValue({
+      id: "new-collection-id",
+      groups: [],
+      users: [],
+    } as any);
 
     command = new CreateCommand(
       cipherService,
@@ -212,6 +216,25 @@ describe("CreateCommand", () => {
       const result = await command["createOrganizationCollection"](makeRequest(), makeOptions());
       expect(result.success).toBe(false);
       expect(result.message).toContain("API error");
+    });
+
+    it("response groups/users reflect server values, not request values", async () => {
+      const requestGroups = [
+        { id: "fake-group-id", readOnly: false, hidePasswords: false, manage: true },
+      ];
+      apiService.postCollection.mockResolvedValue({
+        id: "new-collection-id",
+        groups: [],
+        users: [],
+      } as any);
+      const result = await command["createOrganizationCollection"](
+        makeRequest({ groups: requestGroups }),
+        makeOptions(),
+      );
+      expect(result.success).toBe(true);
+      const data = result.data as any;
+      expect(data.groups).toEqual([]);
+      expect(data.users).toEqual([]);
     });
   });
 });

--- a/apps/cli/src/vault/create.command.ts
+++ b/apps/cli/src/vault/create.command.ts
@@ -28,6 +28,7 @@ import { KeyService } from "@bitwarden/key-management";
 
 import { OrganizationCollectionRequest } from "../admin-console/models/request/organization-collection.request";
 import { OrganizationCollectionResponse } from "../admin-console/models/response/organization-collection.response";
+import { SelectionReadOnly } from "../admin-console/models/selection-read-only";
 import { Response } from "../models/response";
 import { CliUtils } from "../utils";
 
@@ -264,7 +265,13 @@ export class CreateCommand {
       });
       const response = await this.apiService.postCollection(req.organizationId, request);
       const view = CollectionExport.toView(req, response.id);
-      const res = new OrganizationCollectionResponse(view, groups, users);
+      const serverGroups = response.groups.map(
+        (g) => new SelectionReadOnly(g.id, g.readOnly, g.hidePasswords, g.manage),
+      );
+      const serverUsers = response.users.map(
+        (u) => new SelectionReadOnly(u.id, u.readOnly, u.hidePasswords, u.manage),
+      );
+      const res = new OrganizationCollectionResponse(view, serverGroups, serverUsers);
       return Response.success(res);
     } catch (e) {
       return Response.error(e);

--- a/libs/admin-console/src/common/collections/services/default-collection-admin.service.ts
+++ b/libs/admin-console/src/common/collections/services/default-collection-admin.service.ts
@@ -15,7 +15,7 @@ import {
 } from "@bitwarden/common/admin-console/models/collections";
 import { SelectionReadOnlyRequest } from "@bitwarden/common/admin-console/models/request/selection-read-only.request";
 import { EncryptService } from "@bitwarden/common/key-management/crypto/abstractions/encrypt.service";
-import { CollectionId, OrganizationId, UserId } from "@bitwarden/common/types/guid";
+import { OrganizationId, UserId } from "@bitwarden/common/types/guid";
 import { OrgKey } from "@bitwarden/common/types/key";
 import { KeyService } from "@bitwarden/key-management";
 
@@ -69,7 +69,7 @@ export class DefaultCollectionAdminService implements CollectionAdminService {
       request,
     );
 
-    await this.updateLocalCollections(response, collection, userId);
+    await this.updateLocalCollections(response, userId);
 
     return response;
   }
@@ -86,7 +86,7 @@ export class DefaultCollectionAdminService implements CollectionAdminService {
     const response = await this.apiService.postCollection(collection.organizationId, request);
     collection.id = response.id;
 
-    await this.updateLocalCollections(response, collection, userId);
+    await this.updateLocalCollections(response, userId);
 
     return response;
   }
@@ -95,14 +95,8 @@ export class DefaultCollectionAdminService implements CollectionAdminService {
     await this.apiService.deleteCollection(organizationId, collectionId);
   }
 
-  private async updateLocalCollections(
-    response: CollectionDetailsResponse,
-    collection: CollectionAdminView,
-    userId: UserId,
-  ) {
-    response.assigned
-      ? await this.collectionService.upsert(new CollectionData(response), userId)
-      : await this.collectionService.delete([collection.id as CollectionId], userId);
+  private async updateLocalCollections(response: CollectionDetailsResponse, userId: UserId) {
+    await this.collectionService.upsert(new CollectionData(response), userId);
   }
 
   async bulkAssignAccess(

--- a/libs/admin-console/src/common/collections/services/default-collection-admin.service.ts
+++ b/libs/admin-console/src/common/collections/services/default-collection-admin.service.ts
@@ -15,7 +15,7 @@ import {
 } from "@bitwarden/common/admin-console/models/collections";
 import { SelectionReadOnlyRequest } from "@bitwarden/common/admin-console/models/request/selection-read-only.request";
 import { EncryptService } from "@bitwarden/common/key-management/crypto/abstractions/encrypt.service";
-import { OrganizationId, UserId } from "@bitwarden/common/types/guid";
+import { CollectionId, OrganizationId, UserId } from "@bitwarden/common/types/guid";
 import { OrgKey } from "@bitwarden/common/types/key";
 import { KeyService } from "@bitwarden/key-management";
 
@@ -95,8 +95,10 @@ export class DefaultCollectionAdminService implements CollectionAdminService {
     await this.apiService.deleteCollection(organizationId, collectionId);
   }
 
-  private async updateLocalCollections(response: CollectionDetailsResponse, userId: UserId) {
-    await this.collectionService.upsert(new CollectionData(response), userId);
+  private async updateLocalCollections(response: CollectionAccessDetailsResponse, userId: UserId) {
+    response.assigned
+      ? await this.collectionService.upsert(new CollectionData(response), userId)
+      : await this.collectionService.delete([response.id as CollectionId], userId);
   }
 
   async bulkAssignAccess(

--- a/libs/common/src/abstractions/api.service.ts
+++ b/libs/common/src/abstractions/api.service.ts
@@ -5,7 +5,6 @@ import { CreateCollectionRequest, UpdateCollectionRequest } from "@bitwarden/adm
 import { OrganizationConnectionType } from "../admin-console/enums";
 import {
   CollectionAccessDetailsResponse,
-  CollectionDetailsResponse,
   CollectionResponse,
 } from "../admin-console/models/collections";
 import { OrganizationSponsorshipCreateRequest } from "../admin-console/models/request/organization/organization-sponsorship-create.request";
@@ -276,12 +275,12 @@ export abstract class ApiService {
   abstract postCollection(
     organizationId: string,
     request: CreateCollectionRequest,
-  ): Promise<CollectionDetailsResponse>;
+  ): Promise<CollectionAccessDetailsResponse>;
   abstract putCollection(
     organizationId: string,
     id: string,
     request: UpdateCollectionRequest,
-  ): Promise<CollectionDetailsResponse>;
+  ): Promise<CollectionAccessDetailsResponse>;
   abstract deleteCollection(organizationId: string, id: string): Promise<any>;
   abstract deleteManyCollections(organizationId: string, collectionIds: string[]): Promise<any>;
 

--- a/libs/common/src/services/api.service.ts
+++ b/libs/common/src/services/api.service.ts
@@ -13,7 +13,6 @@ import { ApiService as ApiServiceAbstraction } from "../abstractions/api.service
 import { OrganizationConnectionType } from "../admin-console/enums";
 import {
   CollectionAccessDetailsResponse,
-  CollectionDetailsResponse,
   CollectionResponse,
 } from "../admin-console/models/collections";
 import { CollectionBulkDeleteRequest } from "../admin-console/models/request/collection-bulk-delete.request";
@@ -704,7 +703,7 @@ export class ApiService implements ApiServiceAbstraction {
   async postCollection(
     organizationId: string,
     request: CreateCollectionRequest,
-  ): Promise<CollectionDetailsResponse> {
+  ): Promise<CollectionAccessDetailsResponse> {
     const r = await this.send(
       "POST",
       "/organizations/" + organizationId + "/collections",
@@ -719,7 +718,7 @@ export class ApiService implements ApiServiceAbstraction {
     organizationId: string,
     id: string,
     request: UpdateCollectionRequest,
-  ): Promise<CollectionDetailsResponse> {
+  ): Promise<CollectionAccessDetailsResponse> {
     const r = await this.send(
       "PUT",
       "/organizations/" + organizationId + "/collections/" + id,


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/issues?filter=10592&selectedIssue=PM-38595
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
`bw create org-collection` and `bw edit org-collection` return the server's authoritative view of the created/updated collection built from the actual `CollectionAccessDetailsResposne`. Non-existent group ids should no longer appear in the response.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
