### PR TITLE
[PM-40138] desktop-autofill: refactor Autofill IPC Registration

### DIFF
--- a/apps/desktop/desktop_native/napi/index.d.ts
+++ b/apps/desktop/desktop_native/napi/index.d.ts
@@ -184,13 +184,13 @@ export declare namespace autofill {
   }
   export interface AutofillIpcCallbacks {
     /** Function to execute when a passkey registration request is received. */
-    registrationCallback: (error: null | Error, clientId: number, sequenceNumber: number, message: PasskeyRegistrationRequest) => void
-    /** Function to execute when a passkey assertion request is received. */
-    assertionCallback: (error: null | Error, clientId: number, sequenceNumber: number, message: PasskeyAssertionRequest) => void
-    /** Function to execute when a passkey assertion request is received and the UI must not be shown. */
-    assertionWithoutUserInterfaceCallback: (error: null | Error, clientId: number, sequenceNumber: number, message: PasskeyAssertionWithoutUserInterfaceRequest) => void
-    /** Function to execute when a notification of the autofill provider's status is received. */
-    nativeStatusCallback: (error: null | Error, clientId: number, sequenceNumber: number, message: NativeStatus) => void
+  registrationCallback: { (error: null, clientId: number, sequenceNumber: number, message: PasskeyRegistrationRequest): void; (error: Error, clientId: number, sequenceNumber: number, message: null): void; }
+  /** Function to execute when a passkey assertion request is received. */
+  assertionCallback: { (error: null, clientId: number, sequenceNumber: number, message: PasskeyAssertionRequest): void; (error: Error, clientId: number, sequenceNumber: number, message: null): void; }
+  /** Function to execute when a passkey assertion request is received and the UI must not be shown. */
+  assertionWithoutUserInterfaceCallback: { (error: null, clientId: number, sequenceNumber: number, message: PasskeyAssertionWithoutUserInterfaceRequest): void; (error: Error, clientId: number, sequenceNumber: number, message: null): void; }
+  /** Function to execute when a notification of the autofill provider's status is received. */
+  nativeStatusCallback: { (error: null, clientId: number, sequenceNumber: number, message: NativeStatus): void; (error: Error, clientId: number, sequenceNumber: number, message: null): void; }
   }
   export function runCommand(value: string): Promise<string>
 }

--- a/apps/desktop/desktop_native/napi/index.d.ts
+++ b/apps/desktop/desktop_native/napi/index.d.ts
@@ -187,7 +187,10 @@ export declare namespace autofill {
   registrationCallback: { (error: null, clientId: number, sequenceNumber: number, message: PasskeyRegistrationRequest): void; (error: Error, clientId: number, sequenceNumber: number, message: null): void; }
   /** Function to execute when a passkey assertion request is received. */
   assertionCallback: { (error: null, clientId: number, sequenceNumber: number, message: PasskeyAssertionRequest): void; (error: Error, clientId: number, sequenceNumber: number, message: null): void; }
-  /** Function to execute when a passkey assertion request is received and the UI must not be shown. */
+  /**
+   * Function to execute when a passkey assertion request is received and the UI must not be
+   * shown.
+   */
   assertionWithoutUserInterfaceCallback: { (error: null, clientId: number, sequenceNumber: number, message: PasskeyAssertionWithoutUserInterfaceRequest): void; (error: Error, clientId: number, sequenceNumber: number, message: null): void; }
   /** Function to execute when a notification of the autofill provider's status is received. */
   nativeStatusCallback: { (error: null, clientId: number, sequenceNumber: number, message: NativeStatus): void; (error: Error, clientId: number, sequenceNumber: number, message: null): void; }

--- a/apps/desktop/desktop_native/napi/index.d.ts
+++ b/apps/desktop/desktop_native/napi/index.d.ts
@@ -170,9 +170,10 @@ export declare namespace autofill {
      *
      * @param name The endpoint name to listen on. This name uniquely identifies the IPC
      * connection and must be the same for both the server and client. @param callback
-     * This function will be called whenever a message is received from a client.
+     * The functions that will be called whenever a message of the
+     * corresponding type is received from a client.
      */
-    static listen(name: string, registrationCallback: (error: null | Error, clientId: number, sequenceNumber: number, message: PasskeyRegistrationRequest) => void, assertionCallback: (error: null | Error, clientId: number, sequenceNumber: number, message: PasskeyAssertionRequest) => void, assertionWithoutUserInterfaceCallback: (error: null | Error, clientId: number, sequenceNumber: number, message: PasskeyAssertionWithoutUserInterfaceRequest) => void, nativeStatusCallback: (error: null | Error, clientId: number, sequenceNumber: number, message: NativeStatus) => void): Promise<AutofillIpcServer>
+    static listen(name: string, callbacks: AutofillIpcCallbacks): Promise<AutofillIpcServer>
     /** Return the path to the IPC server. */
     getPaths(): Array<string>
     /** Stop the IPC server. */
@@ -180,6 +181,16 @@ export declare namespace autofill {
     completeRegistration(clientId: number, sequenceNumber: number, response: PasskeyRegistrationResponse): number
     completeAssertion(clientId: number, sequenceNumber: number, response: PasskeyAssertionResponse): number
     completeError(clientId: number, sequenceNumber: number, error: string): number
+  }
+  export interface AutofillIpcCallbacks {
+    /** Function to execute when a passkey registration request is received. */
+    registrationCallback: (error: null | Error, clientId: number, sequenceNumber: number, message: PasskeyRegistrationRequest) => void
+    /** Function to execute when a passkey assertion request is received. */
+    assertionCallback: (error: null | Error, clientId: number, sequenceNumber: number, message: PasskeyAssertionRequest) => void
+    /** Function to execute when a passkey assertion request is received and the UI must not be shown. */
+    assertionWithoutUserInterfaceCallback: (error: null | Error, clientId: number, sequenceNumber: number, message: PasskeyAssertionWithoutUserInterfaceRequest) => void
+    /** Function to execute when a notification of the autofill provider's status is received. */
+    nativeStatusCallback: (error: null | Error, clientId: number, sequenceNumber: number, message: NativeStatus) => void
   }
   export function runCommand(value: string): Promise<string>
 }

--- a/apps/desktop/desktop_native/napi/src/autofill.rs
+++ b/apps/desktop/desktop_native/napi/src/autofill.rs
@@ -50,7 +50,8 @@ pub mod autofill {
                 }")]
         pub assertion_callback: ThreadsafeFunction<FnArgs<(u32, u32, PasskeyAssertionRequest)>>,
 
-        /// Function to execute when a passkey assertion request is received and the UI must not be shown.
+        /// Function to execute when a passkey assertion request is received and the UI must not be
+        /// shown.
         #[napi(ts_type = "{ \
             (error: null, clientId: number, sequenceNumber: number, message: PasskeyAssertionWithoutUserInterfaceRequest): void; \
             (error: Error, clientId: number, sequenceNumber: number, message: null): void; \

--- a/apps/desktop/desktop_native/napi/src/autofill.rs
+++ b/apps/desktop/desktop_native/napi/src/autofill.rs
@@ -31,6 +31,35 @@ pub mod autofill {
         server: desktop_core::ipc::server::Server,
     }
 
+    #[napi(object, object_to_js = false)]
+    pub struct AutofillIpcCallbacks {
+        /// Function to execute when a passkey registration request is received.
+        #[napi(
+            ts_type = "(error: null | Error, clientId: number, sequenceNumber: number, message: PasskeyRegistrationRequest) => void"
+        )]
+        pub registration_callback:
+            ThreadsafeFunction<FnArgs<(u32, u32, PasskeyRegistrationRequest)>>,
+
+        /// Function to execute when a passkey assertion request is received.
+        #[napi(
+            ts_type = "(error: null | Error, clientId: number, sequenceNumber: number, message: PasskeyAssertionRequest) => void"
+        )]
+        pub assertion_callback: ThreadsafeFunction<FnArgs<(u32, u32, PasskeyAssertionRequest)>>,
+
+        /// Function to execute when a passkey assertion request is received and the UI must not be shown.
+        #[napi(
+            ts_type = "(error: null | Error, clientId: number, sequenceNumber: number, message: PasskeyAssertionWithoutUserInterfaceRequest) => void"
+        )]
+        pub assertion_without_user_interface_callback:
+            ThreadsafeFunction<FnArgs<(u32, u32, PasskeyAssertionWithoutUserInterfaceRequest)>>,
+
+        /// Function to execute when a notification of the autofill provider's status is received.
+        #[napi(
+            ts_type = "(error: null | Error, clientId: number, sequenceNumber: number, message: NativeStatus) => void"
+        )]
+        pub native_status_callback: ThreadsafeFunction<FnArgs<(u32, u32, NativeStatus)>>,
+    }
+
     // FIXME: Remove unwraps! They panic and terminate the whole application.
     #[allow(clippy::unwrap_used)]
     #[napi]
@@ -39,38 +68,11 @@ pub mod autofill {
         ///
         /// @param name The endpoint name to listen on. This name uniquely identifies the IPC
         /// connection and must be the same for both the server and client. @param callback
-        /// This function will be called whenever a message is received from a client.
+        /// The functions that will be called whenever a message of the
+        /// corresponding type is received from a client.
         #[allow(clippy::unused_async)] // FIXME: Remove unused async!
         #[napi(factory)]
-        pub async fn listen(
-            name: String,
-            // Ideally we'd have a single callback that has an enum containing the request values,
-            // but NAPI doesn't support that just yet
-            #[napi(
-                ts_arg_type = "(error: null | Error, clientId: number, sequenceNumber: number, message: PasskeyRegistrationRequest) => void"
-            )]
-            registration_callback: ThreadsafeFunction<
-                FnArgs<(u32, u32, PasskeyRegistrationRequest)>,
-            >,
-            #[napi(
-                ts_arg_type = "(error: null | Error, clientId: number, sequenceNumber: number, message: PasskeyAssertionRequest) => void"
-            )]
-            assertion_callback: ThreadsafeFunction<
-                FnArgs<(u32, u32, PasskeyAssertionRequest)>,
-            >,
-            #[napi(
-                ts_arg_type = "(error: null | Error, clientId: number, sequenceNumber: number, message: PasskeyAssertionWithoutUserInterfaceRequest) => void"
-            )]
-            assertion_without_user_interface_callback: ThreadsafeFunction<
-                FnArgs<(u32, u32, PasskeyAssertionWithoutUserInterfaceRequest)>,
-            >,
-            #[napi(
-                ts_arg_type = "(error: null | Error, clientId: number, sequenceNumber: number, message: NativeStatus) => void"
-            )]
-            native_status_callback: ThreadsafeFunction<
-                FnArgs<(u32, u32, NativeStatus)>,
-            >,
-        ) -> napi::Result<Self> {
+        pub async fn listen(name: String, callbacks: AutofillIpcCallbacks) -> napi::Result<Self> {
             let (send, mut recv) = tokio::sync::mpsc::channel::<Message>(32);
             tokio::spawn(async move {
                 while let Some(Message {
@@ -105,14 +107,14 @@ pub mod autofill {
                                     let _params = (client_id, msg.sequence_number);
                                     todo!("Add lock_status_callback");
                                     /*
-                                    lock_status_callback.call(
+                                    callbacks.lock_status_callback.call(
                                         Ok(params.into()),
                                         ThreadsafeFunctionCallMode::NonBlocking,
                                     */
                                 }
                                 ExtensionRequest::NativeStatus(native_status) => {
                                     let params = (client_id, msg.sequence_number, native_status);
-                                    native_status_callback.call(
+                                    callbacks.native_status_callback.call(
                                         Ok(params.into()),
                                         ThreadsafeFunctionCallMode::NonBlocking,
                                     );
@@ -120,7 +122,7 @@ pub mod autofill {
                                 ExtensionRequest::PasskeyAssertion(assertion_request) => {
                                     let params =
                                         (client_id, msg.sequence_number, assertion_request);
-                                    assertion_callback.call(
+                                    callbacks.assertion_callback.call(
                                         Ok(params.into()),
                                         ThreadsafeFunctionCallMode::NonBlocking,
                                     );
@@ -130,7 +132,7 @@ pub mod autofill {
                                 ) => {
                                     let params =
                                         (client_id, msg.sequence_number, silent_assertion_request);
-                                    assertion_without_user_interface_callback.call(
+                                    callbacks.assertion_without_user_interface_callback.call(
                                         Ok(params.into()),
                                         ThreadsafeFunctionCallMode::NonBlocking,
                                     );
@@ -138,7 +140,7 @@ pub mod autofill {
                                 ExtensionRequest::PasskeyRegistration(registration_request) => {
                                     let params =
                                         (client_id, msg.sequence_number, registration_request);
-                                    registration_callback.call(
+                                    callbacks.registration_callback.call(
                                         Ok(params.into()),
                                         ThreadsafeFunctionCallMode::NonBlocking,
                                     );
@@ -147,7 +149,7 @@ pub mod autofill {
                                     let _params = (client_id, msg.sequence_number);
                                     todo!("Add window_handle_callback");
                                     /*
-                                    window_handle_callback.call(
+                                    callbacks.window_handle_callback.call(
                                         Ok(params.into()),
                                         ThreadsafeFunctionCallMode::NonBlocking,
                                     */

--- a/apps/desktop/desktop_native/napi/src/autofill.rs
+++ b/apps/desktop/desktop_native/napi/src/autofill.rs
@@ -34,29 +34,33 @@ pub mod autofill {
     #[napi(object, object_to_js = false)]
     pub struct AutofillIpcCallbacks {
         /// Function to execute when a passkey registration request is received.
-        #[napi(
-            ts_type = "(error: null | Error, clientId: number, sequenceNumber: number, message: PasskeyRegistrationRequest) => void"
-        )]
+        #[napi(ts_type = "{ \
+                    (error: null, clientId: number, sequenceNumber: number, message: PasskeyRegistrationRequest): void; \
+                    (error: Error, clientId: number, sequenceNumber: number, message: null): void; \
+                }")]
         pub registration_callback:
             ThreadsafeFunction<FnArgs<(u32, u32, PasskeyRegistrationRequest)>>,
 
         /// Function to execute when a passkey assertion request is received.
-        #[napi(
-            ts_type = "(error: null | Error, clientId: number, sequenceNumber: number, message: PasskeyAssertionRequest) => void"
-        )]
+        #[napi(ts_type = "{ \
+                    (error: null, clientId: number, sequenceNumber: number, message: PasskeyAssertionRequest): void; \
+                    (error: Error, clientId: number, sequenceNumber: number, message: null): void; \
+                }")]
         pub assertion_callback: ThreadsafeFunction<FnArgs<(u32, u32, PasskeyAssertionRequest)>>,
 
         /// Function to execute when a passkey assertion request is received and the UI must not be shown.
-        #[napi(
-            ts_type = "(error: null | Error, clientId: number, sequenceNumber: number, message: PasskeyAssertionWithoutUserInterfaceRequest) => void"
-        )]
+        #[napi(ts_type = "{ \
+            (error: null, clientId: number, sequenceNumber: number, message: PasskeyAssertionWithoutUserInterfaceRequest): void; \
+            (error: Error, clientId: number, sequenceNumber: number, message: null): void; \
+        }")]
         pub assertion_without_user_interface_callback:
             ThreadsafeFunction<FnArgs<(u32, u32, PasskeyAssertionWithoutUserInterfaceRequest)>>,
 
         /// Function to execute when a notification of the autofill provider's status is received.
-        #[napi(
-            ts_type = "(error: null | Error, clientId: number, sequenceNumber: number, message: NativeStatus) => void"
-        )]
+        #[napi(ts_type = "{ \
+            (error: null, clientId: number, sequenceNumber: number, message: NativeStatus): void; \
+            (error: Error, clientId: number, sequenceNumber: number, message: null): void; \
+        }")]
         pub native_status_callback: ThreadsafeFunction<FnArgs<(u32, u32, NativeStatus)>>,
     }
 

--- a/apps/desktop/desktop_native/napi/src/autofill.rs
+++ b/apps/desktop/desktop_native/napi/src/autofill.rs
@@ -31,6 +31,8 @@ pub mod autofill {
         server: desktop_core::ipc::server::Server,
     }
 
+    // TODO(PM-40230): Investigate if we can define the response types on these
+    // callbacks directly.
     #[napi(object, object_to_js = false)]
     pub struct AutofillIpcCallbacks {
         /// Function to execute when a passkey registration request is received.

--- a/apps/desktop/src/autofill/desktop-autofill.preload.ts
+++ b/apps/desktop/src/autofill/desktop-autofill.preload.ts
@@ -1,20 +1,14 @@
 import { ipcRenderer } from "electron";
 
-import type { autofill } from "@bitwarden/desktop-napi";
-type PasskeyAssertionRequest = autofill.PasskeyAssertionRequest;
-type PasskeyAssertionResponse = autofill.PasskeyAssertionResponse;
-type PasskeyAssertionWithoutUserInterfaceRequest =
-  autofill.PasskeyAssertionWithoutUserInterfaceRequest;
-type PasskeyRegistrationRequest = autofill.PasskeyRegistrationRequest;
-type PasskeyRegistrationResponse = autofill.PasskeyRegistrationResponse;
-type NativeStatus = autofill.NativeStatus;
-
 import { RunCommandParams, RunCommandResult } from "./main/main-desktop-autofill.service";
 import { AutofillCommand } from "./models/autofill-command";
 import {
   AutofillIpcChannelControl,
   AutofillIpcChannelIncoming,
   AutofillIpcChannelOutgoing,
+  AutofillIpcDefinitionMap,
+  AutofillIpcRequest,
+  AutofillIpcResponse,
 } from "./models/autofill-ipc-channels";
 import { CompletionCallback, IpcListener } from "./models/ipc-handler.type";
 
@@ -26,31 +20,28 @@ export const DesktopAutofillPreload = {
 
   listenerReady: () => ipcRenderer.send("autofill.listenerReady"),
 
-  listenPasskeyRegistration: makeListener<PasskeyRegistrationRequest, PasskeyRegistrationResponse>(
+  listenPasskeyRegistration: makeListener(
     AutofillIpcChannelIncoming.PasskeyRegistration,
     AutofillIpcChannelOutgoing.PasskeyRegistration,
   ),
-  listenPasskeyAssertion: makeListener<PasskeyAssertionRequest, PasskeyAssertionResponse>(
+  listenPasskeyAssertion: makeListener(
     AutofillIpcChannelIncoming.PasskeyAssertion,
     AutofillIpcChannelOutgoing.PasskeyAssertion,
   ),
 
-  listenPasskeyAssertionWithoutUserInterface: makeListener<
-    PasskeyAssertionWithoutUserInterfaceRequest,
-    PasskeyAssertionResponse
-  >(
+  listenPasskeyAssertionWithoutUserInterface: makeListener(
     AutofillIpcChannelIncoming.PasskeyAssertionWithoutUserInterface,
     AutofillIpcChannelOutgoing.PasskeyAssertion,
   ),
 
-  listenNativeStatus: makeListener<NativeStatus, void>(AutofillIpcChannelIncoming.NativeStatus),
+  listenNativeStatus: makeListener(AutofillIpcChannelIncoming.NativeStatus),
 };
 
-function makeListener<Request, Response>(
-  incomingChannel: AutofillIpcChannelIncoming,
-  outgoingChannel?: AutofillIpcChannelOutgoing,
+function makeListener<K extends AutofillIpcChannelIncoming>(
+  incomingChannel: K,
+  outgoingChannel?: AutofillIpcDefinitionMap[K]["outgoing"],
 ) {
-  return (fn: IpcListener<Request, Response>) => {
+  return (fn: IpcListener<AutofillIpcRequest<K>, AutofillIpcResponse<K>>) => {
     ipcRenderer.on(
       incomingChannel,
       (
@@ -58,28 +49,29 @@ function makeListener<Request, Response>(
         data: {
           clientId: number;
           sequenceNumber: number;
-          request: Request;
+          request: AutofillIpcRequest<K>;
         },
       ) => {
         const { clientId, sequenceNumber, request } = data;
-        const completeCallback: CompletionCallback<Response> | undefined = outgoingChannel
-          ? (error, response) => {
-              if (error) {
-                ipcRenderer.send(AutofillIpcChannelOutgoing.Error, {
+        const completeCallback: CompletionCallback<AutofillIpcResponse<K>> | undefined =
+          outgoingChannel
+            ? (error, response) => {
+                if (error) {
+                  ipcRenderer.send(AutofillIpcChannelOutgoing.Error, {
+                    clientId,
+                    sequenceNumber,
+                    error: error.message,
+                  });
+                  return;
+                }
+
+                ipcRenderer.send(outgoingChannel, {
                   clientId,
                   sequenceNumber,
-                  error: error.message,
+                  response,
                 });
-                return;
               }
-
-              ipcRenderer.send(outgoingChannel, {
-                clientId,
-                sequenceNumber,
-                response,
-              });
-            }
-          : undefined;
+            : undefined;
         fn(clientId, sequenceNumber, request, completeCallback);
       },
     );

--- a/apps/desktop/src/autofill/desktop-autofill.preload.ts
+++ b/apps/desktop/src/autofill/desktop-autofill.preload.ts
@@ -11,34 +11,45 @@ type NativeStatus = autofill.NativeStatus;
 
 import { RunCommandParams, RunCommandResult } from "./main/main-desktop-autofill.service";
 import { AutofillCommand } from "./models/autofill-command";
+import {
+  AutofillIpcChannelControl,
+  AutofillIpcChannelIncoming,
+  AutofillIpcChannelOutgoing,
+} from "./models/autofill-ipc-channels";
 import { CompletionCallback, IpcListener } from "./models/ipc-handler.type";
 
 export const DesktopAutofillPreload = {
   runCommand: <C extends AutofillCommand>(
     params: RunCommandParams<C>,
-  ): Promise<RunCommandResult<C>> => ipcRenderer.invoke("autofill.runCommand", params),
+  ): Promise<RunCommandResult<C>> =>
+    ipcRenderer.invoke(AutofillIpcChannelControl.RunCommand, params),
 
   listenerReady: () => ipcRenderer.send("autofill.listenerReady"),
 
   listenPasskeyRegistration: makeListener<PasskeyRegistrationRequest, PasskeyRegistrationResponse>(
-    "autofill.passkeyRegistration",
-    "autofill.completePasskeyRegistration",
+    AutofillIpcChannelIncoming.PasskeyRegistration,
+    AutofillIpcChannelOutgoing.PasskeyRegistration,
   ),
-
   listenPasskeyAssertion: makeListener<PasskeyAssertionRequest, PasskeyAssertionResponse>(
-    "autofill.passkeyAssertion",
-    "autofill.completePasskeyAssertion",
+    AutofillIpcChannelIncoming.PasskeyAssertion,
+    AutofillIpcChannelOutgoing.PasskeyAssertion,
   ),
 
   listenPasskeyAssertionWithoutUserInterface: makeListener<
     PasskeyAssertionWithoutUserInterfaceRequest,
     PasskeyAssertionResponse
-  >("autofill.passkeyAssertionWithoutUserInterface", "autofill.completePasskeyAssertion"),
+  >(
+    AutofillIpcChannelIncoming.PasskeyAssertionWithoutUserInterface,
+    AutofillIpcChannelOutgoing.PasskeyAssertion,
+  ),
 
-  listenNativeStatus: makeListener<NativeStatus, void>("autofill.nativeStatus"),
+  listenNativeStatus: makeListener<NativeStatus, void>(AutofillIpcChannelIncoming.NativeStatus),
 };
 
-function makeListener<Request, Response>(incomingChannel: string, outgoingChannel?: string) {
+function makeListener<Request, Response>(
+  incomingChannel: AutofillIpcChannelIncoming,
+  outgoingChannel?: AutofillIpcChannelOutgoing,
+) {
   return (fn: IpcListener<Request, Response>) => {
     ipcRenderer.on(
       incomingChannel,
@@ -54,7 +65,7 @@ function makeListener<Request, Response>(incomingChannel: string, outgoingChanne
         const completeCallback: CompletionCallback<Response> | undefined = outgoingChannel
           ? (error, response) => {
               if (error) {
-                ipcRenderer.send("autofill.completeError", {
+                ipcRenderer.send(AutofillIpcChannelOutgoing.Error, {
                   clientId,
                   sequenceNumber,
                   error: error.message,

--- a/apps/desktop/src/autofill/desktop-autofill.preload.ts
+++ b/apps/desktop/src/autofill/desktop-autofill.preload.ts
@@ -1,21 +1,17 @@
 import { ipcRenderer } from "electron";
 
 import type { autofill } from "@bitwarden/desktop-napi";
+type PasskeyAssertionRequest = autofill.PasskeyAssertionRequest;
+type PasskeyAssertionResponse = autofill.PasskeyAssertionResponse;
+type PasskeyAssertionWithoutUserInterfaceRequest =
+  autofill.PasskeyAssertionWithoutUserInterfaceRequest;
+type PasskeyRegistrationRequest = autofill.PasskeyRegistrationRequest;
+type PasskeyRegistrationResponse = autofill.PasskeyRegistrationResponse;
+type NativeStatus = autofill.NativeStatus;
 
 import { RunCommandParams, RunCommandResult } from "./main/main-desktop-autofill.service";
 import { AutofillCommand } from "./models/autofill-command";
-
-type CompletionCallback<T> = {
-  (error: null, response: T): void;
-  (error: Error, response: null): void;
-};
-
-type IpcListener<Request, Response> = (
-  clientId: number,
-  sequenceNumber: number,
-  request: Request,
-  completeCallback: CompletionCallback<Response>,
-) => void;
+import { CompletionCallback, IpcListener } from "./models/ipc-handler.type";
 
 export const DesktopAutofillPreload = {
   runCommand: <C extends AutofillCommand>(
@@ -24,125 +20,57 @@ export const DesktopAutofillPreload = {
 
   listenerReady: () => ipcRenderer.send("autofill.listenerReady"),
 
-  listenPasskeyRegistration: (
-    fn: IpcListener<autofill.PasskeyRegistrationRequest, autofill.PasskeyRegistrationResponse>,
-  ) => {
-    ipcRenderer.on(
-      "autofill.passkeyRegistration",
-      (
-        event,
-        data: {
-          clientId: number;
-          sequenceNumber: number;
-          request: autofill.PasskeyRegistrationRequest;
-        },
-      ) => {
-        const { clientId, sequenceNumber, request } = data;
-        fn(clientId, sequenceNumber, request, (error, response) => {
-          if (error) {
-            ipcRenderer.send("autofill.completeError", {
-              clientId,
-              sequenceNumber,
-              error: error.message,
-            });
-            return;
-          }
+  listenPasskeyRegistration: makeListener<PasskeyRegistrationRequest, PasskeyRegistrationResponse>(
+    "autofill.passkeyRegistration",
+    "autofill.completePasskeyRegistration",
+  ),
 
-          ipcRenderer.send("autofill.completePasskeyRegistration", {
-            clientId,
-            sequenceNumber,
-            response,
-          });
-        });
-      },
-    );
-  },
+  listenPasskeyAssertion: makeListener<PasskeyAssertionRequest, PasskeyAssertionResponse>(
+    "autofill.passkeyAssertion",
+    "autofill.completePasskeyAssertion",
+  ),
 
-  listenPasskeyAssertion: (
-    fn: IpcListener<autofill.PasskeyAssertionRequest, autofill.PasskeyAssertionResponse>,
-  ) => {
-    ipcRenderer.on(
-      "autofill.passkeyAssertion",
-      (
-        event,
-        data: {
-          clientId: number;
-          sequenceNumber: number;
-          request: autofill.PasskeyAssertionRequest;
-        },
-      ) => {
-        const { clientId, sequenceNumber, request } = data;
-        fn(clientId, sequenceNumber, request, (error, response) => {
-          if (error) {
-            ipcRenderer.send("autofill.completeError", {
-              clientId,
-              sequenceNumber,
-              error: error.message,
-            });
-            return;
-          }
+  listenPasskeyAssertionWithoutUserInterface: makeListener<
+    PasskeyAssertionWithoutUserInterfaceRequest,
+    PasskeyAssertionResponse
+  >("autofill.passkeyAssertionWithoutUserInterface", "autofill.completePasskeyAssertion"),
 
-          ipcRenderer.send("autofill.completePasskeyAssertion", {
-            clientId,
-            sequenceNumber,
-            response,
-          });
-        });
-      },
-    );
-  },
-  listenPasskeyAssertionWithoutUserInterface: (
-    fn: IpcListener<
-      autofill.PasskeyAssertionWithoutUserInterfaceRequest,
-      autofill.PasskeyAssertionResponse
-    >,
-  ) => {
-    ipcRenderer.on(
-      "autofill.passkeyAssertionWithoutUserInterface",
-      (
-        event,
-        data: {
-          clientId: number;
-          sequenceNumber: number;
-          request: autofill.PasskeyAssertionWithoutUserInterfaceRequest;
-        },
-      ) => {
-        const { clientId, sequenceNumber, request } = data;
-        fn(clientId, sequenceNumber, request, (error, response) => {
-          if (error) {
-            ipcRenderer.send("autofill.completeError", {
-              clientId,
-              sequenceNumber,
-              error: error.message,
-            });
-            return;
-          }
-
-          ipcRenderer.send("autofill.completePasskeyAssertion", {
-            clientId,
-            sequenceNumber,
-            response,
-          });
-        });
-      },
-    );
-  },
-  listenNativeStatus: (
-    fn: (clientId: number, sequenceNumber: number, request: autofill.NativeStatus) => void,
-  ) => {
-    ipcRenderer.on(
-      "autofill.nativeStatus",
-      (
-        event,
-        data: {
-          clientId: number;
-          sequenceNumber: number;
-          request: autofill.NativeStatus;
-        },
-      ) => {
-        const { clientId, sequenceNumber, request } = data;
-        fn(clientId, sequenceNumber, request);
-      },
-    );
-  },
+  listenNativeStatus: makeListener<NativeStatus, void>("autofill.nativeStatus"),
 };
+
+function makeListener<Request, Response>(incomingChannel: string, outgoingChannel?: string) {
+  return (fn: IpcListener<Request, Response>) => {
+    ipcRenderer.on(
+      incomingChannel,
+      (
+        _event,
+        data: {
+          clientId: number;
+          sequenceNumber: number;
+          request: Request;
+        },
+      ) => {
+        const { clientId, sequenceNumber, request } = data;
+        const completeCallback: CompletionCallback<Response> | undefined = outgoingChannel
+          ? (error, response) => {
+              if (error) {
+                ipcRenderer.send("autofill.completeError", {
+                  clientId,
+                  sequenceNumber,
+                  error: error.message,
+                });
+                return;
+              }
+
+              ipcRenderer.send(outgoingChannel, {
+                clientId,
+                sequenceNumber,
+                response,
+              });
+            }
+          : undefined;
+        fn(clientId, sequenceNumber, request, completeCallback);
+      },
+    );
+  };
+}

--- a/apps/desktop/src/autofill/desktop-autofill.preload.ts
+++ b/apps/desktop/src/autofill/desktop-autofill.preload.ts
@@ -10,6 +10,13 @@ type CompletionCallback<T> = {
   (error: Error, response: null): void;
 };
 
+type IpcListener<Request, Response> = (
+  clientId: number,
+  sequenceNumber: number,
+  request: Request,
+  completeCallback: CompletionCallback<Response>,
+) => void;
+
 export const DesktopAutofillPreload = {
   runCommand: <C extends AutofillCommand>(
     params: RunCommandParams<C>,
@@ -18,12 +25,7 @@ export const DesktopAutofillPreload = {
   listenerReady: () => ipcRenderer.send("autofill.listenerReady"),
 
   listenPasskeyRegistration: (
-    fn: (
-      clientId: number,
-      sequenceNumber: number,
-      request: autofill.PasskeyRegistrationRequest,
-      completeCallback: CompletionCallback<autofill.PasskeyRegistrationResponse>,
-    ) => void,
+    fn: IpcListener<autofill.PasskeyRegistrationRequest, autofill.PasskeyRegistrationResponse>,
   ) => {
     ipcRenderer.on(
       "autofill.passkeyRegistration",
@@ -57,12 +59,7 @@ export const DesktopAutofillPreload = {
   },
 
   listenPasskeyAssertion: (
-    fn: (
-      clientId: number,
-      sequenceNumber: number,
-      request: autofill.PasskeyAssertionRequest,
-      completeCallback: CompletionCallback<autofill.PasskeyAssertionResponse>,
-    ) => void,
+    fn: IpcListener<autofill.PasskeyAssertionRequest, autofill.PasskeyAssertionResponse>,
   ) => {
     ipcRenderer.on(
       "autofill.passkeyAssertion",
@@ -95,12 +92,10 @@ export const DesktopAutofillPreload = {
     );
   },
   listenPasskeyAssertionWithoutUserInterface: (
-    fn: (
-      clientId: number,
-      sequenceNumber: number,
-      request: autofill.PasskeyAssertionWithoutUserInterfaceRequest,
-      completeCallback: CompletionCallback<autofill.PasskeyAssertionResponse>,
-    ) => void,
+    fn: IpcListener<
+      autofill.PasskeyAssertionWithoutUserInterfaceRequest,
+      autofill.PasskeyAssertionResponse
+    >,
   ) => {
     ipcRenderer.on(
       "autofill.passkeyAssertionWithoutUserInterface",
@@ -133,7 +128,7 @@ export const DesktopAutofillPreload = {
     );
   },
   listenNativeStatus: (
-    fn: (clientId: number, sequenceNumber: number, status: { key: string; value: string }) => void,
+    fn: (clientId: number, sequenceNumber: number, request: autofill.NativeStatus) => void,
   ) => {
     ipcRenderer.on(
       "autofill.nativeStatus",
@@ -142,11 +137,11 @@ export const DesktopAutofillPreload = {
         data: {
           clientId: number;
           sequenceNumber: number;
-          status: { key: string; value: string };
+          request: autofill.NativeStatus;
         },
       ) => {
-        const { clientId, sequenceNumber, status } = data;
-        fn(clientId, sequenceNumber, status);
+        const { clientId, sequenceNumber, request } = data;
+        fn(clientId, sequenceNumber, request);
       },
     );
   },

--- a/apps/desktop/src/autofill/main/main-desktop-autofill.service.ts
+++ b/apps/desktop/src/autofill/main/main-desktop-autofill.service.ts
@@ -29,12 +29,10 @@ export type RunCommandParams<C extends AutofillCommandDefinition> = {
 
 export type RunCommandResult<C extends AutofillCommandDefinition> = C["output"];
 
-type Listener<Request> = (
-  error: Error | null,
-  clientId: number,
-  sequenceNumber: number,
-  request: Request,
-) => void;
+type Listener<Request> = {
+  (error: null, clientId: number, sequenceNumber: number, request: Request): void;
+  (error: Error, clientId: number, sequenceNumber: number, request: null): void;
+};
 type CompletionCallback<Response> = (
   clientId: number,
   sequenceNumber: number,
@@ -150,11 +148,11 @@ export class DesktopAutofillMain {
     fromRendererChannel?: AutofillIpcDefinitionMap[K]["outgoing"],
     completeCallback?: CompletionCallback<AutofillIpcResponse<K>>,
   ): Listener<AutofillIpcRequest<K>> {
-    const callback = (
-      error: Error | null,
-      clientId: number,
-      sequenceNumber: number,
-      request: AutofillIpcRequest<K>,
+    const callback: Listener<AutofillIpcRequest<K>> = (
+      error,
+      clientId,
+      sequenceNumber,
+      request,
     ) => {
       if (error) {
         this.logService.error("[NativeAutofillMain]", `${toRendererChannel}:`, error);

--- a/apps/desktop/src/autofill/main/main-desktop-autofill.service.ts
+++ b/apps/desktop/src/autofill/main/main-desktop-autofill.service.ts
@@ -93,30 +93,29 @@ export class DesktopAutofillMain {
     );
 
     // Register IPC listeners and response callbacks
-    const registrationListener = this.makeListener(
+    const registrationCallback = this.makeListener(
       AutofillIpcChannelIncoming.PasskeyRegistration,
       AutofillIpcChannelOutgoing.PasskeyRegistration,
       AutofillIpcServer.prototype.completeRegistration,
     );
-    const assertionListener = this.makeListener(
+    const assertionCallback = this.makeListener(
       AutofillIpcChannelIncoming.PasskeyAssertion,
       AutofillIpcChannelOutgoing.PasskeyAssertion,
       AutofillIpcServer.prototype.completeAssertion,
     );
-    const assertionWithoutUserInterfaceListener = this.makeListener(
+    const assertionWithoutUserInterfaceCallback = this.makeListener(
       AutofillIpcChannelIncoming.PasskeyAssertionWithoutUserInterface,
       AutofillIpcChannelOutgoing.PasskeyAssertion,
       AutofillIpcServer.prototype.completeAssertion,
     );
-    const nativeStatusListener = this.makeListener(AutofillIpcChannelIncoming.NativeStatus);
+    const nativeStatusCallback = this.makeListener(AutofillIpcChannelIncoming.NativeStatus);
 
-    this.ipcServer = await AutofillIpcServer.listen(
-      "af",
-      registrationListener,
-      assertionListener,
-      assertionWithoutUserInterfaceListener,
-      nativeStatusListener,
-    );
+    this.ipcServer = await AutofillIpcServer.listen("af", {
+      registrationCallback,
+      assertionCallback,
+      assertionWithoutUserInterfaceCallback,
+      nativeStatusCallback,
+    });
 
     ipcMain.on(AutofillIpcChannelControl.ListenerReady, () => {
       this.listenerReady = true;

--- a/apps/desktop/src/autofill/main/main-desktop-autofill.service.ts
+++ b/apps/desktop/src/autofill/main/main-desktop-autofill.service.ts
@@ -5,6 +5,16 @@ import { autofill } from "@bitwarden/desktop-napi";
 
 import { WindowMain } from "../../main/window.main";
 import { AutofillCommandDefinition } from "../models/autofill-command";
+import {
+  AutofillIpcChannelControl,
+  AutofillIpcChannelIncoming,
+  AutofillIpcChannelOutgoing,
+  AutofillIpcDefinitionMap,
+  AutofillIpcRequest,
+  AutofillIpcResponse,
+} from "../models/autofill-ipc-channels";
+
+import AutofillIpcServer = autofill.AutofillIpcServer;
 
 type BufferedMessage = {
   channel: string;
@@ -32,7 +42,7 @@ type CompletionCallback<Response> = (
 ) => void;
 
 export class DesktopAutofillMain {
-  private ipcServer?: autofill.AutofillIpcServer;
+  private ipcServer?: AutofillIpcServer;
   private messageBuffer: BufferedMessage[] = [];
   private listenerReady = false;
   private completionCallbacks: Map<string, CompletionCallback<any>> = new Map();
@@ -73,7 +83,7 @@ export class DesktopAutofillMain {
 
   async init() {
     ipcMain.handle(
-      "autofill.runCommand",
+      AutofillIpcChannelControl.RunCommand,
       <C extends AutofillCommandDefinition>(
         _event: any,
         params: RunCommandParams<C>,
@@ -83,39 +93,24 @@ export class DesktopAutofillMain {
     );
 
     // Register IPC listeners and response callbacks
-    const registrationListener = this.makeListener<
-      autofill.PasskeyRegistrationRequest,
-      autofill.PasskeyRegistrationResponse
-    >(
-      "autofill.AutofillIpcServer.registration",
-      "autofill.passkeyRegistration",
-      "autofill.completePasskeyRegistration",
-      autofill.AutofillIpcServer.prototype.completeRegistration,
+    const registrationListener = this.makeListener(
+      AutofillIpcChannelIncoming.PasskeyRegistration,
+      AutofillIpcChannelOutgoing.PasskeyRegistration,
+      AutofillIpcServer.prototype.completeRegistration,
     );
-    const assertionListener = this.makeListener<
-      autofill.PasskeyAssertionRequest,
-      autofill.PasskeyAssertionResponse
-    >(
-      "autofill.AutofillIpcServer.assertion",
-      "autofill.passkeyAssertion",
-      "autofill.completePasskeyAssertion",
-      autofill.AutofillIpcServer.prototype.completeAssertion,
+    const assertionListener = this.makeListener(
+      AutofillIpcChannelIncoming.PasskeyAssertion,
+      AutofillIpcChannelOutgoing.PasskeyAssertion,
+      AutofillIpcServer.prototype.completeAssertion,
     );
-    const assertionWithoutUserInterfaceListener = this.makeListener<
-      autofill.PasskeyAssertionWithoutUserInterfaceRequest,
-      autofill.PasskeyAssertionResponse
-    >(
-      "autofill.AutofillIpcServer.assertionWithoutUserInterface",
-      "autofill.passkeyAssertionWithoutUserInterface",
-      "autofill.completePasskeyAssertion",
-      autofill.AutofillIpcServer.prototype.completeAssertion,
+    const assertionWithoutUserInterfaceListener = this.makeListener(
+      AutofillIpcChannelIncoming.PasskeyAssertionWithoutUserInterface,
+      AutofillIpcChannelOutgoing.PasskeyAssertion,
+      AutofillIpcServer.prototype.completeAssertion,
     );
-    const nativeStatusListener = this.makeListener<autofill.NativeStatus, void>(
-      "autofill.AutofillIpcServer.nativeStatus",
-      "autofill.nativeStatus",
-    );
+    const nativeStatusListener = this.makeListener(AutofillIpcChannelIncoming.NativeStatus);
 
-    this.ipcServer = await autofill.AutofillIpcServer.listen(
+    this.ipcServer = await AutofillIpcServer.listen(
       "af",
       registrationListener,
       assertionListener,
@@ -123,7 +118,7 @@ export class DesktopAutofillMain {
       nativeStatusListener,
     );
 
-    ipcMain.on("autofill.listenerReady", () => {
+    ipcMain.on(AutofillIpcChannelControl.ListenerReady, () => {
       this.listenerReady = true;
       this.logService.info(
         `Listener is ready, flushing ${this.messageBuffer.length} buffered messages`,
@@ -131,8 +126,8 @@ export class DesktopAutofillMain {
       this.flushMessageBuffer();
     });
 
-    ipcMain.on("autofill.completeError", (event, data) => {
-      this.logService.debug("autofill.completeError", data);
+    ipcMain.on(AutofillIpcChannelOutgoing.Error, (event, data) => {
+      this.logService.debug("[DesktopAutofillMain]", AutofillIpcChannelOutgoing.Error, data);
       const { clientId, sequenceNumber, error } = data;
       this.ipcServer?.completeError(clientId, sequenceNumber, String(error));
     });
@@ -145,27 +140,25 @@ export class DesktopAutofillMain {
    * renderer process, which is forwarded back to the autofill IPC server using
    * the given completion callback.
    *
-   * @param {string} listenerName - The name for the listener, used for logging.
    * @param {string} toRendererChannel - Channel to send requests to the renderer process.
    * @param {[string]} fromRendererChannel - Channel to listen for responses from the renderer process. Excluded if the IPC request does not expect a response.
    * @param {[string]} completeCallback - Callback to execute on a response from the renderer process. This should be a reference to a prototype method on {@link autofill.AutofillIpcServer}. Excluded if the IPC request does not expect a response.
    *
    * @returns A callback that can be used to register with {@link autofill.AutofillIpcServer.listen}.
    */
-  private makeListener<Request, Response>(
-    listenerName: string,
-    toRendererChannel: string,
-    fromRendererChannel?: string,
-    completeCallback?: CompletionCallback<Response>,
-  ): Listener<Request> {
+  private makeListener<K extends AutofillIpcChannelIncoming>(
+    toRendererChannel: K,
+    fromRendererChannel?: AutofillIpcDefinitionMap[K]["outgoing"],
+    completeCallback?: CompletionCallback<AutofillIpcResponse<K>>,
+  ): Listener<AutofillIpcRequest<K>> {
     const callback = (
       error: Error | null,
       clientId: number,
       sequenceNumber: number,
-      request: Request,
+      request: AutofillIpcRequest<K>,
     ) => {
       if (error) {
-        this.logService.error(listenerName, error);
+        this.logService.error("[NativeAutofillMain]", `${toRendererChannel}:`, error);
         this.ipcServer?.completeError(clientId, sequenceNumber, String(error));
         return;
       }

--- a/apps/desktop/src/autofill/main/main-desktop-autofill.service.ts
+++ b/apps/desktop/src/autofill/main/main-desktop-autofill.service.ts
@@ -19,10 +19,23 @@ export type RunCommandParams<C extends AutofillCommandDefinition> = {
 
 export type RunCommandResult<C extends AutofillCommandDefinition> = C["output"];
 
+type Listener<Request> = (
+  error: Error | null,
+  clientId: number,
+  sequenceNumber: number,
+  request: Request,
+) => void;
+type CompletionCallback<Response> = (
+  clientId: number,
+  sequenceNumber: number,
+  response: Response,
+) => void;
+
 export class DesktopAutofillMain {
   private ipcServer?: autofill.AutofillIpcServer;
   private messageBuffer: BufferedMessage[] = [];
   private listenerReady = false;
+  private completionCallbacks: Map<string, CompletionCallback<any>> = new Map();
 
   constructor(
     private logService: LogService,
@@ -69,60 +82,45 @@ export class DesktopAutofillMain {
       },
     );
 
+    // Register IPC listeners and response callbacks
+    const registrationListener = this.makeListener<
+      autofill.PasskeyRegistrationRequest,
+      autofill.PasskeyRegistrationResponse
+    >(
+      "autofill.AutofillIpcServer.registration",
+      "autofill.passkeyRegistration",
+      "autofill.completePasskeyRegistration",
+      autofill.AutofillIpcServer.prototype.completeRegistration,
+    );
+    const assertionListener = this.makeListener<
+      autofill.PasskeyAssertionRequest,
+      autofill.PasskeyAssertionResponse
+    >(
+      "autofill.AutofillIpcServer.assertion",
+      "autofill.passkeyAssertion",
+      "autofill.completePasskeyAssertion",
+      autofill.AutofillIpcServer.prototype.completeAssertion,
+    );
+    const assertionWithoutUserInterfaceListener = this.makeListener<
+      autofill.PasskeyAssertionWithoutUserInterfaceRequest,
+      autofill.PasskeyAssertionResponse
+    >(
+      "autofill.AutofillIpcServer.assertionWithoutUserInterface",
+      "autofill.passkeyAssertionWithoutUserInterface",
+      "autofill.completePasskeyAssertion",
+      autofill.AutofillIpcServer.prototype.completeAssertion,
+    );
+    const nativeStatusListener = this.makeListener<autofill.NativeStatus, void>(
+      "autofill.AutofillIpcServer.nativeStatus",
+      "autofill.nativeStatus",
+    );
+
     this.ipcServer = await autofill.AutofillIpcServer.listen(
       "af",
-      // RegistrationCallback
-      (error, clientId, sequenceNumber, request) => {
-        if (error) {
-          this.logService.error("autofill.IpcServer.registration", error);
-          this.ipcServer?.completeError(clientId, sequenceNumber, String(error));
-          return;
-        }
-        this.safeSend("autofill.passkeyRegistration", {
-          clientId,
-          sequenceNumber,
-          request,
-        });
-      },
-      // AssertionCallback
-      (error, clientId, sequenceNumber, request) => {
-        if (error) {
-          this.logService.error("autofill.IpcServer.assertion", error);
-          this.ipcServer?.completeError(clientId, sequenceNumber, String(error));
-          return;
-        }
-        this.safeSend("autofill.passkeyAssertion", {
-          clientId,
-          sequenceNumber,
-          request,
-        });
-      },
-      // AssertionWithoutUserInterfaceCallback
-      (error, clientId, sequenceNumber, request) => {
-        if (error) {
-          this.logService.error("autofill.IpcServer.assertion", error);
-          this.ipcServer?.completeError(clientId, sequenceNumber, String(error));
-          return;
-        }
-        this.safeSend("autofill.passkeyAssertionWithoutUserInterface", {
-          clientId,
-          sequenceNumber,
-          request,
-        });
-      },
-      // NativeStatusCallback
-      (error, clientId, sequenceNumber, status) => {
-        if (error) {
-          this.logService.error("autofill.IpcServer.nativeStatus", error);
-          this.ipcServer?.completeError(clientId, sequenceNumber, String(error));
-          return;
-        }
-        this.safeSend("autofill.nativeStatus", {
-          clientId,
-          sequenceNumber,
-          status,
-        });
-      },
+      registrationListener,
+      assertionListener,
+      assertionWithoutUserInterfaceListener,
+      nativeStatusListener,
     );
 
     ipcMain.on("autofill.listenerReady", () => {
@@ -133,23 +131,89 @@ export class DesktopAutofillMain {
       this.flushMessageBuffer();
     });
 
-    ipcMain.on("autofill.completePasskeyRegistration", (event, data) => {
-      this.logService.debug("autofill.completePasskeyRegistration", data);
-      const { clientId, sequenceNumber, response } = data;
-      this.ipcServer?.completeRegistration(clientId, sequenceNumber, response);
-    });
-
-    ipcMain.on("autofill.completePasskeyAssertion", (event, data) => {
-      this.logService.debug("autofill.completePasskeyAssertion", data);
-      const { clientId, sequenceNumber, response } = data;
-      this.ipcServer?.completeAssertion(clientId, sequenceNumber, response);
-    });
-
     ipcMain.on("autofill.completeError", (event, data) => {
       this.logService.debug("autofill.completeError", data);
       const { clientId, sequenceNumber, error } = data;
       this.ipcServer?.completeError(clientId, sequenceNumber, String(error));
     });
+  }
+
+  /**
+   * Creates a listener function for an autofill IPC request, and selects a Electron
+   * renderer IPC channel to forward the request to. If a response callback is
+   * given, also registers a Electron channel listener for the response from the
+   * renderer process, which is forwarded back to the autofill IPC server using
+   * the given completion callback.
+   *
+   * @param {string} listenerName - The name for the listener, used for logging.
+   * @param {string} toRendererChannel - Channel to send requests to the renderer process.
+   * @param {[string]} fromRendererChannel - Channel to listen for responses from the renderer process. Excluded if the IPC request does not expect a response.
+   * @param {[string]} completeCallback - Callback to execute on a response from the renderer process. This should be a reference to a prototype method on {@link autofill.AutofillIpcServer}. Excluded if the IPC request does not expect a response.
+   *
+   * @returns A callback that can be used to register with {@link autofill.AutofillIpcServer.listen}.
+   */
+  private makeListener<Request, Response>(
+    listenerName: string,
+    toRendererChannel: string,
+    fromRendererChannel?: string,
+    completeCallback?: CompletionCallback<Response>,
+  ): Listener<Request> {
+    const callback = (
+      error: Error | null,
+      clientId: number,
+      sequenceNumber: number,
+      request: Request,
+    ) => {
+      if (error) {
+        this.logService.error(listenerName, error);
+        this.ipcServer?.completeError(clientId, sequenceNumber, String(error));
+        return;
+      }
+
+      this.safeSend(toRendererChannel, {
+        clientId,
+        sequenceNumber,
+        request,
+      });
+    };
+
+    // Only register if we have a callback, and only once
+    if (completeCallback && fromRendererChannel) {
+      if (ipcMain.listenerCount(fromRendererChannel) > 0) {
+        if (completeCallback === this.completionCallbacks.get(fromRendererChannel)) {
+          // if we're registering the same handler for the channel, then just silently continue.
+          return callback;
+        } else {
+          throw new Error(
+            `Tried to register multiple listeners for ${fromRendererChannel}, which is not allowed.`,
+          );
+        }
+      }
+
+      ipcMain.on(fromRendererChannel, (_event, data) => {
+        // This will only happen if we forget to assign `this.ipcServer`, since
+        // we won't receive any requests unless AutofillIpcServer.listen() is
+        // called, and therefore, we won't receive any response callbacks
+        // without ipcServer being set.
+        if (!this.ipcServer) {
+          this.logService.error(
+            "[NativeAutofillMain]",
+            `${fromRendererChannel}: Cannot find IPC server instance to return response to autofill provider.`,
+          );
+          throw new Error(
+            "Received data to send to Autofill IPC, but the IPC client instance is not initialized.",
+          );
+        }
+
+        this.logService.debug(fromRendererChannel, data);
+        const { clientId, sequenceNumber, response } = data;
+        completeCallback.call(this.ipcServer, clientId, sequenceNumber, response);
+      });
+
+      this.completionCallbacks.set(fromRendererChannel, completeCallback);
+    }
+
+    return callback;
   }
 
   private async runCommand<C extends AutofillCommandDefinition>(

--- a/apps/desktop/src/autofill/main/main-desktop-autofill.service.ts
+++ b/apps/desktop/src/autofill/main/main-desktop-autofill.service.ts
@@ -142,9 +142,9 @@ export class DesktopAutofillMain {
    *
    * @param {string} toRendererChannel - Channel to send requests to the renderer process.
    * @param {[string]} fromRendererChannel - Channel to listen for responses from the renderer process. Excluded if the IPC request does not expect a response.
-   * @param {[string]} completeCallback - Callback to execute on a response from the renderer process. This should be a reference to a prototype method on {@link autofill.AutofillIpcServer}. Excluded if the IPC request does not expect a response.
+   * @param {[string]} completeCallback - Callback to execute on a response from the renderer process. This should be a reference to a prototype method on {@link AutofillIpcServer}. Excluded if the IPC request does not expect a response.
    *
-   * @returns A callback that can be used to register with {@link autofill.AutofillIpcServer.listen}.
+   * @returns A callback that can be used to register with {@link AutofillIpcServer.listen}.
    */
   private makeListener<K extends AutofillIpcChannelIncoming>(
     toRendererChannel: K,

--- a/apps/desktop/src/autofill/models/autofill-ipc-channels.ts
+++ b/apps/desktop/src/autofill/models/autofill-ipc-channels.ts
@@ -8,13 +8,13 @@
  */
 
 import type { autofill } from "@bitwarden/desktop-napi";
+type NativeStatus = autofill.NativeStatus;
 type PasskeyAssertionRequest = autofill.PasskeyAssertionRequest;
 type PasskeyAssertionResponse = autofill.PasskeyAssertionResponse;
-type PasskeyRegistrationResponse = autofill.PasskeyRegistrationResponse;
-type PasskeyRegistrationRequest = autofill.PasskeyRegistrationRequest;
 type PasskeyAssertionWithoutUserInterfaceRequest =
   autofill.PasskeyAssertionWithoutUserInterfaceRequest;
-type NativeStatus = autofill.NativeStatus;
+type PasskeyRegistrationResponse = autofill.PasskeyRegistrationResponse;
+type PasskeyRegistrationRequest = autofill.PasskeyRegistrationRequest;
 
 export const AutofillIpcChannelIncoming = Object.freeze({
   NativeStatus: "autofill.nativeStatus",
@@ -42,10 +42,10 @@ export type AutofillIpcChannelOutgoing =
  * `outgoing?: never` marks a fire-and-forget channel that expects no response.
  */
 export type AutofillIpcDefinitionMap = {
-  [AutofillIpcChannelIncoming.PasskeyRegistration]: {
-    request: PasskeyRegistrationRequest;
-    response: PasskeyRegistrationResponse;
-    outgoing: typeof AutofillIpcChannelOutgoing.PasskeyRegistration;
+  [AutofillIpcChannelIncoming.NativeStatus]: {
+    request: NativeStatus;
+    response: void;
+    outgoing?: never;
   };
   [AutofillIpcChannelIncoming.PasskeyAssertion]: {
     request: PasskeyAssertionRequest;
@@ -57,10 +57,10 @@ export type AutofillIpcDefinitionMap = {
     response: PasskeyAssertionResponse;
     outgoing: typeof AutofillIpcChannelOutgoing.PasskeyAssertion;
   };
-  [AutofillIpcChannelIncoming.NativeStatus]: {
-    request: NativeStatus;
-    response: void;
-    outgoing?: never;
+  [AutofillIpcChannelIncoming.PasskeyRegistration]: {
+    request: PasskeyRegistrationRequest;
+    response: PasskeyRegistrationResponse;
+    outgoing: typeof AutofillIpcChannelOutgoing.PasskeyRegistration;
   };
 };
 

--- a/apps/desktop/src/autofill/models/autofill-ipc-channels.ts
+++ b/apps/desktop/src/autofill/models/autofill-ipc-channels.ts
@@ -3,8 +3,18 @@
  * To add a new IPC channel, you must
  * - Define the incoming IPC channel name in {@link AutofillIpcChannelIncoming}.
  * - Optionally, if the request expects a response, define the outgoing IPC channel name in {@link AutofillIpcChannelOutgoing}.
+ * - Associate the incoming and outgoing channel names and request and response types in {@link AutofillIpcDefinitionMap}.
  * - Add the listener in both `../main/main-desktop-autofill.service.ts` and `../preload.ts` {@link ipc.autofill}.
  */
+
+import type { autofill } from "@bitwarden/desktop-napi";
+type PasskeyAssertionRequest = autofill.PasskeyAssertionRequest;
+type PasskeyAssertionResponse = autofill.PasskeyAssertionResponse;
+type PasskeyRegistrationResponse = autofill.PasskeyRegistrationResponse;
+type PasskeyRegistrationRequest = autofill.PasskeyRegistrationRequest;
+type PasskeyAssertionWithoutUserInterfaceRequest =
+  autofill.PasskeyAssertionWithoutUserInterfaceRequest;
+type NativeStatus = autofill.NativeStatus;
 
 export const AutofillIpcChannelIncoming = Object.freeze({
   NativeStatus: "autofill.nativeStatus",
@@ -22,6 +32,44 @@ export const AutofillIpcChannelOutgoing = Object.freeze({
 } as const);
 export type AutofillIpcChannelOutgoing =
   (typeof AutofillIpcChannelOutgoing)[keyof typeof AutofillIpcChannelOutgoing];
+
+/**
+ * Correlates each incoming Autofill IPC channel with its outgoing (completion) channel and the
+ * request/response payload types. Channels are named from the **renderer's** perspective: the
+ * renderer listens on the incoming channel and replies on the outgoing channel, while the main
+ * process sends on the incoming channel and listens on the outgoing channel.
+ *
+ * `outgoing?: never` marks a fire-and-forget channel that expects no response.
+ */
+export type AutofillIpcDefinitionMap = {
+  [AutofillIpcChannelIncoming.PasskeyRegistration]: {
+    request: PasskeyRegistrationRequest;
+    response: PasskeyRegistrationResponse;
+    outgoing: typeof AutofillIpcChannelOutgoing.PasskeyRegistration;
+  };
+  [AutofillIpcChannelIncoming.PasskeyAssertion]: {
+    request: PasskeyAssertionRequest;
+    response: PasskeyAssertionResponse;
+    outgoing: typeof AutofillIpcChannelOutgoing.PasskeyAssertion;
+  };
+  [AutofillIpcChannelIncoming.PasskeyAssertionWithoutUserInterface]: {
+    request: PasskeyAssertionWithoutUserInterfaceRequest;
+    response: PasskeyAssertionResponse;
+    outgoing: typeof AutofillIpcChannelOutgoing.PasskeyAssertion;
+  };
+  [AutofillIpcChannelIncoming.NativeStatus]: {
+    request: NativeStatus;
+    response: void;
+    outgoing?: never;
+  };
+};
+
+/** The request payload type for a given incoming Autofill IPC channel. */
+export type AutofillIpcRequest<K extends AutofillIpcChannelIncoming> =
+  AutofillIpcDefinitionMap[K]["request"];
+/** The response payload type for a given incoming Autofill IPC channel. */
+export type AutofillIpcResponse<K extends AutofillIpcChannelIncoming> =
+  AutofillIpcDefinitionMap[K]["response"];
 
 /**
  * Autofill control channels that are not request/response pairs (no completion channel or payload

--- a/apps/desktop/src/autofill/models/autofill-ipc-channels.ts
+++ b/apps/desktop/src/autofill/models/autofill-ipc-channels.ts
@@ -1,0 +1,33 @@
+/**
+ * This contains the types for the Autofill IPC channels.
+ * To add a new IPC channel, you must
+ * - Define the incoming IPC channel name in {@link AutofillIpcChannelIncoming}.
+ * - Optionally, if the request expects a response, define the outgoing IPC channel name in {@link AutofillIpcChannelOutgoing}.
+ * - Add the listener in both `../main/main-desktop-autofill.service.ts` and `../preload.ts` {@link ipc.autofill}.
+ */
+
+export const AutofillIpcChannelIncoming = Object.freeze({
+  NativeStatus: "autofill.nativeStatus",
+  PasskeyAssertion: "autofill.passkeyAssertion",
+  PasskeyAssertionWithoutUserInterface: "autofill.passkeyAssertionWithoutUserInterface",
+  PasskeyRegistration: "autofill.passkeyRegistration",
+} as const);
+export type AutofillIpcChannelIncoming =
+  (typeof AutofillIpcChannelIncoming)[keyof typeof AutofillIpcChannelIncoming];
+
+export const AutofillIpcChannelOutgoing = Object.freeze({
+  Error: "autofill.completeError",
+  PasskeyAssertion: "autofill.completePasskeyAssertion",
+  PasskeyRegistration: "autofill.completePasskeyRegistration",
+} as const);
+export type AutofillIpcChannelOutgoing =
+  (typeof AutofillIpcChannelOutgoing)[keyof typeof AutofillIpcChannelOutgoing];
+
+/**
+ * Autofill control channels that are not request/response pairs (no completion channel or payload
+ * correlation).
+ */
+export const AutofillIpcChannelControl = Object.freeze({
+  ListenerReady: "autofill.listenerReady",
+  RunCommand: "autofill.runCommand",
+} as const);

--- a/apps/desktop/src/autofill/models/ipc-handler.type.ts
+++ b/apps/desktop/src/autofill/models/ipc-handler.type.ts
@@ -1,0 +1,21 @@
+export type CompletionCallback<Response> = {
+  (error: null, response: Response): void;
+  (error: Error, response: null): void;
+};
+/**
+ * A listener for an Autofill IPC channel. Invoked with the request payload and
+ * an optional callback to return the response (or an error) to the Autofill
+ * main process.
+ */
+export type IpcListener<Request, Response> = (
+  clientId: number,
+  sequenceNumber: number,
+  request: Request,
+  completeCallback?: CompletionCallback<Response>,
+) => void;
+
+/**
+ * A function to bind a listener to an Autofill IPC channel. Should be one of
+ * the `listen*` functions on {@link ipc.autofill}.
+ */
+export type IpcListenerBindFn<Request, Response> = (fn: IpcListener<Request, Response>) => void;

--- a/apps/desktop/src/autofill/services/desktop-autofill.service.ts
+++ b/apps/desktop/src/autofill/services/desktop-autofill.service.ts
@@ -219,8 +219,14 @@ export class DesktopAutofillService implements OnDestroy {
           this.logService.debug(
             `listenPasskeyRegistration: Native credential sync feature flag (${this.featureFlag}) is disabled`,
           );
-          callback(new Error("Native credential sync feature flag is disabled"), null);
+          if (callback) {
+            callback(new Error("Native credential sync feature flag is disabled"), null);
+          }
           return;
+        }
+
+        if (!callback) {
+          throw new Error("No callback specified to return passkey registration response");
         }
 
         this.registrationRequest = request;
@@ -260,8 +266,14 @@ export class DesktopAutofillService implements OnDestroy {
           this.logService.debug(
             `listenPasskeyAssertionWithoutUserInterface: Native credential sync feature flag (${this.featureFlag}) is disabled`,
           );
-          callback(new Error("Native credential sync feature flag is disabled"), null);
+          if (callback) {
+            callback(new Error("Native credential sync feature flag is disabled"), null);
+          }
           return;
+        }
+
+        if (!callback) {
+          throw new Error("No callback specified to return passkey assertion response");
         }
 
         this.logService.debug(
@@ -302,8 +314,14 @@ export class DesktopAutofillService implements OnDestroy {
           this.logService.debug(
             `listenPasskeyAssertion: Native credential sync feature flag (${this.featureFlag}) is disabled`,
           );
-          callback(new Error("Native credential sync feature flag is disabled"), null);
+          if (callback) {
+            callback(new Error("Native credential sync feature flag is disabled"), null);
+          }
           return;
+        }
+
+        if (!callback) {
+          throw new Error("No callback specified to return passkey assertion response");
         }
 
         this.logService.debug("listenPasskeyAssertion", clientId, sequenceNumber, request);

--- a/apps/desktop/src/autofill/services/desktop-autofill.service.ts
+++ b/apps/desktop/src/autofill/services/desktop-autofill.service.ts
@@ -37,6 +37,13 @@ import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.servi
 import { CipherType } from "@bitwarden/common/vault/enums";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { autofill } from "@bitwarden/desktop-napi";
+type PasskeyAssertionRequest = autofill.PasskeyAssertionRequest;
+type PasskeyAssertionResponse = autofill.PasskeyAssertionResponse;
+type PasskeyRegistrationResponse = autofill.PasskeyRegistrationResponse;
+type PasskeyRegistrationRequest = autofill.PasskeyRegistrationRequest;
+type PasskeyAssertionWithoutUserInterfaceRequest =
+  autofill.PasskeyAssertionWithoutUserInterfaceRequest;
+type NativeStatus = autofill.NativeStatus;
 
 import { AutofillStatusCommand } from "../models/autofill-status.command";
 import {
@@ -51,7 +58,7 @@ import type { NativeWindowObject } from "./desktop-fido2-user-interface.service"
 @Injectable()
 export class DesktopAutofillService implements OnDestroy {
   private destroy$ = new Subject<void>();
-  private registrationRequest?: autofill.PasskeyRegistrationRequest;
+  private registrationRequest?: PasskeyRegistrationRequest;
   private featureFlag?: typeof FeatureFlag.MacOsNativeCredentialSync;
   private isEnabled: boolean = false;
 
@@ -214,8 +221,8 @@ export class DesktopAutofillService implements OnDestroy {
   }
 
   async doPasskeyRegistration(
-    request: autofill.PasskeyRegistrationRequest,
-  ): Promise<autofill.PasskeyRegistrationResponse> {
+    request: PasskeyRegistrationRequest,
+  ): Promise<PasskeyRegistrationResponse> {
     const controller = new AbortController();
     this.registrationRequest = request;
 
@@ -227,9 +234,7 @@ export class DesktopAutofillService implements OnDestroy {
     return this.convertRegistrationResponse(request, response);
   }
 
-  async doPasskeyAssertion(
-    request: autofill.PasskeyAssertionRequest,
-  ): Promise<autofill.PasskeyAssertionResponse> {
+  async doPasskeyAssertion(request: PasskeyAssertionRequest): Promise<PasskeyAssertionResponse> {
     const controller = new AbortController();
 
     const assumeUserPresence = false;
@@ -244,8 +249,8 @@ export class DesktopAutofillService implements OnDestroy {
   }
 
   async doPasskeyAssertionWithoutUserInterface(
-    request: autofill.PasskeyAssertionWithoutUserInterfaceRequest,
-  ): Promise<autofill.PasskeyAssertionResponse> {
+    request: PasskeyAssertionWithoutUserInterfaceRequest,
+  ): Promise<PasskeyAssertionResponse> {
     const controller = new AbortController();
 
     const assumeUserPresence = true;
@@ -259,7 +264,7 @@ export class DesktopAutofillService implements OnDestroy {
     return this.convertAssertionResponse(request, response);
   }
 
-  async doNativeStatus(status: autofill.NativeStatus): Promise<void> {
+  async doNativeStatus(status: NativeStatus): Promise<void> {
     this.logService.info("Received native status", status.key, status.value);
     if (status.key === "request-sync") {
       // perform ad-hoc sync
@@ -411,9 +416,7 @@ export class DesktopAutofillService implements OnDestroy {
    * @returns
    */
   private convertAssertionRequest(
-    request:
-      | autofill.PasskeyAssertionRequest
-      | autofill.PasskeyAssertionWithoutUserInterfaceRequest,
+    request: PasskeyAssertionRequest | PasskeyAssertionWithoutUserInterfaceRequest,
     assumeUserPresence: boolean = false,
   ): Fido2AuthenticatorGetAssertionParams {
     let allowedCredentials;
@@ -444,9 +447,7 @@ export class DesktopAutofillService implements OnDestroy {
   }
 
   private convertAssertionResponse(
-    request:
-      | autofill.PasskeyAssertionRequest
-      | autofill.PasskeyAssertionWithoutUserInterfaceRequest,
+    request: PasskeyAssertionRequest | PasskeyAssertionWithoutUserInterfaceRequest,
     response: Fido2AuthenticatorGetAssertionResult,
   ): autofill.PasskeyAssertionResponse {
     // TODO(PM-40112): Model this as an optional field. macOS requires a user handle to be

--- a/apps/desktop/src/autofill/services/desktop-autofill.service.ts
+++ b/apps/desktop/src/autofill/services/desktop-autofill.service.ts
@@ -44,6 +44,7 @@ import {
   AutofillPasswordCredential,
   AutofillSyncCommand,
 } from "../models/autofill-sync.command";
+import { IpcListenerBindFn } from "../models/ipc-handler.type";
 
 import type { NativeWindowObject } from "./desktop-fido2-user-interface.service";
 
@@ -212,159 +213,151 @@ export class DesktopAutofillService implements OnDestroy {
     return this.registrationRequest;
   }
 
+  async doPasskeyRegistration(
+    request: autofill.PasskeyRegistrationRequest,
+  ): Promise<autofill.PasskeyRegistrationResponse> {
+    const controller = new AbortController();
+    this.registrationRequest = request;
+
+    const response = await this.fido2AuthenticatorService.makeCredential(
+      this.convertRegistrationRequest(request),
+      { windowXy: normalizePosition(request.clientWindow.position) },
+      controller,
+    );
+    return this.convertRegistrationResponse(request, response);
+  }
+
+  async doPasskeyAssertion(
+    request: autofill.PasskeyAssertionRequest,
+  ): Promise<autofill.PasskeyAssertionResponse> {
+    const controller = new AbortController();
+
+    const assumeUserPresence = false;
+
+    const response = await this.fido2AuthenticatorService.getAssertion(
+      this.convertAssertionRequest(request, assumeUserPresence),
+      { windowXy: normalizePosition(request.clientWindow.position) },
+      controller,
+    );
+
+    return this.convertAssertionResponse(request, response);
+  }
+
+  async doPasskeyAssertionWithoutUserInterface(
+    request: autofill.PasskeyAssertionWithoutUserInterfaceRequest,
+  ): Promise<autofill.PasskeyAssertionResponse> {
+    const controller = new AbortController();
+
+    const assumeUserPresence = true;
+
+    const response = await this.fido2AuthenticatorService.getAssertion(
+      this.convertAssertionRequest(request, assumeUserPresence),
+      { windowXy: normalizePosition(request.clientWindow.position) },
+      controller,
+    );
+
+    return this.convertAssertionResponse(request, response);
+  }
+
+  async doNativeStatus(status: autofill.NativeStatus): Promise<void> {
+    this.logService.info("Received native status", status.key, status.value);
+    if (status.key === "request-sync") {
+      // perform ad-hoc sync
+      await this.adHocSync();
+    }
+  }
+
   listenIpc() {
-    ipc.autofill.desktopAutofill.listenPasskeyRegistration(
-      async (clientId, sequenceNumber, request, callback) => {
-        if (!this.isEnabled) {
-          this.logService.debug(
-            `listenPasskeyRegistration: Native credential sync feature flag (${this.featureFlag}) is disabled`,
-          );
-          if (callback) {
-            callback(new Error("Native credential sync feature flag is disabled"), null);
-          }
-          return;
-        }
-
-        if (!callback) {
-          throw new Error("No callback specified to return passkey registration response");
-        }
-
-        this.registrationRequest = request;
-
-        this.logService.debug("listenPasskeyRegistration", clientId, sequenceNumber, request);
-        this.logService.debug(
-          "listenPasskeyRegistration2",
-          this.convertRegistrationRequest(request),
-        );
-
-        const controller = new AbortController();
-
-        try {
-          const response = await this.fido2AuthenticatorService.makeCredential(
-            this.convertRegistrationRequest(request),
-            { windowXy: normalizePosition(request.clientWindow.position) },
-            controller,
-          );
-
-          callback(null, this.convertRegistrationResponse(request, response));
-        } catch (error) {
-          this.logService.error("listenPasskeyRegistration error", error);
-          if (error instanceof Error) {
-            callback(error, null);
-          } else if (typeof error === "string") {
-            callback(new Error(error), null);
-          } else {
-            callback(new Error(JSON.stringify(error)), null);
-          }
-        }
-      },
+    const ipcDesktopAutofill = ipc.autofill.desktopAutofill;
+    // These must be arrow functions to bind `this` properly.
+    this.makeListener(ipcDesktopAutofill.listenPasskeyRegistration, (r) =>
+      this.doPasskeyRegistration(r),
     );
 
-    ipc.autofill.desktopAutofill.listenPasskeyAssertionWithoutUserInterface(
-      async (clientId, sequenceNumber, request, callback) => {
-        if (!this.isEnabled) {
-          this.logService.debug(
-            `listenPasskeyAssertionWithoutUserInterface: Native credential sync feature flag (${this.featureFlag}) is disabled`,
-          );
-          if (callback) {
-            callback(new Error("Native credential sync feature flag is disabled"), null);
-          }
-          return;
-        }
-
-        if (!callback) {
-          throw new Error("No callback specified to return passkey assertion response");
-        }
-
-        this.logService.debug(
-          "listenPasskeyAssertion without user interface",
-          clientId,
-          sequenceNumber,
-          request,
-        );
-
-        const controller = new AbortController();
-
-        try {
-          const response = await this.fido2AuthenticatorService.getAssertion(
-            this.convertAssertionRequest(request, true),
-            { windowXy: normalizePosition(request.clientWindow.position) },
-            controller,
-          );
-
-          callback(null, this.convertAssertionResponse(request, response));
-        } catch (error) {
-          this.logService.error("listenPasskeyAssertion error", error);
-
-          if (error instanceof Error) {
-            callback(error, null);
-          } else if (typeof error === "string") {
-            callback(new Error(error), null);
-          } else {
-            callback(new Error(JSON.stringify(error)), null);
-          }
-          return;
-        }
-      },
+    this.makeListener(ipcDesktopAutofill.listenPasskeyAssertion, (r) => this.doPasskeyAssertion(r));
+    this.makeListener(ipcDesktopAutofill.listenPasskeyAssertionWithoutUserInterface, (r) =>
+      this.doPasskeyAssertionWithoutUserInterface(r),
     );
 
-    ipc.autofill.desktopAutofill.listenPasskeyAssertion(
-      async (clientId, sequenceNumber, request, callback) => {
-        if (!this.isEnabled) {
-          this.logService.debug(
-            `listenPasskeyAssertion: Native credential sync feature flag (${this.featureFlag}) is disabled`,
-          );
-          if (callback) {
-            callback(new Error("Native credential sync feature flag is disabled"), null);
-          }
-          return;
-        }
+    this.makeListener(ipcDesktopAutofill.listenNativeStatus, (r) => this.doNativeStatus(r));
 
-        if (!callback) {
-          throw new Error("No callback specified to return passkey assertion response");
-        }
+    ipcDesktopAutofill.listenerReady();
+  }
 
-        this.logService.debug("listenPasskeyAssertion", clientId, sequenceNumber, request);
+  /**
+   * Binds a function to handle messages for an autofill IPC channel.
+   *
+   * @param channelBindFn - A function to register a function with the IPC
+   * channel. Should be one of the `listen*` methods on {@link ipc.autofill.desktopAutofill}.
+   *
+   * @param handleFn - A function to handle the type of request.
+   */
+  makeListener<Request, Response>(
+    channelBindFn: IpcListenerBindFn<Request, Response>,
+    handleFn: (request: Request) => Promise<Response>,
+  ) {
+    /** Name to use in logs.
+     *
+     * The simpler way of doing this, using `channelBindFn.name`, doesn't work
+     * because of how the function is passed from Electron's renderer process.
+     * So we look up the key by the reference to the function.
+     */
+    const handlerName =
+      Object.keys(ipc.autofill.desktopAutofill).find(
+        (key) => (ipc.autofill.desktopAutofill as Record<string, unknown>)[key] === channelBindFn,
+      ) ?? "unknownHandler";
 
-        const controller = new AbortController();
-        try {
-          const response = await this.fido2AuthenticatorService.getAssertion(
-            this.convertAssertionRequest(request),
-            { windowXy: normalizePosition(request.clientWindow.position) },
-            controller,
-          );
-
-          callback(null, this.convertAssertionResponse(request, response));
-        } catch (error) {
-          this.logService.error("listenPasskeyAssertion error", error);
-          if (error instanceof Error) {
-            callback(error, null);
-          } else if (typeof error === "string") {
-            callback(new Error(error), null);
-          } else {
-            callback(new Error(JSON.stringify(error)), null);
-          }
-        }
+    const listener = async (
+      clientId: number,
+      sequenceNumber: number,
+      request: Request,
+      /** Callback to return the response back to Autofill main process. May be
+       * empty for requests that do not expect a response. */
+      completeCallback?: {
+        (error: null, response: Response): void;
+        (error: Error, response: null): void;
       },
-    );
-
-    // Listen for native status messages
-    ipc.autofill.desktopAutofill.listenNativeStatus(async (clientId, sequenceNumber, status) => {
+    ) => {
+      this.logService.debug("[DesktopAutofillService]", `${handlerName}: Received message`, {
+        clientId,
+        sequenceNumber,
+      });
       if (!this.isEnabled) {
         this.logService.debug(
-          `listenNativeStatus: Native credential sync feature flag (${this.featureFlag}) is disabled`,
+          "[DesktopAutofillService]",
+          `${handlerName}: Native credential sync feature flag (${this.featureFlag}) is disabled`,
         );
+        if (completeCallback) {
+          completeCallback(new Error("Native credential sync feature flag is disabled"), null);
+        }
         return;
       }
 
-      this.logService.info("Received native status", status.key, status.value);
-      if (status.key === "request-sync") {
-        // perform ad-hoc sync
-        await this.adHocSync();
+      try {
+        const response = await handleFn(request);
+        if (completeCallback) {
+          completeCallback(null, response);
+        }
+      } catch (error) {
+        this.logService.error(
+          "[DesktopAutofillService]",
+          `${handlerName}: Error occurred during processing`,
+          { clientId, sequenceNumber },
+          error,
+        );
+        if (completeCallback) {
+          if (error instanceof Error) {
+            completeCallback(error, null);
+          } else if (typeof error === "string") {
+            completeCallback(new Error(error), null);
+          } else {
+            completeCallback(new Error(JSON.stringify(error)), null);
+          }
+        }
       }
-    });
+    };
 
-    ipc.autofill.desktopAutofill.listenerReady();
+    channelBindFn(listener);
   }
 
   private convertRegistrationRequest(


### PR DESCRIPTION
## 🎟️ Tracking

[PM-40138](https://bitwarden.atlassian.net/browse/PM-40138)

## 📔 Objective

The Autofill IPC mechanism is getting more use now, so we should refactor to make it easier to add more to it.

This PR refactors the Autofill IPC registration:

- Refactors identical registration methods into a single function for each of main process, preload shim, and the renderer process
- Moves correlation between incoming and outgoing channel names, and request and response types into a single file and adds type-checking.
- Uses named callbacks instead of order-dependent function arguments. 

[PM-40138]: https://bitwarden.atlassian.net/browse/PM-40138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ