### PR TITLE
[PM-40089] Show a banner in the vault view when Fill Assist is active for the current page

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -1368,19 +1368,19 @@
     "message": "Additional options"
   },
   "enableFillAssist": {
-    "message": "Use fill assist"
+    "message": "Use Fill Assist"
   },
   "fillAssistActiveNotice": {
-    "message": "Autofill is using fill assist on this page."
+    "message": "Autofill is using Fill Assist on this page."
   },
   "turnOnFillAssist": {
-    "message": "Turn on fill assist"
+    "message": "Turn on Fill Assist"
   },
   "enableFillAssistDescription": {
-    "message": "Fill assist improves autofill accuracy on supported sites by using site specific rules. No data is collected or saved when you use this feature."
+    "message": "Fill Assist improves autofill accuracy on supported sites by using site specific rules. No data is collected or saved when you use this feature."
   },
   "aboutFillAssist": {
-    "message": "About fill assist"
+    "message": "About Fill Assist"
   },
   "enableContextMenuItem": {
     "message": "Show context menu options"

--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -1370,6 +1370,9 @@
   "enableFillAssist": {
     "message": "Use fill assist"
   },
+  "fillAssistActiveNotice": {
+    "message": "Autofill is using fill assist on this page."
+  },
   "turnOnFillAssist": {
     "message": "Turn on fill assist"
   },

--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -1367,19 +1367,16 @@
   "additionalOptions": {
     "message": "Additional options"
   },
-  "enableFillAssist": {
-    "message": "Use Fill Assist"
-  },
   "fillAssistActiveNotice": {
     "message": "Autofill is using Fill Assist on this page."
   },
-  "turnOnFillAssist": {
+  "activateFillAssist": {
     "message": "Turn on Fill Assist"
   },
-  "enableFillAssistDescription": {
+  "activateFillAssistDescription": {
     "message": "Fill Assist improves autofill accuracy on supported sites by using site specific rules. No data is collected or saved when you use this feature."
   },
-  "aboutFillAssist": {
+  "aboutFillAssistLabel": {
     "message": "About Fill Assist"
   },
   "enableContextMenuItem": {

--- a/apps/browser/src/autofill/popup/settings/autofill.component.html
+++ b/apps/browser/src/autofill/popup/settings/autofill.component.html
@@ -277,7 +277,7 @@
                 type="checkbox"
               />
               <bit-label for="fill-assist">
-                {{ "turnOnFillAssist" | i18n }}
+                {{ "activateFillAssist" | i18n }}
                 <autofill-fill-assist-popover></autofill-fill-assist-popover>
               </bit-label>
             </bit-form-control>

--- a/apps/browser/src/autofill/popup/settings/fill-assist-popover/fill-assist-popover.component.html
+++ b/apps/browser/src/autofill/popup/settings/fill-assist-popover/fill-assist-popover.component.html
@@ -3,14 +3,14 @@
   class="tw-border-none tw-bg-transparent tw-text-primary-600 tw-p-0"
   [bitPopoverTriggerFor]="fillAssistPopover"
   position="above-center"
-  [appA11yTitle]="'aboutFillAssist' | i18n"
+  [appA11yTitle]="'aboutFillAssistLabel' | i18n"
   bitLink
   startIcon="bwi-question-circle"
 ></button>
 
-<bit-popover [title]="'aboutFillAssist' | i18n" #fillAssistPopover>
+<bit-popover [title]="'aboutFillAssistLabel' | i18n" #fillAssistPopover>
   <p>
-    {{ "enableFillAssistDescription" | i18n }}
+    {{ "activateFillAssistDescription" | i18n }}
   </p>
   <div class="tw-flex tw-gap-1.5 tw-items-center">
     <a bitLink href="#" (click)="openLearnMore($event)" class="tw-flex">

--- a/apps/browser/src/vault/popup/components/vault/fill-assist-active-banner/fill-assist-active-banner.component.html
+++ b/apps/browser/src/vault/popup/components/vault/fill-assist-active-banner/fill-assist-active-banner.component.html
@@ -1,4 +1,4 @@
-@if ((showFillAssistActiveBanner$ | async) && !dismissed()) {
+@if (showBanner()) {
   <bit-banner variant="primary" [useAlertRole]="false" (dismiss)="onDismiss()">
     {{ "fillAssistActiveNotice" | i18n }}
   </bit-banner>

--- a/apps/browser/src/vault/popup/components/vault/fill-assist-active-banner/fill-assist-active-banner.component.html
+++ b/apps/browser/src/vault/popup/components/vault/fill-assist-active-banner/fill-assist-active-banner.component.html
@@ -1,0 +1,5 @@
+@if ((showFillAssistActiveBanner$ | async) && !dismissed()) {
+  <bit-banner variant="primary" [useAlertRole]="false" (dismiss)="onDismiss()">
+    {{ "fillAssistActiveNotice" | i18n }}
+  </bit-banner>
+}

--- a/apps/browser/src/vault/popup/components/vault/fill-assist-active-banner/fill-assist-active-banner.component.spec.ts
+++ b/apps/browser/src/vault/popup/components/vault/fill-assist-active-banner/fill-assist-active-banner.component.spec.ts
@@ -39,20 +39,20 @@ describe("FillAssistActiveBannerComponent", () => {
     jest.clearAllMocks();
   });
 
-  it("renders the banner when fill assist is active", () => {
+  it("renders the banner when Fill Assist is active", () => {
     fixture.detectChanges();
 
     expect(bannerIsRendered()).toBe(true);
   });
 
-  it("does not render the banner when fill assist is not active", () => {
+  it("does not render the banner when Fill Assist is not active", () => {
     showBanner$.next(false);
     fixture.detectChanges();
 
     expect(bannerIsRendered()).toBe(false);
   });
 
-  it("hides the banner after dismissal even while fill assist is still active (session-only)", () => {
+  it("hides the banner after dismissal even while Fill Assist is still active (session-only)", () => {
     fixture.detectChanges();
     expect(bannerIsRendered()).toBe(true);
 

--- a/apps/browser/src/vault/popup/components/vault/fill-assist-active-banner/fill-assist-active-banner.component.spec.ts
+++ b/apps/browser/src/vault/popup/components/vault/fill-assist-active-banner/fill-assist-active-banner.component.spec.ts
@@ -1,0 +1,65 @@
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { mock } from "jest-mock-extended";
+import { BehaviorSubject } from "rxjs";
+
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+
+import { VaultPopupAutofillService } from "../../../services/vault-popup-autofill.service";
+
+import { FillAssistActiveBannerComponent } from "./fill-assist-active-banner.component";
+
+describe("FillAssistActiveBannerComponent", () => {
+  let fixture: ComponentFixture<FillAssistActiveBannerComponent>;
+  let component: FillAssistActiveBannerComponent;
+
+  const showBanner$ = new BehaviorSubject<boolean>(true);
+  const mockVaultPopupAutofillService = mock<VaultPopupAutofillService>();
+  const mockI18nService = mock<I18nService>();
+
+  const bannerIsRendered = () => fixture.nativeElement.querySelector("bit-banner") != null;
+
+  beforeEach(async () => {
+    mockI18nService.t.mockImplementation((key) => key);
+    (mockVaultPopupAutofillService as any).showFillAssistActiveBanner$ = showBanner$;
+
+    await TestBed.configureTestingModule({
+      imports: [FillAssistActiveBannerComponent],
+      providers: [
+        { provide: VaultPopupAutofillService, useValue: mockVaultPopupAutofillService },
+        { provide: I18nService, useValue: mockI18nService },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(FillAssistActiveBannerComponent);
+    component = fixture.componentInstance;
+  });
+
+  afterEach(() => {
+    showBanner$.next(true);
+    jest.clearAllMocks();
+  });
+
+  it("renders the banner when fill assist is active", () => {
+    fixture.detectChanges();
+
+    expect(bannerIsRendered()).toBe(true);
+  });
+
+  it("does not render the banner when fill assist is not active", () => {
+    showBanner$.next(false);
+    fixture.detectChanges();
+
+    expect(bannerIsRendered()).toBe(false);
+  });
+
+  it("hides the banner after dismissal even while fill assist is still active (session-only)", () => {
+    fixture.detectChanges();
+    expect(bannerIsRendered()).toBe(true);
+
+    (component as any).onDismiss();
+    fixture.detectChanges();
+
+    expect(bannerIsRendered()).toBe(false);
+    expect(showBanner$.value).toBe(true);
+  });
+});

--- a/apps/browser/src/vault/popup/components/vault/fill-assist-active-banner/fill-assist-active-banner.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/fill-assist-active-banner/fill-assist-active-banner.component.ts
@@ -3,13 +3,13 @@ import { ChangeDetectionStrategy, Component, signal } from "@angular/core";
 import { Observable } from "rxjs";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
-import { BannerModule, TypographyModule } from "@bitwarden/components";
+import { BannerModule } from "@bitwarden/components";
 
 import { VaultPopupAutofillService } from "../../../services/vault-popup-autofill.service";
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [BannerModule, CommonModule, JslibModule, TypographyModule],
+  imports: [BannerModule, CommonModule, JslibModule],
   selector: "fill-assist-active-banner",
   templateUrl: "fill-assist-active-banner.component.html",
 })

--- a/apps/browser/src/vault/popup/components/vault/fill-assist-active-banner/fill-assist-active-banner.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/fill-assist-active-banner/fill-assist-active-banner.component.ts
@@ -1,6 +1,6 @@
 import { CommonModule } from "@angular/common";
-import { ChangeDetectionStrategy, Component, signal } from "@angular/core";
-import { Observable } from "rxjs";
+import { ChangeDetectionStrategy, Component, computed, signal } from "@angular/core";
+import { toSignal } from "@angular/core/rxjs-interop";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { BannerModule } from "@bitwarden/components";
@@ -17,14 +17,21 @@ export class FillAssistActiveBannerComponent {
   /**
    * Flag indicating that Fill Assist targeting rules are in effect for the current tab.
    */
-  protected readonly showFillAssistActiveBanner$: Observable<boolean> =
-    this.vaultPopupAutofillService.showFillAssistActiveBanner$;
+  private readonly fillAssistActive = toSignal(
+    this.vaultPopupAutofillService.showFillAssistActiveBanner$,
+    { initialValue: false },
+  );
 
   /**
    * Session-only dismissal. Lives on the component instance and is not persisted, so it
    * resets each time the popup is reopened.
    */
   protected readonly dismissed = signal(false);
+
+  /**
+   * The banner is shown while Fill Assist is active and the user has not dismissed it this session.
+   */
+  protected readonly showBanner = computed(() => this.fillAssistActive() && !this.dismissed());
 
   constructor(private readonly vaultPopupAutofillService: VaultPopupAutofillService) {}
 

--- a/apps/browser/src/vault/popup/components/vault/fill-assist-active-banner/fill-assist-active-banner.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/fill-assist-active-banner/fill-assist-active-banner.component.ts
@@ -1,0 +1,34 @@
+import { CommonModule } from "@angular/common";
+import { ChangeDetectionStrategy, Component, signal } from "@angular/core";
+import { Observable } from "rxjs";
+
+import { JslibModule } from "@bitwarden/angular/jslib.module";
+import { BannerModule, TypographyModule } from "@bitwarden/components";
+
+import { VaultPopupAutofillService } from "../../../services/vault-popup-autofill.service";
+
+@Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [BannerModule, CommonModule, JslibModule, TypographyModule],
+  selector: "fill-assist-active-banner",
+  templateUrl: "fill-assist-active-banner.component.html",
+})
+export class FillAssistActiveBannerComponent {
+  /**
+   * Flag indicating that fill assist targeting rules are in effect for the current tab.
+   */
+  protected readonly showFillAssistActiveBanner$: Observable<boolean> =
+    this.vaultPopupAutofillService.showFillAssistActiveBanner$;
+
+  /**
+   * Session-only dismissal. Lives on the component instance and is not persisted, so it
+   * resets each time the popup is reopened.
+   */
+  protected readonly dismissed = signal(false);
+
+  constructor(private readonly vaultPopupAutofillService: VaultPopupAutofillService) {}
+
+  protected onDismiss() {
+    this.dismissed.set(true);
+  }
+}

--- a/apps/browser/src/vault/popup/components/vault/fill-assist-active-banner/fill-assist-active-banner.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/fill-assist-active-banner/fill-assist-active-banner.component.ts
@@ -15,7 +15,7 @@ import { VaultPopupAutofillService } from "../../../services/vault-popup-autofil
 })
 export class FillAssistActiveBannerComponent {
   /**
-   * Flag indicating that fill assist targeting rules are in effect for the current tab.
+   * Flag indicating that Fill Assist targeting rules are in effect for the current tab.
    */
   protected readonly showFillAssistActiveBanner$: Observable<boolean> =
     this.vaultPopupAutofillService.showFillAssistActiveBanner$;

--- a/apps/browser/src/vault/popup/components/vault/vault.component.html
+++ b/apps/browser/src/vault/popup/components/vault/vault.component.html
@@ -39,6 +39,10 @@
     <blocked-injection-banner slot="full-width-notice"></blocked-injection-banner>
   }
 
+  @if (vaultState !== VaultStateEnum.Empty) {
+    <fill-assist-active-banner slot="full-width-notice"></fill-assist-active-banner>
+  }
+
   <!-- Show search & filters outside of the scroll area of the page -->
   <ng-container slot="above-scroll-area">
     @if (showPremiumSpotlight$ | async) {

--- a/apps/browser/src/vault/popup/components/vault/vault.component.spec.ts
+++ b/apps/browser/src/vault/popup/components/vault/vault.component.spec.ts
@@ -53,6 +53,7 @@ import { AtRiskPasswordCalloutComponent } from "../at-risk-callout/at-risk-passw
 
 import { AutofillVaultListItemsComponent } from "./autofill-vault-list-items/autofill-vault-list-items.component";
 import { BlockedInjectionBanner } from "./blocked-injection-banner/blocked-injection-banner.component";
+import { FillAssistActiveBannerComponent } from "./fill-assist-active-banner/fill-assist-active-banner.component";
 import { NewItemDropdownComponent } from "./new-item-dropdown/new-item-dropdown.component";
 import { VaultHeaderComponent } from "./vault-header/vault-header.component";
 import { VaultListItemsContainerComponent } from "./vault-list-items-container/vault-list-items-container.component";
@@ -110,6 +111,14 @@ class PopOutStubComponent {}
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 class BlockedInjectionBannerStubComponent {}
+
+@Component({
+  selector: "fill-assist-active-banner",
+  standalone: true,
+  template: "",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class FillAssistActiveBannerStubComponent {}
 
 @Component({
   selector: "vault-at-risk-password-callout",
@@ -332,6 +341,7 @@ describe("VaultComponent", () => {
           NewItemDropdownComponent,
           PopOutComponent,
           BlockedInjectionBanner,
+          FillAssistActiveBannerComponent,
           AtRiskPasswordCalloutComponent,
           AutofillVaultListItemsComponent,
           VaultListItemsContainerComponent,
@@ -349,6 +359,7 @@ describe("VaultComponent", () => {
           NewItemDropdownStubComponent,
           PopOutStubComponent,
           BlockedInjectionBannerStubComponent,
+          FillAssistActiveBannerStubComponent,
           VaultAtRiskCalloutStubComponent,
           AutofillVaultListItemsStubComponent,
           VaultListItemsContainerStubComponent,

--- a/apps/browser/src/vault/popup/components/vault/vault.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/vault.component.ts
@@ -73,6 +73,7 @@ import { VaultFadeInOutSkeletonComponent } from "../vault-fade-in-out-skeleton/v
 import { VaultLoadingSkeletonComponent } from "../vault-loading-skeleton/vault-loading-skeleton.component";
 
 import { BlockedInjectionBanner } from "./blocked-injection-banner/blocked-injection-banner.component";
+import { FillAssistActiveBannerComponent } from "./fill-assist-active-banner/fill-assist-active-banner.component";
 import {
   NewItemDropdownComponent,
   NewItemInitialValues,
@@ -96,6 +97,7 @@ type VaultState = UnionOfValues<typeof VaultState>;
   templateUrl: "vault.component.html",
   imports: [
     BlockedInjectionBanner,
+    FillAssistActiveBannerComponent,
     PopupPageComponent,
     PopupHeaderComponent,
     PopOutComponent,

--- a/apps/browser/src/vault/popup/services/vault-popup-autofill.service.spec.ts
+++ b/apps/browser/src/vault/popup/services/vault-popup-autofill.service.spec.ts
@@ -29,8 +29,15 @@ import {
 import { InlineMenuFieldQualificationService } from "../../../autofill/services/inline-menu-field-qualification.service";
 import { BrowserApi } from "../../../platform/browser/browser-api";
 import BrowserPopupUtils from "../../../platform/browser/browser-popup-utils";
+import { devFlagEnabled } from "../../../platform/flags";
 
 import { VaultPopupAutofillService } from "./vault-popup-autofill.service";
+
+jest.mock("../../../platform/flags", () => ({
+  devFlagEnabled: jest.fn(),
+}));
+
+const mockDevFlagEnabled = devFlagEnabled as jest.Mock;
 
 describe("VaultPopupAutofillService", () => {
   let testBed: TestBed;
@@ -65,6 +72,10 @@ describe("VaultPopupAutofillService", () => {
   let targetingRulesSubject: BehaviorSubject<any>;
 
   beforeEach(() => {
+    // `showFillAssistActiveBanner$` is gated behind this dev flag; default it on so the tests
+    // below exercise the targeting-rule logic. The gate itself is covered by its own test.
+    mockDevFlagEnabled.mockReturnValue(true);
+
     jest.spyOn(BrowserPopupUtils, "inPopout").mockReturnValue(false);
     jest.spyOn(BrowserApi, "getTabFromCurrentWindow").mockResolvedValue(mockCurrentTab);
     jest
@@ -126,6 +137,15 @@ describe("VaultPopupAutofillService", () => {
     // A minimal, non-empty `FormContent[]`. The exact shape is irrelevant here because
     // `getTargetingRulesForUrl` is mocked; only the emptiness of the result matters to the banner.
     const applicableTargetingRules = [{ category: "login", fields: {} }] as any;
+
+    it("emits `false` and skips the targeting-rule lookup when the `fillAssistDevTools` dev flag is disabled", async () => {
+      mockDevFlagEnabled.mockReturnValue(false);
+      mockDomainSettingsService.getTargetingRulesForUrl.mockResolvedValue(applicableTargetingRules);
+
+      expect(await firstValueFrom(service.showFillAssistActiveBanner$)).toBe(false);
+      expect(mockDevFlagEnabled).toHaveBeenCalledWith("fillAssistDevTools");
+      expect(mockDomainSettingsService.getTargetingRulesForUrl).not.toHaveBeenCalled();
+    });
 
     it("emits `true` when the current tab has targeted fill rules", async () => {
       mockDomainSettingsService.getTargetingRulesForUrl.mockResolvedValue(applicableTargetingRules);

--- a/apps/browser/src/vault/popup/services/vault-popup-autofill.service.spec.ts
+++ b/apps/browser/src/vault/popup/services/vault-popup-autofill.service.spec.ts
@@ -1,7 +1,7 @@
 import { TestBed } from "@angular/core/testing";
 import { ActivatedRoute } from "@angular/router";
 import { mock } from "jest-mock-extended";
-import { BehaviorSubject, firstValueFrom, of } from "rxjs";
+import { BehaviorSubject, filter, firstValueFrom, of } from "rxjs";
 
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { DomainSettingsService } from "@bitwarden/common/autofill/services/domain-settings.service";
@@ -94,7 +94,6 @@ describe("VaultPopupAutofillService", () => {
     mockDomainSettingsService.blockedInteractionsUris$ = blockedInteractionsUrisSubject;
     mockDomainSettingsService.resolvedEnableFillAssist$ = resolvedEnableFillAssistSubject;
     mockDomainSettingsService.targetingRules$ = targetingRulesSubject;
-    mockDomainSettingsService.getTargetingRulesForUrl.mockResolvedValue(null);
 
     testBed = TestBed.configureTestingModule({
       providers: [
@@ -134,36 +133,41 @@ describe("VaultPopupAutofillService", () => {
   });
 
   describe("showFillAssistActiveBanner$", () => {
-    // A minimal, non-empty `FormContent[]`. The exact shape is irrelevant here because
-    // `getTargetingRulesForUrl` is mocked; only the emptiness of the result matters to the banner.
-    const applicableTargetingRules = [{ category: "login", fields: {} }] as any;
+    const applicableTargetingRules = {
+      "example.com": { forms: [{ category: "login", fields: {} }] },
+    } as any;
 
-    it("emits `false` and skips the targeting-rule lookup when the `fillAssistDevTools` dev flag is disabled", async () => {
+    it("emits `false` when the `fillAssistDevTools` dev flag is disabled, even if rules apply", async () => {
       mockDevFlagEnabled.mockReturnValue(false);
-      mockDomainSettingsService.getTargetingRulesForUrl.mockResolvedValue(applicableTargetingRules);
+      targetingRulesSubject.next(applicableTargetingRules);
 
       expect(await firstValueFrom(service.showFillAssistActiveBanner$)).toBe(false);
       expect(mockDevFlagEnabled).toHaveBeenCalledWith("fillAssistDevTools");
-      expect(mockDomainSettingsService.getTargetingRulesForUrl).not.toHaveBeenCalled();
     });
 
     it("emits `true` when the current tab has targeted fill rules", async () => {
-      mockDomainSettingsService.getTargetingRulesForUrl.mockResolvedValue(applicableTargetingRules);
-
-      expect(await firstValueFrom(service.showFillAssistActiveBanner$)).toBe(true);
-      expect(mockDomainSettingsService.getTargetingRulesForUrl).toHaveBeenCalledWith(
-        mockCurrentTab.url,
-      );
-    });
-
-    it("emits `true` when the current tab has a targeting-rule blocklist (empty array), which Fill Assist actively enforces", async () => {
-      mockDomainSettingsService.getTargetingRulesForUrl.mockResolvedValue([]);
+      targetingRulesSubject.next(applicableTargetingRules);
 
       expect(await firstValueFrom(service.showFillAssistActiveBanner$)).toBe(true);
     });
 
-    it("emits `false` when no targeting rules apply to the current tab (a null result)", async () => {
-      mockDomainSettingsService.getTargetingRulesForUrl.mockResolvedValue(null);
+    it("emits `true` when the current tab is blocklisted by a targeting rule (a null host entry), which Fill Assist actively enforces", async () => {
+      // A `null` host entry suppresses autofill on all of the host's pages; the matcher returns an
+      // empty array (not `null`), so Fill Assist is still considered active for the tab.
+      targetingRulesSubject.next({ "example.com": null } as any);
+
+      expect(await firstValueFrom(service.showFillAssistActiveBanner$)).toBe(true);
+    });
+
+    it("emits `false` when no targeting rules apply to the current tab", async () => {
+      targetingRulesSubject.next({ "other.example.org": { forms: [{}] } } as any);
+
+      expect(await firstValueFrom(service.showFillAssistActiveBanner$)).toBe(false);
+    });
+
+    it("emits `false` when Fill Assist is disabled, even if rules apply", async () => {
+      resolvedEnableFillAssistSubject.next(false);
+      targetingRulesSubject.next(applicableTargetingRules);
 
       expect(await firstValueFrom(service.showFillAssistActiveBanner$)).toBe(false);
     });
@@ -171,22 +175,24 @@ describe("VaultPopupAutofillService", () => {
     it("emits `false` when there is no current tab, even if rules would otherwise apply", async () => {
       jest.spyOn(BrowserApi, "getTabFromCurrentWindow").mockResolvedValue(null);
       service.refreshCurrentTab();
-      mockDomainSettingsService.getTargetingRulesForUrl.mockResolvedValue(applicableTargetingRules);
+      // `currentAutofillTab$` replays the tab resolved at construction, so wait for the refreshed
+      // (null) tab to propagate before asserting.
+      await firstValueFrom(service.currentAutofillTab$.pipe(filter((tab) => tab == null)));
+      targetingRulesSubject.next(applicableTargetingRules);
 
       expect(await firstValueFrom(service.showFillAssistActiveBanner$)).toBe(false);
     });
 
-    it("emits `false` and skips the targeting-rule lookup while the tab is blocklisted, even if the blocked banner was dismissed", async () => {
-      mockDomainSettingsService.getTargetingRulesForUrl.mockResolvedValue(applicableTargetingRules);
+    it("emits `false` while the tab is blocklisted, even if the blocked banner was dismissed and rules apply", async () => {
+      targetingRulesSubject.next(applicableTargetingRules);
       // `bannerIsDismissed: true` means the blocked banner is hidden, but the tab is still blocked.
       blockedInteractionsUrisSubject.next({ "example.com": { bannerIsDismissed: true } });
 
       expect(await firstValueFrom(service.showFillAssistActiveBanner$)).toBe(false);
-      expect(mockDomainSettingsService.getTargetingRulesForUrl).not.toHaveBeenCalled();
     });
 
     it("re-evaluates and emits `true` once the tab is no longer blocklisted and rules apply", async () => {
-      mockDomainSettingsService.getTargetingRulesForUrl.mockResolvedValue(applicableTargetingRules);
+      targetingRulesSubject.next(applicableTargetingRules);
       blockedInteractionsUrisSubject.next({ "example.com": { bannerIsDismissed: false } });
 
       const tracked = subscribeTo(service.showFillAssistActiveBanner$);

--- a/apps/browser/src/vault/popup/services/vault-popup-autofill.service.spec.ts
+++ b/apps/browser/src/vault/popup/services/vault-popup-autofill.service.spec.ts
@@ -1,7 +1,7 @@
 import { TestBed } from "@angular/core/testing";
 import { ActivatedRoute } from "@angular/router";
 import { mock } from "jest-mock-extended";
-import { BehaviorSubject, of } from "rxjs";
+import { BehaviorSubject, firstValueFrom, of } from "rxjs";
 
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { DomainSettingsService } from "@bitwarden/common/autofill/services/domain-settings.service";
@@ -56,6 +56,14 @@ describe("VaultPopupAutofillService", () => {
   const mockUserId = Utils.newGuid() as UserId;
   const accountService: FakeAccountService = mockAccountServiceWith(mockUserId);
 
+  // Controllable upstream subjects. `showFillAssistActiveBanner$` (and the other banner streams)
+  // capture these references at construction via shareReplay({ refCount: false }), so they must be
+  // wired before `testBed.inject` and driven via `.next()` rather than reassigned afterwards.
+  let pageDetailsSubject: BehaviorSubject<PageDetail[]>;
+  let blockedInteractionsUrisSubject: BehaviorSubject<any>;
+  let resolvedEnableFillAssistSubject: BehaviorSubject<boolean>;
+  let targetingRulesSubject: BehaviorSubject<any>;
+
   beforeEach(() => {
     jest.spyOn(BrowserPopupUtils, "inPopout").mockReturnValue(false);
     jest.spyOn(BrowserApi, "getTabFromCurrentWindow").mockResolvedValue(mockCurrentTab);
@@ -66,8 +74,16 @@ describe("VaultPopupAutofillService", () => {
       .spyOn(mockInlineMenuFieldQualificationService, "isFieldForIdentityForm")
       .mockReturnValue(true);
 
-    mockAutofillService.collectPageDetailsFromTab$.mockReturnValue(new BehaviorSubject([]));
-    mockDomainSettingsService.blockedInteractionsUris$ = new BehaviorSubject({});
+    pageDetailsSubject = new BehaviorSubject<PageDetail[]>([]);
+    blockedInteractionsUrisSubject = new BehaviorSubject({});
+    resolvedEnableFillAssistSubject = new BehaviorSubject(true);
+    targetingRulesSubject = new BehaviorSubject(null);
+
+    mockAutofillService.collectPageDetailsFromTab$.mockReturnValue(pageDetailsSubject);
+    mockDomainSettingsService.blockedInteractionsUris$ = blockedInteractionsUrisSubject;
+    mockDomainSettingsService.resolvedEnableFillAssist$ = resolvedEnableFillAssistSubject;
+    mockDomainSettingsService.targetingRules$ = targetingRulesSubject;
+    mockDomainSettingsService.getTargetingRulesForUrl.mockResolvedValue(null);
 
     testBed = TestBed.configureTestingModule({
       providers: [
@@ -104,6 +120,66 @@ describe("VaultPopupAutofillService", () => {
 
   it("should be created", () => {
     expect(service).toBeTruthy();
+  });
+
+  describe("showFillAssistActiveBanner$", () => {
+    // A minimal, non-empty `FormContent[]`. The exact shape is irrelevant here because
+    // `getTargetingRulesForUrl` is mocked; only the emptiness of the result matters to the banner.
+    const applicableTargetingRules = [{ category: "login", fields: {} }] as any;
+
+    it("emits `true` when the current tab has targeted fill rules", async () => {
+      mockDomainSettingsService.getTargetingRulesForUrl.mockResolvedValue(applicableTargetingRules);
+
+      expect(await firstValueFrom(service.showFillAssistActiveBanner$)).toBe(true);
+      expect(mockDomainSettingsService.getTargetingRulesForUrl).toHaveBeenCalledWith(
+        mockCurrentTab.url,
+      );
+    });
+
+    it("emits `true` when the current tab has a targeting-rule blocklist (empty array), which fill assist actively enforces", async () => {
+      mockDomainSettingsService.getTargetingRulesForUrl.mockResolvedValue([]);
+
+      expect(await firstValueFrom(service.showFillAssistActiveBanner$)).toBe(true);
+    });
+
+    it("emits `false` when no targeting rules apply to the current tab (a null result)", async () => {
+      mockDomainSettingsService.getTargetingRulesForUrl.mockResolvedValue(null);
+
+      expect(await firstValueFrom(service.showFillAssistActiveBanner$)).toBe(false);
+    });
+
+    it("emits `false` when there is no current tab, even if rules would otherwise apply", async () => {
+      jest.spyOn(BrowserApi, "getTabFromCurrentWindow").mockResolvedValue(null);
+      service.refreshCurrentTab();
+      mockDomainSettingsService.getTargetingRulesForUrl.mockResolvedValue(applicableTargetingRules);
+
+      expect(await firstValueFrom(service.showFillAssistActiveBanner$)).toBe(false);
+    });
+
+    it("emits `false` and skips the targeting-rule lookup while the tab is blocklisted, even if the blocked banner was dismissed", async () => {
+      mockDomainSettingsService.getTargetingRulesForUrl.mockResolvedValue(applicableTargetingRules);
+      // `bannerIsDismissed: true` means the blocked banner is hidden, but the tab is still blocked.
+      blockedInteractionsUrisSubject.next({ "example.com": { bannerIsDismissed: true } });
+
+      expect(await firstValueFrom(service.showFillAssistActiveBanner$)).toBe(false);
+      expect(mockDomainSettingsService.getTargetingRulesForUrl).not.toHaveBeenCalled();
+    });
+
+    it("re-evaluates and emits `true` once the tab is no longer blocklisted and rules apply", async () => {
+      mockDomainSettingsService.getTargetingRulesForUrl.mockResolvedValue(applicableTargetingRules);
+      blockedInteractionsUrisSubject.next({ "example.com": { bannerIsDismissed: false } });
+
+      const tracked = subscribeTo(service.showFillAssistActiveBanner$);
+      await tracked.pauseUntilReceived(1);
+      expect(tracked.emissions[0]).toBe(false);
+
+      // Tab is unblocked (removed from the blocked-interactions list).
+      blockedInteractionsUrisSubject.next({});
+      await tracked.pauseUntilReceived(2);
+
+      expect(tracked.emissions[1]).toBe(true);
+      tracked.unsubscribe();
+    });
   });
 
   describe("currentAutofillTab$", () => {

--- a/apps/browser/src/vault/popup/services/vault-popup-autofill.service.spec.ts
+++ b/apps/browser/src/vault/popup/services/vault-popup-autofill.service.spec.ts
@@ -136,7 +136,7 @@ describe("VaultPopupAutofillService", () => {
       );
     });
 
-    it("emits `true` when the current tab has a targeting-rule blocklist (empty array), which fill assist actively enforces", async () => {
+    it("emits `true` when the current tab has a targeting-rule blocklist (empty array), which Fill Assist actively enforces", async () => {
       mockDomainSettingsService.getTargetingRulesForUrl.mockResolvedValue([]);
 
       expect(await firstValueFrom(service.showFillAssistActiveBanner$)).toBe(true);

--- a/apps/browser/src/vault/popup/services/vault-popup-autofill.service.ts
+++ b/apps/browser/src/vault/popup/services/vault-popup-autofill.service.ts
@@ -38,6 +38,7 @@ import {
 import { InlineMenuFieldQualificationService } from "../../../autofill/services/inline-menu-field-qualification.service";
 import { BrowserApi } from "../../../platform/browser/browser-api";
 import BrowserPopupUtils from "../../../platform/browser/browser-popup-utils";
+import { devFlagEnabled } from "../../../platform/flags";
 import { closeViewVaultItemPopout, VaultPopoutType } from "../utils/vault-popout-window";
 
 @Injectable({
@@ -183,6 +184,11 @@ export class VaultPopupAutofillService {
     // `resolvedEnableFillAssist`, `targetingRules` are included to trigger new state
     // resolution, not consumed directly
     switchMap(async ([currentTab, , , tabIsOnBlocklist]) => {
+      // Developer-only banner
+      if (!devFlagEnabled("fillAssistDevTools")) {
+        return false;
+      }
+
       // A blocklisted tab suppresses all autofill, so Fill Assist is moot regardless of the
       // blocked-domains banner's shown/dismissed state.
       if (tabIsOnBlocklist) {

--- a/apps/browser/src/vault/popup/services/vault-popup-autofill.service.ts
+++ b/apps/browser/src/vault/popup/services/vault-popup-autofill.service.ts
@@ -170,6 +170,40 @@ export class VaultPopupAutofillService {
     shareReplay({ refCount: false, bufferSize: 1 }),
   );
 
+  /**
+   * Emits `true` when Fill Assist targeting rules apply to the current tab (any non-`null`
+   * response from {@link DomainSettingsService.getTargetingRulesForUrl}).
+   */
+  showFillAssistActiveBanner$: Observable<boolean> = combineLatest([
+    this.currentAutofillTab$,
+    this.domainSettingsService.resolvedEnableFillAssist$,
+    this.domainSettingsService.targetingRules$,
+    this.currentTabIsOnBlocklist$,
+  ]).pipe(
+    // `resolvedEnableFillAssist`, `targetingRules` are included to trigger new state
+    // resolution, not consumed directly
+    switchMap(async ([currentTab, , , tabIsOnBlocklist]) => {
+      // A blocklisted tab suppresses all autofill, so Fill Assist is moot regardless of the
+      // blocked-domains banner's shown/dismissed state.
+      if (tabIsOnBlocklist) {
+        return false;
+      }
+
+      if (!currentTab?.url?.length) {
+        return false;
+      }
+
+      const targetingRules = await this.domainSettingsService.getTargetingRulesForUrl(
+        currentTab.url,
+      );
+
+      // Any non-`null` result means rules apply, including an empty array (a targeting-rule
+      // blocklist that intentionally suppresses autofill). Only `null` (no rules) is inactive.
+      return Array.isArray(targetingRules);
+    }),
+    shareReplay({ refCount: false, bufferSize: 1 }),
+  );
+
   nonLoginCipherTypesOnPage$: Observable<{
     [CipherType.Card]: boolean;
     [CipherType.Identity]: boolean;

--- a/apps/browser/src/vault/popup/services/vault-popup-autofill.service.ts
+++ b/apps/browser/src/vault/popup/services/vault-popup-autofill.service.ts
@@ -5,6 +5,7 @@ import { ActivatedRoute } from "@angular/router";
 import {
   combineLatest,
   debounceTime,
+  distinctUntilChanged,
   firstValueFrom,
   map,
   Observable,
@@ -19,6 +20,7 @@ import { AccountService } from "@bitwarden/common/auth/abstractions/account.serv
 import { getOptionalUserId } from "@bitwarden/common/auth/services/account.service";
 import { DomainSettingsService } from "@bitwarden/common/autofill/services/domain-settings.service";
 import { isUrlInList } from "@bitwarden/common/autofill/utils";
+import { matchTargetingRulesForUrl } from "@bitwarden/common/autofill/utils/targeting-rules";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
@@ -172,8 +174,12 @@ export class VaultPopupAutofillService {
   );
 
   /**
-   * Emits `true` when Fill Assist targeting rules apply to the current tab (any non-`null`
-   * response from {@link DomainSettingsService.getTargetingRulesForUrl}).
+   * Emits `true` when Fill Assist targeting rules apply to the current tab.
+   *
+   * The vault popup only renders when the vault is unlocked, so the auth/unlock gating that
+   * {@link DomainSettingsService.getTargetingRulesForUrl} performs is already guaranteed here.
+   * That lets us match the resolved rules synchronously via {@link matchTargetingRulesForUrl}
+   * rather than re-resolving (and re-awaiting) that state per emission.
    */
   showFillAssistActiveBanner$: Observable<boolean> = combineLatest([
     this.currentAutofillTab$,
@@ -181,11 +187,13 @@ export class VaultPopupAutofillService {
     this.domainSettingsService.targetingRules$,
     this.currentTabIsOnBlocklist$,
   ]).pipe(
-    // `resolvedEnableFillAssist`, `targetingRules` are included to trigger new state
-    // resolution, not consumed directly
-    switchMap(async ([currentTab, , , tabIsOnBlocklist]) => {
+    map(([currentTab, fillAssistEnabled, targetingRules, tabIsOnBlocklist]) => {
       // Developer-only banner
       if (!devFlagEnabled("fillAssistDevTools")) {
+        return false;
+      }
+
+      if (!fillAssistEnabled) {
         return false;
       }
 
@@ -199,14 +207,13 @@ export class VaultPopupAutofillService {
         return false;
       }
 
-      const targetingRules = await this.domainSettingsService.getTargetingRulesForUrl(
-        currentTab.url,
-      );
+      const matchedTargetingRules = matchTargetingRulesForUrl(targetingRules, currentTab.url);
 
       // Any non-`null` result means rules apply, including an empty array (a targeting-rule
       // blocklist that intentionally suppresses autofill). Only `null` (no rules) is inactive.
-      return Array.isArray(targetingRules);
+      return matchedTargetingRules !== null;
     }),
+    distinctUntilChanged(),
     shareReplay({ refCount: false, bufferSize: 1 }),
   );
 

--- a/libs/common/src/autofill/services/domain-settings.service.ts
+++ b/libs/common/src/autofill/services/domain-settings.service.ts
@@ -36,8 +36,8 @@ import {
   UserKeyDefinition,
 } from "../../platform/state";
 import { UserId } from "../../types/guid";
-import { FormContent, Pathname, TargetingRulesByDomain } from "../types";
-import { punycodeToUnicode } from "../utils/punycode";
+import { FormContent, TargetingRulesByDomain } from "../types";
+import { matchTargetingRulesForUrl } from "../utils/targeting-rules";
 
 const SHOW_FAVICONS = new KeyDefinition(DOMAIN_SETTINGS_DISK, "showFavicons", {
   deserializer: (value: boolean) => value ?? true,
@@ -341,63 +341,7 @@ export class DefaultDomainSettingsService implements DomainSettingsService {
     }
 
     const rules = await firstValueFrom(this.targetingRules$);
-    if (!rules || Object.keys(rules).length === 0) {
-      return null;
-    }
 
-    let parsed: URL;
-    try {
-      parsed = new URL(url);
-    } catch {
-      return null;
-    }
-
-    let hostRules = rules[parsed.host];
-
-    // www subdomain equivalence: if no entry for www.example.com, try example.com
-    if (hostRules === undefined && parsed.host.startsWith("www.")) {
-      hostRules = rules[parsed.host.slice(4)];
-    }
-
-    // If the direct punycode lookup missed, try the unicode form of the host.
-    // This handles rule providers that use unicode host keys (e.g. "münchen.de"
-    // instead of "xn--mnchen-3ya.de").
-    if (hostRules === undefined && parsed.host.includes("xn--")) {
-      const unicodeHost = punycodeToUnicode(parsed.host);
-      hostRules = rules[unicodeHost];
-
-      // www subdomain equivalence on the unicode form
-      if (hostRules === undefined && unicodeHost.startsWith("www.")) {
-        hostRules = rules[unicodeHost.slice(4)];
-      }
-    }
-
-    // No rules for this host; fall through to heuristics
-    if (hostRules === undefined) {
-      return null;
-    }
-
-    // Hostname blocklisted (null or empty): suppress autofill on all paths
-    if (hostRules === null || (!hostRules.forms?.length && !hostRules.pathnames)) {
-      return [];
-    }
-
-    // Check for pathname-specific rules
-    // Fall back to root path `/` to enable checking cases where
-    // a rule signals a form that is ONLY on the domain's root page
-    const pathname = (parsed.pathname.replace(/\/+$/, "") || "/") as Pathname;
-    if (hostRules.pathnames != null && pathname in hostRules.pathnames) {
-      const pathnameEntry = hostRules.pathnames[pathname];
-
-      // Pathname blocklisted (null/undefined/empty): suppress autofill on this path
-      if (!pathnameEntry?.forms?.length) {
-        return [];
-      }
-
-      return pathnameEntry.forms;
-    }
-
-    // No pathname-specific rule; fall back to hostname-level forms
-    return hostRules.forms?.length ? hostRules.forms : null;
+    return matchTargetingRulesForUrl(rules, url);
   }
 }

--- a/libs/common/src/autofill/utils/targeting-rules.ts
+++ b/libs/common/src/autofill/utils/targeting-rules.ts
@@ -1,0 +1,76 @@
+import { FormContent, Pathname, TargetingRulesByDomain } from "../types";
+
+import { punycodeToUnicode } from "./punycode";
+
+/**
+ * Pure matcher that determines which targeting rules apply to a URL, given an already-resolved
+ * {@link TargetingRulesByDomain} set. Checks pathname-specific rules first, then falls back to
+ * hostname-level forms.
+ *
+ * @returns `FormContent[]` with entries for targeted fill,
+ *          `[]` (empty) if the URL is blocklisted (suppress autofill),
+ *          `null` if no rules exist (fall through to heuristics)
+ */
+export function matchTargetingRulesForUrl(
+  rules: TargetingRulesByDomain | null,
+  url: string,
+): FormContent[] | null {
+  if (!rules || Object.keys(rules).length === 0) {
+    return null;
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return null;
+  }
+
+  let hostRules = rules[parsed.host];
+
+  // www subdomain equivalence: if no entry for www.example.com, try example.com
+  if (hostRules === undefined && parsed.host.startsWith("www.")) {
+    hostRules = rules[parsed.host.slice(4)];
+  }
+
+  // If the direct punycode lookup missed, try the unicode form of the host.
+  // This handles rule providers that use unicode host keys (e.g. "münchen.de"
+  // instead of "xn--mnchen-3ya.de").
+  if (hostRules === undefined && parsed.host.includes("xn--")) {
+    const unicodeHost = punycodeToUnicode(parsed.host);
+    hostRules = rules[unicodeHost];
+
+    // www subdomain equivalence on the unicode form
+    if (hostRules === undefined && unicodeHost.startsWith("www.")) {
+      hostRules = rules[unicodeHost.slice(4)];
+    }
+  }
+
+  // No rules for this host; fall through to heuristics
+  if (hostRules === undefined) {
+    return null;
+  }
+
+  // Hostname blocklisted (null or empty): suppress autofill on all paths
+  if (hostRules === null || (!hostRules.forms?.length && !hostRules.pathnames)) {
+    return [];
+  }
+
+  // Check for pathname-specific rules
+  // Fall back to root path `/` to enable checking cases where
+  // a rule signals a form that is ONLY on the domain's root page
+  const pathname = (parsed.pathname.replace(/\/+$/, "") || "/") as Pathname;
+  if (hostRules.pathnames != null && pathname in hostRules.pathnames) {
+    const pathnameEntry = hostRules.pathnames[pathname];
+
+    // Pathname blocklisted (null/undefined/empty): suppress autofill on this path
+    if (!pathnameEntry?.forms?.length) {
+      return [];
+    }
+
+    return pathnameEntry.forms;
+  }
+
+  // No pathname-specific rule; fall back to hostname-level forms
+  return hostRules.forms?.length ? hostRules.forms : null;
+}

--- a/libs/common/src/platform/misc/flags.ts
+++ b/libs/common/src/platform/misc/flags.ts
@@ -12,6 +12,7 @@ export type SharedDevFlags = {
   skipWelcomeOnInstall: boolean;
   configRetrievalIntervalMs: number;
   showRiskInsightsDebug: boolean;
+  fillAssistDevTools: boolean;
   testPhishingUrls: string[];
 };
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-40089](https://bitwarden.atlassian.net/browse/PM-40089)

## 📔 Objective

Note: This task has been updated to make the banner a developer only experience (additionally gated behind the devFlag `fillAssistDevTools`) in order to aid our Fill Assist development and testing work.

Show a banner in the vault view when Fill Assist is active for the current page. Active means there is an entry for the site or site path in the current tab AND the Fill Assist setting is enabled AND the feature flag gating the Fill Assist feature is on AND there are no Blocked Domain entries for the current page site. The banner will go away if any of these conditions change. Dismissing the banner will hide it until the next time the user opens the extension view.

Also, capitalizes instances of "fill assist"

## 📸 Screenshots

| | |
| --- | --- |
| <img width="380" height="603" alt="Screenshot 2026-07-09 at 10 30 33 AM" src="https://github.com/user-attachments/assets/0a4dd2a0-aeb4-4f97-8f4a-c967ce0fca63" /> | <img width="381" height="602" alt="Screenshot 2026-07-09 at 10 30 50 AM" src="https://github.com/user-attachments/assets/2fdae19a-edb9-48aa-ae86-abc8be27cf06" /> |


[PM-40089]: https://bitwarden.atlassian.net/browse/PM-40089?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ