### PR TITLE
[PM-37964] Add Ability to Disable Automatic Invitations in SCIM

### DIFF
--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -9407,6 +9407,20 @@
   "scimApiKeyHelperText": {
     "message": "This API key has access to manage users within your organization. It should be kept secret."
   },
+  "scimInviteUsersAfterProvisioning": {
+    "message": "Automatically send email invitations"
+  },
+  "scimInviteUsersAfterProvisioningHint": {
+    "message": "Send email invitations immediately when users are provisioned via SCIM.",
+    "description": "the text, 'SCIM', is an acronym and should not be translated."
+  },
+  "scimInviteUsersAfterProvisioningHelpTitle": {
+    "message": "About email invitations"
+  },
+  "scimInviteUsersAfterProvisioningHelpBody": {
+    "message": "When this setting is on, members provisioned via SCIM are sent an email invite and appear as invited on the Members page. When it's off, members appear as staged and must be invited manually by an admin or by invite link.",
+    "description": "the text, 'SCIM', is an acronym and should not be translated."
+  },
   "copyScimKey": {
     "message": "Copy the SCIM API key to your clipboard",
     "description": "the text, 'SCIM' and 'API', are acronyms and should not be translated."

--- a/bitwarden_license/bit-web/src/app/admin-console/organizations/manage/scim-v2.component.html
+++ b/bitwarden_license/bit-web/src/app/admin-console/organizations/manage/scim-v2.component.html
@@ -31,6 +31,7 @@
         <label [for]="switchInputId">
           <span [id]="labelId" class="tw-sr-only">{{ "scim" | i18n }}</span>
           <bit-switch
+            #enabledSwitch
             [id]="switchId"
             [formControl]="enabled"
             (change)="submit()"
@@ -84,6 +85,37 @@
           ></button>
           <bit-hint>{{ "scimApiKeyHelperText" | i18n }}</bit-hint>
         </bit-form-field>
+        @if (stagedStatusEnabled()) {
+          <bit-form-control-card>
+            <bit-switch
+              [formControl]="inviteUsersAfterProvisioning"
+              (change)="submit()"
+            ></bit-switch>
+            <bit-label>
+              {{ "scimInviteUsersAfterProvisioning" | i18n }}
+              <button
+                type="button"
+                bitLink
+                startIcon="bwi-question-circle"
+                [bitPopoverTriggerFor]="inviteUsersHelpPopover"
+                position="below-center"
+                appA11yTitle="{{ 'scimInviteUsersAfterProvisioningHelpTitle' | i18n }}"
+              ></button>
+              <bit-popover
+                [title]="'scimInviteUsersAfterProvisioningHelpTitle' | i18n"
+                #inviteUsersHelpPopover
+              >
+                {{ "scimInviteUsersAfterProvisioningHelpBody" | i18n }}
+                <bit-popover-footer>
+                  <a bitLink target="_blank" href="https://bitwarden.com/help/about-scim/">
+                    {{ "learnMore" | i18n }}
+                  </a>
+                </bit-popover-footer>
+              </bit-popover>
+            </bit-label>
+            <bit-hint>{{ "scimInviteUsersAfterProvisioningHint" | i18n }}</bit-hint>
+          </bit-form-control-card>
+        }
       </div>
     </div>
   </bit-card>

--- a/bitwarden_license/bit-web/src/app/admin-console/organizations/manage/scim-v2.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/admin-console/organizations/manage/scim-v2.component.spec.ts
@@ -8,6 +8,7 @@ import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import { OrganizationConnectionType } from "@bitwarden/common/admin-console/enums";
 import { ScimConfigApi } from "@bitwarden/common/admin-console/models/api/scim-config.api";
 import { OrganizationConnectionResponse } from "@bitwarden/common/admin-console/models/response/organization-connection.response";
+import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import {
   Environment,
@@ -46,13 +47,14 @@ describe("ScimV2Component", () => {
   function mockConnection(
     enabled: boolean,
     id: string | null = "connection-id",
+    inviteUsersAfterProvisioning: boolean | null = null,
   ): OrganizationConnectionResponse<ScimConfigApi> {
     if (!enabled && id === null) {
       return null as unknown as OrganizationConnectionResponse<ScimConfigApi>;
     }
     return {
       id,
-      config: { enabled },
+      config: { enabled, inviteUsersAfterProvisioning },
     } as OrganizationConnectionResponse<ScimConfigApi>;
   }
 
@@ -134,6 +136,24 @@ describe("ScimV2Component", () => {
       expect(ta(component).loading()).toBe(false);
     }));
 
+    it("sets inviteUsersAfterProvisioning to false when the connection config disables it", fakeAsync(() => {
+      initComponent(mockConnection(true, "connection-id", false));
+
+      void component.load();
+      tick();
+
+      expect(ta(component).inviteUsersAfterProvisioning.value).toBe(false);
+    }));
+
+    it("defaults inviteUsersAfterProvisioning to true when the connection config omits it", fakeAsync(() => {
+      initComponent(mockConnection(true));
+
+      void component.load();
+      tick();
+
+      expect(ta(component).inviteUsersAfterProvisioning.value).toBe(true);
+    }));
+
     it("does not open dialog on load", fakeAsync(() => {
       initComponent(mockConnection(true));
 
@@ -142,6 +162,23 @@ describe("ScimV2Component", () => {
 
       expect(openSpy).not.toHaveBeenCalled();
     }));
+  });
+
+  describe("staged status feature flag", () => {
+    it("disables the invite toggle when the flag is off", () => {
+      initComponent();
+
+      expect(configService.getFeatureFlag$).toHaveBeenCalledWith(FeatureFlag.StagedStatus);
+      expect(ta(component).stagedStatusEnabled()).toBe(false);
+    });
+
+    it("enables the invite toggle when the flag is on", () => {
+      configService.getFeatureFlag$.mockReturnValue(of(true));
+
+      initComponent();
+
+      expect(ta(component).stagedStatusEnabled()).toBe(true);
+    });
   });
 
   describe("loadApiKey", () => {
@@ -347,6 +384,42 @@ describe("ScimV2Component", () => {
         variant: "success",
         message: "scimSettingsSaved",
       });
+    }));
+
+    it("submits inviteUsersAfterProvisioning true by default", fakeAsync(() => {
+      ta(component).existingConnectionId.set("connection-id");
+      apiService.updateOrganizationConnection.mockResolvedValue(mockConnection(true));
+
+      void ta(component).submit();
+      tick();
+
+      expect(apiService.updateOrganizationConnection).toHaveBeenCalledWith(
+        expect.objectContaining({
+          config: expect.objectContaining({ inviteUsersAfterProvisioning: true }),
+        }),
+        ScimConfigApi,
+        "connection-id",
+      );
+    }));
+
+    it("submits the toggled inviteUsersAfterProvisioning value", fakeAsync(() => {
+      ta(component).existingConnectionId.set("connection-id");
+      ta(component).inviteUsersAfterProvisioning.setValue(false);
+      apiService.updateOrganizationConnection.mockResolvedValue(
+        mockConnection(true, "connection-id", false),
+      );
+
+      void ta(component).submit();
+      tick();
+
+      expect(apiService.updateOrganizationConnection).toHaveBeenCalledWith(
+        expect.objectContaining({
+          config: expect.objectContaining({ inviteUsersAfterProvisioning: false }),
+        }),
+        ScimConfigApi,
+        "connection-id",
+      );
+      expect(ta(component).inviteUsersAfterProvisioning.value).toBe(false);
     }));
   });
 });

--- a/bitwarden_license/bit-web/src/app/admin-console/organizations/manage/scim-v2.component.ts
+++ b/bitwarden_license/bit-web/src/app/admin-console/organizations/manage/scim-v2.component.ts
@@ -19,11 +19,14 @@ import { ScimConfigApi } from "@bitwarden/common/admin-console/models/api/scim-c
 import { OrganizationConnectionRequest } from "@bitwarden/common/admin-console/models/request/organization-connection.request";
 import { ScimConfigRequest } from "@bitwarden/common/admin-console/models/request/scim-config.request";
 import { OrganizationConnectionResponse } from "@bitwarden/common/admin-console/models/response/organization-connection.response";
+import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { EnvironmentService } from "@bitwarden/common/platform/abstractions/environment.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { OrganizationId } from "@bitwarden/common/types/guid";
 import {
+  A11yTitleDirective,
   AriaDisableDirective,
   BaseCardDirective,
   BitActionDirective,
@@ -31,8 +34,10 @@ import {
   CalloutComponent,
   CardComponent,
   DialogService,
+  FormControlCardComponent,
   FormFieldModule,
   LinkComponent,
+  PopoverModule,
   SpinnerComponent,
   SwitchComponent,
   ToastService,
@@ -53,6 +58,7 @@ let nextId = 0;
   imports: [
     WebHeaderComponent,
     ReactiveFormsModule,
+    A11yTitleDirective,
     BaseCardDirective,
     CalloutComponent,
     CardComponent,
@@ -60,7 +66,9 @@ let nextId = 0;
     LinkComponent,
     AriaDisableDirective,
     SwitchComponent,
+    FormControlCardComponent,
     FormFieldModule,
+    PopoverModule,
     BitIconButtonComponent,
     BitActionDirective,
     I18nPipe,
@@ -70,6 +78,7 @@ let nextId = 0;
 export class ScimV2Component {
   private readonly route = inject(ActivatedRoute);
   private readonly apiService = inject(ApiService);
+  private readonly configService = inject(ConfigService);
   private readonly platformUtilsService = inject(PlatformUtilsService);
   private readonly i18nService = inject(I18nService);
   private readonly environmentService = inject(EnvironmentService);
@@ -80,14 +89,19 @@ export class ScimV2Component {
   protected readonly loading = signal(true);
   protected readonly showScimSettings = signal(false);
   protected readonly showScimKey = signal(false);
+  protected readonly stagedStatusEnabled = toSignal(
+    this.configService.getFeatureFlag$(FeatureFlag.StagedStatus),
+    { initialValue: false },
+  );
 
   protected readonly descriptionId = `scim-description-${nextId++}`;
   protected readonly labelId = `scim-label-${nextId++}`;
   protected readonly switchId = `scim-switch-${nextId++}`;
   protected readonly switchInputId = `${this.switchId}-input`;
-  private readonly switchRef = viewChild.required(SwitchComponent);
+  private readonly switchRef = viewChild.required<SwitchComponent>("enabledSwitch");
 
   protected readonly enabled = new FormControl(false);
+  protected readonly inviteUsersAfterProvisioning = new FormControl(true);
   protected readonly formData = new FormGroup({
     endpointUrl: new FormControl(""),
     clientSecret: new FormControl(""),
@@ -201,7 +215,11 @@ export class ScimV2Component {
       this.organizationId(),
       OrganizationConnectionType.Scim,
       true,
-      new ScimConfigRequest(this.enabled.value ?? false),
+      new ScimConfigRequest(
+        this.enabled.value ?? false,
+        null,
+        this.inviteUsersAfterProvisioning.value ?? true,
+      ),
     );
     let response: OrganizationConnectionResponse<ScimConfigApi>;
 
@@ -252,6 +270,9 @@ export class ScimV2Component {
     this.existingConnectionId.set(connection?.id);
     this.cachedApiKey.set(undefined);
     this.showScimKey.set(false);
+    this.inviteUsersAfterProvisioning.setValue(
+      connection?.config?.inviteUsersAfterProvisioning ?? true,
+    );
     if (connection !== null && connection.config?.enabled) {
       await this.scimBannerService.markBannerSeen(this.organizationId());
       this.showScimSettings.set(true);

--- a/bitwarden_license/bit-web/src/app/admin-console/organizations/manage/scim-v2.component.ts
+++ b/bitwarden_license/bit-web/src/app/admin-console/organizations/manage/scim-v2.component.ts
@@ -217,7 +217,7 @@ export class ScimV2Component {
       true,
       new ScimConfigRequest(
         this.enabled.value ?? false,
-        null,
+        undefined,
         this.inviteUsersAfterProvisioning.value ?? true,
       ),
     );

--- a/libs/common/src/admin-console/models/api/scim-config.api.ts
+++ b/libs/common/src/admin-console/models/api/scim-config.api.ts
@@ -6,6 +6,7 @@ import { ScimProviderType } from "../../enums";
 export class ScimConfigApi extends BaseResponse {
   enabled: boolean;
   scimProvider: ScimProviderType;
+  inviteUsersAfterProvisioning: boolean | null;
 
   constructor(data: any) {
     super(data);
@@ -14,5 +15,6 @@ export class ScimConfigApi extends BaseResponse {
     }
     this.enabled = this.getResponseProperty("Enabled");
     this.scimProvider = this.getResponseProperty("ScimProvider");
+    this.inviteUsersAfterProvisioning = this.getResponseProperty("InviteUsersAfterProvisioning");
   }
 }

--- a/libs/common/src/admin-console/models/api/scim-config.api.ts
+++ b/libs/common/src/admin-console/models/api/scim-config.api.ts
@@ -1,18 +1,13 @@
-// FIXME: Update this file to be type safe and remove this and next line
-// @ts-strict-ignore
 import { BaseResponse } from "../../../models/response/base.response";
 import { ScimProviderType } from "../../enums";
 
 export class ScimConfigApi extends BaseResponse {
   enabled: boolean;
   scimProvider: ScimProviderType;
-  inviteUsersAfterProvisioning: boolean | null;
+  inviteUsersAfterProvisioning: boolean | undefined;
 
   constructor(data: any) {
     super(data);
-    if (data == null) {
-      return;
-    }
     this.enabled = this.getResponseProperty("Enabled");
     this.scimProvider = this.getResponseProperty("ScimProvider");
     this.inviteUsersAfterProvisioning = this.getResponseProperty("InviteUsersAfterProvisioning");

--- a/libs/common/src/admin-console/models/request/scim-config.request.ts
+++ b/libs/common/src/admin-console/models/request/scim-config.request.ts
@@ -1,11 +1,9 @@
-// FIXME: Update this file to be type safe and remove this and next line
-// @ts-strict-ignore
 import { ScimProviderType } from "../../enums";
 
 export class ScimConfigRequest {
   constructor(
     private enabled: boolean,
-    private scimProvider: ScimProviderType | null = null,
+    private scimProvider: ScimProviderType | undefined = undefined,
     private inviteUsersAfterProvisioning: boolean = true,
   ) {}
 }

--- a/libs/common/src/admin-console/models/request/scim-config.request.ts
+++ b/libs/common/src/admin-console/models/request/scim-config.request.ts
@@ -5,6 +5,7 @@ import { ScimProviderType } from "../../enums";
 export class ScimConfigRequest {
   constructor(
     private enabled: boolean,
-    private scimProvider: ScimProviderType = null,
+    private scimProvider: ScimProviderType | null = null,
+    private inviteUsersAfterProvisioning: boolean = true,
   ) {}
 }

--- a/libs/common/src/enums/feature-flag.enum.ts
+++ b/libs/common/src/enums/feature-flag.enum.ts
@@ -15,6 +15,7 @@ export enum FeatureFlag {
   PM35153CollectionSdkDecryption = "pm-35153-collection-sdk-decryption",
   PolicyDrawers = "pm-34804-policy-drawers",
   PoliciesInAcceptedState = "pm-34145-policies-in-accepted-state",
+  StagedStatus = "pm-34423-staged-status",
 
   /* Auth */
   SafariAccountSwitching = "pm-5594-safari-account-switching",
@@ -132,6 +133,7 @@ const FALSE = false as boolean;
 export const DefaultFeatureFlagValue = {
   /* Admin Console Team */
   [FeatureFlag.GenerateInviteLink]: FALSE,
+  [FeatureFlag.StagedStatus]: FALSE,
   [FeatureFlag.PM35153CollectionSdkDecryption]: FALSE,
   [FeatureFlag.PolicyDrawers]: FALSE,
   [FeatureFlag.PoliciesInAcceptedState]: FALSE,


### PR DESCRIPTION
## 🎟️ Tracking
[PM-37964](https://bitwarden.atlassian.net/browse/PM-37964)

## 📔 Objective
The penultimate PR for the staged saga, this PR surfaces the UI to provision staged users. Users are able to _disable_ this toggle to prevent provisioned users from being invited, wherein they will land in a staged state.

## 📸 Screenshots
<img width="3216" height="1826" alt="image" src="https://github.com/user-attachments/assets/1f5207cd-a905-4ffb-95eb-ea4b6785c256" />


[PM-37964]: https://bitwarden.atlassian.net/browse/PM-37964?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ