### PR TITLE
Render native form control UI in dark theme with color-scheme: dark

### DIFF
--- a/libs/components/src/tw-theme.css
+++ b/libs/components/src/tw-theme.css
@@ -647,6 +647,14 @@
   --color-nav-border-secondary-focus: var(--color-white);
 }
 
+/* Render browser-drawn form control UI (date picker, spin buttons, select dropdowns) dark so it
+ * stays visible on dark backgrounds. Author-set styles still win. */
+.theme_dark input,
+.theme_dark textarea,
+.theme_dark select {
+  color-scheme: dark;
+}
+
 @layer components {
   /**
   * tw-break-words does not work with table cells:


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-26022

## 📔 Objective

Native form controls (date/time picker calendar indicator, number spin buttons, native
`<select>` dropdowns) rendered with their light UA chrome in dark theme, making them hard
to see against dark backgrounds.

This adds `color-scheme: dark` to native `input`, `textarea`, and `select` elements under
`.theme_dark` so the browser draws their built-in UI using dark variants. Author-set styles
still take precedence, so only browser-drawn chrome is affected — existing `bitInput` /
`bitCheckbox` styled controls are unchanged.

## 📸 Screenshots
Before:
<img width="766" height="107" alt="image" src="https://github.com/user-attachments/assets/fbf7f7b7-11ad-4d2e-a4c3-966e46acd044" />

After:
<img width="798" height="120" alt="image" src="https://github.com/user-attachments/assets/1781f4f8-60b3-4fa6-810c-248acc6ef929" />

