### PR TITLE
[CL-1263] Increase active bottom navigation label font weight

### DIFF
--- a/libs/components/src/bottom-navigation/bottom-navigation.component.html
+++ b/libs/components/src/bottom-navigation/bottom-navigation.component.html
@@ -7,7 +7,7 @@
             <li class="tw-flex-1 tw-list-none tw-relative">
               <button
                 class="tw-w-full tw-rounded-md tw-flex tw-flex-col tw-gap-0.5 tw-items-center tw-py-1 tw-px-2 bit-compact:tw-py-1 tw-bg-transparent tw-no-underline hover:tw-no-underline hover:tw-text-fg-brand tw-group/tab-nav-btn hover:tw-bg-bg-brand-softer focus-visible:tw-ring-2 focus-visible:tw-ring-inset focus-visible:tw-ring-border-focus focus-visible:tw-outline-none focus-visible:tw-text-fg-brand focus-visible:tw-bg-bg-brand-softer [&:hover:not([aria-current=page])_svg_path]:tw-fill-fg-brand [&:focus-visible:not([aria-current=page])_svg_path]:tw-fill-fg-brand"
-                [class.tw-font-medium]="rla.isActive"
+                [class.tw-font-semibold]="rla.isActive"
                 [class.tw-text-fg-brand]="rla.isActive"
                 [class.tw-text-fg-body]="!rla.isActive"
                 [routerLink]="button.page"


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/CL-1263

## 📔 Objective

Bump the active tab label from medium to semibold so the current page reads more distinctly against inactive tabs.

## 📸 Screenshots
<img width="578" height="141" alt="image" src="https://github.com/user-attachments/assets/ec39fada-d391-4e6a-a727-067a3be3eade" />

