### PR TITLE
desktop: Add function to retrieve native window handle

### DIFF
--- a/apps/desktop/src/main/window.main.ts
+++ b/apps/desktop/src/main/window.main.ts
@@ -135,6 +135,14 @@ export class WindowMain {
       }
     });
 
+    ipcMain.handle("get-native-window-details", (_event) => {
+      return {
+        isVisible: this.win.isVisible(),
+        isFocused: this.win.isFocused(),
+        handle: this.win.getNativeWindowHandle().toString("base64"),
+      };
+    });
+
     this.desktopSettingsService.modalMode$
       .pipe(
         pairwise(),
@@ -641,3 +649,15 @@ export class WindowMain {
     );
   }
 }
+
+export type NativeWindowDetails = {
+  isVisible: boolean;
+  isFocused: boolean;
+  /**
+   * Native handle.
+   * - Windows: HWND
+   * - macOS: NSView*
+   * - Linux: unsigned long
+   */
+  handle: Buffer;
+};

--- a/apps/desktop/src/platform/preload.ts
+++ b/apps/desktop/src/platform/preload.ts
@@ -5,6 +5,7 @@ import { EncString } from "@bitwarden/common/key-management/crypto/models/enc-st
 import { ThemeType, LogLevelType } from "@bitwarden/common/platform/enums";
 import { ForwardedIpcMessage, IpcMessage } from "@bitwarden/common/platform/ipc";
 
+import { NativeWindowDetails } from "../main/window.main";
 import {
   EncryptedMessageResponse,
   LegacyMessageWrapper,
@@ -144,6 +145,11 @@ export default {
     });
   },
   focusWindow: () => ipcRenderer.send("window-focus"),
+  getNativeWindowDetails: async (): Promise<NativeWindowDetails> => {
+    const windowDetails = await ipcRenderer.invoke("get-native-window-details");
+    const handle = Buffer.from(windowDetails.handle, "base64");
+    return { ...windowDetails, handle };
+  },
   hideWindow: () => ipcRenderer.send("window-hide"),
   log: (level: LogLevelType, message?: any, ...optionalParams: any[]) =>
     ipcRenderer.invoke("ipc.log", { level, message, optionalParams }),


### PR DESCRIPTION
## 🎟️ Tracking

[PM-29792](https://bitwarden.atlassian.net/browse/PM-29792)

## 📔 Objective

This adds an IPC method to get details about the native OS window. This is needed specifically in the Windows passkey plugin authenticator for passing focus between the passkey client (browser), Electron app, and the Windows Hello user verification dialog.

Cf. https://github.com/bitwarden/clients/blob/skunkworks/PM-29792/autofill-query-window-and-lock-status/apps/desktop/src/autofill/services/desktop-autofill.service.ts#L283 for where we intend to call it, and the eventual consumption in https://github.com/bitwarden/clients/blob/main/apps/desktop/desktop_native/windows_plugin_authenticator/src/authenticator.rs#L244-L258.

[PM-29792]: https://bitwarden.atlassian.net/browse/PM-29792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ