### PR TITLE
fix(desktop): fix crash generating DuckDuckGo native messaging manifests

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -402,12 +402,18 @@ export class Main {
           firstValueFrom(this.desktopAutofillSettingsService.enableDuckDuckGoBrowserIntegration$),
         ]);
 
-        try {
-          // Re-register the native messaging host integrations on startup, in case they are not present
-          if (ddgIntegrationEnabled) {
+        if (ddgIntegrationEnabled) {
+          try {
             await this.nativeMessagingMain.generateDdgManifests();
+          } catch (err) {
+            this.logService.error(
+              "Error while generating DuckDuckGo native messaging manifests:",
+              err,
+            );
           }
+        }
 
+        try {
           await this.nativeMessagingMain.generateManifests();
           await this.nativeMessagingMain.listen();
         } catch (err) {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-28354

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Wrap DuckDuckGo manifest generation in its own try/catch so a failure there doesn't prevent the Chrome/Firefox manifests from being generated and the native messaging listener from starting.


## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
