### PR TITLE
[CL-1272] Support visually-hidden labels in bit-form-field

### DIFF
--- a/libs/components/src/form-field/form-field.component.ts
+++ b/libs/components/src/form-field/form-field.component.ts
@@ -55,6 +55,10 @@ export class BitFormFieldComponent implements AfterContentChecked {
       "has-[input:disabled]:!tw-text-fg-inactive",
       "[&_bit-hint]:tw-m-0",
       "[&_bit-error]:tw-m-0",
+      // When the label is visually hidden, don't reserve the label/field gap so
+      // the field stays centered. Scoped to `bit-label` so the `sr-only`
+      // `(required)` span doesn't trigger it.
+      "has-[bit-label.tw-sr-only]:tw-gap-0",
       ...(this.readOnly ? [] : ["tw-gap-2"]),
     ].join(" ");
   }

--- a/libs/components/src/form-field/form-field.stories.ts
+++ b/libs/components/src/form-field/form-field.stories.ts
@@ -259,6 +259,34 @@ export const Required: Story = {
   }),
 };
 
+export const HiddenLabel: Story = {
+  render: (args) => ({
+    props: {
+      formObj: formObj,
+      ...args,
+    },
+    template: /*html*/ `
+      <!--
+        A visually-hidden (\`sr-only\`) label keeps the field accessible while
+        collapsing the label/field gap, so the field stays vertically centered
+        alongside sibling controls in a row.
+      -->
+      <div class="tw-flex tw-items-center tw-gap-2">
+        <bit-form-field disableMargin class="tw-w-44">
+          <bit-label class="tw-sr-only">Rows per page</bit-label>
+          <bit-select>
+            <bit-option [value]="10" label="10 rows per page"></bit-option>
+            <bit-option [value]="25" label="25 rows per page"></bit-option>
+          </bit-select>
+        </bit-form-field>
+
+        <button type="button" bitIconButton="bwi-angle-left" size="small"></button>
+        <button type="button" bitIconButton="bwi-angle-right" size="small"></button>
+      </div>
+    `,
+  }),
+};
+
 export const Hint: Story = {
   render: (args) => ({
     props: {


### PR DESCRIPTION
## Summary

Adds first-class support for visually-hidden (`sr-only`) labels in `bit-form-field`. When the projected `bit-label` is `sr-only`, the label/field column collapses its gap so the field stays vertically centered — useful when a field sits inline with sibling controls (e.g. a page-size select in a paginator row) and a visible label isn't wanted, but the accessible name must be preserved.

Implemented with `has-[bit-label.tw-sr-only]:tw-gap-0` on the label/field container. Scoped to the `bit-label` element specifically so the `sr-only` `(required)` span doesn't falsely trigger the collapse.

## Why

Previously the only way to use a label-less field was to omit `bit-label` and rely on `aria-label`, but the form-field always renders its `<label>` row + gap, pushing a single-line control off-center in a vertically-centered row. This keeps the `<label for>` association (better a11y than `aria-label` alone) while fixing the layout.

## Notes

- Split out of #20900 (bit-table-v2) as an independent, standalone change.
- Adds a `HiddenLabel` Storybook story demonstrating a label-less `bit-select` centered next to nav buttons.

## Testing

- Storybook: **Component Library/Form/Field → Hidden Label**.