### PR TITLE
[CL-1273] Add bitMenuClose directive to decouple menu dismissal from ARIA roles

### DIFF
--- a/apps/web/src/app/layouts/product-switcher/product-switcher-content.component.html
+++ b/apps/web/src/app/layouts/product-switcher/product-switcher-content.component.html
@@ -11,6 +11,7 @@
     >
       <a
         *ngFor="let product of products.bento"
+        bitMenuClose
         [routerLink]="product.appRoute"
         [ngClass]="
           product.isActive
@@ -42,6 +43,7 @@
         <a
           *ngIf="!product.marketingRoute.external"
           bitLink
+          bitMenuClose
           [routerLink]="product.marketingRoute.route"
           [startIcon]="product.icon"
         >
@@ -51,6 +53,7 @@
         <a
           *ngIf="product.marketingRoute.external"
           bitLink
+          bitMenuClose
           [href]="product.marketingRoute.route"
           target="_blank"
           rel="noreferrer"

--- a/libs/components/src/menu/index.ts
+++ b/libs/components/src/menu/index.ts
@@ -3,4 +3,5 @@ export * from "./menu.component";
 export * from "./menu-trigger-for.directive";
 export * from "./menu-item.component";
 export * from "./menu-divider.component";
+export * from "./menu-close.directive";
 export { MenuPositionIdentifier } from "./default-positions";

--- a/libs/components/src/menu/menu-close.directive.ts
+++ b/libs/components/src/menu/menu-close.directive.ts
@@ -1,0 +1,19 @@
+import { Directive } from "@angular/core";
+
+/**
+ * Marks a clickable element inside a `bit-menu` as dismissing the menu: clicking it
+ * (or any descendant) closes the menu. `bitMenuItem` applies this automatically via
+ * `hostDirectives`, so standard menu items close as expected. Add `bitMenuClose` by
+ * hand only to non-menu-item content that should also close the menu — e.g.
+ * navigation links inside a `dialog`-role menu.
+ *
+ * The menu detects the marker via the `data-bit-menu-close` attribute this directive
+ * binds, which decouples "closes the menu" from ARIA roles.
+ */
+@Directive({
+  selector: "[bitMenuClose]",
+  host: {
+    "[attr.data-bit-menu-close]": "true",
+  },
+})
+export class MenuCloseDirective {}

--- a/libs/components/src/menu/menu-item.component.ts
+++ b/libs/components/src/menu/menu-item.component.ts
@@ -9,10 +9,13 @@ import {
   ChangeDetectionStrategy,
 } from "@angular/core";
 
+import { MenuCloseDirective } from "./menu-close.directive";
+
 @Component({
   selector: "[bitMenuItem]",
   templateUrl: "menu-item.component.html",
   changeDetection: ChangeDetectionStrategy.OnPush,
+  hostDirectives: [MenuCloseDirective],
   host: {
     "[class]": "classList()",
     role: "menuitem",

--- a/libs/components/src/menu/menu.component.html
+++ b/libs/components/src/menu/menu.component.html
@@ -1,6 +1,6 @@
 <ng-template>
   <div
-    (click)="closed.emit()"
+    (click)="onContentClick($event)"
     class="tw-flex tw-shrink-0 tw-flex-col tw-rounded-xl tw-border tw-border-solid tw-border-border-light tw-bg-bg-primary tw-shadow-lg tw-bg-clip-padding tw-p-2 tw-overflow-y-auto"
     [attr.role]="ariaRole()"
     [attr.aria-label]="ariaLabel()"

--- a/libs/components/src/menu/menu.component.ts
+++ b/libs/components/src/menu/menu.component.ts
@@ -39,4 +39,16 @@ export class MenuComponent {
       }
     });
   }
+
+  /**
+   * Closes the menu when a click lands on an element marked with `bitMenuClose`
+   * (which `bitMenuItem` applies automatically). Clicks on other projected content —
+   * e.g. a filter chip's checkboxes, search field, or section headers — leave the
+   * menu open.
+   */
+  protected onContentClick(event: MouseEvent): void {
+    if ((event.target as HTMLElement | null)?.closest("[data-bit-menu-close]")) {
+      this.closed.emit();
+    }
+  }
 }

--- a/libs/components/src/menu/menu.module.ts
+++ b/libs/components/src/menu/menu.module.ts
@@ -1,12 +1,25 @@
 import { NgModule } from "@angular/core";
 
+import { MenuCloseDirective } from "./menu-close.directive";
 import { MenuDividerComponent } from "./menu-divider.component";
 import { MenuItemComponent } from "./menu-item.component";
 import { MenuTriggerForDirective } from "./menu-trigger-for.directive";
 import { MenuComponent } from "./menu.component";
 
 @NgModule({
-  imports: [MenuComponent, MenuTriggerForDirective, MenuItemComponent, MenuDividerComponent],
-  exports: [MenuComponent, MenuTriggerForDirective, MenuItemComponent, MenuDividerComponent],
+  imports: [
+    MenuComponent,
+    MenuTriggerForDirective,
+    MenuItemComponent,
+    MenuDividerComponent,
+    MenuCloseDirective,
+  ],
+  exports: [
+    MenuComponent,
+    MenuTriggerForDirective,
+    MenuItemComponent,
+    MenuDividerComponent,
+    MenuCloseDirective,
+  ],
 })
 export class MenuModule {}


### PR DESCRIPTION
## Summary

Introduces a `bitMenuClose` marker directive that controls which elements dismiss a `bit-menu` on click, decoupling "closes the menu" from ARIA roles.

- **`bitMenuClose`** stamps a `data-bit-menu-close` attribute. Clicking an element (or any descendant) carrying it closes the enclosing menu.
- **`bitMenuItem` applies it automatically** via `hostDirectives`, so standard menu items keep closing exactly as before.
- The menu now closes only when a click lands on a `[data-bit-menu-close]` element, instead of emitting `closed` on **every** content click.

## Behavior change

Previously, *any* click inside the menu content closed it. This is a problem for menus that project interactive content (search fields, checkboxes, section headers), which is why richer menus need finer control. After this change, only marked elements dismiss the menu.

An exhaustive sweep of `bit-menu` consumers found that all existing menus use `bitMenuItem` (which now auto-applies the marker) **except** the web product-switcher, whose bento tiles and marketing links are plain `<a>` elements. Those get an explicit `bitMenuClose` here to preserve their close-on-click behavior.

## Notes

- Split out of #20900 (bit-table-v2) as an independent, standalone change. The upcoming filter-menu relies on this to keep the menu open while users interact with filter controls.

## Testing

- Existing menu stories (Component Library) — menu items still close the menu.
- Web product-switcher — bento tiles and marketing links still close the switcher on navigation.