### PR TITLE
feat(llm): add claude note to make key-management aware of encryption related changes

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -12,6 +12,7 @@
 
 - **NEVER** use code regions: If complexity suggests regions, refactor for better readability
 - **CRITICAL**: new encryption logic should not be added to this repo.
+  - If significant encryption related logic is added or changed, make sure @bitwarden/team-key-management-dev is aware of the PR
 - **NEVER** send unencrypted vault data to API services
 - **NEVER** commit secrets, credentials, or sensitive information.
 - **NEVER** log decrypted data, encryption keys, or PII


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Inadvertently, a lot of teams co-maintain key-management / crypto code. This has led to bugs and stability issues. If claude determines there are significant cryptographic changes, we want to be pinged on the PR. We are not co-owners of the code however.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
