### PR TITLE
[PM-39815] feat: Add linksEnabled to invite-link status response model

### DIFF
--- a/libs/organization-invite-link/src/models/responses/organization-invite-link-status.response.ts
+++ b/libs/organization-invite-link/src/models/responses/organization-invite-link-status.response.ts
@@ -13,12 +13,14 @@ export class OrganizationInviteLinkSsoResponseModel extends BaseResponse {
 
 export class OrganizationInviteLinkStatusResponseModel extends BaseResponse {
   organizationName: string;
+  linksEnabled: boolean;
   seatsAvailable: boolean;
   sso: OrganizationInviteLinkSsoResponseModel | null;
 
   constructor(response: any) {
     super(response);
     this.organizationName = this.getResponseProperty("OrganizationName");
+    this.linksEnabled = this.getResponseProperty("LinksEnabled");
     this.seatsAvailable = this.getResponseProperty("SeatsAvailable");
     const sso = this.getResponseProperty("Sso");
     this.sso = sso == null ? null : new OrganizationInviteLinkSsoResponseModel(sso);


### PR DESCRIPTION
## 🎟️ Tracking

Resolves [PM-39815](https://bitwarden.atlassian.net/browse/PM-39815)
Server PR: https://github.com/bitwarden/server/pull/7928

## 📔 Objective

The server now returns a successful `200 OK` (with `LinksEnabled: false` and `SeatsAvailable: false`) instead of a `400 InviteLinkNotAvailable` error when an organization's `UseInviteLinks` is disabled, so the client can render the organization's name in that case (see server PR #7928).

This adds the matching `linksEnabled` field to `OrganizationInviteLinkStatusResponseModel` in `libs/organization-invite-link` so the client can read this flag off the response.

No UI consumer of this response model exists in the repo yet, so this PR only adds the field to keep the client model in sync with the server contract.

[PM-39815]: https://bitwarden.atlassian.net/browse/PM-39815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ