### PR TITLE
[PM-40247] Fix vault item checkmarks disappearing after clearing a search

### DIFF
--- a/apps/web/src/app/vault/components/vault-items/vault-items.component.spec.ts
+++ b/apps/web/src/app/vault/components/vault-items/vault-items.component.spec.ts
@@ -259,6 +259,18 @@ describe("VaultItemsComponent", () => {
     });
   });
 
+  describe("selection identity", () => {
+    it("keeps checkmarks after ciphers input is re-set with new object references", () => {
+      const mockCipher = cipher1 as CipherView;
+      component.ciphers = [mockCipher];
+      component["selection"].select(component.dataSource.data[0]);
+
+      component.ciphers = [mockCipher];
+
+      expect(component["selection"].isSelected(component.dataSource.data[0])).toBe(true);
+    });
+  });
+
   describe("filter change handling", () => {
     it("clears selection when routed filter changes", () => {
       const items: VaultItem<CipherView>[] = [

--- a/apps/web/src/app/vault/components/vault-items/vault-items.component.ts
+++ b/apps/web/src/app/vault/components/vault-items/vault-items.component.ts
@@ -32,7 +32,12 @@ import {
 } from "@bitwarden/common/vault/utils/cipher-view-like-utils";
 import { SortDirection, TableDataSource } from "@bitwarden/components";
 import { OrganizationId } from "@bitwarden/sdk-internal";
-import { RoutedVaultFilterService, VaultBatchBarService, VaultItem } from "@bitwarden/vault";
+import {
+  compareVaultItems,
+  RoutedVaultFilterService,
+  VaultBatchBarService,
+  VaultItem,
+} from "@bitwarden/vault";
 
 import { GroupView } from "../../../admin-console/organizations/core";
 
@@ -157,7 +162,12 @@ export class VaultItemsComponent<C extends CipherViewLike> {
 
   protected editableItems: VaultItem<C>[] = [];
   protected dataSource = new TableDataSource<VaultItem<C>>();
-  private readonly _localSelection = new SelectionModel<VaultItem<C>>(true, [], true);
+  private readonly _localSelection = new SelectionModel<VaultItem<C>>(
+    true,
+    [],
+    true,
+    compareVaultItems,
+  );
   get selection(): SelectionModel<VaultItem<C>> {
     return this.batchBarService?.selection ?? this._localSelection;
   }

--- a/libs/vault/src/components/vault-item.ts
+++ b/libs/vault/src/components/vault-item.ts
@@ -5,3 +5,16 @@ export interface VaultItem<C extends CipherViewLike> {
   collection?: CollectionView;
   cipher?: C;
 }
+
+export function compareVaultItems<C extends CipherViewLike>(
+  a: VaultItem<C>,
+  b: VaultItem<C>,
+): boolean {
+  if (a.cipher && b.cipher) {
+    return a.cipher.id === b.cipher.id;
+  }
+  if (a.collection && b.collection) {
+    return a.collection.id === b.collection.id;
+  }
+  return false;
+}

--- a/libs/vault/src/index.ts
+++ b/libs/vault/src/index.ts
@@ -37,7 +37,7 @@ export * from "./components/carousel";
 export * from "./components/new-cipher-menu/new-cipher-menu.component";
 export * from "./components/permit-cipher-details-popover/permit-cipher-details-popover.component";
 export * from "./components/vault-items-transfer";
-export { VaultItem } from "./components/vault-item";
+export { VaultItem, compareVaultItems } from "./components/vault-item";
 export { VaultOrganizationUserNotificationsComponent } from "./components/vault-organization-user-notifications/vault-organization-user-notifications.component";
 export {
   VaultOrganizationUserNotificationsService,

--- a/libs/vault/src/services/vault-batch-bar.service.spec.ts
+++ b/libs/vault/src/services/vault-batch-bar.service.spec.ts
@@ -188,6 +188,17 @@ describe("VaultBatchBarService", () => {
     });
   });
 
+  describe("selection identity", () => {
+    it("recognises two VaultItem wrappers with the same cipher ID as the same selection", () => {
+      const item1: VaultItem<CipherView> = { cipher: makeCipher() };
+      const item2: VaultItem<CipherView> = { cipher: makeCipher() };
+
+      service.selection.select(item1);
+
+      expect(service.selection.isSelected(item2)).toBe(true);
+    });
+  });
+
   describe("selection helpers", () => {
     it("selected returns items in SelectionModel", () => {
       const item = makeCipherItem();

--- a/libs/vault/src/services/vault-batch-bar.service.ts
+++ b/libs/vault/src/services/vault-batch-bar.service.ts
@@ -39,7 +39,7 @@ import {
   BulkMoveDialogResult,
   openBulkMoveDialog,
 } from "../components/bulk-action-dialogs/bulk-move-dialog/bulk-move-dialog.component";
-import { VaultItem } from "../components/vault-item";
+import { compareVaultItems, VaultItem } from "../components/vault-item";
 import { All } from "../models/routed-vault-filter.model";
 import {
   ASSIGN_COLLECTIONS_DIALOG,
@@ -143,7 +143,7 @@ export class VaultBatchBarService<C extends CipherViewLike> {
   );
 
   /** The Angular CDK selection model. Add, remove, or clear items directly. */
-  readonly selection = new SelectionModel<VaultItem<C>>(true, [], true);
+  readonly selection = new SelectionModel<VaultItem<C>>(true, [], true, compareVaultItems);
 
   private readonly _completed$ = new Subject<void>();
   /** Emits once after each successful bulk action. Subscribe to trigger a list refresh. */


### PR DESCRIPTION
## 🎟️ Tracking

[PM-40247](https://bitwarden.atlassian.net/browse/PM-40247)

## 📔 Objective

Fixes checkmarks disappearing from vault items after clearing a search. `SelectionModel` now compares by stable cipher/collection ID rather than object reference.

## 📸 Screenshots


https://github.com/user-attachments/assets/ca6627cd-2cf6-4a4e-bd48-f0b25ad874be



[PM-40247]: https://bitwarden.atlassian.net/browse/PM-40247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ