### PR TITLE
[PM-37990] Add UriMatchDefaultPolicy components and stories

### DIFF
--- a/apps/web/src/app/admin-console/organizations/policies/policy-edit-definitions/uri-match-default-modal.component.stories.ts
+++ b/apps/web/src/app/admin-console/organizations/policies/policy-edit-definitions/uri-match-default-modal.component.stories.ts
@@ -1,0 +1,23 @@
+import { Meta, StoryObj } from "@storybook/angular";
+
+import { PolicyDialogStoryArgs, policyModalMeta } from "../policy-drawer-story.helper";
+
+import { UriMatchDefaultPolicy } from "./uri-match-default.component";
+
+/**
+ * Renders the PolicyDrawers-flag-off (modal) experience for this policy, so a visual diff (e.g.
+ * via Chromatic) catches any v2-only design change leaking into the modal. Compare against the
+ * drawer stories in uri-match-default.component.stories.ts.
+ */
+export default {
+  ...policyModalMeta(new UriMatchDefaultPolicy()),
+  title: "Admin Console/Organizations/Policies/Default URI Match Detection/Modal (flag off)",
+} satisfies Meta<PolicyDialogStoryArgs>;
+
+type Story = StoryObj<PolicyDialogStoryArgs>;
+
+export const PolicyOff: Story = {};
+
+export const PolicyOn: Story = {
+  args: { enabled: true },
+};

--- a/apps/web/src/app/admin-console/organizations/policies/policy-edit-definitions/uri-match-default-v2.component.html
+++ b/apps/web/src/app/admin-console/organizations/policies/policy-edit-definitions/uri-match-default-v2.component.html
@@ -1,0 +1,18 @@
+<bit-form-control>
+  <bit-switch [formControl]="enabled" id="enabled"></bit-switch>
+  <bit-label>{{ "enablePolicy" | i18n }}</bit-label>
+</bit-form-control>
+
+<div [formGroup]="data">
+  <bit-form-field class="tw-flex-auto">
+    <bit-label>{{ "uriMatchDetectionOptionsLabel" | i18n }}</bit-label>
+    <bit-select formControlName="uriMatchDetection" id="uriMatchDetection">
+      <bit-option
+        *ngFor="let o of uriMatchOptions"
+        [label]="o.label"
+        [value]="o.value"
+        [disabled]="o.disabled"
+      ></bit-option>
+    </bit-select>
+  </bit-form-field>
+</div>

--- a/apps/web/src/app/admin-console/organizations/policies/policy-edit-definitions/uri-match-default-v2.component.html
+++ b/apps/web/src/app/admin-console/organizations/policies/policy-edit-definitions/uri-match-default-v2.component.html
@@ -7,12 +7,9 @@
   <bit-form-field class="tw-flex-auto">
     <bit-label>{{ "uriMatchDetectionOptionsLabel" | i18n }}</bit-label>
     <bit-select formControlName="uriMatchDetection" id="uriMatchDetection">
-      <bit-option
-        *ngFor="let o of uriMatchOptions"
-        [label]="o.label"
-        [value]="o.value"
-        [disabled]="o.disabled"
-      ></bit-option>
+      @for (o of uriMatchOptions; track o.value) {
+        <bit-option [label]="o.label" [value]="o.value" [disabled]="o.disabled"></bit-option>
+      }
     </bit-select>
   </bit-form-field>
 </div>

--- a/apps/web/src/app/admin-console/organizations/policies/policy-edit-definitions/uri-match-default.component.spec.ts
+++ b/apps/web/src/app/admin-console/organizations/policies/policy-edit-definitions/uri-match-default.component.spec.ts
@@ -1,0 +1,121 @@
+import { NO_ERRORS_SCHEMA } from "@angular/core";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { ReactiveFormsModule } from "@angular/forms";
+import { mock } from "jest-mock-extended";
+import { of } from "rxjs";
+
+import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
+import { PolicyApiServiceAbstraction } from "@bitwarden/common/admin-console/abstractions/policy/policy-api.service.abstraction";
+import { PolicyType } from "@bitwarden/common/admin-console/enums";
+import { PolicyStatusResponse } from "@bitwarden/common/admin-console/models/response/policy-status.response";
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { UriMatchStrategy } from "@bitwarden/common/models/domain/domain-service";
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { FakeAccountService, mockAccountServiceWith } from "@bitwarden/common/spec";
+import { OrganizationId, UserId } from "@bitwarden/common/types/guid";
+import { KeyService } from "@bitwarden/key-management";
+
+import {
+  UriMatchDefaultPolicy,
+  UriMatchDefaultPolicyComponent,
+  UriMatchDefaultPolicyV2Component,
+} from "./uri-match-default.component";
+
+const ORG_ID = "org1" as OrganizationId;
+const USER_ID = "user1" as UserId;
+
+function makePolicyResponse(enabled: boolean, data: object | null = null) {
+  return new PolicyStatusResponse({
+    OrganizationId: ORG_ID,
+    Type: PolicyType.UriMatchDefaults,
+    Enabled: enabled,
+    Data: data,
+  });
+}
+
+describe("UriMatchDefaultPolicy", () => {
+  it("has correct attributes", () => {
+    const policy = new UriMatchDefaultPolicy();
+
+    expect(policy.name).toBe("uriMatchDetectionPolicy");
+    expect(policy.description).toBe("uriMatchDetectionPolicyDesc");
+    expect(policy.type).toBe(PolicyType.UriMatchDefaults);
+    expect(policy.component).toBe(UriMatchDefaultPolicyComponent);
+  });
+
+  it("renders the v2 component inside the drawer, with its own description and prerequisite", () => {
+    const policy = new UriMatchDefaultPolicy();
+
+    expect(policy.v2?.component).toBe(UriMatchDefaultPolicyV2Component);
+    expect(policy.v2?.component).not.toBe(policy.component);
+    expect(policy.v2?.description).toBe("uriMatchDetectionPolicyDescV2");
+    expect(policy.v2?.prerequisiteKey).toBe("requireSsoPolicyReqV2");
+  });
+});
+
+describe.each`
+  description                           | componentClass
+  ${"UriMatchDefaultPolicyComponent"}   | ${UriMatchDefaultPolicyComponent}
+  ${"UriMatchDefaultPolicyV2Component"} | ${UriMatchDefaultPolicyV2Component}
+`("$description", ({ componentClass }) => {
+  let component: UriMatchDefaultPolicyComponent;
+  let fixture: ComponentFixture<UriMatchDefaultPolicyComponent>;
+  let accountService: FakeAccountService;
+
+  beforeEach(async () => {
+    accountService = mockAccountServiceWith(USER_ID);
+
+    await TestBed.configureTestingModule({
+      imports: [ReactiveFormsModule],
+      providers: [
+        { provide: OrganizationService, useValue: { organizations$: () => of([]) } },
+        { provide: AccountService, useValue: accountService },
+        { provide: KeyService, useValue: mock<KeyService>() },
+        { provide: PolicyApiServiceAbstraction, useValue: mock<PolicyApiServiceAbstraction>() },
+        { provide: I18nService, useValue: { t: jest.fn((key: string) => key) } },
+      ],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(componentClass);
+    component = fixture.componentInstance;
+  });
+
+  it("defaults uriMatchDetection to Domain", () => {
+    expect(component.data?.value?.uriMatchDetection).toBe(UriMatchStrategy.Domain);
+  });
+
+  it("builds the four uri match options", () => {
+    expect(component.uriMatchOptions.map((o) => o.value)).toEqual([
+      UriMatchStrategy.Domain,
+      UriMatchStrategy.Host,
+      UriMatchStrategy.Exact,
+      UriMatchStrategy.Never,
+    ]);
+  });
+
+  it("loads uriMatchDetection from policy data on init", () => {
+    fixture.componentRef.setInput(
+      "policyResponse",
+      makePolicyResponse(true, { uriMatchDetection: UriMatchStrategy.Host }),
+    );
+
+    component.ngOnInit();
+
+    expect(component.data?.value?.uriMatchDetection).toBe(UriMatchStrategy.Host);
+  });
+
+  it("builds request data from the uriMatchDetection control", () => {
+    component.data?.patchValue({ uriMatchDetection: UriMatchStrategy.Exact });
+
+    expect(component["buildRequestData"]()).toEqual({
+      uriMatchDetection: UriMatchStrategy.Exact,
+    });
+  });
+
+  it("throws when saving without a selected uriMatchDetection value", async () => {
+    component.data?.patchValue({ uriMatchDetection: null });
+
+    await expect(component.buildRequest()).rejects.toThrow();
+  });
+});

--- a/apps/web/src/app/admin-console/organizations/policies/policy-edit-definitions/uri-match-default.component.stories.ts
+++ b/apps/web/src/app/admin-console/organizations/policies/policy-edit-definitions/uri-match-default.component.stories.ts
@@ -1,0 +1,18 @@
+import { Meta, StoryObj } from "@storybook/angular";
+
+import { PolicyDialogStoryArgs, policyDrawerMeta } from "../policy-drawer-story.helper";
+
+import { UriMatchDefaultPolicy } from "./uri-match-default.component";
+
+export default {
+  ...policyDrawerMeta(new UriMatchDefaultPolicy()),
+  title: "Admin Console/Organizations/Policies/Default URI Match Detection",
+} satisfies Meta<PolicyDialogStoryArgs>;
+
+type Story = StoryObj<PolicyDialogStoryArgs>;
+
+export const PolicyOff: Story = {};
+
+export const PolicyOn: Story = {
+  args: { enabled: true },
+};

--- a/apps/web/src/app/admin-console/organizations/policies/policy-edit-definitions/uri-match-default.component.ts
+++ b/apps/web/src/app/admin-console/organizations/policies/policy-edit-definitions/uri-match-default.component.ts
@@ -9,6 +9,7 @@ import {
 } from "@bitwarden/common/models/domain/domain-service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { OrgKey } from "@bitwarden/common/types/key";
+import { SwitchComponent } from "@bitwarden/components";
 
 import { SharedModule } from "../../../../shared";
 import { BasePolicyEditDefinition, BasePolicyEditComponent } from "../base-policy-edit.component";
@@ -21,6 +22,11 @@ export class UriMatchDefaultPolicy extends BasePolicyEditDefinition {
   category = PolicyCategory.VaultManagement;
   priority = 20;
   component = UriMatchDefaultPolicyComponent;
+  v2 = {
+    component: UriMatchDefaultPolicyV2Component,
+    description: "uriMatchDetectionPolicyDescV2",
+    prerequisiteKey: "requireSsoPolicyReqV2",
+  };
 }
 @Component({
   selector: "uri-match-default-policy-edit",
@@ -79,3 +85,16 @@ export class UriMatchDefaultPolicyComponent extends BasePolicyEditComponent {
     return request;
   }
 }
+
+/**
+ * Drawer (v2) variant. Reuses all form logic from the standard component and only swaps the
+ * template: the enable toggle is rendered as a switch instead of a checkbox, and the prerequisite
+ * callout is rendered by the surrounding PolicyEditDrawerComponent instead of the form.
+ */
+@Component({
+  selector: "uri-match-default-v2-policy-edit",
+  templateUrl: "uri-match-default-v2.component.html",
+  imports: [SharedModule, SwitchComponent],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class UriMatchDefaultPolicyV2Component extends UriMatchDefaultPolicyComponent {}

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -7597,6 +7597,9 @@
   "uriMatchDetectionPolicyDesc": {
     "message": "Determine when logins are suggested for autofill. Admins and owners are exempt from this policy."
   },
+  "uriMatchDetectionPolicyDescV2": {
+    "message": "Set a default for which parts of a website address (URI) need to match for Bitwarden to suggest a login for autofill. This policy won't be enforced for owners and admins."
+  },
   "uriMatchDetectionOptionsLabel": {
     "message": "Default URI match detection"
   },


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-37990

## 📔 Objective

Policy Drawers implementation for new figma mockups

## 📸 Screenshots

<img width="1871" height="902" alt="image" src="https://github.com/user-attachments/assets/cdfc37e5-6d82-47a3-b1ba-1ac7e22d74d4" />

