### PR TITLE
[PM-38519] Add AutoConfirmPolicy V2 component and associated templates

### DIFF
--- a/apps/web/src/app/admin-console/organizations/policies/policy-drawer-story.helper.ts
+++ b/apps/web/src/app/admin-console/organizations/policies/policy-drawer-story.helper.ts
@@ -1,4 +1,5 @@
 import { importProvidersFrom, Type } from "@angular/core";
+import { Router } from "@angular/router";
 import {
   applicationConfig,
   componentWrapperDecorator,
@@ -7,8 +8,10 @@ import {
 } from "@storybook/angular";
 import { of } from "rxjs";
 
+import { AutoConfirmState, AutomaticUserConfirmationService } from "@bitwarden/auto-confirm";
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { PolicyApiServiceAbstraction } from "@bitwarden/common/admin-console/abstractions/policy/policy-api.service.abstraction";
+import { PolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
 import { PolicyStatusResponse } from "@bitwarden/common/admin-console/models/response/policy-status.response";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { AuthService } from "@bitwarden/common/auth/abstractions/auth.service";
@@ -135,6 +138,26 @@ function buildPolicyDialogMeta(
             // directly, but providing it unconditionally is harmless for the drawer component.
             provide: ConfigService,
             useValue: { getFeatureFlag$: () => of(isDrawer) },
+          },
+          {
+            // Only AutoConfirmPolicy's component injects these, but providing them
+            // unconditionally is harmless for every other policy. Without these, Angular throws
+            // a NullInjectorError while creating the policy form component, which is swallowed by
+            // the dialog's async ngAfterViewInit and leaves the step body empty with no visible
+            // error in the story.
+            provide: PolicyService,
+            useValue: { policies$: () => of([]) },
+          },
+          {
+            provide: AutomaticUserConfirmationService,
+            useValue: {
+              configuration$: () => of(new AutoConfirmState()),
+              upsert: () => Promise.resolve(),
+            },
+          },
+          {
+            provide: Router,
+            useValue: { navigate: () => Promise.resolve(true) },
           },
         ],
       }),

--- a/apps/web/src/app/admin-console/organizations/policies/policy-edit-definitions/auto-confirm-policy-modal.component.stories.ts
+++ b/apps/web/src/app/admin-console/organizations/policies/policy-edit-definitions/auto-confirm-policy-modal.component.stories.ts
@@ -1,0 +1,24 @@
+import { Meta, StoryObj } from "@storybook/angular";
+
+import { PolicyDialogStoryArgs, policyModalMeta } from "../policy-drawer-story.helper";
+
+import { AutoConfirmPolicy } from "./auto-confirm-policy.component";
+
+/**
+ * Renders the PolicyDrawers-flag-off (modal) experience for this policy, so a visual diff (e.g.
+ * via Chromatic) catches any v2-only design change (toggle, risk checkbox, footer button, badge)
+ * leaking into the modal. Compare against the drawer stories in
+ * auto-confirm-policy.component.stories.ts.
+ */
+export default {
+  ...policyModalMeta(new AutoConfirmPolicy()),
+  title: "Admin Console/Organizations/Policies/Auto-confirm/Modal (flag off)",
+} satisfies Meta<PolicyDialogStoryArgs>;
+
+type Story = StoryObj<PolicyDialogStoryArgs>;
+
+export const PolicyOff: Story = {};
+
+export const PolicyOn: Story = {
+  args: { enabled: true },
+};

--- a/apps/web/src/app/admin-console/organizations/policies/policy-edit-definitions/auto-confirm-policy-v2.component.html
+++ b/apps/web/src/app/admin-console/organizations/policies/policy-edit-definitions/auto-confirm-policy-v2.component.html
@@ -1,0 +1,110 @@
+<ng-template #step0ContentV2>
+  <p class="tw-mb-6">
+    {{ "autoConfirmPolicyEditDescription" | i18n }}
+  </p>
+
+  <ul class="tw-mb-6 tw-pl-6">
+    <li>
+      <span class="tw-font-medium">
+        {{ "autoConfirmAcceptSecurityRiskTitle" | i18n }}
+      </span>
+      {{ "autoConfirmAcceptSecurityRiskDescription" | i18n }}
+      <a
+        bitLink
+        href="https://bitwarden.com/help/automatic-confirmation/"
+        target="_blank"
+        endIcon="bwi-external-link"
+      >
+        {{ "autoConfirmAcceptSecurityRiskLearnMore" | i18n }}
+      </a>
+    </li>
+
+    <li>
+      @if (singleOrgEnabled$ | async) {
+        <span class="tw-font-medium">
+          {{ "autoConfirmSingleOrgExemption" | i18n }}
+        </span>
+      } @else {
+        <span class="tw-font-medium">
+          {{ "autoConfirmSingleOrgRequired" | i18n }}
+        </span>
+      }
+      {{ "autoConfirmSingleOrgRequiredDesc" | i18n }}
+    </li>
+
+    <li>
+      <span class="tw-font-medium">
+        {{ "autoConfirmNoEmergencyAccess" | i18n }}
+      </span>
+      {{ "autoConfirmNoEmergencyAccessDescription" | i18n }}
+    </li>
+  </ul>
+
+  <bit-form-control class="tw-mb-4">
+    <input type="checkbox" bitCheckbox [formControl]="riskAccepted" id="riskAccepted" />
+    <bit-label>{{ "autoConfirmCheckBoxLabel" | i18n }}</bit-label>
+  </bit-form-control>
+
+  <bit-form-control>
+    <bit-switch [formControl]="enabled" id="enabled"></bit-switch>
+    <bit-label>{{ "enablePolicy" | i18n }}</bit-label>
+  </bit-form-control>
+</ng-template>
+
+<ng-template #step0FooterV2>
+  <button
+    bitButton
+    buttonType="primary"
+    [disabled]="saveDisabled$ | async"
+    bitFormButton
+    type="submit"
+  >
+    {{ "saveAndContinue" | i18n }}
+  </button>
+  <button bitButton buttonType="secondary" type="button" bitDialogClose>
+    {{ "cancel" | i18n }}
+  </button>
+</ng-template>
+
+<!--
+  Step 1 ("how to turn on") is unchanged from the v1 template, but Angular resolves each
+  viewChild.required(...) query (see step1Title/step1Content/step1Footer in
+  auto-confirm-policy.component.ts) against this component's own rendered view - inheriting the
+  signal from the v1 base class does NOT let it find template refs declared in the v1 template.
+  These must be duplicated here unchanged; see auto-confirm-policy.component.html for the v1 copy.
+-->
+<ng-template #step1Title>
+  {{ "howToTurnOnAutoConfirm" | i18n }}
+</ng-template>
+
+<ng-template #step1Content>
+  <div class="tw-flex tw-justify-center tw-mb-6">
+    <bit-svg class="tw-w-[233px]" [content]="autoConfirmSvg"></bit-svg>
+  </div>
+  <ol>
+    <li>1. {{ "autoConfirmExtension1" | i18n }}</li>
+
+    <li>
+      2. {{ "autoConfirmExtension2" | i18n }}
+      <strong>
+        {{ "autoConfirmExtension3" | i18n }}
+      </strong>
+    </li>
+  </ol>
+</ng-template>
+
+<ng-template #step1Footer>
+  <button
+    bitButton
+    buttonType="primary"
+    [disabled]="saveDisabled$ | async"
+    bitFormButton
+    type="submit"
+  >
+    {{ "openExtension" | i18n }}
+    <i class="bwi bwi-external-link tw-ml-1" aria-hidden="true"></i>
+  </button>
+  <button bitButton buttonType="secondary" type="button" bitDialogClose>
+    {{ "close" | i18n }}
+  </button>
+</ng-template>

--- a/apps/web/src/app/admin-console/organizations/policies/policy-edit-definitions/auto-confirm-policy.component.spec.ts
+++ b/apps/web/src/app/admin-console/organizations/policies/policy-edit-definitions/auto-confirm-policy.component.spec.ts
@@ -17,7 +17,11 @@ import { OrganizationId, UserId } from "@bitwarden/common/types/guid";
 import { newGuid } from "@bitwarden/guid";
 import { KeyService } from "@bitwarden/key-management";
 
-import { AutoConfirmPolicy, AutoConfirmPolicyEditComponent } from "./auto-confirm-policy.component";
+import {
+  AutoConfirmPolicy,
+  AutoConfirmPolicyEditComponent,
+  AutoConfirmPolicyEditV2Component,
+} from "./auto-confirm-policy.component";
 
 describe("AutoConfirmPolicy", () => {
   it("has correct attributes", () => {
@@ -28,6 +32,16 @@ describe("AutoConfirmPolicy", () => {
     expect(policy.type).toBe(PolicyType.AutomaticUserConfirmation);
     expect(policy.component).toBe(AutoConfirmPolicyEditComponent);
     expect(policy.showDescription).toBe(false);
+  });
+
+  it("renders the v2 component inside the drawer, with no dialog-level overrides", () => {
+    const policy = new AutoConfirmPolicy();
+
+    expect(policy.v2?.component).toBe(AutoConfirmPolicyEditV2Component);
+    expect(policy.v2?.component).not.toBe(policy.component);
+    // No description/prerequisite override: v2 keeps showDescription = false (its step content
+    // renders the policy copy itself) and relies on the dialog's generic name+badge header.
+    expect(policy.v2?.description).toBeUndefined();
   });
 });
 
@@ -229,6 +243,94 @@ describe("AutoConfirmPolicyEditComponent — policySteps[0].sideEffect", () => {
         showSetupDialog: false,
         showBrowserNotification: false,
       });
+    });
+  });
+});
+
+describe("AutoConfirmPolicyEditV2Component", () => {
+  let component: AutoConfirmPolicyEditV2Component;
+  let fixture: ComponentFixture<AutoConfirmPolicyEditV2Component>;
+  let accountService: FakeAccountService;
+
+  const userId = newGuid() as UserId;
+  const orgId = newGuid() as OrganizationId;
+
+  beforeEach(async () => {
+    accountService = mockAccountServiceWith(userId);
+
+    await TestBed.configureTestingModule({
+      providers: [
+        { provide: AccountService, useValue: accountService },
+        { provide: KeyService, useValue: mock<KeyService>() },
+        { provide: OrganizationService, useValue: mock<OrganizationService>() },
+        { provide: PolicyService, useValue: mock<PolicyService>() },
+        { provide: PolicyApiServiceAbstraction, useValue: mock<PolicyApiServiceAbstraction>() },
+        {
+          provide: AutomaticUserConfirmationService,
+          useValue: mock<AutomaticUserConfirmationService>(),
+        },
+        { provide: Router, useValue: mock<Router>() },
+      ],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AutoConfirmPolicyEditV2Component);
+    component = fixture.componentInstance;
+
+    fixture.componentRef.setInput("organizationId", orgId);
+    fixture.componentRef.setInput("policy", new AutoConfirmPolicy());
+    // Intentionally skip detectChanges() — viewChild signals are not needed for these tests.
+  });
+
+  describe("risk-acceptance gating", () => {
+    it("defaults riskAccepted to unchecked and disables the enable switch when the policy is not yet enabled", () => {
+      fixture.componentRef.setInput("policyResponse", { enabled: false } as any);
+
+      component.ngOnInit();
+
+      expect(component.riskAccepted.value).toBe(false);
+      expect(component.enabled.disabled).toBe(true);
+    });
+
+    it("defaults riskAccepted to checked and keeps the enable switch usable when the policy is already enabled", () => {
+      fixture.componentRef.setInput("policyResponse", { enabled: true } as any);
+
+      component.ngOnInit();
+
+      expect(component.riskAccepted.value).toBe(true);
+      expect(component.enabled.disabled).toBe(false);
+    });
+
+    it("enables the switch once the risk checkbox is checked", () => {
+      fixture.componentRef.setInput("policyResponse", { enabled: false } as any);
+      component.ngOnInit();
+      expect(component.enabled.disabled).toBe(true);
+
+      component.riskAccepted.setValue(true);
+
+      expect(component.enabled.disabled).toBe(false);
+    });
+
+    it("disables the switch again if the risk checkbox is unchecked", () => {
+      fixture.componentRef.setInput("policyResponse", { enabled: true } as any);
+      component.ngOnInit();
+      expect(component.enabled.disabled).toBe(false);
+
+      component.riskAccepted.setValue(false);
+
+      expect(component.enabled.disabled).toBe(true);
+    });
+  });
+
+  describe("policySteps", () => {
+    it("reuses step 1 (title/content/footer/sideEffect) unchanged from the v1 component", () => {
+      expect(component.policySteps[1].titleContent).toBe((component as any).step1Title);
+      expect(component.policySteps[1].bodyContent).toBe((component as any).step1Content);
+      expect(component.policySteps[1].footerContent).toBe((component as any).step1Footer);
+    });
+
+    it("does not set a custom titleContent for step 0, relying on the dialog's generic name+badge header", () => {
+      expect(component.policySteps[0].titleContent).toBeUndefined();
     });
   });
 });

--- a/apps/web/src/app/admin-console/organizations/policies/policy-edit-definitions/auto-confirm-policy.component.spec.ts
+++ b/apps/web/src/app/admin-console/organizations/policies/policy-edit-definitions/auto-confirm-policy.component.spec.ts
@@ -320,6 +320,23 @@ describe("AutoConfirmPolicyEditV2Component", () => {
 
       expect(component.enabled.disabled).toBe(true);
     });
+
+    // Regression test: un-accepting risk after enabling used to only disable() the switch, which
+    // does not clear its value - a disabled FormControl's `.value` (read by buildRequest()) still
+    // returned `true`, so the policy could be saved as enabled despite the switch appearing off.
+    it("resets the switch value to false when risk is unchecked after having been enabled, so it cannot be saved-on", () => {
+      fixture.componentRef.setInput("policyResponse", { enabled: false } as any);
+      component.ngOnInit();
+
+      component.riskAccepted.setValue(true);
+      component.enabled.setValue(true);
+      expect(component.enabled.value).toBe(true);
+
+      component.riskAccepted.setValue(false);
+
+      expect(component.enabled.value).toBe(false);
+      expect(component.enabled.disabled).toBe(true);
+    });
   });
 
   describe("policySteps", () => {

--- a/apps/web/src/app/admin-console/organizations/policies/policy-edit-definitions/auto-confirm-policy.component.stories.ts
+++ b/apps/web/src/app/admin-console/organizations/policies/policy-edit-definitions/auto-confirm-policy.component.stories.ts
@@ -1,0 +1,23 @@
+import { Meta, StoryObj } from "@storybook/angular";
+
+import { PolicyDialogStoryArgs, policyDrawerMeta } from "../policy-drawer-story.helper";
+
+import { AutoConfirmPolicy } from "./auto-confirm-policy.component";
+
+/**
+ * Renders the PolicyDrawers-flag-on (drawer) experience for this policy. This policy uses
+ * MultiStepPolicyEditDialogComponent for both the drawer and modal experiences, so pair this with
+ * auto-confirm-policy-modal.component.stories.ts to catch a v2 leak into the modal.
+ */
+export default {
+  ...policyDrawerMeta(new AutoConfirmPolicy()),
+  title: "Admin Console/Organizations/Policies/Auto-confirm",
+} satisfies Meta<PolicyDialogStoryArgs>;
+
+type Story = StoryObj<PolicyDialogStoryArgs>;
+
+export const PolicyOff: Story = {};
+
+export const PolicyOn: Story = {
+  args: { enabled: true },
+};

--- a/apps/web/src/app/admin-console/organizations/policies/policy-edit-definitions/auto-confirm-policy.component.ts
+++ b/apps/web/src/app/admin-console/organizations/policies/policy-edit-definitions/auto-confirm-policy.component.ts
@@ -1,4 +1,14 @@
-import { ChangeDetectionStrategy, Component, Signal, TemplateRef, viewChild } from "@angular/core";
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  inject,
+  Signal,
+  TemplateRef,
+  viewChild,
+} from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
+import { FormControl } from "@angular/forms";
 import { Router } from "@angular/router";
 import { combineLatest, firstValueFrom, map, Observable, of, startWith, switchMap } from "rxjs";
 
@@ -8,6 +18,7 @@ import { PolicyService } from "@bitwarden/common/admin-console/abstractions/poli
 import { PolicyType } from "@bitwarden/common/admin-console/enums";
 import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
 import { getUserId } from "@bitwarden/common/auth/services/account.service";
+import { SwitchComponent } from "@bitwarden/components";
 
 import { SharedModule } from "../../../../shared";
 import { BasePolicyEditDefinition, BasePolicyEditComponent } from "../base-policy-edit.component";
@@ -27,6 +38,9 @@ export class AutoConfirmPolicy extends BasePolicyEditDefinition {
   component = AutoConfirmPolicyEditComponent;
   showDescription = false;
   editDialogComponent = MultiStepPolicyEditDialogComponent;
+  v2 = {
+    component: AutoConfirmPolicyEditV2Component,
+  };
 
   constructor(readonly firstTimeDialog: boolean = false) {
     super();
@@ -62,9 +76,15 @@ export class AutoConfirmPolicyEditComponent extends BasePolicyEditComponent {
   private readonly step0Content: Signal<TemplateRef<unknown>> = viewChild.required("step0Content");
   private readonly step0Footer: Signal<TemplateRef<unknown>> = viewChild.required("step0Footer");
 
-  private readonly step1Title: Signal<TemplateRef<unknown>> = viewChild.required("step1Title");
-  private readonly step1Content: Signal<TemplateRef<unknown>> = viewChild.required("step1Content");
-  private readonly step1Footer: Signal<TemplateRef<unknown>> = viewChild.required("step1Footer");
+  /**
+   * Step 1 ("how to turn on") title/content/footer templates. Protected (rather than private) so
+   * the v2 variant of this component can reuse them unchanged - only step 0 differs between v1
+   * and v2.
+   */
+  protected readonly step1Title: Signal<TemplateRef<unknown>> = viewChild.required("step1Title");
+  protected readonly step1Content: Signal<TemplateRef<unknown>> =
+    viewChild.required("step1Content");
+  protected readonly step1Footer: Signal<TemplateRef<unknown>> = viewChild.required("step1Footer");
 
   protected readonly autoConfirmEnabled$: Observable<boolean> =
     this.accountService.activeAccount$.pipe(
@@ -156,9 +176,75 @@ export class AutoConfirmPolicyEditComponent extends BasePolicyEditComponent {
     }
   }
 
-  private async navigateToExtensionPromptStep(): Promise<void> {
+  /**
+   * Protected (rather than private) so the v2 variant of this component can reuse it unchanged
+   * as the step 1 sideEffect - only step 0 differs between v1 and v2.
+   */
+  protected async navigateToExtensionPromptStep(): Promise<void> {
     await this.router.navigate(["/browser-extension-prompt"], {
       queryParams: { url: "AutoConfirm" },
     });
   }
+}
+
+/**
+ * Drawer (v2) variant. Reuses step 1 ("how to turn on") and all save/rollback logic from the
+ * standard component unchanged. Step 0 is replaced with a new template that:
+ * - Renders the enable control as a switch (instead of a checkbox) labeled "Enable policy".
+ * - Splits the single "I accept these risks..." checkbox out of the enable control into its own
+ *   risk-confirmation checkbox, which gates (enables/disables) the switch.
+ * - Uses a single, unconditional "Save and continue" footer button instead of the v1 footer's
+ *   conditional "Save"/"Continue" label.
+ */
+@Component({
+  selector: "auto-confirm-policy-v2-edit",
+  templateUrl: "auto-confirm-policy-v2.component.html",
+  imports: [SharedModule, SwitchComponent],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class AutoConfirmPolicyEditV2Component extends AutoConfirmPolicyEditComponent {
+  private readonly destroyRef = inject(DestroyRef);
+
+  /**
+   * Gates the enable switch: an admin must accept the security risk before they can turn the
+   * policy on. Defaults to accepted when editing an already-enabled policy, since the risk was
+   * necessarily accepted the first time it was turned on.
+   */
+  protected readonly riskAccepted = new FormControl(false, { nonNullable: true });
+
+  private readonly step0ContentV2: Signal<TemplateRef<unknown>> =
+    viewChild.required("step0ContentV2");
+  private readonly step0FooterV2: Signal<TemplateRef<unknown>> =
+    viewChild.required("step0FooterV2");
+
+  override ngOnInit(): void {
+    super.ngOnInit();
+
+    this.riskAccepted.setValue(this.enabled.value ?? false);
+
+    this.riskAccepted.valueChanges
+      .pipe(startWith(this.riskAccepted.value), takeUntilDestroyed(this.destroyRef))
+      .subscribe((accepted) => {
+        if (accepted) {
+          this.enabled.enable({ emitEvent: false });
+        } else {
+          this.enabled.disable({ emitEvent: false });
+        }
+      });
+  }
+
+  override readonly policySteps: PolicyStep[] = [
+    {
+      bodyContent: this.step0ContentV2,
+      footerContent: this.step0FooterV2,
+      disableSave: this.saveDisabled$,
+      sideEffect: () => this.savePolicy(),
+    },
+    {
+      titleContent: this.step1Title,
+      bodyContent: this.step1Content,
+      footerContent: this.step1Footer,
+      sideEffect: () => this.navigateToExtensionPromptStep(),
+    },
+  ];
 }

--- a/apps/web/src/app/admin-console/organizations/policies/policy-edit-definitions/auto-confirm-policy.component.ts
+++ b/apps/web/src/app/admin-console/organizations/policies/policy-edit-definitions/auto-confirm-policy.component.ts
@@ -234,11 +234,6 @@ export class AutoConfirmPolicyEditV2Component extends AutoConfirmPolicyEditCompo
           this.enabled.enable({ emitEvent: false });
         } else {
           this.enabled.disable({ emitEvent: false });
-          // Un-accepting risk must also turn the switch back off - otherwise its stale `true`
-          // value would still be readable via getRawValue() (buildRequest() uses .value, which a
-          // disabled control also still returns) and the policy could be saved as enabled despite
-          // the gate being visually off. emitEvent defaults to true here (unlike disable() above)
-          // so saveDisabled$, which only recomputes on enabled.valueChanges, re-evaluates too.
           this.enabled.setValue(false);
         }
       });

--- a/apps/web/src/app/admin-console/organizations/policies/policy-edit-definitions/auto-confirm-policy.component.ts
+++ b/apps/web/src/app/admin-console/organizations/policies/policy-edit-definitions/auto-confirm-policy.component.ts
@@ -234,6 +234,12 @@ export class AutoConfirmPolicyEditV2Component extends AutoConfirmPolicyEditCompo
           this.enabled.enable({ emitEvent: false });
         } else {
           this.enabled.disable({ emitEvent: false });
+          // Un-accepting risk must also turn the switch back off - otherwise its stale `true`
+          // value would still be readable via getRawValue() (buildRequest() uses .value, which a
+          // disabled control also still returns) and the policy could be saved as enabled despite
+          // the gate being visually off. emitEvent defaults to true here (unlike disable() above)
+          // so saveDisabled$, which only recomputes on enabled.valueChanges, re-evaluates too.
+          this.enabled.setValue(false);
         }
       });
   }

--- a/apps/web/src/app/admin-console/organizations/policies/policy-edit-definitions/auto-confirm-policy.component.ts
+++ b/apps/web/src/app/admin-console/organizations/policies/policy-edit-definitions/auto-confirm-policy.component.ts
@@ -38,7 +38,11 @@ export class AutoConfirmPolicy extends BasePolicyEditDefinition {
   component = AutoConfirmPolicyEditComponent;
   showDescription = false;
   editDialogComponent = MultiStepPolicyEditDialogComponent;
-  v2 = {
+  // Explicitly typed against the base class's declared `v2` shape (rather than left to be
+  // inferred from this literal) so that optional fields like `description`/`prerequisiteKey`
+  // remain valid to access - even though this policy doesn't set them - instead of TypeScript
+  // narrowing the field to only `{ component: ... }`.
+  v2: BasePolicyEditDefinition["v2"] = {
     component: AutoConfirmPolicyEditV2Component,
   };
 
@@ -208,9 +212,10 @@ export class AutoConfirmPolicyEditV2Component extends AutoConfirmPolicyEditCompo
   /**
    * Gates the enable switch: an admin must accept the security risk before they can turn the
    * policy on. Defaults to accepted when editing an already-enabled policy, since the risk was
-   * necessarily accepted the first time it was turned on.
+   * necessarily accepted the first time it was turned on. Public (matching {@link enabled}/
+   * {@link data} on the base class) so it can be exercised directly from tests.
    */
-  protected readonly riskAccepted = new FormControl(false, { nonNullable: true });
+  readonly riskAccepted = new FormControl(false, { nonNullable: true });
 
   private readonly step0ContentV2: Signal<TemplateRef<unknown>> =
     viewChild.required("step0ContentV2");

--- a/apps/web/src/app/admin-console/organizations/policies/policy-edit-dialogs/multi-step-policy-edit-dialog.component.spec.ts
+++ b/apps/web/src/app/admin-console/organizations/policies/policy-edit-dialogs/multi-step-policy-edit-dialog.component.spec.ts
@@ -9,11 +9,14 @@ import { DialogRef as CdkDialogRef } from "@angular/cdk/dialog";
 import { ChangeDetectionStrategy, Component, NO_ERRORS_SCHEMA } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { ReactiveFormsModule, UntypedFormGroup } from "@angular/forms";
+import { Router } from "@angular/router";
 import { MockProxy, mock } from "jest-mock-extended";
 import { NEVER, of } from "rxjs";
 
+import { AutomaticUserConfirmationService } from "@bitwarden/auto-confirm";
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { PolicyApiServiceAbstraction } from "@bitwarden/common/admin-console/abstractions/policy/policy-api.service.abstraction";
+import { PolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
 import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
 import { PolicyResponse } from "@bitwarden/common/admin-console/models/response/policy.response";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
@@ -26,6 +29,11 @@ import { DIALOG_DATA, DialogRef, DialogService, ToastService } from "@bitwarden/
 import { KeyService } from "@bitwarden/key-management";
 
 import { BasePolicyEditComponent, BasePolicyEditDefinition } from "../base-policy-edit.component";
+import {
+  AutoConfirmPolicy,
+  AutoConfirmPolicyEditComponent,
+  AutoConfirmPolicyEditV2Component,
+} from "../policy-edit-definitions/auto-confirm-policy.component";
 import { MasterPasswordPolicyV2Component } from "../policy-edit-definitions/master-password-v2.component";
 import {
   MasterPasswordPolicy,
@@ -422,6 +430,12 @@ describe("MultiStepPolicyEditDialogComponent", () => {
       configService.getFeatureFlag$.mockReturnValue(of(isDrawer));
       const authService = mock<AuthService>();
       authService.authStatusFor$.mockReturnValue(of(AuthenticationStatus.Unlocked));
+      const policyService = mock<PolicyService>();
+      policyService.policies$.mockReturnValue(of([]));
+      const router = mock<Router>();
+      // DrawerService reads router.url synchronously at construction time.
+      (router as any).url = "/";
+      (router as any).events = NEVER;
 
       TestBed.resetTestingModule();
       await TestBed.configureTestingModule({
@@ -440,6 +454,14 @@ describe("MultiStepPolicyEditDialogComponent", () => {
           { provide: CdkDialogRef, useValue: { backdropClick: NEVER, keydownEvents: NEVER } },
           { provide: ConfigService, useValue: configService },
           { provide: EncryptService, useValue: mock<EncryptService>() },
+          // Only AutoConfirmPolicy's component injects these, but providing them unconditionally
+          // is harmless for every other policy rendered through this same helper.
+          { provide: PolicyService, useValue: policyService },
+          {
+            provide: AutomaticUserConfirmationService,
+            useValue: mock<AutomaticUserConfirmationService>(),
+          },
+          { provide: Router, useValue: router },
         ],
         schemas: [NO_ERRORS_SCHEMA],
       }).compileComponents();
@@ -506,6 +528,37 @@ describe("MultiStepPolicyEditDialogComponent", () => {
         );
         expect(component.dialogTitle()).toBe("centralizeDataOwnership");
         expect(fixture.nativeElement.querySelector("[bitBadge]")).not.toBeNull();
+      });
+    });
+
+    describe("AutoConfirmPolicy", () => {
+      // Regression test: AutoConfirmPolicyEditV2Component previously threw NG0951 ("Child query
+      // result is required but no value is available") when advancing to step 1, because its
+      // template didn't declare the #step1Title/#step1Content/#step1Footer refs that the
+      // inherited viewChild.required(...) queries (declared on the v1 base class, but resolved
+      // against whichever concrete component's view is actually rendered) require.
+      it("renders the v1 component, no badge, and can render both steps when the flag is off (modal)", async () => {
+        const { fixture, component } = await setupRealPolicy(new AutoConfirmPolicy(), false);
+
+        expect(component.policyComponent()).toBeInstanceOf(AutoConfirmPolicyEditComponent);
+        expect(component.policyComponent()).not.toBeInstanceOf(AutoConfirmPolicyEditV2Component);
+        expect(fixture.nativeElement.querySelector("[bitBadge]")).toBeNull();
+
+        component.currentStep.set(1);
+        expect(() => fixture.detectChanges()).not.toThrow();
+      });
+
+      it("renders the v2 component, a badge, and can render both steps when the flag is on (drawer)", async () => {
+        const { fixture, component } = await setupRealPolicy(new AutoConfirmPolicy(), true);
+
+        expect(component.policyComponent()).toBeInstanceOf(AutoConfirmPolicyEditV2Component);
+        expect(component.dialogTitle()).toBe("automaticUserConfirmation");
+        expect(fixture.nativeElement.querySelector("[bitBadge]")).not.toBeNull();
+
+        component.currentStep.set(1);
+        expect(() => fixture.detectChanges()).not.toThrow();
+        // Step 1's own titleContent takes over from the generic dialogTitle() once rendered.
+        expect(component.dialogTitle()).toBeUndefined();
       });
     });
   });

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -989,6 +989,9 @@
   "save": {
     "message": "Save"
   },
+  "saveAndContinue": {
+    "message": "Save and continue"
+  },
   "cancel": {
     "message": "Cancel"
   },


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-38519

## 📔 Objective

Update AutoConfirmPolicy to V2 for drawer usage

## 📸 Screenshots

<img width="1380" height="903" alt="image" src="https://github.com/user-attachments/assets/89390537-e739-41ca-8489-d6ef0c3a82b5" />

