### PR TITLE
[PM-40195] feat: add shared-folder localization keys

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -1480,6 +1480,18 @@
   "shared": {
     "message": "Shared"
   },
+  "sharedFolder": {
+    "message": "Shared folder"
+  },
+  "sharedFolders": {
+    "message": "Shared folders"
+  },
+  "myFolder": {
+    "message": "My folder"
+  },
+  "myFolders": {
+    "message": "My folders"
+  },
   "bitwardenForBusinessPageDesc": {
     "message": "Bitwarden for Business allows you to share your vault items with others by using an organization. Learn more on the bitwarden.com website."
   },

--- a/apps/cli/src/locales/en/messages.json
+++ b/apps/cli/src/locales/en/messages.json
@@ -14,6 +14,18 @@
   "noneFolder": {
     "message": "No Folder"
   },
+  "sharedFolder": {
+    "message": "Shared folder"
+  },
+  "sharedFolders": {
+    "message": "Shared folders"
+  },
+  "myFolder": {
+    "message": "My folder"
+  },
+  "myFolders": {
+    "message": "My folders"
+  },
   "importEncKeyError": {
     "message": "Error decrypting the exported file. Your encryption key does not match the encryption key used export the data."
   },

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -104,6 +104,18 @@
   "shared": {
     "message": "Shared"
   },
+  "sharedFolder": {
+    "message": "Shared folder"
+  },
+  "sharedFolders": {
+    "message": "Shared folders"
+  },
+  "myFolder": {
+    "message": "My folder"
+  },
+  "myFolders": {
+    "message": "My folders"
+  },
   "share": {
     "message": "Share"
   },

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -1191,6 +1191,18 @@
   "shared": {
     "message": "Shared"
   },
+  "sharedFolder": {
+    "message": "Shared folder"
+  },
+  "sharedFolders": {
+    "message": "Shared folders"
+  },
+  "myFolder": {
+    "message": "My folder"
+  },
+  "myFolders": {
+    "message": "My folders"
+  },
   "attachments": {
     "message": "Attachments"
   },


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-40195

## 📔 Objective

Adds the base English localization keys for the collections → shared-folders terminology migration (PM-39699, tasks.md Task 4). Four keys are added to each client's `en/messages.json`:

| Key | Message |
| --- | --- |
| `sharedFolder` | Shared folder |
| `sharedFolders` | Shared folders |
| `myFolder` | My folder |
| `myFolders` | My folders |

Files:
- `apps/web/src/locales/en/messages.json`
- `apps/browser/src/_locales/en/messages.json`
- `apps/desktop/src/locales/en/messages.json`
- `apps/cli/src/locales/en/messages.json`

Scope is limited to these base keys per the ticket's acceptance criteria and Tech Breakdown diff. Existing `collection*`/`folder*` keys are left intact for rollback. Vault-surface contextual variants land with the component-migration tickets this one blocks (PM-40165, PM-40252/53/54); Admin Console–specific keys are added by the Admin Console team in their own breakdown.

## 📸 Screenshots

<!-- Not applicable — no UI changes; only additive locale keys. -->