### PR TITLE
[PM-40345] Ignore Storybook stories in code coverage

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,5 +1,6 @@
 ignore:
   - "**/*.spec.ts" # Tests
+  - "**/*.stories.ts" # Storybook stories
 
 component_management:
   default_rules:


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-40345

## 📔 Objective

Storybook story files (`*.stories.ts`) are not test targets, but Codecov currently counts them as uncovered source, which drags down coverage numbers and adds noise to coverage diffs on PRs.

This adds `**/*.stories.ts` to the `ignore` list in `.github/codecov.yml`, alongside the existing `**/*.spec.ts` entry, so story files are excluded from coverage reporting. This covers all 157 story files in the repo (all use the `.stories.ts` extension).

## 📸 Screenshots

N/A — no UI changes.