### PR TITLE
[PM-40188] Apply deletion date policy to CLI-created Sends

### DIFF
--- a/apps/cli/src/tools/send/commands/create.command.spec.ts
+++ b/apps/cli/src/tools/send/commands/create.command.spec.ts
@@ -4,11 +4,14 @@ import { mock } from "jest-mock-extended";
 import { of } from "rxjs";
 
 import { PolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
+import { PolicyType } from "@bitwarden/common/admin-console/enums";
+import { Policy } from "@bitwarden/common/admin-console/models/domain/policy";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { BillingAccountProfileStateService } from "@bitwarden/common/billing/abstractions/account/billing-account-profile-state.service";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { EnvironmentService } from "@bitwarden/common/platform/abstractions/environment.service";
 import { mockAccountInfoWith } from "@bitwarden/common/spec";
+import { WhoCanAccessType } from "@bitwarden/common/tools/models/send-who-can-access-type";
 import { SendApiService } from "@bitwarden/common/tools/send/services/send-api.service.abstraction";
 import { SendService } from "@bitwarden/common/tools/send/services/send.service.abstraction";
 import { AuthType } from "@bitwarden/common/tools/send/types/auth-type";
@@ -389,6 +392,112 @@ describe("SendCreateCommand", () => {
         const savedCall = sendApiService.save.mock.calls[0][0];
         expect(savedCall[0].authType).toBe(AuthType.None);
       });
+    });
+  });
+
+  it("with SendControls feature flag OFF, policy enforcement function is not called", async () => {
+    policyService.policiesByType$.mockReturnValue(of([]));
+
+    const requestJson = {
+      type: SendType.Text,
+      text: { text: "Test Send", hidden: false },
+      deletionDate: new Date(Date.now() + 24 * 60 * 60 * 1000),
+    };
+
+    sendService.encrypt.mockImplementation(async (sendView, _file, _password) => [
+      sendView as any,
+      null as any,
+    ]);
+    sendApiService.save.mockResolvedValue(undefined as any);
+    sendService.getFromState.mockResolvedValue({
+      decrypt: jest.fn().mockResolvedValue({}),
+    } as any);
+
+    const response = await command.run(requestJson, {});
+    expect(response.success).toEqual(true);
+    expect(policyService.policiesByType$).not.toHaveBeenCalled();
+  });
+
+  describe("with SendControls feature flag ON", () => {
+    it("enforces whoCanAccess with SpecificPeople and domains", async () => {
+      // Turn on the SendControls policy feature flag and mock the policy
+      configService.getFeatureFlag.mockResolvedValue(true);
+      policyService.policiesByType$.mockReturnValue(
+        of([
+          {
+            type: PolicyType.SendControls,
+            data: {
+              whoCanAccess: WhoCanAccessType.SpecificPeople,
+              allowedDomains: "bitwarden.com",
+            },
+          } as any as Policy,
+        ]),
+      );
+
+      const requestJson = {
+        type: SendType.Text,
+        text: { text: "Test Send", hidden: false },
+        deletionDate: new Date(Date.now() + 24 * 60 * 60 * 1000),
+        authType: AuthType.Email,
+        emails: ["user@badguys.com"],
+      };
+
+      sendService.encrypt.mockImplementation(async (sendView, _file, _password) => [
+        sendView as any,
+        null as any,
+      ]);
+      sendApiService.save.mockResolvedValue(undefined as any);
+      sendService.getFromState.mockResolvedValue({
+        decrypt: jest.fn().mockResolvedValue({}),
+      } as any);
+
+      const response = await command.run(requestJson, {});
+      expect(response.success).toEqual(false);
+      expect(response.message).toEqual(
+        "Organization policy restricts email domains. The following emails are not allowed: user@badguys.com. Allowed domains: bitwarden.com.",
+      );
+    });
+
+    it("enforces deletionHours from policy over user command input", async () => {
+      // Turn on the SendControls policy feature flag and mock the policy
+      configService.getFeatureFlag.mockResolvedValue(true);
+      policyService.policiesByType$.mockReturnValue(
+        of([
+          {
+            type: PolicyType.SendControls,
+            data: {
+              deletionHours: 24,
+            },
+          } as any as Policy,
+        ]),
+      );
+
+      const threeDaysFromNow = new Date(Date.now() + 3 * 24 * 60 * 60 * 1000);
+      const requestJson = {
+        type: SendType.Text,
+        text: { text: "Test Send", hidden: false },
+        deletionDate: threeDaysFromNow,
+      };
+      const cmdOptions = {
+        deleteInDays: 3,
+      };
+
+      sendService.encrypt.mockImplementation(async (sendView, _file, _password) => [
+        sendView as any,
+        null as any,
+      ]);
+      sendApiService.save.mockResolvedValue(undefined as any);
+      sendService.getFromState.mockResolvedValue({
+        decrypt: jest.fn().mockResolvedValue({}),
+      } as any);
+
+      const response = await command.run(requestJson, cmdOptions);
+      expect(response.success).toEqual(true);
+      const savedSendView = sendService.encrypt.mock.calls[0][0];
+      // We expect the deletion date to have been set to 24 hours from now, plus or minus a minute for clock skew
+      expect(
+        Math.abs(savedSendView.deletionDate.getTime() - 24 * 60 * 60 * 1000 - Date.now()),
+      ).toBeLessThan(60 * 1000);
     });
   });
 });

--- a/apps/cli/src/tools/send/commands/create.command.ts
+++ b/apps/cli/src/tools/send/commands/create.command.ts
@@ -109,7 +109,7 @@ export class SendCreateCommand {
       req.authType = AuthType.None;
     }
 
-    const policyError = await this.enforceSendPolicy(req.authType, emails);
+    const policyError = await this.enforceSendPolicy(req);
     if (policyError) {
       return policyError;
     }
@@ -176,10 +176,7 @@ export class SendCreateCommand {
     }
   }
 
-  private async enforceSendPolicy(
-    authType: AuthType,
-    emails: string[] | undefined,
-  ): Promise<Response | null> {
+  private async enforceSendPolicy(req: SendResponse): Promise<Response | null> {
     const sendControlsEnabled = await this.configService.getFeatureFlag(FeatureFlag.SendControls);
     if (!sendControlsEnabled) {
       return null;
@@ -189,20 +186,18 @@ export class SendCreateCommand {
     const policies = await firstValueFrom(
       this.policyService.policiesByType$(PolicyType.SendControls, userId),
     );
-    const policy = policies?.find((p) => p.data?.whoCanAccess != null);
-    if (!policy) {
-      return null;
-    }
-    const policyData: SendControlsPolicyData = policy.data;
 
-    if (policyData.whoCanAccess === WhoCanAccessType.SpecificPeople) {
-      if (authType !== AuthType.Email || !emails?.length) {
+    const whoCanAccessPolicyData = policies.find((p) => p.data?.whoCanAccess != null)?.data as
+      | SendControlsPolicyData
+      | undefined;
+    if (whoCanAccessPolicyData?.whoCanAccess === WhoCanAccessType.SpecificPeople) {
+      if (req.authType !== AuthType.Email || !req.emails?.length) {
         return Response.error(
           "Organization policy requires Send access to be restricted to specific people. Use --emails to specify recipients.",
         );
       }
 
-      const rawDomains = policyData.allowedDomains;
+      const rawDomains = whoCanAccessPolicyData?.allowedDomains;
       if (rawDomains) {
         const allowedDomains = rawDomains
           .split(",")
@@ -210,7 +205,7 @@ export class SendCreateCommand {
           .filter((d: string) => d.length > 0);
 
         if (allowedDomains.length > 0) {
-          const disallowed = emails.filter((email) => {
+          const disallowed = req.emails.filter((email) => {
             const domain = email.split("@")[1]?.toLowerCase();
             return !allowedDomains.includes(domain);
           });
@@ -221,12 +216,25 @@ export class SendCreateCommand {
           }
         }
       }
-    } else if (policyData.whoCanAccess === WhoCanAccessType.PasswordProtected) {
-      if (authType !== AuthType.Password) {
+    } else if (whoCanAccessPolicyData?.whoCanAccess === WhoCanAccessType.PasswordProtected) {
+      if (req.authType !== AuthType.Password) {
         return Response.error(
           "Organization policy requires Send access to be password protected. Use --password to set a password.",
         );
       }
+    }
+    // If org policy specifies a deletion date we comply with it, overriding what
+    // the user has specified. This matches the UI behavior, where users are
+    // barred from using other deletion dates when one is mandated by org policy.
+    const deletionDatePolicyData = policies.find((p) => p.data?.deletionHours)?.data as
+      | SendControlsPolicyData
+      | undefined;
+    if (deletionDatePolicyData?.deletionHours != null) {
+      const policyCompliantDeletionDate = new Date();
+      policyCompliantDeletionDate.setTime(
+        policyCompliantDeletionDate.getTime() + deletionDatePolicyData.deletionHours * 3600000, // ms per hour
+      );
+      req.deletionDate = policyCompliantDeletionDate;
     }
 
     return null;

--- a/apps/cli/src/tools/send/send.program.ts
+++ b/apps/cli/src/tools/send/send.program.ts
@@ -46,7 +46,7 @@ export class SendProgram extends BaseProgram {
       .option("-f, --file", "Specifies that <data> is a filepath")
       .option(
         "-d, --deleteInDays <days>",
-        "The number of days in the future to set deletion date, defaults to 7",
+        "The number of days in the future to set deletion date, defaults to 7. If a particular deletion date is mandated by enterprise policy that value will override this flag.",
         "7",
       )
       .addOption(


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-40188

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR implements policy enforcement for the deletion days portion of the new Manage Send policy in the CLI. It'd be preferable to do this in the SDK but policy enforcement there is waiting on work from AC. The deletion date policy will override what the user specifies in their command input, or the default value of 7 if the input doesn't specify, which matches what the web client does.