### PR TITLE
[PM-40377] Fix bug with form field to have textarea behave the same as an input when disabled

### DIFF
--- a/libs/components/src/form-field/field-container.directive.ts
+++ b/libs/components/src/form-field/field-container.directive.ts
@@ -26,7 +26,7 @@ export class BitFieldContainerDirective {
       "tw-border-border-strong",
       "tw-bg-bg-secondary",
       "tw-placeholder-fg-body-subtle",
-      "has-[input:disabled]:tw-border-border-base",
+      "has-[:is(input,textarea):disabled]:tw-border-border-base",
       "tw-transition-colors",
       "has-[:focus-visible]:tw-border-border-brand",
       "has-[.tw-test-focus-visible]:tw-border-border-brand",
@@ -68,8 +68,8 @@ export class BitFieldContainerDirective {
             "has-[.tw-test-focus-visible]:!tw-ring-border-focus",
           ]
         : [
-            "[&:not(:has(:focus-visible)):not(:has(input:disabled)):hover]:tw-bg-bg-quaternary",
-            "[&:not(:has(:focus-visible)):not(:has(.tw-test-focus-visible)):not(:has(input:disabled)).tw-test-hover]:tw-bg-bg-quaternary",
+            "[&:not(:has(:focus-visible)):not(:has(:is(input,textarea):disabled)):hover]:tw-bg-bg-quaternary",
+            "[&:not(:has(:focus-visible)):not(:has(.tw-test-focus-visible)):not(:has(:is(input,textarea):disabled)).tw-test-hover]:tw-bg-bg-quaternary",
           ]),
     ].join(" ");
   });

--- a/libs/components/src/form-field/form-field.component.ts
+++ b/libs/components/src/form-field/form-field.component.ts
@@ -52,7 +52,7 @@ export class BitFormFieldComponent implements AfterContentChecked {
     return [
       "tw-flex",
       "tw-flex-col",
-      "has-[input:disabled]:!tw-text-fg-inactive",
+      "has-[:is(input,textarea):disabled]:!tw-text-fg-inactive",
       "[&_bit-hint]:tw-m-0",
       "[&_bit-error]:tw-m-0",
       ...(this.readOnly ? [] : ["tw-gap-2"]),


### PR DESCRIPTION
## 🎟️ Tracking

[Jira](https://bitwarden.atlassian.net/browse/PM-40377)

## 📔 Objective

`textarea` fields were not displaying correctly when disabled, this updates it to behave the same as an `input` field

## 📸 Screenshots

Before:
<img width="513" height="793" alt="Screenshot 2026-07-14 at 9 24 59 AM" src="https://github.com/user-attachments/assets/ae87baba-454e-47f2-979a-5239fe359a83" />

After:
<img width="513" height="793" alt="Screenshot 2026-07-14 at 9 24 16 AM" src="https://github.com/user-attachments/assets/a80d92d1-626d-452c-9558-3b7e06f6192d" />
