### PR TITLE
[CL-1277] Add disabled and readonly variants to Textarea story

### DIFF
--- a/libs/components/src/form-field/form-field.stories.ts
+++ b/libs/components/src/form-field/form-field.stories.ts
@@ -582,8 +582,21 @@ export const Textarea: Story = {
     template: /*html*/ `
       <bit-form-field>
         <bit-label>Textarea</bit-label>
-        <textarea bitInput rows="4"></textarea>
+        <textarea bitInput rows="4">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</textarea>
         <button type="button" bitSuffix bitIconButton="bwi-clone" label="Clone Label"></button>
+        <bit-hint>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</bit-hint>
+      </bit-form-field>
+      <bit-form-field>
+        <bit-label>Textarea disabled</bit-label>
+        <textarea bitInput rows="4" disabled>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</textarea>
+        <button type="button" bitSuffix bitIconButton="bwi-clone" label="Clone Label"></button>
+        <bit-hint>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</bit-hint>
+      </bit-form-field>
+      <bit-form-field>
+        <bit-label>Textarea readonly</bit-label>
+        <textarea bitInput rows="4" readonly>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</textarea>
+        <button type="button" bitSuffix bitIconButton="bwi-clone" label="Clone Label"></button>
+        <bit-hint>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</bit-hint>
       </bit-form-field>
     `,
   }),


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/CL-1277

## 📔 Objective

Expands the `Textarea` story in `form-field.stories.ts` to cover more states. Previously the story only showed a single empty, enabled textarea. It now renders three variants — default, `disabled`, and `readonly` — each with initial text, a copy (`bwi-clone`) suffix button, and hint text.

This makes it easier to visually verify textarea styling across states in the component library (notably the disabled-state styling on the form-field chrome).

To be merged before https://github.com/bitwarden/clients/pull/21848 (TDD)

## 📸 Screenshots

<!-- Storybook: Component Library / Form / Field → Textarea -->
