### PR TITLE
desktop-autofill: Move macOS-specific window position to macOS code

### DIFF
--- a/apps/desktop/macos/autofill-extension/CredentialProviderViewController.swift
+++ b/apps/desktop/macos/autofill-extension/CredentialProviderViewController.swift
@@ -199,6 +199,7 @@ class CredentialProviderViewController: ASCredentialProviderViewController {
             attempts += 1
         }
 
+        let x, y: Int32
         let finalWindowFrame = self.view.window?.frame ?? .zero
         logger.log("[autofill-extension] position: Final window frame: \(NSStringFromRect(finalWindowFrame))")
 
@@ -207,15 +208,19 @@ class CredentialProviderViewController: ASCredentialProviderViewController {
             let centerX = Int32(round(finalWindowFrame.origin.x))
             let centerY = Int32(round(screenHeight - finalWindowFrame.origin.y))
             logger.log("[autofill-extension] position: Using window position: x=\(centerX), y=\(centerY)")
-            return WindowDetails(position: Position(x: centerX, y: centerY), handle: nil)
+            x = centerX
+            y = centerY
         } else {
             // Fallback to mouse position
             let mouseLocation = NSEvent.mouseLocation
             let mouseX = Int32(round(mouseLocation.x))
             let mouseY = Int32(round(screenHeight - mouseLocation.y))
             logger.log("[autofill-extension] position: Using mouse position fallback: x=\(mouseX), y=\(mouseY)")
-            return WindowDetails(position: Position(x: mouseX, y: mouseY), handle: nil)
+            x = mouseX
+            y = mouseY
         }
+        // Add 100 pixels to the x-coordinate to offset the native OS dialog positioning.
+        return WindowDetails(position: Position(x: x + 100, y: y), handle: nil)
     }
 
     override func viewDidLoad() {

--- a/apps/desktop/src/autofill/services/desktop-autofill.service.ts
+++ b/apps/desktop/src/autofill/services/desktop-autofill.service.ts
@@ -228,7 +228,7 @@ export class DesktopAutofillService implements OnDestroy {
 
     const response = await this.fido2AuthenticatorService.makeCredential(
       this.convertRegistrationRequest(request),
-      { windowXy: normalizePosition(request.clientWindow.position) },
+      { windowXy: request.clientWindow.position },
       controller,
     );
     return this.convertRegistrationResponse(request, response);
@@ -241,7 +241,7 @@ export class DesktopAutofillService implements OnDestroy {
 
     const response = await this.fido2AuthenticatorService.getAssertion(
       this.convertAssertionRequest(request, assumeUserPresence),
-      { windowXy: normalizePosition(request.clientWindow.position) },
+      { windowXy: request.clientWindow.position },
       controller,
     );
 
@@ -257,7 +257,7 @@ export class DesktopAutofillService implements OnDestroy {
 
     const response = await this.fido2AuthenticatorService.getAssertion(
       this.convertAssertionRequest(request, assumeUserPresence),
-      { windowXy: normalizePosition(request.clientWindow.position) },
+      { windowXy: request.clientWindow.position },
       controller,
     );
 
@@ -471,14 +471,4 @@ export class DesktopAutofillService implements OnDestroy {
     this.destroy$.next();
     this.destroy$.complete();
   }
-}
-
-function normalizePosition(position: { x: number; y: number }): { x: number; y: number } {
-  // Add 100 pixels to the x-coordinate to offset the native OS dialog positioning.
-  const xPositionOffset = 100;
-
-  return {
-    x: Math.round(position.x + xPositionOffset),
-    y: Math.round(position.y),
-  };
 }


### PR DESCRIPTION
## 📔 Objective

This code is specific to macOS, so we should move it into the macOS extension rather than the shared TypeScript service.