### PR TITLE
[PM-40381] Desktop Autofill Cancellation

### DIFF
--- a/apps/desktop/desktop_native/autofill_provider/src/lib.rs
+++ b/apps/desktop/desktop_native/autofill_provider/src/lib.rs
@@ -166,6 +166,7 @@ pub struct ExtensionRequestMessage {
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(tag = "request", content = "params", rename_all = "camelCase")]
 pub enum ExtensionRequest {
+    CancelRequest(String),
     LockStatus,
     NativeStatus(NativeStatus),
     PasskeyAssertion(PasskeyAssertionRequest),
@@ -385,6 +386,14 @@ impl AutofillProviderClient {
     pub fn send_native_status(&self, key: String, value: String) {
         let status = NativeStatus { key, value };
         self.send_request(ExtensionRequest::NativeStatus(status), None);
+    }
+
+    /// Cancel a request.
+    ///
+    /// The `context` parameter should be the same as the `context`
+    /// field from the original request.
+    pub fn cancel_request(&self, context: String) {
+        self.send_request(ExtensionRequest::CancelRequest(context), None);
     }
 
     /// Send a request to create a new passkey to the desktop client.

--- a/apps/desktop/desktop_native/napi/src/autofill.rs
+++ b/apps/desktop/desktop_native/napi/src/autofill.rs
@@ -141,6 +141,13 @@ pub mod autofill {
                                     }
                                 };
                             match msg.request {
+                                ExtensionRequest::CancelRequest(context) => {
+                                    let params = (client_id, msg.sequence_number, context);
+                                    callbacks.cancel_request_callback.call(
+                                        Ok(params.into()),
+                                        ThreadsafeFunctionCallMode::NonBlocking,
+                                    );
+                                }
                                 ExtensionRequest::LockStatus => {
                                     let params = (client_id, msg.sequence_number);
                                     callbacks.lock_status_callback.call(

--- a/apps/desktop/desktop_native/windows_plugin_authenticator/src/authenticator.rs
+++ b/apps/desktop/desktop_native/windows_plugin_authenticator/src/authenticator.rs
@@ -202,7 +202,7 @@ impl<C: IpcConnector> PluginAuthenticator for BitwardenPluginAuthenticator<C> {
             let client = self.get_client()?;
             let context = create_context_string(transaction_id, request.operation_request_hash());
             tracing::debug!("Sending cancel operation for context: {context}");
-            client.send_native_status("cancel-operation".to_string(), context);
+            client.cancel_request(context);
         }
         Ok(())
     }
@@ -371,6 +371,13 @@ mod tests {
 
         fn send_native_status(&self, key: String, value: String) {
             self.sent.lock().unwrap().push((key, value));
+        }
+
+        fn cancel_request(&self, context: String) {
+            self.sent
+                .lock()
+                .unwrap()
+                .push(("cancel-operation".to_string(), context));
         }
 
         fn prepare_passkey_registration(

--- a/apps/desktop/desktop_native/windows_plugin_authenticator/src/ipc.rs
+++ b/apps/desktop/desktop_native/windows_plugin_authenticator/src/ipc.rs
@@ -24,7 +24,11 @@ pub(crate) trait IpcClient: Send + Sync {
     /// response arrives or `timeout` elapses.
     fn get_window_handle(&self, timeout: Duration) -> Result<WindowHandleQueryResponse, String>;
 
+    /// Request that the provider sync its credentials to the OS autofill store.
     fn send_native_status(&self, key: String, value: String);
+
+    /// Cancel an ongoing request.
+    fn cancel_request(&self, context: String);
 
     fn prepare_passkey_registration(
         &self,
@@ -77,6 +81,10 @@ impl IpcClient for RealIpcClient {
 
     fn send_native_status(&self, key: String, value: String) {
         self.0.send_native_status(key, value)
+    }
+
+    fn cancel_request(&self, context: String) {
+        self.0.cancel_request(context)
     }
 
     fn prepare_passkey_registration(

--- a/apps/desktop/macos/autofill-extension/CredentialProviderViewController.swift
+++ b/apps/desktop/macos/autofill-extension/CredentialProviderViewController.swift
@@ -21,6 +21,40 @@ class CredentialProviderViewController: ASCredentialProviderViewController {
     private var connectionMonitorTimer: Timer?
     private var lastConnectionStatus: ConnectionStatus = .disconnected
 
+    // Correlation ID for the request currently being handled by the desktop app,
+    // if any. Used to cancel that request when this view controller is torn down
+    // before the request completes (e.g. the user dismisses the system UI).
+    // Guarded by `requestLock` because host callbacks fire on foreign threads
+    // while the view lifecycle runs on the main thread.
+    private let requestLock = NSLock()
+    private var inFlightRequestContext: String?
+
+    // Records that a request has been sent to the desktop app so that teardown
+    // can cancel it if it hasn't completed yet.
+    private func beginRequest(_ context: String) {
+        requestLock.lock()
+        inFlightRequestContext = context
+        requestLock.unlock()
+    }
+
+    // Marks the in-flight request as finished so teardown won't cancel it.
+    // Called from the completion/error callbacks.
+    private func finishRequest() {
+        requestLock.lock()
+        inFlightRequestContext = nil
+        requestLock.unlock()
+    }
+
+    // Atomically clears and returns the in-flight context, if any, so that the
+    // caller can cancel it exactly once.
+    private func takeInFlightContext() -> String? {
+        requestLock.lock()
+        defer { requestLock.unlock() }
+        let context = inFlightRequestContext
+        inFlightRequestContext = nil
+        return context
+    }
+
     // We changed the getClient method to be async, here's why:
     // This is so that we can check if the app is running, and launch it, without blocking the main thread
     // Blocking the main thread caused MacOS layouting to 'fail' or at least be very delayed, which caused our getWindowPositioning code to sent 0,0.
@@ -230,6 +264,22 @@ class CredentialProviderViewController: ASCredentialProviderViewController {
         self.view.isHidden = true
     }
 
+    // Notify the desktop app that an unfinished request should be cancelled. `takeInFlightContext()` returns
+    // nil once a request has completed, so normal completion doesn't cancel.
+    //
+    // This method is called after `completeRequest` or `cancelRequest`, or if
+    // the system UI is torn down when the user dismisses the sheet. Because of
+    // that, this should be called at every terminal point in the extension's
+    // flow.
+    override func viewWillDisappear() {
+        super.viewWillDisappear()
+
+        if let context = takeInFlightContext() {
+            logger.log("[autofill-extension] View disappearing with in-flight request, cancelling \(context)")
+            self.client?.cancelRequest(context: context)
+        }
+    }
+
     override func prepareInterfaceForExtensionConfiguration() {
         // Show the configuration UI
         self.view.isHidden = false
@@ -277,13 +327,16 @@ class CredentialProviderViewController: ASCredentialProviderViewController {
                     let ctx: ASCredentialProviderExtensionContext
                     let logger: Logger
                     let timeoutTimer: DispatchWorkItem
-                    required init(_ ctx: ASCredentialProviderExtensionContext,_ logger: Logger, _ timeoutTimer: DispatchWorkItem) {
+                    let onFinish: () -> Void
+                    required init(_ ctx: ASCredentialProviderExtensionContext,_ logger: Logger, _ timeoutTimer: DispatchWorkItem, _ onFinish: @escaping () -> Void) {
                         self.ctx = ctx
                         self.logger = logger
                         self.timeoutTimer = timeoutTimer
+                        self.onFinish = onFinish
                     }
 
                     func onComplete(credential: PasskeyAssertionResponse) {
+                        self.onFinish()
                         self.timeoutTimer.cancel()
                         ctx.completeAssertionRequest(using: ASPasskeyAssertionCredential(
                             userHandle: credential.userHandle,
@@ -296,6 +349,7 @@ class CredentialProviderViewController: ASCredentialProviderViewController {
                     }
 
                     func onError(error: BitwardenError) {
+                        self.onFinish()
                         logger.error("[autofill-extension] OnError called, cancelling the request \(error)")
                         self.timeoutTimer.cancel()
                         ctx.cancelRequest(withError: error)
@@ -330,7 +384,8 @@ class CredentialProviderViewController: ASCredentialProviderViewController {
                     )
 
                     let client = await getClient()
-                    client.preparePasskeyAssertionWithoutUserInterface(request: req, callback: CallbackImpl(self.extensionContext, self.logger, timeoutTimer))
+                    self.beginRequest(context)
+                    client.preparePasskeyAssertionWithoutUserInterface(request: req, callback: CallbackImpl(self.extensionContext, self.logger, timeoutTimer, { [weak self] in self?.finishRequest() }))
                 }
                 return
             }
@@ -369,14 +424,17 @@ class CredentialProviderViewController: ASCredentialProviderViewController {
                     let ctx: ASCredentialProviderExtensionContext
                     let timeoutTimer: DispatchWorkItem
                     let logger: Logger
+                    let onFinish: () -> Void
 
-                    required init(_ ctx: ASCredentialProviderExtensionContext, _ logger: Logger,_ timeoutTimer: DispatchWorkItem) {
+                    required init(_ ctx: ASCredentialProviderExtensionContext, _ logger: Logger,_ timeoutTimer: DispatchWorkItem, _ onFinish: @escaping () -> Void) {
                         self.ctx = ctx
                         self.logger = logger
                         self.timeoutTimer = timeoutTimer
+                        self.onFinish = onFinish
                     }
 
                     func onComplete(credential: PasskeyRegistrationResponse) {
+                        self.onFinish()
                         self.timeoutTimer.cancel()
                         ctx.completeRegistrationRequest(using: ASPasskeyRegistrationCredential(
                             relyingParty: credential.rpId,
@@ -387,6 +445,7 @@ class CredentialProviderViewController: ASCredentialProviderViewController {
                     }
 
                     func onError(error: BitwardenError) {
+                        self.onFinish()
                         logger.error("[autofill-extension] OnError called, cancelling the request \(error)")
                         self.timeoutTimer.cancel()
                         ctx.cancelRequest(withError: error)
@@ -428,7 +487,8 @@ class CredentialProviderViewController: ASCredentialProviderViewController {
                     )
 
                     let client = await getClient()
-                    client.preparePasskeyRegistration(request: req, callback: CallbackImpl(self.extensionContext, self.logger, timeoutTimer))
+                    self.beginRequest(context)
+                    client.preparePasskeyRegistration(request: req, callback: CallbackImpl(self.extensionContext, self.logger, timeoutTimer, { [weak self] in self?.finishRequest() }))
                 }
                 return
             }
@@ -448,13 +508,16 @@ class CredentialProviderViewController: ASCredentialProviderViewController {
             let ctx: ASCredentialProviderExtensionContext
             let timeoutTimer: DispatchWorkItem
             let logger: Logger
-            required init(_ ctx: ASCredentialProviderExtensionContext,_ logger: Logger, _ timeoutTimer: DispatchWorkItem) {
+            let onFinish: () -> Void
+            required init(_ ctx: ASCredentialProviderExtensionContext,_ logger: Logger, _ timeoutTimer: DispatchWorkItem, _ onFinish: @escaping () -> Void) {
                 self.ctx = ctx
                 self.logger = logger
                 self.timeoutTimer = timeoutTimer
+                self.onFinish = onFinish
             }
 
             func onComplete(credential: PasskeyAssertionResponse) {
+                self.onFinish()
                 self.timeoutTimer.cancel()
                 ctx.completeAssertionRequest(using: ASPasskeyAssertionCredential(
                     userHandle: credential.userHandle,
@@ -467,6 +530,7 @@ class CredentialProviderViewController: ASCredentialProviderViewController {
             }
 
             func onError(error: BitwardenError) {
+                self.onFinish()
                 logger.error("[autofill-extension] OnError called, cancelling the request \(error)")
                 self.timeoutTimer.cancel()
                 ctx.cancelRequest(withError: error)
@@ -497,7 +561,8 @@ class CredentialProviderViewController: ASCredentialProviderViewController {
             )
 
             let client = await getClient()
-            client.preparePasskeyAssertion(request: req, callback: CallbackImpl(self.extensionContext, self.logger, timeoutTimer))
+            self.beginRequest(context)
+            client.preparePasskeyAssertion(request: req, callback: CallbackImpl(self.extensionContext, self.logger, timeoutTimer, { [weak self] in self?.finishRequest() }))
         }
         return
     }

--- a/apps/desktop/src/autofill/desktop-autofill.preload.ts
+++ b/apps/desktop/src/autofill/desktop-autofill.preload.ts
@@ -20,6 +20,8 @@ export const DesktopAutofillPreload = {
 
   listenerReady: () => ipcRenderer.send("autofill.listenerReady"),
 
+  listenCancelRequest: makeListener(AutofillIpcChannelIncoming.CancelRequest),
+
   listenLockStatus: makeListener(
     AutofillIpcChannelIncoming.LockStatus,
     AutofillIpcChannelOutgoing.LockStatus,

--- a/apps/desktop/src/autofill/services/desktop-autofill.service.spec.ts
+++ b/apps/desktop/src/autofill/services/desktop-autofill.service.spec.ts
@@ -72,4 +72,103 @@ describe("DesktopAutofillService", () => {
       await expect(service.doLockStatus()).resolves.toEqual({ isUnlocked: false });
     });
   });
+
+  describe("doCancelRequest", () => {
+    it("aborts the in-flight request matching the context", async () => {
+      const controller = new AbortController();
+      (service as any).inFlightRequests["ctx-1"] = controller;
+
+      await service.doCancelRequest("ctx-1");
+
+      expect(controller.signal.aborted).toBe(true);
+      expect(controller.signal.reason).toBe("Operation cancelled");
+    });
+
+    it("does nothing when the context does not match an in-flight request", async () => {
+      await expect(service.doCancelRequest("unknown")).resolves.toBeUndefined();
+    });
+  });
+
+  describe("makeListener request correlation", () => {
+    beforeEach(() => {
+      // `makeListener` reads `ipc.autofill.desktopAutofill` to derive a log name.
+      (global as any).ipc = { autofill: { desktopAutofill: {} } };
+      // Correlation only runs once the feature flag has enabled the service.
+      (service as any).isEnabled = true;
+    });
+
+    afterEach(() => {
+      delete (global as any).ipc;
+    });
+
+    // Registers a handler the way `listenIpc` does and returns the listener the
+    // autofill IPC server would invoke on an incoming message.
+    type CapturedListener<Request> = (
+      clientId: number,
+      sequenceNumber: number,
+      request: Request,
+      completeCallback?: (error: Error | null, response: unknown) => void,
+    ) => Promise<void>;
+
+    function registerListener<Request>(
+      handleFn: (request: Request, abortController: AbortController) => Promise<unknown>,
+      deriveTransactionIdFn?: (request: Request) => string,
+    ): CapturedListener<Request> {
+      let listener!: CapturedListener<Request>;
+      const channelBindFn = jest.fn((registered) => (listener = registered));
+      service.makeListener(channelBindFn as any, handleFn as any, deriveTransactionIdFn as any);
+      return listener;
+    }
+
+    it("delivers the abort event to the subscribed handler when the request is cancelled", async () => {
+      const context = "txn-3";
+      const abortListener = jest.fn();
+      let finishHandler!: (response: unknown) => void;
+      const handlerDone = new Promise((resolve) => (finishHandler = resolve));
+
+      // Mirrors the real consumer: the handler reacts to the abort event
+      // (rather than polling `signal.aborted`) and then settles.
+      const requestListener = registerListener<{ context: string }>(
+        (_request, abortController) => {
+          abortController.signal.addEventListener(
+            "abort",
+            () => {
+              abortListener(abortController.signal.reason);
+              finishHandler({ cancelled: true });
+            },
+            { once: true },
+          );
+          return handlerDone;
+        },
+        (request) => request.context,
+      );
+      const cancelListener = registerListener<string>((ctx) => service.doCancelRequest(ctx));
+
+      const completeCallback = jest.fn();
+      const processing = requestListener(1, 2, { context }, completeCallback);
+
+      // Deliver a cancellation the same way the IPC server would.
+      await cancelListener(3, 4, context);
+      await processing;
+
+      expect(abortListener).toHaveBeenCalledWith("Operation cancelled");
+      expect(completeCallback).toHaveBeenCalledWith(null, { cancelled: true });
+      expect((service as any).inFlightRequests[context]).toBeUndefined();
+    });
+
+    it("cleans up the in-flight entry when the handler throws", async () => {
+      const context = "txn-2";
+      const completeCallback = jest.fn();
+
+      const requestListener = registerListener<{ context: string }>(
+        () => Promise.reject(new Error("boom")),
+        (request) => request.context,
+      );
+
+      await requestListener(1, 2, { context }, completeCallback);
+
+      expect(completeCallback).toHaveBeenCalledWith(expect.any(Error), null);
+      expect((service as any).inFlightRequests[context]).toBeUndefined();
+    });
+  });
 });

--- a/apps/desktop/src/autofill/services/desktop-autofill.service.ts
+++ b/apps/desktop/src/autofill/services/desktop-autofill.service.ts
@@ -61,6 +61,7 @@ export class DesktopAutofillService implements OnDestroy {
   private registrationRequest?: PasskeyRegistrationRequest;
   private featureFlag?: typeof FeatureFlag.MacOsNativeCredentialSync;
   private isEnabled: boolean = false;
+  private readonly inFlightRequests: Record<string, AbortController> = {};
 
   constructor(
     private logService: LogService,
@@ -220,6 +221,19 @@ export class DesktopAutofillService implements OnDestroy {
     return this.registrationRequest;
   }
 
+  async doCancelRequest(context: string): Promise<void> {
+    const controller = this.inFlightRequests[context];
+    if (controller) {
+      this.logService.debug("[DesktopAutofillService]", `Cancelling request ${context}`);
+      controller.abort("Operation cancelled");
+    } else {
+      this.logService.debug(
+        "[DesktopAutofillService]",
+        `Ignoring cancellation of unknown request: ${context}`,
+      );
+    }
+  }
+
   async doLockStatus(): Promise<autofill.LockStatusResponse> {
     const isUnlocked =
       (await firstValueFrom(this.authService.activeAccountStatus$)) ===
@@ -229,27 +243,28 @@ export class DesktopAutofillService implements OnDestroy {
 
   async doPasskeyRegistration(
     request: PasskeyRegistrationRequest,
+    abortController: AbortController,
   ): Promise<PasskeyRegistrationResponse> {
-    const controller = new AbortController();
     this.registrationRequest = request;
 
     const response = await this.fido2AuthenticatorService.makeCredential(
       this.convertRegistrationRequest(request),
       { windowXy: request.clientWindow.position },
-      controller,
+      abortController,
     );
     return this.convertRegistrationResponse(request, response);
   }
 
-  async doPasskeyAssertion(request: PasskeyAssertionRequest): Promise<PasskeyAssertionResponse> {
-    const controller = new AbortController();
-
+  async doPasskeyAssertion(
+    request: PasskeyAssertionRequest,
+    abortController: AbortController,
+  ): Promise<PasskeyAssertionResponse> {
     const assumeUserPresence = false;
 
     const response = await this.fido2AuthenticatorService.getAssertion(
       this.convertAssertionRequest(request, assumeUserPresence),
       { windowXy: request.clientWindow.position },
-      controller,
+      abortController,
     );
 
     return this.convertAssertionResponse(request, response);
@@ -257,15 +272,14 @@ export class DesktopAutofillService implements OnDestroy {
 
   async doPasskeyAssertionWithoutUserInterface(
     request: PasskeyAssertionWithoutUserInterfaceRequest,
+    abortController: AbortController,
   ): Promise<PasskeyAssertionResponse> {
-    const controller = new AbortController();
-
     const assumeUserPresence = true;
 
     const response = await this.fido2AuthenticatorService.getAssertion(
       this.convertAssertionRequest(request, assumeUserPresence),
       { windowXy: request.clientWindow.position },
-      controller,
+      abortController,
     );
 
     return this.convertAssertionResponse(request, response);
@@ -282,16 +296,29 @@ export class DesktopAutofillService implements OnDestroy {
   listenIpc() {
     const ipcDesktopAutofill = ipc.autofill.desktopAutofill;
     // These must be arrow functions to bind `this` properly.
-    this.makeListener(ipcDesktopAutofill.listenPasskeyRegistration, (r) =>
-      this.doPasskeyRegistration(r),
+    this.makeListener(ipcDesktopAutofill.listenCancelRequest, (ctx) => this.doCancelRequest(ctx));
+
+    this.makeListener(
+      ipcDesktopAutofill.listenPasskeyRegistration,
+      (request, abortController) => this.doPasskeyRegistration(request, abortController),
+      (request) => request.context,
     );
 
-    this.makeListener(ipcDesktopAutofill.listenPasskeyAssertion, (r) => this.doPasskeyAssertion(r));
-    this.makeListener(ipcDesktopAutofill.listenPasskeyAssertionWithoutUserInterface, (r) =>
-      this.doPasskeyAssertionWithoutUserInterface(r),
+    this.makeListener(
+      ipcDesktopAutofill.listenPasskeyAssertion,
+      (request, abortController) => this.doPasskeyAssertion(request, abortController),
+      (request) => request.context,
+    );
+    this.makeListener(
+      ipcDesktopAutofill.listenPasskeyAssertionWithoutUserInterface,
+      (request, abortController) =>
+        this.doPasskeyAssertionWithoutUserInterface(request, abortController),
+      (request) => request.context,
     );
 
-    this.makeListener(ipcDesktopAutofill.listenNativeStatus, (r) => this.doNativeStatus(r));
+    this.makeListener(ipcDesktopAutofill.listenNativeStatus, (request) =>
+      this.doNativeStatus(request),
+    );
 
     this.makeListener(ipcDesktopAutofill.listenLockStatus, () => this.doLockStatus());
 
@@ -308,7 +335,8 @@ export class DesktopAutofillService implements OnDestroy {
    */
   makeListener<Request, Response>(
     channelBindFn: IpcListenerBindFn<Request, Response>,
-    handleFn: (request: Request) => Promise<Response>,
+    handleFn: (request: Request, abortController: AbortController) => Promise<Response>,
+    deriveTransactionIdFn?: (request: Request) => string,
   ) {
     /** Name to use in logs.
      *
@@ -347,8 +375,19 @@ export class DesktopAutofillService implements OnDestroy {
         return;
       }
 
+      // Setup correlation for cancellation requests
+      let transactionId: string | undefined = undefined;
+      const abortController: AbortController = new AbortController();
+
       try {
-        const response = await handleFn(request);
+        if (deriveTransactionIdFn) {
+          transactionId = deriveTransactionIdFn(request);
+          if (transactionId) {
+            this.inFlightRequests[transactionId] = abortController;
+          }
+        }
+
+        const response = await handleFn(request, abortController);
         if (completeCallback) {
           completeCallback(null, response);
         }
@@ -367,6 +406,10 @@ export class DesktopAutofillService implements OnDestroy {
           } else {
             completeCallback(new Error(JSON.stringify(error)), null);
           }
+        }
+      } finally {
+        if (transactionId) {
+          delete this.inFlightRequests[transactionId];
         }
       }
     };


### PR DESCRIPTION
## 🎟️ Tracking

[PM-40381](https://bitwarden.atlassian.net/browse/PM-40381)

## 📔 Objective

The Fido2UserInterface accepts an `AbortController`, but it is never listened to, and the macOS extension never signals cancellation. This PR:

- Updates macOS to set request context and to emit cancellation signals when the window is closed by the user or by a timeout.
- Unifies Windows and macOS implementations of request cancellation via `autofill_provider`.
- Wires up the `cancel_request_callback` from `DesktopAutofillMain` -> `DesktopAutofillPreload` -> `DesktopAutofillService` (renderer process).

Wiring up the user interface to respond to cancellation is deferred to #21906 to keep this one smaller.

This is a prerequisite for doing native OS user verification for passkey requests.

[PM-40381]: https://bitwarden.atlassian.net/browse/PM-40381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ