### PR TITLE
[PM-40236][RC] Logging out throws error mid-logout due to a race condition. User left in locked state

### DIFF
--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -2022,7 +2022,6 @@ export default class MainBackground {
     );
 
     await Promise.all([
-      this.keyService.clearKeys(userBeingLoggedOut),
       this.cipherService.clear(userBeingLoggedOut),
       this.folderService.clear(userBeingLoggedOut),
       this.biometricStateService.logout(userBeingLoggedOut),
@@ -2034,6 +2033,8 @@ export default class MainBackground {
        *  - userNotificationSettingsService
        */
     ]);
+
+    await this.keyService.clearKeys(userBeingLoggedOut);
 
     //Needs to be checked before state is cleaned
     const needStorageReseed = await this.needsStorageReseed(userBeingLoggedOut);

--- a/apps/desktop/src/app/app.component.ts
+++ b/apps/desktop/src/app/app.component.ts
@@ -748,11 +748,13 @@ export class AppComponent implements OnInit, OnDestroy {
 
       // Provide the userId of the user to upload events for
       await this.eventUploadService.uploadEvents(userBeingLoggedOut);
-      await this.keyService.clearKeys(userBeingLoggedOut);
+
       await this.cipherService.clear(userBeingLoggedOut);
       await this.folderService.clear(userBeingLoggedOut);
       await this.biometricStateService.logout(userBeingLoggedOut);
       await this.pinService.logout(userBeingLoggedOut);
+
+      await this.keyService.clearKeys(userBeingLoggedOut);
 
       await this.stateEventRunnerService.handleEvent("logout", userBeingLoggedOut);
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-40236
(cherry picked from commit ca7057a0a175290c0a0ac823ac52712c5708dac7, see #21858)

## 📔 Objective

Race condition between clearing pin and clearing user key causes pin logout function to throw error. The logout procedure never finishes successfully, which leaves user in locked state.

Root cause: pin logout function uses default sdk client (`userClient$`), which initialises crypto using client managed state, and can fail with error, when user key is not present. Initialisation of user client is conditioned by user key presence, but since clearing of user key and pin key happens in parallel, asynchronously, sometimes the user init crypto is called with user key being present, only to be no longer present moments later within SDK (wasm).

Alternatives:
- Change pin service logout function to use register sdk client - which does not init user crypto. This is fine, since sdk's [unset_pin](https://github.com/bitwarden/sdk-internal/blob/fe351b43b7f6ace9cd9b6be4964bc75265b7782a/crates/bitwarden-core/src/key_management/pin_lock_system.rs#L312) does not use or expect any user crypto state.
- Leave the pin state clearing to `clearOn` event: https://github.com/bitwarden/clients/blob/9e73ef9b4816e50f5aa0519848e035ad1eb39e9c/libs/common/src/key-management/pin/pin.state.ts
- Suppress errors thrown due to user crypto init: #21829. This would cause pin state to be left in memory and on disk, which is not the right approach.

## 📸 Screenshots

https://github.com/user-attachments/assets/496c2a3c-fe3d-4c79-a49e-2739e942f07b

