### PR TITLE
[PM-40104] Relabel "New organization" → "New vault" on org-switcher affordance (web)

### DIFF
--- a/apps/web/src/app/vault/individual-vault/vault-filter/components/vault-filter.component.spec.ts
+++ b/apps/web/src/app/vault/individual-vault/vault-filter/components/vault-filter.component.spec.ts
@@ -25,6 +25,7 @@ import {
   VaultFilterServiceAbstraction as VaultFilterService,
   CipherTypeFilter,
   VaultFilterSection,
+  Vfo1TerminologyService,
 } from "@bitwarden/vault";
 import { OrganizationWarningsService } from "@bitwarden/web-vault/app/billing/organizations/warnings/services";
 
@@ -51,6 +52,8 @@ describe("VaultFilterComponent", () => {
   let vaultFilterService: MockProxy<VaultFilterService>;
   let cipherService: MockProxy<CipherService>;
   let restrictedSubject: BehaviorSubject<RestrictedCipherType[]>;
+  let policyService: MockProxy<PolicyService>;
+  let vfo1Enabled: jest.Mock<boolean, []>;
 
   beforeEach(async () => {
     vaultFilterService = mock<VaultFilterService>();
@@ -76,9 +79,11 @@ describe("VaultFilterComponent", () => {
       { id: "sshKey", name: "typeSshKey", type: CipherType.SshKey, icon: "bwi-key" },
     ]);
 
-    const policyService = mock<PolicyService>();
+    policyService = mock<PolicyService>();
     policyService.policyAppliesToUser$.mockReturnValue(of(false));
     policyService.policiesByType$.mockReturnValue(of([]));
+
+    vfo1Enabled = jest.fn<boolean, []>().mockReturnValue(false);
 
     const i18nService = mock<I18nService>();
     i18nService.t.mockImplementation((key: string) => key);
@@ -110,6 +115,7 @@ describe("VaultFilterComponent", () => {
         { provide: CipherArchiveService, useValue: mock<CipherArchiveService>() },
         { provide: PremiumUpgradePromptService, useValue: mock<PremiumUpgradePromptService>() },
         { provide: OrganizationWarningsService, useValue: mock<OrganizationWarningsService>() },
+        { provide: Vfo1TerminologyService, useValue: { enabled: vfo1Enabled } },
       ],
     }).compileComponents();
 
@@ -277,6 +283,32 @@ describe("VaultFilterComponent", () => {
         const ids = await getTypeFilterIds(section);
 
         expect(ids).not.toContain("card");
+      });
+    });
+  });
+
+  describe("addOrganizationFilter", () => {
+    describe("add label", () => {
+      it('uses "newOrganization" when the VFO1 flag is off', async () => {
+        const section = await component.addOrganizationFilter();
+
+        expect(section.add?.text).toBe("newOrganization");
+      });
+
+      it('uses "newVault" when the VFO1 flag is on', async () => {
+        vfo1Enabled.mockReturnValue(true);
+
+        const section = await component.addOrganizationFilter();
+
+        expect(section.add?.text).toBe("newVault");
+      });
+
+      it("omits the add action when the SingleOrg policy applies", async () => {
+        policyService.policyAppliesToUser$.mockReturnValue(of(true));
+
+        const section = await component.addOrganizationFilter();
+
+        expect(section.add).toBeUndefined();
       });
     });
   });

--- a/apps/web/src/app/vault/individual-vault/vault-filter/components/vault-filter.component.ts
+++ b/apps/web/src/app/vault/individual-vault/vault-filter/components/vault-filter.component.ts
@@ -41,6 +41,7 @@ import {
   CollectionFilter,
   FolderFilter,
   OrganizationFilter,
+  Vfo1TerminologyService,
 } from "@bitwarden/vault";
 import { OrganizationWarningsService } from "@bitwarden/web-vault/app/billing/organizations/warnings/services";
 
@@ -77,6 +78,7 @@ export class VaultFilterComponent implements OnInit, OnDestroy {
   }
 
   protected organizationWarningsService = inject(OrganizationWarningsService);
+  private vfo1TerminologyService = inject(Vfo1TerminologyService);
 
   get searchPlaceholder() {
     if (this.activeFilter.isFavorites) {
@@ -258,7 +260,10 @@ export class VaultFilterComponent implements OnInit, OnDestroy {
     );
 
     const addAction = !singleOrgPolicy
-      ? { text: "newOrganization", route: "/create-organization" }
+      ? {
+          text: this.vfo1TerminologyService.enabled() ? "newVault" : "newOrganization",
+          route: "/create-organization",
+        }
       : undefined;
 
     const orgFilterSection: VaultFilterSection = {

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -2269,6 +2269,9 @@
   "newOrganization": {
     "message": "New organization"
   },
+  "newVault": {
+    "message": "New vault"
+  },
   "noOrganizationsList": {
     "message": "You do not belong to any organizations. Organizations allow you to securely share items with other users."
   },


### PR DESCRIPTION
## 🎟️ Tracking

[PM-40104](https://bitwarden.atlassian.net/browse/PM-40104)

## 📔 Objective

Relabels the "New organization" create affordance in the individual vault's org-switcher sidebar to "New vault", gated behind the `VFO1Foundation` feature flag via `Vfo1TerminologyService`.

Note: AC and the create organization page are out of scope for this ticket. 

## 📸 Screenshots

|Before|After|
|-|-|
|<img width="360" height="265" alt="Screenshot 2026-07-15 at 10 26 36 AM" src="https://github.com/user-attachments/assets/774d3573-2e1c-418d-a158-e2b7b5649740" />|<img width="356" height="327" alt="Screenshot 2026-07-15 at 10 06 19 AM" src="https://github.com/user-attachments/assets/e0f3c320-4ba3-4076-9fbf-48493593fe14" /> |

[PM-40104]: https://bitwarden.atlassian.net/browse/PM-40104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ