### PR TITLE
[PM-24945] Fix `bw send receive` not recognizing --password parameter

### DIFF
--- a/apps/cli/src/tools/send/send.program.spec.ts
+++ b/apps/cli/src/tools/send/send.program.spec.ts
@@ -1,0 +1,47 @@
+import { program } from "commander";
+import { mock } from "jest-mock-extended";
+
+import { Response } from "../../models/response";
+import { ServiceContainer } from "../../service-container/service-container";
+
+import { SendReceiveCommand } from "./commands/receive.command";
+import { SendProgram } from "./send.program";
+
+// Regression coverage for PM-24945: `bw send receive <url> --password <pw>` must forward the
+// password to the command. The `receive` subcommand is nested under `send`, which *also* declares
+// `--password`, so commander binds the flag to the parent and the subcommand's own
+// `options.password` is undefined. The action must therefore resolve the flag via
+// `optsWithGlobals()`. This test exercises the real commander wiring (not the command in
+// isolation), which is where the bug lived.
+describe("SendProgram receive password wiring (PM-24945)", () => {
+  const testUrl = "https://send.bitwarden.com/#/send/abc123/key456";
+  let runSpy: jest.SpyInstance;
+
+  beforeAll(async () => {
+    const serviceContainer = mock<ServiceContainer>();
+    await new SendProgram(serviceContainer).register();
+  });
+
+  beforeEach(() => {
+    // Stub out the actual receive work; we only care about the args commander forwards.
+    runSpy = jest.spyOn(SendReceiveCommand.prototype, "run").mockResolvedValue(Response.success());
+  });
+
+  afterEach(() => {
+    runSpy.mockRestore();
+    // processResponse sets process.exitCode on failure paths; keep tests isolated.
+    process.exitCode = undefined;
+  });
+
+  it("forwards --password for `bw send receive` even though the parent `send` declares --password", async () => {
+    await program.parseAsync(["node", "bw", "send", "receive", testUrl, "--password", "SECRET"]);
+
+    expect(runSpy).toHaveBeenCalledWith(testUrl, expect.objectContaining({ password: "SECRET" }));
+  });
+
+  it("forwards --password for top-level `bw receive`", async () => {
+    await program.parseAsync(["node", "bw", "receive", testUrl, "--password", "SECRET"]);
+
+    expect(runSpy).toHaveBeenCalledWith(testUrl, expect.objectContaining({ password: "SECRET" }));
+  });
+});

--- a/apps/cli/src/tools/send/send.program.ts
+++ b/apps/cli/src/tools/send/send.program.ts
@@ -113,7 +113,7 @@ export class SendProgram extends BaseProgram {
         );
         writeLn("", true);
       })
-      .action(async (url: string, options: OptionValues) => {
+      .action(async (url: string, options: OptionValues, command: Command) => {
         const cmd = new SendReceiveCommand(
           this.serviceContainer.keyService,
           this.serviceContainer.encryptService,
@@ -124,7 +124,11 @@ export class SendProgram extends BaseProgram {
           this.serviceContainer.apiService,
           this.serviceContainer.sendTokenService,
         );
-        const response = await cmd.run(url, options);
+        // When invoked as `bw send receive`, the parent `send` command also declares
+        // `--password`, so commander binds the flag to the parent and this subcommand's
+        // `options.password` is undefined. `optsWithGlobals()` merges ancestor options so the
+        // password is resolved for both `bw send receive` and top-level `bw receive`. (PM-24945)
+        const response = await cmd.run(url, command.optsWithGlobals());
         this.processResponse(response);
       });
   }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-24945

## 📔 Objective

Fixes `bw send receive <url> --password <pw>` prompting for the password even when one was passed as a parameter.

**Root cause:** the `receive` subcommand is nested under the `send` command, which *also* declares a `--password` option. In commander 14, `--password` on `bw send receive …` binds to the parent `send` command, so `receive`'s own `options.password` came through `undefined`. `handlePasswordAuth` reads only `options.password`, so it fell through to the interactive prompt. Top-level `bw receive` was unaffected (no competing parent) — which is why the bug is specific to the `send receive` form.

**Fix:** the `receive` action now resolves options via commander's `command.optsWithGlobals()`, which merges ancestor options so the password is picked up for both `bw send receive` and top-level `bw receive`. This mirrors the workaround the `create` subcommand already uses for the same parent-option quirk. `--passwordenv` / `--passwordfile` / `--obj` / `--output` are receive-only and unaffected.

**Tests:** adds a program-level regression test (`send.program.spec.ts`) that drives the real commander wiring for both `bw send receive --password` and `bw receive --password`; it fails on the pre-fix code and passes after. Existing `receive.command.spec.ts` coverage (password auth, `--passwordenv`, invalid password, email OTP, file download) continues to pass.

## 📸 Screenshots

N/A — CLI behavior only.
