### PR TITLE
[PM-40444] Hide archive/unarchive from bulk bar in Admin Console

### DIFF
--- a/libs/vault/src/services/vault-batch-bar.service.spec.ts
+++ b/libs/vault/src/services/vault-batch-bar.service.spec.ts
@@ -348,6 +348,15 @@ describe("VaultBatchBarService", () => {
 
       expect(service.canArchive()).toBe(true);
     });
+
+    it("returns false when in org vault (admin console)", () => {
+      userCanArchiveSubject.next(true);
+      service.setConfig(makeConfig({ isOrgVault: true }));
+
+      service.selection.select(makeCipherItem({ organizationId: orgId }));
+
+      expect(service.canArchive()).toBe(false);
+    });
   });
 
   describe("canUnarchive", () => {
@@ -379,6 +388,14 @@ describe("VaultBatchBarService", () => {
       service.selection.select(makeCipherItem({ archivedDate: new Date() }));
 
       expect(service.canUnarchive()).toBe(true);
+    });
+
+    it("returns false when in org vault (admin console)", () => {
+      service.setConfig(makeConfig({ isOrgVault: true }));
+
+      service.selection.select(makeCipherItem({ archivedDate: new Date(), organizationId: orgId }));
+
+      expect(service.canUnarchive()).toBe(false);
     });
   });
 

--- a/libs/vault/src/services/vault-batch-bar.service.ts
+++ b/libs/vault/src/services/vault-batch-bar.service.ts
@@ -198,7 +198,13 @@ export class VaultBatchBarService<C extends CipherViewLike> {
   readonly canArchive = computed(() => {
     const selected = this.selected();
     const hasCollections = selected.some((i) => i.collection);
-    if (selected.length === 0 || !this.userCanArchive() || hasCollections || this.inTrash()) {
+    if (
+      selected.length === 0 ||
+      !this.userCanArchive() ||
+      hasCollections ||
+      this.inTrash() ||
+      this.config().isOrgVault
+    ) {
       return false;
     }
     return !selected.find((item) => item.cipher && item.cipher.archivedDate);
@@ -207,7 +213,7 @@ export class VaultBatchBarService<C extends CipherViewLike> {
   /** True when all selected ciphers can be unarchived. */
   readonly canUnarchive = computed(() => {
     const selected = this.selected();
-    if (selected.length === 0 || this.inTrash()) {
+    if (selected.length === 0 || this.inTrash() || this.config().isOrgVault) {
       return false;
     }
     return !selected.find((i) => !i.cipher?.archivedDate);


### PR DESCRIPTION
## 🎟️ Tracking

[PM-40444](https://bitwarden.atlassian.net/browse/PM-40444)

## 📔 Objective

Fixes a regression introduced by #21741 where Archive and Unarchive appeared in the bulk action bar on ciphers in the Admin Console org vault.

## 📸 Screenshots


<video src="https://github.com/user-attachments/assets/f5928f82-ae81-4905-b733-e59d702610c6" />


[PM-40444]: https://bitwarden.atlassian.net/browse/PM-40444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ