### PR TITLE
[PM-40193] feat: add vfo1Icon pipe for flag-gated icon swaps

### DIFF
--- a/libs/vault/src/index.ts
+++ b/libs/vault/src/index.ts
@@ -104,3 +104,4 @@ export { VaultBatchActionComponent } from "./components/vault-batch-bar/vault-ba
 
 export { Vfo1TerminologyService } from "./services/vfo1-terminology.service";
 export { Vfo1I18nPipe } from "./pipes/vfo1-i18n.pipe";
+export { Vfo1IconPipe } from "./pipes/vfo1-icon.pipe";

--- a/libs/vault/src/pipes/vfo1-icon.pipe.spec.ts
+++ b/libs/vault/src/pipes/vfo1-icon.pipe.spec.ts
@@ -1,0 +1,60 @@
+import { TestBed } from "@angular/core/testing";
+
+import { Vfo1TerminologyService } from "../services/vfo1-terminology.service";
+
+import { Vfo1IconPipe } from "./vfo1-icon.pipe";
+
+describe("Vfo1IconPipe", () => {
+  let iconClassFn: jest.Mock<string, [string]>;
+  let enabledFn: jest.Mock<boolean, []>;
+  let pipe: Vfo1IconPipe;
+
+  beforeEach(() => {
+    enabledFn = jest.fn<boolean, []>().mockReturnValue(false);
+    iconClassFn = jest.fn<string, [string]>().mockImplementation((icon) => icon);
+
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: Vfo1TerminologyService,
+          useValue: { enabled: enabledFn, iconClass: iconClassFn },
+        },
+        Vfo1IconPipe,
+      ],
+    });
+
+    pipe = TestBed.inject(Vfo1IconPipe);
+  });
+
+  it("returns the mapped icon class from the service", () => {
+    iconClassFn.mockReturnValue("bwi-shared-folder");
+
+    expect(pipe.transform("bwi-collection-shared")).toBe("bwi-shared-folder");
+    expect(iconClassFn).toHaveBeenCalledWith("bwi-collection-shared");
+  });
+
+  it("returns cached result on repeated call with same args", () => {
+    pipe.transform("bwi-collection-shared");
+    pipe.transform("bwi-collection-shared");
+
+    expect(iconClassFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("recomputes when the flag flips", () => {
+    pipe.transform("bwi-collection-shared");
+
+    enabledFn.mockReturnValue(true);
+
+    pipe.transform("bwi-collection-shared");
+
+    expect(iconClassFn).toHaveBeenCalledTimes(2);
+  });
+
+  it("recomputes when the icon class changes", () => {
+    pipe.transform("bwi-collection-shared");
+    pipe.transform("bwi-user");
+
+    expect(iconClassFn).toHaveBeenCalledTimes(2);
+    expect(iconClassFn).toHaveBeenNthCalledWith(2, "bwi-user");
+  });
+});

--- a/libs/vault/src/pipes/vfo1-icon.pipe.ts
+++ b/libs/vault/src/pipes/vfo1-icon.pipe.ts
@@ -1,0 +1,30 @@
+import { inject, Pipe, PipeTransform } from "@angular/core";
+
+import { Vfo1TerminologyService } from "../services/vfo1-terminology.service";
+
+/**
+ * Pipe for swapping an icon class to its VFO1 equivalent when the vault terminology feature flag
+ * is on. Icon classes without a mapping are returned unchanged.
+ * This pipe is impure because it depends on the feature flag state, which can change at runtime.
+ * It caches the last result to avoid recomputing when the inputs haven't changed.
+ */
+@Pipe({ name: "vfo1Icon", standalone: true, pure: false })
+export class Vfo1IconPipe implements PipeTransform {
+  private terminology = inject(Vfo1TerminologyService);
+
+  private last?: { in: string; enabled: boolean; out: string };
+
+  transform(iconClass: string): string {
+    const enabled = this.terminology.enabled();
+    if (this.last && this.last.in === iconClass && this.last.enabled === enabled) {
+      return this.last.out;
+    }
+
+    const out = this.terminology.iconClass(iconClass);
+
+    // Cache the result for future calls with the same inputs
+    this.last = { in: iconClass, enabled, out };
+
+    return out;
+  }
+}

--- a/libs/vault/src/services/vfo1-terminology.service.spec.ts
+++ b/libs/vault/src/services/vfo1-terminology.service.spec.ts
@@ -52,29 +52,37 @@ describe("Vfo1TerminologyService", () => {
     expect(configService.getFeatureFlag$).toHaveBeenCalledWith(FeatureFlag.VFO1Foundation);
   });
 
-  describe("collectionIconClass", () => {
-    it("emits the legacy collection icon when the flag is off", () => {
+  describe("iconClass", () => {
+    it("returns the icon class unchanged when the flag is off", () => {
       const service = TestBed.inject(Vfo1TerminologyService);
 
-      expect(service.collectionIconClass()).toBe("bwi-collection-shared");
+      expect(service.iconClass("bwi-collection-shared")).toBe("bwi-collection-shared");
     });
 
-    it("emits the shared folder icon when the flag is on", () => {
+    it("returns the mapped icon class when the flag is on", () => {
       flagSubject.next(true);
 
       const service = TestBed.inject(Vfo1TerminologyService);
 
-      expect(service.collectionIconClass()).toBe("bwi-shared-folder");
+      expect(service.iconClass("bwi-collection-shared")).toBe("bwi-shared-folder");
+    });
+
+    it("passes through an unmapped icon class when the flag is on", () => {
+      flagSubject.next(true);
+
+      const service = TestBed.inject(Vfo1TerminologyService);
+
+      expect(service.iconClass("bwi-user")).toBe("bwi-user");
     });
 
     it("updates as the flag changes", () => {
       const service = TestBed.inject(Vfo1TerminologyService);
 
       flagSubject.next(true);
-      expect(service.collectionIconClass()).toBe("bwi-shared-folder");
+      expect(service.iconClass("bwi-collection-shared")).toBe("bwi-shared-folder");
 
       flagSubject.next(false);
-      expect(service.collectionIconClass()).toBe("bwi-collection-shared");
+      expect(service.iconClass("bwi-collection-shared")).toBe("bwi-collection-shared");
     });
   });
 });

--- a/libs/vault/src/services/vfo1-terminology.service.spec.ts
+++ b/libs/vault/src/services/vfo1-terminology.service.spec.ts
@@ -51,4 +51,30 @@ describe("Vfo1TerminologyService", () => {
 
     expect(configService.getFeatureFlag$).toHaveBeenCalledWith(FeatureFlag.VFO1Foundation);
   });
+
+  describe("collectionIconClass", () => {
+    it("emits the legacy collection icon when the flag is off", () => {
+      const service = TestBed.inject(Vfo1TerminologyService);
+
+      expect(service.collectionIconClass()).toBe("bwi-collection-shared");
+    });
+
+    it("emits the shared folder icon when the flag is on", () => {
+      flagSubject.next(true);
+
+      const service = TestBed.inject(Vfo1TerminologyService);
+
+      expect(service.collectionIconClass()).toBe("bwi-shared-folder");
+    });
+
+    it("updates as the flag changes", () => {
+      const service = TestBed.inject(Vfo1TerminologyService);
+
+      flagSubject.next(true);
+      expect(service.collectionIconClass()).toBe("bwi-shared-folder");
+
+      flagSubject.next(false);
+      expect(service.collectionIconClass()).toBe("bwi-collection-shared");
+    });
+  });
 });

--- a/libs/vault/src/services/vfo1-terminology.service.ts
+++ b/libs/vault/src/services/vfo1-terminology.service.ts
@@ -1,8 +1,13 @@
-import { inject, Injectable, Signal } from "@angular/core";
+import { computed, inject, Injectable, Signal } from "@angular/core";
 import { toSignal } from "@angular/core/rxjs-interop";
 
 import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
+
+/** Collection icon shown when the VFO1 terminology flag is off. */
+const LEGACY_COLLECTION_ICON = "bwi-collection-shared";
+/** Collection ("shared folder") icon shown when the VFO1 terminology flag is on. */
+const SHARED_FOLDER_ICON = "bwi-shared-folder";
 
 @Injectable({ providedIn: "root" })
 export class Vfo1TerminologyService {
@@ -10,5 +15,13 @@ export class Vfo1TerminologyService {
   readonly enabled: Signal<boolean> = toSignal(
     this.configService.getFeatureFlag$(FeatureFlag.VFO1Foundation),
     { initialValue: false },
+  );
+
+  /**
+   * The icon class to use for collections. Switches to the "shared folder" icon when the
+   * terminology flag is on. Text terms are handled separately by the `vfo1I18n` pipe.
+   */
+  readonly collectionIconClass: Signal<string> = computed(() =>
+    this.enabled() ? SHARED_FOLDER_ICON : LEGACY_COLLECTION_ICON,
   );
 }

--- a/libs/vault/src/services/vfo1-terminology.service.ts
+++ b/libs/vault/src/services/vfo1-terminology.service.ts
@@ -1,13 +1,16 @@
-import { computed, inject, Injectable, Signal } from "@angular/core";
+import { inject, Injectable, Signal } from "@angular/core";
 import { toSignal } from "@angular/core/rxjs-interop";
 
 import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 
-/** Collection icon shown when the VFO1 terminology flag is off. */
-const LEGACY_COLLECTION_ICON = "bwi-collection-shared";
-/** Collection ("shared folder") icon shown when the VFO1 terminology flag is on. */
-const SHARED_FOLDER_ICON = "bwi-shared-folder";
+/**
+ * Legacy icon class → VFO1 replacement, applied when the terminology flag is on.
+ * Icon classes not present here are returned unchanged.
+ */
+const VFO1_ICON_MAP: Readonly<Record<string, string>> = Object.freeze({
+  "bwi-collection-shared": "bwi-shared-folder",
+});
 
 @Injectable({ providedIn: "root" })
 export class Vfo1TerminologyService {
@@ -18,10 +21,11 @@ export class Vfo1TerminologyService {
   );
 
   /**
-   * The icon class to use for collections. Switches to the "shared folder" icon when the
-   * terminology flag is on. Text terms are handled separately by the `vfo1I18n` pipe.
+   * Returns the VFO1 replacement for `iconClass` when the terminology flag is on, otherwise
+   * `iconClass` unchanged. Icon classes without a mapping are passed through as-is.
+   * Text terms are handled separately by the `vfo1I18n` pipe.
    */
-  readonly collectionIconClass: Signal<string> = computed(() =>
-    this.enabled() ? SHARED_FOLDER_ICON : LEGACY_COLLECTION_ICON,
-  );
+  iconClass(iconClass: string): string {
+    return this.enabled() ? (VFO1_ICON_MAP[iconClass] ?? iconClass) : iconClass;
+  }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-40193

## 📔 Objective

Part of the VFO1 terminology work (epic PM-39699) that renames "collections" to "shared folders" and "folders" to "my folders" behind the `vfo1-foundation` flag.

Text terms are already handled by `Vfo1I18nPipe`, which selects a legacy vs. new i18n key off `Vfo1TerminologyService.enabled()`. The one thing that pipe can't express is the collection icon swap — a CSS class, not a translatable string. Rather than add a per-icon `collectionIconClass` signal, this PR mirrors the text pattern with a generic icon pipe:

- **`Vfo1IconPipe` (`vfo1Icon`)** — an impure pipe (flag state can change at runtime) that takes a legacy icon class and returns its VFO1 replacement when the flag is on, caching its last result to avoid recomputing on unchanged inputs.
- **`Vfo1TerminologyService.iconClass(iconClass)`** — resolves the mapping, backed by a frozen `VFO1_ICON_MAP` (currently `bwi-collection-shared` → `bwi-shared-folder`). Icon classes with no mapping pass through unchanged.

Behavior for the collection icon:

- flag off → `bwi-collection-shared`
- flag on  → `bwi-shared-folder`

The map lives on the terminology service because it's the non-text half of the same flag-gated terminology swap, and it reads the same synchronous `enabled` signal the `vfo1I18n` pipe uses. Using a generic pipe + map (instead of one named signal per icon) lets future icon swaps be added by extending the map alone — no new service members or exports. `Vfo1IconPipe` is exported from `libs/vault/src/index.ts` alongside `Vfo1TerminologyService` and `Vfo1I18nPipe`. Unit tests cover both flag states and pass-through for unmapped classes.

Note: the `bwi-shared-folder` glyph is added under separate icon-update work in PM-39699; this PR only emits the class name. No UI change yet.
