### PR TITLE
[PM-39948][PM-40406] Fix native select issues with dark mode and arrow click handling

### DIFF
--- a/libs/components/src/form-field/field-container.directive.ts
+++ b/libs/components/src/form-field/field-container.directive.ts
@@ -35,6 +35,7 @@ export class BitFieldContainerDirective {
       "has-[:focus-visible]:tw-ring-1",
       "has-[.tw-test-focus-visible]:tw-ring-1",
       "tw-relative",
+      "has-[select]:after:tw-pointer-events-none",
       "has-[select]:after:tw-absolute",
       // spacing here to match visual spacing used by ng-select arrow
       "has-[select]:after:tw-end-[calc(theme(spacing.3)_+_2px)]",

--- a/libs/components/src/form-field/form-field.component.html
+++ b/libs/components/src/form-field/form-field.component.html
@@ -19,7 +19,7 @@
         <ng-content select="[bitPrefix]"></ng-content>
       </div>
       <div
-        class="tw-flex tw-w-full tw-items-center tw-pe-3 has-[[biticonbutton]:last-child]:tw-pe-1 has-[bit-select]:tw-pe-0 has-[bit-multi-select]:tw-pe-0 has-[textarea]:!tw-items-start"
+        class="tw-flex tw-w-full tw-items-center tw-pe-3 has-[[biticonbutton]:last-child]:tw-pe-1 has-[bit-select]:tw-pe-0 has-[select]:tw-pe-0 has-[bit-multi-select]:tw-pe-0 has-[textarea]:!tw-items-start"
       >
         <div [class]="contentContainerClasses" data-default-content>
           <ng-content></ng-content>

--- a/libs/components/src/input/input.directive.ts
+++ b/libs/components/src/input/input.directive.ts
@@ -57,6 +57,9 @@ export class BitInputDirective implements AfterViewInit {
       "focus:tw-outline-none",
       "tw-bg-transparent",
       "tw-text-fg-heading",
+      // native select options need non-transparent colors to work properly in windows dark mode
+      "[&_option]:tw-bg-background",
+      "[&_option]:tw-text-main",
       "[&:is(input,textarea):disabled]:tw-bg-bg-secondary",
       "[&:is(input,textarea):disabled]:!tw-placeholder-fg-inactive",
       "[&:is(input,textarea):disabled]:!tw-text-fg-inactive",


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[PM-39948](https://bitwarden.atlassian.net/browse/PM-39948)
[PM-40406](https://bitwarden.atlassian.net/browse/PM-40406)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Fix 2 issues with the native select:
- Clicking the arrow did not open the dropdown menu
- The dropdown menu was not legible in Windows Chrome dark mode

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

Screencasts from a Windows device.

Before


https://github.com/user-attachments/assets/71dee019-9990-44f1-a177-04bb7f4853a0


After


https://github.com/user-attachments/assets/45c480e0-5e9e-453c-9a60-5e822f128d4a







[PM-39948]: https://bitwarden.atlassian.net/browse/PM-39948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-40406]: https://bitwarden.atlassian.net/browse/PM-40406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ