### PR TITLE
[PM-40457] Fix typos in the message catalogs

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -68,7 +68,7 @@ jobs:
           if [[ "$PACKAGE_VERSION" == "$ELECTRON_BUILDER_VERSION"  ]]; then
             echo "Versions matches"
           else
-            echo "Version missmatch, package.json: $PACKAGE_VERSION, electron-builder.json: $ELECTRON_BUILDER_VERSION"
+            echo "Version mismatch, package.json: $PACKAGE_VERSION, electron-builder.json: $ELECTRON_BUILDER_VERSION"
             exit 1
           fi
 

--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -1455,7 +1455,7 @@
   "accountRestricted": {
     "message": "Account restricted"
   },
-  "filePasswordAndConfirmFilePasswordDoNotMatch": {
+  "filePasswordConfirmationMismatch": {
     "message": "“File password” and “Confirm file password” do not match."
   },
   "warning": {
@@ -1469,7 +1469,7 @@
   "confirmVaultExport": {
     "message": "Confirm vault export"
   },
-  "exportWarningDesc": {
+  "exportUnencryptedWarningDesc": {
     "message": "This export contains your vault data in an unencrypted format. You should not store or send the exported file over insecure channels (such as email). Delete it immediately after you are done using it."
   },
   "encExportKeyWarningDesc": {
@@ -3061,10 +3061,10 @@
   "nativeMessagingWrongUserDesc": {
     "message": "The desktop application is logged into a different account. Please ensure both applications are logged into the same account."
   },
-  "nativeMessagingWrongUserTitle": {
+  "nativeMessagingAccountMismatchTitle": {
     "message": "Account mismatch"
   },
-  "nativeMessagingWrongUserKeyTitle": {
+  "nativeMessagingBiometricKeyMismatchTitle": {
     "message": "Biometric key mismatch"
   },
   "nativeMessagingWrongUserKeyDesc": {
@@ -6042,7 +6042,7 @@
   "linkedHelpText": {
     "message": "Use a linked field when you are experiencing autofill issues for a specific website."
   },
-  "linkedLabelHelpText": {
+  "linkedFieldLabelHelpText": {
     "message": "Enter the field's HTML id, name, aria-label, or placeholder."
   },
   "editField": {

--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -1456,7 +1456,7 @@
     "message": "Account restricted"
   },
   "filePasswordAndConfirmFilePasswordDoNotMatch": {
-    "message": "“File password”  and “Confirm file password“ do not match."
+    "message": "“File password” and “Confirm file password” do not match."
   },
   "warning": {
     "message": "WARNING",
@@ -1470,7 +1470,7 @@
     "message": "Confirm vault export"
   },
   "exportWarningDesc": {
-    "message": "This export contains your vault data in an unencrypted format. You should not store or send the exported file over unsecure channels (such as email). Delete it immediately after you are done using it."
+    "message": "This export contains your vault data in an unencrypted format. You should not store or send the exported file over insecure channels (such as email). Delete it immediately after you are done using it."
   },
   "encExportKeyWarningDesc": {
     "message": "This export encrypts your data using your account's encryption key. If you ever rotate your account's encryption key you should export again since you will not be able to decrypt this export file."
@@ -1614,7 +1614,7 @@
   "premiumSignUpAndGet": {
     "message": "Sign up for a Premium membership and get:"
   },
-  "ppremiumSignUpStorage": {
+  "premiumSignUpStorage": {
     "message": "1 GB encrypted storage for file attachments."
   },
   "premiumSignUpStorageV2": {
@@ -1641,16 +1641,16 @@
   "restartPremium": {
     "message": "Restart Premium"
   },
-  "ppremiumSignUpReports": {
+  "premiumSignUpReports": {
     "message": "Password hygiene, account health, and data breach reports to keep your vault safe."
   },
-  "ppremiumSignUpTotp": {
+  "premiumSignUpTotp": {
     "message": "TOTP verification code (2FA) generator for logins in your vault."
   },
-  "ppremiumSignUpSupport": {
+  "premiumSignUpSupport": {
     "message": "Priority customer support."
   },
-  "ppremiumSignUpFuture": {
+  "premiumSignUpFuture": {
     "message": "All future Premium features. More coming soon!"
   },
   "premiumPurchase": {
@@ -2536,7 +2536,7 @@
   "clearGeneratorHistoryTitle": {
     "message": "Clear generator history"
   },
-  "cleargGeneratorHistoryDescription": {
+  "clearGeneratorHistoryDescription": {
     "message": "If you continue, all entries will be permanently deleted from generator's history. Are you sure you want to continue?"
   },
   "back": {
@@ -3062,10 +3062,10 @@
     "message": "The desktop application is logged into a different account. Please ensure both applications are logged into the same account."
   },
   "nativeMessagingWrongUserTitle": {
-    "message": "Account missmatch"
+    "message": "Account mismatch"
   },
   "nativeMessagingWrongUserKeyTitle": {
-    "message": "Biometric key missmatch"
+    "message": "Biometric key mismatch"
   },
   "nativeMessagingWrongUserKeyDesc": {
     "message": "Biometric unlock failed. The biometric secret key failed to unlock the vault. Please try to set up biometrics again."
@@ -3100,16 +3100,16 @@
   "biometricsFailedDesc": {
     "message": "Biometrics cannot be completed, consider using a master password or logging out. If this persists, please contact Bitwarden support."
   },
-  "nativeMessaginPermissionErrorTitle": {
+  "nativeMessagingPermissionErrorTitle": {
     "message": "Permission not provided"
   },
-  "nativeMessaginPermissionErrorDesc": {
+  "nativeMessagingPermissionErrorDesc": {
     "message": "Without permission to communicate with the Bitwarden Desktop Application we cannot provide biometrics in the browser extension. Please try again."
   },
-  "nativeMessaginPermissionSidebarTitle": {
+  "nativeMessagingPermissionSidebarTitle": {
     "message": "Permission request error"
   },
-  "nativeMessaginPermissionSidebarDesc": {
+  "nativeMessagingPermissionSidebarDesc": {
     "message": "This action cannot be done in the sidebar, please retry the action in the popup or popout."
   },
   "personalOwnershipSubmitError": {
@@ -3918,7 +3918,7 @@
       }
     }
   },
-  "forwaderInvalidToken": {
+  "forwarderInvalidToken": {
     "message": "Invalid $SERVICENAME$ API token",
     "description": "Displayed when the user's API token is empty or rejected by the forwarding service.",
     "placeholders": {
@@ -3928,7 +3928,7 @@
       }
     }
   },
-  "forwaderInvalidTokenWithMessage": {
+  "forwarderInvalidTokenWithMessage": {
     "message": "Invalid $SERVICENAME$ API token: $ERRORMESSAGE$",
     "description": "Displayed when the user's API token is rejected by the forwarding service with an error message.",
     "placeholders": {
@@ -3942,7 +3942,7 @@
       }
     }
   },
-  "forwaderInvalidOperation": {
+  "forwarderInvalidOperation": {
     "message": "$SERVICENAME$ refused your request. Please contact your service provider for assistance.",
     "description": "Displayed when the user is forbidden from using the API by the forwarding service.",
     "placeholders": {
@@ -3952,7 +3952,7 @@
       }
     }
   },
-  "forwaderInvalidOperationWithMessage": {
+  "forwarderInvalidOperationWithMessage": {
     "message": "$SERVICENAME$ refused your request: $ERRORMESSAGE$",
     "description": "Displayed when the user is forbidden from using the API by the forwarding service with an error message.",
     "placeholders": {
@@ -4029,7 +4029,7 @@
   "ssoKeyConnectorError": {
     "message": "Key connector error: make sure key connector is available and working correctly."
   },
-  "premiumSubcriptionRequired": {
+  "premiumSubscriptionRequired": {
     "message": "Premium subscription required"
   },
   "organizationIsDisabled": {
@@ -6043,7 +6043,7 @@
     "message": "Use a linked field when you are experiencing autofill issues for a specific website."
   },
   "linkedLabelHelpText": {
-    "message": "Enter the the field's html id, name, aria-label, or placeholder."
+    "message": "Enter the field's HTML id, name, aria-label, or placeholder."
   },
   "editField": {
     "message": "Edit field"

--- a/apps/browser/src/billing/popup/settings/premium-v2.component.html
+++ b/apps/browser/src/billing/popup/settings/premium-v2.component.html
@@ -21,16 +21,16 @@
               {{ "premiumSignUpEmergency" | i18n }}
             </li>
             <li>
-              {{ "ppremiumSignUpReports" | i18n }}
+              {{ "premiumSignUpReports" | i18n }}
             </li>
             <li>
-              {{ "ppremiumSignUpTotp" | i18n }}
+              {{ "premiumSignUpTotp" | i18n }}
             </li>
             <li>
-              {{ "ppremiumSignUpSupport" | i18n }}
+              {{ "premiumSignUpSupport" | i18n }}
             </li>
             <li>
-              {{ "ppremiumSignUpFuture" | i18n }}
+              {{ "premiumSignUpFuture" | i18n }}
             </li>
           </ul>
         </div>

--- a/apps/browser/src/key-management/shared-unlock/popup/native-messaging-permission-dialog.component.spec.ts
+++ b/apps/browser/src/key-management/shared-unlock/popup/native-messaging-permission-dialog.component.spec.ts
@@ -93,8 +93,8 @@ describe("NativeMessagingPermissionDialogComponent", () => {
       await component.continue();
 
       expect(dialogService.openSimpleDialog).toHaveBeenCalledWith({
-        title: { key: "nativeMessaginPermissionSidebarTitle" },
-        content: { key: "nativeMessaginPermissionSidebarDesc" },
+        title: { key: "nativeMessagingPermissionSidebarTitle" },
+        content: { key: "nativeMessagingPermissionSidebarDesc" },
         acceptButtonText: { key: "ok" },
         cancelButtonText: null,
         type: "info",

--- a/apps/browser/src/key-management/shared-unlock/popup/native-messaging-permission-dialog.component.ts
+++ b/apps/browser/src/key-management/shared-unlock/popup/native-messaging-permission-dialog.component.ts
@@ -77,8 +77,8 @@ export class NativeMessagingPermissionDialogComponent {
     } catch {
       if (this.platformUtilsService.isFirefox() && BrowserPopupUtils.inSidebar(window)) {
         await this.dialogService.openSimpleDialog({
-          title: { key: "nativeMessaginPermissionSidebarTitle" },
-          content: { key: "nativeMessaginPermissionSidebarDesc" },
+          title: { key: "nativeMessagingPermissionSidebarTitle" },
+          content: { key: "nativeMessagingPermissionSidebarDesc" },
           acceptButtonText: { key: "ok" },
           cancelButtonText: null,
           type: "info",

--- a/apps/browser/src/tools/popup/generator/credential-generator-history.component.ts
+++ b/apps/browser/src/tools/popup/generator/credential-generator-history.component.ts
@@ -112,7 +112,7 @@ export class CredentialGeneratorHistoryComponent implements OnChanges, OnInit, O
   clear = async () => {
     const confirmed = await this.dialogService.openSimpleDialog({
       title: { key: "clearGeneratorHistoryTitle" },
-      content: { key: "cleargGeneratorHistoryDescription" },
+      content: { key: "clearGeneratorHistoryDescription" },
       type: "warning",
       acceptButtonText: { key: "clearHistory" },
       cancelButtonText: { key: "cancel" },

--- a/apps/cli/src/locales/en/messages.json
+++ b/apps/cli/src/locales/en/messages.json
@@ -108,7 +108,7 @@
       }
     }
   },
-  "forwaderInvalidToken": {
+  "forwarderInvalidToken": {
     "message": "Invalid $SERVICENAME$ API token",
     "description": "Displayed when the user's API token is empty or rejected by the forwarding service.",
     "placeholders": {
@@ -118,7 +118,7 @@
       }
     }
   },
-  "forwaderInvalidTokenWithMessage": {
+  "forwarderInvalidTokenWithMessage": {
     "message": "Invalid $SERVICENAME$ API token: $ERRORMESSAGE$",
     "description": "Displayed when the user's API token is rejected by the forwarding service with an error message.",
     "placeholders": {
@@ -132,7 +132,7 @@
       }
     }
   },
-  "forwaderInvalidOperation": {
+  "forwarderInvalidOperation": {
     "message": "$SERVICENAME$ refused your request. Please contact your service provider for assistance.",
     "description": "Displayed when the user is forbidden from using the API by the forwarding service.",
     "placeholders": {
@@ -142,7 +142,7 @@
       }
     }
   },
-  "forwaderInvalidOperationWithMessage": {
+  "forwarderInvalidOperationWithMessage": {
     "message": "$SERVICENAME$ refused your request: $ERRORMESSAGE$",
     "description": "Displayed when the user is forbidden from using the API by the forwarding service with an error message.",
     "placeholders": {

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -905,8 +905,8 @@
   "linkedHelpText": {
     "message": "Use a linked field when you are experiencing autofill issues for a specific website."
   },
-  "linkedLabelHelpText": {
-    "message": "Enter the the field's html id, name, aria-label, or placeholder."
+  "linkedFieldLabelHelpText": {
+    "message": "Enter the field's HTML id, name, aria-label, or placeholder."
   },
   "folder": {
     "message": "Folder"
@@ -2378,8 +2378,8 @@
   "restrictCardTypeImportDesc": {
     "message": "A policy set by 1 or more organizations prevents you from importing cards to your vaults."
   },
-  "filePasswordAndConfirmFilePasswordDoNotMatch": {
-    "message": "“File password”  and “Confirm file password“ do not match."
+  "filePasswordConfirmationMismatch": {
+    "message": "“File password” and “Confirm file password” do not match."
   },
   "done": {
     "message": "Done"
@@ -2391,8 +2391,8 @@
   "confirmVaultExport": {
     "message": "Confirm vault export"
   },
-  "exportWarningDesc": {
-    "message": "This export contains your vault data in an unencrypted format. You should not store or send the exported file over unsecure channels (such as email). Delete it immediately after you are done using it."
+  "exportUnencryptedWarningDesc": {
+    "message": "This export contains your vault data in an unencrypted format. You should not store or send the exported file over insecure channels (such as email). Delete it immediately after you are done using it."
   },
   "encExportKeyWarningDesc": {
     "message": "This export encrypts your data using your account's encryption key. If you ever rotate your account's encryption key you should export again since you will not be able to decrypt this export file."

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -2102,7 +2102,7 @@
   "clearGeneratorHistoryTitle": {
     "message": "Clear generator history"
   },
-  "cleargGeneratorHistoryDescription": {
+  "clearGeneratorHistoryDescription": {
     "message": "If you continue, all entries will be permanently deleted from generator's history. Are you sure you want to continue?"
   },
   "clear": {
@@ -3506,7 +3506,7 @@
       }
     }
   },
-  "forwaderInvalidToken": {
+  "forwarderInvalidToken": {
     "message": "Invalid $SERVICENAME$ API token",
     "description": "Displayed when the user's API token is empty or rejected by the forwarding service.",
     "placeholders": {
@@ -3516,7 +3516,7 @@
       }
     }
   },
-  "forwaderInvalidTokenWithMessage": {
+  "forwarderInvalidTokenWithMessage": {
     "message": "Invalid $SERVICENAME$ API token: $ERRORMESSAGE$",
     "description": "Displayed when the user's API token is rejected by the forwarding service with an error message.",
     "placeholders": {
@@ -3530,7 +3530,7 @@
       }
     }
   },
-  "forwaderInvalidOperation": {
+  "forwarderInvalidOperation": {
     "message": "$SERVICENAME$ refused your request. Please contact your service provider for assistance.",
     "description": "Displayed when the user is forbidden from using the API by the forwarding service.",
     "placeholders": {
@@ -3540,7 +3540,7 @@
       }
     }
   },
-  "forwaderInvalidOperationWithMessage": {
+  "forwarderInvalidOperationWithMessage": {
     "message": "$SERVICENAME$ refused your request: $ERRORMESSAGE$",
     "description": "Displayed when the user is forbidden from using the API by the forwarding service with an error message.",
     "placeholders": {
@@ -3614,7 +3614,7 @@
   "apiKey": {
     "message": "API key"
   },
-  "premiumSubcriptionRequired": {
+  "premiumSubscriptionRequired": {
     "message": "Premium subscription required"
   },
   "organizationIsDisabled": {

--- a/apps/web/src/app/billing/members/free-bitwarden-families.component.html
+++ b/apps/web/src/app/billing/members/free-bitwarden-families.component.html
@@ -100,7 +100,7 @@
       <div class="tw-my-5 tw-py-5 tw-flex tw-flex-col tw-items-center">
         <img class="tw-w-32" src="./../../../images/search.svg" alt="Search" />
         <h4 class="tw-mt-3" bitTypography="h4">{{ "noSponsoredFamiliesMessage" | i18n }}</h4>
-        <p bitTypography="body2">{{ "nosponsoredFamiliesDetails" | i18n }}</p>
+        <p bitTypography="body2">{{ "noSponsoredFamiliesDetails" | i18n }}</p>
       </div>
     }
 

--- a/apps/web/src/app/billing/shared/trial-payment-dialog/trial-payment-dialog.component.html
+++ b/apps/web/src/app/billing/shared/trial-payment-dialog/trial-payment-dialog.component.html
@@ -1,6 +1,6 @@
 <bit-dialog dialogSize="default">
   <span bitDialogTitle class="tw-font-medium">
-    {{ "subscribetoEnterprise" | i18n: currentPlanName }}
+    {{ "subscribeToEnterprise" | i18n: currentPlanName }}
   </span>
 
   <div bitDialogContent>

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -2670,7 +2670,7 @@
   "clearGeneratorHistoryTitle": {
     "message": "Clear generator history"
   },
-  "cleargGeneratorHistoryDescription": {
+  "clearGeneratorHistoryDescription": {
     "message": "If you continue, all entries will be permanently deleted from generator's history. Are you sure you want to continue?"
   },
   "noPasswordsInList": {
@@ -5566,7 +5566,7 @@
   "needsApproval": {
     "message": "Needs approval"
   },
-  "areYouTryingtoLogin": {
+  "areYouTryingToLogin": {
     "message": "Are you trying to log in?"
   },
   "logInAttemptBy": {
@@ -8668,7 +8668,7 @@
   "noSponsoredFamiliesMessage": {
     "message": "No sponsored families"
   },
-  "nosponsoredFamiliesDetails": {
+  "noSponsoredFamiliesDetails": {
     "message": "Sponsored non-member families plans will display here"
   },
   "sponsorshipFreeBitwardenFamilies": {
@@ -9410,7 +9410,7 @@
       }
     }
   },
-  "forwaderInvalidToken": {
+  "forwarderInvalidToken": {
     "message": "Invalid $SERVICENAME$ API token",
     "description": "Displayed when the user's API token is empty or rejected by the forwarding service.",
     "placeholders": {
@@ -9420,7 +9420,7 @@
       }
     }
   },
-  "forwaderInvalidTokenWithMessage": {
+  "forwarderInvalidTokenWithMessage": {
     "message": "Invalid $SERVICENAME$ API token: $ERRORMESSAGE$",
     "description": "Displayed when the user's API token is rejected by the forwarding service with an error message.",
     "placeholders": {
@@ -9434,7 +9434,7 @@
       }
     }
   },
-  "forwaderInvalidOperation": {
+  "forwarderInvalidOperation": {
     "message": "$SERVICENAME$ refused your request. Please contact your service provider for assistance.",
     "description": "Displayed when the user is forbidden from using the API by the forwarding service.",
     "placeholders": {
@@ -9444,7 +9444,7 @@
       }
     }
   },
-  "forwaderInvalidOperationWithMessage": {
+  "forwarderInvalidOperationWithMessage": {
     "message": "$SERVICENAME$ refused your request: $ERRORMESSAGE$",
     "description": "Displayed when the user is forbidden from using the API by the forwarding service with an error message.",
     "placeholders": {
@@ -9533,7 +9533,7 @@
       }
     }
   },
-  "premiumSubcriptionRequired": {
+  "premiumSubscriptionRequired": {
     "message": "Premium subscription required"
   },
   "scim": {
@@ -11546,14 +11546,8 @@
   "assignCollectionAccess": {
     "message": "Assign collection access"
   },
-  "collectionsEdited": {
-    "message": "Collections edited"
-  },
   "editedCollections": {
     "message": "Edited collections"
-  },
-  "collectionEdited": {
-    "message": "Collection edited"
   },
   "editedCollection": {
     "message": "Edited collection"
@@ -14096,7 +14090,7 @@
     },
     "description": "A message shown in a non-dismissible dialog to admins of unpaid providers."
   },
-  "subscribetoEnterprise": {
+  "subscribeToEnterprise": {
     "message": "Subscribe to $PLAN$",
     "placeholders": {
       "plan": {
@@ -15500,9 +15494,6 @@
   "progressBar": {
     "message": "Progress bar",
     "description": "This is the name of a page component that displays progress to the user. This string will be used to label the progress bar for a screenreader when multiple progress bars are on a page, like 'Progress bar 1' and 'Progress bar 2'."
-  },
-  "emailVerification": {
-    "message": "Email verification"
   },
   "separateDomainsWithComma": {
     "message": "Separate domains with a comma"

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -2492,8 +2492,8 @@
   "confirmSecretsExport": {
     "message": "Confirm secrets export"
   },
-  "exportWarningDesc": {
-    "message": "This export contains your vault data in an unencrypted format. You should not store or send the exported file over unsecure channels (such as email). Delete it immediately after you are done using it."
+  "exportUnencryptedWarningDesc": {
+    "message": "This export contains your vault data in an unencrypted format. You should not store or send the exported file over insecure channels (such as email). Delete it immediately after you are done using it."
   },
   "exportSecretsWarningDesc": {
     "message": "This export contains your secrets data in an unencrypted format. You should not store or send the exported file over unsecure channels (such as email). Delete it immediately after you are done using it."
@@ -2572,8 +2572,8 @@
   "passwordProtected": {
     "message": "Password protected"
   },
-  "filePasswordAndConfirmFilePasswordDoNotMatch": {
-    "message": "“File password”  and “Confirm file password“ do not match."
+  "filePasswordConfirmationMismatch": {
+    "message": "“File password” and “Confirm file password” do not match."
   },
   "confirmVaultImport": {
     "message": "Confirm vault import"
@@ -13139,8 +13139,8 @@
   "linkedHelpText": {
     "message": "Use a linked field when you are experiencing autofill issues for a specific website."
   },
-  "linkedLabelHelpText": {
-    "message": "Enter the the field's html id, name, aria-label, or placeholder."
+  "linkedFieldLabelHelpText": {
+    "message": "Enter the field's HTML id, name, aria-label, or placeholder."
   },
   "uppercaseDescription": {
     "message": "Include uppercase characters",

--- a/libs/common/src/tools/integration/integration-context.ts
+++ b/libs/common/src/tools/integration/integration-context.ts
@@ -64,7 +64,7 @@ export class IntegrationContext<Settings extends object> {
     // normalize `token` then assert it has a value
     let token = "token" in this.settings ? ((this.settings.token as string) ?? "") : "";
     if (token === "") {
-      const error = this.i18n.t("forwaderInvalidToken", this.metadata.name);
+      const error = this.i18n.t("forwarderInvalidToken", this.metadata.name);
       throw error;
     }
 

--- a/libs/common/src/tools/integration/rpc/rest-client.spec.ts
+++ b/libs/common/src/tools/integration/rpc/rest-client.spec.ts
@@ -52,8 +52,8 @@ describe("RestClient", () => {
     });
 
     it.each([
-      [401, "forwaderInvalidToken"],
-      [403, "forwaderInvalidOperation"],
+      [401, "forwarderInvalidToken"],
+      [403, "forwarderInvalidOperation"],
     ])("throws an invalid token error when HTTP status is %i", async (status, messageKey) => {
       const client = new RestClient(api, i18n);
       const request: IntegrationRequest = { website: null };
@@ -66,12 +66,12 @@ describe("RestClient", () => {
     });
 
     it.each([
-      [401, null, null, "forwaderInvalidToken"],
-      [401, undefined, undefined, "forwaderInvalidToken"],
-      [401, undefined, null, "forwaderInvalidToken"],
-      [403, null, null, "forwaderInvalidOperation"],
-      [403, undefined, undefined, "forwaderInvalidOperation"],
-      [403, undefined, null, "forwaderInvalidOperation"],
+      [401, null, null, "forwarderInvalidToken"],
+      [401, undefined, undefined, "forwarderInvalidToken"],
+      [401, undefined, null, "forwarderInvalidToken"],
+      [403, null, null, "forwarderInvalidOperation"],
+      [403, undefined, undefined, "forwarderInvalidOperation"],
+      [403, undefined, null, "forwarderInvalidOperation"],
     ])(
       "throws an invalid token error when HTTP status is %i, message is %p, and error is %p",
       async (status, message, error, messageKey) => {
@@ -90,10 +90,10 @@ describe("RestClient", () => {
     );
 
     it.each([
-      [401, "message", "forwaderInvalidTokenWithMessage"],
-      [403, "message", "forwaderInvalidOperationWithMessage"],
-      [401, "error", "forwaderInvalidTokenWithMessage"],
-      [403, "error", "forwaderInvalidOperationWithMessage"],
+      [401, "message", "forwarderInvalidTokenWithMessage"],
+      [403, "message", "forwarderInvalidOperationWithMessage"],
+      [401, "error", "forwarderInvalidTokenWithMessage"],
+      [403, "error", "forwarderInvalidOperationWithMessage"],
     ])(
       "throws an invalid token detailed error when HTTP status is %i and the payload has a %s",
       async (status, property, messageKey) => {
@@ -113,8 +113,8 @@ describe("RestClient", () => {
     );
 
     it.each([
-      [401, "forwaderInvalidTokenWithMessage"],
-      [403, "forwaderInvalidOperationWithMessage"],
+      [401, "forwarderInvalidTokenWithMessage"],
+      [403, "forwarderInvalidOperationWithMessage"],
     ])(
       "throws an invalid token detailed error when HTTP status is %i and the payload has a %s",
       async (status, messageKey) => {

--- a/libs/common/src/tools/integration/rpc/rest-client.ts
+++ b/libs/common/src/tools/integration/rpc/rest-client.ts
@@ -48,11 +48,11 @@ export class RestClient {
   private async detectCommonErrors(response: Response): Promise<[string, string] | undefined> {
     if (response.status === 401) {
       const message = await this.tryGetErrorMessage(response);
-      const key = message ? "forwaderInvalidTokenWithMessage" : "forwaderInvalidToken";
+      const key = message ? "forwarderInvalidTokenWithMessage" : "forwarderInvalidToken";
       return [key, message];
     } else if (response.status === 403) {
       const message = await this.tryGetErrorMessage(response);
-      const key = message ? "forwaderInvalidOperationWithMessage" : "forwaderInvalidOperation";
+      const key = message ? "forwarderInvalidOperationWithMessage" : "forwarderInvalidOperation";
       return [key, message];
     } else if (response.status >= 400) {
       const message = await this.tryGetErrorMessage(response);

--- a/libs/tools/export-vault-ui/src/components/export.component.ts
+++ b/libs/tools/export-vault-ui/src/components/export.component.ts
@@ -576,7 +576,7 @@ export class ExportComponent implements OnInit, OnDestroy, AfterViewInit {
       this.toastService.showToast({
         variant: "error",
         title: this.i18nService.t("errorOccurred"),
-        message: this.i18nService.t("filePasswordAndConfirmFilePasswordDoNotMatch"),
+        message: this.i18nService.t("filePasswordConfirmationMismatch"),
       });
       return;
     }
@@ -604,7 +604,7 @@ export class ExportComponent implements OnInit, OnDestroy, AfterViewInit {
   };
 
   private async verifyUser(): Promise<boolean> {
-    let confirmDescription = "exportWarningDesc";
+    let confirmDescription = "exportUnencryptedWarningDesc";
     if (this.isFileEncryptedExport) {
       confirmDescription = "fileEncryptedExportWarningDesc";
     } else if (this.isAccountEncryptedExport) {

--- a/libs/tools/generator/components/src/credential-generator-history-dialog.component.ts
+++ b/libs/tools/generator/components/src/credential-generator-history-dialog.component.ts
@@ -112,7 +112,7 @@ export class CredentialGeneratorHistoryDialogComponent implements OnChanges, OnI
   protected async clear() {
     const confirmed = await this.dialogService.openSimpleDialog({
       title: { key: "clearGeneratorHistoryTitle" },
-      content: { key: "cleargGeneratorHistoryDescription" },
+      content: { key: "clearGeneratorHistoryDescription" },
       type: "warning",
       acceptButtonText: { key: "clearHistory" },
       cancelButtonText: { key: "cancel" },

--- a/libs/vault/src/cipher-form/components/custom-fields/add-edit-custom-field-dialog/add-edit-custom-field-dialog.component.html
+++ b/libs/vault/src/cipher-form/components/custom-fields/add-edit-custom-field-dialog/add-edit-custom-field-dialog.component.html
@@ -22,7 +22,7 @@
       <input bitInput id="fieldLabel" formControlName="label" type="text" />
       @if (customFieldForm.value.type === FieldType.Linked) {
         <bit-hint>
-          {{ "linkedLabelHelpText" | i18n }}
+          {{ "linkedFieldLabelHelpText" | i18n }}
         </bit-hint>
       }
     </bit-form-field>


### PR DESCRIPTION
## 🎟️ Tracking

[PM-40457](https://bitwarden.atlassian.net/browse/PM-40457)

## 📔 Objective

Fix typos in the message catalogs. Note, instances where the change was made _only_ to a catalog entry _value_ still needs a new key, since our translation process does not handle key value updates (only removal/addition).

[PM-40457]: https://bitwarden.atlassian.net/browse/PM-40457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ