### PR TITLE
[PM-40484] Fix Autotype IPC channel mismatch

### DIFF
--- a/apps/desktop/src/autofill/main/main-desktop-autotype.service.spec.ts
+++ b/apps/desktop/src/autofill/main/main-desktop-autotype.service.spec.ts
@@ -116,7 +116,7 @@ describe("MainDesktopAutotypeService", () => {
       );
       expect(ipcMain.on).toHaveBeenCalledWith(AUTOTYPE_IPC_CHANNELS.EXECUTE, expect.any(Function));
       expect(ipcMain.on).toHaveBeenCalledWith(
-        "autofill.completeAutotypeError",
+        AUTOTYPE_IPC_CHANNELS.EXECUTION_ERROR,
         expect.any(Function),
       );
     });
@@ -292,22 +292,22 @@ describe("MainDesktopAutotypeService", () => {
     });
   });
 
-  describe("completeAutotypeError handler", () => {
+  describe("EXECUTION_ERROR handler", () => {
     it("should log autotype match errors", () => {
       const matchError: AutotypeMatchError = {
         windowTitle: "Test Window",
         errorMessage: "No matching vault item",
       };
 
-      const errorHandler = ipcHandlers.get("autofill.completeAutotypeError");
+      const errorHandler = ipcHandlers.get(AUTOTYPE_IPC_CHANNELS.EXECUTION_ERROR);
       errorHandler({}, matchError);
 
       expect(mockLogService.debug).toHaveBeenCalledWith(
-        "autofill.completeAutotypeError",
+        AUTOTYPE_IPC_CHANNELS.EXECUTION_ERROR,
         "No match for window: Test Window",
       );
       expect(mockLogService.error).toHaveBeenCalledWith(
-        "autofill.completeAutotypeError",
+        AUTOTYPE_IPC_CHANNELS.EXECUTION_ERROR,
         "No matching vault item",
       );
     });
@@ -342,6 +342,9 @@ describe("MainDesktopAutotypeService", () => {
       expect(ipcMain.removeAllListeners).toHaveBeenCalledWith(AUTOTYPE_IPC_CHANNELS.TOGGLE);
       expect(ipcMain.removeAllListeners).toHaveBeenCalledWith(AUTOTYPE_IPC_CHANNELS.CONFIGURE);
       expect(ipcMain.removeAllListeners).toHaveBeenCalledWith(AUTOTYPE_IPC_CHANNELS.EXECUTE);
+      expect(ipcMain.removeAllListeners).toHaveBeenCalledWith(
+        AUTOTYPE_IPC_CHANNELS.EXECUTION_ERROR,
+      );
     });
 
     it("should disable autotype", () => {

--- a/apps/desktop/src/autofill/main/main-desktop-autotype.service.ts
+++ b/apps/desktop/src/autofill/main/main-desktop-autotype.service.ts
@@ -53,12 +53,12 @@ export class MainDesktopAutotypeService {
       }
     });
 
-    ipcMain.on("autofill.completeAutotypeError", (_event, matchError: AutotypeMatchError) => {
+    ipcMain.on(AUTOTYPE_IPC_CHANNELS.EXECUTION_ERROR, (_event, matchError: AutotypeMatchError) => {
       this.logService.debug(
-        "autofill.completeAutotypeError",
+        AUTOTYPE_IPC_CHANNELS.EXECUTION_ERROR,
         "No match for window: " + matchError.windowTitle,
       );
-      this.logService.error("autofill.completeAutotypeError", matchError.errorMessage);
+      this.logService.error(AUTOTYPE_IPC_CHANNELS.EXECUTION_ERROR, matchError.errorMessage);
     });
   }
 
@@ -78,6 +78,7 @@ export class MainDesktopAutotypeService {
     ipcMain.removeAllListeners(AUTOTYPE_IPC_CHANNELS.TOGGLE);
     ipcMain.removeAllListeners(AUTOTYPE_IPC_CHANNELS.CONFIGURE);
     ipcMain.removeAllListeners(AUTOTYPE_IPC_CHANNELS.EXECUTE);
+    ipcMain.removeAllListeners(AUTOTYPE_IPC_CHANNELS.EXECUTION_ERROR);
 
     // Also unregister the global shortcut
     this.disableAutotype();


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-40484

## 📔 Objective

**Issue**:

- `apps/desktop/src/autofill/models/ipc-channels.ts` defines a shared constant: `AUTOTYPE_IPC_CHANNELS.EXECUTION_ERROR = "autofill.autotypeExecutionError"`
- The renderer process uses that constant (`apps/desktop/src/autofill/preload.ts:69`)
- The main process doesn’t use it, and uses an older string (see `apps/desktop/src/autofill/main/main-desktop-autotype.service.ts` and search for `autofill.completeAutotypeError`)

This PR fixes the issue by using and following the correct pattern we adopted for the autotype ipc channels.

## 📸 Screenshot

Here is a screenshot of the failure being correctly logged (with the fix from this PR):

<img width="1540" height="229" alt="image" src="https://github.com/user-attachments/assets/e4901339-120c-419d-bb02-503d8209de48" />

## 🧪 Testing

As this is only a small refactor for logging, I don't think QA is needed. The reviewer of this PR can feel free to disagree, I'm good either way. I did test locally that the failure is correctly logged; see the screenshot above.
