### PR TITLE
feat(shared-unlock): support trusted devices

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -7023,7 +7023,7 @@
     "message": "When enabled, unlock state will be shared with Bitwarden web vaults."
   },
   "sharedUnlockUnavailableUntrustedDevice": {
-    "message": "Shared unlock is unavailable because you didn't trust this device when logging in. Log in again and trust this device to use shared unlock."
+    "message": "Shared unlock is not available because you chose not to remember this device. To enable this setting, try logging in again."
   },
   "newPermissionNeeded": {
     "message": "New permission needed"

--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -7022,6 +7022,9 @@
   "sharedUnlockWithWebDescription": {
     "message": "When enabled, unlock state will be shared with Bitwarden web vaults."
   },
+  "sharedUnlockUnavailableUntrustedDevice": {
+    "message": "Shared unlock is unavailable because you didn't trust this device when logging in. Log in again and trust this device to use shared unlock."
+  },
   "newPermissionNeeded": {
     "message": "New permission needed"
   },

--- a/apps/browser/src/auth/popup/settings/account-security.component.html
+++ b/apps/browser/src/auth/popup/settings/account-security.component.html
@@ -115,6 +115,11 @@
                 </bit-hint>
               </bit-form-control>
             }
+            @if (unlockSharingDisabled()) {
+              <bit-hint class="tw-mt-2 tw-text-sm">
+                {{ "sharedUnlockUnavailableUntrustedDevice" | i18n }}
+              </bit-hint>
+            }
           }
         </bit-card>
       </bit-section>

--- a/apps/browser/src/auth/popup/settings/account-security.component.spec.ts
+++ b/apps/browser/src/auth/popup/settings/account-security.component.spec.ts
@@ -169,6 +169,7 @@ describe("AccountSecurityComponent", () => {
     sharedUnlockSettingsService.allowSharingUnlockStateWithWeb$.mockReturnValue(of(false));
     sharedUnlockSettingsService.setAllowSharingUnlockStateWithDesktop.mockResolvedValue(undefined);
     sharedUnlockSettingsService.setAllowSharingUnlockStateWithWeb.mockResolvedValue(undefined);
+    sharedUnlockSettingsService.unlockSharingDisabled$.mockReturnValue(of(false));
 
     policyService.policiesByType$.mockReturnValue(of([null]));
 
@@ -480,6 +481,45 @@ describe("AccountSecurityComponent", () => {
       expect(
         sharedUnlockSettingsService.setAllowSharingUnlockStateWithDesktop,
       ).toHaveBeenCalledWith(false, mockUserId);
+    });
+  });
+
+  describe("unlock sharing disabled for untrusted device", () => {
+    beforeEach(() => {
+      policyService.policiesByType$.mockReturnValue(of([null]));
+      // The shared unlock feature flag is read in the constructor, so rebuild the fixture with it on.
+      configService.getFeatureFlag$.mockReturnValue(of(true));
+    });
+
+    it("disables the shared unlock toggles and shows the message", async () => {
+      sharedUnlockSettingsService.unlockSharingDisabled$.mockReturnValue(of(true));
+
+      fixture = TestBed.createComponent(AccountSecurityComponent);
+      component = fixture.componentInstance;
+
+      await component.ngOnInit();
+      fixture.detectChanges();
+
+      expect(component.form.controls.allowSharingUnlockStateWithDesktop.disabled).toBe(true);
+      expect(component.form.controls.allowSharingUnlockStateWithWeb.disabled).toBe(true);
+      expect(
+        fixture.nativeElement.textContent.includes(
+          "sharedUnlockUnavailableUntrustedDevice-used-i18n",
+        ),
+      ).toBe(true);
+    });
+
+    it("leaves the toggles enabled when sharing is not disabled", async () => {
+      sharedUnlockSettingsService.unlockSharingDisabled$.mockReturnValue(of(false));
+
+      fixture = TestBed.createComponent(AccountSecurityComponent);
+      component = fixture.componentInstance;
+
+      await component.ngOnInit();
+      fixture.detectChanges();
+
+      expect(component.form.controls.allowSharingUnlockStateWithDesktop.disabled).toBe(false);
+      expect(component.form.controls.allowSharingUnlockStateWithWeb.disabled).toBe(false);
     });
   });
 });

--- a/apps/browser/src/auth/popup/settings/account-security.component.ts
+++ b/apps/browser/src/auth/popup/settings/account-security.component.ts
@@ -131,6 +131,9 @@ export class AccountSecurityComponent implements OnInit, OnDestroy {
   protected readonly showSharedUnlockWithDesktop: boolean;
   // Firefox does not support sharing unlock state with the web vault.
   protected readonly showSharedUnlockWithWeb: boolean;
+  // True when the user declined to trust this TDE device, disabling shared unlock. The value cannot
+  // change while this page is open, so it is read once during init.
+  protected readonly unlockSharingDisabled = signal(false);
 
   protected refreshTimeoutSettings$ = new BehaviorSubject<void>(undefined);
   private destroy$ = new Subject<void>();
@@ -208,6 +211,16 @@ export class AccountSecurityComponent implements OnInit, OnDestroy {
       ),
     };
     this.form.patchValue(initialValues, { emitEvent: false });
+
+    const unlockSharingDisabled = await firstValueFrom(
+      this.sharedUnlockSettingsService.unlockSharingDisabled$(activeAccount.id),
+    );
+    this.unlockSharingDisabled.set(unlockSharingDisabled);
+    if (unlockSharingDisabled) {
+      this.form.controls.allowSharingUnlockStateWithDesktop.disable({ emitEvent: false });
+      this.form.controls.allowSharingUnlockStateWithWeb.disable({ emitEvent: false });
+    }
+
     this.loading.set(false);
 
     this.showChangeMasterPass = await this.userVerificationService.hasMasterPassword();

--- a/apps/browser/src/key-management/lock/services/extension-lock-component.service.spec.ts
+++ b/apps/browser/src/key-management/lock/services/extension-lock-component.service.spec.ts
@@ -404,6 +404,7 @@ describe("ExtensionLockComponentService", () => {
       configService.getFeatureFlag$.mockReturnValue(of(false));
       sharedUnlockSettingsService.allowSharingUnlockStateWithDesktop$.mockReturnValue(of(false));
       sharedUnlockSettingsService.allowSharingUnlockStateWithWeb$.mockReturnValue(of(false));
+      sharedUnlockSettingsService.unlockSharingDisabled$.mockReturnValue(of(false));
 
       const unlockOptions = await firstValueFrom(service.getAvailableUnlockOptions$(userId));
 

--- a/apps/browser/src/key-management/lock/services/extension-lock-component.service.ts
+++ b/apps/browser/src/key-management/lock/services/extension-lock-component.service.ts
@@ -74,12 +74,19 @@ export class ExtensionLockComponentService implements LockComponentService {
       combineLatest([
         this.configService.getFeatureFlag$(FeatureFlag.SharedUnlockPart2),
         this.sharedUnlockSettingsService.allowSharingUnlockStateWithDesktop$(userId),
+        this.sharedUnlockSettingsService.unlockSharingDisabled$(userId),
         // Check biometricUnlockEnabled$ first to avoid background native messaging & IPC calls when biometrics is disabled.
         this.biometricStateService.biometricUnlockEnabled$(userId),
       ]).pipe(
         switchMap(
-          async ([sharedUnlockFeatureFlag, allowSharingWithDesktop, biometricUnlockEnabled]) =>
-            biometricUnlockEnabled || (sharedUnlockFeatureFlag && allowSharingWithDesktop)
+          async ([
+            sharedUnlockFeatureFlag,
+            allowSharingWithDesktop,
+            unlockSharingDisabled,
+            biometricUnlockEnabled,
+          ]) =>
+            biometricUnlockEnabled ||
+            (sharedUnlockFeatureFlag && allowSharingWithDesktop && !unlockSharingDisabled)
               ? await this.biometricsService.getBiometricsStatusForUser(userId)
               : BiometricsStatus.NotEnabledLocally,
         ),

--- a/libs/auth/src/angular/login-decryption-options/login-decryption-options.component.spec.ts
+++ b/libs/auth/src/angular/login-decryption-options/login-decryption-options.component.spec.ts
@@ -12,20 +12,18 @@ import { Router } from "@angular/router";
 import { mock, MockProxy } from "jest-mock-extended";
 import { BehaviorSubject, of } from "rxjs";
 
-import {
-  LoginEmailServiceAbstraction,
-  LogoutService,
-  UserDecryptionOptionsServiceAbstraction,
-} from "@bitwarden/auth/common";
+import { LogoutService, UserDecryptionOptionsServiceAbstraction } from "@bitwarden/auth/common";
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import { OrganizationApiServiceAbstraction } from "@bitwarden/common/admin-console/abstractions/organization/organization-api.service.abstraction";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { AuthService } from "@bitwarden/common/auth/abstractions/auth.service";
 import { PasswordResetEnrollmentServiceAbstraction } from "@bitwarden/common/auth/abstractions/password-reset-enrollment.service.abstraction";
 import { SsoLoginServiceAbstraction } from "@bitwarden/common/auth/abstractions/sso-login.service.abstraction";
+import { AuthenticationStatus } from "@bitwarden/common/auth/enums/authentication-status";
 import { ClientType } from "@bitwarden/common/enums";
 import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { DeviceTrustServiceAbstraction } from "@bitwarden/common/key-management/device-trust/abstractions/device-trust.service.abstraction";
-import { SecurityStateService } from "@bitwarden/common/key-management/security-state/abstractions/security-state.service";
+import { SharedUnlockSettingsService } from "@bitwarden/common/key-management/shared-unlock";
 import { SignedSecurityState } from "@bitwarden/common/key-management/types";
 import { AppIdService } from "@bitwarden/common/platform/abstractions/app-id.service";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
@@ -55,7 +53,6 @@ describe("LoginDecryptionOptionsComponent", () => {
   let i18nService: MockProxy<I18nService>;
   let keyService: MockProxy<KeyService>;
   let loginDecryptionOptionsService: MockProxy<LoginDecryptionOptionsService>;
-  let loginEmailService: MockProxy<LoginEmailServiceAbstraction>;
   let messagingService: MockProxy<MessagingService>;
   let organizationApiService: MockProxy<OrganizationApiServiceAbstraction>;
   let passwordResetEnrollmentService: MockProxy<PasswordResetEnrollmentServiceAbstraction>;
@@ -67,10 +64,11 @@ describe("LoginDecryptionOptionsComponent", () => {
   let validationService: MockProxy<ValidationService>;
   let logoutService: MockProxy<LogoutService>;
   let registerSdkService: MockProxy<RegisterSdkService>;
-  let securityStateService: MockProxy<SecurityStateService>;
   let appIdService: MockProxy<AppIdService>;
   let configService: MockProxy<ConfigService>;
   let accountCryptographicStateService: MockProxy<any>;
+  let authService: MockProxy<AuthService>;
+  let sharedUnlockSettingsService: MockProxy<SharedUnlockSettingsService>;
 
   const mockUserId = "user-id-123" as UserId;
   const mockEmail = "test@example.com";
@@ -87,7 +85,6 @@ describe("LoginDecryptionOptionsComponent", () => {
     i18nService = mock<I18nService>();
     keyService = mock<KeyService>();
     loginDecryptionOptionsService = mock<LoginDecryptionOptionsService>();
-    loginEmailService = mock<LoginEmailServiceAbstraction>();
     messagingService = mock<MessagingService>();
     organizationApiService = mock<OrganizationApiServiceAbstraction>();
     passwordResetEnrollmentService = mock<PasswordResetEnrollmentServiceAbstraction>();
@@ -99,12 +96,17 @@ describe("LoginDecryptionOptionsComponent", () => {
     validationService = mock<ValidationService>();
     logoutService = mock<LogoutService>();
     registerSdkService = mock<RegisterSdkService>();
-    securityStateService = mock<SecurityStateService>();
     appIdService = mock<AppIdService>();
     configService = mock<ConfigService>();
     accountCryptographicStateService = mock();
+    authService = mock<AuthService>();
+    sharedUnlockSettingsService = mock<SharedUnlockSettingsService>();
 
     // Setup default mocks
+    authService.authStatusFor$.mockReturnValue(of(AuthenticationStatus.Locked));
+    // takeUntilDestroyed short-circuits when destroyRef.destroyed is truthy; the auto-mock returns a
+    // truthy stub for it, so force it false to keep those streams alive during the test.
+    (destroyRef as { destroyed: boolean }).destroyed = false;
     accountService.activeAccount$ = new BehaviorSubject({
       id: mockUserId,
       email: mockEmail,
@@ -114,6 +116,8 @@ describe("LoginDecryptionOptionsComponent", () => {
     });
     platformUtilsService.getClientType.mockReturnValue(ClientType.Browser);
     deviceTrustService.getShouldTrustDevice.mockResolvedValue(true);
+    deviceTrustService.setShouldTrustDevice.mockResolvedValue(undefined);
+    sharedUnlockSettingsService.setUnlockSharingDisabled.mockResolvedValue(undefined);
     i18nService.t.mockImplementation((key: string) => key);
 
     component = new LoginDecryptionOptionsComponent(
@@ -127,7 +131,6 @@ describe("LoginDecryptionOptionsComponent", () => {
       i18nService,
       keyService,
       loginDecryptionOptionsService,
-      loginEmailService,
       messagingService,
       organizationApiService,
       passwordResetEnrollmentService,
@@ -139,10 +142,11 @@ describe("LoginDecryptionOptionsComponent", () => {
       validationService,
       logoutService,
       registerSdkService,
-      securityStateService,
       appIdService,
       configService,
       accountCryptographicStateService,
+      authService,
+      sharedUnlockSettingsService,
     );
   });
 
@@ -318,6 +322,57 @@ describe("LoginDecryptionOptionsComponent", () => {
       });
       expect(loginDecryptionOptionsService.handleCreateUserSuccess).toHaveBeenCalled();
       expect(router.navigate).toHaveBeenCalledWith(["/tabs/vault"]);
+      // Remember device defaults to true, so shared unlock is not disabled.
+      expect(sharedUnlockSettingsService.setUnlockSharingDisabled).toHaveBeenCalledWith(
+        mockUserId,
+        false,
+      );
+    });
+
+    it("should disable shared unlock when the user proceeds without trusting the device", async () => {
+      configService.getFeatureFlag.mockResolvedValue(true);
+      loginDecryptionOptionsService.handleCreateUserSuccess.mockResolvedValue(undefined);
+      router.navigate.mockResolvedValue(true);
+      appIdService.getAppId.mockResolvedValue("mock-app-id");
+      organizationApiService.getKeys.mockResolvedValue({
+        publicKey: "mock-org-public-key",
+        privateKey: "mock-org-private-key",
+      } as any);
+
+      component["formGroup"].controls.rememberDevice.setValue(false);
+
+      await component["createUser"]();
+
+      expect(sharedUnlockSettingsService.setUnlockSharingDisabled).toHaveBeenCalledWith(
+        mockUserId,
+        true,
+      );
+      expect(
+        sharedUnlockSettingsService.setAllowSharingUnlockStateWithDesktop,
+      ).toHaveBeenCalledWith(false, mockUserId);
+      expect(sharedUnlockSettingsService.setAllowSharingUnlockStateWithWeb).toHaveBeenCalledWith(
+        false,
+        mockUserId,
+      );
+    });
+
+    it("does not clear the allow-sharing settings when the user trusts the device", async () => {
+      configService.getFeatureFlag.mockResolvedValue(true);
+      loginDecryptionOptionsService.handleCreateUserSuccess.mockResolvedValue(undefined);
+      router.navigate.mockResolvedValue(true);
+      appIdService.getAppId.mockResolvedValue("mock-app-id");
+      organizationApiService.getKeys.mockResolvedValue({
+        publicKey: "mock-org-public-key",
+        privateKey: "mock-org-private-key",
+      } as any);
+
+      // Remember device defaults to true.
+      await component["createUser"]();
+
+      expect(
+        sharedUnlockSettingsService.setAllowSharingUnlockStateWithDesktop,
+      ).not.toHaveBeenCalled();
+      expect(sharedUnlockSettingsService.setAllowSharingUnlockStateWithWeb).not.toHaveBeenCalled();
     });
 
     it("should use legacy registration when feature flag is disabled", async () => {
@@ -367,6 +422,49 @@ describe("LoginDecryptionOptionsComponent", () => {
       // Verify navigation
       expect(loginDecryptionOptionsService.handleCreateUserSuccess).toHaveBeenCalled();
       expect(router.navigate).toHaveBeenCalledWith(["/tabs/vault"]);
+    });
+  });
+
+  describe("shared unlock bootstrap on existing untrusted device", () => {
+    beforeEach(() => {
+      userDecryptionOptionsService.userDecryptionOptionsById$.mockReturnValue(
+        of({
+          trustedDeviceOption: {
+            hasAdminApproval: true,
+            hasLoginApprovingDevice: false,
+            hasManageResetPasswordPermission: false,
+            isTdeOffboarding: false,
+          },
+          hasMasterPassword: true,
+          keyConnectorOption: undefined,
+        }),
+      );
+      deviceTrustService.trustDevice.mockResolvedValue(undefined);
+      router.navigate.mockResolvedValue(true);
+    });
+
+    it("trusts the device and navigates to the vault when the account is unlocked externally", async () => {
+      authService.authStatusFor$.mockReturnValue(of(AuthenticationStatus.Unlocked));
+
+      await component.ngOnInit();
+      // Allow the switchMap/defer async work to run.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(deviceTrustService.trustDevice).toHaveBeenCalledWith(mockUserId);
+      expect(sharedUnlockSettingsService.setUnlockSharingDisabled).toHaveBeenCalledWith(
+        mockUserId,
+        false,
+      );
+      expect(router.navigate).toHaveBeenCalledWith(["/tabs/vault"]);
+    });
+
+    it("does not trust the device while the account remains locked", async () => {
+      authService.authStatusFor$.mockReturnValue(of(AuthenticationStatus.Locked));
+
+      await component.ngOnInit();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(deviceTrustService.trustDevice).not.toHaveBeenCalled();
     });
   });
 });

--- a/libs/auth/src/angular/login-decryption-options/login-decryption-options.component.ts
+++ b/libs/auth/src/angular/login-decryption-options/login-decryption-options.component.ts
@@ -9,17 +9,18 @@ import {
   catchError,
   concatMap,
   defer,
+  filter,
   firstValueFrom,
   from,
   map,
   of,
   switchMap,
+  take,
   throwError,
 } from "rxjs";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 import {
-  LoginEmailServiceAbstraction,
   LogoutService,
   UserDecryptionOptions,
   UserDecryptionOptionsServiceAbstraction,
@@ -27,13 +28,15 @@ import {
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import { OrganizationApiServiceAbstraction } from "@bitwarden/common/admin-console/abstractions/organization/organization-api.service.abstraction";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { AuthService } from "@bitwarden/common/auth/abstractions/auth.service";
 import { PasswordResetEnrollmentServiceAbstraction } from "@bitwarden/common/auth/abstractions/password-reset-enrollment.service.abstraction";
 import { SsoLoginServiceAbstraction } from "@bitwarden/common/auth/abstractions/sso-login.service.abstraction";
+import { AuthenticationStatus } from "@bitwarden/common/auth/enums/authentication-status";
 import { ClientType } from "@bitwarden/common/enums";
 import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { AccountCryptographicStateService } from "@bitwarden/common/key-management/account-cryptography/account-cryptographic-state.service";
 import { DeviceTrustServiceAbstraction } from "@bitwarden/common/key-management/device-trust/abstractions/device-trust.service.abstraction";
-import { SecurityStateService } from "@bitwarden/common/key-management/security-state/abstractions/security-state.service";
+import { SharedUnlockSettingsService } from "@bitwarden/common/key-management/shared-unlock";
 import { KeysRequest } from "@bitwarden/common/models/request/keys.request";
 import { AppIdService } from "@bitwarden/common/platform/abstractions/app-id.service";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
@@ -123,7 +126,6 @@ export class LoginDecryptionOptionsComponent implements OnInit {
     private i18nService: I18nService,
     private keyService: KeyService,
     private loginDecryptionOptionsService: LoginDecryptionOptionsService,
-    private loginEmailService: LoginEmailServiceAbstraction,
     private messagingService: MessagingService,
     private organizationApiService: OrganizationApiServiceAbstraction,
     private passwordResetEnrollmentService: PasswordResetEnrollmentServiceAbstraction,
@@ -135,10 +137,11 @@ export class LoginDecryptionOptionsComponent implements OnInit {
     private validationService: ValidationService,
     private logoutService: LogoutService,
     private registerSdkService: RegisterSdkService,
-    private securityStateService: SecurityStateService,
     private appIdService: AppIdService,
     private configService: ConfigService,
     private accountCryptographicStateService: AccountCryptographicStateService,
+    private authService: AuthService,
+    private sharedUnlockSettingsService: SharedUnlockSettingsService,
   ) {
     this.clientType = this.platformUtilsService.getClientType();
   }
@@ -177,6 +180,7 @@ export class LoginDecryptionOptionsComponent implements OnInit {
         await this.loadNewUserData();
       } else {
         this.loadExistingUserUntrustedDeviceData(userDecryptionOptions);
+        this.observeSharedUnlockBootstrap();
       }
     } catch (err) {
       this.validationService.showError(err);
@@ -272,6 +276,61 @@ export class LoginDecryptionOptionsComponent implements OnInit {
     this.canApproveWithMasterPassword = userDecryptionOptions?.hasMasterPassword || false;
   }
 
+  /**
+   * While the user sits on this screen, another of their clients may share its unlock state (the
+   * User Key) with this one via shared unlock. If this happens, we should trust the current device
+   * and auto-navigate.
+   */
+  private observeSharedUnlockBootstrap() {
+    this.authService
+      .authStatusFor$(this.activeAccountId)
+      .pipe(
+        filter((status) => status === AuthenticationStatus.Unlocked),
+        take(1),
+        switchMap(() => defer(() => this.handleSharedUnlockBootstrap())),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe();
+  }
+
+  private async handleSharedUnlockBootstrap() {
+    try {
+      await this.deviceTrustService.trustDevice(this.activeAccountId);
+      await this.sharedUnlockSettingsService.setUnlockSharingDisabled(this.activeAccountId, false);
+      await this.handleCreateUserSuccessNavigation();
+    } catch (err) {
+      this.validationService.showError(err);
+    }
+  }
+
+  /**
+   * Records the consequence of the user's trust choice for shared unlock: a TDE device the user
+   * declined to trust ("remember this device" unchecked) must not participate in shared unlock.
+   * Called when the user proceeds off this screen; trusting itself is handled by the existing
+   * shouldTrustDevice -> trustDeviceIfRequired paths after unlock.
+   */
+  private async persistUnlockSharingChoice() {
+    const trustDevice = this.rememberDeviceControl.value;
+
+    await this.sharedUnlockSettingsService.setUnlockSharingDisabled(
+      this.activeAccountId,
+      !trustDevice,
+    );
+
+    // An untrusted device must not share its unlock state with other clients, so turn both
+    // allow-sharing settings off.
+    if (!trustDevice) {
+      await this.sharedUnlockSettingsService.setAllowSharingUnlockStateWithDesktop(
+        false,
+        this.activeAccountId,
+      );
+      await this.sharedUnlockSettingsService.setAllowSharingUnlockStateWithWeb(
+        false,
+        this.activeAccountId,
+      );
+    }
+  }
+
   protected createUser = async () => {
     if (this.state !== State.NewUser) {
       return;
@@ -347,6 +406,8 @@ export class LoginDecryptionOptionsComponent implements OnInit {
         message: this.i18nService.t("accountSuccessfullyCreated"),
       });
 
+      await this.persistUnlockSharingChoice();
+
       await this.loginDecryptionOptionsService.handleCreateUserSuccess();
 
       if (this.clientType === ClientType.Desktop) {
@@ -368,10 +429,12 @@ export class LoginDecryptionOptionsComponent implements OnInit {
   }
 
   protected async approveFromOtherDevice() {
+    await this.persistUnlockSharingChoice();
     await this.router.navigate(["/login-with-device"]);
   }
 
   protected async approveWithMasterPassword() {
+    await this.persistUnlockSharingChoice();
     await this.router.navigate(["/lock"], {
       queryParams: {
         from: "login-initiated",
@@ -380,6 +443,7 @@ export class LoginDecryptionOptionsComponent implements OnInit {
   }
 
   protected async requestAdminApproval() {
+    await this.persistUnlockSharingChoice();
     await this.router.navigate(["/admin-approval-requested"]);
   }
 

--- a/libs/common/src/key-management/shared-unlock/default-shared-unlock-follower.service.ts
+++ b/libs/common/src/key-management/shared-unlock/default-shared-unlock-follower.service.ts
@@ -76,6 +76,10 @@ export class DefaultSharedUnlockFollowerService implements SharedUnlockFollowerS
   }
 
   private async enabled(userId: UserId): Promise<boolean> {
+    if (await firstValueFrom(this.sharedUnlockSettingsService.unlockSharingDisabled$(userId))) {
+      return false;
+    }
+
     if (this.platformUtilsService.getClientType() === ClientType.Browser) {
       return await firstValueFrom(
         this.sharedUnlockSettingsService.allowSharingUnlockStateWithDesktop$(userId),

--- a/libs/common/src/key-management/shared-unlock/default-shared-unlock-leader.service.ts
+++ b/libs/common/src/key-management/shared-unlock/default-shared-unlock-leader.service.ts
@@ -75,6 +75,10 @@ export class DefaultSharedUnlockLeaderService implements SharedUnlockLeaderServi
   }
 
   private async enabled(userId: UserId): Promise<boolean> {
+    if (await firstValueFrom(this.sharedUnlockSettingsService.unlockSharingDisabled$(userId))) {
+      return false;
+    }
+
     if (this.platformUtilsService.getClientType() === ClientType.Browser) {
       return await firstValueFrom(
         this.sharedUnlockSettingsService.allowSharingUnlockStateWithWeb$(userId),

--- a/libs/common/src/key-management/shared-unlock/default-shared-unlock-settings.service.ts
+++ b/libs/common/src/key-management/shared-unlock/default-shared-unlock-settings.service.ts
@@ -27,9 +27,19 @@ const ALLOW_SHARING_UNLOCK_STATE_WITH_WEB = new UserKeyDefinition<boolean>(
   },
 );
 
+const UNLOCK_SHARING_DISABLED = new UserKeyDefinition<boolean>(
+  SHARED_UNLOCK_SETTINGS_DISK,
+  "unlockSharingDisabled",
+  {
+    deserializer: (b) => b,
+    clearOn: ["logout"],
+  },
+);
+
 // Default off because of native messaging permission
 const DEFAULT_ALLOW_SHARING_UNLOCK_STATE_WITH_DESKTOP = false;
 const DEFAULT_ALLOW_SHARING_UNLOCK_STATE_WITH_WEB = true;
+const DEFAULT_UNLOCK_SHARING_DISABLED = false;
 
 export class DefaultSharedUnlockSettingsService extends SharedUnlockSettingsService {
   constructor(private stateProvider: StateProvider) {
@@ -58,5 +68,15 @@ export class DefaultSharedUnlockSettingsService extends SharedUnlockSettingsServ
     await this.stateProvider
       .getUser(userId, ALLOW_SHARING_UNLOCK_STATE_WITH_WEB)
       .update(() => value);
+  }
+
+  unlockSharingDisabled$(userId: UserId): Observable<boolean> {
+    return this.stateProvider
+      .getUserState$(UNLOCK_SHARING_DISABLED, userId)
+      .pipe(map((v) => v ?? DEFAULT_UNLOCK_SHARING_DISABLED));
+  }
+
+  async setUnlockSharingDisabled(userId: UserId, value: boolean): Promise<void> {
+    await this.stateProvider.getUser(userId, UNLOCK_SHARING_DISABLED).update(() => value);
   }
 }

--- a/libs/common/src/key-management/shared-unlock/shared-unlock-settings.service.ts
+++ b/libs/common/src/key-management/shared-unlock/shared-unlock-settings.service.ts
@@ -8,4 +8,14 @@ export abstract class SharedUnlockSettingsService {
 
   abstract allowSharingUnlockStateWithWeb$(userId: UserId): Observable<boolean>;
   abstract setAllowSharingUnlockStateWithWeb(value: boolean, userId: UserId): Promise<void>;
+
+  /**
+   * Whether shared unlock is disabled for the user on the current device. Set when the user proceeds
+   * through the login-decryption-options screen without trusting the device: a trusted-device
+   * encryption (TDE) device the user declined to trust must not participate in shared unlock, since
+   * receiving/sharing the User Key would bypass the device-trust requirement. Cleared on logout, so a
+   * subsequent login can re-establish trust.
+   */
+  abstract unlockSharingDisabled$(userId: UserId): Observable<boolean>;
+  abstract setUnlockSharingDisabled(userId: UserId, value: boolean): Promise<void>;
 }


### PR DESCRIPTION
https://bitwarden.atlassian.net/browse/PM-37678

Add support for TDE devices during shared unlock. The intent is that:
1. Only trusted devices share unlock. Untrusted devices for TDE accounts *DO NOT* share unlock
2. If you trust your device, all devices unlocked by it will be trusted.
   - I.e "Device" here really means device, not "client" (what we call device internally).
3. For this, we must handle the unlock event emitted by shared unlock, trust the device and navigate away on the login decryption options component
4. If we extend to shared login, the idea is the same, you trust your device, and all clients on the device will be logged in and trusted. Shared login is not implemented here, but we are planning for how we will support it in the future.