### PR TITLE
[PM-40381] desktop-autofill: FIDO2 UI cancellation

### DIFF
--- a/apps/desktop/src/autofill/services/desktop-fido2-user-interface.service.spec.ts
+++ b/apps/desktop/src/autofill/services/desktop-fido2-user-interface.service.spec.ts
@@ -1,0 +1,280 @@
+import { Router } from "@angular/router";
+import { mock, MockProxy } from "jest-mock-extended";
+import { BehaviorSubject } from "rxjs";
+
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { AuthService } from "@bitwarden/common/auth/abstractions/auth.service";
+import { AuthenticationStatus } from "@bitwarden/common/auth/enums/authentication-status";
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
+import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+
+import { DesktopSettingsService } from "../../platform/services/desktop-settings.service";
+
+import { DesktopFido2UserInterfaceSession } from "./desktop-fido2-user-interface.service";
+
+/** Resolves after all pending microtasks so in-flight subscriptions are set up. */
+const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+/** Reason produced by `AbortSignal.timeout`. */
+const timeoutReason = () => new DOMException("The operation timed out.", "TimeoutError");
+
+describe("DesktopFido2UserInterfaceSession", () => {
+  let authService: MockProxy<AuthService>;
+  let cipherService: MockProxy<CipherService>;
+  let accountService: MockProxy<AccountService>;
+  let logService: MockProxy<LogService>;
+  let router: MockProxy<Router>;
+  let desktopSettingsService: MockProxy<DesktopSettingsService>;
+
+  let activeAccountStatus$: BehaviorSubject<AuthenticationStatus>;
+  let abortController: AbortController;
+  // Stands in for the deadline `AbortSignal.timeout(...)` would produce, so tests
+  // can fire the timeout deterministically instead of waiting real time.
+  let deadlineController: AbortController;
+
+  let session: DesktopFido2UserInterfaceSession;
+
+  // The desktop test environment runs on jest-environment-jsdom's bundled
+  // jsdom@20, which predates the `AbortSignal.timeout`/`AbortSignal.any` statics
+  // and `AbortSignal.prototype.throwIfAborted` the service relies on (all present
+  // in the Electron/Chromium runtime). Polyfill them for the duration of each
+  // test: a controllable `timeout`, a faithful `any` that mirrors the reason of
+  // whichever input aborts first, and the standard `throwIfAborted`.
+  const originalTimeout = (AbortSignal as any).timeout;
+  const originalAny = (AbortSignal as any).any;
+  const originalThrowIfAborted = (AbortSignal.prototype as any).throwIfAborted;
+
+  beforeEach(() => {
+    authService = mock<AuthService>();
+    cipherService = mock<CipherService>();
+    accountService = mock<AccountService>();
+    logService = mock<LogService>();
+    router = mock<Router>();
+    desktopSettingsService = mock<DesktopSettingsService>();
+
+    activeAccountStatus$ = new BehaviorSubject<AuthenticationStatus>(AuthenticationStatus.Unlocked);
+    authService.activeAccountStatus$ = activeAccountStatus$;
+
+    abortController = new AbortController();
+    deadlineController = new AbortController();
+
+    (AbortSignal as any).timeout = jest.fn(() => deadlineController.signal);
+    (AbortSignal as any).any = (signals: AbortSignal[]) => {
+      const combined = new AbortController();
+      for (const signal of signals) {
+        if (signal.aborted) {
+          combined.abort(signal.reason);
+          break;
+        }
+        signal.addEventListener("abort", () => combined.abort(signal.reason), { once: true });
+      }
+      return combined.signal;
+    };
+    (AbortSignal.prototype as any).throwIfAborted = function (this: AbortSignal) {
+      if (this.aborted) {
+        throw this.reason;
+      }
+    };
+
+    session = new DesktopFido2UserInterfaceSession(
+      authService,
+      cipherService,
+      accountService,
+      logService,
+      router,
+      desktopSettingsService,
+      abortController,
+      {},
+    );
+  });
+
+  afterEach(() => {
+    (AbortSignal as any).timeout = originalTimeout;
+    (AbortSignal as any).any = originalAny;
+    if (originalThrowIfAborted === undefined) {
+      delete (AbortSignal.prototype as any).throwIfAborted;
+    } else {
+      (AbortSignal.prototype as any).throwIfAborted = originalThrowIfAborted;
+    }
+    jest.restoreAllMocks();
+  });
+
+  describe("pickCredential", () => {
+    const params = {
+      cipherIds: ["cipher-1", "cipher-2"],
+      userVerification: true,
+      assumeUserPresence: false,
+      masterPasswordRepromptRequired: false,
+    };
+
+    it("returns the single cipher without showing UI when user presence is assumed", async () => {
+      await expect(
+        session.pickCredential({
+          cipherIds: ["cipher-1"],
+          userVerification: true,
+          assumeUserPresence: true,
+          masterPasswordRepromptRequired: false,
+        }),
+      ).resolves.toEqual({ cipherId: "cipher-1", userVerified: true });
+
+      expect(desktopSettingsService.setModalMode).not.toHaveBeenCalledWith(
+        true,
+        expect.anything(),
+        expect.anything(),
+      );
+    });
+
+    it("resolves with the cipher the user selects", async () => {
+      const result = session.pickCredential(params);
+      await tick();
+
+      session.confirmChosenCipher("cipher-2", true);
+
+      await expect(result).resolves.toEqual({ cipherId: "cipher-2", userVerified: true });
+    });
+
+    it("resolves to no cipher and logs cancellation when the request is aborted", async () => {
+      const result = session.pickCredential(params);
+      await tick();
+
+      abortController.abort("Operation cancelled");
+
+      await expect(result).resolves.toEqual({ cipherId: undefined, userVerified: false });
+      expect(logService.warning).toHaveBeenCalledWith(
+        "Request was cancelled before the user selected a cipher",
+        expect.anything(),
+      );
+    });
+
+    it("resolves to no cipher and logs a timeout (not a cancellation) when the deadline elapses", async () => {
+      const result = session.pickCredential(params);
+      await tick();
+
+      deadlineController.abort(timeoutReason());
+
+      await expect(result).resolves.toEqual({ cipherId: undefined, userVerified: false });
+      expect(logService.warning).toHaveBeenCalledWith(
+        "Timeout: User did not select a cipher within the allowed time",
+      );
+      expect(logService.warning).not.toHaveBeenCalledWith(
+        "Request was cancelled before the user selected a cipher",
+        expect.anything(),
+      );
+    });
+  });
+
+  describe("confirmNewCredential", () => {
+    const params = {
+      credentialName: "Example",
+      userName: "user@example.com",
+      userHandle: "handle",
+      userVerification: true,
+      rpId: "example.com",
+    };
+
+    it("updates and returns the existing cipher when one was provided by the UI", async () => {
+      const userId = "user-1";
+      accountService.activeAccount$ = new BehaviorSubject({ id: userId } as any);
+      const existing = new CipherView();
+      existing.id = "cipher-1";
+
+      const result = session.confirmNewCredential(params);
+      await tick();
+
+      session.notifyConfirmCreateCredential(true, existing);
+
+      await expect(result).resolves.toEqual({ cipherId: "cipher-1", userVerified: true });
+      expect(cipherService.updateWithServer).toHaveBeenCalledWith(existing, userId);
+    });
+
+    it("returns no cipher when the user declines", async () => {
+      const result = session.confirmNewCredential(params);
+      await tick();
+
+      session.notifyConfirmCreateCredential(false);
+
+      await expect(result).resolves.toEqual({ cipherId: undefined, userVerified: false });
+    });
+
+    it("returns no cipher and logs cancellation when the request is aborted", async () => {
+      const result = session.confirmNewCredential(params);
+      await tick();
+
+      abortController.abort("Operation cancelled");
+
+      await expect(result).resolves.toEqual({ cipherId: undefined, userVerified: false });
+      expect(logService.warning).toHaveBeenCalledWith(
+        "Request was cancelled before the user confirmed a cipher",
+      );
+    });
+  });
+
+  describe("ensureUnlockedVault", () => {
+    it("returns without showing the lock UI when the vault is already unlocked", async () => {
+      activeAccountStatus$.next(AuthenticationStatus.Unlocked);
+
+      await expect(session.ensureUnlockedVault()).resolves.toBeUndefined();
+      expect(desktopSettingsService.setModalMode).not.toHaveBeenCalledWith(
+        true,
+        expect.anything(),
+        expect.anything(),
+      );
+    });
+
+    it("shows the lock UI, then navigates home once the vault unlocks", async () => {
+      activeAccountStatus$.next(AuthenticationStatus.Locked);
+
+      const result = session.ensureUnlockedVault();
+      await tick();
+      activeAccountStatus$.next(AuthenticationStatus.Unlocked);
+
+      await expect(result).resolves.toBeUndefined();
+      expect(router.navigate).toHaveBeenCalledWith(["/"]);
+    });
+
+    it("hides the UI and throws, logging cancellation, when aborted before unlock", async () => {
+      activeAccountStatus$.next(AuthenticationStatus.Locked);
+
+      const result = session.ensureUnlockedVault();
+      await tick();
+      abortController.abort("Operation cancelled");
+
+      await expect(result).rejects.toThrow("Could not retrieve vault unlock status");
+      expect(logService.warning).toHaveBeenCalledWith(
+        "Request was cancelled before the vault was unlocked",
+      );
+      expect(desktopSettingsService.setModalMode).toHaveBeenCalledWith(false);
+    });
+
+    it("does not show the lock UI when already aborted on entry", async () => {
+      activeAccountStatus$.next(AuthenticationStatus.Locked);
+      abortController.abort("Operation cancelled");
+
+      await expect(session.ensureUnlockedVault()).rejects.toThrow(
+        "Could not retrieve vault unlock status",
+      );
+      expect(desktopSettingsService.setModalMode).not.toHaveBeenCalledWith(
+        true,
+        expect.anything(),
+        expect.anything(),
+      );
+    });
+
+    it("logs a timeout (not a cancellation) and throws when the unlock deadline elapses", async () => {
+      activeAccountStatus$.next(AuthenticationStatus.Locked);
+
+      const result = session.ensureUnlockedVault();
+      await tick();
+      deadlineController.abort(timeoutReason());
+
+      await expect(result).rejects.toThrow("Could not retrieve vault unlock status");
+      expect(logService.warning).toHaveBeenCalledWith(
+        "Timeout: Vault was not unlocked within the allowed time",
+      );
+      expect(logService.warning).not.toHaveBeenCalledWith(
+        "Request was cancelled before the vault was unlocked",
+      );
+    });
+  });
+});

--- a/apps/desktop/src/autofill/services/desktop-fido2-user-interface.service.ts
+++ b/apps/desktop/src/autofill/services/desktop-fido2-user-interface.service.ts
@@ -64,7 +64,9 @@ export class DesktopFido2UserInterfaceService implements Fido2UserInterfaceServi
   async newSession(
     fallbackSupported: boolean,
     nativeWindowObject: NativeWindowObject,
-    abortController?: AbortController,
+    // The interface marks this as optional, but in the Desktop implementation, we always pass an AbortController.
+    // We should see if we can change the interface type to require this object.
+    abortController: AbortController,
   ): Promise<DesktopFido2UserInterfaceSession> {
     this.logService.debug("newSession", fallbackSupported, abortController, nativeWindowObject);
     const session = new DesktopFido2UserInterfaceSession(
@@ -74,6 +76,7 @@ export class DesktopFido2UserInterfaceService implements Fido2UserInterfaceServi
       this.logService,
       this.router,
       this.desktopSettingsService,
+      abortController,
       nativeWindowObject,
     );
 
@@ -90,14 +93,15 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
     private logService: LogService,
     private router: Router,
     private desktopSettingsService: DesktopSettingsService,
+    private abortController: AbortController,
     private windowObject: NativeWindowObject,
   ) {}
 
   private confirmCredentialSubject = new Subject<boolean>();
 
-  private updatedCipher: CipherView;
+  private updatedCipher: CipherView | undefined = undefined;
 
-  private rpId = new BehaviorSubject<string>(null);
+  private rpId = new BehaviorSubject<string | null>(null);
   private availableCipherIdsSubject = new BehaviorSubject<string[]>([""]);
   /**
    * Observable that emits available cipher IDs once they're confirmed by the UI
@@ -168,14 +172,23 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
   private async waitForUiChosenCipher(
     timeoutMs: number = 60000,
   ): Promise<{ cipherId?: string; userVerified: boolean } | undefined> {
+    const { promise: cancelPromise, listener: abortFn } = this.subscribeToCancellation();
     try {
-      return await lastValueFrom(this.chosenCipherSubject.pipe(timeout(timeoutMs)));
+      this.abortController.signal.throwIfAborted();
+      const confirmPromise = lastValueFrom(this.chosenCipherSubject.pipe(timeout(timeoutMs)));
+      return await Promise.race([confirmPromise, cancelPromise]);
     } catch {
-      // If we hit a timeout, return undefined instead of throwing
-      this.logService.warning("Timeout: User did not select a cipher within the allowed time", {
-        timeoutMs,
-      });
+      // If we hit a timeout or if the request is cancelled, return undefined instead of throwing
+      if (this.abortController.signal.aborted) {
+        this.logService.warning("Request was cancelled before the user selected a cipher");
+      } else {
+        this.logService.warning("Timeout: User did not select a cipher within the allowed time", {
+          timeoutMs,
+        });
+      }
       return { cipherId: undefined, userVerified: false };
+    } finally {
+      this.unsubscribeCancellation(abortFn);
     }
   }
 
@@ -195,7 +208,23 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
    * @returns
    */
   private async waitForUiNewCredentialConfirmation(): Promise<boolean> {
-    return lastValueFrom(this.confirmCredentialSubject);
+    const { promise: cancelPromise, listener: abortFn } = this.subscribeToCancellation();
+    try {
+      this.abortController.signal.throwIfAborted();
+      const confirmPromise = lastValueFrom(this.confirmCredentialSubject);
+      return await Promise.race([confirmPromise, cancelPromise]);
+    } catch (error) {
+      if (this.abortController.signal.aborted) {
+        this.logService.warning("Request was cancelled before the user confirmed a cipher");
+      } else {
+        this.logService.error("Error occurred while waiting for user confirmation", error);
+      }
+
+      // On cancellation or error, return false instead of throwing
+      return false;
+    } finally {
+      this.unsubscribeCancellation(abortFn);
+    }
   }
 
   /**
@@ -209,7 +238,7 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
     userHandle,
     userVerification,
     rpId,
-  }: NewCredentialParams): Promise<{ cipherId: string; userVerified: boolean }> {
+  }: NewCredentialParams): Promise<{ cipherId: string | undefined; userVerified: boolean }> {
     this.logService.debug(
       "confirmNewCredential",
       credentialName,
@@ -342,16 +371,22 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
       await this.showUi("/lock", this.windowObject.windowXy, true, true);
 
       let status2: AuthenticationStatus;
+      const { promise: cancelPromise, listener: abortFn } = this.subscribeToCancellation();
       try {
-        status2 = await lastValueFrom(
+        const lockStatusPromise = lastValueFrom(
           this.authService.activeAccountStatus$.pipe(
             filter((s) => s === AuthenticationStatus.Unlocked),
             take(1),
             timeout(1000 * 60 * 5), // 5 minutes
           ),
         );
+        status2 = await Promise.race([lockStatusPromise, cancelPromise]);
       } catch (error) {
         this.logService.warning("Error while waiting for vault to unlock", error);
+        await this.hideUi();
+        throw new Error("Could not retrieve vault unlock status");
+      } finally {
+        this.unsubscribeCancellation(abortFn);
       }
 
       if (status2 === AuthenticationStatus.Unlocked) {
@@ -371,5 +406,33 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
 
   async close() {
     this.logService.debug("close");
+  }
+
+  /** Returns a promise that will be rejected if the session's abort signal is fired. */
+  private subscribeToCancellation() {
+    let cancelReject: (reason?: any) => void;
+    const cancelPromise: Promise<never> = new Promise((_, reject) => {
+      cancelReject = reject;
+    });
+    const abortFn = (ev: Event) => {
+      if (ev.target instanceof AbortSignal) {
+        cancelReject(ev.target.reason);
+      }
+    };
+    this.abortController.signal.addEventListener("abort", abortFn, { once: true });
+
+    // Guard against an unhandled rejection. If the signal aborts after the
+    // consumer has already stopped racing this promise (e.g. the UI resolved
+    // first, but the listener hasn't been removed yet), the rejection would
+    // otherwise surface with no attached handler. Racing consumers attach their
+    // own handler, so this no-op does not swallow the cancellation.
+    cancelPromise.catch(() => {});
+
+    return { promise: cancelPromise, listener: abortFn };
+  }
+
+  /** Cleans up event listeners for cancellation */
+  private unsubscribeCancellation(listener: (ev: Event) => void): void {
+    this.abortController.signal.removeEventListener("abort", listener);
   }
 }

--- a/apps/desktop/src/autofill/services/desktop-fido2-user-interface.service.ts
+++ b/apps/desktop/src/autofill/services/desktop-fido2-user-interface.service.ts
@@ -2,14 +2,17 @@
 // @ts-strict-ignore
 import { Router } from "@angular/router";
 import {
-  lastValueFrom,
   firstValueFrom,
   map,
   Subject,
   filter,
   take,
   BehaviorSubject,
-  timeout,
+  fromEvent,
+  merge,
+  switchMap,
+  throwError,
+  MonoTypeOperatorFunction,
 } from "rxjs";
 
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
@@ -45,6 +48,30 @@ export type NativeWindowObject = {
   windowXy?: { x: number; y: number };
 };
 
+/**
+ * RxJS operator that mirrors the source but errors with the signal's abort
+ * `reason` if `signal` fires before the source settles, unsubscribing the
+ * source (and any timers it holds, e.g. `timeout`) immediately.
+ *
+ * Because the abort side never completes on its own, consume the piped stream
+ * with `firstValueFrom` (not `lastValueFrom`): the sources used here emit a
+ * single value, so the first emission both resolves the caller and tears the
+ * abort listener down.
+ *
+ * This does not fire for an already-aborted signal; guard the entry of the
+ * calling API with `signal.throwIfAborted()`.
+ *
+ * TODO: If a second client needs this, promote it to a shared RxJS utility in
+ * `libs/common`.
+ */
+function throwOnAbort<T>(signal: AbortSignal): MonoTypeOperatorFunction<T> {
+  return (source) =>
+    merge(
+      source,
+      fromEvent(signal, "abort").pipe(switchMap(() => throwError(() => signal.reason))),
+    );
+}
+
 export class DesktopFido2UserInterfaceService implements Fido2UserInterfaceServiceAbstraction<NativeWindowObject> {
   constructor(
     private authService: AuthService,
@@ -64,11 +91,16 @@ export class DesktopFido2UserInterfaceService implements Fido2UserInterfaceServi
   async newSession(
     fallbackSupported: boolean,
     nativeWindowObject: NativeWindowObject,
-    // The interface marks this as optional, but in the Desktop implementation, we always pass an AbortController.
-    // We should see if we can change the interface type to require this object.
-    abortController: AbortController,
+    abortController?: AbortController,
   ): Promise<DesktopFido2UserInterfaceSession> {
     this.logService.debug("newSession", fallbackSupported, abortController, nativeWindowObject);
+    // Every entrypoint from DesktopAutofillService passes an AbortController.
+    // If we don't do that, throw an error. This can't be caught at the type
+    // system; we should consider updating the abstraction to require an
+    // AbortController.
+    if (!abortController) {
+      throw new Error("No AbortController passed to desktop");
+    }
     const session = new DesktopFido2UserInterfaceSession(
       this.authService,
       this.cipherService,
@@ -145,7 +177,11 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
 
       await this.showUi("/fido2-assertion", this.windowObject.windowXy, false);
 
-      const chosenCipherResponse = await this.waitForUiChosenCipher();
+      // TODO: Extend this to the deadline indicated by the timeout on the WebAuthn request.
+      const chosenCipherTimeout = AbortSignal.timeout(60 * 1000);
+      const chosenCipherResponse = await this.waitForUiChosenCipher({
+        signal: AbortSignal.any([this.abortController.signal, chosenCipherTimeout]),
+      });
 
       this.logService.debug("Received chosen cipher", chosenCipherResponse);
 
@@ -169,26 +205,24 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
     this.chosenCipherSubject.complete();
   }
 
-  private async waitForUiChosenCipher(
-    timeoutMs: number = 60000,
-  ): Promise<{ cipherId?: string; userVerified: boolean } | undefined> {
-    const { promise: cancelPromise, listener: abortFn } = this.subscribeToCancellation();
+  private async waitForUiChosenCipher({
+    signal,
+  }: {
+    signal: AbortSignal;
+  }): Promise<{ cipherId?: string; userVerified: boolean }> {
     try {
-      this.abortController.signal.throwIfAborted();
-      const confirmPromise = lastValueFrom(this.chosenCipherSubject.pipe(timeout(timeoutMs)));
-      return await Promise.race([confirmPromise, cancelPromise]);
-    } catch {
-      // If we hit a timeout or if the request is cancelled, return undefined instead of throwing
-      if (this.abortController.signal.aborted) {
-        this.logService.warning("Request was cancelled before the user selected a cipher");
-      } else {
-        this.logService.warning("Timeout: User did not select a cipher within the allowed time", {
-          timeoutMs,
-        });
+      signal.throwIfAborted();
+      return await firstValueFrom(this.chosenCipherSubject.pipe(throwOnAbort(signal)));
+    } catch (error) {
+      // If the request is cancelled or timed out, return undefined instead of throwing
+      // We should update pickCredential() to use allow returning undefined or
+      // throw a specific error when we cancel.
+      if (signal.reason instanceof DOMException && signal.reason.name === "TimeoutError") {
+        this.logService.warning("Timeout: User did not select a cipher within the allowed time");
+      } else if (signal.aborted) {
+        this.logService.warning("Request was cancelled before the user selected a cipher", error);
       }
       return { cipherId: undefined, userVerified: false };
-    } finally {
-      this.unsubscribeCancellation(abortFn);
     }
   }
 
@@ -207,14 +241,16 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
    * Returns once the UI has confirmed and completed the operation
    * @returns
    */
-  private async waitForUiNewCredentialConfirmation(): Promise<boolean> {
-    const { promise: cancelPromise, listener: abortFn } = this.subscribeToCancellation();
+  private async waitForUiNewCredentialConfirmation({
+    signal,
+  }: {
+    signal: AbortSignal;
+  }): Promise<boolean> {
     try {
-      this.abortController.signal.throwIfAborted();
-      const confirmPromise = lastValueFrom(this.confirmCredentialSubject);
-      return await Promise.race([confirmPromise, cancelPromise]);
+      signal.throwIfAborted();
+      return await firstValueFrom(this.confirmCredentialSubject.pipe(throwOnAbort(signal)));
     } catch (error) {
-      if (this.abortController.signal.aborted) {
+      if (signal.aborted) {
         this.logService.warning("Request was cancelled before the user confirmed a cipher");
       } else {
         this.logService.error("Error occurred while waiting for user confirmation", error);
@@ -222,8 +258,6 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
 
       // On cancellation or error, return false instead of throwing
       return false;
-    } finally {
-      this.unsubscribeCancellation(abortFn);
     }
   }
 
@@ -253,7 +287,9 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
       await this.showUi("/fido2-creation", this.windowObject.windowXy, false);
 
       // Wait for the UI to wrap up
-      const confirmation = await this.waitForUiNewCredentialConfirmation();
+      const confirmation = await this.waitForUiNewCredentialConfirmation({
+        signal: this.abortController.signal,
+      });
       if (!confirmation) {
         return { cipherId: undefined, userVerified: false };
       }
@@ -368,25 +404,25 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
 
     const status = await firstValueFrom(this.authService.activeAccountStatus$);
     if (status !== AuthenticationStatus.Unlocked) {
-      await this.showUi("/lock", this.windowObject.windowXy, true, true);
-
+      const { signal } = this.abortController;
       let status2: AuthenticationStatus;
-      const { promise: cancelPromise, listener: abortFn } = this.subscribeToCancellation();
       try {
-        const lockStatusPromise = lastValueFrom(
-          this.authService.activeAccountStatus$.pipe(
-            filter((s) => s === AuthenticationStatus.Unlocked),
-            take(1),
-            timeout(1000 * 60 * 5), // 5 minutes
-          ),
-        );
-        status2 = await Promise.race([lockStatusPromise, cancelPromise]);
+        signal.throwIfAborted();
+        await this.showUi("/lock", this.windowObject.windowXy, true, true);
+        const unlockTimeout = AbortSignal.timeout(1000 * 60 * 5); // 5 minutes
+        status2 = await this.waitForVaultUnlock({
+          signal: AbortSignal.any([signal, unlockTimeout]),
+        });
       } catch (error) {
-        this.logService.warning("Error while waiting for vault to unlock", error);
+        if (error instanceof DOMException && error.name === "TimeoutError") {
+          this.logService.warning("Timeout: Vault was not unlocked within the allowed time");
+        } else if (signal.aborted) {
+          this.logService.warning("Request was cancelled before the vault was unlocked");
+        } else {
+          this.logService.warning("Error while waiting for vault to unlock", error);
+        }
         await this.hideUi();
         throw new Error("Could not retrieve vault unlock status");
-      } finally {
-        this.unsubscribeCancellation(abortFn);
       }
 
       if (status2 === AuthenticationStatus.Unlocked) {
@@ -400,39 +436,25 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
     }
   }
 
+  /**
+   * Waits for the vault to become unlocked, rejecting if the request is aborted
+   * (with the abort `reason`).
+   */
+  private waitForVaultUnlock({ signal }: { signal: AbortSignal }): Promise<AuthenticationStatus> {
+    signal.throwIfAborted();
+    return firstValueFrom(
+      this.authService.activeAccountStatus$.pipe(
+        filter((s) => s === AuthenticationStatus.Unlocked),
+        throwOnAbort(signal),
+      ),
+    );
+  }
+
   async informCredentialNotFound(): Promise<void> {
     this.logService.debug("informCredentialNotFound");
   }
 
   async close() {
     this.logService.debug("close");
-  }
-
-  /** Returns a promise that will be rejected if the session's abort signal is fired. */
-  private subscribeToCancellation() {
-    let cancelReject: (reason?: any) => void;
-    const cancelPromise: Promise<never> = new Promise((_, reject) => {
-      cancelReject = reject;
-    });
-    const abortFn = (ev: Event) => {
-      if (ev.target instanceof AbortSignal) {
-        cancelReject(ev.target.reason);
-      }
-    };
-    this.abortController.signal.addEventListener("abort", abortFn, { once: true });
-
-    // Guard against an unhandled rejection. If the signal aborts after the
-    // consumer has already stopped racing this promise (e.g. the UI resolved
-    // first, but the listener hasn't been removed yet), the rejection would
-    // otherwise surface with no attached handler. Racing consumers attach their
-    // own handler, so this no-op does not swallow the cancellation.
-    cancelPromise.catch(() => {});
-
-    return { promise: cancelPromise, listener: abortFn };
-  }
-
-  /** Cleans up event listeners for cancellation */
-  private unsubscribeCancellation(listener: (ev: Event) => void): void {
-    this.abortController.signal.removeEventListener("abort", listener);
   }
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-40381](https://bitwarden.atlassian.net/browse/PM-40381)

## 📔 Objective

Wires up cancellation for the Desktop FIDO2 user interface session. This ensures that the window is closed if the request is closed in the background (e.g. the OS times out the request; or if the user navigates away from the page, and the browser cancels.)

[PM-40381]: https://bitwarden.atlassian.net/browse/PM-40381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ