### PR TITLE
desktop-autofill: Add missing Skunkworks codeownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -195,7 +195,8 @@ apps/desktop/src/autofill/main/main-desktop-autofill*           @bitwarden/team-
 apps/desktop/src/autofill/modal/credentials                     @bitwarden/team-desktop-native-dev  @bitwarden/team-skunkworks
 apps/desktop/src/autofill/models/autofill-*                     @bitwarden/team-desktop-native-dev  @bitwarden/team-skunkworks
 apps/desktop/src/autofill/models/ipc-handler.type.ts            @bitwarden/team-desktop-native-dev  @bitwarden/team-skunkworks
-apps/desktop/src/autofill/services/desktop-autofill*            @bitwarden/team-desktop-native-dev  @bitwarden/team-skunkworks
+apps/desktop/src/autofill/services/desktop-autofill.service.ts  @bitwarden/team-desktop-native-dev  @bitwarden/team-skunkworks
+apps/desktop/src/autofill/services/desktop-autofill.service.spec.ts  @bitwarden/team-desktop-native-dev  @bitwarden/team-skunkworks
 apps/desktop/src/autofill/services/desktop-fido2*               @bitwarden/team-desktop-native-dev  @bitwarden/team-skunkworks
 
 # DuckDuckGo integration

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -189,12 +189,13 @@ apps/desktop/desktop_native/napi/src/autofill.rs                @bitwarden/team-
 apps/desktop/desktop_native/objc/src/native/autofill            @bitwarden/team-desktop-native-dev  @bitwarden/team-skunkworks
 apps/desktop/desktop_native/win_webauthn                        @bitwarden/team-desktop-native-dev  @bitwarden/team-skunkworks
 apps/desktop/desktop_native/windows_plugin_authenticator        @bitwarden/team-desktop-native-dev  @bitwarden/team-skunkworks
-apps/desktop/macos/autofill-extension                           @bitwarden/team-desktop-native-dev  @bitwarden/team-skunkworks
+apps/desktop/macos                                              @bitwarden/team-desktop-native-dev  @bitwarden/team-skunkworks
 apps/desktop/src/autofill/desktop-autofill.preload.ts           @bitwarden/team-desktop-native-dev  @bitwarden/team-skunkworks
 apps/desktop/src/autofill/main/main-desktop-autofill*           @bitwarden/team-desktop-native-dev  @bitwarden/team-skunkworks
 apps/desktop/src/autofill/modal/credentials                     @bitwarden/team-desktop-native-dev  @bitwarden/team-skunkworks
 apps/desktop/src/autofill/models/autofill-*                     @bitwarden/team-desktop-native-dev  @bitwarden/team-skunkworks
-apps/desktop/src/autofill/services/desktop-autofill.service.ts  @bitwarden/team-desktop-native-dev  @bitwarden/team-skunkworks
+apps/desktop/src/autofill/models/ipc-handler.type.ts            @bitwarden/team-desktop-native-dev  @bitwarden/team-skunkworks
+apps/desktop/src/autofill/services/desktop-autofill*            @bitwarden/team-desktop-native-dev  @bitwarden/team-skunkworks
 apps/desktop/src/autofill/services/desktop-fido2*               @bitwarden/team-desktop-native-dev  @bitwarden/team-skunkworks
 
 # DuckDuckGo integration


### PR DESCRIPTION
## 📔 Objective

There's a few files that Skunkworks needs ownership for developing the native desktop autofill feature that were missed in my previous PRs.