### PR TITLE
[PM-40502] communicate message extension payloads using symbol

### DIFF
--- a/apps/browser/src/autofill/services/abstractions/autofill.service.ts
+++ b/apps/browser/src/autofill/services/abstractions/autofill.service.ts
@@ -67,7 +67,6 @@ export type CollectPageDetailsResponseMessage = {
   tab: chrome.tabs.Tab;
   details: AutofillPageDetails;
   sender?: string;
-  webExtSender: chrome.runtime.MessageSender;
 };
 
 export const COLLECT_PAGE_DETAILS_RESPONSE_COMMAND =

--- a/apps/browser/src/autofill/services/autofill.service.spec.ts
+++ b/apps/browser/src/autofill/services/autofill.service.spec.ts
@@ -52,6 +52,7 @@ import { TotpService } from "@bitwarden/common/vault/services/totp.service";
 
 import { BrowserApi } from "../../platform/browser/browser-api";
 import { BrowserScriptInjectorService } from "../../platform/services/browser-script-injector.service";
+import { stampWebExtSender } from "../../platform/utils/web-ext-sender";
 import { AutofillMessageCommand, AutofillMessageSender } from "../enums/autofill-message.enums";
 import { InlineMenuFillTypes } from "../enums/autofill-overlay.enum";
 import AutofillField from "../models/autofill-field";
@@ -207,11 +208,15 @@ describe("AutofillService", () => {
       webExtSender: chrome.runtime.MessageSender = mock<chrome.runtime.MessageSender>(),
       sender: string = AutofillMessageSender.collectPageDetailsFromTabObservable,
     ): CollectPageDetailsResponseMessage {
-      return mock<CollectPageDetailsResponseMessage>({
-        tab,
+      // The browser-authoritative sender is stamped by the runtime-message ingest, not
+      // carried in the message body, so mirror that here rather than setting a property.
+      return stampWebExtSender(
+        mock<CollectPageDetailsResponseMessage>({
+          tab,
+          sender,
+        }),
         webExtSender,
-        sender,
-      });
+      );
     }
 
     beforeEach(() => {
@@ -260,6 +265,25 @@ describe("AutofillService", () => {
       await pausePromise;
 
       expect(tracker.emissions[1]).toBeUndefined();
+    });
+
+    it("drops page details from a message with no stamped sender", async () => {
+      // A message that never passed through the runtime-message ingest carries no
+      // symbol-stamped sender, so it must not be attributed to a frame — fail closed.
+      const unstamped: CollectPageDetailsResponseMessage = {
+        tab,
+        details: mock<AutofillPageDetails>(),
+        sender: AutofillMessageSender.collectPageDetailsFromTabObservable,
+      };
+
+      const tracker = subscribeTo(autofillService.collectPageDetailsFromTab$(tab));
+      const pausePromise = tracker.pauseUntilReceived(1);
+
+      messages.next(unstamped);
+
+      await pausePromise;
+
+      expect(tracker.emissions[0]).toEqual([]);
     });
 
     it("ignores messages from a different sender", async () => {

--- a/apps/browser/src/autofill/services/autofill.service.ts
+++ b/apps/browser/src/autofill/services/autofill.service.ts
@@ -47,6 +47,7 @@ import { IdentityView } from "@bitwarden/common/vault/models/view/identity.view"
 
 import { BrowserApi } from "../../platform/browser/browser-api";
 import { ScriptInjectorService } from "../../platform/services/abstractions/script-injector.service";
+import { getWebExtSender } from "../../platform/utils/web-ext-sender";
 // FIXME (PM-22628): Popup imports are forbidden in background
 // eslint-disable-next-line no-restricted-imports
 import { openVaultItemPasswordRepromptPopout } from "../../vault/popup/utils/vault-popout-window";
@@ -135,20 +136,19 @@ export default class AutofillService implements AutofillServiceInterface {
             message.sender === AutofillMessageSender.collectPageDetailsFromTabObservable &&
             message.tab?.id === tab.id,
         ),
-        scan(
-          (acc: PageDetail[], message): PageDetail[] =>
-            message.webExtSender?.frameId === undefined
-              ? acc
-              : [
-                  ...acc,
-                  {
-                    frameId: message.webExtSender.frameId,
-                    tab: message.tab,
-                    details: message.details,
-                  },
-                ],
-          [] as PageDetail[],
-        ),
+        scan((acc: PageDetail[], message): PageDetail[] => {
+          const frameId = getWebExtSender(message)?.frameId;
+          return frameId === undefined
+            ? acc
+            : [
+                ...acc,
+                {
+                  frameId,
+                  tab: message.tab,
+                  details: message.details,
+                },
+              ];
+        }, [] as PageDetail[]),
       );
 
     void BrowserApi.tabSendMessage(

--- a/apps/browser/src/background/runtime.background.ts
+++ b/apps/browser/src/background/runtime.background.ts
@@ -37,6 +37,7 @@ import BrowserPopupUtils from "../platform/browser/browser-popup-utils";
 import { BrowserEnvironmentService } from "../platform/services/browser-environment.service";
 import BrowserInitialInstallService from "../platform/services/browser-initial-install.service";
 import { BrowserPlatformUtilsService } from "../platform/services/platform-utils/browser-platform-utils.service";
+import { getWebExtSender } from "../platform/utils/web-ext-sender";
 
 import MainBackground from "./main.background";
 
@@ -456,9 +457,7 @@ export default class RuntimeBackground {
    * @returns true if message fails validation
    */
   private async executeMessageActionOrOpenPopup(
-    message: {
-      webExtSender: chrome.runtime.MessageSender;
-    },
+    message: Record<PropertyKey, unknown>,
     messageAction: () => Promise<void>,
   ): Promise<boolean> {
     const hasAccounts = await firstValueFrom(
@@ -472,7 +471,7 @@ export default class RuntimeBackground {
     }
 
     const isValidVaultReferrer = await this.isValidVaultReferrer(
-      Utils.getHostname(message?.webExtSender?.origin),
+      Utils.getHostname(getWebExtSender(message)?.origin),
     );
 
     // When the referrer is not a known vault and the message is external, reject the message

--- a/apps/browser/src/platform/utils/from-chrome-runtime-messaging.ts
+++ b/apps/browser/src/platform/utils/from-chrome-runtime-messaging.ts
@@ -7,6 +7,8 @@ import { tagAsExternal } from "@bitwarden/common/platform/messaging/internal";
 
 import { fromChromeEvent } from "../browser/from-chrome-event";
 
+import { stampWebExtSender } from "./web-ext-sender";
+
 /**
  * Creates an observable that listens to messages through `chrome.runtime.onMessage`.
  * @returns An observable stream of messages.
@@ -16,10 +18,9 @@ export const fromChromeRuntimeMessaging = () => {
     map(([message, sender]) => {
       message ??= {};
 
-      // Force the sender onto the message as long as we won't overwrite anything
-      if (!("webExtSender" in message)) {
-        message.webExtSender = sender;
-      }
+      // Stamp the browser-authoritative sender under a private symbol so consumers that need
+      // trustworthy provenance can read it via `getWebExtSender`.
+      stampWebExtSender(message, sender);
 
       return message;
     }),

--- a/apps/browser/src/platform/utils/web-ext-sender.spec.ts
+++ b/apps/browser/src/platform/utils/web-ext-sender.spec.ts
@@ -1,0 +1,75 @@
+import { mock } from "jest-mock-extended";
+
+import { getWebExtSender, stampWebExtSender } from "./web-ext-sender";
+
+describe("web-ext-sender", () => {
+  describe("stampWebExtSender", () => {
+    it("returns the same message instance", () => {
+      const message = {};
+      const sender = mock<chrome.runtime.MessageSender>();
+
+      expect(stampWebExtSender(message, sender)).toBe(message);
+    });
+
+    it("does not add an enumerable property to the message", () => {
+      const message: Record<string, unknown> = {};
+
+      stampWebExtSender(message, mock<chrome.runtime.MessageSender>());
+
+      expect(Object.keys(message)).toHaveLength(0);
+    });
+
+    it("stamps a tamper-resistant property", () => {
+      const authentic = mock<chrome.runtime.MessageSender>({ frameId: 0 });
+      const message = stampWebExtSender({}, authentic);
+      const [key] = Object.getOwnPropertySymbols(message);
+
+      // In-realm code can recover the key but must not be able to overwrite the stamp.
+      expect(() => {
+        Object.defineProperty(message, key, { value: mock<chrome.runtime.MessageSender>() });
+      }).toThrow();
+      expect(getWebExtSender(message)).toBe(authentic);
+    });
+
+    it("throws if the same message is stamped twice", () => {
+      const message = stampWebExtSender({}, mock<chrome.runtime.MessageSender>());
+
+      expect(() => stampWebExtSender(message, mock<chrome.runtime.MessageSender>())).toThrow();
+    });
+  });
+
+  describe("getWebExtSender", () => {
+    it("reads back a stamped sender", () => {
+      const sender = mock<chrome.runtime.MessageSender>({ frameId: 3 });
+      const message = stampWebExtSender({}, sender);
+
+      expect(getWebExtSender(message)).toBe(sender);
+    });
+
+    it("returns undefined for a message that was never stamped", () => {
+      expect(getWebExtSender({})).toBeUndefined();
+    });
+
+    it.each([null, undefined, "string", 42])("returns undefined for non-objects (%p)", (value) => {
+      expect(getWebExtSender(value)).toBeUndefined();
+    });
+
+    it("ignores a spoofed `webExtSender` body property", () => {
+      // A page can set any property on the body it sends; only the symbol-stamped value
+      // is authoritative, so a body `webExtSender` must not be returned here.
+      const spoofed = { webExtSender: mock<chrome.runtime.MessageSender>({ frameId: 99 }) };
+
+      expect(getWebExtSender(spoofed)).toBeUndefined();
+    });
+
+    it("returns the stamped sender even when a spoofed body property is present", () => {
+      const authentic = mock<chrome.runtime.MessageSender>({ frameId: 0 });
+      const message = stampWebExtSender(
+        { webExtSender: mock<chrome.runtime.MessageSender>({ frameId: 99 }) },
+        authentic,
+      );
+
+      expect(getWebExtSender(message)).toBe(authentic);
+    });
+  });
+});

--- a/apps/browser/src/platform/utils/web-ext-sender.ts
+++ b/apps/browser/src/platform/utils/web-ext-sender.ts
@@ -1,0 +1,60 @@
+/**
+ * Key under which the browser-authoritative {@link chrome.runtime.MessageSender} is
+ * stamped onto an incoming runtime message.
+ *
+ * The key is a module-private symbol, which makes it unforgeable by a page: message
+ * serialization across a context boundary (JSON on Chrome, structured clone on Firefox)
+ * drops symbol-keyed properties, so no value a page attaches to its message body can
+ * arrive under this key. And because the symbol is never exported and is minted with
+ * `Symbol()`, no other code in this realm can re-derive it.
+ *
+ * SECURITY: this must stay `Symbol()`. Switching to `Symbol.for("webExtSender")` would
+ * publish the key to the registry, letting any in-realm code (e.g. a compromised
+ * dependency) overwrite the stamp and spoof the symbol.
+ */
+const WEB_EXT_SENDER = Symbol("webExtSender");
+
+/**
+ * Records the browser-authoritative sender on a runtime message, mutating `message` in
+ * place. Call once, at the message-ingest boundary, with the `sender` argument
+ * `chrome.runtime.onMessage` delivers.
+ *
+ * The stamp is defined non-writable and non-configurable, so in-realm code that recovers
+ * the key (via `getOwnPropertySymbols`) still cannot overwrite or delete it — a tamper
+ * attempt throws. Incoming messages never carry the symbol (serialization strips it), so
+ * the definition never collides; calling this twice on the same object throws by design.
+ *
+ * @returns the same message, for chaining.
+ */
+export function stampWebExtSender<T extends object>(
+  message: T,
+  sender: chrome.runtime.MessageSender,
+): T {
+  Object.defineProperty(message, WEB_EXT_SENDER, {
+    configurable: false,
+    writable: false,
+    enumerable: false,
+    value: sender,
+  });
+  return message;
+}
+
+/**
+ * Reads the browser-authoritative sender stamped by {@link stampWebExtSender}. Prefer this
+ * over any `webExtSender` property on the message body: that property is part of the body
+ * and a page can populate it, whereas the value returned here comes from the browser.
+ *
+ * Returns `undefined` when the value is not a stampable object, or when the message did not
+ * cross a context boundary through the ingest that stamps it — notably intraprocess
+ * (same-context) messages are never stamped. Callers must treat `undefined` as "no trusted
+ * provenance" and fail closed rather than assume a default.
+ */
+export function getWebExtSender(message: unknown): chrome.runtime.MessageSender | undefined {
+  if (typeof message !== "object" || message === null) {
+    return undefined;
+  }
+
+  return (message as Record<symbol, unknown>)[WEB_EXT_SENDER] as
+    | chrome.runtime.MessageSender
+    | undefined;
+}

--- a/apps/browser/src/platform/utils/web-ext-sender.ts
+++ b/apps/browser/src/platform/utils/web-ext-sender.ts
@@ -1,16 +1,6 @@
 /**
  * Key under which the browser-authoritative {@link chrome.runtime.MessageSender} is
  * stamped onto an incoming runtime message.
- *
- * The key is a module-private symbol, which makes it unforgeable by a page: message
- * serialization across a context boundary (JSON on Chrome, structured clone on Firefox)
- * drops symbol-keyed properties, so no value a page attaches to its message body can
- * arrive under this key. And because the symbol is never exported and is minted with
- * `Symbol()`, no other code in this realm can re-derive it.
- *
- * SECURITY: this must stay `Symbol()`. Switching to `Symbol.for("webExtSender")` would
- * publish the key to the registry, letting any in-realm code (e.g. a compromised
- * dependency) overwrite the stamp and spoof the symbol.
  */
 const WEB_EXT_SENDER = Symbol("webExtSender");
 
@@ -20,7 +10,7 @@ const WEB_EXT_SENDER = Symbol("webExtSender");
  * `chrome.runtime.onMessage` delivers.
  *
  * The stamp is defined non-writable and non-configurable, so in-realm code that recovers
- * the key (via `getOwnPropertySymbols`) still cannot overwrite or delete it — a tamper
+ * the key (via `getOwnPropertySymbols`) cannot overwrite or delete it — a tamper
  * attempt throws. Incoming messages never carry the symbol (serialization strips it), so
  * the definition never collides; calling this twice on the same object throws by design.
  *
@@ -45,7 +35,7 @@ export function stampWebExtSender<T extends object>(
  * and a page can populate it, whereas the value returned here comes from the browser.
  *
  * Returns `undefined` when the value is not a stampable object, or when the message did not
- * cross a context boundary through the ingest that stamps it — notably intraprocess
+ * cross a context boundary through the ingest that stamps it. Notably, intraprocess
  * (same-context) messages are never stamped. Callers must treat `undefined` as "no trusted
  * provenance" and fail closed rather than assume a default.
  */


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-40502

## 📔 Objective

Prevent webpages from spoofing message provenance in the autofill data collection subsystem.
