### PR TITLE
[PM-40482] Return to Default Filter After Revoking Last Staged User

### DIFF
--- a/apps/web/src/app/admin-console/organizations/members/members.component.spec.ts
+++ b/apps/web/src/app/admin-console/organizations/members/members.component.spec.ts
@@ -755,4 +755,49 @@ describe("MembersComponent", () => {
       ).rejects.toThrow("Side effect failed");
     });
   });
+
+  describe("staged filter fallback (PM-40482)", () => {
+    const stagedUser = {
+      ...mockUser,
+      id: newGuid(),
+      status: OrganizationUserStatusType.Staged,
+    } as OrganizationUserView;
+
+    it("resets the status filter to All when the last staged member is removed while the Staged view is selected", () => {
+      component["dataSource"]().data = [stagedUser];
+      component["statusToggle"].next(OrganizationUserStatusType.Staged);
+
+      component["dataSource"]().removeUser(stagedUser);
+
+      expect(component["statusToggle"].value).toBeUndefined();
+    });
+
+    it("keeps the Staged filter selected while staged members remain", () => {
+      const otherStagedUser = {
+        ...mockUser,
+        id: newGuid(),
+        status: OrganizationUserStatusType.Staged,
+      } as OrganizationUserView;
+      component["dataSource"]().data = [stagedUser, otherStagedUser];
+      component["statusToggle"].next(OrganizationUserStatusType.Staged);
+
+      component["dataSource"]().removeUser(stagedUser);
+
+      expect(component["statusToggle"].value).toBe(OrganizationUserStatusType.Staged);
+    });
+
+    it("leaves other selected filters unchanged when their count reaches zero", () => {
+      const invitedUser = {
+        ...mockUser,
+        id: newGuid(),
+        status: OrganizationUserStatusType.Invited,
+      } as OrganizationUserView;
+      component["dataSource"]().data = [invitedUser];
+      component["statusToggle"].next(OrganizationUserStatusType.Invited);
+
+      component["dataSource"]().removeUser(invitedUser);
+
+      expect(component["statusToggle"].value).toBe(OrganizationUserStatusType.Invited);
+    });
+  });
 });

--- a/apps/web/src/app/admin-console/organizations/members/members.component.ts
+++ b/apps/web/src/app/admin-console/organizations/members/members.component.ts
@@ -24,7 +24,6 @@ import { OrganizationService } from "@bitwarden/common/admin-console/abstraction
 import { PolicyApiServiceAbstraction } from "@bitwarden/common/admin-console/abstractions/policy/policy-api.service.abstraction";
 import { PolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
 import {
-  OrganizationUserStatusType,
   OrganizationUserType,
   PolicyType,
   RevocationReasonMessageMap,
@@ -42,6 +41,7 @@ import { LogService } from "@bitwarden/common/platform/abstractions/log.service"
 import { ValidationService } from "@bitwarden/common/platform/abstractions/validation.service";
 import { getById } from "@bitwarden/common/platform/misc";
 import { DialogService, ToastService } from "@bitwarden/components";
+import { OrganizationUserStatusType } from "@bitwarden/sdk-internal";
 import { UserId } from "@bitwarden/user-core";
 import { BillingConstraintService } from "@bitwarden/web-vault/app/billing/members/billing-constraint/billing-constraint.service";
 import { OrganizationWarningsService } from "@bitwarden/web-vault/app/billing/organizations/warnings/services";
@@ -162,6 +162,22 @@ export class MembersComponent {
       .subscribe(
         ([searchText, status]) => (this.dataSource().filter = peopleFilter(searchText, status)),
       );
+
+    // The Staged toggle is the only status filter that is removed from the view when it has no
+    // members. If the last staged member is revoked or removed while the Staged view is selected,
+    // the toggle disappears but the filter stays stuck on Staged, stranding the user in a filterless
+    // view showing zero members. Fall back to the "All" view whenever that happens.
+    this.dataSource()
+      .usersUpdated()
+      .pipe(takeUntilDestroyed())
+      .subscribe(() => {
+        if (
+          this.statusToggle.value === OrganizationUserStatusType.Staged &&
+          this.dataSource().stagedUserCount === 0
+        ) {
+          this.statusToggle.next(undefined);
+        }
+      });
 
     const organization$ = this.route.params.pipe(
       concatMap((params) =>


### PR DESCRIPTION
## 🎟️ Tracking
[PM-40482](https://bitwarden.atlassian.net/browse/PM-40482)

## 📔 Objective
As explained in the code comment - the staged filter is the only one that disappears when there are no members present in that status. As such, a little extra TLC could be applied so that users are kicked back to a default state, rather than seeing the results of applying an undefined filter.

## 📸 Screenshots


https://github.com/user-attachments/assets/173a0028-4c28-4adb-8095-a2b7f101cc25



[PM-40482]: https://bitwarden.atlassian.net/browse/PM-40482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ