### PR TITLE
feat(automation-driver): add automation biometrics service

### DIFF
--- a/apps/desktop/src/key-management/biometrics/automation-biometric-message.ts
+++ b/apps/desktop/src/key-management/biometrics/automation-biometric-message.ts
@@ -1,0 +1,27 @@
+import { UserId } from "@bitwarden/common/types/guid";
+import { BiometricsStatus } from "@bitwarden/key-management";
+
+export type AutomationBiometricRequestType = "authenticate" | "unlock";
+
+export interface AutomationBiometricRequest {
+  id: string;
+  type: AutomationBiometricRequestType;
+  userId?: UserId;
+}
+
+export const AutomationBiometricAction = Object.freeze({
+  SetStatus: "setStatus",
+  ListPending: "listPending",
+  Approve: "approve",
+  Deny: "deny",
+} as const);
+export type AutomationBiometricAction =
+  (typeof AutomationBiometricAction)[keyof typeof AutomationBiometricAction];
+
+export type AutomationBiometricMessage = {
+  action: AutomationBiometricAction;
+  status?: BiometricsStatus;
+  id?: string;
+};
+
+export const AUTOMATION_BIOMETRIC_CHANNEL = "automation.biometric";

--- a/apps/desktop/src/key-management/biometrics/automation-biometrics-ipc.listener.ts
+++ b/apps/desktop/src/key-management/biometrics/automation-biometrics-ipc.listener.ts
@@ -1,0 +1,66 @@
+import { ipcMain } from "electron";
+
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+import { BiometricsStatus } from "@bitwarden/key-management";
+
+import { AutomationBiometricsService } from "./automation-biometrics.service";
+
+export const AutomationBiometricAction = Object.freeze({
+  SetStatus: "setStatus",
+  ListPending: "listPending",
+  Approve: "approve",
+  Deny: "deny",
+} as const);
+export type AutomationBiometricAction =
+  (typeof AutomationBiometricAction)[keyof typeof AutomationBiometricAction];
+
+export type AutomationBiometricMessage = {
+  action: AutomationBiometricAction;
+  status?: BiometricsStatus;
+  id?: string;
+};
+
+export const AUTOMATION_BIOMETRIC_CHANNEL = "automation.biometric";
+
+/**
+ * Registers the IPC channel that lets the renderer-side automation driver control the
+ * {@link AutomationBiometricsService} running in the main process. Only wired up when automation
+ * biometrics are active (dev mode + `USE_AUTOMATION_BIOMETRICS`).
+ */
+export class AutomationBiometricsIPCListener {
+  constructor(
+    private biometricsService: AutomationBiometricsService,
+    private logService: LogService,
+  ) {}
+
+  init() {
+    ipcMain.handle(
+      AUTOMATION_BIOMETRIC_CHANNEL,
+      async (event: any, message: AutomationBiometricMessage) => {
+        try {
+          switch (message.action) {
+            case AutomationBiometricAction.SetStatus:
+              this.biometricsService.setMockStatus(message.status as BiometricsStatus);
+              return;
+            case AutomationBiometricAction.ListPending:
+              return this.biometricsService.listPendingRequests();
+            case AutomationBiometricAction.Approve:
+              this.biometricsService.approveRequest(message.id);
+              return;
+            case AutomationBiometricAction.Deny:
+              this.biometricsService.denyRequest(message.id);
+              return;
+            default:
+              return;
+          }
+        } catch (e) {
+          this.logService.error(
+            "[Automation Biometrics IPC Listener] %s failed",
+            message.action,
+            e,
+          );
+        }
+      },
+    );
+  }
+}

--- a/apps/desktop/src/key-management/biometrics/automation-biometrics-ipc.listener.ts
+++ b/apps/desktop/src/key-management/biometrics/automation-biometrics-ipc.listener.ts
@@ -3,24 +3,12 @@ import { ipcMain } from "electron";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { BiometricsStatus } from "@bitwarden/key-management";
 
+import {
+  AUTOMATION_BIOMETRIC_CHANNEL,
+  AutomationBiometricAction,
+  AutomationBiometricMessage,
+} from "./automation-biometric-message";
 import { AutomationBiometricsService } from "./automation-biometrics.service";
-
-export const AutomationBiometricAction = Object.freeze({
-  SetStatus: "setStatus",
-  ListPending: "listPending",
-  Approve: "approve",
-  Deny: "deny",
-} as const);
-export type AutomationBiometricAction =
-  (typeof AutomationBiometricAction)[keyof typeof AutomationBiometricAction];
-
-export type AutomationBiometricMessage = {
-  action: AutomationBiometricAction;
-  status?: BiometricsStatus;
-  id?: string;
-};
-
-export const AUTOMATION_BIOMETRIC_CHANNEL = "automation.biometric";
 
 /**
  * Registers the IPC channel that lets the renderer-side automation driver control the

--- a/apps/desktop/src/key-management/biometrics/automation-biometrics.service.spec.ts
+++ b/apps/desktop/src/key-management/biometrics/automation-biometrics.service.spec.ts
@@ -1,0 +1,133 @@
+import { mock } from "jest-mock-extended";
+
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
+import { UserId } from "@bitwarden/common/types/guid";
+import { BiometricsStatus } from "@bitwarden/key-management";
+
+import { AutomationBiometricsService } from "./automation-biometrics.service";
+
+describe("AutomationBiometricsService", () => {
+  const userId = "user-id" as UserId;
+  const key = new SymmetricCryptoKey(new Uint8Array(64)) as SymmetricCryptoKey;
+
+  let sut: AutomationBiometricsService;
+
+  beforeEach(() => {
+    sut = new AutomationBiometricsService(mock<LogService>());
+  });
+
+  describe("mock status", () => {
+    it("defaults to Available at the platform level", async () => {
+      await expect(sut.supportsBiometrics()).resolves.toBe(true);
+    });
+
+    it("reports the configured status", async () => {
+      sut.setMockStatus(BiometricsStatus.HardwareUnavailable);
+
+      await expect(sut.supportsBiometrics()).resolves.toBe(false);
+      await expect(sut.getBiometricsFirstUnlockStatusForUser(userId)).resolves.toBe(
+        BiometricsStatus.HardwareUnavailable,
+      );
+    });
+  });
+
+  describe("getBiometricsFirstUnlockStatusForUser", () => {
+    it("returns the platform status when biometrics are not available", async () => {
+      sut.setMockStatus(BiometricsStatus.HardwareUnavailable);
+
+      await expect(sut.getBiometricsFirstUnlockStatusForUser(userId)).resolves.toBe(
+        BiometricsStatus.HardwareUnavailable,
+      );
+    });
+
+    it("returns UnlockNeeded when available but no key is held for the user", async () => {
+      await expect(sut.getBiometricsFirstUnlockStatusForUser(userId)).resolves.toBe(
+        BiometricsStatus.UnlockNeeded,
+      );
+    });
+
+    it("returns Available when available and a key is held for the user", async () => {
+      await sut.setBiometricKey(userId, key);
+
+      await expect(sut.getBiometricsFirstUnlockStatusForUser(userId)).resolves.toBe(
+        BiometricsStatus.Available,
+      );
+    });
+  });
+
+  describe("pending authentication requests", () => {
+    it("lists a pending request and resolves true on approval", async () => {
+      const result = sut.authenticateBiometric();
+
+      const pending = sut.listPendingRequests();
+      expect(pending).toHaveLength(1);
+      expect(pending[0].type).toBe("authenticate");
+
+      sut.approveRequest();
+
+      await expect(result).resolves.toBe(true);
+      expect(sut.listPendingRequests()).toHaveLength(0);
+    });
+
+    it("resolves false on denial", async () => {
+      const result = sut.authenticateBiometric();
+
+      sut.denyRequest();
+
+      await expect(result).resolves.toBe(false);
+    });
+
+    it("resolves a specific request by id", async () => {
+      const first = sut.authenticateBiometric();
+      const second = sut.authenticateBiometric();
+
+      const [, secondPending] = sut.listPendingRequests();
+      sut.approveRequest(secondPending.id);
+
+      await expect(second).resolves.toBe(true);
+      expect(sut.listPendingRequests()).toHaveLength(1);
+
+      sut.denyRequest();
+      await expect(first).resolves.toBe(false);
+    });
+  });
+
+  describe("biometric keys", () => {
+    it("returns the stored key after unlock approval", async () => {
+      await sut.setBiometricKey(userId, key);
+
+      const result = sut.getBiometricKey(userId);
+      sut.approveRequest();
+
+      await expect(result).resolves.toBe(key);
+    });
+
+    it("returns null after unlock denial", async () => {
+      await sut.setBiometricKey(userId, key);
+
+      const result = sut.getBiometricKey(userId);
+      sut.denyRequest();
+
+      await expect(result).resolves.toBeNull();
+    });
+
+    it("tracks persistent keys", async () => {
+      await expect(sut.hasPersistentKey(userId)).resolves.toBe(false);
+
+      await sut.enrollPersistent(userId, key);
+
+      await expect(sut.hasPersistentKey(userId)).resolves.toBe(true);
+    });
+
+    it("deletes keys", async () => {
+      await sut.setBiometricKey(userId, key);
+
+      await sut.deleteBiometricKey(userId);
+
+      const result = sut.getBiometricKey(userId);
+      sut.approveRequest();
+      await expect(result).resolves.toBeNull();
+    });
+  });
+});

--- a/apps/desktop/src/key-management/biometrics/automation-biometrics.service.spec.ts
+++ b/apps/desktop/src/key-management/biometrics/automation-biometrics.service.spec.ts
@@ -1,9 +1,10 @@
 import { mock } from "jest-mock-extended";
 
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
-import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
 import { UserId } from "@bitwarden/common/types/guid";
 import { BiometricsStatus } from "@bitwarden/key-management";
+// eslint-disable-next-line no-restricted-imports
+import { SymmetricCryptoKey } from "@bitwarden/legacy-crypto";
 
 import { AutomationBiometricsService } from "./automation-biometrics.service";
 

--- a/apps/desktop/src/key-management/biometrics/automation-biometrics.service.ts
+++ b/apps/desktop/src/key-management/biometrics/automation-biometrics.service.ts
@@ -1,0 +1,135 @@
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
+import { UserId } from "@bitwarden/common/types/guid";
+import { BiometricsStatus } from "@bitwarden/key-management";
+
+import { OsBiometricService } from "./os-biometrics.service";
+
+export type AutomationBiometricRequestType = "authenticate" | "unlock";
+
+export interface AutomationBiometricRequest {
+  id: string;
+  type: AutomationBiometricRequestType;
+  userId?: UserId;
+}
+
+interface PendingRequest extends AutomationBiometricRequest {
+  resolve: (approved: boolean) => void;
+}
+
+/**
+ * A fake {@link OsBiometricService} used for automation (E2E tests, manual automation). It replaces
+ * the real OS biometric service on the desktop main process when running in dev mode with the
+ * `USE_AUTOMATION_BIOMETRICS` environment variable set, so the native OS prompt never fires.
+ *
+ * Biometric requests are queued and block until automation approves or denies them, allowing tests
+ * to deterministically simulate the user accepting or rejecting the native prompt. The reported
+ * biometric status is settable. Biometric keys are held in memory only (no OS keychain), so they do
+ * not persist across restarts.
+ */
+export class AutomationBiometricsService implements OsBiometricService {
+  private mockStatus = BiometricsStatus.Available;
+  private keys = new Map<UserId, SymmetricCryptoKey>();
+  private pendingRequests: PendingRequest[] = [];
+  private nextRequestId = 1;
+
+  constructor(private logService: LogService) {}
+
+  // --- Automation control surface (driven over IPC) ---
+
+  setMockStatus(status: BiometricsStatus): void {
+    this.mockStatus = status;
+  }
+
+  listPendingRequests(): AutomationBiometricRequest[] {
+    return this.pendingRequests.map(({ id, type, userId }) => ({ id, type, userId }));
+  }
+
+  approveRequest(id?: string): void {
+    this.resolveRequests(id, true);
+  }
+
+  denyRequest(id?: string): void {
+    this.resolveRequests(id, false);
+  }
+
+  private resolveRequests(id: string | undefined, approved: boolean): void {
+    const matches =
+      id == null
+        ? this.pendingRequests.splice(0, this.pendingRequests.length)
+        : this.pendingRequests
+            .filter((r) => r.id === id)
+            .map((r) => {
+              this.pendingRequests.splice(this.pendingRequests.indexOf(r), 1);
+              return r;
+            });
+    for (const request of matches) {
+      request.resolve(approved);
+    }
+  }
+
+  private awaitApproval(type: AutomationBiometricRequestType, userId?: UserId): Promise<boolean> {
+    const id = (this.nextRequestId++).toString();
+    this.logService.info(
+      "[AutomationBiometrics] Pending %s request %s awaiting approval",
+      type,
+      id,
+    );
+    return new Promise<boolean>((resolve) => {
+      this.pendingRequests.push({ id, type, userId, resolve });
+    });
+  }
+
+  // --- OsBiometricService implementation ---
+
+  async supportsBiometrics(): Promise<boolean> {
+    return this.mockStatus !== BiometricsStatus.HardwareUnavailable;
+  }
+
+  async needsSetup(): Promise<boolean> {
+    return false;
+  }
+
+  async canAutoSetup(): Promise<boolean> {
+    return false;
+  }
+
+  async runSetup(): Promise<void> {
+    return;
+  }
+
+  async authenticateBiometric(): Promise<boolean> {
+    return await this.awaitApproval("authenticate");
+  }
+
+  async getBiometricKey(userId: UserId): Promise<SymmetricCryptoKey | null> {
+    const approved = await this.awaitApproval("unlock", userId);
+    if (!approved) {
+      return null;
+    }
+    return this.keys.get(userId) ?? null;
+  }
+
+  async setBiometricKey(userId: UserId, key: SymmetricCryptoKey): Promise<void> {
+    this.keys.set(userId, key);
+  }
+
+  async deleteBiometricKey(userId: UserId): Promise<void> {
+    this.keys.delete(userId);
+  }
+
+  async getBiometricsFirstUnlockStatusForUser(userId: UserId): Promise<BiometricsStatus> {
+    if (this.mockStatus !== BiometricsStatus.Available) {
+      return this.mockStatus;
+    }
+    return this.keys.has(userId) ? BiometricsStatus.Available : BiometricsStatus.UnlockNeeded;
+  }
+
+  async enrollPersistent(userId: UserId, key: SymmetricCryptoKey): Promise<void> {
+    this.keys.set(userId, key);
+  }
+
+  async hasPersistentKey(userId: UserId): Promise<boolean> {
+    return this.keys.has(userId);
+  }
+}

--- a/apps/desktop/src/key-management/biometrics/automation-biometrics.service.ts
+++ b/apps/desktop/src/key-management/biometrics/automation-biometrics.service.ts
@@ -30,7 +30,7 @@ export class AutomationBiometricsService implements OsBiometricService {
   private pendingRequests: PendingRequest[] = [];
   private nextRequestId = 1;
 
-  constructor(private logService: LogService) {}
+  constructor(private readonly logService: LogService) {}
 
   // --- Automation control surface (driven over IPC) ---
 

--- a/apps/desktop/src/key-management/biometrics/automation-biometrics.service.ts
+++ b/apps/desktop/src/key-management/biometrics/automation-biometrics.service.ts
@@ -1,7 +1,8 @@
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
-import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
 import { UserId } from "@bitwarden/common/types/guid";
 import { BiometricsStatus } from "@bitwarden/key-management";
+// eslint-disable-next-line no-restricted-imports
+import { SymmetricCryptoKey } from "@bitwarden/legacy-crypto";
 
 import { OsBiometricService } from "./os-biometrics.service";
 

--- a/apps/desktop/src/key-management/biometrics/automation-biometrics.service.ts
+++ b/apps/desktop/src/key-management/biometrics/automation-biometrics.service.ts
@@ -51,15 +51,13 @@ export class AutomationBiometricsService implements OsBiometricService {
   }
 
   private resolveRequests(id: string | undefined, approved: boolean): void {
-    const matches =
-      id == null
-        ? this.pendingRequests.splice(0, this.pendingRequests.length)
-        : this.pendingRequests
-            .filter((r) => r.id === id)
-            .map((r) => {
-              this.pendingRequests.splice(this.pendingRequests.indexOf(r), 1);
-              return r;
-            });
+  let matches: PendingRequest[];                                                                                                
+  if (id == null) {                                                                                                             
+    matches = this.pendingRequests.splice(0, this.pendingRequests.length);                                                      
+  } else {                                                                                                                      
+    const index = this.pendingRequests.findIndex((r) => r.id === id);                                                           
+    matches = index === -1 ? [] : this.pendingRequests.splice(index, 1);                                                        
+  } 
     for (const request of matches) {
       request.resolve(approved);
     }

--- a/apps/desktop/src/key-management/biometrics/automation-biometrics.service.ts
+++ b/apps/desktop/src/key-management/biometrics/automation-biometrics.service.ts
@@ -4,15 +4,11 @@ import { BiometricsStatus } from "@bitwarden/key-management";
 // eslint-disable-next-line no-restricted-imports
 import { SymmetricCryptoKey } from "@bitwarden/legacy-crypto";
 
+import {
+  AutomationBiometricRequest,
+  AutomationBiometricRequestType,
+} from "./automation-biometric-message";
 import { OsBiometricService } from "./os-biometrics.service";
-
-export type AutomationBiometricRequestType = "authenticate" | "unlock";
-
-export interface AutomationBiometricRequest {
-  id: string;
-  type: AutomationBiometricRequestType;
-  userId?: UserId;
-}
 
 interface PendingRequest extends AutomationBiometricRequest {
   resolve: (approved: boolean) => void;

--- a/apps/desktop/src/key-management/biometrics/automation-biometrics.service.ts
+++ b/apps/desktop/src/key-management/biometrics/automation-biometrics.service.ts
@@ -51,13 +51,13 @@ export class AutomationBiometricsService implements OsBiometricService {
   }
 
   private resolveRequests(id: string | undefined, approved: boolean): void {
-  let matches: PendingRequest[];                                                                                                
-  if (id == null) {                                                                                                             
-    matches = this.pendingRequests.splice(0, this.pendingRequests.length);                                                      
-  } else {                                                                                                                      
-    const index = this.pendingRequests.findIndex((r) => r.id === id);                                                           
-    matches = index === -1 ? [] : this.pendingRequests.splice(index, 1);                                                        
-  } 
+    let matches: PendingRequest[];
+    if (id == null) {
+      matches = this.pendingRequests.splice(0, this.pendingRequests.length);
+    } else {
+      const index = this.pendingRequests.findIndex((r) => r.id === id);
+      matches = index === -1 ? [] : this.pendingRequests.splice(index, 1);
+    }
     for (const request of matches) {
       request.resolve(approved);
     }

--- a/apps/desktop/src/key-management/biometrics/main-biometrics.service.ts
+++ b/apps/desktop/src/key-management/biometrics/main-biometrics.service.ts
@@ -7,7 +7,10 @@ import { BiometricsStatus, BiometricStateService } from "@bitwarden/key-manageme
 import { SymmetricCryptoKey } from "@bitwarden/legacy-crypto";
 
 import { WindowMain } from "../../main/window.main";
+import { isDev } from "../../utils";
 
+import { AutomationBiometricsIPCListener } from "./automation-biometrics-ipc.listener";
+import { AutomationBiometricsService } from "./automation-biometrics.service";
 import { DesktopBiometricsService } from "./desktop.biometrics.service";
 import { LinuxBiometricsSystem, WindowsBiometricsSystem } from "./native-v2";
 import { OsBiometricService } from "./os-biometrics.service";
@@ -24,7 +27,16 @@ export class MainBiometricsService extends DesktopBiometricsService {
     private biometricStateService: BiometricStateService,
   ) {
     super();
-    if (platform === "win32") {
+    if (process.env.USE_AUTOMATION_BIOMETRICS && isDev()) {
+      // Replace the OS biometric service with a fake, automation-controlled one so the native OS
+      // prompt never fires. Only ever active in dev mode with the env var set.
+      this.logService.warning(
+        "[BiometricsMain] USE_AUTOMATION_BIOMETRICS is set; using automation biometrics service",
+      );
+      const automationBiometricsService = new AutomationBiometricsService(this.logService);
+      this.osBiometricsService = automationBiometricsService;
+      new AutomationBiometricsIPCListener(automationBiometricsService, this.logService).init();
+    } else if (platform === "win32") {
       this.osBiometricsService = new WindowsBiometricsSystem(
         this.i18nService,
         this.windowMain,

--- a/apps/desktop/src/key-management/biometrics/main-biometrics.service.ts
+++ b/apps/desktop/src/key-management/biometrics/main-biometrics.service.ts
@@ -6,7 +6,10 @@ import { UserKey } from "@bitwarden/common/types/key";
 import { BiometricsStatus, BiometricStateService } from "@bitwarden/key-management";
 
 import { WindowMain } from "../../main/window.main";
+import { isDev } from "../../utils";
 
+import { AutomationBiometricsIPCListener } from "./automation-biometrics-ipc.listener";
+import { AutomationBiometricsService } from "./automation-biometrics.service";
 import { DesktopBiometricsService } from "./desktop.biometrics.service";
 import { LinuxBiometricsSystem, WindowsBiometricsSystem } from "./native-v2";
 import { OsBiometricService } from "./os-biometrics.service";
@@ -23,7 +26,16 @@ export class MainBiometricsService extends DesktopBiometricsService {
     private biometricStateService: BiometricStateService,
   ) {
     super();
-    if (platform === "win32") {
+    if (process.env.USE_AUTOMATION_BIOMETRICS && isDev()) {
+      // Replace the OS biometric service with a fake, automation-controlled one so the native OS
+      // prompt never fires. Only ever active in dev mode with the env var set.
+      this.logService.warning(
+        "[BiometricsMain] USE_AUTOMATION_BIOMETRICS is set; using automation biometrics service",
+      );
+      const automationBiometricsService = new AutomationBiometricsService(this.logService);
+      this.osBiometricsService = automationBiometricsService;
+      new AutomationBiometricsIPCListener(automationBiometricsService, this.logService).init();
+    } else if (platform === "win32") {
       this.osBiometricsService = new WindowsBiometricsSystem(
         this.i18nService,
         this.windowMain,

--- a/apps/desktop/src/key-management/preload.ts
+++ b/apps/desktop/src/key-management/preload.ts
@@ -6,6 +6,13 @@ import { BiometricsStatus } from "@bitwarden/key-management";
 
 import { BiometricMessage, BiometricAction } from "../types/biometric-message";
 
+import {
+  AUTOMATION_BIOMETRIC_CHANNEL,
+  AutomationBiometricAction,
+  AutomationBiometricMessage,
+  AutomationBiometricRequest,
+} from "./biometrics/automation-biometric-message";
+
 const biometric = {
   authenticateWithBiometrics: (): Promise<boolean> =>
     ipcRenderer.invoke("biometric", {
@@ -63,6 +70,32 @@ const biometric = {
     } satisfies BiometricMessage),
 };
 
+// Automation-only surface, controlled by the renderer automation driver (dev mode only).
+const automation = {
+  biometrics: {
+    setStatus: (status: BiometricsStatus): Promise<void> =>
+      ipcRenderer.invoke(AUTOMATION_BIOMETRIC_CHANNEL, {
+        action: AutomationBiometricAction.SetStatus,
+        status: status,
+      } satisfies AutomationBiometricMessage),
+    listPending: (): Promise<AutomationBiometricRequest[]> =>
+      ipcRenderer.invoke(AUTOMATION_BIOMETRIC_CHANNEL, {
+        action: AutomationBiometricAction.ListPending,
+      } satisfies AutomationBiometricMessage),
+    approve: (id?: string): Promise<void> =>
+      ipcRenderer.invoke(AUTOMATION_BIOMETRIC_CHANNEL, {
+        action: AutomationBiometricAction.Approve,
+        id: id,
+      } satisfies AutomationBiometricMessage),
+    deny: (id?: string): Promise<void> =>
+      ipcRenderer.invoke(AUTOMATION_BIOMETRIC_CHANNEL, {
+        action: AutomationBiometricAction.Deny,
+        id: id,
+      } satisfies AutomationBiometricMessage),
+  },
+};
+
 export default {
   biometric,
+  automation,
 };

--- a/apps/desktop/src/platform/preload.ts
+++ b/apps/desktop/src/platform/preload.ts
@@ -136,6 +136,19 @@ export default {
   isAppImage: isAppImage(),
   allowBrowserintegrationOverride: allowBrowserintegrationOverride(),
   reloadProcess: () => ipcRenderer.send("reload-process"),
+  // Automation-only surface, controlled by the renderer automation driver (dev mode only).
+  automation: {
+    biometrics: {
+      setStatus: (status: number): Promise<void> =>
+        ipcRenderer.invoke("automation.biometric", { action: "setStatus", status }),
+      listPending: (): Promise<unknown[]> =>
+        ipcRenderer.invoke("automation.biometric", { action: "listPending" }),
+      approve: (id?: string): Promise<void> =>
+        ipcRenderer.invoke("automation.biometric", { action: "approve", id }),
+      deny: (id?: string): Promise<void> =>
+        ipcRenderer.invoke("automation.biometric", { action: "deny", id }),
+    },
+  },
   registerUpdateRestartHandler: (provide: (resolve: (canRestart: boolean) => void) => void) => {
     const resolve = (canRestart: boolean) => ipcRenderer.send("confirmUpdateRestart", canRestart);
 

--- a/apps/desktop/src/platform/preload.ts
+++ b/apps/desktop/src/platform/preload.ts
@@ -137,6 +137,19 @@ export default {
   isAppImage: isAppImage(),
   allowBrowserintegrationOverride: allowBrowserintegrationOverride(),
   reloadProcess: () => ipcRenderer.send("reload-process"),
+  // Automation-only surface, controlled by the renderer automation driver (dev mode only).
+  automation: {
+    biometrics: {
+      setStatus: (status: number): Promise<void> =>
+        ipcRenderer.invoke("automation.biometric", { action: "setStatus", status }),
+      listPending: (): Promise<unknown[]> =>
+        ipcRenderer.invoke("automation.biometric", { action: "listPending" }),
+      approve: (id?: string): Promise<void> =>
+        ipcRenderer.invoke("automation.biometric", { action: "approve", id }),
+      deny: (id?: string): Promise<void> =>
+        ipcRenderer.invoke("automation.biometric", { action: "deny", id }),
+    },
+  },
   registerUpdateRestartHandler: (provide: (resolve: (canRestart: boolean) => void) => void) => {
     const resolve = (canRestart: boolean) => ipcRenderer.send("confirmUpdateRestart", canRestart);
 

--- a/apps/desktop/src/platform/preload.ts
+++ b/apps/desktop/src/platform/preload.ts
@@ -137,19 +137,6 @@ export default {
   isAppImage: isAppImage(),
   allowBrowserintegrationOverride: allowBrowserintegrationOverride(),
   reloadProcess: () => ipcRenderer.send("reload-process"),
-  // Automation-only surface, controlled by the renderer automation driver (dev mode only).
-  automation: {
-    biometrics: {
-      setStatus: (status: number): Promise<void> =>
-        ipcRenderer.invoke("automation.biometric", { action: "setStatus", status }),
-      listPending: (): Promise<unknown[]> =>
-        ipcRenderer.invoke("automation.biometric", { action: "listPending" }),
-      approve: (id?: string): Promise<void> =>
-        ipcRenderer.invoke("automation.biometric", { action: "approve", id }),
-      deny: (id?: string): Promise<void> =>
-        ipcRenderer.invoke("automation.biometric", { action: "deny", id }),
-    },
-  },
   registerUpdateRestartHandler: (provide: (resolve: (canRestart: boolean) => void) => void) => {
     const resolve = (canRestart: boolean) => ipcRenderer.send("confirmUpdateRestart", canRestart);
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-39560

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Adds an implemention of the automation biometrics service. The intent is to be used by the automation driver to expose the biometric subsystem at runtime to e.g. an agent or test automation. The biometrics requests can be read and answered by injecting commands onto the devtools, which end-to-end tests, as well as agents can use at runtime to simulate biometrics interaction.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>