### PR TITLE
refactor: gate desktop_native core allocator and windows deps

### DIFF
--- a/apps/desktop/desktop_native/Cargo.lock
+++ b/apps/desktop/desktop_native/Cargo.lock
@@ -1063,7 +1063,6 @@ dependencies = [
  "typenum",
  "widestring",
  "windows 0.62.2",
- "windows-future 0.3.2",
  "zbus",
  "zeroizing-alloc",
 ]

--- a/apps/desktop/desktop_native/core/Cargo.toml
+++ b/apps/desktop/desktop_native/core/Cargo.toml
@@ -42,6 +42,8 @@ tokio = { workspace = true, features = ["io-util", "sync", "macros", "net"] }
 tokio-util = { workspace = true, features = ["codec"] }
 tracing = { workspace = true }
 typenum = { workspace = true }
+
+[target.'cfg(not(windows))'.dependencies]
 zeroizing-alloc = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
@@ -65,19 +67,10 @@ scopeguard = { workspace = true }
 secmem-proc = { workspace = true }
 widestring = { workspace = true, optional = true }
 windows = { workspace = true, features = [
-    "Foundation",
-    "Security_Credentials_UI",
-    "Security_Cryptography",
-    "Storage_Streams",
     "Win32_Foundation",
     "Win32_Security_Credentials",
-    "Win32_Security_Cryptography",
-    "Win32_System_WinRT",
-    "Win32_UI_Input_KeyboardAndMouse",
-    "Win32_UI_WindowsAndMessaging",
     "Win32_System_Pipes",
 ], optional = true }
-windows-future = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/apps/desktop/desktop_native/core/src/lib.rs
+++ b/apps/desktop/desktop_native/core/src/lib.rs
@@ -22,7 +22,10 @@ pub mod process_isolation;
 #[allow(missing_docs)] // staged to be removed
 pub mod ssh_agent;
 
+#[cfg(not(target_os = "windows"))]
 use zeroizing_alloc::ZeroAlloc;
 
+// On windows we import bitwarden-crypto which has a global allocator.
+#[cfg(not(target_os = "windows"))]
 #[global_allocator]
 static ALLOC: ZeroAlloc<std::alloc::System> = ZeroAlloc(std::alloc::System);


### PR DESCRIPTION
The follow-up PR to this adds `bitwarden-crypto` to the desktop_native workspace. `bitwarden-crypto` has its own zeroizing alloc, which means we need to remove it for windows.