### PR TITLE
feat: seal windows hello user keys in sdk secret-protected envelopes

### DIFF
--- a/apps/desktop/desktop_native/Cargo.lock
+++ b/apps/desktop/desktop_native/Cargo.lock
@@ -492,6 +492,7 @@ dependencies = [
  "anyhow",
  "bitwarden-crypto",
  "bitwarden-random",
+ "bitwarden-sensitive-value",
  "chacha20poly1305 0.10.1",
  "desktop_core",
  "rand_core 0.10.1",

--- a/apps/desktop/desktop_native/Cargo.toml
+++ b/apps/desktop/desktop_native/Cargo.toml
@@ -32,6 +32,7 @@ async-trait = "=0.1.89"
 base64 = "=0.22.1"
 bitwarden-crypto = { git = "https://github.com/bitwarden/sdk-internal", rev = "f76b51450582cff9be767c9d9f454c42a84a56c1" }
 bitwarden-random = { git = "https://github.com/bitwarden/sdk-internal", rev = "f76b51450582cff9be767c9d9f454c42a84a56c1" }
+bitwarden-sensitive-value = { git = "https://github.com/bitwarden/sdk-internal", rev = "f76b51450582cff9be767c9d9f454c42a84a56c1" }
 byteorder = "=1.5.0"
 bytes = "=1.11.1"
 cbc = "=0.1.2"

--- a/apps/desktop/desktop_native/biometric/Cargo.toml
+++ b/apps/desktop/desktop_native/biometric/Cargo.toml
@@ -19,6 +19,7 @@ zbus_polkit = { workspace = true }
 aes = { workspace = true }
 bitwarden-crypto = { workspace = true }
 bitwarden-random = { workspace = true }
+bitwarden-sensitive-value = { workspace = true }
 chacha20poly1305 = { workspace = true }
 desktop_core = { path = "../core" }
 rand_core = { workspace = true }

--- a/apps/desktop/desktop_native/biometric/src/windows/encryption.rs
+++ b/apps/desktop/desktop_native/biometric/src/windows/encryption.rs
@@ -2,19 +2,26 @@
 //!
 //! Everything here is platform-independent cryptography built on top of a Windows Hello signature.
 //! A [`Challenge`] is signed by Windows Hello to produce a deterministic signature, which is hashed
-//! into a high-entropy [`WindowsHelloPrf`]. That PRF is then used as a key to wrap and unwrap the
-//! vault user key ([`SymmetricCryptoKey`]) in a keychain entry.
+//! into a high-entropy [`WindowsHelloPrf`]. That PRF is then used as the high-entropy secret that
+//! seals and unseals the vault user key ([`SymmetricCryptoKey`]) in a keychain entry.
 //!
 //! The Windows Hello API calls that produce the signature live in [`super::keycredentialmanager`].
 
 use aes::cipher::KeyInit;
 use anyhow::{anyhow, Result};
-use bitwarden_crypto::{BitwardenLegacyKeyBytes, SymmetricCryptoKey};
+use bitwarden_crypto::{
+    safe::{HighEntropySecret, HighEntropySecretSource, SecretProtectedKeyEnvelope},
+    BitwardenLegacyKeyBytes, KeyStore, SymmetricCryptoKey,
+};
+use bitwarden_sensitive_value::{Sensitive, SensitiveSlice};
 use chacha20poly1305::{aead::Aead, XChaCha20Poly1305, XNonce};
 use rand_core::Rng;
 use sha2::{Digest, Sha256};
 
-use super::keychain::WindowsHelloKeychainEntry;
+use super::{
+    keychain::{WindowsHelloKeychainEntryV1, WindowsHelloKeychainEntryV2},
+    persistent::{BiometricIds, BIOMETRIC_NAMESPACE},
+};
 
 pub(crate) const CHALLENGE_LENGTH: usize = 16;
 pub(crate) const PSEUDORANDOM_WINDOWS_HELLO_OUTPUT_LENGTH: usize = 32;
@@ -48,7 +55,7 @@ impl Challenge {
 }
 
 /// The pseudorandom output derived from Windows Hello for a given [`Challenge`]. This is used as
-/// the key to protect the vault unlock key.
+/// the high-entropy secret to protect the vault unlock key.
 ///
 /// The prf is a SHA-256 digest of a Windows Hello signature.
 #[derive(Clone)]
@@ -73,9 +80,56 @@ impl WindowsHelloPrf {
     }
 }
 
-impl WindowsHelloKeychainEntry {
+impl HighEntropySecretSource for WindowsHelloPrf {
+    fn provide_high_entropy_bytes(&self) -> SensitiveSlice<'_> {
+        Sensitive::from(self.0.as_slice())
+    }
+}
+
+impl WindowsHelloKeychainEntryV2 {
+    /// Seal `user_key` into a new keychain entry, challenge
+    pub(super) fn seal(
+        challenge: Challenge,
+        windows_hello_key: &WindowsHelloPrf,
+        user_key: &SymmetricCryptoKey,
+    ) -> Result<Self> {
+        let secret = HighEntropySecret::from(windows_hello_key.clone());
+
+        let store = KeyStore::<BiometricIds>::default();
+        let mut ctx = store.context_mut();
+        let key_id = ctx.add_local_symmetric_key(user_key.clone());
+        let envelope = SecretProtectedKeyEnvelope::seal(key_id, &secret, BIOMETRIC_NAMESPACE, &ctx)
+            .map_err(|e| anyhow!("Failed to seal user key: {e}"))?;
+
+        Ok(Self {
+            challenge,
+            envelope,
+        })
+    }
+
+    /// Unseal the user key from the entry
+    pub(super) fn unseal(&self, windows_hello_key: &WindowsHelloPrf) -> Result<SymmetricCryptoKey> {
+        let secret = HighEntropySecret::from(windows_hello_key.clone());
+
+        let store = KeyStore::<BiometricIds>::default();
+        let mut ctx = store.context_mut();
+        let key_id = self
+            .envelope
+            .unseal(&secret, BIOMETRIC_NAMESPACE, &mut ctx)
+            .map_err(|e| anyhow!("Failed to unseal user key: {e}"))?;
+        #[allow(deprecated)]
+        let user_key = ctx
+            .dangerous_get_symmetric_key(key_id)
+            .map_err(|e| anyhow!("Failed to read unsealed user key: {e}"))?;
+        Ok(user_key.clone())
+    }
+}
+
+impl WindowsHelloKeychainEntryV1 {
     /// Seal `user_key` by wrapping its encoded bytes with XChaCha20Poly1305 under the Windows
-    /// Hello-derived PRF.
+    /// Hello-derived key. Only used by tests to produce legacy entries; the production code path
+    /// seals into the [`WindowsHelloKeychainEntryV2`] envelope format.
+    #[cfg(test)]
     pub(super) fn seal(
         challenge: Challenge,
         windows_hello_key: &WindowsHelloPrf,
@@ -97,7 +151,7 @@ impl WindowsHelloKeychainEntry {
         })
     }
 
-    /// Unseal the user key.
+    /// Unseal the user key
     pub(super) fn unseal(&self, windows_hello_key: &WindowsHelloPrf) -> Result<SymmetricCryptoKey> {
         let cipher = XChaCha20Poly1305::new(windows_hello_key.as_bytes().into());
         let decrypted = cipher
@@ -110,19 +164,134 @@ impl WindowsHelloKeychainEntry {
 
 #[cfg(test)]
 mod tests {
+    use aes::cipher::KeyInit;
     use bitwarden_crypto::{BitwardenLegacyKeyBytes, SymmetricCryptoKey, SymmetricKeyAlgorithm};
+    use chacha20poly1305::{aead::Aead, XChaCha20Poly1305, XNonce};
 
     use super::{
-        super::keychain::WindowsHelloKeychainEntry, Challenge, WindowsHelloPrf, CHALLENGE_LENGTH,
-        PSEUDORANDOM_WINDOWS_HELLO_OUTPUT_LENGTH,
+        super::keychain::{
+            WindowsHelloKeychainEntry, WindowsHelloKeychainEntryV1, WindowsHelloKeychainEntryV2,
+        },
+        Challenge, WindowsHelloPrf, CHALLENGE_LENGTH, PSEUDORANDOM_WINDOWS_HELLO_OUTPUT_LENGTH,
+        XCHACHA20POLY1305_NONCE_LENGTH,
     };
 
     fn user_key(encoded: &[u8]) -> SymmetricCryptoKey {
         SymmetricCryptoKey::try_from(&BitwardenLegacyKeyBytes::from(encoded.to_vec())).unwrap()
     }
 
+    // Fixed, deterministic inputs used to produce and verify the test vector below. The Windows
+    // Hello key stands in for the PRF that Windows Hello would derive from the challenge; the test
+    // never calls Windows, it re-derives the sealing secret directly from these bytes.
+    const TEST_VECTOR_WINDOWS_HELLO_KEY: [u8; PSEUDORANDOM_WINDOWS_HELLO_OUTPUT_LENGTH] =
+        [42u8; PSEUDORANDOM_WINDOWS_HELLO_OUTPUT_LENGTH];
+    const TEST_VECTOR_CHALLENGE: [u8; CHALLENGE_LENGTH] =
+        [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
+    // A valid 64-byte (AES-CBC-HMAC) encoded user key
+    const TEST_VECTOR_USER_KEY: &[u8] = &[9u8; 64];
+
+    // A `WindowsHelloKeychainEntryV2` (challenge + `SecretProtectedKeyEnvelope`), serialized
+    // exactly as it is persisted to the OS keychain. Sealing with
+    // `TEST_VECTOR_WINDOWS_HELLO_KEY` must keep unsealing to `TEST_VECTOR_USER_KEY`; if this
+    // stops decoding, the persisted format broke.
+    const TEST_VECTOR_ENTRY_V2_JSON: &str = r#"{"challenge":[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15],"envelope":"hFg0pAEDA3giYXBwbGljYXRpb24veC5iaXR3YXJkZW4ubGVnYWN5LWtleToAATiBBjoAATiAAqEFTJX+FbmsYy42SWrfHFhQI16UOuY0GTZtLbTetv+Wqj6lVecK8DtCRcyn/e1ULGKaf13Q9tXSrg4rJl4v8GKIJv361FCsgOZ8kxzN7qUDFAUIGYEEW2hDG7kWOVkD56GBg0CiASkzWCAqKJNBFc+VbkGF4V0sv5HXgCn4CcMpw8/UGHyrvP95v/Y="}"#;
+
+    // Fixed nonce used to wrap the V1 test vector below. V1 seals with a random nonce, but the
+    // recorded vector pins one so the ciphertext is reproducible.
+    const TEST_VECTOR_NONCE: [u8; XCHACHA20POLY1305_NONCE_LENGTH] = [
+        100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117,
+        118, 119, 120, 121, 122, 123,
+    ];
+
+    // A `WindowsHelloKeychainEntryV1` (nonce + challenge + XChaCha20Poly1305-wrapped user key),
+    // serialized exactly as legacy enrollments are persisted to the OS keychain. Unsealing with
+    // `TEST_VECTOR_WINDOWS_HELLO_KEY` must keep yielding `TEST_VECTOR_USER_KEY`; if this stops
+    // decoding, backward compatibility for pre-envelope enrollments broke.
+    const TEST_VECTOR_ENTRY_V1_JSON: &str = r#"{"nonce":[100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123],"challenge":[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15],"wrapped_key":[81,218,92,229,12,119,8,54,163,227,74,91,121,250,150,67,17,18,87,203,171,52,240,148,22,32,186,221,13,62,88,100,76,134,2,161,8,214,206,255,148,98,112,209,165,238,212,69,206,211,254,102,160,138,69,28,192,20,15,244,244,187,68,159,162,81,235,10,88,16,242,93,161,225,231,48,172,242,125,176]}"#;
+
+    /// Regenerates the constants above. Ignored so it never runs in CI; run manually with
+    /// `--ignored --nocapture` and paste the printed constant back into the source.
     #[test]
-    fn test_seal_unseal_roundtrip() {
+    #[ignore = "Generates test vectors; run manually"]
+    #[allow(clippy::print_stdout)]
+    fn generate_test_vectors() {
+        let windows_hello_key = WindowsHelloPrf::from_bytes(TEST_VECTOR_WINDOWS_HELLO_KEY);
+
+        let v2 = WindowsHelloKeychainEntryV2::seal(
+            Challenge::from_bytes(TEST_VECTOR_CHALLENGE),
+            &windows_hello_key,
+            &user_key(TEST_VECTOR_USER_KEY),
+        )
+        .unwrap();
+
+        // Round-trip once here to confirm the generated vector is itself valid.
+        let unsealed = v2.unseal(&windows_hello_key).unwrap();
+        assert_eq!(unsealed.to_encoded().to_vec(), TEST_VECTOR_USER_KEY);
+
+        println!(
+            "const TEST_VECTOR_ENTRY_V2_JSON: &str = r#\"{}\"#;",
+            serde_json::to_string(&v2).unwrap()
+        );
+
+        // V1 wraps the user key directly with XChaCha20Poly1305. `seal` picks a random nonce, so
+        // build the entry with the pinned `TEST_VECTOR_NONCE` to keep the recorded vector stable.
+        let cipher = XChaCha20Poly1305::new(windows_hello_key.as_bytes().into());
+        let wrapped_key = cipher
+            .encrypt(
+                XNonce::from_slice(&TEST_VECTOR_NONCE),
+                user_key(TEST_VECTOR_USER_KEY)
+                    .to_encoded()
+                    .to_vec()
+                    .as_slice(),
+            )
+            .unwrap();
+        let v1 = WindowsHelloKeychainEntryV1 {
+            nonce: TEST_VECTOR_NONCE,
+            challenge: Challenge::from_bytes(TEST_VECTOR_CHALLENGE),
+            wrapped_key,
+        };
+
+        let unsealed = v1.unseal(&windows_hello_key).unwrap();
+        assert_eq!(unsealed.to_encoded().to_vec(), TEST_VECTOR_USER_KEY);
+
+        println!(
+            "const TEST_VECTOR_ENTRY_V1_JSON: &str = r#\"{}\"#;",
+            serde_json::to_string(&v1).unwrap()
+        );
+    }
+
+    /// Never regenerate the test vector, it would be a breaking change
+    #[test]
+    fn test_keychain_entry_v2_test_vector() {
+        let windows_hello_key = WindowsHelloPrf::from_bytes(TEST_VECTOR_WINDOWS_HELLO_KEY);
+
+        let entry: WindowsHelloKeychainEntry =
+            serde_json::from_str(TEST_VECTOR_ENTRY_V2_JSON).unwrap();
+        let WindowsHelloKeychainEntry::V2(entry) = entry else {
+            panic!("Test vector must decode as a V2 keychain entry");
+        };
+
+        let unsealed = entry.unseal(&windows_hello_key).unwrap();
+        assert_eq!(unsealed.to_encoded().to_vec(), TEST_VECTOR_USER_KEY);
+    }
+
+    /// Never regenerate the test vector, it would be a breaking change
+    #[test]
+    fn test_keychain_entry_v1_test_vector() {
+        let windows_hello_key = WindowsHelloPrf::from_bytes(TEST_VECTOR_WINDOWS_HELLO_KEY);
+
+        let entry: WindowsHelloKeychainEntry =
+            serde_json::from_str(TEST_VECTOR_ENTRY_V1_JSON).unwrap();
+        let WindowsHelloKeychainEntry::V1(entry) = entry else {
+            panic!("Test vector must decode as a V1 keychain entry");
+        };
+
+        let unsealed = entry.unseal(&windows_hello_key).unwrap();
+        assert_eq!(unsealed.to_encoded().to_vec(), TEST_VECTOR_USER_KEY);
+    }
+
+    #[test]
+    fn test_v2_seal_unseal_roundtrip() {
         let windows_hello_key =
             WindowsHelloPrf::from_bytes([42u8; PSEUDORANDOM_WINDOWS_HELLO_OUTPUT_LENGTH]);
 
@@ -131,7 +300,7 @@ mod tests {
             SymmetricCryptoKey::make(SymmetricKeyAlgorithm::Aes256CbcHmac),
             SymmetricCryptoKey::make(SymmetricKeyAlgorithm::Aes256Gcm),
         ] {
-            let entry = WindowsHelloKeychainEntry::seal(
+            let entry = WindowsHelloKeychainEntryV2::seal(
                 Challenge::from_bytes([0u8; CHALLENGE_LENGTH]),
                 &windows_hello_key,
                 &key,
@@ -143,14 +312,31 @@ mod tests {
     }
 
     #[test]
+    fn test_v1_seal_unseal_roundtrip() {
+        let windows_hello_key =
+            WindowsHelloPrf::from_bytes([42u8; PSEUDORANDOM_WINDOWS_HELLO_OUTPUT_LENGTH]);
+
+        for encoded in [vec![7u8; 32], vec![9u8; 64]] {
+            let entry = WindowsHelloKeychainEntryV1::seal(
+                Challenge::from_bytes([0u8; CHALLENGE_LENGTH]),
+                &windows_hello_key,
+                &user_key(&encoded),
+            )
+            .unwrap();
+            let unsealed = entry.unseal(&windows_hello_key).unwrap();
+            assert_eq!(unsealed.to_encoded().to_vec(), encoded);
+        }
+    }
+
+    #[test]
     fn test_unseal_with_wrong_secret_fails() {
-        let entry = WindowsHelloKeychainEntry::seal(
+        let entry = WindowsHelloKeychainEntryV2::seal(
             Challenge::from_bytes([0u8; CHALLENGE_LENGTH]),
             &WindowsHelloPrf::from_bytes([42u8; PSEUDORANDOM_WINDOWS_HELLO_OUTPUT_LENGTH]),
             &user_key(&[9u8; 64]),
         )
         .unwrap();
-        // A different Windows Hello key must not unseal the entry.
+        // A different Windows Hello key must not unseal the envelope.
         assert!(entry
             .unseal(&WindowsHelloPrf::from_bytes(
                 [7u8; PSEUDORANDOM_WINDOWS_HELLO_OUTPUT_LENGTH]

--- a/apps/desktop/desktop_native/biometric/src/windows/keychain.rs
+++ b/apps/desktop/desktop_native/biometric/src/windows/keychain.rs
@@ -6,6 +6,7 @@
 //! the PRF.
 
 use anyhow::{anyhow, Result};
+use bitwarden_crypto::safe::SecretProtectedKeyEnvelope;
 use desktop_core::password::{self, PASSWORD_NOT_FOUND};
 use tracing::{debug, warn};
 
@@ -13,16 +14,35 @@ use super::encryption::Challenge;
 
 pub(crate) const KEYCHAIN_SERVICE_NAME: &str = "BitwardenBiometricsV2";
 
-/// A keychain entry: the user key is wrapped with XChaCha20Poly1305 using the Windows Hello-derived
-/// PRF as a key. The `challenge` is stored because it is the input used to re-derive the PRF.
+/// V1 keychain entry: the user key is wrapped directly with XChaCha20Poly1305 using the
+/// Windows Hello-derived PRF as a key.
 #[derive(serde::Serialize, serde::Deserialize)]
-pub(crate) struct WindowsHelloKeychainEntry {
+pub(crate) struct WindowsHelloKeychainEntryV1 {
     pub(crate) nonce: [u8; super::encryption::XCHACHA20POLY1305_NONCE_LENGTH],
     pub(crate) challenge: Challenge,
     pub(crate) wrapped_key: Vec<u8>,
 }
 
-pub(crate) async fn set_entry(user_id: &str, entry: &WindowsHelloKeychainEntry) -> Result<()> {
+/// V2 keychain entry: the user key is sealed in a [`SecretProtectedKeyEnvelope`]. The `challenge`
+/// is still stored because it is the input used to re-derive the Windows Hello PRF.
+#[derive(serde::Serialize, serde::Deserialize)]
+pub(crate) struct WindowsHelloKeychainEntryV2 {
+    pub(crate) challenge: Challenge,
+    pub(crate) envelope: SecretProtectedKeyEnvelope,
+}
+
+#[derive(serde::Deserialize)]
+#[serde(untagged)]
+#[allow(clippy::large_enum_variant)]
+pub(crate) enum WindowsHelloKeychainEntry {
+    //The two formats have disjoint required fields (`envelope` vs
+    // `nonce` + `wrapped_key`), so untagged deserialization unambiguously deserializes to the
+    // correct variant
+    V2(WindowsHelloKeychainEntryV2),
+    V1(WindowsHelloKeychainEntryV1),
+}
+
+pub(crate) async fn set_entry(user_id: &str, entry: &WindowsHelloKeychainEntryV2) -> Result<()> {
     password::set_password(
         KEYCHAIN_SERVICE_NAME,
         user_id,
@@ -67,4 +87,48 @@ pub(crate) async fn has_entry(user_id: &str) -> Result<bool> {
                 Err(e)
             }
         })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{super::encryption::CHALLENGE_LENGTH, WindowsHelloKeychainEntry};
+
+    const TEST_VECTOR_CHALLENGE: [u8; CHALLENGE_LENGTH] =
+        [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
+    const TEST_VECTOR_NONCE: [u8; super::super::encryption::XCHACHA20POLY1305_NONCE_LENGTH] = [
+        200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217,
+        218, 219, 220, 221, 222, 223,
+    ];
+    const TEST_VECTOR_WRAPPED_KEY: &[u8] = &[90, 91, 92, 93, 94, 95];
+
+    // Test-vectors for th v1 and v2 keychain entries. Note: These are not cryptographically
+    // meaningful, just enough to ensure the serialization works.
+    const TEST_VECTOR_V2_JSON: &str = r#"{"challenge":[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15],"envelope":"hFg0pAEDA3giYXBwbGljYXRpb24veC5iaXR3YXJkZW4ubGVnYWN5LWtleToAATiBBjoAATiAAqEFTJX+FbmsYy42SWrfHFhQI16UOuY0GTZtLbTetv+Wqj6lVecK8DtCRcyn/e1ULGKaf13Q9tXSrg4rJl4v8GKIJv361FCsgOZ8kxzN7qUDFAUIGYEEW2hDG7kWOVkD56GBg0CiASkzWCAqKJNBFc+VbkGF4V0sv5HXgCn4CcMpw8/UGHyrvP95v/Y="}"#;
+    const TEST_VECTOR_V1_JSON: &str = r#"{"nonce":[200,201,202,203,204,205,206,207,208,209,210,211,212,213,214,215,216,217,218,219,220,221,222,223],"challenge":[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15],"wrapped_key":[90,91,92,93,94,95]}"#;
+
+    /// A recorded current-format entry must keep deserializing to the `V2` variant with its
+    /// challenge intact.
+    #[test]
+    fn test_keychain_entry_v2_format_vector() {
+        let entry: WindowsHelloKeychainEntry = serde_json::from_str(TEST_VECTOR_V2_JSON).unwrap();
+        let WindowsHelloKeychainEntry::V2(entry) = entry else {
+            panic!("A challenge+envelope entry must deserialize to the V2 variant");
+        };
+        assert_eq!(entry.challenge.as_bytes(), &TEST_VECTOR_CHALLENGE);
+    }
+
+    /// A recorded legacy entry must keep deserializing to the `V1` variant with its fields intact,
+    /// and re-serialize to the exact stored bytes. This guards backward compatibility for
+    /// enrollments created before the envelope format.
+    #[test]
+    fn test_keychain_entry_v1_format_vector() {
+        let entry: WindowsHelloKeychainEntry = serde_json::from_str(TEST_VECTOR_V1_JSON).unwrap();
+        let WindowsHelloKeychainEntry::V1(entry) = entry else {
+            panic!("A nonce+challenge+wrapped_key entry must deserialize to the V1 variant");
+        };
+        assert_eq!(entry.nonce, TEST_VECTOR_NONCE);
+        assert_eq!(entry.challenge.as_bytes(), &TEST_VECTOR_CHALLENGE);
+        assert_eq!(entry.wrapped_key, TEST_VECTOR_WRAPPED_KEY);
+        assert_eq!(serde_json::to_string(&entry).unwrap(), TEST_VECTOR_V1_JSON);
+    }
 }

--- a/apps/desktop/desktop_native/biometric/src/windows/mod.rs
+++ b/apps/desktop/desktop_native/biometric/src/windows/mod.rs
@@ -140,11 +140,15 @@ impl super::BiometricTrait for BiometricLockSystem {
 #[cfg(test)]
 #[allow(clippy::print_stdout)]
 mod tests {
+    use bitwarden_crypto::{BitwardenLegacyKeyBytes, SymmetricCryptoKey};
     use rand_core::Rng;
 
     use super::{
         encryption::{Challenge, CHALLENGE_LENGTH, PSEUDORANDOM_WINDOWS_HELLO_OUTPUT_LENGTH},
         ephemeral::windows_hello_authenticate,
+        keychain::{
+            self, WindowsHelloKeychainEntry, WindowsHelloKeychainEntryV1, KEYCHAIN_SERVICE_NAME,
+        },
         keycredentialmanager::KeyCredentialManager,
         BiometricLockSystem,
     };
@@ -247,5 +251,46 @@ mod tests {
             .has_persistent(&user_id)
             .await
             .unwrap());
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn test_legacy_entry_migrates_on_unlock() {
+        let user_id = String::from("test_user");
+        let mut key = [0u8; PSEUDORANDOM_WINDOWS_HELLO_OUTPUT_LENGTH];
+        bitwarden_random::rng().fill_bytes(&mut key);
+
+        let windows_hello_lock_system = BiometricLockSystem::new();
+
+        // Write a legacy (pre-envelope) keychain entry directly, simulating a user enrolled with an
+        // older build.
+        let mut challenge_bytes = [0u8; CHALLENGE_LENGTH];
+        bitwarden_random::rng().fill_bytes(&mut challenge_bytes);
+        let challenge = Challenge::from_bytes(challenge_bytes);
+        let windows_hello_key = KeyCredentialManager::derive_prf(&challenge).await.unwrap();
+        let user_key =
+            SymmetricCryptoKey::try_from(&BitwardenLegacyKeyBytes::from(key.to_vec())).unwrap();
+        let legacy =
+            WindowsHelloKeychainEntryV1::seal(challenge, &windows_hello_key, &user_key).unwrap();
+        desktop_core::password::set_password(
+            KEYCHAIN_SERVICE_NAME,
+            &user_id,
+            &serde_json::to_string(&legacy).unwrap(),
+        )
+        .await
+        .unwrap();
+
+        println!("Unlocking user (should decrypt legacy entry and migrate)");
+        let key_after_unlock = windows_hello_lock_system
+            .unlock(&user_id, Vec::new())
+            .await
+            .unwrap();
+        assert_eq!(key_after_unlock, key);
+
+        // The entry should now be stored in the envelope (V2) format.
+        let migrated = keychain::get_entry(&user_id).await.unwrap();
+        assert!(matches!(migrated, WindowsHelloKeychainEntry::V2(_)));
+
+        windows_hello_lock_system.unenroll(&user_id).await.unwrap();
     }
 }

--- a/apps/desktop/desktop_native/biometric/src/windows/persistent.rs
+++ b/apps/desktop/desktop_native/biometric/src/windows/persistent.rs
@@ -7,14 +7,46 @@
 use std::{collections::HashMap, sync::Arc};
 
 use anyhow::Result;
-use bitwarden_crypto::SymmetricCryptoKey;
+use bitwarden_crypto::{
+    key_slot_ids, safe::SecretProtectedKeyEnvelopeNamespace, SymmetricCryptoKey,
+};
 use tokio::sync::Mutex;
+use tracing::warn;
 
 use super::{
     encryption::Challenge,
-    keychain::{self, WindowsHelloKeychainEntry},
+    keychain::{self, WindowsHelloKeychainEntry, WindowsHelloKeychainEntryV2},
     keycredentialmanager::KeyCredentialManager,
 };
+
+/// Unique content-layer namespace for biometric-protected keys.
+pub(super) const BIOMETRIC_NAMESPACE: SecretProtectedKeyEnvelopeNamespace =
+    SecretProtectedKeyEnvelopeNamespace::DesktopBiometricUnlock;
+
+// The key slots for the biometric module. Only local symmetric keys are used (the user key is
+// added via `add_local_symmetric_key`); the private and signing slots exist solely to satisfy the
+// `KeySlotIds` contract that `KeyStore` requires.
+key_slot_ids! {
+    #[symmetric]
+    pub enum BiometricSymmetricKey {
+        #[local]
+        Local(LocalId),
+    }
+
+    #[private]
+    pub enum BiometricPrivateKey {
+        #[local]
+        Local(LocalId),
+    }
+
+    #[signing]
+    pub enum BiometricSigningKey {
+        #[local]
+        Local(LocalId),
+    }
+
+    pub BiometricIds => BiometricSymmetricKey, BiometricPrivateKey, BiometricSigningKey;
+}
 
 /// Keychain-backed Windows Hello unlock, guarded by a Windows Hello signing prompt.
 pub(super) struct PersistentWindowsHelloSystem {
@@ -36,8 +68,9 @@ impl PersistentWindowsHelloSystem {
     pub(super) async fn enroll(&self, user_id: &str, user_key: &SymmetricCryptoKey) -> Result<()> {
         // Enrollment works by first generating a random challenge unique to the user / enrollment.
         // Then, with the challenge and a Windows-Hello prompt, the "windows hello prf" is
-        // derived. The windows hello prf is used as the key to wrap the user key. The bundle of
-        // nonce, challenge and wrapped key are stored to the keychain.
+        // derived. The windows hello prf is used as the high-entropy secret to seal the user key
+        // into a `SecretProtectedKeyEnvelope`. The bundle of challenge and serialized envelope are
+        // stored to the keychain.
 
         // Each enrollment (per user) has a unique challenge, so that the windows-hello prf is
         // unique
@@ -47,7 +80,7 @@ impl PersistentWindowsHelloSystem {
         // another process reads the challenge and calls the credential manager, it can
         // derive the same PRF.
         let windows_hello_prf = KeyCredentialManager::derive_prf(&challenge).await?;
-        let entry = WindowsHelloKeychainEntry::seal(challenge, &windows_hello_prf, user_key)?;
+        let entry = WindowsHelloKeychainEntryV2::seal(challenge, &windows_hello_prf, user_key)?;
 
         keychain::set_entry(user_id, &entry).await?;
 
@@ -58,12 +91,41 @@ impl PersistentWindowsHelloSystem {
         Ok(())
     }
 
-    /// Unlock the persisted user key for `user_id` via a Windows Hello prompt.
+    /// Unlock the persisted user key for `user_id` via a Windows Hello prompt
     pub(super) async fn unlock(&self, user_id: &str) -> Result<SymmetricCryptoKey> {
-        // Re-derive the PRF via Windows Hello and unseal the persisted user key.
-        let entry = keychain::get_entry(user_id).await?;
-        let windows_hello_prf = KeyCredentialManager::derive_prf(&entry.challenge).await?;
-        entry.unseal(&windows_hello_prf)
+        // Re-derive the PRF via Windows Hello and unseal the persisted user key. Legacy (V1)
+        // entries are migrated on unlock to the V2 format.
+
+        match keychain::get_entry(user_id).await? {
+            WindowsHelloKeychainEntry::V2(entry) => {
+                let windows_hello_prf = KeyCredentialManager::derive_prf(&entry.challenge).await?;
+                entry.unseal(&windows_hello_prf)
+            }
+            WindowsHelloKeychainEntry::V1(entry) => {
+                let windows_hello_prf = KeyCredentialManager::derive_prf(&entry.challenge).await?;
+                let user_key = entry.unseal(&windows_hello_prf)?;
+
+                // Lazily migrate the legacy entry to the envelope format. The same challenge is
+                // reused, so no additional Windows Hello prompt is required. A migration failure
+                // must not fail the unlock - the key was already recovered above.
+                match WindowsHelloKeychainEntryV2::seal(
+                    entry.challenge,
+                    &windows_hello_prf,
+                    &user_key,
+                ) {
+                    Ok(migrated_entry) => {
+                        if let Err(e) = keychain::set_entry(user_id, &migrated_entry).await {
+                            warn!("[Windows Hello] Failed to persist migrated keychain entry: {e}");
+                        }
+                    }
+                    Err(e) => {
+                        warn!("[Windows Hello] Failed to re-seal keychain entry during migration: {e}");
+                    }
+                }
+
+                Ok(user_key)
+            }
+        }
     }
 
     /// Whether a persisted keychain entry exists for `user_id` (cached).


### PR DESCRIPTION
This adds support for SDK-based encryption based on the safe primitive SecretProtectedKeyEnvelope. To make this maintainable, this PR first refactors, by moving the biometrics module, then separating out the implementations (ephemeral, persistent).

Overview of crypto: We store a per-enrollement challenge. This is used via keycredentialmanager to sign the challenge deterministically. The signature is hashed to produce a high-entropy-secret "PRF". This is fed into the secretkeyenvelope seal / unseal. The secretkeyenvelope directly contains the user's user key.
