### PR TITLE
[PM-13643] avatars in org member remove/revoke modal do not match members page fix

### DIFF
--- a/apps/web/src/app/admin-console/organizations/members/components/bulk/bulk-confirm-dialog.component.html
+++ b/apps/web/src/app/admin-console/organizations/members/components/bulk/bulk-confirm-dialog.component.html
@@ -36,7 +36,7 @@
                 <td bitCell class="tw-w-5">
                   <bit-avatar
                     [text]="user | userName"
-                    [id]="user.userId ?? user.id"
+                    [id]="user | avatarId"
                     [color]="user.avatarColor"
                   ></bit-avatar>
                 </td>
@@ -56,7 +56,7 @@
                 <td bitCell class="tw-w-5">
                   <bit-avatar
                     [text]="user | userName"
-                    [id]="user.userId ?? user.id"
+                    [id]="user | avatarId"
                     [color]="user.avatarColor"
                   ></bit-avatar>
                 </td>
@@ -90,7 +90,7 @@
                 <td bitCell class="tw-w-5">
                   <bit-avatar
                     [text]="user | userName"
-                    [id]="user.userId ?? user.id"
+                    [id]="user | avatarId"
                     [color]="user.avatarColor"
                   ></bit-avatar>
                 </td>

--- a/apps/web/src/app/admin-console/organizations/members/components/bulk/bulk-confirm-dialog.component.ts
+++ b/apps/web/src/app/admin-console/organizations/members/components/bulk/bulk-confirm-dialog.component.ts
@@ -31,6 +31,8 @@ import {
 } from "@bitwarden/components";
 import { I18nPipe } from "@bitwarden/ui-common";
 
+import { AvatarIdPipe } from "../../pipes/avatar-id.pipe";
+
 import { BaseBulkConfirmComponent } from "./base-bulk-confirm.component";
 import { BulkUserDetails } from "./bulk-status.component";
 
@@ -46,6 +48,7 @@ type BulkConfirmDialogParams = {
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     AsyncActionsModule,
+    AvatarIdPipe,
     AvatarModule,
     ButtonModule,
     CalloutModule,

--- a/apps/web/src/app/admin-console/organizations/members/components/bulk/bulk-delete-dialog.component.html
+++ b/apps/web/src/app/admin-console/organizations/members/components/bulk/bulk-delete-dialog.component.html
@@ -29,7 +29,7 @@
                 <td bitCell class="tw-w-5">
                   <bit-avatar
                     [text]="user | userName"
-                    [id]="user.userId ?? user.id"
+                    [id]="user | avatarId"
                     [color]="user.avatarColor"
                   ></bit-avatar>
                 </td>
@@ -67,7 +67,7 @@
                 <td bitCell class="tw-w-5">
                   <bit-avatar
                     [text]="user | userName"
-                    [id]="user.userId ?? user.id"
+                    [id]="user | avatarId"
                     [color]="user.avatarColor"
                   ></bit-avatar>
                 </td>

--- a/apps/web/src/app/admin-console/organizations/members/components/bulk/bulk-delete-dialog.component.ts
+++ b/apps/web/src/app/admin-console/organizations/members/components/bulk/bulk-delete-dialog.component.ts
@@ -17,6 +17,7 @@ import {
 } from "@bitwarden/components";
 import { I18nPipe } from "@bitwarden/ui-common";
 
+import { AvatarIdPipe } from "../../pipes/avatar-id.pipe";
 import { DeleteManagedMemberWarningService } from "../../services/delete-managed-member/delete-managed-member-warning.service";
 
 import { BulkUserDetails } from "./bulk-status.component";
@@ -32,6 +33,7 @@ type BulkDeleteDialogParams = {
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
+    AvatarIdPipe,
     AvatarModule,
     BadgeModule,
     ButtonModule,

--- a/apps/web/src/app/admin-console/organizations/members/components/bulk/bulk-enable-sm-dialog.component.html
+++ b/apps/web/src/app/admin-console/organizations/members/components/bulk/bulk-enable-sm-dialog.component.html
@@ -16,7 +16,7 @@
               <div class="tw-flex tw-items-center">
                 <bit-avatar
                   [text]="u | userName"
-                  [id]="u.userId"
+                  [id]="u | avatarId"
                   [color]="u.avatarColor"
                   class="tw-mr-3"
                 ></bit-avatar>

--- a/apps/web/src/app/admin-console/organizations/members/components/bulk/bulk-enable-sm-dialog.component.ts
+++ b/apps/web/src/app/admin-console/organizations/members/components/bulk/bulk-enable-sm-dialog.component.ts
@@ -18,6 +18,7 @@ import {
 import { I18nPipe } from "@bitwarden/ui-common";
 
 import { OrganizationUserView } from "../../../core";
+import { AvatarIdPipe } from "../../pipes/avatar-id.pipe";
 
 export type BulkEnableSecretsManagerDialogData = {
   orgId: string;
@@ -31,6 +32,7 @@ export type BulkEnableSecretsManagerDialogData = {
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     AsyncActionsModule,
+    AvatarIdPipe,
     AvatarModule,
     ButtonModule,
     DialogModule,

--- a/apps/web/src/app/admin-console/organizations/members/components/bulk/bulk-reinvite-failure-dialog.component.html
+++ b/apps/web/src/app/admin-console/organizations/members/components/bulk/bulk-reinvite-failure-dialog.component.html
@@ -32,7 +32,7 @@
                 <div class="tw-flex tw-items-center">
                   <bit-avatar
                     [text]="u | userName"
-                    [id]="u.userId"
+                    [id]="u | avatarId"
                     [color]="u.avatarColor"
                     class="tw-mr-3"
                   ></bit-avatar>

--- a/apps/web/src/app/admin-console/organizations/members/components/bulk/bulk-remove-dialog.component.html
+++ b/apps/web/src/app/admin-console/organizations/members/components/bulk/bulk-remove-dialog.component.html
@@ -37,7 +37,7 @@
                 <td bitCell class="tw-w-5">
                   <bit-avatar
                     [text]="user | userName"
-                    [id]="user.userId ?? user.id"
+                    [id]="user | avatarId"
                     [color]="user.avatarColor"
                   ></bit-avatar>
                 </td>
@@ -81,7 +81,7 @@
                 <td bitCell class="tw-w-5">
                   <bit-avatar
                     [text]="user | userName"
-                    [id]="user.userId ?? user.id"
+                    [id]="user | avatarId"
                     [color]="user.avatarColor"
                   ></bit-avatar>
                 </td>

--- a/apps/web/src/app/admin-console/organizations/members/components/bulk/bulk-remove-dialog.component.ts
+++ b/apps/web/src/app/admin-console/organizations/members/components/bulk/bulk-remove-dialog.component.ts
@@ -20,6 +20,8 @@ import {
 } from "@bitwarden/components";
 import { I18nPipe } from "@bitwarden/ui-common";
 
+import { AvatarIdPipe } from "../../pipes/avatar-id.pipe";
+
 import { BaseBulkRemoveComponent } from "./base-bulk-remove.component";
 import { BulkUserDetails } from "./bulk-status.component";
 
@@ -35,6 +37,7 @@ type BulkRemoveDialogParams = {
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     AsyncActionsModule,
+    AvatarIdPipe,
     AvatarModule,
     ButtonModule,
     CalloutModule,

--- a/apps/web/src/app/admin-console/organizations/members/components/bulk/bulk-restore-revoke.component.html
+++ b/apps/web/src/app/admin-console/organizations/members/components/bulk/bulk-restore-revoke.component.html
@@ -44,7 +44,7 @@
                     <div class="tw-mr-6">
                       <bit-avatar
                         [text]="user | userName"
-                        [id]="user.userId ?? user.id"
+                        [id]="user | avatarId"
                         [color]="user.avatarColor"
                       ></bit-avatar>
                     </div>
@@ -97,7 +97,7 @@
                     <div class="tw-mr-6">
                       <bit-avatar
                         [text]="user | userName"
-                        [id]="user.userId ?? user.id"
+                        [id]="user | avatarId"
                         [color]="user.avatarColor"
                       ></bit-avatar>
                     </div>

--- a/apps/web/src/app/admin-console/organizations/members/components/bulk/bulk-restore-revoke.component.ts
+++ b/apps/web/src/app/admin-console/organizations/members/components/bulk/bulk-restore-revoke.component.ts
@@ -26,6 +26,8 @@ import {
 } from "@bitwarden/components";
 import { I18nPipe } from "@bitwarden/ui-common";
 
+import { AvatarIdPipe } from "../../pipes/avatar-id.pipe";
+
 import { BulkUserDetails } from "./bulk-status.component";
 
 type BulkRestoreDialogParams = {
@@ -41,6 +43,7 @@ type BulkRestoreDialogParams = {
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     AsyncActionsModule,
+    AvatarIdPipe,
     AvatarModule,
     ButtonModule,
     CalloutModule,

--- a/apps/web/src/app/admin-console/organizations/members/components/bulk/bulk-status.component.html
+++ b/apps/web/src/app/admin-console/organizations/members/components/bulk/bulk-status.component.html
@@ -20,7 +20,7 @@
               <td width="30" bitCell>
                 <bit-avatar
                   [text]="item.user | userName"
-                  [id]="item.user.userId ?? item.user.id"
+                  [id]="item.user | avatarId"
                   [color]="item.user.avatarColor"
                 ></bit-avatar>
               </td>

--- a/apps/web/src/app/admin-console/organizations/members/components/bulk/bulk-status.component.ts
+++ b/apps/web/src/app/admin-console/organizations/members/components/bulk/bulk-status.component.ts
@@ -23,6 +23,7 @@ import {
 import { I18nPipe } from "@bitwarden/ui-common";
 
 import { OrganizationUserView } from "../../../core/views/organization-user.view";
+import { AvatarIdPipe } from "../../pipes/avatar-id.pipe";
 
 export interface BulkUserDetails {
   id: string;
@@ -59,6 +60,7 @@ type BulkStatusDialogData = {
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
+    AvatarIdPipe,
     AvatarModule,
     ButtonModule,
     CalloutModule,

--- a/apps/web/src/app/admin-console/organizations/members/members.component.html
+++ b/apps/web/src/app/admin-console/organizations/members/members.component.html
@@ -222,7 +222,7 @@
                   <div class="tw-flex tw-items-center">
                     <bit-avatar
                       [text]="u | userName"
-                      [id]="u.userId"
+                      [id]="u | avatarId"
                       [color]="u.avatarColor"
                       class="tw-mr-3"
                     ></bit-avatar>
@@ -283,7 +283,7 @@
                   <div class="tw-flex tw-items-center">
                     <bit-avatar
                       [text]="u | userName"
-                      [id]="u.userId"
+                      [id]="u | avatarId"
                       [color]="u.avatarColor"
                       class="tw-mr-3"
                     ></bit-avatar>

--- a/apps/web/src/app/admin-console/organizations/members/members.module.ts
+++ b/apps/web/src/app/admin-console/organizations/members/members.module.ts
@@ -27,7 +27,7 @@ import { InviteMembersDialogComponent } from "./components/invite-members-dialog
 import { UserDialogModule } from "./components/member-dialog";
 import { MembersRoutingModule } from "./members-routing.module";
 import { MembersComponent } from "./members.component";
-import { UserStatusPipe } from "./pipes";
+import { AvatarIdPipe, UserStatusPipe } from "./pipes";
 import {
   OrganizationMembersService,
   MemberActionsService,
@@ -50,6 +50,7 @@ import {
     IconModule,
     BerryComponent,
     TooltipDirective,
+    AvatarIdPipe,
     BulkConfirmDialogComponent,
     BulkDeleteDialogComponent,
     BulkEnableSecretsManagerDialogComponent,

--- a/apps/web/src/app/admin-console/organizations/members/pipes/avatar-id.pipe.spec.ts
+++ b/apps/web/src/app/admin-console/organizations/members/pipes/avatar-id.pipe.spec.ts
@@ -1,0 +1,17 @@
+import { AvatarIdPipe } from "./avatar-id.pipe";
+
+describe("AvatarIdPipe", () => {
+  let pipe: AvatarIdPipe;
+
+  beforeEach(() => {
+    pipe = new AvatarIdPipe();
+  });
+
+  it("prefers the account id (userId) when present", () => {
+    expect(pipe.transform({ id: "org-user-id", userId: "account-id" })).toBe("account-id");
+  });
+
+  it("falls back to the org/provider user id when userId is not provided", () => {
+    expect(pipe.transform({ id: "org-user-id" })).toBe("org-user-id");
+  });
+});

--- a/apps/web/src/app/admin-console/organizations/members/pipes/avatar-id.pipe.ts
+++ b/apps/web/src/app/admin-console/organizations/members/pipes/avatar-id.pipe.ts
@@ -2,13 +2,7 @@ import { Pipe, PipeTransform } from "@angular/core";
 
 import { AvatarIdentifiable, resolveAvatarId } from "../utils/resolve-avatar-id";
 
-/**
- * Resolves the identifier passed to `bit-avatar`'s `[id]` input so a member's avatar color is
- * consistent everywhere they're rendered. See {@link resolveAvatarId} for details.
- *
- * A pure pipe (the default) is used instead of a template function call so Angular only
- * re-evaluates it when the `user` reference changes, rather than on every change detection cycle.
- */
+/** Resolves a member's `bit-avatar` id. See {@link resolveAvatarId}. */
 @Pipe({
   name: "avatarId",
 })

--- a/apps/web/src/app/admin-console/organizations/members/pipes/avatar-id.pipe.ts
+++ b/apps/web/src/app/admin-console/organizations/members/pipes/avatar-id.pipe.ts
@@ -1,0 +1,19 @@
+import { Pipe, PipeTransform } from "@angular/core";
+
+import { AvatarIdentifiable, resolveAvatarId } from "../utils/resolve-avatar-id";
+
+/**
+ * Resolves the identifier passed to `bit-avatar`'s `[id]` input so a member's avatar color is
+ * consistent everywhere they're rendered. See {@link resolveAvatarId} for details.
+ *
+ * A pure pipe (the default) is used instead of a template function call so Angular only
+ * re-evaluates it when the `user` reference changes, rather than on every change detection cycle.
+ */
+@Pipe({
+  name: "avatarId",
+})
+export class AvatarIdPipe implements PipeTransform {
+  transform(user: AvatarIdentifiable): string {
+    return resolveAvatarId(user);
+  }
+}

--- a/apps/web/src/app/admin-console/organizations/members/pipes/index.ts
+++ b/apps/web/src/app/admin-console/organizations/members/pipes/index.ts
@@ -1,1 +1,2 @@
+export * from "./avatar-id.pipe";
 export * from "./user-status.pipe";

--- a/apps/web/src/app/admin-console/organizations/members/utils/resolve-avatar-id.spec.ts
+++ b/apps/web/src/app/admin-console/organizations/members/utils/resolve-avatar-id.spec.ts
@@ -1,0 +1,33 @@
+import { resolveAvatarId } from "./resolve-avatar-id";
+
+describe("resolveAvatarId", () => {
+  it("prefers the account id (userId) when present", () => {
+    expect(resolveAvatarId({ id: "org-user-id", userId: "account-id" })).toBe("account-id");
+  });
+
+  it("falls back to the org/provider user id when userId is undefined", () => {
+    expect(resolveAvatarId({ id: "org-user-id", userId: undefined })).toBe("org-user-id");
+  });
+
+  it("falls back to the org/provider user id when userId is not provided", () => {
+    expect(resolveAvatarId({ id: "org-user-id" })).toBe("org-user-id");
+  });
+
+  it("falls back to the org/provider user id when userId is null", () => {
+    const user: { id: string; userId?: string } = { id: "org-user-id", userId: null as any };
+    expect(resolveAvatarId(user)).toBe("org-user-id");
+  });
+
+  it("returns the same id for the same member regardless of which caller resolves it", () => {
+    // Regression test: the members list and every bulk action dialog must resolve the same
+    // avatar identifier for the same member, otherwise the same person shows a different
+    // avatar color in different parts of the UI.
+    const invitedMember: { id: string; userId?: string } = { id: "org-user-id", userId: undefined };
+
+    const idAsRenderedByMembersList = resolveAvatarId(invitedMember);
+    const idAsRenderedByBulkDialog = resolveAvatarId(invitedMember);
+
+    expect(idAsRenderedByMembersList).toBe(idAsRenderedByBulkDialog);
+    expect(idAsRenderedByMembersList).toBe("org-user-id");
+  });
+});

--- a/apps/web/src/app/admin-console/organizations/members/utils/resolve-avatar-id.ts
+++ b/apps/web/src/app/admin-console/organizations/members/utils/resolve-avatar-id.ts
@@ -1,0 +1,23 @@
+/**
+ * Minimal shape needed to resolve a consistent avatar identifier for a member.
+ */
+export interface AvatarIdentifiable {
+  id: string;
+  userId?: string;
+}
+
+/**
+ * Resolve the identifier used by `bit-avatar` to deterministically color a member's avatar when
+ * no explicit `avatarColor` is set.
+ *
+ * Always prefer the account id (`userId`) so the same member shows the same avatar color
+ * everywhere they appear (e.g. the members list and bulk action dialogs). Fall back to the
+ * org/provider user id for members who don't yet have a linked account (e.g. invited or staged
+ * members), since they have no `userId`.
+ *
+ * This must be used consistently everywhere a member's avatar is rendered - using different
+ * fallback logic in different places causes the same member to show different avatar colors.
+ */
+export function resolveAvatarId(user: AvatarIdentifiable): string {
+  return user.userId ?? user.id;
+}

--- a/apps/web/src/app/admin-console/organizations/members/utils/resolve-avatar-id.ts
+++ b/apps/web/src/app/admin-console/organizations/members/utils/resolve-avatar-id.ts
@@ -1,22 +1,11 @@
-/**
- * Minimal shape needed to resolve a consistent avatar identifier for a member.
- */
 export interface AvatarIdentifiable {
   id: string;
   userId?: string;
 }
 
 /**
- * Resolve the identifier used by `bit-avatar` to deterministically color a member's avatar when
- * no explicit `avatarColor` is set.
- *
- * Always prefer the account id (`userId`) so the same member shows the same avatar color
- * everywhere they appear (e.g. the members list and bulk action dialogs). Fall back to the
- * org/provider user id for members who don't yet have a linked account (e.g. invited or staged
- * members), since they have no `userId`.
- *
- * This must be used consistently everywhere a member's avatar is rendered - using different
- * fallback logic in different places causes the same member to show different avatar colors.
+ * Resolves a consistent avatar id for a member, preferring their account id (`userId`) and
+ * falling back to the org/provider user id (e.g. for invited members with no linked account).
  */
 export function resolveAvatarId(user: AvatarIdentifiable): string {
   return user.userId ?? user.id;

--- a/bitwarden_license/bit-web/src/app/admin-console/providers/manage/dialogs/bulk-confirm-dialog.component.ts
+++ b/bitwarden_license/bit-web/src/app/admin-console/providers/manage/dialogs/bulk-confirm-dialog.component.ts
@@ -33,6 +33,7 @@ import {
 import { I18nPipe } from "@bitwarden/ui-common";
 import { BaseBulkConfirmComponent } from "@bitwarden/web-vault/app/admin-console/organizations/members/components/bulk/base-bulk-confirm.component";
 import { BulkUserDetails } from "@bitwarden/web-vault/app/admin-console/organizations/members/components/bulk/bulk-status.component";
+import { AvatarIdPipe } from "@bitwarden/web-vault/app/admin-console/organizations/members/pipes/avatar-id.pipe";
 
 type BulkConfirmDialogParams = {
   providerId: string;
@@ -47,6 +48,7 @@ type BulkConfirmDialogParams = {
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     AsyncActionsModule,
+    AvatarIdPipe,
     AvatarModule,
     ButtonModule,
     CalloutModule,

--- a/bitwarden_license/bit-web/src/app/admin-console/providers/manage/dialogs/bulk-remove-dialog.component.ts
+++ b/bitwarden_license/bit-web/src/app/admin-console/providers/manage/dialogs/bulk-remove-dialog.component.ts
@@ -19,6 +19,7 @@ import {
 import { I18nPipe } from "@bitwarden/ui-common";
 import { BaseBulkRemoveComponent } from "@bitwarden/web-vault/app/admin-console/organizations/members/components/bulk/base-bulk-remove.component";
 import { BulkUserDetails } from "@bitwarden/web-vault/app/admin-console/organizations/members/components/bulk/bulk-status.component";
+import { AvatarIdPipe } from "@bitwarden/web-vault/app/admin-console/organizations/members/pipes/avatar-id.pipe";
 
 type BulkRemoveDialogParams = {
   providerId: string;
@@ -33,6 +34,7 @@ type BulkRemoveDialogParams = {
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     AsyncActionsModule,
+    AvatarIdPipe,
     AvatarModule,
     ButtonModule,
     CalloutModule,


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-13643

## 📔 Objective

Fixes issue where colors of members' avatars do not match modal and members page because of user ID not being used for both.
