### PR TITLE
[PM-38749] Add OrganizationInviteLinkApiService.updateSupportsConfirmation

### DIFF
--- a/libs/organization-invite-link/src/abstractions/organization-invite-link-api.service.ts
+++ b/libs/organization-invite-link/src/abstractions/organization-invite-link-api.service.ts
@@ -1,6 +1,9 @@
+import { OrganizationId } from "@bitwarden/common/types/guid";
+
 import { OrganizationInviteLinkAcceptRequest } from "../models/requests/organization-invite-link-accept.request";
 import { OrganizationInviteLinkCreateRequest } from "../models/requests/organization-invite-link-create.request";
 import { OrganizationInviteLinkRefreshRequest } from "../models/requests/organization-invite-link-refresh.request";
+import { OrganizationInviteLinkUpdateSupportConfirmationRequest } from "../models/requests/organization-invite-link-update-support-confirmation.request";
 import { OrganizationInviteLinkUpdateRequest } from "../models/requests/organization-invite-link-update.request";
 import { OrganizationInviteLinkValidateEmailDomainRequest } from "../models/requests/organization-invite-link-validate-email-domain.request";
 import { OrganizationInviteLinkStatusResponseModel } from "../models/responses/organization-invite-link-status.response";
@@ -24,6 +27,12 @@ export abstract class OrganizationInviteLinkApiService {
   abstract refresh(
     organizationId: string,
     request: OrganizationInviteLinkRefreshRequest,
+  ): Promise<OrganizationInviteLinkResponseModel>;
+
+  /** Update the invite and confirmation-support flag on an existing invite link */
+  abstract updateSupportsConfirmation(
+    organizationId: OrganizationId,
+    request: OrganizationInviteLinkUpdateSupportConfirmationRequest,
   ): Promise<OrganizationInviteLinkResponseModel>;
 
   /** Retrieve the invite link for the given organization */

--- a/libs/organization-invite-link/src/models/requests/index.ts
+++ b/libs/organization-invite-link/src/models/requests/index.ts
@@ -1,5 +1,6 @@
 export * from "./organization-invite-link-accept.request";
 export * from "./organization-invite-link-create.request";
 export * from "./organization-invite-link-refresh.request";
+export * from "./organization-invite-link-update-support-confirmation.request";
 export * from "./organization-invite-link-update.request";
 export * from "./organization-invite-link-validate-email-domain.request";

--- a/libs/organization-invite-link/src/models/requests/organization-invite-link-update-support-confirmation.request.ts
+++ b/libs/organization-invite-link/src/models/requests/organization-invite-link-update-support-confirmation.request.ts
@@ -1,0 +1,17 @@
+import { Invite } from "@bitwarden/sdk-internal";
+
+export class OrganizationInviteLinkUpdateSupportConfirmationRequest {
+  /** The invite cryptographic material for the invite link. */
+  invite: Invite;
+
+  /** Whether this invite link can be used to confirm a user. */
+  supportsConfirmation: boolean;
+
+  constructor(c: { invite: Invite; supportsConfirmation: boolean }) {
+    if (!c.invite) {
+      throw new Error("Invite is required.");
+    }
+    this.invite = c.invite;
+    this.supportsConfirmation = c.supportsConfirmation;
+  }
+}

--- a/libs/organization-invite-link/src/models/responses/organization-invite-link.response.ts
+++ b/libs/organization-invite-link/src/models/responses/organization-invite-link.response.ts
@@ -4,12 +4,19 @@ import { BaseResponse } from "@bitwarden/common/models/response/base.response";
 import { Invite } from "@bitwarden/sdk-internal";
 
 export class OrganizationInviteLinkResponseModel extends BaseResponse {
+  /** The unique identifier of the invite link. */
   id: string;
+  /** The public code used to reference and access the invite link. */
   code: string;
+  /** The identifier of the organization that owns the invite link. */
   organizationId: string;
+  /** The email domains permitted to use the invite link. */
   allowedDomains: string[];
+  /** The invite cryptographic material for the invite link. */
   invite: Invite;
+  /** Whether this invite link can be used to confirm a user. */
   supportsConfirmation: boolean;
+  /** The ISO-8601 date the invite link was created. */
   creationDate: string;
 
   constructor(response: any) {
@@ -25,12 +32,19 @@ export class OrganizationInviteLinkResponseModel extends BaseResponse {
 }
 
 export class OrganizationInviteLink {
+  /** The unique identifier of the invite link. */
   id: string;
+  /** The public code used to reference and access the invite link. */
   code: string;
+  /** The identifier of the organization that owns the invite link. */
   organizationId: string;
+  /** The email domains permitted to use the invite link. */
   allowedDomains: string[];
+  /** The invite cryptographic material for the invite link. */
   invite: Invite;
+  /** Whether this invite link can be used to confirm a user. */
   supportsConfirmation: boolean;
+  /** The ISO-8601 date the invite link was created. */
   creationDate: string;
 
   constructor(response: OrganizationInviteLinkResponseModel) {

--- a/libs/organization-invite-link/src/services/default-organization-invite-link-api.service.ts
+++ b/libs/organization-invite-link/src/services/default-organization-invite-link-api.service.ts
@@ -1,9 +1,11 @@
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
+import { OrganizationId } from "@bitwarden/common/types/guid";
 
 import { OrganizationInviteLinkApiService } from "../abstractions/organization-invite-link-api.service";
 import { OrganizationInviteLinkAcceptRequest } from "../models/requests/organization-invite-link-accept.request";
 import { OrganizationInviteLinkCreateRequest } from "../models/requests/organization-invite-link-create.request";
 import { OrganizationInviteLinkRefreshRequest } from "../models/requests/organization-invite-link-refresh.request";
+import { OrganizationInviteLinkUpdateSupportConfirmationRequest } from "../models/requests/organization-invite-link-update-support-confirmation.request";
 import { OrganizationInviteLinkUpdateRequest } from "../models/requests/organization-invite-link-update.request";
 import { OrganizationInviteLinkValidateEmailDomainRequest } from "../models/requests/organization-invite-link-validate-email-domain.request";
 import { OrganizationInviteLinkStatusResponseModel } from "../models/responses/organization-invite-link-status.response";
@@ -34,6 +36,20 @@ export class DefaultOrganizationInviteLinkApiService implements OrganizationInvi
     const r = await this.apiService.send(
       "POST",
       `/organizations/${organizationId}/invite-link/refresh`,
+      request,
+      true,
+      true,
+    );
+    return new OrganizationInviteLinkResponseModel(r);
+  }
+
+  async updateSupportsConfirmation(
+    organizationId: OrganizationId,
+    request: OrganizationInviteLinkUpdateSupportConfirmationRequest,
+  ): Promise<OrganizationInviteLinkResponseModel> {
+    const r = await this.apiService.send(
+      "PUT",
+      `/organizations/${organizationId}/invite-link/support-confirm`,
       request,
       true,
       true,


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-38749

## 📔 Objective

1. Add OrganizationInviteLinkApiService.updateSupportsConfirmation to call the server API (server [PR](https://github.com/bitwarden/server/pull/7999))
