### PR TITLE
chore(ci): skip platform-community signal for fork PRs

### DIFF
--- a/.github/workflows/platform-community-signal.yml
+++ b/.github/workflows/platform-community-signal.yml
@@ -9,6 +9,7 @@ permissions: {}
 jobs:
   signal:
     name: Signal platform-community review
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     uses: bitwarden/gh-actions/.github/workflows/_platform-community-signal.yml@main
     permissions:
       contents: read


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-40556

## 📔 Objective

https://github.com/bitwarden/clients/pull/21766 introduced a CI check meant to indicate limited team knowledge for a given platform domain, but it did not exclude community forks. This job should just run on internal PRs. This change makes that so.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
