### PR TITLE
fix(desktop): guard will-navigate against renderer escape

### DIFF
--- a/apps/desktop/src/main/window.main.spec.ts
+++ b/apps/desktop/src/main/window.main.spec.ts
@@ -1,0 +1,109 @@
+import { pathToFileURL } from "node:url";
+import * as path from "path";
+
+import { mock } from "jest-mock-extended";
+
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+import { AbstractStorageService } from "@bitwarden/common/platform/abstractions/storage.service";
+import { BiometricStateService } from "@bitwarden/key-management";
+
+import { SafeShell } from "../platform/main/safe-shell.main";
+import { DesktopSettingsService } from "../platform/services/desktop-settings.service";
+
+// window.main.ts registers a privileged scheme at module load time, which
+// requires the electron runtime. Mock the surface the module touches on
+// import so it can be loaded in Jest.
+jest.mock("electron", () => ({
+  app: {},
+  BrowserWindow: jest.fn(),
+  ipcMain: { on: jest.fn() },
+  nativeTheme: {},
+  screen: {},
+  session: {},
+  protocol: { registerSchemesAsPrivileged: jest.fn() },
+  net: {},
+}));
+
+// window.main.ts imports processisolations, which loads a native .node
+// module at import time.
+jest.mock("@bitwarden/desktop-napi", () => ({
+  processisolations: {
+    isolateProcess: jest.fn(),
+    isCoreDumpingDisabled: jest.fn(),
+    disableCoredumps: jest.fn(),
+  },
+}));
+
+import { WindowMain } from "./window.main";
+
+describe("WindowMain", () => {
+  describe("isLocalBundleUrl", () => {
+    let sut: WindowMain;
+    // Access the private method under test without widening its visibility
+    // in production code.
+    let isLocalBundleUrl: (url: string) => boolean;
+
+    // The `file:` branch accepts only the app's own bundle, derived from
+    // __dirname the same way the production code does. __dirname here is
+    // this spec's directory, which is also the directory the code under test
+    // resolves against, so this is the real bundle URL for the running test.
+    const bundleUrl = pathToFileURL(path.join(__dirname, "/index.html")).toString();
+
+    beforeEach(() => {
+      sut = new WindowMain(
+        mock<BiometricStateService>(),
+        mock<LogService>(),
+        mock<AbstractStorageService>(),
+        mock<DesktopSettingsService>(),
+        mock<SafeShell>(),
+        null,
+        () => {},
+        null,
+      );
+
+      isLocalBundleUrl = (url: string) => (sut as any).isLocalBundleUrl(url);
+    });
+
+    it("returns true for the app's own file:// bundle URL", () => {
+      expect(isLocalBundleUrl(bundleUrl)).toBe(true);
+    });
+
+    it("returns true for the app's own bundle URL with a hash", () => {
+      expect(isLocalBundleUrl(`${bundleUrl}#/passkeys`)).toBe(true);
+    });
+
+    it("returns true for the app's own bundle URL with a query", () => {
+      expect(isLocalBundleUrl(`${bundleUrl}?redirectUrl=/passkeys`)).toBe(true);
+    });
+
+    it("returns false for a file:// URL with a foreign host", () => {
+      expect(isLocalBundleUrl("file://attacker.com/index.html")).toBe(false);
+    });
+
+    it("returns false for a file:// URL in a foreign directory", () => {
+      expect(isLocalBundleUrl("file:///tmp/evil/index.html")).toBe(false);
+    });
+
+    it("returns false for a file:// URL that traverses outside the bundle dir", () => {
+      // The `../` segments normalize (via the URL parser) to
+      // /tmp/evil/index.html, outside the bundle.
+      expect(isLocalBundleUrl(`${bundleUrl}/../../../tmp/evil/index.html`)).toBe(false);
+    });
+
+    it("returns true for a bw-desktop-file://bundle/index.html URL", () => {
+      expect(isLocalBundleUrl("bw-desktop-file://bundle/index.html")).toBe(true);
+    });
+
+    it("returns false for an external https URL", () => {
+      expect(isLocalBundleUrl("https://evil.com")).toBe(false);
+    });
+
+    it("returns false for a bw-desktop-file URL with the wrong host", () => {
+      expect(isLocalBundleUrl("bw-desktop-file://evil/index.html")).toBe(false);
+    });
+
+    it("returns false for an unparseable string without throwing", () => {
+      expect(isLocalBundleUrl("not a url")).toBe(false);
+    });
+  });
+});

--- a/apps/desktop/src/main/window.main.ts
+++ b/apps/desktop/src/main/window.main.ts
@@ -300,6 +300,35 @@ export class WindowMain {
     });
   }
 
+  /**
+   * Whether the URL is our own renderer bundle. Accepts both schemes {@link getWindowUrl} can
+   * emit (`file:` and `bw-desktop-file:`) so navigation guards need not know the active build mode.
+   */
+  private isLocalBundleUrl(url: string): boolean {
+    let parsedUrl: URL;
+    try {
+      parsedUrl = new URL(url);
+    } catch {
+      return false;
+    }
+
+    if (parsedUrl.protocol === "file:") {
+      // TODO(PM-33211): remove this branch once the custom-scheme cutover lands. An app no longer
+      // served over file: would keep only a permissive file: attack surface here.
+      //
+      // Check the full path, not the filename: file://attacker.com/index.html would pass a suffix test.
+      // (Hash/query live outside pathname, so index.html#/passkeys still matches.)
+      const bundlePathname = pathToFileURL(path.join(__dirname, "/index.html")).pathname;
+      return parsedUrl.host === "" && parsedUrl.pathname === bundlePathname;
+    }
+
+    if (parsedUrl.protocol === `${customFileScheme}:`) {
+      return parsedUrl.hostname === customFileHost;
+    }
+
+    return false;
+  }
+
   // TODO: REMOVE ONCE WE CAN STOP USING FAKE POP UP BTN FROM TRAY
   // Only used for development
   async loadUrl(targetPath: string, modal: boolean = false) {
@@ -487,6 +516,24 @@ export class WindowMain {
       void this.shell.openExternal(url, UrlType.WebUrl);
 
       return { action: "deny" };
+    });
+
+    // The main window must only ever show the local bundle. Cancelling a
+    // foreign navigation stops the preload re-running and re-exposing
+    // main functions, like window.ipc, on the attacker's page.
+    this.win.webContents.on("will-navigate", (event, url) => {
+      if (!this.isLocalBundleUrl(url)) {
+        event.preventDefault();
+        void this.shell.openExternal(url, UrlType.WebUrl);
+      }
+    });
+
+    // Same purpose as above, but for server-issued redirects
+    this.win.webContents.on("will-redirect", (event, url) => {
+      if (!this.isLocalBundleUrl(url)) {
+        event.preventDefault();
+        void this.shell.openExternal(url, UrlType.WebUrl);
+      }
     });
 
     firstValueFrom(this.desktopSettingsService.preventScreenshots$)


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-38724

## 📔 Objective

Restrict navigation in the desktop app's browser process to only the application's rendered paths. All attempts to navigate the browser to an unknown origin should redirect to the browser instead. This keeps unexpected web content from being able to do things like interact with desktop's ipc.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
