### PR TITLE
[CL-808] Support forced colors mode for form controls

### DIFF
--- a/libs/components/src/checkbox/checkbox.component.ts
+++ b/libs/components/src/checkbox/checkbox.component.ts
@@ -54,7 +54,11 @@ export class CheckboxComponent implements BitFormControlAbstraction {
 
   protected readonly inputClasses = [
     "tw-appearance-none",
-    "tw-outline-none",
+    /**
+     * tailwind's outline-none does not fully remove it because it supports forced colors mode, so
+     * we need to do in manually
+     */
+    "focus-visible:[outline:none]",
     "tw-box-border",
     "tw-relative",
     "tw-transition",
@@ -98,6 +102,8 @@ export class CheckboxComponent implements BitFormControlAbstraction {
     "[&:not(bit-form-control_*,bit-form-control-card_*)]:focus-visible:before:tw-ring-2",
     "[&:not(bit-form-control_*,bit-form-control-card_*)]:focus-visible:before:tw-ring-offset-2",
     "[&:not(bit-form-control_*,bit-form-control-card_*)]:focus-visible:before:tw-ring-border-focus",
+    // use outline instead of unsupported ring for forced colors mode
+    "[&:not(bit-form-control_*,bit-form-control-card_*)]:focus-visible:forced-colors:tw-outline-none",
 
     "disabled:hover:tw-bg-transparent",
     "disabled:before:tw-cursor-default",
@@ -113,6 +119,8 @@ export class CheckboxComponent implements BitFormControlAbstraction {
     "[&>label:hover]:checked:before:tw-bg-bg-brand",
     "[&>label:hover]:checked:before:tw-border-border-brand",
     "checked:after:tw-bg-fg-contrast",
+    // forced-colors strips the masked background; use CanvasText so the svg stays visible
+    "forced-colors:checked:after:tw-bg-[CanvasText]",
     "checked:after:tw-mask-position-[center]",
     "checked:after:tw-mask-repeat-[no-repeat]",
 
@@ -131,6 +139,8 @@ export class CheckboxComponent implements BitFormControlAbstraction {
     "[&>label:hover]:indeterminate:before:tw-bg-bg-brand",
     "[&>label:hover]:indeterminate:before:tw-border-border-brand",
     "indeterminate:after:tw-bg-fg-contrast",
+    // forced-colors strips the masked background; use CanvasText so the svg stays visible
+    "forced-colors:indeterminate:after:tw-bg-[CanvasText]",
     "indeterminate:after:tw-mask-position-[center]",
     "indeterminate:after:tw-mask-repeat-[no-repeat]",
     "indeterminate:after:tw-mask-image-[var(--indeterminate-mask-image)]",

--- a/libs/components/src/checkbox/checkbox.component.ts
+++ b/libs/components/src/checkbox/checkbox.component.ts
@@ -56,7 +56,7 @@ export class CheckboxComponent implements BitFormControlAbstraction {
     "tw-appearance-none",
     /**
      * tailwind's outline-none does not fully remove it because it supports forced colors mode, so
-     * we need to do in manually
+     * we need to do it manually
      */
     "focus-visible:[outline:none]",
     "tw-box-border",

--- a/libs/components/src/form-control/form-control-card.component.html
+++ b/libs/components/src/form-control/form-control-card.component.html
@@ -1,7 +1,8 @@
 @let control = base.formControl();
 <div class="tw-flex tw-flex-col tw-gap-2">
+  <!-- tw-outline-none supports forced colors mode; ring utility does not -->
   <div
-    class="tw-flex tw-items-center tw-relative tw-isolate tw-p-4 tw-border tw-border-border-base tw-rounded-xl tw-justify-between tw-gap-4 has-[input:focus-visible]:tw-ring-2 has-[input:focus-visible]:tw-ring-border-focus has-[input:focus-visible]:tw-border-transparent tw-transition-colors"
+    class="tw-flex tw-items-center tw-relative tw-isolate tw-p-4 tw-border tw-border-border-base tw-rounded-xl tw-justify-between tw-gap-4 has-[input:focus-visible]:tw-ring-2 has-[input:focus-visible]:tw-ring-border-focus has-[input:focus-visible]:tw-outline-none has-[input:focus-visible]:tw-border-transparent tw-transition-colors"
     [class]="
       control.disabled
         ? ''

--- a/libs/components/src/form-control/form-control.component.html
+++ b/libs/components/src/form-control/form-control.component.html
@@ -1,6 +1,7 @@
 @let control = base.formControl();
+<!-- tw-outline-none supports forced colors mode; ring utility does not -->
 <label
-  class="tw-transition tw-items-start tw-gap-2 tw-select-none tw-mb-0 tw-inline-flex tw-rounded has-[:focus-visible]:tw-ring has-[:focus-visible]:tw-ring-border-focus"
+  class="tw-transition tw-items-start tw-gap-2 tw-select-none tw-mb-0 tw-inline-flex tw-rounded has-[:focus-visible]:tw-ring has-[:focus-visible]:tw-ring-border-focus has-[:focus-visible]:tw-outline-none"
   [class.tw-cursor-auto]="control.disabled"
   [class.tw-cursor-pointer]="!control.disabled"
 >

--- a/libs/components/src/radio-button/radio-input.component.ts
+++ b/libs/components/src/radio-button/radio-input.component.ts
@@ -57,7 +57,11 @@ export class RadioInputComponent implements BitFormControlAbstraction {
   @HostBinding("class")
   protected inputClasses = [
     "tw-appearance-none",
-    "tw-outline-none",
+    /**
+     * tailwind's outline-none does not fully remove it because it supports forced colors mode, so
+     * we need to do in manually
+     */
+    "focus-visible:[outline:none]",
     "tw-relative",
     "tw-transition",
     "tw-cursor-pointer",
@@ -81,6 +85,8 @@ export class RadioInputComponent implements BitFormControlAbstraction {
     "[&:not(bit-form-control_*,bit-form-control-card_*)]:focus-visible:before:tw-ring-2",
     "[&:not(bit-form-control_*,bit-form-control-card_*)]:focus-visible:before:tw-ring-offset-2",
     "[&:not(bit-form-control_*,bit-form-control-card_*)]:focus-visible:before:tw-ring-border-focus",
+    // use outline instead of unsupported ring for forced colors mode
+    "[&:not(bit-form-control_*,bit-form-control-card_*)]:focus-visible:forced-colors:tw-outline-none",
 
     "tw-transition-colors",
     "before:tw-content-['']",
@@ -113,6 +119,8 @@ export class RadioInputComponent implements BitFormControlAbstraction {
     "checked:focus-visible:tw-bg-transparent",
 
     "checked:after:tw-bg-bg-brand",
+    // forced-colors strips the background; use CanvasText so the svg stays visible
+    "forced-colors:checked:after:tw-bg-[CanvasText]",
 
     "checked:before:tw-border-2",
     "checked:before:tw-border-border-brand",

--- a/libs/components/src/radio-button/radio-input.component.ts
+++ b/libs/components/src/radio-button/radio-input.component.ts
@@ -59,7 +59,7 @@ export class RadioInputComponent implements BitFormControlAbstraction {
     "tw-appearance-none",
     /**
      * tailwind's outline-none does not fully remove it because it supports forced colors mode, so
-     * we need to do in manually
+     * we need to do it manually
      */
     "focus-visible:[outline:none]",
     "tw-relative",

--- a/libs/components/src/switch/switch.component.ts
+++ b/libs/components/src/switch/switch.component.ts
@@ -71,6 +71,8 @@ export class SwitchComponent implements ControlValueAccessor, BitFormControlAbst
 
   protected readonly trackClasses = computed(() =>
     [
+      // outline supports forced-colors mode
+      "tw-outline-none",
       "tw-flex",
       "tw-relative",
       "tw-shrink-0",
@@ -103,6 +105,8 @@ export class SwitchComponent implements ControlValueAccessor, BitFormControlAbst
 
   protected readonly thumbClasses = computed(() =>
     [
+      // outline supports forced-colors mode
+      "tw-outline-none",
       "tw-flex",
       "tw-items-center",
       "tw-justify-center",


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[CL-808](https://bitwarden.atlassian.net/browse/CL-808)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Add support for forced colors mode for the form control elements.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

**Before (switch)**

<img width="465" height="350" alt="Screenshot 2026-07-17 at 4 14 00 PM" src="https://github.com/user-attachments/assets/bc8f942d-7b44-4d24-aeaa-db5c2d6b8d3c" />


**After (switch)**

<img width="600" height="371" alt="Screenshot 2026-07-17 at 4 11 56 PM" src="https://github.com/user-attachments/assets/57ce6e7f-56d8-4e41-b56a-c379276ceae9" />



**Before (checkbox)**

https://github.com/user-attachments/assets/f6a02a89-4b76-4c03-9d27-8104a495a871


**After (checkbox)**

https://github.com/user-attachments/assets/2a10e199-f35b-427e-b897-896deb0ff225




**Before (radio)**

https://github.com/user-attachments/assets/a20d696b-5749-418d-981c-0218ac007a7a


**After (radio)**

https://github.com/user-attachments/assets/c96fae91-67a3-4008-b403-56422194021e



[CL-808]: https://bitwarden.atlassian.net/browse/CL-808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ