### PR TITLE
[PM-40127] Item history redesign using bit-card-segmented

### DIFF
--- a/libs/components/src/card/card-content.component.ts
+++ b/libs/components/src/card/card-content.component.ts
@@ -5,5 +5,8 @@ import { Component } from "@angular/core";
 @Component({
   selector: "bit-card-content",
   template: `<div class="tw-p-4 [@media(min-width:650px)]:tw-p-6"><ng-content></ng-content></div>`,
+  host: {
+    class: "tw-border-x-0",
+  },
 })
 export class CardContentComponent {}

--- a/libs/components/src/section/section-header.component.ts
+++ b/libs/components/src/section/section-header.component.ts
@@ -10,8 +10,8 @@ import { TypographyModule } from "../typography";
   imports: [TypographyModule],
   host: {
     class:
-      // apply bottom and x padding when a `bit-card` or `bit-item` is the immediate sibling, or nested in the immediate sibling
-      "tw-block has-[+_*_bit-card]:tw-pb-1 has-[+_bit-card]:tw-pb-1 has-[+_*_bit-item]:tw-pb-1 has-[+_bit-item]:tw-pb-1 has-[+_*_bit-card]:tw-px-1 has-[+_bit-card]:tw-px-1 has-[+_*_bit-item]:tw-px-1 has-[+_bit-item]:tw-px-1",
+      // apply bottom and x padding when a `bit-card`, `bit-card-segmented`, or `bit-item` is the immediate sibling, or nested in the immediate sibling
+      "tw-block has-[+_*_bit-card]:tw-pb-1 has-[+_bit-card]:tw-pb-1 has-[+_*_bit-card-segmented]:tw-pb-1 has-[+_bit-card-segmented]:tw-pb-1 has-[+_*_bit-item]:tw-pb-1 has-[+_bit-item]:tw-pb-1 has-[+_*_bit-card]:tw-px-1 has-[+_bit-card]:tw-px-1 has-[+_*_bit-card-segmented]:tw-px-1 has-[+_bit-card-segmented]:tw-px-1 has-[+_*_bit-item]:tw-px-1 has-[+_bit-item]:tw-px-1",
   },
 })
 export class SectionHeaderComponent {}

--- a/libs/vault/src/cipher-view/item-history/item-history-v2.component.html
+++ b/libs/vault/src/cipher-view/item-history/item-history-v2.component.html
@@ -2,34 +2,61 @@
   <bit-section-header>
     <h2 bitTypography="h6">{{ "itemHistory" | i18n }}</h2>
   </bit-section-header>
-  <bit-card>
-    <p class="tw-mb-1 tw-text-xs tw-text-muted tw-select-all">
-      <span class="tw-font-medium">{{ "lastEdited" | i18n }}:</span>
-      {{ cipher.revisionDate | date: "medium" }}
-    </p>
-    <p
-      class="tw-text-xs tw-text-muted tw-select-all"
-      [ngClass]="{
-        'tw-mb-1 ': cipher.hasPasswordHistory,
-        'tw-mb-0': !cipher.hasPasswordHistory,
-      }"
-    >
-      <span class="tw-font-medium">{{ "dateCreated" | i18n }}:</span>
-      {{ cipher.creationDate | date: "medium" }}
-    </p>
-    @if (cipher.passwordRevisionDisplayDate) {
+  @if (vfo1Foundation()) {
+    <bit-card-segmented>
+      @for (row of historyRows; track $index) {
+        <bit-card-content>
+          <div class="tw-flex tw-gap-2 tw-text-fg-body">
+            <span class="tw-flex-1 tw-font-semibold tw-text-sm">{{ row.labelKey | i18n }}</span>
+            <span class="tw-flex-1 tw-text-sm tw-text-right">{{ row.date | date: "medium" }}</span>
+          </div>
+        </bit-card-content>
+      }
+      @if (cipher.hasPasswordHistory) {
+        <bit-card-content>
+          <button
+            bitButton
+            buttonType="secondary"
+            block
+            startIcon="bwi-clock"
+            type="button"
+            (click)="viewPasswordHistory()"
+          >
+            {{ "passwordHistory" | i18n }}
+          </button>
+        </bit-card-content>
+      }
+    </bit-card-segmented>
+  } @else {
+    <bit-card>
+      <p class="tw-mb-1 tw-text-xs tw-text-muted tw-select-all">
+        <span class="tw-font-medium">{{ "lastEdited" | i18n }}:</span>
+        {{ cipher.revisionDate | date: "medium" }}
+      </p>
       <p
         class="tw-text-xs tw-text-muted tw-select-all"
-        [ngClass]="{ 'tw-mb-3': cipher.hasPasswordHistory }"
+        [ngClass]="{
+          'tw-mb-1 ': cipher.hasPasswordHistory,
+          'tw-mb-0': !cipher.hasPasswordHistory,
+        }"
       >
-        <span class="tw-font-medium">{{ "datePasswordUpdated" | i18n }}:</span>
-        {{ cipher.passwordRevisionDisplayDate | date: "medium" }}
+        <span class="tw-font-medium">{{ "dateCreated" | i18n }}:</span>
+        {{ cipher.creationDate | date: "medium" }}
       </p>
-    }
-    @if (cipher.hasPasswordHistory) {
-      <button (click)="viewPasswordHistory()" bitTypography="body2" bitLink type="button">
-        {{ "passwordHistory" | i18n }}
-      </button>
-    }
-  </bit-card>
+      @if (cipher.passwordRevisionDisplayDate) {
+        <p
+          class="tw-text-xs tw-text-muted tw-select-all"
+          [ngClass]="{ 'tw-mb-3': cipher.hasPasswordHistory }"
+        >
+          <span class="tw-font-medium">{{ "datePasswordUpdated" | i18n }}:</span>
+          {{ cipher.passwordRevisionDisplayDate | date: "medium" }}
+        </p>
+      }
+      @if (cipher.hasPasswordHistory) {
+        <button (click)="viewPasswordHistory()" bitTypography="body2" bitLink type="button">
+          {{ "passwordHistory" | i18n }}
+        </button>
+      }
+    </bit-card>
+  }
 </bit-section>

--- a/libs/vault/src/cipher-view/item-history/item-history-v2.component.ts
+++ b/libs/vault/src/cipher-view/item-history/item-history-v2.component.ts
@@ -2,17 +2,23 @@
 // @ts-strict-ignore
 import { CommonModule } from "@angular/common";
 import { Component, Input } from "@angular/core";
+import { toSignal } from "@angular/core/rxjs-interop";
 import { RouterModule } from "@angular/router";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
+import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { ViewPasswordHistoryService } from "@bitwarden/common/vault/abstractions/view-password-history.service";
 import { CipherType } from "@bitwarden/common/vault/enums";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import {
+  ButtonModule,
   CardComponent,
+  CardContentComponent,
   LinkModule,
   SectionComponent,
   SectionHeaderComponent,
+  SegmentedCardComponent,
   TypographyModule,
 } from "@bitwarden/components";
 
@@ -26,9 +32,12 @@ import {
     JslibModule,
     RouterModule,
     CardComponent,
+    CardContentComponent,
     SectionComponent,
     SectionHeaderComponent,
+    SegmentedCardComponent,
     TypographyModule,
+    ButtonModule,
     LinkModule,
   ],
 })
@@ -37,10 +46,29 @@ export class ItemHistoryV2Component {
   // eslint-disable-next-line @angular-eslint/prefer-signals
   @Input() cipher: CipherView;
 
-  constructor(private viewPasswordHistoryService: ViewPasswordHistoryService) {}
+  protected readonly vfo1Foundation = toSignal(
+    this.configService.getFeatureFlag$(FeatureFlag.VFO1Foundation),
+    { initialValue: false },
+  );
+
+  constructor(
+    private viewPasswordHistoryService: ViewPasswordHistoryService,
+    private configService: ConfigService,
+  ) {}
 
   get isLogin() {
     return this.cipher.type === CipherType.Login;
+  }
+
+  protected get historyRows(): { labelKey: string; date: Date | null | undefined }[] {
+    const rows: { labelKey: string; date: Date | null | undefined }[] = [
+      { labelKey: "lastEdited", date: this.cipher.revisionDate },
+      { labelKey: "dateCreated", date: this.cipher.creationDate },
+    ];
+    if (this.cipher.passwordRevisionDisplayDate) {
+      rows.push({ labelKey: "datePasswordUpdated", date: this.cipher.passwordRevisionDisplayDate });
+    }
+    return rows;
   }
 
   /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -2115,6 +2115,24 @@
         }
       }
     },
+    "node_modules/@angular-eslint/builder/node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@angular-eslint/builder/node_modules/picomatch": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
@@ -2126,6 +2144,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@angular-eslint/builder/node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@angular-eslint/builder/node_modules/rxjs": {
@@ -9146,6 +9180,21 @@
         "@msgpack/msgpack": "^2.7.0"
       }
     },
+    "node_modules/@microsoft/signalr/node_modules/utf-8-validate": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
     "node_modules/@microsoft/signalr/node_modules/ws": {
       "version": "7.5.10",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
@@ -12333,6 +12382,7 @@
       "version": "2.5.6",
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
       "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -12372,6 +12422,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12392,6 +12443,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12412,6 +12464,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12432,6 +12485,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12452,6 +12506,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12472,6 +12527,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12492,6 +12548,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12512,6 +12569,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12532,6 +12590,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12552,6 +12611,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12572,6 +12632,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12592,6 +12653,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12612,6 +12674,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12629,6 +12692,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -17278,6 +17342,24 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/angular-eslint/node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/angular-eslint/node_modules/cli-cursor": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
@@ -17405,6 +17487,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/angular-eslint/node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/angular-eslint/node_modules/restore-cursor": {
@@ -21649,7 +21747,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -27050,7 +27148,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -27115,7 +27213,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -37737,6 +37835,7 @@
         "!riscv64",
         "!x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -37750,6 +37849,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -37766,6 +37866,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -37782,6 +37883,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -37798,6 +37900,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -37814,6 +37917,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -37830,6 +37934,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -37846,6 +37951,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -37862,6 +37968,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -37878,6 +37985,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -37894,6 +38002,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -37910,6 +38019,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -37926,6 +38036,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -37942,6 +38053,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -37958,6 +38070,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -37971,6 +38084,7 @@
       "version": "1.99.0",
       "resolved": "https://registry.npmjs.org/sass-embedded-unknown-all/-/sass-embedded-unknown-all-1.99.0.tgz",
       "integrity": "sha512-P7MxiUtL/XzGo3PX0CaB8lNNEFLQWKikPA8pbKytx9ZCLZSDkt2NJcdAbblB/sqMs4AV3EK2NadV8rI/diq3xg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -37990,6 +38104,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -38006,6 +38121,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [


### PR DESCRIPTION
## 🎟️ Tracking

[PM-40127](https://bitwarden.atlassian.net/browse/PM-40127)

## 📔 Objective

Redesigns the item history section of the cipher view using [`bit-card-segmented`](https://github.com/bitwarden/clients/pull/21776), gated behind the `VFO1Foundation` flag. Each history row and the password history button become individual card segments. Also includes two component library fixes discovered during implementation:

- **`bit-card-content`** — adds `tw-border-x-0` to prevent a left border on desktop, where Tailwind preflight is disabled and `tw-divide-solid` would otherwise reveal the CSS initial `border-left-width: medium`.
- **`bit-section-header`** — extends the `has-[+]` padding selectors to match `bit-card-segmented` siblings.

## 📸 Screenshots

| Web | Desktop | Extension |
|-----|---------|-----------|
|     |         |           |

[PM-40127]: https://bitwarden.atlassian.net/browse/PM-40127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ