### PR TITLE
fix(key-connector): fix sdk key-connector login not working

### DIFF
--- a/libs/common/src/auth/models/response/identity-token.response.ts
+++ b/libs/common/src/auth/models/response/identity-token.response.ts
@@ -118,7 +118,10 @@ export class IdentityTokenResponse extends BaseResponse {
     //
     // Ideally, the server would track key connector enrollment, and deliver a status indicating whether the user
     // is enrolled fully, or needs migration, but this is currently not present.
-    return this.userDecryptionOptions?.keyConnectorOption != null && this.userDecryptionOptions.hasMasterPassword == false;
+    return (
+      this.userDecryptionOptions?.keyConnectorOption != null &&
+      this.userDecryptionOptions.hasMasterPassword == false
+    );
   }
 
   intoKeyConnectorUnlockData(): KeyConnectorUnlockData {

--- a/libs/common/src/auth/models/response/identity-token.response.ts
+++ b/libs/common/src/auth/models/response/identity-token.response.ts
@@ -112,7 +112,13 @@ export class IdentityTokenResponse extends BaseResponse {
   }
 
   canUnlockWithKeyConnector(): boolean {
-    return this.userDecryptionOptions?.keyConnectorOption != null;
+    // A key connector option may be present if the user has not yet enrolled into key-connector, but is supposed
+    // to enroll, just after key-connector has been enabled for the organization. Thus, we need to check that the
+    // master password is also not present. Upon migration, the master-password will be removed from the user.
+    //
+    // Ideally, the server would track key connector enrollment, and deliver a status indicating whether the user
+    // is enrolled fully, or needs migration, but this is currently not present.
+    return this.userDecryptionOptions?.keyConnectorOption != null && this.userDecryptionOptions.hasMasterPassword == false;
   }
 
   intoKeyConnectorUnlockData(): KeyConnectorUnlockData {


### PR DESCRIPTION
https://bitwarden.atlassian.net/browse/PM-30584

The sdk login path incorrectly detected users that have not yet migrated with key-connector, but should migrate, as 'canUnlockWithkeyConnector()', which lead to a failed unlock attempt, when unlocking with the SDK key-connector feature-flag enabled.