### PR TITLE
[PM-40543] Default new SCIM connections to staged

### DIFF
--- a/bitwarden_license/bit-web/src/app/admin-console/organizations/manage/scim-v2.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/admin-console/organizations/manage/scim-v2.component.spec.ts
@@ -145,13 +145,38 @@ describe("ScimV2Component", () => {
       expect(ta(component).inviteUsersAfterProvisioning.value).toBe(false);
     }));
 
-    it("defaults inviteUsersAfterProvisioning to true when the connection config omits it", fakeAsync(() => {
+    it("defaults inviteUsersAfterProvisioning to true when an existing connection omits it", fakeAsync(() => {
       initComponent(mockConnection(true));
 
       void component.load();
       tick();
 
       expect(ta(component).inviteUsersAfterProvisioning.value).toBe(true);
+    }));
+
+    it("defaults inviteUsersAfterProvisioning to true for a new connection when the staged status flag is off", fakeAsync(() => {
+      initComponent({
+        id: null,
+        config: null,
+      } as unknown as OrganizationConnectionResponse<ScimConfigApi>);
+
+      void component.load();
+      tick();
+
+      expect(ta(component).inviteUsersAfterProvisioning.value).toBe(true);
+    }));
+
+    it("defaults inviteUsersAfterProvisioning to false for a new connection when the staged status flag is on", fakeAsync(() => {
+      configService.getFeatureFlag$.mockReturnValue(of(true));
+      initComponent({
+        id: null,
+        config: null,
+      } as unknown as OrganizationConnectionResponse<ScimConfigApi>);
+
+      void component.load();
+      tick();
+
+      expect(ta(component).inviteUsersAfterProvisioning.value).toBe(false);
     }));
 
     it("does not open dialog on load", fakeAsync(() => {
@@ -384,6 +409,25 @@ describe("ScimV2Component", () => {
         variant: "success",
         message: "scimSettingsSaved",
       });
+    }));
+
+    it("submits inviteUsersAfterProvisioning false when creating a new connection", fakeAsync(() => {
+      ta(component).existingConnectionId.set(undefined);
+      ta(component).inviteUsersAfterProvisioning.setValue(false);
+      ta(component).enabled.setValue(true);
+      apiService.createOrganizationConnection.mockResolvedValue(
+        mockConnection(true, "connection-id", false),
+      );
+
+      void ta(component).submit();
+      tick();
+
+      expect(apiService.createOrganizationConnection).toHaveBeenCalledWith(
+        expect.objectContaining({
+          config: expect.objectContaining({ inviteUsersAfterProvisioning: false }),
+        }),
+        ScimConfigApi,
+      );
     }));
 
     it("submits inviteUsersAfterProvisioning true by default", fakeAsync(() => {

--- a/bitwarden_license/bit-web/src/app/admin-console/organizations/manage/scim-v2.component.ts
+++ b/bitwarden_license/bit-web/src/app/admin-console/organizations/manage/scim-v2.component.ts
@@ -270,8 +270,13 @@ export class ScimV2Component {
     this.existingConnectionId.set(connection?.id);
     this.cachedApiKey.set(undefined);
     this.showScimKey.set(false);
+    // New connections (no saved config yet) default to staged (toggle off) only when the staged
+    // status feature is enabled; otherwise they keep the legacy "invite" default. Existing
+    // connections keep their stored value; a missing flag on an existing connection is treated as
+    // invite (on) for backwards compatibility with connections created before this setting existed.
+    const config = connection?.config;
     this.inviteUsersAfterProvisioning.setValue(
-      connection?.config?.inviteUsersAfterProvisioning ?? true,
+      config == null ? !this.stagedStatusEnabled() : (config.inviteUsersAfterProvisioning ?? true),
     );
     if (connection !== null && connection.config?.enabled) {
       await this.scimBannerService.markBannerSeen(this.organizationId());


### PR DESCRIPTION
## 🎟️ Tracking

PM-40543

## 📔 Objective

Default new SCIM connections to staged provisioning when the Staged Status feature flag (`pm-34423-staged-status`) is enabled.

Previously the "invite users after provisioning" toggle defaulted to on (invite) for every connection. With the staged-status feature enabled, a newly created SCIM connection (one with no saved config yet) now defaults the toggle to off, so provisioned users are staged rather than invited.

The behavior is gated entirely on the client:

- **New connection + flag on** → staged (invite toggle off)
- **New connection + flag off** → legacy invite-on default (unchanged)
- **Existing connection** → keeps its stored value; a missing flag is treated as invite (on) for backwards compatibility with connections created before this setting existed

Orgs without the feature flag are unaffected — the client sends the same `inviteUsersAfterProvisioning: true` it did before, so there is no reliance on server-side gating and no behavior change for flag-off orgs.