### PR TITLE
[PM-40654] feat: gate org-creation default collection name behind VFO1 terminology

### DIFF
--- a/apps/web/src/app/billing/individual/upgrade/premium-org-upgrade-payment/services/premium-org-upgrade.service.spec.ts
+++ b/apps/web/src/app/billing/individual/upgrade/premium-org-upgrade-payment/services/premium-org-upgrade.service.spec.ts
@@ -7,8 +7,10 @@ import {
   BusinessSubscriptionPricingTierIds,
   PersonalSubscriptionPricingTierIds,
 } from "@bitwarden/common/billing/types/subscription-pricing-tier";
+import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { EncryptService } from "@bitwarden/common/key-management/crypto/abstractions/encrypt.service";
 import { EncString } from "@bitwarden/common/key-management/crypto/models/enc-string";
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.service.abstraction";
 import { KeyService } from "@bitwarden/key-management";
@@ -33,6 +35,7 @@ describe("PremiumOrgUpgradeService", () => {
   let keyService: jest.Mocked<KeyService>;
   let encryptService: jest.Mocked<EncryptService>;
   let i18nService: jest.Mocked<I18nService>;
+  let configService: jest.Mocked<ConfigService>;
 
   const mockAccount = { id: "user-id", email: "test@bitwarden.com" } as Account;
   const mockPlanDetails: PremiumOrgUpgradePlanDetails = {
@@ -90,6 +93,9 @@ describe("PremiumOrgUpgradeService", () => {
     i18nService = {
       t: jest.fn().mockReturnValue("Default Collection"),
     } as any;
+    configService = {
+      getFeatureFlag: jest.fn().mockResolvedValue(false),
+    } as any;
 
     TestBed.configureTestingModule({
       providers: [
@@ -102,6 +108,7 @@ describe("PremiumOrgUpgradeService", () => {
         { provide: KeyService, useValue: keyService },
         { provide: EncryptService, useValue: encryptService },
         { provide: I18nService, useValue: i18nService },
+        { provide: ConfigService, useValue: configService },
       ],
     });
 
@@ -135,6 +142,34 @@ describe("PremiumOrgUpgradeService", () => {
       );
       expect(syncService.fullSync).toHaveBeenCalledWith(true);
       expect(result).toBe("new-org-id");
+    });
+
+    it("names the default collection using the collection terminology when the VFO1 flag is off", async () => {
+      configService.getFeatureFlag.mockResolvedValue(false);
+
+      await service.upgradeToOrganization(
+        mockAccount,
+        "Test Organization",
+        mockPlanDetails.tier,
+        mockBillingAddress,
+      );
+
+      expect(configService.getFeatureFlag).toHaveBeenCalledWith(FeatureFlag.VFO1Foundation);
+      expect(i18nService.t).toHaveBeenCalledWith("defaultCollection");
+    });
+
+    it("names the default collection using the shared-folder terminology when the VFO1 flag is on", async () => {
+      configService.getFeatureFlag.mockResolvedValue(true);
+
+      await service.upgradeToOrganization(
+        mockAccount,
+        "Test Organization",
+        mockPlanDetails.tier,
+        mockBillingAddress,
+      );
+
+      expect(configService.getFeatureFlag).toHaveBeenCalledWith(FeatureFlag.VFO1Foundation);
+      expect(i18nService.t).toHaveBeenCalledWith("defaultSharedFolder");
     });
 
     it("should throw an error when payment method is an unverified bank account", async () => {

--- a/apps/web/src/app/billing/individual/upgrade/premium-org-upgrade-payment/services/premium-org-upgrade.service.ts
+++ b/apps/web/src/app/billing/individual/upgrade/premium-org-upgrade-payment/services/premium-org-upgrade.service.ts
@@ -11,8 +11,10 @@ import {
   PersonalSubscriptionPricingTierIds,
   SubscriptionCadenceIds,
 } from "@bitwarden/common/billing/types/subscription-pricing-tier";
+import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { EncryptService } from "@bitwarden/common/key-management/crypto/abstractions/encrypt.service";
 import { EncString } from "@bitwarden/common/key-management/crypto/models/enc-string";
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
 import { OrgKey } from "@bitwarden/common/types/key";
@@ -67,6 +69,7 @@ export class PremiumOrgUpgradeService {
     private i18nService: I18nService,
     private encryptService: EncryptService,
     private syncService: SyncService,
+    private configService: ConfigService,
   ) {}
 
   async previewProratedInvoice(
@@ -184,8 +187,9 @@ export class PremiumOrgUpgradeService {
   }> {
     const orgKey = await this.keyService.makeOrgKey<OrgKey>(activeUserId);
     const key = orgKey[0].encryptedString as string;
+    const vfo1Enabled = await this.configService.getFeatureFlag(FeatureFlag.VFO1Foundation);
     const collection = await this.encryptService.encryptString(
-      this.i18nService.t("defaultCollection"),
+      this.i18nService.t(vfo1Enabled ? "defaultSharedFolder" : "defaultCollection"),
       orgKey[1],
     );
     const collectionCt = collection.encryptedString as string;

--- a/apps/web/src/app/billing/shared/self-hosting-license-uploader/organization-self-hosting-license-uploader.component.ts
+++ b/apps/web/src/app/billing/shared/self-hosting-license-uploader/organization-self-hosting-license-uploader.component.ts
@@ -10,7 +10,9 @@ import { OrganizationKeysRequest } from "@bitwarden/common/admin-console/models/
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { TokenService } from "@bitwarden/common/auth/abstractions/token.service";
 import { getUserId } from "@bitwarden/common/auth/services/account.service";
+import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { EncryptService } from "@bitwarden/common/key-management/crypto/abstractions/encrypt.service";
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { SyncService } from "@bitwarden/common/platform/sync";
@@ -51,6 +53,7 @@ export class OrganizationSelfHostingLicenseUploaderComponent extends AbstractSel
     private readonly organizationApiService: OrganizationApiServiceAbstraction,
     private readonly syncService: SyncService,
     private readonly accountService: AccountService,
+    private readonly configService: ConfigService,
   ) {
     super(formBuilder, i18nService, platformUtilsService, toastService, tokenService);
   }
@@ -60,8 +63,9 @@ export class OrganizationSelfHostingLicenseUploaderComponent extends AbstractSel
     const activeUserId = await firstValueFrom(getUserId(this.accountService.activeAccount$));
     const orgKey = await this.keyService.makeOrgKey<OrgKey>(activeUserId);
     const key = orgKey[0].encryptedString;
+    const vfo1Enabled = await this.configService.getFeatureFlag(FeatureFlag.VFO1Foundation);
     const collection = await this.encryptService.encryptString(
-      this.i18nService.t("defaultCollection"),
+      this.i18nService.t(vfo1Enabled ? "defaultSharedFolder" : "defaultCollection"),
       orgKey[1],
     );
     const collectionCt = collection.encryptedString;

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -4555,6 +4555,9 @@
   "defaultCollection": {
     "message": "Default collection"
   },
+  "defaultSharedFolder": {
+    "message": "Default shared folder"
+  },
   "getHelp": {
     "message": "Get help"
   },

--- a/bitwarden_license/bit-web/src/app/admin-console/providers/services/web-provider.service.spec.ts
+++ b/bitwarden_license/bit-web/src/app/admin-console/providers/services/web-provider.service.spec.ts
@@ -5,8 +5,10 @@ import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import { ProviderApiServiceAbstraction } from "@bitwarden/common/admin-console/abstractions/provider/provider-api.service.abstraction";
 import { OrganizationKeysRequest } from "@bitwarden/common/admin-console/models/request/organization-keys.request";
 import { PlanType } from "@bitwarden/common/billing/enums";
+import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { EncryptService } from "@bitwarden/common/key-management/crypto/abstractions/encrypt.service";
 import { EncString } from "@bitwarden/common/key-management/crypto/models/enc-string";
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
 import { OrgKey, ProviderKey } from "@bitwarden/common/types/key";
@@ -25,6 +27,7 @@ describe("WebProviderService", () => {
   let i18nService: MockProxy<I18nService>;
   let encryptService: MockProxy<EncryptService>;
   let providerApiService: MockProxy<ProviderApiServiceAbstraction>;
+  let configService: MockProxy<ConfigService>;
 
   const activeUserId = newGuid() as UserId;
   const providerId = "provider-123";
@@ -41,6 +44,7 @@ describe("WebProviderService", () => {
     i18nService = mock();
     encryptService = mock();
     providerApiService = mock();
+    configService = mock();
 
     sut = new WebProviderService(
       keyService,
@@ -49,6 +53,7 @@ describe("WebProviderService", () => {
       i18nService,
       encryptService,
       providerApiService,
+      configService,
     );
   });
 
@@ -165,6 +170,38 @@ describe("WebProviderService", () => {
 
       expect(apiService.refreshIdentityToken).toHaveBeenCalled();
       expect(syncService.fullSync).toHaveBeenCalledWith(true);
+    });
+
+    it("names the default collection using the collection terminology when the VFO1 flag is off", async () => {
+      configService.getFeatureFlag.mockResolvedValue(false);
+
+      await sut.createClientOrganization(
+        providerId,
+        name,
+        ownerEmail,
+        planType,
+        seats,
+        activeUserId,
+      );
+
+      expect(configService.getFeatureFlag).toHaveBeenCalledWith(FeatureFlag.VFO1Foundation);
+      expect(i18nService.t).toHaveBeenCalledWith("defaultCollection");
+    });
+
+    it("names the default collection using the shared-folder terminology when the VFO1 flag is on", async () => {
+      configService.getFeatureFlag.mockResolvedValue(true);
+
+      await sut.createClientOrganization(
+        providerId,
+        name,
+        ownerEmail,
+        planType,
+        seats,
+        activeUserId,
+      );
+
+      expect(configService.getFeatureFlag).toHaveBeenCalledWith(FeatureFlag.VFO1Foundation);
+      expect(i18nService.t).toHaveBeenCalledWith("defaultSharedFolder");
     });
 
     it("throws an error if provider key is not found", async () => {

--- a/bitwarden_license/bit-web/src/app/admin-console/providers/services/web-provider.service.ts
+++ b/bitwarden_license/bit-web/src/app/admin-console/providers/services/web-provider.service.ts
@@ -9,7 +9,9 @@ import { CreateProviderOrganizationRequest } from "@bitwarden/common/admin-conso
 import { OrganizationKeysRequest } from "@bitwarden/common/admin-console/models/request/organization-keys.request";
 import { assertNonNullish } from "@bitwarden/common/auth/utils";
 import { PlanType } from "@bitwarden/common/billing/enums";
+import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { EncryptService } from "@bitwarden/common/key-management/crypto/abstractions/encrypt.service";
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { OrganizationId, ProviderId, UserId } from "@bitwarden/common/types/guid";
 import { OrgKey } from "@bitwarden/common/types/key";
@@ -25,6 +27,7 @@ export class WebProviderService {
     private i18nService: I18nService,
     private encryptService: EncryptService,
     private providerApiService: ProviderApiServiceAbstraction,
+    private configService: ConfigService,
   ) {}
 
   async addOrganizationToProvider(
@@ -64,8 +67,9 @@ export class WebProviderService {
 
     const [publicKey, encryptedPrivateKey] = await this.keyService.makeKeyPair(organizationKey);
 
+    const vfo1Enabled = await this.configService.getFeatureFlag(FeatureFlag.VFO1Foundation);
     const encryptedCollectionName = await this.encryptService.encryptString(
-      this.i18nService.t("defaultCollection"),
+      this.i18nService.t(vfo1Enabled ? "defaultSharedFolder" : "defaultCollection"),
       organizationKey,
     );
 

--- a/libs/angular/src/services/jslib-services.module.ts
+++ b/libs/angular/src/services/jslib-services.module.ts
@@ -1652,6 +1652,7 @@ const safeProviders: SafeProvider[] = [
       I18nServiceAbstraction,
       OrganizationApiServiceAbstraction,
       SyncService,
+      ConfigService,
     ],
   }),
   safeProvider({
@@ -1772,6 +1773,7 @@ const safeProviders: SafeProvider[] = [
       OrganizationUserApiService,
       I18nServiceAbstraction,
       GlobalStateProvider,
+      ConfigService,
     ],
   }),
   safeProvider({

--- a/libs/common/src/auth/organization-invite/services/implementations/default-organization-invite.service.spec.ts
+++ b/libs/common/src/auth/organization-invite/services/implementations/default-organization-invite.service.spec.ts
@@ -20,8 +20,10 @@ import { MasterPasswordPolicyOptions } from "../../../../admin-console/models/do
 import { Policy } from "../../../../admin-console/models/domain/policy";
 import { ResetPasswordPolicyOptions } from "../../../../admin-console/models/domain/reset-password-policy-options";
 import { OrganizationKeysResponse } from "../../../../admin-console/models/response/organization-keys.response";
+import { FeatureFlag } from "../../../../enums/feature-flag.enum";
 import { EncryptService } from "../../../../key-management/crypto/abstractions/encrypt.service";
 import { EncString } from "../../../../key-management/crypto/models/enc-string";
+import { ConfigService } from "../../../../platform/abstractions/config/config.service";
 import { I18nService } from "../../../../platform/abstractions/i18n.service";
 import { LogService } from "../../../../platform/abstractions/log.service";
 import { Utils } from "../../../../platform/misc/utils";
@@ -44,6 +46,7 @@ describe("DefaultOrganizationInviteService", () => {
   let organizationUserApiService: MockProxy<OrganizationUserApiService>;
   let i18nService: MockProxy<I18nService>;
   let globalStateProvider: FakeGlobalStateProvider;
+  let configService: MockProxy<ConfigService>;
 
   beforeEach(() => {
     apiService = mock();
@@ -57,6 +60,7 @@ describe("DefaultOrganizationInviteService", () => {
     organizationUserApiService = mock();
     i18nService = mock();
     globalStateProvider = new FakeGlobalStateProvider();
+    configService = mock();
 
     sut = new DefaultOrganizationInviteService(
       apiService,
@@ -70,6 +74,7 @@ describe("DefaultOrganizationInviteService", () => {
       organizationUserApiService,
       i18nService,
       globalStateProvider,
+      configService,
     );
   });
 
@@ -137,6 +142,42 @@ describe("DefaultOrganizationInviteService", () => {
       expect(authService.logOut).not.toHaveBeenCalled();
       const stored = await sut.getOrganizationInvite();
       expect(stored).toBeNull();
+    });
+
+    it("names the default collection using the collection terminology when the VFO1 flag is off", async () => {
+      keyService.makeOrgKey.mockResolvedValue([
+        { encryptedString: "string" } as EncString,
+        "orgPrivateKey" as unknown as OrgKey,
+      ]);
+      keyService.makeKeyPair.mockResolvedValue([
+        "orgPublicKey",
+        { encryptedString: "string" } as EncString,
+      ]);
+      encryptService.encryptString.mockResolvedValue({ encryptedString: "string" } as EncString);
+      configService.getFeatureFlag.mockResolvedValue(false);
+
+      await sut.validateAndAcceptInvite(createOrgInvite({ initOrganization: true }), activeUserId);
+
+      expect(configService.getFeatureFlag).toHaveBeenCalledWith(FeatureFlag.VFO1Foundation);
+      expect(i18nService.t).toHaveBeenCalledWith("defaultCollection");
+    });
+
+    it("names the default collection using the shared-folder terminology when the VFO1 flag is on", async () => {
+      keyService.makeOrgKey.mockResolvedValue([
+        { encryptedString: "string" } as EncString,
+        "orgPrivateKey" as unknown as OrgKey,
+      ]);
+      keyService.makeKeyPair.mockResolvedValue([
+        "orgPublicKey",
+        { encryptedString: "string" } as EncString,
+      ]);
+      encryptService.encryptString.mockResolvedValue({ encryptedString: "string" } as EncString);
+      configService.getFeatureFlag.mockResolvedValue(true);
+
+      await sut.validateAndAcceptInvite(createOrgInvite({ initOrganization: true }), activeUserId);
+
+      expect(configService.getFeatureFlag).toHaveBeenCalledWith(FeatureFlag.VFO1Foundation);
+      expect(i18nService.t).toHaveBeenCalledWith("defaultSharedFolder");
     });
 
     it("logs out the user and stores the invite when a master password policy check is required", async () => {

--- a/libs/common/src/auth/organization-invite/services/implementations/default-organization-invite.service.ts
+++ b/libs/common/src/auth/organization-invite/services/implementations/default-organization-invite.service.ts
@@ -20,7 +20,9 @@ import { PolicyType } from "../../../../admin-console/enums";
 import { MasterPasswordPolicyOptions } from "../../../../admin-console/models/domain/master-password-policy-options";
 import { Policy } from "../../../../admin-console/models/domain/policy";
 import { OrganizationKeysRequest } from "../../../../admin-console/models/request/organization-keys.request";
+import { FeatureFlag } from "../../../../enums/feature-flag.enum";
 import { EncryptService } from "../../../../key-management/crypto/abstractions/encrypt.service";
+import { ConfigService } from "../../../../platform/abstractions/config/config.service";
 import { I18nService } from "../../../../platform/abstractions/i18n.service";
 import { LogService } from "../../../../platform/abstractions/log.service";
 import { Utils } from "../../../../platform/misc/utils";
@@ -52,6 +54,7 @@ export class DefaultOrganizationInviteService implements OrganizationInviteServi
     private readonly organizationUserApiService: OrganizationUserApiService,
     private readonly i18nService: I18nService,
     private readonly globalStateProvider: GlobalStateProvider,
+    private readonly configService: ConfigService,
   ) {
     this.organizationInviteState = this.globalStateProvider.get(ORGANIZATION_INVITE);
   }
@@ -161,8 +164,9 @@ export class DefaultOrganizationInviteService implements OrganizationInviteServi
   ): Promise<OrganizationUserAcceptInitRequest> {
     const [encryptedOrgKey, orgKey] = await this.keyService.makeOrgKey<OrgKey>(userId);
     const [orgPublicKey, encryptedOrgPrivateKey] = await this.keyService.makeKeyPair(orgKey);
+    const vfo1Enabled = await this.configService.getFeatureFlag(FeatureFlag.VFO1Foundation);
     const collection = await this.encryptService.encryptString(
-      this.i18nService.t("defaultCollection"),
+      this.i18nService.t(vfo1Enabled ? "defaultSharedFolder" : "defaultCollection"),
       orgKey,
     );
 

--- a/libs/common/src/billing/services/organization-billing.service.spec.ts
+++ b/libs/common/src/billing/services/organization-billing.service.spec.ts
@@ -10,8 +10,10 @@ import { ApiService } from "../../abstractions/api.service";
 import { OrganizationApiServiceAbstraction as OrganizationApiService } from "../../admin-console/abstractions/organization/organization-api.service.abstraction";
 import { OrganizationKeysRequest } from "../../admin-console/models/request/organization-keys.request";
 import { OrganizationResponse } from "../../admin-console/models/response/organization.response";
+import { FeatureFlag } from "../../enums/feature-flag.enum";
 import { EncryptService } from "../../key-management/crypto/abstractions/encrypt.service";
 import { EncString } from "../../key-management/crypto/models/enc-string";
+import { ConfigService } from "../../platform/abstractions/config/config.service";
 import { I18nService } from "../../platform/abstractions/i18n.service";
 import { SymmetricCryptoKey } from "../../platform/models/domain/symmetric-crypto-key";
 import { SyncService } from "../../platform/sync";
@@ -33,6 +35,7 @@ describe("OrganizationBillingService", () => {
   let i18nService: jest.Mocked<I18nService>;
   let organizationApiService: jest.Mocked<OrganizationApiService>;
   let syncService: jest.Mocked<SyncService>;
+  let configService: jest.Mocked<ConfigService>;
 
   let sut: OrganizationBillingService;
 
@@ -46,6 +49,7 @@ describe("OrganizationBillingService", () => {
     i18nService = mock<I18nService>();
     organizationApiService = mock<OrganizationApiService>();
     syncService = mock<SyncService>();
+    configService = mock<ConfigService>();
 
     sut = new OrganizationBillingService(
       apiService,
@@ -55,6 +59,7 @@ describe("OrganizationBillingService", () => {
       i18nService,
       organizationApiService,
       syncService,
+      configService,
     );
   });
 
@@ -398,6 +403,38 @@ describe("OrganizationBillingService", () => {
         expect(organizationApiService.create).toHaveBeenCalledWith(
           expect.not.objectContaining({ coupons: expect.anything() }),
         );
+      });
+
+      it("names the default collection using the collection terminology when the VFO1 flag is off", async () => {
+        const subscriptionWithPayment = {
+          ...mockSubscription,
+          payment: {
+            paymentMethod: ["test-token", PaymentMethodType.Card],
+            billing: { postalCode: "12345", country: "US" },
+          } as PaymentInformation,
+        } as SubscriptionInformation;
+        configService.getFeatureFlag.mockResolvedValue(false);
+
+        await sut.purchaseSubscription(subscriptionWithPayment, mockUserId);
+
+        expect(configService.getFeatureFlag).toHaveBeenCalledWith(FeatureFlag.VFO1Foundation);
+        expect(i18nService.t).toHaveBeenCalledWith("defaultCollection");
+      });
+
+      it("names the default collection using the shared-folder terminology when the VFO1 flag is on", async () => {
+        const subscriptionWithPayment = {
+          ...mockSubscription,
+          payment: {
+            paymentMethod: ["test-token", PaymentMethodType.Card],
+            billing: { postalCode: "12345", country: "US" },
+          } as PaymentInformation,
+        } as SubscriptionInformation;
+        configService.getFeatureFlag.mockResolvedValue(true);
+
+        await sut.purchaseSubscription(subscriptionWithPayment, mockUserId);
+
+        expect(configService.getFeatureFlag).toHaveBeenCalledWith(FeatureFlag.VFO1Foundation);
+        expect(i18nService.t).toHaveBeenCalledWith("defaultSharedFolder");
       });
     });
 

--- a/libs/common/src/billing/services/organization-billing.service.ts
+++ b/libs/common/src/billing/services/organization-billing.service.ts
@@ -10,8 +10,10 @@ import { OrganizationApiServiceAbstraction as OrganizationApiService } from "../
 import { OrganizationCreateRequest } from "../../admin-console/models/request/organization-create.request";
 import { OrganizationKeysRequest } from "../../admin-console/models/request/organization-keys.request";
 import { OrganizationResponse } from "../../admin-console/models/response/organization.response";
+import { FeatureFlag } from "../../enums/feature-flag.enum";
 import { EncryptService } from "../../key-management/crypto/abstractions/encrypt.service";
 import { EncString } from "../../key-management/crypto/models/enc-string";
+import { ConfigService } from "../../platform/abstractions/config/config.service";
 import { I18nService } from "../../platform/abstractions/i18n.service";
 import { SyncService } from "../../platform/sync";
 import { OrgKey } from "../../types/key";
@@ -42,6 +44,7 @@ export class OrganizationBillingService implements OrganizationBillingServiceAbs
     private i18nService: I18nService,
     private organizationApiService: OrganizationApiService,
     private syncService: SyncService,
+    private configService: ConfigService,
   ) {}
 
   async purchaseSubscription(
@@ -122,8 +125,9 @@ export class OrganizationBillingService implements OrganizationBillingServiceAbs
   private async makeOrganizationKeys(activeUserId: UserId): Promise<OrganizationKeys> {
     const [encryptedKey, key] = await this.keyService.makeOrgKey<OrgKey>(activeUserId);
     const [publicKey, encryptedPrivateKey] = await this.keyService.makeKeyPair(key);
+    const vfo1Enabled = await this.configService.getFeatureFlag(FeatureFlag.VFO1Foundation);
     const encryptedCollectionName = await this.encryptService.encryptString(
-      this.i18nService.t("defaultCollection"),
+      this.i18nService.t(vfo1Enabled ? "defaultSharedFolder" : "defaultCollection"),
       key,
     );
     return {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-40654
https://bitwarden.atlassian.net/browse/PM-40882

Part of epic PM-39699 (Change "collections" to "shared folders"). Independent of PM-40252 — branches off `main`.

## 📔 Objective

The collection auto-created at organization setup is named via the `defaultCollection` i18n key ("Default collection"). Behind the `vfo1-foundation` flag, it should instead read **"Default shared folder"**.

This gates the name at all five org-creation call sites:

- `organization-billing.service.ts` (libs/common) — purchase / free / restart flows
- `default-organization-invite.service.ts` (libs/common) — accept-and-init flow
- `premium-org-upgrade.service.ts` (web) — premium → org upgrade
- `organization-self-hosting-license-uploader.component.ts` (web) — self-host license upload
- `web-provider.service.ts` (bit-web) — MSP/provider client-org creation

Each site resolves `ConfigService.getFeatureFlag(VFO1Foundation)` and selects the `defaultSharedFolder` / `defaultCollection` key. The two `libs/common` services gain a `ConfigService` dependency (both `deps` arrays updated in `jslib-services.module.ts`). `WebProviderService` also gains a `ConfigService` dependency; it uses Angular constructor injection with no `deps` array, so it resolves automatically.

Unlike the display-only terminology work elsewhere in the epic, this renames the **persisted** collection name, so it reads the resolved flag value rather than the `Vfo1TerminologyService` signal (which defaults to `true` before the flag resolves). New `defaultSharedFolder` key added to web's `en` locale; `defaultCollection` retained for the flag-off path.

Behavior only changes for orgs created after deploy.

## 📸 Screenshots

<!-- Not applicable — no UI change (collection name string only). -->
