### PR TITLE
feat(data-recovery): add fido2 step

### DIFF
--- a/apps/web/src/app/key-management/data-recovery/data-recovery.component.spec.ts
+++ b/apps/web/src/app/key-management/data-recovery/data-recovery.component.spec.ts
@@ -98,12 +98,13 @@ describe("DataRecoveryComponent", () => {
 
     it("should initialize steps in correct order", () => {
       const steps = component.steps();
-      expect(steps.length).toBe(5);
+      expect(steps.length).toBe(6);
       expect(steps[0].title).toBe("recoveryStepUserInfoTitle_used-i18n");
       expect(steps[1].title).toBe("recoveryStepSyncTitle_used-i18n");
       expect(steps[2].title).toBe("recoveryStepPrivateKeyTitle_used-i18n");
       expect(steps[3].title).toBe("recoveryStepFoldersTitle_used-i18n");
-      expect(steps[4].title).toBe("recoveryStepCipherTitle_used-i18n");
+      expect(steps[4].title).toBe("recoveryStepFido2Title_used-i18n");
+      expect(steps[5].title).toBe("recoveryStepCipherTitle_used-i18n");
     });
   });
 
@@ -112,7 +113,7 @@ describe("DataRecoveryComponent", () => {
 
     beforeEach(() => {
       // Create mock steps
-      mockSteps = Array(5)
+      mockSteps = Array(6)
         .fill(null)
         .map(() => {
           const mockStep = mock<RecoveryStep>();
@@ -233,9 +234,10 @@ describe("DataRecoveryComponent", () => {
         encryptedPrivateKey: null,
         ciphers: [],
         folders: [],
+        fido2CorruptCipherIds: [],
       };
 
-      mockSteps = Array(5)
+      mockSteps = Array(6)
         .fill(null)
         .map(() => {
           const mockStep = mock<RecoveryStep>();

--- a/apps/web/src/app/key-management/data-recovery/data-recovery.component.ts
+++ b/apps/web/src/app/key-management/data-recovery/data-recovery.component.ts
@@ -27,6 +27,7 @@ import {
   RecoveryWorkingData,
   FolderStep,
   CipherStep,
+  Fido2Step,
 } from "./steps";
 
 export const StepStatus = Object.freeze({
@@ -75,6 +76,7 @@ export class DataRecoveryComponent {
       this.cryptoFunctionService,
     ),
     new FolderStep(this.folderApiService, this.dialogService),
+    new Fido2Step(this.cipherEncryptService, this.apiService, this.dialogService),
     new CipherStep(this.apiService, this.cipherEncryptService, this.dialogService),
   ];
   private workingData: RecoveryWorkingData | null = null;
@@ -108,6 +110,7 @@ export class DataRecoveryComponent {
       encryptedPrivateKey: null,
       ciphers: [],
       folders: [],
+      fido2CorruptCipherIds: [],
     };
 
     await this.runDiagnosticsInternal();

--- a/apps/web/src/app/key-management/data-recovery/steps/cipher-step.spec.ts
+++ b/apps/web/src/app/key-management/data-recovery/steps/cipher-step.spec.ts
@@ -36,6 +36,7 @@ describe("CipherStep", () => {
         isPrivateKeyCorrupt: false,
         ciphers: [],
         folders: [],
+        fido2CorruptCipherIds: [],
       };
 
       const result = await cipherStep.runDiagnostics(workingData, logger);
@@ -56,6 +57,7 @@ describe("CipherStep", () => {
         isPrivateKeyCorrupt: false,
         ciphers: [cipher1, cipher2],
         folders: [],
+        fido2CorruptCipherIds: [],
       };
 
       cipherEncryptionService.decrypt.mockResolvedValue({} as any);
@@ -80,6 +82,7 @@ describe("CipherStep", () => {
         isPrivateKeyCorrupt: false,
         ciphers: [userCipher, orgCipher1, orgCipher2],
         folders: [],
+        fido2CorruptCipherIds: [],
       };
 
       cipherEncryptionService.decrypt.mockResolvedValue({} as any);
@@ -108,6 +111,7 @@ describe("CipherStep", () => {
         isPrivateKeyCorrupt: false,
         ciphers: [cipher1, cipher2, cipher3],
         folders: [],
+        fido2CorruptCipherIds: [],
       };
 
       cipherEncryptionService.decrypt
@@ -123,6 +127,36 @@ describe("CipherStep", () => {
       expect(logger.record).toHaveBeenCalledWith("Found 2 undecryptable ciphers");
     });
 
+    it("excludes ciphers listed in fido2CorruptCipherIds from undecryptable counts", async () => {
+      const userId = "user-id" as UserId;
+      const okCipher = { id: "cipher-1", organizationId: null } as Cipher;
+      const fido2Cipher = { id: "cipher-fido2", organizationId: null } as Cipher;
+      const brokenCipher = { id: "cipher-broken", organizationId: null } as Cipher;
+
+      const workingData: RecoveryWorkingData = {
+        userId,
+        userKey: null,
+        encryptedPrivateKey: null,
+        isPrivateKeyCorrupt: false,
+        ciphers: [okCipher, fido2Cipher, brokenCipher],
+        folders: [],
+        fido2CorruptCipherIds: ["cipher-fido2"],
+      };
+
+      cipherEncryptionService.decrypt
+        .mockResolvedValueOnce({} as any) // okCipher succeeds
+        .mockRejectedValueOnce(new Error("Decryption failed")) // fido2Cipher fails (fido2-only)
+        .mockRejectedValueOnce(new Error("Decryption failed")); // brokenCipher fails
+
+      const result = await cipherStep.runDiagnostics(workingData, logger);
+
+      expect(result).toBe(false);
+      expect(cipherStep["undecryptableCipherIds"]).toEqual(["cipher-broken"]);
+      expect(logger.record).not.toHaveBeenCalledWith("Cipher ID cipher-fido2 was undecryptable");
+      expect(logger.record).toHaveBeenCalledWith("Cipher ID cipher-broken was undecryptable");
+      expect(logger.record).toHaveBeenCalledWith("Found 1 undecryptable ciphers");
+    });
+
     it("returns correct results when running diagnostics multiple times", async () => {
       const userId = "user-id" as UserId;
       const cipher1 = { id: "cipher-1", organizationId: null } as Cipher;
@@ -135,6 +169,7 @@ describe("CipherStep", () => {
         isPrivateKeyCorrupt: false,
         ciphers: [cipher1, cipher2],
         folders: [],
+        fido2CorruptCipherIds: [],
       };
 
       // First run: cipher1 succeeds, cipher2 fails
@@ -172,6 +207,7 @@ describe("CipherStep", () => {
           { id: "cipher-2", organizationId: null } as Cipher,
         ],
         folders: [],
+        fido2CorruptCipherIds: [],
       };
 
       cipherEncryptionService.decrypt.mockResolvedValue({} as any);
@@ -194,6 +230,7 @@ describe("CipherStep", () => {
           { id: "cipher-2", organizationId: null } as Cipher,
         ],
         folders: [],
+        fido2CorruptCipherIds: [],
       };
 
       cipherEncryptionService.decrypt.mockRejectedValueOnce(new Error("Decryption failed"));
@@ -216,6 +253,7 @@ describe("CipherStep", () => {
           { id: "cipher-2", organizationId: null } as Cipher,
         ],
         folders: [],
+        fido2CorruptCipherIds: [],
       };
 
       cipherEncryptionService.decrypt.mockRejectedValue(new Error("Decryption failed"));
@@ -236,6 +274,7 @@ describe("CipherStep", () => {
         isPrivateKeyCorrupt: false,
         ciphers: [],
         folders: [],
+        fido2CorruptCipherIds: [],
       };
 
       await cipherStep.runRecovery(workingData, logger);
@@ -254,6 +293,7 @@ describe("CipherStep", () => {
         isPrivateKeyCorrupt: false,
         ciphers: [{ id: "cipher-1", organizationId: null } as Cipher],
         folders: [],
+        fido2CorruptCipherIds: [],
       };
 
       cipherEncryptionService.decrypt.mockRejectedValue(new Error("Decryption failed"));
@@ -282,6 +322,7 @@ describe("CipherStep", () => {
         isPrivateKeyCorrupt: false,
         ciphers: [cipher1, cipher2],
         folders: [],
+        fido2CorruptCipherIds: [],
       };
 
       cipherEncryptionService.decrypt.mockRejectedValue(new Error("Decryption failed"));

--- a/apps/web/src/app/key-management/data-recovery/steps/cipher-step.ts
+++ b/apps/web/src/app/key-management/data-recovery/steps/cipher-step.ts
@@ -4,6 +4,7 @@ import { DialogService } from "@bitwarden/components";
 
 import { LogRecorder } from "../log-recorder";
 
+import { logCipherCorruption } from "./corruption-log";
 import { RecoveryStep, RecoveryWorkingData } from "./recovery-step";
 
 export class CipherStep implements RecoveryStep {
@@ -35,7 +36,13 @@ export class CipherStep implements RecoveryStep {
         await this.cipherService.decrypt(cipher, workingData.userId);
         this.decryptableCipherIds.push(cipher.id);
       } catch {
+        // Ciphers that only fail because of corrupt FIDO2 credentials are handled by the FIDO2
+        // step; exclude them here so they aren't counted (and deleted) as whole-cipher failures.
+        if (workingData.fido2CorruptCipherIds.includes(cipher.id)) {
+          continue;
+        }
         logger.record(`Cipher ID ${cipher.id} was undecryptable`);
+        logCipherCorruption(cipher, logger);
         this.undecryptableCipherIds.push(cipher.id);
       }
     }

--- a/apps/web/src/app/key-management/data-recovery/steps/corruption-log.ts
+++ b/apps/web/src/app/key-management/data-recovery/steps/corruption-log.ts
@@ -1,0 +1,14 @@
+import { Cipher } from "@bitwarden/common/vault/models/domain/cipher";
+
+import { LogRecorder } from "../log-recorder";
+
+/**
+ * Records diagnostic details about a corrupt cipher: its id and whether it carries a per-item
+ * vault item key (cipher key). No decrypted data is logged.
+ */
+export function logCipherCorruption(cipher: Cipher, logger: LogRecorder, note?: string): void {
+  const cipherKeyPresent = cipher.key != null;
+  logger.record(
+    `Corrupt cipher ${cipher.id}${note ? ` (${note})` : ""}: cipherKeyPresent=${cipherKeyPresent}`,
+  );
+}

--- a/apps/web/src/app/key-management/data-recovery/steps/fido2-step.spec.ts
+++ b/apps/web/src/app/key-management/data-recovery/steps/fido2-step.spec.ts
@@ -1,0 +1,202 @@
+import { mock, MockProxy } from "jest-mock-extended";
+
+import { ApiService } from "@bitwarden/common/abstractions/api.service";
+import { CipherEncryptionService } from "@bitwarden/common/vault/abstractions/cipher-encryption.service";
+import { CipherType } from "@bitwarden/common/vault/enums";
+import { Cipher } from "@bitwarden/common/vault/models/domain/cipher";
+import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+import { DialogService } from "@bitwarden/components";
+import { UserId } from "@bitwarden/user-core";
+
+import { LogRecorder } from "../log-recorder";
+
+import { Fido2Step } from "./fido2-step";
+import { RecoveryWorkingData } from "./recovery-step";
+
+function buildLoginCipherWithFido2(id: string, organizationId: string | null = null): Cipher {
+  const encString = "2.aaa|bbb|ccc";
+  const now = new Date().toISOString();
+  return Cipher.fromJSON({
+    id,
+    organizationId,
+    type: CipherType.Login,
+    favorite: false,
+    edit: true,
+    viewPassword: true,
+    organizationUseTotp: false,
+    reprompt: 0,
+    collectionIds: [],
+    creationDate: now,
+    revisionDate: now,
+    login: {
+      username: encString,
+      fido2Credentials: [
+        {
+          credentialId: encString,
+          keyType: encString,
+          keyAlgorithm: encString,
+          keyCurve: encString,
+          keyValue: encString,
+          rpId: encString,
+          counter: encString,
+          discoverable: encString,
+          creationDate: now,
+        },
+      ],
+    },
+  } as any)!;
+}
+
+function buildWorkingData(ciphers: Cipher[]): RecoveryWorkingData {
+  return {
+    userId: "user-id" as UserId,
+    userKey: null,
+    encryptedPrivateKey: null,
+    isPrivateKeyCorrupt: false,
+    ciphers,
+    folders: [],
+    fido2CorruptCipherIds: [],
+  };
+}
+
+describe("Fido2Step", () => {
+  let fido2Step: Fido2Step;
+  let cipherEncryptionService: MockProxy<CipherEncryptionService>;
+  let apiService: MockProxy<ApiService>;
+  let dialogService: MockProxy<DialogService>;
+  let logger: MockProxy<LogRecorder>;
+
+  const healthyView = (): CipherView => ({ decryptionFailure: false }) as CipherView;
+
+  beforeEach(() => {
+    cipherEncryptionService = mock<CipherEncryptionService>();
+    apiService = mock<ApiService>();
+    dialogService = mock<DialogService>();
+    logger = mock<LogRecorder>();
+
+    fido2Step = new Fido2Step(cipherEncryptionService, apiService, dialogService);
+  });
+
+  describe("runDiagnostics", () => {
+    it("returns false and logs when userId is missing", async () => {
+      const workingData = buildWorkingData([]);
+      workingData.userId = null;
+
+      const result = await fido2Step.runDiagnostics(workingData, logger);
+
+      expect(result).toBe(false);
+      expect(logger.record).toHaveBeenCalledWith("Missing user ID");
+    });
+
+    it("flags ciphers that decrypt only after removing FIDO2 credentials", async () => {
+      const cipher = buildLoginCipherWithFido2("cipher-1");
+      const workingData = buildWorkingData([cipher]);
+
+      // First call: original cipher fails. Second call: stripped clone succeeds.
+      cipherEncryptionService.decrypt
+        .mockRejectedValueOnce(new Error("Decryption failed"))
+        .mockResolvedValueOnce(healthyView());
+
+      const result = await fido2Step.runDiagnostics(workingData, logger);
+
+      expect(result).toBe(false);
+      expect(workingData.fido2CorruptCipherIds).toEqual(["cipher-1"]);
+      expect(logger.record).toHaveBeenCalledWith("Found 1 ciphers with corrupt FIDO2 credentials");
+    });
+
+    it("does not flag ciphers that still fail after removing FIDO2 credentials", async () => {
+      const cipher = buildLoginCipherWithFido2("cipher-1");
+      const workingData = buildWorkingData([cipher]);
+
+      cipherEncryptionService.decrypt.mockRejectedValue(new Error("Decryption failed"));
+
+      const result = await fido2Step.runDiagnostics(workingData, logger);
+
+      expect(result).toBe(true);
+      expect(workingData.fido2CorruptCipherIds).toEqual([]);
+    });
+
+    it("skips healthy FIDO2 ciphers", async () => {
+      const cipher = buildLoginCipherWithFido2("cipher-1");
+      const workingData = buildWorkingData([cipher]);
+
+      cipherEncryptionService.decrypt.mockResolvedValue(healthyView());
+
+      const result = await fido2Step.runDiagnostics(workingData, logger);
+
+      expect(result).toBe(true);
+      expect(workingData.fido2CorruptCipherIds).toEqual([]);
+      // Only the original decrypt is attempted for a healthy cipher.
+      expect(cipherEncryptionService.decrypt).toHaveBeenCalledTimes(1);
+    });
+
+    it("skips organization ciphers and logins without FIDO2 credentials", async () => {
+      const orgCipher = buildLoginCipherWithFido2("org-cipher", "org-1");
+      const noFido2 = { id: "no-fido2", organizationId: null, type: CipherType.Login } as Cipher;
+      const nonLogin = {
+        id: "note",
+        organizationId: null,
+        type: CipherType.SecureNote,
+      } as Cipher;
+      const workingData = buildWorkingData([orgCipher, noFido2, nonLogin]);
+
+      const result = await fido2Step.runDiagnostics(workingData, logger);
+
+      expect(result).toBe(true);
+      expect(cipherEncryptionService.decrypt).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("canRecover", () => {
+    it("returns true only when there are corrupt FIDO2 ciphers", () => {
+      const empty = buildWorkingData([]);
+      expect(fido2Step.canRecover(empty)).toBe(false);
+
+      const withCorrupt = buildWorkingData([]);
+      withCorrupt.fido2CorruptCipherIds = ["cipher-1"];
+      expect(fido2Step.canRecover(withCorrupt)).toBe(true);
+    });
+  });
+
+  describe("runRecovery", () => {
+    it("returns early when there is nothing to recover", async () => {
+      const workingData = buildWorkingData([]);
+
+      await fido2Step.runRecovery(workingData, logger);
+
+      expect(dialogService.openSimpleDialog).not.toHaveBeenCalled();
+      expect(apiService.putCipher).not.toHaveBeenCalled();
+    });
+
+    it("throws when the user cancels", async () => {
+      const cipher = buildLoginCipherWithFido2("cipher-1");
+      const workingData = buildWorkingData([cipher]);
+      workingData.fido2CorruptCipherIds = ["cipher-1"];
+
+      dialogService.openSimpleDialog.mockResolvedValue(false);
+
+      await expect(fido2Step.runRecovery(workingData, logger)).rejects.toThrow(
+        "FIDO2 recovery cancelled by user",
+      );
+      expect(apiService.putCipher).not.toHaveBeenCalled();
+    });
+
+    it("PUTs each cipher with FIDO2 credentials removed when confirmed", async () => {
+      const cipher = buildLoginCipherWithFido2("cipher-1");
+      const workingData = buildWorkingData([cipher]);
+      workingData.fido2CorruptCipherIds = ["cipher-1"];
+
+      dialogService.openSimpleDialog.mockResolvedValue(true);
+      apiService.putCipher.mockResolvedValue(undefined as any);
+
+      await fido2Step.runRecovery(workingData, logger);
+
+      expect(apiService.putCipher).toHaveBeenCalledTimes(1);
+      const [id, request] = apiService.putCipher.mock.calls[0];
+      expect(id).toBe("cipher-1");
+      expect(request.encryptedFor).toBe(workingData.userId);
+      expect(request.login.fido2Credentials).toBeUndefined();
+      expect(logger.record).toHaveBeenCalledWith("Removed FIDO2 credentials from cipher cipher-1");
+    });
+  });
+});

--- a/apps/web/src/app/key-management/data-recovery/steps/fido2-step.ts
+++ b/apps/web/src/app/key-management/data-recovery/steps/fido2-step.ts
@@ -1,0 +1,163 @@
+import { ApiService } from "@bitwarden/common/abstractions/api.service";
+import { CipherEncryptionService } from "@bitwarden/common/vault/abstractions/cipher-encryption.service";
+import { CipherType } from "@bitwarden/common/vault/enums";
+import { Cipher } from "@bitwarden/common/vault/models/domain/cipher";
+import { CipherRequest } from "@bitwarden/common/vault/models/request/cipher.request";
+import { DialogService } from "@bitwarden/components";
+import { UserId } from "@bitwarden/user-core";
+
+import { LogRecorder } from "../log-recorder";
+
+import { logCipherCorruption } from "./corruption-log";
+import { RecoveryStep, RecoveryWorkingData } from "./recovery-step";
+
+/**
+ * Detects Login ciphers whose only decryption failure is corrupt FIDO2 credentials, and repairs
+ * them by stripping the FIDO2 part while preserving the rest of the login. Ciphers that fail to
+ * decrypt even without their FIDO2 credentials are left for the cipher step.
+ */
+export class Fido2Step implements RecoveryStep {
+  title = "recoveryStepFido2Title";
+
+  constructor(
+    private cipherService: CipherEncryptionService,
+    private apiService: ApiService,
+    private dialogService: DialogService,
+  ) {}
+
+  async runDiagnostics(workingData: RecoveryWorkingData, logger: LogRecorder): Promise<boolean> {
+    if (!workingData.userId) {
+      logger.record("Missing user ID");
+      return false;
+    }
+
+    workingData.fido2CorruptCipherIds = [];
+
+    // Skip anything that is not a user-owned Login cipher with FIDO2 credentials.
+    const fido2Ciphers = workingData.ciphers.filter(
+      (c) =>
+        c.organizationId == null &&
+        c.type === CipherType.Login &&
+        (c.login?.fido2Credentials?.length ?? 0) > 0,
+    );
+
+    for (const cipher of fido2Ciphers) {
+      if (await this.decryptSucceeds(cipher, workingData.userId)) {
+        continue;
+      }
+
+      // The cipher is undecryptable. Try again with the FIDO2 credentials removed to determine
+      // whether the corruption is isolated to the FIDO2 part.
+      const strippedCipher = this.stripFido2Credentials(cipher);
+      if (
+        strippedCipher != null &&
+        (await this.decryptSucceeds(strippedCipher, workingData.userId))
+      ) {
+        workingData.fido2CorruptCipherIds.push(cipher.id);
+        logCipherCorruption(cipher, logger, "fido2");
+      }
+    }
+
+    logger.record(
+      `Found ${workingData.fido2CorruptCipherIds.length} ciphers with corrupt FIDO2 credentials`,
+    );
+
+    return workingData.fido2CorruptCipherIds.length == 0;
+  }
+
+  canRecover(workingData: RecoveryWorkingData): boolean {
+    return workingData.fido2CorruptCipherIds.length > 0;
+  }
+
+  async runRecovery(workingData: RecoveryWorkingData, logger: LogRecorder): Promise<void> {
+    if (workingData.fido2CorruptCipherIds.length === 0) {
+      logger.record("No ciphers with corrupt FIDO2 credentials to recover");
+      return;
+    }
+
+    if (!workingData.userId) {
+      logger.record("Missing user ID");
+      throw new Error("Missing user ID");
+    }
+
+    logger.record(
+      `Showing confirmation dialog for ${workingData.fido2CorruptCipherIds.length} ciphers`,
+    );
+
+    const confirmed = await this.dialogService.openSimpleDialog({
+      title: { key: "recoveryDeleteFido2Title" },
+      content: { key: "recoveryDeleteFido2Desc" },
+      acceptButtonText: { key: "ok" },
+      cancelButtonText: { key: "cancel" },
+      type: "danger",
+    });
+
+    if (!confirmed) {
+      logger.record("User cancelled FIDO2 credential deletion");
+      throw new Error("FIDO2 recovery cancelled by user");
+    }
+
+    logger.record(
+      `Removing FIDO2 credentials from ${workingData.fido2CorruptCipherIds.length} ciphers`,
+    );
+
+    for (const cipherId of workingData.fido2CorruptCipherIds) {
+      const cipher = workingData.ciphers.find((c) => c.id === cipherId);
+      if (cipher == null) {
+        logger.record(`Cipher ${cipherId} no longer present, skipping`);
+        continue;
+      }
+
+      const strippedCipher = this.stripFido2Credentials(cipher);
+      if (strippedCipher == null) {
+        logger.record(`Failed to prepare cipher ${cipherId} for FIDO2 removal`);
+        continue;
+      }
+
+      try {
+        const request = new CipherRequest({
+          cipher: strippedCipher,
+          encryptedFor: workingData.userId,
+        });
+        await this.apiService.putCipher(strippedCipher.id, request);
+        logger.record(`Removed FIDO2 credentials from cipher ${cipherId}`);
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        logger.record(
+          `Failed to remove FIDO2 credentials from cipher ${cipherId}: ${errorMessage}`,
+        );
+        throw error;
+      }
+    }
+
+    logger.record(
+      `Successfully removed FIDO2 credentials from ${workingData.fido2CorruptCipherIds.length} ciphers`,
+    );
+  }
+
+  /**
+   * Returns true when the cipher decrypts without a decryption failure, false on any error or a
+   * flagged decryption failure.
+   */
+  private async decryptSucceeds(cipher: Cipher, userId: UserId): Promise<boolean> {
+    try {
+      const view = await this.cipherService.decrypt(cipher, userId);
+      return !view.decryptionFailure;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Deep-clones the encrypted cipher and removes its FIDO2 credentials, leaving the rest of the
+   * login intact. Returns undefined if the cipher cannot be cloned.
+   */
+  private stripFido2Credentials(cipher: Cipher): Cipher | undefined {
+    const clone = Cipher.fromJSON(JSON.parse(JSON.stringify(cipher)));
+    if (clone?.login == null) {
+      return undefined;
+    }
+    clone.login.fido2Credentials = undefined;
+    return clone;
+  }
+}

--- a/apps/web/src/app/key-management/data-recovery/steps/folder-step.spec.ts
+++ b/apps/web/src/app/key-management/data-recovery/steps/folder-step.spec.ts
@@ -52,6 +52,7 @@ describe("FolderStep", () => {
         userKey: null,
         encryptedPrivateKey: null,
         isPrivateKeyCorrupt: false,
+        fido2CorruptCipherIds: [],
         ciphers: [],
         folders: [],
       };
@@ -71,6 +72,7 @@ describe("FolderStep", () => {
         userKey: mockUserKey,
         encryptedPrivateKey: null,
         isPrivateKeyCorrupt: false,
+        fido2CorruptCipherIds: [],
         ciphers: [],
         folders: [folder1, folder2] as Folder[],
       };
@@ -102,6 +104,7 @@ describe("FolderStep", () => {
         userKey: mockUserKey,
         encryptedPrivateKey: null,
         isPrivateKeyCorrupt: false,
+        fido2CorruptCipherIds: [],
         ciphers: [],
         folders: [folder1, folder2, folder3] as Folder[],
       };
@@ -127,6 +130,7 @@ describe("FolderStep", () => {
         userKey: mockUserKey,
         encryptedPrivateKey: null,
         isPrivateKeyCorrupt: false,
+        fido2CorruptCipherIds: [],
         ciphers: [],
         folders: [folder1, folder2, folder3] as Folder[],
       };
@@ -162,6 +166,7 @@ describe("FolderStep", () => {
         userKey: mockUserKey,
         encryptedPrivateKey: null,
         isPrivateKeyCorrupt: false,
+        fido2CorruptCipherIds: [],
         ciphers: [],
         folders: [folder1, folder2] as Folder[],
       };
@@ -197,6 +202,7 @@ describe("FolderStep", () => {
         userKey: mockUserKey,
         encryptedPrivateKey: null,
         isPrivateKeyCorrupt: false,
+        fido2CorruptCipherIds: [],
         ciphers: [],
         folders: [
           { id: "folder-1", name: { encryptedString: "encrypted-name-1" } },
@@ -218,6 +224,7 @@ describe("FolderStep", () => {
         userKey: mockUserKey,
         encryptedPrivateKey: null,
         isPrivateKeyCorrupt: false,
+        fido2CorruptCipherIds: [],
         ciphers: [],
         folders: [
           { id: "folder-1", name: { encryptedString: "encrypted-name-1" } },
@@ -243,6 +250,7 @@ describe("FolderStep", () => {
         userKey: mockUserKey,
         encryptedPrivateKey: null,
         isPrivateKeyCorrupt: false,
+        fido2CorruptCipherIds: [],
         ciphers: [],
         folders: [
           { id: "folder-1", name: { encryptedString: "encrypted-name-1" } },
@@ -268,6 +276,7 @@ describe("FolderStep", () => {
         userKey: mockUserKey,
         encryptedPrivateKey: null,
         isPrivateKeyCorrupt: false,
+        fido2CorruptCipherIds: [],
         ciphers: [],
         folders: [],
       };
@@ -287,6 +296,7 @@ describe("FolderStep", () => {
         userKey: mockUserKey,
         encryptedPrivateKey: null,
         isPrivateKeyCorrupt: false,
+        fido2CorruptCipherIds: [],
         ciphers: [],
         folders: [folder1] as Folder[],
       };
@@ -312,6 +322,7 @@ describe("FolderStep", () => {
         userKey: mockUserKey,
         encryptedPrivateKey: null,
         isPrivateKeyCorrupt: false,
+        fido2CorruptCipherIds: [],
         ciphers: [],
         folders: [folder1] as Folder[],
       };
@@ -342,6 +353,7 @@ describe("FolderStep", () => {
         userKey: mockUserKey,
         encryptedPrivateKey: null,
         isPrivateKeyCorrupt: false,
+        fido2CorruptCipherIds: [],
         ciphers: [],
         folders: [folder1, folder2] as Folder[],
       };
@@ -376,6 +388,7 @@ describe("FolderStep", () => {
         userKey: mockUserKey,
         encryptedPrivateKey: null,
         isPrivateKeyCorrupt: false,
+        fido2CorruptCipherIds: [],
         ciphers: [],
         folders: [folder1, folder2, folder3] as Folder[],
       };

--- a/apps/web/src/app/key-management/data-recovery/steps/index.ts
+++ b/apps/web/src/app/key-management/data-recovery/steps/index.ts
@@ -4,4 +4,5 @@ export * from "./recovery-step";
 export * from "./private-key-step";
 export * from "./folder-step";
 export * from "./cipher-step";
+export * from "./fido2-step";
 export * from "./corruption-log";

--- a/apps/web/src/app/key-management/data-recovery/steps/index.ts
+++ b/apps/web/src/app/key-management/data-recovery/steps/index.ts
@@ -4,3 +4,4 @@ export * from "./recovery-step";
 export * from "./private-key-step";
 export * from "./folder-step";
 export * from "./cipher-step";
+export * from "./corruption-log";

--- a/apps/web/src/app/key-management/data-recovery/steps/recovery-step.ts
+++ b/apps/web/src/app/key-management/data-recovery/steps/recovery-step.ts
@@ -40,4 +40,9 @@ export type RecoveryWorkingData = {
   isPrivateKeyCorrupt: boolean;
   ciphers: Cipher[];
   folders: Folder[];
+  /**
+   * Ids of Login ciphers whose only decryption failure is corrupt FIDO2 credentials.
+   * Populated by the FIDO2 step so the cipher step can exclude them from its own counts.
+   */
+  fido2CorruptCipherIds: string[];
 };

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -14644,6 +14644,15 @@
   "recoveryStepFoldersTitle": {
     "message": "Verifying folder integrity"
   },
+  "recoveryStepFido2Title": {
+    "message": "Verifying passkey integrity"
+  },
+  "recoveryDeleteFido2Title": {
+    "message": "Delete unrecoverable passkeys"
+  },
+  "recoveryDeleteFido2Desc": {
+    "message": "Some of your vault items have passkeys that could not be recovered. Do you want to delete these unrecoverable passkeys? The rest of each item will be kept."
+  },
   "dataRecoveryTitle": {
     "message": "Data Recovery and Diagnostics"
   },


### PR DESCRIPTION
Add a step to detect and recover from fido2 errors. The assumption currently is that specifically only the fido2 part may be getting corrupted. This is not yet confirmed, and this step will help to confirm it. It is also entirely possible that these are field-encrypted-cipher-corruption-issues.