### PR TITLE
[PM-40680] chromium-importer: Replace deprecated LSFindApplicationForInfo function

### DIFF
--- a/apps/desktop/desktop_native/objc/src/native/chromium_importer/commands/check_browser_installed.m
+++ b/apps/desktop/desktop_native/objc/src/native/chromium_importer/commands/check_browser_installed.m
@@ -1,5 +1,5 @@
+#import <AppKit/AppKit.h>
 #import <Foundation/Foundation.h>
-#import <CoreServices/CoreServices.h>
 #import "../../interop.h"
 #import "check_browser_installed.h"
 
@@ -10,20 +10,7 @@ void checkBrowserInstalledCommand(void* context, NSDictionary *params) {
     return _return(context, _error(@"Missing required parameter: bundleId"));
   }
 
-  CFURLRef appURL = NULL;
-  OSStatus status = LSFindApplicationForInfo(
-    kLSUnknownCreator,
-    (__bridge CFStringRef)bundleId,
-    NULL,
-    NULL,
-    &appURL
-  );
-
-  BOOL isInstalled = (status == noErr && appURL != NULL);
-
-  if (appURL != NULL) {
-    CFRelease(appURL);
-  }
+  BOOL isInstalled = [[NSWorkspace sharedWorkspace] URLForApplicationWithBundleIdentifier:bundleId] != nil;
 
   _return(context, _success(@{@"isInstalled": @(isInstalled)}));
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-40680](https://bitwarden.atlassian.net/browse/PM-40680)


## 📔 Objective

Replaces a deprecated `LSFindApplicationForInfo()` with `URLForApplicationWithBundleIdentifier()`, available since macOS 10.6

[PM-40680]: https://bitwarden.atlassian.net/browse/PM-40680?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ