### PR TITLE
[PM-40682] desktop-autofill: Graceful Windows plugin registration

### DIFF
--- a/apps/desktop/desktop_native/win_webauthn/src/api/plugin/mod.rs
+++ b/apps/desktop/desktop_native/win_webauthn/src/api/plugin/mod.rs
@@ -347,10 +347,13 @@ impl WebAuthnPlugin {
 
     /// Adds this implementation as a Windows WebAuthn plugin.
     ///
+    /// Returns None if the authenticator already is registered; call
+    /// [WebAuthnPlugin::update_authenticator_details] to update the details.
+    ///
     /// This only needs to be called on installation of your application.
     pub fn add_authenticator(
         options: &PluginAddAuthenticatorOptions,
-    ) -> Result<PluginAddAuthenticatorResponse, WinWebAuthnError> {
+    ) -> Result<Option<PluginAddAuthenticatorResponse>, WinWebAuthnError> {
         let options_raw = options.try_into()?;
         add_authenticator(&options_raw)
     }

--- a/apps/desktop/desktop_native/win_webauthn/src/api/plugin/mod.rs
+++ b/apps/desktop/desktop_native/win_webauthn/src/api/plugin/mod.rs
@@ -355,6 +355,14 @@ impl WebAuthnPlugin {
         add_authenticator(&options_raw)
     }
 
+    /// Updates details about your Windows WebAuthn plugin.
+    pub fn update_authenticator_details(
+        options: &PluginUpdateAuthenticatorDetails,
+    ) -> Result<(), WinWebAuthnError> {
+        let options_raw = options.try_into()?;
+        update_authenticator(&options_raw)
+    }
+
     /// Perform user verification related to an associated MakeCredential or GetAssertion request.
     ///
     /// # Arguments

--- a/apps/desktop/desktop_native/win_webauthn/src/api/plugin/types/authenticator.rs
+++ b/apps/desktop/desktop_native/win_webauthn/src/api/plugin/types/authenticator.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use base64::{engine::general_purpose::STANDARD, Engine as _};
-use windows::core::GUID;
+use windows::{core::GUID, Win32::Foundation::NTE_EXISTS};
 
 use crate::{
     api::{
@@ -183,7 +183,7 @@ impl TryFrom<&PluginAddAuthenticatorOptions> for PluginAddAuthenticatorOptionsRa
 
 pub(crate) fn add_authenticator(
     options: &PluginAddAuthenticatorOptionsRaw,
-) -> Result<PluginAddAuthenticatorResponse, WinWebAuthnError> {
+) -> Result<Option<PluginAddAuthenticatorResponse>, WinWebAuthnError> {
     let raw_response = {
         let mut raw_response = MaybeUninit::uninit();
         // SAFETY: We are holding references to all the input data beyond the OS call, so it is
@@ -191,6 +191,10 @@ pub(crate) fn add_authenticator(
         let result = unsafe {
             webauthn_plugin_add_authenticator(&options.inner, raw_response.as_mut_ptr())?
         };
+
+        if result == NTE_EXISTS {
+            return Ok(None);
+        }
 
         result.ok().map_err(|err| {
             WinWebAuthnError::with_cause(
@@ -205,7 +209,7 @@ pub(crate) fn add_authenticator(
     if let Some(response) = NonNull::new(raw_response) {
         // SAFETY: The pointer was allocated by a successful call to
         // webauthn_plugin_add_authenticator, so we trust that it's valid.
-        unsafe { Ok(PluginAddAuthenticatorResponse::try_from_ptr(response)) }
+        unsafe { Ok(Some(PluginAddAuthenticatorResponse::try_from_ptr(response))) }
     } else {
         Err(WinWebAuthnError::new(
             ErrorKind::WindowsInternal,

--- a/apps/desktop/desktop_native/win_webauthn/src/api/plugin/types/authenticator.rs
+++ b/apps/desktop/desktop_native/win_webauthn/src/api/plugin/types/authenticator.rs
@@ -13,8 +13,9 @@ use crate::{
             webauthn_plugin_add_authenticator, webauthn_plugin_authenticator_add_credentials,
             webauthn_plugin_authenticator_remove_all_credentials,
             webauthn_plugin_free_add_authenticator_response,
-            WEBAUTHN_CTAPCBOR_AUTHENTICATOR_OPTIONS, WEBAUTHN_PLUGIN_ADD_AUTHENTICATOR_OPTIONS,
-            WEBAUTHN_PLUGIN_ADD_AUTHENTICATOR_RESPONSE, WEBAUTHN_PLUGIN_CREDENTIAL_DETAILS,
+            webauthn_plugin_update_authenticator_details, WEBAUTHN_CTAPCBOR_AUTHENTICATOR_OPTIONS,
+            WEBAUTHN_PLUGIN_ADD_AUTHENTICATOR_OPTIONS, WEBAUTHN_PLUGIN_ADD_AUTHENTICATOR_RESPONSE,
+            WEBAUTHN_PLUGIN_CREDENTIAL_DETAILS, WEBAUTHN_PLUGIN_UPDATE_AUTHENTICATOR_DETAILS,
         },
         webauthn::{AuthenticatorInfo, UserId},
         WindowsString,
@@ -52,6 +53,11 @@ impl WebAuthnCtapCborAuthenticatorOptions {
     }
 }
 
+fn encode_svg(svg: &str) -> Vec<u16> {
+    let logo_b64: String = STANDARD.encode(svg);
+    logo_b64.to_utf16()
+}
+
 pub struct PluginAddAuthenticatorOptions {
     /// Authenticator Name
     pub authenticator_name: String,
@@ -82,11 +88,6 @@ pub struct PluginAddAuthenticatorOptions {
     ///
     /// Should be [None] if all RPs are supported.
     pub supported_rp_ids: Option<Vec<String>>,
-}
-
-fn encode_svg(svg: &str) -> Vec<u16> {
-    let logo_b64: String = STANDARD.encode(svg);
-    logo_b64.to_utf16()
 }
 
 pub(crate) struct PluginAddAuthenticatorOptionsRaw {
@@ -254,6 +255,157 @@ impl Drop for PluginAddAuthenticatorResponse {
             let _ = webauthn_plugin_free_add_authenticator_response(self.inner.as_mut());
         }
     }
+}
+
+pub struct PluginUpdateAuthenticatorDetails {
+    /// Authenticator Name
+    pub authenticator_name: String,
+
+    /// Existing plugin COM ClsId
+    pub clsid: Clsid,
+
+    /// New plugin COM ClsId to set.
+    pub clsid_new: Clsid,
+
+    /// Plugin Authenticator Logo for the Light themes.
+    ///
+    /// String should contain a valid SVG 1.1 document.
+    pub light_theme_logo_svg: Option<String>,
+
+    // Plugin Authenticator Logo for the Dark themes.
+    ///
+    /// String should contain a valid SVG 1.1 element.
+    pub dark_theme_logo_svg: Option<String>,
+
+    /// CTAP authenticatorGetInfo values
+    pub authenticator_info: AuthenticatorInfo,
+
+    /// List of supported RP IDs (Relying Party IDs) this authenticator is
+    /// restricted to use.
+    ///
+    /// Should be [None] if all RPs are supported.
+    pub supported_rp_ids: Option<Vec<String>>,
+}
+
+pub(crate) struct PluginUpdateAuthenticatorDetailsRaw {
+    pub(super) inner: WEBAUTHN_PLUGIN_UPDATE_AUTHENTICATOR_DETAILS,
+    _authenticator_name: Vec<u16>,
+    _clsid: Box<GUID>,
+    _clsid_new: Box<GUID>,
+    _light_logo_b64: Option<Vec<u16>>,
+    _dark_logo_b64: Option<Vec<u16>>,
+    _authenticator_info: Vec<u8>,
+    _supported_rp_ids: Option<Vec<Vec<u16>>>,
+    _supported_rp_id_ptrs: Option<Vec<*const u16>>,
+}
+
+impl TryFrom<&PluginUpdateAuthenticatorDetails> for PluginUpdateAuthenticatorDetailsRaw {
+    type Error = WinWebAuthnError;
+
+    fn try_from(value: &PluginUpdateAuthenticatorDetails) -> Result<Self, Self::Error> {
+        let rclsid = Box::new(value.clsid.as_guid());
+        let rclsid_new = Box::new(value.clsid_new.as_guid());
+
+        let authenticator_name = value.authenticator_name.to_utf16();
+
+        let light_logo_b64 = value.light_theme_logo_svg.as_deref().map(encode_svg);
+        let dark_logo_b64 = value.dark_theme_logo_svg.as_deref().map(encode_svg);
+
+        let authenticator_info = value.authenticator_info.as_ctap_bytes()?;
+
+        let supported_rp_ids_len: Option<u32> = value
+            .supported_rp_ids
+            .as_ref()
+            .map(|v| {
+                v.len().try_into().map_err(|err| {
+                    WinWebAuthnError::with_cause(
+                        ErrorKind::InvalidArguments,
+                        "Too many supported RP IDs specified, must be less than 2^32.",
+                        err,
+                    )
+                })
+            })
+            .transpose()?;
+
+        let supported_rp_ids: Option<Vec<Vec<u16>>> = value
+            .supported_rp_ids
+            .as_ref()
+            .map(|ids| ids.iter().map(|id| id.to_utf16()).collect());
+        let supported_rp_id_ptrs: Option<Vec<*const u16>> = supported_rp_ids
+            .as_ref()
+            .map(|ids| ids.iter().map(Vec::as_ptr).collect());
+
+        let inner = WEBAUTHN_PLUGIN_UPDATE_AUTHENTICATOR_DETAILS {
+            pwszAuthenticatorName: authenticator_name.as_ptr(),
+            rclsid: rclsid.as_ref(),
+            rclsidNew: rclsid_new.as_ref(),
+            pwszLightThemeLogoSvg: light_logo_b64
+                .as_ref()
+                .map_or(std::ptr::null(), |v| v.as_ptr()),
+            pwszDarkThemeLogoSvg: dark_logo_b64
+                .as_ref()
+                .map_or(std::ptr::null(), |v| v.as_ptr()),
+            cbAuthenticatorInfo: authenticator_info.len().try_into().map_err(|err| {
+                WinWebAuthnError::with_cause(
+                    ErrorKind::InvalidArguments,
+                    "Authenticator info is too long; must be less than 2^32 bytes.",
+                    err,
+                )
+            })?,
+            pbAuthenticatorInfo: authenticator_info.as_ptr(),
+            // These pointers are self-referential and can cause issues if the
+            // wrapper struct is moved, or if the Vec is modified without also
+            // updating the pointers in inner.pbSupportedRpIds.
+            // Consider removing this wrapper struct and inlining the call to
+            // webauthn_plugin_update_authenticator to avoid this.
+            cSupportedRpIds: supported_rp_ids_len.unwrap_or(0),
+            pbSupportedRpIds: supported_rp_id_ptrs
+                .as_ref()
+                .map_or(std::ptr::null(), |v| v.as_ptr()),
+        };
+        Ok(Self {
+            inner,
+            _clsid: rclsid,
+            _clsid_new: rclsid_new,
+            _authenticator_name: authenticator_name,
+            _light_logo_b64: light_logo_b64,
+            _dark_logo_b64: dark_logo_b64,
+            _authenticator_info: authenticator_info,
+            _supported_rp_ids: supported_rp_ids,
+            _supported_rp_id_ptrs: supported_rp_id_ptrs,
+        })
+    }
+}
+
+impl From<PluginAddAuthenticatorOptions> for PluginUpdateAuthenticatorDetails {
+    fn from(value: PluginAddAuthenticatorOptions) -> Self {
+        Self {
+            authenticator_name: value.authenticator_name,
+            clsid: value.clsid,
+            clsid_new: value.clsid,
+            light_theme_logo_svg: value.light_theme_logo_svg,
+            dark_theme_logo_svg: value.dark_theme_logo_svg,
+            authenticator_info: value.authenticator_info,
+            supported_rp_ids: value.supported_rp_ids,
+        }
+    }
+}
+
+pub(crate) fn update_authenticator(
+    options: &PluginUpdateAuthenticatorDetailsRaw,
+) -> Result<(), WinWebAuthnError> {
+    // SAFETY: We are holding references to all the input data beyond the OS call, so it is
+    // valid during the call.
+    let result = unsafe { webauthn_plugin_update_authenticator_details(&options.inner)? };
+
+    result.ok().map_err(|err| {
+        WinWebAuthnError::with_cause(
+            ErrorKind::WindowsInternal,
+            "Failed to update authenticator",
+            err,
+        )
+    })?;
+    Ok(())
 }
 
 // Credential syncing types

--- a/apps/desktop/desktop_native/win_webauthn/src/api/sys/plugin.rs
+++ b/apps/desktop/desktop_native/win_webauthn/src/api/sys/plugin.rs
@@ -277,6 +277,44 @@ pub(in crate::api) struct WEBAUTHN_PLUGIN_ADD_AUTHENTICATOR_RESPONSE {
     pub(in crate::api) pbOpSignPubKey: *mut u8,
 }
 
+/// Used when updating a Windows plugin authenticator.
+/// Header File Name: _WEBAUTHN_PLUGIN_UPDATE_AUTHENTICATOR_DETAILS
+/// Header File Usage: WebAuthNPluginUpdateAuthenticatorDetails()
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub(in crate::api) struct WEBAUTHN_PLUGIN_UPDATE_AUTHENTICATOR_DETAILS {
+    /// Authenticator Name
+    pub(in crate::api) pwszAuthenticatorName: *const u16,
+
+    /// Current Plugin COM ClsId
+    pub(in crate::api) rclsid: *const GUID,
+
+    /// New Plugin COM ClsId to set.
+    pub(in crate::api) rclsidNew: *const GUID,
+
+    /// Plugin Authenticator Logo for the Light themes.  base64-encoded SVG 1.1
+    ///
+    /// The data should be encoded as `UTF16(BASE64(UTF8(svg_text)))`.
+    pub(in crate::api) pwszLightThemeLogoSvg: *const u16,
+
+    /// Plugin Authenticator Logo for the Dark themes.  base64-encoded SVG 1.1
+    ///
+    /// The data should be encoded as `UTF16(BASE64(UTF8(svg_text)))`.
+    pub(in crate::api) pwszDarkThemeLogoSvg: *const u16,
+
+    /// CTAP CBOR-encoded authenticatorGetInfo response (size)
+    pub(in crate::api) cbAuthenticatorInfo: u32,
+    /// CTAP CBOR-encoded authenticatorGetInfo output
+    pub(in crate::api) pbAuthenticatorInfo: *const u8,
+
+    /// Count of supported RP IDs
+    pub(in crate::api) cSupportedRpIds: u32,
+    /// List of supported RP IDs (Relying Party IDs).
+    ///
+    /// Should be null if all RPs are supported.
+    pub(in crate::api) pbSupportedRpIds: *const *const u16,
+}
+
 #[repr(C)]
 pub(in crate::api) struct WEBAUTHN_PLUGIN_CANCEL_OPERATION_REQUEST {
     pub(in crate::api) transactionId: GUID,
@@ -452,6 +490,17 @@ webauthn_call!("WebAuthNPluginAddAuthenticator" as
 fn webauthn_plugin_add_authenticator(
     pPluginAddAuthenticatorOptions: *const WEBAUTHN_PLUGIN_ADD_AUTHENTICATOR_OPTIONS,
     ppPluginAddAuthenticatorResponse: *mut *mut WEBAUTHN_PLUGIN_ADD_AUTHENTICATOR_RESPONSE
+) -> HRESULT);
+
+webauthn_call!("WebAuthNPluginUpdateAuthenticatorDetails" as
+/// Register authenticator info for a plugin COM server.
+/// 
+/// Returns [S_OK](windows::Win32::Foundation::S_OK) on success.
+/// 
+/// # Arguments
+/// - `pPluginUpdateAuthenticatorDetails`: Details about the authenticator to update.
+fn webauthn_plugin_update_authenticator_details(
+    pPluginUpdateAuthenticatorDetails: *const WEBAUTHN_PLUGIN_UPDATE_AUTHENTICATOR_DETAILS,
 ) -> HRESULT);
 
 webauthn_call!("WebAuthNPluginAuthenticatorAddCredentials" as

--- a/apps/desktop/desktop_native/windows_plugin_authenticator/src/lib.rs
+++ b/apps/desktop/desktop_native/windows_plugin_authenticator/src/lib.rs
@@ -49,6 +49,12 @@ pub fn register() -> Result<(), String> {
     };
     let response = WebAuthnPlugin::add_authenticator(&options)
         .map_err(|err| format!("Failed to add the authenticator: {err}"))?;
+    // We already registered before, so update the details.
+    if response.is_none() {
+        let update_options = options.into();
+        WebAuthnPlugin::update_authenticator_details(&update_options)
+            .map_err(|err| format!("Failed to update the authenticator: {err}"))?;
+    }
     tracing::debug!("Added the authenticator: {response:?}");
     Ok(())
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-40682](https://bitwarden.atlassian.net/browse/PM-40682)

## 📔 Objective

The Windows plugin doesn't seem to provide a lookup or upsert for plugin details, so we check whether the add method fails due to already existing, and then call update. This avoids unnecessary errors in the electron app, and keeps it up to date every time the app starts.

[PM-40682]: https://bitwarden.atlassian.net/browse/PM-40682?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ