### PR TITLE
chore: Add team-ai-sme as CODEOWNERS for .mcp.json

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -280,3 +280,4 @@ apps/desktop/native-messaging-test-runner/package-lock.json  @bitwarden/team-pla
 .claude/                           @bitwarden/team-ai-sme
 .github/workflows/respond.yml      @bitwarden/team-ai-sme
 .github/workflows/review-code.yml  @bitwarden/team-ai-sme
+.mcp.json                          @bitwarden/team-ai-sme


### PR DESCRIPTION
## 🎟️ Tracking

No Jira ticket — small governance follow-up to #21483, which added `.mcp.json`.

## 📔 Objective

`.mcp.json` at the repo root had no CODEOWNERS entry, so changes to it (which register MCP servers Claude Code will run for this project) could be approved by anyone. This adds `@bitwarden/team-ai-sme` as owner, in line with the existing `.claude/` and Claude-related workflow entries in the same "Claude related files" group.