### PR TITLE
[PM-40682] desktop-autofill: Register Windows native passkey plugin

### DIFF
--- a/apps/desktop/src/autofill/desktop-autofill.preload.ts
+++ b/apps/desktop/src/autofill/desktop-autofill.preload.ts
@@ -20,6 +20,15 @@ export const DesktopAutofillPreload = {
 
   listenerReady: () => ipcRenderer.send("autofill.listenerReady"),
 
+  /**
+   * Signals the main process whether native credential sync is enabled. The main process only
+   * registers the native OS credential provider and starts the autofill IPC server once this is
+   * called with `true`, so the flag-gating decision stays in the renderer where the feature flag
+   * is evaluated. Resolves to whether native autofill is running in the main process.
+   */
+  setEnabled: (enabled: boolean): Promise<boolean> =>
+    ipcRenderer.invoke(AutofillIpcChannelControl.SetEnabled, enabled),
+
   listenCancelRequest: makeListener(AutofillIpcChannelIncoming.CancelRequest),
 
   listenLockStatus: makeListener(

--- a/apps/desktop/src/autofill/main/main-desktop-autofill.service.spec.ts
+++ b/apps/desktop/src/autofill/main/main-desktop-autofill.service.spec.ts
@@ -1,10 +1,11 @@
-import { BrowserWindow } from "electron";
+import { BrowserWindow, ipcMain } from "electron";
 import { mock, MockProxy } from "jest-mock-extended";
 
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { autofill } from "@bitwarden/desktop-napi";
 
 import { WindowMain } from "../../main/window.main";
+import { AutofillIpcChannelControl } from "../models/autofill-ipc-channels";
 
 import { DesktopAutofillMain } from "./main-desktop-autofill.service";
 
@@ -13,13 +14,23 @@ import AutofillIpcServer = autofill.AutofillIpcServer;
 jest.mock("electron", () => ({
   ipcMain: {
     on: jest.fn(),
+    handle: jest.fn(),
     removeAllListeners: jest.fn(),
+    listenerCount: jest.fn().mockReturnValue(0),
   },
 }));
 
-// The napi native binding can't load in jest; only the `autofill` namespace shape is needed.
+// The napi native binding can't load in jest; only the shape used by the service is needed.
 jest.mock("@bitwarden/desktop-napi", () => ({
-  autofill: {},
+  autofill: {
+    AutofillIpcServer: {
+      listen: jest.fn(),
+      prototype: {},
+    },
+  },
+  passkey_authenticator: {
+    register: jest.fn(),
+  },
 }));
 
 describe("DesktopAutofillMain", () => {
@@ -33,6 +44,7 @@ describe("DesktopAutofillMain", () => {
     (service as any).doWindowHandleQuery(error, clientId, sequenceNumber, null);
 
   beforeEach(() => {
+    jest.clearAllMocks();
     logService = mock<LogService>();
     windowMain = mock<WindowMain>();
     ipcServer = mock<AutofillIpcServer>();
@@ -40,6 +52,58 @@ describe("DesktopAutofillMain", () => {
     service = new DesktopAutofillMain(logService, windowMain);
     // `ipcServer` is only assigned inside `listenIpc()`; plant the mock directly.
     (service as any).ipcServer = ipcServer;
+  });
+
+  describe("native autofill gating", () => {
+    // Captures the SetEnabled handler registered by init() so tests can drive it directly.
+    const getSetEnabledHandler = () => {
+      const call = (ipcMain.handle as jest.Mock).mock.calls.find(
+        ([channel]) => channel === AutofillIpcChannelControl.SetEnabled,
+      );
+      return call?.[1] as (event: unknown, enabled: boolean) => Promise<boolean>;
+    };
+
+    beforeEach(() => {
+      // `enable()` plants a fresh server; start each test un-enabled.
+      (service as any).ipcServer = undefined;
+      (AutofillIpcServer.listen as jest.Mock).mockResolvedValue(ipcServer);
+    });
+
+    it("registers the SetEnabled handler on init without starting the IPC server", () => {
+      service.init();
+
+      expect(getSetEnabledHandler()).toBeDefined();
+      expect(AutofillIpcServer.listen).not.toHaveBeenCalled();
+    });
+
+    it("starts the IPC server and reports running when enabled", async () => {
+      service.init();
+
+      const started = await getSetEnabledHandler()(null, true);
+
+      expect(started).toBe(true);
+      expect(AutofillIpcServer.listen).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not start the IPC server twice when enabled repeatedly", async () => {
+      service.init();
+      const handler = getSetEnabledHandler();
+
+      await handler(null, true);
+      const secondResult = await handler(null, true);
+
+      expect(secondResult).toBe(true);
+      expect(AutofillIpcServer.listen).toHaveBeenCalledTimes(1);
+    });
+
+    it("reports not running when disabled before ever being enabled", async () => {
+      service.init();
+
+      const started = await getSetEnabledHandler()(null, false);
+
+      expect(started).toBe(false);
+      expect(AutofillIpcServer.listen).not.toHaveBeenCalled();
+    });
   });
 
   describe("handleWindowHandleQuery", () => {

--- a/apps/desktop/src/autofill/main/main-desktop-autofill.service.ts
+++ b/apps/desktop/src/autofill/main/main-desktop-autofill.service.ts
@@ -44,6 +44,7 @@ export class DesktopAutofillMain {
   private ipcServer?: AutofillIpcServer;
   private messageBuffer: BufferedMessage[] = [];
   private listenerReady = false;
+  private enabled = false;
   private completionCallbacks: Map<string, CompletionCallback<any>> = new Map();
 
   constructor(
@@ -80,7 +81,34 @@ export class DesktopAutofillMain {
     this.messageBuffer = [];
   }
 
-  async init() {
+  /**
+   * Registers the control handler that waits for the renderer to signal whether native credential
+   * sync is enabled via the {@link AutofillIpcChannelControl.SetEnabled} channel.
+   */
+  init() {
+    ipcMain.handle(
+      AutofillIpcChannelControl.SetEnabled,
+      (_event, enabled: boolean): Promise<boolean> => {
+        if (!enabled) {
+          return Promise.resolve(this.enabled);
+        }
+        return this.enable();
+      },
+    );
+  }
+
+  /**
+   * Registers the native OS credential provider and starts the autofill IPC server. Idempotent:
+   * subsequent calls are ignored while already enabled.
+   *
+   * @returns whether native autofill is running after this call.
+   */
+  private async enable(): Promise<boolean> {
+    if (this.enabled) {
+      this.logService.info("Native autofill is already enabled, ignoring enable request");
+      return true;
+    }
+
     ipcMain.handle(
       AutofillIpcChannelControl.RunCommand,
       <C extends AutofillCommandDefinition>(
@@ -145,6 +173,9 @@ export class DesktopAutofillMain {
       const { clientId, sequenceNumber, error } = data;
       this.ipcServer?.completeError(clientId, sequenceNumber, String(error));
     });
+
+    this.enabled = true;
+    return true;
   }
 
   /**
@@ -266,7 +297,10 @@ export class DesktopAutofillMain {
       this.logService.error(`Error running autofill command '${command.command}':`, e);
 
       if (e instanceof Error) {
-        return { type: "error", error: e.stack ?? String(e) } as RunCommandResult<C>;
+        return {
+          type: "error",
+          error: e.stack ?? String(e),
+        } as RunCommandResult<C>;
       }
 
       return { type: "error", error: String(e) } as RunCommandResult<C>;

--- a/apps/desktop/src/autofill/main/main-desktop-autofill.service.ts
+++ b/apps/desktop/src/autofill/main/main-desktop-autofill.service.ts
@@ -1,7 +1,7 @@
 import { ipcMain } from "electron";
 
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
-import { autofill } from "@bitwarden/desktop-napi";
+import { autofill, passkey_authenticator } from "@bitwarden/desktop-napi";
 
 import { WindowMain } from "../../main/window.main";
 import { AutofillCommandDefinition } from "../models/autofill-command";
@@ -107,6 +107,16 @@ export class DesktopAutofillMain {
     if (this.enabled) {
       this.logService.info("Native autofill is already enabled, ignoring enable request");
       return true;
+    }
+
+    if (process.platform === "win32") {
+      try {
+        passkey_authenticator.register();
+      } catch (err) {
+        this.logService.error("Failed to register windows passkey plugin:", err);
+        this.enabled = false;
+        return false;
+      }
     }
 
     ipcMain.handle(

--- a/apps/desktop/src/autofill/models/autofill-ipc-channels.ts
+++ b/apps/desktop/src/autofill/models/autofill-ipc-channels.ts
@@ -94,4 +94,5 @@ export type AutofillIpcResponse<K extends AutofillIpcChannelIncoming> =
 export const AutofillIpcChannelControl = Object.freeze({
   ListenerReady: "autofill.listenerReady",
   RunCommand: "autofill.runCommand",
+  SetEnabled: "autofill.setEnabled",
 } as const);

--- a/apps/desktop/src/autofill/services/desktop-autofill.service.ts
+++ b/apps/desktop/src/autofill/services/desktop-autofill.service.ts
@@ -59,7 +59,8 @@ import type { NativeWindowObject } from "./desktop-fido2-user-interface.service"
 export class DesktopAutofillService implements OnDestroy {
   private destroy$ = new Subject<void>();
   private registrationRequest?: PasskeyRegistrationRequest;
-  private featureFlag?: typeof FeatureFlag.MacOsNativeCredentialSync;
+  private featureFlag?:
+    typeof FeatureFlag.MacOsNativeCredentialSync | typeof FeatureFlag.WindowsNativeCredentialSync;
   private isEnabled: boolean = false;
   private readonly inFlightRequests: Record<string, AbortController> = {};
 
@@ -75,6 +76,8 @@ export class DesktopAutofillService implements OnDestroy {
     const deviceType = platformUtilsService.getDevice();
     if (deviceType === DeviceType.MacOsDesktop) {
       this.featureFlag = FeatureFlag.MacOsNativeCredentialSync;
+    } else if (deviceType === DeviceType.WindowsDesktop) {
+      this.featureFlag = FeatureFlag.WindowsNativeCredentialSync;
     }
   }
 

--- a/apps/desktop/src/autofill/services/desktop-autofill.service.ts
+++ b/apps/desktop/src/autofill/services/desktop-autofill.service.ts
@@ -90,6 +90,18 @@ export class DesktopAutofillService implements OnDestroy {
       return;
     }
 
+    // Signal the main process to register the native OS credential provider and start the autofill
+    // IPC server. Gated here because the main process cannot evaluate the feature flag itself.
+    const ipcServerStarted = await ipc.autofill.desktopAutofill.setEnabled(true);
+    if (!ipcServerStarted) {
+      this.logService.error(
+        "[DesktopAutofillService]",
+        "Main process failed to start native autofill; aborting init",
+      );
+      this.isEnabled = false;
+      return;
+    }
+
     this.configService
       .getFeatureFlag$(this.featureFlag)
       .pipe(

--- a/libs/common/src/enums/feature-flag.enum.ts
+++ b/libs/common/src/enums/feature-flag.enum.ts
@@ -31,14 +31,15 @@ export enum FeatureFlag {
 
   /* Autofill */
   UseUndeterminedCipherScenarioTriggeringLogic = "undetermined-cipher-scenario-logic",
-  MacOsNativeCredentialSync = "macos-native-credential-sync",
   EnableAutofillTriage = "enable-autofill-triage",
   FillAssistTargetingRules = "fill-assist-targeting-rules",
   DefaultPasswordManagerPrompt = "pm-39071-default-password-manager-prompt",
 
   /* Desktop Native */
+  MacOsNativeCredentialSync = "macos-native-credential-sync",
   WindowsDesktopAutotype = "windows-desktop-autotype",
   WindowsDesktopAutotypeGA = "windows-desktop-autotype-ga",
+  WindowsNativeCredentialSync = "windows-native-credential-sync",
   SSHAgentV2 = "ssh-agent-v2",
   SSHecdsa = "ssh-ecdsa",
 
@@ -149,14 +150,15 @@ export const DefaultFeatureFlagValue = {
   /* Autofill */
   [FeatureFlag.FillAssistTargetingRules]: FALSE,
   [FeatureFlag.UseUndeterminedCipherScenarioTriggeringLogic]: FALSE,
-  [FeatureFlag.MacOsNativeCredentialSync]: FALSE,
   [FeatureFlag.EnableAutofillTriage]: FALSE,
   [FeatureFlag.DefaultPasswordManagerPrompt]: FALSE,
   [FeatureFlag.PM31039ItemActionInExtension]: FALSE,
 
   /* Desktop Native */
+  [FeatureFlag.MacOsNativeCredentialSync]: FALSE,
   [FeatureFlag.WindowsDesktopAutotype]: FALSE,
   [FeatureFlag.WindowsDesktopAutotypeGA]: FALSE,
+  [FeatureFlag.WindowsNativeCredentialSync]: FALSE,
   [FeatureFlag.SSHAgentV2]: FALSE,
   [FeatureFlag.SSHecdsa]: FALSE,
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-40682](https://bitwarden.atlassian.net/browse/PM-40682)

## 📔 Objective

Adds a feature flag for the Windows native passkey plugin and calls the Windows OS API to register Bitwarden as a passkey plugin behind the new feature flag.

[PM-40682]: https://bitwarden.atlassian.net/browse/PM-40682?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ