### PR TITLE
[PM-40726] Add filter-as-you-type to autofill inline menu

### DIFF
--- a/apps/browser/src/autofill/background/abstractions/overlay.background.ts
+++ b/apps/browser/src/autofill/background/abstractions/overlay.background.ts
@@ -132,6 +132,10 @@ export type CloseInlineMenuMessage = {
   overlayElement?: string;
 };
 
+export type FilterInlineMenuMessage = {
+  filterValue?: string;
+};
+
 export type ToggleInlineMenuHiddenMessage = {
   isInlineMenuHidden?: boolean;
   setTransparentInlineMenu?: boolean;
@@ -161,6 +165,7 @@ export type OverlayBackgroundExtensionMessage = {
   iframeTargetedFields?: { selector: string; fieldType: string; formCategory?: string }[];
 } & OverlayAddNewItemMessage &
   CloseInlineMenuMessage &
+  FilterInlineMenuMessage &
   ToggleInlineMenuHiddenMessage &
   UpdateInlineMenuVisibilityMessage;
 
@@ -254,6 +259,7 @@ export type OverlayBackgroundExtensionMessageHandlers = {
   getInlineMenuCardsVisibility: () => void;
   getInlineMenuIdentitiesVisibility: () => void;
   closeAutofillInlineMenu: ({ message, sender }: BackgroundOnMessageHandlerParams) => void;
+  filterAutofillInlineMenu: ({ message, sender }: BackgroundOnMessageHandlerParams) => void;
   checkAutofillInlineMenuFocused: ({ sender }: BackgroundSenderParam) => void;
   focusAutofillInlineMenuList: () => void;
   getAutofillInlineMenuPosition: () => InlineMenuPosition;

--- a/apps/browser/src/autofill/background/overlay.background.spec.ts
+++ b/apps/browser/src/autofill/background/overlay.background.spec.ts
@@ -78,6 +78,7 @@ import {
 import { ModifyLoginCipherFormData } from "./abstractions/overlay-notifications.background";
 import {
   FocusedFieldData,
+  InlineMenuCipherData,
   InlineMenuPosition,
   PageDetailsForTab,
   PasswordGenerateRequestSource,
@@ -1028,6 +1029,16 @@ describe("OverlayBackground", () => {
           ["inline-menu-cipher-1", loginCipher1],
         ]),
       );
+    });
+
+    it("resets any active inline menu filter value when refreshing the overlay ciphers", async () => {
+      getTabFromCurrentWindowIdSpy.mockResolvedValueOnce(tab);
+      overlayBackground["inlineMenuFilterValue"] = "stale-filter";
+
+      await overlayBackground.updateOverlayCiphers();
+      await flushPromises();
+
+      expect(overlayBackground["inlineMenuFilterValue"]).toBeUndefined();
     });
 
     it("queries only login ciphers when not updating all cipher types", async () => {
@@ -2166,7 +2177,318 @@ describe("OverlayBackground", () => {
       });
     });
 
+    describe("checkGetInlineMenuCipherData correct return count according to filter", () => {
+      let focusedFieldData: FocusedFieldData;
+
+      beforeEach(() => {
+        focusedFieldData = createFocusedFieldDataMock();
+        sendMockExtensionMessage(
+          { command: "updateFocusedFieldData", focusedFieldData },
+          mock<chrome.runtime.MessageSender>({ tab: { id: 2 }, frameId: 0 }),
+        );
+      });
+
+      const userMap = new Map([
+        [
+          "inline-menu-cipher-1",
+          mock<CipherView>({
+            name: "Example",
+            type: CipherType.Login,
+            login: {
+              username: "username1",
+              password: "password1",
+              uri: "https://example.com",
+            },
+          }),
+        ],
+        [
+          "inline-menu-cipher-2",
+          mock<CipherView>({
+            name: "Company 4",
+            type: CipherType.Login,
+            login: {
+              username: "Jamie1",
+              password: "smith",
+              uri: "https://company.eu",
+            },
+          }),
+        ],
+      ]);
+
+      const mapCases = (expectedLength: number, values: string[]): [string, number][] =>
+        values.map((v) => [v, expectedLength]);
+
+      const testCases = [
+        mapCases(2, ["1", "m", "M", "am", undefined, null, ""]),
+        mapCases(1, [
+          "username",
+          "userna",
+          "Username",
+          "Userna",
+          "usernAme",
+          "usernA",
+          "Example",
+          " ",
+          "y 4",
+        ]),
+        mapCases(0, ["asd", "nomatch"]),
+      ].flatMap((v) => v);
+
+      test.each(testCases)(
+        "returns true if the overlay login ciphers are filtered by %s correctly (%i hits)",
+        async (filterInput, expectedLength) => {
+          overlayBackground["inlineMenuCiphers"] = userMap;
+          overlayBackground["inlineMenuFilterValue"] = filterInput;
+          const entries = await overlayBackground["getInlineMenuCipherData"]();
+          expect(entries).toHaveLength(expectedLength);
+        },
+      );
+
+      it("tracks the total cipher count separately from the filtered count", async () => {
+        overlayBackground["inlineMenuCiphers"] = userMap;
+        overlayBackground["inlineMenuFilterValue"] = "username";
+
+        const entries = await overlayBackground["getInlineMenuCipherData"]();
+
+        expect(entries).toHaveLength(1);
+        expect(overlayBackground["currentInlineMenuCiphersCount"]).toBe(2);
+        expect(overlayBackground["filteredInlineMenuCiphersCount"]).toBe(1);
+      });
+    });
+
+    describe("getInlineMenuCipherData filtering across cipher types", () => {
+      const buildEntries = async (
+        filterValue: string,
+        fillType: CipherType,
+        ciphers: Map<string, CipherView>,
+      ) => {
+        sendMockExtensionMessage(
+          {
+            command: "updateFocusedFieldData",
+            focusedFieldData: createFocusedFieldDataMock({ inlineMenuFillType: fillType }),
+          },
+          mock<chrome.runtime.MessageSender>({ tab: { id: 2 }, frameId: 0 }),
+        );
+        overlayBackground["inlineMenuCiphers"] = ciphers;
+        overlayBackground["inlineMenuFilterValue"] = filterValue;
+        return overlayBackground["getInlineMenuCipherData"]();
+      };
+
+      const loginCiphers = new Map([
+        [
+          "inline-menu-cipher-1",
+          mock<CipherView>({
+            name: "Acme",
+            type: CipherType.Login,
+            login: { username: "user", uri: "https://example.com", password: "pw" },
+          }),
+        ],
+      ]);
+
+      const cardCiphers = new Map([
+        [
+          "inline-menu-cipher-1",
+          mock<CipherView>({
+            name: "Personal card",
+            type: CipherType.Card,
+            card: { subTitle: "Visa, *4242" },
+          }),
+        ],
+      ]);
+
+      const identityCiphers = new Map([
+        [
+          "inline-menu-cipher-1",
+          mock<CipherView>({
+            name: "Home",
+            type: CipherType.Identity,
+            identity: { firstName: "Jane", lastName: "Doe" },
+          }),
+        ],
+      ]);
+
+      const accentedLoginCiphers = new Map([
+        [
+          "inline-menu-cipher-1",
+          mock<CipherView>({
+            name: "José",
+            type: CipherType.Login,
+            login: { username: "user", uri: "https://example.com", password: "pw" },
+          }),
+        ],
+      ]);
+
+      const plainNameLoginCiphers = new Map([
+        [
+          "inline-menu-cipher-1",
+          mock<CipherView>({
+            name: "Jose",
+            type: CipherType.Login,
+            login: { username: "user", uri: "https://example.com", password: "pw" },
+          }),
+        ],
+      ]);
+
+      it("matches a login by its URI", async () => {
+        expect(await buildEntries("example.com", CipherType.Login, loginCiphers)).toHaveLength(1);
+      });
+
+      it("matches a card by its subtitle (brand and last four)", async () => {
+        expect(await buildEntries("visa", CipherType.Card, cardCiphers)).toHaveLength(1);
+        expect(await buildEntries("4242", CipherType.Card, cardCiphers)).toHaveLength(1);
+        expect(await buildEntries("mastercard", CipherType.Card, cardCiphers)).toHaveLength(0);
+      });
+
+      it("matches an identity by its full name", async () => {
+        expect(await buildEntries("jane", CipherType.Identity, identityCiphers)).toHaveLength(1);
+        expect(await buildEntries("doe", CipherType.Identity, identityCiphers)).toHaveLength(1);
+      });
+
+      it("matches ignoring accents/diacritics in both directions", async () => {
+        // plain query against accented cipher data
+        expect(await buildEntries("jose", CipherType.Login, accentedLoginCiphers)).toHaveLength(1);
+        // accented query against plain cipher data
+        expect(await buildEntries("josé", CipherType.Login, plainNameLoginCiphers)).toHaveLength(1);
+      });
+    });
+
+    describe("account creation inline menu ciphers filtering", () => {
+      const accountCreationLoginCiphers = new Map([
+        [
+          "inline-menu-cipher-1",
+          mock<CipherView>({
+            name: "Example",
+            type: CipherType.Login,
+            login: { username: "user", password: "pw", uri: "https://example.com" },
+          }),
+        ],
+      ]);
+
+      beforeEach(() => {
+        sendMockExtensionMessage(
+          {
+            command: "updateFocusedFieldData",
+            focusedFieldData: createFocusedFieldDataMock({
+              inlineMenuFillType: InlineMenuFillTypes.AccountCreationUsername,
+            }),
+          },
+          mock<chrome.runtime.MessageSender>({ tab: { id: 2 }, frameId: 0 }),
+        );
+        overlayBackground["inlineMenuCiphers"] = accountCreationLoginCiphers;
+      });
+
+      it("filters account creation login ciphers by the active filter value", async () => {
+        overlayBackground["inlineMenuFilterValue"] = "example";
+        expect(await overlayBackground["getInlineMenuCipherData"]()).toHaveLength(1);
+
+        overlayBackground["inlineMenuFilterValue"] = "nomatch";
+        expect(await overlayBackground["getInlineMenuCipherData"]()).toHaveLength(0);
+      });
+    });
+
+    describe("filterAutofillInlineMenu message handler", () => {
+      let sender: chrome.runtime.MessageSender;
+      let updateListSpy: jest.SpyInstance;
+      let toggleHiddenSpy: jest.SpyInstance;
+
+      beforeEach(() => {
+        sender = mock<chrome.runtime.MessageSender>({ tab: { id: 1 }, frameId: 0 });
+        overlayBackground["focusedFieldData"] = createFocusedFieldDataMock({
+          tabId: 1,
+          frameId: 0,
+        });
+        updateListSpy = jest
+          .spyOn(overlayBackground as any, "updateInlineMenuListCiphers")
+          .mockResolvedValue(undefined);
+        toggleHiddenSpy = jest
+          .spyOn(overlayBackground as any, "toggleInlineMenuHidden")
+          .mockResolvedValue(undefined);
+      });
+
+      it("stores the filter value and updates the inline menu list without rebuilding the cipher data", async () => {
+        sendMockExtensionMessage(
+          { command: "filterAutofillInlineMenu", filterValue: "abc" },
+          sender,
+        );
+        await flushPromises();
+
+        expect(overlayBackground["inlineMenuFilterValue"]).toBe("abc");
+        expect(updateListSpy).toHaveBeenCalledWith(sender.tab, false);
+      });
+
+      it("shows the inline menu list when the filter returns matching ciphers", async () => {
+        overlayBackground["filteredInlineMenuCiphersCount"] = 2;
+
+        sendMockExtensionMessage({ command: "filterAutofillInlineMenu", filterValue: "a" }, sender);
+        await flushPromises();
+
+        expect(toggleHiddenSpy).toHaveBeenCalledWith({ isInlineMenuHidden: false }, sender);
+      });
+
+      it("hides the inline menu list when the filter returns no matching ciphers", async () => {
+        overlayBackground["filteredInlineMenuCiphersCount"] = 0;
+
+        sendMockExtensionMessage(
+          { command: "filterAutofillInlineMenu", filterValue: "nomatch" },
+          sender,
+        );
+        await flushPromises();
+
+        expect(toggleHiddenSpy).toHaveBeenCalledWith({ isInlineMenuHidden: true }, sender);
+      });
+    });
+
+    describe("filtering reuses the built cipher data instead of rebuilding", () => {
+      let sender: chrome.runtime.MessageSender;
+      let buildSpy: jest.SpyInstance;
+      let filteredSpy: jest.SpyInstance;
+
+      beforeEach(() => {
+        sender = mock<chrome.runtime.MessageSender>({ tab: { id: 1 }, frameId: 0 });
+        overlayBackground["focusedFieldData"] = createFocusedFieldDataMock({
+          tabId: 1,
+          frameId: 0,
+        });
+        overlayBackground["builtInlineMenuCipherData"] = [
+          mock<InlineMenuCipherData>({
+            name: "Example",
+            login: { username: "user", passkey: null },
+          }),
+        ];
+        jest.spyOn(overlayBackground as any, "toggleInlineMenuHidden").mockResolvedValue(undefined);
+        jest.spyOn(overlayBackground as any, "checkFocusedFieldHasValue").mockResolvedValue(true);
+        buildSpy = jest.spyOn(overlayBackground as any, "buildInlineMenuCipherData");
+        filteredSpy = jest.spyOn(overlayBackground as any, "getFilteredInlineMenuCipherData");
+      });
+
+      it("does not rebuild the cipher data while filtering", async () => {
+        sendMockExtensionMessage(
+          { command: "filterAutofillInlineMenu", filterValue: "exa" },
+          sender,
+        );
+        await flushPromises();
+
+        expect(filteredSpy).toHaveBeenCalled();
+        expect(buildSpy).not.toHaveBeenCalled();
+      });
+    });
+
     describe("updateFocusedFieldData message handler", () => {
+      it("resets the inline menu filter value so a newly focused field is not shown a stale filtered list", async () => {
+        overlayBackground["inlineMenuFilterValue"] = "stale-filter";
+        const tab = createChromeTabMock({ id: 2 });
+        const sender = mock<chrome.runtime.MessageSender>({ tab, frameId: 100 });
+        const focusedFieldData = createFocusedFieldDataMock({
+          tabId: tab.id,
+          frameId: sender.frameId,
+        });
+
+        sendMockExtensionMessage({ command: "updateFocusedFieldData", focusedFieldData }, sender);
+        await flushPromises();
+
+        expect(overlayBackground["inlineMenuFilterValue"]).toBeUndefined();
+      });
+
       it("sends a message to the sender frame to unset the most recently focused field data when the currently focused field does not belong to the sender", async () => {
         const tab = createChromeTabMock({ id: 2 });
         const firstSender = mock<chrome.runtime.MessageSender>({ tab, frameId: 100 });

--- a/apps/browser/src/autofill/background/overlay.background.ts
+++ b/apps/browser/src/autofill/background/overlay.background.ts
@@ -94,6 +94,7 @@ import { ModifyLoginCipherFormData } from "./abstractions/overlay-notifications.
 import {
   BuildCipherDataParams,
   CloseInlineMenuMessage,
+  FilterInlineMenuMessage,
   CurrentAddNewItemData,
   FocusedFieldData,
   InlineMenuButtonPortMessageHandlers,
@@ -151,8 +152,11 @@ export class OverlayBackground implements OverlayBackgroundInterface {
   private inlineMenuFido2Credentials: Set<string> = new Set();
   private inlineMenuPageTranslations: Record<string, string> | null = null;
   private inlineMenuPosition: InlineMenuPosition = {};
+  private inlineMenuFilterValue: string | undefined;
+  private builtInlineMenuCipherData: InlineMenuCipherData[] = [];
   private cardAndIdentityCiphers: Set<CipherView> | null = null;
   private currentInlineMenuCiphersCount: number = 0;
+  private filteredInlineMenuCiphersCount: number = 0;
   private currentAddNewItemData: CurrentAddNewItemData | null = null;
   private focusedFieldData: FocusedFieldData | null = null;
   private allFieldData: AutofillField[] = [];
@@ -191,6 +195,8 @@ export class OverlayBackground implements OverlayBackgroundInterface {
     getInlineMenuIdentitiesVisibility: () => this.getInlineMenuIdentitiesVisibility(),
     closeAutofillInlineMenu: ({ message, sender }) =>
       void this.withSenderTab(sender, () => this.closeInlineMenu(sender, message)),
+    filterAutofillInlineMenu: ({ message, sender }) =>
+      void this.withSenderTab(sender, () => this.filterInlineMenu(sender, message)),
     checkAutofillInlineMenuFocused: ({ sender }) =>
       void this.withSenderTab(sender, () => this.checkInlineMenuFocused(sender)),
     focusAutofillInlineMenuList: () => this.focusInlineMenuList(),
@@ -503,6 +509,10 @@ export class OverlayBackground implements OverlayBackgroundInterface {
       this.storeInlineMenuFido2Credentials$.next(tabId);
     }
 
+    // Clear any active filter so a full refresh of the ciphers starts unfiltered; the filter is
+    // only meant to live for the duration of an active typing session on the focused field.
+    this.inlineMenuFilterValue = undefined;
+
     const ciphersViews = await this.getCipherViews(currentTab, updateAllCipherTypes);
     for (let cipherIndex = 0; cipherIndex < ciphersViews.length; cipherIndex++) {
       this.inlineMenuCiphers.set(`inline-menu-cipher-${cipherIndex}`, ciphersViews[cipherIndex]);
@@ -519,9 +529,14 @@ export class OverlayBackground implements OverlayBackgroundInterface {
    * Updates the inline menu list's ciphers and sends the updated list to the inline menu list iframe.
    *
    * @param tab - The current tab
+   * @param refreshCipherData - Rebuilds the cipher data from the vault ciphers when true. When
+   * false, the previously built cipher data is reused and only the active filter is re-applied,
+   * avoiding an expensive rebuild on each keystroke while filtering.
    */
-  private async updateInlineMenuListCiphers(tab: chrome.tabs.Tab) {
-    const ciphers = await this.getInlineMenuCipherData();
+  private async updateInlineMenuListCiphers(tab: chrome.tabs.Tab, refreshCipherData = true) {
+    const ciphers = refreshCipherData
+      ? await this.getInlineMenuCipherData()
+      : this.getFilteredInlineMenuCipherData();
     this.postMessageToPort(this.inlineMenuListPort, {
       command: "updateAutofillInlineMenuListCiphers",
       ciphers,
@@ -605,35 +620,54 @@ export class OverlayBackground implements OverlayBackgroundInterface {
   }
 
   /**
-   * Strips out unnecessary data from the ciphers and returns an array of
-   * objects that contain the cipher data needed for the inline menu list.
+   * Rebuilds the inline menu cipher data from the vault ciphers, caches the unfiltered result,
+   * and returns the data with the active filter applied. This is the expensive path and should
+   * only run when the underlying ciphers or the focused field change - not on every keystroke.
    */
   private async getInlineMenuCipherData(): Promise<InlineMenuCipherData[]> {
+    this.builtInlineMenuCipherData = await this.buildInlineMenuCipherData();
+    this.currentInlineMenuCiphersCount = this.builtInlineMenuCipherData.length;
+    return this.getFilteredInlineMenuCipherData();
+  }
+
+  /**
+   * Strips out unnecessary data from the ciphers and returns an unfiltered array of objects that
+   * contain the cipher data needed for the inline menu list.
+   */
+  private async buildInlineMenuCipherData(): Promise<InlineMenuCipherData[]> {
     const [showFavicons, env] = await Promise.all([
       firstValueFrom(this.domainSettingsService.showFavicons$),
       firstValueFrom(this.environmentService.environment$),
     ]);
     const iconsServerUrl: string | null = env.getIconsUrl() ?? null;
     const inlineMenuCiphersArray = Array.from(this.inlineMenuCiphers);
-    let inlineMenuCipherData: InlineMenuCipherData[];
-    this.showPasskeysLabelsWithinInlineMenu = false;
 
     if (this.shouldShowInlineMenuAccountCreation()) {
-      inlineMenuCipherData = await this.buildInlineMenuAccountCreationCiphers(
+      return this.buildInlineMenuAccountCreationCiphers(
         inlineMenuCiphersArray,
         true,
         iconsServerUrl,
       );
-    } else {
-      inlineMenuCipherData = await this.buildInlineMenuCiphers(
-        inlineMenuCiphersArray,
-        showFavicons,
-        iconsServerUrl,
-      );
     }
 
-    this.currentInlineMenuCiphersCount = inlineMenuCipherData.length;
-    return inlineMenuCipherData;
+    return this.buildInlineMenuCiphers(inlineMenuCiphersArray, showFavicons, iconsServerUrl);
+  }
+
+  /**
+   * Applies the active filter to the previously built cipher data, updating the filtered cipher
+   * count and the passkey labels flag to reflect what is actually shown. Does not rebuild the
+   * cipher data, so it is cheap enough to run on each keystroke while filtering.
+   */
+  private getFilteredInlineMenuCipherData(): InlineMenuCipherData[] {
+    const filteredInlineMenuCipherData = this.filterInlineMenuCipherData(
+      this.builtInlineMenuCipherData,
+    );
+    this.filteredInlineMenuCiphersCount = filteredInlineMenuCipherData.length;
+    this.showPasskeysLabelsWithinInlineMenu =
+      filteredInlineMenuCipherData.some((cipherData) => cipherData.login?.passkey != null) &&
+      filteredInlineMenuCipherData.some((cipherData) => cipherData.login?.passkey == null);
+
+    return filteredInlineMenuCipherData;
   }
 
   /**
@@ -767,12 +801,55 @@ export class OverlayBackground implements OverlayBackgroundInterface {
     }
 
     if (passkeyCipherData.length) {
-      this.showPasskeysLabelsWithinInlineMenu =
-        passkeyCipherData.length > 0 && inlineMenuCipherData.length > 0;
       return passkeyCipherData.concat(inlineMenuCipherData);
     }
 
     return inlineMenuCipherData;
+  }
+
+  /**
+   * Filters the provided inline menu entries by the active filter value. Matches against the
+   * user-facing fields of each cipher type (login, card, and identity) so the filter behaves as a
+   * search across whatever items the focused field can offer. Matching is case- and
+   * accent-insensitive.
+   *
+   * @param inlineMenuCipherData - Array of inline menu cipher data to filter
+   */
+  private filterInlineMenuCipherData(inlineMenuCipherData: InlineMenuCipherData[]) {
+    if (!this.inlineMenuFilterValue) {
+      return inlineMenuCipherData;
+    }
+
+    const filterValue = this.normalizeFilterValue(this.inlineMenuFilterValue);
+    return inlineMenuCipherData.filter((cipherData) => {
+      // The URI is not part of the data sent to the inline menu list, so match it against the
+      // source cipher (looked up by id) to avoid sending extra data to the list iframe.
+      const cipherUri = this.inlineMenuCiphers.get(cipherData.id)?.login?.uri;
+      return [
+        cipherData.name,
+        cipherData.login?.username,
+        cipherUri,
+        cipherData.login?.passkey?.userName,
+        cipherData.login?.passkey?.rpName,
+        cipherData.card,
+        cipherData.identity?.fullName,
+        cipherData.identity?.username,
+      ].some((value) => !!value && this.normalizeFilterValue(value).includes(filterValue));
+    });
+  }
+
+  /**
+   * Normalizes a value for filtering by lower-casing it and stripping accents/diacritics. Mirrors
+   * the vault search normalization (`normalizeSearchQuery` in search.service.ts); inlined here to
+   * avoid pulling the search service into the background bundle.
+   *
+   * @param value - The value to normalize
+   */
+  private normalizeFilterValue(value: string) {
+    return value
+      .normalize("NFD")
+      .replace(/[\u0300-\u036f]/g, "")
+      .toLowerCase();
   }
 
   /**
@@ -1671,6 +1748,26 @@ export class OverlayBackground implements OverlayBackgroundInterface {
   }
 
   /**
+   * Filters the autofill inline menu and shows/hides the list if empty.
+   *
+   * @param sender - The sender of the port message
+   * @param filterValue - The current filter value
+   */
+  private async filterInlineMenu(
+    sender: chrome.runtime.MessageSender,
+    { filterValue }: FilterInlineMenuMessage = {},
+  ) {
+    this.inlineMenuFilterValue = filterValue;
+
+    await this.updateInlineMenuListCiphers(sender.tab, false);
+
+    await this.toggleInlineMenuHidden(
+      { isInlineMenuHidden: !this.filteredInlineMenuCiphersCount },
+      sender,
+    );
+  }
+
+  /**
    * Sends a message to the sender tab to trigger a delayed closure of the inline menu.
    * This is used to ensure that we capture click events on the inline menu in the case
    * that some on page programmatic method attempts to force focus redirection.
@@ -2060,6 +2157,10 @@ export class OverlayBackground implements OverlayBackgroundInterface {
     };
     this.allFieldData = allFieldsRect ?? [];
     this.isFieldCurrentlyFocused = true;
+
+    // Reset the inline menu filter when focus moves so a newly focused field is
+    // not shown a list filtered by the previously focused field's value.
+    this.inlineMenuFilterValue = undefined;
 
     if (this.shouldUpdatePasswordGeneratorMenuOnFieldFocus()) {
       this.updateInlineMenuGeneratedPasswordOnFocus(sender.tab).catch((error) =>

--- a/apps/browser/src/autofill/services/autofill-overlay-content.service.spec.ts
+++ b/apps/browser/src/autofill/services/autofill-overlay-content.service.spec.ts
@@ -11,7 +11,6 @@ import { ModifyLoginCipherFormData } from "../background/abstractions/overlay-no
 import AutofillInit from "../content/autofill-init";
 import { AutofillFieldQualifier } from "../enums/autofill-field.enums";
 import {
-  AutofillOverlayElement,
   InlineMenuFillTypes,
   MAX_SUB_FRAME_DEPTH,
   RedirectFocusDirection,
@@ -528,7 +527,7 @@ describe("AutofillOverlayContentService", () => {
           );
         });
 
-        it("Closes the inline menu list and does not re-open the inline menu if the field has a value", async () => {
+        it("Updates the inline menu list if the value of the field has changed", async () => {
           (autofillFieldElement as HTMLInputElement).value = "test";
 
           await autofillOverlayContentService.setupOverlayListeners(
@@ -539,10 +538,13 @@ describe("AutofillOverlayContentService", () => {
           autofillFieldElement.dispatchEvent(new Event("input"));
           await flushPromises();
 
-          expect(sendExtensionMessageSpy).toHaveBeenCalledWith("closeAutofillInlineMenu", {
-            overlayElement: AutofillOverlayElement.List,
-            forceCloseInlineMenu: true,
+          expect(sendExtensionMessageSpy).toHaveBeenCalledWith("filterAutofillInlineMenu", {
+            filterValue: "test",
           });
+          expect(sendExtensionMessageSpy).toHaveBeenCalledWith(
+            "updateFocusedFieldData",
+            expect.anything(),
+          );
           expect(sendExtensionMessageSpy).not.toHaveBeenCalledWith("openAutofillInlineMenu");
         });
 
@@ -556,6 +558,7 @@ describe("AutofillOverlayContentService", () => {
           await flushPromises();
 
           expect(sendExtensionMessageSpy).toHaveBeenCalledWith("openAutofillInlineMenu");
+          expect(sendExtensionMessageSpy).not.toHaveBeenCalledWith("updateFocusedFieldData");
         });
 
         describe("input changes on a field filled by a card cipher", () => {

--- a/apps/browser/src/autofill/services/autofill-overlay-content.service.ts
+++ b/apps/browser/src/autofill/services/autofill-overlay-content.service.ts
@@ -23,7 +23,6 @@ import {
 import { AutofillExtensionMessage } from "../content/abstractions/autofill-init";
 import { AutofillFieldQualifier, AutofillFieldQualifierType } from "../enums/autofill-field.enums";
 import {
-  AutofillOverlayElement,
   InlineMenuAccountCreationFieldType,
   InlineMenuFillTypes,
   MAX_SUB_FRAME_DEPTH,
@@ -867,9 +866,8 @@ export class AutofillOverlayContentService implements AutofillOverlayContentServ
       return;
     }
 
-    await this.sendExtensionMessage("closeAutofillInlineMenu", {
-      overlayElement: AutofillOverlayElement.List,
-      forceCloseInlineMenu: true,
+    await this.sendExtensionMessage("filterAutofillInlineMenu", {
+      filterValue: formFieldElement.value,
     });
 
     if (!formFieldElement?.value) {


### PR DESCRIPTION
This pull request implements the same filter-as-you-type behavior for the autofill inline menu as #20543. The two take different approaches; the main differences are below.

**Where filtering is applied**
- This pull request builds the full inline-menu cipher list once, caches it, and applies the filter to the cached built data on each keystroke.
- #20543 filters the source cipher list at the start of `getInlineMenuCipherData` and rebuilds the matching entries on each keystroke (including regenerating TOTP codes via `buildCipherData`).

**Cipher count tracking**
- This pull request keeps two counts: `currentInlineMenuCiphersCount` (total built) and `filteredInlineMenuCiphersCount` (after filtering). `checkIsInlineMenuCiphersPopulated` reads the total; the show/hide decision reads the filtered count.
- #20543 sets `currentInlineMenuCiphersCount` to the filtered length and reads that value both for the show/hide decision and in `checkIsInlineMenuCiphersPopulated`.

**Matched fields**
- This pull request matches: cipher name, login username, login URI, passkey userName, passkey rpName, card subtitle (brand + last four), identity full name, identity username.
- #20543 matches: cipher name, login username, card number, identity full name.

**Card matching**
- This pull request matches the card subtitle as shown in the list.
- #20543 matches the full card number.

**Text normalization**
- This pull request normalizes the query and candidate values with Unicode NFD + combining-mark stripping in addition to lowercasing (mirroring `normalizeSearchQuery` from the vault search service).
- #20543 lowercases the query and candidate values.

**Filter state and lifecycle**
- This pull request stores the active filter value as instance state and clears it on focus change and on a full cipher refresh (`handleOverlayCiphersUpdate`).
- #20543 passes the filter value as a message/method parameter and does not store it.

**Empty-result handling**
- This pull request hides the list via `toggleInlineMenuHidden` when the filtered count is zero.
- #20543 closes the list via `closeInlineMenu` with `forceCloseInlineMenu` when the count is zero and a filter is set.

**Passkey section labels**
- This pull request recomputes `showPasskeysLabelsWithinInlineMenu` from the filtered result set.
- #20543 sets it while building from the already-filtered source list.

**Content-script input handling**
- This pull request sends `filterAutofillInlineMenu` with the field value and, when the field is empty, also sends `openAutofillInlineMenu`.
- #20543 sends `filterInlineMenuCiphers` with the current field value (empty string when the field is empty).

**Tests**
- This pull request adds background tests for filter matching across login/card/identity ciphers, URI and diacritic matching, the total-vs-filtered count, reuse of the built data while filtering, account-creation filtering, and the filter reset on focus/refresh, alongside content-service tests.
- #20543 updates the content-service tests for the new message.