### PR TITLE
[PM-40766] Handle punycode-unicode domain matching for "Host" URI matching strategy

### DIFF
--- a/libs/common/src/platform/misc/utils.spec.ts
+++ b/libs/common/src/platform/misc/utils.spec.ts
@@ -221,6 +221,42 @@ describe("Utils Service", () => {
       expect(Utils.getHostname("https://subdomain.bütwarden.com")).toBe("subdomain.bütwarden.com");
     });
 
+    // Test examples here gathered from https://www.iana.org/domains/reserved
+    it("should support urls containing unicode characters", () => {
+      // Arabic Arabic
+      expect(Utils.getHostname("https://www.إختبار.com")).toBe("www.إختبار.com");
+
+      // Persian Arabic
+      expect(Utils.getHostname("https://www.آزمایشی.com")).toBe("www.آزمایشی.com");
+
+      // Chinese Han (Simplified variant)
+      expect(Utils.getHostname("https://www.测试.com")).toBe("www.测试.com");
+
+      // Chinese Han (Traditional variant)
+      expect(Utils.getHostname("https://www.測試.com")).toBe("www.測試.com");
+
+      // Russian Cyrillic
+      expect(Utils.getHostname("https://www.испытание.com")).toBe("www.испытание.com");
+
+      // Hindi Devanagari (Nagari)
+      expect(Utils.getHostname("https://www.परीक्षा.com")).toBe("www.परीक्षा.com");
+
+      // Greek, Modern (1453-) Greek
+      expect(Utils.getHostname("https://www.δοκιμή.com")).toBe("www.δοκιμή.com");
+
+      // Korean Hangul (Hangŭl, Hangeul)
+      expect(Utils.getHostname("https://www.테스트.com")).toBe("www.테스트.com");
+
+      // Yiddish Hebrew
+      expect(Utils.getHostname("https://www.טעסט.com")).toBe("www.טעסט.com");
+
+      // Japanese Katakana
+      expect(Utils.getHostname("https://www.テスト.com")).toBe("www.テスト.com");
+
+      // Tamil Tamil
+      expect(Utils.getHostname("https://www.பரிட்சை.com")).toBe("www.பரிட்சை.com");
+    });
+
     it("should support punycode urls", () => {
       expect(Utils.getHostname("xn--btwarden-65a.com")).toBe("xn--btwarden-65a.com");
       expect(Utils.getHostname("xn--btwarden-65a.com")).toBe("xn--btwarden-65a.com");

--- a/libs/common/src/vault/models/view/login-uri-view.spec.ts
+++ b/libs/common/src/vault/models/view/login-uri-view.spec.ts
@@ -40,6 +40,66 @@ const exampleUris = {
   noEquivalentDomains: () => new Set<string>(),
 };
 
+// IANA reserved internationalized domain names (https://www.iana.org/domains/reserved),
+// paired with their punycode equivalents.
+const idnTestDomains = [
+  {
+    script: "Arabic Arabic",
+    unicode: "https://www.إختبار.com",
+    punycode: "https://www.xn--kgbechtv.com",
+  },
+  {
+    script: "Persian Arabic",
+    unicode: "https://www.آزمایشی.com",
+    punycode: "https://www.xn--hgbk6aj7f53bba.com",
+  },
+  {
+    script: "Chinese Han (Simplified variant)",
+    unicode: "https://www.测试.com",
+    punycode: "https://www.xn--0zwm56d.com",
+  },
+  {
+    script: "Chinese Han (Traditional variant)",
+    unicode: "https://www.測試.com",
+    punycode: "https://www.xn--g6w251d.com",
+  },
+  {
+    script: "Russian Cyrillic",
+    unicode: "https://www.испытание.com",
+    punycode: "https://www.xn--80akhbyknj4f.com",
+  },
+  {
+    script: "Hindi Devanagari (Nagari)",
+    unicode: "https://www.परीक्षा.com",
+    punycode: "https://www.xn--11b5bs3a9aj6g.com",
+  },
+  {
+    script: "Greek, Modern (1453-) Greek",
+    unicode: "https://www.δοκιμή.com",
+    punycode: "https://www.xn--jxalpdlp.com",
+  },
+  {
+    script: "Korean Hangul (Hangŭl, Hangeul)",
+    unicode: "https://www.테스트.com",
+    punycode: "https://www.xn--9t4b11yi5a.com",
+  },
+  {
+    script: "Yiddish Hebrew",
+    unicode: "https://www.טעסט.com",
+    punycode: "https://www.xn--deba0ad.com",
+  },
+  {
+    script: "Japanese Katakana",
+    unicode: "https://www.テスト.com",
+    punycode: "https://www.xn--zckzah.com",
+  },
+  {
+    script: "Tamil Tamil",
+    unicode: "https://www.பரிட்சை.com",
+    punycode: "https://www.xn--hlcj6aya9esc7a.com",
+  },
+];
+
 describe("LoginUriView", () => {
   it("isWebsite() given an invalid domain should return false", async () => {
     const uri = new LoginUriView();
@@ -97,6 +157,50 @@ describe("LoginUriView", () => {
         const uri = uriFactory(UriMatchStrategy.Domain, exampleUris.standard);
         const actual = uri.matchesUri(
           exampleUris.differentDomain,
+          exampleUris.noEquivalentDomains(),
+        );
+        expect(actual).toBe(false);
+      });
+
+      // Internationalized domain names (IDN): a saved URI and the target URI may
+      // express the same registrable domain in either unicode or punycode form.
+      describe.each(idnTestDomains)("$script IDN domains", ({ unicode, punycode }) => {
+        it("matches a saved unicode domain against a punycode target", () => {
+          const uri = uriFactory(UriMatchStrategy.Domain, unicode);
+          expect(uri.matchesUri(punycode, exampleUris.noEquivalentDomains())).toBe(true);
+        });
+
+        it("matches a saved punycode domain against a unicode target", () => {
+          const uri = uriFactory(UriMatchStrategy.Domain, punycode);
+          expect(uri.matchesUri(unicode, exampleUris.noEquivalentDomains())).toBe(true);
+        });
+
+        it("matches a saved unicode domain against a unicode target", () => {
+          const uri = uriFactory(UriMatchStrategy.Domain, unicode);
+          expect(uri.matchesUri(unicode, exampleUris.noEquivalentDomains())).toBe(true);
+        });
+
+        it("matches a saved punycode domain against a punycode target", () => {
+          const uri = uriFactory(UriMatchStrategy.Domain, punycode);
+          expect(uri.matchesUri(punycode, exampleUris.noEquivalentDomains())).toBe(true);
+        });
+      });
+
+      it("matches IDN domains across subdomains", () => {
+        // Chinese Han (Simplified): www.测试.com and login.xn--0zwm56d.com share a domain.
+        const uri = uriFactory(UriMatchStrategy.Domain, "https://www.测试.com");
+        const actual = uri.matchesUri(
+          "https://login.xn--0zwm56d.com",
+          exampleUris.noEquivalentDomains(),
+        );
+        expect(actual).toBe(true);
+      });
+
+      it("does not match different IDN domains", () => {
+        // Arabic إختبار.com should not match Chinese 测试.com (xn--0zwm56d.com).
+        const uri = uriFactory(UriMatchStrategy.Domain, "https://www.إختبار.com");
+        const actual = uri.matchesUri(
+          "https://www.xn--0zwm56d.com",
           exampleUris.noEquivalentDomains(),
         );
         expect(actual).toBe(false);

--- a/libs/common/src/vault/models/view/login-uri.view.ts
+++ b/libs/common/src/vault/models/view/login-uri.view.ts
@@ -2,6 +2,7 @@ import { Jsonify } from "type-fest";
 
 import { LoginUriView as SdkLoginUriView } from "@bitwarden/sdk-internal";
 
+import { punycodeToUnicode } from "../../../autofill/utils/punycode";
 import { UriMatchStrategy, UriMatchStrategySetting } from "../../../models/domain/domain-service";
 import { View } from "../../../models/view/view";
 import { SafeUrls, UrlType } from "../../../platform/misc/safe-urls";
@@ -193,7 +194,19 @@ export class LoginUriView implements View {
   }
 
   private matchesDomain(targetUri: string, matchDomains: Set<string>) {
-    if (targetUri == null || this.domain == null || !matchDomains.has(this.domain)) {
+    if (targetUri == null || this.domain == null) {
+      return false;
+    }
+
+    // A saved URI and the target URI may express the same registrable domain in
+    // different forms; unicode ("测试.com") vs punycode ("xn--0zwm56d.com").
+    // Collapse both sides to their unicode form before comparing.
+    const normalizedDomain = punycodeToUnicode(this.domain);
+    const domainMatches = Array.from(matchDomains).some(
+      (matchDomain) => matchDomain != null && punycodeToUnicode(matchDomain) === normalizedDomain,
+    );
+
+    if (!domainMatches) {
       return false;
     }
 

--- a/libs/common/src/vault/models/view/login-uri.view.ts
+++ b/libs/common/src/vault/models/view/login-uri.view.ts
@@ -198,16 +198,20 @@ export class LoginUriView implements View {
       return false;
     }
 
-    // A saved URI and the target URI may express the same registrable domain in
-    // different forms; unicode ("测试.com") vs punycode ("xn--0zwm56d.com").
-    // Collapse both sides to their unicode form before comparing.
-    const normalizedDomain = punycodeToUnicode(this.domain);
-    const domainMatches = Array.from(matchDomains).some(
-      (matchDomain) => matchDomain != null && punycodeToUnicode(matchDomain) === normalizedDomain,
-    );
+    // Fast path: an exact match covers the common all-ASCII case without any
+    // punycode work. Fall back to normalized comparison only on a miss.
+    if (!matchDomains.has(this.domain)) {
+      // A saved URI and the target URI may express the same registrable domain in
+      // different forms; unicode ("测试.com") vs punycode ("xn--0zwm56d.com").
+      // Collapse both sides to their unicode form before comparing.
+      const normalizedDomain = punycodeToUnicode(this.domain);
+      const domainMatches = Array.from(matchDomains).some(
+        (matchDomain) => matchDomain != null && punycodeToUnicode(matchDomain) === normalizedDomain,
+      );
 
-    if (!domainMatches) {
-      return false;
+      if (!domainMatches) {
+        return false;
+      }
     }
 
     if (Utils.DomainMatchBlacklist.has(this.domain)) {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-40766](https://bitwarden.atlassian.net/browse/PM-40766)

## 📔 Objective

Addressed https://github.com/bitwarden/clients/issues/4372

> we support IDN/punycode comparison when using the "Host" URI match detection strategy, but not when the "Base domain" (the out-of-the-box default) strategy is used

[PM-40766]: https://bitwarden.atlassian.net/browse/PM-40766?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ