### PR TITLE
[PM-40771] Update policy enabled method to accept PolicyStatusResponse

### DIFF
--- a/apps/web/src/app/admin-console/organizations/policies/base-policy-edit.component.ts
+++ b/apps/web/src/app/admin-console/organizations/policies/base-policy-edit.component.ts
@@ -144,7 +144,7 @@ export abstract class BasePolicyEditDefinition {
 
    * Note: this only affects policy editing in Admin Console, it does not affect its enforcement.
    */
-  enabled(policy: PolicyResponse): boolean {
+  enabled(policy: PolicyResponse | PolicyStatusResponse): boolean {
     return policy.enabled;
   }
 }

--- a/apps/web/src/app/admin-console/organizations/policies/policy-edit-definitions/send-controls.component.ts
+++ b/apps/web/src/app/admin-console/organizations/policies/policy-edit-definitions/send-controls.component.ts
@@ -26,6 +26,7 @@ import { OrgDomainApiServiceAbstraction } from "@bitwarden/common/admin-console/
 import { PolicyType } from "@bitwarden/common/admin-console/enums";
 import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
 import { SavePolicyRequest } from "@bitwarden/common/admin-console/models/request/save-policy.request";
+import { PolicyStatusResponse } from "@bitwarden/common/admin-console/models/response/policy-status.response";
 import { PolicyResponse } from "@bitwarden/common/admin-console/models/response/policy.response";
 import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
@@ -62,7 +63,7 @@ export class SendControlsPolicy extends BasePolicyEditDefinition {
     return configService.getFeatureFlag$(FeatureFlag.SendControls);
   }
 
-  override enabled(policy: PolicyResponse): boolean {
+  override enabled(policy: PolicyResponse | PolicyStatusResponse): boolean {
     // This policy is always enabled, and is driven entirely through its `policy.data` configuration.
     // The 'enabled' UI reflects whether the Send feature is enabled, rather than whether the policy is enabled.
 

--- a/apps/web/src/app/admin-console/organizations/policies/policy-edit-drawer.component.ts
+++ b/apps/web/src/app/admin-console/organizations/policies/policy-edit-drawer.component.ts
@@ -153,7 +153,7 @@ export class PolicyEditDrawerComponent implements AfterViewInit {
     componentRef.setInput("policyResponse", policyResponse);
     const component = componentRef.instance;
     this.policyComponent.set(component);
-    this.policyEnabled.set(policyResponse.enabled);
+    this.policyEnabled.set(this.data.policy.enabled(policyResponse));
 
     combineLatest([
       component.enabled.valueChanges.pipe(startWith(policyResponse.enabled)),


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-40771

## 📔 Objective

Modified the `enabled` method in `BasePolicyEditDefinition` and `SendControlsPolicy` to accept both `PolicyResponse` and `PolicyStatusResponse` types. Updated the `policyEnabled` setting in `PolicyEditDrawerComponent` to utilize the new method signature, ensuring compatibility with the updated policy response structure. 

This fix fixes the issue where the policy was shown as always on once you've edited it.
