### PR TITLE
webauthn: Pass PRF input on unlock passkey creation

### DIFF
--- a/apps/web/src/app/auth/core/services/webauthn-login/webauthn-login-admin.service.spec.ts
+++ b/apps/web/src/app/auth/core/services/webauthn-login/webauthn-login-admin.service.spec.ts
@@ -40,6 +40,7 @@ describe("WebauthnAdminService", () => {
 
   let originalAuthenticatorAssertionResponse!: AuthenticatorAssertionResponse | any;
   const mockUserId = newGuid() as UserId;
+  const mockPrfWrappingKey = makeSymmetricCryptoKey(64, 1) as PrfKey;
   const mockUserKey = makeSymmetricCryptoKey(64) as UserKey;
 
   beforeAll(() => {
@@ -68,6 +69,7 @@ describe("WebauthnAdminService", () => {
     global.AuthenticatorAssertionResponse = MockAuthenticatorAssertionResponse;
 
     keyService.userKey$.mockReturnValue(of(mockUserKey));
+    webAuthnLoginPrfKeyService.createSymmetricKeyFromPrf.mockResolvedValue(mockPrfWrappingKey);
   });
 
   beforeEach(() => {
@@ -90,7 +92,7 @@ describe("WebauthnAdminService", () => {
     });
 
     it("should return credential when navigator.credentials does not throw", async () => {
-      const deviceResponse = createDeviceResponse({ prf: false });
+      const deviceResponse = createDeviceResponse({ prfEnabled: false });
       credentials.create.mockResolvedValue(deviceResponse as PublicKeyCredential);
       const createOptions = createCredentialCreateOptions();
 
@@ -104,13 +106,92 @@ describe("WebauthnAdminService", () => {
     });
 
     it("should return supportsPrf=true when extensions contain prf", async () => {
-      const deviceResponse = createDeviceResponse({ prf: true });
+      const deviceResponse = createDeviceResponse({ prfEnabled: true });
       credentials.create.mockResolvedValue(deviceResponse as PublicKeyCredential);
       const createOptions = createCredentialCreateOptions();
 
       const result = await service.createCredential(createOptions);
 
       expect(result.supportsPrf).toBe(true);
+    });
+
+    it("should return prfResult when PRF extension output contains value", async () => {
+      const deviceResponse = createDeviceResponse({ prfEnabled: true, prfResult: true });
+      credentials.create.mockResolvedValue(deviceResponse as PublicKeyCredential);
+      const createOptions = createCredentialCreateOptions();
+
+      const result = await service.createCredential(createOptions);
+
+      expect(result.supportsPrf).toBe(true);
+      expect(result.prfResult).toBeDefined();
+    });
+
+    it("should return prfResult=undefined when authenticator does not support PRF on create", async () => {
+      const deviceResponse = createDeviceResponse({ prfEnabled: true, prfResult: false });
+      credentials.create.mockResolvedValue(deviceResponse as PublicKeyCredential);
+      const createOptions = createCredentialCreateOptions();
+
+      const result = await service.createCredential(createOptions);
+
+      expect(result.supportsPrf).toBe(true);
+      expect(result.prfResult).toBeUndefined();
+    });
+  });
+
+  describe("createKeySet", () => {
+    it("should return prfKeySet when supportsPrf == true", async () => {
+      const createdCredential = createDeviceResponse({ prfEnabled: true });
+      credentials.create.mockResolvedValue(createdCredential as PublicKeyCredential);
+      const createOptions = createCredentialCreateOptions();
+
+      const pendingCredential: PendingWebauthnLoginCredentialView = {
+        createOptions,
+        deviceResponse: createdCredential,
+        supportsPrf: true,
+        prfResult: undefined,
+      };
+
+      const assertedCredential = getDeviceResponse({ prfResult: true });
+      credentials.get.mockResolvedValueOnce(assertedCredential);
+
+      const mockEncryptedPublicKey = new EncString("test_encryptedPublicKey");
+      const mockEncryptedUserKey = new EncString("test_encryptedUserKey");
+      const mockedKeySet = new RotateableKeySet<PrfKey>(
+        mockEncryptedUserKey,
+        mockEncryptedPublicKey,
+      );
+      rotateableKeySetService.createKeySet.mockResolvedValue(mockedKeySet);
+
+      const keySet = await service.createKeySet(pendingCredential, mockUserId);
+
+      expect(credentials.get).toHaveBeenCalled();
+      expect(keySet).toEqual(mockedKeySet);
+    });
+
+    it("should return prfKeySet when prfResult contains value", async () => {
+      const createdCredential = createDeviceResponse({ prfEnabled: true, prfResult: true });
+      credentials.create.mockResolvedValue(createdCredential as PublicKeyCredential);
+      const createOptions = createCredentialCreateOptions();
+
+      const pendingCredential = {
+        createOptions,
+        deviceResponse: createdCredential,
+        supportsPrf: true,
+        prfResult: createdCredential.getClientExtensionResults().prf.results.first,
+      };
+
+      const mockEncryptedPublicKey = new EncString("test_encryptedPublicKey");
+      const mockEncryptedUserKey = new EncString("test_encryptedUserKey");
+      const mockedKeySet = new RotateableKeySet<PrfKey>(
+        mockEncryptedUserKey,
+        mockEncryptedPublicKey,
+      );
+      rotateableKeySetService.createKeySet.mockResolvedValue(mockedKeySet);
+
+      const keySet = await service.createKeySet(pendingCredential, mockUserId);
+
+      expect(credentials.get).not.toHaveBeenCalled();
+      expect(keySet).toEqual(mockedKeySet);
     });
   });
 
@@ -366,7 +447,10 @@ function createCredentialCreateOptions(): CredentialCreateOptionsView {
   return new CredentialCreateOptionsView(challenge as any, Symbol() as any);
 }
 
-function createDeviceResponse({ prf = false }: { prf?: boolean } = {}): PublicKeyCredential {
+function createDeviceResponse({
+  prfEnabled = false,
+  prfResult = false,
+}: { prfEnabled?: boolean; prfResult?: boolean } = {}): PublicKeyCredential {
   const credential = {
     id: "Y29yb2l1IHdhcyBoZXJl",
     rawId: new Uint8Array([0x74, 0x65, 0x73, 0x74]),
@@ -376,8 +460,23 @@ function createDeviceResponse({ prf = false }: { prf?: boolean } = {}): PublicKe
       clientDataJSON: "eyJ0ZXN0IjoidGVzdCJ9",
     },
     getClientExtensionResults: () => {
-      if (!prf) {
+      if (!prfEnabled && !prfResult) {
         return {};
+      }
+
+      if (prfResult) {
+        return {
+          prf: {
+            enabled: Boolean(prfEnabled),
+            results: {
+              first: new Uint8Array([
+                0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d,
+                0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b,
+                0x1c, 0x1d, 0x1e, 0x1f,
+              ]),
+            },
+          },
+        };
       }
 
       return {
@@ -390,6 +489,42 @@ function createDeviceResponse({ prf = false }: { prf?: boolean } = {}): PublicKe
 
   Object.setPrototypeOf(credential, PublicKeyCredential.prototype);
   Object.setPrototypeOf(credential.response, AuthenticatorAttestationResponse.prototype);
+
+  return credential;
+}
+
+function getDeviceResponse({
+  prfResult = false,
+}: { prfResult?: boolean } = {}): PublicKeyCredential {
+  const credential = {
+    id: "Y29yb2l1IHdhcyBoZXJl",
+    rawId: new Uint8Array([0x74, 0x65, 0x73, 0x74]),
+    type: "public-key",
+    response: {
+      authenticatorData: new Uint8Array([0, 0, 0]),
+      signature: new Uint8Array([0x01, 0x02, 0x03, 0x04]),
+    },
+    getClientExtensionResults: () => {
+      if (!prfResult) {
+        return {};
+      }
+
+      return {
+        prf: {
+          results: {
+            first: new Uint8Array([
+              0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d,
+              0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b,
+              0x1c, 0x1d, 0x1e, 0x1f,
+            ]),
+          },
+        },
+      };
+    },
+  } as any;
+
+  Object.setPrototypeOf(credential, PublicKeyCredential.prototype);
+  Object.setPrototypeOf(credential.response, AuthenticatorAssertionResponse.prototype);
 
   return credential;
 }
@@ -438,6 +573,11 @@ class MockPublicKeyCredential implements PublicKeyCredential {
         },
       },
     };
+  }
+
+  toJSON(): string {
+    // Not currently needed for mocks.
+    throw Error("Not implemented");
   }
 
   static isConditionalMediationAvailable(): Promise<boolean> {

--- a/apps/web/src/app/auth/core/services/webauthn-login/webauthn-login-admin.service.ts
+++ b/apps/web/src/app/auth/core/services/webauthn-login/webauthn-login-admin.service.ts
@@ -116,19 +116,26 @@ export class WebauthnLoginAdminService implements UserKeyRotationDataProvider<We
     const nativeOptions: CredentialCreationOptions = {
       publicKey: credentialOptions.options,
     };
-    // TODO: Remove `any` when typescript typings add support for PRF
     nativeOptions.publicKey.extensions = {
       prf: { eval: { first: await this.webAuthnLoginPrfKeyService.getLoginWithPrfSalt() } },
-    } as any;
+    };
 
     try {
       const response = await this.navigatorCredentials.create(nativeOptions);
       if (!(response instanceof PublicKeyCredential)) {
         return undefined;
       }
-      // TODO: Remove `any` when typescript typings add support for PRF
-      const supportsPrf = Boolean((response.getClientExtensionResults() as any).prf?.enabled);
-      return new PendingWebauthnLoginCredentialView(credentialOptions, response, supportsPrf);
+
+      const prfExtensionOutput = response.getClientExtensionResults().prf;
+      const supportsPrf = Boolean(prfExtensionOutput?.enabled);
+      const prfResult = prfExtensionOutput?.results?.first;
+
+      return new PendingWebauthnLoginCredentialView(
+        credentialOptions,
+        response,
+        supportsPrf,
+        prfResult,
+      );
     } catch (error) {
       this.logService?.error(error);
       return undefined;
@@ -139,6 +146,10 @@ export class WebauthnLoginAdminService implements UserKeyRotationDataProvider<We
    * Create a key set from the given pending credential. The credential must support PRF.
    * This will trigger the browsers WebAuthn API to generate a PRF-output.
    *
+   * If the authenticator only supports returning PRF responses on .get() and
+   * not on .create(), then the user will be prompted to assert their credential
+   * again.
+   *
    * @param pendingCredential A credential created using `createCredential`.
    * @param userId The target users id.
    * @returns A key set that can be saved to the server. Undefined is returned if the credential doesn't support PRF.
@@ -147,6 +158,28 @@ export class WebauthnLoginAdminService implements UserKeyRotationDataProvider<We
     pendingCredential: PendingWebauthnLoginCredentialView,
     userId: UserId,
   ): Promise<PrfKeySet | undefined> {
+    const prfResult =
+      pendingCredential.prfResult ?? (await this.requestPrfCredential(pendingCredential));
+
+    if (!prfResult) {
+      return undefined;
+    }
+
+    try {
+      const symmetricPrfKey = await this.webAuthnLoginPrfKeyService.createSymmetricKeyFromPrf(
+        prfResult as ArrayBuffer,
+      );
+      const userKey = await firstValueFrom(this.keyService.userKey$(userId));
+      return await this.rotateableKeySetService.createKeySet(symmetricPrfKey, userKey);
+    } catch (error) {
+      this.logService?.error(error);
+      return undefined;
+    }
+  }
+
+  private async requestPrfCredential(
+    pendingCredential: PendingWebauthnLoginCredentialView,
+  ): Promise<BufferSource | undefined> {
     const nativeOptions: CredentialRequestOptions = {
       publicKey: {
         challenge: pendingCredential.createOptions.options.challenge,
@@ -155,10 +188,9 @@ export class WebauthnLoginAdminService implements UserKeyRotationDataProvider<We
         timeout: pendingCredential.createOptions.options.timeout,
         userVerification:
           pendingCredential.createOptions.options.authenticatorSelection.userVerification,
-        // TODO: Remove `any` when typescript typings add support for PRF
         extensions: {
           prf: { eval: { first: await this.webAuthnLoginPrfKeyService.getLoginWithPrfSalt() } },
-        } as any,
+        },
       },
     };
 
@@ -168,17 +200,7 @@ export class WebauthnLoginAdminService implements UserKeyRotationDataProvider<We
         return undefined;
       }
 
-      // TODO: Remove `any` when typescript typings add support for PRF
-      const prfResult = (response.getClientExtensionResults() as any).prf?.results?.first;
-
-      if (prfResult === undefined) {
-        return undefined;
-      }
-
-      const symmetricPrfKey =
-        await this.webAuthnLoginPrfKeyService.createSymmetricKeyFromPrf(prfResult);
-      const userKey = await firstValueFrom(this.keyService.userKey$(userId));
-      return await this.rotateableKeySetService.createKeySet(symmetricPrfKey, userKey);
+      return response.getClientExtensionResults().prf?.results?.first;
     } catch (error) {
       this.logService?.error(error);
       return undefined;

--- a/apps/web/src/app/auth/core/services/webauthn-login/webauthn-login-admin.service.ts
+++ b/apps/web/src/app/auth/core/services/webauthn-login/webauthn-login-admin.service.ts
@@ -118,7 +118,7 @@ export class WebauthnLoginAdminService implements UserKeyRotationDataProvider<We
     };
     // TODO: Remove `any` when typescript typings add support for PRF
     nativeOptions.publicKey.extensions = {
-      prf: {},
+      prf: { eval: { first: await this.webAuthnLoginPrfKeyService.getLoginWithPrfSalt() } },
     } as any;
 
     try {

--- a/apps/web/src/app/auth/core/views/pending-webauthn-login-credential.view.ts
+++ b/apps/web/src/app/auth/core/views/pending-webauthn-login-credential.view.ts
@@ -8,5 +8,6 @@ export class PendingWebauthnLoginCredentialView {
     readonly createOptions: CredentialCreateOptionsView,
     readonly deviceResponse: PublicKeyCredential,
     readonly supportsPrf: boolean,
+    readonly prfResult: BufferSource | undefined,
   ) {}
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-40775](https://bitwarden.atlassian.net/browse/PM-40775)

## 📔 Objective

Two goals here:
- WebAuthn has been updated to allow passing PRF inputs on create, so you don't have to do two authentication ceremonies.
- Windows Hello supports PRF, but there's a bug where they don't signal PRF support if you don't pass PRF input on create, which is not compliant with the spec. This means that our users couldn't use Windows Hello passkeys to unlock their vaults.

Fixing the former also fixes the latter. 😎 

## 📸 Screenshots

https://github.com/user-attachments/assets/ddfd3eee-4973-40b3-a9f6-26569953cbd0




[PM-40775]: https://bitwarden.atlassian.net/browse/PM-40775?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ