### PR TITLE
[PM-40200] Migrate ApiService cipher-collection calls to shared-folder endpoints

### DIFF
--- a/libs/common/src/services/api.service.ts
+++ b/libs/common/src/services/api.service.ts
@@ -459,7 +459,7 @@ export class ApiService implements ApiServiceAbstraction {
   ): Promise<OptionalCipherResponse> {
     const response = await this.send(
       "PUT",
-      "/ciphers/" + id + "/collections_v2",
+      "/ciphers/" + id + "/shared-folders_v2",
       request,
       true,
       true,
@@ -468,7 +468,7 @@ export class ApiService implements ApiServiceAbstraction {
   }
 
   putCipherCollectionsAdmin(id: string, request: CipherCollectionsRequest): Promise<any> {
-    return this.send("PUT", "/ciphers/" + id + "/collections-admin", request, true, true);
+    return this.send("PUT", "/ciphers/" + id + "/shared-folders-admin", request, true, true);
   }
 
   postPurgeCiphers(


### PR DESCRIPTION
## 🎟️ Tracking

[Jira](https://bitwarden.atlassian.net/browse/PM-40200)

## 📔 Objective

Point the two ApiService methods that hit the renamed Vault routes at the new shared-folder paths: putCipherCollections (/ciphers/{id}/collections_v2 → /shared-folders_v2) and putCipherCollectionsAdmin (/ciphers/{id}/collections-admin → /shared-folders-admin). Straight path-string swap — unflagged/additive; client commits to new endpoints on ship. Request/response models unchanged.

