### PR TITLE
docs(vault): document deprecation of TypeScript vault item decryption

### DIFF
--- a/libs/common/src/vault/models/domain/cipher.ts
+++ b/libs/common/src/vault/models/domain/cipher.ts
@@ -141,6 +141,11 @@ export class Cipher extends Domain implements Decryptable<CipherView> {
     }
   }
 
+  /**
+   * @deprecated WARNING: This API may fail to decrypt ciphers if they are using blob encryption.
+   * If you are using this, please migrate off of it immediately! This function will be removed
+   * in a near release.
+   */
   async decrypt(userKeyOrOrgKey: SymmetricCryptoKey): Promise<CipherView> {
     assertNonNullish(userKeyOrOrgKey, "userKeyOrOrgKey", "Cipher decryption");
 


### PR DESCRIPTION
Docs only changes; the decrypt api was accidentally used in passkey reports; we should clarify that this really shouldn't be used. I have a conversation open with @shane-melton / @nikwithak on whether we can migrate off immediately without too much trouble by introducing a temporary sdk API.