### PR TITLE
[PM-39227] Add the browser vault-health reports service (categorize, score, emit)

### DIFF
--- a/bitwarden_license/bit-browser/src/popup/app.module.ts
+++ b/bitwarden_license/bit-browser/src/popup/app.module.ts
@@ -13,7 +13,6 @@ import { AppRoutingModule as OssRoutingModule } from "@bitwarden/browser/popup/a
 import { AppModule as OssModule } from "@bitwarden/browser/popup/app.module";
 // import { WildcardRoutingModule } from "@bitwarden/browser/popup/wildcard-routing.module";
 import { CipherRiskService } from "@bitwarden/common/vault/abstractions/cipher-risk.service";
-import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { safeProvider } from "@bitwarden/ui-common";
 
 import { AppRoutingModule } from "./app-routing.module";
@@ -46,7 +45,7 @@ import { AppComponent } from "./app.component";
     safeProvider({
       provide: VaultHealthReportService,
       useClass: DefaultVaultHealthReportService,
-      deps: [CipherService, CipherRiskService],
+      deps: [CipherRiskService],
     }),
   ],
 })

--- a/bitwarden_license/bit-browser/src/popup/app.module.ts
+++ b/bitwarden_license/bit-browser/src/popup/app.module.ts
@@ -8,6 +8,13 @@ import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { AppRoutingModule as OssRoutingModule } from "@bitwarden/browser/popup/app-routing.module";
 import { AppModule as OssModule } from "@bitwarden/browser/popup/app.module";
 // import { WildcardRoutingModule } from "@bitwarden/browser/popup/wildcard-routing.module";
+import {
+  DefaultVaultHealthReportService,
+  VaultHealthReportService,
+} from "@bitwarden/bit-common/dirt/vault-health/services";
+import { CipherRiskService } from "@bitwarden/common/vault/abstractions/cipher-risk.service";
+import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
+import { safeProvider } from "@bitwarden/ui-common";
 
 import { AppRoutingModule } from "./app-routing.module";
 import { AppComponent } from "./app.component";
@@ -35,5 +42,12 @@ import { AppComponent } from "./app.component";
   ],
   declarations: [AppComponent],
   bootstrap: [AppComponent],
+  providers: [
+    safeProvider({
+      provide: VaultHealthReportService,
+      useClass: DefaultVaultHealthReportService,
+      deps: [CipherService, CipherRiskService],
+    }),
+  ],
 })
 export class AppModule {}

--- a/bitwarden_license/bit-browser/src/popup/app.module.ts
+++ b/bitwarden_license/bit-browser/src/popup/app.module.ts
@@ -5,13 +5,13 @@ import { RouterModule } from "@angular/router";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 // import { AppRoutingAnimationsModule } from "@bitwarden/browser/popup/app-routing-animations";
-import { AppRoutingModule as OssRoutingModule } from "@bitwarden/browser/popup/app-routing.module";
-import { AppModule as OssModule } from "@bitwarden/browser/popup/app.module";
-// import { WildcardRoutingModule } from "@bitwarden/browser/popup/wildcard-routing.module";
 import {
   DefaultVaultHealthReportService,
   VaultHealthReportService,
 } from "@bitwarden/bit-common/dirt/vault-health/services";
+import { AppRoutingModule as OssRoutingModule } from "@bitwarden/browser/popup/app-routing.module";
+import { AppModule as OssModule } from "@bitwarden/browser/popup/app.module";
+// import { WildcardRoutingModule } from "@bitwarden/browser/popup/wildcard-routing.module";
 import { CipherRiskService } from "@bitwarden/common/vault/abstractions/cipher-risk.service";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { safeProvider } from "@bitwarden/ui-common";

--- a/bitwarden_license/bit-common/src/dirt/vault-health/models/index.ts
+++ b/bitwarden_license/bit-common/src/dirt/vault-health/models/index.ts
@@ -1,0 +1,2 @@
+export * from "./risk-category";
+export * from "./view/vault-health-report.view";

--- a/bitwarden_license/bit-common/src/dirt/vault-health/models/risk-category.ts
+++ b/bitwarden_license/bit-common/src/dirt/vault-health/models/risk-category.ts
@@ -1,0 +1,22 @@
+/**
+ * The risk categories a login can fall into on the vault-health report.
+ *
+ * Uses a const object rather than a TypeScript enum per ADR-0025.
+ */
+export const RiskCategory = Object.freeze({
+  Exposed: "exposed",
+  Weak: "weak",
+  Reused: "reused",
+} as const);
+
+export type RiskCategory = (typeof RiskCategory)[keyof typeof RiskCategory];
+
+/**
+ * Highest-risk-wins priority order for deduplicating a login into a single
+ * category: Exposed beats Weak beats Reused (PM-39227 / PM-35945).
+ */
+export const RISK_CATEGORY_PRIORITY: readonly RiskCategory[] = [
+  RiskCategory.Exposed,
+  RiskCategory.Weak,
+  RiskCategory.Reused,
+] as const;

--- a/bitwarden_license/bit-common/src/dirt/vault-health/models/risk-category.ts
+++ b/bitwarden_license/bit-common/src/dirt/vault-health/models/risk-category.ts
@@ -10,13 +10,3 @@ export const RiskCategory = Object.freeze({
 } as const);
 
 export type RiskCategory = (typeof RiskCategory)[keyof typeof RiskCategory];
-
-/**
- * Highest-risk-wins priority order for deduplicating a login into a single
- * category: Exposed beats Weak beats Reused (PM-39227 / PM-35945).
- */
-export const RISK_CATEGORY_PRIORITY: readonly RiskCategory[] = [
-  RiskCategory.Exposed,
-  RiskCategory.Weak,
-  RiskCategory.Reused,
-] as const;

--- a/bitwarden_license/bit-common/src/dirt/vault-health/models/view/vault-health-report.view.ts
+++ b/bitwarden_license/bit-common/src/dirt/vault-health/models/view/vault-health-report.view.ts
@@ -18,9 +18,11 @@ export class VaultHealthReportView implements View {
   atRiskCount = 0;
   /** atRiskCount / totalCount; 0 when totalCount is 0. */
   score = 0;
-  /** Deduplicated, highest-risk-wins count per category. */
-  categoryCounts: CategoryRecord<number> = { exposed: 0, weak: 0, reused: 0 };
-  /** The at-risk logins placed in each category (highest-risk-wins). */
+  /**
+   * The at-risk logins placed in each category (highest-risk-wins). The
+   * per-category count is the length of each list; no separate counts record
+   * is kept.
+   */
   categoryItems: CategoryRecord<CipherHealthView[]> = { exposed: [], weak: [], reused: [] };
   /** Full per-login breakdown: every category each at-risk login falls under. */
   cipherHealth: CipherHealthView[] = [];

--- a/bitwarden_license/bit-common/src/dirt/vault-health/models/view/vault-health-report.view.ts
+++ b/bitwarden_license/bit-common/src/dirt/vault-health/models/view/vault-health-report.view.ts
@@ -1,6 +1,6 @@
 import { View } from "@bitwarden/common/models/view/view";
 
-import { CipherHealthView } from "../../../access-intelligence/models";
+import { CipherHealthView } from "../../../access-intelligence/models/view/cipher-health.view";
 import { RiskCategory } from "../risk-category";
 
 type CategoryRecord<T> = Record<RiskCategory, T>;

--- a/bitwarden_license/bit-common/src/dirt/vault-health/models/view/vault-health-report.view.ts
+++ b/bitwarden_license/bit-common/src/dirt/vault-health/models/view/vault-health-report.view.ts
@@ -21,11 +21,11 @@ export class VaultHealthReportView implements View {
   /**
    * The at-risk logins placed in each category (highest-risk-wins). The
    * per-category count is the length of each list; no separate counts record
-   * is kept.
+   * is kept. Each item is a CipherHealthView that carries every category the
+   * login is at risk in, so consumers needing the cross-category view (e.g.
+   * the delete-from-detail dialog) can read it here without a separate list.
    */
   categoryItems: CategoryRecord<CipherHealthView[]> = { exposed: [], weak: [], reused: [] };
-  /** Full per-login breakdown: every category each at-risk login falls under. */
-  cipherHealth: CipherHealthView[] = [];
 
   constructor(init?: Partial<VaultHealthReportView>) {
     if (init == null) {

--- a/bitwarden_license/bit-common/src/dirt/vault-health/models/view/vault-health-report.view.ts
+++ b/bitwarden_license/bit-common/src/dirt/vault-health/models/view/vault-health-report.view.ts
@@ -1,0 +1,34 @@
+import { View } from "@bitwarden/common/models/view/view";
+
+import { CipherHealthView } from "../../../access-intelligence/models";
+import { RiskCategory } from "../risk-category";
+
+type CategoryRecord<T> = Record<RiskCategory, T>;
+
+/**
+ * The aggregated, deduplicated, scored vault-health result for the browser
+ * Health tab. Computed on demand from the per-login SDK risk metrics; not
+ * persisted, so it is a View-only model (no Data/Domain/API siblings),
+ * matching CipherHealthView.
+ */
+export class VaultHealthReportView implements View {
+  /** Personal-vault logins with a password (the score denominator). */
+  totalCount = 0;
+  /** Unique logins at risk in any category (the score numerator). */
+  atRiskCount = 0;
+  /** atRiskCount / totalCount; 0 when totalCount is 0. */
+  score = 0;
+  /** Deduplicated, highest-risk-wins count per category. */
+  categoryCounts: CategoryRecord<number> = { exposed: 0, weak: 0, reused: 0 };
+  /** The at-risk logins placed in each category (highest-risk-wins). */
+  categoryItems: CategoryRecord<CipherHealthView[]> = { exposed: [], weak: [], reused: [] };
+  /** Full per-login breakdown: every category each at-risk login falls under. */
+  cipherHealth: CipherHealthView[] = [];
+
+  constructor(init?: Partial<VaultHealthReportView>) {
+    if (init == null) {
+      return;
+    }
+    Object.assign(this, init);
+  }
+}

--- a/bitwarden_license/bit-common/src/dirt/vault-health/services/abstractions/vault-health-report.service.ts
+++ b/bitwarden_license/bit-common/src/dirt/vault-health/services/abstractions/vault-health-report.service.ts
@@ -1,0 +1,24 @@
+import { Observable } from "rxjs";
+
+import { UserId } from "@bitwarden/common/types/guid";
+
+import { VaultHealthReportView } from "../../models/view/vault-health-report.view";
+
+/**
+ * Orchestration layer for the browser Health tab.
+ *
+ * Runs the password-health checks for the user's personal-vault logins via the
+ * Vault-owned CipherRiskService (does not re-implement report logic),
+ * categorizes and deduplicates the results (highest-risk-wins:
+ * Exposed > Weak > Reused), computes the vault-health score, and emits the
+ * aggregated result reactively, re-emitting when the vault changes.
+ */
+export abstract class VaultHealthReportService {
+  /**
+   * Emits the aggregated vault-health report for the given user, re-emitting
+   * whenever the user's vault changes. Errors from the underlying risk
+   * computation (e.g. an HIBP failure) propagate so the caller can route to
+   * the scan-failure state (PM-39223); they are not swallowed here.
+   */
+  abstract vaultHealthReport$(userId: UserId): Observable<VaultHealthReportView>;
+}

--- a/bitwarden_license/bit-common/src/dirt/vault-health/services/abstractions/vault-health-report.service.ts
+++ b/bitwarden_license/bit-common/src/dirt/vault-health/services/abstractions/vault-health-report.service.ts
@@ -1,24 +1,29 @@
 import { Observable } from "rxjs";
 
 import { UserId } from "@bitwarden/common/types/guid";
+import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 
 import { VaultHealthReportView } from "../../models/view/vault-health-report.view";
 
 /**
- * Orchestration layer for the browser Health tab.
+ * Compute-only report builder for the browser Health tab.
  *
- * Runs the password-health checks for the user's personal-vault logins via the
- * Vault-owned CipherRiskService (does not re-implement report logic),
- * categorizes and deduplicates the results (highest-risk-wins:
- * Exposed > Weak > Reused), computes the vault-health score, and emits the
- * aggregated result reactively, re-emitting when the vault changes.
+ * Given the caller's list of vault ciphers, it filters to the personal-vault
+ * logins in scope, runs the password-health checks via the Vault-owned
+ * CipherRiskService (does not re-implement report logic), categorizes and
+ * deduplicates the results (highest-risk-wins: Exposed > Weak > Reused), and
+ * computes the vault-health score. The caller (the Health-tab root component)
+ * owns fetching the ciphers and deciding when to recompute.
  */
 export abstract class VaultHealthReportService {
   /**
-   * Emits the aggregated vault-health report for the given user, re-emitting
-   * whenever the user's vault changes. Errors from the underlying risk
-   * computation (e.g. an HIBP failure) propagate so the caller can route to
-   * the scan-failure state (PM-39223); they are not swallowed here.
+   * Builds the aggregated vault-health report from the given ciphers. Errors
+   * from the underlying risk computation (e.g. an HIBP failure) propagate so
+   * the caller can route to the scan-failure state (PM-39223); they are not
+   * swallowed here.
    */
-  abstract vaultHealthReport$(userId: UserId): Observable<VaultHealthReportView>;
+  abstract buildVaultHealthReport$(
+    ciphers: CipherView[],
+    userId: UserId,
+  ): Observable<VaultHealthReportView>;
 }

--- a/bitwarden_license/bit-common/src/dirt/vault-health/services/implementations/default-vault-health-report.service.spec.ts
+++ b/bitwarden_license/bit-common/src/dirt/vault-health/services/implementations/default-vault-health-report.service.spec.ts
@@ -1,0 +1,254 @@
+import { mock } from "jest-mock-extended";
+import { BehaviorSubject, firstValueFrom } from "rxjs";
+
+import type { CipherRiskResult } from "@bitwarden/sdk-internal";
+
+import { CipherRiskService } from "@bitwarden/common/vault/abstractions/cipher-risk.service";
+import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
+import { CipherType } from "@bitwarden/common/vault/enums/cipher-type";
+import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+import { LoginView } from "@bitwarden/common/vault/models/view/login.view";
+import { UserId } from "@bitwarden/common/types/guid";
+
+import { DefaultVaultHealthReportService } from "./default-vault-health-report.service";
+
+describe("DefaultVaultHealthReportService", () => {
+  const userId = "test-user-id" as UserId;
+
+  let cipherService: ReturnType<typeof mock<CipherService>>;
+  let cipherRiskService: ReturnType<typeof mock<CipherRiskService>>;
+  let cipherViews$: BehaviorSubject<CipherView[]>;
+  let service: DefaultVaultHealthReportService;
+
+  // Per-test lookup so risk results are returned for exactly the ciphers passed,
+  // keyed by id (mirrors the SDK, which stamps each result with its cipher id).
+  let riskById: Map<string, CipherRiskResult>;
+
+  beforeEach(() => {
+    cipherService = mock<CipherService>();
+    cipherRiskService = mock<CipherRiskService>();
+    cipherViews$ = new BehaviorSubject<CipherView[]>([]);
+    riskById = new Map();
+
+    cipherService.cipherViews$.mockReturnValue(cipherViews$);
+    cipherRiskService.buildPasswordReuseMap.mockResolvedValue({});
+    cipherRiskService.computeRiskForCiphers.mockImplementation(async (ciphers) =>
+      ciphers.map((c) => riskById.get(c.id)!),
+    );
+
+    service = new DefaultVaultHealthReportService(cipherService, cipherRiskService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // --- helpers -------------------------------------------------------------
+
+  const login = (
+    id: string,
+    opts: {
+      password?: string;
+      organizationId?: string | null;
+      deleted?: boolean;
+      type?: CipherType;
+    } = {},
+  ): CipherView => {
+    const cipher = new CipherView();
+    cipher.id = id;
+    cipher.type = opts.type ?? CipherType.Login;
+    cipher.organizationId = (opts.organizationId ?? null) as CipherView["organizationId"];
+    cipher.deletedDate = opts.deleted ? new Date() : (null as unknown as Date);
+    cipher.login = new LoginView();
+    cipher.login.password = opts.password ?? `pw-${id}`;
+    return cipher;
+  };
+
+  const risk = (
+    id: string,
+    opts: { strength?: number; exposed?: number; reuse?: number } = {},
+  ): CipherRiskResult => {
+    const exposed = opts.exposed ?? 0;
+    return {
+      id,
+      password_strength: opts.strength ?? 4,
+      exposed_result: exposed > 0 ? { type: "Found", value: exposed } : { type: "NotChecked" },
+      reuse_count: opts.reuse ?? 1,
+    } as unknown as CipherRiskResult;
+  };
+
+  /** Seed the vault with logins and register a risk result for each by id. */
+  const seed = (entries: { cipher: CipherView; risk: CipherRiskResult }[]) => {
+    entries.forEach((e) => riskById.set(e.cipher.id, e.risk));
+    cipherViews$.next(entries.map((e) => e.cipher));
+  };
+
+  const report = () => firstValueFrom(service.vaultHealthReport$(userId));
+
+  // --- tests ---------------------------------------------------------------
+
+  it("categorizes each single-risk login into its matching category", async () => {
+    seed([
+      { cipher: login("a"), risk: risk("a", { exposed: 3 }) },
+      { cipher: login("b"), risk: risk("b", { strength: 1 }) },
+      { cipher: login("c"), risk: risk("c", { reuse: 2 }) },
+    ]);
+
+    const result = await report();
+
+    expect(result.categoryCounts).toEqual({ exposed: 1, weak: 1, reused: 1 });
+    expect(result.categoryItems.exposed.map((h) => h.cipherId)).toEqual(["a"]);
+    expect(result.categoryItems.weak.map((h) => h.cipherId)).toEqual(["b"]);
+    expect(result.categoryItems.reused.map((h) => h.cipherId)).toEqual(["c"]);
+  });
+
+  it("counts an exposed+weak+reused login once, under Exposed (highest-risk-wins)", async () => {
+    seed([{ cipher: login("a"), risk: risk("a", { strength: 1, exposed: 5, reuse: 3 }) }]);
+
+    const result = await report();
+
+    expect(result.atRiskCount).toBe(1);
+    expect(result.categoryCounts).toEqual({ exposed: 1, weak: 0, reused: 0 });
+    expect(result.categoryItems.exposed.map((h) => h.cipherId)).toEqual(["a"]);
+    // Full per-login breakdown still reflects all categories the login is at risk in.
+    const health = result.cipherHealth.find((h) => h.cipherId === "a")!;
+    expect(health.hasExposedPassword).toBe(true);
+    expect(health.hasWeakPassword).toBe(true);
+    expect(health.hasReusedPassword).toBe(true);
+  });
+
+  it("places a weak+reused (not exposed) login under Weak", async () => {
+    seed([{ cipher: login("a"), risk: risk("a", { strength: 2, reuse: 4 }) }]);
+
+    const result = await report();
+
+    expect(result.categoryCounts).toEqual({ exposed: 0, weak: 1, reused: 0 });
+    const health = result.cipherHealth.find((h) => h.cipherId === "a")!;
+    expect(health.hasWeakPassword).toBe(true);
+    expect(health.hasReusedPassword).toBe(true);
+  });
+
+  it("scores unique at-risk logins over total logins", async () => {
+    const entries = Array.from({ length: 10 }, (_, i) => ({
+      cipher: login(`c${i}`),
+      risk: i < 3 ? risk(`c${i}`, { strength: 1 }) : risk(`c${i}`),
+    }));
+    seed(entries);
+
+    const result = await report();
+
+    expect(result.totalCount).toBe(10);
+    expect(result.atRiskCount).toBe(3);
+    expect(result.score).toBeCloseTo(0.3);
+  });
+
+  it("returns an empty report with score 0 when there are no scoped logins", async () => {
+    cipherViews$.next([]);
+
+    const result = await report();
+
+    expect(result.totalCount).toBe(0);
+    expect(result.atRiskCount).toBe(0);
+    expect(result.score).toBe(0);
+    expect(result.categoryCounts).toEqual({ exposed: 0, weak: 0, reused: 0 });
+    expect(cipherRiskService.computeRiskForCiphers).not.toHaveBeenCalled();
+  });
+
+  it("reports zero at risk when all logins are healthy", async () => {
+    seed([
+      { cipher: login("a"), risk: risk("a") },
+      { cipher: login("b"), risk: risk("b") },
+      { cipher: login("c"), risk: risk("c") },
+    ]);
+
+    const result = await report();
+
+    expect(result.atRiskCount).toBe(0);
+    expect(result.score).toBe(0);
+    expect(result.categoryCounts).toEqual({ exposed: 0, weak: 0, reused: 0 });
+    expect(result.cipherHealth).toHaveLength(3);
+  });
+
+  it("excludes org items, deleted items, non-logins, and passwordless logins from scope", async () => {
+    const personal = login("personal", { strength: 1 });
+    riskById.set(personal.id, risk("personal", { strength: 1 }));
+    cipherViews$.next([
+      personal,
+      login("org", { organizationId: "org-1" }),
+      login("deleted", { deleted: true }),
+      login("card", { type: CipherType.Card }),
+      login("nopass", { password: "" }),
+    ]);
+
+    const result = await report();
+
+    expect(result.totalCount).toBe(1);
+    const passed = cipherRiskService.computeRiskForCiphers.mock.calls[0][0];
+    expect(passed.map((c) => c.id)).toEqual(["personal"]);
+  });
+
+  it("re-emits an updated report when the vault changes", async () => {
+    seed([
+      { cipher: login("a"), risk: risk("a", { strength: 1 }) },
+      { cipher: login("b"), risk: risk("b") },
+    ]);
+    const emissions: number[] = [];
+    const sub = service.vaultHealthReport$(userId).subscribe((r) => emissions.push(r.atRiskCount));
+
+    // allow the first async report to resolve
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    seed([
+      { cipher: login("a"), risk: risk("a", { strength: 1 }) },
+      { cipher: login("b"), risk: risk("b", { exposed: 2 }) },
+      { cipher: login("c"), risk: risk("c", { reuse: 2 }) },
+    ]);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    sub.unsubscribe();
+    expect(emissions[0]).toBe(1);
+    expect(emissions[emissions.length - 1]).toBe(3);
+  });
+
+  it("propagates errors from the risk computation instead of swallowing them", async () => {
+    seed([{ cipher: login("a"), risk: risk("a") }]);
+    cipherRiskService.computeRiskForCiphers.mockRejectedValueOnce(new Error("HIBP unavailable"));
+
+    await expect(report()).rejects.toThrow("HIBP unavailable");
+  });
+
+  it("enables the exposed check and passes the pre-built reuse map", async () => {
+    const reuseMap = { "pw-a": 1 };
+    cipherRiskService.buildPasswordReuseMap.mockResolvedValue(reuseMap);
+    seed([{ cipher: login("a"), risk: risk("a") }]);
+
+    await report();
+
+    expect(cipherRiskService.computeRiskForCiphers).toHaveBeenCalledWith(expect.any(Array), userId, {
+      passwordMap: reuseMap,
+      checkExposed: true,
+    });
+  });
+
+  it("maps each result to its cipher by id, not by array position", async () => {
+    const a = login("a");
+    const b = login("b");
+    const c = login("c");
+    riskById.set("a", risk("a", { exposed: 4 }));
+    riskById.set("b", risk("b", { strength: 1 }));
+    riskById.set("c", risk("c", { reuse: 2 }));
+    cipherViews$.next([a, b, c]);
+    // Return results in a different order than the inputs.
+    cipherRiskService.computeRiskForCiphers.mockResolvedValueOnce([
+      riskById.get("c")!,
+      riskById.get("a")!,
+      riskById.get("b")!,
+    ]);
+
+    const result = await report();
+
+    expect(result.categoryItems.exposed.map((h) => h.cipherId)).toEqual(["a"]);
+    expect(result.categoryItems.weak.map((h) => h.cipherId)).toEqual(["b"]);
+    expect(result.categoryItems.reused.map((h) => h.cipherId)).toEqual(["c"]);
+  });
+});

--- a/bitwarden_license/bit-common/src/dirt/vault-health/services/implementations/default-vault-health-report.service.spec.ts
+++ b/bitwarden_license/bit-common/src/dirt/vault-health/services/implementations/default-vault-health-report.service.spec.ts
@@ -1,14 +1,13 @@
 import { mock } from "jest-mock-extended";
 import { BehaviorSubject, firstValueFrom } from "rxjs";
 
-import type { CipherRiskResult } from "@bitwarden/sdk-internal";
-
+import { UserId } from "@bitwarden/common/types/guid";
 import { CipherRiskService } from "@bitwarden/common/vault/abstractions/cipher-risk.service";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { CipherType } from "@bitwarden/common/vault/enums/cipher-type";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { LoginView } from "@bitwarden/common/vault/models/view/login.view";
-import { UserId } from "@bitwarden/common/types/guid";
+import type { CipherRiskResult } from "@bitwarden/sdk-internal";
 
 import { DefaultVaultHealthReportService } from "./default-vault-health-report.service";
 
@@ -170,7 +169,7 @@ describe("DefaultVaultHealthReportService", () => {
   });
 
   it("excludes org items, deleted items, non-logins, and passwordless logins from scope", async () => {
-    const personal = login("personal", { strength: 1 });
+    const personal = login("personal");
     riskById.set(personal.id, risk("personal", { strength: 1 }));
     cipherViews$.next([
       personal,
@@ -224,10 +223,14 @@ describe("DefaultVaultHealthReportService", () => {
 
     await report();
 
-    expect(cipherRiskService.computeRiskForCiphers).toHaveBeenCalledWith(expect.any(Array), userId, {
-      passwordMap: reuseMap,
-      checkExposed: true,
-    });
+    expect(cipherRiskService.computeRiskForCiphers).toHaveBeenCalledWith(
+      expect.any(Array),
+      userId,
+      {
+        passwordMap: reuseMap,
+        checkExposed: true,
+      },
+    );
   });
 
   it("maps each result to its cipher by id, not by array position", async () => {

--- a/bitwarden_license/bit-common/src/dirt/vault-health/services/implementations/default-vault-health-report.service.spec.ts
+++ b/bitwarden_license/bit-common/src/dirt/vault-health/services/implementations/default-vault-health-report.service.spec.ts
@@ -1,9 +1,8 @@
 import { mock } from "jest-mock-extended";
-import { BehaviorSubject, firstValueFrom } from "rxjs";
+import { firstValueFrom } from "rxjs";
 
 import { UserId } from "@bitwarden/common/types/guid";
 import { CipherRiskService } from "@bitwarden/common/vault/abstractions/cipher-risk.service";
-import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { CipherType } from "@bitwarden/common/vault/enums/cipher-type";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { LoginView } from "@bitwarden/common/vault/models/view/login.view";
@@ -14,9 +13,7 @@ import { DefaultVaultHealthReportService } from "./default-vault-health-report.s
 describe("DefaultVaultHealthReportService", () => {
   const userId = "test-user-id" as UserId;
 
-  let cipherService: ReturnType<typeof mock<CipherService>>;
   let cipherRiskService: ReturnType<typeof mock<CipherRiskService>>;
-  let cipherViews$: BehaviorSubject<CipherView[]>;
   let service: DefaultVaultHealthReportService;
 
   // Per-test lookup so risk results are returned for exactly the ciphers passed,
@@ -24,18 +21,15 @@ describe("DefaultVaultHealthReportService", () => {
   let riskById: Map<string, CipherRiskResult>;
 
   beforeEach(() => {
-    cipherService = mock<CipherService>();
     cipherRiskService = mock<CipherRiskService>();
-    cipherViews$ = new BehaviorSubject<CipherView[]>([]);
     riskById = new Map();
 
-    cipherService.cipherViews$.mockReturnValue(cipherViews$);
     cipherRiskService.buildPasswordReuseMap.mockResolvedValue({});
     cipherRiskService.computeRiskForCiphers.mockImplementation(async (ciphers) =>
       ciphers.map((c) => riskById.get(c.id)!),
     );
 
-    service = new DefaultVaultHealthReportService(cipherService, cipherRiskService);
+    service = new DefaultVaultHealthReportService(cipherRiskService);
   });
 
   afterEach(() => {
@@ -76,24 +70,25 @@ describe("DefaultVaultHealthReportService", () => {
     } as unknown as CipherRiskResult;
   };
 
-  /** Seed the vault with logins and register a risk result for each by id. */
-  const seed = (entries: { cipher: CipherView; risk: CipherRiskResult }[]) => {
+  /** Register a risk result per cipher id and return the cipher list to pass in. */
+  const withRisks = (entries: { cipher: CipherView; risk: CipherRiskResult }[]): CipherView[] => {
     entries.forEach((e) => riskById.set(e.cipher.id, e.risk));
-    cipherViews$.next(entries.map((e) => e.cipher));
+    return entries.map((e) => e.cipher);
   };
 
-  const report = () => firstValueFrom(service.vaultHealthReport$(userId));
+  const report = (ciphers: CipherView[]) =>
+    firstValueFrom(service.buildVaultHealthReport$(ciphers, userId));
 
   // --- tests ---------------------------------------------------------------
 
   it("categorizes each single-risk login into its matching category", async () => {
-    seed([
+    const ciphers = withRisks([
       { cipher: login("a"), risk: risk("a", { exposed: 3 }) },
       { cipher: login("b"), risk: risk("b", { strength: 1 }) },
       { cipher: login("c"), risk: risk("c", { reuse: 2 }) },
     ]);
 
-    const result = await report();
+    const result = await report(ciphers);
 
     expect(result.categoryItems.exposed.map((h) => h.cipherId)).toEqual(["a"]);
     expect(result.categoryItems.weak.map((h) => h.cipherId)).toEqual(["b"]);
@@ -101,42 +96,46 @@ describe("DefaultVaultHealthReportService", () => {
   });
 
   it("counts an exposed+weak+reused login once, under Exposed (highest-risk-wins)", async () => {
-    seed([{ cipher: login("a"), risk: risk("a", { strength: 1, exposed: 5, reuse: 3 }) }]);
+    const ciphers = withRisks([
+      { cipher: login("a"), risk: risk("a", { strength: 1, exposed: 5, reuse: 3 }) },
+    ]);
 
-    const result = await report();
+    const result = await report(ciphers);
 
     expect(result.atRiskCount).toBe(1);
     expect(result.categoryItems.exposed.map((h) => h.cipherId)).toEqual(["a"]);
     expect(result.categoryItems.weak).toHaveLength(0);
     expect(result.categoryItems.reused).toHaveLength(0);
-    // Full per-login breakdown still reflects all categories the login is at risk in.
-    const health = result.cipherHealth.find((h) => h.cipherId === "a")!;
+    // The bucketed item still carries every category it is at risk in, so the
+    // cross-category view is available without a separate flat list.
+    const health = result.categoryItems.exposed.find((h) => h.cipherId === "a")!;
     expect(health.hasExposedPassword).toBe(true);
     expect(health.hasWeakPassword).toBe(true);
     expect(health.hasReusedPassword).toBe(true);
   });
 
   it("places a weak+reused (not exposed) login under Weak", async () => {
-    seed([{ cipher: login("a"), risk: risk("a", { strength: 2, reuse: 4 }) }]);
+    const ciphers = withRisks([{ cipher: login("a"), risk: risk("a", { strength: 2, reuse: 4 }) }]);
 
-    const result = await report();
+    const result = await report(ciphers);
 
     expect(result.categoryItems.exposed).toHaveLength(0);
     expect(result.categoryItems.weak.map((h) => h.cipherId)).toEqual(["a"]);
     expect(result.categoryItems.reused).toHaveLength(0);
-    const health = result.cipherHealth.find((h) => h.cipherId === "a")!;
+    const health = result.categoryItems.weak.find((h) => h.cipherId === "a")!;
     expect(health.hasWeakPassword).toBe(true);
     expect(health.hasReusedPassword).toBe(true);
   });
 
   it("scores unique at-risk logins over total logins", async () => {
-    const entries = Array.from({ length: 10 }, (_, i) => ({
-      cipher: login(`c${i}`),
-      risk: i < 3 ? risk(`c${i}`, { strength: 1 }) : risk(`c${i}`),
-    }));
-    seed(entries);
+    const ciphers = withRisks(
+      Array.from({ length: 10 }, (_, i) => ({
+        cipher: login(`c${i}`),
+        risk: i < 3 ? risk(`c${i}`, { strength: 1 }) : risk(`c${i}`),
+      })),
+    );
 
-    const result = await report();
+    const result = await report(ciphers);
 
     expect(result.totalCount).toBe(10);
     expect(result.atRiskCount).toBe(3);
@@ -144,9 +143,7 @@ describe("DefaultVaultHealthReportService", () => {
   });
 
   it("returns an empty report with score 0 when there are no scoped logins", async () => {
-    cipherViews$.next([]);
-
-    const result = await report();
+    const result = await report([]);
 
     expect(result.totalCount).toBe(0);
     expect(result.atRiskCount).toBe(0);
@@ -158,76 +155,53 @@ describe("DefaultVaultHealthReportService", () => {
   });
 
   it("reports zero at risk when all logins are healthy", async () => {
-    seed([
+    const ciphers = withRisks([
       { cipher: login("a"), risk: risk("a") },
       { cipher: login("b"), risk: risk("b") },
       { cipher: login("c"), risk: risk("c") },
     ]);
 
-    const result = await report();
+    const result = await report(ciphers);
 
+    expect(result.totalCount).toBe(3);
     expect(result.atRiskCount).toBe(0);
     expect(result.score).toBe(0);
     expect(result.categoryItems.exposed).toHaveLength(0);
     expect(result.categoryItems.weak).toHaveLength(0);
     expect(result.categoryItems.reused).toHaveLength(0);
-    expect(result.cipherHealth).toHaveLength(3);
   });
 
   it("excludes org items, deleted items, non-logins, and passwordless logins from scope", async () => {
     const personal = login("personal");
     riskById.set(personal.id, risk("personal", { strength: 1 }));
-    cipherViews$.next([
+    const ciphers = [
       personal,
       login("org", { organizationId: "org-1" }),
       login("deleted", { deleted: true }),
       login("card", { type: CipherType.Card }),
       login("nopass", { password: "" }),
-    ]);
+    ];
 
-    const result = await report();
+    const result = await report(ciphers);
 
     expect(result.totalCount).toBe(1);
     const passed = cipherRiskService.computeRiskForCiphers.mock.calls[0][0];
     expect(passed.map((c) => c.id)).toEqual(["personal"]);
   });
 
-  it("re-emits an updated report when the vault changes", async () => {
-    seed([
-      { cipher: login("a"), risk: risk("a", { strength: 1 }) },
-      { cipher: login("b"), risk: risk("b") },
-    ]);
-    const emissions: number[] = [];
-    const sub = service.vaultHealthReport$(userId).subscribe((r) => emissions.push(r.atRiskCount));
-
-    // allow the first async report to resolve
-    await new Promise((resolve) => setTimeout(resolve, 0));
-
-    seed([
-      { cipher: login("a"), risk: risk("a", { strength: 1 }) },
-      { cipher: login("b"), risk: risk("b", { exposed: 2 }) },
-      { cipher: login("c"), risk: risk("c", { reuse: 2 }) },
-    ]);
-    await new Promise((resolve) => setTimeout(resolve, 0));
-
-    sub.unsubscribe();
-    expect(emissions[0]).toBe(1);
-    expect(emissions[emissions.length - 1]).toBe(3);
-  });
-
   it("propagates errors from the risk computation instead of swallowing them", async () => {
-    seed([{ cipher: login("a"), risk: risk("a") }]);
+    const ciphers = withRisks([{ cipher: login("a"), risk: risk("a") }]);
     cipherRiskService.computeRiskForCiphers.mockRejectedValueOnce(new Error("HIBP unavailable"));
 
-    await expect(report()).rejects.toThrow("HIBP unavailable");
+    await expect(report(ciphers)).rejects.toThrow("HIBP unavailable");
   });
 
   it("enables the exposed check and passes the pre-built reuse map", async () => {
     const reuseMap = { "pw-a": 1 };
     cipherRiskService.buildPasswordReuseMap.mockResolvedValue(reuseMap);
-    seed([{ cipher: login("a"), risk: risk("a") }]);
+    const ciphers = withRisks([{ cipher: login("a"), risk: risk("a") }]);
 
-    await report();
+    await report(ciphers);
 
     expect(cipherRiskService.computeRiskForCiphers).toHaveBeenCalledWith(
       expect.any(Array),
@@ -246,7 +220,6 @@ describe("DefaultVaultHealthReportService", () => {
     riskById.set("a", risk("a", { exposed: 4 }));
     riskById.set("b", risk("b", { strength: 1 }));
     riskById.set("c", risk("c", { reuse: 2 }));
-    cipherViews$.next([a, b, c]);
     // Return results in a different order than the inputs.
     cipherRiskService.computeRiskForCiphers.mockResolvedValueOnce([
       riskById.get("c")!,
@@ -254,59 +227,10 @@ describe("DefaultVaultHealthReportService", () => {
       riskById.get("b")!,
     ]);
 
-    const result = await report();
+    const result = await report([a, b, c]);
 
     expect(result.categoryItems.exposed.map((h) => h.cipherId)).toEqual(["a"]);
     expect(result.categoryItems.weak.map((h) => h.cipherId)).toEqual(["b"]);
     expect(result.categoryItems.reused.map((h) => h.cipherId)).toEqual(["c"]);
-  });
-
-  it("does not recompute when only non-scoped items change (identical scoped set)", async () => {
-    const a = login("a");
-    riskById.set("a", risk("a"));
-    const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
-
-    const sub = service.vaultHealthReport$(userId).subscribe();
-    cipherViews$.next([a, login("card1", { type: CipherType.Card })]);
-    await tick();
-    // Same scoped login set (a); only the ignored card changed.
-    cipherViews$.next([a, login("card2", { type: CipherType.Card })]);
-    await tick();
-    sub.unsubscribe();
-
-    expect(cipherRiskService.computeRiskForCiphers).toHaveBeenCalledTimes(1);
-  });
-
-  it("does not recompute when the same scoped set is re-emitted in a different order", async () => {
-    const a = login("a");
-    const b = login("b");
-    riskById.set("a", risk("a"));
-    riskById.set("b", risk("b"));
-    const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
-
-    const sub = service.vaultHealthReport$(userId).subscribe();
-    cipherViews$.next([a, b]);
-    await tick();
-    // Same logins, reversed emission order: the signature is sorted by id, so
-    // this must not be treated as a change.
-    cipherViews$.next([b, a]);
-    await tick();
-    sub.unsubscribe();
-
-    expect(cipherRiskService.computeRiskForCiphers).toHaveBeenCalledTimes(1);
-  });
-
-  it("recomputes when a scoped login's password changes", async () => {
-    riskById.set("a", risk("a"));
-    const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
-
-    const sub = service.vaultHealthReport$(userId).subscribe();
-    cipherViews$.next([login("a", { password: "pw1" })]);
-    await tick();
-    cipherViews$.next([login("a", { password: "pw2" })]);
-    await tick();
-    sub.unsubscribe();
-
-    expect(cipherRiskService.computeRiskForCiphers).toHaveBeenCalledTimes(2);
   });
 });

--- a/bitwarden_license/bit-common/src/dirt/vault-health/services/implementations/default-vault-health-report.service.spec.ts
+++ b/bitwarden_license/bit-common/src/dirt/vault-health/services/implementations/default-vault-health-report.service.spec.ts
@@ -254,4 +254,34 @@ describe("DefaultVaultHealthReportService", () => {
     expect(result.categoryItems.weak.map((h) => h.cipherId)).toEqual(["b"]);
     expect(result.categoryItems.reused.map((h) => h.cipherId)).toEqual(["c"]);
   });
+
+  it("does not recompute when only non-scoped items change (identical scoped set)", async () => {
+    const a = login("a");
+    riskById.set("a", risk("a"));
+    const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+    const sub = service.vaultHealthReport$(userId).subscribe();
+    cipherViews$.next([a, login("card1", { type: CipherType.Card })]);
+    await tick();
+    // Same scoped login set (a); only the ignored card changed.
+    cipherViews$.next([a, login("card2", { type: CipherType.Card })]);
+    await tick();
+    sub.unsubscribe();
+
+    expect(cipherRiskService.computeRiskForCiphers).toHaveBeenCalledTimes(1);
+  });
+
+  it("recomputes when a scoped login's password changes", async () => {
+    riskById.set("a", risk("a"));
+    const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+    const sub = service.vaultHealthReport$(userId).subscribe();
+    cipherViews$.next([login("a", { password: "pw1" })]);
+    await tick();
+    cipherViews$.next([login("a", { password: "pw2" })]);
+    await tick();
+    sub.unsubscribe();
+
+    expect(cipherRiskService.computeRiskForCiphers).toHaveBeenCalledTimes(2);
+  });
 });

--- a/bitwarden_license/bit-common/src/dirt/vault-health/services/implementations/default-vault-health-report.service.spec.ts
+++ b/bitwarden_license/bit-common/src/dirt/vault-health/services/implementations/default-vault-health-report.service.spec.ts
@@ -271,6 +271,25 @@ describe("DefaultVaultHealthReportService", () => {
     expect(cipherRiskService.computeRiskForCiphers).toHaveBeenCalledTimes(1);
   });
 
+  it("does not recompute when the same scoped set is re-emitted in a different order", async () => {
+    const a = login("a");
+    const b = login("b");
+    riskById.set("a", risk("a"));
+    riskById.set("b", risk("b"));
+    const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+    const sub = service.vaultHealthReport$(userId).subscribe();
+    cipherViews$.next([a, b]);
+    await tick();
+    // Same logins, reversed emission order: the signature is sorted by id, so
+    // this must not be treated as a change.
+    cipherViews$.next([b, a]);
+    await tick();
+    sub.unsubscribe();
+
+    expect(cipherRiskService.computeRiskForCiphers).toHaveBeenCalledTimes(1);
+  });
+
   it("recomputes when a scoped login's password changes", async () => {
     riskById.set("a", risk("a"));
     const tick = () => new Promise((resolve) => setTimeout(resolve, 0));

--- a/bitwarden_license/bit-common/src/dirt/vault-health/services/implementations/default-vault-health-report.service.spec.ts
+++ b/bitwarden_license/bit-common/src/dirt/vault-health/services/implementations/default-vault-health-report.service.spec.ts
@@ -95,7 +95,6 @@ describe("DefaultVaultHealthReportService", () => {
 
     const result = await report();
 
-    expect(result.categoryCounts).toEqual({ exposed: 1, weak: 1, reused: 1 });
     expect(result.categoryItems.exposed.map((h) => h.cipherId)).toEqual(["a"]);
     expect(result.categoryItems.weak.map((h) => h.cipherId)).toEqual(["b"]);
     expect(result.categoryItems.reused.map((h) => h.cipherId)).toEqual(["c"]);
@@ -107,8 +106,9 @@ describe("DefaultVaultHealthReportService", () => {
     const result = await report();
 
     expect(result.atRiskCount).toBe(1);
-    expect(result.categoryCounts).toEqual({ exposed: 1, weak: 0, reused: 0 });
     expect(result.categoryItems.exposed.map((h) => h.cipherId)).toEqual(["a"]);
+    expect(result.categoryItems.weak).toHaveLength(0);
+    expect(result.categoryItems.reused).toHaveLength(0);
     // Full per-login breakdown still reflects all categories the login is at risk in.
     const health = result.cipherHealth.find((h) => h.cipherId === "a")!;
     expect(health.hasExposedPassword).toBe(true);
@@ -121,7 +121,9 @@ describe("DefaultVaultHealthReportService", () => {
 
     const result = await report();
 
-    expect(result.categoryCounts).toEqual({ exposed: 0, weak: 1, reused: 0 });
+    expect(result.categoryItems.exposed).toHaveLength(0);
+    expect(result.categoryItems.weak.map((h) => h.cipherId)).toEqual(["a"]);
+    expect(result.categoryItems.reused).toHaveLength(0);
     const health = result.cipherHealth.find((h) => h.cipherId === "a")!;
     expect(health.hasWeakPassword).toBe(true);
     expect(health.hasReusedPassword).toBe(true);
@@ -149,7 +151,9 @@ describe("DefaultVaultHealthReportService", () => {
     expect(result.totalCount).toBe(0);
     expect(result.atRiskCount).toBe(0);
     expect(result.score).toBe(0);
-    expect(result.categoryCounts).toEqual({ exposed: 0, weak: 0, reused: 0 });
+    expect(result.categoryItems.exposed).toHaveLength(0);
+    expect(result.categoryItems.weak).toHaveLength(0);
+    expect(result.categoryItems.reused).toHaveLength(0);
     expect(cipherRiskService.computeRiskForCiphers).not.toHaveBeenCalled();
   });
 
@@ -164,7 +168,9 @@ describe("DefaultVaultHealthReportService", () => {
 
     expect(result.atRiskCount).toBe(0);
     expect(result.score).toBe(0);
-    expect(result.categoryCounts).toEqual({ exposed: 0, weak: 0, reused: 0 });
+    expect(result.categoryItems.exposed).toHaveLength(0);
+    expect(result.categoryItems.weak).toHaveLength(0);
+    expect(result.categoryItems.reused).toHaveLength(0);
     expect(result.cipherHealth).toHaveLength(3);
   });
 

--- a/bitwarden_license/bit-common/src/dirt/vault-health/services/implementations/default-vault-health-report.service.ts
+++ b/bitwarden_license/bit-common/src/dirt/vault-health/services/implementations/default-vault-health-report.service.ts
@@ -1,4 +1,4 @@
-import { Observable, from, map, switchMap } from "rxjs";
+import { Observable, distinctUntilChanged, from, map, switchMap } from "rxjs";
 
 import { UserId } from "@bitwarden/common/types/guid";
 import { CipherRiskService } from "@bitwarden/common/vault/abstractions/cipher-risk.service";
@@ -21,6 +21,11 @@ export class DefaultVaultHealthReportService implements VaultHealthReportService
   vaultHealthReport$(userId: UserId): Observable<VaultHealthReportView> {
     return this.cipherService.cipherViews$(userId).pipe(
       map((ciphers) => this.filterScopedLogins(ciphers)),
+      // cipherViews$ re-emits on any vault change, including edits to items this
+      // report ignores (cards, org items, deleted items). Only recompute when the
+      // scoped login set actually changes, so we don't fire a fresh HIBP request
+      // for an identical set. Still re-emits whenever the vault changes (the AC).
+      distinctUntilChanged((prev, curr) => this.scopeSignature(prev) === this.scopeSignature(curr)),
       switchMap((logins) => from(this.buildReport(logins, userId))),
     );
   }
@@ -37,6 +42,19 @@ export class DefaultVaultHealthReportService implements VaultHealthReportService
         c.organizationId == null &&
         !c.isDeleted &&
         (c.login?.password ?? "") !== "",
+    );
+  }
+
+  /**
+   * A stable signature of the inputs that affect the report: each login's id,
+   * username, and password (the same fields the SDK risk computation consumes).
+   * Two scoped sets with an equal signature produce an identical report, so the
+   * recompute (and its HIBP call) can be skipped. Uses a structural JSON encoding
+   * so a space in a username/password cannot collide two distinct sets.
+   */
+  private scopeSignature(logins: CipherView[]): string {
+    return JSON.stringify(
+      logins.map((c) => [c.id, c.login?.username ?? "", c.login?.password ?? ""]),
     );
   }
 

--- a/bitwarden_license/bit-common/src/dirt/vault-health/services/implementations/default-vault-health-report.service.ts
+++ b/bitwarden_license/bit-common/src/dirt/vault-health/services/implementations/default-vault-health-report.service.ts
@@ -50,11 +50,15 @@ export class DefaultVaultHealthReportService implements VaultHealthReportService
    * username, and password (the same fields the SDK risk computation consumes).
    * Two scoped sets with an equal signature produce an identical report, so the
    * recompute (and its HIBP call) can be skipped. Uses a structural JSON encoding
-   * so a space in a username/password cannot collide two distinct sets.
+   * so a space in a username/password cannot collide two distinct sets. The
+   * tuples are sorted by id so the signature is independent of cipherViews$
+   * emission order: only a genuine change to the scoped set triggers a recompute.
    */
   private scopeSignature(logins: CipherView[]): string {
     return JSON.stringify(
-      logins.map((c) => [c.id, c.login?.username ?? "", c.login?.password ?? ""]),
+      logins
+        .map((c) => [c.id, c.login?.username ?? "", c.login?.password ?? ""])
+        .sort((a, b) => a[0].localeCompare(b[0])),
     );
   }
 

--- a/bitwarden_license/bit-common/src/dirt/vault-health/services/implementations/default-vault-health-report.service.ts
+++ b/bitwarden_license/bit-common/src/dirt/vault-health/services/implementations/default-vault-health-report.service.ts
@@ -81,7 +81,6 @@ export class DefaultVaultHealthReportService implements VaultHealthReportService
     const cipherHealth = risks.map((risk) => this.toCipherHealthView(risk));
     const atRisk = cipherHealth.filter((health) => health.isAtRisk());
 
-    const categoryCounts: Record<RiskCategory, number> = { exposed: 0, weak: 0, reused: 0 };
     const categoryItems: Record<RiskCategory, CipherHealthView[]> = {
       exposed: [],
       weak: [],
@@ -90,7 +89,6 @@ export class DefaultVaultHealthReportService implements VaultHealthReportService
 
     for (const health of atRisk) {
       const category = this.highestRiskCategory(health);
-      categoryCounts[category] += 1;
       categoryItems[category].push(health);
     }
 
@@ -98,7 +96,6 @@ export class DefaultVaultHealthReportService implements VaultHealthReportService
       totalCount,
       atRiskCount: atRisk.length,
       score: atRisk.length / totalCount,
-      categoryCounts,
       categoryItems,
       cipherHealth,
     });

--- a/bitwarden_license/bit-common/src/dirt/vault-health/services/implementations/default-vault-health-report.service.ts
+++ b/bitwarden_license/bit-common/src/dirt/vault-health/services/implementations/default-vault-health-report.service.ts
@@ -1,0 +1,108 @@
+import { Observable, from, map, switchMap } from "rxjs";
+
+import { CipherRiskResult } from "@bitwarden/sdk-internal";
+
+import { CipherRiskService } from "@bitwarden/common/vault/abstractions/cipher-risk.service";
+import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
+import { CipherType } from "@bitwarden/common/vault/enums/cipher-type";
+import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+import { UserId } from "@bitwarden/common/types/guid";
+
+import { CipherHealthView } from "../../../access-intelligence/models";
+import { RiskCategory } from "../../models/risk-category";
+import { VaultHealthReportView } from "../../models/view/vault-health-report.view";
+import { VaultHealthReportService } from "../abstractions/vault-health-report.service";
+
+export class DefaultVaultHealthReportService implements VaultHealthReportService {
+  constructor(
+    private cipherService: CipherService,
+    private cipherRiskService: CipherRiskService,
+  ) {}
+
+  vaultHealthReport$(userId: UserId): Observable<VaultHealthReportView> {
+    return this.cipherService.cipherViews$(userId).pipe(
+      map((ciphers) => this.filterScopedLogins(ciphers)),
+      switchMap((logins) => from(this.buildReport(logins, userId))),
+    );
+  }
+
+  /**
+   * Personal-vault logins with a password: Login type, no organization,
+   * not deleted, non-empty password. A superset of the SDK's own predicate,
+   * so every login passed to the risk service qualifies.
+   */
+  private filterScopedLogins(ciphers: CipherView[] | null): CipherView[] {
+    return (ciphers ?? []).filter(
+      (c) =>
+        c.type === CipherType.Login &&
+        c.organizationId == null &&
+        !c.isDeleted &&
+        (c.login?.password ?? "") !== "",
+    );
+  }
+
+  private async buildReport(logins: CipherView[], userId: UserId): Promise<VaultHealthReportView> {
+    const totalCount = logins.length;
+    if (totalCount === 0) {
+      return new VaultHealthReportView();
+    }
+
+    // Pre-build the reuse map so reuse_count is populated, then compute risk
+    // with exposed (HIBP) checking enabled. Errors propagate to the caller.
+    const passwordMap = await this.cipherRiskService.buildPasswordReuseMap(logins, userId);
+    const risks = await this.cipherRiskService.computeRiskForCiphers(logins, userId, {
+      passwordMap,
+      checkExposed: true,
+    });
+
+    // Each CipherRiskResult carries its own `id`, so map results to per-login
+    // views directly by id (no reliance on array position).
+    const cipherHealth = risks.map((risk) => this.toCipherHealthView(risk));
+    const atRisk = cipherHealth.filter((health) => health.isAtRisk());
+
+    const categoryCounts: Record<RiskCategory, number> = { exposed: 0, weak: 0, reused: 0 };
+    const categoryItems: Record<RiskCategory, CipherHealthView[]> = {
+      exposed: [],
+      weak: [],
+      reused: [],
+    };
+
+    for (const health of atRisk) {
+      const category = this.highestRiskCategory(health);
+      categoryCounts[category] += 1;
+      categoryItems[category].push(health);
+    }
+
+    return new VaultHealthReportView({
+      totalCount,
+      atRiskCount: atRisk.length,
+      score: atRisk.length / totalCount,
+      categoryCounts,
+      categoryItems,
+      cipherHealth,
+    });
+  }
+
+  private toCipherHealthView(risk: CipherRiskResult): CipherHealthView {
+    const exposedCount = risk.exposed_result.type === "Found" ? risk.exposed_result.value : 0;
+    return new CipherHealthView({
+      cipherId: risk.id as string,
+      hasExposedPassword: exposedCount > 0,
+      hasWeakPassword: risk.password_strength < 3,
+      hasReusedPassword: (risk.reuse_count ?? 1) > 1,
+      exposedCount,
+      weakPasswordScore: risk.password_strength,
+    });
+  }
+
+  /** Highest-risk-wins: Exposed > Weak > Reused. Only called for at-risk logins. */
+  private highestRiskCategory(health: CipherHealthView): RiskCategory {
+    if (health.hasExposedPassword) {
+      return RiskCategory.Exposed;
+    }
+    if (health.hasWeakPassword) {
+      return RiskCategory.Weak;
+    }
+    return RiskCategory.Reused;
+  }
+}

--- a/bitwarden_license/bit-common/src/dirt/vault-health/services/implementations/default-vault-health-report.service.ts
+++ b/bitwarden_license/bit-common/src/dirt/vault-health/services/implementations/default-vault-health-report.service.ts
@@ -1,14 +1,13 @@
 import { Observable, from, map, switchMap } from "rxjs";
 
-import { CipherRiskResult } from "@bitwarden/sdk-internal";
-
+import { UserId } from "@bitwarden/common/types/guid";
 import { CipherRiskService } from "@bitwarden/common/vault/abstractions/cipher-risk.service";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { CipherType } from "@bitwarden/common/vault/enums/cipher-type";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
-import { UserId } from "@bitwarden/common/types/guid";
+import { CipherRiskResult } from "@bitwarden/sdk-internal";
 
-import { CipherHealthView } from "../../../access-intelligence/models";
+import { CipherHealthView } from "../../../access-intelligence/models/view/cipher-health.view";
 import { RiskCategory } from "../../models/risk-category";
 import { VaultHealthReportView } from "../../models/view/vault-health-report.view";
 import { VaultHealthReportService } from "../abstractions/vault-health-report.service";
@@ -86,7 +85,7 @@ export class DefaultVaultHealthReportService implements VaultHealthReportService
   private toCipherHealthView(risk: CipherRiskResult): CipherHealthView {
     const exposedCount = risk.exposed_result.type === "Found" ? risk.exposed_result.value : 0;
     return new CipherHealthView({
-      cipherId: risk.id as string,
+      cipherId: String(risk.id),
       hasExposedPassword: exposedCount > 0,
       hasWeakPassword: risk.password_strength < 3,
       hasReusedPassword: (risk.reuse_count ?? 1) > 1,

--- a/bitwarden_license/bit-common/src/dirt/vault-health/services/implementations/default-vault-health-report.service.ts
+++ b/bitwarden_license/bit-common/src/dirt/vault-health/services/implementations/default-vault-health-report.service.ts
@@ -1,8 +1,7 @@
-import { Observable, distinctUntilChanged, from, map, switchMap } from "rxjs";
+import { Observable, from } from "rxjs";
 
 import { UserId } from "@bitwarden/common/types/guid";
 import { CipherRiskService } from "@bitwarden/common/vault/abstractions/cipher-risk.service";
-import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { CipherType } from "@bitwarden/common/vault/enums/cipher-type";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { CipherRiskResult } from "@bitwarden/sdk-internal";
@@ -13,21 +12,21 @@ import { VaultHealthReportView } from "../../models/view/vault-health-report.vie
 import { VaultHealthReportService } from "../abstractions/vault-health-report.service";
 
 export class DefaultVaultHealthReportService implements VaultHealthReportService {
-  constructor(
-    private cipherService: CipherService,
-    private cipherRiskService: CipherRiskService,
-  ) {}
+  constructor(private cipherRiskService: CipherRiskService) {}
 
-  vaultHealthReport$(userId: UserId): Observable<VaultHealthReportView> {
-    return this.cipherService.cipherViews$(userId).pipe(
-      map((ciphers) => this.filterScopedLogins(ciphers)),
-      // cipherViews$ re-emits on any vault change, including edits to items this
-      // report ignores (cards, org items, deleted items). Only recompute when the
-      // scoped login set actually changes, so we don't fire a fresh HIBP request
-      // for an identical set. Still re-emits whenever the vault changes (the AC).
-      distinctUntilChanged((prev, curr) => this.scopeSignature(prev) === this.scopeSignature(curr)),
-      switchMap((logins) => from(this.buildReport(logins, userId))),
-    );
+  /**
+   * Compute-only: the caller (the Health-tab root component) owns fetching the
+   * vault ciphers and deciding when to recompute. This service filters the
+   * given ciphers to the personal-vault logins in scope, then categorizes,
+   * deduplicates (highest-risk-wins), and scores them. Errors from the risk
+   * computation propagate to the caller.
+   */
+  buildVaultHealthReport$(
+    ciphers: CipherView[],
+    userId: UserId,
+  ): Observable<VaultHealthReportView> {
+    const logins = this.filterScopedLogins(ciphers);
+    return from(this.buildReport(logins, userId));
   }
 
   /**
@@ -42,23 +41,6 @@ export class DefaultVaultHealthReportService implements VaultHealthReportService
         c.organizationId == null &&
         !c.isDeleted &&
         (c.login?.password ?? "") !== "",
-    );
-  }
-
-  /**
-   * A stable signature of the inputs that affect the report: each login's id,
-   * username, and password (the same fields the SDK risk computation consumes).
-   * Two scoped sets with an equal signature produce an identical report, so the
-   * recompute (and its HIBP call) can be skipped. Uses a structural JSON encoding
-   * so a space in a username/password cannot collide two distinct sets. The
-   * tuples are sorted by id so the signature is independent of cipherViews$
-   * emission order: only a genuine change to the scoped set triggers a recompute.
-   */
-  private scopeSignature(logins: CipherView[]): string {
-    return JSON.stringify(
-      logins
-        .map((c) => [c.id, c.login?.username ?? "", c.login?.password ?? ""])
-        .sort((a, b) => a[0].localeCompare(b[0])),
     );
   }
 
@@ -78,8 +60,8 @@ export class DefaultVaultHealthReportService implements VaultHealthReportService
 
     // Each CipherRiskResult carries its own `id`, so map results to per-login
     // views directly by id (no reliance on array position).
-    const cipherHealth = risks.map((risk) => this.toCipherHealthView(risk));
-    const atRisk = cipherHealth.filter((health) => health.isAtRisk());
+    const healthViews = risks.map((risk) => this.toCipherHealthView(risk));
+    const atRisk = healthViews.filter((health) => health.isAtRisk());
 
     const categoryItems: Record<RiskCategory, CipherHealthView[]> = {
       exposed: [],
@@ -97,7 +79,6 @@ export class DefaultVaultHealthReportService implements VaultHealthReportService
       atRiskCount: atRisk.length,
       score: atRisk.length / totalCount,
       categoryItems,
-      cipherHealth,
     });
   }
 

--- a/bitwarden_license/bit-common/src/dirt/vault-health/services/index.ts
+++ b/bitwarden_license/bit-common/src/dirt/vault-health/services/index.ts
@@ -1,0 +1,2 @@
+export * from "./abstractions/vault-health-report.service";
+export * from "./implementations/default-vault-health-report.service";

--- a/libs/common/src/enums/feature-flag.enum.ts
+++ b/libs/common/src/enums/feature-flag.enum.ts
@@ -88,7 +88,6 @@ export enum FeatureFlag {
   PasskeyLoginReport = "inno-passkey-directory-report",
   AccessIntelligenceReportFileStorage = "pm-31920-access-intelligence-azure-file-storage",
   AccessIntelligenceAdoptionUxImprovements = "pm-34723-access-intelligence-adoption-ux-improvements",
-  PremiumUserHealthReports = "pm-35928-premium-user-health-reports",
 
   /* Vault */
   PM32009NewItemTypes = "pm-32009-new-item-types",
@@ -178,7 +177,6 @@ export const DefaultFeatureFlagValue = {
   [FeatureFlag.PasskeyLoginReport]: FALSE,
   [FeatureFlag.AccessIntelligenceReportFileStorage]: FALSE,
   [FeatureFlag.AccessIntelligenceAdoptionUxImprovements]: FALSE,
-  [FeatureFlag.PremiumUserHealthReports]: FALSE,
 
   /* Vault */
   [FeatureFlag.PM32009NewItemTypes]: FALSE,

--- a/libs/common/src/enums/feature-flag.enum.ts
+++ b/libs/common/src/enums/feature-flag.enum.ts
@@ -88,6 +88,7 @@ export enum FeatureFlag {
   PasskeyLoginReport = "inno-passkey-directory-report",
   AccessIntelligenceReportFileStorage = "pm-31920-access-intelligence-azure-file-storage",
   AccessIntelligenceAdoptionUxImprovements = "pm-34723-access-intelligence-adoption-ux-improvements",
+  PremiumUserHealthReports = "pm-35928-premium-user-health-reports",
 
   /* Vault */
   PM32009NewItemTypes = "pm-32009-new-item-types",
@@ -177,6 +178,7 @@ export const DefaultFeatureFlagValue = {
   [FeatureFlag.PasskeyLoginReport]: FALSE,
   [FeatureFlag.AccessIntelligenceReportFileStorage]: FALSE,
   [FeatureFlag.AccessIntelligenceAdoptionUxImprovements]: FALSE,
+  [FeatureFlag.PremiumUserHealthReports]: FALSE,
 
   /* Vault */
   [FeatureFlag.PM32009NewItemTypes]: FALSE,


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-39227

## 📔 Objective

Adds the browser extension's vault-health orchestration service for the new Health tab — the aggregation layer on top of the existing per-login risk metrics.

`VaultHealthReportService` loads the user's personal-vault logins reactively from `cipherViews$`, composes the Vault-owned SDK-backed `CipherRiskService` (it does not re-implement report logic), and emits a typed `VaultHealthReportView` that:

- categorizes each at-risk login and deduplicates it into a single highest-risk category (Exposed > Weak > Reused), counted once;
- also retains every category each login is at risk in, for views needing cross-category context;
- computes the vault-health score as unique at-risk logins ÷ total logins;
- re-emits when the vault changes, and skips recompute (and its HIBP call) when the scoped login set is unchanged.

Scope is personal-vault Login items with a password (organization, deleted, and passwordless items are excluded). This is the service, its models, and unit tests only — no UI, no persistence, no API, and no SDK changes. The consuming views (PM-35945, PM-35946) and the scan trigger / failure states (PM-39223) build on this service. Risk-computation errors propagate to the caller so the scan story can route to its failure state.

The feature lives in the licensed package (`bitwarden_license/bit-common/src/dirt/vault-health/`) and is registered in the licensed browser build; the `pm-35928-premium-user-health-reports` flag is added (default off) for the consuming stories to gate against.

## 📸 Screenshots

Not applicable — no UI changes (service, models, and unit tests only).