### PR TITLE
only serve desktop bundle through bitwarden-desktop-file://

### DIFF
--- a/apps/desktop/scripts/after-pack.js
+++ b/apps/desktop/scripts/after-pack.js
@@ -180,10 +180,9 @@ async function addElectronFuses(context) {
     // App refuses to open when enabled
     [FuseV1Options.LoadBrowserProcessSpecificV8Snapshot]: false,
 
-    // To disable this, we should stop using the file:// protocol to load the app bundle
-    // This can be done by defining a custom app:// protocol and loading the bundle from there,
-    // but then any requests to the server will be blocked by CORS policy
-    [FuseV1Options.GrantFileProtocolExtraPrivileges]: true,
+    // The app bundle loads over a custom bw-desktop-file:// protocol, not file://,
+    // so file:// needs no extra privileges.
+    [FuseV1Options.GrantFileProtocolExtraPrivileges]: false,
 
     // Enables V8 signal handlers to trap Out of Bounds memory access from WebAssembly
     [FuseV1Options.WasmTrapHandlers]: true,

--- a/apps/desktop/src/main/window.main.spec.ts
+++ b/apps/desktop/src/main/window.main.spec.ts
@@ -1,6 +1,3 @@
-import { pathToFileURL } from "node:url";
-import * as path from "path";
-
 import { mock } from "jest-mock-extended";
 
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
@@ -43,12 +40,6 @@ describe("WindowMain", () => {
     // in production code.
     let isLocalBundleUrl: (url: string) => boolean;
 
-    // The `file:` branch accepts only the app's own bundle, derived from
-    // __dirname the same way the production code does. __dirname here is
-    // this spec's directory, which is also the directory the code under test
-    // resolves against, so this is the real bundle URL for the running test.
-    const bundleUrl = pathToFileURL(path.join(__dirname, "/index.html")).toString();
-
     beforeEach(() => {
       sut = new WindowMain(
         mock<BiometricStateService>(),
@@ -64,30 +55,8 @@ describe("WindowMain", () => {
       isLocalBundleUrl = (url: string) => (sut as any).isLocalBundleUrl(url);
     });
 
-    it("returns true for the app's own file:// bundle URL", () => {
-      expect(isLocalBundleUrl(bundleUrl)).toBe(true);
-    });
-
-    it("returns true for the app's own bundle URL with a hash", () => {
-      expect(isLocalBundleUrl(`${bundleUrl}#/passkeys`)).toBe(true);
-    });
-
-    it("returns true for the app's own bundle URL with a query", () => {
-      expect(isLocalBundleUrl(`${bundleUrl}?redirectUrl=/passkeys`)).toBe(true);
-    });
-
-    it("returns false for a file:// URL with a foreign host", () => {
-      expect(isLocalBundleUrl("file://attacker.com/index.html")).toBe(false);
-    });
-
-    it("returns false for a file:// URL in a foreign directory", () => {
-      expect(isLocalBundleUrl("file:///tmp/evil/index.html")).toBe(false);
-    });
-
-    it("returns false for a file:// URL that traverses outside the bundle dir", () => {
-      // The `../` segments normalize (via the URL parser) to
-      // /tmp/evil/index.html, outside the bundle.
-      expect(isLocalBundleUrl(`${bundleUrl}/../../../tmp/evil/index.html`)).toBe(false);
+    it("returns false for any file:// URL regardless of host or path", () => {
+      expect(isLocalBundleUrl("file:///Applications/Bitwarden/dist/index.html")).toBe(false);
     });
 
     it("returns true for a bw-desktop-file://bundle/index.html URL", () => {

--- a/apps/desktop/src/main/window.main.ts
+++ b/apps/desktop/src/main/window.main.ts
@@ -279,18 +279,6 @@ export class WindowMain {
   }
 
   private getWindowUrl(partial: Partial<url.UrlObject> = {}): string {
-    // TODO(PM-33211): The custom file scheme only works on servers that support it for CORS (>=2026.3.0).
-    // We have it disabled by default until self-hosted users are updated to maintain compatibility.
-    // When removing this, remember to disable the [FuseV1Options.GrantFileProtocolExtraPrivileges] fuse in after-pack.js.
-    if (process.env.BITWARDEN_USE_CUSTOM_FILE_SCHEME !== "true") {
-      return url.format({
-        protocol: "file:",
-        pathname: path.join(__dirname, "/index.html"),
-        slashes: true,
-        ...partial,
-      });
-    }
-
     return url.format({
       protocol: customFileScheme,
       host: customFileHost,
@@ -301,8 +289,8 @@ export class WindowMain {
   }
 
   /**
-   * Whether the URL is our own renderer bundle. Accepts both schemes {@link getWindowUrl} can
-   * emit (`file:` and `bw-desktop-file:`) so navigation guards need not know the active build mode.
+   * Whether the URL is our own renderer bundle, served over the custom {@link customFileScheme}
+   * protocol by {@link getWindowUrl}.
    */
   private isLocalBundleUrl(url: string): boolean {
     let parsedUrl: URL;
@@ -312,21 +300,7 @@ export class WindowMain {
       return false;
     }
 
-    if (parsedUrl.protocol === "file:") {
-      // TODO(PM-33211): remove this branch once the custom-scheme cutover lands. An app no longer
-      // served over file: would keep only a permissive file: attack surface here.
-      //
-      // Check the full path, not the filename: file://attacker.com/index.html would pass a suffix test.
-      // (Hash/query live outside pathname, so index.html#/passkeys still matches.)
-      const bundlePathname = pathToFileURL(path.join(__dirname, "/index.html")).pathname;
-      return parsedUrl.host === "" && parsedUrl.pathname === bundlePathname;
-    }
-
-    if (parsedUrl.protocol === `${customFileScheme}:`) {
-      return parsedUrl.hostname === customFileHost;
-    }
-
-    return false;
+    return parsedUrl.protocol === `${customFileScheme}:` && parsedUrl.hostname === customFileHost;
   }
 
   // TODO: REMOVE ONCE WE CAN STOP USING FAKE POP UP BTN FROM TRAY


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-40845

## 📔 Objective

In #19208 we started using a custom url protocol to load the desktop app bundle. We left some backwards compatibility logic in when switching because of independent server requirements. See bitwarden/server#7080 for more info on these.

All non-compliant versions have since rolled out of support, so we can cut this condition now. This commit does that.