### PR TITLE
[PM-40693] Hide copy button on file Sends

### DIFF
--- a/apps/browser/src/tools/popup/send-v2/add-edit/send-add-edit.component.ts
+++ b/apps/browser/src/tools/popup/send-v2/add-edit/send-add-edit.component.ts
@@ -235,9 +235,6 @@ export class SendAddEditComponent {
       const sendDisabledReason = await this.sendPolicyService.sendDisabledReason(
         this.config.originalSend,
       );
-      const showMakeCopyButton =
-        sendDisabledReason !== SendDisabledReason.None &&
-        this.config.originalSend.type === SendType.Text;
       if (sendDisabledReason === SendDisabledReason.RestrictedType) {
         this.disabledSendConfig.set({
           title:
@@ -245,13 +242,17 @@ export class SendAddEditComponent {
               ? "orgDoesNotAllowTextSends"
               : "orgDoesNotAllowFileSends",
           message: "sendWillAutomaticallyExpire",
-          showMakeCopyButton,
+          // It's impossible to make a compliant copy of this Send
+          // without changing the type so we hide the button
+          showMakeCopyButton: false,
         });
       } else if (sendDisabledReason === SendDisabledReason.Other) {
         this.disabledSendConfig.set({
           title: "sendNotCompliantWithYourOrgsPolicy",
           message: "sendDisabledNonCompliantBannerMessage",
-          showMakeCopyButton,
+          // We can't attach an existing file to a new Send so
+          // we can only make a copy if the Send is of type Text
+          showMakeCopyButton: this.config.originalSend?.type === SendType.Text,
         });
       } else {
         this.disabledSendConfig.set(null);

--- a/apps/browser/src/tools/popup/send-v2/add-edit/send-add-edit.component.ts
+++ b/apps/browser/src/tools/popup/send-v2/add-edit/send-add-edit.component.ts
@@ -235,6 +235,10 @@ export class SendAddEditComponent {
       const sendDisabledReason = await this.sendPolicyService.sendDisabledReason(
         this.config.originalSend,
       );
+      // We can make a copy of a disabled Send only if two conditions are met
+      // 1. The Send doesn't violate the SendType restriction of the policy (if Text
+      // Sends aren't allowed we'd have to turn the copy into a File Send)
+      // 2. The Send is a Text Send (we can't attach existing files to new Sends)
       if (sendDisabledReason === SendDisabledReason.RestrictedType) {
         this.disabledSendConfig.set({
           title:
@@ -242,17 +246,18 @@ export class SendAddEditComponent {
               ? "orgDoesNotAllowTextSends"
               : "orgDoesNotAllowFileSends",
           message: "sendWillAutomaticallyExpire",
-          // It's impossible to make a compliant copy of this Send
-          // without changing the type so we hide the button
+          // This branch violates condition 1 so we never allow copying
           showMakeCopyButton: false,
         });
       } else if (sendDisabledReason === SendDisabledReason.Other) {
+        // This branch meets condition 1, so all we need to check is condition 2
+        const showMakeCopyButton = this.config.originalSend?.type === SendType.Text;
         this.disabledSendConfig.set({
           title: "sendNotCompliantWithYourOrgsPolicy",
-          message: "sendDisabledNonCompliantBannerMessage",
-          // We can't attach an existing file to a new Send so
-          // we can only make a copy if the Send is of type Text
-          showMakeCopyButton: this.config.originalSend?.type === SendType.Text,
+          message: showMakeCopyButton
+            ? "sendDisabledNonCompliantBannerMessage"
+            : "sendWillAutomaticallyExpire",
+          showMakeCopyButton,
         });
       } else {
         this.disabledSendConfig.set(null);

--- a/apps/browser/src/tools/popup/send-v2/add-edit/send-add-edit.component.ts
+++ b/apps/browser/src/tools/popup/send-v2/add-edit/send-add-edit.component.ts
@@ -236,8 +236,8 @@ export class SendAddEditComponent {
         this.config.originalSend,
       );
       // We can make a copy of a disabled Send only if two conditions are met
-      // 1. The Send doesn't violate the SendType restriction of the policy (if Text
-      // Sends aren't allowed we'd have to turn the copy into a File Send)
+      // 1. The Send doesn't violate the SendType restriction of the policy (if
+      // Text Sends are disallowed we cannot make a new one for the copy)
       // 2. The Send is a Text Send (we can't attach existing files to new Sends)
       if (sendDisabledReason === SendDisabledReason.RestrictedType) {
         this.disabledSendConfig.set({

--- a/apps/browser/src/tools/popup/send-v2/add-edit/send-add-edit.component.ts
+++ b/apps/browser/src/tools/popup/send-v2/add-edit/send-add-edit.component.ts
@@ -235,6 +235,9 @@ export class SendAddEditComponent {
       const sendDisabledReason = await this.sendPolicyService.sendDisabledReason(
         this.config.originalSend,
       );
+      const showMakeCopyButton =
+        sendDisabledReason !== SendDisabledReason.None &&
+        this.config.originalSend.type === SendType.Text;
       if (sendDisabledReason === SendDisabledReason.RestrictedType) {
         this.disabledSendConfig.set({
           title:
@@ -242,17 +245,19 @@ export class SendAddEditComponent {
               ? "orgDoesNotAllowTextSends"
               : "orgDoesNotAllowFileSends",
           message: "sendWillAutomaticallyExpire",
-          showMakeCopyButton: false,
+          showMakeCopyButton,
         });
       } else if (sendDisabledReason === SendDisabledReason.Other) {
         this.disabledSendConfig.set({
           title: "sendNotCompliantWithYourOrgsPolicy",
           message: "sendDisabledNonCompliantBannerMessage",
-          showMakeCopyButton: true,
+          showMakeCopyButton,
         });
       } else {
         this.disabledSendConfig.set(null);
       }
+    } else {
+      this.disabledSendConfig.set(null);
     }
   }
 
@@ -332,6 +337,7 @@ export class SendAddEditComponent {
               : AuthType.None,
       },
     };
+    await this.setSendDisabledConfig();
     this.editSend();
   }
 }

--- a/libs/tools/send/send-ui/src/add-edit/send-add-edit-dialog.component.ts
+++ b/libs/tools/send/send-ui/src/add-edit/send-add-edit-dialog.component.ts
@@ -180,9 +180,6 @@ export class SendAddEditDialogComponent {
       const sendDisabledReason = await this.sendPolicyService.sendDisabledReason(
         this.config.originalSend,
       );
-      const showMakeCopyButton =
-        sendDisabledReason !== SendDisabledReason.None &&
-        this.config.originalSend.type === SendType.Text;
       if (sendDisabledReason === SendDisabledReason.RestrictedType) {
         this.disabledSendConfig.set({
           title:
@@ -190,13 +187,17 @@ export class SendAddEditDialogComponent {
               ? "orgDoesNotAllowTextSends"
               : "orgDoesNotAllowFileSends",
           message: "sendWillAutomaticallyExpire",
-          showMakeCopyButton,
+          // It's impossible to make a compliant copy of this Send
+          // without changing the type so we hide the button
+          showMakeCopyButton: false,
         });
       } else if (sendDisabledReason === SendDisabledReason.Other) {
         this.disabledSendConfig.set({
           title: "sendNotCompliantWithYourOrgsPolicy",
           message: "sendDisabledNonCompliantBannerMessage",
-          showMakeCopyButton,
+          // We can't attach an existing file to a new Send so
+          // we can only make a copy if the Send is of type Text
+          showMakeCopyButton: this.config.originalSend?.type === SendType.Text,
         });
       } else {
         this.disabledSendConfig.set(null);

--- a/libs/tools/send/send-ui/src/add-edit/send-add-edit-dialog.component.ts
+++ b/libs/tools/send/send-ui/src/add-edit/send-add-edit-dialog.component.ts
@@ -181,8 +181,8 @@ export class SendAddEditDialogComponent {
         this.config.originalSend,
       );
       // We can make a copy of a disabled Send only if two conditions are met
-      // 1. The Send doesn't violate the SendType restriction of the policy (if Text
-      // Sends aren't allowed we'd have to turn the copy into a File Send)
+      // 1. The Send doesn't violate the SendType restriction of the policy (if
+      // Text Sends are disallowed we cannot make a new one for the copy)
       // 2. The Send is a Text Send (we can't attach existing files to new Sends)
       if (sendDisabledReason === SendDisabledReason.RestrictedType) {
         this.disabledSendConfig.set({

--- a/libs/tools/send/send-ui/src/add-edit/send-add-edit-dialog.component.ts
+++ b/libs/tools/send/send-ui/src/add-edit/send-add-edit-dialog.component.ts
@@ -180,6 +180,10 @@ export class SendAddEditDialogComponent {
       const sendDisabledReason = await this.sendPolicyService.sendDisabledReason(
         this.config.originalSend,
       );
+      // We can make a copy of a disabled Send only if two conditions are met
+      // 1. The Send doesn't violate the SendType restriction of the policy (if Text
+      // Sends aren't allowed we'd have to turn the copy into a File Send)
+      // 2. The Send is a Text Send (we can't attach existing files to new Sends)
       if (sendDisabledReason === SendDisabledReason.RestrictedType) {
         this.disabledSendConfig.set({
           title:
@@ -187,17 +191,18 @@ export class SendAddEditDialogComponent {
               ? "orgDoesNotAllowTextSends"
               : "orgDoesNotAllowFileSends",
           message: "sendWillAutomaticallyExpire",
-          // It's impossible to make a compliant copy of this Send
-          // without changing the type so we hide the button
+          // This branch violates condition 1 so we never allow copying
           showMakeCopyButton: false,
         });
       } else if (sendDisabledReason === SendDisabledReason.Other) {
+        // This branch meets condition 1, so all we need to check is condition 2
+        const showMakeCopyButton = this.config.originalSend?.type === SendType.Text;
         this.disabledSendConfig.set({
           title: "sendNotCompliantWithYourOrgsPolicy",
-          message: "sendDisabledNonCompliantBannerMessage",
-          // We can't attach an existing file to a new Send so
-          // we can only make a copy if the Send is of type Text
-          showMakeCopyButton: this.config.originalSend?.type === SendType.Text,
+          message: showMakeCopyButton
+            ? "sendDisabledNonCompliantBannerMessage"
+            : "sendWillAutomaticallyExpire",
+          showMakeCopyButton,
         });
       } else {
         this.disabledSendConfig.set(null);

--- a/libs/tools/send/send-ui/src/add-edit/send-add-edit-dialog.component.ts
+++ b/libs/tools/send/send-ui/src/add-edit/send-add-edit-dialog.component.ts
@@ -169,7 +169,7 @@ export class SendAddEditDialogComponent {
     private sendFormService: SendFormService,
     private sendPolicyService: SendPolicyService,
   ) {
-    // We only want to load from the input params the first time the component opens,
+    // We only want to load from the input params the first time the component initializes,
     // since the makeCopy function works by replacing the config object and re-initializing
     this.config = this.params.formConfig;
     void this.init();

--- a/libs/tools/send/send-ui/src/add-edit/send-add-edit-dialog.component.ts
+++ b/libs/tools/send/send-ui/src/add-edit/send-add-edit-dialog.component.ts
@@ -169,15 +169,20 @@ export class SendAddEditDialogComponent {
     private sendFormService: SendFormService,
     private sendPolicyService: SendPolicyService,
   ) {
+    // We only want to load from the input params the first time the component opens,
+    // since the makeCopy function works by replacing the config object and re-initializing
+    this.config = this.params.formConfig;
     void this.init();
   }
 
   async init() {
-    this.config = this.params.formConfig;
     if (this.config.originalSend) {
       const sendDisabledReason = await this.sendPolicyService.sendDisabledReason(
         this.config.originalSend,
       );
+      const showMakeCopyButton =
+        sendDisabledReason !== SendDisabledReason.None &&
+        this.config.originalSend.type === SendType.Text;
       if (sendDisabledReason === SendDisabledReason.RestrictedType) {
         this.disabledSendConfig.set({
           title:
@@ -185,17 +190,19 @@ export class SendAddEditDialogComponent {
               ? "orgDoesNotAllowTextSends"
               : "orgDoesNotAllowFileSends",
           message: "sendWillAutomaticallyExpire",
-          showMakeCopyButton: false,
+          showMakeCopyButton,
         });
       } else if (sendDisabledReason === SendDisabledReason.Other) {
         this.disabledSendConfig.set({
           title: "sendNotCompliantWithYourOrgsPolicy",
           message: "sendDisabledNonCompliantBannerMessage",
-          showMakeCopyButton: true,
+          showMakeCopyButton,
         });
       } else {
         this.disabledSendConfig.set(null);
       }
+    } else {
+      this.disabledSendConfig.set(null);
     }
     this.editing.set(this.config.mode === "add");
     this.showCopyButton.set(


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-40693

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR fixes a bug where the "Make a Copy" button was incorrectly displayed for File Sends, which can't be copied. It also fixes two unrelated bugs, one that would incorrectly show the "Send is Disabled" banner after the "Make a Copy" button was pressed on the browser extension, and one that would prevent the "Make a Copy" button from properly re-initializing the Send edit drawer on web.