### PR TITLE
[PM-26503] Bugfix - Allow inline menu to escape aria model focus traps

### DIFF
--- a/apps/browser/src/autofill/overlay/inline-menu/content/autofill-inline-menu-content.service.spec.ts
+++ b/apps/browser/src/autofill/overlay/inline-menu/content/autofill-inline-menu-content.service.spec.ts
@@ -84,6 +84,52 @@ describe("AutofillInlineMenuContentService", () => {
     });
   });
 
+  describe("inline menu element visibility checks", () => {
+    beforeEach(() => {
+      // Background reports the element as visible; the DOM-connectivity guard is
+      // what these tests exercise.
+      sendExtensionMessageSpy.mockResolvedValue(true);
+    });
+
+    it("treats a detached button element as not visible so it is re-appended", async () => {
+      const detachedButton = document.createElement("div");
+      autofillInlineMenuContentService["buttonElement"] = detachedButton;
+
+      await expect(autofillInlineMenuContentService["isInlineMenuButtonVisible"]()).resolves.toBe(
+        false,
+      );
+    });
+
+    it("treats a connected, background-visible button element as visible", async () => {
+      const connectedButton = document.createElement("div");
+      document.body.appendChild(connectedButton);
+      autofillInlineMenuContentService["buttonElement"] = connectedButton;
+
+      await expect(autofillInlineMenuContentService["isInlineMenuButtonVisible"]()).resolves.toBe(
+        true,
+      );
+    });
+
+    it("treats a detached list element as not visible so it is re-appended", async () => {
+      const detachedList = document.createElement("div");
+      autofillInlineMenuContentService["listElement"] = detachedList;
+
+      await expect(autofillInlineMenuContentService["isInlineMenuListVisible"]()).resolves.toBe(
+        false,
+      );
+    });
+
+    it("treats a connected, background-visible list element as visible", async () => {
+      const connectedList = document.createElement("div");
+      document.body.appendChild(connectedList);
+      autofillInlineMenuContentService["listElement"] = connectedList;
+
+      await expect(autofillInlineMenuContentService["isInlineMenuListVisible"]()).resolves.toBe(
+        true,
+      );
+    });
+  });
+
   describe("extension message handlers", () => {
     describe("closeAutofillInlineMenu message handler", () => {
       beforeEach(() => {

--- a/apps/browser/src/autofill/overlay/inline-menu/content/autofill-inline-menu-content.service.spec.ts
+++ b/apps/browser/src/autofill/overlay/inline-menu/content/autofill-inline-menu-content.service.spec.ts
@@ -329,6 +329,51 @@ describe("AutofillInlineMenuContentService", () => {
           autofillInlineMenuContentService["buttonElement"],
         );
       });
+
+      it("appends the inline menu element to a containing ARIA `alertdialog` modal", async () => {
+        isInlineMenuButtonVisibleSpy.mockResolvedValue(false);
+        const ariaModalElement = document.createElement("div");
+        ariaModalElement.setAttribute("role", "alertdialog");
+        ariaModalElement.setAttribute("aria-modal", "true");
+        const ariaModalAppendSpy = jest.spyOn(ariaModalElement, "appendChild");
+        const inputElement = document.createElement("input");
+        ariaModalElement.appendChild(inputElement);
+        document.body.appendChild(ariaModalElement);
+        Object.defineProperty(document, "activeElement", {
+          value: inputElement,
+          writable: true,
+        });
+
+        sendMockExtensionMessage({
+          command: "appendAutofillInlineMenuToDom",
+          overlayElement: AutofillOverlayElement.Button,
+        });
+        await flushPromises();
+
+        expect(ariaModalAppendSpy).toHaveBeenCalledWith(
+          autofillInlineMenuContentService["buttonElement"],
+        );
+      });
+
+      it("appends the inline menu element to `document.body` when the focused field is not inside a modal", async () => {
+        isInlineMenuButtonVisibleSpy.mockResolvedValue(false);
+        const inputElement = document.createElement("input");
+        document.body.appendChild(inputElement);
+        Object.defineProperty(document, "activeElement", {
+          value: inputElement,
+          writable: true,
+        });
+
+        sendMockExtensionMessage({
+          command: "appendAutofillInlineMenuToDom",
+          overlayElement: AutofillOverlayElement.Button,
+        });
+        await flushPromises();
+
+        expect(globalThis.document.body.appendChild).toHaveBeenCalledWith(
+          autofillInlineMenuContentService["buttonElement"],
+        );
+      });
     });
   });
 

--- a/apps/browser/src/autofill/overlay/inline-menu/content/autofill-inline-menu-content.service.spec.ts
+++ b/apps/browser/src/autofill/overlay/inline-menu/content/autofill-inline-menu-content.service.spec.ts
@@ -258,6 +258,31 @@ describe("AutofillInlineMenuContentService", () => {
           autofillInlineMenuContentService["buttonElement"],
         );
       });
+
+      it("appends the inline menu element to a containing ARIA modal when the focused field is not inside a native dialog", async () => {
+        isInlineMenuButtonVisibleSpy.mockResolvedValue(false);
+        const ariaModalElement = document.createElement("div");
+        ariaModalElement.setAttribute("role", "dialog");
+        ariaModalElement.setAttribute("aria-modal", "true");
+        const ariaModalAppendSpy = jest.spyOn(ariaModalElement, "appendChild");
+        const inputElement = document.createElement("input");
+        ariaModalElement.appendChild(inputElement);
+        document.body.appendChild(ariaModalElement);
+        Object.defineProperty(document, "activeElement", {
+          value: inputElement,
+          writable: true,
+        });
+
+        sendMockExtensionMessage({
+          command: "appendAutofillInlineMenuToDom",
+          overlayElement: AutofillOverlayElement.Button,
+        });
+        await flushPromises();
+
+        expect(ariaModalAppendSpy).toHaveBeenCalledWith(
+          autofillInlineMenuContentService["buttonElement"],
+        );
+      });
     });
   });
 

--- a/apps/browser/src/autofill/overlay/inline-menu/content/autofill-inline-menu-content.service.ts
+++ b/apps/browser/src/autofill/overlay/inline-menu/content/autofill-inline-menu-content.service.ts
@@ -149,8 +149,9 @@ export class AutofillInlineMenuContentService implements AutofillInlineMenuConte
    * Checks if the inline menu button is visible at the top frame.
    */
   private async isInlineMenuButtonVisible() {
+    // `isConnected` check for extra defensiveness in cases where the host element is disconnected
     return (
-      !!this.buttonElement &&
+      !!this.buttonElement?.isConnected &&
       (await this.sendExtensionMessage("checkIsAutofillInlineMenuButtonVisible")) === true
     );
   }
@@ -159,8 +160,9 @@ export class AutofillInlineMenuContentService implements AutofillInlineMenuConte
    * Checks if the inline menu list if visible at the top frame.
    */
   private async isInlineMenuListVisible() {
+    // `isConnected` check for extra defensiveness in cases where the host element is disconnected
     return (
-      !!this.listElement &&
+      !!this.listElement?.isConnected &&
       (await this.sendExtensionMessage("checkIsAutofillInlineMenuListVisible")) === true
     );
   }

--- a/apps/browser/src/autofill/overlay/inline-menu/content/autofill-inline-menu-content.service.ts
+++ b/apps/browser/src/autofill/overlay/inline-menu/content/autofill-inline-menu-content.service.ts
@@ -282,15 +282,40 @@ export class AutofillInlineMenuContentService implements AutofillInlineMenuConte
    * @param element - The inline menu element to append to the menu container.
    */
   private appendInlineMenuElementToDom(element: HTMLElement) {
-    const parentDialogElement = globalThis.document.activeElement?.closest("dialog");
+    const containerElement = this.getInlineMenuContainerElement();
+    this.observeContainerElement(containerElement);
+    containerElement.appendChild(element);
+  }
+
+  /**
+   * Determines which element the inline menu should be appended to. When the
+   * focused field lives inside a modal, the menu must be appended within that
+   * modal so it shares the modal's DOM subtree. Modals commonly run a focus trap
+   * that forces focus back inside their subtree; a menu appended to
+   * `document.body` sits outside it, so the trap steals focus the moment the user
+   * interacts with the menu and both clicks and keyboard navigation fail.
+   * Both native top-layer `<dialog>` modals and ARIA modals
+   * (`role="dialog"`/`role="alertdialog"` with `aria-modal="true"`) are
+   * handled; otherwise the menu is appended to `document.body`.
+   */
+  private getInlineMenuContainerElement(): HTMLElement {
+    const activeElement = globalThis.document.activeElement;
+
+    const parentDialogElement = activeElement?.closest("dialog");
+
     if (parentDialogElement?.open && parentDialogElement.matches(":modal")) {
-      this.observeContainerElement(parentDialogElement);
-      parentDialogElement.appendChild(element);
-      return;
+      return parentDialogElement;
     }
 
-    this.observeContainerElement(globalThis.document.body);
-    globalThis.document.body.appendChild(element);
+    const parentAriaModalElement = activeElement?.closest<HTMLElement>(
+      '[role="dialog"][aria-modal="true"], [role="alertdialog"][aria-modal="true"]',
+    );
+
+    if (parentAriaModalElement) {
+      return parentAriaModalElement;
+    }
+
+    return globalThis.document.body;
   }
 
   /**


### PR DESCRIPTION
## 🎟️ Tracking

[PM-26503](https://bitwarden.atlassian.net/browse/PM-26503)

## 📔 Objective

Resolves focus trap cases like that seen on medium.com's login modal, allowing the inline menu to gain focus again

[PM-26503]: https://bitwarden.atlassian.net/browse/PM-26503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ