### PR TITLE
[PM-40847] Add any missing inline menu renderings to storybook for QA

### DIFF
--- a/apps/browser/src/autofill/content/components/lit-stories/inline-menu/cipher-list.lit-stories.ts
+++ b/apps/browser/src/autofill/content/components/lit-stories/inline-menu/cipher-list.lit-stories.ts
@@ -2,6 +2,8 @@ import { Meta, StoryObj } from "@storybook/web-components";
 import { html } from "lit";
 
 import { ThemeTypes } from "@bitwarden/common/platform/enums/theme-type.enum";
+import { CipherType } from "@bitwarden/common/vault/enums";
+import { CipherRepromptType } from "@bitwarden/common/vault/enums/cipher-reprompt-type";
 
 import { InlineMenuCipherData } from "../../../../background/abstractions/overlay.background";
 import { InlineMenuCipherList, InlineMenuCipherListProps } from "../../inline-menu/cipher-list";
@@ -14,77 +16,71 @@ const mockIcon = {
   icon: "globe",
 };
 
+function makeCipher(
+  overrides: Omit<Partial<InlineMenuCipherData>, "id" | "name" | "type"> &
+    Pick<InlineMenuCipherData, "id" | "name" | "type">,
+): InlineMenuCipherData {
+  return {
+    favorite: false,
+    reprompt: CipherRepromptType.None,
+    icon: mockIcon,
+    ...overrides,
+  };
+}
+
 const mockCiphers: InlineMenuCipherData[] = [
-  {
+  makeCipher({
     id: "1",
     name: "bitwarden.com",
-    type: 1,
-    favorite: false,
-    reprompt: 0,
-    icon: mockIcon,
+    type: CipherType.Login,
     login: { username: "test@bitwarden.com", passkey: null },
-  },
-  {
+  }),
+  makeCipher({
     id: "2",
-    name: "bitwarden.com",
-    type: 1,
-    favorite: false,
-    reprompt: 0,
-    icon: mockIcon,
-    login: { username: "test@bitwarden.com", passkey: null },
-  },
-  {
+    name: "example.com",
+    type: CipherType.Login,
+    login: { username: "codestradamus", passkey: null },
+  }),
+  makeCipher({
     id: "3",
-    name: "bitwarden.com",
-    type: 1,
-    favorite: false,
-    reprompt: 0,
-    icon: mockIcon,
-    login: { username: "test@bitwarden.com", passkey: null },
-  },
+    name: "A really long site name that should ellipsize in the list",
+    type: CipherType.Login,
+    login: { username: "long.username@example.com", passkey: null },
+  }),
 ];
 
 const mockTotpCiphers: InlineMenuCipherData[] = [
-  {
+  makeCipher({
     id: "1",
     name: "site-a",
-    type: 1,
-    favorite: false,
-    reprompt: 0,
-    icon: mockIcon,
+    type: CipherType.Login,
     login: {
-      username: "ergbreb",
+      username: "alice@example.com",
       totp: "454143",
       totpField: true,
       totpCodeTimeInterval: 30,
       passkey: null,
     },
-  },
-  {
+  }),
+  makeCipher({
     id: "2",
     name: "site-b",
-    type: 1,
-    favorite: false,
-    reprompt: 0,
-    icon: mockIcon,
+    type: CipherType.Login,
     login: {
-      username: "tesd",
+      username: "liz@example.com",
       totp: "174593",
       totpField: true,
       totpCodeTimeInterval: 30,
       passkey: null,
     },
-  },
+  }),
 ];
 
 const mockPasskeyCiphers: InlineMenuCipherData[] = [
-  {
+  makeCipher({
     id: "1",
     name: "bitwarden.com",
-    type: 1,
-    favorite: false,
-    reprompt: 0,
-    icon: mockIcon,
+    type: CipherType.Login,
     login: {
       username: "test@bitwarden.com",
       passkey: {
@@ -92,37 +88,79 @@ const mockPasskeyCiphers: InlineMenuCipherData[] = [
         userName: "test@bitwarden.com",
       },
     },
-  },
-  {
+  }),
+  makeCipher({
     id: "2",
     name: "Example Site",
-    type: 1,
-    favorite: false,
-    reprompt: 0,
-    icon: mockIcon,
+    type: CipherType.Login,
     login: {
       passkey: {
         rpName: "Example Site",
         userName: "passkey-user",
       },
     },
-  },
+  }),
 ];
 
 const mockPasskeysAndPasswords: InlineMenuCipherData[] = [
   ...mockPasskeyCiphers,
-  {
+  makeCipher({
     id: "3",
     name: "bitwarden.com",
-    type: 1,
-    favorite: false,
-    reprompt: 0,
-    icon: mockIcon,
+    type: CipherType.Login,
     login: { username: "password-user@bitwarden.com", passkey: null },
-  },
+  }),
+];
+
+const mockCardCiphers: InlineMenuCipherData[] = [
+  makeCipher({
+    id: "1",
+    name: "Personal Visa",
+    type: CipherType.Card,
+    card: "Visa, *4242",
+  }),
+  makeCipher({
+    id: "2",
+    name: "Work Amex",
+    type: CipherType.Card,
+    card: "Amex, *10005",
+  }),
+];
+
+const mockIdentityCiphers: InlineMenuCipherData[] = [
+  makeCipher({
+    id: "1",
+    name: "Home Address",
+    type: CipherType.Identity,
+    identity: { fullName: "Jane Doe" },
+  }),
+  makeCipher({
+    id: "2",
+    name: "Work Profile",
+    type: CipherType.Identity,
+    identity: { fullName: "Jane Doe", username: "jane.doe@bitwarden.com" },
+  }),
 ];
 
 type ComponentAndControls = InlineMenuCipherListProps & { width: number };
+
+const baseArgs: ComponentAndControls = {
+  ciphers: mockCiphers,
+  theme: ThemeTypes.Dark,
+  viewButtonText: mockI18n.view,
+  opensInANewWindowText: mockI18n.opensInANewWindow,
+  fillCredentialsForText: mockI18n.fillCredentialsFor,
+  logInWithPasskeyAriaLabel: mockI18n.logInWithPasskeyAriaLabel,
+  usernameText: mockI18n.username,
+  cardNumberEndsWithText: mockI18n.cardNumberEndsWith,
+  fillVerificationCodeText: mockI18n.fillVerificationCode,
+  totpCodeAria: mockI18n.totpCodeAria,
+  passkeysText: mockI18n.passkeys,
+  passwordsText: mockI18n.passwords,
+  handleFillCipher: (cipher) => alert(`Fill ${cipher.name}`),
+  handleViewCipher: (cipher) => alert(`View ${cipher.name}`),
+  width: 280,
+};
 
 export default {
   title: "Components/Inline Menu/Cipher List",
@@ -133,23 +171,7 @@ export default {
     handleViewCipher: { control: false },
     width: { control: "number", min: 160, max: 480, step: 8 },
   },
-  args: {
-    ciphers: mockCiphers,
-    theme: ThemeTypes.Dark,
-    viewButtonText: mockI18n.view,
-    opensInANewWindowText: mockI18n.opensInANewWindow,
-    fillCredentialsForText: mockI18n.fillCredentialsFor,
-    logInWithPasskeyAriaLabel: mockI18n.logInWithPasskeyAriaLabel,
-    usernameText: mockI18n.username,
-    cardNumberEndsWithText: mockI18n.cardNumberEndsWith,
-    fillVerificationCodeText: mockI18n.fillVerificationCode,
-    totpCodeAria: mockI18n.totpCodeAria,
-    passkeysText: mockI18n.passkeys,
-    passwordsText: mockI18n.passwords,
-    handleFillCipher: (cipher) => alert(`Fill ${cipher.name}`),
-    handleViewCipher: (cipher) => alert(`View ${cipher.name}`),
-    width: 280,
-  },
+  args: baseArgs,
 } as Meta<ComponentAndControls>;
 
 const Template = (args: ComponentAndControls) => {
@@ -193,6 +215,20 @@ export const Passkeys: StoryObj<ComponentAndControls> = {
 export const PasskeysAndPasswords: StoryObj<ComponentAndControls> = {
   args: {
     ciphers: mockPasskeysAndPasswords,
+  },
+  render: Template,
+};
+
+export const Cards: StoryObj<ComponentAndControls> = {
+  args: {
+    ciphers: mockCardCiphers,
+  },
+  render: Template,
+};
+
+export const Identities: StoryObj<ComponentAndControls> = {
+  args: {
+    ciphers: mockIdentityCiphers,
   },
   render: Template,
 };

--- a/apps/browser/src/autofill/content/components/lit-stories/inline-menu/prompt.lit-stories.ts
+++ b/apps/browser/src/autofill/content/components/lit-stories/inline-menu/prompt.lit-stories.ts
@@ -12,6 +12,16 @@ type ComponentAndControls = Omit<InlineMenuPromptProps, "icon"> & {
   iconName: "plus" | "lock" | "none";
 };
 
+const baseArgs: ComponentAndControls = {
+  message: mockI18n.noItemsToShow,
+  actionText: mockI18n.newLogin,
+  i18n: { actionAria: mockI18n.addNewLoginItemAria },
+  iconName: "plus",
+  theme: ThemeTypes.Light,
+  handleAction: () => alert("Action"),
+  width: 280,
+};
+
 export default {
   title: "Components/Inline Menu/Prompt",
   argTypes: {
@@ -22,15 +32,7 @@ export default {
     handleAction: { control: false },
     width: { control: "number", min: 160, max: 480, step: 8 },
   },
-  args: {
-    message: mockI18n.noItemsToShow,
-    actionText: mockI18n.newLogin,
-    i18n: { actionAria: mockI18n.addNewLoginItemAria },
-    iconName: "plus",
-    theme: ThemeTypes.Light,
-    handleAction: () => alert("Action"),
-    width: 280,
-  },
+  args: baseArgs,
 } as Meta<ComponentAndControls>;
 
 const resolveIcon = (iconName: ComponentAndControls["iconName"]) => {
@@ -52,11 +54,36 @@ const Template = (args: ComponentAndControls) => {
 
 export const Empty: StoryObj<ComponentAndControls> = {
   args: {
-    message: mockI18n.noItemsToShow,
-    actionText: mockI18n.newLogin,
-    i18n: { actionAria: mockI18n.addNewLoginItemAria },
-    iconName: "plus",
-    theme: ThemeTypes.Dark,
+    dataTestId: "inline-menu-empty-state",
+    actionDataTestId: "inline-menu-new-item-button",
+  },
+  render: Template,
+};
+
+export const EmptyCard: StoryObj<ComponentAndControls> = {
+  args: {
+    actionText: mockI18n.newCard,
+    i18n: { actionAria: mockI18n.addNewCardItemAria },
+    dataTestId: "inline-menu-empty-state",
+    actionDataTestId: "inline-menu-new-item-button",
+  },
+  render: Template,
+};
+
+export const EmptyIdentity: StoryObj<ComponentAndControls> = {
+  args: {
+    actionText: mockI18n.newIdentity,
+    i18n: { actionAria: mockI18n.addNewIdentityItemAria },
+    dataTestId: "inline-menu-empty-state",
+    actionDataTestId: "inline-menu-new-item-button",
+  },
+  render: Template,
+};
+
+export const EmptyNewItem: StoryObj<ComponentAndControls> = {
+  args: {
+    actionText: mockI18n.newItem,
+    i18n: { actionAria: mockI18n.addNewVaultItem },
     dataTestId: "inline-menu-empty-state",
     actionDataTestId: "inline-menu-new-item-button",
   },
@@ -69,7 +96,6 @@ export const Locked: StoryObj<ComponentAndControls> = {
     actionText: mockI18n.unlockAccount,
     i18n: { actionAria: mockI18n.unlockAccountAria },
     iconName: "lock",
-    theme: ThemeTypes.Dark,
     dataTestId: "inline-menu-locked-state",
     actionDataTestId: "inline-menu-unlock-button",
   },
@@ -84,7 +110,6 @@ export const SaveLogin: StoryObj<ComponentAndControls> = {
       actionAria: `${mockI18n.saveToBitwarden}, ${mockI18n.opensInANewWindow}`,
     },
     iconName: "none",
-    theme: ThemeTypes.Dark,
     dataTestId: "inline-menu-save-login",
     actionDataTestId: "inline-menu-save-login-button",
   },

--- a/apps/browser/src/autofill/content/components/lit-stories/mock-data.ts
+++ b/apps/browser/src/autofill/content/components/lit-stories/mock-data.ts
@@ -102,7 +102,10 @@ export const mockTasks = [
 ];
 
 export const mockI18n = {
-  addNewLoginItemAria: "Add new login item",
+  addNewLoginItemAria: "Add new vault login item, opens in a new window",
+  addNewCardItemAria: "Add new vault card item, opens in a new window",
+  addNewIdentityItemAria: "Add new vault identity item, opens in a new window",
+  addNewVaultItem: "Add new vault item",
   appName: "Bitwarden",
   atRiskPassword: "At-risk password",
   atRiskNavigatePromptV2:
@@ -131,6 +134,8 @@ export const mockI18n = {
   nextSecurityTaskAction: "Change next password",
   newItem: "New item",
   newLogin: "New login",
+  newCard: "New card",
+  newIdentity: "New identity",
   never: "Never",
   noItemsToShow: "No items to show",
   myVault: "My vault",


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-40847
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

 >[!NOTE]
 > WIP until password generator work is merged in order to apply same changes to stories. 

Add the remaining Lit Storybook coverage for the inline menu surfaces QA needs to review, matching the current production empty, prompt, and cipher list states.

This includes card and identity cipher list stories, empty state prompt variants for login, card, identity, and generic new item CTAs, updated mockI18n strings aligned with `messages.json`, and simplified story fixtures to make these states easier to test in Storybook.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
![Uploading Screenshot 2026-07-24 at 1.08.29 PM.png…]()
