### PR TITLE
use getLastFocused for shortcut tab resolution

### DIFF
--- a/apps/browser/src/platform/browser/browser-api.spec.ts
+++ b/apps/browser/src/platform/browser/browser-api.spec.ts
@@ -1190,7 +1190,7 @@ describe("BrowserApi", () => {
         jest.restoreAllMocks();
       });
 
-      describe.each([BrowserApi.getTabFromCurrentWindow, BrowserApi.getTabFromCurrentWindowId])(
+      describe.each([BrowserApi.getTabFromCurrentWindow])(
         "%p",
         (getCurrTabFn) => {
           it("returns the first tab when the query result has one tab", async () => {
@@ -1249,6 +1249,119 @@ describe("BrowserApi", () => {
       );
     },
   );
+
+  describe("getTabFromCurrentWindowId (Safari path regression guard)", () => {
+    let originalIsSafariApi = BrowserApi.isSafariApi;
+    const expectedWindowId = 10;
+    const wrongWindowId = expectedWindowId + 1;
+
+    const resolvedTabsQueryResult = [
+      mock<chrome.tabs.Tab>({
+        title: "tab[0] is a pinned tab from another window",
+        pinned: true,
+        windowId: wrongWindowId,
+      }),
+      mock<chrome.tabs.Tab>({
+        title: "tab[1] is the tab with the correct foreground window",
+        windowId: expectedWindowId,
+      }),
+    ];
+
+    beforeEach(() => {
+      originalIsSafariApi = BrowserApi.isSafariApi;
+      BrowserApi.isSafariApi = true;
+      jest
+        .spyOn(BrowserApi, "getCurrentWindow")
+        .mockResolvedValue(mock<chrome.windows.Window>({ id: expectedWindowId }));
+      jest.spyOn(BrowserApi, "tabsQuery").mockResolvedValue(resolvedTabsQueryResult);
+    });
+
+    afterEach(() => {
+      BrowserApi.isSafariApi = originalIsSafariApi;
+      jest.restoreAllMocks();
+    });
+
+    it("returns the tab matching the current window ID", async () => {
+      const actualTab = await BrowserApi.getTabFromCurrentWindowId();
+      expect(actualTab.windowId).toBe(expectedWindowId);
+    });
+
+  });
+
+  describe("getTabFromCurrentWindowId (non-Safari getLastFocused path)", () => {
+    let originalIsSafariApi = BrowserApi.isSafariApi;
+    const focusedWindowId = 42;
+
+    const activeTabInFocusedWindow = mock<chrome.tabs.Tab>({
+      title: "active tab in the OS-focused window",
+      windowId: focusedWindowId,
+    });
+
+    beforeEach(() => {
+      originalIsSafariApi = BrowserApi.isSafariApi;
+      BrowserApi.isSafariApi = false;
+    });
+
+    afterEach(() => {
+      BrowserApi.isSafariApi = originalIsSafariApi;
+      jest.restoreAllMocks();
+    });
+
+    it("returns the active tab from the last-focused window", async () => {
+      jest
+        .spyOn(BrowserApi, "getLastFocusedWindow")
+        .mockResolvedValue(mock<chrome.windows.Window>({ id: focusedWindowId }));
+      const tabsQueryFirstSpy = jest
+        .spyOn(BrowserApi, "tabsQueryFirst")
+        .mockResolvedValue(activeTabInFocusedWindow);
+
+      const actualTab = await BrowserApi.getTabFromCurrentWindowId();
+
+      expect(tabsQueryFirstSpy).toHaveBeenCalledWith({
+        active: true,
+        windowId: focusedWindowId,
+      });
+      expect(actualTab).toBe(activeTabInFocusedWindow);
+    });
+
+    it.each([
+      ["null", null],
+      ["a window with no id", mock<chrome.windows.Window>({ id: undefined })],
+    ])(
+      "falls back to a currentWindow query when getLastFocused returns %s",
+      async (_label, focusedWindow) => {
+        jest.spyOn(BrowserApi, "getLastFocusedWindow").mockResolvedValue(focusedWindow);
+        const tabsQueryFirstSpy = jest
+          .spyOn(BrowserApi, "tabsQueryFirst")
+          .mockResolvedValue(activeTabInFocusedWindow);
+
+        const actualTab = await BrowserApi.getTabFromCurrentWindowId();
+
+        expect(tabsQueryFirstSpy).toHaveBeenCalledWith({
+          active: true,
+          currentWindow: true,
+        });
+        expect(actualTab).toBe(activeTabInFocusedWindow);
+      },
+    );
+  });
+
+  describe("getLastFocusedWindow", () => {
+    it("calls chrome.windows.getLastFocused without populating tabs", async () => {
+      const focusedWindow = mock<chrome.windows.Window>({ id: 7 });
+      (chrome.windows.getLastFocused as jest.Mock).mockImplementation((_options, callback) =>
+        callback(focusedWindow),
+      );
+
+      const result = await BrowserApi.getLastFocusedWindow();
+
+      expect(chrome.windows.getLastFocused).toHaveBeenCalledWith(
+        { populate: false },
+        expect.anything(),
+      );
+      expect(result).toBe(focusedWindow);
+    });
+  });
 
   describe("isSidePanelApiSupported", () => {
     it("returns true when chrome.sidePanel is defined", () => {

--- a/apps/browser/src/platform/browser/browser-api.ts
+++ b/apps/browser/src/platform/browser/browser-api.ts
@@ -138,6 +138,20 @@ export class BrowserApi {
   }
 
   /**
+   * Gets the browser window that was most recently focused at the OS level.
+   *
+   * Unlike {@link chrome.windows.WINDOW_ID_CURRENT}, which resolves to the extension
+   * context's "current" window (undefined from a background service worker when
+   * multiple windows exist), this resolves to the window the user last interacted with.
+   * This is the correct target for keyboard-shortcut-driven actions.
+   */
+  static async getLastFocusedWindow(): Promise<chrome.windows.Window> {
+    return new Promise((resolve) =>
+      chrome.windows.getLastFocused({ populate: false }, (window) => resolve(window)),
+    );
+  }
+
+  /**
    * Gets the window with the given id.
    *
    * @param windowId - The id of the window to get.
@@ -212,10 +226,19 @@ export class BrowserApi {
   }
 
   static async getTabFromCurrentWindowId(): Promise<chrome.tabs.Tab> | null {
-    return await BrowserApi.tabsQueryFirstCurrentWindowForSafari({
-      active: true,
-      windowId: chrome.windows.WINDOW_ID_CURRENT,
-    });
+    if (BrowserApi.isSafariApi) {
+      return await BrowserApi.tabsQueryFirstCurrentWindowForSafari({
+        active: true,
+        windowId: chrome.windows.WINDOW_ID_CURRENT,
+      });
+    }
+
+    const lastFocusedWindow = await BrowserApi.getLastFocusedWindow();
+    if (lastFocusedWindow?.id == null) {
+      return await BrowserApi.tabsQueryFirst({ active: true, currentWindow: true });
+    }
+
+    return await BrowserApi.tabsQueryFirst({ active: true, windowId: lastFocusedWindow.id });
   }
 
   static getBrowserClientVendor(clientWindow: Window): BrowserClientVendor {

--- a/apps/browser/test.setup.ts
+++ b/apps/browser/test.setup.ts
@@ -86,6 +86,7 @@ const windows = {
   create: jest.fn(),
   get: jest.fn(),
   getCurrent: jest.fn(),
+  getLastFocused: jest.fn(),
   update: jest.fn(),
   remove: jest.fn(),
   onFocusChanged: {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-40825

## 📔 Objective

use `getLastFocused` to detect the last focused browser pane when running shortcuts

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
