### PR TITLE
[PM-40975] Add keyboard shortcut for username generation in browser extension

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -1980,6 +1980,9 @@
   "commandGeneratePasswordDesc": {
     "message": "Generate and copy a new random password to the clipboard"
   },
+  "commandGenerateUsernameDesc": {
+    "message": "Generate and copy a new random username to the clipboard"
+  },
   "commandLockVaultDesc": {
     "message": "Lock the vault"
   },

--- a/apps/browser/src/background/commands.background.ts
+++ b/apps/browser/src/background/commands.background.ts
@@ -26,6 +26,7 @@ export default class CommandsBackground {
     private platformUtilsService: PlatformUtilsService,
     private authService: AuthService,
     private generatePasswordToClipboard: () => Observable<string>,
+    private generateUsernameToClipboard: () => Observable<string>,
     private accountService: AccountService,
     private lockService: LockService,
   ) {
@@ -54,6 +55,9 @@ export default class CommandsBackground {
     switch (command) {
       case ExtensionCommand.GeneratePassword:
         await firstValueFrom(this.generatePasswordToClipboard(), { defaultValue: undefined });
+        break;
+      case ExtensionCommand.GenerateUsername:
+        await firstValueFrom(this.generateUsernameToClipboard(), { defaultValue: undefined });
         break;
       case ExtensionCommand.AutofillLogin:
         await this.triggerAutofillCommand(

--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -1532,6 +1532,7 @@ export default class MainBackground {
       this.platformUtilsService,
       this.authService,
       () => this.generatePasswordToClipboard(),
+      () => this.generateUsernameToClipboard(),
       this.accountService,
       this.lockService,
     );
@@ -2309,6 +2310,36 @@ export default class MainBackground {
       .generate$({
         on$: concat(
           of({ source: PasswordGenerateRequestSource.Clipboard, type: Type.password }),
+          NEVER,
+        ),
+        account$: this.accountService.activeAccount$,
+      })
+      .pipe(
+        concatMap(async (generated) => {
+          this.platformUtilsService.copyToClipboard(generated.credential);
+          try {
+            await trackGeneratedCredential(
+              this.generatorHistoryService,
+              this.accountService.activeAccount$,
+              generated,
+            );
+          } catch (e) {
+            this.logService.error(e);
+          }
+          return generated.credential;
+        }),
+      );
+  };
+
+  generateUsernameToClipboard = () => {
+    if (!this.credentialGeneratorService || !this.generatorHistoryService) {
+      return EMPTY;
+    }
+
+    return this.credentialGeneratorService
+      .generate$({
+        on$: concat(
+          of({ source: PasswordGenerateRequestSource.Clipboard, type: Type.username }),
           NEVER,
         ),
         account$: this.accountService.activeAccount$,

--- a/apps/browser/src/manifest.json
+++ b/apps/browser/src/manifest.json
@@ -125,6 +125,9 @@
       },
       "description": "__MSG_commandGeneratePasswordDesc__"
     },
+    "generate_username": {
+      "description": "__MSG_commandGenerateUsernameDesc__"
+    },
     "lock_vault": {
       "description": "__MSG_commandLockVaultDesc__"
     }

--- a/apps/browser/src/manifest.v3.json
+++ b/apps/browser/src/manifest.v3.json
@@ -154,6 +154,9 @@
       },
       "description": "__MSG_commandGeneratePasswordDesc__"
     },
+    "generate_username": {
+      "description": "__MSG_commandGenerateUsernameDesc__"
+    },
     "lock_vault": {
       "description": "__MSG_commandLockVaultDesc__"
     }

--- a/libs/common/src/autofill/constants/index.ts
+++ b/libs/common/src/autofill/constants/index.ts
@@ -139,6 +139,7 @@ export const ExtensionCommand = {
   AutofillLogin: "autofill_login",
   OpenAutofillOverlay: "open_autofill_overlay",
   GeneratePassword: "generate_password",
+  GenerateUsername: "generate_username",
   OpenPopup: "open_popup",
   LockVault: "lock_vault",
   NoopCommand: "noop",


### PR DESCRIPTION
## 🎟️ Tracking

https://github.com/orgs/bitwarden/discussions/21384
https://community.bitwarden.com/t/keyboard-shortcut-for-username-generation/41810

## 📔 Objective

Adds a new browser extension command that generates a random username and copies it to the clipboard, mirroring the existing password generation shortcut (`generate_password`).

- Registers `generate_username` in both manifest v2 and v3
- No default keybinding is set — users configure it via the browser's extension shortcuts page (e.g., `chrome://extensions/shortcuts`)
- Uses the user's configured username generation method via `CredentialGeneratorService`
- Records generated credentials in generator history

This addresses a long-standing community request (since 2022) for parity between password and username generation shortcuts.