### PR TITLE
fix(desktop): use x11 clipboard by default and only use portal as fallback

### DIFF
--- a/apps/desktop/desktop_native/core/src/clipboard/portal_backend.rs
+++ b/apps/desktop/desktop_native/core/src/clipboard/portal_backend.rs
@@ -23,15 +23,11 @@ const MIME_TEXT: &str = "text/plain;charset=utf-8";
 /// File name (under the config dir) used to persist the RemoteDesktop session restore token.
 const TOKEN_FILE: &str = "remote_desktop_portal_token";
 
-/// Whether the portal-based clipboard fallback should be used when the direct `arboard` write
+/// Whether the portal-based clipboard fallback should be used when the direct `arboard` access
 /// fails.
-///
-/// True on a GNOME desktop, where `arboard` cannot reliably set the clipboard on Wayland. Reads
-/// `XDG_CURRENT_DESKTOP` for the desktop environment.
 pub(crate) fn should_use_portal() -> bool {
-    std::env::var("XDG_CURRENT_DESKTOP")
-        .map(|desktop| desktop.to_ascii_uppercase().contains("GNOME"))
-        .unwrap_or(false)
+    let clipboard_works = super::arboard_backend::read().is_ok();
+    !clipboard_works;
 }
 
 /// Set the clipboard to `text` via the Clipboard portal over a RemoteDesktop session.

--- a/apps/desktop/desktop_native/core/src/clipboard/portal_backend.rs
+++ b/apps/desktop/desktop_native/core/src/clipboard/portal_backend.rs
@@ -26,8 +26,16 @@ const TOKEN_FILE: &str = "remote_desktop_portal_token";
 /// Whether the portal-based clipboard fallback should be used when the direct `arboard` access
 /// fails.
 pub(crate) fn should_use_portal() -> bool {
-    let clipboard_works = super::arboard_backend::read().is_ok();
-    !clipboard_works
+    match super::arboard_backend::read() {
+        Ok(_) => false,
+        // An empty clipboard, or one holding non-text content, reports `ContentNotAvailable`.
+        // That is a successful read of nothing rather than a broken backend, so it must not
+        // trigger the portal fallback.
+        Err(err) => !matches!(
+            err.downcast_ref::<arboard::Error>(),
+            Some(arboard::Error::ContentNotAvailable)
+        ),
+    }
 }
 
 /// Set the clipboard to `text` via the Clipboard portal over a RemoteDesktop session.

--- a/apps/desktop/desktop_native/core/src/clipboard/portal_backend.rs
+++ b/apps/desktop/desktop_native/core/src/clipboard/portal_backend.rs
@@ -27,7 +27,7 @@ const TOKEN_FILE: &str = "remote_desktop_portal_token";
 /// fails.
 pub(crate) fn should_use_portal() -> bool {
     let clipboard_works = super::arboard_backend::read().is_ok();
-    !clipboard_works;
+    !clipboard_works
 }
 
 /// Set the clipboard to `text` via the Clipboard portal over a RemoteDesktop session.


### PR DESCRIPTION
`arboard` supports x11 and wayland (via `zwlr_data_control_manager_v1`). Gnome supports Xwayland, and Bitwarden can use the clipboard via X11, in cases it is available. In cases Xwayland is not available, we need to use the remote-desktop portal.

We previously enabled the remote desktop portal by default, but it seems there are some issues with it for some cases. This PR enables the X11 backend *by default* and only uses the portal as a fallback.

https://bitwarden.atlassian.net/browse/PM-40918