### PR TITLE
fix: race condition leading to decryption errors

### DIFF
--- a/libs/common/src/platform/services/sdk/default-sdk.service.spec.ts
+++ b/libs/common/src/platform/services/sdk/default-sdk.service.spec.ts
@@ -15,9 +15,9 @@ import {
 } from "../../../../spec";
 import { ApiService } from "../../../abstractions/api.service";
 import { AccountCryptographicStateService } from "../../../key-management/account-cryptography/account-cryptographic-state.service";
-import { EncryptedString } from "../../../key-management/crypto/models/enc-string";
+import { EncryptedString, EncString } from "../../../key-management/crypto/models/enc-string";
 import { V2UpgradeTokenStateService } from "../../../key-management/upgrade-token/abstractions/v2-upgrade-token-state.service.abstraction";
-import { UserId } from "../../../types/guid";
+import { OrganizationId, UserId } from "../../../types/guid";
 import { UserKey } from "../../../types/key";
 import { ConfigService } from "../../abstractions/config/config.service";
 import { Environment, EnvironmentService } from "../../abstractions/environment.service";
@@ -30,6 +30,12 @@ import { Utils } from "../../misc/utils";
 import { SymmetricCryptoKey } from "../../models/domain/symmetric-crypto-key";
 
 import { DefaultSdkService } from "./default-sdk.service";
+
+/**
+ * Comfortably longer than the `auditTime` window `internalClient$` applies to its non-userKey
+ * state, so advancing by this always lets a pending state change through.
+ */
+const PAST_AUDIT_WINDOW_MS = 250;
 
 class TestSdkLoadService extends SdkLoadService {
   protected override load(): Promise<void> {
@@ -142,8 +148,8 @@ describe("DefaultSdkService", () => {
           service.userClient$(userId).subscribe(subject_1);
           service.userClient$(userId).subscribe(subject_2);
 
-          // Wait for debounceTime(100) in internalClient$ plus async client initialization
-          await new Promise((resolve) => setTimeout(resolve, 150));
+          // Wait for the audit window in internalClient$ plus async client initialization
+          await new Promise((resolve) => setTimeout(resolve, PAST_AUDIT_WINDOW_MS));
 
           expect(subject_1.value.take().value).toBe(mockClient);
           expect(subject_2.value.take().value).toBe(mockClient);
@@ -208,6 +214,58 @@ describe("DefaultSdkService", () => {
           expect(userClientTracker.emissions[1]).toBeDefined();
         });
 
+        it("rebuilds the client as soon as the userKey changes, without waiting out the audit window", async () => {
+          jest.useFakeTimers();
+          const userKey$ = new BehaviorSubject(
+            new SymmetricCryptoKey(new Uint8Array(64)) as UserKey,
+          );
+          keyService.userKey$.calledWith(userId).mockReturnValue(userKey$);
+
+          const subject = new BehaviorSubject<Rc<PasswordManagerClient> | undefined>(undefined);
+          const subscription = service.userClient$(userId).subscribe(subject);
+
+          // Let the initial client settle past the audit window.
+          await jest.advanceTimersByTimeAsync(PAST_AUDIT_WINDOW_MS);
+          expect(sdkClientFactory.createSdkClient).toHaveBeenCalledTimes(1);
+
+          userKey$.next(new SymmetricCryptoKey(new Uint8Array(64).fill(1)) as UserKey);
+
+          // Only drain the microtask queue -- the userKey must not be subject to the audit window.
+          await jest.advanceTimersByTimeAsync(0);
+          expect(sdkClientFactory.createSdkClient).toHaveBeenCalledTimes(2);
+
+          subscription.unsubscribe();
+          jest.useRealTimers();
+        });
+
+        it("coalesces a burst of non-userKey state changes into a single client", async () => {
+          jest.useFakeTimers();
+          const orgKeys$ = new BehaviorSubject<Record<OrganizationId, EncString>>({});
+          keyService.encryptedOrgKeys$.calledWith(userId).mockReturnValue(orgKeys$);
+
+          const subject = new BehaviorSubject<Rc<PasswordManagerClient> | undefined>(undefined);
+          const subscription = service.userClient$(userId).subscribe(subject);
+
+          await jest.advanceTimersByTimeAsync(PAST_AUDIT_WINDOW_MS);
+          expect(sdkClientFactory.createSdkClient).toHaveBeenCalledTimes(1);
+
+          const lastOrgId = Utils.newGuid() as OrganizationId;
+          orgKeys$.next({ [Utils.newGuid() as OrganizationId]: new EncString("4.first") });
+          orgKeys$.next({ [Utils.newGuid() as OrganizationId]: new EncString("4.second") });
+          orgKeys$.next({ [lastOrgId]: new EncString("4.third") });
+
+          await jest.advanceTimersByTimeAsync(PAST_AUDIT_WINDOW_MS);
+
+          // One rebuild for the whole burst, initialized with the final value.
+          expect(sdkClientFactory.createSdkClient).toHaveBeenCalledTimes(2);
+          expect(mockClient.crypto().initialize_org_crypto).toHaveBeenLastCalledWith({
+            organizationKeys: new Map([[lastOrgId, "4.third"]]),
+          });
+
+          subscription.unsubscribe();
+          jest.useRealTimers();
+        });
+
         it("completes the subscription and frees the internal SDK client when the environment is unset (logout)", async () => {
           const env$ = new BehaviorSubject<Environment | undefined>(mock<Environment>());
           environmentService.getEnvironment$
@@ -215,10 +273,12 @@ describe("DefaultSdkService", () => {
             .mockReturnValue(env$ as BehaviorSubject<Environment>);
 
           const userClientTracker = new ObservableTracker(service.userClient$(userId), false);
-          await userClientTracker.pauseUntilReceived(1);
+          // The environment is part of the audited state, so both the initial client and the
+          // completion triggered by unsetting it wait out the audit window.
+          await userClientTracker.pauseUntilReceived(1, PAST_AUDIT_WINDOW_MS);
 
           env$.next(undefined);
-          await userClientTracker.expectCompletion();
+          await userClientTracker.expectCompletion(PAST_AUDIT_WINDOW_MS);
 
           expect(mockClient.free).toHaveBeenCalledTimes(1);
         });
@@ -276,9 +336,9 @@ describe("DefaultSdkService", () => {
           sdkClientFactory.createSdkClient.mockResolvedValue(mockInternalClient);
           const userClientTracker = new ObservableTracker(service.userClient$(userId), false);
 
-          const firstEmission = userClientTracker.pauseUntilReceived(1, 200);
-          // Advance past the debounceTime(100) in internalClient$ so the first emission fires
-          await jest.advanceTimersByTimeAsync(100);
+          const firstEmission = userClientTracker.pauseUntilReceived(1, 500);
+          // Advance past the audit window in internalClient$ so the first emission fires
+          await jest.advanceTimersByTimeAsync(PAST_AUDIT_WINDOW_MS);
           await firstEmission;
 
           service.setClient(userId, mockOverrideClient);

--- a/libs/common/src/platform/services/sdk/default-sdk.service.ts
+++ b/libs/common/src/platform/services/sdk/default-sdk.service.ts
@@ -1,4 +1,5 @@
 import {
+  auditTime,
   combineLatest,
   concatMap,
   Observable,
@@ -189,26 +190,32 @@ export class DefaultSdkService implements SdkService {
       .v2UpgradeToken$(userId)
       .pipe(distinctUntilChanged());
 
-    const client$ = combineLatest([
+    // Slow-moving state. These are frequently written in quick succession, and building a
+    // client per intermediate combination is both expensive and hands out clients assembled
+    // from a half-updated set of values. `auditTime` waits out the burst and emits only the
+    // final combination, so a burst results in exactly one client.
+    const clientState$ = combineLatest([
       this.environmentService.getEnvironment$(userId),
       account$,
       kdfParams$,
       accountCryptographicState$,
-      userKey$,
       orgKeys$,
       v2UpgradeToken$,
+    ]).pipe(auditTime(100));
+
+    const client$ = combineLatest([
+      clientState$,
+      // The user key is deliberately kept out of the audit window above: lock and unlock must
+      // be reflected in the client immediately, otherwise consumers can take a stale client
+      // and fail to decrypt.
+      userKey$,
       SdkLoadService.Ready, // Makes sure we wait (once) for the SDK to be loaded
     ]).pipe(
       // switchMap is required to allow the clean-up logic to be executed when `combineLatest` emits a new value.
       switchMap(
         ([
-          env,
-          account,
-          kdfParams,
-          accountCryptographicState,
+          [env, account, kdfParams, accountCryptographicState, orgKeys, v2UpgradeToken],
           userKey,
-          orgKeys,
-          v2UpgradeToken,
         ]) => {
           // Create our own observable to be able to implement clean-up logic
           return new Observable<Rc<PasswordManagerClient>>((subscriber) => {

--- a/libs/common/src/platform/services/sdk/default-sdk.service.ts
+++ b/libs/common/src/platform/services/sdk/default-sdk.service.ts
@@ -1,5 +1,4 @@
 import {
-  asyncScheduler,
   combineLatest,
   concatMap,
   Observable,
@@ -18,7 +17,6 @@ import {
   throwIfEmpty,
   firstValueFrom,
   filter,
-  throttleTime,
 } from "rxjs";
 
 // This import has been flagged as unallowed for this class. It may be involved in a circular dependency loop.
@@ -201,9 +199,6 @@ export class DefaultSdkService implements SdkService {
       v2UpgradeToken$,
       SdkLoadService.Ready, // Makes sure we wait (once) for the SDK to be loaded
     ]).pipe(
-      // Do not emit when multiple state values are written in quick succession.
-      // leading: emit immediately on first change; trailing: always process the final state in a burst.
-      throttleTime(20, asyncScheduler, { leading: true, trailing: true }),
       // switchMap is required to allow the clean-up logic to be executed when `combineLatest` emits a new value.
       switchMap(
         ([


### PR DESCRIPTION
We introduced the deduplication of SDK emissions because frequent SDK emissions cause partially incorrect states, as well as causing severe and unexpected performance issues. The debounce may briefly swallow emissions, if a state write happens first, then the client gets unlocked. In this case, the `client` emits, and is used for cipher decryption *before* the crypto is initialized. This leads to temporary decryption errors.

We fix this by decoupling the debounce for state writes, from the user-key (lock state) changing. 

Note: The medium term solution is to change the paradigm. We would much prefer to have the same pattern as on mobile / to keep SDK instances around rather than re-initializing constantly.

https://bitwarden.atlassian.net/browse/PM-40983