### PR TITLE
feat(data-recovery): add detection of field decryption ciphers

### DIFF
--- a/apps/web/src/app/key-management/data-recovery/data-recovery.component.spec.ts
+++ b/apps/web/src/app/key-management/data-recovery/data-recovery.component.spec.ts
@@ -4,6 +4,7 @@ import { mock, MockProxy } from "jest-mock-extended";
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { CryptoFunctionService } from "@bitwarden/common/key-management/crypto/abstractions/crypto-function.service";
+import { EncryptService } from "@bitwarden/common/key-management/crypto/abstractions/encrypt.service";
 import { FileDownloadService } from "@bitwarden/common/platform/abstractions/file-download/file-download.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { FakeAccountService, mockAccountServiceWith } from "@bitwarden/common/spec";
@@ -40,6 +41,7 @@ describe("DataRecoveryComponent", () => {
   let mockLogService: MockProxy<LogService>;
   let mockCryptoFunctionService: MockProxy<CryptoFunctionService>;
   let mockFileDownloadService: MockProxy<FileDownloadService>;
+  let mockEncryptService: MockProxy<EncryptService>;
 
   const mockUserId = "user-id" as UserId;
 
@@ -55,6 +57,7 @@ describe("DataRecoveryComponent", () => {
     mockLogService = mock<LogService>();
     mockCryptoFunctionService = mock<CryptoFunctionService>();
     mockFileDownloadService = mock<FileDownloadService>();
+    mockEncryptService = mock<EncryptService>();
 
     mockI18nService.t.mockImplementation((key) => `${key}_used-i18n`);
 
@@ -75,6 +78,7 @@ describe("DataRecoveryComponent", () => {
         { provide: LogService, useValue: mockLogService },
         { provide: CryptoFunctionService, useValue: mockCryptoFunctionService },
         { provide: FileDownloadService, useValue: mockFileDownloadService },
+        { provide: EncryptService, useValue: mockEncryptService },
       ],
     }).compileComponents();
 

--- a/apps/web/src/app/key-management/data-recovery/data-recovery.component.ts
+++ b/apps/web/src/app/key-management/data-recovery/data-recovery.component.ts
@@ -7,6 +7,7 @@ import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { CryptoFunctionService } from "@bitwarden/common/key-management/crypto/abstractions/crypto-function.service";
+import { EncryptService } from "@bitwarden/common/key-management/crypto/abstractions/encrypt.service";
 import { FileDownloadService } from "@bitwarden/common/platform/abstractions/file-download/file-download.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { CipherEncryptionService } from "@bitwarden/common/vault/abstractions/cipher-encryption.service";
@@ -62,6 +63,7 @@ export class DataRecoveryComponent {
   private dialogService = inject(DialogService);
   private privateKeyRegenerationService = inject(UserAsymmetricKeysRegenerationService);
   private cryptoFunctionService = inject(CryptoFunctionService);
+  private encryptService = inject(EncryptService);
   private logService = inject(LogService);
   private fileDownloadService = inject(FileDownloadService);
 
@@ -75,7 +77,12 @@ export class DataRecoveryComponent {
       this.cryptoFunctionService,
     ),
     new FolderStep(this.folderApiService, this.dialogService),
-    new CipherStep(this.apiService, this.cipherEncryptService, this.dialogService),
+    new CipherStep(
+      this.apiService,
+      this.cipherEncryptService,
+      this.dialogService,
+      this.encryptService,
+    ),
   ];
   private workingData: RecoveryWorkingData | null = null;
 

--- a/apps/web/src/app/key-management/data-recovery/steps/cipher-step.spec.ts
+++ b/apps/web/src/app/key-management/data-recovery/steps/cipher-step.spec.ts
@@ -1,7 +1,12 @@
 import { mock, MockProxy } from "jest-mock-extended";
 
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
+import { EncryptService } from "@bitwarden/common/key-management/crypto/abstractions/encrypt.service";
+import { EncString } from "@bitwarden/common/key-management/crypto/models/enc-string";
+import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
+import { UserKey } from "@bitwarden/common/types/key";
 import { CipherEncryptionService } from "@bitwarden/common/vault/abstractions/cipher-encryption.service";
+import { CipherType } from "@bitwarden/common/vault/enums";
 import { Cipher } from "@bitwarden/common/vault/models/domain/cipher";
 import { DialogService } from "@bitwarden/components";
 import { UserId } from "@bitwarden/user-core";
@@ -16,15 +21,19 @@ describe("CipherStep", () => {
   let apiService: MockProxy<ApiService>;
   let cipherEncryptionService: MockProxy<CipherEncryptionService>;
   let dialogService: MockProxy<DialogService>;
+  let encryptService: MockProxy<EncryptService>;
   let logger: MockProxy<LogRecorder>;
+
+  const userKey = new SymmetricCryptoKey(new Uint8Array(64)) as UserKey;
 
   beforeEach(() => {
     apiService = mock<ApiService>();
     cipherEncryptionService = mock<CipherEncryptionService>();
     dialogService = mock<DialogService>();
+    encryptService = mock<EncryptService>();
     logger = mock<LogRecorder>();
 
-    cipherStep = new CipherStep(apiService, cipherEncryptionService, dialogService);
+    cipherStep = new CipherStep(apiService, cipherEncryptionService, dialogService, encryptService);
   });
 
   describe("runDiagnostics", () => {
@@ -118,9 +127,66 @@ describe("CipherStep", () => {
       const result = await cipherStep.runDiagnostics(workingData, logger);
 
       expect(result).toBe(false);
-      expect(logger.record).toHaveBeenCalledWith("Cipher ID cipher-2 was undecryptable");
-      expect(logger.record).toHaveBeenCalledWith("Cipher ID cipher-3 was undecryptable");
+      expect(logger.record).toHaveBeenCalledWith(
+        "Cipher ID cipher-2 was undecryptable (cipher key absent, item type unknown, FIDO2 credentials absent): full decryption failed: Decryption failed",
+      );
+      expect(logger.record).toHaveBeenCalledWith(
+        "Cipher ID cipher-3 was undecryptable (cipher key absent, item type unknown, FIDO2 credentials absent): full decryption failed: Decryption failed",
+      );
       expect(logger.record).toHaveBeenCalledWith("Found 2 undecryptable ciphers");
+    });
+
+    it("logs that a cipher key is present on an undecryptable cipher", async () => {
+      const userId = "user-id" as UserId;
+      const cipher = {
+        id: "cipher-1",
+        organizationId: null,
+        key: new EncString("2.key-iv|key-data|key-mac"),
+      } as Cipher;
+
+      const workingData: RecoveryWorkingData = {
+        userId,
+        userKey,
+        encryptedPrivateKey: null,
+        isPrivateKeyCorrupt: false,
+        ciphers: [cipher],
+        folders: [],
+      };
+
+      cipherEncryptionService.decrypt.mockRejectedValue(new Error("Decryption failed"));
+
+      await cipherStep.runDiagnostics(workingData, logger);
+
+      expect(logger.record).toHaveBeenCalledWith(
+        "Cipher ID cipher-1 was undecryptable (cipher key present, item type unknown, FIDO2 credentials absent): full decryption failed: Decryption failed",
+      );
+    });
+
+    it("logs the item type and FIDO2 credential state of an undecryptable cipher", async () => {
+      const userId = "user-id" as UserId;
+      const cipher = {
+        id: "cipher-1",
+        organizationId: null,
+        type: CipherType.Login,
+        login: { fido2Credentials: [{}] },
+      } as Cipher;
+
+      const workingData: RecoveryWorkingData = {
+        userId,
+        userKey,
+        encryptedPrivateKey: null,
+        isPrivateKeyCorrupt: false,
+        ciphers: [cipher],
+        folders: [],
+      };
+
+      cipherEncryptionService.decrypt.mockRejectedValue(new Error("Decryption failed"));
+
+      await cipherStep.runDiagnostics(workingData, logger);
+
+      expect(logger.record).toHaveBeenCalledWith(
+        `Cipher ID cipher-1 was undecryptable (cipher key absent, item type ${CipherType.Login}, FIDO2 credentials present): full decryption failed: Decryption failed`,
+      );
     });
 
     it("returns correct results when running diagnostics multiple times", async () => {
@@ -156,6 +222,171 @@ describe("CipherStep", () => {
       expect(cipherStep.canRecover(workingData)).toBe(false);
       expect(cipherStep["undecryptableCipherIds"]).toHaveLength(0);
       expect(cipherStep["decryptableCipherIds"]).toHaveLength(2);
+    });
+
+    describe("name field check", () => {
+      const userId = "user-id" as UserId;
+      const encryptedName = new EncString("2.name-iv|name-data|name-mac");
+
+      const workingDataFor = (
+        cipher: Cipher,
+        key: UserKey | null = userKey,
+      ): RecoveryWorkingData => ({
+        userId,
+        userKey: key,
+        encryptedPrivateKey: null,
+        isPrivateKeyCorrupt: false,
+        ciphers: [cipher],
+        folders: [],
+      });
+
+      beforeEach(() => {
+        cipherEncryptionService.decrypt.mockResolvedValue({} as any);
+      });
+
+      it("does not probe a cipher with no name", async () => {
+        const workingData = workingDataFor({ id: "cipher-1", organizationId: null } as Cipher);
+
+        const result = await cipherStep.runDiagnostics(workingData, logger);
+
+        expect(result).toBe(true);
+        expect(encryptService.decryptString).not.toHaveBeenCalled();
+        expect(encryptService.unwrapSymmetricKey).not.toHaveBeenCalled();
+      });
+
+      it("does not probe a name that is not an AesCbc256_HmacSha256 encrypted string", async () => {
+        const workingData = workingDataFor({
+          id: "cipher-1",
+          organizationId: null,
+          name: new EncString("7.cose-data"),
+        } as Cipher);
+
+        const result = await cipherStep.runDiagnostics(workingData, logger);
+
+        expect(result).toBe(true);
+        expect(encryptService.decryptString).not.toHaveBeenCalled();
+      });
+
+      it("does not probe when the user key is missing", async () => {
+        const workingData = workingDataFor(
+          { id: "cipher-1", organizationId: null, name: encryptedName } as Cipher,
+          null,
+        );
+
+        const result = await cipherStep.runDiagnostics(workingData, logger);
+
+        expect(result).toBe(true);
+        expect(encryptService.decryptString).not.toHaveBeenCalled();
+      });
+
+      it("does not probe when the user key is not an AesCbc256_HmacSha256 key", async () => {
+        // A COSE user key cannot decrypt an AesCbc256_HmacSha256 name, so the probe would report a
+        // failure that says nothing about the cipher.
+        const coseUserKey = new SymmetricCryptoKey(new Uint8Array(70)) as UserKey;
+        const workingData = workingDataFor(
+          { id: "cipher-1", organizationId: null, name: encryptedName } as Cipher,
+          coseUserKey,
+        );
+
+        const result = await cipherStep.runDiagnostics(workingData, logger);
+
+        expect(result).toBe(true);
+        expect(encryptService.decryptString).not.toHaveBeenCalled();
+        expect(encryptService.unwrapSymmetricKey).not.toHaveBeenCalled();
+      });
+
+      it("decrypts the name with the user key when the cipher has no cipher key", async () => {
+        const workingData = workingDataFor({
+          id: "cipher-1",
+          organizationId: null,
+          name: encryptedName,
+        } as Cipher);
+
+        encryptService.decryptString.mockResolvedValue("name");
+
+        const result = await cipherStep.runDiagnostics(workingData, logger);
+
+        expect(result).toBe(true);
+        expect(encryptService.unwrapSymmetricKey).not.toHaveBeenCalled();
+        expect(encryptService.decryptString).toHaveBeenCalledWith(encryptedName, userKey);
+      });
+
+      it("decrypts the name with the unwrapped cipher key when the cipher has one", async () => {
+        const cipherKey = new EncString("2.key-iv|key-data|key-mac");
+        const unwrappedKey = new SymmetricCryptoKey(new Uint8Array(64).fill(1));
+        const workingData = workingDataFor({
+          id: "cipher-1",
+          organizationId: null,
+          name: encryptedName,
+          key: cipherKey,
+        } as Cipher);
+
+        encryptService.unwrapSymmetricKey.mockResolvedValue(unwrappedKey);
+        encryptService.decryptString.mockResolvedValue("name");
+
+        const result = await cipherStep.runDiagnostics(workingData, logger);
+
+        expect(result).toBe(true);
+        expect(encryptService.unwrapSymmetricKey).toHaveBeenCalledWith(cipherKey, userKey);
+        expect(encryptService.decryptString).toHaveBeenCalledWith(encryptedName, unwrappedKey);
+      });
+
+      it("flags a cipher whose name fails to decrypt even when full decryption succeeds", async () => {
+        const workingData = workingDataFor({
+          id: "cipher-1",
+          organizationId: null,
+          name: encryptedName,
+        } as Cipher);
+
+        encryptService.decryptString.mockRejectedValue(new Error("mac mismatch"));
+
+        const result = await cipherStep.runDiagnostics(workingData, logger);
+
+        expect(result).toBe(false);
+        expect(logger.record).toHaveBeenCalledWith(
+          "Cipher ID cipher-1 was undecryptable (cipher key absent, item type unknown, FIDO2 credentials absent): name field could not be decrypted: mac mismatch",
+        );
+      });
+
+      it("flags a cipher whose cipher key cannot be unwrapped", async () => {
+        const workingData = workingDataFor({
+          id: "cipher-1",
+          organizationId: null,
+          name: encryptedName,
+          key: new EncString("2.key-iv|key-data|key-mac"),
+        } as Cipher);
+
+        encryptService.unwrapSymmetricKey.mockRejectedValue(new Error("mac mismatch"));
+
+        const result = await cipherStep.runDiagnostics(workingData, logger);
+
+        expect(result).toBe(false);
+        expect(encryptService.decryptString).not.toHaveBeenCalled();
+        expect(logger.record).toHaveBeenCalledWith(
+          "Cipher ID cipher-1 was undecryptable (cipher key present, item type unknown, FIDO2 credentials absent): cipher key could not be unwrapped: mac mismatch",
+        );
+      });
+
+      it("reports both failures when full decryption and the name probe fail", async () => {
+        const workingData = workingDataFor({
+          id: "cipher-1",
+          organizationId: null,
+          name: encryptedName,
+        } as Cipher);
+
+        cipherEncryptionService.decrypt.mockRejectedValue(new Error("no elements in sequence"));
+        encryptService.decryptString.mockRejectedValue(new Error("mac mismatch"));
+
+        const result = await cipherStep.runDiagnostics(workingData, logger);
+
+        expect(result).toBe(false);
+        expect(logger.record).toHaveBeenCalledWith(
+          "Cipher ID cipher-1 was undecryptable " +
+            "(cipher key absent, item type unknown, FIDO2 credentials absent): " +
+            "full decryption failed: no elements in sequence; " +
+            "name field could not be decrypted: mac mismatch",
+        );
+      });
     });
   });
 

--- a/apps/web/src/app/key-management/data-recovery/steps/cipher-step.ts
+++ b/apps/web/src/app/key-management/data-recovery/steps/cipher-step.ts
@@ -1,10 +1,22 @@
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
+import { EncryptService } from "@bitwarden/common/key-management/crypto/abstractions/encrypt.service";
+import { EncryptionType } from "@bitwarden/common/platform/enums";
+import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
+import { UserKey } from "@bitwarden/common/types/key";
 import { CipherEncryptionService } from "@bitwarden/common/vault/abstractions/cipher-encryption.service";
+import { Cipher } from "@bitwarden/common/vault/models/domain/cipher";
 import { DialogService } from "@bitwarden/components";
 
 import { LogRecorder } from "../log-recorder";
 
 import { RecoveryStep, RecoveryWorkingData } from "./recovery-step";
+
+/** Prefix of an AesCbc256_HmacSha256_B64 encrypted string. */
+const AES_CBC_256_HMAC_SHA_256_PREFIX = "2.";
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
 
 export class CipherStep implements RecoveryStep {
   title = "recoveryStepCipherTitle";
@@ -16,6 +28,7 @@ export class CipherStep implements RecoveryStep {
     private apiService: ApiService,
     private cipherService: CipherEncryptionService,
     private dialogService: DialogService,
+    private encryptService: EncryptService,
   ) {}
 
   async runDiagnostics(workingData: RecoveryWorkingData, logger: LogRecorder): Promise<boolean> {
@@ -31,18 +44,73 @@ export class CipherStep implements RecoveryStep {
     // For now, this just filters out and does not consider corrupt organization ciphers.
     const userCiphers = workingData.ciphers.filter((c) => c.organizationId == null);
     for (const cipher of userCiphers) {
+      const failures: string[] = [];
+
       try {
         await this.cipherService.decrypt(cipher, workingData.userId);
-        this.decryptableCipherIds.push(cipher.id);
-      } catch {
-        logger.record(`Cipher ID ${cipher.id} was undecryptable`);
-        this.undecryptableCipherIds.push(cipher.id);
+      } catch (error) {
+        failures.push(`full decryption failed: ${errorMessage(error)}`);
       }
+
+      // A cipher can survive a full decryption attempt while an individual field is corrupt, so
+      // probe the name ciphertext directly.
+      const nameFailure = await this.checkNameDecrypts(cipher, workingData.userKey);
+      if (nameFailure != null) {
+        failures.push(nameFailure);
+      }
+
+      if (failures.length === 0) {
+        this.decryptableCipherIds.push(cipher.id);
+        continue;
+      }
+
+      const cipherKeyState = cipher.key != null ? "present" : "absent";
+      const itemType = cipher.type != null ? cipher.type : "unknown";
+      const fido2CredentialsPresent = cipher.login?.fido2Credentials != null ? "present" : "absent";
+      logger.record(
+        `Cipher ID ${cipher.id} was undecryptable (cipher key ${cipherKeyState}, item type ${itemType}, FIDO2 credentials ${fido2CredentialsPresent}): ${failures.join("; ")}`,
+      );
+      this.undecryptableCipherIds.push(cipher.id);
     }
     logger.record(`Found ${this.undecryptableCipherIds.length} undecryptable ciphers`);
     logger.record(`Found ${this.decryptableCipherIds.length} decryptable ciphers`);
 
     return this.undecryptableCipherIds.length == 0;
+  }
+
+  /**
+   * Probes the cipher's name field for field-level corruption. Returns a failure reason, or null
+   * when the name decrypts or is not a form we probe.
+   *
+   * Null means that the check did not fail. A string value means the check failed.
+   */
+  private async checkNameDecrypts(cipher: Cipher, userKey: UserKey | null): Promise<string | null> {
+    const encryptedName = cipher.name?.encryptedString;
+    if (
+      userKey == null ||
+      userKey.inner().type !== EncryptionType.AesCbc256_HmacSha256_B64 ||
+      encryptedName == null ||
+      !encryptedName.startsWith(AES_CBC_256_HMAC_SHA_256_PREFIX)
+    ) {
+      return null;
+    }
+
+    // Fields are encrypted with the cipher key when one is present, otherwise with the user key.
+    let vaultItemDecryptionKey: SymmetricCryptoKey = userKey;
+    if (cipher.key != null) {
+      try {
+        vaultItemDecryptionKey = await this.encryptService.unwrapSymmetricKey(cipher.key, userKey);
+      } catch (error) {
+        return `cipher key could not be unwrapped: ${errorMessage(error)}`;
+      }
+    }
+
+    try {
+      await this.encryptService.decryptString(cipher.name!, vaultItemDecryptionKey);
+      return null;
+    } catch (error) {
+      return `name field could not be decrypted: ${errorMessage(error)}`;
+    }
   }
 
   canRecover(workingData: RecoveryWorkingData): boolean {
@@ -79,8 +147,7 @@ export class CipherStep implements RecoveryStep {
         await this.apiService.deleteCipher(cipherId);
         logger.record(`Deleted cipher ${cipherId}`);
       } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : String(error);
-        logger.record(`Failed to delete cipher ${cipherId}: ${errorMessage}`);
+        logger.record(`Failed to delete cipher ${cipherId}: ${errorMessage(error)}`);
         throw error;
       }
     }


### PR DESCRIPTION
Add field-level-cipher-corruption detection. Namely, we probe a cipher by trying to decrypt the "name" field. Please note, that the name field *may* be absent for v2 ciphers that use blob encryption. This recovery step is skipped, exactly if the user-key is a v2 key.

https://bitwarden.atlassian.net/browse/PM-40990

Mainly, we want to detect the "passkey corrupted" vault items, all of which have no cipher-key. We want the information to be present whether there is a passkey, and whether there is a cipher-key in the logs.