### PR TITLE
[CL] mark bit-table-v2 as Beta in Storybook docs

### DIFF
--- a/libs/components/src/filter-menu/filter-menu.mdx
+++ b/libs/components/src/filter-menu/filter-menu.mdx
@@ -13,7 +13,8 @@ single on/off chip with no menu.
 The chips work like a reactive form: each chip has a `key`, owns its own selection, and reports its
 value up. The chips are **host-agnostic** — outside a table they just track their selection. Inside
 a `bit-table-v2`, a chip registers itself automatically and its value lands in
-`table.filterValues()` — see [Table V2 › Filtering](?path=/docs/component-library-table-v2--docs).
+`table.filterValues()` — see
+[Table V2 › Filtering](?path=/docs/component-library-table-v2-beta--docs).
 
 <Canvas of={stories.Default} />
 
@@ -64,7 +65,7 @@ message shows when nothing matches. The term resets when the menu closes.
 Project a chip into a `bit-table-v2` and it registers itself. The chip's value lands in
 `table.filterValues()` under its `key`; the table's `filter(row, values)` reads it. There are no
 matchers and no per-chip state — see
-[Table V2 › Filtering](?path=/docs/component-library-table-v2--docs).
+[Table V2 › Filtering](?path=/docs/component-library-table-v2-beta--docs).
 
 ```html
 <bit-filter-menu key="type" placeholderText="Type" unsetLabel="All">

--- a/libs/components/src/table/table.mdx
+++ b/libs/components/src/table/table.mdx
@@ -6,10 +6,10 @@ import * as stories from "./table.stories";
 
 # Table
 
-> **`bit-table` is deprecated.** Use [`bit-table-v2`](?path=/docs/component-library-table-v2--docs)
-> for new tables, and see
-> [Migrating from V1](?path=/docs/component-library-table-v2-migrating-from-v1--docs) to move an
-> existing table over.
+> **`bit-table` is deprecated.** Use
+> [`bit-table-v2`](?path=/docs/component-library-table-v2-beta--docs) for new tables, and see
+> [Migrating from V1](?path=/docs/component-library-table-v2-beta-migrating-from-v1--docs) to move
+> an existing table over.
 
 The table component provides a comprehensive way to display, sort and filter data. It consists of
 two portions, a UI component called `bit-table` and the underlying data source `TableDataSource`.

--- a/libs/components/src/table/v2/table-v2-migration.mdx
+++ b/libs/components/src/table/v2/table-v2-migration.mdx
@@ -1,6 +1,6 @@
 import { Meta } from "@storybook/addon-docs/blocks";
 
-<Meta title="Component Library/Table V2/Migrating from V1" />
+<Meta title="Component Library/Table V2 (Beta)/Migrating from V1" />
 
 # Migrating from `bit-table` to `bit-table-v2`
 
@@ -9,8 +9,8 @@ in the template (`*ngFor` / `rows$ | async`); `bit-table-v2` declares one `<bit-
 — each pairing a `<bit-header-cell>` with a `*bitCellDef` cell template — and iterates the data
 itself.
 
-For the full v2 API, see the [Table V2 docs](?path=/docs/component-library-table-v2--docs). This
-page covers only the v1 → v2 mapping.
+For the full v2 API, see the [Table V2 docs](?path=/docs/component-library-table-v2-beta--docs).
+This page covers only the v1 → v2 mapping.
 
 ## Pick the mode
 

--- a/libs/components/src/table/v2/table-v2.component.ts
+++ b/libs/components/src/table/v2/table-v2.component.ts
@@ -145,6 +145,10 @@ type RenderItem<T> =
   | { kind: "row"; row: T }
   | { kind: "group"; group: BitRowGroupComponent<T>; count: number; level: number };
 
+/**
+ * **Beta.** `bit-table-v2` is still stabilizing; its still getting some polish.
+ * Do not adopt it in production without approval from the UI Foundation team.
+ */
 @Component({
   selector: "bit-table-v2",
   exportAs: "bitTableV2",

--- a/libs/components/src/table/v2/table-v2.mdx
+++ b/libs/components/src/table/v2/table-v2.mdx
@@ -547,15 +547,18 @@ viewport renders the interleaved headers and rows.
 By default the table grows to fit its rows and scrolls with the page. To bound it — so the body
 scrolls and the header stays pinned — set `[height]`:
 
-- **`height="fill"`** — fill the height of a bounded, full-height container. This is the idiomatic
-  way to make a table fill the main content area, inside the body of a
-  [`bit-page`](?path=/docs/component-library-layout-page--docs):
+- **`height="fill"`** — fill the height of the parent. The parent **must have a resolved height** of
+  its own; without one the table has nothing to fill and collapses. The typical such parent is the
+  body of a [`bit-page`](?path=/docs/component-library-layout-page--docs), which is the idiomatic
+  way to make a table fill the main content area:
 
   ```html
   <bit-page>
     <bit-table-v2 [tableDef]="table" height="fill">…columns…</bit-table-v2>
   </bit-page>
   ```
+
+  <Canvas of={stories.FillPage} />
 
 - **`[height]="N"`** — cap the body at `N` rows (minimum 4), then scroll. This needs a known row
   height, so it applies only to [virtualized](#virtual-scrolling) tables and is a no-op otherwise.

--- a/libs/components/src/table/v2/table-v2.mdx
+++ b/libs/components/src/table/v2/table-v2.mdx
@@ -4,14 +4,17 @@ import * as stories from "./table-v2.stories";
 
 <Meta of={stories} />
 
-# Table V2
+# Table V2 (Beta)
+
+> **Beta — not yet approved for production.** `bit-table-v2` is still stabilizing; its still getting
+> some polish. Do not adopt it in production without approval from the UI Foundation team.
 
 `bit-table-v2` renders tabular data with sorting, filtering, selection, pagination, loading and
 empty states, and virtual scrolling built in. You declare each column once — its header and its
 per-row cell — and the table handles the rest.
 
 Use `bit-table-v2` for new tables. The legacy `bit-table` is deprecated — see
-[Migrating from V1](?path=/docs/component-library-table-v2-migrating-from-v1--docs) to move an
+[Migrating from V1](?path=/docs/component-library-table-v2-beta-migrating-from-v1--docs) to move an
 existing table over.
 
 <Primary />

--- a/libs/components/src/table/v2/table-v2.stories.ts
+++ b/libs/components/src/table/v2/table-v2.stories.ts
@@ -375,7 +375,7 @@ class DemoUrlSyncTableComponent {
 }
 
 export default {
-  title: "Component Library/Table V2",
+  title: "Component Library/Table V2 (Beta)",
   decorators: [
     positionFixedWrapperDecorator(undefined, { border: false }),
     moduleMetadata({


### PR DESCRIPTION
Adds a "(Beta)" label and a not-for-production disclaimer to the Table V2 Storybook docs, component JSDoc, and MDX. Updates the affected cross-reference links.

Also documents the `height="fill"` parent-height requirement and embeds the FillPage story as a live example.