### PR TITLE
[PM-40961] fix: don't show no master password warning for staged users

### DIFF
--- a/apps/web/src/app/admin-console/organizations/members/components/bulk/bulk-remove-dialog.component.ts
+++ b/apps/web/src/app/admin-console/organizations/members/components/bulk/bulk-remove-dialog.component.ts
@@ -5,7 +5,6 @@ import {
   OrganizationUserBulkResponse,
 } from "@bitwarden/admin-console/common";
 import { UserNamePipe } from "@bitwarden/angular/pipes/user-name.pipe";
-import { OrganizationUserStatusType } from "@bitwarden/common/admin-console/enums";
 import { ListResponse } from "@bitwarden/common/models/response/list.response";
 import {
   AsyncActionsModule,
@@ -18,6 +17,7 @@ import {
   DialogService,
   TableModule,
 } from "@bitwarden/components";
+import { OrganizationUserStatusType } from "@bitwarden/sdk-internal";
 import { I18nPipe } from "@bitwarden/ui-common";
 
 import { AvatarIdPipe } from "../../pipes/avatar-id.pipe";
@@ -56,9 +56,13 @@ export class BulkRemoveDialogComponent extends BaseBulkRemoveComponent {
 
   constructor() {
     super();
+    const masterPasswordWarningStatuses: BulkUserDetails["status"][] = [
+      OrganizationUserStatusType.Accepted,
+      OrganizationUserStatusType.Confirmed,
+    ];
     this.showNoMasterPasswordWarning.set(
       this.users().some(
-        (u) => u.status > OrganizationUserStatusType.Invited && u.hasMasterPassword === false,
+        (u) => masterPasswordWarningStatuses.includes(u.status) && u.hasMasterPassword === false,
       ),
     );
   }

--- a/apps/web/src/app/admin-console/organizations/members/components/edit-member-dialog/edit-member-dialog.component.ts
+++ b/apps/web/src/app/admin-console/organizations/members/components/edit-member-dialog/edit-member-dialog.component.ts
@@ -18,10 +18,6 @@ import {
   OrganizationUserUpdateRequest,
 } from "@bitwarden/admin-console/common";
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
-import {
-  OrganizationUserStatusType,
-  OrganizationUserType,
-} from "@bitwarden/common/admin-console/enums";
 import { PermissionsApi } from "@bitwarden/common/admin-console/models/api/permissions.api";
 import {
   CollectionAccessSelectionView,
@@ -58,6 +54,7 @@ import {
   TabsModule,
   ToastService,
 } from "@bitwarden/components";
+import { OrganizationUserType, OrganizationUserStatusType } from "@bitwarden/sdk-internal";
 import { I18nPipe } from "@bitwarden/ui-common";
 import { BillingConstraintService } from "@bitwarden/web-vault/app/billing/members/billing-constraint/billing-constraint.service";
 
@@ -322,8 +319,9 @@ export class EditMemberDialogComponent {
   ) {
     this.isRevoked.set(userDetails.status === OrganizationUserStatusType.Revoked);
     this.showNoMasterPasswordWarning.set(
-      userDetails.status > OrganizationUserStatusType.Invited &&
-        userDetails.hasMasterPassword === false,
+      [OrganizationUserStatusType.Accepted, OrganizationUserStatusType.Confirmed].includes(
+        userDetails.status,
+      ) && userDetails.hasMasterPassword === false,
     );
     const allCollectionsPermissions = {
       createNewCollections: userDetails.permissions.createNewCollections,

--- a/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.ts
+++ b/apps/web/src/app/admin-console/organizations/members/components/member-dialog/member-dialog.component.ts
@@ -20,10 +20,6 @@ import {
   OrganizationUserService,
 } from "@bitwarden/admin-console/common";
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
-import {
-  OrganizationUserStatusType,
-  OrganizationUserType,
-} from "@bitwarden/common/admin-console/enums";
 import { PermissionsApi } from "@bitwarden/common/admin-console/models/api/permissions.api";
 import {
   CollectionAccessSelectionView,
@@ -44,6 +40,7 @@ import {
   DialogService,
   ToastService,
 } from "@bitwarden/components";
+import { OrganizationUserStatusType, OrganizationUserType } from "@bitwarden/sdk-internal";
 
 import {
   GroupApiService,
@@ -402,8 +399,9 @@ export class MemberDialogComponent implements OnDestroy {
     }
     this.isRevoked = userDetails.status === OrganizationUserStatusType.Revoked;
     this.showNoMasterPasswordWarning =
-      userDetails.status > OrganizationUserStatusType.Invited &&
-      userDetails.hasMasterPassword === false;
+      [OrganizationUserStatusType.Accepted, OrganizationUserStatusType.Confirmed].includes(
+        userDetails.status,
+      ) && userDetails.hasMasterPassword === false;
     const allCollectionsPermissions = {
       createNewCollections: userDetails.permissions.createNewCollections,
       editAnyCollection: userDetails.permissions.editAnyCollection,

--- a/apps/web/src/app/admin-console/organizations/members/services/member-dialog-manager/member-dialog-manager.service.spec.ts
+++ b/apps/web/src/app/admin-console/organizations/members/services/member-dialog-manager/member-dialog-manager.service.spec.ts
@@ -536,6 +536,21 @@ describe("MemberDialogManagerService", () => {
       });
       expect(result).toBe(true);
     });
+
+    it("should not show no master password warning for staged users", async () => {
+      const stagedUser = {
+        ...mockUser,
+        status: OrganizationUserStatusType.Staged,
+        hasMasterPassword: false,
+      } as OrganizationUserView;
+
+      dialogService.openSimpleDialog.mockResolvedValue(true);
+
+      const result = await service.openRemoveUserConfirmationDialog(stagedUser);
+
+      expect(dialogService.openSimpleDialog).toHaveBeenCalledTimes(1);
+      expect(result).toBe(true);
+    });
   });
 
   describe("openRevokeUserConfirmationDialog", () => {
@@ -576,6 +591,22 @@ describe("MemberDialogManagerService", () => {
       const result = await service.openRevokeUserConfirmationDialog(noMpUser);
 
       expect(dialogService.openSimpleDialog).toHaveBeenCalledTimes(2);
+      expect(result).toBe(true);
+    });
+
+    it("should not show no master password warning for staged users", async () => {
+      const stagedUser = {
+        ...mockUser,
+        status: OrganizationUserStatusType.Staged,
+        hasMasterPassword: false,
+      } as OrganizationUserView;
+
+      i18nService.t.mockReturnValue("Revoke user confirmation");
+      dialogService.openSimpleDialog.mockResolvedValue(true);
+
+      const result = await service.openRevokeUserConfirmationDialog(stagedUser);
+
+      expect(dialogService.openSimpleDialog).toHaveBeenCalledTimes(1);
       expect(result).toBe(true);
     });
   });

--- a/apps/web/src/app/admin-console/organizations/members/services/member-dialog-manager/member-dialog-manager.service.ts
+++ b/apps/web/src/app/admin-console/organizations/members/services/member-dialog-manager/member-dialog-manager.service.ts
@@ -12,6 +12,7 @@ import { ConfigService } from "@bitwarden/common/platform/abstractions/config/co
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { OrganizationId } from "@bitwarden/common/types/guid";
 import { CenterPositionStrategy, DialogService, ToastService } from "@bitwarden/components";
+import { OrganizationUserStatusType } from "@bitwarden/sdk-internal";
 import { openEntityEventsDialog } from "@bitwarden/web-vault/app/dirt/event-logs/components/entity-events/entity-events.component";
 
 import { OrganizationUserView } from "../../../core/views/organization-user.view";
@@ -277,7 +278,12 @@ export class MemberDialogManagerService {
       return false;
     }
 
-    if (user.status > 0 && user.hasMasterPassword === false) {
+    if (
+      [OrganizationUserStatusType.Accepted, OrganizationUserStatusType.Confirmed].includes(
+        user.status,
+      ) &&
+      user.hasMasterPassword === false
+    ) {
       return await this.openNoMasterPasswordConfirmationDialog(user);
     }
 
@@ -296,7 +302,12 @@ export class MemberDialogManagerService {
       return false;
     }
 
-    if (user.status > 0 && user.hasMasterPassword === false) {
+    if (
+      [OrganizationUserStatusType.Accepted, OrganizationUserStatusType.Confirmed].includes(
+        user.status,
+      ) &&
+      user.hasMasterPassword === false
+    ) {
       return await this.openNoMasterPasswordConfirmationDialog(user);
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-40961

## 📔 Objective

We're moving away from ordinal comparisons of organization user status types (`>= Accepted`) and to nominal comparisons (`=== Confirmed`) for explicitness. This master password prompt modal is one such example.

<details><summary> 🤖  Slop </summary>
<p>

When removing a Staged user from **Admin Console → Members**, a second confirmation modal — "Account does not have master password" — appeared after the "user will lose access" modal, even when the user has a configured master password.

That warning (originally from AC-1144) is only meaningful for joined members (Accepted/Confirmed) who authenticate via SSO and never set a master password. It was gated by `user.status > 0 && user.hasMasterPassword === false`, which misfires for staged users for two reasons:

- The `Staged` status (`3`) was added *after* this check was written, so `status > 0` now sweeps in staged users the warning was never intended for.
- `hasMasterPassword` defaults to `false` when the API omits it, so a staged user (a provisioning stub) always satisfies `=== false` regardless of their real account state.

This replaces the fragile greater-than status checks with an explicit `Accepted`/`Confirmed` allowlist, so a future status inserted above `Confirmed` can't re-trip the same bug. Applied consistently across all four call sites that compute the warning:

- `member-dialog-manager.service.ts` — single-member remove and revoke flows (the reported bug)
- `bulk-remove-dialog.component.ts` — bulk-remove inline callout
- `member-dialog.component.ts` and `edit-member-dialog.component.ts` — edit-dialog remove/revoke

Added regression tests covering the staged-user case for both remove and revoke.

</p>
</details> 
