### PR TITLE
[PM-40590] Run chromatic workflow when the workflow file is updated, to enable dep testing

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -61,6 +61,7 @@ jobs:
               - "package.json"
               - ".storybook/**"
               - "apps/browser/src/autofill/content/components/**"
+              - ".github/workflows/chromatic.yml"
 
       - name: Get Node version
         id: retrieve-node-version


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[PM-40590](https://bitwarden.atlassian.net/browse/PM-40590)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Every once in a while, we need to update the dependency version of an action used in our Chromatic workflow file. The workflow only runs when the `filesChanged` filter returns `true`, so to enable us to run the workflow when the workflow is updated, we should add it to the filter.



[PM-40590]: https://bitwarden.atlassian.net/browse/PM-40590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ