### PR TITLE
[PM-35791] Remove old Send access endpoints

### DIFF
--- a/apps/cli/src/tools/send/commands/receive.command.spec.ts
+++ b/apps/cli/src/tools/send/commands/receive.command.spec.ts
@@ -90,7 +90,7 @@ describe("SendReceiveCommand", () => {
       it("should successfully access Send with cached token", async () => {
         const mockToken = new SendAccessToken("test-token", Date.now() + 3600000);
         sendTokenService.tryGetSendAccessToken$.mockReturnValue(of(mockToken));
-        sendApiService.postSendAccessV2.mockResolvedValue({} as any);
+        sendApiService.postSendAccess.mockResolvedValue({} as any);
         jest.spyOn(command as any, "accessSendWithToken").mockResolvedValue(Response.success());
 
         const response = await command.run(testUrl, {});
@@ -135,7 +135,7 @@ describe("SendReceiveCommand", () => {
 
         const mockToken = new SendAccessToken("test-token", Date.now() + 3600000);
         sendTokenService.getSendAccessToken$.mockReturnValue(of(mockToken));
-        sendApiService.postSendAccessV2.mockResolvedValue({} as any);
+        sendApiService.postSendAccess.mockResolvedValue({} as any);
         jest.spyOn(command as any, "accessSendWithToken").mockResolvedValue(Response.success());
 
         const response = await command.run(testUrl, { password: "correct-password" });
@@ -317,9 +317,9 @@ describe("SendReceiveCommand", () => {
           },
         };
 
-        sendApiService.postSendAccessV2.mockResolvedValue({} as any);
+        sendApiService.postSendAccess.mockResolvedValue({} as any);
         jest.spyOn(SendAccess.prototype, "decrypt").mockResolvedValueOnce(mockSendResponse as any);
-        sendApiService.getSendFileDownloadDataV2.mockResolvedValue({
+        sendApiService.getSendFileDownloadData.mockResolvedValue({
           url: "https://example.com/download",
         } as any);
 
@@ -329,7 +329,7 @@ describe("SendReceiveCommand", () => {
         const response = await command.run(testUrl, { output: "./test.pdf" });
 
         expect(response.success).toBe(true);
-        expect(sendApiService.getSendFileDownloadDataV2).toHaveBeenCalledWith(
+        expect(sendApiService.getSendFileDownloadData).toHaveBeenCalledWith(
           expect.any(Object),
           mockToken,
           "https://api.bitwarden.com",
@@ -351,10 +351,10 @@ describe("SendReceiveCommand", () => {
           },
         };
 
-        sendApiService.postSendAccessV2.mockResolvedValue({} as any);
+        sendApiService.postSendAccess.mockResolvedValue({} as any);
         jest.spyOn(SendAccess.prototype, "decrypt").mockResolvedValueOnce(mockSendResponse as any);
         const fileDownloadUrl = "https://example.com/download";
-        sendApiService.getSendFileDownloadDataV2.mockResolvedValue({
+        sendApiService.getSendFileDownloadData.mockResolvedValue({
           url: fileDownloadUrl,
         } as any);
 
@@ -399,7 +399,7 @@ describe("SendReceiveCommand", () => {
 
         const secretText = "This is a secret message";
 
-        sendApiService.postSendAccessV2.mockResolvedValue({} as any);
+        sendApiService.postSendAccess.mockResolvedValue({} as any);
 
         // Mock the entire accessSendWithToken to avoid encryption issues
         jest.spyOn(command as any, "accessSendWithToken").mockImplementation(async () => {
@@ -427,7 +427,7 @@ describe("SendReceiveCommand", () => {
           text: { text: "secret message" },
         };
 
-        sendApiService.postSendAccessV2.mockResolvedValue({} as any);
+        sendApiService.postSendAccess.mockResolvedValue({} as any);
 
         // Mock the entire accessSendWithToken to avoid encryption issues
         jest.spyOn(command as any, "accessSendWithToken").mockImplementation(async () => {

--- a/apps/cli/src/tools/send/commands/receive.command.ts
+++ b/apps/cli/src/tools/send/commands/receive.command.ts
@@ -341,7 +341,7 @@ export class SendReceiveCommand extends DownloadCommand {
     options: OptionValues,
   ): Promise<Response> {
     try {
-      const sendResponse = await this.sendApiService.postSendAccessV2(accessToken, apiUrl);
+      const sendResponse = await this.sendApiService.postSendAccess(accessToken, apiUrl);
 
       const sendAccess = new SendAccess(sendResponse);
       this.decKey = await this.keyService.makeSendKey(keyArray);
@@ -357,7 +357,7 @@ export class SendReceiveCommand extends DownloadCommand {
           return Response.success();
 
         case SendType.File: {
-          const downloadData = await this.sendApiService.getSendFileDownloadDataV2(
+          const downloadData = await this.sendApiService.getSendFileDownloadData(
             decryptedView,
             accessToken,
             apiUrl,

--- a/apps/web/src/app/tools/send/send-access/access.component.ts
+++ b/apps/web/src/app/tools/send/send-access/access.component.ts
@@ -7,8 +7,6 @@ import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { ActivatedRoute } from "@angular/router";
 
 import { SendAccessToken } from "@bitwarden/common/auth/send-access";
-import { SendAccessRequest } from "@bitwarden/common/tools/send/models/request/send-access.request";
-import { SendAccessResponse } from "@bitwarden/common/tools/send/models/response/send-access.response";
 
 import { SharedModule } from "../../../shared";
 
@@ -33,8 +31,6 @@ export class AccessComponent implements OnInit {
   key: string;
 
   sendAccessToken: SendAccessToken | null = null;
-  sendAccessResponse: SendAccessResponse | null = null;
-  sendAccessRequest: SendAccessRequest = new SendAccessRequest();
 
   constructor(
     private route: ActivatedRoute,
@@ -49,9 +45,7 @@ export class AccessComponent implements OnInit {
       // when pasting sequential Send URLs into the browser,
       // Angular reuses the SendAuthComponent instance
       // Reset state so child components are recreated with fresh data
-      this.sendAccessResponse = null;
       this.sendAccessToken = null;
-      this.sendAccessRequest = new SendAccessRequest();
 
       // Temporarily set viewState to null to destroy the current child component,
       // then set it back to Auth on the next tick to recreate it with the new id/key.
@@ -64,13 +58,7 @@ export class AccessComponent implements OnInit {
     this.viewState.set(SendViewState.Auth);
   }
 
-  onAccessGranted(event: {
-    response?: SendAccessResponse;
-    request?: SendAccessRequest;
-    accessToken?: SendAccessToken;
-  }) {
-    this.sendAccessResponse = event.response;
-    this.sendAccessRequest = event.request;
+  onAccessGranted(event: { accessToken: SendAccessToken }) {
     this.sendAccessToken = event.accessToken;
     this.viewState.set(SendViewState.View);
   }

--- a/apps/web/src/app/tools/send/send-access/send-access-file.component.ts
+++ b/apps/web/src/app/tools/send/send-access/send-access-file.component.ts
@@ -42,7 +42,7 @@ export class SendAccessFileComponent {
       return;
     }
 
-    const downloadData = await this.sendApiService.getSendFileDownloadDataV2(
+    const downloadData = await this.sendApiService.getSendFileDownloadData(
       this.send(),
       accessToken,
     );

--- a/apps/web/src/app/tools/send/send-access/send-auth.component.ts
+++ b/apps/web/src/app/tools/send/send-access/send-auth.component.ts
@@ -19,8 +19,6 @@ import {
 import { CryptoFunctionService } from "@bitwarden/common/key-management/crypto/abstractions/crypto-function.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
-import { SendAccessRequest } from "@bitwarden/common/tools/send/models/request/send-access.request";
-import { SendAccessResponse } from "@bitwarden/common/tools/send/models/response/send-access.response";
 import { SEND_KDF_ITERATIONS } from "@bitwarden/common/tools/send/send-kdf";
 import { AuthType } from "@bitwarden/common/tools/send/types/auth-type";
 import { AnonLayoutWrapperDataService, ToastService } from "@bitwarden/components";
@@ -41,9 +39,7 @@ export class SendAuthComponent implements OnInit {
   protected readonly key = input.required<string>();
 
   protected accessGranted = output<{
-    response?: SendAccessResponse;
-    request?: SendAccessRequest;
-    accessToken?: SendAccessToken;
+    accessToken: SendAccessToken;
   }>();
 
   authType = AuthType;

--- a/apps/web/src/app/tools/send/send-access/send-view.component.ts
+++ b/apps/web/src/app/tools/send/send-access/send-view.component.ts
@@ -85,7 +85,7 @@ export class SendViewComponent implements OnInit {
         this.authRequired.emit();
         return;
       }
-      const response = await this.sendApiService.postSendAccessV2(accessToken);
+      const response = await this.sendApiService.postSendAccess(accessToken);
       const keyArray = Utils.fromUrlB64ToArray(this.key());
       const sendAccess = new SendAccess(response);
       this.decKey = await this.keyService.makeSendKey(keyArray);

--- a/libs/common/src/tools/send/models/request/send-access.request.ts
+++ b/libs/common/src/tools/send/models/request/send-access.request.ts
@@ -1,5 +1,0 @@
-// FIXME: Update this file to be type safe and remove this and next line
-// @ts-strict-ignore
-export class SendAccessRequest {
-  password: string;
-}

--- a/libs/common/src/tools/send/services/send-api-service.selector.spec.ts
+++ b/libs/common/src/tools/send/services/send-api-service.selector.spec.ts
@@ -6,7 +6,6 @@ import { FeatureFlag } from "../../../enums/feature-flag.enum";
 import { ConfigService } from "../../../platform/abstractions/config/config.service";
 import { EncArrayBuffer } from "../../../platform/models/domain/enc-array-buffer";
 import { Send } from "../models/domain/send";
-import { SendAccessRequest } from "../models/request/send-access.request";
 import { SendAccessView } from "../models/view/send-access.view";
 import { AuthType } from "../types/auth-type";
 import { SendType } from "../types/send-type";
@@ -187,79 +186,48 @@ describe("SendApiServiceSelector", () => {
   });
 
   describe("postSendAccess", () => {
-    const request = new SendAccessRequest();
+    const accessToken: SendAccessToken = { token: "tok" } as SendAccessToken;
 
     it("routes to legacy when apiUrl is supplied, even with the flag on", async () => {
       const selector = buildSelector(true);
 
-      await selector.postSendAccess("id", request, "https://other.example");
+      await selector.postSendAccess(accessToken, "https://other.example");
 
-      expect(legacy.postSendAccess).toHaveBeenCalledWith("id", request, "https://other.example");
+      expect(legacy.postSendAccess).toHaveBeenCalledWith(accessToken, "https://other.example");
       expect(sdk.postSendAccess).not.toHaveBeenCalled();
     });
 
     it("routes to SDK without apiUrl when the flag is on", async () => {
       const selector = buildSelector(true);
 
-      await selector.postSendAccess("id", request);
+      await selector.postSendAccess(accessToken);
 
-      expect(sdk.postSendAccess).toHaveBeenCalledWith("id", request);
+      expect(sdk.postSendAccess).toHaveBeenCalledWith(accessToken);
       expect(legacy.postSendAccess).not.toHaveBeenCalled();
     });
 
     it("routes to legacy without apiUrl when the flag is off", async () => {
       const selector = buildSelector(false);
 
-      await selector.postSendAccess("id", request);
+      await selector.postSendAccess(accessToken);
 
-      expect(legacy.postSendAccess).toHaveBeenCalledWith("id", request);
+      expect(legacy.postSendAccess).toHaveBeenCalledWith(accessToken);
       expect(sdk.postSendAccess).not.toHaveBeenCalled();
-    });
-  });
-
-  describe("postSendAccessV2", () => {
-    const accessToken: SendAccessToken = { token: "tok" } as SendAccessToken;
-
-    it("routes to legacy when apiUrl is supplied, even with the flag on", async () => {
-      const selector = buildSelector(true);
-
-      await selector.postSendAccessV2(accessToken, "https://other.example");
-
-      expect(legacy.postSendAccessV2).toHaveBeenCalledWith(accessToken, "https://other.example");
-      expect(sdk.postSendAccessV2).not.toHaveBeenCalled();
-    });
-
-    it("routes to SDK without apiUrl when the flag is on", async () => {
-      const selector = buildSelector(true);
-
-      await selector.postSendAccessV2(accessToken);
-
-      expect(sdk.postSendAccessV2).toHaveBeenCalledWith(accessToken);
-      expect(legacy.postSendAccessV2).not.toHaveBeenCalled();
-    });
-
-    it("routes to legacy without apiUrl when the flag is off", async () => {
-      const selector = buildSelector(false);
-
-      await selector.postSendAccessV2(accessToken);
-
-      expect(legacy.postSendAccessV2).toHaveBeenCalledWith(accessToken);
-      expect(sdk.postSendAccessV2).not.toHaveBeenCalled();
     });
   });
 
   describe("getSendFileDownloadData", () => {
     const accessView = mock<SendAccessView>();
-    const request = new SendAccessRequest();
+    const accessToken: SendAccessToken = { token: "tok" } as SendAccessToken;
 
     it("routes to legacy when apiUrl is supplied, even with the flag on", async () => {
       const selector = buildSelector(true);
 
-      await selector.getSendFileDownloadData(accessView, request, "https://other.example");
+      await selector.getSendFileDownloadData(accessView, accessToken, "https://other.example");
 
       expect(legacy.getSendFileDownloadData).toHaveBeenCalledWith(
         accessView,
-        request,
+        accessToken,
         "https://other.example",
       );
       expect(sdk.getSendFileDownloadData).not.toHaveBeenCalled();
@@ -268,55 +236,19 @@ describe("SendApiServiceSelector", () => {
     it("routes to SDK without apiUrl when the flag is on", async () => {
       const selector = buildSelector(true);
 
-      await selector.getSendFileDownloadData(accessView, request);
+      await selector.getSendFileDownloadData(accessView, accessToken);
 
-      expect(sdk.getSendFileDownloadData).toHaveBeenCalledWith(accessView, request);
+      expect(sdk.getSendFileDownloadData).toHaveBeenCalledWith(accessView, accessToken);
       expect(legacy.getSendFileDownloadData).not.toHaveBeenCalled();
     });
 
     it("routes to legacy without apiUrl when the flag is off", async () => {
       const selector = buildSelector(false);
 
-      await selector.getSendFileDownloadData(accessView, request);
+      await selector.getSendFileDownloadData(accessView, accessToken);
 
-      expect(legacy.getSendFileDownloadData).toHaveBeenCalledWith(accessView, request);
+      expect(legacy.getSendFileDownloadData).toHaveBeenCalledWith(accessView, accessToken);
       expect(sdk.getSendFileDownloadData).not.toHaveBeenCalled();
-    });
-  });
-
-  describe("getSendFileDownloadDataV2", () => {
-    const accessView = mock<SendAccessView>();
-    const accessToken: SendAccessToken = { token: "tok" } as SendAccessToken;
-
-    it("routes to legacy when apiUrl is supplied, even with the flag on", async () => {
-      const selector = buildSelector(true);
-
-      await selector.getSendFileDownloadDataV2(accessView, accessToken, "https://other.example");
-
-      expect(legacy.getSendFileDownloadDataV2).toHaveBeenCalledWith(
-        accessView,
-        accessToken,
-        "https://other.example",
-      );
-      expect(sdk.getSendFileDownloadDataV2).not.toHaveBeenCalled();
-    });
-
-    it("routes to SDK without apiUrl when the flag is on", async () => {
-      const selector = buildSelector(true);
-
-      await selector.getSendFileDownloadDataV2(accessView, accessToken);
-
-      expect(sdk.getSendFileDownloadDataV2).toHaveBeenCalledWith(accessView, accessToken);
-      expect(legacy.getSendFileDownloadDataV2).not.toHaveBeenCalled();
-    });
-
-    it("routes to legacy without apiUrl when the flag is off", async () => {
-      const selector = buildSelector(false);
-
-      await selector.getSendFileDownloadDataV2(accessView, accessToken);
-
-      expect(legacy.getSendFileDownloadDataV2).toHaveBeenCalledWith(accessView, accessToken);
-      expect(sdk.getSendFileDownloadDataV2).not.toHaveBeenCalled();
     });
   });
 

--- a/libs/common/src/tools/send/services/send-api-service.selector.ts
+++ b/libs/common/src/tools/send/services/send-api-service.selector.ts
@@ -6,7 +6,6 @@ import { ListResponse } from "../../../models/response/list.response";
 import { ConfigService } from "../../../platform/abstractions/config/config.service";
 import { EncArrayBuffer } from "../../../platform/models/domain/enc-array-buffer";
 import { Send } from "../models/domain/send";
-import { SendAccessRequest } from "../models/request/send-access.request";
 import { SendAccessResponse } from "../models/response/send-access.response";
 import { SendFileDownloadDataResponse } from "../models/response/send-file-download-data.response";
 import { SendResponse } from "../models/response/send.response";
@@ -95,25 +94,11 @@ export class SendApiServiceSelector implements SendApiServiceAbstraction {
    * receive, e.g. the CLI opening a self-hosted Send link while signed in to a
    * different server) because the SDK client targets only its configured environment.
    */
-  async postSendAccess(
-    id: string,
-    request: SendAccessRequest,
-    apiUrl?: string,
-  ): Promise<SendAccessResponse> {
+  async postSendAccess(accessToken: SendAccessToken, apiUrl?: string): Promise<SendAccessResponse> {
     if (apiUrl != null) {
-      return this.sendApiService.postSendAccess(id, request, apiUrl);
+      return this.sendApiService.postSendAccess(accessToken, apiUrl);
     }
-    return (await this.getService()).postSendAccess(id, request);
-  }
-
-  async postSendAccessV2(
-    accessToken: SendAccessToken,
-    apiUrl?: string,
-  ): Promise<SendAccessResponse> {
-    if (apiUrl != null) {
-      return this.sendApiService.postSendAccessV2(accessToken, apiUrl);
-    }
-    return (await this.getService()).postSendAccessV2(accessToken);
+    return (await this.getService()).postSendAccess(accessToken);
   }
 
   /**
@@ -144,23 +129,12 @@ export class SendApiServiceSelector implements SendApiServiceAbstraction {
   /** See {@link postSendAccess} — cross-instance callers (those passing `apiUrl`) route to legacy. */
   async getSendFileDownloadData(
     send: SendAccessView,
-    request: SendAccessRequest,
-    apiUrl?: string,
-  ): Promise<SendFileDownloadDataResponse> {
-    if (apiUrl != null) {
-      return this.sendApiService.getSendFileDownloadData(send, request, apiUrl);
-    }
-    return (await this.getService()).getSendFileDownloadData(send, request);
-  }
-
-  async getSendFileDownloadDataV2(
-    send: SendAccessView,
     accessToken: SendAccessToken,
     apiUrl?: string,
   ): Promise<SendFileDownloadDataResponse> {
     if (apiUrl != null) {
-      return this.sendApiService.getSendFileDownloadDataV2(send, accessToken, apiUrl);
+      return this.sendApiService.getSendFileDownloadData(send, accessToken, apiUrl);
     }
-    return (await this.getService()).getSendFileDownloadDataV2(send, accessToken);
+    return (await this.getService()).getSendFileDownloadData(send, accessToken);
   }
 }

--- a/libs/common/src/tools/send/services/send-api.service.abstraction.ts
+++ b/libs/common/src/tools/send/services/send-api.service.abstraction.ts
@@ -2,7 +2,6 @@ import { SendAccessToken } from "../../../auth/send-access";
 import { ListResponse } from "../../../models/response/list.response";
 import { EncArrayBuffer } from "../../../platform/models/domain/enc-array-buffer";
 import { Send } from "../models/domain/send";
-import { SendAccessRequest } from "../models/request/send-access.request";
 import { SendAccessResponse } from "../models/response/send-access.response";
 import { SendFileDownloadDataResponse } from "../models/response/send-file-download-data.response";
 import { SendResponse } from "../models/response/send.response";
@@ -11,11 +10,6 @@ import { SendAccessView } from "../models/view/send-access.view";
 export abstract class SendApiService {
   abstract getSend(id: string): Promise<SendResponse>;
   abstract postSendAccess(
-    id: string,
-    request: SendAccessRequest,
-    apiUrl?: string,
-  ): Promise<SendAccessResponse>;
-  abstract postSendAccessV2(
     accessToken: SendAccessToken,
     apiUrl?: string,
   ): Promise<SendAccessResponse>;
@@ -23,11 +17,6 @@ export abstract class SendApiService {
   abstract putSendRemovePassword(id: string): Promise<SendResponse>;
   abstract deleteSend(id: string): Promise<any>;
   abstract getSendFileDownloadData(
-    send: SendAccessView,
-    request: SendAccessRequest,
-    apiUrl?: string,
-  ): Promise<SendFileDownloadDataResponse>;
-  abstract getSendFileDownloadDataV2(
     send: SendAccessView,
     accessToken: SendAccessToken,
     apiUrl?: string,

--- a/libs/common/src/tools/send/services/send-api.service.ts
+++ b/libs/common/src/tools/send/services/send-api.service.ts
@@ -9,7 +9,6 @@ import {
 import { EncArrayBuffer } from "../../../platform/models/domain/enc-array-buffer";
 import { SendData } from "../models/data/send.data";
 import { Send } from "../models/domain/send";
-import { SendAccessRequest } from "../models/request/send-access.request";
 import { SendRequest } from "../models/request/send.request";
 import { SendAccessResponse } from "../models/response/send-access.response";
 import { SendFileDownloadDataResponse } from "../models/response/send-file-download-data.response";
@@ -33,30 +32,7 @@ export class SendApiService implements SendApiServiceAbstraction {
     return new SendResponse(r);
   }
 
-  async postSendAccess(
-    id: string,
-    request: SendAccessRequest,
-    apiUrl?: string,
-  ): Promise<SendAccessResponse> {
-    const addSendIdHeader = (headers: Headers) => {
-      headers.set("Send-Id", id);
-    };
-    const r = await this.apiService.send(
-      "POST",
-      "/sends/access/" + id,
-      request,
-      false,
-      true,
-      apiUrl,
-      addSendIdHeader,
-    );
-    return new SendAccessResponse(r);
-  }
-
-  async postSendAccessV2(
-    accessToken: SendAccessToken,
-    apiUrl?: string,
-  ): Promise<SendAccessResponse> {
+  async postSendAccess(accessToken: SendAccessToken, apiUrl?: string): Promise<SendAccessResponse> {
     const setAuthTokenHeader = (headers: Headers) => {
       headers.set("Authorization", "Bearer " + accessToken.token);
     };
@@ -73,26 +49,6 @@ export class SendApiService implements SendApiServiceAbstraction {
   }
 
   async getSendFileDownloadData(
-    send: SendAccessView,
-    request: SendAccessRequest,
-    apiUrl?: string,
-  ): Promise<SendFileDownloadDataResponse> {
-    const addSendIdHeader = (headers: Headers) => {
-      headers.set("Send-Id", send.id);
-    };
-    const r = await this.apiService.send(
-      "POST",
-      "/sends/" + send.id + "/access/file/" + send.file.id,
-      request,
-      false,
-      true,
-      apiUrl,
-      addSendIdHeader,
-    );
-    return new SendFileDownloadDataResponse(r);
-  }
-
-  async getSendFileDownloadDataV2(
     send: SendAccessView,
     accessToken: SendAccessToken,
     apiUrl?: string,

--- a/libs/common/src/tools/send/services/send-sdk-api.service.ts
+++ b/libs/common/src/tools/send/services/send-sdk-api.service.ts
@@ -20,7 +20,6 @@ import { EncArrayBuffer } from "../../../platform/models/domain/enc-array-buffer
 import { UserId } from "../../../types/guid";
 import { SendData } from "../models/data/send.data";
 import { Send } from "../models/domain/send";
-import { SendAccessRequest } from "../models/request/send-access.request";
 import { SendAccessResponse } from "../models/response/send-access.response";
 import { SendFileDownloadDataResponse } from "../models/response/send-file-download-data.response";
 import { SendResponse } from "../models/response/send.response";
@@ -161,13 +160,7 @@ export class SendSdkApiService implements SendApiServiceAbstraction {
 
   // `apiUrl` is intentionally omitted; `SendApiServiceSelector` routes per-call `apiUrl`
   // to the legacy service.
-  async postSendAccess(id: string, request: SendAccessRequest): Promise<SendAccessResponse> {
-    const sdk: PasswordManagerClient = await firstValueFrom(this.sdkService.client$);
-    const view = await sdk.sends().access_send_v1(id, request.password ?? undefined);
-    return new SendAccessResponse(view);
-  }
-
-  async postSendAccessV2(accessToken: SendAccessToken): Promise<SendAccessResponse> {
+  async postSendAccess(accessToken: SendAccessToken): Promise<SendAccessResponse> {
     const sdk: PasswordManagerClient = await firstValueFrom(this.sdkService.client$);
     const view = await sdk.sends().access_send(accessToken.token);
     return new SendAccessResponse(view);
@@ -215,19 +208,6 @@ export class SendSdkApiService implements SendApiServiceAbstraction {
   // `apiUrl` is intentionally omitted; `SendApiServiceSelector` routes per-call `apiUrl`
   // to the legacy service.
   async getSendFileDownloadData(
-    send: SendAccessView,
-    request: SendAccessRequest,
-  ): Promise<SendFileDownloadDataResponse> {
-    const sdk: PasswordManagerClient = await firstValueFrom(this.sdkService.client$);
-    const data = await sdk
-      .sends()
-      .get_file_download_data_v1(send.id, send.file.id, request.password ?? undefined);
-    return new SendFileDownloadDataResponse(data);
-  }
-
-  // `apiUrl` is intentionally omitted; `SendApiServiceSelector` routes per-call `apiUrl`
-  // to the legacy service.
-  async getSendFileDownloadDataV2(
     send: SendAccessView,
     accessToken: SendAccessToken,
   ): Promise<SendFileDownloadDataResponse> {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-35791

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR removes the two endpoints that used to be used for Send access, removes the V2 suffix we were using on a couple functions to distinguish the new flow from the old, and removes some leftover fields in the Send auth component from the old access flow. There are no changes to functionality, this is pure cleanup.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
No UI changes 
