### PR TITLE
VaultPopupListTableComponent + Storybook

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -2593,6 +2593,15 @@
       }
     }
   },
+  "nSharedFolders": {
+    "message": "$COUNT$ shared folders",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      }
+    }
+  },
   "favorites": {
     "message": "Favorites"
   },

--- a/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.html
+++ b/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.html
@@ -13,6 +13,7 @@
       [placeholder]="'search' | i18n"
       [(ngModel)]="searchText"
       (ngModelChange)="onSearchTextChanged()"
+      appAutofocus
     ></bit-search>
   </bit-table-toolbar>
 

--- a/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.html
+++ b/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.html
@@ -114,8 +114,6 @@
           [label]="'refresh' | i18n"
         ></button>
       }
-      <!-- Stop propagation so opening the info popover doesn't also toggle the collapsible group header. -->
-      <app-simplified-autofill-info (click)="$event.stopPropagation()" />
     </div>
     <bit-row-group [match]="isLogin">{{ "typeLogin" | i18n }}</bit-row-group>
     <bit-row-group [match]="isCard">{{ "typeCard" | i18n }}</bit-row-group>

--- a/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.html
+++ b/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.html
@@ -88,7 +88,7 @@
             bitIconButton="bwi-external-link"
             size="small"
             (click)="launchCipher(row.cipher)"
-            [label]="'launchWebsiteName' | i18n: row.cipher.name"
+            [label]="'launchWebsiteForName' | i18n: row.cipher.name"
           ></button>
         }
         <app-item-copy-actions [cipher]="row.cipher"></app-item-copy-actions>

--- a/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.html
+++ b/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.html
@@ -114,7 +114,6 @@
         ></button>
       }
     </div>
-    <bit-row-group [match]="isLogin">{{ "typeLogin" | i18n }}</bit-row-group>
     <bit-row-group [match]="isCard">{{ "typeCard" | i18n }}</bit-row-group>
     <bit-row-group [match]="isIdentity">{{ "typeIdentity" | i18n }}</bit-row-group>
   </bit-row-group>

--- a/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.html
+++ b/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.html
@@ -88,7 +88,7 @@
             bitIconButton="bwi-external-link"
             size="small"
             (click)="launchCipher(row.cipher)"
-            [label]="'launchWebsiteForName' | i18n: row.cipher.name"
+            [label]="'launchWebsite' | i18n"
           ></button>
         }
         <app-item-copy-actions [cipher]="row.cipher"></app-item-copy-actions>

--- a/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.html
+++ b/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.html
@@ -20,6 +20,7 @@
   <bit-column>
     <bit-header-cell>{{ "name" | i18n }}</bit-header-cell>
     <bit-cell *bitCellDef="table.columns.name; let row">
+      <!-- CL-1297 will refactor this to a bit-item, currently the focus state does not cover the full row -->
       <button
         type="button"
         (click)="onCipherSelect(row)"
@@ -28,7 +29,7 @@
           row.actions.titleKey
             | i18n: row.cipher.name : CipherViewLikeUtils.getLogin(row.cipher)?.username
         "
-        class="tw-flex tw-items-center tw-gap-2 tw-w-full tw-min-w-0 tw-p-0 tw-bg-transparent tw-border-0 tw-text-left tw-text-main tw-cursor-pointer focus-visible:tw-outline-none after:tw-content-[''] after:tw-absolute after:tw-inset-0 after:tw-rounded-lg focus-visible:after:tw-ring-2 focus-visible:after:tw-ring-inset focus-visible:after:tw-ring-primary-600"
+        class="tw-flex tw-items-center tw-gap-2 tw-w-full tw-min-w-0 tw-p-0 tw-bg-transparent tw-border-0 tw-text-left tw-text-main tw-cursor-pointer tw-rounded-lg focus-visible:tw-ring-2 focus-visible:tw-ring-inset focus-visible:tw-ring-primary-600"
       >
         <div class="tw-justify-start tw-w-7 tw-flex tw-shrink-0">
           <app-vault-icon [cipher]="row.cipher"></app-vault-icon>

--- a/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.html
+++ b/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.html
@@ -1,0 +1,142 @@
+<bit-table-v2
+  [tableDef]="table"
+  presentation="list"
+  height="fill"
+  [virtualRowHeight]="itemHeight()"
+  [loading]="loading()"
+  [trackBy]="trackRow"
+>
+  <bit-table-toolbar>
+    <bit-search
+      class="tw-flex-1"
+      autocomplete="off"
+      [placeholder]="'search' | i18n"
+      [(ngModel)]="searchText"
+      (ngModelChange)="onSearchTextChanged()"
+    ></bit-search>
+  </bit-table-toolbar>
+
+  <bit-column>
+    <bit-header-cell>{{ "name" | i18n }}</bit-header-cell>
+    <bit-cell *bitCellDef="table.columns.name; let row">
+      <button
+        type="button"
+        (click)="onCipherSelect(row)"
+        (dblclick)="launchCipher(row.cipher)"
+        [appA11yTitle]="
+          row.actions.titleKey
+            | i18n: row.cipher.name : CipherViewLikeUtils.getLogin(row.cipher)?.username
+        "
+        class="tw-flex tw-items-center tw-gap-2 tw-w-full tw-min-w-0 tw-p-0 tw-bg-transparent tw-border-0 tw-text-left tw-text-main tw-cursor-pointer focus-visible:tw-outline-none after:tw-content-[''] after:tw-absolute after:tw-inset-0 after:tw-rounded-lg focus-visible:after:tw-ring-2 focus-visible:after:tw-ring-inset focus-visible:after:tw-ring-primary-600"
+      >
+        <div class="tw-justify-start tw-w-7 tw-flex tw-shrink-0">
+          <app-vault-icon [cipher]="row.cipher"></app-vault-icon>
+        </div>
+        <div class="tw-flex tw-flex-col tw-flex-1 tw-min-w-0">
+          <div class="tw-flex tw-items-center tw-gap-1.5 tw-min-w-0">
+            <span data-testid="item-name" bitTypography="body2" class="tw-truncate tw-min-w-0">{{
+              row.cipher.name
+            }}</span>
+            <div class="tw-flex tw-items-center tw-gap-1.5 tw-shrink-0">
+              @if (row.cipher.organizationId) {
+                <i
+                  appOrgIcon
+                  [tierType]="row.cipher.organization!.productTierType"
+                  [size]="'small'"
+                  [appA11yTitle]="orgIconTooltip(row.cipher)"
+                ></i>
+              }
+              @if (CipherViewLikeUtils.hasAttachments(row.cipher)) {
+                <bit-icon
+                  name="bwi-paperclip"
+                  class="bwi-sm"
+                  [appA11yTitle]="'attachments' | i18n"
+                ></bit-icon>
+              }
+            </div>
+          </div>
+          <span class="tw-text-muted tw-text-xs tw-truncate">
+            {{ CipherViewLikeUtils.subtitle(row.cipher, i18nService) }}
+          </span>
+        </div>
+      </button>
+      <div slot="end" class="tw-flex tw-items-center tw-shrink-0 tw-relative tw-z-10">
+        @if (row.actions.showFillOnHover) {
+          <button
+            type="button"
+            (click)="doAutofill(row.cipher)"
+            class="tw-text-primary-600 tw-font-semibold tw-px-2 tw-bg-transparent tw-border-0 tw-opacity-0 group-hover/row:tw-opacity-100 group-focus-within/row:tw-opacity-100"
+            bitTypography="body2"
+          >
+            {{ "fill" | i18n }}
+          </button>
+        }
+        @if (row.actions.showAutofillBadge) {
+          <button
+            type="button"
+            bit-chip-action
+            variant="primary"
+            (click)="doAutofill(row.cipher)"
+            [title]="autofillShortcutTooltip() ?? ('autofillTitle' | i18n: row.cipher.name)"
+            [attr.aria-label]="'autofillTitle' | i18n: row.cipher.name"
+            [label]="'fill' | i18n"
+          ></button>
+        }
+        @if (row.actions.showLaunch && CipherViewLikeUtils.canLaunch(row.cipher)) {
+          <button
+            type="button"
+            bitIconButton="bwi-external-link"
+            size="small"
+            (click)="launchCipher(row.cipher)"
+            [label]="'launchWebsiteName' | i18n: row.cipher.name"
+          ></button>
+        }
+        <app-item-copy-actions [cipher]="row.cipher"></app-item-copy-actions>
+        <app-item-more-options
+          [cipher]="row.cipher"
+          [showAutofill]="row.actions.showAutofillInMenu"
+          [showViewOption]="row.actions.showViewInMenu"
+        ></app-item-more-options>
+      </div>
+    </bit-cell>
+  </bit-column>
+
+  <bit-row-group collapsible [match]="isAutofill">
+    <div class="tw-flex tw-gap-2 tw-items-center">
+      {{ autofillSectionKey() | i18n }}
+      @if (showRefresh) {
+        <!-- Stop propagation so refreshing doesn't also toggle the collapsible group header. -->
+        <button
+          bitIconButton="bwi-refresh"
+          type="button"
+          size="small"
+          (click)="$event.stopPropagation(); refreshCurrentTab()"
+          [label]="'refresh' | i18n"
+        ></button>
+      }
+      <!-- Stop propagation so opening the info popover doesn't also toggle the collapsible group header. -->
+      <app-simplified-autofill-info (click)="$event.stopPropagation()" />
+    </div>
+    <bit-row-group [match]="isLogin">{{ "typeLogin" | i18n }}</bit-row-group>
+    <bit-row-group [match]="isCard">{{ "typeCard" | i18n }}</bit-row-group>
+    <bit-row-group [match]="isIdentity">{{ "typeIdentity" | i18n }}</bit-row-group>
+  </bit-row-group>
+
+  <bit-row-group
+    collapsible
+    [match]="isFavorites"
+    [collapsed]="!favoritesOpenState()"
+    (collapsedChange)="setSectionCollapsed('favorites', $event)"
+  >
+    {{ "favorites" | i18n }}
+  </bit-row-group>
+
+  <bit-row-group
+    collapsible
+    [match]="isAllItems"
+    [collapsed]="!allItemsOpenState()"
+    (collapsedChange)="setSectionCollapsed('allItems', $event)"
+  >
+    {{ allItemsSectionKey() | i18n }}
+  </bit-row-group>
+</bit-table-v2>

--- a/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.html
+++ b/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.html
@@ -101,16 +101,15 @@
     </bit-cell>
   </bit-column>
 
-  <bit-row-group collapsible [match]="isAutofill">
+  <bit-row-group [match]="isAutofill">
     <div class="tw-flex tw-gap-2 tw-items-center">
       {{ autofillSectionKey() | i18n }}
       @if (showRefresh) {
-        <!-- Stop propagation so refreshing doesn't also toggle the collapsible group header. -->
         <button
           bitIconButton="bwi-refresh"
           type="button"
           size="small"
-          (click)="$event.stopPropagation(); refreshCurrentTab()"
+          (click)="refreshCurrentTab()"
           [label]="'refresh' | i18n"
         ></button>
       }

--- a/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.spec.ts
+++ b/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.spec.ts
@@ -1,0 +1,314 @@
+import { ComponentFixture, TestBed, fakeAsync, tick } from "@angular/core/testing";
+import { NoopAnimationsModule } from "@angular/platform-browser/animations";
+import { RouterTestingModule } from "@angular/router/testing";
+import { mock } from "jest-mock-extended";
+import { BehaviorSubject, of } from "rxjs";
+
+import { CollectionService } from "@bitwarden/admin-console/common";
+import { WINDOW } from "@bitwarden/angular/services/injection-tokens";
+import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { DomainSettingsService } from "@bitwarden/common/autofill/services/domain-settings.service";
+import { BillingAccountProfileStateService } from "@bitwarden/common/billing/abstractions/account/billing-account-profile-state.service";
+import { EventCollectionService } from "@bitwarden/common/dirt/event-logs";
+import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
+import { EnvironmentService } from "@bitwarden/common/platform/abstractions/environment.service";
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
+import { CipherArchiveService } from "@bitwarden/common/vault/abstractions/cipher-archive.service";
+import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
+import { TotpService } from "@bitwarden/common/vault/abstractions/totp.service";
+import { VaultSettingsService } from "@bitwarden/common/vault/abstractions/vault-settings/vault-settings.service";
+import { CipherType } from "@bitwarden/common/vault/enums";
+import { CipherAuthorizationService } from "@bitwarden/common/vault/services/cipher-authorization.service";
+import { RestrictedItemTypesService } from "@bitwarden/common/vault/services/restricted-item-types.service";
+import { SearchTextDebounceInterval } from "@bitwarden/common/vault/services/search.service";
+import { CompactModeService, DialogService, ToastService } from "@bitwarden/components";
+import { StateProvider } from "@bitwarden/state";
+import { PasswordRepromptService } from "@bitwarden/vault";
+
+import { VaultPopupAutofillService } from "../../../services/vault-popup-autofill.service";
+import { VaultPopupCopyButtonsService } from "../../../services/vault-popup-copy-buttons.service";
+import { VaultPopupItemsService } from "../../../services/vault-popup-items.service";
+import { VaultPopupLoadingService } from "../../../services/vault-popup-loading.service";
+import { VaultPopupSectionService } from "../../../services/vault-popup-section.service";
+import { PopupCipherViewLike } from "../../../views/popup-cipher.view";
+
+import { VaultPopupListTableComponent } from "./vault-popup-list-table.component";
+
+const makeCipher = (overrides: Partial<PopupCipherViewLike> = {}): PopupCipherViewLike =>
+  ({
+    id: "cipher-1",
+    name: "Test Login",
+    type: CipherType.Login,
+    login: { username: "user@example.com", uris: [] },
+    favorite: false,
+    reprompt: 0,
+    organizationId: null,
+    collectionIds: [],
+    edit: true,
+    viewPassword: true,
+    collections: [],
+    ...overrides,
+  }) as any;
+
+// A section-tagged row. `actions` is irrelevant to the section/type predicates under test here
+// (they read only `_section`/`type`); the resolved actions are covered in the service spec.
+const makeRow = (
+  section: "autofill" | "favorites" | "allItems",
+  overrides: Partial<PopupCipherViewLike> = {},
+) => ({ cipher: makeCipher(overrides), _section: section, actions: {} }) as any;
+
+describe("VaultPopupListTableComponent", () => {
+  let fixture: ComponentFixture<VaultPopupListTableComponent>;
+  let component: VaultPopupListTableComponent;
+
+  const featureFlag$ = new BehaviorSubject<boolean>(false);
+  const currentTabIsOnBlocklist$ = new BehaviorSubject<boolean>(false);
+  const autoFillCiphers$ = new BehaviorSubject<PopupCipherViewLike[]>([]);
+  const favoriteCiphers$ = new BehaviorSubject<PopupCipherViewLike[]>([]);
+  const filteredCiphers$ = new BehaviorSubject<PopupCipherViewLike[]>([]);
+  const loading$ = new BehaviorSubject<boolean>(false);
+  const searchText$ = new BehaviorSubject<string>("");
+  const hasSearchText$ = new BehaviorSubject<boolean>(false);
+  const clickItemsToAutofillVaultView$ = new BehaviorSubject<boolean>(true);
+
+  const configService = {
+    getFeatureFlag$: jest.fn().mockImplementation((flag: FeatureFlag) => {
+      if (flag === FeatureFlag.PM31039ItemActionInExtension) {
+        return featureFlag$.asObservable();
+      }
+      return of(false);
+    }),
+  };
+
+  const vaultPopupAutofillService = {
+    currentTabIsOnBlocklist$: currentTabIsOnBlocklist$.asObservable(),
+    doAutofill: jest.fn(),
+  };
+
+  const vaultPopupItemsService = {
+    autoFillCiphers$: autoFillCiphers$.asObservable(),
+    favoriteCiphers$: favoriteCiphers$.asObservable(),
+    filteredCiphers$: filteredCiphers$.asObservable(),
+    loading$: loading$.asObservable(),
+    searchText$: searchText$.asObservable(),
+    hasSearchText$: hasSearchText$.asObservable(),
+    applyFilter: jest.fn(),
+  };
+
+  const vaultPopupLoadingService = {
+    loading$: loading$.asObservable(),
+  };
+
+  const vaultPopupSectionService = {
+    getOpenDisplayStateForSection: jest.fn().mockReturnValue(() => true),
+    updateSectionOpenStoredState: jest.fn(),
+  };
+
+  const compactModeEnabled$ = new BehaviorSubject<boolean>(false);
+  const compactModeService = {
+    enabled$: compactModeEnabled$.asObservable(),
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    featureFlag$.next(false);
+    currentTabIsOnBlocklist$.next(false);
+    autoFillCiphers$.next([]);
+    favoriteCiphers$.next([]);
+    filteredCiphers$.next([]);
+    loading$.next(false);
+    searchText$.next("");
+    hasSearchText$.next(false);
+    compactModeEnabled$.next(false);
+    clickItemsToAutofillVaultView$.next(true);
+
+    await TestBed.configureTestingModule({
+      imports: [VaultPopupListTableComponent, NoopAnimationsModule, RouterTestingModule],
+      providers: [
+        { provide: WINDOW, useValue: window },
+        { provide: ConfigService, useValue: configService },
+        { provide: VaultPopupAutofillService, useValue: vaultPopupAutofillService },
+        { provide: VaultPopupItemsService, useValue: vaultPopupItemsService },
+        { provide: VaultPopupLoadingService, useValue: vaultPopupLoadingService },
+        { provide: VaultPopupSectionService, useValue: vaultPopupSectionService },
+        { provide: CompactModeService, useValue: compactModeService },
+        { provide: I18nService, useValue: mock<I18nService>({ t: (k: string) => k }) },
+        { provide: CipherService, useValue: mock<CipherService>() },
+        { provide: AccountService, useValue: { activeAccount$: of({ id: "test-user-id" }) } },
+        { provide: PasswordRepromptService, useValue: mock<PasswordRepromptService>() },
+        { provide: DialogService, useValue: mock<DialogService>() },
+        // Providers for the child components rendered in each row (vault-icon, copy actions,
+        // more-options menu, simplified-autofill-info), mirroring the Storybook setup.
+        {
+          provide: EnvironmentService,
+          useValue: { environment$: of({ getIconsUrl: () => "https://icons.bitwarden.net" }) },
+        },
+        { provide: DomainSettingsService, useValue: { showFavicons$: of(true) } },
+        { provide: VaultPopupCopyButtonsService, useValue: { showQuickCopyActions$: of(false) } },
+        {
+          provide: StateProvider,
+          useValue: {
+            getUserState$: () => of({ hasSeen: true, hasDismissed: true }),
+            getUser: () => ({ update: async () => {} }),
+          },
+        },
+        { provide: RestrictedItemTypesService, useValue: { restricted$: of([]) } },
+        {
+          provide: VaultSettingsService,
+          useValue: {
+            clickItemsToAutofillVaultView$: clickItemsToAutofillVaultView$.asObservable(),
+          },
+        },
+        {
+          provide: PlatformUtilsService,
+          useValue: { getAutofillKeyboardShortcut: async () => "" },
+        },
+        { provide: ToastService, useValue: {} },
+        { provide: OrganizationService, useValue: { hasOrganizations: () => of(false) } },
+        {
+          provide: CipherAuthorizationService,
+          useValue: { canDeleteCipher$: () => of(false), canCloneCipher$: () => of(false) },
+        },
+        { provide: CollectionService, useValue: { decryptedCollections$: () => of([]) } },
+        { provide: CipherArchiveService, useValue: { userCanArchive$: () => of(false) } },
+        { provide: EventCollectionService, useValue: {} },
+        { provide: TotpService, useValue: {} },
+        {
+          provide: BillingAccountProfileStateService,
+          useValue: { hasPremiumFromAnySource$: () => of(true) },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(VaultPopupListTableComponent);
+    component = fixture.componentInstance;
+  });
+
+  describe("group predicates", () => {
+    it("isAutofill returns true only for autofill-tagged rows", () => {
+      const row = makeRow("autofill");
+      expect(component["isAutofill"](row)).toBe(true);
+      expect(component["isFavorites"](row)).toBe(false);
+      expect(component["isAllItems"](row)).toBe(false);
+    });
+
+    it("isFavorites returns true only for favorites-tagged rows", () => {
+      const row = makeRow("favorites");
+      expect(component["isAutofill"](row)).toBe(false);
+      expect(component["isFavorites"](row)).toBe(true);
+      expect(component["isAllItems"](row)).toBe(false);
+    });
+
+    it("isAllItems returns true only for allItems-tagged rows", () => {
+      const row = makeRow("allItems");
+      expect(component["isAutofill"](row)).toBe(false);
+      expect(component["isFavorites"](row)).toBe(false);
+      expect(component["isAllItems"](row)).toBe(true);
+    });
+  });
+
+  describe("type subgroup predicates", () => {
+    it("isLogin returns true for Login ciphers", () => {
+      const row = makeRow("autofill", { type: CipherType.Login });
+      expect(component["isLogin"](row)).toBe(true);
+      expect(component["isCard"](row)).toBe(false);
+      expect(component["isIdentity"](row)).toBe(false);
+    });
+
+    it("isCard returns true for Card ciphers", () => {
+      const row = makeRow("autofill", { type: CipherType.Card });
+      expect(component["isLogin"](row)).toBe(false);
+      expect(component["isCard"](row)).toBe(true);
+      expect(component["isIdentity"](row)).toBe(false);
+    });
+
+    it("isIdentity returns true for Identity ciphers", () => {
+      const row = makeRow("autofill", { type: CipherType.Identity });
+      expect(component["isLogin"](row)).toBe(false);
+      expect(component["isCard"](row)).toBe(false);
+      expect(component["isIdentity"](row)).toBe(true);
+    });
+  });
+
+  describe("search", () => {
+    it("syncs searchText from the search text already applied to the vault", () => {
+      searchText$.next("synced text");
+      fixture.detectChanges();
+
+      expect(component["searchText"]).toBe("synced text");
+    });
+
+    it("applies the search filter (debounced) when the search text changes", fakeAsync(() => {
+      component["searchText"] = "foo";
+      component.onSearchTextChanged();
+      tick(SearchTextDebounceInterval);
+
+      expect(vaultPopupItemsService.applyFilter).toHaveBeenCalledWith("foo");
+    }));
+  });
+
+  describe("loading state", () => {
+    it("reflects loading$ from vaultPopupLoadingService", () => {
+      loading$.next(true);
+      fixture.detectChanges();
+
+      expect(component["loading"]()).toBe(true);
+    });
+
+    it("reflects non-loading state", () => {
+      loading$.next(false);
+      fixture.detectChanges();
+
+      expect(component["loading"]()).toBe(false);
+    });
+  });
+
+  describe("itemHeight", () => {
+    it("returns 59 in normal mode", () => {
+      compactModeEnabled$.next(false);
+      fixture.detectChanges();
+      expect(component["itemHeight"]()).toBe(59);
+    });
+
+    it("returns 53 in compact mode", () => {
+      compactModeEnabled$.next(true);
+      fixture.detectChanges();
+      expect(component["itemHeight"]()).toBe(53);
+    });
+  });
+
+  describe("onCipherSelect", () => {
+    it("autofills rows whose resolved action is fill-on-click", () => {
+      const doAutofill = jest
+        .spyOn(component["listTableService"], "doAutofill")
+        .mockResolvedValue();
+      const viewCipher = jest
+        .spyOn(component["listTableService"], "viewCipher")
+        .mockResolvedValue();
+
+      const row = { cipher: makeCipher(), actions: { primaryAutofill: true } } as any;
+      void component.onCipherSelect(row);
+
+      expect(doAutofill).toHaveBeenCalledWith(row.cipher);
+      expect(viewCipher).not.toHaveBeenCalled();
+    });
+
+    it("navigates to view for rows whose resolved action is view-on-click", () => {
+      const doAutofill = jest
+        .spyOn(component["listTableService"], "doAutofill")
+        .mockResolvedValue();
+      const viewCipher = jest
+        .spyOn(component["listTableService"], "viewCipher")
+        .mockResolvedValue();
+
+      const row = { cipher: makeCipher(), actions: { primaryAutofill: false } } as any;
+      void component.onCipherSelect(row);
+
+      expect(viewCipher).toHaveBeenCalledWith(row.cipher);
+      expect(doAutofill).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.spec.ts
+++ b/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.spec.ts
@@ -26,10 +26,9 @@ import { RestrictedItemTypesService } from "@bitwarden/common/vault/services/res
 import { SearchTextDebounceInterval } from "@bitwarden/common/vault/services/search.service";
 import { CompactModeService, DialogService, ToastService } from "@bitwarden/components";
 import { StateProvider } from "@bitwarden/state";
-import { PasswordRepromptService } from "@bitwarden/vault";
+import { PasswordRepromptService, VaultCopyButtonsService } from "@bitwarden/vault";
 
 import { VaultPopupAutofillService } from "../../../services/vault-popup-autofill.service";
-import { VaultPopupCopyButtonsService } from "../../../services/vault-popup-copy-buttons.service";
 import { VaultPopupItemsService } from "../../../services/vault-popup-items.service";
 import { VaultPopupLoadingService } from "../../../services/vault-popup-loading.service";
 import { VaultPopupSectionService } from "../../../services/vault-popup-section.service";
@@ -147,7 +146,7 @@ describe("VaultPopupListTableComponent", () => {
           useValue: { environment$: of({ getIconsUrl: () => "https://icons.bitwarden.net" }) },
         },
         { provide: DomainSettingsService, useValue: { showFavicons$: of(true) } },
-        { provide: VaultPopupCopyButtonsService, useValue: { showQuickCopyActions$: of(false) } },
+        { provide: VaultCopyButtonsService, useValue: { showQuickCopyActions$: of(false) } },
         {
           provide: StateProvider,
           useValue: {

--- a/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.spec.ts
+++ b/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.spec.ts
@@ -141,7 +141,7 @@ describe("VaultPopupListTableComponent", () => {
         { provide: PasswordRepromptService, useValue: mock<PasswordRepromptService>() },
         { provide: DialogService, useValue: mock<DialogService>() },
         // Providers for the child components rendered in each row (vault-icon, copy actions,
-        // more-options menu, simplified-autofill-info), mirroring the Storybook setup.
+        // more-options menu), mirroring the Storybook setup.
         {
           provide: EnvironmentService,
           useValue: { environment$: of({ getIconsUrl: () => "https://icons.bitwarden.net" }) },

--- a/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.spec.ts
+++ b/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.spec.ts
@@ -211,23 +211,14 @@ describe("VaultPopupListTableComponent", () => {
   });
 
   describe("type subgroup predicates", () => {
-    it("isLogin returns true for Login ciphers", () => {
-      const row = makeRow("autofill", { type: CipherType.Login });
-      expect(component["isLogin"](row)).toBe(true);
-      expect(component["isCard"](row)).toBe(false);
-      expect(component["isIdentity"](row)).toBe(false);
-    });
-
     it("isCard returns true for Card ciphers", () => {
       const row = makeRow("autofill", { type: CipherType.Card });
-      expect(component["isLogin"](row)).toBe(false);
       expect(component["isCard"](row)).toBe(true);
       expect(component["isIdentity"](row)).toBe(false);
     });
 
     it("isIdentity returns true for Identity ciphers", () => {
       const row = makeRow("autofill", { type: CipherType.Identity });
-      expect(component["isLogin"](row)).toBe(false);
       expect(component["isCard"](row)).toBe(false);
       expect(component["isIdentity"](row)).toBe(true);
     });

--- a/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.ts
@@ -44,7 +44,6 @@ import { VaultPopupSectionService } from "../../../services/vault-popup-section.
 import { PopupCipherViewLike } from "../../../views/popup-cipher.view";
 import { ItemCopyActionsComponent } from "../item-copy-action/item-copy-actions.component";
 import { ItemMoreOptionsComponent } from "../item-more-options/item-more-options.component";
-import { SimplifiedAutofillInfoComponent } from "../simplified-autofill-info/simplified-autofill-info.component";
 
 @Component({
   selector: "app-vault-popup-list-table",
@@ -74,7 +73,6 @@ import { SimplifiedAutofillInfoComponent } from "../simplified-autofill-info/sim
     ItemCopyActionsComponent,
     ItemMoreOptionsComponent,
     OrgIconDirective,
-    SimplifiedAutofillInfoComponent,
   ],
 })
 export class VaultPopupListTableComponent {

--- a/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.ts
@@ -1,0 +1,223 @@
+// FIXME(https://bitwarden.atlassian.net/browse/CL-1062): `OnPush` components should not use mutable properties
+/* eslint-disable @bitwarden/components/enforce-readonly-angular-properties */
+import { CommonModule } from "@angular/common";
+import { ChangeDetectionStrategy, Component, computed, inject, signal } from "@angular/core";
+import { takeUntilDestroyed, toSignal } from "@angular/core/rxjs-interop";
+import { FormsModule } from "@angular/forms";
+import { filter, map, Subject } from "rxjs";
+
+import { JslibModule } from "@bitwarden/angular/jslib.module";
+import { WINDOW } from "@bitwarden/angular/services/injection-tokens";
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
+import { CipherType } from "@bitwarden/common/vault/enums";
+import {
+  CipherViewLike,
+  CipherViewLikeUtils,
+} from "@bitwarden/common/vault/utils/cipher-view-like-utils";
+import {
+  BitCellComponent,
+  BitCellDefDirective,
+  BitColumnComponent,
+  BitHeaderCellComponent,
+  BitRowGroupComponent,
+  BitTableToolbarComponent,
+  BitTableV2Component,
+  ChipActionComponent,
+  CompactModeService,
+  defineTable,
+  IconButtonModule,
+  IconComponent,
+  SearchModule,
+  TypographyModule,
+} from "@bitwarden/components";
+import { OrgIconDirective } from "@bitwarden/vault";
+
+import BrowserPopupUtils from "../../../../../platform/browser/browser-popup-utils";
+import { VaultPopupAutofillService } from "../../../services/vault-popup-autofill.service";
+import {
+  VaultPopupListTableService,
+  VaultTableRow,
+} from "../../../services/vault-popup-list-table.service";
+import { VaultPopupLoadingService } from "../../../services/vault-popup-loading.service";
+import { VaultPopupSectionService } from "../../../services/vault-popup-section.service";
+import { PopupCipherViewLike } from "../../../views/popup-cipher.view";
+import { ItemCopyActionsComponent } from "../item-copy-action/item-copy-actions.component";
+import { ItemMoreOptionsComponent } from "../item-more-options/item-more-options.component";
+import { SimplifiedAutofillInfoComponent } from "../simplified-autofill-info/simplified-autofill-info.component";
+
+@Component({
+  selector: "app-vault-popup-list-table",
+  templateUrl: "vault-popup-list-table.component.html",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    // Forward height through to the `height="fill"` table so it can size to a bounded parent
+    // (e.g. the popup-page scroll area). Without this the host collapses to 0 and no rows show.
+    class: "tw-flex tw-flex-col tw-flex-1 tw-min-h-0",
+  },
+  imports: [
+    CommonModule,
+    FormsModule,
+    JslibModule,
+    BitTableV2Component,
+    BitColumnComponent,
+    BitHeaderCellComponent,
+    BitCellComponent,
+    BitCellDefDirective,
+    BitRowGroupComponent,
+    BitTableToolbarComponent,
+    IconButtonModule,
+    IconComponent,
+    SearchModule,
+    TypographyModule,
+    ChipActionComponent,
+    ItemCopyActionsComponent,
+    ItemMoreOptionsComponent,
+    OrgIconDirective,
+    SimplifiedAutofillInfoComponent,
+  ],
+})
+export class VaultPopupListTableComponent {
+  private readonly vaultPopupLoadingService = inject(VaultPopupLoadingService);
+  private readonly vaultPopupAutofillService = inject(VaultPopupAutofillService);
+  private readonly vaultPopupSectionService = inject(VaultPopupSectionService);
+  private readonly compactModeService = inject(CompactModeService);
+  private readonly listTableService = inject(VaultPopupListTableService);
+  private readonly platformUtilsService = inject(PlatformUtilsService);
+  protected readonly i18nService = inject(I18nService);
+  private readonly window = inject<Window>(WINDOW);
+
+  protected readonly CipherViewLikeUtils = CipherViewLikeUtils;
+
+  protected searchText: string = "";
+  private readonly searchText$ = new Subject<string>();
+
+  protected readonly loading = toSignal(this.vaultPopupLoadingService.loading$, {
+    initialValue: true,
+  });
+
+  protected readonly rows = toSignal(this.listTableService.rows$, {
+    initialValue: [] as VaultTableRow[],
+  });
+
+  protected readonly hasSearchText = toSignal(this.listTableService.hasSearchText$, {
+    initialValue: false,
+  });
+
+  protected readonly table = defineTable<VaultTableRow, "name">(this.rows);
+
+  protected readonly itemHeight = toSignal(
+    this.compactModeService.enabled$.pipe(map((enabled) => (enabled ? 53 : 59))),
+    { initialValue: 59 },
+  );
+
+  protected readonly currentUriIsBlocked = toSignal(
+    this.vaultPopupAutofillService.currentTabIsOnBlocklist$,
+  );
+
+  /** Whether the popup is rendered in the sidebar, where the autofill refresh control is offered. */
+  protected readonly showRefresh = BrowserPopupUtils.inSidebar(this.window);
+
+  /** Keyboard-shortcut tooltip shown on the legacy (flag-off) autofill chip, e.g. "Autofill ⌘⇧L". */
+  protected readonly autofillShortcutTooltip = signal<string | undefined>(undefined);
+
+  /** The all-items section heading, which becomes "Search results" while a search is active. */
+  protected readonly allItemsSectionKey = computed(() =>
+    this.hasSearchText() ? "searchResults" : "allItems",
+  );
+
+  /** The autofill section heading, which becomes "Suggested items" when the current URI is blocked. */
+  protected readonly autofillSectionKey = computed(() =>
+    this.currentUriIsBlocked() ? "itemSuggestions" : "autofillSuggestions",
+  );
+
+  protected readonly favoritesOpenState = computed(
+    () => this.vaultPopupSectionService.getOpenDisplayStateForSection("favorites")() ?? true,
+  );
+
+  protected readonly allItemsOpenState = computed(
+    () => this.vaultPopupSectionService.getOpenDisplayStateForSection("allItems")() ?? true,
+  );
+
+  /** Persist a section's open/closed state when the user toggles its collapsible header. */
+  protected setSectionCollapsed(section: "favorites" | "allItems", collapsed: boolean) {
+    return this.vaultPopupSectionService.updateSectionOpenStoredState(section, !collapsed);
+  }
+
+  /**
+   * Stable row identity for the table. The section prefix matters: the same cipher can appear in
+   * both the autofill/favorites sections and all-items, so a bare `cipher.id` would collide.
+   */
+  protected readonly trackRow = (_: number, row: VaultTableRow) =>
+    `${row._section}:${row.cipher.id}`;
+
+  protected readonly isAutofill = (row: VaultTableRow) => row._section === "autofill";
+  protected readonly isFavorites = (row: VaultTableRow) => row._section === "favorites";
+  protected readonly isAllItems = (row: VaultTableRow) => row._section === "allItems";
+
+  protected readonly isLogin = (row: VaultTableRow) =>
+    CipherViewLikeUtils.getType(row.cipher) === CipherType.Login;
+  protected readonly isCard = (row: VaultTableRow) =>
+    CipherViewLikeUtils.getType(row.cipher) === CipherType.Card;
+  protected readonly isIdentity = (row: VaultTableRow) =>
+    CipherViewLikeUtils.getType(row.cipher) === CipherType.Identity;
+
+  constructor() {
+    // Keep the input in sync with the search text already applied to the vault (e.g. restored state).
+    this.listTableService.searchText$
+      .pipe(
+        takeUntilDestroyed(),
+        filter((text) => !!text),
+      )
+      .subscribe((text) => (this.searchText = text));
+
+    // Debounced apply lives in the service; the component just feeds it and owns the subscription.
+    this.listTableService
+      .applyFilterOnInput(this.searchText$)
+      .pipe(takeUntilDestroyed())
+      .subscribe();
+
+    // Resolve the keyboard-shortcut tooltip for the legacy (flag-off) autofill chip.
+    void this.setAutofillShortcutTooltip();
+  }
+
+  private async setAutofillShortcutTooltip() {
+    const shortcut = await this.platformUtilsService.getAutofillKeyboardShortcut();
+    this.autofillShortcutTooltip.set(
+      shortcut === "" ? undefined : `${this.i18nService.t("autofillVerb")} ${shortcut}`,
+    );
+  }
+
+  onSearchTextChanged() {
+    this.searchText$.next(this.searchText);
+  }
+
+  /**
+   * Primary click action for a row: autofill for autofill-section rows, otherwise navigate to view.
+   */
+  onCipherSelect(row: VaultTableRow) {
+    return row.actions.primaryAutofill
+      ? this.listTableService.doAutofill(row.cipher)
+      : this.listTableService.viewCipher(row.cipher);
+  }
+
+  launchCipher(cipher: CipherViewLike) {
+    return this.listTableService.launchCipher(cipher);
+  }
+
+  doAutofill(cipher: PopupCipherViewLike) {
+    return this.listTableService.doAutofill(cipher);
+  }
+
+  /** Refreshes the current tab so the autofill suggestions repopulate. */
+  refreshCurrentTab() {
+    return this.listTableService.refreshCurrentTab();
+  }
+
+  orgIconTooltip({ collectionIds, collections }: PopupCipherViewLike) {
+    if (collectionIds.length > 1 || !collections) {
+      return this.i18nService.t("nSharedFolders", collectionIds.length);
+    }
+    return collections[0]?.name;
+  }
+}

--- a/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.ts
@@ -153,8 +153,6 @@ export class VaultPopupListTableComponent {
   protected readonly isFavorites = (row: VaultTableRow) => row._section === "favorites";
   protected readonly isAllItems = (row: VaultTableRow) => row._section === "allItems";
 
-  protected readonly isLogin = (row: VaultTableRow) =>
-    CipherViewLikeUtils.getType(row.cipher) === CipherType.Login;
   protected readonly isCard = (row: VaultTableRow) =>
     CipherViewLikeUtils.getType(row.cipher) === CipherType.Card;
   protected readonly isIdentity = (row: VaultTableRow) =>

--- a/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.stories.ts
+++ b/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.stories.ts
@@ -50,9 +50,18 @@ import { VaultPopupListTableComponent } from "./vault-popup-list-table.component
 // `subTitle` getter that surfaces a login's username) straight off the model, so building the actual
 // class is both simpler than mocking every getter and a truer exercise of the component.
 
-const pick = <T>(items: readonly T[]): T => items[Math.floor(Math.random() * items.length)];
-const randomDigits = (length: number): string =>
-  Array.from({ length }, () => Math.floor(Math.random() * 10)).join("");
+// Fixtures must be deterministic: Storybook snapshots these stories in Chromatic on every PR, so any
+// randomness here would diff against its baseline every build and erode the visual-regression signal.
+// `pick` rotates through each list in a fixed order — its own cursor per array — so fixtures keep
+// their variety without randomness.
+const pickCursors = new WeakMap<readonly unknown[], number>();
+const pick = <T>(items: readonly T[]): T => {
+  const next = pickCursors.get(items) ?? 0;
+  pickCursors.set(items, next + 1);
+  return items[next % items.length];
+};
+const sequentialDigits = (length: number): string =>
+  Array.from({ length }, (_, i) => String((i + 1) % 10)).join("");
 
 const WEBSITES = [
   { name: "GitHub", uri: "https://github.com" },
@@ -89,7 +98,7 @@ const LAST_NAMES = [
 const EMAIL_DOMAINS = ["gmail.com", "proton.me", "outlook.com", "fastmail.com"] as const;
 const CARD_BRANDS = ["Visa", "Mastercard", "American Express", "Discover"] as const;
 
-const randomEmail = (first = pick(FIRST_NAMES), last = pick(LAST_NAMES)): string =>
+const makeEmail = (first = pick(FIRST_NAMES), last = pick(LAST_NAMES)): string =>
   `${first}.${last}@${pick(EMAIL_DOMAINS)}`.toLowerCase();
 
 /** A real `CipherView` with a random id, editable and viewable by default. */
@@ -103,38 +112,38 @@ const baseCipher = (type: CipherType, name: string): CipherView => {
   return cipher;
 };
 
-const randomLogin = (
+const makeLogin = (
   overrides: { name?: string; username?: string; favorite?: boolean } = {},
 ): CipherView => {
   const site = pick(WEBSITES);
   const cipher = baseCipher(CipherType.Login, overrides.name ?? site.name);
   cipher.favorite = overrides.favorite ?? false;
-  // `"username" in overrides` distinguishes "no override" (random email) from an explicit
+  // `"username" in overrides` distinguishes "no override" (default email) from an explicit
   // `undefined` (a password-only login, whose subtitle is intentionally blank).
-  cipher.login.username = "username" in overrides ? overrides.username : randomEmail();
+  cipher.login.username = "username" in overrides ? overrides.username : makeEmail();
   const uri = new LoginUriView();
   uri.uri = site.uri;
   cipher.login.uris = [uri];
   return cipher;
 };
 
-const randomCard = (): CipherView => {
+const makeCard = (): CipherView => {
   const brand = pick(CARD_BRANDS);
   const cipher = baseCipher(CipherType.Card, `${brand} card`);
   cipher.card.brand = brand;
-  cipher.card.number = randomDigits(16);
-  cipher.card.expMonth = String(1 + Math.floor(Math.random() * 12));
-  cipher.card.expYear = String(2027 + Math.floor(Math.random() * 5));
+  cipher.card.number = sequentialDigits(16);
+  cipher.card.expMonth = "8";
+  cipher.card.expYear = "2030";
   return cipher;
 };
 
-const randomIdentity = (): CipherView => {
+const makeIdentity = (): CipherView => {
   const first = pick(FIRST_NAMES);
   const last = pick(LAST_NAMES);
   const cipher = baseCipher(CipherType.Identity, `${first} ${last}`);
   cipher.identity.firstName = first;
   cipher.identity.lastName = last;
-  cipher.identity.email = randomEmail(first, last);
+  cipher.identity.email = makeEmail(first, last);
   return cipher;
 };
 
@@ -167,29 +176,29 @@ const inOrganization = (
 };
 
 const AUTOFILL_CIPHERS: PopupCipherViewLike[] = [
-  randomLogin(),
-  randomLogin(),
+  makeLogin(),
+  makeLogin(),
   // No username, so its accessible title omits the field (`autofillTitle` vs `autofillTitleWithField`)
   // and its subtitle is blank. The logins above exercise the `*WithField` variants.
-  randomLogin({ name: "Password-only Login", username: undefined }),
+  makeLogin({ name: "Password-only Login", username: undefined }),
   // A card and identity so the autofill section's type subgroups (Card / Identity) render.
-  randomCard(),
-  randomIdentity(),
+  makeCard(),
+  makeIdentity(),
 ];
 
-const FAVORITE_CIPHERS: PopupCipherViewLike[] = [randomLogin({ favorite: true })];
+const FAVORITE_CIPHERS: PopupCipherViewLike[] = [makeLogin({ favorite: true })];
 
 const ALL_ITEM_CIPHERS: PopupCipherViewLike[] = [
-  randomLogin(),
-  randomLogin(),
-  randomCard(),
-  randomIdentity(),
+  makeLogin(),
+  makeLogin(),
+  makeCard(),
+  makeIdentity(),
   // Has an attachment, so the paperclip icon renders with its `attachments` accessible title.
-  withAttachment(randomLogin()),
+  withAttachment(makeLogin()),
   // In an organization across multiple shared folders: the org icon tooltip reads `nSharedFolders`.
-  inOrganization(randomLogin(), ProductTierType.Enterprise, ["Engineering", "Marketing"]),
+  inOrganization(makeLogin(), ProductTierType.Enterprise, ["Engineering", "Marketing"]),
   // In an organization within a single shared folder: the org icon tooltip reads that folder's name.
-  inOrganization(randomLogin(), ProductTierType.Families, ["Engineering"]),
+  inOrganization(makeLogin(), ProductTierType.Families, ["Engineering"]),
 ];
 
 type StoryArgs = {
@@ -362,8 +371,10 @@ const buildProviders = (args: StoryArgs) => {
       useValue: { environment$: of({ getIconsUrl: () => "https://icons.bitwarden.net" }) },
     },
     {
+      // Favicons off so snapshots don't attempt remote favicon fetches during Chromatic builds,
+      // which would make the rendered icons non-deterministic (and require network access offline).
       provide: DomainSettingsService,
-      useValue: { showFavicons$: of(true) },
+      useValue: { showFavicons$: of(false) },
     },
     {
       provide: VaultPopupCopyButtonsService,

--- a/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.stories.ts
+++ b/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.stories.ts
@@ -304,12 +304,6 @@ const buildProviders = (args: StoryArgs) => {
           refresh: "Refresh",
           favorites: "Favorites",
           allItems: "All items",
-          // app-simplified-autofill-info
-          openSimplifiedAutofillPopover: "Open simplified autofill popover",
-          simplifiedAutofill: "Simplified autofill",
-          simplifiedAutofillDescription:
-            "When you click a suggested autofill item, it fills rather than taking you to details. You can still view these items from the More menu.",
-          gotIt: "Got it",
           typeLogin: "Login",
           typeCard: "Card",
           typeIdentity: "Identity",

--- a/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.stories.ts
+++ b/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.stories.ts
@@ -363,7 +363,7 @@ const buildProviders = (args: StoryArgs) => {
           upgradeToUseArchive: "Upgrade to use archive",
           delete: "Delete",
           launchWebsiteName: "Launch __$1__",
-          itemCount: "__$1__ item | __$1__ items",
+          itemCount: "__$1__ items",
         }),
     },
     {

--- a/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.stories.ts
+++ b/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.stories.ts
@@ -361,7 +361,7 @@ const buildProviders = (args: StoryArgs) => {
           archiveVerb: "Archive",
           upgradeToUseArchive: "Upgrade to use archive",
           delete: "Delete",
-          launchWebsiteForName: "Launch __$1__",
+          launchWebsite: "Launch website",
           itemCount: "__$1__ items",
         }),
     },

--- a/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.stories.ts
+++ b/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.stories.ts
@@ -1,0 +1,538 @@
+import { Router } from "@angular/router";
+import { applicationConfig, Meta, StoryObj } from "@storybook/angular";
+import { BehaviorSubject, of } from "rxjs";
+
+import { CollectionService } from "@bitwarden/admin-console/common";
+import { WINDOW } from "@bitwarden/angular/services/injection-tokens";
+import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
+import { CollectionView } from "@bitwarden/common/admin-console/models/collections";
+import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { DomainSettingsService } from "@bitwarden/common/autofill/services/domain-settings.service";
+import { BillingAccountProfileStateService } from "@bitwarden/common/billing/abstractions/account/billing-account-profile-state.service";
+import { ProductTierType } from "@bitwarden/common/billing/enums";
+import { EventCollectionService } from "@bitwarden/common/dirt/event-logs";
+import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
+import { EnvironmentService } from "@bitwarden/common/platform/abstractions/environment.service";
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
+import { CollectionId, OrganizationId } from "@bitwarden/common/types/guid";
+import { CipherArchiveService } from "@bitwarden/common/vault/abstractions/cipher-archive.service";
+import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
+import { TotpService } from "@bitwarden/common/vault/abstractions/totp.service";
+import { VaultSettingsService } from "@bitwarden/common/vault/abstractions/vault-settings/vault-settings.service";
+import { CipherType } from "@bitwarden/common/vault/enums";
+import { AttachmentView } from "@bitwarden/common/vault/models/view/attachment.view";
+import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+import { LoginUriView } from "@bitwarden/common/vault/models/view/login-uri.view";
+import { CipherAuthorizationService } from "@bitwarden/common/vault/services/cipher-authorization.service";
+import { RestrictedItemTypesService } from "@bitwarden/common/vault/services/restricted-item-types.service";
+import {
+  CompactModeService,
+  DialogService,
+  I18nMockService,
+  ToastService,
+} from "@bitwarden/components";
+import { StateProvider } from "@bitwarden/state";
+import { PasswordRepromptService } from "@bitwarden/vault";
+
+import { VaultPopupAutofillService } from "../../../services/vault-popup-autofill.service";
+import { VaultPopupCopyButtonsService } from "../../../services/vault-popup-copy-buttons.service";
+import { VaultPopupItemsService } from "../../../services/vault-popup-items.service";
+import { VaultPopupLoadingService } from "../../../services/vault-popup-loading.service";
+import { VaultPopupSectionService } from "../../../services/vault-popup-section.service";
+import { PopupCipherViewLike } from "../../../views/popup-cipher.view";
+
+import { VaultPopupListTableComponent } from "./vault-popup-list-table.component";
+
+// Real `CipherView` instances rather than hand-mocked shapes: the row reads derived values (e.g. the
+// `subTitle` getter that surfaces a login's username) straight off the model, so building the actual
+// class is both simpler than mocking every getter and a truer exercise of the component.
+
+const pick = <T>(items: readonly T[]): T => items[Math.floor(Math.random() * items.length)];
+const randomDigits = (length: number): string =>
+  Array.from({ length }, () => Math.floor(Math.random() * 10)).join("");
+
+const WEBSITES = [
+  { name: "GitHub", uri: "https://github.com" },
+  { name: "Google", uri: "https://accounts.google.com" },
+  { name: "Bitwarden", uri: "https://vault.bitwarden.com" },
+  { name: "Amazon", uri: "https://amazon.com" },
+  { name: "Netflix", uri: "https://netflix.com" },
+  { name: "Spotify", uri: "https://open.spotify.com" },
+  { name: "Reddit", uri: "https://reddit.com" },
+  { name: "Dropbox", uri: "https://dropbox.com" },
+  { name: "Steam", uri: "https://store.steampowered.com" },
+  { name: "Figma", uri: "https://figma.com" },
+] as const;
+const FIRST_NAMES = [
+  "Alex",
+  "Jordan",
+  "Taylor",
+  "Morgan",
+  "Casey",
+  "Riley",
+  "Jamie",
+  "Quinn",
+] as const;
+const LAST_NAMES = [
+  "Rivera",
+  "Chen",
+  "Patel",
+  "Okafor",
+  "Nguyen",
+  "Silva",
+  "Haddad",
+  "Kim",
+] as const;
+const EMAIL_DOMAINS = ["gmail.com", "proton.me", "outlook.com", "fastmail.com"] as const;
+const CARD_BRANDS = ["Visa", "Mastercard", "American Express", "Discover"] as const;
+
+const randomEmail = (first = pick(FIRST_NAMES), last = pick(LAST_NAMES)): string =>
+  `${first}.${last}@${pick(EMAIL_DOMAINS)}`.toLowerCase();
+
+/** A real `CipherView` with a random id, editable and viewable by default. */
+const baseCipher = (type: CipherType, name: string): CipherView => {
+  const cipher = new CipherView();
+  cipher.id = crypto.randomUUID();
+  cipher.type = type;
+  cipher.name = name;
+  cipher.edit = true;
+  cipher.viewPassword = true;
+  return cipher;
+};
+
+const randomLogin = (
+  overrides: { name?: string; username?: string; favorite?: boolean } = {},
+): CipherView => {
+  const site = pick(WEBSITES);
+  const cipher = baseCipher(CipherType.Login, overrides.name ?? site.name);
+  cipher.favorite = overrides.favorite ?? false;
+  // `"username" in overrides` distinguishes "no override" (random email) from an explicit
+  // `undefined` (a password-only login, whose subtitle is intentionally blank).
+  cipher.login.username = "username" in overrides ? overrides.username : randomEmail();
+  const uri = new LoginUriView();
+  uri.uri = site.uri;
+  cipher.login.uris = [uri];
+  return cipher;
+};
+
+const randomCard = (): CipherView => {
+  const brand = pick(CARD_BRANDS);
+  const cipher = baseCipher(CipherType.Card, `${brand} card`);
+  cipher.card.brand = brand;
+  cipher.card.number = randomDigits(16);
+  cipher.card.expMonth = String(1 + Math.floor(Math.random() * 12));
+  cipher.card.expYear = String(2027 + Math.floor(Math.random() * 5));
+  return cipher;
+};
+
+const randomIdentity = (): CipherView => {
+  const first = pick(FIRST_NAMES);
+  const last = pick(LAST_NAMES);
+  const cipher = baseCipher(CipherType.Identity, `${first} ${last}`);
+  cipher.identity.firstName = first;
+  cipher.identity.lastName = last;
+  cipher.identity.email = randomEmail(first, last);
+  return cipher;
+};
+
+/** Give the cipher a single attachment so the paperclip icon renders. */
+const withAttachment = (cipher: CipherView): CipherView => {
+  cipher.attachments = [new AttachmentView()];
+  return cipher;
+};
+
+/** Tag a cipher as organization-owned and attach the popup's org/collection decorations. */
+const inOrganization = (
+  cipher: CipherView,
+  productTierType: ProductTierType,
+  collectionNames: string[],
+): PopupCipherViewLike => {
+  const organizationId = crypto.randomUUID() as OrganizationId;
+  cipher.organizationId = organizationId;
+  cipher.collectionIds = collectionNames.map(() => crypto.randomUUID());
+
+  const organization = new Organization();
+  organization.id = organizationId;
+  organization.productTierType = productTierType;
+
+  const collections = collectionNames.map(
+    (name, i) =>
+      new CollectionView({ id: cipher.collectionIds[i] as CollectionId, organizationId, name }),
+  );
+
+  return Object.assign(cipher, { organization, collections }) as PopupCipherViewLike;
+};
+
+const AUTOFILL_CIPHERS: PopupCipherViewLike[] = [
+  randomLogin(),
+  randomLogin(),
+  // No username, so its accessible title omits the field (`autofillTitle` vs `autofillTitleWithField`)
+  // and its subtitle is blank. The logins above exercise the `*WithField` variants.
+  randomLogin({ name: "Password-only Login", username: undefined }),
+  // A card and identity so the autofill section's type subgroups (Card / Identity) render.
+  randomCard(),
+  randomIdentity(),
+];
+
+const FAVORITE_CIPHERS: PopupCipherViewLike[] = [randomLogin({ favorite: true })];
+
+const ALL_ITEM_CIPHERS: PopupCipherViewLike[] = [
+  randomLogin(),
+  randomLogin(),
+  randomCard(),
+  randomIdentity(),
+  // Has an attachment, so the paperclip icon renders with its `attachments` accessible title.
+  withAttachment(randomLogin()),
+  // In an organization across multiple shared folders: the org icon tooltip reads `nSharedFolders`.
+  inOrganization(randomLogin(), ProductTierType.Enterprise, ["Engineering", "Marketing"]),
+  // In an organization within a single shared folder: the org icon tooltip reads that folder's name.
+  inOrganization(randomLogin(), ProductTierType.Families, ["Engineering"]),
+];
+
+type StoryArgs = {
+  autoFillCiphers: PopupCipherViewLike[];
+  favoriteCiphers: PopupCipherViewLike[];
+  filteredCiphers: PopupCipherViewLike[];
+  loading: boolean;
+  /** When true, the current tab is blocklisted: autofill is disabled and the section is retitled. */
+  currentUriIsBlocked?: boolean;
+  /** When true, render as if in the sidebar so the autofill section shows the refresh control. */
+  inSidebar?: boolean;
+  /** PM31039ItemActionInExtension flag. Defaults to on (the simplified item-action design). */
+  simplifiedItemActionEnabled?: boolean;
+  /** Legacy (flag-off) setting: whether clicking an autofill suggestion fills it. Defaults to on. */
+  clickItemsToAutofillVaultView?: boolean;
+};
+
+const buildProviders = (args: StoryArgs) => {
+  const autoFillCiphers$ = new BehaviorSubject(args.autoFillCiphers);
+  const favoriteCiphers$ = new BehaviorSubject(args.favoriteCiphers);
+  const loading$ = new BehaviorSubject(args.loading);
+
+  // The all-items list narrows as the user searches; keep the unfiltered set to search against.
+  const allItems = args.filteredCiphers;
+  const filteredCiphers$ = new BehaviorSubject(allItems);
+  const searchText$ = new BehaviorSubject("");
+  const hasSearchText$ = new BehaviorSubject(false);
+
+  // Minimal stand-in for the real search service so the toolbar search folds the list live.
+  const applyFilter = (text: string) => {
+    const term = (text ?? "").trim().toLowerCase();
+    searchText$.next(text ?? "");
+    hasSearchText$.next(term.length > 0);
+    filteredCiphers$.next(
+      term ? allItems.filter((c) => c.name.toLowerCase().includes(term)) : allItems,
+    );
+  };
+
+  // `showRefresh` reads `BrowserPopupUtils.inSidebar(window)`, which checks the window URL for
+  // `uilocation=sidebar`. Provide a fake `WINDOW` per story so the refresh control is controlled by
+  // injection (isolated per story, including on the docs page) rather than by mutating a global.
+  const fakeWindow = {
+    location: {
+      href: args.inSidebar ? "https://example.com/?uilocation=sidebar" : "https://example.com/",
+    },
+  } as Window;
+
+  return [
+    { provide: WINDOW, useValue: fakeWindow },
+    {
+      provide: VaultPopupItemsService,
+      useValue: {
+        autoFillCiphers$: autoFillCiphers$.asObservable(),
+        favoriteCiphers$: favoriteCiphers$.asObservable(),
+        filteredCiphers$: filteredCiphers$.asObservable(),
+        loading$: loading$.asObservable(),
+        searchText$: searchText$.asObservable(),
+        hasSearchText$: hasSearchText$.asObservable(),
+        applyFilter,
+      },
+    },
+    {
+      provide: VaultPopupLoadingService,
+      useValue: { loading$: loading$.asObservable() },
+    },
+    {
+      provide: VaultPopupAutofillService,
+      useValue: {
+        currentTabIsOnBlocklist$: of(args.currentUriIsBlocked ?? false),
+        autofillAllowed$: of(false),
+        currentAutofillTab$: of(null),
+        doAutofill: async () => {},
+      },
+    },
+    {
+      provide: VaultPopupSectionService,
+      useValue: {
+        getOpenDisplayStateForSection: () => () => true,
+        updateSectionOpenStoredState: async () => {},
+      },
+    },
+    {
+      provide: CompactModeService,
+      useValue: { enabled$: of(false) },
+    },
+    {
+      provide: ConfigService,
+      useValue: {
+        getFeatureFlag$: (flag: FeatureFlag) => {
+          if (flag === FeatureFlag.PM31039ItemActionInExtension) {
+            return of(args.simplifiedItemActionEnabled ?? true);
+          }
+          return of(false);
+        },
+      },
+    },
+    {
+      provide: VaultSettingsService,
+      useValue: { clickItemsToAutofillVaultView$: of(args.clickItemsToAutofillVaultView ?? true) },
+    },
+    {
+      provide: I18nService,
+      useFactory: () =>
+        new I18nMockService({
+          search: "Search",
+          searchResults: "Search results",
+          resetSearch: "Reset search",
+          name: "Name",
+          autofillSuggestions: "Autofill suggestions",
+          itemSuggestions: "Suggested items",
+          // Sidebar-only autofill refresh control; not rendered in Storybook (not a sidebar).
+          refresh: "Refresh",
+          favorites: "Favorites",
+          allItems: "All items",
+          // app-simplified-autofill-info
+          openSimplifiedAutofillPopover: "Open simplified autofill popover",
+          simplifiedAutofill: "Simplified autofill",
+          simplifiedAutofillDescription:
+            "When you click a suggested autofill item, it fills rather than taking you to details. You can still view these items from the More menu.",
+          gotIt: "Got it",
+          typeLogin: "Login",
+          typeCard: "Card",
+          typeIdentity: "Identity",
+          fill: "Fill",
+          // Accessible row titles (appA11yTitle on the row button and attachment icon)
+          autofillTitle: "Autofill - __$1__",
+          autofillTitleWithField: "Autofill - __$1__ - __$2__",
+          viewItemTitle: "View item - __$1__",
+          viewItemTitleWithField: "View item - __$1__ - __$2__",
+          attachments: "Attachments",
+          // Org-icon tooltip (appA11yTitle) for ciphers in multiple shared folders
+          nSharedFolders: "__$1__ shared folders",
+          noItemsMatchSearch: "No items match your search",
+          nothingToShow: "Nothing to show",
+          // Copyable-field labels used by app-item-copy-actions
+          username: "Username",
+          password: "Password",
+          verificationCodeTotp: "Verification code (TOTP)",
+          securityCode: "Security code",
+          cardNumber: "Card number",
+          address: "Address",
+          email: "Email",
+          phone: "Phone",
+          copy: "Copy",
+          moreOptionsLabelNoPlaceholder: "More options",
+          copyFieldCipherName: "Copy __$1__ for __$2__",
+          copyInfoTitle: "Copy info for __$1__",
+          copyNoteTitle: "Copy note for __$1__",
+          noValuesToCopy: "No values to copy",
+          copyUsername: "Copy username",
+          copyPassword: "Copy password",
+          copyVerificationCode: "Copy verification code",
+          copyNumber: "Copy number",
+          copySecurityCode: "Copy security code",
+          copyEmail: "Copy email",
+          copyAddress: "Copy address",
+          copyPhone: "Copy phone",
+          close: "Close",
+          // app-item-more-options menu
+          autofillVerb: "Autofill",
+          view: "View",
+          favorite: "Favorite",
+          unfavorite: "Unfavorite",
+          edit: "Edit",
+          clone: "Clone",
+          assignToCollections: "Assign to shared folders",
+          archiveVerb: "Archive",
+          upgradeToUseArchive: "Upgrade to use archive",
+          delete: "Delete",
+          launchWebsiteName: "Launch __$1__",
+          itemCount: "__$1__ item | __$1__ items",
+        }),
+    },
+    {
+      provide: EnvironmentService,
+      useValue: { environment$: of({ getIconsUrl: () => "https://icons.bitwarden.net" }) },
+    },
+    {
+      provide: DomainSettingsService,
+      useValue: { showFavicons$: of(true) },
+    },
+    {
+      provide: VaultPopupCopyButtonsService,
+      useValue: { showQuickCopyActions$: of(false) },
+    },
+    {
+      provide: AccountService,
+      useValue: { activeAccount$: of({ id: "story-user-id" }) },
+    },
+    {
+      provide: StateProvider,
+      useValue: {
+        getUserState$: () => of({ hasSeen: false, hasDismissed: false }),
+        getUser: () => ({ update: async () => {} }),
+      },
+    },
+    {
+      provide: RestrictedItemTypesService,
+      useValue: { restricted$: of([]) },
+    },
+    { provide: CipherService, useValue: {} },
+    { provide: PasswordRepromptService, useValue: {} },
+    { provide: ToastService, useValue: {} },
+    { provide: DialogService, useValue: {} },
+    { provide: OrganizationService, useValue: { hasOrganizations: () => of(false) } },
+    {
+      provide: CipherAuthorizationService,
+      useValue: {
+        canDeleteCipher$: () => of(false),
+        canCloneCipher$: () => of(false),
+      },
+    },
+    { provide: CollectionService, useValue: { decryptedCollections$: () => of([]) } },
+    { provide: CipherArchiveService, useValue: { userCanArchive$: () => of(false) } },
+    {
+      provide: PlatformUtilsService,
+      useValue: { getAutofillKeyboardShortcut: async () => "Ctrl+Shift+L" },
+    },
+    { provide: EventCollectionService, useValue: {} },
+    { provide: TotpService, useValue: {} },
+    {
+      provide: BillingAccountProfileStateService,
+      useValue: { hasPremiumFromAnySource$: () => of(true) },
+    },
+    { provide: Router, useValue: { navigate: () => Promise.resolve(true) } },
+  ];
+};
+
+export default {
+  title: "Browser/Vault/VaultPopupListTable",
+  component: VaultPopupListTableComponent,
+} as Meta<VaultPopupListTableComponent>;
+
+// `StoryArgs` is the input to `buildProviders`, not Storybook args (data flows through providers,
+// not the args table), so the Story type is keyed on the component alone.
+type Story = StoryObj<VaultPopupListTableComponent>;
+
+export const Default: Story = {
+  decorators: [
+    applicationConfig({
+      providers: buildProviders({
+        autoFillCiphers: AUTOFILL_CIPHERS,
+        favoriteCiphers: FAVORITE_CIPHERS,
+        // Mirrors the real service: `filteredCiphers$` is the full list, so it also
+        // contains the autofill and favorite ciphers that render in their own sections.
+        filteredCiphers: [...AUTOFILL_CIPHERS, ...FAVORITE_CIPHERS, ...ALL_ITEM_CIPHERS],
+        loading: false,
+      }),
+    }),
+  ],
+  render: () => ({
+    template: `<div class="tw-flex tw-flex-col" style="height: 500px"><app-vault-popup-list-table></app-vault-popup-list-table></div>`,
+  }),
+};
+
+export const Loading: Story = {
+  decorators: [
+    applicationConfig({
+      providers: buildProviders({
+        autoFillCiphers: [],
+        favoriteCiphers: [],
+        filteredCiphers: [],
+        loading: true,
+      }),
+    }),
+  ],
+  render: () => ({
+    template: `<div class="tw-flex tw-flex-col" style="height: 500px"><app-vault-popup-list-table></app-vault-popup-list-table></div>`,
+  }),
+};
+
+export const EmptyVault: Story = {
+  decorators: [
+    applicationConfig({
+      providers: buildProviders({
+        autoFillCiphers: [],
+        favoriteCiphers: [],
+        filteredCiphers: [],
+        loading: false,
+      }),
+    }),
+  ],
+  render: () => ({
+    template: `<div class="tw-flex tw-flex-col" style="height: 500px"><app-vault-popup-list-table></app-vault-popup-list-table></div>`,
+  }),
+};
+
+// Rendered as if in the sidebar (`inSidebar: true` provides a fake window whose URL carries
+// `uilocation=sidebar`): the autofill section header shows the refresh button. The injected window
+// scopes this to this story alone, so the control never leaks into the others on the docs page.
+export const SidebarRefresh: Story = {
+  decorators: [
+    applicationConfig({
+      providers: buildProviders({
+        autoFillCiphers: AUTOFILL_CIPHERS,
+        favoriteCiphers: FAVORITE_CIPHERS,
+        filteredCiphers: [...AUTOFILL_CIPHERS, ...FAVORITE_CIPHERS, ...ALL_ITEM_CIPHERS],
+        loading: false,
+        inSidebar: true,
+      }),
+    }),
+  ],
+  render: () => ({
+    template: `<div class="tw-flex tw-flex-col" style="height: 500px"><app-vault-popup-list-table></app-vault-popup-list-table></div>`,
+  }),
+};
+
+// Legacy (PM31039ItemActionInExtension off) affordance: autofill suggestions show a primary "Fill"
+// chip (with a keyboard-shortcut tooltip) instead of fill-on-click. `clickItemsToAutofillVaultView`
+// is off so the chip is shown rather than the click itself autofilling.
+export const LegacyAutofillButton: Story = {
+  decorators: [
+    applicationConfig({
+      providers: buildProviders({
+        autoFillCiphers: AUTOFILL_CIPHERS,
+        favoriteCiphers: FAVORITE_CIPHERS,
+        filteredCiphers: [...AUTOFILL_CIPHERS, ...FAVORITE_CIPHERS, ...ALL_ITEM_CIPHERS],
+        loading: false,
+        simplifiedItemActionEnabled: false,
+        clickItemsToAutofillVaultView: false,
+      }),
+    }),
+  ],
+  render: () => ({
+    template: `<div class="tw-flex tw-flex-col" style="height: 500px"><app-vault-popup-list-table></app-vault-popup-list-table></div>`,
+  }),
+};
+
+// The current tab is blocklisted: the autofill section heading reads "Suggested items"
+// instead of "Autofill suggestions", and autofill is no longer the primary click action.
+export const BlockedUri: Story = {
+  decorators: [
+    applicationConfig({
+      providers: buildProviders({
+        autoFillCiphers: AUTOFILL_CIPHERS,
+        favoriteCiphers: FAVORITE_CIPHERS,
+        filteredCiphers: [...AUTOFILL_CIPHERS, ...FAVORITE_CIPHERS, ...ALL_ITEM_CIPHERS],
+        loading: false,
+        currentUriIsBlocked: true,
+      }),
+    }),
+  ],
+  render: () => ({
+    template: `<div class="tw-flex tw-flex-col" style="height: 500px"><app-vault-popup-list-table></app-vault-popup-list-table></div>`,
+  }),
+};

--- a/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.stories.ts
+++ b/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.stories.ts
@@ -35,10 +35,9 @@ import {
   ToastService,
 } from "@bitwarden/components";
 import { StateProvider } from "@bitwarden/state";
-import { PasswordRepromptService } from "@bitwarden/vault";
+import { PasswordRepromptService, VaultCopyButtonsService } from "@bitwarden/vault";
 
 import { VaultPopupAutofillService } from "../../../services/vault-popup-autofill.service";
-import { VaultPopupCopyButtonsService } from "../../../services/vault-popup-copy-buttons.service";
 import { VaultPopupItemsService } from "../../../services/vault-popup-items.service";
 import { VaultPopupLoadingService } from "../../../services/vault-popup-loading.service";
 import { VaultPopupSectionService } from "../../../services/vault-popup-section.service";
@@ -377,7 +376,7 @@ const buildProviders = (args: StoryArgs) => {
       useValue: { showFavicons$: of(false) },
     },
     {
-      provide: VaultPopupCopyButtonsService,
+      provide: VaultCopyButtonsService,
       useValue: { showQuickCopyActions$: of(false) },
     },
     {

--- a/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.stories.ts
+++ b/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.stories.ts
@@ -361,7 +361,7 @@ const buildProviders = (args: StoryArgs) => {
           archiveVerb: "Archive",
           upgradeToUseArchive: "Upgrade to use archive",
           delete: "Delete",
-          launchWebsiteName: "Launch __$1__",
+          launchWebsiteForName: "Launch __$1__",
           itemCount: "__$1__ items",
         }),
     },

--- a/apps/browser/src/vault/popup/services/vault-popup-list-table.service.spec.ts
+++ b/apps/browser/src/vault/popup/services/vault-popup-list-table.service.spec.ts
@@ -1,0 +1,401 @@
+import { TestBed, fakeAsync, tick } from "@angular/core/testing";
+import { Router } from "@angular/router";
+import { mock, MockProxy } from "jest-mock-extended";
+import { BehaviorSubject, firstValueFrom, of, Subject } from "rxjs";
+
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
+import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
+import { VaultSettingsService } from "@bitwarden/common/vault/abstractions/vault-settings/vault-settings.service";
+import { CipherType } from "@bitwarden/common/vault/enums";
+import { SearchTextDebounceInterval } from "@bitwarden/common/vault/services/search.service";
+import { CipherViewLikeUtils } from "@bitwarden/common/vault/utils/cipher-view-like-utils";
+import { DialogService } from "@bitwarden/components";
+import { DecryptionFailureDialogComponent, PasswordRepromptService } from "@bitwarden/vault";
+
+import { BrowserApi } from "../../../platform/browser/browser-api";
+import BrowserPopupUtils from "../../../platform/browser/browser-popup-utils";
+import { PopupCipherViewLike } from "../views/popup-cipher.view";
+
+import { VaultPopupAutofillService } from "./vault-popup-autofill.service";
+import { VaultPopupItemsService } from "./vault-popup-items.service";
+import { VaultPopupListTableService } from "./vault-popup-list-table.service";
+import { VaultPopupLoadingService } from "./vault-popup-loading.service";
+
+describe("VaultPopupListTableService", () => {
+  let service: VaultPopupListTableService;
+  let cipherService: MockProxy<CipherService>;
+  let vaultPopupAutofillService: MockProxy<VaultPopupAutofillService>;
+  let passwordRepromptService: MockProxy<PasswordRepromptService>;
+  let router: MockProxy<Router>;
+
+  const autoFillCiphers$ = new BehaviorSubject<PopupCipherViewLike[]>([]);
+  const favoriteCiphers$ = new BehaviorSubject<PopupCipherViewLike[]>([]);
+  const filteredCiphers$ = new BehaviorSubject<PopupCipherViewLike[]>([]);
+  const hasSearchText$ = new BehaviorSubject<boolean>(false);
+  const searchText$ = new BehaviorSubject<string>("");
+  const loading$ = new BehaviorSubject<boolean>(false);
+  const applyFilter = jest.fn();
+
+  // Inputs to the per-row action policy (feature flag, blocklist, click-to-autofill setting).
+  const simplifiedItemActionEnabled$ = new BehaviorSubject<boolean>(false);
+  const currentTabIsOnBlocklist$ = new BehaviorSubject<boolean>(false);
+  const clickItemsToAutofillVaultView$ = new BehaviorSubject<boolean>(true);
+
+  const makeCipher = (overrides: Partial<PopupCipherViewLike> = {}): PopupCipherViewLike =>
+    ({ id: "cipher-1", name: "Item", type: CipherType.Login, ...overrides }) as PopupCipherViewLike;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    autoFillCiphers$.next([]);
+    favoriteCiphers$.next([]);
+    filteredCiphers$.next([]);
+    hasSearchText$.next(false);
+    searchText$.next("");
+    loading$.next(false);
+    simplifiedItemActionEnabled$.next(false);
+    currentTabIsOnBlocklist$.next(false);
+    clickItemsToAutofillVaultView$.next(true);
+
+    cipherService = mock<CipherService>();
+    vaultPopupAutofillService = mock<VaultPopupAutofillService>();
+    vaultPopupAutofillService.currentTabIsOnBlocklist$ = currentTabIsOnBlocklist$.asObservable();
+    passwordRepromptService = mock<PasswordRepromptService>();
+    router = mock<Router>();
+
+    const accountService = mock<AccountService>();
+    accountService.activeAccount$ = of({ id: "user-1" } as any);
+
+    const configService = {
+      getFeatureFlag$: jest
+        .fn()
+        .mockImplementation((flag: FeatureFlag) =>
+          flag === FeatureFlag.PM31039ItemActionInExtension
+            ? simplifiedItemActionEnabled$.asObservable()
+            : of(false),
+        ),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        VaultPopupListTableService,
+        {
+          provide: VaultPopupItemsService,
+          useValue: {
+            autoFillCiphers$: autoFillCiphers$.asObservable(),
+            favoriteCiphers$: favoriteCiphers$.asObservable(),
+            filteredCiphers$: filteredCiphers$.asObservable(),
+            hasSearchText$: hasSearchText$.asObservable(),
+            searchText$: searchText$.asObservable(),
+            applyFilter,
+          },
+        },
+        {
+          provide: VaultPopupLoadingService,
+          useValue: { loading$: loading$.asObservable() },
+        },
+        { provide: CipherService, useValue: cipherService },
+        { provide: AccountService, useValue: accountService },
+        { provide: PasswordRepromptService, useValue: passwordRepromptService },
+        { provide: DialogService, useValue: mock<DialogService>() },
+        { provide: Router, useValue: router },
+        { provide: VaultPopupAutofillService, useValue: vaultPopupAutofillService },
+        { provide: ConfigService, useValue: configService },
+        {
+          provide: VaultSettingsService,
+          useValue: {
+            clickItemsToAutofillVaultView$: clickItemsToAutofillVaultView$.asObservable(),
+          },
+        },
+      ],
+    });
+
+    service = TestBed.inject(VaultPopupListTableService);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("rows$", () => {
+    it("merges autofill, favorites, and all-items sections in order when not searching", async () => {
+      autoFillCiphers$.next([makeCipher({ id: "a", name: "Autofill" })]);
+      favoriteCiphers$.next([makeCipher({ id: "f", name: "Favorite" })]);
+      filteredCiphers$.next([makeCipher({ id: "i", name: "All Items" })]);
+
+      const rows = await firstValueFrom(service.rows$);
+
+      expect(rows.map((r) => r._section)).toEqual(["autofill", "favorites", "allItems"]);
+      expect(rows.map((r) => r.cipher.name)).toEqual(["Autofill", "Favorite", "All Items"]);
+    });
+
+    it("folds to a single all-items section of filtered ciphers when searching", async () => {
+      autoFillCiphers$.next([makeCipher({ id: "a", name: "Autofill" })]);
+      favoriteCiphers$.next([makeCipher({ id: "f", name: "Favorite" })]);
+      filteredCiphers$.next([
+        makeCipher({ id: "m1", name: "Match 1" }),
+        makeCipher({ id: "m2", name: "Match 2" }),
+      ]);
+      hasSearchText$.next(true);
+
+      const rows = await firstValueFrom(service.rows$);
+
+      expect(rows).toHaveLength(2);
+      expect(rows.every((r) => r._section === "allItems")).toBe(true);
+      expect(rows.map((r) => r.cipher.name)).toEqual(["Match 1", "Match 2"]);
+    });
+
+    it("is empty when there are no ciphers", async () => {
+      expect(await firstValueFrom(service.rows$)).toEqual([]);
+    });
+
+    it("tags rows without mutating the source ciphers", async () => {
+      const original = makeCipher({ id: "i", name: "All Items" });
+      filteredCiphers$.next([original]);
+
+      const rows = await firstValueFrom(service.rows$);
+
+      expect((original as unknown as { _section?: string })._section).toBeUndefined();
+      expect(rows[0]._section).toBe("allItems");
+    });
+  });
+
+  describe("row actions", () => {
+    // The action context streams seed themselves with `startWith`, so `rows$` emits a seeded value
+    // before settling. Read the latest synchronous emission (as `toSignal` does), not the first.
+    const latestRows = () => {
+      let latest: any[] = [];
+      service.rows$.subscribe((rows) => (latest = rows)).unsubscribe();
+      return latest;
+    };
+    const autofillRow = () => {
+      autoFillCiphers$.next([makeCipher({ id: "a" })]);
+      return latestRows()[0].actions;
+    };
+    const sectionRow = (section: "favorites" | "allItems") => {
+      (section === "favorites" ? favoriteCiphers$ : filteredCiphers$).next([
+        makeCipher({ id: section }),
+      ]);
+      return latestRows().find((r) => r._section === section)!.actions;
+    };
+
+    describe("simplified item action (feature flag on)", () => {
+      beforeEach(() => {
+        simplifiedItemActionEnabled$.next(true);
+        currentTabIsOnBlocklist$.next(false);
+      });
+
+      it("fills autofill-section rows on click and offers View (not Autofill) in the menu", async () => {
+        expect(autofillRow()).toMatchObject({
+          primaryAutofill: true,
+          showFillOnHover: true,
+          showLaunch: false,
+          showAutofillInMenu: false,
+          showViewInMenu: true,
+          showAutofillBadge: false,
+        });
+      });
+
+      it("views favorites/all-items rows on click and offers Autofill (not View) in the menu", async () => {
+        expect(sectionRow("favorites")).toMatchObject({
+          primaryAutofill: false,
+          showFillOnHover: false,
+          showLaunch: true,
+          showAutofillInMenu: true,
+          showViewInMenu: false,
+        });
+      });
+
+      it("never fills on click when the current URI is blocked", async () => {
+        currentTabIsOnBlocklist$.next(true);
+        expect(autofillRow()).toMatchObject({ primaryAutofill: false, showFillOnHover: false });
+      });
+    });
+
+    describe("legacy autofill affordance (feature flag off)", () => {
+      beforeEach(() => {
+        simplifiedItemActionEnabled$.next(false);
+      });
+
+      it("shows the Fill chip on autofill rows when click-to-autofill is off and the URI isn't blocked", async () => {
+        clickItemsToAutofillVaultView$.next(false);
+        expect(autofillRow()).toMatchObject({ showAutofillBadge: true, primaryAutofill: false });
+        expect(sectionRow("favorites")).toMatchObject({ showAutofillBadge: false });
+      });
+
+      it("hides the Fill chip and fills on click when click-to-autofill is on", async () => {
+        clickItemsToAutofillVaultView$.next(true);
+        expect(autofillRow()).toMatchObject({ showAutofillBadge: false, primaryAutofill: true });
+      });
+
+      it("hides the Fill chip and never autofills when the URI is blocked", async () => {
+        clickItemsToAutofillVaultView$.next(false);
+        currentTabIsOnBlocklist$.next(true);
+        expect(autofillRow()).toMatchObject({ showAutofillBadge: false, primaryAutofill: false });
+      });
+
+      it("offers Autofill in the menu for non-autofill rows only", async () => {
+        expect(autofillRow()).toMatchObject({ showAutofillInMenu: false });
+        expect(sectionRow("favorites")).toMatchObject({ showAutofillInMenu: true });
+      });
+    });
+
+    describe("titleKey", () => {
+      it("uses the autofill title (named field when a username is present) for fill-on-click rows", async () => {
+        simplifiedItemActionEnabled$.next(true);
+        jest.spyOn(CipherViewLikeUtils, "getLogin").mockReturnValue({ username: "user" } as any);
+        expect(autofillRow().titleKey).toBe("autofillTitleWithField");
+      });
+
+      it("uses the view title for view-on-click rows without a username field", async () => {
+        jest.spyOn(CipherViewLikeUtils, "getLogin").mockReturnValue({ username: null } as any);
+        expect(sectionRow("allItems").titleKey).toBe("viewItemTitle");
+      });
+    });
+  });
+
+  describe("hasSearchText$", () => {
+    it("passes through the items service value", async () => {
+      hasSearchText$.next(true);
+      expect(await firstValueFrom(service.hasSearchText$)).toBe(true);
+    });
+  });
+
+  describe("applyFilterOnInput", () => {
+    it("applies the search term to the vault after the debounce interval", fakeAsync(() => {
+      const input$ = new Subject<string>();
+      const sub = service.applyFilterOnInput(input$).subscribe();
+
+      input$.next("git");
+      expect(applyFilter).not.toHaveBeenCalled();
+
+      tick(SearchTextDebounceInterval);
+      expect(applyFilter).toHaveBeenCalledWith("git");
+
+      sub.unsubscribe();
+    }));
+
+    it("applies immediately (no debounce) while the vault is loading", fakeAsync(() => {
+      loading$.next(true);
+      const input$ = new Subject<string>();
+      const sub = service.applyFilterOnInput(input$).subscribe();
+
+      input$.next("git");
+      tick(0);
+      expect(applyFilter).toHaveBeenCalledWith("git");
+
+      sub.unsubscribe();
+    }));
+  });
+
+  describe("doAutofill", () => {
+    it("autofills a full CipherView directly", async () => {
+      jest.spyOn(CipherViewLikeUtils, "isCipherListView").mockReturnValue(false);
+      const cipher = makeCipher();
+
+      await service.doAutofill(cipher);
+
+      expect(vaultPopupAutofillService.doAutofill).toHaveBeenCalledWith(cipher);
+      expect(cipherService.cipherView$).not.toHaveBeenCalled();
+    });
+
+    it("fetches the full cipher view before autofilling a CipherListView", async () => {
+      jest.spyOn(CipherViewLikeUtils, "isCipherListView").mockReturnValue(true);
+      const fullView = makeCipher({ id: "full" });
+      cipherService.cipherView$.mockReturnValue(of(fullView as any));
+
+      await service.doAutofill(makeCipher());
+
+      expect(vaultPopupAutofillService.doAutofill).toHaveBeenCalledWith(fullView);
+    });
+
+    it("does not autofill when the full cipher view cannot be resolved", async () => {
+      jest.spyOn(CipherViewLikeUtils, "isCipherListView").mockReturnValue(true);
+      cipherService.cipherView$.mockReturnValue(of(null as any));
+
+      await service.doAutofill(makeCipher());
+
+      expect(vaultPopupAutofillService.doAutofill).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("viewCipher", () => {
+    beforeEach(() => {
+      // Navigate immediately (no double-click launch delay) unless a test overrides it.
+      jest.spyOn(CipherViewLikeUtils, "canLaunch").mockReturnValue(false);
+    });
+
+    it("navigates to view-cipher when the password reprompt passes", fakeAsync(() => {
+      jest.spyOn(CipherViewLikeUtils, "decryptionFailure").mockReturnValue(false);
+      passwordRepromptService.passwordRepromptCheck.mockResolvedValue(true);
+
+      void service.viewCipher(makeCipher({ id: "c1", type: CipherType.Login }));
+      tick();
+
+      expect(router.navigate).toHaveBeenCalledWith(["/view-cipher"], {
+        queryParams: { cipherId: "c1", type: CipherType.Login },
+      });
+    }));
+
+    it("does not navigate when the password reprompt fails", fakeAsync(() => {
+      jest.spyOn(CipherViewLikeUtils, "decryptionFailure").mockReturnValue(false);
+      passwordRepromptService.passwordRepromptCheck.mockResolvedValue(false);
+
+      void service.viewCipher(makeCipher());
+      tick();
+
+      expect(router.navigate).not.toHaveBeenCalled();
+    }));
+
+    it("opens the decryption-failure dialog and skips navigation on decryption failure", fakeAsync(() => {
+      jest.spyOn(CipherViewLikeUtils, "decryptionFailure").mockReturnValue(true);
+      const openSpy = jest
+        .spyOn(DecryptionFailureDialogComponent, "open")
+        .mockReturnValue({} as any);
+
+      void service.viewCipher(makeCipher({ id: "c1" }));
+      tick();
+
+      expect(openSpy).toHaveBeenCalled();
+      expect(router.navigate).not.toHaveBeenCalled();
+    }));
+
+    it("ignores a second view request while one is already pending", fakeAsync(() => {
+      jest.spyOn(CipherViewLikeUtils, "decryptionFailure").mockReturnValue(false);
+      passwordRepromptService.passwordRepromptCheck.mockResolvedValue(true);
+
+      void service.viewCipher(makeCipher({ id: "first" }));
+      void service.viewCipher(makeCipher({ id: "second" }));
+      tick();
+
+      expect(router.navigate).toHaveBeenCalledTimes(1);
+      expect(router.navigate).toHaveBeenCalledWith(["/view-cipher"], {
+        queryParams: { cipherId: "first", type: CipherType.Login },
+      });
+    }));
+  });
+
+  describe("launchCipher", () => {
+    it("does nothing when the cipher cannot launch", async () => {
+      jest.spyOn(CipherViewLikeUtils, "canLaunch").mockReturnValue(false);
+      jest.spyOn(CipherViewLikeUtils, "getLaunchUri").mockReturnValue(undefined);
+
+      await service.launchCipher(makeCipher());
+
+      expect(cipherService.updateLastLaunchedDate).not.toHaveBeenCalled();
+    });
+
+    it("updates the last-launched date and opens a new tab", async () => {
+      jest.spyOn(CipherViewLikeUtils, "canLaunch").mockReturnValue(true);
+      jest.spyOn(CipherViewLikeUtils, "getLaunchUri").mockReturnValue("https://example.com");
+      const newTab = jest.spyOn(BrowserApi, "createNewTab").mockResolvedValue({} as any);
+      jest.spyOn(BrowserPopupUtils, "inPopup").mockReturnValue(false);
+
+      await service.launchCipher(makeCipher({ id: "c1" }));
+
+      expect(cipherService.updateLastLaunchedDate).toHaveBeenCalledWith("c1", "user-1");
+      expect(newTab).toHaveBeenCalledWith("https://example.com");
+    });
+  });
+});

--- a/apps/browser/src/vault/popup/services/vault-popup-list-table.service.ts
+++ b/apps/browser/src/vault/popup/services/vault-popup-list-table.service.ts
@@ -1,0 +1,318 @@
+import { inject, Injectable, NgZone } from "@angular/core";
+import { Router } from "@angular/router";
+import {
+  combineLatest,
+  debounce,
+  distinctUntilChanged,
+  firstValueFrom,
+  map,
+  Observable,
+  startWith,
+  tap,
+  timer,
+} from "rxjs";
+
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { getUserId } from "@bitwarden/common/auth/services/account.service";
+import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
+import { uuidAsString } from "@bitwarden/common/platform/abstractions/sdk/sdk.service";
+import { CipherId } from "@bitwarden/common/types/guid";
+import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
+import { VaultSettingsService } from "@bitwarden/common/vault/abstractions/vault-settings/vault-settings.service";
+import { SearchTextDebounceInterval } from "@bitwarden/common/vault/services/search.service";
+import {
+  CipherViewLike,
+  CipherViewLikeUtils,
+} from "@bitwarden/common/vault/utils/cipher-view-like-utils";
+import { DialogService } from "@bitwarden/components";
+import { DecryptionFailureDialogComponent, PasswordRepromptService } from "@bitwarden/vault";
+
+import { BrowserApi } from "../../../platform/browser/browser-api";
+import BrowserPopupUtils from "../../../platform/browser/browser-popup-utils";
+import { PopupCipherViewLike } from "../views/popup-cipher.view";
+
+import { VaultPopupAutofillService } from "./vault-popup-autofill.service";
+import { VaultPopupItemsService } from "./vault-popup-items.service";
+import { VaultPopupLoadingService } from "./vault-popup-loading.service";
+
+/** The section a row belongs to within the vault list table. */
+export type VaultSection = "autofill" | "favorites" | "allItems";
+
+/**
+ * The resolved action affordances for a single row — which click action it takes and which
+ * buttons/menu entries it exposes. Precomputed here so the template stays declarative and the
+ * feature-flag/blocklist branching lives in one testable place.
+ */
+export interface VaultRowActions {
+  /** Whether clicking the row autofills (vs. navigating to view). */
+  primaryAutofill: boolean;
+  /** Reveal the "Fill" text on hover — simplified (flag-on) design only. */
+  showFillOnHover: boolean;
+  /** Show the standalone primary "Fill" chip — legacy (flag-off) design only. */
+  showAutofillBadge: boolean;
+  /** Show the launch-in-new-tab button (still gated on the cipher being launchable). */
+  showLaunch: boolean;
+  /** Offer "Autofill" in the more-options menu. */
+  showAutofillInMenu: boolean;
+  /** Offer "View" in the more-options menu. */
+  showViewInMenu: boolean;
+  /** Resolved i18n key for the row's accessible title. */
+  titleKey: string;
+}
+
+/** A cipher tagged with the section it renders under and its resolved actions; the row model. */
+export type VaultTableRow = {
+  cipher: PopupCipherViewLike;
+  _section: VaultSection;
+  actions: VaultRowActions;
+};
+
+/** Feature-flag, blocklist, and click-setting inputs that decide a row's action affordances. */
+interface RowActionContext {
+  simplifiedItemActionEnabled: boolean;
+  currentUriIsBlocked: boolean;
+  clickItemsToAutofillVaultView: boolean;
+}
+
+/**
+ * Derives the ordered, section-tagged rows for the vault list table and encapsulates the primary
+ * interactions a user can perform on a row (autofill, launch, and view). Kept independent of the
+ * component so the section/search-branching behavior and item actions can be tested in isolation.
+ */
+@Injectable({
+  providedIn: "root",
+})
+export class VaultPopupListTableService {
+  private readonly vaultPopupItemsService = inject(VaultPopupItemsService);
+  private readonly vaultPopupLoadingService = inject(VaultPopupLoadingService);
+  private readonly ngZone = inject(NgZone);
+  private readonly cipherService = inject(CipherService);
+  private readonly accountService = inject(AccountService);
+  private readonly passwordRepromptService = inject(PasswordRepromptService);
+  private readonly dialogService = inject(DialogService);
+  private readonly router = inject(Router);
+  private readonly vaultPopupAutofillService = inject(VaultPopupAutofillService);
+  private readonly configService = inject(ConfigService);
+  private readonly vaultSettingsService = inject(VaultSettingsService);
+
+  /**
+   * Timeout used to add a small delay when selecting a cipher to allow for double click to launch.
+   */
+  private viewCipherTimeout?: number;
+
+  /** The search text currently applied to the vault (e.g. restored from stored state). */
+  readonly searchText$ = this.vaultPopupItemsService.searchText$;
+
+  /** Whether a search term is currently narrowing the vault list. */
+  readonly hasSearchText$ = this.vaultPopupItemsService.hasSearchText$;
+
+  /**
+   * The inputs that decide each row's action affordances. `startWith` defaults keep {@link rows$}
+   * emitting promptly: the feature flag and blocklist streams resolve asynchronously, so without a
+   * seed the whole list would wait on them before first render.
+   */
+  private readonly rowActionContext$: Observable<RowActionContext> = combineLatest([
+    this.configService
+      .getFeatureFlag$(FeatureFlag.PM31039ItemActionInExtension)
+      .pipe(startWith(false)),
+    this.vaultPopupAutofillService.currentTabIsOnBlocklist$.pipe(startWith(false)),
+    this.vaultSettingsService.clickItemsToAutofillVaultView$.pipe(startWith(true)),
+  ]).pipe(
+    map(([simplifiedItemActionEnabled, currentUriIsBlocked, clickItemsToAutofillVaultView]) => ({
+      simplifiedItemActionEnabled,
+      currentUriIsBlocked,
+      clickItemsToAutofillVaultView: clickItemsToAutofillVaultView ?? true,
+    })),
+  );
+
+  /**
+   * The rows to render, in display order. When a search is active the list collapses to a single
+   * flat "all items" section (mirroring the existing vault, which folds every filtered cipher into
+   * one container); otherwise it splits into the autofill, favorites, and all-items sections.
+   */
+  readonly rows$: Observable<VaultTableRow[]> = combineLatest([
+    this.vaultPopupItemsService.autoFillCiphers$,
+    this.vaultPopupItemsService.favoriteCiphers$,
+    this.vaultPopupItemsService.filteredCiphers$,
+    this.vaultPopupItemsService.hasSearchText$,
+    this.rowActionContext$,
+  ]).pipe(
+    map(([autoFillCiphers, favoriteCiphers, filteredCiphers, hasSearchText, context]) => {
+      if (hasSearchText) {
+        return filteredCiphers.map((cipher) => this.toRow(cipher, "allItems", context));
+      }
+
+      return [
+        ...autoFillCiphers.map((cipher) => this.toRow(cipher, "autofill", context)),
+        ...favoriteCiphers.map((cipher) => this.toRow(cipher, "favorites", context)),
+        ...filteredCiphers.map((cipher) => this.toRow(cipher, "allItems", context)),
+      ];
+    }),
+  );
+
+  private toRow(
+    cipher: PopupCipherViewLike,
+    section: VaultSection,
+    context: RowActionContext,
+  ): VaultTableRow {
+    return {
+      cipher,
+      _section: section,
+      actions: this.resolveActions(cipher, section, context),
+    };
+  }
+
+  /**
+   * Resolves a row's action affordances from its section and the current context. Pure so the
+   * feature-flag/blocklist branching can be exercised directly. The `simplifiedItemActionEnabled`
+   * (flag-off) branch mirrors the pre-flag `vault-list-items-container` behavior and can be removed
+   * once {@link FeatureFlag.PM31039ItemActionInExtension} is fully rolled out.
+   */
+  private resolveActions(
+    cipher: PopupCipherViewLike,
+    section: VaultSection,
+    {
+      simplifiedItemActionEnabled,
+      currentUriIsBlocked,
+      clickItemsToAutofillVaultView,
+    }: RowActionContext,
+  ): VaultRowActions {
+    const isAutofill = section === "autofill";
+
+    // Whether clicking the row autofills. Simplified: the autofill section fills unless the URI is
+    // blocked. Legacy: the autofill section fills only when the user's click-to-autofill setting is
+    // on, and never when the URI is blocked.
+    const primaryAutofill = simplifiedItemActionEnabled
+      ? isAutofill && !currentUriIsBlocked
+      : !currentUriIsBlocked && isAutofill && clickItemsToAutofillVaultView;
+
+    const login = CipherViewLikeUtils.getLogin(cipher as CipherViewLike);
+    const titleBase = primaryAutofill ? "autofillTitle" : "viewItemTitle";
+
+    return {
+      primaryAutofill,
+      showFillOnHover: simplifiedItemActionEnabled && primaryAutofill,
+      // Legacy standalone chip: shown on autofill rows when click-to-autofill is off and not blocked.
+      showAutofillBadge:
+        !simplifiedItemActionEnabled &&
+        isAutofill &&
+        !currentUriIsBlocked &&
+        !clickItemsToAutofillVaultView,
+      showLaunch: !isAutofill,
+      showAutofillInMenu: simplifiedItemActionEnabled
+        ? !primaryAutofill
+        : !currentUriIsBlocked && !isAutofill,
+      showViewInMenu: primaryAutofill,
+      // Name the login's username field in the label when it has one.
+      titleKey: login?.username != null ? `${titleBase}WithField` : titleBase,
+    };
+  }
+
+  /**
+   * Applies debounced search input to the vault, mirroring the existing vault search behavior:
+   * applied immediately while the vault is loading (to avoid stale results), otherwise debounced by
+   * {@link SearchTextDebounceInterval}. Returns a stream the caller subscribes to (and tears down)
+   * so the subscription stays tied to the consuming component's lifecycle.
+   */
+  applyFilterOnInput(searchText$: Observable<string>): Observable<string> {
+    return combineLatest([searchText$, this.vaultPopupLoadingService.loading$]).pipe(
+      debounce(([, isLoading]) => timer(isLoading ? 0 : SearchTextDebounceInterval)),
+      distinctUntilChanged(
+        ([prevText, prevLoading], [newText, newLoading]) =>
+          prevText === newText && prevLoading === newLoading,
+      ),
+      map(([text]) => text),
+      tap((text) =>
+        this.ngZone.runOutsideAngular(() =>
+          this.ngZone.run(() => this.vaultPopupItemsService.applyFilter(text)),
+        ),
+      ),
+    );
+  }
+
+  /**
+   * Refreshes the current tab so the autofill suggestions repopulate. Used by the sidebar, which
+   * stays open across navigations and can otherwise show stale suggestions.
+   */
+  refreshCurrentTab() {
+    this.vaultPopupAutofillService.refreshCurrentTab();
+  }
+
+  /**
+   * Launches the login cipher in a new browser tab.
+   */
+  async launchCipher(cipher: CipherViewLike) {
+    const launchURI = CipherViewLikeUtils.getLaunchUri(cipher);
+    if (!CipherViewLikeUtils.canLaunch(cipher) || !launchURI) {
+      return;
+    }
+
+    // If there is a view action pending, clear it
+    if (this.viewCipherTimeout != null) {
+      window.clearTimeout(this.viewCipherTimeout);
+      this.viewCipherTimeout = undefined;
+    }
+
+    const activeUserId = await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId));
+    await this.cipherService.updateLastLaunchedDate(uuidAsString(cipher.id!), activeUserId);
+
+    await BrowserApi.createNewTab(launchURI);
+
+    if (BrowserPopupUtils.inPopup(window)) {
+      BrowserApi.closePopup(window);
+    }
+  }
+
+  async doAutofill(cipher: PopupCipherViewLike) {
+    if (!CipherViewLikeUtils.isCipherListView(cipher)) {
+      await this.vaultPopupAutofillService.doAutofill(cipher);
+      return;
+    }
+
+    // When only the `CipherListView` is available, fetch the full cipher details
+    const activeUserId = await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId));
+    const cipherView = await firstValueFrom(
+      this.cipherService.cipherView$(activeUserId, uuidAsString(cipher.id!) as CipherId),
+    );
+
+    if (!cipherView) {
+      return;
+    }
+
+    await this.vaultPopupAutofillService.doAutofill(cipherView);
+  }
+
+  async viewCipher(cipher: PopupCipherViewLike) {
+    // We already have a view action in progress, don't start another
+    if (this.viewCipherTimeout != null) {
+      return;
+    }
+
+    // Wrap in a timeout to allow for double click to launch
+    this.viewCipherTimeout = window.setTimeout(
+      async () => {
+        try {
+          if (CipherViewLikeUtils.decryptionFailure(cipher)) {
+            DecryptionFailureDialogComponent.open(this.dialogService, {
+              cipherIds: [cipher.id as CipherId],
+            });
+            return;
+          }
+
+          const repromptPassed = await this.passwordRepromptService.passwordRepromptCheck(cipher);
+          if (!repromptPassed) {
+            return;
+          }
+          await this.router.navigate(["/view-cipher"], {
+            queryParams: { cipherId: cipher.id, type: cipher.type },
+          });
+        } finally {
+          // Ensure the timeout is always cleared
+          this.viewCipherTimeout = undefined;
+        }
+      },
+      CipherViewLikeUtils.canLaunch(cipher) ? 200 : 0,
+    );
+  }
+}

--- a/libs/components/src/table/v2/bit-row-group.component.spec.ts
+++ b/libs/components/src/table/v2/bit-row-group.component.spec.ts
@@ -1,0 +1,82 @@
+import { ChangeDetectionStrategy, Component, signal } from "@angular/core";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { By } from "@angular/platform-browser";
+
+import { BitRowGroupComponent } from "./bit-row-group.component";
+import { BitTableV2Component } from "./table-v2.component";
+
+@Component({
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [BitRowGroupComponent],
+  template: `
+    <bit-row-group
+      collapsible
+      [match]="match"
+      [collapsed]="collapsed()"
+      (collapsedChange)="onCollapsedChange($event)"
+    >
+      Header
+    </bit-row-group>
+  `,
+})
+class TestHostComponent {
+  match = (_row: unknown) => true;
+  readonly collapsed = signal(false);
+  changes: boolean[] = [];
+
+  // Mirror a real two-way consumer: record the emission and update the bound source so the
+  // one-way `[collapsed]` input doesn't revert the group on the next change detection.
+  onCollapsedChange(value: boolean) {
+    this.changes.push(value);
+    this.collapsed.set(value);
+  }
+}
+
+describe("BitRowGroupComponent", () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+  let host: TestHostComponent;
+  let group: BitRowGroupComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+      providers: [
+        // The group registers itself with the nearest table via DI; a stub is all it needs here.
+        {
+          provide: BitTableV2Component,
+          useValue: { registerGroup: () => {}, unregisterGroup: () => {} },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    host = fixture.componentInstance;
+    fixture.detectChanges();
+    group = fixture.debugElement.query(By.directive(BitRowGroupComponent)).componentInstance;
+  });
+
+  it("is not collapsed by default", () => {
+    expect(group.collapsed()).toBe(false);
+  });
+
+  it("reflects the seeded collapsed input without emitting", () => {
+    host.collapsed.set(true);
+    fixture.detectChanges();
+
+    expect(group.collapsed()).toBe(true);
+    expect(host.changes).toEqual([]);
+  });
+
+  it("flips the state and emits when toggled", () => {
+    group.toggle();
+    fixture.detectChanges();
+    expect(group.collapsed()).toBe(true);
+    expect(host.changes).toEqual([true]);
+
+    group.toggle();
+    fixture.detectChanges();
+    expect(group.collapsed()).toBe(false);
+    expect(host.changes).toEqual([true, false]);
+  });
+});

--- a/libs/components/src/table/v2/bit-row-group.component.ts
+++ b/libs/components/src/table/v2/bit-row-group.component.ts
@@ -6,6 +6,7 @@ import {
   forwardRef,
   inject,
   input,
+  model,
   signal,
   TemplateRef,
   viewChild,
@@ -34,14 +35,16 @@ export class BitRowGroupComponent<T = unknown> {
   /** When set, the header becomes a toggle that collapses the group's rows (open by default). */
   readonly collapsible = input(false, { transform: booleanAttribute });
 
-  private readonly _collapsed = signal(false);
-
-  /** Whether the group's rows are currently hidden. Only meaningful when {@link collapsible}. */
-  readonly collapsed = this._collapsed.asReadonly();
+  /**
+   * Whether the group's rows are currently hidden. Only meaningful when {@link collapsible}.
+   * Two-way bindable (`[(collapsed)]`) so a consumer can seed the initial state and persist
+   * changes when the user toggles the header.
+   */
+  readonly collapsed = model(false);
 
   /** Flips the collapsed state; the table re-derives its render list. */
   toggle(): void {
-    this._collapsed.update((collapsed) => !collapsed);
+    this.collapsed.update((collapsed) => !collapsed);
   }
 
   /** The projected header label, stamped by `<bit-table-v2>` once per non-empty group. */

--- a/libs/components/src/table/v2/bit-row.component.ts
+++ b/libs/components/src/table/v2/bit-row.component.ts
@@ -49,7 +49,9 @@ export class BitRowComponent {
     const layout = "tw-group/row tw-grid tw-grid-flow-col tw-auto-cols-fr";
     if (this.table?.presentation() === "list") {
       // `list` rows size to content off a `bit-item`-style minimum height.
-      return `${layout} tw-min-h-9 tw-mb-1.5 tw-rounded-lg tw-bg-background tw-border-0 tw-border-b tw-border-solid tw-border-b-shadow hover:tw-bg-hover-default`;
+      // `tw-relative` lets a cell's primary action stretch a click target over
+      // the whole row (see the stretched `::after` overlay pattern in cells).
+      return `${layout} tw-relative tw-min-h-9 tw-mb-1.5 tw-rounded-lg tw-bg-background tw-border-0 tw-border-b tw-border-solid tw-border-b-shadow hover:tw-bg-hover-default`;
     }
     // `table` rows own the fixed row height; cells stretch to fill it and center content.
     return `${layout} tw-h-16 tw-border-0 tw-border-t tw-border-solid tw-border-border-base first:tw-border-t-0`;

--- a/libs/components/src/table/v2/bit-row.component.ts
+++ b/libs/components/src/table/v2/bit-row.component.ts
@@ -49,9 +49,7 @@ export class BitRowComponent {
     const layout = "tw-group/row tw-grid tw-grid-flow-col tw-auto-cols-fr";
     if (this.table?.presentation() === "list") {
       // `list` rows size to content off a `bit-item`-style minimum height.
-      // `tw-relative` lets a cell's primary action stretch a click target over
-      // the whole row (see the stretched `::after` overlay pattern in cells).
-      return `${layout} tw-relative tw-min-h-9 tw-mb-1.5 tw-rounded-lg tw-bg-background tw-border-0 tw-border-b tw-border-solid tw-border-b-shadow hover:tw-bg-hover-default`;
+      return `${layout} tw-min-h-9 tw-mb-1.5 tw-rounded-lg tw-bg-background tw-border-0 tw-border-b tw-border-solid tw-border-b-shadow hover:tw-bg-hover-default`;
     }
     // `table` rows own the fixed row height; cells stretch to fill it and center content.
     return `${layout} tw-h-16 tw-border-0 tw-border-t tw-border-solid tw-border-border-base first:tw-border-t-0`;

--- a/libs/components/src/table/v2/table-v2.stories.ts
+++ b/libs/components/src/table/v2/table-v2.stories.ts
@@ -831,6 +831,43 @@ export const GroupedVirtualized: Story = {
   }),
 };
 
+/**
+ * A group's `collapsed` state is a two-way model. A consumer can seed the initial state with
+ * `[collapsed]` — here the "Cards" group starts collapsed — and persist user toggles by listening
+ * to `(collapsedChange)`.
+ */
+export const GroupedInitiallyCollapsed: Story = {
+  render: () => ({
+    props: {
+      table: groupedTable,
+      trackBy: (_: number, item: GroupedRow) => item.id,
+      isLogin: (row: GroupedRow) => row.type === "login",
+      isCard: (row: GroupedRow) => row.type === "card",
+      isNote: (row: GroupedRow) => row.type === "note",
+    },
+    template: `
+      <bit-layout>
+        <bit-table-v2
+          [tableDef]="table"
+          presentation="list"
+          [virtualRowHeight]="44"
+          [trackBy]="trackBy"
+          [height]="8"
+        >
+          <bit-column sortable defaultSort="asc">
+            <bit-header-cell>Name</bit-header-cell>
+            <bit-cell *bitCellDef="table.columns.name; let row">{{ row.name }}</bit-cell>
+          </bit-column>
+
+          <bit-row-group collapsible [match]="isLogin">Logins</bit-row-group>
+          <bit-row-group collapsible [collapsed]="true" [match]="isCard">Cards</bit-row-group>
+          <bit-row-group collapsible [match]="isNote">Notes</bit-row-group>
+        </bit-table-v2>
+      </bit-layout>
+    `,
+  }),
+};
+
 type WideRow = {
   id: number;
   name: string;


### PR DESCRIPTION
## 🎟️ Tracking

[PM-40326](https://bitwarden.atlassian.net/browse/PM-40326)

## 📔 Objective

Introduces a new bit-table-v2-based list view for the browser vault popup (`vault-popup-list-table`).
- Persists existing styles and functionality 
- Includes search integration, filtering will come in future work
- Removes the autofill suggestion info icon, waiting for confirmation in slack.

@bitwarden/team-ui-foundation two changes to maintain existing functionality that I thought were easy adds here. If you'd like me to pull them out separately I can! 
- Adds the ability for a consumer to control the collapsed state, we currently save this to disk on the extension
- ~~Changed the styling on the row a bit so the focus state covers the entire cell rather than just item itself.~~

## 📸 Screenshots

|Sidebar Refresh|Blocked URI|Loading|Default|
|-|-|-|-|
|<img width="786" height="549" alt="Screenshot 2026-08-06 at 10 33 06 AM" src="https://github.com/user-attachments/assets/a9e0f923-0641-462c-8f31-cf697694660a" />|<img width="750" height="534" alt="Screenshot 2026-08-06 at 10 28 09 AM" src="https://github.com/user-attachments/assets/bc84f230-e588-43f5-bcd5-635485e07842" />|<img width="744" height="289" alt="Screenshot 2026-08-06 at 10 27 44 AM" src="https://github.com/user-attachments/assets/5ac5c7ba-501e-46ad-a70c-6c7a4d4a3fff" />|<img width="750" height="558" alt="Screenshot 2026-08-06 at 10 27 40 AM" src="https://github.com/user-attachments/assets/a17f8373-6674-4ca0-80b7-a88b7f1068e7" />|

[PM-40326]: https://bitwarden.atlassian.net/browse/PM-40326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ