### PR TITLE
[PM-40734] Settings Collection Terminology changes

### DIFF
--- a/apps/web/src/app/admin-console/organizations/settings/account.component.html
+++ b/apps/web/src/app/admin-console/organizations/settings/account.component.html
@@ -56,24 +56,43 @@
     [bitSubmit]="submitCollectionManagement"
     [formGroup]="collectionManagementFormGroup"
   >
-    <h1 bitTypography="h1" class="tw-mt-16 tw-pb-2.5">{{ "collectionManagement" | i18n }}</h1>
-    <p bitTypography="body1">{{ "collectionManagementDescription" | i18n }}</p>
+    <h1 bitTypography="h1" class="tw-mt-16 tw-pb-2.5">
+      {{ "collectionManagement" | vfo1I18n: "sharedFolderManagement" }}
+    </h1>
+    <p bitTypography="body1">
+      {{ "collectionManagementDescription" | vfo1I18n: "sharedFolderManagementDescription" }}
+    </p>
     <bit-form-control>
-      <bit-label>{{ "allowAdminAccessToAllCollectionItemsDescription" | i18n }}</bit-label>
+      <bit-label>
+        {{
+          "allowAdminAccessToAllCollectionItemsDescription"
+            | vfo1I18n: "allowAdminAccessToAllSharedFoldersDescription"
+        }}
+      </bit-label>
       <input type="checkbox" bitCheckbox formControlName="allowAdminAccessToAllCollectionItems" />
     </bit-form-control>
     <bit-form-control>
-      <bit-label>{{ "restrictCollectionCreationDescription" | i18n }}</bit-label>
+      <bit-label>
+        {{
+          "restrictCollectionCreationDescription"
+            | vfo1I18n: "restrictSharedFolderCreationDescription"
+        }}
+      </bit-label>
       <input type="checkbox" bitCheckbox formControlName="limitCollectionCreation" />
     </bit-form-control>
     <bit-form-control>
-      <bit-label>{{ "restrictCollectionDeletionDescription" | i18n }}</bit-label>
+      <bit-label>
+        {{
+          "restrictCollectionDeletionDescription"
+            | vfo1I18n: "restrictSharedFolderDeletionDescription"
+        }}
+      </bit-label>
       <input type="checkbox" bitCheckbox formControlName="limitCollectionDeletion" />
     </bit-form-control>
     <bit-form-control>
       <bit-label>
         {{ "restrictItemDeletionDescriptionStart" | i18n }}
-        <span class="tw-italic">{{ "manageCollection" | i18n }}</span>
+        <span class="tw-italic">{{ "manageCollection" | vfo1I18n: "manage" }}</span>
         {{ "restrictItemDeletionDescriptionEnd" | i18n }}
       </bit-label>
       <input type="checkbox" bitCheckbox formControlName="limitItemDeletion" />

--- a/apps/web/src/app/admin-console/organizations/settings/account.component.html
+++ b/apps/web/src/app/admin-console/organizations/settings/account.component.html
@@ -61,6 +61,17 @@
     </h1>
     <p bitTypography="body1">
       {{ "collectionManagementDescription" | vfo1I18n: "sharedFolderManagementDescription" }}
+      <a
+        bitLink
+        href="https://bitwarden.com/help/collection-management/"
+        target="_blank"
+        rel="noreferrer"
+      >
+        {{
+          "learnMoreAboutCollectionManagement" | vfo1I18n: "learnMoreAboutSharedFolderManagement"
+        }}
+        <bit-icon name="bwi-external-link"></bit-icon>
+      </a>
     </p>
     <bit-form-control>
       <bit-label>

--- a/apps/web/src/app/admin-console/organizations/settings/account.component.stories.ts
+++ b/apps/web/src/app/admin-console/organizations/settings/account.component.stories.ts
@@ -1,0 +1,145 @@
+import { importProvidersFrom } from "@angular/core";
+import { ActivatedRoute, Router } from "@angular/router";
+import { applicationConfig, Meta, moduleMetadata, StoryObj } from "@storybook/angular";
+import { of } from "rxjs";
+
+import { TwoFactorIconComponent } from "@bitwarden/angular/auth/components/two-factor-icon.component";
+import { PremiumBadgeComponent } from "@bitwarden/angular/billing/components/premium-badge";
+import { OrganizationApiServiceAbstraction } from "@bitwarden/common/admin-console/abstractions/organization/organization-api.service.abstraction";
+import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
+import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
+import { OrganizationKeysResponse } from "@bitwarden/common/admin-console/models/response/organization-keys.response";
+import { OrganizationResponse } from "@bitwarden/common/admin-console/models/response/organization.response";
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
+import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
+import { OrganizationId, UserId } from "@bitwarden/common/types/guid";
+import { DialogService, ItemModule, ToastService } from "@bitwarden/components";
+import { KeyService } from "@bitwarden/key-management";
+import { Vfo1I18nPipe } from "@bitwarden/vault";
+
+import { DangerZoneComponent } from "../../../auth/settings/account/danger-zone.component";
+import { PreloadedEnglishI18nModule } from "../../../core/tests";
+import { AccountFingerprintComponent } from "../../../key-management/account-fingerprint/account-fingerprint.component";
+import { HeaderModule } from "../../../layouts/header/header.module";
+import { SharedModule } from "../../../shared";
+
+import { AccountComponent } from "./account.component";
+
+const ORG_ID = "org-1" as OrganizationId;
+const USER_ID = "user-1" as UserId;
+
+const mockOrganization = Object.assign(new Organization(), {
+  id: ORG_ID,
+  name: "Acme Corp",
+  canEditSubscription: false,
+  useApi: false,
+});
+
+const mockOrganizationResponse = new OrganizationResponse({
+  id: ORG_ID,
+  name: "Acme Corp",
+  billingEmail: "billing@acme.com",
+  hasPublicAndPrivateKeys: true,
+  useApi: false,
+  limitCollectionCreation: false,
+  limitCollectionDeletion: false,
+  limitItemDeletion: false,
+  allowAdminAccessToAllCollectionItems: true,
+});
+
+const mockOrganizationKeysResponse = new OrganizationKeysResponse({
+  publicKey: "cHVibGljS2V5",
+});
+
+const mockActivatedRoute = {
+  params: of({ organizationId: ORG_ID }),
+};
+
+const mockPlatformUtilsService = { isSelfHost: () => false };
+
+const mockKeyService = {
+  orgKeys$: () => of({}),
+  makeKeyPair: () => Promise.resolve(["publicKey", { encryptedString: "encryptedPrivateKey" }]),
+  getFingerprint: () => Promise.resolve(["acme", "fingerprint", "words", "here"]),
+};
+
+const mockRouter = { navigate: () => Promise.resolve(true) };
+
+const mockAccountService = {
+  activeAccount$: of({ id: USER_ID, email: "alice@example.com" }),
+};
+
+const mockOrganizationService = {
+  organizations$: () => of([mockOrganization]),
+};
+
+const mockDialogService = {
+  openSimpleDialog: () => Promise.resolve(false),
+};
+
+const mockToastService = { showToast: () => {} };
+
+const mockOrganizationApiService = {
+  get: () => Promise.resolve(mockOrganizationResponse),
+  getKeys: () => Promise.resolve(mockOrganizationKeysResponse),
+  save: () => Promise.resolve(mockOrganizationResponse),
+  updateCollectionManagement: () => Promise.resolve(),
+};
+
+export default {
+  title: "Admin Console/Organizations/Settings/Account",
+  component: AccountComponent,
+  decorators: [
+    moduleMetadata({
+      declarations: [AccountComponent],
+      imports: [
+        SharedModule,
+        AccountFingerprintComponent,
+        DangerZoneComponent,
+        HeaderModule,
+        PremiumBadgeComponent,
+        ItemModule,
+        TwoFactorIconComponent,
+        Vfo1I18nPipe,
+      ],
+      providers: [
+        { provide: ActivatedRoute, useValue: mockActivatedRoute },
+        { provide: Router, useValue: mockRouter },
+        { provide: PlatformUtilsService, useValue: mockPlatformUtilsService },
+        { provide: KeyService, useValue: mockKeyService },
+        { provide: AccountService, useValue: mockAccountService },
+        { provide: OrganizationService, useValue: mockOrganizationService },
+        { provide: OrganizationApiServiceAbstraction, useValue: mockOrganizationApiService },
+        { provide: DialogService, useValue: mockDialogService },
+        { provide: ToastService, useValue: mockToastService },
+      ],
+    }),
+    applicationConfig({
+      providers: [importProvidersFrom(PreloadedEnglishI18nModule)],
+    }),
+  ],
+} as Meta;
+
+type Story = StoryObj<AccountComponent>;
+
+/** Organization settings, including the Collection management section. */
+export const Default: Story = {
+  render: () => ({
+    template: `<app-org-account></app-org-account>`,
+  }),
+};
+
+/**
+ * The Collection management section with the VFO1 terminology flag on — the section heading,
+ * description, checkbox labels, and the "Manage" permission all render "shared folder" terminology
+ * (with the "Manage collection" permission shortened to just "Manage").
+ */
+export const Vfo1Enabled: Story = {
+  render: () => ({
+    moduleMetadata: {
+      providers: [{ provide: ConfigService, useValue: { getFeatureFlag$: () => of(true) } }],
+    },
+    template: `<app-org-account></app-org-account>`,
+  }),
+};

--- a/apps/web/src/app/admin-console/organizations/settings/account.component.stories.ts
+++ b/apps/web/src/app/admin-console/organizations/settings/account.component.stories.ts
@@ -1,4 +1,4 @@
-import { importProvidersFrom } from "@angular/core";
+import { ChangeDetectionStrategy, Component, importProvidersFrom } from "@angular/core";
 import { ActivatedRoute, Router } from "@angular/router";
 import { applicationConfig, Meta, moduleMetadata, StoryObj } from "@storybook/angular";
 import { of } from "rxjs";
@@ -21,10 +21,21 @@ import { Vfo1I18nPipe } from "@bitwarden/vault";
 import { DangerZoneComponent } from "../../../auth/settings/account/danger-zone.component";
 import { PreloadedEnglishI18nModule } from "../../../core/tests";
 import { AccountFingerprintComponent } from "../../../key-management/account-fingerprint/account-fingerprint.component";
-import { HeaderModule } from "../../../layouts/header/header.module";
 import { SharedModule } from "../../../shared";
 
 import { AccountComponent } from "./account.component";
+
+/**
+ * The real `app-header` (`WebHeaderComponent`) pulls in `<app-product-switcher>` and
+ * `<app-account-menu>`, which depend on many app-wide services that aren't worth stubbing out
+ * for this story. Stub it out instead, matching the pattern in
+ * `vault-header.component.stories.ts`.
+ */
+@Component({
+  selector: "app-header",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class StubHeaderComponent {}
 
 const ORG_ID = "org-1" as OrganizationId;
 const USER_ID = "user-1" as UserId;
@@ -32,7 +43,6 @@ const USER_ID = "user-1" as UserId;
 const mockOrganization = Object.assign(new Organization(), {
   id: ORG_ID,
   name: "Acme Corp",
-  canEditSubscription: false,
   useApi: false,
 });
 
@@ -97,7 +107,7 @@ export default {
         SharedModule,
         AccountFingerprintComponent,
         DangerZoneComponent,
-        HeaderModule,
+        StubHeaderComponent,
         PremiumBadgeComponent,
         ItemModule,
         TwoFactorIconComponent,

--- a/apps/web/src/app/admin-console/organizations/settings/account.component.stories.ts
+++ b/apps/web/src/app/admin-console/organizations/settings/account.component.stories.ts
@@ -116,7 +116,13 @@ export default {
       ],
     }),
     applicationConfig({
-      providers: [importProvidersFrom(PreloadedEnglishI18nModule)],
+      providers: [
+        importProvidersFrom(PreloadedEnglishI18nModule),
+        // Vfo1TerminologyService is `providedIn: "root"`, so it resolves ConfigService from the
+        // application root injector. Provide a flag-off default here so the `Default` story
+        // renders without relying on the global feature-flag toolbar (see .storybook/preview.tsx).
+        { provide: ConfigService, useValue: { getFeatureFlag$: () => of(false) } },
+      ],
     }),
   ],
 } as Meta;
@@ -137,7 +143,9 @@ export const Default: Story = {
  */
 export const Vfo1Enabled: Story = {
   render: () => ({
-    moduleMetadata: {
+    // Overriding ConfigService requires applicationConfig (not moduleMetadata) since
+    // Vfo1TerminologyService resolves it from the application root injector.
+    applicationConfig: {
       providers: [{ provide: ConfigService, useValue: { getFeatureFlag$: () => of(true) } }],
     },
     template: `<app-org-account></app-org-account>`,

--- a/apps/web/src/app/admin-console/organizations/settings/account.component.ts
+++ b/apps/web/src/app/admin-console/organizations/settings/account.component.ts
@@ -32,6 +32,7 @@ import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { OrganizationId } from "@bitwarden/common/types/guid";
 import { DialogService, ToastService } from "@bitwarden/components";
 import { KeyService } from "@bitwarden/key-management";
+import { Vfo1TerminologyService } from "@bitwarden/vault";
 
 import { ApiKeyComponent } from "../../../auth/settings/security/api-key.component";
 import { PurgeVaultComponent } from "../../../vault/settings/purge-vault.component";
@@ -95,6 +96,7 @@ export class AccountComponent implements OnInit, OnDestroy {
     private dialogService: DialogService,
     private formBuilder: FormBuilder,
     private toastService: ToastService,
+    private vfo1TerminologyService: Vfo1TerminologyService,
   ) {}
 
   async ngOnInit() {
@@ -211,7 +213,11 @@ export class AccountComponent implements OnInit, OnDestroy {
     this.toastService.showToast({
       variant: "success",
       title: null,
-      message: this.i18nService.t("updatedCollectionManagement"),
+      message: this.i18nService.t(
+        this.vfo1TerminologyService.enabled()
+          ? "updatedSharedFolderManagement"
+          : "updatedCollectionManagement",
+      ),
     });
   };
 

--- a/apps/web/src/app/admin-console/organizations/settings/organization-settings.module.ts
+++ b/apps/web/src/app/admin-console/organizations/settings/organization-settings.module.ts
@@ -3,6 +3,7 @@ import { NgModule } from "@angular/core";
 import { TwoFactorIconComponent } from "@bitwarden/angular/auth/components/two-factor-icon.component";
 import { PremiumBadgeComponent } from "@bitwarden/angular/billing/components/premium-badge";
 import { ItemModule } from "@bitwarden/components";
+import { Vfo1I18nPipe } from "@bitwarden/vault";
 
 import { DangerZoneComponent } from "../../../auth/settings/account/danger-zone.component";
 import { AccountFingerprintComponent } from "../../../key-management/account-fingerprint/account-fingerprint.component";
@@ -23,6 +24,7 @@ import { TwoFactorSetupComponent } from "./two-factor-setup.component";
     PremiumBadgeComponent,
     ItemModule,
     TwoFactorIconComponent,
+    Vfo1I18nPipe,
   ],
   declarations: [AccountComponent, TwoFactorSetupComponent],
 })

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -11838,17 +11838,32 @@
   "collectionManagement": {
     "message": "Collection management"
   },
+  "sharedFolderManagement": {
+    "message": "Shared folder management"
+  },
   "collectionManagementDescription": {
     "message": "Configure the collection behavior for the organization"
+  },
+  "sharedFolderManagementDescription": {
+    "message": "Configure the shared folder behavior for the organization"
   },
   "allowAdminAccessToAllCollectionItemsDescription": {
     "message": "Allow owners and admins to manage all collections and items from the Admin Console"
   },
+  "allowAdminAccessToAllSharedFoldersDescription": {
+    "message": "Allow owners and admins to manage all shared folders and items from the Admin Console"
+  },
   "restrictCollectionCreationDescription": {
     "message": "Restrict collection creation to owners and admins"
   },
+  "restrictSharedFolderCreationDescription": {
+    "message": "Restrict shared folder creation to owners and admins"
+  },
   "restrictCollectionDeletionDescription": {
     "message": "Restrict collection deletion to owners and admins"
+  },
+  "restrictSharedFolderDeletionDescription": {
+    "message": "Restrict shared folder deletion to owners and admins"
   },
   "restrictItemDeletionDescriptionStart": {
     "message": "Restrict item deletion to members with the ",
@@ -11860,6 +11875,9 @@
   },
   "updatedCollectionManagement": {
     "message": "Updated collection management setting"
+  },
+  "updatedSharedFolderManagement": {
+    "message": "Updated shared folder management setting"
   },
   "passwordManagerPlanPrice": {
     "message": "Password Manager plan price"

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -11839,13 +11839,19 @@
     "message": "Collection management"
   },
   "sharedFolderManagement": {
-    "message": "Shared folder management"
+    "message": "Shared folders settings"
   },
   "collectionManagementDescription": {
     "message": "Configure the collection behavior for the organization"
   },
   "sharedFolderManagementDescription": {
-    "message": "Configure the shared folder behavior for the organization"
+    "message": "Configure how shared folders behave within the organization vault."
+  },
+  "learnMoreAboutCollectionManagement": {
+    "message": "Learn more about collections"
+  },
+  "learnMoreAboutSharedFolderManagement": {
+    "message": "Learn more about shared folders"
   },
   "allowAdminAccessToAllCollectionItemsDescription": {
     "message": "Allow owners and admins to manage all collections and items from the Admin Console"


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-40734

## 📔 Objective

Updates the terminology on the settings page of Admin Console for `Collections` to `Shared Folders` for VFO 1

## 📸 Screenshots


<img width="1491" height="905" alt="image" src="https://github.com/user-attachments/assets/a70dea5b-419c-4d59-a9fb-c3bab5bcc071" />
<img width="326" height="107" alt="image" src="https://github.com/user-attachments/assets/6eeb73de-9a64-44d5-9e78-cda91a3cdd24" />
