### PR TITLE
desktop-autofill: Implement Windows plugin credential sync [PM-41025]

### DIFF
--- a/apps/desktop/desktop_native/Cargo.lock
+++ b/apps/desktop/desktop_native/Cargo.lock
@@ -1537,6 +1537,7 @@ dependencies = [
  "security-framework-sys",
  "serde",
  "serde_json",
+ "serde_with",
  "sha2 0.10.9",
  "ssh-key",
  "sysinfo",

--- a/apps/desktop/desktop_native/core/Cargo.toml
+++ b/apps/desktop/desktop_native/core/Cargo.toml
@@ -68,6 +68,7 @@ scopeguard = { workspace = true }
 secmem-proc = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
+serde_with = { workspace = true, features = ["base64"] }
 widestring = { workspace = true, optional = true }
 win_webauthn = { path = "../win_webauthn" }
 windows = { workspace = true, features = [

--- a/apps/desktop/desktop_native/core/src/autofill/windows/mod.rs
+++ b/apps/desktop/desktop_native/core/src/autofill/windows/mod.rs
@@ -1,10 +1,12 @@
 mod status;
+mod sync;
 
 use std::{fs::File, io::Read, path::PathBuf, sync::OnceLock};
 
 use anyhow::{anyhow, Context, Result};
 use serde::{Deserialize, Serialize};
 use status::{handle_status_request, StatusResponse};
+use sync::{handle_sync_request, SyncParameters, SyncResponse};
 use win_webauthn::plugin::Clsid;
 use windows::{
     core::HRESULT, ApplicationModel::Package, Win32::Foundation::APPMODEL_ERROR_NO_PACKAGE,
@@ -30,6 +32,7 @@ async fn dispatch_command(value: String) -> Result<CommandResponse> {
 
     tokio::task::spawn_blocking(move || match request.command {
         RunCommand::Status(_) => handle_status_request().map(CommandResponse::from),
+        RunCommand::Sync(params) => handle_sync_request(params).map(CommandResponse::from),
     })
     .await
     .context("Autofill command task failed")?
@@ -48,6 +51,7 @@ struct RunCommandRequest {
 #[serde(rename_all = "camelCase")]
 enum RunCommand {
     Status(()),
+    Sync(SyncParameters),
 }
 
 #[derive(Serialize)]
@@ -72,6 +76,7 @@ impl From<anyhow::Result<CommandResponse>> for CommandResult {
 #[serde(untagged)]
 enum CommandResponse {
     Status(StatusResponse),
+    Sync(SyncResponse),
 }
 
 impl From<StatusResponse> for CommandResponse {
@@ -196,6 +201,26 @@ mod tests {
     #[tokio::test]
     async fn run_command_reports_unknown_command_as_error_result() {
         let json = r#"{"namespace":"autofill","command":"explode","params":{}}"#;
+
+        run_command_error(json).await;
+    }
+
+    #[tokio::test]
+    async fn run_command_reports_missing_sync_params_as_error_result() {
+        let json = r#"{"namespace":"autofill","command":"sync"}"#;
+
+        run_command_error(json).await;
+    }
+
+    #[tokio::test]
+    async fn run_command_reports_non_base64_credential_id_as_error_result() {
+        let json = r#"{"namespace":"autofill","command":"sync","params":{"credentials":[{
+            "type":"fido2",
+            "credentialId":"not valid base64!!",
+            "rpId":"example.com",
+            "userHandle":"dXNlckhhbmRsZQ",
+            "userName":"user@example.com"
+        }]}}"#;
 
         run_command_error(json).await;
     }

--- a/apps/desktop/desktop_native/core/src/autofill/windows/sync.rs
+++ b/apps/desktop/desktop_native/core/src/autofill/windows/sync.rs
@@ -1,0 +1,405 @@
+use anyhow::{anyhow, Context, Result};
+use serde::{Deserialize, Serialize};
+use serde_with::{
+    base64::{Base64, UrlSafe},
+    formats::Unpadded,
+    serde_as,
+};
+use win_webauthn::{
+    plugin::{Clsid, PluginCredentialDetails, WebAuthnPlugin},
+    CredentialId, UserId,
+};
+
+use super::{get_clsid, CommandResponse};
+
+pub(super) fn handle_sync_request(params: SyncParameters) -> Result<SyncResponse> {
+    let Some(clsid) = get_clsid()? else {
+        return Err(anyhow!(
+            "[core::autofill::sync] Sync requested, but CLSID not found"
+        ));
+    };
+
+    let win_credentials = to_plugin_credentials(params.credentials)?;
+    let added = sync_credentials_to_windows(win_credentials, clsid)?;
+    Ok(SyncResponse { added })
+}
+
+/// Drops credential types Windows cannot store, converts the rest, and skips any
+/// individual credential Windows would reject rather than failing the whole batch.
+fn to_plugin_credentials(credentials: Vec<SyncCredential>) -> Result<Vec<PluginCredentialDetails>> {
+    let win_credentials =
+        credentials
+            .into_iter()
+            .enumerate()
+            .filter_map(|(i, c)| match c {
+                SyncCredential::Fido2(cred) => Some((i, cred)),
+                SyncCredential::Password => None,
+            })
+            .filter_map(|(i, cred)| {
+                PluginCredentialDetails::try_from(cred)
+                    .map_err(|err| {
+                        tracing::warn!(
+                            "[core::autofill] Skipping sync of credential {i} due to error: {err:#}"
+                        );
+                    })
+                    .ok()
+            })
+            // Windows array lengths are represented with u32, so we can't submit more than that.
+            .take(u32::MAX.try_into().context(
+                "Windows binary unexpectedly running on an architecture where usize < u32",
+            )?)
+            .collect();
+    Ok(win_credentials)
+}
+
+/// Initiates credential sync from Electron to Windows - called when Electron wants to push
+/// credentials to Windows
+fn sync_credentials_to_windows(
+    win_credentials: Vec<PluginCredentialDetails>,
+    plugin_clsid: Clsid,
+) -> Result<u32> {
+    tracing::debug!(
+        "[core::autofill] sync_credentials_to_windows called with {} credentials for plugin CLSID: {}",
+        win_credentials.len(),
+        plugin_clsid
+    );
+
+    let plugin = WebAuthnPlugin::new(plugin_clsid);
+
+    // INVARIANT: to_plugin_credentials limits the list length to u32::MAX.
+    let num_to_add = win_credentials
+        .len()
+        .try_into()
+        .expect("Credential list to be <= u32::MAX");
+    tracing::debug!(
+        "[core::autofill] Synchronizing {} credentials to Windows",
+        win_credentials.len()
+    );
+
+    plugin
+        .sync_credentials(win_credentials)
+        .context("Failed to synchronize credentials")?;
+    Ok(num_to_add)
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct SyncParameters {
+    credentials: Vec<SyncCredential>,
+}
+
+#[serde_as]
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type")]
+#[serde(rename_all = "camelCase")]
+enum SyncCredential {
+    // Currently Windows only supports syncing passkeys, so this is unused.
+    Password,
+    Fido2(SyncFido2Credential),
+}
+
+#[serde_as]
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SyncFido2Credential {
+    rp_id: String,
+
+    #[serde_as(as = "Base64<UrlSafe, Unpadded>")]
+    credential_id: Vec<u8>,
+
+    user_name: Option<String>,
+
+    #[serde_as(as = "Option<Base64<UrlSafe, Unpadded>>")]
+    user_handle: Option<Vec<u8>>,
+}
+
+impl TryFrom<SyncFido2Credential> for PluginCredentialDetails {
+    type Error = anyhow::Error;
+
+    fn try_from(value: SyncFido2Credential) -> Result<Self, Self::Error> {
+        let cred_id =
+            CredentialId::try_from(value.credential_id).context("Invalid credential ID")?;
+        let user_id = value
+            .user_handle
+            .ok_or_else(|| anyhow!("No user handle specified"))
+            .and_then(|id| UserId::try_from(id).context("Invalid user ID"))?;
+        let user_name = value
+            .user_name
+            .ok_or_else(|| anyhow!("No username specified"))?;
+
+        Ok(PluginCredentialDetails {
+            credential_id: cred_id,
+            rp_id: value.rp_id.clone(),
+            rp_friendly_name: Some(value.rp_id.clone()), // Use RP ID as friendly name for now
+            user_id,
+            user_name: user_name.clone(),
+            user_display_name: user_name, // Use user name as display name for now
+        })
+    }
+}
+
+#[derive(Serialize)]
+pub(super) struct SyncResponse {
+    added: u32,
+}
+
+impl From<SyncResponse> for CommandResponse {
+    fn from(value: SyncResponse) -> Self {
+        Self::Sync(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+    use win_webauthn::plugin::PluginCredentialDetails;
+
+    use super::{to_plugin_credentials, SyncCredential, SyncFido2Credential, SyncResponse};
+    use crate::autofill::autofill::{
+        CommandResponse, CommandResult, RunCommand, RunCommandRequest,
+    };
+
+    /// Windows accepts credential IDs of 16..=1023 bytes and user handles of 1..=64 bytes.
+    fn fido2_credential(credential_id: Vec<u8>, user_handle: Vec<u8>) -> SyncFido2Credential {
+        SyncFido2Credential {
+            rp_id: "example.com".to_string(),
+            credential_id,
+            user_name: Some("user@example.com".to_string()),
+            user_handle: Some(user_handle),
+        }
+    }
+
+    fn valid_credential() -> SyncFido2Credential {
+        fido2_credential(vec![7u8; 16], vec![9u8; 32])
+    }
+
+    #[test]
+    fn converts_credential_and_fills_placeholder_display_names() {
+        let details = PluginCredentialDetails::try_from(valid_credential()).unwrap();
+
+        assert_eq!([7u8; 16].as_slice(), details.credential_id.as_ref());
+        assert_eq!([9u8; 32].as_slice(), details.user_id.as_ref());
+        assert_eq!("example.com", details.rp_id);
+        assert_eq!("user@example.com", details.user_name);
+        // Both are placeholders today. If Bitwarden starts sending real friendly names,
+        // these assertions should be updated deliberately rather than silently drift.
+        assert_eq!(Some("example.com".to_string()), details.rp_friendly_name);
+        assert_eq!("user@example.com", details.user_display_name);
+    }
+
+    #[test]
+    fn accepts_credential_id_at_length_bounds() {
+        for len in [16, 1023] {
+            let cred = fido2_credential(vec![1u8; len], vec![9u8; 32]);
+            assert!(
+                PluginCredentialDetails::try_from(cred).is_ok(),
+                "credential ID of {len} bytes should be accepted"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_credential_id_outside_length_bounds() {
+        for len in [0, 15, 1024] {
+            let cred = fido2_credential(vec![1u8; len], vec![9u8; 32]);
+            assert!(
+                PluginCredentialDetails::try_from(cred).is_err(),
+                "credential ID of {len} bytes should be rejected"
+            );
+        }
+    }
+
+    /// Passkeys imported from other providers may carry no user handle. Windows rejects an
+    /// empty user ID, so such credentials are silently dropped from the sync today.
+    #[test]
+    fn rejects_empty_user_handle() {
+        let cred = fido2_credential(vec![1u8; 16], vec![]);
+        assert!(PluginCredentialDetails::try_from(cred).is_err());
+    }
+
+    #[test]
+    fn rejects_none_user_handle() {
+        let mut cred = fido2_credential(vec![1u8; 16], vec![]);
+        cred.user_handle = None;
+        assert!(PluginCredentialDetails::try_from(cred).is_err());
+    }
+
+    #[test]
+    fn accepts_user_handle_at_maximum_length() {
+        let cred = fido2_credential(vec![1u8; 16], vec![9u8; 64]);
+        assert!(PluginCredentialDetails::try_from(cred).is_ok());
+    }
+
+    #[test]
+    fn rejects_user_handle_above_maximum_length() {
+        let cred = fido2_credential(vec![1u8; 16], vec![9u8; 65]);
+        assert!(PluginCredentialDetails::try_from(cred).is_err());
+    }
+
+    /// Conversion failures are written to the log, so they must describe the problem by
+    /// length only - never by credential contents, RP ID, or username.
+    #[test]
+    fn conversion_error_does_not_leak_credential_contents() {
+        let cred = SyncFido2Credential {
+            rp_id: "secret-rp.example".to_string(),
+            credential_id: b"short".to_vec(),
+            user_name: Some("victim@example.com".to_string()),
+            user_handle: Some(vec![9u8; 32]),
+        };
+
+        let err = PluginCredentialDetails::try_from(cred).unwrap_err();
+        let rendered = format!("{err:#}");
+
+        assert!(
+            rendered.contains("received 5"),
+            "error should report the length: {rendered}"
+        );
+        for secret in ["secret-rp.example", "victim@example.com", "short"] {
+            assert!(
+                !rendered.contains(secret),
+                "error leaked {secret:?}: {rendered}"
+            );
+        }
+    }
+
+    #[test]
+    fn filters_out_password_credentials() {
+        let credentials = vec![
+            SyncCredential::Password,
+            SyncCredential::Fido2(valid_credential()),
+            SyncCredential::Password,
+        ];
+
+        assert_eq!(1, to_plugin_credentials(credentials).unwrap().len());
+    }
+
+    #[test]
+    fn skips_invalid_credentials_without_aborting_the_batch() {
+        let usernameless = SyncFido2Credential {
+            rp_id: "example.com".to_string(),
+            credential_id: vec![4u8; 16],
+            user_name: None,
+            user_handle: Some(vec![9u8; 16]),
+        };
+
+        let credentials = vec![
+            SyncCredential::Fido2(fido2_credential(vec![1u8; 16], vec![9u8; 32])),
+            // Invalid: credential ID is one byte under the minimum.
+            SyncCredential::Fido2(fido2_credential(vec![2u8; 15], vec![9u8; 32])),
+            SyncCredential::Fido2(fido2_credential(vec![3u8; 16], vec![9u8; 32])),
+            SyncCredential::Fido2(fido2_credential(vec![3u8; 16], vec![])),
+            SyncCredential::Fido2(usernameless),
+        ];
+
+        let result = to_plugin_credentials(credentials).unwrap();
+
+        assert_eq!(2, result.len());
+        assert_eq!([1u8; 16].as_slice(), result[0].credential_id.as_ref());
+        assert_eq!([3u8; 16].as_slice(), result[1].credential_id.as_ref());
+    }
+
+    /// Signing out syncs an empty list to clear the Windows autofill store, so an empty
+    /// input must produce an empty list rather than an error.
+    #[test]
+    fn returns_empty_list_for_empty_input() {
+        assert!(to_plugin_credentials(vec![]).unwrap().is_empty());
+    }
+
+    #[test]
+    fn returns_empty_list_when_all_credentials_are_passwords() {
+        let credentials = vec![SyncCredential::Password, SyncCredential::Password];
+        assert!(to_plugin_credentials(credentials).unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_optional_fields_deserialize_to_none_when_null() {
+        let json = r#"{
+            "type":"fido2",
+            "cipherId":"c7ea35e7-5e7a-48ff-b4ce-b4940151967a",
+            "credentialId":"Y3JlZGVudGlhbElk-v_D",
+            "rpId":"example.com",
+            "userHandle": null,
+            "userName": null
+        }"#;
+
+        let cred = serde_json::from_str::<SyncCredential>(json).unwrap();
+        let SyncCredential::Fido2(fido_cred) = cred else {
+            panic!("expected Fido2 credential");
+        };
+        assert!(fido_cred.user_handle.is_none());
+        assert!(fido_cred.user_name.is_none());
+    }
+
+    #[test]
+    fn test_optional_fields_deserialize_to_none_when_absent() {
+        let json = r#"{
+            "type":"fido2",
+            "cipherId":"c7ea35e7-5e7a-48ff-b4ce-b4940151967a",
+            "credentialId":"Y3JlZGVudGlhbElk-v_D",
+            "rpId":"example.com"
+        }"#;
+
+        let cred = serde_json::from_str::<SyncCredential>(json).unwrap();
+        let SyncCredential::Fido2(fido_cred) = cred else {
+            panic!("expected Fido2 credential");
+        };
+        assert!(fido_cred.user_handle.is_none());
+    }
+
+    #[test]
+    fn test_request_deserialization() {
+        let json = r#"{
+            "namespace":"autofill",
+            "command":"sync",
+            "params": { "credentials": [{
+                "type":"fido2",
+                "cipherId":"c7ea35e7-5e7a-48ff-b4ce-b4940151967a",
+                "credentialId":"Y3JlZGVudGlhbElk-v_D",
+                "rpId":"example.com",
+                "userHandle":"dXNlckhhbmRsZQD6_8M-",
+                "userName":"bitwarden-windows-demo1"
+            }]}
+        }"#;
+        let request: RunCommandRequest = serde_json::from_str(json).unwrap();
+
+        let RunCommandRequest {
+            command: RunCommand::Sync(params),
+            ..
+        } = &request
+        else {
+            panic!("should match sync");
+        };
+        assert_eq!("autofill", request.namespace);
+        let SyncCredential::Fido2(SyncFido2Credential {
+            rp_id,
+            credential_id,
+            user_name,
+            user_handle,
+            ..
+        }) = &params.credentials[0]
+        else {
+            panic!("should have matched")
+        };
+        assert_eq!("example.com", rp_id);
+        assert_eq!(b"credentialId\xfa\xff\xc3", credential_id.as_slice());
+        assert_eq!(
+            b"userHandle\x00\xfa\xff\xc3>",
+            user_handle.as_ref().unwrap().as_slice()
+        );
+        assert_eq!("bitwarden-windows-demo1", user_name.as_ref().unwrap());
+    }
+
+    #[test]
+    fn test_result_serialization() {
+        let result = CommandResult::Success {
+            value: CommandResponse::Sync(SyncResponse { added: 10 }),
+        };
+        let json = serde_json::to_string(&result).unwrap();
+        let expected_json = json!({
+            "type": "success",
+            "value": { "added": 10 },
+        })
+        .to_string();
+        assert_eq!(expected_json, json);
+    }
+}

--- a/apps/desktop/desktop_native/win_webauthn/src/api/plugin/mod.rs
+++ b/apps/desktop/desktop_native/win_webauthn/src/api/plugin/mod.rs
@@ -406,6 +406,15 @@ impl WebAuthnPlugin {
             ));
         };
 
+        // With nothing to add, removing is the whole operation - signing out syncs an empty
+        // list to clear the store - so a failure here cannot be reported as a successful sync.
+        if credentials.is_empty() {
+            tracing::debug!("No credentials to add to Windows, removing all existing ones...");
+            remove_all_credentials(self.clsid)?;
+            tracing::debug!("Successfully removed existing credentials - sync completed");
+            return Ok(());
+        }
+
         // First try to remove all existing credentials for this plugin
         tracing::debug!("Attempting to remove all existing credentials before sync...");
         match remove_all_credentials(self.clsid) {
@@ -417,12 +426,6 @@ impl WebAuthnPlugin {
                 // Continue anyway, as this might be the first sync or an older Windows version
             }
         };
-
-        // Add the new credentials (only if we have any)
-        if credentials.is_empty() {
-            tracing::debug!("No credentials to add to Windows - sync completed successfully");
-            return Ok(());
-        }
         tracing::debug!("Adding new credentials to Windows...");
 
         // Convert to raw credentials to Windows credential details

--- a/apps/desktop/src/autofill/main/main-desktop-autofill.service.ts
+++ b/apps/desktop/src/autofill/main/main-desktop-autofill.service.ts
@@ -195,14 +195,14 @@ export class DesktopAutofillMain {
    */
   private doWindowHandleQuery: Listener<void> = (error, clientId, sequenceNumber) => {
     if (error) {
-      this.logService.error("[NativeAutofillMain]", "windowHandleQuery", error);
+      this.logService.error("[DesktopAutofillMain]", "windowHandleQuery", error);
       this.ipcServer?.completeError(clientId, sequenceNumber, String(error));
       return;
     }
 
     const window = this.windowMain.win;
     if (!window) {
-      this.logService.error("[NativeAutofillMain]", "windowHandleQuery: No window available");
+      this.logService.error("[DesktopAutofillMain]", "windowHandleQuery: No window available");
       this.ipcServer?.completeError(clientId, sequenceNumber, "No window available");
       return;
     }
@@ -240,7 +240,7 @@ export class DesktopAutofillMain {
       request,
     ) => {
       if (error) {
-        this.logService.error("[NativeAutofillMain]", `${toRendererChannel}:`, error);
+        this.logService.error("[DesktopAutofillMain]", `${toRendererChannel}:`, error);
         this.ipcServer?.completeError(clientId, sequenceNumber, String(error));
         return;
       }
@@ -272,7 +272,7 @@ export class DesktopAutofillMain {
         // without ipcServer being set.
         if (!this.ipcServer) {
           this.logService.error(
-            "[NativeAutofillMain]",
+            "[DesktopAutofillMain]",
             `${fromRendererChannel}: Cannot find IPC server instance to return response to autofill provider.`,
           );
           throw new Error(
@@ -280,8 +280,12 @@ export class DesktopAutofillMain {
           );
         }
 
-        this.logService.debug(fromRendererChannel, data);
         const { clientId, sequenceNumber, response } = data;
+        this.logService.debug(
+          "[DesktopAutofillMain]",
+          `${fromRendererChannel}: Received response from renderer channel`,
+          { clientId, sequenceNumber },
+        );
         completeCallback.call(this.ipcServer, clientId, sequenceNumber, response);
       });
 

--- a/apps/desktop/src/autofill/services/desktop-autofill.service.ts
+++ b/apps/desktop/src/autofill/services/desktop-autofill.service.ts
@@ -153,7 +153,7 @@ export class DesktopAutofillService implements OnDestroy {
     }
 
     const cipherViewMap = await firstValueFrom(this.cipherService.cipherViews$(userId));
-    this.logService.info("Performing AdHoc sync", Object.values(cipherViewMap ?? []));
+    this.logService.info(`Performing AdHoc sync over ${cipherViewMap?.length ?? 0} ciphers`);
     await this.sync(Object.values(cipherViewMap ?? []));
   }
 
@@ -203,8 +203,8 @@ export class DesktopAutofillService implements OnDestroy {
     }
 
     this.logService.info("Syncing autofill credentials", {
-      fido2Credentials,
-      passwordCredentials,
+      fido2Credentials: fido2Credentials.length,
+      passwordCredentials: passwordCredentials.length,
     });
 
     const syncResult = await ipc.autofill.desktopAutofill.runCommand<AutofillSyncCommand>({


### PR DESCRIPTION
## 🎟️ Tracking

[PM-41025](https://bitwarden.atlassian.net/browse/PM-41025)

## 📔 Objective

Synchronizes credentials from Bitwarden to Windows autofill store.
- Adds support to query plugin enabled/disabled state via webauthn.dll
- Moves functions to read Appx resources from windows_plugin_authenticator to `desktop_core::autofill`, since they are shared by both `desktop_core` and 
- Implements the native side of the status request from DesktopAutofillService, informing whether the credentials should sync or not
- Implements the conversion from Bitwarden to Windows native credentials

This enables passkey assertion with conditional mediation and from the Windows Hello autofill selection dialog, as shown in the demo below.

Note this work is still behind a feature flag; the UI glitches in the demo below will be addressed in future PRs.

## 📸 Screenshots

https://github.com/user-attachments/assets/2c8352cc-0850-4dbd-8a80-570068bd8339




[PM-41025]: https://bitwarden.atlassian.net/browse/PM-41025?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ