### PR TITLE
[PM-40549] Desktop add quick copy icon setting

### DIFF
--- a/apps/desktop/src/app/accounts/settings.component.html
+++ b/apps/desktop/src/app/accounts/settings.component.html
@@ -198,19 +198,21 @@
                   runInBackgroundDescText
                 }}</small>
               </div>
-              <div class="form-group">
-                <div class="checkbox">
-                  <label for="showQuickCopyActions">
-                    <input
-                      id="showQuickCopyActions"
-                      type="checkbox"
-                      formControlName="showQuickCopyActions"
-                      (change)="saveQuickCopyActions()"
-                    />
-                    {{ "showQuickCopyActions" | i18n }}
-                  </label>
+              @if (showQuickCopyActionsSetting()) {
+                <div class="form-group">
+                  <div class="checkbox">
+                    <label for="showQuickCopyActions">
+                      <input
+                        id="showQuickCopyActions"
+                        type="checkbox"
+                        formControlName="showQuickCopyActions"
+                        (change)="saveQuickCopyActions()"
+                      />
+                      {{ "showQuickCopyActions" | i18n }}
+                    </label>
+                  </div>
                 </div>
-              </div>
+              }
               <div class="form-group" *ngIf="showOpenAtLoginOption">
                 <div class="checkbox">
                   <label for="openAtLogin">

--- a/apps/desktop/src/app/accounts/settings.component.html
+++ b/apps/desktop/src/app/accounts/settings.component.html
@@ -198,6 +198,19 @@
                   runInBackgroundDescText
                 }}</small>
               </div>
+              <div class="form-group">
+                <div class="checkbox">
+                  <label for="showQuickCopyActions">
+                    <input
+                      id="showQuickCopyActions"
+                      type="checkbox"
+                      formControlName="showQuickCopyActions"
+                      (change)="saveQuickCopyActions()"
+                    />
+                    {{ "showQuickCopyActions" | i18n }}
+                  </label>
+                </div>
+              </div>
               <div class="form-group" *ngIf="showOpenAtLoginOption">
                 <div class="checkbox">
                   <label for="openAtLogin">

--- a/apps/desktop/src/app/accounts/settings.component.html
+++ b/apps/desktop/src/app/accounts/settings.component.html
@@ -210,6 +210,9 @@
                       />
                       {{ "showQuickCopyActions" | i18n }}
                     </label>
+                    <div class="tw-inline-block tw-ml-2">
+                      <show-quick-copy-actions-details-popover></show-quick-copy-actions-details-popover>
+                    </div>
                   </div>
                 </div>
               }

--- a/apps/desktop/src/app/accounts/settings.component.html
+++ b/apps/desktop/src/app/accounts/settings.component.html
@@ -208,7 +208,7 @@
                         formControlName="showQuickCopyActions"
                         (change)="saveQuickCopyActions()"
                       />
-                      {{ "showQuickCopyActions" | i18n }}
+                      {{ "showQuickCopyActionsInVault" | i18n }}
                     </label>
                     <div class="tw-inline-block tw-ml-2">
                       <show-quick-copy-actions-details-popover></show-quick-copy-actions-details-popover>

--- a/apps/desktop/src/app/accounts/settings.component.spec.ts
+++ b/apps/desktop/src/app/accounts/settings.component.spec.ts
@@ -33,6 +33,7 @@ import { UserKey } from "@bitwarden/common/types/key";
 import { DialogRef, DialogService, ToastService } from "@bitwarden/components";
 import { BiometricStateService, BiometricsStatus, KeyService } from "@bitwarden/key-management";
 import { SessionTimeoutSettingsComponent } from "@bitwarden/key-management-ui";
+import { VaultCopyButtonsService } from "@bitwarden/vault";
 
 import { SetPinComponent } from "../../auth/components/set-pin.component";
 import { SshAgentPromptType } from "../../autofill/models/ssh-agent-setting";
@@ -82,6 +83,7 @@ describe("SettingsComponent", () => {
   const billingAccountProfileStateService = mock<BillingAccountProfileStateService>();
   const configService = mock<ConfigService>();
   const userVerificationService = mock<UserVerificationService>();
+  const vaultCopyButtonsService = mock<VaultCopyButtonsService>();
 
   const mockUserKey = new SymmetricCryptoKey(new Uint8Array(64)) as unknown as UserKey;
 
@@ -143,6 +145,7 @@ describe("SettingsComponent", () => {
         { provide: ToastService, useValue: mock<ToastService>() },
         { provide: DesktopAutotypeService, useValue: desktopAutotypeService },
         { provide: BillingAccountProfileStateService, useValue: billingAccountProfileStateService },
+        { provide: VaultCopyButtonsService, useValue: vaultCopyButtonsService },
       ],
       schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
@@ -180,6 +183,7 @@ describe("SettingsComponent", () => {
     desktopSettingsService.preventScreenshots$ = of(false);
     domainSettingsService.showFavicons$ = of(false);
     desktopAutofillSettingsService.enableDuckDuckGoBrowserIntegration$ = of(false);
+    vaultCopyButtonsService.showQuickCopyActions$ = of(false);
     themeStateService.selectedTheme$ = of(ThemeType.System);
     i18nService.userSetLocale$ = of("en");
     pinServiceAbstraction.isPinSet.mockResolvedValue(false);

--- a/apps/desktop/src/app/accounts/settings.component.spec.ts
+++ b/apps/desktop/src/app/accounts/settings.component.spec.ts
@@ -107,6 +107,8 @@ describe("SettingsComponent", () => {
     i18nService.supportedTranslationLocales = [];
     i18nService.t.mockImplementation((key: string) => key);
 
+    configService.getFeatureFlag$.mockReturnValue(of(false));
+
     await TestBed.configureTestingModule({
       imports: [],
       providers: [
@@ -191,7 +193,6 @@ describe("SettingsComponent", () => {
     desktopAutotypeService.autotypeEnabledUserSetting$ = of(false);
     desktopAutotypeService.autotypeKeyboardShortcut$ = of(["Control", "Alt", "B"]);
     billingAccountProfileStateService.hasPremiumFromAnySource$.mockReturnValue(of(false));
-    configService.getFeatureFlag$.mockReturnValue(of(false));
   });
 
   afterEach(() => {

--- a/apps/desktop/src/app/accounts/settings.component.ts
+++ b/apps/desktop/src/app/accounts/settings.component.ts
@@ -50,7 +50,7 @@ import {
 import { KeyService, BiometricStateService, BiometricsStatus } from "@bitwarden/key-management";
 import { SessionTimeoutSettingsComponent } from "@bitwarden/key-management-ui";
 import { I18nPipe } from "@bitwarden/ui-common";
-import { PermitCipherDetailsPopoverComponent } from "@bitwarden/vault";
+import { PermitCipherDetailsPopoverComponent, VaultCopyButtonsService } from "@bitwarden/vault";
 
 import { SetPinComponent } from "../../auth/components/set-pin.component";
 import { AutotypeShortcutComponent } from "../../autofill/components/autotype-shortcut.component";
@@ -146,6 +146,7 @@ export class SettingsComponent implements OnInit, OnDestroy {
     sshAgentPromptBehavior: SshAgentPromptType.Always,
     allowScreenshots: false,
     enableDuckDuckGoBrowserIntegration: false,
+    showQuickCopyActions: false,
     enableAutotype: this.formBuilder.control<boolean>({
       value: false,
       disabled: true,
@@ -184,6 +185,7 @@ export class SettingsComponent implements OnInit, OnDestroy {
     private configService: ConfigService,
     private validationService: ValidationService,
     private billingAccountProfileStateService: BillingAccountProfileStateService,
+    private vaultCopyButtonsService: VaultCopyButtonsService,
   ) {
     this.isMac = this.platformUtilsService.getDevice() === DeviceType.MacOsDesktop;
     this.isLinux = this.platformUtilsService.getDevice() === DeviceType.LinuxDesktop;
@@ -288,6 +290,9 @@ export class SettingsComponent implements OnInit, OnDestroy {
       openAtLogin: await firstValueFrom(this.desktopSettingsService.openAtLogin$),
       enableDuckDuckGoBrowserIntegration: await firstValueFrom(
         this.desktopAutofillSettingsService.enableDuckDuckGoBrowserIntegration$,
+      ),
+      showQuickCopyActions: await firstValueFrom(
+        this.vaultCopyButtonsService.showQuickCopyActions$,
       ),
       enableHardwareAcceleration: await firstValueFrom(
         this.desktopSettingsService.hardwareAcceleration$,
@@ -508,6 +513,12 @@ export class SettingsComponent implements OnInit, OnDestroy {
   async saveFavicons() {
     await this.domainSettingsService.setShowFavicons(this.form.value.enableFavicons);
     this.messagingService.send("refreshCiphers");
+  }
+
+  async saveQuickCopyActions() {
+    await this.vaultCopyButtonsService.setShowQuickCopyActions(
+      this.form.value.showQuickCopyActions,
+    );
   }
 
   async saveRunInBackground() {

--- a/apps/desktop/src/app/accounts/settings.component.ts
+++ b/apps/desktop/src/app/accounts/settings.component.ts
@@ -2,6 +2,7 @@
 // @ts-strict-ignore
 import { CommonModule } from "@angular/common";
 import { Component, OnDestroy, OnInit } from "@angular/core";
+import { toSignal } from "@angular/core/rxjs-interop";
 import { FormBuilder, FormsModule, ReactiveFormsModule } from "@angular/forms";
 import { RouterModule } from "@angular/router";
 import { BehaviorSubject, Observable, Subject, firstValueFrom, of } from "rxjs";
@@ -127,6 +128,12 @@ export class SettingsComponent implements OnInit, OnDestroy {
   userHasPinSet: boolean;
 
   pinEnabled$: Observable<boolean> = of(true);
+
+  /** Controls whether the quick copy actions setting is shown, matching the vault list feature. */
+  protected readonly showQuickCopyActionsSetting = toSignal(
+    this.configService.getFeatureFlag$(FeatureFlag.PM28091_AddCopyAndQuickLaunchActions),
+    { initialValue: false },
+  );
 
   form = this.formBuilder.group({
     // Security

--- a/apps/desktop/src/app/accounts/settings.component.ts
+++ b/apps/desktop/src/app/accounts/settings.component.ts
@@ -134,9 +134,9 @@ export class SettingsComponent implements OnInit, OnDestroy {
 
   pinEnabled$: Observable<boolean> = of(true);
 
-  /** Controls whether the quick copy actions setting is shown, matching the vault list feature. */
+  /** Controls whether the quick copy actions setting is shown */
   protected readonly showQuickCopyActionsSetting = toSignal(
-    this.configService.getFeatureFlag$(FeatureFlag.PM28091_AddCopyAndQuickLaunchActions),
+    this.configService.getFeatureFlag$(FeatureFlag.PM40435_QuickCopyIconSetting),
     { initialValue: false },
   );
 

--- a/apps/desktop/src/app/accounts/settings.component.ts
+++ b/apps/desktop/src/app/accounts/settings.component.ts
@@ -51,7 +51,11 @@ import {
 import { KeyService, BiometricStateService, BiometricsStatus } from "@bitwarden/key-management";
 import { SessionTimeoutSettingsComponent } from "@bitwarden/key-management-ui";
 import { I18nPipe } from "@bitwarden/ui-common";
-import { PermitCipherDetailsPopoverComponent, VaultCopyButtonsService } from "@bitwarden/vault";
+import {
+  PermitCipherDetailsPopoverComponent,
+  VaultCopyButtonsService,
+  ShowQuickCopyActionsDetailsPopoverComponent,
+} from "@bitwarden/vault";
 
 import { SetPinComponent } from "../../auth/components/set-pin.component";
 import { AutotypeShortcutComponent } from "../../autofill/components/autotype-shortcut.component";
@@ -97,6 +101,7 @@ import { NativeMessagingManifestService } from "../services/native-messaging-man
     SessionTimeoutSettingsComponent,
     PermitCipherDetailsPopoverComponent,
     PremiumBadgeComponent,
+    ShowQuickCopyActionsDetailsPopoverComponent,
   ],
 })
 export class SettingsComponent implements OnInit, OnDestroy {

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -1980,6 +1980,12 @@
   "noValuesToCopy": {
     "message": "No values to copy"
   },
+  "givenName": {
+    "message": "Given name"
+  },
+  "surname": {
+   "message": "Surname"
+  },
   "runInBackground": {
     "message": "Keep Bitwarden running in the background"
   },

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -1967,6 +1967,19 @@
   "showQuickCopyActions": {
     "message": "Show quick copy actions on Vault"
   },
+  "copyNoteTitle": {
+    "message": "Copy Note - $ITEMNAME$",
+    "description": "Title for a button copies a note to the clipboard.",
+    "placeholders": {
+      "itemname": {
+        "content": "$1",
+        "example": "Secret Note Item"
+      }
+    }
+  },
+  "noValuesToCopy": {
+    "message": "No values to copy"
+  },
   "runInBackground": {
     "message": "Keep Bitwarden running in the background"
   },

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -477,6 +477,15 @@
   "launch": {
     "message": "Launch"
   },
+  "launchWebsiteForName": {
+    "message": "Launch website for $ITEMNAME$",
+    "placeholders": {
+      "itemname": {
+        "content": "$1",
+        "example": "Secret item"
+      }
+    }
+  },
   "copyValue": {
     "message": "Copy value",
     "description": "Copy value to clipboard"

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -3492,6 +3492,9 @@
   "options": {
     "message": "Options"
   },
+  "moreOptions": {
+    "message": "More options"
+  },
   "sessionTimeout": {
     "message": "Your session has timed out. Please go back and try logging in again."
   },

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -2063,6 +2063,31 @@
   "copyVerificationCode": {
     "message": "Copy verification code"
   },
+  "noUsername": {
+    "message": "No username"
+  },
+  "noPassword": {
+    "message": "No password"
+  },
+  "noVerificationCode": {
+    "message": "No verification code"
+  },
+  "noNumber": {
+    "message": "No number"
+  },
+  "noSecurityCode": {
+    "message": "No security code"
+  },
+  "copyDetailsTitle": {
+    "message": "Copy details for $ITEMNAME$",
+    "description": "Title for a button that opens a menu with options to copy information from an item.",
+    "placeholders": {
+      "itemname": {
+        "content": "$1",
+        "example": "Secret Item"
+      }
+    }
+  },
   "copyUsername": {
     "message": "Copy username"
   },

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -1980,12 +1980,6 @@
   "noValuesToCopy": {
     "message": "No values to copy"
   },
-  "givenName": {
-    "message": "First name"
-  },
-  "surname": {
-   "message": "Last name"
-  },
   "runInBackground": {
     "message": "Keep Bitwarden running in the background"
   },

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -1964,6 +1964,9 @@
   "showIconsChangePasswordUrls": {
     "message": "Show website icons and retrieve change password URLs"
   },
+  "showQuickCopyActions": {
+    "message": "Show quick copy actions on Vault"
+  },
   "runInBackground": {
     "message": "Keep Bitwarden running in the background"
   },

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -1981,10 +1981,10 @@
     "message": "No values to copy"
   },
   "givenName": {
-    "message": "Given name"
+    "message": "First name"
   },
   "surname": {
-   "message": "Surname"
+   "message": "Last name"
   },
   "runInBackground": {
     "message": "Keep Bitwarden running in the background"

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -1973,8 +1973,8 @@
   "showIconsChangePasswordUrls": {
     "message": "Show website icons and retrieve change password URLs"
   },
-  "showQuickCopyActions": {
-    "message": "Show quick copy actions on Vault"
+  "showQuickCopyActionsInVault": {
+    "message": "Show quick copy actions in vault"
   },
   "copyNoteTitle": {
     "message": "Copy Note - $ITEMNAME$",
@@ -1986,8 +1986,8 @@
       }
     }
   },
-  "noValuesToCopy": {
-    "message": "No values to copy"
+  "noDetailsToCopy": {
+    "message": "No details to copy"
   },
   "runInBackground": {
     "message": "Keep Bitwarden running in the background"
@@ -5310,7 +5310,7 @@
     "message": "Bitwarden will use saved login URIs to identify which icon or change password URL should be used to improve your experience. No information is collected or saved when you use this service."
   },
   "showQuickCopyActionsDetailsDescription": {
-    "message": "Add three quick-copy action buttons next to items to specifically copy your username, password, or verification code to the clipboard."
+    "message": "Add 3 quick copy buttons next to items to copy your username, password, or verification code to the clipboard."
   },
   "assignToCollections": {
     "message": "Assign to collections"

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -5297,6 +5297,9 @@
   "permitCipherDetailsDescription": {
     "message": "Bitwarden will use saved login URIs to identify which icon or change password URL should be used to improve your experience. No information is collected or saved when you use this service."
   },
+  "showQuickCopyActionsDetailsDescription": {
+    "message": "Add three quick-copy action buttons next to items to specifically copy your username, password, or verification code to the clipboard."
+  },
   "assignToCollections": {
     "message": "Assign to collections"
   },

--- a/apps/desktop/src/vault/app/vault-v3/vault-items/vault-cipher-row.component.html
+++ b/apps/desktop/src/vault/app/vault-v3/vault-items/vault-cipher-row.component.html
@@ -63,7 +63,7 @@
       size="small"
       bitIconButton="bwi-ellipsis-v"
       type="button"
-      label="{{ 'options' | i18n }}"
+      label="{{ 'moreOptions' | i18n }}"
     ></button>
     <bit-menu #corruptedCipherOptions>
       @if (canDeleteCipher()) {
@@ -98,7 +98,7 @@
       [disabled]="disabled()"
       bitIconButton="bwi-ellipsis-v"
       type="button"
-      label="{{ 'options' | i18n }}"
+      label="{{ 'moreOptions' | i18n }}"
     ></button>
     <bit-menu #cipherOptions>
       @if (showFavorite()) {

--- a/apps/desktop/src/vault/app/vault-v3/vault-items/vault-cipher-row.component.html
+++ b/apps/desktop/src/vault/app/vault-v3/vault-items/vault-cipher-row.component.html
@@ -88,6 +88,7 @@
         class="tw-inline-flex tw-items-center tw-gap-2 tw-align-middle [&_button[biticonbutton]]:-tw-mx-1"
         [cipher]="cipher()"
         [showQuickCopyActions]="showQuickCopyActions()"
+        [disabled]="disabled()"
       ></vault-item-copy-actions>
     }
 

--- a/apps/desktop/src/vault/app/vault-v3/vault-items/vault-cipher-row.component.html
+++ b/apps/desktop/src/vault/app/vault-v3/vault-items/vault-cipher-row.component.html
@@ -79,7 +79,7 @@
         [disabled]="disabled()"
         bitIconButton="bwi-external-link"
         type="button"
-        label="{{ 'launch' | i18n }}"
+        [label]="'launchWebsiteForName' | i18n: cipher().name"
         (click)="handleLaunch()"
       ></button>
     }

--- a/apps/desktop/src/vault/app/vault-v3/vault-items/vault-cipher-row.component.html
+++ b/apps/desktop/src/vault/app/vault-v3/vault-items/vault-cipher-row.component.html
@@ -83,22 +83,12 @@
         (click)="handleLaunch()"
       ></button>
     }
-    @if (showCopyButton()) {
-      <button
-        [bitMenuTriggerFor]="copyOptions"
-        [disabled]="disabled()"
-        bitIconButton="bwi-clone"
-        type="button"
-        label="{{ 'copyValue' | i18n }}"
-      ></button>
-      <bit-menu #copyOptions>
-        @for (copyField of copyFields(); track copyField.field) {
-          <button type="button" bitMenuItem [appCopyField]="copyField.field" [cipher]="cipher()">
-            <i class="bwi bwi-fw bwi-clone" aria-hidden="true"></i>
-            {{ copyField.title | i18n }}
-          </button>
-        }
-      </bit-menu>
+    @if (showCopyActions()) {
+      <vault-item-copy-actions
+        class="tw-inline-flex tw-items-center tw-gap-2 tw-align-middle [&_button[biticonbutton]]:-tw-mx-1"
+        [cipher]="cipher()"
+        [showQuickCopyActions]="showQuickCopyActions()"
+      ></vault-item-copy-actions>
     }
 
     <button

--- a/apps/desktop/src/vault/app/vault-v3/vault-items/vault-cipher-row.component.html
+++ b/apps/desktop/src/vault/app/vault-v3/vault-items/vault-cipher-row.component.html
@@ -86,7 +86,7 @@
     @if (showCopyActions()) {
       <vault-item-copy-actions
         [cipher]="cipher()"
-        [showQuickCopyActions]="showQuickCopyActions() && quickCopyIconFeatureFlag()"
+        [showQuickCopyActions]="showQuickCopyActions()"
         [disabled]="disabled()"
       ></vault-item-copy-actions>
     }

--- a/apps/desktop/src/vault/app/vault-v3/vault-items/vault-cipher-row.component.html
+++ b/apps/desktop/src/vault/app/vault-v3/vault-items/vault-cipher-row.component.html
@@ -87,7 +87,7 @@
       <vault-item-copy-actions
         class="tw-inline-flex tw-items-center tw-gap-2 tw-align-middle [&_button[biticonbutton]]:-tw-mx-1"
         [cipher]="cipher()"
-        [showQuickCopyActions]="showQuickCopyActions()"
+        [showQuickCopyActions]="showQuickCopyActions() && quickCopyIconFeatureFlag()"
         [disabled]="disabled()"
       ></vault-item-copy-actions>
     }

--- a/apps/desktop/src/vault/app/vault-v3/vault-items/vault-cipher-row.component.html
+++ b/apps/desktop/src/vault/app/vault-v3/vault-items/vault-cipher-row.component.html
@@ -85,6 +85,7 @@
     }
     @if (showCopyActions()) {
       <vault-item-copy-actions
+        class="tw-inline-flex tw-align-middle"
         [cipher]="cipher()"
         [showQuickCopyActions]="showQuickCopyActions()"
         [disabled]="disabled()"

--- a/apps/desktop/src/vault/app/vault-v3/vault-items/vault-cipher-row.component.html
+++ b/apps/desktop/src/vault/app/vault-v3/vault-items/vault-cipher-row.component.html
@@ -85,7 +85,6 @@
     }
     @if (showCopyActions()) {
       <vault-item-copy-actions
-        class="tw-inline-flex tw-items-center tw-gap-2 tw-align-middle [&_button[biticonbutton]]:-tw-mx-1"
         [cipher]="cipher()"
         [showQuickCopyActions]="showQuickCopyActions() && quickCopyIconFeatureFlag()"
         [disabled]="disabled()"

--- a/apps/desktop/src/vault/app/vault-v3/vault-items/vault-cipher-row.component.spec.ts
+++ b/apps/desktop/src/vault/app/vault-v3/vault-items/vault-cipher-row.component.spec.ts
@@ -17,7 +17,7 @@ import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { LoginUriView } from "@bitwarden/common/vault/models/view/login-uri.view";
 import { LoginView } from "@bitwarden/common/vault/models/view/login.view";
 import { CipherViewLike } from "@bitwarden/common/vault/utils/cipher-view-like-utils";
-import { CopyCipherFieldService } from "@bitwarden/vault";
+import { CopyCipherFieldService, VaultCopyButtonsService } from "@bitwarden/vault";
 
 import { VaultCipherRowComponent } from "./vault-cipher-row.component";
 
@@ -39,8 +39,11 @@ console.error = (...args: unknown[]) => {
 describe("VaultCipherRowComponent", () => {
   let fixture: ComponentFixture<VaultCipherRowComponent<CipherViewLike>>;
   let overlayContainer: OverlayContainer;
+  let showQuickCopyActions$: BehaviorSubject<boolean>;
 
   beforeEach(async () => {
+    showQuickCopyActions$ = new BehaviorSubject<boolean>(false);
+
     await TestBed.configureTestingModule({
       imports: [VaultCipherRowComponent],
       providers: [
@@ -67,6 +70,10 @@ describe("VaultCipherRowComponent", () => {
         {
           provide: DomainSettingsService,
           useValue: { showFavicons$: new BehaviorSubject(false).asObservable() },
+        },
+        {
+          provide: VaultCopyButtonsService,
+          useValue: { showQuickCopyActions$: showQuickCopyActions$.asObservable() },
         },
       ],
     }).compileComponents();
@@ -167,6 +174,15 @@ describe("VaultCipherRowComponent", () => {
     it("still renders the copy button in the row", () => {
       const copyBtn = fixture.nativeElement.querySelector('button[biticonbutton="bwi-clone"]');
       expect(copyBtn).toBeTruthy();
+    });
+
+    it("renders individual quick-copy icons when quick copy actions are enabled", () => {
+      showQuickCopyActions$.next(true);
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.querySelector('button[biticonbutton="bwi-user"]')).toBeTruthy();
+      expect(fixture.nativeElement.querySelector('button[biticonbutton="bwi-clock"]')).toBeTruthy();
+      expect(fixture.nativeElement.querySelector('button[biticonbutton="bwi-clone"]')).toBeNull();
     });
   });
 

--- a/apps/desktop/src/vault/app/vault-v3/vault-items/vault-cipher-row.component.spec.ts
+++ b/apps/desktop/src/vault/app/vault-v3/vault-items/vault-cipher-row.component.spec.ts
@@ -59,7 +59,7 @@ describe("VaultCipherRowComponent", () => {
         },
         {
           provide: ConfigService,
-          useValue: { getFeatureFlag$: jest.fn().mockReturnValue(of(false)) },
+          useValue: { getFeatureFlag$: jest.fn().mockReturnValue(of(true)) },
         },
         {
           provide: EnvironmentService,

--- a/apps/desktop/src/vault/app/vault-v3/vault-items/vault-cipher-row.component.ts
+++ b/apps/desktop/src/vault/app/vault-v3/vault-items/vault-cipher-row.component.ts
@@ -7,6 +7,8 @@ import { toSignal } from "@angular/core/rxjs-interop";
 import { PremiumBadgeComponent } from "@bitwarden/angular/billing/components/premium-badge/premium-badge.component";
 import { IconComponent } from "@bitwarden/angular/vault/components/icon.component";
 import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
+import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import {
@@ -95,10 +97,16 @@ export class VaultCipherRowComponent<C extends CipherViewLike> {
   private platformUtilsService = inject(PlatformUtilsService);
   private i18nService = inject(I18nService);
   private vaultCopyButtonsService = inject(VaultCopyButtonsService);
+  private configService = inject(ConfigService);
 
   /** Whether copy actions render as individual quick-copy icons rather than a single menu. */
   protected readonly showQuickCopyActions = toSignal(
     this.vaultCopyButtonsService.showQuickCopyActions$,
+    { initialValue: false },
+  );
+
+  protected readonly quickCopyIconFeatureFlag = toSignal(
+    this.configService.getFeatureFlag$(FeatureFlag.PM40435_QuickCopyIconSetting),
     { initialValue: false },
   );
 

--- a/apps/desktop/src/vault/app/vault-v3/vault-items/vault-cipher-row.component.ts
+++ b/apps/desktop/src/vault/app/vault-v3/vault-items/vault-cipher-row.component.ts
@@ -9,7 +9,6 @@ import { IconComponent } from "@bitwarden/angular/vault/components/icon.componen
 import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
-import { CipherType } from "@bitwarden/common/vault/enums";
 import {
   CipherViewLike,
   CipherViewLikeUtils,
@@ -66,7 +65,6 @@ export class VaultCipherRowComponent<C extends CipherViewLike> {
   protected readonly disabled = input<boolean>();
   protected readonly cipher = input<C>();
   protected readonly showOwner = input<boolean>();
-  protected readonly showPremiumFeatures = input<boolean>();
   protected readonly useEvents = input<boolean>();
   protected readonly cloneable = input<boolean>();
   protected readonly organizations = input<Organization[]>();
@@ -93,8 +91,6 @@ export class VaultCipherRowComponent<C extends CipherViewLike> {
   protected readonly selected = input<boolean>(false);
   protected readonly checkboxChange = output<void>();
   protected readonly onEvent = output<VaultItemEvent<C>>();
-
-  protected CipherType = CipherType;
 
   private platformUtilsService = inject(PlatformUtilsService);
   private i18nService = inject(I18nService);

--- a/apps/desktop/src/vault/app/vault-v3/vault-items/vault-cipher-row.component.ts
+++ b/apps/desktop/src/vault/app/vault-v3/vault-items/vault-cipher-row.component.ts
@@ -2,6 +2,7 @@
 // @ts-strict-ignore
 import { NgClass } from "@angular/common";
 import { Component, HostListener, computed, inject, input, output, viewChild } from "@angular/core";
+import { toSignal } from "@angular/core/rxjs-interop";
 
 import { PremiumBadgeComponent } from "@bitwarden/angular/billing/components/premium-badge/premium-badge.component";
 import { IconComponent } from "@bitwarden/angular/vault/components/icon.component";
@@ -24,21 +25,15 @@ import {
 } from "@bitwarden/components";
 import { I18nPipe } from "@bitwarden/ui-common";
 import {
-  CopyAction,
-  CopyCipherFieldDirective,
   GetOrgNameFromIdPipe,
   OrganizationNameBadgeComponent,
+  VaultCopyButtonsService,
+  VaultItemCopyActionsComponent,
   Vfo1I18nPipe,
   Vfo1IconPipe,
 } from "@bitwarden/vault";
 
 import { VaultItemEvent } from "./vault-item-event";
-
-/** Configuration for a copyable field */
-interface CopyFieldConfig {
-  field: CopyAction;
-  title: string;
-}
 
 // FIXME(https://bitwarden.atlassian.net/browse/CL-764): Migrate to OnPush
 // eslint-disable-next-line @angular-eslint/prefer-on-push-component-change-detection
@@ -52,7 +47,7 @@ interface CopyFieldConfig {
     OrganizationNameBadgeComponent,
     BitIconButtonComponent,
     MenuModule,
-    CopyCipherFieldDirective,
+    VaultItemCopyActionsComponent,
     PremiumBadgeComponent,
     GetOrgNameFromIdPipe,
     IconComponent,
@@ -103,6 +98,13 @@ export class VaultCipherRowComponent<C extends CipherViewLike> {
 
   private platformUtilsService = inject(PlatformUtilsService);
   private i18nService = inject(I18nService);
+  private vaultCopyButtonsService = inject(VaultCopyButtonsService);
+
+  /** Whether copy actions render as individual quick-copy icons rather than a single menu. */
+  protected readonly showQuickCopyActions = toSignal(
+    this.vaultCopyButtonsService.showQuickCopyActions$,
+    { initialValue: false },
+  );
 
   protected readonly showArchiveButton = computed(() => {
     return (
@@ -189,94 +191,12 @@ export class VaultCipherRowComponent<C extends CipherViewLike> {
   });
 
   /**
-   * Returns the list of copyable fields based on cipher type.
-   * Used to render copy menu items dynamically.
+   * Determines if the copy actions should be shown. Copy actions are hidden for deleted or
+   * archived items; the shared component decides which fields are copyable per cipher type.
    */
-  protected readonly copyFields = computed((): CopyFieldConfig[] => {
+  protected readonly showCopyActions = computed(() => {
     const cipher = this.cipher();
-
-    // No copy options for deleted or archived items
-    if (this.isDeleted() || CipherViewLikeUtils.isArchived(cipher)) {
-      return [];
-    }
-
-    const cipherType = CipherViewLikeUtils.getType(cipher);
-
-    switch (cipherType) {
-      case CipherType.Login: {
-        const fields: CopyFieldConfig[] = [{ field: "username", title: "copyUsername" }];
-        if (cipher.viewPassword) {
-          fields.push({ field: "password", title: "copyPassword" });
-        }
-        if (
-          CipherViewLikeUtils.getLogin(cipher).totp &&
-          (cipher.organizationUseTotp || this.showPremiumFeatures())
-        ) {
-          fields.push({ field: "totp", title: "copyVerificationCode" });
-        }
-        return fields;
-      }
-      case CipherType.Card:
-        return [
-          { field: "cardNumber", title: "copyNumber" },
-          { field: "securityCode", title: "copySecurityCode" },
-        ];
-      case CipherType.Identity:
-        return [
-          { field: "username", title: "copyUsername" },
-          { field: "email", title: "copyEmail" },
-          { field: "phone", title: "copyPhone" },
-          { field: "address", title: "copyAddress" },
-        ];
-      case CipherType.SecureNote:
-        return [{ field: "secureNote", title: "copyNote" }];
-      case CipherType.BankAccount:
-        return [
-          { field: "nameOnAccount", title: "copyNameOnAccount" },
-          { field: "accountNumber", title: "copyAccountNumber" },
-          { field: "routingNumber", title: "copyRoutingNumber" },
-          { field: "branchNumber", title: "copyBranchNumber" },
-          { field: "pin", title: "copyPin" },
-          { field: "iban", title: "copyIban" },
-          { field: "swiftCode", title: "copySwiftCode" },
-        ];
-      case CipherType.Passport:
-        return [
-          { field: "givenName", title: "copyFirstName" },
-          { field: "surname", title: "copyLastName" },
-          { field: "passportNumber", title: "copyPassportNumber" },
-          {
-            field: "nationalIdentificationNumber",
-            title: "copyNationalIdentificationNumber",
-          },
-        ];
-      case CipherType.DriversLicense:
-        return [
-          { field: "firstNameLicense", title: "copyFirstName" },
-          { field: "middleNameLicense", title: "copyMiddleName" },
-          { field: "lastNameLicense", title: "copyLastName" },
-          { field: "licenseNumber", title: "copyLicenseNumber" },
-        ];
-      case CipherType.SshKey:
-        return [
-          { field: "privateKey", title: "copyPrivateKey" },
-          { field: "publicKey", title: "copyPublicKey" },
-          { field: "keyFingerprint", title: "copyFingerprint" },
-        ];
-      default:
-        return [];
-    }
-  });
-
-  /**
-   * Determines if the copy button should be shown.
-   * Returns true only if at least one field has a copyable value.
-   */
-  protected readonly showCopyButton = computed(() => {
-    const cipher = this.cipher();
-    return this.copyFields().some(({ field }) =>
-      CipherViewLikeUtils.hasCopyableValue(cipher, field),
-    );
+    return !this.isDeleted() && !CipherViewLikeUtils.isArchived(cipher);
   });
 
   protected clone() {

--- a/apps/desktop/src/vault/app/vault-v3/vault-items/vault-cipher-row.component.ts
+++ b/apps/desktop/src/vault/app/vault-v3/vault-items/vault-cipher-row.component.ts
@@ -99,15 +99,19 @@ export class VaultCipherRowComponent<C extends CipherViewLike> {
   private vaultCopyButtonsService = inject(VaultCopyButtonsService);
   private configService = inject(ConfigService);
 
-  /** Whether copy actions render as individual quick-copy icons rather than a single menu. */
-  protected readonly showQuickCopyActions = toSignal(
+  private readonly quickCopyActionsSetting = toSignal(
     this.vaultCopyButtonsService.showQuickCopyActions$,
     { initialValue: false },
   );
 
-  protected readonly quickCopyIconFeatureFlag = toSignal(
+  private readonly quickCopyIconFeatureFlag = toSignal(
     this.configService.getFeatureFlag$(FeatureFlag.PM40435_QuickCopyIconSetting),
     { initialValue: false },
+  );
+
+  /** Whether copy actions render as individual quick-copy icons rather than a single menu. */
+  protected readonly showQuickCopyActions = computed(
+    () => this.quickCopyIconFeatureFlag() && this.quickCopyActionsSetting(),
   );
 
   protected readonly showArchiveButton = computed(() => {

--- a/apps/desktop/src/vault/app/vault-v3/vault-list.component.html
+++ b/apps/desktop/src/vault/app/vault-v3/vault-list.component.html
@@ -82,7 +82,6 @@
               [disabled]="disabled()"
               [cipher]="item.cipher"
               [showOwner]="showOwner()"
-              [showPremiumFeatures]="showPremiumFeatures()"
               [cloneable]="canClone$(item) | async"
               [organizations]="allOrganizations()"
               [canEditCipher]="canEditCipher(item.cipher)"

--- a/apps/desktop/src/vault/app/vault-v3/vault-list.component.ts
+++ b/apps/desktop/src/vault/app/vault-v3/vault-list.component.ts
@@ -78,7 +78,6 @@ export class VaultListComponent<C extends CipherViewLike> {
 
   protected readonly disabled = input<boolean>();
   protected readonly showOwner = input<boolean>();
-  protected readonly showPremiumFeatures = input<boolean>();
   protected readonly allOrganizations = input<Organization[]>([]);
   protected readonly allCollections = input<CollectionView[]>([]);
   protected readonly userCanArchive = input<boolean>();

--- a/apps/desktop/src/vault/app/vault-v3/vault.component.html
+++ b/apps/desktop/src/vault/app/vault-v3/vault.component.html
@@ -31,7 +31,6 @@
     [allOrganizations]="allOrganizations"
     [disabled]="refreshing"
     [showOwner]="true"
-    [showPremiumFeatures]="userHasPremium()"
     [userCanArchive]="userCanArchive$ | async"
     [enforceOrgDataOwnershipPolicy]="enforceOrgDataOwnershipPolicy$ | async"
     [placeholderText]="searchPlaceholderText"

--- a/libs/vault/src/components/copy-cipher-field.directive.spec.ts
+++ b/libs/vault/src/components/copy-cipher-field.directive.spec.ts
@@ -44,7 +44,7 @@ describe("CopyCipherFieldDirective", () => {
 
       await copyCipherFieldDirective.ngOnChanges();
 
-      expect(copyCipherFieldDirective["disabled"]).toBe(null);
+      expect(copyCipherFieldDirective["hostDisabled"]).toBe(null);
     });
 
     it("should be disabled when the field is not available", async () => {
@@ -56,7 +56,32 @@ describe("CopyCipherFieldDirective", () => {
 
       await copyCipherFieldDirective.ngOnChanges();
 
-      expect(copyCipherFieldDirective["disabled"]).toBe(true);
+      expect(copyCipherFieldDirective["hostDisabled"]).toBe(true);
+    });
+
+    it("should be disabled when externally disabled even if the field is available", async () => {
+      copyCipherFieldDirective.action = "username";
+      (copyCipherFieldDirective.cipher as CipherView).login.username = "test-username";
+      copyCipherFieldDirective.disabled = true;
+
+      await copyCipherFieldDirective.ngOnChanges();
+
+      expect(copyCipherFieldDirective["hostDisabled"]).toBe(true);
+    });
+
+    it("stays disabled for an unavailable field when the external disabled state is toggled off", async () => {
+      // Empty cipher, so the field has no value to copy.
+      copyCipherFieldDirective.cipher = new CipherView();
+      copyCipherFieldDirective.cipher.type = CipherType.Login;
+      copyCipherFieldDirective.action = "username";
+
+      // Simulate a list refresh toggling the external disabled state true -> false.
+      copyCipherFieldDirective.disabled = true;
+      await copyCipherFieldDirective.ngOnChanges();
+      copyCipherFieldDirective.disabled = false;
+      await copyCipherFieldDirective.ngOnChanges();
+
+      expect(copyCipherFieldDirective["hostDisabled"]).toBe(true);
     });
 
     it("updates icon button disabled state", async () => {
@@ -100,6 +125,30 @@ describe("CopyCipherFieldDirective", () => {
       await copyCipherFieldDirective.ngOnChanges();
 
       expect(menuItemComponent.disabled).toBe(true);
+    });
+  });
+
+  describe("copy guard", () => {
+    it("does not copy when the field has no value", async () => {
+      copyCipherFieldDirective.cipher = new CipherView();
+      copyCipherFieldDirective.cipher.type = CipherType.Login;
+      copyCipherFieldDirective.action = "username";
+
+      await copyCipherFieldDirective.ngOnChanges();
+      await copyCipherFieldDirective.copy();
+
+      expect(copyFieldService.copy).not.toHaveBeenCalled();
+    });
+
+    it("does not copy when externally disabled", async () => {
+      copyCipherFieldDirective.action = "username";
+      (copyCipherFieldDirective.cipher as CipherView).login.username = "test-username";
+      copyCipherFieldDirective.disabled = true;
+
+      await copyCipherFieldDirective.ngOnChanges();
+      await copyCipherFieldDirective.copy();
+
+      expect(copyFieldService.copy).not.toHaveBeenCalled();
     });
   });
 

--- a/libs/vault/src/components/copy-cipher-field.directive.ts
+++ b/libs/vault/src/components/copy-cipher-field.directive.ts
@@ -1,4 +1,12 @@
-import { Directive, HostBinding, HostListener, Input, OnChanges, Optional } from "@angular/core";
+import {
+  booleanAttribute,
+  Directive,
+  HostBinding,
+  HostListener,
+  Input,
+  OnChanges,
+  Optional,
+} from "@angular/core";
 import { firstValueFrom } from "rxjs";
 
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
@@ -44,6 +52,18 @@ export class CopyCipherFieldDirective implements OnChanges {
   @Input({ required: true })
   cipher!: CipherViewLike;
 
+  /**
+   * Externally-forced disabled state, e.g. while the containing list is refreshing. This is
+   * combined with the field-availability check so the directive remains the sole writer of the
+   * host and icon-button disabled state. Binding `[disabled]` directly on the same element would
+   * otherwise clobber the disabled state this directive owns — an external re-enable could make a
+   * button with no value to copy clickable again.
+   */
+  // FIXME(https://bitwarden.atlassian.net/browse/CL-903): Migrate to Signals
+  // eslint-disable-next-line @angular-eslint/prefer-signals
+  @Input({ transform: booleanAttribute })
+  disabled = false;
+
   constructor(
     private copyCipherFieldService: CopyCipherFieldService,
     private accountService: AccountService,
@@ -53,7 +73,7 @@ export class CopyCipherFieldDirective implements OnChanges {
   ) {}
 
   @HostBinding("attr.disabled")
-  protected disabled: boolean | null = null;
+  protected hostDisabled: boolean | null = null;
 
   /**
    * Hide the element if it is disabled and is a menu item.
@@ -61,11 +81,16 @@ export class CopyCipherFieldDirective implements OnChanges {
    */
   @HostBinding("class.tw-hidden")
   private get hidden() {
-    return this.disabled && this.menuItemComponent;
+    return this.hostDisabled && this.menuItemComponent;
   }
 
   @HostListener("click")
   async copy() {
+    // Guard against copying when disabled. The click-capture guard normally prevents this, but
+    // this ensures a disabled field (no value, or externally disabled) never copies an empty value.
+    if (this.hostDisabled) {
+      return;
+    }
     const value = await this.getValueToCopy();
     await this.copyCipherFieldService.copy(value ?? "", this.action, this.cipher);
   }
@@ -75,21 +100,21 @@ export class CopyCipherFieldDirective implements OnChanges {
   }
 
   private async updateDisabledState() {
-    this.disabled =
+    const unavailable =
       !this.cipher ||
       !this.hasValueToCopy() ||
-      (this.action === "totp" && !(await this.copyCipherFieldService.totpAllowed(this.cipher)))
-        ? true
-        : null;
+      (this.action === "totp" && !(await this.copyCipherFieldService.totpAllowed(this.cipher)));
+
+    this.hostDisabled = this.disabled || unavailable ? true : null;
 
     // When used on an icon button, update the disabled state of the button component
     if (this.iconButtonComponent) {
-      this.iconButtonComponent.disabled.set(this.disabled ?? false);
+      this.iconButtonComponent.disabled.set(this.hostDisabled ?? false);
     }
 
     // If the directive is used on a menu item, update the menu item to prevent keyboard navigation
     if (this.menuItemComponent) {
-      this.menuItemComponent.disabled = this.disabled ?? false;
+      this.menuItemComponent.disabled = this.hostDisabled ?? false;
     }
   }
 

--- a/libs/vault/src/components/item-copy-actions/item-copy-actions.component.html
+++ b/libs/vault/src/components/item-copy-actions/item-copy-actions.component.html
@@ -8,6 +8,7 @@
         size="small"
         appCopyField="username"
         [cipher]="_cipher"
+        [disabled]="disabled()"
         [label]="
           CipherViewLikeUtils.hasCopyableValue(_cipher, 'username')
             ? ('copyUsername' | i18n)
@@ -23,6 +24,7 @@
           size="small"
           appCopyField="password"
           [cipher]="_cipher"
+          [disabled]="disabled()"
           [label]="
             CipherViewLikeUtils.hasCopyableValue(_cipher, 'password')
               ? ('copyPassword' | i18n)
@@ -38,6 +40,7 @@
         size="small"
         appCopyField="totp"
         [cipher]="_cipher"
+        [disabled]="disabled()"
         [label]="
           CipherViewLikeUtils.hasCopyableValue(_cipher, 'totp')
             ? ('copyVerificationCode' | i18n)
@@ -55,6 +58,7 @@
           [label]="'copyFieldCipherName' | i18n: singleCopyableLogin.key : _cipher.name"
           [appCopyField]="singleCopyableLogin.field"
           [cipher]="_cipher"
+          [disabled]="disabled()"
         ></button>
       }
       @if (!singleCopyableLogin) {
@@ -65,7 +69,7 @@
           [label]="
             hasLoginValues ? ('copyDetailsTitle' | i18n: _cipher.name) : ('noDetailsToCopy' | i18n)
           "
-          [disabled]="!hasLoginValues"
+          [disabled]="disabled() || !hasLoginValues"
           [bitMenuTriggerFor]="loginOptions"
         ></button>
         <bit-menu #loginOptions>
@@ -95,6 +99,7 @@
         size="small"
         appCopyField="cardNumber"
         [cipher]="_cipher"
+        [disabled]="disabled()"
         [label]="
           CipherViewLikeUtils.hasCopyableValue(_cipher, 'cardNumber')
             ? ('copyNumber' | i18n)
@@ -109,6 +114,7 @@
         size="small"
         appCopyField="securityCode"
         [cipher]="_cipher"
+        [disabled]="disabled()"
         [label]="
           CipherViewLikeUtils.hasCopyableValue(_cipher, 'securityCode')
             ? ('copySecurityCode' | i18n)
@@ -126,6 +132,7 @@
           [label]="'copyFieldCipherName' | i18n: singleCopyableCard.key : _cipher.name"
           [appCopyField]="singleCopyableCard.field"
           [cipher]="_cipher"
+          [disabled]="disabled()"
           showToast
         ></button>
       }
@@ -137,7 +144,7 @@
           [label]="
             hasCardValues ? ('copyDetailsTitle' | i18n: _cipher.name) : ('noDetailsToCopy' | i18n)
           "
-          [disabled]="!hasCardValues"
+          [disabled]="disabled() || !hasCardValues"
           [bitMenuTriggerFor]="cardOptions"
         ></button>
         <bit-menu #cardOptions>
@@ -163,6 +170,7 @@
         [label]="'copyFieldCipherName' | i18n: singleCopyableIdentity.key : _cipher.name"
         [appCopyField]="singleCopyableIdentity.field"
         [cipher]="_cipher"
+        [disabled]="disabled()"
         showToast
       ></button>
     }
@@ -174,7 +182,7 @@
         [label]="
           hasIdentityValues ? ('copyDetailsTitle' | i18n: _cipher.name) : ('noDetailsToCopy' | i18n)
         "
-        [disabled]="!hasIdentityValues"
+        [disabled]="disabled() || !hasIdentityValues"
         [bitMenuTriggerFor]="identityOptions"
       ></button>
       <bit-menu #identityOptions>
@@ -206,6 +214,7 @@
       "
       appCopyField="secureNote"
       [cipher]="_cipher"
+      [disabled]="disabled()"
     ></button>
   </bit-item-action>
 }
@@ -219,7 +228,7 @@
       [label]="
         hasSshKeyValues ? ('copyDetailsTitle' | i18n: _cipher.name) : ('noDetailsToCopy' | i18n)
       "
-      [disabled]="!hasSshKeyValues"
+      [disabled]="disabled() || !hasSshKeyValues"
       [bitMenuTriggerFor]="sshKeyOptions"
     ></button>
     <bit-menu #sshKeyOptions>
@@ -246,6 +255,7 @@
         [label]="'copyFieldCipherName' | i18n: singleCopyableBankAccount.key : _cipher.name"
         [appCopyField]="singleCopyableBankAccount.field"
         [cipher]="_cipher"
+        [disabled]="disabled()"
         showToast
       ></button>
     } @else {
@@ -258,7 +268,7 @@
             ? ('copyDetailsTitle' | i18n: _cipher.name)
             : ('noDetailsToCopy' | i18n)
         "
-        [disabled]="!hasBankAccountValues"
+        [disabled]="disabled() || !hasBankAccountValues"
         [bitMenuTriggerFor]="bankAccountOptions"
       ></button>
       <bit-menu #bankAccountOptions>
@@ -298,6 +308,7 @@
         [label]="'copyFieldCipherName' | i18n: singleCopyableDriversLicense.key : _cipher.name"
         [appCopyField]="singleCopyableDriversLicense.field"
         [cipher]="_cipher"
+        [disabled]="disabled()"
         showToast
       ></button>
     } @else {
@@ -310,7 +321,7 @@
             ? ('copyDetailsTitle' | i18n: _cipher.name)
             : ('noDetailsToCopy' | i18n)
         "
-        [disabled]="!hasDriversLicenseValues"
+        [disabled]="disabled() || !hasDriversLicenseValues"
         [bitMenuTriggerFor]="driversLicenseOptions"
       ></button>
       <bit-menu #driversLicenseOptions>
@@ -341,6 +352,7 @@
         [label]="'copyFieldCipherName' | i18n: singleCopyablePassport.key : _cipher.name"
         [appCopyField]="singleCopyablePassport.field"
         [cipher]="_cipher"
+        [disabled]="disabled()"
         showToast
       ></button>
     } @else {
@@ -351,7 +363,7 @@
         [label]="
           hasPassportValues ? ('copyDetailsTitle' | i18n: _cipher.name) : ('noDetailsToCopy' | i18n)
         "
-        [disabled]="!hasPassportValues"
+        [disabled]="disabled() || !hasPassportValues"
         [bitMenuTriggerFor]="passportOptions"
       ></button>
       <bit-menu #passportOptions>

--- a/libs/vault/src/components/item-copy-actions/item-copy-actions.component.spec.ts
+++ b/libs/vault/src/components/item-copy-actions/item-copy-actions.component.spec.ts
@@ -173,6 +173,27 @@ describe("VaultItemCopyActionsComponent", () => {
       expect(disabledFor("bwi-key")).toBe("true");
       expect(disabledFor("bwi-clock")).toBe("true");
     });
+
+    it("keeps empty-value copy actions disabled after disabled toggles off (list refresh)", async () => {
+      // A login with no username: the username quick-copy button should always be disabled.
+      (component.cipher() as any).__copyable = { username: false, password: true, totp: true };
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      // Simulate a list refresh toggling the disabled input true -> false.
+      fixture.componentRef.setInput("disabled", true);
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      fixture.componentRef.setInput("disabled", false);
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      // The empty username button must remain disabled; the populated ones become enabled again.
+      expect(disabledFor("bwi-user")).toBe("true");
+      expect(disabledFor("bwi-key")).toBeNull();
+      expect(disabledFor("bwi-clock")).toBeNull();
+    });
   });
 
   describe("findSingleCopyableItem", () => {

--- a/libs/vault/src/components/item-copy-actions/item-copy-actions.component.spec.ts
+++ b/libs/vault/src/components/item-copy-actions/item-copy-actions.component.spec.ts
@@ -25,11 +25,15 @@ describe("VaultItemCopyActionsComponent", () => {
   let component: VaultItemCopyActionsComponent;
 
   let i18nService: jest.Mocked<I18nService>;
+  let copyCipherFieldService: jest.Mocked<CopyCipherFieldService>;
 
   beforeEach(async () => {
     i18nService = {
       t: jest.fn((key: string) => `translated-${key}`),
     } as unknown as jest.Mocked<I18nService>;
+
+    copyCipherFieldService = mock<CopyCipherFieldService>();
+    copyCipherFieldService.totpAllowed.mockResolvedValue(true);
 
     await TestBed.configureTestingModule({
       imports: [
@@ -42,7 +46,7 @@ describe("VaultItemCopyActionsComponent", () => {
       ],
       providers: [
         { provide: I18nService, useValue: i18nService },
-        { provide: CopyCipherFieldService, useValue: mock<CopyCipherFieldService>() },
+        { provide: CopyCipherFieldService, useValue: copyCipherFieldService },
         { provide: AccountService, useValue: mock<AccountService>() },
         { provide: CipherService, useValue: mock<CipherService>() },
       ],

--- a/libs/vault/src/components/item-copy-actions/item-copy-actions.component.spec.ts
+++ b/libs/vault/src/components/item-copy-actions/item-copy-actions.component.spec.ts
@@ -140,6 +140,41 @@ describe("VaultItemCopyActionsComponent", () => {
     });
   });
 
+  describe("disabled input", () => {
+    beforeEach(() => {
+      jest.spyOn(CipherViewLikeUtils, "isCipherListView").mockReturnValue(false);
+      fixture.componentRef.setInput("showQuickCopyActions", true);
+      (component.cipher() as any).__copyable = { username: true, password: true, totp: true };
+    });
+
+    const disabledFor = (icon: string) =>
+      fixture.debugElement
+        .query(By.css(`button[bitIconButton="${icon}"]`))
+        ?.nativeElement.getAttribute("aria-disabled");
+
+    it("leaves copy actions enabled by default", async () => {
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      expect(disabledFor("bwi-user")).toBeNull();
+      expect(disabledFor("bwi-key")).toBeNull();
+      expect(disabledFor("bwi-clock")).toBeNull();
+    });
+
+    it("disables copy actions when disabled is true", async () => {
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      fixture.componentRef.setInput("disabled", true);
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      expect(disabledFor("bwi-user")).toBe("true");
+      expect(disabledFor("bwi-key")).toBe("true");
+      expect(disabledFor("bwi-clock")).toBe("true");
+    });
+  });
+
   describe("findSingleCopyableItem", () => {
     it("returns the single item with value and translates its key", () => {
       const items = [

--- a/libs/vault/src/components/item-copy-actions/item-copy-actions.component.ts
+++ b/libs/vault/src/components/item-copy-actions/item-copy-actions.component.ts
@@ -38,6 +38,9 @@ export class VaultItemCopyActionsComponent {
 
   readonly showQuickCopyActions = input(false);
 
+  /** Disables all copy actions, e.g. while the containing list is refreshing. */
+  readonly disabled = input(false);
+
   protected readonly CipherViewLikeUtils = CipherViewLikeUtils;
   protected readonly CipherType = CipherType;
 


### PR DESCRIPTION
## 🎟️ Tracking

[Jira](https://bitwarden.atlassian.net/browse/PM-40549)

## 📔 Objective

The experience in the desktop and web app should mirror that of the extension with the following changes to the location of the setting toggle.

Desktop App Setting
- Location: Settings > App settings (all accounts)
- Type: Checkbox
- Text: Show quick copy actions on Vault
- Default: OFF
- Setting sync: Setting is per client, does not sync to the account

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/f4545d8d-87a8-413c-b308-abc919813357