### PR TITLE
feat(crypto): add user-key id tracking

### DIFF
--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -133,8 +133,6 @@ import { DefaultMasterPasswordUnlockService } from "@bitwarden/common/key-manage
 import { MasterPasswordService } from "@bitwarden/common/key-management/master-password/services/master-password.service";
 import { PinServiceAbstraction } from "@bitwarden/common/key-management/pin/pin.service.abstraction";
 import { PinService } from "@bitwarden/common/key-management/pin/pin.service.implementation";
-import { SecurityStateService } from "@bitwarden/common/key-management/security-state/abstractions/security-state.service";
-import { DefaultSecurityStateService } from "@bitwarden/common/key-management/security-state/services/security-state.service";
 import { DefaultProcessReloadService } from "@bitwarden/common/key-management/services/default-process-reload.service";
 import {
   SharedUnlockLeaderService,
@@ -558,7 +556,6 @@ export default class MainBackground {
   cipherEncryptionService: CipherEncryptionService;
   collectionEncryptionService: CollectionEncryptionService;
   private restrictedItemTypesService: RestrictedItemTypesService;
-  private securityStateService: SecurityStateService;
 
   ipcContentScriptManagerService: IpcContentScriptManagerService;
   ipcService: IpcService;
@@ -762,10 +759,6 @@ export default class MainBackground {
       this.encryptService,
       this.logService,
       logoutCallback,
-    );
-
-    this.securityStateService = new DefaultSecurityStateService(
-      this.accountCryptographicStateService,
     );
 
     this.popupViewCacheBackgroundService = new PopupViewCacheBackgroundService(
@@ -1241,11 +1234,8 @@ export default class MainBackground {
       this.tokenService,
       this.authService,
       this.stateProvider,
-      this.securityStateService,
-      this.kdfConfigService,
-      this.accountCryptographicStateService,
-      this.v2UpgradeTokenStateService,
       this.configService,
+      this.sdkService,
     );
 
     this.syncServiceListener = new SyncServiceListener(

--- a/apps/cli/src/service-container/service-container.ts
+++ b/apps/cli/src/service-container/service-container.ts
@@ -1025,11 +1025,8 @@ export class ServiceContainer {
       this.tokenService,
       this.authService,
       this.stateProvider,
-      this.securityStateService,
-      this.kdfConfigService,
-      this.accountCryptographicStateService,
-      this.v2UpgradeTokenStateService,
       this.configService,
+      this.sdkService,
     );
 
     this.totpService = new TotpService(this.sdkService);

--- a/libs/angular/src/services/jslib-services.module.ts
+++ b/libs/angular/src/services/jslib-services.module.ts
@@ -1016,8 +1016,6 @@ const safeProviders: SafeProvider[] = [
       TokenServiceAbstraction,
       AuthServiceAbstraction,
       StateProvider,
-      KdfConfigService,
-      V2UpgradeTokenStateService,
       ConfigService,
       SdkService,
     ],

--- a/libs/angular/src/services/jslib-services.module.ts
+++ b/libs/angular/src/services/jslib-services.module.ts
@@ -1016,11 +1016,10 @@ const safeProviders: SafeProvider[] = [
       TokenServiceAbstraction,
       AuthServiceAbstraction,
       StateProvider,
-      SecurityStateService,
       KdfConfigService,
-      AccountCryptographicStateService,
       V2UpgradeTokenStateService,
       ConfigService,
+      SdkService,
     ],
   }),
   safeProvider({

--- a/libs/common/src/key-management/models/response/user-decryption.response.spec.ts
+++ b/libs/common/src/key-management/models/response/user-decryption.response.spec.ts
@@ -72,4 +72,21 @@ describe("UserDecryptionResponse", () => {
       expect(userDecryptionResponse.v2UpgradeToken).toBeUndefined();
     },
   );
+
+  it("should parse userKeyId when UserKeyId is provided", () => {
+    const userKeyId = "0123456789abcdef0123456789abcdef";
+
+    const userDecryptionResponse = new UserDecryptionResponse({ UserKeyId: userKeyId });
+
+    expect(userDecryptionResponse.userKeyId).toEqual(userKeyId);
+  });
+
+  it.each([null, undefined, 1234, {}])(
+    "should leave userKeyId undefined when UserKeyId is %s",
+    (userKeyId) => {
+      const userDecryptionResponse = new UserDecryptionResponse({ UserKeyId: userKeyId });
+
+      expect(userDecryptionResponse.userKeyId).toBeUndefined();
+    },
+  );
 });

--- a/libs/common/src/key-management/models/response/user-decryption.response.ts
+++ b/libs/common/src/key-management/models/response/user-decryption.response.ts
@@ -13,6 +13,12 @@ export class UserDecryptionResponse extends BaseResponse {
 
   v2UpgradeToken?: V2UpgradeTokenResponse;
 
+  /**
+   * Hex-encoded key id of the user's current user key, when the server knows it. Absent for
+   * accounts that have not reported their key id yet.
+   */
+  userKeyId?: string;
+
   constructor(response: unknown) {
     super(response);
 
@@ -31,6 +37,11 @@ export class UserDecryptionResponse extends BaseResponse {
     const v2UpgradeToken = this.getResponseProperty("V2UpgradeToken");
     if (v2UpgradeToken != null && typeof v2UpgradeToken === "object") {
       this.v2UpgradeToken = new V2UpgradeTokenResponse(v2UpgradeToken);
+    }
+
+    const userKeyId = this.getResponseProperty("UserKeyId");
+    if (typeof userKeyId === "string") {
+      this.userKeyId = userKeyId;
     }
   }
 }

--- a/libs/common/src/platform/sync/default-sync.service.spec.ts
+++ b/libs/common/src/platform/sync/default-sync.service.spec.ts
@@ -14,6 +14,7 @@ import {
 // This import has been flagged as unallowed for this class. It may be involved in a circular dependency loop.
 // eslint-disable-next-line no-restricted-imports
 import { KdfConfigService, KeyService, PBKDF2KdfConfig } from "@bitwarden/key-management";
+import { KmSyncData } from "@bitwarden/sdk-internal";
 
 import { Matrix } from "../../../spec/matrix";
 import { ApiService } from "../../abstractions/api.service";
@@ -39,7 +40,6 @@ import {
   MasterPasswordSalt,
   MasterPasswordUnlockData,
 } from "../../key-management/master-password/types/master-password.types";
-import { SecurityStateService } from "../../key-management/security-state/abstractions/security-state.service";
 import { V2UpgradeTokenStateService } from "../../key-management/upgrade-token/abstractions/v2-upgrade-token-state.service.abstraction";
 import { SendApiService } from "../../tools/send/services/send-api.service.abstraction";
 import { InternalSendService } from "../../tools/send/services/send.service.abstraction";
@@ -49,6 +49,7 @@ import { FolderApiServiceAbstraction } from "../../vault/abstractions/folder/fol
 import { InternalFolderService } from "../../vault/abstractions/folder/folder.service.abstraction";
 import { ConfigService } from "../abstractions/config/config.service";
 import { LogService } from "../abstractions/log.service";
+import { SdkService } from "../abstractions/sdk/sdk.service";
 import { MessageSender } from "../messaging";
 import { StateProvider } from "../state";
 
@@ -81,11 +82,12 @@ describe("DefaultSyncService", () => {
   let tokenService: MockProxy<TokenService>;
   let authService: MockProxy<AuthService>;
   let stateProvider: MockProxy<StateProvider>;
-  let securityStateService: MockProxy<SecurityStateService>;
   let kdfConfigService: MockProxy<KdfConfigService>;
   let accountCryptographicStateService: MockProxy<AccountCryptographicStateService>;
   let v2UpgradeTokenStateService: MockProxy<V2UpgradeTokenStateService>;
   let configService: MockProxy<ConfigService>;
+  let sdkService: MockProxy<SdkService>;
+  let kmSyncHandler: { on_sync: jest.Mock<Promise<void>, [KmSyncData]> };
 
   let sut: DefaultSyncService;
 
@@ -116,11 +118,20 @@ describe("DefaultSyncService", () => {
     tokenService = mock();
     authService = mock();
     stateProvider = mock();
-    securityStateService = mock();
     kdfConfigService = mock();
     accountCryptographicStateService = mock();
     v2UpgradeTokenStateService = mock();
     configService = mock();
+    sdkService = mock();
+    kmSyncHandler = { on_sync: jest.fn().mockResolvedValue(undefined) };
+    sdkService.userClient$.mockReturnValue(
+      of({
+        take: () => ({
+          value: { km_sync_handler: () => kmSyncHandler },
+          [Symbol.dispose]: jest.fn(),
+        }),
+      }) as unknown as ReturnType<typeof sdkService.userClient$>,
+    );
 
     sut = new DefaultSyncService(
       masterPasswordAbstraction,
@@ -148,11 +159,11 @@ describe("DefaultSyncService", () => {
       tokenService,
       authService,
       stateProvider,
-      securityStateService,
       kdfConfigService,
       accountCryptographicStateService,
       v2UpgradeTokenStateService,
       configService,
+      sdkService,
     );
   });
 
@@ -161,6 +172,12 @@ describe("DefaultSyncService", () => {
   const emptySyncResponse = new SyncResponse({
     profile: {
       id: user1,
+      accountKeys: {
+        publicKeyEncryptionKeyPair: {
+          wrappedPrivateKey: "wrappedPrivateKey",
+          publicKey: "publicKey",
+        },
+      },
     },
     folders: [],
     collections: [],
@@ -181,44 +198,120 @@ describe("DefaultSyncService", () => {
       stateProvider.getUser.mockReturnValue(mock());
     });
 
-    it("sets the correct keys for a V1 user with old response model", async () => {
-      const v1Profile = {
-        id: user1,
-        key: "encryptedUserKey",
-        privateKey: "privateKey",
-        providers: [] as any[],
-        organizations: [] as any[],
-        providerOrganizations: [] as any[],
-        avatarColor: "#fff",
-        securityStamp: "stamp",
-        emailVerified: true,
-        verifyDevices: false,
-        premiumPersonally: false,
-        premiumFromOrganization: false,
-        usesKeyConnector: false,
-      };
-      apiService.getSync.mockResolvedValue(
+    describe("key management sync handler", () => {
+      const syncResponseWithUserDecryption = (userDecryption: Record<string, unknown>) =>
         new SyncResponse({
-          profile: v1Profile,
+          profile: {
+            id: user1,
+            accountKeys: {
+              publicKeyEncryptionKeyPair: {
+                wrappedPrivateKey: "wrappedPrivateKey",
+                publicKey: "publicKey",
+              },
+            },
+          },
           folders: [],
           collections: [],
           ciphers: [],
           sends: [],
           domains: [],
           policies: [],
-        }),
-      );
-      await sut.fullSync(true);
-      expect(masterPasswordAbstraction.setMasterKeyEncryptedUserKey).toHaveBeenCalledWith(
-        new EncString("encryptedUserKey"),
-        user1,
-      );
-      expect(accountCryptographicStateService.setAccountCryptographicState).toHaveBeenCalledWith(
-        { V1: { private_key: "privateKey" } },
-        user1,
-      );
-      expect(keyService.setProviderKeys).toHaveBeenCalledWith([], user1);
-      expect(keyService.setOrgKeys).toHaveBeenCalledWith([], [], user1);
+          userDecryption,
+        });
+
+      it("is not called when the feature flag is off", async () => {
+        configService.getFeatureFlag.mockImplementation(async () => false);
+        apiService.getSync.mockResolvedValue(syncResponseWithUserDecryption({}));
+
+        await sut.fullSync(true);
+
+        expect(kmSyncHandler.on_sync).not.toHaveBeenCalled();
+      });
+
+      it("passes an undefined key id through when the server did not report one", async () => {
+        configService.getFeatureFlag.mockImplementation(
+          async (flag) => flag === FeatureFlag.PostUserKeyId,
+        );
+        apiService.getSync.mockResolvedValue(syncResponseWithUserDecryption({}));
+
+        await sut.fullSync(true);
+
+        const data = kmSyncHandler.on_sync.mock.calls[0][0];
+        expect(data.userDecryption?.userKeyId).toBeUndefined();
+      });
+
+      it("passes the server's key id through when it reported one", async () => {
+        const userKeyId = "0123456789abcdef0123456789abcdef";
+        configService.getFeatureFlag.mockImplementation(
+          async (flag) => flag === FeatureFlag.PostUserKeyId,
+        );
+        apiService.getSync.mockResolvedValue(syncResponseWithUserDecryption({ userKeyId }));
+
+        await sut.fullSync(true);
+
+        const data = kmSyncHandler.on_sync.mock.calls[0][0];
+        expect(data.userDecryption?.userKeyId).toEqual(userKeyId);
+      });
+
+      it("passes the master password unlock data and upgrade token through", async () => {
+        configService.getFeatureFlag.mockImplementation(
+          async (flag) => flag === FeatureFlag.PostUserKeyId,
+        );
+        apiService.getSync.mockResolvedValue(
+          syncResponseWithUserDecryption({
+            masterPasswordUnlock: {
+              salt: "test@example.com",
+              kdf: { kdfType: 0, iterations: 600000 },
+              masterKeyEncryptedUserKey: "encryptedUserKey",
+            },
+            v2UpgradeToken: {
+              wrappedUserKey1: "wrappedUserKey1",
+              wrappedUserKey2: "wrappedUserKey2",
+            },
+          }),
+        );
+
+        await sut.fullSync(true);
+
+        const data = kmSyncHandler.on_sync.mock.calls[0][0];
+        expect(data.userDecryption?.masterPasswordUnlock).toEqual(
+          expect.objectContaining({ salt: "test@example.com" }),
+        );
+        // The SDK's V2UpgradeToken has no serde rename, so its fields stay snake_case.
+        expect(data.userDecryption?.v2UpgradeToken).toEqual({
+          wrapped_user_key_1: "wrappedUserKey1",
+          wrapped_user_key_2: "wrappedUserKey2",
+        });
+      });
+
+      it("leaves userDecryption undefined when the server reported none", async () => {
+        configService.getFeatureFlag.mockImplementation(
+          async (flag) => flag === FeatureFlag.PostUserKeyId,
+        );
+        apiService.getSync.mockResolvedValue(emptySyncResponse);
+
+        await sut.fullSync(true);
+
+        const data = kmSyncHandler.on_sync.mock.calls[0][0];
+        expect(data.userDecryption).toBeUndefined();
+        // Current servers always return account keys.
+        expect(data.accountCryptographicState).toBeDefined();
+      });
+
+      it("does not fail the sync when the handler throws", async () => {
+        configService.getFeatureFlag.mockImplementation(
+          async (flag) => flag === FeatureFlag.PostUserKeyId,
+        );
+        apiService.getSync.mockResolvedValue(syncResponseWithUserDecryption({}));
+        kmSyncHandler.on_sync.mockRejectedValue(new Error("boom"));
+
+        await expect(sut.fullSync(true)).resolves.toBe(true);
+
+        expect(logService.error).toHaveBeenCalledWith(
+          "[Sync] Key management sync handler failed:",
+          expect.any(Error),
+        );
+      });
     });
 
     it("sets the correct keys for a V1 user", async () => {
@@ -257,10 +350,6 @@ describe("DefaultSyncService", () => {
       await sut.fullSync(true);
       expect(masterPasswordAbstraction.setMasterKeyEncryptedUserKey).toHaveBeenCalledWith(
         new EncString("encryptedUserKey"),
-        user1,
-      );
-      expect(accountCryptographicStateService.setAccountCryptographicState).toHaveBeenCalledWith(
-        { V1: { private_key: "wrappedPrivateKey" } },
         user1,
       );
       expect(keyService.setProviderKeys).toHaveBeenCalledWith([], user1);
@@ -313,7 +402,6 @@ describe("DefaultSyncService", () => {
         new EncString("encryptedUserKey"),
         user1,
       );
-      expect(accountCryptographicStateService.setAccountCryptographicState).toHaveBeenCalled();
       expect(keyService.setProviderKeys).toHaveBeenCalledWith([], user1);
       expect(keyService.setOrgKeys).toHaveBeenCalledWith([], [], user1);
     });
@@ -415,6 +503,12 @@ describe("DefaultSyncService", () => {
         const syncResponse = new SyncResponse({
           Profile: {
             Id: user1,
+            AccountKeys: {
+              publicKeyEncryptionKeyPair: {
+                wrappedPrivateKey: "wrappedPrivateKey",
+                publicKey: "publicKey",
+              },
+            },
           },
           UserDecryption: {
             MasterPasswordUnlock: {
@@ -445,6 +539,12 @@ describe("DefaultSyncService", () => {
         const syncResponse = new SyncResponse({
           Profile: {
             Id: user1,
+            AccountKeys: {
+              publicKeyEncryptionKeyPair: {
+                wrappedPrivateKey: "wrappedPrivateKey",
+                publicKey: "publicKey",
+              },
+            },
           },
           UserDecryption: {},
         });
@@ -459,7 +559,15 @@ describe("DefaultSyncService", () => {
         const wrappedUserKey1 = "mockWrappedUserKey1";
         const wrappedUserKey2 = "mockWrappedUserKey2";
         const syncResponse = new SyncResponse({
-          Profile: { Id: user1 },
+          Profile: {
+            Id: user1,
+            AccountKeys: {
+              publicKeyEncryptionKeyPair: {
+                wrappedPrivateKey: "wrappedPrivateKey",
+                publicKey: "publicKey",
+              },
+            },
+          },
           UserDecryption: {
             V2UpgradeToken: {
               WrappedUserKey1: wrappedUserKey1,
@@ -480,7 +588,15 @@ describe("DefaultSyncService", () => {
 
       it("should clear the V2 upgrade token when the response omits it", async () => {
         const syncResponse = new SyncResponse({
-          Profile: { Id: user1 },
+          Profile: {
+            Id: user1,
+            AccountKeys: {
+              publicKeyEncryptionKeyPair: {
+                wrappedPrivateKey: "wrappedPrivateKey",
+                publicKey: "publicKey",
+              },
+            },
+          },
           UserDecryption: {},
         });
         apiService.getSync.mockResolvedValue(syncResponse);
@@ -589,7 +705,15 @@ describe("DefaultSyncService", () => {
     describe("policy sync", () => {
       it("syncs policies from response.policies into policyService", async () => {
         const syncResponse = new SyncResponse({
-          Profile: { Id: user1 },
+          Profile: {
+            Id: user1,
+            AccountKeys: {
+              publicKeyEncryptionKeyPair: {
+                wrappedPrivateKey: "wrappedPrivateKey",
+                publicKey: "publicKey",
+              },
+            },
+          },
           Policies: [{ Id: "policy1", OrganizationId: "org1", Type: 0, Enabled: true }],
         });
         apiService.getSync.mockResolvedValue(syncResponse);
@@ -612,7 +736,15 @@ describe("DefaultSyncService", () => {
 
       it("calls newPolicyService.replace when policiesNew is present in the response", async () => {
         const syncResponse = new SyncResponse({
-          Profile: { Id: user1 },
+          Profile: {
+            Id: user1,
+            AccountKeys: {
+              publicKeyEncryptionKeyPair: {
+                wrappedPrivateKey: "wrappedPrivateKey",
+                publicKey: "publicKey",
+              },
+            },
+          },
           PoliciesNew: [{ Id: "policy-new-1", OrganizationId: "org1", Type: 0, Enabled: true }],
         });
         apiService.getSync.mockResolvedValue(syncResponse);
@@ -627,7 +759,15 @@ describe("DefaultSyncService", () => {
 
       it("routes policies and policiesNew to their respective services independently", async () => {
         const syncResponse = new SyncResponse({
-          Profile: { Id: user1 },
+          Profile: {
+            Id: user1,
+            AccountKeys: {
+              publicKeyEncryptionKeyPair: {
+                wrappedPrivateKey: "wrappedPrivateKey",
+                publicKey: "publicKey",
+              },
+            },
+          },
           Policies: [{ Id: "old-policy", OrganizationId: "org1", Type: 0, Enabled: true }],
           PoliciesNew: [{ Id: "new-policy", OrganizationId: "org1", Type: 0, Enabled: true }],
         });
@@ -647,7 +787,15 @@ describe("DefaultSyncService", () => {
 
       it("falls back to policies when policiesNew is absent", async () => {
         const syncResponse = new SyncResponse({
-          Profile: { Id: user1 },
+          Profile: {
+            Id: user1,
+            AccountKeys: {
+              publicKeyEncryptionKeyPair: {
+                wrappedPrivateKey: "wrappedPrivateKey",
+                publicKey: "publicKey",
+              },
+            },
+          },
           Policies: [{ Id: "policy1", OrganizationId: "org1", Type: 0, Enabled: true }],
         });
         apiService.getSync.mockResolvedValue(syncResponse);
@@ -662,7 +810,15 @@ describe("DefaultSyncService", () => {
 
       it("falls back to policies when policiesNew is an empty array", async () => {
         const syncResponse = new SyncResponse({
-          Profile: { Id: user1 },
+          Profile: {
+            Id: user1,
+            AccountKeys: {
+              publicKeyEncryptionKeyPair: {
+                wrappedPrivateKey: "wrappedPrivateKey",
+                publicKey: "publicKey",
+              },
+            },
+          },
           Policies: [{ Id: "policy1", OrganizationId: "org1", Type: 0, Enabled: true }],
           PoliciesNew: [],
         });
@@ -711,6 +867,12 @@ describe("DefaultSyncService", () => {
         const syncResponse = new SyncResponse({
           Profile: {
             Id: user1,
+            AccountKeys: {
+              publicKeyEncryptionKeyPair: {
+                wrappedPrivateKey: "wrappedPrivateKey",
+                publicKey: "publicKey",
+              },
+            },
             Organizations: [{ Id: "org1", Status: OrganizationUserStatusType.Confirmed }],
             ProviderOrganizations: [] as any[],
           },
@@ -736,6 +898,12 @@ describe("DefaultSyncService", () => {
         const syncResponse = new SyncResponse({
           Profile: {
             Id: user1,
+            AccountKeys: {
+              publicKeyEncryptionKeyPair: {
+                wrappedPrivateKey: "wrappedPrivateKey",
+                publicKey: "publicKey",
+              },
+            },
             Organizations: [{ Id: "old-org", Status: OrganizationUserStatusType.Confirmed }],
             OrganizationsNew: [{ Id: "new-org", Status: OrganizationUserStatusType.Accepted }],
             ProviderOrganizations: [] as any[],
@@ -762,6 +930,12 @@ describe("DefaultSyncService", () => {
         const syncResponse = new SyncResponse({
           Profile: {
             Id: user1,
+            AccountKeys: {
+              publicKeyEncryptionKeyPair: {
+                wrappedPrivateKey: "wrappedPrivateKey",
+                publicKey: "publicKey",
+              },
+            },
             Organizations: [] as any[],
             OrganizationsNew: [{ Id: "org1", Status: OrganizationUserStatusType.Accepted }],
             ProviderOrganizations: [
@@ -796,7 +970,15 @@ describe("DefaultSyncService", () => {
   describe("SyncResponse", () => {
     it("maps PoliciesNew from the server response", () => {
       const response = new SyncResponse({
-        Profile: { Id: user1 },
+        Profile: {
+          Id: user1,
+          AccountKeys: {
+            publicKeyEncryptionKeyPair: {
+              wrappedPrivateKey: "wrappedPrivateKey",
+              publicKey: "publicKey",
+            },
+          },
+        },
         PoliciesNew: [{ Id: "policy1", OrganizationId: "org1", Type: 1, Enabled: true }],
       });
 
@@ -806,14 +988,32 @@ describe("DefaultSyncService", () => {
     });
 
     it("leaves policiesNew undefined when the property is absent from the server response", () => {
-      const response = new SyncResponse({ Profile: { Id: user1 } });
+      const response = new SyncResponse({
+        Profile: {
+          Id: user1,
+          AccountKeys: {
+            publicKeyEncryptionKeyPair: {
+              wrappedPrivateKey: "wrappedPrivateKey",
+              publicKey: "publicKey",
+            },
+          },
+        },
+      });
 
       expect(response.policiesNew).toBeUndefined();
     });
 
     it("parses policies and policiesNew independently", () => {
       const response = new SyncResponse({
-        Profile: { Id: user1 },
+        Profile: {
+          Id: user1,
+          AccountKeys: {
+            publicKeyEncryptionKeyPair: {
+              wrappedPrivateKey: "wrappedPrivateKey",
+              publicKey: "publicKey",
+            },
+          },
+        },
         Policies: [{ Id: "old", OrganizationId: "org1", Type: 0, Enabled: true }],
         PoliciesNew: [{ Id: "new", OrganizationId: "org1", Type: 0, Enabled: false }],
       });

--- a/libs/common/src/platform/sync/default-sync.service.spec.ts
+++ b/libs/common/src/platform/sync/default-sync.service.spec.ts
@@ -13,7 +13,7 @@ import {
 } from "@bitwarden/auth/common";
 // This import has been flagged as unallowed for this class. It may be involved in a circular dependency loop.
 // eslint-disable-next-line no-restricted-imports
-import { KdfConfigService, KeyService, PBKDF2KdfConfig } from "@bitwarden/key-management";
+import { KeyService } from "@bitwarden/key-management";
 import { KmSyncData } from "@bitwarden/sdk-internal";
 
 import { Matrix } from "../../../spec/matrix";
@@ -31,16 +31,9 @@ import { AuthenticationStatus } from "../../auth/enums/authentication-status";
 import { DomainSettingsService } from "../../autofill/services/domain-settings.service";
 import { BillingAccountProfileStateService } from "../../billing/abstractions";
 import { FeatureFlag } from "../../enums/feature-flag.enum";
-import { AccountCryptographicStateService } from "../../key-management/account-cryptography/account-cryptographic-state.service";
 import { EncString } from "../../key-management/crypto/models/enc-string";
 import { KeyConnectorService } from "../../key-management/key-connector/abstractions/key-connector.service";
 import { InternalMasterPasswordServiceAbstraction } from "../../key-management/master-password/abstractions/master-password.service.abstraction";
-import {
-  MasterKeyWrappedUserKey,
-  MasterPasswordSalt,
-  MasterPasswordUnlockData,
-} from "../../key-management/master-password/types/master-password.types";
-import { V2UpgradeTokenStateService } from "../../key-management/upgrade-token/abstractions/v2-upgrade-token-state.service.abstraction";
 import { SendApiService } from "../../tools/send/services/send-api.service.abstraction";
 import { InternalSendService } from "../../tools/send/services/send.service.abstraction";
 import { UserId } from "../../types/guid";
@@ -82,9 +75,6 @@ describe("DefaultSyncService", () => {
   let tokenService: MockProxy<TokenService>;
   let authService: MockProxy<AuthService>;
   let stateProvider: MockProxy<StateProvider>;
-  let kdfConfigService: MockProxy<KdfConfigService>;
-  let accountCryptographicStateService: MockProxy<AccountCryptographicStateService>;
-  let v2UpgradeTokenStateService: MockProxy<V2UpgradeTokenStateService>;
   let configService: MockProxy<ConfigService>;
   let sdkService: MockProxy<SdkService>;
   let kmSyncHandler: { on_sync: jest.Mock<Promise<void>, [KmSyncData]> };
@@ -118,9 +108,6 @@ describe("DefaultSyncService", () => {
     tokenService = mock();
     authService = mock();
     stateProvider = mock();
-    kdfConfigService = mock();
-    accountCryptographicStateService = mock();
-    v2UpgradeTokenStateService = mock();
     configService = mock();
     sdkService = mock();
     kmSyncHandler = { on_sync: jest.fn().mockResolvedValue(undefined) };
@@ -159,9 +146,6 @@ describe("DefaultSyncService", () => {
       tokenService,
       authService,
       stateProvider,
-      kdfConfigService,
-      accountCryptographicStateService,
-      v2UpgradeTokenStateService,
       configService,
       sdkService,
     );
@@ -219,19 +203,7 @@ describe("DefaultSyncService", () => {
           userDecryption,
         });
 
-      it("is not called when the feature flag is off", async () => {
-        configService.getFeatureFlag.mockImplementation(async () => false);
-        apiService.getSync.mockResolvedValue(syncResponseWithUserDecryption({}));
-
-        await sut.fullSync(true);
-
-        expect(kmSyncHandler.on_sync).not.toHaveBeenCalled();
-      });
-
       it("passes an undefined key id through when the server did not report one", async () => {
-        configService.getFeatureFlag.mockImplementation(
-          async (flag) => flag === FeatureFlag.PostUserKeyId,
-        );
         apiService.getSync.mockResolvedValue(syncResponseWithUserDecryption({}));
 
         await sut.fullSync(true);
@@ -242,9 +214,6 @@ describe("DefaultSyncService", () => {
 
       it("passes the server's key id through when it reported one", async () => {
         const userKeyId = "0123456789abcdef0123456789abcdef";
-        configService.getFeatureFlag.mockImplementation(
-          async (flag) => flag === FeatureFlag.PostUserKeyId,
-        );
         apiService.getSync.mockResolvedValue(syncResponseWithUserDecryption({ userKeyId }));
 
         await sut.fullSync(true);
@@ -254,9 +223,6 @@ describe("DefaultSyncService", () => {
       });
 
       it("passes the master password unlock data and upgrade token through", async () => {
-        configService.getFeatureFlag.mockImplementation(
-          async (flag) => flag === FeatureFlag.PostUserKeyId,
-        );
         apiService.getSync.mockResolvedValue(
           syncResponseWithUserDecryption({
             masterPasswordUnlock: {
@@ -285,9 +251,6 @@ describe("DefaultSyncService", () => {
       });
 
       it("leaves userDecryption undefined when the server reported none", async () => {
-        configService.getFeatureFlag.mockImplementation(
-          async (flag) => flag === FeatureFlag.PostUserKeyId,
-        );
         apiService.getSync.mockResolvedValue(emptySyncResponse);
 
         await sut.fullSync(true);
@@ -299,9 +262,6 @@ describe("DefaultSyncService", () => {
       });
 
       it("does not fail the sync when the handler throws", async () => {
-        configService.getFeatureFlag.mockImplementation(
-          async (flag) => flag === FeatureFlag.PostUserKeyId,
-        );
         apiService.getSync.mockResolvedValue(syncResponseWithUserDecryption({}));
         kmSyncHandler.on_sync.mockRejectedValue(new Error("boom"));
 
@@ -491,120 +451,6 @@ describe("DefaultSyncService", () => {
 
         expect(sut["inFlightApiCalls"].refreshToken).toBeNull();
         expect(sut["inFlightApiCalls"].sync).toBeNull();
-      });
-    });
-
-    describe("syncUserDecryption", () => {
-      const salt = "test@example.com";
-      const kdf = new PBKDF2KdfConfig(600_000);
-      const encryptedUserKey = "testUserKey";
-
-      it("should set master password unlock when present in user decryption", async () => {
-        const syncResponse = new SyncResponse({
-          Profile: {
-            Id: user1,
-            AccountKeys: {
-              publicKeyEncryptionKeyPair: {
-                wrappedPrivateKey: "wrappedPrivateKey",
-                publicKey: "publicKey",
-              },
-            },
-          },
-          UserDecryption: {
-            MasterPasswordUnlock: {
-              Salt: salt,
-              Kdf: {
-                KdfType: kdf.kdfType,
-                Iterations: kdf.iterations,
-              },
-              MasterKeyEncryptedUserKey: encryptedUserKey,
-            },
-          },
-        });
-        apiService.getSync.mockResolvedValue(syncResponse);
-
-        await sut.fullSync(true, true);
-
-        expect(masterPasswordAbstraction.setMasterPasswordUnlockData).toHaveBeenCalledWith(
-          new MasterPasswordUnlockData(
-            salt as MasterPasswordSalt,
-            kdf,
-            encryptedUserKey as MasterKeyWrappedUserKey,
-          ),
-          user1,
-        );
-      });
-
-      it("should not set master password unlock when not present in user decryption", async () => {
-        const syncResponse = new SyncResponse({
-          Profile: {
-            Id: user1,
-            AccountKeys: {
-              publicKeyEncryptionKeyPair: {
-                wrappedPrivateKey: "wrappedPrivateKey",
-                publicKey: "publicKey",
-              },
-            },
-          },
-          UserDecryption: {},
-        });
-        apiService.getSync.mockResolvedValue(syncResponse);
-
-        await sut.fullSync(true, true);
-
-        expect(masterPasswordAbstraction.setMasterPasswordUnlockData).not.toHaveBeenCalled();
-      });
-
-      it("should persist the V2 upgrade token when present on the user decryption response", async () => {
-        const wrappedUserKey1 = "mockWrappedUserKey1";
-        const wrappedUserKey2 = "mockWrappedUserKey2";
-        const syncResponse = new SyncResponse({
-          Profile: {
-            Id: user1,
-            AccountKeys: {
-              publicKeyEncryptionKeyPair: {
-                wrappedPrivateKey: "wrappedPrivateKey",
-                publicKey: "publicKey",
-              },
-            },
-          },
-          UserDecryption: {
-            V2UpgradeToken: {
-              WrappedUserKey1: wrappedUserKey1,
-              WrappedUserKey2: wrappedUserKey2,
-            },
-          },
-        });
-        apiService.getSync.mockResolvedValue(syncResponse);
-
-        await sut.fullSync(true, true);
-
-        expect(v2UpgradeTokenStateService.setV2UpgradeToken).toHaveBeenCalledWith(
-          { wrapped_user_key_1: wrappedUserKey1, wrapped_user_key_2: wrappedUserKey2 },
-          user1,
-        );
-        expect(v2UpgradeTokenStateService.clearV2UpgradeToken).not.toHaveBeenCalled();
-      });
-
-      it("should clear the V2 upgrade token when the response omits it", async () => {
-        const syncResponse = new SyncResponse({
-          Profile: {
-            Id: user1,
-            AccountKeys: {
-              publicKeyEncryptionKeyPair: {
-                wrappedPrivateKey: "wrappedPrivateKey",
-                publicKey: "publicKey",
-              },
-            },
-          },
-          UserDecryption: {},
-        });
-        apiService.getSync.mockResolvedValue(syncResponse);
-
-        await sut.fullSync(true, true);
-
-        expect(v2UpgradeTokenStateService.clearV2UpgradeToken).toHaveBeenCalledWith(user1);
-        expect(v2UpgradeTokenStateService.setV2UpgradeToken).not.toHaveBeenCalled();
       });
     });
 

--- a/libs/common/src/platform/sync/default-sync.service.ts
+++ b/libs/common/src/platform/sync/default-sync.service.ts
@@ -7,8 +7,8 @@ import { firstValueFrom, map } from "rxjs";
 import { CollectionService } from "@bitwarden/admin-console/common";
 // This import has been flagged as unallowed for this class. It may be involved in a circular dependency loop.
 // eslint-disable-next-line no-restricted-imports
-import { KdfConfigService, KeyService } from "@bitwarden/key-management";
-import { EncString as SdkEncString } from "@bitwarden/sdk-internal";
+import { KeyService } from "@bitwarden/key-management";
+import { KeyId as SdkKeyId } from "@bitwarden/sdk-internal";
 
 // This import has been flagged as unallowed for this class. It may be involved in a circular dependency loop.
 // eslint-disable-next-line no-restricted-imports
@@ -40,12 +40,10 @@ import { ForceSetPasswordReason } from "../../auth/models/domain/force-set-passw
 import { DomainSettingsService } from "../../autofill/services/domain-settings.service";
 import { BillingAccountProfileStateService } from "../../billing/abstractions";
 import { FeatureFlag } from "../../enums/feature-flag.enum";
-import { AccountCryptographicStateService } from "../../key-management/account-cryptography/account-cryptographic-state.service";
 import { KeyConnectorService } from "../../key-management/key-connector/abstractions/key-connector.service";
 import { InternalMasterPasswordServiceAbstraction } from "../../key-management/master-password/abstractions/master-password.service.abstraction";
 import { UserDecryptionResponse } from "../../key-management/models/response/user-decryption.response";
-import { SecurityStateService } from "../../key-management/security-state/abstractions/security-state.service";
-import { V2UpgradeTokenStateService } from "../../key-management/upgrade-token/abstractions/v2-upgrade-token-state.service.abstraction";
+import { withPasswordManagerSdk } from "../../key-management/utils";
 import { DomainsResponse } from "../../models/response/domains.response";
 import { ProfileResponse } from "../../models/response/profile.response";
 import { SendData } from "../../tools/send/models/data/send.data";
@@ -62,6 +60,7 @@ import { CipherResponse } from "../../vault/models/response/cipher.response";
 import { FolderResponse } from "../../vault/models/response/folder.response";
 import { ConfigService } from "../abstractions/config/config.service";
 import { LogService } from "../abstractions/log.service";
+import { SdkService } from "../abstractions/sdk/sdk.service";
 import { MessageSender } from "../messaging";
 import { StateProvider } from "../state";
 
@@ -107,11 +106,8 @@ export class DefaultSyncService extends CoreSyncService {
     tokenService: TokenService,
     authService: AuthService,
     stateProvider: StateProvider,
-    private securityStateService: SecurityStateService,
-    private kdfConfigService: KdfConfigService,
-    private accountCryptographicStateService: AccountCryptographicStateService,
-    private readonly v2UpgradeTokenStateService: V2UpgradeTokenStateService,
     private configService: ConfigService,
+    private sdkService: SdkService,
   ) {
     super(
       tokenService,
@@ -198,6 +194,7 @@ export class DefaultSyncService extends CoreSyncService {
       await this.syncSettings(response.domains, response.profile.id);
       await this.syncPolicies(response.policies, response.profile.id);
       await this.syncNewPolicies(response.policiesNew, response.policies, response.profile.id);
+      await this.runKmSyncHandler(response.profile.id, response.profile, response.userDecryption);
 
       await this.setLastSync(now, userId);
       return this.syncCompleted(true, userId);
@@ -246,27 +243,11 @@ export class DefaultSyncService extends CoreSyncService {
       throw new Error("Stamp has changed");
     }
 
-    // Users with no master password will not have a key.
+    // This is for key-connector users
     if (response?.key) {
       await this.masterPasswordService.setMasterKeyEncryptedUserKey(response.key, response.id);
     }
 
-    // Cleanup: Only the first branch should be kept after the server always returns accountKeys https://bitwarden.atlassian.net/browse/PM-21768
-    if (response.accountKeys != null) {
-      await this.accountCryptographicStateService.setAccountCryptographicState(
-        response.accountKeys.toWrappedAccountCryptographicState(),
-        response.id,
-      );
-    } else {
-      await this.accountCryptographicStateService.setAccountCryptographicState(
-        {
-          V1: {
-            private_key: response.privateKey as SdkEncString,
-          },
-        },
-        response.id,
-      );
-    }
     await this.keyService.setProviderKeys(response.providers, response.id);
     await this.keyService.setOrgKeys(
       response.organizations,
@@ -457,21 +438,45 @@ export class DefaultSyncService extends CoreSyncService {
     return await this.newPolicyService.replace(policies, userId);
   }
 
+  /**
+   * Runs the SDK's key management sync handler.
+   *
+   * Hands the handler the key-management parts of the sync response and lets it decide what to do
+   * with each. Failures are logged and swallowed: nothing here is required for the sync itself to
+   * have succeeded.
+   */
+  private async runKmSyncHandler(
+    userId: UserId,
+    profile: ProfileResponse,
+    userDecryption: UserDecryptionResponse | undefined,
+  ) {
+    try {
+      await withPasswordManagerSdk(userId, this.sdkService, (sdk) =>
+        sdk.km_sync_handler().on_sync({
+          userDecryption:
+            userDecryption == null
+              ? undefined
+              : {
+                  userKeyId: userDecryption.userKeyId as SdkKeyId | undefined,
+                  masterPasswordUnlock: userDecryption.masterPasswordUnlock
+                    ?.toMasterPasswordUnlockData()
+                    .toSdk(),
+                  v2UpgradeToken: userDecryption.v2UpgradeToken?.toV2UpgradeToken(),
+                },
+          accountCryptographicState: profile.accountKeys?.toWrappedAccountCryptographicState(),
+        }),
+      );
+    } catch (error) {
+      this.logService.error("[Sync] Key management sync handler failed:", error);
+    }
+  }
+
   private async syncUserDecryption(
     userId: UserId,
     userDecryption: UserDecryptionResponse | undefined,
   ) {
     if (userDecryption == null) {
       return;
-    }
-    if (userDecryption.masterPasswordUnlock != null) {
-      const masterPasswordUnlockData =
-        userDecryption.masterPasswordUnlock.toMasterPasswordUnlockData();
-      await this.masterPasswordService.setMasterPasswordUnlockData(
-        masterPasswordUnlockData,
-        userId,
-      );
-      await this.kdfConfigService.setKdfConfig(userId, masterPasswordUnlockData.kdf);
     }
 
     // Update WebAuthn PRF options if present
@@ -510,15 +515,6 @@ export class DefaultSyncService extends CoreSyncService {
       } catch (error) {
         this.logService.error("[Sync] Failed to update WebAuthn PRF options:", error);
       }
-    }
-
-    if (userDecryption.v2UpgradeToken != null) {
-      await this.v2UpgradeTokenStateService.setV2UpgradeToken(
-        userDecryption.v2UpgradeToken.toV2UpgradeToken(),
-        userId,
-      );
-    } else {
-      await this.v2UpgradeTokenStateService.clearV2UpgradeToken(userId);
     }
   }
 }


### PR DESCRIPTION
https://bitwarden.atlassian.net/browse/PM-39454

https://github.com/bitwarden/server/pull/8076
https://github.com/bitwarden/sdk-internal/pull/1307
https://github.com/bitwarden/clients/pull/22128

We want to track the current key ID of the user-key. This is required for encryption stability. With follow-up work this will allow us to:
- Reject KDF Changes, Password changes, Account Recovery Enrollments, Emergency Access Enrollements, Vault Item Modifications, Vault Item Creations, that have a wrong user-key contained / used for encryption. The cryptographic metadata is compared against the stored key id.
- Find bugs easily leading to the above encryption stability

The user key id is set as part of the registration for new users. For existing users an upgrade endpoint that can be used *once* is provided. Key rotations will also set the key id.

Password changes, and kdf changes may not change the key ID and will reject in case the user had a wrong user-key in their client. 

## Client Specific notes

Syncing logic of KM is *mostly* where possible moved to the SDK. We may move other syncing logic (organization keys, webauthn unlock) to the SDK into the same KM handler in a future PR. However, we do copy over all syncing logic, I have added GitHub comments referencing the copied over logic.

## Screenshot
<img width="1410" height="1170" alt="image" src="https://github.com/user-attachments/assets/22783669-c5c3-4142-83b4-6d00559ef713" />
