### PR TITLE
[CL-1293] add description and hideOnEmpty inputs to bit-row-group

### DIFF
--- a/libs/components/src/table/v2/bit-row-group.component.ts
+++ b/libs/components/src/table/v2/bit-row-group.component.ts
@@ -2,7 +2,10 @@ import {
   booleanAttribute,
   ChangeDetectionStrategy,
   Component,
+  computed,
+  contentChild,
   DestroyRef,
+  ElementRef,
   forwardRef,
   inject,
   input,
@@ -19,13 +22,18 @@ import { BitTableV2Component } from "./table-v2.component";
  * the rows passing {@link match}; the projected content is the group's header
  * label (the row count is appended automatically by the table).
  *
- * Rows partition first-match-wins in declaration order, and empty groups render
- * nothing. Registers with the nearest ancestor `<bit-table-v2>` via DI, so a
- * group can sit anywhere in the descendant tree — including emitted by a helper.
+ * Rows partition first-match-wins in declaration order. Empty groups render
+ * nothing by default; project `slot="empty" content to instead
+ * keep the group's header visible and show that content in place of rows (e.g. a
+ * tip). Registers with the nearest ancestor `<bit-table-v2>` via DI, so a group
+ * can sit anywhere in the descendant tree — including emitted by a helper.
  */
 @Component({
   selector: "bit-row-group",
-  template: `<ng-template #header><ng-content></ng-content></ng-template>`,
+  template: `
+    <ng-template #header><ng-content></ng-content></ng-template>
+    <ng-template #empty><ng-content select="[slot=empty]"></ng-content></ng-template>
+  `,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class BitRowGroupComponent<T = unknown> {
@@ -49,6 +57,14 @@ export class BitRowGroupComponent<T = unknown> {
 
   /** The projected header label, stamped by `<bit-table-v2>` once per non-empty group. */
   readonly headerTemplate = viewChild.required<TemplateRef<void>>("header");
+
+  /** The `slot="empty"` content, stamped by `<bit-table-v2>` when the group is empty. */
+  readonly emptyTemplate = viewChild.required<TemplateRef<void>>("empty");
+
+  private readonly slotContainer = contentChild<ElementRef<HTMLElement>>("slotContainer");
+
+  /** Whether `slot="empty"` content is projected; when true the table keeps the header and shows it in place of rows. */
+  readonly hasEmptyContent = computed(() => this.slotContainer() != null);
 
   private readonly _children = signal<BitRowGroupComponent<T>[]>([]);
 

--- a/libs/components/src/table/v2/bit-row-group.component.ts
+++ b/libs/components/src/table/v2/bit-row-group.component.ts
@@ -2,10 +2,7 @@ import {
   booleanAttribute,
   ChangeDetectionStrategy,
   Component,
-  computed,
-  contentChild,
   DestroyRef,
-  ElementRef,
   forwardRef,
   inject,
   input,
@@ -22,18 +19,14 @@ import { BitTableV2Component } from "./table-v2.component";
  * the rows passing {@link match}; the projected content is the group's header
  * label (the row count is appended automatically by the table).
  *
- * Rows partition first-match-wins in declaration order. Empty groups render
- * nothing by default; project `slot="empty" content to instead
- * keep the group's header visible and show that content in place of rows (e.g. a
- * tip). Registers with the nearest ancestor `<bit-table-v2>` via DI, so a group
- * can sit anywhere in the descendant tree — including emitted by a helper.
+ * Rows partition first-match-wins in declaration order, and a group with no
+ * matching rows renders nothing unless it clears {@link hideOnEmpty}. Registers with
+ * the nearest ancestor `<bit-table-v2>` via DI, so a group can sit anywhere in the
+ * descendant tree — including emitted by a helper.
  */
 @Component({
   selector: "bit-row-group",
-  template: `
-    <ng-template #header><ng-content></ng-content></ng-template>
-    <ng-template #empty><ng-content select="[slot=empty]"></ng-content></ng-template>
-  `,
+  template: `<ng-template #header><ng-content></ng-content></ng-template>`,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class BitRowGroupComponent<T = unknown> {
@@ -42,6 +35,15 @@ export class BitRowGroupComponent<T = unknown> {
 
   /** When set, the header becomes a toggle that collapses the group's rows (open by default). */
   readonly collapsible = input(false, { transform: booleanAttribute });
+
+  /** Explanatory text rendered under the header, above the group's rows. */
+  readonly description = input<string>();
+
+  /**
+   * Whether the group disappears when no rows match. Clear it to keep the header — and
+   * any {@link description} — on screen, so the description can stand in for the rows.
+   */
+  readonly hideOnEmpty = input(true, { transform: booleanAttribute });
 
   /**
    * Whether the group's rows are currently hidden. Only meaningful when {@link collapsible}.
@@ -55,16 +57,8 @@ export class BitRowGroupComponent<T = unknown> {
     this.collapsed.update((collapsed) => !collapsed);
   }
 
-  /** The projected header label, stamped by `<bit-table-v2>` once per non-empty group. */
+  /** The projected header label, stamped by `<bit-table-v2>` once per rendered group. */
   readonly headerTemplate = viewChild.required<TemplateRef<void>>("header");
-
-  /** The `slot="empty"` content, stamped by `<bit-table-v2>` when the group is empty. */
-  readonly emptyTemplate = viewChild.required<TemplateRef<void>>("empty");
-
-  private readonly slotContainer = contentChild<ElementRef<HTMLElement>>("slotContainer");
-
-  /** Whether `slot="empty"` content is projected; when true the table keeps the header and shows it in place of rows. */
-  readonly hasEmptyContent = computed(() => this.slotContainer() != null);
 
   private readonly _children = signal<BitRowGroupComponent<T>[]>([]);
 

--- a/libs/components/src/table/v2/bit-row-group.component.ts
+++ b/libs/components/src/table/v2/bit-row-group.component.ts
@@ -19,7 +19,7 @@ import { BitTableV2Component } from "./table-v2.component";
  * the rows passing {@link match}; the projected content is the group's header
  * label (the row count is appended automatically by the table).
  *
- * Rows partition first-match-wins in declaration order, and a group with no
+ * Rows partition first-match-wins in declaration order, and a top-level group with no
  * matching rows renders nothing unless it clears {@link hideOnEmpty}. Registers with
  * the nearest ancestor `<bit-table-v2>` via DI, so a group can sit anywhere in the
  * descendant tree — including emitted by a helper.
@@ -36,12 +36,16 @@ export class BitRowGroupComponent<T = unknown> {
   /** When set, the header becomes a toggle that collapses the group's rows (open by default). */
   readonly collapsible = input(false, { transform: booleanAttribute });
 
-  /** Explanatory text rendered under the header, above the group's rows. */
+  /**
+   * Explanatory text rendered under the header, above the group's rows. Top-level groups
+   * only — a nested subgroup's description is ignored.
+   */
   readonly description = input<string>();
 
   /**
    * Whether the group disappears when no rows match. Clear it to keep the header — and
    * any {@link description} — on screen, so the description can stand in for the rows.
+   * Top-level groups only; an empty nested subgroup always hides.
    */
   readonly hideOnEmpty = input(true, { transform: booleanAttribute });
 

--- a/libs/components/src/table/v2/bit-row-group.component.ts
+++ b/libs/components/src/table/v2/bit-row-group.component.ts
@@ -2,7 +2,10 @@ import {
   booleanAttribute,
   ChangeDetectionStrategy,
   Component,
+  computed,
+  contentChild,
   DestroyRef,
+  ElementRef,
   forwardRef,
   inject,
   input,
@@ -18,13 +21,18 @@ import { BitTableV2Component } from "./table-v2.component";
  * the rows passing {@link match}; the projected content is the group's header
  * label (the row count is appended automatically by the table).
  *
- * Rows partition first-match-wins in declaration order, and empty groups render
- * nothing. Registers with the nearest ancestor `<bit-table-v2>` via DI, so a
- * group can sit anywhere in the descendant tree — including emitted by a helper.
+ * Rows partition first-match-wins in declaration order. Empty groups render
+ * nothing by default; project `slot="empty" content to instead
+ * keep the group's header visible and show that content in place of rows (e.g. a
+ * tip). Registers with the nearest ancestor `<bit-table-v2>` via DI, so a group
+ * can sit anywhere in the descendant tree — including emitted by a helper.
  */
 @Component({
   selector: "bit-row-group",
-  template: `<ng-template #header><ng-content></ng-content></ng-template>`,
+  template: `
+    <ng-template #header><ng-content></ng-content></ng-template>
+    <ng-template #empty><ng-content select="[slot=empty]"></ng-content></ng-template>
+  `,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class BitRowGroupComponent<T = unknown> {
@@ -46,6 +54,14 @@ export class BitRowGroupComponent<T = unknown> {
 
   /** The projected header label, stamped by `<bit-table-v2>` once per non-empty group. */
   readonly headerTemplate = viewChild.required<TemplateRef<void>>("header");
+
+  /** The `slot="empty"` content, stamped by `<bit-table-v2>` when the group is empty. */
+  readonly emptyTemplate = viewChild.required<TemplateRef<void>>("empty");
+
+  private readonly slotContainer = contentChild<ElementRef<HTMLElement>>("slotContainer");
+
+  /** Whether `slot="empty"` content is projected; when true the table keeps the header and shows it in place of rows. */
+  readonly hasEmptyContent = computed(() => this.slotContainer() != null);
 
   private readonly _children = signal<BitRowGroupComponent<T>[]>([]);
 

--- a/libs/components/src/table/v2/table-v2.component.html
+++ b/libs/components/src/table/v2/table-v2.component.html
@@ -111,7 +111,9 @@
   } @else if (item.kind === "groupDescription") {
     <!--
       Virtualized, the cell takes the fixed height the scroll strategy allocated and clamps
-      the text to the two lines that height covers; otherwise it grows to content.
+      the text to the two lines that height covers; otherwise it grows to content. The
+      tooltip reaches whatever the clamp cut off — the text itself stays in the
+      accessibility tree either way.
     -->
     <div role="row">
       <div
@@ -120,6 +122,7 @@
         class="tw-px-1 tw-pb-2 tw-text-sm tw-text-fg-body-subtle"
         [class.tw-line-clamp-2]="forceHeight"
         [style.height.px]="forceHeight ? groupDescriptionHeight : null"
+        [bitTooltip]="item.group.description()"
       >
         {{ item.group.description() }}
       </div>

--- a/libs/components/src/table/v2/table-v2.component.html
+++ b/libs/components/src/table/v2/table-v2.component.html
@@ -108,16 +108,16 @@
         </div>
       }
     </div>
-  } @else if (item.kind === "groupEmpty") {
-    <!-- An empty group's `slot="empty"` content, spanning every column. -->
+  } @else if (item.kind === "groupDescription") {
+    <!-- Sized like a header, so the scroll strategy's fixed height holds; text clips past one line. -->
     <div role="row">
       <div
         role="cell"
         [attr.aria-colspan]="columnCount()"
-        class="tw-px-1 tw-py-2"
+        class="tw-px-1 tw-pb-2 tw-text-sm tw-text-muted"
         [style.height.px]="forceHeight ? headerHeight(item.level) : null"
       >
-        <ng-container *ngTemplateOutlet="item.group.emptyTemplate()"></ng-container>
+        {{ item.group.description() }}
       </div>
     </div>
   } @else {

--- a/libs/components/src/table/v2/table-v2.component.html
+++ b/libs/components/src/table/v2/table-v2.component.html
@@ -109,13 +109,17 @@
       }
     </div>
   } @else if (item.kind === "groupDescription") {
-    <!-- Sized like a header, so the scroll strategy's fixed height holds; text clips past one line. -->
+    <!--
+      Virtualized, the cell takes the fixed height the scroll strategy allocated and clamps
+      the text to the two lines that height covers; otherwise it grows to content.
+    -->
     <div role="row">
       <div
         role="cell"
         [attr.aria-colspan]="columnCount()"
         class="tw-px-1 tw-pb-2 tw-text-sm tw-text-muted"
-        [style.height.px]="forceHeight ? headerHeight(item.level) : null"
+        [class.tw-line-clamp-2]="forceHeight"
+        [style.height.px]="forceHeight ? groupDescriptionHeight : null"
       >
         {{ item.group.description() }}
       </div>

--- a/libs/components/src/table/v2/table-v2.component.html
+++ b/libs/components/src/table/v2/table-v2.component.html
@@ -102,7 +102,12 @@
   } @else if (item.kind === "groupEmpty") {
     <!-- An empty group's `slot="empty"` content, spanning every column. -->
     <div role="row">
-      <div role="cell" [attr.aria-colspan]="columnCount()" class="tw-px-1 tw-py-2">
+      <div
+        role="cell"
+        [attr.aria-colspan]="columnCount()"
+        class="tw-px-1 tw-py-2"
+        [style.height.px]="forceHeight ? headerHeight(item.level) : null"
+      >
         <ng-container *ngTemplateOutlet="item.group.emptyTemplate()"></ng-container>
       </div>
     </div>

--- a/libs/components/src/table/v2/table-v2.component.html
+++ b/libs/components/src/table/v2/table-v2.component.html
@@ -111,7 +111,12 @@
   } @else if (item.kind === "groupEmpty") {
     <!-- An empty group's `slot="empty"` content, spanning every column. -->
     <div role="row">
-      <div role="cell" [attr.aria-colspan]="columnCount()" class="tw-px-1 tw-py-2">
+      <div
+        role="cell"
+        [attr.aria-colspan]="columnCount()"
+        class="tw-px-1 tw-py-2"
+        [style.height.px]="forceHeight ? headerHeight(item.level) : null"
+      >
         <ng-container *ngTemplateOutlet="item.group.emptyTemplate()"></ng-container>
       </div>
     </div>

--- a/libs/components/src/table/v2/table-v2.component.html
+++ b/libs/components/src/table/v2/table-v2.component.html
@@ -75,8 +75,8 @@
           (click)="item.group.toggle()"
         >
           <ng-container *ngTemplateOutlet="item.group.headerTemplate()"></ng-container>
-          <!-- Count only on top-level group headers. -->
-          @if (item.level === 0) {
+          <!-- Count only on non-empty top-level group headers. -->
+          @if (item.level === 0 && item.count > 0) {
             <span class="tw-ms-auto tw-font-normal">{{ item.count }}</span>
           }
           <bit-icon
@@ -93,11 +93,18 @@
           [style.height.px]="forceHeight ? headerHeight(item.level) : null"
         >
           <ng-container *ngTemplateOutlet="item.group.headerTemplate()"></ng-container>
-          @if (item.level === 0) {
+          @if (item.level === 0 && item.count > 0) {
             <span class="tw-ms-auto tw-font-normal">{{ item.count }}</span>
           }
         </div>
       }
+    </div>
+  } @else if (item.kind === "groupEmpty") {
+    <!-- An empty group's `slot="empty"` content, spanning every column. -->
+    <div role="row">
+      <div role="cell" [attr.aria-colspan]="columnCount()" class="tw-px-1 tw-py-2">
+        <ng-container *ngTemplateOutlet="item.group.emptyTemplate()"></ng-container>
+      </div>
     </div>
   } @else {
     <bit-row>

--- a/libs/components/src/table/v2/table-v2.component.html
+++ b/libs/components/src/table/v2/table-v2.component.html
@@ -84,8 +84,8 @@
           (click)="item.group.toggle()"
         >
           <ng-container *ngTemplateOutlet="item.group.headerTemplate()"></ng-container>
-          <!-- Count only on top-level group headers. -->
-          @if (item.level === 0) {
+          <!-- Count only on non-empty top-level group headers. -->
+          @if (item.level === 0 && item.count > 0) {
             <span class="tw-ms-auto tw-font-normal">{{ item.count }}</span>
           }
           <bit-icon
@@ -102,11 +102,18 @@
           [style.height.px]="forceHeight ? headerHeight(item.level) : null"
         >
           <ng-container *ngTemplateOutlet="item.group.headerTemplate()"></ng-container>
-          @if (item.level === 0) {
+          @if (item.level === 0 && item.count > 0) {
             <span class="tw-ms-auto tw-font-normal">{{ item.count }}</span>
           }
         </div>
       }
+    </div>
+  } @else if (item.kind === "groupEmpty") {
+    <!-- An empty group's `slot="empty"` content, spanning every column. -->
+    <div role="row">
+      <div role="cell" [attr.aria-colspan]="columnCount()" class="tw-px-1 tw-py-2">
+        <ng-container *ngTemplateOutlet="item.group.emptyTemplate()"></ng-container>
+      </div>
     </div>
   } @else {
     <bit-row>

--- a/libs/components/src/table/v2/table-v2.component.html
+++ b/libs/components/src/table/v2/table-v2.component.html
@@ -117,7 +117,7 @@
       <div
         role="cell"
         [attr.aria-colspan]="columnCount()"
-        class="tw-px-1 tw-pb-2 tw-text-sm tw-text-muted"
+        class="tw-px-1 tw-pb-2 tw-text-sm tw-text-fg-body-subtle"
         [class.tw-line-clamp-2]="forceHeight"
         [style.height.px]="forceHeight ? groupDescriptionHeight : null"
       >

--- a/libs/components/src/table/v2/table-v2.component.ts
+++ b/libs/components/src/table/v2/table-v2.component.ts
@@ -60,6 +60,15 @@ const SELECTION_COLUMN_WIDTH = "56px";
 const GROUP_HEADER_HEIGHT = 40;
 const SUBGROUP_HEADER_HEIGHT = 28;
 
+/**
+ * Fixed height (px) of a group description when virtualized: two `text-sm` lines (20px
+ * each) plus the cell's `tw-pb-2`. Descriptions are consumer-supplied localized strings,
+ * so they wrap in narrow tables even where English doesn't — two lines is the allowance,
+ * and the cell clamps past it. The strategy never measures, so every description gets
+ * this height whether or not it wraps.
+ */
+const GROUP_DESCRIPTION_HEIGHT = 48;
+
 /** The `filterValues` key a projected `bit-search`'s term is adopted under. */
 const SEARCH_FILTER_KEY = "search";
 
@@ -767,10 +776,18 @@ export class BitTableV2Component<T = unknown, S extends string = never, F = Reco
     if (rowHeight === undefined) {
       return [];
     }
-    return this.renderItems().map((item) =>
-      item.kind === "row" ? rowHeight : this.headerHeight(item.level),
-    );
+    return this.renderItems().map((item) => {
+      if (item.kind === "row") {
+        return rowHeight;
+      }
+      return item.kind === "groupDescription"
+        ? this.groupDescriptionHeight
+        : this.headerHeight(item.level);
+    });
   });
+
+  /** @see {@link GROUP_DESCRIPTION_HEIGHT} */
+  protected readonly groupDescriptionHeight = GROUP_DESCRIPTION_HEIGHT;
 
   /** Fixed virtualized height for a group header at `level` (0 = top, 1 = subgroup). */
   protected headerHeight(level: number): number {

--- a/libs/components/src/table/v2/table-v2.component.ts
+++ b/libs/components/src/table/v2/table-v2.component.ts
@@ -722,7 +722,9 @@ export class BitTableV2Component<T = unknown, S extends string = never, F = Reco
         // Empty groups auto-hide unless they project `slot="empty"` content.
         if (group.hasEmptyContent()) {
           items.push({ kind: "group", group, count: 0, level: 0 });
-          items.push({ kind: "groupEmpty", group, level: 0 });
+          if (!(group.collapsible() && group.collapsed())) {
+            items.push({ kind: "groupEmpty", group, level: 0 });
+          }
         }
         continue;
       }

--- a/libs/components/src/table/v2/table-v2.component.ts
+++ b/libs/components/src/table/v2/table-v2.component.ts
@@ -139,7 +139,8 @@ function sortRows<T>(
 /** A flattened body item: a data row, or a group header with its row-group and count. */
 type RenderItem<T> =
   | { kind: "row"; row: T }
-  | { kind: "group"; group: BitRowGroupComponent<T>; count: number; level: number };
+  | { kind: "group"; group: BitRowGroupComponent<T>; count: number; level: number }
+  | { kind: "groupEmpty"; group: BitRowGroupComponent<T>; level: number };
 
 /**
  * **Beta.** `bit-table-v2` is still stabilizing. Do not adopt it in production
@@ -718,6 +719,11 @@ export class BitTableV2Component<T = unknown, S extends string = never, F = Reco
     for (const group of this._groups()) {
       const groupRows = top.buckets.get(group);
       if (!groupRows?.length) {
+        // Empty groups auto-hide unless they project `slot="empty"` content.
+        if (group.hasEmptyContent()) {
+          items.push({ kind: "group", group, count: 0, level: 0 });
+          items.push({ kind: "groupEmpty", group, level: 0 });
+        }
         continue;
       }
       // A collapsed group still shows its header (with the full count) but hides its body.
@@ -780,8 +786,12 @@ export class BitTableV2Component<T = unknown, S extends string = never, F = Reco
    * {@link trackBy}, falling back to row identity.
    */
   protected readonly trackRenderItem: TrackByFunction<RenderItem<T>> = (index, item) => {
-    if (item.kind !== "row") {
+    if (item.kind === "group") {
       return item.group;
+    }
+    // Distinct from the group's header, which is also keyed by `item.group`.
+    if (item.kind === "groupEmpty") {
+      return item.group.emptyTemplate();
     }
     const trackBy = this.trackBy();
     return trackBy ? trackBy(index, item.row) : item.row;

--- a/libs/components/src/table/v2/table-v2.component.ts
+++ b/libs/components/src/table/v2/table-v2.component.ts
@@ -738,7 +738,9 @@ export class BitTableV2Component<T = unknown, S extends string = never, F = Reco
         // Empty groups auto-hide unless they project `slot="empty"` content.
         if (group.hasEmptyContent()) {
           items.push({ kind: "group", group, count: 0, level: 0 });
-          items.push({ kind: "groupEmpty", group, level: 0 });
+          if (!(group.collapsible() && group.collapsed())) {
+            items.push({ kind: "groupEmpty", group, level: 0 });
+          }
         }
         continue;
       }

--- a/libs/components/src/table/v2/table-v2.component.ts
+++ b/libs/components/src/table/v2/table-v2.component.ts
@@ -143,7 +143,8 @@ function sortRows<T>(
  */
 type RenderItem<T> =
   | { kind: "row"; row: T }
-  | { kind: "group"; group: BitRowGroupComponent<T>; count: number; level: number };
+  | { kind: "group"; group: BitRowGroupComponent<T>; count: number; level: number }
+  | { kind: "groupEmpty"; group: BitRowGroupComponent<T>; level: number };
 
 /**
  * **Beta.** `bit-table-v2` is still stabilizing; its still getting some polish.
@@ -734,6 +735,11 @@ export class BitTableV2Component<T = unknown, S extends string = never, F = Reco
     for (const group of this._groups()) {
       const groupRows = top.buckets.get(group);
       if (!groupRows?.length) {
+        // Empty groups auto-hide unless they project `slot="empty"` content.
+        if (group.hasEmptyContent()) {
+          items.push({ kind: "group", group, count: 0, level: 0 });
+          items.push({ kind: "groupEmpty", group, level: 0 });
+        }
         continue;
       }
       // A collapsed group still shows its header (with the full count) but hides its body.
@@ -798,8 +804,12 @@ export class BitTableV2Component<T = unknown, S extends string = never, F = Reco
    * `cdkVirtualFor` and the non-virtualized `@for`.
    */
   protected readonly trackRenderItem: TrackByFunction<RenderItem<T>> = (index, item) => {
-    if (item.kind !== "row") {
+    if (item.kind === "group") {
       return item.group;
+    }
+    // Distinct from the group's header, which is also keyed by `item.group`.
+    if (item.kind === "groupEmpty") {
+      return item.group.emptyTemplate();
     }
     const trackBy = this.trackBy();
     return trackBy ? trackBy(index, item.row) : item.row;

--- a/libs/components/src/table/v2/table-v2.component.ts
+++ b/libs/components/src/table/v2/table-v2.component.ts
@@ -136,11 +136,11 @@ function sortRows<T>(
   });
 }
 
-/** A flattened body item: a data row, or a group header with its row-group and count. */
+/** A flattened body item: a data row, a group header with its row-group and count, or a group description. */
 type RenderItem<T> =
   | { kind: "row"; row: T }
   | { kind: "group"; group: BitRowGroupComponent<T>; count: number; level: number }
-  | { kind: "groupEmpty"; group: BitRowGroupComponent<T>; level: number };
+  | { kind: "groupDescription"; group: BitRowGroupComponent<T>; level: number };
 
 /**
  * **Beta.** `bit-table-v2` is still stabilizing. Do not adopt it in production
@@ -684,7 +684,8 @@ export class BitTableV2Component<T = unknown, S extends string = never, F = Reco
   /**
    * The non-virtualized body's render list: {@link rows} as-is when ungrouped, else
    * interleaved headers and rows. A row joins the first group whose `match` claims it;
-   * empty groups are skipped, and unclaimed rows trail in a headerless block.
+   * empty groups are skipped unless they clear `hideOnEmpty`, and unclaimed rows trail in
+   * a headerless block.
    */
   protected readonly renderItems = computed<RenderItem<T>[]>(() => {
     const rows = this.rows();
@@ -717,21 +718,19 @@ export class BitTableV2Component<T = unknown, S extends string = never, F = Reco
     const items: RenderItem<T>[] = [];
     const top = partition(this._groups(), rows);
     for (const group of this._groups()) {
-      const groupRows = top.buckets.get(group);
-      if (!groupRows?.length) {
-        // Empty groups auto-hide unless they project `slot="empty"` content.
-        if (group.hasEmptyContent()) {
-          items.push({ kind: "group", group, count: 0, level: 0 });
-          if (!(group.collapsible() && group.collapsed())) {
-            items.push({ kind: "groupEmpty", group, level: 0 });
-          }
-        }
+      const groupRows = top.buckets.get(group) ?? [];
+      if (!groupRows.length && group.hideOnEmpty()) {
         continue;
       }
       // A collapsed group still shows its header (with the full count) but hides its body.
       items.push({ kind: "group", group, count: groupRows.length, level: 0 });
       if (group.collapsible() && group.collapsed()) {
         continue;
+      }
+      // A grid row, so it hides when collapsed — `aria-expanded="false"` has to mean
+      // nothing of the group is rendered.
+      if (group.description()) {
+        items.push({ kind: "groupDescription", group, level: 0 });
       }
       const children = group.children();
       if (children.length === 0) {
@@ -791,9 +790,9 @@ export class BitTableV2Component<T = unknown, S extends string = never, F = Reco
     if (item.kind === "group") {
       return item.group;
     }
-    // Distinct from the group's header, which is also keyed by `item.group`.
-    if (item.kind === "groupEmpty") {
-      return item.group.emptyTemplate();
+    if (item.kind === "groupDescription") {
+      // Stable and per-group, but not `item.group` — that already keys the header.
+      return item.group.headerTemplate();
     }
     const trackBy = this.trackBy();
     return trackBy ? trackBy(index, item.row) : item.row;

--- a/libs/components/src/table/v2/table-v2.component.ts
+++ b/libs/components/src/table/v2/table-v2.component.ts
@@ -34,6 +34,7 @@ import { SearchComponent } from "../../search/search.component";
 import { SkeletonTextComponent } from "../../skeleton";
 import { StatusLockupComponent } from "../../status-lockup/status-lockup.component";
 import { SvgComponent } from "../../svg";
+import { TooltipDirective } from "../../tooltip";
 import { ParamState, ParamValue, queryParamStore } from "../../utils";
 import { SortDirection, SortFn } from "../table-data-source";
 
@@ -184,6 +185,7 @@ type RenderItem<T> =
     SkeletonTextComponent,
     SvgComponent,
     SyncScrollLeftDirective,
+    TooltipDirective,
     I18nPipe,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/libs/components/src/table/v2/table-v2.mdx
+++ b/libs/components/src/table/v2/table-v2.mdx
@@ -537,9 +537,8 @@ projected content is the header label, and the row count is appended automatical
 - **First-match-wins**, in declaration order. Rows no group claims render in a trailing headerless
   block; empty groups render nothing by default.
 - **`collapsible`** turns the header into a toggle that hides the group's rows (open by default).
-- **`[description]`** renders a line of explanatory text under the header. Keep it to one line —
-  under virtualization the row is fixed to the header's height, so longer text clips. Top-level
-  groups only.
+- **`[description]`** renders explanatory text under the header. Under virtualization it gets a
+  fixed two-line allowance and clamps past that, so keep it short. Top-level groups only.
 - **`[hideOnEmpty]`** (default `true`) drops a group with no matching rows. Clear it to keep the
   header and description on screen instead, so the description stands in for the missing rows — the
   extension's "Save a login item for this site to autofill" tip under an empty autofill-suggestions

--- a/libs/components/src/table/v2/table-v2.mdx
+++ b/libs/components/src/table/v2/table-v2.mdx
@@ -542,7 +542,7 @@ projected content is the header label, and the row count is appended automatical
 - **`[hideOnEmpty]`** (default `true`) drops a group with no matching rows. Clear it to keep the
   header and description on screen instead, so the description stands in for the missing rows — the
   extension's "Save a login item for this site to autofill" tip under an empty autofill-suggestions
-  group.
+  group. Top-level groups only; an empty nested subgroup always hides.
 - **One level of nesting** — a `<bit-row-group>` inside another sub-partitions its parent's rows;
   deeper nesting is ignored (and warns).
 

--- a/libs/components/src/table/v2/table-v2.mdx
+++ b/libs/components/src/table/v2/table-v2.mdx
@@ -535,8 +535,15 @@ projected content is the header label, and the row count is appended automatical
 ```
 
 - **First-match-wins**, in declaration order. Rows no group claims render in a trailing headerless
-  block; empty groups render nothing.
+  block; empty groups render nothing by default.
 - **`collapsible`** turns the header into a toggle that hides the group's rows (open by default).
+- **`[description]`** renders a line of explanatory text under the header. Keep it to one line —
+  under virtualization the row is fixed to the header's height, so longer text clips. Top-level
+  groups only.
+- **`[hideOnEmpty]`** (default `true`) drops a group with no matching rows. Clear it to keep the
+  header and description on screen instead, so the description stands in for the missing rows — the
+  extension's "Save a login item for this site to autofill" tip under an empty autofill-suggestions
+  group.
 - **One level of nesting** — a `<bit-row-group>` inside another sub-partitions its parent's rows;
   deeper nesting is ignored (and warns).
 
@@ -545,6 +552,8 @@ combined with a paginator. It composes with [virtual scrolling](#virtual-scrolli
 viewport renders the interleaved headers and rows.
 
 <Canvas of={stories.GroupedVirtualized} />
+
+<Canvas of={stories.GroupedDescription} />
 
 ## Scrolling and the sticky header
 

--- a/libs/components/src/table/v2/table-v2.stories.ts
+++ b/libs/components/src/table/v2/table-v2.stories.ts
@@ -1117,20 +1117,19 @@ const emptyGroupTable = defineTable<GroupedRow>(
   signal(
     [...Array(6).keys()].map((i) => ({
       id: i + 1,
-      name: `Item ${i + 1}`,
-      // Cards and notes only — nothing matches the "autofill suggestions" group.
-      type: (["card", "note"] as const)[i % 2],
+      name: `Note ${i + 1}`,
+      // Notes only, so both the "autofill suggestions" and "cards" groups come up empty.
+      type: "note" as const,
     })),
   ),
 );
 
 /**
- * A group with no matching rows renders nothing by default. Project
- * `slot="empty" #slotContainer` content to instead keep the group's header visible
- * and show that content in place of rows — here, an empty autofill-suggestions
- * group's "save a login for this site" tip. The other empty groups still auto-hide.
+ * `[description]` renders explanatory text under a group's header. Pair it with
+ * `[hideOnEmpty]="false"` to keep the group on screen when no rows match, so the text stands
+ * in for the missing rows. Empty groups otherwise auto-hide, as "Cards" does here.
  */
-export const GroupedEmptySlot: Story = {
+export const GroupedDescription: Story = {
   render: () => ({
     props: {
       table: emptyGroupTable,
@@ -1151,11 +1150,12 @@ export const GroupedEmptySlot: Story = {
             <bit-cell *bitCellDef="table.columns.name; let row">{{ row.name }}</bit-cell>
           </bit-column>
 
-          <bit-row-group [match]="isAutofill">
+          <bit-row-group
+            [match]="isAutofill"
+            [hideOnEmpty]="false"
+            description="Save a login item for this site to autofill"
+          >
             Autofill suggestions
-            <span slot="empty" #slotContainer class="tw-text-sm tw-text-muted">
-              Save a login item for this site to autofill
-            </span>
           </bit-row-group>
           <bit-row-group [match]="isCard">Cards</bit-row-group>
           <bit-row-group [match]="isNote">Notes</bit-row-group>

--- a/libs/components/src/table/v2/table-v2.stories.ts
+++ b/libs/components/src/table/v2/table-v2.stories.ts
@@ -749,6 +749,58 @@ export const GroupedVirtualized: Story = {
   }),
 };
 
+const emptyGroupTable = defineTable<GroupedRow>(
+  signal(
+    [...Array(6).keys()].map((i) => ({
+      id: i + 1,
+      name: `Item ${i + 1}`,
+      // Cards and notes only — nothing matches the "autofill suggestions" group.
+      type: (["card", "note"] as const)[i % 2],
+    })),
+  ),
+);
+
+/**
+ * A group with no matching rows renders nothing by default. Project
+ * `slot="empty" #slotContainer` content to instead keep the group's header visible
+ * and show that content in place of rows — here, an empty autofill-suggestions
+ * group's "save a login for this site" tip. The other empty groups still auto-hide.
+ */
+export const GroupedEmptySlot: Story = {
+  render: () => ({
+    props: {
+      table: emptyGroupTable,
+      isAutofill: (row: GroupedRow) => row.type === "login",
+      isCard: (row: GroupedRow) => row.type === "card",
+      isNote: (row: GroupedRow) => row.type === "note",
+    },
+    template: `
+      <bit-layout>
+        <bit-table-v2
+          [tableDef]="table"
+          presentation="list"
+          [virtualRowHeight]="44"
+          [height]="8"
+        >
+          <bit-column>
+            <bit-header-cell>Name</bit-header-cell>
+            <bit-cell *bitCellDef="table.columns.name; let row">{{ row.name }}</bit-cell>
+          </bit-column>
+
+          <bit-row-group [match]="isAutofill">
+            Autofill suggestions
+            <span slot="empty" #slotContainer class="tw-text-sm tw-text-muted">
+              Save a login item for this site to autofill
+            </span>
+          </bit-row-group>
+          <bit-row-group [match]="isCard">Cards</bit-row-group>
+          <bit-row-group [match]="isNote">Notes</bit-row-group>
+        </bit-table-v2>
+      </bit-layout>
+    `,
+  }),
+};
+
 type WideRow = {
   id: number;
   name: string;

--- a/libs/components/src/table/v2/table-v2.stories.ts
+++ b/libs/components/src/table/v2/table-v2.stories.ts
@@ -1113,6 +1113,58 @@ export const GroupedInitiallyCollapsed: Story = {
   }),
 };
 
+const emptyGroupTable = defineTable<GroupedRow>(
+  signal(
+    [...Array(6).keys()].map((i) => ({
+      id: i + 1,
+      name: `Item ${i + 1}`,
+      // Cards and notes only — nothing matches the "autofill suggestions" group.
+      type: (["card", "note"] as const)[i % 2],
+    })),
+  ),
+);
+
+/**
+ * A group with no matching rows renders nothing by default. Project
+ * `slot="empty" #slotContainer` content to instead keep the group's header visible
+ * and show that content in place of rows — here, an empty autofill-suggestions
+ * group's "save a login for this site" tip. The other empty groups still auto-hide.
+ */
+export const GroupedEmptySlot: Story = {
+  render: () => ({
+    props: {
+      table: emptyGroupTable,
+      isAutofill: (row: GroupedRow) => row.type === "login",
+      isCard: (row: GroupedRow) => row.type === "card",
+      isNote: (row: GroupedRow) => row.type === "note",
+    },
+    template: `
+      <bit-layout>
+        <bit-table-v2
+          [tableDef]="table"
+          presentation="list"
+          [virtualRowHeight]="44"
+          [height]="8"
+        >
+          <bit-column>
+            <bit-header-cell>Name</bit-header-cell>
+            <bit-cell *bitCellDef="table.columns.name; let row">{{ row.name }}</bit-cell>
+          </bit-column>
+
+          <bit-row-group [match]="isAutofill">
+            Autofill suggestions
+            <span slot="empty" #slotContainer class="tw-text-sm tw-text-muted">
+              Save a login item for this site to autofill
+            </span>
+          </bit-row-group>
+          <bit-row-group [match]="isCard">Cards</bit-row-group>
+          <bit-row-group [match]="isNote">Notes</bit-row-group>
+        </bit-table-v2>
+      </bit-layout>
+    `,
+  }),
+};
+
 type WideRow = {
   id: number;
   name: string;


### PR DESCRIPTION
https://bitwarden.atlassian.net/browse/CL-1293

Adds two inputs to `bit-row-group`: `description`, a line of text under the group's header, and `hideOnEmpty` (default `true`), which when cleared keeps the group on screen with no matching rows so the description can stand in for them (e.g. an empty autofill-suggestions group's "save a login for this site" tip).

Adds a `GroupedDescription` story.

<img width="1273" height="456" alt="image" src="https://github.com/user-attachments/assets/af5fc614-ce5f-48cc-91be-16255fcdc8a7" />
