### PR TITLE
feat(vault): enable SSH key import from clipboard on web vault

### DIFF
--- a/apps/web/src/app/core/web-platform-utils.service.spec.ts
+++ b/apps/web/src/app/core/web-platform-utils.service.spec.ts
@@ -1,6 +1,9 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
+import { mock, MockProxy } from "jest-mock-extended";
+
 import { DeviceType } from "@bitwarden/common/enums";
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 
 import { WebPlatformUtilsService } from "./web-platform-utils.service";
 
@@ -232,6 +235,72 @@ describe("Web Platform Utils Service", () => {
     test.each(nonChromiumDevices)("returns false when getDevice() is %s", (deviceType) => {
       jest.spyOn(webPlatformUtilsService, "getDevice").mockReturnValue(deviceType);
       expect(webPlatformUtilsService.isChromium()).toBe(false);
+    });
+  });
+
+  describe("readFromClipboard", () => {
+    let logService: MockProxy<LogService>;
+    let service: WebPlatformUtilsService;
+
+    beforeEach(() => {
+      logService = mock<LogService>();
+      service = new WebPlatformUtilsService(null, null, logService);
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+      delete (navigator as any).clipboard;
+      delete (document as any).queryCommandSupported;
+      delete (document as any).execCommand;
+    });
+
+    it("reads text using the clipboard API when supported", async () => {
+      Object.defineProperty(navigator, "clipboard", {
+        value: { readText: jest.fn().mockResolvedValue("clipboard-text") },
+        configurable: true,
+      });
+
+      const result = await service.readFromClipboard();
+
+      expect(result).toBe("clipboard-text");
+    });
+
+    it("falls back to the legacy method when the clipboard API is not supported", async () => {
+      (document as any).queryCommandSupported = jest.fn().mockReturnValue(true);
+      (document as any).execCommand = jest.fn().mockImplementation((command) => {
+        if (command === "paste") {
+          document.querySelector("textarea").value = "legacy-text";
+          return true;
+        }
+        return false;
+      });
+
+      const result = await service.readFromClipboard();
+
+      expect(document.execCommand).toHaveBeenCalledWith("paste");
+      expect(result).toBe("legacy-text");
+    });
+
+    it("falls back to the legacy method when the clipboard API throws", async () => {
+      Object.defineProperty(navigator, "clipboard", {
+        value: { readText: jest.fn().mockRejectedValue(new Error("denied")) },
+        configurable: true,
+      });
+      (document as any).queryCommandSupported = jest.fn().mockReturnValue(true);
+      (document as any).execCommand = jest.fn().mockReturnValue(true);
+
+      await service.readFromClipboard();
+
+      expect(document.execCommand).toHaveBeenCalledWith("paste");
+      expect(logService.debug).toHaveBeenCalled();
+    });
+
+    it("returns an empty string when neither the clipboard API nor the legacy method are supported", async () => {
+      (document as any).queryCommandSupported = jest.fn().mockReturnValue(false);
+
+      const result = await service.readFromClipboard();
+
+      expect(result).toBe("");
     });
   });
 });

--- a/apps/web/src/app/core/web-platform-utils.service.ts
+++ b/apps/web/src/app/core/web-platform-utils.service.ts
@@ -212,8 +212,44 @@ export class WebPlatformUtilsService implements PlatformUtilsService {
     }
   }
 
-  readFromClipboard(options?: any): Promise<string> {
-    throw new Error("Cannot read from clipboard on web.");
+  async readFromClipboard(): Promise<string> {
+    if (this.isClipboardApiSupported(window, "readText")) {
+      try {
+        return await window.navigator.clipboard.readText();
+      } catch (e) {
+        this.logService.debug(
+          `Error reading from clipboard using the clipboard API, attempting legacy method: ${e}`,
+        );
+      }
+    }
+
+    return this.readFromClipboardLegacy(window);
+  }
+
+  private readFromClipboardLegacy(win: Window): string {
+    const doc = win.document;
+    if (!doc.queryCommandSupported || !doc.queryCommandSupported("paste")) {
+      this.logService.debug("Legacy paste method not supported.");
+      return "";
+    }
+
+    const textarea = doc.createElement("textarea");
+    textarea.style.position = "fixed";
+    doc.body.appendChild(textarea);
+    textarea.focus();
+
+    try {
+      return doc.execCommand("paste") ? textarea.value : "";
+    } catch (e) {
+      this.logService.debug(`Error reading from clipboard: ${e}`);
+      return "";
+    } finally {
+      doc.body.removeChild(textarea);
+    }
+  }
+
+  private isClipboardApiSupported(win: Window, method: "writeText" | "readText"): boolean {
+    return "clipboard" in win.navigator && method in win.navigator.clipboard;
   }
 
   supportsSecureStorage() {

--- a/libs/vault/src/cipher-form/components/sshkey-section/sshkey-section.component.spec.ts
+++ b/libs/vault/src/cipher-form/components/sshkey-section/sshkey-section.component.spec.ts
@@ -4,9 +4,7 @@ import { By } from "@angular/platform-browser";
 import { mock } from "jest-mock-extended";
 import { BehaviorSubject, Subject } from "rxjs";
 
-import { ClientType } from "@bitwarden/common/enums";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
-import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { SdkService } from "@bitwarden/common/platform/abstractions/sdk/sdk.service";
 import { SshKeyView } from "@bitwarden/common/vault/models/view/ssh-key.view";
 import { generate_ssh_key } from "@bitwarden/sdk-internal";
@@ -41,8 +39,6 @@ describe("SshKeySectionComponent", () => {
 
   let sshImportPromptService: { importSshKeyFromClipboard: jest.Mock };
 
-  let platformUtilsService: { getClientType: jest.Mock };
-
   beforeEach(async () => {
     formStatusChange$ = new Subject<string>();
 
@@ -60,10 +56,6 @@ describe("SshKeySectionComponent", () => {
       importSshKeyFromClipboard: jest.fn(),
     };
 
-    platformUtilsService = {
-      getClientType: jest.fn(),
-    };
-
     await TestBed.configureTestingModule({
       imports: [SshKeySectionComponent],
       providers: [
@@ -71,7 +63,6 @@ describe("SshKeySectionComponent", () => {
         { provide: CipherFormContainer, useValue: cipherFormContainer },
         { provide: SdkService, useValue: sdkService },
         { provide: SshImportPromptService, useValue: sshImportPromptService },
-        { provide: PlatformUtilsService, useValue: platformUtilsService },
       ],
       schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
@@ -117,8 +108,6 @@ describe("SshKeySectionComponent", () => {
       sshKey: { privateKey: "p1", publicKey: "p2", keyFingerprint: "p3" },
     });
 
-    platformUtilsService.getClientType.mockReturnValue(ClientType.Desktop);
-
     await component.ngOnInit();
 
     expect(generate_ssh_key).not.toHaveBeenCalled();
@@ -133,8 +122,6 @@ describe("SshKeySectionComponent", () => {
       edit: true,
       sshKey: { privateKey: "o1", publicKey: "o2", keyFingerprint: "o3" },
     });
-
-    platformUtilsService.getClientType.mockReturnValue(ClientType.Desktop);
 
     await component.ngOnInit();
 
@@ -154,8 +141,6 @@ describe("SshKeySectionComponent", () => {
       fingerprint: "genFp",
     });
 
-    platformUtilsService.getClientType.mockReturnValue(ClientType.Desktop);
-
     await component.ngOnInit();
 
     expect(generate_ssh_key).toHaveBeenCalledTimes(1);
@@ -165,12 +150,11 @@ describe("SshKeySectionComponent", () => {
     expect(component.sshKeyForm.get("keyFingerprint")?.value).toBe("genFp");
   });
 
-  it("sets showImport true when not Web and originalCipherView.edit is true", async () => {
+  it("sets showImport true when originalCipherView.edit is true", async () => {
     cipherFormContainer.getInitialCipherView.mockReturnValue({
       sshKey: { privateKey: "p1", publicKey: "p2", keyFingerprint: "p3" },
     });
 
-    platformUtilsService.getClientType.mockReturnValue(ClientType.Desktop);
     fixture.componentRef.setInput("originalCipherView", { edit: true, sshKey: null } as any);
 
     await component.ngOnInit();
@@ -178,13 +162,12 @@ describe("SshKeySectionComponent", () => {
     expect(component.showImport()).toBe(true);
   });
 
-  it("keeps showImport false when client type is Web", async () => {
+  it("sets showImport false when originalCipherView.edit is false", async () => {
     cipherFormContainer.getInitialCipherView.mockReturnValue({
       sshKey: { privateKey: "p1", publicKey: "p2", keyFingerprint: "p3" },
     });
 
-    platformUtilsService.getClientType.mockReturnValue(ClientType.Web);
-    fixture.componentRef.setInput("originalCipherView", { edit: true, sshKey: null } as any);
+    fixture.componentRef.setInput("originalCipherView", { edit: false, sshKey: null } as any);
 
     await component.ngOnInit();
 
@@ -196,7 +179,6 @@ describe("SshKeySectionComponent", () => {
       sshKey: { privateKey: "p1", publicKey: "p2", keyFingerprint: "p3" },
     });
 
-    platformUtilsService.getClientType.mockReturnValue(ClientType.Desktop);
     fixture.componentRef.setInput("originalCipherView", { edit: true, sshKey: null } as any);
 
     await component.ngOnInit();

--- a/libs/vault/src/cipher-form/components/sshkey-section/sshkey-section.component.ts
+++ b/libs/vault/src/cipher-form/components/sshkey-section/sshkey-section.component.ts
@@ -7,8 +7,6 @@ import { FormBuilder, ReactiveFormsModule } from "@angular/forms";
 import { firstValueFrom } from "rxjs";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
-import { ClientType } from "@bitwarden/common/enums";
-import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { SdkService } from "@bitwarden/common/platform/abstractions/sdk/sdk.service";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { SshKeyView } from "@bitwarden/common/vault/models/view/ssh-key.view";
@@ -58,12 +56,8 @@ export class SshKeySectionComponent implements OnInit {
   });
 
   readonly showImport = computed(() => {
-    return (
-      // Web does not support clipboard access
-      this.platformUtilsService.getClientType() !== ClientType.Web &&
-      // null means a new cipher is being created, which always has edit access
-      (this.originalCipherView() == null || this.originalCipherView()!.edit)
-    );
+    // null means a new cipher is being created, which always has edit access
+    return this.originalCipherView() == null || this.originalCipherView()!.edit;
   });
 
   constructor(
@@ -71,7 +65,6 @@ export class SshKeySectionComponent implements OnInit {
     private formBuilder: FormBuilder,
     private sdkService: SdkService,
     private sshImportPromptService: SshImportPromptService,
-    private platformUtilsService: PlatformUtilsService,
   ) {
     this.cipherFormContainer.registerChildForm("sshKeyDetails", this.sshKeyForm);
     this.sshKeyForm.valueChanges.pipe(takeUntilDestroyed()).subscribe((value) => {


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-41099

## 📔 Objective

Enable SSH key import from clipboard in the web vault. It was previously blocked by a ClientType.Web check even though desktop and browser already support it.

- Implement readFromClipboard() in WebPlatformUtilsService (Clipboard API with a legacy execCommand fallback). Was a stub that threw.
- Remove the ClientType.Web exclusion in SshKeySectionComponent.
- Add unit test coverage for both.

Manually verified: valid key import populates private key, public key, and fingerprint correctly; invalid clipboard content shows an error toast without corrupting the form; import button shows correctly in create and edit modes.
