### PR TITLE
desktop-autofill: Implement Windows native status command [PM-41025]

### DIFF
--- a/apps/desktop/desktop_native/Cargo.lock
+++ b/apps/desktop/desktop_native/Cargo.lock
@@ -1535,6 +1535,8 @@ dependencies = [
  "secmem-proc",
  "security-framework",
  "security-framework-sys",
+ "serde",
+ "serde_json",
  "sha2 0.10.9",
  "ssh-key",
  "sysinfo",
@@ -6295,8 +6297,7 @@ version = "0.0.0"
 dependencies = [
  "autofill_provider",
  "base64",
- "serde",
- "serde_json",
+ "desktop_core",
  "tracing",
  "tracing-subscriber",
  "win_webauthn",

--- a/apps/desktop/desktop_native/Cargo.lock
+++ b/apps/desktop/desktop_native/Cargo.lock
@@ -1546,6 +1546,7 @@ dependencies = [
  "tracing",
  "typenum",
  "widestring",
+ "win_webauthn",
  "windows 0.62.2",
  "zbus",
  "zeroizing-alloc",

--- a/apps/desktop/desktop_native/core/Cargo.toml
+++ b/apps/desktop/desktop_native/core/Cargo.toml
@@ -65,8 +65,12 @@ security-framework-sys = { workspace = true, optional = true }
 pin-project = { workspace = true }
 scopeguard = { workspace = true }
 secmem-proc = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
 widestring = { workspace = true, optional = true }
 windows = { workspace = true, features = [
+    "ApplicationModel_PackageExtensions",
+    "Storage_Search",
     "Win32_Foundation",
     "Win32_Security_Credentials",
     "Win32_System_Pipes",

--- a/apps/desktop/desktop_native/core/Cargo.toml
+++ b/apps/desktop/desktop_native/core/Cargo.toml
@@ -68,6 +68,7 @@ secmem-proc = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 widestring = { workspace = true, optional = true }
+win_webauthn = { path = "../win_webauthn" }
 windows = { workspace = true, features = [
     "ApplicationModel_PackageExtensions",
     "Storage_Search",

--- a/apps/desktop/desktop_native/core/src/autofill/mod.rs
+++ b/apps/desktop/desktop_native/core/src/autofill/mod.rs
@@ -1,6 +1,6 @@
 #[allow(clippy::module_inception)]
 #[cfg_attr(target_os = "linux", path = "unix.rs")]
-#[cfg_attr(target_os = "windows", path = "windows.rs")]
+#[cfg_attr(target_os = "windows", path = "windows/mod.rs")]
 #[cfg_attr(target_os = "macos", path = "macos.rs")]
 mod autofill;
 pub use autofill::*;

--- a/apps/desktop/desktop_native/core/src/autofill/windows.rs
+++ b/apps/desktop/desktop_native/core/src/autofill/windows.rs
@@ -1,6 +1,0 @@
-use anyhow::Result;
-
-#[allow(clippy::unused_async)]
-pub async fn run_command(_value: String) -> Result<String> {
-    todo!("Windows does not support autofill");
-}

--- a/apps/desktop/desktop_native/core/src/autofill/windows/mod.rs
+++ b/apps/desktop/desktop_native/core/src/autofill/windows/mod.rs
@@ -1,0 +1,122 @@
+use std::{fs::File, io::Read, path::PathBuf};
+
+use anyhow::{Context, Result};
+use serde::Deserialize;
+use windows::{
+    core::HRESULT, ApplicationModel::Package, Win32::Foundation::APPMODEL_ERROR_NO_PACKAGE,
+};
+
+/// `Package::Current()` reports this when the process is not running from an Appx package.
+const NO_PACKAGE: HRESULT = HRESULT::from_win32(APPMODEL_ERROR_NO_PACKAGE.0);
+
+#[allow(clippy::unused_async)]
+pub async fn run_command(_value: String) -> Result<String> {
+    todo!("Windows does not support autofill");
+}
+
+/// Reads config file stored in Appx package.
+///
+/// Returns `Ok(None)` when this process is not running from an Appx package, and an error when
+/// it is packaged but the config file could not be read. Callers must not conflate the two: the
+/// former is the normal unpackaged build, the latter is a packaging defect.
+pub fn read_plugin_config_file() -> Result<Option<ConfigFile>> {
+    // This is set in apps/desktop/electron-builder*.json.
+    let Some(config_path) = get_resource_path("plugin_authenticator_config.json")? else {
+        return Ok(None);
+    };
+    tracing::debug!("[core::autofill] Reading config file from {config_path:?}");
+    let config_file = File::options()
+        .read(true)
+        .open(config_path)
+        .context("Could not open authenticator config file")?;
+    let config: ConfigFile = parse_config(&config_file)?;
+    tracing::debug!("[core::autofill] Parsed config file: {config:?}");
+    Ok(Some(config))
+}
+
+fn parse_config(config_file: impl Read) -> Result<ConfigFile> {
+    serde_json::from_reader(config_file).context("Could not parse authenticator config file")
+}
+
+/// Reads logo SVG file stored in Appx package.
+///
+/// Unlike [`read_plugin_config_file`], a missing package is an error rather than `Ok(None)`: the
+/// logo is only read once the config file has already established that this build is packaged.
+pub fn read_plugin_logo() -> Result<String> {
+    // This is set in apps/desktop/electron-builder*.json.
+    let logo_path = get_resource_path("plugin_authenticator_logo.svg")?
+        .context("Not running from an Appx package")?;
+
+    let mut logo = String::new();
+    File::open(logo_path)
+        .context("Could not open authenticator logo file")?
+        .read_to_string(&mut logo)
+        .context("Could not read logo file")?;
+    Ok(logo)
+}
+
+/// Returns `Ok(None)` when this process is not running from an Appx package.
+fn get_resource_path(resource: &str) -> Result<Option<PathBuf>> {
+    let installed_location = Package::Current()
+        .and_then(|package| package.InstalledLocation())
+        .and_then(|folder| folder.Path());
+    let mut path = match installed_location {
+        Ok(path) => PathBuf::from(path.to_os_string()),
+        Err(err) if err.code() == NO_PACKAGE => return Ok(None),
+        Err(err) => return Err(err).context("Could not read Appx package location"),
+    };
+    // Base path of Electron Build
+    path.push("app\\resources");
+    path.push(resource);
+    Ok(Some(path))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ConfigFile {
+    pub clsid: String,
+    pub name: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_config;
+
+    #[test]
+    fn parse_config_succeeds_with_valid_json() {
+        let json = br#"{
+            "clsid": "0f7dc5d9-69ce-4652-8572-6877fd695062",
+            "name": "Bitwarden"
+        }"#;
+        let config = parse_config(json.as_slice()).unwrap();
+        assert_eq!(config.clsid, "0f7dc5d9-69ce-4652-8572-6877fd695062");
+        assert_eq!(config.name, "Bitwarden");
+    }
+
+    #[test]
+    fn parse_config_fails_when_clsid_is_missing() {
+        let json = br#"{"name": "Bitwarden"}"#;
+        assert!(parse_config(json.as_slice()).is_err());
+    }
+
+    #[test]
+    fn parse_config_fails_when_name_is_missing() {
+        let json = br#"{"clsid": "0f7dc5d9-69ce-4652-8572-6877fd695062"}"#;
+        assert!(parse_config(json.as_slice()).is_err());
+    }
+
+    #[test]
+    fn parse_config_fails_on_malformed_json() {
+        let json = b"not json at all";
+        assert!(parse_config(json.as_slice()).is_err());
+    }
+
+    #[test]
+    fn parse_config_error_message_mentions_config_file() {
+        let json = b"{}";
+        let err = parse_config(json.as_slice()).unwrap_err();
+        assert!(
+            err.to_string().contains("authenticator config file"),
+            "error was: {err}"
+        );
+    }
+}

--- a/apps/desktop/desktop_native/core/src/autofill/windows/mod.rs
+++ b/apps/desktop/desktop_native/core/src/autofill/windows/mod.rs
@@ -1,17 +1,104 @@
-use std::{fs::File, io::Read, path::PathBuf};
+mod status;
 
-use anyhow::{Context, Result};
-use serde::Deserialize;
+use std::{fs::File, io::Read, path::PathBuf, sync::OnceLock};
+
+use anyhow::{anyhow, Context, Result};
+use serde::{Deserialize, Serialize};
+use status::{handle_status_request, StatusResponse};
+use win_webauthn::plugin::Clsid;
 use windows::{
     core::HRESULT, ApplicationModel::Package, Win32::Foundation::APPMODEL_ERROR_NO_PACKAGE,
 };
 
+static PLUGIN_ID: OnceLock<Clsid> = OnceLock::new();
+
 /// `Package::Current()` reports this when the process is not running from an Appx package.
 const NO_PACKAGE: HRESULT = HRESULT::from_win32(APPMODEL_ERROR_NO_PACKAGE.0);
 
-#[allow(clippy::unused_async)]
-pub async fn run_command(_value: String) -> Result<String> {
-    todo!("Windows does not support autofill");
+pub async fn run_command(value: String) -> Result<String> {
+    let response = dispatch_command(value).await;
+    serde_json::to_string(&CommandResult::from(response)).context("Failed to serialize response")
+}
+
+async fn dispatch_command(value: String) -> Result<CommandResponse> {
+    let request: RunCommandRequest =
+        serde_json::from_str(&value).context("Failed to deserialize autofill request")?;
+
+    if request.namespace != "autofill" {
+        return Err(anyhow!("Unknown namespace: {}", request.namespace));
+    }
+
+    tokio::task::spawn_blocking(move || match request.command {
+        RunCommand::Status(_) => handle_status_request().map(CommandResponse::from),
+    })
+    .await
+    .context("Autofill command task failed")?
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RunCommandRequest {
+    namespace: String,
+    #[serde(flatten)]
+    command: RunCommand,
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "command", content = "params")]
+#[serde(rename_all = "camelCase")]
+enum RunCommand {
+    Status(()),
+}
+
+#[derive(Serialize)]
+#[serde(tag = "type", rename_all = "camelCase")]
+enum CommandResult {
+    Success { value: CommandResponse },
+    Error { error: String },
+}
+
+impl From<anyhow::Result<CommandResponse>> for CommandResult {
+    fn from(value: anyhow::Result<CommandResponse>) -> Self {
+        match value {
+            Ok(response) => Self::Success { value: response },
+            Err(err) => Self::Error {
+                error: format!("{err:#}"),
+            },
+        }
+    }
+}
+
+#[derive(Serialize)]
+#[serde(untagged)]
+enum CommandResponse {
+    Status(StatusResponse),
+}
+
+impl From<StatusResponse> for CommandResponse {
+    fn from(value: StatusResponse) -> Self {
+        Self::Status(value)
+    }
+}
+
+/// Read the CLSID from the Appx config file, then cache it for the lifetime of the process.
+///
+/// Returns `Ok(None)` when this build is not packaged as an Appx and so has no plugin. A failure
+/// to read a config file that *is* present is returned as an error rather than being cached as
+/// "no plugin", which would otherwise wedge the plugin as unavailable until the process restarts.
+fn get_clsid() -> Result<Option<Clsid>> {
+    if let Some(clsid) = PLUGIN_ID.get() {
+        return Ok(Some(*clsid));
+    }
+
+    let Some(config_file) = read_plugin_config_file()? else {
+        return Ok(None);
+    };
+    let clsid = Clsid::try_from(format!("{{{}}}", config_file.clsid).as_str())
+        .context("Failed to parse valid CLSID from package.")?;
+
+    // Multiple threads may race here, but they all parse the same config file, so whichever
+    // value wins is the one they all return.
+    Ok(Some(*PLUGIN_ID.get_or_init(|| clsid)))
 }
 
 /// Reads config file stored in Appx package.
@@ -79,7 +166,39 @@ pub struct ConfigFile {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_config;
+    use serde_json::Value;
+
+    use super::{parse_config, run_command};
+
+    /// Malformed requests are rejected before dispatch, so these never reach Windows.
+    async fn run_command_error(json: &str) -> String {
+        let response = run_command(json.to_string())
+            .await
+            .expect("run_command should report failures in its payload, not reject");
+        let result: Value = serde_json::from_str(&response).unwrap();
+
+        assert_eq!("error", result["type"], "full response: {result}");
+        result["error"]
+            .as_str()
+            .expect("error payload should be a string")
+            .to_string()
+    }
+
+    #[tokio::test]
+    async fn run_command_reports_unknown_namespace_as_error_result() {
+        let json = r#"{"namespace":"not-autofill","command":"status","params":{}}"#;
+
+        let err = run_command_error(json).await;
+
+        assert!(err.contains("Unknown namespace"), "error was: {err}");
+    }
+
+    #[tokio::test]
+    async fn run_command_reports_unknown_command_as_error_result() {
+        let json = r#"{"namespace":"autofill","command":"explode","params":{}}"#;
+
+        run_command_error(json).await;
+    }
 
     #[test]
     fn parse_config_succeeds_with_valid_json() {

--- a/apps/desktop/desktop_native/core/src/autofill/windows/status.rs
+++ b/apps/desktop/desktop_native/core/src/autofill/windows/status.rs
@@ -1,0 +1,101 @@
+use anyhow::Result;
+use serde::Serialize;
+use win_webauthn::plugin::{AuthenticatorState, WebAuthnPlugin};
+
+use super::get_clsid;
+
+pub(super) fn handle_status_request() -> Result<StatusResponse> {
+    let clsid = get_clsid()?;
+    let Some(clsid) = clsid else {
+        // Not packaged as an Appx, so ignoring and returning status == disabled.
+        return Ok(StatusResponse {
+            support: StatusSupport {
+                fido2: false,
+                password: false,
+                incremental_updates: false,
+            },
+            state: StatusState { enabled: false },
+        });
+    };
+
+    let plugin = WebAuthnPlugin::new(clsid);
+    let authenticator_state = plugin.get_authenticator_state()?;
+    let fido_enabled = matches!(authenticator_state, AuthenticatorState::Enabled);
+    // Windows currently only supports FIDO2 credentials, so we report as
+    // disabled if the FIDO2 credentials can't sync.
+    let enabled = fido_enabled;
+    Ok(StatusResponse {
+        support: StatusSupport {
+            fido2: fido_enabled,
+            password: false,
+            incremental_updates: false,
+        },
+        state: StatusState { enabled },
+    })
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct StatusResponse {
+    support: StatusSupport,
+    state: StatusState,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct StatusSupport {
+    fido2: bool,
+    password: bool,
+    incremental_updates: bool,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct StatusState {
+    enabled: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::{StatusResponse, StatusState, StatusSupport};
+    use crate::autofill::autofill::{
+        CommandResponse, CommandResult, RunCommand, RunCommandRequest,
+    };
+
+    #[test]
+    fn test_status_request_deserialization() {
+        let json = json!({
+            "namespace": "autofill",
+            "command": "status",
+            "params": {},
+        });
+        let request: RunCommandRequest = serde_json::from_value(json).unwrap();
+
+        assert!(matches!(request.command, RunCommand::Status(())));
+        assert_eq!("autofill", request.namespace);
+    }
+
+    #[test]
+    fn test_status_serializes_expected_response() {
+        let result = CommandResult::Success {
+            value: CommandResponse::Status(StatusResponse {
+                support: StatusSupport {
+                    fido2: true,
+                    password: false,
+                    incremental_updates: false,
+                },
+                state: StatusState { enabled: true },
+            }),
+        };
+        let expected = json!({
+            "type": "success",
+            "value": {
+                "support": { "fido2": true, "password": false, "incrementalUpdates": false },
+                "state": { "enabled": true },
+            },
+        });
+        assert_eq!(expected, serde_json::to_value(&result).unwrap());
+    }
+}

--- a/apps/desktop/desktop_native/win_webauthn/src/api/plugin/mod.rs
+++ b/apps/desktop/desktop_native/win_webauthn/src/api/plugin/mod.rs
@@ -257,6 +257,10 @@ impl WebAuthnPlugin {
         }
     }
 
+    pub fn get_authenticator_state(&self) -> Result<AuthenticatorState, WinWebAuthnError> {
+        get_authenticator_state(&self.clsid)
+    }
+
     /// Registers a COM server with Windows and starts the COM message loop on a dedicated thread.
     ///
     /// The handler should be an instance of your type that implements [PluginAuthenticator].

--- a/apps/desktop/desktop_native/win_webauthn/src/api/plugin/types/authenticator.rs
+++ b/apps/desktop/desktop_native/win_webauthn/src/api/plugin/types/authenticator.rs
@@ -13,7 +13,8 @@ use crate::{
             webauthn_plugin_add_authenticator, webauthn_plugin_authenticator_add_credentials,
             webauthn_plugin_authenticator_remove_all_credentials,
             webauthn_plugin_free_add_authenticator_response,
-            webauthn_plugin_update_authenticator_details, WEBAUTHN_CTAPCBOR_AUTHENTICATOR_OPTIONS,
+            webauthn_plugin_get_authenticator_state, webauthn_plugin_update_authenticator_details,
+            AUTHENTICATOR_STATE, WEBAUTHN_CTAPCBOR_AUTHENTICATOR_OPTIONS,
             WEBAUTHN_PLUGIN_ADD_AUTHENTICATOR_OPTIONS, WEBAUTHN_PLUGIN_ADD_AUTHENTICATOR_RESPONSE,
             WEBAUTHN_PLUGIN_CREDENTIAL_DETAILS, WEBAUTHN_PLUGIN_UPDATE_AUTHENTICATOR_DETAILS,
         },
@@ -21,8 +22,80 @@ use crate::{
         WindowsString,
     },
     plugin::Clsid,
-    CredentialId, ErrorKind, WinWebAuthnError,
+    CredentialId,
+    ErrorKind::{self, WindowsInternal},
+    WinWebAuthnError,
 };
+
+/// Specifies whether a plugin authenticator is enabled.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum AuthenticatorState {
+    Disabled,
+    Enabled,
+}
+
+impl TryFrom<AUTHENTICATOR_STATE> for AuthenticatorState {
+    type Error = WinWebAuthnError;
+
+    fn try_from(value: AUTHENTICATOR_STATE) -> Result<Self, Self::Error> {
+        match value.0 {
+            0 => Ok(AuthenticatorState::Disabled),
+            1 => Ok(AuthenticatorState::Enabled),
+            other => Err(WinWebAuthnError::new(
+                ErrorKind::WindowsInternal,
+                &format!("Invalid authenticator state value passed: {other}"),
+            )),
+        }
+    }
+}
+
+pub fn get_authenticator_state(clsid: &Clsid) -> Result<AuthenticatorState, WinWebAuthnError> {
+    // SAFETY: We check the return type before reading the memory that Windows
+    // initializes.
+    let state = unsafe {
+        let mut state_ptr = MaybeUninit::uninit();
+        webauthn_plugin_get_authenticator_state(&clsid.as_guid(), state_ptr.as_mut_ptr())?
+            .ok()
+            .map_err(|err| {
+                WinWebAuthnError::with_cause(
+                    WindowsInternal,
+                    "Failed to lookup plugin authenticator state",
+                    err,
+                )
+            })?;
+        state_ptr.assume_init()
+    };
+    state.try_into()
+}
+
+#[cfg(test)]
+mod authenticator_state_tests {
+    use super::{AuthenticatorState, AUTHENTICATOR_STATE};
+
+    #[test]
+    fn maps_documented_state_values() {
+        assert_eq!(
+            AuthenticatorState::Disabled,
+            AUTHENTICATOR_STATE(0).try_into().unwrap()
+        );
+        assert_eq!(
+            AuthenticatorState::Enabled,
+            AUTHENTICATOR_STATE(1).try_into().unwrap()
+        );
+    }
+
+    /// A future Windows release could report a state this build does not know about.
+    /// It must fail closed rather than being silently treated as enabled.
+    #[test]
+    fn rejects_undocumented_state_values() {
+        for value in [2, 3, -1, i32::MAX, i32::MIN] {
+            assert!(
+                AuthenticatorState::try_from(AUTHENTICATOR_STATE(value)).is_err(),
+                "state {value} should be rejected"
+            );
+        }
+    }
+}
 
 // Plugin Registration types
 pub type WebAuthnCtapCborAuthenticatorOptions = WEBAUTHN_CTAPCBOR_AUTHENTICATOR_OPTIONS;

--- a/apps/desktop/desktop_native/win_webauthn/src/api/sys/plugin.rs
+++ b/apps/desktop/desktop_native/win_webauthn/src/api/sys/plugin.rs
@@ -12,6 +12,14 @@ use super::{
     WEBAUTHN_CREDENTIAL_LIST, WEBAUTHN_RP_ENTITY_INFORMATION, WEBAUTHN_USER_ENTITY_INFORMATION,
 };
 
+/// Specifies whether a plugin authenticator is enabled.
+///
+/// Valid values:
+/// AuthenticatorState_Disabled = 0,
+/// AuthenticatorState_Enabled = 1
+#[repr(transparent)]
+pub(in crate::api) struct AUTHENTICATOR_STATE(pub(in crate::api) i32);
+
 /// Plugin lock status enum as defined in the IDL
 #[repr(u32)]
 #[derive(Debug, Copy, Clone)]
@@ -546,6 +554,27 @@ webauthn_call!("WebAuthNPluginFreeUserVerificationResponse" as
 fn webauthn_plugin_free_user_verification_response(
     pbResponse: *mut u8
 ) -> ());
+
+webauthn_call!("WebAuthNPluginGetAuthenticatorState" as
+/// Gets the current enabled or disabled state of a plugin authenticator.
+///
+/// # Arguments
+///
+/// - `rclsid`: The class identifier of the registered plugin authenticator.
+/// - `pluginAuthenticatorState`: Receives an AUTHENTICATOR_STATE value that indicates whether the
+///   plugin authenticator is enabled or disabled.
+///
+/// # Returns
+///
+/// If the function succeeds, it returns S_OK. Otherwise, it returns an HRESULT error code.
+///
+/// # Remarks
+/// Use this function to determine whether Windows currently considers the specified plugin
+/// authenticator available for WebAuthn operations.
+fn webauthn_plugin_get_authenticator_state(
+  rclsid: *const GUID,
+  pluginAuthenticatorState: *mut AUTHENTICATOR_STATE,
+) -> HRESULT);
 
 webauthn_call!("WebAuthNPluginPerformUserVerification" as
 /// Request user verification for a WebAuthn operation.

--- a/apps/desktop/desktop_native/win_webauthn/src/lib.rs
+++ b/apps/desktop/desktop_native/win_webauthn/src/lib.rs
@@ -28,7 +28,7 @@ pub use api::{
 pub struct WinWebAuthnError {
     kind: ErrorKind,
     description: Option<String>,
-    cause: Option<Box<dyn std::error::Error>>,
+    cause: Option<Box<dyn std::error::Error + Send + Sync>>,
 }
 
 impl WinWebAuthnError {
@@ -40,12 +40,12 @@ impl WinWebAuthnError {
         }
     }
 
-    pub(crate) fn with_cause<E: std::error::Error + 'static>(
+    pub(crate) fn with_cause<E: std::error::Error + Send + Sync + 'static>(
         kind: ErrorKind,
         description: &str,
         cause: E,
     ) -> Self {
-        let cause: Box<dyn std::error::Error> = Box::new(cause);
+        let cause: Box<dyn std::error::Error + Send + Sync> = Box::new(cause);
         Self {
             kind,
             description: Some(description.to_string()),

--- a/apps/desktop/desktop_native/win_webauthn/src/plugin.rs
+++ b/apps/desktop/desktop_native/win_webauthn/src/plugin.rs
@@ -1,7 +1,8 @@
 //! Types useful for implementing a Windows passkey plugin authenticator.
 pub use crate::api::plugin::{
-    Clsid, PluginAddAuthenticatorOptions, PluginAddAuthenticatorResponse, PluginAuthenticator,
-    PluginCancelOperationRequest, PluginCredentialDetails, PluginGetAssertionRequest,
-    PluginLockStatus, PluginMakeCredentialRequest, PluginMakeCredentialResponse,
-    PluginUserVerificationRequest, PluginUserVerificationResponse, WebAuthnPlugin,
+    AuthenticatorState, Clsid, PluginAddAuthenticatorOptions, PluginAddAuthenticatorResponse,
+    PluginAuthenticator, PluginCancelOperationRequest, PluginCredentialDetails,
+    PluginGetAssertionRequest, PluginLockStatus, PluginMakeCredentialRequest,
+    PluginMakeCredentialResponse, PluginUserVerificationRequest, PluginUserVerificationResponse,
+    WebAuthnPlugin,
 };

--- a/apps/desktop/desktop_native/windows_plugin_authenticator/Cargo.toml
+++ b/apps/desktop/desktop_native/windows_plugin_authenticator/Cargo.toml
@@ -8,15 +8,12 @@ publish = { workspace = true }
 [target.'cfg(windows)'.dependencies]
 autofill_provider = { path = "../autofill_provider" }
 base64 = { workspace = true }
-serde = { workspace = true, features = ["derive"] }
-serde_json = { workspace = true }
+desktop_core = { path = "../core" }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 win_webauthn = { path = "../win_webauthn" }
 windows = { workspace = true, features = [
-    "ApplicationModel_PackageExtensions",
     "System",
-    "Storage_Search",
     "Win32_Foundation",
     "Win32_Security",
     "Win32_System_Com",

--- a/apps/desktop/desktop_native/windows_plugin_authenticator/src/lib.rs
+++ b/apps/desktop/desktop_native/windows_plugin_authenticator/src/lib.rs
@@ -1,20 +1,27 @@
 #![cfg(target_os = "windows")]
-use std::{collections::HashSet, io::Read, path::PathBuf};
+use std::collections::HashSet;
 
-use serde::Deserialize;
+use desktop_core::autofill::{read_plugin_config_file, read_plugin_logo};
 use win_webauthn::{
     plugin::{Clsid, PluginAddAuthenticatorOptions, WebAuthnPlugin},
     AuthenticatorInfo, CtapVersion, PublicKeyCredentialParameters,
 };
-use windows::ApplicationModel::Package;
 
 pub const AAGUID: &str = "d548826e-79b4-db40-a3d8-11116f7e8349";
 pub const RPID: &str = "bitwarden.com";
 
 pub fn register() -> Result<(), String> {
     tracing::debug!("register() called...");
-    let config = read_config_file()?;
-    let logo = read_logo()?;
+    let Some(config) = read_plugin_config_file()
+        .map_err(|err| format!("Could not read the plugin authenticator config file: {err:#}"))?
+    else {
+        tracing::debug!(
+            "Not running from an Appx package, so there is no plugin authenticator to register."
+        );
+        return Ok(());
+    };
+    let logo = read_plugin_logo()
+        .map_err(|err| format!("Could not read the plugin authenticator logo: {err:#}"))?;
 
     let aaguid = AAGUID
         .try_into()
@@ -57,89 +64,4 @@ pub fn register() -> Result<(), String> {
     }
     tracing::debug!("Added the authenticator: {response:?}");
     Ok(())
-}
-
-pub fn read_config_file() -> Result<ConfigFile, String> {
-    let config_path = get_resource_path("plugin_authenticator_config.json")
-        .map_err(|err| format!("Failed to find configuration file path: {err}"))?;
-
-    let config_file = std::fs::File::open(config_path)
-        .map_err(|err| format!("Could not open authenticator config file: {err}"))?;
-    let config = parse_config(config_file)?;
-    tracing::debug!("Found config file: {config:?}");
-    Ok(config)
-}
-
-fn get_resource_path(resource: &str) -> Result<PathBuf, windows::core::Error> {
-    let mut path = Package::Current()
-        .and_then(|package| package.InstalledLocation())
-        .and_then(|folder| folder.Path())
-        .map(|path| PathBuf::from(path.to_os_string()))?;
-    path.push("app\\resources");
-    path.push(resource);
-    Ok(path)
-}
-
-fn parse_config(reader: impl std::io::Read) -> Result<ConfigFile, String> {
-    serde_json::from_reader(reader)
-        .map_err(|err| format!("Could not read authenticator config file: {err}"))
-}
-
-fn read_logo() -> Result<String, String> {
-    let logo_path = get_resource_path("plugin_authenticator_logo.svg")
-        .map_err(|err| format!("Failed to find logo path: {err}"))?;
-
-    let mut logo = String::new();
-    std::fs::File::open(logo_path)
-        .map_err(|err| format!("Could not open authenticator logo file: {err}"))?
-        .read_to_string(&mut logo)
-        .map_err(|err| format!("Could not read logo file: {err}"))?;
-    Ok(logo)
-}
-
-#[derive(Debug, Deserialize)]
-pub struct ConfigFile {
-    pub clsid: String,
-    pub name: String,
-}
-
-#[cfg(test)]
-mod tests {
-    use super::parse_config;
-
-    #[test]
-    fn parse_config_succeeds_with_valid_json() {
-        let json = br#"{"clsid": "0f7dc5d9-69ce-4652-8572-6877fd695062", "name": "Bitwarden"}"#;
-        let config = parse_config(json.as_slice()).unwrap();
-        assert_eq!(config.clsid, "0f7dc5d9-69ce-4652-8572-6877fd695062");
-        assert_eq!(config.name, "Bitwarden");
-    }
-
-    #[test]
-    fn parse_config_fails_when_clsid_is_missing() {
-        let json = br#"{"name": "Bitwarden"}"#;
-        assert!(parse_config(json.as_slice()).is_err());
-    }
-
-    #[test]
-    fn parse_config_fails_when_name_is_missing() {
-        let json = br#"{"clsid": "0f7dc5d9-69ce-4652-8572-6877fd695062"}"#;
-        assert!(parse_config(json.as_slice()).is_err());
-    }
-
-    #[test]
-    fn parse_config_fails_on_malformed_json() {
-        let json = b"not json at all";
-        assert!(parse_config(json.as_slice()).is_err());
-    }
-
-    #[test]
-    fn parse_config_error_message_mentions_config_file() {
-        let json = b"{}";
-        let err = parse_config(json.as_slice()).unwrap_err();
-        assert!(
-            err.contains("authenticator config file"),
-            "error was: {err}"
-        );
-    }
 }

--- a/apps/desktop/desktop_native/windows_plugin_authenticator/src/main.rs
+++ b/apps/desktop/desktop_native/windows_plugin_authenticator/src/main.rs
@@ -17,6 +17,8 @@ mod util;
 use std::{mem::MaybeUninit, path::PathBuf};
 
 #[cfg(target_os = "windows")]
+use desktop_core::autofill::read_plugin_config_file;
+#[cfg(target_os = "windows")]
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 // Re-export main functionality
 #[cfg(target_os = "windows")]
@@ -105,7 +107,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             let thread_id = unsafe { GetCurrentThreadId() };
             tracing::info!(%thread_id, "Starting plugin authenticator...");
             let clsid = {
-                let com_id = windows_plugin_authenticator::read_config_file()?.clsid;
+                let com_id = read_plugin_config_file()?
+                    .ok_or("Plugin authenticator is not running from an Appx package")?
+                    .clsid;
                 Clsid::try_from(format!("{{{}}}", com_id).as_str()).map_err(|err| {
                     format!("Could not read plugin authenticator CLSID from config file: {err}")
                 })?


### PR DESCRIPTION
## 🎟️ Tracking

[PM-41025](https://bitwarden.atlassian.net/browse/PM-41025)

## 📔 Objective

This is the first half of enabling credential syncing to the Windows autofill store for passkey autofill and conditional mediation.

- Adds support to query plugin enabled/disabled state via webauthn.dll
- Moves functions to read Appx resources from windows_plugin_authenticator to `desktop_core::autofill`, since they are shared by both `desktop_core` and 
- Implements the native side of the status request from DesktopAutofillService, informing whether the credentials should sync or not

This is still behind a feature flag. If enabled, syncing will fail with an error, and passkey autofill will not be available, though if the RP uses a non-discoverable flow, this still works. The actual syncing will be done in a follow-up PR.

[PM-41025]: https://bitwarden.atlassian.net/browse/PM-41025?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ