### PR TITLE
build: Fix Windows cross-compiled builds

### DIFF
--- a/apps/desktop/desktop_native/build.js
+++ b/apps/desktop/desktop_native/build.js
@@ -119,7 +119,7 @@ function installTarget(target) {
     runCommand("rustup", ["target", "add", target]);
     // Install cargo-xwin for cross-platform builds targeting Windows
     if (target.includes('windows') && process.platform !== 'win32') {
-        runCommand("cargo", ["install", "--version", "0.20.2", "--locked", "cargo-xwin"]);
+        runCommand("cargo", ["install", "--version", "0.23.0", "--locked", "cargo-xwin"]);
         // install tools needed for packaging Appx, only supported on macOS for now.
         if (process.platform === "darwin") {
             runCommand("brew", ["install", "iinuwa/msix-packaging-tap/msix-packaging", "osslsigncode"]);
@@ -132,6 +132,14 @@ function effectivePlatform(target) {
         return rustTargetsMap[target].platform
     }
     return process.platform
+}
+
+// Commands spawned by `runCommand` inherit `process.env`, so variables set here are picked up by
+// every build tool we invoke, as well as the tools those spawn in turn (`napi` -> `cargo-xwin` -> `cargo`).
+if (effectivePlatform(target) === "win32" && process.platform !== "win32") {
+    // In order to compile the ring crate, we need to force cargo-xwin to use the clang
+    // compiler rather than clang-cl.
+    process.env["XWIN_CROSS_COMPILER"] = "clang";
 }
 
 if (!crossPlatform && !target) {

--- a/apps/desktop/scripts/appx-cross-build.ps1
+++ b/apps/desktop/scripts/appx-cross-build.ps1
@@ -94,7 +94,7 @@ if (!(Get-Command osslsigncode -ErrorAction SilentlyContinue)) {
 if (!(Get-Command cargo-xwin -ErrorAction SilentlyContinue)) {
     Write-Error "The `cargo-xwin` tool is required to cross-compile Windows native code."
     Write-Error "You can install with cargo:"
-    Write-Error "  cargo install --version 0.20.2 --locked cargo-xwin"
+    Write-Error "  cargo install --version 0.23.0 --locked cargo-xwin"
     Exit 1
 }
 


### PR DESCRIPTION
## 📔 Objective

We recently added the `ring` crate to our apps/desktop/desktop_native dependencies, which has a build.rs script that imposes special compiler requirements. In order to keep cross-compiling to Windows, we must:
- update cargo-xwin to 0.23.0, and
- set cargo-xwin cross-compiler to clang instead of clang-cl

We currently do not cross-compile to Windows in CI, so this should not affect any production builds, but it improves local developer workflows.