### PR TITLE
Add t:deps label for SDK update PRs automatically

### DIFF
--- a/.github/workflows/sdk-update.yml
+++ b/.github/workflows/sdk-update.yml
@@ -349,7 +349,7 @@ jobs:
             echo "## ✅ Updated PR: $PR_URL" >> "$GITHUB_STEP_SUMMARY"
           else
             echo "📝 Creating new PR..."
-            LABELS="automated pr"
+            LABELS="automated pr,t:deps"
 
             PR_URL=$(gh pr create \
               --title "$PR_TITLE" \


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-41116

## 📔 Objective

Adds `t:deps` label automatically when creating a PR for SDK updates in `clients`, so that the label requirement check doesn't fail and require manually adding the label on every PR.
