### PR TITLE
[PM-40107] Deprecate TS generator logic available in the SDK 

### DIFF
--- a/libs/tools/generator/core/src/engine/password-randomizer.ts
+++ b/libs/tools/generator/core/src/engine/password-randomizer.ts
@@ -16,7 +16,12 @@ import { Randomizer } from "./abstractions";
 import { Ascii } from "./data";
 import { CharacterSet, EffWordListRequest, RandomAsciiRequest } from "./types";
 
-/** Generation algorithms that produce randomized secrets */
+/**
+ * Generation algorithms that produce randomized secrets.
+ *
+ * @deprecated Legacy TS composition. Generate passwords and passphrases through the
+ * SDK-backed {@link CredentialGeneratorService.generate$} instead.
+ */
 export class PasswordRandomizer
   implements
     CredentialGenerator<PassphraseGenerationOptions>,

--- a/libs/tools/generator/core/src/strategies/passphrase-generator-strategy.ts
+++ b/libs/tools/generator/core/src/strategies/passphrase-generator-strategy.ts
@@ -13,7 +13,12 @@ import { observe$PerUserId, optionsToEffWordListRequest, sharedStateByUserId } f
 
 import { PASSPHRASE_SETTINGS } from "./storage";
 
-/** Generates passphrases composed of random words */
+/**
+ * Generates passphrases composed of random words.
+ *
+ * @deprecated Legacy TS strategy. Generate passphrases through the SDK-backed
+ * {@link CredentialGeneratorService.generate$} instead.
+ */
 export class PassphraseGeneratorStrategy implements GeneratorStrategy<
   PassphraseGenerationOptions,
   PassphraseGeneratorPolicy

--- a/libs/tools/generator/core/src/strategies/password-generator-strategy.ts
+++ b/libs/tools/generator/core/src/strategies/password-generator-strategy.ts
@@ -11,7 +11,12 @@ import { observe$PerUserId, optionsToRandomAsciiRequest, sharedStateByUserId } f
 
 import { PASSWORD_SETTINGS } from "./storage";
 
-/** Generates passwords composed of random characters */
+/**
+ * Generates passwords composed of random characters.
+ *
+ * @deprecated Legacy TS strategy. Generate passwords through the SDK-backed
+ * {@link CredentialGeneratorService.generate$} instead.
+ */
 export class PasswordGeneratorStrategy implements GeneratorStrategy<
   PasswordGenerationOptions,
   PasswordGeneratorPolicy


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-40107

## 📔 Objective

Our SDK exposes generator capability with near full-parity with respect to the legacy TS implementation. This PR deprecates TS implementations of generator logic that should instead use the SDK implementation. 
