### PR TITLE
feat(vault): plumb the PAM partialData gating marker through the cipher model

### DIFF
--- a/libs/common/src/vault/models/data/cipher.data.ts
+++ b/libs/common/src/vault/models/data/cipher.data.ts
@@ -48,6 +48,12 @@ export class CipherData {
   reprompt: CipherRepromptType = CipherRepromptType.None;
   key?: string;
   data?: string;
+  /**
+   * Raw JSON-string partial-data payload for PAM-gated rows. See {@link CipherResponse.partialData}.
+   * Widened to allow `null` so a `CipherResponse` (whose `partialData` is `string | null`)
+   * stays structurally assignable to `CipherData`.
+   */
+  partialData?: string | null;
 
   constructor(response?: CipherResponse, collectionIds?: string[]) {
     if (response == null) {
@@ -74,6 +80,7 @@ export class CipherData {
     this.reprompt = response.reprompt;
     this.key = response.key;
     this.data = response.data;
+    this.partialData = response.partialData ?? undefined;
 
     switch (this.type) {
       case CipherType.Login:

--- a/libs/common/src/vault/models/domain/cipher-sdk-mapper.ts
+++ b/libs/common/src/vault/models/domain/cipher-sdk-mapper.ts
@@ -20,4 +20,14 @@ export class CipherRecordMapper implements SdkRecordMapper<CipherData, SdkCipher
     const cipher = Cipher.fromSdkCipher(value);
     return cipher!.toCipherData();
   }
+
+  /**
+   * Excludes PAM gated rows from the SDK-visible state. The SDK has no partial-data
+   * decrypt path and rejects sparsely-populated ciphers with a serde
+   * "invalid type: unit value" error, so we hide them entirely. They still live in
+   * client state, where the cipher service and the vault-row badge can see them.
+   */
+  shouldInclude(value: CipherData): boolean {
+    return value.partialData == null;
+  }
 }

--- a/libs/common/src/vault/models/domain/cipher.ts
+++ b/libs/common/src/vault/models/domain/cipher.ts
@@ -70,6 +70,16 @@ export class Cipher extends Domain implements Decryptable<CipherView> {
   reprompt: CipherRepromptType = CipherRepromptType.None;
   key?: EncString;
   data?: string;
+  /** Raw JSON-string partial-data payload for PAM-gated rows; see {@link CipherData.partialData}. */
+  partialData?: string;
+  /**
+   * Client-only, transient marker stamped on a full cipher served under an active PAM
+   * lease. Unlike {@link partialData} it is never sent by the server, persisted to
+   * `CipherData`, or round-tripped through JSON — it exists only so gating surfaces can
+   * tell a leased cipher is PAM-governed once it is fully decrypted and `partialData`
+   * is gone.
+   */
+  leaseGated?: boolean;
 
   constructor(obj?: CipherData, localData?: LocalData) {
     super();
@@ -98,6 +108,7 @@ export class Cipher extends Domain implements Decryptable<CipherView> {
     this.reprompt = obj.reprompt;
     this.key = conditionalEncString(obj.key);
     this.data = obj.data;
+    this.partialData = obj.partialData ?? undefined;
 
     switch (this.type) {
       case CipherType.Login:
@@ -300,6 +311,8 @@ export class Cipher extends Domain implements Decryptable<CipherView> {
     }
 
     c.archivedDate = this.archivedDate != null ? this.archivedDate.toISOString() : undefined;
+    // `leaseGated` is deliberately not persisted — it is transient, per-view state.
+    c.partialData = this.partialData;
 
     this.buildDataModel(this, c, {
       name: null,
@@ -382,6 +395,9 @@ export class Cipher extends Domain implements Decryptable<CipherView> {
     if (obj.permissions != null) {
       domain.permissions = new CipherPermissionsApi(obj.permissions);
     }
+
+    // `leaseGated` is deliberately absent — it must not survive serialization.
+    domain.partialData = obj.partialData ?? undefined;
 
     domain.collectionIds = obj.collectionIds;
     domain.localData = obj.localData;

--- a/libs/common/src/vault/models/response/cipher.response.spec.ts
+++ b/libs/common/src/vault/models/response/cipher.response.spec.ts
@@ -1,0 +1,120 @@
+import { CipherType } from "../../enums";
+
+import { CipherResponse } from "./cipher.response";
+
+// Encrypted (EncString) placeholders — the decrypt path runs later; here we only
+// assert that the gated blob's encrypted fields are lifted onto the response.
+const ENC_NAME = "2.name==|name==|name==";
+const ENC_URI = "2.uri==|uri==|uri==";
+const ENC_CHECKSUM = "2.sum==|sum==|sum==";
+const ENC_PASSWORD = "2.pass==|pass==|pass==";
+
+function gatedResponse(partial: Record<string, unknown>, type: CipherType = CipherType.Login) {
+  return new CipherResponse({
+    Id: "cipher-1",
+    Type: type,
+    // Sensitive top-level fields are absent on a gated row; the server ships them
+    // (encrypted, partially) inside PartialData instead.
+    PartialData: JSON.stringify(partial),
+  });
+}
+
+describe("CipherResponse PAM partial data", () => {
+  it("lifts the encrypted Name onto the response so the standard decrypt path runs", () => {
+    const response = gatedResponse({ Name: ENC_NAME, Uris: [] });
+
+    expect(response.name).toBe(ENC_NAME);
+    expect(response.partialData).toContain(ENC_NAME);
+  });
+
+  it("lifts gated login URIs so the partial view exposes a domain", () => {
+    const response = gatedResponse({
+      Name: ENC_NAME,
+      Uris: [{ Uri: ENC_URI, UriChecksum: ENC_CHECKSUM }],
+    });
+
+    expect(response.login).not.toBeNull();
+    expect(response.login.uris).toHaveLength(1);
+    expect(response.login.uris[0].uri).toBe(ENC_URI);
+  });
+
+  it("does not lift any secret login fields the gated view should never carry", () => {
+    // Even if a blob were to over-share, only URIs are lifted onto the gated view.
+    const response = gatedResponse({
+      Name: ENC_NAME,
+      Uris: [{ Uri: ENC_URI }],
+      Password: ENC_PASSWORD,
+      Totp: ENC_PASSWORD,
+    });
+
+    expect(response.login.uris[0].uri).toBe(ENC_URI);
+    expect(response.login.password).toBeUndefined();
+    expect(response.login.totp).toBeUndefined();
+  });
+
+  it("leaves login unset when the gated cipher has no URIs", () => {
+    const response = gatedResponse({ Name: ENC_NAME, Uris: [] });
+
+    // No URIs in the blob → nothing to surface → keep the minimal gated shape so
+    // the icon falls back to the generic glyph rather than a favicon.
+    expect(response.login).toBeUndefined();
+  });
+
+  it("does not build a login for a non-Login gated cipher", () => {
+    const response = gatedResponse(
+      { Name: ENC_NAME, Uris: [{ Uri: ENC_URI }] },
+      CipherType.SecureNote,
+    );
+
+    expect(response.login).toBeUndefined();
+  });
+
+  it("prefers a real top-level Name over the blob's", () => {
+    const response = new CipherResponse({
+      Id: "cipher-1",
+      Type: CipherType.Login,
+      Name: ENC_NAME,
+      PartialData: JSON.stringify({ Name: "2.other==|other==|other==" }),
+    });
+
+    expect(response.name).toBe(ENC_NAME);
+  });
+
+  it("accepts an already-parsed PartialData object and normalizes it to a string", () => {
+    // Some transports hand back parsed JSON rather than a string.
+    const response = new CipherResponse({
+      Id: "cipher-1",
+      Type: CipherType.Login,
+      PartialData: { Name: ENC_NAME, Uris: [{ Uri: ENC_URI }] },
+    });
+
+    expect(typeof response.partialData).toBe("string");
+    expect(response.name).toBe(ENC_NAME);
+    expect(response.login.uris[0].uri).toBe(ENC_URI);
+  });
+
+  it("preserves the gating marker when the blob is malformed", () => {
+    const response = new CipherResponse({
+      Id: "cipher-1",
+      Type: CipherType.Login,
+      PartialData: "{not json",
+    });
+
+    // Failing to parse must not un-gate the row: the marker survives even though
+    // there is no name to show.
+    expect(response.partialData).toBe("{not json");
+    expect(response.name).toBeUndefined();
+    expect(response.login).toBeUndefined();
+  });
+
+  it("leaves partialData null for a normal, non-gated cipher", () => {
+    const response = new CipherResponse({
+      Id: "cipher-1",
+      Type: CipherType.Login,
+      Name: ENC_NAME,
+      Data: "{}",
+    });
+
+    expect(response.partialData).toBeNull();
+  });
+});

--- a/libs/common/src/vault/models/response/cipher.response.ts
+++ b/libs/common/src/vault/models/response/cipher.response.ts
@@ -53,6 +53,14 @@ export class CipherResponse extends BaseResponse {
   reprompt: CipherRepromptType;
   key: string;
   data?: string;
+  /**
+   * Raw JSON-string payload the server returns on PAM-gated rows in place of the
+   * sensitive fields: the encrypted name and, for logins, the encrypted URIs.
+   * Its presence is the "this row is gated" marker used by the vault-row badge
+   * and the cipher-open gate. Distinct from {@link data}, which carries the full
+   * (blob-encrypted) payload for ciphers the caller may open.
+   */
+  partialData: string | null = null;
 
   constructor(response: any) {
     super(response);
@@ -135,5 +143,32 @@ export class CipherResponse extends BaseResponse {
     this.reprompt = this.getResponseProperty("Reprompt") || CipherRepromptType.None;
     this.key = this.getResponseProperty("Key") || null;
     this.data = this.getResponseProperty("Data");
+
+    // PAM gated rows ship a `partialData` JSON blob in place of the sensitive fields.
+    // Keep the raw string as the gating marker, and lift the encrypted `Name` from the
+    // blob into the top-level `name` so the standard cipher decrypt path can decrypt it
+    // like any other cipher name.
+    const partialData = this.getResponseProperty("PartialData");
+    if (partialData != null) {
+      this.partialData =
+        typeof partialData === "string" ? partialData : JSON.stringify(partialData);
+      try {
+        const parsed = JSON.parse(this.partialData);
+        if (parsed?.Name != null && this.name == null) {
+          this.name = parsed.Name;
+        }
+        // Likewise lift the encrypted login URIs so the partial view exposes a domain
+        // (favicon, launch). Only `Uris` ships in the blob — the secret login fields
+        // (password, TOTP, …) stay gated — so the decrypted partial view gains a domain
+        // but no credentials. Build the login from `Uris` alone so an expanded blob can
+        // never leak more onto the gated view.
+        if (this.type === CipherType.Login && this.login == null && parsed?.Uris?.length > 0) {
+          this.login = new LoginApi({ Uris: parsed.Uris });
+        }
+      } catch {
+        // Malformed blob — leave name as-is. The cipher renders with an empty name, but
+        // the gating signal (partialData) is still preserved, so it stays gated.
+      }
+    }
   }
 }

--- a/libs/common/src/vault/models/view/cipher.view.ts
+++ b/libs/common/src/vault/models/view/cipher.view.ts
@@ -70,6 +70,22 @@ export class CipherView implements View, InitializerMetadata {
   key?: EncString;
 
   /**
+   * Raw JSON-string partial-data payload (PAM gated rows). Its presence is the gating
+   * marker for UI surfaces. The SDK round trip drops this field, so the encryption
+   * service re-attaches it onto the resulting view from the source Cipher.
+   */
+  partialData?: string;
+
+  /**
+   * Client-only, transient companion to {@link partialData}: set when this view came from
+   * a cipher served under an active PAM lease (full data, so `partialData` is absent).
+   * The SDK round trip drops it, so the encryption service re-attaches it from the source
+   * Cipher. Lets gating surfaces keep rendering lease state once a lease lands and
+   * `partialData` is gone.
+   */
+  leaseGated?: boolean;
+
+  /**
    * Flag to indicate if the cipher decryption failed.
    */
   decryptionFailure = false;
@@ -98,6 +114,8 @@ export class CipherView implements View, InitializerMetadata {
     // Old locally stored ciphers might have reprompt == null. If so set it to None.
     this.reprompt = c.reprompt ?? CipherRepromptType.None;
     this.key = c.key;
+    this.partialData = c.partialData;
+    this.leaseGated = c.leaseGated;
   }
 
   private get item(): ItemView | undefined {
@@ -237,6 +255,10 @@ export class CipherView implements View, InitializerMetadata {
     view.organizationUseTotp = obj.organizationUseTotp ?? false;
     view.localData = obj.localData ? obj.localData : undefined;
     view.permissions = obj.permissions ? CipherPermissionsApi.fromJSON(obj.permissions) : undefined;
+    // `leaseGated` is deliberately absent — it must not survive serialization.
+    if (obj.partialData != null) {
+      view.partialData = obj.partialData;
+    }
     view.reprompt = obj.reprompt ?? CipherRepromptType.None;
     view.decryptionFailure = obj.decryptionFailure ?? false;
     if (obj.creationDate) {

--- a/libs/common/src/vault/services/default-cipher-encryption.service.spec.ts
+++ b/libs/common/src/vault/services/default-cipher-encryption.service.spec.ts
@@ -540,6 +540,22 @@ describe("DefaultCipherEncryptionService", () => {
       );
       expect(Fido2CredentialView.fromSdkFido2CredentialView).toHaveBeenCalledTimes(1);
     });
+
+    it("re-attaches the client-only PAM markers the SDK round trip drops", async () => {
+      cipherObj.partialData = '{"Name":"enc-name"}';
+      cipherObj.leaseGated = true;
+
+      mockSdkClient.vault().ciphers().decrypt.mockReturnValue(sdkCipherView);
+      jest.spyOn(CipherView, "fromSdkCipherView").mockReturnValue({
+        id: cipherId as string,
+        type: CipherType.Login,
+      } as CipherView);
+
+      const result = await cipherEncryptionService.decrypt(cipherObj, userId);
+
+      expect(result.partialData).toBe('{"Name":"enc-name"}');
+      expect(result.leaseGated).toBe(true);
+    });
   });
 
   describe("decryptManyLegacy", () => {
@@ -580,6 +596,28 @@ describe("DefaultCipherEncryptionService", () => {
       expect(failedDecryptions).toEqual([]);
       expect(mockSdkClient.vault().ciphers().decrypt).toHaveBeenCalledTimes(2);
       expect(CipherView.fromSdkCipherView).toHaveBeenCalledTimes(2);
+    });
+
+    it("re-attaches the client-only PAM markers the SDK round trip drops", async () => {
+      const gated = new Cipher(cipherData);
+      gated.partialData = '{"Name":"enc-name"}';
+      gated.leaseGated = true;
+
+      mockSdkClient
+        .vault()
+        .ciphers()
+        .decrypt.mockReturnValue({ id: cipherId } as unknown as SdkCipherView);
+      jest
+        .spyOn(CipherView, "fromSdkCipherView")
+        .mockReturnValue({ id: cipherId as string } as CipherView);
+
+      const [successfulDecryptions] = await cipherEncryptionService.decryptManyLegacy(
+        [gated],
+        userId,
+      );
+
+      expect(successfulDecryptions[0].partialData).toBe('{"Name":"enc-name"}');
+      expect(successfulDecryptions[0].leaseGated).toBe(true);
     });
   });
 

--- a/libs/common/src/vault/services/default-cipher-encryption.service.ts
+++ b/libs/common/src/vault/services/default-cipher-encryption.service.ts
@@ -142,6 +142,11 @@ export class DefaultCipherEncryptionService implements CipherEncryptionService {
 
           const clientCipherView = CipherView.fromSdkCipherView(sdkCipherView)!;
 
+          // The SDK round trip drops the client-only PAM markers; re-attach them from the
+          // source cipher so gating surfaces still see them on the decrypted view.
+          clientCipherView.partialData = cipher.partialData;
+          clientCipherView.leaseGated = cipher.leaseGated;
+
           // Decrypt Fido2 credentials if available
           if (
             clientCipherView.type === CipherType.Login &&
@@ -191,6 +196,11 @@ export class DefaultCipherEncryptionService implements CipherEncryptionService {
             try {
               const sdkCipherView = await ref.value.vault().ciphers().decrypt(cipher.toSdkCipher());
               const clientCipherView = CipherView.fromSdkCipherView(sdkCipherView)!;
+
+              // Re-attach the client-only PAM markers dropped by the SDK round trip;
+              // see CipherView.partialData.
+              clientCipherView.partialData = cipher.partialData;
+              clientCipherView.leaseGated = cipher.leaseGated;
 
               // Handle FIDO2 credentials if present
               if (


### PR DESCRIPTION
## 🎟️ Tracking

PAM cipher gating, 2/4. Stacked on #22168 (needs its `shouldInclude` hook).
Server side: bitwarden/server#8114 (field) and #8115 (behavior).

## 📔 Objective

The server withholds a PAM-gated cipher's sensitive fields and returns a reduced blob
instead — the encrypted name plus, for logins, the encrypted URIs. This carries that blob
from the wire down to `CipherView`, where UI surfaces can use its presence as the "this row
is gated" signal.

- **`CipherResponse`** reads `PartialData` (accepting a string or an already-parsed object)
  and lifts the encrypted `Name` onto `name` so the normal decrypt path handles it. For
  logins it also lifts `Uris`, building the login from **`Uris` alone** — a deliberate
  allowlist, so an over-sharing blob can never leak a password or TOTP onto a gated view.
  A malformed blob keeps the marker and drops the name: failing to parse must not un-gate
  the row.
- The marker is carried through `CipherData` → `Cipher` → `CipherView`.
- **`CipherRecordMapper.shouldInclude`** hides gated rows from the SDK (no partial-data
  decrypt path; it rejects sparse ciphers). They stay in client state.
- **`DefaultCipherEncryptionService`** re-attaches the marker after the SDK round trip
  drops it, on both the single and bulk decrypt paths.

### Note for reviewers

This is **additive to the existing `data` field**, which carries the full blob-encrypted
payload (PM-32696). The two are unrelated and both are kept.

Also adds `leaseGated`, the transient companion marker for a cipher served under active
access. It is deliberately never persisted to `CipherData` nor serialized in `fromJSON`,
and has **no producer yet** — declared here because the cipher-view banner seam (#22171)
forwards it.

## Verification

`npm test -- libs/common/src/vault libs/common/src/platform/services/sdk` — 784 passed
across 47 suites. `npm run test:types` clean.

New `cipher.response.spec.ts` covers the name/URI lift, that no secret login field is ever
lifted, the malformed-blob and already-parsed-object paths, and that a real top-level `Name`
wins over the blob's.

## 🚨 Breaking Changes

None — purely additive. With no server sending `PartialData`, `partialData` is always
absent and every path behaves exactly as before.