### PR TITLE
feat(vault): decrypt PAM gated rows outside the SDK

### DIFF
--- a/libs/common/src/vault/services/cipher.service.spec.ts
+++ b/libs/common/src/vault/services/cipher.service.spec.ts
@@ -996,6 +996,98 @@ describe("Cipher Service", () => {
     });
   });
 
+  describe("decryptCiphers with PAM gated rows", () => {
+    const gated_id = "33333333-3333-3333-3333-333333333333";
+    const normal_id = "44444444-4444-4444-4444-444444444444";
+    let gatedCipher: Cipher;
+    let normalCipher: Cipher;
+
+    beforeEach(() => {
+      const keys = {
+        userKey: new SymmetricCryptoKey(new Uint8Array(32)) as UserKey,
+        orgKeys: { [orgId]: new SymmetricCryptoKey(new Uint8Array(32)) as OrgKey },
+      } as CipherDecryptionKeys;
+      keyService.cipherDecryptionKeys$.mockReturnValue(of(keys));
+
+      gatedCipher = new Cipher({ ...cipherData, id: gated_id, organizationId: orgId });
+      gatedCipher.partialData = '{"Name":"enc-name"}';
+
+      normalCipher = new Cipher({ ...cipherData, id: normal_id, organizationId: orgId });
+
+      jest.spyOn(gatedCipher, "decrypt").mockResolvedValue({
+        id: gated_id,
+        name: "Gated item",
+        partialData: gatedCipher.partialData,
+      } as CipherView);
+    });
+
+    it("keeps gated ciphers out of the SDK and merges them into the results", async () => {
+      cipherEncryptionService.decryptManyLegacy.mockResolvedValue([
+        [{ id: normal_id, name: "Normal item" } as CipherView],
+        [],
+      ]);
+
+      const [successes] = await (cipherService as any).decryptCiphers(
+        [gatedCipher, normalCipher],
+        userId,
+      );
+
+      // The SDK has no partial-data decrypt path, so it must only see the normal cipher.
+      expect(cipherEncryptionService.decryptManyLegacy).toHaveBeenCalledWith(
+        [normalCipher],
+        userId,
+      );
+      expect(gatedCipher.decrypt).toHaveBeenCalledTimes(1);
+      expect(successes.map((c: CipherView) => c.name)).toEqual(["Gated item", "Normal item"]);
+    });
+
+    it("keeps gated ciphers out of the lightweight SDK path too", async () => {
+      cipherEncryptionService.decryptManyWithFailures.mockResolvedValue([
+        [{ id: normal_id, name: "Normal item" } as unknown as CipherListView],
+        [],
+      ]);
+
+      const [successes] = await (cipherService as any).decryptCiphersWithSdk(
+        [gatedCipher, normalCipher],
+        userId,
+        false,
+      );
+
+      expect(cipherEncryptionService.decryptManyWithFailures).toHaveBeenCalledWith(
+        [normalCipher],
+        userId,
+      );
+      expect(successes).toHaveLength(2);
+    });
+
+    it("renders a gated row with an empty name when no key is available for its scope", async () => {
+      const unknownOrgCipher = new Cipher({
+        ...cipherData,
+        id: gated_id,
+        organizationId: "99999999-9999-9999-9999-999999999999",
+      });
+      unknownOrgCipher.partialData = '{"Name":"enc-name"}';
+      const decryptSpy = jest.spyOn(unknownOrgCipher, "decrypt");
+      cipherEncryptionService.decryptManyLegacy.mockResolvedValue([[], []]);
+
+      const [successes] = await (cipherService as any).decryptCiphers([unknownOrgCipher], userId);
+
+      // Dropping the row would silently hide a vault item; show it nameless instead.
+      expect(decryptSpy).not.toHaveBeenCalled();
+      expect(successes).toHaveLength(1);
+      expect(successes[0].name).toBe("");
+      expect(successes[0].partialData).toBe('{"Name":"enc-name"}');
+    });
+
+    it("does not fetch decryption keys when there are no gated ciphers", async () => {
+      cipherEncryptionService.decryptManyLegacy.mockResolvedValue([[], []]);
+
+      await (cipherService as any).decryptCiphers([normalCipher], userId);
+
+      expect(keyService.cipherDecryptionKeys$).not.toHaveBeenCalled();
+    });
+  });
+
   describe("softDelete", () => {
     it("clears archivedDate when soft deleting", async () => {
       const cipherId = "cipher-id-1" as CipherId;

--- a/libs/common/src/vault/services/cipher.service.ts
+++ b/libs/common/src/vault/services/cipher.service.ts
@@ -2164,16 +2164,25 @@ export class CipherService implements CipherServiceAbstraction {
       return [[], []];
     }
 
+    // PAM gated rows can't go through the SDK (no partial-data decrypt path), so decrypt
+    // them separately and merge the results back in, keeping them in the vault list.
+    const partialCiphers = ciphers.filter((c) => c.partialData != null);
+    const decryptableCiphers = ciphers.filter((c) => c.partialData == null);
+    const partialViews = await this.decryptPartialCiphers(partialCiphers, userId);
+
     if (fullDecryption) {
       const [decryptedViews, failedViews] = await this.cipherEncryptionService.decryptManyLegacy(
-        ciphers,
+        decryptableCiphers,
         userId,
       );
-      return [decryptedViews.sort(this.getLocaleSortingFunction()), failedViews];
+      return [
+        [...partialViews, ...decryptedViews].sort(this.getLocaleSortingFunction()),
+        failedViews,
+      ];
     }
 
     const [decrypted, failures] = await this.cipherEncryptionService.decryptManyWithFailures(
-      ciphers,
+      decryptableCiphers,
       userId,
     );
 
@@ -2184,7 +2193,48 @@ export class CipherService implements CipherServiceAbstraction {
       return cipher_view;
     });
 
-    return [decrypted.sort(this.getLocaleSortingFunction()), failedViews];
+    return [[...partialViews, ...decrypted].sort(this.getLocaleSortingFunction()), failedViews];
+  }
+
+  /**
+   * Decrypt PAM gated rows. The encrypted name has been lifted out of `partialData` onto
+   * `cipher.name` by {@link CipherResponse}, so the standard decrypt path handles it; every
+   * other field on a gated cipher is null, so the type-specific branches short-circuit and
+   * the view ends up with just a decrypted name (plus login URIs, for logins) and the
+   * `partialData` marker that keeps it gated.
+   *
+   * This is the one caller that still needs the deprecated {@link Cipher.decrypt}. That
+   * deprecation is about blob encryption, and a gated cipher never carries a blob — the
+   * server only strips ciphers whose data is not blob-encrypted. Going through the SDK
+   * instead is what fails here, and decrypting the fields by hand would mean duplicating
+   * the login-URI checksum validation, which is not worth reimplementing.
+   */
+  private async decryptPartialCiphers(ciphers: Cipher[], userId: UserId): Promise<CipherView[]> {
+    if (ciphers.length === 0) {
+      return [];
+    }
+
+    const keys = await firstValueFrom(
+      this.keyService.cipherDecryptionKeys$(userId, true).pipe(filterOutNullish()),
+    );
+
+    return Promise.all(
+      ciphers.map(async (cipher) => {
+        const key = cipher.organizationId
+          ? keys.orgKeys?.[cipher.organizationId as OrganizationId]
+          : keys.userKey;
+
+        if (key == null) {
+          // No key for this cipher's scope. Render the row with an empty name rather than
+          // dropping it — the gating marker is preserved either way.
+          const view = new CipherView(cipher);
+          view.name = "";
+          return view;
+        }
+
+        return cipher.decrypt(key);
+      }),
+    );
   }
 
   /** Fetches the full `CipherView` when a `CipherListView` is passed. */


### PR DESCRIPTION
## 🎟️ Tracking

PAM cipher gating, 3/4. Stacked on #22169.

## 📔 Objective

`decryptCiphersWithSdk` now partitions gated rows out before calling the SDK and merges the
results back in, so gated ciphers still appear in the vault list. Without this they would
**vanish**: the SDK has no partial-data decrypt path and rejects sparsely-populated ciphers.

The encrypted name has already been lifted out of the partial blob onto `cipher.name`
(#22169), so the standard decrypt path handles it; every other field is null, so the
type-specific branches short-circuit and the view ends up with a decrypted name (plus login
URIs) and nothing else.

When no key is available for the cipher's scope the row renders with an **empty name rather
than being dropped** — silently hiding a vault item is worse than showing it nameless.

## ⚠️ Reviewer note: this uses a deprecated API

This becomes the only caller of `Cipher.decrypt`, which `main` marks
`@deprecated … will be removed in a near release`. I'd like a second opinion, but the case
for it:

- The deprecation is about **blob encryption**, and a gated cipher never carries a blob —
  the server only strips ciphers whose data is *not* blob-encrypted.
- Going through the SDK is precisely what fails here.
- Hand-decrypting the fields would mean duplicating the **login-URI checksum validation**,
  which guards against a compromised server tampering with URIs. Reimplementing that
  security-sensitive logic seemed clearly worse than using the deprecated path.

If `Cipher.decrypt` is removed before the real gate ships, this needs a replacement — most
likely an SDK-side partial-decrypt path, which would also let #22169 drop its
`shouldInclude` filter.

## Verification

`npm test -- libs/common/src/vault` — 731 passed. `npm run test:types` clean.

This path had **no test coverage in the reference implementation**; added tests for
partitioning on both the full and lightweight paths, the merge, the missing-key fallback,
and that no key fetch happens when nothing is gated.

## 🚨 Breaking Changes

None — with no gated ciphers present, the partition is empty and behavior is unchanged.