### PR TITLE
mock missing observables to suppress console errors

### DIFF
--- a/apps/browser/src/tools/popup/send-v2/send-v2.component.spec.ts
+++ b/apps/browser/src/tools/popup/send-v2/send-v2.component.spec.ts
@@ -9,6 +9,7 @@ import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { AuthService } from "@bitwarden/common/auth/abstractions/auth.service";
 import { AvatarService } from "@bitwarden/common/auth/abstractions/avatar.service";
+import { AuthenticationStatus } from "@bitwarden/common/auth/enums/authentication-status";
 import { BillingAccountProfileStateService } from "@bitwarden/common/billing/abstractions";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { EnvironmentService } from "@bitwarden/common/platform/abstractions/environment.service";
@@ -100,8 +101,16 @@ describe("SendV2Component", () => {
             }),
           },
         },
-        { provide: AuthService, useValue: mock<AuthService>() },
-        { provide: AvatarService, useValue: mock<AvatarService>() },
+        {
+          provide: AuthService,
+          useValue: mock<AuthService>({
+            activeAccountStatus$: of(AuthenticationStatus.Unlocked),
+          }),
+        },
+        {
+          provide: AvatarService,
+          useValue: mock<AvatarService>({ avatarColor$: of(null) }),
+        },
         {
           provide: BillingAccountProfileStateService,
           useValue: { hasPremiumFromAnySource$: of(false) },


### PR DESCRIPTION
## 🎟️ Tracking

N/A - unit test fixes

## 📔 Objective

Fix noisy console errors.

## 🫚 Root cause

The console error isn't from `SendV2Component` itself — it surfaces through a child component.

`CurrentAccountComponent`'s constructor builds a `combineLatest` over three streams:

```ts
combineLatest([
  this.accountService.activeAccount$,   // provided as of({...}) ✓
  this.avatarService.avatarColor$,      // ✗ bare mock → jest fn
  this.authService.activeAccountStatus$, // ✗ bare mock → jest fn
])
```

In the spec, `AuthService` and `AvatarService` were provided as bare `mock<AuthService>()` / `mock<AvatarService>()`. `jest-mock-extended` stubs every property — including observable-typed ones — as jest mock functions. So `combineLatest` received `function () { return fn.apply(this, arguments); }` where it expected a stream, and threw a `createInvalidObservableTypeError`.
