### PR TITLE
desktop-autofill: Prepare native OS user verification [PM-29791]

### DIFF
--- a/apps/desktop/desktop_native/Cargo.lock
+++ b/apps/desktop/desktop_native/Cargo.lock
@@ -6287,7 +6287,6 @@ name = "windows_plugin_authenticator"
 version = "0.0.0"
 dependencies = [
  "autofill_provider",
- "base64",
  "desktop_core",
  "tracing",
  "tracing-subscriber",

--- a/apps/desktop/desktop_native/core/src/autofill/windows/context.rs
+++ b/apps/desktop/desktop_native/core/src/autofill/windows/context.rs
@@ -1,0 +1,94 @@
+//! Encoding for the transaction context that ties a follow-up call, such as a
+//! user verification prompt, back to the WebAuthn operation that triggered it.
+//!
+//! The context leaves this process as an opaque base64 string and comes back
+//! later, so the encoding and decoding halves live together to stop them
+//! drifting apart.
+
+use anyhow::{anyhow, Context as _, Result};
+use base64::engine::{general_purpose::STANDARD, Engine as _};
+use windows::core::GUID;
+
+/// Length of the transaction ID prefix of a context string, in bytes.
+const TRANSACTION_ID_LEN: usize = size_of::<u128>();
+
+/// Encodes a transaction ID and the hash of its originating operation request
+/// into an opaque context string.
+pub fn create_context_string(transaction_id: GUID, request_hash: &[u8]) -> String {
+    let context = &[&transaction_id.to_u128().to_le_bytes(), request_hash].concat();
+    STANDARD.encode(context)
+}
+
+/// Decodes a context string produced by [`create_context_string`] back into its
+/// transaction ID and operation request hash.
+pub fn parse_context_string(context: &str) -> Result<(GUID, Vec<u8>)> {
+    let decoded = STANDARD
+        .decode(context)
+        .context("Context string is not valid base64")?;
+
+    if decoded.len() < TRANSACTION_ID_LEN {
+        return Err(anyhow!(
+            "Context string is too short: expected at least {TRANSACTION_ID_LEN} bytes, got {}",
+            decoded.len()
+        ));
+    }
+
+    let (transaction_id, request_hash) = decoded.split_at(TRANSACTION_ID_LEN);
+    // `split_at` guarantees the length, so this conversion cannot fail.
+    let transaction_id: [u8; TRANSACTION_ID_LEN] = transaction_id
+        .try_into()
+        .expect("transaction ID slice is TRANSACTION_ID_LEN bytes");
+
+    Ok((
+        GUID::from_u128(u128::from_le_bytes(transaction_id)),
+        request_hash.to_vec(),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use base64::engine::{general_purpose::STANDARD, Engine as _};
+    use windows::core::GUID;
+
+    use super::{create_context_string, parse_context_string};
+
+    const TRANSACTION_ID: GUID = GUID {
+        data1: 1,
+        data2: 2,
+        data3: 3,
+        data4: [4; 8],
+    };
+
+    #[test]
+    fn context_string_round_trips() {
+        let hash = b"abcd";
+
+        let context = create_context_string(TRANSACTION_ID, hash);
+        let (transaction_id, parsed_hash) = parse_context_string(&context).unwrap();
+
+        assert_eq!(TRANSACTION_ID, transaction_id);
+        assert_eq!(hash, parsed_hash.as_slice());
+    }
+
+    #[test]
+    fn context_string_round_trips_without_a_hash() {
+        let context = create_context_string(TRANSACTION_ID, &[]);
+        let (transaction_id, parsed_hash) = parse_context_string(&context).unwrap();
+
+        assert_eq!(TRANSACTION_ID, transaction_id);
+        assert!(parsed_hash.is_empty());
+    }
+
+    #[test]
+    fn parsing_a_context_string_that_is_not_base64_fails() {
+        assert!(parse_context_string("not base64!").is_err());
+    }
+
+    #[test]
+    fn parsing_a_context_string_shorter_than_the_transaction_id_fails() {
+        // Valid base64, but only eight bytes of a sixteen byte transaction ID.
+        let truncated = STANDARD.encode([0u8; 8]);
+
+        assert!(parse_context_string(&truncated).is_err());
+    }
+}

--- a/apps/desktop/desktop_native/core/src/autofill/windows/mod.rs
+++ b/apps/desktop/desktop_native/core/src/autofill/windows/mod.rs
@@ -1,9 +1,11 @@
+mod context;
 mod status;
 mod sync;
 
 use std::{fs::File, io::Read, path::PathBuf, sync::OnceLock};
 
 use anyhow::{anyhow, Context, Result};
+pub use context::{create_context_string, parse_context_string};
 use serde::{Deserialize, Serialize};
 use status::{handle_status_request, StatusResponse};
 use sync::{handle_sync_request, SyncParameters, SyncResponse};

--- a/apps/desktop/desktop_native/win_webauthn/src/api/plugin/types/user_verification.rs
+++ b/apps/desktop/desktop_native/win_webauthn/src/api/plugin/types/user_verification.rs
@@ -113,7 +113,7 @@ pub(crate) fn perform_user_verification(
             Ok(signature)
         }
         NTE_USER_CANCELLED => Err(WinWebAuthnError::new(
-            ErrorKind::Other,
+            ErrorKind::UserCancelled,
             "User cancelled user verification",
         )),
         _ => Err(WinWebAuthnError::with_cause(

--- a/apps/desktop/desktop_native/win_webauthn/src/lib.rs
+++ b/apps/desktop/desktop_native/win_webauthn/src/lib.rs
@@ -52,6 +52,13 @@ impl WinWebAuthnError {
             cause: Some(cause),
         }
     }
+
+    /// Whether the user dismissed an OS prompt, as opposed to the operation
+    /// failing. Callers generally want to report this as an outcome rather than
+    /// an error.
+    pub fn is_user_cancelled(&self) -> bool {
+        matches!(self.kind, ErrorKind::UserCancelled)
+    }
 }
 
 #[derive(Debug)]
@@ -68,6 +75,9 @@ enum ErrorKind {
     /// An unknown error occurred.
     Other,
 
+    /// The user dismissed an OS prompt.
+    UserCancelled,
+
     /// An internal library error occurred.
     WindowsInternal,
 }
@@ -79,6 +89,7 @@ impl Display for WinWebAuthnError {
             ErrorKind::DllLoad => "Failed to load function from DLL",
             ErrorKind::InvalidArguments => "Invalid arguments passed to function",
             ErrorKind::Other => "An error occurred",
+            ErrorKind::UserCancelled => "The user cancelled the operation",
             ErrorKind::WindowsInternal => "A Windows error occurred",
         };
         f.write_str(msg)?;

--- a/apps/desktop/desktop_native/windows_plugin_authenticator/Cargo.toml
+++ b/apps/desktop/desktop_native/windows_plugin_authenticator/Cargo.toml
@@ -7,7 +7,6 @@ publish = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
 autofill_provider = { path = "../autofill_provider" }
-base64 = { workspace = true }
 desktop_core = { path = "../core" }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/apps/desktop/desktop_native/windows_plugin_authenticator/src/assert.rs
+++ b/apps/desktop/desktop_native/windows_plugin_authenticator/src/assert.rs
@@ -8,12 +8,10 @@ use autofill_provider::{
     PasskeyAssertionWithoutUserInterfaceRequest, Position, TimedCallback, UserVerification,
     WindowDetails,
 };
+use desktop_core::autofill::create_context_string;
 use win_webauthn::{plugin::PluginGetAssertionRequest, CborWriter};
 
-use crate::{
-    ipc::IpcClient,
-    util::{create_context_string, HwndExt},
-};
+use crate::{ipc::IpcClient, util::HwndExt};
 
 pub fn get_assertion(
     ipc_client: &dyn IpcClient,

--- a/apps/desktop/desktop_native/windows_plugin_authenticator/src/authenticator.rs
+++ b/apps/desktop/desktop_native/windows_plugin_authenticator/src/authenticator.rs
@@ -10,6 +10,7 @@ use std::{
 };
 
 use autofill_provider::{ConnectionStatus, WindowHandleQueryResponse};
+use desktop_core::autofill::create_context_string;
 use win_webauthn::plugin::{
     Clsid, PluginAuthenticator, PluginCancelOperationRequest, PluginGetAssertionRequest,
     PluginLockStatus, PluginMakeCredentialRequest, WebAuthnPlugin,
@@ -25,10 +26,7 @@ use windows::{
     },
 };
 
-use crate::{
-    ipc::{IpcClient, IpcConnector, RealIpcConnector},
-    util::create_context_string,
-};
+use crate::ipc::{IpcClient, IpcConnector, RealIpcConnector};
 
 pub(super) fn run_server(clsid: Clsid) -> Result<WebAuthnPlugin, String> {
     tracing::debug!("Setting up COM server");

--- a/apps/desktop/desktop_native/windows_plugin_authenticator/src/make_credential.rs
+++ b/apps/desktop/desktop_native/windows_plugin_authenticator/src/make_credential.rs
@@ -8,15 +8,13 @@ use autofill_provider::{
     CallbackError, PasskeyRegistrationRequest, PasskeyRegistrationResponse, Position,
     TimedCallback, UserVerification, WindowDetails,
 };
+use desktop_core::autofill::create_context_string;
 use win_webauthn::{
     plugin::{PluginMakeCredentialRequest, PluginMakeCredentialResponse},
     CborParser, CborValue, CtapTransport,
 };
 
-use crate::{
-    ipc::IpcClient,
-    util::{create_context_string, HwndExt},
-};
+use crate::{ipc::IpcClient, util::HwndExt};
 
 pub fn make_credential(
     ipc_client: &dyn IpcClient,

--- a/apps/desktop/desktop_native/windows_plugin_authenticator/src/util.rs
+++ b/apps/desktop/desktop_native/windows_plugin_authenticator/src/util.rs
@@ -1,8 +1,4 @@
-use base64::engine::{general_purpose::STANDARD, Engine as _};
-use windows::{
-    core::GUID,
-    Win32::{Foundation::*, UI::WindowsAndMessaging::GetWindowRect},
-};
+use windows::Win32::{Foundation::*, UI::WindowsAndMessaging::GetWindowRect};
 
 pub trait HwndExt {
     fn center_position(&self) -> windows::core::Result<(i32, i32)>;
@@ -24,37 +20,5 @@ impl HwndExt for HWND {
             tracing::debug!("Coordinates for {:?}: {center:?}", *self);
             Ok(center)
         }
-    }
-}
-
-pub fn create_context_string(transaction_id: GUID, request_hash: &[u8]) -> String {
-    let context = &[&transaction_id.to_u128().to_le_bytes(), request_hash].concat();
-    STANDARD.encode(context)
-}
-
-#[cfg(test)]
-mod tests {
-    use base64::engine::{general_purpose::STANDARD, Engine as _};
-    use windows::core::GUID;
-
-    use super::create_context_string;
-
-    #[test]
-    fn context_string_guid_round_trips() {
-        let guid1 = GUID {
-            data1: 1,
-            data2: 2,
-            data3: 3,
-            data4: [4; 8],
-        };
-        let hash1 = b"abcd";
-        let result = create_context_string(guid1, hash1);
-
-        let decoded = STANDARD.decode(&result).unwrap();
-        let (guid_bytes, hash2) = decoded.split_at(16);
-        let guid2 = GUID::from_u128(u128::from_le_bytes(guid_bytes.try_into().unwrap()));
-
-        assert_eq!(guid1, guid2);
-        assert_eq!(hash1, hash2);
     }
 }

--- a/apps/desktop/src/autofill/desktop-autofill.preload.ts
+++ b/apps/desktop/src/autofill/desktop-autofill.preload.ts
@@ -21,6 +21,14 @@ export const DesktopAutofillPreload = {
   listenerReady: () => ipcRenderer.send("autofill.listenerReady"),
 
   /**
+   * Returns the native handle of the Bitwarden app window, for native prompts
+   * that must attach themselves to a window. Resolves to null when there is no
+   * window, e.g. while the app is starting up.
+   */
+  getAppWindowHandle: (): Promise<Uint8Array | null> =>
+    ipcRenderer.invoke(AutofillIpcChannelControl.GetAppWindowHandle),
+
+  /**
    * Signals the main process whether native credential sync is enabled. The main process only
    * registers the native OS credential provider and starts the autofill IPC server once this is
    * called with `true`, so the flag-gating decision stays in the renderer where the feature flag

--- a/apps/desktop/src/autofill/main/main-desktop-autofill.service.ts
+++ b/apps/desktop/src/autofill/main/main-desktop-autofill.service.ts
@@ -95,6 +95,13 @@ export class DesktopAutofillMain {
         return this.enable();
       },
     );
+
+    // Read on demand rather than sent with each request: the handle belongs to
+    // the window, not to any one request, and the window may be recreated.
+    ipcMain.handle(
+      AutofillIpcChannelControl.GetAppWindowHandle,
+      (): Uint8Array | null => this.windowMain.win?.getNativeWindowHandle() ?? null,
+    );
   }
 
   /**
@@ -178,7 +185,7 @@ export class DesktopAutofillMain {
       this.flushMessageBuffer();
     });
 
-    ipcMain.on(AutofillIpcChannelOutgoing.Error, (event, data) => {
+    ipcMain.on(AutofillIpcChannelOutgoing.Error, (_event, data) => {
       this.logService.debug("[DesktopAutofillMain]", AutofillIpcChannelOutgoing.Error, data);
       const { clientId, sequenceNumber, error } = data;
       this.ipcServer?.completeError(clientId, sequenceNumber, String(error));

--- a/apps/desktop/src/autofill/models/autofill-command.ts
+++ b/apps/desktop/src/autofill/models/autofill-command.ts
@@ -1,5 +1,6 @@
 import { AutofillStatusCommand } from "./autofill-status.command";
 import { AutofillSyncCommand } from "./autofill-sync.command";
+import { AutofillUserVerificationCommand } from "./autofill-user-verification.command";
 
 export type AutofillCommandDefinition = {
   namespace: string;
@@ -20,4 +21,5 @@ export type IpcCommandInvoker<C extends AutofillCommandDefinition> = (
 ) => Promise<AutofillCommandOutput<C["output"]>>;
 
 /** A list of all available commands */
-export type AutofillCommand = AutofillSyncCommand | AutofillStatusCommand;
+export type AutofillCommand =
+  AutofillSyncCommand | AutofillStatusCommand | AutofillUserVerificationCommand;

--- a/apps/desktop/src/autofill/models/autofill-ipc-channels.ts
+++ b/apps/desktop/src/autofill/models/autofill-ipc-channels.ts
@@ -92,6 +92,7 @@ export type AutofillIpcResponse<K extends AutofillIpcChannelIncoming> =
  * correlation).
  */
 export const AutofillIpcChannelControl = Object.freeze({
+  GetAppWindowHandle: "autofill.getAppWindowHandle",
   ListenerReady: "autofill.listenerReady",
   RunCommand: "autofill.runCommand",
   SetEnabled: "autofill.setEnabled",

--- a/apps/desktop/src/autofill/models/autofill-user-verification.command.ts
+++ b/apps/desktop/src/autofill/models/autofill-user-verification.command.ts
@@ -1,0 +1,36 @@
+import { AutofillCommandDefinition, AutofillCommandOutput } from "./autofill-command";
+
+export interface AutofillUserVerificationCommand extends AutofillCommandDefinition {
+  name: "userVerification";
+  input: AutofillUserVerificationParams;
+  output: AutofillUserVerificationResult;
+}
+
+export type AutofillUserVerificationParams =
+  WindowsAutofillUserVerificationParams | MacOsAutofillUserVerificationParams;
+
+export type WindowsAutofillUserVerificationParams = {
+  /** Base64 encoded bytes of the handle of the window to attach the prompt to. */
+  windowHandle: string;
+  /** Opaque context binding the prompt to the WebAuthn operation that needs it. */
+  transactionContext: string;
+  displayHint: string;
+  username: string;
+};
+
+export type MacOsAutofillUserVerificationParams = {
+  displayHint: string;
+  username: string;
+};
+
+/**
+ * Whether the user completed verification or dismissed the prompt.
+ *
+ * Dismissal is reported as a successful command with a `cancelled` outcome so
+ * that callers don't have to recognize platform-specific error strings.
+ */
+export type AutofillUserVerificationOutcome = "verified" | "cancelled";
+
+export type AutofillUserVerificationResult = AutofillCommandOutput<{
+  outcome: AutofillUserVerificationOutcome;
+}>;

--- a/apps/desktop/src/autofill/services/desktop-autofill.service.ts
+++ b/apps/desktop/src/autofill/services/desktop-autofill.service.ts
@@ -264,7 +264,7 @@ export class DesktopAutofillService implements OnDestroy {
 
     const response = await this.fido2AuthenticatorService.makeCredential(
       this.convertRegistrationRequest(request),
-      { windowXy: request.clientWindow.position },
+      await this.nativeWindowObject(request),
       abortController,
     );
     return this.convertRegistrationResponse(request, response);
@@ -278,7 +278,7 @@ export class DesktopAutofillService implements OnDestroy {
 
     const response = await this.fido2AuthenticatorService.getAssertion(
       this.convertAssertionRequest(request, assumeUserPresence),
-      { windowXy: request.clientWindow.position },
+      await this.nativeWindowObject(request),
       abortController,
     );
 
@@ -293,11 +293,33 @@ export class DesktopAutofillService implements OnDestroy {
 
     const response = await this.fido2AuthenticatorService.getAssertion(
       this.convertAssertionRequest(request, assumeUserPresence),
-      { windowXy: request.clientWindow.position },
+      await this.nativeWindowObject(request),
       abortController,
     );
 
     return this.convertAssertionResponse(request, response);
+  }
+
+  /**
+   * Collects everything the FIDO2 user interface needs to know about the
+   * windows involved in a request: where to position our own UI, and which
+   * native windows an OS prompt can attach itself to.
+   */
+  private async nativeWindowObject(
+    request:
+      | PasskeyRegistrationRequest
+      | PasskeyAssertionRequest
+      | PasskeyAssertionWithoutUserInterfaceRequest,
+  ): Promise<NativeWindowObject> {
+    return {
+      windowXy: request.clientWindow.position,
+      clientWindowHandle: request.clientWindow.handle
+        ? new Uint8Array(request.clientWindow.handle)
+        : null,
+      appWindowHandle: await ipc.autofill.desktopAutofill.getAppWindowHandle(),
+      rpId: request.rpId,
+      requestContext: request.context,
+    };
   }
 
   async doNativeStatus(status: NativeStatus): Promise<void> {

--- a/apps/desktop/src/autofill/services/desktop-fido2-user-interface.service.spec.ts
+++ b/apps/desktop/src/autofill/services/desktop-fido2-user-interface.service.spec.ts
@@ -85,7 +85,13 @@ describe("DesktopFido2UserInterfaceSession", () => {
       router,
       desktopSettingsService,
       abortController,
-      {},
+      {
+        rpId: "example.com",
+        requestContext: "request-context",
+        windowXy: { x: 0, y: 0 },
+        appWindowHandle: new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]),
+        clientWindowHandle: new Uint8Array([8, 7, 6, 5, 4, 3, 2, 1]),
+      },
     );
   });
 

--- a/apps/desktop/src/autofill/services/desktop-fido2-user-interface.service.ts
+++ b/apps/desktop/src/autofill/services/desktop-fido2-user-interface.service.ts
@@ -43,9 +43,31 @@ import { DesktopSettingsService } from "../../platform/services/desktop-settings
  */
 export type NativeWindowObject = {
   /**
-   * The position of the window, first entry is the x position, second is the y position
+   * The position of the client window.
    */
-  windowXy?: { x: number; y: number };
+  windowXy: { x: number; y: number };
+
+  /**
+   * The native handle of the client window.
+   */
+  clientWindowHandle: Uint8Array | null;
+
+  /**
+   * The native handle of the Bitwarden app window, or null if the app has no
+   * window at the time of the request.
+   */
+  appWindowHandle: Uint8Array | null;
+
+  /**
+   * OS-specific request context required for calls back to the OS during the
+   * authentication ceremony.
+   */
+  requestContext: string;
+
+  /**
+   * RP ID of the request.
+   */
+  rpId: string;
 };
 
 /**


### PR DESCRIPTION
## 🎟️ Tracking

[PM-29791](https://bitwarden.atlassian.net/browse/PM-29791)

## 📔 Objective

This is the first of 4 PRs implementing native OS user verification for passkey ceremonies on Windows and macOS.

This is all just prep:

- Move context string parsing utility from windows_plugin_authenticator so it can be shared with desktop_core::autofill
- Gather necessary context (RP ID, app window handle) and pass it to the passkey handlers
- Wire up IPC channels for native user verification calls

[PM-29791]: https://bitwarden.atlassian.net/browse/PM-29791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ