### PR TITLE
desktop-autofill: Verify user without UI on assertion when possible [PM-29791]

### DIFF
--- a/apps/desktop/src/autofill/services/desktop-fido2-user-interface.service.spec.ts
+++ b/apps/desktop/src/autofill/services/desktop-fido2-user-interface.service.spec.ts
@@ -1,6 +1,6 @@
 import { Router } from "@angular/router";
 import { mock, MockProxy } from "jest-mock-extended";
-import { BehaviorSubject } from "rxjs";
+import { BehaviorSubject, of } from "rxjs";
 
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { AuthService } from "@bitwarden/common/auth/abstractions/auth.service";
@@ -10,6 +10,7 @@ import { LogService } from "@bitwarden/common/platform/abstractions/log.service"
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { CipherRepromptType } from "@bitwarden/common/vault/enums";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+import { CipherListView } from "@bitwarden/sdk-internal";
 import { PasswordRepromptService } from "@bitwarden/vault";
 
 import { ModalModeState } from "../../platform/models/domain/window-state";
@@ -73,6 +74,11 @@ describe("DesktopFido2UserInterfaceSession", () => {
 
     activeAccountStatus$ = new BehaviorSubject<AuthenticationStatus>(AuthenticationStatus.Unlocked);
     authService.activeAccountStatus$ = activeAccountStatus$;
+    accountService.activeAccount$ = new BehaviorSubject({ id: "user-1" } as any);
+
+    // Default to a vault with no credentials. Tests that need the ceremony to
+    // find one stub this with the cipher they expect it to retrieve.
+    cipherService.cipherListViews$.mockReturnValue(of([]));
 
     desktopSettingsService.modalMode$ = new BehaviorSubject<ModalModeState>({
       isModalModeActive: false,
@@ -143,15 +149,15 @@ describe("DesktopFido2UserInterfaceSession", () => {
       masterPasswordRepromptRequired: false,
     };
 
-    it("returns the single cipher without showing UI when user presence is assumed", async () => {
+    it("returns the single cipher without showing UI when user presence is assumed and user verification is not required", async () => {
       await expect(
         session.pickCredential({
           cipherIds: ["cipher-1"],
-          userVerification: true,
+          userVerification: false,
           assumeUserPresence: true,
           masterPasswordRepromptRequired: false,
         }),
-      ).resolves.toEqual({ cipherId: "cipher-1", userVerified: true });
+      ).resolves.toEqual({ cipherId: "cipher-1", userVerified: false });
 
       expect(desktopSettingsService.setModalMode).not.toHaveBeenCalledWith(
         true,
@@ -160,16 +166,34 @@ describe("DesktopFido2UserInterfaceSession", () => {
       );
     });
 
-    it("leaves the window the user already had open alone when no UI was shown", async () => {
-      accountService.activeAccount$ = new BehaviorSubject({
-        id: "user-1",
-      } as any);
+    it("leaves the window the user already had open alone when no prompt was needed", async () => {
       await session.pickCredential({
         cipherIds: ["cipher-1"],
-        userVerification: true,
+        userVerification: false,
         assumeUserPresence: true,
         masterPasswordRepromptRequired: false,
       });
+
+      expect(router.navigate).not.toHaveBeenCalled();
+      expect(accountService.setShowHeader).not.toHaveBeenCalled();
+    });
+
+    it("leaves the window the user already had open alone when only the OS prompt was shown", async () => {
+      // The lone credential is verified through the OS, so the ceremony finishes
+      // without routing to any of our own UI.
+      cipherService.cipherListViews$.mockReturnValue(
+        of([Object.assign(new CipherView(), { id: "cipher-1" })] as unknown as CipherListView[]),
+      );
+      userVerificationService.verify.mockResolvedValue(true);
+
+      await expect(
+        session.pickCredential({
+          cipherIds: ["cipher-1"],
+          userVerification: true,
+          assumeUserPresence: false,
+          masterPasswordRepromptRequired: false,
+        }),
+      ).resolves.toEqual({ cipherId: "cipher-1", userVerified: true });
 
       expect(router.navigate).not.toHaveBeenCalled();
       expect(accountService.setShowHeader).not.toHaveBeenCalled();
@@ -376,10 +400,6 @@ describe("DesktopFido2UserInterfaceSession", () => {
   describe("user verification", () => {
     const singleCipherId = "cipher-1";
 
-    beforeEach(() => {
-      accountService.activeAccount$ = new BehaviorSubject({ id: "user-1" } as any);
-    });
-
     const confirmNewCredentialParams = {
       credentialName: "Example",
       userName: "user@example.com",
@@ -397,144 +417,259 @@ describe("DesktopFido2UserInterfaceSession", () => {
         masterPasswordRepromptRequired: true,
       });
 
-    it("attaches the prompt to the Bitwarden window while our own UI is showing", async () => {
-      userVerificationService.verify.mockResolvedValue(true);
+    /** Makes `singleCipherId` the only credential in the vault. */
+    const stubSingleCipher = () => {
+      const cipher = new CipherView();
+      cipher.id = singleCipherId;
+      cipherService.cipherListViews$.mockReturnValue(of([cipher] as unknown as CipherListView[]));
+    };
 
-      const result = session.confirmNewCredential(confirmNewCredentialParams);
-      await tick();
-      session.notifyConfirmCreateCredential(true, Object.assign(new CipherView(), { id: "c1" }));
-      await result;
+    describe("assertion", () => {
+      /** Picks the lone credential, which needs no picker UI. */
+      const pickSingleCredential = () =>
+        session.pickCredential({
+          cipherIds: [singleCipherId],
+          userVerification: true,
+          assumeUserPresence: false,
+          masterPasswordRepromptRequired: false,
+        });
 
-      expect(userVerificationService.verify).toHaveBeenCalledWith(
-        expect.objectContaining({
-          operation: "overwrite",
-          rpId: "example.com",
-          requestContext: "request-context",
-          windowHandle: new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]),
-        }),
-        expect.anything(),
-      );
-    });
+      it("returns the single cipher as verified when the OS verifies the user, without showing UI", async () => {
+        stubSingleCipher();
+        userVerificationService.verify.mockResolvedValue(true);
 
-    it("rejects credential creation as NotAllowed when the user dismisses the prompt", async () => {
-      userVerificationService.verify.mockRejectedValue(new UserVerificationCanceled());
+        await expect(pickSingleCredential()).resolves.toEqual({
+          cipherId: singleCipherId,
+          userVerified: true,
+        });
+        expect(desktopSettingsService.setModalMode).not.toHaveBeenCalledWith(
+          true,
+          expect.anything(),
+          expect.anything(),
+        );
+      });
 
-      const result = session.confirmNewCredential(confirmNewCredentialParams);
-      await tick();
-      session.notifyConfirmCreateCredential(true, Object.assign(new CipherView(), { id: "c1" }));
+      it("still verifies through the OS when user presence is assumed but verification is required", async () => {
+        stubSingleCipher();
+        userVerificationService.verify.mockResolvedValue(true);
 
-      await expect(result).rejects.toMatchObject({
-        errorCode: Fido2AuthenticatorErrorCode.NotAllowed,
+        await expect(
+          session.pickCredential({
+            cipherIds: [singleCipherId],
+            userVerification: true,
+            assumeUserPresence: true,
+            masterPasswordRepromptRequired: false,
+          }),
+        ).resolves.toEqual({ cipherId: singleCipherId, userVerified: true });
+
+        expect(userVerificationService.verify).toHaveBeenCalled();
+      });
+
+      it("attaches the prompt to the client window while our own UI is hidden", async () => {
+        stubSingleCipher();
+        userVerificationService.verify.mockResolvedValue(true);
+
+        await pickSingleCredential();
+
+        expect(userVerificationService.verify).toHaveBeenCalledWith(
+          expect.objectContaining({
+            operation: "assertion",
+            rpId: "example.com",
+            requestContext: "request-context",
+            windowHandle: new Uint8Array([8, 7, 6, 5, 4, 3, 2, 1]),
+          }),
+          expect.anything(),
+        );
+      });
+
+      it("rejects the ceremony as NotAllowed when the user dismisses the silent prompt", async () => {
+        stubSingleCipher();
+        userVerificationService.verify.mockRejectedValue(new UserVerificationCanceled());
+
+        await expect(pickSingleCredential()).rejects.toMatchObject({
+          errorCode: Fido2AuthenticatorErrorCode.NotAllowed,
+        });
+      });
+
+      it("falls back to the picker when silent verification fails for a recoverable reason", async () => {
+        stubSingleCipher();
+        userVerificationService.verify.mockRejectedValueOnce(new Error("no biometrics enrolled"));
+        userVerificationService.verify.mockResolvedValue(true);
+
+        const result = pickSingleCredential();
+        await tick();
+        session.confirmChosenCipher(Object.assign(new CipherView(), { id: singleCipherId }));
+
+        await expect(result).resolves.toEqual({
+          cipherId: singleCipherId,
+          userVerified: true,
+        });
+        expect(desktopSettingsService.setModalMode).toHaveBeenCalledWith(
+          true,
+          expect.anything(),
+          expect.anything(),
+        );
+      });
+
+      it("does not prompt when the user unlocked their vault during this assertion ceremony", async () => {
+        stubSingleCipher();
+        activeAccountStatus$.next(AuthenticationStatus.Locked);
+
+        const unlocked = session.ensureUnlockedVault();
+        await tick();
+        activeAccountStatus$.next(AuthenticationStatus.Unlocked);
+        await unlocked;
+
+        await expect(pickSingleCredential()).resolves.toEqual({
+          cipherId: singleCipherId,
+          userVerified: true,
+        });
+        expect(userVerificationService.verify).not.toHaveBeenCalled();
       });
     });
 
-    it("does not prompt when the relying party did not ask for verification", async () => {
-      const result = session.confirmNewCredential({
-        ...confirmNewCredentialParams,
-        userVerification: false,
+    describe("registration", () => {
+      it("attaches the prompt to the Bitwarden window while our own UI is showing", async () => {
+        userVerificationService.verify.mockResolvedValue(true);
+
+        const result = session.confirmNewCredential(confirmNewCredentialParams);
+        await tick();
+        session.notifyConfirmCreateCredential(true, Object.assign(new CipherView(), { id: "c1" }));
+        await result;
+
+        expect(userVerificationService.verify).toHaveBeenCalledWith(
+          expect.objectContaining({
+            operation: "overwrite",
+            rpId: "example.com",
+            requestContext: "request-context",
+            windowHandle: new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]),
+          }),
+          expect.anything(),
+        );
       });
-      await tick();
-      session.notifyConfirmCreateCredential(true, Object.assign(new CipherView(), { id: "c1" }));
 
-      await expect(result).resolves.toEqual({ cipherId: "c1", userVerified: false });
-      expect(userVerificationService.verify).not.toHaveBeenCalled();
-    });
+      it("rejects credential creation as NotAllowed when the user dismisses the prompt", async () => {
+        userVerificationService.verify.mockRejectedValue(new UserVerificationCanceled());
 
-    it("does not prompt when the user unlocked their vault during this ceremony", async () => {
-      activeAccountStatus$.next(AuthenticationStatus.Locked);
+        const result = session.confirmNewCredential(confirmNewCredentialParams);
+        await tick();
+        session.notifyConfirmCreateCredential(true, Object.assign(new CipherView(), { id: "c1" }));
 
-      const unlocked = session.ensureUnlockedVault();
-      await tick();
-      activeAccountStatus$.next(AuthenticationStatus.Unlocked);
-      await unlocked;
-
-      const result = session.confirmNewCredential(confirmNewCredentialParams);
-      await tick();
-      session.notifyConfirmCreateCredential(true, Object.assign(new CipherView(), { id: "c1" }));
-
-      await expect(result).resolves.toEqual({ cipherId: "c1", userVerified: true });
-      expect(userVerificationService.verify).not.toHaveBeenCalled();
-    });
-
-    it("verifies via master-password reprompt instead of the OS for a reprompt-protected cipher", async () => {
-      passwordRepromptService.showPasswordPrompt.mockResolvedValue(true);
-
-      const result = pickCredentialFromList();
-      await tick();
-      session.confirmChosenCipher(repromptCipher(singleCipherId));
-
-      await expect(result).resolves.toEqual({ cipherId: singleCipherId, userVerified: true });
-      expect(passwordRepromptService.showPasswordPrompt).toHaveBeenCalled();
-      expect(userVerificationService.verify).not.toHaveBeenCalled();
-    });
-
-    it("rejects the ceremony as NotAllowed when the master-password reprompt is dismissed", async () => {
-      passwordRepromptService.showPasswordPrompt.mockResolvedValue(false);
-
-      const result = pickCredentialFromList();
-      await tick();
-      session.confirmChosenCipher(repromptCipher(singleCipherId));
-
-      await expect(result).rejects.toMatchObject({
-        errorCode: Fido2AuthenticatorErrorCode.NotAllowed,
+        await expect(result).rejects.toMatchObject({
+          errorCode: Fido2AuthenticatorErrorCode.NotAllowed,
+        });
       });
-      expect(userVerificationService.verify).not.toHaveBeenCalled();
-    });
 
-    it("ignores the master password reprompt flag and verifies through the OS when the account has no master password", async () => {
-      passwordRepromptService.enabled.mockResolvedValue(false);
-      userVerificationService.verify.mockResolvedValue(true);
+      it("does not prompt when the relying party did not ask for verification", async () => {
+        const result = session.confirmNewCredential({
+          ...confirmNewCredentialParams,
+          userVerification: false,
+        });
+        await tick();
+        session.notifyConfirmCreateCredential(true, Object.assign(new CipherView(), { id: "c1" }));
 
-      const result = pickCredentialFromList();
-      await tick();
-      session.confirmChosenCipher(repromptCipher(singleCipherId));
-
-      await expect(result).resolves.toEqual({ cipherId: singleCipherId, userVerified: true });
-      expect(passwordRepromptService.showPasswordPrompt).not.toHaveBeenCalled();
-      expect(userVerificationService.verify).toHaveBeenCalled();
-    });
-
-    it("refuses the ceremony when the cipher uses an unrecognized reprompt type", async () => {
-      const result = pickCredentialFromList();
-      await tick();
-      session.confirmChosenCipher(
-        Object.assign(new CipherView(), { id: singleCipherId, reprompt: 99 }),
-      );
-
-      await expect(result).rejects.toMatchObject({
-        errorCode: Fido2AuthenticatorErrorCode.NotAllowed,
+        await expect(result).resolves.toEqual({ cipherId: "c1", userVerified: false });
+        expect(userVerificationService.verify).not.toHaveBeenCalled();
       });
-      expect(passwordRepromptService.showPasswordPrompt).not.toHaveBeenCalled();
-      expect(userVerificationService.verify).not.toHaveBeenCalled();
-    });
 
-    it("verifies a reprompt-protected cipher via master-password reprompt during creation", async () => {
-      passwordRepromptService.showPasswordPrompt.mockResolvedValue(true);
-      const existing = repromptCipher(singleCipherId);
+      it("does not prompt when the user unlocked their vault during this registration ceremony", async () => {
+        activeAccountStatus$.next(AuthenticationStatus.Locked);
 
-      const result = session.confirmNewCredential({
-        ...confirmNewCredentialParams,
-        userVerification: false,
+        const unlocked = session.ensureUnlockedVault();
+        await tick();
+        activeAccountStatus$.next(AuthenticationStatus.Unlocked);
+        await unlocked;
+
+        const result = session.confirmNewCredential(confirmNewCredentialParams);
+        await tick();
+        session.notifyConfirmCreateCredential(true, Object.assign(new CipherView(), { id: "c1" }));
+
+        await expect(result).resolves.toEqual({ cipherId: "c1", userVerified: true });
+        expect(userVerificationService.verify).not.toHaveBeenCalled();
       });
-      await tick();
-      session.notifyConfirmCreateCredential(true, existing);
-
-      await expect(result).resolves.toEqual({ cipherId: singleCipherId, userVerified: true });
-      expect(passwordRepromptService.showPasswordPrompt).toHaveBeenCalled();
-      expect(userVerificationService.verify).not.toHaveBeenCalled();
-      expect(cipherService.updateWithServer).toHaveBeenCalledWith(existing, "user-1");
     });
 
-    it("skips the master-password reprompt when the account has no master password", async () => {
-      passwordRepromptService.enabled.mockResolvedValue(false);
-      userVerificationService.verify.mockResolvedValue(true);
+    describe("master password reprompt", () => {
+      it("verifies a reprompt-protected cipher via master-password reprompt during assertion", async () => {
+        passwordRepromptService.showPasswordPrompt.mockResolvedValue(true);
 
-      const result = session.confirmNewCredential(confirmNewCredentialParams);
-      await tick();
-      session.notifyConfirmCreateCredential(true, repromptCipher(singleCipherId));
-      await result;
+        const result = pickCredentialFromList();
+        await tick();
+        session.confirmChosenCipher(repromptCipher(singleCipherId));
 
-      expect(passwordRepromptService.showPasswordPrompt).not.toHaveBeenCalled();
+        await expect(result).resolves.toEqual({ cipherId: singleCipherId, userVerified: true });
+        expect(passwordRepromptService.showPasswordPrompt).toHaveBeenCalled();
+        expect(userVerificationService.verify).not.toHaveBeenCalled();
+      });
+
+      it("verifies a reprompt-protected cipher via master-password reprompt during creation", async () => {
+        passwordRepromptService.showPasswordPrompt.mockResolvedValue(true);
+        const existing = repromptCipher(singleCipherId);
+
+        const result = session.confirmNewCredential({
+          ...confirmNewCredentialParams,
+          userVerification: false,
+        });
+        await tick();
+        session.notifyConfirmCreateCredential(true, existing);
+
+        await expect(result).resolves.toEqual({ cipherId: singleCipherId, userVerified: true });
+        expect(passwordRepromptService.showPasswordPrompt).toHaveBeenCalled();
+        expect(userVerificationService.verify).not.toHaveBeenCalled();
+        expect(cipherService.updateWithServer).toHaveBeenCalledWith(existing, "user-1");
+      });
+
+      it("rejects the assertion as NotAllowed when the master-password reprompt is dismissed", async () => {
+        passwordRepromptService.showPasswordPrompt.mockResolvedValue(false);
+
+        const result = pickCredentialFromList();
+        await tick();
+        session.confirmChosenCipher(repromptCipher(singleCipherId));
+
+        await expect(result).rejects.toMatchObject({
+          errorCode: Fido2AuthenticatorErrorCode.NotAllowed,
+        });
+        expect(userVerificationService.verify).not.toHaveBeenCalled();
+      });
+
+      it("ignores the reprompt flag and verifies through the OS during assertion when the account has no master password", async () => {
+        passwordRepromptService.enabled.mockResolvedValue(false);
+        userVerificationService.verify.mockResolvedValue(true);
+
+        const result = pickCredentialFromList();
+        await tick();
+        session.confirmChosenCipher(repromptCipher(singleCipherId));
+
+        await expect(result).resolves.toEqual({ cipherId: singleCipherId, userVerified: true });
+        expect(passwordRepromptService.showPasswordPrompt).not.toHaveBeenCalled();
+        expect(userVerificationService.verify).toHaveBeenCalled();
+      });
+
+      it("skips the master-password reprompt during creation when the account has no master password", async () => {
+        passwordRepromptService.enabled.mockResolvedValue(false);
+        userVerificationService.verify.mockResolvedValue(true);
+
+        const result = session.confirmNewCredential(confirmNewCredentialParams);
+        await tick();
+        session.notifyConfirmCreateCredential(true, repromptCipher(singleCipherId));
+        await result;
+
+        expect(passwordRepromptService.showPasswordPrompt).not.toHaveBeenCalled();
+      });
+
+      it("refuses the ceremony when the cipher uses an unrecognized reprompt type", async () => {
+        const result = pickCredentialFromList();
+        await tick();
+        session.confirmChosenCipher(
+          Object.assign(new CipherView(), { id: singleCipherId, reprompt: 99 }),
+        );
+
+        await expect(result).rejects.toMatchObject({
+          errorCode: Fido2AuthenticatorErrorCode.NotAllowed,
+        });
+        expect(passwordRepromptService.showPasswordPrompt).not.toHaveBeenCalled();
+        expect(userVerificationService.verify).not.toHaveBeenCalled();
+      });
     });
   });
 });

--- a/apps/desktop/src/autofill/services/desktop-fido2-user-interface.service.spec.ts
+++ b/apps/desktop/src/autofill/services/desktop-fido2-user-interface.service.spec.ts
@@ -1,6 +1,6 @@
 import { Router } from "@angular/router";
 import { mock, MockProxy } from "jest-mock-extended";
-import { BehaviorSubject } from "rxjs";
+import { BehaviorSubject, of } from "rxjs";
 
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { AuthService } from "@bitwarden/common/auth/abstractions/auth.service";
@@ -10,6 +10,7 @@ import { LogService } from "@bitwarden/common/platform/abstractions/log.service"
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { CipherRepromptType } from "@bitwarden/common/vault/enums";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+import { CipherListView } from "@bitwarden/sdk-internal";
 import { PasswordRepromptService } from "@bitwarden/vault";
 
 import { ModalModeState } from "../../platform/models/domain/window-state";
@@ -73,6 +74,11 @@ describe("DesktopFido2UserInterfaceSession", () => {
 
     activeAccountStatus$ = new BehaviorSubject<AuthenticationStatus>(AuthenticationStatus.Unlocked);
     authService.activeAccountStatus$ = activeAccountStatus$;
+    accountService.activeAccount$ = new BehaviorSubject({ id: "user-1" } as any);
+
+    // Default to a vault with no credentials. Tests that need the ceremony to
+    // find one stub this with the cipher they expect it to retrieve.
+    cipherService.cipherListViews$.mockReturnValue(of([]));
 
     desktopSettingsService.modalMode$ = new BehaviorSubject<ModalModeState>({
       isModalModeActive: false,
@@ -143,15 +149,15 @@ describe("DesktopFido2UserInterfaceSession", () => {
       masterPasswordRepromptRequired: false,
     };
 
-    it("returns the single cipher without showing UI when user presence is assumed", async () => {
+    it("returns the single cipher without showing UI when user presence is assumed and user verification is not required", async () => {
       await expect(
         session.pickCredential({
           cipherIds: ["cipher-1"],
-          userVerification: true,
+          userVerification: false,
           assumeUserPresence: true,
           masterPasswordRepromptRequired: false,
         }),
-      ).resolves.toEqual({ cipherId: "cipher-1", userVerified: true });
+      ).resolves.toEqual({ cipherId: "cipher-1", userVerified: false });
 
       expect(desktopSettingsService.setModalMode).not.toHaveBeenCalledWith(
         true,
@@ -160,16 +166,34 @@ describe("DesktopFido2UserInterfaceSession", () => {
       );
     });
 
-    it("leaves the window the user already had open alone when no UI was shown", async () => {
-      accountService.activeAccount$ = new BehaviorSubject({
-        id: "user-1",
-      } as any);
+    it("leaves the window the user already had open alone when no prompt was needed", async () => {
       await session.pickCredential({
         cipherIds: ["cipher-1"],
-        userVerification: true,
+        userVerification: false,
         assumeUserPresence: true,
         masterPasswordRepromptRequired: false,
       });
+
+      expect(router.navigate).not.toHaveBeenCalled();
+      expect(accountService.setShowHeader).not.toHaveBeenCalled();
+    });
+
+    it("leaves the window the user already had open alone when only the OS prompt was shown", async () => {
+      // The lone credential is verified through the OS, so the ceremony finishes
+      // without routing to any of our own UI.
+      cipherService.cipherListViews$.mockReturnValue(
+        of([Object.assign(new CipherView(), { id: "cipher-1" })] as unknown as CipherListView[]),
+      );
+      userVerificationService.verify.mockResolvedValue(true);
+
+      await expect(
+        session.pickCredential({
+          cipherIds: ["cipher-1"],
+          userVerification: true,
+          assumeUserPresence: false,
+          masterPasswordRepromptRequired: false,
+        }),
+      ).resolves.toEqual({ cipherId: "cipher-1", userVerified: true });
 
       expect(router.navigate).not.toHaveBeenCalled();
       expect(accountService.setShowHeader).not.toHaveBeenCalled();
@@ -376,10 +400,6 @@ describe("DesktopFido2UserInterfaceSession", () => {
   describe("user verification", () => {
     const singleCipherId = "cipher-1";
 
-    beforeEach(() => {
-      accountService.activeAccount$ = new BehaviorSubject({ id: "user-1" } as any);
-    });
-
     const confirmNewCredentialParams = {
       credentialName: "Example",
       userName: "user@example.com",
@@ -397,144 +417,241 @@ describe("DesktopFido2UserInterfaceSession", () => {
         masterPasswordRepromptRequired: true,
       });
 
-    it("attaches the prompt to the Bitwarden window while our own UI is showing", async () => {
-      userVerificationService.verify.mockResolvedValue(true);
+    /** Makes `singleCipherId` the only credential in the vault. */
+    const stubSingleCipher = () => {
+      const cipher = new CipherView();
+      cipher.id = singleCipherId;
+      cipherService.cipherListViews$.mockReturnValue(of([cipher] as unknown as CipherListView[]));
+    };
 
-      const result = session.confirmNewCredential(confirmNewCredentialParams);
-      await tick();
-      session.notifyConfirmCreateCredential(true, Object.assign(new CipherView(), { id: "c1" }));
-      await result;
+    describe("assertion", () => {
+      /** Picks the lone credential, which needs no picker UI. */
+      const pickSingleCredential = () =>
+        session.pickCredential({
+          cipherIds: [singleCipherId],
+          userVerification: true,
+          assumeUserPresence: false,
+          masterPasswordRepromptRequired: false,
+        });
 
-      expect(userVerificationService.verify).toHaveBeenCalledWith(
-        expect.objectContaining({
-          operation: "overwrite",
-          rpId: "example.com",
-          requestContext: "request-context",
-          windowHandle: new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]),
-        }),
-        expect.anything(),
-      );
-    });
+      it("returns the single cipher as verified when the OS verifies the user, without showing UI", async () => {
+        stubSingleCipher();
+        userVerificationService.verify.mockResolvedValue(true);
 
-    it("rejects credential creation as NotAllowed when the user dismisses the prompt", async () => {
-      userVerificationService.verify.mockRejectedValue(new UserVerificationCanceled());
+        await expect(pickSingleCredential()).resolves.toEqual({
+          cipherId: singleCipherId,
+          userVerified: true,
+        });
+        expect(desktopSettingsService.setModalMode).not.toHaveBeenCalledWith(
+          true,
+          expect.anything(),
+          expect.anything(),
+        );
+      });
 
-      const result = session.confirmNewCredential(confirmNewCredentialParams);
-      await tick();
-      session.notifyConfirmCreateCredential(true, Object.assign(new CipherView(), { id: "c1" }));
+      it("attaches the prompt to the client window while our own UI is hidden", async () => {
+        stubSingleCipher();
+        userVerificationService.verify.mockResolvedValue(true);
 
-      await expect(result).rejects.toMatchObject({
-        errorCode: Fido2AuthenticatorErrorCode.NotAllowed,
+        await pickSingleCredential();
+
+        expect(userVerificationService.verify).toHaveBeenCalledWith(
+          expect.objectContaining({
+            operation: "assertion",
+            rpId: "example.com",
+            requestContext: "request-context",
+            windowHandle: new Uint8Array([8, 7, 6, 5, 4, 3, 2, 1]),
+          }),
+          expect.anything(),
+        );
+      });
+
+      it("rejects the ceremony as NotAllowed when the user dismisses the silent prompt", async () => {
+        stubSingleCipher();
+        userVerificationService.verify.mockRejectedValue(new UserVerificationCanceled());
+
+        await expect(pickSingleCredential()).rejects.toMatchObject({
+          errorCode: Fido2AuthenticatorErrorCode.NotAllowed,
+        });
+      });
+
+      it("falls back to the picker when silent verification fails for a recoverable reason", async () => {
+        stubSingleCipher();
+        userVerificationService.verify.mockRejectedValueOnce(new Error("no biometrics enrolled"));
+        userVerificationService.verify.mockResolvedValue(true);
+
+        const result = pickSingleCredential();
+        await tick();
+        session.confirmChosenCipher(Object.assign(new CipherView(), { id: singleCipherId }));
+
+        await expect(result).resolves.toEqual({
+          cipherId: singleCipherId,
+          userVerified: true,
+        });
+        expect(desktopSettingsService.setModalMode).toHaveBeenCalledWith(
+          true,
+          expect.anything(),
+          expect.anything(),
+        );
+      });
+
+      it("does not prompt when the user unlocked their vault during this assertion ceremony", async () => {
+        stubSingleCipher();
+        activeAccountStatus$.next(AuthenticationStatus.Locked);
+
+        const unlocked = session.ensureUnlockedVault();
+        await tick();
+        activeAccountStatus$.next(AuthenticationStatus.Unlocked);
+        await unlocked;
+
+        await expect(pickSingleCredential()).resolves.toEqual({
+          cipherId: singleCipherId,
+          userVerified: true,
+        });
+        expect(userVerificationService.verify).not.toHaveBeenCalled();
       });
     });
 
-    it("does not prompt when the relying party did not ask for verification", async () => {
-      const result = session.confirmNewCredential({
-        ...confirmNewCredentialParams,
-        userVerification: false,
+    describe("registration", () => {
+      it("attaches the prompt to the Bitwarden window while our own UI is showing", async () => {
+        userVerificationService.verify.mockResolvedValue(true);
+
+        const result = session.confirmNewCredential(confirmNewCredentialParams);
+        await tick();
+        session.notifyConfirmCreateCredential(true, Object.assign(new CipherView(), { id: "c1" }));
+        await result;
+
+        expect(userVerificationService.verify).toHaveBeenCalledWith(
+          expect.objectContaining({
+            operation: "overwrite",
+            rpId: "example.com",
+            requestContext: "request-context",
+            windowHandle: new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]),
+          }),
+          expect.anything(),
+        );
       });
-      await tick();
-      session.notifyConfirmCreateCredential(true, Object.assign(new CipherView(), { id: "c1" }));
 
-      await expect(result).resolves.toEqual({ cipherId: "c1", userVerified: false });
-      expect(userVerificationService.verify).not.toHaveBeenCalled();
-    });
+      it("rejects credential creation as NotAllowed when the user dismisses the prompt", async () => {
+        userVerificationService.verify.mockRejectedValue(new UserVerificationCanceled());
 
-    it("does not prompt when the user unlocked their vault during this ceremony", async () => {
-      activeAccountStatus$.next(AuthenticationStatus.Locked);
+        const result = session.confirmNewCredential(confirmNewCredentialParams);
+        await tick();
+        session.notifyConfirmCreateCredential(true, Object.assign(new CipherView(), { id: "c1" }));
 
-      const unlocked = session.ensureUnlockedVault();
-      await tick();
-      activeAccountStatus$.next(AuthenticationStatus.Unlocked);
-      await unlocked;
-
-      const result = session.confirmNewCredential(confirmNewCredentialParams);
-      await tick();
-      session.notifyConfirmCreateCredential(true, Object.assign(new CipherView(), { id: "c1" }));
-
-      await expect(result).resolves.toEqual({ cipherId: "c1", userVerified: true });
-      expect(userVerificationService.verify).not.toHaveBeenCalled();
-    });
-
-    it("verifies via master-password reprompt instead of the OS for a reprompt-protected cipher", async () => {
-      passwordRepromptService.showPasswordPrompt.mockResolvedValue(true);
-
-      const result = pickCredentialFromList();
-      await tick();
-      session.confirmChosenCipher(repromptCipher(singleCipherId));
-
-      await expect(result).resolves.toEqual({ cipherId: singleCipherId, userVerified: true });
-      expect(passwordRepromptService.showPasswordPrompt).toHaveBeenCalled();
-      expect(userVerificationService.verify).not.toHaveBeenCalled();
-    });
-
-    it("rejects the ceremony as NotAllowed when the master-password reprompt is dismissed", async () => {
-      passwordRepromptService.showPasswordPrompt.mockResolvedValue(false);
-
-      const result = pickCredentialFromList();
-      await tick();
-      session.confirmChosenCipher(repromptCipher(singleCipherId));
-
-      await expect(result).rejects.toMatchObject({
-        errorCode: Fido2AuthenticatorErrorCode.NotAllowed,
+        await expect(result).rejects.toMatchObject({
+          errorCode: Fido2AuthenticatorErrorCode.NotAllowed,
+        });
       });
-      expect(userVerificationService.verify).not.toHaveBeenCalled();
-    });
 
-    it("ignores the master password reprompt flag and verifies through the OS when the account has no master password", async () => {
-      passwordRepromptService.enabled.mockResolvedValue(false);
-      userVerificationService.verify.mockResolvedValue(true);
+      it("does not prompt when the relying party did not ask for verification", async () => {
+        const result = session.confirmNewCredential({
+          ...confirmNewCredentialParams,
+          userVerification: false,
+        });
+        await tick();
+        session.notifyConfirmCreateCredential(true, Object.assign(new CipherView(), { id: "c1" }));
 
-      const result = pickCredentialFromList();
-      await tick();
-      session.confirmChosenCipher(repromptCipher(singleCipherId));
-
-      await expect(result).resolves.toEqual({ cipherId: singleCipherId, userVerified: true });
-      expect(passwordRepromptService.showPasswordPrompt).not.toHaveBeenCalled();
-      expect(userVerificationService.verify).toHaveBeenCalled();
-    });
-
-    it("refuses the ceremony when the cipher uses an unrecognized reprompt type", async () => {
-      const result = pickCredentialFromList();
-      await tick();
-      session.confirmChosenCipher(
-        Object.assign(new CipherView(), { id: singleCipherId, reprompt: 99 }),
-      );
-
-      await expect(result).rejects.toMatchObject({
-        errorCode: Fido2AuthenticatorErrorCode.NotAllowed,
+        await expect(result).resolves.toEqual({ cipherId: "c1", userVerified: false });
+        expect(userVerificationService.verify).not.toHaveBeenCalled();
       });
-      expect(passwordRepromptService.showPasswordPrompt).not.toHaveBeenCalled();
-      expect(userVerificationService.verify).not.toHaveBeenCalled();
-    });
 
-    it("verifies a reprompt-protected cipher via master-password reprompt during creation", async () => {
-      passwordRepromptService.showPasswordPrompt.mockResolvedValue(true);
-      const existing = repromptCipher(singleCipherId);
+      it("does not prompt when the user unlocked their vault during this registration ceremony", async () => {
+        activeAccountStatus$.next(AuthenticationStatus.Locked);
 
-      const result = session.confirmNewCredential({
-        ...confirmNewCredentialParams,
-        userVerification: false,
+        const unlocked = session.ensureUnlockedVault();
+        await tick();
+        activeAccountStatus$.next(AuthenticationStatus.Unlocked);
+        await unlocked;
+
+        const result = session.confirmNewCredential(confirmNewCredentialParams);
+        await tick();
+        session.notifyConfirmCreateCredential(true, Object.assign(new CipherView(), { id: "c1" }));
+
+        await expect(result).resolves.toEqual({ cipherId: "c1", userVerified: true });
+        expect(userVerificationService.verify).not.toHaveBeenCalled();
       });
-      await tick();
-      session.notifyConfirmCreateCredential(true, existing);
 
-      await expect(result).resolves.toEqual({ cipherId: singleCipherId, userVerified: true });
-      expect(passwordRepromptService.showPasswordPrompt).toHaveBeenCalled();
-      expect(userVerificationService.verify).not.toHaveBeenCalled();
-      expect(cipherService.updateWithServer).toHaveBeenCalledWith(existing, "user-1");
-    });
+      it("verifies via master-password reprompt instead of the OS for a reprompt-protected cipher", async () => {
+        passwordRepromptService.showPasswordPrompt.mockResolvedValue(true);
 
-    it("skips the master-password reprompt when the account has no master password", async () => {
-      passwordRepromptService.enabled.mockResolvedValue(false);
-      userVerificationService.verify.mockResolvedValue(true);
+        const result = pickCredentialFromList();
+        await tick();
+        session.confirmChosenCipher(repromptCipher(singleCipherId));
 
-      const result = session.confirmNewCredential(confirmNewCredentialParams);
-      await tick();
-      session.notifyConfirmCreateCredential(true, repromptCipher(singleCipherId));
-      await result;
+        await expect(result).resolves.toEqual({ cipherId: singleCipherId, userVerified: true });
+        expect(passwordRepromptService.showPasswordPrompt).toHaveBeenCalled();
+        expect(userVerificationService.verify).not.toHaveBeenCalled();
+      });
 
-      expect(passwordRepromptService.showPasswordPrompt).not.toHaveBeenCalled();
+      it("rejects the ceremony as NotAllowed when the master-password reprompt is dismissed", async () => {
+        passwordRepromptService.showPasswordPrompt.mockResolvedValue(false);
+
+        const result = pickCredentialFromList();
+        await tick();
+        session.confirmChosenCipher(repromptCipher(singleCipherId));
+
+        await expect(result).rejects.toMatchObject({
+          errorCode: Fido2AuthenticatorErrorCode.NotAllowed,
+        });
+        expect(userVerificationService.verify).not.toHaveBeenCalled();
+      });
+
+      it("ignores the master password reprompt flag and verifies through the OS when the account has no master password", async () => {
+        passwordRepromptService.enabled.mockResolvedValue(false);
+        userVerificationService.verify.mockResolvedValue(true);
+
+        const result = pickCredentialFromList();
+        await tick();
+        session.confirmChosenCipher(repromptCipher(singleCipherId));
+
+        await expect(result).resolves.toEqual({ cipherId: singleCipherId, userVerified: true });
+        expect(passwordRepromptService.showPasswordPrompt).not.toHaveBeenCalled();
+        expect(userVerificationService.verify).toHaveBeenCalled();
+      });
+
+      it("refuses the ceremony when the cipher uses an unrecognized reprompt type", async () => {
+        const result = pickCredentialFromList();
+        await tick();
+        session.confirmChosenCipher(
+          Object.assign(new CipherView(), { id: singleCipherId, reprompt: 99 }),
+        );
+
+        await expect(result).rejects.toMatchObject({
+          errorCode: Fido2AuthenticatorErrorCode.NotAllowed,
+        });
+        expect(passwordRepromptService.showPasswordPrompt).not.toHaveBeenCalled();
+        expect(userVerificationService.verify).not.toHaveBeenCalled();
+      });
+
+      it("verifies a reprompt-protected cipher via master-password reprompt during creation", async () => {
+        passwordRepromptService.showPasswordPrompt.mockResolvedValue(true);
+        const existing = repromptCipher(singleCipherId);
+
+        const result = session.confirmNewCredential({
+          ...confirmNewCredentialParams,
+          userVerification: false,
+        });
+        await tick();
+        session.notifyConfirmCreateCredential(true, existing);
+
+        await expect(result).resolves.toEqual({ cipherId: singleCipherId, userVerified: true });
+        expect(passwordRepromptService.showPasswordPrompt).toHaveBeenCalled();
+        expect(userVerificationService.verify).not.toHaveBeenCalled();
+        expect(cipherService.updateWithServer).toHaveBeenCalledWith(existing, "user-1");
+      });
+
+      it("skips the master-password reprompt when the account has no master password", async () => {
+        passwordRepromptService.enabled.mockResolvedValue(false);
+        userVerificationService.verify.mockResolvedValue(true);
+
+        const result = session.confirmNewCredential(confirmNewCredentialParams);
+        await tick();
+        session.notifyConfirmCreateCredential(true, repromptCipher(singleCipherId));
+        await result;
+
+        expect(passwordRepromptService.showPasswordPrompt).not.toHaveBeenCalled();
+      });
     });
   });
 });

--- a/apps/desktop/src/autofill/services/desktop-fido2-user-interface.service.ts
+++ b/apps/desktop/src/autofill/services/desktop-fido2-user-interface.service.ts
@@ -199,42 +199,41 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
   private uiShown = false;
 
   // Method implementation
-  async pickCredential({
-    cipherIds,
-    userVerification,
-    assumeUserPresence,
-    masterPasswordRepromptRequired,
-  }: PickCredentialParams): Promise<{ cipherId: string | undefined; userVerified: boolean }> {
-    this.logService.debug("pickCredential desktop function", {
-      cipherIds,
-      userVerification,
-      assumeUserPresence,
-      masterPasswordRepromptRequired,
-    });
+  async pickCredential(
+    params: PickCredentialParams,
+  ): Promise<{ cipherId: string | undefined; userVerified: boolean }> {
+    this.logService.debug("pickCredential desktop function", params);
 
     try {
-      // Check if we can return the credential without user interaction
-      if (assumeUserPresence && cipherIds.length === 1 && !masterPasswordRepromptRequired) {
-        this.logService.debug(
-          "shortcut - Assuming user presence and returning cipherId",
-          cipherIds[0],
+      const abortSignal = this.abortController.signal;
+      if (abortSignal.aborted) {
+        this.logService.warning(
+          "[DesktopFido2UserInterfaceSession]",
+          "Request was cancelled before a credential was selected",
         );
-        return { cipherId: cipherIds[0], userVerified: userVerification };
+        return { cipherId: undefined, userVerified: false };
+      }
+
+      // Check if we can return the credential without user interaction
+      const response = await this.tryWithoutUserInteraction(params, {
+        signal: abortSignal,
+      });
+      if (response) {
+        return response;
       }
 
       this.logService.debug("Could not shortcut, showing UI");
 
       // make the cipherIds available to the UI.
-      this.availableCipherIdsSubject.next(cipherIds);
+      this.availableCipherIdsSubject.next(params.cipherIds);
 
       await this.showUi("/fido2-assertion", this.windowObject.windowXy, false);
 
       // TODO: Extend this to the deadline indicated by the timeout on the WebAuthn request.
       const chosenCipherTimeout = AbortSignal.timeout(60 * 1000);
       const chosenCipher = await this.waitForUiChosenCipher({
-        signal: AbortSignal.any([this.abortController.signal, chosenCipherTimeout]),
+        signal: AbortSignal.any([abortSignal, chosenCipherTimeout]),
       });
-
       this.logService.debug("Received chosen cipher", chosenCipher?.id);
 
       if (!chosenCipher) {
@@ -245,9 +244,9 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
       const userVerified = await this.verifyUser(
         "assertion",
         username,
-        userVerification,
+        params.userVerification,
         chosenCipher,
-        { signal: this.abortController.signal },
+        { signal: abortSignal },
       );
 
       return { cipherId: chosenCipher.id, userVerified };
@@ -266,6 +265,108 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
   confirmChosenCipher(cipher?: CipherView): void {
     this.chosenCipherSubject.next(cipher);
     this.chosenCipherSubject.complete();
+  }
+
+  /**
+   * Attempts to satisfy user verification without prompting the Bitwarden
+   * app UI. OS user verification dialogs still may appear.
+   *
+   * @param params Parameters for the assertion flow.
+   * @param options Includes a signal to cancel the UI flow.
+   * @returns The selected cipherId and user verification result, or `undefined` if UI was required.
+   */
+  private async tryWithoutUserInteraction(
+    params: PickCredentialParams,
+    { signal }: { signal: AbortSignal },
+  ): Promise<{ cipherId: string; userVerified: boolean } | undefined> {
+    signal.throwIfAborted();
+
+    const canRetrieveSilently =
+      params.cipherIds.length === 1 && !params.masterPasswordRepromptRequired;
+    if (!canRetrieveSilently) {
+      return undefined;
+    }
+
+    const selectedCipherId = params.cipherIds[0];
+    const needsUserVerification = params.userVerification;
+
+    if (needsUserVerification) {
+      // retrieve the cipher from the active account
+      const activeUserId = await firstValueFrom(
+        this.accountService.activeAccount$.pipe(map((a) => a?.id)),
+      );
+
+      if (!activeUserId) {
+        return;
+      }
+      const cipherView = await firstValueFrom(
+        this.cipherService.cipherListViews$(activeUserId).pipe(
+          map((ciphers) => {
+            return ciphers.find((cipher) => cipher.id == selectedCipherId && !cipher.deletedDate);
+          }),
+          throwOnAbort(signal),
+        ),
+      );
+
+      if (!cipherView) {
+        this.logService.warning(
+          "[DesktopFido2UserInterfaceSession]",
+          `Could not find an active cipher for ID: ${selectedCipherId}`,
+        );
+        return undefined;
+      }
+
+      // Reprompts require showing Bitwarden UI, so stop if we detect that.
+      if (cipherView.reprompt !== CipherRepromptType.None) {
+        return undefined;
+      }
+
+      const username = fido2UserNameFromCipher(cipherView);
+
+      // Prompt the user to verify themselves. An OS user verification dialog
+      // may be shown, or if the user unlocked their vault during the ceremony,
+      // this should succeed without further prompts.
+      try {
+        const userVerified = await this.verifyUser(
+          "assertion",
+          username,
+          params.userVerification,
+          cipherView,
+          { signal },
+        );
+        const response = { cipherId: selectedCipherId, userVerified };
+        this.logService.debug(
+          "[DesktopFido2UserInterfaceSession]",
+          "tryWithoutUserInteraction() succeeded",
+          response,
+        );
+        return response;
+      } catch (error) {
+        // A dismissed prompt or a cipher we refuse to use ends the ceremony
+        // outright; only a recoverable failure falls back to the picker.
+        if (error instanceof UserVerificationCanceled || error instanceof Fido2AuthenticatorError) {
+          throw error;
+        }
+        // Fall back to showing the picker, which offers the user another way
+        // through the ceremony.
+        this.logService.debug(
+          "[DesktopFido2UserInterfaceSession]",
+          "Failed to prompt for user verification without showing UI",
+          error,
+        );
+        return undefined;
+      }
+    } else if (params.assumeUserPresence) {
+      // If user verification is not required by the RP, and the user did some
+      // selection in the OS dialog, we use that interaction as satisfying user
+      // presence, and continue with UV = false.
+      this.logService.debug(
+        "[DesktopFido2UserInterfaceSession]",
+        "shortcut - Assuming user presence and returning cipherId",
+        selectedCipherId,
+      );
+      return { cipherId: selectedCipherId, userVerified: false };
+    }
   }
 
   private async waitForUiChosenCipher({
@@ -335,7 +436,10 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
     userHandle,
     userVerification: needsUserVerification,
     rpId,
-  }: NewCredentialParams): Promise<{ cipherId: string | undefined; userVerified: boolean }> {
+  }: NewCredentialParams): Promise<{
+    cipherId: string | undefined;
+    userVerified: boolean;
+  }> {
     this.logService.debug(
       "confirmNewCredential",
       credentialName,
@@ -348,6 +452,7 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
 
     const abortSignal = this.abortController.signal;
     try {
+      abortSignal.throwIfAborted();
       await this.showUi("/fido2-creation", this.windowObject.windowXy, false);
 
       // Wait for the UI to wrap up
@@ -597,6 +702,8 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
     cipher: CipherViewLike | undefined,
     { signal }: { signal: AbortSignal },
   ): Promise<boolean> {
+    signal.throwIfAborted();
+
     const repromptType = cipher?.reprompt ?? CipherRepromptType.None;
     switch (repromptType) {
       case CipherRepromptType.None:

--- a/apps/desktop/src/autofill/services/desktop-fido2-user-interface.service.ts
+++ b/apps/desktop/src/autofill/services/desktop-fido2-user-interface.service.ts
@@ -199,42 +199,34 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
   private uiShown = false;
 
   // Method implementation
-  async pickCredential({
-    cipherIds,
-    userVerification,
-    assumeUserPresence,
-    masterPasswordRepromptRequired,
-  }: PickCredentialParams): Promise<{ cipherId: string | undefined; userVerified: boolean }> {
-    this.logService.debug("pickCredential desktop function", {
-      cipherIds,
-      userVerification,
-      assumeUserPresence,
-      masterPasswordRepromptRequired,
-    });
+  async pickCredential(
+    params: PickCredentialParams,
+  ): Promise<{ cipherId: string | undefined; userVerified: boolean }> {
+    this.logService.debug("pickCredential desktop function", params);
+
+    const abortSignal = this.abortController.signal;
 
     try {
       // Check if we can return the credential without user interaction
-      if (assumeUserPresence && cipherIds.length === 1 && !masterPasswordRepromptRequired) {
-        this.logService.debug(
-          "shortcut - Assuming user presence and returning cipherId",
-          cipherIds[0],
-        );
-        return { cipherId: cipherIds[0], userVerified: userVerification };
+      const response = await this.tryWithoutUserInteraction(params, {
+        signal: abortSignal,
+      });
+      if (response) {
+        return response;
       }
 
       this.logService.debug("Could not shortcut, showing UI");
 
       // make the cipherIds available to the UI.
-      this.availableCipherIdsSubject.next(cipherIds);
+      this.availableCipherIdsSubject.next(params.cipherIds);
 
       await this.showUi("/fido2-assertion", this.windowObject.windowXy, false);
 
       // TODO: Extend this to the deadline indicated by the timeout on the WebAuthn request.
       const chosenCipherTimeout = AbortSignal.timeout(60 * 1000);
       const chosenCipher = await this.waitForUiChosenCipher({
-        signal: AbortSignal.any([this.abortController.signal, chosenCipherTimeout]),
+        signal: AbortSignal.any([abortSignal, chosenCipherTimeout]),
       });
-
       this.logService.debug("Received chosen cipher", chosenCipher?.id);
 
       if (!chosenCipher) {
@@ -245,9 +237,9 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
       const userVerified = await this.verifyUser(
         "assertion",
         username,
-        userVerification,
+        params.userVerification,
         chosenCipher,
-        { signal: this.abortController.signal },
+        { signal: abortSignal },
       );
 
       return { cipherId: chosenCipher.id, userVerified };
@@ -266,6 +258,84 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
   confirmChosenCipher(cipher?: CipherView): void {
     this.chosenCipherSubject.next(cipher);
     this.chosenCipherSubject.complete();
+  }
+
+  private async tryWithoutUserInteraction(
+    params: PickCredentialParams,
+    { signal }: { signal: AbortSignal },
+  ): Promise<{ cipherId: string; userVerified: boolean } | undefined> {
+    const canRetrieveSilently =
+      params.cipherIds.length === 1 && !params.masterPasswordRepromptRequired;
+    if (!canRetrieveSilently) {
+      return undefined;
+    }
+
+    const selectedCipherId = params.cipherIds[0];
+
+    if (params.userVerification) {
+      // retrieve the cipher
+      const activeUserId = await firstValueFrom(
+        this.accountService.activeAccount$.pipe(map((a) => a?.id)),
+      );
+
+      if (!activeUserId) {
+        return;
+      }
+      const cipherView = await firstValueFrom(
+        this.cipherService.cipherListViews$(activeUserId).pipe(
+          map((ciphers) => {
+            return ciphers.find((cipher) => cipher.id == selectedCipherId && !cipher.deletedDate);
+          }),
+        ),
+      );
+
+      if (!cipherView) {
+        this.logService.warning(
+          "[DesktopFido2UserInterfaceSession]",
+          `Could not find an active cipher for ID: ${selectedCipherId}`,
+        );
+        return undefined;
+      }
+
+      const username = fido2UserNameFromCipher(cipherView);
+      try {
+        const userVerified = await this.verifyUser(
+          "assertion",
+          username,
+          params.userVerification,
+          cipherView,
+          { signal },
+        );
+        const response = { cipherId: selectedCipherId, userVerified };
+        this.logService.debug(
+          "[DesktopFido2UserInterfaceSession]",
+          "tryWithoutUserInteraction() succeeded",
+          response,
+        );
+        return response;
+      } catch (error) {
+        // A dismissed prompt or a cipher we refuse to use ends the ceremony
+        // outright; only a recoverable failure falls back to the picker.
+        if (error instanceof UserVerificationCanceled || error instanceof Fido2AuthenticatorError) {
+          throw error;
+        }
+        // Fall back to showing the picker, which offers the user another way
+        // through the ceremony.
+        this.logService.debug(
+          "[DesktopFido2UserInterfaceSession]",
+          "Failed to prompt for user verification without showing UI",
+          error,
+        );
+        return undefined;
+      }
+    } else if (params.assumeUserPresence) {
+      this.logService.debug(
+        "[DesktopFido2UserInterfaceSession]",
+        "shortcut - Assuming user presence and returning cipherId",
+        selectedCipherId,
+      );
+      return { cipherId: selectedCipherId, userVerified: false };
+    }
   }
 
   private async waitForUiChosenCipher({
@@ -335,7 +405,10 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
     userHandle,
     userVerification: needsUserVerification,
     rpId,
-  }: NewCredentialParams): Promise<{ cipherId: string | undefined; userVerified: boolean }> {
+  }: NewCredentialParams): Promise<{
+    cipherId: string | undefined;
+    userVerified: boolean;
+  }> {
     this.logService.debug(
       "confirmNewCredential",
       credentialName,


### PR DESCRIPTION
## 🎟️ Tracking

[PM-29791](https://bitwarden.atlassian.net/browse/PM-29791)

## 📔 Objective

This implements the business for native OS user verification for passkeys.

- Defines business logic for user verification, centralizing logic for verifying via master password reprompt, vault unlock method or OS native user verification
- Allows keeping the Bitwarden window hidden on assertion if 1 passkey is selected and the vault is unlocked
- If the vault is unlocked for the passkey ceremony, the user is not re-prompted for user verification
- Adds a user verification service abstraction that each OS will implement/override.

For now, there is a no-op UV implementation that always returns false. macOS and Windows implementations will come in subsequent PRs.

[PM-29791]: https://bitwarden.atlassian.net/browse/PM-29791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ