### PR TITLE
desktop-autofill: macOS native user verification [PM-29791]

### DIFF
--- a/apps/desktop/desktop_native/objc/src/native/autofill/commands/user_verification.h
+++ b/apps/desktop/desktop_native/objc/src/native/autofill/commands/user_verification.h
@@ -1,0 +1,8 @@
+#ifndef USER_VERIFICATION_H
+#define USER_VERIFICATION_H
+
+#import <Foundation/Foundation.h>
+
+void userVerification(void *context, NSDictionary *params);
+
+#endif

--- a/apps/desktop/desktop_native/objc/src/native/autofill/commands/user_verification.m
+++ b/apps/desktop/desktop_native/objc/src/native/autofill/commands/user_verification.m
@@ -1,0 +1,41 @@
+#import <Foundation/Foundation.h>
+#import <LocalAuthentication/LocalAuthentication.h>
+#import "../../interop.h"
+#import "user_verification.h"
+
+void userVerification(void* context, NSDictionary *params) {
+  NSString *displayHint = params[@"displayHint"];
+  if (displayHint == nil) {
+    return _return(context, _error(@"No display hint was provided for the user verification prompt"));
+  }
+
+  LAContext *uvContext = [[LAContext alloc] init];
+  // The device password is accepted alongside biometrics so that machines with
+  // no enrolled biometric can still complete a passkey ceremony.
+  LAPolicy policy = LAPolicyDeviceOwnerAuthentication;
+
+  NSError *error = nil;
+  if (![uvContext canEvaluatePolicy:policy error:&error]) {
+    return _return(context, _error_er(error));
+  }
+
+  [uvContext evaluatePolicy:policy
+            localizedReason:displayHint
+                      reply:^(BOOL success, NSError *_Nullable replyError) {
+    if (success) {
+      return _return(context, _success(@{@"outcome": @"verified"}));
+    }
+
+    // Dismissing the prompt is an answer, not a failure, so it is reported as
+    // an outcome the caller can act on rather than an error indistinguishable
+    // from a broken request.
+    switch (replyError.code) {
+      case LAErrorUserCancel:
+      case LAErrorSystemCancel:
+      case LAErrorAppCancel:
+        return _return(context, _success(@{@"outcome": @"cancelled"}));
+      default:
+        return _return(context, _error_er(replyError));
+    }
+  }];
+}

--- a/apps/desktop/desktop_native/objc/src/native/autofill/run_autofill_command.m
+++ b/apps/desktop/desktop_native/objc/src/native/autofill/run_autofill_command.m
@@ -1,6 +1,7 @@
 #import <Foundation/Foundation.h>
 #import "commands/sync.h"
 #import "commands/status.h"
+#import "commands/user_verification.h"
 #import "../interop.h"
 #import "../utils.h"
 #import "run_autofill_command.h"
@@ -13,6 +14,9 @@ void runAutofillCommand(void* context, NSDictionary *input) {
     return status(context, params);
   } else if ([command isEqual:@"sync"]) {
     return runSync(context, params);
+  }
+  else if ([command isEqual:@"userVerification"]) {
+    return userVerification(context, params);
   }
 
   _return(context, _error([NSString stringWithFormat:@"Unknown command: %@", command]));

--- a/apps/desktop/src/app/services/services.module.ts
+++ b/apps/desktop/src/app/services/services.module.ts
@@ -59,7 +59,7 @@ import { WebAuthnLoginPrfKeyServiceAbstraction } from "@bitwarden/common/auth/ab
 import { PendingAuthRequestsStateService } from "@bitwarden/common/auth/services/auth-request-answering/pending-auth-requests.state";
 import { AutofillSettingsServiceAbstraction } from "@bitwarden/common/autofill/services/autofill-settings.service";
 import { BillingAccountProfileStateService } from "@bitwarden/common/billing/abstractions";
-import { ClientType } from "@bitwarden/common/enums";
+import { ClientType, DeviceType } from "@bitwarden/common/enums";
 import { ProcessReloadServiceAbstraction } from "@bitwarden/common/key-management/abstractions/process-reload.service";
 import { AccountCryptographicStateService } from "@bitwarden/common/key-management/account-cryptography/account-cryptographic-state.service";
 import {
@@ -162,6 +162,7 @@ import { DesktopAutofillSettingsService } from "../../autofill/services/desktop-
 import { DesktopAutofillService } from "../../autofill/services/desktop-autofill.service";
 import { DesktopAutotypeMvpService } from "../../autofill/services/desktop-autotype-mvp.service";
 import { DesktopAutotypeDefaultSettingPolicy } from "../../autofill/services/desktop-autotype-policy.service";
+import { DesktopFido2MacOsUserVerificationService } from "../../autofill/services/desktop-fido2-macos-user-verification.service";
 import { DesktopFido2UnsupportedUserVerificationService } from "../../autofill/services/desktop-fido2-unsupported-user-verification.service";
 import { DesktopFido2UserInterfaceService } from "../../autofill/services/desktop-fido2-user-interface.service";
 import { DesktopFido2UserVerificationService } from "../../autofill/services/desktop-fido2-user-verification.service.abstraction";
@@ -441,8 +442,19 @@ const safeProviders: SafeProvider[] = [
   }),
   safeProvider({
     provide: DesktopFido2UserVerificationService,
-    useClass: DesktopFido2UnsupportedUserVerificationService,
-    deps: [LogServiceAbstraction],
+    useFactory: (
+      platformUtilsService: PlatformUtilsServiceAbstraction,
+      i18nService: I18nServiceAbstraction,
+      logService: LogServiceAbstraction,
+    ): DesktopFido2UserVerificationService => {
+      switch (platformUtilsService.getDevice()) {
+        case DeviceType.MacOsDesktop:
+          return new DesktopFido2MacOsUserVerificationService(i18nService, logService);
+        default:
+          return new DesktopFido2UnsupportedUserVerificationService(logService);
+      }
+    },
+    deps: [PlatformUtilsServiceAbstraction, I18nServiceAbstraction, LogServiceAbstraction],
   }),
   safeProvider({
     provide: DesktopFido2UserInterfaceService,

--- a/apps/desktop/src/app/services/services.module.ts
+++ b/apps/desktop/src/app/services/services.module.ts
@@ -59,7 +59,7 @@ import { WebAuthnLoginPrfKeyServiceAbstraction } from "@bitwarden/common/auth/ab
 import { PendingAuthRequestsStateService } from "@bitwarden/common/auth/services/auth-request-answering/pending-auth-requests.state";
 import { AutofillSettingsServiceAbstraction } from "@bitwarden/common/autofill/services/autofill-settings.service";
 import { BillingAccountProfileStateService } from "@bitwarden/common/billing/abstractions";
-import { ClientType } from "@bitwarden/common/enums";
+import { ClientType, DeviceType } from "@bitwarden/common/enums";
 import { ProcessReloadServiceAbstraction } from "@bitwarden/common/key-management/abstractions/process-reload.service";
 import { AccountCryptographicStateService } from "@bitwarden/common/key-management/account-cryptography/account-cryptographic-state.service";
 import { KeyGenerationService } from "@bitwarden/common/key-management/crypto";
@@ -159,6 +159,7 @@ import { DesktopAutofillSettingsService } from "../../autofill/services/desktop-
 import { DesktopAutofillService } from "../../autofill/services/desktop-autofill.service";
 import { DesktopAutotypeDefaultSettingPolicy } from "../../autofill/services/desktop-autotype-policy.service";
 import { DesktopAutotypeService } from "../../autofill/services/desktop-autotype.service";
+import { DesktopFido2MacOsUserVerificationService } from "../../autofill/services/desktop-fido2-macos-user-verification.service";
 import { DesktopFido2UnsupportedUserVerificationService } from "../../autofill/services/desktop-fido2-unsupported-user-verification.service";
 import { DesktopFido2UserInterfaceService } from "../../autofill/services/desktop-fido2-user-interface.service";
 import { DesktopFido2UserVerificationService } from "../../autofill/services/desktop-fido2-user-verification.service.abstraction";
@@ -442,8 +443,19 @@ const safeProviders: SafeProvider[] = [
   }),
   safeProvider({
     provide: DesktopFido2UserVerificationService,
-    useClass: DesktopFido2UnsupportedUserVerificationService,
-    deps: [LogServiceAbstraction],
+    useFactory: (
+      platformUtilsService: PlatformUtilsServiceAbstraction,
+      i18nService: I18nServiceAbstraction,
+      logService: LogServiceAbstraction,
+    ): DesktopFido2UserVerificationService => {
+      switch (platformUtilsService.getDevice()) {
+        case DeviceType.MacOsDesktop:
+          return new DesktopFido2MacOsUserVerificationService(i18nService, logService);
+        default:
+          return new DesktopFido2UnsupportedUserVerificationService(logService);
+      }
+    },
+    deps: [PlatformUtilsServiceAbstraction, I18nServiceAbstraction, LogServiceAbstraction],
   }),
   safeProvider({
     provide: DesktopFido2UserInterfaceService,

--- a/apps/desktop/src/autofill/services/desktop-fido2-macos-user-verification.service.ts
+++ b/apps/desktop/src/autofill/services/desktop-fido2-macos-user-verification.service.ts
@@ -1,0 +1,36 @@
+import { MacOsAutofillUserVerificationParams } from "../models/autofill-user-verification.command";
+
+import {
+  Fido2UserVerificationOperation,
+  Fido2UserVerificationRequest,
+} from "./desktop-fido2-user-verification.service.abstraction";
+import { DesktopFido2UserVerificationServiceBase } from "./desktop-fido2-user-verification.service.base";
+
+/**
+ * Verifies the user with Touch ID or the device password through
+ * `LocalAuthentication`.
+ *
+ * See `apps/desktop/desktop_native/objc/src/native/autofill/commands/user_verification.m`
+ * for the native implementation.
+ */
+export class DesktopFido2MacOsUserVerificationService extends DesktopFido2UserVerificationServiceBase {
+  protected readonly logPrefix = "[DesktopFido2MacOsUserVerificationService]";
+
+  /** macOS attaches the prompt to the active application, not to a window. */
+  protected buildParams(
+    request: Fido2UserVerificationRequest,
+  ): MacOsAutofillUserVerificationParams {
+    return {
+      username: request.username,
+      displayHint: this.displayHint(request),
+    };
+  }
+
+  protected messageKey(operation: Fido2UserVerificationOperation): string {
+    return {
+      registration: "confirmPasskeyRegistrationMacOS",
+      overwrite: "confirmPasskeyOverwriteMacOS",
+      assertion: "confirmPasskeyAssertionMacOS",
+    }[operation];
+  }
+}

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -6358,5 +6358,47 @@
         "example": "Login"
       }
     }
+  },
+  "confirmPasskeyRegistrationMacOS": {
+    "message": "create a new $RPID$ passkey for $USERNAME$",
+    "description": "Prompt for the user to create a passkey. Shown in macOS Touch ID prompt as \"Bitwarden is trying to {message}.\", so sentence capitalization and ending punctuation should be omitted.",
+    "placeholders": {
+      "rpId": {
+        "content": "$1",
+        "example": "example.com"
+      },
+      "username": {
+        "content": "$2",
+        "example": "user@acme.com"
+      }
+    }
+  },
+  "confirmPasskeyOverwriteMacOS": {
+    "message": "overwrite a $RPID$ passkey for $USERNAME$",
+    "description": "Prompt for the user to overwrite an existing passkey. Shown in macOS Touch ID prompt as \"Bitwarden is trying to {message}.\", so sentence capitalization and ending punctuation should be omitted.",
+    "placeholders": {
+      "rpId": {
+        "content": "$1",
+        "example": "example.com"
+      },
+      "username": {
+        "content": "$2",
+        "example": "user@acme.com"
+      }
+    }
+  },
+  "confirmPasskeyAssertionMacOS": {
+    "message": "sign in as $USERNAME$ with your $RPID$ passkey",
+    "description": "Prompt for the user to use a passkey. Shown in macOS Touch ID prompt as \"Bitwarden is trying to {message}.\", so sentence capitalization and ending punctuation should be omitted.",
+    "placeholders": {
+      "rpId": {
+        "content": "$1",
+        "example": "example.com"
+      },
+      "username": {
+        "content": "$2",
+        "example": "user@acme.com"
+      }
+    }
   }
 }

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -6303,5 +6303,47 @@
         "example": "Login"
       }
     }
+  },
+  "confirmPasskeyRegistrationMacOS": {
+    "message": "create a new $RPID$ passkey for $USERNAME$",
+    "description": "Prompt for the user to create a passkey. Shown in macOS Touch ID prompt as \"Bitwarden is trying to {message}.\", so sentence capitalization and ending punctuation should be omitted.",
+    "placeholders": {
+      "rpId": {
+        "content": "$1",
+        "example": "example.com"
+      },
+      "username": {
+        "content": "$2",
+        "example": "user@acme.com"
+      }
+    }
+  },
+  "confirmPasskeyOverwriteMacOS": {
+    "message": "overwrite a $RPID$ passkey for $USERNAME$",
+    "description": "Prompt for the user to overwrite an existing passkey. Shown in macOS Touch ID prompt as \"Bitwarden is trying to {message}.\", so sentence capitalization and ending punctuation should be omitted.",
+    "placeholders": {
+      "rpId": {
+        "content": "$1",
+        "example": "example.com"
+      },
+      "username": {
+        "content": "$2",
+        "example": "user@acme.com"
+      }
+    }
+  },
+  "confirmPasskeyAssertionMacOS": {
+    "message": "sign in as $USERNAME$ with your $RPID$ passkey",
+    "description": "Prompt for the user to use a passkey. Shown in macOS Touch ID prompt as \"Bitwarden is trying to {message}.\", so sentence capitalization and ending punctuation should be omitted.",
+    "placeholders": {
+      "rpId": {
+        "content": "$1",
+        "example": "example.com"
+      },
+      "username": {
+        "content": "$2",
+        "example": "user@acme.com"
+      }
+    }
   }
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-29791](https://bitwarden.atlassian.net/browse/PM-29791)

## 📔 Objective

Implements native macOS user verification

## 📸 Screenshots

Register and assert with a username.

https://github.com/user-attachments/assets/dcf05344-ad3b-4c15-8077-c3f2f90b7d5d

Assert without a username/discoverable credential


https://github.com/user-attachments/assets/b316817c-0bf2-4197-bfe1-b589e4887f2b



[PM-29791]: https://bitwarden.atlassian.net/browse/PM-29791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ