### PR TITLE
desktop-autofill: Windows native user verification [PM-29791]

### DIFF
--- a/apps/desktop/desktop_native/core/src/autofill/windows/mod.rs
+++ b/apps/desktop/desktop_native/core/src/autofill/windows/mod.rs
@@ -1,6 +1,7 @@
 mod context;
 mod status;
 mod sync;
+mod user_verification;
 
 use std::{fs::File, io::Read, path::PathBuf, sync::OnceLock};
 
@@ -9,6 +10,9 @@ pub use context::{create_context_string, parse_context_string};
 use serde::{Deserialize, Serialize};
 use status::{handle_status_request, StatusResponse};
 use sync::{handle_sync_request, SyncParameters, SyncResponse};
+use user_verification::{
+    handle_user_verification_request, UserVerificationParameters, UserVerificationResponse,
+};
 use win_webauthn::plugin::Clsid;
 use windows::{
     core::HRESULT, ApplicationModel::Package, Win32::Foundation::APPMODEL_ERROR_NO_PACKAGE,
@@ -35,6 +39,9 @@ async fn dispatch_command(value: String) -> Result<CommandResponse> {
     tokio::task::spawn_blocking(move || match request.command {
         RunCommand::Status(_) => handle_status_request().map(CommandResponse::from),
         RunCommand::Sync(params) => handle_sync_request(params).map(CommandResponse::from),
+        RunCommand::UserVerification(params) => {
+            handle_user_verification_request(params).map(CommandResponse::from)
+        }
     })
     .await
     .context("Autofill command task failed")?
@@ -54,6 +61,7 @@ struct RunCommandRequest {
 enum RunCommand {
     Status(()),
     Sync(SyncParameters),
+    UserVerification(UserVerificationParameters),
 }
 
 #[derive(Serialize)]
@@ -79,6 +87,7 @@ impl From<anyhow::Result<CommandResponse>> for CommandResult {
 enum CommandResponse {
     Status(StatusResponse),
     Sync(SyncResponse),
+    UserVerification(UserVerificationResponse),
 }
 
 impl From<StatusResponse> for CommandResponse {

--- a/apps/desktop/desktop_native/core/src/autofill/windows/user_verification.rs
+++ b/apps/desktop/desktop_native/core/src/autofill/windows/user_verification.rs
@@ -1,0 +1,125 @@
+use std::ffi::c_void;
+
+use anyhow::{anyhow, Context, Result};
+use serde::{Deserialize, Serialize};
+use serde_with::{
+    base64::{Base64, Standard},
+    formats::Padded,
+    serde_as,
+};
+use win_webauthn::plugin::{PluginUserVerificationRequest, WebAuthnPlugin};
+use windows::Win32::Foundation::HWND;
+
+use super::{get_clsid, parse_context_string, CommandResponse};
+
+pub(super) fn handle_user_verification_request(
+    request: UserVerificationParameters,
+) -> Result<UserVerificationResponse> {
+    // The request carries the username of the credential in use, so it is not
+    // logged here.
+    tracing::debug!("Handling user verification request");
+
+    let Some(clsid) = get_clsid()? else {
+        return Err(anyhow!("[core::autofill::user_verification] UV requested, but no CLSID was found. Skipping request."));
+    };
+
+    let (transaction_id, operation_request_hash) =
+        parse_context_string(&request.transaction_context)
+            .context("Failed to parse transaction context")?;
+
+    let uv_request = PluginUserVerificationRequest {
+        window_handle: parse_window_handle(&request.window_handle)?,
+        transaction_id,
+        user_name: request.username,
+        display_hint: Some(request.display_hint),
+    };
+
+    let plugin = WebAuthnPlugin::new(clsid);
+    match plugin.perform_user_verification(uv_request, &operation_request_hash) {
+        Ok(()) => Ok(UserVerificationResponse {
+            outcome: UserVerificationOutcome::Verified,
+        }),
+        // Dismissing the Windows Hello prompt is an answer, not a failure, so
+        // it is reported as an outcome the caller can act on rather than an
+        // error indistinguishable from a broken request.
+        Err(err) if err.is_user_cancelled() => Ok(UserVerificationResponse {
+            outcome: UserVerificationOutcome::Cancelled,
+        }),
+        Err(err) => Err(anyhow::Error::new(err).context("User verification request failed")),
+    }
+}
+
+/// Rebuilds a window handle from the raw bytes of Electron's
+/// `getNativeWindowHandle()` buffer.
+///
+/// Only the length is checked: if the handle is invalid when passed to Windows,
+/// the request is rejected by the OS.
+fn parse_window_handle(bytes: &[u8]) -> Result<HWND> {
+    let handle: [u8; size_of::<usize>()] = bytes.try_into().map_err(|_| {
+        anyhow!(
+            "Invalid window handle: expected {} bytes, got {}",
+            size_of::<usize>(),
+            bytes.len()
+        )
+    })?;
+
+    Ok(HWND(usize::from_le_bytes(handle) as *mut c_void))
+}
+
+#[serde_as]
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct UserVerificationParameters {
+    /// Raw bytes of the handle of the window the prompt should attach to.
+    #[serde_as(as = "Base64<Standard, Padded>")]
+    window_handle: Vec<u8>,
+
+    /// Opaque context binding this prompt to the WebAuthn operation that needs
+    /// it. See [`parse_context_string`].
+    transaction_context: String,
+
+    display_hint: String,
+
+    username: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct UserVerificationResponse {
+    outcome: UserVerificationOutcome,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+enum UserVerificationOutcome {
+    /// The user completed verification.
+    Verified,
+    /// The user dismissed the prompt.
+    Cancelled,
+}
+
+impl From<UserVerificationResponse> for CommandResponse {
+    fn from(response: UserVerificationResponse) -> Self {
+        Self::UserVerification(response)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_window_handle;
+
+    #[test]
+    fn parses_a_pointer_sized_window_handle() {
+        let bytes = 0x1234usize.to_le_bytes();
+
+        let handle = parse_window_handle(&bytes).unwrap();
+
+        assert_eq!(handle.0 as usize, 0x1234);
+    }
+
+    #[test]
+    fn rejects_a_window_handle_of_the_wrong_length() {
+        assert!(parse_window_handle(&[0u8; 4]).is_err());
+        assert!(parse_window_handle(&[]).is_err());
+    }
+}

--- a/apps/desktop/src/app/services/services.module.ts
+++ b/apps/desktop/src/app/services/services.module.ts
@@ -166,6 +166,7 @@ import { DesktopFido2MacOsUserVerificationService } from "../../autofill/service
 import { DesktopFido2UnsupportedUserVerificationService } from "../../autofill/services/desktop-fido2-unsupported-user-verification.service";
 import { DesktopFido2UserInterfaceService } from "../../autofill/services/desktop-fido2-user-interface.service";
 import { DesktopFido2UserVerificationService } from "../../autofill/services/desktop-fido2-user-verification.service.abstraction";
+import { DesktopFido2WindowsUserVerificationService } from "../../autofill/services/desktop-fido2-windows-user-verification.service";
 import { DesktopBiometricsService } from "../../key-management/biometrics/desktop.biometrics.service";
 import { RendererBiometricsService } from "../../key-management/biometrics/renderer-biometrics.service";
 import { ElectronKeyService } from "../../key-management/electron-key.service";
@@ -450,6 +451,8 @@ const safeProviders: SafeProvider[] = [
       switch (platformUtilsService.getDevice()) {
         case DeviceType.MacOsDesktop:
           return new DesktopFido2MacOsUserVerificationService(i18nService, logService);
+        case DeviceType.WindowsDesktop:
+          return new DesktopFido2WindowsUserVerificationService(i18nService, logService);
         default:
           return new DesktopFido2UnsupportedUserVerificationService(logService);
       }

--- a/apps/desktop/src/app/services/services.module.ts
+++ b/apps/desktop/src/app/services/services.module.ts
@@ -163,6 +163,7 @@ import { DesktopFido2MacOsUserVerificationService } from "../../autofill/service
 import { DesktopFido2UnsupportedUserVerificationService } from "../../autofill/services/desktop-fido2-unsupported-user-verification.service";
 import { DesktopFido2UserInterfaceService } from "../../autofill/services/desktop-fido2-user-interface.service";
 import { DesktopFido2UserVerificationService } from "../../autofill/services/desktop-fido2-user-verification.service.abstraction";
+import { DesktopFido2WindowsUserVerificationService } from "../../autofill/services/desktop-fido2-windows-user-verification.service";
 import { DesktopBiometricsService } from "../../key-management/biometrics/desktop.biometrics.service";
 import { RendererBiometricsService } from "../../key-management/biometrics/renderer-biometrics.service";
 import { ElectronKeyService } from "../../key-management/electron-key.service";
@@ -451,6 +452,8 @@ const safeProviders: SafeProvider[] = [
       switch (platformUtilsService.getDevice()) {
         case DeviceType.MacOsDesktop:
           return new DesktopFido2MacOsUserVerificationService(i18nService, logService);
+        case DeviceType.WindowsDesktop:
+          return new DesktopFido2WindowsUserVerificationService(i18nService, logService);
         default:
           return new DesktopFido2UnsupportedUserVerificationService(logService);
       }

--- a/apps/desktop/src/autofill/services/desktop-fido2-windows-user-verification.service.ts
+++ b/apps/desktop/src/autofill/services/desktop-fido2-windows-user-verification.service.ts
@@ -1,0 +1,45 @@
+import { Utils } from "@bitwarden/common/platform/misc/utils";
+
+import { WindowsAutofillUserVerificationParams } from "../models/autofill-user-verification.command";
+
+import {
+  Fido2UserVerificationOperation,
+  Fido2UserVerificationRequest,
+} from "./desktop-fido2-user-verification.service.abstraction";
+import { DesktopFido2UserVerificationServiceBase } from "./desktop-fido2-user-verification.service.base";
+
+/**
+ * Verifies the user with Windows Hello through the plugin authenticator API.
+ *
+ * See `apps/desktop/desktop_native/core/src/autofill/windows/user_verification.rs`
+ * for the native implementation.
+ */
+export class DesktopFido2WindowsUserVerificationService extends DesktopFido2UserVerificationServiceBase {
+  protected readonly logPrefix = "[DesktopFido2WindowsUserVerificationService]";
+
+  protected buildParams(
+    request: Fido2UserVerificationRequest,
+  ): WindowsAutofillUserVerificationParams {
+    if (!request.windowHandle) {
+      // The handle is optional in the abstraction because not every platform
+      // attaches its prompt to a window. Windows always does, so an absent
+      // handle here is a programming error rather than a runtime condition.
+      throw new Error("Cannot perform user verification: the request has no window handle");
+    }
+
+    return {
+      username: request.username,
+      displayHint: this.displayHint(request),
+      windowHandle: Utils.fromArrayToB64(request.windowHandle),
+      transactionContext: request.requestContext,
+    };
+  }
+
+  protected messageKey(operation: Fido2UserVerificationOperation): string {
+    return {
+      registration: "confirmPasskeyRegistrationWindows",
+      overwrite: "confirmPasskeyOverwriteWindows",
+      assertion: "confirmPasskeyAssertionWindows",
+    }[operation];
+  }
+}

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -6400,5 +6400,47 @@
         "example": "user@acme.com"
       }
     }
+  },
+  "confirmPasskeyRegistrationWindows": {
+    "message": "Verify it's you to create a new $RPID$ passkey for $USERNAME$.",
+    "description": "Prompt in Windows Hello to register a new passkey.",
+    "placeholders": {
+      "rpId": {
+        "content": "$1",
+        "example": "example.com"
+      },
+      "username": {
+        "content": "$2",
+        "example": "user@acme.com"
+      }
+    }
+  },
+  "confirmPasskeyOverwriteWindows": {
+    "message": "Verify it's you to overwrite a $RPID$ passkey for $USERNAME$.",
+    "description": "Prompt in Windows Hello to overwrite an existing passkey.",
+    "placeholders": {
+      "rpId": {
+        "content": "$1",
+        "example": "example.com"
+      },
+      "username": {
+        "content": "$2",
+        "example": "user@acme.com"
+      }
+    }
+  },
+  "confirmPasskeyAssertionWindows": {
+    "message": "Verify it's you to sign in as $USERNAME$ with your $RPID$ passkey.",
+    "description": "Prompt in Windows Hello to use an existing passkey.",
+    "placeholders": {
+      "rpId": {
+        "content": "$1",
+        "example": "example.com"
+      },
+      "username": {
+        "content": "$2",
+        "example": "user@acme.com"
+      }
+    }
   }
 }

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -6345,5 +6345,47 @@
         "example": "user@acme.com"
       }
     }
+  },
+  "confirmPasskeyRegistrationWindows": {
+    "message": "Verify it's you to create a new $RPID$ passkey for $USERNAME$.",
+    "description": "Prompt in Windows Hello to register a new passkey.",
+    "placeholders": {
+      "rpId": {
+        "content": "$1",
+        "example": "example.com"
+      },
+      "username": {
+        "content": "$2",
+        "example": "user@acme.com"
+      }
+    }
+  },
+  "confirmPasskeyOverwriteWindows": {
+    "message": "Verify it's you to overwrite a $RPID$ passkey for $USERNAME$.",
+    "description": "Prompt in Windows Hello to overwrite an existing passkey.",
+    "placeholders": {
+      "rpId": {
+        "content": "$1",
+        "example": "example.com"
+      },
+      "username": {
+        "content": "$2",
+        "example": "user@acme.com"
+      }
+    }
+  },
+  "confirmPasskeyAssertionWindows": {
+    "message": "Verify it's you to sign in as $USERNAME$ with your $RPID$ passkey.",
+    "description": "Prompt in Windows Hello to use an existing passkey.",
+    "placeholders": {
+      "rpId": {
+        "content": "$1",
+        "example": "example.com"
+      },
+      "username": {
+        "content": "$2",
+        "example": "user@acme.com"
+      }
+    }
   }
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-29791](https://bitwarden.atlassian.net/browse/PM-29791)

## 📔 Objective

Implement Windows native OS user verification for passkeys.

## 📸 Screenshots

Shows the native Windows Hello user verification for registration and assertion. When the credential is selected from the Windows Hello dialog or browser autofill, no Bitwarden UI is shown, and focus is given directly to the Windows Hello PIN input:

https://github.com/user-attachments/assets/d14fb5e2-8015-4c95-9e93-98ed81f8440f

When the vault is locked, the user's unlock method serves as user verification and they are not required to put in the Windows Hello PIN:

https://github.com/user-attachments/assets/0994253f-6d2d-4d38-90c0-bf9a432ead84



[PM-29791]: https://bitwarden.atlassian.net/browse/PM-29791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ