### PR TITLE
[BRE-2153] fix(ci): Stage bit-common for commercial browser builds

### DIFF
--- a/.github/workflows/build-browser.yml
+++ b/.github/workflows/build-browser.yml
@@ -180,10 +180,12 @@ jobs:
           mkdir -p browser-source/apps/browser
           cp -r apps/browser/* browser-source/apps/browser
 
-          # Copy bitwarden_license/bit-browser to the Browser source directory
+          # Copy bitwarden_license/bit-browser and its bit-common dependency to the Browser source directory
           if [[ ${{matrix.license_type.include_bitwarden_license_folder}} == "true" ]]; then
             mkdir -p browser-source/bitwarden_license/bit-browser
             cp -r bitwarden_license/bit-browser/* browser-source/bitwarden_license/bit-browser
+            mkdir -p browser-source/bitwarden_license/bit-common
+            cp -r bitwarden_license/bit-common/* browser-source/bitwarden_license/bit-common
           fi
 
           # Copy libs to Browser source directory


### PR DESCRIPTION


## 🎟️ Tracking

[BRE-2153](https://bitwarden.atlassian.net/browse/BRE-2153)

## 📔 Objective

The Build Browser workflow stages a pruned source tree into browser-source/ and compiles the extension from that archive rather than a full checkout. The copy block enumerated bit-browser only, so once bit-browser gained its first dependency on bit-common the commercial builds failed to resolve the module.

Copy bitwarden_license/bit-common alongside bit-browser inside the existing commercial-license guard so the archive matches the actual dependency graph.

* Resolve TS2307 on @bitwarden/bit-common/dirt/vault-health/services
* Restore sdk-alias.d.ts, referenced by the bit-browser tsconfig include list but never present in the archive
* Leave open source archives unchanged; the copy stays behind include_bitwarden_license_folder

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->


[BRE-2153]: https://bitwarden.atlassian.net/browse/BRE-2153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ