### PR TITLE
[PM-41288] Fix bug preventing edits of existing File Sends

### DIFF
--- a/libs/common/src/tools/send/services/send.service.ts
+++ b/libs/common/src/tools/send/services/send.service.ts
@@ -138,6 +138,14 @@ export class SendService implements InternalSendServiceAbstraction {
         } else {
           fileData = await this.parseFile(send, file, model.cryptoKey, userId);
         }
+      } else if (model.file.fileName) {
+        // When editing an existing File Send and using the SDK (`pm-30110-sdk-sends-api` feature flag is on)
+        // the `file.fileName` field is required for the edit to succeed (this is enforced both by the SDK and
+        // by `send-sdk-api.service` even though the server doesn't perform any edits with the field).
+        send.file.fileName = await this.encryptService.encryptString(
+          model.file.fileName,
+          model.cryptoKey,
+        );
       }
     }
 

--- a/libs/tools/send/send-ui/src/send-form/services/default-send-form.service.ts
+++ b/libs/tools/send/send-ui/src/send-form/services/default-send-form.service.ts
@@ -14,7 +14,6 @@ import { SendView } from "@bitwarden/common/tools/send/models/view/send.view";
 import { SendApiService } from "@bitwarden/common/tools/send/services/send-api.service.abstraction";
 import { SendService } from "@bitwarden/common/tools/send/services/send.service.abstraction";
 import { AuthType } from "@bitwarden/common/tools/send/types/auth-type";
-import { SendType } from "@bitwarden/common/tools/send/types/send-type";
 import { DialogService, ToastService } from "@bitwarden/components";
 
 import { SendItemDialogResult } from "../../add-edit/send-add-edit-dialog.component";
@@ -95,15 +94,6 @@ export class DefaultSendFormService implements SendFormService {
       }
       originalSendView = await this.decryptSend(this.sendFormConfig.originalSend);
       updatedSendView = Object.assign(updatedSendView, originalSendView);
-      if (originalSendView.type === SendType.File) {
-        // When editing an existing File Send and using the SDK (`pm-30110-sdk-sends-api` feature flag is on)
-        // there is one required field on the SDK's SendFileView, which is mapped to by the `fileName` field.
-        // The Send is encrypted and then decrypted before being sent to the SDK, so to avoid adjusting the
-        // encryption code in `send.service.ts` we need the `file` property to be set. Neither the SDK nor the
-        // legacy paths use the encrypted file contents when editing an existing Send so we create an empty,
-        // stand-in File object with the correct decrypted name.
-        this.file = new File([], originalSendView.file.fileName);
-      }
     }
     this._originalSendView.set(originalSendView);
     this._updatedSendView.set(updatedSendView);

--- a/libs/tools/send/send-ui/src/send-form/services/default-send-form.service.ts
+++ b/libs/tools/send/send-ui/src/send-form/services/default-send-form.service.ts
@@ -14,6 +14,7 @@ import { SendView } from "@bitwarden/common/tools/send/models/view/send.view";
 import { SendApiService } from "@bitwarden/common/tools/send/services/send-api.service.abstraction";
 import { SendService } from "@bitwarden/common/tools/send/services/send.service.abstraction";
 import { AuthType } from "@bitwarden/common/tools/send/types/auth-type";
+import { SendType } from "@bitwarden/common/tools/send/types/send-type";
 import { DialogService, ToastService } from "@bitwarden/components";
 
 import { SendItemDialogResult } from "../../add-edit/send-add-edit-dialog.component";
@@ -94,6 +95,15 @@ export class DefaultSendFormService implements SendFormService {
       }
       originalSendView = await this.decryptSend(this.sendFormConfig.originalSend);
       updatedSendView = Object.assign(updatedSendView, originalSendView);
+      if (originalSendView.type === SendType.File) {
+        // When editing an existing File Send and using the SDK (`pm-30110-sdk-sends-api` feature flag is on)
+        // there is one required field on the SDK's SendFileView, which is mapped to by the `fileName` field.
+        // The Send is encrypted and then decrypted before being sent to the SDK, so to avoid adjusting the
+        // encryption code in `send.service.ts` we need the `file` property to be set. Neither the SDK nor the
+        // legacy paths use the encrypted file contents when editing an existing Send so we create an empty,
+        // stand-in File object with the correct decrypted name.
+        this.file = new File([], originalSendView.file.fileName);
+      }
     }
     this._originalSendView.set(originalSendView);
     this._updatedSendView.set(updatedSendView);


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-41288

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR fixes a bug that would prevent editing an existing File Send when using the SDK instead of the legacy API path.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
No change
