### PR TITLE
[PM-41467] set min-release-age (.npmrc)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,6 @@
 save-exact=true
 # Increase available heap size to avoid running out of memory when compiling.
 # This applies to all npm scripts in this repository.
-node-options=--max-old-space-size=8192
+node-options="--max-old-space-size=8192"
+# supply-chain security
+min-release-age=4


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

Improve the (npm) supply chain security posture of this repo by making `npm install` refuse by default to install a dependency (or sub-dependency) that was published within the last 4 days (this is configurable).

Threat model: if any dependency is compromised with a new malicious release published in the last 4 days, AND the user is running npm >= 11.10.0, then npm will refuse to install the package by default.

(npm < 11.10.0 doesn't support this config and will allow the install without additional protections).

In the event of such a threat, the hope is that the community will catch it and delete the published release before the 4 day mark is hit.


references:
* https://github.com/npm/cli/releases/tag/v11.10.0
* https://github.com/npm/cli/pull/8965

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
