### PR TITLE
[PM-8711] inconsistent casing between vault management api feedback and api docs

### DIFF
--- a/apps/cli/src/commands/edit.command.spec.ts
+++ b/apps/cli/src/commands/edit.command.spec.ts
@@ -207,7 +207,7 @@ describe("EditCommand", () => {
         makeOptions(),
       );
       expect(result.success).toBe(false);
-      expect(result.message).toContain("`organizationid` option does not match request object");
+      expect(result.message).toContain("does not match");
     });
 
     it("returns bad request when collection name is empty string", async () => {

--- a/apps/cli/src/commands/edit.command.spec.ts
+++ b/apps/cli/src/commands/edit.command.spec.ts
@@ -138,20 +138,47 @@ describe("EditCommand", () => {
   });
 
   describe("editOrganizationCollection", () => {
-    it("returns bad request when organizationId option is missing", async () => {
+    it("falls back to the request's organizationId when the option is missing", async () => {
       const result = await command["editOrganizationCollection"](validCollectionId, makeRequest(), {
         organizationId: null,
       });
-      expect(result.success).toBe(false);
-      expect(result.message).toContain("`organizationid` option is required");
+      expect(result.success).toBe(true);
+      expect(apiService.putCollection).toHaveBeenCalledWith(
+        validOrgId,
+        validCollectionId,
+        expect.anything(),
+      );
     });
 
-    it("returns bad request when organizationId option is empty string", async () => {
+    it("falls back to the request's organizationId when the option is an empty string", async () => {
       const result = await command["editOrganizationCollection"](validCollectionId, makeRequest(), {
         organizationId: "",
       });
+      expect(result.success).toBe(true);
+    });
+
+    it("falls back to the option's organizationId when the request does not provide one", async () => {
+      const result = await command["editOrganizationCollection"](
+        validCollectionId,
+        makeRequest({ organizationId: null }),
+        makeOptions(),
+      );
+      expect(result.success).toBe(true);
+      expect(apiService.putCollection).toHaveBeenCalledWith(
+        validOrgId,
+        validCollectionId,
+        expect.anything(),
+      );
+    });
+
+    it("returns bad request when organizationId is missing from both the option and the request", async () => {
+      const result = await command["editOrganizationCollection"](
+        validCollectionId,
+        makeRequest({ organizationId: null }),
+        { organizationId: null },
+      );
       expect(result.success).toBe(false);
-      expect(result.message).toContain("`organizationid` option is required");
+      expect(result.message).toContain("An organization id is required");
     });
 
     it("returns bad request when collection id is not a valid GUID", async () => {

--- a/apps/cli/src/commands/edit.command.ts
+++ b/apps/cli/src/commands/edit.command.ts
@@ -226,7 +226,9 @@ export class EditCommand {
       : options.organizationId;
     if (Utils.isNullOrWhitespace(organizationId)) {
       return Response.badRequest(
-        "An organization id is required, either via the `organizationid` option or the request's `organizationId` property.",
+        "An organization id is required, either via the `--organizationid` option " +
+          "(or `organizationId` query parameter when using `bw serve`), " +
+          "or the request's `organizationId` property.",
       );
     }
     if (!Utils.isGuid(organizationId)) {
@@ -237,7 +239,10 @@ export class EditCommand {
       !Utils.isNullOrWhitespace(req.organizationId) &&
       options.organizationId !== req.organizationId
     ) {
-      return Response.badRequest("`organizationid` option does not match request object.");
+      return Response.badRequest(
+        "The `--organizationid` option (or `organizationId` query parameter) does not match " +
+          "the request's `organizationId` property.",
+      );
     }
     req.organizationId = organizationId as OrganizationId;
     if (req.name == null || req.name.trim() === "") {

--- a/apps/cli/src/commands/edit.command.ts
+++ b/apps/cli/src/commands/edit.command.ts
@@ -215,18 +215,31 @@ export class EditCommand {
     req: OrganizationCollectionRequest,
     options: Options,
   ) {
-    if (options.organizationId == null || options.organizationId === "") {
-      return Response.badRequest("`organizationid` option is required.");
-    }
     if (!Utils.isGuid(id)) {
       return Response.badRequest("`" + id + "` is not a GUID.");
     }
-    if (!Utils.isGuid(options.organizationId)) {
-      return Response.badRequest("`" + options.organizationId + "` is not a GUID.");
+    // The organization id can come from either the `organizationid` option (e.g. a CLI flag, or a
+    // query string parameter when using `bw serve`) or the request body's `organizationId` property.
+    // If both are provided, they must agree; otherwise whichever one was provided is used.
+    const organizationId = Utils.isNullOrWhitespace(options.organizationId)
+      ? req?.organizationId
+      : options.organizationId;
+    if (Utils.isNullOrWhitespace(organizationId)) {
+      return Response.badRequest(
+        "An organization id is required, either via the `organizationid` option or the request's `organizationId` property.",
+      );
     }
-    if (options.organizationId !== req.organizationId) {
+    if (!Utils.isGuid(organizationId)) {
+      return Response.badRequest("`" + organizationId + "` is not a GUID.");
+    }
+    if (
+      !Utils.isNullOrWhitespace(options.organizationId) &&
+      !Utils.isNullOrWhitespace(req.organizationId) &&
+      options.organizationId !== req.organizationId
+    ) {
       return Response.badRequest("`organizationid` option does not match request object.");
     }
+    req.organizationId = organizationId as OrganizationId;
     if (req.name == null || req.name.trim() === "") {
       return Response.badRequest("Collection name is required.");
     }
@@ -235,7 +248,7 @@ export class EditCommand {
         this.accountService.activeAccount$.pipe(
           getUserId,
           switchMap((userId) => this.keyService.orgKeys$(userId)),
-          map((orgKeys) => orgKeys[options.organizationId as OrganizationId] ?? null),
+          map((orgKeys) => orgKeys[organizationId as OrganizationId] ?? null),
         ),
       );
       if (orgKey == null) {

--- a/apps/cli/src/vault/create.command.spec.ts
+++ b/apps/cli/src/vault/create.command.spec.ts
@@ -146,7 +146,7 @@ describe("CreateCommand", () => {
         makeOptions(),
       );
       expect(result.success).toBe(false);
-      expect(result.message).toContain("`organizationid` option does not match request object");
+      expect(result.message).toContain("does not match");
     });
 
     it("returns bad request when collection name is empty string", async () => {

--- a/apps/cli/src/vault/create.command.spec.ts
+++ b/apps/cli/src/vault/create.command.spec.ts
@@ -95,22 +95,39 @@ describe("CreateCommand", () => {
   });
 
   describe("createOrganizationCollection", () => {
-    it("returns bad request when organizationId option is missing", async () => {
+    it("falls back to the request's organizationId when the option is missing", async () => {
       const result = await command["createOrganizationCollection"](
         makeRequest(),
         makeOptions({ organizationId: null }),
       );
-      expect(result.success).toBe(false);
-      expect(result.message).toContain("`organizationid` option is required");
+      expect(result.success).toBe(true);
+      expect(apiService.postCollection).toHaveBeenCalledWith(validOrgId, expect.anything());
     });
 
-    it("returns bad request when organizationId option is empty string", async () => {
+    it("falls back to the request's organizationId when the option is an empty string", async () => {
       const result = await command["createOrganizationCollection"](
         makeRequest(),
         makeOptions({ organizationId: "" }),
       );
+      expect(result.success).toBe(true);
+    });
+
+    it("falls back to the option's organizationId when the request does not provide one", async () => {
+      const result = await command["createOrganizationCollection"](
+        makeRequest({ organizationId: null }),
+        makeOptions(),
+      );
+      expect(result.success).toBe(true);
+      expect(apiService.postCollection).toHaveBeenCalledWith(validOrgId, expect.anything());
+    });
+
+    it("returns bad request when organizationId is missing from both the option and the request", async () => {
+      const result = await command["createOrganizationCollection"](
+        makeRequest({ organizationId: null }),
+        makeOptions({ organizationId: null }),
+      );
       expect(result.success).toBe(false);
-      expect(result.message).toContain("`organizationid` option is required");
+      expect(result.message).toContain("An organization id is required");
     });
 
     it("returns bad request when organizationId is not a valid GUID", async () => {

--- a/apps/cli/src/vault/create.command.ts
+++ b/apps/cli/src/vault/create.command.ts
@@ -19,6 +19,7 @@ import { CollectionExport } from "@bitwarden/common/models/export/collection.exp
 import { FolderExport } from "@bitwarden/common/models/export/folder.export";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
+import { OrganizationId } from "@bitwarden/common/types/guid";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { FolderApiServiceAbstraction } from "@bitwarden/common/vault/abstractions/folder/folder-api.service.abstraction";
 import { FolderService } from "@bitwarden/common/vault/abstractions/folder/folder.service.abstraction";
@@ -219,15 +220,28 @@ export class CreateCommand {
   }
 
   private async createOrganizationCollection(req: OrganizationCollectionRequest, options: Options) {
-    if (options.organizationId == null || options.organizationId === "") {
-      return Response.badRequest("`organizationid` option is required.");
+    // The organization id can come from either the `organizationid` option (e.g. a CLI flag, or a
+    // query string parameter when using `bw serve`) or the request body's `organizationId` property.
+    // If both are provided, they must agree; otherwise whichever one was provided is used.
+    const organizationId = Utils.isNullOrWhitespace(options.organizationId)
+      ? req?.organizationId
+      : options.organizationId;
+    if (Utils.isNullOrWhitespace(organizationId)) {
+      return Response.badRequest(
+        "An organization id is required, either via the `organizationid` option or the request's `organizationId` property.",
+      );
     }
-    if (!Utils.isGuid(options.organizationId)) {
-      return Response.badRequest("`" + options.organizationId + "` is not a GUID.");
+    if (!Utils.isGuid(organizationId)) {
+      return Response.badRequest("`" + organizationId + "` is not a GUID.");
     }
-    if (options.organizationId !== req.organizationId) {
+    if (
+      !Utils.isNullOrWhitespace(options.organizationId) &&
+      !Utils.isNullOrWhitespace(req.organizationId) &&
+      options.organizationId !== req.organizationId
+    ) {
       return Response.badRequest("`organizationid` option does not match request object.");
     }
+    req.organizationId = organizationId as OrganizationId;
     if (req.name == null || req.name.trim() === "") {
       return Response.badRequest("Collection name is required.");
     }

--- a/apps/cli/src/vault/create.command.ts
+++ b/apps/cli/src/vault/create.command.ts
@@ -228,7 +228,9 @@ export class CreateCommand {
       : options.organizationId;
     if (Utils.isNullOrWhitespace(organizationId)) {
       return Response.badRequest(
-        "An organization id is required, either via the `organizationid` option or the request's `organizationId` property.",
+        "An organization id is required, either via the `--organizationid` option " +
+          "(or `organizationId` query parameter when using `bw serve`), " +
+          "or the request's `organizationId` property.",
       );
     }
     if (!Utils.isGuid(organizationId)) {
@@ -239,7 +241,10 @@ export class CreateCommand {
       !Utils.isNullOrWhitespace(req.organizationId) &&
       options.organizationId !== req.organizationId
     ) {
-      return Response.badRequest("`organizationid` option does not match request object.");
+      return Response.badRequest(
+        "The `--organizationid` option (or `organizationId` query parameter) does not match " +
+          "the request's `organizationId` property.",
+      );
     }
     req.organizationId = organizationId as OrganizationId;
     if (req.name == null || req.name.trim() === "") {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-8711

## 📔 Objective
Docs claimed an error when not providing the `organizationId` in the query params... It seems the CLI wanted both the query params and request body to have the `organizationId` provided before proceeding. This PR allows either one to be used, but also still continues to work if both are provided. This ensures the documentation is still technically correct.
