### PR TITLE
SSH Agent: fix flaky integration test

### DIFF
--- a/apps/desktop/desktop_native/ssh_agent/src/agent.rs
+++ b/apps/desktop/desktop_native/ssh_agent/src/agent.rs
@@ -68,3 +68,20 @@ where
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{approval::MockApprovalRequester, storage::keystore::MockKeyStore};
+
+    #[test]
+    fn stop_clears_the_keystore() {
+        let mut keystore = MockKeyStore::new();
+        keystore.expect_clear().once().return_const(());
+        let approval_handler = MockApprovalRequester::new();
+
+        let mut agent = BitwardenSSHAgent::new(keystore, approval_handler);
+
+        agent.stop();
+    }
+}

--- a/apps/desktop/desktop_native/ssh_agent/tests/server_unix.rs
+++ b/apps/desktop/desktop_native/ssh_agent/tests/server_unix.rs
@@ -110,42 +110,6 @@ async fn test_server_can_restart() {
 
 #[serial]
 #[tokio::test(flavor = "multi_thread")]
-async fn test_stop_clears_keys() {
-    setup();
-    let mut agent = agent_with_keys(vec![test_ed25519_key()]);
-    agent.start().unwrap();
-
-    // Verify a key is visible before stop
-    let mut stream = UnixStream::connect(test_socket_path()).await.unwrap();
-    stream
-        .write_all(&framed_request_identities())
-        .await
-        .unwrap();
-    let response = read_framed_response(&mut stream).await;
-    assert_eq!(u32::from_be_bytes(response[1..5].try_into().unwrap()), 1);
-
-    // Stop clears keys; restart to re-open the socket for a new connection
-    agent.stop();
-    agent.start().unwrap();
-
-    // New connection sees an empty keystore
-    let mut stream2 = UnixStream::connect(test_socket_path()).await.unwrap();
-    stream2
-        .write_all(&framed_request_identities())
-        .await
-        .unwrap();
-    let response2 = read_framed_response(&mut stream2).await;
-    assert_eq!(
-        u32::from_be_bytes(response2[1..5].try_into().unwrap()),
-        0,
-        "stop() must clear the keystore"
-    );
-
-    agent.stop();
-}
-
-#[serial]
-#[tokio::test(flavor = "multi_thread")]
 async fn test_list_keys_returns_empty_when_no_keys_set() {
     setup();
     let mut agent = always_approving_agent();

--- a/apps/desktop/desktop_native/ssh_agent/tests/server_windows.rs
+++ b/apps/desktop/desktop_native/ssh_agent/tests/server_windows.rs
@@ -84,42 +84,6 @@ async fn test_server_can_restart() {
 
 #[serial]
 #[tokio::test(flavor = "multi_thread")]
-async fn test_stop_clears_keys() {
-    setup();
-    let mut agent = agent_with_keys(vec![test_ed25519_key()]);
-    agent.start().unwrap();
-
-    // Verify a key is visible before stop
-    let mut client = ClientOptions::new().open(PIPE_NAME).unwrap();
-    client
-        .write_all(&framed_request_identities())
-        .await
-        .unwrap();
-    let response = read_framed_response(&mut client).await;
-    assert_eq!(u32::from_be_bytes(response[1..5].try_into().unwrap()), 1);
-
-    // Stop clears keys; restart to re-open the pipe for a new connection
-    agent.stop();
-    agent.start().unwrap();
-
-    // New connection sees an empty keystore
-    let mut client2 = ClientOptions::new().open(PIPE_NAME).unwrap();
-    client2
-        .write_all(&framed_request_identities())
-        .await
-        .unwrap();
-    let response2 = read_framed_response(&mut client2).await;
-    assert_eq!(
-        u32::from_be_bytes(response2[1..5].try_into().unwrap()),
-        0,
-        "stop() must clear the keystore"
-    );
-
-    agent.stop();
-}
-
-#[serial]
-#[tokio::test(flavor = "multi_thread")]
 async fn test_list_keys_returns_empty_when_no_keys_set() {
     setup();
     let mut agent = always_approving_agent();


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-41477

## 📔 Objective

Sometimes the integration test case `test_stop_clears_keys` on Windows fails in CI, but a retry solves it. This is because SSHAgentServer::stop() aborts the accept loop without awaiting it, so the listener's idle NamedPipeServer instance can outlive the call. test_stop_clears_keys then calls start(), registering a second instance under the same pipe name and reconnects immediately. Windows may route the client to the orphan, which no task services: read_exact can then fail with UnexpectedEof. 

The purpose of that integration test was to assert the stop function of the agent clearing the keystore. That is achievable by moving the test to a unit test.

