### PR TITLE
Browser: Refactor client state definitions for Health feature

### DIFF
--- a/bitwarden_license/bit-browser/src/popup/dirt/health/services/health-access.service.spec.ts
+++ b/bitwarden_license/bit-browser/src/popup/dirt/health/services/health-access.service.spec.ts
@@ -226,7 +226,7 @@ describe("HealthAccessService", () => {
       await firstValueFrom(service.hasRunHealthScan$(userId));
 
       expect(stateProvider.mock.getUserState$).toHaveBeenCalledWith(
-        expect.objectContaining({ key: "runHealthScan" }),
+        expect.objectContaining({ key: "hasRunHealthScan" }),
         userId,
       );
     });
@@ -237,7 +237,7 @@ describe("HealthAccessService", () => {
       await service.setHasRunHealthScan(userId);
 
       expect(stateProvider.mock.setUserState).toHaveBeenCalledWith(
-        expect.objectContaining({ key: "runHealthScan" }),
+        expect.objectContaining({ key: "hasRunHealthScan" }),
         true,
         userId,
       );

--- a/bitwarden_license/bit-browser/src/popup/dirt/health/services/health-access.service.ts
+++ b/bitwarden_license/bit-browser/src/popup/dirt/health/services/health-access.service.ts
@@ -10,12 +10,7 @@ import { ConfigService } from "@bitwarden/common/platform/abstractions/config/co
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { UserId } from "@bitwarden/common/types/guid";
 import { ToastService } from "@bitwarden/components";
-import {
-  HEALTH_TAB_VIEWED_DISK,
-  RUN_HEALTH_SCAN_DISK,
-  StateProvider,
-  UserKeyDefinition,
-} from "@bitwarden/state";
+import { BROWSER_HEALTH_DISK, StateProvider, UserKeyDefinition } from "@bitwarden/state";
 
 /**
  * Service responsible for determining access to the browser extension Health report feature.
@@ -105,17 +100,21 @@ export class HealthAccessService {
 }
 
 const HEALTH_TAB_OPENED_KEY = new UserKeyDefinition<boolean>(
-  HEALTH_TAB_VIEWED_DISK,
+  BROWSER_HEALTH_DISK,
   "healthTabOpened",
   {
     deserializer: (value) => value ?? false,
     clearOn: [],
   },
 );
-const RUN_HEALTH_SCAN_KEY = new UserKeyDefinition<boolean>(RUN_HEALTH_SCAN_DISK, "runHealthScan", {
-  deserializer: (value) => value ?? false,
-  clearOn: [],
-});
+const RUN_HEALTH_SCAN_KEY = new UserKeyDefinition<boolean>(
+  BROWSER_HEALTH_DISK,
+  "hasRunHealthScan",
+  {
+    deserializer: (value) => value ?? false,
+    clearOn: [],
+  },
+);
 
 export const canAccessHealth: CanActivateFn = () => {
   const router = inject(Router);

--- a/libs/state/src/core/state-definitions.ts
+++ b/libs/state/src/core/state-definitions.ts
@@ -123,10 +123,7 @@ export const ACCESS_INTELLIGENCE_WELCOME_DIALOG_DISK = new StateDefinition(
     web: "disk-local",
   },
 );
-export const HEALTH_TAB_VIEWED_DISK = new StateDefinition("healthTabViewed", "disk", {
-  web: "disk-local",
-});
-export const RUN_HEALTH_SCAN_DISK = new StateDefinition("runHealthScan", "disk", {
+export const BROWSER_HEALTH_DISK = new StateDefinition("browserHealth", "disk", {
   web: "disk-local",
 });
 


### PR DESCRIPTION
## 🎟️ Tracking
N/A

## 📔 Objective
Pare down to a single top level client side state definition for the Browser Health feature. State slices are added under a single `browserHealth` parent. 

## 📸 Screenshots
**Updated state values**

<img width="711" height="142" alt="image" src="https://github.com/user-attachments/assets/2d4baf66-466a-4ea8-9785-8720983be75a" />
