### PR TITLE
[PM-40312] Add VaultNextComponent behind vfo1-foundation flag

### DIFF
--- a/apps/web/src/app/vault/individual-vault/vault-next.component.html
+++ b/apps/web/src/app/vault/individual-vault/vault-next.component.html
@@ -1,0 +1,22 @@
+<app-vault-banners [organizations]="organizationOptions()"></app-vault-banners>
+
+<vault-items-table
+  [ciphers]="rows()"
+  [rowActions]="rowActions()"
+  [folders]="folders()"
+  [collections]="collectionOptions()"
+  [organizations]="organizationOptions()"
+  [itemAction]="itemAction"
+  (action)="onVaultItemsEvent($event)"
+>
+  <button
+    slot="toolbar"
+    id="vault-next_button_add-item"
+    type="button"
+    bitButton
+    buttonType="primary"
+    (click)="openAddItemDialog()"
+  >
+    {{ "addItem" | i18n }}
+  </button>
+</vault-items-table>

--- a/apps/web/src/app/vault/individual-vault/vault-next.component.spec.ts
+++ b/apps/web/src/app/vault/individual-vault/vault-next.component.spec.ts
@@ -286,6 +286,9 @@ describe("VaultNextComponent", () => {
       ],
       schemas: [NO_ERRORS_SCHEMA],
     })
+      // Note: TestBed supplies the component-level providers itself, so this suite cannot catch a
+      // subclass that forgets to declare VAULT_COMPONENT_PROVIDERS — that surfaces only when the
+      // real app builds the component (NG0201). Verified separately against the AOT build.
       .overrideComponent(VaultNextComponent, {
         set: {
           providers: [

--- a/apps/web/src/app/vault/individual-vault/vault-next.component.spec.ts
+++ b/apps/web/src/app/vault/individual-vault/vault-next.component.spec.ts
@@ -1,0 +1,423 @@
+import { SelectionModel } from "@angular/cdk/collections";
+import { NO_ERRORS_SCHEMA, signal } from "@angular/core";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { ActivatedRoute, convertToParamMap, Params, provideRouter } from "@angular/router";
+import { mock } from "jest-mock-extended";
+import { BehaviorSubject, EMPTY, of } from "rxjs";
+import { map } from "rxjs/operators";
+
+import {
+  CollectionAdminService,
+  CollectionService,
+  OrganizationUserApiService,
+} from "@bitwarden/admin-console/common";
+import { SearchPipe } from "@bitwarden/angular/pipes/search.pipe";
+import { VaultProfileService } from "@bitwarden/angular/vault/services/vault-profile.service";
+import { AuthRequestServiceAbstraction, LockService, LogoutService } from "@bitwarden/auth/common";
+import { AutomaticUserConfirmationService } from "@bitwarden/auto-confirm";
+import { ApiService } from "@bitwarden/common/abstractions/api.service";
+import { OrganizationApiServiceAbstraction } from "@bitwarden/common/admin-console/abstractions/organization/organization-api.service.abstraction";
+import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
+import { PolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
+import { ProviderService } from "@bitwarden/common/admin-console/abstractions/provider.service";
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { AvatarService } from "@bitwarden/common/auth/abstractions/avatar.service";
+import { BillingAccountProfileStateService } from "@bitwarden/common/billing/abstractions/account/billing-account-profile-state.service";
+import { BillingApiServiceAbstraction } from "@bitwarden/common/billing/abstractions/billing-api.service.abstraction";
+import { EventCollectionService } from "@bitwarden/common/dirt/event-logs";
+import { VaultTimeoutSettingsService } from "@bitwarden/common/key-management/vault-timeout";
+import { BroadcasterService } from "@bitwarden/common/platform/abstractions/broadcaster.service";
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
+import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
+import { StateProvider } from "@bitwarden/common/platform/state";
+import { SyncService } from "@bitwarden/common/platform/sync";
+import { UserId } from "@bitwarden/common/types/guid";
+import { CipherArchiveService } from "@bitwarden/common/vault/abstractions/cipher-archive.service";
+import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
+import { FolderService } from "@bitwarden/common/vault/abstractions/folder/folder.service.abstraction";
+import { PremiumUpgradePromptService } from "@bitwarden/common/vault/abstractions/premium-upgrade-prompt.service";
+import { SearchService } from "@bitwarden/common/vault/abstractions/search.service";
+import { TotpService } from "@bitwarden/common/vault/abstractions/totp.service";
+import { CipherType } from "@bitwarden/common/vault/enums";
+import { Cipher } from "@bitwarden/common/vault/models/domain/cipher";
+import { TreeNode } from "@bitwarden/common/vault/models/domain/tree-node";
+import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+import { CipherAuthorizationService } from "@bitwarden/common/vault/services/cipher-authorization.service";
+import { RestrictedItemTypesService } from "@bitwarden/common/vault/services/restricted-item-types.service";
+import { DialogService, ScrollLayoutService, ToastService } from "@bitwarden/components";
+import { MessageListener } from "@bitwarden/messaging";
+import {
+  ASSIGN_COLLECTIONS_DIALOG,
+  AssignCollectionsDialogRef,
+  AssignCollectionsResult,
+  BULK_DELETE_DIALOG,
+  BulkDeleteDialogRef,
+  BulkDeleteDialogResult,
+  DefaultCipherFormConfigService,
+  PasswordRepromptService,
+  RoutedVaultFilterBridgeService,
+  RoutedVaultFilterService,
+  VaultBatchBarService,
+  VaultFilter,
+  VaultFilterServiceAbstraction,
+  VaultItem,
+  VaultItemsTransferService,
+} from "@bitwarden/vault";
+
+import { OrganizationWarningsService } from "../../billing/organizations/warnings/services";
+import { ProductSwitcherService } from "../../layouts/product-switcher/shared/product-switcher.service";
+import { WebVaultExtensionPromptService } from "../services/web-vault-extension-prompt.service";
+import { WebVaultPromptService } from "../services/web-vault-prompt.service";
+import { WelcomeDialogService } from "../services/welcome-dialog.service";
+
+import { VaultBannersService } from "./vault-banners/services/vault-banners.service";
+import { VaultNextComponent } from "./vault-next.component";
+import { VaultOnboardingService } from "./vault-onboarding/services/abstraction/vault-onboarding.service";
+
+const TEST_USER_ID = "test-user-id" as UserId;
+
+/** A row the table would render, standing in for a decrypted cipher. */
+const login = (overrides: Partial<CipherView> = {}) =>
+  ({
+    id: "cipher-1",
+    name: "GitHub",
+    type: CipherType.Login,
+    favorite: false,
+    reprompt: 0,
+    ...overrides,
+  }) as CipherView;
+
+describe("VaultNextComponent", () => {
+  let component: VaultNextComponent<CipherView>;
+  let fixture: ComponentFixture<VaultNextComponent<CipherView>>;
+  let userCanArchive$: BehaviorSubject<boolean>;
+  let cipherListViews$: BehaviorSubject<CipherView[]>;
+  let restricted$: BehaviorSubject<unknown[]>;
+
+  /**
+   * Reads the row-action ids the component currently offers. The actions are `protected`, so the
+   * cast is how a spec reaches them without widening the component's API.
+   */
+  const actionIds = () =>
+    (component as unknown as { rowActions: () => { id: string }[] }).rowActions().map((a) => a.id);
+
+  const rows = () => (component as unknown as { rows: () => CipherView[] }).rows();
+
+  beforeEach(async () => {
+    userCanArchive$ = new BehaviorSubject<boolean>(false);
+    cipherListViews$ = new BehaviorSubject<CipherView[]>([]);
+    restricted$ = new BehaviorSubject<unknown[]>([]);
+
+    const queryParamsSubject = new BehaviorSubject<Params>({});
+
+    const mockCipher = {
+      id: "cipher-1",
+      reprompt: 0,
+      type: CipherType.Login,
+      edit: true,
+    } as Cipher;
+
+    const cipherServiceMock = mock<CipherService>();
+    cipherServiceMock.get.mockResolvedValue(mockCipher);
+    cipherServiceMock.cipherListViews$.mockReturnValue(cipherListViews$ as any);
+    cipherServiceMock.failedToDecryptCiphers$.mockReturnValue(of([]) as any);
+
+    const organizationServiceMock = mock<OrganizationService>();
+    organizationServiceMock.organizations$.mockReturnValue(of([]) as any);
+
+    const collectionServiceMock = mock<CollectionService>();
+    collectionServiceMock.decryptedCollections$.mockReturnValue(of([]) as any);
+
+    const folderServiceMock = mock<FolderService>();
+    folderServiceMock.folderViews$.mockReturnValue(of([]) as any);
+
+    const billingMock = mock<BillingAccountProfileStateService>();
+    billingMock.hasPremiumFromAnySource$.mockReturnValue(of(false));
+
+    const policyServiceMock = mock<PolicyService>();
+    policyServiceMock.policyAppliesToUser$.mockReturnValue(of(false));
+    policyServiceMock.policiesByType$.mockReturnValue(of([]));
+
+    const mockActivatedRoute = {
+      queryParams: queryParamsSubject.asObservable(),
+      params: of({}),
+      queryParamMap: queryParamsSubject.pipe(map((p) => convertToParamMap(p))),
+      paramMap: of(convertToParamMap({})),
+      data: of({}),
+    };
+
+    const emptyTreeNode = (name: string) => new TreeNode({ id: "", name } as any, null);
+
+    await TestBed.configureTestingModule({
+      imports: [VaultNextComponent],
+      providers: [
+        provideRouter([]),
+        { provide: MessagingService, useValue: mock<MessagingService>() },
+        { provide: PlatformUtilsService, useValue: mock<PlatformUtilsService>() },
+        { provide: BroadcasterService, useValue: mock<BroadcasterService>() },
+        {
+          provide: VaultFilterServiceAbstraction,
+          useValue: {
+            ...mock<VaultFilterServiceAbstraction>(),
+            clearOrganizationFilter: jest.fn(),
+            collectionTree$: of(emptyTreeNode("collections")),
+            folderTree$: of(emptyTreeNode("folders")),
+            organizationTree$: of(emptyTreeNode("organizations")),
+            cipherTypeTree$: of(emptyTreeNode("cipherTypes")),
+            filteredCollections$: of([]),
+          },
+        },
+        { provide: PasswordRepromptService, useValue: mock<PasswordRepromptService>() },
+        { provide: FolderService, useValue: folderServiceMock },
+        { provide: LogService, useValue: mock<LogService>() },
+        { provide: TotpService, useValue: mock<TotpService>() },
+        { provide: EventCollectionService, useValue: mock<EventCollectionService>() },
+        { provide: SearchService, useValue: mock<SearchService>() },
+        { provide: SearchPipe, useValue: mock<SearchPipe>() },
+        { provide: ApiService, useValue: mock<ApiService>() },
+        { provide: ToastService, useValue: mock<ToastService>() },
+        { provide: BillingApiServiceAbstraction, useValue: mock<BillingApiServiceAbstraction>() },
+        { provide: OrganizationWarningsService, useValue: mock<OrganizationWarningsService>() },
+        { provide: PremiumUpgradePromptService, useValue: mock<PremiumUpgradePromptService>() },
+        { provide: SyncService, useValue: mock<SyncService>() },
+        { provide: ScrollLayoutService, useValue: mock<ScrollLayoutService>() },
+        {
+          provide: ConfigService,
+          useValue: {
+            ...mock<ConfigService>(),
+            getFeatureFlag$: jest.fn().mockReturnValue(of(false)),
+          },
+        },
+        { provide: DialogService, useValue: mock<DialogService>() },
+        { provide: WelcomeDialogService, useValue: mock<WelcomeDialogService>() },
+        { provide: OrganizationUserApiService, useValue: mock<OrganizationUserApiService>() },
+        { provide: CollectionAdminService, useValue: mock<CollectionAdminService>() },
+        { provide: CipherAuthorizationService, useValue: mock<CipherAuthorizationService>() },
+        { provide: ProviderService, useValue: mock<ProviderService>() },
+        { provide: LogoutService, useValue: mock<LogoutService>() },
+        { provide: LockService, useValue: mock<LockService>() },
+        {
+          provide: AvatarService,
+          useValue: { ...mock<AvatarService>(), avatarColor$: of(null) },
+        },
+        {
+          provide: StateProvider,
+          useValue: {
+            ...mock<StateProvider>(),
+            getUser: jest.fn().mockReturnValue({ update: jest.fn(), state$: of({}) }),
+          },
+        },
+        {
+          provide: OrganizationApiServiceAbstraction,
+          useValue: mock<OrganizationApiServiceAbstraction>(),
+        },
+        {
+          provide: AuthRequestServiceAbstraction,
+          useValue: mock<AuthRequestServiceAbstraction>(),
+        },
+        {
+          provide: AutomaticUserConfirmationService,
+          useValue: mock<AutomaticUserConfirmationService>(),
+        },
+        {
+          provide: WebVaultExtensionPromptService,
+          useValue: mock<WebVaultExtensionPromptService>(),
+        },
+        { provide: ActivatedRoute, useValue: mockActivatedRoute },
+        { provide: CipherService, useValue: cipherServiceMock },
+        { provide: CollectionService, useValue: collectionServiceMock },
+        { provide: BillingAccountProfileStateService, useValue: billingMock },
+        { provide: OrganizationService, useValue: organizationServiceMock },
+        { provide: PolicyService, useValue: policyServiceMock },
+        { provide: I18nService, useValue: { t: (key: string) => key } },
+        { provide: MessageListener, useValue: { allMessages$: EMPTY } },
+        {
+          provide: VaultOnboardingService,
+          useValue: { vaultOnboardingState$: jest.fn().mockReturnValue({ state$: of([]) }) },
+        },
+        {
+          provide: AccountService,
+          useValue: {
+            activeAccount$: of({
+              id: TEST_USER_ID,
+              email: "test@test.com",
+              emailVerified: true,
+              name: "Test",
+            }),
+          },
+        },
+        {
+          provide: RestrictedItemTypesService,
+          useValue: {
+            restricted$,
+            // Restriction is keyed off the type list the spec pushes into `restricted$`.
+            isCipherRestricted: (cipher: CipherView, restricted: { cipherType: CipherType }[]) =>
+              restricted.some((r) => r.cipherType === cipher.type),
+          },
+        },
+        {
+          provide: CipherArchiveService,
+          useValue: {
+            userCanArchive$: jest.fn().mockReturnValue(userCanArchive$),
+            showSubscriptionEndedMessaging$: jest.fn().mockReturnValue(of(false)),
+            archivedCiphers$: jest.fn().mockReturnValue(of([])),
+            userHasPremium$: jest.fn().mockReturnValue(of([])),
+          },
+        },
+        {
+          provide: VaultTimeoutSettingsService,
+          useValue: { availableVaultTimeoutActions$: () => of([]) },
+        },
+        {
+          provide: ProductSwitcherService,
+          useValue: {
+            products$: of({ bento: [], other: [] }),
+            organizations$: of([]),
+            providers$: of([]),
+          },
+        },
+        {
+          provide: VaultProfileService,
+          useValue: { getProfileCreationDate: jest.fn().mockResolvedValue(new Date()) },
+        },
+      ],
+      schemas: [NO_ERRORS_SCHEMA],
+    })
+      .overrideComponent(VaultNextComponent, {
+        set: {
+          providers: [
+            { provide: RoutedVaultFilterService, useValue: { filter$: of({}) } },
+            {
+              provide: RoutedVaultFilterBridgeService,
+              useValue: { activeFilter$: of(new VaultFilter()), navigate: jest.fn() },
+            },
+            {
+              provide: DefaultCipherFormConfigService,
+              useValue: { buildConfig: jest.fn().mockResolvedValue({}) },
+            },
+            { provide: WebVaultPromptService, useValue: { conditionallyPromptUser: jest.fn() } },
+            { provide: VaultItemsTransferService, useValue: mock<VaultItemsTransferService>() },
+            {
+              provide: VaultBatchBarService,
+              useValue: {
+                completed$: EMPTY,
+                selection: new SelectionModel<VaultItem<any>>(true, [], true),
+                setConfig: jest.fn(),
+                enabled: signal(false),
+                barVisible: signal(false),
+              },
+            },
+            {
+              provide: ASSIGN_COLLECTIONS_DIALOG,
+              useValue: {
+                open: jest.fn().mockResolvedValue(AssignCollectionsResult.Canceled),
+              } satisfies AssignCollectionsDialogRef,
+            },
+            {
+              provide: BULK_DELETE_DIALOG,
+              useValue: {
+                open: jest.fn().mockResolvedValue(BulkDeleteDialogResult.Canceled),
+              } satisfies BulkDeleteDialogRef,
+            },
+          ],
+        },
+      })
+      .overrideProvider(VaultBannersService, { useValue: mock<VaultBannersService>() })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(VaultNextComponent<CipherView>);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it("creates", () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe("rows", () => {
+    it("exposes the user's ciphers", () => {
+      cipherListViews$.next([login()]);
+      expect(rows().map((c) => c.id)).toEqual(["cipher-1"]);
+    });
+
+    it("drops ciphers whose type the policy restricts", () => {
+      restricted$.next([{ cipherType: CipherType.Card }]);
+      cipherListViews$.next([login(), login({ id: "cipher-2", type: CipherType.Card })]);
+
+      expect(rows().map((c) => c.id)).toEqual(["cipher-1"]);
+    });
+  });
+
+  describe("rowActions", () => {
+    it("offers the standard actions", () => {
+      expect(actionIds()).toEqual([
+        "favorite",
+        "unfavorite",
+        "edit",
+        "attachments",
+        "clone",
+        "assignToCollections",
+        "delete",
+      ]);
+    });
+
+    it("adds archive once the user can archive", () => {
+      userCanArchive$.next(true);
+      expect(actionIds()).toContain("archive");
+    });
+
+    it("keeps delete last so the danger action stays at the bottom of the menu", () => {
+      userCanArchive$.next(true);
+      expect(actionIds().at(-1)).toBe("delete");
+    });
+
+    it("shows favorite only for unfavorited items, and unfavorite only for favorited ones", () => {
+      const actions = (
+        component as unknown as {
+          rowActions: () => { id: string; show?: (item: CipherView) => boolean }[];
+        }
+      ).rowActions();
+      const favorite = actions.find((a) => a.id === "favorite")!;
+      const unfavorite = actions.find((a) => a.id === "unfavorite")!;
+
+      expect(favorite.show!(login({ favorite: false }))).toBe(true);
+      expect(favorite.show!(login({ favorite: true }))).toBe(false);
+      expect(unfavorite.show!(login({ favorite: true }))).toBe(true);
+      expect(unfavorite.show!(login({ favorite: false }))).toBe(false);
+    });
+
+    it("builds events the base class's dispatcher understands", () => {
+      const actions = (
+        component as unknown as {
+          rowActions: () => { id: string; event: (item: CipherView) => unknown }[];
+        }
+      ).rowActions();
+      const item = login();
+
+      expect(actions.find((a) => a.id === "edit")!.event(item)).toEqual({
+        type: "editCipher",
+        item,
+      });
+      expect(actions.find((a) => a.id === "delete")!.event(item)).toEqual({
+        type: "delete",
+        items: [{ cipher: item }],
+      });
+      expect(actions.find((a) => a.id === "assignToCollections")!.event(item)).toEqual({
+        type: "assignToCollections",
+        items: [item],
+      });
+    });
+  });
+
+  describe("itemAction", () => {
+    it("opens the item for editing when a row's name is activated", () => {
+      const item = login();
+      expect(
+        (component as unknown as { itemAction: (item: CipherView) => unknown }).itemAction(item),
+      ).toEqual({ type: "editCipher", item });
+    });
+  });
+});

--- a/apps/web/src/app/vault/individual-vault/vault-next.component.ts
+++ b/apps/web/src/app/vault/individual-vault/vault-next.component.ts
@@ -21,7 +21,7 @@ import {
 } from "@bitwarden/vault";
 
 import { VaultBannersComponent } from "./vault-banners/vault-banners.component";
-import { VaultComponent } from "./vault.component";
+import { VAULT_COMPONENT_PROVIDERS, VaultComponent } from "./vault.component";
 
 /**
  * The vault page behind the `vfo1-foundation` flag: the same individual vault, rendered on the
@@ -35,12 +35,17 @@ import { VaultComponent } from "./vault.component";
  *
  * The table owns search, filtering, and sorting internally, so this page renders no
  * `app-vault-filter` sidebar — the reason the flag swaps the whole page rather than just the list.
+ *
+ * The base class's providers have to be repeated here: Angular inherits a base class's code but
+ * not its `@Component` metadata, so without {@link VAULT_COMPONENT_PROVIDERS} the inherited
+ * services fail to resolve at runtime (NG0201).
  */
 @Component({
   selector: "app-vault-next",
   templateUrl: "vault-next.component.html",
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [ButtonModule, I18nPipe, VaultBannersComponent, VaultItemsTableComponent],
+  providers: VAULT_COMPONENT_PROVIDERS,
 })
 export class VaultNextComponent<C extends CipherViewLike> extends VaultComponent<C> {
   private readonly i18nStrings = inject(I18nService);

--- a/apps/web/src/app/vault/individual-vault/vault-next.component.ts
+++ b/apps/web/src/app/vault/individual-vault/vault-next.component.ts
@@ -1,0 +1,175 @@
+import { ChangeDetectionStrategy, Component, computed, inject, Signal } from "@angular/core";
+import { toSignal } from "@angular/core/rxjs-interop";
+import { combineLatest } from "rxjs";
+import { filter, map, switchMap } from "rxjs/operators";
+
+import { CollectionService } from "@bitwarden/admin-console/common";
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { getUserId } from "@bitwarden/common/auth/services/account.service";
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { CipherArchiveService } from "@bitwarden/common/vault/abstractions/cipher-archive.service";
+import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
+import { FolderService } from "@bitwarden/common/vault/abstractions/folder/folder.service.abstraction";
+import { RestrictedItemTypesService } from "@bitwarden/common/vault/services/restricted-item-types.service";
+import { CipherViewLike } from "@bitwarden/common/vault/utils/cipher-view-like-utils";
+import { ButtonModule } from "@bitwarden/components";
+import { I18nPipe } from "@bitwarden/ui-common";
+import {
+  VaultItemEvent,
+  VaultItemsTableComponent,
+  VaultItemsTableRowAction,
+} from "@bitwarden/vault";
+
+import { VaultBannersComponent } from "./vault-banners/vault-banners.component";
+import { VaultComponent } from "./vault.component";
+
+/**
+ * The vault page behind the `vfo1-foundation` flag: the same individual vault, rendered on the
+ * shared {@link VaultItemsTableComponent} instead of `app-vault-items` + `app-vault-filter`.
+ *
+ * It extends {@link VaultComponent} rather than reimplementing it. Every action a row can take —
+ * edit, clone, attachments, archive, delete, collection assignment — routes through dialogs and
+ * reprompt checks that already live on the base class, so this subclass supplies only what the new
+ * table needs: the row-action set, and the folders/collections/organizations its columns and
+ * filter chips resolve names from. Behavior stays in one place, and the two pages can't drift.
+ *
+ * The table owns search, filtering, and sorting internally, so this page renders no
+ * `app-vault-filter` sidebar — the reason the flag swaps the whole page rather than just the list.
+ */
+@Component({
+  selector: "app-vault-next",
+  templateUrl: "vault-next.component.html",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [ButtonModule, I18nPipe, VaultBannersComponent, VaultItemsTableComponent],
+})
+export class VaultNextComponent<C extends CipherViewLike> extends VaultComponent<C> {
+  private readonly i18nStrings = inject(I18nService);
+  private readonly accountsStore = inject(AccountService);
+  private readonly cipherStore = inject(CipherService);
+  private readonly folderStore = inject(FolderService);
+  private readonly collectionStore = inject(CollectionService);
+  private readonly archiveStore = inject(CipherArchiveService);
+  private readonly restrictedTypes = inject(RestrictedItemTypesService);
+
+  private readonly activeUserId$ = this.accountsStore.activeAccount$.pipe(getUserId);
+
+  /**
+   * The rows.
+   *
+   * Built here rather than read off the base class's `ciphers` field: that field is assigned from
+   * a subscription inside the base `ngOnInit`, so it is neither a signal nor an observable and
+   * can't drive an OnPush template. This is the same stream the base class composes — the user's
+   * ciphers minus the types policy restricts — without the routed-filter and search stages, which
+   * the table now owns.
+   *
+   * The cast mirrors the base class's own: `cipherListViews$` is typed
+   * `CipherListView[] | CipherView[]`, and which of the two arrives is a runtime concern the `C`
+   * parameter can't express.
+   */
+  protected readonly rows: Signal<C[]> = toSignal(
+    combineLatest([
+      this.activeUserId$.pipe(
+        switchMap((userId) => this.cipherStore.cipherListViews$(userId)),
+        filter((ciphers) => ciphers != null),
+      ),
+      this.restrictedTypes.restricted$,
+    ]).pipe(
+      map(
+        ([ciphers, restricted]) =>
+          ciphers.filter(
+            (cipher) => !this.restrictedTypes.isCipherRestricted(cipher, restricted),
+          ) as C[],
+      ),
+    ),
+    { initialValue: [] as C[] },
+  );
+
+  protected readonly folders = toSignal(
+    this.activeUserId$.pipe(switchMap((userId) => this.folderStore.folderViews$(userId))),
+    { initialValue: [] },
+  );
+
+  protected readonly collectionOptions = toSignal(
+    this.activeUserId$.pipe(
+      switchMap((userId) => this.collectionStore.decryptedCollections$(userId)),
+    ),
+    { initialValue: [] },
+  );
+
+  protected readonly organizationOptions = toSignal(this.organizations$, { initialValue: [] });
+
+  private readonly userCanArchive = toSignal(
+    this.activeUserId$.pipe(switchMap((userId) => this.archiveStore.userCanArchive$(userId))),
+    { initialValue: false },
+  );
+
+  /**
+   * The overflow-menu actions, as event factories the table invokes on selection — it builds no
+   * domain events itself. Each resulting event goes back through
+   * {@link VaultComponent.onVaultItemsEvent}, the same dispatcher the current page uses.
+   */
+  protected readonly rowActions = computed<VaultItemsTableRowAction<C, VaultItemEvent<C>>[]>(() => {
+    const actions: VaultItemsTableRowAction<C, VaultItemEvent<C>>[] = [
+      {
+        id: "favorite",
+        label: this.i18nStrings.t("favorite"),
+        icon: "bwi-star",
+        show: (item) => !item.favorite,
+        event: (item) => ({ type: "toggleFavorite", item }),
+      },
+      {
+        id: "unfavorite",
+        label: this.i18nStrings.t("unfavorite"),
+        icon: "bwi-star",
+        show: (item) => item.favorite,
+        event: (item) => ({ type: "toggleFavorite", item }),
+      },
+      {
+        id: "edit",
+        label: this.i18nStrings.t("edit"),
+        icon: "bwi-pencil-square",
+        event: (item) => ({ type: "editCipher", item }),
+      },
+      {
+        id: "attachments",
+        label: this.i18nStrings.t("attachments"),
+        icon: "bwi-paperclip",
+        event: (item) => ({ type: "viewAttachments", item }),
+      },
+      {
+        id: "clone",
+        label: this.i18nStrings.t("clone"),
+        icon: "bwi-files",
+        event: (item) => ({ type: "clone", item }),
+      },
+      {
+        id: "assignToCollections",
+        label: this.i18nStrings.t("assignToCollections"),
+        icon: "bwi-collection-shared",
+        event: (item) => ({ type: "assignToCollections", items: [item] }),
+      },
+    ];
+
+    if (this.userCanArchive()) {
+      actions.push({
+        id: "archive",
+        label: this.i18nStrings.t("archiveVerb"),
+        icon: "bwi-archive",
+        event: (item) => ({ type: "archive", items: [item] }),
+      });
+    }
+
+    actions.push({
+      id: "delete",
+      label: this.i18nStrings.t("delete"),
+      icon: "bwi-trash",
+      variant: "danger",
+      event: (item) => ({ type: "delete", items: [{ cipher: item }] }),
+    });
+
+    return actions;
+  });
+
+  /** Opens a row's item dialog when its name is activated. */
+  protected readonly itemAction = (item: C): VaultItemEvent<C> => ({ type: "editCipher", item });
+}

--- a/apps/web/src/app/vault/individual-vault/vault-routing.module.ts
+++ b/apps/web/src/app/vault/individual-vault/vault-routing.module.ts
@@ -1,13 +1,22 @@
 import { NgModule } from "@angular/core";
 import { RouterModule, Routes } from "@angular/router";
 
+import { featureFlaggedRoute } from "@bitwarden/angular/platform/utils/feature-flagged-route";
+import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
+
+import { VaultNextComponent } from "./vault-next.component";
 import { VaultComponent } from "./vault.component";
+
 const routes: Routes = [
-  {
-    path: "",
-    component: VaultComponent,
-    data: { titleId: "vaults" },
-  },
+  ...featureFlaggedRoute({
+    defaultComponent: VaultComponent,
+    flaggedComponent: VaultNextComponent,
+    featureFlag: FeatureFlag.VFO1Foundation,
+    routeOptions: {
+      path: "",
+      data: { titleId: "vaults" },
+    },
+  }),
 ];
 @NgModule({
   imports: [RouterModule.forChild(routes)],

--- a/apps/web/src/app/vault/individual-vault/vault.component.ts
+++ b/apps/web/src/app/vault/individual-vault/vault.component.ts
@@ -162,6 +162,25 @@ type EmptyStateItem = {
 
 type EmptyStateMap = Record<EmptyStateType, EmptyStateItem>;
 
+/**
+ * The services {@link VaultComponent} and its subclasses provide at the component level.
+ *
+ * Shared as a constant because Angular does not inherit `@Component` metadata: a subclass gets the
+ * base class's *code* but none of its `providers`, so any page extending `VaultComponent` has to
+ * declare these itself or fail at runtime with NG0201. Referencing this list keeps the two
+ * declarations from drifting apart.
+ */
+export const VAULT_COMPONENT_PROVIDERS = [
+  RoutedVaultFilterService,
+  RoutedVaultFilterBridgeService,
+  DefaultCipherFormConfigService,
+  WebVaultPromptService,
+  { provide: VaultItemsTransferService, useClass: DefaultVaultItemsTransferService },
+  VaultBatchBarService,
+  { provide: ASSIGN_COLLECTIONS_DIALOG, useClass: AssignCollectionsWebDialogAdapter },
+  { provide: BULK_DELETE_DIALOG, useClass: BulkDeleteDialogWebAdapter },
+];
+
 // FIXME(https://bitwarden.atlassian.net/browse/CL-764): Migrate to OnPush
 // eslint-disable-next-line @angular-eslint/prefer-on-push-component-change-detection
 @Component({
@@ -177,16 +196,7 @@ type EmptyStateMap = Record<EmptyStateType, EmptyStateItem>;
     SharedModule,
     VaultBatchActionComponent,
   ],
-  providers: [
-    RoutedVaultFilterService,
-    RoutedVaultFilterBridgeService,
-    DefaultCipherFormConfigService,
-    WebVaultPromptService,
-    { provide: VaultItemsTransferService, useClass: DefaultVaultItemsTransferService },
-    VaultBatchBarService,
-    { provide: ASSIGN_COLLECTIONS_DIALOG, useClass: AssignCollectionsWebDialogAdapter },
-    { provide: BULK_DELETE_DIALOG, useClass: BulkDeleteDialogWebAdapter },
-  ],
+  providers: VAULT_COMPONENT_PROVIDERS,
 })
 export class VaultComponent<C extends CipherViewLike> implements OnInit, OnDestroy {
   private readonly vfo1TerminologyService = inject(Vfo1TerminologyService);


### PR DESCRIPTION
## 🎟️ Tracking

[PM-40312](https://bitwarden.atlassian.net/browse/PM-40312)

## 📔 Objective

Adds the web `VaultNextComponent` that hosts the shared `VaultItemsTableComponent`, completing the
second half of PM-40312. The page is route-swapped against the existing vault via
`featureFlaggedRoute`, gated on the `vfo1-foundation` flag.

> [!NOTE]
> Based on `vault/pm-40312/vault-items-table-component` (#22237), not `main`. Retarget to `main`
> once that PR merges.

Includes:

- `VaultNextComponent`, which **extends** `VaultComponent` so every row action reuses the base
  class's dialogs and password-reprompt checks rather than reimplementing them. The subclass
  supplies only the row-action set plus the folders/collections/organizations the table's columns
  and filter chips resolve names from.
- The flag-gated route in `vault-routing.module.ts`.
- Unit coverage for the row-action policy, the event factories, and cipher-type restriction.

The new page omits `app-vault-filter` — the shared table owns search, filtering, and sorting
itself, which is why the flag swaps the whole page rather than just the list.

## ⚙️ Notes

Two things worth a reviewer's attention:

- **Rows are rebuilt from `cipherListViews$`** rather than read off the base class. `VaultComponent`
  assigns its `ciphers` field from a subscription, so it is neither a signal nor an observable and
  cannot drive an OnPush template. The stream here is the same one the base composes, minus the
  routed-filter and search stages the table now owns.
- **Inheriting forced renames of every injected service** (`cipherStore`, `collectionStore`,
  `i18nStrings`, …) to avoid private-field collisions with the base class. It type-checks, but the
  awkward names are a real cost of the inheritance approach. Composition would first require
  extracting the base class's event handlers into a service — a larger refactor than this ticket.

`VAULT_COMPONENT_PROVIDERS` is extracted from `VaultComponent` and shared by both pages: Angular
inherits a base class's code but not its `@Component` metadata, so a subclass that doesn't repeat
the provider list fails at runtime with NG0201. Note that the unit suite cannot guard this —
`TestBed` supplies those providers itself — so it needs to hold up in the running app.

## ⏰ Reminders before requesting review

- [x] Applicable issues opened
- [ ] Manual QA: not yet exercised in the running app with the flag enabled
- [x] Tests written where necessary

## 🦮 Reviewer guidelines

<!-- Please leave an emoji to indicate the priority/type of comment -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) for confusion or clarification
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-40312]: https://bitwarden.atlassian.net/browse/PM-40312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ