### PR TITLE
desktop-autofill: Refactor UV reprompt and window management [PM-29791]

### DIFF
--- a/apps/desktop/src/app/services/services.module.ts
+++ b/apps/desktop/src/app/services/services.module.ts
@@ -149,6 +149,7 @@ import {
   RoutedVaultFilterBridgeService,
   VAULT_FILTER_BASE_ROUTE,
   Vfo1TerminologyService,
+  PasswordRepromptService,
 } from "@bitwarden/vault";
 
 import { DesktopLoginComponentService } from "../../auth/login/desktop-login-component.service";
@@ -448,6 +449,7 @@ const safeProviders: SafeProvider[] = [
       MessagingServiceAbstraction,
       Router,
       DesktopSettingsService,
+      PasswordRepromptService,
     ],
   }),
   safeProvider({

--- a/apps/desktop/src/autofill/modal/credentials/fido2-create.component.spec.ts
+++ b/apps/desktop/src/autofill/modal/credentials/fido2-create.component.spec.ts
@@ -13,7 +13,6 @@ import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.servi
 import { CipherRepromptType, CipherType } from "@bitwarden/common/vault/enums";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { DialogService } from "@bitwarden/components";
-import { PasswordRepromptService } from "@bitwarden/vault";
 
 import { DesktopAutofillService } from "../../../autofill/services/desktop-autofill.service";
 import { DesktopSettingsService } from "../../../platform/services/desktop-settings.service";
@@ -34,7 +33,6 @@ describe("Fido2CreateComponent", () => {
   let mockDialogService: MockProxy<DialogService>;
   let mockDomainSettingsService: MockProxy<DomainSettingsService>;
   let mockLogService: MockProxy<LogService>;
-  let mockPasswordRepromptService: MockProxy<PasswordRepromptService>;
   let mockRouter: MockProxy<Router>;
   let mockSession: MockProxy<DesktopFido2UserInterfaceSession>;
   let mockI18nService: MockProxy<I18nService>;
@@ -56,7 +54,6 @@ describe("Fido2CreateComponent", () => {
     mockDialogService = mock<DialogService>();
     mockDomainSettingsService = mock<DomainSettingsService>();
     mockLogService = mock<LogService>();
-    mockPasswordRepromptService = mock<PasswordRepromptService>();
     mockRouter = mock<Router>();
     mockSession = mock<DesktopFido2UserInterfaceSession>();
     mockI18nService = mock<I18nService>();
@@ -75,7 +72,6 @@ describe("Fido2CreateComponent", () => {
         { provide: DialogService, useValue: mockDialogService },
         { provide: DomainSettingsService, useValue: mockDomainSettingsService },
         { provide: LogService, useValue: mockLogService },
-        { provide: PasswordRepromptService, useValue: mockPasswordRepromptService },
         { provide: Router, useValue: mockRouter },
         { provide: I18nService, useValue: mockI18nService },
       ],
@@ -157,16 +153,6 @@ describe("Fido2CreateComponent", () => {
       await component.addCredentialToCipher(cipher);
 
       expect(mockSession.notifyConfirmCreateCredential).toHaveBeenCalledWith(true, cipher);
-    });
-
-    it("should not add passkey when password reprompt is cancelled", async () => {
-      const cipher = createMockCiphers()[0];
-      cipher.reprompt = CipherRepromptType.Password;
-      mockPasswordRepromptService.showPasswordPrompt.mockResolvedValue(false);
-
-      await component.addCredentialToCipher(cipher);
-
-      expect(mockSession.notifyConfirmCreateCredential).toHaveBeenCalledWith(false, cipher);
     });
 
     it("should call openSimpleDialog when cipher already has a fido2 credential", async () => {

--- a/apps/desktop/src/autofill/modal/credentials/fido2-create.component.ts
+++ b/apps/desktop/src/autofill/modal/credentials/fido2-create.component.ts
@@ -29,7 +29,6 @@ import {
   SimpleDialogOptions,
 } from "@bitwarden/components";
 import { I18nPipe } from "@bitwarden/ui-common";
-import { PasswordRepromptService } from "@bitwarden/vault";
 
 import { DesktopAutofillService } from "../../../autofill/services/desktop-autofill.service";
 import { DesktopSettingsService } from "../../../platform/services/desktop-settings.service";
@@ -98,7 +97,6 @@ export class Fido2CreateComponent implements OnInit, OnDestroy {
     private readonly desktopAutofillService: DesktopAutofillService,
     private readonly dialogService: DialogService,
     private readonly domainSettingsService: DomainSettingsService,
-    private readonly passwordRepromptService: PasswordRepromptService,
     private readonly router: Router,
   ) {}
 
@@ -207,10 +205,6 @@ export class Fido2CreateComponent implements OnInit, OnDestroy {
       if (!overwriteConfirmed) {
         return false;
       }
-    }
-
-    if (cipher.reprompt) {
-      return this.passwordRepromptService.showPasswordPrompt();
     }
 
     return true;

--- a/apps/desktop/src/autofill/modal/credentials/fido2-create.component.ts
+++ b/apps/desktop/src/autofill/modal/credentials/fido2-create.component.ts
@@ -149,15 +149,15 @@ export class Fido2CreateComponent implements OnInit, OnDestroy {
   }
 
   async closeModal(): Promise<void> {
-    await this.desktopSettingsService.setModalMode(false);
-    await this.accountService.setShowHeader(true);
-
+    // Let the session clean up the modal, if present.
     if (this.session) {
       this.session.notifyConfirmCreateCredential(false);
       this.session.confirmChosenCipher(null);
+    } else {
+      await this.desktopSettingsService.setModalMode(false);
+      await this.accountService.setShowHeader(true);
+      await this.router.navigate(["/"]);
     }
-
-    await this.router.navigate(["/"]);
   }
 
   private initializeCiphersObservable(rpid: string): void {

--- a/apps/desktop/src/autofill/modal/credentials/fido2-excluded-ciphers.component.spec.ts
+++ b/apps/desktop/src/autofill/modal/credentials/fido2-excluded-ciphers.component.spec.ts
@@ -64,14 +64,28 @@ describe("Fido2ExcludedCiphersComponent", () => {
   });
 
   describe("closeModal", () => {
-    it("should close modal and notify session when session exists", async () => {
+    it("should notify the session and let it reset the window when a session exists", async () => {
       component.session = mockSession;
+
+      await component.closeModal();
+
+      expect(mockSession.notifyConfirmCreateCredential).toHaveBeenCalledWith(false);
+      expect(mockSession.confirmChosenCipher).toHaveBeenCalledWith(null);
+      expect(mockSession.hideUi).toHaveBeenCalled();
+
+      // The session owns this teardown; the component must not duplicate it.
+      expect(mockDesktopSettingsService.setModalMode).not.toHaveBeenCalled();
+      expect(mockAccountService.setShowHeader).not.toHaveBeenCalled();
+      expect(mockRouter.navigate).not.toHaveBeenCalled();
+    });
+
+    it("should reset the window itself when there is no session to hand off to", async () => {
+      component.session = null;
 
       await component.closeModal();
 
       expect(mockDesktopSettingsService.setModalMode).toHaveBeenCalledWith(false);
       expect(mockAccountService.setShowHeader).toHaveBeenCalledWith(true);
-      expect(mockSession.notifyConfirmCreateCredential).toHaveBeenCalledWith(false);
       expect(mockRouter.navigate).toHaveBeenCalledWith(["/"]);
     });
   });

--- a/apps/desktop/src/autofill/modal/credentials/fido2-excluded-ciphers.component.ts
+++ b/apps/desktop/src/autofill/modal/credentials/fido2-excluded-ciphers.component.ts
@@ -66,17 +66,19 @@ export class Fido2ExcludedCiphersComponent implements OnInit, OnDestroy {
   }
 
   async closeModal(): Promise<void> {
-    // Clean up modal state
-    await this.desktopSettingsService.setModalMode(false);
-    await this.accountService.setShowHeader(true);
-
-    // Clean up session state
     if (this.session) {
+      // Clean up session state
       this.session.notifyConfirmCreateCredential(false);
       this.session.confirmChosenCipher(null);
-    }
 
-    // Navigate away
-    await this.router.navigate(["/"]);
+      // The session knows whether this ceremony showed any UI, so let it decide
+      // whether the window needs to be reset and navigated away from.
+      await this.session.hideUi();
+    } else {
+      // There is no session to hand this off to, so reset the window here.
+      await this.desktopSettingsService.setModalMode(false);
+      await this.accountService.setShowHeader(true);
+      await this.router.navigate(["/"]);
+    }
   }
 }

--- a/apps/desktop/src/autofill/modal/credentials/fido2-vault.component.spec.ts
+++ b/apps/desktop/src/autofill/modal/credentials/fido2-vault.component.spec.ts
@@ -11,7 +11,6 @@ import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.servi
 import { CipherRepromptType, CipherType } from "@bitwarden/common/vault/enums";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { DialogService } from "@bitwarden/components";
-import { PasswordRepromptService } from "@bitwarden/vault";
 
 import { DesktopSettingsService } from "../../../platform/services/desktop-settings.service";
 import {
@@ -29,7 +28,6 @@ describe("Fido2VaultComponent", () => {
   let mockCipherService: MockProxy<CipherService>;
   let mockAccountService: MockProxy<AccountService>;
   let mockLogService: MockProxy<LogService>;
-  let mockPasswordRepromptService: MockProxy<PasswordRepromptService>;
   let mockRouter: MockProxy<Router>;
   let mockSession: MockProxy<DesktopFido2UserInterfaceSession>;
   let mockI18nService: MockProxy<I18nService>;
@@ -43,7 +41,6 @@ describe("Fido2VaultComponent", () => {
     mockCipherService = mock<CipherService>();
     mockAccountService = mock<AccountService>();
     mockLogService = mock<LogService>();
-    mockPasswordRepromptService = mock<PasswordRepromptService>();
     mockRouter = mock<Router>();
     mockSession = mock<DesktopFido2UserInterfaceSession>();
     mockI18nService = mock<I18nService>();
@@ -61,7 +58,6 @@ describe("Fido2VaultComponent", () => {
         { provide: CipherService, useValue: mockCipherService },
         { provide: AccountService, useValue: mockAccountService },
         { provide: LogService, useValue: mockLogService },
-        { provide: PasswordRepromptService, useValue: mockPasswordRepromptService },
         { provide: Router, useValue: mockRouter },
         { provide: I18nService, useValue: mockI18nService },
       ],
@@ -162,26 +158,6 @@ describe("Fido2VaultComponent", () => {
 
       expect(mockSession.confirmChosenCipher).toHaveBeenCalledWith(cipher.id, true);
       expect(mockRouter.navigate).toHaveBeenCalledWith(["/"]);
-    });
-
-    it("should prompt for password when cipher requires reprompt", async () => {
-      cipher.reprompt = CipherRepromptType.Password;
-      mockPasswordRepromptService.showPasswordPrompt.mockResolvedValue(true);
-
-      await component.chooseCipher(cipher);
-
-      expect(mockPasswordRepromptService.showPasswordPrompt).toHaveBeenCalled();
-      expect(mockSession.confirmChosenCipher).toHaveBeenCalledWith(cipher.id, true);
-    });
-
-    it("should not choose cipher when password reprompt is cancelled", async () => {
-      cipher.reprompt = CipherRepromptType.Password;
-      mockPasswordRepromptService.showPasswordPrompt.mockResolvedValue(false);
-
-      await component.chooseCipher(cipher);
-
-      expect(mockPasswordRepromptService.showPasswordPrompt).toHaveBeenCalled();
-      expect(mockSession.confirmChosenCipher).toHaveBeenCalledWith(cipher.id, false);
     });
   });
 

--- a/apps/desktop/src/autofill/modal/credentials/fido2-vault.component.spec.ts
+++ b/apps/desktop/src/autofill/modal/credentials/fido2-vault.component.spec.ts
@@ -116,11 +116,11 @@ describe("Fido2VaultComponent", () => {
     });
 
     it("should handle when no active session found", async () => {
-      mockFido2UserInterfaceService.getCurrentSession.mockReturnValue(null);
+      mockFido2UserInterfaceService.getCurrentSession.mockReturnValue(undefined);
 
       await component.ngOnInit();
 
-      expect(component.session).toBeNull();
+      expect(component.session).toBeUndefined();
     });
 
     it("should filter out deleted ciphers", async () => {
@@ -151,12 +151,19 @@ describe("Fido2VaultComponent", () => {
       component.session = mockSession;
     });
 
-    it("should choose cipher when access is validated", async () => {
-      cipher.reprompt = CipherRepromptType.None;
-
+    it("hands the chosen cipher to the session", async () => {
       await component.chooseCipher(cipher);
 
-      expect(mockSession.confirmChosenCipher).toHaveBeenCalledWith(cipher.id, true);
+      // Verification (master-password reprompt or OS) is handled by the session.
+      expect(mockSession.confirmChosenCipher).toHaveBeenCalledWith(cipher);
+    });
+
+    it("closes the modal if the session is not found when cipher is chosen ", async () => {
+      component.session = undefined;
+      await component.chooseCipher(cipher);
+
+      // Verification (master-password reprompt or OS) is handled by the session.
+      expect(mockSession.confirmChosenCipher).not.toHaveBeenCalled();
       expect(mockRouter.navigate).toHaveBeenCalledWith(["/"]);
     });
   });
@@ -167,7 +174,7 @@ describe("Fido2VaultComponent", () => {
 
       await component.closeModal();
 
-      expect(mockRouter.navigate).toHaveBeenCalledWith(["/"]);
+      expect(mockRouter.navigate).not.toHaveBeenCalled();
       expect(mockSession.notifyConfirmCreateCredential).toHaveBeenCalledWith(false);
       expect(mockSession.confirmChosenCipher).toHaveBeenCalledWith(null);
     });

--- a/apps/desktop/src/autofill/modal/credentials/fido2-vault.component.ts
+++ b/apps/desktop/src/autofill/modal/credentials/fido2-vault.component.ts
@@ -21,7 +21,6 @@ import { BitwardenShield } from "@bitwarden/assets/svg";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
-import { CipherRepromptType } from "@bitwarden/common/vault/enums";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import {
   BadgeModule,
@@ -36,7 +35,6 @@ import {
   SectionHeaderComponent,
 } from "@bitwarden/components";
 import { I18nPipe } from "@bitwarden/ui-common";
-import { PasswordRepromptService } from "@bitwarden/vault";
 
 import { DesktopSettingsService } from "../../../platform/services/desktop-settings.service";
 import {
@@ -79,7 +77,6 @@ export class Fido2VaultComponent implements OnInit, OnDestroy {
     private readonly accountService: AccountService,
     private readonly dialogService: DialogService,
     private readonly logService: LogService,
-    private readonly passwordRepromptService: PasswordRepromptService,
     private readonly router: Router,
   ) {}
 
@@ -156,7 +153,6 @@ export class Fido2VaultComponent implements OnInit, OnDestroy {
         error: (error: unknown) => this.logService.error("Failed to load ciphers", error),
       });
   }
-
   private async validateCipherAccess(cipher: CipherView): Promise<boolean> {
     if (cipher.reprompt !== CipherRepromptType.None) {
       return this.passwordRepromptService.showPasswordPrompt();

--- a/apps/desktop/src/autofill/modal/credentials/fido2-vault.component.ts
+++ b/apps/desktop/src/autofill/modal/credentials/fido2-vault.component.ts
@@ -105,22 +105,20 @@ export class Fido2VaultComponent implements OnInit, OnDestroy {
       return;
     }
 
-    const isConfirmed = await this.validateCipherAccess(cipher);
-    this.session.confirmChosenCipher(cipher.id, isConfirmed);
+    this.session.confirmChosenCipher(cipher);
 
     await this.closeModal();
   }
 
   async closeModal(): Promise<void> {
-    await this.desktopSettingsService.setModalMode(false);
-    await this.accountService.setShowHeader(true);
-
     if (this.session) {
       this.session.notifyConfirmCreateCredential(false);
       this.session.confirmChosenCipher(null);
+    } else {
+      await this.desktopSettingsService.setModalMode(false);
+      await this.accountService.setShowHeader(true);
+      await this.router.navigate(["/"]);
     }
-
-    await this.router.navigate(["/"]);
   }
 
   private async loadCiphers(): Promise<void> {
@@ -152,12 +150,5 @@ export class Fido2VaultComponent implements OnInit, OnDestroy {
         next: (ciphers) => this.ciphersSubject.next(ciphers as CipherView[]),
         error: (error: unknown) => this.logService.error("Failed to load ciphers", error),
       });
-  }
-  private async validateCipherAccess(cipher: CipherView): Promise<boolean> {
-    if (cipher.reprompt !== CipherRepromptType.None) {
-      return this.passwordRepromptService.showPasswordPrompt();
-    }
-
-    return true;
   }
 }

--- a/apps/desktop/src/autofill/services/desktop-fido2-user-interface.service.spec.ts
+++ b/apps/desktop/src/autofill/services/desktop-fido2-user-interface.service.spec.ts
@@ -386,4 +386,29 @@ describe("DesktopFido2UserInterfaceSession", () => {
       );
     });
   });
+
+  describe("informExcludedCredential", () => {
+    it("shows the excluded credentials UI and returns without waiting for the user", async () => {
+      await session.informExcludedCredential(["cipher-1"]);
+
+      expect(desktopSettingsService.setModalMode).toHaveBeenCalledWith(true, false, {
+        x: 0,
+        y: 0,
+      });
+      expect(accountService.setShowHeader).toHaveBeenCalledWith(false);
+      expect(router.navigate).toHaveBeenCalledWith([
+        "/fido2-excluded",
+        { "disable-redirect": null },
+      ]);
+    });
+
+    it("resets the window when the component displaying the message hides the UI", async () => {
+      await session.informExcludedCredential(["cipher-1"]);
+      await session.hideUi();
+
+      expect(desktopSettingsService.setModalMode).toHaveBeenCalledWith(false);
+      expect(accountService.setShowHeader).toHaveBeenCalledWith(true);
+      expect(router.navigate).toHaveBeenCalledWith(["/"]);
+    });
+  });
 });

--- a/apps/desktop/src/autofill/services/desktop-fido2-user-interface.service.spec.ts
+++ b/apps/desktop/src/autofill/services/desktop-fido2-user-interface.service.spec.ts
@@ -5,9 +5,12 @@ import { BehaviorSubject } from "rxjs";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { AuthService } from "@bitwarden/common/auth/abstractions/auth.service";
 import { AuthenticationStatus } from "@bitwarden/common/auth/enums/authentication-status";
+import { Fido2AuthenticatorErrorCode } from "@bitwarden/common/platform/abstractions/fido2/fido2-authenticator.service.abstraction";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
+import { CipherRepromptType } from "@bitwarden/common/vault/enums";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+import { PasswordRepromptService } from "@bitwarden/vault";
 
 import { DesktopSettingsService } from "../../platform/services/desktop-settings.service";
 
@@ -19,6 +22,10 @@ const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
 /** Reason produced by `AbortSignal.timeout`. */
 const timeoutReason = () => new DOMException("The operation timed out.", "TimeoutError");
 
+/** A cipher protected by a master-password reprompt. */
+const repromptCipher = (id: string) =>
+  Object.assign(new CipherView(), { id, reprompt: CipherRepromptType.Password });
+
 describe("DesktopFido2UserInterfaceSession", () => {
   let authService: MockProxy<AuthService>;
   let cipherService: MockProxy<CipherService>;
@@ -26,6 +33,7 @@ describe("DesktopFido2UserInterfaceSession", () => {
   let logService: MockProxy<LogService>;
   let router: MockProxy<Router>;
   let desktopSettingsService: MockProxy<DesktopSettingsService>;
+  let passwordRepromptService: MockProxy<PasswordRepromptService>;
 
   let activeAccountStatus$: BehaviorSubject<AuthenticationStatus>;
   let abortController: AbortController;
@@ -52,6 +60,9 @@ describe("DesktopFido2UserInterfaceSession", () => {
     logService = mock<LogService>();
     router = mock<Router>();
     desktopSettingsService = mock<DesktopSettingsService>();
+
+    passwordRepromptService = mock<PasswordRepromptService>();
+    passwordRepromptService.enabled.mockResolvedValue(true);
 
     activeAccountStatus$ = new BehaviorSubject<AuthenticationStatus>(AuthenticationStatus.Unlocked);
     authService.activeAccountStatus$ = activeAccountStatus$;
@@ -92,6 +103,7 @@ describe("DesktopFido2UserInterfaceSession", () => {
         appWindowHandle: new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]),
         clientWindowHandle: new Uint8Array([8, 7, 6, 5, 4, 3, 2, 1]),
       },
+      passwordRepromptService,
     );
   });
 
@@ -135,9 +147,58 @@ describe("DesktopFido2UserInterfaceSession", () => {
       const result = session.pickCredential(params);
       await tick();
 
-      session.confirmChosenCipher("cipher-2", true);
+      session.confirmChosenCipher(Object.assign(new CipherView(), { id: "cipher-2" }));
 
       await expect(result).resolves.toEqual({ cipherId: "cipher-2", userVerified: true });
+    });
+
+    it("reprompts for the master password when the chosen cipher requires it", async () => {
+      passwordRepromptService.showPasswordPrompt.mockResolvedValue(true);
+
+      const result = session.pickCredential(params);
+      await tick();
+
+      session.confirmChosenCipher(repromptCipher("cipher-2"));
+
+      await expect(result).resolves.toEqual({ cipherId: "cipher-2", userVerified: true });
+      expect(passwordRepromptService.showPasswordPrompt).toHaveBeenCalled();
+    });
+
+    it("reports the chosen cipher as unverified when the reprompt is dismissed", async () => {
+      passwordRepromptService.showPasswordPrompt.mockResolvedValue(false);
+
+      const result = session.pickCredential(params);
+      await tick();
+
+      session.confirmChosenCipher(repromptCipher("cipher-2"));
+
+      await expect(result).resolves.toEqual({ cipherId: "cipher-2", userVerified: false });
+    });
+
+    it("reports the chosen cipher as unverified when the account has no master password", async () => {
+      passwordRepromptService.enabled.mockResolvedValue(false);
+
+      const result = session.pickCredential(params);
+      await tick();
+
+      session.confirmChosenCipher(repromptCipher("cipher-2"));
+
+      await expect(result).resolves.toEqual({ cipherId: "cipher-2", userVerified: false });
+      expect(passwordRepromptService.showPasswordPrompt).not.toHaveBeenCalled();
+    });
+
+    it("refuses the ceremony when the cipher uses an unrecognized reprompt type", async () => {
+      const result = session.pickCredential(params);
+      await tick();
+
+      session.confirmChosenCipher(
+        Object.assign(new CipherView(), { id: "cipher-2", reprompt: 99 }),
+      );
+
+      await expect(result).rejects.toMatchObject({
+        errorCode: Fido2AuthenticatorErrorCode.NotAllowed,
+      });
+      expect(passwordRepromptService.showPasswordPrompt).not.toHaveBeenCalled();
     });
 
     it("resolves to no cipher and logs cancellation when the request is aborted", async () => {
@@ -201,6 +262,19 @@ describe("DesktopFido2UserInterfaceSession", () => {
       session.notifyConfirmCreateCredential(false);
 
       await expect(result).resolves.toEqual({ cipherId: undefined, userVerified: false });
+    });
+
+    it("does not overwrite a reprompt-protected cipher when the reprompt is dismissed", async () => {
+      accountService.activeAccount$ = new BehaviorSubject({ id: "user-1" } as any);
+      passwordRepromptService.showPasswordPrompt.mockResolvedValue(false);
+
+      const result = session.confirmNewCredential(params);
+      await tick();
+
+      session.notifyConfirmCreateCredential(true, repromptCipher("cipher-1"));
+
+      await expect(result).resolves.toEqual({ cipherId: undefined, userVerified: false });
+      expect(cipherService.updateWithServer).not.toHaveBeenCalled();
     });
 
     it("returns no cipher and logs cancellation when the request is aborted", async () => {

--- a/apps/desktop/src/autofill/services/desktop-fido2-user-interface.service.spec.ts
+++ b/apps/desktop/src/autofill/services/desktop-fido2-user-interface.service.spec.ts
@@ -143,6 +143,21 @@ describe("DesktopFido2UserInterfaceSession", () => {
       );
     });
 
+    it("leaves the window the user already had open alone when no UI was shown", async () => {
+      accountService.activeAccount$ = new BehaviorSubject({
+        id: "user-1",
+      } as any);
+      await session.pickCredential({
+        cipherIds: ["cipher-1"],
+        userVerification: true,
+        assumeUserPresence: true,
+        masterPasswordRepromptRequired: false,
+      });
+
+      expect(router.navigate).not.toHaveBeenCalled();
+      expect(accountService.setShowHeader).not.toHaveBeenCalled();
+    });
+
     it("resolves with the cipher the user selects", async () => {
       const result = session.pickCredential(params);
       await tick();
@@ -150,6 +165,18 @@ describe("DesktopFido2UserInterfaceSession", () => {
       session.confirmChosenCipher(Object.assign(new CipherView(), { id: "cipher-2" }));
 
       await expect(result).resolves.toEqual({ cipherId: "cipher-2", userVerified: true });
+    });
+
+    it("returns to the standard UI once the ceremony that showed it finishes", async () => {
+      const result = session.pickCredential(params);
+      await tick();
+
+      session.confirmChosenCipher(Object.assign(new CipherView(), { id: "cipher-2" }));
+      await result;
+
+      expect(desktopSettingsService.setModalMode).toHaveBeenCalledWith(false);
+      expect(accountService.setShowHeader).toHaveBeenCalledWith(true);
+      expect(router.navigate).toHaveBeenCalledWith(["/"]);
     });
 
     it("reprompts for the master password when the chosen cipher requires it", async () => {
@@ -339,6 +366,8 @@ describe("DesktopFido2UserInterfaceSession", () => {
         expect.anything(),
         expect.anything(),
       );
+      // Nothing of ours was on screen, so the user's own window keeps its route.
+      expect(router.navigate).not.toHaveBeenCalled();
     });
 
     it("logs a timeout (not a cancellation) and throws when the unlock deadline elapses", async () => {

--- a/apps/desktop/src/autofill/services/desktop-fido2-user-interface.service.ts
+++ b/apps/desktop/src/autofill/services/desktop-fido2-user-interface.service.ts
@@ -173,6 +173,13 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
 
   private chosenCipherSubject = new Subject<CipherView | undefined>();
 
+  /**
+   * Whether this ceremony took over the app window to show UI. Some ceremonies
+   * complete without any UI at all, and those must leave a window the user
+   * already had open untouched.
+   */
+  private uiShown = false;
+
   // Method implementation
   async pickCredential({
     cipherIds,
@@ -189,7 +196,6 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
 
     try {
       // Check if we can return the credential without user interaction
-      await this.accountService.setShowHeader(false);
       if (assumeUserPresence && cipherIds.length === 1 && !masterPasswordRepromptRequired) {
         this.logService.debug(
           "shortcut - Assuming user presence and returning cipherId",
@@ -351,7 +357,23 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
   }
 
   private async hideUi(): Promise<void> {
+  /**
+   * Returns the app to the state it was in before this ceremony showed any UI,
+   * leaving a window the user already had open untouched when no UI was shown.
+   */
+    // Always clear modal mode so the app can never get stuck in it. The main
+    // process only restyles the window on the modal -> standard transition, so
+    // this is inert when the ceremony never entered modal mode.
     await this.desktopSettingsService.setModalMode(false);
+
+    // The ceremony completed without showing UI, so there is nothing of ours to
+    // tear down. The user may have had a window open the whole time; leave it
+    // where they left it.
+    if (!this.uiShown) {
+      return;
+    }
+
+    // Reset to standard UI.
     await this.accountService.setShowHeader(true);
     await this.router.navigate(["/"]);
   }
@@ -371,6 +393,7 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
         "disable-redirect": disableRedirect || null,
       },
     ]);
+    this.uiShown = true;
   }
 
   /**
@@ -431,7 +454,6 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
     // make the cipherIds available to the UI.
     this.availableCipherIdsSubject.next(existingCipherIds);
 
-    await this.accountService.setShowHeader(false);
     await this.showUi("/fido2-excluded", this.windowObject.windowXy, false);
   }
 

--- a/apps/desktop/src/autofill/services/desktop-fido2-user-interface.service.ts
+++ b/apps/desktop/src/autofill/services/desktop-fido2-user-interface.service.ts
@@ -19,6 +19,10 @@ import { AccountService } from "@bitwarden/common/auth/abstractions/account.serv
 import { AuthService } from "@bitwarden/common/auth/abstractions/auth.service";
 import { AuthenticationStatus } from "@bitwarden/common/auth/enums/authentication-status";
 import {
+  Fido2AuthenticatorError,
+  Fido2AuthenticatorErrorCode,
+} from "@bitwarden/common/platform/abstractions/fido2/fido2-authenticator.service.abstraction";
+import {
   Fido2UserInterfaceService as Fido2UserInterfaceServiceAbstraction,
   Fido2UserInterfaceSession,
   NewCredentialParams,
@@ -35,6 +39,7 @@ import { IdentityView } from "@bitwarden/common/vault/models/view/identity.view"
 import { LoginUriView } from "@bitwarden/common/vault/models/view/login-uri.view";
 import { LoginView } from "@bitwarden/common/vault/models/view/login.view";
 import { SecureNoteView } from "@bitwarden/common/vault/models/view/secure-note.view";
+import { PasswordRepromptService } from "@bitwarden/vault";
 
 import { DesktopSettingsService } from "../../platform/services/desktop-settings.service";
 
@@ -103,6 +108,7 @@ export class DesktopFido2UserInterfaceService implements Fido2UserInterfaceServi
     private messagingService: MessagingService,
     private router: Router,
     private desktopSettingsService: DesktopSettingsService,
+    private passwordRepromptService: PasswordRepromptService,
   ) {}
   private currentSession: any;
 
@@ -132,6 +138,7 @@ export class DesktopFido2UserInterfaceService implements Fido2UserInterfaceServi
       this.desktopSettingsService,
       abortController,
       nativeWindowObject,
+      this.passwordRepromptService,
     );
 
     this.currentSession = session;
@@ -149,6 +156,7 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
     private desktopSettingsService: DesktopSettingsService,
     private abortController: AbortController,
     private windowObject: NativeWindowObject,
+    private passwordRepromptService: PasswordRepromptService,
   ) {}
 
   private confirmCredentialSubject = new Subject<boolean>();
@@ -165,7 +173,7 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
     take(1),
   );
 
-  private chosenCipherSubject = new Subject<{ cipherId: string; userVerified: boolean }>();
+  private chosenCipherSubject = new Subject<CipherView | undefined>();
 
   // Method implementation
   async pickCredential({
@@ -173,7 +181,7 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
     userVerification,
     assumeUserPresence,
     masterPasswordRepromptRequired,
-  }: PickCredentialParams): Promise<{ cipherId: string; userVerified: boolean }> {
+  }: PickCredentialParams): Promise<{ cipherId: string | undefined; userVerified: boolean }> {
     this.logService.debug("pickCredential desktop function", {
       cipherIds,
       userVerification,
@@ -201,16 +209,19 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
 
       // TODO: Extend this to the deadline indicated by the timeout on the WebAuthn request.
       const chosenCipherTimeout = AbortSignal.timeout(60 * 1000);
-      const chosenCipherResponse = await this.waitForUiChosenCipher({
+      const chosenCipher = await this.waitForUiChosenCipher({
         signal: AbortSignal.any([this.abortController.signal, chosenCipherTimeout]),
       });
 
-      this.logService.debug("Received chosen cipher", chosenCipherResponse);
+      this.logService.debug("Received chosen cipher", chosenCipher?.id);
 
-      return {
-        cipherId: chosenCipherResponse?.cipherId,
-        userVerified: chosenCipherResponse?.userVerified,
-      };
+      if (!chosenCipher) {
+        return { cipherId: undefined, userVerified: false };
+      }
+
+      const userVerified = await this.verifyWithReprompt(chosenCipher);
+
+      return { cipherId: chosenCipher.id, userVerified };
     } finally {
       // Make sure to clean up so the app is never stuck in modal mode?
       await this.desktopSettingsService.setModalMode(false);
@@ -222,8 +233,8 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
     return firstValueFrom(this.rpId.pipe(filter((id) => id != null)));
   }
 
-  confirmChosenCipher(cipherId: string, userVerified: boolean = false): void {
-    this.chosenCipherSubject.next({ cipherId, userVerified });
+  confirmChosenCipher(cipher?: CipherView): void {
+    this.chosenCipherSubject.next(cipher);
     this.chosenCipherSubject.complete();
   }
 
@@ -231,7 +242,7 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
     signal,
   }: {
     signal: AbortSignal;
-  }): Promise<{ cipherId?: string; userVerified: boolean }> {
+  }): Promise<CipherView | undefined> {
     try {
       signal.throwIfAborted();
       return await firstValueFrom(this.chosenCipherSubject.pipe(throwOnAbort(signal)));
@@ -244,7 +255,7 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
       } else if (signal.aborted) {
         this.logService.warning("Request was cancelled before the user selected a cipher", error);
       }
-      return { cipherId: undefined, userVerified: false };
+      return undefined;
     }
   }
 
@@ -313,6 +324,12 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
         signal: this.abortController.signal,
       });
       if (!confirmation) {
+        return { cipherId: undefined, userVerified: false };
+      }
+
+      // Abort before persisting anything so a dismissed reprompt never leaves a
+      // dangling cipher or an unwanted overwrite.
+      if (this.updatedCipher && !(await this.verifyWithReprompt(this.updatedCipher))) {
         return { cipherId: undefined, userVerified: false };
       }
 
@@ -478,5 +495,48 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
 
   async close() {
     this.logService.debug("close");
+  }
+
+  /**
+   * Reprompts for the master password when the chosen cipher requires it.
+   *
+   * @returns whether the user may proceed with the cipher.
+   */
+  private async verifyWithReprompt(cipher: CipherView): Promise<boolean> {
+    switch (cipher.reprompt) {
+      case CipherRepromptType.None:
+        return true;
+      case CipherRepromptType.Password:
+        return await this.repromptMasterPassword();
+      default:
+        // The user deliberately protected this cipher with a method this build
+        // doesn't recognize. Refuse the ceremony rather than substituting a
+        // different check or letting it through unverified.
+        this.logService.error(
+          "[DesktopFido2UserInterfaceSession]",
+          `Refusing to use a cipher protected by unrecognized reprompt type ${cipher.reprompt}`,
+        );
+        throw new Fido2AuthenticatorError(Fido2AuthenticatorErrorCode.NotAllowed);
+    }
+  }
+
+  /**
+   * Prompts the user for their master password.
+   *
+   * @returns whether the user entered it. Accounts without a master password
+   * report unverified: `showPasswordPrompt` reports success without prompting
+   * when there is no master password to ask for, and no user verification
+   * actually took place.
+   */
+  private async repromptMasterPassword(): Promise<boolean> {
+    if (!(await this.passwordRepromptService.enabled())) {
+      this.logService.info(
+        "[DesktopFido2UserInterfaceSession]",
+        "Cannot reprompt for the master password because the account does not have one",
+      );
+      return false;
+    }
+
+    return await this.passwordRepromptService.showPasswordPrompt();
   }
 }

--- a/apps/desktop/src/autofill/services/desktop-fido2-user-interface.service.ts
+++ b/apps/desktop/src/autofill/services/desktop-fido2-user-interface.service.ts
@@ -221,9 +221,8 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
 
       return { cipherId: chosenCipher.id, userVerified };
     } finally {
-      // Make sure to clean up so the app is never stuck in modal mode?
-      await this.desktopSettingsService.setModalMode(false);
-      await this.accountService.setShowHeader(true);
+      // Make sure to clean up so the app is never stuck in modal mode
+      await this.hideUi();
     }
   }
 
@@ -346,14 +345,14 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
         return { cipherId: createdCipher.id, userVerified: userVerification };
       }
     } finally {
-      // Make sure to clean up so the app is never stuck in modal mode?
-      await this.desktopSettingsService.setModalMode(false);
-      await this.accountService.setShowHeader(true);
+      // Make sure to clean up so the app is never stuck in modal mode
+      await this.hideUi();
     }
   }
 
   private async hideUi(): Promise<void> {
     await this.desktopSettingsService.setModalMode(false);
+    await this.accountService.setShowHeader(true);
     await this.router.navigate(["/"]);
   }
 

--- a/apps/desktop/src/autofill/services/desktop-fido2-user-interface.service.ts
+++ b/apps/desktop/src/autofill/services/desktop-fido2-user-interface.service.ts
@@ -1,5 +1,3 @@
-// FIXME: Update this file to be type safe and remove this and next line
-// @ts-strict-ignore
 import { Router } from "@angular/router";
 import {
   firstValueFrom,

--- a/apps/desktop/src/autofill/services/desktop-fido2-user-interface.service.ts
+++ b/apps/desktop/src/autofill/services/desktop-fido2-user-interface.service.ts
@@ -356,11 +356,16 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
     }
   }
 
-  private async hideUi(): Promise<void> {
   /**
    * Returns the app to the state it was in before this ceremony showed any UI,
    * leaving a window the user already had open untouched when no UI was shown.
+   *
+   * `pickCredential` and `confirmNewCredential` wait for a result and call this
+   * from their own `finally`. `informExcludedCredential` doesn't: it returns as
+   * soon as the message is on screen, so the component showing that message
+   * calls this when the user dismisses it. Safe to call more than once.
    */
+  async hideUi(): Promise<void> {
     // Always clear modal mode so the app can never get stuck in it. The main
     // process only restyles the window on the modal -> standard transition, so
     // this is inert when the ceremony never entered modal mode.

--- a/libs/common/src/platform/abstractions/fido2/fido2-user-interface.service.abstraction.ts
+++ b/libs/common/src/platform/abstractions/fido2/fido2-user-interface.service.abstraction.ts
@@ -84,7 +84,7 @@ export abstract class Fido2UserInterfaceSession {
    */
   abstract pickCredential(
     params: PickCredentialParams,
-  ): Promise<{ cipherId: string; userVerified: boolean }>;
+  ): Promise<{ cipherId: string | undefined; userVerified: boolean }>;
 
   /**
    * Ask the user to confirm the creation of a new credential.


### PR DESCRIPTION
## 🎟️ Tracking


[PM-29791](https://bitwarden.atlassian.net/browse/PM-29791)
## 📔 Objective

Refactoring for future user verification PRs.

Moves master password reprompts out of the UI components into the DesktopFido2UserInterfaceSession, so that this can be grouped with vault unlock and native OS user verification.

This also transfers responsibility to close the modal to the session rather than the UI component.

[PM-29791]: https://bitwarden.atlassian.net/browse/PM-29791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ