### PR TITLE
desktop-autofill: Define the desktop FIDO2 user verification service [PM-29791]

### DIFF
--- a/apps/desktop/src/app/services/services.module.ts
+++ b/apps/desktop/src/app/services/services.module.ts
@@ -162,7 +162,9 @@ import { DesktopAutofillSettingsService } from "../../autofill/services/desktop-
 import { DesktopAutofillService } from "../../autofill/services/desktop-autofill.service";
 import { DesktopAutotypeMvpService } from "../../autofill/services/desktop-autotype-mvp.service";
 import { DesktopAutotypeDefaultSettingPolicy } from "../../autofill/services/desktop-autotype-policy.service";
+import { DesktopFido2UnsupportedUserVerificationService } from "../../autofill/services/desktop-fido2-unsupported-user-verification.service";
 import { DesktopFido2UserInterfaceService } from "../../autofill/services/desktop-fido2-user-interface.service";
+import { DesktopFido2UserVerificationService } from "../../autofill/services/desktop-fido2-user-verification.service.abstraction";
 import { DesktopBiometricsService } from "../../key-management/biometrics/desktop.biometrics.service";
 import { RendererBiometricsService } from "../../key-management/biometrics/renderer-biometrics.service";
 import { ElectronKeyService } from "../../key-management/electron-key.service";
@@ -436,6 +438,11 @@ const safeProviders: SafeProvider[] = [
       AuthService,
       PlatformUtilsService,
     ],
+  }),
+  safeProvider({
+    provide: DesktopFido2UserVerificationService,
+    useClass: DesktopFido2UnsupportedUserVerificationService,
+    deps: [LogServiceAbstraction],
   }),
   safeProvider({
     provide: DesktopFido2UserInterfaceService,

--- a/apps/desktop/src/app/services/services.module.ts
+++ b/apps/desktop/src/app/services/services.module.ts
@@ -159,7 +159,9 @@ import { DesktopAutofillSettingsService } from "../../autofill/services/desktop-
 import { DesktopAutofillService } from "../../autofill/services/desktop-autofill.service";
 import { DesktopAutotypeDefaultSettingPolicy } from "../../autofill/services/desktop-autotype-policy.service";
 import { DesktopAutotypeService } from "../../autofill/services/desktop-autotype.service";
+import { DesktopFido2UnsupportedUserVerificationService } from "../../autofill/services/desktop-fido2-unsupported-user-verification.service";
 import { DesktopFido2UserInterfaceService } from "../../autofill/services/desktop-fido2-user-interface.service";
+import { DesktopFido2UserVerificationService } from "../../autofill/services/desktop-fido2-user-verification.service.abstraction";
 import { DesktopBiometricsService } from "../../key-management/biometrics/desktop.biometrics.service";
 import { RendererBiometricsService } from "../../key-management/biometrics/renderer-biometrics.service";
 import { ElectronKeyService } from "../../key-management/electron-key.service";
@@ -437,6 +439,11 @@ const safeProviders: SafeProvider[] = [
       AuthService,
       PlatformUtilsService,
     ],
+  }),
+  safeProvider({
+    provide: DesktopFido2UserVerificationService,
+    useClass: DesktopFido2UnsupportedUserVerificationService,
+    deps: [LogServiceAbstraction],
   }),
   safeProvider({
     provide: DesktopFido2UserInterfaceService,

--- a/apps/desktop/src/autofill/services/desktop-fido2-unsupported-user-verification.service.ts
+++ b/apps/desktop/src/autofill/services/desktop-fido2-unsupported-user-verification.service.ts
@@ -1,0 +1,21 @@
+import { LogService } from "@bitwarden/logging";
+
+import { DesktopFido2UserVerificationService } from "./desktop-fido2-user-verification.service.abstraction";
+
+/**
+ * Used on platforms with no OS user verification integration.
+ *
+ * Verification always fails rather than throwing, so ceremonies that require it
+ * are rejected by the authenticator while ceremonies that don't are unaffected.
+ */
+export class DesktopFido2UnsupportedUserVerificationService implements DesktopFido2UserVerificationService {
+  constructor(private readonly logService: LogService) {}
+
+  async verify(): Promise<boolean> {
+    this.logService.error(
+      "[DesktopFido2UnsupportedUserVerificationService]",
+      "This platform has no operating system user verification support",
+    );
+    return false;
+  }
+}

--- a/apps/desktop/src/autofill/services/desktop-fido2-user-verification.service.abstraction.ts
+++ b/apps/desktop/src/autofill/services/desktop-fido2-user-verification.service.abstraction.ts
@@ -1,0 +1,52 @@
+/** The step of a passkey ceremony that verification is being performed for. */
+export type Fido2UserVerificationOperation = "registration" | "overwrite" | "assertion";
+
+export type Fido2UserVerificationRequest = {
+  operation: Fido2UserVerificationOperation;
+
+  /** RP ID of the request. Shown to the user in the OS prompt. */
+  rpId: string;
+
+  /** Username of the credential in use. Shown to the user in the OS prompt. */
+  username: string;
+
+  /**
+   * Native handle of the window the OS prompt should attach to: Bitwarden's
+   * window while our own UI is showing, otherwise the calling client's window.
+   * Null on platforms that don't attach the prompt to a window.
+   */
+  windowHandle: Uint8Array | null;
+
+  /**
+   * OS-specific context binding this prompt to the in-flight WebAuthn request.
+   * Empty on platforms that don't require it.
+   */
+  requestContext: string;
+};
+
+/** Verifies the user through the operating system during a passkey ceremony. */
+export abstract class DesktopFido2UserVerificationService {
+  /**
+   * Prompts the user to verify themselves.
+   *
+   * @returns whether the user was verified.
+   * @throws {UserVerificationCanceled} if the user dismissed the prompt.
+   */
+  abstract verify(
+    request: Fido2UserVerificationRequest,
+    options: { signal: AbortSignal },
+  ): Promise<boolean>;
+}
+
+/**
+ * Thrown when the user dismisses the OS verification prompt.
+ *
+ * Dismissal ends the ceremony rather than falling back to another verification
+ * method: the user can retry from the relying party if they didn't mean it.
+ */
+export class UserVerificationCanceled extends Error {
+  constructor() {
+    super("The user dismissed the user verification prompt");
+    this.name = "UserVerificationCanceled";
+  }
+}

--- a/apps/desktop/src/autofill/services/desktop-fido2-user-verification.service.base.ts
+++ b/apps/desktop/src/autofill/services/desktop-fido2-user-verification.service.base.ts
@@ -1,0 +1,75 @@
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { LogService } from "@bitwarden/logging";
+
+import {
+  AutofillUserVerificationCommand,
+  AutofillUserVerificationParams,
+} from "../models/autofill-user-verification.command";
+
+import {
+  DesktopFido2UserVerificationService,
+  Fido2UserVerificationOperation,
+  Fido2UserVerificationRequest,
+  UserVerificationCanceled,
+} from "./desktop-fido2-user-verification.service.abstraction";
+
+/**
+ * Runs the native `userVerification` command, leaving each platform to supply
+ * the parameters and prompt text that its OS expects.
+ */
+export abstract class DesktopFido2UserVerificationServiceBase implements DesktopFido2UserVerificationService {
+  /** Prefix identifying this implementation in logs. */
+  protected abstract readonly logPrefix: string;
+
+  constructor(
+    protected readonly i18nService: I18nService,
+    protected readonly logService: LogService,
+  ) {}
+
+  async verify(
+    request: Fido2UserVerificationRequest,
+    // No platform exposes a way to dismiss its prompt programmatically yet, so
+    // an abort during verification is only observed once the prompt returns.
+    _options: { signal: AbortSignal },
+  ): Promise<boolean> {
+    const result = await ipc.autofill.desktopAutofill.runCommand<AutofillUserVerificationCommand>({
+      namespace: "autofill",
+      command: "userVerification",
+      params: this.buildParams(request),
+    });
+
+    if (result.type === "error") {
+      this.logService.error(this.logPrefix, "User verification failed", result.error);
+      return false;
+    }
+
+    if (result.value.outcome === "verified") {
+      return true;
+    }
+
+    if (result.value.outcome === "cancelled") {
+      this.logService.info(this.logPrefix, "The user dismissed the user verification prompt");
+      throw new UserVerificationCanceled();
+    }
+
+    this.logService.error(
+      this.logPrefix,
+      "User verification returned with unexpected response",
+      result,
+    );
+    throw new Error("Unexpected user verification response");
+  }
+
+  /** Builds the platform-specific parameters for the native command. */
+  protected abstract buildParams(
+    request: Fido2UserVerificationRequest,
+  ): AutofillUserVerificationParams;
+
+  /** The message key holding this platform's prompt text for `operation`. */
+  protected abstract messageKey(operation: Fido2UserVerificationOperation): string;
+
+  /** The prompt text the OS displays to the user. */
+  protected displayHint(request: Fido2UserVerificationRequest): string {
+    return this.i18nService.t(this.messageKey(request.operation), request.rpId, request.username);
+  }
+}


### PR DESCRIPTION
## 🎟️ Tracking

[PM-29791](https://bitwarden.atlassian.net/browse/PM-29791)

## 📔 Objective

Creates the abstraction for implementing user verification for FIDO2 ceremonies on the desktop client. Implementation will be added in a subsequent PR.

[PM-29791]: https://bitwarden.atlassian.net/browse/PM-29791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ