### PR TITLE
desktop-autofill: Implement FIDO2 user verification logic [PM-29791]

### DIFF
--- a/apps/desktop/src/app/services/services.module.ts
+++ b/apps/desktop/src/app/services/services.module.ts
@@ -455,6 +455,7 @@ const safeProviders: SafeProvider[] = [
       MessagingServiceAbstraction,
       Router,
       DesktopSettingsService,
+      DesktopFido2UserVerificationService,
       PasswordRepromptService,
     ],
   }),

--- a/apps/desktop/src/app/services/services.module.ts
+++ b/apps/desktop/src/app/services/services.module.ts
@@ -456,6 +456,7 @@ const safeProviders: SafeProvider[] = [
       MessagingServiceAbstraction,
       Router,
       DesktopSettingsService,
+      DesktopFido2UserVerificationService,
       PasswordRepromptService,
     ],
   }),

--- a/apps/desktop/src/autofill/services/desktop-fido2-user-interface.service.spec.ts
+++ b/apps/desktop/src/autofill/services/desktop-fido2-user-interface.service.spec.ts
@@ -12,9 +12,14 @@ import { CipherRepromptType } from "@bitwarden/common/vault/enums";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { PasswordRepromptService } from "@bitwarden/vault";
 
+import { ModalModeState } from "../../platform/models/domain/window-state";
 import { DesktopSettingsService } from "../../platform/services/desktop-settings.service";
 
 import { DesktopFido2UserInterfaceSession } from "./desktop-fido2-user-interface.service";
+import {
+  DesktopFido2UserVerificationService,
+  UserVerificationCanceled,
+} from "./desktop-fido2-user-verification.service.abstraction";
 
 /** Resolves after all pending microtasks so in-flight subscriptions are set up. */
 const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
@@ -33,6 +38,7 @@ describe("DesktopFido2UserInterfaceSession", () => {
   let logService: MockProxy<LogService>;
   let router: MockProxy<Router>;
   let desktopSettingsService: MockProxy<DesktopSettingsService>;
+  let userVerificationService: MockProxy<DesktopFido2UserVerificationService>;
   let passwordRepromptService: MockProxy<PasswordRepromptService>;
 
   let activeAccountStatus$: BehaviorSubject<AuthenticationStatus>;
@@ -60,12 +66,22 @@ describe("DesktopFido2UserInterfaceSession", () => {
     logService = mock<LogService>();
     router = mock<Router>();
     desktopSettingsService = mock<DesktopSettingsService>();
+    userVerificationService = mock<DesktopFido2UserVerificationService>();
 
     passwordRepromptService = mock<PasswordRepromptService>();
     passwordRepromptService.enabled.mockResolvedValue(true);
 
     activeAccountStatus$ = new BehaviorSubject<AuthenticationStatus>(AuthenticationStatus.Unlocked);
     authService.activeAccountStatus$ = activeAccountStatus$;
+
+    desktopSettingsService.modalMode$ = new BehaviorSubject<ModalModeState>({
+      isModalModeActive: false,
+    });
+    desktopSettingsService.setModalMode.mockImplementation(
+      async (isActive, _showTrafficButtons, _modalPosition) => {
+        desktopSettingsService.modalMode$.next({ isModalModeActive: isActive });
+      },
+    );
 
     abortController = new AbortController();
     deadlineController = new AbortController();
@@ -103,6 +119,7 @@ describe("DesktopFido2UserInterfaceSession", () => {
         appWindowHandle: new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]),
         clientWindowHandle: new Uint8Array([8, 7, 6, 5, 4, 3, 2, 1]),
       },
+      userVerificationService,
       passwordRepromptService,
     );
   });
@@ -158,15 +175,6 @@ describe("DesktopFido2UserInterfaceSession", () => {
       expect(accountService.setShowHeader).not.toHaveBeenCalled();
     });
 
-    it("resolves with the cipher the user selects", async () => {
-      const result = session.pickCredential(params);
-      await tick();
-
-      session.confirmChosenCipher(Object.assign(new CipherView(), { id: "cipher-2" }));
-
-      await expect(result).resolves.toEqual({ cipherId: "cipher-2", userVerified: true });
-    });
-
     it("returns to the standard UI once the ceremony that showed it finishes", async () => {
       const result = session.pickCredential(params);
       await tick();
@@ -179,66 +187,15 @@ describe("DesktopFido2UserInterfaceSession", () => {
       expect(router.navigate).toHaveBeenCalledWith(["/"]);
     });
 
-    it("reprompts for the master password when the chosen cipher requires it", async () => {
-      passwordRepromptService.showPasswordPrompt.mockResolvedValue(true);
+    it("resolves with the cipher the user selects, verified through the OS", async () => {
+      userVerificationService.verify.mockResolvedValue(true);
 
       const result = session.pickCredential(params);
       await tick();
 
-      session.confirmChosenCipher(repromptCipher("cipher-2"));
+      session.confirmChosenCipher(Object.assign(new CipherView(), { id: "cipher-2" }));
 
       await expect(result).resolves.toEqual({ cipherId: "cipher-2", userVerified: true });
-      expect(passwordRepromptService.showPasswordPrompt).toHaveBeenCalled();
-    });
-
-    it("reports the chosen cipher as unverified when the reprompt is dismissed", async () => {
-      passwordRepromptService.showPasswordPrompt.mockResolvedValue(false);
-
-      const result = session.pickCredential(params);
-      await tick();
-
-      session.confirmChosenCipher(repromptCipher("cipher-2"));
-
-      await expect(result).resolves.toEqual({ cipherId: "cipher-2", userVerified: false });
-    });
-
-    it("reports the chosen cipher as unverified when the account has no master password", async () => {
-      passwordRepromptService.enabled.mockResolvedValue(false);
-
-      const result = session.pickCredential(params);
-      await tick();
-
-      session.confirmChosenCipher(repromptCipher("cipher-2"));
-
-      await expect(result).resolves.toEqual({ cipherId: "cipher-2", userVerified: false });
-      expect(passwordRepromptService.showPasswordPrompt).not.toHaveBeenCalled();
-    });
-
-    it("refuses the ceremony when the cipher uses an unrecognized reprompt type", async () => {
-      const result = session.pickCredential(params);
-      await tick();
-
-      session.confirmChosenCipher(
-        Object.assign(new CipherView(), { id: "cipher-2", reprompt: 99 }),
-      );
-
-      await expect(result).rejects.toMatchObject({
-        errorCode: Fido2AuthenticatorErrorCode.NotAllowed,
-      });
-      expect(passwordRepromptService.showPasswordPrompt).not.toHaveBeenCalled();
-    });
-
-    it("resolves to no cipher and logs cancellation when the request is aborted", async () => {
-      const result = session.pickCredential(params);
-      await tick();
-
-      abortController.abort("Operation cancelled");
-
-      await expect(result).resolves.toEqual({ cipherId: undefined, userVerified: false });
-      expect(logService.warning).toHaveBeenCalledWith(
-        "Request was cancelled before the user selected a cipher",
-        expect.anything(),
-      );
     });
 
     it("resolves to no cipher and logs a timeout (not a cancellation) when the deadline elapses", async () => {
@@ -272,6 +229,7 @@ describe("DesktopFido2UserInterfaceSession", () => {
       accountService.activeAccount$ = new BehaviorSubject({ id: userId } as any);
       const existing = new CipherView();
       existing.id = "cipher-1";
+      userVerificationService.verify.mockResolvedValue(true);
 
       const result = session.confirmNewCredential(params);
       await tick();
@@ -282,6 +240,22 @@ describe("DesktopFido2UserInterfaceSession", () => {
       expect(cipherService.updateWithServer).toHaveBeenCalledWith(existing, userId);
     });
 
+    it("neither creates nor updates a cipher when user verification is required but not given", async () => {
+      accountService.activeAccount$ = new BehaviorSubject({ id: "user-1" } as any);
+      const existing = new CipherView();
+      existing.id = "cipher-1";
+      userVerificationService.verify.mockResolvedValue(false);
+
+      const result = session.confirmNewCredential(params);
+      await tick();
+
+      session.notifyConfirmCreateCredential(true, existing);
+
+      await expect(result).resolves.toEqual({ cipherId: undefined, userVerified: false });
+      expect(cipherService.updateWithServer).not.toHaveBeenCalled();
+      expect(cipherService.createWithServer).not.toHaveBeenCalled();
+    });
+
     it("returns no cipher when the user declines", async () => {
       const result = session.confirmNewCredential(params);
       await tick();
@@ -289,19 +263,6 @@ describe("DesktopFido2UserInterfaceSession", () => {
       session.notifyConfirmCreateCredential(false);
 
       await expect(result).resolves.toEqual({ cipherId: undefined, userVerified: false });
-    });
-
-    it("does not overwrite a reprompt-protected cipher when the reprompt is dismissed", async () => {
-      accountService.activeAccount$ = new BehaviorSubject({ id: "user-1" } as any);
-      passwordRepromptService.showPasswordPrompt.mockResolvedValue(false);
-
-      const result = session.confirmNewCredential(params);
-      await tick();
-
-      session.notifyConfirmCreateCredential(true, repromptCipher("cipher-1"));
-
-      await expect(result).resolves.toEqual({ cipherId: undefined, userVerified: false });
-      expect(cipherService.updateWithServer).not.toHaveBeenCalled();
     });
 
     it("returns no cipher and logs cancellation when the request is aborted", async () => {
@@ -409,6 +370,171 @@ describe("DesktopFido2UserInterfaceSession", () => {
       expect(desktopSettingsService.setModalMode).toHaveBeenCalledWith(false);
       expect(accountService.setShowHeader).toHaveBeenCalledWith(true);
       expect(router.navigate).toHaveBeenCalledWith(["/"]);
+    });
+  });
+
+  describe("user verification", () => {
+    const singleCipherId = "cipher-1";
+
+    beforeEach(() => {
+      accountService.activeAccount$ = new BehaviorSubject({ id: "user-1" } as any);
+    });
+
+    const confirmNewCredentialParams = {
+      credentialName: "Example",
+      userName: "user@example.com",
+      userHandle: "handle",
+      userVerification: true,
+      rpId: "example.com",
+    };
+
+    /** Picks from a list long enough to require the picker UI. */
+    const pickCredentialFromList = () =>
+      session.pickCredential({
+        cipherIds: [singleCipherId, "cipher-2"],
+        userVerification: true,
+        assumeUserPresence: false,
+        masterPasswordRepromptRequired: true,
+      });
+
+    it("attaches the prompt to the Bitwarden window while our own UI is showing", async () => {
+      userVerificationService.verify.mockResolvedValue(true);
+
+      const result = session.confirmNewCredential(confirmNewCredentialParams);
+      await tick();
+      session.notifyConfirmCreateCredential(true, Object.assign(new CipherView(), { id: "c1" }));
+      await result;
+
+      expect(userVerificationService.verify).toHaveBeenCalledWith(
+        expect.objectContaining({
+          operation: "overwrite",
+          rpId: "example.com",
+          requestContext: "request-context",
+          windowHandle: new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]),
+        }),
+        expect.anything(),
+      );
+    });
+
+    it("rejects credential creation as NotAllowed when the user dismisses the prompt", async () => {
+      userVerificationService.verify.mockRejectedValue(new UserVerificationCanceled());
+
+      const result = session.confirmNewCredential(confirmNewCredentialParams);
+      await tick();
+      session.notifyConfirmCreateCredential(true, Object.assign(new CipherView(), { id: "c1" }));
+
+      await expect(result).rejects.toMatchObject({
+        errorCode: Fido2AuthenticatorErrorCode.NotAllowed,
+      });
+    });
+
+    it("does not prompt when the relying party did not ask for verification", async () => {
+      const result = session.confirmNewCredential({
+        ...confirmNewCredentialParams,
+        userVerification: false,
+      });
+      await tick();
+      session.notifyConfirmCreateCredential(true, Object.assign(new CipherView(), { id: "c1" }));
+
+      await expect(result).resolves.toEqual({ cipherId: "c1", userVerified: false });
+      expect(userVerificationService.verify).not.toHaveBeenCalled();
+    });
+
+    it("does not prompt when the user unlocked their vault during this ceremony", async () => {
+      activeAccountStatus$.next(AuthenticationStatus.Locked);
+
+      const unlocked = session.ensureUnlockedVault();
+      await tick();
+      activeAccountStatus$.next(AuthenticationStatus.Unlocked);
+      await unlocked;
+
+      const result = session.confirmNewCredential(confirmNewCredentialParams);
+      await tick();
+      session.notifyConfirmCreateCredential(true, Object.assign(new CipherView(), { id: "c1" }));
+
+      await expect(result).resolves.toEqual({ cipherId: "c1", userVerified: true });
+      expect(userVerificationService.verify).not.toHaveBeenCalled();
+    });
+
+    it("verifies via master-password reprompt instead of the OS for a reprompt-protected cipher", async () => {
+      passwordRepromptService.showPasswordPrompt.mockResolvedValue(true);
+
+      const result = pickCredentialFromList();
+      await tick();
+      session.confirmChosenCipher(repromptCipher(singleCipherId));
+
+      await expect(result).resolves.toEqual({ cipherId: singleCipherId, userVerified: true });
+      expect(passwordRepromptService.showPasswordPrompt).toHaveBeenCalled();
+      expect(userVerificationService.verify).not.toHaveBeenCalled();
+    });
+
+    it("rejects the ceremony as NotAllowed when the master-password reprompt is dismissed", async () => {
+      passwordRepromptService.showPasswordPrompt.mockResolvedValue(false);
+
+      const result = pickCredentialFromList();
+      await tick();
+      session.confirmChosenCipher(repromptCipher(singleCipherId));
+
+      await expect(result).rejects.toMatchObject({
+        errorCode: Fido2AuthenticatorErrorCode.NotAllowed,
+      });
+      expect(userVerificationService.verify).not.toHaveBeenCalled();
+    });
+
+    it("ignores the master password reprompt flag and verifies through the OS when the account has no master password", async () => {
+      passwordRepromptService.enabled.mockResolvedValue(false);
+      userVerificationService.verify.mockResolvedValue(true);
+
+      const result = pickCredentialFromList();
+      await tick();
+      session.confirmChosenCipher(repromptCipher(singleCipherId));
+
+      await expect(result).resolves.toEqual({ cipherId: singleCipherId, userVerified: true });
+      expect(passwordRepromptService.showPasswordPrompt).not.toHaveBeenCalled();
+      expect(userVerificationService.verify).toHaveBeenCalled();
+    });
+
+    it("refuses the ceremony when the cipher uses an unrecognized reprompt type", async () => {
+      const result = pickCredentialFromList();
+      await tick();
+      session.confirmChosenCipher(
+        Object.assign(new CipherView(), { id: singleCipherId, reprompt: 99 }),
+      );
+
+      await expect(result).rejects.toMatchObject({
+        errorCode: Fido2AuthenticatorErrorCode.NotAllowed,
+      });
+      expect(passwordRepromptService.showPasswordPrompt).not.toHaveBeenCalled();
+      expect(userVerificationService.verify).not.toHaveBeenCalled();
+    });
+
+    it("verifies a reprompt-protected cipher via master-password reprompt during creation", async () => {
+      passwordRepromptService.showPasswordPrompt.mockResolvedValue(true);
+      const existing = repromptCipher(singleCipherId);
+
+      const result = session.confirmNewCredential({
+        ...confirmNewCredentialParams,
+        userVerification: false,
+      });
+      await tick();
+      session.notifyConfirmCreateCredential(true, existing);
+
+      await expect(result).resolves.toEqual({ cipherId: singleCipherId, userVerified: true });
+      expect(passwordRepromptService.showPasswordPrompt).toHaveBeenCalled();
+      expect(userVerificationService.verify).not.toHaveBeenCalled();
+      expect(cipherService.updateWithServer).toHaveBeenCalledWith(existing, "user-1");
+    });
+
+    it("skips the master-password reprompt when the account has no master password", async () => {
+      passwordRepromptService.enabled.mockResolvedValue(false);
+      userVerificationService.verify.mockResolvedValue(true);
+
+      const result = session.confirmNewCredential(confirmNewCredentialParams);
+      await tick();
+      session.notifyConfirmCreateCredential(true, repromptCipher(singleCipherId));
+      await result;
+
+      expect(passwordRepromptService.showPasswordPrompt).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/desktop/src/autofill/services/desktop-fido2-user-interface.service.ts
+++ b/apps/desktop/src/autofill/services/desktop-fido2-user-interface.service.ts
@@ -37,9 +37,19 @@ import { IdentityView } from "@bitwarden/common/vault/models/view/identity.view"
 import { LoginUriView } from "@bitwarden/common/vault/models/view/login-uri.view";
 import { LoginView } from "@bitwarden/common/vault/models/view/login.view";
 import { SecureNoteView } from "@bitwarden/common/vault/models/view/secure-note.view";
+import {
+  CipherViewLike,
+  CipherViewLikeUtils,
+} from "@bitwarden/common/vault/utils/cipher-view-like-utils";
 import { PasswordRepromptService } from "@bitwarden/vault";
 
 import { DesktopSettingsService } from "../../platform/services/desktop-settings.service";
+
+import {
+  DesktopFido2UserVerificationService,
+  Fido2UserVerificationOperation,
+  UserVerificationCanceled,
+} from "./desktop-fido2-user-verification.service.abstraction";
 
 /**
  * This type is used to pass the window position from the native UI
@@ -106,6 +116,7 @@ export class DesktopFido2UserInterfaceService implements Fido2UserInterfaceServi
     private messagingService: MessagingService,
     private router: Router,
     private desktopSettingsService: DesktopSettingsService,
+    private userVerificationService: DesktopFido2UserVerificationService,
     private passwordRepromptService: PasswordRepromptService,
   ) {}
   private currentSession: any;
@@ -136,6 +147,7 @@ export class DesktopFido2UserInterfaceService implements Fido2UserInterfaceServi
       this.desktopSettingsService,
       abortController,
       nativeWindowObject,
+      this.userVerificationService,
       this.passwordRepromptService,
     );
 
@@ -154,6 +166,7 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
     private desktopSettingsService: DesktopSettingsService,
     private abortController: AbortController,
     private windowObject: NativeWindowObject,
+    private userVerificationService: DesktopFido2UserVerificationService,
     private passwordRepromptService: PasswordRepromptService,
   ) {}
 
@@ -161,6 +174,11 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
 
   private updatedCipher: CipherView | undefined = undefined;
 
+  /**
+   * Whether the user unlocked their vault as part of this ceremony. Unlocking
+   * already verifies the user, so the OS is not asked to do it a second time.
+   */
+  private vaultUnlockedDuringCeremony: boolean = false;
   private rpId = new BehaviorSubject<string | null>(null);
   private availableCipherIdsSubject = new BehaviorSubject<string[]>([""]);
   /**
@@ -223,9 +241,18 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
         return { cipherId: undefined, userVerified: false };
       }
 
-      const userVerified = await this.verifyWithReprompt(chosenCipher);
+      const username = fido2UserNameFromCipher(chosenCipher);
+      const userVerified = await this.verifyUser(
+        "assertion",
+        username,
+        userVerification,
+        chosenCipher,
+        { signal: this.abortController.signal },
+      );
 
       return { cipherId: chosenCipher.id, userVerified };
+    } catch (error) {
+      throw this.mapUserVerificationCancellation(error);
     } finally {
       // Make sure to clean up so the app is never stuck in modal mode
       await this.hideUi();
@@ -306,7 +333,7 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
     credentialName,
     userName,
     userHandle,
-    userVerification,
+    userVerification: needsUserVerification,
     rpId,
   }: NewCredentialParams): Promise<{ cipherId: string | undefined; userVerified: boolean }> {
     this.logService.debug(
@@ -314,31 +341,51 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
       credentialName,
       userName,
       userHandle,
-      userVerification,
+      needsUserVerification,
       rpId,
     );
     this.rpId.next(rpId);
 
+    const abortSignal = this.abortController.signal;
     try {
       await this.showUi("/fido2-creation", this.windowObject.windowXy, false);
 
       // Wait for the UI to wrap up
       const confirmation = await this.waitForUiNewCredentialConfirmation({
-        signal: this.abortController.signal,
+        signal: abortSignal,
       });
       if (!confirmation) {
         return { cipherId: undefined, userVerified: false };
       }
 
-      // Abort before persisting anything so a dismissed reprompt never leaves a
+      // Confirming in our own UI establishes user presence, so we only verify
+      // when the relying party asked for it or the chosen cipher requires a
+      // master-password reprompt. `verifyUser` decides which prompt to show.
+      const operation = this.updatedCipher ? "overwrite" : "registration";
+      const userVerified = await this.verifyUser(
+        operation,
+        userName,
+        needsUserVerification,
+        this.updatedCipher,
+        { signal: abortSignal },
+      );
+
+      // Abort before persisting anything so a failed verification never leaves a
       // dangling cipher or an unwanted overwrite.
-      if (this.updatedCipher && !(await this.verifyWithReprompt(this.updatedCipher))) {
+      const repromptRequired =
+        this.updatedCipher && this.updatedCipher.reprompt !== CipherRepromptType.None;
+      const verificationExpected = needsUserVerification || repromptRequired;
+      if (verificationExpected && !userVerified) {
+        this.logService.warning(
+          "[DesktopFido2UserInterfaceSession]",
+          "Aborting credential creation because user verification was unsuccessful",
+        );
         return { cipherId: undefined, userVerified: false };
       }
 
       if (this.updatedCipher) {
         await this.updateCredential(this.updatedCipher);
-        return { cipherId: this.updatedCipher.id, userVerified: userVerification };
+        return { cipherId: this.updatedCipher.id, userVerified };
       } else {
         // Create the cipher
         const createdCipher = await this.createCipher({
@@ -346,10 +393,12 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
           userName,
           rpId,
           userHandle,
-          userVerification,
+          userVerification: needsUserVerification,
         });
-        return { cipherId: createdCipher.id, userVerified: userVerification };
+        return { cipherId: createdCipher.id, userVerified };
       }
+    } catch (error) {
+      throw this.mapUserVerificationCancellation(error);
     } finally {
       // Make sure to clean up so the app is never stuck in modal mode
       await this.hideUi();
@@ -488,14 +537,18 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
         throw new Error("Could not retrieve vault unlock status");
       }
 
-      if (status2 === AuthenticationStatus.Unlocked) {
-        await this.router.navigate(["/"]);
-      }
-
       if (status2 !== AuthenticationStatus.Unlocked) {
         await this.hideUi();
         throw new Error("Vault is not unlocked");
       }
+
+      // The user authenticated to Bitwarden to get here, which satisfies user
+      // verification for the rest of this ceremony.
+      this.vaultUnlockedDuringCeremony = true;
+      // TODO: Navigate straight to the next modal screen instead of home. The
+      // caller shows its own route immediately afterwards, so routing through
+      // "/" flashes the main vault screen in between.
+      await this.router.navigate(["/"]);
     }
   }
 
@@ -522,45 +575,109 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
   }
 
   /**
-   * Reprompts for the master password when the chosen cipher requires it.
+   * Verifies the user for the chosen cipher, choosing the strongest form of
+   * verification already available before falling back to the OS prompt:
    *
-   * @returns whether the user may proceed with the cipher.
+   * 1. A master-password reprompt on the cipher is itself user verification, so
+   *    satisfy the requirement with it rather than prompting the OS.
+   * 2. Otherwise, unlocking the vault during this ceremony already verified the
+   *    user.
+   * 3. Otherwise verify through the OS when the relying party asked for it.
+   *
+   * The reprompt is checked before the vault-unlock shortcut because unlocking
+   * may have used a method other than the master password (PIN, biometrics),
+   * which does not satisfy a master-password reprompt.
+   *
+   * @throws {UserVerificationCanceled} if the user dismissed the prompt.
    */
-  private async verifyWithReprompt(cipher: CipherView): Promise<boolean> {
-    switch (cipher.reprompt) {
+  private async verifyUser(
+    operation: Fido2UserVerificationOperation,
+    username: string,
+    needsUserVerification: boolean,
+    cipher: CipherViewLike | undefined,
+    { signal }: { signal: AbortSignal },
+  ): Promise<boolean> {
+    const repromptType = cipher?.reprompt ?? CipherRepromptType.None;
+    switch (repromptType) {
       case CipherRepromptType.None:
-        return true;
+        break;
       case CipherRepromptType.Password:
-        return await this.repromptMasterPassword();
+        // TODO: Elide this prompt when the vault was unlocked with the master
+        // password during this ceremony, since that already satisfies the reprompt.
+        if (!(await this.passwordRepromptService.enabled())) {
+          // An account with no master password can't be reprompted for one, so
+          // the flag is inert — `PasswordRepromptService.showPasswordPrompt`
+          // reports success without prompting for exactly this reason. Treat the
+          // cipher as unprotected and verify by the usual means below, rather
+          // than reporting a verification that never happened.
+          break;
+        }
+        if (!(await this.passwordRepromptService.showPasswordPrompt())) {
+          throw new UserVerificationCanceled();
+        }
+        return true;
       default:
         // The user deliberately protected this cipher with a method this build
         // doesn't recognize. Refuse the ceremony rather than substituting a
         // different check or letting it through unverified.
         this.logService.error(
           "[DesktopFido2UserInterfaceSession]",
-          `Refusing to use a cipher protected by unrecognized reprompt type ${cipher.reprompt}`,
+          `Refusing to use a cipher protected by unrecognized reprompt type ${repromptType}`,
         );
         throw new Fido2AuthenticatorError(Fido2AuthenticatorErrorCode.NotAllowed);
     }
-  }
 
-  /**
-   * Prompts the user for their master password.
-   *
-   * @returns whether the user entered it. Accounts without a master password
-   * report unverified: `showPasswordPrompt` reports success without prompting
-   * when there is no master password to ask for, and no user verification
-   * actually took place.
-   */
-  private async repromptMasterPassword(): Promise<boolean> {
-    if (!(await this.passwordRepromptService.enabled())) {
+    if (this.vaultUnlockedDuringCeremony) {
       this.logService.info(
         "[DesktopFido2UserInterfaceSession]",
-        "Cannot reprompt for the master password because the account does not have one",
+        "Skipping user verification because the user unlocked their vault during this ceremony",
       );
+      return true;
+    }
+
+    if (!needsUserVerification) {
       return false;
     }
 
-    return await this.passwordRepromptService.showPasswordPrompt();
+    const modalMode = await firstValueFrom(this.desktopSettingsService.modalMode$);
+    const isShowing = modalMode?.isModalModeActive ?? false;
+    const windowHandle = isShowing
+      ? this.windowObject.appWindowHandle
+      : this.windowObject.clientWindowHandle;
+
+    return await this.userVerificationService.verify(
+      {
+        operation,
+        username,
+        rpId: this.windowObject.rpId,
+        requestContext: this.windowObject.requestContext,
+        // Attach the prompt to whichever window the user is looking at.
+        windowHandle,
+      },
+      { signal },
+    );
   }
+
+  /**
+   * Translates a dismissed verification prompt into the error the authenticator
+   * reports to the relying party, and passes anything else through untouched.
+   */
+  private mapUserVerificationCancellation(error: unknown): unknown {
+    if (!(error instanceof UserVerificationCanceled)) {
+      return error;
+    }
+
+    this.logService.info(
+      "[DesktopFido2UserInterfaceSession]",
+      "User cancelled during user verification. Aborting the request.",
+    );
+    return new Fido2AuthenticatorError(Fido2AuthenticatorErrorCode.NotAllowed);
+  }
+}
+
+function fido2UserNameFromCipher(cipherView: CipherViewLike): string {
+  const login = CipherViewLikeUtils.getLogin(cipherView);
+  const username =
+    (login?.fido2Credentials ?? []).at(0)?.userName ?? login?.username ?? cipherView.name;
+  return username;
 }

--- a/apps/desktop/src/autofill/services/desktop-fido2-user-interface.service.ts
+++ b/apps/desktop/src/autofill/services/desktop-fido2-user-interface.service.ts
@@ -37,9 +37,19 @@ import { IdentityView } from "@bitwarden/common/vault/models/view/identity.view"
 import { LoginUriView } from "@bitwarden/common/vault/models/view/login-uri.view";
 import { LoginView } from "@bitwarden/common/vault/models/view/login.view";
 import { SecureNoteView } from "@bitwarden/common/vault/models/view/secure-note.view";
+import {
+  CipherViewLike,
+  CipherViewLikeUtils,
+} from "@bitwarden/common/vault/utils/cipher-view-like-utils";
 import { PasswordRepromptService } from "@bitwarden/vault";
 
 import { DesktopSettingsService } from "../../platform/services/desktop-settings.service";
+
+import {
+  DesktopFido2UserVerificationService,
+  Fido2UserVerificationOperation,
+  UserVerificationCanceled,
+} from "./desktop-fido2-user-verification.service.abstraction";
 
 /**
  * This type is used to pass the window position from the native UI
@@ -106,6 +116,7 @@ export class DesktopFido2UserInterfaceService implements Fido2UserInterfaceServi
     private messagingService: MessagingService,
     private router: Router,
     private desktopSettingsService: DesktopSettingsService,
+    private userVerificationService: DesktopFido2UserVerificationService,
     private passwordRepromptService: PasswordRepromptService,
   ) {}
   private currentSession: any;
@@ -136,6 +147,7 @@ export class DesktopFido2UserInterfaceService implements Fido2UserInterfaceServi
       this.desktopSettingsService,
       abortController,
       nativeWindowObject,
+      this.userVerificationService,
       this.passwordRepromptService,
     );
 
@@ -154,6 +166,7 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
     private desktopSettingsService: DesktopSettingsService,
     private abortController: AbortController,
     private windowObject: NativeWindowObject,
+    private userVerificationService: DesktopFido2UserVerificationService,
     private passwordRepromptService: PasswordRepromptService,
   ) {}
 
@@ -161,6 +174,11 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
 
   private updatedCipher: CipherView | undefined = undefined;
 
+  /**
+   * Whether the user unlocked their vault as part of this ceremony. Unlocking
+   * already verifies the user, so the OS is not asked to do it a second time.
+   */
+  private vaultUnlockedDuringCeremony: boolean = false;
   private rpId = new BehaviorSubject<string | null>(null);
   private availableCipherIdsSubject = new BehaviorSubject<string[]>([""]);
   /**
@@ -223,9 +241,18 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
         return { cipherId: undefined, userVerified: false };
       }
 
-      const userVerified = await this.verifyWithReprompt(chosenCipher);
+      const username = fido2UserNameFromCipher(chosenCipher);
+      const userVerified = await this.verifyUser(
+        "assertion",
+        username,
+        userVerification,
+        chosenCipher,
+        { signal: this.abortController.signal },
+      );
 
       return { cipherId: chosenCipher.id, userVerified };
+    } catch (error) {
+      throw this.mapUserVerificationCancellation(error);
     } finally {
       // Make sure to clean up so the app is never stuck in modal mode
       await this.hideUi();
@@ -306,7 +333,7 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
     credentialName,
     userName,
     userHandle,
-    userVerification,
+    userVerification: needsUserVerification,
     rpId,
   }: NewCredentialParams): Promise<{ cipherId: string | undefined; userVerified: boolean }> {
     this.logService.debug(
@@ -314,31 +341,48 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
       credentialName,
       userName,
       userHandle,
-      userVerification,
+      needsUserVerification,
       rpId,
     );
     this.rpId.next(rpId);
 
+    const abortSignal = this.abortController.signal;
     try {
       await this.showUi("/fido2-creation", this.windowObject.windowXy, false);
 
       // Wait for the UI to wrap up
       const confirmation = await this.waitForUiNewCredentialConfirmation({
-        signal: this.abortController.signal,
+        signal: abortSignal,
       });
       if (!confirmation) {
         return { cipherId: undefined, userVerified: false };
       }
 
-      // Abort before persisting anything so a dismissed reprompt never leaves a
+      // Confirming in our own UI establishes user presence, so we only verify
+      // when the relying party asked for it or the chosen cipher requires a
+      // master-password reprompt. `verifyUser` decides which prompt to show.
+      const operation = this.updatedCipher ? "overwrite" : "registration";
+      const userVerified = await this.verifyUser(
+        operation,
+        userName,
+        needsUserVerification,
+        this.updatedCipher,
+        { signal: abortSignal },
+      );
+
+      // Abort before persisting anything so a failed verification never leaves a
       // dangling cipher or an unwanted overwrite.
-      if (this.updatedCipher && !(await this.verifyWithReprompt(this.updatedCipher))) {
+      if (needsUserVerification && !userVerified) {
+        this.logService.warning(
+          "[DesktopFido2UserInterfaceSession]",
+          "Aborting credential creation because user verification was unsuccessful",
+        );
         return { cipherId: undefined, userVerified: false };
       }
 
       if (this.updatedCipher) {
         await this.updateCredential(this.updatedCipher);
-        return { cipherId: this.updatedCipher.id, userVerified: userVerification };
+        return { cipherId: this.updatedCipher.id, userVerified };
       } else {
         // Create the cipher
         const createdCipher = await this.createCipher({
@@ -346,10 +390,12 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
           userName,
           rpId,
           userHandle,
-          userVerification,
+          userVerification: needsUserVerification,
         });
-        return { cipherId: createdCipher.id, userVerified: userVerification };
+        return { cipherId: createdCipher.id, userVerified };
       }
+    } catch (error) {
+      throw this.mapUserVerificationCancellation(error);
     } finally {
       // Make sure to clean up so the app is never stuck in modal mode
       await this.hideUi();
@@ -488,14 +534,18 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
         throw new Error("Could not retrieve vault unlock status");
       }
 
-      if (status2 === AuthenticationStatus.Unlocked) {
-        await this.router.navigate(["/"]);
-      }
-
       if (status2 !== AuthenticationStatus.Unlocked) {
         await this.hideUi();
         throw new Error("Vault is not unlocked");
       }
+
+      // The user authenticated to Bitwarden to get here, which satisfies user
+      // verification for the rest of this ceremony.
+      this.vaultUnlockedDuringCeremony = true;
+      // TODO: Navigate straight to the next modal screen instead of home. The
+      // caller shows its own route immediately afterwards, so routing through
+      // "/" flashes the main vault screen in between.
+      await this.router.navigate(["/"]);
     }
   }
 
@@ -522,45 +572,109 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
   }
 
   /**
-   * Reprompts for the master password when the chosen cipher requires it.
+   * Verifies the user for the chosen cipher, choosing the strongest form of
+   * verification already available before falling back to the OS prompt:
    *
-   * @returns whether the user may proceed with the cipher.
+   * 1. A master-password reprompt on the cipher is itself user verification, so
+   *    satisfy the requirement with it rather than prompting the OS.
+   * 2. Otherwise, unlocking the vault during this ceremony already verified the
+   *    user.
+   * 3. Otherwise verify through the OS when the relying party asked for it.
+   *
+   * The reprompt is checked before the vault-unlock shortcut because unlocking
+   * may have used a method other than the master password (PIN, biometrics),
+   * which does not satisfy a master-password reprompt.
+   *
+   * @throws {UserVerificationCanceled} if the user dismissed the prompt.
    */
-  private async verifyWithReprompt(cipher: CipherView): Promise<boolean> {
-    switch (cipher.reprompt) {
+  private async verifyUser(
+    operation: Fido2UserVerificationOperation,
+    username: string,
+    needsUserVerification: boolean,
+    cipher: CipherViewLike | undefined,
+    { signal }: { signal: AbortSignal },
+  ): Promise<boolean> {
+    const repromptType = cipher?.reprompt ?? CipherRepromptType.None;
+    switch (repromptType) {
       case CipherRepromptType.None:
-        return true;
+        break;
       case CipherRepromptType.Password:
-        return await this.repromptMasterPassword();
+        // TODO: Elide this prompt when the vault was unlocked with the master
+        // password during this ceremony, since that already satisfies the reprompt.
+        if (!(await this.passwordRepromptService.enabled())) {
+          // An account with no master password can't be reprompted for one, so
+          // the flag is inert — `PasswordRepromptService.showPasswordPrompt`
+          // reports success without prompting for exactly this reason. Treat the
+          // cipher as unprotected and verify by the usual means below, rather
+          // than reporting a verification that never happened.
+          break;
+        }
+        if (!(await this.passwordRepromptService.showPasswordPrompt())) {
+          throw new UserVerificationCanceled();
+        }
+        return true;
       default:
         // The user deliberately protected this cipher with a method this build
         // doesn't recognize. Refuse the ceremony rather than substituting a
         // different check or letting it through unverified.
         this.logService.error(
           "[DesktopFido2UserInterfaceSession]",
-          `Refusing to use a cipher protected by unrecognized reprompt type ${cipher.reprompt}`,
+          `Refusing to use a cipher protected by unrecognized reprompt type ${repromptType}`,
         );
         throw new Fido2AuthenticatorError(Fido2AuthenticatorErrorCode.NotAllowed);
     }
-  }
 
-  /**
-   * Prompts the user for their master password.
-   *
-   * @returns whether the user entered it. Accounts without a master password
-   * report unverified: `showPasswordPrompt` reports success without prompting
-   * when there is no master password to ask for, and no user verification
-   * actually took place.
-   */
-  private async repromptMasterPassword(): Promise<boolean> {
-    if (!(await this.passwordRepromptService.enabled())) {
+    if (this.vaultUnlockedDuringCeremony) {
       this.logService.info(
         "[DesktopFido2UserInterfaceSession]",
-        "Cannot reprompt for the master password because the account does not have one",
+        "Skipping user verification because the user unlocked their vault during this ceremony",
       );
+      return true;
+    }
+
+    if (!needsUserVerification) {
       return false;
     }
 
-    return await this.passwordRepromptService.showPasswordPrompt();
+    const modalMode = await firstValueFrom(this.desktopSettingsService.modalMode$);
+    const isShowing = modalMode?.isModalModeActive ?? false;
+    const windowHandle = isShowing
+      ? this.windowObject.appWindowHandle
+      : this.windowObject.clientWindowHandle;
+
+    return await this.userVerificationService.verify(
+      {
+        operation,
+        username,
+        rpId: this.windowObject.rpId,
+        requestContext: this.windowObject.requestContext,
+        // Attach the prompt to whichever window the user is looking at.
+        windowHandle,
+      },
+      { signal },
+    );
   }
+
+  /**
+   * Translates a dismissed verification prompt into the error the authenticator
+   * reports to the relying party, and passes anything else through untouched.
+   */
+  private mapUserVerificationCancellation(error: unknown): unknown {
+    if (!(error instanceof UserVerificationCanceled)) {
+      return error;
+    }
+
+    this.logService.info(
+      "[DesktopFido2UserInterfaceSession]",
+      "User cancelled during user verification. Aborting the request.",
+    );
+    return new Fido2AuthenticatorError(Fido2AuthenticatorErrorCode.NotAllowed);
+  }
+}
+
+function fido2UserNameFromCipher(cipherView: CipherViewLike): string {
+  const login = CipherViewLikeUtils.getLogin(cipherView);
+  const username =
+    (login?.fido2Credentials ?? []).at(0)?.userName ?? login?.username ?? cipherView.name;
+  return username;
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-29791](https://bitwarden.atlassian.net/browse/PM-29791)

## 📔 Objective

Implements user verification for desktop FIDO2 ceremonies.

- If the selected cipher has master password reprompt checked, then the password is verified, and that satisfies UV
- If the vault is unlocked during the ceremony, that counts as UV (but if it was already unlocked, it does not).
- Otherwise, fall back to native OS user verification

Right now, the native user verification is just a stub that returns false. Windows and macOS implementations are coming in subsequent PRs.

[PM-29791]: https://bitwarden.atlassian.net/browse/PM-29791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ