### PR TITLE
[PM-37839] Browser: Delete item from at risk category view

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -7765,5 +7765,25 @@
   },
   "reusedPasswordsDescription": {
     "message": "These logins have a reused password. Create a unique password for each account to prevent someone accessing multiple accounts with one password."
+  },
+  "deleteAtRiskItemDescription": {
+    "message": "Deleting this login removes it from your vault but doesn't fix the risk. To protect your account, change your password first."
+  },
+  "passwordHasAdditionalRisks": {
+    "message": "This password has additional risks:"
+  },
+  "reused": {
+    "message": "Reused",
+    "description": "ex. A password that is reused across multiple logins."
+  },
+  "xTimes": {
+    "message": "$COUNT$ times",
+    "description": "The number of times a password is reused. ex. 6 times",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "6"
+      }
+    }
   }
 }

--- a/bitwarden_license/bit-browser/src/popup/dirt/health/health-delete-at-risk-item-dialog.component.html
+++ b/bitwarden_license/bit-browser/src/popup/dirt/health/health-delete-at-risk-item-dialog.component.html
@@ -29,7 +29,7 @@
     }
   </div>
   <div bitDialogFooter class="tw-flex tw-flex-col tw-gap-2">
-    <button bitButton type="button" buttonType="danger" (click)="onDeleteItem()">
+    <button bitButton type="button" buttonType="danger" [bitAction]="onDeleteItem">
       {{ "delete" | i18n }}
     </button>
     <button bitButton type="button" bitDialogClose>{{ "cancel" | i18n }}</button>

--- a/bitwarden_license/bit-browser/src/popup/dirt/health/health-delete-at-risk-item-dialog.component.html
+++ b/bitwarden_license/bit-browser/src/popup/dirt/health/health-delete-at-risk-item-dialog.component.html
@@ -5,8 +5,26 @@
       Deleting this login removes it from your vault but doesn't fix the risk. To protect your
       account, change your password first.
     </p>
-    <strong>{{ item().name }}</strong>
-    <!-- TODO: ADDITIONAL RISKS TABLE HERE -->
+    <!-- TODO: update below to read categories properly for item -->
+    @if (true) {
+      <bit-section>
+        <bit-section-header>
+          <p>This password has additional risks:</p>
+        </bit-section-header>
+        <bit-card class="tw-flex tw-flex-col tw-gap-2 tw-justify-start tw-items-start">
+          <div class="tw-w-full tw-flex tw-flex-row tw-items-center tw-justify-start tw-gap-2">
+            <bit-icon-tile icon="bwi-warning" variant="warning" slot="start" />
+            Weak
+            <span class="tw-ml-auto">Yes</span>
+          </div>
+          <div class="tw-w-full tw-flex tw-flex-row tw-items-center tw-justify-start tw-gap-2">
+            <bit-icon-tile icon="bwi-refresh" variant="primary" slot="start" />
+            Reused
+            <span class="tw-ml-auto">6 times</span>
+          </div>
+        </bit-card>
+      </bit-section>
+    }
   </div>
   <div bitDialogFooter class="tw-flex tw-flex-col tw-gap-2">
     <button bitButton type="button" buttonType="danger" (click)="onDeleteItem()">Delete</button>

--- a/bitwarden_license/bit-browser/src/popup/dirt/health/health-delete-at-risk-item-dialog.component.html
+++ b/bitwarden_license/bit-browser/src/popup/dirt/health/health-delete-at-risk-item-dialog.component.html
@@ -5,10 +5,11 @@
       Deleting this login removes it from your vault but doesn't fix the risk. To protect your
       account, change your password first.
     </p>
+    <strong>{{ item().name }}</strong>
     <!-- TODO: ADDITIONAL RISKS TABLE HERE -->
   </div>
   <div bitDialogFooter class="tw-flex tw-flex-col tw-gap-2">
-    <button bitButton type="button" buttonType="danger">Delete</button>
+    <button bitButton type="button" buttonType="danger" (click)="onDeleteItem()">Delete</button>
     <button bitButton type="button" bitDialogClose>Cancel</button>
   </div>
 </bit-simple-dialog>

--- a/bitwarden_license/bit-browser/src/popup/dirt/health/health-delete-at-risk-item-dialog.component.html
+++ b/bitwarden_license/bit-browser/src/popup/dirt/health/health-delete-at-risk-item-dialog.component.html
@@ -21,7 +21,7 @@
             <div class="tw-w-full tw-flex tw-flex-row tw-items-center tw-justify-start tw-gap-2">
               <bit-icon-tile icon="bwi-refresh" variant="primary" slot="start" />
               {{ "reused" | i18n }}
-              <span class="tw-ml-auto">{{ "yes" | i18n }}</span>
+              <span class="tw-ml-auto">{{ "xTimes" | i18n: item().reuseCount }}</span>
             </div>
           }
         </bit-card>

--- a/bitwarden_license/bit-browser/src/popup/dirt/health/health-delete-at-risk-item-dialog.component.html
+++ b/bitwarden_license/bit-browser/src/popup/dirt/health/health-delete-at-risk-item-dialog.component.html
@@ -4,23 +4,26 @@
     <p class="tw-text-left">
       {{ "deleteAtRiskItemDescription" | i18n }}
     </p>
-    <!-- TODO: update below to read categories properly for item -->
-    @if (true) {
+    @if (additionalRisks().showWeak || additionalRisks().showReused) {
       <bit-section>
         <bit-section-header>
           <p>{{ "passwordHasAdditionalRisks" | i18n }}</p>
         </bit-section-header>
         <bit-card class="tw-flex tw-flex-col tw-gap-2 tw-justify-start tw-items-start">
-          <div class="tw-w-full tw-flex tw-flex-row tw-items-center tw-justify-start tw-gap-2">
-            <bit-icon-tile icon="bwi-warning" variant="warning" slot="start" />
-            {{ "weak" | i18n }}
-            <span class="tw-ml-auto">{{ "yes" | i18n }}</span>
-          </div>
-          <div class="tw-w-full tw-flex tw-flex-row tw-items-center tw-justify-start tw-gap-2">
-            <bit-icon-tile icon="bwi-refresh" variant="primary" slot="start" />
-            {{ "reused" | i18n }}
-            <span class="tw-ml-auto">{{ "xTimes" | i18n: 6 }}</span>
-          </div>
+          @if (additionalRisks().showWeak) {
+            <div class="tw-w-full tw-flex tw-flex-row tw-items-center tw-justify-start tw-gap-2">
+              <bit-icon-tile icon="bwi-warning" variant="warning" slot="start" />
+              {{ "weak" | i18n }}
+              <span class="tw-ml-auto">{{ "yes" | i18n }}</span>
+            </div>
+          }
+          @if (additionalRisks().showReused) {
+            <div class="tw-w-full tw-flex tw-flex-row tw-items-center tw-justify-start tw-gap-2">
+              <bit-icon-tile icon="bwi-refresh" variant="primary" slot="start" />
+              {{ "reused" | i18n }}
+              <span class="tw-ml-auto">{{ "yes" | i18n }}</span>
+            </div>
+          }
         </bit-card>
       </bit-section>
     }

--- a/bitwarden_license/bit-browser/src/popup/dirt/health/health-delete-at-risk-item-dialog.component.html
+++ b/bitwarden_license/bit-browser/src/popup/dirt/health/health-delete-at-risk-item-dialog.component.html
@@ -9,16 +9,20 @@
         <bit-section-header>
           <p>{{ "passwordHasAdditionalRisks" | i18n }}</p>
         </bit-section-header>
-        <bit-card class="tw-flex tw-flex-col tw-gap-2 tw-justify-start tw-items-start">
+        <bit-card class="tw-flex tw-flex-col tw-gap-4 tw-justify-start tw-items-start">
           @if (additionalRisks().showWeak) {
-            <div class="tw-w-full tw-flex tw-flex-row tw-items-center tw-justify-start tw-gap-2">
+            <div
+              class="tw-w-full tw-flex tw-flex-row tw-items-center tw-justify-start tw-gap-2 tw-text-fg-body-subtle"
+            >
               <bit-icon-tile icon="bwi-warning" variant="warning" slot="start" />
               {{ "weak" | i18n }}
               <span class="tw-ml-auto">{{ "yes" | i18n }}</span>
             </div>
           }
           @if (additionalRisks().showReused) {
-            <div class="tw-w-full tw-flex tw-flex-row tw-items-center tw-justify-start tw-gap-2">
+            <div
+              class="tw-w-full tw-flex tw-flex-row tw-items-center tw-justify-start tw-gap-2 tw-text-fg-body-subtle"
+            >
               <bit-icon-tile icon="bwi-refresh" variant="primary" slot="start" />
               {{ "reused" | i18n }}
               <span class="tw-ml-auto">{{ "xTimes" | i18n: item().reuseCount }}</span>

--- a/bitwarden_license/bit-browser/src/popup/dirt/health/health-delete-at-risk-item-dialog.component.html
+++ b/bitwarden_license/bit-browser/src/popup/dirt/health/health-delete-at-risk-item-dialog.component.html
@@ -1,0 +1,14 @@
+<bit-simple-dialog title="Delete item" hideIcon>
+  <div bitDialogTitle class="tw-text-left">Delete item</div>
+  <div bitDialogContent class="tw-flex tw-flex-col tw-gap-2 tw-w-full">
+    <p class="tw-text-left">
+      Deleting this login removes it from your vault but doesn't fix the risk. To protect your
+      account, change your password first.
+    </p>
+    <!-- TODO: ADDITIONAL RISKS TABLE HERE -->
+  </div>
+  <div bitDialogFooter class="tw-flex tw-flex-col tw-gap-2">
+    <button bitButton type="button" buttonType="danger">Delete</button>
+    <button bitButton type="button" bitDialogClose>Cancel</button>
+  </div>
+</bit-simple-dialog>

--- a/bitwarden_license/bit-browser/src/popup/dirt/health/health-delete-at-risk-item-dialog.component.html
+++ b/bitwarden_license/bit-browser/src/popup/dirt/health/health-delete-at-risk-item-dialog.component.html
@@ -1,33 +1,34 @@
-<bit-simple-dialog title="Delete item" hideIcon>
-  <div bitDialogTitle class="tw-text-left">Delete item</div>
+<bit-simple-dialog hideIcon>
+  <div bitDialogTitle class="tw-text-left">{{ "deleteItem" | i18n }}</div>
   <div bitDialogContent class="tw-flex tw-flex-col tw-gap-2 tw-w-full">
     <p class="tw-text-left">
-      Deleting this login removes it from your vault but doesn't fix the risk. To protect your
-      account, change your password first.
+      {{ "deleteAtRiskItemDescription" | i18n }}
     </p>
     <!-- TODO: update below to read categories properly for item -->
     @if (true) {
       <bit-section>
         <bit-section-header>
-          <p>This password has additional risks:</p>
+          <p>{{ "passwordHasAdditionalRisks" | i18n }}</p>
         </bit-section-header>
         <bit-card class="tw-flex tw-flex-col tw-gap-2 tw-justify-start tw-items-start">
           <div class="tw-w-full tw-flex tw-flex-row tw-items-center tw-justify-start tw-gap-2">
             <bit-icon-tile icon="bwi-warning" variant="warning" slot="start" />
-            Weak
-            <span class="tw-ml-auto">Yes</span>
+            {{ "weak" | i18n }}
+            <span class="tw-ml-auto">{{ "yes" | i18n }}</span>
           </div>
           <div class="tw-w-full tw-flex tw-flex-row tw-items-center tw-justify-start tw-gap-2">
             <bit-icon-tile icon="bwi-refresh" variant="primary" slot="start" />
-            Reused
-            <span class="tw-ml-auto">6 times</span>
+            {{ "reused" | i18n }}
+            <span class="tw-ml-auto">{{ "xTimes" | i18n: 6 }}</span>
           </div>
         </bit-card>
       </bit-section>
     }
   </div>
   <div bitDialogFooter class="tw-flex tw-flex-col tw-gap-2">
-    <button bitButton type="button" buttonType="danger" (click)="onDeleteItem()">Delete</button>
-    <button bitButton type="button" bitDialogClose>Cancel</button>
+    <button bitButton type="button" buttonType="danger" (click)="onDeleteItem()">
+      {{ "delete" | i18n }}
+    </button>
+    <button bitButton type="button" bitDialogClose>{{ "cancel" | i18n }}</button>
   </div>
 </bit-simple-dialog>

--- a/bitwarden_license/bit-browser/src/popup/dirt/health/health-delete-at-risk-item-dialog.component.html
+++ b/bitwarden_license/bit-browser/src/popup/dirt/health/health-delete-at-risk-item-dialog.component.html
@@ -25,7 +25,7 @@
             >
               <bit-icon-tile icon="bwi-refresh" variant="primary" slot="start" />
               {{ "reused" | i18n }}
-              <span class="tw-ml-auto">{{ "xTimes" | i18n: item().reuseCount }}</span>
+              <span class="tw-ml-auto">{{ "xTimes" | i18n: this.item.reuseCount }}</span>
             </div>
           }
         </bit-card>

--- a/bitwarden_license/bit-browser/src/popup/dirt/health/health-delete-at-risk-item-dialog.component.spec.ts
+++ b/bitwarden_license/bit-browser/src/popup/dirt/health/health-delete-at-risk-item-dialog.component.spec.ts
@@ -5,6 +5,7 @@ import { mock, MockProxy } from "jest-mock-extended";
 import { ReplaySubject } from "rxjs";
 
 import { CipherHealthView } from "@bitwarden/bit-common/dirt/access-intelligence/models/view/cipher-health.view";
+import { RiskCategory } from "@bitwarden/bit-common/dirt/vault-health/models";
 import { Account, AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
@@ -33,6 +34,7 @@ describe("HealthDeleteAtRiskItemDialogComponent", () => {
       hasReusedPassword: false,
       hasExposedPassword: false,
       exposedCount: 0,
+      reuseCount: 0,
       ...args,
     });
   }
@@ -43,7 +45,7 @@ describe("HealthDeleteAtRiskItemDialogComponent", () => {
    */
   async function initComponent(data: Partial<HealthDeleteAtRiskItemDialogData> = {}) {
     const dialogData: HealthDeleteAtRiskItemDialogData = {
-      currentCategory: "exposed-passwords",
+      currentCategory: RiskCategory.Exposed,
       item: buildHealthView(),
       ...data,
     };
@@ -139,7 +141,7 @@ describe("HealthDeleteAtRiskItemDialogComponent", () => {
       /** Exposed sits at the top of the hierarchy, so both lower risks can appear. */
       async function initExposed(flags: { weak: boolean; reused: boolean }) {
         await initComponent({
-          currentCategory: "exposed-passwords",
+          currentCategory: RiskCategory.Exposed,
           item: buildHealthView({
             hasExposedPassword: true,
             hasWeakPassword: flags.weak,
@@ -184,7 +186,7 @@ describe("HealthDeleteAtRiskItemDialogComponent", () => {
       /** Weak sits in the middle, so only reused can appear — never weak itself. */
       async function initWeak(flags: { reused: boolean }) {
         await initComponent({
-          currentCategory: "weak-passwords",
+          currentCategory: RiskCategory.Weak,
           item: buildHealthView({
             hasWeakPassword: true,
             hasReusedPassword: flags.reused,
@@ -218,7 +220,7 @@ describe("HealthDeleteAtRiskItemDialogComponent", () => {
       /** Reused sits at the bottom, so there is never a lower risk to surface. */
       it("shows no risk section even when the item is exposed and weak", async () => {
         await initComponent({
-          currentCategory: "reused-passwords",
+          currentCategory: RiskCategory.Reused,
           item: buildHealthView({
             hasExposedPassword: true,
             hasWeakPassword: true,
@@ -232,7 +234,7 @@ describe("HealthDeleteAtRiskItemDialogComponent", () => {
 
       it("shows no risk section when the item has no other risks", async () => {
         await initComponent({
-          currentCategory: "reused-passwords",
+          currentCategory: RiskCategory.Reused,
           item: buildHealthView({ hasReusedPassword: true }),
         });
 

--- a/bitwarden_license/bit-browser/src/popup/dirt/health/health-delete-at-risk-item-dialog.component.spec.ts
+++ b/bitwarden_license/bit-browser/src/popup/dirt/health/health-delete-at-risk-item-dialog.component.spec.ts
@@ -1,0 +1,300 @@
+import { DIALOG_DATA } from "@angular/cdk/dialog";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { provideNoopAnimations } from "@angular/platform-browser/animations";
+import { mock, MockProxy } from "jest-mock-extended";
+import { ReplaySubject } from "rxjs";
+
+import { CipherHealthView } from "@bitwarden/bit-common/dirt/access-intelligence/models/view/cipher-health.view";
+import { Account, AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { Utils } from "@bitwarden/common/platform/misc/utils";
+import { UserId } from "@bitwarden/common/types/guid";
+import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
+import { DialogRef, ToastService } from "@bitwarden/components";
+
+import {
+  HealthDeleteAtRiskItemDialogComponent,
+  HealthDeleteAtRiskItemDialogData,
+} from "./health-delete-at-risk-item-dialog.component";
+
+describe("HealthDeleteAtRiskItemDialogComponent", () => {
+  const userId = Utils.newGuid() as UserId;
+
+  let fixture: ComponentFixture<HealthDeleteAtRiskItemDialogComponent>;
+  let activeAccount$: ReplaySubject<Account | null>;
+  let cipherService: MockProxy<CipherService>;
+  let toastService: MockProxy<ToastService>;
+  let dialogRef: MockProxy<DialogRef>;
+
+  function buildHealthView(args: Partial<CipherHealthView> = {}): CipherHealthView {
+    return new CipherHealthView({
+      cipherId: "cipher-1",
+      hasWeakPassword: false,
+      hasReusedPassword: false,
+      hasExposedPassword: false,
+      exposedCount: 0,
+      ...args,
+    });
+  }
+
+  /**
+   * Creates the dialog. The component reads its inputs off `DIALOG_DATA` at construction, so the
+   * testing module is rebuilt per case rather than mutating a shared fixture.
+   */
+  async function initComponent(data: Partial<HealthDeleteAtRiskItemDialogData> = {}) {
+    const dialogData: HealthDeleteAtRiskItemDialogData = {
+      currentCategory: "exposed-passwords",
+      item: buildHealthView(),
+      ...data,
+    };
+
+    TestBed.resetTestingModule();
+    await TestBed.configureTestingModule({
+      imports: [HealthDeleteAtRiskItemDialogComponent],
+      providers: [
+        provideNoopAnimations(),
+        { provide: DIALOG_DATA, useValue: dialogData },
+        { provide: DialogRef, useValue: dialogRef },
+        { provide: AccountService, useValue: { activeAccount$ } },
+        { provide: CipherService, useValue: cipherService },
+        { provide: ToastService, useValue: toastService },
+        { provide: I18nService, useValue: { t: (key: string) => key } },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(HealthDeleteAtRiskItemDialogComponent);
+    fixture.detectChanges();
+    await fixture.whenStable();
+  }
+
+  /** `fixture.nativeElement` is untyped, so narrow it once for the query helpers below. */
+  function host(): HTMLElement {
+    return fixture.nativeElement as HTMLElement;
+  }
+
+  /** All rendered text. The i18n mock echoes keys, so keys are matched directly. */
+  function text(): string {
+    return host().textContent ?? "";
+  }
+
+  /** The additional risks card, or null when the dialog renders no additional risks. */
+  function riskCard(): HTMLElement | null {
+    return host().querySelector("bit-card");
+  }
+
+  /** Whether the "This password has additional risks" section is on screen at all. */
+  function showsRiskSection(): boolean {
+    return text().includes("passwordHasAdditionalRisks") && riskCard() != null;
+  }
+
+  /**
+   * Risk rows are matched inside the card rather than against the whole dialog — the surrounding
+   * copy also contains the words "weak" and "reused", which would defeat negative assertions.
+   */
+  function showsWeakRisk(): boolean {
+    return riskCard()?.textContent?.includes("weak") ?? false;
+  }
+
+  function showsReusedRisk(): boolean {
+    return riskCard()?.textContent?.includes("reused") ?? false;
+  }
+
+  function deleteButton(): HTMLButtonElement {
+    return Array.from(host().querySelectorAll<HTMLButtonElement>("button")).find((button) =>
+      button.textContent?.includes("delete"),
+    )!;
+  }
+
+  beforeEach(() => {
+    activeAccount$ = new ReplaySubject<Account | null>(1);
+    activeAccount$.next({ id: userId } as Account);
+
+    cipherService = mock<CipherService>();
+    cipherService.softDeleteWithServer.mockResolvedValue(undefined);
+
+    toastService = mock<ToastService>();
+
+    dialogRef = mock<DialogRef>();
+    dialogRef.close.mockResolvedValue({ closed: true });
+  });
+
+  describe("static copy", () => {
+    it("renders the title, description and actions", async () => {
+      await initComponent();
+
+      expect(text()).toContain("deleteItem");
+      expect(text()).toContain("deleteAtRiskItemDescription");
+      expect(text()).toContain("delete");
+      expect(text()).toContain("cancel");
+    });
+  });
+
+  /**
+   * The at-risk hierarchy is exposed > weak > reused. The dialog only surfaces risks strictly
+   * below the category the user came from, so it never repeats the category they are already
+   * looking at back to them.
+   */
+  describe("additional risks", () => {
+    describe("exposed passwords", () => {
+      /** Exposed sits at the top of the hierarchy, so both lower risks can appear. */
+      async function initExposed(flags: { weak: boolean; reused: boolean }) {
+        await initComponent({
+          currentCategory: "exposed-passwords",
+          item: buildHealthView({
+            hasExposedPassword: true,
+            hasWeakPassword: flags.weak,
+            hasReusedPassword: flags.reused,
+          }),
+        });
+      }
+
+      it("shows both weak and reused when the item is also weak and reused", async () => {
+        await initExposed({ weak: true, reused: true });
+
+        expect(showsRiskSection()).toBe(true);
+        expect(showsWeakRisk()).toBe(true);
+        expect(showsReusedRisk()).toBe(true);
+      });
+
+      it("shows only weak when the item is also weak", async () => {
+        await initExposed({ weak: true, reused: false });
+
+        expect(showsRiskSection()).toBe(true);
+        expect(showsWeakRisk()).toBe(true);
+        expect(showsReusedRisk()).toBe(false);
+      });
+
+      it("shows only reused when the item is also reused", async () => {
+        await initExposed({ weak: false, reused: true });
+
+        expect(showsRiskSection()).toBe(true);
+        expect(showsWeakRisk()).toBe(false);
+        expect(showsReusedRisk()).toBe(true);
+      });
+
+      it("shows no risk section when the item has no lower risks", async () => {
+        await initExposed({ weak: false, reused: false });
+
+        expect(showsRiskSection()).toBe(false);
+        expect(riskCard()).toBeNull();
+      });
+    });
+
+    describe("weak passwords", () => {
+      /** Weak sits in the middle, so only reused can appear — never weak itself. */
+      async function initWeak(flags: { reused: boolean }) {
+        await initComponent({
+          currentCategory: "weak-passwords",
+          item: buildHealthView({
+            hasWeakPassword: true,
+            hasReusedPassword: flags.reused,
+          }),
+        });
+      }
+
+      it("shows only reused when the item is also reused", async () => {
+        await initWeak({ reused: true });
+
+        expect(showsRiskSection()).toBe(true);
+        expect(showsWeakRisk()).toBe(false);
+        expect(showsReusedRisk()).toBe(true);
+      });
+
+      it("shows no risk section when the item is not reused", async () => {
+        await initWeak({ reused: false });
+
+        expect(showsRiskSection()).toBe(false);
+        expect(riskCard()).toBeNull();
+      });
+
+      it("never repeats weak, the category being viewed", async () => {
+        await initWeak({ reused: true });
+
+        expect(showsWeakRisk()).toBe(false);
+      });
+    });
+
+    describe("reused passwords", () => {
+      /** Reused sits at the bottom, so there is never a lower risk to surface. */
+      it("shows no risk section even when the item is exposed and weak", async () => {
+        await initComponent({
+          currentCategory: "reused-passwords",
+          item: buildHealthView({
+            hasExposedPassword: true,
+            hasWeakPassword: true,
+            hasReusedPassword: true,
+          }),
+        });
+
+        expect(showsRiskSection()).toBe(false);
+        expect(riskCard()).toBeNull();
+      });
+
+      it("shows no risk section when the item has no other risks", async () => {
+        await initComponent({
+          currentCategory: "reused-passwords",
+          item: buildHealthView({ hasReusedPassword: true }),
+        });
+
+        expect(showsRiskSection()).toBe(false);
+        expect(riskCard()).toBeNull();
+      });
+    });
+  });
+
+  describe("deleting the item", () => {
+    it("soft deletes the item for the active account", async () => {
+      await initComponent({ item: buildHealthView({ cipherId: "cipher-42" }) });
+
+      deleteButton().click();
+      await fixture.whenStable();
+
+      expect(cipherService.softDeleteWithServer).toHaveBeenCalledTimes(1);
+      expect(cipherService.softDeleteWithServer).toHaveBeenCalledWith("cipher-42", userId);
+    });
+
+    it("shows a success toast", async () => {
+      await initComponent();
+
+      deleteButton().click();
+      await fixture.whenStable();
+
+      expect(toastService.showToast).toHaveBeenCalledWith({
+        message: "deletedItem",
+        variant: "success",
+      });
+    });
+
+    it("closes the dialog", async () => {
+      await initComponent();
+
+      deleteButton().click();
+      await fixture.whenStable();
+
+      expect(dialogRef.close).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not show the success toast until the delete resolves", async () => {
+      let resolveDelete: () => void;
+      cipherService.softDeleteWithServer.mockReturnValue(
+        new Promise<void>((resolve) => {
+          resolveDelete = resolve;
+        }),
+      );
+      await initComponent();
+
+      deleteButton().click();
+      await fixture.whenStable();
+
+      expect(cipherService.softDeleteWithServer).toHaveBeenCalled();
+      expect(toastService.showToast).not.toHaveBeenCalled();
+      expect(dialogRef.close).not.toHaveBeenCalled();
+
+      resolveDelete!();
+      await fixture.whenStable();
+
+      expect(toastService.showToast).toHaveBeenCalled();
+      expect(dialogRef.close).toHaveBeenCalled();
+    });
+  });
+});

--- a/bitwarden_license/bit-browser/src/popup/dirt/health/health-delete-at-risk-item-dialog.component.spec.ts
+++ b/bitwarden_license/bit-browser/src/popup/dirt/health/health-delete-at-risk-item-dialog.component.spec.ts
@@ -6,6 +6,7 @@ import { ReplaySubject } from "rxjs";
 
 import { CipherHealthView } from "@bitwarden/bit-common/dirt/access-intelligence/models/view/cipher-health.view";
 import { RiskCategory } from "@bitwarden/bit-common/dirt/vault-health/models";
+import { VaultHealthReportService } from "@bitwarden/bit-common/dirt/vault-health/services";
 import { Account, AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
@@ -24,6 +25,7 @@ describe("HealthDeleteAtRiskItemDialogComponent", () => {
   let fixture: ComponentFixture<HealthDeleteAtRiskItemDialogComponent>;
   let activeAccount$: ReplaySubject<Account | null>;
   let cipherService: MockProxy<CipherService>;
+  let vaultHealthReportService: MockProxy<VaultHealthReportService>;
   let toastService: MockProxy<ToastService>;
   let dialogRef: MockProxy<DialogRef>;
 
@@ -59,6 +61,7 @@ describe("HealthDeleteAtRiskItemDialogComponent", () => {
         { provide: DialogRef, useValue: dialogRef },
         { provide: AccountService, useValue: { activeAccount$ } },
         { provide: CipherService, useValue: cipherService },
+        { provide: VaultHealthReportService, useValue: vaultHealthReportService },
         { provide: ToastService, useValue: toastService },
         { provide: I18nService, useValue: { t: (key: string) => key } },
       ],
@@ -113,6 +116,9 @@ describe("HealthDeleteAtRiskItemDialogComponent", () => {
 
     cipherService = mock<CipherService>();
     cipherService.softDeleteWithServer.mockResolvedValue(undefined);
+
+    vaultHealthReportService = mock<VaultHealthReportService>();
+    vaultHealthReportService.deleteItemFromReport.mockReturnValue(undefined);
 
     toastService = mock<ToastService>();
 
@@ -253,6 +259,20 @@ describe("HealthDeleteAtRiskItemDialogComponent", () => {
 
       expect(cipherService.softDeleteWithServer).toHaveBeenCalledTimes(1);
       expect(cipherService.softDeleteWithServer).toHaveBeenCalledWith("cipher-42", userId);
+    });
+
+    it("deletes the item from the health report for active account", async () => {
+      await initComponent({ item: buildHealthView({ cipherId: "cipher-42" }) });
+
+      deleteButton().click();
+      await fixture.whenStable();
+
+      expect(vaultHealthReportService.deleteItemFromReport).toHaveBeenCalledTimes(1);
+      expect(vaultHealthReportService.deleteItemFromReport).toHaveBeenCalledWith(
+        "cipher-42",
+        RiskCategory.Exposed,
+        userId,
+      );
     });
 
     it("shows a success toast", async () => {

--- a/bitwarden_license/bit-browser/src/popup/dirt/health/health-delete-at-risk-item-dialog.component.ts
+++ b/bitwarden_license/bit-browser/src/popup/dirt/health/health-delete-at-risk-item-dialog.component.ts
@@ -3,6 +3,7 @@ import { Component, ChangeDetectionStrategy, input, inject, computed } from "@an
 import { firstValueFrom } from "rxjs";
 
 import { CipherHealthView } from "@bitwarden/bit-common/dirt/access-intelligence/models/view/cipher-health.view";
+import { RiskCategory } from "@bitwarden/bit-common/dirt/vault-health/models";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
@@ -19,7 +20,7 @@ import {
 import { I18nPipe } from "@bitwarden/ui-common";
 
 export interface HealthDeleteAtRiskItemDialogData {
-  currentCategory: string;
+  currentCategory: RiskCategory;
   item: CipherHealthView;
 }
 
@@ -46,7 +47,7 @@ export class HealthDeleteAtRiskItemDialogComponent {
   readonly inputData = inject<HealthDeleteAtRiskItemDialogData>(DIALOG_DATA);
 
   readonly item = input<CipherHealthView>(this.inputData.item);
-  readonly currentCategory = input<string>(this.inputData.currentCategory);
+  readonly currentCategory = input<RiskCategory>(this.inputData.currentCategory);
 
   readonly additionalRisks = computed<{ showWeak: boolean; showReused: boolean }>(() => {
     const item = this.item();
@@ -54,11 +55,11 @@ export class HealthDeleteAtRiskItemDialogComponent {
 
     // only show additional risk categories when the item currently being viewed also falls into lower risk categories. respects the at-risk hierarchy: exposed > weak > reused.
     switch (category) {
-      case "exposed-passwords":
+      case RiskCategory.Exposed:
         return { showWeak: item.hasWeakPassword, showReused: item.hasReusedPassword };
-      case "weak-passwords":
+      case RiskCategory.Weak:
         return { showWeak: false, showReused: item.hasReusedPassword };
-      case "reused-passwords":
+      case RiskCategory.Reused:
       default:
         return { showWeak: false, showReused: false };
     }

--- a/bitwarden_license/bit-browser/src/popup/dirt/health/health-delete-at-risk-item-dialog.component.ts
+++ b/bitwarden_license/bit-browser/src/popup/dirt/health/health-delete-at-risk-item-dialog.component.ts
@@ -1,11 +1,11 @@
 import { DIALOG_DATA } from "@angular/cdk/dialog";
-import { Component, ChangeDetectionStrategy, input, inject } from "@angular/core";
+import { Component, ChangeDetectionStrategy, input, inject, computed } from "@angular/core";
 import { firstValueFrom } from "rxjs";
 
+import { CipherHealthView } from "@bitwarden/bit-common/dirt/access-intelligence/models/view/cipher-health.view";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
-import type { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import {
   DialogModule,
   ButtonModule,
@@ -19,7 +19,8 @@ import {
 import { I18nPipe } from "@bitwarden/ui-common";
 
 export interface HealthDeleteAtRiskItemDialogData {
-  item: CipherView;
+  currentCategory: string;
+  item: CipherHealthView;
 }
 
 @Component({
@@ -44,7 +45,24 @@ export class HealthDeleteAtRiskItemDialogComponent {
   readonly dialogRef = inject(DialogRef);
   readonly inputData = inject<HealthDeleteAtRiskItemDialogData>(DIALOG_DATA);
 
-  readonly item = input<CipherView>(this.inputData.item);
+  readonly item = input<CipherHealthView>(this.inputData.item);
+  readonly currentCategory = input<string>(this.inputData.currentCategory);
+
+  readonly additionalRisks = computed<{ showWeak: boolean; showReused: boolean }>(() => {
+    const item = this.item();
+    const category = this.currentCategory();
+
+    // only show additional risk categories when the item currently being viewed also falls into lower risk categories. respects the at-risk hierarchy: exposed > weak > reused.
+    switch (category) {
+      case "exposed-passwords":
+        return { showWeak: item.hasWeakPassword, showReused: item.hasReusedPassword };
+      case "weak-passwords":
+        return { showWeak: false, showReused: item.hasReusedPassword };
+      case "reused-passwords":
+      default:
+        return { showWeak: false, showReused: false };
+    }
+  });
 
   readonly onDeleteItem = async () => {
     const user = await firstValueFrom(this.accountService.activeAccount$);
@@ -52,7 +70,7 @@ export class HealthDeleteAtRiskItemDialogComponent {
       return;
     }
 
-    await this.cipherService.softDeleteWithServer(this.item().id, user.id);
+    await this.cipherService.softDeleteWithServer(this.item().cipherId, user.id);
 
     this.toastService.showToast({
       message: this.i18nService.t("deletedItem"),

--- a/bitwarden_license/bit-browser/src/popup/dirt/health/health-delete-at-risk-item-dialog.component.ts
+++ b/bitwarden_license/bit-browser/src/popup/dirt/health/health-delete-at-risk-item-dialog.component.ts
@@ -55,7 +55,7 @@ export class HealthDeleteAtRiskItemDialogComponent {
     const item = this.item();
     const category = this.currentCategory();
 
-    // only show additional risk categories when the item currently being viewed also falls into lower risk categories. respects the at-risk hierarchy: exposed > weak > reused.
+    // only show additional risk categories when the item currently being viewed also falls into lower risk categories. respects the at-risk hierarchy: exposed > weak > reused (implemented in DefaultVaultHealthReportService.highestRiskCategory)
     switch (category) {
       case RiskCategory.Exposed:
         return { showWeak: item.hasWeakPassword, showReused: item.hasReusedPassword };

--- a/bitwarden_license/bit-browser/src/popup/dirt/health/health-delete-at-risk-item-dialog.component.ts
+++ b/bitwarden_license/bit-browser/src/popup/dirt/health/health-delete-at-risk-item-dialog.component.ts
@@ -3,6 +3,7 @@ import { Component, ChangeDetectionStrategy, input, inject } from "@angular/core
 import { firstValueFrom } from "rxjs";
 
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import type { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import {
@@ -15,6 +16,7 @@ import {
   IconTileComponent,
   CardComponent,
 } from "@bitwarden/components";
+import { I18nPipe } from "@bitwarden/ui-common";
 
 export interface HealthDeleteAtRiskItemDialogData {
   item: CipherView;
@@ -31,12 +33,14 @@ export interface HealthDeleteAtRiskItemDialogData {
     SectionHeaderComponent,
     IconTileComponent,
     CardComponent,
+    I18nPipe,
   ],
 })
 export class HealthDeleteAtRiskItemDialogComponent {
   readonly accountService = inject(AccountService);
   readonly cipherService = inject(CipherService);
   readonly toastService = inject(ToastService);
+  readonly i18nService = inject(I18nService);
   readonly dialogRef = inject(DialogRef);
   readonly inputData = inject<HealthDeleteAtRiskItemDialogData>(DIALOG_DATA);
 
@@ -51,7 +55,7 @@ export class HealthDeleteAtRiskItemDialogComponent {
     await this.cipherService.softDeleteWithServer(this.item().id, user.id);
 
     this.toastService.showToast({
-      message: "Item deleted",
+      message: this.i18nService.t("deletedItem"),
       variant: "success",
     });
 

--- a/bitwarden_license/bit-browser/src/popup/dirt/health/health-delete-at-risk-item-dialog.component.ts
+++ b/bitwarden_license/bit-browser/src/popup/dirt/health/health-delete-at-risk-item-dialog.component.ts
@@ -1,0 +1,11 @@
+import { Component, ChangeDetectionStrategy } from "@angular/core";
+
+import { DialogModule, ButtonModule } from "@bitwarden/components";
+
+@Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  selector: "health-delete-at-risk-item-dialog",
+  templateUrl: "./health-delete-at-risk-item-dialog.component.html",
+  imports: [DialogModule, ButtonModule],
+})
+export class HealthDeleteAtRiskItemDialogComponent {}

--- a/bitwarden_license/bit-browser/src/popup/dirt/health/health-delete-at-risk-item-dialog.component.ts
+++ b/bitwarden_license/bit-browser/src/popup/dirt/health/health-delete-at-risk-item-dialog.component.ts
@@ -1,6 +1,15 @@
-import { Component, ChangeDetectionStrategy } from "@angular/core";
+import { DIALOG_DATA } from "@angular/cdk/dialog";
+import { Component, ChangeDetectionStrategy, input, inject } from "@angular/core";
+import { firstValueFrom } from "rxjs";
 
-import { DialogModule, ButtonModule } from "@bitwarden/components";
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
+import type { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+import { DialogModule, ButtonModule, DialogRef, ToastService } from "@bitwarden/components";
+
+export interface HealthDeleteAtRiskItemDialogData {
+  item: CipherView;
+}
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -8,4 +17,28 @@ import { DialogModule, ButtonModule } from "@bitwarden/components";
   templateUrl: "./health-delete-at-risk-item-dialog.component.html",
   imports: [DialogModule, ButtonModule],
 })
-export class HealthDeleteAtRiskItemDialogComponent {}
+export class HealthDeleteAtRiskItemDialogComponent {
+  readonly accountService = inject(AccountService);
+  readonly cipherService = inject(CipherService);
+  readonly toastService = inject(ToastService);
+  readonly dialogRef = inject(DialogRef);
+  readonly inputData = inject<HealthDeleteAtRiskItemDialogData>(DIALOG_DATA);
+
+  readonly item = input<CipherView>(this.inputData.item);
+
+  readonly onDeleteItem = async () => {
+    const user = await firstValueFrom(this.accountService.activeAccount$);
+    if (!user) {
+      return;
+    }
+
+    await this.cipherService.softDeleteWithServer(this.item().id, user.id);
+
+    this.toastService.showToast({
+      message: "Item deleted",
+      variant: "success",
+    });
+
+    await this.dialogRef.close();
+  };
+}

--- a/bitwarden_license/bit-browser/src/popup/dirt/health/health-delete-at-risk-item-dialog.component.ts
+++ b/bitwarden_license/bit-browser/src/popup/dirt/health/health-delete-at-risk-item-dialog.component.ts
@@ -1,5 +1,5 @@
 import { DIALOG_DATA } from "@angular/cdk/dialog";
-import { Component, ChangeDetectionStrategy, input, inject, computed } from "@angular/core";
+import { Component, ChangeDetectionStrategy, inject, computed } from "@angular/core";
 import { firstValueFrom } from "rxjs";
 
 import { CipherHealthView } from "@bitwarden/bit-common/dirt/access-intelligence/models/view/cipher-health.view";
@@ -48,19 +48,16 @@ export class HealthDeleteAtRiskItemDialogComponent {
   readonly dialogRef = inject(DialogRef);
   readonly inputData = inject<HealthDeleteAtRiskItemDialogData>(DIALOG_DATA);
 
-  readonly item = input<CipherHealthView>(this.inputData.item);
-  readonly currentCategory = input<RiskCategory>(this.inputData.currentCategory);
+  readonly item = this.inputData.item;
+  readonly currentCategory = this.inputData.currentCategory;
 
   readonly additionalRisks = computed<{ showWeak: boolean; showReused: boolean }>(() => {
-    const item = this.item();
-    const category = this.currentCategory();
-
     // only show additional risk categories when the item currently being viewed also falls into lower risk categories. respects the at-risk hierarchy: exposed > weak > reused (implemented in DefaultVaultHealthReportService.highestRiskCategory)
-    switch (category) {
+    switch (this.currentCategory) {
       case RiskCategory.Exposed:
-        return { showWeak: item.hasWeakPassword, showReused: item.hasReusedPassword };
+        return { showWeak: this.item.hasWeakPassword, showReused: this.item.hasReusedPassword };
       case RiskCategory.Weak:
-        return { showWeak: false, showReused: item.hasReusedPassword };
+        return { showWeak: false, showReused: this.item.hasReusedPassword };
       case RiskCategory.Reused:
       default:
         return { showWeak: false, showReused: false };
@@ -73,7 +70,7 @@ export class HealthDeleteAtRiskItemDialogComponent {
       return;
     }
 
-    await this.cipherService.softDeleteWithServer(this.item().cipherId, user.id);
+    await this.cipherService.softDeleteWithServer(this.item.cipherId, user.id);
 
     this.toastService.showToast({
       message: this.i18nService.t("deletedItem"),

--- a/bitwarden_license/bit-browser/src/popup/dirt/health/health-delete-at-risk-item-dialog.component.ts
+++ b/bitwarden_license/bit-browser/src/popup/dirt/health/health-delete-at-risk-item-dialog.component.ts
@@ -16,6 +16,7 @@ import {
   SectionHeaderComponent,
   IconTileComponent,
   CardComponent,
+  AsyncActionsModule,
 } from "@bitwarden/components";
 import { I18nPipe } from "@bitwarden/ui-common";
 
@@ -36,6 +37,7 @@ export interface HealthDeleteAtRiskItemDialogData {
     IconTileComponent,
     CardComponent,
     I18nPipe,
+    AsyncActionsModule,
   ],
 })
 export class HealthDeleteAtRiskItemDialogComponent {

--- a/bitwarden_license/bit-browser/src/popup/dirt/health/health-delete-at-risk-item-dialog.component.ts
+++ b/bitwarden_license/bit-browser/src/popup/dirt/health/health-delete-at-risk-item-dialog.component.ts
@@ -5,7 +5,16 @@ import { firstValueFrom } from "rxjs";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import type { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
-import { DialogModule, ButtonModule, DialogRef, ToastService } from "@bitwarden/components";
+import {
+  DialogModule,
+  ButtonModule,
+  DialogRef,
+  ToastService,
+  SectionComponent,
+  SectionHeaderComponent,
+  IconTileComponent,
+  CardComponent,
+} from "@bitwarden/components";
 
 export interface HealthDeleteAtRiskItemDialogData {
   item: CipherView;
@@ -15,7 +24,14 @@ export interface HealthDeleteAtRiskItemDialogData {
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: "health-delete-at-risk-item-dialog",
   templateUrl: "./health-delete-at-risk-item-dialog.component.html",
-  imports: [DialogModule, ButtonModule],
+  imports: [
+    DialogModule,
+    ButtonModule,
+    SectionComponent,
+    SectionHeaderComponent,
+    IconTileComponent,
+    CardComponent,
+  ],
 })
 export class HealthDeleteAtRiskItemDialogComponent {
   readonly accountService = inject(AccountService);

--- a/bitwarden_license/bit-browser/src/popup/dirt/health/health-delete-at-risk-item-dialog.component.ts
+++ b/bitwarden_license/bit-browser/src/popup/dirt/health/health-delete-at-risk-item-dialog.component.ts
@@ -4,6 +4,7 @@ import { firstValueFrom } from "rxjs";
 
 import { CipherHealthView } from "@bitwarden/bit-common/dirt/access-intelligence/models/view/cipher-health.view";
 import { RiskCategory } from "@bitwarden/bit-common/dirt/vault-health/models";
+import { VaultHealthReportService } from "@bitwarden/bit-common/dirt/vault-health/services";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
@@ -43,6 +44,7 @@ export interface HealthDeleteAtRiskItemDialogData {
 export class HealthDeleteAtRiskItemDialogComponent {
   readonly accountService = inject(AccountService);
   readonly cipherService = inject(CipherService);
+  readonly vaultHealthReportService = inject(VaultHealthReportService);
   readonly toastService = inject(ToastService);
   readonly i18nService = inject(I18nService);
   readonly dialogRef = inject(DialogRef);
@@ -71,6 +73,13 @@ export class HealthDeleteAtRiskItemDialogComponent {
     }
 
     await this.cipherService.softDeleteWithServer(this.item.cipherId, user.id);
+
+    // update the health report to remove item from current category
+    this.vaultHealthReportService.deleteItemFromReport(
+      this.item.cipherId,
+      this.currentCategory,
+      user.id,
+    );
 
     this.toastService.showToast({
       message: this.i18nService.t("deletedItem"),

--- a/bitwarden_license/bit-browser/src/popup/dirt/health/health-risk-category-detail.component.html
+++ b/bitwarden_license/bit-browser/src/popup/dirt/health/health-risk-category-detail.component.html
@@ -57,7 +57,12 @@
                 ></button>
               </bit-item-action>
               <bit-menu #itemMenu>
-                <button bitMenuItem type="button" variant="danger" (click)="onDeleteItem(item)">
+                <button
+                  bitMenuItem
+                  type="button"
+                  variant="danger"
+                  (click)="onDeleteItem(item, cipher)"
+                >
                   <bit-icon name="bwi-delete" slot="start" />
                   {{ "deleteItem" | i18n }}
                 </button>

--- a/bitwarden_license/bit-browser/src/popup/dirt/health/health-risk-category-detail.component.html
+++ b/bitwarden_license/bit-browser/src/popup/dirt/health/health-risk-category-detail.component.html
@@ -53,14 +53,6 @@
                   type="button"
                   bitIconButton="bwi-more-horizontal"
                   label="{{ 'options' | i18n }}"
-                ></button>
-              </bit-item-action>
-
-              <bit-item-action>
-                <button
-                  type="button"
-                  bitIconButton="bwi-more-horizontal"
-                  label="{{ 'options' | i18n }}"
                   [bitMenuTriggerFor]="itemMenu"
                 ></button>
               </bit-item-action>

--- a/bitwarden_license/bit-browser/src/popup/dirt/health/health-risk-category-detail.component.html
+++ b/bitwarden_license/bit-browser/src/popup/dirt/health/health-risk-category-detail.component.html
@@ -67,7 +67,7 @@
               <bit-menu #itemMenu>
                 <button bitMenuItem type="button" variant="danger" (click)="onDeleteItem(item)">
                   <bit-icon name="bwi-delete" slot="start" />
-                  Delete item
+                  {{ "deleteItem" | i18n }}
                 </button>
               </bit-menu>
             </div>

--- a/bitwarden_license/bit-browser/src/popup/dirt/health/health-risk-category-detail.component.html
+++ b/bitwarden_license/bit-browser/src/popup/dirt/health/health-risk-category-detail.component.html
@@ -55,18 +55,18 @@
                   label="{{ 'options' | i18n }}"
                   [bitMenuTriggerFor]="itemMenu"
                 ></button>
+                <bit-menu #itemMenu>
+                  <button
+                    bitMenuItem
+                    type="button"
+                    variant="danger"
+                    (click)="onDeleteItem(item, cipher)"
+                  >
+                    <bit-icon name="bwi-delete" slot="start" />
+                    {{ "deleteItem" | i18n }}
+                  </button>
+                </bit-menu>
               </bit-item-action>
-              <bit-menu #itemMenu>
-                <button
-                  bitMenuItem
-                  type="button"
-                  variant="danger"
-                  (click)="onDeleteItem(item, cipher)"
-                >
-                  <bit-icon name="bwi-delete" slot="start" />
-                  {{ "deleteItem" | i18n }}
-                </button>
-              </bit-menu>
             </div>
           </bit-item>
         }

--- a/bitwarden_license/bit-browser/src/popup/dirt/health/health-risk-category-detail.component.html
+++ b/bitwarden_license/bit-browser/src/popup/dirt/health/health-risk-category-detail.component.html
@@ -55,6 +55,21 @@
                   label="{{ 'options' | i18n }}"
                 ></button>
               </bit-item-action>
+
+              <bit-item-action>
+                <button
+                  type="button"
+                  bitIconButton="bwi-more-horizontal"
+                  label="{{ 'options' | i18n }}"
+                  [bitMenuTriggerFor]="itemMenu"
+                ></button>
+              </bit-item-action>
+              <bit-menu #itemMenu>
+                <button bitMenuItem type="button" variant="danger" (click)="onDeleteItem(item)">
+                  <bit-icon name="bwi-delete" slot="start" />
+                  Delete item
+                </button>
+              </bit-menu>
             </div>
           </bit-item>
         }

--- a/bitwarden_license/bit-browser/src/popup/dirt/health/health-risk-category-detail.component.spec.ts
+++ b/bitwarden_license/bit-browser/src/popup/dirt/health/health-risk-category-detail.component.spec.ts
@@ -572,9 +572,7 @@ describe("HealthRiskCategoryDetailComponent", () => {
 
       expect(moreOptionsButton(0)).not.toBeNull();
       expect(moreOptionsButton(1)).not.toBeNull();
-      expect(moreOptionsButton(0)!.getAttribute("aria-label")).toBe(
-        "moreOptionsLabelNoPlaceholder",
-      );
+      expect(moreOptionsButton(0)!.getAttribute("aria-label")).toBe("options");
     });
 
     it("renders the delete item entry in the ellipsis menu", async () => {

--- a/bitwarden_license/bit-browser/src/popup/dirt/health/health-risk-category-detail.component.spec.ts
+++ b/bitwarden_license/bit-browser/src/popup/dirt/health/health-risk-category-detail.component.spec.ts
@@ -26,9 +26,27 @@ import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.servi
 import { CipherType } from "@bitwarden/common/vault/enums";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { LoginUriView } from "@bitwarden/common/vault/models/view/login-uri.view";
+import { DialogRef, DialogService } from "@bitwarden/components";
 import { PasswordRepromptService } from "@bitwarden/vault";
 
+import { HealthDeleteAtRiskItemDialogComponent } from "./health-delete-at-risk-item-dialog.component";
 import { HealthRiskCategoryDetailComponent } from "./health-risk-category-detail.component";
+
+// eslint-disable-next-line no-console
+const originalError = console.error;
+
+// eslint-disable-next-line no-console
+console.error = (...args: unknown[]) => {
+  if (
+    typeof args[0] === "object" &&
+    (args[0] as Error).message.includes("Could not parse CSS stylesheet")
+  ) {
+    // Opening the menu's overlay container in tests causes stylesheets to be parsed, which can
+    // lead to JSDOM unable to parse CSS errors. These can be ignored safely.
+    return;
+  }
+  originalError(...args);
+};
 
 @Component({
   selector: "popup-page",
@@ -105,6 +123,7 @@ describe("HealthRiskCategoryDetailComponent", () => {
   let changeLoginPasswordService: MockProxy<ChangeLoginPasswordService>;
   let passwordRepromptService: MockProxy<PasswordRepromptService>;
   let platformUtilsService: MockProxy<PlatformUtilsService>;
+  let dialogService: MockProxy<DialogService>;
 
   /**
    * `login.uri` is a getter over `login.uris`, so fixtures have to be real views — an object
@@ -192,6 +211,35 @@ describe("HealthRiskCategoryDetailComponent", () => {
     ).find((button) => button.textContent?.includes("changePassword"));
   }
 
+  /**
+   * The row's ellipsis trigger. Matched on `bitIconButton` — the menu trigger is bound as a
+   * property, so `bitMenuTriggerFor` never reaches the DOM.
+   */
+  function moreOptionsButton(index: number): HTMLButtonElement | null {
+    return rows()[index].querySelector("button[bitIconButton]");
+  }
+
+  /**
+   * The open menu panel. The menu's content is projected through an `ng-template` into a CDK
+   * overlay, so it lives outside the fixture and is only in the DOM while the menu is open.
+   */
+  function menuPanel(): HTMLElement | null {
+    return document.querySelector(".bit-menu-panel");
+  }
+
+  /** An entry in the open menu, matched on its rendered text. */
+  function menuItem(label: string): HTMLButtonElement | undefined {
+    return Array.from(menuPanel()?.querySelectorAll<HTMLButtonElement>("[bitMenuItem]") ?? []).find(
+      (button) => button.textContent?.includes(label),
+    );
+  }
+
+  /** Opens the ellipsis menu on the given row. */
+  function openMenu(index: number) {
+    moreOptionsButton(index)!.click();
+    fixture.detectChanges();
+  }
+
   /** The count rendered alongside the section header. */
   function itemCount(): string | undefined {
     return fixture.nativeElement.querySelector("bit-section-header span[slot=end]")?.textContent;
@@ -225,6 +273,9 @@ describe("HealthRiskCategoryDetailComponent", () => {
 
     platformUtilsService = mock<PlatformUtilsService>();
     platformUtilsService.launchUri.mockImplementation(() => {});
+    // `onDeleteItem` only awaits `open()`, so a minimal `DialogRef`-shaped return is enough.
+    dialogService = mock<DialogService>();
+    dialogService.open.mockReturnValue({ closed: of(undefined) } as DialogRef<unknown>);
 
     await TestBed.configureTestingModule({
       imports: [HealthRiskCategoryDetailComponent],
@@ -239,6 +290,7 @@ describe("HealthRiskCategoryDetailComponent", () => {
         { provide: CipherService, useValue: cipherService },
         { provide: ChangeLoginPasswordService, useValue: changeLoginPasswordService },
         { provide: PasswordRepromptService, useValue: passwordRepromptService },
+        { provide: DialogService, useValue: dialogService },
         { provide: I18nService, useValue: { t: (key: string) => key } },
         { provide: PlatformUtilsService, useValue: platformUtilsService },
       ],
@@ -264,6 +316,11 @@ describe("HealthRiskCategoryDetailComponent", () => {
         },
       })
       .compileComponents();
+  });
+
+  afterEach(() => {
+    // Overlays are attached to the document body, so they outlive the fixture unless removed.
+    document.querySelectorAll(".cdk-overlay-container").forEach((overlay) => overlay.remove());
   });
 
   describe("category content", () => {
@@ -500,6 +557,74 @@ describe("HealthRiskCategoryDetailComponent", () => {
       );
       expect(platformUtilsService.launchUri).toHaveBeenCalledWith(
         "https://another.example.com/password",
+      );
+    });
+  });
+
+  describe("ellipsis menu", () => {
+    it("renders an ellipsis menu trigger on every row", async () => {
+      setReport(RiskCategory.Exposed, [
+        buildLogin({ id: "cipher-1" }),
+        buildLogin({ id: "cipher-2" }),
+      ]);
+
+      await initComponent();
+
+      expect(moreOptionsButton(0)).not.toBeNull();
+      expect(moreOptionsButton(1)).not.toBeNull();
+      expect(moreOptionsButton(0)!.getAttribute("aria-label")).toBe(
+        "moreOptionsLabelNoPlaceholder",
+      );
+    });
+
+    it("renders the delete item entry in the ellipsis menu", async () => {
+      setReport(RiskCategory.Exposed, [buildLogin({ id: "cipher-1" })]);
+      await initComponent();
+
+      openMenu(0);
+
+      expect(menuPanel()).not.toBeNull();
+      expect(menuItem("deleteItem")).toBeDefined();
+    });
+
+    it("opens the delete dialog when the menu entry is clicked", async () => {
+      setReport(RiskCategory.Exposed, [buildLogin({ id: "cipher-1" })]);
+      await initComponent();
+      openMenu(0);
+
+      menuItem("deleteItem")!.click();
+      await fixture.whenStable();
+
+      expect(dialogService.open).toHaveBeenCalledTimes(1);
+      expect(dialogService.open).toHaveBeenCalledWith(
+        HealthDeleteAtRiskItemDialogComponent,
+        expect.anything(),
+      );
+    });
+
+    // The risk flags on the passed view are placeholders today, so only the item's identity and
+    // the category are asserted — the hierarchy they drive is covered in the dialog's own spec.
+    it("passes the clicked item and the current category to the dialog", async () => {
+      params$.next({ category: RiskCategory.Exposed });
+      setReport(RiskCategory.Exposed, [
+        buildLogin({ id: "cipher-1" }),
+        buildLogin({ id: "cipher-2" }),
+        buildLogin({ id: "cipher-3" }),
+      ]);
+      await initComponent();
+      openMenu(1);
+
+      menuItem("deleteItem")!.click();
+      await fixture.whenStable();
+
+      expect(dialogService.open).toHaveBeenCalledWith(
+        HealthDeleteAtRiskItemDialogComponent,
+        expect.objectContaining({
+          data: expect.objectContaining({
+            currentCategory: RiskCategory.Exposed,
+            item: expect.objectContaining({ cipherId: "cipher-2" }),
+          }),
+        }),
       );
     });
   });

--- a/bitwarden_license/bit-browser/src/popup/dirt/health/health-risk-category-detail.component.spec.ts
+++ b/bitwarden_license/bit-browser/src/popup/dirt/health/health-risk-category-detail.component.spec.ts
@@ -585,6 +585,30 @@ describe("HealthRiskCategoryDetailComponent", () => {
       expect(menuItem("deleteItem")).toBeDefined();
     });
 
+    it("checks the master password reprompt for the delete item", async () => {
+      setReport(RiskCategory.Exposed, [buildLogin({ id: "cipher-1" })]);
+      await initComponent();
+      openMenu(0);
+
+      menuItem("deleteItem")!.click();
+      await fixture.whenStable();
+      expect(passwordRepromptService.passwordRepromptCheck).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "cipher-1" }),
+      );
+    });
+
+    it("delete dialog is not opened when the master password reprompt is not satisfied", async () => {
+      passwordRepromptService.passwordRepromptCheck.mockResolvedValue(false);
+      setReport(RiskCategory.Exposed, [buildLogin({ id: "cipher-1" })]);
+      await initComponent();
+      openMenu(0);
+
+      menuItem("deleteItem")!.click();
+      await fixture.whenStable();
+
+      expect(dialogService.open).not.toHaveBeenCalled();
+    });
+
     it("opens the delete dialog when the menu entry is clicked", async () => {
       setReport(RiskCategory.Exposed, [buildLogin({ id: "cipher-1" })]);
       await initComponent();

--- a/bitwarden_license/bit-browser/src/popup/dirt/health/health-risk-category-detail.component.ts
+++ b/bitwarden_license/bit-browser/src/popup/dirt/health/health-risk-category-detail.component.ts
@@ -132,7 +132,12 @@ export class HealthRiskCategoryDetailComponent {
     });
   };
 
-  readonly onDeleteItem = async (health: CipherHealthView) => {
+  readonly onDeleteItem = async (health: CipherHealthView, cipher: CipherView) => {
+    const repromptPassed = await this.passwordRepromptService.passwordRepromptCheck(cipher);
+    if (!repromptPassed) {
+      return;
+    }
+
     await this.dialogService.open(HealthDeleteAtRiskItemDialogComponent, {
       positionStrategy: new CenterPositionStrategy(),
       data: {

--- a/bitwarden_license/bit-browser/src/popup/dirt/health/health-risk-category-detail.component.ts
+++ b/bitwarden_license/bit-browser/src/popup/dirt/health/health-risk-category-detail.component.ts
@@ -132,21 +132,11 @@ export class HealthRiskCategoryDetailComponent {
     });
   };
 
-  readonly onDeleteItem = async (item: CipherView) => {
-    // TODO: UPDATE - FOR TESTING ONLY
-    const cipherHealthView = new CipherHealthView({
-      cipherId: item.id,
-      hasWeakPassword: true,
-      hasReusedPassword: true,
-      hasExposedPassword: true,
-      exposedCount: 1,
-      reuseCount: 1,
-    });
-
+  readonly onDeleteItem = async (health: CipherHealthView) => {
     await this.dialogService.open(HealthDeleteAtRiskItemDialogComponent, {
       positionStrategy: new CenterPositionStrategy(),
       data: {
-        item: cipherHealthView,
+        item: health,
         currentCategory: this.category(),
       } satisfies HealthDeleteAtRiskItemDialogData,
     });

--- a/bitwarden_license/bit-browser/src/popup/dirt/health/health-risk-category-detail.component.ts
+++ b/bitwarden_license/bit-browser/src/popup/dirt/health/health-risk-category-detail.component.ts
@@ -130,6 +130,7 @@ export class HealthRiskCategoryDetailComponent {
   readonly onDeleteItem = async (item: CipherView) => {
     await this.dialogService.open(HealthDeleteAtRiskItemDialogComponent, {
       positionStrategy: new CenterPositionStrategy(),
+      data: { item },
     });
   };
 

--- a/bitwarden_license/bit-browser/src/popup/dirt/health/health-risk-category-detail.component.ts
+++ b/bitwarden_license/bit-browser/src/popup/dirt/health/health-risk-category-detail.component.ts
@@ -137,7 +137,7 @@ export class HealthRiskCategoryDetailComponent {
       positionStrategy: new CenterPositionStrategy(),
       data: {
         item: health,
-        currentCategory: this.category(),
+        currentCategory: this.category()!,
       } satisfies HealthDeleteAtRiskItemDialogData,
     });
   };

--- a/bitwarden_license/bit-browser/src/popup/dirt/health/health-risk-category-detail.component.ts
+++ b/bitwarden_license/bit-browser/src/popup/dirt/health/health-risk-category-detail.component.ts
@@ -26,11 +26,14 @@ import {
   IconButtonModule,
   MenuModule,
   IconModule,
+  DialogService,
+  CenterPositionStrategy,
 } from "@bitwarden/components";
 import { I18nPipe } from "@bitwarden/ui-common";
 import { PasswordRepromptService } from "@bitwarden/vault";
 
 const HEALTH_OVERVIEW_ROUTE = "/tabs/health";
+import { HealthDeleteAtRiskItemDialogComponent } from "./health-delete-at-risk-item-dialog.component";
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -62,6 +65,7 @@ export class HealthRiskCategoryDetailComponent {
   readonly passwordRepromptService = inject(PasswordRepromptService);
   readonly platformUtilsService = inject(PlatformUtilsService);
   readonly vaultHealthReportService = inject(VaultHealthReportService);
+  readonly dialogService = inject(DialogService);
 
   constructor() {
     effect(() => {
@@ -120,6 +124,12 @@ export class HealthRiskCategoryDetailComponent {
     }
     await this.router.navigate(["/view-cipher"], {
       queryParams: { cipherId: item.id, type: item.type },
+    });
+  };
+
+  readonly onDeleteItem = async (item: CipherView) => {
+    await this.dialogService.open(HealthDeleteAtRiskItemDialogComponent, {
+      positionStrategy: new CenterPositionStrategy(),
     });
   };
 

--- a/bitwarden_license/bit-browser/src/popup/dirt/health/health-risk-category-detail.component.ts
+++ b/bitwarden_license/bit-browser/src/popup/dirt/health/health-risk-category-detail.component.ts
@@ -32,8 +32,12 @@ import {
 import { I18nPipe } from "@bitwarden/ui-common";
 import { PasswordRepromptService } from "@bitwarden/vault";
 
+import {
+  HealthDeleteAtRiskItemDialogComponent,
+  HealthDeleteAtRiskItemDialogData,
+} from "./health-delete-at-risk-item-dialog.component";
+
 const HEALTH_OVERVIEW_ROUTE = "/tabs/health";
-import { HealthDeleteAtRiskItemDialogComponent } from "./health-delete-at-risk-item-dialog.component";
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -130,7 +134,7 @@ export class HealthRiskCategoryDetailComponent {
   readonly onDeleteItem = async (item: CipherView) => {
     await this.dialogService.open(HealthDeleteAtRiskItemDialogComponent, {
       positionStrategy: new CenterPositionStrategy(),
-      data: { item },
+      data: { item } satisfies HealthDeleteAtRiskItemDialogData,
     });
   };
 

--- a/bitwarden_license/bit-browser/src/popup/dirt/health/health-risk-category-detail.component.ts
+++ b/bitwarden_license/bit-browser/src/popup/dirt/health/health-risk-category-detail.component.ts
@@ -4,6 +4,7 @@ import { ActivatedRoute, Router } from "@angular/router";
 import { map, switchMap } from "rxjs/operators";
 
 import { IconComponent as AppVaultIconComponent } from "@bitwarden/angular/vault/components/icon.component";
+import { CipherHealthView } from "@bitwarden/bit-common/dirt/access-intelligence/models/view/cipher-health.view";
 import { RiskCategory } from "@bitwarden/bit-common/dirt/vault-health/models";
 import { VaultHealthReportService } from "@bitwarden/bit-common/dirt/vault-health/services";
 import { CurrentAccountComponent } from "@bitwarden/browser/auth/popup/account-switching/current-account.component";
@@ -132,9 +133,22 @@ export class HealthRiskCategoryDetailComponent {
   };
 
   readonly onDeleteItem = async (item: CipherView) => {
+    // TODO: UPDATE - FOR TESTING ONLY
+    const cipherHealthView = new CipherHealthView({
+      cipherId: item.id,
+      hasWeakPassword: true,
+      hasReusedPassword: true,
+      hasExposedPassword: true,
+      exposedCount: 1,
+      reuseCount: 1,
+    });
+
     await this.dialogService.open(HealthDeleteAtRiskItemDialogComponent, {
       positionStrategy: new CenterPositionStrategy(),
-      data: { item } satisfies HealthDeleteAtRiskItemDialogData,
+      data: {
+        item: cipherHealthView,
+        currentCategory: this.category(),
+      } satisfies HealthDeleteAtRiskItemDialogData,
     });
   };
 

--- a/bitwarden_license/bit-browser/src/popup/dirt/health/health-risk-category-detail.component.ts
+++ b/bitwarden_license/bit-browser/src/popup/dirt/health/health-risk-category-detail.component.ts
@@ -24,6 +24,8 @@ import {
   TypographyModule,
   ButtonModule,
   IconButtonModule,
+  MenuModule,
+  IconModule,
 } from "@bitwarden/components";
 import { I18nPipe } from "@bitwarden/ui-common";
 import { PasswordRepromptService } from "@bitwarden/vault";
@@ -47,6 +49,8 @@ const HEALTH_OVERVIEW_ROUTE = "/tabs/health";
     IconButtonModule,
     AppVaultIconComponent,
     I18nPipe,
+    MenuModule,
+    IconModule,
   ],
 })
 export class HealthRiskCategoryDetailComponent {

--- a/bitwarden_license/bit-common/src/dirt/vault-health/services/abstractions/vault-health-report.service.ts
+++ b/bitwarden_license/bit-common/src/dirt/vault-health/services/abstractions/vault-health-report.service.ts
@@ -3,6 +3,7 @@ import { Observable } from "rxjs";
 import { UserId } from "@bitwarden/common/types/guid";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 
+import { RiskCategory } from "../../models";
 import { VaultHealthReportView } from "../../models/view/vault-health-report.view";
 
 /**
@@ -30,4 +31,14 @@ export abstract class VaultHealthReportService {
    * null until a scan completes for that user
    */
   abstract getVaultHealthReport$(userId: UserId): Observable<VaultHealthReportView | null>;
+
+  /**
+   * Delete an item from an existing vault health report, without rebuilding the report.
+   *
+   * @param cipherId the id of the cipher/item to be deleted from the report
+   * @param category the risk category the cipher/item belongs to
+   * @param userId the id of the user deleting the item
+   * @returns n/a
+   */
+  abstract deleteItemFromReport(cipherId: string, category: RiskCategory, userId: UserId): void;
 }

--- a/bitwarden_license/bit-common/src/dirt/vault-health/services/implementations/default-vault-health-report.service.spec.ts
+++ b/bitwarden_license/bit-common/src/dirt/vault-health/services/implementations/default-vault-health-report.service.spec.ts
@@ -1,5 +1,5 @@
 import { mock } from "jest-mock-extended";
-import { firstValueFrom } from "rxjs";
+import { firstValueFrom, Subject, takeUntil } from "rxjs";
 
 import { UserId } from "@bitwarden/common/types/guid";
 import { CipherRiskService } from "@bitwarden/common/vault/abstractions/cipher-risk.service";
@@ -23,9 +23,13 @@ describe("DefaultVaultHealthReportService", () => {
   // keyed by id (mirrors the SDK, which stamps each result with its cipher id).
   let riskById: Map<string, CipherRiskResult>;
 
+  /** Tears down the long-lived subscriptions the emission tests set up. */
+  let destroy$: Subject<void>;
+
   beforeEach(() => {
     cipherRiskService = mock<CipherRiskService>();
     riskById = new Map();
+    destroy$ = new Subject<void>();
 
     cipherRiskService.buildPasswordReuseMap.mockResolvedValue({});
     cipherRiskService.computeRiskForCiphers.mockImplementation(async (ciphers) =>
@@ -36,6 +40,8 @@ describe("DefaultVaultHealthReportService", () => {
   });
 
   afterEach(() => {
+    destroy$.next();
+    destroy$.complete();
     jest.clearAllMocks();
   });
 
@@ -322,6 +328,20 @@ describe("DefaultVaultHealthReportService", () => {
   });
 
   describe("deleteItemFromReport", () => {
+    /** Collects every report emitted from now on, so missed emissions are visible. */
+    const observeReports = (): VaultHealthReportView[] => {
+      const emitted: VaultHealthReportView[] = [];
+      service
+        .getVaultHealthReport$(userId)
+        .pipe(takeUntil(destroy$))
+        .subscribe((report) => {
+          if (report != null) {
+            emitted.push(report);
+          }
+        });
+      return emitted;
+    };
+
     it("removes the item from the report and decrements counts", async () => {
       const ciphers = withRisks([
         { cipher: login("a"), risk: risk("a", { exposed: 3 }) },
@@ -337,6 +357,73 @@ describe("DefaultVaultHealthReportService", () => {
       expect(updated!.totalCount).toBe(2);
       expect(cipherIds(updated!.categoryItems.exposed)).toEqual(["c"]);
       expect(cipherIds(updated!.categoryItems.weak)).toEqual(["b"]);
+    });
+
+    // Guards against mutating the published report in place: subscribers already
+    // attached must see the delete, so a new report instance has to be emitted.
+    it("emits the updated report to subscribers attached before the delete", async () => {
+      const ciphers = withRisks([
+        { cipher: login("a"), risk: risk("a", { exposed: 3 }) },
+        { cipher: login("b"), risk: risk("b", { strength: 1 }) },
+        { cipher: login("c"), risk: risk("c", { exposed: 2 }) },
+      ]);
+      await service.buildVaultHealthReport(ciphers, userId);
+
+      const emitted = observeReports();
+      service.deleteItemFromReport("a", "exposed", userId);
+
+      expect(emitted).toHaveLength(2);
+      expect(cipherIds(emitted[1].categoryItems.exposed)).toEqual(["c"]);
+      expect(emitted[1].atRiskCount).toBe(2);
+      expect(emitted[1].totalCount).toBe(2);
+      // the previously published report is left untouched
+      expect(cipherIds(emitted[0].categoryItems.exposed)).toEqual(["a", "c"]);
+      expect(emitted[0].atRiskCount).toBe(3);
+    });
+
+    it("recomputes the score from the adjusted counts", async () => {
+      const ciphers = withRisks([
+        { cipher: login("a"), risk: risk("a", { exposed: 3 }) },
+        { cipher: login("b"), risk: risk("b", { strength: 1 }) },
+        { cipher: login("c"), risk: risk("c", { exposed: 2 }) },
+        { cipher: login("d"), risk: risk("d") },
+      ]);
+      await service.buildVaultHealthReport(ciphers, userId);
+      expect((await firstValueFrom(service.getVaultHealthReport$(userId)))!.score).toBe(0.75);
+
+      service.deleteItemFromReport("a", "exposed", userId);
+      const updated = await firstValueFrom(service.getVaultHealthReport$(userId));
+
+      expect(updated!.score).toBeCloseTo(2 / 3);
+    });
+
+    it("scores an emptied report as 0 rather than NaN", async () => {
+      const ciphers = withRisks([{ cipher: login("a"), risk: risk("a", { exposed: 3 }) }]);
+      await service.buildVaultHealthReport(ciphers, userId);
+
+      service.deleteItemFromReport("a", "exposed", userId);
+      const updated = await firstValueFrom(service.getVaultHealthReport$(userId));
+
+      expect(updated!.totalCount).toBe(0);
+      expect(updated!.score).toBe(0);
+    });
+
+    it("does nothing if the item is not in the given category", async () => {
+      const ciphers = withRisks([
+        { cipher: login("a"), risk: risk("a", { exposed: 3 }) },
+        { cipher: login("b"), risk: risk("b", { strength: 1 }) },
+      ]);
+      await service.buildVaultHealthReport(ciphers, userId);
+
+      const emitted = observeReports();
+      // "b" is bucketed as weak, so the exposed list must be left alone
+      service.deleteItemFromReport("b", "exposed", userId);
+
+      expect(emitted).toHaveLength(1);
+      expect(cipherIds(emitted[0].categoryItems.exposed)).toEqual(["a"]);
+      expect(cipherIds(emitted[0].categoryItems.weak)).toEqual(["b"]);
+      expect(emitted[0].atRiskCount).toBe(2);
+      expect(emitted[0].totalCount).toBe(2);
     });
 
     it("does nothing if the userId does not match the current report", async () => {

--- a/bitwarden_license/bit-common/src/dirt/vault-health/services/implementations/default-vault-health-report.service.spec.ts
+++ b/bitwarden_license/bit-common/src/dirt/vault-health/services/implementations/default-vault-health-report.service.spec.ts
@@ -320,4 +320,35 @@ describe("DefaultVaultHealthReportService", () => {
       expect(cipherIds(other!.categoryItems.weak)).toEqual(["b"]);
     });
   });
+
+  describe("deleteItemFromReport", () => {
+    it("removes the item from the report and decrements counts", async () => {
+      const ciphers = withRisks([
+        { cipher: login("a"), risk: risk("a", { exposed: 3 }) },
+        { cipher: login("b"), risk: risk("b", { strength: 1 }) },
+        { cipher: login("c"), risk: risk("c", { exposed: 2 }) },
+      ]);
+      await service.buildVaultHealthReport(ciphers, userId);
+
+      service.deleteItemFromReport("a", "exposed", userId);
+      const updated = await firstValueFrom(service.getVaultHealthReport$(userId));
+
+      expect(updated!.atRiskCount).toBe(2);
+      expect(updated!.totalCount).toBe(2);
+      expect(cipherIds(updated!.categoryItems.exposed)).toEqual(["c"]);
+      expect(cipherIds(updated!.categoryItems.weak)).toEqual(["b"]);
+    });
+
+    it("does nothing if the userId does not match the current report", async () => {
+      const ciphers = withRisks([{ cipher: login("a"), risk: risk("a", { exposed: 3 }) }]);
+      await service.buildVaultHealthReport(ciphers, userId);
+
+      service.deleteItemFromReport("a", "exposed", "other-user-id" as UserId);
+      const updated = await firstValueFrom(service.getVaultHealthReport$(userId));
+
+      expect(updated!.atRiskCount).toBe(1);
+      expect(updated!.totalCount).toBe(1);
+      expect(updated!.categoryItems.exposed).toHaveLength(1);
+    });
+  });
 });

--- a/bitwarden_license/bit-common/src/dirt/vault-health/services/implementations/default-vault-health-report.service.ts
+++ b/bitwarden_license/bit-common/src/dirt/vault-health/services/implementations/default-vault-health-report.service.ts
@@ -46,7 +46,9 @@ export class DefaultVaultHealthReportService implements VaultHealthReportService
   }
 
   /**
-   * Delete an item from an existing vault health report, without rebuilding the report.
+   * Delete an item from an existing vault health report, without rebuilding the
+   * report. Publishes a new report to `getVaultHealthReport$` with the item
+   * removed and the counts and score adjusted.
    *
    * @param cipherId the id of the cipher/item to be deleted from the report
    * @param category the risk category the cipher/item belongs to
@@ -59,18 +61,25 @@ export class DefaultVaultHealthReportService implements VaultHealthReportService
       return;
     }
 
-    const report = current.report;
-    const itemIndex = report.categoryItems[category].findIndex(
-      (item) => item.cipherId === cipherId,
-    );
+    const { report } = current;
+    const items = report.categoryItems[category].filter((item) => item.cipherId !== cipherId);
+    if (items.length === report.categoryItems[category].length) {
+      return;
+    }
 
-    // remove the deleted item from report
-    report.categoryItems[category].splice(itemIndex, 1);
-    report.atRiskCount--;
-    report.totalCount--;
+    const atRiskCount = report.atRiskCount - 1;
+    const totalCount = report.totalCount - 1;
 
-    // update subject
-    this.report.next({ userId, report });
+    this.report.next({
+      userId,
+      report: new VaultHealthReportView({
+        ...report,
+        atRiskCount,
+        totalCount,
+        score: totalCount === 0 ? 0 : atRiskCount / totalCount,
+        categoryItems: { ...report.categoryItems, [category]: items },
+      }),
+    });
   }
 
   /**

--- a/bitwarden_license/bit-common/src/dirt/vault-health/services/implementations/default-vault-health-report.service.ts
+++ b/bitwarden_license/bit-common/src/dirt/vault-health/services/implementations/default-vault-health-report.service.ts
@@ -46,6 +46,34 @@ export class DefaultVaultHealthReportService implements VaultHealthReportService
   }
 
   /**
+   * Delete an item from an existing vault health report, without rebuilding the report.
+   *
+   * @param cipherId the id of the cipher/item to be deleted from the report
+   * @param category the risk category the cipher/item belongs to
+   * @param userId the id of the user deleting the item
+   * @returns n/a
+   */
+  deleteItemFromReport(cipherId: string, category: RiskCategory, userId: UserId): void {
+    const current = this.report.value;
+    if (current?.userId !== userId) {
+      return;
+    }
+
+    const report = current.report;
+    const itemIndex = report.categoryItems[category].findIndex(
+      (item) => item.cipherId === cipherId,
+    );
+
+    // remove the deleted item from report
+    report.categoryItems[category].splice(itemIndex, 1);
+    report.atRiskCount--;
+    report.totalCount--;
+
+    // update subject
+    this.report.next({ userId, report });
+  }
+
+  /**
    * Personal-vault logins with a password: Login type, no organization,
    * not deleted, non-empty password. A superset of the SDK's own predicate,
    * so every login passed to the risk service qualifies.

--- a/libs/common/src/enums/feature-flag.enum.ts
+++ b/libs/common/src/enums/feature-flag.enum.ts
@@ -182,7 +182,7 @@ export const DefaultFeatureFlagValue = {
   [FeatureFlag.PasskeyLoginReport]: FALSE,
   [FeatureFlag.AccessIntelligenceReportFileStorage]: FALSE,
   [FeatureFlag.AccessIntelligenceAdoptionUxImprovements]: FALSE,
-  [FeatureFlag.BrowserExtensionHealthReport]: FALSE,
+  [FeatureFlag.BrowserExtensionHealthReport]: true,
 
   /* Vault */
   [FeatureFlag.PM32009NewItemTypes]: FALSE,

--- a/libs/common/src/enums/feature-flag.enum.ts
+++ b/libs/common/src/enums/feature-flag.enum.ts
@@ -182,7 +182,7 @@ export const DefaultFeatureFlagValue = {
   [FeatureFlag.PasskeyLoginReport]: FALSE,
   [FeatureFlag.AccessIntelligenceReportFileStorage]: FALSE,
   [FeatureFlag.AccessIntelligenceAdoptionUxImprovements]: FALSE,
-  [FeatureFlag.BrowserExtensionHealthReport]: true,
+  [FeatureFlag.BrowserExtensionHealthReport]: FALSE,
 
   /* Vault */
   [FeatureFlag.PM32009NewItemTypes]: FALSE,


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-37839

## 📔 Objective
From within the Health report categories, users are able to select items to (soft) delete from their vault. These changes implement a new dialog that will handle deleting the items from their vault, and therefore from appearing within their Health report. The dialog includes a section to display all at risk categories the selected item falls under before they confirm deletion.

Deleting an item from within the health report detail view will soft delete the item from the user's vault, as well as immediately remove it from the last health report that was run, without triggering a new report to be built.


## 📸 Screenshots

https://github.com/user-attachments/assets/f23018ef-091b-46f3-a1ff-0991ae719744


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>