### PR TITLE
[PM-41775] fix(desktop): enable background throttling for hidden windows

### DIFF
--- a/apps/desktop/src/main/window.main.spec.ts
+++ b/apps/desktop/src/main/window.main.spec.ts
@@ -1,7 +1,9 @@
 import { pathToFileURL } from "node:url";
 import * as path from "path";
 
-import { mock } from "jest-mock-extended";
+import { BrowserWindow } from "electron";
+import { mock, mockDeep } from "jest-mock-extended";
+import { of } from "rxjs";
 
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { AbstractStorageService } from "@bitwarden/common/platform/abstractions/storage.service";
@@ -37,6 +39,59 @@ jest.mock("@bitwarden/desktop-napi", () => ({
 import { WindowMain } from "./window.main";
 
 describe("WindowMain", () => {
+  describe("createWindow", () => {
+    it("enables Electron background throttling for the main window", async () => {
+      Object.defineProperty(globalThis, "BIT_ENVIRONMENT", {
+        value: "production",
+        configurable: true,
+      });
+
+      const browserWindow = mockDeep<BrowserWindow>();
+      Object.defineProperty(browserWindow.webContents, "userAgent", {
+        value: "Mozilla/5.0 (Macintosh) Bitwarden/2026 Electron/43 Safari/605.1.15",
+      });
+      browserWindow.loadURL.mockResolvedValue(undefined);
+      (BrowserWindow as unknown as jest.Mock).mockReturnValue(browserWindow);
+
+      const storageService = mock<AbstractStorageService>();
+      storageService.get.mockResolvedValue("light");
+
+      const desktopSettingsService = mock<DesktopSettingsService>();
+      Object.defineProperties(desktopSettingsService, {
+        window$: {
+          value: of({
+            x: 10,
+            y: 10,
+            width: 950,
+            height: 790,
+            isMaximized: false,
+          }),
+        },
+        alwaysOnTop$: { value: of(false) },
+        preventScreenshots$: { value: of(false) },
+      });
+
+      const sut = new WindowMain(
+        mock<BiometricStateService>(),
+        mock<LogService>(),
+        storageService,
+        desktopSettingsService,
+        mock<SafeShell>(),
+        null,
+        () => {},
+        null,
+      );
+
+      await sut.createWindow("full-app", false);
+
+      expect(BrowserWindow).toHaveBeenCalledWith(
+        expect.objectContaining({
+          webPreferences: expect.objectContaining({ backgroundThrottling: true }),
+        }),
+      );
+    });
+  });
+
   describe("isLocalBundleUrl", () => {
     let sut: WindowMain;
     // Access the private method under test without widening its visibility

--- a/apps/desktop/src/main/window.main.ts
+++ b/apps/desktop/src/main/window.main.ts
@@ -407,7 +407,7 @@ export class WindowMain {
         preload: path.join(__dirname, "preload.js"),
         spellcheck: false,
         nodeIntegration: false,
-        backgroundThrottling: false,
+        backgroundThrottling: true,
         contextIsolation: true,
         session: this.session,
         devTools: isDev(),


### PR DESCRIPTION
## 🎟️ Tracking

Original Bitwarden change: https://github.com/bitwarden/jslib/pull/196

Related Electron behavior change: https://github.com/electron/electron/pull/38924

## 📔 Objective

Reduce unnecessary CPU and energy use when the desktop main window is hidden by enabling Electron background throttling.

The desktop client has disabled background throttling since [bitwarden/jslib#196](https://github.com/bitwarden/jslib/pull/196) to avoid suppressed redraws during minimize and other window state changes. [electron/electron#38924](https://github.com/electron/electron/pull/38924) later expanded the effect of disabling throttling so that Electron also keeps compositor frame generation active while a window is hidden. The original workaround can therefore allow renderer and GPU work to continue when no frames are visible.

This change enables background throttling and adds focused unit coverage for the `BrowserWindow` configuration.

## 🧪 Testing done

- Added a unit test that verifies background throttling is enabled for the main window.
- Ran the focused desktop main-window test suite.
- Built the desktop main process in production mode.
- Ran formatting and targeted lint checks for the changed files.
- Manually compared otherwise identical macOS builds with background throttling enabled and disabled. In an affected hidden-window state, the disabled build sustained 8–21% renderer CPU usage, later respawned the renderer, and produced higher transient spikes. The enabled build remained idle in the equivalent hidden state. Confirmed that foreground rendering remains active while the window is visible.
- Repeated the comparison after signing in. Both builds were mostly idle with occasional short background work, indicating that the sustained activity is state-dependent rather than universal.
