### PR TITLE
chore(native-messaging): rename native messaging plug to dot-native-messaging

### DIFF
--- a/apps/desktop/electron-builder.json
+++ b/apps/desktop/electron-builder.json
@@ -290,7 +290,8 @@
         }
       },
       {
-        "personal-files": {
+        "dot-native-messaging": {
+          "interface": "personal-files",
           "read": [],
           "write": [
             "$HOME/.config/chromium/NativeMessagingHosts",


### PR DESCRIPTION
https://forum.snapcraft.io/t/bitwarden-snapcraft-update-submission-blocked-despite-snap-plug-approval/52547