### PR TITLE
refactor(crypto): move EncArrayBuffer callers to legacy-crypto

### DIFF
--- a/apps/cli/src/platform/services/node-env-secure-storage.service.ts
+++ b/apps/cli/src/platform/services/node-env-secure-storage.service.ts
@@ -6,8 +6,9 @@ import { EncryptService } from "@bitwarden/common/key-management/crypto/abstract
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { AbstractStorageService } from "@bitwarden/common/platform/abstractions/storage.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
-import { EncArrayBuffer } from "@bitwarden/common/platform/models/domain/enc-array-buffer";
 import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
+// eslint-disable-next-line no-restricted-imports
+import { EncArrayBuffer } from "@bitwarden/legacy-crypto";
 
 export class NodeEnvSecureStorageService implements AbstractStorageService {
   constructor(

--- a/apps/cli/src/tools/send/commands/receive.command.ts
+++ b/apps/cli/src/tools/send/commands/receive.command.ts
@@ -26,14 +26,13 @@ import { ErrorResponse } from "@bitwarden/common/models/response/error.response"
 import { EnvironmentService } from "@bitwarden/common/platform/abstractions/environment.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
-import { EncArrayBuffer } from "@bitwarden/common/platform/models/domain/enc-array-buffer";
 import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
 import { SendAccess } from "@bitwarden/common/tools/send/models/domain/send-access";
 import { SendApiService } from "@bitwarden/common/tools/send/services/send-api.service.abstraction";
 import { AuthType } from "@bitwarden/common/tools/send/types/auth-type";
 import { SendType } from "@bitwarden/common/tools/send/types/send-type";
 // eslint-disable-next-line no-restricted-imports
-import { LegacyCompatKeyService } from "@bitwarden/legacy-crypto";
+import { EncArrayBuffer, LegacyCompatKeyService } from "@bitwarden/legacy-crypto";
 import { NodeUtils } from "@bitwarden/node/node-utils";
 
 import { DownloadCommand } from "../../../commands/download.command";

--- a/apps/web/src/app/tools/send/send-access/send-access-file.component.ts
+++ b/apps/web/src/app/tools/send/send-access/send-access-file.component.ts
@@ -9,11 +9,12 @@ import { EncryptService } from "@bitwarden/common/key-management/crypto/abstract
 import { FileDownloadService } from "@bitwarden/common/platform/abstractions/file-download/file-download.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
-import { EncArrayBuffer } from "@bitwarden/common/platform/models/domain/enc-array-buffer";
 import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
 import { SendAccessView } from "@bitwarden/common/tools/send/models/view/send-access.view";
 import { SendApiService } from "@bitwarden/common/tools/send/services/send-api.service.abstraction";
 import { ToastService } from "@bitwarden/components";
+// eslint-disable-next-line no-restricted-imports
+import { EncArrayBuffer } from "@bitwarden/legacy-crypto";
 
 import { SharedModule } from "../../../shared";
 

--- a/bitwarden_license/bit-common/src/dirt/access-intelligence/services/abstractions/access-report-encryption.service.ts
+++ b/bitwarden_license/bit-common/src/dirt/access-intelligence/services/abstractions/access-report-encryption.service.ts
@@ -1,8 +1,9 @@
 import { Observable } from "rxjs";
 
 import { EncString } from "@bitwarden/common/key-management/crypto/models/enc-string";
-import { EncArrayBuffer } from "@bitwarden/common/platform/models/domain/enc-array-buffer";
 import { OrganizationId, UserId } from "@bitwarden/common/types/guid";
+// eslint-disable-next-line no-restricted-imports
+import { EncArrayBuffer } from "@bitwarden/legacy-crypto";
 
 import {
   MemberRegistryEntryData,

--- a/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/persistence/default-access-report-encryption.service.spec.ts
+++ b/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/persistence/default-access-report-encryption.service.spec.ts
@@ -4,14 +4,13 @@ import { BehaviorSubject, firstValueFrom } from "rxjs";
 import { EncryptService } from "@bitwarden/common/key-management/crypto/abstractions/encrypt.service";
 import { EncString } from "@bitwarden/common/key-management/crypto/models/enc-string";
 import { SdkLoadService } from "@bitwarden/common/platform/abstractions/sdk/sdk-load.service";
-import { EncArrayBuffer } from "@bitwarden/common/platform/models/domain/enc-array-buffer";
 import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
 import { makeSymmetricCryptoKey } from "@bitwarden/common/spec";
 import { OrganizationId, UserId } from "@bitwarden/common/types/guid";
 import { OrgKey } from "@bitwarden/common/types/key";
 import { KeyService } from "@bitwarden/key-management";
 // eslint-disable-next-line no-restricted-imports
-import { EncryptionType, KeyGenerationService } from "@bitwarden/legacy-crypto";
+import { EncArrayBuffer, EncryptionType, KeyGenerationService } from "@bitwarden/legacy-crypto";
 import { LogService } from "@bitwarden/logging";
 import { PureCrypto } from "@bitwarden/sdk-internal";
 

--- a/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/persistence/default-access-report-encryption.service.ts
+++ b/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/persistence/default-access-report-encryption.service.ts
@@ -3,12 +3,11 @@ import { Observable, catchError, forkJoin, from, map, switchMap, take } from "rx
 import { EncryptService } from "@bitwarden/common/key-management/crypto/abstractions/encrypt.service";
 import { EncString } from "@bitwarden/common/key-management/crypto/models/enc-string";
 import { SdkLoadService } from "@bitwarden/common/platform/abstractions/sdk/sdk-load.service";
-import { EncArrayBuffer } from "@bitwarden/common/platform/models/domain/enc-array-buffer";
 import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
 import { OrganizationId, UserId } from "@bitwarden/common/types/guid";
 import { KeyService } from "@bitwarden/key-management";
 // eslint-disable-next-line no-restricted-imports
-import { KeyGenerationService } from "@bitwarden/legacy-crypto";
+import { EncArrayBuffer, KeyGenerationService } from "@bitwarden/legacy-crypto";
 import { LogService } from "@bitwarden/logging";
 import { PureCrypto } from "@bitwarden/sdk-internal";
 

--- a/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/persistence/file-report-persistence.service.spec.ts
+++ b/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/persistence/file-report-persistence.service.spec.ts
@@ -8,11 +8,10 @@ import {
   FileUploadService,
 } from "@bitwarden/common/platform/abstractions/file-upload/file-upload.service";
 import { FileUploadType } from "@bitwarden/common/platform/enums";
-import { EncArrayBuffer } from "@bitwarden/common/platform/models/domain/enc-array-buffer";
 import { makeEncString } from "@bitwarden/common/spec";
 import { OrganizationId, OrganizationReportId, UserId } from "@bitwarden/common/types/guid";
 // eslint-disable-next-line no-restricted-imports
-import { EncryptionType } from "@bitwarden/legacy-crypto";
+import { EncArrayBuffer, EncryptionType } from "@bitwarden/legacy-crypto";
 import { LogService } from "@bitwarden/logging";
 
 import {

--- a/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/persistence/file-report-persistence.service.ts
+++ b/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/persistence/file-report-persistence.service.ts
@@ -19,8 +19,9 @@ import {
   FileUploadService,
 } from "@bitwarden/common/platform/abstractions/file-upload/file-upload.service";
 import { FileUploadType } from "@bitwarden/common/platform/enums";
-import { EncArrayBuffer } from "@bitwarden/common/platform/models/domain/enc-array-buffer";
 import { OrganizationReportId, OrganizationId } from "@bitwarden/common/types/guid";
+// eslint-disable-next-line no-restricted-imports
+import { EncArrayBuffer } from "@bitwarden/legacy-crypto";
 import { LogService } from "@bitwarden/logging";
 
 import {

--- a/libs/angular/src/tools/send/add-edit.component.ts
+++ b/libs/angular/src/tools/send/add-edit.component.ts
@@ -24,7 +24,6 @@ import { MessagingService } from "@bitwarden/common/platform/abstractions/messag
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { StateService } from "@bitwarden/common/platform/abstractions/state.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
-import { EncArrayBuffer } from "@bitwarden/common/platform/models/domain/enc-array-buffer";
 import { Send } from "@bitwarden/common/tools/send/models/domain/send";
 import { SendFileView } from "@bitwarden/common/tools/send/models/view/send-file.view";
 import { SendTextView } from "@bitwarden/common/tools/send/models/view/send-text.view";
@@ -34,6 +33,8 @@ import { SendService } from "@bitwarden/common/tools/send/services/send.service.
 import { SendType } from "@bitwarden/common/tools/send/types/send-type";
 import { PremiumUpgradePromptService } from "@bitwarden/common/vault/abstractions/premium-upgrade-prompt.service";
 import { DialogService, ToastService } from "@bitwarden/components";
+// eslint-disable-next-line no-restricted-imports
+import { EncArrayBuffer } from "@bitwarden/legacy-crypto";
 import { SendPolicyService } from "@bitwarden/send-ui";
 
 // Value = hours

--- a/libs/common/src/platform/abstractions/file-upload/file-upload.service.ts
+++ b/libs/common/src/platform/abstractions/file-upload/file-upload.service.ts
@@ -1,6 +1,8 @@
+// eslint-disable-next-line no-restricted-imports
+import { EncArrayBuffer } from "@bitwarden/legacy-crypto";
+
 import { EncString } from "../../../key-management/crypto/models/enc-string";
 import { FileUploadType } from "../../enums";
-import { EncArrayBuffer } from "../../models/domain/enc-array-buffer";
 
 export abstract class FileUploadService {
   abstract upload(

--- a/libs/common/src/platform/models/domain/enc-array-buffer.ts
+++ b/libs/common/src/platform/models/domain/enc-array-buffer.ts
@@ -1,5 +1,0 @@
-/**
- * @deprecated Moved to `@bitwarden/legacy-crypto`. These primitives are being retired in favour of
- * the SDK — do not add new callers. Contact the Key Management team.
- */
-export { EncArrayBuffer } from "@bitwarden/legacy-crypto/models/enc-array-buffer";

--- a/libs/common/src/platform/services/file-upload/azure-file-upload.service.spec.ts
+++ b/libs/common/src/platform/services/file-upload/azure-file-upload.service.spec.ts
@@ -1,10 +1,12 @@
 import { mock, MockProxy } from "jest-mock-extended";
 
+// eslint-disable-next-line no-restricted-imports
+import { EncArrayBuffer } from "@bitwarden/legacy-crypto";
+
 import { ApiService } from "../../../abstractions/api.service";
 import { ConfigService } from "../../abstractions/config/config.service";
 import { UploadOptions } from "../../abstractions/file-upload/file-upload.service";
 import { LogService } from "../../abstractions/log.service";
-import { EncArrayBuffer } from "../../models/domain/enc-array-buffer";
 
 import { AzureFileUploadService } from "./azure-file-upload.service";
 

--- a/libs/common/src/platform/services/file-upload/azure-file-upload.service.ts
+++ b/libs/common/src/platform/services/file-upload/azure-file-upload.service.ts
@@ -1,12 +1,14 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
+// eslint-disable-next-line no-restricted-imports
+import { EncArrayBuffer } from "@bitwarden/legacy-crypto";
+
 import { ApiService } from "../../../abstractions/api.service";
 import { FeatureFlag } from "../../../enums/feature-flag.enum";
 import { ConfigService } from "../../abstractions/config/config.service";
 import { UploadOptions } from "../../abstractions/file-upload/file-upload.service";
 import { LogService } from "../../abstractions/log.service";
 import { Utils } from "../../misc/utils";
-import { EncArrayBuffer } from "../../models/domain/enc-array-buffer";
 
 const MAX_SINGLE_BLOB_UPLOAD_SIZE = 256 * 1024 * 1024; // 256 MiB
 const MAX_BLOCKS_PER_BLOB = 50000;

--- a/libs/common/src/platform/services/file-upload/bitwarden-file-upload.service.ts
+++ b/libs/common/src/platform/services/file-upload/bitwarden-file-upload.service.ts
@@ -1,5 +1,7 @@
+// eslint-disable-next-line no-restricted-imports
+import { EncArrayBuffer } from "@bitwarden/legacy-crypto";
+
 import { Utils } from "../../misc/utils";
-import { EncArrayBuffer } from "../../models/domain/enc-array-buffer";
 
 export class BitwardenFileUploadService {
   async upload(

--- a/libs/common/src/platform/services/file-upload/file-upload.service.ts
+++ b/libs/common/src/platform/services/file-upload/file-upload.service.ts
@@ -1,5 +1,8 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
+// eslint-disable-next-line no-restricted-imports
+import { EncArrayBuffer } from "@bitwarden/legacy-crypto";
+
 import { ApiService } from "../../../abstractions/api.service";
 import { EncString } from "../../../key-management/crypto/models/enc-string";
 import { ConfigService } from "../../abstractions/config/config.service";
@@ -10,7 +13,6 @@ import {
 } from "../../abstractions/file-upload/file-upload.service";
 import { LogService } from "../../abstractions/log.service";
 import { FileUploadType } from "../../enums";
-import { EncArrayBuffer } from "../../models/domain/enc-array-buffer";
 
 import { AzureFileUploadService } from "./azure-file-upload.service";
 import { BitwardenFileUploadService } from "./bitwarden-file-upload.service";

--- a/libs/common/src/tools/send/services/send-api-service.selector.spec.ts
+++ b/libs/common/src/tools/send/services/send-api-service.selector.spec.ts
@@ -1,10 +1,12 @@
 import { mock, MockProxy } from "jest-mock-extended";
 import { BehaviorSubject } from "rxjs";
 
+// eslint-disable-next-line no-restricted-imports
+import { EncArrayBuffer } from "@bitwarden/legacy-crypto";
+
 import { SendAccessToken } from "../../../auth/send-access";
 import { FeatureFlag } from "../../../enums/feature-flag.enum";
 import { ConfigService } from "../../../platform/abstractions/config/config.service";
-import { EncArrayBuffer } from "../../../platform/models/domain/enc-array-buffer";
 import { Send } from "../models/domain/send";
 import { SendAccessView } from "../models/view/send-access.view";
 import { AuthType } from "../types/auth-type";

--- a/libs/common/src/tools/send/services/send-api-service.selector.ts
+++ b/libs/common/src/tools/send/services/send-api-service.selector.ts
@@ -1,10 +1,12 @@
 import { Observable, firstValueFrom, map, shareReplay } from "rxjs";
 
+// eslint-disable-next-line no-restricted-imports
+import { EncArrayBuffer } from "@bitwarden/legacy-crypto";
+
 import { SendAccessToken } from "../../../auth/send-access";
 import { FeatureFlag } from "../../../enums/feature-flag.enum";
 import { ListResponse } from "../../../models/response/list.response";
 import { ConfigService } from "../../../platform/abstractions/config/config.service";
-import { EncArrayBuffer } from "../../../platform/models/domain/enc-array-buffer";
 import { Send } from "../models/domain/send";
 import { SendAccessResponse } from "../models/response/send-access.response";
 import { SendFileDownloadDataResponse } from "../models/response/send-file-download-data.response";

--- a/libs/common/src/tools/send/services/send-api.service.abstraction.ts
+++ b/libs/common/src/tools/send/services/send-api.service.abstraction.ts
@@ -1,6 +1,8 @@
+// eslint-disable-next-line no-restricted-imports
+import { EncArrayBuffer } from "@bitwarden/legacy-crypto";
+
 import { SendAccessToken } from "../../../auth/send-access";
 import { ListResponse } from "../../../models/response/list.response";
-import { EncArrayBuffer } from "../../../platform/models/domain/enc-array-buffer";
 import { Send } from "../models/domain/send";
 import { SendAccessResponse } from "../models/response/send-access.response";
 import { SendFileDownloadDataResponse } from "../models/response/send-file-download-data.response";

--- a/libs/common/src/tools/send/services/send-api.service.ts
+++ b/libs/common/src/tools/send/services/send-api.service.ts
@@ -1,3 +1,6 @@
+// eslint-disable-next-line no-restricted-imports
+import { EncArrayBuffer } from "@bitwarden/legacy-crypto";
+
 import { ApiService } from "../../../abstractions/api.service";
 import { SendAccessToken } from "../../../auth/send-access";
 import { ErrorResponse } from "../../../models/response/error.response";
@@ -6,7 +9,6 @@ import {
   FileUploadApiMethods,
   FileUploadService,
 } from "../../../platform/abstractions/file-upload/file-upload.service";
-import { EncArrayBuffer } from "../../../platform/models/domain/enc-array-buffer";
 import { SendData } from "../models/data/send.data";
 import { Send } from "../models/domain/send";
 import { SendRequest } from "../models/request/send.request";

--- a/libs/common/src/tools/send/services/send-sdk-api.service.spec.ts
+++ b/libs/common/src/tools/send/services/send-sdk-api.service.spec.ts
@@ -1,6 +1,8 @@
 import { mock, MockProxy } from "jest-mock-extended";
 import { of } from "rxjs";
 
+// eslint-disable-next-line no-restricted-imports
+import { EncArrayBuffer } from "@bitwarden/legacy-crypto";
 import {
   AuthEdit,
   SendAddRequest,
@@ -14,7 +16,6 @@ import { AccountService } from "../../../auth/abstractions/account.service";
 import { LogService } from "../../../platform/abstractions/log.service";
 import { SdkService } from "../../../platform/abstractions/sdk/sdk.service";
 import { Utils } from "../../../platform/misc/utils";
-import { EncArrayBuffer } from "../../../platform/models/domain/enc-array-buffer";
 import { UserId } from "../../../types/guid";
 import { Send } from "../models/domain/send";
 import { SendResponse } from "../models/response/send.response";

--- a/libs/common/src/tools/send/services/send-sdk-api.service.ts
+++ b/libs/common/src/tools/send/services/send-sdk-api.service.ts
@@ -1,5 +1,7 @@
 import { catchError, firstValueFrom, switchMap } from "rxjs";
 
+// eslint-disable-next-line no-restricted-imports
+import { EncArrayBuffer } from "@bitwarden/legacy-crypto";
 import {
   AuthEdit,
   PasswordManagerClient,
@@ -17,7 +19,6 @@ import { getUserId } from "../../../auth/services/account.service";
 import { ListResponse } from "../../../models/response/list.response";
 import { LogService } from "../../../platform/abstractions/log.service";
 import { SdkService, asUuid } from "../../../platform/abstractions/sdk/sdk.service";
-import { EncArrayBuffer } from "../../../platform/models/domain/enc-array-buffer";
 import { UserId } from "../../../types/guid";
 import { SendData } from "../models/data/send.data";
 import { Send } from "../models/domain/send";

--- a/libs/common/src/tools/send/services/send.service.abstraction.ts
+++ b/libs/common/src/tools/send/services/send.service.abstraction.ts
@@ -3,8 +3,9 @@ import { Observable } from "rxjs";
 // This import has been flagged as unallowed for this class. It may be involved in a circular dependency loop.
 // eslint-disable-next-line no-restricted-imports
 import { UserKeyRotationDataProvider } from "@bitwarden/key-management";
+// eslint-disable-next-line no-restricted-imports
+import { EncArrayBuffer } from "@bitwarden/legacy-crypto";
 
-import { EncArrayBuffer } from "../../../platform/models/domain/enc-array-buffer";
 import { SymmetricCryptoKey } from "../../../platform/models/domain/symmetric-crypto-key";
 import { UserId } from "../../../types/guid";
 import { UserKey } from "../../../types/key";

--- a/libs/common/src/tools/send/services/send.service.ts
+++ b/libs/common/src/tools/send/services/send.service.ts
@@ -6,7 +6,7 @@ import { Observable, concatMap, distinctUntilChanged, firstValueFrom, map } from
 // eslint-disable-next-line no-restricted-imports
 import { PBKDF2KdfConfig, KeyService } from "@bitwarden/key-management";
 // eslint-disable-next-line no-restricted-imports
-import { KeyGenerationService } from "@bitwarden/legacy-crypto";
+import { EncArrayBuffer, KeyGenerationService } from "@bitwarden/legacy-crypto";
 
 import { AccountService } from "../../../auth/abstractions/account.service";
 import { EncryptService } from "../../../key-management/crypto/abstractions/encrypt.service";
@@ -14,7 +14,6 @@ import { EncString } from "../../../key-management/crypto/models/enc-string";
 import { ConfigService } from "../../../platform/abstractions/config/config.service";
 import { I18nService } from "../../../platform/abstractions/i18n.service";
 import { Utils } from "../../../platform/misc/utils";
-import { EncArrayBuffer } from "../../../platform/models/domain/enc-array-buffer";
 import { SymmetricCryptoKey } from "../../../platform/models/domain/symmetric-crypto-key";
 import { UserId } from "../../../types/guid";
 import { UserKey } from "../../../types/key";

--- a/libs/common/src/vault/abstractions/file-upload/cipher-file-upload.service.ts
+++ b/libs/common/src/vault/abstractions/file-upload/cipher-file-upload.service.ts
@@ -1,7 +1,9 @@
+// eslint-disable-next-line no-restricted-imports
+import { EncArrayBuffer } from "@bitwarden/legacy-crypto";
+
 import { EncString } from "../../../key-management/crypto/models/enc-string";
 import { UploadOptions } from "../../../platform/abstractions/file-upload/file-upload.service";
 import { FileUploadType } from "../../../platform/enums";
-import { EncArrayBuffer } from "../../../platform/models/domain/enc-array-buffer";
 import { SymmetricCryptoKey } from "../../../platform/models/domain/symmetric-crypto-key";
 import { UserId } from "../../../types/guid";
 import { Cipher } from "../../models/domain/cipher";

--- a/libs/common/src/vault/services/cipher.service.spec.ts
+++ b/libs/common/src/vault/services/cipher.service.spec.ts
@@ -5,7 +5,7 @@ import { BehaviorSubject, Observable, filter, firstValueFrom, map, of, throwErro
 // eslint-disable-next-line no-restricted-imports
 import { CipherDecryptionKeys, KeyService } from "@bitwarden/key-management";
 // eslint-disable-next-line no-restricted-imports
-import { LegacyCompatKeyService } from "@bitwarden/legacy-crypto";
+import { EncArrayBuffer, LegacyCompatKeyService } from "@bitwarden/legacy-crypto";
 import { MessageSender } from "@bitwarden/messaging";
 import { CipherListView } from "@bitwarden/sdk-internal";
 
@@ -24,7 +24,6 @@ import { I18nService } from "../../platform/abstractions/i18n.service";
 import { LogService } from "../../platform/abstractions/log.service";
 import { FileUploadType } from "../../platform/enums";
 import { Utils } from "../../platform/misc/utils";
-import { EncArrayBuffer } from "../../platform/models/domain/enc-array-buffer";
 import { SymmetricCryptoKey } from "../../platform/models/domain/symmetric-crypto-key";
 import { ContainerService } from "../../platform/services/container.service";
 import { CipherId, UserId, OrganizationId, CollectionId } from "../../types/guid";

--- a/libs/common/src/vault/services/cipher.service.ts
+++ b/libs/common/src/vault/services/cipher.service.ts
@@ -15,7 +15,7 @@ import {
 // eslint-disable-next-line no-restricted-imports
 import { KeyService } from "@bitwarden/key-management";
 // eslint-disable-next-line no-restricted-imports
-import { LegacyCompatKeyService } from "@bitwarden/legacy-crypto";
+import { EncArrayBuffer, LegacyCompatKeyService } from "@bitwarden/legacy-crypto";
 import { CipherListView } from "@bitwarden/sdk-internal";
 
 import { ApiService } from "../../abstractions/api.service";
@@ -37,7 +37,6 @@ import { uuidAsString } from "../../platform/abstractions/sdk/sdk.service";
 import { FileUploadType } from "../../platform/enums";
 import { MessageSender } from "../../platform/messaging";
 import Domain from "../../platform/models/domain/domain-base";
-import { EncArrayBuffer } from "../../platform/models/domain/enc-array-buffer";
 import { SymmetricCryptoKey } from "../../platform/models/domain/symmetric-crypto-key";
 import { StateProvider } from "../../platform/state";
 import { CipherId, CollectionId, OrganizationId, UserId } from "../../types/guid";

--- a/libs/common/src/vault/services/file-upload/cipher-file-upload.service.spec.ts
+++ b/libs/common/src/vault/services/file-upload/cipher-file-upload.service.spec.ts
@@ -1,5 +1,8 @@
 import { mock } from "jest-mock-extended";
 
+// eslint-disable-next-line no-restricted-imports
+import { EncArrayBuffer } from "@bitwarden/legacy-crypto";
+
 import { ApiService } from "../../../abstractions/api.service";
 import { FeatureFlag } from "../../../enums/feature-flag.enum";
 import { EncString } from "../../../key-management/crypto/models/enc-string";
@@ -8,7 +11,6 @@ import { ConfigService } from "../../../platform/abstractions/config/config.serv
 import { FileUploadService } from "../../../platform/abstractions/file-upload/file-upload.service";
 import { FileUploadType } from "../../../platform/enums";
 import { Utils } from "../../../platform/misc/utils";
-import { EncArrayBuffer } from "../../../platform/models/domain/enc-array-buffer";
 import { SymmetricCryptoKey } from "../../../platform/models/domain/symmetric-crypto-key";
 import { CipherId, UserId } from "../../../types/guid";
 import { CipherSdkService } from "../../abstractions/cipher-sdk.service";

--- a/libs/common/src/vault/services/file-upload/cipher-file-upload.service.ts
+++ b/libs/common/src/vault/services/file-upload/cipher-file-upload.service.ts
@@ -1,6 +1,9 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
 
+// eslint-disable-next-line no-restricted-imports
+import { EncArrayBuffer } from "@bitwarden/legacy-crypto";
+
 import { ApiService } from "../../../abstractions/api.service";
 import { FeatureFlag } from "../../../enums/feature-flag.enum";
 import { EncString } from "../../../key-management/crypto/models/enc-string";
@@ -12,7 +15,6 @@ import {
   UploadOptions,
 } from "../../../platform/abstractions/file-upload/file-upload.service";
 import { FileUploadType } from "../../../platform/enums";
-import { EncArrayBuffer } from "../../../platform/models/domain/enc-array-buffer";
 import { SymmetricCryptoKey } from "../../../platform/models/domain/symmetric-crypto-key";
 import { CipherId, UserId } from "../../../types/guid";
 import { CipherSdkService } from "../../abstractions/cipher-sdk.service";

--- a/libs/vault/src/components/download-attachment/download-attachment.component.spec.ts
+++ b/libs/vault/src/components/download-attachment/download-attachment.component.spec.ts
@@ -10,7 +10,6 @@ import { ErrorResponse } from "@bitwarden/common/models/response/error.response"
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { FileDownloadService } from "@bitwarden/common/platform/abstractions/file-download/file-download.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
-import { EncArrayBuffer } from "@bitwarden/common/platform/models/domain/enc-array-buffer";
 import { StateProvider } from "@bitwarden/common/platform/state";
 import { CipherSdkService } from "@bitwarden/common/vault/abstractions/cipher-sdk.service";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
@@ -18,6 +17,8 @@ import { CipherType } from "@bitwarden/common/vault/enums";
 import { AttachmentView } from "@bitwarden/common/vault/models/view/attachment.view";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { ToastService } from "@bitwarden/components";
+// eslint-disable-next-line no-restricted-imports
+import { EncArrayBuffer } from "@bitwarden/legacy-crypto";
 
 import { PasswordRepromptService } from "../../services/password-reprompt.service";
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->