### PR TITLE
feat(pam): unified vault-row access-state badge

### DIFF
--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -17012,6 +17012,39 @@
   "pamStatusUnknown": {
     "message": "Unknown"
   },
+  "pamAccessBadgePrivileged": {
+    "message": "Privileged"
+  },
+  "pamAccessBadgePending": {
+    "message": "Pending approval"
+  },
+  "pamAccessBadgeUnavailable": {
+    "message": "Unavailable"
+  },
+  "pamAccessBadgeReady": {
+    "message": "Ready to use"
+  },
+  "pamAccessBadgeTimeLeft": {
+    "message": "$DURATION$ left",
+    "placeholders": {
+      "duration": {
+        "content": "$1",
+        "example": "18m"
+      }
+    }
+  },
+  "pamAccessBadgeEndingSoon": {
+    "message": "Ending soon • $DURATION$ left",
+    "placeholders": {
+      "duration": {
+        "content": "$1",
+        "example": "4m"
+      }
+    }
+  },
+  "pamAccessBadgeSessionEnded": {
+    "message": "Session ended"
+  },
   "pamAuditKindLeaseEndedByHolder": {
     "message": "Lease ended by holder"
   },

--- a/bitwarden_license/bit-web/src/app/pam/abstractions/access-lease.ts
+++ b/bitwarden_license/bit-web/src/app/pam/abstractions/access-lease.ts
@@ -16,6 +16,7 @@ export type {
   AccessRequestId,
   AccessRequestStatus,
   AccessRequestView,
+  CipherAccessStateView,
   LeasingError,
 } from "@bitwarden/sdk-internal";
 export { isLeasingError } from "@bitwarden/sdk-internal";

--- a/bitwarden_license/bit-web/src/app/pam/abstractions/access-request-sdk.service.ts
+++ b/bitwarden_license/bit-web/src/app/pam/abstractions/access-request-sdk.service.ts
@@ -1,4 +1,9 @@
-import type { AccessLeaseView, AccessRequestId, AccessRequestView } from "./access-lease";
+import type {
+  AccessLeaseView,
+  AccessRequestId,
+  AccessRequestView,
+  CipherAccessStateView,
+} from "./access-lease";
 
 /**
  * Access-request lifecycle (list/get/activate/cancel) is served by the Rust
@@ -13,4 +18,12 @@ export abstract class AccessRequestSdkService {
   abstract getAccessRequest(id: AccessRequestId): Promise<AccessRequestView>;
   abstract activateAccessRequest(id: AccessRequestId): Promise<AccessLeaseView>;
   abstract cancelAccessRequest(id: AccessRequestId): Promise<void>;
+
+  /**
+   * Read the caller's current access state for a gated cipher — the active lease, pending
+   * request, or approved-but-not-activated request that drives the vault-row access-state
+   * badge. `cipherId` is a plain `string` (matching the seam tokens in `libs/vault`/`apps/web`,
+   * which never carry the SDK's branded `CipherId`) and converted internally.
+   */
+  abstract getCipherAccessState(cipherId: string): Promise<CipherAccessStateView>;
 }

--- a/bitwarden_license/bit-web/src/app/pam/access-state-badge/access-badge-state.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-state-badge/access-badge-state.spec.ts
@@ -1,0 +1,54 @@
+import type { CipherAccessStateView } from "../abstractions/access-lease";
+
+import { cipherAccessBadgeState } from "./access-badge-state";
+
+describe("cipherAccessBadgeState", () => {
+  const view = (over: Partial<CipherAccessStateView>): CipherAccessStateView =>
+    ({
+      activeLease: undefined,
+      pendingRequest: undefined,
+      approvedRequest: undefined,
+      ...over,
+    }) as CipherAccessStateView;
+
+  it("returns null when there is no access state", () => {
+    expect(cipherAccessBadgeState(null)).toBeNull();
+    expect(cipherAccessBadgeState(undefined)).toBeNull();
+  });
+
+  it("resolves an active lease to the active state carrying its expiry", () => {
+    const notAfter = "2024-01-01T01:00:00.000Z";
+
+    expect(cipherAccessBadgeState(view({ activeLease: { notAfter } as never }))).toEqual({
+      kind: "active",
+      expiresAt: new Date(notAfter),
+    });
+  });
+
+  it("ranks an active lease above an approved and a pending request", () => {
+    const state = cipherAccessBadgeState(
+      view({
+        activeLease: { notAfter: "2024-01-01T01:00:00.000Z" } as never,
+        approvedRequest: {} as never,
+        pendingRequest: {} as never,
+      }),
+    );
+
+    expect(state?.kind).toBe("active");
+  });
+
+  it("ranks an approved request (ready) above a pending one", () => {
+    expect(
+      cipherAccessBadgeState(view({ approvedRequest: {} as never, pendingRequest: {} as never }))
+        ?.kind,
+    ).toBe("ready");
+  });
+
+  it("resolves a pending request to the pending state", () => {
+    expect(cipherAccessBadgeState(view({ pendingRequest: {} as never }))?.kind).toBe("pending");
+  });
+
+  it("falls back to privileged for a gated item with no request or lease in play", () => {
+    expect(cipherAccessBadgeState(view({}))?.kind).toBe("privileged");
+  });
+});

--- a/bitwarden_license/bit-web/src/app/pam/access-state-badge/access-badge-state.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-state-badge/access-badge-state.ts
@@ -1,0 +1,49 @@
+import type { CipherAccessStateView } from "../abstractions/access-lease";
+
+/**
+ * The unified access-state badge model, per the "Unifying access-state badges consistently
+ * across vault, modal, and Requests page" spec (Figma node 88-1699). Every surface that shows
+ * an access-state pill renders it from this one model via {@link AccessStateBadgeComponent}, so
+ * the recipe (colour + icon + copy) and the countdown escalation stay identical everywhere.
+ *
+ * Exactly one badge shows for a gated item at a time. The escalation between the accent
+ * "N left" badge and the danger "Ending soon" badge is a function of the live countdown, not a
+ * separate state — so `active` carries only `expiresAt` and the component derives the rest.
+ *
+ * `unavailable` (the item is held by another user) is part of the model for completeness but is
+ * NOT yet produced by {@link cipherAccessBadgeState}: `CipherAccessStateView` is caller-scoped
+ * and never reports someone else's lease. Producing it needs an SDK + server change — see the
+ * tracked follow-up.
+ */
+export type AccessBadgeState =
+  | { readonly kind: "privileged" | "pending" | "unavailable" | "ready" | "expired" }
+  | { readonly kind: "active"; readonly expiresAt: Date };
+
+/**
+ * Resolve the single badge to show for a gated cipher from its caller-scoped access state,
+ * applying the spec's precedence (highest-ranked true state wins):
+ *
+ *   active lease  →  approved (ready to use)  →  pending approval  →  privileged (resting)
+ *
+ * The `active` → `Ending soon` escalation is left to the component (it is a countdown threshold,
+ * not a distinct state). `unavailable` is intentionally not resolved here (see {@link AccessBadgeState}).
+ * Returns `null` when there is nothing to badge (e.g. the cipher is not gated).
+ */
+export function cipherAccessBadgeState(
+  state: CipherAccessStateView | null | undefined,
+): AccessBadgeState | null {
+  if (state == null) {
+    return null;
+  }
+  if (state.activeLease != null) {
+    return { kind: "active", expiresAt: new Date(state.activeLease.notAfter) };
+  }
+  if (state.approvedRequest != null) {
+    return { kind: "ready" };
+  }
+  if (state.pendingRequest != null) {
+    return { kind: "pending" };
+  }
+  // Resting state for any gated item with no request or lease in play.
+  return { kind: "privileged" };
+}

--- a/bitwarden_license/bit-web/src/app/pam/access-state-badge/access-state-badge.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-state-badge/access-state-badge.component.html
@@ -1,0 +1,11 @@
+@if (recipe(); as recipe) {
+  <bit-badge
+    [variant]="recipe.variant"
+    [startIcon]="recipe.icon"
+    size="small"
+    [title]="recipe.label"
+    [attr.data-testid]="recipe.testId"
+  >
+    {{ recipe.label }}
+  </bit-badge>
+}

--- a/bitwarden_license/bit-web/src/app/pam/access-state-badge/access-state-badge.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-state-badge/access-state-badge.component.spec.ts
@@ -1,0 +1,80 @@
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+
+import { AccessBadgeState } from "./access-badge-state";
+import { AccessStateBadgeComponent } from "./access-state-badge.component";
+
+describe("AccessStateBadgeComponent", () => {
+  let fixture: ComponentFixture<AccessStateBadgeComponent>;
+  let component: AccessStateBadgeComponent;
+
+  function create(state: AccessBadgeState | null): void {
+    fixture = TestBed.createComponent(AccessStateBadgeComponent);
+    fixture.componentRef.setInput("state", state);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [AccessStateBadgeComponent],
+      providers: [
+        {
+          provide: I18nService,
+          useValue: { t: (key: string, ...args: unknown[]) => [key, ...args].join(" ") },
+        },
+      ],
+    });
+  });
+
+  afterEach(() => {
+    fixture?.destroy();
+  });
+
+  it("renders nothing when there is no state", () => {
+    create(null);
+    expect(component["recipe"]()).toBeNull();
+  });
+
+  it.each([
+    ["privileged", "primary", "bwi-key", "pamAccessBadgePrivileged"],
+    ["pending", "warning", "bwi-clock", "pamAccessBadgePending"],
+    ["unavailable", "subtle", "bwi-lock", "pamAccessBadgeUnavailable"],
+    ["ready", "success", "bwi-check", "pamAccessBadgeReady"],
+    ["expired", "subtle", "bwi-lock", "pamAccessBadgeSessionEnded"],
+  ])("maps the %s state to its badge recipe", (kind, variant, icon, label) => {
+    create({ kind } as AccessBadgeState);
+
+    const recipe = component["recipe"]()!;
+    expect(recipe.variant).toBe(variant);
+    expect(recipe.icon).toBe(icon);
+    expect(recipe.label).toBe(label);
+  });
+
+  it("shows the accent countdown above the 5-minute threshold", () => {
+    create({ kind: "active", expiresAt: new Date(Date.now() + 18 * 60_000) });
+
+    const recipe = component["recipe"]()!;
+    expect(recipe.variant).toBe("accent-primary");
+    expect(recipe.icon).toBe("bwi-unlock");
+    expect(recipe.label).toContain("pamAccessBadgeTimeLeft");
+  });
+
+  it("escalates to the danger 'Ending soon' badge at or below 5 minutes", () => {
+    create({ kind: "active", expiresAt: new Date(Date.now() + 3 * 60_000) });
+
+    const recipe = component["recipe"]()!;
+    expect(recipe.variant).toBe("danger");
+    expect(recipe.icon).toBe("bwi-exclamation-triangle");
+    expect(recipe.label).toContain("pamAccessBadgeEndingSoon");
+  });
+
+  it("shows the expired badge once an active lease has lapsed", () => {
+    create({ kind: "active", expiresAt: new Date(Date.now() - 1_000) });
+
+    const recipe = component["recipe"]()!;
+    expect(recipe.variant).toBe("subtle");
+    expect(recipe.label).toBe("pamAccessBadgeSessionEnded");
+  });
+});

--- a/bitwarden_license/bit-web/src/app/pam/access-state-badge/access-state-badge.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-state-badge/access-state-badge.component.ts
@@ -1,0 +1,134 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  effect,
+  inject,
+  input,
+  signal,
+} from "@angular/core";
+
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { BadgeComponent, BadgeVariant } from "@bitwarden/components";
+
+import { formatRemaining } from "../date/format-remaining";
+
+import { AccessBadgeState } from "./access-badge-state";
+
+/** At or below this remaining time an active lease escalates to the danger "Ending soon" badge. */
+const ENDING_SOON_THRESHOLD_MS = 5 * 60 * 1000;
+
+/** One of the six glyphs the spec pairs with the access-state badges. */
+type BadgeIcon =
+  "bwi-key" | "bwi-clock" | "bwi-lock" | "bwi-unlock" | "bwi-check" | "bwi-exclamation-triangle";
+
+type BadgeRecipe = {
+  readonly variant: BadgeVariant;
+  readonly icon: BadgeIcon;
+  readonly label: string;
+  readonly testId: string;
+};
+
+/**
+ * Renders the unified access-state badge for a gated item — the one pill recipe used across the
+ * vault row, the cipher-view modal, and the Requests page (Figma node 88-1699). Callers resolve
+ * an {@link AccessBadgeState} (e.g. via `cipherAccessBadgeState`) and pass it in; this component
+ * owns the colour/icon/copy mapping, the 5-minute danger escalation, and the live countdown so
+ * every surface behaves identically. Renders nothing when `state` is null.
+ */
+@Component({
+  selector: "app-pam-access-state-badge",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [BadgeComponent],
+  templateUrl: "./access-state-badge.component.html",
+})
+export class AccessStateBadgeComponent {
+  readonly state = input.required<AccessBadgeState | null>();
+
+  private readonly i18nService = inject(I18nService);
+
+  /** Ticks once a second while an active-lease countdown is showing so the label stays live. */
+  private readonly now = signal(Date.now());
+
+  protected readonly recipe = computed<BadgeRecipe | null>(() => {
+    const state = this.state();
+    if (state == null) {
+      return null;
+    }
+
+    if (state.kind === "active") {
+      const remainingMs = state.expiresAt.getTime() - this.now();
+      if (remainingMs <= 0) {
+        // The lease lapsed locally before a refetch — show the resting "Session ended" badge.
+        return this.staticRecipe("expired");
+      }
+      const remaining = formatRemaining(remainingMs);
+      if (remainingMs <= ENDING_SOON_THRESHOLD_MS) {
+        return {
+          variant: "danger",
+          icon: "bwi-exclamation-triangle",
+          label: this.i18nService.t("pamAccessBadgeEndingSoon", remaining),
+          testId: "access-state-badge-ending-soon",
+        };
+      }
+      return {
+        variant: "accent-primary",
+        icon: "bwi-unlock",
+        label: this.i18nService.t("pamAccessBadgeTimeLeft", remaining),
+        testId: "access-state-badge-active",
+      };
+    }
+
+    return this.staticRecipe(state.kind);
+  });
+
+  constructor() {
+    effect((onCleanup) => {
+      if (this.state()?.kind !== "active") {
+        return;
+      }
+      const id = setInterval(() => this.now.set(Date.now()), 1000);
+      onCleanup(() => clearInterval(id));
+    });
+  }
+
+  private staticRecipe(kind: Exclude<AccessBadgeState["kind"], "active">): BadgeRecipe {
+    switch (kind) {
+      case "privileged":
+        return {
+          variant: "primary",
+          icon: "bwi-key",
+          label: this.i18nService.t("pamAccessBadgePrivileged"),
+          testId: "access-state-badge-privileged",
+        };
+      case "pending":
+        return {
+          variant: "warning",
+          icon: "bwi-clock",
+          label: this.i18nService.t("pamAccessBadgePending"),
+          testId: "access-state-badge-pending",
+        };
+      case "unavailable":
+        return {
+          variant: "subtle",
+          icon: "bwi-lock",
+          label: this.i18nService.t("pamAccessBadgeUnavailable"),
+          testId: "access-state-badge-unavailable",
+        };
+      case "ready":
+        return {
+          variant: "success",
+          icon: "bwi-check",
+          label: this.i18nService.t("pamAccessBadgeReady"),
+          testId: "access-state-badge-ready",
+        };
+      case "expired":
+        return {
+          variant: "subtle",
+          icon: "bwi-lock",
+          label: this.i18nService.t("pamAccessBadgeSessionEnded"),
+          testId: "access-state-badge-expired",
+        };
+    }
+  }
+}

--- a/bitwarden_license/bit-web/src/app/pam/provide-pam.ts
+++ b/bitwarden_license/bit-web/src/app/pam/provide-pam.ts
@@ -2,12 +2,14 @@ import { AccountService } from "@bitwarden/common/auth/abstractions/account.serv
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { SdkService } from "@bitwarden/common/platform/abstractions/sdk/sdk.service";
 import { SafeProvider, safeProvider } from "@bitwarden/ui-common";
+import { VAULT_ROW_LEASE_BADGE } from "@bitwarden/web-vault/app/vault/components/vault-items/vault-row-lease-badge.token";
 
 import { CidrValidationService } from "./access-rules/access-rule-edit/ip-allowlist/cidr-validation.service";
 import { DefaultCidrValidationService } from "./access-rules/access-rule-edit/ip-allowlist/default-cidr-validation.service";
 import { AccessLeasesSdkService } from "./services/access-leases-sdk.service";
 import { AccessRequestsSdkService } from "./services/access-requests-sdk.service";
 import { AccessRulesSdkService } from "./services/access-rules-sdk.service";
+import { VaultRowLeaseBadgeComponent } from "./vault-row-lease-badge/vault-row-lease-badge.component";
 
 import { AccessLeaseSdkService, AccessRequestSdkService, AccessRuleSdkService } from ".";
 
@@ -44,6 +46,10 @@ export function providePam(): SafeProvider[] {
       provide: CidrValidationService,
       useClass: DefaultCidrValidationService,
       deps: [],
+    }),
+    safeProvider({
+      provide: VAULT_ROW_LEASE_BADGE,
+      useValue: VaultRowLeaseBadgeComponent,
     }),
   ];
 }

--- a/bitwarden_license/bit-web/src/app/pam/services/access-requests-sdk.service.ts
+++ b/bitwarden_license/bit-web/src/app/pam/services/access-requests-sdk.service.ts
@@ -3,8 +3,14 @@ import { catchError, firstValueFrom, switchMap } from "rxjs";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { getUserId } from "@bitwarden/common/auth/services/account.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
-import { SdkService } from "@bitwarden/common/platform/abstractions/sdk/sdk.service";
-import type { AccessLeaseView, AccessRequestId, AccessRequestView } from "@bitwarden/sdk-internal";
+import { asUuid, SdkService } from "@bitwarden/common/platform/abstractions/sdk/sdk.service";
+import type {
+  AccessLeaseView,
+  AccessRequestId,
+  AccessRequestView,
+  CipherAccessStateView,
+  CipherId as SdkCipherId,
+} from "@bitwarden/sdk-internal";
 
 import { AccessRequestSdkService } from "..";
 
@@ -88,6 +94,23 @@ export class AccessRequestsSdkService extends AccessRequestSdkService {
         }),
         catchError((error: unknown) => {
           this.logService.error(`Failed to cancel access request: ${error}`);
+          throw error;
+        }),
+      ),
+    );
+  }
+
+  async getCipherAccessState(cipherId: string): Promise<CipherAccessStateView> {
+    const id = asUuid<SdkCipherId>(cipherId);
+    const userId = await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId));
+    return firstValueFrom(
+      this.sdkService.userClient$(userId).pipe(
+        switchMap(async (sdk) => {
+          using ref = sdk.take();
+          return await ref.value.commercial().pam().access_requests().cipher_access_state(id);
+        }),
+        catchError((error: unknown) => {
+          this.logService.error(`Failed to get cipher access state: ${error}`);
           throw error;
         }),
       ),

--- a/bitwarden_license/bit-web/src/app/pam/vault-row-lease-badge/vault-row-lease-badge.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/vault-row-lease-badge/vault-row-lease-badge.component.html
@@ -1,0 +1,1 @@
+<app-pam-access-state-badge [state]="badge()" />

--- a/bitwarden_license/bit-web/src/app/pam/vault-row-lease-badge/vault-row-lease-badge.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/vault-row-lease-badge/vault-row-lease-badge.component.spec.ts
@@ -1,0 +1,127 @@
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { BehaviorSubject } from "rxjs";
+
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+import type { CipherAccessStateView } from "@bitwarden/sdk-internal";
+
+import { AccessRequestSdkService } from "../abstractions/access-request-sdk.service";
+
+import { VaultRowLeaseBadgeComponent } from "./vault-row-lease-badge.component";
+
+describe("VaultRowLeaseBadgeComponent", () => {
+  let fixture: ComponentFixture<VaultRowLeaseBadgeComponent>;
+  let component: VaultRowLeaseBadgeComponent;
+  let enabled$: BehaviorSubject<boolean>;
+  let accessRequestSdkService: {
+    getCipherAccessState: jest.Mock<Promise<CipherAccessStateView>, [string]>;
+  };
+
+  function create(cipher: CipherView): void {
+    fixture = TestBed.createComponent(VaultRowLeaseBadgeComponent);
+    fixture.componentRef.setInput("cipher", cipher);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }
+
+  function gatedCipher(): CipherView {
+    const cipher = new CipherView();
+    cipher.id = "cipher-1";
+    cipher.partial = true;
+    return cipher;
+  }
+
+  beforeEach(() => {
+    enabled$ = new BehaviorSubject<boolean>(true);
+    accessRequestSdkService = { getCipherAccessState: jest.fn() };
+
+    TestBed.configureTestingModule({
+      imports: [VaultRowLeaseBadgeComponent],
+      providers: [
+        { provide: ConfigService, useValue: { getFeatureFlag$: () => enabled$ } },
+        { provide: AccessRequestSdkService, useValue: accessRequestSdkService },
+        {
+          provide: I18nService,
+          useValue: { t: (key: string, ...args: unknown[]) => [key, ...args].join(" ") },
+        },
+      ],
+    });
+  });
+
+  it("renders nothing for a non-gated cipher", async () => {
+    accessRequestSdkService.getCipherAccessState.mockResolvedValue({} as CipherAccessStateView);
+    const cipher = new CipherView();
+    cipher.id = "cipher-1";
+    cipher.partial = false;
+
+    create(cipher);
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(component["badge"]()).toBeNull();
+    expect(accessRequestSdkService.getCipherAccessState).not.toHaveBeenCalled();
+  });
+
+  it("renders nothing when the PAM flag is off, even if the cipher is gated", async () => {
+    enabled$.next(false);
+
+    create(gatedCipher());
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(component["badge"]()).toBeNull();
+    expect(accessRequestSdkService.getCipherAccessState).not.toHaveBeenCalled();
+  });
+
+  it("resolves the privileged (resting) state when gated with no request or lease", async () => {
+    accessRequestSdkService.getCipherAccessState.mockResolvedValue({
+      activeLease: undefined,
+      pendingRequest: undefined,
+      approvedRequest: undefined,
+    } as unknown as CipherAccessStateView);
+
+    create(gatedCipher());
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(component["badge"]()?.kind).toBe("privileged");
+  });
+
+  it("resolves the active state with the lease expiry when a lease is active", async () => {
+    const notAfter = new Date(Date.now() + 60_000).toISOString();
+    accessRequestSdkService.getCipherAccessState.mockResolvedValue({
+      activeLease: { id: "lease-1", notAfter },
+    } as unknown as CipherAccessStateView);
+
+    create(gatedCipher());
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const badge = component["badge"]();
+    expect(badge?.kind).toBe("active");
+    expect(badge).toEqual({ kind: "active", expiresAt: new Date(notAfter) });
+  });
+
+  it("resolves the pending state when a request is awaiting a decision", async () => {
+    accessRequestSdkService.getCipherAccessState.mockResolvedValue({
+      pendingRequest: {},
+    } as unknown as CipherAccessStateView);
+
+    create(gatedCipher());
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(component["badge"]()?.kind).toBe("pending");
+  });
+
+  it("renders nothing when the access-state fetch fails", async () => {
+    accessRequestSdkService.getCipherAccessState.mockRejectedValue(new Error("boom"));
+
+    create(gatedCipher());
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(component["badge"]()).toBeNull();
+  });
+});

--- a/bitwarden_license/bit-web/src/app/pam/vault-row-lease-badge/vault-row-lease-badge.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/vault-row-lease-badge/vault-row-lease-badge.component.ts
@@ -1,0 +1,57 @@
+import { ChangeDetectionStrategy, Component, inject, input } from "@angular/core";
+import { toObservable, toSignal } from "@angular/core/rxjs-interop";
+import { catchError, combineLatest, from, map, Observable, of, switchMap } from "rxjs";
+
+import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
+import { CipherViewLike } from "@bitwarden/common/vault/utils/cipher-view-like-utils";
+
+import { AccessRequestSdkService } from "../abstractions/access-request-sdk.service";
+import { AccessBadgeState, cipherAccessBadgeState } from "../access-state-badge/access-badge-state";
+import { AccessStateBadgeComponent } from "../access-state-badge/access-state-badge.component";
+
+/**
+ * Binds `VAULT_ROW_LEASE_BADGE` for one row in the vault list. Encapsulates every PAM dependency
+ * so the row component stays PAM-free: pass the row's cipher, get the shared access-state badge
+ * (or nothing) back. The badge recipe, copy, and countdown live in {@link AccessStateBadgeComponent}
+ * so this row renders exactly what the modal and Requests page do.
+ *
+ * Fetches the cipher's access state once per cipher/flag change (not on an interval — a vault list
+ * can render many gated rows at once, and the reveal-in-place behavior that needs live polling lives
+ * in the cipher-view banner / gated-cipher reloader, not here). The active-lease countdown ticks
+ * locally inside the shared badge once fetched.
+ */
+@Component({
+  selector: "app-pam-vault-row-lease-badge",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [AccessStateBadgeComponent],
+  templateUrl: "./vault-row-lease-badge.component.html",
+})
+export class VaultRowLeaseBadgeComponent {
+  readonly cipher = input.required<CipherViewLike>();
+
+  private readonly configService = inject(ConfigService);
+  private readonly accessRequestSdkService = inject(AccessRequestSdkService);
+
+  private readonly cipher$ = toObservable(this.cipher);
+  private readonly enabled$ = this.configService.getFeatureFlag$(FeatureFlag.Pam);
+
+  private readonly state$: Observable<AccessBadgeState | null> = combineLatest([
+    this.cipher$,
+    this.enabled$,
+  ]).pipe(
+    switchMap(([cipher, enabled]) => {
+      // Gating is driven by the SDK's `partial` flag, carried on both `CipherView` and
+      // `CipherListView`. No flag, no id, or the flag off — no badge.
+      if (!enabled || !cipher.partial || cipher.id == null) {
+        return of(null);
+      }
+      return from(this.accessRequestSdkService.getCipherAccessState(String(cipher.id))).pipe(
+        map(cipherAccessBadgeState),
+        catchError(() => of(null)),
+      );
+    }),
+  );
+
+  protected readonly badge = toSignal(this.state$, { initialValue: null });
+}


### PR DESCRIPTION
## 🎟️ Tracking

Implements the "Unifying access-state badges consistently across vault, modal, and Requests page" spec ([Figma 88-1699](https://www.figma.com/design/FvfC7E5GqKPS6Mbc9IyhkU/Password-Manager-Vault--Member-Experience-?node-id=88-1699&m=dev)) for the **vault-row** surface.

## 📔 Objective

Replace the two-state, icon-only vault-row lease badge with the unified access-state badge from the spec: a `bit-badge` pill with per-state colour + icon + copy, mutually exclusive precedence, and the 5-minute danger "Ending soon" escalation. The recipe lives in a reusable `AccessStateBadgeComponent` so the cipher-view modal and Requests page can adopt the identical recipe in follow-ups.

### State model

| State | Variant | Icon | Copy |
|---|---|---|---|
| Privileged (resting, gated) | `primary` | `bwi-key` | "Privileged" |
| Pending | `warning` | `bwi-clock` | "Pending approval" |
| Ready to use (approved, not activated) | `success` | `bwi-check` | "Ready to use" |
| Active lease > 5m | `accent-primary` | `bwi-unlock` | "18m left" |
| Active lease ≤ 5m | `danger` | `bwi-exclamation-triangle` | "Ending soon • 4m left" |
| Session ended (expired) | `subtle` | `bwi-lock` | "Session ended" |
| Unavailable (held by another) | `subtle` | `bwi-lock` | "Unavailable" — **modelled, not yet produced (see Deferred)** |

Precedence (highest-ranked true state wins): active lease → ready → pending → privileged.

### What's here
- `access-state-badge/` — `AccessStateBadgeComponent` + `cipherAccessBadgeState` resolver + specs.
- `vault-row-lease-badge/` — the `VAULT_ROW_LEASE_BADGE` provider, rewritten to render the shared badge.
- `AccessRequestSdkService.getCipherAccessState` (binds `commercial().pam().access_requests().cipher_access_state`).
- `provide-pam` binds `VAULT_ROW_LEASE_BADGE`; 7 `pamAccessBadge*` i18n keys.

### Deferred
**"Unavailable / held by another user"** is modelled in `AccessBadgeState` and the recipe but not yet produced by the resolver: `CipherAccessStateView` is caller-scoped and never reports *another* user's lease. Lighting it up needs a new signal on the SDK `CipherAccessStateView` fed by the server access-state query.

## ⚠️ Draft — stacked, CI red on inherited base drift

Stacks on **#22171** (the `VAULT_ROW_LEASE_BADGE` seam token) + **#22147** (the PAM SDK request services). The PR base is an integration branch (`pam/vault-row-access-badge-base` = `main` + #22171 + #22147) so the diff shows **only the badge**. Retarget once the team settles the stack.

CI is **red on 20 pre-existing errors inherited from the base PRs — none in the badge code**:
- **#22171** reads `partial` / `partialData`, which are absent from the published `@bitwarden/sdk-internal@0.2.0-main.956` and need the still-unpublished **`sdk-internal` #1359**.
- **#22147** predates the SDK `AccessDecider` union refactor (`deciderKind` / `name` / `email` no longer exist on `AccessRequestDecisionView`).

The badge's own files are clean — ESLint + prettier pass, 29 unit tests pass, and the badge logic typechecks (its only build error is the inherited `cipher.partial`). This goes green once #1359 publishes and the base PRs adopt their drift fixes.

## Verification
- `jest` over `access-state-badge`, `vault-row-lease-badge`, `access-requests-sdk.service` → **29 passed**.
- `lint-staged` (ESLint + prettier) clean on all 13 changed files.
