### PR TITLE
[chore] Add CODEOWNERS entry for the licensed browser DIRT directory

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -53,6 +53,7 @@ libs/tools                                                     @bitwarden/team-t
 apps/browser/src/dirt                   @bitwarden/team-data-insights-and-reporting-dev
 apps/web/src/app/dirt                   @bitwarden/team-data-insights-and-reporting-dev
 apps/cli/src/dirt                       @bitwarden/team-data-insights-and-reporting-dev
+bitwarden_license/bit-browser/src/popup/dirt  @bitwarden/team-data-insights-and-reporting-dev
 bitwarden_license/bit-common/src/dirt   @bitwarden/team-data-insights-and-reporting-dev
 bitwarden_license/bit-web/src/app/dirt  @bitwarden/team-data-insights-and-reporting-dev
 libs/dirt                               @bitwarden/team-data-insights-and-reporting-dev


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

`.github/CODEOWNERS` lists every other `dirt` path but not `bitwarden_license/bit-browser/src/popup/dirt`, so the browser Health tab that moved there in [#22223](https://github.com/bitwarden/clients/pull/22223) has been unowned since. GitHub does not auto-request DIRT review for changes to that directory, and the feature work landing there now inherits the same gap.

One line, matching the six sibling entries:

```
bitwarden_license/bit-browser/src/popup/dirt  @bitwarden/team-data-insights-and-reporting-dev
```

The path is 44 characters, longer than the column that block aligns to, so it takes two spaces before the owner. That matches how the file already handles other over-length paths such as `apps/web/src/app/components/environment-selector`.

Split out of [#22235](https://github.com/bitwarden/clients/pull/22235) so the tech-leads review this file requires is not attached to a feature PR.

Verified with the GitHub CODEOWNERS validation API: 0 errors on the file for this branch.

## 📸 Screenshots

Not applicable, no UI changes.