### PR TITLE
appx: custom signing and COM [PM-37680] (dont-merge)

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -890,15 +890,50 @@ jobs:
         if: ${{ needs.setup.outputs.has_secrets == 'true' }}
         run: ./scripts/validate-chromium-importer-thumbprint.ps1
 
+      # The Appx built above keeps the Microsoft-assigned publisher and stays unsigned,
+      # which is what the Store requires but also what makes it uninstallable outside the
+      # Store. It moves aside under the -store name so the signed, directly installable
+      # package built below can take the plain artifact name.
       - name: Rename appx files for store
         if: ${{ needs.setup.outputs.has_secrets == 'true' }}
         run: |
-          Copy-Item "./dist/Bitwarden-Beta-$env:_PACKAGE_VERSION-ia32.appx" `
-            -Destination "./dist/Bitwarden-Beta-$env:_PACKAGE_VERSION-ia32-store.appx"
-          Copy-Item "./dist/Bitwarden-Beta-$env:_PACKAGE_VERSION-x64.appx" `
-            -Destination "./dist/Bitwarden-Beta-$env:_PACKAGE_VERSION-x64-store.appx"
-          Copy-Item "./dist/Bitwarden-Beta-$env:_PACKAGE_VERSION-arm64.appx" `
-            -Destination "./dist/Bitwarden-Beta-$env:_PACKAGE_VERSION-arm64-store.appx"
+          Rename-Item -Path "./dist/Bitwarden-Beta-$env:_PACKAGE_VERSION-ia32.appx" `
+            -NewName "Bitwarden-Beta-$env:_PACKAGE_VERSION-ia32-store.appx"
+          Rename-Item -Path "./dist/Bitwarden-Beta-$env:_PACKAGE_VERSION-x64.appx" `
+            -NewName "Bitwarden-Beta-$env:_PACKAGE_VERSION-x64-store.appx"
+          Rename-Item -Path "./dist/Bitwarden-Beta-$env:_PACKAGE_VERSION-arm64.appx" `
+            -NewName "Bitwarden-Beta-$env:_PACKAGE_VERSION-arm64-store.appx"
+
+      # An Appx can only be signed when its manifest publisher matches the certificate
+      # subject, so read the subject back off a binary the pack just signed. Hardcoding it
+      # would silently rot the next time the signing certificate is rotated.
+      - name: Read signing certificate subject
+        id: cert-subject
+        if: ${{ needs.setup.outputs.has_secrets == 'true' }}
+        run: |
+          $signature = Get-AuthenticodeSignature "./dist/win-unpacked/Bitwarden Beta.exe"
+          if ($null -eq $signature.SignerCertificate) {
+            Write-Error "Expected a signed exe, got status '$($signature.Status)': $($signature.StatusMessage)"
+            exit 1
+          }
+          $subject = $signature.SignerCertificate.Subject
+          Write-Host "Signing certificate subject: $subject"
+          "publisher=$subject" >> $env:GITHUB_OUTPUT
+
+      # Repacks the Appx targets only, reusing the app directories from the pack above, so
+      # this costs one compression pass per architecture rather than a second full build.
+      - name: Pack & sign appx for direct download
+        if: ${{ needs.setup.outputs.has_secrets == 'true' }}
+        env:
+          ELECTRON_BUILDER_SIGN: 1
+          ELECTRON_BUILDER_SIGN_APPX: 1
+          SIGNING_VAULT_URL: ${{ steps.retrieve-secrets.outputs.code-signing-vault-url }}
+          SIGNING_CLIENT_ID: ${{ steps.retrieve-secrets.outputs.code-signing-client-id }}
+          SIGNING_TENANT_ID: ${{ steps.retrieve-secrets.outputs.code-signing-tenant-id }}
+          SIGNING_CLIENT_SECRET: ${{ steps.retrieve-secrets.outputs.code-signing-client-secret }}
+          SIGNING_CERT_NAME: ${{ steps.retrieve-secrets.outputs.code-signing-cert-name }}
+          _APPX_PUBLISHER: ${{ steps.cert-subject.outputs.publisher }}
+        run: ./scripts/pack-signed-appx.ps1 -Config electron-builder.beta.json -Publisher $env:_APPX_PUBLISHER
 
       - name: Fix NSIS artifact names for auto-updater
         if: ${{ needs.setup.outputs.has_secrets == 'true' }}

--- a/apps/desktop/custom-appx-manifest.xml
+++ b/apps/desktop/custom-appx-manifest.xml
@@ -89,10 +89,10 @@
         <rescap:Capability Name="runFullTrust" />
     </Capabilities>
     <Applications>
-        <Application Id="bitwardendesktop" Executable="${executable}"
+        <Application Id="${applicationId}" Executable="${executable}"
             EntryPoint="Windows.FullTrustApplication">
             <uap:VisualElements
-                BackgroundColor="#175DDC"
+                BackgroundColor="${backgroundColor}"
                 DisplayName="${displayName}"
                 Square150x150Logo="assets\Square150x150Logo.png"
                 Square44x44Logo="assets\Square44x44Logo.png"

--- a/apps/desktop/electron-builder.beta.json
+++ b/apps/desktop/electron-builder.beta.json
@@ -15,6 +15,7 @@
   "afterSign": "scripts/after-sign.js",
   "afterPack": "scripts/after-pack.js",
   "beforePack": "scripts/before-pack.js",
+  "appxManifestCreated": "scripts/appx-manifest-created-beta.js",
   "files": [
     "!node_modules/@bitwarden/desktop-napi/scripts",
     "!node_modules/@bitwarden/desktop-napi/src",
@@ -161,7 +162,8 @@
   },
   "appx": {
     "artifactName": "Bitwarden-Beta-${version}-${arch}.${ext}",
-    "backgroundColor": "#175DDC",
+    "backgroundColor": "#FDC700",
+    "customManifestPath": "./custom-appx-manifest.xml",
     "applicationId": "BitwardenBeta",
     "identityName": "8bitSolutionsLLC.BitwardenBeta",
     "publisher": "CN=14D52771-DE3C-4886-B8BF-825BA7690418",

--- a/apps/desktop/scripts/appx-cross-build.ps1
+++ b/apps/desktop/scripts/appx-cross-build.ps1
@@ -184,6 +184,7 @@ Write-Host "Building Appx manifest"
 $translationMap = @{
     'arch' = $arch
     'applicationId' = $builderConfig.appx.applicationId
+    'backgroundColor' = $builderConfig.appx.backgroundColor
     'displayName' = $productName
     'executable' = "app\${productName}.exe"
     'identityName' = $builderConfig.appx.identityName
@@ -198,12 +199,9 @@ $translationMap.Keys | ForEach-Object {
 }
 
 # Manual Fixups for Beta
-# electron-builder can't template these variables, so we substitute known values with the ones we want:
+# The manifest carries the stable COM class ID, which electron-builder has no macro for,
+# so swap in the beta one. scripts/appx-manifest-created-beta.js does the same for CI builds.
 if ($Beta) {
-    # Update color
-    $manifest = $manifest.Replace("#175DDC", "#FDC700")
-
-    # Update COM ID
     $PluginStableConfig = Get-Content $srcDir/resources/windows_plugin_authenticator_config.json | ConvertFrom-Json
     $PluginBetaConfig = Get-Content $srcDir/resources/windows_plugin_authenticator_config.beta.json | ConvertFrom-Json
     $manifest = $manifest.Replace($PluginStableConfig.clsid, $PluginBetaConfig.clsid)

--- a/apps/desktop/scripts/appx-manifest-created-beta.js
+++ b/apps/desktop/scripts/appx-manifest-created-beta.js
@@ -1,0 +1,51 @@
+/* eslint-disable @typescript-eslint/no-require-imports, no-console */
+/**
+ * Point the Appx COM server at the beta passkey provider's class ID.
+ *
+ * custom-appx-manifest.xml is shared by both channels and carries the stable class ID.
+ * electron-builder substitutes only its own manifest macros, so the beta class ID is
+ * swapped in here, from the same config files the app itself is packaged with.
+ *
+ * The declared class ID has to match the one the beta app registers with Windows at
+ * runtime, or activating the beta provider finds nothing to launch. Leaving the stable
+ * class ID in place is worse than a no-op: the beta package would declare the stable
+ * app's COM class, so whichever installed last would answer for it.
+ *
+ * Registered as `appxManifestCreated` from electron-builder.beta.json only, which is what
+ * scopes it to beta builds. electron-builder calls it after writing the manifest and
+ * before makeappx packs it.
+ */
+const fs = require("fs");
+const path = require("path");
+
+const configDir = path.resolve(__dirname, "../resources");
+
+function readClsid(configFile) {
+  const configPath = path.join(configDir, configFile);
+  const { clsid } = JSON.parse(fs.readFileSync(configPath, "utf8"));
+  if (!clsid) {
+    throw new Error(`No plugin authenticator clsid found in ${configPath}`);
+  }
+  return clsid;
+}
+
+exports.default = function (manifestPath) {
+  const stableClsid = readClsid("windows_plugin_authenticator_config.json");
+  const betaClsid = readClsid("windows_plugin_authenticator_config.beta.json");
+  if (stableClsid === betaClsid) {
+    throw new Error(
+      `The beta plugin authenticator clsid must differ from the stable one, got ${betaClsid} for both.`,
+    );
+  }
+
+  const manifest = fs.readFileSync(manifestPath, "utf8");
+  if (!manifest.includes(stableClsid)) {
+    throw new Error(
+      `Expected the stable plugin authenticator clsid ${stableClsid} in ${manifestPath}. ` +
+        `Check that appx.customManifestPath points at a manifest declaring the COM server.`,
+    );
+  }
+
+  fs.writeFileSync(manifestPath, manifest.replaceAll(stableClsid, betaClsid));
+  console.log(`[*] Set beta plugin authenticator clsid ${betaClsid} in ${manifestPath}`);
+};

--- a/apps/desktop/scripts/pack-signed-appx.ps1
+++ b/apps/desktop/scripts/pack-signed-appx.ps1
@@ -1,0 +1,76 @@
+#!/usr/bin/env pwsh
+
+<#
+.SYNOPSIS
+Repackages an already-built Windows app directory as a signed Appx.
+
+.DESCRIPTION
+An Appx names its publisher in the package manifest, and signing fails unless that
+publisher matches the subject of the signing certificate. Store packages therefore have
+to keep the Microsoft-assigned publisher (a UUID) and stay unsigned, which leaves them
+uninstallable by anyone outside the Store.
+
+To offer a directly installable Appx as well, this script rebuilds only the Appx target
+from the `dist/win*-unpacked` directories electron-builder already produced, overriding
+the publisher to the certificate subject and signing the result. Nothing is recompiled
+and the app binaries keep the signatures from the original pack, so this costs one Appx
+compression pass per architecture instead of a second full build.
+
+The signed Appx lands on the configured `appx.artifactName`, so move or rename the
+unsigned Store package first if both are wanted.
+
+.PARAMETER Publisher
+Subject of the signing certificate, e.g. `CN=Contoso Inc., O=Contoso Inc., C=US`. Signing
+rejects any other value, so read it off a binary the same certificate signed rather than
+hardcoding it.
+
+.EXAMPLE
+$publisher = (Get-AuthenticodeSignature "./dist/win-unpacked/Bitwarden Beta.exe").SignerCertificate.Subject
+./scripts/pack-signed-appx.ps1 -Publisher $publisher -Config electron-builder.beta.json
+
+.NOTES
+Signing is delegated to `sign.js`, which needs ELECTRON_BUILDER_SIGN=1 plus its Azure
+Key Vault environment, and ELECTRON_BUILDER_SIGN_APPX=1 to sign Appx files at all.
+#>
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]
+    $Publisher,
+
+    [string]
+    # electron-builder config to pack with.
+    $Config = "electron-builder.json",
+
+    [ValidateSet("ia32", "x64", "arm64")]
+    [string[]]
+    # Architectures to repackage. Each needs its `dist/win*-unpacked` directory present.
+    $Architectures = @("ia32", "x64", "arm64")
+)
+
+$ErrorActionPreference = "Stop"
+$PSNativeCommandUseErrorActionPreference = $true
+
+Push-Location $PSScriptRoot/..
+try {
+    foreach ($arch in $Architectures) {
+        # electron-builder omits the arch suffix for the default architecture.
+        $unpackedDir = if ($arch -eq "x64") { "dist/win-unpacked" } else { "dist/win-$arch-unpacked" }
+        if (!(Test-Path $unpackedDir)) {
+            Write-Error "$unpackedDir not found. Pack the $arch app before repackaging it as a signed Appx."
+            exit 1
+        }
+
+        Write-Host "Packaging signed $arch Appx from $unpackedDir with publisher '$Publisher'"
+        & npx electron-builder `
+            --config $Config `
+            --win appx `
+            --$arch `
+            --prepackaged $unpackedDir `
+            --publish never `
+            "-c.appx.publisher=$Publisher"
+    }
+}
+finally {
+    Pop-Location
+}

--- a/apps/desktop/sign.js
+++ b/apps/desktop/sign.js
@@ -3,7 +3,15 @@ const child_process = require("child_process");
 
 exports.default = async function (configuration) {
   const ext = configuration.path.split(".").at(-1);
-  if (parseInt(process.env.ELECTRON_BUILDER_SIGN) === 1 && ["exe", "dll", "node"].includes(ext)) {
+  // An Appx embeds its publisher in the manifest, and signing fails unless that
+  // publisher matches the certificate subject. Store packages are published unsigned
+  // under the Microsoft-assigned publisher, so Appx signing is opt-in per build rather
+  // than always on.
+  const signExts = ["exe", "dll", "node"];
+  if (parseInt(process.env.ELECTRON_BUILDER_SIGN_APPX) === 1) {
+    signExts.push("appx");
+  }
+  if (parseInt(process.env.ELECTRON_BUILDER_SIGN) === 1 && signExts.includes(ext)) {
     console.log(`[*] Signing file: ${configuration.path}`);
     child_process.execFileSync(
       "azuresigntool",


### PR DESCRIPTION
## 🎟️ Tracking

[PM-37680](https://bitwarden.atlassian.net/browse/PM-37680)


## 📔 Objective
This is a test of signing the Windows Beta Appx to see if we can get a build with the passkey plugin authenticator. Not intended to be reviewed deeply or merged.

Features:
- Creates separate artifacts for Microsoft store (`-store` suffix) and CI (no `-store` suffix) builds; previously these were the exact same contents, just copied to a new file name. Now the Microsoft Store appx builds are unsigned, and the CI builds are signed with the CI signing key. (Consequently, the publisher is different in CI than the Microsoft Store one.) BRE should be able to use the same process to publish to the Microsoft store while also allowing CI builds to be run by testers.
- dynamically reads the subject of the CI signing certificate from the built artifacts
- repackages the appx without a full rebuild, so we only need to recompress the artifacts to sign them.
- adds a new environment variable `ELECTRON_BUILDER_SIGN_APPX` which allows signing Appx.

Some breaking changes:
- sets a custom logo and background color: this is just to make it easy to see the difference while installing the two different apps. This should be reverted
- Removes BadgeLogo, intentional, unneeded. 

TODOs:
- Get real logos and background colors for the Beta
- convert .ps1 script to TypeScript, per the repo's recent preference to use TypeScript build scripts over PowerShell.

[PM-37680]: https://bitwarden.atlassian.net/browse/PM-37680?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ