### PR TITLE
[PM-41691] Fix issue where edit item, hidden passwords wipes password, TOTP

### DIFF
--- a/apps/cli/src/commands/edit.command.spec.ts
+++ b/apps/cli/src/commands/edit.command.spec.ts
@@ -195,6 +195,140 @@ describe("EditCommand", () => {
       expect(savedView.fields[0].value).toBe("real-hidden-value");
       expect(savedView.fields[1].value).toBe("visible-value");
     });
+
+    it("preserves hidden field values by name when fields are reordered in the request", async () => {
+      const cipher = { id: cipherId, edit: true } as Cipher;
+
+      const cipherView = new CipherView();
+      cipherView.id = cipherId;
+      cipherView.type = CipherType.Login;
+      cipherView.viewPassword = false;
+      cipherView.login = Object.assign(new LoginView(), {});
+      cipherView.fields = [
+        Object.assign(new FieldView(), { type: FieldType.Hidden, name: "a", value: "real-a" }),
+        Object.assign(new FieldView(), { type: FieldType.Hidden, name: "b", value: "real-b" }),
+      ];
+
+      cipherService.get.mockResolvedValue(cipher);
+      cipherService.decrypt.mockResolvedValue(cipherView);
+      cipherAuthorizationService.canEditCipher$.mockReturnValue(of(true));
+      cliRestrictedItemTypesService.isCipherRestricted.mockResolvedValue(false);
+      policyService.policyAppliesToUser$.mockReturnValue(of(false));
+      billingAccountProfileStateService.hasPremiumFromAnySource$.mockReturnValue(of(true));
+      cipherService.updateWithServer.mockImplementation(async (view: any) => view);
+
+      // Request reorders the fields (b before a) relative to the original cipher.
+      const redactedReq: any = {
+        type: CipherType.Login,
+        name: "Renamed item",
+        login: {},
+        fields: [
+          { type: FieldType.Hidden, name: "b", value: null },
+          { type: FieldType.Hidden, name: "a", value: null },
+        ],
+      };
+      const encodedRedactedReq = Buffer.from(JSON.stringify(redactedReq)).toString("base64");
+
+      const result = await command.run("item", cipherId, encodedRedactedReq, {});
+
+      expect(result.success).toBe(true);
+      const savedView = cipherService.updateWithServer.mock.calls[0][0] as CipherView;
+      const savedByName = new Map(savedView.fields.map((f) => [f.name, f.value]));
+      expect(savedByName.get("a")).toBe("real-a");
+      expect(savedByName.get("b")).toBe("real-b");
+    });
+
+    it("preserves hidden field values by name when a field is removed from the request", async () => {
+      const cipher = { id: cipherId, edit: true } as Cipher;
+
+      const cipherView = new CipherView();
+      cipherView.id = cipherId;
+      cipherView.type = CipherType.Login;
+      cipherView.viewPassword = false;
+      cipherView.login = Object.assign(new LoginView(), {});
+      cipherView.fields = [
+        Object.assign(new FieldView(), {
+          type: FieldType.Text,
+          name: "note",
+          value: "visible-value",
+        }),
+        Object.assign(new FieldView(), {
+          type: FieldType.Hidden,
+          name: "secret",
+          value: "real-hidden-value",
+        }),
+      ];
+
+      cipherService.get.mockResolvedValue(cipher);
+      cipherService.decrypt.mockResolvedValue(cipherView);
+      cipherAuthorizationService.canEditCipher$.mockReturnValue(of(true));
+      cliRestrictedItemTypesService.isCipherRestricted.mockResolvedValue(false);
+      policyService.policyAppliesToUser$.mockReturnValue(of(false));
+      billingAccountProfileStateService.hasPremiumFromAnySource$.mockReturnValue(of(true));
+      cipherService.updateWithServer.mockImplementation(async (view: any) => view);
+
+      // Request drops the leading "note" field, shifting "secret" from index 1 to index 0.
+      const redactedReq: any = {
+        type: CipherType.Login,
+        name: "Renamed item",
+        login: {},
+        fields: [{ type: FieldType.Hidden, name: "secret", value: null }],
+      };
+      const encodedRedactedReq = Buffer.from(JSON.stringify(redactedReq)).toString("base64");
+
+      const result = await command.run("item", cipherId, encodedRedactedReq, {});
+
+      expect(result.success).toBe(true);
+      const savedView = cipherService.updateWithServer.mock.calls[0][0] as CipherView;
+      expect(savedView.fields[0].value).toBe("real-hidden-value");
+    });
+
+    it("applies explicit new password, totp, and hidden field values from a hide-passwords user", async () => {
+      const cipher = { id: cipherId, edit: true } as Cipher;
+
+      const cipherView = new CipherView();
+      cipherView.id = cipherId;
+      cipherView.type = CipherType.Login;
+      cipherView.viewPassword = false;
+      cipherView.login = Object.assign(new LoginView(), {
+        password: "real-password",
+        totp: "real-totp",
+      });
+      cipherView.fields = [
+        Object.assign(new FieldView(), {
+          type: FieldType.Hidden,
+          name: "secret",
+          value: "real-hidden-value",
+        }),
+      ];
+
+      cipherService.get.mockResolvedValue(cipher);
+      cipherService.decrypt.mockResolvedValue(cipherView);
+      cipherAuthorizationService.canEditCipher$.mockReturnValue(of(true));
+      cliRestrictedItemTypesService.isCipherRestricted.mockResolvedValue(false);
+      policyService.policyAppliesToUser$.mockReturnValue(of(false));
+      billingAccountProfileStateService.hasPremiumFromAnySource$.mockReturnValue(of(true));
+      cipherService.updateWithServer.mockImplementation(async (view: any) => view);
+
+      // A user without permission to view the password/hidden fields can still supply explicit
+      // new values (e.g. via automation rotating a credential); these must not be discarded in
+      // favor of the original values.
+      const req: any = {
+        type: CipherType.Login,
+        name: "Renamed item",
+        login: { password: "new-password", totp: "new-totp" },
+        fields: [{ type: FieldType.Hidden, name: "secret", value: "new-hidden-value" }],
+      };
+      const encodedReq = Buffer.from(JSON.stringify(req)).toString("base64");
+
+      const result = await command.run("item", cipherId, encodedReq, {});
+
+      expect(result.success).toBe(true);
+      const savedView = cipherService.updateWithServer.mock.calls[0][0] as CipherView;
+      expect(savedView.login.password).toBe("new-password");
+      expect(savedView.login.totp).toBe("new-totp");
+      expect(savedView.fields[0].value).toBe("new-hidden-value");
+    });
   });
 
   describe("editOrganizationCollection", () => {

--- a/apps/cli/src/commands/edit.command.spec.ts
+++ b/apps/cli/src/commands/edit.command.spec.ts
@@ -12,8 +12,11 @@ import { OrganizationId } from "@bitwarden/common/types/guid";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { FolderApiServiceAbstraction } from "@bitwarden/common/vault/abstractions/folder/folder-api.service.abstraction";
 import { FolderService } from "@bitwarden/common/vault/abstractions/folder/folder.service.abstraction";
+import { CipherType, FieldType } from "@bitwarden/common/vault/enums";
 import { Cipher } from "@bitwarden/common/vault/models/domain/cipher";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+import { FieldView } from "@bitwarden/common/vault/models/view/field.view";
+import { LoginView } from "@bitwarden/common/vault/models/view/login.view";
 import { CipherAuthorizationService } from "@bitwarden/common/vault/services/cipher-authorization.service";
 import { KeyService } from "@bitwarden/key-management";
 import { UserId } from "@bitwarden/user-core";
@@ -134,6 +137,63 @@ describe("EditCommand", () => {
       expect(cipherAuthorizationService.canEditCipher$).toHaveBeenCalledWith(cipher);
       expect(cipherService.updateWithServer).toHaveBeenCalled();
       expect(result.success).toBe(true);
+    });
+
+    it("preserves password, totp, and hidden field values when user cannot view passwords", async () => {
+      const cipher = { id: cipherId, edit: true } as Cipher;
+
+      const cipherView = new CipherView();
+      cipherView.id = cipherId;
+      cipherView.type = CipherType.Login;
+      cipherView.viewPassword = false;
+      cipherView.login = Object.assign(new LoginView(), {
+        password: "real-password",
+        totp: "real-totp",
+      });
+      cipherView.fields = [
+        Object.assign(new FieldView(), {
+          type: FieldType.Hidden,
+          name: "secret",
+          value: "real-hidden-value",
+        }),
+        Object.assign(new FieldView(), {
+          type: FieldType.Text,
+          name: "note",
+          value: "visible-value",
+        }),
+      ];
+
+      cipherService.get.mockResolvedValue(cipher);
+      cipherService.decrypt.mockResolvedValue(cipherView);
+      cipherAuthorizationService.canEditCipher$.mockReturnValue(of(true));
+      cliRestrictedItemTypesService.isCipherRestricted.mockResolvedValue(false);
+      policyService.policyAppliesToUser$.mockReturnValue(of(false));
+      billingAccountProfileStateService.hasPremiumFromAnySource$.mockReturnValue(of(true));
+      cipherService.updateWithServer.mockImplementation(async (view: any) => view);
+
+      // Simulates a real-world `bw get item | ... | bw edit item` round trip: the CLI only
+      // ever hands back redacted (null) password/totp/hidden field values to a user without
+      // permission to view passwords, so those show up as explicit `null`s in the edit request.
+      const redactedReq: any = {
+        type: CipherType.Login,
+        name: "Renamed item",
+        login: { password: null, totp: null },
+        fields: [
+          { type: FieldType.Hidden, name: "secret", value: null },
+          { type: FieldType.Text, name: "note", value: "visible-value" },
+        ],
+      };
+      const encodedRedactedReq = Buffer.from(JSON.stringify(redactedReq)).toString("base64");
+
+      const result = await command.run("item", cipherId, encodedRedactedReq, {});
+
+      expect(result.success).toBe(true);
+      const savedView = cipherService.updateWithServer.mock.calls[0][0] as CipherView;
+      expect(savedView.name).toBe("Renamed item");
+      expect(savedView.login.password).toBe("real-password");
+      expect(savedView.login.totp).toBe("real-totp");
+      expect(savedView.fields[0].value).toBe("real-hidden-value");
+      expect(savedView.fields[1].value).toBe("visible-value");
     });
   });
 

--- a/apps/cli/src/commands/edit.command.spec.ts
+++ b/apps/cli/src/commands/edit.command.spec.ts
@@ -329,6 +329,44 @@ describe("EditCommand", () => {
       expect(savedView.login.totp).toBe("new-totp");
       expect(savedView.fields[0].value).toBe("new-hidden-value");
     });
+
+    it("preserves each hidden field's own value in order when multiple fields share a name", async () => {
+      const cipher = { id: cipherId, edit: true } as Cipher;
+
+      const cipherView = new CipherView();
+      cipherView.id = cipherId;
+      cipherView.type = CipherType.Login;
+      cipherView.viewPassword = false;
+      cipherView.fields = [
+        Object.assign(new FieldView(), { type: FieldType.Hidden, name: "dup", value: "first" }),
+        Object.assign(new FieldView(), { type: FieldType.Hidden, name: "dup", value: "second" }),
+      ];
+
+      cipherService.get.mockResolvedValue(cipher);
+      cipherService.decrypt.mockResolvedValue(cipherView);
+      cipherAuthorizationService.canEditCipher$.mockReturnValue(of(true));
+      cliRestrictedItemTypesService.isCipherRestricted.mockResolvedValue(false);
+      policyService.policyAppliesToUser$.mockReturnValue(of(false));
+      billingAccountProfileStateService.hasPremiumFromAnySource$.mockReturnValue(of(true));
+      cipherService.updateWithServer.mockImplementation(async (view: any) => view);
+
+      const req: any = {
+        type: CipherType.Login,
+        name: "Renamed item",
+        fields: [
+          { type: FieldType.Hidden, name: "dup", value: null },
+          { type: FieldType.Hidden, name: "dup", value: null },
+        ],
+      };
+      const encodedReq = Buffer.from(JSON.stringify(req)).toString("base64");
+
+      const result = await command.run("item", cipherId, encodedReq, {});
+
+      expect(result.success).toBe(true);
+      const savedView = cipherService.updateWithServer.mock.calls[0][0] as CipherView;
+      expect(savedView.fields[0].value).toBe("first");
+      expect(savedView.fields[1].value).toBe("second");
+    });
   });
 
   describe("editOrganizationCollection", () => {

--- a/apps/cli/src/commands/edit.command.spec.ts
+++ b/apps/cli/src/commands/edit.command.spec.ts
@@ -196,17 +196,17 @@ describe("EditCommand", () => {
       expect(savedView.fields[1].value).toBe("visible-value");
     });
 
-    it("preserves hidden field values by name when fields are reordered in the request", async () => {
+    it("preserves hidden field values when fields are removed or reordered", async () => {
       const cipher = { id: cipherId, edit: true } as Cipher;
 
       const cipherView = new CipherView();
       cipherView.id = cipherId;
       cipherView.type = CipherType.Login;
       cipherView.viewPassword = false;
-      cipherView.login = Object.assign(new LoginView(), {});
       cipherView.fields = [
-        Object.assign(new FieldView(), { type: FieldType.Hidden, name: "a", value: "real-a" }),
-        Object.assign(new FieldView(), { type: FieldType.Hidden, name: "b", value: "real-b" }),
+        Object.assign(new FieldView(), { type: FieldType.Text, name: "note", value: "a note" }),
+        Object.assign(new FieldView(), { type: FieldType.Hidden, name: "a", value: "value-a" }),
+        Object.assign(new FieldView(), { type: FieldType.Hidden, name: "b", value: "value-b" }),
       ];
 
       cipherService.get.mockResolvedValue(cipher);
@@ -217,73 +217,27 @@ describe("EditCommand", () => {
       billingAccountProfileStateService.hasPremiumFromAnySource$.mockReturnValue(of(true));
       cipherService.updateWithServer.mockImplementation(async (view: any) => view);
 
-      // Request reorders the fields (b before a) relative to the original cipher.
-      const redactedReq: any = {
+      // The text field is dropped and the two hidden fields swap places, so positions no
+      // longer line up with the original cipher.
+      const reorderedReq: any = {
         type: CipherType.Login,
         name: "Renamed item",
-        login: {},
         fields: [
           { type: FieldType.Hidden, name: "b", value: null },
           { type: FieldType.Hidden, name: "a", value: null },
         ],
       };
-      const encodedRedactedReq = Buffer.from(JSON.stringify(redactedReq)).toString("base64");
+      const encodedReorderedReq = Buffer.from(JSON.stringify(reorderedReq)).toString("base64");
 
-      const result = await command.run("item", cipherId, encodedRedactedReq, {});
-
-      expect(result.success).toBe(true);
-      const savedView = cipherService.updateWithServer.mock.calls[0][0] as CipherView;
-      const savedByName = new Map(savedView.fields.map((f) => [f.name, f.value]));
-      expect(savedByName.get("a")).toBe("real-a");
-      expect(savedByName.get("b")).toBe("real-b");
-    });
-
-    it("preserves hidden field values by name when a field is removed from the request", async () => {
-      const cipher = { id: cipherId, edit: true } as Cipher;
-
-      const cipherView = new CipherView();
-      cipherView.id = cipherId;
-      cipherView.type = CipherType.Login;
-      cipherView.viewPassword = false;
-      cipherView.login = Object.assign(new LoginView(), {});
-      cipherView.fields = [
-        Object.assign(new FieldView(), {
-          type: FieldType.Text,
-          name: "note",
-          value: "visible-value",
-        }),
-        Object.assign(new FieldView(), {
-          type: FieldType.Hidden,
-          name: "secret",
-          value: "real-hidden-value",
-        }),
-      ];
-
-      cipherService.get.mockResolvedValue(cipher);
-      cipherService.decrypt.mockResolvedValue(cipherView);
-      cipherAuthorizationService.canEditCipher$.mockReturnValue(of(true));
-      cliRestrictedItemTypesService.isCipherRestricted.mockResolvedValue(false);
-      policyService.policyAppliesToUser$.mockReturnValue(of(false));
-      billingAccountProfileStateService.hasPremiumFromAnySource$.mockReturnValue(of(true));
-      cipherService.updateWithServer.mockImplementation(async (view: any) => view);
-
-      // Request drops the leading "note" field, shifting "secret" from index 1 to index 0.
-      const redactedReq: any = {
-        type: CipherType.Login,
-        name: "Renamed item",
-        login: {},
-        fields: [{ type: FieldType.Hidden, name: "secret", value: null }],
-      };
-      const encodedRedactedReq = Buffer.from(JSON.stringify(redactedReq)).toString("base64");
-
-      const result = await command.run("item", cipherId, encodedRedactedReq, {});
+      const result = await command.run("item", cipherId, encodedReorderedReq, {});
 
       expect(result.success).toBe(true);
       const savedView = cipherService.updateWithServer.mock.calls[0][0] as CipherView;
-      expect(savedView.fields[0].value).toBe("real-hidden-value");
+      expect(savedView.fields[0].value).toBe("value-b");
+      expect(savedView.fields[1].value).toBe("value-a");
     });
 
-    it("applies explicit new password, totp, and hidden field values from a hide-passwords user", async () => {
+    it("does not restore password, totp, or hidden field values the user explicitly set", async () => {
       const cipher = { id: cipherId, edit: true } as Cipher;
 
       const cipherView = new CipherView();
@@ -310,62 +264,21 @@ describe("EditCommand", () => {
       billingAccountProfileStateService.hasPremiumFromAnySource$.mockReturnValue(of(true));
       cipherService.updateWithServer.mockImplementation(async (view: any) => view);
 
-      // A user without permission to view the password/hidden fields can still supply explicit
-      // new values (e.g. via automation rotating a credential); these must not be discarded in
-      // favor of the original values.
       const req: any = {
         type: CipherType.Login,
         name: "Renamed item",
-        login: { password: "new-password", totp: "new-totp" },
-        fields: [{ type: FieldType.Hidden, name: "secret", value: "new-hidden-value" }],
+        login: { password: "rotated-password", totp: "rotated-totp" },
+        fields: [{ type: FieldType.Hidden, name: "secret", value: "user-supplied-value" }],
       };
-      const encodedReq = Buffer.from(JSON.stringify(req)).toString("base64");
+      const encoded = Buffer.from(JSON.stringify(req)).toString("base64");
 
-      const result = await command.run("item", cipherId, encodedReq, {});
+      const result = await command.run("item", cipherId, encoded, {});
 
       expect(result.success).toBe(true);
       const savedView = cipherService.updateWithServer.mock.calls[0][0] as CipherView;
-      expect(savedView.login.password).toBe("new-password");
-      expect(savedView.login.totp).toBe("new-totp");
-      expect(savedView.fields[0].value).toBe("new-hidden-value");
-    });
-
-    it("preserves each hidden field's own value in order when multiple fields share a name", async () => {
-      const cipher = { id: cipherId, edit: true } as Cipher;
-
-      const cipherView = new CipherView();
-      cipherView.id = cipherId;
-      cipherView.type = CipherType.Login;
-      cipherView.viewPassword = false;
-      cipherView.fields = [
-        Object.assign(new FieldView(), { type: FieldType.Hidden, name: "dup", value: "first" }),
-        Object.assign(new FieldView(), { type: FieldType.Hidden, name: "dup", value: "second" }),
-      ];
-
-      cipherService.get.mockResolvedValue(cipher);
-      cipherService.decrypt.mockResolvedValue(cipherView);
-      cipherAuthorizationService.canEditCipher$.mockReturnValue(of(true));
-      cliRestrictedItemTypesService.isCipherRestricted.mockResolvedValue(false);
-      policyService.policyAppliesToUser$.mockReturnValue(of(false));
-      billingAccountProfileStateService.hasPremiumFromAnySource$.mockReturnValue(of(true));
-      cipherService.updateWithServer.mockImplementation(async (view: any) => view);
-
-      const req: any = {
-        type: CipherType.Login,
-        name: "Renamed item",
-        fields: [
-          { type: FieldType.Hidden, name: "dup", value: null },
-          { type: FieldType.Hidden, name: "dup", value: null },
-        ],
-      };
-      const encodedReq = Buffer.from(JSON.stringify(req)).toString("base64");
-
-      const result = await command.run("item", cipherId, encodedReq, {});
-
-      expect(result.success).toBe(true);
-      const savedView = cipherService.updateWithServer.mock.calls[0][0] as CipherView;
-      expect(savedView.fields[0].value).toBe("first");
-      expect(savedView.fields[1].value).toBe("second");
+      expect(savedView.login.password).toBe("rotated-password");
+      expect(savedView.login.totp).toBe("rotated-totp");
+      expect(savedView.fields[0].value).toBe("user-supplied-value");
     });
   });
 

--- a/apps/cli/src/commands/edit.command.ts
+++ b/apps/cli/src/commands/edit.command.ts
@@ -123,11 +123,8 @@ export class EditCommand {
     // hidden field values from `bw get`/`bw list` (they're redacted to `null`, matching how the
     // web/browser/desktop clients disable those fields for editing). If those redacted `null`s
     // are round-tripped back through `bw edit`, preserve the real, already-decrypted values
-    // instead of letting them be overwritten and lost. See PM-16160/PM-33526.
-    //
-    // Only fall back to the original value when the request's value is missing/`null` (i.e. the
-    // redacted sentinel). An explicit non-null value in the request is a deliberate update (e.g.
-    // rotating a password via automation) and must still be applied.
+    // instead of letting them be overwritten and lost. A non-null value is a deliberate write
+    // and is left alone. See PM-16160/PM-33526.
     const canViewPassword = cipherView.viewPassword;
     const originalLoginPassword = cipherView.login?.password;
     const originalLoginTotp = cipherView.login?.totp;

--- a/apps/cli/src/commands/edit.command.ts
+++ b/apps/cli/src/commands/edit.command.ts
@@ -125,32 +125,42 @@ export class EditCommand {
     // are round-tripped back through `bw edit`, preserve the real, already-decrypted values
     // instead of letting them be overwritten and lost. See PM-16160/PM-33526.
     //
-    // Hidden field values are restored by matching on field name rather than array position,
-    // since the request's `fields` array can freely add, remove, or reorder entries relative to
-    // the original cipher (the CLI has no UI to prevent this, unlike the other clients).
-    //
     // Only fall back to the original value when the request's value is missing/`null` (i.e. the
     // redacted sentinel). An explicit non-null value in the request is a deliberate update (e.g.
     // rotating a password via automation) and must still be applied.
     const canViewPassword = cipherView.viewPassword;
     const originalLoginPassword = cipherView.login?.password;
     const originalLoginTotp = cipherView.login?.totp;
-    const originalHiddenFieldValuesByName = new Map(
-      (cipherView.fields ?? [])
-        .filter((f) => f.type === FieldType.Hidden)
-        .map((f) => [f.name, f.value]),
-    );
+    // Values are keyed by field name rather than position so that adding, removing, or
+    // reordering fields in the request can't shift a value onto the wrong field. Fields
+    // sharing a name keep their original relative order.
+    const originalHiddenFieldValues = new Map<string, string[]>();
+    for (const field of cipherView.fields ?? []) {
+      if (field.type === FieldType.Hidden) {
+        const values = originalHiddenFieldValues.get(field.name) ?? [];
+        values.push(field.value);
+        originalHiddenFieldValues.set(field.name, values);
+      }
+    }
 
     cipherView = CipherExport.toView(req, cipherView);
 
     if (!canViewPassword) {
       if (cipherView.login != null) {
-        cipherView.login.password ??= originalLoginPassword;
-        cipherView.login.totp ??= originalLoginTotp;
+        if (cipherView.login.password == null) {
+          cipherView.login.password = originalLoginPassword;
+        }
+        if (cipherView.login.totp == null) {
+          cipherView.login.totp = originalLoginTotp;
+        }
       }
       cipherView.fields?.forEach((field) => {
-        if (field.type === FieldType.Hidden && originalHiddenFieldValuesByName.has(field.name)) {
-          field.value ??= originalHiddenFieldValuesByName.get(field.name);
+        if (field.type !== FieldType.Hidden || field.value != null) {
+          return;
+        }
+        const values = originalHiddenFieldValues.get(field.name);
+        if (values?.length > 0) {
+          field.value = values.shift();
         }
       });
     }

--- a/apps/cli/src/commands/edit.command.ts
+++ b/apps/cli/src/commands/edit.command.ts
@@ -20,6 +20,7 @@ import { OrganizationId } from "@bitwarden/common/types/guid";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { FolderApiServiceAbstraction } from "@bitwarden/common/vault/abstractions/folder/folder-api.service.abstraction";
 import { FolderService } from "@bitwarden/common/vault/abstractions/folder/folder.service.abstraction";
+import { FieldType } from "@bitwarden/common/vault/enums";
 import { Folder } from "@bitwarden/common/vault/models/domain/folder";
 import { CipherAuthorizationService } from "@bitwarden/common/vault/services/cipher-authorization.service";
 import { KeyService } from "@bitwarden/key-management";
@@ -117,7 +118,32 @@ export class EditCommand {
     if (cipherView.isDeleted) {
       return Response.badRequest("You may not edit a deleted item. Use the restore command first.");
     }
+
+    // Users without permission to view passwords never receive the real login password/TOTP or
+    // hidden field values from `bw get`/`bw list` (they're redacted to `null`, matching how the
+    // web/browser/desktop clients disable those fields for editing). If those redacted `null`s
+    // are round-tripped back through `bw edit`, preserve the real, already-decrypted values
+    // instead of letting them be overwritten and lost. See PM-16160/PM-33526.
+    const canViewPassword = cipherView.viewPassword;
+    const originalLoginPassword = cipherView.login?.password;
+    const originalLoginTotp = cipherView.login?.totp;
+    const originalHiddenFieldValues = (cipherView.fields ?? []).map((f) =>
+      f.type === FieldType.Hidden ? f.value : undefined,
+    );
+
     cipherView = CipherExport.toView(req, cipherView);
+
+    if (!canViewPassword) {
+      if (cipherView.login != null) {
+        cipherView.login.password = originalLoginPassword;
+        cipherView.login.totp = originalLoginTotp;
+      }
+      cipherView.fields?.forEach((field, i) => {
+        if (field.type === FieldType.Hidden && originalHiddenFieldValues[i] !== undefined) {
+          field.value = originalHiddenFieldValues[i];
+        }
+      });
+    }
 
     // When a user is editing an archived cipher and does not have premium, automatically unarchive it
     if (cipherView.isArchived && !hasPremium) {

--- a/apps/cli/src/commands/edit.command.ts
+++ b/apps/cli/src/commands/edit.command.ts
@@ -124,23 +124,33 @@ export class EditCommand {
     // web/browser/desktop clients disable those fields for editing). If those redacted `null`s
     // are round-tripped back through `bw edit`, preserve the real, already-decrypted values
     // instead of letting them be overwritten and lost. See PM-16160/PM-33526.
+    //
+    // Hidden field values are restored by matching on field name rather than array position,
+    // since the request's `fields` array can freely add, remove, or reorder entries relative to
+    // the original cipher (the CLI has no UI to prevent this, unlike the other clients).
+    //
+    // Only fall back to the original value when the request's value is missing/`null` (i.e. the
+    // redacted sentinel). An explicit non-null value in the request is a deliberate update (e.g.
+    // rotating a password via automation) and must still be applied.
     const canViewPassword = cipherView.viewPassword;
     const originalLoginPassword = cipherView.login?.password;
     const originalLoginTotp = cipherView.login?.totp;
-    const originalHiddenFieldValues = (cipherView.fields ?? []).map((f) =>
-      f.type === FieldType.Hidden ? f.value : undefined,
+    const originalHiddenFieldValuesByName = new Map(
+      (cipherView.fields ?? [])
+        .filter((f) => f.type === FieldType.Hidden)
+        .map((f) => [f.name, f.value]),
     );
 
     cipherView = CipherExport.toView(req, cipherView);
 
     if (!canViewPassword) {
       if (cipherView.login != null) {
-        cipherView.login.password = originalLoginPassword;
-        cipherView.login.totp = originalLoginTotp;
+        cipherView.login.password ??= originalLoginPassword;
+        cipherView.login.totp ??= originalLoginTotp;
       }
-      cipherView.fields?.forEach((field, i) => {
-        if (field.type === FieldType.Hidden && originalHiddenFieldValues[i] !== undefined) {
-          field.value = originalHiddenFieldValues[i];
+      cipherView.fields?.forEach((field) => {
+        if (field.type === FieldType.Hidden && originalHiddenFieldValuesByName.has(field.name)) {
+          field.value ??= originalHiddenFieldValuesByName.get(field.name);
         }
       });
     }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-41691

## 📔 Objective

Fixes bug QA found where edit item, hidden passwords would then wipe password and TOTP fields
