### PR TITLE
[PM-41539] fix: recognize both Keeper SSO callback URL forms (#22265)

### DIFF
--- a/apps/browser/src/tools/popup/settings/import/browser-keeper-sso-tab-monitor.ts
+++ b/apps/browser/src/tools/popup/settings/import/browser-keeper-sso-tab-monitor.ts
@@ -1,6 +1,6 @@
 import { Injectable } from "@angular/core";
 
-import { KeeperSsoTabMonitor } from "@bitwarden/importer-ui";
+import { isSsoCallbackUrl, KeeperSsoTabMonitor } from "@bitwarden/importer-ui";
 
 import { BrowserApi } from "../../../../platform/browser/browser-api";
 
@@ -12,7 +12,7 @@ export class BrowserKeeperSsoTabMonitor implements KeeperSsoTabMonitor {
     | undefined;
   private activeRemovedListener: ((tabId: number) => void) | undefined;
 
-  async launchAndWaitForToken(ssoUrl: string, callbackUrlPattern: RegExp): Promise<string> {
+  async launchAndWaitForToken(ssoUrl: string): Promise<string> {
     const tab = await BrowserApi.createNewTab(ssoUrl, true);
     this.activeTabId = tab.id;
 
@@ -30,7 +30,7 @@ export class BrowserKeeperSsoTabMonitor implements KeeperSsoTabMonitor {
           return;
         }
 
-        if (!callbackUrlPattern.test(updatedTab.url)) {
+        if (!isSsoCallbackUrl(updatedTab.url, ssoUrl)) {
           return;
         }
 

--- a/libs/importer/src/components/keeper/keeper-direct-import-ui.service.ts
+++ b/libs/importer/src/components/keeper/keeper-direct-import-ui.service.ts
@@ -21,9 +21,6 @@ import {
 import { KeeperAuthDialogComponent } from "./dialog/keeper-auth-dialog.component";
 import { KEEPER_SSO_TAB_MONITOR } from "./services/keeper-sso-tab-monitor";
 
-const SSO_CALLBACK_URL_PATTERN =
-  /^https:\/\/keepersecurity\.[^/]+\/api\/rest\/sso\/saml\/\d+\/saml\/sso/i;
-
 export type KeeperAuthStage =
   | { kind: "idle" }
   | { kind: "selectApproval"; methods: DeviceApprovalChannel[] }
@@ -270,7 +267,7 @@ export class KeeperDirectImportUIService implements Ui {
     // loading state covers the wait, and the tab monitor delivers the token.
     if (this.autoCaptureSsoToken) {
       try {
-        return await this.ssoTabMonitor.launchAndWaitForToken(url, SSO_CALLBACK_URL_PATTERN);
+        return await this.ssoTabMonitor.launchAndWaitForToken(url);
       } finally {
         this.ssoTabMonitor.cancel();
       }
@@ -278,9 +275,7 @@ export class KeeperDirectImportUIService implements Ui {
 
     // Desktop / web: open the IdP and let the user paste the token back.
     this.setStage({ kind: "ssoToken" });
-    void this.ssoTabMonitor
-      .launchAndWaitForToken(url, SSO_CALLBACK_URL_PATTERN)
-      .catch((): void => undefined);
+    void this.ssoTabMonitor.launchAndWaitForToken(url).catch((): void => undefined);
 
     try {
       return await this.waitForUser<string | typeof Cancel>();

--- a/libs/importer/src/components/keeper/services/index.ts
+++ b/libs/importer/src/components/keeper/services/index.ts
@@ -1,1 +1,5 @@
-export { KEEPER_SSO_TAB_MONITOR, KeeperSsoTabMonitor } from "./keeper-sso-tab-monitor";
+export {
+  KEEPER_SSO_TAB_MONITOR,
+  KeeperSsoTabMonitor,
+  isSsoCallbackUrl,
+} from "./keeper-sso-tab-monitor";

--- a/libs/importer/src/components/keeper/services/keeper-sso-tab-monitor.ts
+++ b/libs/importer/src/components/keeper/services/keeper-sso-tab-monitor.ts
@@ -13,23 +13,50 @@ import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/pl
 export interface KeeperSsoTabMonitor {
   /**
    * Opens `ssoUrl` and resolves with the SSO token once the callback page
-   * matching `callbackUrlPattern` has loaded.
+   * matching `isSsoCallbackUrl` has loaded.
    *
    * Implementations that cannot intercept the callback (web, desktop, CLI)
    * should still open the URL, then reject so the caller can fall back to a
    * manual paste flow.
    *
    * @param ssoUrl IdP URL to navigate to.
-   * @param callbackUrlPattern Regex the post-auth landing URL must match.
    * @returns The token extracted from the callback page.
    */
-  launchAndWaitForToken(ssoUrl: string, callbackUrlPattern: RegExp): Promise<string>;
+  launchAndWaitForToken(ssoUrl: string): Promise<string>;
 
   /**
    * Aborts an in-flight `launchAndWaitForToken` call: detaches listeners and
    * closes any tab the monitor opened. Safe to call when nothing is in flight.
    */
   cancel(): void;
+}
+
+/**
+ * Keeper accepts the assertion at two addresses, depending on identity provider setup:
+ *
+ *   Okta catalog app:  https://keepersecurity.com/api/rest/sso/saml/1463918128005127/saml/sso
+ *   Everything else:   https://keepersecurity.com/api/rest/sso/saml/sso/1463918128005127
+ */
+export function isSsoCallbackUrl(candidate: string, ssoUrl: string): boolean {
+  let url: URL;
+  let launched: URL;
+  try {
+    url = new URL(candidate);
+    launched = new URL(ssoUrl);
+  } catch {
+    return false;
+  }
+
+  if (url.origin !== launched.origin) {
+    return false;
+  }
+
+  const path = url.pathname;
+  if (!path.startsWith("/api/rest/sso/saml/")) {
+    return false;
+  }
+
+  return path.includes("/saml/sso/") || path.endsWith("/saml/sso");
 }
 
 class DefaultKeeperSsoTabMonitor implements KeeperSsoTabMonitor {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-41539

## 📔 Objective

The Keeper Direct Importer feature supports Keeper SSO Connect, their equivalent of our Login with SSO feature. The original importer on our side was tested against Okta to validate SSO Connect compatible login. However, Keeper has at least one (possibly multiple) formats for the Redirect URL. The Direct Importer in our client needs to detect when the Redirect URL is open in the browser, and is unable to detect this when an unexpected Redirect URL format is used in SSO Connect.
