### PR TITLE
fix(biometrics): change the biometric persistent encryption migration to handle the case where the aes-cbc-hmac key has a key id

### DIFF
--- a/libs/common/src/key-management/encrypted-migrator/migrations/biometric-persistent-encryption-migration.spec.ts
+++ b/libs/common/src/key-management/encrypted-migrator/migrations/biometric-persistent-encryption-migration.spec.ts
@@ -57,7 +57,7 @@ describe("BiometricPersistentMigration", () => {
       expect(result).toBe("noMigrationNeeded");
     });
 
-    it("should return 'needsMigration' when enrolled key ID does not match current key ID (v2 to v2 migration)", async () => {
+    it("should return 'needsMigration' when enrolled key ID does not match current key ID", async () => {
       mockBiometricStateService.biometricUnlockEnabled$.mockReturnValue(of(true));
       mockBiometricsService.hasPersistentKey.mockResolvedValue(true);
       mockKeyService.userKey$.mockReturnValue(of(mockUserKey));
@@ -69,7 +69,7 @@ describe("BiometricPersistentMigration", () => {
       expect(result).toBe("needsMigration");
     });
 
-    it("should return 'needsMigration' when no enrolled key ID exists (v1 to v2 migration)", async () => {
+    it("should return 'needsMigration' when the user key has a key ID but none is enrolled", async () => {
       mockBiometricStateService.biometricUnlockEnabled$.mockReturnValue(of(true));
       mockBiometricsService.hasPersistentKey.mockResolvedValue(true);
       mockKeyService.userKey$.mockReturnValue(of(mockUserKey));
@@ -81,7 +81,31 @@ describe("BiometricPersistentMigration", () => {
       expect(result).toBe("needsMigration");
     });
 
-    it("should return 'noMigrationNeeded' when enrolled key ID matches current key ID (v2 hot path)", async () => {
+    it("should return 'needsMigration' when a key ID is enrolled but the user key has none", async () => {
+      mockBiometricStateService.biometricUnlockEnabled$.mockReturnValue(of(true));
+      mockBiometricsService.hasPersistentKey.mockResolvedValue(true);
+      mockKeyService.userKey$.mockReturnValue(of(mockUserKey));
+      ((CryptoClient as any).get_key_id_for_symmetric_key as jest.Mock).mockReturnValue(undefined);
+      mockBiometricStateService.getBiometricEnrolledKeyId.mockResolvedValue(mockKeyIdB64);
+
+      const result = await sut.needsMigration(mockUserId);
+
+      expect(result).toBe("needsMigration");
+    });
+
+    it("should return 'noMigrationNeeded' when neither the user key nor the enrollment has a key ID", async () => {
+      mockBiometricStateService.biometricUnlockEnabled$.mockReturnValue(of(true));
+      mockBiometricsService.hasPersistentKey.mockResolvedValue(true);
+      mockKeyService.userKey$.mockReturnValue(of(mockUserKey));
+      ((CryptoClient as any).get_key_id_for_symmetric_key as jest.Mock).mockReturnValue(undefined);
+      mockBiometricStateService.getBiometricEnrolledKeyId.mockResolvedValue(null);
+
+      const result = await sut.needsMigration(mockUserId);
+
+      expect(result).toBe("noMigrationNeeded");
+    });
+
+    it("should return 'noMigrationNeeded' when enrolled key ID matches current key ID", async () => {
       mockBiometricStateService.biometricUnlockEnabled$.mockReturnValue(of(true));
       mockBiometricsService.hasPersistentKey.mockResolvedValue(true);
       mockKeyService.userKey$.mockReturnValue(of(mockUserKey));

--- a/libs/common/src/key-management/encrypted-migrator/migrations/biometric-persistent-encryption-migration.ts
+++ b/libs/common/src/key-management/encrypted-migrator/migrations/biometric-persistent-encryption-migration.ts
@@ -14,7 +14,8 @@ import { EncryptedMigration, MigrationRequirement } from "./encrypted-migration"
 /**
  * This migration re-enrolls biometric stored keys when the user key has changed
  * since the last biometric enrollment. It detects this by comparing the stored
- * enrolled key ID with the current user key's key ID.
+ * enrolled key ID with the current user key's key ID; any mismatch - including a
+ * key ID appearing or disappearing - triggers a re-enrollment.
  */
 export class BiometricPersistentMigration implements EncryptedMigration {
   constructor(
@@ -39,18 +40,11 @@ export class BiometricPersistentMigration implements EncryptedMigration {
     }
 
     await SdkLoadService.Ready;
-    const currentKeyId = CryptoClient.get_key_id_for_symmetric_key(userKey.toEncoded());
+    const keyId = CryptoClient.get_key_id_for_symmetric_key(userKey.toEncoded());
+    const currentKeyId = keyId == null ? null : Utils.fromBufferToB64(keyId);
     const enrolledKeyId = await this.biometricStateService.getBiometricEnrolledKeyId(userId);
-    const isV1ToV2Migration = enrolledKeyId == null && currentKeyId != null;
-    const isV2ToV2Migration =
-      enrolledKeyId != null &&
-      currentKeyId != null &&
-      enrolledKeyId !== Utils.fromBufferToB64(currentKeyId);
-    if (isV1ToV2Migration || isV2ToV2Migration) {
-      return "needsMigration";
-    }
 
-    return "noMigrationNeeded";
+    return currentKeyId === enrolledKeyId ? "noMigrationNeeded" : "needsMigration";
   }
 
   async runMigrations(userId: UserId, _masterPassword: string | null): Promise<void> {


### PR DESCRIPTION
The SDK is adding support for deterministically deriving a key id for an aes-cbc-hmac key. This breaks the biometric persistent encryption migration which assumes that an aes-cbc-hmac (v1 encryption) key has no key id but a xaes-gcm key (v2 encryption) has one.

https://bitwarden.atlassian.net/browse/PM-40816