### PR TITLE
[PM-40337] Fix desktop SSO launch behind pre-authenticating reverse proxy

### DIFF
--- a/apps/desktop/src/app/services/services.module.ts
+++ b/apps/desktop/src/app/services/services.module.ts
@@ -528,6 +528,7 @@ const safeProviders: SafeProvider[] = [
       I18nServiceAbstraction,
       ToastService,
       SsoUrlService,
+      ServerCommunicationConfigService,
     ],
   }),
   safeProvider({

--- a/apps/desktop/src/auth/login/desktop-login-component.service.spec.ts
+++ b/apps/desktop/src/auth/login/desktop-login-component.service.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from "@angular/core/testing";
 import { MockProxy, mock } from "jest-mock-extended";
-import { of } from "rxjs";
+import { of, throwError } from "rxjs";
 
 import { DefaultLoginComponentService } from "@bitwarden/auth/angular";
 import { SsoUrlService } from "@bitwarden/auth/common";
@@ -187,6 +187,18 @@ describe("DesktopLoginComponentService", () => {
         );
         expect(ssoUrlService.buildSsoLaunchConnectorUrl).toHaveBeenCalled();
         expect(ssoUrlService.buildSsoUrl).not.toHaveBeenCalled();
+        expect(platformUtilsService.launchUri).toHaveBeenCalled();
+      });
+
+      it("fails safe to the direct SSO URL when bootstrap detection errors", async () => {
+        serverCommunicationConfigService.needsBootstrap$.mockReturnValue(
+          throwError(() => new Error("detection failed")),
+        );
+
+        await service.redirectToSsoLogin("test@bitwarden.com");
+
+        expect(ssoUrlService.buildSsoUrl).toHaveBeenCalled();
+        expect(ssoUrlService.buildSsoLaunchConnectorUrl).not.toHaveBeenCalled();
         expect(platformUtilsService.launchUri).toHaveBeenCalled();
       });
 

--- a/apps/desktop/src/auth/login/desktop-login-component.service.spec.ts
+++ b/apps/desktop/src/auth/login/desktop-login-component.service.spec.ts
@@ -18,6 +18,7 @@ import { ToastService } from "@bitwarden/components";
 import { PasswordGenerationServiceAbstraction } from "@bitwarden/generator-legacy";
 
 import { ElectronPlatformUtilsService } from "../../platform/services/electron-platform-utils.service";
+import { ServerCommunicationConfigService } from "../../platform/services/server-communication-config/server-communication-config.service";
 
 import { DesktopLoginComponentService } from "./desktop-login-component.service";
 
@@ -44,6 +45,7 @@ describe("DesktopLoginComponentService", () => {
   let i18nService: MockProxy<I18nService>;
   let toastService: MockProxy<ToastService>;
   let ssoUrlService: MockProxy<SsoUrlService>;
+  let serverCommunicationConfigService: MockProxy<ServerCommunicationConfigService>;
 
   beforeEach(() => {
     cryptoFunctionService = mock<CryptoFunctionService>();
@@ -63,6 +65,9 @@ describe("DesktopLoginComponentService", () => {
     toastService = mock<ToastService>();
     platformUtilsService.getClientType.mockReturnValue(ClientType.Desktop);
     ssoUrlService = mock<SsoUrlService>();
+    serverCommunicationConfigService = mock<ServerCommunicationConfigService>();
+    // Default to a non-proxied server so SSO uses the direct fragment URL.
+    serverCommunicationConfigService.needsBootstrap$.mockReturnValue(of(false));
 
     TestBed.configureTestingModule({
       providers: [
@@ -78,6 +83,7 @@ describe("DesktopLoginComponentService", () => {
               i18nService,
               toastService,
               ssoUrlService,
+              serverCommunicationConfigService,
             ),
         },
         { provide: DefaultLoginComponentService, useExisting: DesktopLoginComponentService },
@@ -89,6 +95,10 @@ describe("DesktopLoginComponentService", () => {
         { provide: I18nService, useValue: i18nService },
         { provide: ToastService, useValue: toastService },
         { provide: SsoUrlService, useValue: ssoUrlService },
+        {
+          provide: ServerCommunicationConfigService,
+          useValue: serverCommunicationConfigService,
+        },
       ],
     });
 
@@ -136,6 +146,7 @@ describe("DesktopLoginComponentService", () => {
             codeChallenge,
             state,
             email,
+            false,
             undefined,
           );
         } else {
@@ -143,6 +154,56 @@ describe("DesktopLoginComponentService", () => {
           expect(ssoLoginService.setCodeVerifier).toHaveBeenCalledWith(codeVerifier);
           expect(platformUtilsService.launchUri).toHaveBeenCalled();
         }
+      });
+    });
+
+    describe("pre-auth proxy launch URL selection (packaged app)", () => {
+      beforeEach(() => {
+        (global as any).ipc.platform.isAppImage = false;
+        (global as any).ipc.platform.isDev = false;
+
+        passwordGenerationService.generatePassword.mockResolvedValueOnce("testState");
+        passwordGenerationService.generatePassword.mockResolvedValueOnce("testCodeVerifier");
+        jest.spyOn(Utils, "fromArrayToUrlB64").mockReturnValue("testCodeChallenge");
+      });
+
+      it("uses the direct SSO URL when the server is not behind a pre-auth proxy", async () => {
+        serverCommunicationConfigService.needsBootstrap$.mockReturnValue(of(false));
+
+        await service.redirectToSsoLogin("test@bitwarden.com");
+
+        expect(ssoUrlService.buildSsoUrl).toHaveBeenCalled();
+        expect(ssoUrlService.buildSsoLaunchConnectorUrl).not.toHaveBeenCalled();
+        expect(platformUtilsService.launchUri).toHaveBeenCalled();
+      });
+
+      it("uses the launch connector URL when the server needs bootstrap (pre-auth proxy)", async () => {
+        serverCommunicationConfigService.needsBootstrap$.mockReturnValue(of(true));
+
+        await service.redirectToSsoLogin("test@bitwarden.com");
+
+        expect(serverCommunicationConfigService.needsBootstrap$).toHaveBeenCalledWith(
+          "webvault.bitwarden.com",
+        );
+        expect(ssoUrlService.buildSsoLaunchConnectorUrl).toHaveBeenCalled();
+        expect(ssoUrlService.buildSsoUrl).not.toHaveBeenCalled();
+        expect(platformUtilsService.launchUri).toHaveBeenCalled();
+      });
+
+      it("forwards useSsoLaunchConnector to the localhost callback for AppImage/dev builds", async () => {
+        (global as any).ipc.platform.isAppImage = true;
+        serverCommunicationConfigService.needsBootstrap$.mockReturnValue(of(true));
+
+        await service.redirectToSsoLogin("test@bitwarden.com");
+
+        expect(ipc.platform.localhostCallbackService.openSsoPrompt).toHaveBeenCalledWith(
+          "testCodeChallenge",
+          "testState",
+          "test@bitwarden.com",
+          true,
+          undefined,
+        );
+        expect(platformUtilsService.launchUri).not.toHaveBeenCalled();
       });
     });
   });
@@ -178,6 +239,7 @@ describe("DesktopLoginComponentService", () => {
             codeChallenge,
             state,
             email,
+            false,
             orgSsoIdentifier,
           );
         } else {

--- a/apps/desktop/src/auth/login/desktop-login-component.service.ts
+++ b/apps/desktop/src/auth/login/desktop-login-component.service.ts
@@ -1,7 +1,7 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
 import { Injectable } from "@angular/core";
-import { firstValueFrom } from "rxjs";
+import { catchError, firstValueFrom, of } from "rxjs";
 
 import { DefaultLoginComponentService, LoginComponentService } from "@bitwarden/auth/angular";
 import { DESKTOP_SSO_CALLBACK, SsoUrlService } from "@bitwarden/auth/common";
@@ -63,8 +63,13 @@ export class DesktopLoginComponentService
     // because the proxy only ever sees `GET /` on the wire. Every other server uses the direct URL,
     // so this adds no connector dependency for non-proxied deployments. Both callback mechanisms
     // below (custom-scheme and localhost) share this decision, since it concerns the launch leg.
+    // Fail safe to the direct URL: if bootstrap detection errors (e.g. the SDK client call rejects,
+    // or `Utils.getHostname` returns null for a host `tldts` cannot parse), fall back to `false` so
+    // the SSO launch proceeds via the direct URL instead of aborting the whole flow.
     const useSsoLaunchConnector = await firstValueFrom(
-      this.serverCommunicationConfigService.needsBootstrap$(Utils.getHostname(webVaultUrl)),
+      this.serverCommunicationConfigService
+        .needsBootstrap$(Utils.getHostname(webVaultUrl))
+        .pipe(catchError(() => of(false))),
     );
 
     // For platforms that cannot support a protocol-based (e.g. bitwarden://) callback, we use a localhost callback

--- a/apps/desktop/src/auth/login/desktop-login-component.service.ts
+++ b/apps/desktop/src/auth/login/desktop-login-component.service.ts
@@ -10,8 +10,11 @@ import { CryptoFunctionService } from "@bitwarden/common/key-management/crypto/a
 import { EnvironmentService } from "@bitwarden/common/platform/abstractions/environment.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
+import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { ToastService } from "@bitwarden/components";
 import { PasswordGenerationServiceAbstraction } from "@bitwarden/generator-legacy";
+
+import { ServerCommunicationConfigService } from "../../platform/services/server-communication-config/server-communication-config.service";
 
 @Injectable()
 export class DesktopLoginComponentService
@@ -27,6 +30,7 @@ export class DesktopLoginComponentService
     protected i18nService: I18nService,
     protected toastService: ToastService,
     protected ssoUrlService: SsoUrlService,
+    protected serverCommunicationConfigService: ServerCommunicationConfigService,
   ) {
     super(
       cryptoFunctionService,
@@ -50,25 +54,51 @@ export class DesktopLoginComponentService
     codeChallenge: string,
     orgSsoIdentifier?: string,
   ): Promise<void> {
+    const env = await firstValueFrom(this.environmentService.environment$);
+    const webVaultUrl = env.getWebVaultUrl();
+
+    // A server that requires bootstrap sits behind a pre-authenticating reverse proxy. In that case
+    // SSO must be started via the launch connector so the launch URL is a real path + query that
+    // survives the proxy's sign-in roundtrip; a direct `/#/sso?...` fragment URL would be dropped,
+    // because the proxy only ever sees `GET /` on the wire. Every other server uses the direct URL,
+    // so this adds no connector dependency for non-proxied deployments. Both callback mechanisms
+    // below (custom-scheme and localhost) share this decision, since it concerns the launch leg.
+    const useSsoLaunchConnector = await firstValueFrom(
+      this.serverCommunicationConfigService.needsBootstrap$(Utils.getHostname(webVaultUrl)),
+    );
+
     // For platforms that cannot support a protocol-based (e.g. bitwarden://) callback, we use a localhost callback
     // Otherwise, we launch the SSO component in a browser window and wait for the callback
     if (ipc.platform.isAppImage || ipc.platform.isDev) {
-      await this.initiateSsoThroughLocalhostCallback(email, state, codeChallenge, orgSsoIdentifier);
-    } else {
-      const env = await firstValueFrom(this.environmentService.environment$);
-      const webVaultUrl = env.getWebVaultUrl();
-
-      const redirectUri = DESKTOP_SSO_CALLBACK;
-
-      const ssoWebAppUrl = this.ssoUrlService.buildSsoUrl(
-        webVaultUrl,
-        this.clientType,
-        redirectUri,
+      await this.initiateSsoThroughLocalhostCallback(
+        email,
         state,
         codeChallenge,
-        email,
+        useSsoLaunchConnector,
         orgSsoIdentifier,
       );
+    } else {
+      const redirectUri = DESKTOP_SSO_CALLBACK;
+
+      const ssoWebAppUrl = useSsoLaunchConnector
+        ? this.ssoUrlService.buildSsoLaunchConnectorUrl(
+            webVaultUrl,
+            this.clientType,
+            redirectUri,
+            state,
+            codeChallenge,
+            email,
+            orgSsoIdentifier,
+          )
+        : this.ssoUrlService.buildSsoUrl(
+            webVaultUrl,
+            this.clientType,
+            redirectUri,
+            state,
+            codeChallenge,
+            email,
+            orgSsoIdentifier,
+          );
 
       this.platformUtilsService.launchUri(ssoWebAppUrl);
     }
@@ -78,6 +108,7 @@ export class DesktopLoginComponentService
     email: string,
     state: string,
     challenge: string,
+    useSsoLaunchConnector: boolean,
     orgSsoIdentifier?: string,
   ): Promise<void> {
     try {
@@ -85,6 +116,7 @@ export class DesktopLoginComponentService
         challenge,
         state,
         email,
+        useSsoLaunchConnector,
         orgSsoIdentifier,
       );
       // FIXME: Remove when updating file. Eslint update

--- a/apps/desktop/src/auth/services/sso-localhost-callback.service.ts
+++ b/apps/desktop/src/auth/services/sso-localhost-callback.service.ts
@@ -27,21 +27,25 @@ export class SSOLocalhostCallbackService {
   ) {
     ipcMain.handle(
       "openSsoPrompt",
-      async (event, { codeChallenge, state, email, orgSsoIdentifier }) => {
+      async (event, { codeChallenge, state, email, useSsoLaunchConnector, orgSsoIdentifier }) => {
         // Close any existing server before starting new one
         if (this.currentServer) {
           await this.closeCurrentServer();
         }
 
-        return this.openSsoPrompt(codeChallenge, state, email, orgSsoIdentifier).then(
-          ({ ssoCode, recvState }) => {
-            this.messagingService.send("ssoCallback", {
-              code: ssoCode,
-              state: recvState,
-              redirectUri: this.ssoRedirectUri,
-            });
-          },
-        );
+        return this.openSsoPrompt(
+          codeChallenge,
+          state,
+          email,
+          useSsoLaunchConnector,
+          orgSsoIdentifier,
+        ).then(({ ssoCode, recvState }) => {
+          this.messagingService.send("ssoCallback", {
+            code: ssoCode,
+            state: recvState,
+            redirectUri: this.ssoRedirectUri,
+          });
+        });
       },
     );
   }
@@ -63,6 +67,7 @@ export class SSOLocalhostCallbackService {
     codeChallenge: string,
     state: string,
     email: string,
+    useSsoLaunchConnector: boolean,
     orgSsoIdentifier?: string,
   ): Promise<{ ssoCode: string; recvState: string }> {
     // Use the global environment because the user-scoped environment is not set until authentication is complete.
@@ -121,15 +126,28 @@ export class SSOLocalhostCallbackService {
         }
 
         this.ssoRedirectUri = "http://localhost:" + port;
-        const ssoUrl = this.ssoUrlService.buildSsoUrl(
-          webUrl,
-          ClientType.Desktop,
-          this.ssoRedirectUri,
-          state,
-          codeChallenge,
-          email,
-          orgSsoIdentifier,
-        );
+        // Behind a pre-authenticating reverse proxy, start SSO via the launch connector so the URL
+        // is a real path + query that survives the proxy's sign-in roundtrip (a `/#/sso?...`
+        // fragment would be dropped). Otherwise navigate straight to the SSO hash route.
+        const ssoUrl = useSsoLaunchConnector
+          ? this.ssoUrlService.buildSsoLaunchConnectorUrl(
+              webUrl,
+              ClientType.Desktop,
+              this.ssoRedirectUri,
+              state,
+              codeChallenge,
+              email,
+              orgSsoIdentifier,
+            )
+          : this.ssoUrlService.buildSsoUrl(
+              webUrl,
+              ClientType.Desktop,
+              this.ssoRedirectUri,
+              state,
+              codeChallenge,
+              email,
+              orgSsoIdentifier,
+            );
 
         // Set up error handler before attempting to listen
         callbackServer.once("error", (err: any) => {

--- a/apps/desktop/src/platform/preload.ts
+++ b/apps/desktop/src/platform/preload.ts
@@ -108,9 +108,16 @@ const localhostCallbackService = {
     codeChallenge: string,
     state: string,
     email: string,
+    useSsoLaunchConnector: boolean,
     orgSsoIdentifier?: string,
   ): Promise<void> => {
-    return ipcRenderer.invoke("openSsoPrompt", { codeChallenge, state, email, orgSsoIdentifier });
+    return ipcRenderer.invoke("openSsoPrompt", {
+      codeChallenge,
+      state,
+      email,
+      useSsoLaunchConnector,
+      orgSsoIdentifier,
+    });
   },
 };
 

--- a/apps/web/src/connectors/README.md
+++ b/apps/web/src/connectors/README.md
@@ -127,9 +127,16 @@ All clients ultimately construct a 2FA token as `code|state` (`Duo2faResult.toke
 ## SSO Flow
 
 Unlike the Duo and WebAuthn connectors — which act as intermediaries for all clients including
-mobile — the SSO connector (`sso-connector.html` / `sso.ts`) is only used by **web** and
-**browser extension**. Desktop and CLI receive IdP callbacks directly via deep link or localhost
-HTTP server, bypassing the connector entirely.
+mobile — the SSO **callback** connector (`sso-connector.html` / `sso.ts`) is only used by **web**
+and **browser extension**. Desktop and CLI receive IdP callbacks directly via deep link or localhost
+HTTP server, bypassing the callback connector entirely.
+
+There is a second, distinct SSO connector used only for the **launch** leg: the SSO launch connector
+(`sso-launch-connector.html` / `sso-launch.ts`). It is only relevant when the web vault is served
+behind a pre-authenticating reverse proxy (the `ssoCookieVendor` communication mode) and is used by
+**desktop** to _begin_ an SSO login against such a server. See
+[Desktop launch behind a pre-authenticating reverse proxy](#desktop-launch-behind-a-pre-authenticating-reverse-proxy)
+below.
 
 All clients share a common `SsoComponent` (`libs/auth/src/angular/sso/sso.component.ts`) hosted on
 the web vault that handles org identifier input and IdP redirect. The callback path after IdP
@@ -157,6 +164,31 @@ The browser extension also sets `redirect_uri` to `{webVaultUrl}/sso-connector.h
 5. Background handler (`runtime.background.ts`) validates the referrer is a known vault URL via `isValidVaultReferrer()`
 6. On success, opens an SSO popout window at `popup/index.html#/sso?code={code}&state={state}` via `openSsoAuthResultPopout()` (`auth-popout-window.ts`)
 7. The extension's `SsoComponent` instance completes the token exchange
+
+### Desktop launch behind a pre-authenticating reverse proxy
+
+This concerns the **launch** leg (how desktop opens the browser to _start_ SSO), not the callback.
+It applies only when the server sits behind a pre-authenticating reverse proxy — detected via
+`ServerCommunicationConfigService.needsBootstrap$()` (`desktop-login-component.service.ts`). For
+every other server, desktop launches the browser directly at the `/#/sso?...` hash URL built by
+`SsoUrlService.buildSsoUrl()` and this connector is not involved. If detection errors, the code
+fails safe to that direct URL.
+
+The proxy only ever sees the path + query on the wire (`GET /`), so it can neither capture nor
+restore a URL fragment. Launching directly at `/#/sso?...` would silently drop the SSO parameters
+across the proxy's sign-in roundtrip.
+
+1. Desktop builds the launch URL via `SsoUrlService.buildSsoLaunchConnectorUrl()`, targeting
+   `{webVaultUrl}/sso-launch-connector.html?{clientId,redirectUri,state,codeChallenge,email,identifier}`
+   — a real path + query page the proxy can observe and restore (`sso-url.service.ts`). Both desktop
+   callback mechanisms below use this launch URL; the choice only concerns the launch leg.
+2. Desktop launches the system browser at that URL. If the proxy re-challenges the user, it restores
+   this same path + query after sign-in.
+3. `sso-launch.ts` runs on load and forwards to the SSO hash route via a same-origin, browser-local
+   navigation: `window.location.href = {origin}/#/sso{window.location.search}`, preserving the query
+   string verbatim.
+4. `SsoComponent` handles org identifier input / IdP redirect as usual; the flow then proceeds
+   through one of the desktop callback mechanisms below.
 
 ### Desktop App Callback (bypasses sso-connector.html)
 

--- a/apps/web/src/connectors/sso-launch.html
+++ b/apps/web/src/connectors/sso-launch.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html class="theme_light">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=1010" />
+    <meta name="theme-color" content="#175DDC" />
+
+    <title>Bitwarden</title>
+
+    <link rel="apple-touch-icon" sizes="180x180" href="../images/icons/apple-touch-icon.png" />
+    <link rel="icon" type="image/png" sizes="32x32" href="../images/icons/favicon-32x32.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="../images/icons/favicon-16x16.png" />
+    <link rel="mask-icon" href="../images/icons/safari-pinned-tab.svg" color="#175DDC" />
+    <link rel="manifest" href="../manifest.json" />
+  </head>
+
+  <body class="layout_frontend">
+    <div class="tw-p-8 tw-flex tw-flex-col tw-items-center">
+      <img class="new-logo-themed tw-mb-4" alt="Bitwarden" />
+      <div id="content">
+        <p class="tw-text-center">
+          <i
+            class="bwi bwi-spinner bwi-spin bwi-2x tw-text-muted"
+            title="Loading"
+            aria-hidden="true"
+          ></i>
+        </p>
+      </div>
+    </div>
+  </body>
+</html>

--- a/apps/web/src/connectors/sso-launch.spec.ts
+++ b/apps/web/src/connectors/sso-launch.spec.ts
@@ -1,0 +1,47 @@
+import { initiateSsoLaunch } from "./sso-launch";
+
+describe("sso-launch", () => {
+  let originalLocation: Location;
+
+  const mockLocation = (search: string) => {
+    Object.defineProperty(window, "location", {
+      value: {
+        href: "",
+        origin: "https://test.bitwarden.com",
+        search,
+      },
+      writable: true,
+    });
+  };
+
+  beforeEach(() => {
+    originalLocation = window.location;
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, "location", { value: originalLocation });
+    jest.clearAllMocks();
+  });
+
+  describe("initiateSsoLaunch", () => {
+    it("forwards the query string to the SSO hash route on the same origin", () => {
+      mockLocation(
+        "?clientId=desktop&redirectUri=bitwarden%3A%2F%2Fsso-callback&state=abc&codeChallenge=xyz",
+      );
+
+      initiateSsoLaunch();
+
+      expect(window.location.href).toBe(
+        "https://test.bitwarden.com/#/sso?clientId=desktop&redirectUri=bitwarden%3A%2F%2Fsso-callback&state=abc&codeChallenge=xyz",
+      );
+    });
+
+    it("navigates to the bare SSO route when there is no query string", () => {
+      mockLocation("");
+
+      initiateSsoLaunch();
+
+      expect(window.location.href).toBe("https://test.bitwarden.com/#/sso");
+    });
+  });
+});

--- a/apps/web/src/connectors/sso-launch.ts
+++ b/apps/web/src/connectors/sso-launch.ts
@@ -1,0 +1,27 @@
+/**
+ * SSO launch connector.
+ *
+ * ONLY relevant when the web vault is served behind a pre-authenticating reverse proxy (the
+ * `ssoCookieVendor` communication mode). Native clients (e.g. desktop) launch the system browser
+ * here to *begin* an SSO login.
+ *
+ * The web vault uses hash-based routing, so the SSO screen normally lives at `/#/sso?...`. A native
+ * client cannot launch the browser straight at that fragment URL when a pre-auth proxy is in front:
+ * the proxy only ever sees the path + query on the wire (`GET /`), so when it has to re-challenge
+ * the user it can neither capture nor restore the fragment, and the SSO parameters are silently
+ * dropped across the sign-in roundtrip.
+ *
+ * This connector is a real path + query page (`/sso-launch-connector.html?...`) that the proxy CAN
+ * observe and restore. Once the proxy challenge is satisfied the browser lands back here with its
+ * query string intact, and we hand off to the SSO hash route with a same-origin, browser-local
+ * navigation.
+ */
+export function initiateSsoLaunch() {
+  // Preserve the exact query string (clientId, redirectUri, state, codeChallenge, email, identifier)
+  // and forward it to the SSO hash route. window.location.search includes the leading "?".
+  window.location.href = `${window.location.origin}/#/sso${window.location.search}`;
+}
+
+window.addEventListener("load", () => {
+  initiateSsoLaunch();
+});

--- a/apps/web/webpack.base.js
+++ b/apps/web/webpack.base.js
@@ -147,6 +147,11 @@ module.exports.buildConfig = function buildConfig(params) {
       chunks: ["connectors/redirect", "styles"],
     }),
     new HtmlWebpackPlugin({
+      template: path.resolve(__dirname, "src/connectors/sso-launch.html"),
+      filename: "sso-launch-connector.html",
+      chunks: ["connectors/sso-launch", "styles"],
+    }),
+    new HtmlWebpackPlugin({
       template: path.resolve(__dirname, "src/connectors/duo-redirect.html"),
       filename: "duo-redirect-connector.html",
       chunks: ["connectors/duo-redirect", "styles"],
@@ -392,6 +397,7 @@ module.exports.buildConfig = function buildConfig(params) {
         "src/connectors/webauthn-fallback.ts",
       ),
       "connectors/sso": path.resolve(__dirname, "src/connectors/sso.ts"),
+      "connectors/sso-launch": path.resolve(__dirname, "src/connectors/sso-launch.ts"),
       "connectors/duo-redirect": path.resolve(__dirname, "src/connectors/duo-redirect.ts"),
       "connectors/redirect": path.resolve(__dirname, "src/connectors/redirect.ts"),
       "connectors/platform/proxy-cookie-redirect": path.resolve(

--- a/libs/auth/src/common/services/sso-redirect/sso-url.service.spec.ts
+++ b/libs/auth/src/common/services/sso-redirect/sso-url.service.spec.ts
@@ -115,4 +115,68 @@ describe("SsoUrlService", () => {
     );
     expect(result).toBe(expectedUrl);
   });
+
+  describe("buildSsoLaunchConnectorUrl", () => {
+    it("targets the sso-launch-connector.html page with the same query params as buildSsoUrl", () => {
+      const baseUrl = "https://web-vault.bitwarden.com";
+      const clientType = ClientType.Desktop;
+      const redirectUri = DESKTOP_SSO_CALLBACK;
+      const state = "abc123";
+      const codeChallenge = "xyz789";
+      const email = "test@bitwarden.com";
+
+      const expectedUrl = `${baseUrl}/sso-launch-connector.html?clientId=desktop&redirectUri=${encodeURIComponent(redirectUri)}&state=${state}&codeChallenge=${codeChallenge}&email=${encodeURIComponent(email)}`;
+
+      const result = service.buildSsoLaunchConnectorUrl(
+        baseUrl,
+        clientType,
+        redirectUri,
+        state,
+        codeChallenge,
+        email,
+      );
+      expect(result).toBe(expectedUrl);
+    });
+
+    it("includes the Org SSO Identifier when provided", () => {
+      const baseUrl = "https://web-vault.bitwarden.com";
+      const clientType = ClientType.Desktop;
+      const redirectUri = DESKTOP_SSO_CALLBACK;
+      const state = "abc123";
+      const codeChallenge = "xyz789";
+      const email = "test@bitwarden.com";
+      const orgSsoIdentifier = "test-org";
+
+      const expectedUrl = `${baseUrl}/sso-launch-connector.html?clientId=desktop&redirectUri=${encodeURIComponent(redirectUri)}&state=${state}&codeChallenge=${codeChallenge}&email=${encodeURIComponent(email)}&identifier=${encodeURIComponent(orgSsoIdentifier)}`;
+
+      const result = service.buildSsoLaunchConnectorUrl(
+        baseUrl,
+        clientType,
+        redirectUri,
+        state,
+        codeChallenge,
+        email,
+        orgSsoIdentifier,
+      );
+      expect(result).toBe(expectedUrl);
+    });
+
+    it("only differs from buildSsoUrl by the path (fragment route vs connector page)", () => {
+      const baseUrl = "https://web-vault.bitwarden.com";
+      const args = [
+        baseUrl,
+        ClientType.Desktop,
+        DESKTOP_SSO_CALLBACK,
+        "abc123",
+        "xyz789",
+        "test@bitwarden.com",
+        "test-org",
+      ] as const;
+
+      const direct = service.buildSsoUrl(...args);
+      const connector = service.buildSsoLaunchConnectorUrl(...args);
+
+      expect(direct.replace("/#/sso?", "/sso-launch-connector.html?")).toBe(connector);
+    });
+  });
 });

--- a/libs/auth/src/common/services/sso-redirect/sso-url.service.ts
+++ b/libs/auth/src/common/services/sso-redirect/sso-url.service.ts
@@ -23,9 +23,65 @@ export class SsoUrlService {
     email?: string,
     orgSsoIdentifier?: string,
   ): string {
-    let url =
+    return (
       webAppUrl +
-      "/#/sso?clientId=" +
+      "/#/sso?" +
+      this.buildSsoQueryParams(
+        clientType,
+        redirectUri,
+        state,
+        codeChallenge,
+        email,
+        orgSsoIdentifier,
+      )
+    );
+  }
+
+  /**
+   * Builds a URL that starts SSO via the web app's `sso-launch-connector.html` page rather than
+   * navigating the browser directly to the `/#/sso` hash route.
+   *
+   * The connector is a real path + query page, so the launch URL survives the sign-in roundtrip of
+   * a pre-authenticating reverse proxy, which can neither observe nor restore a URL fragment. Use
+   * this variant for native clients (e.g. desktop) launching the system browser against a server
+   * that sits behind such a proxy. For every other case {@link buildSsoUrl} is sufficient.
+   *
+   * The parameters are identical to {@link buildSsoUrl}; the connector forwards them verbatim to the
+   * SSO hash route once the proxy challenge has been satisfied.
+   */
+  buildSsoLaunchConnectorUrl(
+    webAppUrl: string,
+    clientType: ClientType,
+    redirectUri: string,
+    state: string,
+    codeChallenge: string,
+    email?: string,
+    orgSsoIdentifier?: string,
+  ): string {
+    return (
+      webAppUrl +
+      "/sso-launch-connector.html?" +
+      this.buildSsoQueryParams(
+        clientType,
+        redirectUri,
+        state,
+        codeChallenge,
+        email,
+        orgSsoIdentifier,
+      )
+    );
+  }
+
+  private buildSsoQueryParams(
+    clientType: ClientType,
+    redirectUri: string,
+    state: string,
+    codeChallenge: string,
+    email?: string,
+    orgSsoIdentifier?: string,
+  ): string {
+    let params =
+      "clientId=" +
       clientType +
       "&redirectUri=" +
       encodeURIComponent(redirectUri) +
@@ -35,13 +91,13 @@ export class SsoUrlService {
       codeChallenge;
 
     if (email) {
-      url += "&email=" + encodeURIComponent(email);
+      params += "&email=" + encodeURIComponent(email);
     }
 
     if (orgSsoIdentifier) {
-      url += "&identifier=" + encodeURIComponent(orgSsoIdentifier);
+      params += "&identifier=" + encodeURIComponent(orgSsoIdentifier);
     }
 
-    return url;
+    return params;
   }
 }

--- a/scripts/reverse-proxy-emulator/README.md
+++ b/scripts/reverse-proxy-emulator/README.md
@@ -4,7 +4,7 @@ A local development tool that emulates AWS ELB authentication without real AWS i
 
 ## How it works
 
-- **Bypass paths** (`/api/config`, `/api/cookie-vendor`) are forwarded to the backend unconditionally, because the client needs them before it can authenticate.
+- **Bypass paths** (`/api/config`, `/api/sso-cookie-vendor`) are forwarded to the backend unconditionally, because the client needs them before it can authenticate.
 - All other requests are checked for the `BitwardenLoadBalancerCookie`. Requests that carry the cookie are proxied to the backend.
 - Requests without the cookie are redirected to `/_elb-auth`, which serves a page with a "Continue" button. Clicking the button sets the cookie in the browser and redirects back to the original URL.
 

--- a/scripts/reverse-proxy-emulator/index.ts
+++ b/scripts/reverse-proxy-emulator/index.ts
@@ -83,7 +83,7 @@ function parseCookies(header: string | undefined): Record<string, string> {
   );
 }
 
-const BYPASS_PATHS = ["/api/config", "/api/cookie-vendor"];
+const BYPASS_PATHS = ["/api/config", "/api/sso-cookie-vendor"];
 
 function isBypassPath(urlPath: string): boolean {
   return BYPASS_PATHS.some((bp) => urlPath === bp || urlPath.startsWith(bp + "/"));


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-40337

## 📔 Objective

Desktop SSO does not work when the self-hosted server sits behind a pre-authenticating reverse proxy (e.g. Azure Entra Application Proxy).

The desktop launches the system browser at a **fragment** URL (`<vault>/#/sso?...`, built by `SsoUrlService.buildSsoUrl`). Because the web vault uses hash-based routing, the SSO parameters live after the `#` and are never sent on the wire — the browser only issues `GET /`. When the proxy has to re-challenge the user, it can only serialize the path + query it actually received, so the fragment is lost across the sign-in roundtrip. The browser lands back on the bare vault URL with an empty hash, the SPA shows the normal login page, and SSO silently never starts.

This adds an **`sso-launch-connector.html`** page: a real path + query URL that the proxy *can* observe and restore. After the proxy challenge is satisfied the browser returns to the connector with its query string intact, and the connector hands off to the `/#/sso` hash route via a same-origin, browser-local navigation (the same technique the existing `proxy-cookie-redirect` connector uses).

Both desktop launch paths use it, gated on whether the server requires bootstrap (i.e. is behind such a proxy):
- **Packaged builds** (custom-scheme `bitwarden://` callback) — `DesktopLoginComponentService`.
- **AppImage / dev builds** (localhost callback) — the `useSsoLaunchConnector` flag is threaded through the `openSsoPrompt` IPC to `SSOLocalhostCallbackService`, since that path builds its URL in the main process.

Non-proxied servers keep the direct `/#/sso` fragment URL, so there is no behavior change and no new connector dependency for them. The gate reads `ServerCommunicationConfigService.needsBootstrap$` and fails safe to the direct URL.

### Notes for reviewers
- `buildSsoUrl` output is unchanged; the connector variant (`buildSsoLaunchConnectorUrl`) shares a private query-string builder, so existing SSO entry URLs for web/browser/CLI are untouched.
- **Version skew:** the connector is a web asset, so a pre-auth server must be on a build that includes it. The client gate only selects the connector for servers advertising `ssoCookieVendor` bootstrap, so ordinary (including older self-hosted) servers are unaffected.
- **Not covered by automated tests:** the connector surviving a real Application Proxy roundtrip requires the App Proxy test environment (INT-338) to verify end to end.

## 📸 Screenshots

<!-- No UI changes (connector is a headless redirect page). -->

- [ ] TODO: capture desktop SSO completing against the INT-338 Azure App Proxy environment (before/after).