### PR TITLE
[PM-41867] add client side changes for attachment event log

### DIFF
--- a/apps/web/src/app/dirt/event-logs/services/event.service.ts
+++ b/apps/web/src/app/dirt/event-logs/services/event.service.ts
@@ -159,6 +159,13 @@ export class EventService {
           this.getShortId(ev.cipherId),
         );
         break;
+      case EventType.Cipher_AttachmentDownloaded:
+        msg = this.i18nService.t("downloadedAttachmentForItem", this.formatCipherId(ev, options));
+        humanReadableMsg = this.i18nService.t(
+          "downloadedAttachmentForItem",
+          this.getShortId(ev.cipherId),
+        );
+        break;
       case EventType.Cipher_Shared:
         msg = this.i18nService.t("movedItemIdToOrg", this.formatCipherId(ev, options));
         humanReadableMsg = this.i18nService.t("movedItemIdToOrg", this.getShortId(ev.cipherId));

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -6049,6 +6049,15 @@
       }
     }
   },
+  "downloadedAttachmentForItem": {
+    "message": "Downloaded attachment for item $ID$.",
+    "placeholders": {
+      "id": {
+        "content": "$1",
+        "example": "Google"
+      }
+    }
+  },
   "editedCollectionsForItem": {
     "message": "Edited collections for item $ID$.",
     "placeholders": {

--- a/libs/common/src/dirt/event-logs/enums/event-type.enum.ts
+++ b/libs/common/src/dirt/event-logs/enums/event-type.enum.ts
@@ -48,6 +48,7 @@ export enum EventType {
   Cipher_ClientToggledIbanVisible = 1130,
   Cipher_ClientCopiedNationalIdentificationNumber = 1131,
   Cipher_ClientToggledNationalIdentificationNumberVisible = 1132,
+  Cipher_AttachmentDownloaded = 1133,
 
   Collection_Created = 1300,
   Collection_Updated = 1301,


### PR DESCRIPTION
## 🎟️ Tracking

this is tracking a parallel server change: https://github.com/bitwarden/server/pull/8190

## 📔 Objective

please see https://github.com/bitwarden/server/pull/8190

## 📸 Screenshots
<img width="1442" height="446" alt="Screenshot 2026-08-11 at 12 36 54 PM" src="https://github.com/user-attachments/assets/fd8eb0b9-b9f0-49d3-89e5-3dffacd36b3c" />