### PR TITLE
[PM-40327] feat: Wire the popup list table's toolbar filters to VaultPopupListFiltersService

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -432,7 +432,10 @@
   "noFoldersAdded": {
     "message": "No folders added"
   },
-  "createFoldersToOrganize": {
+  "noFoldersLabel": {
+    "message": "No folders"
+  },
+"createFoldersToOrganize": {
     "message": "Create folders to organize your vault items"
   },
   "deleteFolderPermanently": {
@@ -7759,7 +7762,7 @@
   },
   "weakPasswordsDescription": {
     "message": "These passwords can be easily guessed because they are too short or simple. Strengthen them by making them more complex."
-  },    
+  },
   "reusedPasswordsTitle": {
     "message": "Reused passwords"
   },

--- a/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-filter-chip.directive.ts
+++ b/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-filter-chip.directive.ts
@@ -2,7 +2,7 @@ import { DestroyRef, Directive, OnInit, effect, inject, input, untracked } from 
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { FormControl } from "@angular/forms";
 
-import { FILTER_CONTROL } from "@bitwarden/components";
+import { ChipFilterOption, FILTER_CONTROL } from "@bitwarden/components";
 
 import {
   PopupListFilter,
@@ -11,6 +11,9 @@ import {
 
 /** The `filterForm` controls a chip can drive. */
 export type VaultFilterKey = keyof PopupListFilter;
+
+/** A filter value that carries an id — every dimension except `cipherType`, which is a scalar. */
+type IdentifiableFilterValue = { id?: string | null };
 
 /**
  * Bridges a `bit-filter-menu` chip to a control on `VaultPopupListFiltersService.filterForm`.
@@ -26,7 +29,7 @@ export type VaultFilterKey = keyof PopupListFilter;
  *
  * @example
  * ```html
- * <bit-filter-menu key="cipherType" bitVaultFilterChip="cipherType" placeholderText="Type">
+ * <bit-filter-menu key="cipherType" bitVaultFilterChip="cipherType" [filterOptions]="cipherTypeOptions()">
  * ```
  */
 @Directive({
@@ -42,6 +45,18 @@ export class VaultFilterChipDirective implements OnInit {
    * a fixed control, so this is a static binding rather than a reactive one.
    */
   readonly key = input.required<VaultFilterKey>({ alias: "bitVaultFilterChip" });
+
+  /**
+   * The chip's options, so a form value can be resolved to the instance the options actually hold.
+   *
+   * The chip matches its options by reference (`FilterMenuComponent.isSelected` compares with
+   * `===`), but the form's value is routinely an equal-but-distinct object: the view cache restores
+   * "My vault" as a fresh `Organization`, and `getAllFoldersNested` rebuilds a `FolderView` copy per
+   * emission — so `folders$` re-emits new instances on any cipher change. Seeding the raw value
+   * would leave the chip active (dismiss button, applied-count berry) but label-less, with nothing
+   * marked selected in the menu or the responsive dialog.
+   */
+  readonly filterOptions = input<ChipFilterOption<unknown>[]>([]);
 
   /**
    * Guards against the two directions echoing each other: whichever side is mid-write marks itself
@@ -61,6 +76,27 @@ export class VaultFilterChipDirective implements OnInit {
     return this.filtersService.filterForm.controls[this.key()] as FormControl<
       PopupListFilter[VaultFilterKey] | null
     >;
+  }
+
+  /**
+   * The option instance equal to `value`, matched on `id` for the object-valued dimensions and by
+   * identity for `cipherType`. Falls back to `value` itself when no option matches — the org filter
+   * can name a folder the current list no longer contains, and clearing it here would fight
+   * `validateOrganizationChange`, which owns that reset.
+   */
+  private resolveToOption(value: unknown): unknown {
+    if (value == null) {
+      return value;
+    }
+    if (typeof value !== "object") {
+      return value;
+    }
+    const id = (value as IdentifiableFilterValue).id;
+    // "Items with no folder" has a falsy id, so match on the property's presence rather than truthiness.
+    const match = this.filterOptions().find(
+      (option) => (option.value as IdentifiableFilterValue | undefined)?.id === id,
+    );
+    return match ? match.value : value;
   }
 
   constructor() {
@@ -85,6 +121,24 @@ export class VaultFilterChipDirective implements OnInit {
         }
       });
     });
+
+    // Re-resolve the chip onto the current option instances whenever the options are rebuilt, so a
+    // sync or item edit doesn't silently drop the chip's visible selection while the rows stay
+    // filtered. Reads `filterOptions` as the dependency; the form value is read untracked.
+    effect(() => {
+      this.filterOptions();
+
+      untracked(() => {
+        const value = this.formControl.value;
+        if (value == null) {
+          return;
+        }
+        const resolved = this.resolveToOption(value);
+        if (resolved !== this.control.value()) {
+          this.control.setValue(resolved);
+        }
+      });
+    });
   }
 
   ngOnInit() {
@@ -92,7 +146,7 @@ export class VaultFilterChipDirective implements OnInit {
 
     // Seed the chip from the form: it may already hold filters restored from the view cache before
     // this chip ever existed.
-    this.control.setValue(formControl.value ?? null);
+    this.control.setValue(this.resolveToOption(formControl.value ?? null));
 
     // Form → chip, for writes from outside the table — the vault header's own filter UI, the
     // organization-change validation that resets collection/folder, or `resetFilterForm()`.
@@ -102,7 +156,7 @@ export class VaultFilterChipDirective implements OnInit {
       }
       this.syncing = true;
       try {
-        this.control.setValue(value ?? null);
+        this.control.setValue(this.resolveToOption(value ?? null));
       } finally {
         this.syncing = false;
       }

--- a/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-filter-chip.directive.ts
+++ b/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-filter-chip.directive.ts
@@ -1,0 +1,111 @@
+import { DestroyRef, Directive, OnInit, effect, inject, input, untracked } from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
+import { FormControl } from "@angular/forms";
+
+import { FILTER_CONTROL } from "@bitwarden/components";
+
+import {
+  PopupListFilter,
+  VaultPopupListFiltersService,
+} from "../../../services/vault-popup-list-filters.service";
+
+/** The `filterForm` controls a chip can drive. */
+export type VaultFilterKey = keyof PopupListFilter;
+
+/**
+ * Bridges a `bit-filter-menu` chip to a control on `VaultPopupListFiltersService.filterForm`.
+ *
+ * The chips own their selection (they're not `ControlValueAccessor`s), but the popup's filter state
+ * has to stay on `filterForm` — `filterFunction$`, the view-cache serialization, and the other
+ * filter option streams all read it, and the non-table vault header still writes it. So rather than
+ * moving state ownership onto the chips, this keeps the form authoritative and syncs both ways:
+ * the form seeds the chip, and the chip's edits are written back.
+ *
+ * Values stay whole domain objects (`Organization`, `CollectionView`, `FolderView`) to match
+ * `PopupListFilter`, so `bit-filter-option [value]` binds the same objects the form holds.
+ *
+ * @example
+ * ```html
+ * <bit-filter-menu key="cipherType" bitVaultFilterChip="cipherType" placeholderText="Type">
+ * ```
+ */
+@Directive({
+  selector: "bit-filter-menu[bitVaultFilterChip]",
+})
+export class VaultFilterChipDirective implements OnInit {
+  private readonly filtersService = inject(VaultPopupListFiltersService);
+  private readonly control = inject(FILTER_CONTROL);
+  private readonly destroyRef = inject(DestroyRef);
+
+  /**
+   * The `filterForm` control this chip drives. Read once in `ngOnInit` — a chip is declared against
+   * a fixed control, so this is a static binding rather than a reactive one.
+   */
+  readonly key = input.required<VaultFilterKey>({ alias: "bitVaultFilterChip" });
+
+  /**
+   * Guards against the two directions echoing each other: whichever side is mid-write marks itself
+   * so the resulting notification from the other is ignored rather than bounced back.
+   */
+  private syncing = false;
+
+  /**
+   * The form control this chip drives, widened to the union of every filter value.
+   *
+   * `filterForm.controls[key]` is typed per-key, so indexing it with the `VaultFilterKey` union
+   * gives a union of `FormControl`s whose `setValue` parameter narrows to `never`. The chip is
+   * value-agnostic by design (it round-trips whatever object it was seeded with), so a single
+   * widened control type is the accurate signature here.
+   */
+  private get formControl(): FormControl<PopupListFilter[VaultFilterKey] | null> {
+    return this.filtersService.filterForm.controls[this.key()] as FormControl<
+      PopupListFilter[VaultFilterKey] | null
+    >;
+  }
+
+  constructor() {
+    // Chip → form. `value` is a signal, so this fires on every selection the user makes, whether in
+    // the chip's popover menu or in the responsive filter dialog (both drive the same control).
+    effect(() => {
+      const value = this.control.value() ?? null;
+
+      untracked(() => {
+        if (this.syncing) {
+          return;
+        }
+        const formControl = this.formControl;
+        if (formControl.value === value) {
+          return;
+        }
+        this.syncing = true;
+        try {
+          formControl.setValue(value as PopupListFilter[VaultFilterKey]);
+        } finally {
+          this.syncing = false;
+        }
+      });
+    });
+  }
+
+  ngOnInit() {
+    const formControl = this.formControl;
+
+    // Seed the chip from the form: it may already hold filters restored from the view cache before
+    // this chip ever existed.
+    this.control.setValue(formControl.value ?? null);
+
+    // Form → chip, for writes from outside the table — the vault header's own filter UI, the
+    // organization-change validation that resets collection/folder, or `resetFilterForm()`.
+    formControl.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((value) => {
+      if (this.syncing) {
+        return;
+      }
+      this.syncing = true;
+      try {
+        this.control.setValue(value ?? null);
+      } finally {
+        this.syncing = false;
+      }
+    });
+  }
+}

--- a/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.html
+++ b/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.html
@@ -31,6 +31,7 @@
     <bit-filter-menu
       key="cipherType"
       bitVaultFilterChip="cipherType"
+      [filterOptions]="cipherTypeOptions()"
       [placeholderText]="'type' | i18n"
       [unsetLabel]="'all' | i18n"
     >
@@ -43,6 +44,7 @@
       <bit-filter-menu
         key="organization"
         bitVaultFilterChip="organization"
+        [filterOptions]="organizationOptions()"
         [placeholderText]="'vault' | vfo1I18n: 'vaults'"
         [unsetLabel]="'all' | i18n"
       >
@@ -56,6 +58,7 @@
       <bit-filter-menu
         key="collection"
         bitVaultFilterChip="collection"
+        [filterOptions]="collectionOptions()"
         [placeholderText]="'collection' | vfo1I18n: 'sharedFolders'"
         [unsetLabel]="'all' | i18n"
       >
@@ -69,6 +72,7 @@
       <bit-filter-menu
         key="folder"
         bitVaultFilterChip="folder"
+        [filterOptions]="folderOptions()"
         [placeholderText]="'folder' | vfo1I18n: 'myFolders'"
         [unsetLabel]="'all' | i18n"
       >

--- a/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.html
+++ b/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.html
@@ -36,7 +36,9 @@
       [unsetLabel]="'all' | i18n"
     >
       @for (option of cipherTypeOptions(); track option.value) {
-        <bit-filter-option [value]="option.value">{{ option.label }}</bit-filter-option>
+        <bit-filter-option [value]="option.value" [count]="cipherTypeCount(option.value)">{{
+          option.label
+        }}</bit-filter-option>
       }
     </bit-filter-menu>
 
@@ -49,7 +51,9 @@
         [unsetLabel]="'all' | i18n"
       >
         @for (option of organizationOptions(); track option.value.id) {
-          <bit-filter-option [value]="option.value">{{ option.label }}</bit-filter-option>
+          <bit-filter-option [value]="option.value" [count]="organizationCount(option.value)">{{
+            option.label
+          }}</bit-filter-option>
         }
       </bit-filter-menu>
     }
@@ -63,7 +67,9 @@
         [unsetLabel]="'all' | i18n"
       >
         @for (option of collectionOptions(); track option.value.id) {
-          <bit-filter-option [value]="option.value">{{ option.label }}</bit-filter-option>
+          <bit-filter-option [value]="option.value" [count]="collectionCount(option.value)">{{
+            option.label
+          }}</bit-filter-option>
         }
       </bit-filter-menu>
     }
@@ -77,7 +83,9 @@
         [unsetLabel]="'all' | i18n"
       >
         @for (option of folderOptions(); track option.value.id) {
-          <bit-filter-option [value]="option.value">{{ option.label }}</bit-filter-option>
+          <bit-filter-option [value]="option.value" [count]="folderCount(option.value)">{{
+            option.label
+          }}</bit-filter-option>
         }
       </bit-filter-menu>
     }

--- a/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.html
+++ b/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.html
@@ -103,7 +103,7 @@
             bitIconButton="bwi-external-link"
             size="small"
             (click)="launchCipher(row.cipher)"
-            [label]="'launchWebsite' | i18n"
+            [label]="'launchWebsiteName' | i18n: row.cipher.name"
           ></button>
         }
         <app-item-copy-actions [cipher]="row.cipher"></app-item-copy-actions>
@@ -116,7 +116,7 @@
     </bit-cell>
   </bit-column>
 
-  <bit-row-group [match]="isAutofill">
+  <bit-row-group collapsible [match]="isAutofill">
     <div class="tw-flex tw-gap-2 tw-items-center">
       {{ autofillSectionKey() | i18n }}
       @if (showRefresh) {
@@ -124,7 +124,7 @@
           bitIconButton="bwi-refresh"
           type="button"
           size="small"
-          (click)="refreshCurrentTab()"
+          (click)="$event.stopPropagation(); refreshCurrentTab()"
           [label]="'refresh' | i18n"
         ></button>
       }

--- a/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.html
+++ b/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.html
@@ -116,7 +116,7 @@
     </bit-cell>
   </bit-column>
 
-  <bit-row-group collapsible [match]="isAutofill">
+  <bit-row-group [match]="isAutofill">
     <div class="tw-flex tw-gap-2 tw-items-center">
       {{ autofillSectionKey() | i18n }}
       @if (showRefresh) {
@@ -124,7 +124,7 @@
           bitIconButton="bwi-refresh"
           type="button"
           size="small"
-          (click)="$event.stopPropagation(); refreshCurrentTab()"
+          (click)="refreshCurrentTab()"
           [label]="'refresh' | i18n"
         ></button>
       }

--- a/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.html
+++ b/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.html
@@ -201,7 +201,7 @@
     </bit-cell>
   </bit-column>
 
-  <bit-row-group [match]="isAutofill">
+  <bit-row-group collapsible [match]="isAutofill">
     <div class="tw-flex tw-gap-2 tw-items-center">
       {{ autofillSectionKey() | i18n }}
       @if (showRefresh) {

--- a/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.html
+++ b/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.html
@@ -103,7 +103,7 @@
             bitIconButton="bwi-external-link"
             size="small"
             (click)="launchCipher(row.cipher)"
-            [label]="'launchWebsiteName' | i18n: row.cipher.name"
+            [label]="'launchWebsiteForName' | i18n: row.cipher.name"
           ></button>
         }
         <app-item-copy-actions [cipher]="row.cipher"></app-item-copy-actions>

--- a/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.html
+++ b/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.html
@@ -82,12 +82,26 @@
       </bit-filter-menu>
     }
   </bit-table-toolbar>
-  <!-- Zeroes `bit-no-items`' built-in top padding, which would offset the centering. -->
-  <bit-no-items slot="empty" class="tw-mx-3 tw-my-auto [&>div]:!tw-pt-0">
+  <!--
+    Zeroes `bit-no-items`' built-in top padding, which would offset the centering.
+
+    A suspended organization filter yields no rows, so it lands here rather than replacing the
+    table: unmounting would take the toolbar with it and leave the filter stuck with no way to
+    clear it.
+  -->
+  <bit-no-items
+    slot="empty"
+    class="tw-mx-3 tw-my-auto [&>div]:!tw-pt-0"
+    [icon]="showDeactivatedOrg() ? deactivatedIcon : noResultsIcon"
+  >
     <span slot="title">{{
-      (hasSearchText() ? "noItemsMatchSearch" : "nothingToShow") | i18n
+      showDeactivatedOrg()
+        ? ("organizationIsDeactivated" | i18n)
+        : ((hasSearchText() ? "noItemsMatchSearch" : "nothingToShow") | i18n)
     }}</span>
-    @if (hasSearchText()) {
+    @if (showDeactivatedOrg()) {
+      <span slot="description">{{ "contactYourOrgAdmin" | i18n }}</span>
+    } @else if (hasSearchText()) {
       <span slot="description">{{ "clearFiltersOrTryAnother" | i18n }}</span>
     }
   </bit-no-items>

--- a/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.html
+++ b/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.html
@@ -65,6 +65,7 @@
         [filterOptions]="collectionOptions()"
         [placeholderText]="'collection' | vfo1I18n: 'sharedFolders'"
         [unsetLabel]="'all' | i18n"
+        multiple
       >
         @for (option of collectionOptions(); track option.value.id) {
           <bit-filter-option [value]="option.value" [count]="collectionCount(option.value)">{{
@@ -80,7 +81,7 @@
         bitVaultFilterChip="folder"
         [filterOptions]="folderOptions()"
         [placeholderText]="'folder' | vfo1I18n: 'myFolders'"
-        [unsetLabel]="'all' | i18n"
+        multiple
       >
         @for (option of folderOptions(); track option.value.id) {
           <bit-filter-option [value]="option.value" [count]="folderCount(option.value)">{{

--- a/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.html
+++ b/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.html
@@ -76,7 +76,7 @@
         [placeholderText]="'folder' | vfo1I18n: 'myFolders'"
         [unsetLabel]="'all' | i18n"
       >
-        @for (option of folderOptions(); track option.label) {
+        @for (option of folderOptions(); track option.value.id) {
           <bit-filter-option [value]="option.value">{{ option.label }}</bit-filter-option>
         }
       </bit-filter-menu>

--- a/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.html
+++ b/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.html
@@ -19,6 +19,64 @@
       (ngModelChange)="onSearchTextChanged()"
       appAutofocus
     ></bit-search>
+
+    <!--
+      The dimension chips. Each drives its `filterForm` control through
+      `bitVaultFilterChip`, which keeps the form authoritative rather than moving filter
+      state onto the chips — `filterFunction$` (applied upstream in
+      `VaultPopupItemsService`) reads the form, so a selection here re-narrows the rows
+      the table receives. Deliberately no Favorites toggle: favorites are their own
+      section rather than a filter.
+    -->
+    <bit-filter-menu
+      key="cipherType"
+      bitVaultFilterChip="cipherType"
+      [placeholderText]="'type' | i18n"
+      [unsetLabel]="'all' | i18n"
+    >
+      @for (option of cipherTypeOptions(); track option.value) {
+        <bit-filter-option [value]="option.value">{{ option.label }}</bit-filter-option>
+      }
+    </bit-filter-menu>
+
+    @if (organizationOptions().length) {
+      <bit-filter-menu
+        key="organization"
+        bitVaultFilterChip="organization"
+        [placeholderText]="'vault' | vfo1I18n: 'vaults'"
+        [unsetLabel]="'all' | i18n"
+      >
+        @for (option of organizationOptions(); track option.value.id) {
+          <bit-filter-option [value]="option.value">{{ option.label }}</bit-filter-option>
+        }
+      </bit-filter-menu>
+    }
+
+    @if (collectionOptions().length) {
+      <bit-filter-menu
+        key="collection"
+        bitVaultFilterChip="collection"
+        [placeholderText]="'collection' | vfo1I18n: 'sharedFolders'"
+        [unsetLabel]="'all' | i18n"
+      >
+        @for (option of collectionOptions(); track option.value.id) {
+          <bit-filter-option [value]="option.value">{{ option.label }}</bit-filter-option>
+        }
+      </bit-filter-menu>
+    }
+
+    @if (folderOptions().length) {
+      <bit-filter-menu
+        key="folder"
+        bitVaultFilterChip="folder"
+        [placeholderText]="'folder' | vfo1I18n: 'myFolders'"
+        [unsetLabel]="'all' | i18n"
+      >
+        @for (option of folderOptions(); track option.label) {
+          <bit-filter-option [value]="option.value">{{ option.label }}</bit-filter-option>
+        }
+      </bit-filter-menu>
+    }
   </bit-table-toolbar>
   <!-- Zeroes `bit-no-items`' built-in top padding, which would offset the centering. -->
   <bit-no-items slot="empty" class="tw-mx-3 tw-my-auto [&>div]:!tw-pt-0">

--- a/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.spec.ts
+++ b/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.spec.ts
@@ -157,7 +157,7 @@ describe("VaultPopupListTableComponent", () => {
           provide: StateProvider,
           useValue: {
             getUserState$: () => of({ hasSeen: true, hasDismissed: true }),
-            getUser: () => ({ update: async () => {} }),
+            getUser: () => ({ update: async () => { } }),
           },
         },
         { provide: RestrictedItemTypesService, useValue: { restricted$: of([]) } },

--- a/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.spec.ts
+++ b/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.spec.ts
@@ -1,3 +1,4 @@
+import { LiveAnnouncer } from "@angular/cdk/a11y";
 import { ElementRef } from "@angular/core";
 import { ComponentFixture, TestBed, fakeAsync, tick } from "@angular/core/testing";
 import { FormControl, FormGroup } from "@angular/forms";
@@ -89,6 +90,7 @@ describe("VaultPopupListTableComponent", () => {
   const searchText$ = new BehaviorSubject<string>("");
   const hasSearchText$ = new BehaviorSubject<boolean>(false);
   const showDeactivatedOrg$ = new BehaviorSubject<boolean>(false);
+  const liveAnnouncer = mock<LiveAnnouncer>();
   const clickItemsToAutofillVaultView$ = new BehaviorSubject<boolean>(true);
 
   const configService = {
@@ -170,6 +172,7 @@ describe("VaultPopupListTableComponent", () => {
     collections$.next([]);
     folders$.next([]);
     clickItemsToAutofillVaultView$.next(true);
+    liveAnnouncer.announce.mockClear();
 
     await TestBed.configureTestingModule({
       imports: [VaultPopupListTableComponent, NoopAnimationsModule, RouterTestingModule],
@@ -183,6 +186,7 @@ describe("VaultPopupListTableComponent", () => {
         { provide: VaultPopupListFiltersService, useValue: vaultPopupListFiltersService },
         { provide: CompactModeService, useValue: compactModeService },
         { provide: I18nService, useValue: mock<I18nService>({ t: (k: string) => k }) },
+        { provide: LiveAnnouncer, useValue: liveAnnouncer },
         { provide: CipherService, useValue: mock<CipherService>() },
         { provide: AccountService, useValue: { activeAccount$: of({ id: "test-user-id" }) } },
         { provide: PasswordRepromptService, useValue: mock<PasswordRepromptService>() },
@@ -294,6 +298,48 @@ describe("VaultPopupListTableComponent", () => {
 
         expect(component["rows"]()).toHaveLength(1);
         expect(fixture.nativeElement.textContent).not.toContain("organizationIsDeactivated");
+      });
+
+      it("announces the notice, which the empty slot can't carry a live region for", () => {
+        expect(liveAnnouncer.announce).toHaveBeenCalledWith("organizationIsDeactivated", "polite");
+      });
+    });
+
+    /**
+     * The table stamps the empty slot with a structural `@if`, so a live region inside it would
+     * enter the DOM alongside its content and go unannounced. These cover the imperative
+     * announcement that replaces it.
+     */
+    describe("announcements", () => {
+      it("announces the search-specific copy when a search matches nothing", () => {
+        hasSearchText$.next(true);
+        filteredCiphers$.next([]);
+        fixture.detectChanges();
+
+        expect(liveAnnouncer.announce).toHaveBeenCalledWith("noItemsMatchSearch", "polite");
+      });
+
+      it("announces the generic copy when there is nothing to show", () => {
+        hasSearchText$.next(false);
+        filteredCiphers$.next([]);
+        fixture.detectChanges();
+
+        expect(liveAnnouncer.announce).toHaveBeenCalledWith("nothingToShow", "polite");
+      });
+
+      it("stays silent while rows are rendering", () => {
+        filteredCiphers$.next([makeCipher({})]);
+        fixture.detectChanges();
+
+        expect(liveAnnouncer.announce).not.toHaveBeenCalled();
+      });
+
+      it("stays silent while loading, so the empty copy isn't announced before rows arrive", () => {
+        loading$.next(true);
+        filteredCiphers$.next([]);
+        fixture.detectChanges();
+
+        expect(liveAnnouncer.announce).not.toHaveBeenCalled();
       });
     });
   });

--- a/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.spec.ts
+++ b/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.spec.ts
@@ -43,7 +43,10 @@ import { PasswordRepromptService, VaultCopyButtonsService } from "@bitwarden/vau
 
 import { VaultPopupAutofillService } from "../../../services/vault-popup-autofill.service";
 import { VaultPopupItemsService } from "../../../services/vault-popup-items.service";
-import { VaultPopupListFiltersService } from "../../../services/vault-popup-list-filters.service";
+import {
+  MY_VAULT_ID,
+  VaultPopupListFiltersService,
+} from "../../../services/vault-popup-list-filters.service";
 import { VaultPopupLoadingService } from "../../../services/vault-popup-loading.service";
 import { VaultPopupSectionService } from "../../../services/vault-popup-section.service";
 import { PopupCipherViewLike } from "../../../views/popup-cipher.view";
@@ -522,6 +525,67 @@ describe("VaultPopupListTableComponent", () => {
       fixture.detectChanges();
 
       expect(component["folderOptions"]().map((o) => o.value)).toEqual([parent, child]);
+    });
+
+    /**
+     * The chip matches its options by reference, but the form's value is frequently an
+     * equal-but-distinct object: the view cache rebuilds "My vault" as a fresh `Organization`, and
+     * `getAllFoldersNested` copies each `FolderView` per emission. Seeding the raw value would leave
+     * the chip active but label-less, so the directive resolves it against the option list first.
+     */
+    describe("identity-independent seeding", () => {
+      it("selects a seeded organization that is a different instance than its option", () => {
+        const option = { id: MY_VAULT_ID } as Organization;
+        organizations$.next([{ value: option, label: "My vault" }]);
+        // A distinct object with the same id — what `deserializeFilters` restores from the cache.
+        filterForm.controls.organization.setValue({ id: MY_VAULT_ID } as Organization);
+        fixture.detectChanges();
+
+        const chip = chipFor("organization");
+        expect(chip.active()).toBe(true);
+        // Resolved onto the option's own instance, so the chip's reference-based `isSelected` marks
+        // it selected — which is what drives the label and the menu/dialog checkmark.
+        expect(chip.value()).toBe(option);
+        expect(chip.isSelected(option)).toBe(true);
+      });
+
+      it("selects a seeded folder that is a different instance than its option", () => {
+        const option = { id: "folder-1", name: "Work" } as FolderView;
+        folders$.next([{ value: option, label: "Work" }]);
+        filterForm.controls.folder.setValue({ id: "folder-1", name: "Work" } as FolderView);
+        fixture.detectChanges();
+
+        const chip = chipFor("folder");
+        expect(chip.value()).toBe(option);
+        expect(chip.isSelected(option)).toBe(true);
+      });
+
+      it("re-resolves onto the new instance when the options are rebuilt", () => {
+        const first = { id: "folder-1", name: "Work" } as FolderView;
+        folders$.next([{ value: first, label: "Work" }]);
+        filterForm.controls.folder.setValue(first);
+        fixture.detectChanges();
+
+        // `folders$` re-emits rebuilt copies on any cipher change (a sync, an item edit).
+        const rebuilt = { id: "folder-1", name: "Work" } as FolderView;
+        folders$.next([{ value: rebuilt, label: "Work" }]);
+        fixture.detectChanges();
+
+        const chip = chipFor("folder");
+        expect(chip.value()).toBe(rebuilt);
+        expect(chip.isSelected(rebuilt)).toBe(true);
+      });
+
+      it("leaves a selection that matches no option untouched", () => {
+        // The org filter can name a folder the current option list no longer contains; clearing it
+        // here would fight `validateOrganizationChange`, which owns that reset.
+        const orphan = { id: "folder-gone", name: "Archived" } as FolderView;
+        folders$.next([{ value: { id: "folder-1", name: "Work" } as FolderView, label: "Work" }]);
+        filterForm.controls.folder.setValue(orphan);
+        fixture.detectChanges();
+
+        expect(filterForm.controls.folder.value).toBe(orphan);
+      });
     });
   });
 

--- a/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.spec.ts
+++ b/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.spec.ts
@@ -88,6 +88,7 @@ describe("VaultPopupListTableComponent", () => {
   const loading$ = new BehaviorSubject<boolean>(false);
   const searchText$ = new BehaviorSubject<string>("");
   const hasSearchText$ = new BehaviorSubject<boolean>(false);
+  const showDeactivatedOrg$ = new BehaviorSubject<boolean>(false);
   const clickItemsToAutofillVaultView$ = new BehaviorSubject<boolean>(true);
 
   const configService = {
@@ -111,6 +112,7 @@ describe("VaultPopupListTableComponent", () => {
     loading$: loading$.asObservable(),
     searchText$: searchText$.asObservable(),
     hasSearchText$: hasSearchText$.asObservable(),
+    showDeactivatedOrg$: showDeactivatedOrg$.asObservable(),
     applyFilter: jest.fn(),
   };
 
@@ -160,6 +162,7 @@ describe("VaultPopupListTableComponent", () => {
     loading$.next(false);
     searchText$.next("");
     hasSearchText$.next(false);
+    showDeactivatedOrg$.next(false);
     compactModeEnabled$.next(false);
     filterForm.reset({ organization: null, collection: null, folder: null, cipherType: null });
     cipherTypes$.next([]);
@@ -257,6 +260,41 @@ describe("VaultPopupListTableComponent", () => {
       expect(text).toContain("nothingToShow");
       expect(text).not.toContain("noItemsMatchSearch");
       expect(text).not.toContain("clearFiltersOrTryAnother");
+    });
+
+    /**
+     * A suspended organization's ciphers match its own filter, so the rows have to be withheld
+     * here — and the table has to stay mounted regardless, since it carries the only control that
+     * can clear the filter responsible for the state.
+     */
+    describe("deactivated organization", () => {
+      beforeEach(() => {
+        filteredCiphers$.next([makeCipher({ organizationId: "org-1" })]);
+        showDeactivatedOrg$.next(true);
+        fixture.detectChanges();
+      });
+
+      it("withholds the rows and shows the deactivated notice", () => {
+        expect(component["rows"]()).toEqual([]);
+
+        const text = fixture.nativeElement.textContent;
+        expect(text).toContain("organizationIsDeactivated");
+        expect(text).toContain("contactYourOrgAdmin");
+        expect(text).not.toContain("nothingToShow");
+      });
+
+      it("keeps the toolbar mounted so the filter stays clearable", () => {
+        expect(fixture.nativeElement.querySelector("bit-table-toolbar")).not.toBeNull();
+        expect(fixture.nativeElement.querySelector("bit-search")).not.toBeNull();
+      });
+
+      it("restores the rows once the filter moves off the suspended organization", () => {
+        showDeactivatedOrg$.next(false);
+        fixture.detectChanges();
+
+        expect(component["rows"]()).toHaveLength(1);
+        expect(fixture.nativeElement.textContent).not.toContain("organizationIsDeactivated");
+      });
     });
   });
 

--- a/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.spec.ts
+++ b/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.spec.ts
@@ -519,12 +519,40 @@ describe("VaultPopupListTableComponent", () => {
     it("flattens nested folder options into one option per node", () => {
       const parent = { id: "f-1", name: "Parent" } as FolderView;
       const child = { id: "f-2", name: "Parent/Child" } as FolderView;
+      // Nesting keeps only the trailing segment on each node, so the child's label is "Child".
       folders$.next([
-        { value: parent, label: "Parent", children: [{ value: child, label: "Parent/Child" }] },
+        { value: parent, label: "Parent", children: [{ value: child, label: "Child" }] },
       ]);
       fixture.detectChanges();
 
       expect(component["folderOptions"]().map((o) => o.value)).toEqual([parent, child]);
+    });
+
+    it("keeps each nested option's own label, which may repeat across branches", () => {
+      // "Work/Personal" and "Home/Personal" both nest to a node labeled "Personal". Options are
+      // rendered with their own label and tracked by id, so the repeat is expected, not a defect.
+      folders$.next([
+        {
+          value: { id: "f-1", name: "Work" } as FolderView,
+          label: "Work",
+          children: [
+            { value: { id: "f-2", name: "Work/Personal" } as FolderView, label: "Personal" },
+          ],
+        },
+        {
+          value: { id: "f-3", name: "Home" } as FolderView,
+          label: "Home",
+          children: [
+            { value: { id: "f-4", name: "Home/Personal" } as FolderView, label: "Personal" },
+          ],
+        },
+      ]);
+      fixture.detectChanges();
+
+      const options = component["folderOptions"]();
+      expect(options.map((o) => o.label)).toEqual(["Work", "Personal", "Home", "Personal"]);
+      // Ids stay unique, which is what keeps the `@for` track expression stable.
+      expect(new Set(options.map((o) => o.value.id)).size).toBe(4);
     });
 
     /**

--- a/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.spec.ts
+++ b/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.spec.ts
@@ -1,5 +1,7 @@
 import { ElementRef } from "@angular/core";
 import { ComponentFixture, TestBed, fakeAsync, tick } from "@angular/core/testing";
+import { FormControl, FormGroup } from "@angular/forms";
+import { By } from "@angular/platform-browser";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
 import { RouterTestingModule } from "@angular/router/testing";
 import { mock } from "jest-mock-extended";
@@ -8,6 +10,8 @@ import { BehaviorSubject, of } from "rxjs";
 import { CollectionService } from "@bitwarden/admin-console/common";
 import { WINDOW } from "@bitwarden/angular/services/injection-tokens";
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
+import { CollectionView } from "@bitwarden/common/admin-console/models/collections";
+import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { DomainSettingsService } from "@bitwarden/common/autofill/services/domain-settings.service";
 import { BillingAccountProfileStateService } from "@bitwarden/common/billing/abstractions/account/billing-account-profile-state.service";
@@ -22,12 +26,15 @@ import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.servi
 import { TotpService } from "@bitwarden/common/vault/abstractions/totp.service";
 import { VaultSettingsService } from "@bitwarden/common/vault/abstractions/vault-settings/vault-settings.service";
 import { CipherType } from "@bitwarden/common/vault/enums";
+import { FolderView } from "@bitwarden/common/vault/models/view/folder.view";
 import { CipherAuthorizationService } from "@bitwarden/common/vault/services/cipher-authorization.service";
 import { RestrictedItemTypesService } from "@bitwarden/common/vault/services/restricted-item-types.service";
 import { SearchTextDebounceInterval } from "@bitwarden/common/vault/services/search.service";
 import {
+  ChipFilterOption,
   CompactModeService,
   DialogService,
+  FilterMenuComponent,
   ScrollLayoutService,
   ToastService,
 } from "@bitwarden/components";
@@ -36,6 +43,7 @@ import { PasswordRepromptService, VaultCopyButtonsService } from "@bitwarden/vau
 
 import { VaultPopupAutofillService } from "../../../services/vault-popup-autofill.service";
 import { VaultPopupItemsService } from "../../../services/vault-popup-items.service";
+import { VaultPopupListFiltersService } from "../../../services/vault-popup-list-filters.service";
 import { VaultPopupLoadingService } from "../../../services/vault-popup-loading.service";
 import { VaultPopupSectionService } from "../../../services/vault-popup-section.service";
 import { PopupCipherViewLike } from "../../../views/popup-cipher.view";
@@ -112,6 +120,28 @@ describe("VaultPopupListTableComponent", () => {
     updateSectionOpenStoredState: jest.fn(),
   };
 
+  // A real `FormGroup`, since the filter chips are bridged to it by `VaultFilterChipDirective` and
+  // the two-way sync is exercised through its actual value/`valueChanges` behavior.
+  const filterForm = new FormGroup({
+    organization: new FormControl<Organization | null>(null),
+    collection: new FormControl<CollectionView | null>(null),
+    folder: new FormControl<FolderView | null>(null),
+    cipherType: new FormControl<CipherType | null>(null),
+  });
+
+  const cipherTypes$ = new BehaviorSubject<ChipFilterOption<CipherType>[]>([]);
+  const organizations$ = new BehaviorSubject<ChipFilterOption<Organization>[]>([]);
+  const collections$ = new BehaviorSubject<ChipFilterOption<CollectionView>[]>([]);
+  const folders$ = new BehaviorSubject<ChipFilterOption<FolderView>[]>([]);
+
+  const vaultPopupListFiltersService = {
+    filterForm,
+    cipherTypes$: cipherTypes$.asObservable(),
+    organizations$: organizations$.asObservable(),
+    collections$: collections$.asObservable(),
+    folders$: folders$.asObservable(),
+  };
+
   const compactModeEnabled$ = new BehaviorSubject<boolean>(false);
   const compactModeService = {
     enabled$: compactModeEnabled$.asObservable(),
@@ -128,6 +158,11 @@ describe("VaultPopupListTableComponent", () => {
     searchText$.next("");
     hasSearchText$.next(false);
     compactModeEnabled$.next(false);
+    filterForm.reset({ organization: null, collection: null, folder: null, cipherType: null });
+    cipherTypes$.next([]);
+    organizations$.next([]);
+    collections$.next([]);
+    folders$.next([]);
     clickItemsToAutofillVaultView$.next(true);
 
     await TestBed.configureTestingModule({
@@ -139,6 +174,7 @@ describe("VaultPopupListTableComponent", () => {
         { provide: VaultPopupItemsService, useValue: vaultPopupItemsService },
         { provide: VaultPopupLoadingService, useValue: vaultPopupLoadingService },
         { provide: VaultPopupSectionService, useValue: vaultPopupSectionService },
+        { provide: VaultPopupListFiltersService, useValue: vaultPopupListFiltersService },
         { provide: CompactModeService, useValue: compactModeService },
         { provide: I18nService, useValue: mock<I18nService>({ t: (k: string) => k }) },
         { provide: CipherService, useValue: mock<CipherService>() },
@@ -401,6 +437,91 @@ describe("VaultPopupListTableComponent", () => {
       const row = makeRow("autofill", { type: CipherType.Identity });
       expect(component["isCard"](row)).toBe(false);
       expect(component["isIdentity"](row)).toBe(true);
+    });
+  });
+
+  /**
+   * The chips are bridged to `VaultPopupListFiltersService.filterForm` rather than owning the
+   * filter state themselves, so these assert the round trip in both directions. Filtering itself
+   * is applied upstream (`filterFunction$` in `VaultPopupItemsService`), so a chip's job ends at
+   * writing the form.
+   */
+  describe("filter chips", () => {
+    /** Resolves the projected `bit-filter-menu` for a `filterForm` control. */
+    const chipFor = (key: string) =>
+      fixture.debugElement
+        .queryAll(By.directive(FilterMenuComponent))
+        .find((chip) => chip.componentInstance.key() === key)?.componentInstance;
+
+    it("renders a chip per dimension, omitting those whose options are empty", () => {
+      cipherTypes$.next([{ value: CipherType.Login, label: "Login" }]);
+      fixture.detectChanges();
+
+      // Type is unconditional; the other three are hidden while their option streams are empty
+      // (no orgs, or folders/collections narrowed away by the selected organization).
+      expect(chipFor("cipherType")).toBeDefined();
+      expect(chipFor("organization")).toBeUndefined();
+      expect(chipFor("collection")).toBeUndefined();
+      expect(chipFor("folder")).toBeUndefined();
+
+      organizations$.next([{ value: { id: "org-1" } as Organization, label: "Org 1" }]);
+      fixture.detectChanges();
+
+      expect(chipFor("organization")).toBeDefined();
+    });
+
+    it("writes a chip selection back to its filterForm control", () => {
+      cipherTypes$.next([{ value: CipherType.Card, label: "Card" }]);
+      fixture.detectChanges();
+
+      chipFor("cipherType").toggle(CipherType.Card);
+      fixture.detectChanges();
+
+      expect(filterForm.controls.cipherType.value).toBe(CipherType.Card);
+    });
+
+    it("clears the filterForm control when the chip is cleared", () => {
+      cipherTypes$.next([{ value: CipherType.Card, label: "Card" }]);
+      fixture.detectChanges();
+
+      chipFor("cipherType").toggle(CipherType.Card);
+      fixture.detectChanges();
+      chipFor("cipherType").clear();
+      fixture.detectChanges();
+
+      expect(filterForm.controls.cipherType.value).toBeNull();
+    });
+
+    it("reflects filterForm writes made outside the table onto the chip", () => {
+      cipherTypes$.next([{ value: CipherType.Identity, label: "Identity" }]);
+      fixture.detectChanges();
+
+      // e.g. the vault header's own filter UI, or `resetFilterForm()`.
+      filterForm.controls.cipherType.setValue(CipherType.Identity);
+      fixture.detectChanges();
+
+      expect(chipFor("cipherType").value()).toBe(CipherType.Identity);
+      expect(chipFor("cipherType").active()).toBe(true);
+    });
+
+    it("seeds a chip from filters already applied before it rendered", () => {
+      // The view cache restores filters into the form before the table mounts.
+      filterForm.controls.cipherType.setValue(CipherType.Card);
+      cipherTypes$.next([{ value: CipherType.Card, label: "Card" }]);
+      fixture.detectChanges();
+
+      expect(chipFor("cipherType").value()).toBe(CipherType.Card);
+    });
+
+    it("flattens nested folder options into one option per node", () => {
+      const parent = { id: "f-1", name: "Parent" } as FolderView;
+      const child = { id: "f-2", name: "Parent/Child" } as FolderView;
+      folders$.next([
+        { value: parent, label: "Parent", children: [{ value: child, label: "Parent/Child" }] },
+      ]);
+      fixture.detectChanges();
+
+      expect(component["folderOptions"]().map((o) => o.value)).toEqual([parent, child]);
     });
   });
 

--- a/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.spec.ts
+++ b/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.spec.ts
@@ -215,7 +215,7 @@ describe("VaultPopupListTableComponent", () => {
           provide: StateProvider,
           useValue: {
             getUserState$: () => of({ hasSeen: true, hasDismissed: true }),
-            getUser: () => ({ update: async () => { } }),
+            getUser: () => ({ update: async () => {} }),
           },
         },
         { provide: RestrictedItemTypesService, useValue: { restricted$: of([]) } },
@@ -259,9 +259,9 @@ describe("VaultPopupListTableComponent", () => {
   describe("collapsible sections", () => {
     /** The rendered collapse toggle for a section, found by its header label. */
     const headerToggle = (label: string): HTMLButtonElement | undefined =>
-      Array.from(
-        fixture.nativeElement.querySelectorAll<HTMLButtonElement>("button[aria-expanded]"),
-      ).find((button) => button.textContent?.includes(label));
+      Array.from(fixture.nativeElement.querySelectorAll("button[aria-expanded]")).find((button) =>
+        (button as HTMLButtonElement).textContent?.includes(label),
+      ) as HTMLButtonElement | undefined;
 
     /**
      * Renders the table with both collapsible sections populated.

--- a/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.spec.ts
+++ b/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.spec.ts
@@ -46,6 +46,7 @@ import { VaultPopupAutofillService } from "../../../services/vault-popup-autofil
 import { VaultPopupItemsService } from "../../../services/vault-popup-items.service";
 import {
   MY_VAULT_ID,
+  FilterOptionCounts,
   VaultPopupListFiltersService,
 } from "../../../services/vault-popup-list-filters.service";
 import { VaultPopupLoadingService } from "../../../services/vault-popup-loading.service";
@@ -141,12 +142,20 @@ describe("VaultPopupListTableComponent", () => {
   const collections$ = new BehaviorSubject<ChipFilterOption<CollectionView>[]>([]);
   const folders$ = new BehaviorSubject<ChipFilterOption<FolderView>[]>([]);
 
+  const filterOptionCounts$ = new BehaviorSubject<FilterOptionCounts>({
+    cipherType: new Map(),
+    organization: new Map(),
+    collection: new Map(),
+    folder: new Map(),
+  });
+
   const vaultPopupListFiltersService = {
     filterForm,
     cipherTypes$: cipherTypes$.asObservable(),
     organizations$: organizations$.asObservable(),
     collections$: collections$.asObservable(),
     folders$: folders$.asObservable(),
+    filterOptionCounts$: filterOptionCounts$.asObservable(),
   };
 
   const compactModeEnabled$ = new BehaviorSubject<boolean>(false);
@@ -156,6 +165,9 @@ describe("VaultPopupListTableComponent", () => {
 
   beforeEach(async () => {
     jest.clearAllMocks();
+    // `clearAllMocks` resets calls but not implementations, so restore the default open state —
+    // otherwise a test that seeds a section collapsed leaks that into the ones after it.
+    vaultPopupSectionService.getOpenDisplayStateForSection.mockReturnValue(() => true);
     featureFlag$.next(false);
     currentTabIsOnBlocklist$.next(false);
     autoFillCiphers$.next([]);
@@ -244,6 +256,64 @@ describe("VaultPopupListTableComponent", () => {
    * from an empty vault — both leave it with zero rows. The empty state is projected for that
    * reason, so these assert the rendered copy rather than the absence of something.
    */
+  describe("collapsible sections", () => {
+    /** The rendered collapse toggle for a section, found by its header label. */
+    const headerToggle = (label: string): HTMLButtonElement | undefined =>
+      Array.from(
+        fixture.nativeElement.querySelectorAll<HTMLButtonElement>("button[aria-expanded]"),
+      ).find((button) => button.textContent?.includes(label));
+
+    /**
+     * Renders the table with both collapsible sections populated.
+     *
+     * The table virtualizes its rows into a `height="fill"` viewport, which measures 0 in JSDOM and
+     * so renders nothing — the host needs a real height before the group headers exist to click.
+     */
+    const render = async () => {
+      favoriteCiphers$.next([makeCipher({ id: "fav-1", favorite: true })]);
+      filteredCiphers$.next([makeCipher({ id: "all-1" })]);
+      fixture.nativeElement.style.height = "600px";
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+    };
+
+    it("persists the collapsed state when the user collapses a section", async () => {
+      await render();
+
+      const toggle = headerToggle("favorites");
+      expect(toggle).toBeDefined();
+      expect(toggle!.getAttribute("aria-expanded")).toBe("true");
+
+      toggle!.click();
+      fixture.detectChanges();
+
+      expect(vaultPopupSectionService.updateSectionOpenStoredState).toHaveBeenCalledWith(
+        "favorites",
+        false,
+      );
+      expect(headerToggle("favorites")!.getAttribute("aria-expanded")).toBe("false");
+    });
+
+    it("persists the expanded state when the user re-expands a section", async () => {
+      // Seeded collapsed before the first render, so the click is an expand. Set here rather than
+      // by rebuilding the fixture: a second live fixture fights the first over the scroll host.
+      vaultPopupSectionService.getOpenDisplayStateForSection.mockReturnValue(() => false);
+      await render();
+
+      const toggle = headerToggle("favorites");
+      expect(toggle!.getAttribute("aria-expanded")).toBe("false");
+
+      toggle!.click();
+      fixture.detectChanges();
+
+      expect(vaultPopupSectionService.updateSectionOpenStoredState).toHaveBeenCalledWith(
+        "favorites",
+        true,
+      );
+    });
+  });
+
   describe("empty state", () => {
     it("shows the search-specific copy and recovery hint when a search matches nothing", () => {
       hasSearchText$.next(true);

--- a/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.ts
@@ -55,7 +55,11 @@ import { OrgIconDirective, Vfo1I18nPipe } from "@bitwarden/vault";
 import BrowserPopupUtils from "../../../../../platform/browser/browser-popup-utils";
 import { PopupPageComponent } from "../../../../../platform/popup/layout/popup-page.component";
 import { VaultPopupAutofillService } from "../../../services/vault-popup-autofill.service";
-import { VaultPopupListFiltersService } from "../../../services/vault-popup-list-filters.service";
+import {
+  FilterOptionCounts,
+  NO_FOLDER_COUNT_KEY,
+  VaultPopupListFiltersService,
+} from "../../../services/vault-popup-list-filters.service";
 import {
   VaultPopupListTableService,
   VaultTableRow,
@@ -212,6 +216,40 @@ export class VaultPopupListTableComponent implements OnDestroy {
    */
   protected readonly collectionOptions = computed(() => flattenOptions(this.collectionTree()));
   protected readonly folderOptions = computed(() => flattenOptions(this.folderTree()));
+
+  /**
+   * Item counts per filter option, shown to the right of each option row.
+   *
+   * The table can't derive these itself: `bit-table-v2` counts its own rows, which are already
+   * narrowed by `filterFunction$` upstream, so every unselected option would read zero. The
+   * service counts the whole vault instead.
+   */
+  private readonly optionCounts = toSignal(this.listFiltersService.filterOptionCounts$, {
+    initialValue: {
+      cipherType: new Map(),
+      organization: new Map(),
+      collection: new Map(),
+      folder: new Map(),
+    } as FilterOptionCounts,
+  });
+
+  /** An option's count, defaulting to zero so a dimension with no matches still renders a number. */
+  protected cipherTypeCount(type: CipherType): number {
+    return this.optionCounts().cipherType.get(type) ?? 0;
+  }
+
+  protected organizationCount(organization: Organization): number {
+    return this.optionCounts().organization.get(organization.id) ?? 0;
+  }
+
+  protected collectionCount(collection: CollectionView): number {
+    return this.optionCounts().collection.get(collection.id) ?? 0;
+  }
+
+  /** "Items with no folder" has no id, so it counts under {@link NO_FOLDER_COUNT_KEY}. */
+  protected folderCount(folder: FolderView): number {
+    return this.optionCounts().folder.get(folder.id ?? NO_FOLDER_COUNT_KEY) ?? 0;
+  }
 
   protected readonly itemHeight = toSignal(
     this.compactModeService.enabled$.pipe(map((enabled) => (enabled ? 53 : 59))),

--- a/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.ts
@@ -1,11 +1,13 @@
 // FIXME(https://bitwarden.atlassian.net/browse/CL-1062): `OnPush` components should not use mutable properties
 /* eslint-disable @bitwarden/components/enforce-readonly-angular-properties */
+import { LiveAnnouncer } from "@angular/cdk/a11y";
 import { CommonModule } from "@angular/common";
 import {
   afterRenderEffect,
   ChangeDetectionStrategy,
   Component,
   computed,
+  effect,
   ElementRef,
   inject,
   OnDestroy,
@@ -125,6 +127,7 @@ export class VaultPopupListTableComponent implements OnDestroy {
   private readonly platformUtilsService = inject(PlatformUtilsService);
   private readonly scrollLayout = inject(ScrollLayoutService);
   private readonly host = inject<ElementRef<HTMLElement>>(ElementRef);
+  private readonly liveAnnouncer = inject(LiveAnnouncer);
   protected readonly i18nService = inject(I18nService);
   private readonly window = inject<Window>(WINDOW);
 
@@ -287,6 +290,37 @@ export class VaultPopupListTableComponent implements OnDestroy {
   protected readonly autofillSectionKey = computed(() =>
     this.currentUriIsBlocked() ? "itemSuggestions" : "autofillSuggestions",
   );
+
+  /**
+   * The empty-slot title key, or `null` while rows are rendering. Mirrors the template's empty
+   * slot, which the table stamps whenever it has no rows to show.
+   */
+  private readonly emptyStateKey = computed(() => {
+    if (this.loading() || this.rows().length > 0) {
+      return null;
+    }
+
+    if (this.showDeactivatedOrg()) {
+      return "organizationIsDeactivated";
+    }
+
+    return this.hasSearchText() ? "noItemsMatchSearch" : "nothingToShow";
+  });
+
+  /**
+   * Announces the empty state as it appears.
+   *
+   * The message can't carry `role="status"` itself: the table stamps the empty slot with a
+   * structural `@if`, so the live region and its content would enter the DOM in the same pass and
+   * screen readers generally skip that. Announcing imperatively sidesteps the timing entirely.
+   */
+  private readonly _announceEmptyState = effect(() => {
+    const key = this.emptyStateKey();
+
+    if (key !== null) {
+      void this.liveAnnouncer.announce(this.i18nService.t(key), "polite");
+    }
+  });
 
   protected readonly favoritesOpenState = computed(
     () => this.vaultPopupSectionService.getOpenDisplayStateForSection("favorites")() ?? true,

--- a/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.ts
@@ -17,9 +17,12 @@ import { filter, map, Subject } from "rxjs";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { WINDOW } from "@bitwarden/angular/services/injection-tokens";
+import { CollectionView } from "@bitwarden/common/admin-console/models/collections";
+import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { CipherType } from "@bitwarden/common/vault/enums";
+import { FolderView } from "@bitwarden/common/vault/models/view/folder.view";
 import {
   CipherViewLike,
   CipherViewLikeUtils,
@@ -33,8 +36,10 @@ import {
   BitTableToolbarComponent,
   BitTableV2Component,
   ChipActionComponent,
+  ChipFilterOption,
   CompactModeService,
   defineTable,
+  FilterMenuModule,
   IconButtonModule,
   IconComponent,
   NoItemsModule,
@@ -42,11 +47,12 @@ import {
   SearchModule,
   TypographyModule,
 } from "@bitwarden/components";
-import { OrgIconDirective } from "@bitwarden/vault";
+import { OrgIconDirective, Vfo1I18nPipe, Vfo1IconPipe } from "@bitwarden/vault";
 
 import BrowserPopupUtils from "../../../../../platform/browser/browser-popup-utils";
 import { PopupPageComponent } from "../../../../../platform/popup/layout/popup-page.component";
 import { VaultPopupAutofillService } from "../../../services/vault-popup-autofill.service";
+import { VaultPopupListFiltersService } from "../../../services/vault-popup-list-filters.service";
 import {
   VaultPopupListTableService,
   VaultTableRow,
@@ -56,6 +62,13 @@ import { VaultPopupSectionService } from "../../../services/vault-popup-section.
 import { PopupCipherViewLike } from "../../../views/popup-cipher.view";
 import { ItemCopyActionsComponent } from "../item-copy-action/item-copy-actions.component";
 import { ItemMoreOptionsComponent } from "../item-more-options/item-more-options.component";
+
+import { VaultFilterChipDirective } from "./vault-filter-chip.directive";
+
+/** Flattens a nested `ChipFilterOption` tree into a single depth-first list. */
+function flattenOptions<T>(options: ChipFilterOption<T>[]): ChipFilterOption<T>[] {
+  return options.flatMap((option) => [option, ...flattenOptions(option.children ?? [])]);
+}
 
 @Component({
   selector: "app-vault-popup-list-table",
@@ -81,6 +94,7 @@ import { ItemMoreOptionsComponent } from "../item-more-options/item-more-options
     BitCellDefDirective,
     BitRowGroupComponent,
     BitTableToolbarComponent,
+    FilterMenuModule,
     IconButtonModule,
     IconComponent,
     NoItemsModule,
@@ -90,6 +104,9 @@ import { ItemMoreOptionsComponent } from "../item-more-options/item-more-options
     ItemCopyActionsComponent,
     ItemMoreOptionsComponent,
     OrgIconDirective,
+    VaultFilterChipDirective,
+    Vfo1I18nPipe,
+    Vfo1IconPipe,
   ],
 })
 export class VaultPopupListTableComponent implements OnDestroy {
@@ -98,6 +115,7 @@ export class VaultPopupListTableComponent implements OnDestroy {
   private readonly vaultPopupSectionService = inject(VaultPopupSectionService);
   private readonly compactModeService = inject(CompactModeService);
   private readonly listTableService = inject(VaultPopupListTableService);
+  private readonly listFiltersService = inject(VaultPopupListFiltersService);
   private readonly platformUtilsService = inject(PlatformUtilsService);
   private readonly scrollLayout = inject(ScrollLayoutService);
   private readonly host = inject<ElementRef<HTMLElement>>(ElementRef);
@@ -132,6 +150,35 @@ export class VaultPopupListTableComponent implements OnDestroy {
   });
 
   protected readonly table = defineTable<VaultTableRow, "name">(this.rows);
+
+  /**
+   * The dimension-filter options. Each stream hides its own chip when empty — organizations are
+   * absent for a user with no orgs, and folders/collections narrow to the selected organization —
+   * so the chips are rendered conditionally on these having entries.
+   */
+  protected readonly cipherTypeOptions = toSignal(this.listFiltersService.cipherTypes$, {
+    initialValue: [] as ChipFilterOption<CipherType>[],
+  });
+
+  protected readonly organizationOptions = toSignal(this.listFiltersService.organizations$, {
+    initialValue: [] as ChipFilterOption<Organization>[],
+  });
+
+  private readonly collectionTree = toSignal(this.listFiltersService.collections$, {
+    initialValue: [] as ChipFilterOption<CollectionView>[],
+  });
+
+  private readonly folderTree = toSignal(this.listFiltersService.folders$, {
+    initialValue: [] as ChipFilterOption<FolderView>[],
+  });
+
+  /**
+   * Collections and folders arrive as nested trees, but a chip's options are a flat list, so the
+   * nesting is flattened into one option per node. Names already carry their full path (folders are
+   * nested by splitting on "/"), so a flat list still reads unambiguously.
+   */
+  protected readonly collectionOptions = computed(() => flattenOptions(this.collectionTree()));
+  protected readonly folderOptions = computed(() => flattenOptions(this.folderTree()));
 
   protected readonly itemHeight = toSignal(
     this.compactModeService.enabled$.pipe(map((enabled) => (enabled ? 53 : 59))),

--- a/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.ts
@@ -17,6 +17,7 @@ import { filter, map, Subject } from "rxjs";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { WINDOW } from "@bitwarden/angular/services/injection-tokens";
+import { DeactivatedOrg, NoResults } from "@bitwarden/assets/svg";
 import { CollectionView } from "@bitwarden/common/admin-console/models/collections";
 import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
@@ -139,6 +140,10 @@ export class VaultPopupListTableComponent implements OnDestroy {
 
   protected readonly CipherViewLikeUtils = CipherViewLikeUtils;
 
+  /** Empty-slot icons: the default no-results graphic, or the suspended-organization one. */
+  protected readonly noResultsIcon = NoResults;
+  protected readonly deactivatedIcon = DeactivatedOrg;
+
   protected searchText: string = "";
   private readonly searchText$ = new Subject<string>();
 
@@ -146,13 +151,30 @@ export class VaultPopupListTableComponent implements OnDestroy {
     initialValue: true,
   });
 
-  protected readonly rows = toSignal(this.listTableService.rows$, {
-    initialValue: [] as VaultTableRow[],
-  });
-
   protected readonly hasSearchText = toSignal(this.listTableService.hasSearchText$, {
     initialValue: false,
   });
+
+  /**
+   * Whether the selected organization filter points at a suspended organization. The toolbar stays
+   * mounted in this state so the filter that caused it remains clearable — unmounting the table
+   * would strip the chips and the search box along with it.
+   */
+  protected readonly showDeactivatedOrg = toSignal(this.listTableService.showDeactivatedOrg$, {
+    initialValue: false,
+  });
+
+  private readonly allRows = toSignal(this.listTableService.rows$, {
+    initialValue: [] as VaultTableRow[],
+  });
+
+  /**
+   * A suspended organization's ciphers still match its own filter, so they have to be withheld
+   * here rather than by `filterFunction$` — otherwise the list would show items belonging to an
+   * organization the user can no longer act on. Emptying the rows also hands the state over to the
+   * table's empty slot, which renders the notice.
+   */
+  protected readonly rows = computed(() => (this.showDeactivatedOrg() ? [] : this.allRows()));
 
   protected readonly table = defineTable<VaultTableRow, "name">(this.rows);
 

--- a/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.ts
@@ -47,7 +47,7 @@ import {
   SearchModule,
   TypographyModule,
 } from "@bitwarden/components";
-import { OrgIconDirective, Vfo1I18nPipe, Vfo1IconPipe } from "@bitwarden/vault";
+import { OrgIconDirective, Vfo1I18nPipe } from "@bitwarden/vault";
 
 import BrowserPopupUtils from "../../../../../platform/browser/browser-popup-utils";
 import { PopupPageComponent } from "../../../../../platform/popup/layout/popup-page.component";
@@ -106,7 +106,6 @@ function flattenOptions<T>(options: ChipFilterOption<T>[]): ChipFilterOption<T>[
     OrgIconDirective,
     VaultFilterChipDirective,
     Vfo1I18nPipe,
-    Vfo1IconPipe,
   ],
 })
 export class VaultPopupListTableComponent implements OnDestroy {
@@ -174,8 +173,11 @@ export class VaultPopupListTableComponent implements OnDestroy {
 
   /**
    * Collections and folders arrive as nested trees, but a chip's options are a flat list, so the
-   * nesting is flattened into one option per node. Names already carry their full path (folders are
-   * nested by splitting on "/"), so a flat list still reads unambiguously.
+   * nesting is flattened into one option per node.
+   *
+   * Each node keeps the label the tree gave it — the trailing path segment — so a child of "Work"
+   * shows as "EU" rather than "Work/EU". Options are therefore tracked by id, not label, since
+   * two folders like "Work/Personal" and "Home/Personal" flatten to the same label.
    */
   protected readonly collectionOptions = computed(() => flattenOptions(this.collectionTree()));
   protected readonly folderOptions = computed(() => flattenOptions(this.folderTree()));

--- a/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.ts
@@ -65,7 +65,13 @@ import { ItemMoreOptionsComponent } from "../item-more-options/item-more-options
 
 import { VaultFilterChipDirective } from "./vault-filter-chip.directive";
 
-/** Flattens a nested `ChipFilterOption` tree into a single depth-first list. */
+/**
+ * Flattens a nested `ChipFilterOption` tree into a single depth-first list.
+ *
+ * Interim: the designs call for an indented, expand/collapse tree, but `bit-filter-option` has no
+ * depth or children concept, so a flat list is the only shape the menu renders today. Recursive
+ * nesting is being added in CL-985; revisit this (and drop the flattening) once it lands.
+ */
 function flattenOptions<T>(options: ChipFilterOption<T>[]): ChipFilterOption<T>[] {
   return options.flatMap((option) => [option, ...flattenOptions(option.children ?? [])]);
 }

--- a/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.stories.ts
+++ b/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.stories.ts
@@ -361,7 +361,7 @@ const buildProviders = (args: StoryArgs) => {
           archiveVerb: "Archive",
           upgradeToUseArchive: "Upgrade to use archive",
           delete: "Delete",
-          launchWebsiteName: "Launch website",
+          launchWebsiteName: "Launch __$1__",
           itemCount: "__$1__ items",
         }),
     },

--- a/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.stories.ts
+++ b/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.stories.ts
@@ -44,7 +44,9 @@ import { PopupWidthOptions } from "../../../../../platform/browser/browser-popup
 import { VaultPopupAutofillService } from "../../../services/vault-popup-autofill.service";
 import { VaultPopupItemsService } from "../../../services/vault-popup-items.service";
 import {
+  FilterOptionCounts,
   MY_VAULT_ID,
+  NO_FOLDER_COUNT_KEY,
   PopupListFilter,
   VaultPopupListFiltersService,
 } from "../../../services/vault-popup-list-filters.service";
@@ -265,6 +267,36 @@ const CIPHER_TYPE_OPTIONS = [
   { value: CipherType.SecureNote, label: "Note" },
 ];
 
+/**
+ * Option counts derived from the story's own ciphers, rather than hardcoded numbers that would
+ * drift from the rows on screen. Mirrors the real service: counts are absolute, so the applied
+ * filters don't narrow them.
+ */
+const buildOptionCounts = (ciphers: PopupCipherViewLike[]): FilterOptionCounts => {
+  const counts: FilterOptionCounts = {
+    cipherType: new Map<CipherType, number>(),
+    organization: new Map<string, number>(),
+    collection: new Map<string, number>(),
+    folder: new Map<string, number>(),
+  };
+
+  const increment = <K>(map: Map<K, number>, key: K) => {
+    map.set(key, (map.get(key) ?? 0) + 1);
+  };
+
+  for (const cipher of ciphers) {
+    // The fixtures are real `CipherView`s, so `type` is readable without `CipherViewLikeUtils`.
+    increment(counts.cipherType, (cipher as CipherView).type);
+    increment(counts.organization, cipher.organizationId ?? MY_VAULT_ID);
+    for (const collectionId of cipher.collectionIds ?? []) {
+      increment(counts.collection, collectionId);
+    }
+    increment(counts.folder, cipher.folderId ?? NO_FOLDER_COUNT_KEY);
+  }
+
+  return counts;
+};
+
 const buildProviders = (args: StoryArgs) => {
   const autoFillCiphers$ = new BehaviorSubject(args.autoFillCiphers);
   const favoriteCiphers$ = new BehaviorSubject(args.favoriteCiphers);
@@ -318,6 +350,15 @@ const buildProviders = (args: StoryArgs) => {
         organizations$: of(ORGANIZATION_OPTIONS),
         collections$: of(COLLECTION_OPTIONS),
         folders$: of(FOLDER_OPTIONS),
+        // Counted across every section's ciphers, so the chip counts cover the whole list rather
+        // than just the all-items section.
+        filterOptionCounts$: of(
+          buildOptionCounts([
+            ...args.autoFillCiphers,
+            ...args.favoriteCiphers,
+            ...args.filteredCiphers,
+          ]),
+        ),
       },
     },
     {

--- a/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.stories.ts
+++ b/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.stories.ts
@@ -251,7 +251,8 @@ const FOLDER_OPTIONS = [
     value: { id: "folder-work", name: "Work" } as FolderView,
     label: "Work",
     children: [
-      { value: { id: "folder-work-eu", name: "Work/EU" } as FolderView, label: "Work/EU" },
+      // Nested nodes carry only their trailing segment; the component rejoins the full path.
+      { value: { id: "folder-work-eu", name: "Work/EU" } as FolderView, label: "EU" },
     ],
   },
   { value: { id: "folder-personal", name: "Personal" } as FolderView, label: "Personal" },

--- a/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.stories.ts
+++ b/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.stories.ts
@@ -269,14 +269,14 @@ const buildProviders = (args: StoryArgs) => {
         currentTabIsOnBlocklist$: of(args.currentUriIsBlocked ?? false),
         autofillAllowed$: of(false),
         currentAutofillTab$: of(null),
-        doAutofill: async () => {},
+        doAutofill: async () => { },
       },
     },
     {
       provide: VaultPopupSectionService,
       useValue: {
         getOpenDisplayStateForSection: () => () => true,
-        updateSectionOpenStoredState: async () => {},
+        updateSectionOpenStoredState: async () => { },
       },
     },
     {
@@ -312,6 +312,12 @@ const buildProviders = (args: StoryArgs) => {
           refresh: "Refresh",
           favorites: "Favorites",
           allItems: "All items",
+          // app-simplified-autofill-info
+          openSimplifiedAutofillPopover: "Open simplified autofill popover",
+          simplifiedAutofill: "Simplified autofill",
+          simplifiedAutofillDescription:
+            "When you click a suggested autofill item, it fills rather than taking you to details. You can still view these items from the More menu.",
+          gotIt: "Got it",
           typeLogin: "Login",
           typeCard: "Card",
           typeIdentity: "Identity",
@@ -361,7 +367,7 @@ const buildProviders = (args: StoryArgs) => {
           archiveVerb: "Archive",
           upgradeToUseArchive: "Upgrade to use archive",
           delete: "Delete",
-          launchWebsite: "Launch website",
+          launchWebsiteName: "Launch website",
           itemCount: "__$1__ items",
         }),
     },
@@ -387,7 +393,7 @@ const buildProviders = (args: StoryArgs) => {
       provide: StateProvider,
       useValue: {
         getUserState$: () => of({ hasSeen: false, hasDismissed: false }),
-        getUser: () => ({ update: async () => {} }),
+        getUser: () => ({ update: async () => { } }),
       },
     },
     {

--- a/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.stories.ts
+++ b/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.stories.ts
@@ -312,12 +312,6 @@ const buildProviders = (args: StoryArgs) => {
           refresh: "Refresh",
           favorites: "Favorites",
           allItems: "All items",
-          // app-simplified-autofill-info
-          openSimplifiedAutofillPopover: "Open simplified autofill popover",
-          simplifiedAutofill: "Simplified autofill",
-          simplifiedAutofillDescription:
-            "When you click a suggested autofill item, it fills rather than taking you to details. You can still view these items from the More menu.",
-          gotIt: "Got it",
           typeLogin: "Login",
           typeCard: "Card",
           typeIdentity: "Identity",

--- a/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.stories.ts
+++ b/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.stories.ts
@@ -251,7 +251,7 @@ const FOLDER_OPTIONS = [
     value: { id: "folder-work", name: "Work" } as FolderView,
     label: "Work",
     children: [
-      // Nested nodes carry only their trailing segment; the component rejoins the full path.
+      // Nested nodes carry only their trailing segment, which is what the option renders.
       { value: { id: "folder-work-eu", name: "Work/EU" } as FolderView, label: "EU" },
     ],
   },

--- a/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.stories.ts
+++ b/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.stories.ts
@@ -329,6 +329,9 @@ const buildProviders = (args: StoryArgs) => {
         loading$: loading$.asObservable(),
         searchText$: searchText$.asObservable(),
         hasSearchText$: hasSearchText$.asObservable(),
+        // The table withholds its rows and shows the suspended-organization notice when true; no
+        // story exercises that state, so it stays off.
+        showDeactivatedOrg$: of(false),
         applyFilter,
       },
     },

--- a/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.stories.ts
+++ b/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.stories.ts
@@ -1,3 +1,5 @@
+import { computed, signal } from "@angular/core";
+import { FormControl, FormGroup } from "@angular/forms";
 import { Router } from "@angular/router";
 import { applicationConfig, Meta, StoryObj } from "@storybook/angular";
 import { BehaviorSubject, of } from "rxjs";
@@ -25,6 +27,7 @@ import { VaultSettingsService } from "@bitwarden/common/vault/abstractions/vault
 import { CipherType } from "@bitwarden/common/vault/enums";
 import { AttachmentView } from "@bitwarden/common/vault/models/view/attachment.view";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+import { FolderView } from "@bitwarden/common/vault/models/view/folder.view";
 import { LoginUriView } from "@bitwarden/common/vault/models/view/login-uri.view";
 import { CipherAuthorizationService } from "@bitwarden/common/vault/services/cipher-authorization.service";
 import { RestrictedItemTypesService } from "@bitwarden/common/vault/services/restricted-item-types.service";
@@ -39,6 +42,12 @@ import { PasswordRepromptService, VaultCopyButtonsService } from "@bitwarden/vau
 
 import { VaultPopupAutofillService } from "../../../services/vault-popup-autofill.service";
 import { VaultPopupItemsService } from "../../../services/vault-popup-items.service";
+import {
+  MY_VAULT_ID,
+  PopupListFilter,
+  VaultPopupListFiltersService,
+} from "../../../services/vault-popup-list-filters.service";
+import { VaultSection } from "../../../services/vault-popup-list-table.service";
 import { VaultPopupLoadingService } from "../../../services/vault-popup-loading.service";
 import { VaultPopupSectionService } from "../../../services/vault-popup-section.service";
 import { PopupCipherViewLike } from "../../../views/popup-cipher.view";
@@ -213,7 +222,46 @@ type StoryArgs = {
   simplifiedItemActionEnabled?: boolean;
   /** Legacy (flag-off) setting: whether clicking an autofill suggestion fills it. Defaults to on. */
   clickItemsToAutofillVaultView?: boolean;
+  /** Filters pre-applied to `filterForm`, so the chips render in their active state. */
+  appliedFilters?: Partial<PopupListFilter>;
+  /** Sections rendered collapsed. Defaults to all expanded. */
+  collapsedSections?: VaultSection[];
 };
+
+// Option sets for the toolbar's filter chips. Organizations/collections/folders are only rendered
+// when their stream has entries, so these also control which chips appear.
+const ORGANIZATION_OPTIONS = [
+  { value: { id: MY_VAULT_ID } as Organization, label: "My vault", icon: "bwi-user" as const },
+  {
+    value: { id: "org-engineering" } as Organization,
+    label: "Acme Co",
+    icon: "bwi-business" as const,
+  },
+];
+
+const COLLECTION_OPTIONS = [
+  { value: { id: "col-eng", name: "Engineering" } as CollectionView, label: "Engineering" },
+  { value: { id: "col-mkt", name: "Marketing" } as CollectionView, label: "Marketing" },
+];
+
+// Nested to exercise the tree flattening: the child renders as its own option.
+const FOLDER_OPTIONS = [
+  {
+    value: { id: "folder-work", name: "Work" } as FolderView,
+    label: "Work",
+    children: [
+      { value: { id: "folder-work-eu", name: "Work/EU" } as FolderView, label: "Work/EU" },
+    ],
+  },
+  { value: { id: "folder-personal", name: "Personal" } as FolderView, label: "Personal" },
+];
+
+const CIPHER_TYPE_OPTIONS = [
+  { value: CipherType.Login, label: "Login" },
+  { value: CipherType.Card, label: "Card" },
+  { value: CipherType.Identity, label: "Identity" },
+  { value: CipherType.SecureNote, label: "Note" },
+];
 
 const buildProviders = (args: StoryArgs) => {
   const autoFillCiphers$ = new BehaviorSubject(args.autoFillCiphers);
@@ -245,8 +293,31 @@ const buildProviders = (args: StoryArgs) => {
     },
   } as Window;
 
+  // A real `FormGroup`, since the chips are bridged to it rather than owning their own state; the
+  // story's `appliedFilters` seed it exactly the way the view cache does on a real popup open.
+  const filterForm = new FormGroup({
+    organization: new FormControl<Organization | null>(args.appliedFilters?.organization ?? null),
+    collection: new FormControl<CollectionView | null>(args.appliedFilters?.collection ?? null),
+    folder: new FormControl<FolderView | null>(args.appliedFilters?.folder ?? null),
+    cipherType: new FormControl<CipherType | null>(args.appliedFilters?.cipherType ?? null),
+  });
+
+  // A signal, matching the real service's `Signal<boolean | undefined>` return, so toggling a
+  // section header in the story actually re-renders it.
+  const collapsedSections = signal(new Set(args.collapsedSections ?? []));
+
   return [
     { provide: WINDOW, useValue: fakeWindow },
+    {
+      provide: VaultPopupListFiltersService,
+      useValue: {
+        filterForm,
+        cipherTypes$: of(CIPHER_TYPE_OPTIONS),
+        organizations$: of(ORGANIZATION_OPTIONS),
+        collections$: of(COLLECTION_OPTIONS),
+        folders$: of(FOLDER_OPTIONS),
+      },
+    },
     {
       provide: VaultPopupItemsService,
       useValue: {
@@ -275,8 +346,20 @@ const buildProviders = (args: StoryArgs) => {
     {
       provide: VaultPopupSectionService,
       useValue: {
-        getOpenDisplayStateForSection: () => () => true,
-        updateSectionOpenStoredState: async () => { },
+        getOpenDisplayStateForSection: (section: VaultSection) =>
+          computed(() => !collapsedSections().has(section)),
+        updateSectionOpenStoredState: async (section: VaultSection, open: boolean) => {
+          // Persisted for real by the section service; here it just keeps the story interactive.
+          collapsedSections.update((sections) => {
+            const next = new Set(sections);
+            if (open) {
+              next.delete(section);
+            } else {
+              next.add(section);
+            }
+            return next;
+          });
+        },
       },
     },
     {
@@ -363,6 +446,24 @@ const buildProviders = (args: StoryArgs) => {
           delete: "Delete",
           launchWebsiteForName: "Launch __$1__",
           itemCount: "__$1__ items",
+          // Toolbar filter chips (and the responsive filter dialog they collapse into)
+          all: "All",
+          type: "Type",
+          vault: "Vault",
+          vaults: "Vaults",
+          collection: "Collection",
+          sharedFolders: "Shared folders",
+          folder: "Folder",
+          myFolders: "My folders",
+          filter: "Filter",
+          filters: "Filters",
+          filtersSelected: "__$1__ selected",
+          removeItem: "Remove __$1__",
+          clear: "Clear",
+          clearAll: "Clear all",
+          done: "Done",
+          back: "Back",
+          noMatchingItems: "No matching items",
         }),
     },
     {
@@ -514,6 +615,49 @@ export const LegacyAutofillButton: Story = {
         loading: false,
         simplifiedItemActionEnabled: false,
         clickItemsToAutofillVaultView: false,
+      }),
+    }),
+  ],
+  render: () => ({
+    template: `<div class="tw-flex tw-flex-col" style="height: 500px"><app-vault-popup-list-table></app-vault-popup-list-table></div>`,
+  }),
+};
+
+// Filters pre-applied to `filterForm`: the Type and Vault chips render in their active (selected)
+// styling with the selection reflected in the chip label. Narrow the viewport in Storybook to see
+// the chip row collapse into the sliders trigger, with these shown as dismissible active-filter
+// chips beneath it.
+export const ActiveFilters: Story = {
+  decorators: [
+    applicationConfig({
+      providers: buildProviders({
+        autoFillCiphers: AUTOFILL_CIPHERS,
+        favoriteCiphers: FAVORITE_CIPHERS,
+        filteredCiphers: [...AUTOFILL_CIPHERS, ...FAVORITE_CIPHERS, ...ALL_ITEM_CIPHERS],
+        loading: false,
+        appliedFilters: {
+          cipherType: CipherType.Login,
+          organization: ORGANIZATION_OPTIONS[1].value,
+        },
+      }),
+    }),
+  ],
+  render: () => ({
+    template: `<div class="tw-flex tw-flex-col" style="height: 500px"><app-vault-popup-list-table></app-vault-popup-list-table></div>`,
+  }),
+};
+
+// Both collapsible sections start closed, so only their headers render. The autofill section has no
+// `collapsible` (its suggestions are always shown), so it stays expanded.
+export const CollapsedSections: Story = {
+  decorators: [
+    applicationConfig({
+      providers: buildProviders({
+        autoFillCiphers: AUTOFILL_CIPHERS,
+        favoriteCiphers: FAVORITE_CIPHERS,
+        filteredCiphers: [...AUTOFILL_CIPHERS, ...FAVORITE_CIPHERS, ...ALL_ITEM_CIPHERS],
+        loading: false,
+        collapsedSections: ["favorites", "allItems"],
       }),
     }),
   ],

--- a/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.stories.ts
+++ b/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.stories.ts
@@ -386,7 +386,7 @@ const buildProviders = (args: StoryArgs) => {
         currentTabIsOnBlocklist$: of(args.currentUriIsBlocked ?? false),
         autofillAllowed$: of(false),
         currentAutofillTab$: of(null),
-        doAutofill: async () => { },
+        doAutofill: async () => {},
       },
     },
     {
@@ -534,7 +534,7 @@ const buildProviders = (args: StoryArgs) => {
       provide: StateProvider,
       useValue: {
         getUserState$: () => of({ hasSeen: false, hasDismissed: false }),
-        getUser: () => ({ update: async () => { } }),
+        getUser: () => ({ update: async () => {} }),
       },
     },
     {

--- a/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.stories.ts
+++ b/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.stories.ts
@@ -40,6 +40,7 @@ import {
 import { StateProvider } from "@bitwarden/state";
 import { PasswordRepromptService, VaultCopyButtonsService } from "@bitwarden/vault";
 
+import { PopupWidthOptions } from "../../../../../platform/browser/browser-popup-utils";
 import { VaultPopupAutofillService } from "../../../services/vault-popup-autofill.service";
 import { VaultPopupItemsService } from "../../../services/vault-popup-items.service";
 import {
@@ -645,6 +646,16 @@ export const ActiveFilters: Story = {
   render: () => ({
     template: `<div class="tw-flex tw-flex-col" style="height: 500px"><app-vault-popup-list-table></app-vault-popup-list-table></div>`,
   }),
+  parameters: {
+    // The toolbar picks its presentation from the *viewport* (`matchMedia`), not from the host
+    // element's width, so a story constrained by CSS alone still renders the wide chip row on a wide
+    // screen — the one presentation the extension never shows. Pin the widths instead: every popup
+    // size (380/480/600) is below the `md` breakpoint, so the popup always collapses the chip row
+    // into the sliders trigger + filter dialog. 1280 keeps the wide row covered for the sidebar.
+    chromatic: {
+      viewports: [PopupWidthOptions.narrow, PopupWidthOptions.default, 1280],
+    },
+  },
 };
 
 // Both collapsible sections start closed, so only their headers render. The autofill section has no

--- a/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.stories.ts
+++ b/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.stories.ts
@@ -361,7 +361,7 @@ const buildProviders = (args: StoryArgs) => {
           archiveVerb: "Archive",
           upgradeToUseArchive: "Upgrade to use archive",
           delete: "Delete",
-          launchWebsiteName: "Launch __$1__",
+          launchWebsiteForName: "Launch __$1__",
           itemCount: "__$1__ items",
         }),
     },

--- a/apps/browser/src/vault/popup/components/vault/vault.component.html
+++ b/apps/browser/src/vault/popup/components/vault/vault.component.html
@@ -121,12 +121,12 @@
 
   @if (vaultState !== VaultStateEnum.Empty) {
     <!--
-      The table owns the search input, so it has to stay mounted in the no-results state —
-      unmounting it would remove the only way to clear the term, and it renders its own empty
-      state. It must still yield to the deactivated-org state, which exists to stop showing items
-      belonging to a suspended organization.
+      The table owns the search input and the filter chips, so it stays mounted in the no-results
+      AND deactivated-org states — unmounting it would remove the only way to clear the term or the
+      organization filter that produced the state. It renders both messages in its own empty slot,
+      so no rows belonging to a suspended organization are shown either way.
     -->
-    @if (vfo1Enabled() && vaultState !== VaultStateEnum.DeactivatedOrg) {
+    @if (vfo1Enabled()) {
       <app-vault-popup-list-table></app-vault-popup-list-table>
     } @else if (!vfo1Enabled() && vaultState === VaultStateEnum.NoResults) {
       <div class="tw-flex tw-flex-col tw-justify-center tw-h-full">
@@ -140,12 +140,14 @@
     <!-- For better consistency with screen readers, the role/aria needs to be on an element that isn't dynamic by @if -->
     <!-- The height is bound rather than static so the empty region stays rendered (and so still in
          the accessibility tree) without claiming space it isn't using. -->
+    <!-- Only the legacy list needs this block: the table renders the same notice in its empty slot,
+         so leaving it unguarded would show the message twice with the flag on. -->
     <div
       role="status"
       aria-live="polite"
-      [class.tw-h-full]="vaultState === VaultStateEnum.DeactivatedOrg"
+      [class.tw-h-full]="!vfo1Enabled() && vaultState === VaultStateEnum.DeactivatedOrg"
     >
-      @if (vaultState === VaultStateEnum.DeactivatedOrg) {
+      @if (!vfo1Enabled() && vaultState === VaultStateEnum.DeactivatedOrg) {
         <div class="tw-flex tw-flex-col tw-justify-center tw-h-full">
           <bit-no-items class="[&>div]:!tw-pt-0" [icon]="deactivatedIcon">
             <ng-container slot="title">

--- a/apps/browser/src/vault/popup/components/vault/vault.component.spec.ts
+++ b/apps/browser/src/vault/popup/components/vault/vault.component.spec.ts
@@ -593,17 +593,32 @@ describe("VaultComponent", () => {
     }));
 
     /**
-     * The deactivated-org state exists to stop showing items belonging to a suspended
-     * organization, so the table must yield to it rather than render alongside it.
+     * The table carries the organization filter that produces this state, so unmounting it would
+     * leave the filter applied with no control able to clear it. It stays mounted and renders the
+     * notice (and withholds the suspended organization's rows) in its own empty slot, so the
+     * page-level block must stand down to avoid showing the message twice.
      */
-    it("unmounts the table in the deactivated-org state", fakeAsync(() => {
+    it("keeps the table mounted in the deactivated-org state", fakeAsync(() => {
       const fixture = createWithFlag(true);
 
       itemsSvc.showDeactivatedOrg$.next(true);
       tick();
       fixture.detectChanges();
 
-      expect(fixture.nativeElement.querySelector("app-vault-popup-list-table")).toBeNull();
+      expect(fixture.nativeElement.querySelector("app-vault-popup-list-table")).toBeTruthy();
+      // The table is stubbed here, so the notice it renders is covered in its own spec.
+      expect(fixture.nativeElement.textContent).not.toContain("organizationIsDeactivated");
+
+      flush();
+    }));
+
+    it("still renders the page-level deactivated-org notice when the flag is off", fakeAsync(() => {
+      const fixture = createWithFlag(false);
+
+      itemsSvc.showDeactivatedOrg$.next(true);
+      tick();
+      fixture.detectChanges();
+
       expect(fixture.nativeElement.textContent).toContain("organizationIsDeactivated");
 
       flush();

--- a/apps/browser/src/vault/popup/components/vault/vault.component.spec.ts
+++ b/apps/browser/src/vault/popup/components/vault/vault.component.spec.ts
@@ -499,7 +499,7 @@ describe("VaultComponent", () => {
     allFilters$.next({});
     tick();
 
-    const initialCalls = scrollSvc.start.mock.calls.length;
+    const initialCalls = (scrollSvc.start as jest.Mock).mock.calls.length;
     expect(initialCalls).toBeGreaterThan(0);
 
     // A later host takes over, as the table's viewport does once it renders.
@@ -508,7 +508,7 @@ describe("VaultComponent", () => {
     tick();
 
     expect(scrollSvc.start).toHaveBeenCalledWith(viewport);
-    expect(scrollSvc.start.mock.calls.length).toBeGreaterThan(initialCalls);
+    expect((scrollSvc.start as jest.Mock).mock.calls.length).toBeGreaterThan(initialCalls);
 
     flush();
   }));

--- a/apps/browser/src/vault/popup/components/vault/vault.stories.ts
+++ b/apps/browser/src/vault/popup/components/vault/vault.stories.ts
@@ -47,6 +47,7 @@ import { VaultSettingsService } from "@bitwarden/common/vault/abstractions/vault
 import { CipherType } from "@bitwarden/common/vault/enums";
 import { AttachmentView } from "@bitwarden/common/vault/models/view/attachment.view";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+import { FolderView } from "@bitwarden/common/vault/models/view/folder.view";
 import { LoginUriView } from "@bitwarden/common/vault/models/view/login-uri.view";
 import { CipherAuthorizationService } from "@bitwarden/common/vault/services/cipher-authorization.service";
 import { RestrictedItemTypesService } from "@bitwarden/common/vault/services/restricted-item-types.service";
@@ -72,7 +73,10 @@ import { PopupRouterCacheService } from "../../../../platform/popup/view-cache/p
 import { IntroCarouselService } from "../../services/intro-carousel.service";
 import { VaultPopupAutofillService } from "../../services/vault-popup-autofill.service";
 import { VaultPopupItemsService } from "../../services/vault-popup-items.service";
-import { VaultPopupListFiltersService } from "../../services/vault-popup-list-filters.service";
+import {
+  MY_VAULT_ID,
+  VaultPopupListFiltersService,
+} from "../../services/vault-popup-list-filters.service";
 import { VaultPopupLoadingService } from "../../services/vault-popup-loading.service";
 import { VaultPopupScrollPositionService } from "../../services/vault-popup-scroll-position.service";
 import { VaultPopupSectionService } from "../../services/vault-popup-section.service";
@@ -236,6 +240,54 @@ const STORY_USER_ID = "00000000-0000-4000-8000-0000000000ff" as UserId;
 const STORY_ORG_ID = "00000000-0000-4000-8000-0000000000fe" as OrganizationId;
 
 /**
+ * Options for the list table's toolbar filter chips (VFO1 on). Each chip only renders when its
+ * stream has entries, so these decide which of Vault / Shared folders / My folders appear at all —
+ * without them the toolbar would show a lone inert Type chip, under-representing the real one.
+ *
+ * IDs are fixed rather than generated: these feed chip labels that Chromatic snapshots.
+ */
+const FILTER_ORGANIZATION_OPTIONS = [
+  { value: { id: MY_VAULT_ID } as Organization, label: "My vault", icon: "bwi-user" as const },
+  { value: { id: STORY_ORG_ID } as Organization, label: "Acme Co", icon: "bwi-business" as const },
+];
+
+const FILTER_COLLECTION_OPTIONS = [
+  {
+    value: { id: "00000000-0000-4000-8000-0000000000fa", name: "Engineering" } as CollectionView,
+    label: "Engineering",
+  },
+  {
+    value: { id: "00000000-0000-4000-8000-0000000000fb", name: "Marketing" } as CollectionView,
+    label: "Marketing",
+  },
+];
+
+// Nested, to exercise the chip's tree flattening: the child renders as its own option.
+const FILTER_FOLDER_OPTIONS = [
+  {
+    value: { id: "00000000-0000-4000-8000-0000000000fc", name: "Work" } as FolderView,
+    label: "Work",
+    children: [
+      {
+        value: { id: "00000000-0000-4000-8000-0000000000fd", name: "Work/EU" } as FolderView,
+        label: "Work/EU",
+      },
+    ],
+  },
+  {
+    value: { id: "00000000-0000-4000-8000-0000000000f9", name: "Personal" } as FolderView,
+    label: "Personal",
+  },
+];
+
+const FILTER_CIPHER_TYPE_OPTIONS = [
+  { value: CipherType.Login, label: "Login" },
+  { value: CipherType.Card, label: "Card" },
+  { value: CipherType.Identity, label: "Identity" },
+  { value: CipherType.SecureNote, label: "Note" },
+];
+
+/**
  * Fixed so the org-notification banner's revision date never shifts between Chromatic builds. The
  * banner compares this against the dismissal timestamp in state (kept `null`) to decide visibility.
  */
@@ -385,14 +437,23 @@ const buildProviders = (args: StoryArgs) => {
       useValue: {
         // The component's `loading$` stays true until `allFilters$` emits, so this must be a
         // BehaviorSubject-like stream with a value rather than a bare `Subject`.
-        allFilters$: of({ organizations: [], collections: [], folders: [] }),
+        // Kept in step with the individual streams below: the legacy (VFO1-off) header reads this
+        // one, the list table's chips read those, and a mismatch would make the two presentations
+        // disagree about which filters exist.
+        allFilters$: of({
+          organizations: FILTER_ORGANIZATION_OPTIONS,
+          collections: FILTER_COLLECTION_OPTIONS,
+          folders: FILTER_FOLDER_OPTIONS,
+        }),
+        // No filters applied, so the chips render in their unset state and the legacy header's
+        // count badge stays hidden — matching `hasFilterApplied$: of(false)` above.
         filters$: of({}),
         filterVisibilityState$: of(false),
         numberOfAppliedFilters$: of(0),
-        organizations$: of([]),
-        collections$: of([]),
-        folders$: of([]),
-        cipherTypes$: of([]),
+        organizations$: of(FILTER_ORGANIZATION_OPTIONS),
+        collections$: of(FILTER_COLLECTION_OPTIONS),
+        folders$: of(FILTER_FOLDER_OPTIONS),
+        cipherTypes$: of(FILTER_CIPHER_TYPE_OPTIONS),
         // `app-vault-list-filters` binds this directly to a `[formGroup]`, so it has to be a real
         // FormGroup with the controls the template names.
         filterForm: new FormBuilder().group({
@@ -629,6 +690,21 @@ const buildProviders = (args: StoryArgs) => {
           collection: "Collection",
           folder: "Folder",
           type: "Type",
+          // The list table's filter chips (flag on). The three vfo1-terminology chips resolve to
+          // the plural VFO1 keys, so omitting those makes `Vfo1I18nPipe` throw and the chips render
+          // label-less.
+          vaults: "Vaults",
+          sharedFolders: "Shared folders",
+          myFolders: "My folders",
+          all: "All",
+          // The chips' menus, and the dialog the filter row collapses into below `md`.
+          filter: "Filter",
+          filtersSelected: "__$1__ selected",
+          removeItem: "Remove __$1__",
+          clear: "Clear",
+          clearAll: "Clear all",
+          done: "Done",
+          noMatchingItems: "No matching items",
           // Legacy grouped list containers
           searchResults: "Search results",
           favorites: "Favorites",

--- a/apps/browser/src/vault/popup/components/vault/vault.stories.ts
+++ b/apps/browser/src/vault/popup/components/vault/vault.stories.ts
@@ -457,6 +457,14 @@ const buildProviders = (args: StoryArgs) => {
         collections$: of(FILTER_COLLECTION_OPTIONS),
         folders$: of(FILTER_FOLDER_OPTIONS),
         cipherTypes$: of(FILTER_CIPHER_TYPE_OPTIONS),
+        // Empty maps: the chips' option counts fall back to zero. The list-table stories are where
+        // counts are exercised against real ciphers; these stories cover the page around them.
+        filterOptionCounts$: of({
+          cipherType: new Map(),
+          organization: new Map(),
+          collection: new Map(),
+          folder: new Map(),
+        }),
         // `app-vault-list-filters` binds this directly to a `[formGroup]`, so it has to be a real
         // FormGroup with the controls the template names.
         filterForm: new FormBuilder().group({

--- a/apps/browser/src/vault/popup/components/vault/vault.stories.ts
+++ b/apps/browser/src/vault/popup/components/vault/vault.stories.ts
@@ -270,8 +270,10 @@ const FILTER_FOLDER_OPTIONS = [
     label: "Work",
     children: [
       {
+        // Nesting splits the name and keeps only the trailing segment on each node, so the real
+        // `folders$` labels this "EU" — never the full "Work/EU" path.
         value: { id: "00000000-0000-4000-8000-0000000000fd", name: "Work/EU" } as FolderView,
-        label: "Work/EU",
+        label: "EU",
       },
     ],
   },

--- a/apps/browser/src/vault/popup/components/vault/vault.stories.ts
+++ b/apps/browser/src/vault/popup/components/vault/vault.stories.ts
@@ -65,7 +65,7 @@ import {
 } from "@bitwarden/components";
 import { LogService } from "@bitwarden/logging";
 import { StateProvider } from "@bitwarden/state";
-import { enabledFlags, featureFlagModes } from "@bitwarden/storybook";
+import { enabledFlags, featureFlagModesAtWidth } from "@bitwarden/storybook";
 import { PasswordRepromptService, VaultCopyButtonsService } from "@bitwarden/vault";
 
 import AutofillService from "../../../../autofill/services/autofill.service";
@@ -813,13 +813,14 @@ export default {
     // story already provides `ConfigService` via `applicationConfig` — so this file must not provide
     // one, or the modes would silently stop taking effect.
     //
-    // The viewport is pinned to the popup's own width because `popupFrame` constrains the story with
-    // CSS, while the list table's toolbar picks its presentation from `matchMedia` — so on a wide
-    // screen these would snapshot the inline chip row, which the extension never shows. Every popup
-    // width is below `md`, so the real popup always collapses the chips into the filter dialog.
+    // Each mode also pins the viewport to the popup's own width: `popupFrame` constrains the story
+    // with CSS, while the list table's toolbar picks its presentation from `matchMedia` — so on a
+    // wide screen these would snapshot the inline chip row, which the extension never shows. Every
+    // popup width is below `md`, so the real popup always collapses the chips into the filter
+    // dialog. The width rides inside each mode because Chromatic rejects `viewports` and `modes`
+    // together on one story.
     chromatic: {
-      modes: featureFlagModes(FeatureFlag.VFO1Foundation),
-      viewports: [PopupWidthOptions.narrow],
+      modes: featureFlagModesAtWidth(PopupWidthOptions.narrow, FeatureFlag.VFO1Foundation),
     },
   },
 } as Meta<VaultComponent>;
@@ -916,12 +917,20 @@ export const WithNotifications: Story = {
   ...buildStory({ showOrgNotification: true }),
   parameters: {
     chromatic: {
+      // This map replaces the meta-level one wholesale, so it has to re-pin the popup width too —
+      // see the note there on why the width rides inside each mode.
       modes: {
-        "flag off": enabledFlags(FeatureFlag.PM31948_OrgUserNotificationBanner),
-        "flag on": enabledFlags(
-          FeatureFlag.PM31948_OrgUserNotificationBanner,
-          FeatureFlag.VFO1Foundation,
-        ),
+        "flag off": {
+          ...enabledFlags(FeatureFlag.PM31948_OrgUserNotificationBanner),
+          viewport: { width: PopupWidthOptions.narrow },
+        },
+        "flag on": {
+          ...enabledFlags(
+            FeatureFlag.PM31948_OrgUserNotificationBanner,
+            FeatureFlag.VFO1Foundation,
+          ),
+          viewport: { width: PopupWidthOptions.narrow },
+        },
       },
     },
   },

--- a/apps/browser/src/vault/popup/components/vault/vault.stories.ts
+++ b/apps/browser/src/vault/popup/components/vault/vault.stories.ts
@@ -69,6 +69,7 @@ import { enabledFlags, featureFlagModes } from "@bitwarden/storybook";
 import { PasswordRepromptService, VaultCopyButtonsService } from "@bitwarden/vault";
 
 import AutofillService from "../../../../autofill/services/autofill.service";
+import { PopupWidthOptions } from "../../../../platform/browser/browser-popup-utils";
 import { PopupRouterCacheService } from "../../../../platform/popup/view-cache/popup-router-cache.service";
 import { IntroCarouselService } from "../../services/intro-carousel.service";
 import { VaultPopupAutofillService } from "../../services/vault-popup-autofill.service";
@@ -811,7 +812,15 @@ export default {
     // mock `ConfigService` at the application root. That decorator explicitly SKIPS itself when the
     // story already provides `ConfigService` via `applicationConfig` — so this file must not provide
     // one, or the modes would silently stop taking effect.
-    chromatic: { modes: featureFlagModes(FeatureFlag.VFO1Foundation) },
+    //
+    // The viewport is pinned to the popup's own width because `popupFrame` constrains the story with
+    // CSS, while the list table's toolbar picks its presentation from `matchMedia` — so on a wide
+    // screen these would snapshot the inline chip row, which the extension never shows. Every popup
+    // width is below `md`, so the real popup always collapses the chips into the filter dialog.
+    chromatic: {
+      modes: featureFlagModes(FeatureFlag.VFO1Foundation),
+      viewports: [PopupWidthOptions.narrow],
+    },
   },
 } as Meta<VaultComponent>;
 

--- a/apps/browser/src/vault/popup/services/vault-popup-list-filters.service.spec.ts
+++ b/apps/browser/src/vault/popup/services/vault-popup-list-filters.service.spec.ts
@@ -1,7 +1,7 @@
 import { Injector, WritableSignal, runInInjectionContext, signal } from "@angular/core";
 import { TestBed, discardPeriodicTasks, fakeAsync, tick } from "@angular/core/testing";
 import { FormBuilder } from "@angular/forms";
-import { BehaviorSubject, skipWhile } from "rxjs";
+import { BehaviorSubject, firstValueFrom, skipWhile } from "rxjs";
 
 import { CollectionService } from "@bitwarden/admin-console/common";
 import { ViewCacheService } from "@bitwarden/angular/platform/view-cache";
@@ -35,6 +35,7 @@ import { PopupCipherViewLike } from "../views/popup-cipher.view";
 import {
   CachedFilterState,
   MY_VAULT_ID,
+  NO_FOLDER_COUNT_KEY,
   VaultPopupListFiltersService,
 } from "./vault-popup-list-filters.service";
 
@@ -636,6 +637,110 @@ describe("VaultPopupListFiltersService", () => {
 
         service.filterForm.patchValue({ organization });
       });
+    });
+  });
+
+  describe("filterOptionCounts$", () => {
+    const countedCiphers = [
+      { id: "1", type: CipherType.Login, collectionIds: [], organizationId: null },
+      {
+        id: "2",
+        type: CipherType.Login,
+        collectionIds: [],
+        folderId: "folder-a",
+        organizationId: null,
+      },
+      {
+        id: "3",
+        type: CipherType.Card,
+        collectionIds: [asUuid("cbcae898-9f9a-48eb-863e-edf92e3ad7e0")],
+        organizationId: "org-1",
+      },
+      {
+        id: "4",
+        type: CipherType.Identity,
+        collectionIds: [asUuid("cbcae898-9f9a-48eb-863e-edf92e3ad7e0")],
+        folderId: "folder-a",
+        organizationId: "org-1",
+      },
+    ] as unknown as CipherView[];
+
+    /**
+     * The latest counts for a set of ciphers. `cipherListViews$` is a `BehaviorSubject` shared
+     * across the suite and `filterOptionCounts$` replays, so a bare `subscribe` would see the
+     * previous test's emission first — take the value settled after this test's own input.
+     */
+    const countsFor = async (ciphers: CipherView[]) => {
+      cipherListViews$.next({ ...ciphers });
+      return await firstValueFrom(service.filterOptionCounts$);
+    };
+
+    it("counts the items belonging to each cipher type", async () => {
+      const counts = await countsFor(countedCiphers);
+
+      expect(counts.cipherType.get(CipherType.Login)).toBe(2);
+      expect(counts.cipherType.get(CipherType.Card)).toBe(1);
+      expect(counts.cipherType.get(CipherType.Identity)).toBe(1);
+    });
+
+    it("counts organization-less ciphers under My vault", async () => {
+      const counts = await countsFor(countedCiphers);
+
+      expect(counts.organization.get(MY_VAULT_ID)).toBe(2);
+      expect(counts.organization.get("org-1")).toBe(2);
+    });
+
+    it("counts a cipher toward every collection it belongs to", async () => {
+      const sharedByTwo = {
+        id: "5",
+        type: CipherType.Login,
+        collectionIds: [
+          asUuid("cbcae898-9f9a-48eb-863e-edf92e3ad7e0"),
+          asUuid("dbcae898-9f9a-48eb-863e-edf92e3ad7e1"),
+        ],
+        organizationId: "org-1",
+      } as unknown as CipherView;
+
+      const counts = await countsFor([...countedCiphers, sharedByTwo]);
+
+      expect(counts.collection.get("cbcae898-9f9a-48eb-863e-edf92e3ad7e0")).toBe(3);
+      expect(counts.collection.get("dbcae898-9f9a-48eb-863e-edf92e3ad7e1")).toBe(1);
+    });
+
+    it("counts folderless ciphers under the no-folder key", async () => {
+      const counts = await countsFor(countedCiphers);
+
+      expect(counts.folder.get("folder-a")).toBe(2);
+      expect(counts.folder.get(NO_FOLDER_COUNT_KEY)).toBe(2);
+    });
+
+    it("excludes deleted ciphers from every count", async () => {
+      // `CipherViewLikeUtils.isDeleted` reads `isDeleted` on a `CipherView` (it only consults
+      // `deletedDate` for a `CipherListView`), and these fixtures are the former.
+      const deleted = {
+        id: "6",
+        type: CipherType.Login,
+        collectionIds: [],
+        organizationId: null,
+        isDeleted: true,
+      } as unknown as CipherView;
+
+      const counts = await countsFor([...countedCiphers, deleted]);
+
+      expect(counts.cipherType.get(CipherType.Login)).toBe(2);
+    });
+
+    it("counts the whole vault regardless of which filters are applied", async () => {
+      service.filterForm.patchValue({ organization: { id: "org-1" } as Organization });
+
+      const counts = await countsFor(countedCiphers);
+
+      // Absolute, not faceted: the org filter narrows the list but leaves every count alone.
+      expect(counts.cipherType.get(CipherType.Login)).toBe(2);
+      expect(counts.cipherType.get(CipherType.Card)).toBe(1);
+      expect(counts.cipherType.get(CipherType.Identity)).toBe(1);
+      expect(counts.organization.get(MY_VAULT_ID)).toBe(2);
+      expect(counts.organization.get("org-1")).toBe(2);
     });
   });
 

--- a/apps/browser/src/vault/popup/services/vault-popup-list-filters.service.ts
+++ b/apps/browser/src/vault/popup/services/vault-popup-list-filters.service.ts
@@ -92,6 +92,62 @@ const INITIAL_FILTERS: PopupListFilter = {
   cipherType: null,
 };
 
+/** Whether a cipher satisfies every filter in `filters`. Backs `filterFunction$`. */
+function matchesFilters(cipher: PopupCipherViewLike, filters: Partial<PopupListFilter>): boolean {
+  // Vault popup lists never show deleted ciphers
+  if (CipherViewLikeUtils.isDeleted(cipher)) {
+    return false;
+  }
+
+  if (filters.cipherType != null && CipherViewLikeUtils.getType(cipher) !== filters.cipherType) {
+    return false;
+  }
+
+  if (filters.collection && !cipher.collectionIds?.includes(asUuid(filters.collection.id!))) {
+    return false;
+  }
+
+  if (filters.folder) {
+    if (!filters.folder.id) {
+      // "Items with no folder" (id is falsy): match ciphers where folderId is null, undefined, or empty
+      if (cipher.folderId) {
+        return false;
+      }
+    } else if (cipher.folderId !== filters.folder.id) {
+      return false;
+    }
+  }
+
+  const isMyVault = filters.organization?.id === MY_VAULT_ID;
+
+  if (isMyVault) {
+    if (cipher.organizationId != null) {
+      return false;
+    }
+  } else if (filters.organization) {
+    if (cipher.organizationId !== filters.organization.id) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Item counts for each filter dimension's options, keyed by the option's identity: the
+ * `CipherType` for `cipherType`, and the entity id for the object-valued dimensions ("Items with
+ * no folder" has no id, so it counts under {@link NO_FOLDER_COUNT_KEY}).
+ */
+export type FilterOptionCounts = {
+  cipherType: Map<CipherType, number>;
+  organization: Map<string, number>;
+  collection: Map<string, number>;
+  folder: Map<string, number>;
+};
+
+/** The `folder` count key for the "Items with no folder" option, which has no id of its own. */
+export const NO_FOLDER_COUNT_KEY = "";
+
 @Injectable({
   providedIn: "root",
 })
@@ -239,53 +295,55 @@ export class VaultPopupListFiltersService {
     this.filters$.pipe(
       map(
         (filters) => (ciphers: PopupCipherViewLike[]) =>
-          ciphers.filter((cipher) => {
-            // Vault popup lists never shows deleted ciphers
-            if (CipherViewLikeUtils.isDeleted(cipher)) {
-              return false;
-            }
-
-            if (
-              filters.cipherType !== null &&
-              CipherViewLikeUtils.getType(cipher) !== filters.cipherType
-            ) {
-              return false;
-            }
-
-            if (
-              filters.collection &&
-              !cipher.collectionIds?.includes(asUuid(filters.collection.id!))
-            ) {
-              return false;
-            }
-
-            if (filters.folder) {
-              if (!filters.folder.id) {
-                // "Items with no folder" (id is falsy): match ciphers where folderId is null, undefined, or empty
-                if (cipher.folderId) {
-                  return false;
-                }
-              } else if (cipher.folderId !== filters.folder.id) {
-                return false;
-              }
-            }
-
-            const isMyVault = filters.organization?.id === MY_VAULT_ID;
-
-            if (isMyVault) {
-              if (cipher.organizationId != null) {
-                return false;
-              }
-            } else if (filters.organization) {
-              if (cipher.organizationId !== filters.organization.id) {
-                return false;
-              }
-            }
-
-            return true;
-          }),
+          ciphers.filter((cipher) => matchesFilters(cipher, filters)),
       ),
     );
+
+  /**
+   * Absolute item counts for every filter option: how many of the vault's items belong to each
+   * option, independent of what's currently filtered.
+   *
+   * The applied filters deliberately don't narrow these — an option reads the same whether or not
+   * other chips are set, so the numbers stay stable as the user moves through the menus. Deleted
+   * items are still excluded, since they're never listed.
+   */
+  filterOptionCounts$: Observable<FilterOptionCounts> = this.activeUserId$.pipe(
+    switchMap((userId) => this.cipherService.cipherListViews$(userId)),
+    map((cipherViews) => {
+      const ciphers = cipherViews ? Object.values(cipherViews) : [];
+      const counts: FilterOptionCounts = {
+        cipherType: new Map<CipherType, number>(),
+        organization: new Map<string, number>(),
+        collection: new Map<string, number>(),
+        folder: new Map<string, number>(),
+      };
+
+      const increment = <K>(map: Map<K, number>, key: K) => {
+        map.set(key, (map.get(key) ?? 0) + 1);
+      };
+
+      for (const cipher of ciphers) {
+        if (CipherViewLikeUtils.isDeleted(cipher)) {
+          continue;
+        }
+
+        increment(counts.cipherType, CipherViewLikeUtils.getType(cipher));
+
+        // Ciphers outside an organization belong to the synthetic "My vault" option.
+        increment(counts.organization, cipher.organizationId ?? MY_VAULT_ID);
+
+        // A cipher can sit in several collections, so it counts toward each of them.
+        for (const collectionId of cipher.collectionIds ?? []) {
+          increment(counts.collection, collectionId);
+        }
+
+        increment(counts.folder, cipher.folderId ?? NO_FOLDER_COUNT_KEY);
+      }
+
+      return counts;
+    }),
+    shareReplay({ refCount: true, bufferSize: 1 }),
+  );
 
   /**
    * All available cipher types (filtered by policy restrictions and feature flags)

--- a/apps/browser/src/vault/popup/services/vault-popup-list-filters.service.ts
+++ b/apps/browser/src/vault/popup/services/vault-popup-list-filters.service.ts
@@ -490,11 +490,11 @@ export class VaultPopupListFiltersService {
               // Update `name` of the "no folder" option to "Items with no folder"
               const updatedNoFolder = {
                 ...noFolder,
-                name: this.i18nService.t("itemsWithNoFolder"),
+                name: this.i18nService.t("noFoldersLabel"),
               };
 
               // Move the "no folder" option to the end of the list
-              arrangedFolders = [...folders.filter((f) => f.id), updatedNoFolder];
+              arrangedFolders = [updatedNoFolder, ...folders.filter((f) => f.id)];
             }
             return [filters as PopupListFilter, arrangedFolders, cipherViews];
           },

--- a/apps/browser/src/vault/popup/services/vault-popup-list-table.service.ts
+++ b/apps/browser/src/vault/popup/services/vault-popup-list-table.service.ts
@@ -108,6 +108,13 @@ export class VaultPopupListTableService {
   readonly hasSearchText$ = this.vaultPopupItemsService.hasSearchText$;
 
   /**
+   * Whether the selected organization filter points at a suspended organization. The table stays
+   * mounted in this state (so the filter remains clearable) and surfaces the notice in its empty
+   * slot instead.
+   */
+  readonly showDeactivatedOrg$ = this.vaultPopupItemsService.showDeactivatedOrg$;
+
+  /**
    * The inputs that decide each row's action affordances. `startWith` defaults keep {@link rows$}
    * emitting promptly: the feature flag and blocklist streams resolve asynchronously, so without a
    * seed the whole list would wait on them before first render.

--- a/libs/components/src/table/v2/bit-row.component.ts
+++ b/libs/components/src/table/v2/bit-row.component.ts
@@ -61,29 +61,29 @@ export class BitRowComponent {
       ...(this.fixedHeight() != null ? ["tw-overflow-clip"] : []),
       ...(this.table?.presentation() === "list"
         ? // `list` rows size to content off a `bit-item`-style minimum height.
-          [
-            "tw-min-h-9",
-            "tw-mb-1.5",
-            "tw-rounded-lg",
-            "tw-bg-background",
-            "tw-border-0",
-            "tw-border-b",
-            "tw-border-solid",
-            "tw-border-b-shadow",
-            "hover:tw-bg-hover-default",
-          ]
+        [
+          "tw-min-h-9",
+          "tw-mb-1.5",
+          "tw-rounded-lg",
+          "tw-bg-background",
+          "tw-border-0",
+          "tw-border-b",
+          "tw-border-solid",
+          "tw-border-b-shadow",
+          "hover:tw-bg-hover-default",
+        ]
         : [
-            // Omitted when virtualized: a min-height would clamp a `virtualRowHeight`
-            // below it, breaking the offsets the scroll strategy positions rows at.
-            ...(this.fixedHeight() != null ? [] : ["tw-min-h-14"]),
-            "tw-border-0",
-            "tw-border-b",
-            "tw-border-solid",
-            "tw-border-border-base",
-            "hover:tw-bg-bg-brand-softer",
-            // Outranks the hover rule above on specificity.
-            "has-[[data-selection-input]:checked]:tw-bg-bg-brand-soft",
-          ]),
+          // Omitted when virtualized: a min-height would clamp a `virtualRowHeight`
+          // below it, breaking the offsets the scroll strategy positions rows at.
+          ...(this.fixedHeight() != null ? [] : ["tw-min-h-14"]),
+          "tw-border-0",
+          "tw-border-b",
+          "tw-border-solid",
+          "tw-border-border-base",
+          "hover:tw-bg-bg-brand-softer",
+          // Outranks the hover rule above on specificity.
+          "has-[[data-selection-input]:checked]:tw-bg-bg-brand-soft",
+        ]),
     ].join(" "),
   );
 }

--- a/libs/components/src/table/v2/bit-row.component.ts
+++ b/libs/components/src/table/v2/bit-row.component.ts
@@ -61,29 +61,29 @@ export class BitRowComponent {
       ...(this.fixedHeight() != null ? ["tw-overflow-clip"] : []),
       ...(this.table?.presentation() === "list"
         ? // `list` rows size to content off a `bit-item`-style minimum height.
-        [
-          "tw-min-h-9",
-          "tw-mb-1.5",
-          "tw-rounded-lg",
-          "tw-bg-background",
-          "tw-border-0",
-          "tw-border-b",
-          "tw-border-solid",
-          "tw-border-b-shadow",
-          "hover:tw-bg-hover-default",
-        ]
+          [
+            "tw-min-h-9",
+            "tw-mb-1.5",
+            "tw-rounded-lg",
+            "tw-bg-background",
+            "tw-border-0",
+            "tw-border-b",
+            "tw-border-solid",
+            "tw-border-b-shadow",
+            "hover:tw-bg-hover-default",
+          ]
         : [
-          // Omitted when virtualized: a min-height would clamp a `virtualRowHeight`
-          // below it, breaking the offsets the scroll strategy positions rows at.
-          ...(this.fixedHeight() != null ? [] : ["tw-min-h-14"]),
-          "tw-border-0",
-          "tw-border-b",
-          "tw-border-solid",
-          "tw-border-border-base",
-          "hover:tw-bg-bg-brand-softer",
-          // Outranks the hover rule above on specificity.
-          "has-[[data-selection-input]:checked]:tw-bg-bg-brand-soft",
-        ]),
+            // Omitted when virtualized: a min-height would clamp a `virtualRowHeight`
+            // below it, breaking the offsets the scroll strategy positions rows at.
+            ...(this.fixedHeight() != null ? [] : ["tw-min-h-14"]),
+            "tw-border-0",
+            "tw-border-b",
+            "tw-border-solid",
+            "tw-border-border-base",
+            "hover:tw-bg-bg-brand-softer",
+            // Outranks the hover rule above on specificity.
+            "has-[[data-selection-input]:checked]:tw-bg-bg-brand-soft",
+          ]),
     ].join(" "),
   );
 }

--- a/libs/storybook/src/addons/feature-flags/constants.spec.ts
+++ b/libs/storybook/src/addons/feature-flags/constants.spec.ts
@@ -1,4 +1,4 @@
-import { FEATURE_FLAGS_GLOBAL, featureFlagModes } from "./constants";
+import { FEATURE_FLAGS_GLOBAL, featureFlagModes, featureFlagModesAtWidth } from "./constants";
 
 describe("featureFlagModes", () => {
   it("builds off and on Chromatic modes for the given flags", () => {
@@ -6,5 +6,17 @@ describe("featureFlagModes", () => {
 
     expect(modes["flag off"]).toEqual({ [FEATURE_FLAGS_GLOBAL]: [] });
     expect(modes["flag on"]).toEqual({ [FEATURE_FLAGS_GLOBAL]: ["flag-a", "flag-b"] });
+  });
+});
+
+describe("featureFlagModesAtWidth", () => {
+  it("pins every mode to the given width", () => {
+    const modes = featureFlagModesAtWidth(400, "flag-a");
+
+    expect(modes["flag off"]).toEqual({ [FEATURE_FLAGS_GLOBAL]: [], viewport: { width: 400 } });
+    expect(modes["flag on"]).toEqual({
+      [FEATURE_FLAGS_GLOBAL]: ["flag-a"],
+      viewport: { width: 400 },
+    });
   });
 });

--- a/libs/storybook/src/addons/feature-flags/constants.ts
+++ b/libs/storybook/src/addons/feature-flags/constants.ts
@@ -53,3 +53,21 @@ export function featureFlagModes(...flags: string[]) {
     "flag on": enabledFlags(...flags),
   };
 }
+
+/**
+ * Same as {@link featureFlagModes}, but also pins each mode to `width`.
+ *
+ * Chromatic rejects `viewports` and `modes` on the same story, so a story that needs both a
+ * flag matrix and a fixed width has to carry the width *inside* each mode instead.
+ *
+ * ```ts
+ * parameters: { chromatic: { modes: featureFlagModesAtWidth(400, FeatureFlag.Foobar) } },
+ * ```
+ */
+export function featureFlagModesAtWidth(width: number, ...flags: string[]) {
+  const viewport = { width };
+  return {
+    "flag off": { ...enabledFlags(), viewport },
+    "flag on": { ...enabledFlags(...flags), viewport },
+  };
+}


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-40327

> [!NOTE]
> Stacked on #22288 (PM-40329). Review that one first — this PR targets its branch, so the diff here is just this ticket's work.

## 📔 Objective

Wires the vault popup list table's toolbar filters to `VaultPopupListFiltersService`: the Type / Vault / Shared folders / My folders chips, seeded from the filter form and pushing edits back.

**The form stays the source of truth.** The library's `bit-filter-menu` chips own their selection rather than implementing `ControlValueAccessor`, but the popup's filter state has to live on `filterForm` — `filterFunction$`, the view-cache serialization, and the option streams all read it, and the non-table vault header still writes it. Rather than moving ownership onto the chips, the new `VaultFilterChipDirective` bridges the two, syncing both directions with a re-entrancy guard.

Two notes on scope, both deliberate:

- **No `[filter]` binding on the table.** The ticket called for supplying it from `filterFunction$`, but rows arrive already filtered: all three row sources (`filteredCiphers$`, `autoFillCiphers$`, `favoriteCiphers$`) derive from `_filteredCipherList$`, which applies `filterFunction$` upstream in `VaultPopupItemsService`. Binding it would filter twice. The chips write the form, and the narrowed rows flow back.
- **The responsive filter dialog and active-filter chips needed no work.** `bit-table-toolbar` already provides both, and section-collapse persistence landed with PM-40329. That part of the ticket was verification rather than implementation.

Folder and collection options arrive as nested trees and are flattened to one option per node, since a chip's options are a flat list. No Favorites toggle — favorites are their own section, not a filter.

### Stories

`ActiveFilters` and `CollapsedSections` on the table. The vault page's filter stub now serves real options instead of empty arrays, so its chips render populated across the existing stories — which also required adding the VFO1 terminology keys to its i18n mock. Without `vaults` / `sharedFolders` / `myFolders`, `Vfo1I18nPipe` throws and those three chips render label-less.

## 📸 Screenshots

https://github.com/user-attachments/assets/e3575be9-229b-4775-9116-ee7340b4c590

