### PR TITLE
refactor(auth): unlock via UnlockService in login strategies

### DIFF
--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -1073,6 +1073,7 @@ export default class MainBackground {
       this.stateProvider,
       this.authRequestApiService,
       this.accountService,
+      this.unlockService,
     );
 
     // Instantiated for its constructor side-effect: registers the login session timeout

--- a/apps/cli/src/service-container/service-container.ts
+++ b/apps/cli/src/service-container/service-container.ts
@@ -817,6 +817,7 @@ export class ServiceContainer {
       this.stateProvider,
       this.authRequestApiService,
       this.accountService,
+      this.unlockService,
     );
 
     this.billingAccountProfileStateService = new DefaultBillingAccountProfileStateService(

--- a/libs/angular/src/services/jslib-services.module.ts
+++ b/libs/angular/src/services/jslib-services.module.ts
@@ -1560,6 +1560,7 @@ const safeProviders: SafeProvider[] = [
       StateProvider,
       AuthRequestApiServiceAbstraction,
       AccountServiceAbstraction,
+      UnlockService,
     ],
   }),
   safeProvider({

--- a/libs/auth/src/common/login-strategies/auth-request-login.strategy.spec.ts
+++ b/libs/auth/src/common/login-strategies/auth-request-login.strategy.spec.ts
@@ -27,6 +27,7 @@ import { makeEncString, FakeAccountService, mockAccountServiceWith } from "@bitw
 import { UserId } from "@bitwarden/common/types/guid";
 import { UserKey } from "@bitwarden/common/types/key";
 import { KdfConfigService, KeyService } from "@bitwarden/key-management";
+import { UnlockService } from "@bitwarden/unlock";
 
 import { InternalUserDecryptionOptionsServiceAbstraction } from "../abstractions/user-decryption-options.service.abstraction";
 import { AuthRequestLoginCredentials } from "../models/domain/login-credentials";
@@ -58,6 +59,7 @@ describe("AuthRequestLoginStrategy", () => {
   let environmentService: MockProxy<EnvironmentService>;
   let configService: MockProxy<ConfigService>;
   let accountCryptographicStateService: MockProxy<AccountCryptographicStateService>;
+  let unlockService: MockProxy<UnlockService>;
 
   const mockUserId = Utils.newGuid() as UserId;
   let accountService: FakeAccountService;
@@ -95,6 +97,7 @@ describe("AuthRequestLoginStrategy", () => {
     environmentService = mock<EnvironmentService>();
     configService = mock<ConfigService>();
     accountCryptographicStateService = mock<AccountCryptographicStateService>();
+    unlockService = mock<UnlockService>();
 
     accountService = mockAccountServiceWith(mockUserId);
     masterPasswordService = new FakeMasterPasswordService();
@@ -107,6 +110,7 @@ describe("AuthRequestLoginStrategy", () => {
 
     authRequestLoginStrategy = new AuthRequestLoginStrategy(
       cache,
+      unlockService,
       deviceTrustService,
       accountService,
       masterPasswordService,
@@ -163,12 +167,12 @@ describe("AuthRequestLoginStrategy", () => {
     // setMasterKey and setMasterKeyHash should not be called
     expect(masterPasswordService.mock.setMasterKey).not.toHaveBeenCalled();
 
-    // setMasterKeyEncryptedUserKey, setUserKey, and setPrivateKey should still be called
+    // setMasterKeyEncryptedUserKey, the unlock, and setPrivateKey should still be called
     expect(masterPasswordService.mock.setMasterKeyEncryptedUserKey).toHaveBeenCalledWith(
       tokenResponse.key,
       mockUserId,
     );
-    expect(keyService.setUserKey).toHaveBeenCalledWith(decUserKey, mockUserId);
+    expect(unlockService.unlockWithDecryptedUserKey).toHaveBeenCalledWith(mockUserId, decUserKey);
     expect(accountCryptographicStateService.setAccountCryptographicState).toHaveBeenCalledWith(
       { V1: { private_key: tokenResponse.privateKey } },
       mockUserId,

--- a/libs/auth/src/common/login-strategies/auth-request-login.strategy.ts
+++ b/libs/auth/src/common/login-strategies/auth-request-login.strategy.ts
@@ -9,6 +9,7 @@ import { TokenTwoFactorRequest } from "@bitwarden/common/auth/models/request/ide
 import { IdentityTokenResponse } from "@bitwarden/common/auth/models/response/identity-token.response";
 import { DeviceTrustServiceAbstraction } from "@bitwarden/common/key-management/device-trust/abstractions/device-trust.service.abstraction";
 import { UserId } from "@bitwarden/common/types/guid";
+import { UnlockService } from "@bitwarden/unlock";
 
 import { AuthRequestLoginCredentials } from "../models/domain/login-credentials";
 import { CacheData } from "../services/login-strategies/login-strategy.state";
@@ -37,6 +38,7 @@ export class AuthRequestLoginStrategy extends LoginStrategy {
 
   constructor(
     data: AuthRequestLoginStrategyData,
+    private unlockService: UnlockService,
     private deviceTrustService: DeviceTrustServiceAbstraction,
     ...sharedDeps: ConstructorParameters<typeof LoginStrategy>
   ) {
@@ -78,7 +80,11 @@ export class AuthRequestLoginStrategy extends LoginStrategy {
   protected override async unlock(response: IdentityTokenResponse, userId: UserId): Promise<void> {
     const authRequestCredentials = this.cache.value.authRequestCredentials;
     await this.masterPasswordService.setMasterKeyEncryptedUserKey(response.key, userId);
-    await this.keyService.setUserKey(authRequestCredentials.decryptedUserKey, userId);
+    // Login with device: the approving device supplies an already-decrypted user key.
+    await this.unlockService.unlockWithDecryptedUserKey(
+      userId,
+      authRequestCredentials.decryptedUserKey,
+    );
     // Establish trust if required after setting user key
     await this.deviceTrustService.trustDeviceIfRequired(userId);
   }

--- a/libs/auth/src/common/login-strategies/password-login.strategy.spec.ts
+++ b/libs/auth/src/common/login-strategies/password-login.strategy.spec.ts
@@ -219,7 +219,6 @@ describe("PasswordLoginStrategy", () => {
     expect(masterPasswordService.mock.setMasterKey).not.toHaveBeenCalled();
     expect(masterPasswordService.mock.setMasterKeyEncryptedUserKey).not.toHaveBeenCalled();
     expect(masterPasswordService.mock.decryptUserKeyWithMasterKey).not.toHaveBeenCalled();
-    expect(keyService.setUserKey).not.toHaveBeenCalled();
   });
 
   describe("makePasswordPreloginMasterKey", () => {
@@ -486,7 +485,7 @@ describe("PasswordLoginStrategy", () => {
   });
 
   describe("encryptionKeyMigrationRequired", () => {
-    it("returns requiresEncryptionKeyMigration and skips setUserKey when response has no key", async () => {
+    it("returns requiresEncryptionKeyMigration and skips the unlock when response has no key", async () => {
       // Very old accounts were encrypted with the master key directly (no user key). These
       // accounts have no `key` field on the token response. PasswordLoginStrategy overrides
       // encryptionKeyMigrationRequired to return true when key is absent, which causes the base

--- a/libs/auth/src/common/login-strategies/sso-login.strategy.spec.ts
+++ b/libs/auth/src/common/login-strategies/sso-login.strategy.spec.ts
@@ -202,7 +202,7 @@ describe("SsoLoginStrategy", () => {
     await ssoLoginStrategy.logIn(credentials);
 
     expect(masterPasswordService.mock.setMasterKey).not.toHaveBeenCalled();
-    expect(keyService.setUserKey).not.toHaveBeenCalled();
+    expect(unlockService.unlockWithDecryptedUserKey).not.toHaveBeenCalled();
     expect(accountCryptographicStateService.setAccountCryptographicState).not.toHaveBeenCalled();
   });
 
@@ -300,16 +300,14 @@ describe("SsoLoginStrategy", () => {
       deviceTrustService.getDeviceKey.mockResolvedValue(mockDeviceKey);
       deviceTrustService.decryptUserKeyWithDeviceKey.mockResolvedValue(mockUserKey);
 
-      const cryptoSvcSetUserKeySpy = jest.spyOn(keyService, "setUserKey");
-
       // Act
       await ssoLoginStrategy.logIn(credentials);
 
       // Assert
       expect(deviceTrustService.getDeviceKey).toHaveBeenCalledTimes(1);
       expect(deviceTrustService.decryptUserKeyWithDeviceKey).toHaveBeenCalledTimes(1);
-      expect(cryptoSvcSetUserKeySpy).toHaveBeenCalledTimes(1);
-      expect(cryptoSvcSetUserKeySpy).toHaveBeenCalledWith(mockUserKey, userId);
+      expect(unlockService.unlockWithDecryptedUserKey).toHaveBeenCalledTimes(1);
+      expect(unlockService.unlockWithDecryptedUserKey).toHaveBeenCalledWith(userId, mockUserKey);
     });
 
     it("does not set the user key when deviceKey is missing", async () => {
@@ -327,7 +325,7 @@ describe("SsoLoginStrategy", () => {
       await ssoLoginStrategy.logIn(credentials);
 
       // Assert
-      expect(keyService.setUserKey).not.toHaveBeenCalled();
+      expect(unlockService.unlockWithDecryptedUserKey).not.toHaveBeenCalled();
     });
 
     describe.each([
@@ -348,7 +346,7 @@ describe("SsoLoginStrategy", () => {
         await ssoLoginStrategy.logIn(credentials);
 
         // Assert
-        expect(keyService.setUserKey).not.toHaveBeenCalled();
+        expect(unlockService.unlockWithDecryptedUserKey).not.toHaveBeenCalled();
       });
     });
 
@@ -367,7 +365,7 @@ describe("SsoLoginStrategy", () => {
       await ssoLoginStrategy.logIn(credentials);
 
       // Assert
-      expect(keyService.setUserKey).not.toHaveBeenCalled();
+      expect(unlockService.unlockWithDecryptedUserKey).not.toHaveBeenCalled();
     });
 
     it("logs when a device key is found but no decryption keys were received in token response", async () => {
@@ -549,7 +547,7 @@ describe("SsoLoginStrategy", () => {
         userId,
         undefined,
       );
-      expect(keyService.setUserKey).toHaveBeenCalledWith(userKey, userId);
+      expect(unlockService.unlockWithDecryptedUserKey).toHaveBeenCalledWith(userId, userKey);
     });
   });
 });

--- a/libs/auth/src/common/login-strategies/sso-login.strategy.ts
+++ b/libs/auth/src/common/login-strategies/sso-login.strategy.ts
@@ -322,7 +322,8 @@ export class SsoLoginStrategy extends LoginStrategy {
     );
 
     if (userKey) {
-      await this.keyService.setUserKey(userKey, userId);
+      // TDE unlock during SSO login; the user key comes from DeviceTrustService.decryptUserKeyWithDeviceKey.
+      await this.unlockService.unlockWithDecryptedUserKey(userId, userKey);
     }
   }
 
@@ -340,7 +341,7 @@ export class SsoLoginStrategy extends LoginStrategy {
     }
 
     const userKey = await this.masterPasswordService.decryptUserKeyWithMasterKey(masterKey, userId);
-    await this.keyService.setUserKey(userKey, userId);
+    await this.unlockService.unlockWithDecryptedUserKey(userId, userKey);
   }
 
   exportCache(): CacheData {

--- a/libs/auth/src/common/login-strategies/user-api-login.strategy.spec.ts
+++ b/libs/auth/src/common/login-strategies/user-api-login.strategy.spec.ts
@@ -280,7 +280,7 @@ describe("UserApiLoginStrategy", () => {
       userId,
       undefined,
     );
-    expect(keyService.setUserKey).toHaveBeenCalledWith(userKey, userId);
+    expect(unlockService.unlockWithDecryptedUserKey).toHaveBeenCalledWith(userId, userKey);
   });
 
   it("uses the legacy Key Connector user key path when SDK handling is disabled", async () => {
@@ -310,7 +310,7 @@ describe("UserApiLoginStrategy", () => {
       userId,
       undefined,
     );
-    expect(keyService.setUserKey).toHaveBeenCalledWith(userKey, userId);
+    expect(unlockService.unlockWithDecryptedUserKey).toHaveBeenCalledWith(userId, userKey);
   });
 
   it("sets account cryptographic state when accountKeysResponseModel is present", async () => {

--- a/libs/auth/src/common/login-strategies/user-api-login.strategy.ts
+++ b/libs/auth/src/common/login-strategies/user-api-login.strategy.ts
@@ -90,7 +90,7 @@ export class UserApiLoginStrategy extends LoginStrategy {
           masterKey,
           userId,
         );
-        await this.keyService.setUserKey(userKey, userId);
+        await this.unlockService.unlockWithDecryptedUserKey(userId, userKey);
       }
     }
   }

--- a/libs/auth/src/common/login-strategies/webauthn-login.strategy.spec.ts
+++ b/libs/auth/src/common/login-strategies/webauthn-login.strategy.spec.ts
@@ -29,6 +29,7 @@ import { FakeAccountService, mockAccountServiceWith } from "@bitwarden/common/sp
 import { UserId } from "@bitwarden/common/types/guid";
 import { PrfKey, UserKey } from "@bitwarden/common/types/key";
 import { KdfConfigService, KeyService } from "@bitwarden/key-management";
+import { UnlockService } from "@bitwarden/unlock";
 
 import { InternalUserDecryptionOptionsServiceAbstraction } from "../abstractions/user-decryption-options.service.abstraction";
 import { WebAuthnLoginCredentials } from "../models/domain/login-credentials";
@@ -58,6 +59,7 @@ describe("WebAuthnLoginStrategy", () => {
   let environmentService: MockProxy<EnvironmentService>;
   let configService: MockProxy<ConfigService>;
   let accountCryptographicStateService: MockProxy<AccountCryptographicStateService>;
+  let unlockService: MockProxy<UnlockService>;
 
   let webAuthnLoginStrategy!: WebAuthnLoginStrategy;
 
@@ -104,6 +106,7 @@ describe("WebAuthnLoginStrategy", () => {
     environmentService = mock<EnvironmentService>();
     configService = mock<ConfigService>();
     accountCryptographicStateService = mock<AccountCryptographicStateService>();
+    unlockService = mock<UnlockService>();
 
     tokenService.getTwoFactorToken.mockResolvedValue(null);
     appIdService.getAppId.mockResolvedValue(deviceId);
@@ -113,6 +116,7 @@ describe("WebAuthnLoginStrategy", () => {
 
     webAuthnLoginStrategy = new WebAuthnLoginStrategy(
       cache,
+      unlockService,
       accountService,
       masterPasswordService,
       keyService,
@@ -262,7 +266,7 @@ describe("WebAuthnLoginStrategy", () => {
       idTokenResponse.userDecryptionOptions.webAuthnPrfOption.encryptedUserKey,
       mockPrfPrivateKey,
     );
-    expect(keyService.setUserKey).toHaveBeenCalledWith(mockUserKey, userId);
+    expect(unlockService.unlockWithDecryptedUserKey).toHaveBeenCalledWith(userId, mockUserKey);
     expect(accountCryptographicStateService.setAccountCryptographicState).toHaveBeenCalledWith(
       { V1: { private_key: idTokenResponse.privateKey } },
       userId,
@@ -290,7 +294,7 @@ describe("WebAuthnLoginStrategy", () => {
     // Assert
     expect(encryptService.unwrapDecapsulationKey).not.toHaveBeenCalled();
     expect(encryptService.decapsulateKeyUnsigned).not.toHaveBeenCalled();
-    expect(keyService.setUserKey).not.toHaveBeenCalled();
+    expect(unlockService.unlockWithDecryptedUserKey).not.toHaveBeenCalled();
   });
 
   describe.each([
@@ -310,7 +314,7 @@ describe("WebAuthnLoginStrategy", () => {
       await webAuthnLoginStrategy.logIn(webAuthnCredentials);
 
       // Assert
-      expect(keyService.setUserKey).not.toHaveBeenCalled();
+      expect(unlockService.unlockWithDecryptedUserKey).not.toHaveBeenCalled();
     });
   });
 
@@ -329,7 +333,7 @@ describe("WebAuthnLoginStrategy", () => {
     await webAuthnLoginStrategy.logIn(webAuthnCredentials);
 
     // Assert
-    expect(keyService.setUserKey).not.toHaveBeenCalled();
+    expect(unlockService.unlockWithDecryptedUserKey).not.toHaveBeenCalled();
   });
 
   it("does not set the user key when the encrypted user key decryption fails", async () => {
@@ -347,7 +351,7 @@ describe("WebAuthnLoginStrategy", () => {
     await webAuthnLoginStrategy.logIn(webAuthnCredentials);
 
     // Assert
-    expect(keyService.setUserKey).not.toHaveBeenCalled();
+    expect(unlockService.unlockWithDecryptedUserKey).not.toHaveBeenCalled();
   });
 
   it("sets account cryptographic state when accountKeysResponseModel is present", async () => {

--- a/libs/auth/src/common/login-strategies/webauthn-login.strategy.ts
+++ b/libs/auth/src/common/login-strategies/webauthn-login.strategy.ts
@@ -9,6 +9,7 @@ import { IdentityTokenResponse } from "@bitwarden/common/auth/models/response/id
 import { EncString } from "@bitwarden/common/key-management/crypto/models/enc-string";
 import { UserId } from "@bitwarden/common/types/guid";
 import { UserKey } from "@bitwarden/common/types/key";
+import { UnlockService } from "@bitwarden/unlock";
 
 import { WebAuthnLoginCredentials } from "../models/domain/login-credentials";
 import { CacheData } from "../services/login-strategies/login-strategy.state";
@@ -32,6 +33,7 @@ export class WebAuthnLoginStrategy extends LoginStrategy {
 
   constructor(
     data: WebAuthnLoginStrategyData,
+    private unlockService: UnlockService,
     ...sharedDeps: ConstructorParameters<typeof LoginStrategy>
   ) {
     super(...sharedDeps);
@@ -95,7 +97,8 @@ export class WebAuthnLoginStrategy extends LoginStrategy {
       );
 
       if (userKey) {
-        await this.keyService.setUserKey(userKey as UserKey, userId);
+        // TODO: PRF decryption should move into the SDK so this can use a dedicated PRF unlock method.
+        await this.unlockService.unlockWithDecryptedUserKey(userId, userKey as UserKey);
       }
     }
   }

--- a/libs/auth/src/common/services/auth-request/auth-request.service.spec.ts
+++ b/libs/auth/src/common/services/auth-request/auth-request.service.spec.ts
@@ -18,6 +18,7 @@ import { newGuid } from "@bitwarden/guid";
 import { KeyService } from "@bitwarden/key-management";
 // eslint-disable-next-line no-restricted-imports
 import { LegacyCompatKeyService } from "@bitwarden/legacy-crypto";
+import { UnlockService } from "@bitwarden/unlock";
 
 import { DefaultAuthRequestApiService } from "./auth-request-api.service";
 import { AuthRequestService } from "./auth-request.service";
@@ -34,6 +35,7 @@ describe("AuthRequestService", () => {
   const apiService = mock<ApiService>();
   const authRequestApiService = mock<DefaultAuthRequestApiService>();
   const accountService = mock<AccountService>();
+  const unlockService = mock<UnlockService>();
 
   let mockPrivateKey: Uint8Array;
   let mockPublicKey: Uint8Array;
@@ -53,6 +55,7 @@ describe("AuthRequestService", () => {
       stateProvider,
       authRequestApiService,
       accountService,
+      unlockService,
     );
 
     mockPrivateKey = new Uint8Array(64);
@@ -140,7 +143,7 @@ describe("AuthRequestService", () => {
       const mockDecryptedUserKey = {} as UserKey;
       jest.spyOn(sut, "decryptPubKeyEncryptedUserKey").mockResolvedValueOnce(mockDecryptedUserKey);
 
-      keyService.setUserKey.mockResolvedValueOnce(undefined);
+      unlockService.unlockWithDecryptedUserKey.mockResolvedValueOnce(undefined);
 
       // Act
       await sut.setUserKeyAfterDecryptingSharedUserKey(
@@ -154,7 +157,10 @@ describe("AuthRequestService", () => {
         mockAuthReqResponse.key,
         mockPrivateKey,
       );
-      expect(keyService.setUserKey).toHaveBeenCalledWith(mockDecryptedUserKey, mockUserId);
+      expect(unlockService.unlockWithDecryptedUserKey).toHaveBeenCalledWith(
+        mockUserId,
+        mockDecryptedUserKey,
+      );
     });
   });
 

--- a/libs/auth/src/common/services/auth-request/auth-request.service.ts
+++ b/libs/auth/src/common/services/auth-request/auth-request.service.ts
@@ -26,6 +26,7 @@ import { UserKey } from "@bitwarden/common/types/key";
 import { KeyService } from "@bitwarden/key-management";
 // eslint-disable-next-line no-restricted-imports
 import { LegacyCompatKeyService } from "@bitwarden/legacy-crypto";
+import { UnlockService } from "@bitwarden/unlock";
 
 import { AuthRequestApiServiceAbstraction } from "../../abstractions/auth-request-api.service";
 import { AuthRequestServiceAbstraction } from "../../abstractions/auth-request.service.abstraction";
@@ -61,6 +62,7 @@ export class AuthRequestService implements AuthRequestServiceAbstraction {
     private stateProvider: StateProvider,
     private authRequestApiService: AuthRequestApiServiceAbstraction,
     private accountService: AccountService,
+    private unlockService: UnlockService,
   ) {
     this.authRequestPushNotification$ = this.authRequestPushNotificationSubject.asObservable();
     this.adminLoginApproved$ = this.adminLoginApprovedSubject.asObservable();
@@ -162,7 +164,7 @@ export class AuthRequestService implements AuthRequestServiceAbstraction {
       authReqResponse.key,
       authReqPrivateKey,
     );
-    await this.keyService.setUserKey(userKey, userId);
+    await this.unlockService.unlockWithDecryptedUserKey(userId, userKey);
   }
 
   // Decryption helpers

--- a/libs/auth/src/common/services/login-strategies/login-strategy.service.ts
+++ b/libs/auth/src/common/services/login-strategies/login-strategy.service.ts
@@ -358,12 +358,14 @@ export class LoginStrategyService implements LoginStrategyServiceAbstraction {
           case AuthenticationType.AuthRequest:
             return new AuthRequestLoginStrategy(
               data?.authRequest ?? new AuthRequestLoginStrategyData(),
+              this.unlockService,
               this.deviceTrustService,
               ...sharedDeps,
             );
           case AuthenticationType.WebAuthn:
             return new WebAuthnLoginStrategy(
               data?.webAuthn ?? new WebAuthnLoginStrategyData(),
+              this.unlockService,
               ...sharedDeps,
             );
         }


### PR DESCRIPTION
Part of the `setUserKey` deprecation. 
https://bitwarden.atlassian.net/browse/PM-41489

Moves to the unlockService equivalent of `setUserKey`. Ideally all login strategies would use the appropriate unlock method, rather than the decryptedKeyMethod. However, the goal here is to remove `setUserKey`.