### PR TITLE
refactor(key-management-ui): stop re-setting the user key after unlock

### DIFF
--- a/apps/browser/src/key-management/biometrics/background-browser-biometrics.service.ts
+++ b/apps/browser/src/key-management/biometrics/background-browser-biometrics.service.ts
@@ -112,7 +112,7 @@ export class BackgroundBrowserBiometricsService extends BiometricsService {
           }
 
           await this.biometricStateService.setBiometricUnlockEnabled(true, userId);
-          await this.keyService.setUserKey(userKey, userId);
+          await this.unlockService!.unlockWithDecryptedUserKey(userId, userKey);
           // to update badge and other things
           this.messagingService.send("switchAccount", { userId });
           return userKey;

--- a/libs/key-management-ui/src/lock/components/lock.component.spec.ts
+++ b/libs/key-management-ui/src/lock/components/lock.component.spec.ts
@@ -23,7 +23,7 @@ import { MessagingService } from "@bitwarden/common/platform/abstractions/messag
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
 import { SyncService } from "@bitwarden/common/platform/sync";
-import { makeSymmetricCryptoKey, mockAccountServiceWith } from "@bitwarden/common/spec";
+import { mockAccountServiceWith } from "@bitwarden/common/spec";
 import { PasswordStrengthServiceAbstraction } from "@bitwarden/common/tools/password-strength";
 import { UserId } from "@bitwarden/common/types/guid";
 import { UserKey } from "@bitwarden/common/types/key";
@@ -188,7 +188,8 @@ describe("LockComponent", () => {
         expect(mockLogService.error).toHaveBeenCalledWith(
           "[LockComponent] successfulMasterPasswordUnlock called with invalid data.",
         );
-        expect(mockKeyService.setUserKey).not.toHaveBeenCalled();
+        expect(mockDeviceTrustService.trustDeviceIfRequired).not.toHaveBeenCalled();
+        expect(mockMessagingService.send).not.toHaveBeenCalledWith("unlocked");
       },
     );
 
@@ -304,11 +305,35 @@ describe("LockComponent", () => {
     });
 
     function assertUnlocked(): void {
-      expect(mockKeyService.setUserKey).toHaveBeenCalledWith(
-        mockUserKey,
+      expect(mockDeviceTrustService.trustDeviceIfRequired).toHaveBeenCalledWith(
         component.activeAccount!.id,
       );
     }
+  });
+
+  describe("onPrfUnlockSuccess", () => {
+    const mockUserKey = new SymmetricCryptoKey(new Uint8Array(64)) as UserKey;
+
+    beforeEach(async () => {
+      component.activeAccount = await firstValueFrom(mockAccountService.activeAccount$);
+    });
+
+    it("unlocks with the decrypted user key via the unlock service", async () => {
+      await component.onPrfUnlockSuccess(mockUserKey);
+
+      expect(mockUnlockService.unlockWithDecryptedUserKey).toHaveBeenCalledWith(
+        userId,
+        mockUserKey,
+      );
+      expect(mockDeviceTrustService.trustDeviceIfRequired).toHaveBeenCalledWith(userId);
+    });
+
+    it("throws when there is no active account", async () => {
+      component.activeAccount = null;
+
+      await expect(component.onPrfUnlockSuccess(mockUserKey)).rejects.toThrow("No active user.");
+      expect(mockUnlockService.unlockWithDecryptedUserKey).not.toHaveBeenCalled();
+    });
   });
 
   describe("logOut", () => {
@@ -397,11 +422,7 @@ describe("LockComponent", () => {
   });
 
   describe("unlockViaBiometrics", () => {
-    it("ignores concurrent unlock attempts while one biometric unlock is in progress", async () => {
-      let resolvePendingUnlock: (() => void) | undefined;
-      const pendingUnlock = new Promise<void>((resolve) => {
-        resolvePendingUnlock = resolve;
-      });
+    beforeEach(async () => {
       component.activeAccount = await firstValueFrom(mockAccountService.activeAccount$);
       component.unlockOptions = {
         biometrics: { enabled: true, biometricsStatus: BiometricsStatus.Available },
@@ -409,9 +430,14 @@ describe("LockComponent", () => {
         masterPassword: { enabled: true },
         prf: { enabled: false },
       };
-      const newUserKey = makeSymmetricCryptoKey(64) as UserKey;
+    });
+
+    it("ignores concurrent unlock attempts while one biometric unlock is in progress", async () => {
+      let resolvePendingUnlock: (() => void) | undefined;
+      const pendingUnlock = new Promise<void>((resolve) => {
+        resolvePendingUnlock = resolve;
+      });
       mockUnlockService.unlockWithBiometrics.mockReturnValue(pendingUnlock);
-      mockKeyService.userKey$.mockReturnValue(of(newUserKey));
 
       const firstAttempt = component.unlockViaBiometrics();
       await component.unlockViaBiometrics();
@@ -419,6 +445,27 @@ describe("LockComponent", () => {
       await firstAttempt;
 
       expect(mockUnlockService.unlockWithBiometrics).toHaveBeenCalledTimes(1);
+    });
+
+    it("continues the unlock flow after the unlock service unlocks", async () => {
+      mockUnlockService.unlockWithBiometrics.mockResolvedValue();
+
+      await component.unlockViaBiometrics();
+
+      expect(mockUnlockService.unlockWithBiometrics).toHaveBeenCalledWith(userId);
+      expect(mockDeviceTrustService.trustDeviceIfRequired).toHaveBeenCalledWith(userId);
+    });
+
+    it("does not continue the unlock flow when the unlock service throws", async () => {
+      mockUnlockService.unlockWithBiometrics.mockRejectedValue(new Error("cancelled"));
+
+      await component.unlockViaBiometrics();
+
+      expect(mockDeviceTrustService.trustDeviceIfRequired).not.toHaveBeenCalled();
+      expect(mockLogService.info).toHaveBeenCalledWith(
+        "[LockComponent] Failed to unlock via biometrics.",
+        expect.any(Error),
+      );
     });
   });
 

--- a/libs/key-management-ui/src/lock/components/lock.component.ts
+++ b/libs/key-management-ui/src/lock/components/lock.component.ts
@@ -436,13 +436,10 @@ export class LockComponent implements OnInit, OnDestroy {
 
       await this.biometricStateService.setUserPromptCancelled(this.activeAccount.id);
 
+      // Throws if the user cancels the biometric prompt.
       await this.unlockService.unlockWithBiometrics(this.activeAccount.id);
-      const userKey = await firstValueFrom(this.keyService.userKey$(this.activeAccount.id));
 
-      // If user cancels biometric prompt, userKey is undefined.
-      if (userKey) {
-        await this.setUserKeyAndContinue(userKey);
-      }
+      await this.continueAfterSettingUserKey();
     } catch (e) {
       // Biometrics may fail if the user does not accept or if the desktop app is disconnected.
       this.logService.info("[LockComponent] Failed to unlock via biometrics.", e);
@@ -452,7 +449,13 @@ export class LockComponent implements OnInit, OnDestroy {
   }
 
   async onPrfUnlockSuccess(userKey: UserKey): Promise<void> {
-    await this.setUserKeyAndContinue(userKey);
+    if (this.activeAccount == null) {
+      throw new Error("No active user.");
+    }
+
+    await this.unlockService.unlockWithDecryptedUserKey(this.activeAccount.id, userKey);
+
+    await this.continueAfterSettingUserKey();
   }
 
   togglePassword() {
@@ -483,8 +486,7 @@ export class LockComponent implements OnInit, OnDestroy {
 
     try {
       await this.unlockService.unlockWithPin(this.activeAccount.id, pin);
-      const userKey = await this.keyService.getUserKey(this.activeAccount.id);
-      await this.setUserKeyAndContinue(userKey!);
+      await this.continueAfterSettingUserKey();
     } catch {
       // Failure state: invalid PIN or failed decryption
       this.invalidPinAttempts++;
@@ -518,15 +520,18 @@ export class LockComponent implements OnInit, OnDestroy {
       return;
     }
 
-    await this.setUserKeyAndContinue(event.userKey, {
+    await this.continueAfterSettingUserKey({
       passwordEvaluation: {
         masterPassword: event.masterPassword,
       },
     });
   }
 
-  protected async setUserKeyAndContinue(
-    key: UserKey,
+  /**
+   * Shared tail of the lock screen's unlock methods. Callers are responsible for setting the user
+   * key via the matching {@link UnlockService} method before calling this.
+   */
+  protected async continueAfterSettingUserKey(
     afterUnlockActions: AfterUnlockActions = {},
   ): Promise<void> {
     if (this.activeAccount == null) {
@@ -535,8 +540,6 @@ export class LockComponent implements OnInit, OnDestroy {
 
     // Add a mark to indicate that the user has unlocked their vault. A good starting point for measuring unlock performance.
     this.logService.mark("Vault unlocked");
-
-    await this.keyService.setUserKey(key, this.activeAccount.id);
 
     // Now that we have a decrypted user key in memory, we can check if we
     // need to establish trust on the current device


### PR DESCRIPTION
Part of the `setUserKey` deprecation. 
https://bitwarden.atlassian.net/browse/PM-41489

The lock screen unlocked through `UnlockService` and then called `setUserKey` again with the same key. `setUserKeyAndContinue` becomes `continueAfterSettingUserKey`, each unlock path owns its own `UnlockService` call, and the duplicate write is gone.

Browser background biometric unlock moves onto `UnlockService` for the same reason.