### PR TITLE
[PM-41874] refactor(crypto): move key-management callers to @bitwarden/legacy-crypto

### DIFF
--- a/apps/browser/src/background/nativeMessaging.background.ts
+++ b/apps/browser/src/background/nativeMessaging.background.ts
@@ -1,18 +1,20 @@
 import { firstValueFrom, Subscription, timer } from "rxjs";
 
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
-import { CryptoFunctionService } from "@bitwarden/common/key-management/crypto/abstractions/crypto-function.service";
-import { EncryptService } from "@bitwarden/common/key-management/crypto/abstractions/encrypt.service";
-import { EncString } from "@bitwarden/common/key-management/crypto/models/enc-string";
 import { AppIdService } from "@bitwarden/common/platform/abstractions/app-id.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
-import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
 import { KeyService, BiometricStateService } from "@bitwarden/key-management";
 // eslint-disable-next-line no-restricted-imports
-import { LegacyCompatKeyService } from "@bitwarden/legacy-crypto";
+import {
+  CryptoFunctionService,
+  EncryptService,
+  EncString,
+  LegacyCompatKeyService,
+  SymmetricCryptoKey,
+} from "@bitwarden/legacy-crypto";
 
 import { BrowserApi } from "../platform/browser/browser-api";
 

--- a/apps/browser/src/key-management/biometrics/background-browser-biometrics.service.ts
+++ b/apps/browser/src/key-management/biometrics/background-browser-biometrics.service.ts
@@ -7,7 +7,6 @@ import { LogService } from "@bitwarden/common/platform/abstractions/log.service"
 import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
 import { IpcService } from "@bitwarden/common/platform/ipc";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
-import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
 import { UserId } from "@bitwarden/common/types/guid";
 import { UserKey } from "@bitwarden/common/types/key";
 import {
@@ -17,6 +16,8 @@ import {
   KeyService,
   BiometricStateService,
 } from "@bitwarden/key-management";
+// eslint-disable-next-line no-restricted-imports
+import { SymmetricCryptoKey } from "@bitwarden/legacy-crypto";
 import {
   ipcRequestAuthenticateBiometrics,
   ipcRequestGetBiometricsStatus,

--- a/apps/browser/src/key-management/biometrics/foreground-browser-biometrics.ts
+++ b/apps/browser/src/key-management/biometrics/foreground-browser-biometrics.ts
@@ -1,8 +1,9 @@
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
-import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
 import { UserId } from "@bitwarden/common/types/guid";
 import { UserKey } from "@bitwarden/common/types/key";
 import { BiometricsCommands, BiometricsService, BiometricsStatus } from "@bitwarden/key-management";
+// eslint-disable-next-line no-restricted-imports
+import { SymmetricCryptoKey } from "@bitwarden/legacy-crypto";
 
 import { BrowserApi } from "../../platform/browser/browser-api";
 

--- a/apps/cli/src/key-management/cli-biometrics-service.ts
+++ b/apps/cli/src/key-management/cli-biometrics-service.ts
@@ -1,7 +1,8 @@
-import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
 import { UserId } from "@bitwarden/common/types/guid";
 import { UserKey } from "@bitwarden/common/types/key";
 import { BiometricsService, BiometricsStatus } from "@bitwarden/key-management";
+// eslint-disable-next-line no-restricted-imports
+import { SymmetricCryptoKey } from "@bitwarden/legacy-crypto";
 
 export class CliBiometricsService extends BiometricsService {
   async authenticateWithBiometrics(): Promise<boolean> {

--- a/apps/cli/src/key-management/commands/unlock.command.spec.ts
+++ b/apps/cli/src/key-management/commands/unlock.command.spec.ts
@@ -9,7 +9,8 @@ import { EnvironmentService } from "@bitwarden/common/platform/abstractions/envi
 import { SdkLoadService } from "@bitwarden/common/platform/abstractions/sdk/sdk-load.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { mockAccountInfoWith } from "@bitwarden/common/spec";
-import { CsprngArray } from "@bitwarden/common/types/csprng";
+// eslint-disable-next-line no-restricted-imports
+import { CsprngArray } from "@bitwarden/legacy-crypto";
 import { ConsoleLogService } from "@bitwarden/logging";
 import { PureCrypto, SymmetricKey } from "@bitwarden/sdk-internal";
 import { UnlockService } from "@bitwarden/unlock";

--- a/apps/cli/src/key-management/commands/unlock.command.ts
+++ b/apps/cli/src/key-management/commands/unlock.command.ts
@@ -8,8 +8,9 @@ import { EncryptedMigrator } from "@bitwarden/common/key-management/encrypted-mi
 import { KeyConnectorService } from "@bitwarden/common/key-management/key-connector/abstractions/key-connector.service";
 import { EnvironmentService } from "@bitwarden/common/platform/abstractions/environment.service";
 import { SdkLoadService } from "@bitwarden/common/platform/abstractions/sdk/sdk-load.service";
-import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
 import { ConsoleLogService } from "@bitwarden/common/platform/services/console-log.service";
+// eslint-disable-next-line no-restricted-imports
+import { SymmetricCryptoKey } from "@bitwarden/legacy-crypto";
 import { PureCrypto } from "@bitwarden/sdk-internal";
 import { UnlockService } from "@bitwarden/unlock";
 

--- a/apps/desktop/src/key-management/biometrics/main-biometrics-ipc.listener.ts
+++ b/apps/desktop/src/key-management/biometrics/main-biometrics-ipc.listener.ts
@@ -1,8 +1,9 @@
 import { ipcMain } from "electron";
 
-import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
 import { ConsoleLogService } from "@bitwarden/common/platform/services/console-log.service";
 import { UserId } from "@bitwarden/common/types/guid";
+// eslint-disable-next-line no-restricted-imports
+import { SymmetricCryptoKey } from "@bitwarden/legacy-crypto";
 
 import { BiometricMessage, BiometricAction } from "../../types/biometric-message";
 

--- a/apps/desktop/src/key-management/biometrics/main-biometrics.service.spec.ts
+++ b/apps/desktop/src/key-management/biometrics/main-biometrics.service.spec.ts
@@ -2,8 +2,6 @@ import { mock, MockProxy } from "jest-mock-extended";
 
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
-import { EncryptionType } from "@bitwarden/common/platform/enums";
-import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
 import { UserId } from "@bitwarden/common/types/guid";
 import { newGuid } from "@bitwarden/guid";
 import {
@@ -11,6 +9,8 @@ import {
   BiometricsStatus,
   BiometricStateService,
 } from "@bitwarden/key-management";
+// eslint-disable-next-line no-restricted-imports
+import { EncryptionType, SymmetricCryptoKey } from "@bitwarden/legacy-crypto";
 
 import { WindowMain } from "../../main/window.main";
 

--- a/apps/desktop/src/key-management/biometrics/main-biometrics.service.ts
+++ b/apps/desktop/src/key-management/biometrics/main-biometrics.service.ts
@@ -1,9 +1,10 @@
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
-import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
 import { UserId } from "@bitwarden/common/types/guid";
 import { UserKey } from "@bitwarden/common/types/key";
 import { BiometricsStatus, BiometricStateService } from "@bitwarden/key-management";
+// eslint-disable-next-line no-restricted-imports
+import { SymmetricCryptoKey } from "@bitwarden/legacy-crypto";
 
 import { WindowMain } from "../../main/window.main";
 

--- a/apps/desktop/src/key-management/biometrics/native-v2/os-biometrics-linux.service.spec.ts
+++ b/apps/desktop/src/key-management/biometrics/native-v2/os-biometrics-linux.service.spec.ts
@@ -1,7 +1,8 @@
-import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
 import { UserId } from "@bitwarden/common/types/guid";
 import { biometrics, passwords } from "@bitwarden/desktop-napi";
 import { BiometricsStatus } from "@bitwarden/key-management";
+// eslint-disable-next-line no-restricted-imports
+import { SymmetricCryptoKey } from "@bitwarden/legacy-crypto";
 
 import OsBiometricsServiceLinux from "./os-biometrics-linux.service";
 

--- a/apps/desktop/src/key-management/biometrics/native-v2/os-biometrics-linux.service.ts
+++ b/apps/desktop/src/key-management/biometrics/native-v2/os-biometrics-linux.service.ts
@@ -1,9 +1,10 @@
 import { spawn } from "child_process";
 
-import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
 import { UserId } from "@bitwarden/common/types/guid";
 import { biometrics, passwords } from "@bitwarden/desktop-napi";
 import { BiometricsStatus } from "@bitwarden/key-management";
+// eslint-disable-next-line no-restricted-imports
+import { SymmetricCryptoKey } from "@bitwarden/legacy-crypto";
 
 import { isSnapStore, isFlatpak, isLinux } from "../../../utils";
 import { OsBiometricService } from "../os-biometrics.service";

--- a/apps/desktop/src/key-management/biometrics/native-v2/os-biometrics-windows.service.spec.ts
+++ b/apps/desktop/src/key-management/biometrics/native-v2/os-biometrics-windows.service.spec.ts
@@ -1,10 +1,11 @@
 import { mock } from "jest-mock-extended";
 
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
-import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
 import { UserId } from "@bitwarden/common/types/guid";
 import { biometrics } from "@bitwarden/desktop-napi";
 import { BiometricsStatus } from "@bitwarden/key-management";
+// eslint-disable-next-line no-restricted-imports
+import { SymmetricCryptoKey } from "@bitwarden/legacy-crypto";
 import { LogService } from "@bitwarden/logging";
 
 import { WindowMain } from "../../main/window.main";

--- a/apps/desktop/src/key-management/biometrics/native-v2/os-biometrics-windows.service.ts
+++ b/apps/desktop/src/key-management/biometrics/native-v2/os-biometrics-windows.service.ts
@@ -1,8 +1,9 @@
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
-import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
 import { UserId } from "@bitwarden/common/types/guid";
 import { biometrics } from "@bitwarden/desktop-napi";
 import { BiometricsStatus } from "@bitwarden/key-management";
+// eslint-disable-next-line no-restricted-imports
+import { SymmetricCryptoKey } from "@bitwarden/legacy-crypto";
 import { LogService } from "@bitwarden/logging";
 
 import { WindowMain } from "../../../main/window.main";

--- a/apps/desktop/src/key-management/biometrics/os-biometrics-mac.service.ts
+++ b/apps/desktop/src/key-management/biometrics/os-biometrics-mac.service.ts
@@ -2,10 +2,11 @@ import { systemPreferences } from "electron";
 
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
-import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
 import { UserId } from "@bitwarden/common/types/guid";
 import { passwords } from "@bitwarden/desktop-napi";
 import { BiometricsStatus } from "@bitwarden/key-management";
+// eslint-disable-next-line no-restricted-imports
+import { SymmetricCryptoKey } from "@bitwarden/legacy-crypto";
 
 import { OsBiometricService } from "./os-biometrics.service";
 

--- a/apps/desktop/src/key-management/biometrics/os-biometrics.service.ts
+++ b/apps/desktop/src/key-management/biometrics/os-biometrics.service.ts
@@ -1,6 +1,7 @@
-import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
 import { UserId } from "@bitwarden/common/types/guid";
 import { BiometricsStatus } from "@bitwarden/key-management";
+// eslint-disable-next-line no-restricted-imports
+import { SymmetricCryptoKey } from "@bitwarden/legacy-crypto";
 
 export interface OsBiometricService {
   supportsBiometrics(): Promise<boolean>;

--- a/apps/desktop/src/key-management/biometrics/renderer-biometrics.service.spec.ts
+++ b/apps/desktop/src/key-management/biometrics/renderer-biometrics.service.spec.ts
@@ -2,11 +2,11 @@ import { mock } from "jest-mock-extended";
 
 import { TokenService } from "@bitwarden/common/auth/abstractions/token.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
-import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
-import { CsprngArray } from "@bitwarden/common/types/csprng";
 import { UserId } from "@bitwarden/common/types/guid";
 import { UserKey } from "@bitwarden/common/types/key";
 import { BiometricStateService, BiometricsStatus } from "@bitwarden/key-management";
+// eslint-disable-next-line no-restricted-imports
+import { CsprngArray, SymmetricCryptoKey } from "@bitwarden/legacy-crypto";
 import { CryptoClient } from "@bitwarden/sdk-internal";
 
 import { RendererBiometricsService } from "./renderer-biometrics.service";

--- a/apps/desktop/src/key-management/biometrics/renderer-biometrics.service.ts
+++ b/apps/desktop/src/key-management/biometrics/renderer-biometrics.service.ts
@@ -7,9 +7,10 @@ import { fromSdkUserId } from "@bitwarden/common/key-management/utils";
 import { SdkLoadService } from "@bitwarden/common/platform/abstractions/sdk/sdk-load.service";
 import { IpcService } from "@bitwarden/common/platform/ipc";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
-import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
 import { UserKey } from "@bitwarden/common/types/key";
 import { BiometricsStatus, BiometricStateService } from "@bitwarden/key-management";
+// eslint-disable-next-line no-restricted-imports
+import { SymmetricCryptoKey } from "@bitwarden/legacy-crypto";
 import {
   CryptoClient,
   ipcRegisterBiometricsHandlers,

--- a/apps/desktop/src/key-management/electron-key.service.spec.ts
+++ b/apps/desktop/src/key-management/electron-key.service.spec.ts
@@ -1,8 +1,6 @@
 import { mock } from "jest-mock-extended";
 
 import { AccountCryptographicStateService } from "@bitwarden/common/key-management/account-cryptography/account-cryptographic-state.service";
-import { CryptoFunctionService } from "@bitwarden/common/key-management/crypto/abstractions/crypto-function.service";
-import { EncryptService } from "@bitwarden/common/key-management/crypto/abstractions/encrypt.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { StateService } from "@bitwarden/common/platform/abstractions/state.service";
@@ -10,6 +8,8 @@ import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { UserId } from "@bitwarden/common/types/guid";
 import { UserKey } from "@bitwarden/common/types/key";
 import { BiometricStateService } from "@bitwarden/key-management";
+// eslint-disable-next-line no-restricted-imports
+import { CryptoFunctionService, EncryptService } from "@bitwarden/legacy-crypto";
 
 import {
   FakeAccountService,

--- a/apps/desktop/src/key-management/electron-key.service.ts
+++ b/apps/desktop/src/key-management/electron-key.service.ts
@@ -1,6 +1,4 @@
 import { AccountCryptographicStateService } from "@bitwarden/common/key-management/account-cryptography/account-cryptographic-state.service";
-import { CryptoFunctionService } from "@bitwarden/common/key-management/crypto/abstractions/crypto-function.service";
-import { EncryptService } from "@bitwarden/common/key-management/crypto/abstractions/encrypt.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { StateService } from "@bitwarden/common/platform/abstractions/state.service";
@@ -9,6 +7,8 @@ import { StateProvider } from "@bitwarden/common/platform/state";
 import { UserId } from "@bitwarden/common/types/guid";
 import { UserKey } from "@bitwarden/common/types/key";
 import { DefaultKeyService, BiometricStateService } from "@bitwarden/key-management";
+// eslint-disable-next-line no-restricted-imports
+import { CryptoFunctionService, EncryptService } from "@bitwarden/legacy-crypto";
 
 import { DesktopBiometricsService } from "./biometrics/desktop.biometrics.service";
 

--- a/apps/desktop/src/services/biometric-message-handler.service.ts
+++ b/apps/desktop/src/services/biometric-message-handler.service.ts
@@ -4,15 +4,18 @@ import { firstValueFrom } from "rxjs";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { AuthService } from "@bitwarden/common/auth/abstractions/auth.service";
 import { AuthenticationStatus } from "@bitwarden/common/auth/enums/authentication-status";
-import { CryptoFunctionService } from "@bitwarden/common/key-management/crypto/abstractions/crypto-function.service";
-import { EncryptService } from "@bitwarden/common/key-management/crypto/abstractions/encrypt.service";
-import { EncString } from "@bitwarden/common/key-management/crypto/models/enc-string";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { SdkLoadService } from "@bitwarden/common/platform/abstractions/sdk/sdk-load.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
-import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
 import { UserId } from "@bitwarden/common/types/guid";
 import { BiometricsCommands, BiometricsStatus } from "@bitwarden/key-management";
+// eslint-disable-next-line no-restricted-imports
+import {
+  CryptoFunctionService,
+  EncryptService,
+  EncString,
+  SymmetricCryptoKey,
+} from "@bitwarden/legacy-crypto";
 import { PureCrypto } from "@bitwarden/sdk-internal";
 
 import { DesktopBiometricsService } from "../key-management/biometrics/desktop.biometrics.service";

--- a/apps/web/src/app/key-management/change-kdf/change-kdf-confirmation.component.spec.ts
+++ b/apps/web/src/app/key-management/change-kdf/change-kdf-confirmation.component.spec.ts
@@ -4,7 +4,6 @@ import { mock, MockProxy } from "jest-mock-extended";
 import { of } from "rxjs";
 
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
-import { EncString } from "@bitwarden/common/key-management/crypto/models/enc-string";
 import { InternalMasterPasswordServiceAbstraction } from "@bitwarden/common/key-management/master-password/abstractions/master-password.service.abstraction";
 import {
   MasterKeyWrappedUserKey,
@@ -18,7 +17,8 @@ import { SdkService } from "@bitwarden/common/platform/abstractions/sdk/sdk.serv
 import { FakeAccountService, makeEncString, mockAccountServiceWith } from "@bitwarden/common/spec";
 import { UserId } from "@bitwarden/common/types/guid";
 import { DIALOG_DATA, DialogRef, ToastService } from "@bitwarden/components";
-import { KdfType, PBKDF2KdfConfig, Argon2KdfConfig } from "@bitwarden/key-management";
+// eslint-disable-next-line no-restricted-imports
+import { Argon2KdfConfig, EncString, KdfType, PBKDF2KdfConfig } from "@bitwarden/legacy-crypto";
 
 import { SharedModule } from "../../shared";
 

--- a/apps/web/src/app/key-management/change-kdf/change-kdf-confirmation.component.ts
+++ b/apps/web/src/app/key-management/change-kdf/change-kdf-confirmation.component.ts
@@ -15,7 +15,8 @@ import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.servic
 import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
 import { SdkService } from "@bitwarden/common/platform/abstractions/sdk/sdk.service";
 import { DIALOG_DATA, DialogRef, ToastService } from "@bitwarden/components";
-import { KdfConfig, KdfType } from "@bitwarden/key-management";
+// eslint-disable-next-line no-restricted-imports
+import { KdfConfig, KdfType } from "@bitwarden/legacy-crypto";
 
 // FIXME(https://bitwarden.atlassian.net/browse/CL-764): Migrate to OnPush
 // eslint-disable-next-line @angular-eslint/prefer-on-push-component-change-detection

--- a/apps/web/src/app/key-management/change-kdf/change-kdf.component.spec.ts
+++ b/apps/web/src/app/key-management/change-kdf/change-kdf.component.spec.ts
@@ -20,12 +20,9 @@ import {
   SelectModule,
   TypographyModule,
 } from "@bitwarden/components";
-import {
-  KdfConfigService,
-  Argon2KdfConfig,
-  PBKDF2KdfConfig,
-  KdfType,
-} from "@bitwarden/key-management";
+import { KdfConfigService } from "@bitwarden/key-management";
+// eslint-disable-next-line no-restricted-imports
+import { Argon2KdfConfig, KdfType, PBKDF2KdfConfig } from "@bitwarden/legacy-crypto";
 import { Kdf, PasswordManagerClient } from "@bitwarden/sdk-internal";
 import { I18nPipe } from "@bitwarden/ui-common";
 

--- a/apps/web/src/app/key-management/change-kdf/change-kdf.component.ts
+++ b/apps/web/src/app/key-management/change-kdf/change-kdf.component.ts
@@ -17,13 +17,9 @@ import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { SdkService } from "@bitwarden/common/platform/abstractions/sdk/sdk.service";
 import { DialogService } from "@bitwarden/components";
-import {
-  KdfConfigService,
-  Argon2KdfConfig,
-  KdfConfig,
-  PBKDF2KdfConfig,
-  KdfType,
-} from "@bitwarden/key-management";
+import { KdfConfigService } from "@bitwarden/key-management";
+// eslint-disable-next-line no-restricted-imports
+import { Argon2KdfConfig, KdfConfig, KdfType, PBKDF2KdfConfig } from "@bitwarden/legacy-crypto";
 
 import { ChangeKdfConfirmationComponent } from "./change-kdf-confirmation.component";
 

--- a/apps/web/src/app/key-management/data-recovery/data-recovery.component.spec.ts
+++ b/apps/web/src/app/key-management/data-recovery/data-recovery.component.spec.ts
@@ -3,8 +3,6 @@ import { mock, MockProxy } from "jest-mock-extended";
 
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
-import { CryptoFunctionService } from "@bitwarden/common/key-management/crypto/abstractions/crypto-function.service";
-import { EncryptService } from "@bitwarden/common/key-management/crypto/abstractions/encrypt.service";
 import { FileDownloadService } from "@bitwarden/common/platform/abstractions/file-download/file-download.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { FakeAccountService, mockAccountServiceWith } from "@bitwarden/common/spec";
@@ -13,6 +11,8 @@ import { CipherEncryptionService } from "@bitwarden/common/vault/abstractions/ci
 import { FolderApiServiceAbstraction } from "@bitwarden/common/vault/abstractions/folder/folder-api.service.abstraction";
 import { DialogService } from "@bitwarden/components";
 import { KeyService, UserAsymmetricKeysRegenerationService } from "@bitwarden/key-management";
+// eslint-disable-next-line no-restricted-imports
+import { CryptoFunctionService, EncryptService } from "@bitwarden/legacy-crypto";
 import { LogService } from "@bitwarden/logging";
 
 import { DataRecoveryComponent, StepStatus } from "./data-recovery.component";

--- a/apps/web/src/app/key-management/data-recovery/data-recovery.component.ts
+++ b/apps/web/src/app/key-management/data-recovery/data-recovery.component.ts
@@ -6,13 +6,14 @@ import { ChangeDetectionStrategy, Component, inject, signal } from "@angular/cor
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
-import { EncryptService } from "@bitwarden/common/key-management/crypto/abstractions/encrypt.service";
 import { FileDownloadService } from "@bitwarden/common/platform/abstractions/file-download/file-download.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { CipherEncryptionService } from "@bitwarden/common/vault/abstractions/cipher-encryption.service";
 import { FolderApiServiceAbstraction } from "@bitwarden/common/vault/abstractions/folder/folder-api.service.abstraction";
 import { ButtonModule, DialogService } from "@bitwarden/components";
 import { KeyService, UserAsymmetricKeysRegenerationService } from "@bitwarden/key-management";
+// eslint-disable-next-line no-restricted-imports
+import { EncryptService } from "@bitwarden/legacy-crypto";
 import { LogService } from "@bitwarden/logging";
 
 import { SharedModule } from "../../shared";

--- a/apps/web/src/app/key-management/data-recovery/steps/cipher-step.spec.ts
+++ b/apps/web/src/app/key-management/data-recovery/steps/cipher-step.spec.ts
@@ -1,14 +1,13 @@
 import { mock, MockProxy } from "jest-mock-extended";
 
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
-import { EncryptService } from "@bitwarden/common/key-management/crypto/abstractions/encrypt.service";
-import { EncString } from "@bitwarden/common/key-management/crypto/models/enc-string";
-import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
 import { UserKey } from "@bitwarden/common/types/key";
 import { CipherEncryptionService } from "@bitwarden/common/vault/abstractions/cipher-encryption.service";
 import { CipherType } from "@bitwarden/common/vault/enums";
 import { Cipher } from "@bitwarden/common/vault/models/domain/cipher";
 import { DialogService } from "@bitwarden/components";
+// eslint-disable-next-line no-restricted-imports
+import { EncryptService, EncString, SymmetricCryptoKey } from "@bitwarden/legacy-crypto";
 import { UserId } from "@bitwarden/user-core";
 
 import { LogRecorder } from "../log-recorder";

--- a/apps/web/src/app/key-management/data-recovery/steps/cipher-step.ts
+++ b/apps/web/src/app/key-management/data-recovery/steps/cipher-step.ts
@@ -1,11 +1,10 @@
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
-import { EncryptService } from "@bitwarden/common/key-management/crypto/abstractions/encrypt.service";
-import { EncryptionType } from "@bitwarden/common/platform/enums";
-import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
 import { UserKey } from "@bitwarden/common/types/key";
 import { CipherEncryptionService } from "@bitwarden/common/vault/abstractions/cipher-encryption.service";
 import { Cipher } from "@bitwarden/common/vault/models/domain/cipher";
 import { DialogService } from "@bitwarden/components";
+// eslint-disable-next-line no-restricted-imports
+import { EncryptionType, EncryptService, SymmetricCryptoKey } from "@bitwarden/legacy-crypto";
 
 import { LogRecorder } from "../log-recorder";
 

--- a/apps/web/src/app/key-management/data-recovery/steps/private-key-step.ts
+++ b/apps/web/src/app/key-management/data-recovery/steps/private-key-step.ts
@@ -1,6 +1,7 @@
-import { EncryptionType } from "@bitwarden/common/platform/enums";
 import { DialogService } from "@bitwarden/components";
 import { UserAsymmetricKeysRegenerationService } from "@bitwarden/key-management";
+// eslint-disable-next-line no-restricted-imports
+import { EncryptionType } from "@bitwarden/legacy-crypto";
 
 import { LogRecorder } from "../log-recorder";
 

--- a/apps/web/src/app/key-management/data-recovery/steps/user-info-step.ts
+++ b/apps/web/src/app/key-management/data-recovery/steps/user-info-step.ts
@@ -1,8 +1,9 @@
 import { firstValueFrom } from "rxjs";
 
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
-import { EncryptionType } from "@bitwarden/common/platform/enums";
 import { KeyService } from "@bitwarden/key-management";
+// eslint-disable-next-line no-restricted-imports
+import { EncryptionType } from "@bitwarden/legacy-crypto";
 
 import { LogRecorder } from "../log-recorder";
 

--- a/apps/web/src/app/key-management/key-rotation/model/public-key-encryption-key-pair-request.model.ts
+++ b/apps/web/src/app/key-management/key-rotation/model/public-key-encryption-key-pair-request.model.ts
@@ -1,5 +1,6 @@
-import { UnsignedPublicKey, WrappedPrivateKey } from "@bitwarden/common/key-management/types";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
+// eslint-disable-next-line no-restricted-imports
+import { UnsignedPublicKey, WrappedPrivateKey } from "@bitwarden/legacy-crypto";
 import { SignedPublicKey } from "@bitwarden/sdk-internal";
 
 export class PublicKeyEncryptionKeyPairRequestModel {

--- a/apps/web/src/app/key-management/key-rotation/model/signature-key-pair-request-request.model.ts
+++ b/apps/web/src/app/key-management/key-rotation/model/signature-key-pair-request-request.model.ts
@@ -1,4 +1,5 @@
-import { VerifyingKey, WrappedSigningKey } from "@bitwarden/common/key-management/types";
+// eslint-disable-next-line no-restricted-imports
+import { VerifyingKey, WrappedSigningKey } from "@bitwarden/legacy-crypto";
 import { SignatureAlgorithm } from "@bitwarden/sdk-internal";
 
 export class SignatureKeyPairRequestModel {

--- a/apps/web/src/app/key-management/key-rotation/request/account-keys.request.ts
+++ b/apps/web/src/app/key-management/key-rotation/request/account-keys.request.ts
@@ -1,7 +1,8 @@
 import { SecurityStateRequest } from "@bitwarden/common/key-management/security-state/request/security-state.request";
-import { WrappedPrivateKey } from "@bitwarden/common/key-management/types";
 import { SdkLoadService } from "@bitwarden/common/platform/abstractions/sdk/sdk-load.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
+// eslint-disable-next-line no-restricted-imports
+import { WrappedPrivateKey } from "@bitwarden/legacy-crypto";
 import { PureCrypto } from "@bitwarden/sdk-internal";
 
 import { PublicKeyEncryptionKeyPairRequestModel } from "../model/public-key-encryption-key-pair-request.model";

--- a/apps/web/src/app/key-management/key-rotation/request/master-password-unlock-data.request.ts
+++ b/apps/web/src/app/key-management/key-rotation/request/master-password-unlock-data.request.ts
@@ -1,4 +1,5 @@
-import { Argon2KdfConfig, KdfConfig, KdfType } from "@bitwarden/key-management";
+// eslint-disable-next-line no-restricted-imports
+import { Argon2KdfConfig, KdfConfig, KdfType } from "@bitwarden/legacy-crypto";
 
 export class MasterPasswordUnlockDataRequest {
   kdfType: KdfType = KdfType.PBKDF2_SHA256;

--- a/apps/web/src/app/key-management/key-rotation/types/v1-cryptographic-state.ts
+++ b/apps/web/src/app/key-management/key-rotation/types/v1-cryptographic-state.ts
@@ -1,5 +1,6 @@
-import { UnsignedPublicKey, WrappedPrivateKey } from "@bitwarden/common/key-management/types";
 import { UserKey } from "@bitwarden/common/types/key";
+// eslint-disable-next-line no-restricted-imports
+import { UnsignedPublicKey, WrappedPrivateKey } from "@bitwarden/legacy-crypto";
 
 export type V1UserCryptographicState = {
   userKey: UserKey;

--- a/apps/web/src/app/key-management/key-rotation/types/v2-cryptographic-state.ts
+++ b/apps/web/src/app/key-management/key-rotation/types/v2-cryptographic-state.ts
@@ -1,13 +1,14 @@
+import { Utils } from "@bitwarden/common/platform/misc/utils";
+import { UserKey } from "@bitwarden/common/types/key";
+// eslint-disable-next-line no-restricted-imports
 import {
   SignedSecurityState,
+  SymmetricCryptoKey,
   UnsignedPublicKey,
   VerifyingKey,
   WrappedPrivateKey,
   WrappedSigningKey,
-} from "@bitwarden/common/key-management/types";
-import { Utils } from "@bitwarden/common/platform/misc/utils";
-import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
-import { UserKey } from "@bitwarden/common/types/key";
+} from "@bitwarden/legacy-crypto";
 import { SignedPublicKey, UserCryptoV2KeysResponse } from "@bitwarden/sdk-internal";
 
 export type V2UserCryptographicState = {

--- a/apps/web/src/app/key-management/key-rotation/user-key-rotation.service.spec.ts
+++ b/apps/web/src/app/key-management/key-rotation/user-key-rotation.service.spec.ts
@@ -6,31 +6,16 @@ import { LogoutService } from "@bitwarden/auth/common";
 import { Account } from "@bitwarden/common/auth/abstractions/account.service";
 import { WebauthnRotateCredentialRequest } from "@bitwarden/common/auth/models/request/webauthn-rotate-credential.request";
 import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
-import { CryptoFunctionService } from "@bitwarden/common/key-management/crypto/abstractions/crypto-function.service";
-import { EncryptService } from "@bitwarden/common/key-management/crypto/abstractions/encrypt.service";
-import {
-  EncryptedString,
-  EncString,
-} from "@bitwarden/common/key-management/crypto/models/enc-string";
 import { DeviceTrustServiceAbstraction } from "@bitwarden/common/key-management/device-trust/abstractions/device-trust.service.abstraction";
 import { MasterPasswordServiceAbstraction } from "@bitwarden/common/key-management/master-password/abstractions/master-password.service.abstraction";
 import { MasterPasswordSalt } from "@bitwarden/common/key-management/master-password/types/master-password.types";
 import { SecurityStateService } from "@bitwarden/common/key-management/security-state/abstractions/security-state.service";
-import {
-  SignedPublicKey,
-  SignedSecurityState,
-  UnsignedPublicKey,
-  VerifyingKey,
-  WrappedPrivateKey,
-  WrappedSigningKey,
-} from "@bitwarden/common/key-management/types";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { SdkClientFactory } from "@bitwarden/common/platform/abstractions/sdk/sdk-client-factory";
 import { SdkLoadService } from "@bitwarden/common/platform/abstractions/sdk/sdk-load.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
-import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
 import { mockAccountInfoWith } from "@bitwarden/common/spec";
 import { SendWithIdRequest } from "@bitwarden/common/tools/send/models/request/send-with-id.request";
 import { SendService } from "@bitwarden/common/tools/send/services/send.service.abstraction";
@@ -43,20 +28,30 @@ import { CipherType } from "@bitwarden/common/vault/enums";
 import { CipherWithIdRequest } from "@bitwarden/common/vault/models/request/cipher-with-id.request";
 import { FolderWithIdRequest } from "@bitwarden/common/vault/models/request/folder-with-id.request";
 import { DialogService, ToastService } from "@bitwarden/components";
-import {
-  KeyService,
-  PBKDF2KdfConfig,
-  KdfConfigService,
-  KdfConfig,
-  KdfType,
-} from "@bitwarden/key-management";
+import { KeyService, KdfConfigService } from "@bitwarden/key-management";
 import {
   AccountRecoveryTrustComponent,
   EmergencyAccessTrustComponent,
   KeyRotationTrustInfoComponent,
 } from "@bitwarden/key-management-ui";
 // eslint-disable-next-line no-restricted-imports
-import { LegacyCompatKeyService } from "@bitwarden/legacy-crypto";
+import {
+  CryptoFunctionService,
+  EncryptedString,
+  EncryptService,
+  EncString,
+  KdfConfig,
+  KdfType,
+  LegacyCompatKeyService,
+  PBKDF2KdfConfig,
+  SignedPublicKey,
+  SignedSecurityState,
+  SymmetricCryptoKey,
+  UnsignedPublicKey,
+  VerifyingKey,
+  WrappedPrivateKey,
+  WrappedSigningKey,
+} from "@bitwarden/legacy-crypto";
 import { BitwardenClient, PureCrypto } from "@bitwarden/sdk-internal";
 import { UserKeyRotationServiceAbstraction } from "@bitwarden/user-crypto-management";
 

--- a/apps/web/src/app/key-management/key-rotation/user-key-rotation.service.ts
+++ b/apps/web/src/app/key-management/key-rotation/user-key-rotation.service.ts
@@ -4,27 +4,15 @@ import { firstValueFrom, Observable } from "rxjs";
 import { LogoutService } from "@bitwarden/auth/common";
 import { Account } from "@bitwarden/common/auth/abstractions/account.service";
 import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
-import { CryptoFunctionService } from "@bitwarden/common/key-management/crypto/abstractions/crypto-function.service";
-import { EncryptService } from "@bitwarden/common/key-management/crypto/abstractions/encrypt.service";
-import { EncString } from "@bitwarden/common/key-management/crypto/models/enc-string";
 import { DeviceTrustServiceAbstraction } from "@bitwarden/common/key-management/device-trust/abstractions/device-trust.service.abstraction";
 import { MasterPasswordServiceAbstraction } from "@bitwarden/common/key-management/master-password/abstractions/master-password.service.abstraction";
 import { SecurityStateService } from "@bitwarden/common/key-management/security-state/abstractions/security-state.service";
-import {
-  SignedPublicKey,
-  SignedSecurityState,
-  UnsignedPublicKey,
-  WrappedPrivateKey,
-  WrappedSigningKey,
-} from "@bitwarden/common/key-management/types";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { SdkClientFactory } from "@bitwarden/common/platform/abstractions/sdk/sdk-client-factory";
 import { SdkLoadService } from "@bitwarden/common/platform/abstractions/sdk/sdk-load.service";
 import { asUuid } from "@bitwarden/common/platform/abstractions/sdk/sdk.service";
-import { EncryptionType } from "@bitwarden/common/platform/enums";
-import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
 import { SendService } from "@bitwarden/common/tools/send/services/send.service.abstraction";
 import { UserId } from "@bitwarden/common/types/guid";
 import { UserKey } from "@bitwarden/common/types/key";
@@ -32,14 +20,27 @@ import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.servi
 import { FolderService } from "@bitwarden/common/vault/abstractions/folder/folder.service.abstraction";
 import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.service.abstraction";
 import { DialogService, ToastService } from "@bitwarden/components";
-import { KdfConfig, KdfConfigService, KeyService } from "@bitwarden/key-management";
+import { KdfConfigService, KeyService } from "@bitwarden/key-management";
 import {
   AccountRecoveryTrustComponent,
   EmergencyAccessTrustComponent,
   KeyRotationTrustInfoComponent,
 } from "@bitwarden/key-management-ui";
 // eslint-disable-next-line no-restricted-imports
-import { LegacyCompatKeyService } from "@bitwarden/legacy-crypto";
+import {
+  CryptoFunctionService,
+  EncryptionType,
+  EncryptService,
+  EncString,
+  KdfConfig,
+  LegacyCompatKeyService,
+  SignedPublicKey,
+  SignedSecurityState,
+  SymmetricCryptoKey,
+  UnsignedPublicKey,
+  WrappedPrivateKey,
+  WrappedSigningKey,
+} from "@bitwarden/legacy-crypto";
 import { PureCrypto, TokenProvider } from "@bitwarden/sdk-internal";
 import { UserKeyRotationServiceAbstraction } from "@bitwarden/user-crypto-management";
 

--- a/apps/web/src/app/key-management/web-biometric.service.ts
+++ b/apps/web/src/app/key-management/web-biometric.service.ts
@@ -1,7 +1,8 @@
-import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
 import { UserId } from "@bitwarden/common/types/guid";
 import { UserKey } from "@bitwarden/common/types/key";
 import { BiometricsService, BiometricsStatus } from "@bitwarden/key-management";
+// eslint-disable-next-line no-restricted-imports
+import { SymmetricCryptoKey } from "@bitwarden/legacy-crypto";
 
 export class WebBiometricsService extends BiometricsService {
   async authenticateWithBiometrics(): Promise<boolean> {

--- a/libs/common/src/key-management/device-trust/abstractions/device-trust.service.abstraction.ts
+++ b/libs/common/src/key-management/device-trust/abstractions/device-trust.service.abstraction.ts
@@ -1,10 +1,12 @@
 import { Observable } from "rxjs";
 
+// eslint-disable-next-line no-restricted-imports
+import { EncString } from "@bitwarden/legacy-crypto";
+
 import { DeviceResponse } from "../../../auth/abstractions/devices/responses/device.response";
 import { OtherDeviceKeysUpdateRequest } from "../../../auth/models/request/update-devices-trust.request";
 import { UserId } from "../../../types/guid";
 import { DeviceKey, UserKey } from "../../../types/key";
-import { EncString } from "../../crypto/models/enc-string";
 
 export abstract class DeviceTrustServiceAbstraction {
   /**

--- a/libs/common/src/key-management/device-trust/services/device-trust.service.implementation.ts
+++ b/libs/common/src/key-management/device-trust/services/device-trust.service.implementation.ts
@@ -8,6 +8,13 @@ import { UserDecryptionOptionsServiceAbstraction } from "@bitwarden/auth/common"
 // This import has been flagged as unallowed for this class. It may be involved in a circular dependency loop.
 // eslint-disable-next-line no-restricted-imports
 import { KeyService } from "@bitwarden/key-management";
+// eslint-disable-next-line no-restricted-imports
+import {
+  CryptoFunctionService,
+  EncryptService,
+  EncString,
+  SymmetricCryptoKey,
+} from "@bitwarden/legacy-crypto";
 import { PureCrypto } from "@bitwarden/sdk-internal";
 
 import { AccountService } from "../../../auth/abstractions/account.service";
@@ -28,13 +35,9 @@ import { SdkLoadService } from "../../../platform/abstractions/sdk/sdk-load.serv
 import { AbstractStorageService } from "../../../platform/abstractions/storage.service";
 import { StorageLocation } from "../../../platform/enums";
 import { StorageOptions } from "../../../platform/models/domain/storage-options";
-import { SymmetricCryptoKey } from "../../../platform/models/domain/symmetric-crypto-key";
 import { DEVICE_TRUST_DISK_LOCAL, StateProvider, UserKeyDefinition } from "../../../platform/state";
 import { UserId } from "../../../types/guid";
 import { UserKey, DeviceKey } from "../../../types/key";
-import { CryptoFunctionService } from "../../crypto/abstractions/crypto-function.service";
-import { EncryptService } from "../../crypto/abstractions/encrypt.service";
-import { EncString } from "../../crypto/models/enc-string";
 import { RotateableKeySet } from "../../keys/models/rotateable-key-set";
 import { DeviceTrustServiceAbstraction } from "../abstractions/device-trust.service.abstraction";
 

--- a/libs/common/src/key-management/device-trust/services/device-trust.service.spec.ts
+++ b/libs/common/src/key-management/device-trust/services/device-trust.service.spec.ts
@@ -12,6 +12,15 @@ import {
 // This import has been flagged as unallowed for this class. It may be involved in a circular dependency loop.
 // eslint-disable-next-line no-restricted-imports
 import { KeyService } from "@bitwarden/key-management";
+// eslint-disable-next-line no-restricted-imports
+import {
+  CryptoFunctionService,
+  CsprngArray,
+  EncryptionType,
+  EncryptService,
+  EncString,
+  SymmetricCryptoKey,
+} from "@bitwarden/legacy-crypto";
 import { PureCrypto } from "@bitwarden/sdk-internal";
 
 import { FakeAccountService, mockAccountServiceWith } from "../../../../spec/fake-account-service";
@@ -31,16 +40,10 @@ import { PlatformUtilsService } from "../../../platform/abstractions/platform-ut
 import { SdkLoadService } from "../../../platform/abstractions/sdk/sdk-load.service";
 import { AbstractStorageService } from "../../../platform/abstractions/storage.service";
 import { StorageLocation } from "../../../platform/enums";
-import { EncryptionType } from "../../../platform/enums/encryption-type.enum";
 import { Utils } from "../../../platform/misc/utils";
 import { StorageOptions } from "../../../platform/models/domain/storage-options";
-import { SymmetricCryptoKey } from "../../../platform/models/domain/symmetric-crypto-key";
-import { CsprngArray } from "../../../types/csprng";
 import { UserId } from "../../../types/guid";
 import { DeviceKey, UserKey } from "../../../types/key";
-import { CryptoFunctionService } from "../../crypto/abstractions/crypto-function.service";
-import { EncryptService } from "../../crypto/abstractions/encrypt.service";
-import { EncString } from "../../crypto/models/enc-string";
 
 import {
   SHOULD_TRUST_DEVICE,

--- a/libs/common/src/key-management/encrypted-migrator/migrations/biometric-persistent-encryption-migration.spec.ts
+++ b/libs/common/src/key-management/encrypted-migrator/migrations/biometric-persistent-encryption-migration.spec.ts
@@ -3,11 +3,12 @@ import { of } from "rxjs";
 
 // eslint-disable-next-line no-restricted-imports
 import { BiometricStateService, BiometricsService, KeyService } from "@bitwarden/key-management";
+// eslint-disable-next-line no-restricted-imports
+import { SymmetricCryptoKey } from "@bitwarden/legacy-crypto";
 import { LogService } from "@bitwarden/logging";
 import { CryptoClient } from "@bitwarden/sdk-internal";
 
 import { Utils } from "../../../platform/misc/utils";
-import { SymmetricCryptoKey } from "../../../platform/models/domain/symmetric-crypto-key";
 import { UserId } from "../../../types/guid";
 import { UserKey } from "../../../types/key";
 

--- a/libs/common/src/key-management/encrypted-migrator/migrations/minimum-kdf-migration.spec.ts
+++ b/libs/common/src/key-management/encrypted-migrator/migrations/minimum-kdf-migration.spec.ts
@@ -2,12 +2,9 @@ import { mock } from "jest-mock-extended";
 import { of } from "rxjs";
 
 // eslint-disable-next-line no-restricted-imports
-import {
-  Argon2KdfConfig,
-  KdfConfigService,
-  KdfType,
-  PBKDF2KdfConfig,
-} from "@bitwarden/key-management";
+import { KdfConfigService } from "@bitwarden/key-management";
+// eslint-disable-next-line no-restricted-imports
+import { Argon2KdfConfig, EncString, KdfType, PBKDF2KdfConfig } from "@bitwarden/legacy-crypto";
 import { LogService } from "@bitwarden/logging";
 
 import { makeEncString } from "../../../../spec";
@@ -16,7 +13,6 @@ import { ConfigService } from "../../../platform/abstractions/config/config.serv
 import { SdkService } from "../../../platform/abstractions/sdk/sdk.service";
 import { SyncService } from "../../../platform/sync";
 import { UserId } from "../../../types/guid";
-import { EncString } from "../../crypto/models/enc-string";
 import { InternalMasterPasswordServiceAbstraction } from "../../master-password/abstractions/master-password.service.abstraction";
 import {
   MasterKeyWrappedUserKey,

--- a/libs/common/src/key-management/encrypted-migrator/migrations/minimum-kdf-migration.ts
+++ b/libs/common/src/key-management/encrypted-migrator/migrations/minimum-kdf-migration.ts
@@ -1,5 +1,7 @@
 // eslint-disable-next-line no-restricted-imports
-import { KdfConfigService, KdfType, PBKDF2KdfConfig } from "@bitwarden/key-management";
+import { KdfConfigService } from "@bitwarden/key-management";
+// eslint-disable-next-line no-restricted-imports
+import { KdfType, PBKDF2KdfConfig } from "@bitwarden/legacy-crypto";
 import { LogService } from "@bitwarden/logging";
 
 import { assertNonNullish } from "../../../auth/utils";

--- a/libs/common/src/key-management/encrypted-migrator/migrations/v2-key-rotation-migration.spec.ts
+++ b/libs/common/src/key-management/encrypted-migrator/migrations/v2-key-rotation-migration.spec.ts
@@ -3,20 +3,20 @@ import { of } from "rxjs";
 
 // eslint-disable-next-line no-restricted-imports
 import { KeyService } from "@bitwarden/key-management";
+// eslint-disable-next-line no-restricted-imports
+import { EncString, SymmetricCryptoKey } from "@bitwarden/legacy-crypto";
 import { LogService } from "@bitwarden/logging";
 import { UserKeyRotationServiceAbstraction } from "@bitwarden/user-crypto-management";
 
 import { FeatureFlag } from "../../../enums/feature-flag.enum";
 import { ConfigService } from "../../../platform/abstractions/config/config.service";
 import { SdkService } from "../../../platform/abstractions/sdk/sdk.service";
-import { SymmetricCryptoKey } from "../../../platform/models/domain/symmetric-crypto-key";
 import { SyncService } from "../../../platform/sync";
 import { UserId } from "../../../types/guid";
 import { UserKey } from "../../../types/key";
 import { CipherService } from "../../../vault/abstractions/cipher.service";
 import { AttachmentView } from "../../../vault/models/view/attachment.view";
 import { CipherView } from "../../../vault/models/view/cipher.view";
-import { EncString } from "../../crypto/models/enc-string";
 import { MasterPasswordServiceAbstraction } from "../../master-password/abstractions/master-password.service.abstraction";
 
 import { V2KeyRotationMigration } from "./v2-key-rotation-migration";

--- a/libs/common/src/key-management/encrypted-migrator/migrations/v2-key-rotation-migration.ts
+++ b/libs/common/src/key-management/encrypted-migrator/migrations/v2-key-rotation-migration.ts
@@ -2,6 +2,8 @@ import { firstValueFrom } from "rxjs";
 
 // eslint-disable-next-line no-restricted-imports
 import { KeyService } from "@bitwarden/key-management";
+// eslint-disable-next-line no-restricted-imports
+import { EncryptionType } from "@bitwarden/legacy-crypto";
 import { LogService } from "@bitwarden/logging";
 import { UserKeyRotationServiceAbstraction } from "@bitwarden/user-crypto-management";
 
@@ -9,7 +11,6 @@ import { assertNonNullish } from "../../../auth/utils";
 import { FeatureFlag } from "../../../enums/feature-flag.enum";
 import { ConfigService } from "../../../platform/abstractions/config/config.service";
 import { SdkService } from "../../../platform/abstractions/sdk/sdk.service";
-import { EncryptionType } from "../../../platform/enums";
 import { SyncService } from "../../../platform/sync";
 import { UserId } from "../../../types/guid";
 import { CipherService } from "../../../vault/abstractions/cipher.service";

--- a/libs/common/src/key-management/key-connector/models/new-sso-user-key-connector-conversion.ts
+++ b/libs/common/src/key-management/key-connector/models/new-sso-user-key-connector-conversion.ts
@@ -1,6 +1,6 @@
 // This import has been flagged as unallowed for this class. It may be involved in a circular dependency loop.
 // eslint-disable-next-line no-restricted-imports
-import { KdfConfig } from "@bitwarden/key-management";
+import { KdfConfig } from "@bitwarden/legacy-crypto";
 
 export interface NewSsoUserKeyConnectorConversion {
   kdfConfig: KdfConfig;

--- a/libs/common/src/key-management/key-connector/models/set-key-connector-key.request.ts
+++ b/libs/common/src/key-management/key-connector/models/set-key-connector-key.request.ts
@@ -1,6 +1,6 @@
 // This import has been flagged as unallowed for this class. It may be involved in a circular dependency loop.
 // eslint-disable-next-line no-restricted-imports
-import { KdfConfig, KdfType } from "@bitwarden/key-management";
+import { KdfConfig, KdfType } from "@bitwarden/legacy-crypto";
 
 import { KeysRequest } from "../../../models/request/keys.request";
 

--- a/libs/common/src/key-management/key-connector/services/key-connector.service.spec.ts
+++ b/libs/common/src/key-management/key-connector/services/key-connector.service.spec.ts
@@ -9,9 +9,16 @@ import {
 } from "@bitwarden/auth/common";
 // This import has been flagged as unallowed for this class. It may be involved in a circular dependency loop.
 // eslint-disable-next-line no-restricted-imports
-import { Argon2KdfConfig, KdfType, KeyService, PBKDF2KdfConfig } from "@bitwarden/key-management";
+import { KeyService } from "@bitwarden/key-management";
 // eslint-disable-next-line no-restricted-imports
-import { LegacyCompatKeyService } from "@bitwarden/legacy-crypto";
+import {
+  Argon2KdfConfig,
+  EncString,
+  KdfType,
+  LegacyCompatKeyService,
+  PBKDF2KdfConfig,
+  SymmetricCryptoKey,
+} from "@bitwarden/legacy-crypto";
 import { BitwardenClient, PureCrypto } from "@bitwarden/sdk-internal";
 
 import { FakeAccountService, FakeStateProvider, mockAccountServiceWith } from "../../../../spec";
@@ -31,11 +38,9 @@ import { SdkLoadService } from "../../../platform/abstractions/sdk/sdk-load.serv
 import { SdkService } from "../../../platform/abstractions/sdk/sdk.service";
 import { Rc } from "../../../platform/misc/reference-counting/rc";
 import { Utils } from "../../../platform/misc/utils";
-import { SymmetricCryptoKey } from "../../../platform/models/domain/symmetric-crypto-key";
 import { OrganizationId, UserId } from "../../../types/guid";
 import { MasterKey, UserKey } from "../../../types/key";
 import { AccountCryptographicStateService } from "../../account-cryptography/account-cryptographic-state.service";
-import { EncString } from "../../crypto/models/enc-string";
 import { FakeMasterPasswordService } from "../../master-password/services/fake-master-password.service";
 import { KeyConnectorUserKeyRequest } from "../models/key-connector-user-key.request";
 import { NewSsoUserKeyConnectorConversion } from "../models/new-sso-user-key-connector-conversion";

--- a/libs/common/src/key-management/key-connector/services/key-connector.service.ts
+++ b/libs/common/src/key-management/key-connector/services/key-connector.service.ts
@@ -10,15 +10,17 @@ import {
 } from "@bitwarden/auth/common";
 // This import has been flagged as unallowed for this class. It may be involved in a circular dependency loop.
 // eslint-disable-next-line no-restricted-imports
+import { KeyService } from "@bitwarden/key-management";
+// eslint-disable-next-line no-restricted-imports
 import {
   Argon2KdfConfig,
+  EncString,
   KdfConfig,
   KdfType,
-  KeyService,
+  LegacyCompatKeyService,
   PBKDF2KdfConfig,
-} from "@bitwarden/key-management";
-// eslint-disable-next-line no-restricted-imports
-import { LegacyCompatKeyService } from "@bitwarden/legacy-crypto";
+  SymmetricCryptoKey,
+} from "@bitwarden/legacy-crypto";
 import { LogService } from "@bitwarden/logging";
 import { PureCrypto } from "@bitwarden/sdk-internal";
 
@@ -35,12 +37,10 @@ import { RegisterSdkService } from "../../../platform/abstractions/sdk/register-
 import { SdkLoadService } from "../../../platform/abstractions/sdk/sdk-load.service";
 import { SdkService } from "../../../platform/abstractions/sdk/sdk.service";
 import { Utils } from "../../../platform/misc/utils";
-import { SymmetricCryptoKey } from "../../../platform/models/domain/symmetric-crypto-key";
 import { KEY_CONNECTOR_DISK, StateProvider, UserKeyDefinition } from "../../../platform/state";
 import { UserId } from "../../../types/guid";
 import { MasterKey, UserKey } from "../../../types/key";
 import { AccountCryptographicStateService } from "../../account-cryptography/account-cryptographic-state.service";
-import { EncString } from "../../crypto/models/enc-string";
 import { InternalMasterPasswordServiceAbstraction } from "../../master-password/abstractions/master-password.service.abstraction";
 import { KeyConnectorService as KeyConnectorServiceAbstraction } from "../abstractions/key-connector.service";
 import { KeyConnectorDomainConfirmation } from "../models/key-connector-domain-confirmation";

--- a/libs/common/src/key-management/keys/models/rotateable-key-set.ts
+++ b/libs/common/src/key-management/keys/models/rotateable-key-set.ts
@@ -1,6 +1,7 @@
-import { SymmetricCryptoKey } from "../../../platform/models/domain/symmetric-crypto-key";
+// eslint-disable-next-line no-restricted-imports
+import { EncString, SymmetricCryptoKey } from "@bitwarden/legacy-crypto";
+
 import { PrfKey } from "../../../types/key";
-import { EncString } from "../../crypto/models/enc-string";
 
 declare const tag: unique symbol;
 

--- a/libs/common/src/key-management/keys/response/public-key-encryption-key-pair.response.ts
+++ b/libs/common/src/key-management/keys/response/public-key-encryption-key-pair.response.ts
@@ -1,5 +1,7 @@
+// eslint-disable-next-line no-restricted-imports
+import { SignedPublicKey, UnsignedPublicKey, WrappedPrivateKey } from "@bitwarden/legacy-crypto";
+
 import { Utils } from "../../../platform/misc/utils";
-import { SignedPublicKey, UnsignedPublicKey, WrappedPrivateKey } from "../../types";
 
 export class PublicKeyEncryptionKeyPairResponse {
   readonly wrappedPrivateKey: WrappedPrivateKey;

--- a/libs/common/src/key-management/keys/response/public-keys.response.ts
+++ b/libs/common/src/key-management/keys/response/public-keys.response.ts
@@ -1,6 +1,6 @@
+// eslint-disable-next-line no-restricted-imports
+import { UnsignedPublicKey, VerifyingKey } from "@bitwarden/legacy-crypto";
 import { SignedPublicKey } from "@bitwarden/sdk-internal";
-
-import { UnsignedPublicKey, VerifyingKey } from "../../types";
 
 /**
  * The publicly accessible view of an entity (account / org)'s keys. That includes the encryption public key, and the verifying key if available.

--- a/libs/common/src/key-management/keys/response/signature-key-pair.response.ts
+++ b/libs/common/src/key-management/keys/response/signature-key-pair.response.ts
@@ -1,4 +1,5 @@
-import { VerifyingKey, WrappedSigningKey } from "../../types";
+// eslint-disable-next-line no-restricted-imports
+import { VerifyingKey, WrappedSigningKey } from "@bitwarden/legacy-crypto";
 
 export class SignatureKeyPairResponse {
   readonly wrappedSigningKey: WrappedSigningKey;

--- a/libs/common/src/key-management/keys/services/abstractions/rotateable-key-set.service.ts
+++ b/libs/common/src/key-management/keys/services/abstractions/rotateable-key-set.service.ts
@@ -1,4 +1,6 @@
-import { SymmetricCryptoKey } from "../../../../platform/models/domain/symmetric-crypto-key";
+// eslint-disable-next-line no-restricted-imports
+import { SymmetricCryptoKey } from "@bitwarden/legacy-crypto";
+
 import { RotateableKeySet } from "../../models/rotateable-key-set";
 
 export abstract class RotateableKeySetService {

--- a/libs/common/src/key-management/keys/services/default-rotateable-key-set.service.spec.ts
+++ b/libs/common/src/key-management/keys/services/default-rotateable-key-set.service.spec.ts
@@ -1,12 +1,14 @@
 import { mock, MockProxy } from "jest-mock-extended";
 
 // eslint-disable-next-line no-restricted-imports
-import { LegacyCompatKeyService } from "@bitwarden/legacy-crypto";
+import {
+  EncryptService,
+  EncString,
+  LegacyCompatKeyService,
+  SymmetricCryptoKey,
+} from "@bitwarden/legacy-crypto";
 
 import { Utils } from "../../../platform/misc/utils";
-import { SymmetricCryptoKey } from "../../../platform/models/domain/symmetric-crypto-key";
-import { EncryptService } from "../../crypto/abstractions/encrypt.service";
-import { EncString } from "../../crypto/models/enc-string";
 import { RotateableKeySet } from "../models/rotateable-key-set";
 
 import { DefaultRotateableKeySetService } from "./default-rotateable-key-set.service";

--- a/libs/common/src/key-management/keys/services/default-rotateable-key-set.service.ts
+++ b/libs/common/src/key-management/keys/services/default-rotateable-key-set.service.ts
@@ -1,9 +1,11 @@
 // eslint-disable-next-line no-restricted-imports
-import { LegacyCompatKeyService } from "@bitwarden/legacy-crypto";
+import {
+  EncryptService,
+  LegacyCompatKeyService,
+  SymmetricCryptoKey,
+} from "@bitwarden/legacy-crypto";
 
 import { Utils } from "../../../platform/misc/utils";
-import { SymmetricCryptoKey } from "../../../platform/models/domain/symmetric-crypto-key";
-import { EncryptService } from "../../crypto/abstractions/encrypt.service";
 import { RotateableKeySet } from "../models/rotateable-key-set";
 
 import { RotateableKeySetService } from "./abstractions/rotateable-key-set.service";

--- a/libs/common/src/key-management/local-user-data-key-mapper.ts
+++ b/libs/common/src/key-management/local-user-data-key-mapper.ts
@@ -1,10 +1,10 @@
+// eslint-disable-next-line no-restricted-imports
+import { LocalUserDataKey } from "@bitwarden/legacy-crypto";
 import { LocalUserDataKeyState } from "@bitwarden/sdk-internal";
 
 import { LOCAL_USER_DATA_KEY } from "../platform/services/key-state/local-user-data-key.state";
 import { SdkRecordMapper } from "../platform/services/sdk/client-managed-state";
 import { UserKeyDefinition } from "../platform/state";
-
-import { LocalUserDataKey } from "./types";
 
 export class LocalUserDataKeyRecordMapper implements SdkRecordMapper<
   LocalUserDataKey,

--- a/libs/common/src/key-management/master-password/abstractions/master-password.service.abstraction.spec.ts
+++ b/libs/common/src/key-management/master-password/abstractions/master-password.service.abstraction.spec.ts
@@ -2,11 +2,10 @@ import { mock } from "jest-mock-extended";
 import { of } from "rxjs";
 
 // eslint-disable-next-line no-restricted-imports
-import { PBKDF2KdfConfig } from "@bitwarden/key-management";
+import { EncString, PBKDF2KdfConfig } from "@bitwarden/legacy-crypto";
 
 import { makeEncString } from "../../../../spec";
 import { UserId } from "../../../types/guid";
-import { EncString } from "../../crypto/models/enc-string";
 import {
   MasterKeyWrappedUserKey,
   MasterPasswordSalt,

--- a/libs/common/src/key-management/master-password/abstractions/master-password.service.abstraction.ts
+++ b/libs/common/src/key-management/master-password/abstractions/master-password.service.abstraction.ts
@@ -1,13 +1,12 @@
 import { firstValueFrom, Observable } from "rxjs";
 
 // eslint-disable-next-line no-restricted-imports
-import { KdfConfig } from "@bitwarden/key-management";
+import { EncString, KdfConfig } from "@bitwarden/legacy-crypto";
 
 import { ForceSetPasswordReason } from "../../../auth/models/domain/force-set-password-reason";
 import { assertNonNullish } from "../../../auth/utils";
 import { UserId } from "../../../types/guid";
 import { MasterKey, UserKey } from "../../../types/key";
-import { EncString } from "../../crypto/models/enc-string";
 import {
   MasterPasswordAuthenticationData,
   MasterPasswordSalt,

--- a/libs/common/src/key-management/master-password/models/response/master-password-unlock.response.spec.ts
+++ b/libs/common/src/key-management/master-password/models/response/master-password-unlock.response.spec.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line no-restricted-imports
-import { KdfType, PBKDF2KdfConfig } from "@bitwarden/key-management";
+import { KdfType, PBKDF2KdfConfig } from "@bitwarden/legacy-crypto";
 
 import { MasterPasswordUnlockResponse } from "./master-password-unlock.response";
 

--- a/libs/common/src/key-management/master-password/services/default-master-password-unlock.service.spec.ts
+++ b/libs/common/src/key-management/master-password/services/default-master-password-unlock.service.spec.ts
@@ -3,14 +3,15 @@ import { of } from "rxjs";
 
 import { newGuid } from "@bitwarden/guid";
 // eslint-disable-next-line no-restricted-imports
-import { Argon2KdfConfig } from "@bitwarden/key-management";
-// eslint-disable-next-line no-restricted-imports
-import { LegacyCompatKeyService } from "@bitwarden/legacy-crypto";
+import {
+  Argon2KdfConfig,
+  LegacyCompatKeyService,
+  SymmetricCryptoKey,
+} from "@bitwarden/legacy-crypto";
 import { LogService } from "@bitwarden/logging";
 import { CryptoError } from "@bitwarden/sdk-internal";
 import { UserId } from "@bitwarden/user-core";
 
-import { SymmetricCryptoKey } from "../../../platform/models/domain/symmetric-crypto-key";
 import { MasterKey, UserKey } from "../../../types/key";
 import { InternalMasterPasswordServiceAbstraction } from "../abstractions/master-password.service.abstraction";
 import {

--- a/libs/common/src/key-management/master-password/services/fake-master-password.service.ts
+++ b/libs/common/src/key-management/master-password/services/fake-master-password.service.ts
@@ -5,12 +5,11 @@ import { ReplaySubject, Observable } from "rxjs";
 
 // FIXME: Update this file to be type safe and remove this and next line
 // eslint-disable-next-line no-restricted-imports
-import { KdfConfig } from "@bitwarden/key-management";
+import { EncString, KdfConfig } from "@bitwarden/legacy-crypto";
 
 import { ForceSetPasswordReason } from "../../../auth/models/domain/force-set-password-reason";
 import { UserId } from "../../../types/guid";
 import { MasterKey, UserKey } from "../../../types/key";
-import { EncString } from "../../crypto/models/enc-string";
 import { InternalMasterPasswordServiceAbstraction } from "../abstractions/master-password.service.abstraction";
 import {
   MasterPasswordAuthenticationData,

--- a/libs/common/src/key-management/master-password/services/master-password.service.spec.ts
+++ b/libs/common/src/key-management/master-password/services/master-password.service.spec.ts
@@ -2,7 +2,15 @@ import { mock, MockProxy } from "jest-mock-extended";
 import { firstValueFrom } from "rxjs";
 
 // eslint-disable-next-line no-restricted-imports
-import { Argon2KdfConfig, KdfConfig, PBKDF2KdfConfig } from "@bitwarden/key-management";
+import {
+  Argon2KdfConfig,
+  CryptoFunctionService,
+  EncString,
+  KdfConfig,
+  KeyGenerationService,
+  PBKDF2KdfConfig,
+  SymmetricCryptoKey,
+} from "@bitwarden/legacy-crypto";
 import { PureCrypto } from "@bitwarden/sdk-internal";
 
 import {
@@ -18,13 +26,9 @@ import { ServerConfig } from "../../../platform/abstractions/config/server-confi
 import { LogService } from "../../../platform/abstractions/log.service";
 import { SdkLoadService } from "../../../platform/abstractions/sdk/sdk-load.service";
 import { Utils } from "../../../platform/misc/utils";
-import { SymmetricCryptoKey } from "../../../platform/models/domain/symmetric-crypto-key";
 import { USER_SERVER_CONFIG } from "../../../platform/services/config/default-config.service";
 import { UserId } from "../../../types/guid";
 import { MasterKey, UserKey } from "../../../types/key";
-import { KeyGenerationService } from "../../crypto";
-import { CryptoFunctionService } from "../../crypto/abstractions/crypto-function.service";
-import { EncString } from "../../crypto/models/enc-string";
 import { MASTER_PASSWORD_UNLOCK_DATA } from "../../state-definitions";
 import {
   MasterKeyWrappedUserKey,

--- a/libs/common/src/key-management/master-password/services/master-password.service.ts
+++ b/libs/common/src/key-management/master-password/services/master-password.service.ts
@@ -3,7 +3,14 @@
 import { firstValueFrom, from, iif, map, Observable, of, switchMap } from "rxjs";
 
 // eslint-disable-next-line no-restricted-imports
-import { KdfConfig } from "@bitwarden/key-management";
+import {
+  CryptoFunctionService,
+  EncryptedString,
+  EncString,
+  KdfConfig,
+  KeyGenerationService,
+  SymmetricCryptoKey,
+} from "@bitwarden/legacy-crypto";
 import { PureCrypto } from "@bitwarden/sdk-internal";
 
 import { AccountService } from "../../../auth/abstractions/account.service";
@@ -13,7 +20,6 @@ import { FeatureFlag, getFeatureFlagValue } from "../../../enums/feature-flag.en
 import { LogService } from "../../../platform/abstractions/log.service";
 import { SdkLoadService } from "../../../platform/abstractions/sdk/sdk-load.service";
 import { Utils } from "../../../platform/misc/utils";
-import { SymmetricCryptoKey } from "../../../platform/models/domain/symmetric-crypto-key";
 import { USER_SERVER_CONFIG } from "../../../platform/services/config/default-config.service";
 import {
   MASTER_PASSWORD_DISK,
@@ -23,9 +29,6 @@ import {
 } from "../../../platform/state";
 import { UserId } from "../../../types/guid";
 import { MasterKey, UserKey } from "../../../types/key";
-import { KeyGenerationService } from "../../crypto";
-import { CryptoFunctionService } from "../../crypto/abstractions/crypto-function.service";
-import { EncryptedString, EncString } from "../../crypto/models/enc-string";
 import { USES_KEY_CONNECTOR } from "../../key-connector/services/key-connector.service";
 import { MASTER_PASSWORD_UNLOCK_DATA } from "../../state-definitions";
 import { InternalMasterPasswordServiceAbstraction } from "../abstractions/master-password.service.abstraction";

--- a/libs/common/src/key-management/master-password/types/master-password.types.ts
+++ b/libs/common/src/key-management/master-password/types/master-password.types.ts
@@ -2,12 +2,12 @@ import { Jsonify, Opaque } from "type-fest";
 
 // eslint-disable-next-line no-restricted-imports
 import {
-  fromSdkKdfConfig,
   Argon2KdfConfig,
+  fromSdkKdfConfig,
   KdfConfig,
   KdfType,
   PBKDF2KdfConfig,
-} from "@bitwarden/key-management";
+} from "@bitwarden/legacy-crypto";
 import {
   EncString,
   MasterPasswordUnlockData as SdkMasterPasswordUnlockData,

--- a/libs/common/src/key-management/models/response/kdf-config.response.spec.ts
+++ b/libs/common/src/key-management/models/response/kdf-config.response.spec.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line no-restricted-imports
-import { Argon2KdfConfig, KdfType, PBKDF2KdfConfig } from "@bitwarden/key-management";
+import { Argon2KdfConfig, KdfType, PBKDF2KdfConfig } from "@bitwarden/legacy-crypto";
 
 import { KdfConfigResponse } from "./kdf-config.response";
 

--- a/libs/common/src/key-management/models/response/kdf-config.response.ts
+++ b/libs/common/src/key-management/models/response/kdf-config.response.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line no-restricted-imports
-import { Argon2KdfConfig, KdfConfig, KdfType, PBKDF2KdfConfig } from "@bitwarden/key-management";
+import { Argon2KdfConfig, KdfConfig, KdfType, PBKDF2KdfConfig } from "@bitwarden/legacy-crypto";
 
 import { BaseResponse } from "../../../models/response/base.response";
 

--- a/libs/common/src/key-management/models/response/user-decryption.response.spec.ts
+++ b/libs/common/src/key-management/models/response/user-decryption.response.spec.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line no-restricted-imports
-import { KdfType } from "@bitwarden/key-management";
+import { KdfType } from "@bitwarden/legacy-crypto";
 
 import { UserDecryptionResponse } from "./user-decryption.response";
 

--- a/libs/common/src/key-management/security-state/abstractions/security-state.service.ts
+++ b/libs/common/src/key-management/security-state/abstractions/security-state.service.ts
@@ -1,7 +1,9 @@
 import { Observable } from "rxjs";
 
+// eslint-disable-next-line no-restricted-imports
+import { SignedSecurityState } from "@bitwarden/legacy-crypto";
+
 import { UserId } from "../../../types/guid";
-import { SignedSecurityState } from "../../types";
 
 export abstract class SecurityStateService {
   /**

--- a/libs/common/src/key-management/security-state/request/security-state.request.ts
+++ b/libs/common/src/key-management/security-state/request/security-state.request.ts
@@ -1,4 +1,5 @@
-import { SignedSecurityState } from "../../types";
+// eslint-disable-next-line no-restricted-imports
+import { SignedSecurityState } from "@bitwarden/legacy-crypto";
 
 export class SecurityStateRequest {
   constructor(

--- a/libs/common/src/key-management/security-state/response/security-state.response.ts
+++ b/libs/common/src/key-management/security-state/response/security-state.response.ts
@@ -1,4 +1,5 @@
-import { SignedSecurityState } from "../../types";
+// eslint-disable-next-line no-restricted-imports
+import { SignedSecurityState } from "@bitwarden/legacy-crypto";
 
 export class SecurityStateResponse {
   readonly securityState: SignedSecurityState | null = null;

--- a/libs/common/src/key-management/security-state/services/security-state.service.ts
+++ b/libs/common/src/key-management/security-state/services/security-state.service.ts
@@ -1,8 +1,10 @@
 import { map, Observable } from "rxjs";
 
+// eslint-disable-next-line no-restricted-imports
+import { SignedSecurityState } from "@bitwarden/legacy-crypto";
+
 import { UserId } from "../../../types/guid";
 import { AccountCryptographicStateService } from "../../account-cryptography/account-cryptographic-state.service";
-import { SignedSecurityState } from "../../types";
 import { SecurityStateService } from "../abstractions/security-state.service";
 
 export class DefaultSecurityStateService implements SecurityStateService {

--- a/libs/common/src/key-management/sends/services/default-send-password.service.spec.ts
+++ b/libs/common/src/key-management/sends/services/default-send-password.service.spec.ts
@@ -1,7 +1,9 @@
 import { mock, MockProxy } from "jest-mock-extended";
 
+// eslint-disable-next-line no-restricted-imports
+import { CryptoFunctionService } from "@bitwarden/legacy-crypto";
+
 import { SEND_KDF_ITERATIONS } from "../../../tools/send/send-kdf";
-import { CryptoFunctionService } from "../../crypto/abstractions/crypto-function.service";
 import { SendPasswordKeyMaterial } from "../types";
 
 import { DefaultSendPasswordService } from "./default-send-password.service";

--- a/libs/common/src/key-management/sends/services/default-send-password.service.ts
+++ b/libs/common/src/key-management/sends/services/default-send-password.service.ts
@@ -1,5 +1,7 @@
+// eslint-disable-next-line no-restricted-imports
+import { CryptoFunctionService } from "@bitwarden/legacy-crypto";
+
 import { SEND_KDF_ITERATIONS } from "../../../tools/send/send-kdf";
-import { CryptoFunctionService } from "../../crypto/abstractions/crypto-function.service";
 import { SendPasswordService } from "../abstractions/send-password.service";
 import { SendHashedPassword, SendPasswordKeyMaterial } from "../types/send-hashed-password.type";
 

--- a/libs/common/src/key-management/shared-unlock/default-shared-unlock-follower.service.ts
+++ b/libs/common/src/key-management/shared-unlock/default-shared-unlock-follower.service.ts
@@ -5,6 +5,8 @@ import { LockService } from "@bitwarden/auth/common";
 import { ClientType } from "@bitwarden/client-type";
 // eslint-disable-next-line no-restricted-imports
 import { KeyService } from "@bitwarden/key-management";
+// eslint-disable-next-line no-restricted-imports
+import { SymmetricCryptoKey } from "@bitwarden/legacy-crypto";
 import { SharedUnlockFollower } from "@bitwarden/sdk-internal";
 import { UnlockService } from "@bitwarden/unlock";
 
@@ -13,7 +15,6 @@ import { EnvironmentService } from "../../platform/abstractions/environment.serv
 import { PlatformUtilsService } from "../../platform/abstractions/platform-utils.service";
 import { asUuid } from "../../platform/abstractions/sdk/sdk.service";
 import { IpcService } from "../../platform/ipc";
-import { SymmetricCryptoKey } from "../../platform/models/domain/symmetric-crypto-key";
 import { UserId } from "../../types/guid";
 import { VaultTimeoutSettingsService } from "../vault-timeout/abstractions/vault-timeout-settings.service";
 

--- a/libs/common/src/key-management/shared-unlock/default-shared-unlock-leader.service.ts
+++ b/libs/common/src/key-management/shared-unlock/default-shared-unlock-leader.service.ts
@@ -5,6 +5,8 @@ import { LockService } from "@bitwarden/auth/common";
 import { ClientType } from "@bitwarden/client-type";
 // eslint-disable-next-line no-restricted-imports
 import { KeyService } from "@bitwarden/key-management";
+// eslint-disable-next-line no-restricted-imports
+import { SymmetricCryptoKey } from "@bitwarden/legacy-crypto";
 import { SharedUnlockLeader } from "@bitwarden/sdk-internal";
 import { UnlockService } from "@bitwarden/unlock";
 
@@ -13,7 +15,6 @@ import { EnvironmentService } from "../../platform/abstractions/environment.serv
 import { PlatformUtilsService } from "../../platform/abstractions/platform-utils.service";
 import { asUuid } from "../../platform/abstractions/sdk/sdk.service";
 import { IpcService } from "../../platform/ipc";
-import { SymmetricCryptoKey } from "../../platform/models/domain/symmetric-crypto-key";
 import { UserId } from "../../types/guid";
 import { VaultTimeoutSettingsService } from "../vault-timeout/abstractions/vault-timeout-settings.service";
 

--- a/libs/common/src/key-management/shared-unlock/shared-unlock-driver.ts
+++ b/libs/common/src/key-management/shared-unlock/shared-unlock-driver.ts
@@ -4,6 +4,8 @@ import { firstValueFrom } from "rxjs";
 import { LockService } from "@bitwarden/auth/common";
 // eslint-disable-next-line no-restricted-imports
 import { KeyService } from "@bitwarden/key-management";
+// eslint-disable-next-line no-restricted-imports
+import { SymmetricCryptoKey } from "@bitwarden/legacy-crypto";
 import { UserId, SharedUnlockDriver, SymmetricKey } from "@bitwarden/sdk-internal";
 import { UnlockService } from "@bitwarden/unlock";
 import { UserId as TSUserId } from "@bitwarden/user-core";
@@ -12,7 +14,6 @@ import { AccountService } from "../../auth/abstractions/account.service";
 import { EnvironmentService } from "../../platform/abstractions/environment.service";
 import { PlatformUtilsService } from "../../platform/abstractions/platform-utils.service";
 import { asUuid, uuidAsString } from "../../platform/abstractions/sdk/sdk.service";
-import { SymmetricCryptoKey } from "../../platform/models/domain/symmetric-crypto-key";
 import { UserKey } from "../../types/key";
 import { VaultTimeoutSettingsService } from "../vault-timeout/abstractions/vault-timeout-settings.service";
 

--- a/libs/common/src/key-management/shared-unlock/unlock-state-poll.spec.ts
+++ b/libs/common/src/key-management/shared-unlock/unlock-state-poll.spec.ts
@@ -4,9 +4,10 @@ import { BehaviorSubject, of } from "rxjs";
 import { newGuid } from "@bitwarden/guid";
 // eslint-disable-next-line no-restricted-imports
 import { KeyService } from "@bitwarden/key-management";
+// eslint-disable-next-line no-restricted-imports
+import { SymmetricCryptoKey } from "@bitwarden/legacy-crypto";
 
 import { AccountInfo, AccountService } from "../../auth/abstractions/account.service";
-import { SymmetricCryptoKey } from "../../platform/models/domain/symmetric-crypto-key";
 import { UserId } from "../../types/guid";
 import { UserKey } from "../../types/key";
 

--- a/libs/common/src/key-management/shared-unlock/unlock-state-poll.ts
+++ b/libs/common/src/key-management/shared-unlock/unlock-state-poll.ts
@@ -2,10 +2,11 @@ import { firstValueFrom } from "rxjs";
 
 // eslint-disable-next-line no-restricted-imports
 import { KeyService } from "@bitwarden/key-management";
+// eslint-disable-next-line no-restricted-imports
+import { SymmetricCryptoKey } from "@bitwarden/legacy-crypto";
 import { UserId } from "@bitwarden/user-core";
 
 import { AccountService } from "../../auth/abstractions/account.service";
-import { SymmetricCryptoKey } from "../../platform/models/domain/symmetric-crypto-key";
 
 /**
  * A poller that checks for all users whether they have transitioned from a locked state to an unlocked state.

--- a/libs/common/src/key-management/state-bridge.ts
+++ b/libs/common/src/key-management/state-bridge.ts
@@ -2,7 +2,7 @@ import { filter, firstValueFrom, map, race, timer } from "rxjs";
 
 // There is no way to prevent this restricted import currently. These should be extracted out into a separate package.
 // eslint-disable-next-line no-restricted-imports
-import { fromSdkKdfConfig } from "@bitwarden/key-management";
+import { fromSdkKdfConfig, SymmetricCryptoKey } from "@bitwarden/legacy-crypto";
 import {
   EncString,
   MasterPasswordUnlockData as SdkMasterPasswordUnlockData,
@@ -17,7 +17,6 @@ import {
 import { UserId } from "@bitwarden/user-core";
 
 import { compareValues } from "../platform/misc/compare-values";
-import { SymmetricCryptoKey } from "../platform/models/domain/symmetric-crypto-key";
 import { StateProvider, UserKeyDefinition } from "../state-migrations";
 import { UserKey } from "../types/key";
 

--- a/libs/common/src/key-management/state-definitions.spec.ts
+++ b/libs/common/src/key-management/state-definitions.spec.ts
@@ -1,7 +1,7 @@
 import { Jsonify } from "type-fest";
 
 // eslint-disable-next-line no-restricted-imports
-import { Argon2KdfConfig, KdfConfig, KdfType, PBKDF2KdfConfig } from "@bitwarden/key-management";
+import { Argon2KdfConfig, KdfConfig, KdfType, PBKDF2KdfConfig } from "@bitwarden/legacy-crypto";
 import { WrappedAccountCryptographicState } from "@bitwarden/sdk-internal";
 
 import {

--- a/libs/common/src/key-management/state-definitions.ts
+++ b/libs/common/src/key-management/state-definitions.ts
@@ -2,7 +2,13 @@ import { Jsonify } from "type-fest";
 
 // There is no way to prevent this restricted import currently. These should be extracted out into a separate package.
 // eslint-disable-next-line no-restricted-imports
-import { Argon2KdfConfig, KdfConfig, KdfType, PBKDF2KdfConfig } from "@bitwarden/key-management";
+import {
+  Argon2KdfConfig,
+  KdfConfig,
+  KdfType,
+  PBKDF2KdfConfig,
+  SymmetricCryptoKey,
+} from "@bitwarden/legacy-crypto";
 import {
   EncString,
   EphemeralPinEnvelopeState,
@@ -21,7 +27,6 @@ import {
   UserKeyDefinition,
 } from "@bitwarden/state";
 
-import { SymmetricCryptoKey } from "../platform/models/domain/symmetric-crypto-key";
 import { UserKey } from "../types/key";
 
 import { MasterPasswordUnlockData } from "./master-password/types/master-password.types";

--- a/libs/common/src/key-management/user-key-mapper.ts
+++ b/libs/common/src/key-management/user-key-mapper.ts
@@ -1,6 +1,7 @@
+// eslint-disable-next-line no-restricted-imports
+import { SymmetricCryptoKey } from "@bitwarden/legacy-crypto";
 import { UserKeyState } from "@bitwarden/sdk-internal";
 
-import { SymmetricCryptoKey } from "../platform/models/domain/symmetric-crypto-key";
 import { SdkRecordMapper } from "../platform/services/sdk/client-managed-state";
 import { UserKeyDefinition } from "../platform/state";
 import { UserKey } from "../types/key";

--- a/libs/key-management-ui/src/lock/components/lock.component.spec.ts
+++ b/libs/key-management-ui/src/lock/components/lock.component.spec.ts
@@ -21,7 +21,6 @@ import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.servic
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
-import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
 import { SyncService } from "@bitwarden/common/platform/sync";
 import { makeSymmetricCryptoKey, mockAccountServiceWith } from "@bitwarden/common/spec";
 import { PasswordStrengthServiceAbstraction } from "@bitwarden/common/tools/password-strength";
@@ -43,6 +42,8 @@ import {
   KeyService,
   UserAsymmetricKeysRegenerationService,
 } from "@bitwarden/key-management";
+// eslint-disable-next-line no-restricted-imports
+import { SymmetricCryptoKey } from "@bitwarden/legacy-crypto";
 import { UnlockService } from "@bitwarden/unlock";
 
 import {

--- a/libs/key-management-ui/src/lock/components/master-password-lock/master-password-lock.component.spec.ts
+++ b/libs/key-management-ui/src/lock/components/master-password-lock/master-password-lock.component.spec.ts
@@ -10,7 +10,6 @@ import { ClientType } from "@bitwarden/client-type";
 import { Account, AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
-import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
 import { mockAccountInfoWith } from "@bitwarden/common/spec";
 import { UserKey } from "@bitwarden/common/types/key";
 import {
@@ -22,6 +21,8 @@ import {
   ToastService,
 } from "@bitwarden/components";
 import { BiometricsStatus, KeyService } from "@bitwarden/key-management";
+// eslint-disable-next-line no-restricted-imports
+import { SymmetricCryptoKey } from "@bitwarden/legacy-crypto";
 import { LogService } from "@bitwarden/logging";
 import { CommandDefinition, MessageListener } from "@bitwarden/messaging";
 import { UnlockService } from "@bitwarden/unlock";

--- a/libs/key-management-ui/src/lock/services/default-webauthn-prf-unlock.service.ts
+++ b/libs/key-management-ui/src/lock/services/default-webauthn-prf-unlock.service.ts
@@ -2,8 +2,6 @@ import { firstValueFrom } from "rxjs";
 
 import { WebAuthnLoginPrfKeyServiceAbstraction } from "@bitwarden/common/auth/abstractions/webauthn/webauthn-login-prf-key.service.abstraction";
 import { ClientType } from "@bitwarden/common/enums";
-import { EncryptService } from "@bitwarden/common/key-management/crypto/abstractions/encrypt.service";
-import { EncString } from "@bitwarden/common/key-management/crypto/models/enc-string";
 import { WEBAUTHN_PRF_OPTIONS } from "@bitwarden/common/key-management/state-definitions";
 import { EnvironmentService } from "@bitwarden/common/platform/abstractions/environment.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
@@ -12,6 +10,8 @@ import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { Fido2Utils } from "@bitwarden/common/platform/services/fido2/fido2-utils";
 import { UserId } from "@bitwarden/common/types/guid";
 import { PrfKey, UserKey } from "@bitwarden/common/types/key";
+// eslint-disable-next-line no-restricted-imports
+import { EncryptService, EncString } from "@bitwarden/legacy-crypto";
 import { WebAuthnPrfUnlockOption } from "@bitwarden/sdk-internal";
 import { StateProvider } from "@bitwarden/state";
 

--- a/libs/key-management/src/abstractions/kdf-config.service.ts
+++ b/libs/key-management/src/abstractions/kdf-config.service.ts
@@ -1,8 +1,8 @@
 import { Observable } from "rxjs";
 
 import { UserId } from "@bitwarden/common/types/guid";
-
-import { KdfConfig } from "../models/kdf-config";
+// eslint-disable-next-line no-restricted-imports
+import { KdfConfig } from "@bitwarden/legacy-crypto";
 
 export abstract class KdfConfigService {
   abstract setKdfConfig(userId: UserId, KdfConfig: KdfConfig): Promise<void>;

--- a/libs/key-management/src/abstractions/key.service.ts
+++ b/libs/key-management/src/abstractions/key.service.ts
@@ -3,11 +3,6 @@ import { Observable } from "rxjs";
 import { ProfileOrganizationResponse } from "@bitwarden/common/admin-console/models/response/profile-organization.response";
 import { ProfileProviderOrganizationResponse } from "@bitwarden/common/admin-console/models/response/profile-provider-organization.response";
 import { ProfileProviderResponse } from "@bitwarden/common/admin-console/models/response/profile-provider.response";
-import {
-  EncryptedString,
-  EncString,
-} from "@bitwarden/common/key-management/crypto/models/enc-string";
-import { SignedPublicKey, WrappedSigningKey } from "@bitwarden/common/key-management/types";
 import { KeySuffixOptions } from "@bitwarden/common/platform/enums";
 import { OrganizationId, ProviderId, UserId } from "@bitwarden/common/types/guid";
 import {
@@ -17,6 +12,13 @@ import {
   UserPrivateKey,
   UserPublicKey,
 } from "@bitwarden/common/types/key";
+// eslint-disable-next-line no-restricted-imports
+import {
+  EncryptedString,
+  EncString,
+  SignedPublicKey,
+  WrappedSigningKey,
+} from "@bitwarden/legacy-crypto";
 
 export class UserPrivateKeyDecryptionFailedError extends Error {
   constructor() {

--- a/libs/key-management/src/biometrics/biometric-state.service.spec.ts
+++ b/libs/key-management/src/biometrics/biometric-state.service.spec.ts
@@ -1,6 +1,5 @@
 import { firstValueFrom } from "rxjs";
 
-import { EncryptedString } from "@bitwarden/common/key-management/crypto/models/enc-string";
 import {
   makeEncString,
   trackEmissions,
@@ -10,6 +9,8 @@ import {
   mockAccountServiceWith,
 } from "@bitwarden/common/spec";
 import { UserId } from "@bitwarden/common/types/guid";
+// eslint-disable-next-line no-restricted-imports
+import { EncryptedString } from "@bitwarden/legacy-crypto";
 
 import { BiometricStateService, DefaultBiometricStateService } from "./biometric-state.service";
 import {

--- a/libs/key-management/src/biometrics/biometric-state.service.ts
+++ b/libs/key-management/src/biometrics/biometric-state.service.ts
@@ -1,12 +1,10 @@
 import { Observable, firstValueFrom, map } from "rxjs";
 
 import { assertNonNullish } from "@bitwarden/common/auth/utils";
-import {
-  EncryptedString,
-  EncString,
-} from "@bitwarden/common/key-management/crypto/models/enc-string";
 import { GlobalState, StateProvider } from "@bitwarden/common/platform/state";
 import { UserId } from "@bitwarden/common/types/guid";
+// eslint-disable-next-line no-restricted-imports
+import { EncryptedString, EncString } from "@bitwarden/legacy-crypto";
 
 import {
   BIOMETRIC_UNLOCK_ENABLED,

--- a/libs/key-management/src/biometrics/biometric.service.ts
+++ b/libs/key-management/src/biometrics/biometric.service.ts
@@ -1,6 +1,7 @@
-import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
 import { UserId } from "@bitwarden/common/types/guid";
 import { UserKey } from "@bitwarden/common/types/key";
+// eslint-disable-next-line no-restricted-imports
+import { SymmetricCryptoKey } from "@bitwarden/legacy-crypto";
 import { UnlockService } from "@bitwarden/unlock";
 
 import { BiometricsStatus } from "./biometrics-status";

--- a/libs/key-management/src/biometrics/biometric.state.ts
+++ b/libs/key-management/src/biometrics/biometric.state.ts
@@ -1,10 +1,11 @@
-import { EncryptedString } from "@bitwarden/common/key-management/crypto/models/enc-string";
 import {
   KeyDefinition,
   BIOMETRIC_SETTINGS_DISK,
   UserKeyDefinition,
 } from "@bitwarden/common/platform/state";
 import { UserId } from "@bitwarden/common/types/guid";
+// eslint-disable-next-line no-restricted-imports
+import { EncryptedString } from "@bitwarden/legacy-crypto";
 
 /**
  * Indicates whether the user elected to store a biometric key to unlock their vault.

--- a/libs/key-management/src/kdf-config.service.spec.ts
+++ b/libs/key-management/src/kdf-config.service.spec.ts
@@ -8,9 +8,10 @@ import {
   mockAccountServiceWith,
 } from "@bitwarden/common/spec";
 import { UserId } from "@bitwarden/common/types/guid";
+// eslint-disable-next-line no-restricted-imports
+import { Argon2KdfConfig, KdfConfig, PBKDF2KdfConfig } from "@bitwarden/legacy-crypto";
 
 import { DefaultKdfConfigService } from "./kdf-config.service";
-import { Argon2KdfConfig, KdfConfig, PBKDF2KdfConfig } from "./models/kdf-config";
 
 describe("KdfConfigService", () => {
   let sutKdfConfigService: DefaultKdfConfigService;

--- a/libs/key-management/src/kdf-config.service.ts
+++ b/libs/key-management/src/kdf-config.service.ts
@@ -3,9 +3,10 @@ import { firstValueFrom, Observable } from "rxjs";
 import { KDF_CONFIG } from "@bitwarden/common/key-management/state-definitions";
 import { StateProvider } from "@bitwarden/common/platform/state";
 import { UserId } from "@bitwarden/common/types/guid";
+// eslint-disable-next-line no-restricted-imports
+import { KdfConfig } from "@bitwarden/legacy-crypto";
 
 import { KdfConfigService } from "./abstractions/kdf-config.service";
-import { KdfConfig } from "./models/kdf-config";
 
 export class DefaultKdfConfigService implements KdfConfigService {
   constructor(private stateProvider: StateProvider) {}

--- a/libs/key-management/src/key.service.spec.ts
+++ b/libs/key-management/src/key.service.spec.ts
@@ -4,15 +4,8 @@ import { BehaviorSubject, bufferCount, firstValueFrom, lastValueFrom, of, take }
 import { ClientType } from "@bitwarden/client-type";
 import { EncryptedOrganizationKeyData } from "@bitwarden/common/admin-console/models/data/encrypted-organization-key.data";
 import { AccountCryptographicStateService } from "@bitwarden/common/key-management/account-cryptography/account-cryptographic-state.service";
-import { CryptoFunctionService } from "@bitwarden/common/key-management/crypto/abstractions/crypto-function.service";
-import { EncryptService } from "@bitwarden/common/key-management/crypto/abstractions/encrypt.service";
-import {
-  EncString,
-  EncryptedString,
-} from "@bitwarden/common/key-management/crypto/models/enc-string";
 import { FakeMasterPasswordService } from "@bitwarden/common/key-management/master-password/services/fake-master-password.service";
 import { USER_KEY } from "@bitwarden/common/key-management/state-definitions";
-import { UnsignedPublicKey } from "@bitwarden/common/key-management/types";
 import { VaultTimeoutStringType } from "@bitwarden/common/key-management/vault-timeout";
 import { VAULT_TIMEOUT } from "@bitwarden/common/key-management/vault-timeout/services/vault-timeout-settings.state";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
@@ -21,7 +14,6 @@ import { SdkLoadService } from "@bitwarden/common/platform/abstractions/sdk/sdk-
 import { StateService } from "@bitwarden/common/platform/abstractions/state.service";
 import { KeySuffixOptions } from "@bitwarden/common/platform/enums";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
-import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
 import { USER_ENCRYPTED_ORGANIZATION_KEYS } from "@bitwarden/common/platform/services/key-state/org-keys.state";
 import { USER_ENCRYPTED_PROVIDER_KEYS } from "@bitwarden/common/platform/services/key-state/provider-keys.state";
 import { USER_EVER_HAD_USER_KEY } from "@bitwarden/common/platform/services/key-state/user-key.state";
@@ -36,9 +28,18 @@ import {
   FakeStateProvider,
   FakeSingleUserState,
 } from "@bitwarden/common/spec";
-import { CsprngArray } from "@bitwarden/common/types/csprng";
 import { OrganizationId, ProviderId, UserId } from "@bitwarden/common/types/guid";
 import { UserKey, MasterKey, ProviderKey } from "@bitwarden/common/types/key";
+// eslint-disable-next-line no-restricted-imports
+import {
+  CryptoFunctionService,
+  CsprngArray,
+  EncryptedString,
+  EncryptService,
+  EncString,
+  SymmetricCryptoKey,
+  UnsignedPublicKey,
+} from "@bitwarden/legacy-crypto";
 
 import { DefaultKeyService } from "./key.service";
 

--- a/libs/key-management/src/key.service.ts
+++ b/libs/key-management/src/key.service.ts
@@ -20,14 +20,7 @@ import { ProfileOrganizationResponse } from "@bitwarden/common/admin-console/mod
 import { ProfileProviderOrganizationResponse } from "@bitwarden/common/admin-console/models/response/profile-provider-organization.response";
 import { ProfileProviderResponse } from "@bitwarden/common/admin-console/models/response/profile-provider.response";
 import { AccountCryptographicStateService } from "@bitwarden/common/key-management/account-cryptography/account-cryptographic-state.service";
-import { CryptoFunctionService } from "@bitwarden/common/key-management/crypto/abstractions/crypto-function.service";
-import { EncryptService } from "@bitwarden/common/key-management/crypto/abstractions/encrypt.service";
-import {
-  EncString,
-  EncryptedString,
-} from "@bitwarden/common/key-management/crypto/models/enc-string";
 import { USER_KEY } from "@bitwarden/common/key-management/state-definitions";
-import { SignedPublicKey, WrappedSigningKey } from "@bitwarden/common/key-management/types";
 import { VaultTimeoutStringType } from "@bitwarden/common/key-management/vault-timeout";
 import { VAULT_TIMEOUT } from "@bitwarden/common/key-management/vault-timeout/services/vault-timeout-settings.state";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
@@ -36,7 +29,6 @@ import { StateService } from "@bitwarden/common/platform/abstractions/state.serv
 import { KeySuffixOptions } from "@bitwarden/common/platform/enums";
 import { convertValues } from "@bitwarden/common/platform/misc/convert-values";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
-import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
 import { USER_ENCRYPTED_ORGANIZATION_KEYS } from "@bitwarden/common/platform/services/key-state/org-keys.state";
 import { USER_ENCRYPTED_PROVIDER_KEYS } from "@bitwarden/common/platform/services/key-state/provider-keys.state";
 import { USER_EVER_HAD_USER_KEY } from "@bitwarden/common/platform/services/key-state/user-key.state";
@@ -50,6 +42,16 @@ import {
   UserPrivateKey,
   UserPublicKey,
 } from "@bitwarden/common/types/key";
+// eslint-disable-next-line no-restricted-imports
+import {
+  CryptoFunctionService,
+  EncryptedString,
+  EncryptService,
+  EncString,
+  SignedPublicKey,
+  SymmetricCryptoKey,
+  WrappedSigningKey,
+} from "@bitwarden/legacy-crypto";
 import { WrappedAccountCryptographicState } from "@bitwarden/sdk-internal";
 
 import {

--- a/libs/key-management/src/user-asymmetric-key-regeneration/models/requests/key-regeneration.request.ts
+++ b/libs/key-management/src/user-asymmetric-key-regeneration/models/requests/key-regeneration.request.ts
@@ -1,4 +1,5 @@
-import { EncString } from "@bitwarden/common/key-management/crypto/models/enc-string";
+// eslint-disable-next-line no-restricted-imports
+import { EncString } from "@bitwarden/legacy-crypto";
 
 export class KeyRegenerationRequest {
   userPublicKey: string;

--- a/libs/key-management/src/user-asymmetric-key-regeneration/services/default-user-asymmetric-key-regeneration.service.spec.ts
+++ b/libs/key-management/src/user-asymmetric-key-regeneration/services/default-user-asymmetric-key-regeneration.service.spec.ts
@@ -3,11 +3,11 @@ import { of } from "rxjs";
 
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
-import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
 import { MockSdkService } from "@bitwarden/common/platform/spec/mock-sdk.service";
-import { CsprngArray } from "@bitwarden/common/types/csprng";
 import { UserId } from "@bitwarden/common/types/guid";
 import { UserKey } from "@bitwarden/common/types/key";
+// eslint-disable-next-line no-restricted-imports
+import { CsprngArray, SymmetricCryptoKey } from "@bitwarden/legacy-crypto";
 
 import { KeyService } from "../../abstractions/key.service";
 

--- a/libs/unlock/src/default-unlock.service.spec.ts
+++ b/libs/unlock/src/default-unlock.service.spec.ts
@@ -14,9 +14,7 @@ import { VaultTimeoutStringType } from "@bitwarden/common/key-management/vault-t
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { RegisterSdkService } from "@bitwarden/common/platform/abstractions/sdk/register-sdk.service";
 import { SdkLoadService } from "@bitwarden/common/platform/abstractions/sdk/sdk-load.service";
-import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
 import { USER_EVER_HAD_USER_KEY } from "@bitwarden/common/platform/services/key-state/user-key.state";
-import { CsprngArray } from "@bitwarden/common/types/csprng";
 import { UserId } from "@bitwarden/common/types/guid";
 import { UserKey } from "@bitwarden/common/types/key";
 import {
@@ -24,6 +22,8 @@ import {
   BiometricStateService,
   KdfConfigService,
 } from "@bitwarden/key-management";
+// eslint-disable-next-line no-restricted-imports
+import { CsprngArray, SymmetricCryptoKey } from "@bitwarden/legacy-crypto";
 import { LogService } from "@bitwarden/logging";
 import { EncString, PureCrypto, V2UpgradeToken } from "@bitwarden/sdk-internal";
 import { StateProvider, StateService } from "@bitwarden/state";

--- a/libs/unlock/src/default-unlock.service.ts
+++ b/libs/unlock/src/default-unlock.service.ts
@@ -16,15 +16,15 @@ import { RegisterSdkService } from "@bitwarden/common/platform/abstractions/sdk/
 import { SdkLoadService } from "@bitwarden/common/platform/abstractions/sdk/sdk-load.service";
 import { asUuid } from "@bitwarden/common/platform/abstractions/sdk/sdk.service";
 import { Ref } from "@bitwarden/common/platform/misc/reference-counting/rc";
-import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
 import { USER_EVER_HAD_USER_KEY } from "@bitwarden/common/platform/services/key-state/user-key.state";
 import { MasterKey } from "@bitwarden/common/types/key";
 import {
   BiometricsService,
   BiometricStateService,
-  KdfConfig,
   KdfConfigService,
 } from "@bitwarden/key-management";
+// eslint-disable-next-line no-restricted-imports
+import { KdfConfig, SymmetricCryptoKey } from "@bitwarden/legacy-crypto";
 import { LogService } from "@bitwarden/logging";
 import {
   EncString,

--- a/libs/unlock/src/unlock.service.ts
+++ b/libs/unlock/src/unlock.service.ts
@@ -1,5 +1,6 @@
-import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
 import { UserId } from "@bitwarden/common/types/guid";
+// eslint-disable-next-line no-restricted-imports
+import { SymmetricCryptoKey } from "@bitwarden/legacy-crypto";
 
 import { KeyConnectorUnlockData } from "./default-unlock.service";
 


### PR DESCRIPTION
move callers for key-management from the barrel-re-export to the legacy-crypto module directly. The re-exports will be removed in a follow-up PR.

Ticket: https://bitwarden.atlassian.net/browse/PM-41874
